### PR TITLE
fix(selfhost): bound malformed dead-letter retries

### DIFF
--- a/src/selfhost/pg-queue.ts
+++ b/src/selfhost/pg-queue.ts
@@ -1024,7 +1024,7 @@ export function createPgQueue(
         message = JSON.parse(job.payload) as JobMessage;
       } catch {
         await pool.query(
-          `UPDATE ${TABLE} SET status='dead', last_error='unparseable payload', dead_at=$1 WHERE id=$2`,
+          `UPDATE ${TABLE} SET status='dead', attempts=attempts+1, last_error='unparseable payload', dead_at=$1 WHERE id=$2`,
           [Date.now(), job.id],
         );
         await recordQueueMetric("gittensory_jobs_dead_total");

--- a/src/selfhost/sqlite-queue.ts
+++ b/src/selfhost/sqlite-queue.ts
@@ -767,7 +767,7 @@ export function createSqliteQueue(
         message = JSON.parse(job.payload) as JobMessage;
       } catch {
         driver.query(
-          `UPDATE ${TABLE} SET status='dead', last_error='unparseable payload', dead_at=? WHERE id=?`,
+          `UPDATE ${TABLE} SET status='dead', attempts=attempts+1, last_error='unparseable payload', dead_at=? WHERE id=?`,
           [Date.now(), job.id],
         );
         recordQueueMetric(driver, "gittensory_jobs_dead_total");

--- a/test/unit/selfhost-pg-queue.test.ts
+++ b/test/unit/selfhost-pg-queue.test.ts
@@ -1952,8 +1952,10 @@ describe("createPgQueue (durable #977)", () => {
     const q = createPgQueue(m.pool, async () => undefined, { maxRetries: 3 });
     await q.init();
     await q.drain();
-    // UPDATE dead + then no more rows → pump exits cleanly.
-    expect(m.pool.query).toHaveBeenCalledWith(expect.stringContaining("status='dead'"), expect.arrayContaining(["1"]));
+    // UPDATE dead + then no more rows → pump exits cleanly. Asserts the full clause set (not just "status='dead'")
+    // so a malformed payload provably consumes the same bounded retry budget as a normal failure -- attempts must
+    // be bumped, or the dead-letter reviver's own "attempts<ceiling" SELECT would requeue this row forever.
+    expect(m.pool.query).toHaveBeenCalledWith(expect.stringContaining("status='dead', attempts=attempts+1, last_error='unparseable payload'"), expect.arrayContaining(["1"]));
   });
 
   it("retries a failing job (job_error audit emitted) then dead-letters at maxRetries (job_dead)", async () => {

--- a/test/unit/selfhost-sqlite-queue.test.ts
+++ b/test/unit/selfhost-sqlite-queue.test.ts
@@ -2999,6 +2999,9 @@ describe("createSqliteQueue (durable #980)", () => {
     const [row] = q.listDeadLetterJobs(10, 0);
     expect(row).toMatchObject({ jobType: "unknown", lastError: "unparseable payload" });
     expect(row!.deadAtMs).not.toBeNull();
+    // A malformed payload consumes the same bounded retry budget as a normal failure (previously left `attempts`
+    // at its pre-death value, so the dead-letter reviver would requeue the same unparseable row forever).
+    expect(row!.attempts).toBe(1);
   });
 
   it("sendBatch enqueues all; default backoff reschedules a failure into the future", async () => {


### PR DESCRIPTION
### Motivation
- Malformed/unparseable persisted queue payloads were being marked `status='dead'` without persisting an incremented `attempts`, allowing the dead-letter reviver to requeue those rows indefinitely and bypass the intended retry ceiling.
- Make the behavior consistent across both self-host backends so malformed rows exhaust the same bounded revive budget as normal retryable failures.
- No linked issue: small, self-diagnosed queue-reliability fix, not a pre-planned feature.

### Description
- Persist `attempts=attempts+1` when dead-lettering an unparseable payload in `src/selfhost/sqlite-queue.ts` and `src/selfhost/pg-queue.ts`.
- Strengthened unit tests in `test/unit/selfhost-sqlite-queue.test.ts` and `test/unit/selfhost-pg-queue.test.ts` to assert the dead-lettered row's persisted `attempts`, not just the query's `status='dead'` substring.
- Rebased onto current `main` (branch was ~54 commits behind) and re-applied the fix on top of the dead-letter-queue dashboard feature (`dead_at` column) that landed in the interim.

### Testing
- `npm run typecheck` — clean.
- `git diff --check` — clean.
- `npx vitest run test/unit/selfhost-sqlite-queue.test.ts test/unit/selfhost-pg-queue.test.ts` — 245/245 passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48904a41a4832c95219a78aa5f1514)
