### PR TITLE
fix(enrichment): scan environment-specific dotenv files for IaC misconfig

### DIFF
--- a/review-enrichment/src/analyzers/iac-misconfig.ts
+++ b/review-enrichment/src/analyzers/iac-misconfig.ts
@@ -4,7 +4,7 @@ const MAX_FINDINGS = 25;
 const MAX_LINE_CHARS = 2000;
 
 const CONFIG_PATH_RE =
-  /(?:^|\/)(?:docker-compose[^/]*\.ya?ml|compose[^/]*\.ya?ml|values(?:\.[^/]+)?\.ya?ml|.*\.(?:tf|ya?ml|json|toml|ini|conf|env)|Dockerfile(?:\.[^/]+)?|nginx[^/]*\.conf)$/i;
+  /(?:^|\/)(?:docker-compose[^/]*\.ya?ml|compose[^/]*\.ya?ml|values(?:\.[^/]+)?\.ya?ml|\.env(?:\.[^/]+)?|.*\.(?:tf|ya?ml|json|toml|ini|conf|env)|Dockerfile(?:\.[^/]+)?|nginx[^/]*\.conf)$/i;
 
 const CORS_ORIGIN_RE =
   /\b(?:access-control-allow-origin|allow_origin|cors_origin|origin)\b[\s"'=:,\[\]-]*\*/i;

--- a/review-enrichment/test/iac-misconfig.test.ts
+++ b/review-enrichment/test/iac-misconfig.test.ts
@@ -1,7 +1,11 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { scanPatchForIacMisconfig } from "../dist/analyzers/iac-misconfig.js";
+import {
+  isRelevantConfigPath,
+  scanIacMisconfig,
+  scanPatchForIacMisconfig,
+} from "../dist/analyzers/iac-misconfig.js";
 
 test("scanPatchForIacMisconfig flags hostNetwork and compose host network mode", () => {
   const k8s = scanPatchForIacMisconfig(
@@ -84,6 +88,32 @@ test("scanPatchForIacMisconfig does not flag NODE_TLS_REJECT_UNAUTHORIZED when T
     ),
     [],
   );
+});
+
+test("isRelevantConfigPath recognizes environment-specific dotenv files", async () => {
+  // The path gate must admit mode-suffixed dotenv files (`.env.production`, `.env.local`,
+  // `apps/api/.env.staging`) — the canonical home of `NODE_TLS_REJECT_UNAUTHORIZED=0` — not only a bare `.env`.
+  // Otherwise the analyzer entrypoint skips them and the TLS/CORS/secret findings never fire in real use.
+  assert.equal(isRelevantConfigPath(".env"), true);
+  assert.equal(isRelevantConfigPath(".env.production"), true);
+  assert.equal(isRelevantConfigPath(".env.local"), true);
+  assert.equal(isRelevantConfigPath("apps/api/.env.staging"), true);
+  // Must not over-match a non-dotenv name that merely contains "env".
+  assert.equal(isRelevantConfigPath(".environment"), false);
+  assert.equal(isRelevantConfigPath("src/index.ts"), false);
+
+  // End-to-end through the gated entrypoint: a mode-suffixed dotenv file must actually be scanned.
+  const findings = await scanIacMisconfig({
+    files: [
+      {
+        path: ".env.production",
+        patch: "@@ -1,0 +7,1 @@\n+NODE_TLS_REJECT_UNAUTHORIZED=0",
+      },
+    ],
+  });
+  assert.deepEqual(findings, [
+    { file: ".env.production", line: 7, kind: "tls-verification-disabled" },
+  ]);
 });
 
 test("scanPatchForIacMisconfig ignores unchanged lines and honors maxFindings", () => {


### PR DESCRIPTION
## Summary

The `iac-misconfig` analyzer (`review-enrichment/src/analyzers/iac-misconfig.ts`) gates every scan on `isRelevantConfigPath()` → `CONFIG_PATH_RE`. That regex only recognized dotenv files where `env` is the **final** extension (`.env`, `app.env`) via the terminal `.*\.(?:…|env)$` alternative. Environment-specific dotenv files — `.env.production`, `.env.local`, `.env.staging`, `apps/api/.env.production` — have a final segment of `production`/`local`/… and so did **not** match: `scanIacMisconfig` skipped them before scanning a single line.

That is exactly where the just-landed `NODE_TLS_REJECT_UNAUTHORIZED=0` detector (#3021) most needs to run — per-environment dotenv files are the standard, and most common real-world, home of that setting. Concretely, before this change:

```
scanIacMisconfig({ files: [{ path: ".env.production",
  patch: "@@ -1,0 +7,1 @@\n+NODE_TLS_REJECT_UNAUTHORIZED=0" }] })  →  []   (silently skipped)
```

This adds a `\.env(?:\.[^/]+)?` alternative to the path gate so `.env` and `.env.<suffix>` both match, without over-matching `.environment`, `foo.environment`, `.envrc`, or unrelated files (verified against an 18-path battery; no regression on previously-matching paths). Adds a regression test that drives the gate **end-to-end** — the existing TLS test called `scanPatchForIacMisconfig` directly, bypassing `isRelevantConfigPath`, so it passed while the real entrypoint dropped the file.

No linked issue: issue creation on this repo is restricted to collaborators, and this is a small, self-contained correctness fix (one regex alternative on the path gate) completing #3021's intended coverage; the rationale is self-evident from the diff.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- The full `npm run test:ci` aggregate ran green (including `rees:test`, the review-enrichment build + node test suite, with the new regression test passing) plus `npm audit --audit-level=moderate` (0 vulnerabilities). This is a `review-enrichment/**` change (not measured by Codecov); its node suite is the gate, and the new test fails on the old regex and passes on the fix.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

This widens a security-signal analyzer's file coverage (it flags *more* real misconfig, e.g. disabled TLS verification in production dotenv files); it exposes no secrets. No auth/CORS/session/API/OpenAPI/UI surface.

## Notes

- One regex alternative added to `CONFIG_PATH_RE`, plus an end-to-end regression test. No schema, migration, OpenAPI, wrangler, or generated-artifact impact.
