### PR TITLE
fix(review): key the durable CI-state cache on resolved required contexts

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -3321,13 +3321,19 @@ export function deserializeCachedCiAggregate(
 ): LiveCiAggregate | null {
   if (!cached.ciState) return null;
   try {
+    const failingDetails = JSON.parse(cached.ciFailingDetailsJson ?? "[]");
+    const nonRequiredFailingDetails = JSON.parse(cached.ciNonRequiredFailingDetailsJson ?? "[]");
+    // A corrupted/malformed row (e.g. hand-edited D1 row, or a future schema change that leaves an old JSON
+    // shape behind) must fail OPEN as a cache miss, not hand callers a wrong shape -- never trust the parse
+    // result's type just because JSON.parse didn't throw.
+    if (!Array.isArray(failingDetails) || !Array.isArray(nonRequiredFailingDetails)) return null;
     return {
       ciState: cached.ciState,
       hasPending: cached.ciHasPending ?? false,
       hasVisiblePending: cached.ciHasVisiblePending ?? false,
       hasMissingRequiredContext: cached.ciHasMissingRequiredContext ?? false,
-      failingDetails: JSON.parse(cached.ciFailingDetailsJson ?? "[]"),
-      nonRequiredFailingDetails: JSON.parse(cached.ciNonRequiredFailingDetailsJson ?? "[]"),
+      failingDetails,
+      nonRequiredFailingDetails,
       ciCompletenessWarning: cached.ciCompletenessWarning ?? null,
     };
   } catch {

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -534,6 +534,17 @@ function expectedCiContextsKeyPart(expectedCiContexts: ReadonlyArray<string> | n
   return [...expectedCiContexts].sort().join(" ");
 }
 
+// Stable, order-independent cache-key fragment for the RESOLVED required-contexts set (#selfhost-ci-verification):
+// unlike expectedCiContextsKeyPart above (the raw, unresolved settings.expectedCiContexts config), this reflects
+// mergeRequiredCiContexts' actual output -- live branch-protection required contexts unioned with config. The
+// durable cross-job CI-state cache (cachedFetchLiveCiAggregate) MUST key on this, not on the raw config: branch
+// protection can change server-side while expectedCiContexts config stays put, and a stale durable row keyed only
+// on the unchanged config would keep serving an aggregate computed against the old required-context set.
+function resolvedRequiredContextsKeyPart(requiredContexts: ReadonlySet<string> | null | undefined): string {
+  if (!requiredContexts || requiredContexts.size === 0) return "";
+  return [...requiredContexts].sort().join(" ");
+}
+
 // RC2 + #selfhost-ci-verification: the EFFECTIVE required-status-check contexts for this repo/baseRef, merging
 // live branch-protection required contexts with the maintainer-configured settings.expectedCiContexts fallback
 // (mergeRequiredCiContexts — branch protection stays authoritative when readable; expectedCiContexts is the
@@ -582,10 +593,11 @@ function evictLiveFactOnReject<T>(
  * degrades to a live fetch, never blocks it.
  *
  * `forceRefresh` (set by refreshLiveCiAggregate below, mirroring refreshLiveMergeState's OWN "never durable-
- * cached" contract for merge-state): skips the cache READ entirely, always fetching live -- a "refresh" caller
- * needs a genuinely fresh read even within the SAME job pass (e.g. re-checking CI right after this pass's own
- * gate/check-run publication, which can flip a status GitHub hasn't sent a webhook for yet). The WRITE-through
- * still happens on a forced refresh, so a LATER pass/job still benefits from this read.
+ * cached" contract for merge-state): skips the freshness CHECK entirely (the existing row is still fetched, to
+ * carry its `status` field into the write-through's previousState, but is never treated as a hit), so this always
+ * fetches live -- a "refresh" caller needs a genuinely fresh read even within the SAME job pass (e.g. re-checking
+ * CI right after this pass's own gate/check-run publication, which can flip a status GitHub hasn't sent a webhook
+ * for yet). The WRITE-through still happens on a forced refresh, so a LATER pass/job still benefits from this read.
  *
  * Deliberately implemented HERE, not in backfill.ts (where writeThroughCiStateCache/isCiStateCacheFresh/
  * deserializeCachedCiAggregate live) -- a same-module call from backfill.ts to its own
@@ -650,7 +662,7 @@ function fetchLiveCiAggregateWithRequiredContexts(
     .then((requiredContexts) => ({ requiredContexts, resolved: true }))
     .catch(() => ({ requiredContexts: null, resolved: false }))
     .then(({ requiredContexts, resolved }) =>
-      cachedFetchLiveCiAggregate(env, repoFullName, prNumber, headSha, token, requiredContexts, expectedCiContextsKeyPart(expectedCiContexts), forceRefresh, resolved, admissionKey),
+      cachedFetchLiveCiAggregate(env, repoFullName, prNumber, headSha, token, requiredContexts, resolvedRequiredContextsKeyPart(requiredContexts), forceRefresh, resolved, admissionKey),
     );
 }
 

--- a/test/unit/pr-detail-durable-cache.test.ts
+++ b/test/unit/pr-detail-durable-cache.test.ts
@@ -646,6 +646,36 @@ describe("durable CI-state cache (#selfhost-ci-verification)", () => {
       ).toBeNull();
     });
 
+    it("fails open to null when ciFailingDetailsJson parses to valid JSON that is NOT an array (corrupted row shape)", () => {
+      // JSON.parse succeeds here (it's valid JSON), so this exercises the Array.isArray guard specifically,
+      // not the catch block above -- a corrupted/malformed row must never hand callers a wrong shape.
+      expect(
+        deserializeCachedCiAggregate({
+          ciState: "passed",
+          ciHasPending: false,
+          ciHasVisiblePending: false,
+          ciHasMissingRequiredContext: false,
+          ciFailingDetailsJson: '{"not":"an array"}',
+          ciNonRequiredFailingDetailsJson: "[]",
+          ciCompletenessWarning: null,
+        }),
+      ).toBeNull();
+    });
+
+    it("fails open to null when ciNonRequiredFailingDetailsJson parses to valid JSON that is NOT an array (corrupted row shape)", () => {
+      expect(
+        deserializeCachedCiAggregate({
+          ciState: "passed",
+          ciHasPending: false,
+          ciHasVisiblePending: false,
+          ciHasMissingRequiredContext: false,
+          ciFailingDetailsJson: "[]",
+          ciNonRequiredFailingDetailsJson: '"just a string"',
+          ciCompletenessWarning: null,
+        }),
+      ).toBeNull();
+    });
+
     it("defaults hasPending/hasVisiblePending/hasMissingRequiredContext to false and the JSON arrays to [] when null", () => {
       expect(
         deserializeCachedCiAggregate({

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -2170,6 +2170,64 @@ describe("queue processors", () => {
     expect(deferred?.n).toBe(0);
   });
 
+  // REGRESSION (#selfhost-ci-verification): the DURABLE cross-job CI-state cache row must be keyed on the actual
+  // RESOLVED required-contexts set (mergeRequiredCiContexts' output: live branch-protection contexts unioned with
+  // settings.expectedCiContexts), not on the raw, unresolved expectedCiContexts config alone. Branch protection can
+  // change server-side (a maintainer adds a required check in GitHub's UI) while expectedCiContexts config stays
+  // put and the head_sha is unchanged -- if the durable row were keyed only on the config, the readiness path would
+  // keep serving a stale aggregate computed against the OLD required-context set for up to the 60s TTL, producing a
+  // wrong merge/close verdict. Two processJob passes at the SAME head_sha, same unchanged expectedCiContexts config,
+  // but DIFFERENT branch-protection required contexts between them, must each independently reach a live CI read
+  // (both misses) and each persist their OWN ciRequiredContextsKey -- proving the key tracks the resolved set.
+  it("REGRESSION (#selfhost-ci-verification): the durable CI-state cache keys on the RESOLVED required-contexts set, not the raw expectedCiContexts config", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: { pull_requests: "write", checks: "write" }, events: [] } });
+    await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", gateCheckMode: "enabled", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Branch protection drift", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, base: { ref: "main" }, labels: [], body: "Closes #1" });
+    // expectedCiContexts is configured ONCE and never changes across the two calls below -- only branch protection
+    // (the OTHER input to mergeRequiredCiContexts) drifts between them.
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { gate: { expectedCiContexts: ["lint"] } });
+    let requiredContextsFromBranchProtection: Array<string | null> = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (/\/pulls\/7(?:\?|$)/.test(url) && method === "GET") return Response.json({ number: 7, title: "Branch protection drift", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, mergeable_state: "clean", labels: [], body: "Closes #1" });
+      if (url.includes("/pulls/7/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+export const ok = true;" }]);
+      if (url.includes("/commits/a7/check-runs")) return Response.json({ total_count: 1, check_runs: [{ name: "lint", status: "completed", conclusion: "success", app: { slug: "github-actions" } }] });
+      if (url.includes("/commits/a7/status")) return Response.json({ state: "success", statuses: [] });
+      if (url.includes("/issues/1")) return Response.json({ number: 1, title: "Issue", state: "open", labels: [], user: { login: "reporter" } });
+      if (url.includes("/branches/")) return Response.json({ contexts: requiredContextsFromBranchProtection });
+      return Response.json({});
+    });
+
+    // Pass 1: branch protection requires nothing extra beyond expectedCiContexts's own "lint" -- the resolved set
+    // is exactly {"lint"}, satisfied by the check-run above, so CI resolves and the durable row's key reflects it.
+    requiredContextsFromBranchProtection = [];
+    await processJob(env, { type: "agent-regate-pr", deliveryId: "branch-protection-before", repoFullName: "owner/agent-repo", prNumber: 7, installationId: 9001 });
+    const rowAfterPass1 = await getPullRequestDetailSyncState(env, "owner/agent-repo", 7);
+    expect(rowAfterPass1?.ciState).toBe("passed");
+    const keyAfterPass1 = rowAfterPass1?.ciRequiredContextsKey ?? null;
+
+    // A maintainer now adds "required-build" as a branch-protection required check via GitHub's UI -- the SAME
+    // head_sha, the SAME (unchanged) expectedCiContexts config, but the RESOLVED required-contexts set just grew.
+    requiredContextsFromBranchProtection = ["required-build"];
+    await processJob(env, { type: "agent-regate-pr", deliveryId: "branch-protection-after", repoFullName: "owner/agent-repo", prNumber: 7, installationId: 9001 });
+    const rowAfterPass2 = await getPullRequestDetailSyncState(env, "owner/agent-repo", 7);
+    const keyAfterPass2 = rowAfterPass2?.ciRequiredContextsKey ?? null;
+
+    // The durable row's key must differ once the RESOLVED set changed -- if it were still derived from the raw,
+    // unchanged expectedCiContexts config (the bug), keyAfterPass2 would equal keyAfterPass1 even though the
+    // resolved required-contexts set is now materially different (missing "required-build" entirely).
+    expect(keyAfterPass2).not.toBe(keyAfterPass1);
+    // "required-build" never appears in any check-run/status ⇒ once it is folded into the resolved required set,
+    // reduceLiveCiAggregate can no longer treat it as satisfied ⇒ the aggregate correctly flips to pending,
+    // proving pass 2 actually re-derived against the NEW resolved set rather than serving pass 1's stale "passed"
+    // row from a durable cache keyed on the unchanged config.
+    expect(rowAfterPass2?.ciState).toBe("pending");
+  });
+
   it("#sweep-resync: a failing resync upsert is swallowed (fail-open) — the sweep never throws", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });


