### PR TITLE
fix(review): tighten reward labels and linked issue gates

### DIFF
--- a/apps/gittensory-ui/public/openapi.json
+++ b/apps/gittensory-ui/public/openapi.json
@@ -9101,6 +9101,73 @@
           "pendingClosureLabel": {
             "type": "string",
             "nullable": true
+          },
+          "linkedIssueHardRules": {
+            "type": "object",
+            "properties": {
+              "ownerAssignedClose": {
+                "type": "string",
+                "enum": [
+                  "block",
+                  "off"
+                ]
+              },
+              "assignedIssueClose": {
+                "type": "string",
+                "enum": [
+                  "block",
+                  "off"
+                ]
+              },
+              "missingPointLabelClose": {
+                "type": "string",
+                "enum": [
+                  "block",
+                  "off"
+                ]
+              },
+              "maintainerOnlyLabelClose": {
+                "type": "string",
+                "enum": [
+                  "block",
+                  "off"
+                ]
+              },
+              "pointBearingLabels": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "maintainerOnlyLabels": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "defaultLabelRepo": {
+                "type": "boolean"
+              },
+              "verifyBeforeClose": {
+                "type": "boolean"
+              },
+              "closeDelaySeconds": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 300
+              }
+            },
+            "required": [
+              "ownerAssignedClose",
+              "assignedIssueClose",
+              "missingPointLabelClose",
+              "maintainerOnlyLabelClose",
+              "pointBearingLabels",
+              "maintainerOnlyLabels",
+              "defaultLabelRepo",
+              "verifyBeforeClose",
+              "closeDelaySeconds"
+            ]
           }
         },
         "required": [

--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -167,6 +167,7 @@ import { DEFAULT_GLOBAL_MODERATION_CONFIG, MAX_MODERATION_VIOLATION_DECAY_DAYS, 
 import { normalizeAutonomyPolicy, normalizeAutoMaintainPolicy, DEFAULT_AUTO_MAINTAIN_POLICY } from "../settings/autonomy";
 import { DEFAULT_TYPE_LABELS, normalizeTypeLabelSet } from "../settings/pr-type-label";
 import { DEFAULT_LINKED_ISSUE_LABEL_PROPAGATION, normalizeLinkedIssueLabelPropagationConfig } from "../review/linked-issue-label-propagation";
+import { DEFAULT_LINKED_ISSUE_HARD_RULES } from "../review/linked-issue-hard-rules-config";
 import { decryptSecret, encryptSecret, sha256Hex } from "../utils/crypto";
 import { errorMessage, jsonString, nowIso, parseJson, repoParts } from "../utils/json";
 import { PUBLIC_LOCAL_PATH_SCRUB_PATTERN } from "../signals/redaction";
@@ -501,6 +502,7 @@ export async function getRepositorySettings(env: Env, fullName: string): Promise
       typeLabelsEnabled: true,
       typeLabels: { ...DEFAULT_TYPE_LABELS },
       linkedIssueLabelPropagation: { ...DEFAULT_LINKED_ISSUE_LABEL_PROPAGATION, mappings: [] },
+      linkedIssueHardRules: { ...DEFAULT_LINKED_ISSUE_HARD_RULES, pointBearingLabels: [], maintainerOnlyLabels: [] },
       gittensorLabel: "gittensor",
       blacklistLabel: "slop",
       createMissingLabel: true,
@@ -570,6 +572,7 @@ export async function getRepositorySettings(env: Env, fullName: string): Promise
     typeLabelsEnabled: row.typeLabelsEnabled,
     typeLabels: parseTypeLabelSet(row.typeLabelsJson),
     linkedIssueLabelPropagation: parseLinkedIssueLabelPropagationConfig(row.linkedIssueLabelPropagationJson),
+    linkedIssueHardRules: { ...DEFAULT_LINKED_ISSUE_HARD_RULES, pointBearingLabels: [], maintainerOnlyLabels: [] },
     gittensorLabel: row.gittensorLabel,
     blacklistLabel: row.blacklistLabel,
     createMissingLabel: row.createMissingLabel,

--- a/src/openapi/schemas.ts
+++ b/src/openapi/schemas.ts
@@ -636,6 +636,19 @@ export const RepositorySettingsSchema = z
         mappings: z.array(z.object({ issueLabel: z.string(), prLabel: z.string(), removeOtherTypeLabels: z.boolean() })),
       })
       .optional(),
+    linkedIssueHardRules: z
+      .object({
+        ownerAssignedClose: z.enum(["block", "off"]),
+        assignedIssueClose: z.enum(["block", "off"]),
+        missingPointLabelClose: z.enum(["block", "off"]),
+        maintainerOnlyLabelClose: z.enum(["block", "off"]),
+        pointBearingLabels: z.array(z.string()),
+        maintainerOnlyLabels: z.array(z.string()),
+        defaultLabelRepo: z.boolean(),
+        verifyBeforeClose: z.boolean(),
+        closeDelaySeconds: z.number().int().min(0).max(300),
+      })
+      .optional(),
     gittensorLabel: z.string(),
     blacklistLabel: z.string().nullable(),
     createMissingLabel: z.boolean(),

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -2334,6 +2334,7 @@ async function runAgentMaintenancePlanAndExecute(
     body: pr.body,
     linkedIssues: pr.linkedIssues,
     ciToken,
+    prAuthorLogin: pr.authorLogin,
     installationId,
   });
 
