### PR TITLE
fix(mcp): compare prerelease identifiers per semver precedence

### DIFF
--- a/src/services/mcp-compatibility.ts
+++ b/src/services/mcp-compatibility.ts
@@ -76,6 +76,36 @@ function parseSemver(version: string) {
   };
 }
 
+/**
+ * Compare two dot-separated prerelease strings per semver §11.4. A plain numeric `localeCompare` on the
+ * whole string is wrong: it compares leading digit runs numerically and so ranks `2` above `1a`, whereas
+ * semver compares identifier-by-identifier, where a purely numeric identifier always has LOWER precedence
+ * than an alphanumeric one. Case-insensitive per-identifier compare is preserved intentionally (matching
+ * the existing `RC.1` == `rc.1` behavior).
+ */
+function comparePrerelease(left: string, right: string): -1 | 0 | 1 {
+  const leftIds = left.split(".");
+  const rightIds = right.split(".");
+  const max = Math.max(leftIds.length, rightIds.length);
+  for (let index = 0; index < max; index += 1) {
+    if (index >= leftIds.length) return -1; // fewer identifiers = lower precedence
+    if (index >= rightIds.length) return 1;
+    const a = leftIds[index]!;
+    const b = rightIds[index]!;
+    const aNumeric = /^\d+$/.test(a);
+    const bNumeric = /^\d+$/.test(b);
+    if (aNumeric && bNumeric) {
+      if (Number(a) !== Number(b)) return Number(a) < Number(b) ? -1 : 1;
+    } else if (aNumeric !== bNumeric) {
+      return aNumeric ? -1 : 1; // numeric identifier ranks below alphanumeric
+    } else {
+      const comparison = a.toLowerCase().localeCompare(b.toLowerCase());
+      if (comparison !== 0) return comparison < 0 ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
 export function compareMcpSemver(leftVersion: string, rightVersion: string): number | null {
   const left = parseSemver(leftVersion);
   const right = parseSemver(rightVersion);
@@ -86,6 +116,5 @@ export function compareMcpSemver(leftVersion: string, rightVersion: string): num
   if (left.prerelease === right.prerelease) return 0;
   if (!left.prerelease) return 1;
   if (!right.prerelease) return -1;
-  const prereleaseComparison = left.prerelease.localeCompare(right.prerelease, undefined, { numeric: true, sensitivity: "base" });
-  return prereleaseComparison === 0 ? 0 : prereleaseComparison < 0 ? -1 : 1;
+  return comparePrerelease(left.prerelease, right.prerelease);
 }

--- a/test/unit/mcp-compatibility.test.ts
+++ b/test/unit/mcp-compatibility.test.ts
@@ -121,6 +121,10 @@ describe("MCP compatibility telemetry", () => {
     expect(compareMcpSemver("0.3.0-alpha", "0.3.0-beta")).toBe(-1);
     expect(compareMcpSemver("0.3.0-1", "0.3.0-alpha")).toBe(-1);
     expect(compareMcpSemver("0.3.0-alpha", "0.3.0-1")).toBe(1);
+    // A numeric identifier ranks below an alphanumeric one even when its digits sort higher (semver
+    // §11.4.3): `2` < `1a`, not `2` > `1a` as a whole-string numeric compare would rank it.
+    expect(compareMcpSemver("0.3.0-2", "0.3.0-1a")).toBe(-1);
+    expect(compareMcpSemver("0.3.0-1a", "0.3.0-2")).toBe(1);
     expect(compareMcpSemver("0.3.0-rc.1", "0.3.0-rc.1.1")).toBe(-1);
     expect(compareMcpSemver("0.3.0-rc.1.1", "0.3.0-rc.1")).toBe(1);
     expect(compareMcpSemver("0.3.0-rc.1", "0.3.0-rc.1")).toBe(0);


### PR DESCRIPTION
## Summary

`compareMcpSemver` in `src/services/mcp-compatibility.ts` compared two prerelease tags by running a single
numeric-collation `localeCompare` over the **whole** prerelease string. Semver (§11.4) compares
prerelease tags **identifier by identifier** (dot-separated), where a purely numeric identifier always has
**lower** precedence than an alphanumeric one. Whole-string numeric collation instead compares the leading
digit runs numerically, so it mis-ranks any pair where the alphanumeric identifier starts with a smaller
digit:

```ts
compareMcpSemver("0.3.0-2", "0.3.0-1a")
// before: 1   (compares 2 vs leading "1" numerically → 2 > 1)
// after:  -1  (identifier "2" is numeric, "1a" is alphanumeric → numeric ranks lower)
```

Fix: replace the whole-string compare with a per-identifier `comparePrerelease` that applies semver
precedence — numeric identifiers compared numerically, alphanumeric compared lexically, numeric ranked
below alphanumeric, and a shorter identifier list ranked lower when all preceding fields are equal. The
pre-existing case-insensitive behavior (`RC.1` == `rc.1`) is intentionally preserved.

No linked issue: small, self-evident correctness fix to one deterministic semver helper, with no public
API, auth, schema, or deploy surface change — fits the repo's `preferred` (not required) linked-issue
policy.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran locally: `git diff --check` (clean), `npm run typecheck` (clean), and a focused `test:coverage`
  over `test/unit/mcp-compatibility.test.ts` — 8 tests pass and the changed lines are at **100% branch
  coverage** (the new per-identifier comparator's numeric/alpha/field-length branches are all exercised;
  the only uncovered line in the file, 38, is a pre-existing snapshot builder outside this diff), so
  `codecov/patch` is 100% on this diff.
- Not run locally: the UI, MCP-pack, workers, OpenAPI, actionlint, and audit jobs. This is a `src/`-only
  change to one deterministic helper touching no UI/API/OpenAPI/DB/workflow surface, so those jobs are
  no-ops for this diff; they run on CI (Linux).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- No UI, auth, CORS, API, or schema surface is touched — a pure deterministic semver-compare fix, so the
  auth/UI/OpenAPI boxes are N/A.
- Regression test added in `test/unit/mcp-compatibility.test.ts`: `compareMcpSemver("0.3.0-2", "0.3.0-1a")`
  is now `-1` (and the reverse `1`). All 16 existing prerelease-precedence assertions still hold under the
  per-identifier comparator.
