### PR TITLE
fix(miner): treat null enqueue priority as default 0

### DIFF
--- a/packages/gittensory-miner/lib/portfolio-queue.d.ts
+++ b/packages/gittensory-miner/lib/portfolio-queue.d.ts
@@ -11,7 +11,7 @@ export type QueueEntry = {
 export type EnqueueItem = {
   repoFullName: string;
   identifier: string;
-  priority?: number;
+  priority?: number | null;
 };
 
 export type PortfolioQueueStore = {

--- a/packages/gittensory-miner/lib/portfolio-queue.js
+++ b/packages/gittensory-miner/lib/portfolio-queue.js
@@ -54,7 +54,7 @@ function normalizeIdentifier(identifier) {
 
 /** Priority is a placeholder numeric input; an omitted priority defaults to 0, a non-finite or negative one is rejected. */
 function normalizePriority(priority) {
-  if (priority === undefined) return 0;
+  if (priority === undefined || priority === null) return 0;
   if (typeof priority !== "number" || !Number.isFinite(priority) || priority < 0) {
     throw new Error("invalid_priority");
   }

--- a/test/unit/miner-portfolio-queue.test.ts
+++ b/test/unit/miner-portfolio-queue.test.ts
@@ -61,6 +61,11 @@ describe("gittensory-miner portfolio/queue store (#2292)", () => {
     expect(typeof entry.enqueuedAt).toBe("string");
   });
 
+  it("treats a null priority as the default 0", () => {
+    const entry = tempStore().enqueue({ repoFullName: "o/a", identifier: "x", priority: null });
+    expect(entry.priority).toBe(0);
+  });
+
   it("dequeues highest-priority first, then by insertion order within a priority band", () => {
     // Freeze the clock so same-priority items share enqueued_at — proving the rowid FIFO tie-break, not a timestamp.
     vi.useFakeTimers();


### PR DESCRIPTION
## Summary

- Treat `enqueue({ priority: null })` as the default priority 0, matching omitted priority behavior.
- Aligns portfolio queue with nullish filter handling elsewhere in the miner local stores.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] Focused on portfolio-queue priority validation only — no unrelated miner CLI or UI changes.

## Validation

- [ ] `npm run test:ci` locally — CI will run the full gate on push.
- [x] Unit test covers null priority defaulting to 0 on enqueue.

## Safety

- [x] No secrets, wallet details, hotkeys, or private scoring output in code or PR text.
- [x] Deterministic, read/write-local only: no network calls.

## UI Evidence

Not applicable — miner library only.

## Notes

Follow-up to #2972 and #2982 — completes nullish input parity for portfolio queue enqueue (#2292).
