### PR TITLE
fix(miner): treat null listClaims filters as unscoped

### DIFF
--- a/packages/gittensory-miner/lib/claim-ledger.d.ts
+++ b/packages/gittensory-miner/lib/claim-ledger.d.ts
@@ -16,8 +16,8 @@ export type RecordClaimInput = {
 };
 
 export type ListClaimsFilter = {
-  repoFullName?: string;
-  status?: ClaimStatus;
+  repoFullName?: string | null;
+  status?: ClaimStatus | null;
 };
 
 export type ClaimLedger = {

--- a/packages/gittensory-miner/lib/claim-ledger.js
+++ b/packages/gittensory-miner/lib/claim-ledger.js
@@ -122,8 +122,13 @@ export function openClaimLedger(dbPath = resolveClaimLedgerDbPath()) {
     "SELECT * FROM miner_claims WHERE repo_full_name = ? AND status = ? ORDER BY id ASC",
   );
 
+  function normalizeListRepoFilter(repoFullName) {
+    if (repoFullName === undefined || repoFullName === null) return undefined;
+    return normalizeRepoFullName(repoFullName);
+  }
+
   function normalizeStatusFilter(status) {
-    if (status === undefined) return undefined;
+    if (status === undefined || status === null) return undefined;
     if (!CLAIM_STATUSES.includes(status)) throw new Error("invalid_status");
     return status;
   }
@@ -155,9 +160,7 @@ export function openClaimLedger(dbPath = resolveClaimLedgerDbPath()) {
       return row ? rowToClaim(row) : null;
     },
     listClaims(filter = {}) {
-      const repoFullName = filter.repoFullName === undefined
-        ? undefined
-        : normalizeRepoFullName(filter.repoFullName);
+      const repoFullName = normalizeListRepoFilter(filter.repoFullName);
       const status = normalizeStatusFilter(filter.status);
 
       let rows;

--- a/test/unit/miner-claim-ledger.test.ts
+++ b/test/unit/miner-claim-ledger.test.ts
@@ -104,6 +104,15 @@ describe("gittensory-miner claim ledger (#2314)", () => {
     expect(ledger.listClaims({ repoFullName: "o/a", status: "released" }).map((c) => c.issueNumber)).toEqual([2]);
   });
 
+  it("treats null listClaims filters as unscoped", () => {
+    const ledger = tempLedger();
+    ledger.recordClaim({ repoFullName: "o/a", issueNumber: 1 });
+    ledger.recordClaim({ repoFullName: "o/b", issueNumber: 2 });
+    expect(ledger.listClaims({ repoFullName: null })).toHaveLength(2);
+    expect(ledger.listClaims({ status: null })).toHaveLength(2);
+    expect(ledger.listClaims({ repoFullName: null, status: null })).toHaveLength(2);
+  });
+
   it("rejects malformed inputs rather than persisting them", () => {
     const ledger = tempLedger();
     expect(() => ledger.recordClaim({ repoFullName: "no-slash", issueNumber: 1 })).toThrow("invalid_repo_full_name");


### PR DESCRIPTION
## Summary

- Treat null `repoFullName` and `status` filters in `listClaims` as unscoped, matching governor-ledger and event-ledger read semantics.
- Prevents `{ repoFullName: null }` from throwing and `{ status: null }` from being rejected as `invalid_status`.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] Focused on claim-ledger list filtering only — no unrelated miner CLI or UI changes.

## Validation

- [ ] `npm run test:ci` locally — CI will run the full gate on push.
- [x] Unit tests cover null repo/status filters returning all claims.

## Safety

- [x] No secrets, wallet details, hotkeys, or private scoring output in code or PR text.
- [x] Deterministic, read/write-local only: no network calls.

## UI Evidence

Not applicable — miner library only.

## Notes

Follow-up consistency fix after #2955 null read-filter normalization in the event ledger.
