### PR TITLE
fix(miner): reject invalid dependsOn refs in plan store saves

### DIFF
--- a/packages/gittensory-miner/lib/plan-store.js
+++ b/packages/gittensory-miner/lib/plan-store.js
@@ -84,6 +84,11 @@ function validatePlanDag(plan) {
     if (seenStepIds.has(step.id)) throw new Error("invalid_plan");
     seenStepIds.add(step.id);
   }
+  for (const step of plan.steps) {
+    for (const dep of step.dependsOn) {
+      if (dep === step.id || !seenStepIds.has(dep)) throw new Error("invalid_plan");
+    }
+  }
   return plan;
 }
 

--- a/test/unit/miner-plan-store.test.ts
+++ b/test/unit/miner-plan-store.test.ts
@@ -98,6 +98,21 @@ describe("gittensory-miner plan store (#2318)", () => {
     ).toThrow("invalid_plan");
   });
 
+  it("rejects unknown or self-referential dependsOn entries on save", () => {
+    const store = tempStore();
+    const pendingStep = { id: "a", title: "A", dependsOn: [] as string[], status: "pending" as const, attempts: 0, maxAttempts: 1 };
+    expect(() =>
+      store.savePlan("missing-dep", {
+        steps: [{ ...pendingStep, dependsOn: ["ghost"] }],
+      }),
+    ).toThrow("invalid_plan");
+    expect(() =>
+      store.savePlan("self-dep", {
+        steps: [{ ...pendingStep, dependsOn: ["a"] }],
+      }),
+    ).toThrow("invalid_plan");
+  });
+
   it("rejects a corrupted plan blob on load instead of returning a malformed plan", () => {
     const store = tempStore();
     store.savePlan("p1", PLAN);


### PR DESCRIPTION
## Summary

- Extend `validatePlanDag` to reject plans whose steps reference unknown or self-referential `dependsOn` ids.
- Prevents dangling dependency edges from being persisted locally and breaking stateless plan advancement.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] Focused on plan-store validation only — no unrelated miner CLI or UI changes.

## Validation

- [ ] `npm run test:ci` locally — CI will run the full gate on push.
- [x] Unit tests cover unknown and self-referential `dependsOn` rejection on save.

## Safety

- [x] No secrets, wallet details, hotkeys, or private scoring output in code or PR text.
- [x] Deterministic, read/write-local only: no network calls.

## UI Evidence

Not applicable — miner library only.

## Notes

Follow-up to #2949 duplicate step-id validation in the same foundation plan store (#2318).
