### PR TITLE
feat(enrichment): detect Anthropic API keys in secret-scan

### DIFF
--- a/review-enrichment/src/analyzers/secret-scan.ts
+++ b/review-enrichment/src/analyzers/secret-scan.ts
@@ -61,6 +61,13 @@ const RULES: Rule[] = [
     confidence: "high",
   },
   {
+    // Anthropic API key: `sk-ant-` prefix + base64url body (e.g. `sk-ant-api03-…`).
+    // Distinct from Stripe's `sk_live_` / `rk_live_` (underscore) and OpenAI's bare `sk-` keys.
+    kind: "anthropic_api_key",
+    re: /\bsk-ant-[A-Za-z0-9_-]{20,}\b/,
+    confidence: "high",
+  },
+  {
     kind: "private_key",
     re: /-----BEGIN (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----/,
     confidence: "high",
@@ -114,7 +121,12 @@ export function scanPatch(path: string, patch: string): SecretFinding[] {
       let matched = false;
       for (const rule of RULES) {
         if (rule.re.test(content)) {
-          findings.push({ file: path, line: newLine, kind: rule.kind, confidence: rule.confidence });
+          findings.push({
+            file: path,
+            line: newLine,
+            kind: rule.kind,
+            confidence: rule.confidence,
+          });
           matched = true;
           break; // one finding per line — first (most specific) rule wins
         }
@@ -124,12 +136,21 @@ export function scanPatch(path: string, patch: string): SecretFinding[] {
       // common "two sequential variable assignments" shape. Skipped once this line already matched on its own.
       const lastPrevious = previousLiterals.at(-1);
       const firstCurrent = currentLiterals[0];
-      if (!matched && lastPrevious !== undefined && firstCurrent !== undefined) {
+      if (
+        !matched &&
+        lastPrevious !== undefined &&
+        firstCurrent !== undefined
+      ) {
         const joined = lastPrevious + firstCurrent;
         for (const rule of RULES) {
           if (rule.re.test(joined)) {
             // "medium" regardless of the rule's own confidence — a joined pair is a heuristic, not a direct match.
-            findings.push({ file: path, line: newLine, kind: rule.kind, confidence: "medium" });
+            findings.push({
+              file: path,
+              line: newLine,
+              kind: rule.kind,
+              confidence: "medium",
+            });
             break;
           }
         }

--- a/review-enrichment/test/secret-scan.test.ts
+++ b/review-enrichment/test/secret-scan.test.ts
@@ -4,7 +4,8 @@ import assert from "node:assert/strict";
 
 import { scanPatch } from "../dist/analyzers/secret-scan.js";
 
-const hunk = (lines) => `@@ -1,0 +1,${lines.length} @@\n${lines.map((l) => `+${l}`).join("\n")}`;
+const hunk = (lines) =>
+  `@@ -1,0 +1,${lines.length} @@\n${lines.map((l) => `+${l}`).join("\n")}`;
 
 // Built from fragments at test-run time (never a contiguous secret-shaped literal in the committed source) so
 // GitHub push protection does not flag this fixture file the way it would flag a real leaked credential — the
@@ -17,6 +18,9 @@ const fakeAwsKey = awsKeyFragmentA + awsKeyFragmentB;
 const fakeStripeKey = ["sk_live_", "abcdefghijklmnop1234567890"].join(""); // sk_live_ + 26 base62
 const fakeSendgridKey = ["SG.", "a".repeat(22), ".", "b".repeat(43)].join("");
 const fakeHuggingfaceToken = "hf_" + "a".repeat(34);
+// Anthropic keys are `sk-ant-` + a long base64url body (built from fragments so push protection
+// never sees a contiguous secret-shaped literal in the committed source).
+const fakeAnthropicKey = ["sk-ant-", "api03-", "a".repeat(20)].join("");
 const fakeGitlabToken = "glpat-" + "aBcDeFgHiJkLmNoPqRsT"; // 20 chars after the prefix
 const fakeNpmToken = "npm_" + "a".repeat(36);
 // A high-entropy value that matches NO format-specific rule, so it only trips the
@@ -24,7 +28,10 @@ const fakeNpmToken = "npm_" + "a".repeat(36);
 const fakeGenericValue = "aK9xQ2mZw7Ln" + "4Rv8Pt3Bh6Tc";
 
 test("scanPatch flags a single-line AWS access key with high confidence", () => {
-  const findings = scanPatch("src/config.ts", hunk([`const key = "${fakeAwsKey}";`]));
+  const findings = scanPatch(
+    "src/config.ts",
+    hunk([`const key = "${fakeAwsKey}";`]),
+  );
   assert.equal(findings.length, 1);
   assert.equal(findings[0].kind, "aws_access_key_id");
   assert.equal(findings[0].confidence, "high");
@@ -33,34 +40,49 @@ test("scanPatch flags a single-line AWS access key with high confidence", () => 
 });
 
 test("scanPatch flags a private key header", () => {
-  const findings = scanPatch("id_rsa", hunk(["-----BEGIN RSA PRIVATE KEY-----"]));
+  const findings = scanPatch(
+    "id_rsa",
+    hunk(["-----BEGIN RSA PRIVATE KEY-----"]),
+  );
   assert.equal(findings.length, 1);
   assert.equal(findings[0].kind, "private_key");
 });
 
 test("scanPatch flags a GitLab access token with high confidence", () => {
-  const findings = scanPatch("src/config.ts", hunk([`const gl = "${fakeGitlabToken}";`]));
+  const findings = scanPatch(
+    "src/config.ts",
+    hunk([`const gl = "${fakeGitlabToken}";`]),
+  );
   assert.equal(findings.length, 1);
   assert.equal(findings[0].kind, "gitlab_token");
   assert.equal(findings[0].confidence, "high");
 });
 
 test("scanPatch flags an npm token with high confidence", () => {
-  const findings = scanPatch("src/config.ts", hunk([`const registryAuth = "${fakeNpmToken}";`]));
+  const findings = scanPatch(
+    "src/config.ts",
+    hunk([`const registryAuth = "${fakeNpmToken}";`]),
+  );
   assert.equal(findings.length, 1);
   assert.equal(findings[0].kind, "npm_token");
   assert.equal(findings[0].confidence, "high");
 });
 
 test("scanPatch flags a Stripe live secret key with high confidence", () => {
-  const findings = scanPatch("src/config.ts", hunk([`const apiKey = "${fakeStripeKey}";`]));
+  const findings = scanPatch(
+    "src/config.ts",
+    hunk([`const apiKey = "${fakeStripeKey}";`]),
+  );
   assert.equal(findings.length, 1);
   assert.equal(findings[0].kind, "stripe_secret_key");
   assert.equal(findings[0].confidence, "high");
 });
 
 test("scanPatch flags a SendGrid API key with high confidence", () => {
-  const findings = scanPatch("src/config.ts", hunk([`const sg = "${fakeSendgridKey}";`]));
+  const findings = scanPatch(
+    "src/config.ts",
+    hunk([`const sg = "${fakeSendgridKey}";`]),
+  );
   assert.equal(findings.length, 1);
   assert.equal(findings[0].kind, "sendgrid_key");
   assert.equal(findings[0].confidence, "high");
@@ -70,28 +92,60 @@ test("scanPatch flags a SendGrid key whose final secret character is a hyphen", 
   // Regression: a `\b` terminator would miss a key ending in `-`; the rule uses a
   // negative lookahead so the trailing hyphen still terminates the match.
   const hyphenTail = ["SG.", "a".repeat(22), ".", "b".repeat(42), "-"].join("");
-  const findings = scanPatch("src/config.ts", hunk([`const sg = "${hyphenTail}";`]));
+  const findings = scanPatch(
+    "src/config.ts",
+    hunk([`const sg = "${hyphenTail}";`]),
+  );
   assert.equal(findings.length, 1);
   assert.equal(findings[0].kind, "sendgrid_key");
   assert.equal(findings[0].confidence, "high");
 });
 
 test("scanPatch flags a Hugging Face access token with high confidence", () => {
-  const findings = scanPatch("src/config.ts", hunk([`const hfToken = "${fakeHuggingfaceToken}";`]));
+  const findings = scanPatch(
+    "src/config.ts",
+    hunk([`const hfToken = "${fakeHuggingfaceToken}";`]),
+  );
   assert.equal(findings.length, 1);
   assert.equal(findings[0].kind, "huggingface_token");
   assert.equal(findings[0].confidence, "high");
 });
 
+test("scanPatch flags an Anthropic API key with high confidence", () => {
+  const findings = scanPatch(
+    "src/config.ts",
+    hunk([`const anthropicKey = "${fakeAnthropicKey}";`]),
+  );
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "anthropic_api_key");
+  assert.equal(findings[0].confidence, "high");
+});
+
+test("scanPatch does not flag Stripe live keys as Anthropic keys", () => {
+  // Stripe uses `sk_live_` (underscore); Anthropic uses `sk-ant-` (hyphen). The two must not cross-match.
+  const findings = scanPatch(
+    "src/config.ts",
+    hunk([`const apiKey = "${fakeStripeKey}";`]),
+  );
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "stripe_secret_key");
+});
+
 test("scanPatch flags a generic secret assignment", () => {
-  const findings = scanPatch("src/config.ts", hunk([`const apiKey = "${fakeGenericValue}";`]));
+  const findings = scanPatch(
+    "src/config.ts",
+    hunk([`const apiKey = "${fakeGenericValue}";`]),
+  );
   assert.equal(findings.length, 1);
   assert.equal(findings[0].kind, "generic_secret_assignment");
   assert.equal(findings[0].confidence, "medium");
 });
 
 test("scanPatch reports nothing for clean code", () => {
-  const findings = scanPatch("src/app.ts", hunk(['const greeting = "hello world";', "export function run() {}"]));
+  const findings = scanPatch(
+    "src/app.ts",
+    hunk(['const greeting = "hello world";', "export function run() {}"]),
+  );
   assert.equal(findings.length, 0);
 });
 
@@ -100,7 +154,11 @@ test("scanPatch reports nothing for clean code", () => {
 test("scanPatch catches an AWS key split across two adjacent added lines via concatenation (#2454)", () => {
   const findings = scanPatch(
     "src/config.ts",
-    hunk([`const part1 = "${awsKeyFragmentA}";`, `const part2 = "${awsKeyFragmentB}";`, "const awsKey = part1 + part2;"]),
+    hunk([
+      `const part1 = "${awsKeyFragmentA}";`,
+      `const part2 = "${awsKeyFragmentB}";`,
+      "const awsKey = part1 + part2;",
+    ]),
   );
   assert.equal(findings.length, 1);
   assert.equal(findings[0].kind, "aws_access_key_id");
@@ -144,7 +202,10 @@ test("scanPatch does not join literals across a hunk boundary (#2454)", () => {
 test("scanPatch does not double-report a line that already matched on its own", () => {
   const findings = scanPatch(
     "src/config.ts",
-    hunk([`const key = "${fakeAwsKey}";`, 'const other = "unrelated-string-value";']),
+    hunk([
+      `const key = "${fakeAwsKey}";`,
+      'const other = "unrelated-string-value";',
+    ]),
   );
   // The first line already matches directly; its literal must not ALSO be joined into a second, duplicate finding.
   assert.equal(findings.length, 1);
@@ -152,14 +213,20 @@ test("scanPatch does not double-report a line that already matched on its own", 
 });
 
 test("scanPatch does not join two unrelated short literals into a false positive", () => {
-  const findings = scanPatch("src/app.ts", hunk(['const a = "hello";', 'const b = "world";']));
+  const findings = scanPatch(
+    "src/app.ts",
+    hunk(['const a = "hello";', 'const b = "world";']),
+  );
   assert.equal(findings.length, 0);
 });
 
 // Regression: an added line whose content starts with `++` renders as `+++...` in the diff. A header-prefix
 // guard (even the anchored `+++ `) mistakes it for a `+++ b/file` header and skips it, so a secret on such a
 // line is never scanned. Both `++x` (-> `+++x`) and `++ x` (-> `+++ x`) content shapes must be scanned.
-for (const content of ['++const key = "AWS_KEY";', '++ const key = "AWS_KEY";']) {
+for (const content of [
+  '++const key = "AWS_KEY";',
+  '++ const key = "AWS_KEY";',
+]) {
   test(`scanPatch scans an added line whose content starts with ++ (rendered +${content})`, () => {
     const patch = `@@ -1,0 +1,1 @@\n+${content.replace("AWS_KEY", fakeAwsKey)}`;
     const findings = scanPatch("src/config.ts", patch);


### PR DESCRIPTION
## Summary
The `secret` analyzer recognizes many high-confidence credential prefixes (GitHub, GitLab, npm, Stripe, SendGrid, Hugging Face) but **missed Anthropic API keys** (`sk-ant-…`). A PR that adds an Anthropic key in source went unflagged.

## Scope
Adds one high-confidence rule scoped to the `sk-ant-` prefix + a base64url body (`/\bsk-ant-[A-Za-z0-9_-]{20,}\b/`). Distinct from Stripe's `sk_live_` / `rk_live_` (underscore) so the two cannot cross-match. No value is returned — only kind/confidence/file/line, matching existing rules.

## Test plan
- [x] Extends `review-enrichment/test/secret-scan.test.ts` with a positive Anthropic key case and a Stripe non-cross-match guard.
- [x] `node --test test/secret-scan.test.ts` — 19 passed.

## No linked issue
Self-contained detection-coverage improvement; no tracking issue. Touches only `secret-scan.ts` and its test.

Made with [Cursor](https://cursor.com)