### PR TITLE
fix(ui): step back a page instead of stranding operator on empty DLQ page

### DIFF
--- a/apps/gittensory-ui/src/components/site/dead-letter-queue-panel.test.tsx
+++ b/apps/gittensory-ui/src/components/site/dead-letter-queue-panel.test.tsx
@@ -408,6 +408,127 @@ describe("DeadLetterQueuePanel row actions and purge", () => {
     await waitFor(() => expect(replayButtons[1].disabled).toBe(false));
   });
 
+  // Navigates from a real page-1 render to a real page-2 render by clicking Next, the same way a user
+  // would -- `offset` is component STATE (starts at 0), not something a mocked response body can fake, so
+  // reaching a genuine "offset=25" request requires actually driving the Next click.
+  async function navigateToPageTwo(pageTwoData: typeof SAMPLE_PAGE) {
+    apiFetch.mockResolvedValueOnce({
+      ok: true,
+      data: { ...SAMPLE_PAGE, total: pageTwoData.total },
+    }); // page 1
+    render(<DeadLetterQueuePanel />);
+    await screen.findByText("github-webhook");
+
+    apiFetch.mockResolvedValueOnce({ ok: true, data: pageTwoData }); // page 2
+    fireEvent.click(screen.getByRole("link", { name: /next/i }));
+    await waitFor(() =>
+      expect(apiFetch).toHaveBeenCalledWith(
+        "https://api.test/v1/app/selfhost/queue/dead?limit=25&offset=25",
+        expect.any(Object),
+      ),
+    );
+  }
+
+  it("REGRESSION: replaying the only item on a non-first page steps back a page instead of reloading the same now-empty offset", async () => {
+    // A single row on page 2 (offset=25) of a 26-total queue. Reloading the SAME offset after removing it
+    // would fetch zero items there, even though page 1 still has 25 real jobs -- stranding the operator on a
+    // misleadingly-empty page instead of showing them the queue still has work.
+    const lastPageOfOne = {
+      generatedAt: SAMPLE_PAGE.generatedAt,
+      limit: 25,
+      offset: 25,
+      total: 26,
+      items: [
+        {
+          id: 50,
+          jobType: "agent-regate-pr",
+          attempts: 2,
+          lastError: null,
+          createdAtMs: 3_000,
+          deadAtMs: 8_000,
+        },
+      ],
+    };
+    await navigateToPageTwo(lastPageOfOne);
+    await screen.findByText("agent-regate-pr");
+
+    apiFetch.mockClear();
+    apiFetch.mockResolvedValueOnce({ ok: true, data: { ok: true, id: 50 } }); // replay call
+    apiFetch.mockResolvedValueOnce({ ok: true, data: SAMPLE_PAGE }); // the stepped-back page 1 fetch
+
+    fireEvent.click(screen.getByRole("button", { name: "Replay" }));
+
+    await waitFor(() =>
+      expect(apiFetch).toHaveBeenCalledWith(
+        "https://api.test/v1/app/selfhost/queue/dead/50/replay",
+        expect.objectContaining({ method: "POST" }),
+      ),
+    );
+    // Must step back to offset=0, NOT re-fetch the same now-empty offset=25.
+    await waitFor(() =>
+      expect(apiFetch).toHaveBeenCalledWith(
+        "https://api.test/v1/app/selfhost/queue/dead?limit=25&offset=0",
+        expect.any(Object),
+      ),
+    );
+    expect(apiFetch).not.toHaveBeenCalledWith(
+      "https://api.test/v1/app/selfhost/queue/dead?limit=25&offset=25",
+      expect.any(Object),
+    );
+  });
+
+  it("does NOT step back a page when other items remain on the current (non-first) page", async () => {
+    const twoOnPageTwo = {
+      generatedAt: SAMPLE_PAGE.generatedAt,
+      limit: 25,
+      offset: 25,
+      total: 27,
+      items: [
+        {
+          id: 51,
+          jobType: "agent-regate-pr",
+          attempts: 1,
+          lastError: null,
+          createdAtMs: 3_000,
+          deadAtMs: 8_000,
+        },
+        {
+          id: 50,
+          jobType: "agent-regate-pr",
+          attempts: 2,
+          lastError: null,
+          createdAtMs: 2_000,
+          deadAtMs: 7_000,
+        },
+      ],
+    };
+    await navigateToPageTwo(twoOnPageTwo);
+    await screen.findAllByText("agent-regate-pr");
+
+    apiFetch.mockClear();
+    apiFetch.mockResolvedValueOnce({ ok: true, data: { ok: true, id: 51 } }); // replay call
+    apiFetch.mockResolvedValueOnce({
+      ok: true,
+      data: { ...twoOnPageTwo, total: 26, items: [twoOnPageTwo.items[1]] },
+    }); // in-place refetch
+
+    fireEvent.click(screen.getAllByRole("button", { name: "Replay" })[0]);
+
+    await waitFor(() =>
+      expect(apiFetch).toHaveBeenCalledWith(
+        "https://api.test/v1/app/selfhost/queue/dead/51/replay",
+        expect.objectContaining({ method: "POST" }),
+      ),
+    );
+    // A sibling item remains on this page -- refetch the SAME offset, don't step back.
+    await waitFor(() =>
+      expect(apiFetch).toHaveBeenCalledWith(
+        "https://api.test/v1/app/selfhost/queue/dead?limit=25&offset=25",
+        expect.any(Object),
+      ),
+    );
+  });
+
   it("Purge all opens a confirmation dialog with the expected warning text", async () => {
     apiFetch.mockResolvedValueOnce({ ok: true, data: SAMPLE_PAGE });
     render(<DeadLetterQueuePanel />);

--- a/apps/gittensory-ui/src/components/site/dead-letter-queue-panel.tsx
+++ b/apps/gittensory-ui/src/components/site/dead-letter-queue-panel.tsx
@@ -48,22 +48,28 @@ export function DeadLetterQueuePanel() {
 
   async function purgeAll() {
     setPurging(true);
-    const result = await apiFetch<{ ok: true; purged: number }>(
-      apiUrl(DEAD_LETTER_QUEUE_PURGE_PATH),
-      {
-        method: "DELETE",
-        label: "Purge dead-letter queue",
-        credentials: "include",
-      },
-    );
-    setPurging(false);
-    if (result.ok) {
-      toast.success("Dead-letter queue purged", {
-        description: `Purged ${result.data.purged} job${result.data.purged === 1 ? "" : "s"}.`,
-      });
-      resource.reload();
-    } else {
-      toast.error("Purge failed", { description: result.message });
+    try {
+      const result = await apiFetch<{ ok: true; purged: number }>(
+        apiUrl(DEAD_LETTER_QUEUE_PURGE_PATH),
+        {
+          method: "DELETE",
+          label: "Purge dead-letter queue",
+          credentials: "include",
+        },
+      );
+      if (result.ok) {
+        toast.success("Dead-letter queue purged", {
+          description: `Purged ${result.data.purged} job${result.data.purged === 1 ? "" : "s"}.`,
+        });
+        // Deliberately no step-back-a-page logic here (unlike runJobAction below): purge empties the ENTIRE
+        // queue, so any offset now legitimately returns zero items -- there's no earlier page with real data
+        // to redirect to, unlike a single-row action where other pages still have jobs.
+        resource.reload();
+      } else {
+        toast.error("Purge failed", { description: result.message });
+      }
+    } finally {
+      setPurging(false);
     }
   }
 
@@ -98,6 +104,7 @@ export function DeadLetterQueuePanel() {
                 <AlertDialogAction
                   className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
                   onClick={() => void purgeAll()}
+                  disabled={purging}
                 >
                   Purge all
                 </AlertDialogAction>
@@ -160,27 +167,43 @@ function DeadLetterQueueTable({
 
   async function runJobAction(id: number, action: "replay" | "delete") {
     setPendingRowIds((current) => new Set(current).add(id));
-    const result = await apiFetch<{ ok: true; id: number }>(
-      apiUrl(buildDeadLetterJobActionPath(id, action)),
-      {
-        method: action === "replay" ? "POST" : "DELETE",
-        label: action === "replay" ? "Replay dead-letter job" : "Delete dead-letter job",
-        credentials: "include",
-      },
-    );
-    setPendingRowIds((current) => {
-      const next = new Set(current);
-      next.delete(id);
-      return next;
-    });
-    if (result.ok) {
-      toast.success(action === "replay" ? "Job queued for replay" : "Job deleted", {
-        description: `Job #${id} ${action === "replay" ? "was requeued." : "was removed from the dead-letter queue."}`,
-      });
-      onReload();
-    } else {
-      toast.error(action === "replay" ? "Replay failed" : "Delete failed", {
-        description: result.message,
+    try {
+      const result = await apiFetch<{ ok: true; id: number }>(
+        apiUrl(buildDeadLetterJobActionPath(id, action)),
+        {
+          method: action === "replay" ? "POST" : "DELETE",
+          label: action === "replay" ? "Replay dead-letter job" : "Delete dead-letter job",
+          credentials: "include",
+        },
+      );
+      if (result.ok) {
+        toast.success(action === "replay" ? "Job queued for replay" : "Job deleted", {
+          description: `Job #${id} ${action === "replay" ? "was requeued." : "was removed from the dead-letter queue."}`,
+        });
+        // The row just acted on was the ONLY item on a non-first page -- reloading the SAME offset would
+        // return zero items there (even though earlier pages still have jobs), stranding the operator on a
+        // misleadingly-empty page. Step back a page instead; any other case just refetches in place.
+        // KNOWN LIMITATION: page.items.length is a snapshot from this render, shared by every in-flight
+        // action's closure -- if an operator fires two DIFFERENT rows' actions on the same 2-item page before
+        // either resolves, both closures see length===2 and neither steps back, even though together they
+        // empty the page. Recoverable (Previous still works) and narrow enough that fixing it would need a
+        // bigger redesign (e.g. tracking resolved-this-batch count instead of a static snapshot) -- left as a
+        // deliberate, documented gap rather than expanding this fix's scope.
+        if (page.items.length === 1 && page.offset > 0) {
+          onPageChange(Math.max(0, page.offset - page.limit));
+        } else {
+          onReload();
+        }
+      } else {
+        toast.error(action === "replay" ? "Replay failed" : "Delete failed", {
+          description: result.message,
+        });
+      }
+    } finally {
+      setPendingRowIds((current) => {
+        const next = new Set(current);
+        next.delete(id);
+        return next;
       });
     }
   }
@@ -265,6 +288,7 @@ function DeadLetterQueueTable({
                             <AlertDialogAction
                               className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
                               onClick={() => void runJobAction(item.id, "delete")}
+                              disabled={pendingRowIds.has(item.id)}
                             >
                               Delete
                             </AlertDialogAction>


### PR DESCRIPTION
## Summary

- Follow-up to #2952 (dead-letter-queue replay/delete/purge actions, merged) — addresses the blocker Gittensory's own review found on that PR after it had already been merged, so it never made it into the original diff.
- **The bug**: replaying or deleting the *only* item on a non-first DLQ page reloaded the same now-empty offset, showing "No dead-letter jobs" even though earlier pages still had real work — misleading the operator into thinking the queue was clear.
- **The fix**: when the acted-on row was the only item on a page with `offset > 0`, step back a page (`Math.max(0, page.offset - page.limit)`) instead of reloading in place; every other case is unchanged.
- Also fixed the review's two lower-severity nits: `purgeAll`/`runJobAction`'s pending-state cleanup now runs in `try/finally` (a thrown request can no longer leave the controls permanently disabled), and the destructive `AlertDialogAction` confirm buttons are now `disabled` while their own request is in flight.
- **Documented, deliberately out-of-scope limitation**: two independent adversarial review passes (run before this push, given the file's track record — every prior round on this component found a real issue) both surfaced the same finding: concurrently resolving two *different* rows' actions on the same 2-item non-first page can each capture a stale per-render item count and neither steps back. Both agreed this is real but narrow (needs a deliberate near-simultaneous double-action), fully recoverable (Previous still works), and would need a larger redesign (tracking a live resolved-this-batch count instead of a static snapshot) to close — left as an explicitly commented gap rather than expanding this fix's scope.

## Scope

- [x] Conventional Commit title.
- [x] Focused — one UI bug fix plus two directly-related hardening nits from the same review, no unrelated changes.
- [x] Follows `CONTRIBUTING.md`, no `site/`/`CNAME`/`lovable` changes.
- [x] Linked context: follow-up to #2952/#2215.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` (not run — no `.github/workflows/**` changes)
- [x] `npm run typecheck`
- [x] `dead-letter-queue-panel.test.tsx` — 30/30 passing, including two new regression tests that genuinely drive a real page-2 navigation (clicking the actual Next control, not just mocking a response body that claims a nonzero offset — verified this distinction matters by first writing a version of the test that didn't do this and watching it fail against the real component behavior). Sanity-checked the primary regression test is meaningful by temporarily reverting the fix locally and confirming it fails, then restoring the fix and confirming it passes again.
- [ ] `npm run test:workers` (not run — no Workers-pool-specific code touched)
- [ ] `npm run build:mcp` / `npm run test:mcp-pack` (not run — no `packages/gittensory-mcp` changes)
- [x] `npm run ui:openapi:check` (unaffected by this diff, re-verified clean)
- [x] `npm run ui:lint`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] Ran a dedicated 2-lens adversarial review (correctness + edge-cases) against this diff before pushing, given the prior rounds' track record on this file — both lenses' findings are addressed or explicitly documented above.

## Safety

- [x] No secrets/wallet/hotkey/trust-score/reward data exposed.
- [x] Public GitHub text unaffected.
- [x] N/A — no auth/cookie/CORS/session changes.
- [x] No API/OpenAPI shape change (pure client-side pagination/state-handling fix).
- [x] UI still uses live API data; this only changes which page is requested/shown after a mutation.
- [ ] No UI Evidence table — this changes pagination *behavior* after a mutation, not visible layout/styling; the fix is exercised by the two new automated tests.
- [x] No changelog edit.

## Notes

Same timeline pattern as the previous two PRs in this chain (#2921→#2931, #2952→this one): the maintainer reviewed and merged #2952 shortly after its first round of CI went green, before this second review-round fix could land on that branch — so this PR carries the fix fresh against current `main`.