### PR TITLE
fix(ci): retry-poll Sentry release validation in the Orb release pipeline

### DIFF
--- a/.github/workflows/release-selfhost.yml
+++ b/.github/workflows/release-selfhost.yml
@@ -250,7 +250,26 @@ jobs:
           SENTRY_REQUIRE_COMMITS: "true"
           SENTRY_REQUIRE_DEPLOY: "false"
           SENTRY_REQUIRE_FINALIZED: "true"
-        run: node review-enrichment/scripts/validate-sentry-release.mjs
+        run: |
+          set -euo pipefail
+          # The CLI's `set-commits` was replaced with a direct PUT above after it silently no-op'd on
+          # orb-v0.1.0-beta.1, but Sentry's release-commits read path can still lag briefly behind a
+          # write. review-enrichment/src/upload-sourcemaps.ts's runReleaseValidation() already
+          # retry-polls this same script for REES's Railway deploy path -- mirror that here instead of
+          # failing the whole release build on a transient read-lag.
+          attempts=5
+          delay_secs=10
+          for attempt in $(seq 1 "$attempts"); do
+            if node review-enrichment/scripts/validate-sentry-release.mjs; then
+              exit 0
+            fi
+            if [ "$attempt" -lt "$attempts" ]; then
+              echo "::warning::Sentry release validation attempt ${attempt}/${attempts} failed; retrying in ${delay_secs}s"
+              sleep "$delay_secs"
+            fi
+          done
+          echo "::error::Sentry release validation failed after ${attempts} attempts"
+          exit 1
 
       - name: GitHub Release
         if: github.event_name == 'push'


### PR DESCRIPTION
## Summary

- The "Validate Sentry release" step in `release-selfhost.yml` (the `release-orb` workflow) ran `validate-sentry-release.mjs` exactly once, with no tolerance for Sentry's release-commits read path lagging briefly behind a write.
- `orb-v0.1.0-beta.1`'s release run failed at this exact step (`release has no associated commits`) even though the Docker image itself built and pushed successfully — the failure only blocked the GitHub Release step, and required manual cleanup afterward.
- `review-enrichment/src/upload-sourcemaps.ts`'s `runReleaseValidation()` already solves this same problem for REES's Railway deploy path by re-invoking this exact script in a bounded retry loop with a short delay between attempts, rather than baking retry into the script itself.
- This PR applies that same established pattern to the self-host Orb release workflow: the step now retries up to 5 times with a 10s delay, logging a `::warning::` on each retry and only failing the build if every attempt is exhausted.
- `validate-sentry-release.mjs` itself is unchanged (still a pure, single-attempt, testable module) — only the calling workflow step gained the retry loop, keeping the fix consistent with how the script is already used elsewhere in the codebase.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed. (No issue: a small, self-contained CI reliability fix scoped to one workflow step, following the same pattern already shipped elsewhere in the codebase.)

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage`
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [ ] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This PR only changes a `.github/workflows/*.yml` step's shell script (a retry loop around an existing, unchanged Node invocation). No `src/`, `apps/`, `test/`, or schema files changed, so the TS/UI/coverage/OpenAPI/MCP checks above are inapplicable — `actionlint` is the relevant local check for workflow YAML/shell and passed clean.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session/CORS changes.)
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP changes.)
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes.)
- [ ] Visible UI changes include a `UI Evidence` section below with screenshots. (N/A — no visible UI changes.)
- [ ] Public docs/changelogs are updated where needed. (N/A — no docs/changelog changes.)

## Notes

- Not a fix for a currently-reproducing bug: the direct-PUT commit-association workaround already shipped in #2823 (in response to beta.1's failure) and `orb-v0.1.0-beta.2`'s release run completed cleanly without needing any retry. This is defense-in-depth against the same class of eventual-consistency lag, matching the retry pattern the codebase already relies on for the equivalent Railway/REES deploy path.