### PR TITLE
fix(signals): classify Dart/Flutter *_test.dart files as tests

### DIFF
--- a/packages/gittensory-mcp/lib/local-branch.js
+++ b/packages/gittensory-mcp/lib/local-branch.js
@@ -596,7 +596,7 @@ export function isTestFile(file) {
   return (
     /(^|\/)(test|tests|spec|__tests__)\//i.test(file) ||
     /(^|\/)src\/test\//i.test(file) ||
-    /(^|\/)[^/]+_test\.(go|py|rb)$/i.test(file) ||
+    /(^|\/)[^/]+_test\.(go|py|rb|dart)$/i.test(file) || // Dart/Flutter `foo_test.dart` co-located with source
     /(^|\/)test_[^/]*\.py$/i.test(file) || // pytest's default `test_*.py` prefix convention (the suffix rule above only catches `*_test.py`)
     /(^|\/)[^/]+_spec\.rb$/i.test(file) ||
     /\.(test|spec)\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs)$/i.test(file) ||

--- a/packages/gittensory-mcp/scripts/gittensor-score-preview.mjs
+++ b/packages/gittensory-mcp/scripts/gittensor-score-preview.mjs
@@ -6,7 +6,7 @@ function isTestFile(file) {
   return (
     /(^|\/)(test|tests|spec|__tests__)\//i.test(file) ||
     /(^|\/)src\/test\//i.test(file) ||
-    /(^|\/)[^/]+_test\.(go|py|rb)$/i.test(file) ||
+    /(^|\/)[^/]+_test\.(go|py|rb|dart)$/i.test(file) || // Dart/Flutter `foo_test.dart` co-located with source
     /(^|\/)test_[^/]*\.py$/i.test(file) || // pytest's default `test_*.py` prefix (the suffix rule above only catches `*_test.py`)
     /(^|\/)[^/]+_spec\.rb$/i.test(file) ||
     /\.(test|spec)\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs)$/i.test(file) ||

--- a/packages/gittensory-mcp/scripts/gittensor-score-preview.py
+++ b/packages/gittensory-mcp/scripts/gittensor-score-preview.py
@@ -17,7 +17,7 @@ from pathlib import Path
 # dir, and ".test.mjs" matched non-tests like `dist/widget.test.mjs.map` where the extension is not end-of-path.
 _TEST_PATH_RES = (
     re.compile(r"(?:^|/)(?:tests?|spec|__tests__|__snapshots__|src/test)/", re.IGNORECASE),  # dir conventions
-    re.compile(r"(?:^|/)[^/]+_test\.(?:go|py|rb)$", re.IGNORECASE),  # go/py/rb *_test suffix
+    re.compile(r"(?:^|/)[^/]+_test\.(?:go|py|rb|dart)$", re.IGNORECASE),  # go/py/rb/dart *_test suffix
     re.compile(r"(?:^|/)test_[^/]*\.py$", re.IGNORECASE),  # pytest test_*.py prefix
     re.compile(r"(?:^|/)[^/]+_spec\.rb$", re.IGNORECASE),  # RSpec *_spec.rb suffix
     re.compile(r"\.(?:test|spec)\.(?:ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs)$", re.IGNORECASE),  # .test/.spec.<ext>

--- a/src/signals/test-evidence.ts
+++ b/src/signals/test-evidence.ts
@@ -2,7 +2,7 @@ export function isTestPath(file: string): boolean {
   return (
     /(^|\/)(test|tests|spec|__tests__)\//i.test(file) ||
     /(^|\/)src\/test\//i.test(file) ||
-    /(^|\/)[^/]+_test\.(go|py|rb)$/i.test(file) ||
+    /(^|\/)[^/]+_test\.(go|py|rb|dart)$/i.test(file) || // Dart/Flutter `foo_test.dart` co-located with source
     /(^|\/)test_[^/]*\.py$/i.test(file) || // pytest's default `test_*.py` prefix convention (the suffix rule above only catches `*_test.py`)
     /(^|\/)[^/]+_spec\.rb$/i.test(file) ||
     /\.(test|spec)\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs)$/i.test(file) ||

--- a/test/unit/score-preview-script.test.ts
+++ b/test/unit/score-preview-script.test.ts
@@ -108,6 +108,30 @@ describe("gittensor-score-preview.mjs classifier parity with the server", () => 
     expect(py.nonCodeTokenScore).toBe(0);
   });
 
+  it("classifies Dart/Flutter *_test.dart as a test in both .mjs and .py previews", () => {
+    // Parity with src/signals/test-evidence.ts: co-located `foo_test.dart` must count as test evidence,
+    // not source/non-code, in every mirrored classifier.
+    const files = [
+      { path: "lib/models/user_test.dart", additions: 8, deletions: 0 },
+      { path: "lib/models/user.dart", additions: 3, deletions: 0 }, // non-code (dart not in isCodeFile)
+    ];
+    const mjs = runPreview(files);
+    expect(mjs.testTokenScore).toBe(8);
+    expect(mjs.sourceTokenScore).toBe(0);
+    expect(mjs.nonCodeTokenScore).toBe(3);
+
+    const python = findPython();
+    if (!python) return;
+    const env = { ...process.env };
+    delete env.GITTENSOR_ROOT;
+    const res = spawnSync(python, [scriptPy], { input: JSON.stringify({ changedFiles: files }), encoding: "utf8", env });
+    expect(res.status, res.stderr).toBe(0);
+    const py = JSON.parse(res.stdout);
+    expect(py.testTokenScore).toBe(8);
+    expect(py.sourceTokenScore).toBe(0);
+    expect(py.nonCodeTokenScore).toBe(3);
+  });
+
   it("does not misclassify a *.test.mjs.map source-map as a test (extension anchored to end-of-path, matching the server)", () => {
     // A substring match on ".test.mjs" wrongly flagged non-tests like dist/widget.test.mjs.map; the rule must be
     // end-anchored like isTestPath. It's a source-map — neither test nor code — so it counts as non-code.

--- a/test/unit/test-evidence.test.ts
+++ b/test/unit/test-evidence.test.ts
@@ -34,6 +34,14 @@ describe("test evidence helpers", () => {
     expect(isTestPath("src/app/testing.py")).toBe(false); // no `test_` boundary ⇒ not a test
   });
 
+  it("detects Dart/Flutter *_test.dart co-located with source", () => {
+    // Paths NOT under a test/ directory, so only the `_test.dart` suffix rule can match.
+    expect(isTestPath("lib/models/user_test.dart")).toBe(true);
+    expect(isTestPath("lib/widgets/card_test.dart")).toBe(true);
+    expect(isTestPath("lib/models/user.dart")).toBe(false); // source, not a test
+    expect(isTestPath("lib/models/latest_config.dart")).toBe(false); // `_test` not at the stem boundary
+  });
+
   it("detects JVM / C# / Swift class-suffix test conventions", () => {
     // Paths NOT under a test/ directory, so only the class-suffix rule can match.
     expect(isTestPath("app/src/main/java/WidgetTest.java")).toBe(true); // JUnit


### PR DESCRIPTION
## Summary
`isTestPath` recognized Go/Python/Ruby `*_test.*` files co-located with source, but **missed Dart/Flutter's `foo_test.dart` convention**. Those files ranked as source in diff budgeting and undercounted test coverage for Dart PRs.

## Scope
Adds `dart` to the `_test.(go|py|rb)` suffix alternation in **every mirrored classifier**, so local score previews stay in parity with the server gate:
- `src/signals/test-evidence.ts` (canonical)
- `packages/gittensory-mcp/scripts/gittensor-score-preview.mjs`
- `packages/gittensory-mcp/scripts/gittensor-score-preview.py`
- `packages/gittensory-mcp/lib/local-branch.js`

Does not affect `user.dart` or stems that merely contain `_test` mid-name.

## Test plan
- [x] `test/unit/test-evidence.test.ts` — `user_test.dart` / `card_test.dart` (true), `user.dart` / `latest_config.dart` (false).
- [x] `test/unit/score-preview-script.test.ts` — both `.mjs` and `.py` previews count `lib/models/user_test.dart` as test evidence.
- [x] `npx vitest run test/unit/test-evidence.test.ts test/unit/score-preview-script.test.ts` — 17 passed.

## No linked issue
Self-contained classifier precision fix; no tracking issue.

Made with [Cursor](https://cursor.com)