### PR TITLE
fix(miner): reject cyclic dependsOn graphs in plan store saves

### DIFF
--- a/packages/gittensory-miner/lib/plan-store.js
+++ b/packages/gittensory-miner/lib/plan-store.js
@@ -95,6 +95,23 @@ function validatePlanDag(plan) {
       if (dep === step.id || !seenStepIds.has(dep)) throw new Error("invalid_plan");
     }
   }
+  const color = new Map();
+  const byId = new Map(plan.steps.map((step) => [step.id, step]));
+  const hasCycle = (id) => {
+    color.set(id, 1);
+    for (const dep of byId.get(id)?.dependsOn ?? []) {
+      const depColor = color.get(dep) ?? 0;
+      if (depColor === 1) return true;
+      if (depColor === 0 && byId.has(dep) && hasCycle(dep)) return true;
+    }
+    color.set(id, 2);
+    return false;
+  };
+  for (const step of plan.steps) {
+    if ((color.get(step.id) ?? 0) === 0 && hasCycle(step.id)) {
+      throw new Error("invalid_plan");
+    }
+  }
   return plan;
 }
 

--- a/test/unit/miner-plan-store.test.ts
+++ b/test/unit/miner-plan-store.test.ts
@@ -122,6 +122,29 @@ describe("gittensory-miner plan store (#2318)", () => {
     ).toThrow("invalid_plan");
   });
 
+  it("rejects cyclic dependsOn graphs on save", () => {
+    const store = tempStore();
+    const step = (id: string, dependsOn: string[]) => ({
+      id,
+      title: id,
+      dependsOn,
+      status: "pending" as const,
+      attempts: 0,
+      maxAttempts: 1,
+    });
+
+    expect(() =>
+      store.savePlan("two-cycle", {
+        steps: [step("a", ["b"]), step("b", ["a"])],
+      }),
+    ).toThrow("invalid_plan");
+    expect(() =>
+      store.savePlan("three-cycle", {
+        steps: [step("a", ["c"]), step("b", ["a"]), step("c", ["b"])],
+      }),
+    ).toThrow("invalid_plan");
+  });
+
   it("rejects a corrupted plan blob on load instead of returning a malformed plan", () => {
     const store = tempStore();
     store.savePlan("p1", PLAN);


### PR DESCRIPTION
## Summary

- Reject cyclic `dependsOn` graphs in `validatePlanDag` so permanently blocked plans cannot be persisted locally.
- Aligns the miner plan store with the MCP `plan-dag` validator, which already treats dependency cycles as invalid.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] Focused on plan-store validation only — no unrelated miner CLI or UI changes.

## Validation

- [ ] `npm run test:ci` locally — CI will run the full gate on push.
- [x] Unit tests cover 2-node and 3-node cyclic `dependsOn` rejection on save.

## Safety

- [x] No secrets, wallet details, hotkeys, or private scoring output in code or PR text.
- [x] Deterministic, read/write-local only: no network calls.

## UI Evidence

Not applicable — miner library only.

## Notes

Follow-up to #2953 unknown/self `dependsOn` validation in the same foundation plan store (#2318).
