### PR TITLE
fix(review): make guardrail paths config-only

### DIFF
--- a/.gittensory.yml.example
+++ b/.gittensory.yml.example
@@ -13,6 +13,8 @@
 #   this file  >  per-repo dashboard/API settings  >  built-in safe defaults
 #   The typed `gate:` block below is an alias for the gate fields and wins over
 #   the generic `settings:` block for those same fields.
+#   Hard path guardrails are an explicit config-as-code exception: omitted or
+#   [] means no path guardrails, never hidden engine defaults.
 #
 # SAFE BY DEFAULT: with no file and no dashboard row, a repo falls back to a
 # quiet, non-blocking profile — gate off, AI review off, slop scoring off,
@@ -389,6 +391,11 @@ settings:
   # the `close` autonomy class below + adverse-signal conditions). Automation-bot PRs stay exempt regardless
   # of this setting. Bool. Default: false.
   closeOwnerAuthors: false
+
+  # Hard manual-review path guardrails are config-as-code only. Omit or use [] for no path guardrails;
+  # set concrete globs when otherwise-mergeable PRs touching those paths must be held for a person.
+  # This never falls back to hidden engine path defaults.
+  hardGuardrailGlobs: []
 
   # Require a linked issue on every PR (dashboard equivalent of the toggle that
   # can auto-promote gate.linkedIssue to block). Bool. Default: false.

--- a/apps/gittensory-ui/src/routes/docs.tuning.tsx
+++ b/apps/gittensory-ui/src/routes/docs.tuning.tsx
@@ -78,6 +78,11 @@ function Tuning() {
         <li>built-in safe defaults.</li>
       </ul>
       <p>
+        Path holds are explicit config-as-code only: omitted or empty{" "}
+        <code>settings.hardGuardrailGlobs</code> means no path guardrails, not a hidden engine
+        fallback.
+      </p>
+      <p>
         The friendly <code>gate:</code> block in <code>.gittensory.yml</code> is a typed alias for
         the gate-related fields and wins over the generic <code>settings:</code> block for those
         same fields. Gittensory looks for the manifest at the first match of{" "}

--- a/apps/gittensory-ui/src/routes/docs.tuning.tsx
+++ b/apps/gittensory-ui/src/routes/docs.tuning.tsx
@@ -424,7 +424,10 @@ settings:
   commentMode: detected_contributors_only
   checkRunMode: enabled
   checkRunDetailLevel: standard
-  badgeEnabled: true`}
+  badgeEnabled: true
+  # Optional path holds. Omitted or [] means no path guardrails.
+  # hardGuardrailGlobs:
+  #   - "src/selfhost/**"`}
       />
 
       <Callout variant="warn" title="Roll forward one step at a time">

--- a/config/examples/README.md
+++ b/config/examples/README.md
@@ -130,9 +130,9 @@ Two `autonomy` classes govern every label the bot can apply, and they are **inde
   to `auto` only if you specifically want that commentary as GitHub labels too.
 
 All disposition labels are configurable under `settings.*Label`, and explicit `null` disables the
