### PR TITLE
feat(enrichment): detect console.dir/console.table log sinks for secrets & PII

### DIFF
--- a/review-enrichment/src/analyzers/secret-log.ts
+++ b/review-enrichment/src/analyzers/secret-log.ts
@@ -10,9 +10,11 @@ const MAX_FINDINGS = 25; // keep the brief bounded
 const MAX_LINE_CHARS = 2000; // skip pathologically long lines (defensive)
 
 // All matchers below are FLAT alternations (no group is itself quantified), so each is linear-time — the analyzer
-// can never be the DoS class it sits beside (#1503). Logging / stdout sinks:
+// can never be the DoS class it sits beside (#1503). Logging / stdout sinks. `dir`/`table` are included because
+// `console.dir(obj)` and `console.table(data)` dump an object/collection straight to stdout — the same egress path
+// as `console.log`, and a common way sensitive request/session data leaks into logs.
 const SINK_RE =
-  /\b(?:console|logger|log|winston|pino|bunyan)\s*\.\s*(?:log|info|warn|error|debug|trace|fatal|verbose|silly)\s*\(|\bprocess\s*\.\s*std(?:out|err)\s*\.\s*write\s*\(/;
+  /\b(?:console|logger|log|winston|pino|bunyan)\s*\.\s*(?:log|info|warn|error|debug|trace|fatal|verbose|silly|dir|table)\s*\(|\bprocess\s*\.\s*std(?:out|err)\s*\.\s*write\s*\(/;
 
 // Sensitive names, matched only against CODE (after string messages are stripped) so a hit means the value is
 // actually referenced, not merely named in a log message.

--- a/review-enrichment/test/secret-log.test.ts
+++ b/review-enrichment/test/secret-log.test.ts
@@ -1,0 +1,120 @@
+// Units for the secrets/PII-in-logs analyzer (#1507). Own file so concurrent analyzer PRs don't collide.
+// Pure compute, no network. Runs against the compiled dist/.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  codeOnly,
+  detectSecretLog,
+  scanPatchForSecretLog,
+  scanSecretLog,
+} from "../dist/analyzers/secret-log.js";
+
+test("detectSecretLog flags a secret referenced as code in a console.log sink", () => {
+  assert.deepEqual(detectSecretLog("console.log(req.headers.authorization)"), {
+    sink: "console.log",
+    category: "secret",
+  });
+});
+
+test("detectSecretLog flags PII and request-object dumps", () => {
+  assert.deepEqual(detectSecretLog("logger.info(`ssn=${user.ssn}`)"), {
+    sink: "logger.info",
+    category: "pii",
+  });
+  assert.deepEqual(detectSecretLog("console.error(req.body)"), {
+    sink: "console.error",
+    category: "request-object",
+  });
+});
+
+test("detectSecretLog does not flag string-literal log messages", () => {
+  // The sensitive word lives only inside a string message, not as code, so it must not trigger.
+  assert.equal(
+    detectSecretLog('console.log("password reset email sent")'),
+    null,
+  );
+  assert.equal(detectSecretLog("console.log('request received')"), null);
+});
+
+test("detectSecretLog flags console.dir dumping a request object", () => {
+  // Regression for the sink list missing `console.dir`, which prints an object straight to stdout.
+  assert.deepEqual(detectSecretLog("console.dir(req.headers)"), {
+    sink: "console.dir",
+    category: "request-object",
+  });
+});
+
+test("detectSecretLog flags console.table dumping sensitive rows", () => {
+  // Regression for the sink list missing `console.table`, which dumps a collection to stdout.
+  assert.deepEqual(
+    detectSecretLog("console.table(users.map((u) => u.password))"),
+    {
+      sink: "console.table",
+      category: "secret",
+    },
+  );
+});
+
+test("detectSecretLog ignores console.dir/table on innocuous data", () => {
+  // The new sinks must stay precision-first: no sensitive token as code ⇒ no finding.
+  assert.equal(detectSecretLog("console.dir(config.timeoutMs)"), null);
+  assert.equal(detectSecretLog("console.table(rows)"), null);
+});
+
+test("codeOnly strips string messages but keeps interpolation bodies as code", () => {
+  assert.equal(
+    codeOnly('console.log("just a message")').includes("message"),
+    false,
+  );
+  assert.equal(
+    codeOnly("console.log(`token=${apiKey}`)").includes("apiKey"),
+    true,
+  );
+});
+
+test("scanPatchForSecretLog cites the added line via the hunk header", () => {
+  const patch = [
+    "@@ -1,0 +42,2 @@",
+    "+console.dir(req.headers)",
+    " const untouched = 1;",
+  ].join("\n");
+  assert.deepEqual(scanPatchForSecretLog("src/app.ts", patch), [
+    {
+      file: "src/app.ts",
+      line: 42,
+      sink: "console.dir",
+      category: "request-object",
+    },
+  ]);
+});
+
+test("scanPatchForSecretLog ignores context and removed lines", () => {
+  const patch = [
+    "@@ -1,2 +1,1 @@",
+    " console.log(req.headers)",
+    "-console.log(req.body)",
+  ].join("\n");
+  assert.deepEqual(scanPatchForSecretLog("src/app.ts", patch), []);
+});
+
+test("scanSecretLog scans every changed file's added lines", async () => {
+  const findings = await scanSecretLog({
+    files: [
+      { path: "a.ts", patch: "@@ -1,0 +1,1 @@\n+console.table(req.body)" },
+      {
+        path: "b.ts",
+        patch: "@@ -1,0 +5,1 @@\n+logger.info(`key=${clientSecret}`)",
+      },
+    ],
+  });
+  assert.deepEqual(findings, [
+    {
+      file: "a.ts",
+      line: 1,
+      sink: "console.table",
+      category: "request-object",
+    },
+    { file: "b.ts", line: 5, sink: "logger.info", category: "secret" },
+  ]);
+});


### PR DESCRIPTION
## Summary
- The `secretLog` analyzer (registered, `defaultEnabled: true`) flags added lines that pass sensitive values/PII/request objects into a logging or stdout sink. Its documented scope is "added lines that call console, logger, process.stdout, or process.stderr sinks."
- The sink matcher covered `console.log/info/warn/error/debug/trace/fatal/verbose/silly` and `process.stdout/stderr.write`, but **missed `console.dir` and `console.table`** — both of which dump an object/collection straight to stdout (`console.dir(req.headers)`, `console.table(users)`). These are the exact egress path the analyzer exists to catch, so secret/PII leaks through them went unflagged.
- This extends the existing **flat, linear-time** sink alternation to include `dir` and `table` (the ReDoS-safety invariant is preserved — no group is quantified). The downstream secret/PII/request-object matchers are unchanged, so precision is unchanged: a hit still requires a sensitive token referenced *as code*, not in a string message.

## Validation
- Adds `review-enrichment/test/secret-log.test.ts` — the analyzer's **first dedicated test suite**, exercising the real exported paths (`detectSecretLog`, `scanPatchForSecretLog`, `scanSecretLog`, `codeOnly`):
  - new `console.dir`/`console.table` sinks flag request-object and secret dumps;
  - precision guards: innocuous `console.dir(config.timeoutMs)` / `console.table(rows)` and string-only messages are not flagged;
  - existing behaviors (hunk-line citation, context/removed-line skipping, multi-file scan, interpolation-body handling).

## Test plan
- [x] `node --test test/secret-log.test.ts` — 10 passed.
- [x] Full REES suite `node --test test/**/*.test.ts` — 554 passed, 0 failed.
- [x] `generate-analyzer-metadata.mjs --check` clean; `validate-sourcemaps.mjs` clean; Prettier clean.