### PR TITLE
fix(agent): preserve scoped pending action autonomy

### DIFF
--- a/src/services/agent-action-executor.ts
+++ b/src/services/agent-action-executor.ts
@@ -687,6 +687,7 @@ async function performAction(env: Env, ctx: AgentActionExecutionContext, action:
 /** The execute-time payload of a planned action, persisted so the approval queue (#779) can run it on accept. */
 export function actionParams(action: PlannedAgentAction): AgentPendingActionParams {
   return {
+    ...(action.autonomyClass !== undefined ? { autonomyClass: action.autonomyClass } : {}),
     ...(action.label !== undefined ? { label: action.label } : {}),
     ...(action.labelOp !== undefined ? { labelOp: action.labelOp } : {}),
     ...(action.comment !== undefined ? { comment: action.comment } : {}),

--- a/src/types.ts
+++ b/src/types.ts
@@ -984,6 +984,10 @@ export type AutoMaintainPolicy = {
 /** The payload needed to execute a staged action when a maintainer accepts it (#779). Only the field for the
  *  action's class is set, mirroring PlannedAgentAction. */
 export type AgentPendingActionParams = {
+  // #label-scoping: a staged `label` action can be governed by a narrower purpose class (for example `close`
+  // for enforcement metadata, or `review_state_label` for disposition labels). Persist it so accept-time replay
+  // re-checks the same autonomy class that authorized staging, not the generic label dial.
+  autonomyClass?: AgentActionClass;
   label?: string;
   // Flag-then-close double-check: whether a `label` action ADDs (default/absent) or REMOVEs its label, plus an
   // optional comment posted alongside the label mutation. Persisted so a staged label action replays faithfully.

--- a/test/unit/agent-action-executor.test.ts
+++ b/test/unit/agent-action-executor.test.ts
@@ -105,6 +105,16 @@ describe("executeAgentMaintenanceActions (#778 gate stack)", () => {
     expect(actionParams(merge)).toEqual({ mergeMethod: "squash" });
   });
 
+  it("#label-scoping: actionParams preserves autonomyClass so pending replay re-checks the original scope", () => {
+    const scopedLabel: PlannedAgentAction = { actionClass: "label", autonomyClass: "close", requiresApproval: true, reason: "blacklisted contributor", label: "slop", labelOp: "add" };
+
+    const persisted = actionParams(scopedLabel);
+    const replayed = pendingActionToPlanned({ actionClass: "label", params: persisted, reason: scopedLabel.reason });
+
+    expect(persisted).toEqual({ autonomyClass: "close", label: "slop", labelOp: "add" });
+    expect(replayed).toMatchObject({ actionClass: "label", autonomyClass: "close", requiresApproval: false, reason: "blacklisted contributor", label: "slop", labelOp: "add" });
+  });
+
   it("LIVE: executes each action class via its GitHub primitive and audits completed", async () => {
     const env = createTestEnv({});
     const outcomes = await executeAgentMaintenanceActions(env, ctx(), [label, requestChanges, approve, merge, close, updateBranch]);

--- a/test/unit/agent-approval-queue.test.ts
+++ b/test/unit/agent-approval-queue.test.ts
@@ -933,6 +933,7 @@ describe("agent approval queue (#779)", () => {
 
   it("actionParams extracts only the field for the action class", () => {
     expect(actionParams({ actionClass: "label", requiresApproval: false, reason: "x", label: "L" })).toEqual({ label: "L" });
+    expect(actionParams({ actionClass: "label", autonomyClass: "review_state_label", requiresApproval: false, reason: "x", label: "L" })).toEqual({ autonomyClass: "review_state_label", label: "L" });
     expect(actionParams({ actionClass: "request_changes", requiresApproval: false, reason: "x", reviewBody: "B" })).toEqual({ reviewBody: "B" });
     expect(actionParams({ actionClass: "merge", requiresApproval: false, reason: "x", mergeMethod: "rebase" })).toEqual({ mergeMethod: "rebase" });
     expect(actionParams({ actionClass: "close", requiresApproval: false, reason: "x", closeComment: "C" })).toEqual({ closeComment: "C" });


### PR DESCRIPTION
### Motivation

- A `PlannedAgentAction.autonomyClass` field was added so label actions can be authorized under a different autonomy class (e.g. `close` or `review_state_label`), but that scope was not persisted through the approval queue, causing staged label actions to be rechecked against the wrong autonomy class at accept-time.

### Description

- Add `autonomyClass?: AgentActionClass` to `AgentPendingActionParams` so the governing scope can be persisted. (`src/types.ts`)
- Serialize `autonomyClass` from `PlannedAgentAction` in `actionParams()` so staged rows include the scope. (`src/services/agent-action-executor.ts`)
- Add regression tests that assert `actionParams()` preserves `autonomyClass` through `pendingActionToPlanned()` and that `actionParams()` extracts `autonomyClass` for scoped label cases. (`test/unit/agent-action-executor.test.ts`, `test/unit/agent-approval-queue.test.ts`)

### Testing

- Ran `git diff --check` with no issues reported. (success)
- Ran `npm run typecheck` and it completed successfully. (success)
- Ran targeted unit tests: `npx vitest run test/unit/agent-action-executor.test.ts -t "actionParams preserves autonomyClass"` and `npx vitest run test/unit/agent-approval-queue.test.ts -t "actionParams extracts"`, both passed. (success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48ad65733c832c98f10a21eb0b20aa)