### PR TITLE
fix(engine): fall back to createdAt when a metadata issue's updatedAt is unparseable

### DIFF
--- a/packages/gittensory-engine/src/opportunity-metadata.ts
+++ b/packages/gittensory-engine/src/opportunity-metadata.ts
@@ -78,13 +78,16 @@ const STALE_AGE_DAYS = 9999;
 
 /* v8 ignore start -- Internal timestamp helpers mirror freshness semantics; exercised via exported ranker paths. */
 function pickMetadataTimestamp(issue: MetadataCandidateIssue): string {
+  // Mirror freshness semantics (opportunity-freshness's pickTimestamp): only commit to a timestamp that actually
+  // parses. Without the guard, a present-but-unparseable updatedAt shadows a valid createdAt, so issueAgeDays
+  // hits the STALE_AGE_DAYS sentinel and a genuinely fresh issue is scored as maximally stale.
   if (typeof issue.updatedAt === "string") {
     const updated = issue.updatedAt.trim();
-    if (updated) return updated;
+    if (updated && Number.isFinite(Date.parse(updated))) return updated;
   }
   if (typeof issue.createdAt === "string") {
     const created = issue.createdAt.trim();
-    if (created) return created;
+    if (created && Number.isFinite(Date.parse(created))) return created;
   }
   return "";
 }

--- a/test/unit/opportunity-metadata-signals.test.ts
+++ b/test/unit/opportunity-metadata-signals.test.ts
@@ -128,6 +128,11 @@ describe("opportunity metadata signals", () => {
     expect(
       computeMetadataFeasibility({ ...base, updatedAt: "not-a-date", createdAt: null }, NOW),
     ).toBeLessThan(computeMetadataFeasibility(base, NOW));
+    // A present-but-unparseable updatedAt must fall through to a valid createdAt, not shadow it into the stale
+    // sentinel: a fresh createdAt scores strictly higher than having no usable timestamp at all.
+    expect(
+      computeMetadataFeasibility({ ...base, updatedAt: "not-a-date", createdAt: "2026-07-03T00:00:00.000Z" }, NOW),
+    ).toBeGreaterThan(computeMetadataFeasibility({ ...base, updatedAt: "not-a-date", createdAt: null }, NOW));
   });
 
   it("treats blank titles as maximum dup risk and exact title matches as overlaps", () => {


### PR DESCRIPTION
## Summary

`pickMetadataTimestamp()` in `packages/gittensory-engine/src/opportunity-metadata.ts` chooses the timestamp used to age-score a metadata-only issue candidate (feeding `computeMetadataFeasibility`). It returned `updatedAt` as soon as it was a non-empty string — **without checking it parses**. So a present-but-unparseable `updatedAt` (a malformed value from an adapter) shadowed a perfectly valid `createdAt`: `issueAgeDays` then `Date.parse`d the garbage to `NaN`, fell to the `STALE_AGE_DAYS = 9999` sentinel, and drove `ageScore = exp(-9999/45) ≈ 0` — scoring a genuinely fresh, same-day issue as **maximally stale**.

This directly contradicts the module's own intent: the helper sits in a region commented "*Internal timestamp helpers mirror freshness semantics*," but the freshness sibling `pickTimestamp` (in `opportunity-freshness.ts`) guards each candidate with a parseability check before committing to it. The result was an internal contradiction — the **freshness** signal scored a malformed-`updatedAt` issue as fresh (via its `createdAt` fallback), while the **feasibility** signal scored the same issue as maximally stale.

This guards each candidate on `Number.isFinite(Date.parse(...))`, mirroring the freshness sibling, so an unparseable `updatedAt` falls through to a valid `createdAt`. Adds a regression test (a malformed `updatedAt` with a valid `createdAt` now scores strictly higher than the same issue with no usable timestamp at all).

No linked issue: issue creation on this repo is restricted to collaborators, and this is a small, self-contained correctness fix (add the parseability guard the sibling already uses) whose rationale is self-evident from the diff.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- The full `npm run test:ci` aggregate ran green plus `npm audit --audit-level=moderate` (0 vulnerabilities). The new regression test exercises the fixed fallthrough via the exported `computeMetadataFeasibility`. The changed helper lives under `packages/` (not measured by Codecov) and inside a `/* v8 ignore */` region, so there is no `codecov/patch` burden — the behavior is covered through the exported ranker path.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

Pure scoring-heuristic logic in the engine package; no auth/CORS/session surface, no API/OpenAPI shape change, no UI. The `Safety` boxes are checked on that basis.

## Notes

- Two-line guard (`Number.isFinite(Date.parse(...))`) plus an explanatory comment, mirroring `opportunity-freshness`'s `pickTimestamp`. No schema, migration, OpenAPI, wrangler, or generated-artifact impact.
