### PR TITLE
test(enrichment): unit-cover the provenance PyPI version matcher and input guard

### DIFF
--- a/review-enrichment/test/provenance-version-matcher.test.ts
+++ b/review-enrichment/test/provenance-version-matcher.test.ts
@@ -1,0 +1,45 @@
+// Units for the provenance analyzer's PyPI distribution-filename matcher and input guard (#2777 area).
+// Kept in a separate file so analyzer PRs avoid collisions.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { matchesPypiVersion, isSafeToCheck } from "../dist/analyzers/provenance.js";
+
+test("matchesPypiVersion accepts a wheel and both sdist archive extensions at an exact version", () => {
+  assert.equal(matchesPypiVersion("requests-2.31.0-py3-none-any.whl", "requests", "2.31.0"), true); // wheel: version + "-"
+  assert.equal(matchesPypiVersion("requests-2.31.0.tar.gz", "requests", "2.31.0"), true); // sdist: version + ".tar"
+  assert.equal(matchesPypiVersion("requests-2.31.0.zip", "requests", "2.31.0"), true); // sdist: version + ".zip"
+});
+
+test("matchesPypiVersion rejects a version that is only a prefix of the filename's version", () => {
+  // A post/dev/local suffix is a DIFFERENT release — the version must be followed by a real component boundary.
+  assert.equal(matchesPypiVersion("requests-2.31.0.post1-py3-none-any.whl", "requests", "2.31.0"), false);
+  assert.equal(matchesPypiVersion("requests-2.31.0.1.tar.gz", "requests", "2.31.0"), false);
+  // ...and a longer numeric version that merely contains the target as a trailing substring must not match.
+  assert.equal(matchesPypiVersion("requests-12.31.0.tar.gz", "requests", "2.31.0"), false);
+});
+
+test("matchesPypiVersion treats -, _, . in the package name as equivalent (PEP 503) and is case-insensitive", () => {
+  assert.equal(matchesPypiVersion("my-pkg-1.0.0.tar.gz", "my_pkg", "1.0.0"), true);
+  assert.equal(matchesPypiVersion("my.pkg-1.0.0.tar.gz", "my-pkg", "1.0.0"), true);
+  assert.equal(matchesPypiVersion("Requests-2.31.0.tar.gz", "requests", "2.31.0"), true);
+  // A local-version segment (with the regex-special "+") is escaped and matched literally.
+  assert.equal(matchesPypiVersion("pkg-1.0.0+cpu.tar.gz", "pkg", "1.0.0+cpu"), true);
+});
+
+test("matchesPypiVersion requires the package name to anchor at the start of the filename", () => {
+  assert.equal(matchesPypiVersion("evil-requests-2.31.0.tar.gz", "requests", "2.31.0"), false);
+});
+
+test("isSafeToCheck accepts a normal package/version and rejects unsafe or oversized inputs", () => {
+  assert.equal(isSafeToCheck("requests", "2.31.0"), true);
+  assert.equal(isSafeToCheck("pkg", "1.0.0-beta.1+build_2"), true);
+  // Version must start with a digit and contain only [0-9A-Za-z._+-] — injection/space/leading-letter are rejected.
+  assert.equal(isSafeToCheck("pkg", "v2.0"), false);
+  assert.equal(isSafeToCheck("pkg", "1.0 0"), false);
+  assert.equal(isSafeToCheck("pkg", "1.0;rm -rf"), false);
+  assert.equal(isSafeToCheck("pkg", ""), false);
+  // Length ceilings (pkg <= 200, version <= 100).
+  assert.equal(isSafeToCheck("a".repeat(201), "1.0.0"), false);
+  assert.equal(isSafeToCheck("pkg", "1" + "0".repeat(100)), false);
+});


### PR DESCRIPTION
## Summary

The provenance analyzer's `matchesPypiVersion` and `isSafeToCheck` (`review-enrichment/src/analyzers/provenance.ts`) had no direct unit tests — they were only exercised indirectly. This adds a dedicated unit suite pinning their contracts, in the same shape as the EOL analyzer's `extractVersionPins` tests (#2932):

- **`matchesPypiVersion`** — accepts a wheel (`pkg-ver-…​.whl`) and both sdist archive forms (`pkg-ver.tar.…`, `pkg-ver.zip`); treats `-`/`_`/`.` in the package name as equivalent (PEP 503) and matches case-insensitively; **rejects a version that is only a prefix** of the filename's version (`2.31.0` must not match `2.31.0.post1`, `2.31.0.1`, or `12.31.0`) — the subtle boundary the analyzer's regex is built around; and requires the package name to anchor at the start of the filename (so `evil-requests-2.31.0.tar.gz` does not match `requests`).
- **`isSafeToCheck`** — accepts a normal digit-led version, and rejects a leading-letter version, spaces, injection-style characters, an empty version, and over-length package/version inputs (the `MAX_PKG_LEN` / `MAX_VER_LEN` ceilings).

No production behavior changes — this is coverage-only (the two helpers were already `export`ed).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- The full `npm run test:ci` aggregate ran green (including `rees:test`, the review-enrichment build + node test suite, with the new `provenance-version-matcher.test.ts` passing) plus `npm audit --audit-level=moderate` (0 vulnerabilities). This is a `review-enrichment/**` test addition (not measured by Codecov); its node test suite is the gate.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

Test-only change in the review-enrichment package; no runtime behavior change, no auth/CORS/session surface, no API/OpenAPI shape change, no UI. It pins a security-relevant version-boundary invariant (exact-version provenance matching).

## Notes

- Adds `review-enrichment/test/provenance-version-matcher.test.ts` only; no source change. No schema, migration, OpenAPI, wrangler, or generated-artifact impact.
