### PR TITLE
fix(miner): treat null repo filter as unscoped in event ledger reads

### DIFF
--- a/packages/gittensory-miner/lib/event-ledger.d.ts
+++ b/packages/gittensory-miner/lib/event-ledger.d.ts
@@ -14,7 +14,7 @@ export type AppendEventInput = {
 };
 
 export type ReadEventsFilter = {
-  repoFullName?: string;
+  repoFullName?: string | null;
   since?: number;
 };
 

--- a/packages/gittensory-miner/lib/event-ledger.js
+++ b/packages/gittensory-miner/lib/event-ledger.js
@@ -63,6 +63,12 @@ function normalizeOptionalSince(since) {
   return since;
 }
 
+/** Read-filter repo scope: omitted/nullish → unscoped (all events); otherwise a validated `owner/repo`. */
+function normalizeReadRepoFilter(repoFullName) {
+  if (repoFullName === undefined || repoFullName === null) return undefined;
+  return normalizeOptionalRepoFullName(repoFullName);
+}
+
 // Serialize an audit payload, enforcing that it round-trips through JSON VERBATIM. A plain JSON.stringify would
 // silently drop `undefined`/function/symbol values and coerce `NaN`/`Infinity` to `null` (and throw on BigInt or a
 // cycle), so a read-back would not equal the appended event. We reject any such lossy payload outright — an audit
@@ -159,9 +165,7 @@ export function initEventLedger(dbPath = resolveEventLedgerDbPath()) {
       }
     },
     readEvents(filter = {}) {
-      const repoFullName = filter.repoFullName === undefined
-        ? undefined
-        : normalizeOptionalRepoFullName(filter.repoFullName);
+      const repoFullName = normalizeReadRepoFilter(filter.repoFullName);
       // `since` returns events with a seq STRICTLY greater than it — the "give me everything after the last seq I
       // saw" polling shape.
       const since = normalizeOptionalSince(filter.since);

--- a/test/unit/miner-event-ledger.test.ts
+++ b/test/unit/miner-event-ledger.test.ts
@@ -87,6 +87,24 @@ describe("gittensory-miner event ledger (#2290)", () => {
     ]);
   });
 
+  it("treats a null repo filter as unscoped and returns all events", () => {
+    const ledger = tempLedger();
+    ledger.appendEvent({ type: "plan_built", payload: {} });
+    ledger.appendEvent({ type: "discovered_issue", repoFullName: "o/a", payload: {} });
+    ledger.appendEvent({ type: "pr_prepared", repoFullName: "o/b", payload: {} });
+    const events = ledger.readEvents({ repoFullName: null });
+    expect(events).toHaveLength(3);
+    expect(events.map((entry) => entry.type)).toEqual(["plan_built", "discovered_issue", "pr_prepared"]);
+  });
+
+  it("keeps a null repo filter unscoped when combined with since", () => {
+    const ledger = tempLedger();
+    ledger.appendEvent({ type: "discovered_issue", repoFullName: "o/a", payload: {} }); // seq 1
+    ledger.appendEvent({ type: "plan_built", payload: {} }); // seq 2
+    ledger.appendEvent({ type: "pr_prepared", repoFullName: "o/a", payload: {} }); // seq 3
+    expect(ledger.readEvents({ repoFullName: null, since: 1 }).map((entry) => entry.seq)).toEqual([2, 3]);
+  });
+
   it("filters by `since` (strictly greater seq), and combines with repoFullName", () => {
     const ledger = tempLedger();
     ledger.appendEvent({ type: "discovered_issue", repoFullName: "o/a", payload: {} }); // seq 1


### PR DESCRIPTION
## Summary

- Treat a null `repoFullName` read filter as unscoped so `readEvents` returns every event, matching governor-ledger semantics.
- Prevents `{ repoFullName: null }` from silently narrowing results to global-scope rows only.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] Focused on event-ledger read filtering only — no unrelated miner CLI or UI changes.

## Validation

- [ ] `npm run test:ci` locally — CI will run the full gate on push.
- [x] Unit tests cover null repo filter alone and combined with `since`.

## Safety

- [x] No secrets, wallet details, hotkeys, or private scoring output in code or PR text.
- [x] Deterministic, read/write-local only: no network calls.

## UI Evidence

Not applicable — miner library only.

## Notes

Append-time repo scope is unchanged: omitted/nullish event scopes still persist as `NULL`. Only read-filter normalization is split out.
