### PR TITLE
fix(mcp): reuse test matcher for branch summaries

### DIFF
--- a/packages/gittensory-mcp/bin/gittensory-mcp.js
+++ b/packages/gittensory-mcp/bin/gittensory-mcp.js
@@ -6,7 +6,7 @@ import { delimiter, dirname, join } from "node:path";
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
-import { buildBranchAnalysisPayload, collectLocalDiff, collectLocalBranchMetadata, probeLocalScorer, referenceScorePreviewExample, resolveScorePreviewCommand, resolveWorkspaceCwd, sanitizeLocalScorerStatus, setupGuidanceForLocalScorer } from "../lib/local-branch.js";
+import { buildBranchAnalysisPayload, collectLocalDiff, collectLocalBranchMetadata, probeLocalScorer, referenceScorePreviewExample, resolveScorePreviewCommand, resolveWorkspaceCwd, sanitizeLocalScorerStatus, setupGuidanceForLocalScorer, isTestFile } from "../lib/local-branch.js";
 
 const defaultApiUrl = "https://gittensory-api.aethereal.dev";
 const legacyDefaultApiUrls = new Set(["https://gittensory-api.zeronode.workers.dev"]);
@@ -3585,7 +3585,7 @@ async function analyzeCurrentBranch(input) {
       mergeBaseSha: body.mergeBaseSha,
       remoteTrackingSha: body.remoteTrackingSha,
       changedFileCount: body.changedFiles?.length ?? 0,
-      testFileCount: body.changedFiles?.filter((file) => /(^|\/)(test|tests|spec|__tests__)\/|(^|\/)src\/test\/|(^|\/)[^/]+_test\.(go|py|rb)$|(^|\/)[^/]+_spec\.rb$|\.(test|spec)\.(ts|tsx|js|jsx|py|rb|rs)$/i.test(file.path)).length ?? 0,
+      testFileCount: body.changedFiles?.filter((file) => isTestFile(file.path)).length ?? 0,
       passedValidationCount: body.validation?.filter((entry) => entry.status === "passed").length ?? 0,
       localScorerStatus: sanitizeLocalScorerStatus(localScorerStatus),
       setupGuidance: setupGuidanceForLocalScorer(localScorerStatus),

--- a/packages/gittensory-mcp/lib/local-branch.js
+++ b/packages/gittensory-mcp/lib/local-branch.js
@@ -601,16 +601,16 @@ export function isTestFile(file) {
     /(^|\/)[^/]+_spec\.rb$/i.test(file) ||
     /\.(test|spec)\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs)$/i.test(file) ||
     /(^|\/)[^/]+\.(cy|e2e)\.(ts|tsx|mts|cts|js|jsx|mjs|cjs)$/i.test(file) ||
-    // JVM / C# / Swift `SomethingTest(s)`/`SomethingSpec` class-suffix convention (JUnit, Kotlin/ScalaTest,
-    // Spock, xUnit/NUnit, XCTest). Case-sensitive on the PascalCase suffix so it can't false-positive on words
-    // that merely end in "test"/"spec" (Latest.java, Contest.cs, manifest.scala).
-    /(^|\/)\w*(Tests?|Spec)\.(java|kt|kts|scala|cs|swift|groovy)$/.test(file) ||
+    // JVM / C# / Swift / PHP `SomethingTest(s)`/`SomethingSpec` class-suffix convention (JUnit, Kotlin/ScalaTest,
+    // Spock, xUnit/NUnit, XCTest, PHPUnit/PHPSpec). Case-sensitive on the PascalCase suffix so it can't false-positive on words
+    // that merely end in "test"/"spec" (Latest.java, Contest.cs, manifest.scala, Latest.php).
+    /(^|\/)\w*(Tests?|Spec)\.(java|kt|kts|scala|cs|swift|groovy|php)$/.test(file) ||
     /(^|\/)__snapshots__\//i.test(file)
   );
 }
 
 export function isCodeFile(file) {
-  return /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy)$/i.test(file) && !isTestFile(file);
+  return /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy|php)$/i.test(file) && !isTestFile(file);
 }
 
 function numberValue(value) {

--- a/test/unit/local-branch.test.ts
+++ b/test/unit/local-branch.test.ts
@@ -1762,15 +1762,15 @@ describe("local MCP git metadata collection", () => {
       expect(isTestFile(file)).toBe(true);
       expect(isCodeFile(file)).toBe(false);
     }
-    // #2666 + #2743 parity: the pytest `test_*.py` prefix and the JVM/C#/Swift `SomethingTest(s)`/`Spec`
+    // #2666 + #2743 parity: the pytest `test_*.py` prefix and the JVM/C#/Swift/PHP `SomethingTest(s)`/`Spec`
     // class-suffix conventions were added to the server isTestPath but not this MCP copy — so the local
-    // predictor wrongly counted Java/Kotlin/Scala/C#/Swift tests and pytest-prefixed files as SOURCE.
-    for (const file of ["tests/test_utils.py", "test_api.py", "app/FooTests.java", "src/BarSpec.kt", "core/BazTest.scala", "svc/QuuxTests.cs", "ios/CorgeSpec.swift", "build/GraultTest.groovy"]) {
+    // predictor wrongly counted Java/Kotlin/Scala/C#/Swift/PHP tests and pytest-prefixed files as SOURCE.
+    for (const file of ["tests/test_utils.py", "test_api.py", "app/FooTests.java", "src/BarSpec.kt", "core/BazTest.scala", "svc/QuuxTests.cs", "ios/CorgeSpec.swift", "build/GraultTest.groovy", "lib/WaldoSpec.php"]) {
       expect(isTestFile(file)).toBe(true);
       expect(isCodeFile(file)).toBe(false);
     }
-    // Case-sensitive on the PascalCase suffix: a JVM source merely ENDING in "test"/"spec" stays source.
-    for (const file of ["src/Latest.java", "core/manifest.scala", "app/MyService.kt"]) {
+    // Case-sensitive on the PascalCase suffix: a JVM/PHP source merely ENDING in "test"/"spec" stays source.
+    for (const file of ["src/Latest.java", "core/manifest.scala", "app/MyService.kt", "web/Latest.php"]) {
       expect(isTestFile(file)).toBe(false);
       expect(isCodeFile(file)).toBe(true);
     }


### PR DESCRIPTION
### Motivation

- The server-side canonical test matcher was extended to recognize pytest `test_*.py` prefixes, but duplicated client/CLI classifiers remained stale, causing local MCP summaries to misclassify pytest-prefixed files as source and undercount test evidence.

### Description

- Replace the CLI inline `testFileCount` regex in `packages/gittensory-mcp/bin/gittensory-mcp.js` with a call to the packaged `isTestFile` helper so the summary uses the single canonical matcher via the MCP package.
- Update `packages/gittensory-mcp/lib/local-branch.js` to bring the packaged matcher into parity by including PHP `SomethingTest(s)`/`SomethingSpec` suffix detection and adding `.php` to the code-extension list.
- Extend `test/unit/local-branch.test.ts` to include PHP test/source cases to cover the added branches.
- No change to the server-side canonical matcher in `src/signals/test-evidence.ts` is made by this PR; this only aligns the MCP/CLI mirrors with it.

### Testing

- Ran `npx vitest run test/unit/local-branch.test.ts` and all targeted tests passed.
- Ran `npm run build:mcp` which completed successfully.
- Verified `git diff --check` (no whitespace/conflict issues) locally.
- `npm run test:ci` was attempted but aborted early due to an unrelated generated-file drift in UI env references, and `npm audit --audit-level=moderate` failed with a registry `403` response; these environment/external issues did not affect the MCP-specific validation above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4891f46f24832cbaba90efb7b075bb)