### PR TITLE
feat(ui): dead-letter-queue replay + purge actions with confirm (#2215)

### DIFF
--- a/apps/gittensory-ui/public/openapi.json
+++ b/apps/gittensory-ui/public/openapi.json
@@ -12,11 +12,15 @@
         "properties": {
           "status": {
             "type": "string",
-            "enum": ["ok"]
+            "enum": [
+              "ok"
+            ]
           },
           "service": {
             "type": "string",
-            "enum": ["gittensory-api"]
+            "enum": [
+              "gittensory-api"
+            ]
           },
           "time": {
             "type": "string"
@@ -28,18 +32,28 @@
             "type": "string"
           }
         },
-        "required": ["status", "service", "time", "minMcpVersion", "latestRecommendedMcpVersion"]
+        "required": [
+          "status",
+          "service",
+          "time",
+          "minMcpVersion",
+          "latestRecommendedMcpVersion"
+        ]
       },
       "McpCompatibility": {
         "type": "object",
         "properties": {
           "status": {
             "type": "string",
-            "enum": ["ok"]
+            "enum": [
+              "ok"
+            ]
           },
           "service": {
             "type": "string",
-            "enum": ["gittensory-api"]
+            "enum": [
+              "gittensory-api"
+            ]
           },
           "apiVersion": {
             "type": "string"
@@ -91,7 +105,10 @@
                   "type": "string"
                 }
               },
-              "required": ["code", "message"]
+              "required": [
+                "code",
+                "message"
+              ]
             }
           },
           "breakingChanges": {
@@ -109,7 +126,10 @@
                   "type": "string"
                 }
               },
-              "required": ["version", "summary"]
+              "required": [
+                "version",
+                "summary"
+              ]
             }
           },
           "generatedAt": {
@@ -143,13 +163,19 @@
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": ["api", "raw-github"]
+                "enum": [
+                  "api",
+                  "raw-github"
+                ]
               },
               "url": {
                 "type": "string"
               }
             },
-            "required": ["kind", "url"]
+            "required": [
+              "kind",
+              "url"
+            ]
           },
           "repoCount": {
             "type": "number"
@@ -278,7 +304,14 @@
             ]
           }
         },
-        "required": ["fullName", "owner", "name", "isInstalled", "isRegistered", "isPrivate"]
+        "required": [
+          "fullName",
+          "owner",
+          "name",
+          "isInstalled",
+          "isRegistered",
+          "isPrivate"
+        ]
       },
       "PublicRepoStats": {
         "type": "object",
@@ -300,7 +333,11 @@
           },
           "source": {
             "type": "string",
-            "enum": ["github", "cache", "stale_cache"]
+            "enum": [
+              "github",
+              "cache",
+              "stale_cache"
+            ]
           },
           "stale": {
             "type": "boolean"
@@ -392,7 +429,10 @@
                 "type": "number"
               }
             },
-            "required": ["reviewed", "merged"]
+            "required": [
+              "reviewed",
+              "merged"
+            ]
           },
           "byProject": {
             "type": "array",
@@ -416,11 +456,23 @@
                   "nullable": true
                 }
               },
-              "required": ["project", "reviewed", "merged", "closed", "accuracyPct"]
+              "required": [
+                "project",
+                "reviewed",
+                "merged",
+                "closed",
+                "accuracyPct"
+              ]
             }
           }
         },
-        "required": ["generatedAt", "updatedAt", "totals", "weekly", "byProject"]
+        "required": [
+          "generatedAt",
+          "updatedAt",
+          "totals",
+          "weekly",
+          "byProject"
+        ]
       },
       "Advisory": {
         "type": "object",
@@ -430,7 +482,11 @@
           },
           "targetType": {
             "type": "string",
-            "enum": ["repository", "pull_request", "issue"]
+            "enum": [
+              "repository",
+              "pull_request",
+              "issue"
+            ]
           },
           "targetKey": {
             "type": "string"
@@ -449,11 +505,19 @@
           },
           "conclusion": {
             "type": "string",
-            "enum": ["success", "neutral", "action_required"]
+            "enum": [
+              "success",
+              "neutral",
+              "action_required"
+            ]
           },
           "severity": {
             "type": "string",
-            "enum": ["info", "warning", "critical"]
+            "enum": [
+              "info",
+              "warning",
+              "critical"
+            ]
           },
           "title": {
             "type": "string"
@@ -495,7 +559,11 @@
           },
           "severity": {
             "type": "string",
-            "enum": ["info", "warning", "critical"]
+            "enum": [
+              "info",
+              "warning",
+              "critical"
+            ]
           },
           "detail": {
             "type": "string"
@@ -507,7 +575,12 @@
             "type": "string"
           }
         },
-        "required": ["code", "title", "severity", "detail"]
+        "required": [
+          "code",
+          "title",
+          "severity",
+          "detail"
+        ]
       },
       "ActionPortfolio": {
         "type": "object",
@@ -542,7 +615,12 @@
                   }
                 }
               },
-              "required": ["bucket", "label", "summary", "actions"]
+              "required": [
+                "bucket",
+                "label",
+                "summary",
+                "actions"
+              ]
             }
           },
           "topActions": {
@@ -561,11 +639,25 @@
             "type": "string"
           }
         },
-        "required": ["generatedAt", "bucketOrder", "buckets", "topActions", "counts", "summary"]
+        "required": [
+          "generatedAt",
+          "bucketOrder",
+          "buckets",
+          "topActions",
+          "counts",
+          "summary"
+        ]
       },
       "ActionPortfolioBucketName": {
         "type": "string",
-        "enum": ["cleanup", "wait", "direct_pr", "issue_discovery", "avoid", "maintainer_lane"]
+        "enum": [
+          "cleanup",
+          "wait",
+          "direct_pr",
+          "issue_discovery",
+          "avoid",
+          "maintainer_lane"
+        ]
       },
       "ActionPortfolioItem": {
         "type": "object",
@@ -587,7 +679,11 @@
           },
           "status": {
             "type": "string",
-            "enum": ["recommended", "blocked", "watch"]
+            "enum": [
+              "recommended",
+              "blocked",
+              "watch"
+            ]
           },
           "whyNow": {
             "type": "array",
@@ -630,14 +726,19 @@
           },
           "source": {
             "type": "string",
-            "enum": ["decision_pack"]
+            "enum": [
+              "decision_pack"
+            ]
           },
           "scenarioProjection": {
             "type": "object",
             "properties": {
               "source": {
                 "type": "string",
-                "enum": ["github_observed", "user_supplied"]
+                "enum": [
+                  "github_observed",
+                  "user_supplied"
+                ]
               },
               "pendingMergedPrCount": {
                 "type": "number"
@@ -698,7 +799,13 @@
       },
       "DecisionRecommendation": {
         "type": "string",
-        "enum": ["pursue", "cleanup_first", "maintainer_lane", "avoid_for_now", "watch"]
+        "enum": [
+          "pursue",
+          "cleanup_first",
+          "maintainer_lane",
+          "avoid_for_now",
+          "watch"
+        ]
       },
       "WorkboardItem": {
         "type": "object",
@@ -721,7 +828,11 @@
           },
           "fit": {
             "type": "string",
-            "enum": ["good", "caution", "hold"]
+            "enum": [
+              "good",
+              "caution",
+              "hold"
+            ]
           },
           "reasons": {
             "type": "array",
@@ -730,7 +841,14 @@
             }
           }
         },
-        "required": ["repoFullName", "issueNumber", "title", "state", "fit", "reasons"]
+        "required": [
+          "repoFullName",
+          "issueNumber",
+          "title",
+          "state",
+          "fit",
+          "reasons"
+        ]
       },
       "QueueHealth": {
         "type": "object",
@@ -746,7 +864,12 @@
           },
           "level": {
             "type": "string",
-            "enum": ["low", "medium", "high", "critical"]
+            "enum": [
+              "low",
+              "medium",
+              "high",
+              "critical"
+            ]
           },
           "summary": {
             "type": "string"
@@ -785,7 +908,11 @@
                     "type": "number"
                   }
                 },
-                "required": ["under7Days", "days7To30", "over30Days"]
+                "required": [
+                  "under7Days",
+                  "days7To30",
+                  "over30Days"
+                ]
               },
               "likelyReviewablePullRequests": {
                 "type": "number"
@@ -795,7 +922,11 @@
               },
               "likelyReviewablePullRequestsSource": {
                 "type": "string",
-                "enum": ["cache", "sampled_cache", "authoritative"]
+                "enum": [
+                  "cache",
+                  "sampled_cache",
+                  "authoritative"
+                ]
               }
             },
             "required": [
@@ -848,7 +979,11 @@
                 "type": "number"
               }
             },
-            "required": ["clusterCount", "highRiskCount", "itemsReviewed"]
+            "required": [
+              "clusterCount",
+              "highRiskCount",
+              "itemsReviewed"
+            ]
           },
           "clusters": {
             "type": "array",
@@ -857,7 +992,12 @@
             }
           }
         },
-        "required": ["repoFullName", "generatedAt", "summary", "clusters"]
+        "required": [
+          "repoFullName",
+          "generatedAt",
+          "summary",
+          "clusters"
+        ]
       },
       "CollisionCluster": {
         "type": "object",
@@ -867,7 +1007,11 @@
           },
           "risk": {
             "type": "string",
-            "enum": ["low", "medium", "high"]
+            "enum": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "reason": {
             "type": "string"
@@ -879,14 +1023,22 @@
             }
           }
         },
-        "required": ["id", "risk", "reason", "items"]
+        "required": [
+          "id",
+          "risk",
+          "reason",
+          "items"
+        ]
       },
       "CollisionItem": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": ["issue", "pull_request"]
+            "enum": [
+              "issue",
+              "pull_request"
+            ]
           },
           "number": {
             "type": "number"
@@ -903,7 +1055,11 @@
             "nullable": true
           }
         },
-        "required": ["type", "number", "title"]
+        "required": [
+          "type",
+          "number",
+          "title"
+        ]
       },
       "ConfigQuality": {
         "type": "object",
@@ -919,7 +1075,12 @@
           },
           "level": {
             "type": "string",
-            "enum": ["excellent", "good", "needs_attention", "fragile"]
+            "enum": [
+              "excellent",
+              "good",
+              "needs_attention",
+              "fragile"
+            ]
           },
           "lane": {
             "$ref": "#/components/schemas/LaneAdvice"
@@ -966,7 +1127,13 @@
         "properties": {
           "lane": {
             "type": "string",
-            "enum": ["direct_pr", "issue_discovery", "split", "inactive", "unknown"]
+            "enum": [
+              "direct_pr",
+              "issue_discovery",
+              "split",
+              "inactive",
+              "unknown"
+            ]
           },
           "repoFullName": {
             "type": "string"
@@ -987,7 +1154,13 @@
             "type": "string"
           }
         },
-        "required": ["lane", "repoFullName", "summary", "contributorGuidance", "maintainerGuidance"]
+        "required": [
+          "lane",
+          "repoFullName",
+          "summary",
+          "contributorGuidance",
+          "maintainerGuidance"
+        ]
       },
       "LabelAudit": {
         "type": "object",
@@ -1028,7 +1201,12 @@
                   "type": "boolean"
                 }
               },
-              "required": ["name", "count", "configured", "existsOnGitHub"]
+              "required": [
+                "name",
+                "count",
+                "configured",
+                "existsOnGitHub"
+              ]
             }
           },
           "missingConfiguredLabels": {
@@ -1112,14 +1290,24 @@
               },
               "source": {
                 "type": "string",
-                "enum": ["github", "unavailable"]
+                "enum": [
+                  "github",
+                  "unavailable"
+                ]
               }
             },
-            "required": ["login", "topLanguages", "source"]
+            "required": [
+              "login",
+              "topLanguages",
+              "source"
+            ]
           },
           "source": {
             "type": "string",
-            "enum": ["gittensor_api", "github_cache"]
+            "enum": [
+              "gittensor_api",
+              "github_cache"
+            ]
           },
           "gittensor": {
             "type": "object",
@@ -1344,7 +1532,11 @@
               },
               "level": {
                 "type": "string",
-                "enum": ["new", "emerging", "established"]
+                "enum": [
+                  "new",
+                  "emerging",
+                  "established"
+                ]
               },
               "unlinkedOpenPullRequests": {
                 "type": "number"
@@ -1384,22 +1576,38 @@
           },
           "fit": {
             "type": "string",
-            "enum": ["good", "caution", "hold"]
+            "enum": [
+              "good",
+              "caution",
+              "hold"
+            ]
           },
           "score": {
             "type": "number"
           },
           "lane": {
             "type": "string",
-            "enum": ["direct_pr", "issue_discovery", "split", "inactive", "unknown"]
+            "enum": [
+              "direct_pr",
+              "issue_discovery",
+              "split",
+              "inactive",
+              "unknown"
+            ]
           },
           "multiplierTier": {
             "type": "string",
-            "enum": ["maintainer_created", "community"]
+            "enum": [
+              "maintainer_created",
+              "community"
+            ]
           },
           "availability": {
             "type": "string",
-            "enum": ["ready", "maintainer_wip"]
+            "enum": [
+              "ready",
+              "maintainer_wip"
+            ]
           },
           "reasons": {
             "type": "array",
@@ -1439,7 +1647,10 @@
             }
           }
         },
-        "required": ["profile", "opportunities"]
+        "required": [
+          "profile",
+          "opportunities"
+        ]
       },
       "ContributorFit": {
         "type": "object",
@@ -1472,7 +1683,10 @@
                   "type": "boolean"
                 }
               },
-              "required": ["repoFullName", "match"]
+              "required": [
+                "repoFullName",
+                "match"
+              ]
             }
           },
           "repoStats": {
@@ -1583,7 +1797,13 @@
           },
           "source": {
             "type": "string",
-            "enum": ["github_association", "repo_owner_match", "gittensor_api", "cache", "unknown"]
+            "enum": [
+              "github_association",
+              "repo_owner_match",
+              "gittensor_api",
+              "cache",
+              "unknown"
+            ]
           },
           "association": {
             "type": "string",
@@ -1622,7 +1842,10 @@
           },
           "source": {
             "type": "string",
-            "enum": ["gittensor_api", "github_cache"]
+            "enum": [
+              "gittensor_api",
+              "github_cache"
+            ]
           },
           "reconciliation": {
             "type": "object",
@@ -1635,7 +1858,10 @@
               },
               "source": {
                 "type": "string",
-                "enum": ["gittensor_api", "github_cache"]
+                "enum": [
+                  "gittensor_api",
+                  "github_cache"
+                ]
               },
               "officialAuthoritative": {
                 "type": "boolean"
@@ -1809,7 +2035,10 @@
                     ]
                   }
                 },
-                "required": ["cached", "effective"]
+                "required": [
+                  "cached",
+                  "effective"
+                ]
               },
               "repos": {
                 "type": "array",
@@ -2059,7 +2288,10 @@
           },
           "patternType": {
             "type": "string",
-            "enum": ["success", "failure"]
+            "enum": [
+              "success",
+              "failure"
+            ]
           },
           "patterns": {
             "type": "array",
@@ -2074,18 +2306,29 @@
             "type": "string"
           }
         },
-        "required": ["login", "generatedAt", "patternType", "patterns", "summary"]
+        "required": [
+          "login",
+          "generatedAt",
+          "patternType",
+          "patterns",
+          "summary"
+        ]
       },
       "ContributorDecisionPack": {
         "type": "object",
         "properties": {
           "status": {
             "type": "string",
-            "enum": ["ready"]
+            "enum": [
+              "ready"
+            ]
           },
           "source": {
             "type": "string",
-            "enum": ["computed", "snapshot"]
+            "enum": [
+              "computed",
+              "snapshot"
+            ]
           },
           "login": {
             "type": "string"
@@ -2252,7 +2495,12 @@
       },
       "DecisionPackFreshness": {
         "type": "string",
-        "enum": ["fresh", "stale", "rebuilding", "missing"]
+        "enum": [
+          "fresh",
+          "stale",
+          "rebuilding",
+          "missing"
+        ]
       },
       "AgentRecommendationOutcomeSummary": {
         "type": "object",
@@ -2327,7 +2575,10 @@
                 "type": "number"
               }
             },
-            "required": ["explicit", "inferred"]
+            "required": [
+              "explicit",
+              "inferred"
+            ]
           },
           "states": {
             "type": "array",
@@ -2354,7 +2605,10 @@
                 }
               }
             },
-            "required": ["total", "states"]
+            "required": [
+              "total",
+              "states"
+            ]
           },
           "privateSummary": {
             "type": "string"
@@ -2382,11 +2636,22 @@
             "type": "number"
           }
         },
-        "required": ["state", "count"]
+        "required": [
+          "state",
+          "count"
+        ]
       },
       "AgentRecommendationOutcomeState": {
         "type": "string",
-        "enum": ["accepted", "rejected", "ignored", "stale", "merged", "closed", "improved"]
+        "enum": [
+          "accepted",
+          "rejected",
+          "ignored",
+          "stale",
+          "merged",
+          "closed",
+          "improved"
+        ]
       },
       "AgentRecommendationOutcomeRepoSummary": {
         "type": "object",
@@ -2433,7 +2698,12 @@
           },
           "signal": {
             "type": "string",
-            "enum": ["positive", "negative", "mixed", "neutral"]
+            "enum": [
+              "positive",
+              "negative",
+              "mixed",
+              "neutral"
+            ]
           }
         },
         "required": [
@@ -2492,7 +2762,10 @@
                   "properties": {
                     "source": {
                       "type": "string",
-                      "enum": ["github_observed", "user_supplied"]
+                      "enum": [
+                        "github_observed",
+                        "user_supplied"
+                      ]
                     },
                     "pendingMergedPrCount": {
                       "type": "number"
@@ -2536,7 +2809,13 @@
                             }
                           }
                         },
-                        "required": ["repoFullName", "number", "title", "classification", "reasons"]
+                        "required": [
+                          "repoFullName",
+                          "number",
+                          "title",
+                          "classification",
+                          "reasons"
+                        ]
                       }
                     }
                   },
@@ -2550,7 +2829,10 @@
                   ]
                 }
               },
-              "required": ["repoFullName", "detection"]
+              "required": [
+                "repoFullName",
+                "detection"
+              ]
             }
           },
           "pullRequests": {
@@ -2631,7 +2913,9 @@
         "properties": {
           "status": {
             "type": "string",
-            "enum": ["needs_snapshot_refresh"]
+            "enum": [
+              "needs_snapshot_refresh"
+            ]
           },
           "login": {
             "type": "string"
@@ -2644,24 +2928,37 @@
           },
           "reason": {
             "type": "string",
-            "enum": ["missing_snapshot"]
+            "enum": [
+              "missing_snapshot"
+            ]
           },
           "freshness": {
             "type": "string",
-            "enum": ["missing"]
+            "enum": [
+              "missing"
+            ]
           },
           "rebuildEnqueued": {
             "type": "boolean"
           }
         },
-        "required": ["status", "login", "generatedAt", "reason", "freshness", "rebuildEnqueued"]
+        "required": [
+          "status",
+          "login",
+          "generatedAt",
+          "reason",
+          "freshness",
+          "rebuildEnqueued"
+        ]
       },
       "RepoDecisionResponse": {
         "type": "object",
         "properties": {
           "status": {
             "type": "string",
-            "enum": ["ready"]
+            "enum": [
+              "ready"
+            ]
           },
           "login": {
             "type": "string"
@@ -2674,7 +2971,10 @@
           },
           "source": {
             "type": "string",
-            "enum": ["computed", "snapshot"]
+            "enum": [
+              "computed",
+              "snapshot"
+            ]
           },
           "freshness": {
             "$ref": "#/components/schemas/DecisionPackFreshness"
@@ -2712,11 +3012,16 @@
         "properties": {
           "status": {
             "type": "string",
-            "enum": ["ready"]
+            "enum": [
+              "ready"
+            ]
           },
           "source": {
             "type": "string",
-            "enum": ["computed", "snapshot"]
+            "enum": [
+              "computed",
+              "snapshot"
+            ]
           },
           "repoFullName": {
             "type": "string"
@@ -2806,7 +3111,10 @@
             "properties": {
               "source": {
                 "type": "string",
-                "enum": ["snapshot", "computed"]
+                "enum": [
+                  "snapshot",
+                  "computed"
+                ]
               },
               "generatedAt": {
                 "type": "string"
@@ -2816,10 +3124,18 @@
               },
               "freshness": {
                 "type": "string",
-                "enum": ["fresh", "stale"]
+                "enum": [
+                  "fresh",
+                  "stale"
+                ]
               }
             },
-            "required": ["source", "generatedAt", "ageSeconds", "freshness"]
+            "required": [
+              "source",
+              "generatedAt",
+              "ageSeconds",
+              "freshness"
+            ]
           }
         },
         "required": [
@@ -2845,17 +3161,26 @@
             "anyOf": [
               {
                 "type": "number",
-                "enum": [7]
+                "enum": [
+                  7
+                ]
               },
               {
                 "type": "number",
-                "enum": [30]
+                "enum": [
+                  30
+                ]
               }
             ]
           },
           "level": {
             "type": "string",
-            "enum": ["low", "medium", "high", "critical"]
+            "enum": [
+              "low",
+              "medium",
+              "high",
+              "critical"
+            ]
           },
           "forecast": {
             "type": "object",
@@ -2894,7 +3219,13 @@
           },
           "lane": {
             "type": "string",
-            "enum": ["direct_pr", "issue_discovery", "split", "inactive", "unknown"]
+            "enum": [
+              "direct_pr",
+              "issue_discovery",
+              "split",
+              "inactive",
+              "unknown"
+            ]
           },
           "primaryLanguage": {
             "type": "string",
@@ -3001,7 +3332,11 @@
           },
           "status": {
             "type": "string",
-            "enum": ["complete", "partial", "missing"]
+            "enum": [
+              "complete",
+              "partial",
+              "missing"
+            ]
           }
         },
         "required": [
@@ -3021,11 +3356,16 @@
         "properties": {
           "status": {
             "type": "string",
-            "enum": ["ready"]
+            "enum": [
+              "ready"
+            ]
           },
           "source": {
             "type": "string",
-            "enum": ["snapshot", "computed"]
+            "enum": [
+              "snapshot",
+              "computed"
+            ]
           },
           "repoFullName": {
             "type": "string"
@@ -3038,7 +3378,10 @@
           },
           "freshness": {
             "type": "string",
-            "enum": ["fresh", "stale"]
+            "enum": [
+              "fresh",
+              "stale"
+            ]
           },
           "patterns": {
             "$ref": "#/components/schemas/RepoOutcomePatterns"
@@ -3074,7 +3417,11 @@
           },
           "recommendedRegistrationMode": {
             "type": "string",
-            "enum": ["direct_pr", "issue_discovery", "split"]
+            "enum": [
+              "direct_pr",
+              "issue_discovery",
+              "split"
+            ]
           },
           "issuePolicy": {
             "type": "string",
@@ -3098,7 +3445,10 @@
                 }
               }
             },
-            "required": ["ready", "reasons"]
+            "required": [
+              "ready",
+              "reasons"
+            ]
           },
           "issueDiscoveryReadiness": {
             "type": "object",
@@ -3108,7 +3458,11 @@
               },
               "recommendation": {
                 "type": "string",
-                "enum": ["enabled", "recommended", "not_recommended"]
+                "enum": [
+                  "enabled",
+                  "recommended",
+                  "not_recommended"
+                ]
               },
               "reasons": {
                 "type": "array",
@@ -3117,7 +3471,11 @@
                 }
               }
             },
-            "required": ["ready", "recommendation", "reasons"]
+            "required": [
+              "ready",
+              "recommendation",
+              "reasons"
+            ]
           },
           "labelPolicy": {
             "type": "object",
@@ -3136,14 +3494,20 @@
             "properties": {
               "status": {
                 "type": "string",
-                "enum": ["gate_ready", "gate_unknown"]
+                "enum": [
+                  "gate_ready",
+                  "gate_unknown"
+                ]
               },
               "trustedLabelPipelineReady": {
                 "type": "boolean"
               },
               "checkRunMode": {
                 "type": "string",
-                "enum": ["off", "enabled"]
+                "enum": [
+                  "off",
+                  "enabled"
+                ]
               },
               "requiredGate": {
                 "type": "array",
@@ -3175,7 +3539,12 @@
             "properties": {
               "level": {
                 "type": "string",
-                "enum": ["low", "medium", "high", "critical"]
+                "enum": [
+                  "low",
+                  "medium",
+                  "high",
+                  "critical"
+                ]
               },
               "burdenScore": {
                 "type": "number"
@@ -3187,7 +3556,12 @@
                 "type": "string"
               }
             },
-            "required": ["level", "burdenScore", "reviewablePullRequests", "summary"]
+            "required": [
+              "level",
+              "burdenScore",
+              "reviewablePullRequests",
+              "summary"
+            ]
           },
           "contributorIntakeHealth": {
             "type": "object",
@@ -3209,23 +3583,41 @@
               },
               "publicSurface": {
                 "type": "string",
-                "enum": ["off", "comment_and_label", "comment_only", "label_only"]
+                "enum": [
+                  "off",
+                  "comment_and_label",
+                  "comment_only",
+                  "label_only"
+                ]
               },
               "commentMode": {
                 "type": "string",
-                "enum": ["off", "detected_contributors_only", "all_prs"]
+                "enum": [
+                  "off",
+                  "detected_contributors_only",
+                  "all_prs"
+                ]
               },
               "publicAudienceMode": {
                 "type": "string",
-                "enum": ["oss_maintainer", "gittensor_only"]
+                "enum": [
+                  "oss_maintainer",
+                  "gittensor_only"
+                ]
               },
               "checkRunMode": {
                 "type": "string",
-                "enum": ["off", "enabled"]
+                "enum": [
+                  "off",
+                  "enabled"
+                ]
               },
               "gateCheckMode": {
                 "type": "string",
-                "enum": ["off", "enabled"]
+                "enum": [
+                  "off",
+                  "enabled"
+                ]
               },
               "quietByDefault": {
                 "type": "boolean"
@@ -3241,7 +3633,11 @@
               },
               "reviewCheckMode": {
                 "type": "string",
-                "enum": ["required", "visible", "disabled"]
+                "enum": [
+                  "required",
+                  "visible",
+                  "disabled"
+                ]
               }
             },
             "required": [
@@ -3266,7 +3662,9 @@
               },
               "source": {
                 "type": "string",
-                "enum": ["focus_manifest_policy"]
+                "enum": [
+                  "focus_manifest_policy"
+                ]
               },
               "previewOnly": {
                 "type": "boolean"
@@ -3294,7 +3692,11 @@
                     },
                     "severity": {
                       "type": "string",
-                      "enum": ["info", "warning", "critical"]
+                      "enum": [
+                        "info",
+                        "warning",
+                        "critical"
+                      ]
                     },
                     "title": {
                       "type": "string"
@@ -3306,7 +3708,14 @@
                       "type": "string"
                     }
                   },
-                  "required": ["code", "category", "severity", "title", "detail", "action"]
+                  "required": [
+                    "code",
+                    "category",
+                    "severity",
+                    "title",
+                    "detail",
+                    "action"
+                  ]
                 }
               },
               "droppedPublicWarnings": {
@@ -3319,10 +3728,15 @@
                     },
                     "reason": {
                       "type": "string",
-                      "enum": ["unsafe_public_text"]
+                      "enum": [
+                        "unsafe_public_text"
+                      ]
                     }
                   },
-                  "required": ["code", "reason"]
+                  "required": [
+                    "code",
+                    "reason"
+                  ]
                 }
               },
               "summary": {
@@ -3351,15 +3765,21 @@
               },
               "source": {
                 "type": "string",
-                "enum": ["policy_compiler"]
+                "enum": [
+                  "policy_compiler"
+                ]
               },
               "previewOnly": {
                 "type": "boolean",
-                "enum": [true]
+                "enum": [
+                  true
+                ]
               },
               "publicSafe": {
                 "type": "boolean",
-                "enum": [true]
+                "enum": [
+                  true
+                ]
               },
               "contributionLanes": {
                 "type": "array",
@@ -3437,7 +3857,12 @@
                     "nullable": true
                   }
                 },
-                "required": ["preferredLabels", "requiredLabels", "discouragedLabels", "note"]
+                "required": [
+                  "preferredLabels",
+                  "requiredLabels",
+                  "discouragedLabels",
+                  "note"
+                ]
               },
               "validationExpectations": {
                 "type": "array",
@@ -3476,10 +3901,16 @@
                     },
                     "reason": {
                       "type": "string",
-                      "enum": ["empty", "unsafe_public_text"]
+                      "enum": [
+                        "empty",
+                        "unsafe_public_text"
+                      ]
                     }
                   },
-                  "required": ["field", "reason"]
+                  "required": [
+                    "field",
+                    "reason"
+                  ]
                 }
               },
               "privateOwnerContext": {
@@ -3490,21 +3921,30 @@
                   },
                   "includedInPublicPreview": {
                     "type": "boolean",
-                    "enum": [false]
+                    "enum": [
+                      false
+                    ]
                   }
                 },
-                "required": ["itemCount", "includedInPublicPreview"]
+                "required": [
+                  "itemCount",
+                  "includedInPublicPreview"
+                ]
               },
               "publication": {
                 "type": "object",
                 "properties": {
                   "status": {
                     "type": "string",
-                    "enum": ["preview_only"]
+                    "enum": [
+                      "preview_only"
+                    ]
                   },
                   "allowed": {
                     "type": "boolean",
-                    "enum": [false]
+                    "enum": [
+                      false
+                    ]
                   },
                   "actions": {
                     "type": "array",
@@ -3516,7 +3956,12 @@
                     "type": "string"
                   }
                 },
-                "required": ["status", "allowed", "actions", "reason"]
+                "required": [
+                  "status",
+                  "allowed",
+                  "actions",
+                  "reason"
+                ]
               }
             },
             "required": [
@@ -3660,11 +4105,21 @@
           },
           "recommendation": {
             "type": "string",
-            "enum": ["pursue", "cleanup_first", "maintainer_lane", "avoid_for_now", "unknown"]
+            "enum": [
+              "pursue",
+              "cleanup_first",
+              "maintainer_lane",
+              "avoid_for_now",
+              "unknown"
+            ]
           },
           "confidence": {
             "type": "string",
-            "enum": ["high", "medium", "low"]
+            "enum": [
+              "high",
+              "medium",
+              "low"
+            ]
           },
           "reasons": {
             "type": "array",
@@ -3727,14 +4182,22 @@
           },
           "status": {
             "type": "string",
-            "enum": ["ready", "needs_work", "hold"]
+            "enum": [
+              "ready",
+              "needs_work",
+              "hold"
+            ]
           },
           "lane": {
             "$ref": "#/components/schemas/LaneAdvice"
           },
           "reviewBurden": {
             "type": "string",
-            "enum": ["low", "medium", "high"]
+            "enum": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "linkedIssues": {
             "type": "array",
@@ -3809,7 +4272,9 @@
                 ]
               }
             },
-            "required": ["localDiff"]
+            "required": [
+              "localDiff"
+            ]
           }
         ]
       },
@@ -3839,7 +4304,12 @@
             "properties": {
               "status": {
                 "type": "string",
-                "enum": ["fresh", "stale", "possibly_stale", "unknown"]
+                "enum": [
+                  "fresh",
+                  "stale",
+                  "possibly_stale",
+                  "unknown"
+                ]
               },
               "baseRef": {
                 "type": "string"
@@ -4096,13 +4566,21 @@
                         },
                         "severity": {
                           "type": "string",
-                          "enum": ["blocker", "reducer", "context"]
+                          "enum": [
+                            "blocker",
+                            "reducer",
+                            "context"
+                          ]
                         },
                         "detail": {
                           "type": "string"
                         }
                       },
-                      "required": ["code", "severity", "detail"]
+                      "required": [
+                        "code",
+                        "severity",
+                        "detail"
+                      ]
                     }
                   },
                   "linkedIssueMultiplier": {
@@ -4110,7 +4588,11 @@
                     "properties": {
                       "mode": {
                         "type": "string",
-                        "enum": ["none", "standard", "maintainer"]
+                        "enum": [
+                          "none",
+                          "standard",
+                          "maintainer"
+                        ]
                       },
                       "status": {
                         "type": "string",
@@ -4393,13 +4875,21 @@
                         },
                         "severity": {
                           "type": "string",
-                          "enum": ["blocker", "reducer", "context"]
+                          "enum": [
+                            "blocker",
+                            "reducer",
+                            "context"
+                          ]
                         },
                         "detail": {
                           "type": "string"
                         }
                       },
-                      "required": ["code", "severity", "detail"]
+                      "required": [
+                        "code",
+                        "severity",
+                        "detail"
+                      ]
                     }
                   },
                   "linkedIssueMultiplier": {
@@ -4407,7 +4897,11 @@
                     "properties": {
                       "mode": {
                         "type": "string",
-                        "enum": ["none", "standard", "maintainer"]
+                        "enum": [
+                          "none",
+                          "standard",
+                          "maintainer"
+                        ]
                       },
                       "status": {
                         "type": "string",
@@ -4690,13 +5184,21 @@
                         },
                         "severity": {
                           "type": "string",
-                          "enum": ["blocker", "reducer", "context"]
+                          "enum": [
+                            "blocker",
+                            "reducer",
+                            "context"
+                          ]
                         },
                         "detail": {
                           "type": "string"
                         }
                       },
-                      "required": ["code", "severity", "detail"]
+                      "required": [
+                        "code",
+                        "severity",
+                        "detail"
+                      ]
                     }
                   },
                   "linkedIssueMultiplier": {
@@ -4704,7 +5206,11 @@
                     "properties": {
                       "mode": {
                         "type": "string",
-                        "enum": ["none", "standard", "maintainer"]
+                        "enum": [
+                          "none",
+                          "standard",
+                          "maintainer"
+                        ]
                       },
                       "status": {
                         "type": "string",
@@ -4987,13 +5493,21 @@
                         },
                         "severity": {
                           "type": "string",
-                          "enum": ["blocker", "reducer", "context"]
+                          "enum": [
+                            "blocker",
+                            "reducer",
+                            "context"
+                          ]
                         },
                         "detail": {
                           "type": "string"
                         }
                       },
-                      "required": ["code", "severity", "detail"]
+                      "required": [
+                        "code",
+                        "severity",
+                        "detail"
+                      ]
                     }
                   },
                   "linkedIssueMultiplier": {
@@ -5001,7 +5515,11 @@
                     "properties": {
                       "mode": {
                         "type": "string",
-                        "enum": ["none", "standard", "maintainer"]
+                        "enum": [
+                          "none",
+                          "standard",
+                          "maintainer"
+                        ]
                       },
                       "status": {
                         "type": "string",
@@ -5284,13 +5802,21 @@
                         },
                         "severity": {
                           "type": "string",
-                          "enum": ["blocker", "reducer", "context"]
+                          "enum": [
+                            "blocker",
+                            "reducer",
+                            "context"
+                          ]
                         },
                         "detail": {
                           "type": "string"
                         }
                       },
-                      "required": ["code", "severity", "detail"]
+                      "required": [
+                        "code",
+                        "severity",
+                        "detail"
+                      ]
                     }
                   },
                   "linkedIssueMultiplier": {
@@ -5298,7 +5824,11 @@
                     "properties": {
                       "mode": {
                         "type": "string",
-                        "enum": ["none", "standard", "maintainer"]
+                        "enum": [
+                          "none",
+                          "standard",
+                          "maintainer"
+                        ]
                       },
                       "status": {
                         "type": "string",
@@ -5409,7 +5939,12 @@
                       "type": "string"
                     }
                   },
-                  "required": ["gate", "current", "projected", "explanation"]
+                  "required": [
+                    "gate",
+                    "current",
+                    "projected",
+                    "explanation"
+                  ]
                 }
               },
               "blockedBy": {
@@ -5440,17 +5975,30 @@
                     },
                     "severity": {
                       "type": "string",
-                      "enum": ["blocker", "reducer", "context"]
+                      "enum": [
+                        "blocker",
+                        "reducer",
+                        "context"
+                      ]
                     },
                     "detail": {
                       "type": "string"
                     }
                   },
