### PR TITLE
fix(scoring): exempt the maintainer lane from the issue-discovery validity floor

### DIFF
--- a/src/scoring/preview.ts
+++ b/src/scoring/preview.ts
@@ -421,9 +421,11 @@ function computeScoreCore(
   const issueCredibilityFloor = constant(constants, "MIN_ISSUE_CREDIBILITY");
   const validSolvedIssuesObserved = input.validSolvedIssues !== undefined ? nonNegative(input.validSolvedIssues) : undefined;
   const issueCredibilityObserved = input.issueCredibility !== undefined ? clamp(input.issueCredibility, 0, 1) : undefined;
-  // Issue-discovery validity mirrors upstream's separate issue lane — only gate previews that
-  // actually claim linked-issue / issue-discovery scoring, not every repo with a non-zero share.
-  const issueDiscoveryRelevant = (input.linkedIssueMode ?? "none") !== "none";
+  // Issue-discovery validity mirrors upstream's separate issue lane, which is the `standard` linked-issue
+  // lane only. The `maintainer` lane explicitly does not require solved-by-PR issue linkage (see
+  // decideLinkedIssueMultiplier), so it must not be gated by the solved-issue history floor — otherwise a
+  // maintainer preview with sparse issue history is wrongly zeroed and flagged issue_discovery_validity_floor.
+  const issueDiscoveryRelevant = (input.linkedIssueMode ?? "none") === "standard";
   const issueDiscoveryHistoryKnown = validSolvedIssuesObserved !== undefined && issueCredibilityObserved !== undefined;
   const issueDiscoveryHistoryMultiplier =
     !issueDiscoveryRelevant || !issueDiscoveryHistoryKnown

--- a/test/unit/scoring.test.ts
+++ b/test/unit/scoring.test.ts
@@ -1590,6 +1590,34 @@ NOVELTY_BONUS_SCALAR = 3
       ).toBe(true);
     });
 
+    it("does not gate the maintainer lane by the issue-discovery validity floor (#808)", () => {
+      const issueDiscoveryRepo: RepositoryRecord = {
+        ...repo,
+        registryConfig: { ...repo.registryConfig!, issueDiscoveryShare: 0.25 },
+      };
+      // The same sparse solved-issue history that zeroes a `standard` preview must not gate the maintainer
+      // lane, which does not require solved-by-PR issue linkage.
+      const maintainer = buildScorePreview({
+        repo: issueDiscoveryRepo,
+        snapshot,
+        input: {
+          repoFullName: issueDiscoveryRepo.fullName,
+          sourceTokenScore: 60,
+          totalTokenScore: 90,
+          sourceLines: 50,
+          openPrCount: 0,
+          credibility: 1,
+          mergedPullRequests: 5,
+          linkedIssueMode: "maintainer" as const,
+          validSolvedIssues: 2,
+          issueCredibility: 0.9,
+        },
+      });
+      expect(maintainer.scoreEstimate.issueDiscoveryHistoryMultiplier).toBe(1);
+      expect(maintainer.effectiveEstimatedScore).toBeGreaterThan(0);
+      expect(maintainer.blockedBy.some((b) => b.code === "issue_discovery_validity_floor")).toBe(false);
+    });
+
     it("issue-discovery validity floor is skipped when issue-discovery is not relevant or history is unknown", () => {
       const issueDiscoveryRepo: RepositoryRecord = {
         ...repo,


### PR DESCRIPTION
## Summary

`computeScoreCore` in `src/scoring/preview.ts` applies an issue-discovery **solved-issue history floor**
(`MIN_VALID_SOLVED_ISSUES` / `MIN_ISSUE_CREDIBILITY`) as a hard `0`/`1` multiplier over the whole
estimated score, gated by `issueDiscoveryRelevant`:

```ts
const issueDiscoveryRelevant = (input.linkedIssueMode ?? "none") !== "none";
```

That treats **both** `standard` and `maintainer` linked-issue modes as issue-discovery work. But the
`maintainer` lane is explicitly exempt from solved-by-PR issue linkage — `decideLinkedIssueMultiplier`
returns for `mode === "maintainer"`: *"Maintainer-lane multiplier does not require solved-by-PR issue
linkage"* (`status: "not_required"`, `eligible: true`). Gating that same maintainer preview by the
solved-issue floor contradicts that (and the line's own comment: "only gate previews that actually claim
… issue-discovery scoring").

Effect: a `maintainer`-lane score preview that supplies sparse issue history
(`validSolvedIssues`/`issueCredibility` below the floors) is **wrongly zeroed** (`issueDiscoveryHistoryMultiplier
= 0` → `estimatedMergedScore = 0`) and gets a false `issue_discovery_validity_floor` blocker. This is
reachable: the public score-preview API (`src/api/routes.ts`) and the MCP score-preview tool
(`src/mcp/server.ts`) both accept `linkedIssueMode: "maintainer"` alongside optional `validSolvedIssues`
and `issueCredibility`.

Fix: gate the issue-discovery floor to the `standard` lane only — the lane that actually claims
issue-discovery scoring. `none` and `maintainer` are ungated (multiplier `1`); `standard` behavior is
unchanged.

No linked issue: small, self-evident correctness fix that aligns one gate with the module's own
maintainer-lane exemption; it only stops the maintainer lane from being wrongly zeroed (a strict
improvement for that lane) and changes no `standard`/`none` behavior — fits the repo's `preferred` (not
required) linked-issue policy.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran locally: `git diff --check` (clean), `npm run typecheck` (clean), and a focused `test:coverage`
  over `test/unit/scoring.test.ts` — 87 tests pass and the changed line is fully covered (`none` /
  `standard` / `maintainer` all exercised; the only uncovered lines in the file, 1141-1143 and 1175-1191,
  are pre-existing and outside this diff), so `codecov/patch` is 100% on this diff.
- Not run locally: the UI, MCP, workers, OpenAPI, actionlint, and audit jobs. This is a `src/`-only change
  to one deterministic scoring helper touching no UI/API-shape/OpenAPI/DB/workflow surface, so those jobs
  are no-ops for this diff; they run on CI (Linux).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- No API/OpenAPI shape change — the score-preview request/response schemas are unchanged; only the
  computed `issueDiscoveryHistoryMultiplier` (and downstream score/blocker) is corrected for the maintainer
  lane. No auth/UI surface touched.
- Regression test added in `test/unit/scoring.test.ts` ("does not gate the maintainer lane by the
  issue-discovery validity floor"): a `maintainer` preview with the same sparse history that zeroes a
  `standard` preview now keeps `issueDiscoveryHistoryMultiplier === 1`, a positive score, and no
  `issue_discovery_validity_floor` blocker. The existing `standard`-lane floor and skip tests are unchanged.
