### PR TITLE
fix(db): fail-closed global kill-switch read when freeze is engaged

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -2309,15 +2309,23 @@ export async function getProductUsageRollupStatus(
 // this during an incident concurrent with a D1 hiccup (or on a self-host instance that never ran migration
 // 0059, or whose singleton row was later lost to a backup restore / manual cleanup) needs a visible signal that
 // the kill-switch may not have actually engaged, not silent normal-looking operation. (#2125)
+let processLocalGlobalAgentFrozen: boolean | null = null;
+export function clearProcessLocalGlobalAgentFrozenCacheForTest(): void { processLocalGlobalAgentFrozen = null; }
 export async function isGlobalAgentFrozen(env: Env): Promise<boolean> {
   try {
     const row = await env.DB.prepare("SELECT frozen FROM global_agent_controls WHERE id = 'singleton'").first<{ frozen: number }>();
     if (!row) {
       console.warn(JSON.stringify({ ev: "global_kill_switch_row_missing", message: "global_agent_controls has no singleton row — treating as unfrozen; re-run migrations or re-seed the row" }));
+      processLocalGlobalAgentFrozen = false;
+      return false;
     }
-    return row?.frozen === 1;
+    const frozen = row.frozen === 1;
+    processLocalGlobalAgentFrozen = frozen;
+    return frozen;
   } catch (error) {
-    console.warn(JSON.stringify({ ev: "global_kill_switch_read_error", message: errorMessage(error).slice(0, 200) }));
+    const message = error instanceof Error ? error.message.slice(0, 200) : String(error).slice(0, 200);
+    console.warn(JSON.stringify({ ev: "global_kill_switch_read_error", message }));
+    if (processLocalGlobalAgentFrozen === true) { console.warn(JSON.stringify({ ev: "global_kill_switch_read_error_fail_closed", message: "process-local cache shows frozen=1 — halting agent actions despite the read error" })); return true; }
     return false;
   }
 }
@@ -2350,6 +2358,7 @@ export async function setGlobalAgentFrozen(env: Env, frozen: boolean, updatedBy?
   )
     .bind(frozen ? 1 : 0, updatedBy ?? null)
     .run();
+  processLocalGlobalAgentFrozen = frozen;
 }
 
 /** Strict (non-fail-open) read of the kill-switch row, for the operator route's read-after-write verification

--- a/src/review/ops.ts
+++ b/src/review/ops.ts
@@ -159,18 +159,7 @@ export const defaultOpsHealthDeps: OpsHealthDeps = {
   // hardcoded false. Raw SQL keeps this module self-contained; fail-open on a read error — but this is the
   // operator-facing health surface used to CONFIRM a freeze took effect, so a swallowed read failure must be
   // visible, not silently reported as an ordinary "unfrozen" (#2125).
-  isFrozen: async (env) => {
-    try {
-      const row = await env.DB.prepare("SELECT frozen FROM global_agent_controls WHERE id = 'singleton'").first<{ frozen: number }>();
-      if (!row) {
-        console.warn(JSON.stringify({ ev: "global_kill_switch_row_missing", message: "global_agent_controls has no singleton row — /status will report unfrozen" }));
-      }
-      return row?.frozen === 1;
-    } catch (error) {
-      console.warn(JSON.stringify({ ev: "global_kill_switch_read_error", message: error instanceof Error ? error.message.slice(0, 200) : String(error).slice(0, 200) }));
-      return false;
-    }
-  },
+  isFrozen: async (env, _project) => (await import("../db/repositories")).isGlobalAgentFrozen(env),
   isHoldOnly: async () => false,
 };
 

--- a/test/unit/agent-action-executor.test.ts
+++ b/test/unit/agent-action-executor.test.ts
@@ -55,7 +55,7 @@ import {
 } from "../../src/services/agent-action-executor";
 import type { PlannedAgentAction } from "../../src/settings/agent-actions";
 import { AGENT_LABEL_PENDING_CLOSURE } from "../../src/review/linked-issue-hard-rules";
-import { getGlobalContributorBlacklist, isGlobalAgentFrozen, setGlobalAgentFrozen, upsertGlobalModerationConfig, upsertPullRequestFromGitHub } from "../../src/db/repositories";
+import { clearProcessLocalGlobalAgentFrozenCacheForTest, getGlobalContributorBlacklist, isGlobalAgentFrozen, setGlobalAgentFrozen, upsertGlobalModerationConfig, upsertPullRequestFromGitHub } from "../../src/db/repositories";
 import * as repositoriesModule from "../../src/db/repositories";
 import { renderMetrics, resetMetrics } from "../../src/selfhost/metrics";
 import { createTestEnv } from "../helpers/d1";
@@ -534,11 +534,13 @@ describe("executeAgentMaintenanceActions (#778 gate stack)", () => {
   });
 
   it("isGlobalAgentFrozen fails open (false) on a read error — a D1 hiccup never freezes the fleet by itself", async () => {
+    clearProcessLocalGlobalAgentFrozenCacheForTest();
     const broken = { ...createTestEnv({}), DB: null } as unknown as Env;
     expect(await isGlobalAgentFrozen(broken)).toBe(false);
   });
 
   it("isGlobalAgentFrozen's fail-open is never SILENT — a read error is observable, not indistinguishable from a genuine unfrozen state (#2125)", async () => {
+    clearProcessLocalGlobalAgentFrozenCacheForTest();
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const broken = { ...createTestEnv({}), DB: null } as unknown as Env;
     expect(await isGlobalAgentFrozen(broken)).toBe(false);
@@ -547,12 +549,33 @@ describe("executeAgentMaintenanceActions (#778 gate stack)", () => {
   });
 
   it("isGlobalAgentFrozen also warns (but still fails open) when the table exists but the singleton row is absent (#2125)", async () => {
+    clearProcessLocalGlobalAgentFrozenCacheForTest();
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const env = createTestEnv({});
     await env.DB.prepare("DELETE FROM global_agent_controls WHERE id = 'singleton'").run();
     expect(await isGlobalAgentFrozen(env)).toBe(false);
     expect(warn).toHaveBeenCalledWith(expect.stringContaining("global_kill_switch_row_missing"));
     warn.mockRestore();
+  });
+
+  it("REGRESSION: after operator freeze, a read error fail-closes on this process so agent actions stay halted (#2125)", async () => {
+    clearProcessLocalGlobalAgentFrozenCacheForTest();
+    const env = createTestEnv({});
+    await setGlobalAgentFrozen(env, true, "operator");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const broken = { ...env, DB: null } as unknown as Env;
+    expect(await isGlobalAgentFrozen(broken)).toBe(true);
+    expect(warn).toHaveBeenCalledWith(expect.stringContaining("global_kill_switch_read_error_fail_closed"));
+    warn.mockRestore();
+  });
+
+  it("REGRESSION: after operator unfreeze, a read error fails open again on this process", async () => {
+    clearProcessLocalGlobalAgentFrozenCacheForTest();
+    const env = createTestEnv({});
+    await setGlobalAgentFrozen(env, true, "operator");
+    await setGlobalAgentFrozen(env, false, "operator");
+    const broken = { ...env, DB: null } as unknown as Env;
+    expect(await isGlobalAgentFrozen(broken)).toBe(false);
   });
 
   it("auto_with_approval: stages the action (queued) instead of executing", async () => {

--- a/test/unit/ops.test.ts
+++ b/test/unit/ops.test.ts
@@ -8,20 +8,22 @@ import {
   handleInternalStatus,
   type OpsAgentConfig,
 } from "../../src/review/ops";
-import { setGlobalAgentFrozen } from "../../src/db/repositories";
+import { clearProcessLocalGlobalAgentFrozenCacheForTest, setGlobalAgentFrozen } from "../../src/db/repositories";
 import { createTestEnv } from "../helpers/d1";
 
 describe("defaultOpsHealthDeps.isFrozen — DB-backed global freeze (#audit-§5.2)", () => {
   it("reports the live DB freeze state and fails open on a read error", async () => {
+    clearProcessLocalGlobalAgentFrozenCacheForTest();
     const env = createTestEnv();
     expect(await defaultOpsHealthDeps.isFrozen(env, "owner/repo")).toBe(false); // default singleton frozen=0
     await setGlobalAgentFrozen(env, true);
     expect(await defaultOpsHealthDeps.isFrozen(env, "owner/repo")).toBe(true);
     const broken = { ...env, DB: null } as unknown as Env;
-    expect(await defaultOpsHealthDeps.isFrozen(broken, "owner/repo")).toBe(false); // fail-open on a read error
+    expect(await defaultOpsHealthDeps.isFrozen(broken, "owner/repo")).toBe(true); // sticky fail-closed after freeze
   });
 
   it("warns (but still fails open) on a read error and on an absent singleton row (#2125)", async () => {
+    clearProcessLocalGlobalAgentFrozenCacheForTest();
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const env = createTestEnv();
     const broken = { ...env, DB: null } as unknown as Env;
@@ -36,6 +38,7 @@ describe("defaultOpsHealthDeps.isFrozen — DB-backed global freeze (#audit-§5.
   });
 
   it("formats a non-Error throw (e.g. a driver rejecting with a plain string) without crashing", async () => {
+    clearProcessLocalGlobalAgentFrozenCacheForTest();
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     const thrown: Env = {
       DB: {


### PR DESCRIPTION
## Summary

The DB-backed global agent kill switch (`global_agent_controls.frozen`) is the operator emergency brake for halting merge/close/approve across the fleet without redeploying. `isGlobalAgentFrozen()` is consulted on every agent enforcement hot path.

Previously, **any** DB read error returned `false` (fail-open). If an operator engaged the freeze and a concurrent read failed, that worker kept executing PR mutations as if unfrozen — while `/v1/app/kill-switch` (strict read) might still report success on the write path.

This PR adds a **process-local sticky cache** of the last known freeze state:

- Successful reads and `setGlobalAgentFrozen()` update the cache.
- Read errors **fail-closed (return `true`)** only when the cache shows `frozen=1`.
- Read errors still **fail-open (return `false`)** when this process has never observed an engaged freeze (preserves #2125 behavior for ordinary D1 blips).

`/status` ops health now delegates to `isGlobalAgentFrozen()` instead of duplicating the SQL, so health and enforcement share the same contract.

## Changed files

| File | Change |
| ---- | ------ |
| `src/db/repositories.ts` | Sticky cache helpers; `isGlobalAgentFrozen` fail-closed on read error when cache is frozen; `setGlobalAgentFrozen` updates cache; export `clearProcessLocalGlobalAgentFrozenCacheForTest`. |
| `src/review/ops.ts` | `defaultOpsHealthDeps.isFrozen` delegates to `isGlobalAgentFrozen`. |
| `src/api/routes.ts` | Comment only — documents updated fail-open/fail-closed contract. |
| `test/unit/agent-action-executor.test.ts` | Regression tests for sticky fail-closed + unfreeze fail-open; clear cache in existing tests. |
| `test/unit/ops.test.ts` | Align ops health tests with shared reader; clear cache between cases. |

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] Focused change — no UI, OpenAPI, MCP, or migration changes.
- [x] Follows `CONTRIBUTING.md` house rules.
- [ ] Linked issue (or summary explains why none is needed).

## Validation

- [ ] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck` (after local run)
- [ ] `npm run test:coverage` (unsharded — confirm `codecov/patch` on `src/db/repositories.ts` diff)
- [ ] `npm run test:ci`

Locally verified:

```sh
npm run test -- test/unit/agent-action-executor.test.ts test/unit/ops.test.ts
npm run typecheck
```

## Safety

- [x] No secrets, wallets, hotkeys, trust scores, or reward internals in code/tests/PR text.
- [x] Auth unchanged; behavior change is internal enforcement only.
- [x] Regression tests cover fail-closed after freeze and fail-open after unfreeze.
- [x] No changelog edit (normal PR).

## UI Evidence

N/A — backend kill-switch enforcement only.

## Test plan

- [x] Never-frozen process + read error → `false` (fail-open unchanged)
- [x] Read error emits `global_kill_switch_read_error` warn (unchanged)
- [x] Missing singleton row → `false` + warn (unchanged)
- [x] After `setGlobalAgentFrozen(true)` + read error → `true` + `global_kill_switch_read_error_fail_closed` warn
- [x] After freeze + read error → `isGlobalAgentFrozen` returns `true` (executor hot path uses the same reader)
- [x] After unfreeze + read error → `false` again
- [x] Ops `/status` health deps share the same sticky contract
- [ ] Full `npm run test:ci` green before push

## Notes

**Limitation (documented):** the sticky cache is **process-local**. A worker that never observed the freeze (no successful read and no local `setGlobalAgentFrozen` call) still fail-opens on read error. Cross-worker propagation relies on a successful DB read or the operator hitting the kill-switch route on that isolate. `AGENT_ACTIONS_PAUSED` remains the env-var hard backstop that does not depend on DB.

Analogues: #2125 observable warn-on-fail-open; `getGlobalAgentFrozenState` strict throw for operator verification (#2359).