-                  "required": ["code", "severity", "detail"]
+                  "required": [
+                    "code",
+                    "severity",
+                    "detail"
+                  ]
                 }
               }
             },
-            "required": ["current", "bestReasonableCase", "gateDeltas", "blockedBy"]
+            "required": [
+              "current",
+              "bestReasonableCase",
+              "gateDeltas",
+              "blockedBy"
+            ]
           },
           "observedPullRequestScenarios": {
             "type": "object",
@@ -5495,7 +6043,9 @@
             "properties": {
               "source": {
                 "type": "string",
-                "enum": ["cached_github_data"]
+                "enum": [
+                  "cached_github_data"
+                ]
               },
               "status": {
                 "type": "string",
@@ -5530,7 +6080,11 @@
                 }
               }
             },
-            "required": ["source", "status", "notes"]
+            "required": [
+              "source",
+              "status",
+              "notes"
+            ]
           },
           "branchEligibility": {
             "type": "object",
@@ -5540,11 +6094,19 @@
               },
               "status": {
                 "type": "string",
-                "enum": ["eligible", "ineligible", "unknown", "not_required"]
+                "enum": [
+                  "eligible",
+                  "ineligible",
+                  "unknown",
+                  "not_required"
+                ]
               },
               "evidence": {
                 "type": "string",
-                "enum": ["provided", "missing"]
+                "enum": [
+                  "provided",
+                  "missing"
+                ]
               },
               "source": {
                 "type": "string",
@@ -5572,7 +6134,14 @@
                 }
               }
             },
-            "required": ["required", "status", "evidence", "source", "stale", "warnings"]
+            "required": [
+              "required",
+              "status",
+              "evidence",
+              "source",
+              "stale",
+              "warnings"
+            ]
           },
           "rewardRisk": {
             "$ref": "#/components/schemas/RepoRewardRisk"
@@ -5609,11 +6178,21 @@
             "properties": {
               "recommendation": {
                 "type": "string",
-                "enum": ["pursue", "cleanup_first", "maintainer_lane", "avoid_for_now", "unknown"]
+                "enum": [
+                  "pursue",
+                  "cleanup_first",
+                  "maintainer_lane",
+                  "avoid_for_now",
+                  "unknown"
+                ]
               },
               "reviewBurden": {
                 "type": "string",
-                "enum": ["low", "medium", "high"]
+                "enum": [
+                  "low",
+                  "medium",
+                  "high"
+                ]
               },
               "role": {
                 "type": "string",
@@ -5659,15 +6238,27 @@
               },
               "source": {
                 "type": "string",
-                "enum": ["repo_file", "api_record", "none"]
+                "enum": [
+                  "repo_file",
+                  "api_record",
+                  "none"
+                ]
               },
               "linkedIssuePolicy": {
                 "type": "string",
-                "enum": ["required", "preferred", "optional"]
+                "enum": [
+                  "required",
+                  "preferred",
+                  "optional"
+                ]
               },
               "issueDiscoveryPolicy": {
                 "type": "string",
-                "enum": ["encouraged", "neutral", "discouraged"]
+                "enum": [
+                  "encouraged",
+                  "neutral",
+                  "discouraged"
+                ]
               },
               "matchedWantedPaths": {
                 "type": "array",
@@ -5697,7 +6288,11 @@
                     },
                     "severity": {
                       "type": "string",
-                      "enum": ["info", "warning", "critical"]
+                      "enum": [
+                        "info",
+                        "warning",
+                        "critical"
+                      ]
                     },
                     "title": {
                       "type": "string"
@@ -5709,7 +6304,12 @@
                       "type": "string"
                     }
                   },
-                  "required": ["code", "severity", "title", "detail"]
+                  "required": [
+                    "code",
+                    "severity",
+                    "title",
+                    "detail"
+                  ]
                 }
               },
               "publicNextSteps": {
@@ -5766,7 +6366,10 @@
                       }
                     }
                   },
-                  "required": ["heading", "lines"]
+                  "required": [
+                    "heading",
+                    "lines"
+                  ]
                 }
               },
               "reviewerNotes": {
@@ -5797,7 +6400,14 @@
                         },
                         "status": {
                           "type": "string",
-                          "enum": ["passed", "failed", "not_run", "skipped", "focused", "unknown"]
+                          "enum": [
+                            "passed",
+                            "failed",
+                            "not_run",
+                            "skipped",
+                            "focused",
+                            "unknown"
+                          ]
                         },
                         "summary": {
                           "type": "string"
@@ -5809,11 +6419,19 @@
                           "type": "number"
                         }
                       },
-                      "required": ["command", "status"]
+                      "required": [
+                        "command",
+                        "status"
+                      ]
                     }
                   }
                 },
-                "required": ["passed", "failed", "notRun", "commands"]
+                "required": [
+                  "passed",
+                  "failed",
+                  "notRun",
+                  "commands"
+                ]
               },
               "publicSafeWarnings": {
                 "type": "array",
@@ -5894,7 +6512,9 @@
           },
           "privateOnly": {
             "type": "boolean",
-            "enum": [true]
+            "enum": [
+              true
+            ]
           },
           "laneMath": {
             "type": "object",
@@ -5970,11 +6590,22 @@
             "properties": {
               "mode": {
                 "type": "string",
-                "enum": ["none", "standard", "maintainer"]
+                "enum": [
+                  "none",
+                  "standard",
+                  "maintainer"
+                ]
               },
               "status": {
                 "type": "string",
-                "enum": ["not_required", "raw", "plausible", "validated", "invalid", "unavailable"]
+                "enum": [
+                  "not_required",
+                  "raw",
+                  "plausible",
+                  "validated",
+                  "invalid",
+                  "unavailable"
+                ]
               },
               "source": {
                 "type": "string",
@@ -6110,11 +6741,19 @@
               },
               "status": {
                 "type": "string",
-                "enum": ["eligible", "ineligible", "unknown", "not_required"]
+                "enum": [
+                  "eligible",
+                  "ineligible",
+                  "unknown",
+                  "not_required"
+                ]
               },
               "evidence": {
                 "type": "string",
-                "enum": ["provided", "missing"]
+                "enum": [
+                  "provided",
+                  "missing"
+                ]
               },
               "source": {
                 "type": "string",
@@ -6142,7 +6781,14 @@
                 }
               }
             },
-            "required": ["required", "status", "evidence", "source", "stale", "warnings"]
+            "required": [
+              "required",
+              "status",
+              "evidence",
+              "source",
+              "stale",
+              "warnings"
+            ]
           },
           "effectiveEstimatedScore": {
             "type": "number"
@@ -6178,13 +6824,21 @@
                 },
                 "severity": {
                   "type": "string",
-                  "enum": ["blocker", "reducer", "context"]
+                  "enum": [
+                    "blocker",
+                    "reducer",
+                    "context"
+                  ]
                 },
                 "detail": {
                   "type": "string"
                 }
               },
-              "required": ["code", "severity", "detail"]
+              "required": [
+                "code",
+                "severity",
+                "detail"
+              ]
             }
           },
           "gateDeltas": {
@@ -6213,7 +6867,12 @@
                   "type": "string"
                 }
               },
-              "required": ["gate", "current", "projected", "explanation"]
+              "required": [
+                "gate",
+                "current",
+                "projected",
+                "explanation"
+              ]
             }
           },
           "scenarioPreviews": {
@@ -6416,13 +7075,21 @@
                       },
                       "severity": {
                         "type": "string",
-                        "enum": ["blocker", "reducer", "context"]
+                        "enum": [
+                          "blocker",
+                          "reducer",
+                          "context"
+                        ]
                       },
                       "detail": {
                         "type": "string"
                       }
                     },
-                    "required": ["code", "severity", "detail"]
+                    "required": [
+                      "code",
+                      "severity",
+                      "detail"
+                    ]
                   }
                 },
                 "linkedIssueMultiplier": {
@@ -6430,7 +7097,11 @@
                   "properties": {
                     "mode": {
                       "type": "string",
-                      "enum": ["none", "standard", "maintainer"]
+                      "enum": [
+                        "none",
+                        "standard",
+                        "maintainer"
+                      ]
                     },
                     "status": {
                       "type": "string",
@@ -6518,7 +7189,12 @@
           },
           "scoreabilityStatus": {
             "type": "string",
-            "enum": ["blocked", "conditionally_scoreable", "scoreable", "hold"]
+            "enum": [
+              "blocked",
+              "conditionally_scoreable",
+              "scoreable",
+              "hold"
+            ]
           },
           "warnings": {
             "type": "array",
@@ -6537,7 +7213,12 @@
             "properties": {
               "level": {
                 "type": "string",
-                "enum": ["strong_fit", "reasonable_fit", "needs_work", "hold"]
+                "enum": [
+                  "strong_fit",
+                  "reasonable_fit",
+                  "needs_work",
+                  "hold"
+                ]
               },
               "actions": {
                 "type": "array",
@@ -6546,7 +7227,10 @@
                 }
               }
             },
-            "required": ["level", "actions"]
+            "required": [
+              "level",
+              "actions"
+            ]
           }
         },
         "required": [
@@ -6591,14 +7275,25 @@
           },
           "recommendation": {
             "type": "string",
-            "enum": ["pursue", "cleanup_first", "maintainer_lane", "avoid_for_now", "unknown"]
+            "enum": [
+              "pursue",
+              "cleanup_first",
+              "maintainer_lane",
+              "avoid_for_now",
+              "unknown"
+            ]
           },
           "rewardUpside": {
             "type": "object",
             "properties": {
               "relevantLane": {
                 "type": "string",
-                "enum": ["direct_pr", "issue_discovery", "maintainer_lane", "none"]
+                "enum": [
+                  "direct_pr",
+                  "issue_discovery",
+                  "maintainer_lane",
+                  "none"
+                ]
               },
               "repoSlice": {
                 "type": "number"
@@ -6634,7 +7329,10 @@
                     "type": "number"
                   }
                 },
-                "required": ["competitionFactor", "freshnessFactor"]
+                "required": [
+                  "competitionFactor",
+                  "freshnessFactor"
+                ]
               }
             },
             "required": [
@@ -6661,7 +7359,12 @@
             "properties": {
               "queueBurden": {
                 "type": "string",
-                "enum": ["low", "medium", "high", "critical"]
+                "enum": [
+                  "low",
+                  "medium",
+                  "high",
+                  "critical"
+                ]
               },
               "queueBurdenScore": {
                 "type": "number"
@@ -6683,7 +7386,11 @@
               },
               "reviewChurnRisk": {
                 "type": "string",
-                "enum": ["low", "medium", "high"]
+                "enum": [
+                  "low",
+                  "medium",
+                  "high"
+                ]
               }
             },
             "required": [
@@ -6776,7 +7483,12 @@
           },
           "severity": {
             "type": "string",
-            "enum": ["critical", "warning", "tip", "info"]
+            "enum": [
+              "critical",
+              "warning",
+              "tip",
+              "info"
+            ]
           },
           "priorityScore": {
             "type": "number"
@@ -6832,20 +7544,27 @@
         "properties": {
           "version": {
             "type": "number",
-            "enum": [2]
+            "enum": [
+              2
+            ]
           },
           "sourceUpload": {
             "type": "object",
             "properties": {
               "enabled": {
                 "type": "boolean",
-                "enum": [false]
+                "enum": [
+                  false
+                ]
               },
               "detail": {
                 "type": "string"
               }
             },
-            "required": ["enabled", "detail"]
+            "required": [
+              "enabled",
+              "detail"
+            ]
           },
           "branch": {
             "type": "object",
@@ -6863,7 +7582,9 @@
                 "type": "number"
               }
             },
-            "required": ["pendingCommitCount"]
+            "required": [
+              "pendingCommitCount"
+            ]
           },
           "changedFiles": {
             "type": "object",
@@ -6893,14 +7614,27 @@
                 }
               }
             },
-            "required": ["total", "added", "modified", "deleted", "renamed", "binary", "paths"]
+            "required": [
+              "total",
+              "added",
+              "modified",
+              "deleted",
+              "renamed",
+              "binary",
+              "paths"
+            ]
           },
           "testEvidence": {
             "type": "object",
             "properties": {
               "level": {
                 "type": "string",
-                "enum": ["test_files", "validation_commands", "both", "none"]
+                "enum": [
+                  "test_files",
+                  "validation_commands",
+                  "both",
+                  "none"
+                ]
               },
               "testFileCount": {
                 "type": "number"
@@ -6918,17 +7652,29 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": ["passed", "failed", "not_run"]
+                      "enum": [
+                        "passed",
+                        "failed",
+                        "not_run"
+                      ]
                     },
                     "summary": {
                       "type": "string"
                     }
                   },
-                  "required": ["command", "status"]
+                  "required": [
+                    "command",
+                    "status"
+                  ]
                 }
               }
             },
-            "required": ["level", "testFileCount", "passedValidationCount", "commands"]
+            "required": [
+              "level",
+              "testFileCount",
+              "passedValidationCount",
+              "commands"
+            ]
           },
           "linkedIssues": {
             "type": "array",
@@ -6941,7 +7687,12 @@
             "properties": {
               "status": {
                 "type": "string",
-                "enum": ["fresh", "stale", "possibly_stale", "unknown"]
+                "enum": [
+                  "fresh",
+                  "stale",
+                  "possibly_stale",
+                  "unknown"
+                ]
               },
               "baseRef": {
                 "type": "string"
@@ -7010,7 +7761,11 @@
                 "type": "boolean"
               }
             },
-            "required": ["mode", "warnings", "metadataOnly"]
+            "required": [
+              "mode",
+              "warnings",
+              "metadataOnly"
+            ]
           },
           "blockers": {
             "type": "object",
@@ -7028,7 +7783,10 @@
                 }
               }
             },
-            "required": ["branchQuality", "accountState"]
+            "required": [
+              "branchQuality",
+              "accountState"
+            ]
           },
           "rerunWhen": {
             "type": "string"
@@ -7082,7 +7840,11 @@
                 },
                 "reviewPriority": {
                   "type": "string",
-                  "enum": ["review", "needs_author", "watch"]
+                  "enum": [
+                    "review",
+                    "needs_author",
+                    "watch"
+                  ]
                 },
                 "reasons": {
                   "type": "array",
@@ -7091,7 +7853,12 @@
                   }
                 }
               },
-              "required": ["number", "title", "reviewPriority", "reasons"]
+              "required": [
+                "number",
+                "title",
+                "reviewPriority",
+                "reasons"
+              ]
             }
           },
           "suggestedActions": {
@@ -7172,7 +7939,12 @@
           },
           "level": {
             "type": "string",
-            "enum": ["healthy", "watch", "strained", "blocked"]
+            "enum": [
+              "healthy",
+              "watch",
+              "strained",
+              "blocked"
+            ]
           },
           "score": {
             "type": "number"
@@ -7185,7 +7957,12 @@
           },
           "configLevel": {
             "type": "string",
-            "enum": ["excellent", "good", "needs_attention", "fragile"]
+            "enum": [
+              "excellent",
+              "good",
+              "needs_attention",
+              "fragile"
+            ]
           },
           "duplicateClusters": {
             "type": "number"
@@ -7277,7 +8054,11 @@
           },
           "reviewPriority": {
             "type": "string",
-            "enum": ["review", "needs_author", "watch"]
+            "enum": [
+              "review",
+              "needs_author",
+              "watch"
+            ]
           },
           "summary": {
             "type": "string"
@@ -7401,7 +8182,13 @@
               },
               "recommendation": {
                 "type": "string",
-                "enum": ["review", "needs_author", "watch", "likely_duplicate", "maintainer_lane"]
+                "enum": [
+                  "review",
+                  "needs_author",
+                  "watch",
+                  "likely_duplicate",
+                  "maintainer_lane"
+                ]
               },
               "privateSummary": {
                 "type": "string"
@@ -7413,7 +8200,11 @@
                 }
               }
             },
-            "required": ["roleContext", "recommendation", "privateSummary"]
+            "required": [
+              "roleContext",
+              "recommendation",
+              "privateSummary"
+            ]
           }
         ]
       },
@@ -7455,7 +8246,13 @@
             "nullable": true
           }
         },
-        "required": ["id", "repoFullName", "issueNumber", "status", "payload"]
+        "required": [
+          "id",
+          "repoFullName",
+          "issueNumber",
+          "status",
+          "payload"
+        ]
       },
       "BountyAdvisory": {
         "type": "object",
@@ -7489,11 +8286,19 @@
           },
           "fundingStatus": {
             "type": "string",
-            "enum": ["funded", "target_only", "unknown"]
+            "enum": [
+              "funded",
+              "target_only",
+              "unknown"
+            ]
           },
           "consensusRisk": {
             "type": "string",
-            "enum": ["low", "medium", "high"]
+            "enum": [
+              "low",
+              "medium",
+              "high"
+            ]
           },
           "source": {
             "type": "object",
@@ -7520,10 +8325,17 @@
               },
               "freshness": {
                 "type": "string",
-                "enum": ["fresh", "stale", "unknown"]
+                "enum": [
+                  "fresh",
+                  "stale",
+                  "unknown"
+                ]
               }
             },
-            "required": ["ageDays", "freshness"]
+            "required": [
+              "ageDays",
+              "freshness"
+            ]
           },
           "linkedPrs": {
             "type": "array",
@@ -7535,13 +8347,22 @@
                 },
                 "state": {
                   "type": "string",
-                  "enum": ["open", "closed", "merged", "unknown"]
+                  "enum": [
+                    "open",
+                    "closed",
+                    "merged",
+                    "unknown"
+                  ]
                 },
                 "isActive": {
                   "type": "boolean"
                 }
               },
-              "required": ["number", "state", "isActive"]
+              "required": [
+                "number",
+                "state",
+                "isActive"
+              ]
             }
           },
           "findings": {
@@ -7613,7 +8434,10 @@
             }
           }
         },
-        "required": ["bountyId", "events"]
+        "required": [
+          "bountyId",
+          "events"
+        ]
       },
       "RepositorySettings": {
         "type": "object",
@@ -7623,43 +8447,78 @@
           },
           "commentMode": {
             "type": "string",
-            "enum": ["off", "detected_contributors_only", "all_prs"]
+            "enum": [
+              "off",
+              "detected_contributors_only",
+              "all_prs"
+            ]
           },
           "publicAudienceMode": {
             "type": "string",
-            "enum": ["oss_maintainer", "gittensor_only"]
+            "enum": [
+              "oss_maintainer",
+              "gittensor_only"
+            ]
           },
           "publicSignalLevel": {
             "type": "string",
-            "enum": ["minimal", "standard"]
+            "enum": [
+              "minimal",
+              "standard"
+            ]
           },
           "checkRunMode": {
             "type": "string",
-            "enum": ["off", "enabled"]
+            "enum": [
+              "off",
+              "enabled"
+            ]
           },
           "checkRunDetailLevel": {
             "type": "string",
-            "enum": ["minimal", "standard", "deep"]
+            "enum": [
+              "minimal",
+              "standard",
+              "deep"
+            ]
           },
           "gateCheckMode": {
             "type": "string",
-            "enum": ["off", "enabled"]
+            "enum": [
+              "off",
+              "enabled"
+            ]
           },
           "gatePack": {
             "type": "string",
-            "enum": ["gittensor", "oss-anti-slop"]
+            "enum": [
+              "gittensor",
+              "oss-anti-slop"
+            ]
           },
           "linkedIssueGateMode": {
             "type": "string",
-            "enum": ["off", "advisory", "block"]
+            "enum": [
+              "off",
+              "advisory",
+              "block"
+            ]
           },
           "duplicatePrGateMode": {
             "type": "string",
-            "enum": ["off", "advisory", "block"]
+            "enum": [
+              "off",
+              "advisory",
+              "block"
+            ]
           },
           "qualityGateMode": {
             "type": "string",
-            "enum": ["off", "advisory", "block"]
+            "enum": [
+              "off",
+              "advisory",
+              "block"
+            ]
           },
           "qualityGateMinScore": {
             "type": "number",
@@ -7667,15 +8526,27 @@
           },
           "slopGateMode": {
             "type": "string",
-            "enum": ["off", "advisory", "block"]
+            "enum": [
+              "off",
+              "advisory",
+              "block"
+            ]
           },
           "sizeGateMode": {
             "type": "string",
-            "enum": ["off", "advisory", "block"]
+            "enum": [
+              "off",
+              "advisory",
+              "block"
+            ]
           },
           "lockfileIntegrityGateMode": {
             "type": "string",
-            "enum": ["off", "advisory", "block"]
+            "enum": [
+              "off",
+              "advisory",
+              "block"
+            ]
           },
           "gateDryRun": {
             "type": "boolean"
@@ -7691,15 +8562,27 @@
           },
           "mergeReadinessGateMode": {
             "type": "string",
-            "enum": ["off", "advisory", "block"]
+            "enum": [
+              "off",
+              "advisory",
+              "block"
+            ]
           },
           "manifestPolicyGateMode": {
             "type": "string",
-            "enum": ["off", "advisory", "block"]
+            "enum": [
+              "off",
+              "advisory",
+              "block"
+            ]
           },
           "selfAuthoredLinkedIssueGateMode": {
             "type": "string",
-            "enum": ["off", "advisory", "block"]
+            "enum": [
+              "off",
+              "advisory",
+              "block"
+            ]
           },
           "firstTimeContributorGrace": {
             "type": "boolean"
@@ -7713,7 +8596,11 @@
           },
           "aiReviewMode": {
             "type": "string",
-            "enum": ["off", "advisory", "block"]
+            "enum": [
+              "off",
+              "advisory",
+              "block"
+            ]
           },
           "aiReviewByok": {
             "type": "boolean"
@@ -7721,7 +8608,11 @@
           "aiReviewProvider": {
             "type": "string",
             "nullable": true,
-            "enum": ["anthropic", "openai", null]
+            "enum": [
+              "anthropic",
+              "openai",
+              null
+            ]
           },
           "aiReviewModel": {
             "type": "string",
@@ -7737,12 +8628,21 @@
           "aiReviewCombine": {
             "type": "string",
             "nullable": true,
-            "enum": ["single", "consensus", "synthesis", null]
+            "enum": [
+              "single",
+              "consensus",
+              "synthesis",
+              null
+            ]
           },
           "aiReviewOnMerge": {
             "type": "string",
             "nullable": true,
-            "enum": ["either", "both", null]
+            "enum": [
+              "either",
+              "both",
+              null
+            ]
           },
           "aiReviewReviewers": {
             "type": "array",
@@ -7758,7 +8658,9 @@
                   "nullable": true
                 }
               },
-              "required": ["model"]
+              "required": [
+                "model"
+              ]
             }
           },
           "closeOwnerAuthors": {
@@ -7779,7 +8681,12 @@
           },
           "publicSurface": {
             "type": "string",
-            "enum": ["off", "comment_and_label", "comment_only", "label_only"]
+            "enum": [
+              "off",
+              "comment_and_label",
+              "comment_only",
+              "label_only"
+            ]
           },
           "includeMaintainerAuthors": {
             "type": "boolean"
@@ -7803,7 +8710,12 @@
                 "type": "array",
                 "items": {
                   "type": "string",
-                  "enum": ["maintainer", "collaborator", "pr_author", "confirmed_miner"]
+                  "enum": [
+                    "maintainer",
+                    "collaborator",
+                    "pr_author",
+                    "confirmed_miner"
+                  ]
                 }
               },
               "commands": {
@@ -7812,12 +8724,20 @@
                   "type": "array",
                   "items": {
                     "type": "string",
-                    "enum": ["maintainer", "collaborator", "pr_author", "confirmed_miner"]
+                    "enum": [
+                      "maintainer",
+                      "collaborator",
+                      "pr_author",
+                      "confirmed_miner"
+                    ]
                   }
                 }
               }
             },
-            "required": ["default", "commands"]
+            "required": [
+              "default",
+              "commands"
+            ]
           },
           "contributorBlacklist": {
             "type": "array",
@@ -7840,7 +8760,9 @@
                   "type": "string"
                 }
               },
-              "required": ["login"]
+              "required": [
+                "login"
+              ]
             }
           },
           "autonomy": {
@@ -7848,31 +8770,73 @@
             "properties": {
               "review": {
                 "type": "string",
-                "enum": ["observe", "suggest", "propose", "auto_with_approval", "auto"]
+                "enum": [
+                  "observe",
+                  "suggest",
+                  "propose",
+                  "auto_with_approval",
+                  "auto"
+                ]
               },
               "request_changes": {
                 "type": "string",
-                "enum": ["observe", "suggest", "propose", "auto_with_approval", "auto"]
+                "enum": [
+                  "observe",
+                  "suggest",
+                  "propose",
+                  "auto_with_approval",
+                  "auto"
+                ]
               },
               "approve": {
                 "type": "string",
-                "enum": ["observe", "suggest", "propose", "auto_with_approval", "auto"]
+                "enum": [
+                  "observe",
+                  "suggest",
+                  "propose",
+                  "auto_with_approval",
+                  "auto"
+                ]
               },
               "merge": {
                 "type": "string",
-                "enum": ["observe", "suggest", "propose", "auto_with_approval", "auto"]
+                "enum": [
+                  "observe",
+                  "suggest",
+                  "propose",
+                  "auto_with_approval",
+                  "auto"
+                ]
               },
               "close": {
                 "type": "string",
-                "enum": ["observe", "suggest", "propose", "auto_with_approval", "auto"]
+                "enum": [
+                  "observe",
+                  "suggest",
+                  "propose",
+                  "auto_with_approval",
+                  "auto"
+                ]
               },
               "label": {
                 "type": "string",
-                "enum": ["observe", "suggest", "propose", "auto_with_approval", "auto"]
+                "enum": [
+                  "observe",
+                  "suggest",
+                  "propose",
+                  "auto_with_approval",
+                  "auto"
+                ]
               },
               "review_state_label": {
                 "type": "string",
-                "enum": ["observe", "suggest", "propose", "auto_with_approval", "auto"]
+                "enum": [
+                  "observe",
+                  "suggest",
+                  "propose",
+                  "auto_with_approval",
+                  "auto"
+                ]
               }
             }
           },
@@ -7884,10 +8848,17 @@
               },
               "mergeMethod": {
                 "type": "string",
-                "enum": ["merge", "squash", "rebase"]
+                "enum": [
+                  "merge",
+                  "squash",
+                  "rebase"
+                ]
               }
             },
-            "required": ["requireApprovals", "mergeMethod"]
+            "required": [
+              "requireApprovals",
+              "mergeMethod"
+            ]
           },
           "agentPaused": {
             "type": "boolean"
@@ -7913,7 +8884,11 @@
           },
           "reviewNagPolicy": {
             "type": "string",
-            "enum": ["off", "hold", "close"]
+            "enum": [
+              "off",
+              "hold",
+              "close"
+            ]
           },
           "reviewNagMaxPings": {
             "type": "integer",
@@ -7947,7 +8922,10 @@
           },
           "commandRateLimitPolicy": {
             "type": "string",
-            "enum": ["off", "hold"]
+            "enum": [
+              "off",
+              "hold"
+            ]
           },
           "commandRateLimitMaxPerWindow": {
             "type": "integer",
@@ -7980,7 +8958,11 @@
           },
           "claGateMode": {
             "type": "string",
-            "enum": ["off", "advisory", "block"]
+            "enum": [
+              "off",
+              "advisory",
+              "block"
+            ]
           },
           "claConsentPhrase": {
             "type": "string",
@@ -7999,13 +8981,21 @@
           },
           "moderationGateMode": {
             "type": "string",
-            "enum": ["inherit", "off", "enabled"]
+            "enum": [
+              "inherit",
+              "off",
+              "enabled"
+            ]
           },
           "moderationRules": {
             "type": "array",
             "items": {
               "type": "string",
-              "enum": ["contributor_cap", "blacklist", "review_nag"]
+              "enum": [
+                "contributor_cap",
+                "blacklist",
+                "review_nag"
+              ]
             }
           },
           "moderationWarningLabel": {
@@ -8027,7 +9017,11 @@
                 "type": "string"
               }
             },
-            "required": ["bug", "feature", "priority"]
+            "required": [
+              "bug",
+              "feature",
+              "priority"
+            ]
           },
           "linkedIssueLabelPropagation": {
             "type": "object",
@@ -8037,7 +9031,9 @@
               },
               "mode": {
                 "type": "string",
-                "enum": ["exclusive_type_label"]
+                "enum": [
+                  "exclusive_type_label"
+                ]
               },
               "mappings": {
                 "type": "array",
@@ -8054,11 +9050,19 @@
                       "type": "boolean"
                     }
                   },
-                  "required": ["issueLabel", "prLabel", "removeOtherTypeLabels"]
+                  "required": [
+                    "issueLabel",
+                    "prLabel",
+                    "removeOtherTypeLabels"
+                  ]
                 }
               }
             },
-            "required": ["enabled", "mode", "mappings"]
+            "required": [
+              "enabled",
+              "mode",
+              "mappings"
+            ]
           },
           "claCheckRunAppSlug": {
             "type": "string",
@@ -8072,7 +9076,11 @@
           },
           "reviewCheckMode": {
             "type": "string",
-            "enum": ["required", "visible", "disabled"]
+            "enum": [
+              "required",
+              "visible",
+              "disabled"
+            ]
           }
         },
         "required": [
@@ -8136,30 +9144,52 @@
                   "properties": {
                     "publicSurface": {
                       "type": "string",
-                      "enum": ["off", "comment_and_label", "comment_only", "label_only"]
+                      "enum": [
+                        "off",
+                        "comment_and_label",
+                        "comment_only",
+                        "label_only"
+                      ]
                     },
                     "commentMode": {
                       "type": "string",
-                      "enum": ["off", "detected_contributors_only", "all_prs"]
+                      "enum": [
+                        "off",
+                        "detected_contributors_only",
+                        "all_prs"
+                      ]
                     },
                     "publicAudienceMode": {
                       "type": "string",
-                      "enum": ["oss_maintainer", "gittensor_only"]
+                      "enum": [
+                        "oss_maintainer",
+                        "gittensor_only"
+                      ]
                     },
                     "checkRunMode": {
                       "type": "string",
-                      "enum": ["off", "enabled"]
+                      "enum": [
+                        "off",
+                        "enabled"
+                      ]
                     },
                     "gateCheckMode": {
                       "type": "string",
-                      "enum": ["off", "enabled"]
+                      "enum": [
+                        "off",
+                        "enabled"
+                      ]
                     },
                     "autoLabelEnabled": {
                       "type": "boolean"
                     },
                     "reviewCheckMode": {
                       "type": "string",
-                      "enum": ["required", "visible", "disabled"]
+                      "enum": [
+                        "required",
+                        "visible",
+                        "disabled"
+                      ]
                     }
                   },
                   "required": [
@@ -8173,7 +9203,11 @@
                   ]
                 }
               },
-              "required": ["repoFullName", "isRegistered", "settings"]
+              "required": [
+                "repoFullName",
+                "isRegistered",
+                "settings"
+              ]
             }
           },
           "requiredPermissions": {
@@ -8207,7 +9241,12 @@
               "properties": {
                 "mode": {
                   "type": "string",
-                  "enum": ["comment", "label", "check_run", "gate_check"]
+                  "enum": [
+                    "comment",
+                    "label",
+                    "check_run",
+                    "gate_check"
+                  ]
                 },
                 "enabled": {
                   "type": "boolean"
@@ -8233,7 +9272,12 @@
                         "type": "boolean"
                       }
                     },
-                    "required": ["permission", "requiredAccess", "missing", "optional"]
+                    "required": [
+                      "permission",
+                      "requiredAccess",
+                      "missing",
+                      "optional"
+                    ]
                   }
                 },
                 "summary": {
@@ -8274,7 +9318,13 @@
                   "type": "string"
                 }
               },
-              "required": ["event", "missing", "optional", "summary", "action"]
+              "required": [
+                "event",
+                "missing",
+                "optional",
+                "summary",
+                "action"
+              ]
             }
           },
           "repairSteps": {
@@ -8288,7 +9338,9 @@
             "properties": {
               "method": {
                 "type": "string",
-                "enum": ["POST"]
+                "enum": [
+                  "POST"
+                ]
               },
               "path": {
                 "type": "string"
@@ -8297,7 +9349,11 @@
                 "type": "string"
               }
             },
-            "required": ["method", "path", "lastCheckedAt"]
+            "required": [
+              "method",
+              "path",
+              "lastCheckedAt"
+            ]
           },
           "refreshed": {
             "type": "boolean"
@@ -8338,7 +9394,11 @@
           },
           "status": {
             "type": "string",
-            "enum": ["healthy", "needs_attention", "broken"]
+            "enum": [
+              "healthy",
+              "needs_attention",
+              "broken"
+            ]
           },
           "missingPermissions": {
             "type": "array",
@@ -8410,7 +9470,13 @@
                   "type": "string"
                 }
               },
-              "required": ["permission", "requiredAccess", "currentAccess", "ok", "action"]
+              "required": [
+                "permission",
+                "requiredAccess",
+                "currentAccess",
+                "ok",
+                "action"
+              ]
             }
           },
           "eventRemediation": {
@@ -8428,7 +9494,11 @@
                   "type": "string"
                 }
               },
-              "required": ["event", "ok", "action"]
+              "required": [
+                "event",
+                "ok",
+                "action"
+              ]
             }
           },
           "repairSteps": {
@@ -8439,7 +9509,10 @@
           },
           "authMode": {
             "type": "string",
-            "enum": ["local", "broker"]
+            "enum": [
+              "local",
+              "broker"
+            ]
           }
         },
         "required": [
@@ -8470,47 +9543,87 @@
             "properties": {
               "publicSurface": {
                 "type": "string",
-                "enum": ["off", "comment_and_label", "comment_only", "label_only"]
+                "enum": [
+                  "off",
+                  "comment_and_label",
+                  "comment_only",
+                  "label_only"
+                ]
               },
               "commentMode": {
                 "type": "string",
-                "enum": ["off", "detected_contributors_only", "all_prs"]
+                "enum": [
+                  "off",
+                  "detected_contributors_only",
+                  "all_prs"
+                ]
               },
               "publicAudienceMode": {
                 "type": "string",
-                "enum": ["oss_maintainer", "gittensor_only"]
+                "enum": [
+                  "oss_maintainer",
+                  "gittensor_only"
+                ]
               },
               "publicSignalLevel": {
                 "type": "string",
-                "enum": ["minimal", "standard"]
+                "enum": [
+                  "minimal",
+                  "standard"
+                ]
               },
               "checkRunMode": {
                 "type": "string",
-                "enum": ["off", "enabled"]
+                "enum": [
+                  "off",
+                  "enabled"
+                ]
               },
               "checkRunDetailLevel": {
                 "type": "string",
-                "enum": ["minimal", "standard", "deep"]
+                "enum": [
+                  "minimal",
+                  "standard",
+                  "deep"
+                ]
               },
               "gateCheckMode": {
                 "type": "string",
-                "enum": ["off", "enabled"]
+                "enum": [
+                  "off",
+                  "enabled"
+                ]
               },
               "gatePack": {
                 "type": "string",
-                "enum": ["gittensor", "oss-anti-slop"]
+                "enum": [
+                  "gittensor",
+                  "oss-anti-slop"
+                ]
               },
               "linkedIssueGateMode": {
                 "type": "string",
-                "enum": ["off", "advisory", "block"]
+                "enum": [
+                  "off",
+                  "advisory",
+                  "block"
+                ]
               },
               "duplicatePrGateMode": {
                 "type": "string",
-                "enum": ["off", "advisory", "block"]
+                "enum": [
+                  "off",
+                  "advisory",
+                  "block"
+                ]
               },
               "qualityGateMode": {
                 "type": "string",
-                "enum": ["off", "advisory", "block"]
+                "enum": [
+                  "off",
+                  "advisory",
+                  "block"
+                ]
               },
               "qualityGateMinScore": {
                 "type": "number",
@@ -8518,19 +9631,35 @@
               },
               "slopGateMode": {
                 "type": "string",
-                "enum": ["off", "advisory", "block"]
+                "enum": [
+                  "off",
+                  "advisory",
+                  "block"
+                ]
               },
               "mergeReadinessGateMode": {
                 "type": "string",
-                "enum": ["off", "advisory", "block"]
+                "enum": [
+                  "off",
+                  "advisory",
+                  "block"
+                ]
               },
               "manifestPolicyGateMode": {
                 "type": "string",
-                "enum": ["off", "advisory", "block"]
+                "enum": [
+                  "off",
+                  "advisory",
+                  "block"
+                ]
               },
               "selfAuthoredLinkedIssueGateMode": {
                 "type": "string",
-                "enum": ["off", "advisory", "block"]
+                "enum": [
+                  "off",
+                  "advisory",
+                  "block"
+                ]
               },
               "firstTimeContributorGrace": {
                 "type": "boolean"
@@ -8562,7 +9691,11 @@
               },
               "aiReviewMode": {
                 "type": "string",
-                "enum": ["off", "advisory", "block"]
+                "enum": [
+                  "off",
+                  "advisory",
+                  "block"
+                ]
               },
               "aiReviewByok": {
                 "type": "boolean"
@@ -8585,7 +9718,12 @@
                     "type": "array",
                     "items": {
                       "type": "string",
-                      "enum": ["maintainer", "collaborator", "pr_author", "confirmed_miner"]
+                      "enum": [
+                        "maintainer",
+                        "collaborator",
+                        "pr_author",
+                        "confirmed_miner"
+                      ]
                     }
                   },
                   "commandOverrides": {
@@ -8600,22 +9738,37 @@
                           "type": "array",
                           "items": {
                             "type": "string",
-                            "enum": ["maintainer", "collaborator", "pr_author", "confirmed_miner"]
+                            "enum": [
+                              "maintainer",
+                              "collaborator",
+                              "pr_author",
+                              "confirmed_miner"
+                            ]
                           }
                         }
                       },
-                      "required": ["command", "allowedRoles"]
+                      "required": [
+                        "command",
+                        "allowedRoles"
+                      ]
                     }
                   }
                 },
