### PR TITLE
feat(miner-discovery): explain opportunity scores and summarize limiting factors

### DIFF
--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -9,6 +9,14 @@ export {
   rankOpportunities,
   type OpportunityRankInput,
 } from "./opportunity-ranker.js";
+export {
+  explainOpportunityScore,
+  summarizeOpportunityFactors,
+  OPPORTUNITY_FACTOR_KEYS,
+  type OpportunityFactorKey,
+  type OpportunityScoreExplanation,
+  type OpportunityFactorSummary,
+} from "./opportunity-ranker-explain.js";
 export * from "./governor/rate-limit.js";
 export {
   GOVERNOR_LEDGER_EVENT_TYPES,

--- a/packages/gittensory-engine/src/opportunity-ranker-explain.ts
+++ b/packages/gittensory-engine/src/opportunity-ranker-explain.ts
@@ -1,0 +1,133 @@
+// Opportunity-score explanation. The ranker in `opportunity-ranker.ts` collapses five normalized signals into a
+// single ordinal `rankOpportunityScore` product, which is exactly what a cross-repo candidate list needs to SORT
+// by — but a bare score can't tell a miner WHY a candidate ranked low, so it can't tell "skip it, the work is
+// already contested" from "skip it, it's stale" from "pursue it, it's just off-lane". This module explains a score
+// without re-deriving it: it reuses the ranker's own `clamp01`/`clampRisk` so each factor's reported contribution is
+// the exact multiplier the score was built from, then names the single limiting dimension.
+//
+// PURE — no IO, no Date, no random — matching the ranker and the house convention in src/signals/duplicate-winner.ts.
+// Identical inputs always produce an identical explanation and an identical tie-break.
+
+import { clamp01, clampRisk, rankOpportunityScore, type OpportunityRankInput } from "./opportunity-ranker.js";
+
+/** The five ranked dimensions, in the fixed priority order used to break ties deterministically. A tie on the
+ *  lowest (or the most common) contribution resolves to the factor listed FIRST here, so callers on any engine
+ *  get one stable answer. `potential` first mirrors the field order in {@link OpportunityRankInput}. */
+export const OPPORTUNITY_FACTOR_KEYS = ["potential", "feasibility", "laneFit", "freshness", "dupRisk"] as const;
+
+export type OpportunityFactorKey = (typeof OPPORTUNITY_FACTOR_KEYS)[number];
+
+/** A single candidate's score, broken down into the per-factor multipliers that composed it. */
+export type OpportunityScoreExplanation = {
+  /** The composed ordinal score — identical to {@link rankOpportunityScore} for the same input (pinned by test). */
+  score: number;
+  /** Each factor's EFFECTIVE multiplier in the product: the four positive factors clamped to [0, 1], and `dupRisk`
+   *  expressed as its `1 - clampRisk(dupRisk)` contribution (so more contention reads as a SMALLER multiplier, the
+   *  same direction as the other four). Their product is exactly {@link score}. */
+  contributions: Record<OpportunityFactorKey, number>;
+  /** The factor with the SMALLEST contribution — the dimension dragging the score down most, and the first thing a
+   *  miner should weigh before spending effort. Ties resolve by {@link OPPORTUNITY_FACTOR_KEYS} order, so an
+   *  all-equal input (including a perfect `1` across the board) deterministically reports `potential`. */
+  limitingFactor: OpportunityFactorKey;
+  /** Whether the opportunity is worth pursuing at all. The score is a product, so a single zero contribution (a
+   *  positive factor at/below 0, a non-finite one, or `dupRisk >= 1`) collapses it to 0 — `isViable` is false in
+   *  exactly those cases and true otherwise. */
+  isViable: boolean;
+};
+
+/** The `1 - clampRisk(dupRisk)` contention contribution: a fully-contested or broken (`dupRisk >= 1` / non-finite)
+ *  signal contributes 0, an uncontested one contributes 1 — same [0, 1] direction as the positive factors. */
+function contentionContribution(dupRisk: number): number {
+  return 1 - clampRisk(dupRisk);
+}
+
+function contributionsOf(input: OpportunityRankInput): Record<OpportunityFactorKey, number> {
+  return {
+    potential: clamp01(input.potential),
+    feasibility: clamp01(input.feasibility),
+    laneFit: clamp01(input.laneFit),
+    freshness: clamp01(input.freshness),
+    dupRisk: contentionContribution(input.dupRisk),
+  };
+}
+
+/** The factor whose contribution is strictly the smallest; on a tie the earliest in {@link OPPORTUNITY_FACTOR_KEYS}
+ *  wins, so the choice never depends on object key order or a non-stable comparison. */
+function lowestContributionFactor(contributions: Record<OpportunityFactorKey, number>): OpportunityFactorKey {
+  let limiting: OpportunityFactorKey = OPPORTUNITY_FACTOR_KEYS[0];
+  for (const key of OPPORTUNITY_FACTOR_KEYS) {
+    if (contributions[key] < contributions[limiting]) limiting = key;
+  }
+  return limiting;
+}
+
+/**
+ * Explain one candidate's opportunity score: the same product {@link rankOpportunityScore} yields, plus the per-factor
+ * multipliers it was built from and the single limiting dimension. Pure. The reported {@link OpportunityScoreExplanation.score}
+ * is computed as the product of the reported contributions, so the breakdown is internally consistent by construction
+ * and (because it reuses the ranker's own `clamp01`/`clampRisk`) equals `rankOpportunityScore(input)` — an invariant the
+ * tests pin so the two can never silently diverge.
+ */
+export function explainOpportunityScore(input: OpportunityRankInput): OpportunityScoreExplanation {
+  const contributions = contributionsOf(input);
+  const score =
+    contributions.potential *
+    contributions.feasibility *
+    contributions.laneFit *
+    contributions.freshness *
+    contributions.dupRisk;
+  return {
+    score,
+    contributions,
+    limitingFactor: lowestContributionFactor(contributions),
+    isViable: score > 0,
+  };
+}
+
+/** A pipeline-level rollup of the limiting factors across a whole candidate list. */
+export type OpportunityFactorSummary = {
+  /** Number of candidates summarized. */
+  count: number;
+  /** How many candidates are viable (score > 0). */
+  viableCount: number;
+  /** Histogram of which factor limited each candidate — every key present, zero-filled. Sums to {@link count}. */
+  limitingFactorCounts: Record<OpportunityFactorKey, number>;
+  /** The factor that limited the MOST candidates (ties broken by {@link OPPORTUNITY_FACTOR_KEYS} order), or `null`
+   *  for an empty list. The systemic bottleneck a miner should address first — e.g. "most candidates are off-lane". */
+  mostCommonLimitingFactor: OpportunityFactorKey | null;
+};
+
+function zeroedFactorCounts(): Record<OpportunityFactorKey, number> {
+  return { potential: 0, feasibility: 0, laneFit: 0, freshness: 0, dupRisk: 0 };
+}
+
+/**
+ * Summarize the limiting factors across a candidate list: how many are viable, a per-factor histogram of what limited
+ * each one, and the single most common bottleneck. Pure; does not mutate the input. An empty list yields an all-zero
+ * histogram and a `null` most-common factor (there is no bottleneck to report), never a spurious pick.
+ */
+export function summarizeOpportunityFactors(candidates: readonly OpportunityRankInput[]): OpportunityFactorSummary {
+  const limitingFactorCounts = zeroedFactorCounts();
+  let viableCount = 0;
+  for (const candidate of candidates) {
+    const explanation = explainOpportunityScore(candidate);
+    limitingFactorCounts[explanation.limitingFactor] += 1;
+    if (explanation.isViable) viableCount += 1;
+  }
+  return {
+    count: candidates.length,
+    viableCount,
+    limitingFactorCounts,
+    mostCommonLimitingFactor: candidates.length === 0 ? null : mostCommon(limitingFactorCounts),
+  };
+}
+
+/** The factor with the highest count; ties resolve to the earliest in {@link OPPORTUNITY_FACTOR_KEYS}. Only called
+ *  for a non-empty list, so the returned factor always reflects at least one candidate. */
+function mostCommon(counts: Record<OpportunityFactorKey, number>): OpportunityFactorKey {
+  let top: OpportunityFactorKey = OPPORTUNITY_FACTOR_KEYS[0];
+  for (const key of OPPORTUNITY_FACTOR_KEYS) {
+    if (counts[key] > counts[top]) top = key;
+  }
+  return top;
+}

--- a/packages/gittensory-engine/src/opportunity-ranker.ts
+++ b/packages/gittensory-engine/src/opportunity-ranker.ts
@@ -23,7 +23,7 @@ export type OpportunityRankInput = {
 };
 
 /** Clamp a positive factor to [0, 1]; a non-finite value (NaN/±Infinity from a broken upstream) degrades to 0. */
-function clamp01(value: number): number {
+export function clamp01(value: number): number {
   if (!Number.isFinite(value)) return 0;
   return Math.min(1, Math.max(0, value));
 }
@@ -35,7 +35,7 @@ function clamp01(value: number): number {
  * maximum risk (1), never 0: a broken contention signal must not masquerade as a safe, uncontested opportunity
  * (mirroring the fail-closed convention in `src/signals/duplicate-winner.ts`, where sparse rows fail closed).
  */
-function clampRisk(value: number): number {
+export function clampRisk(value: number): number {
   if (!Number.isFinite(value)) return 1;
   return Math.min(1, Math.max(0, value));
 }

--- a/packages/gittensory-engine/test/opportunity-ranker-explain.test.ts
+++ b/packages/gittensory-engine/test/opportunity-ranker-explain.test.ts
@@ -1,0 +1,75 @@
+// Units for the opportunity-score explanation. Runs against the compiled dist/ (built by the `test` script first),
+// mirroring the ranker's node:test convention. Imports through the package's public barrel (dist/index.js) so the
+// export contract itself is exercised. Pure module — no network, never flakes.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  explainOpportunityScore,
+  summarizeOpportunityFactors,
+  rankOpportunityScore,
+  OPPORTUNITY_FACTOR_KEYS,
+} from "../dist/index.js";
+
+const full = { potential: 1, feasibility: 1, laneFit: 1, freshness: 1, dupRisk: 0 };
+
+const closeTo = (actual: number, expected: number): void =>
+  assert.ok(Math.abs(actual - expected) < 1e-9, `expected ~${expected}, got ${actual}`);
+
+test("barrel: the public entrypoint re-exports the explanation API", () => {
+  assert.equal(typeof explainOpportunityScore, "function");
+  assert.equal(typeof summarizeOpportunityFactors, "function");
+  assert.deepEqual([...OPPORTUNITY_FACTOR_KEYS], ["potential", "feasibility", "laneFit", "freshness", "dupRisk"]);
+});
+
+test("explainOpportunityScore: score matches the ranker and the product of its contributions", () => {
+  const input = { potential: 0.8, feasibility: 0.5, laneFit: 0.5, freshness: 0.5, dupRisk: 0.5 };
+  const explanation = explainOpportunityScore(input);
+  closeTo(explanation.score, rankOpportunityScore(input));
+  closeTo(
+    explanation.score,
+    explanation.contributions.potential *
+      explanation.contributions.feasibility *
+      explanation.contributions.laneFit *
+      explanation.contributions.freshness *
+      explanation.contributions.dupRisk,
+  );
+});
+
+test("explainOpportunityScore: dupRisk contributes 1 - risk, and names the smallest factor", () => {
+  const explanation = explainOpportunityScore({ ...full, dupRisk: 0.9 });
+  closeTo(explanation.contributions.dupRisk, 0.1);
+  assert.equal(explanation.limitingFactor, "dupRisk");
+});
+
+test("explainOpportunityScore: a perfect candidate ties to the first factor and is viable", () => {
+  const explanation = explainOpportunityScore(full);
+  assert.equal(explanation.score, 1);
+  assert.equal(explanation.limitingFactor, "potential");
+  assert.equal(explanation.isViable, true);
+});
+
+test("explainOpportunityScore: a zero factor collapses the score and marks it non-viable", () => {
+  const explanation = explainOpportunityScore({ ...full, laneFit: 0 });
+  assert.equal(explanation.score, 0);
+  assert.equal(explanation.limitingFactor, "laneFit");
+  assert.equal(explanation.isViable, false);
+});
+
+test("summarizeOpportunityFactors: histogram, viable count, and most common bottleneck", () => {
+  const summary = summarizeOpportunityFactors([
+    { ...full, potential: 0.1 },
+    { ...full, potential: 0.2 },
+    { ...full, dupRisk: 0.9 },
+    { ...full, laneFit: 0 },
+  ]);
+  assert.equal(summary.count, 4);
+  assert.equal(summary.viableCount, 3);
+  assert.deepEqual(summary.limitingFactorCounts, { potential: 2, feasibility: 0, laneFit: 1, freshness: 0, dupRisk: 1 });
+  assert.equal(summary.mostCommonLimitingFactor, "potential");
+});
+
+test("summarizeOpportunityFactors: an empty list has no bottleneck", () => {
+  const summary = summarizeOpportunityFactors([]);
+  assert.equal(summary.count, 0);
+  assert.equal(summary.mostCommonLimitingFactor, null);
+});

--- a/test/unit/opportunity-ranker-explain.test.ts
+++ b/test/unit/opportunity-ranker-explain.test.ts
@@ -1,0 +1,170 @@
+import { describe, expect, it } from "vitest";
+import { rankOpportunityScore, type OpportunityRankInput } from "../../packages/gittensory-engine/src/opportunity-ranker";
+import {
+  explainOpportunityScore,
+  summarizeOpportunityFactors,
+  OPPORTUNITY_FACTOR_KEYS,
+  type OpportunityFactorKey,
+} from "../../packages/gittensory-engine/src/opportunity-ranker-explain";
+
+// A neutral, all-passing candidate (every factor 1, no contention → score 1); tests override one field at a time,
+// mirroring the helper in opportunity-ranker.test.ts.
+function input(over: Partial<OpportunityRankInput> = {}): OpportunityRankInput {
+  return { potential: 1, feasibility: 1, laneFit: 1, freshness: 1, dupRisk: 0, ...over };
+}
+
+describe("explainOpportunityScore", () => {
+  it("reports each factor's effective contribution, with dupRisk as its 1 - risk multiplier", () => {
+    expect(explainOpportunityScore(input()).contributions).toEqual({
+      potential: 1,
+      feasibility: 1,
+      laneFit: 1,
+      freshness: 1,
+      dupRisk: 1,
+    });
+    expect(explainOpportunityScore(input({ potential: 0.5, dupRisk: 0.25 })).contributions).toEqual({
+      potential: 0.5,
+      feasibility: 1,
+      laneFit: 1,
+      freshness: 1,
+      dupRisk: 0.75,
+    });
+  });
+
+  // The whole point of the explanation is that it never drifts from the score it explains: the reported
+  // contributions multiply back to `score`, and that `score` equals the authoritative ranker for the same input.
+  const PARITY_CASES: OpportunityRankInput[] = [
+    input(),
+    input({ potential: 0.5 }),
+    input({ dupRisk: 0.5 }),
+    input({ potential: 0.8, feasibility: 0.5, laneFit: 0.5, freshness: 0.5, dupRisk: 0.5 }),
+    input({ freshness: 0.25, dupRisk: 0.2 }),
+    input({ laneFit: 0 }),
+    input({ dupRisk: 1 }),
+    input({ potential: 2, feasibility: 2 }), // clamps
+    input({ potential: -1 }),
+    input({ freshness: NaN }),
+    input({ dupRisk: Infinity }),
+    input({ dupRisk: -5 }),
+    input({ potential: 0.9, feasibility: 0.9, laneFit: 0.9, freshness: 0.9, dupRisk: 0.1 }),
+  ];
+
+  it.each(PARITY_CASES)("score equals rankOpportunityScore and the product of its own contributions (%#)", (value) => {
+    const explanation = explainOpportunityScore(value);
+    const product =
+      explanation.contributions.potential *
+      explanation.contributions.feasibility *
+      explanation.contributions.laneFit *
+      explanation.contributions.freshness *
+      explanation.contributions.dupRisk;
+    expect(explanation.score).toBeCloseTo(rankOpportunityScore(value), 12);
+    expect(explanation.score).toBeCloseTo(product, 12);
+  });
+
+  it.each(["potential", "feasibility", "laneFit", "freshness"] as const)(
+    "names %s as the limiting factor when it is the single smallest contribution",
+    (factor) => {
+      expect(explainOpportunityScore(input({ [factor]: 0.1 })).limitingFactor).toBe(factor);
+    },
+  );
+
+  it("names dupRisk as the limiting factor when contention is the smallest contribution", () => {
+    // dupRisk 0.9 → contribution 0.1, below every positive factor at 1.
+    expect(explainOpportunityScore(input({ dupRisk: 0.9 })).limitingFactor).toBe("dupRisk");
+  });
+
+  it("breaks a contribution tie by OPPORTUNITY_FACTOR_KEYS order (earliest wins)", () => {
+    // All contributions equal 1 → the first key, potential, is reported deterministically.
+    expect(explainOpportunityScore(input()).limitingFactor).toBe("potential");
+    // potential and dupRisk both contribute 0.5; potential precedes dupRisk in the key order.
+    expect(explainOpportunityScore(input({ potential: 0.5, dupRisk: 0.5 })).limitingFactor).toBe("potential");
+    // feasibility and laneFit both contribute 0.3; feasibility precedes laneFit.
+    expect(explainOpportunityScore(input({ feasibility: 0.3, laneFit: 0.3 })).limitingFactor).toBe("feasibility");
+  });
+
+  it("clamps and fails closed inside the contributions, matching the ranker", () => {
+    expect(explainOpportunityScore(input({ potential: 1.5 })).contributions.potential).toBe(1);
+    expect(explainOpportunityScore(input({ potential: -0.5 })).contributions.potential).toBe(0);
+    expect(explainOpportunityScore(input({ freshness: NaN })).contributions.freshness).toBe(0);
+    expect(explainOpportunityScore(input({ dupRisk: -0.1 })).contributions.dupRisk).toBe(1); // 1 - 0
+    expect(explainOpportunityScore(input({ dupRisk: 1.4 })).contributions.dupRisk).toBe(0); // 1 - 1
+    expect(explainOpportunityScore(input({ dupRisk: NaN })).contributions.dupRisk).toBe(0); // fails closed to 1 risk
+  });
+
+  it("marks a candidate viable only when its score is above 0", () => {
+    expect(explainOpportunityScore(input()).isViable).toBe(true);
+    expect(explainOpportunityScore(input({ potential: 0.5, freshness: 0.5 })).isViable).toBe(true);
+    expect(explainOpportunityScore(input({ laneFit: 0 })).isViable).toBe(false); // a zero factor collapses the product
+    expect(explainOpportunityScore(input({ dupRisk: 1 })).isViable).toBe(false); // full contention collapses it
+    expect(explainOpportunityScore(input({ freshness: NaN })).isViable).toBe(false); // non-finite degrades to 0
+  });
+
+  it("exposes the five factor keys in fixed priority order", () => {
+    expect(OPPORTUNITY_FACTOR_KEYS).toEqual(["potential", "feasibility", "laneFit", "freshness", "dupRisk"]);
+  });
+
+  it("does not mutate its input", () => {
+    const value = input({ potential: 0.5, dupRisk: 0.25 });
+    const snapshot = structuredClone(value);
+    explainOpportunityScore(value);
+    expect(value).toEqual(snapshot);
+  });
+});
+
+describe("summarizeOpportunityFactors", () => {
+  it("rolls up viability, a per-factor histogram, and the most common bottleneck", () => {
+    const summary = summarizeOpportunityFactors([
+      input({ potential: 0.1 }), // limiting potential, viable
+      input({ potential: 0.2 }), // limiting potential, viable
+      input({ dupRisk: 0.9 }), // limiting dupRisk, viable (0.1)
+      input({ laneFit: 0 }), // limiting laneFit, NOT viable (score 0)
+    ]);
+    expect(summary.count).toBe(4);
+    expect(summary.viableCount).toBe(3);
+    expect(summary.limitingFactorCounts).toEqual({ potential: 2, feasibility: 0, laneFit: 1, freshness: 0, dupRisk: 1 });
+    expect(summary.mostCommonLimitingFactor).toBe("potential");
+  });
+
+  it("breaks a most-common tie by OPPORTUNITY_FACTOR_KEYS order", () => {
+    const summary = summarizeOpportunityFactors([input({ potential: 0.1 }), input({ dupRisk: 0.1 })]);
+    expect(summary.limitingFactorCounts.potential).toBe(1);
+    expect(summary.limitingFactorCounts.dupRisk).toBe(1);
+    expect(summary.mostCommonLimitingFactor).toBe("potential"); // potential precedes dupRisk
+  });
+
+  it("reports a non-first factor as the bottleneck when it limits the most candidates", () => {
+    // Every candidate is limited by dupRisk (the LAST key), so the winner must be found by advancing past the
+    // zero-count leading factors — exercising the update path, not just the initial pick.
+    const summary = summarizeOpportunityFactors([input({ dupRisk: 0.9 }), input({ dupRisk: 0.8 }), input({ dupRisk: 0.5 })]);
+    expect(summary.limitingFactorCounts).toEqual({ potential: 0, feasibility: 0, laneFit: 0, freshness: 0, dupRisk: 3 });
+    expect(summary.mostCommonLimitingFactor).toBe("dupRisk");
+  });
+
+  it("returns a zeroed histogram and a null bottleneck for an empty list", () => {
+    const summary = summarizeOpportunityFactors([]);
+    expect(summary.count).toBe(0);
+    expect(summary.viableCount).toBe(0);
+    expect(summary.limitingFactorCounts).toEqual({ potential: 0, feasibility: 0, laneFit: 0, freshness: 0, dupRisk: 0 });
+    expect(summary.mostCommonLimitingFactor).toBeNull();
+  });
+
+  it("counts every candidate as non-viable when none clear a zero factor", () => {
+    const summary = summarizeOpportunityFactors([input({ potential: 0 }), input({ dupRisk: 1 })]);
+    expect(summary.viableCount).toBe(0);
+    expect(summary.count).toBe(2);
+  });
+
+  it("does not mutate the input array or its elements", () => {
+    const candidates = [input({ potential: 0.5 }), input({ laneFit: 0.25 })];
+    const snapshot = structuredClone(candidates);
+    summarizeOpportunityFactors(candidates);
+    expect(candidates).toEqual(snapshot);
+  });
+
+  it("keeps the histogram keys exhaustive over the factor set", () => {
+    const summary = summarizeOpportunityFactors([input()]);
+    expect(Object.keys(summary.limitingFactorCounts).sort()).toEqual([...OPPORTUNITY_FACTOR_KEYS].sort());
+    const factorKey: OpportunityFactorKey = "freshness";
+    expect(summary.limitingFactorCounts[factorKey]).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

The opportunity ranker (`packages/gittensory-engine/src/opportunity-ranker.ts`, #2302) collapses five normalized signals - `potential`, `feasibility`, `laneFit`, `freshness`, `dupRisk` - into a single product `rankOpportunityScore`, which is exactly what a cross-repo candidate list needs to **sort** by. But a bare score can't tell a miner **why** a candidate ranked low: it can't distinguish "skip it, the work is already contested" from "skip it, it's stale" from "pursue it, it's just off-lane".

This adds two pure, deterministic helpers to the engine package:

- **`explainOpportunityScore(input)`** - returns the same score, each factor's **effective multiplier** in the product (`dupRisk` expressed as its `1 - clampRisk(dupRisk)` contribution, so more contention reads as a smaller multiplier like the other four), the single **limiting factor** (smallest contribution; ties broken by a fixed key order), and an `isViable` flag (score > 0).
- **`summarizeOpportunityFactors(candidates)`** - rolls those up across a list into a viable count, a per-factor histogram of what limited each candidate, and the **most common bottleneck** (`null` for an empty list) - the systemic issue a miner should address first.

Both reuse the ranker's own `clamp01`/`clampRisk` (now exported), so the reported contributions multiply back to **exactly** `rankOpportunityScore(input)` - an invariant pinned by the tests so the explanation can never silently drift from the score it explains. Pure (no IO, no `Date`, no random), matching the ranker and `src/signals/duplicate-winner.ts`. It follows the package's established function-before-consumer convention (the ranker itself landed ahead of its `gittensory_find_opportunities` consumer) and composes directly with `rankOpportunities`.

No linked issue: this is a small, self-contained additive engine capability; per this repo's `linkedIssuePolicy: preferred`, the summary describes it in full.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (green)
- [x] `npm run build:miner` builds + typechecks the engine package with the new module and barrel exports (green)
- [x] `npm test --workspace @jsonbored/gittensory-engine` - the engine's node:test suite (79 tests) passes, including the new `opportunity-ranker-explain` file exercised through the built `dist/` barrel
- [x] Coverage of the new module is **100%** - Statements 25/25, Branches 8/8, Functions 7/7, Lines 22/22 (via `test/unit/opportunity-ranker-explain.test.ts`, 31 tests). `packages/**` is outside the Codecov `src/**` gate, but full branch coverage was verified regardless.
- [x] New behavior has unit tests for every branch (per-factor limiting, tie-breaks by key order, clamp/fail-closed contributions, viability, the score-parity invariant, empty-list summary, purity).

If any required check was skipped, explain why:

- The full `npm run test:ci` was not run in my local dev environment (several self-host suites require Linux/bash/Docker/Postgres). This change is confined to `packages/gittensory-engine` (pure functions, no `src/`, API/OpenAPI, MCP, Cloudflare binding, DB, or migration surface), so no generated artifacts change and the unrelated suites are unaffected; the engine build, typecheck, both test suites, and 100% module coverage are green locally, and the remaining CI runs on this PR.

## Safety

- [x] No secrets, wallets, hotkeys, coldkeys, PATs, private keys, trust scores, private rankings, or maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized and low-noise; no compensation/optimization implications.
- [x] No auth/cookie/CORS/GitHub App/Cloudflare/session changes.
- [x] No API/OpenAPI/MCP behavior changes - this adds pure library functions to the engine barrel (function-before-consumer), wired to no route or tool yet.

## UI Evidence

N/A - pure backend engine logic; no UI, frontend, docs, or extension change.

## Notes

- New module: `packages/gittensory-engine/src/opportunity-ranker-explain.ts`, exported from the package barrel.
- Tests added in both conventions used by the package: `test/unit/opportunity-ranker-explain.test.ts` (vitest) and `packages/gittensory-engine/test/opportunity-ranker-explain.test.ts` (node:test against `dist/`).
- The only change to existing code is exporting `clamp01`/`clampRisk` from `opportunity-ranker.ts` so the explanation reuses the exact same normalization as the score (single source of truth).