### PR TITLE
fix(engine): guard plan template dispatch

### DIFF
--- a/packages/gittensory-engine/src/plan-templates.ts
+++ b/packages/gittensory-engine/src/plan-templates.ts
@@ -121,7 +121,9 @@ export const PLAN_TEMPLATE_BUILDERS: Readonly<Record<PlanTemplateStage, (context
 // Build the raw-step template for a stage. Pure — a thin dispatcher over `PLAN_TEMPLATE_BUILDERS` that rejects an
 // unknown stage with a clear error rather than a generic "not a function" TypeError (guards non-TypeScript callers).
 export function buildPlanTemplate(stage: PlanTemplateStage, context: PlanTemplateContext = {}): RawPlanStep[] {
-  const builder = PLAN_TEMPLATE_BUILDERS[stage];
-  if (!builder) throw new Error(`Unknown plan-template stage: ${String(stage)}`);
+  const builder = Object.prototype.hasOwnProperty.call(PLAN_TEMPLATE_BUILDERS, stage)
+    ? PLAN_TEMPLATE_BUILDERS[stage]
+    : undefined;
+  if (typeof builder !== "function") throw new Error(`Unknown plan-template stage: ${String(stage)}`);
   return builder(context);
 }

--- a/test/unit/plan-templates.test.ts
+++ b/test/unit/plan-templates.test.ts
@@ -125,6 +125,15 @@ describe("plan-templates", () => {
     expect(() => buildPlanTemplate("bogus" as PlanTemplateStage)).toThrow(/Unknown plan-template stage/);
   });
 
+  it.each(["constructor", "toString", "hasOwnProperty"])(
+    "rejects inherited Object.prototype stage '%s' instead of dispatching it",
+    (stage) => {
+      expect(() => buildPlanTemplate(stage as PlanTemplateStage, [] as unknown as never)).toThrow(
+        /Unknown plan-template stage/,
+      );
+    },
+  );
+
   it("exposes a frozen registry so the shared dispatch table cannot be mutated", () => {
     expect(Object.isFrozen(PLAN_TEMPLATE_BUILDERS)).toBe(true);
   });


### PR DESCRIPTION
### Motivation
- Prevent runtime allowlist-bypass/crash when `buildPlanTemplate` indexes `PLAN_TEMPLATE_BUILDERS` with inherited `Object.prototype` names such as `constructor`, `toString`, or `hasOwnProperty`.
- Make the dispatcher robust for non-TypeScript callers by only dispatching known own properties that are functions and returning a clear `Unknown plan-template stage` error for any other input.

### Description
- Change `buildPlanTemplate` to select the builder with `Object.prototype.hasOwnProperty.call(PLAN_TEMPLATE_BUILDERS, stage)` and verify `typeof builder === "function"` before calling it. (changed file: `packages/gittensory-engine/src/plan-templates.ts`).
- Add regression unit tests that assert inherited names (`"constructor"`, `"toString"`, `"hasOwnProperty"`) are rejected instead of dispatched. (changed file: `test/unit/plan-templates.test.ts`).
- Preserve the original error message path so unknown stages continue to throw a clear `Unknown plan-template stage` error.

### Testing
- Ran `git diff --check` locally and it passed without whitespace/conflict errors. 
- Built the engine with `npm --workspace @jsonbored/gittensory-engine run build` and the TypeScript build succeeded. 
- Ran the unit tests for the changed file with `npx vitest run test/unit/plan-templates.test.ts` and all tests passed (`28 tests`).
- Attempted `npm run test:coverage` and `npm audit --audit-level=moderate`; `test:coverage` did not complete within the session window and `npm audit` returned a `403 Forbidden` from the registry so the audit step could not finish.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48904a6294832c9c7b458f5e66c147)