### PR TITLE
fix(github): stop the @gittensory mention parser matching lookalike usernames

### DIFF
--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -163,7 +163,10 @@ export type MaintainerQueueDigest = {
 
 export function parseGittensoryMentionCommand(body: string | null | undefined): GittensoryMentionCommand | null {
   if (!body) return null;
-  const match = body.match(/(?:^|\s)@gittensory(?:\s+([a-z-]+))?([^\n\r]*)/i);
+  // `(?![\w-])` requires the mention to end at a non-identifier char, so other usernames that merely
+  // start with "@gittensory" — `@gittensory-bot`, `@gittensorybot`, `@gittensory2` — are not misread as a
+  // bare `@gittensory help` command. A space, end-of-string, or punctuation still matches.
+  const match = body.match(/(?:^|\s)@gittensory(?![\w-])(?:\s+([a-z-]+))?([^\n\r]*)/i);
   if (!match) return null;
   const requested = (match[1]?.toLowerCase() || "help") as GittensoryMentionCommandName | GittensoryActionCommandName;
   if (ACTION_COMMANDS.has(requested as GittensoryActionCommandName)) {

--- a/test/unit/github-commands.test.ts
+++ b/test/unit/github-commands.test.ts
@@ -39,6 +39,10 @@ describe("GitHub mention commands", () => {
       reason: "known false positive, shipping",
     });
     expect(parseGittensoryMentionCommand("gittensory preflight")).toBeNull();
+    // Other usernames that merely start with "@gittensory" must not be read as a bare "@gittensory help".
+    expect(parseGittensoryMentionCommand("@gittensory-bot can you take a look?")).toBeNull();
+    expect(parseGittensoryMentionCommand("@gittensorybot help")).toBeNull();
+    expect(parseGittensoryMentionCommand("@gittensory2 preflight")).toBeNull();
     expect(isMaintainerOnlyCommand("queue-summary")).toBe(true);
     expect(isMaintainerOnlyCommand("preflight")).toBe(false);
   });


### PR DESCRIPTION
## Summary

`parseGittensoryMentionCommand` in `src/github/commands.ts` anchored the mention start with `(?:^|\s)`
but placed **no boundary after** `@gittensory`. Because the command group `(?:\s+([a-z-]+))?` is
optional, a body that mentions a *different* username beginning with `@gittensory` skips that group and
the trailing `([^\n\r]*)` swallows the rest — so the parser reports a bare `@gittensory help` command:

```ts
parseGittensoryMentionCommand("@gittensory-bot can you take a look?")
// before: { name: "help", raw: "@gittensory-bot can you take a look?" }  → bot posts a help card
// after:  null                                                            → not our mention
```

The same misfire hit `@gittensorybot`, `@gittensory2`, `@gittensory-helper`, etc. — every
`@gittensory<continuation>` username triggered an unsolicited public bot reply.

Fix: add a `(?![\w-])` negative lookahead so the mention must end at a non-identifier character. A space,
end-of-string, or punctuation still matches, so `@gittensory`, `@gittensory ask …`, `@gittensory!` all
keep working; a following letter/digit/underscore/hyphen (i.e. a longer username) no longer matches.

No linked issue: small, self-evident recognizer correctness fix (one lookahead in an existing regex) with
no schema, auth, or deploy change; it only narrows an over-broad match, so it fits the repo's `preferred`
(not required) linked-issue policy.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran locally: `git diff --check` (clean), `npm run typecheck` (clean), and a focused `test:coverage`
  over `test/unit/github-commands.test.ts` — 26 tests pass and the changed line is covered (the edit is
  inside the regex literal and adds no new branch; the only uncovered line in the file, 224, is
  pre-existing and outside this diff), so `codecov/patch` is 100% on this diff.
- Not run locally: the UI, MCP, workers, OpenAPI, actionlint, and audit jobs. This is a `src/`-only change
  to one deterministic parser touching no UI/API/OpenAPI/MCP/DB/workflow surface, so those jobs are no-ops
  for this diff; they run on CI (Linux).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- This narrows the GitHub App's public mention recognizer so it no longer replies to unrelated
  `@gittensory*` usernames — it only *reduces* bot noise; recognized commands are unchanged. No auth,
  CORS, API, schema, or UI surface is touched.
- Regression test added in `test/unit/github-commands.test.ts`: `@gittensory-bot …`, `@gittensorybot help`,
  and `@gittensory2 preflight` now return `null`. All existing mention-command assertions still hold.
