### PR TITLE
fix(engine): fail closed on broken competition inputs

### DIFF
--- a/packages/gittensory-engine/src/opportunity-competition.ts
+++ b/packages/gittensory-engine/src/opportunity-competition.ts
@@ -11,6 +11,11 @@ function finiteNonNegative(value: number): number {
   return Math.max(0, value);
 }
 
+function finiteClusterPressure(value: number): number {
+  if (!Number.isFinite(value)) return Number.POSITIVE_INFINITY;
+  return Math.max(0, value);
+}
+
 /**
  * Compute a [0, 1] competition factor from duplicate-cluster pressure and open PR volume, mirroring
  * `opportunityCompetitionFactor` in `src/signals/reward-risk.ts` so the miner engine can derive `dupRisk`
@@ -20,7 +25,7 @@ export function computeOpportunityCompetition(
   highRiskDuplicateClusters: number,
   openPullRequests: number,
 ): number {
-  const clusters = finiteNonNegative(highRiskDuplicateClusters);
+  const clusters = finiteClusterPressure(highRiskDuplicateClusters);
   const openPrs = finiteNonNegative(openPullRequests);
   return round4(clamp(clusters / Math.max(1, openPrs), 0, 1));
 }

--- a/packages/gittensory-engine/src/opportunity-competition.ts
+++ b/packages/gittensory-engine/src/opportunity-competition.ts
@@ -11,7 +11,10 @@ function finiteNonNegative(value: number): number {
   return Math.max(0, value);
 }
 
-function finiteClusterPressure(value: number): number {
+function failClosedClusterPressure(value: number): number {
+  // Non-finite input (NaN/±Infinity) means the duplicate-cluster signal is broken, not absent, so
+  // treat it as maximal pressure instead of `finiteNonNegative`'s fail-open 0 — dividing by
+  // `Math.max(1, openPrs)` and clamping below then yields the maximum competition factor of 1.
   if (!Number.isFinite(value)) return Number.POSITIVE_INFINITY;
   return Math.max(0, value);
 }
@@ -25,7 +28,7 @@ export function computeOpportunityCompetition(
   highRiskDuplicateClusters: number,
   openPullRequests: number,
 ): number {
-  const clusters = finiteClusterPressure(highRiskDuplicateClusters);
+  const clusters = failClosedClusterPressure(highRiskDuplicateClusters);
   const openPrs = finiteNonNegative(openPullRequests);
   return round4(clamp(clusters / Math.max(1, openPrs), 0, 1));
 }

--- a/packages/gittensory-engine/test/opportunity-competition.test.ts
+++ b/packages/gittensory-engine/test/opportunity-competition.test.ts
@@ -22,8 +22,13 @@ test("computeOpportunityCompetition: scales high-risk clusters against open PR v
   assert.equal(computeOpportunityCompetition(10, 4), 1);
 });
 
-test("computeOpportunityCompetition: non-finite and negative inputs degrade safely", () => {
-  assert.equal(computeOpportunityCompetition(Number.NaN, 4), 0);
+test("computeOpportunityCompetition: non-finite cluster pressure fails closed", () => {
+  assert.equal(computeOpportunityCompetition(Number.NaN, 4), 1);
+  assert.equal(computeOpportunityCompetition(Number.POSITIVE_INFINITY, 4), 1);
+  assert.equal(computeOpportunityCompetition(Number.NEGATIVE_INFINITY, 4), 1);
+});
+
+test("computeOpportunityCompetition: non-finite open PR volume and negative inputs degrade safely", () => {
   assert.equal(computeOpportunityCompetition(2, Number.POSITIVE_INFINITY), 1);
   assert.equal(computeOpportunityCompetition(-3, 4), 0);
   assert.equal(computeOpportunityCompetition(2, -1), 1);

--- a/test/unit/opportunity-competition.test.ts
+++ b/test/unit/opportunity-competition.test.ts
@@ -8,9 +8,10 @@ describe("computeOpportunityCompetition", () => {
     expect(computeOpportunityCompetition(9, 3)).toBe(1);
   });
 
-  it("treats a broken cluster count as zero contention", () => {
-    expect(computeOpportunityCompetition(Number.NaN, 3)).toBe(0);
-    expect(computeOpportunityCompetition(Number.NEGATIVE_INFINITY, 3)).toBe(0);
+  it("fails closed when cluster pressure is broken", () => {
+    expect(computeOpportunityCompetition(Number.NaN, 3)).toBe(1);
+    expect(computeOpportunityCompetition(Number.POSITIVE_INFINITY, 3)).toBe(1);
+    expect(computeOpportunityCompetition(Number.NEGATIVE_INFINITY, 3)).toBe(1);
   });
 
   it("never divides by zero when open PR volume is missing", () => {

--- a/test/unit/opportunity-metadata-signals.test.ts
+++ b/test/unit/opportunity-metadata-signals.test.ts
@@ -87,7 +87,7 @@ describe("opportunity metadata signals", () => {
 
   it("freshness and competition helpers stay pure with injected clocks and safe inputs", () => {
     expect(computeOpportunityFreshness([{ state: "closed", updatedAt: "2026-07-03T00:00:00.000Z" }], NOW)).toBe(0);
-    expect(computeOpportunityCompetition(Number.NaN, 3)).toBe(0);
+    expect(computeOpportunityCompetition(Number.NaN, 3)).toBe(1);
     expect(computeOpportunityCompetition(1, 0)).toBe(1);
     expect(computeOpportunityFreshness([{ state: "open", updatedAt: "2026-07-03T00:00:00.000Z" }], NOW)).toBeGreaterThan(
       0.8,


### PR DESCRIPTION
### Motivation

- The engine helper `computeOpportunityCompetition` previously mapped any non-finite duplicate-cluster count (NaN/±Infinity) to 0, which made broken contention signals appear as no duplicate risk, diverging from the ranker's fail-closed convention elsewhere in this package.
- The change makes the local helper fail closed by treating non-finite cluster pressure as maximal competition, so malformed data cannot masquerade as a safe opportunity.
- No linked issue: this is a small, self-evident correctness fix scoped to a single pure helper and its tests, with no public behavior surface beyond the engine package.

### Description

- Add `failClosedClusterPressure(value)` that maps non-finite cluster pressure to `Number.POSITIVE_INFINITY` (documented inline) and otherwise floors negative values to 0.
- Use `failClosedClusterPressure` for `highRiskDuplicateClusters` in `computeOpportunityCompetition` while preserving `finiteNonNegative` for `openPullRequests`.
- Update engine package tests and the repository root unit tests (including the sibling `test/unit/opportunity-metadata-signals.test.ts` assertion that was initially missed) to assert that `NaN`, `+Infinity`, and `-Infinity` cluster pressure produce a fail-closed competition factor of 1 and cover the other negative/fallback branches.

### Testing

- `npx vitest run test/unit/opportunity-metadata-signals.test.ts test/unit/opportunity-competition.test.ts` — all pass.
- `npm --workspace @jsonbored/gittensory-engine run build && npm --workspace @jsonbored/gittensory-engine test` — 73/73 pass.
- `npm run typecheck` — clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48b6869c70832cb2ddd92742e7bd17)
