### PR TITLE
fix(enrichment): detect regex literals in unspaced arrow-function bodies

### DIFF
--- a/review-enrichment/src/analyzers/redos.ts
+++ b/review-enrichment/src/analyzers/redos.ts
@@ -39,7 +39,9 @@ function* patchLines(patch: string): Generator<string> {
 // never produce a false finding on its own.
 
 // `/` opens a regex literal (not division) when the char just before it is a statement/operator boundary.
-const REGEX_POSITION_PREFIX = "=(,:?&|!{[;";
+// `>` covers arrow-function bodies written without a space (`() =>/foo/`), which are valid JS and a
+// common minified form; without it the extractor mistakes the `/` for division and misses the literal.
+const REGEX_POSITION_PREFIX = "=(,:?&|!{[;>";
 
 function isWordChar(ch: string): boolean {
   return (

--- a/review-enrichment/test/redos.test.ts
+++ b/review-enrichment/test/redos.test.ts
@@ -9,9 +9,24 @@ import {
 } from "../dist/analyzers/redos.js";
 
 test("extractRegexSources pulls bodies from /.../ literals and RegExp(...) args", () => {
-  assert.deepEqual(extractRegexSources("const re = /(a+)+/.test(x);"), ["(a+)+"]);
+  assert.deepEqual(extractRegexSources("const re = /(a+)+/.test(x);"), [
+    "(a+)+",
+  ]);
   assert.deepEqual(extractRegexSources('new RegExp("a|b")'), ["a|b"]);
   assert.deepEqual(extractRegexSources("plain text, no slashes"), []);
+});
+
+test("extractRegexSources finds a regex literal in an arrow body written without a space", () => {
+  // `() =>/foo/` is valid JS; the `/` follows `>`, which must count as a regex-position boundary.
+  assert.deepEqual(
+    extractRegexSources("const match = (s) =>/(a+)+/.test(s);"),
+    ["(a+)+"],
+  );
+  // Spaced form already worked via the whitespace branch; keep it locked.
+  assert.deepEqual(
+    extractRegexSources("const match = (s) => /(a+)+/.test(s);"),
+    ["(a+)+"],
+  );
 });
 
 test("hasCatastrophicBacktracking flags a nested unbounded quantifier and spares linear shapes", () => {
@@ -24,7 +39,12 @@ test("hasCatastrophicBacktracking flags a nested unbounded quantifier and spares
 });
 
 test("scanPatchForRedos cites the added-line number of a catastrophic literal", () => {
-  const patch = ["@@ -1,2 +1,3 @@", " context", "+const re = /(a+)+/;", " more"].join("\n");
+  const patch = [
+    "@@ -1,2 +1,3 @@",
+    " context",
+    "+const re = /(a+)+/;",
+    " more",
+  ].join("\n");
   const findings = scanPatchForRedos("src/x.ts", patch);
   assert.equal(findings.length, 1);
   assert.equal(findings[0]?.file, "src/x.ts");


### PR DESCRIPTION
## Summary
The ReDoS extractor only treated `/` as a regex opener after whitespace or a fixed punctuator set (`= ( , : ? & | ! { [ ;`). An arrow body written **without a space** (`() =>/foo/`) is valid JavaScript, but the `/` after `>` was treated as division, so a catastrophic literal like `() =>/(a+)+/` was silently missed.

## Scope
Adds `>` to `REGEX_POSITION_PREFIX`. Spaced arrows (`() => /foo/`) already worked via the whitespace branch and stay locked by tests. The matcher remains a flat character-set check (no quantified groups), preserving the analyzer's linear-time / ReDoS-safety invariant.

## Test plan
- [x] Extends `review-enrichment/test/redos.test.ts` with unspaced and spaced arrow-body extractions sources.
- [x] `node --test test/redos.test.ts` — 5 passed.

## No linked issue
Self-contained extractor precision fix; no tracking issue. Touches only `redos.ts` and its test.

Made with [Cursor](https://cursor.com)