### PR TITLE
fix(review): include undocumentedExport in REES analyzer allowlist

### DIFF
--- a/src/review/enrichment-analyzer-names.ts
+++ b/src/review/enrichment-analyzer-names.ts
@@ -23,6 +23,7 @@ export const REES_ANALYZER_NAMES = [
   "nativeBuild",
   "history",
   "docCommentDrift",
+  "undocumentedExport",
 ] as const;
 
 export type ReesAnalyzerName = (typeof REES_ANALYZER_NAMES)[number];

--- a/test/unit/enrichment-wire.test.ts
+++ b/test/unit/enrichment-wire.test.ts
@@ -615,10 +615,13 @@ describe("resolveReesAnalyzers", () => {
     warnSpy.mockRestore();
   });
 
-  it("accepts docCommentDrift as a configured analyzer subset", () => {
+  it("accepts newer github-light analyzers as configured analyzer subsets", () => {
     expect(
       resolveReesAnalyzers(env({ REES_ANALYZERS: "docCommentDrift" })),
     ).toEqual(["docCommentDrift"]);
+    expect(
+      resolveReesAnalyzers(env({ REES_ANALYZERS: "undocumentedExport" })),
+    ).toEqual(["undocumentedExport"]);
   });
 
   it("accepts every REES analyzer currently registered by the service", () => {
@@ -626,7 +629,7 @@ describe("resolveReesAnalyzers", () => {
       resolveReesAnalyzers(
         env({
           REES_ANALYZERS:
-            "dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift",
+            "dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift,undocumentedExport",
         }),
       ),
     ).toEqual([
@@ -649,6 +652,7 @@ describe("resolveReesAnalyzers", () => {
       "nativeBuild",
       "history",
       "docCommentDrift",
+      "undocumentedExport",
     ]);
   });
 


### PR DESCRIPTION
### Motivation
- The new `undocumentedExport` analyzer was registered in the enrichment service but the engine-side allowlist omitted it, causing explicit `REES_ANALYZERS=undocumentedExport` to be treated as invalid and dropped before requests reached REES.
- Add the analyzer to the canonical registry so operator env selection and per-repo enrichment toggles validate and forward the new analyzer name.

### Description
- Add `"undocumentedExport"` to the canonical `REES_ANALYZER_NAMES` array in `src/review/enrichment-analyzer-names.ts` so the engine allowlist includes the analyzer.
- Update `test/unit/enrichment-wire.test.ts` to add regression coverage asserting that `REES_ANALYZERS=undocumentedExport` resolves to `"undocumentedExport"` and that the full registered-analyzers list still validates.
- No UI or generated artifacts changed; change is limited to analyzer-name configuration and tests.

### Testing
- Ran the unit tests `npx vitest run test/unit/enrichment-wire.test.ts test/unit/review-enrichment-config.test.ts`, and the updated tests passed.
- Ran `npm run typecheck`, which completed successfully.
- Attempted full gate `npm run test:ci` and `npm audit --audit-level=moderate`, but these were blocked by unrelated local environment / registry checks (stale selfhost env reference and an `npm audit` 403) and were not completed in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4891226514832ca9ef82d6669f4be0)