### PR TITLE
feat(enrichment): flag PYTHONHTTPSVERIFY/GIT_SSL_NO_VERIFY TLS-disable env vars

### DIFF
--- a/review-enrichment/src/analyzers/iac-misconfig.ts
+++ b/review-enrichment/src/analyzers/iac-misconfig.ts
@@ -19,7 +19,7 @@ const PUBLIC_BUCKET_RE =
 const SAME_SITE_NONE_RE = /\bsameSite\b[\s"'=:,-]*["']?none["']?\b/i;
 const SECURE_FALSE_RE = /\bsecure\b[\s"'=:,-]*false\b/i;
 const TLS_DISABLED_RE =
-  /\brejectUnauthorized\b[\s"'=:,-]*false\b|\bverify\s*=\s*False\b|\bssl_verify\b[\s"'=:,-]*false\b|\binsecureSkipTLSVerify\b[\s"'=:,-]*true\b|\bskipTLSVerify\b[\s"'=:,-]*true\b|\bNODE_TLS_REJECT_UNAUTHORIZED\b[\s"'=:,-]*["']?0\b/i;
+  /\brejectUnauthorized\b[\s"'=:,-]*false\b|\bverify\s*=\s*False\b|\bssl_verify\b[\s"'=:,-]*false\b|\binsecureSkipTLSVerify\b[\s"'=:,-]*true\b|\bskipTLSVerify\b[\s"'=:,-]*true\b|\bNODE_TLS_REJECT_UNAUTHORIZED\b[\s"'=:,-]*["']?0\b|\bPYTHONHTTPSVERIFY\b[\s"'=:,-]*["']?0\b|\bGIT_SSL_NO_VERIFY\b[\s"'=:,-]*["']?(?:true|1|yes|on)\b/i;
 const PROD_RE =
   /\b(?:NODE_ENV|ENVIRONMENT|APP_ENV)\b[\s"'=:,-]*production\b|\bproduction\s*:/i;
 const DEBUG_TRUE_RE = /\bdebug\b[\s"'=:,-]*true\b|\bDEBUG\b[\s"'=:,-]*true\b/i;

--- a/review-enrichment/test/iac-misconfig.test.ts
+++ b/review-enrichment/test/iac-misconfig.test.ts
@@ -86,6 +86,52 @@ test("scanPatchForIacMisconfig does not flag NODE_TLS_REJECT_UNAUTHORIZED when T
   );
 });
 
+test("scanPatchForIacMisconfig flags PYTHONHTTPSVERIFY=0 and GIT_SSL_NO_VERIFY truthy as disabled TLS", () => {
+  // Canonical per-runtime env vars that globally disable TLS certificate verification.
+  const python = scanPatchForIacMisconfig(
+    ".env",
+    ["@@ -1,0 +2,1 @@", "+PYTHONHTTPSVERIFY=0"].join("\n"),
+  );
+  assert.deepEqual(python, [
+    { file: ".env", line: 2, kind: "tls-verification-disabled" },
+  ]);
+
+  const git = scanPatchForIacMisconfig(
+    "Dockerfile",
+    ["@@ -1,0 +4,1 @@", "+ENV GIT_SSL_NO_VERIFY true"].join("\n"),
+  );
+  assert.deepEqual(git, [
+    { file: "Dockerfile", line: 4, kind: "tls-verification-disabled" },
+  ]);
+
+  const gitNumeric = scanPatchForIacMisconfig(
+    "ci.yaml",
+    ["@@ -1,0 +6,1 @@", '+  GIT_SSL_NO_VERIFY: "1"'].join("\n"),
+  );
+  assert.deepEqual(gitNumeric, [
+    { file: "ci.yaml", line: 6, kind: "tls-verification-disabled" },
+  ]);
+});
+
+test("scanPatchForIacMisconfig does not flag Python/Git TLS env vars when verification stays on", () => {
+  // Opposite polarities: PYTHONHTTPSVERIFY=1 keeps verification on; GIT_SSL_NO_VERIFY=false/0 means "verify".
+  assert.deepEqual(
+    scanPatchForIacMisconfig(".env", "@@ -1,0 +1,1 @@\n+PYTHONHTTPSVERIFY=1"),
+    [],
+  );
+  assert.deepEqual(
+    scanPatchForIacMisconfig(
+      ".env",
+      "@@ -1,0 +1,1 @@\n+GIT_SSL_NO_VERIFY=false",
+    ),
+    [],
+  );
+  assert.deepEqual(
+    scanPatchForIacMisconfig(".env", "@@ -1,0 +1,1 @@\n+GIT_SSL_NO_VERIFY=0"),
+    [],
+  );
+});
+
 test("scanPatchForIacMisconfig ignores unchanged lines and honors maxFindings", () => {
   assert.deepEqual(
     scanPatchForIacMisconfig(


### PR DESCRIPTION
## Summary
The `iacMisconfig` analyzer's `tls-verification-disabled` rule detects several ways config disables TLS certificate verification (`rejectUnauthorized: false`, `insecureSkipTLSVerify: true`, `NODE_TLS_REJECT_UNAUTHORIZED=0`, …), but it only covered the **Node** global. It **missed the other two canonical per-runtime env vars** that turn off TLS verification process-wide:
- **Python** — `PYTHONHTTPSVERIFY=0` disables HTTPS certificate verification for the whole interpreter.
- **Git** — `GIT_SSL_NO_VERIFY` (truthy) makes git skip server certificate verification for all HTTPS remotes.

These are exactly the same class of dangerous, hard-to-spot config as the Node var already handled, so they map to the existing `tls-verification-disabled` finding kind.

## Scope (precise, per-var disabling value only)
Each var is added to the existing **flat, linear-time** `TLS_DISABLED_RE` as its own literal branch, scoped to the value that actually disables verification — and the two have **opposite polarities**, which the tests lock down:
- `PYTHONHTTPSVERIFY=0` → flagged; `PYTHONHTTPSVERIFY=1` → not flagged.
- `GIT_SSL_NO_VERIFY=true` / `=1` → flagged; `GIT_SSL_NO_VERIFY=false` / `=0` → not flagged.

No new finding kind, type, or descriptor change; reuses `tls-verification-disabled`, runs only on the analyzer's existing config-path scope (`.env`, Dockerfile, YAML/JSON, …). The ReDoS-safety invariant (no quantified group) is preserved.

## Test plan
- [x] Extends `review-enrichment/test/iac-misconfig.test.ts` with positives (`.env`, Dockerfile `ENV`, quoted YAML) and the verification-still-on negatives for both vars, exercising the real exported `scanPatchForIacMisconfig` path.
- [x] `node --test test/iac-misconfig.test.ts` — 8 passed.
- [x] Full REES suite `node --test test/**/*.test.ts` — 559 passed, 0 failed.
- [x] `generate-analyzer-metadata.mjs --check` clean; `validate-sourcemaps.mjs` clean; Prettier clean.

## No linked issue
Self-contained precision improvement to an existing analyzer's detection coverage; no tracking issue. Touches only `review-enrichment/src/analyzers/iac-misconfig.ts` and its test, with no cross-cutting or API changes.

Made with [Cursor](https://cursor.com)