### PR TITLE
fix(review): keep repo analyzer toggles within operator policy

### DIFF
--- a/src/review/enrichment-wire.ts
+++ b/src/review/enrichment-wire.ts
@@ -220,27 +220,22 @@ interface EnrichmentInput {
 }
 
 /**
- * Combine the operator's env analyzer selection with a repo's per-analyzer `review.enrichment` toggles into the
- * final list sent to REES. The env selection (`undefined` ⇒ REES runs its full registry) is the base; each explicit
- * repo toggle then adds (`true`) or removes (`false`) an analyzer, restricted to the known registry. Returns
- * `undefined` — omitting the field so REES runs everything, byte-identical to today — only when there is no repo
- * override, or when the base is the full registry and the toggles leave it that way. Otherwise an explicit,
- * registry-ordered list. Pure.
+ * Apply a repo's per-analyzer `review.enrichment` toggles without widening the operator's REES policy. When
+ * `REES_ANALYZERS` is unset, keep omitting `analyzers` so REES can apply `REES_PROFILE` cost filtering itself; turning
+ * repo-owned toggles into an explicit near-full list would bypass profile limits. When the operator did provide an
+ * explicit list, repo toggles may only narrow that list (`false` removes); `true` is a no-op rather than an addition.
+ * The returned explicit list stays in registry order. Pure.
  */
 export function resolveEnrichmentAnalyzerSelection(
   envSelected: string[] | undefined,
   toggles: Partial<Record<ReesAnalyzerName, boolean>> | undefined,
 ): string[] | undefined {
-  if (toggles === undefined || Object.keys(toggles).length === 0) return envSelected;
-  const enabled = new Set<string>(envSelected ?? REES_ANALYZER_NAMES);
+  if (toggles === undefined || Object.keys(toggles).length === 0 || envSelected === undefined) return envSelected;
+  const enabled = new Set<string>(envSelected);
   for (const name of REES_ANALYZER_NAMES) {
-    const flag = toggles[name];
-    if (flag === true) enabled.add(name);
-    else if (flag === false) enabled.delete(name);
+    if (toggles[name] === false) enabled.delete(name);
   }
-  const selected = REES_ANALYZER_NAMES.filter((name) => enabled.has(name));
-  if (envSelected === undefined && selected.length === REES_ANALYZER_NAMES.length) return undefined;
-  return selected;
+  return REES_ANALYZER_NAMES.filter((name) => enabled.has(name));
 }
 
 /** Prefer explicit linkedIssues; fall back to Fixes #N parsing from the PR body. */

--- a/test/unit/review-enrichment-config.test.ts
+++ b/test/unit/review-enrichment-config.test.ts
@@ -9,13 +9,8 @@ describe("resolveEnrichmentAnalyzerSelection (env + per-repo toggle composition)
     expect(resolveEnrichmentAnalyzerSelection(["secret"], undefined)).toEqual(["secret"]);
   });
 
-  it("removes a disabled analyzer from the full default set (env unset)", () => {
-    const result = resolveEnrichmentAnalyzerSelection(undefined, { secret: false });
-    expect(result).toEqual(REES_ANALYZER_NAMES.filter((n) => n !== "secret"));
-    expect(result).not.toContain("secret");
-  });
-
-  it("stays byte-identical (undefined) when a toggle only re-enables an already-included analyzer", () => {
+  it("keeps the implicit REES default when env is unset so profile filtering remains authoritative", () => {
+    expect(resolveEnrichmentAnalyzerSelection(undefined, { secret: false })).toBeUndefined();
     expect(resolveEnrichmentAnalyzerSelection(undefined, { secret: true })).toBeUndefined();
   });
 
@@ -23,8 +18,8 @@ describe("resolveEnrichmentAnalyzerSelection (env + per-repo toggle composition)
     expect(resolveEnrichmentAnalyzerSelection(["dependency", "secret"], { secret: false })).toEqual(["dependency"]);
   });
 
-  it("adds an enabled analyzer to an explicit env list in registry order", () => {
-    expect(resolveEnrichmentAnalyzerSelection(["dependency"], { secret: true })).toEqual(["dependency", "secret"]);
+  it("does not let a repo enable toggle widen an explicit operator env list", () => {
+    expect(resolveEnrichmentAnalyzerSelection(["dependency"], { secret: true })).toEqual(["dependency"]);
   });
 
   it("can disable every analyzer in an explicit list, yielding an empty (not undefined) selection", () => {


### PR DESCRIPTION
### Motivation

- Prevent repo-controlled `review.enrichment` toggles from converting an implicit analyzer selection into an explicit analyzer list that bypasses operator `REES_PROFILE` cost limits and causes GitHub-backed analyzers to run unexpectedly.

### Description

- Change `resolveEnrichmentAnalyzerSelection` in `src/review/enrichment-wire.ts` to keep `undefined` (implicit) when `REES_ANALYZERS` is unset so REES profile filtering remains authoritative, and to only allow repo toggles to *narrow* an explicit operator list (treat `true` as a no-op, `false` removes).
- Update unit expectations in `test/unit/review-enrichment-config.test.ts` to cover the hardening: implicit selection remains implicit, explicit lists can be narrowed, and repo enable toggles cannot widen an operator-provided list.

### Testing

- Ran targeted unit tests with `npx vitest run test/unit/review-enrichment-config.test.ts test/unit/enrichment-wire.test.ts test/unit/enrichment-wiring.test.ts`, and those tests passed.
- Attempted full local gate (`npm run test:ci` / `npm run test:coverage`) but the environment-run did not complete: `selfhost:env-reference:check` flagged a pre-existing stale generated file and `npm audit --audit-level=moderate` returned `403 Forbidden`; `test:coverage` was started but did not finish within the session time. The targeted regression tests covering the change passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48cc8f3370832c9fd742d1853ea24f)