### PR TITLE
feat(review): add config-gated 'review effort: N/5 (~M min)' line to the unified comment

### DIFF
--- a/apps/gittensory-ui/src/lib/selfhost-env-reference.ts
+++ b/apps/gittensory-ui/src/lib/selfhost-env-reference.ts
@@ -291,7 +291,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "PGPOOL_MAX",
-    firstReference: "src/selfhost/queue-common.ts:710",
+    firstReference: "src/selfhost/queue-common.ts:713",
   },
   {
     name: "PGVECTOR_ENABLED",
@@ -327,11 +327,11 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "QUEUE_DEAD_LETTER_AUTO_RETRY_MAX_EXTRA_ATTEMPTS",
-    firstReference: "src/selfhost/queue-common.ts:718",
+    firstReference: "src/selfhost/queue-common.ts:721",
   },
   {
     name: "QUEUE_STARTUP_JITTER_MIN_JOBS",
-    firstReference: "src/selfhost/queue-common.ts:699",
+    firstReference: "src/selfhost/queue-common.ts:702",
   },
   {
     name: "REDIS_URL",
@@ -457,7 +457,7 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| `OTEL_TRACES_EXPORTER` | `src/selfhost/otel.ts:40` |",
   "| `OTEL_TRACES_SAMPLER` | `src/selfhost/otel.ts:74` |",
   "| `OTEL_TRACES_SAMPLER_ARG` | `src/selfhost/otel.ts:76` |",
-  "| `PGPOOL_MAX` | `src/selfhost/queue-common.ts:710` |",
+  "| `PGPOOL_MAX` | `src/selfhost/queue-common.ts:713` |",
   "| `PGVECTOR_ENABLED` | `src/server.ts:229` |",
   "| `PORT` | `src/server.ts:715` |",
   "| `PUBLIC_API_ORIGIN` | `src/selfhost/preflight.ts:192` |",
@@ -466,8 +466,8 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| `QDRANT_URL` | `src/server.ts:527` |",
   "| `QUEUE_BACKGROUND_CONCURRENCY` | `src/selfhost/queue-common.ts:130` |",
   "| `QUEUE_CONCURRENCY` | `src/selfhost/pg-queue.ts:285` |",
-  "| `QUEUE_DEAD_LETTER_AUTO_RETRY_MAX_EXTRA_ATTEMPTS` | `src/selfhost/queue-common.ts:718` |",
-  "| `QUEUE_STARTUP_JITTER_MIN_JOBS` | `src/selfhost/queue-common.ts:699` |",
+  "| `QUEUE_DEAD_LETTER_AUTO_RETRY_MAX_EXTRA_ATTEMPTS` | `src/selfhost/queue-common.ts:721` |",
+  "| `QUEUE_STARTUP_JITTER_MIN_JOBS` | `src/selfhost/queue-common.ts:702` |",
   "| `REDIS_URL` | `src/selfhost/preflight.ts:144` |",
   "| `REVIEW_AUDIT_DIR` | `src/server.ts:572` |",
   "| `SELFHOST_BUNDLE_ALL` | `scripts/build-selfhost.mjs:13` |",

--- a/src/review/unified-comment.ts
+++ b/src/review/unified-comment.ts
@@ -166,6 +166,11 @@ export interface UnifiedReviewInput {
   consensusBlocker?: boolean;
   /** Reviewers that produced no parseable verdict (a partial review → held, not ready). */
   failedCount?: number;
+  /** Optional per-PR review-effort estimate (config-gated: `review.effort_score`, default off). Presence renders
+   *  a compact "review effort: N/5 (~M min)" chip; omission keeps the comment byte-identical. The caller computes
+   *  this from the estimator (src/review/review-effort.ts) and passes the OUTPUT — this module never imports the
+   *  estimator itself, staying self-contained. (#2069) */
+  reviewEffort?: { band: 1 | 2 | 3 | 4 | 5; minutes: number };
 }
 
 /** One row of the readiness signal table (gittensory side, host-provided; the engine adds Code review). */
@@ -323,6 +328,7 @@ function statusChips(input: UnifiedReviewInput, ctx: UnifiedCommentContext): str
     chips.push(ci === "passed" ? "`CI green`" : ci === "failed" ? "`CI failing`" : "`CI pending`");
     if (input.readiness.mergeStateLabel) chips.push(`\`${escapePublicHtmlAngles(input.readiness.mergeStateLabel)}\``);
   }