-label without disabling the underlying merge/close/hold decision. Hard path guardrails use built-in
-safety defaults when `settings.hardGuardrailGlobs` is omitted. A concrete list replaces those
-defaults, and an explicit empty list means no path guardrails.
+label without disabling the underlying merge/close/hold decision. Hard path guardrails are
+config-as-code only: omitting `settings.hardGuardrailGlobs` or setting it to `[]` means no path
+guardrails, and a concrete list replaces any lower-layer private global default.
 
 ```yaml
 # .gittensory.yml (global default) — recommended one-shot baseline

--- a/config/examples/global.gittensory.yml
+++ b/config/examples/global.gittensory.yml
@@ -48,8 +48,8 @@ settings:
   autoCloseExemptLogins:
     - your-admin-login
 
-  # Hard manual-review path guardrails use built-in safe defaults when omitted. A concrete list
-  # replaces those defaults, and this empty list is an explicit no-path-guardrail opt-out.
+  # Hard manual-review path guardrails are config-as-code only. Omit or use [] for no path
+  # guardrails; set a concrete list when you want otherwise-mergeable PRs held for a person.
   hardGuardrailGlobs: []
 
   # Disposition label names are config-as-code, not engine identity. Set any value to your repo's

--- a/src/review/guardrail-config.ts
+++ b/src/review/guardrail-config.ts
@@ -1,67 +1,12 @@
 import type { RepositorySettings } from "../types";
 
-// Built-in defense-in-depth defaults used only when the operator has not configured guardrails at all.
-// A concrete `hardGuardrailGlobs: []` in private global or repo config remains the explicit opt-out.
-export const DEFAULT_CRUCIAL_GUARDRAIL_GLOBS = [".github/workflows/**", "scripts/**"];
-
-export const CONFIG_AS_CODE_GUARDRAIL_GLOBS = [
-  ".gittensory.yml",
-  ".gittensory.yaml",
-  ".gittensory.json",
-  ".github/gittensory.yml",
-  ".github/gittensory.yaml",
-  ".github/gittensory.json",
-  "**/codecov.yml",
-  "**/codecov.yaml",
-  "**/.codecov.yml",
-];
-
-export const ENGINE_DECISION_GUARDRAIL_GLOBS = [
-  "src/rules/**",
-  "src/services/**",
-  "src/settings/agent-actions.ts",
-  "src/settings/agent-execution.ts",
-  "src/settings/agent-sweep.ts",
-  "src/settings/autonomy.ts",
-  "src/queue/**",
-  "src/github/pr-actions.ts",
-  "src/github/app.ts",
-  "src/github/backfill.ts",
-  "src/scoring/**",
-  "src/auth/**",
-  "src/review/safety.ts",
-  "src/review/guardrail-config.ts",
-  "src/review/cutover-gate.ts",
-  "src/review/linked-issue-hard-rules.ts",
-  "src/review/outcomes-wire.ts",
-];
-
-export const SELFHOST_RUNTIME_GUARDRAIL_GLOBS = [
-  "src/selfhost/**",
-  "src/server.ts",
-  "src/db/**",
-  "Dockerfile",
-  "docker-compose*.yml*",
-  "docker-compose*.yaml*",
-  "compose*.yml*",
-  "compose*.yaml*",
-  "systemd/**",
-];
-
-export const DEFAULT_HARD_GUARDRAIL_GLOBS = [
-  ...DEFAULT_CRUCIAL_GUARDRAIL_GLOBS,
-  ...CONFIG_AS_CODE_GUARDRAIL_GLOBS,
-  ...ENGINE_DECISION_GUARDRAIL_GLOBS,
-  ...SELFHOST_RUNTIME_GUARDRAIL_GLOBS,
-];
-
 /**
- * Resolve hard-guardrail path globs from already-effective repo settings. Missing settings keep built-in safety
- * defaults; a concrete list replaces them wholesale, and `[]` is the explicit opt-out.
+ * Resolve hard-guardrail path globs from the already-effective repo settings. Path holds are config-as-code only:
+ * omitted/null settings mean no path guardrails, and arrays replace lower layers wholesale.
  */
 export function resolveHardGuardrailGlobs(
   settings: Pick<RepositorySettings, "hardGuardrailGlobs"> | null | undefined,
 ): string[] {
   const configured = settings?.hardGuardrailGlobs;
-  return Array.isArray(configured) ? [...configured] : [...DEFAULT_HARD_GUARDRAIL_GLOBS];
+  return Array.isArray(configured) ? [...configured] : [];
 }

--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -1165,8 +1165,8 @@ function parseSettingsOverride(value: JsonValue | undefined, warnings: string[])
     if (logins.length > 0) out.autoCloseExemptLogins = logins;
   }
   // Hard manual-review guardrails are config-as-code only. Arrays replace lower layers wholesale, so only an
-  // explicit [] or a non-empty valid list replaces a private global or built-in default. Null/malformed values are
-  // ignored instead of clearing.
+  // explicit [] or a non-empty valid list replaces a private global setting. Null/malformed values are ignored
+  // instead of clearing.
   if (Array.isArray(r.hardGuardrailGlobs)) {
     const hardGuardrailGlobs = normalizeStringList(r.hardGuardrailGlobs, "settings.hardGuardrailGlobs", warnings);
     if (r.hardGuardrailGlobs.length === 0 || hardGuardrailGlobs.length > 0) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -819,8 +819,8 @@ export type RepositorySettings = {
    *  `[]`); optional so existing settings fixtures/callers need not be touched. */
   autoCloseExemptLogins?: string[] | undefined;
   /** Hard manual-review guardrail globs. Config-as-code only: set in private/global or per-repo
-   *  `.gittensory.yml` under `settings.hardGuardrailGlobs`. Absent keeps the engine's built-in safe defaults.
-   *  Arrays are replacement overlays, so a repo can clear a global or built-in default with `[]`. */
+   *  `.gittensory.yml` under `settings.hardGuardrailGlobs`. Absent means no path guardrails. Arrays are
+   *  replacement overlays, so a repo can clear a global default with `[]`. */
   hardGuardrailGlobs?: string[] | null | undefined;
   /** Label applied when an otherwise-ready PR is held for manual review by a guardrail. Config-as-code only;
    *  `null` disables the label while keeping the hold. Distinct from `review_state_label`, so operators can

--- a/test/unit/guardrail-config.test.ts
+++ b/test/unit/guardrail-config.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, it } from "vitest";
-import { DEFAULT_HARD_GUARDRAIL_GLOBS, resolveHardGuardrailGlobs } from "../../src/review/guardrail-config";
+import { resolveHardGuardrailGlobs } from "../../src/review/guardrail-config";
 
 describe("resolveHardGuardrailGlobs", () => {
-  it("defaults to built-in safety guardrails when effective settings omit hardGuardrailGlobs", () => {
-    expect(resolveHardGuardrailGlobs(undefined)).toEqual(DEFAULT_HARD_GUARDRAIL_GLOBS);
-    expect(resolveHardGuardrailGlobs(null)).toEqual(DEFAULT_HARD_GUARDRAIL_GLOBS);
-    expect(resolveHardGuardrailGlobs({})).toEqual(DEFAULT_HARD_GUARDRAIL_GLOBS);
-    expect(resolveHardGuardrailGlobs({ hardGuardrailGlobs: null })).toEqual(DEFAULT_HARD_GUARDRAIL_GLOBS);
+  it("does not invent path guardrails when effective settings omit hardGuardrailGlobs", () => {
+    expect(resolveHardGuardrailGlobs(undefined)).toEqual([]);
+    expect(resolveHardGuardrailGlobs(null)).toEqual([]);
+    expect(resolveHardGuardrailGlobs({})).toEqual([]);
+    expect(resolveHardGuardrailGlobs({ hardGuardrailGlobs: null })).toEqual([]);
   });
 
   it("returns a clone of the configured guardrail globs", () => {
@@ -20,7 +20,7 @@ describe("resolveHardGuardrailGlobs", () => {
     expect(configured).toEqual(["src/settings/**", ".github/workflows/**"]);
   });
 
-  it("preserves an explicit empty list as the only no-guardrail opt-out", () => {
+  it("preserves an explicit empty list as no path guardrails", () => {
     expect(resolveHardGuardrailGlobs({ hardGuardrailGlobs: [] })).toEqual([]);
   });
 });

--- a/test/unit/predicted-gate.test.ts
+++ b/test/unit/predicted-gate.test.ts
@@ -418,10 +418,10 @@ describe("buildPredictedGateVerdict", () => {
     expect(result.blockers).toHaveLength(0);
   });
 
-  it("REGRESSION: keeps built-in guardrails when hardGuardrailGlobs is omitted", () => {
+  it("does NOT predict a guardrail hold when hardGuardrailGlobs is omitted", () => {
     const result = verdict({ gate: { duplicates: "block" }, changedPaths: [".github/workflows/ci.yml"] });
-    expect(result.conclusion).toBe("neutral");
-    expect(result.warnings.some((w) => w.code === "guardrail_hold")).toBe(true);
+    expect(result.conclusion).toBe("success");
+    expect(result.warnings.some((w) => w.code === "guardrail_hold")).toBe(false);
   });
 
   it("does NOT predict a guardrail hold when hardGuardrailGlobs is explicitly empty", () => {

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -19854,6 +19854,7 @@ describe("auto-action convergence: end-to-end plan+execute for the general heuri
       const url = input.toString();
       const method = init?.method ?? "GET";
       if (url === "https://api.gittensor.io/miners") return Response.json([]);
+      if (url === "https://raw.githubusercontent.com/JSONbored/gittensory/HEAD/.gittensory.yml") return new Response("settings:\n  hardGuardrailGlobs:\n    - .github/workflows/**\n");
       if (url === "https://api.github.com/graphql") return Response.json({ data: { repository: { pullRequest: { reviewDecision: "APPROVED" } } } });
       if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
       if (url.includes("/pulls/61/files")) return Response.json([{ filename: ".github/workflows/ci.yml", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+  x: 1" }]);


### PR DESCRIPTION
## Summary
- make hard path guardrails purely config-as-code instead of applying hidden engine defaults when the setting is omitted
- keep configured guardrail arrays as replacement overlays, including explicit `[]` for no path guardrails
- update config examples/docs and regression tests for the omitted-setting behavior

## Why
Path guardrails were being controlled from two places: private/public config and a hidden code fallback. That made it easy for operators to believe guardrails were disabled or narrowed while the engine still held PRs for broad built-in paths. This change makes the effective config the only source of path holds.

## Validation
- `npx vitest run test/unit/guardrail-config.test.ts test/unit/predicted-gate.test.ts test/unit/focus-manifest.test.ts -t "guardrail|hardGuardrailGlobs"`
- `npm run typecheck`
- `git diff --check`

## Notes
- `npm run ui:typecheck` was not completed locally because the reused dependency tree was missing UI workspace dev dependencies before it reached this docs change; CI should run against a fresh install.
