### PR TITLE
fix(api): cap /v1/orb/token request body to prevent large-body DoS

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -132,7 +132,13 @@ import { handleOrbIngest, readOrbIngestBody } from "../orb/ingest";
 import { handleOrbWebhook } from "../orb/webhook";
 import { handleOrbOAuthCallback } from "../orb/oauth";
 import { brokerOrbToken, isOrbBrokerEnabled, issueOrbEnrollment } from "../orb/broker";
-import { pullRelayPending, readOrbRelayRegisterBody, registerValidatedOrbRelay, validateOrbRelayEnrollment } from "../orb/relay";
+import {
+  MAX_ORB_RELAY_REGISTER_BODY_BYTES,
+  pullRelayPending,
+  readOrbRelayRegisterBody,
+  registerValidatedOrbRelay,
+  validateOrbRelayEnrollment,
+} from "../orb/relay";
 import { computeFleetAnalytics } from "../orb/analytics";
 import { handleMcpRequest } from "../mcp/server";
 import { buildOpenApiSpec } from "../openapi/spec";
@@ -3118,7 +3124,16 @@ export function createApp() {
     const auth = c.req.header("authorization") ?? "";
     const secret = auth.startsWith("Bearer ") ? auth.slice(7).trim() : "";
     if (!secret) return c.json({ error: "missing_enrollment_secret" }, 401);
-    const body = await c.req.json().catch(() => null);
+    const rawBody = await readOrbRelayRegisterBody(c.req.raw, c.req.header("content-length"));
+    if (rawBody === null) return c.json({ error: "payload_too_large", maxBytes: MAX_ORB_RELAY_REGISTER_BODY_BYTES }, 413);
+    let body: unknown = null;
+    if (rawBody) {
+      try {
+        body = JSON.parse(rawBody) as unknown;
+      } catch {
+        body = null;
+      }
+    }
     const forceRefresh = typeof body === "object" && body !== null && (body as { forceRefresh?: unknown }).forceRefresh === true;
     let result: Awaited<ReturnType<typeof brokerOrbToken>>;
     try {

--- a/test/integration/orb-broker.test.ts
+++ b/test/integration/orb-broker.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createApp } from "../../src/api/routes";
 import { brokerOrbToken, isOrbBrokerEnabled, issueOrbEnrollment } from "../../src/orb/broker";
+import { MAX_ORB_RELAY_REGISTER_BODY_BYTES } from "../../src/orb/relay";
 import { createTestEnv, type TestD1Database } from "../helpers/d1";
 
 async function pkcs8Pem(): Promise<string> {
@@ -259,6 +260,53 @@ describe("broker endpoints", () => {
     const { secret } = (await issueOrbEnrollment(e, 401)) as { secret: string };
     await db(e).prepare("UPDATE orb_github_installations SET registered=0 WHERE installation_id=401").run();
     expect((await app.request("/v1/orb/token", { method: "POST", headers: { authorization: `Bearer ${secret}` } }, e)).status).toBe(403);
+  });
+
+  it("/v1/orb/token rejects oversized force-refresh bodies before parsing or validating the bearer", async () => {
+    const e = await brokerEnv();
+    const parseSpy = vi.spyOn(JSON, "parse");
+    const res = await app.request(
+      "/v1/orb/token",
+      {
+        method: "POST",
+        headers: { authorization: "Bearer orbsec_bad", "content-length": String(MAX_ORB_RELAY_REGISTER_BODY_BYTES + 1) },
+        body: "{}",
+      },
+      e,
+    );
+
+    expect(res.status).toBe(413);
+    expect(parseSpy).not.toHaveBeenCalled();
+    parseSpy.mockRestore();
+    await expect(res.json()).resolves.toEqual({ error: "payload_too_large", maxBytes: MAX_ORB_RELAY_REGISTER_BODY_BYTES });
+  });
+
+  it("/v1/orb/token caps streamed bodies when no content-length is declared", async () => {
+    const e = await brokerEnv();
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new Uint8Array(MAX_ORB_RELAY_REGISTER_BODY_BYTES + 1));
+        controller.close();
+      },
+    });
+    const res = await app.request("/v1/orb/token", { method: "POST", headers: { authorization: "Bearer orbsec_bad" }, body: stream, duplex: "half" } as RequestInit, e);
+
+    expect(res.status).toBe(413);
+    await expect(res.json()).resolves.toMatchObject({ error: "payload_too_large" });
+  });
+
+  it("/v1/orb/token accepts small force-refresh JSON and ignores malformed JSON", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-25T07:00:00Z"));
+    const e = await brokerEnv({ TOKEN_ENCRYPTION_SECRET: "orb-route-cache-secret" });
+    await seedInstall(e, 405, { registered: 1 });
+    const { secret } = (await issueOrbEnrollment(e, 405)) as { secret: string };
+    const calls = countingTokenFetch("2026-06-25T08:00:00Z", { contents: "write" });
+
+    expect((await app.request("/v1/orb/token", { method: "POST", headers: { authorization: `Bearer ${secret}` }, body: "{bad" }, e)).status).toBe(200);
+    expect(calls()).toBe(1);
+    expect((await app.request("/v1/orb/token", { method: "POST", headers: { authorization: `Bearer ${secret}` }, body: JSON.stringify({ forceRefresh: true }) }, e)).status).toBe(200);
+    expect(calls()).toBe(2);
   });
 
   it("/v1/internal/orb/enrollments: 400 missing id, 409 unregistered, 404 unknown", async () => {


### PR DESCRIPTION
### Motivation
- Prevent an availability DoS where the token-exempt `/v1/orb/token` route parsed an unbounded JSON body when any non-empty `Authorization: Bearer` header was present, allowing an attacker to force large-body buffering before the enrollment secret was validated.
- Use the same bounded readers already in the Orb paths so the optional `forceRefresh` flag can be inspected safely without exposing unbounded memory/CPU use.

### Description
- Replace the unconditional `c.req.json()` call in the `/v1/orb/token` handler with the bounded reader `readOrbRelayRegisterBody(c.req.raw, c.req.header("content-length"))` and return `413 payload_too_large` when the reader signals an oversize body using `MAX_ORB_RELAY_REGISTER_BODY_BYTES`.
- Parse the small body with `JSON.parse` inside a `try/catch` and derive `forceRefresh` only from safely-read JSON, preserving behavior for malformed or absent bodies.
- Add integration tests in `test/integration/orb-broker.test.ts` that assert oversized declared bodies are rejected before parsing, streamed oversized bodies without `content-length` are capped, malformed small JSON is ignored, and valid `forceRefresh` JSON still exercises the cache bypass.

### Testing
- Ran the targeted integration suite with `npx vitest run test/integration/orb-broker.test.ts --config vitest.config.ts --reporter verbose` and the updated Orb-broker tests passed (21/21).
- Ran typecheck (`npm run typecheck`) and OpenAPI check (`npm run ui:openapi:check`) which succeeded locally.
- Attempted full coverage (`npm run test:coverage`) and `npm audit --audit-level=moderate`; the full coverage run exposed unrelated long-running/timeout failures in other suites outside the Orb change and the audit call failed due to the environment returning `403 Forbidden` from the registry audit endpoint.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48cd17a9d8832cae76365d98ac5c39)