-                "required": ["defaultAllowed", "commandOverrides"]
+                "required": [
+                  "defaultAllowed",
+                  "commandOverrides"
+                ]
               },
               "typeLabelsEnabled": {
                 "type": "boolean"
               },
               "reviewCheckMode": {
                 "type": "string",
-                "enum": ["required", "visible", "disabled"]
+                "enum": [
+                  "required",
+                  "visible",
+                  "disabled"
+                ]
               }
             },
             "required": [
@@ -8675,25 +9828,51 @@
                   },
                   "actorKind": {
                     "type": "string",
-                    "enum": ["maintainer", "author", "none"]
+                    "enum": [
+                      "maintainer",
+                      "author",
+                      "none"
+                    ]
                   },
                   "matchedRole": {
                     "type": "string",
                     "nullable": true,
-                    "enum": ["maintainer", "collaborator", "pr_author", "confirmed_miner", null]
+                    "enum": [
+                      "maintainer",
+                      "collaborator",
+                      "pr_author",
+                      "confirmed_miner",
+                      null
+                    ]
                   },
                   "allowedRoles": {
                     "type": "array",
                     "items": {
                       "type": "string",
-                      "enum": ["maintainer", "collaborator", "pr_author", "confirmed_miner"]
+                      "enum": [
+                        "maintainer",
+                        "collaborator",
+                        "pr_author",
+                        "confirmed_miner"
+                      ]
                     }
                   }
                 },
-                "required": ["authorized", "reason", "actorKind", "matchedRole", "allowedRoles"]
+                "required": [
+                  "authorized",
+                  "reason",
+                  "actorKind",
+                  "matchedRole",
+                  "allowedRoles"
+                ]
               }
             },
-            "required": ["commandName", "commenterLogin", "commenterAssociation", "decision"]
+            "required": [
+              "commandName",
+              "commenterLogin",
+              "commenterAssociation",
+              "decision"
+            ]
           },
           "installation": {
             "type": "object",
@@ -8704,7 +9883,11 @@
               },
               "status": {
                 "type": "string",
-                "enum": ["healthy", "needs_attention", "broken"]
+                "enum": [
+                  "healthy",
+                  "needs_attention",
+                  "broken"
+                ]
               },
               "missingPermissions": {
                 "type": "array",
@@ -8739,7 +9922,13 @@
                       "type": "string"
                     }
                   },
-                  "required": ["permission", "requiredAccess", "currentAccess", "ok", "action"]
+                  "required": [
+                    "permission",
+                    "requiredAccess",
+                    "currentAccess",
+                    "ok",
+                    "action"
+                  ]
                 }
               }
             },
@@ -8765,7 +9954,11 @@
               },
               "minerStatus": {
                 "type": "string",
-                "enum": ["confirmed", "not_found", "unavailable"]
+                "enum": [
+                  "confirmed",
+                  "not_found",
+                  "unavailable"
+                ]
               },
               "title": {
                 "type": "string"
@@ -8825,7 +10018,13 @@
                 "type": "array",
                 "items": {
                   "type": "string",
-                  "enum": ["skip", "comment", "label", "check_run", "none"]
+                  "enum": [
+                    "skip",
+                    "comment",
+                    "label",
+                    "check_run",
+                    "none"
+                  ]
                 }
               },
               "summary": {
@@ -8862,17 +10061,29 @@
               },
               "detailLevel": {
                 "type": "string",
-                "enum": ["minimal", "standard", "deep"]
+                "enum": [
+                  "minimal",
+                  "standard",
+                  "deep"
+                ]
               }
             },
-            "required": ["willCreate", "title", "detailLevel"]
+            "required": [
+              "willCreate",
+              "title",
+              "detailLevel"
+            ]
           },
           "installPreview": {
             "type": "object",
             "properties": {
               "status": {
                 "type": "string",
-                "enum": ["ready", "needs_attention", "blocked"]
+                "enum": [
+                  "ready",
+                  "needs_attention",
+                  "blocked"
+                ]
               },
               "summary": {
                 "type": "string"
@@ -8900,7 +10111,11 @@
                 "properties": {
                   "status": {
                     "type": "string",
-                    "enum": ["ready", "needs_attention", "blocked"]
+                    "enum": [
+                      "ready",
+                      "needs_attention",
+                      "blocked"
+                    ]
                   },
                   "required": {
                     "type": "array",
@@ -8924,7 +10139,13 @@
                     "type": "string"
                   }
                 },
-                "required": ["status", "required", "missing", "missingEvents", "summary"]
+                "required": [
+                  "status",
+                  "required",
+                  "missing",
+                  "missingEvents",
+                  "summary"
+                ]
               },
               "publicOutputs": {
                 "type": "array",
@@ -8984,7 +10205,11 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": ["ready", "needs_attention", "blocked"]
+                      "enum": [
+                        "ready",
+                        "needs_attention",
+                        "blocked"
+                      ]
                     },
                     "label": {
                       "type": "string"
@@ -8996,7 +10221,14 @@
                       "type": "string"
                     }
                   },
-                  "required": ["id", "category", "status", "label", "summary", "action"]
+                  "required": [
+                    "id",
+                    "category",
+                    "status",
+                    "label",
+                    "summary",
+                    "action"
+                  ]
                 }
               }
             },
@@ -9081,7 +10313,11 @@
                 "nullable": true
               }
             },
-            "required": ["repoFullName", "reason", "since"]
+            "required": [
+              "repoFullName",
+              "reason",
+              "since"
+            ]
           },
           "items": {
             "type": "array",
@@ -9106,11 +10342,23 @@
                   "type": "string"
                 }
               },
-              "required": ["repoFullName", "pullNumber", "reason", "timestamp", "remediation"]
+              "required": [
+                "repoFullName",
+                "pullNumber",
+                "reason",
+                "timestamp",
+                "remediation"
+              ]
             }
           }
         },
-        "required": ["generatedAt", "limit", "hasMore", "filters", "items"]
+        "required": [
+          "generatedAt",
+          "limit",
+          "hasMore",
+          "filters",
+          "items"
+        ]
       },
       "CommandPreviewResponse": {
         "type": "object",
@@ -9140,7 +10388,14 @@
                 "type": "string"
               }
             },
-            "required": ["id", "command", "audience", "boundary", "description", "endpoint"]
+            "required": [
+              "id",
+              "command",
+              "audience",
+              "boundary",
+              "description",
+              "endpoint"
+            ]
           },
           "request": {
             "type": "object",
@@ -9153,7 +10408,12 @@
             "properties": {
               "boundary": {
                 "type": "string",
-                "enum": ["public", "public-safe", "private-api", "private-mcp"]
+                "enum": [
+                  "public",
+                  "public-safe",
+                  "private-api",
+                  "private-mcp"
+                ]
               },
               "endpoint": {
                 "type": "string"
@@ -9191,7 +10451,13 @@
                       "type": "string"
                     }
                   },
-                  "required": ["permission", "requiredAccess", "currentAccess", "ok", "action"]
+                  "required": [
+                    "permission",
+                    "requiredAccess",
+                    "currentAccess",
+                    "ok",
+                    "action"
+                  ]
                 }
               },
               "warnings": {
@@ -9205,7 +10471,12 @@
                 "properties": {
                   "status": {
                     "type": "string",
-                    "enum": ["ready", "skipped", "missing_permission", "private_api"]
+                    "enum": [
+                      "ready",
+                      "skipped",
+                      "missing_permission",
+                      "private_api"
+                    ]
                   },
                   "willComment": {
                     "type": "boolean"
@@ -9227,7 +10498,13 @@
                     "type": "array",
                     "items": {
                       "type": "string",
-                      "enum": ["comment", "label", "check_run", "skip", "none"]
+                      "enum": [
+                        "comment",
+                        "label",
+                        "check_run",
+                        "skip",
+                        "none"
+                      ]
                     }
                   },
                   "summary": {
@@ -9268,7 +10545,11 @@
                   },
                   "minerStatus": {
                     "type": "string",
-                    "enum": ["confirmed", "not_found", "unavailable"]
+                    "enum": [
+                      "confirmed",
+                      "not_found",
+                      "unavailable"
+                    ]
                   },
                   "title": {
                     "type": "string"
@@ -9317,7 +10598,10 @@
                     }
                   }
                 },
-                "required": ["passed", "forbiddenTerms"]
+                "required": [
+                  "passed",
+                  "forbiddenTerms"
+                ]
               }
             },
             "required": [
@@ -9332,7 +10616,12 @@
             ]
           }
         },
-        "required": ["generatedAt", "command", "request", "preview"]
+        "required": [
+          "generatedAt",
+          "command",
+          "request",
+          "preview"
+        ]
       },
       "AgentRun": {
         "type": "object",
@@ -9348,19 +10637,36 @@
           },
           "surface": {
             "type": "string",
-            "enum": ["mcp", "github_comment", "api"]
+            "enum": [
+              "mcp",
+              "github_comment",
+              "api"
+            ]
           },
           "mode": {
             "type": "string",
-            "enum": ["copilot"]
+            "enum": [
+              "copilot"
+            ]
           },
           "status": {
             "type": "string",
-            "enum": ["queued", "running", "completed", "failed", "needs_snapshot_refresh"]
+            "enum": [
+              "queued",
+              "running",
+              "completed",
+              "failed",
+              "needs_snapshot_refresh"
+            ]
           },
           "dataQualityStatus": {
             "type": "string",
-            "enum": ["complete", "degraded", "blocked", "unknown"]
+            "enum": [
+              "complete",
+              "degraded",
+              "blocked",
+              "unknown"
+            ]
           },
           "errorSummary": {
             "type": "string",
@@ -9428,7 +10734,13 @@
           },
           "status": {
             "type": "string",
-            "enum": ["recommended", "ready", "blocked", "watch", "needs_input"]
+            "enum": [
+              "recommended",
+              "ready",
+              "blocked",
+              "watch",
+              "needs_input"
+            ]
           },
           "recommendation": {
             "type": "string"
@@ -9472,7 +10784,11 @@
           },
           "safetyClass": {
             "type": "string",
-            "enum": ["private", "public_safe", "approval_required"]
+            "enum": [
+              "private",
+              "public_safe",
+              "approval_required"
+            ]
           },
           "payload": {
             "type": "object",
@@ -9545,7 +10861,10 @@
                   }
                 }
               },
-              "required": ["category", "items"]
+              "required": [
+                "category",
+                "items"
+              ]
             }
           },
           "rerunWhen": {
@@ -9564,7 +10883,11 @@
                 "type": "string"
               }
             },
-            "required": ["summary", "whyNow", "rerunWhen"]
+            "required": [
+              "summary",
+              "whyNow",
+              "rerunWhen"
+            ]
           }
         },
         "required": [
@@ -9619,7 +10942,13 @@
             "nullable": true
           }
         },
-        "required": ["id", "runId", "repoSignalSnapshotIds", "freshnessWarnings", "payload"]
+        "required": [
+          "id",
+          "runId",
+          "repoSignalSnapshotIds",
+          "freshnessWarnings",
+          "payload"
+        ]
       },
       "AgentRunBundle": {
         "type": "object",
@@ -9643,7 +10972,12 @@
             "type": "string"
           }
         },
-        "required": ["run", "actions", "contextSnapshots", "summary"]
+        "required": [
+          "run",
+          "actions",
+          "contextSnapshots",
+          "summary"
+        ]
       },
       "RepoSyncState": {
         "type": "object",
@@ -9667,7 +11001,11 @@
           },
           "sourceKind": {
             "type": "string",
-            "enum": ["github", "installation", "test"]
+            "enum": [
+              "github",
+              "installation",
+              "test"
+            ]
           },
           "primaryLanguage": {
             "type": "string",
@@ -9778,11 +11116,19 @@
           },
           "sourceKind": {
             "type": "string",
-            "enum": ["github", "installation", "test"]
+            "enum": [
+              "github",
+              "installation",
+              "test"
+            ]
           },
           "mode": {
             "type": "string",
-            "enum": ["light", "full", "resume"]
+            "enum": [
+              "light",
+              "full",
+              "resume"
+            ]
           },
           "lastCursor": {
             "type": "string",
@@ -9867,7 +11213,10 @@
           },
           "resource": {
             "type": "string",
-            "enum": ["rest", "graphql"]
+            "enum": [
+              "rest",
+              "graphql"
+            ]
           },
           "path": {
             "type": "string"
@@ -9892,14 +11241,23 @@
             "nullable": true
           }
         },
-        "required": ["resource", "path", "statusCode"]
+        "required": [
+          "resource",
+          "path",
+          "statusCode"
+        ]
       },
       "SignalFidelity": {
         "type": "object",
         "properties": {
           "status": {
             "type": "string",
-            "enum": ["complete", "degraded", "blocked", "unknown"]
+            "enum": [
+              "complete",
+              "degraded",
+              "blocked",
+              "unknown"
+            ]
           },
           "repoCount": {
             "type": "number"
@@ -9968,7 +11326,11 @@
             "properties": {
               "status": {
                 "type": "string",
-                "enum": ["fresh", "degraded", "blocked"]
+                "enum": [
+                  "fresh",
+                  "degraded",
+                  "blocked"
+                ]
               },
               "generatedAt": {
                 "type": "string"
@@ -10063,7 +11425,11 @@
           },
           "historyCoverage": {
             "type": "string",
-            "enum": ["sampled", "counts_only", "full"]
+            "enum": [
+              "sampled",
+              "counts_only",
+              "full"
+            ]
           },
           "refreshingRepos": {
             "type": "array",
@@ -10139,7 +11505,12 @@
         "properties": {
           "status": {
             "type": "string",
-            "enum": ["complete", "degraded", "blocked", "unknown"]
+            "enum": [
+              "complete",
+              "degraded",
+              "blocked",
+              "unknown"
+            ]
           },
           "repoCount": {
             "type": "number"
@@ -10173,7 +11544,11 @@
           },
           "historyCoverage": {
             "type": "string",
-            "enum": ["sampled", "counts_only", "full"]
+            "enum": [
+              "sampled",
+              "counts_only",
+              "full"
+            ]
           }
         },
         "required": [
@@ -10196,7 +11571,12 @@
           },
           "status": {
             "type": "string",
-            "enum": ["current", "drift_detected", "stale", "unavailable"]
+            "enum": [
+              "current",
+              "drift_detected",
+              "stale",
+              "unavailable"
+            ]
           },
           "latestCommitSha": {
             "type": "string",
@@ -10224,7 +11604,13 @@
           "highestSeverity": {
             "type": "string",
             "nullable": true,
-            "enum": ["low", "medium", "high", "blocking", null]
+            "enum": [
+              "low",
+              "medium",
+              "high",
+              "blocking",
+              null
+            ]
           },
           "affectedAreas": {
             "type": "array",
@@ -10330,11 +11716,21 @@
           },
           "severity": {
             "type": "string",
-            "enum": ["low", "medium", "high", "blocking"]
+            "enum": [
+              "low",
+              "medium",
+              "high",
+              "blocking"
+            ]
           },
           "status": {
             "type": "string",
-            "enum": ["open", "acknowledged", "resolved", "ignored"]
+            "enum": [
+              "open",
+              "acknowledged",
+              "resolved",
+              "ignored"
+            ]
           },
           "summary": {
             "type": "string"
@@ -10369,7 +11765,10 @@
                 "nullable": true
               }
             },
-            "required": ["repo", "ref"]
+            "required": [
+              "repo",
+              "ref"
+            ]
           },
           "recommendedFollowUp": {
             "type": "array",
@@ -10443,7 +11842,11 @@
           },
           "sourceKind": {
             "type": "string",
-            "enum": ["github", "installation", "test"]
+            "enum": [
+              "github",
+              "installation",
+              "test"
+            ]
           },
           "fetchedAt": {
             "type": "string"
@@ -10480,7 +11883,10 @@
         "properties": {
           "status": {
             "type": "string",
-            "enum": ["ready", "needs_attention"]
+            "enum": [
+              "ready",
+              "needs_attention"
+            ]
           },
           "generatedAt": {
             "type": "string"
@@ -10499,7 +11905,11 @@
             "properties": {
               "status": {
                 "type": "string",
-                "enum": ["fresh", "degraded", "blocked"]
+                "enum": [
+                  "fresh",
+                  "degraded",
+                  "blocked"
+                ]
               },
               "generatedAt": {
                 "type": "string"
@@ -10594,7 +12004,11 @@
           },
           "historyCoverage": {
             "type": "string",
-            "enum": ["sampled", "counts_only", "full"]
+            "enum": [
+              "sampled",
+              "counts_only",
+              "full"
+            ]
           },
           "partialRepos": {
             "type": "array",
@@ -10659,13 +12073,22 @@
                     "type": "string"
                   }
                 },
-                "required": ["kind", "url"]
+                "required": [
+                  "kind",
+                  "url"
+                ]
               },
               "warningCount": {
                 "type": "number"
               }
             },
-            "required": ["snapshotId", "repoCount", "totalEmissionShare", "source", "warningCount"]
+            "required": [
+              "snapshotId",
+              "repoCount",
+              "totalEmissionShare",
+              "source",
+              "warningCount"
+            ]
           },
           "scoringModel": {
             "type": "object",
@@ -10693,7 +12116,13 @@
                 "type": "number"
               }
             },
-            "required": ["snapshotId", "activeModel", "sourceKind", "fetchedAt", "warningCount"]
+            "required": [
+              "snapshotId",
+              "activeModel",
+              "sourceKind",
+              "fetchedAt",
+              "warningCount"
+            ]
           },
           "githubBackfill": {
             "type": "object",
@@ -10724,7 +12153,9 @@
                       "nullable": true
                     }
                   },
-                  "required": ["repoFullName"]
+                  "required": [
+                    "repoFullName"
+                  ]
                 }
               },
               "incompleteSyncs": {
@@ -10737,14 +12168,21 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": ["never_synced", "running", "skipped"]
+                      "enum": [
+                        "never_synced",
+                        "running",
+                        "skipped"
+                      ]
                     },
                     "lastCompletedAt": {
                       "type": "string",
                       "nullable": true
                     }
                   },
-                  "required": ["repoFullName", "status"]
+                  "required": [
+                    "repoFullName",
+                    "status"
+                  ]
                 }
               },
               "segmentCount": {
@@ -10781,7 +12219,10 @@
                       "nullable": true
                     }
                   },
-                  "required": ["repoFullName", "segment"]
+                  "required": [
+                    "repoFullName",
+                    "segment"
+                  ]
                 }
               },
               "rateLimitedSegments": {
@@ -10800,7 +12241,10 @@
                       "nullable": true
                     }
                   },
-                  "required": ["repoFullName", "segment"]
+                  "required": [
+                    "repoFullName",
+                    "segment"
+                  ]
                 }
               },
               "latestRateLimits": {
@@ -10837,7 +12281,11 @@
                 "type": "number"
               }
             },
-            "required": ["count", "healthCount", "unhealthyCount"]
+            "required": [
+              "count",
+              "healthCount",
+              "unhealthyCount"
+            ]
           },
           "secrets": {
             "type": "object",
@@ -11010,14 +12458,23 @@
                   }
                 }
               },
-              "required": ["repoFullName", "changes"]
+              "required": [
+                "repoFullName",
+                "changes"
+              ]
             }
           },
           "summary": {
             "type": "string"
           }
         },
-        "required": ["generatedAt", "addedRepos", "removedRepos", "changedRepos", "summary"]
+        "required": [
+          "generatedAt",
+          "addedRepos",
+          "removedRepos",
+          "changedRepos",
+          "summary"
+        ]
       },
       "ScoringModelSnapshot": {
         "type": "object",
@@ -11027,7 +12484,12 @@
           },
           "sourceKind": {
             "type": "string",
-            "enum": ["raw-github", "api", "fallback", "test"]
+            "enum": [
+              "raw-github",
+              "api",
+              "fallback",
+              "test"
+            ]
           },
           "sourceUrl": {
             "type": "string"
@@ -11099,7 +12561,12 @@
           },
           "targetType": {
             "type": "string",
-            "enum": ["planned_pr", "pull_request", "local_diff", "variant"]
+            "enum": [
+              "planned_pr",
+              "pull_request",
+              "local_diff",
+              "variant"
+            ]
           },
           "targetKey": {
             "type": "string"
@@ -11172,11 +12639,21 @@
                   "properties": {
                     "status": {
                       "type": "string",
-                      "enum": ["raw", "plausible", "validated", "invalid", "unavailable"]
+                      "enum": [
+                        "raw",
+                        "plausible",
+                        "validated",
+                        "invalid",
+                        "unavailable"
+                      ]
                     },
                     "source": {
                       "type": "string",
-                      "enum": ["official_mirror", "github_cache", "missing"]
+                      "enum": [
+                        "official_mirror",
+                        "github_cache",
+                        "missing"
+                      ]
                     },
                     "solvedByPullRequests": {
                       "type": "array",
@@ -11194,7 +12671,13 @@
                       }
                     }
                   },
-                  "required": ["status", "source", "solvedByPullRequests", "reason", "warnings"]
+                  "required": [
+                    "status",
+                    "source",
+                    "solvedByPullRequests",
+                    "reason",
+                    "warnings"
+                  ]
                 },
                 "bounty": {
                   "type": "object",
@@ -11219,11 +12702,19 @@
                     },
                     "fundingStatus": {
                       "type": "string",
-                      "enum": ["funded", "target_only", "unknown"]
+                      "enum": [
+                        "funded",
+                        "target_only",
+                        "unknown"
+                      ]
                     },
                     "consensusRisk": {
                       "type": "string",
-                      "enum": ["low", "medium", "high"]
+                      "enum": [
+                        "low",
+                        "medium",
+                        "high"
+                      ]
                     },
                     "source": {
                       "type": "object",
@@ -11250,10 +12741,17 @@
                         },
                         "freshness": {
                           "type": "string",
-                          "enum": ["fresh", "stale", "unknown"]
+                          "enum": [
+                            "fresh",
+                            "stale",
+                            "unknown"
+                          ]
                         }
                       },
-                      "required": ["ageDays", "freshness"]
+                      "required": [
+                        "ageDays",
+                        "freshness"
+                      ]
                     },
                     "linkedPrs": {
                       "type": "array",
@@ -11265,13 +12763,22 @@
                           },
                           "state": {
                             "type": "string",
-                            "enum": ["open", "closed", "merged", "unknown"]
+                            "enum": [
+                              "open",
+                              "closed",
+                              "merged",
+                              "unknown"
+                            ]
                           },
                           "isActive": {
                             "type": "boolean"
                           }
                         },
-                        "required": ["number", "state", "isActive"]
+                        "required": [
+                          "number",
+                          "state",
+                          "isActive"
+                        ]
                       }
                     }
                   },
@@ -11287,7 +12794,12 @@
                 },
                 "status": {
                   "type": "string",
-                  "enum": ["ready", "needs_proof", "hold", "do_not_use"]
+                  "enum": [
+                    "ready",
+                    "needs_proof",
+                    "hold",
+                    "do_not_use"
+                  ]
                 },
                 "score": {
                   "type": "number"
@@ -11305,25 +12817,43 @@
                   }
                 }
               },
-              "required": ["number", "title", "status", "score", "reasons", "warnings"]
+              "required": [
+                "number",
+                "title",
+                "status",
+                "score",
+                "reasons",
+                "warnings"
+              ]
             }
           },
           "summary": {
             "type": "string"
           }
         },
-        "required": ["repoFullName", "generatedAt", "lane", "issues", "summary"]
+        "required": [
+          "repoFullName",
+          "generatedAt",
+          "lane",
+          "issues",
+          "summary"
+        ]
       },
       "IssueQualityResponse": {
         "type": "object",
         "properties": {
           "status": {
             "type": "string",
-            "enum": ["ready"]
+            "enum": [
+              "ready"
+            ]
           },
           "source": {
             "type": "string",
-            "enum": ["snapshot", "computed"]
+            "enum": [
+              "snapshot",
+              "computed"
+            ]
           },
           "repoFullName": {
             "type": "string"
@@ -11335,7 +12865,13 @@
             "$ref": "#/components/schemas/IssueQualityReport"
           }
         },
-        "required": ["status", "source", "repoFullName", "generatedAt", "report"]
+        "required": [
+          "status",
+          "source",
+          "repoFullName",
+          "generatedAt",
+          "report"
+        ]
       },
       "ContributorScoringProfile": {
         "type": "object",
@@ -11362,7 +12898,13 @@
             }
           }
         },
-        "required": ["login", "generatedAt", "scoringModelSnapshotId", "evidence", "privateSignals"]
+        "required": [
+          "login",
+          "generatedAt",
+          "scoringModelSnapshotId",
+          "evidence",
+          "privateSignals"
+        ]
       },
       "ContributorStrategy": {
         "type": "object",
@@ -11578,7 +13120,12 @@
           },
           "level": {
             "type": "string",
-            "enum": ["low", "medium", "high", "critical"]
+            "enum": [
+              "low",
+              "medium",
+              "high",
+              "critical"
+            ]
           },
           "noiseSources": {
             "type": "array",
@@ -11935,7 +13482,11 @@
                       }
                     }
                   },
-                  "required": ["generatedAt", "upstreamDrift", "reports"]
+                  "required": [
+                    "generatedAt",
+                    "upstreamDrift",
+                    "reports"
+                  ]
                 }
               }
             }
@@ -12052,7 +13603,10 @@
                       }
                     }
                   },
-                  "required": ["installations", "health"]
+                  "required": [
+                    "installations",
+                    "health"
+                  ]
                 }
               }
             }
@@ -12167,11 +13721,15 @@
                       "properties": {
                         "mode": {
                           "type": "string",
-                          "enum": ["opt_in"]
+                          "enum": [
+                            "opt_in"
+                          ]
                         },
                         "defaultState": {
                           "type": "string",
-                          "enum": ["disabled"]
+                          "enum": [
+                            "disabled"
+                          ]
                         },
                         "channels": {
                           "type": "array",
@@ -12183,7 +13741,10 @@
                               },
                               "transport": {
                                 "type": "string",
-                                "enum": ["in_app", "web_push"]
+                                "enum": [
+                                  "in_app",
+                                  "web_push"
+                                ]
                               },
                               "defaultEnabled": {
                                 "type": "boolean"
@@ -12195,7 +13756,12 @@
                                 "type": "string"
                               }
                             },
-                            "required": ["id", "transport", "defaultEnabled", "purpose"]
+                            "required": [
+                              "id",
+                              "transport",
+                              "defaultEnabled",
+                              "purpose"
+                            ]
                           }
                         },
                         "privacyGuards": {
@@ -12206,7 +13772,9 @@
                         },
                         "fallbackWhenUnavailable": {
                           "type": "string",
-                          "enum": ["in_app_digest_only"]
+                          "enum": [
+                            "in_app_digest_only"
+                          ]
                         }
                       },
                       "required": [
@@ -12230,7 +13798,11 @@
                           "type": "string"
                         }
                       },
-                      "required": ["nativeDependency", "manifestPath", "serviceWorkerPath"]
+                      "required": [
+                        "nativeDependency",
+                        "manifestPath",
+                        "serviceWorkerPath"
+                      ]
                     },
                     "mobileReadyRoutes": {
                       "type": "array",
@@ -12592,7 +14164,10 @@
                       }
                     }
                   },
-                  "required": ["repoFullName", "events"]
+                  "required": [
+                    "repoFullName",
+                    "events"
+                  ]
                 }
               }
             }
@@ -13107,7 +14682,9 @@
                       }
                     }
                   },
-                  "required": ["runs"]
+                  "required": [
+                    "runs"
+                  ]
                 }
               }
             }
@@ -13878,7 +15455,10 @@
           {
             "schema": {
               "type": "string",
-              "enum": ["public", "operator"],
+              "enum": [
+                "public",
+                "operator"
+              ],
               "example": "public"
             },
             "required": false,
@@ -13899,7 +15479,10 @@
           {
             "schema": {
               "type": "string",
-              "enum": ["json", "markdown"],
+              "enum": [
+                "json",
+                "markdown"
+              ],
               "example": "markdown"
             },
             "required": false,

--- a/apps/gittensory-ui/public/openapi.json
+++ b/apps/gittensory-ui/public/openapi.json
@@ -16199,6 +16199,18 @@
           {
             "GittensorySessionCookie": []
           }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "example": "812"
+            },
+            "required": true,
+            "description": "Dead-letter job id.",
+            "name": "id",
+            "in": "path"
+          }
         ]
       }
     },
@@ -16240,6 +16252,18 @@
           },
           {
             "GittensorySessionCookie": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "example": "812"
+            },
+            "required": true,
+            "description": "Dead-letter job id.",
+            "name": "id",
+            "in": "path"
           }
         ]
       }

--- a/apps/gittensory-ui/public/openapi.json
+++ b/apps/gittensory-ui/public/openapi.json
@@ -12,15 +12,11 @@
         "properties": {
           "status": {
             "type": "string",
-            "enum": [
-              "ok"
-            ]
+            "enum": ["ok"]
           },
           "service": {
             "type": "string",
-            "enum": [
-              "gittensory-api"
-            ]
+            "enum": ["gittensory-api"]
           },
           "time": {
             "type": "string"
@@ -32,28 +28,18 @@
             "type": "string"
           }
         },
-        "required": [
-          "status",
-          "service",
-          "time",
-          "minMcpVersion",
-          "latestRecommendedMcpVersion"
-        ]
+        "required": ["status", "service", "time", "minMcpVersion", "latestRecommendedMcpVersion"]
       },
       "McpCompatibility": {
         "type": "object",
         "properties": {
           "status": {
             "type": "string",
-            "enum": [
-              "ok"
-            ]
+            "enum": ["ok"]
           },
           "service": {
             "type": "string",
-            "enum": [
-              "gittensory-api"
-            ]
+            "enum": ["gittensory-api"]
           },
           "apiVersion": {
             "type": "string"
@@ -105,10 +91,7 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "code",
-                "message"
-              ]
+              "required": ["code", "message"]
             }
           },
           "breakingChanges": {
@@ -126,10 +109,7 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "version",
-                "summary"
-              ]
+              "required": ["version", "summary"]
             }
           },
           "generatedAt": {
@@ -163,19 +143,13 @@
             "properties": {
               "kind": {
                 "type": "string",
-                "enum": [
-                  "api",
-                  "raw-github"
-                ]
+                "enum": ["api", "raw-github"]
               },
               "url": {
                 "type": "string"
               }
             },
-            "required": [
-              "kind",
-              "url"
-            ]
+            "required": ["kind", "url"]
           },
           "repoCount": {
             "type": "number"
@@ -304,14 +278,7 @@
             ]
           }
         },
-        "required": [
-          "fullName",
-          "owner",
-          "name",
-          "isInstalled",
-          "isRegistered",
-          "isPrivate"
-        ]
+        "required": ["fullName", "owner", "name", "isInstalled", "isRegistered", "isPrivate"]
       },
       "PublicRepoStats": {
         "type": "object",
@@ -333,11 +300,7 @@
           },
           "source": {
             "type": "string",
-            "enum": [
-              "github",
-              "cache",
-              "stale_cache"
-            ]
+            "enum": ["github", "cache", "stale_cache"]
           },
           "stale": {
             "type": "boolean"
@@ -429,10 +392,7 @@
                 "type": "number"
               }
             },
-            "required": [
-              "reviewed",
-              "merged"
-            ]
+            "required": ["reviewed", "merged"]
           },
           "byProject": {
             "type": "array",
@@ -456,23 +416,11 @@
                   "nullable": true
                 }
               },
-              "required": [
-                "project",
-                "reviewed",
-                "merged",
-                "closed",
-                "accuracyPct"
-              ]
+              "required": ["project", "reviewed", "merged", "closed", "accuracyPct"]
             }
           }
         },
-        "required": [
-          "generatedAt",
-          "updatedAt",
-          "totals",
-          "weekly",
-          "byProject"
-        ]
+        "required": ["generatedAt", "updatedAt", "totals", "weekly", "byProject"]
       },
       "Advisory": {
         "type": "object",
@@ -482,11 +430,7 @@
           },
           "targetType": {
             "type": "string",
-            "enum": [
-              "repository",
-              "pull_request",
-              "issue"
-            ]
+            "enum": ["repository", "pull_request", "issue"]
           },
           "targetKey": {
             "type": "string"
@@ -505,19 +449,11 @@
           },
           "conclusion": {
             "type": "string",
-            "enum": [
-              "success",
-              "neutral",
-              "action_required"
-            ]
+            "enum": ["success", "neutral", "action_required"]
           },
           "severity": {
             "type": "string",
-            "enum": [
-              "info",
-              "warning",
-              "critical"
-            ]
+            "enum": ["info", "warning", "critical"]
           },
           "title": {
             "type": "string"
@@ -559,11 +495,7 @@
           },
           "severity": {
             "type": "string",
-            "enum": [
-              "info",
-              "warning",
-              "critical"
-            ]
+            "enum": ["info", "warning", "critical"]
           },
           "detail": {
             "type": "string"
@@ -575,12 +507,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "code",
-          "title",
-          "severity",
-          "detail"
-        ]
+        "required": ["code", "title", "severity", "detail"]
       },
       "ActionPortfolio": {
         "type": "object",
@@ -615,12 +542,7 @@
                   }
                 }
               },
-              "required": [
-                "bucket",
-                "label",
-                "summary",
-                "actions"
-              ]
+              "required": ["bucket", "label", "summary", "actions"]
             }
           },
           "topActions": {
@@ -639,25 +561,11 @@
             "type": "string"
           }
         },
