### PR TITLE
fix(agent): serialize concurrent approval-queue decisions

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -4403,7 +4403,22 @@ export async function getPendingAgentAction(env: Env, id: string): Promise<Agent
   return row ? toAgentPendingActionRecord(row) : null;
 }
 
-/** Mark a staged action accepted/rejected. Idempotency is the caller's concern (it checks status === pending). */
+/** Atomically transition a pending approval-queue row to a decided status. Exactly one concurrent caller wins
+ *  (changes === 1); the rest must treat a false return as already_decided and must not execute the action. */
+export async function claimPendingAgentActionDecision(
+  env: Env,
+  id: string,
+  update: { status: AgentPendingActionStatus; decidedBy: string },
+): Promise<boolean> {
+  const result = await getDb(env.DB)
+    .update(agentPendingActions)
+    .set({ status: update.status, decidedBy: update.decidedBy, decidedAt: nowIso(), updatedAt: nowIso() })
+    .where(and(eq(agentPendingActions.id, id), eq(agentPendingActions.status, "pending")));
+  /* v8 ignore next -- D1 update metadata normally includes changes; the ?? 0 fallback protects driver anomalies. */
+  return Number(result.meta.changes ?? 0) === 1;
+}
+
+/** Mark a staged action accepted/rejected/errored after it has already been claimed. */
 export async function setPendingAgentActionStatus(env: Env, id: string, update: { status: AgentPendingActionStatus; decidedBy: string | null }): Promise<void> {
   await getDb(env.DB)
     .update(agentPendingActions)

--- a/src/services/agent-approval-queue.ts
+++ b/src/services/agent-approval-queue.ts
@@ -1,4 +1,4 @@
-import { getInstallation, getPullRequest, getPendingAgentAction, recordAuditEvent, setPendingAgentActionStatus } from "../db/repositories";
+import { claimPendingAgentActionDecision, getInstallation, getPullRequest, getPendingAgentAction, recordAuditEvent, setPendingAgentActionStatus } from "../db/repositories";
 import { resolveRepositorySettings } from "../settings/repository-settings";
 import { createInstallationToken } from "../github/app";
 import { loadLinkedIssueHardRules, resolveLinkedIssueHardRule } from "../review/linked-issue-hard-rules";
@@ -23,7 +23,7 @@ export type ApprovalDecisionResult = {
  * Decide a staged approval-queue action (#779). Accept → run the action through the current executor gates
  * (the maintainer's accept IS the approval, so only the approval queue gate is bypassed). Reject → cancel.
  * Either decision marks the row decided (idempotent: a second decision is a no-op) and records an audit event
- * that feeds the trust loop.
+ * that feeds the trust loop. Concurrent accepts/rejects are serialized by an atomic pending→decided claim.
  */
 export async function decidePendingAgentAction(env: Env, input: { id: string; decision: ApprovalDecision; decidedBy: string }): Promise<ApprovalDecisionResult> {
   const pending = await getPendingAgentAction(env, input.id);
@@ -33,9 +33,18 @@ export async function decidePendingAgentAction(env: Env, input: { id: string; de
   const baseMetadata = { pendingId: pending.id, repoFullName: pending.repoFullName, pullNumber: pending.pullNumber, actionClass: pending.actionClass, autonomyLevel: pending.autonomyLevel };
 
   if (input.decision === "reject") {
-    await setPendingAgentActionStatus(env, pending.id, { status: "rejected", decidedBy: input.decidedBy });
+    if (!(await claimPendingAgentActionDecision(env, pending.id, { status: "rejected", decidedBy: input.decidedBy }))) {
+      const current = await getPendingAgentAction(env, pending.id);
+      return { status: "already_decided", action: current ?? pending };
+    }
     await recordAuditEvent(env, { eventType: "agent.pending_action.rejected", actor: input.decidedBy, targetKey, outcome: "completed", detail: `rejected ${pending.actionClass}`, metadata: baseMetadata });
     return { status: "rejected", action: { ...pending, status: "rejected", decidedBy: input.decidedBy } };
+  }
+
+  // Claim before any async re-validation or execution so two concurrent accepts cannot both reach the executor.
+  if (!(await claimPendingAgentActionDecision(env, pending.id, { status: "accepted", decidedBy: input.decidedBy }))) {
+    const current = await getPendingAgentAction(env, pending.id);
+    return { status: "already_decided", action: current ?? pending };
   }
 
   // accept → execute the staged action live, then record the result.

--- a/test/unit/agent-approval-queue.test.ts
+++ b/test/unit/agent-approval-queue.test.ts
@@ -52,6 +52,7 @@ import { fetchLiveCiAggregate, fetchLivePullRequestMergeState, fetchLivePullRequ
 import { resolveLinkedIssueHardRule } from "../../src/review/linked-issue-hard-rules";
 import { upsertRepoFocusManifest } from "../../src/signals/focus-manifest-loader";
 import { actionParams, executeAgentMaintenanceActions, pendingActionToPlanned, type AgentActionExecutionContext } from "../../src/services/agent-action-executor";
+import * as agentActionExecutor from "../../src/services/agent-action-executor";
 import { decidePendingAgentAction } from "../../src/services/agent-approval-queue";
 import {
   countPendingAgentActions,
@@ -1122,6 +1123,40 @@ describe("agent approval queue (#779)", () => {
     const second = await decidePendingAgentAction(env, { id: action.id, decision: "accept", decidedBy: "owner" });
     expect(second.status).toBe("already_decided");
     expect(second.action?.status).toBe("rejected");
+  });
+
+  it("REGRESSION: two concurrent accepts execute the staged action at most once", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: "x" });
+    await upsertRepositorySettings(env, { repoFullName: "owner/repo", autonomy: { merge: "auto_with_approval" } });
+    await seedInstallation(env);
+    await upsertPullRequestFromGitHub(env, "owner/repo", { number: 7, title: "PR", state: "open", user: { login: "contributor" }, head: { sha: "h7" }, labels: [], body: "x" });
+    const { action } = await createPendingAgentActionIfAbsent(env, {
+      repoFullName: "owner/repo",
+      pullNumber: 7,
+      installationId: 5,
+      actionClass: "merge",
+      autonomyLevel: "auto_with_approval",
+      params: { mergeMethod: "squash", expectedHeadSha: "h7" },
+      reason: "clean",
+    });
+
+    let unblockExecution = () => {};
+    const executionBlocked = new Promise<void>((resolve) => {
+      unblockExecution = resolve;
+    });
+    const execSpy = vi.spyOn(agentActionExecutor, "executeAgentMaintenanceActions").mockImplementation(async () => {
+      await executionBlocked;
+      return [{ actionClass: "merge", outcome: "completed", detail: "merged" }];
+    });
+
+    const first = decidePendingAgentAction(env, { id: action.id, decision: "accept", decidedBy: "owner" });
+    const second = decidePendingAgentAction(env, { id: action.id, decision: "accept", decidedBy: "owner" });
+    unblockExecution();
+    const [result1, result2] = await Promise.all([first, second]);
+
+    expect([result1.status, result2.status].sort()).toEqual(["accepted", "already_decided"]);
+    expect(execSpy).toHaveBeenCalledTimes(1);
+    execSpy.mockRestore();
   });
 
   it("returns not_found for an unknown id", async () => {

--- a/test/unit/db-parsers.test.ts
+++ b/test/unit/db-parsers.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  claimPendingAgentActionDecision,
   claimRegateFanoutSlot,
   countRecentDeadLetters,
   countRecentDeadLettersByType,
@@ -23,6 +24,8 @@ import {
   extractLinkedIssueNumbers,
   extractLinkedIssueNumbersWithOverflow,
   MAX_LINKED_ISSUE_NUMBERS,
+  createPendingAgentActionIfAbsent,
+  getPendingAgentAction,
 } from "../../src/db/repositories";
 import { getDb } from "../../src/db/client";
 import { webhookEvents } from "../../src/db/schema";
@@ -313,6 +316,22 @@ describe("database row parser hardening", () => {
     expect(await claimRegateFanoutSlot(env, "2026-06-25T01:00:50.000Z", W)).toBe(false); // +50s, still inside → loses
     expect(await claimRegateFanoutSlot(env, "2026-06-25T01:01:31.000Z", W)).toBe(true); // +91s, outside window → wins again
     expect(await claimRegateFanoutSlot(env, "2026-06-25T01:01:40.000Z", W)).toBe(false); // back inside the new window → loses
+  });
+
+  it("claimPendingAgentActionDecision lets exactly one caller decide a pending row", async () => {
+    const env = createTestEnv();
+    const { action } = await createPendingAgentActionIfAbsent(env, {
+      repoFullName: "owner/repo",
+      pullNumber: 7,
+      installationId: 5,
+      actionClass: "merge",
+      autonomyLevel: "auto_with_approval",
+      params: {},
+      reason: "x",
+    });
+    expect(await claimPendingAgentActionDecision(env, action.id, { status: "rejected", decidedBy: "owner" })).toBe(true);
+    expect(await claimPendingAgentActionDecision(env, action.id, { status: "rejected", decidedBy: "owner" })).toBe(false);
+    expect((await getPendingAgentAction(env, action.id))?.status).toBe("rejected");
   });
 
   it("REGRESSION: recordWebhookEvent updates payload_hash when processing an existing queued delivery", async () => {


### PR DESCRIPTION
## Summary

Two concurrent accept requests on the same staged approval-queue row could both pass the initial `status === "pending"` check and both call `executeAgentMaintenanceActions`, risking duplicate merge/close/approve side effects (double-click, retry, or MCP + HTTP at the same time).

This PR adds an atomic `pending → decided` claim before any reject audit or accept re-validation/execution. Exactly one caller wins; losers return `already_decided` and never reach the executor.

## Changed files

| File | Change |
| ---- | ------ |
| `src/db/repositories.ts` | Add `claimPendingAgentActionDecision()` — conditional `UPDATE … WHERE id = ? AND status = 'pending'`, returns `true` only when `changes === 1`. Update `setPendingAgentActionStatus` doc to note it runs after claim. |
| `src/services/agent-approval-queue.ts` | Call claim at the start of reject (`pending → rejected`) and accept (`pending → accepted`) paths in `decidePendingAgentAction`. Losers re-read the row and return `already_decided`. |
| `test/unit/db-parsers.test.ts` | Unit test: second claim on the same row returns `false`. |
| `test/unit/agent-approval-queue.test.ts` | Regression test: two concurrent accepts with a blocked executor — one `accepted`, one `already_decided`, executor called once. |

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Full gate run via `npm run test:ci` (includes migration/schema/cf-typegen checks, `rees:test`, `build:miner`, `ui:openapi:settings-parity`, `ui:version-audit`, `ui:test`, and the rest). Green locally (~8 min).
- `codecov/patch` not verified locally — depends on GitHub CI upload.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

No UI, API, OpenAPI, or MCP surface changes — backend concurrency fix only.

## UI Evidence

N/A — no visible UI changes.

## Test plan

- [x] `claimPendingAgentActionDecision` — first claim wins, second returns `false`, row ends `rejected`
- [x] Concurrent accept regression — executor invoked exactly once; statuses are `accepted` + `already_decided`
- [x] Existing approval-queue suite (59 tests) still passes
- [x] Full `npm run test:ci` green (8,234+ tests)

## Notes

Analogue: `claimRegateFanoutSlot()` in `src/db/repositories.ts` uses the same `UPDATE … WHERE …` + `meta.changes === 1` pattern for burst dedup.

Accept claims `pending → accepted` before async re-validation so the row is decided immediately; supersede paths still update to `rejected`, and executor errors still update to `errored`.
