### PR TITLE
fix(enrichment): match bare Dockerfile names case-insensitively

### DIFF
--- a/review-enrichment/src/analyzers/eol-check.ts
+++ b/review-enrichment/src/analyzers/eol-check.ts
@@ -42,12 +42,13 @@ function leadingVersion(value: string): string | null {
   return /^v?(\d+(?:\.\d+)*)/.exec(value.trim())?.[1] ?? null;
 }
 
-/** True for a Dockerfile the FROM-pin parser understands: the literal `Dockerfile`, or a `*.dockerfile`
- *  (e.g. `web.dockerfile`). Exported so the scheduler's runtime-pin gate shares ONE predicate and cannot
- *  drift from what this analyzer actually parses. */
+/** True for a Dockerfile the FROM-pin parser understands: the bare name `Dockerfile` (any casing —
+ *  Docker and case-insensitive filesystems treat it that way, and sibling matchers like the IaC
+ *  config-path gate already use `/i`), or a `*.dockerfile` (e.g. `web.dockerfile`). Exported so the
+ *  scheduler's runtime-pin gate shares ONE predicate and cannot drift from what this analyzer parses. */
 export function isDockerfile(path: string): boolean {
   const base = path.split("/").pop() ?? path;
-  return base === "Dockerfile" || /\.dockerfile$/i.test(base);
+  return /^dockerfile$/i.test(base) || /\.dockerfile$/i.test(base);
 }
 
 /** Pull (product, version) pins out of the added lines of changed Dockerfile / .nvmrc / go.mod. Pure. */
@@ -164,7 +165,10 @@ export async function scanEol(
     if (seen.has(key)) continue;
     seen.add(key);
     if (!cyclesByProduct.has(pin.product))
-      cyclesByProduct.set(pin.product, await fetchCycles(pin.product, fetchImpl, options));
+      cyclesByProduct.set(
+        pin.product,
+        await fetchCycles(pin.product, fetchImpl, options),
+      );
     const cycles = cyclesByProduct.get(pin.product);
     if (!cycles) continue;
     const cycle = matchCycle(cycles, pin.version);

--- a/review-enrichment/test/eol-check.test.ts
+++ b/review-enrichment/test/eol-check.test.ts
@@ -2,29 +2,74 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { extractVersionPins } from "../dist/analyzers/eol-check.js";
+import {
+  extractVersionPins,
+  isDockerfile,
+} from "../dist/analyzers/eol-check.js";
 
 function added(path: string, ...lines: string[]) {
-  return { path, patch: ["@@ -1 +1," + lines.length + " @@", ...lines.map((l) => "+" + l)].join("\n") };
+  return {
+    path,
+    patch: [
+      "@@ -1 +1," + lines.length + " @@",
+      ...lines.map((l) => "+" + l),
+    ].join("\n"),
+  };
 }
 
 test("extractVersionPins reads a Dockerfile FROM tag into (product, leading-version)", () => {
-  const pins = extractVersionPins([added("Dockerfile", "FROM python:3.8-slim")]);
-  assert.deepEqual(pins, [{ file: "Dockerfile", product: "python", version: "3.8" }]);
+  const pins = extractVersionPins([
+    added("Dockerfile", "FROM python:3.8-slim"),
+  ]);
+  assert.deepEqual(pins, [
+    { file: "Dockerfile", product: "python", version: "3.8" },
+  ]);
 });
 
 test("extractVersionPins maps the node image to nodejs and drops an unknown product", () => {
-  const pins = extractVersionPins([added("Dockerfile", "FROM node:18.17.0", "FROM mystery:1.2.3")]);
-  assert.deepEqual(pins, [{ file: "Dockerfile", product: "nodejs", version: "18.17.0" }]);
+  const pins = extractVersionPins([
+    added("Dockerfile", "FROM node:18.17.0", "FROM mystery:1.2.3"),
+  ]);
+  assert.deepEqual(pins, [
+    { file: "Dockerfile", product: "nodejs", version: "18.17.0" },
+  ]);
 });
 
 test("extractVersionPins reads .nvmrc and go.mod pins", () => {
-  assert.deepEqual(extractVersionPins([added(".nvmrc", "18.17.0")]), [{ file: ".nvmrc", product: "nodejs", version: "18.17.0" }]);
-  assert.deepEqual(extractVersionPins([added("go.mod", "go 1.21")]), [{ file: "go.mod", product: "go", version: "1.21" }]);
+  assert.deepEqual(extractVersionPins([added(".nvmrc", "18.17.0")]), [
+    { file: ".nvmrc", product: "nodejs", version: "18.17.0" },
+  ]);
+  assert.deepEqual(extractVersionPins([added("go.mod", "go 1.21")]), [
+    { file: "go.mod", product: "go", version: "1.21" },
+  ]);
 });
 
 test("extractVersionPins ignores removed/context lines and files with no patch", () => {
-  const patch = ["@@ -1 +1,2 @@", "-FROM python:3.7", " FROM python:3.9"].join("\n");
+  const patch = ["@@ -1 +1,2 @@", "-FROM python:3.7", " FROM python:3.9"].join(
+    "\n",
+  );
   assert.deepEqual(extractVersionPins([{ path: "Dockerfile", patch }]), []);
   assert.deepEqual(extractVersionPins([{ path: "Dockerfile" }]), []);
+});
+
+test("isDockerfile matches the bare name case-insensitively", () => {
+  // Docker and case-insensitive filesystems treat `dockerfile` / `DOCKERFILE` as the default Dockerfile;
+  // the `*.dockerfile` branch was already case-insensitive, so the bare-name branch must match.
+  assert.equal(isDockerfile("Dockerfile"), true);
+  assert.equal(isDockerfile("dockerfile"), true);
+  assert.equal(isDockerfile("DOCKERFILE"), true);
+  assert.equal(isDockerfile("deploy/DOCKERFILE"), true);
+  assert.equal(isDockerfile("web.dockerfile"), true);
+  assert.equal(isDockerfile("web.Dockerfile"), true);
+  assert.equal(isDockerfile("Makefile"), false);
+  assert.equal(isDockerfile("Dockerfile.bak"), false);
+});
+
+test("extractVersionPins reads FROM pins from a lowercase dockerfile path", () => {
+  const pins = extractVersionPins([
+    added("dockerfile", "FROM python:3.8-slim"),
+  ]);
+  assert.deepEqual(pins, [
+    { file: "dockerfile", product: "python", version: "3.8" },
+  ]);
 });


### PR DESCRIPTION
## Summary
`isDockerfile` (shared by the EOL analyzer and the scheduler's runtime-pin gate) treated the bare name as **case-sensitive** (`Dockerfile` only), while the `*.dockerfile` branch already used `/i` and sibling config-path matchers (IaC, RAG allow-list) already match `Dockerfile` case-insensitively. A PR that changes `dockerfile` or `DOCKERFILE` silently skipped EOL analysis.

## Scope
Replace `base === "Dockerfile"` with `/^dockerfile$/i`. The `*.dockerfile` branch is unchanged. Non-Dockerfile names (`Makefile`, `Dockerfile.bak`) still return false.

## Test plan
- [x] Extends `review-enrichment/test/eol-check.test.ts` with direct `isDockerfile` casing cases and an `extractVersionPins` path through lowercase `dockerfile`.
- [x] `node --test test/eol-check.test.ts` — 6 passed.

## No linked issue
Self-contained predicate consistency fix; no tracking issue. Touches only `eol-check.ts` and its test.

Made with [Cursor](https://cursor.com)