-        "required": [
-          "generatedAt",
-          "bucketOrder",
-          "buckets",
-          "topActions",
-          "counts",
-          "summary"
-        ]
+        "required": ["generatedAt", "bucketOrder", "buckets", "topActions", "counts", "summary"]
       },
       "ActionPortfolioBucketName": {
         "type": "string",
-        "enum": [
-          "cleanup",
-          "wait",
-          "direct_pr",
-          "issue_discovery",
-          "avoid",
-          "maintainer_lane"
-        ]
+        "enum": ["cleanup", "wait", "direct_pr", "issue_discovery", "avoid", "maintainer_lane"]
       },
       "ActionPortfolioItem": {
         "type": "object",
@@ -679,11 +587,7 @@
           },
           "status": {
             "type": "string",
-            "enum": [
-              "recommended",
-              "blocked",
-              "watch"
-            ]
+            "enum": ["recommended", "blocked", "watch"]
           },
           "whyNow": {
             "type": "array",
@@ -726,19 +630,14 @@
           },
           "source": {
             "type": "string",
-            "enum": [
-              "decision_pack"
-            ]
+            "enum": ["decision_pack"]
           },
           "scenarioProjection": {
             "type": "object",
             "properties": {
               "source": {
                 "type": "string",
-                "enum": [
-                  "github_observed",
-                  "user_supplied"
-                ]
+                "enum": ["github_observed", "user_supplied"]
               },
               "pendingMergedPrCount": {
                 "type": "number"
@@ -799,13 +698,7 @@
       },
       "DecisionRecommendation": {
         "type": "string",
-        "enum": [
-          "pursue",
-          "cleanup_first",
-          "maintainer_lane",
-          "avoid_for_now",
-          "watch"
-        ]
+        "enum": ["pursue", "cleanup_first", "maintainer_lane", "avoid_for_now", "watch"]
       },
       "WorkboardItem": {
         "type": "object",
@@ -828,11 +721,7 @@
           },
           "fit": {
             "type": "string",
-            "enum": [
-              "good",
-              "caution",
-              "hold"
-            ]
+            "enum": ["good", "caution", "hold"]
           },
           "reasons": {
             "type": "array",
@@ -841,14 +730,7 @@
             }
           }
         },
-        "required": [
-          "repoFullName",
-          "issueNumber",
-          "title",
-          "state",
-          "fit",
-          "reasons"
-        ]
+        "required": ["repoFullName", "issueNumber", "title", "state", "fit", "reasons"]
       },
       "QueueHealth": {
         "type": "object",
@@ -864,12 +746,7 @@
           },
           "level": {
             "type": "string",
-            "enum": [
-              "low",
-              "medium",
-              "high",
-              "critical"
-            ]
+            "enum": ["low", "medium", "high", "critical"]
           },
           "summary": {
             "type": "string"
@@ -908,11 +785,7 @@
                     "type": "number"
                   }
                 },
-                "required": [
-                  "under7Days",
-                  "days7To30",
-                  "over30Days"
-                ]
+                "required": ["under7Days", "days7To30", "over30Days"]
               },
               "likelyReviewablePullRequests": {
                 "type": "number"
@@ -922,11 +795,7 @@
               },
               "likelyReviewablePullRequestsSource": {
                 "type": "string",
-                "enum": [
-                  "cache",
-                  "sampled_cache",
-                  "authoritative"
-                ]
+                "enum": ["cache", "sampled_cache", "authoritative"]
               }
             },
             "required": [
@@ -979,11 +848,7 @@
                 "type": "number"
               }
             },
-            "required": [
-              "clusterCount",
-              "highRiskCount",
-              "itemsReviewed"
-            ]
+            "required": ["clusterCount", "highRiskCount", "itemsReviewed"]
           },
           "clusters": {
             "type": "array",
@@ -992,12 +857,7 @@
             }
           }
         },
-        "required": [
-          "repoFullName",
-          "generatedAt",
-          "summary",
-          "clusters"
-        ]
+        "required": ["repoFullName", "generatedAt", "summary", "clusters"]
       },
       "CollisionCluster": {
         "type": "object",
@@ -1007,11 +867,7 @@
           },
           "risk": {
             "type": "string",
-            "enum": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "enum": ["low", "medium", "high"]
           },
           "reason": {
             "type": "string"
@@ -1023,22 +879,14 @@
             }
           }
         },
-        "required": [
-          "id",
-          "risk",
-          "reason",
-          "items"
-        ]
+        "required": ["id", "risk", "reason", "items"]
       },
       "CollisionItem": {
         "type": "object",
         "properties": {
           "type": {
             "type": "string",
-            "enum": [
-              "issue",
-              "pull_request"
-            ]
+            "enum": ["issue", "pull_request"]
           },
           "number": {
             "type": "number"
@@ -1055,11 +903,7 @@
             "nullable": true
           }
         },
-        "required": [
-          "type",
-          "number",
-          "title"
-        ]
+        "required": ["type", "number", "title"]
       },
       "ConfigQuality": {
         "type": "object",
@@ -1075,12 +919,7 @@
           },
           "level": {
             "type": "string",
-            "enum": [
-              "excellent",
-              "good",
-              "needs_attention",
-              "fragile"
-            ]
+            "enum": ["excellent", "good", "needs_attention", "fragile"]
           },
           "lane": {
             "$ref": "#/components/schemas/LaneAdvice"
@@ -1127,13 +966,7 @@
         "properties": {
           "lane": {
             "type": "string",
-            "enum": [
-              "direct_pr",
-              "issue_discovery",
-              "split",
-              "inactive",
-              "unknown"
-            ]
+            "enum": ["direct_pr", "issue_discovery", "split", "inactive", "unknown"]
           },
           "repoFullName": {
             "type": "string"
@@ -1154,13 +987,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "lane",
-          "repoFullName",
-          "summary",
-          "contributorGuidance",
-          "maintainerGuidance"
-        ]
+        "required": ["lane", "repoFullName", "summary", "contributorGuidance", "maintainerGuidance"]
       },
       "LabelAudit": {
         "type": "object",
@@ -1201,12 +1028,7 @@
                   "type": "boolean"
                 }
               },
-              "required": [
-                "name",
-                "count",
-                "configured",
-                "existsOnGitHub"
-              ]
+              "required": ["name", "count", "configured", "existsOnGitHub"]
             }
           },
           "missingConfiguredLabels": {
@@ -1290,24 +1112,14 @@
               },
               "source": {
                 "type": "string",
-                "enum": [
-                  "github",
-                  "unavailable"
-                ]
+                "enum": ["github", "unavailable"]
               }
             },
-            "required": [
-              "login",
-              "topLanguages",
-              "source"
-            ]
+            "required": ["login", "topLanguages", "source"]
           },
           "source": {
             "type": "string",
-            "enum": [
-              "gittensor_api",
-              "github_cache"
-            ]
+            "enum": ["gittensor_api", "github_cache"]
           },
           "gittensor": {
             "type": "object",
@@ -1532,11 +1344,7 @@
               },
               "level": {
                 "type": "string",
-                "enum": [
-                  "new",
-                  "emerging",
-                  "established"
-                ]
+                "enum": ["new", "emerging", "established"]
               },
               "unlinkedOpenPullRequests": {
                 "type": "number"
@@ -1576,38 +1384,22 @@
           },
           "fit": {
             "type": "string",
-            "enum": [
-              "good",
-              "caution",
-              "hold"
-            ]
+            "enum": ["good", "caution", "hold"]
           },
           "score": {
             "type": "number"
           },
           "lane": {
             "type": "string",
-            "enum": [
-              "direct_pr",
-              "issue_discovery",
-              "split",
-              "inactive",
-              "unknown"
-            ]
+            "enum": ["direct_pr", "issue_discovery", "split", "inactive", "unknown"]
           },
           "multiplierTier": {
             "type": "string",
-            "enum": [
-              "maintainer_created",
-              "community"
-            ]
+            "enum": ["maintainer_created", "community"]
           },
           "availability": {
             "type": "string",
-            "enum": [
-              "ready",
-              "maintainer_wip"
-            ]
+            "enum": ["ready", "maintainer_wip"]
           },
           "reasons": {
             "type": "array",
@@ -1647,10 +1439,7 @@
             }
           }
         },
-        "required": [
-          "profile",
-          "opportunities"
-        ]
+        "required": ["profile", "opportunities"]
       },
       "ContributorFit": {
         "type": "object",
@@ -1683,10 +1472,7 @@
                   "type": "boolean"
                 }
               },
-              "required": [
-                "repoFullName",
-                "match"
-              ]
+              "required": ["repoFullName", "match"]
             }
           },
           "repoStats": {
@@ -1797,13 +1583,7 @@
           },
           "source": {
             "type": "string",
-            "enum": [
-              "github_association",
-              "repo_owner_match",
-              "gittensor_api",
-              "cache",
-              "unknown"
-            ]
+            "enum": ["github_association", "repo_owner_match", "gittensor_api", "cache", "unknown"]
           },
           "association": {
             "type": "string",
@@ -1842,10 +1622,7 @@
           },
           "source": {
             "type": "string",
-            "enum": [
-              "gittensor_api",
-              "github_cache"
-            ]
+            "enum": ["gittensor_api", "github_cache"]
           },
           "reconciliation": {
             "type": "object",
@@ -1858,10 +1635,7 @@
               },
               "source": {
                 "type": "string",
-                "enum": [
-                  "gittensor_api",
-                  "github_cache"
-                ]
+                "enum": ["gittensor_api", "github_cache"]
               },
               "officialAuthoritative": {
                 "type": "boolean"
@@ -2035,10 +1809,7 @@
                     ]
                   }
                 },
-                "required": [
-                  "cached",
-                  "effective"
-                ]
+                "required": ["cached", "effective"]
               },
               "repos": {
                 "type": "array",
@@ -2288,10 +2059,7 @@
           },
           "patternType": {
             "type": "string",
-            "enum": [
-              "success",
-              "failure"
-            ]
+            "enum": ["success", "failure"]
           },
           "patterns": {
             "type": "array",
@@ -2306,29 +2074,18 @@
             "type": "string"
           }
         },
-        "required": [
-          "login",
-          "generatedAt",
-          "patternType",
-          "patterns",
-          "summary"
-        ]
+        "required": ["login", "generatedAt", "patternType", "patterns", "summary"]
       },
       "ContributorDecisionPack": {
         "type": "object",
         "properties": {
           "status": {
             "type": "string",
-            "enum": [
-              "ready"
-            ]
+            "enum": ["ready"]
           },
           "source": {
             "type": "string",
-            "enum": [
-              "computed",
-              "snapshot"
-            ]
+            "enum": ["computed", "snapshot"]
           },
           "login": {
             "type": "string"
@@ -2495,12 +2252,7 @@
       },
       "DecisionPackFreshness": {
         "type": "string",
-        "enum": [
-          "fresh",
-          "stale",
-          "rebuilding",
-          "missing"
-        ]
+        "enum": ["fresh", "stale", "rebuilding", "missing"]
       },
       "AgentRecommendationOutcomeSummary": {
         "type": "object",
@@ -2575,10 +2327,7 @@
                 "type": "number"
               }
             },
-            "required": [
-              "explicit",
-              "inferred"
-            ]
+            "required": ["explicit", "inferred"]
           },
           "states": {
             "type": "array",
@@ -2605,10 +2354,7 @@
                 }
               }
             },
-            "required": [
-              "total",
-              "states"
-            ]
+            "required": ["total", "states"]
           },
           "privateSummary": {
             "type": "string"
@@ -2636,22 +2382,11 @@
             "type": "number"
           }
         },
-        "required": [
-          "state",
-          "count"
-        ]
+        "required": ["state", "count"]
       },
       "AgentRecommendationOutcomeState": {
         "type": "string",
-        "enum": [
-          "accepted",
-          "rejected",
-          "ignored",
-          "stale",
-          "merged",
-          "closed",
-          "improved"
-        ]
+        "enum": ["accepted", "rejected", "ignored", "stale", "merged", "closed", "improved"]
       },
       "AgentRecommendationOutcomeRepoSummary": {
         "type": "object",
@@ -2698,12 +2433,7 @@
           },
           "signal": {
             "type": "string",
-            "enum": [
-              "positive",
-              "negative",
-              "mixed",
-              "neutral"
-            ]
+            "enum": ["positive", "negative", "mixed", "neutral"]
           }
         },
         "required": [
@@ -2762,10 +2492,7 @@
                   "properties": {
                     "source": {
                       "type": "string",
-                      "enum": [
-                        "github_observed",
-                        "user_supplied"
-                      ]
+                      "enum": ["github_observed", "user_supplied"]
                     },
                     "pendingMergedPrCount": {
                       "type": "number"
@@ -2809,13 +2536,7 @@
                             }
                           }
                         },
-                        "required": [
-                          "repoFullName",
-                          "number",
-                          "title",
-                          "classification",
-                          "reasons"
-                        ]
+                        "required": ["repoFullName", "number", "title", "classification", "reasons"]
                       }
                     }
                   },
@@ -2829,10 +2550,7 @@
                   ]
                 }
               },
-              "required": [
-                "repoFullName",
-                "detection"
-              ]
+              "required": ["repoFullName", "detection"]
             }
           },
           "pullRequests": {
@@ -2913,9 +2631,7 @@
         "properties": {
           "status": {
             "type": "string",
-            "enum": [
-              "needs_snapshot_refresh"
-            ]
+            "enum": ["needs_snapshot_refresh"]
           },
           "login": {
             "type": "string"
@@ -2928,37 +2644,24 @@
           },
           "reason": {
             "type": "string",
-            "enum": [
-              "missing_snapshot"
-            ]
+            "enum": ["missing_snapshot"]
           },
           "freshness": {
             "type": "string",
-            "enum": [
-              "missing"
-            ]
+            "enum": ["missing"]
           },
           "rebuildEnqueued": {
             "type": "boolean"
           }
         },
-        "required": [
-          "status",
-          "login",
-          "generatedAt",
-          "reason",
-          "freshness",
-          "rebuildEnqueued"
-        ]
+        "required": ["status", "login", "generatedAt", "reason", "freshness", "rebuildEnqueued"]
       },
       "RepoDecisionResponse": {
         "type": "object",
         "properties": {
           "status": {
             "type": "string",
-            "enum": [
-              "ready"
-            ]
+            "enum": ["ready"]
           },
           "login": {
             "type": "string"
@@ -2971,10 +2674,7 @@
           },
           "source": {
             "type": "string",
-            "enum": [
-              "computed",
-              "snapshot"
-            ]
+            "enum": ["computed", "snapshot"]
           },
           "freshness": {
             "$ref": "#/components/schemas/DecisionPackFreshness"
@@ -3012,16 +2712,11 @@
         "properties": {
           "status": {
             "type": "string",
-            "enum": [
-              "ready"
-            ]
+            "enum": ["ready"]
           },
           "source": {
             "type": "string",
-            "enum": [
-              "computed",
-              "snapshot"
-            ]
+            "enum": ["computed", "snapshot"]
           },
           "repoFullName": {
             "type": "string"
@@ -3111,10 +2806,7 @@
             "properties": {
               "source": {
                 "type": "string",
-                "enum": [
-                  "snapshot",
-                  "computed"
-                ]
+                "enum": ["snapshot", "computed"]
               },
               "generatedAt": {
                 "type": "string"
@@ -3124,18 +2816,10 @@
               },
               "freshness": {
                 "type": "string",
-                "enum": [
-                  "fresh",
-                  "stale"
-                ]
+                "enum": ["fresh", "stale"]
               }
             },
-            "required": [
-              "source",
-              "generatedAt",
-              "ageSeconds",
-              "freshness"
-            ]
+            "required": ["source", "generatedAt", "ageSeconds", "freshness"]
           }
         },
         "required": [
@@ -3161,26 +2845,17 @@
             "anyOf": [
               {
                 "type": "number",
-                "enum": [
-                  7
-                ]
+                "enum": [7]
               },
               {
                 "type": "number",
-                "enum": [
-                  30
-                ]
+                "enum": [30]
               }
             ]
           },
           "level": {
             "type": "string",
-            "enum": [
-              "low",
-              "medium",
-              "high",
-              "critical"
-            ]
+            "enum": ["low", "medium", "high", "critical"]
           },
           "forecast": {
             "type": "object",
@@ -3219,13 +2894,7 @@
           },
           "lane": {
             "type": "string",
-            "enum": [
-              "direct_pr",
-              "issue_discovery",
-              "split",
-              "inactive",
-              "unknown"
-            ]
+            "enum": ["direct_pr", "issue_discovery", "split", "inactive", "unknown"]
           },
           "primaryLanguage": {
             "type": "string",
@@ -3332,11 +3001,7 @@
           },
           "status": {
             "type": "string",
-            "enum": [
-              "complete",
-              "partial",
-              "missing"
-            ]
+            "enum": ["complete", "partial", "missing"]
           }
         },
         "required": [
@@ -3356,16 +3021,11 @@
         "properties": {
           "status": {
             "type": "string",
-            "enum": [
-              "ready"
-            ]
+            "enum": ["ready"]
           },
           "source": {
             "type": "string",
-            "enum": [
-              "snapshot",
-              "computed"
-            ]
+            "enum": ["snapshot", "computed"]
           },
           "repoFullName": {
             "type": "string"
@@ -3378,10 +3038,7 @@
           },
           "freshness": {
             "type": "string",
-            "enum": [
-              "fresh",
-              "stale"
-            ]
+            "enum": ["fresh", "stale"]
           },
           "patterns": {
             "$ref": "#/components/schemas/RepoOutcomePatterns"
@@ -3417,11 +3074,7 @@
           },
           "recommendedRegistrationMode": {
             "type": "string",
-            "enum": [
-              "direct_pr",
-              "issue_discovery",
-              "split"
-            ]
+            "enum": ["direct_pr", "issue_discovery", "split"]
           },
           "issuePolicy": {
             "type": "string",
@@ -3445,10 +3098,7 @@
                 }
               }
             },
-            "required": [
-              "ready",
-              "reasons"
-            ]
+            "required": ["ready", "reasons"]
           },
           "issueDiscoveryReadiness": {
             "type": "object",
@@ -3458,11 +3108,7 @@
               },
               "recommendation": {
                 "type": "string",
-                "enum": [
-                  "enabled",
-                  "recommended",
-                  "not_recommended"
-                ]
+                "enum": ["enabled", "recommended", "not_recommended"]
               },
               "reasons": {
                 "type": "array",
@@ -3471,11 +3117,7 @@
                 }
               }
             },
-            "required": [
-              "ready",
-              "recommendation",
-              "reasons"
-            ]
+            "required": ["ready", "recommendation", "reasons"]
           },
           "labelPolicy": {
             "type": "object",
@@ -3494,20 +3136,14 @@
             "properties": {
               "status": {
                 "type": "string",
-                "enum": [
-                  "gate_ready",
-                  "gate_unknown"
-                ]
+                "enum": ["gate_ready", "gate_unknown"]
               },
               "trustedLabelPipelineReady": {
                 "type": "boolean"
               },
               "checkRunMode": {
                 "type": "string",
-                "enum": [
-                  "off",
-                  "enabled"
-                ]
+                "enum": ["off", "enabled"]
               },
               "requiredGate": {
                 "type": "array",
@@ -3539,12 +3175,7 @@
             "properties": {
               "level": {
                 "type": "string",
-                "enum": [
-                  "low",
-                  "medium",
-                  "high",
-                  "critical"
-                ]
+                "enum": ["low", "medium", "high", "critical"]
               },
               "burdenScore": {
                 "type": "number"
@@ -3556,12 +3187,7 @@
                 "type": "string"
               }
             },
-            "required": [
-              "level",
-              "burdenScore",
-              "reviewablePullRequests",
-              "summary"
-            ]
+            "required": ["level", "burdenScore", "reviewablePullRequests", "summary"]
           },
           "contributorIntakeHealth": {
             "type": "object",
@@ -3583,41 +3209,23 @@
               },
               "publicSurface": {
                 "type": "string",
-                "enum": [
-                  "off",
-                  "comment_and_label",
-                  "comment_only",
-                  "label_only"
-                ]
+                "enum": ["off", "comment_and_label", "comment_only", "label_only"]
               },
               "commentMode": {
                 "type": "string",
-                "enum": [
-                  "off",
-                  "detected_contributors_only",
-                  "all_prs"
-                ]
+                "enum": ["off", "detected_contributors_only", "all_prs"]
               },
               "publicAudienceMode": {
                 "type": "string",
-                "enum": [
-                  "oss_maintainer",
-                  "gittensor_only"
-                ]
+                "enum": ["oss_maintainer", "gittensor_only"]
               },
               "checkRunMode": {
                 "type": "string",
-                "enum": [
-                  "off",
-                  "enabled"
-                ]
+                "enum": ["off", "enabled"]
               },
               "gateCheckMode": {
                 "type": "string",
-                "enum": [
-                  "off",
-                  "enabled"
-                ]
+                "enum": ["off", "enabled"]
               },
               "quietByDefault": {
                 "type": "boolean"
@@ -3633,11 +3241,7 @@
               },
               "reviewCheckMode": {
                 "type": "string",
-                "enum": [
-                  "required",
-                  "visible",
-                  "disabled"
-                ]
+                "enum": ["required", "visible", "disabled"]
               }
             },
             "required": [
@@ -3662,9 +3266,7 @@
               },
               "source": {
                 "type": "string",
-                "enum": [
-                  "focus_manifest_policy"
-                ]
+                "enum": ["focus_manifest_policy"]
               },
               "previewOnly": {
                 "type": "boolean"
@@ -3692,11 +3294,7 @@
                     },
                     "severity": {
                       "type": "string",
-                      "enum": [
-                        "info",
-                        "warning",
-                        "critical"
-                      ]
+                      "enum": ["info", "warning", "critical"]
                     },
                     "title": {
                       "type": "string"
@@ -3708,14 +3306,7 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "code",
-                    "category",
-                    "severity",
-                    "title",
-                    "detail",
-                    "action"
-                  ]
+                  "required": ["code", "category", "severity", "title", "detail", "action"]
                 }
               },
               "droppedPublicWarnings": {
@@ -3728,15 +3319,10 @@
                     },
                     "reason": {
                       "type": "string",
-                      "enum": [
-                        "unsafe_public_text"
-                      ]
+                      "enum": ["unsafe_public_text"]
                     }
                   },
-                  "required": [
-                    "code",
-                    "reason"
-                  ]
+                  "required": ["code", "reason"]
                 }
               },
               "summary": {
@@ -3765,21 +3351,15 @@
               },
               "source": {
                 "type": "string",
-                "enum": [
-                  "policy_compiler"
-                ]
+                "enum": ["policy_compiler"]
               },
               "previewOnly": {
                 "type": "boolean",
-                "enum": [
-                  true
-                ]
+                "enum": [true]
               },
               "publicSafe": {
                 "type": "boolean",
-                "enum": [
-                  true
-                ]
+                "enum": [true]
               },
               "contributionLanes": {
                 "type": "array",
@@ -3857,12 +3437,7 @@
                     "nullable": true
                   }
                 },
-                "required": [
-                  "preferredLabels",
-                  "requiredLabels",
-                  "discouragedLabels",
-                  "note"
-                ]
+                "required": ["preferredLabels", "requiredLabels", "discouragedLabels", "note"]
               },
               "validationExpectations": {
                 "type": "array",
@@ -3901,16 +3476,10 @@
                     },
                     "reason": {
                       "type": "string",
-                      "enum": [
-                        "empty",
-                        "unsafe_public_text"
-                      ]
+                      "enum": ["empty", "unsafe_public_text"]
                     }
                   },
-                  "required": [
-                    "field",
-                    "reason"
-                  ]
+                  "required": ["field", "reason"]
                 }
               },
               "privateOwnerContext": {
@@ -3921,30 +3490,21 @@
                   },
                   "includedInPublicPreview": {
                     "type": "boolean",
-                    "enum": [
-                      false
-                    ]
+                    "enum": [false]
                   }
                 },
-                "required": [
-                  "itemCount",
-                  "includedInPublicPreview"
-                ]
+                "required": ["itemCount", "includedInPublicPreview"]
               },
               "publication": {
                 "type": "object",
                 "properties": {
                   "status": {
                     "type": "string",
-                    "enum": [
-                      "preview_only"
-                    ]
+                    "enum": ["preview_only"]
                   },
                   "allowed": {
                     "type": "boolean",
-                    "enum": [
-                      false
-                    ]
+                    "enum": [false]
                   },
                   "actions": {
                     "type": "array",
@@ -3956,12 +3516,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "status",
-                  "allowed",
-                  "actions",
-                  "reason"
-                ]
+                "required": ["status", "allowed", "actions", "reason"]
               }
             },
             "required": [
@@ -4105,21 +3660,11 @@
           },
           "recommendation": {
             "type": "string",
-            "enum": [
-              "pursue",
-              "cleanup_first",
-              "maintainer_lane",
-              "avoid_for_now",
-              "unknown"
-            ]
+            "enum": ["pursue", "cleanup_first", "maintainer_lane", "avoid_for_now", "unknown"]
           },
           "confidence": {
             "type": "string",
-            "enum": [
-              "high",
-              "medium",
-              "low"
-            ]
+            "enum": ["high", "medium", "low"]
           },
           "reasons": {
             "type": "array",
@@ -4182,22 +3727,14 @@
           },
           "status": {
             "type": "string",
-            "enum": [
-              "ready",
-              "needs_work",
-              "hold"
-            ]
+            "enum": ["ready", "needs_work", "hold"]
           },
           "lane": {
             "$ref": "#/components/schemas/LaneAdvice"
           },
           "reviewBurden": {
             "type": "string",
-            "enum": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "enum": ["low", "medium", "high"]
           },
           "linkedIssues": {
             "type": "array",
@@ -4272,9 +3809,7 @@
                 ]
               }
             },
-            "required": [
-              "localDiff"
-            ]
+            "required": ["localDiff"]
           }
         ]
       },
@@ -4304,12 +3839,7 @@
             "properties": {
               "status": {
                 "type": "string",
-                "enum": [
-                  "fresh",
-                  "stale",
-                  "possibly_stale",
-                  "unknown"
-                ]
+                "enum": ["fresh", "stale", "possibly_stale", "unknown"]
               },
               "baseRef": {
                 "type": "string"
@@ -4566,21 +4096,13 @@
                         },
                         "severity": {
                           "type": "string",
-                          "enum": [
-                            "blocker",
-                            "reducer",
-                            "context"
-                          ]
+                          "enum": ["blocker", "reducer", "context"]
                         },
                         "detail": {
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "code",
-                        "severity",
-                        "detail"
-                      ]
+                      "required": ["code", "severity", "detail"]
                     }
                   },
                   "linkedIssueMultiplier": {
@@ -4588,11 +4110,7 @@
                     "properties": {
                       "mode": {
                         "type": "string",
-                        "enum": [
-                          "none",
-                          "standard",
-                          "maintainer"
-                        ]
+                        "enum": ["none", "standard", "maintainer"]
                       },
                       "status": {
                         "type": "string",
@@ -4875,21 +4393,13 @@
                         },
                         "severity": {
                           "type": "string",
-                          "enum": [
-                            "blocker",
-                            "reducer",
-                            "context"
-                          ]
+                          "enum": ["blocker", "reducer", "context"]
                         },
                         "detail": {
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "code",
-                        "severity",
-                        "detail"
-                      ]
+                      "required": ["code", "severity", "detail"]
                     }
                   },
                   "linkedIssueMultiplier": {
@@ -4897,11 +4407,7 @@
                     "properties": {
                       "mode": {
                         "type": "string",
-                        "enum": [
-                          "none",
-                          "standard",
-                          "maintainer"
-                        ]
+                        "enum": ["none", "standard", "maintainer"]
                       },
                       "status": {
                         "type": "string",
@@ -5184,21 +4690,13 @@
                         },
                         "severity": {
                           "type": "string",
-                          "enum": [
-                            "blocker",
-                            "reducer",
-                            "context"
-                          ]
+                          "enum": ["blocker", "reducer", "context"]
                         },
                         "detail": {
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "code",
-                        "severity",
-                        "detail"
-                      ]
+                      "required": ["code", "severity", "detail"]
                     }
                   },
                   "linkedIssueMultiplier": {
@@ -5206,11 +4704,7 @@
                     "properties": {
                       "mode": {
                         "type": "string",
-                        "enum": [
-                          "none",
-                          "standard",
-                          "maintainer"
-                        ]
+                        "enum": ["none", "standard", "maintainer"]
                       },
                       "status": {
                         "type": "string",
@@ -5493,21 +4987,13 @@
                         },
                         "severity": {
                           "type": "string",
-                          "enum": [
-                            "blocker",
-                            "reducer",
-                            "context"
-                          ]
+                          "enum": ["blocker", "reducer", "context"]
                         },
                         "detail": {
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "code",
-                        "severity",
-                        "detail"
-                      ]
+                      "required": ["code", "severity", "detail"]
                     }
                   },
                   "linkedIssueMultiplier": {
@@ -5515,11 +5001,7 @@
                     "properties": {
                       "mode": {
                         "type": "string",
-                        "enum": [
-                          "none",
-                          "standard",
-                          "maintainer"
-                        ]
+                        "enum": ["none", "standard", "maintainer"]
                       },
                       "status": {
                         "type": "string",
@@ -5802,21 +5284,13 @@
                         },
                         "severity": {
                           "type": "string",
-                          "enum": [
-                            "blocker",
-                            "reducer",
-                            "context"
-                          ]
+                          "enum": ["blocker", "reducer", "context"]
                         },
                         "detail": {
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "code",
-                        "severity",
-                        "detail"
-                      ]
+                      "required": ["code", "severity", "detail"]
                     }
                   },
                   "linkedIssueMultiplier": {
@@ -5824,11 +5298,7 @@
                     "properties": {
                       "mode": {
                         "type": "string",
-                        "enum": [
-                          "none",
-                          "standard",
-                          "maintainer"
-                        ]
+                        "enum": ["none", "standard", "maintainer"]
                       },
                       "status": {
                         "type": "string",
@@ -5939,12 +5409,7 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "gate",
-                    "current",
-                    "projected",
-                    "explanation"
-                  ]
+                  "required": ["gate", "current", "projected", "explanation"]
                 }
               },
               "blockedBy": {
@@ -5975,30 +5440,17 @@
                     },
                     "severity": {
                       "type": "string",
-                      "enum": [
-                        "blocker",
-                        "reducer",
-                        "context"
-                      ]
+                      "enum": ["blocker", "reducer", "context"]
                     },
                     "detail": {
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "code",
-                    "severity",
-                    "detail"
-                  ]
+                  "required": ["code", "severity", "detail"]
                 }
               }
             },
-            "required": [
-              "current",
-              "bestReasonableCase",
-              "gateDeltas",
-              "blockedBy"
-            ]
+            "required": ["current", "bestReasonableCase", "gateDeltas", "blockedBy"]
           },
           "observedPullRequestScenarios": {
             "type": "object",
@@ -6043,9 +5495,7 @@
             "properties": {
               "source": {
                 "type": "string",
-                "enum": [
-                  "cached_github_data"
-                ]
+                "enum": ["cached_github_data"]
               },
               "status": {
                 "type": "string",
@@ -6080,11 +5530,7 @@
                 }
               }
             },
-            "required": [
-              "source",
-              "status",
-              "notes"
-            ]
+            "required": ["source", "status", "notes"]
           },
           "branchEligibility": {
             "type": "object",
@@ -6094,19 +5540,11 @@
               },
               "status": {
                 "type": "string",
-                "enum": [
-                  "eligible",
-                  "ineligible",
-                  "unknown",
-                  "not_required"
-                ]
+                "enum": ["eligible", "ineligible", "unknown", "not_required"]
               },
               "evidence": {
                 "type": "string",
-                "enum": [
-                  "provided",
-                  "missing"
-                ]
+                "enum": ["provided", "missing"]
               },
               "source": {
                 "type": "string",
@@ -6134,14 +5572,7 @@
                 }
               }
             },
-            "required": [
-              "required",
-              "status",
-              "evidence",
-              "source",
-              "stale",
-              "warnings"
-            ]
+            "required": ["required", "status", "evidence", "source", "stale", "warnings"]
           },
           "rewardRisk": {
             "$ref": "#/components/schemas/RepoRewardRisk"
@@ -6178,21 +5609,11 @@
             "properties": {
               "recommendation": {
                 "type": "string",
-                "enum": [
-                  "pursue",
-                  "cleanup_first",
-                  "maintainer_lane",
-                  "avoid_for_now",
-                  "unknown"
-                ]
+                "enum": ["pursue", "cleanup_first", "maintainer_lane", "avoid_for_now", "unknown"]
               },
               "reviewBurden": {
                 "type": "string",
-                "enum": [
-                  "low",
-                  "medium",
-                  "high"
-                ]
+                "enum": ["low", "medium", "high"]
               },
               "role": {
                 "type": "string",
@@ -6238,27 +5659,15 @@
               },
               "source": {
                 "type": "string",
-                "enum": [
-                  "repo_file",
-                  "api_record",
-                  "none"
-                ]
+                "enum": ["repo_file", "api_record", "none"]
               },
               "linkedIssuePolicy": {
                 "type": "string",
-                "enum": [
-                  "required",
-                  "preferred",
-                  "optional"
-                ]
+                "enum": ["required", "preferred", "optional"]
               },
               "issueDiscoveryPolicy": {
                 "type": "string",
-                "enum": [
-                  "encouraged",
-                  "neutral",
-                  "discouraged"
-                ]
+                "enum": ["encouraged", "neutral", "discouraged"]
               },
               "matchedWantedPaths": {
                 "type": "array",
@@ -6288,11 +5697,7 @@
                     },
                     "severity": {
                       "type": "string",
-                      "enum": [
-                        "info",
-                        "warning",
-                        "critical"
-                      ]
+                      "enum": ["info", "warning", "critical"]
                     },
                     "title": {
                       "type": "string"
@@ -6304,12 +5709,7 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "code",
-                    "severity",
-                    "title",
-                    "detail"
-                  ]
+                  "required": ["code", "severity", "title", "detail"]
                 }
               },
               "publicNextSteps": {
@@ -6366,10 +5766,7 @@
                       }
                     }
                   },
-                  "required": [
-                    "heading",
-                    "lines"
-                  ]
+                  "required": ["heading", "lines"]
                 }
               },
               "reviewerNotes": {
@@ -6400,14 +5797,7 @@
                         },
                         "status": {
                           "type": "string",
-                          "enum": [
-                            "passed",
-                            "failed",
-                            "not_run",
-                            "skipped",
-                            "focused",
-                            "unknown"
-                          ]
+                          "enum": ["passed", "failed", "not_run", "skipped", "focused", "unknown"]
                         },
                         "summary": {
                           "type": "string"
@@ -6419,19 +5809,11 @@
                           "type": "number"
                         }
                       },
-                      "required": [
-                        "command",
-                        "status"
-                      ]
+                      "required": ["command", "status"]
                     }
                   }
                 },
-                "required": [
-                  "passed",
-                  "failed",
-                  "notRun",
-                  "commands"
-                ]
+                "required": ["passed", "failed", "notRun", "commands"]
               },
               "publicSafeWarnings": {
                 "type": "array",
@@ -6512,9 +5894,7 @@
           },
           "privateOnly": {
             "type": "boolean",
-            "enum": [
-              true
-            ]
+            "enum": [true]
           },
           "laneMath": {
             "type": "object",
@@ -6590,22 +5970,11 @@
             "properties": {
               "mode": {
                 "type": "string",
-                "enum": [
-                  "none",
-                  "standard",
-                  "maintainer"
-                ]
+                "enum": ["none", "standard", "maintainer"]
               },
               "status": {
                 "type": "string",
-                "enum": [
-                  "not_required",
-                  "raw",
-                  "plausible",
-                  "validated",
-                  "invalid",
-                  "unavailable"
-                ]
+                "enum": ["not_required", "raw", "plausible", "validated", "invalid", "unavailable"]
               },
               "source": {
                 "type": "string",
@@ -6741,19 +6110,11 @@
               },
               "status": {
                 "type": "string",
-                "enum": [
-                  "eligible",
-                  "ineligible",
-                  "unknown",
-                  "not_required"
-                ]
+                "enum": ["eligible", "ineligible", "unknown", "not_required"]
               },
               "evidence": {
                 "type": "string",
-                "enum": [
-                  "provided",
-                  "missing"
-                ]
+                "enum": ["provided", "missing"]
               },
               "source": {
                 "type": "string",
@@ -6781,14 +6142,7 @@
                 }
               }
             },
