### PR TITLE
fix(miner): reject negative portfolio queue priorities

### DIFF
--- a/packages/gittensory-miner/lib/portfolio-queue.js
+++ b/packages/gittensory-miner/lib/portfolio-queue.js
@@ -52,10 +52,12 @@ function normalizeIdentifier(identifier) {
   return trimmed;
 }
 
-/** Priority is a placeholder numeric input; an omitted priority defaults to 0, a non-finite one is rejected. */
+/** Priority is a placeholder numeric input; an omitted priority defaults to 0, a non-finite or negative one is rejected. */
 function normalizePriority(priority) {
   if (priority === undefined) return 0;
-  if (typeof priority !== "number" || !Number.isFinite(priority)) throw new Error("invalid_priority");
+  if (typeof priority !== "number" || !Number.isFinite(priority) || priority < 0) {
+    throw new Error("invalid_priority");
+  }
   return priority;
 }
 

--- a/test/unit/miner-portfolio-queue.test.ts
+++ b/test/unit/miner-portfolio-queue.test.ts
@@ -154,6 +154,7 @@ describe("gittensory-miner portfolio/queue store (#2292)", () => {
     expect(() => store.enqueue({ repoFullName: "o/a", identifier: "1", priority: Number.NaN })).toThrow(
       "invalid_priority",
     );
+    expect(() => store.enqueue({ repoFullName: "o/a", identifier: "1", priority: -1 })).toThrow("invalid_priority");
     // listQueue and markDone enforce the same repo/identifier validation as enqueue.
     expect(() => store.listQueue("no-slash")).toThrow("invalid_repo_full_name");
     expect(() => store.markDone("no-slash", "1")).toThrow("invalid_repo_full_name");


### PR DESCRIPTION
## Summary

- Reject negative portfolio queue priorities during enqueue validation.
- Keeps placeholder priority semantics non-negative so `priority DESC` ordering stays predictable.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] Focused on portfolio-queue priority validation only — no unrelated miner CLI or UI changes.

## Validation

- [ ] `npm run test:ci` locally — CI will run the full gate on push.
- [x] Unit test covers negative priority rejection on enqueue.

## Safety

- [x] No secrets, wallet details, hotkeys, or private scoring output in code or PR text.
- [x] Deterministic, read/write-local only: no network calls.

## UI Evidence

Not applicable — miner library only.
