### PR TITLE
fix(review): derive repo-profile check publication from reviewCheckMode

### DIFF
--- a/src/review/repo-profile.ts
+++ b/src/review/repo-profile.ts
@@ -55,8 +55,10 @@ export type RepoProfileCommands = {
 };
 
 export type RepoProfileContributionWorkflow = {
-  /** Whether the review gate publishes a check at all (settings.gateCheckMode / checkRunMode), reusing the
-   *  EXISTING settings resolver rather than re-deriving gate presence from raw repo files. */
+  /** Whether the review gate publishes a check at all, derived from `settings.reviewCheckMode` -- the actual
+   *  runtime authority for check publication (#2852); `gateCheckMode`/`checkRunMode` are legacy fields kept
+   *  only for API/back-compat display and no longer drive this decision. Reuses the EXISTING settings
+   *  resolver rather than re-deriving gate presence from raw repo files. */
   gatePublishesCheck: boolean;
   linkedIssuePolicy: "required" | "preferred" | "optional";
   requireLinkedIssue: boolean;
@@ -206,7 +208,10 @@ function deriveCommandsFromPackageJson(packageJsonText: string | null): RepoProf
   const packageManagerField = typeof record.packageManager === "string" ? record.packageManager : null;
   const packageManagerMatch = packageManagerField ? /^(npm|yarn|pnpm|bun)@/.exec(packageManagerField) : null;
   const packageManager = (packageManagerMatch?.[1] as RepoProfilePackageManager | undefined) ?? null;
-  const scripts = record.scripts && typeof record.scripts === "object" ? (record.scripts as Record<string, unknown>) : {};
+  const scripts =
+    record.scripts && typeof record.scripts === "object" && !Array.isArray(record.scripts)
+      ? (record.scripts as Record<string, unknown>)
+      : {};
   const buildCommands: string[] = [];
   const testCommands: string[] = [];
   const lintCommands: string[] = [];
@@ -263,7 +268,7 @@ export async function extractRepoProfile(env: Env, repoFullName: string, options
     conventions: deriveConventions(paths),
     commands: deriveCommandsFromPackageJson(packageJsonText),
     contributionWorkflow: {
-      gatePublishesCheck: settings.gateCheckMode === "enabled" || settings.checkRunMode === "enabled",
+      gatePublishesCheck: settings.reviewCheckMode !== "disabled",
       linkedIssuePolicy: manifest.linkedIssuePolicy,
       requireLinkedIssue: settings.requireLinkedIssue,
       ciWorkflowFiles: deriveCiWorkflowFiles(paths),

--- a/test/unit/repo-profile.test.ts
+++ b/test/unit/repo-profile.test.ts
@@ -234,22 +234,54 @@ describe("extractRepoProfile (#2999)", () => {
     expect(profile.commands.testCommands).toEqual([]);
   });
 
-  it("reflects gatePublishesCheck true via checkRunMode even when gateCheckMode is off", async () => {
+  it("treats an array-valued scripts field as malformed rather than walking its indices", async () => {
     const env = createTestEnv({});
     await seedChunk(env, "src/widget.ts", "x");
-    await upsertRepositorySettings(env, { repoFullName: REPO, gateCheckMode: "off", checkRunMode: "enabled" });
+    await seedChunk(env, "package.json", JSON.stringify({ scripts: ["test", "build"] }));
+    const profile = await extractRepoProfile(env, REPO);
+    if (!profile.present) throw new Error("expected present profile");
+    expect(profile.commands).toEqual({ packageManager: null, buildCommands: [], testCommands: [], lintCommands: [] });
+  });
+
+  it("reflects gatePublishesCheck true when reviewCheckMode is required, regardless of legacy checkRunMode", async () => {
+    const env = createTestEnv({});
+    await seedChunk(env, "src/widget.ts", "x");
+    await upsertRepositorySettings(env, {
+      repoFullName: REPO,
+      gateCheckMode: "off",
+      checkRunMode: "off",
+      reviewCheckMode: "required",
+    });
     const profile = await extractRepoProfile(env, REPO);
     if (!profile.present) throw new Error("expected present profile");
     expect(profile.contributionWorkflow.gatePublishesCheck).toBe(true);
   });
 
-  it("reflects gatePublishesCheck false when both gateCheckMode and checkRunMode are off", async () => {
+  it("reflects gatePublishesCheck false when reviewCheckMode is disabled (#3039 regression)", async () => {
     const env = createTestEnv({});
     await seedChunk(env, "src/widget.ts", "x");
-    await upsertRepositorySettings(env, { repoFullName: REPO, gateCheckMode: "off", checkRunMode: "off" });
+    // Legacy checkRunMode says "enabled", but reviewCheckMode -- the actual runtime authority for check
+    // publication (#2852) -- says "disabled". gatePublishesCheck must follow reviewCheckMode, not the
+    // legacy back-compat-only field, or a repo that disabled the check via .gittensory.yml's
+    // gate.checkMode still gets reported as publishing one.
+    await upsertRepositorySettings(env, {
+      repoFullName: REPO,
+      gateCheckMode: "enabled",
+      checkRunMode: "enabled",
+      reviewCheckMode: "disabled",
+    });
     const profile = await extractRepoProfile(env, REPO);
     if (!profile.present) throw new Error("expected present profile");
     expect(profile.contributionWorkflow.gatePublishesCheck).toBe(false);
+  });
+
+  it("reflects gatePublishesCheck true when reviewCheckMode is visible", async () => {
+    const env = createTestEnv({});
+    await seedChunk(env, "src/widget.ts", "x");
+    await upsertRepositorySettings(env, { repoFullName: REPO, reviewCheckMode: "visible" });
+    const profile = await extractRepoProfile(env, REPO);
+    if (!profile.present) throw new Error("expected present profile");
+    expect(profile.contributionWorkflow.gatePublishesCheck).toBe(true);
   });
 
   it("defaults linkedIssuePolicy to optional when the repo has no manifest", async () => {


### PR DESCRIPTION
## Summary

- PR #3039 (merged) added `extractRepoProfile`'s `contributionWorkflow.gatePublishesCheck` field, but derived it from the legacy `gateCheckMode`/`checkRunMode` settings fields directly instead of `reviewCheckMode` — the actual runtime authority for whether the review check publishes (#2852). A repo with `reviewCheckMode: "disabled"` and a stale legacy `gateCheckMode: "enabled"` was reported as publishing a check it does not actually publish.
- Fixes the derivation to `settings.reviewCheckMode !== "disabled"`, matching the settings resolver's own authority.
- Replaced the two existing tests that encoded the old (buggy) legacy-field-only behavior with tests asserting the correct `reviewCheckMode`-driven behavior across all three of its values (`required`, `visible`, `disabled`), including the exact stale-legacy-field scenario described above.
- Also applied a cheap, related hardening nit from the same review: `deriveCommandsFromPackageJson`'s `scripts` parse now excludes array values (`typeof [] === "object"` in JS, so an array-valued `scripts` field previously slipped past the object check), with a regression test.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed. (No issue: a small, scoped correctness fix to PR #3039, found by that PR's own review and fixed same-day after it merged before the fix could land.)

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage`
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran typecheck plus the full targeted test file (`test/unit/repo-profile.test.ts`, 30/30 passing, confirmed 100% branch coverage on `src/review/repo-profile.ts` via `vitest run --coverage --coverage.include`) rather than the full suite, per this repo's convention of scoping local verification to the affected area for small fixes and letting CI verify the rest. Proved causality on both changes by reverting each fix and confirming its regression test fails, then restoring and confirming it passes.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session/CORS changes.)
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP changes; `extractRepoProfile` is not yet wired to a route.)
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes.)
- [ ] Visible UI changes include a `UI Evidence` section below with screenshots. (N/A — no visible UI changes.)
- [ ] Public docs/changelogs are updated where needed. (N/A — no docs/changelog changes.)