### PR TITLE
fix(miner): fail closed on corrupted governor ledger rows on read

### DIFF
--- a/packages/gittensory-miner/lib/governor-ledger.js
+++ b/packages/gittensory-miner/lib/governor-ledger.js
@@ -43,6 +43,15 @@ function normalizeOptionalRepoFullName(repoFullName) {
 }
 
 function rowToEntry(row) {
+  let payload;
+  try {
+    payload = JSON.parse(row.payload_json);
+    if (payload === null || typeof payload !== "object" || Array.isArray(payload)) {
+      throw new Error("corrupted_governor_row");
+    }
+  } catch {
+    throw new Error("corrupted_governor_row");
+  }
   return {
     id: row.id,
     ts: row.ts,
@@ -51,7 +60,7 @@ function rowToEntry(row) {
     actionClass: row.action_class,
     decision: row.decision,
     reason: row.reason,
-    payload: JSON.parse(row.payload_json),
+    payload,
   };
 }
 

--- a/test/unit/miner-governor-ledger.test.ts
+++ b/test/unit/miner-governor-ledger.test.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@jsonbored/gittensory-engine", async () => {
@@ -100,6 +101,20 @@ describe("gittensory-miner governor ledger (#2328)", () => {
     expect(() => ledger.readGovernorEvents({ repoFullName: 42 as unknown as string })).toThrow(
       /invalid_repo_full_name/,
     );
+  });
+
+  it("rejects a corrupted payload blob on read instead of returning malformed data", () => {
+    const ledger = tempLedger();
+    ledger.appendGovernorEvent({
+      eventType: "allowed",
+      actionClass: "analyze",
+      decision: "allow",
+      reason: "ok",
+    });
+    const raw = new DatabaseSync(ledger.dbPath);
+    raw.prepare("UPDATE governor_events SET payload_json = ? WHERE id = 1").run("{bad");
+    raw.close();
+    expect(() => ledger.readGovernorEvents()).toThrow("corrupted_governor_row");
   });
 
   it("records throttled and kill_switch outcomes for later audit", () => {


### PR DESCRIPTION
## Summary

- Fail closed when reading governor ledger rows whose stored `payload_json` is no longer valid JSON or object-shaped.
- Matches the plan store's `corrupted_plan_row` contract so audit polling cannot crash on a single bad SQLite row.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] Focused on governor-ledger read-path validation only — no unrelated miner CLI or UI changes.

## Validation

- [ ] `npm run test:ci` locally — CI will run the full gate on push.
- [x] Unit test covers corrupted `payload_json` rejection on read.

## Safety

- [x] No secrets, wallet details, hotkeys, or private scoring output in code or PR text.
- [x] Deterministic, read/write-local only: no network calls.

## UI Evidence

Not applicable — miner library only.

## Notes

Follow-up hardening for the foundation governor ledger (#2328), mirroring plan-store corrupted-row handling (#2318).
