### PR TITLE
feat(review): add config-gated 'review effort: N/5 (~M min)' line to the unified comment

### DIFF
--- a/apps/gittensory-ui/src/lib/selfhost-env-reference.ts
+++ b/apps/gittensory-ui/src/lib/selfhost-env-reference.ts
@@ -11,11 +11,11 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "AI_EMBED_API_KEY",
-    firstReference: "src/server.ts:445",
+    firstReference: "src/server.ts:440",
   },
   {
     name: "AI_EMBED_BASE_URL",
-    firstReference: "src/server.ts:442",
+    firstReference: "src/server.ts:437",
   },
   {
     name: "AI_EMBED_MODEL",
@@ -43,7 +43,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "BACKUP_ACKNOWLEDGED",
-    firstReference: "src/server.ts:384",
+    firstReference: "src/server.ts:379",
   },
   {
     name: "BROWSER_WS_ENDPOINT",
@@ -79,11 +79,11 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "CRON_INTERVAL_MS",
-    firstReference: "src/server.ts:921",
+    firstReference: "src/server.ts:916",
   },
   {
     name: "DATABASE_PATH",
-    firstReference: "src/server.ts:250",
+    firstReference: "src/server.ts:249",
   },
   {
     name: "DATABASE_URL",
@@ -111,15 +111,15 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "GITHUB_CACHE_TTL_SECONDS",
-    firstReference: "src/server.ts:513",
+    firstReference: "src/server.ts:508",
   },
   {
     name: "GITTENSORY_REPO_CONFIG_DIR",
-    firstReference: "src/server.ts:289",
+    firstReference: "src/server.ts:288",
   },
   {
     name: "GITTENSORY_VERSION",
-    firstReference: "src/selfhost/health.ts:29",
+    firstReference: "src/selfhost/otel.ts:62",
   },
   {
     name: "HOME",
@@ -131,7 +131,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "MIGRATIONS_DIR",
-    firstReference: "src/server.ts:397",
+    firstReference: "src/server.ts:392",
   },
   {
     name: "OBSERVABILITY_SMOKE_POLL_MS",
@@ -191,7 +191,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "ORB_BROKER_URL",
-    firstReference: "src/server.ts:970",
+    firstReference: "src/server.ts:965",
   },
   {
     name: "ORB_COLLECTOR_TOKEN",
@@ -207,7 +207,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "ORB_RELAY_MODE",
-    firstReference: "src/server.ts:972",
+    firstReference: "src/server.ts:967",
   },
   {
     name: "OTEL_EXPORTER_OTLP_ENDPOINT",
@@ -239,11 +239,11 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "PGVECTOR_ENABLED",
-    firstReference: "src/server.ts:230",
+    firstReference: "src/server.ts:229",
   },
   {
     name: "PORT",
-    firstReference: "src/server.ts:720",
+    firstReference: "src/server.ts:715",
   },
   {
     name: "PUBLIC_API_ORIGIN",
@@ -259,7 +259,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "QDRANT_URL",
-    firstReference: "src/server.ts:532",
+    firstReference: "src/server.ts:527",
   },
   {
     name: "QUEUE_BACKGROUND_CONCURRENCY",
@@ -271,7 +271,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "REVIEW_AUDIT_DIR",
-    firstReference: "src/server.ts:577",
+    firstReference: "src/server.ts:572",
   },
   {
     name: "SELFHOST_BUNDLE_ALL",
@@ -307,7 +307,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "SETUP_OUTPUT_PATH",
-    firstReference: "src/server.ts:837",
+    firstReference: "src/server.ts:832",
   },
   {
     name: "SLACK_WEBHOOK_URL",
@@ -319,15 +319,15 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| Name | First reference |",
   "| --- | --- |",
   "| `AI_COMBINE` | `src/selfhost/ai.ts:936` |",
-  "| `AI_EMBED_API_KEY` | `src/server.ts:445` |",
-  "| `AI_EMBED_BASE_URL` | `src/server.ts:442` |",
+  "| `AI_EMBED_API_KEY` | `src/server.ts:440` |",
+  "| `AI_EMBED_BASE_URL` | `src/server.ts:437` |",
   "| `AI_EMBED_MODEL` | `src/selfhost/ai.ts:832` |",
   "| `AI_ON_MERGE` | `src/selfhost/ai.ts:938` |",
   "| `AI_PROVIDER` | `src/selfhost/ai-config.ts:43` |",
   "| `ANTHROPIC_AI_BASE_URL` | `src/selfhost/ai.ts:836` |",
   "| `ANTHROPIC_AI_MODEL` | `src/selfhost/ai.ts:57` |",
   "| `ANTHROPIC_API_KEY` | `src/selfhost/ai.ts:835` |",
-  "| `BACKUP_ACKNOWLEDGED` | `src/server.ts:384` |",
+  "| `BACKUP_ACKNOWLEDGED` | `src/server.ts:379` |",
   "| `BROWSER_WS_ENDPOINT` | `src/selfhost/stubs/puppeteer.ts:11` |",
   "| `CLAUDE_AI_EFFORT` | `src/selfhost/ai.ts:108` |",
   "| `CLAUDE_AI_MODEL` | `src/selfhost/ai.ts:49` |",
@@ -336,20 +336,20 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| `CODEX_AI_MODEL` | `src/selfhost/ai.ts:53` |",
   "| `CODEX_AI_TIMEOUT_MS` | `src/selfhost/ai.ts:112` |",
   "| `CODEX_HOME` | `src/selfhost/ai.ts:274` |",
-  "| `CRON_INTERVAL_MS` | `src/server.ts:921` |",
-  "| `DATABASE_PATH` | `src/server.ts:250` |",
+  "| `CRON_INTERVAL_MS` | `src/server.ts:916` |",
+  "| `DATABASE_PATH` | `src/server.ts:249` |",
   "| `DATABASE_URL` | `src/selfhost/preflight.ts:201` |",
   "| `DISCORD_REPO_WEBHOOKS` | `src/services/notify-discord.ts:41` |",
   "| `DISCORD_WEBHOOK_URL` | `src/services/notify-discord.ts:78` |",
   "| `FOREGROUND_LIVENESS_ENABLED` | `src/selfhost/foreground-liveness.ts:41` |",
   "| `GITHUB_APP_ID` | `src/selfhost/orb-collector.ts:59` |",
   "| `GITHUB_APP_PRIVATE_KEY` | `src/selfhost/orb-collector.ts:166` |",
-  "| `GITHUB_CACHE_TTL_SECONDS` | `src/server.ts:513` |",
-  "| `GITTENSORY_REPO_CONFIG_DIR` | `src/server.ts:289` |",
-  "| `GITTENSORY_VERSION` | `src/selfhost/health.ts:29` |",
+  "| `GITHUB_CACHE_TTL_SECONDS` | `src/server.ts:508` |",
+  "| `GITTENSORY_REPO_CONFIG_DIR` | `src/server.ts:288` |",
+  "| `GITTENSORY_VERSION` | `src/selfhost/otel.ts:62` |",
   "| `HOME` | `src/selfhost/ai.ts:274` |",
   "| `MAINTENANCE_ADMISSION_ENABLED` | `src/selfhost/maintenance-admission.ts:126` |",
-  "| `MIGRATIONS_DIR` | `src/server.ts:397` |",
+  "| `MIGRATIONS_DIR` | `src/server.ts:392` |",
   "| `OBSERVABILITY_SMOKE_POLL_MS` | `scripts/smoke-observability-traces.mjs:8` |",
   "| `OBSERVABILITY_SMOKE_TIMEOUT_MS` | `scripts/smoke-observability-traces.mjs:6` |",
   "| `OLLAMA_AI_API_KEY` | `src/selfhost/ai.ts:829` |",
@@ -364,11 +364,11 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| `ORB_AIR_GAP` | `src/selfhost/orb-collector.ts:161` |",
   "| `ORB_ANONYMIZE` | `src/selfhost/orb-collector.ts:174` |",
   "| `ORB_APP_ID` | `src/selfhost/orb-collector.ts:59` |",
-  "| `ORB_BROKER_URL` | `src/server.ts:970` |",
+  "| `ORB_BROKER_URL` | `src/server.ts:965` |",
   "| `ORB_COLLECTOR_TOKEN` | `src/selfhost/orb-collector.ts:205` |",
   "| `ORB_COLLECTOR_URL` | `src/selfhost/orb-collector.ts:172` |",
   "| `ORB_ENROLLMENT_SECRET` | `src/selfhost/orb-collector.ts:165` |",
-  "| `ORB_RELAY_MODE` | `src/server.ts:972` |",
+  "| `ORB_RELAY_MODE` | `src/server.ts:967` |",
   "| `OTEL_EXPORTER_OTLP_ENDPOINT` | `src/selfhost/otel.ts:47` |",
   "| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | `src/selfhost/otel.ts:45` |",
   "| `OTEL_SERVICE_ENVIRONMENT` | `src/selfhost/otel.ts:60` |",
@@ -376,15 +376,15 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| `OTEL_TRACES_EXPORTER` | `src/selfhost/otel.ts:40` |",
   "| `OTEL_TRACES_SAMPLER` | `src/selfhost/otel.ts:74` |",
   "| `OTEL_TRACES_SAMPLER_ARG` | `src/selfhost/otel.ts:76` |",
-  "| `PGVECTOR_ENABLED` | `src/server.ts:230` |",
-  "| `PORT` | `src/server.ts:720` |",
+  "| `PGVECTOR_ENABLED` | `src/server.ts:229` |",
+  "| `PORT` | `src/server.ts:715` |",
   "| `PUBLIC_API_ORIGIN` | `src/selfhost/preflight.ts:192` |",
   "| `QDRANT_API_KEY` | `src/selfhost/qdrant-vectorize.ts:50` |",
   "| `QDRANT_DIM` | `src/selfhost/qdrant-vectorize.ts:71` |",
-  "| `QDRANT_URL` | `src/server.ts:532` |",
+  "| `QDRANT_URL` | `src/server.ts:527` |",
   "| `QUEUE_BACKGROUND_CONCURRENCY` | `src/selfhost/queue-common.ts:120` |",
   "| `REDIS_URL` | `src/selfhost/preflight.ts:144` |",
-  "| `REVIEW_AUDIT_DIR` | `src/server.ts:577` |",
+  "| `REVIEW_AUDIT_DIR` | `src/server.ts:572` |",
   "| `SELFHOST_BUNDLE_ALL` | `scripts/build-selfhost.mjs:13` |",
   "| `SELFHOST_SERVICE` | `scripts/smoke-observability-traces.mjs:5` |",
   "| `SELFHOST_SETUP_TOKEN` | `src/selfhost/preflight.ts:186` |",
@@ -393,6 +393,6 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| `SENTRY_RELEASE` | `src/selfhost/otel.ts:62` |",
   "| `SENTRY_SERVER_NAME` | `src/selfhost/sentry.ts:383` |",
   "| `SENTRY_TRACES_SAMPLE_RATE` | `src/selfhost/sentry.ts:171` |",
-  "| `SETUP_OUTPUT_PATH` | `src/server.ts:837` |",
+  "| `SETUP_OUTPUT_PATH` | `src/server.ts:832` |",
   "| `SLACK_WEBHOOK_URL` | `src/services/notify-discord.ts:173` |",
 ].join("\n");

