### PR TITLE
feat(enrichment): flag PYTHONHTTPSVERIFY=0 as disabled TLS verification

### DIFF
--- a/review-enrichment/src/analyzers/iac-misconfig.ts
+++ b/review-enrichment/src/analyzers/iac-misconfig.ts
@@ -19,7 +19,7 @@ const PUBLIC_BUCKET_RE =
 const SAME_SITE_NONE_RE = /\bsameSite\b[\s"'=:,-]*["']?none["']?\b/i;
 const SECURE_FALSE_RE = /\bsecure\b[\s"'=:,-]*false\b/i;
 const TLS_DISABLED_RE =
-  /\brejectUnauthorized\b[\s"'=:,-]*false\b|\bverify\s*=\s*False\b|\bssl_verify\b[\s"'=:,-]*false\b|\binsecureSkipTLSVerify\b[\s"'=:,-]*true\b|\bskipTLSVerify\b[\s"'=:,-]*true\b|\bNODE_TLS_REJECT_UNAUTHORIZED\b[\s"'=:,-]*["']?0\b/i;
+  /\brejectUnauthorized\b[\s"'=:,-]*false\b|\bverify\s*=\s*False\b|\bssl_verify\b[\s"'=:,-]*false\b|\binsecureSkipTLSVerify\b[\s"'=:,-]*true\b|\bskipTLSVerify\b[\s"'=:,-]*true\b|\bNODE_TLS_REJECT_UNAUTHORIZED\b[\s"'=:,-]*["']?0\b|\bPYTHONHTTPSVERIFY\b[\s"'=:,-]*["']?0\b/i;
 const PROD_RE =
   /\b(?:NODE_ENV|ENVIRONMENT|APP_ENV)\b[\s"'=:,-]*production\b|\bproduction\s*:/i;
 const DEBUG_TRUE_RE = /\bdebug\b[\s"'=:,-]*true\b|\bDEBUG\b[\s"'=:,-]*true\b/i;

--- a/review-enrichment/test/iac-misconfig.test.ts
+++ b/review-enrichment/test/iac-misconfig.test.ts
@@ -86,6 +86,34 @@ test("scanPatchForIacMisconfig does not flag NODE_TLS_REJECT_UNAUTHORIZED when T
   );
 });
 
+test("scanPatchForIacMisconfig flags PYTHONHTTPSVERIFY=0 as TLS verification disabled", () => {
+  // Python's global HTTPS-verification switch: PYTHONHTTPSVERIFY=0 disables certificate verification for the
+  // whole interpreter — the Python equivalent of the already-detected NODE_TLS_REJECT_UNAUTHORIZED=0.
+  const dotenv = scanPatchForIacMisconfig(
+    ".env.production",
+    ["@@ -1,0 +2,1 @@", "+PYTHONHTTPSVERIFY=0"].join("\n"),
+  );
+  assert.deepEqual(dotenv, [
+    { file: ".env.production", line: 2, kind: "tls-verification-disabled" },
+  ]);
+
+  const quoted = scanPatchForIacMisconfig(
+    "compose.yaml",
+    ["@@ -1,0 +7,1 @@", '+      PYTHONHTTPSVERIFY: "0"'].join("\n"),
+  );
+  assert.deepEqual(quoted, [
+    { file: "compose.yaml", line: 7, kind: "tls-verification-disabled" },
+  ]);
+});
+
+test("scanPatchForIacMisconfig does not flag PYTHONHTTPSVERIFY when verification stays on", () => {
+  // Only `0` disables; any other value keeps Python's certificate verification enabled.
+  assert.deepEqual(
+    scanPatchForIacMisconfig(".env", "@@ -1,0 +1,1 @@\n+PYTHONHTTPSVERIFY=1"),
+    [],
+  );
+});
+
 test("scanPatchForIacMisconfig ignores unchanged lines and honors maxFindings", () => {
   assert.deepEqual(
     scanPatchForIacMisconfig(


### PR DESCRIPTION
## Summary
The `iacMisconfig` analyzer's `tls-verification-disabled` rule detects several ways config disables TLS certificate verification (`rejectUnauthorized: false`, `insecureSkipTLSVerify: true`, `NODE_TLS_REJECT_UNAUTHORIZED=0`, …). It covers the **Node** runtime global but not **Python's** equivalent: `PYTHONHTTPSVERIFY=0` disables HTTPS certificate verification for the entire interpreter. This adds it, mapping to the existing `tls-verification-disabled` finding kind.

## Scope (precise, value-`0`-only)
`PYTHONHTTPSVERIFY` is value-based: only `0` disables verification; any other value keeps it on. The new alternative is added to the existing **flat, linear-time** `TLS_DISABLED_RE`, scoped strictly to `0`:
- matches `PYTHONHTTPSVERIFY=0` and quoted `PYTHONHTTPSVERIFY: "0"` (YAML/JSON);
- does **not** match `PYTHONHTTPSVERIFY=1` (verification on).

No new finding kind, type, or descriptor change; reuses `tls-verification-disabled`, runs only on the analyzer's existing config-path scope (`.env`, Dockerfile, YAML/JSON, …). The ReDoS-safety invariant (no quantified group) is preserved.

## Test plan
- [x] Extends `review-enrichment/test/iac-misconfig.test.ts` with the `.env`/quoted-YAML positives and the `=1` negative, exercising the real exported `scanPatchForIacMisconfig` path.
- [x] `node --test test/iac-misconfig.test.ts` — 8 passed.
- [x] Full REES suite `node --test test/**/*.test.ts` — 559 passed, 0 failed.
- [x] `generate-analyzer-metadata.mjs --check` clean; `validate-sourcemaps.mjs` clean; Prettier clean.

## No linked issue
Self-contained precision improvement to an existing analyzer's detection coverage; no tracking issue. Touches only `review-enrichment/src/analyzers/iac-misconfig.ts` and its test, with no cross-cutting or API changes.

Made with [Cursor](https://cursor.com)