### PR TITLE
fix(docs): keep quoted command-reference entries

### DIFF
--- a/scripts/gen-command-reference.mjs
+++ b/scripts/gen-command-reference.mjs
@@ -29,11 +29,11 @@ export function extractCatalogEntries(sourceText, catalogConstName) {
   const catalogPattern = new RegExp(`const\\s+${catalogConstName}\\s*=\\s*\\[([\\s\\S]*?)\\]\\s*as\\s*const;`);
   const catalogMatch = catalogPattern.exec(sourceText);
   if (!catalogMatch) return [];
-  const entryPattern = /id:\s*"([^"]+)"\s*,\s*title:\s*"([^"]+)"\s*,\s*description:\s*"([^"]+)"/g;
+  const entryPattern = /id:\s*"((?:\\.|[^"\\])*)"\s*,\s*title:\s*"((?:\\.|[^"\\])*)"\s*,\s*description:\s*"((?:\\.|[^"\\])*)"/g;
   return [...catalogMatch[1].matchAll(entryPattern)].map((match) => ({
-    id: match[1],
-    title: match[2],
-    description: match[3],
+    id: JSON.parse(`"${match[1]}"`),
+    title: JSON.parse(`"${match[2]}"`),
+    description: JSON.parse(`"${match[3]}"`),
   }));
 }
 

--- a/test/unit/gen-command-reference-script.test.ts
+++ b/test/unit/gen-command-reference-script.test.ts
@@ -45,6 +45,19 @@ describe("gen-command-reference script (#3046)", () => {
     it("returns an empty array when the named catalog does not exist", () => {
       expect(extractCatalogEntries(fixture, "MISSING_CATALOG")).toEqual([]);
     });
+
+    it("keeps entries whose title or description contains escaped quotes", () => {
+      const escapedQuote = `${String.fromCharCode(92)}"`;
+      const source = [
+        "const PUBLIC_MENTION_COMMAND_CATALOG = [",
+        `{ id: "quote-test", title: "Say ${escapedQuote}quote${escapedQuote}", description: "Render ${escapedQuote}quoted${escapedQuote} command text." },`,
+        "] as const;",
+      ].join("\n");
+
+      expect(extractCatalogEntries(source, "PUBLIC_MENTION_COMMAND_CATALOG")).toEqual([
+        { id: "quote-test", title: 'Say "quote"', description: 'Render "quoted" command text.' },
+      ]);
+    });
   });
 
   describe("renderCommandList", () => {


### PR DESCRIPTION
## Summary

- Fixes `scripts/gen-command-reference.mjs` so command catalog entries with escaped JavaScript string contents are still extracted instead of being skipped.
- Adds a focused regression test proving an entry with quoted title and description text is preserved.
- No linked issue because this is a small scripts-only regression found while tracing the newly generated command reference path; the repo policy marks linked issues as preferred, not required.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` locally; this PR touches only `scripts/**` and `test/**`, so Codecov has no `src/**` patch-coverage obligation.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran `npx vitest run test/unit/gen-command-reference-script.test.ts` clean: 11 tests passed, including the new escaped-string regression.
- Ran `npm run command-reference:check` clean: generated command reference remains current.
- A scoped `npm run test:coverage -- test/unit/gen-command-reference-script.test.ts` executed the 11 tests successfully but exited nonzero because project-wide `src/**` coverage thresholds see 0% when only this scripts-only test is selected; that command is not counted above as passing.
- Full `npm run test:ci` was not run locally in this Windows worktree due time and environment cost; the changed paths are covered by the focused script test, typecheck, generator check, and audit above.

## Safety

- [x] No credentials, private keys, user PATs, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A - no auth/session/CORS changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A - no API/OpenAPI/MCP surface changes.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A - no UI changes.)
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. (N/A - no visible UI change.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A - no visible UI/frontend/docs render change; generated output remains byte-identical for the current command catalogs.

## Notes

- The generated `apps/gittensory-ui/src/lib/command-reference.ts` file did not change after regeneration; the fix only makes future catalog entries with escaped string contents safe.