### PR TITLE
fix(miner): reject empty plan step lists in plan store saves

### DIFF
--- a/packages/gittensory-miner/lib/plan-store.js
+++ b/packages/gittensory-miner/lib/plan-store.js
@@ -83,7 +83,9 @@ function validatePlanDag(plan) {
   if (!plan || typeof plan !== "object" || Array.isArray(plan)) throw new Error("invalid_plan");
   const keys = Object.keys(plan);
   if (keys.length !== 1 || keys[0] !== "steps") throw new Error("invalid_plan");
-  if (!Array.isArray(plan.steps) || plan.steps.length > 100) throw new Error("invalid_plan");
+  if (!Array.isArray(plan.steps) || plan.steps.length === 0 || plan.steps.length > 100) {
+    throw new Error("invalid_plan");
+  }
   if (!plan.steps.every(isValidStep)) throw new Error("invalid_plan");
   const seenStepIds = new Set();
   for (const step of plan.steps) {

--- a/test/unit/miner-plan-store.test.ts
+++ b/test/unit/miner-plan-store.test.ts
@@ -95,6 +95,7 @@ describe("gittensory-miner plan store (#2318)", () => {
     const store = tempStore();
     expect(() => store.savePlan("x", { steps: [{ id: "s1", title: "no status", dependsOn: [], attempts: 0, maxAttempts: 1 } as never] })).toThrow("invalid_plan");
     expect(() => store.savePlan("x", { steps: "nope" as never })).toThrow("invalid_plan");
+    expect(() => store.savePlan("empty", { steps: [] })).toThrow("invalid_plan");
     expect(() => store.savePlan("x", { steps: [], extra: 1 } as never)).toThrow("invalid_plan"); // strict: no unknown keys
     expect(() => store.savePlan("", PLAN)).toThrow("invalid_plan_id");
     expect(() =>


### PR DESCRIPTION
## Summary

- Reject plan DAGs with zero steps in `validatePlanDag` so empty plans cannot be persisted locally.
- Aligns the plan store with the MCP `buildPlan` contract, which requires at least one step.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] Focused on plan-store validation only — no unrelated miner CLI or UI changes.

## Validation

- [ ] `npm run test:ci` locally — CI will run the full gate on push.
- [x] Unit test covers empty `steps: []` rejected on save.

## Safety

- [x] No secrets, wallet details, hotkeys, or private scoring output in code or PR text.
- [x] Deterministic, read/write-local only: no network calls.

## UI Evidence

Not applicable — miner library only.

## Notes

Follow-up validation hardening in the foundation plan store (#2318), alongside #2949 and #2953.
