### PR TITLE
fix(agent-actions): close terminal PRs during pending CI

### DIFF
--- a/src/settings/agent-actions.ts
+++ b/src/settings/agent-actions.ts
@@ -558,16 +558,29 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
   if (input.conclusion === "skipped") return actions;
 
   // CI state over ALL of the PR's checks (required OR not — codecov/patch included) — reviewbot's ci_red
-  // parity. A red CI is NEVER approved/merged and is itself a close-worthy signal (non-owner); while CI is
-  // still running we take NO action and wait for the check-completion webhook to re-run this planner.
+  // parity. A red CI is NEVER approved/merged and is itself a close-worthy signal (non-owner). While CI is
+  // still running, never approve or merge, but do not let unrelated pending checks mask terminal close reasons
+  // that are already known now (a base conflict or a blocking gate verdict).
   const ciPassed = input.ciState === "passed";
   const ciFailed = input.ciState === "failed";
-  // Settle-before-decide: never approve / merge / close on a half-finished CI run.
-  if (input.ciState === "pending" || input.ciHasPending === true) return actions;
+  const ciPending = input.ciState === "pending" || input.ciHasPending === true;
 
   // The gate verdict is authoritative. Green CI is still required for merge/approve, but it does not rewrite an AI
   // or review-thread blocker into success once the gate has classified it as blocking.
   const conclusion: GateCheckConclusion = input.conclusion;
+  const isConflict = input.pr.mergeableState === "dirty"; // conflicts with base — can't merge as-is
+  const isContributor = !input.authorIsOwner && !input.authorIsAdmin && !input.authorIsAutomationBot;
+  // The owner-close exemption is PER-REPO CONFIGURABLE (#configurable-owner-close): by default the repo owner's
+  // own PRs are exempt from auto-close (closeOwnerAuthors !== true ⇒ merge or manual-hold only), but a maintainer
+  // can opt in to closing them like a contributor's. #2133 folds the fleet-operator admin allowlist into the same
+  // trusted-identity exemption (a login honored as a maintainer everywhere else in the codebase must not be
+  // treated as an ordinary contributor here). Automation bots stay exempt regardless (a noise heuristic must not
+  // kill a recurring maintainer-managed accumulator).
+  const closeEligible = isContributor || ((input.authorIsOwner || input.authorIsAdmin) && input.closeOwnerAuthors === true);
+  const pendingCiTerminalClose = closeEligible && acting("close") && (conclusion === "failure" || isConflict);
+  // Settle-before-decide: pending CI suppresses success-path work, but not terminal close work. Otherwise a PR
+  // with a known base conflict or blocking gate verdict can sit open forever behind an unrelated stuck check.
+  if (ciPending && !pendingCiTerminalClose) return actions;
 
   // Only SUCCESS earns the review-good auto-merge. A NEUTRAL gate flows (no longer silently returns []) but is
   // NOT auto-merged — it falls through to a HELD + labeled state for review. (Auto-merging a neutral / grace
@@ -596,16 +609,7 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
   // would-approve/would-merge dispositions into a manual hold.
   const ciUnverified = input.ciState === "unverified";
   const reviewGood = gatePassing && ciPassed;
-  const isContributor = !input.authorIsOwner && !input.authorIsAdmin && !input.authorIsAutomationBot;
-  // The owner-close exemption is PER-REPO CONFIGURABLE (#configurable-owner-close): by default the repo owner's
-  // own PRs are exempt from auto-close (closeOwnerAuthors !== true ⇒ merge or manual-hold only), but a maintainer
-  // can opt in to closing them like a contributor's. #2133 folds the fleet-operator admin allowlist into the same
-  // trusted-identity exemption (a login honored as a maintainer everywhere else in the codebase must not be
-  // treated as an ordinary contributor here). Automation bots stay exempt regardless (a noise heuristic must not
-  // kill a recurring maintainer-managed accumulator).
-  const closeEligible = isContributor || ((input.authorIsOwner || input.authorIsAdmin) && input.closeOwnerAuthors === true);
   const mergeableClean = input.pr.mergeableState === "clean";
