### PR TITLE
fix(enrichment): treat uppercase/mixed-case action SHA pins as immutable

### DIFF
--- a/review-enrichment/src/analyzers/actions-pin.ts
+++ b/review-enrichment/src/analyzers/actions-pin.ts
@@ -5,8 +5,11 @@
 import type { EnrichRequest, ActionPinFinding } from "../types.js";
 import { isWorkflowPath } from "../workflow-path.js";
 
-const USES_RE = /^\s*-?\s*["']?uses["']?\s*:\s*["']?([\w.-]+\/[\w./-]+)@([^\s"'#]+)/;
-const FULL_SHA = /^[0-9a-f]{40}$/;
+const USES_RE =
+  /^\s*-?\s*["']?uses["']?\s*:\s*["']?([\w.-]+\/[\w./-]+)@([^\s"'#]+)/;
+// Git commit SHAs are case-insensitive; accept uppercase/mixed-case 40-char hex so a pin like
+// `@A1B2…` is not mis-flagged as a mutable tag/branch.
+const FULL_SHA = /^[0-9a-f]{40}$/i;
 // GitHub org/user names are case-insensitive (mirrors isWorkflowPath's case-insensitive path match), so the
 // official-action exclusion matches case-insensitively — otherwise `Actions/checkout` would be mis-flagged as a
 // mutable third-party action. GitHub reserves the `actions`/`github` orgs, so this can never over-match a real one.

--- a/review-enrichment/test/actions-pin.test.ts
+++ b/review-enrichment/test/actions-pin.test.ts
@@ -99,6 +99,23 @@ test("scanWorkflowPins ignores patches without added mutable third-party uses", 
   );
 });
 
+test("scanWorkflowPins accepts uppercase and mixed-case 40-char SHA pins", () => {
+  // Git SHAs are case-insensitive; an uppercase/mixed-case full SHA is still an immutable pin.
+  const upperSha = "A".repeat(40);
+  const mixedSha = `${"a".repeat(20)}${"B".repeat(20)}`;
+  assert.deepEqual(
+    scanWorkflowPins(
+      workflowPath,
+      [
+        "@@ -1,0 +1,2 @@",
+        `+    - uses: tj-actions/changed-files@${upperSha}`,
+        `+    - uses: docker/login-action@${mixedSha}`,
+      ].join("\n"),
+    ),
+    [],
+  );
+});
+
 test("scanActionPins scans only changed workflow YAML files with patches", async () => {
   const findings = await scanActionPins({
     repoFullName: "o/r",


### PR DESCRIPTION
## Summary
The `actionPin` analyzer flags third-party GitHub Actions pinned to mutable tags/branches instead of a full commit SHA. Its `FULL_SHA` matcher only accepted **lowercase** hex (`/^[0-9a-f]{40}$/`), so an uppercase or mixed-case 40-char pin (e.g. `@A1B2…EF`) was mis-flagged as mutable even though Git commit SHAs are case-insensitive and the pin is immutable.

## Scope
One-character change: add the `/i` flag to `FULL_SHA`. Official `actions/*` / `github/*` exclusion and mutable-tag detection are unchanged.

## Test plan
- [x] Extends `review-enrichment/test/actions-pin.test.ts` with uppercase and mixed-case 40-char SHA pins (no findings).
- [x] `node --test test/actions-pin.test.ts` — 7 passed.

## No linked issue
Self-contained precision fix to an existing analyzer; no tracking issue. Touches only `actions-pin.ts` and its test.

Made with [Cursor](https://cursor.com)