@@ -6962,7 +6963,6 @@ async function maybePublishPrPublicSurface(
               repoFullName,
               linkedIssues: pr.linkedIssues,
               installationId,
-              prAuthorLogin: pr.authorLogin,
             })
           : [];
       const decisionResult = resolvePrTypeLabel({

--- a/src/review/linked-issue-hard-rules-config.ts
+++ b/src/review/linked-issue-hard-rules-config.ts
@@ -1,0 +1,85 @@
+import type { LinkedIssueHardRulesConfig, LinkedIssueHardRulesMode } from "../types";
+
+const VALID_LINKED_ISSUE_HARD_RULE_MODES: readonly LinkedIssueHardRulesMode[] = ["block", "off"];
+const DEFAULT_CLOSE_DELAY_SECONDS = 30;
+const MAX_CLOSE_DELAY_SECONDS = 300;
+
+export const DEFAULT_LINKED_ISSUE_HARD_RULES: LinkedIssueHardRulesConfig = {
+  ownerAssignedClose: "off",
+  assignedIssueClose: "off",
+  missingPointLabelClose: "off",
+  maintainerOnlyLabelClose: "off",
+  pointBearingLabels: [],
+  maintainerOnlyLabels: [],
+  defaultLabelRepo: false,
+  verifyBeforeClose: true,
+  closeDelaySeconds: DEFAULT_CLOSE_DELAY_SECONDS,
+};
+
+export function isLinkedIssueHardRuleMode(value: unknown): value is LinkedIssueHardRulesMode {
+  return typeof value === "string" && (VALID_LINKED_ISSUE_HARD_RULE_MODES as readonly string[]).includes(value);
+}
+
+function normalizeStringList(value: unknown, field: string, warnings: string[]): string[] {
+  if (value === undefined) return [];
+  if (!Array.isArray(value)) {
+    warnings.push(`settings.linkedIssueHardRules.${field} must be an array; using no labels.`);
+    return [];
+  }
+  const labels: string[] = [];
+  for (const [index, item] of value.entries()) {
+    if (typeof item !== "string" || item.trim().length === 0) {
+      warnings.push(`settings.linkedIssueHardRules.${field}[${index}] must be a non-empty string; ignoring it.`);
+      continue;
+    }
+    labels.push(item.trim());
+  }
+  return labels;
+}
+
+function normalizeMode(
+  value: unknown,
+  field: "ownerAssignedClose" | "assignedIssueClose" | "missingPointLabelClose" | "maintainerOnlyLabelClose",
+  warnings: string[],
+): LinkedIssueHardRulesMode {
+  if (value === undefined) return DEFAULT_LINKED_ISSUE_HARD_RULES[field];
+  if (isLinkedIssueHardRuleMode(value)) return value;
+  warnings.push(`settings.linkedIssueHardRules.${field} must be one of block, off; using the default "${DEFAULT_LINKED_ISSUE_HARD_RULES[field]}".`);
+  return DEFAULT_LINKED_ISSUE_HARD_RULES[field];
+}
+
+function normalizeBoolean(value: unknown, field: "defaultLabelRepo" | "verifyBeforeClose", warnings: string[]): boolean {
+  if (value === undefined) return DEFAULT_LINKED_ISSUE_HARD_RULES[field];
+  if (typeof value === "boolean") return value;
+  warnings.push(`settings.linkedIssueHardRules.${field} must be a boolean; using the default "${DEFAULT_LINKED_ISSUE_HARD_RULES[field]}".`);
+  return DEFAULT_LINKED_ISSUE_HARD_RULES[field];
+}
+
+function normalizeCloseDelaySeconds(value: unknown, warnings: string[]): number {
+  if (value === undefined) return DEFAULT_LINKED_ISSUE_HARD_RULES.closeDelaySeconds;
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    warnings.push(`settings.linkedIssueHardRules.closeDelaySeconds must be a non-negative number; using the default "${DEFAULT_CLOSE_DELAY_SECONDS}".`);
+    return DEFAULT_CLOSE_DELAY_SECONDS;
+  }
+  return Math.min(MAX_CLOSE_DELAY_SECONDS, Math.floor(value));
+}
+
+export function normalizeLinkedIssueHardRulesConfig(input: unknown, warnings: string[]): LinkedIssueHardRulesConfig {
+  if (input === undefined) return { ...DEFAULT_LINKED_ISSUE_HARD_RULES, pointBearingLabels: [], maintainerOnlyLabels: [] };
+  if (typeof input !== "object" || input === null || Array.isArray(input)) {
+    warnings.push("settings.linkedIssueHardRules must be an object; using the default all-off policy.");
+    return { ...DEFAULT_LINKED_ISSUE_HARD_RULES, pointBearingLabels: [], maintainerOnlyLabels: [] };
+  }
+  const record = input as Record<string, unknown>;
+  return {
+    ownerAssignedClose: normalizeMode(record.ownerAssignedClose, "ownerAssignedClose", warnings),
+    assignedIssueClose: normalizeMode(record.assignedIssueClose, "assignedIssueClose", warnings),
+    missingPointLabelClose: normalizeMode(record.missingPointLabelClose, "missingPointLabelClose", warnings),
+    maintainerOnlyLabelClose: normalizeMode(record.maintainerOnlyLabelClose, "maintainerOnlyLabelClose", warnings),
+    pointBearingLabels: normalizeStringList(record.pointBearingLabels, "pointBearingLabels", warnings),
+    maintainerOnlyLabels: normalizeStringList(record.maintainerOnlyLabels, "maintainerOnlyLabels", warnings),
+    defaultLabelRepo: normalizeBoolean(record.defaultLabelRepo, "defaultLabelRepo", warnings),
+    verifyBeforeClose: normalizeBoolean(record.verifyBeforeClose, "verifyBeforeClose", warnings),
+    closeDelaySeconds: normalizeCloseDelaySeconds(record.closeDelaySeconds, warnings),
+  };
+}

--- a/src/review/linked-issue-hard-rules.ts
+++ b/src/review/linked-issue-hard-rules.ts
@@ -1,75 +1,37 @@
 import { fetchLinkedIssueFacts } from "../github/backfill";
 import { githubRateLimitAdmissionKeyForToken } from "../github/client";
 import { extractLinkedIssueNumbersWithOverflow } from "../db/repositories";
+import { resolveRepositorySettings } from "../settings/repository-settings";
+import { DEFAULT_LINKED_ISSUE_HARD_RULES } from "./linked-issue-hard-rules-config";
+import type { LinkedIssueHardRulesConfig } from "../types";
+export { DEFAULT_LINKED_ISSUE_HARD_RULES } from "./linked-issue-hard-rules-config";
+export type { LinkedIssueHardRulesConfig, LinkedIssueHardRulesMode } from "../types";
 
 // Linked-issue HARD-RULE auto-close (#linked-issue-hard-rules). A DETERMINISTIC rule about the issue(s) a
 // contributor PR links — not an AI verdict. When a contributor links an issue that violates one of the
 // operator's hard rules, the PR is one-shot CLOSED with the SPECIFIC rule cited, so the contributor knows
 // exactly why (and which issue). The three rules (close when ANY linked OPEN issue trips one):
 //   1. owner-assigned    — the issue is assigned to the repo owner (reserved for the maintainer).
-//   2. missing-point     — a default-label repo AND the issue carries NONE of the point-bearing labels
+//   2. assigned-issue    — the issue is assigned to someone other than the PR author.
+//   3. missing-point     — a default-label repo AND the issue carries NONE of the point-bearing labels
 //                          (gittensor:bug / gittensor:feature / gittensor:priority) → not a scored contribution.
-//   3. maintainer-only   — the issue is labeled `maintainer-only` → not open for community PRs.
+//   4. maintainer-only   — the issue is labeled `maintainer-only` → not open for community PRs.
 //
 // Each rule is independently `"block"` (enforce) or `"off"` (ignore). Because this is deterministic (no
 // hallucination risk), the close fires REGARDLESS of a hard-guardrail path hit — but NEVER for the owner or
 // an automation bot (the planner's `isContributor` guard owns that exemption).
-
-export type LinkedIssueHardRulesMode = "block" | "off";
-
-export type LinkedIssueHardRulesConfig = {
-  ownerAssignedClose: LinkedIssueHardRulesMode;
-  missingPointLabelClose: LinkedIssueHardRulesMode;
-  maintainerOnlyLabelClose: LinkedIssueHardRulesMode;
-  // The point-bearing labels that make an issue eligible for a scored contribution.
-  pointBearingLabels: string[];
-  // The labels that mark an issue as maintainer-only (not open for community PRs).
-  maintainerOnlyLabels: string[];
-  // True when the repo uses the default gittensor labels, which is the precondition for the missing-point rule
-  // (a repo that does NOT use point labels must never auto-close for "missing point label").
-  defaultLabelRepo: boolean;
-  // Flag-then-close double-check (#linked-issue-verify-before-close). When TRUE (default), a hard-rule
-  // violation does NOT close on first detection: the planner FLAGS the PR (adds the pending-closure label + a
-  // warning comment) and only CLOSES on the NEXT gate evaluation if the violation STILL holds AND the label is
-  // already present (a label-based two-pass state machine — the second pass is the verification). When FALSE,
-  // the close fires immediately on first detection (the original GAP-5 behavior).
-  verifyBeforeClose: boolean;
-  // How long (seconds) until the verification pass — surfaced in the flag comment, and used to delay the
-  // optional re-review re-enqueue so Pass 2 doesn't wait for the slow sweep. Clamped to [0, 300].
-  closeDelaySeconds: number;
-};
-
-// Fail-SAFE default: every mode OFF, empty label lists, NOT a default-label repo. With hosted reviews retired,
-// this loader no longer reads external policy storage; deterministic linked-issue auto-closes stay off
-// unless/until they are wired through self-host repo config.
 
 // Fallback label that marks a PR as flagged-for-closure by the linked-issue hard rule (Pass 1). Its presence + a
 // persisting violation on the next evaluation is the verification trigger (Pass 2 → close). Operators can rename
 // or disable it with `settings.pendingClosureLabel`; the fallback intentionally avoids project-specific labels.
 export const AGENT_LABEL_PENDING_CLOSURE = "pending-closure";
 
-// Default verification delay (seconds) — how long until the second-pass close. Clamped to this range on load.
-const DEFAULT_CLOSE_DELAY_SECONDS = 30;
-
-export const DEFAULT_LINKED_ISSUE_HARD_RULES: LinkedIssueHardRulesConfig = {
-  ownerAssignedClose: "off",
-  missingPointLabelClose: "off",
-  maintainerOnlyLabelClose: "off",
-  pointBearingLabels: [],
-  maintainerOnlyLabels: [],
-  defaultLabelRepo: false,
-  // Default ON: a hard-rule violation flags first, then closes on re-verification (the operator's double-check).
-  verifyBeforeClose: true,
-  closeDelaySeconds: DEFAULT_CLOSE_DELAY_SECONDS,
-};
-
 /**
- * Resolve a repo's linked-issue hard-rule config. Kept async to avoid touching the processor call graph, but this
- * no longer reads external policy storage; the fail-safe all-off default ensures deterministic linked-issue closes
- * cannot fire from stale hosted-review configuration.
+ * Resolve a repo's linked-issue hard-rule config through the same private/global config-as-code resolver the
+ * rest of the action engine uses. Fail safe: if settings cannot be resolved, rules stay all-off.
  */
-export async function loadLinkedIssueHardRules(_env: Env, _repoFullName: string): Promise<LinkedIssueHardRulesConfig> {
-  return DEFAULT_LINKED_ISSUE_HARD_RULES;
+export async function loadLinkedIssueHardRules(env: Env, repoFullName: string): Promise<LinkedIssueHardRulesConfig> {
+  return (await resolveRepositorySettings(env, repoFullName).catch(() => undefined))?.linkedIssueHardRules ?? DEFAULT_LINKED_ISSUE_HARD_RULES;
 }
 
 export type LinkedIssueFacts = {
@@ -86,9 +48,18 @@ export type LinkedIssueHardRuleResult = {
 
 const NO_VIOLATION: LinkedIssueHardRuleResult = { violated: false, reason: null };
 
-function labelMatches(labels: string[], candidates: string[]): boolean {
+function findMatchingLabel(labels: string[], candidates: string[]): string | null {
   const wanted = new Set(candidates.map((c) => c.toLowerCase()));
-  return labels.some((label) => wanted.has(label.toLowerCase()));
+  return labels.find((label) => wanted.has(label.toLowerCase())) ?? null;
+}
+
+function labelMatches(labels: string[], candidates: string[]): boolean {
+  return findMatchingLabel(labels, candidates) !== null;
+}
+
+function issueIsAssignedToAuthor(issue: LinkedIssueFacts, prAuthorLogin: string | null | undefined): boolean {
+  const author = prAuthorLogin?.trim().toLowerCase();
+  return !!author && issue.assignees.some((assignee) => assignee.toLowerCase() === author);
 }
 
 /**
@@ -101,36 +72,56 @@ export function evaluateLinkedIssueHardRules(input: {
   issues: LinkedIssueFacts[];
   config: LinkedIssueHardRulesConfig;
   repoOwner: string;
+  prAuthorLogin?: string | null | undefined;
 }): LinkedIssueHardRuleResult {
   const { config, repoOwner } = input;
   const ownerLower = repoOwner.toLowerCase();
-  const anyRuleOn = config.ownerAssignedClose === "block" || config.missingPointLabelClose === "block" || config.maintainerOnlyLabelClose === "block";
+  const anyRuleOn =
+    config.ownerAssignedClose === "block" ||
+    config.assignedIssueClose === "block" ||
+    config.missingPointLabelClose === "block" ||
+    config.maintainerOnlyLabelClose === "block";
   if (!anyRuleOn) return NO_VIOLATION;
 
   for (const issue of input.issues) {
     if (issue.state !== "open") continue;
+    const assignedToPrAuthor = issueIsAssignedToAuthor(issue, input.prAuthorLogin);
 
     // Rule 1 — owner-assigned. The maintainer reserved this issue; a contributor PR for it can't be auto-accepted.
-    if (config.ownerAssignedClose === "block" && ownerLower.length > 0 && issue.assignees.some((assignee) => assignee.toLowerCase() === ownerLower)) {
+    if (
+      config.ownerAssignedClose === "block" &&
+      ownerLower.length > 0 &&
+      !assignedToPrAuthor &&
+      issue.assignees.some((assignee) => assignee.toLowerCase() === ownerLower)
+    ) {
       return {
         violated: true,
         reason: `Linked issue #${issue.number} is assigned to the maintainer (@${repoOwner}) — that work is reserved for the maintainer, so this PR cannot be auto-accepted.`,
       };
     }
 
-    // Rule 3 — maintainer-only label. Not open for community PRs.
-    if (config.maintainerOnlyLabelClose === "block" && labelMatches(issue.labels, config.maintainerOnlyLabels)) {
+    // Rule 2 — assigned to someone else. Prevents contributors from racing or taking already-claimed issues.
+    if (config.assignedIssueClose === "block" && issue.assignees.length > 0 && !assignedToPrAuthor) {
       return {
         violated: true,
-        reason: `Linked issue #${issue.number} is labeled \`maintainer-only\` — it is not open for community PRs.`,
+        reason: `Linked issue #${issue.number} is already assigned to @${issue.assignees[0]} — only the assignee or a maintainer can submit that work.`,
       };
     }
 
-    // Rule 2 — missing point-bearing label (default-label repos only). Not eligible for a scored contribution.
+    // Rule 3 — maintainer-only label. Not open for community PRs.
+    const maintainerOnlyLabel = findMatchingLabel(issue.labels, config.maintainerOnlyLabels);
+    if (config.maintainerOnlyLabelClose === "block" && maintainerOnlyLabel !== null && !assignedToPrAuthor) {
+      return {
+        violated: true,
+        reason: `Linked issue #${issue.number} is labeled \`${maintainerOnlyLabel}\` — it is not open for community PRs unless assigned by a maintainer.`,
+      };
+    }
+
+    // Rule 4 — missing point-bearing label (default-label repos only). Not eligible for a scored contribution.
     if (config.missingPointLabelClose === "block" && config.defaultLabelRepo && !labelMatches(issue.labels, config.pointBearingLabels)) {
       return {
         violated: true,
-        reason: `Linked issue #${issue.number} has no point-bearing label (needs one of gittensor:bug, gittensor:feature, gittensor:priority) — it is not eligible for a scored contribution.`,
+        reason: `Linked issue #${issue.number} has no point-bearing label (needs one of ${config.pointBearingLabels.join(", ") || "the configured point labels"}) — it is not eligible for a scored contribution.`,
       };
     }
   }
@@ -154,6 +145,7 @@ export async function resolveLinkedIssueHardRule(args: {
   body: string | null | undefined;
   linkedIssues: number[];
   ciToken: string | undefined;
+  prAuthorLogin?: string | null | undefined;
   // The installation id for `ciToken` (undefined for public-token reads). The admission key is DERIVED from the
   // token + this id via the one shared resolver, so an installation-token read attributes to its installation bucket
   // (not "unknown") and the key can never be passed out of sync with the token it belongs to.
@@ -161,6 +153,7 @@ export async function resolveLinkedIssueHardRule(args: {
 }): Promise<LinkedIssueHardRuleResult | undefined> {
   const anyRuleOn =
     args.config.ownerAssignedClose === "block" ||
+    args.config.assignedIssueClose === "block" ||
     args.config.missingPointLabelClose === "block" ||
     args.config.maintainerOnlyLabelClose === "block";
   if (!anyRuleOn) return undefined;
@@ -189,5 +182,5 @@ export async function resolveLinkedIssueHardRule(args: {
     }
     return undefined;
   }
-  return evaluateLinkedIssueHardRules({ issues: issueFacts, config: args.config, repoOwner: args.repoOwner });
+  return evaluateLinkedIssueHardRules({ issues: issueFacts, config: args.config, repoOwner: args.repoOwner, prAuthorLogin: args.prAuthorLogin });
 }

--- a/src/review/linked-issue-label-propagation-fetch.ts
+++ b/src/review/linked-issue-label-propagation-fetch.ts
@@ -18,9 +18,9 @@ import { githubRateLimitAdmissionKeyForToken } from "../github/client";
 const MAX_LINKED_ISSUES_TO_FETCH = 50;
 
 /** FETCH every linked issue's labels (fail-open) and flatten into one label list for
- *  `resolvePrTypeLabel` (`src/settings/pr-type-label.ts`) to match against. Only OPEN issues
- *  that are tied to the PR author (authored by them or assigned to them) can contribute labels;
- *  closing-keyword text in a PR body is author-controlled and is not authority by itself. Mirrors
+ *  `resolvePrTypeLabel` (`src/settings/pr-type-label.ts`) to match against. Only verified OPEN issues
+ *  can contribute labels; closing-keyword text in a PR body is author-controlled and is not authority by
+ *  itself. Mirrors
  *  `resolveLinkedIssueHardRule`'s own fetch idiom (`src/review/linked-issue-hard-rules.ts`): a per-issue
  *  fetch failure contributes no labels rather than throwing, so if EVERY linked issue fails, the result is
  *  `[]` — which can never match a mapping, meaning a sensitive label like `gittensor:priority` never applies
@@ -38,19 +38,11 @@ export async function fetchLinkedIssueLabelsForPropagation(args: {
   repoFullName: string;
   linkedIssues: number[];
   installationId: number;
-  prAuthorLogin?: string | null | undefined;
 }): Promise<string[]> {
   if (args.linkedIssues.length === 0) return [];
   const linkedIssues = args.linkedIssues.slice(0, MAX_LINKED_ISSUES_TO_FETCH);
   const token = (await createInstallationToken(args.env, args.installationId).catch(() => undefined)) ?? args.env.GITHUB_PUBLIC_TOKEN;
   const admissionKey = githubRateLimitAdmissionKeyForToken(args.env, token, args.installationId);
   const results = await Promise.all(linkedIssues.map((issueNumber) => fetchLinkedIssueFacts(args.env, args.repoFullName, issueNumber, token, admissionKey)));
-  const prAuthorLogin = args.prAuthorLogin?.toLowerCase();
-  if (!prAuthorLogin) return [];
-  return results.flatMap((result) => {
-    if (result.status !== "found" || result.facts.state !== "open") return [];
-    const issueAuthorLogin = result.facts.authorLogin?.toLowerCase();
-    const assignees = new Set(result.facts.assignees.map((login) => login.toLowerCase()));
-    return issueAuthorLogin === prAuthorLogin || assignees.has(prAuthorLogin) ? result.facts.labels : [];
-  });
+  return results.flatMap((result) => (result.status === "found" && result.facts.state === "open" ? result.facts.labels : []));
 }

--- a/src/services/agent-approval-queue.ts
+++ b/src/services/agent-approval-queue.ts
@@ -159,6 +159,7 @@ export async function decidePendingAgentAction(env: Env, input: { id: string; de
         body: pr.body,
         linkedIssues: pr.linkedIssues,
         ciToken,
+        prAuthorLogin: pr.authorLogin,
         installationId: pending.installationId,
       });
       stillJustified = linkedIssueHardRule?.violated === true;
@@ -318,6 +319,7 @@ export async function decidePendingAgentAction(env: Env, input: { id: string; de
         body: pr.body,
         linkedIssues: pr.linkedIssues,
         ciToken,
+        prAuthorLogin: pr.authorLogin,
         installationId: pending.installationId,
       });
       if (linkedIssueHardRule?.violated) {

--- a/src/settings/pr-type-label.ts
+++ b/src/settings/pr-type-label.ts
@@ -20,12 +20,20 @@ export const DEFAULT_TYPE_LABELS: PrTypeLabelSet = {
 
 export const ALL_TYPE_LABELS: readonly string[] = [DEFAULT_TYPE_LABELS.bug, DEFAULT_TYPE_LABELS.feature, DEFAULT_TYPE_LABELS.priority];
 
-/** feature ONLY for genuine new functionality (feat); EVERYTHING else — fix, test, docs, chore, refactor,
- *  perf, ci, build, style, revert — is bug (a test PR is a test, not a feature). (reviewbot auto-label.ts:27) */
+const FEATURE_TITLE_ACTION_RE = /\b(add|adds|added|create|creates|created|enable|enables|enabled|implement|implements|implemented|integrate|integrates|integrated|introduce|introduces|introduced|launch|launches|launched|support|supports|supported|wire|wires|wired)\b/i;
+const FEATURE_TITLE_DOWNGRADE_RE = /\b(avoid|block|bug|bugfix|cache|classify|classifies|classifying|cleanup|clean-up|clean up|detect|detects|detecting|docs?|fix|format|guard|lint|normalize|recognize|recognizes|recognizing|refactor|regression|rename|test|tests|testing|tighten|typo)\b/i;
+
+/** feature ONLY for substantial new functionality: a feat/feature prefix plus a concrete add/support/enable
+ *  action, with small recognition/classification/cleanup-style work downgraded to bug/work. EVERYTHING else —
+ *  fix, test, docs, chore, refactor, perf, ci, build, style, revert — is bug. */
 export function deriveKindFromTitle(title: string | undefined): "bug" | "feature" {
-  const match = /^([a-zA-Z]+)/.exec((title ?? "").trim());
+  const normalized = (title ?? "").trim();
+  const match = /^([a-zA-Z]+)/.exec(normalized);
   const type = match?.[1]?.toLowerCase();
-  return type === "feat" || type === "feature" ? "feature" : "bug";
+  if (type !== "feat" && type !== "feature") return "bug";
+  const subject = normalized.replace(/^[a-zA-Z]+(?:\([^)]*\))?:?\s*/, "");
+  if (!FEATURE_TITLE_ACTION_RE.test(subject)) return "bug";
+  return FEATURE_TITLE_DOWNGRADE_RE.test(subject) ? "bug" : "feature";
 }
 
 /** Defaults-fill a per-repo `typeLabels` override (config-as-code): each of bug/feature/priority is

--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -1,11 +1,12 @@
 import { parse as parseYaml } from "yaml";
-import type { GatePolicyPack, GateRuleMode, JsonValue, LinkedIssueLabelPropagationConfig, PrTypeLabelSet, RepositorySettings, ReviewCheckMode } from "../types";
+import type { GatePolicyPack, GateRuleMode, JsonValue, LinkedIssueHardRulesConfig, LinkedIssueLabelPropagationConfig, PrTypeLabelSet, RepositorySettings, ReviewCheckMode } from "../types";
 import { normalizeAutonomyPolicy, normalizeAutoMaintainPolicy } from "../settings/autonomy";
 import { normalizeCommandAuthorizationPolicy } from "../settings/command-authorization";
 import { mergeContributorBlacklists, normalizeContributorBlacklist } from "../settings/contributor-blacklist";
 import { normalizeAutoCloseExemptLogins } from "../settings/auto-close-exempt";
 import { DEFAULT_TYPE_LABELS, normalizeTypeLabelSet } from "../settings/pr-type-label";
 import { DEFAULT_LINKED_ISSUE_LABEL_PROPAGATION, normalizeLinkedIssueLabelPropagationConfig, VALID_LINKED_ISSUE_LABEL_PROPAGATION_MODES } from "../review/linked-issue-label-propagation";
+import { DEFAULT_LINKED_ISSUE_HARD_RULES, isLinkedIssueHardRuleMode, normalizeLinkedIssueHardRulesConfig } from "../review/linked-issue-hard-rules-config";
 import { normalizeModerationLabel, normalizeModerationRules } from "../settings/moderation-rules";
 import { REES_ANALYZER_NAME_SET, type ReesAnalyzerName } from "../review/enrichment-analyzer-names";
 import { hasUnsafeWildcardCount } from "./change-guardrail";
@@ -221,7 +222,7 @@ export type FocusManifestSettings = Partial<
     | "moderationBannedLabel"
   >
 > & {
-  // `typeLabels`/`linkedIssueLabelPropagation` are declared PARTIAL here (not via the `Pick<RepositorySettings,
+  // `typeLabels`/`linkedIssueLabelPropagation`/`linkedIssueHardRules` are declared PARTIAL here (not via the `Pick<RepositorySettings,
   // ...>` above, which would force a complete, defaults-filled object) so `resolveEffectiveSettings` can merge
   // them field-by-field against the DB value — a `.gittensory.yml` override naming only one key (e.g. just
   // `typeLabels.priority`) must inherit the OTHER keys from the DB-persisted value, not silently reset them to
@@ -230,6 +231,7 @@ export type FocusManifestSettings = Partial<
   // documented array-replace-wholesale overlay behavior).
   typeLabels?: Partial<PrTypeLabelSet> | undefined;
   linkedIssueLabelPropagation?: Partial<LinkedIssueLabelPropagationConfig> | undefined;
+  linkedIssueHardRules?: Partial<LinkedIssueHardRulesConfig> | undefined;
 };
 
 /** Field keys for the public review-panel rows a maintainer can show/hide via `review.fields`. */
@@ -1086,6 +1088,27 @@ function parseSettingsOverride(value: JsonValue | undefined, warnings: string[])
   } else if (r.linkedIssueLabelPropagation !== undefined) {
     warnings.push(`Manifest "settings.linkedIssueLabelPropagation" must be an object; ignoring it and keeping any existing policy.`);
   }
+  // Linked-issue hard rules: same sparse-partial overlay contract as linkedIssueLabelPropagation. A global config
+  // can enable the policy and set label lists; a repo override can toggle one mode without resetting those lists.
+  if (typeof r.linkedIssueHardRules === "object" && r.linkedIssueHardRules !== null && !Array.isArray(r.linkedIssueHardRules)) {
+    const rawRules = r.linkedIssueHardRules as Record<string, unknown>;
+    const validated = normalizeLinkedIssueHardRulesConfig(rawRules, warnings);
+    const sparseRules: Partial<LinkedIssueHardRulesConfig> = {};
+    if (isLinkedIssueHardRuleMode(rawRules.ownerAssignedClose)) sparseRules.ownerAssignedClose = validated.ownerAssignedClose;
+    if (isLinkedIssueHardRuleMode(rawRules.assignedIssueClose)) sparseRules.assignedIssueClose = validated.assignedIssueClose;
+    if (isLinkedIssueHardRuleMode(rawRules.missingPointLabelClose)) sparseRules.missingPointLabelClose = validated.missingPointLabelClose;
+    if (isLinkedIssueHardRuleMode(rawRules.maintainerOnlyLabelClose)) sparseRules.maintainerOnlyLabelClose = validated.maintainerOnlyLabelClose;
+    if (Array.isArray(rawRules.pointBearingLabels)) sparseRules.pointBearingLabels = validated.pointBearingLabels;
+    if (Array.isArray(rawRules.maintainerOnlyLabels)) sparseRules.maintainerOnlyLabels = validated.maintainerOnlyLabels;
+    if (typeof rawRules.defaultLabelRepo === "boolean") sparseRules.defaultLabelRepo = validated.defaultLabelRepo;
+    if (typeof rawRules.verifyBeforeClose === "boolean") sparseRules.verifyBeforeClose = validated.verifyBeforeClose;
+    if (typeof rawRules.closeDelaySeconds === "number" && Number.isFinite(rawRules.closeDelaySeconds) && rawRules.closeDelaySeconds >= 0) {
+      sparseRules.closeDelaySeconds = validated.closeDelaySeconds;
+    }
+    out.linkedIssueHardRules = sparseRules;
+  } else if (r.linkedIssueHardRules !== undefined) {
+    warnings.push(`Manifest "settings.linkedIssueHardRules" must be an object; ignoring it and keeping any existing policy.`);
+  }
   // Contributor blacklist (#1425): `settings.contributorBlacklist` is a list of banned-login entries. Only set it
   // when at least one VALID entry survives normalization, so a malformed block never blanks the DB-configured
   // list via the resolver's `{...dbSettings, ...manifest.settings}` overlay. Normalization warnings are folded in.
@@ -1617,13 +1640,19 @@ export function resolveEffectiveSettings(
   manifest: FocusManifest,
   sharedContributorBlacklist: RepositorySettings["contributorBlacklist"] = [],
 ): RepositorySettings {
-  // `typeLabels`/`linkedIssueLabelPropagation` are parsed as SPARSE partials (see parseFocusManifest above),
+  // `typeLabels`/`linkedIssueLabelPropagation`/`linkedIssueHardRules` are parsed as SPARSE partials (see
+  // parseFocusManifest above),
   // unlike every other `manifest.settings` field, which is always a complete value ready to overlay the DB
   // value wholesale via the spread below. Pull them out of the spread and merge each field individually,
   // manifest override > DB value > built-in default, so a `.gittensory.yml` naming only one key (e.g.
   // `typeLabels.priority`) can never silently reset the others back to the built-in default and discard a
   // DB-customized value (#priority-linked-issue-gate).
-  const { typeLabels: typeLabelsOverride, linkedIssueLabelPropagation: linkedIssueLabelPropagationOverride, ...restManifestSettings } = manifest.settings;
+  const {
+    typeLabels: typeLabelsOverride,
+    linkedIssueLabelPropagation: linkedIssueLabelPropagationOverride,
+    linkedIssueHardRules: linkedIssueHardRulesOverride,
+    ...restManifestSettings
+  } = manifest.settings;
   const effective: RepositorySettings = { ...dbSettings, ...restManifestSettings };
   if (typeLabelsOverride !== undefined) {
     const base = dbSettings.typeLabels ?? DEFAULT_TYPE_LABELS;
@@ -1635,6 +1664,20 @@ export function resolveEffectiveSettings(
       enabled: linkedIssueLabelPropagationOverride.enabled ?? base.enabled,
       mode: linkedIssueLabelPropagationOverride.mode ?? base.mode,
       mappings: linkedIssueLabelPropagationOverride.mappings ?? base.mappings,
+    };
+  }
+  if (linkedIssueHardRulesOverride !== undefined) {
+    const base = dbSettings.linkedIssueHardRules ?? DEFAULT_LINKED_ISSUE_HARD_RULES;
+    effective.linkedIssueHardRules = {
+      ownerAssignedClose: linkedIssueHardRulesOverride.ownerAssignedClose ?? base.ownerAssignedClose,
+      assignedIssueClose: linkedIssueHardRulesOverride.assignedIssueClose ?? base.assignedIssueClose,
+      missingPointLabelClose: linkedIssueHardRulesOverride.missingPointLabelClose ?? base.missingPointLabelClose,
+      maintainerOnlyLabelClose: linkedIssueHardRulesOverride.maintainerOnlyLabelClose ?? base.maintainerOnlyLabelClose,
+      pointBearingLabels: linkedIssueHardRulesOverride.pointBearingLabels ?? base.pointBearingLabels,
+      maintainerOnlyLabels: linkedIssueHardRulesOverride.maintainerOnlyLabels ?? base.maintainerOnlyLabels,
+      defaultLabelRepo: linkedIssueHardRulesOverride.defaultLabelRepo ?? base.defaultLabelRepo,
+      verifyBeforeClose: linkedIssueHardRulesOverride.verifyBeforeClose ?? base.verifyBeforeClose,
+      closeDelaySeconds: linkedIssueHardRulesOverride.closeDelaySeconds ?? base.closeDelaySeconds,
     };
   }
   const gate = manifest.gate;

--- a/src/types.ts
+++ b/src/types.ts
@@ -740,6 +740,11 @@ export type RepositorySettings = {
    *  (`enabled: false`, no mappings) — a self-hoster opts in per repo. Always populated by the DB
    *  layer; optional so existing settings fixtures/callers need not be touched. */
   linkedIssueLabelPropagation?: LinkedIssueLabelPropagationConfig | undefined;
+  /** Deterministic linked-issue hard rules. Config-as-code only; set with
+   *  `.gittensory.yml settings.linkedIssueHardRules` in private/global or per-repo config. These rules close
+   *  contributor PRs that link ineligible issues before spending AI review budget: owner/other-assigned,
+   *  maintainer-only, or missing point-label issues. Defaults all-off so self-hosters opt into their own policy. */
+  linkedIssueHardRules?: LinkedIssueHardRulesConfig | undefined;
   publicSurface: "off" | "comment_and_label" | "comment_only" | "label_only";
   includeMaintainerAuthors: boolean;
   requireLinkedIssue: boolean;
@@ -938,6 +943,21 @@ export type LinkedIssueLabelPropagationConfig = {
   enabled: boolean;
   mode: LinkedIssueLabelPropagationMode;
   mappings: LinkedIssueLabelPropagationMapping[];
+};
+
+export type LinkedIssueHardRulesMode = "block" | "off";
+
+export type LinkedIssueHardRulesConfig = {
+  ownerAssignedClose: LinkedIssueHardRulesMode;
+  /** Close when an open linked issue is assigned to someone other than the PR author. */
+  assignedIssueClose: LinkedIssueHardRulesMode;
+  missingPointLabelClose: LinkedIssueHardRulesMode;
+  maintainerOnlyLabelClose: LinkedIssueHardRulesMode;
+  pointBearingLabels: string[];
+  maintainerOnlyLabels: string[];
+  defaultLabelRepo: boolean;
+  verifyBeforeClose: boolean;
+  closeDelaySeconds: number;
 };
 
 /** A blocked contributor (#1425, anti-abuse): a GitHub `login` plus optional maintainer metadata. The converged

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -1962,6 +1962,72 @@ describe("parseFocusManifest settings override + resolveEffectiveSettings", () =
     expect(eff.linkedIssueLabelPropagation).toEqual(db.linkedIssueLabelPropagation);
   });
 
+  it("wires settings.linkedIssueHardRules into the manifest parser as a sparse override", () => {
+    const parsed = parseFocusManifest({
+      settings: {
+        linkedIssueHardRules: {
+          assignedIssueClose: "block",
+          maintainerOnlyLabels: ["maintainer-only"],
+          verifyBeforeClose: false,
+          closeDelaySeconds: 3.8,
+        },
+      },
+    });
+    expect(parsed.settings.linkedIssueHardRules).toEqual({
+      assignedIssueClose: "block",
+      maintainerOnlyLabels: ["maintainer-only"],
+      verifyBeforeClose: false,
+      closeDelaySeconds: 3,
+    });
+    expect(parsed.warnings).toEqual([]);
+  });
+
+  it("resolveEffectiveSettings merges partial linkedIssueHardRules overrides without clearing lower-layer labels", () => {
+    const db = {
+      linkedIssueHardRules: {
+        ownerAssignedClose: "off",
+        assignedIssueClose: "off",
+        missingPointLabelClose: "off",
+        maintainerOnlyLabelClose: "block",
+        pointBearingLabels: ["gittensor:bug", "gittensor:feature", "gittensor:priority"],
+        maintainerOnlyLabels: ["maintainer-only"],
+        defaultLabelRepo: true,
+        verifyBeforeClose: true,
+        closeDelaySeconds: 30,
+      },
+    } as unknown as RepositorySettings;
+    const eff = resolveEffectiveSettings(db, parseFocusManifest({ settings: { linkedIssueHardRules: { assignedIssueClose: "block" } } }));
+    expect(eff.linkedIssueHardRules).toEqual({
+      ownerAssignedClose: "off",
+      assignedIssueClose: "block",
+      missingPointLabelClose: "off",
+      maintainerOnlyLabelClose: "block",
+      pointBearingLabels: ["gittensor:bug", "gittensor:feature", "gittensor:priority"],
+      maintainerOnlyLabels: ["maintainer-only"],
+      defaultLabelRepo: true,
+      verifyBeforeClose: true,
+      closeDelaySeconds: 30,
+    });
+  });
+
+  it("drops malformed linkedIssueHardRules fields instead of replacing existing policy with defaults", () => {
+    const parsed = parseFocusManifest({
+      settings: {
+        linkedIssueHardRules: {
+          assignedIssueClose: "close",
+          maintainerOnlyLabels: "maintainer-only",
+          defaultLabelRepo: "true",
+          closeDelaySeconds: -1,
+        },
+      },
+    });
+    expect(parsed.settings.linkedIssueHardRules).toEqual({});
+    expect(parsed.warnings.some((w) => w.includes("settings.linkedIssueHardRules.assignedIssueClose"))).toBe(true);
+    expect(parsed.warnings.some((w) => w.includes("settings.linkedIssueHardRules.maintainerOnlyLabels"))).toBe(true);
+    expect(parsed.warnings.some((w) => w.includes("settings.linkedIssueHardRules.defaultLabelRepo"))).toBe(true);
+    expect(parsed.warnings.some((w) => w.includes("settings.linkedIssueHardRules.closeDelaySeconds"))).toBe(true);
+  });
+
   it("parses aiReview from settings: and lets gate.aiReview win in resolveEffectiveSettings", () => {
     const parsed = parseFocusManifest({ settings: { aiReviewMode: "advisory", aiReviewByok: true } });
     expect(parsed.settings.aiReviewMode).toBe("advisory");

--- a/test/unit/linked-issue-hard-rules.test.ts
+++ b/test/unit/linked-issue-hard-rules.test.ts
@@ -9,12 +9,15 @@ import {
   type LinkedIssueFacts,
   type LinkedIssueHardRulesConfig,
 } from "../../src/review/linked-issue-hard-rules";
+import { normalizeLinkedIssueHardRulesConfig } from "../../src/review/linked-issue-hard-rules-config";
 import { parseFocusManifest, resolveEffectiveSettings } from "../../src/signals/focus-manifest";
+import { setLocalManifestReader } from "../../src/signals/focus-manifest-loader";
 import type { RepositorySettings } from "../../src/types";
 
 function config(overrides: Partial<LinkedIssueHardRulesConfig> = {}): LinkedIssueHardRulesConfig {
   return {
     ownerAssignedClose: "off",
+    assignedIssueClose: "off",
     missingPointLabelClose: "off",
     maintainerOnlyLabelClose: "off",
     pointBearingLabels: ["gittensor:bug", "gittensor:feature", "gittensor:priority"],
@@ -31,6 +34,8 @@ function issue(overrides: Partial<LinkedIssueFacts> & { number: number }): Linke
 }
 
 const OWNER = "jsonbored";
+
+afterEach(() => setLocalManifestReader(null));
 
 describe("evaluateLinkedIssueHardRules", () => {
   it("returns no violation when every rule is off (even if every condition is met)", () => {
@@ -77,6 +82,50 @@ describe("evaluateLinkedIssueHardRules", () => {
         issues: [issue({ number: 7, assignees: ["contributor-x"] })],
         config: config({ ownerAssignedClose: "block" }),
         repoOwner: OWNER,
+      });
+      expect(result.violated).toBe(false);
+    });
+
+    it("allows an assignee-author to work an owner-assigned issue", () => {
+      const result = evaluateLinkedIssueHardRules({
+        issues: [issue({ number: 7, assignees: ["jsonbored", "contributor-x"] })],
+        config: config({ ownerAssignedClose: "block" }),
+        repoOwner: OWNER,
+        prAuthorLogin: "contributor-x",
+      });
+      expect(result.violated).toBe(false);
+    });
+  });
+
+  describe("rule 2: assigned issue", () => {
+    it("fires when the linked issue is already assigned to another contributor", () => {
+      const result = evaluateLinkedIssueHardRules({
+        issues: [issue({ number: 12, assignees: ["claimed-dev"] })],
+        config: config({ assignedIssueClose: "block" }),
+        repoOwner: OWNER,
+        prAuthorLogin: "drive-by",
+      });
+      expect(result.violated).toBe(true);
+      expect(result.reason).toContain("#12");
+      expect(result.reason).toContain("@claimed-dev");
+    });
+
+    it("does not fire when the PR author is the assignee", () => {
+      const result = evaluateLinkedIssueHardRules({
+        issues: [issue({ number: 12, assignees: ["Claimed-Dev"] })],
+        config: config({ assignedIssueClose: "block" }),
+        repoOwner: OWNER,
+        prAuthorLogin: "claimed-dev",
+      });
+      expect(result.violated).toBe(false);
+    });
+
+    it("is silent when the rule is off", () => {
+      const result = evaluateLinkedIssueHardRules({
+        issues: [issue({ number: 12, assignees: ["claimed-dev"] })],
+        config: config({ assignedIssueClose: "off" }),
+        repoOwner: OWNER,
+        prAuthorLogin: "drive-by",
       });
       expect(result.violated).toBe(false);
     });
@@ -160,6 +209,16 @@ describe("evaluateLinkedIssueHardRules", () => {
       });
       expect(result.violated).toBe(false);
     });
+
+    it("allows the assignee to work a maintainer-only issue", () => {
+      const result = evaluateLinkedIssueHardRules({
+        issues: [issue({ number: 3, labels: ["Maintainer-Only"], assignees: ["assigned-dev"] })],
+        config: config({ maintainerOnlyLabelClose: "block" }),
+        repoOwner: OWNER,
+        prAuthorLogin: "assigned-dev",
+      });
+      expect(result.violated).toBe(false);
+    });
   });
 
   describe("issue state + multiple issues", () => {
@@ -205,6 +264,7 @@ describe("loadLinkedIssueHardRules", () => {
         LEGACY_POLICY: {
           linkedIssueHardRules: {
             ownerAssignedClose: "block",
+            assignedIssueClose: "block",
             missingPointLabelClose: "block",
             maintainerOnlyLabelClose: "block",
             pointBearingLabels: ["gittensor:bug"],
@@ -224,6 +284,7 @@ describe("loadLinkedIssueHardRules", () => {
     const cfg = await loadLinkedIssueHardRules({} as Env, "soloname");
     expect(cfg).toEqual({
       ownerAssignedClose: "off",
+      assignedIssueClose: "off",
       missingPointLabelClose: "off",
       maintainerOnlyLabelClose: "off",
       pointBearingLabels: [],
@@ -233,12 +294,38 @@ describe("loadLinkedIssueHardRules", () => {
       closeDelaySeconds: 30,
     });
   });
+
+  it("loads linked-issue hard rules from the effective private repo config", async () => {
+    setLocalManifestReader(async (repoFullName) =>
+      repoFullName === "owner/configured"
+        ? [
+            "settings:",
+            "  linkedIssueHardRules:",
+            "    assignedIssueClose: block",
+            "    maintainerOnlyLabelClose: block",
+            "    maintainerOnlyLabels:",
+            "      - maintainer-only",
+            "    verifyBeforeClose: false",
+            "    closeDelaySeconds: 5",
+          ].join("\n")
+        : null,
+    );
+    const cfg = await loadLinkedIssueHardRules(createTestEnv(), "owner/configured");
+    expect(cfg).toMatchObject({
+      assignedIssueClose: "block",
+      maintainerOnlyLabelClose: "block",
+      maintainerOnlyLabels: ["maintainer-only"],
+      verifyBeforeClose: false,
+      closeDelaySeconds: 5,
+    });
+  });
 });
 
 describe("evaluateLinkedIssueHardRules with explicit config", () => {
   it("supports a fully enabled config for self-host config plumbing", () => {
     const cfg: LinkedIssueHardRulesConfig = {
       ownerAssignedClose: "block",
+      assignedIssueClose: "block",
       missingPointLabelClose: "block",
       maintainerOnlyLabelClose: "block",
       pointBearingLabels: ["gittensor:bug"],
@@ -249,8 +336,34 @@ describe("evaluateLinkedIssueHardRules with explicit config", () => {
     };
     expect(evaluateLinkedIssueHardRules({ issues: [issue({ number: 9, labels: ["reserved"] })], config: cfg, repoOwner: OWNER })).toEqual({
       violated: true,
-      reason: "Linked issue #9 is labeled `maintainer-only` — it is not open for community PRs.",
+      reason: "Linked issue #9 is labeled `reserved` — it is not open for community PRs unless assigned by a maintainer.",
     });
+  });
+
+  it("normalizes malformed linked-issue hard-rule config shapes without preserving invalid label entries", () => {
+    const warnings: string[] = [];
+    const cfg = normalizeLinkedIssueHardRulesConfig(
+      {
+        assignedIssueClose: "block",
+        pointBearingLabels: ["gittensor:bug", "", 1],
+        maintainerOnlyLabels: "maintainer-only",
+      },
+      warnings,
+    );
+
+    expect(cfg.assignedIssueClose).toBe("block");
+    expect(cfg.pointBearingLabels).toEqual(["gittensor:bug"]);
+    expect(cfg.maintainerOnlyLabels).toEqual([]);
+    expect(warnings.some((warning) => warning.includes("pointBearingLabels[1]"))).toBe(true);
+    expect(warnings.some((warning) => warning.includes("pointBearingLabels[2]"))).toBe(true);
+    expect(warnings.some((warning) => warning.includes("maintainerOnlyLabels must be an array"))).toBe(true);
+  });
+
+  it("normalizes a malformed linked-issue hard-rule top-level value back to the all-off default", () => {
+    const warnings: string[] = [];
+
+    expect(normalizeLinkedIssueHardRulesConfig([], warnings)).toEqual(DEFAULT_LINKED_ISSUE_HARD_RULES);
+    expect(warnings).toEqual(["settings.linkedIssueHardRules must be an object; using the default all-off policy."]);
   });
 });
 
@@ -331,6 +444,26 @@ describe("resolveLinkedIssueHardRule (#1144 — overflow + orchestration)", () =
     const r = await resolveLinkedIssueHardRule(args({ config: config({ ownerAssignedClose: "block" }), ciToken: "tok", body: "closes #1", linkedIssues: [1] }));
     expect(r).toBeDefined();
     expect(typeof r?.violated).toBe("boolean");
+  });
+
+  it("REGRESSION: blocks a PR that links an issue assigned to someone else, but not the assignee", async () => {
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) =>
+      input.toString().includes("/issues/")
+        ? Response.json({ number: 1, state: "open", labels: [], assignees: [{ login: "claimed-dev" }] })
+        : new Response("missing", { status: 404 }),
+    );
+    const blocked = await resolveLinkedIssueHardRule(
+      args({ config: config({ assignedIssueClose: "block" }), ciToken: "tok", body: "closes #1", linkedIssues: [1], prAuthorLogin: "drive-by" }),
+    );
+    expect(blocked).toEqual({
+      violated: true,
+      reason: "Linked issue #1 is already assigned to @claimed-dev — only the assignee or a maintainer can submit that work.",
+    });
+
+    const assignee = await resolveLinkedIssueHardRule(
+      args({ config: config({ assignedIssueClose: "block" }), ciToken: "tok", body: "closes #1", linkedIssues: [1], prAuthorLogin: "claimed-dev" }),
+    );
+    expect(assignee).toEqual({ violated: false, reason: null });
   });
 
   it("derives the installation admission key from the ci token + installation id so installation reads attribute to the installation bucket, not 'unknown' (#1951 blocker)", async () => {

--- a/test/unit/linked-issue-label-propagation-fetch.test.ts
+++ b/test/unit/linked-issue-label-propagation-fetch.test.ts
@@ -29,7 +29,7 @@ describe("fetchLinkedIssueLabelsForPropagation (#priority-linked-issue-gate)", (
       return new Response("not found", { status: 404 });
     });
     const env = createTestEnv({});
-    const result = await fetchLinkedIssueLabelsForPropagation({ env, repoFullName: "owner/repo", linkedIssues: [1], installationId: 123, prAuthorLogin: "contrib" });
+    const result = await fetchLinkedIssueLabelsForPropagation({ env, repoFullName: "owner/repo", linkedIssues: [1], installationId: 123 });
     expect(result).toEqual(["gittensor:priority", "help wanted"]);
   });
 
@@ -41,7 +41,7 @@ describe("fetchLinkedIssueLabelsForPropagation (#priority-linked-issue-gate)", (
       return new Response("not found", { status: 404 });
     });
     const env = createTestEnv({});
-    const result = await fetchLinkedIssueLabelsForPropagation({ env, repoFullName: "owner/repo", linkedIssues: [1, 2], installationId: 123, prAuthorLogin: "contrib" });
+    const result = await fetchLinkedIssueLabelsForPropagation({ env, repoFullName: "owner/repo", linkedIssues: [1, 2], installationId: 123 });
     expect(result).toEqual(["gittensor:priority"]);
   });
 
@@ -59,7 +59,7 @@ describe("fetchLinkedIssueLabelsForPropagation (#priority-linked-issue-gate)", (
     const spy = vi.spyOn(appModule, "createInstallationToken").mockRejectedValue(new Error("mint failed"));
     stubFetch((url) => (url.endsWith("/issues/1") ? Response.json({ number: 1, state: "open", user: { login: "contrib" }, labels: ["gittensor:priority"] }) : new Response("not found", { status: 404 })));
     const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
-    const result = await fetchLinkedIssueLabelsForPropagation({ env, repoFullName: "owner/repo", linkedIssues: [1], installationId: 123, prAuthorLogin: "contrib" });
+    const result = await fetchLinkedIssueLabelsForPropagation({ env, repoFullName: "owner/repo", linkedIssues: [1], installationId: 123 });
     expect(result).toEqual(["gittensor:priority"]);
     spy.mockRestore();
   });
@@ -76,20 +76,20 @@ describe("fetchLinkedIssueLabelsForPropagation (#priority-linked-issue-gate)", (
     });
     const env = createTestEnv({});
     const manyIssues = Array.from({ length: 75 }, (_, i) => i + 1);
-    const result = await fetchLinkedIssueLabelsForPropagation({ env, repoFullName: "owner/repo", linkedIssues: manyIssues, installationId: 123, prAuthorLogin: "contrib" });
+    const result = await fetchLinkedIssueLabelsForPropagation({ env, repoFullName: "owner/repo", linkedIssues: manyIssues, installationId: 123 });
     expect(issueFetchCount).toBe(50);
     expect(result).toEqual(Array(50).fill("gittensor:priority"));
   });
 
-  it("ignores a priority label on an unrelated linked issue, even when the PR body names it", async () => {
+  it("trusts a priority label on any verified open linked issue, independent of PR author ownership", async () => {
     stubFetch((url) => {
       if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
       if (url.endsWith("/issues/777")) return Response.json({ number: 777, state: "open", user: { login: "maintainer" }, assignees: [], labels: ["gittensor:priority"] });
       return new Response("not found", { status: 404 });
     });
     const env = createTestEnv({});
-    const result = await fetchLinkedIssueLabelsForPropagation({ env, repoFullName: "owner/repo", linkedIssues: [777], installationId: 123, prAuthorLogin: "drive-by" });
-    expect(result).toEqual([]);
+    const result = await fetchLinkedIssueLabelsForPropagation({ env, repoFullName: "owner/repo", linkedIssues: [777], installationId: 123 });
+    expect(result).toEqual(["gittensor:priority"]);
   });
 
   it("ignores a priority label on a closed linked issue, even when the PR author is tied to it", async () => {
@@ -99,11 +99,11 @@ describe("fetchLinkedIssueLabelsForPropagation (#priority-linked-issue-gate)", (
       return new Response("not found", { status: 404 });
     });
     const env = createTestEnv({});
-    const result = await fetchLinkedIssueLabelsForPropagation({ env, repoFullName: "owner/repo", linkedIssues: [777], installationId: 123, prAuthorLogin: "contrib" });
+    const result = await fetchLinkedIssueLabelsForPropagation({ env, repoFullName: "owner/repo", linkedIssues: [777], installationId: 123 });
     expect(result).toEqual([]);
   });
 
-  it("ignores linked-issue labels when the PR author is unavailable", async () => {
+  it("does not require a PR author to propagate labels from a verified open linked issue", async () => {
     stubFetch((url) => {
       if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
       if (url.endsWith("/issues/1")) return Response.json({ number: 1, state: "open", user: { login: "contrib" }, labels: ["gittensor:priority"] });
@@ -111,7 +111,7 @@ describe("fetchLinkedIssueLabelsForPropagation (#priority-linked-issue-gate)", (
     });
     const env = createTestEnv({});
     const result = await fetchLinkedIssueLabelsForPropagation({ env, repoFullName: "owner/repo", linkedIssues: [1], installationId: 123 });
-    expect(result).toEqual([]);
+    expect(result).toEqual(["gittensor:priority"]);
   });
 
 });

--- a/test/unit/pr-type-label.test.ts
+++ b/test/unit/pr-type-label.test.ts
@@ -3,9 +3,11 @@ import { DEFAULT_TYPE_LABELS, deriveKindFromTitle, normalizeTypeLabelSet, resolv
 import type { LinkedIssueLabelPropagationConfig } from "../../src/types";
 
 describe("deriveKindFromTitle", () => {
-  it("maps feat/feature → feature; everything else → bug", () => {
-    expect(deriveKindFromTitle("feat: add X")).toBe("feature");
-    expect(deriveKindFromTitle("feature(api): boards")).toBe("feature");
+  it("maps substantial feat/feature titles to feature and keeps small feat-style work as bug", () => {
+    expect(deriveKindFromTitle("feat: add provider fallback")).toBe("feature");
+    expect(deriveKindFromTitle("feature(api): support board exports")).toBe("feature");
+    expect(deriveKindFromTitle("feat(signals): recognize Conan dependency manifests")).toBe("bug");
+    expect(deriveKindFromTitle("feature(api): boards")).toBe("bug");
     expect(deriveKindFromTitle("fix: bug")).toBe("bug");
     expect(deriveKindFromTitle("test: add coverage")).toBe("bug");
     expect(deriveKindFromTitle("docs: readme")).toBe("bug");
@@ -22,7 +24,7 @@ function propagation(overrides: Partial<LinkedIssueLabelPropagationConfig> = {})
 
 describe("resolvePrTypeLabel (#priority-linked-issue-gate)", () => {
   it("returns the feature label by title when propagation is not configured", () => {
-    const result = resolvePrTypeLabel({ title: "feat: x" });
+    const result = resolvePrTypeLabel({ title: "feat: add provider fallback" });
     expect(result).toEqual({ applyLabels: [DEFAULT_TYPE_LABELS.feature], removeLabels: [DEFAULT_TYPE_LABELS.bug, DEFAULT_TYPE_LABELS.priority], source: "title" });
   });
 
@@ -92,14 +94,14 @@ describe("resolvePrTypeLabel (#priority-linked-issue-gate)", () => {
   });
 
   it("does not crash on an empty mappings array and falls through to title-based", () => {
-    const result = resolvePrTypeLabel({ title: "feat: x", linkedIssueLabels: ["anything"], propagation: propagation({ mappings: [] }) });
+    const result = resolvePrTypeLabel({ title: "feat: add provider fallback", linkedIssueLabels: ["anything"], propagation: propagation({ mappings: [] }) });
     expect(result.applyLabels).toEqual([DEFAULT_TYPE_LABELS.feature]);
     expect(result.source).toBe("title");
   });
 
   it("does not crash when linkedIssueLabels is omitted entirely (propagation enabled with mappings configured)", () => {
     const result = resolvePrTypeLabel({
-      title: "feat: x",
+      title: "feat: add provider fallback",
       propagation: propagation({ mappings: [{ issueLabel: "gittensor:priority", prLabel: "gittensor:priority", removeOtherTypeLabels: true }] }),
     });
     expect(result.applyLabels).toEqual([DEFAULT_TYPE_LABELS.feature]);
@@ -123,7 +125,7 @@ describe("resolvePrTypeLabel (#priority-linked-issue-gate)", () => {
 
   it("respects a custom typeLabels set for both the title fallback and the removal set", () => {
     const custom = { bug: "kind:bug", feature: "kind:feature", priority: "kind:priority" };
-    const result = resolvePrTypeLabel({ title: "feat: x", labels: custom });
+    const result = resolvePrTypeLabel({ title: "feat: add provider fallback", labels: custom });
     expect(result).toEqual({ applyLabels: ["kind:feature"], removeLabels: ["kind:bug", "kind:priority"], source: "title" });
   });
 });


### PR DESCRIPTION
## Summary
- tighten reward type-label classification so `gittensor:feature` is reserved for substantial feature-style PRs
- make linked-issue priority propagation depend on verified open issue labels, not PR title or author-controlled text
- add config-driven linked-issue hard rules for assigned/maintainer-only/point-label issue states

## What changed
- Added `settings.linkedIssueHardRules` to the repo settings schema and private/global config resolver.
- Added an assigned-issue hard rule that blocks contributor PRs for issues already assigned to someone else, while allowing the assigned author.
- Kept all linked-issue hard rules all-off by default and configurable per repo/global config.
- Updated priority-label propagation so configured labels like `gittensor:priority` only copy from verified open linked issues.
- Regenerated the UI OpenAPI schema.

## Validation
- `npm run typecheck`
- `npm run ui:openapi:check`
- `npm run ui:openapi:settings-parity`
- `npx vitest run test/unit/pr-type-label.test.ts test/unit/linked-issue-label-propagation-fetch.test.ts test/unit/linked-issue-hard-rules.test.ts test/unit/focus-manifest.test.ts`
- `npx vitest run test/unit/queue.test.ts -t "type label|priority-linked-issue-gate"`
- `npm run test:coverage` (8,441 passed, 7 skipped)