### PR TITLE
fix(product-usage): stop over-redacting all-caps words that start with the actor handle

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -5460,9 +5460,9 @@ function redactProductUsageActor(value: string | null, actorRedactor: ProductUsa
   if (!value || !actorRedactor) return value;
   return value.replace(actorRedactor.pattern, (match, offset: number, source: string) => {
     const previous = offset > 0 ? source[offset - 1] : undefined;
-    const next = source[offset + match.length];
+    const next = source[offset + match.length] ?? "";
     const hasLeftBoundary = isProductUsageActorTokenBoundary(previous) || isProductUsageCamelBoundaryBefore(previous, match);
-    const hasRightBoundary = isProductUsageActorTokenBoundary(next) || isProductUsageCamelBoundaryAfter(next);
+    const hasRightBoundary = isProductUsageActorTokenBoundary(next) || isProductUsageCamelBoundaryAfter(next, match);
     return hasLeftBoundary && hasRightBoundary ? "<redacted-actor>" : match;
   });
 }
@@ -5479,8 +5479,12 @@ function isProductUsageCamelBoundaryBefore(previous: string | undefined, match: 
   return Boolean(previous && /[a-z0-9]/.test(previous) && /^[A-Z]/.test(match));
 }
 
-function isProductUsageCamelBoundaryAfter(next: string | undefined): boolean {
-  return Boolean(next && /[A-Z]/.test(next));
+function isProductUsageCamelBoundaryAfter(next: string, match: string): boolean {
+  // Mirror of isProductUsageCamelBoundaryBefore: a camelCase boundary after the match requires the match
+  // to END in a lowercase/digit and the next char to be uppercase (a real `bob`→`Key` hump). Without the
+  // `match` end check, an uppercase→uppercase transition inside an all-caps word (e.g. `bob` matched in
+  // `BOBCAT`) is mistaken for a boundary and the surrounding word is wrongly redacted.
+  return /[A-Z]/.test(next) && /[a-z0-9]$/.test(match);
 }
 
 async function upsertProductUsageDailyRollup(env: Env, day: string, generatedAt: string): Promise<ProductUsageDailyRollupRecord> {

--- a/test/unit/product-usage.test.ts
+++ b/test/unit/product-usage.test.ts
@@ -115,6 +115,26 @@ describe("product usage events", () => {
     expect(JSON.stringify(row)).not.toMatch(/\bbob\b|bobKey|forBob/i);
   });
 
+  it("does not over-redact an all-caps word that merely starts with the actor handle", async () => {
+    const env = createTestEnv({ PRODUCT_USAGE_HASH_SALT: "fixed-test-salt" });
+
+    await recordProductUsageEvent(env, {
+      surface: "api",
+      eventName: "local_branch_analysis_completed",
+      actor: "bob",
+      repoFullName: "acme/tool",
+      targetKey: "acme:tool#1",
+      metadata: { note: "BOBCAT ran the job", viewer: "bob" },
+    });
+
+    const [row] = await listProductUsageEvents(env);
+    expect(row).toBeDefined();
+    if (!row) throw new Error("expected product usage event");
+    // "BOBCAT" is one all-caps word, not a `bob`+`Cat` camelCase hump, so it must stay readable while the
+    // standalone actor handle is still redacted.
+    expect(row.metadata).toMatchObject({ note: "BOBCAT ran the job", viewer: "<redacted-actor>" });
+  });
+
   it("bounds actor redaction patterns while still covering long valid handles", async () => {
     const env = createTestEnv({ PRODUCT_USAGE_HASH_SALT: "fixed-test-salt" });
     const actor = "a".repeat(200);


### PR DESCRIPTION
## Summary

`redactProductUsageActor` in `src/db/repositories.ts` replaces occurrences of the event actor's handle
in product-usage telemetry with `<redacted-actor>`, but only at a genuine token or camelCase boundary so
it doesn't corrupt unrelated words. The left-boundary check is correct:

```ts
function isProductUsageCamelBoundaryBefore(previous, match) {
  return Boolean(previous && /[a-z0-9]/.test(previous) && /^[A-Z]/.test(match)); // lower/digit → UPPER hump
}
```

but the right-boundary check was asymmetric — it flagged a camelCase boundary whenever the **next** char
was uppercase, ignoring whether the matched text actually **ends** in a lowercase/digit:

```ts
function isProductUsageCamelBoundaryAfter(next) {
  return Boolean(next && /[A-Z]/.test(next)); // missing the "match ends lower/digit" check
}
```

So an uppercase→uppercase transition **inside an all-caps word** was mistaken for a camelCase hump. For a
realistic lowercase actor handle like `bob`, an all-caps word beginning with those letters is corrupted:

```
actor "bob", telemetry value "BOBCAT ran the job"
// before: "<redacted-actor>CAT ran the job"   ← "BOB" matched, next "C" is uppercase → wrongly redacted
// after:  "BOBCAT ran the job"                ← unchanged; "BOB" ends uppercase, so it's not a hump
```

This is reachable: `recordProductUsageEvent` runs the redactor over `repoFullName`, `targetKey`,
`clientName`, `clientVersion`, and every metadata string, so any all-caps token starting with the actor's
letters (env-var names, acronyms, SCREAMING_CASE identifiers common in telemetry) is mangled.

Fix: make the right boundary the exact mirror of the left — require the match to **end** in a
lowercase/digit as well as the next char being uppercase. This leaves acronym-adjacent matches readable
**consistently with the left side** (which likewise does not redact e.g. `Server` inside `HTTPServer`), so
no additional redaction is dropped beyond what the module already leaves. `next` is coalesced to a string
at the call site so the helper keeps a clean, fully-covered predicate. The standalone handle and genuine
`handleKey` camelCase humps are still redacted.

No linked issue: small, self-evident correctness fix that makes one boundary check symmetric with its
sibling; it only stops over-redaction (a strict improvement — it never leaks more than the module already
does) with no schema/API/deploy change — fits the repo's `preferred` (not required) linked-issue policy.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran locally: `git diff --check` (clean), `npm run typecheck` (clean), and a focused `test:coverage`
  over `test/unit/product-usage.test.ts` — 26 tests pass and the changed lines are at **100% branch
  coverage** (verified via lcov: the `?? ""` fallback and the boundary predicate both have every branch
  taken), so `codecov/patch` is 100% on this diff.
- Not run locally: the UI, MCP, workers, OpenAPI, actionlint, and audit jobs. This is a `src/`-only change
  to one deterministic redaction helper touching no UI/API-shape/OpenAPI/MCP/DB-schema/workflow surface,
  so those jobs are no-ops for this diff; they run on CI (Linux).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- This is an actor-privacy redaction path. The change only makes the right camelCase boundary **stricter
  by exactly mirroring the already-correct left boundary** — it never redacts less than the left side
  already does for the symmetric case (e.g. `Server` in `HTTPServer` is likewise left readable). So it
  fixes over-redaction (data corruption of legitimate telemetry) without weakening actor privacy.
- Regression test added in `test/unit/product-usage.test.ts` ("does not over-redact an all-caps word that
  merely starts with the actor handle"): with actor `bob`, metadata `"BOBCAT ran the job"` now stays
  readable while the standalone `bob` handle is still redacted. Existing redaction assertions (bobcat
  readable, `bobKey → <redacted-actor>Key`, `forBob`, standalone handle) are unchanged.