-            "required": [
-              "required",
-              "status",
-              "evidence",
-              "source",
-              "stale",
-              "warnings"
-            ]
+            "required": ["required", "status", "evidence", "source", "stale", "warnings"]
           },
           "effectiveEstimatedScore": {
             "type": "number"
@@ -6824,21 +6178,13 @@
                 },
                 "severity": {
                   "type": "string",
-                  "enum": [
-                    "blocker",
-                    "reducer",
-                    "context"
-                  ]
+                  "enum": ["blocker", "reducer", "context"]
                 },
                 "detail": {
                   "type": "string"
                 }
               },
-              "required": [
-                "code",
-                "severity",
-                "detail"
-              ]
+              "required": ["code", "severity", "detail"]
             }
           },
           "gateDeltas": {
@@ -6867,12 +6213,7 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "gate",
-                "current",
-                "projected",
-                "explanation"
-              ]
+              "required": ["gate", "current", "projected", "explanation"]
             }
           },
           "scenarioPreviews": {
@@ -7075,21 +6416,13 @@
                       },
                       "severity": {
                         "type": "string",
-                        "enum": [
-                          "blocker",
-                          "reducer",
-                          "context"
-                        ]
+                        "enum": ["blocker", "reducer", "context"]
                       },
                       "detail": {
                         "type": "string"
                       }
                     },
-                    "required": [
-                      "code",
-                      "severity",
-                      "detail"
-                    ]
+                    "required": ["code", "severity", "detail"]
                   }
                 },
                 "linkedIssueMultiplier": {
@@ -7097,11 +6430,7 @@
                   "properties": {
                     "mode": {
                       "type": "string",
-                      "enum": [
-                        "none",
-                        "standard",
-                        "maintainer"
-                      ]
+                      "enum": ["none", "standard", "maintainer"]
                     },
                     "status": {
                       "type": "string",
@@ -7189,12 +6518,7 @@
           },
           "scoreabilityStatus": {
             "type": "string",
-            "enum": [
-              "blocked",
-              "conditionally_scoreable",
-              "scoreable",
-              "hold"
-            ]
+            "enum": ["blocked", "conditionally_scoreable", "scoreable", "hold"]
           },
           "warnings": {
             "type": "array",
@@ -7213,12 +6537,7 @@
             "properties": {
               "level": {
                 "type": "string",
-                "enum": [
-                  "strong_fit",
-                  "reasonable_fit",
-                  "needs_work",
-                  "hold"
-                ]
+                "enum": ["strong_fit", "reasonable_fit", "needs_work", "hold"]
               },
               "actions": {
                 "type": "array",
@@ -7227,10 +6546,7 @@
                 }
               }
             },
-            "required": [
-              "level",
-              "actions"
-            ]
+            "required": ["level", "actions"]
           }
         },
         "required": [
@@ -7275,25 +6591,14 @@
           },
           "recommendation": {
             "type": "string",
-            "enum": [
-              "pursue",
-              "cleanup_first",
-              "maintainer_lane",
-              "avoid_for_now",
-              "unknown"
-            ]
+            "enum": ["pursue", "cleanup_first", "maintainer_lane", "avoid_for_now", "unknown"]
           },
           "rewardUpside": {
             "type": "object",
             "properties": {
               "relevantLane": {
                 "type": "string",
-                "enum": [
-                  "direct_pr",
-                  "issue_discovery",
-                  "maintainer_lane",
-                  "none"
-                ]
+                "enum": ["direct_pr", "issue_discovery", "maintainer_lane", "none"]
               },
               "repoSlice": {
                 "type": "number"
@@ -7329,10 +6634,7 @@
                     "type": "number"
                   }
                 },
-                "required": [
-                  "competitionFactor",
-                  "freshnessFactor"
-                ]
+                "required": ["competitionFactor", "freshnessFactor"]
               }
             },
             "required": [
@@ -7359,12 +6661,7 @@
             "properties": {
               "queueBurden": {
                 "type": "string",
-                "enum": [
-                  "low",
-                  "medium",
-                  "high",
-                  "critical"
-                ]
+                "enum": ["low", "medium", "high", "critical"]
               },
               "queueBurdenScore": {
                 "type": "number"
@@ -7386,11 +6683,7 @@
               },
               "reviewChurnRisk": {
                 "type": "string",
-                "enum": [
-                  "low",
-                  "medium",
-                  "high"
-                ]
+                "enum": ["low", "medium", "high"]
               }
             },
             "required": [
@@ -7483,12 +6776,7 @@
           },
           "severity": {
             "type": "string",
-            "enum": [
-              "critical",
-              "warning",
-              "tip",
-              "info"
-            ]
+            "enum": ["critical", "warning", "tip", "info"]
           },
           "priorityScore": {
             "type": "number"
@@ -7544,27 +6832,20 @@
         "properties": {
           "version": {
             "type": "number",
-            "enum": [
-              2
-            ]
+            "enum": [2]
           },
           "sourceUpload": {
             "type": "object",
             "properties": {
               "enabled": {
                 "type": "boolean",
-                "enum": [
-                  false
-                ]
+                "enum": [false]
               },
               "detail": {
                 "type": "string"
               }
             },
-            "required": [
-              "enabled",
-              "detail"
-            ]
+            "required": ["enabled", "detail"]
           },
           "branch": {
             "type": "object",
@@ -7582,9 +6863,7 @@
                 "type": "number"
               }
             },
-            "required": [
-              "pendingCommitCount"
-            ]
+            "required": ["pendingCommitCount"]
           },
           "changedFiles": {
             "type": "object",
@@ -7614,27 +6893,14 @@
                 }
               }
             },
-            "required": [
-              "total",
-              "added",
-              "modified",
-              "deleted",
-              "renamed",
-              "binary",
-              "paths"
-            ]
+            "required": ["total", "added", "modified", "deleted", "renamed", "binary", "paths"]
           },
           "testEvidence": {
             "type": "object",
             "properties": {
               "level": {
                 "type": "string",
-                "enum": [
-                  "test_files",
-                  "validation_commands",
-                  "both",
-                  "none"
-                ]
+                "enum": ["test_files", "validation_commands", "both", "none"]
               },
               "testFileCount": {
                 "type": "number"
@@ -7652,29 +6918,17 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": [
-                        "passed",
-                        "failed",
-                        "not_run"
-                      ]
+                      "enum": ["passed", "failed", "not_run"]
                     },
                     "summary": {
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "command",
-                    "status"
-                  ]
+                  "required": ["command", "status"]
                 }
               }
             },
-            "required": [
-              "level",
-              "testFileCount",
-              "passedValidationCount",
-              "commands"
-            ]
+            "required": ["level", "testFileCount", "passedValidationCount", "commands"]
           },
           "linkedIssues": {
             "type": "array",
@@ -7687,12 +6941,7 @@
             "properties": {
               "status": {
                 "type": "string",
-                "enum": [
-                  "fresh",
-                  "stale",
-                  "possibly_stale",
-                  "unknown"
-                ]
+                "enum": ["fresh", "stale", "possibly_stale", "unknown"]
               },
               "baseRef": {
                 "type": "string"
@@ -7761,11 +7010,7 @@
                 "type": "boolean"
               }
             },
-            "required": [
-              "mode",
-              "warnings",
-              "metadataOnly"
-            ]
+            "required": ["mode", "warnings", "metadataOnly"]
           },
           "blockers": {
             "type": "object",
@@ -7783,10 +7028,7 @@
                 }
               }
             },
-            "required": [
-              "branchQuality",
-              "accountState"
-            ]
+            "required": ["branchQuality", "accountState"]
           },
           "rerunWhen": {
             "type": "string"
@@ -7840,11 +7082,7 @@
                 },
                 "reviewPriority": {
                   "type": "string",
-                  "enum": [
-                    "review",
-                    "needs_author",
-                    "watch"
-                  ]
+                  "enum": ["review", "needs_author", "watch"]
                 },
                 "reasons": {
                   "type": "array",
@@ -7853,12 +7091,7 @@
                   }
                 }
               },
-              "required": [
-                "number",
-                "title",
-                "reviewPriority",
-                "reasons"
-              ]
+              "required": ["number", "title", "reviewPriority", "reasons"]
             }
           },
           "suggestedActions": {
@@ -7939,12 +7172,7 @@
           },
           "level": {
             "type": "string",
-            "enum": [
-              "healthy",
-              "watch",
-              "strained",
-              "blocked"
-            ]
+            "enum": ["healthy", "watch", "strained", "blocked"]
           },
           "score": {
             "type": "number"
@@ -7957,12 +7185,7 @@
           },
           "configLevel": {
             "type": "string",
-            "enum": [
-              "excellent",
-              "good",
-              "needs_attention",
-              "fragile"
-            ]
+            "enum": ["excellent", "good", "needs_attention", "fragile"]
           },
           "duplicateClusters": {
             "type": "number"
@@ -8054,11 +7277,7 @@
           },
           "reviewPriority": {
             "type": "string",
-            "enum": [
-              "review",
-              "needs_author",
-              "watch"
-            ]
+            "enum": ["review", "needs_author", "watch"]
           },
           "summary": {
             "type": "string"
@@ -8182,13 +7401,7 @@
               },
               "recommendation": {
                 "type": "string",
-                "enum": [
-                  "review",
-                  "needs_author",
-                  "watch",
-                  "likely_duplicate",
-                  "maintainer_lane"
-                ]
+                "enum": ["review", "needs_author", "watch", "likely_duplicate", "maintainer_lane"]
               },
               "privateSummary": {
                 "type": "string"
@@ -8200,11 +7413,7 @@
                 }
               }
             },
-            "required": [
-              "roleContext",
-              "recommendation",
-              "privateSummary"
-            ]
+            "required": ["roleContext", "recommendation", "privateSummary"]
           }
         ]
       },
@@ -8246,13 +7455,7 @@
             "nullable": true
           }
         },
-        "required": [
-          "id",
-          "repoFullName",
-          "issueNumber",
-          "status",
-          "payload"
-        ]
+        "required": ["id", "repoFullName", "issueNumber", "status", "payload"]
       },
       "BountyAdvisory": {
         "type": "object",
@@ -8286,19 +7489,11 @@
           },
           "fundingStatus": {
             "type": "string",
-            "enum": [
-              "funded",
-              "target_only",
-              "unknown"
-            ]
+            "enum": ["funded", "target_only", "unknown"]
           },
           "consensusRisk": {
             "type": "string",
-            "enum": [
-              "low",
-              "medium",
-              "high"
-            ]
+            "enum": ["low", "medium", "high"]
           },
           "source": {
             "type": "object",
@@ -8325,17 +7520,10 @@
               },
               "freshness": {
                 "type": "string",
-                "enum": [
-                  "fresh",
-                  "stale",
-                  "unknown"
-                ]
+                "enum": ["fresh", "stale", "unknown"]
               }
             },
-            "required": [
-              "ageDays",
-              "freshness"
-            ]
+            "required": ["ageDays", "freshness"]
           },
           "linkedPrs": {
             "type": "array",
@@ -8347,22 +7535,13 @@
                 },
                 "state": {
                   "type": "string",
-                  "enum": [
-                    "open",
-                    "closed",
-                    "merged",
-                    "unknown"
-                  ]
+                  "enum": ["open", "closed", "merged", "unknown"]
                 },
                 "isActive": {
                   "type": "boolean"
                 }
               },
-              "required": [
-                "number",
-                "state",
-                "isActive"
-              ]
+              "required": ["number", "state", "isActive"]
             }
           },
           "findings": {
@@ -8434,10 +7613,7 @@
             }
           }
         },
-        "required": [
-          "bountyId",
-          "events"
-        ]
+        "required": ["bountyId", "events"]
       },
       "RepositorySettings": {
         "type": "object",
@@ -8447,78 +7623,43 @@
           },
           "commentMode": {
             "type": "string",
-            "enum": [
-              "off",
-              "detected_contributors_only",
-              "all_prs"
-            ]
+            "enum": ["off", "detected_contributors_only", "all_prs"]
           },
           "publicAudienceMode": {
             "type": "string",
-            "enum": [
-              "oss_maintainer",
-              "gittensor_only"
-            ]
+            "enum": ["oss_maintainer", "gittensor_only"]
           },
           "publicSignalLevel": {
             "type": "string",
-            "enum": [
-              "minimal",
-              "standard"
-            ]
+            "enum": ["minimal", "standard"]
           },
           "checkRunMode": {
             "type": "string",
-            "enum": [
-              "off",
-              "enabled"
-            ]
+            "enum": ["off", "enabled"]
           },
           "checkRunDetailLevel": {
             "type": "string",
-            "enum": [
-              "minimal",
-              "standard",
-              "deep"
-            ]
+            "enum": ["minimal", "standard", "deep"]
           },
           "gateCheckMode": {
             "type": "string",
-            "enum": [
-              "off",
-              "enabled"
-            ]
+            "enum": ["off", "enabled"]
           },
           "gatePack": {
             "type": "string",
-            "enum": [
-              "gittensor",
-              "oss-anti-slop"
-            ]
+            "enum": ["gittensor", "oss-anti-slop"]
           },
           "linkedIssueGateMode": {
             "type": "string",
-            "enum": [
-              "off",
-              "advisory",
-              "block"
-            ]
+            "enum": ["off", "advisory", "block"]
           },
           "duplicatePrGateMode": {
             "type": "string",
-            "enum": [
-              "off",
-              "advisory",
-              "block"
-            ]
+            "enum": ["off", "advisory", "block"]
           },
           "qualityGateMode": {
             "type": "string",
-            "enum": [
-              "off",
-              "advisory",
-              "block"
-            ]
+            "enum": ["off", "advisory", "block"]
           },
           "qualityGateMinScore": {
             "type": "number",
@@ -8526,27 +7667,15 @@
           },
           "slopGateMode": {
             "type": "string",
-            "enum": [
-              "off",
-              "advisory",
-              "block"
-            ]
+            "enum": ["off", "advisory", "block"]
           },
           "sizeGateMode": {
             "type": "string",
-            "enum": [
-              "off",
-              "advisory",
-              "block"
-            ]
+            "enum": ["off", "advisory", "block"]
           },
           "lockfileIntegrityGateMode": {
             "type": "string",
-            "enum": [
-              "off",
-              "advisory",
-              "block"
-            ]
+            "enum": ["off", "advisory", "block"]
           },
           "gateDryRun": {
             "type": "boolean"
@@ -8562,27 +7691,15 @@
           },
           "mergeReadinessGateMode": {
             "type": "string",
-            "enum": [
-              "off",
-              "advisory",
-              "block"
-            ]
+            "enum": ["off", "advisory", "block"]
           },
           "manifestPolicyGateMode": {
             "type": "string",
-            "enum": [
-              "off",
-              "advisory",
-              "block"
-            ]
+            "enum": ["off", "advisory", "block"]
           },
           "selfAuthoredLinkedIssueGateMode": {
             "type": "string",
-            "enum": [
-              "off",
-              "advisory",
-              "block"
-            ]
+            "enum": ["off", "advisory", "block"]
           },
           "firstTimeContributorGrace": {
             "type": "boolean"
@@ -8596,11 +7713,7 @@
           },
           "aiReviewMode": {
             "type": "string",
-            "enum": [
-              "off",
-              "advisory",
-              "block"
-            ]
+            "enum": ["off", "advisory", "block"]
           },
           "aiReviewByok": {
             "type": "boolean"
@@ -8608,11 +7721,7 @@
           "aiReviewProvider": {
             "type": "string",
             "nullable": true,
-            "enum": [
-              "anthropic",
-              "openai",
-              null
-            ]
+            "enum": ["anthropic", "openai", null]
           },
           "aiReviewModel": {
             "type": "string",
@@ -8628,21 +7737,12 @@
           "aiReviewCombine": {
             "type": "string",
             "nullable": true,
-            "enum": [
-              "single",
-              "consensus",
-              "synthesis",
-              null
-            ]
+            "enum": ["single", "consensus", "synthesis", null]
           },
           "aiReviewOnMerge": {
             "type": "string",
             "nullable": true,
-            "enum": [
-              "either",
-              "both",
-              null
-            ]
+            "enum": ["either", "both", null]
           },
           "aiReviewReviewers": {
             "type": "array",
@@ -8658,9 +7758,7 @@
                   "nullable": true
                 }
               },
-              "required": [
-                "model"
-              ]
+              "required": ["model"]
             }
           },
           "closeOwnerAuthors": {
@@ -8681,12 +7779,7 @@
           },
           "publicSurface": {
             "type": "string",
-            "enum": [
-              "off",
-              "comment_and_label",
-              "comment_only",
-              "label_only"
-            ]
+            "enum": ["off", "comment_and_label", "comment_only", "label_only"]
           },
           "includeMaintainerAuthors": {
             "type": "boolean"
@@ -8710,12 +7803,7 @@
                 "type": "array",
                 "items": {
                   "type": "string",
-                  "enum": [
-                    "maintainer",
-                    "collaborator",
-                    "pr_author",
-                    "confirmed_miner"
-                  ]
+                  "enum": ["maintainer", "collaborator", "pr_author", "confirmed_miner"]
                 }
               },
               "commands": {
@@ -8724,20 +7812,12 @@
                   "type": "array",
                   "items": {
                     "type": "string",
-                    "enum": [
-                      "maintainer",
-                      "collaborator",
-                      "pr_author",
-                      "confirmed_miner"
-                    ]
+                    "enum": ["maintainer", "collaborator", "pr_author", "confirmed_miner"]
                   }
                 }
               }
             },
-            "required": [
-              "default",
-              "commands"
-            ]
+            "required": ["default", "commands"]
           },
           "contributorBlacklist": {
             "type": "array",
@@ -8760,9 +7840,7 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "login"
-              ]
+              "required": ["login"]
             }
           },
           "autonomy": {
@@ -8770,73 +7848,31 @@
             "properties": {
               "review": {
                 "type": "string",
-                "enum": [
-                  "observe",
-                  "suggest",
-                  "propose",
-                  "auto_with_approval",
-                  "auto"
-                ]
+                "enum": ["observe", "suggest", "propose", "auto_with_approval", "auto"]
               },
               "request_changes": {
                 "type": "string",
-                "enum": [
-                  "observe",
-                  "suggest",
-                  "propose",
-                  "auto_with_approval",
-                  "auto"
-                ]
+                "enum": ["observe", "suggest", "propose", "auto_with_approval", "auto"]
               },
               "approve": {
                 "type": "string",
-                "enum": [
-                  "observe",
-                  "suggest",
-                  "propose",
-                  "auto_with_approval",
-                  "auto"
-                ]
+                "enum": ["observe", "suggest", "propose", "auto_with_approval", "auto"]
               },
               "merge": {
                 "type": "string",
-                "enum": [
-                  "observe",
-                  "suggest",
-                  "propose",
-                  "auto_with_approval",
-                  "auto"
-                ]
+                "enum": ["observe", "suggest", "propose", "auto_with_approval", "auto"]
               },
               "close": {
                 "type": "string",
-                "enum": [
-                  "observe",
-                  "suggest",
-                  "propose",
-                  "auto_with_approval",
-                  "auto"
-                ]
+                "enum": ["observe", "suggest", "propose", "auto_with_approval", "auto"]
               },
               "label": {
                 "type": "string",
-                "enum": [
-                  "observe",
-                  "suggest",
-                  "propose",
-                  "auto_with_approval",
-                  "auto"
-                ]
+                "enum": ["observe", "suggest", "propose", "auto_with_approval", "auto"]
               },
               "review_state_label": {
                 "type": "string",
-                "enum": [
-                  "observe",
-                  "suggest",
-                  "propose",
-                  "auto_with_approval",
-                  "auto"
-                ]
+                "enum": ["observe", "suggest", "propose", "auto_with_approval", "auto"]
               }
             }
           },
@@ -8848,17 +7884,10 @@
               },
               "mergeMethod": {
                 "type": "string",
-                "enum": [
-                  "merge",
-                  "squash",
-                  "rebase"
-                ]
+                "enum": ["merge", "squash", "rebase"]
               }
             },
-            "required": [
-              "requireApprovals",
-              "mergeMethod"
-            ]
+            "required": ["requireApprovals", "mergeMethod"]
           },
           "agentPaused": {
             "type": "boolean"
@@ -8884,11 +7913,7 @@
           },
           "reviewNagPolicy": {
             "type": "string",
-            "enum": [
-              "off",
-              "hold",
-              "close"
-            ]
+            "enum": ["off", "hold", "close"]
           },
           "reviewNagMaxPings": {
             "type": "integer",
@@ -8922,10 +7947,7 @@
           },
           "commandRateLimitPolicy": {
             "type": "string",
-            "enum": [
-              "off",
-              "hold"
-            ]
+            "enum": ["off", "hold"]
           },
           "commandRateLimitMaxPerWindow": {
             "type": "integer",
@@ -8958,11 +7980,7 @@
           },
           "claGateMode": {
             "type": "string",
-            "enum": [
-              "off",
-              "advisory",
-              "block"
-            ]
+            "enum": ["off", "advisory", "block"]
           },
           "claConsentPhrase": {
             "type": "string",
@@ -8981,21 +7999,13 @@
           },
           "moderationGateMode": {
             "type": "string",
-            "enum": [
-              "inherit",
-              "off",
-              "enabled"
-            ]
+            "enum": ["inherit", "off", "enabled"]
           },
           "moderationRules": {
             "type": "array",
             "items": {
               "type": "string",
-              "enum": [
-                "contributor_cap",
-                "blacklist",
-                "review_nag"
-              ]
+              "enum": ["contributor_cap", "blacklist", "review_nag"]
             }
           },
           "moderationWarningLabel": {
@@ -9017,11 +8027,7 @@
                 "type": "string"
               }
             },
-            "required": [
-              "bug",
-              "feature",
-              "priority"
-            ]
+            "required": ["bug", "feature", "priority"]
           },
           "linkedIssueLabelPropagation": {
             "type": "object",
@@ -9031,9 +8037,7 @@
               },
               "mode": {
                 "type": "string",
-                "enum": [
-                  "exclusive_type_label"
-                ]
+                "enum": ["exclusive_type_label"]
               },
               "mappings": {
                 "type": "array",
@@ -9050,19 +8054,11 @@
                       "type": "boolean"
                     }
                   },
-                  "required": [
-                    "issueLabel",
-                    "prLabel",
-                    "removeOtherTypeLabels"
-                  ]
+                  "required": ["issueLabel", "prLabel", "removeOtherTypeLabels"]
                 }
               }
             },
-            "required": [
-              "enabled",
-              "mode",
-              "mappings"
-            ]
+            "required": ["enabled", "mode", "mappings"]
           },
           "claCheckRunAppSlug": {
             "type": "string",
@@ -9076,11 +8072,7 @@
           },
           "reviewCheckMode": {
             "type": "string",
-            "enum": [
-              "required",
-              "visible",
-              "disabled"
-            ]
+            "enum": ["required", "visible", "disabled"]
           }
         },
         "required": [
@@ -9144,52 +8136,30 @@
                   "properties": {
                     "publicSurface": {
                       "type": "string",
-                      "enum": [
-                        "off",
-                        "comment_and_label",
-                        "comment_only",
-                        "label_only"
-                      ]
+                      "enum": ["off", "comment_and_label", "comment_only", "label_only"]
                     },
                     "commentMode": {
                       "type": "string",
-                      "enum": [
-                        "off",
-                        "detected_contributors_only",
-                        "all_prs"
-                      ]
+                      "enum": ["off", "detected_contributors_only", "all_prs"]
                     },
                     "publicAudienceMode": {
                       "type": "string",
-                      "enum": [
-                        "oss_maintainer",
-                        "gittensor_only"
-                      ]
+                      "enum": ["oss_maintainer", "gittensor_only"]
                     },
                     "checkRunMode": {
                       "type": "string",
-                      "enum": [
-                        "off",
-                        "enabled"
-                      ]
+                      "enum": ["off", "enabled"]
                     },
                     "gateCheckMode": {
                       "type": "string",
-                      "enum": [
-                        "off",
-                        "enabled"
-                      ]
+                      "enum": ["off", "enabled"]
                     },
                     "autoLabelEnabled": {
                       "type": "boolean"
                     },
                     "reviewCheckMode": {
                       "type": "string",
-                      "enum": [
-                        "required",
-                        "visible",
-                        "disabled"
-                      ]
+                      "enum": ["required", "visible", "disabled"]
                     }
                   },
                   "required": [
@@ -9203,11 +8173,7 @@
                   ]
                 }
               },
-              "required": [
-                "repoFullName",
-                "isRegistered",
-                "settings"
-              ]
+              "required": ["repoFullName", "isRegistered", "settings"]
             }
           },
           "requiredPermissions": {
@@ -9241,12 +8207,7 @@
               "properties": {
                 "mode": {
                   "type": "string",
-                  "enum": [
-                    "comment",
-                    "label",
-                    "check_run",
-                    "gate_check"
-                  ]
+                  "enum": ["comment", "label", "check_run", "gate_check"]
                 },
                 "enabled": {
                   "type": "boolean"
@@ -9272,12 +8233,7 @@
                         "type": "boolean"
                       }
                     },
-                    "required": [
-                      "permission",
-                      "requiredAccess",
-                      "missing",
-                      "optional"
-                    ]
+                    "required": ["permission", "requiredAccess", "missing", "optional"]
                   }
                 },
                 "summary": {
@@ -9318,13 +8274,7 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "event",
-                "missing",
-                "optional",
-                "summary",
-                "action"
-              ]
+              "required": ["event", "missing", "optional", "summary", "action"]
             }
           },
           "repairSteps": {
@@ -9338,9 +8288,7 @@
             "properties": {
               "method": {
                 "type": "string",
-                "enum": [
-                  "POST"
-                ]
+                "enum": ["POST"]
               },
               "path": {
                 "type": "string"
@@ -9349,11 +8297,7 @@
                 "type": "string"
               }
             },
-            "required": [
-              "method",
-              "path",
-              "lastCheckedAt"
-            ]
+            "required": ["method", "path", "lastCheckedAt"]
           },
           "refreshed": {
             "type": "boolean"
@@ -9394,11 +8338,7 @@
           },
           "status": {
             "type": "string",
-            "enum": [
-              "healthy",
-              "needs_attention",
-              "broken"
-            ]
+            "enum": ["healthy", "needs_attention", "broken"]
           },
           "missingPermissions": {
             "type": "array",
@@ -9470,13 +8410,7 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "permission",
-                "requiredAccess",
-                "currentAccess",
-                "ok",
-                "action"
-              ]
+              "required": ["permission", "requiredAccess", "currentAccess", "ok", "action"]
             }
           },
           "eventRemediation": {
@@ -9494,11 +8428,7 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "event",
-                "ok",
-                "action"
-              ]
+              "required": ["event", "ok", "action"]
             }
           },
           "repairSteps": {
@@ -9509,10 +8439,7 @@
           },
           "authMode": {
             "type": "string",
-            "enum": [
-              "local",
-              "broker"
-            ]
+            "enum": ["local", "broker"]
           }
         },
         "required": [
@@ -9543,87 +8470,47 @@
             "properties": {
               "publicSurface": {
                 "type": "string",
-                "enum": [
-                  "off",
-                  "comment_and_label",
-                  "comment_only",
-                  "label_only"
-                ]
+                "enum": ["off", "comment_and_label", "comment_only", "label_only"]
               },
               "commentMode": {
                 "type": "string",
-                "enum": [
-                  "off",
-                  "detected_contributors_only",
-                  "all_prs"
-                ]
+                "enum": ["off", "detected_contributors_only", "all_prs"]
               },
               "publicAudienceMode": {
                 "type": "string",
-                "enum": [
-                  "oss_maintainer",
-                  "gittensor_only"
-                ]
+                "enum": ["oss_maintainer", "gittensor_only"]
               },
               "publicSignalLevel": {
                 "type": "string",
-                "enum": [
-                  "minimal",
-                  "standard"
-                ]
+                "enum": ["minimal", "standard"]
               },
               "checkRunMode": {
                 "type": "string",
-                "enum": [
-                  "off",
-                  "enabled"
-                ]
+                "enum": ["off", "enabled"]
               },
               "checkRunDetailLevel": {
                 "type": "string",
-                "enum": [
-                  "minimal",
-                  "standard",
-                  "deep"
-                ]
+                "enum": ["minimal", "standard", "deep"]
               },
               "gateCheckMode": {
                 "type": "string",
-                "enum": [
-                  "off",
-                  "enabled"
-                ]
+                "enum": ["off", "enabled"]
               },
               "gatePack": {
                 "type": "string",
-                "enum": [
-                  "gittensor",
-                  "oss-anti-slop"
-                ]
+                "enum": ["gittensor", "oss-anti-slop"]
               },
               "linkedIssueGateMode": {
                 "type": "string",
-                "enum": [
-                  "off",
-                  "advisory",
-                  "block"
-                ]
+                "enum": ["off", "advisory", "block"]
               },
               "duplicatePrGateMode": {
                 "type": "string",
-                "enum": [
-                  "off",
-                  "advisory",
-                  "block"
-                ]
+                "enum": ["off", "advisory", "block"]
               },
               "qualityGateMode": {
                 "type": "string",
-                "enum": [
-                  "off",
-                  "advisory",
-                  "block"
-                ]
+                "enum": ["off", "advisory", "block"]
               },
               "qualityGateMinScore": {
                 "type": "number",
@@ -9631,35 +8518,19 @@
               },
               "slopGateMode": {
                 "type": "string",
-                "enum": [
-                  "off",
-                  "advisory",
-                  "block"
-                ]
+                "enum": ["off", "advisory", "block"]
               },
               "mergeReadinessGateMode": {
                 "type": "string",
-                "enum": [
-                  "off",
-                  "advisory",
-                  "block"
-                ]
+                "enum": ["off", "advisory", "block"]
               },
               "manifestPolicyGateMode": {
                 "type": "string",
-                "enum": [
-                  "off",
-                  "advisory",
-                  "block"
-                ]
+                "enum": ["off", "advisory", "block"]
               },
               "selfAuthoredLinkedIssueGateMode": {
                 "type": "string",
-                "enum": [
-                  "off",
-                  "advisory",
-                  "block"
-                ]
+                "enum": ["off", "advisory", "block"]
               },
               "firstTimeContributorGrace": {
                 "type": "boolean"
@@ -9691,11 +8562,7 @@
               },
               "aiReviewMode": {
                 "type": "string",
-                "enum": [
-                  "off",
-                  "advisory",
-                  "block"
-                ]
+                "enum": ["off", "advisory", "block"]
               },
               "aiReviewByok": {
                 "type": "boolean"
@@ -9718,12 +8585,7 @@
                     "type": "array",
                     "items": {
                       "type": "string",
-                      "enum": [
-                        "maintainer",
-                        "collaborator",
-                        "pr_author",
-                        "confirmed_miner"
-                      ]
+                      "enum": ["maintainer", "collaborator", "pr_author", "confirmed_miner"]
                     }
                   },
                   "commandOverrides": {
@@ -9738,37 +8600,22 @@
                           "type": "array",
                           "items": {
                             "type": "string",
-                            "enum": [
-                              "maintainer",
-                              "collaborator",
-                              "pr_author",
-                              "confirmed_miner"
-                            ]
+                            "enum": ["maintainer", "collaborator", "pr_author", "confirmed_miner"]
                           }
                         }
                       },
-                      "required": [
-                        "command",
-                        "allowedRoles"
-                      ]
+                      "required": ["command", "allowedRoles"]
                     }
                   }
                 },
-                "required": [
-                  "defaultAllowed",
-                  "commandOverrides"
-                ]
+                "required": ["defaultAllowed", "commandOverrides"]
               },
               "typeLabelsEnabled": {
                 "type": "boolean"
               },
               "reviewCheckMode": {
                 "type": "string",
-                "enum": [
-                  "required",
-                  "visible",
-                  "disabled"
-                ]
+                "enum": ["required", "visible", "disabled"]
               }
             },
             "required": [
@@ -9828,51 +8675,25 @@
                   },
                   "actorKind": {
                     "type": "string",
-                    "enum": [
-                      "maintainer",
-                      "author",
-                      "none"
-                    ]
+                    "enum": ["maintainer", "author", "none"]
                   },
                   "matchedRole": {
                     "type": "string",
                     "nullable": true,
-                    "enum": [
-                      "maintainer",
-                      "collaborator",
-                      "pr_author",
-                      "confirmed_miner",
-                      null
-                    ]
+                    "enum": ["maintainer", "collaborator", "pr_author", "confirmed_miner", null]
                   },
                   "allowedRoles": {
                     "type": "array",
                     "items": {
                       "type": "string",
-                      "enum": [
-                        "maintainer",
-                        "collaborator",
-                        "pr_author",
-                        "confirmed_miner"
-                      ]
+                      "enum": ["maintainer", "collaborator", "pr_author", "confirmed_miner"]
                     }
                   }
                 },
-                "required": [
-                  "authorized",
-                  "reason",
-                  "actorKind",
-                  "matchedRole",
-                  "allowedRoles"
-                ]
+                "required": ["authorized", "reason", "actorKind", "matchedRole", "allowedRoles"]
               }
             },
-            "required": [
-              "commandName",
-              "commenterLogin",
-              "commenterAssociation",
-              "decision"
-            ]
+            "required": ["commandName", "commenterLogin", "commenterAssociation", "decision"]
           },
           "installation": {
             "type": "object",
@@ -9883,11 +8704,7 @@
               },
               "status": {
                 "type": "string",
-                "enum": [
-                  "healthy",
-                  "needs_attention",
-                  "broken"
-                ]
+                "enum": ["healthy", "needs_attention", "broken"]
               },
               "missingPermissions": {
                 "type": "array",
@@ -9922,13 +8739,7 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "permission",
-                    "requiredAccess",
-                    "currentAccess",
-                    "ok",
-                    "action"
-                  ]
+                  "required": ["permission", "requiredAccess", "currentAccess", "ok", "action"]
                 }
               }
             },
@@ -9954,11 +8765,7 @@
               },
               "minerStatus": {
                 "type": "string",
-                "enum": [
-                  "confirmed",
-                  "not_found",
-                  "unavailable"
-                ]
+                "enum": ["confirmed", "not_found", "unavailable"]
               },
               "title": {
                 "type": "string"
@@ -10018,13 +8825,7 @@
                 "type": "array",
                 "items": {
                   "type": "string",
-                  "enum": [
-                    "skip",
-                    "comment",
-                    "label",
-                    "check_run",
-                    "none"
-                  ]
+                  "enum": ["skip", "comment", "label", "check_run", "none"]
                 }
               },
               "summary": {
@@ -10061,29 +8862,17 @@
               },
               "detailLevel": {
                 "type": "string",
-                "enum": [
-                  "minimal",
-                  "standard",
-                  "deep"
-                ]
+                "enum": ["minimal", "standard", "deep"]
               }
             },
-            "required": [
-              "willCreate",
-              "title",
-              "detailLevel"
-            ]
+            "required": ["willCreate", "title", "detailLevel"]
           },
           "installPreview": {
             "type": "object",
             "properties": {
               "status": {
                 "type": "string",
-                "enum": [
-                  "ready",
-                  "needs_attention",
-                  "blocked"
-                ]
+                "enum": ["ready", "needs_attention", "blocked"]
               },
               "summary": {
                 "type": "string"
@@ -10111,11 +8900,7 @@
                 "properties": {
                   "status": {
                     "type": "string",
-                    "enum": [
-                      "ready",
-                      "needs_attention",
-                      "blocked"
-                    ]
+                    "enum": ["ready", "needs_attention", "blocked"]
                   },
                   "required": {
                     "type": "array",
@@ -10139,13 +8924,7 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "status",
-                  "required",
-                  "missing",
-                  "missingEvents",
-                  "summary"
-                ]
+                "required": ["status", "required", "missing", "missingEvents", "summary"]
               },
               "publicOutputs": {
                 "type": "array",
@@ -10205,11 +8984,7 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": [
-                        "ready",
-                        "needs_attention",
-                        "blocked"
-                      ]
+                      "enum": ["ready", "needs_attention", "blocked"]
                     },
                     "label": {
                       "type": "string"
@@ -10221,14 +8996,7 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "id",
-                    "category",
-                    "status",
-                    "label",
-                    "summary",
-                    "action"
-                  ]
+                  "required": ["id", "category", "status", "label", "summary", "action"]
                 }
               }
             },
