### PR TITLE
feat(enrichment): flag NODE_TLS_REJECT_UNAUTHORIZED=0 as disabled TLS verification

### DIFF
--- a/review-enrichment/src/analyzers/iac-misconfig.ts
+++ b/review-enrichment/src/analyzers/iac-misconfig.ts
@@ -19,7 +19,7 @@ const PUBLIC_BUCKET_RE =
 const SAME_SITE_NONE_RE = /\bsameSite\b[\s"'=:,-]*["']?none["']?\b/i;
 const SECURE_FALSE_RE = /\bsecure\b[\s"'=:,-]*false\b/i;
 const TLS_DISABLED_RE =
-  /\brejectUnauthorized\b[\s"'=:,-]*false\b|\bverify\s*=\s*False\b|\bssl_verify\b[\s"'=:,-]*false\b|\binsecureSkipTLSVerify\b[\s"'=:,-]*true\b|\bskipTLSVerify\b[\s"'=:,-]*true\b/i;
+  /\brejectUnauthorized\b[\s"'=:,-]*false\b|\bverify\s*=\s*False\b|\bssl_verify\b[\s"'=:,-]*false\b|\binsecureSkipTLSVerify\b[\s"'=:,-]*true\b|\bskipTLSVerify\b[\s"'=:,-]*true\b|\bNODE_TLS_REJECT_UNAUTHORIZED\b[\s"'=:,-]*["']?0\b/i;
 const PROD_RE =
   /\b(?:NODE_ENV|ENVIRONMENT|APP_ENV)\b[\s"'=:,-]*production\b|\bproduction\s*:/i;
 const DEBUG_TRUE_RE = /\bdebug\b[\s"'=:,-]*true\b|\bDEBUG\b[\s"'=:,-]*true\b/i;

--- a/review-enrichment/test/iac-misconfig.test.ts
+++ b/review-enrichment/test/iac-misconfig.test.ts
@@ -6,15 +6,23 @@ import { scanPatchForIacMisconfig } from "../dist/analyzers/iac-misconfig.js";
 test("scanPatchForIacMisconfig flags hostNetwork and compose host network mode", () => {
   const k8s = scanPatchForIacMisconfig(
     "deploy/k8s/app.yaml",
-    ["@@ -10,0 +10,2 @@", "+      hostNetwork: true", "+      dnsPolicy: ClusterFirstWithHostNet"].join("\n"),
+    [
+      "@@ -10,0 +10,2 @@",
+      "+      hostNetwork: true",
+      "+      dnsPolicy: ClusterFirstWithHostNet",
+    ].join("\n"),
   );
-  assert.deepEqual(k8s, [{ file: "deploy/k8s/app.yaml", line: 10, kind: "open-ingress" }]);
+  assert.deepEqual(k8s, [
+    { file: "deploy/k8s/app.yaml", line: 10, kind: "open-ingress" },
+  ]);
 
   const compose = scanPatchForIacMisconfig(
     "docker-compose.yml",
     ["@@ -1,0 +5,1 @@", "+    network_mode: host"].join("\n"),
   );
-  assert.deepEqual(compose, [{ file: "docker-compose.yml", line: 5, kind: "open-ingress" }]);
+  assert.deepEqual(compose, [
+    { file: "docker-compose.yml", line: 5, kind: "open-ingress" },
+  ]);
 });
 
 test("scanPatchForIacMisconfig flags K8s and Helm TLS skip settings", () => {
@@ -22,24 +30,78 @@ test("scanPatchForIacMisconfig flags K8s and Helm TLS skip settings", () => {
     "values.yaml",
     ["@@ -20,0 +20,1 @@", "+  insecureSkipTLSVerify: true"].join("\n"),
   );
-  assert.deepEqual(k8s, [{ file: "values.yaml", line: 20, kind: "tls-verification-disabled" }]);
+  assert.deepEqual(k8s, [
+    { file: "values.yaml", line: 20, kind: "tls-verification-disabled" },
+  ]);
 
   const helm = scanPatchForIacMisconfig(
     "charts/app/values.yaml",
     ["@@ -3,0 +3,1 @@", '+  skipTLSVerify: "true"'].join("\n"),
   );
-  assert.deepEqual(helm, [{ file: "charts/app/values.yaml", line: 3, kind: "tls-verification-disabled" }]);
+  assert.deepEqual(helm, [
+    {
+      file: "charts/app/values.yaml",
+      line: 3,
+      kind: "tls-verification-disabled",
+    },
+  ]);
+});
+
+test("scanPatchForIacMisconfig flags NODE_TLS_REJECT_UNAUTHORIZED=0 as TLS verification disabled", () => {
+  // Canonical Node env var that disables ALL TLS certificate verification process-wide — the env-var equivalent
+  // of the already-detected `rejectUnauthorized: false`. Covers .env, Dockerfile ENV, and quoted YAML/JSON forms.
+  const dotenv = scanPatchForIacMisconfig(
+    ".env.production",
+    ["@@ -1,0 +7,1 @@", "+NODE_TLS_REJECT_UNAUTHORIZED=0"].join("\n"),
+  );
+  assert.deepEqual(dotenv, [
+    { file: ".env.production", line: 7, kind: "tls-verification-disabled" },
+  ]);
+
+  const dockerfile = scanPatchForIacMisconfig(
+    "Dockerfile",
+    ["@@ -1,0 +3,1 @@", "+ENV NODE_TLS_REJECT_UNAUTHORIZED 0"].join("\n"),
+  );
+  assert.deepEqual(dockerfile, [
+    { file: "Dockerfile", line: 3, kind: "tls-verification-disabled" },
+  ]);
+
+  const quoted = scanPatchForIacMisconfig(
+    "compose.yaml",
+    ["@@ -1,0 +9,1 @@", '+      NODE_TLS_REJECT_UNAUTHORIZED: "0"'].join("\n"),
+  );
+  assert.deepEqual(quoted, [
+    { file: "compose.yaml", line: 9, kind: "tls-verification-disabled" },
+  ]);
+});
+
+test("scanPatchForIacMisconfig does not flag NODE_TLS_REJECT_UNAUTHORIZED when TLS stays enabled", () => {
+  // Only the value `0` disables verification; `1` (verification on) must not be flagged.
+  assert.deepEqual(
+    scanPatchForIacMisconfig(
+      ".env",
+      "@@ -1,0 +1,1 @@\n+NODE_TLS_REJECT_UNAUTHORIZED=1",
+    ),
+    [],
+  );
 });
 
 test("scanPatchForIacMisconfig ignores unchanged lines and honors maxFindings", () => {
   assert.deepEqual(
-    scanPatchForIacMisconfig("docker-compose.yml", "@@ -1,1 +1,1 @@\n     network_mode: host"),
+    scanPatchForIacMisconfig(
+      "docker-compose.yml",
+      "@@ -1,1 +1,1 @@\n     network_mode: host",
+    ),
     [],
   );
   assert.deepEqual(
-    scanPatchForIacMisconfig("docker-compose.yml", "@@ -1,0 +1,1 @@\n+    network_mode: host", {
-      maxFindings: 0,
-    }),
+    scanPatchForIacMisconfig(
+      "docker-compose.yml",
+      "@@ -1,0 +1,1 @@\n+    network_mode: host",
+      {
+        maxFindings: 0,
+      },
+    ),
     [],
   );
 });
@@ -49,9 +111,13 @@ test("scanPatchForIacMisconfig aborts when the signal is aborted", () => {
   controller.abort();
   assert.throws(
     () =>
-      scanPatchForIacMisconfig("docker-compose.yml", "@@ -1,0 +1,1 @@\n+    network_mode: host", {
-        signal: controller.signal,
-      }),
+      scanPatchForIacMisconfig(
+        "docker-compose.yml",
+        "@@ -1,0 +1,1 @@\n+    network_mode: host",
+        {
+          signal: controller.signal,
+        },
+      ),
     /analyzer_aborted/,
   );
 });


### PR DESCRIPTION
## Summary
The `iacMisconfig` analyzer (registered, `defaultEnabled: true`) flags risky IaC/config changes. Its `tls-verification-disabled` rule already detects `rejectUnauthorized: false`, `ssl_verify: false`, `insecureSkipTLSVerify: true`, and `skipTLSVerify: true`, but **missed `NODE_TLS_REJECT_UNAUTHORIZED=0`** — the canonical Node.js environment variable that disables **all** TLS certificate verification process-wide (Node itself emits a security warning when it is set to `0`). It is the env-var equivalent of the `rejectUnauthorized: false` case the analyzer already catches, so it maps to the exact same finding kind.

## Scope (precise, value-`0`-only)
The new alternative is added to the existing **flat, linear-time** `TLS_DISABLED_RE` and is scoped strictly to the disabling value:
- matches `NODE_TLS_REJECT_UNAUTHORIZED=0`, `ENV NODE_TLS_REJECT_UNAUTHORIZED 0` (Dockerfile), and quoted `NODE_TLS_REJECT_UNAUTHORIZED: "0"` (YAML/JSON);
- does **not** match `NODE_TLS_REJECT_UNAUTHORIZED=1` (verification on), so there is no false positive when TLS stays enabled.

No new finding kind, type, or descriptor change — it reuses the existing `tls-verification-disabled` kind, and only runs on the analyzer's existing config-path scope (`.env`, Dockerfile, Terraform, YAML/JSON, etc.). The ReDoS-safety invariant (no quantified group) is preserved.

## Test plan
- [x] Extends `review-enrichment/test/iac-misconfig.test.ts` with the `.env`/Dockerfile/quoted-YAML positives and the `=1` negative, exercising the real exported `scanPatchForIacMisconfig` path.
- [x] `node --test test/iac-misconfig.test.ts` — 6 passed.
- [x] Full REES suite `node --test test/**/*.test.ts` — 557 passed, 0 failed.
- [x] `generate-analyzer-metadata.mjs --check` clean; `validate-sourcemaps.mjs` clean; Prettier clean.

## No linked issue
This is a self-contained precision improvement to an existing analyzer's detection coverage; there is no tracking issue for it. It touches only `review-enrichment/src/analyzers/iac-misconfig.ts` and its test, with no cross-cutting or API changes.

Made with [Cursor](https://cursor.com)