### PR TITLE
fix(scoring): keep label classes with a literal dash after a range matchable

### DIFF
--- a/src/scoring/preview.ts
+++ b/src/scoring/preview.ts
@@ -1046,8 +1046,19 @@ function escapeRegExpLiteral(value: string): string {
 
 function hasDescendingCharacterRange(body: string): boolean {
   const start = body.startsWith("!") ? 1 : 0;
-  for (let i = start + 1; i < body.length - 1; i += 1) {
-    if (body.charAt(i) === "-" && body.charCodeAt(i - 1) > body.charCodeAt(i + 1)) return true;
+  // Walk the class left-to-right, consuming each `X-Y` range as a unit so a range endpoint can't be
+  // misread as the start of a spurious second range. Only a genuinely inverted range like `[z-a]` — the
+  // case JS `RegExp` actually throws on — must degrade the class to never-match; a literal `-` that
+  // follows a completed range (as in `[a-z-9]`, a valid class) must NOT be suppressed. The prior scan
+  // flagged any `-` whose left neighbor outranked its right neighbor, so it wrongly killed `[a-z-9]`.
+  let i = start;
+  while (i < body.length) {
+    if (i + 2 < body.length && body.charAt(i + 1) === "-") {
+      if (body.charCodeAt(i) > body.charCodeAt(i + 2)) return true;
+      i += 3;
+    } else {
+      i += 1;
+    }
   }
   return false;
 }

--- a/test/unit/scoring.test.ts
+++ b/test/unit/scoring.test.ts
@@ -1950,6 +1950,26 @@ describe("label pattern matcher memoization (#2106)", () => {
     expect(labelMatchesPattern("bugfix", "bug")).toBe(false);
   });
 
+  it("REGRESSION: a literal `-` following a completed range keeps the class valid, not a descending range", () => {
+    // `[a-z-9]` is `a`-`z` plus a literal `-` plus `9` — a valid class that JS `RegExp` compiles and Python
+    // fnmatch matches, so the preview must too. The descending-range suppressor previously misread the
+    // trailing `-9` as an inverted range and degraded the whole class to never-match, silently dropping any
+    // `label_multipliers` key shaped like this to the neutral default. Only a genuinely inverted range
+    // (the case JS `RegExp` throws on) may be suppressed.
+    expect(labelMatchesPattern("m", "[a-z-9]")).toBe(true); // inside the a-z range
+    expect(labelMatchesPattern("9", "[a-z-9]")).toBe(true); // the trailing literal member
+    expect(labelMatchesPattern("-", "[a-z-9]")).toBe(true); // the literal dash member
+    expect(labelMatchesPattern("5", "[a-z-9]")).toBe(false); // 5 is not in {a-z, -, 9}
+    // A genuinely inverted range stays a never-match — the fix preserves the JS-`RegExp`-throws case.
+    expect(labelMatchesPattern("m", "[z-a]")).toBe(false);
+    // The same literal-dash handling applies inside a negated class `[!a-z-9]` (matches only chars OUTSIDE it).
+    expect(labelMatchesPattern("5", "[!a-z-9]")).toBe(true);
+    expect(labelMatchesPattern("a", "[!a-z-9]")).toBe(false);
+    // A plain multi-character class with no range exercises the non-range walk arm.
+    expect(labelMatchesPattern("b", "[abc]")).toBe(true);
+    expect(labelMatchesPattern("d", "[abc]")).toBe(false);
+  });
+
   it("SECURITY (ReDoS, #2456): a label pattern with too many chained wildcards no longer risks catastrophic backtracking — it fails SAFE TOWARD NO MULTIPLIER (never matches) instead of ever compiling the pathological pattern", () => {
     // 3 chained wildcards is already empirically dangerous for the identical `.*`-chaining shape this reuses
     // from change-guardrail.ts's globToRegExp (see MAX_GLOB_WILDCARD_GROUPS's rationale: over 2 seconds at a


### PR DESCRIPTION
## Summary

`labelMatchesPattern` (`src/scoring/preview.ts`) compiles each configured `label_multipliers` fnmatch key to an anchored `RegExp`. Its `hasDescendingCharacterRange` guard exists to degrade only *genuinely invalid* ranges -- the ones JS `RegExp` throws on, e.g. `[z-a]` -- to a never-match `(?!)`. It instead flagged **any** `-` whose left neighbor outranked its right neighbor, so a **literal** `-` following a completed range was misread as an inverted range and a **valid** class compiled to match nothing.

Example: `labelMatchesPattern("m", "[a-z-9]")` returned `false`, though `[a-z-9]` (`a`-`z` plus a literal `-` plus `9`) is a valid class that both JS `RegExp` and Python `fnmatch` match. A registry key like `{"[a-z-9]": 2.0}` therefore never matched, so `selectLabelMultiplier` silently fell back to the neutral default and the config-quality / label-audit signals reported the label as "not observed".

The fix walks the class left-to-right, consuming each `X-Y` range as a unit so a range endpoint cannot seed a spurious second range; only a genuinely inverted range (the JS-`RegExp`-throws case) is suppressed. `[z-a]` remains a never-match.

No linked issue: this is a small, self-contained correctness fix in pure scoring logic; per `linkedIssuePolicy: preferred`, the defect is fully described above.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] This is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] Scoped coverage: `src/scoring/preview.ts` shows 100% branch coverage of the changed function via `test/unit/scoring.test.ts` (added regression test); `labelMatchesPattern` verified against `new RegExp` across range / literal-dash / negated / inverted inputs.
- [x] New behavior has unit tests for the new branches (range-consume, literal-dash-after-range, negated class, inverted-range never-match, plain class).

If any required check was skipped, explain why:

- The full `npm run test:ci` was not run in this local dev environment; several self-host suites require Linux/bash/Docker/Postgres. This change is a single pure-logic function under `src/scoring/` with no API/OpenAPI/MCP/wrangler-binding/DB/migration/UI surface, so the directly relevant checks are `typecheck` (green) and changed-line branch coverage (100%, verified). The remaining CI jobs run on this PR.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized and does not imply compensation guarantees or optimization tactics.
- [x] No auth, cookie, CORS, GitHub App, Cloudflare, or session behavior is changed.
- [x] No API/OpenAPI/MCP behavior changes (pure internal scoring helper).
- [x] No UI changes.
- [x] No docs/changelog changes needed.

## UI Evidence

N/A -- pure backend scoring-logic fix, no UI/frontend/docs/extension change.

## Notes

- Regression test added in `test/unit/scoring.test.ts`.