### PR DESCRIPTION
## Summary

- PR #2984 added a durable, webhook-invalidated CI-state snapshot cache (`pull_request_detail_sync_state`), but `cachedFetchLiveCiAggregate`'s durable-row key was derived from the raw, unresolved `settings.expectedCiContexts` config instead of the actually-resolved required-contexts set that `cachedRequiredStatusContexts` computes (branch protection merged with config, via `mergeRequiredCiContexts`).
- If branch protection changes server-side (a maintainer adds/removes a required check in GitHub's UI) while `expectedCiContexts` config and the PR's `head_sha` stay the same, the durable cache key was unchanged, so the readiness path could keep serving a stale aggregate computed against the *old* required-context set for up to the cache's 60s TTL — a wrong merge/close verdict window. This PR derives the durable key from the resolved set (`resolvedRequiredContextsKeyPart`) instead.
- Also hardens `deserializeCachedCiAggregate`: `JSON.parse` succeeding does not guarantee the parsed value is an array, so a corrupted/malformed row's `failingDetails`/`nonRequiredFailingDetails` now fail open to a cache miss via an explicit `Array.isArray` check rather than handing callers a wrong shape.
- Generic self-host engine behavior only; no repo-specific logic.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed. (Direct follow-up correctness fix to the durable CI-state cache landed in #2984; no separate issue needed.)

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` (not run — no workflow files touched)
- [x] `npm run typecheck`
- [x] Ran the affected test files directly and confirmed the new regression tests fail against the pre-fix code and pass against the fix (`npx vitest run test/unit/queue.test.ts test/unit/pr-detail-durable-cache.test.ts`, 527/527 passing); full unsharded `npm run test:coverage` not re-run locally per this repo's own guidance to trust CI for the full suite on a narrowly-scoped fix.
- [ ] `npm run test:workers` (not run — no Cloudflare-Workers-pool-specific code touched)
- [ ] `npm run build:mcp` / `npm run test:mcp-pack` (not run — no MCP package changes)
- [ ] `npm run ui:openapi:check` / `npm run ui:lint` / `npm run ui:typecheck` / `npm run ui:build` (not run — no API/OpenAPI surface or `apps/gittensory-ui` changes)
- [x] `npm audit --audit-level=moderate` (unaffected by this diff; last known-clean from the same working tree)
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Skipped checks above are for UI/MCP/Workers surfaces this PR does not touch (backend-only fix to the CI-state cache key derivation); CI's `validate` job runs them as a backstop.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session/CORS changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP surface changed; this is an internal cache.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes.)
- [x] Visible UI changes include a `UI Evidence` section below with screenshots. (N/A — no visible UI changes.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (N/A.)

## Notes

- Follow-up correctness fix to #2984 (durable webhook-invalidated CI-state snapshot cache), found during post-merge review of that PR's own added code.