### PR TITLE
fix(agent-approval-queue): recheck legacy heuristic closes with unknown mergeable-state justification

### DIFF
--- a/src/services/agent-approval-queue.ts
+++ b/src/services/agent-approval-queue.ts
@@ -176,14 +176,19 @@ export async function decidePendingAgentAction(env: Env, input: { id: string; de
   // mutation call independently needs a valid token/state and will fail cleanly if something is actually wrong).
   // (#2126, #2478)
   let liveParams: AgentPendingActionParams = pending.params;
-  // For close, scoped to closeRequiresMergeableState === true (a base-conflict-justified heuristic close) --
-  // NOT the broader closeRequiresCiState === "not_required" (any non-CI reason). A duplicate/slop/blocker-only
-  // close has no cheap live re-derivation, so it is intentionally left out of this recheck entirely (see the
-  // field's doc comment on AgentPendingActionParams in types.ts).
+  // For close, scoped to closeRequiresMergeableState !== false -- i.e. `true` (a base-conflict-justified
+  // heuristic close) OR `undefined` (a LEGACY row staged before this field existed, whose original
+  // justification is unknown). NOT the broader closeRequiresCiState === "not_required" (any non-CI reason).
+  // A duplicate/slop/blocker-only close (closeRequiresMergeableState === false, always explicit per the
+  // field's own doc comment) has no cheap live re-derivation, so it is intentionally left out of this
+  // recheck. But `undefined` must NOT be treated the same as `false`: a strict `=== true` comparison would
+  // silently skip the live recheck for any pre-existing auto_with_approval close row staged before this
+  // field was introduced, even one that WAS originally conflict-justified -- exactly the safety gap this
+  // recheck exists to close. Fail toward "revalidate" for the unknown case, not "skip" (gate review finding).
   const shouldRecheckLiveDisposition =
     pr?.headSha &&
     (pending.actionClass === "merge" ||
-      (pending.actionClass === "close" && pending.params.closeKind === "heuristic" && pending.params.closeRequiresMergeableState === true));
+      (pending.actionClass === "close" && pending.params.closeKind === "heuristic" && pending.params.closeRequiresMergeableState !== false));
   if (shouldRecheckLiveDisposition) {
     const token = await createInstallationToken(env, pending.installationId).catch(() => undefined);
     const admissionKey = githubRateLimitAdmissionKeyForToken(env, token, pending.installationId);
@@ -219,7 +224,7 @@ export async function decidePendingAgentAction(env: Env, input: { id: string; de
             : reviewDecision === "CHANGES_REQUESTED"
               ? "a reviewer has since requested changes"
               : null
-        : // Only reached when closeRequiresMergeableState === true (see shouldRecheckLiveDisposition above), so
+        : // Only reached when closeRequiresMergeableState !== false (see shouldRecheckLiveDisposition above), so
           // CI state is irrelevant to this specific close's justification and the only live signal that matters
           // is whether the conflict has cleared. reviewFetchSucceeded is required alongside the value check --
           // see its own comment above -- so a failed live-review read fails open instead of masquerading as

--- a/test/unit/agent-approval-queue.test.ts
+++ b/test/unit/agent-approval-queue.test.ts
@@ -864,6 +864,62 @@ describe("agent approval queue (#779)", () => {
     expect(fetchLivePullRequestReviewDecision).not.toHaveBeenCalled();
   });
 
+  it("REGRESSION (gate review): a LEGACY heuristic close row (closeRequiresMergeableState undefined, staged before the field existed) still gets the live recheck", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: "x" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/repo", autonomy: { close: "auto_with_approval" } });
+    await seedInstallation(env);
+    await upsertPullRequestFromGitHub(env, "owner/repo", { number: 7, title: "PR", state: "open", user: { login: "contributor" }, head: { sha: "h7" }, labels: [], body: "x" });
+    // mergeableState reads "clean" (the default mock). This row predates closeRequiresMergeableState entirely
+    // (never planned with it, so it's undefined, NOT explicitly false) -- its original justification is
+    // unknown, so a strict `=== true` scoping would silently skip the live recheck and execute unchecked. The
+    // fix must fail toward "revalidate" for the unknown/legacy case, not "skip" (the exact gap the gittensory
+    // orb flagged: undefined must not be treated the same as the explicit `false` case above).
+    const { action } = await createPendingAgentActionIfAbsent(env, {
+      repoFullName: "owner/repo",
+      pullNumber: 7,
+      installationId: 5,
+      actionClass: "close",
+      autonomyLevel: "auto_with_approval",
+      params: { closeComment: "base conflict", closeKind: "heuristic", closeRequiresCiState: "not_required", expectedHeadSha: "h7" },
+      reason: "base branch now conflicts",
+    });
+
+    const result = await decidePendingAgentAction(env, { id: action.id, decision: "accept", decidedBy: "owner" });
+
+    expect(result.status).toBe("rejected");
+    expect(result.executionOutcome).toBe("stale_disposition");
+    const { closePullRequest } = await import("../../src/github/pr-actions");
+    expect(closePullRequest).not.toHaveBeenCalled();
+    const audit = await env.DB.prepare("select detail from audit_events where event_type = ?").bind("agent.pending_action.superseded").first<{ detail: string }>();
+    expect(audit?.detail).toContain("the conflict that justified this close has since cleared");
+  });
+
+  it("REGRESSION (gate review): a LEGACY heuristic close row still executes when the live conflict signal remains", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: "x" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/repo", autonomy: { close: "auto_with_approval" } });
+    await seedInstallation(env);
+    await upsertPullRequestFromGitHub(env, "owner/repo", { number: 7, title: "PR", state: "open", user: { login: "contributor" }, head: { sha: "h7" }, labels: [], body: "x" });
+    // Same legacy row shape (closeRequiresMergeableState undefined) but the live mergeable-state read still
+    // shows "dirty" -- the recheck fires (per the test above) but finds nothing stale, so the close proceeds.
+    vi.mocked(fetchLivePullRequestMergeState).mockResolvedValueOnce("dirty");
+    const { action } = await createPendingAgentActionIfAbsent(env, {
+      repoFullName: "owner/repo",
+      pullNumber: 7,
+      installationId: 5,
+      actionClass: "close",
+      autonomyLevel: "auto_with_approval",
+      params: { closeComment: "base conflict", closeKind: "heuristic", closeRequiresCiState: "not_required", expectedHeadSha: "h7" },
+      reason: "base branch now conflicts",
+    });
+
+    const result = await decidePendingAgentAction(env, { id: action.id, decision: "accept", decidedBy: "owner" });
+
+    expect(result.status).toBe("accepted");
+    expect(result.executionOutcome).toBe("completed");
+    const { closePullRequest } = await import("../../src/github/pr-actions");
+    expect(closePullRequest).toHaveBeenCalledWith(env, 5, "owner/repo", 7);
+  });
+
   it("REGRESSION (gate review): a failed live review-decision read fails open instead of masquerading as 'no changes requested'", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: "x" });
     await upsertRepositorySettings(env, { repoFullName: "owner/repo", autonomy: { close: "auto_with_approval" } });
@@ -895,7 +951,10 @@ describe("agent approval queue (#779)", () => {
     await upsertRepositorySettings(env, { repoFullName: "owner/repo", autonomy: { close: "auto_with_approval", review_state_label: "auto" } });
     await seedInstallation(env);
     await upsertPullRequestFromGitHub(env, "owner/repo", { number: 8, title: "PR", state: "open", user: { login: "contributor" }, head: { sha: "h8" }, labels: [], body: "x" });
-    const { action } = await createPendingAgentActionIfAbsent(env, { repoFullName: "owner/repo", pullNumber: 8, installationId: 5, actionClass: "close", autonomyLevel: "auto_with_approval", params: { closeComment: "noise", closeKind: "heuristic", expectedHeadSha: "h8" }, reason: "ci-failed" });
+    // closeRequiresCiState/closeRequiresMergeableState explicitly set (this is a CI-driven close, not
+    // conflict-justified) so the accept-time mergeable-state recheck's legacy-row fallback doesn't treat
+    // this fixture as an unknown-justification row and supersede it before the close breaker even runs.
+    const { action } = await createPendingAgentActionIfAbsent(env, { repoFullName: "owner/repo", pullNumber: 8, installationId: 5, actionClass: "close", autonomyLevel: "auto_with_approval", params: { closeComment: "noise", closeKind: "heuristic", closeRequiresCiState: "failed", closeRequiresMergeableState: false, expectedHeadSha: "h8" }, reason: "ci-failed" });
     await env.DB.prepare("INSERT INTO system_flags (key, value) VALUES (?, ?)").bind("closehold:owner/repo", "true").run();
 
     const result = await decidePendingAgentAction(env, { id: action.id, decision: "accept", decidedBy: "owner" });


### PR DESCRIPTION
## Summary
- Follow-up to #2902 (already merged as 706d1c1e), which added an accept-time live-disposition recheck for conflict-justified heuristic closes but scoped it with a strict `closeRequiresMergeableState === true` check.
- That strict comparison meant any `auto_with_approval` close row staged **before** `closeRequiresMergeableState` existed (field is `undefined`, not `false`) silently skipped the live recheck and executed unchecked, even if originally staged for a base conflict that has since cleared.
- Scopes the recheck to `closeRequiresMergeableState !== false` instead: a known non-conflict close (`false`, always explicit for freshly planned closes) is still excluded, but an unknown/legacy justification (`undefined`) now fails toward revalidating rather than silently skipping.

## Scope
- `src/services/agent-approval-queue.ts`: broaden `shouldRecheckLiveDisposition`'s close-side predicate and update the two comments describing it.
- `test/unit/agent-approval-queue.test.ts`: two new regression tests covering both branches of the legacy (`undefined`) case, plus an update to a pre-existing unrelated test fixture (`accept downgrades a staged heuristic close to a needs-human-review label when the close breaker engaged (#2127)`) to explicitly set `closeRequiresCiState`/`closeRequiresMergeableState` so it isn't accidentally treated as an unknown-justification legacy row by this change.

## Validation
- `npm run typecheck`
- `npx vitest run test/unit/agent-approval-queue.test.ts test/unit/agent-actions.test.ts test/unit/agent-action-executor.test.ts` — 346 passed
- `npx vitest run test/unit/agent-approval-queue.test.ts --coverage --coverage.include='src/services/agent-approval-queue.ts'` — 100% statements/branches/functions/lines on the changed file

## Safety
- No secrets, wallets, hotkeys, trust scores, or reward values touched.
- Preserves the existing invariant that a known non-conflict close (`closeRequiresMergeableState: false`, duplicate/slop/blocker-only) is still never touched by the recheck.