### PR TITLE
fix(selfhost): bound Orb relay error body reads

### DIFF
--- a/apps/gittensory-ui/src/lib/selfhost-env-reference.ts
+++ b/apps/gittensory-ui/src/lib/selfhost-env-reference.ts
@@ -7,7 +7,7 @@ export type SelfHostEnvReferenceRow = {
 export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   {
     name: "AI_COMBINE",
-    firstReference: "src/selfhost/ai.ts:968",
+    firstReference: "src/selfhost/ai.ts:982",
   },
   {
     name: "AI_EMBED_API_KEY",
@@ -19,11 +19,11 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "AI_EMBED_MODEL",
-    firstReference: "src/selfhost/ai.ts:864",
+    firstReference: "src/selfhost/ai.ts:872",
   },
   {
     name: "AI_ON_MERGE",
-    firstReference: "src/selfhost/ai.ts:970",
+    firstReference: "src/selfhost/ai.ts:984",
   },
   {
     name: "AI_PROVIDER",
@@ -31,7 +31,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "ANTHROPIC_AI_BASE_URL",
-    firstReference: "src/selfhost/ai.ts:868",
+    firstReference: "src/selfhost/ai.ts:876",
   },
   {
     name: "ANTHROPIC_AI_MODEL",
@@ -39,7 +39,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "ANTHROPIC_API_KEY",
-    firstReference: "src/selfhost/ai.ts:867",
+    firstReference: "src/selfhost/ai.ts:875",
   },
   {
     name: "BACKUP_ACKNOWLEDGED",
@@ -195,11 +195,11 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "OLLAMA_AI_API_KEY",
-    firstReference: "src/selfhost/ai.ts:861",
+    firstReference: "src/selfhost/ai.ts:869",
   },
   {
     name: "OLLAMA_AI_BASE_URL",
-    firstReference: "src/selfhost/ai.ts:857",
+    firstReference: "src/selfhost/ai.ts:865",
   },
   {
     name: "OLLAMA_AI_MODEL",
@@ -207,7 +207,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "OPENAI_AI_BASE_URL",
-    firstReference: "src/selfhost/ai.ts:859",
+    firstReference: "src/selfhost/ai.ts:867",
   },
   {
     name: "OPENAI_AI_MODEL",
@@ -215,15 +215,15 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "OPENAI_API_KEY",
-    firstReference: "src/selfhost/ai.ts:861",
+    firstReference: "src/selfhost/ai.ts:869",
   },
   {
     name: "OPENAI_COMPATIBLE_AI_API_KEY",
-    firstReference: "src/selfhost/ai.ts:861",
+    firstReference: "src/selfhost/ai.ts:869",
   },
   {
     name: "OPENAI_COMPATIBLE_AI_BASE_URL",
-    firstReference: "src/selfhost/ai.ts:860",
+    firstReference: "src/selfhost/ai.ts:868",
   },
   {
     name: "OPENAI_COMPATIBLE_AI_MODEL",
@@ -386,15 +386,15 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
 export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| Name | First reference |",
   "| --- | --- |",
-  "| `AI_COMBINE` | `src/selfhost/ai.ts:968` |",
+  "| `AI_COMBINE` | `src/selfhost/ai.ts:982` |",
   "| `AI_EMBED_API_KEY` | `src/server.ts:440` |",
   "| `AI_EMBED_BASE_URL` | `src/server.ts:437` |",
-  "| `AI_EMBED_MODEL` | `src/selfhost/ai.ts:864` |",
-  "| `AI_ON_MERGE` | `src/selfhost/ai.ts:970` |",
+  "| `AI_EMBED_MODEL` | `src/selfhost/ai.ts:872` |",
+  "| `AI_ON_MERGE` | `src/selfhost/ai.ts:984` |",
   "| `AI_PROVIDER` | `src/selfhost/ai-config.ts:43` |",
-  "| `ANTHROPIC_AI_BASE_URL` | `src/selfhost/ai.ts:868` |",
+  "| `ANTHROPIC_AI_BASE_URL` | `src/selfhost/ai.ts:876` |",
   "| `ANTHROPIC_AI_MODEL` | `src/selfhost/ai.ts:85` |",
-  "| `ANTHROPIC_API_KEY` | `src/selfhost/ai.ts:867` |",
+  "| `ANTHROPIC_API_KEY` | `src/selfhost/ai.ts:875` |",
   "| `BACKUP_ACKNOWLEDGED` | `src/server.ts:379` |",
   "| `BROWSER_WS_ENDPOINT` | `src/selfhost/stubs/puppeteer.ts:11` |",
   "| `CLAUDE_AI_EFFORT` | `src/selfhost/ai.ts:136` |",
@@ -433,14 +433,14 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| `MIGRATIONS_DIR` | `src/server.ts:392` |",
   "| `OBSERVABILITY_SMOKE_POLL_MS` | `scripts/smoke-observability-traces.mjs:8` |",
   "| `OBSERVABILITY_SMOKE_TIMEOUT_MS` | `scripts/smoke-observability-traces.mjs:6` |",
-  "| `OLLAMA_AI_API_KEY` | `src/selfhost/ai.ts:861` |",
-  "| `OLLAMA_AI_BASE_URL` | `src/selfhost/ai.ts:857` |",
+  "| `OLLAMA_AI_API_KEY` | `src/selfhost/ai.ts:869` |",
+  "| `OLLAMA_AI_BASE_URL` | `src/selfhost/ai.ts:865` |",
   "| `OLLAMA_AI_MODEL` | `src/selfhost/ai.ts:89` |",
-  "| `OPENAI_AI_BASE_URL` | `src/selfhost/ai.ts:859` |",
+  "| `OPENAI_AI_BASE_URL` | `src/selfhost/ai.ts:867` |",
   "| `OPENAI_AI_MODEL` | `src/selfhost/ai.ts:90` |",
-  "| `OPENAI_API_KEY` | `src/selfhost/ai.ts:861` |",
-  "| `OPENAI_COMPATIBLE_AI_API_KEY` | `src/selfhost/ai.ts:861` |",
-  "| `OPENAI_COMPATIBLE_AI_BASE_URL` | `src/selfhost/ai.ts:860` |",
+  "| `OPENAI_API_KEY` | `src/selfhost/ai.ts:869` |",
+  "| `OPENAI_COMPATIBLE_AI_API_KEY` | `src/selfhost/ai.ts:869` |",
+  "| `OPENAI_COMPATIBLE_AI_BASE_URL` | `src/selfhost/ai.ts:868` |",
   "| `OPENAI_COMPATIBLE_AI_MODEL` | `src/selfhost/ai.ts:91` |",
   "| `ORB_AIR_GAP` | `src/selfhost/orb-collector.ts:161` |",
   "| `ORB_ANONYMIZE` | `src/selfhost/orb-collector.ts:174` |",

--- a/src/orb/broker-client.ts
+++ b/src/orb/broker-client.ts
@@ -87,11 +87,49 @@ export async function fetchBrokeredInstallationToken(
 const ORB_RELAY_REGISTER_ERROR_BODY_MAX_BYTES = 2_000;
 const ORB_RELAY_REGISTER_ERROR_HINT_MAX_CHARS = 200;
 
+async function boundedResponseText(res: Response, maxBytes: number): Promise<string | undefined> {
+  const contentLength = res.headers.get("content-length");
+  if (contentLength && Number(contentLength) > maxBytes) {
+    await res.body?.cancel();
+    return undefined;
+  }
+  if (!res.body) return undefined;
+
+  const reader = res.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let received = 0;
+  try {
+    while (received < maxBytes) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      const remaining = maxBytes - received;
+      const chunk = value.length > remaining ? value.slice(0, remaining) : value;
+      chunks.push(chunk);
+      received += chunk.length;
+      if (value.length > remaining || received >= maxBytes) {
+        await reader.cancel();
+        break;
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  if (received === 0) return undefined;
+  const bytes = new Uint8Array(received);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.length;
+  }
+  return new TextDecoder().decode(bytes);
+}
+
 async function safeOrbRelayRegisterErrorHint(res: Response): Promise<string | undefined> {
   try {
-    const text = await res.text();
+    const text = await boundedResponseText(res, ORB_RELAY_REGISTER_ERROR_BODY_MAX_BYTES);
     if (!text) return undefined;
-    const parsed = JSON.parse(text.slice(0, ORB_RELAY_REGISTER_ERROR_BODY_MAX_BYTES)) as { error?: unknown; message?: unknown };
+    const parsed = JSON.parse(text) as { error?: unknown; message?: unknown };
     const hint = typeof parsed.error === "string" ? parsed.error : typeof parsed.message === "string" ? parsed.message : undefined;
     return hint ? hint.slice(0, ORB_RELAY_REGISTER_ERROR_HINT_MAX_CHARS) : undefined;
   } catch {

--- a/test/unit/orb-broker-client.test.ts
+++ b/test/unit/orb-broker-client.test.ts
@@ -158,7 +158,11 @@ describe("registerOrbRelayTarget", () => {
     const errBody = (async () => Response.json({ error: "database unavailable" }, { status: 500 })) as typeof fetch;
     expect(await registerOrbRelayTarget(cfg, errBody)).toEqual({ status: "failed", reason: "http_500: database unavailable" });
 
-    const messageBody = (async () => Response.json({ message: "install not found" }, { status: 404 })) as typeof fetch;
+    const messageBody = (async () =>
+      new Response(JSON.stringify({ message: "install not found" }), {
+        status: 404,
+        headers: { "content-length": "31", "content-type": "application/json" },
+      })) as typeof fetch;
     expect(await registerOrbRelayTarget(cfg, messageBody)).toEqual({ status: "failed", reason: "http_404: install not found" });
   });
 
@@ -180,6 +184,79 @@ describe("registerOrbRelayTarget", () => {
     const longMessage = "x".repeat(500);
     const result = await registerOrbRelayTarget(cfg, (async () => Response.json({ error: longMessage }, { status: 500 })) as typeof fetch);
     expect(result.reason).toBe(`http_500: ${"x".repeat(200)}`);
+  });
+
+  it("does not read relay registration failure bodies whose Content-Length exceeds the diagnostic cap", async () => {
+    const cfg = { ORB_ENROLLMENT_SECRET: "s", PUBLIC_API_ORIGIN: "https://me.example" };
+    let canceled = false;
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.enqueue(new TextEncoder().encode('{"error":"must not be read"}'));
+        controller.close();
+      },
+      cancel() {
+        canceled = true;
+      },
+    });
+
+    const result = await registerOrbRelayTarget(
+      cfg,
+      (async () =>
+        new Response(body, {
+          status: 500,
+          headers: { "content-length": "2001" },
+        })) as typeof fetch,
+    );
+
+    expect(result).toEqual({ status: "failed", reason: "http_500" });
+    expect(canceled).toBe(true);
+  });
+
+
+  it("falls back to the bare status when the diagnostic response has no body", async () => {
+    const cfg = { ORB_ENROLLMENT_SECRET: "s", PUBLIC_API_ORIGIN: "https://me.example" };
+    const result = await registerOrbRelayTarget(cfg, (async () => new Response(null, { status: 500 })) as typeof fetch);
+    expect(result).toEqual({ status: "failed", reason: "http_500" });
+  });
+
+  it("truncates and cancels a single oversized diagnostic stream chunk", async () => {
+    const cfg = { ORB_ENROLLMENT_SECRET: "s", PUBLIC_API_ORIGIN: "https://me.example" };
+    let canceled = false;
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.enqueue(new TextEncoder().encode('{"error":"oversized_chunk"}'.padEnd(2_100, " ")));
+      },
+      cancel() {
+        canceled = true;
+      },
+    });
+
+    const result = await registerOrbRelayTarget(cfg, (async () => new Response(body, { status: 500 })) as typeof fetch);
+
+    expect(result).toEqual({ status: "failed", reason: "http_500: oversized_chunk" });
+    expect(canceled).toBe(true);
+  });
+
+  it("stream-reads at most the relay registration diagnostic cap and cancels the remainder", async () => {
+    const cfg = { ORB_ENROLLMENT_SECRET: "s", PUBLIC_API_ORIGIN: "https://me.example" };
+    let pulls = 0;
+    let canceled = false;
+    const boundedJson = '{"error":"bounded_broker_error"}';
+    const body = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        pulls += 1;
+        controller.enqueue(new TextEncoder().encode(pulls === 1 ? boundedJson.padEnd(2_000, " ") : "x".repeat(10_000)));
+      },
+      cancel() {
+        canceled = true;
+      },
+    });
+
+    const result = await registerOrbRelayTarget(cfg, (async () => new Response(body, { status: 500 })) as typeof fetch);
+
+    expect(result).toEqual({ status: "failed", reason: "http_500: bounded_broker_error" });
+    expect(pulls).toBeLessThanOrEqual(2);
+    expect(canceled).toBe(true);
   });
 });
 


