### PR TITLE
fix(miner): treat null readEvents since filter as unscoped

### DIFF
--- a/packages/gittensory-miner/lib/event-ledger.d.ts
+++ b/packages/gittensory-miner/lib/event-ledger.d.ts
@@ -15,7 +15,7 @@ export type AppendEventInput = {
 
 export type ReadEventsFilter = {
   repoFullName?: string | null;
-  since?: number;
+  since?: number | null;
 };
 
 export type EventLedger = {

--- a/packages/gittensory-miner/lib/event-ledger.js
+++ b/packages/gittensory-miner/lib/event-ledger.js
@@ -56,7 +56,7 @@ function normalizeOptionalRepoFullName(repoFullName) {
 
 /** Optional seq cursor for polling: omitted → undefined; otherwise a non-negative integer last-seen seq. */
 function normalizeOptionalSince(since) {
-  if (since === undefined) return undefined;
+  if (since === undefined || since === null) return undefined;
   if (typeof since !== "number" || !Number.isInteger(since) || since < 0) {
     throw new Error("invalid_since");
   }

--- a/test/unit/miner-event-ledger.test.ts
+++ b/test/unit/miner-event-ledger.test.ts
@@ -97,6 +97,13 @@ describe("gittensory-miner event ledger (#2290)", () => {
     expect(events.map((entry) => entry.type)).toEqual(["plan_built", "discovered_issue", "pr_prepared"]);
   });
 
+  it("treats a null since filter as unscoped", () => {
+    const ledger = tempLedger();
+    ledger.appendEvent({ type: "discovered_issue", payload: {} }); // seq 1
+    ledger.appendEvent({ type: "plan_built", payload: {} }); // seq 2
+    expect(ledger.readEvents({ since: null }).map((entry) => entry.seq)).toEqual([1, 2]);
+  });
+
   it("keeps a null repo filter unscoped when combined with since", () => {
     const ledger = tempLedger();
     ledger.appendEvent({ type: "discovered_issue", repoFullName: "o/a", payload: {} }); // seq 1


### PR DESCRIPTION
## Summary

- Treat `readEvents({ since: null })` as an unscoped poll, matching how null repo filters already behave.
- Prevents nullable filter objects from throwing `invalid_since` when callers omit a seq cursor via `null`.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] Focused on event-ledger `readEvents` filtering only — no unrelated miner CLI or UI changes.

## Validation

- [ ] `npm run test:ci` locally — CI will run the full gate on push.
- [x] Unit test covers null `since` returning all events.

## Safety

- [x] No secrets, wallet details, hotkeys, or private scoring output in code or PR text.
- [x] Deterministic, read/write-local only: no network calls.

## UI Evidence

Not applicable — miner library only.

## Notes

Follow-up to #2897 and #2955 — completes nullish read-filter parity for the event ledger (#2290).
