### PR TITLE
fix(enrichment): gate EOL analysis on the analyzer's own Dockerfile predicate

### DIFF
--- a/review-enrichment/src/analyzers/eol-check.ts
+++ b/review-enrichment/src/analyzers/eol-check.ts
@@ -42,7 +42,10 @@ function leadingVersion(value: string): string | null {
   return /^v?(\d+(?:\.\d+)*)/.exec(value.trim())?.[1] ?? null;
 }
 
-function isDockerfile(path: string): boolean {
+/** True for a Dockerfile the FROM-pin parser understands: the literal `Dockerfile`, or a `*.dockerfile`
+ *  (e.g. `web.dockerfile`). Exported so the scheduler's runtime-pin gate shares ONE predicate and cannot
+ *  drift from what this analyzer actually parses. */
+export function isDockerfile(path: string): boolean {
   const base = path.split("/").pop() ?? path;
   return base === "Dockerfile" || /\.dockerfile$/i.test(base);
 }

--- a/review-enrichment/src/scheduler.ts
+++ b/review-enrichment/src/scheduler.ts
@@ -4,6 +4,7 @@ import {
   ANALYZER_NAMES,
   getAnalyzerDescriptor,
 } from "./analyzers/registry.js";
+import { isDockerfile } from "./analyzers/eol-check.js";
 import type {
   AnalyzerCostClass,
   AnalyzerDescriptor,
@@ -400,9 +401,8 @@ function historyCanRunWithoutGitHub(
 
 function isRuntimePinPath(path: string): boolean {
   const basename = path.split("/").pop() ?? path;
-  return (
-    /^Dockerfile(?:\..*)?$/.test(basename) ||
-    basename === ".nvmrc" ||
-    basename === "go.mod"
-  );
+  // Share the eol analyzer's own Dockerfile predicate so the gate can't skip a file the analyzer would
+  // parse. The prior bespoke `/^Dockerfile(?:\..*)?$/` missed `*.dockerfile` (e.g. web.dockerfile), silently
+  // dropping eol analysis for it even though isDockerfile() handles it.
+  return isDockerfile(path) || basename === ".nvmrc" || basename === "go.mod";
 }

--- a/review-enrichment/test/scheduler.test.ts
+++ b/review-enrichment/test/scheduler.test.ts
@@ -300,3 +300,30 @@ test("lockfileDrift runs for mixed-case lockfile paths", async () => {
   assert.equal(brief.analyzerStatus.lockfileDrift, "ok");
   assert.notEqual(brief.telemetry.analyzers.lockfileDrift.skipReason, "no_lockfile");
 });
+
+test("eol runs for a *.dockerfile path (gate shares the analyzer's Dockerfile predicate)", async () => {
+  let eolRan = false;
+  const brief = await buildBrief(
+    {
+      repoFullName: "JSONbored/gittensory",
+      prNumber: 2940,
+      analyzers: ["eol"],
+      files: [
+        {
+          path: "deploy/web.dockerfile",
+          patch: "@@ -1,0 +1,1 @@\n+FROM node:16-alpine",
+        },
+      ],
+    },
+    {
+      eol: async () => {
+        eolRan = true;
+        return [];
+      },
+    },
+  );
+
+  assert.equal(eolRan, true);
+  assert.equal(brief.analyzerStatus.eol, "ok");
+  assert.notEqual(brief.telemetry.analyzers.eol.skipReason, "no_runtime_pin");
+});


### PR DESCRIPTION
## Summary

The review-enrichment scheduler decides whether to run the EOL (end-of-life runtime) analyzer with `isRuntimePinPath()` in `review-enrichment/src/scheduler.ts` — when no changed path looks like a runtime pin it skips the analyzer with `skipReason: "no_runtime_pin"`. That gate recognized Dockerfiles with a bespoke `/^Dockerfile(?:\..*)?$/` regex, but the EOL analyzer's own `isDockerfile()` (in `analyzers/eol-check.ts`) matches `Dockerfile` **and** `*.dockerfile`. The two disagreed on conventionally-named files:

| basename | analyzer `isDockerfile` | gate `isRuntimePinPath` (before) |
|---|---|---|
| `Dockerfile` | ✅ | ✅ |
| `web.dockerfile` | ✅ | ❌ (false negative — EOL silently skipped) |
| `Dockerfile.prod` | ❌ | ✅ (benign wasted run — analyzer parses nothing) |

So a PR whose only runtime-pin file is `web.dockerfile` / `api.dockerfile` (e.g. adding `FROM node:16-alpine`, already past EOL) had EOL analysis skipped entirely, even though the analyzer is fully capable of parsing it.

This exports `isDockerfile` and has the gate share the exact predicate the analyzer parses with, so the gate can never skip a Dockerfile the analyzer would handle — and the two can't re-drift. Adds a scheduler test that EOL runs for a `*.dockerfile` path (mirroring the existing "runs for mixed-case workflow/lockfile paths" tests).

No linked issue: issue creation on this repo is restricted to collaborators, and this is a small, self-contained correctness fix (share one predicate between a gate and the analyzer it gates) whose rationale is self-evident from the diff.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- The full `npm run test:ci` aggregate ran green (including `rees:test`, the review-enrichment build + node test suite: 540 passing) plus `npm audit --audit-level=moderate` (0 vulnerabilities). The changed lines are exercised by the new scheduler test; this change is under `review-enrichment/**`, which Codecov does not measure (its own node test suite is the gate).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

Pure analyzer-scheduling logic in the review-enrichment package; no auth/CORS/session surface, no API/OpenAPI shape change, no UI. The `Safety` boxes are checked on that basis.

## Notes

- Exports the existing `isDockerfile` predicate and reuses it in the scheduler gate (single source of truth); no behavior change beyond correctly gating `*.dockerfile` in and the benign `Dockerfile.prod` wasted-run out. No schema, migration, OpenAPI, wrangler, or generated-artifact impact.
