### PR TITLE
fix(api): gate app overview fleet metrics behind maintainer roles

### DIFF
--- a/apps/gittensory-ui/public/openapi.json
+++ b/apps/gittensory-ui/public/openapi.json
@@ -15187,6 +15187,9 @@
           },
           "401": {
             "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient role"
           }
         },
         "security": [

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -1146,6 +1146,8 @@ export function createApp() {
   });
 
   app.get("/v1/app/overview", async (c) => {
+    const forbidden = await requireAppRole(c, ["maintainer", "owner", "operator"]);
+    if (forbidden) return forbidden;
     const identity = await authenticateRequestIdentity(c);
     const login = identity?.kind === "session" ? identity.actor : undefined;
     const [repositories, installations, health, registry, scoring, upstreamDrift, rateLimits, runs, roleSummary] = await Promise.all([

--- a/src/openapi/spec.ts
+++ b/src/openapi/spec.ts
@@ -713,6 +713,7 @@ export function buildOpenApiSpec() {
     responses: {
       200: { description: "Live app overview assembled from backend data", content: { "application/json": { schema: z.record(z.string(), z.unknown()) } } },
       401: { description: "Unauthorized" },
+      403: { description: "Insufficient role" },
     },
   });
   for (const path of [

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -2199,8 +2199,8 @@ describe("api routes", () => {
     });
     expect(JSON.stringify(unknownSessionBody)).not.toMatch(/wallet|hotkey|raw trust|payout|reward estimate|farming|private reviewability|public score estimate|\/Users|github_pat|ghp_/i);
     const unknownOverview = await app.request("/v1/app/overview", { headers: unknownHeaders }, unknownEnv);
-    expect(unknownOverview.status).toBe(200);
-    await expect(unknownOverview.json()).resolves.toMatchObject({ roleSummary: { roles: [], onboarding: { status: "needs_setup" } } });
+    expect(unknownOverview.status).toBe(403);
+    await expect(unknownOverview.json()).resolves.toMatchObject({ error: "insufficient_role" });
     expect((await app.request("/v1/app/operator-dashboard", { headers: unknownHeaders }, unknownEnv)).status).toBe(403);
     expect((await app.request("/v1/app/maintainer-dashboard", { headers: unknownHeaders }, unknownEnv)).status).toBe(403);
     expect((await app.request("/v1/app/commands/usefulness", { headers: unknownHeaders }, unknownEnv)).status).toBe(403);


### PR DESCRIPTION
## Summary

`/v1/app/overview` assembled fleet-wide control-panel metrics (registered/installed repo counts, registry and scoring snapshots, upstream drift, GitHub rate-limit observations) for any authenticated OAuth session. Users with `roles: []` and `onboarding.status: needs_setup` received HTTP 200 with that data, while sibling routes such as `/v1/app/maintainer-dashboard`, `/v1/app/operator-dashboard`, and `/v1/app/digest` already returned 403.

This PR adds the same `requireAppRole(c, ["maintainer", "owner", "operator"])` guard used by `/v1/app/digest` before loading fleet data. Static service tokens (`api` / `internal`) continue to pass through unchanged; extension-scoped tokens remain blocked by existing middleware.

## Changed files

| File | Change |
| ---- | ------ |
| `src/api/routes.ts` | Call `requireAppRole` at the top of the `/v1/app/overview` handler. |
| `test/integration/api.test.ts` | Expect 403 + `insufficient_role` for a signed-in login with no roles (was 200). |
| `src/openapi/spec.ts` | Document 403 response on overview. |
| `apps/gittensory-ui/public/openapi.json` | Regenerated via `npm run ui:openapi`. |

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` (full unsharded run — required before push for `codecov/patch`)
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has integration tests for the 403 negative path

Locally verified:

- [x] `npm run test -- test/integration/api.test.ts` (41 passed)
- [x] `npm run ui:openapi:check`
- [x] `npm run typecheck`

Run before push:

```sh
npm run test:ci
npm run test:coverage   # unsharded — confirm codecov/patch ≥99% on src/api/routes.ts diff
```

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth change includes negative-path test (403 for role-less session).
- [x] API/OpenAPI behavior is updated where needed.
- [x] UI already renders overview errors as empty/error states (`app.index.tsx`); no UI code change required.
- [ ] Visible UI changes include a `UI Evidence` section — N/A (API-only auth tightening).
- [x] Public docs/changelogs are not edited (normal PR).

## UI Evidence

N/A — API auth guard only. The control-panel overview page already shows “App overview is unavailable” when the API returns an error; users with no roles still see session role cards and onboarding from `/v1/auth/session`.

## Test plan

- [x] Role-less session (`roles: []`) → `/v1/app/overview` returns 403 `insufficient_role`
- [x] Operator session (`oktofeesh1`) → overview still returns 200 with metrics
- [x] Static API token → overview still returns 200 (unchanged)
- [x] Extension token → overview still returns 403 `insufficient_scope` (unchanged)
- [ ] Full `npm run test:ci` green before push

## Notes

Analogue: `/v1/app/digest` (`routes.ts:1712–1714`) uses the same role set before loading fleet-wide repository, installation, and rate-limit data.

Confirmed miners (`roles: ["miner"]` only) will also receive 403 on overview. That is intentional — the payload includes deployment-wide repo/install counts, not contributor-scoped data. Miners still use `/v1/app/miner-dashboard` and `/v1/auth/session` for self-scoped surfaces.
