### PR TITLE
fix(bounties): tolerate a null payload in normalizeGittBountySnapshot

### DIFF
--- a/src/bounties/ingest.ts
+++ b/src/bounties/ingest.ts
@@ -16,8 +16,11 @@ type GittIssueListPayload = {
 };
 
 export function normalizeGittBountySnapshot(payload: unknown): BountyRecord[] {
-  const data = payload as GittIssueListPayload;
-  return (data.issues ?? []).flatMap((issue) => {
+  // `payload` is `unknown` and reaches here as `null` when the import route's `c.req.json()` rejects on an
+  // empty/malformed body (`.catch(() => null)`). Optional-chain so a null/undefined payload degrades to an
+  // empty list — matching how every other non-object value already yields `[]` — instead of throwing.
+  const data = payload as GittIssueListPayload | null | undefined;
+  return (data?.issues ?? []).flatMap((issue) => {
     if (issue.id === undefined || !issue.repository_full_name || !issue.issue_number || !issue.status) return [];
     const amountText = issue.bounty_alpha ?? (issue.bounty_amount === undefined ? undefined : String(issue.bounty_amount));
     return [

--- a/test/unit/adapters.test.ts
+++ b/test/unit/adapters.test.ts
@@ -22,6 +22,9 @@ describe("small adapters and normalizers", () => {
 
   it("normalizes gitt bounty snapshots and drops incomplete rows", () => {
     expect(normalizeGittBountySnapshot({})).toEqual([]);
+    // The import route feeds `null` when the request body is empty/malformed — degrade to [], never throw.
+    expect(normalizeGittBountySnapshot(null)).toEqual([]);
+    expect(normalizeGittBountySnapshot(undefined)).toEqual([]);
     const records = normalizeGittBountySnapshot({
       success: true,
       issues: [


### PR DESCRIPTION
## Summary

`normalizeGittBountySnapshot(payload: unknown)` in `src/bounties/ingest.ts` casts `payload` and immediately
reads `.issues`:

```ts
const data = payload as GittIssueListPayload;
return (data.issues ?? []).flatMap((issue) => { … });
```

When `payload` is `null`, the member access `data.issues` throws
`TypeError: Cannot read properties of null (reading 'issues')` — the `?? []` never runs, because the throw
happens during the property access, not on its result.

This is reachable. The import route feeds a possibly-`null` body:

```ts
// src/api/routes.ts — POST /v1/internal/bounties/import
const body = await c.req.json().catch(() => null);
const bounties = normalizeGittBountySnapshot(body);
```

So an empty request body, malformed JSON, or a literal JSON `null` makes `c.req.json()` reject → caught →
`body = null` → the normalizer **throws an unhandled error and the import route 500s**, instead of
importing zero bounties. The signature is `unknown` (arbitrary input is the intended contract), and every
other non-object value (string/number/array) already degrades safely to `[]` via `data.issues` being
`undefined` — only `null`/`undefined` crash.

Fix: optional-chain the access (`data?.issues ?? []`) so a nullish payload degrades to an empty list, the
same as `{}` already does.

No linked issue: small, self-evident robustness fix (one optional-chain) to align null/undefined input
with the existing empty-payload behavior; no schema/API-shape/deploy change — fits the repo's `preferred`
(not required) linked-issue policy.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran locally: `git diff --check` (clean), `npm run typecheck` (clean), and a focused `test:coverage`
  over `test/unit/adapters.test.ts` — 9 tests pass and `src/bounties/ingest.ts` is at **100%
  statements/branches/functions/lines** (both the nullish and non-nullish optional-chain branches are
  exercised), so `codecov/patch` is 100% on this diff.
- Not run locally: the UI, MCP, workers, OpenAPI, actionlint, and audit jobs. This is a `src/`-only change
  to one deterministic normalizer touching no UI/API-shape/OpenAPI/MCP/DB-schema/workflow surface, so those
  jobs are no-ops for this diff; they run on CI (Linux).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Behavior for any object payload is unchanged; this only stops a `null`/`undefined` payload from throwing,
  making the `/v1/internal/bounties/import` route return an empty import instead of a 500 on an empty or
  malformed body. No API/OpenAPI shape change.
- Regression test added in `test/unit/adapters.test.ts`: `normalizeGittBountySnapshot(null)` and
  `(undefined)` now return `[]`. The existing `{}` and populated-payload assertions are unchanged.
