### PR TITLE
fix(agent-actions): close on already-red CI despite unrelated pending checks

### DIFF
--- a/src/settings/agent-actions.ts
+++ b/src/settings/agent-actions.ts
@@ -560,7 +560,8 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
   // CI state over ALL of the PR's checks (required OR not — codecov/patch included) — reviewbot's ci_red
   // parity. A red CI is NEVER approved/merged and is itself a close-worthy signal (non-owner). While CI is
   // still running, never approve or merge, but do not let unrelated pending checks mask terminal close reasons
-  // that are already known now (a base conflict or a blocking gate verdict).
+  // that are already known now (a base conflict, a blocking gate verdict, or CI that has already gone red even
+  // if some other, unrelated check is still pending).
   const ciPassed = input.ciState === "passed";
   const ciFailed = input.ciState === "failed";
   const ciPending = input.ciState === "pending" || input.ciHasPending === true;
@@ -577,10 +578,15 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
   // treated as an ordinary contributor here). Automation bots stay exempt regardless (a noise heuristic must not
   // kill a recurring maintainer-managed accumulator).
   const closeEligible = isContributor || ((input.authorIsOwner || input.authorIsAdmin) && input.closeOwnerAuthors === true);
-  const pendingCiTerminalClose = closeEligible && acting("close") && (conclusion === "failure" || isConflict);
+  // A terminal reason is one that CANNOT be un-decided by an unrelated check eventually settling: a confirmed
+  // gate failure, a base conflict, or CI already red (red is red regardless of what else is still pending —
+  // see #ci-fail-closes-guarded below, which closes on `ciFailed` once fully settled; this bypass just lets
+  // that same verdict fire immediately instead of waiting on unrelated pending checks to catch up).
+  const pendingCiMayStillCloseForTerminalReason = closeEligible && acting("close") && (conclusion === "failure" || isConflict || ciFailed);
   // Settle-before-decide: pending CI suppresses success-path work, but not terminal close work. Otherwise a PR
-  // with a known base conflict or blocking gate verdict can sit open forever behind an unrelated stuck check.
-  if (ciPending && !pendingCiTerminalClose) return actions;
+  // with a known base conflict, a blocking gate verdict, or already-red CI can sit open forever behind an
+  // unrelated stuck check.
+  if (ciPending && !pendingCiMayStillCloseForTerminalReason) return actions;
 
   // Only SUCCESS earns the review-good auto-merge. A NEUTRAL gate flows (no longer silently returns []) but is
   // NOT auto-merged — it falls through to a HELD + labeled state for review. (Auto-merging a neutral / grace

--- a/test/unit/agent-actions.test.ts
+++ b/test/unit/agent-actions.test.ts
@@ -667,6 +667,25 @@ describe("planAgentMaintenanceActions (#778)", () => {
       });
     });
 
+    it("CLOSES on already-red CI even while an unrelated check is still pending — red is terminal, it does not need the rest to settle", () => {
+      const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { approve: "auto", merge: "auto", close: "auto" }, ciState: "failed", ciHasPending: true, failingCheckNames: ["build"], pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED" } }));
+      const cls = classes(plan);
+      expect(cls).not.toContain("approve");
+      expect(cls).not.toContain("merge");
+      expect(cls).toContain("close");
+      expect(plan.find((a) => a.actionClass === "close")).toMatchObject({
+        closeKind: "heuristic",
+        closeConcreteEvidence: true,
+        closeRequiresMergeableState: false,
+        closeRequiresCiState: "failed",
+      });
+    });
+
+    it("DEFERS red-but-pending CI for a non-close-eligible author (owner without closeOwnerAuthors) — the terminal bypass never overrides the close-eligibility guard", () => {
+      const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { approve: "auto", merge: "auto", close: "auto" }, ciState: "failed", ciHasPending: true, authorIsOwner: true, pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED" } }));
+      expect(plan).toEqual([]);
+    });
+
     it("HOLDS a contributor's gate-passing PR whose CI is UNVERIFIED — NEVER closes it (fork workflows awaiting approval) (#harm-stop)", () => {
       const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { review_state_label: "auto", approve: "auto", merge: "auto", close: "auto" }, ciState: "unverified", pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED" } }));
       const cls = classes(plan);


### PR DESCRIPTION
## Summary
- The pending-CI terminal-close bypass in `planAgentMaintenanceActions` only covered a confirmed gate failure or a base conflict, so a PR with `ciState: "failed"` but `ciHasPending: true` (CI already red, but some unrelated check is still running) was deferred indefinitely instead of closing.
- Red CI is already treated as a terminal, close-worthy signal once fully settled (see the `willClose` check below in the same function) — this makes the pending-CI bypass consistent with that by including `ciFailed` in the terminal-close predicate, and renames it to `pendingCiMayStillCloseForTerminalReason` for clarity.
- Follows up on the review nits left on #3020 (merged), which introduced the bypass for base-conflict/gate-failure but left this exact edge case as an open question in an adjacent code comment.

## Test plan
- [x] `npx vitest run test/unit/agent-actions.test.ts` — 178 passed, including 2 new regression tests (closes on red+pending CI; still defers for a non-close-eligible author)
- [x] Verified causality: reverted the source change and confirmed the new "CLOSES on already-red CI" test fails (`expected [] to include 'close'`) without the fix
- [x] `npm run typecheck` — clean