### PR TITLE
fix(review): report claudeMode as unknown, not a guessed symlink, when reusing an existing repo-doc PR

### DIFF
--- a/src/github/repo-doc-pr.ts
+++ b/src/github/repo-doc-pr.ts
@@ -19,7 +19,7 @@ const CLAUDE_FILE_PATH = "CLAUDE.md";
 const PR_TITLE = "docs: generate AGENTS.md and CLAUDE.md from repo profile";
 
 export type RepoDocPullRequestResult =
-  | { opened: true; reused: boolean; pullNumber: number; url: string; claudeMode: "symlink" | "copy" }
+  | { opened: true; reused: boolean; pullNumber: number; url: string; claudeMode: "symlink" | "copy" | "unknown" }
   | { opened: false; reason: string };
 
 // Non-throwing split (mirrors repo-profile.ts's splitRepoFullName, not pr-actions.ts's throwing splitRepo):
@@ -99,7 +99,12 @@ export async function openRepoDocPullRequest(env: Env, repoFullName: string, mod
 
       const existingOpenPrs = await octokit.request("GET /repos/{owner}/{repo}/pulls", { owner, repo, state: "open", head: `${owner}:${REPO_DOC_BRANCH_NAME}`, base: baseBranch });
       const existing = (existingOpenPrs.data as Array<{ number: number; html_url: string }>)[0];
-      if (existing) return { opened: true, reused: true, pullNumber: existing.number, url: existing.html_url, claudeMode: "symlink" };
+      // "unknown", not "symlink": this short-circuit deliberately avoids a further tree/contents lookup (the
+      // whole point of reusing the existing PR instead of rebuilding it), so there is no real signal here for
+      // whether ITS CLAUDE.md landed as a symlink or the copy fallback (buildRepoDocTree only reports that for
+      // a tree IT just built). Reporting "symlink" unconditionally would misrepresent every reused PR that
+      // actually fell back to a copy.
+      if (existing) return { opened: true, reused: true, pullNumber: existing.number, url: existing.html_url, claudeMode: "unknown" };
 
       const branchInfo = await octokit.request("GET /repos/{owner}/{repo}/branches/{branch}", { owner, repo, branch: baseBranch });
       const baseCommitSha = branchInfo.data.commit.sha;

--- a/test/unit/repo-doc-pr.test.ts
+++ b/test/unit/repo-doc-pr.test.ts
@@ -96,7 +96,10 @@ describe("openRepoDocPullRequest (#3000)", () => {
       return new Response("unexpected", { status: 500 });
     });
     const result = await openRepoDocPullRequest(env, REPO, "live");
-    expect(result).toEqual({ opened: true, reused: true, pullNumber: 7, url: "https://github.com/owner/widgets/pull/7", claudeMode: "symlink" });
+    // REGRESSION: claudeMode must be "unknown" here, not a guessed "symlink" — this short-circuit never looks
+    // at the existing PR's actual tree (that's the whole point of reusing it instead of rebuilding), so there
+    // is no real signal for whether that PR's CLAUDE.md landed as a symlink or the copy fallback.
+    expect(result).toEqual({ opened: true, reused: true, pullNumber: 7, url: "https://github.com/owner/widgets/pull/7", claudeMode: "unknown" });
     expect(calls.some((c) => c.url.includes("/git/trees"))).toBe(false);
   });
 


### PR DESCRIPTION
## Summary

`openRepoDocPullRequest` (`src/github/repo-doc-pr.ts`) generates `AGENTS.md`/`CLAUDE.md` from a repo profile and opens (or reuses) a PR carrying them. `CLAUDE.md` is delivered either as a real symlink to `AGENTS.md`, or — when the target repo/platform rejects a symlink tree entry — as a byte-identical regular-file copy (`buildRepoDocTree`'s documented fallback). The result type honestly reports which happened... except on the "already an open PR exists" short-circuit:

```ts
const existing = (existingOpenPrs.data as Array<{ number: number; html_url: string }>)[0];
if (existing) return { opened: true, reused: true, pullNumber: existing.number, url: existing.html_url, claudeMode: "symlink" };
```

This branch deliberately never rebuilds the tree or inspects the existing PR's files (that's the entire point of reusing it instead of doing the work again) — so there is no real signal for whether that PR's `CLAUDE.md` actually landed as a symlink or fell back to a copy. Hardcoding `"symlink"` here misreports every reused PR whose original run took the copy fallback.

The existing test for this path locked the wrong value in directly: `expect(result).toEqual({ ..., claudeMode: "symlink" })`.

## Fix

Extends `RepoDocPullRequestResult`'s `claudeMode` to `"symlink" | "copy" | "unknown"` and returns `"unknown"` on the reused-PR short-circuit, since this path genuinely has no signal for the real value without an extra API call it deliberately avoids. Updated the test that was asserting the guessed value to assert `"unknown"` instead.

Note: `openRepoDocPullRequest` isn't wired to a caller yet (found only in its own file and its own test suite) — this is a correctness fix in already-merged, not-yet-invoked code, ahead of it being wired up.

## Why no linked issue

Small, self-contained, single-function fix; the incorrect behavior is directly demonstrated by the test it corrects. This repo's `linkedIssuePolicy` is `preferred`, not required, for a change this scoped.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Backend-only change, no API/OpenAPI/UI surface touched, so `ui:openapi:check`, `ui:lint`, `ui:typecheck`, and `ui:build` are not applicable.
- `npm run test:coverage` was run scoped to `test/unit/repo-doc-pr.test.ts` (`--coverage.include` on `src/github/repo-doc-pr.ts`): 100% statement/branch/function/line coverage. Also ran `test/unit/repo-doc-pr.test.ts` + `test/unit/repo-doc-render.test.ts` + `test/unit/repo-profile.test.ts` together (62 tests) clean. The full unsharded suite could not be run clean in my local Windows dev environment for unrelated reasons: several test files depend on tooling not present there (Docker daemon, Python, `sentry-cli`), and generated-file "stale" checks (openapi.json, cf-typegen, selfhost-env-reference) false-positive on this checkout's CRLF line endings vs. the repo's LF convention — confirmed unrelated to this diff on a clean, unmodified `main`.
- `npm run test:mcp-pack` hits a Windows-only `spawnSync("npm", ...)` resolution failure locally (no `shell: true`, `npm` resolves to `npm.cmd` on Windows) — unrelated to this diff, expected to run on the Linux CI runner.
- `npm run actionlint`, `npm run typecheck`, `npm run test:workers`, `npm run build:mcp`, and `npm audit` all ran clean.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no such changes.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, `RepoDocPullRequestResult` is an internal type with no external caller yet.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section below. — N/A, no UI changes.
- [ ] Public docs/changelogs are updated where needed. — N/A, no docs/changelog changes.

## UI Evidence

N/A — no UI/frontend/docs changes.

## Notes

- Corrected an existing test that was asserting the buggy hardcoded value directly (`test/unit/repo-doc-pr.test.ts`, "returns the already-open PR without creating a new branch/commit").
