### PR TITLE
fix(queue): escape monitored mention logins to match bot-shaped logins literally

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -9859,11 +9859,11 @@ const MONITORED_MENTION_PING_EVENT_TYPE = "github_app.monitored_mention_ping";
 
 /** Word-boundary, case-insensitive check for `@login` in a comment body — the SAME precision level as
  *  `parseGittensoryMentionCommand`'s own `@gittensory` detection (a literal match, not an intent classifier):
- *  conservative and testable, per the feature's design goal. `login` is only ever a value that already survived
- *  `normalizeAutoCloseExemptLogins`'s GitHub-login-format validation (alphanumeric + internal hyphens), so it
- *  is safe to embed directly in a RegExp without escaping. */
+ *  conservative and testable, per the feature's design goal. `login` already survived
+ *  `normalizeAutoCloseExemptLogins`'s GitHub-login-format validation, but bot-shaped logins contain `[bot]`;
+ *  escape before embedding so every configured login is matched literally. */
 function bodyMentionsLogin(body: string, login: string): boolean {
-  return new RegExp(`(?:^|\\s)@${login}(?:\\s|$|[^\\w-])`, "i").test(body);
+  return new RegExp(`(?:^|\\s)@${escapeRegExp(login)}(?:\\s|$|[^\\w-])`, "i").test(body);
 }
 
 /**

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -15374,6 +15374,50 @@ describe("queue processors", () => {
       expect(seen.closed).toBe(false);
     });
 
+    it("REGRESSION: matches bot-shaped monitored logins literally", async () => {
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+      await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", reviewNagPolicy: "close", reviewNagMaxPings: 3, reviewNagMonitoredMentions: ["dependabot[bot]"] });
+      await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 312, title: "Bot mention", state: "open", user: { login: "chatty" }, author_association: "NONE", labels: [], body: "" });
+      const seen = { comments: [] as string[], labels: [] as string[], closed: false };
+      stubMonitoredMentionFetch(312, seen);
+      await processJob(env, {
+        type: "github-webhook",
+        deliveryId: "mention-bot-shaped-literal",
+        eventName: "issue_comment",
+        payload: {
+          action: "created",
+          installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+          repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+          issue: { number: 312, title: "Bot mention", state: "open", pull_request: {}, user: { login: "chatty" }, author_association: "NONE" },
+          comment: { id: 1, body: "Please check this @dependabot[bot].", user: { login: "chatty", type: "User" }, author_association: "NONE" },
+        },
+      });
+      const pings = await env.DB.prepare("select count(*) as n from audit_events where event_type = 'github_app.monitored_mention_ping'").first<{ n: number }>();
+      expect(pings?.n).toBe(1);
+    });
+
+    it("REGRESSION: does not treat bot-login metacharacters as a regex character class", async () => {
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+      await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", reviewNagPolicy: "close", reviewNagMonitoredMentions: ["dependabot[bot]"] });
+      await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 313, title: "Bot false positive", state: "open", user: { login: "chatty" }, author_association: "NONE", labels: [], body: "" });
+      const seen = { comments: [] as string[], labels: [] as string[], closed: false };
+      stubMonitoredMentionFetch(313, seen);
+      await processJob(env, {
+        type: "github-webhook",
+        deliveryId: "mention-bot-shaped-false-positive",
+        eventName: "issue_comment",
+        payload: {
+          action: "created",
+          installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+          repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+          issue: { number: 313, title: "Bot false positive", state: "open", pull_request: {}, user: { login: "chatty" }, author_association: "NONE" },
+          comment: { id: 1, body: "This mentions @dependabotb, not the bot actor.", user: { login: "chatty", type: "User" }, author_association: "NONE" },
+        },
+      });
+      const pings = await env.DB.prepare("select count(*) as n from audit_events where event_type = 'github_app.monitored_mention_ping'").first<{ n: number }>();
+      expect(pings?.n).toBe(0);
+    });
+
     it("case-insensitively matches a monitored login and ignores an unrelated mention", async () => {
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
       await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", reviewNagPolicy: "close", reviewNagMonitoredMentions: ["JSONbored"] });


### PR DESCRIPTION
### Motivation
- Correct a regression where allowing bot-shaped logins like `dependabot[bot]` in the shared normalizer caused monitored-mention matching to treat `[`/`]` as regex metacharacters and therefore miss literal `@dependabot[bot]` mentions or create false positives.

### Description
- Escape monitored-login values before embedding them into the review-nag matcher `RegExp` so configured logins are matched literally (use `escapeRegExp(login)` in `bodyMentionsLogin`).
- Reuse the existing `escapeRegExp` helper already present in the file to avoid duplicate implementations.
- Add two regression tests to `test/unit/queue.test.ts` that assert a bot-shaped configured login `dependabot[bot]` is matched literally and that `@dependabotb` does not produce a false positive.

### Testing
- Ran targeted unit tests with Vitest: `npx vitest run test/unit/queue.test.ts -t "bot-shaped monitored|metacharacters"`, which passed.
- Ran the monitored/mention test group: `npx vitest run test/unit/queue.test.ts -t "monitored"`, which passed.
- Ran TypeScript typecheck: `npm run typecheck`, which passed with no errors.
- Attempted the full local gate `npm run test:ci`, which did not complete due to pre-existing repository state issues unrelated to this change (a stale generated UI file flagged by `selfhost:env-reference:check`) and an environment `npm audit` call that failed with a network/permission error; these failures are external to the code change and did not affect the new unit tests added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4891d5f8e4832cba7eeafd6fad3f20)