### PR TITLE
fix(review): preserve labels after anti-abuse closes

### DIFF
--- a/src/services/agent-action-executor.ts
+++ b/src/services/agent-action-executor.ts
@@ -262,30 +262,37 @@ export async function executeAgentMaintenanceActions(env: Env, ctx: AgentActionE
     //    leave a PR mislabeled "closed for X" while still open. A coupled close that is still "queued" (awaiting
     //    the SAME approval) or "completed" lets the label through unchanged; a close with no `closeKind` match
     //    (e.g. a plain review_state_label) is unaffected.
+    let pairedCloseOutcome: AgentActionOutcome["outcome"] | undefined;
     if (action.actionClass === "label" && action.closeKind) {
-      const closeOutcome = coupledCloseOutcome(planned, outcomes, action.closeKind);
-      if (closeOutcome === "denied" || closeOutcome === "error") {
-        await audit("denied", `paired ${action.closeKind} close did not complete (${closeOutcome}) — skipping the companion label so the PR isn't mislabeled while still open`);
+      pairedCloseOutcome = coupledCloseOutcome(planned, outcomes, action.closeKind);
+      if (pairedCloseOutcome === "denied" || pairedCloseOutcome === "error") {
+        await audit("denied", `paired ${action.closeKind} close did not complete (${pairedCloseOutcome}) — skipping the companion label so the PR isn't mislabeled while still open`);
         continue;
       }
     }
     // 7) Freshness guard: every supported live action mutates PR state or PR-visible output, so it must still
     //    target the reviewed, open head. This protects approval-queue replays and slow webhook jobs from
-    //    force-pushes or manual closes that happen after the review was planned.
+    //    force-pushes or manual closes that happen after the review was planned. A companion anti-abuse label
+    //    whose paired close just completed in this same batch reuses the close's already-passed guard: the
+    //    successful close intentionally flips the PR to closed, so a second open-PR freshness read would deny
+    //    the label for the state transition this executor just performed.
     const expectedHeadSha = action.expectedHeadSha ?? ctx.headSha ?? null;
-    if (!expectedHeadSha) {
-      await audit("denied", "live PR head guard unavailable — action not executed");
-      continue;
-    }
-    const freshness = await fetchPullRequestFreshness(env, {
-      installationId: ctx.installationId,
-      repoFullName: ctx.repoFullName,
-      pullNumber: ctx.pullNumber,
-      expectedHeadSha,
-    });
-    if (freshness.status !== "current") {
-      await audit("denied", `${pullRequestFreshnessDetail(freshness)} — action not executed`);
-      continue;
+    const freshnessAlreadyProvenByPairedClose = action.actionClass === "label" && action.closeKind !== undefined && pairedCloseOutcome === "completed";
+    if (!freshnessAlreadyProvenByPairedClose) {
+      if (!expectedHeadSha) {
+        await audit("denied", "live PR head guard unavailable — action not executed");
+        continue;
+      }
+      const freshness = await fetchPullRequestFreshness(env, {
+        installationId: ctx.installationId,
+        repoFullName: ctx.repoFullName,
+        pullNumber: ctx.pullNumber,
+        expectedHeadSha,
+      });
+      if (freshness.status !== "current") {
+        await audit("denied", `${pullRequestFreshnessDetail(freshness)} — action not executed`);
+        continue;
+      }
     }
     // 8) Live CI re-verification for a merge or a CI-driven heuristic close (#2128): the CI aggregate that drove
     //    either decision was read seconds-to-tens-of-seconds earlier, in the planning pass, and the freshness

--- a/test/unit/agent-action-executor.test.ts
+++ b/test/unit/agent-action-executor.test.ts
@@ -636,6 +636,10 @@ describe("executeAgentMaintenanceActions (#778 gate stack)", () => {
     const coupledClose: PlannedAgentAction = { actionClass: "close", requiresApproval: false, reason: "over the per-contributor open-item cap", closeComment: "closing", closeKind: "contributor_cap" };
     const coupledLabel: PlannedAgentAction = { actionClass: "label", autonomyClass: "close", requiresApproval: false, reason: "over the per-contributor open-item cap", label: "over-contributor-limit", labelOp: "add", closeKind: "contributor_cap" };
     vi.mocked(fetchPullRequestFreshness)
+      // First resolution: the close's own freshness check (open, current). The second resolution is the
+      // regression tripwire -- it must NEVER be consumed, because the label reuses the close's already-proven
+      // outcome instead of re-checking freshness against the now-closed PR (which would read "stale"/closed and
+      // wrongly deny the label). The toHaveBeenCalledTimes(1) assertion below is what actually proves this.
       .mockResolvedValueOnce({ status: "current", liveHeadSha: "sha7", liveState: "open" })
       .mockResolvedValueOnce({ status: "stale", reason: "closed", expectedHeadSha: "sha7", liveHeadSha: "sha7", liveState: "closed" });
     const outcomes = await executeAgentMaintenanceActions(env, ctx(), [coupledClose, coupledLabel]);

--- a/test/unit/agent-action-executor.test.ts
+++ b/test/unit/agent-action-executor.test.ts
@@ -631,14 +631,18 @@ describe("executeAgentMaintenanceActions (#778 gate stack)", () => {
     });
   });
 
-  it("#label-close-split-brain: a coupled anti-abuse label+close pair (matching closeKind) BOTH complete when the close succeeds", async () => {
+  it("#label-close-split-brain: a coupled anti-abuse label+close pair (matching closeKind) BOTH complete when the close succeeds and closes the PR before the label", async () => {
     const env = createTestEnv({});
     const coupledClose: PlannedAgentAction = { actionClass: "close", requiresApproval: false, reason: "over the per-contributor open-item cap", closeComment: "closing", closeKind: "contributor_cap" };
     const coupledLabel: PlannedAgentAction = { actionClass: "label", autonomyClass: "close", requiresApproval: false, reason: "over the per-contributor open-item cap", label: "over-contributor-limit", labelOp: "add", closeKind: "contributor_cap" };
+    vi.mocked(fetchPullRequestFreshness)
+      .mockResolvedValueOnce({ status: "current", liveHeadSha: "sha7", liveState: "open" })
+      .mockResolvedValueOnce({ status: "stale", reason: "closed", expectedHeadSha: "sha7", liveHeadSha: "sha7", liveState: "closed" });
     const outcomes = await executeAgentMaintenanceActions(env, ctx(), [coupledClose, coupledLabel]);
     expect(outcomes.map((o) => o.outcome)).toEqual(["completed", "completed"]);
     expect(closePullRequest).toHaveBeenCalledTimes(1);
     expect(ensurePullRequestLabel).toHaveBeenCalledTimes(1);
+    expect(fetchPullRequestFreshness).toHaveBeenCalledTimes(1);
   });
 
   it("#label-close-split-brain (confirmed root cause of PR-cap miscounting): a coupled anti-abuse label is SKIPPED, not posted, when its paired close is denied for lacking pull_requests:write — `label` mutates via the Issues API and is otherwise exempt from that gate, so without this correlation a PR could be mislabeled 'over-contributor-limit' while it stays open forever", async () => {


### PR DESCRIPTION
### Motivation
- A recent reordering emitted anti-abuse `close` actions before their companion `label`, but the executor's freshness guard then rejected the label after the successful close set the PR state to `closed`, causing companion labels to be skipped.
- Ensure companion anti-abuse labels still apply when their paired `close` completed in the same execution batch while preserving the existing freshness protection for all other cases.
- No linked issue: small, self-diagnosed regression fix in the maintenance action executor, not a pre-planned feature.

### Description
- Reuse the paired close outcome inside `executeAgentMaintenanceActions` and, when a companion label's paired close completed this pass, skip the second live-PR freshness read so the label is not denied just because the close transitioned the PR to `closed` (`src/services/agent-action-executor.ts`).
- Add a regression unit test that simulates the post-close freshness transition and verifies the companion label still applies (`test/unit/agent-action-executor.test.ts`), plus a comment clarifying why the test's second freshness mock must never be consumed.
- Rebased onto current `main` (branch was ~54 commits behind) and regenerated the self-host environment reference artifact to match.

### Testing
- `npm run typecheck` — clean.
- `git diff --check` — clean.
- `npm run selfhost:env-reference:check` — clean (77 env var references, regenerated).
- `npx vitest run test/unit/agent-action-executor.test.ts` — 106/106 passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a488f7a0878832c9f5cd93b9c7a3c29)
