### PR TITLE
fix(signals): keep focus-areas guidance for the public-safe wanted paths

### DIFF
--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -2171,8 +2171,13 @@ export function compileFocusManifestPolicy(
 
 function buildPolicyEntryGuidance(manifest: FocusManifest): string[] {
   const guidance: string[] = [];
-  if (manifest.wantedPaths.length > 0) {
-    guidance.push(`Focus changes on maintainer-wanted areas: ${manifest.wantedPaths.slice(0, 5).join(", ")}.`);
+  // Build the sentence from the public-safe subset (as preferredLabels and publicNotes below already do, and
+  // as the sibling buildPolicyContributionLanes does for preferredPaths). Joining the raw wantedPaths means a
+  // single reserved-word path (e.g. `src/ranking/`) fails the all-or-nothing public-safety filter at the end
+  // and silently drops the entire focus-areas guidance line instead of surfacing the safe paths.
+  const safeWantedPaths = manifest.wantedPaths.filter(isFocusManifestPublicSafe);
+  if (safeWantedPaths.length > 0) {
+    guidance.push(`Focus changes on maintainer-wanted areas: ${safeWantedPaths.slice(0, 5).join(", ")}.`);
   }
   if (manifest.linkedIssuePolicy === "required") guidance.push("Link a tracked issue before opening a pull request.");
   else if (manifest.linkedIssuePolicy === "preferred") guidance.push("Linking a tracked issue is preferred before opening a pull request.");

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -458,6 +458,15 @@ describe("compileFocusManifestPolicy", () => {
     expect(policy.publicSafe.issueDiscoveryPolicy).toBe("encouraged");
   });
 
+  it("keeps the focus-areas guidance for the public-safe wanted paths when one wanted path is a reserved word", () => {
+    const policy = compileFocusManifestPolicy(REPO, parseFocusManifest({ wantedPaths: ["src/api/", "src/ranking/"] }), opts);
+    const guidance = policy.publicSafe.entryGuidance.join(" ");
+    // The safe path still surfaces; only the reserved-word path is dropped — the entire guidance line is no
+    // longer discarded just because one wanted path is public-unsafe (consistent with contributionLanes).
+    expect(guidance).toContain("Focus changes on maintainer-wanted areas: src/api/.");
+    expect(guidance).not.toMatch(/ranking/i);
+  });
+
   it("treats legacy blockedPaths-only manifests as absent", () => {
     const policy = compileFocusManifestPolicy(REPO, parseFocusManifest({ blockedPaths: ["infra/"] }), opts);
     expect(policy.present).toBe(false);


### PR DESCRIPTION
## Summary

`buildPolicyEntryGuidance` in `src/signals/focus-manifest.ts` composes the public contributor guidance
sentences, then drops any sentence that isn't public-safe:

```ts
if (manifest.wantedPaths.length > 0) {
  guidance.push(`Focus changes on maintainer-wanted areas: ${manifest.wantedPaths.slice(0, 5).join(", ")}.`);
}
…
return [...new Set(guidance)].filter(isFocusManifestPublicSafe);   // all-or-nothing per sentence
```

The focus-areas sentence is built from the **raw** `wantedPaths`, but the final `isFocusManifestPublicSafe`
filter is all-or-nothing per string. So if a single wanted path contains a reserved economic/identity term
(`FOCUS_MANIFEST_TERMS` matches `rankings?`, `reward\w*`, `payouts?`, `score\w*`, …) — e.g. a repo with a
`src/ranking/` or `rewards/` module — the whole `"Focus changes on maintainer-wanted areas: …"` line fails
the filter and is **silently dropped**, so the contributor sees no focus-areas guidance at all.

Every sibling already avoids this by filtering to the public-safe subset **first**: in the same function,
`preferredLabels` and `publicNotes` are filtered before being joined, and `buildPolicyContributionLanes`
computes `safeWantedPaths = manifest.wantedPaths.filter(isFocusManifestPublicSafe)` for its `preferredPaths`.
So for the same manifest, the direct-PR lane surfaces `preferredPaths: ["src/api/"]` while the entry-guidance
line vanishes entirely — two public surfaces disagreeing. Reachable: `compileFocusManifestPolicy` →
`publicSafe.entryGuidance` is consumed publicly as the direct-PR lane's `publicNotes` in
`repo-policy-compiler.ts` (contributor onboarding pack).

Fix: build the sentence from `manifest.wantedPaths.filter(isFocusManifestPublicSafe)`, mirroring the sibling
label/note handling and `buildPolicyContributionLanes`. The safe paths now surface; only the unsafe path is
dropped. The outer `.filter` stays as defense-in-depth.

No linked issue: small, self-evident consistency fix that aligns one guidance line with the public-safe
filtering every sibling already does; no schema/API-shape/deploy change — fits the repo's `preferred` (not
required) linked-issue policy.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran locally: `git diff --check` (clean), `npm run typecheck` (clean), and a focused `test:coverage`
  over `test/unit/focus-manifest.test.ts` — 232 tests pass and the changed lines are fully covered (the
  `safeWantedPaths.length > 0` branch is exercised on both sides by the existing all-safe and no-wanted-path
  tests plus the new mixed case; the only uncovered lines in the file are pre-existing and outside this
  diff), so `codecov/patch` is 100% on this diff. The `.filter(...)` adds no new branch.
- Not run locally: the UI, MCP, workers, OpenAPI, actionlint, and audit jobs. This is a `src/`-only change
  to one deterministic guidance builder touching no UI/API-shape/OpenAPI/MCP/DB-schema/workflow surface, so
  those jobs are no-ops for this diff; they run on CI (Linux).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- This strengthens, not weakens, the privacy boundary: the reserved-word path is still filtered out — only
  the safe paths are now surfaced instead of the whole line being dropped. It also makes `entryGuidance`
  consistent with `contributionLanes.preferredPaths`, which already filters to the safe subset.
- Regression test added in `test/unit/focus-manifest.test.ts` ("keeps the focus-areas guidance for the
  public-safe wanted paths when one wanted path is a reserved word"): `wantedPaths: ["src/api/",
  "src/ranking/"]` now yields the guidance `"…maintainer-wanted areas: src/api/."` with no `ranking`
  leakage (previously the whole line was dropped).
