### PR TITLE
feat(enrichment): detect Anthropic API keys in secret-scan

### DIFF
--- a/review-enrichment/src/analyzers/secret-scan.ts
+++ b/review-enrichment/src/analyzers/secret-scan.ts
@@ -61,6 +61,13 @@ const RULES: Rule[] = [
     confidence: "high",
   },
   {
+    // Anthropic API key: `sk-ant-` + base64url body. Distinct from Stripe `sk_live_` (underscore).
+    // Negative-lookahead terminator (not `\b`) so a body ending in `-` still matches, like SendGrid.
+    kind: "anthropic_api_key",
+    re: /\bsk-ant-[A-Za-z0-9_-]{20,}(?![A-Za-z0-9_-])/,
+    confidence: "high",
+  },
+  {
     kind: "private_key",
     re: /-----BEGIN (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----/,
     confidence: "high",

--- a/review-enrichment/test/secret-scan.test.ts
+++ b/review-enrichment/test/secret-scan.test.ts
@@ -17,6 +17,8 @@ const fakeAwsKey = awsKeyFragmentA + awsKeyFragmentB;
 const fakeStripeKey = ["sk_live_", "abcdefghijklmnop1234567890"].join(""); // sk_live_ + 26 base62
 const fakeSendgridKey = ["SG.", "a".repeat(22), ".", "b".repeat(43)].join("");
 const fakeHuggingfaceToken = "hf_" + "a".repeat(34);
+// Anthropic keys are `sk-ant-` + a long base64url body (fragments only — never a contiguous literal in source).
+const fakeAnthropicKey = ["sk-ant-", "api03-", "a".repeat(20)].join("");
 const fakeGitlabToken = "glpat-" + "aBcDeFgHiJkLmNoPqRsT"; // 20 chars after the prefix
 const fakeNpmToken = "npm_" + "a".repeat(36);
 // A high-entropy value that matches NO format-specific rule, so it only trips the
@@ -168,3 +170,19 @@ for (const content of ['++const key = "AWS_KEY";', '++ const key = "AWS_KEY";'])
     assert.equal(findings[0].line, 1);
   });
 }
+
+test("scanPatch flags an Anthropic API key with high confidence", () => {
+  const findings = scanPatch("src/config.ts", hunk([`const anthropicKey = "${fakeAnthropicKey}";`]));
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "anthropic_api_key");
+  assert.equal(findings[0].confidence, "high");
+});
+
+test("scanPatch flags an Anthropic key whose final body character is a hyphen", () => {
+  // Negative lookahead (not `\b`) so a body ending in `-` still matches — same style as SendGrid.
+  const hyphenTail = ["sk-ant-", "api03-", "a".repeat(19), "-"].join("");
+  const findings = scanPatch("src/config.ts", hunk([`const anthropicKey = "${hyphenTail}";`]));
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "anthropic_api_key");
+  assert.equal(findings[0].confidence, "high");
+});


### PR DESCRIPTION
## Summary
The `secret` analyzer recognizes many high-confidence credential prefixes (GitHub, GitLab, npm, Stripe, SendGrid, Hugging Face) but **missed Anthropic API keys** (`sk-ant-…`).

## Scope
Adds one high-confidence rule:
```
/\bsk-ant-[A-Za-z0-9_-]{20,}(?![A-Za-z0-9_-])/
```
- Scoped to the `sk-ant-` prefix (cannot cross-match Stripe's `sk_live_`).
- Terminator is a **negative lookahead** (not `\b`), matching the existing SendGrid rule, so a body whose final character is `-` is still reported.
- No secret value is returned — only kind/confidence/file/line.
- Diff is additive-only (no reformatting of existing fixtures).

## Test plan
- [x] Positive Anthropic key case.
- [x] Hyphen-tail regression (body ending in `-`).
- [x] `node --test test/secret-scan.test.ts` — 19 passed.

## No linked issue
Self-contained detection-coverage improvement; no tracking issue. Touches only `secret-scan.ts` and additive tests.

Made with [Cursor](https://cursor.com)