### PR TITLE
fix(signals): classify Dart/Flutter *_test.dart files as tests

### DIFF
--- a/src/signals/test-evidence.ts
+++ b/src/signals/test-evidence.ts
@@ -2,7 +2,7 @@ export function isTestPath(file: string): boolean {
   return (
     /(^|\/)(test|tests|spec|__tests__)\//i.test(file) ||
     /(^|\/)src\/test\//i.test(file) ||
-    /(^|\/)[^/]+_test\.(go|py|rb)$/i.test(file) ||
+    /(^|\/)[^/]+_test\.(go|py|rb|dart)$/i.test(file) || // Dart/Flutter `foo_test.dart` co-located with source
     /(^|\/)test_[^/]*\.py$/i.test(file) || // pytest's default `test_*.py` prefix convention (the suffix rule above only catches `*_test.py`)
     /(^|\/)[^/]+_spec\.rb$/i.test(file) ||
     /\.(test|spec)\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs)$/i.test(file) ||

--- a/test/unit/test-evidence.test.ts
+++ b/test/unit/test-evidence.test.ts
@@ -34,6 +34,14 @@ describe("test evidence helpers", () => {
     expect(isTestPath("src/app/testing.py")).toBe(false); // no `test_` boundary ⇒ not a test
   });
 
+  it("detects Dart/Flutter *_test.dart co-located with source", () => {
+    // Paths NOT under a test/ directory, so only the `_test.dart` suffix rule can match.
+    expect(isTestPath("lib/models/user_test.dart")).toBe(true);
+    expect(isTestPath("lib/widgets/card_test.dart")).toBe(true);
+    expect(isTestPath("lib/models/user.dart")).toBe(false); // source, not a test
+    expect(isTestPath("lib/models/latest_config.dart")).toBe(false); // `_test` not at the stem boundary
+  });
+
   it("detects JVM / C# / Swift class-suffix test conventions", () => {
     // Paths NOT under a test/ directory, so only the class-suffix rule can match.
     expect(isTestPath("app/src/main/java/WidgetTest.java")).toBe(true); // JUnit


### PR DESCRIPTION
## Summary
`isTestPath` recognized Go/Python/Ruby `*_test.*` files co-located with source, but **missed Dart/Flutter's `foo_test.dart` convention**. Those files ranked as source in diff budgeting and undercounted test coverage for Dart PRs.

## Scope
Adds `dart` to the existing `_test.(go|py|rb)` suffix alternation. Case-insensitive like the sibling extensions. Does not affect `user.dart` or stems that merely contain `_test` mid-name.

## Test plan
- [x] Extends `test/unit/test-evidence.test.ts` with `lib/models/user_test.dart` / `card_test.dart` (true) and `user.dart` / `latest_config.dart` (false).
- [x] `npx vitest run test/unit/test-evidence.test.ts` — 11 passed.

## No linked issue
Self-contained classifier precision fix; no tracking issue. Touches only `test-evidence.ts` and its test.

Made with [Cursor](https://cursor.com)