-  const isConflict = input.pr.mergeableState === "dirty"; // conflicts with base — can't merge as-is
   // RC3: a prior merge attempt failed terminally for THIS exact head SHA (403/405/409/conflict) → never re-plan
   // the merge; it can't complete for this commit. A new commit makes the live head differ from mergeBlockedSha.
   const mergeTerminallyBlocked = input.pr.mergeBlockedSha != null && input.pr.headSha != null && input.pr.mergeBlockedSha === input.pr.headSha;

--- a/test/unit/agent-actions.test.ts
+++ b/test/unit/agent-actions.test.ts
@@ -622,11 +622,11 @@ describe("planAgentMaintenanceActions (#778)", () => {
       expect(label?.label).toBe(AGENT_LABEL_CHANGES);
     });
 
-    it("DEFERS every action while CI is still pending (settle-before-decide)", () => {
+    it("DEFERS success-path actions while CI is still pending (settle-before-decide)", () => {
       expect(planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { review_state_label: "auto", approve: "auto", merge: "auto", close: "auto" }, ciState: "pending", pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED" } }))).toEqual([]);
     });
 
-    it("DEFERS every action when optional visible CI is still pending after required CI passed", () => {
+    it("DEFERS success-path actions when optional visible CI is still pending after required CI passed", () => {
       expect(
         planAgentMaintenanceActions(
           input({
@@ -639,6 +639,32 @@ describe("planAgentMaintenanceActions (#778)", () => {
           }),
         ),
       ).toEqual([]);
+    });
+
+    it("CLOSES a base-conflicting contributor PR even while CI is still pending (#2968)", () => {
+      const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { approve: "auto", merge: "auto", close: "auto" }, ciState: "pending", pr: { labels: [], mergeableState: "dirty", reviewDecision: "APPROVED" } }));
+      const cls = classes(plan);
+      expect(cls).not.toContain("approve");
+      expect(cls).not.toContain("merge");
+      expect(cls).toContain("close");
+      expect(plan.find((a) => a.actionClass === "close")).toMatchObject({
+        closeKind: "heuristic",
+        closeConcreteEvidence: true,
+        closeRequiresMergeableState: true,
+      });
+    });
+
+    it("CLOSES a blocking gate failure even when optional visible CI is still pending", () => {
+      const plan = planAgentMaintenanceActions(input({ conclusion: "failure", autonomy: { approve: "auto", merge: "auto", close: "auto" }, ciState: "passed", ciHasPending: true, gateBlockerCodes: ["ai_consensus_defect"], blockerTitles: ["AI review found a defect"], pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED" } }));
+      const cls = classes(plan);
+      expect(cls).not.toContain("approve");
+      expect(cls).not.toContain("merge");
+      expect(cls).toContain("close");
+      expect(plan.find((a) => a.actionClass === "close")).toMatchObject({
+        closeKind: "heuristic",
+        closeConcreteEvidence: false,
+        closeRequiresMergeableState: false,
+      });
     });
 
     it("HOLDS a contributor's gate-passing PR whose CI is UNVERIFIED — NEVER closes it (fork workflows awaiting approval) (#harm-stop)", () => {


### PR DESCRIPTION
## Summary
- Allow terminal close actions to proceed while unrelated CI is still pending.
- Keep pending CI as a blocker for approve, merge, and ordinary success-path labels.
- Add regressions for the PR #2968 shape: a conflicted contributor PR must close instead of being held behind pending CI.

## What changed
- Planner now computes base-conflict and gate-failure terminal close eligibility before the pending-CI short-circuit.
- Pending CI still returns no actions for clean, gate-passing PRs.
- Tests cover conflicted PRs and blocking gate failures with pending visible CI.

## Why
PRs with known terminal close reasons were being held as `CI pending`, which left conflicted or blocked contributor PRs open until unrelated checks settled. A base conflict or blocking gate verdict is already enough to close in one-shot mode; pending CI should not mask that.

## Validation
- `npx vitest run test/unit/agent-actions.test.ts -t "pending|base-conflicting|blocking gate failure"`
- `npx vitest run test/unit/agent-actions.test.ts`
- `npm run typecheck`
- `git diff --check`