### PR TITLE
fix(enrichment): don't treat an added '+++' content line as a diff file header

### DIFF
--- a/review-enrichment/src/analyzers/undocumented-export.ts
+++ b/review-enrichment/src/analyzers/undocumented-export.ts
@@ -7,6 +7,7 @@
 // aggregate symbols documented at their definition); a missing token/head-sha, an unresolvable repo slug, or any
 // fetch error yields no finding rather than an error.
 import type { EnrichRequest, UndocumentedExportFinding } from "../types.js";
+import { isDiffFileHeaderLine } from "./diff-lines.js";
 
 const GITHUB_API = "https://api.github.com";
 const MAX_FILES = 10;
@@ -104,7 +105,11 @@ export function parseAddedExports(patch: string): Array<{ symbol: string; newLin
       continue;
     }
     if (raw.startsWith("+")) {
-      if (!raw.startsWith("+++")) {
+      // Skip only a real unified-diff file header (`+++ b/path`), not added CONTENT that merely starts with
+      // `++` (git renders `++x;` as `+++x;`). The bespoke startsWith("+++") guard dropped such a line and left
+      // the new-file cursor un-advanced, mis-numbering (and thus losing) every export after it. Use the shared
+      // header predicate the sibling diff analyzers rely on.
+      if (!isDiffFileHeaderLine(raw)) {
         for (const symbol of exportedSymbols(raw.slice(1))) out.push({ symbol, newLine });
         newLine += 1;
       }

--- a/review-enrichment/test/undocumented-export.test.ts
+++ b/review-enrichment/test/undocumented-export.test.ts
@@ -186,3 +186,10 @@ test("scanUndocumentedExport: no token or no headSha → skipped (no finding, no
   assert.deepEqual(await scanUndocumentedExport(req(files, { githubToken: undefined }), headFetch(HEAD)), []);
   assert.deepEqual(await scanUndocumentedExport(req(files, { headSha: undefined }), headFetch(HEAD)), []);
 });
+
+test("parseAddedExports: an added content line rendered as '+++...' is not mistaken for a diff header", () => {
+  // git renders an added source line "++x;" as "+" + "++x;" = "+++x;". The old startsWith("+++") guard skipped
+  // it as if it were a "+++ b/path" file header, failing to advance the new-file cursor and mis-numbering foo.
+  const patch = ["@@ -1,1 +1,2 @@", "+++x;", "+export function foo() {}"].join("\n");
+  assert.deepEqual(parseAddedExports(patch), [{ symbol: "foo", newLine: 2 }]);
+});


### PR DESCRIPTION
## Summary

`parseAddedExports()` in `review-enrichment/src/analyzers/undocumented-export.ts` walks a unified diff to collect newly-added exported symbols with their new-file line numbers. It guarded the diff **file header** (`+++ b/path`) with a bare `!raw.startsWith("+++")` — but that also matches added **content** whose source text begins with `++`, because git renders a `+`-added line `++x;` as `+` (the add marker) + `++x;` = `+++x;`.

The effect: such a content line is skipped **without advancing the new-file cursor**, so every export after it in that hunk is recorded one (or more) lines too low. In `scanUndocumentedExport`, the confirmation step reads the export back from the fetched file at that (wrong) line, finds no export there, and **silently drops the finding** — an undocumented public export ships unflagged.

Concretely, for the patch:
```
@@ -1,1 +1,2 @@
+++x;
+export function foo() {}
```
`parseAddedExports` returned `[{ symbol: "foo", newLine: 1 }]` (wrong — `foo` is on new-file line 2), which then fails confirmation and is dropped. Expected: `[{ symbol: "foo", newLine: 2 }]`.

This uses the shared `isDiffFileHeaderLine` predicate (`/^(?:\+\+\+|---) (?:[ab]\/|\/dev\/null)/`) that the sibling diff analyzers (`heavy-dependency`, `history`, `dependency-scan`, `lockfile-drift`) already rely on — a real `+++ b/path` header still matches (unchanged), but `+++x;` content is now scanned and advances the cursor. Adds a regression test for the `+++`-content case.

No linked issue: issue creation on this repo is restricted to collaborators, and this is a small, self-contained correctness fix (reuse the shared header predicate the other diff analyzers use) whose rationale is self-evident from the diff.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- The full `npm run test:ci` aggregate ran green (including `rees:test`, the review-enrichment build + node test suite: 540 passing) plus `npm audit --audit-level=moderate` (0 vulnerabilities). The change is under `review-enrichment/**`, which Codecov does not measure; its node test suite is the gate, and the new test exercises the fixed branch.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

Pure diff-parsing logic in the review-enrichment package; no auth/CORS/session surface, no API/OpenAPI shape change, no UI. The `Safety` boxes are checked on that basis.

## Notes

- Reuses the existing `isDiffFileHeaderLine` helper (single source of truth shared with the other diff analyzers) instead of the bespoke prefix check. No schema, migration, OpenAPI, wrangler, or generated-artifact impact.
