### PR TITLE
fix(enrichment): ignore no-newline marker in IaC misconfig line numbers

### DIFF
--- a/review-enrichment/src/analyzers/iac-misconfig.ts
+++ b/review-enrichment/src/analyzers/iac-misconfig.ts
@@ -96,7 +96,10 @@ export function scanPatchForIacMisconfig(
     // Skip pre-hunk preamble; inside a hunk `+++x`/`+++ x` is added content, not a header.
     if (!inHunk) continue;
     if (!line.startsWith("+")) {
-      if (!line.startsWith("-")) newLine++;
+      // A `\ No newline at end of file` marker is not a content line, so it must not advance the
+      // new-file line counter — otherwise every finding after it is reported one line too high. Mirrors
+      // the sibling analyzers (e.g. undocumented-export.ts) that already skip `\`-prefixed markers.
+      if (!line.startsWith("-") && !line.startsWith("\\")) newLine++;
       continue;
     }
 

--- a/review-enrichment/test/iac-misconfig.test.ts
+++ b/review-enrichment/test/iac-misconfig.test.ts
@@ -151,3 +151,23 @@ test("scanPatchForIacMisconfig aborts when the signal is aborted", () => {
     /analyzer_aborted/,
   );
 });
+
+test("scanPatchForIacMisconfig keeps line numbers correct across a no-newline marker", () => {
+  // A dotenv file with no trailing newline (very common) gets a `\ No newline at end of file` marker
+  // mid-hunk. The marker must not shift the new-file line counter, so NODE_TLS_REJECT_UNAUTHORIZED=0 is
+  // reported at line 2, not line 3.
+  const findings = scanPatchForIacMisconfig(
+    ".env.production",
+    [
+      "@@ -1,1 +1,2 @@",
+      "-FOO=bar",
+      "\\ No newline at end of file",
+      "+FOO=bar",
+      "+NODE_TLS_REJECT_UNAUTHORIZED=0",
+      "\\ No newline at end of file",
+    ].join("\n"),
+  );
+  assert.deepEqual(findings, [
+    { file: ".env.production", line: 2, kind: "tls-verification-disabled" },
+  ]);
+});


### PR DESCRIPTION
## Summary

`scanPatchForIacMisconfig` in `review-enrichment/src/analyzers/iac-misconfig.ts` walks a unified diff and
tracks the new-file line number so each misconfig finding reports where it lives. Its line-advance guard
skipped only `+` (added) and `-` (removed) prefixes:

```ts
if (!line.startsWith("+")) {
  if (!line.startsWith("-")) newLine++;
  continue;
}
```

A unified diff can also contain the marker line `\ No newline at end of file`, which starts with `\` —
neither `+` nor `-` — so it fell through and **incremented `newLine`**, treating the marker as a real
content line. Every finding after that marker was then reported **one line too high**.

This is reachable and observable: `scanIacMisconfig` feeds real GitHub `file.patch` strings, and files
without a trailing newline (very common for `.env`/dotenv config — the canonical home of the TLS/CORS
misconfig this analyzer flags) emit the marker mid-hunk. For example, adding
`NODE_TLS_REJECT_UNAUTHORIZED=0` to the end of a no-trailing-newline `.env.production` reported the finding
at line 3 instead of line 2.

Fix: also skip `\`-prefixed marker lines when advancing the counter. This is safe because in a unified
diff every real content line is prefixed by ` `, `+`, or `-` (added `\…` content renders as `+\…`,
context as ` \…`, removed as `-\…`, all handled by the other branches), so a raw leading `\` is
unambiguously the marker. The change mirrors sibling analyzers that already handle it — e.g.
`undocumented-export.ts` (`!raw.startsWith("-") && !raw.startsWith("\\")`), `heavy-dependency.ts`,
`duplication-scan.ts`, and `doc-comment-drift.ts`.

No linked issue: small, self-evident correctness fix aligning one analyzer with the established
no-newline-marker handling the sibling analyzers already use; no schema, config, or deploy change — fits
the repo's `preferred` (not required) linked-issue policy.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run typecheck`
- [x] `npm run rees:test` — the review-enrichment build + analyzer suite (see note below)
- [ ] `npm run test:coverage` (N/A — this file is in `review-enrichment/`, outside the `src/**` Codecov scope)
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran locally: `git diff --check` (clean), the review-enrichment TypeScript build (`npm --prefix
  review-enrichment run build`, clean), and the analyzer test suite via `node --test` — **8/8
  `iac-misconfig` tests pass**, including the new no-newline-marker regression. The change is confined to
  `review-enrichment/`, which is outside the `src/**` Codecov scope, so `test:coverage` does not apply.
- Not run locally: the UI, root typecheck, and `metadata:check` step of `rees:test`. `metadata:check`
  compares the committed `analyzer-metadata.json` (generated on CI/Linux) against a local regeneration and
  reports a spurious byte difference on this Windows dev box (it fails identically on unmodified `main`);
  this change touches only the analyzer's diff-walking logic, not its declared metadata (id/kinds/severity/
  description), so the committed metadata is unchanged and `metadata:check` passes on CI (Linux). The
  `analyzer-metadata.json` was deliberately NOT modified.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Analyzer output shape is unchanged — only the `line` number of findings that follow a `\ No newline`
  marker is corrected. `analyzer-metadata.json` is intentionally untouched (the fix does not change any
  analyzer descriptor).
- Regression test added in `review-enrichment/test/iac-misconfig.test.ts` ("keeps line numbers correct
  across a no-newline marker"): a no-trailing-newline `.env.production` patch that adds
  `NODE_TLS_REJECT_UNAUTHORIZED=0` after a `\ No newline at end of file` marker now reports the finding at
  `line: 2` (was `line: 3`). All 7 existing `iac-misconfig` tests still pass.
