### PR TITLE
fix(miner): use precision-safe numeric comparison in the CLI update-check semver comparator

### DIFF
--- a/packages/gittensory-mcp/bin/gittensory-mcp.js
+++ b/packages/gittensory-mcp/bin/gittensory-mcp.js
@@ -3467,6 +3467,13 @@ function parseSemver(version) {
 // Compares two dot-separated semver prerelease strings per the semver spec:
 // numeric identifiers compare numerically, others lexically, numeric < non-numeric,
 // and a shorter set of identifiers has lower precedence when all earlier ones match.
+//
+// Numeric identifiers are compared as decimal strings, not via Number(), which loses precision beyond
+// Number.MAX_SAFE_INTEGER (2^53-1): two distinct digit strings past that width can round to the SAME float,
+// making Number(leftId) !== Number(rightId) wrongly report them as equal (mirrors the same fix already applied
+// to compareMcpSemver's comparePrerelease in src/services/mcp-compatibility.ts, #3049). With no leading zeros
+// (semver's own numeric-identifier rule), a longer digit string is the larger number, and equal-length strings
+// compare lexicographically.
 function comparePrerelease(a, b) {
   const left = a.split(".");
   const right = b.split(".");
@@ -3478,7 +3485,8 @@ function comparePrerelease(a, b) {
     const leftNumeric = /^\d+$/.test(leftId);
     const rightNumeric = /^\d+$/.test(rightId);
     if (leftNumeric && rightNumeric) {
-      if (Number(leftId) !== Number(rightId)) return Number(leftId) < Number(rightId) ? -1 : 1;
+      if (leftId.length !== rightId.length) return leftId.length < rightId.length ? -1 : 1;
+      if (leftId !== rightId) return leftId < rightId ? -1 : 1;
     } else if (leftNumeric !== rightNumeric) {
       return leftNumeric ? -1 : 1;
     } else if (leftId !== rightId) {

--- a/packages/gittensory-miner/lib/update-check.js
+++ b/packages/gittensory-miner/lib/update-check.js
@@ -58,6 +58,12 @@ function parseSemver(version) {
   };
 }
 
+// Numeric identifiers are compared as decimal strings, not via Number(), which loses precision beyond
+// Number.MAX_SAFE_INTEGER (2^53-1): two distinct digit strings past that width can round to the SAME float,
+// making Number(leftId) !== Number(rightId) wrongly report them as equal (mirrors the same fix already applied
+// to compareMcpSemver's comparePrerelease in src/services/mcp-compatibility.ts, #3049). With no leading zeros
+// (semver's own numeric-identifier rule), a longer digit string is the larger number, and equal-length strings
+// compare lexicographically.
 function comparePrerelease(a, b) {
   const left = a.split(".");
   const right = b.split(".");
@@ -69,8 +75,8 @@ function comparePrerelease(a, b) {
     const leftNumeric = /^\d+$/.test(leftId);
     const rightNumeric = /^\d+$/.test(rightId);
     if (leftNumeric && rightNumeric) {
-      if (Number(leftId) !== Number(rightId))
-        return Number(leftId) < Number(rightId) ? -1 : 1;
+      if (leftId.length !== rightId.length) return leftId.length < rightId.length ? -1 : 1;
+      if (leftId !== rightId) return leftId < rightId ? -1 : 1;
     } else if (leftNumeric !== rightNumeric) {
       return leftNumeric ? -1 : 1;
     } else if (leftId !== rightId) {

--- a/test/unit/miner-cli.test.ts
+++ b/test/unit/miner-cli.test.ts
@@ -162,6 +162,16 @@ describe("gittensory-miner startup update check (#2331)", () => {
     expect(compareSemver("0.6.0", "0.7.0-rc.1")).toBe(-1);
   });
 
+  it("REGRESSION: compares numeric prerelease identifiers as decimal strings, not via Number() (precision loss past 2^53-1)", () => {
+    // 9007199254740992 is 2^53 (Number.MAX_SAFE_INTEGER + 1); 9007199254740993 (2^53+1) cannot be represented
+    // exactly as a float64 and rounds DOWN to the same value, so Number(leftId) !== Number(rightId) would
+    // wrongly report these two distinct numeric identifiers as equal. Comparing as strings (length, then
+    // lexicographic) gets it right: the second is genuinely one greater than the first.
+    expect(compareSemver("0.1.0-9007199254740993", "0.1.0-9007199254740992")).toBe(1);
+    expect(compareSemver("0.1.0-9007199254740992", "0.1.0-9007199254740993")).toBe(-1);
+    expect(compareSemver("0.1.0-9007199254740992", "0.1.0-9007199254740992")).toBe(0);
+  });
+
   it("prints a one-line upgrade nudge when npm latest is newer", async () => {
     const registryUrl = await startRegistryFixture({ latestVersion: "9.9.9" });
     const stderr = vi


### PR DESCRIPTION
## Summary

`comparePrerelease` in both `packages/gittensory-miner/lib/update-check.js` and `packages/gittensory-mcp/bin/gittensory-mcp.js` (two independent, byte-identical copies used by each CLI's own npm-registry upgrade-nudge check) compares numeric semver prerelease identifiers via `Number(leftId) !== Number(rightId)`:

```js
if (leftNumeric && rightNumeric) {
  if (Number(leftId) !== Number(rightId)) return Number(leftId) < Number(rightId) ? -1 : 1;
}
```

`Number()` loses precision past `Number.MAX_SAFE_INTEGER` (2^53-1 = 9007199254740991). Two distinct digit strings past that width can round to the exact same float64 value — e.g. `"9007199254740993"` (2^53+1) is not representable and rounds down to `9007199254740992` (2^53), the same value `"9007199254740992"` itself produces. `Number(leftId) !== Number(rightId)` then reads `false`, so the comparator wrongly reports two genuinely different, orderable numeric identifiers as equal.

## Fix

Compare numeric identifiers as decimal strings instead: with no leading zeros (semver's own rule for numeric identifiers), a longer digit string is unconditionally the larger number, and equal-length strings compare lexicographically — never through `Number()`. Applied identically to both copies so the two CLIs' upgrade-nudge comparisons stay byte-identical, per the existing "mirrors gittensory-mcp" comments already in both files.

This is the exact same fix already applied to `compareMcpSemver`'s `comparePrerelease` in `src/services/mcp-compatibility.ts` in the recently-merged #3049 — that fix's own doc comment explicitly calls out avoiding `Number()` for this reason. These two CLI-package copies are separate, independent implementations (not touched by #3049, which only fixed the `src/services/` MCP-compatibility service) that had the identical latent gap.

## Why no linked issue

Small, self-evident, mechanical fix mirroring an already-merged sibling fix (#3049) in a different pair of files; this repo's `linkedIssuePolicy` is `preferred`, not required, for a change this scoped.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — see note below on `packages/**` scope.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This PR touches only `packages/**` (plus a `test/unit/miner-cli.test.ts` regression test), no `src/**` API/OpenAPI/UI surface, so `ui:openapi:check`, `ui:lint`, `ui:typecheck`, and `ui:build` are not applicable. Per `codecov.yml`, coverage is collected by vitest over `src/**` only — `packages/**` is outside the Codecov patch-coverage gate entirely — but I still added a real regression test (`test/unit/miner-cli.test.ts`, exercising `packages/gittensory-miner/lib/update-check.js`'s exported `compareSemver`) proving the exact precision bug and its fix, and ran the full `test/unit/miner-cli.test.ts` suite (23 tests) clean. `packages/gittensory-mcp/bin/gittensory-mcp.js` has no existing unit-test entry points for its internal (non-exported) `comparePrerelease`/`compareSemver` — consistent with the file's current test coverage, I verified it only via `npm run build:mcp` (`node --check`, syntax/build validity) plus a manual read-through confirming byte-parity with the now-fixed, tested `update-check.js` copy.
- `npm run build:miner` and `npm run build:mcp` both ran clean (`node --check` on every changed file).
- `npm run test:mcp-pack` hits a Windows-only `spawnSync("npm", ...)` resolution failure locally (no `shell: true`, `npm` resolves to `npm.cmd` on Windows) — unrelated to this diff, expected to run on the Linux CI runner.
- The full unsharded `test:coverage` suite could not be run clean in my local Windows dev environment for unrelated reasons: several test files depend on tooling not present there (Docker daemon, Python, `sentry-cli`), and generated-file "stale" checks (openapi.json, cf-typegen, selfhost-env-reference) false-positive on this checkout's CRLF line endings vs. the repo's LF convention — confirmed unrelated to this diff by reproducing them identically on a clean, unmodified `main`.
- `npm run actionlint`, `npm run typecheck`, `npm run test:workers`, and `npm audit` all ran clean.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no such changes.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no request/response schema changes; this is an internal CLI-only version comparator.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section below. — N/A, no UI changes.
- [ ] Public docs/changelogs are updated where needed. — N/A, no docs/changelog changes.

## UI Evidence

N/A — no UI/frontend/docs changes.

## Notes

- New regression test: "compares numeric prerelease identifiers as decimal strings, not via Number() (precision loss past 2^53-1)" in `test/unit/miner-cli.test.ts`.
