### PR TITLE
test(enrichment): unit-cover the asset-weight analyzer's pure helpers

### DIFF
--- a/review-enrichment/src/analyzers/asset-weight.ts
+++ b/review-enrichment/src/analyzers/asset-weight.ts
@@ -82,14 +82,18 @@ interface ScanOptions {
 const REPO_SEGMENT = /^[A-Za-z0-9._-]+$/;
 const SHA_RE = /^[0-9a-fA-F]{7,64}$/;
 
-function isBinaryAsset(path: string): boolean {
+/** True when a path's extension is a genuinely binary asset (image/font/media/archive/binary). Text formats
+ *  like .svg/.json are deliberately excluded — their bytes are already in the textual diff. Pure. */
+export function isBinaryAsset(path: string): boolean {
   const dot = path.lastIndexOf(".");
   return dot >= 0 && BINARY_EXTS.has(path.slice(dot + 1).toLowerCase());
 }
 
 type EnrichFile = NonNullable<EnrichRequest["files"]>[number];
 
-function basePathForGrowth(file: EnrichFile): string | null {
+/** The base-side path to measure growth against: the same path for a modified/changed file, the pre-rename
+ *  path for a rename, and null for anything else (added/removed have no comparable base size). Pure. */
+export function basePathForGrowth(file: EnrichFile): string | null {
   if (file.status === "modified" || file.status === "changed") return file.path;
   if (file.status === "renamed") return file.previousPath || null;
   return null;
@@ -104,7 +108,9 @@ function githubHeaders(token: string): Record<string, string> {
   };
 }
 
-function encodeRepoPath(path: string): string | null {
+/** Percent-encode each segment of a repo path for a Contents API URL, rejecting (null) an empty path or any
+ *  empty / `.` / `..` segment so a crafted path can never traverse out of the tree. Pure. */
+export function encodeRepoPath(path: string): string | null {
   const segments = path.split("/");
   if (!path || segments.some((seg) => !seg || seg === "." || seg === "..")) {
     return null;

--- a/review-enrichment/test/asset-weight.test.ts
+++ b/review-enrichment/test/asset-weight.test.ts
@@ -1,0 +1,48 @@
+// Units for the asset-weight analyzer's pure helpers (#1506). Kept separate so analyzer PRs avoid collisions.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  isBinaryAsset,
+  basePathForGrowth,
+  encodeRepoPath,
+} from "../dist/analyzers/asset-weight.js";
+
+test("isBinaryAsset flags genuine binary extensions and ignores text/case", () => {
+  // Genuine binary assets (image / font / media / archive / native binary).
+  for (const p of ["ui/logo.png", "fonts/Inter.woff2", "media/demo.mp4", "vendor/lib.wasm", "dist/app.zip"]) {
+    assert.equal(isBinaryAsset(p), true, p);
+  }
+  // Extension match is case-insensitive.
+  assert.equal(isBinaryAsset("assets/HERO.PNG"), true);
+  // Text formats whose bytes are already in the diff are NOT binary assets.
+  for (const p of ["icons/logo.svg", "data/config.json", "src/index.ts", "README.md"]) {
+    assert.equal(isBinaryAsset(p), false, p);
+  }
+  // A path with no extension, or a dotfile with no real extension after the dot, is not a binary asset.
+  assert.equal(isBinaryAsset("Makefile"), false);
+  assert.equal(isBinaryAsset("noext"), false);
+});
+
+test("basePathForGrowth resolves the base-side path per file status", () => {
+  assert.equal(basePathForGrowth({ path: "a.png", status: "modified" }), "a.png");
+  assert.equal(basePathForGrowth({ path: "a.png", status: "changed" }), "a.png");
+  assert.equal(basePathForGrowth({ path: "new.png", previousPath: "old.png", status: "renamed" }), "old.png");
+  // A rename with no previousPath has no comparable base.
+  assert.equal(basePathForGrowth({ path: "new.png", status: "renamed" }), null);
+  // Added/removed files have no base size to grow from.
+  assert.equal(basePathForGrowth({ path: "a.png", status: "added" }), null);
+  assert.equal(basePathForGrowth({ path: "a.png", status: "removed" }), null);
+});
+
+test("encodeRepoPath percent-encodes segments and rejects traversal", () => {
+  assert.equal(encodeRepoPath("assets/logo.png"), "assets/logo.png");
+  // Spaces and other unsafe characters are percent-encoded per segment (the '/' separators are preserved).
+  assert.equal(encodeRepoPath("my assets/a b.png"), "my%20assets/a%20b.png");
+  // An empty path, or any empty / "." / ".." segment, is rejected so a crafted path can't traverse the tree.
+  assert.equal(encodeRepoPath(""), null);
+  assert.equal(encodeRepoPath("a/../b"), null);
+  assert.equal(encodeRepoPath("a/./b"), null);
+  assert.equal(encodeRepoPath("a//b"), null);
+  assert.equal(encodeRepoPath(".."), null);
+});


### PR DESCRIPTION
## Summary

The image/binary asset-weight analyzer (`review-enrichment/src/analyzers/asset-weight.ts`, #1506) had a few pure path helpers that were only ever exercised indirectly through the fetch-orchestrating `scanAssetWeight`. This adds dedicated unit coverage for them — the same shape as the EOL analyzer's `extractVersionPins` unit tests (#2932) — by exporting the helpers and pinning their contracts directly:

- **`isBinaryAsset`** — genuine binary extensions (image/font/media/archive/native) are flagged, text formats whose bytes are already in the diff (`.svg`, `.json`, `.ts`, `.md`) are not, matching is case-insensitive, and a path with no real extension is not an asset.
- **`basePathForGrowth`** — the base-side path to measure growth against: same path for `modified`/`changed`, the pre-rename path for `renamed`, `null` for `added`/`removed` (no comparable base) and for a rename missing `previousPath`.
- **`encodeRepoPath`** — per-segment percent-encoding, and the empty / `.` / `..` / empty-segment rejection that keeps the Contents API fetch from traversing out of the tree (a small but security-relevant invariant now pinned).

No production behavior changes — the helpers gain an `export` and a doc-comment; the logic is untouched. This is coverage-only.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- The full `npm run test:ci` aggregate ran green (including `rees:test`, the review-enrichment build + node test suite, with the new `asset-weight.test.ts` passing) plus `npm audit --audit-level=moderate` (0 vulnerabilities). This is a `review-enrichment/**` test addition (not measured by Codecov); its node test suite is the gate.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

Test-only change (plus three `export` keywords and doc-comments) in the review-enrichment package; no auth/CORS/session surface, no API/OpenAPI shape change, no UI, no runtime behavior change.

## Notes

- Adds `review-enrichment/test/asset-weight.test.ts` and exports three existing pure helpers so they can be unit-tested directly (the module's established pattern, cf. `eol-check.ts`'s exported `extractVersionPins`). No schema, migration, OpenAPI, wrangler, or generated-artifact impact.
