### PR TITLE
fix(enrichment): map GHSA MODERATE advisories to medium severity

### DIFF
--- a/review-enrichment/src/analyzers/dependency-scan.ts
+++ b/review-enrichment/src/analyzers/dependency-scan.ts
@@ -151,6 +151,10 @@ function severityOf(vuln: OsvVuln): Cve["severity"] {
     label === "low"
   )
     return label;
+  // GHSA — the dominant OSV source for npm/PyPI — labels medium advisories with GitHub's word
+  // "moderate", which maps to "medium". Without this, MODERATE CVEs fall through to the CVSS branch,
+  // whose OSV `score` is a vector string (not a number) and so degrades every such advisory to "unknown".
+  if (label === "moderate") return "medium";
   const score = Number(
     vuln.severity?.find((s) => s.type?.startsWith("CVSS"))?.score,
   );

--- a/review-enrichment/src/analyzers/lockfile-drift.ts
+++ b/review-enrichment/src/analyzers/lockfile-drift.ts
@@ -68,6 +68,10 @@ function severityOf(vuln: OsvVuln): Cve["severity"] {
     label === "low"
   )
     return label;
+  // GHSA — the dominant OSV source for npm/PyPI — labels medium advisories with GitHub's word
+  // "moderate", which maps to "medium". Without this, MODERATE CVEs fall through to the CVSS branch,
+  // whose OSV `score` is a vector string (not a number) and so degrades every such advisory to "unknown".
+  if (label === "moderate") return "medium";
   const score = Number(
     vuln.severity?.find((s) => s.type?.startsWith("CVSS"))?.score,
   );

--- a/review-enrichment/test/osv-severity.test.ts
+++ b/review-enrichment/test/osv-severity.test.ts
@@ -1,0 +1,48 @@
+// Units for the OSV severity label mapping shared by the dependency-scan and lockfile-drift analyzers.
+// Own file so concurrent analyzer PRs don't collide. Runs against the compiled dist/.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { queryOsvBatch as queryOsvBatchDependency } from "../dist/analyzers/dependency-scan.js";
+import { queryOsvBatch as queryOsvBatchLockfile } from "../dist/analyzers/lockfile-drift.js";
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+// GHSA — the dominant OSV source for npm/PyPI — labels medium advisories with GitHub's word "MODERATE",
+// and puts a CVSS *vector string* (not a number) in `severity[].score`. Both analyzers must map MODERATE
+// to "medium"; without it the vector-string CVSS fallback yields NaN and the advisory is mislabeled
+// "unknown" (and sorted to the bottom). The fix is identical in both, so assert the same contract on each.
+for (const [name, queryOsvBatch] of [
+  ["dependency-scan", queryOsvBatchDependency],
+  ["lockfile-drift", queryOsvBatchLockfile],
+] as const) {
+  test(`${name} severity: maps a GHSA MODERATE advisory to "medium", not "unknown"`, async () => {
+    const fetchImpl = (async () =>
+      jsonResponse({
+        results: [
+          {
+            vulns: [
+              {
+                id: "GHSA-p6mc-m468-83gw",
+                summary: "moderate-severity advisory",
+                database_specific: { severity: "MODERATE" },
+                severity: [{ type: "CVSS_V3", score: "CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:L" }],
+              },
+            ],
+          },
+        ],
+      })) as unknown as typeof fetch;
+
+    const result = await queryOsvBatch(
+      [{ ecosystem: "npm", package: "lodash", from: null, to: "4.17.20" }],
+      fetchImpl,
+    );
+    const cves = [...result.values()][0] ?? [];
+    assert.equal(cves.length, 1);
+    assert.equal(cves[0]?.severity, "medium");
+  });
+}


### PR DESCRIPTION
## Summary

`severityOf` in the OSV vulnerability scanners (`review-enrichment/src/analyzers/dependency-scan.ts` and
its duplicate in `lockfile-drift.ts`) maps an advisory's `database_specific.severity` label to a
`Cve["severity"]`, checking only `critical` / `high` / `medium` / `low` and otherwise falling back to a
numeric CVSS score:

```ts
const label = vuln.database_specific?.severity?.toLowerCase();
if (label === "critical" || label === "high" || label === "medium" || label === "low") return label;
const score = Number(vuln.severity?.find((s) => s.type?.startsWith("CVSS"))?.score);
if (!Number.isFinite(score)) return "unknown";
```

GHSA (the GitHub Advisory Database) is the dominant OSV source for npm/PyPI, and it labels
medium-severity advisories with GitHub's vocabulary word **`MODERATE`**, not `MEDIUM`. `MODERATE` matches
none of the four cases, so it falls through to the CVSS branch — but OSV's `severity[].score` is a CVSS
**vector string** (e.g. `"CVSS:3.1/AV:N/AC:H/..."`), so `Number(...)` is `NaN` and the advisory is
mislabeled **`"unknown"`**. Because the CVSS branch can never yield a number for a `CVSS_V3`/`CVSS_V4`
entry, the label branch is the only path that produces a real severity — so **every** MODERATE advisory
(a large fraction of npm/PyPI CVEs) is downgraded to `unknown`, rendered as `**unknown**`, and sorted to
the bottom of the findings.

This is reachable on live data: `scanDependencyChanges` / `scanLockfileDrift` query `api.osv.dev` and run
`severityOf` over the returned advisories.

Fix: map `moderate → medium` (GitHub's own canonical severity equivalence) in both analyzers. Purely
additive — `moderate` was previously unhandled, so no existing mapping changes and no regex/backtracking
surface is introduced.

No linked issue: small, self-evident severity-mapping correctness fix (one additive case per analyzer)
with no schema/config/deploy change — fits the repo's `preferred` (not required) linked-issue policy.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run typecheck`
- [x] `npm run rees:test` — the review-enrichment build + analyzer suite (see note below)
- [ ] `npm run test:coverage` (N/A — these files are in `review-enrichment/`, outside the `src/**` Codecov scope)
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran locally: `git diff --check` (clean), the review-enrichment TypeScript build (`npm --prefix
  review-enrichment run build`, clean), and the analyzer test suite via `node --test` — **20/20 tests
  pass**, including the new MODERATE→medium regression asserted against **both** analyzers. The change is
  confined to `review-enrichment/`, outside the `src/**` Codecov scope, so `test:coverage` does not apply.
- Not run locally: the UI, root typecheck, and the `metadata:check` step of `rees:test`. `metadata:check`
  compares the committed `analyzer-metadata.json` (generated on CI/Linux) against a local regeneration and
  reports a spurious byte difference on this Windows dev box (it fails identically on unmodified `main`);
  this change touches only `severityOf`'s label mapping, not any analyzer descriptor, so the committed
  metadata is unchanged and `metadata:check` passes on CI (Linux). `analyzer-metadata.json` was NOT modified.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Both `severityOf` copies (dependency-scan + lockfile-drift) carry the identical defect, so both are
  fixed in this PR — matching how #2609's OSV "fixed in" fix and its `osv-fixed-version.test.ts` cover both
  analyzers together. `analyzer-metadata.json` is intentionally untouched (no descriptor changed).
- Regression tests added in a new `review-enrichment/test/osv-severity.test.ts` (mirroring the
  `osv-fixed-version.test.ts` convention of a per-fix file to avoid concurrent-PR collisions): a GHSA
  advisory with `database_specific.severity: "MODERATE"` and a CVSS vector `score` now resolves to
  `severity: "medium"` via each analyzer's exported `queryOsvBatch` (was `"unknown"`).
