### PR TITLE
fix(miner): don't let a blank AI-USAGE.md swallow a ban in CONTRIBUTING.md

### DIFF
--- a/packages/gittensory-miner/lib/opportunity-fanout.js
+++ b/packages/gittensory-miner/lib/opportunity-fanout.js
@@ -147,7 +147,11 @@ async function fetchRepoDoc(target, path, githubToken, options, summary, warning
 
 async function resolveRepoAiPolicy(target, githubToken, options, summary, warnings) {
   const aiUsage = await fetchRepoDoc(target, "AI-USAGE.md", githubToken, options, summary, warnings);
-  if (aiUsage !== null) {
+  // Short-circuit only on AI-USAGE.md that has real content. A present-but-blank AI-USAGE.md must still fall
+  // through to CONTRIBUTING.md — otherwise a stub AI-USAGE.md silently fails open and swallows a ban declared in
+  // CONTRIBUTING.md (the exact case resolveAiPolicyVerdict was fixed to handle in #2900, which can only fire if
+  // both docs reach it).
+  if (aiUsage !== null && aiUsage.trim().length > 0) {
     return resolveAiPolicyVerdict({ aiUsage, contributing: null });
   }
   const contributing = await fetchRepoDoc(

--- a/test/unit/miner-opportunity-fanout.test.ts
+++ b/test/unit/miner-opportunity-fanout.test.ts
@@ -112,6 +112,24 @@ describe("fetchCandidateIssues (#2307)", () => {
     expect(calls[0]).toContain("/repos/acme/banned/contents/AI-USAGE.md");
   });
 
+  it("does not let a blank AI-USAGE.md swallow an AI ban in CONTRIBUTING.md", async () => {
+    const calls: string[] = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      calls.push(url);
+      if (url.endsWith("/contents/AI-USAGE.md")) return contentResponse("   "); // exists but blank/whitespace
+      if (url.endsWith("/contents/CONTRIBUTING.md")) return contentResponse("No AI-generated pull requests.");
+      if (url.includes("/issues?")) return jsonResponse([issue(7)]);
+      return jsonResponse({}, { status: 404 });
+    });
+
+    const result = await fetchCandidateIssues([{ owner: "acme", repo: "banned" }], "", { apiBaseUrl: API });
+
+    // The ban in CONTRIBUTING.md must win, and it must actually be consulted (not skipped by the blank AI-USAGE.md).
+    expect(result).toEqual([]);
+    expect(calls.some((url) => url.endsWith("/contents/CONTRIBUTING.md"))).toBe(true);
+  });
+
   it("fans out allowed repos while banned repos contribute no issue calls", async () => {
     const calls: string[] = [];
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {


### PR DESCRIPTION
## Summary

`resolveRepoAiPolicy()` in `packages/gittensory-miner/lib/opportunity-fanout.js` decides whether the miner may target a repo's issues, based on the repo's AI policy docs. It fetched `AI-USAGE.md` and short-circuited on **presence** (`aiUsage !== null`) rather than **content**:

```js
const aiUsage = await fetchRepoDoc(target, "AI-USAGE.md", …);
if (aiUsage !== null) {
  return resolveAiPolicyVerdict({ aiUsage, contributing: null });   // CONTRIBUTING.md never fetched
}
```

A repo whose `AI-USAGE.md` **exists but is blank/whitespace** decodes to `""` (not `null`), so this branch fired and `CONTRIBUTING.md` was never fetched. `resolveAiPolicyVerdict({ aiUsage: "", contributing: null })` treats the empty AI-USAGE as absent and, with no CONTRIBUTING, returns **allowed** — so the miner would list and target a repo that explicitly bans AI-generated PRs in its `CONTRIBUTING.md`.

This is precisely the fail-open that **#2900** closed *inside* `resolveAiPolicyVerdict` (an empty `AI-USAGE.md` must fall through to `CONTRIBUTING.md`) — but that engine fix can only fire when **both** docs are passed to it, which this caller prevented by short-circuiting first. The fix short-circuits only on `AI-USAGE.md` with real content, so a stub `AI-USAGE.md` falls through to `CONTRIBUTING.md` and its ban is honored. Adds a regression test (blank `AI-USAGE.md` + banning `CONTRIBUTING.md` ⇒ no issues, and `CONTRIBUTING.md` is actually consulted).

No linked issue: issue creation on this repo is restricted to collaborators, and this is a small, self-contained correctness fix (guard the short-circuit on non-empty content, completing #2900's intent at the call site) whose rationale is self-evident from the diff.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- The full `npm run test:ci` aggregate ran green plus `npm audit --audit-level=moderate` (0 vulnerabilities). The new regression test exercises the fixed fallthrough (a blank AI-USAGE.md now consults CONTRIBUTING.md and blocks). The change lives under `packages/` (not measured by Codecov); its unit test suite is the gate.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

This tightens an AI-policy safety gate (it makes the miner *more* conservative — honoring a ban it previously missed); it exposes no secrets or private data. The regression test is the negative-path test for this gate. No auth/CORS/session/API/OpenAPI/UI surface otherwise.

## Notes

- One-clause guard (`aiUsage.trim().length > 0`) plus an explanatory comment referencing #2900. No schema, migration, OpenAPI, wrangler, or generated-artifact impact.