--- a/src/review/unified-comment.ts
+++ b/src/review/unified-comment.ts
@@ -166,6 +166,11 @@ export interface UnifiedReviewInput {
   consensusBlocker?: boolean;
   /** Reviewers that produced no parseable verdict (a partial review → held, not ready). */
   failedCount?: number;
+  /** Optional per-PR review-effort estimate (config-gated: `review.effort_score`, default off). Presence renders
+   *  a compact "review effort: N/5 (~M min)" chip; omission keeps the comment byte-identical. The caller computes
+   *  this from the estimator (src/review/review-effort.ts) and passes the OUTPUT — this module never imports the
+   *  estimator itself, staying self-contained. (#2069) */
+  reviewEffort?: { band: 1 | 2 | 3 | 4 | 5; minutes: number };
 }
 
 /** One row of the readiness signal table (gittensory side, host-provided; the engine adds Code review). */
@@ -323,6 +328,7 @@ function statusChips(input: UnifiedReviewInput, ctx: UnifiedCommentContext): str
     chips.push(ci === "passed" ? "`CI green`" : ci === "failed" ? "`CI failing`" : "`CI pending`");
     if (input.readiness.mergeStateLabel) chips.push(`\`${escapePublicHtmlAngles(input.readiness.mergeStateLabel)}\``);
   }