@@ -10313,11 +9081,7 @@
                 "nullable": true
               }
             },
-            "required": [
-              "repoFullName",
-              "reason",
-              "since"
-            ]
+            "required": ["repoFullName", "reason", "since"]
           },
           "items": {
             "type": "array",
@@ -10342,23 +9106,11 @@
                   "type": "string"
                 }
               },
-              "required": [
-                "repoFullName",
-                "pullNumber",
-                "reason",
-                "timestamp",
-                "remediation"
-              ]
+              "required": ["repoFullName", "pullNumber", "reason", "timestamp", "remediation"]
             }
           }
         },
-        "required": [
-          "generatedAt",
-          "limit",
-          "hasMore",
-          "filters",
-          "items"
-        ]
+        "required": ["generatedAt", "limit", "hasMore", "filters", "items"]
       },
       "CommandPreviewResponse": {
         "type": "object",
@@ -10388,14 +9140,7 @@
                 "type": "string"
               }
             },
-            "required": [
-              "id",
-              "command",
-              "audience",
-              "boundary",
-              "description",
-              "endpoint"
-            ]
+            "required": ["id", "command", "audience", "boundary", "description", "endpoint"]
           },
           "request": {
             "type": "object",
@@ -10408,12 +9153,7 @@
             "properties": {
               "boundary": {
                 "type": "string",
-                "enum": [
-                  "public",
-                  "public-safe",
-                  "private-api",
-                  "private-mcp"
-                ]
+                "enum": ["public", "public-safe", "private-api", "private-mcp"]
               },
               "endpoint": {
                 "type": "string"
@@ -10451,13 +9191,7 @@
                       "type": "string"
                     }
                   },
-                  "required": [
-                    "permission",
-                    "requiredAccess",
-                    "currentAccess",
-                    "ok",
-                    "action"
-                  ]
+                  "required": ["permission", "requiredAccess", "currentAccess", "ok", "action"]
                 }
               },
               "warnings": {
@@ -10471,12 +9205,7 @@
                 "properties": {
                   "status": {
                     "type": "string",
-                    "enum": [
-                      "ready",
-                      "skipped",
-                      "missing_permission",
-                      "private_api"
-                    ]
+                    "enum": ["ready", "skipped", "missing_permission", "private_api"]
                   },
                   "willComment": {
                     "type": "boolean"
@@ -10498,13 +9227,7 @@
                     "type": "array",
                     "items": {
                       "type": "string",
-                      "enum": [
-                        "comment",
-                        "label",
-                        "check_run",
-                        "skip",
-                        "none"
-                      ]
+                      "enum": ["comment", "label", "check_run", "skip", "none"]
                     }
                   },
                   "summary": {
@@ -10545,11 +9268,7 @@
                   },
                   "minerStatus": {
                     "type": "string",
-                    "enum": [
-                      "confirmed",
-                      "not_found",
-                      "unavailable"
-                    ]
+                    "enum": ["confirmed", "not_found", "unavailable"]
                   },
                   "title": {
                     "type": "string"
@@ -10598,10 +9317,7 @@
                     }
                   }
                 },
-                "required": [
-                  "passed",
-                  "forbiddenTerms"
-                ]
+                "required": ["passed", "forbiddenTerms"]
               }
             },
             "required": [
@@ -10616,12 +9332,7 @@
             ]
           }
         },
-        "required": [
-          "generatedAt",
-          "command",
-          "request",
-          "preview"
-        ]
+        "required": ["generatedAt", "command", "request", "preview"]
       },
       "AgentRun": {
         "type": "object",
@@ -10637,36 +9348,19 @@
           },
           "surface": {
             "type": "string",
-            "enum": [
-              "mcp",
-              "github_comment",
-              "api"
-            ]
+            "enum": ["mcp", "github_comment", "api"]
           },
           "mode": {
             "type": "string",
-            "enum": [
-              "copilot"
-            ]
+            "enum": ["copilot"]
           },
           "status": {
             "type": "string",
-            "enum": [
-              "queued",
-              "running",
-              "completed",
-              "failed",
-              "needs_snapshot_refresh"
-            ]
+            "enum": ["queued", "running", "completed", "failed", "needs_snapshot_refresh"]
           },
           "dataQualityStatus": {
             "type": "string",
-            "enum": [
-              "complete",
-              "degraded",
-              "blocked",
-              "unknown"
-            ]
+            "enum": ["complete", "degraded", "blocked", "unknown"]
           },
           "errorSummary": {
             "type": "string",
@@ -10734,13 +9428,7 @@
           },
           "status": {
             "type": "string",
-            "enum": [
-              "recommended",
-              "ready",
-              "blocked",
-              "watch",
-              "needs_input"
-            ]
+            "enum": ["recommended", "ready", "blocked", "watch", "needs_input"]
           },
           "recommendation": {
             "type": "string"
@@ -10784,11 +9472,7 @@
           },
           "safetyClass": {
             "type": "string",
-            "enum": [
-              "private",
-              "public_safe",
-              "approval_required"
-            ]
+            "enum": ["private", "public_safe", "approval_required"]
           },
           "payload": {
             "type": "object",
@@ -10861,10 +9545,7 @@
                   }
                 }
               },
-              "required": [
-                "category",
-                "items"
-              ]
+              "required": ["category", "items"]
             }
           },
           "rerunWhen": {
@@ -10883,11 +9564,7 @@
                 "type": "string"
               }
             },
-            "required": [
-              "summary",
-              "whyNow",
-              "rerunWhen"
-            ]
+            "required": ["summary", "whyNow", "rerunWhen"]
           }
         },
         "required": [
@@ -10942,13 +9619,7 @@
             "nullable": true
           }
         },
-        "required": [
-          "id",
-          "runId",
-          "repoSignalSnapshotIds",
-          "freshnessWarnings",
-          "payload"
-        ]
+        "required": ["id", "runId", "repoSignalSnapshotIds", "freshnessWarnings", "payload"]
       },
       "AgentRunBundle": {
         "type": "object",
@@ -10972,12 +9643,7 @@
             "type": "string"
           }
         },
-        "required": [
-          "run",
-          "actions",
-          "contextSnapshots",
-          "summary"
-        ]
+        "required": ["run", "actions", "contextSnapshots", "summary"]
       },
       "RepoSyncState": {
         "type": "object",
@@ -11001,11 +9667,7 @@
           },
           "sourceKind": {
             "type": "string",
-            "enum": [
-              "github",
-              "installation",
-              "test"
-            ]
+            "enum": ["github", "installation", "test"]
           },
           "primaryLanguage": {
             "type": "string",
@@ -11116,19 +9778,11 @@
           },
           "sourceKind": {
             "type": "string",
-            "enum": [
-              "github",
-              "installation",
-              "test"
-            ]
+            "enum": ["github", "installation", "test"]
           },
           "mode": {
             "type": "string",
-            "enum": [
-              "light",
-              "full",
-              "resume"
-            ]
+            "enum": ["light", "full", "resume"]
           },
           "lastCursor": {
             "type": "string",
@@ -11213,10 +9867,7 @@
           },
           "resource": {
             "type": "string",
-            "enum": [
-              "rest",
-              "graphql"
-            ]
+            "enum": ["rest", "graphql"]
           },
           "path": {
             "type": "string"
@@ -11241,23 +9892,14 @@
             "nullable": true
           }
         },
-        "required": [
-          "resource",
-          "path",
-          "statusCode"
-        ]
+        "required": ["resource", "path", "statusCode"]
       },
       "SignalFidelity": {
         "type": "object",
         "properties": {
           "status": {
             "type": "string",
-            "enum": [
-              "complete",
-              "degraded",
-              "blocked",
-              "unknown"
-            ]
+            "enum": ["complete", "degraded", "blocked", "unknown"]
           },
           "repoCount": {
             "type": "number"
@@ -11326,11 +9968,7 @@
             "properties": {
               "status": {
                 "type": "string",
-                "enum": [
-                  "fresh",
-                  "degraded",
-                  "blocked"
-                ]
+                "enum": ["fresh", "degraded", "blocked"]
               },
               "generatedAt": {
                 "type": "string"
@@ -11425,11 +10063,7 @@
           },
           "historyCoverage": {
             "type": "string",
-            "enum": [
-              "sampled",
-              "counts_only",
-              "full"
-            ]
+            "enum": ["sampled", "counts_only", "full"]
           },
           "refreshingRepos": {
             "type": "array",
@@ -11505,12 +10139,7 @@
         "properties": {
           "status": {
             "type": "string",
-            "enum": [
-              "complete",
-              "degraded",
-              "blocked",
-              "unknown"
-            ]
+            "enum": ["complete", "degraded", "blocked", "unknown"]
           },
           "repoCount": {
             "type": "number"
@@ -11544,11 +10173,7 @@
           },
           "historyCoverage": {
             "type": "string",
-            "enum": [
-              "sampled",
-              "counts_only",
-              "full"
-            ]
+            "enum": ["sampled", "counts_only", "full"]
           }
         },
         "required": [
@@ -11571,12 +10196,7 @@
           },
           "status": {
             "type": "string",
-            "enum": [
-              "current",
-              "drift_detected",
-              "stale",
-              "unavailable"
-            ]
+            "enum": ["current", "drift_detected", "stale", "unavailable"]
           },
           "latestCommitSha": {
             "type": "string",
@@ -11604,13 +10224,7 @@
           "highestSeverity": {
             "type": "string",
             "nullable": true,
-            "enum": [
-              "low",
-              "medium",
-              "high",
-              "blocking",
-              null
-            ]
+            "enum": ["low", "medium", "high", "blocking", null]
           },
           "affectedAreas": {
             "type": "array",
@@ -11716,21 +10330,11 @@
           },
           "severity": {
             "type": "string",
-            "enum": [
-              "low",
-              "medium",
-              "high",
-              "blocking"
-            ]
+            "enum": ["low", "medium", "high", "blocking"]
           },
           "status": {
             "type": "string",
-            "enum": [
-              "open",
-              "acknowledged",
-              "resolved",
-              "ignored"
-            ]
+            "enum": ["open", "acknowledged", "resolved", "ignored"]
           },
           "summary": {
             "type": "string"
@@ -11765,10 +10369,7 @@
                 "nullable": true
               }
             },
-            "required": [
-              "repo",
-              "ref"
-            ]
+            "required": ["repo", "ref"]
           },
           "recommendedFollowUp": {
             "type": "array",
@@ -11842,11 +10443,7 @@
           },
           "sourceKind": {
             "type": "string",
-            "enum": [
-              "github",
-              "installation",
-              "test"
-            ]
+            "enum": ["github", "installation", "test"]
           },
           "fetchedAt": {
             "type": "string"
@@ -11883,10 +10480,7 @@
         "properties": {
           "status": {
             "type": "string",
-            "enum": [
-              "ready",
-              "needs_attention"
-            ]
+            "enum": ["ready", "needs_attention"]
           },
           "generatedAt": {
             "type": "string"
@@ -11905,11 +10499,7 @@
             "properties": {
               "status": {
                 "type": "string",
-                "enum": [
-                  "fresh",
-                  "degraded",
-                  "blocked"
-                ]
+                "enum": ["fresh", "degraded", "blocked"]
               },
               "generatedAt": {
                 "type": "string"
@@ -12004,11 +10594,7 @@
           },
           "historyCoverage": {
             "type": "string",
-            "enum": [
-              "sampled",
-              "counts_only",
-              "full"
-            ]
+            "enum": ["sampled", "counts_only", "full"]
           },
           "partialRepos": {
             "type": "array",
@@ -12073,22 +10659,13 @@
                     "type": "string"
                   }
                 },
-                "required": [
-                  "kind",
-                  "url"
-                ]
+                "required": ["kind", "url"]
               },
               "warningCount": {
                 "type": "number"
               }
             },
-            "required": [
-              "snapshotId",
-              "repoCount",
-              "totalEmissionShare",
-              "source",
-              "warningCount"
-            ]
+            "required": ["snapshotId", "repoCount", "totalEmissionShare", "source", "warningCount"]
           },
           "scoringModel": {
             "type": "object",
@@ -12116,13 +10693,7 @@
                 "type": "number"
               }
             },
-            "required": [
-              "snapshotId",
-              "activeModel",
-              "sourceKind",
-              "fetchedAt",
-              "warningCount"
-            ]
+            "required": ["snapshotId", "activeModel", "sourceKind", "fetchedAt", "warningCount"]
           },
           "githubBackfill": {
             "type": "object",
@@ -12153,9 +10724,7 @@
                       "nullable": true
                     }
                   },
-                  "required": [
-                    "repoFullName"
-                  ]
+                  "required": ["repoFullName"]
                 }
               },
               "incompleteSyncs": {
@@ -12168,21 +10737,14 @@
                     },
                     "status": {
                       "type": "string",
-                      "enum": [
-                        "never_synced",
-                        "running",
-                        "skipped"
-                      ]
+                      "enum": ["never_synced", "running", "skipped"]
                     },
                     "lastCompletedAt": {
                       "type": "string",
                       "nullable": true
                     }
                   },
-                  "required": [
-                    "repoFullName",
-                    "status"
-                  ]
+                  "required": ["repoFullName", "status"]
                 }
               },
               "segmentCount": {
@@ -12219,10 +10781,7 @@
                       "nullable": true
                     }
                   },
-                  "required": [
-                    "repoFullName",
-                    "segment"
-                  ]
+                  "required": ["repoFullName", "segment"]
                 }
               },
               "rateLimitedSegments": {
@@ -12241,10 +10800,7 @@
                       "nullable": true
                     }
                   },
-                  "required": [
-                    "repoFullName",
-                    "segment"
-                  ]
+                  "required": ["repoFullName", "segment"]
                 }
               },
               "latestRateLimits": {
@@ -12281,11 +10837,7 @@
                 "type": "number"
               }
             },
-            "required": [
-              "count",
-              "healthCount",
-              "unhealthyCount"
-            ]
+            "required": ["count", "healthCount", "unhealthyCount"]
           },
           "secrets": {
             "type": "object",
@@ -12458,23 +11010,14 @@
                   }
                 }
               },
-              "required": [
-                "repoFullName",
-                "changes"
-              ]
+              "required": ["repoFullName", "changes"]
             }
           },
           "summary": {
             "type": "string"
           }
         },
-        "required": [
-          "generatedAt",
-          "addedRepos",
-          "removedRepos",
-          "changedRepos",
-          "summary"
-        ]
+        "required": ["generatedAt", "addedRepos", "removedRepos", "changedRepos", "summary"]
       },
       "ScoringModelSnapshot": {
         "type": "object",
@@ -12484,12 +11027,7 @@
           },
           "sourceKind": {
             "type": "string",
-            "enum": [
-              "raw-github",
-              "api",
-              "fallback",
-              "test"
-            ]
+            "enum": ["raw-github", "api", "fallback", "test"]
           },
           "sourceUrl": {
             "type": "string"
@@ -12561,12 +11099,7 @@
           },
           "targetType": {
             "type": "string",
-            "enum": [
-              "planned_pr",
-              "pull_request",
-              "local_diff",
-              "variant"
-            ]
+            "enum": ["planned_pr", "pull_request", "local_diff", "variant"]
           },
           "targetKey": {
             "type": "string"
@@ -12639,21 +11172,11 @@
                   "properties": {
                     "status": {
                       "type": "string",
-                      "enum": [
-                        "raw",
-                        "plausible",
-                        "validated",
-                        "invalid",
-                        "unavailable"
-                      ]
+                      "enum": ["raw", "plausible", "validated", "invalid", "unavailable"]
                     },
                     "source": {
                       "type": "string",
-                      "enum": [
-                        "official_mirror",
-                        "github_cache",
-                        "missing"
-                      ]
+                      "enum": ["official_mirror", "github_cache", "missing"]
                     },
                     "solvedByPullRequests": {
                       "type": "array",
@@ -12671,13 +11194,7 @@
                       }
                     }
                   },
-                  "required": [
-                    "status",
-                    "source",
-                    "solvedByPullRequests",
-                    "reason",
-                    "warnings"
-                  ]
+                  "required": ["status", "source", "solvedByPullRequests", "reason", "warnings"]
                 },
                 "bounty": {
                   "type": "object",
@@ -12702,19 +11219,11 @@
                     },
                     "fundingStatus": {
                       "type": "string",
-                      "enum": [
-                        "funded",
-                        "target_only",
-                        "unknown"
-                      ]
+                      "enum": ["funded", "target_only", "unknown"]
                     },
                     "consensusRisk": {
                       "type": "string",
-                      "enum": [
-                        "low",
-                        "medium",
-                        "high"
-                      ]
+                      "enum": ["low", "medium", "high"]
                     },
                     "source": {
                       "type": "object",
@@ -12741,17 +11250,10 @@
                         },
                         "freshness": {
                           "type": "string",
-                          "enum": [
-                            "fresh",
-                            "stale",
-                            "unknown"
-                          ]
+                          "enum": ["fresh", "stale", "unknown"]
                         }
                       },
-                      "required": [
-                        "ageDays",
-                        "freshness"
-                      ]
+                      "required": ["ageDays", "freshness"]
                     },
                     "linkedPrs": {
                       "type": "array",
@@ -12763,22 +11265,13 @@
                           },
                           "state": {
                             "type": "string",
-                            "enum": [
-                              "open",
-                              "closed",
-                              "merged",
-                              "unknown"
-                            ]
+                            "enum": ["open", "closed", "merged", "unknown"]
                           },
                           "isActive": {
                             "type": "boolean"
                           }
                         },
-                        "required": [
-                          "number",
-                          "state",
-                          "isActive"
-                        ]
+                        "required": ["number", "state", "isActive"]
                       }
                     }
                   },
@@ -12794,12 +11287,7 @@
                 },
                 "status": {
                   "type": "string",
-                  "enum": [
-                    "ready",
-                    "needs_proof",
-                    "hold",
-                    "do_not_use"
-                  ]
+                  "enum": ["ready", "needs_proof", "hold", "do_not_use"]
                 },
                 "score": {
                   "type": "number"
@@ -12817,43 +11305,25 @@
                   }
                 }
               },
-              "required": [
-                "number",
-                "title",
-                "status",
-                "score",
-                "reasons",
-                "warnings"
-              ]
+              "required": ["number", "title", "status", "score", "reasons", "warnings"]
             }
           },
           "summary": {
             "type": "string"
           }
         },
-        "required": [
-          "repoFullName",
-          "generatedAt",
-          "lane",
-          "issues",
-          "summary"
-        ]
+        "required": ["repoFullName", "generatedAt", "lane", "issues", "summary"]
       },
       "IssueQualityResponse": {
         "type": "object",
         "properties": {
           "status": {
             "type": "string",
-            "enum": [
-              "ready"
-            ]
+            "enum": ["ready"]
           },
           "source": {
             "type": "string",
-            "enum": [
-              "snapshot",
-              "computed"
-            ]
+            "enum": ["snapshot", "computed"]
           },
           "repoFullName": {
             "type": "string"
@@ -12865,13 +11335,7 @@
             "$ref": "#/components/schemas/IssueQualityReport"
           }
         },
-        "required": [
-          "status",
-          "source",
-          "repoFullName",
-          "generatedAt",
-          "report"
-        ]
+        "required": ["status", "source", "repoFullName", "generatedAt", "report"]
       },
       "ContributorScoringProfile": {
         "type": "object",
@@ -12898,13 +11362,7 @@
             }
           }
         },
-        "required": [
-          "login",
-          "generatedAt",
-          "scoringModelSnapshotId",
-          "evidence",
-          "privateSignals"
-        ]
+        "required": ["login", "generatedAt", "scoringModelSnapshotId", "evidence", "privateSignals"]
       },
       "ContributorStrategy": {
         "type": "object",
@@ -13120,12 +11578,7 @@
           },
           "level": {
             "type": "string",
-            "enum": [
-              "low",
-              "medium",
-              "high",
-              "critical"
-            ]
+            "enum": ["low", "medium", "high", "critical"]
           },
           "noiseSources": {
             "type": "array",
@@ -13482,11 +11935,7 @@
                       }
                     }
                   },
-                  "required": [
-                    "generatedAt",
-                    "upstreamDrift",
-                    "reports"
-                  ]
+                  "required": ["generatedAt", "upstreamDrift", "reports"]
                 }
               }
             }
@@ -13603,10 +12052,7 @@
                       }
                     }
                   },
-                  "required": [
-                    "installations",
-                    "health"
-                  ]
+                  "required": ["installations", "health"]
                 }
               }
             }
@@ -13721,15 +12167,11 @@
                       "properties": {
                         "mode": {
                           "type": "string",
-                          "enum": [
-                            "opt_in"
-                          ]
+                          "enum": ["opt_in"]
                         },
                         "defaultState": {
                           "type": "string",
-                          "enum": [
-                            "disabled"
-                          ]
+                          "enum": ["disabled"]
                         },
                         "channels": {
                           "type": "array",
@@ -13741,10 +12183,7 @@
                               },
                               "transport": {
                                 "type": "string",
-                                "enum": [
-                                  "in_app",
-                                  "web_push"
-                                ]
+                                "enum": ["in_app", "web_push"]
                               },
                               "defaultEnabled": {
                                 "type": "boolean"
@@ -13756,12 +12195,7 @@
                                 "type": "string"
                               }
                             },
-                            "required": [
-                              "id",
-                              "transport",
-                              "defaultEnabled",
-                              "purpose"
-                            ]
+                            "required": ["id", "transport", "defaultEnabled", "purpose"]
                           }
                         },
                         "privacyGuards": {
@@ -13772,9 +12206,7 @@
                         },
                         "fallbackWhenUnavailable": {
                           "type": "string",
-                          "enum": [
-                            "in_app_digest_only"
-                          ]
+                          "enum": ["in_app_digest_only"]
                         }
                       },
                       "required": [
@@ -13798,11 +12230,7 @@
                           "type": "string"
                         }
                       },
-                      "required": [
-                        "nativeDependency",
-                        "manifestPath",
-                        "serviceWorkerPath"
-                      ]
+                      "required": ["nativeDependency", "manifestPath", "serviceWorkerPath"]
                     },
                     "mobileReadyRoutes": {
                       "type": "array",
@@ -14164,10 +12592,7 @@
                       }
                     }
                   },
-                  "required": [
-                    "repoFullName",
-                    "events"
-                  ]
+                  "required": ["repoFullName", "events"]
                 }
               }
             }
@@ -14682,9 +13107,7 @@
                       }
                     }
                   },
-                  "required": [
-                    "runs"
-                  ]
+                  "required": ["runs"]
                 }
               }
             }
