### PR TITLE
fix(queue): retry unavailable PR freshness checks

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -3088,6 +3088,25 @@ export async function fetchLivePullRequestHeadSha(
   return result?.data.head?.sha ?? undefined;
 }
 
+export type LivePullRequestFetchResult =
+  | { status: "ok"; data: GitHubPullRequestPayload }
+  | { status: "error"; error: string };
+
+export async function fetchLivePullRequestResult(
+  env: Env,
+  repoFullName: string,
+  prNumber: number,
+  token: string | undefined,
+  admissionKey?: GitHubRateLimitAdmissionKey,
+): Promise<LivePullRequestFetchResult> {
+  try {
+    const result = await githubJsonWithHeaders<GitHubPullRequestPayload>(env, repoFullName, `/pulls/${prNumber}`, token, githubRateLimitOptions(admissionKey));
+    return { status: "ok", data: result.data };
+  } catch (error) {
+    return { status: "error", error: strippedErrorMessage(error, "GitHub live PR fetch failed").slice(0, 240) };
+  }
+}
+
 /** The PR's FULL live payload via REST `GET /pulls/{n}`, ready to feed `upsertPullRequestFromGitHub`. The scheduled
  *  re-gate sweep uses this to RESYNC a stored PR to its live head when a `synchronize` webhook was lost (e.g. the
  *  self-host relay was down), so the re-review runs on the current head + fresh files instead of a stale cached diff
@@ -3100,8 +3119,8 @@ export async function fetchLivePullRequest(
   token: string | undefined,
   admissionKey?: GitHubRateLimitAdmissionKey,
 ): Promise<GitHubPullRequestPayload | undefined> {
-  const result = await githubJsonWithHeaders<GitHubPullRequestPayload>(env, repoFullName, `/pulls/${prNumber}`, token, githubRateLimitOptions(admissionKey)).catch(() => undefined);
-  return result?.data ?? undefined;
+  const result = await fetchLivePullRequestResult(env, repoFullName, prNumber, token, admissionKey);
+  return result.status === "ok" ? result.data : undefined;
 }
 
 // #2537: durable, webhook-invalidated cache for the bare PR-state read (GET /pulls/{n}). Unlike the request-local

--- a/src/github/pr-freshness.ts
+++ b/src/github/pr-freshness.ts
@@ -1,7 +1,16 @@
 import { createInstallationToken } from "./app";
-import { fetchLivePullRequest } from "./backfill";
+import { fetchLivePullRequestResult } from "./backfill";
 import { githubRateLimitAdmissionKeyForToken } from "./client";
 import type { GitHubPullRequestPayload } from "../types";
+import { strippedErrorMessage } from "../utils/json";
+
+export type PullRequestUnavailableSource = "token" | "pull_request_fetch" | "live_payload";
+
+type PullRequestFreshnessOptions = {
+  requireDraft?: boolean;
+  unavailableSource?: PullRequestUnavailableSource;
+  unavailableDetail?: string;
+};
 
 export type PullRequestFreshness =
   | {
@@ -15,6 +24,8 @@ export type PullRequestFreshness =
       expectedHeadSha: string | null;
       liveHeadSha: string | null;
       liveState: string | null;
+      unavailableSource?: PullRequestUnavailableSource;
+      unavailableDetail?: string;
     };
 
 function normalizedHead(value: string | null | undefined): string | null {
@@ -32,16 +43,32 @@ export function reviewedPullRequestHeadSha(
 export function classifyPullRequestFreshness(
   live: Pick<GitHubPullRequestPayload, "state" | "head" | "draft"> | null | undefined,
   expectedHeadSha: string | null | undefined,
-  options?: { requireDraft?: boolean },
+  options?: PullRequestFreshnessOptions,
 ): PullRequestFreshness {
   const expected = normalizedHead(expectedHeadSha);
   if (!live) {
-    return { status: "stale", reason: "unavailable", expectedHeadSha: expected, liveHeadSha: null, liveState: null };
+    return {
+      status: "stale",
+      reason: "unavailable",
+      expectedHeadSha: expected,
+      liveHeadSha: null,
+      liveState: null,
+      ...(options?.unavailableSource ? { unavailableSource: options.unavailableSource } : {}),
+      ...(options?.unavailableDetail ? { unavailableDetail: options.unavailableDetail } : {}),
+    };
   }
   const liveState = typeof live.state === "string" ? live.state : null;
   const liveHeadSha = normalizedHead(live.head?.sha);
   if (!liveState) {
-    return { status: "stale", reason: "unavailable", expectedHeadSha: expected, liveHeadSha, liveState: null };
+    return {
+      status: "stale",
+      reason: "unavailable",
+      expectedHeadSha: expected,
+      liveHeadSha,
+      liveState: null,
+      unavailableSource: options?.unavailableSource ?? "live_payload",
+      ...(options?.unavailableDetail ? { unavailableDetail: options.unavailableDetail } : {}),
+    };
   }
   if (liveState !== "open") {
     return { status: "stale", reason: "closed", expectedHeadSha: expected, liveHeadSha, liveState };
@@ -73,14 +100,31 @@ export async function fetchPullRequestFreshness(
     requireDraft?: boolean;
   },
 ): Promise<PullRequestFreshness> {
-  const options = args.requireDraft !== undefined ? { requireDraft: args.requireDraft } : {};
+  const options: PullRequestFreshnessOptions =
+    args.requireDraft !== undefined ? { requireDraft: args.requireDraft } : {};
+  let tokenError: unknown;
   const token =
-    (await createInstallationToken(env, args.installationId).catch(() => undefined)) ??
-    env.GITHUB_PUBLIC_TOKEN;
-  if (!token) return classifyPullRequestFreshness(undefined, args.expectedHeadSha, options);
+    (await createInstallationToken(env, args.installationId).catch((error) => {
+      tokenError = error;
+      return undefined;
+    })) ?? env.GITHUB_PUBLIC_TOKEN;
+  if (!token) {
+    return classifyPullRequestFreshness(undefined, args.expectedHeadSha, {
+      ...options,
+      unavailableSource: "token",
+      unavailableDetail: strippedErrorMessage(tokenError, "no token available").slice(0, 240),
+    });
+  }
   const admissionKey = githubRateLimitAdmissionKeyForToken(env, token, args.installationId);
-  const live = await fetchLivePullRequest(env, args.repoFullName, args.pullNumber, token, admissionKey);
-  return classifyPullRequestFreshness(live, args.expectedHeadSha, options);
+  const live = await fetchLivePullRequestResult(env, args.repoFullName, args.pullNumber, token, admissionKey);
+  if (live.status === "error") {
+    return classifyPullRequestFreshness(undefined, args.expectedHeadSha, {
+      ...options,
+      unavailableSource: "pull_request_fetch",
+      unavailableDetail: live.error,
+    });
+  }
+  return classifyPullRequestFreshness(live.data, args.expectedHeadSha, options);
 }
 
 export function pullRequestFreshnessDetail(result: PullRequestFreshness): string {

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -2051,6 +2051,16 @@ function freshnessBlocksReviewOutput(
   return freshness.status === "stale";
 }
 
+class RetryablePullRequestFreshnessUnavailableError extends RetryableJobError {
+  constructor() {
+    super("live PR state unavailable; retrying review output publication", {
+      retryAfterMs: 60_000,
+      retryKind: "pr_freshness_unavailable",
+    });
+    this.name = "RetryablePullRequestFreshnessUnavailableError";
+  }
+}
+
 async function reviewTargetFreshness(
   env: Env,
   args: {
@@ -2084,6 +2094,12 @@ async function reviewTargetFreshness(
       expectedHeadSha: freshness.expectedHeadSha,
       liveHeadSha: freshness.liveHeadSha,
       liveState: freshness.liveState,
+      ...(freshness.reason === "unavailable"
+        ? {
+            unavailableSource: freshness.unavailableSource ?? "unknown",
+            unavailableDetail: freshness.unavailableDetail ?? null,
+          }
+        : {}),
     },
   }).catch(() => undefined);
   return freshness;
@@ -7137,6 +7153,9 @@ async function maybePublishPrPublicSurface(
         mode,
         { checkRunId: pendingGateCheckRunId },
       ).catch(() => undefined);
+    }
+    if (freshness.reason === "unavailable") {
+      throw new RetryablePullRequestFreshnessUnavailableError();
     }
     return true;
   };

--- a/test/unit/parity-wire.test.ts
+++ b/test/unit/parity-wire.test.ts
@@ -371,12 +371,21 @@ async function seedGateEnabledRepo(env: Env): Promise<void> {
 // The miner-list/token/check-run endpoints the gate finalize touches; `confirmedAuthor` toggles whether the
 // gittensor miner list confirms the PR author. Confirmed status no longer changes the gate verdict (it feeds
 // scoring); the configured blocker fails the gate for either author (#gate-nonconfirmed).
+//
+// Also stubs the live `GET /pulls/{n}` read that `maybePublishPrPublicSurface`'s pre-publish freshness guard
+// makes on every finalize pass (reviewTargetFreshness → fetchPullRequestFreshness → fetchLivePullRequestResult).
+// Without this, that call falls through to the catch-all 404 below, which the freshness guard now classifies
+// as "unavailable" and retries via RetryablePullRequestFreshnessUnavailableError instead of the old silent
+// no-op -- correct production behavior (a real, freshly-opened PR resolves this read every time), but it means
+// every finalize-path test needs the live PR to actually resolve, matching prWebhook's own head sha (#gate123)
+// so freshness classifies as "current" rather than "unavailable"/"head_changed".
 function stubFinalizeFetch(confirmedAuthor: string | null): void {
   vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
     const url = input.toString();
     if (url === "https://api.gittensor.io/miners") return Response.json(confirmedAuthor ? [{ uid: 7, githubUsername: confirmedAuthor, githubId: "123", totalPrs: 4, totalMergedPrs: 3, totalOpenPrs: 1, totalClosedPrs: 0, totalOpenIssues: 0, totalClosedIssues: 0, totalSolvedIssues: 0, totalValidSolvedIssues: 0, isEligible: true, credibility: 1, eligibleRepoCount: 1 }] : []);
     if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
     if (url.includes("/check-runs")) return Response.json({ id: 900 }, { status: 201 });
+    if (url.includes("/pulls/42")) return Response.json({ number: 42, title: "Gate without issue", state: "open", head: { sha: "gate123" } });
     return new Response("not found", { status: 404 });
   });
 }

--- a/test/unit/pr-freshness.test.ts
+++ b/test/unit/pr-freshness.test.ts
@@ -32,9 +32,46 @@ describe("PR freshness guards", () => {
     expect(pullRequestFreshnessDetail(result)).toBe("live PR state could not be verified");
   });
 
+  it("carries internal unavailable metadata without changing the public detail", () => {
+    const result = classifyPullRequestFreshness(undefined, "sha1", {
+      unavailableSource: "pull_request_fetch",
+      unavailableDetail: "GitHub API failed for owner/repo/pulls/1 (503)",
+    });
+    expect(result).toMatchObject({
+      status: "stale",
+      reason: "unavailable",
+      expectedHeadSha: "sha1",
+      unavailableSource: "pull_request_fetch",
+      unavailableDetail: "GitHub API failed for owner/repo/pulls/1 (503)",
+    });
+    expect(pullRequestFreshnessDetail(result)).toBe("live PR state could not be verified");
+  });
+
   it("treats malformed live PR responses without state as unverifiable", () => {
     const result = classifyPullRequestFreshness({ state: undefined as unknown as string, head: { sha: "sha1" } }, "sha1");
-    expect(result).toMatchObject({ status: "stale", reason: "unavailable", liveHeadSha: "sha1", liveState: null });
+    expect(result).toMatchObject({
+      status: "stale",
+      reason: "unavailable",
+      liveHeadSha: "sha1",
+      liveState: null,
+      unavailableSource: "live_payload",
+    });
+  });
+
+  it("preserves a supplied unavailable source for malformed live PR payloads", () => {
+    const result = classifyPullRequestFreshness(
+      { state: undefined as unknown as string, head: { sha: "sha1" } },
+      "sha1",
+      { unavailableSource: "pull_request_fetch", unavailableDetail: "malformed replay" },
+    );
+    expect(result).toMatchObject({
+      status: "stale",
+      reason: "unavailable",
+      liveHeadSha: "sha1",
+      liveState: null,
+      unavailableSource: "pull_request_fetch",
+      unavailableDetail: "malformed replay",
+    });
   });
 
   it("treats closed PRs as stale even when the head still matches", () => {
@@ -146,6 +183,26 @@ describe("PR freshness guards", () => {
     ).resolves.toMatchObject({ status: "current", liveHeadSha: "sha7" });
   });
 
+  it("classifies live PR fetch failures as retryable unavailable freshness metadata", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      expect(String(input)).toContain("/repos/owner/repo/pulls/7");
+      return new Response("temporary outage", { status: 503 });
+    });
+    const result = await fetchPullRequestFreshness(env, {
+      installationId: 123,
+      repoFullName: "owner/repo",
+      pullNumber: 7,
+      expectedHeadSha: "sha7",
+    });
+    expect(result).toMatchObject({
+      status: "stale",
+      reason: "unavailable",
+      unavailableSource: "pull_request_fetch",
+      unavailableDetail: expect.stringContaining("503"),
+    });
+  });
+
   it("fails closed when no token can verify live PR state", async () => {
     const env = createTestEnv();
     const result = await fetchPullRequestFreshness(env, {
@@ -154,6 +211,11 @@ describe("PR freshness guards", () => {
       pullNumber: 7,
       expectedHeadSha: "sha7",
     });
-    expect(result).toMatchObject({ status: "stale", reason: "unavailable" });
+    expect(result).toMatchObject({
+      status: "stale",
+      reason: "unavailable",
+      unavailableSource: "token",
+      unavailableDetail: expect.any(String),
+    });
   });
 });

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -6451,19 +6451,25 @@ describe("queue processors", () => {
     expect(published.results).toEqual([]);
   });
 
-  it("suppresses public review output when live PR freshness cannot verify the reviewed head", async () => {
+  it("retries unavailable live PR freshness while suppressing terminal stale review output", async () => {
     const cases = [
       {
         pullNumber: 59,
         deliveryId: "unavailable-before-public-output",
         title: "Unavailable before publish",
-        freshness: classifyPullRequestFreshness(undefined, "oldsha"),
+        freshness: classifyPullRequestFreshness(undefined, "oldsha", {
+          unavailableSource: "pull_request_fetch",
+          unavailableDetail: "GitHub API failed for JSONbored/gittensory/pulls/59 (503)",
+        }),
+        expectRetry: true,
         expectedDetail: "live PR state could not be verified",
         expectedMetadata: {
           reason: "unavailable",
           expectedHeadSha: "oldsha",
           liveHeadSha: null,
           liveState: null,
+          unavailableSource: "pull_request_fetch",
+          unavailableDetail: "GitHub API failed for JSONbored/gittensory/pulls/59 (503)",
         },
       },
       {
@@ -6477,12 +6483,29 @@ describe("queue processors", () => {
           },
           "oldsha",
         ),
+        expectRetry: false,
         expectedDetail: "live PR head SHA could not be verified",
         expectedMetadata: {
           reason: "head_unresolved",
           expectedHeadSha: "oldsha",
           liveHeadSha: null,
           liveState: "open",
+        },
+      },
+      {
+        pullNumber: 61,
+        deliveryId: "unavailable-no-detail-before-public-output",
+        title: "Unavailable before publish without detail",
+        freshness: classifyPullRequestFreshness(undefined, "oldsha"),
+        expectRetry: true,
+        expectedDetail: "live PR state could not be verified",
+        expectedMetadata: {
+          reason: "unavailable",
+          expectedHeadSha: "oldsha",
+          liveHeadSha: null,
+          liveState: null,
+          unavailableSource: "unknown",
+          unavailableDetail: null,
         },
       },
     ] as const;
@@ -6523,7 +6546,7 @@ describe("queue processors", () => {
       });
       vi.mocked(fetchPullRequestFreshness).mockResolvedValue(scenario.freshness);
 
-      await processJob(env, {
+      const job = processJob(env, {
         type: "github-webhook",
         deliveryId: scenario.deliveryId,
         eventName: "pull_request",
@@ -6534,6 +6557,8 @@ describe("queue processors", () => {
           pull_request: { number: scenario.pullNumber, title: scenario.title, state: "open", user: { login: "contributor" }, head: { sha: "oldsha" }, labels: [], body: "Fixes #1" },
         },
       });
+      if (scenario.expectRetry) await expect(job).rejects.toThrow("live PR state unavailable");
+      else await expect(job).resolves.toBeUndefined();
 
       expect(commentPosts).toBe(0);
       const stale = await env.DB.prepare("select detail, metadata_json from audit_events where event_type = ?")


### PR DESCRIPTION
## Summary
- Retry review-publication jobs when live PR freshness cannot be verified instead of silently completing the job.
- Preserve terminal stale suppression for closed, changed-head, unresolved-head, and no-longer-draft PRs.
- Add source/detail metadata to stale-review audit rows so transient freshness failures are diagnosable.

## What changed
- Split live PR fetches into explicit ok/error results while preserving the existing optional wrapper behavior.
- Thread unavailable freshness source metadata through PR freshness classification and queue audits.
- Convert unavailable freshness at public-output time into a retryable queue error.

## Validation
- `git diff --check`
- `npm run typecheck -- --pretty false`
- `npx vitest run test/unit/pr-freshness.test.ts test/unit/fetch-live-pull-request.test.ts --silent`
- `npx vitest run test/unit/queue.test.ts --silent`
- `COVERAGE_NO_THRESHOLDS=1 npx vitest run --coverage test/unit/pr-freshness.test.ts test/unit/fetch-live-pull-request.test.ts test/unit/queue.test.ts --silent`
- Inspected targeted LCOV for changed runtime lines and branches.