### PR TITLE
fix(product-usage): recognize the plural "reviewers" role as maintainer

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -5849,6 +5849,7 @@ function normalizeProductUsageRole(value: string): ProductUsageRole | null {
     case "maintainer":
     case "maintainers":
     case "reviewer":
+    case "reviewers":
       return "maintainer";
     case "owner":
     case "owners":

--- a/test/unit/product-usage.test.ts
+++ b/test/unit/product-usage.test.ts
@@ -731,6 +731,27 @@ describe("product usage events", () => {
     expect(JSON.stringify(result.rollups[0])).not.toMatch(/multi-role-actor|reviewer-actor|none-actor|invalid-role-actor|public-surface-actor|fixed-test-salt/i);
   });
 
+  it("buckets the plural 'reviewers' role as maintainer, like every other role's plural", async () => {
+    const env = createTestEnv({ PRODUCT_USAGE_HASH_SALT: "fixed-test-salt" });
+    const day = "2026-06-16";
+    // Every other role accepts its plural (miners/owners/operators/contributors/maintainers); "reviewers"
+    // is a maintainer synonym and must bucket the same, not fall through to "unknown".
+    await recordProductUsageEvent(env, {
+      surface: "control_panel",
+      eventName: "command_previewed",
+      actor: "reviewers-actor",
+      outcome: "success",
+      metadata: { roles: ["reviewers"] },
+      occurredAt: `${day}T01:00:00.000Z`,
+    });
+
+    const result = await rollupProductUsageDaily(env, { day, nowIso: `${day}T23:00:00.000Z` });
+
+    expect(result.rollups[0]?.byRole).toEqual(
+      expect.arrayContaining([{ role: "maintainer", count: 1, activeActors: 1, activeRepos: 0 }]),
+    );
+  });
+
   it("builds role activation and coarse retention rollups without exposing actors", async () => {
     const env = createTestEnv({ PRODUCT_USAGE_HASH_SALT: "fixed-test-salt" });
     const day = "2026-06-10";


### PR DESCRIPTION
## Summary

`normalizeProductUsageRole` in `src/db/repositories.ts` maps free-form role/audience metadata values to a
`ProductUsageRole` bucket. Every role accepts both its singular and plural form —
`miner`/`miners`, `owner`/`owners`, `operator`/`operators`, `contributor`/`contributors`, and
`maintainer`/`maintainers` — **except** the reviewer synonym, which only had the singular:

```ts
case "maintainer":
case "maintainers":
case "reviewer":          // singular handled; plural "reviewers" was missing
  return "maintainer";
```

So a `"reviewers"` value falls through to `default → null`. Because the role set is then empty,
`productUsageBaseRolesForEvent` falls back to event inference, and a normal `control_panel` /
`command_previewed` event misclassifies to the **`unknown`** bucket instead of **`maintainer`** (on an MCP
event it would land in `miner`).

This is reachable: `recordProductUsageEvent` → `resolveProductUsageRole` →
`addProductUsageRolesFromValue` reads client-supplied `metadata.role` / `roles` / `audience` / `actorRole`
/ `actorKind`, and those fields naturally take plural values (the existing role test itself feeds
`"miners"`, `"maintainers"`, `"owners"`, `"operators"`, `"contributors"`). So telemetry that labels an
actor `"reviewers"` is silently bucketed as `unknown`, skewing the per-role rollups.

Fix: add the missing `case "reviewers":` so it maps to `maintainer`, exactly like the singular `reviewer`
and the plural `maintainers` it is a synonym of. One additive case.

No linked issue: small, self-evident consistency fix (one switch case) that makes the reviewer synonym
accept its plural like every other role; no schema/API-shape/deploy change — fits the repo's `preferred`
(not required) linked-issue policy.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran locally: `git diff --check` (clean), `npm run typecheck` (clean), and `test/unit/product-usage.test.ts`
  — 27 tests pass, including the new one that exercises the added `case "reviewers"` (asserting it buckets
  as `maintainer`). The changed line is a single switch case reached by that test, so `codecov/patch` is
  100% on this diff.
- Not run locally: the UI, MCP, workers, OpenAPI, actionlint, and audit jobs. This is a `src/`-only change
  to one deterministic normalizer touching no UI/API-shape/OpenAPI/MCP/DB-schema/workflow surface, so those
  jobs are no-ops for this diff; they run on CI (Linux).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- No API/OpenAPI shape change — this only corrects which internal role bucket a `"reviewers"` telemetry
  value aggregates into. All other role mappings are unchanged.
- Regression test added in `test/unit/product-usage.test.ts` ("buckets the plural 'reviewers' role as
  maintainer, like every other role's plural"): an event with `metadata: { roles: ["reviewers"] }` now
  aggregates under `maintainer` (was `unknown`). The existing role-variants test (which already covers the
  singular `reviewer` and plural `maintainers`) is unchanged.
