### PR TITLE
fix(review): record native close dispositions for self-tune

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -2488,6 +2488,18 @@ async function runAgentMaintenancePlanAndExecute(
     blocker_class: disposition.blockerClass,
     autonomy_level: resolveAutonomy(settings.autonomy, disposition.actionClass === "merge" ? "merge" : "close"),
   });
+  // The native eval source is used by the self-tune precision breakers, so the stored prediction must reflect the
+  // downstream autonomous disposition (merge/close/hold), not only the gate check conclusion. In particular, a
+  // failing gate can still become a concrete auto-close after CI/conflict/duplicate/linked-issue planning; recording
+  // only the gate's hold-shaped conclusion would blind the close-precision breaker to those live closes.
+  await recordNativeGateDecision(env, {
+    project: repoFullName,
+    pullNumber: pr.number,
+    headSha: pr.headSha,
+    conclusion: gate.conclusion,
+    action: disposition.actionClass,
+    reasonCode: disposition.blockerClass === "none" ? gate.conclusion : disposition.blockerClass,
+  });
   if (disposition.actionClass === "hold") {
     const gateBlockerCodes = gate.blockers.map((blocker) => blocker.code);
     const holdDetail = agentHoldAuditDetail({

--- a/src/review/parity-wire.ts
+++ b/src/review/parity-wire.ts
@@ -137,12 +137,12 @@ type ParityRecorderEnv = {
  */
 export async function recordNativeGateDecision(
   env: ParityRecorderEnv,
-  input: { project: string; pullNumber: number; headSha: string | null | undefined; conclusion: GateCheckConclusion; reasonCode?: string | null | undefined },
+  input: { project: string; pullNumber: number; headSha: string | null | undefined; conclusion: GateCheckConclusion; reasonCode?: string | null | undefined; action?: GateAction | undefined },
 ): Promise<void> {
   // Self-hosted instances always record (their own local DB; exportOrbBatch needs this data). The cloud
   // worker keeps the exact flag-gated, byte-identical-when-off contract.
   if (!isSelfHostedReviewRuntime(env) && !isParityAuditEnabled(env)) return;
-  const action = nativeGateActionFromConclusion(input.conclusion);
+  const action = input.action ?? nativeGateActionFromConclusion(input.conclusion);
   if (action === null) return; // not a comparable decision (neutral/skipped) → nothing to record
   if (!input.headSha) return; // parity REQUIRES head_sha to pair a decision to a commit; no sha → not comparable
   const project = input.project.slice(0, 200);

--- a/test/unit/parity-wire.test.ts
+++ b/test/unit/parity-wire.test.ts
@@ -128,6 +128,16 @@ describe("recordNativeGateDecision — flag-gated SHADOW recording into review_a
     expect(rows[0]).toMatchObject({ decision: "hold", summary: "slop_risk" }); // failure → hold, latest wins
   });
 
+  it("can replace the gate-shaped hold with the downstream native close disposition for self-tune", async () => {
+    const env = createTestEnv({ GITTENSORY_REVIEW_PARITY_AUDIT: "true" });
+    await recordNativeGateDecision(env, { project: "owner/repo", pullNumber: 7, headSha: "abc123", conclusion: "failure", reasonCode: "slop_risk" });
+    await recordNativeGateDecision(env, { project: "owner/repo", pullNumber: 7, headSha: "abc123", conclusion: "failure", action: "close", reasonCode: "ci_failed" });
+
+    const rows = await rawAll(env, "SELECT * FROM review_audit");
+    expect(rows.length).toBe(1);
+    expect(rows[0]).toMatchObject({ decision: "close", summary: "ci_failed", source: GITTENSORY_NATIVE_SOURCE });
+  });
+
   it("a new commit gets its OWN row", async () => {
     const env = createTestEnv({ GITTENSORY_REVIEW_PARITY_AUDIT: "true" });
     await recordNativeGateDecision(env, { project: "owner/repo", pullNumber: 7, headSha: "sha1", conclusion: "success" });

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -19839,6 +19839,8 @@ describe("auto-action convergence: end-to-end plan+execute for the general heuri
     // code (missing_linked_issue, from the default linkedIssueGateMode:block + no-linked-issue body) as the
     // bounded blocker_class -- proof this reaches the real gate.blockers, not just a hardcoded label.
     expect(await renderMetrics()).toContain('gittensory_agent_disposition_total{action_class="close",autonomy_level="auto",blocker_class="missing_linked_issue"} 1');
+    const nativeDecision = await env.DB.prepare("select decision, summary, source from review_audit where event_type = 'gate_decision' and target_id = ?").bind(`${REPO}#60`).first<{ decision: string; summary: string; source: string }>();
+    expect(nativeDecision).toMatchObject({ decision: "close", summary: "missing_linked_issue", source: "gittensory-native" });
   });
 
   // REGRESSION (gate-flagged gap, #terminal-outcome-audit): a PR that touches a guardrail-protected path (e.g.


### PR DESCRIPTION
### Motivation
- Self-tune precision breakers were scoped to the `gittensory-native` audit source but the native gate writer only recorded gate check conclusions (which map failures to `hold`), so live downstream autonomous `close` decisions were invisible to the close-precision tuner and the close-side breaker could never engage.
- The change ensures the self-tune loop observes the actual downstream disposition (merge/close/hold) so the close-precision circuit breaker can protect against bad autonomous closes.

### Description
- Record the downstream native agent disposition into the native gate_decision row by calling `recordNativeGateDecision` from the agent plan-and-execute site with an explicit `action` (the final `merge`/`close`/`hold`), not just the gate conclusion (file: `src/queue/processors.ts`).
- Extend `recordNativeGateDecision` to accept an optional `action` parameter and fall back to the existing `nativeGateActionFromConclusion` mapping when absent (file: `src/review/parity-wire.ts`).
- Add a unit regression that demonstrates a gate-shaped `hold` row can be replaced by a downstream native `close` prediction (file: `test/unit/parity-wire.test.ts`).
- Add an end-to-end assertion that the live auto-close convergence path stores a `gittensory-native` `close` decision for an actually-closed contributor PR (file: `test/unit/queue.test.ts`).

### Testing
- Ran typecheck: `npx tsc --noEmit --pretty false` and it passed.
- Ran targeted unit suites: `npx vitest run test/unit/parity-wire.test.ts` and `npx vitest run test/unit/outcomes-wire.test.ts test/unit/precision-breakers-chain.test.ts` and the targeted `queue` sub-suites (`npx vitest run test/unit/queue.test.ts -t "auto-action convergence"` and `-t "blocked contributor PR"`) and those targeted tests passed; added parity regression tests passed.
- Attempted full coverage and audit: `npm run test:coverage` was started but interrupted by long-running existing backfill retries in a large integration suite, and `npm audit --audit-level=moderate` failed due to an npm registry `403` response, so a full coverage/audit run could not be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48bf04ef1c832c86bc6322ce19945a)