### PR TITLE
fix(selfhost): track direct AI readiness failures

### DIFF
--- a/src/selfhost/ai.ts
+++ b/src/selfhost/ai.ts
@@ -686,6 +686,14 @@ export function resetAiProviderHealthForTest(): void {
   aiConsecutiveFailures = 0;
 }
 
+function recordAiProviderSuccess(): void {
+  aiConsecutiveFailures = 0;
+}
+
+function recordAiProvidersExhausted(): void {
+  aiConsecutiveFailures += 1;
+}
+
 // Per-provider circuit breaker (#2540): a provider that is failing hard (bad credential, sustained outage)
 // otherwise pays the FULL cost of a fresh attempt (a real HTTP call, or a real CLI subprocess spawn) on
 // every single review during the outage. This is independent of `aiConsecutiveFailures` above -- that streak
@@ -742,7 +750,7 @@ export function createChainAi(providers: Array<{ name: string; ai: SelfHostAi }>
       for (const p of providers) {
         try {
           const result = await runProviderWithOtel(p, model, options);
-          aiConsecutiveFailures = 0;
+          recordAiProviderSuccess();
           return result;
         } catch (error) {
           lastError = error;
@@ -750,7 +758,7 @@ export function createChainAi(providers: Array<{ name: string; ai: SelfHostAi }>
           console.error(JSON.stringify({ level: "warn", event: "selfhost_ai_provider_failed_in_chain", provider: p.name, error: errorMessage(error) }));
         }
       }
-      aiConsecutiveFailures += 1;
+      recordAiProvidersExhausted();
       console.error(
         JSON.stringify({
           level: "error",
@@ -861,9 +869,15 @@ export function routeProviders(providers: Array<{ name: string; ai: SelfHostAi }
       const colon = trimmed.indexOf(":");
       const name = (colon < 0 ? trimmed : trimmed.slice(0, colon)).toLowerCase();
       const direct = byName.get(name);
-      return direct
-        ? runProviderWithOtel({ name, ai: direct }, colon < 0 ? "" : trimmed.slice(colon + 1), options)
-        : chain.run(model, options);
+      if (!direct) return chain.run(model, options);
+      try {
+        const result = await runProviderWithOtel({ name, ai: direct }, colon < 0 ? "" : trimmed.slice(colon + 1), options);
+        recordAiProviderSuccess();
+        return result;
+      } catch (error) {
+        recordAiProvidersExhausted();
+        throw error;
+      }
     },
   };
 }

--- a/test/unit/selfhost-ai.test.ts
+++ b/test/unit/selfhost-ai.test.ts
@@ -416,11 +416,16 @@ describe("isAiProviderHealthy (readiness streak, #2497)", () => {
     expect(isAiProviderHealthy()).toBe(false);
 
     vi.useFakeTimers();
-    await vi.advanceTimersByTimeAsync(60_001);
-    shouldFail = false;
-    await expect(route.run("openai", { prompt: "x" })).resolves.toEqual({ response: "ok" });
-    expect(isAiProviderHealthy()).toBe(true);
-    vi.useRealTimers();
+    try {
+      await vi.advanceTimersByTimeAsync(60_001);
+      shouldFail = false;
+      await expect(route.run("openai", { prompt: "x" })).resolves.toEqual({ response: "ok" });
+      expect(isAiProviderHealthy()).toBe(true);
+    } finally {
+      // Guarantee real timers are restored even if an assertion above throws, so a failure here can't leak
+      // fake-timer state into later tests in this file/worker.
+      vi.useRealTimers();
+    }
   });
 });
 

--- a/test/unit/selfhost-ai.test.ts
+++ b/test/unit/selfhost-ai.test.ts
@@ -389,6 +389,39 @@ describe("isAiProviderHealthy (readiness streak, #2497)", () => {
     await expect(createChainAi([working]).run("m", { prompt: "x" })).resolves.toEqual({ response: "ok" });
     expect(isAiProviderHealthy()).toBe(true);
   });
+
+  it("regression: direct provider-name review failures update readiness", async () => {
+    const directFailing = { name: "openai", ai: { run: vi.fn(async () => { throw new Error("ai_http_401"); }) } };
+    const route = routeProviders([directFailing]);
+
+    await expect(route.run("openai", { prompt: "x" })).rejects.toThrow(/ai_http_401/);
+    await expect(route.run("openai", { prompt: "x" })).rejects.toThrow(/ai_http_401/);
+    expect(isAiProviderHealthy()).toBe(true);
+
+    await expect(route.run("openai", { prompt: "x" })).rejects.toThrow(/ai_http_401|circuit_open/);
+    expect(isAiProviderHealthy()).toBe(false);
+  });
+
+  it("direct provider-name review success resets readiness after direct failures", async () => {
+    let shouldFail = true;
+    const direct = { name: "openai", ai: { run: vi.fn(async () => {
+      if (shouldFail) throw new Error("ai_http_401");
+      return { response: "ok" };
+    }) } };
+    const route = routeProviders([direct]);
+
+    for (let i = 0; i < 3; i += 1) {
+      await expect(route.run("openai", { prompt: "x" })).rejects.toThrow();
+    }
+    expect(isAiProviderHealthy()).toBe(false);
+
+    vi.useFakeTimers();
+    await vi.advanceTimersByTimeAsync(60_001);
+    shouldFail = false;
+    await expect(route.run("openai", { prompt: "x" })).resolves.toEqual({ response: "ok" });
+    expect(isAiProviderHealthy()).toBe(true);
+    vi.useRealTimers();
+  });
 });
 
 describe("shouldMarkAiProviderUnhealthyAtBoot (#2497 follow-up)", () => {


### PR DESCRIPTION
### Motivation

- The `/ready` AI readiness probe used a module-level consecutive-failure streak (`aiConsecutiveFailures`) that was only updated by the fallback `createChainAi` path, so direct provider-name review calls (the normal self-host reviewer path) bypassed the streak and could leave `/ready` reporting healthy while configured providers were failing. 
- Make the readiness signal observe both fallback-chain executions and direct provider invocations so `/ready` reflects real review availability.
- No linked issue: small, self-diagnosed readiness-signal fix discovered during self-host AI health-check review.

### Description

- Add shared helpers `recordAiProviderSuccess()` and `recordAiProvidersExhausted()` and use them to centralize updates to the `aiConsecutiveFailures` streak. 
- Replace inline `aiConsecutiveFailures` mutations in `createChainAi` with the new helpers, and update `routeProviders` so direct provider-name calls call `runProviderWithOtel` inside a try/catch that updates the same streak on success/failure. 
- Add regression tests in `test/unit/selfhost-ai.test.ts` that exercise the failing direct-provider path and verify repeated direct failures make `isAiProviderHealthy()` go unhealthy and that a subsequent direct success recovers the streak. 

### Testing

- Ran targeted unit tests with `npx vitest run test/unit/selfhost-ai.test.ts test/unit/selfhost-health.test.ts --reporter=dot` and both files passed (`test/unit/selfhost-ai.test.ts` and `test/unit/selfhost-health.test.ts` passed). 
- Ran TypeScript checks via `npm run typecheck`, which completed with no errors. 
- Attempted a full coverage run with `npm run test:coverage`; the unsharded coverage job was started but could not be completed to completion in this environment due to long run time constraints, so targeted unit tests and typecheck are the primary validated signals here.
- Wrapped the fake-timer section of the readiness-recovery test in try/finally so a failed assertion can't leak fake-timer state into later tests, per gate review nit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a488f7b373c832c9be8f5a099093eee)
