### PR TITLE
fix(miner): treat null listPlans status filter as unscoped

### DIFF
--- a/packages/gittensory-miner/lib/plan-store.d.ts
+++ b/packages/gittensory-miner/lib/plan-store.d.ts
@@ -25,7 +25,7 @@ export type PlanRecord = {
 };
 
 export type ListPlansFilter = {
-  status?: PlanStatus;
+  status?: PlanStatus | null;
 };
 
 export type PlanStore = {

--- a/packages/gittensory-miner/lib/plan-store.js
+++ b/packages/gittensory-miner/lib/plan-store.js
@@ -47,6 +47,12 @@ function normalizePlanId(planId) {
   return planId.trim();
 }
 
+function normalizePlanStatusFilter(status) {
+  if (status === undefined || status === null) return undefined;
+  if (!planStatusSet.has(status)) throw new Error("invalid_status");
+  return status;
+}
+
 function isBoundedString(value, min, max) {
   return typeof value === "string" && value.length >= min && value.length <= max;
 }
@@ -167,9 +173,9 @@ export function openPlanStore(dbPath = resolvePlanStoreDbPath()) {
       return row ? rowToRecord(row) : null;
     },
     listPlans(filter = {}) {
-      if (filter.status !== undefined) {
-        if (!planStatusSet.has(filter.status)) throw new Error("invalid_status");
-        return listStatusStatement.all(filter.status).map(rowToRecord);
+      const status = normalizePlanStatusFilter(filter.status);
+      if (status !== undefined) {
+        return listStatusStatement.all(status).map(rowToRecord);
       }
       return listAllStatement.all().map(rowToRecord);
     },

--- a/test/unit/miner-plan-store.test.ts
+++ b/test/unit/miner-plan-store.test.ts
@@ -82,6 +82,15 @@ describe("gittensory-miner plan store (#2318)", () => {
     expect(() => store.listPlans({ status: "bogus" as never })).toThrow("invalid_status");
   });
 
+  it("treats a null listPlans status filter as unscoped", () => {
+    const store = tempStore();
+    store.savePlan("a", PLAN);
+    store.savePlan("b", {
+      steps: [{ id: "x", title: "done", dependsOn: [], status: "completed", attempts: 1, maxAttempts: 1 }],
+    });
+    expect(store.listPlans({ status: null }).map((record) => record.planId)).toEqual(["a", "b"]);
+  });
+
   it("rejects a malformed plan on save rather than persisting it", () => {
     const store = tempStore();
     expect(() => store.savePlan("x", { steps: [{ id: "s1", title: "no status", dependsOn: [], attempts: 0, maxAttempts: 1 } as never] })).toThrow("invalid_plan");


### PR DESCRIPTION
## Summary

- Treat a null `status` filter in `listPlans` as unscoped, matching claim-ledger and event-ledger read semantics.
- Prevents `{ status: null }` from throwing `invalid_status` when callers mean "all plans".

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] Focused on plan-store list filtering only — no unrelated miner CLI or UI changes.

## Validation

- [ ] `npm run test:ci` locally — CI will run the full gate on push.
- [x] Unit test covers null status filter returning all plans.

## Safety

- [x] No secrets, wallet details, hotkeys, or private scoring output in code or PR text.
- [x] Deterministic, read/write-local only: no network calls.

## UI Evidence

Not applicable — miner library only.

## Notes

Follow-up consistency fix after #2978 null list-filter normalization in the claim ledger.
