### PR TITLE
fix(enrichment): accept current REES analyzers (include approvalIntegrity)

### DIFF
--- a/src/review/enrichment-analyzer-names.ts
+++ b/src/review/enrichment-analyzer-names.ts
@@ -23,6 +23,12 @@ export const REES_ANALYZER_NAMES = [
   "nativeBuild",
   "history",
   "docCommentDrift",
+  "duplication",
+  "churnHotspot",
+  "blameLink",
+  "approvalIntegrity",
+  "ciCheckSignals",
+  "undocumentedExport",
 ] as const;
 
 export type ReesAnalyzerName = (typeof REES_ANALYZER_NAMES)[number];

--- a/test/unit/enrichment-wire.test.ts
+++ b/test/unit/enrichment-wire.test.ts
@@ -615,10 +615,10 @@ describe("resolveReesAnalyzers", () => {
     warnSpy.mockRestore();
   });
 
-  it("accepts docCommentDrift as a configured analyzer subset", () => {
+  it("accepts approvalIntegrity as a configured analyzer subset", () => {
     expect(
-      resolveReesAnalyzers(env({ REES_ANALYZERS: "docCommentDrift" })),
-    ).toEqual(["docCommentDrift"]);
+      resolveReesAnalyzers(env({ REES_ANALYZERS: "approvalIntegrity" })),
+    ).toEqual(["approvalIntegrity"]);
   });
 
   it("accepts every REES analyzer currently registered by the service", () => {
@@ -626,7 +626,7 @@ describe("resolveReesAnalyzers", () => {
       resolveReesAnalyzers(
         env({
           REES_ANALYZERS:
-            "dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift",
+            "dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity,ciCheckSignals,undocumentedExport",
         }),
       ),
     ).toEqual([
@@ -649,6 +649,12 @@ describe("resolveReesAnalyzers", () => {
       "nativeBuild",
       "history",
       "docCommentDrift",
+      "duplication",
+      "churnHotspot",
+      "blameLink",
+      "approvalIntegrity",
+      "ciCheckSignals",
+      "undocumentedExport",
     ]);
   });
 


### PR DESCRIPTION
### Motivation
- Keep the Worker-side REES analyzer allowlist in sync with the REES registry and generated docs so explicit `REES_ANALYZERS` operator configurations (e.g. `approvalIntegrity`) are honored rather than dropped.

### Description
- Add the currently-registered analyzer keys (including `approvalIntegrity`, `duplication`, `churnHotspot`, `blameLink`, `ciCheckSignals`, and `undocumentedExport`) to the canonical Worker-side analyzer registry in `src/review/enrichment-analyzer-names.ts`.
- Update the regression coverage in `test/unit/enrichment-wire.test.ts` to assert that `approvalIntegrity` is accepted as an explicit analyzer and that the full current analyzer list resolves intact.

### Testing
- Ran `git diff --check` and it reported no issues. (passed)
- Ran targeted unit tests with `npx vitest run test/unit/enrichment-wire.test.ts test/unit/review-enrichment-config.test.ts` and they passed (all tests in those files succeeded).
- Ran `npm run typecheck` (TS `tsc --noEmit`) and it completed successfully. 
- Started `npm run test:coverage` (unsharded coverage run) but the full coverage job did not complete within the session time; targeted unit tests and typecheck passed and cover the changed logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48ae1405b4832ca379b5740feef59a)