### PR TITLE
fix(enrichment): allow configured blameLink analyzer

### DIFF
--- a/src/review/enrichment-analyzer-names.ts
+++ b/src/review/enrichment-analyzer-names.ts
@@ -23,6 +23,12 @@ export const REES_ANALYZER_NAMES = [
   "nativeBuild",
   "history",
   "docCommentDrift",
+  "duplication",
+  "churnHotspot",
+  "blameLink",
+  "approvalIntegrity",
+  "ciCheckSignals",
+  "undocumentedExport",
 ] as const;
 
 export type ReesAnalyzerName = (typeof REES_ANALYZER_NAMES)[number];

--- a/test/unit/enrichment-wire.test.ts
+++ b/test/unit/enrichment-wire.test.ts
@@ -615,6 +615,12 @@ describe("resolveReesAnalyzers", () => {
     warnSpy.mockRestore();
   });
 
+  it("accepts blameLink as a configured analyzer subset", () => {
+    expect(
+      resolveReesAnalyzers(env({ REES_ANALYZERS: "blameLink" })),
+    ).toEqual(["blameLink"]);
+  });
+
   it("accepts docCommentDrift as a configured analyzer subset", () => {
     expect(
       resolveReesAnalyzers(env({ REES_ANALYZERS: "docCommentDrift" })),
@@ -626,7 +632,7 @@ describe("resolveReesAnalyzers", () => {
       resolveReesAnalyzers(
         env({
           REES_ANALYZERS:
-            "dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift",
+            "dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity,ciCheckSignals,undocumentedExport",
         }),
       ),
     ).toEqual([
@@ -649,6 +655,12 @@ describe("resolveReesAnalyzers", () => {
       "nativeBuild",
       "history",
       "docCommentDrift",
+      "duplication",
+      "churnHotspot",
+      "blameLink",
+      "approvalIntegrity",
+      "ciCheckSignals",
+      "undocumentedExport",
     ]);
   });
 


### PR DESCRIPTION
### Motivation
- The REES service added the `blameLink` analyzer and advertised it in generated metadata and `.env.example`, but the engine-side allowlist used to validate `REES_ANALYZERS` was not updated, so an explicit `REES_ANALYZERS=blameLink` was treated as invalid and resulted in sending `analyzers: []` to REES (no analyzers run). 
- This change restores operator-facing parity between advertised/registered REES analyzers and the engine allowlist so explicit selections behave as intended.

### Description
- Add the current generated analyzer names (including `blameLink` and other newly-advertised keys) to the engine allowlist in `src/review/enrichment-analyzer-names.ts`. 
- Add a regression unit test `test/unit/enrichment-wire.test.ts` that asserts `resolveReesAnalyzers(env({ REES_ANALYZERS: "blameLink" }))` returns `["blameLink"]` and update the full explicit-analyzer-list test to include the current registry. 
- Preserve existing semantics for unset/`all`/`*` behavior and for mixed valid/invalid names; no behavior changes to REES request body formation other than allowing advertised names to be selected explicitly.

### Testing
- Ran targeted unit tests with `npx vitest run test/unit/enrichment-wire.test.ts test/unit/review-enrichment-config.test.ts --reporter=dot` and the test suite passed (all tests in those files passed). 
- Ran type checking with `npm run typecheck` and it succeeded. 
- Attempted the full gate `git diff --check && npm run test:ci` but it failed early on an unrelated stale generated-file check (`selfhost:env-reference:check`) in the repository, so the global CI gate was not fully exercised here. 
- `npm audit --audit-level=moderate` could not complete due to an external `403 Forbidden` from the npm audit endpoint; this is an external infrastructure observation, not caused by the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48904a599c832c92cba0063b69112a)