+  if (input.reviewEffort) chips.push(`\`review effort: ${input.reviewEffort.band}/5 (~${input.reviewEffort.minutes} min)\``);
   return chips.join(" · ");
 }
 
@@ -544,6 +550,9 @@ export function buildUnifiedReviewInput(opts: {
   decision?: Verdict;
   merged?: boolean;
   verdictReason?: string;
+  /** The estimator's OUTPUT (src/review/review-effort.ts estimateReviewEffort), already computed by the caller
+   *  and gated on `review.effort_score` — omit to keep the comment byte-identical. (#2069) */
+  reviewEffort?: { band: 1 | 2 | 3 | 4 | 5; minutes: number };
 }): UnifiedReviewInput {
   const ex = extractReviewSummary(opts.reviews);
   const changedFiles = typeof opts.changedFiles === "number" ? opts.changedFiles : opts.changedFiles.length;
@@ -560,6 +569,7 @@ export function buildUnifiedReviewInput(opts: {
     ...(opts.decision !== undefined ? { decision: opts.decision } : {}),
     ...(opts.merged !== undefined ? { merged: opts.merged } : {}),
     ...(opts.verdictReason !== undefined ? { verdictReason: opts.verdictReason } : {}),
+    ...(opts.reviewEffort !== undefined ? { reviewEffort: opts.reviewEffort } : {}),
   };
 }
 

--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -271,6 +271,11 @@ export type FocusManifestReviewConfig = {
    *  comments = byte-identical behavior. Operator-gated too (GITTENSORY_REVIEW_INLINE_COMMENTS + allowlist).
    *  (#inline-comments) */
   inlineComments: boolean | null;
+  /** `review.effort_score`: when true, the unified review comment ALSO renders a compact
+   *  "review effort: N/5 (~M min)" line from the deterministic per-PR effort estimator. null/false (default,
+   *  absent) = no effort line = byte-identical comment. Display-only — does not affect the AI reviewer prompt.
+   *  (#2069) */
+  effortScore: boolean | null;
   /** `review.path_instructions`: per-path natural-language guidance handed to the AI reviewer when the PR's
    *  changed files match the glob. Empty (default) ⇒ byte-identical reviewer prompt. (#review-path-instructions) */
   pathInstructions: ReviewPathInstruction[];
@@ -439,7 +444,7 @@ const EMPTY_MANIFEST: FocusManifest = {
   publicNotes: [],
   gate: { ...EMPTY_GATE_CONFIG },
   settings: {},
-  review: { present: false, footerText: null, note: null, fields: {}, enrichmentAnalyzers: {}, profile: null, securityFocus: null, inlineComments: null, pathInstructions: [], instructions: null, excludePaths: [], preMergeChecks: [] },
+  review: { present: false, footerText: null, note: null, fields: {}, enrichmentAnalyzers: {}, profile: null, securityFocus: null, inlineComments: null, effortScore: null, pathInstructions: [], instructions: null, excludePaths: [], preMergeChecks: [] },
   features: { ...EMPTY_FEATURES_CONFIG },
   contentLane: { ...EMPTY_CONTENT_LANE_CONFIG },
   warnings: [],
@@ -468,7 +473,7 @@ function emptyManifest(source: FocusManifestSource, warnings: string[] = []): Fo
     warnings,
     gate: { ...EMPTY_GATE_CONFIG },
     settings: {},
-    review: { present: false, footerText: null, note: null, fields: {}, enrichmentAnalyzers: {}, profile: null, securityFocus: null, inlineComments: null, pathInstructions: [], instructions: null, excludePaths: [], preMergeChecks: [] },
+    review: { present: false, footerText: null, note: null, fields: {}, enrichmentAnalyzers: {}, profile: null, securityFocus: null, inlineComments: null, effortScore: null, pathInstructions: [], instructions: null, excludePaths: [], preMergeChecks: [] },
     features: { ...EMPTY_FEATURES_CONFIG },
     contentLane: { ...EMPTY_CONTENT_LANE_CONFIG },
   };
@@ -1275,7 +1280,7 @@ function parsePublicSafeText(value: JsonValue | undefined, field: string, warnin
  * throws; invalid/unsafe values are dropped with warnings.
  */
 function parseReviewConfig(value: JsonValue | undefined, warnings: string[]): FocusManifestReviewConfig {
-  const empty: FocusManifestReviewConfig = { present: false, footerText: null, note: null, fields: {}, enrichmentAnalyzers: {}, profile: null, securityFocus: null, inlineComments: null, pathInstructions: [], instructions: null, excludePaths: [], preMergeChecks: [] };
+  const empty: FocusManifestReviewConfig = { present: false, footerText: null, note: null, fields: {}, enrichmentAnalyzers: {}, profile: null, securityFocus: null, inlineComments: null, effortScore: null, pathInstructions: [], instructions: null, excludePaths: [], preMergeChecks: [] };
   if (value === undefined || value === null) return empty;
   if (typeof value !== "object" || Array.isArray(value)) {
     warnings.push(`Manifest field "review" must be a mapping; ignoring it.`);
@@ -1311,6 +1316,7 @@ function parseReviewConfig(value: JsonValue | undefined, warnings: string[]): Fo
   const profile = parseReviewProfile(r.profile, warnings);
   const securityFocus = normalizeOptionalBoolean(r.security_focus, "review.security_focus", warnings);
   const inlineComments = normalizeOptionalBoolean(r.inline_comments, "review.inline_comments", warnings);
+  const effortScore = normalizeOptionalBoolean(r.effort_score, "review.effort_score", warnings);
   const pathInstructions = parseReviewPathInstructions(r.path_instructions, warnings);
   const instructions = parsePublicSafeText(r.instructions, "review.instructions", warnings);
   const excludePaths = parseReviewExcludePaths(r.exclude_paths, warnings);
@@ -1322,6 +1328,7 @@ function parseReviewConfig(value: JsonValue | undefined, warnings: string[]): Fo
       profile !== null ||
       securityFocus !== null ||
       inlineComments !== null ||
+      effortScore !== null ||
       pathInstructions.length > 0 ||
       instructions !== null ||
       excludePaths.length > 0 ||
@@ -1335,6 +1342,7 @@ function parseReviewConfig(value: JsonValue | undefined, warnings: string[]): Fo
     profile,
     securityFocus,
     inlineComments,
+    effortScore,
     pathInstructions,
     instructions,
     excludePaths,
@@ -1482,6 +1490,7 @@ export function reviewConfigToJson(review: FocusManifestReviewConfig): JsonValue
   if (review.profile !== null) out.profile = review.profile;
   if (review.securityFocus !== null) out.security_focus = review.securityFocus;
   if (review.inlineComments !== null) out.inline_comments = review.inlineComments;
+  if (review.effortScore !== null) out.effort_score = review.effortScore;
   if (review.instructions !== null) out.instructions = review.instructions;
   if (review.pathInstructions.length > 0) out.path_instructions = review.pathInstructions.map((entry) => ({ path: entry.path, instructions: entry.instructions }));
   if (review.excludePaths.length > 0) out.exclude_paths = [...review.excludePaths];
@@ -1532,6 +1541,14 @@ export function resolveReviewPromptOverrides(manifest: FocusManifest | null): { 
  *  than inline in the processor. (#review-pre-merge-checks) */
 export function resolveReviewPreMergeChecks(manifest: FocusManifest | null): PreMergeCheck[] {
   return manifest?.review.preMergeChecks ?? [];
+}
+
+/** Resolve `review.effort_score` to a strict boolean from a possibly-null manifest (null = load failure ⇒ off,
+ *  byte-identical comment). True ONLY when the manifest explicitly set review.effort_score: true. Centralized so
+ *  the future unified-comment caller reads it in one place with the null-manifest branch covered here
+ *  (unit-tested) rather than inline at the call site. (#2069) */
+export function resolveReviewEffortScoreEnabled(manifest: FocusManifest | null): boolean {
+  return manifest?.review.effortScore === true;
 }
 
 /** Resolve `review.enrichment` analyzer toggles from a possibly-null manifest (null = load failure ⇒ no toggles ⇒

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -15,6 +15,7 @@ import {
   excludeReviewPaths,
   resolveReviewPathInstructions,
   resolveReviewPreMergeChecks,
+  resolveReviewEffortScoreEnabled,
   composeRepoReviewContext,
   resolveReviewPromptOverrides,
   reviewConfigToJson,
@@ -514,7 +515,7 @@ describe("compileFocusManifestPolicy", () => {
       publicNotes: ["Keep PRs focused.", "Maximize your reward payout"],
       gate: { present: false, enabled: null, checkMode: null, pack: null, linkedIssue: null, duplicates: null, readinessMode: null, readinessMinScore: null, slopMode: null, slopMinScore: null, slopAiAdvisory: null, sizeMode: null, lockfileIntegrityMode: null, aiReviewMode: null, aiReviewByok: null, aiReviewProvider: null, aiReviewModel: null, aiReviewAllAuthors: null, aiReviewCloseConfidence: null, aiReviewCombine: null, aiReviewOnMerge: null, aiReviewReviewers: null, mergeReadiness: null, selfAuthoredLinkedIssue: null, manifestPolicy: null, dryRun: null, firstTimeContributorGrace: null, premergeContentRecheck: null, requireFreshRebaseWindowMinutes: null, claMode: null, claConsentPhrase: null, claCheckRunName: null, claCheckRunAppSlug: null, expectedCiContexts: null },
       settings: {},
-      review: { present: false, footerText: null, note: null, fields: {}, enrichmentAnalyzers: {}, profile: null, securityFocus: null, inlineComments: null, pathInstructions: [], instructions: null, excludePaths: [], preMergeChecks: [] },
+      review: { present: false, footerText: null, note: null, fields: {}, enrichmentAnalyzers: {}, profile: null, securityFocus: null, inlineComments: null, effortScore: null, pathInstructions: [], instructions: null, excludePaths: [], preMergeChecks: [] },
       features: { present: false, rag: null, reputation: null, unifiedComment: null, safety: null },
       contentLane: { present: false, entryFileGlob: null, providerFileGlob: null, artifactGlob: null, collectionField: null, maxAppendedEntries: null, duplicateKeyFields: [], validatorId: null },
       warnings: [],
@@ -2212,6 +2213,31 @@ describe("resolveReviewPathInstructions (#review-path-instructions)", () => {
     const bad = parseFocusManifest({ review: { inline_comments: "yes" } });
     expect(bad.review.inlineComments).toBeNull();
     expect(bad.warnings.some((w) => /review\.inline_comments.*must be a boolean/.test(w))).toBe(true);
+  });
+
+  it("parses review.effort_score (default OFF), marks present, round-trips, and warns on a non-boolean (#2069)", () => {
+    expect(parseFocusManifest({ review: { effort_score: true } }).review.effortScore).toBe(true);
+    const on = parseFocusManifest({ review: { effort_score: true } });
+    expect(on.review.present).toBe(true); // an effort-score-only manifest IS present
+    expect(parseFocusManifest({ review: reviewConfigToJson(on.review) }).review).toEqual(on.review); // survives round-trip
+    // Explicit false is retained (and marks present, since the maintainer set it).
+    const off = parseFocusManifest({ review: { effort_score: false } });
+    expect(off.review.effortScore).toBe(false);
+    expect(off.review.present).toBe(true);
+    // Absent ⇒ null (the byte-identical default), config not present.
+    expect(parseFocusManifest({ review: {} }).review.effortScore).toBeNull();
+    expect(parseFocusManifest({ review: {} }).review.present).toBe(false);
+    // A non-boolean is ignored with a warning.
+    const bad = parseFocusManifest({ review: { effort_score: "yes" } });
+    expect(bad.review.effortScore).toBeNull();
+    expect(bad.warnings.some((w) => /review\.effort_score.*must be a boolean/.test(w))).toBe(true);
+  });
+
+  it("resolveReviewEffortScoreEnabled: true only when the manifest explicitly set review.effort_score: true; null manifest → false (#2069)", () => {
+    expect(resolveReviewEffortScoreEnabled(parseFocusManifest({ review: { effort_score: true } }))).toBe(true);
+    expect(resolveReviewEffortScoreEnabled(parseFocusManifest({ review: { effort_score: false } }))).toBe(false);
+    expect(resolveReviewEffortScoreEnabled(parseFocusManifest({ review: {} }))).toBe(false);
+    expect(resolveReviewEffortScoreEnabled(null)).toBe(false);
   });
 });
 

--- a/test/unit/signals-coverage.test.ts
+++ b/test/unit/signals-coverage.test.ts
@@ -1127,7 +1127,7 @@ describe("signal coverage edge cases", () => {
       collisions: buildCollisionReport(directRepo.fullName, [], [currentPr]),
       preflight: buildPreflightResult({ repoFullName: directRepo.fullName, title: "Fix isolated issue", body: "Fixes #99", linkedIssues: [99] }, directRepo, [], [currentPr]),
       settings: gateSettings,
-      review: { present: true, footerText: "Reviewed by the Acme maintainer bot.", note: "Run npm test before pushing.", fields: { relatedWork: false }, enrichmentAnalyzers: {}, profile: null, securityFocus: null, inlineComments: null, pathInstructions: [], instructions: null, excludePaths: [], preMergeChecks: [] },
+      review: { present: true, footerText: "Reviewed by the Acme maintainer bot.", note: "Run npm test before pushing.", fields: { relatedWork: false }, enrichmentAnalyzers: {}, profile: null, securityFocus: null, inlineComments: null, effortScore: null, pathInstructions: [], instructions: null, excludePaths: [], preMergeChecks: [] },
       aiReview: { notes: "The change is focused.\n\n**Nits (2)**\n- Add a test for the </details> edge case.\n- Keep the validator helper scoped." },
     });
     expect(customizedComment).toContain("Reviewed by the Acme maintainer bot."); // custom footer lead

--- a/test/unit/unified-comment.test.ts
+++ b/test/unit/unified-comment.test.ts
@@ -154,6 +154,13 @@ describe("renderUnifiedReviewComment", () => {
     expect(md).toContain("Checked by Gittensory.");
   });
 
+  it("renders the compact review-effort chip only when input.reviewEffort is present — omitted keeps the comment byte-identical (#2069)", () => {
+    const withEffort = renderUnifiedReviewComment({ ...base, decision: "merge", reviewEffort: { band: 3, minutes: 15 } }, ctx);
+    expect(withEffort).toContain("`review effort: 3/5 (~15 min)`");
+    const withoutEffort = renderUnifiedReviewComment({ ...base, decision: "merge" }, ctx);
+    expect(withoutEffort).not.toContain("review effort:");
+  });
+
   it("does not describe a single reviewer as synthesized", () => {
     const md = renderUnifiedReviewComment({ ...base, reviewerCount: 1, decision: "manual", recommendations: ["manual_review"] }, ctx);
     expect(md).toContain("`1 AI reviewer`");
@@ -469,6 +476,13 @@ describe("buildUnifiedReviewInput", () => {
     expect(input.readiness).toEqual({ ciState: "passed" });
     expect(input.merged).toBe(true);
     expect(input.verdictReason).toBe("auto-merged after green CI");
+  });
+
+  it("threads the caller's reviewEffort estimator output through; omitted when absent (#2069)", () => {
+    const withEffort = buildUnifiedReviewInput({ changedFiles: 1, reviews: [reviewNote("merge")], reviewEffort: { band: 2, minutes: 8 } });
+    expect(withEffort.reviewEffort).toEqual({ band: 2, minutes: 8 });
+    const withoutEffort = buildUnifiedReviewInput({ changedFiles: 1, reviews: [reviewNote("merge")] });
+    expect(withoutEffort.reviewEffort).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

Adds a `review.effort_score` display toggle (default off) to `FocusManifestReviewConfig`, plus a `resolveReviewEffortScoreEnabled` accessor, mirroring the existing `security_focus`/`inline_comments` boolean-toggle pattern (parse in `parseReviewConfig`, included in `present`, serialized in `reviewConfigToJson`). Separately, `renderUnifiedReviewComment`/`buildUnifiedReviewInput` (`src/review/unified-comment.ts`) now accept an optional `reviewEffort: { band, minutes }` — the estimator's OUTPUT from the already-merged `estimateReviewEffort` (`src/review/review-effort.ts`) — and render it as a compact `` `review effort: N/5 (~M min)` `` status chip. Omitting the field (toggle off) keeps the comment byte-identical to today.

This is a fresh PR replacing #2968, which the gate auto-closed for a base conflict in the generated `apps/gittensory-ui/src/lib/selfhost-env-reference.ts` (this repo's `main` moves very fast, so that file drifts frequently); this branch is rebased onto current `main` with that file regenerated and no conflicts.

This is the same feature requested by GitHub issues 2152 and 2069 (both open at the time of this PR). **No issue is linked here intentionally**: issue 2152 is `maintainer-only` and assigned to the repo owner, so it is not eligible to be closed by a contributor PR (linking it would trip the linked-issue hard rule and auto-close this PR). Issue 2069 tracks the same request and remains open/unassigned; this PR does not claim to close it either — it is submitted standalone per `linkedIssuePolicy: preferred` (not required), with this paragraph as the explicit no-linked-issue rationale.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed. — see the Summary's no-linked-issue rationale above.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — the new `effortScore`/`reviewEffort` code paths (both toggle-on and toggle-off/omitted branches) are covered by new unit tests in `test/unit/focus-manifest.test.ts` and `test/unit/unified-comment.test.ts`.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — both the present/omitted render branches and the boolean/round-trip/warning parse branches are tested.

Ran the full local gate via `npm run test:ci` (chains all of the above plus `db:migrations:check`, `db:schema-drift:check`, `selfhost:env-reference:check`, `cf-typegen:check`, `rees:test`, `ui:test`) — green, immediately before opening this PR.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no auth/session/CORS surface touched.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — no public API/OpenAPI/MCP surface changes; `ui:openapi:check` passes unchanged.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section below... — N/A, no visible UI change (backend-only; the env-reference regeneration is a generated data file, not a visible UI change).
- [ ] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — N/A, no changelog edit in this normal PR.

## Notes

- The unified-comment renderer this PR extends (`src/review/unified-comment.ts` / `unified-comment-bridge.ts`) is currently additive and dormant (not yet wired into the live comment-posting path per its own header comment), consistent with how the sibling `review.*` toggles in this file were added ahead of the eventual cutover.