### PR TITLE
fix(queue): prefer clear foreground deferrals

### DIFF
--- a/apps/gittensory-ui/src/lib/selfhost-env-reference.ts
+++ b/apps/gittensory-ui/src/lib/selfhost-env-reference.ts
@@ -7,7 +7,7 @@ export type SelfHostEnvReferenceRow = {
 export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   {
     name: "AI_COMBINE",
-    firstReference: "src/selfhost/ai.ts:968",
+    firstReference: "src/selfhost/ai.ts:982",
   },
   {
     name: "AI_EMBED_API_KEY",
@@ -19,11 +19,11 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "AI_EMBED_MODEL",
-    firstReference: "src/selfhost/ai.ts:864",
+    firstReference: "src/selfhost/ai.ts:872",
   },
   {
     name: "AI_ON_MERGE",
-    firstReference: "src/selfhost/ai.ts:970",
+    firstReference: "src/selfhost/ai.ts:984",
   },
   {
     name: "AI_PROVIDER",
@@ -31,7 +31,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "ANTHROPIC_AI_BASE_URL",
-    firstReference: "src/selfhost/ai.ts:868",
+    firstReference: "src/selfhost/ai.ts:876",
   },
   {
     name: "ANTHROPIC_AI_MODEL",
@@ -39,7 +39,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "ANTHROPIC_API_KEY",
-    firstReference: "src/selfhost/ai.ts:867",
+    firstReference: "src/selfhost/ai.ts:875",
   },
   {
     name: "BACKUP_ACKNOWLEDGED",
@@ -195,11 +195,11 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "OLLAMA_AI_API_KEY",
-    firstReference: "src/selfhost/ai.ts:861",
+    firstReference: "src/selfhost/ai.ts:869",
   },
   {
     name: "OLLAMA_AI_BASE_URL",
-    firstReference: "src/selfhost/ai.ts:857",
+    firstReference: "src/selfhost/ai.ts:865",
   },
   {
     name: "OLLAMA_AI_MODEL",
@@ -207,7 +207,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "OPENAI_AI_BASE_URL",
-    firstReference: "src/selfhost/ai.ts:859",
+    firstReference: "src/selfhost/ai.ts:867",
   },
   {
     name: "OPENAI_AI_MODEL",
@@ -215,15 +215,15 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "OPENAI_API_KEY",
-    firstReference: "src/selfhost/ai.ts:861",
+    firstReference: "src/selfhost/ai.ts:869",
   },
   {
     name: "OPENAI_COMPATIBLE_AI_API_KEY",
-    firstReference: "src/selfhost/ai.ts:861",
+    firstReference: "src/selfhost/ai.ts:869",
   },
   {
     name: "OPENAI_COMPATIBLE_AI_BASE_URL",
-    firstReference: "src/selfhost/ai.ts:860",
+    firstReference: "src/selfhost/ai.ts:868",
   },
   {
     name: "OPENAI_COMPATIBLE_AI_MODEL",
@@ -386,15 +386,15 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
 export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| Name | First reference |",
   "| --- | --- |",
-  "| `AI_COMBINE` | `src/selfhost/ai.ts:968` |",
+  "| `AI_COMBINE` | `src/selfhost/ai.ts:982` |",
   "| `AI_EMBED_API_KEY` | `src/server.ts:440` |",
   "| `AI_EMBED_BASE_URL` | `src/server.ts:437` |",
-  "| `AI_EMBED_MODEL` | `src/selfhost/ai.ts:864` |",
-  "| `AI_ON_MERGE` | `src/selfhost/ai.ts:970` |",
+  "| `AI_EMBED_MODEL` | `src/selfhost/ai.ts:872` |",
+  "| `AI_ON_MERGE` | `src/selfhost/ai.ts:984` |",
   "| `AI_PROVIDER` | `src/selfhost/ai-config.ts:43` |",
-  "| `ANTHROPIC_AI_BASE_URL` | `src/selfhost/ai.ts:868` |",
+  "| `ANTHROPIC_AI_BASE_URL` | `src/selfhost/ai.ts:876` |",
   "| `ANTHROPIC_AI_MODEL` | `src/selfhost/ai.ts:85` |",
-  "| `ANTHROPIC_API_KEY` | `src/selfhost/ai.ts:867` |",
+  "| `ANTHROPIC_API_KEY` | `src/selfhost/ai.ts:875` |",
   "| `BACKUP_ACKNOWLEDGED` | `src/server.ts:379` |",
   "| `BROWSER_WS_ENDPOINT` | `src/selfhost/stubs/puppeteer.ts:11` |",
   "| `CLAUDE_AI_EFFORT` | `src/selfhost/ai.ts:136` |",
@@ -433,14 +433,14 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| `MIGRATIONS_DIR` | `src/server.ts:392` |",
   "| `OBSERVABILITY_SMOKE_POLL_MS` | `scripts/smoke-observability-traces.mjs:8` |",
   "| `OBSERVABILITY_SMOKE_TIMEOUT_MS` | `scripts/smoke-observability-traces.mjs:6` |",
-  "| `OLLAMA_AI_API_KEY` | `src/selfhost/ai.ts:861` |",
-  "| `OLLAMA_AI_BASE_URL` | `src/selfhost/ai.ts:857` |",
+  "| `OLLAMA_AI_API_KEY` | `src/selfhost/ai.ts:869` |",
+  "| `OLLAMA_AI_BASE_URL` | `src/selfhost/ai.ts:865` |",
   "| `OLLAMA_AI_MODEL` | `src/selfhost/ai.ts:89` |",
-  "| `OPENAI_AI_BASE_URL` | `src/selfhost/ai.ts:859` |",
+  "| `OPENAI_AI_BASE_URL` | `src/selfhost/ai.ts:867` |",
   "| `OPENAI_AI_MODEL` | `src/selfhost/ai.ts:90` |",
-  "| `OPENAI_API_KEY` | `src/selfhost/ai.ts:861` |",
-  "| `OPENAI_COMPATIBLE_AI_API_KEY` | `src/selfhost/ai.ts:861` |",
-  "| `OPENAI_COMPATIBLE_AI_BASE_URL` | `src/selfhost/ai.ts:860` |",
+  "| `OPENAI_API_KEY` | `src/selfhost/ai.ts:869` |",
+  "| `OPENAI_COMPATIBLE_AI_API_KEY` | `src/selfhost/ai.ts:869` |",
+  "| `OPENAI_COMPATIBLE_AI_BASE_URL` | `src/selfhost/ai.ts:868` |",
   "| `OPENAI_COMPATIBLE_AI_MODEL` | `src/selfhost/ai.ts:91` |",
   "| `ORB_AIR_GAP` | `src/selfhost/orb-collector.ts:161` |",
   "| `ORB_ANONYMIZE` | `src/selfhost/orb-collector.ts:174` |",

--- a/src/selfhost/foreground-liveness.ts
+++ b/src/selfhost/foreground-liveness.ts
@@ -67,19 +67,26 @@ export function isForegroundDeferralStale(config: ForegroundLivenessConfig, pend
 
 /** PURE ramp-up selection: given every candidate ELIGIBLE for release this sweep (already filtered by
  *  isForegroundDeferralStale or a live rate-limit-clear check -- this function does not itself decide
- *  eligibility), pick at most `maxReleasePerSweep` of them, prioritizing the OLDEST (longest-pending) first.
+ *  eligibility), pick at most `maxReleasePerSweep` of them, prioritizing candidates whose rate-limit bucket is
+ *  CURRENTLY clear before using age order. The stale-age backstop must not let an older still-blocked bucket
+ *  monopolize the global ramp-up cap and starve newer clear-bucket foreground work across repeated sweeps.
  *  When candidates already fit within the cap, every one is released (a small/moderate backlog is never
  *  artificially throttled) -- the cap only engages for a genuinely large backlog, gradually draining it over
  *  several sweep ticks instead of releasing hundreds of jobs into one instant. Ties broken by the original
  *  array order (stable) so behavior is deterministic given the same input. Pure. */
-export function selectForegroundDeferralsToRelease<T extends { pendingSinceMs: number }>(
+export function selectForegroundDeferralsToRelease<T extends { pendingSinceMs: number; rateLimitClear: boolean }>(
   candidates: readonly T[],
   maxReleasePerSweep: number,
 ): T[] {
   if (candidates.length <= maxReleasePerSweep) return [...candidates];
   return [...candidates]
     .map((candidate, index) => ({ candidate, index }))
-    .sort((a, b) => a.candidate.pendingSinceMs - b.candidate.pendingSinceMs || a.index - b.index)
+    .sort(
+      (a, b) =>
+        Number(b.candidate.rateLimitClear) - Number(a.candidate.rateLimitClear) ||
+        a.candidate.pendingSinceMs - b.candidate.pendingSinceMs ||
+        a.index - b.index,
+    )
     .slice(0, maxReleasePerSweep)
     .map(({ candidate }) => candidate);
 }

--- a/src/selfhost/pg-queue.ts
+++ b/src/selfhost/pg-queue.ts
@@ -698,12 +698,13 @@ export function createPgQueue(
       `SELECT id, payload, created_at FROM ${TABLE} WHERE status='pending' AND priority>=$1 AND run_after>$2`,
       [FOREGROUND_QUEUE_PRIORITY_FLOOR, now],
     );
-    const eligible: Array<{ id: string; pendingSinceMs: number; ageStale: boolean }> = [];
+    const eligible: Array<{ id: string; pendingSinceMs: number; ageStale: boolean; rateLimitClear: boolean }> = [];
     for (const row of res.rows as Array<{ id: string; payload: string; created_at: number | string }>) {
       const pendingSinceMs = Number(row.created_at);
       const ageStale = isForegroundDeferralStale(foregroundLivenessConfig, pendingSinceMs, now);
-      if (!ageStale && !(await isRateLimitAdmissionNowClear(row.payload))) continue;
-      eligible.push({ id: row.id, pendingSinceMs, ageStale });
+      const rateLimitClear = await isRateLimitAdmissionNowClear(row.payload);
+      if (!ageStale && !rateLimitClear) continue;
+      eligible.push({ id: row.id, pendingSinceMs, ageStale, rateLimitClear });
     }
     const toRelease = selectForegroundDeferralsToRelease(eligible, foregroundLivenessConfig.maxReleasePerSweep);
     let released = 0;

--- a/src/selfhost/sqlite-queue.ts
+++ b/src/selfhost/sqlite-queue.ts
@@ -386,11 +386,12 @@ export function createSqliteQueue(
       `SELECT id, payload, created_at FROM ${TABLE} WHERE status='pending' AND priority>=? AND run_after>?`,
       [FOREGROUND_QUEUE_PRIORITY_FLOOR, now],
     );
-    const eligible: Array<{ id: number; pendingSinceMs: number; ageStale: boolean }> = [];
+    const eligible: Array<{ id: number; pendingSinceMs: number; ageStale: boolean; rateLimitClear: boolean }> = [];
     for (const row of rows as Array<{ id: number; payload: string; created_at: number }>) {
       const ageStale = isForegroundDeferralStale(foregroundLivenessConfig, row.created_at, now);
-      if (!ageStale && !isRateLimitAdmissionNowClear(row.payload)) continue;
-      eligible.push({ id: row.id, pendingSinceMs: row.created_at, ageStale });
+      const rateLimitClear = isRateLimitAdmissionNowClear(row.payload);
+      if (!ageStale && !rateLimitClear) continue;
+      eligible.push({ id: row.id, pendingSinceMs: row.created_at, ageStale, rateLimitClear });
     }
     const toRelease = selectForegroundDeferralsToRelease(eligible, foregroundLivenessConfig.maxReleasePerSweep);
     let released = 0;

--- a/test/unit/selfhost-foreground-liveness.test.ts
+++ b/test/unit/selfhost-foreground-liveness.test.ts
@@ -126,7 +126,10 @@ describe("isForegroundDeferralStale", () => {
 
 describe("selectForegroundDeferralsToRelease (#selfhost-queue-liveness ramp-up)", () => {
   it("returns every candidate unchanged when the count is at or below the cap", () => {
-    const candidates = [{ id: "a", pendingSinceMs: 100 }, { id: "b", pendingSinceMs: 50 }];
+    const candidates = [
+      { id: "a", pendingSinceMs: 100, rateLimitClear: true },
+      { id: "b", pendingSinceMs: 50, rateLimitClear: true },
+    ];
     expect(selectForegroundDeferralsToRelease(candidates, 2)).toEqual(candidates);
     expect(selectForegroundDeferralsToRelease(candidates, 5)).toEqual(candidates);
   });
@@ -137,9 +140,9 @@ describe("selectForegroundDeferralsToRelease (#selfhost-queue-liveness ramp-up)"
 
   it("picks the OLDEST (smallest pendingSinceMs) candidates first when count exceeds the cap", () => {
     const candidates = [
-      { id: "newest", pendingSinceMs: 300 },
-      { id: "oldest", pendingSinceMs: 100 },
-      { id: "middle", pendingSinceMs: 200 },
+      { id: "newest", pendingSinceMs: 300, rateLimitClear: true },
+      { id: "oldest", pendingSinceMs: 100, rateLimitClear: true },
+      { id: "middle", pendingSinceMs: 200, rateLimitClear: true },
     ];
     const selected = selectForegroundDeferralsToRelease(candidates, 2);
     expect(selected.map((c) => c.id)).toEqual(["oldest", "middle"]);
@@ -147,16 +150,31 @@ describe("selectForegroundDeferralsToRelease (#selfhost-queue-liveness ramp-up)"
 
   it("breaks ties by original array order (stable) when pendingSinceMs is equal", () => {
     const candidates = [
-      { id: "first", pendingSinceMs: 100 },
-      { id: "second", pendingSinceMs: 100 },
-      { id: "third", pendingSinceMs: 100 },
+      { id: "first", pendingSinceMs: 100, rateLimitClear: true },
+      { id: "second", pendingSinceMs: 100, rateLimitClear: true },
+      { id: "third", pendingSinceMs: 100, rateLimitClear: true },
     ];
     const selected = selectForegroundDeferralsToRelease(candidates, 2);
     expect(selected.map((c) => c.id)).toEqual(["first", "second"]);
   });
 
   it("a cap of exactly the candidate count releases all of them", () => {
-    const candidates = [{ id: "a", pendingSinceMs: 1 }, { id: "b", pendingSinceMs: 2 }];
+    const candidates = [
+      { id: "a", pendingSinceMs: 1, rateLimitClear: true },
+      { id: "b", pendingSinceMs: 2, rateLimitClear: true },
+    ];
     expect(selectForegroundDeferralsToRelease(candidates, 2).length).toBe(2);
+  });
+
+  it("prefers rate-limit-clear candidates before older still-blocked stale candidates", () => {
+    const candidates = [
+      { id: "blocked-oldest", pendingSinceMs: 100, rateLimitClear: false },
+      { id: "clear-newer", pendingSinceMs: 300, rateLimitClear: true },
+      { id: "blocked-middle", pendingSinceMs: 200, rateLimitClear: false },
+    ];
+
+    const selected = selectForegroundDeferralsToRelease(candidates, 2);
+
+    expect(selected.map((c) => c.id)).toEqual(["clear-newer", "blocked-oldest"]);
   });
 });

--- a/test/unit/selfhost-pg-queue.test.ts
+++ b/test/unit/selfhost-pg-queue.test.ts
@@ -2292,6 +2292,48 @@ describe("createPgQueue (durable #977)", () => {
       delete process.env.FOREGROUND_LIVENESS_MAX_RELEASE_PER_SWEEP;
     });
 
+    it("does not let older still-blocked stale rows consume the cap before a newer clear row", async () => {
+      process.env.FOREGROUND_LIVENESS_MAX_DEFER_MS = "60000";
+      process.env.FOREGROUND_LIVENESS_MAX_RELEASE_PER_SWEEP = "2";
+      const m = makePool();
+      const now = Date.now();
+      m.setRateLimitRows([
+        {
+          admission_key: "installation:111",
+          remaining: 1,
+          reset_at: new Date(now + 30 * 60_000).toISOString(),
+          observed_at: new Date(now).toISOString(),
+        },
+      ]);
+      const payload = (deliveryId: string, installationId: number) =>
+        JSON.stringify({
+          type: "github-webhook",
+          deliveryId,
+          eventName: "x",
+          payload: { installation: { id: installationId } },
+        });
+      m.setForegroundLivenessCandidates([
+        { id: "blocked-oldest", created_at: now - 10 * 60_000, payload: payload("blocked-oldest", 111) },
+        { id: "blocked-second", created_at: now - 9 * 60_000, payload: payload("blocked-second", 111) },
+        { id: "clear-newer", created_at: now - 5 * 60_000, payload: payload("clear-newer", 222) },
+      ]);
+      const q = createPgQueue(m.pool, async () => undefined);
+
+      const released = await q.releaseStaleForegroundDeferrals();
+
+      expect(released).toBe(2);
+      for (const id of ["clear-newer", "blocked-oldest"]) {
+        expect(m.fn).toHaveBeenCalledWith(
+          expect.stringContaining("SET run_after=$1 WHERE id=$2 AND status='pending' AND run_after>$1"),
+          expect.arrayContaining([id]),
+        );
+      }
+      expect(m.fn).not.toHaveBeenCalledWith(
+        expect.stringContaining("SET run_after=$1 WHERE id=$2 AND status='pending' AND run_after>$1"),
+        expect.arrayContaining(["blocked-second"]),
+      );
+    });
+
     // A stale candidate can lose the UPDATE race (another instance/tick already moved it) -- mirrors
     // reviveDeadLetterJobs' own "AND status='dead'" re-check pattern: only rows whose UPDATE actually matched
     // (rowCount 1) count toward the release total, never the raw SELECT candidate count.

--- a/test/unit/selfhost-sqlite-queue.test.ts
+++ b/test/unit/selfhost-sqlite-queue.test.ts
@@ -2305,6 +2305,45 @@ describe("createSqliteQueue (durable #980)", () => {
       expect(remainingFuture.c).toBe(2);
     });
 
+    it("does not let older still-blocked stale rows consume the cap before a newer clear row", async () => {
+      process.env.FOREGROUND_LIVENESS_MAX_DEFER_MS = "60000";
+      process.env.FOREGROUND_LIVENESS_MAX_RELEASE_PER_SWEEP = "2";
+      const driver = makeDriver();
+      const now = Date.now();
+      seedExhaustedRateLimitObservation(driver, "installation:111", new Date(now + 30 * 60_000).toISOString());
+      const q = createSqliteQueue(driver, async () => undefined);
+      const farFuture = now + 60 * 60_000;
+      const rows = [
+        { deliveryId: "blocked-oldest", installationId: 111, createdAt: now - 10 * 60_000 },
+        { deliveryId: "blocked-second", installationId: 111, createdAt: now - 9 * 60_000 },
+        { deliveryId: "clear-newer", installationId: 222, createdAt: now - 5 * 60_000 },
+      ];
+      for (const row of rows) {
+        driver.query(
+          `INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at, priority, job_key, is_maintenance)
+           VALUES (?, 'pending', 0, ?, ?, 10, NULL, 0)`,
+          [
+            JSON.stringify({
+              type: "github-webhook",
+              deliveryId: row.deliveryId,
+              eventName: "x",
+              payload: { installation: { id: row.installationId } },
+            }),
+            farFuture,
+            row.createdAt,
+          ],
+        );
+      }
+
+      const released = q.releaseStaleForegroundDeferrals();
+
+      expect(released).toBe(2);
+      const releasedIds = driver.query(`SELECT payload FROM _selfhost_jobs WHERE run_after<?`, [farFuture]).rows.map((row) =>
+        JSON.parse((row as { payload: string }).payload).deliveryId,
+      );
+      expect(releasedIds).toEqual(["blocked-oldest", "clear-newer"]);
+    });
+
     // Mirrors reviveDeadLetterJobsSafely's own regression test: the foreground-liveness interval had no error
     // handler of its own, so a thrown driver/metric failure on that tick would surface as an uncaught exception
     // and could terminate the process -- exactly the failure mode pump()'s own try/catch already guards against


### PR DESCRIPTION
### Motivation
- Prevent a starvation/availability regression where a new global oldest-first release cap could let age-stale but still-rate-limited foreground jobs repeatedly consume the per-sweep budget and block newer foreground jobs whose GitHub admission buckets are clear.

### Description
- Change the ramp-up selector to prefer candidates whose rate-limit bucket is currently clear before falling back to oldest-first ordering, preserving stability within ties.
- Update Postgres and SQLite foreground-liveness sweeps to compute `rateLimitClear` for each eligible candidate and pass that flag into the selector so still-blocked age-stale rows cannot monopolize the cap.
- Add regression tests for the pure selector plus Pg and SQLite paths that reproduce and prevent the cross-installation starvation scenario.
- Regenerate the self-host env reference file that was stale after the change.

### Testing
- Ran unit tests `npx vitest run test/unit/selfhost-foreground-liveness.test.ts test/unit/selfhost-sqlite-queue.test.ts test/unit/selfhost-pg-queue.test.ts` and they passed (all tests in those suites succeeded).
- Ran type checking with `npm run typecheck` which completed successfully.
- Re-generated and validated the self-host env reference via `npm run selfhost:env-reference` / `npm run selfhost:env-reference:check`, which passed.
- Attempted the full local gate `npm run test:ci` but the run could not fully complete in this environment due to external network/audit restrictions (the `npm audit` endpoint returned HTTP 403); most internal CI steps executed successfully up to that point.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48cb8df44c832cb85c8cb0d3eeeb93)