+  if (input.reviewEffort) chips.push(`\`review effort: ${input.reviewEffort.band}/5 (~${input.reviewEffort.minutes} min)\``);
   return chips.join(" · ");
 }
 
@@ -544,6 +550,9 @@ export function buildUnifiedReviewInput(opts: {
   decision?: Verdict;
   merged?: boolean;
   verdictReason?: string;
+  /** The estimator's OUTPUT (src/review/review-effort.ts estimateReviewEffort), already computed by the caller
+   *  and gated on `review.effort_score` — omit to keep the comment byte-identical. (#2069) */
+  reviewEffort?: { band: 1 | 2 | 3 | 4 | 5; minutes: number };
 }): UnifiedReviewInput {
   const ex = extractReviewSummary(opts.reviews);
   const changedFiles = typeof opts.changedFiles === "number" ? opts.changedFiles : opts.changedFiles.length;
@@ -560,6 +569,7 @@ export function buildUnifiedReviewInput(opts: {
     ...(opts.decision !== undefined ? { decision: opts.decision } : {}),
     ...(opts.merged !== undefined ? { merged: opts.merged } : {}),
     ...(opts.verdictReason !== undefined ? { verdictReason: opts.verdictReason } : {}),
+    ...(opts.reviewEffort !== undefined ? { reviewEffort: opts.reviewEffort } : {}),
   };
 }
 

--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -271,6 +271,11 @@ export type FocusManifestReviewConfig = {
    *  comments = byte-identical behavior. Operator-gated too (GITTENSORY_REVIEW_INLINE_COMMENTS + allowlist).
    *  (#inline-comments) */
   inlineComments: boolean | null;
+  /** `review.effort_score`: when true, the unified review comment ALSO renders a compact
+   *  "review effort: N/5 (~M min)" line from the deterministic per-PR effort estimator. null/false (default,
+   *  absent) = no effort line = byte-identical comment. Display-only — does not affect the AI reviewer prompt.
+   *  (#2069) */
+  effortScore: boolean | null;
   /** `review.path_instructions`: per-path natural-language guidance handed to the AI reviewer when the PR's
    *  changed files match the glob. Empty (default) ⇒ byte-identical reviewer prompt. (#review-path-instructions) */
   pathInstructions: ReviewPathInstruction[];
@@ -442,7 +447,7 @@ const EMPTY_MANIFEST: FocusManifest = {
   publicNotes: [],
   gate: { ...EMPTY_GATE_CONFIG },
   settings: {},
-  review: { present: false, footerText: null, note: null, fields: {}, enrichmentAnalyzers: {}, profile: null, securityFocus: null, inlineComments: null, pathInstructions: [], instructions: null, excludePaths: [], preMergeChecks: [] },
+  review: { present: false, footerText: null, note: null, fields: {}, enrichmentAnalyzers: {}, profile: null, securityFocus: null, inlineComments: null, effortScore: null, pathInstructions: [], instructions: null, excludePaths: [], preMergeChecks: [] },
   features: { ...EMPTY_FEATURES_CONFIG },
   contentLane: { ...EMPTY_CONTENT_LANE_CONFIG },
   warnings: [],
@@ -471,7 +476,7 @@ function emptyManifest(source: FocusManifestSource, warnings: string[] = []): Fo
     warnings,
     gate: { ...EMPTY_GATE_CONFIG },
     settings: {},
-    review: { present: false, footerText: null, note: null, fields: {}, enrichmentAnalyzers: {}, profile: null, securityFocus: null, inlineComments: null, pathInstructions: [], instructions: null, excludePaths: [], preMergeChecks: [] },
+    review: { present: false, footerText: null, note: null, fields: {}, enrichmentAnalyzers: {}, profile: null, securityFocus: null, inlineComments: null, effortScore: null, pathInstructions: [], instructions: null, excludePaths: [], preMergeChecks: [] },
     features: { ...EMPTY_FEATURES_CONFIG },
     contentLane: { ...EMPTY_CONTENT_LANE_CONFIG },
   };
@@ -1278,7 +1283,7 @@ function parsePublicSafeText(value: JsonValue | undefined, field: string, warnin
  * throws; invalid/unsafe values are dropped with warnings.
  */
 function parseReviewConfig(value: JsonValue | undefined, warnings: string[]): FocusManifestReviewConfig {
-  const empty: FocusManifestReviewConfig = { present: false, footerText: null, note: null, fields: {}, enrichmentAnalyzers: {}, profile: null, securityFocus: null, inlineComments: null, pathInstructions: [], instructions: null, excludePaths: [], preMergeChecks: [] };
+  const empty: FocusManifestReviewConfig = { present: false, footerText: null, note: null, fields: {}, enrichmentAnalyzers: {}, profile: null, securityFocus: null, inlineComments: null, effortScore: null, pathInstructions: [], instructions: null, excludePaths: [], preMergeChecks: [] };
   if (value === undefined || value === null) return empty;
   if (typeof value !== "object" || Array.isArray(value)) {
     warnings.push(`Manifest field "review" must be a mapping; ignoring it.`);
@@ -1314,6 +1319,7 @@ function parseReviewConfig(value: JsonValue | undefined, warnings: string[]): Fo
   const profile = parseReviewProfile(r.profile, warnings);
   const securityFocus = normalizeOptionalBoolean(r.security_focus, "review.security_focus", warnings);
   const inlineComments = normalizeOptionalBoolean(r.inline_comments, "review.inline_comments", warnings);
+  const effortScore = normalizeOptionalBoolean(r.effort_score, "review.effort_score", warnings);
   const pathInstructions = parseReviewPathInstructions(r.path_instructions, warnings);
   const instructions = parsePublicSafeText(r.instructions, "review.instructions", warnings);
   const excludePaths = parseReviewExcludePaths(r.exclude_paths, warnings);
@@ -1325,6 +1331,7 @@ function parseReviewConfig(value: JsonValue | undefined, warnings: string[]): Fo
       profile !== null ||
       securityFocus !== null ||
       inlineComments !== null ||
+      effortScore !== null ||
       pathInstructions.length > 0 ||
       instructions !== null ||
       excludePaths.length > 0 ||
@@ -1338,6 +1345,7 @@ function parseReviewConfig(value: JsonValue | undefined, warnings: string[]): Fo
     profile,
     securityFocus,
     inlineComments,
+    effortScore,
     pathInstructions,
     instructions,
     excludePaths,
@@ -1485,6 +1493,7 @@ export function reviewConfigToJson(review: FocusManifestReviewConfig): JsonValue
   if (review.profile !== null) out.profile = review.profile;
   if (review.securityFocus !== null) out.security_focus = review.securityFocus;
   if (review.inlineComments !== null) out.inline_comments = review.inlineComments;
+  if (review.effortScore !== null) out.effort_score = review.effortScore;
   if (review.instructions !== null) out.instructions = review.instructions;
   if (review.pathInstructions.length > 0) out.path_instructions = review.pathInstructions.map((entry) => ({ path: entry.path, instructions: entry.instructions }));
   if (review.excludePaths.length > 0) out.exclude_paths = [...review.excludePaths];
@@ -1535,6 +1544,14 @@ export function resolveReviewPromptOverrides(manifest: FocusManifest | null): { 
  *  than inline in the processor. (#review-pre-merge-checks) */
 export function resolveReviewPreMergeChecks(manifest: FocusManifest | null): PreMergeCheck[] {
   return manifest?.review.preMergeChecks ?? [];
+}
+
+/** Resolve `review.effort_score` to a strict boolean from a possibly-null manifest (null = load failure ⇒ off,
+ *  byte-identical comment). True ONLY when the manifest explicitly set review.effort_score: true. Centralized so
+ *  the future unified-comment caller reads it in one place with the null-manifest branch covered here
+ *  (unit-tested) rather than inline at the call site. (#2069) */
+export function resolveReviewEffortScoreEnabled(manifest: FocusManifest | null): boolean {
+  return manifest?.review.effortScore === true;
 }
 
 /** Resolve `review.enrichment` analyzer toggles from a possibly-null manifest (null = load failure ⇒ no toggles ⇒

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -15,6 +15,7 @@ import {
   excludeReviewPaths,
   resolveReviewPathInstructions,
   resolveReviewPreMergeChecks,
+  resolveReviewEffortScoreEnabled,
   composeRepoReviewContext,
   resolveReviewPromptOverrides,
   reviewConfigToJson,
@@ -518,7 +519,7 @@ describe("compileFocusManifestPolicy", () => {
       publicNotes: ["Keep PRs focused.", "Maximize your reward payout"],
       gate: { present: false, enabled: null, checkMode: null, pack: null, linkedIssue: null, duplicates: null, readinessMode: null, readinessMinScore: null, slopMode: null, slopMinScore: null, slopAiAdvisory: null, sizeMode: null, lockfileIntegrityMode: null, aiReviewMode: null, aiReviewByok: null, aiReviewProvider: null, aiReviewModel: null, aiReviewAllAuthors: null, aiReviewCloseConfidence: null, aiReviewCombine: null, aiReviewOnMerge: null, aiReviewReviewers: null, mergeReadiness: null, selfAuthoredLinkedIssue: null, manifestPolicy: null, dryRun: null, firstTimeContributorGrace: null, premergeContentRecheck: null, requireFreshRebaseWindowMinutes: null, claMode: null, claConsentPhrase: null, claCheckRunName: null, claCheckRunAppSlug: null, expectedCiContexts: null },
       settings: {},
-      review: { present: false, footerText: null, note: null, fields: {}, enrichmentAnalyzers: {}, profile: null, securityFocus: null, inlineComments: null, pathInstructions: [], instructions: null, excludePaths: [], preMergeChecks: [] },
+      review: { present: false, footerText: null, note: null, fields: {}, enrichmentAnalyzers: {}, profile: null, securityFocus: null, inlineComments: null, effortScore: null, pathInstructions: [], instructions: null, excludePaths: [], preMergeChecks: [] },
       features: { present: false, rag: null, reputation: null, unifiedComment: null, safety: null },
       contentLane: { present: false, entryFileGlob: null, providerFileGlob: null, artifactGlob: null, collectionField: null, maxAppendedEntries: null, duplicateKeyFields: [], validatorId: null },
       warnings: [],
@@ -2216,6 +2217,31 @@ describe("resolveReviewPathInstructions (#review-path-instructions)", () => {
     const bad = parseFocusManifest({ review: { inline_comments: "yes" } });
     expect(bad.review.inlineComments).toBeNull();
     expect(bad.warnings.some((w) => /review\.inline_comments.*must be a boolean/.test(w))).toBe(true);
+  });
+
+  it("parses review.effort_score (default OFF), marks present, round-trips, and warns on a non-boolean (#2069)", () => {
+    expect(parseFocusManifest({ review: { effort_score: true } }).review.effortScore).toBe(true);
+    const on = parseFocusManifest({ review: { effort_score: true } });
+    expect(on.review.present).toBe(true); // an effort-score-only manifest IS present
+    expect(parseFocusManifest({ review: reviewConfigToJson(on.review) }).review).toEqual(on.review); // survives round-trip
+    // Explicit false is retained (and marks present, since the maintainer set it).
+    const off = parseFocusManifest({ review: { effort_score: false } });
+    expect(off.review.effortScore).toBe(false);
+    expect(off.review.present).toBe(true);
+    // Absent ⇒ null (the byte-identical default), config not present.
+    expect(parseFocusManifest({ review: {} }).review.effortScore).toBeNull();
+    expect(parseFocusManifest({ review: {} }).review.present).toBe(false);
+    // A non-boolean is ignored with a warning.
+    const bad = parseFocusManifest({ review: { effort_score: "yes" } });
+    expect(bad.review.effortScore).toBeNull();
+    expect(bad.warnings.some((w) => /review\.effort_score.*must be a boolean/.test(w))).toBe(true);
+  });
+
+  it("resolveReviewEffortScoreEnabled: true only when the manifest explicitly set review.effort_score: true; null manifest → false (#2069)", () => {
+    expect(resolveReviewEffortScoreEnabled(parseFocusManifest({ review: { effort_score: true } }))).toBe(true);
+    expect(resolveReviewEffortScoreEnabled(parseFocusManifest({ review: { effort_score: false } }))).toBe(false);
+    expect(resolveReviewEffortScoreEnabled(parseFocusManifest({ review: {} }))).toBe(false);
+    expect(resolveReviewEffortScoreEnabled(null)).toBe(false);
   });
 });
 

--- a/test/unit/signals-coverage.test.ts
+++ b/test/unit/signals-coverage.test.ts
@@ -1127,7 +1127,7 @@ describe("signal coverage edge cases", () => {
       collisions: buildCollisionReport(directRepo.fullName, [], [currentPr]),
       preflight: buildPreflightResult({ repoFullName: directRepo.fullName, title: "Fix isolated issue", body: "Fixes #99", linkedIssues: [99] }, directRepo, [], [currentPr]),
       settings: gateSettings,
-      review: { present: true, footerText: "Reviewed by the Acme maintainer bot.", note: "Run npm test before pushing.", fields: { relatedWork: false }, enrichmentAnalyzers: {}, profile: null, securityFocus: null, inlineComments: null, pathInstructions: [], instructions: null, excludePaths: [], preMergeChecks: [] },
+      review: { present: true, footerText: "Reviewed by the Acme maintainer bot.", note: "Run npm test before pushing.", fields: { relatedWork: false }, enrichmentAnalyzers: {}, profile: null, securityFocus: null, inlineComments: null, effortScore: null, pathInstructions: [], instructions: null, excludePaths: [], preMergeChecks: [] },
       aiReview: { notes: "The change is focused.\n\n**Nits (2)**\n- Add a test for the </details> edge case.\n- Keep the validator helper scoped." },
     });
     expect(customizedComment).toContain("Reviewed by the Acme maintainer bot."); // custom footer lead

--- a/test/unit/unified-comment.test.ts
+++ b/test/unit/unified-comment.test.ts
@@ -154,6 +154,13 @@ describe("renderUnifiedReviewComment", () => {
     expect(md).toContain("Checked by Gittensory.");
   });
 
+  it("renders the compact review-effort chip only when input.reviewEffort is present — omitted keeps the comment byte-identical (#2069)", () => {
+    const withEffort = renderUnifiedReviewComment({ ...base, decision: "merge", reviewEffort: { band: 3, minutes: 15 } }, ctx);
+    expect(withEffort).toContain("`review effort: 3/5 (~15 min)`");
+    const withoutEffort = renderUnifiedReviewComment({ ...base, decision: "merge" }, ctx);
+    expect(withoutEffort).not.toContain("review effort:");
+  });
+
   it("does not describe a single reviewer as synthesized", () => {
     const md = renderUnifiedReviewComment({ ...base, reviewerCount: 1, decision: "manual", recommendations: ["manual_review"] }, ctx);
     expect(md).toContain("`1 AI reviewer`");
@@ -469,6 +476,13 @@ describe("buildUnifiedReviewInput", () => {
     expect(input.readiness).toEqual({ ciState: "passed" });
     expect(input.merged).toBe(true);
     expect(input.verdictReason).toBe("auto-merged after green CI");
+  });
+
+  it("threads the caller's reviewEffort estimator output through; omitted when absent (#2069)", () => {
+    const withEffort = buildUnifiedReviewInput({ changedFiles: 1, reviews: [reviewNote("merge")], reviewEffort: { band: 2, minutes: 8 } });
+    expect(withEffort.reviewEffort).toEqual({ band: 2, minutes: 8 });
+    const withoutEffort = buildUnifiedReviewInput({ changedFiles: 1, reviews: [reviewNote("merge")] });
+    expect(withoutEffort.reviewEffort).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

Adds a `review.effort_score` display toggle (default off) to `FocusManifestReviewConfig`, plus a `resolveReviewEffortScoreEnabled` accessor, mirroring the existing `security_focus`/`inline_comments` boolean-toggle pattern (parse in `parseReviewConfig`, included in `present`, serialized in `reviewConfigToJson`). Separately, `renderUnifiedReviewComment`/`buildUnifiedReviewInput` (`src/review/unified-comment.ts`) now accept an optional `reviewEffort: { band, minutes }` — the estimator's OUTPUT from the already-merged `estimateReviewEffort` (`src/review/review-effort.ts`) — and render it as a compact `` `review effort: N/5 (~M min)` `` status chip. Omitting the field (toggle off) keeps the comment byte-identical to today.

This is the same feature requested by GitHub issues 2152 and 2069 (both open at the time of this PR). **No issue is linked here intentionally**: issue 2152 is `maintainer-only` and assigned to the repo owner, so it is not eligible to be closed by a contributor PR (linking it would trip the linked-issue hard rule and auto-close this PR). Issue 2069 tracks the same request and remains open/unassigned; this PR does not claim to close it either — it is submitted standalone per `linkedIssuePolicy: preferred` (not required), with this paragraph as the explicit no-linked-issue rationale.

Also regenerates `apps/gittensory-ui/src/lib/selfhost-env-reference.ts`, which had drifted (stale `src/server.ts` line references) from unrelated upstream changes and was failing `npm run selfhost:env-reference:check` on `main` at the time this branch was cut — included so the local gate is green.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed. — see the Summary's no-linked-issue rationale above.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — the new `effortScore`/`reviewEffort` code paths (both toggle-on and toggle-off/omitted branches) are covered by new unit tests in `test/unit/focus-manifest.test.ts` and `test/unit/unified-comment.test.ts`.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — both the present/omitted render branches and the boolean/round-trip/warning parse branches are tested.

Ran the full local gate via `npm run test:ci` (which chains all of the above plus `db:migrations:check`, `db:schema-drift:check`, `selfhost:env-reference:check`, `cf-typegen:check`, `rees:test`, `ui:test`) — green.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no auth/session/CORS surface touched.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — no public API/OpenAPI/MCP surface changes; `ui:openapi:check` passes unchanged.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section below... — N/A, no visible UI change (backend-only; the env-reference regeneration is a generated data file, not a visible UI change).
- [ ] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — N/A, no changelog edit in this normal PR.

## Notes

- The unified-comment renderer this PR extends (`src/review/unified-comment.ts` / `unified-comment-bridge.ts`) is currently additive and dormant (not yet wired into the live comment-posting path per its own header comment), consistent with how the sibling `review.*` toggles in this file were added ahead of the eventual cutover.