### PR TITLE
fix(miner): treat null listQueue repo filter as unscoped

### DIFF
--- a/packages/gittensory-miner/lib/portfolio-queue.d.ts
+++ b/packages/gittensory-miner/lib/portfolio-queue.d.ts
@@ -18,7 +18,7 @@ export type PortfolioQueueStore = {
   dbPath: string;
   enqueue(item: EnqueueItem): QueueEntry;
   dequeueNext(): QueueEntry | null;
-  listQueue(repoFullName?: string): QueueEntry[];
+  listQueue(repoFullName?: string | null): QueueEntry[];
   markDone(repoFullName: string, identifier: string): QueueEntry | null;
   close(): void;
 };
@@ -33,7 +33,7 @@ export function enqueue(item: EnqueueItem): QueueEntry;
 
 export function dequeueNext(): QueueEntry | null;
 
-export function listQueue(repoFullName?: string): QueueEntry[];
+export function listQueue(repoFullName?: string | null): QueueEntry[];
 
 export function markDone(repoFullName: string, identifier: string): QueueEntry | null;
 

--- a/packages/gittensory-miner/lib/portfolio-queue.js
+++ b/packages/gittensory-miner/lib/portfolio-queue.js
@@ -149,7 +149,7 @@ export function initPortfolioQueueStore(dbPath = resolvePortfolioQueueDbPath()) 
       return row ? rowToEntry(row) : null;
     },
     listQueue(repoFullName) {
-      const rows = repoFullName === undefined
+      const rows = repoFullName === undefined || repoFullName === null
         ? listAllStatement.all()
         : listRepoStatement.all(normalizeRepoFullName(repoFullName));
       return rows.map(rowToEntry);

--- a/test/unit/miner-portfolio-queue.test.ts
+++ b/test/unit/miner-portfolio-queue.test.ts
@@ -111,6 +111,7 @@ describe("gittensory-miner portfolio/queue store (#2292)", () => {
     expect(store.listQueue("o/a").map((entry) => entry.identifier)).toEqual(["2", "1"]); // priority DESC
     expect(store.listQueue("o/b").map((entry) => entry.repoFullName)).toEqual(["o/b"]);
     expect(store.listQueue().length).toBe(3);
+    expect(store.listQueue(null).length).toBe(3);
   });
 
   it("re-enqueue re-activates a done item and refreshes its placeholder priority", () => {


### PR DESCRIPTION
## Summary

- Treat a null `repoFullName` argument to `listQueue` as unscoped, matching claim-ledger and plan-store list semantics.
- Prevents `listQueue(null)` from throwing `invalid_repo_full_name` when callers mean "all queue rows".

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] Focused on portfolio-queue list filtering only — no unrelated miner CLI or UI changes.

## Validation

- [ ] `npm run test:ci` locally — CI will run the full gate on push.
- [x] Unit test covers null repo filter returning all queue rows.

## Safety

- [x] No secrets, wallet details, hotkeys, or private scoring output in code or PR text.
- [x] Deterministic, read/write-local only: no network calls.

## UI Evidence

Not applicable — miner library only.

## Notes

Follow-up consistency fix after #2980 null list-filter normalization in the plan store.
