### PR TITLE
fix(signals): count not_modified merged-PR history as full coverage

### DIFF
--- a/src/signals/data-quality.ts
+++ b/src/signals/data-quality.ts
@@ -230,7 +230,16 @@ export function buildCoreSignalFidelity(
     const requiredSegments = repoSegments.filter((segment) => REQUIRED_OPEN_SEGMENTS.has(segment.segment));
     const historySegment = repoSegments.find((segment) => segment.segment === "recent_merged_pull_requests");
     if ((historySegment?.fetchedCount ?? 0) > 0) hasHistoricalSample = true;
-    if (!historySegment || !repoTotals || historySegment.status !== "complete" || historySegment.fetchedCount < repoTotals.mergedPullRequestsTotal) hasFullHistory = false;
+    // A `not_modified` (HTTP 304) merged-PR history segment is fully synced — its persisted rows are the
+    // complete history — so it counts as full history just like `complete`, mirroring isFreshSegmentStatus
+    // in backfill.ts. Treating only `complete` here wrongly downgrades an unchanged repo to "sampled".
+    if (
+      !historySegment ||
+      !repoTotals ||
+      (historySegment.status !== "complete" && historySegment.status !== "not_modified") ||
+      historySegment.fetchedCount < repoTotals.mergedPullRequestsTotal
+    )
+      hasFullHistory = false;
 
     const repoWaiting = requiredSegments.some((segment) => {
       const expected = expectedForRequiredSegment(segment, repoTotals);

--- a/test/unit/data-quality.test.ts
+++ b/test/unit/data-quality.test.ts
@@ -563,6 +563,22 @@ describe("sync data quality", () => {
     });
   });
 
+  it("counts a not_modified merged-PR history segment as full historical coverage", () => {
+    const segments = [
+      segment({ segment: "metadata", fetchedCount: 1, expectedCount: 1 }),
+      segment({ segment: "labels", fetchedCount: 2, expectedCount: 2 }),
+      segment({ segment: "open_issues", fetchedCount: 2911, expectedCount: 2911 }),
+      segment({ segment: "open_pull_requests", fetchedCount: 167, expectedCount: 167 }),
+      segment({ segment: "pull_request_files", fetchedCount: 167, expectedCount: 167 }),
+      segment({ segment: "pull_request_reviews", fetchedCount: 167, expectedCount: 167 }),
+      segment({ segment: "check_summaries", fetchedCount: 167, expectedCount: 167 }),
+      // A 304 re-sync: nothing new merged, so the persisted rows are the full merged-PR history.
+      segment({ segment: "recent_merged_pull_requests", status: "not_modified", fetchedCount: 6411, expectedCount: 6411 }),
+    ];
+
+    expect(buildCoreSignalFidelity(1, [repoState()], segments, [totals()], []).historyCoverage).toBe("full");
+  });
+
   it("keeps core fidelity complete when rate-limited required segments have last complete coverage", () => {
     const segments = [
       segment({ segment: "metadata", fetchedCount: 1, expectedCount: 1 }),


### PR DESCRIPTION
## Summary

`buildCoreSignalFidelity` in `src/signals/data-quality.ts` derives `historyCoverage` (`full` /
`sampled` / `counts_only`) for the merged-PR history. Its full-history check accepted only the segment
status `"complete"`:

```ts
if (!historySegment || !repoTotals || historySegment.status !== "complete" || historySegment.fetchedCount < repoTotals.mergedPullRequestsTotal) hasFullHistory = false;
```

But `"not_modified"` (an HTTP 304 re-sync — nothing new merged since the last full crawl) also represents
fully-synced history: `src/github/backfill.ts` sets that status on a 304 and recomputes `fetchedCount`
from the persisted rows to the full history count. Every other freshness check in the codebase already
treats the two the same — `isFreshSegmentStatus` (`backfill.ts`) is `status === "complete" || status ===
"not_modified"`, and `isTerminalSegmentStatus` includes both. This full-history check was the lone place
omitting `not_modified`.

Effect: any repo whose merged-PR history hadn't changed since the last sync (the common 304 case) was
wrongly downgraded from `historyCoverage: "full"` to `"sampled"` — an observable regression on the API
surface (`historyCoverage` is returned from the fidelity endpoints and is part of the OpenAPI enum).

Fix: accept `not_modified` alongside `complete`, mirroring `isFreshSegmentStatus`. The `fetchedCount <
mergedPullRequestsTotal` guard still applies, so a genuinely partial (`not_modified` but under-count)
segment stays `"sampled"`.

No linked issue: small, self-evident correctness fix that aligns one status check with the codebase's
existing `isFreshSegmentStatus` semantics; no public API shape, auth, schema, or deploy change (the
`historyCoverage` enum values are unchanged) — fits the repo's `preferred` (not required) linked-issue
policy.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran locally: `git diff --check` (clean), `npm run typecheck` (clean), and a focused `test:coverage`
  over `test/unit/data-quality.test.ts` — 34 tests pass and the changed condition is fully branch-covered
  (`complete` / `not_modified` / other status, and the `fetchedCount` comparison; the only uncovered lines
  in the file, 295 and 414, are pre-existing and outside this diff), so `codecov/patch` is 100% on this
  diff.
- Not run locally: the UI, MCP, workers, OpenAPI, actionlint, and audit jobs. This is a `src/`-only change
  to one deterministic signal builder touching no UI/API-shape/OpenAPI/MCP/DB/workflow surface, so those
  jobs are no-ops for this diff; they run on CI (Linux).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- The `historyCoverage` enum values are unchanged — this only corrects when `"full"` vs `"sampled"` is
  reported, so no OpenAPI/schema change is needed.
- Regression test added in `test/unit/data-quality.test.ts` ("counts a not_modified merged-PR history
  segment as full historical coverage"): a `recent_merged_pull_requests` segment with
  `status: "not_modified"` and a full `fetchedCount` now yields `historyCoverage: "full"` (was `"sampled"`).
  The existing `complete` → `full` and `sampled` → `sampled` assertions still hold.