@@ -15455,10 +13878,7 @@
           {
             "schema": {
               "type": "string",
-              "enum": [
-                "public",
-                "operator"
-              ],
+              "enum": ["public", "operator"],
               "example": "public"
             },
             "required": false,
@@ -15479,10 +13899,7 @@
           {
             "schema": {
               "type": "string",
-              "enum": [
-                "json",
-                "markdown"
-              ],
+              "enum": ["json", "markdown"],
               "example": "markdown"
             },
             "required": false,
@@ -16114,6 +14531,124 @@
           },
           "401": {
             "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "GittensoryBearer": []
+          },
+          {
+            "GittensorySessionCookie": []
+          }
+        ]
+      },
+      "delete": {
+        "responses": {
+          "200": {
+            "description": "Dead-letter jobs purged",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient app role (operator only)"
+          },
+          "501": {
+            "description": "This deployment's queue backend does not expose dead-letter admin"
+          }
+        },
+        "security": [
+          {
+            "GittensoryBearer": []
+          },
+          {
+            "GittensorySessionCookie": []
+          }
+        ]
+      }
+    },
+    "/v1/app/selfhost/queue/dead/{id}/replay": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Job replayed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid job id"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient app role (operator only)"
+          },
+          "404": {
+            "description": "Dead-letter job not found"
+          },
+          "501": {
+            "description": "This deployment's queue backend does not expose dead-letter admin"
+          }
+        },
+        "security": [
+          {
+            "GittensoryBearer": []
+          },
+          {
+            "GittensorySessionCookie": []
+          }
+        ]
+      }
+    },
+    "/v1/app/selfhost/queue/dead/{id}": {
+      "delete": {
+        "responses": {
+          "200": {
+            "description": "Job deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid job id"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient app role (operator only)"
+          },
+          "404": {
+            "description": "Dead-letter job not found"
+          },
+          "501": {
+            "description": "This deployment's queue backend does not expose dead-letter admin"
           }
         },
         "security": [

--- a/apps/gittensory-ui/src/components/site/dead-letter-queue-panel-model.ts
+++ b/apps/gittensory-ui/src/components/site/dead-letter-queue-panel-model.ts
@@ -28,6 +28,14 @@ export function buildDeadLetterQueuePath(
   return `/v1/app/selfhost/queue/dead?${params.toString()}`;
 }
 
+export const DEAD_LETTER_QUEUE_PURGE_PATH = "/v1/app/selfhost/queue/dead";
+
+/** Builds the admin-action path for a single dead-letter job (replay, or the bare id path for delete). */
+export function buildDeadLetterJobActionPath(id: number, action: "replay" | "delete"): string {
+  const base = `${DEAD_LETTER_QUEUE_PURGE_PATH}/${id}`;
+  return action === "replay" ? `${base}/replay` : base;
+}
+
 function isDeadLetterQueueItem(value: unknown): value is DeadLetterQueueItem {
   if (!value || typeof value !== "object") return false;
   const item = value as Partial<DeadLetterQueueItem>;

--- a/apps/gittensory-ui/src/components/site/dead-letter-queue-panel.test.tsx
+++ b/apps/gittensory-ui/src/components/site/dead-letter-queue-panel.test.tsx
@@ -255,7 +255,44 @@ describe("DeadLetterQueuePanel row actions and purge", () => {
     expect(apiFetch).toHaveBeenCalledTimes(2);
   });
 
-  it("delete success: DELETEs the right path, toasts success, and refetches", async () => {
+  // Delete is confirm-gated (like Purge all): clicking the row trigger opens an AlertDialog, and only the
+  // dialog's own destructive confirm action actually fires the DELETE call.
+  function confirmRowDelete() {
+    fireEvent.click(getRowButton("Delete"));
+    const deleteButtons = screen.getAllByRole("button", { name: "Delete" });
+    fireEvent.click(deleteButtons[deleteButtons.length - 1]);
+  }
+
+  it("delete: clicking the row trigger opens a confirmation dialog naming the job id", async () => {
+    apiFetch.mockResolvedValueOnce({ ok: true, data: SAMPLE_PAGE });
+    render(<DeadLetterQueuePanel />);
+    await screen.findByText("github-webhook");
+
+    fireEvent.click(getRowButton("Delete"));
+    expect(await screen.findByText("Delete job #2?")).toBeTruthy();
+    expect(apiFetch).not.toHaveBeenCalledWith(
+      "https://api.test/v1/app/selfhost/queue/dead/2",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+
+  it("delete: clicking Cancel closes the dialog without calling the delete endpoint", async () => {
+    apiFetch.mockResolvedValueOnce({ ok: true, data: SAMPLE_PAGE });
+    render(<DeadLetterQueuePanel />);
+    await screen.findByText("github-webhook");
+
+    fireEvent.click(getRowButton("Delete"));
+    await screen.findByText("Delete job #2?");
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+
+    await waitFor(() => expect(screen.queryByText("Delete job #2?")).toBeNull());
+    expect(apiFetch).not.toHaveBeenCalledWith(
+      "https://api.test/v1/app/selfhost/queue/dead/2",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+
+  it("delete success: confirming DELETEs the right path, toasts success, and refetches", async () => {
     apiFetch.mockResolvedValueOnce({ ok: true, data: SAMPLE_PAGE }); // initial GET
     render(<DeadLetterQueuePanel />);
     await screen.findByText("github-webhook");
@@ -263,7 +300,7 @@ describe("DeadLetterQueuePanel row actions and purge", () => {
     apiFetch.mockResolvedValueOnce({ ok: true, data: { ok: true, id: 2 } }); // delete call
     apiFetch.mockResolvedValueOnce({ ok: true, data: SAMPLE_PAGE }); // refetch after reload
 
-    fireEvent.click(getRowButton("Delete"));
+    confirmRowDelete();
 
     await waitFor(() =>
       expect(apiFetch).toHaveBeenCalledWith(
@@ -281,14 +318,14 @@ describe("DeadLetterQueuePanel row actions and purge", () => {
     );
   });
 
-  it("delete failure: toasts an error and does NOT refetch", async () => {
+  it("delete failure: confirming toasts an error and does NOT refetch", async () => {
     apiFetch.mockResolvedValueOnce({ ok: true, data: SAMPLE_PAGE }); // initial GET
     render(<DeadLetterQueuePanel />);
     await screen.findByText("github-webhook");
 
     apiFetch.mockResolvedValueOnce({ ok: false, message: "not found" }); // delete call fails
 
-    fireEvent.click(getRowButton("Delete"));
+    confirmRowDelete();
 
     await waitFor(() =>
       expect(apiFetch).toHaveBeenCalledWith(
@@ -391,6 +428,26 @@ describe("DeadLetterQueuePanel row actions and purge", () => {
     const [, options] = toastSuccess.mock.calls[0] as [string, { description?: string }];
     expect(options.description).toContain("2");
     expect(await screen.findByText("No dead-letter jobs")).toBeTruthy();
+  });
+
+  it("Purge all: confirming a single-job purge uses the singular 'job' wording", async () => {
+    apiFetch.mockResolvedValueOnce({ ok: true, data: SAMPLE_PAGE }); // initial GET
+    render(<DeadLetterQueuePanel />);
+    await screen.findByText("github-webhook");
+
+    apiFetch.mockResolvedValueOnce({ ok: true, data: { ok: true, purged: 1 } }); // purge call
+    apiFetch.mockResolvedValueOnce({ ok: true, data: { ...SAMPLE_PAGE, total: 0, items: [] } }); // refetch
+
+    fireEvent.click(screen.getByRole("button", { name: "Purge all" }));
+    await screen.findByText(
+      "This permanently deletes every dead-letter job. This cannot be undone.",
+    );
+    const purgeButtons = screen.getAllByRole("button", { name: "Purge all" });
+    fireEvent.click(purgeButtons[purgeButtons.length - 1]);
+
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalled());
+    const [, options] = toastSuccess.mock.calls[0] as [string, { description?: string }];
+    expect(options.description).toBe("Purged 1 job.");
   });
 
   it("Purge all: failure toasts an error", async () => {

--- a/apps/gittensory-ui/src/components/site/dead-letter-queue-panel.test.tsx
+++ b/apps/gittensory-ui/src/components/site/dead-letter-queue-panel.test.tsx
@@ -5,9 +5,22 @@ const { apiFetch } = vi.hoisted(() => ({ apiFetch: vi.fn() }));
 vi.mock("@/lib/api/request", () => ({ apiFetch: (...args: unknown[]) => apiFetch(...args) }));
 vi.mock("@/lib/api/origin", () => ({ getApiOrigin: () => "https://api.test" }));
 
+const { toastSuccess, toastError } = vi.hoisted(() => ({
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+}));
+vi.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccess(...args),
+    error: (...args: unknown[]) => toastError(...args),
+  },
+}));
+
 import {
+  buildDeadLetterJobActionPath,
   buildDeadLetterQueuePath,
   DEAD_LETTER_ERROR_TRUNCATE_LENGTH,
+  DEAD_LETTER_QUEUE_PURGE_PATH,
   formatDeadLetterTimestamp,
   normalizeDeadLetterQueuePage,
   truncateErrorMessage,
@@ -74,6 +87,17 @@ describe("dead-letter queue panel model", () => {
     // Exact boundary: a message of exactly maxLength characters must NOT be truncated.
     const exact = "y".repeat(DEAD_LETTER_ERROR_TRUNCATE_LENGTH);
     expect(truncateErrorMessage(exact)).toBe(exact);
+  });
+
+  it("builds the per-job action path for replay vs. delete", () => {
+    expect(buildDeadLetterJobActionPath(123, "replay")).toBe(
+      "/v1/app/selfhost/queue/dead/123/replay",
+    );
+    expect(buildDeadLetterJobActionPath(123, "delete")).toBe("/v1/app/selfhost/queue/dead/123");
+  });
+
+  it("exposes the bulk purge path", () => {
+    expect(DEAD_LETTER_QUEUE_PURGE_PATH).toBe("/v1/app/selfhost/queue/dead");
   });
 });
 
@@ -168,5 +192,237 @@ describe("DeadLetterQueuePanel", () => {
     render(<DeadLetterQueuePanel />);
     await screen.findByText("github-webhook");
     expect(screen.getByRole("link", { name: /next/i }).getAttribute("aria-disabled")).toBe("true");
+  });
+});
+
+describe("DeadLetterQueuePanel row actions and purge", () => {
+  beforeEach(() => {
+    apiFetch.mockReset();
+    toastSuccess.mockReset();
+    toastError.mockReset();
+  });
+
+  // The row for item id 2 ("github-webhook") has both Replay and Delete buttons.
+  function getRowButton(name: "Replay" | "Delete") {
+    return screen.getAllByRole("button", { name })[0];
+  }
+
+  it("replay success: POSTs the right path, toasts success, and refetches", async () => {
+    apiFetch.mockResolvedValueOnce({ ok: true, data: SAMPLE_PAGE }); // initial GET
+    render(<DeadLetterQueuePanel />);
+    await screen.findByText("github-webhook");
+
+    apiFetch.mockResolvedValueOnce({ ok: true, data: { ok: true, id: 2 } }); // replay call
+    apiFetch.mockResolvedValueOnce({ ok: true, data: SAMPLE_PAGE }); // refetch after reload
+
+    fireEvent.click(getRowButton("Replay"));
+
+    await waitFor(() =>
+      expect(apiFetch).toHaveBeenCalledWith(
+        "https://api.test/v1/app/selfhost/queue/dead/2/replay",
+        expect.objectContaining({ method: "POST" }),
+      ),
+    );
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalled());
+    expect(toastError).not.toHaveBeenCalled();
+    // Refetch happened: base GET path called again.
+    await waitFor(() =>
+      expect(apiFetch).toHaveBeenCalledWith(
+        "https://api.test/v1/app/selfhost/queue/dead?limit=25&offset=0",
+        expect.any(Object),
+      ),
+    );
+  });
+
+  it("replay failure: toasts an error and does NOT refetch", async () => {
+    apiFetch.mockResolvedValueOnce({ ok: true, data: SAMPLE_PAGE }); // initial GET
+    render(<DeadLetterQueuePanel />);
+    await screen.findByText("github-webhook");
+
+    apiFetch.mockResolvedValueOnce({ ok: false, message: "not found" }); // replay call fails
+
+    fireEvent.click(getRowButton("Replay"));
+
+    await waitFor(() =>
+      expect(apiFetch).toHaveBeenCalledWith(
+        "https://api.test/v1/app/selfhost/queue/dead/2/replay",
+        expect.objectContaining({ method: "POST" }),
+      ),
+    );
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
+    expect(toastSuccess).not.toHaveBeenCalled();
+    // No refetch: only the initial GET + the failed replay call were made.
+    expect(apiFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("delete success: DELETEs the right path, toasts success, and refetches", async () => {
+    apiFetch.mockResolvedValueOnce({ ok: true, data: SAMPLE_PAGE }); // initial GET
+    render(<DeadLetterQueuePanel />);
+    await screen.findByText("github-webhook");
+
+    apiFetch.mockResolvedValueOnce({ ok: true, data: { ok: true, id: 2 } }); // delete call
+    apiFetch.mockResolvedValueOnce({ ok: true, data: SAMPLE_PAGE }); // refetch after reload
+
+    fireEvent.click(getRowButton("Delete"));
+
+    await waitFor(() =>
+      expect(apiFetch).toHaveBeenCalledWith(
+        "https://api.test/v1/app/selfhost/queue/dead/2",
+        expect.objectContaining({ method: "DELETE" }),
+      ),
+    );
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalled());
+    expect(toastError).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(apiFetch).toHaveBeenCalledWith(
+        "https://api.test/v1/app/selfhost/queue/dead?limit=25&offset=0",
+        expect.any(Object),
+      ),
+    );
+  });
+
+  it("delete failure: toasts an error and does NOT refetch", async () => {
+    apiFetch.mockResolvedValueOnce({ ok: true, data: SAMPLE_PAGE }); // initial GET
+    render(<DeadLetterQueuePanel />);
+    await screen.findByText("github-webhook");
+
+    apiFetch.mockResolvedValueOnce({ ok: false, message: "not found" }); // delete call fails
+
+    fireEvent.click(getRowButton("Delete"));
+
+    await waitFor(() =>
+      expect(apiFetch).toHaveBeenCalledWith(
+        "https://api.test/v1/app/selfhost/queue/dead/2",
+        expect.objectContaining({ method: "DELETE" }),
+      ),
+    );
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(apiFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it("disables only the acted-on row's buttons while a request is in flight", async () => {
+    apiFetch.mockResolvedValueOnce({ ok: true, data: SAMPLE_PAGE }); // initial GET
+    render(<DeadLetterQueuePanel />);
+    await screen.findByText("github-webhook");
+
+    let resolveReplay: (value: unknown) => void = () => {};
+    apiFetch.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveReplay = resolve;
+      }),
+    );
+
+    const replayButtons = screen.getAllByRole("button", { name: "Replay" }) as HTMLButtonElement[];
+    const deleteButtons = screen.getAllByRole("button", { name: "Delete" }) as HTMLButtonElement[];
+    fireEvent.click(replayButtons[0]);
+
+    await waitFor(() => expect(replayButtons[0].disabled).toBe(true));
+    expect(deleteButtons[0].disabled).toBe(true);
+    // The other row (job id 1) stays enabled.
+    expect(replayButtons[1].disabled).toBe(false);
+    expect(deleteButtons[1].disabled).toBe(false);
+
+    resolveReplay({ ok: true, data: { ok: true, id: 2 } });
+    apiFetch.mockResolvedValueOnce({ ok: true, data: SAMPLE_PAGE });
+    await waitFor(() => expect(replayButtons[0].disabled).toBe(false));
+  });
+
+  it("Purge all opens a confirmation dialog with the expected warning text", async () => {
+    apiFetch.mockResolvedValueOnce({ ok: true, data: SAMPLE_PAGE });
+    render(<DeadLetterQueuePanel />);
+    await screen.findByText("github-webhook");
+
+    fireEvent.click(screen.getByRole("button", { name: "Purge all" }));
+    expect(
+      await screen.findByText(
+        "This permanently deletes every dead-letter job. This cannot be undone.",
+      ),
+    ).toBeTruthy();
+  });
+
+  it("Purge all: clicking Cancel closes the dialog without calling the purge endpoint", async () => {
+    apiFetch.mockResolvedValueOnce({ ok: true, data: SAMPLE_PAGE });
+    render(<DeadLetterQueuePanel />);
+    await screen.findByText("github-webhook");
+
+    fireEvent.click(screen.getByRole("button", { name: "Purge all" }));
+    await screen.findByText(
+      "This permanently deletes every dead-letter job. This cannot be undone.",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    await waitFor(() =>
+      expect(
+        screen.queryByText(
+          "This permanently deletes every dead-letter job. This cannot be undone.",
+        ),
+      ).toBeNull(),
+    );
+    expect(apiFetch).not.toHaveBeenCalledWith(
+      "https://api.test/v1/app/selfhost/queue/dead",
+      expect.objectContaining({ method: "DELETE" }),
+    );
+  });
+
+  it("Purge all: confirming DELETEs the purge path, shows the purged count, and refetches", async () => {
+    apiFetch.mockResolvedValueOnce({ ok: true, data: SAMPLE_PAGE }); // initial GET
+    render(<DeadLetterQueuePanel />);
+    await screen.findByText("github-webhook");
+
+    apiFetch.mockResolvedValueOnce({ ok: true, data: { ok: true, purged: 2 } }); // purge call
+    apiFetch.mockResolvedValueOnce({ ok: true, data: { ...SAMPLE_PAGE, total: 0, items: [] } }); // refetch
+
+    fireEvent.click(screen.getByRole("button", { name: "Purge all" }));
+    await screen.findByText(
+      "This permanently deletes every dead-letter job. This cannot be undone.",
+    );
+    // Two elements read "Purge all": the trigger and the destructive confirm action.
+    const purgeButtons = screen.getAllByRole("button", { name: "Purge all" });
+    fireEvent.click(purgeButtons[purgeButtons.length - 1]);
+
+    await waitFor(() =>
+      expect(apiFetch).toHaveBeenCalledWith(
+        "https://api.test/v1/app/selfhost/queue/dead",
+        expect.objectContaining({ method: "DELETE" }),
+      ),
+    );
+    await waitFor(() => expect(toastSuccess).toHaveBeenCalled());
+    const [, options] = toastSuccess.mock.calls[0] as [string, { description?: string }];
+    expect(options.description).toContain("2");
+    expect(await screen.findByText("No dead-letter jobs")).toBeTruthy();
+  });
+
+  it("Purge all: failure toasts an error", async () => {
+    apiFetch.mockResolvedValueOnce({ ok: true, data: SAMPLE_PAGE }); // initial GET
+    render(<DeadLetterQueuePanel />);
+    await screen.findByText("github-webhook");
+
+    apiFetch.mockResolvedValueOnce({ ok: false, message: "unsupported" }); // purge call fails
+
+    fireEvent.click(screen.getByRole("button", { name: "Purge all" }));
+    await screen.findByText(
+      "This permanently deletes every dead-letter job. This cannot be undone.",
+    );
+    const purgeButtons = screen.getAllByRole("button", { name: "Purge all" });
+    fireEvent.click(purgeButtons[purgeButtons.length - 1]);
+
+    await waitFor(() =>
+      expect(apiFetch).toHaveBeenCalledWith(
+        "https://api.test/v1/app/selfhost/queue/dead",
+        expect.objectContaining({ method: "DELETE" }),
+      ),
+    );
+    await waitFor(() => expect(toastError).toHaveBeenCalled());
+    expect(toastSuccess).not.toHaveBeenCalled();
+  });
+
+  it("disables the Purge all trigger when the queue is empty", async () => {
+    apiFetch.mockResolvedValue({ ok: true, data: { ...SAMPLE_PAGE, total: 0, items: [] } });
+    render(<DeadLetterQueuePanel />);
+    await screen.findByText("No dead-letter jobs");
+    expect((screen.getByRole("button", { name: "Purge all" }) as HTMLButtonElement).disabled).toBe(
+      true,
+    );
   });
 });

--- a/apps/gittensory-ui/src/components/site/dead-letter-queue-panel.test.tsx
+++ b/apps/gittensory-ui/src/components/site/dead-letter-queue-panel.test.tsx
@@ -365,6 +365,44 @@ describe("DeadLetterQueuePanel row actions and purge", () => {
     await waitFor(() => expect(replayButtons[0].disabled).toBe(false));
   });
 
+  it("REGRESSION: two different rows in flight at once don't clear each other's pending state", async () => {
+    // A single shared "pendingRowId" (rather than a Set) would have row A's completion clear row B's
+    // still-in-flight indicator too, since they'd share one variable -- letting a duplicate click fire
+    // against row B's active request.
+    apiFetch.mockResolvedValueOnce({ ok: true, data: SAMPLE_PAGE }); // initial GET
+    render(<DeadLetterQueuePanel />);
+    await screen.findByText("github-webhook");
+
+    let resolveRowA: (value: unknown) => void = () => {};
+    apiFetch.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveRowA = resolve;
+      }),
+    );
+    let resolveRowB: (value: unknown) => void = () => {};
+    apiFetch.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveRowB = resolve;
+      }),
+    );
+
+    const replayButtons = screen.getAllByRole("button", { name: "Replay" }) as HTMLButtonElement[];
+    fireEvent.click(replayButtons[0]); // row A (job id 2) starts
+    await waitFor(() => expect(replayButtons[0].disabled).toBe(true));
+    fireEvent.click(replayButtons[1]); // row B (job id 1) starts while A is still in flight
+    await waitFor(() => expect(replayButtons[1].disabled).toBe(true));
+
+    resolveRowA({ ok: true, data: { ok: true, id: 2 } }); // A resolves first
+    apiFetch.mockResolvedValueOnce({ ok: true, data: SAMPLE_PAGE }); // A's refetch
+    await waitFor(() => expect(replayButtons[0].disabled).toBe(false));
+    // B is STILL in flight -- its own disabled state must be untouched by A's completion.
+    expect(replayButtons[1].disabled).toBe(true);
+
+    resolveRowB({ ok: true, data: { ok: true, id: 1 } });
+    apiFetch.mockResolvedValueOnce({ ok: true, data: SAMPLE_PAGE }); // B's refetch
+    await waitFor(() => expect(replayButtons[1].disabled).toBe(false));
+  });
+
   it("Purge all opens a confirmation dialog with the expected warning text", async () => {
     apiFetch.mockResolvedValueOnce({ ok: true, data: SAMPLE_PAGE });
     render(<DeadLetterQueuePanel />);

--- a/apps/gittensory-ui/src/components/site/dead-letter-queue-panel.tsx
+++ b/apps/gittensory-ui/src/components/site/dead-letter-queue-panel.tsx
@@ -239,12 +239,30 @@ function DeadLetterQueueTable({
                       >
                         Replay
                       </StateActionButton>
-                      <StateActionButton
-                        onClick={() => void runJobAction(item.id, "delete")}
-                        disabled={pendingRowId === item.id}
-                      >
-                        Delete
-                      </StateActionButton>
+                      <AlertDialog>
+                        <AlertDialogTrigger asChild>
+                          <StateActionButton disabled={pendingRowId === item.id}>
+                            Delete
+                          </StateActionButton>
+                        </AlertDialogTrigger>
+                        <AlertDialogContent>
+                          <AlertDialogHeader>
+                            <AlertDialogTitle>Delete job #{item.id}?</AlertDialogTitle>
+                            <AlertDialogDescription>
+                              This permanently removes this dead-letter job. This cannot be undone.
+                            </AlertDialogDescription>
+                          </AlertDialogHeader>
+                          <AlertDialogFooter>
+                            <AlertDialogCancel>Cancel</AlertDialogCancel>
+                            <AlertDialogAction
+                              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                              onClick={() => void runJobAction(item.id, "delete")}
+                            >
+                              Delete
+                            </AlertDialogAction>
+                          </AlertDialogFooter>
+                        </AlertDialogContent>
+                      </AlertDialog>
                     </div>
                   </td>
                 </tr>

--- a/apps/gittensory-ui/src/components/site/dead-letter-queue-panel.tsx
+++ b/apps/gittensory-ui/src/components/site/dead-letter-queue-panel.tsx
@@ -152,10 +152,14 @@ function DeadLetterQueueTable({
       return next;
     });
 
-  const [pendingRowId, setPendingRowId] = useState<number | null>(null);
+  // A Set, not a single id: two DIFFERENT rows can have requests in flight at once (the user clicks Replay on
+  // row A, then Delete on row B before A resolves). A single shared "pendingRowId" would have row A's own
+  // completion clear row B's still-in-flight indicator too, letting a duplicate click fire against row B's
+  // active request.
+  const [pendingRowIds, setPendingRowIds] = useState<Set<number>>(new Set());
 
   async function runJobAction(id: number, action: "replay" | "delete") {
-    setPendingRowId(id);
+    setPendingRowIds((current) => new Set(current).add(id));
     const result = await apiFetch<{ ok: true; id: number }>(
       apiUrl(buildDeadLetterJobActionPath(id, action)),
       {
@@ -164,7 +168,11 @@ function DeadLetterQueueTable({
         credentials: "include",
       },
     );
-    setPendingRowId(null);
+    setPendingRowIds((current) => {
+      const next = new Set(current);
+      next.delete(id);
+      return next;
+    });
     if (result.ok) {
       toast.success(action === "replay" ? "Job queued for replay" : "Job deleted", {
         description: `Job #${id} ${action === "replay" ? "was requeued." : "was removed from the dead-letter queue."}`,
@@ -235,13 +243,13 @@ function DeadLetterQueueTable({
                     <div className="flex flex-wrap items-center gap-2">
                       <StateActionButton
                         onClick={() => void runJobAction(item.id, "replay")}
-                        disabled={pendingRowId === item.id}
+                        disabled={pendingRowIds.has(item.id)}
                       >
                         Replay
                       </StateActionButton>
                       <AlertDialog>
                         <AlertDialogTrigger asChild>
-                          <StateActionButton disabled={pendingRowId === item.id}>
+                          <StateActionButton disabled={pendingRowIds.has(item.id)}>
                             Delete
                           </StateActionButton>
                         </AlertDialogTrigger>

--- a/apps/gittensory-ui/src/components/site/dead-letter-queue-panel.tsx
+++ b/apps/gittensory-ui/src/components/site/dead-letter-queue-panel.tsx
@@ -1,14 +1,28 @@
 import { useMemo, useState } from "react";
+import { toast } from "sonner";
 
 import {
+  buildDeadLetterJobActionPath,
   buildDeadLetterQueuePath,
+  DEAD_LETTER_QUEUE_PURGE_PATH,
   formatDeadLetterTimestamp,
   normalizeDeadLetterQueuePage,
   truncateErrorMessage,
   type DeadLetterQueueItem,
 } from "@/components/site/dead-letter-queue-panel-model";
 import { StatusPill } from "@/components/site/control-primitives";
-import { StateBoundary } from "@/components/site/state-views";
+import { StateActionButton, StateBoundary } from "@/components/site/state-views";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from "@/components/ui/alert-dialog";
 import {
   Pagination,
   PaginationContent,
@@ -16,7 +30,13 @@ import {
   PaginationNext,
   PaginationPrevious,
 } from "@/components/ui/pagination";
+import { getApiOrigin } from "@/lib/api/origin";
+import { apiFetch } from "@/lib/api/request";
 import { useApiResource } from "@/lib/api/use-api-resource";
+
+function apiUrl(path: string): string {
+  return `${getApiOrigin().replace(/\/$/, "")}${path}`;
+}
 
 export function DeadLetterQueuePanel() {
   const [offset, setOffset] = useState(0);
@@ -24,6 +44,28 @@ export function DeadLetterQueuePanel() {
   const resource = useApiResource<unknown>(path, "Dead-letter queue");
   const page = resource.status === "ready" ? normalizeDeadLetterQueuePage(resource.data) : null;
   const isMalformed = resource.status === "ready" && page === null;
+  const [purging, setPurging] = useState(false);
+
+  async function purgeAll() {
+    setPurging(true);
+    const result = await apiFetch<{ ok: true; purged: number }>(
+      apiUrl(DEAD_LETTER_QUEUE_PURGE_PATH),
+      {
+        method: "DELETE",
+        label: "Purge dead-letter queue",
+        credentials: "include",
+      },
+    );
+    setPurging(false);
+    if (result.ok) {
+      toast.success("Dead-letter queue purged", {
+        description: `Purged ${result.data.purged} job${result.data.purged === 1 ? "" : "s"}.`,
+      });
+      resource.reload();
+    } else {
+      toast.error("Purge failed", { description: result.message });
+    }
+  }
 
   return (
     <section className="rounded-token border border-border bg-transparent p-5">
@@ -34,9 +76,35 @@ export function DeadLetterQueuePanel() {
             Jobs that exhausted their retry budget. Newest failures first.
           </p>
         </div>
-        {page ? (
-          <StatusPill status={page.total === 0 ? "ready" : "warn"}>{page.total} dead</StatusPill>
-        ) : null}
+        <div className="flex items-center gap-2">
+          {page ? (
+            <StatusPill status={page.total === 0 ? "ready" : "warn"}>{page.total} dead</StatusPill>
+          ) : null}
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <StateActionButton disabled={!page || page.total === 0 || purging}>
+                Purge all
+              </StateActionButton>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Purge the dead-letter queue?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  This permanently deletes every dead-letter job. This cannot be undone.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction
+                  className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                  onClick={() => void purgeAll()}
+                >
+                  Purge all
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
+        </div>
       </div>
 
       <div className="mt-4">
@@ -58,7 +126,7 @@ export function DeadLetterQueuePanel() {
           }
         >
           {page && page.items.length > 0 ? (
-            <DeadLetterQueueTable page={page} onPageChange={setOffset} />
+            <DeadLetterQueueTable page={page} onPageChange={setOffset} onReload={resource.reload} />
           ) : null}
         </StateBoundary>
       </div>
@@ -69,9 +137,11 @@ export function DeadLetterQueuePanel() {
 function DeadLetterQueueTable({
   page,
   onPageChange,
+  onReload,
 }: {
   page: { limit: number; offset: number; total: number; items: DeadLetterQueueItem[] };
   onPageChange: (offset: number) => void;
+  onReload: () => void;
 }) {
   const [expanded, setExpanded] = useState<Set<number>>(new Set());
   const toggleExpanded = (id: number) =>
@@ -82,6 +152,31 @@ function DeadLetterQueueTable({
       return next;
     });
 
+  const [pendingRowId, setPendingRowId] = useState<number | null>(null);
+
+  async function runJobAction(id: number, action: "replay" | "delete") {
+    setPendingRowId(id);
+    const result = await apiFetch<{ ok: true; id: number }>(
+      apiUrl(buildDeadLetterJobActionPath(id, action)),
+      {
+        method: action === "replay" ? "POST" : "DELETE",
+        label: action === "replay" ? "Replay dead-letter job" : "Delete dead-letter job",
+        credentials: "include",
+      },
+    );
+    setPendingRowId(null);
+    if (result.ok) {
+      toast.success(action === "replay" ? "Job queued for replay" : "Job deleted", {
+        description: `Job #${id} ${action === "replay" ? "was requeued." : "was removed from the dead-letter queue."}`,
+      });
+      onReload();
+    } else {
+      toast.error(action === "replay" ? "Replay failed" : "Delete failed", {
+        description: result.message,
+      });
+    }
+  }
+
   const rangeStart = page.total === 0 ? 0 : page.offset + 1;
   const rangeEnd = Math.min(page.offset + page.items.length, page.total);
   const hasPrevious = page.offset > 0;
@@ -90,7 +185,7 @@ function DeadLetterQueueTable({
   return (
     <div className="space-y-3">
       <div className="overflow-x-auto rounded-token border border-border bg-transparent">
-        <table className="w-full min-w-[760px] text-left text-token-sm">
+        <table className="w-full min-w-[880px] text-left text-token-sm">
           <thead className="border-b border-border text-token-xs uppercase text-muted-foreground">
             <tr>
               <th className="px-4 py-3 font-medium">Job ID</th>
@@ -99,6 +194,7 @@ function DeadLetterQueueTable({
               <th className="px-4 py-3 font-medium">Last error</th>
               <th className="px-4 py-3 font-medium">Created</th>
               <th className="px-4 py-3 font-medium">Died</th>
+              <th className="px-4 py-3 font-medium">Actions</th>
             </tr>
           </thead>
           <tbody>
@@ -134,6 +230,22 @@ function DeadLetterQueueTable({
                   </td>
                   <td className="px-4 py-3 font-mono text-token-xs text-muted-foreground whitespace-nowrap">
                     {formatDeadLetterTimestamp(item.deadAtMs)}
+                  </td>
+                  <td className="px-4 py-3">
+                    <div className="flex flex-wrap items-center gap-2">
+                      <StateActionButton
+                        onClick={() => void runJobAction(item.id, "replay")}
+                        disabled={pendingRowId === item.id}
+                      >
+                        Replay
+                      </StateActionButton>
+                      <StateActionButton
+                        onClick={() => void runJobAction(item.id, "delete")}
+                        disabled={pendingRowId === item.id}
+                      >
+                        Delete
+                      </StateActionButton>
+                    </div>
                   </td>
                 </tr>
               );

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -271,7 +271,12 @@ import type {
   RepositorySettings,
 } from "../types";
 import { errorMessage, nowIso } from "../utils/json";
-import { queueDeadLetterPageFromBinding } from "../selfhost/queue-common";
+import {
+  queueDeadLetterPageFromBinding,
+  queueDeleteDeadLetterJobViaBinding,
+  queuePurgeDeadLetterJobsViaBinding,
+  queueReplayDeadLetterJobViaBinding,
+} from "../selfhost/queue-common";
 
 type AppBindings = { Bindings: Env };
 type AppContext = Context<AppBindings>;
@@ -1400,6 +1405,84 @@ export function createApp() {
       );
     }
     return c.json({ generatedAt: nowIso(), limit, offset, total: page.total, items: page.items });
+  });
+
+  // Dead-letter-queue admin actions (#2215): replay/delete a single dead job, or purge all of them. Same
+  // env.JOBS-binding mirror and null/501 "admin unavailable" contract as the read-only GET route above --
+  // absent entirely on Cloudflare, where the plain Queue binding exposes none of these methods.
+  app.post("/v1/app/selfhost/queue/dead/:id/replay", async (c) => {
+    const forbidden = await requireAppRole(c, ["operator"]);
+    if (forbidden) return forbidden;
+    const id = Number(c.req.param("id"));
+    if (!Number.isInteger(id) || id <= 0) return c.json({ error: "invalid_job_id" }, 400);
+    const identity = await authenticateRequestIdentity(c);
+    /* v8 ignore next -- requireAppRole already rejects an unauthenticated caller before this handler runs. */
+    if (!identity) return c.json({ error: "unauthorized" }, 401);
+    const result = await queueReplayDeadLetterJobViaBinding(c.env.JOBS, id);
+    if (result === null) {
+      return c.json(
+        { error: "dead_letter_admin_unavailable", message: "This deployment's queue backend does not expose dead-letter admin." },
+        501,
+      );
+    }
+    if (result === false) return c.json({ error: "dead_letter_job_not_found" }, 404);
+    await recordAuditEvent(c.env, {
+      eventType: "operator.dlq_job_replayed",
+      actor: identity.actor,
+      targetKey: `selfhost_jobs#${id}`,
+      outcome: "completed",
+      metadata: { id },
+    });
+    return c.json({ ok: true, id });
+  });
+
+  app.delete("/v1/app/selfhost/queue/dead/:id", async (c) => {
+    const forbidden = await requireAppRole(c, ["operator"]);
+    if (forbidden) return forbidden;
+    const id = Number(c.req.param("id"));
+    if (!Number.isInteger(id) || id <= 0) return c.json({ error: "invalid_job_id" }, 400);
+    const identity = await authenticateRequestIdentity(c);
+    /* v8 ignore next -- requireAppRole already rejects an unauthenticated caller before this handler runs. */
+    if (!identity) return c.json({ error: "unauthorized" }, 401);
+    const result = await queueDeleteDeadLetterJobViaBinding(c.env.JOBS, id);
+    if (result === null) {
+      return c.json(
+        { error: "dead_letter_admin_unavailable", message: "This deployment's queue backend does not expose dead-letter admin." },
+        501,
+      );
+    }
+    if (result === false) return c.json({ error: "dead_letter_job_not_found" }, 404);
+    await recordAuditEvent(c.env, {
+      eventType: "operator.dlq_job_deleted",
+      actor: identity.actor,
+      targetKey: `selfhost_jobs#${id}`,
+      outcome: "completed",
+      metadata: { id },
+    });
+    return c.json({ ok: true, id });
+  });
+
+  app.delete("/v1/app/selfhost/queue/dead", async (c) => {
+    const forbidden = await requireAppRole(c, ["operator"]);
+    if (forbidden) return forbidden;
+    const identity = await authenticateRequestIdentity(c);
+    /* v8 ignore next -- requireAppRole already rejects an unauthenticated caller before this handler runs. */
+    if (!identity) return c.json({ error: "unauthorized" }, 401);
+    const purged = await queuePurgeDeadLetterJobsViaBinding(c.env.JOBS);
+    if (purged === null) {
+      return c.json(
+        { error: "dead_letter_admin_unavailable", message: "This deployment's queue backend does not expose dead-letter admin." },
+        501,
+      );
+    }
+    await recordAuditEvent(c.env, {
+      eventType: "operator.dlq_purged",
+      actor: identity.actor,
+      targetKey: "selfhost_jobs#all",
+      outcome: "completed",
+      metadata: { purged },
+    });
+    return c.json({ ok: true, purged });
   });
 
   // Global agent kill-switch (#2359): the write side (setGlobalAgentFrozen) previously had zero callers — the

--- a/src/openapi/spec.ts
+++ b/src/openapi/spec.ts
@@ -739,6 +739,11 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "post",
     path: "/v1/app/selfhost/queue/dead/{id}/replay",
+    request: {
+      params: z.object({
+        id: z.string().openapi({ param: { description: "Dead-letter job id." }, example: "812" }),
+      }),
+    },
     responses: {
       200: { description: "Job replayed", content: { "application/json": { schema: z.record(z.string(), z.unknown()) } } },
       400: { description: "Invalid job id" },
@@ -751,6 +756,11 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "delete",
     path: "/v1/app/selfhost/queue/dead/{id}",
+    request: {
+      params: z.object({
+        id: z.string().openapi({ param: { description: "Dead-letter job id." }, example: "812" }),
+      }),
+    },
     responses: {
       200: { description: "Job deleted", content: { "application/json": { schema: z.record(z.string(), z.unknown()) } } },
       400: { description: "Invalid job id" },

--- a/src/openapi/spec.ts
+++ b/src/openapi/spec.ts
@@ -737,6 +737,40 @@ export function buildOpenApiSpec() {
     });
   }
   registry.registerPath({
+    method: "post",
+    path: "/v1/app/selfhost/queue/dead/{id}/replay",
+    responses: {
+      200: { description: "Job replayed", content: { "application/json": { schema: z.record(z.string(), z.unknown()) } } },
+      400: { description: "Invalid job id" },
+      401: { description: "Unauthorized" },
+      403: { description: "Insufficient app role (operator only)" },
+      404: { description: "Dead-letter job not found" },
+      501: { description: "This deployment's queue backend does not expose dead-letter admin" },
+    },
+  });
+  registry.registerPath({
+    method: "delete",
+    path: "/v1/app/selfhost/queue/dead/{id}",
+    responses: {
+      200: { description: "Job deleted", content: { "application/json": { schema: z.record(z.string(), z.unknown()) } } },
+      400: { description: "Invalid job id" },
+      401: { description: "Unauthorized" },
+      403: { description: "Insufficient app role (operator only)" },
+      404: { description: "Dead-letter job not found" },
+      501: { description: "This deployment's queue backend does not expose dead-letter admin" },
+    },
+  });
+  registry.registerPath({
+    method: "delete",
+    path: "/v1/app/selfhost/queue/dead",
+    responses: {
+      200: { description: "Dead-letter jobs purged", content: { "application/json": { schema: z.record(z.string(), z.unknown()) } } },
+      401: { description: "Unauthorized" },
+      403: { description: "Insufficient app role (operator only)" },
+      501: { description: "This deployment's queue backend does not expose dead-letter admin" },
+    },
+  });
+  registry.registerPath({
     method: "get",
     path: "/v1/app/analytics/weekly-value-report",
     request: {

--- a/src/selfhost/pg-queue.ts
+++ b/src/selfhost/pg-queue.ts
@@ -225,6 +225,15 @@ export interface PgDurableQueue {
   /** Paginated dead-letter rows, newest-death-first, for the DLQ dashboard table (#2214). Also mirrored onto
    *  `binding` (see queue-common.ts's SelfHostQueueDeadLetterAdmin) so Hono routes can reach it via env.JOBS. */
   listDeadLetterJobs(limit: number, offset: number): Promise<DeadLetterJob[]>;
+  /** Manually requeues ONE dead job by id with a fresh retry budget (#2215). Also mirrored onto `binding` (see
+   *  queue-common.ts's SelfHostQueueDeadLetterAdmin) so Hono routes can reach it via env.JOBS. */
+  replayDeadLetterJob(id: number): Promise<boolean>;
+  /** Permanently deletes ONE dead job by id (#2215). Also mirrored onto `binding` (see queue-common.ts's
+   *  SelfHostQueueDeadLetterAdmin) so Hono routes can reach it via env.JOBS. */
+  deleteDeadLetterJob(id: number): Promise<boolean>;
+  /** Permanently deletes EVERY dead job (#2215). Also mirrored onto `binding` (see queue-common.ts's
+   *  SelfHostQueueDeadLetterAdmin) so Hono routes can reach it via env.JOBS. */
+  purgeDeadLetterJobs(): Promise<number>;
 }
 
 interface JobRow {
@@ -534,6 +543,28 @@ export function createPgQueue(
       createdAtMs: Number(row.created_at),
       deadAtMs: row.dead_at === null ? null : Number(row.dead_at),
     }));
+  }
+
+  // Manual, operator-initiated dead-letter actions (#2215), triggered from a dashboard button -- distinct from
+  // reviveEligibleDeadJobs above, which is an AUTOMATIC bulk sweep that deliberately preserves attempts under a
+  // ceiling. A human clicking "replay" on one specific job is a conscious, one-off decision, so it resets
+  // attempts to 0 for a full fresh retry budget instead of inheriting whatever the automatic sweep would allow.
+  async function replayDeadLetterJob(id: number): Promise<boolean> {
+    const result = await pool.query(
+      `UPDATE ${TABLE} SET status='pending', run_after=$1, last_error=NULL, dead_at=NULL, attempts=0 WHERE id=$2 AND status='dead'`,
+      [Date.now(), id],
+    );
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  async function deleteDeadLetterJob(id: number): Promise<boolean> {
+    const result = await pool.query(`DELETE FROM ${TABLE} WHERE id=$1 AND status='dead'`, [id]);
+    return (result.rowCount ?? 0) > 0;
+  }
+
+  async function purgeDeadLetterJobs(): Promise<number> {
+    const result = await pool.query(`DELETE FROM ${TABLE} WHERE status='dead'`);
+    return result.rowCount ?? 0;
   }
 
   async function recoverProcessingJobs(): Promise<number> {
@@ -1346,10 +1377,16 @@ export function createPgQueue(
     },
     deadCount,
     listDeadLetterJobs,
+    replayDeadLetterJob,
+    deleteDeadLetterJob,
+    purgeDeadLetterJobs,
   } as unknown as Queue & {
     snapshot(): Promise<SelfHostQueueSnapshot>;
     deadCount(): Promise<number>;
     listDeadLetterJobs(limit: number, offset: number): Promise<DeadLetterJob[]>;
+    replayDeadLetterJob(id: number): Promise<boolean>;
+    deleteDeadLetterJob(id: number): Promise<boolean>;
+    purgeDeadLetterJobs(): Promise<number>;
   };
 
   return {
@@ -1417,6 +1454,9 @@ export function createPgQueue(
     },
     topBacklogRepos,
     listDeadLetterJobs,
+    replayDeadLetterJob,
+    deleteDeadLetterJob,
+    purgeDeadLetterJobs,
   };
 
   async function reclaimExpiredProcessingJobs(): Promise<number> {

--- a/src/selfhost/queue-common.ts
+++ b/src/selfhost/queue-common.ts
@@ -67,6 +67,16 @@ export type DeadLetterJob = {
 export interface SelfHostQueueDeadLetterAdmin {
   deadCount(): number | Promise<number>;
   listDeadLetterJobs(limit: number, offset: number): DeadLetterJob[] | Promise<DeadLetterJob[]>;
+  /** Manually requeues ONE dead job by id with a FRESH retry budget (attempts reset to 0) -- distinct from the
+   *  automatic reviveDeadLetterJobs() sweep, which deliberately preserves attempts under a ceiling to avoid an
+   *  unsupervised infinite-retry loop for a permanently-broken job. An operator clicking replay is a conscious,
+   *  one-off decision, so it gets a full budget. Returns false if no row with that id is currently dead (already
+   *  handled, already deleted, or never existed) -- the route maps that to 404, not a false-success 200. */
+  replayDeadLetterJob(id: number): boolean | Promise<boolean>;
+  /** Permanently deletes ONE dead job by id. Returns false if no row with that id is currently dead. */
+  deleteDeadLetterJob(id: number): boolean | Promise<boolean>;
+  /** Permanently deletes EVERY dead job. Returns the number of rows deleted. */
+  purgeDeadLetterJobs(): number | Promise<number>;
 }
 
 // Webhook-driven work (a fresh PR -> its review) jumps ahead of heavy background jobs. Per-PR review refreshes
@@ -215,6 +225,32 @@ export async function queueDeadLetterPageFromBinding(
     Promise.resolve(admin.deadCount()),
   ]);
   return { items, total };
+}
+
+/** Null when the binding doesn't expose the admin surface at all (Cloudflare, or not wired) -- same 501
+ *  contract as queueDeadLetterPageFromBinding. A boolean false (id not found / not dead) is a real, valid
+ *  result distinct from null, so callers can tell "admin unavailable" apart from "nothing to replay". */
+export async function queueReplayDeadLetterJobViaBinding(binding: Queue, id: number): Promise<boolean | null> {
+  const admin = binding as Queue & Partial<SelfHostQueueDeadLetterAdmin>;
+  if (typeof admin.replayDeadLetterJob !== "function") return null;
+  const result = await Promise.resolve(admin.replayDeadLetterJob(id));
+  return typeof result === "boolean" ? result : null;
+}
+
+/** Same null/boolean contract as queueReplayDeadLetterJobViaBinding, for permanently deleting one dead job. */
+export async function queueDeleteDeadLetterJobViaBinding(binding: Queue, id: number): Promise<boolean | null> {
+  const admin = binding as Queue & Partial<SelfHostQueueDeadLetterAdmin>;
+  if (typeof admin.deleteDeadLetterJob !== "function") return null;
+  const result = await Promise.resolve(admin.deleteDeadLetterJob(id));
+  return typeof result === "boolean" ? result : null;
+}
+
+/** Null when the binding doesn't expose the admin surface; otherwise the count of dead jobs purged. */
+export async function queuePurgeDeadLetterJobsViaBinding(binding: Queue): Promise<number | null> {
+  const admin = binding as Queue & Partial<SelfHostQueueDeadLetterAdmin>;
+  if (typeof admin.purgeDeadLetterJobs !== "function") return null;
+  const result = await Promise.resolve(admin.purgeDeadLetterJobs());
+  return typeof result === "number" ? result : null;
 }
 
 function queueStatus(value: unknown): SelfHostQueueJobStatus | null {

--- a/src/selfhost/sqlite-queue.ts
+++ b/src/selfhost/sqlite-queue.ts
@@ -140,6 +140,13 @@ export interface DurableQueue {
   /** Paginated dead-letter rows, newest-death-first, for the DLQ dashboard table (#2214). Also mirrored onto
    *  `binding` (see queue-common.ts's SelfHostQueueDeadLetterAdmin) so Hono routes can reach it via env.JOBS. */
   listDeadLetterJobs(limit: number, offset: number): DeadLetterJob[];
+  /** Manual, operator-initiated replay of ONE dead job with a FRESH retry budget (#2215) -- unlike the automatic
+   *  reviveDeadLetterJobs() sweep above, which deliberately preserves `attempts` under a ceiling. */
+  replayDeadLetterJob(id: number): boolean;
+  /** Manual, operator-initiated permanent delete of ONE dead job (#2215). */
+  deleteDeadLetterJob(id: number): boolean;
+  /** Manual, operator-initiated permanent delete of EVERY dead job (#2215). */
+  purgeDeadLetterJobs(): number;
 }
 
 interface JobRow {
@@ -669,6 +676,34 @@ export function createSqliteQueue(
     }));
   }
 
+  // Manual, operator-initiated dead-letter actions (#2215) -- distinct from reviveEligibleDeadJobs above, which
+  // is an unattended timer sweep that deliberately preserves `attempts` under a ceiling. These three are each
+  // triggered by a human clicking a specific button for a specific job on the dashboard, so they don't need (and
+  // must not reuse) that automatic ceiling/jitter machinery.
+
+  /** Manually requeues ONE dead job with a FRESH retry budget (attempts reset to 0) -- see the doc comment on
+   *  SelfHostQueueDeadLetterAdmin.replayDeadLetterJob in queue-common.ts for the full rationale. Returns false
+   *  if no row with that id is currently dead. */
+  function replayDeadLetterJob(id: number): boolean {
+    const { changes } = driver.query(
+      `UPDATE ${TABLE} SET status='pending', run_after=?, last_error=NULL, dead_at=NULL, attempts=0 WHERE id=? AND status='dead'`,
+      [Date.now(), id],
+    );
+    return changes > 0;
+  }
+
+  /** Permanently deletes ONE dead job by id. Returns false if no row with that id is currently dead. */
+  function deleteDeadLetterJob(id: number): boolean {
+    const { changes } = driver.query(`DELETE FROM ${TABLE} WHERE id=? AND status='dead'`, [id]);
+    return changes > 0;
+  }
+
+  /** Permanently deletes EVERY dead job. Returns the number of rows deleted. */
+  function purgeDeadLetterJobs(): number {
+    const { changes } = driver.query(`DELETE FROM ${TABLE} WHERE status='dead'`, []);
+    return changes;
+  }
+
   function claimNextWhere(
     now: number,
     priorityPredicate: string,
@@ -1041,10 +1076,16 @@ export function createSqliteQueue(
     },
     deadCount,
     listDeadLetterJobs,
+    replayDeadLetterJob,
+    deleteDeadLetterJob,
+    purgeDeadLetterJobs,
   } as unknown as Queue & {
     snapshot(): SelfHostQueueSnapshot;
     deadCount(): number;
     listDeadLetterJobs(limit: number, offset: number): DeadLetterJob[];
+    replayDeadLetterJob(id: number): boolean;
+    deleteDeadLetterJob(id: number): boolean;
+    purgeDeadLetterJobs(): number;
   };
 
   return {
@@ -1111,6 +1152,9 @@ export function createSqliteQueue(
     },
     topBacklogRepos,
     listDeadLetterJobs,
+    replayDeadLetterJob,
+    deleteDeadLetterJob,
+    purgeDeadLetterJobs,
   };
 }
 

--- a/test/unit/routes-selfhost-dead-letter-queue.test.ts
+++ b/test/unit/routes-selfhost-dead-letter-queue.test.ts
@@ -12,13 +12,28 @@ import { createTestEnv } from "../helpers/d1";
 function selfhostJobsStub(overrides: {
   listDeadLetterJobs?: (limit: number, offset: number) => unknown[];
   deadCount?: () => number;
+  replayDeadLetterJob?: (id: number) => boolean;
+  deleteDeadLetterJob?: (id: number) => boolean;
+  purgeDeadLetterJobs?: () => number;
 } = {}): Queue {
   return {
     async send() {},
     async sendBatch() {},
     listDeadLetterJobs: overrides.listDeadLetterJobs ?? (() => []),
     deadCount: overrides.deadCount ?? (() => 0),
+    replayDeadLetterJob: overrides.replayDeadLetterJob ?? (() => true),
+    deleteDeadLetterJob: overrides.deleteDeadLetterJob ?? (() => true),
+    purgeDeadLetterJobs: overrides.purgeDeadLetterJobs ?? (() => 0),
   } as unknown as Queue;
+}
+
+async function auditRows(env: Env, eventType: string): Promise<Array<{ actor: string; outcome: string; metadata_json: string }>> {
+  const result = (await env.DB.prepare(
+    "select actor, outcome, metadata_json from audit_events where event_type = ? order by created_at desc",
+  )
+    .bind(eventType)
+    .all()) as { results: Array<{ actor: string; outcome: string; metadata_json: string }> };
+  return result.results;
 }
 
 describe("dead-letter-queue table route (#2214)", () => {
@@ -111,5 +126,255 @@ describe("dead-letter-queue table route (#2214)", () => {
 
     expect(res.status).toBe(400);
     await expect(res.json()).resolves.toMatchObject({ error: "invalid_query" });
+  });
+});
+
+// #2215: the admin action trio built on top of the #2214 read-only view -- replay/delete a single dead job,
+// or purge all of them. Same env.JOBS-binding mirror and null/501 "admin unavailable" contract.
+
+describe("dead-letter-queue replay route (#2215)", () => {
+  it("is unauthorized with no identity at all", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const res = await app.request("/v1/app/selfhost/queue/dead/1/replay", { method: "POST" }, env);
+    expect(res.status).toBe(401);
+  });
+
+  it("is forbidden for an authenticated session without the operator role", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const { token } = await createSessionForGitHubUser(env, { login: "not-an-operator", id: 501 });
+    const res = await app.request(
+      "/v1/app/selfhost/queue/dead/1/replay",
+      { method: "POST", headers: { cookie: `gittensory_session=${token}` } },
+      env,
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it.each(["abc", "-1", "0", "1.5"])("rejects an invalid job id %s", async (badId) => {
+    const app = createApp();
+    const env = createTestEnv({ JOBS: selfhostJobsStub() });
+    const { token } = await createSessionForGitHubUser(env, { login: "jsonbored", id: 1 });
+    const res = await app.request(
+      `/v1/app/selfhost/queue/dead/${badId}/replay`,
+      { method: "POST", headers: { cookie: `gittensory_session=${token}` } },
+      env,
+    );
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({ error: "invalid_job_id" });
+  });
+
+  it("returns 501 when the queue backend has no dead-letter admin surface", async () => {
+    const app = createApp();
+    const env = createTestEnv(); // default JOBS stub is Cloudflare-shaped: no replayDeadLetterJob
+    const { token } = await createSessionForGitHubUser(env, { login: "jsonbored", id: 1 });
+    const res = await app.request(
+      "/v1/app/selfhost/queue/dead/1/replay",
+      { method: "POST", headers: { cookie: `gittensory_session=${token}` } },
+      env,
+    );
+    expect(res.status).toBe(501);
+    await expect(res.json()).resolves.toMatchObject({ error: "dead_letter_admin_unavailable" });
+  });
+
+  it("returns 404 when the job isn't found or isn't currently dead", async () => {
+    const app = createApp();
+    const env = createTestEnv({ JOBS: selfhostJobsStub({ replayDeadLetterJob: () => false }) });
+    const { token } = await createSessionForGitHubUser(env, { login: "jsonbored", id: 1 });
+    const res = await app.request(
+      "/v1/app/selfhost/queue/dead/99/replay",
+      { method: "POST", headers: { cookie: `gittensory_session=${token}` } },
+      env,
+    );
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toMatchObject({ error: "dead_letter_job_not_found" });
+  });
+
+  it("replays the job for an operator session and audits it", async () => {
+    const app = createApp();
+    let seenId = -1;
+    const env = createTestEnv({
+      JOBS: selfhostJobsStub({
+        replayDeadLetterJob: (id) => {
+          seenId = id;
+          return true;
+        },
+      }),
+    });
+    const { token } = await createSessionForGitHubUser(env, { login: "jsonbored", id: 1 });
+
+    const res = await app.request(
+      "/v1/app/selfhost/queue/dead/7/replay",
+      { method: "POST", headers: { cookie: `gittensory_session=${token}` } },
+      env,
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ ok: true, id: 7 });
+    expect(seenId).toBe(7);
+
+    const audits = await auditRows(env, "operator.dlq_job_replayed");
+    expect(audits).toHaveLength(1);
+    expect(audits[0]).toMatchObject({ actor: "jsonbored", outcome: "completed" });
+    expect(JSON.parse(audits[0]!.metadata_json)).toMatchObject({ id: 7 });
+  });
+});
+
+describe("dead-letter-queue delete route (#2215)", () => {
+  it("is unauthorized with no identity at all", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const res = await app.request("/v1/app/selfhost/queue/dead/1", { method: "DELETE" }, env);
+    expect(res.status).toBe(401);
+  });
+
+  it("is forbidden for an authenticated session without the operator role", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const { token } = await createSessionForGitHubUser(env, { login: "not-an-operator", id: 501 });
+    const res = await app.request(
+      "/v1/app/selfhost/queue/dead/1",
+      { method: "DELETE", headers: { cookie: `gittensory_session=${token}` } },
+      env,
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it.each(["abc", "-1", "0", "1.5"])("rejects an invalid job id %s", async (badId) => {
+    const app = createApp();
+    const env = createTestEnv({ JOBS: selfhostJobsStub() });
+    const { token } = await createSessionForGitHubUser(env, { login: "jsonbored", id: 1 });
+    const res = await app.request(
+      `/v1/app/selfhost/queue/dead/${badId}`,
+      { method: "DELETE", headers: { cookie: `gittensory_session=${token}` } },
+      env,
+    );
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({ error: "invalid_job_id" });
+  });
+
+  it("returns 501 when the queue backend has no dead-letter admin surface", async () => {
+    const app = createApp();
+    const env = createTestEnv(); // default JOBS stub is Cloudflare-shaped: no deleteDeadLetterJob
+    const { token } = await createSessionForGitHubUser(env, { login: "jsonbored", id: 1 });
+    const res = await app.request(
+      "/v1/app/selfhost/queue/dead/1",
+      { method: "DELETE", headers: { cookie: `gittensory_session=${token}` } },
+      env,
+    );
+    expect(res.status).toBe(501);
+    await expect(res.json()).resolves.toMatchObject({ error: "dead_letter_admin_unavailable" });
+  });
+
+  it("returns 404 when the job isn't found or isn't currently dead", async () => {
+    const app = createApp();
+    const env = createTestEnv({ JOBS: selfhostJobsStub({ deleteDeadLetterJob: () => false }) });
+    const { token } = await createSessionForGitHubUser(env, { login: "jsonbored", id: 1 });
+    const res = await app.request(
+      "/v1/app/selfhost/queue/dead/99",
+      { method: "DELETE", headers: { cookie: `gittensory_session=${token}` } },
+      env,
+    );
+    expect(res.status).toBe(404);
+    await expect(res.json()).resolves.toMatchObject({ error: "dead_letter_job_not_found" });
+  });
+
+  it("deletes the job for an operator session and audits it", async () => {
+    const app = createApp();
+    let seenId = -1;
+    const env = createTestEnv({
+      JOBS: selfhostJobsStub({
+        deleteDeadLetterJob: (id) => {
+          seenId = id;
+          return true;
+        },
+      }),
+    });
+    const { token } = await createSessionForGitHubUser(env, { login: "jsonbored", id: 1 });
+
+    const res = await app.request(
+      "/v1/app/selfhost/queue/dead/7",
+      { method: "DELETE", headers: { cookie: `gittensory_session=${token}` } },
+      env,
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ ok: true, id: 7 });
+    expect(seenId).toBe(7);
+
+    const audits = await auditRows(env, "operator.dlq_job_deleted");
+    expect(audits).toHaveLength(1);
+    expect(audits[0]).toMatchObject({ actor: "jsonbored", outcome: "completed" });
+    expect(JSON.parse(audits[0]!.metadata_json)).toMatchObject({ id: 7 });
+  });
+});
+
+describe("dead-letter-queue purge route (#2215)", () => {
+  it("is unauthorized with no identity at all", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const res = await app.request("/v1/app/selfhost/queue/dead", { method: "DELETE" }, env);
+    expect(res.status).toBe(401);
+  });
+
+  it("is forbidden for an authenticated session without the operator role", async () => {
+    const app = createApp();
+    const env = createTestEnv();
+    const { token } = await createSessionForGitHubUser(env, { login: "not-an-operator", id: 501 });
+    const res = await app.request(
+      "/v1/app/selfhost/queue/dead",
+      { method: "DELETE", headers: { cookie: `gittensory_session=${token}` } },
+      env,
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 501 when the queue backend has no dead-letter admin surface", async () => {
+    const app = createApp();
+    const env = createTestEnv(); // default JOBS stub is Cloudflare-shaped: no purgeDeadLetterJobs
+    const { token } = await createSessionForGitHubUser(env, { login: "jsonbored", id: 1 });
+    const res = await app.request(
+      "/v1/app/selfhost/queue/dead",
+      { method: "DELETE", headers: { cookie: `gittensory_session=${token}` } },
+      env,
+    );
+    expect(res.status).toBe(501);
+    await expect(res.json()).resolves.toMatchObject({ error: "dead_letter_admin_unavailable" });
+  });
+
+  it("purges all dead-letter jobs for an operator session and audits it", async () => {
+    const app = createApp();
+    const env = createTestEnv({ JOBS: selfhostJobsStub({ purgeDeadLetterJobs: () => 3 }) });
+    const { token } = await createSessionForGitHubUser(env, { login: "jsonbored", id: 1 });
+
+    const res = await app.request(
+      "/v1/app/selfhost/queue/dead",
+      { method: "DELETE", headers: { cookie: `gittensory_session=${token}` } },
+      env,
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ ok: true, purged: 3 });
+
+    const audits = await auditRows(env, "operator.dlq_purged");
+    expect(audits).toHaveLength(1);
+    expect(audits[0]).toMatchObject({ actor: "jsonbored", outcome: "completed" });
+    expect(JSON.parse(audits[0]!.metadata_json)).toMatchObject({ purged: 3 });
+  });
+
+  it("purges zero dead-letter jobs without error when the DLQ is already empty", async () => {
+    const app = createApp();
+    const env = createTestEnv({ JOBS: selfhostJobsStub({ purgeDeadLetterJobs: () => 0 }) });
+    const { token } = await createSessionForGitHubUser(env, { login: "jsonbored", id: 1 });
+
+    const res = await app.request(
+      "/v1/app/selfhost/queue/dead",
+      { method: "DELETE", headers: { cookie: `gittensory_session=${token}` } },
+      env,
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ ok: true, purged: 0 });
   });
 });

--- a/test/unit/selfhost-pg-queue.test.ts
+++ b/test/unit/selfhost-pg-queue.test.ts
@@ -1501,6 +1501,15 @@ describe("createPgQueue (durable #977)", () => {
       expect(m.calls[0]?.params).toEqual([expect.any(Number), 7]);
     });
 
+    it("REGRESSION: replayDeadLetterJob falls back to false (not null/undefined) when the driver omits rowCount", async () => {
+      // Same rationale as purgeDeadLetterJobs's own regression test below: rowCount:0 and rowCount:null both
+      // take the ">0 === false" branch, so only an explicit null proves the `?? 0` fallback itself fires.
+      const m = stubReplay(null);
+      const q = createPgQueue(m.pool as unknown as Pool, async () => undefined);
+
+      expect(await q.replayDeadLetterJob(7)).toBe(false);
+    });
+
     it("deleteDeadLetterJob deletes one dead row by id and returns true", async () => {
       const m = stubDeleteById(1);
       const q = createPgQueue(m.pool as unknown as Pool, async () => undefined);
@@ -1516,6 +1525,13 @@ describe("createPgQueue (durable #977)", () => {
 
       expect(await q.deleteDeadLetterJob(9)).toBe(false);
       expect(m.calls[0]?.params).toEqual([9]);
+    });
+
+    it("REGRESSION: deleteDeadLetterJob falls back to false (not null/undefined) when the driver omits rowCount", async () => {
+      const m = stubDeleteById(null);
+      const q = createPgQueue(m.pool as unknown as Pool, async () => undefined);
+
+      expect(await q.deleteDeadLetterJob(9)).toBe(false);
     });
 
     it("purgeDeadLetterJobs deletes every dead row with no id param and returns the count", async () => {

--- a/test/unit/selfhost-pg-queue.test.ts
+++ b/test/unit/selfhost-pg-queue.test.ts
@@ -1419,6 +1419,132 @@ describe("createPgQueue (durable #977)", () => {
     });
   });
 
+  describe("replay/delete/purge dead-letter jobs (#2215)", () => {
+    // Manual, operator-initiated dead-letter actions (distinct from the automatic reviveEligibleDeadJobs sweep
+    // tested below under "reviveDeadLetterJobs (#audit-rate-headroom)"). Each stub matches on a distinguishing
+    // SQL fragment so a test can't accidentally satisfy the wrong query -- delete-by-id is distinguished from
+    // purge-all by the presence/absence of "id=$1", mirroring how stubDeadLetterRows above matches on SQL text.
+    function stubReplay(rowCount: number | null): {
+      pool: { query: Pool["query"] };
+      calls: Array<{ sql: string; params: unknown[] }>;
+    } {
+      const calls: Array<{ sql: string; params: unknown[] }> = [];
+      return {
+        pool: {
+          query: (async (sql: unknown, params?: unknown[]) => {
+            const q = String(sql);
+            if (q.includes("SET status='pending'") && q.includes("attempts=0")) {
+              calls.push({ sql: q, params: params ?? [] });
+              return { rows: [], rowCount };
+            }
+            return { rows: [], rowCount: 0 };
+          }) as Pool["query"],
+        },
+        calls,
+      };
+    }
+
+    function stubDeleteById(rowCount: number | null): {
+      pool: { query: Pool["query"] };
+      calls: Array<{ sql: string; params: unknown[] }>;
+    } {
+      const calls: Array<{ sql: string; params: unknown[] }> = [];
+      return {
+        pool: {
+          query: (async (sql: unknown, params?: unknown[]) => {
+            const q = String(sql);
+            if (q.includes("DELETE FROM") && q.includes("status='dead'") && q.includes("id=$1")) {
+              calls.push({ sql: q, params: params ?? [] });
+              return { rows: [], rowCount };
+            }
+            return { rows: [], rowCount: 0 };
+          }) as Pool["query"],
+        },
+        calls,
+      };
+    }
+
+    function stubPurge(rowCount: number | null): {
+      pool: { query: Pool["query"] };
+      calls: Array<{ sql: string; params: unknown[] }>;
+    } {
+      const calls: Array<{ sql: string; params: unknown[] }> = [];
+      return {
+        pool: {
+          query: (async (sql: unknown, params?: unknown[]) => {
+            const q = String(sql);
+            if (q.includes("DELETE FROM") && q.includes("status='dead'") && !q.includes("id=$1")) {
+              calls.push({ sql: q, params: params ?? [] });
+              return { rows: [], rowCount };
+            }
+            return { rows: [], rowCount: 0 };
+          }) as Pool["query"],
+        },
+        calls,
+      };
+    }
+
+    it("replayDeadLetterJob requeues a dead row with a fresh attempts budget and returns true", async () => {
+      const m = stubReplay(1);
+      const q = createPgQueue(m.pool as unknown as Pool, async () => undefined);
+
+      expect(await q.replayDeadLetterJob(7)).toBe(true);
+      expect(m.calls).toHaveLength(1);
+      expect(m.calls[0]?.params).toEqual([expect.any(Number), 7]);
+    });
+
+    it("replayDeadLetterJob returns false when the id is not currently dead (already handled/deleted/never existed)", async () => {
+      const m = stubReplay(0);
+      const q = createPgQueue(m.pool as unknown as Pool, async () => undefined);
+
+      expect(await q.replayDeadLetterJob(7)).toBe(false);
+      expect(m.calls[0]?.params).toEqual([expect.any(Number), 7]);
+    });
+
+    it("deleteDeadLetterJob deletes one dead row by id and returns true", async () => {
+      const m = stubDeleteById(1);
+      const q = createPgQueue(m.pool as unknown as Pool, async () => undefined);
+
+      expect(await q.deleteDeadLetterJob(9)).toBe(true);
+      expect(m.calls).toHaveLength(1);
+      expect(m.calls[0]?.params).toEqual([9]);
+    });
+
+    it("deleteDeadLetterJob returns false when the id is not currently dead", async () => {
+      const m = stubDeleteById(0);
+      const q = createPgQueue(m.pool as unknown as Pool, async () => undefined);
+
+      expect(await q.deleteDeadLetterJob(9)).toBe(false);
+      expect(m.calls[0]?.params).toEqual([9]);
+    });
+
+    it("purgeDeadLetterJobs deletes every dead row with no id param and returns the count", async () => {
+      const m = stubPurge(3);
+      const q = createPgQueue(m.pool as unknown as Pool, async () => undefined);
+
+      expect(await q.purgeDeadLetterJobs()).toBe(3);
+      expect(m.calls).toHaveLength(1);
+      expect(m.calls[0]?.params).toEqual([]);
+    });
+
+    it("purgeDeadLetterJobs returns 0 when nothing was dead", async () => {
+      const m = stubPurge(0);
+      const q = createPgQueue(m.pool as unknown as Pool, async () => undefined);
+
+      expect(await q.purgeDeadLetterJobs()).toBe(0);
+    });
+
+    it("REGRESSION: purgeDeadLetterJobs falls back to 0 (not null/undefined/NaN) when the driver omits rowCount", async () => {
+      // Exercises the `?? 0` branch specifically: a plain rowCount:0 response takes the SAME branch as a null
+      // rowCount here (0 ?? 0 === 0), so it doesn't prove the nullish fallback actually fires. Returning
+      // rowCount: null (a real pg driver possibility for some statement shapes) does.
+      const m = stubPurge(null);
+      const q = createPgQueue(m.pool as unknown as Pool, async () => undefined);
+
+      expect(await q.purgeDeadLetterJobs()).toBe(0);
+    });
+  });
+
   it("REGRESSION: releases the reserved background slot when a background claim query rejects (#selfhost-bg-slot-leak)", async () => {
     // A raw pool failure during the BACKGROUND claim (a dropped connection / lock timeout — the exact failures
     // pump() is documented to catch) rejects out of claimNext(), which runs OUTSIDE processOne's try/finally, so

--- a/test/unit/selfhost-queue-common.test.ts
+++ b/test/unit/selfhost-queue-common.test.ts
@@ -31,6 +31,9 @@ import {
   queueDeadLetterAutoRetryMaxExtraAttempts,
   queueDeadLetterPageFromBinding,
   queueDeadLetterReviveIntervalMs,
+  queueDeleteDeadLetterJobViaBinding,
+  queuePurgeDeadLetterJobsViaBinding,
+  queueReplayDeadLetterJobViaBinding,
   queueProcessingTimeoutMs,
   queueRecoveryJitterMs,
   queueSnapshotBacklog,
@@ -175,6 +178,54 @@ describe("self-host queue common helpers", () => {
     } as unknown as Queue;
 
     await expect(queueDeadLetterPageFromBinding(binding, 25, 0)).resolves.toEqual({ items, total: 1 });
+  });
+
+  it("replays/deletes/purges dead-letter jobs only via a binding that exposes the admin surface (#2215)", async () => {
+    const bareBinding = { async send() {}, async sendBatch() {} } as unknown as Queue;
+    await expect(queueReplayDeadLetterJobViaBinding(bareBinding, 1)).resolves.toBeNull();
+    await expect(queueDeleteDeadLetterJobViaBinding(bareBinding, 1)).resolves.toBeNull();
+    await expect(queuePurgeDeadLetterJobsViaBinding(bareBinding)).resolves.toBeNull();
+
+    const syncBinding = {
+      async send() {},
+      async sendBatch() {},
+      replayDeadLetterJob: (id: number) => {
+        expect(id).toBe(42);
+        return true;
+      },
+      deleteDeadLetterJob: (id: number) => {
+        expect(id).toBe(42);
+        return false;
+      },
+      purgeDeadLetterJobs: () => 3,
+    } as unknown as Queue;
+    await expect(queueReplayDeadLetterJobViaBinding(syncBinding, 42)).resolves.toBe(true);
+    await expect(queueDeleteDeadLetterJobViaBinding(syncBinding, 42)).resolves.toBe(false);
+    await expect(queuePurgeDeadLetterJobsViaBinding(syncBinding)).resolves.toBe(3);
+
+    const asyncBinding = {
+      async send() {},
+      async sendBatch() {},
+      replayDeadLetterJob: async () => false,
+      deleteDeadLetterJob: async () => true,
+      purgeDeadLetterJobs: async () => 0,
+    } as unknown as Queue;
+    await expect(queueReplayDeadLetterJobViaBinding(asyncBinding, 7)).resolves.toBe(false);
+    await expect(queueDeleteDeadLetterJobViaBinding(asyncBinding, 7)).resolves.toBe(true);
+    await expect(queuePurgeDeadLetterJobsViaBinding(asyncBinding)).resolves.toBe(0);
+
+    // A binding that returns the wrong result TYPE (a future bug, or a misbehaving plugin binding) is treated
+    // the same as "admin unavailable" -- null -- not coerced/trusted as if it were a real boolean/count.
+    const malformedBinding = {
+      async send() {},
+      async sendBatch() {},
+      replayDeadLetterJob: () => "yes",
+      deleteDeadLetterJob: () => 1,
+      purgeDeadLetterJobs: () => "three",
+    } as unknown as Queue;
+    await expect(queueReplayDeadLetterJobViaBinding(malformedBinding, 1)).resolves.toBeNull();
+    await expect(queueDeleteDeadLetterJobViaBinding(malformedBinding, 1)).resolves.toBeNull();
+    await expect(queuePurgeDeadLetterJobsViaBinding(malformedBinding)).resolves.toBeNull();
   });
 
   it("identifies GitHub-budget background jobs without pre-yielding fresh webhooks or manual re-gates", () => {

--- a/test/unit/selfhost-sqlite-queue.test.ts
+++ b/test/unit/selfhost-sqlite-queue.test.ts
@@ -1782,6 +1782,108 @@ describe("createSqliteQueue (durable #980)", () => {
     });
   });
 
+  describe("replay/delete/purge dead-letter jobs (#2215)", () => {
+    it("replayDeadLetterJob requeues an existing dead row with a fresh retry budget", () => {
+      const driver = makeDriver();
+      const q = createSqliteQueue(driver, async () => undefined);
+      driver.query(
+        "INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at, last_error, dead_at) VALUES (?, 'dead', 3, 0, 1000, 'boom', 5000)",
+        [JSON.stringify(msg("agent-regate-pr"))],
+      );
+      expect(q.replayDeadLetterJob(1)).toBe(true);
+      const row = driver.query("SELECT status, attempts, last_error, dead_at, run_after FROM _selfhost_jobs WHERE id=1", [])
+        .rows[0] as { status: string; attempts: number; last_error: string | null; dead_at: number | null; run_after: number };
+      expect(row.status).toBe("pending");
+      expect(row.attempts).toBe(0);
+      expect(row.last_error).toBeNull();
+      expect(row.dead_at).toBeNull();
+      expect(row.run_after).toBeGreaterThan(0);
+    });
+
+    it("replayDeadLetterJob returns false for a non-existent id", () => {
+      const driver = makeDriver();
+      const q = createSqliteQueue(driver, async () => undefined);
+      expect(q.replayDeadLetterJob(999)).toBe(false);
+    });
+
+    it("replayDeadLetterJob returns false and leaves a non-dead row untouched", () => {
+      const driver = makeDriver();
+      const q = createSqliteQueue(driver, async () => undefined);
+      driver.query(
+        "INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at) VALUES (?, 'pending', 0, 42, 1000)",
+        [JSON.stringify(msg("agent-regate-pr"))],
+      );
+      expect(q.replayDeadLetterJob(1)).toBe(false);
+      const row = driver.query("SELECT status, run_after FROM _selfhost_jobs WHERE id=1", []).rows[0] as {
+        status: string;
+        run_after: number;
+      };
+      expect(row.status).toBe("pending");
+      expect(row.run_after).toBe(42);
+    });
+
+    it("deleteDeadLetterJob removes an existing dead row", () => {
+      const driver = makeDriver();
+      const q = createSqliteQueue(driver, async () => undefined);
+      driver.query(
+        "INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at, dead_at) VALUES (?, 'dead', 1, 0, 1000, 1000)",
+        [JSON.stringify(msg("agent-regate-pr"))],
+      );
+      expect(q.deleteDeadLetterJob(1)).toBe(true);
+      expect(driver.query("SELECT id FROM _selfhost_jobs WHERE id=1", []).rows).toEqual([]);
+    });
+
+    it("deleteDeadLetterJob returns false for a non-existent id", () => {
+      const driver = makeDriver();
+      const q = createSqliteQueue(driver, async () => undefined);
+      expect(q.deleteDeadLetterJob(999)).toBe(false);
+    });
+
+    it("deleteDeadLetterJob returns false and does not delete a non-dead row", () => {
+      const driver = makeDriver();
+      const q = createSqliteQueue(driver, async () => undefined);
+      driver.query(
+        "INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at) VALUES (?, 'processing', 0, 0, 1000)",
+        [JSON.stringify(msg("agent-regate-pr"))],
+      );
+      expect(q.deleteDeadLetterJob(1)).toBe(false);
+      expect(driver.query("SELECT id FROM _selfhost_jobs WHERE id=1", []).rows).toHaveLength(1);
+    });
+
+    it("purgeDeadLetterJobs deletes every dead row and leaves non-dead rows untouched", () => {
+      const driver = makeDriver();
+      const q = createSqliteQueue(driver, async () => undefined);
+      for (let i = 0; i < 3; i++) {
+        driver.query(
+          "INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at, dead_at) VALUES (?, 'dead', 0, 0, ?, ?)",
+          [JSON.stringify(msg("agent-regate-pr")), 1000 + i, 1000 + i],
+        );
+      }
+      driver.query(
+        "INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at) VALUES (?, 'pending', 0, 0, 2000)",
+        [JSON.stringify(msg("agent-regate-pr"))],
+      );
+      driver.query(
+        "INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at) VALUES (?, 'processing', 0, 0, 3000)",
+        [JSON.stringify(msg("agent-regate-pr"))],
+      );
+      expect(q.purgeDeadLetterJobs()).toBe(3);
+      expect((driver.query("SELECT COUNT(*) AS c FROM _selfhost_jobs WHERE status='dead'", []).rows[0] as { c: number }).c).toBe(0);
+      expect((driver.query("SELECT COUNT(*) AS c FROM _selfhost_jobs WHERE status!='dead'", []).rows[0] as { c: number }).c).toBe(2);
+    });
+
+    it("purgeDeadLetterJobs returns 0 and touches nothing when there are no dead rows", () => {
+      const driver = makeDriver();
+      const q = createSqliteQueue(driver, async () => undefined);
+      driver.query(
+        "INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at) VALUES (?, 'pending', 0, 0, 1000)",
+        [JSON.stringify(msg("agent-regate-pr"))],
+      );
+      expect(q.purgeDeadLetterJobs()).toBe(0);
+      expect((driver.query("SELECT COUNT(*) AS c FROM _selfhost_jobs", []).rows[0] as { c: number }).c).toBe(1);
+    });
+  });
+
   it("retries then dead-letters after maxRetries", async () => {
     const driver = makeDriver();
     let calls = 0;


### PR DESCRIPTION
## Summary

- Follow-up to #2921/#2214 (the read-only DLQ table view). Adds the action half per #2215: per-row Replay and Delete buttons, and a bulk "Purge all" action, all on the same operator-only dashboard panel.
- Backend: `replayDeadLetterJob`/`deleteDeadLetterJob`/`purgeDeadLetterJobs` added to both queue engines (`src/selfhost/sqlite-queue.ts`, `src/selfhost/pg-queue.ts`), mirroring #2214's `listDeadLetterJobs`/`deadCount` pattern exactly (one shared implementation reused via property shorthand on both the `.binding` mirror and the returned queue object — no duplicate logic). Replay gives the job a **fresh** retry budget (`attempts=0`, clears `last_error`/`dead_at`) since it's an operator's conscious one-off decision, deliberately distinct from the automatic `reviveDeadLetterJobs` sweep, which preserves `attempts` under a ceiling to avoid an unsupervised retry loop.
- Routes: `POST /v1/app/selfhost/queue/dead/:id/replay`, `DELETE /v1/app/selfhost/queue/dead/:id`, `DELETE /v1/app/selfhost/queue/dead` (purge-all) — all `requireAppRole(c, ["operator"])`-gated, mapping `null → 501` (admin unavailable), `false → 404` (id not found/not dead), success → `200`. Every completed action is audit-logged (`operator.dlq_job_replayed` / `operator.dlq_job_deleted` / `operator.dlq_purged`) with the real authenticated actor, mirroring the existing `/v1/app/kill-switch` audit pattern.
- UI: per-row Replay/Delete `StateActionButton`s (disabled only for the row being acted on) and a header "Purge all" action, **both Delete and Purge-all gated behind an `AlertDialog` confirmation** (destructive-styled, Cancel/Confirm) since both are permanent, irreversible mutations.
- This PR was built by a background multi-agent workflow (parallel backend/routes/UI implementation, then an adversarial review pass across correctness, destructive-action safety, and test-coverage lenses) — I independently re-verified everything myself afterward (see Validation) and fixed the two real issues the review surfaced before pushing.

## Scope

- [x] Conventional Commit title.
- [x] Focused — backend actions + routes + UI for one feature, no unrelated changes.
- [x] Follows `CONTRIBUTING.md`, no `site/`/`CNAME`/`lovable` changes.
- [x] Linked context: part of #1208, action-half of #2215 (read-only half was #2214/#2921).

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` (not run — no `.github/workflows/**` changes)
- [x] `npm run typecheck`
- [x] Full affected-test-file run (I re-ran this myself after the workflow, and again after fixing the review findings): `selfhost-sqlite-queue.test.ts` (131), `selfhost-pg-queue.test.ts` (114), `selfhost-queue-common.test.ts` (79), `routes-selfhost-dead-letter-queue.test.ts` (30), and the UI `dead-letter-queue-panel.test.tsx` (27) — **381/381 passing**. Verified branch coverage directly against `coverage/lcov.info` for every new line in `sqlite-queue.ts`/`pg-queue.ts`/`routes.ts` — no gaps outside pre-existing, already-`/* v8 ignore next */`-annotated branches unrelated to this diff.
- [ ] `npm run test:workers` (not run — no Workers-pool-specific code touched)
- [ ] `npm run build:mcp` / `npm run test:mcp-pack` (not run — no `packages/gittensory-mcp` changes)
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] New behavior has unit tests for new branches: replay/delete success and not-found-or-not-dead paths (both backends), purge with a mix of dead/non-dead rows, the `rowCount ?? 0` nullish-fallback branch specifically (both a plain `0` and an explicit driver-omitted `null`, since those collapse to the same boolean outcome and only the latter proves the fallback fires), route-level 400/401/403/404/501/200 for all three routes plus an audit-row assertion, and UI confirm/cancel/success/failure for both Delete and Purge (including the purge-success singular vs. plural toast wording).

## Safety

- [x] No secrets/wallet/hotkey/trust-score/reward data exposed — same private operator-only surface as #2921.
- [x] Public GitHub text unaffected.
- [x] Auth: all three routes have explicit 401 (unauthenticated) and 403 (non-operator) tests.
- [x] API/OpenAPI updated (three new paths registered in `src/openapi/spec.ts` with their real 400/401/403/404/501 outcomes, not just 200/401; regenerated `openapi.json`).
- [x] UI uses live API data via `apiFetch`/`useApiResource`, real loading/empty/error states.
- [ ] UI Evidence screenshots — see note below.
- [x] **Destructive-action safety, specifically reviewed**: both Delete (single job) and Purge all (every dead job) require an explicit `AlertDialog` confirmation before the mutating call fires — this was NOT true in the workflow's first draft (Delete fired immediately) and was the one real defect its own adversarial review caught; fixed before this push. All three backend mutations are atomic, single SQL statements scoped to `status='dead'`, so a concurrent duplicate action just returns `false`/`0` rather than corrupting state.
- [x] No changelog edit.

## UI Evidence

Verified live via a local dev server (Chrome preview) signed in through the sanctioned `?preview=1` local-preview session, with the dashboard/DLQ endpoints stubbed via a `window.fetch` override: confirmed the "Actions" column renders Replay/Delete per row and "Purge all" in the header; confirmed clicking a row's Delete button opens an `AlertDialog` reading "Delete job #<id>?" with Cancel/destructive-Delete, matching the same pattern already used for Purge-all. I don't have a mechanism in this environment to upload screenshots to a GitHub-hosted URL for embedding in this table (same limitation as prior PRs) — happy to attach as a follow-up comment if there's a preferred upload path, or a maintainer can pull the branch and check `/app/operator?preview=1` directly.

## Notes

- Per the issue's own scope note ("This is the action half only... scoped to the action controls + optimistic refresh"), all three actions call `resource.reload()`/`onReload()` after a successful mutation rather than mutating local state directly, to avoid a stale-page bug on the current DLQ page.

Closes #2215 