### PR TITLE
fix(scenarios): order signal entry ids with natural numeric sort

### DIFF
--- a/src/scenarios/input-model.ts
+++ b/src/scenarios/input-model.ts
@@ -372,7 +372,10 @@ function optionalScenarioText(value: string | undefined, maxLength: number): str
 }
 
 function sortEntries(entries: ScenarioSignalEntry[]): ScenarioSignalEntry[] {
-  return [...entries].sort((left, right) => left.id.localeCompare(right.id));
+  // Numeric-aware compare so sequentially numbered ids sort in natural order — otherwise a plain
+  // lexicographic compare orders `assumption_10` before `assumption_2`, scrambling caller-supplied
+  // note order (and any other numeric-suffixed bucket) once there are 10+ entries.
+  return [...entries].sort((left, right) => left.id.localeCompare(right.id, undefined, { numeric: true }));
 }
 
 function compactRepoConfig(args: { repoFullName: string; registered?: boolean; maintainerLane?: boolean }): ScenarioRepoConfig {

--- a/test/unit/scenario-input-model.test.ts
+++ b/test/unit/scenario-input-model.test.ts
@@ -123,6 +123,18 @@ describe("agent scenario input model", () => {
     );
     expect(normalized.facts.map((entry) => entry.id)).toEqual(["a", "z"]);
   });
+
+  it("orders numeric-suffixed ids naturally, preserving caller note order past 9 (assumption_10 after assumption_2)", () => {
+    const notes = Array.from({ length: 12 }, (_, index) => `n${index + 1}`);
+    const input = scenarioInputFromLocalBranchMetadata({
+      scenarioType: "branch_preflight",
+      login: "miner",
+      repoFullName: "octo/demo",
+      scenarioNotes: notes,
+    });
+    expect(input.assumptions.map((entry) => entry.id)).toEqual(notes.map((_, index) => `assumption_${index + 1}`));
+    expect(input.assumptions.map((entry) => entry.detail)).toEqual(notes);
+  });
 });
 
 describe("public vs private serialization", () => {


### PR DESCRIPTION
## Summary

`sortEntries` in `src/scenarios/input-model.ts` (run over every signal bucket during
`normalizeScenarioInput`) ordered entries with a plain lexicographic `localeCompare`. Entry ids can carry
sequential numeric suffixes — `scenarioInputFromLocalBranchMetadata` generates caller assumptions as
`assumption_${index + 1}` — so lexicographic ordering scrambles them once there are 10+:
`assumption_10` sorts before `assumption_2`.

```ts
scenarioInputFromLocalBranchMetadata({ scenarioType: "branch_preflight", repoFullName: "octo/demo",
  scenarioNotes: ["n1","n2",…,"n12"] })
// input.assumptions.map(a => a.detail)
// before: ["n1","n10","n11","n12","n2","n3","n4","n5","n6","n7","n8","n9"]  ← caller order scrambled
// after:  ["n1","n2","n3","n4","n5","n6","n7","n8","n9","n10","n11","n12"]
```

That scrambled order is what `serializeScenarioInputPublic` emits, so a caller's ordered advisory notes
come out shuffled. Fix: pass `{ numeric: true }` to `localeCompare` so numeric-suffixed ids sort in
natural order. Purely lexical ids (e.g. `a`/`z`, `actor`/`repo`) are unaffected, so existing ordering is
preserved.

No linked issue: small, self-evident ordering-correctness fix (one comparator option) in a single
deterministic helper, with no public API, auth, schema, or deploy surface change — fits the repo's
`preferred` (not required) linked-issue policy.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran locally: `git diff --check` (clean), `npm run typecheck` (clean), and a focused `test:coverage`
  over `test/unit/scenario-input-model.test.ts` — 18 tests pass and `src/scenarios/input-model.ts` is at
  **100% statements/branches/functions/lines**, so `codecov/patch` is 100% on this diff.
- Not run locally: the UI, MCP, workers, OpenAPI, actionlint, and audit jobs. This is a `src/`-only change
  to one deterministic helper touching no UI/API/OpenAPI/MCP/DB/workflow surface, so those jobs are no-ops
  for this diff; they run on CI (Linux).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- No UI, auth, CORS, API, or schema surface is touched — a pure deterministic ordering fix, so the
  auth/UI/OpenAPI boxes are N/A.
- Regression test added in `test/unit/scenario-input-model.test.ts`: building metadata-only input from 12
  caller notes now yields `assumption_1..assumption_12` in caller order (was scrambled). The existing
  "sorts entries by id during normalization" (`z`/`a`) assertion still holds under numeric collation.