### PR DESCRIPTION
### Motivation

- The relay-registration diagnostic path previously called `res.text()` and therefore buffered the entire non-OK broker response before applying the configured `ORB_RELAY_REGISTER_ERROR_BODY_MAX_BYTES` cap, which can allow a malicious or misconfigured broker to force large memory allocations in self-hosted deployments. 

### Description

- Add `boundedResponseText(res, maxBytes)` which rejects overly large `Content-Length` values, stream-reads at most `maxBytes`, and cancels the remainder to avoid unbounded allocations. 
- Replace the `res.text()` call in `safeOrbRelayRegisterErrorHint` with the bounded reader and preserve the existing sanitized `error`/`message` hint and truncation behavior. 
- Add unit tests covering oversized `Content-Length`, null/no body, a single oversized stream chunk, and bounded stream-reading + cancel behavior. 
- Regenerate the self-host environment reference artifact so the repository's generated-file check stays green. 

### Testing

- Ran `npx vitest run test/unit/orb-broker-client.test.ts`, which passed (all new and existing unit tests in that file succeeded). 
- Ran `npm run test:coverage -- test/unit/orb-broker-client.test.ts` (scoped coverage run) and it passed for the scoped tests. 
- Ran `npm run typecheck` and `npm run selfhost:env-reference:check`, both of which completed successfully. 
- Attempted `npm run test:ci` and `npm audit --audit-level=moderate`; `test:ci` progressed through early checks but the full coverage/audit phases did not complete in this environment (network/registry access issues prevented a full audit run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48c6d229dc832c9b5b00a4265712d2)