### PR TITLE
fix(enrichment): do not let no-newline markers skew ReDoS line numbers

### DIFF
--- a/review-enrichment/src/analyzers/redos.ts
+++ b/review-enrichment/src/analyzers/redos.ts
@@ -276,7 +276,9 @@ export function scanPatchForRedos(
         }
       }
       newLine++;
-    } else if (!line.startsWith("-")) {
+    } else if (!line.startsWith("-") && !line.startsWith("\\")) {
+      // A `\ No newline at end of file` marker is not a new-file line — do not advance the cursor
+      // (same class as the iac-misconfig / undocumented-export fix).
       newLine++;
     }
   }

--- a/review-enrichment/test/redos.test.ts
+++ b/review-enrichment/test/redos.test.ts
@@ -52,6 +52,21 @@ test("scanPatchForRedos cites the added-line number of a catastrophic literal", 
   assert.equal(findings[0]?.kind, "nested-quantifier");
 });
 
+test("scanPatchForRedos does not let a no-newline marker skew the line number", () => {
+  // `\ No newline at end of file` is not a new-file line; advancing past it would cite the
+  // catastrophic literal one line too high (same class as the iac-misconfig regression).
+  const patch = [
+    "@@ -1,1 +1,2 @@",
+    "-const x = 1;",
+    "\\ No newline at end of file",
+    "+const x = 1;",
+    "+const re = /(a+)+/;",
+  ].join("\n");
+  const findings = scanPatchForRedos("src/x.ts", patch);
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0]?.line, 2);
+});
+
 test("scanPatchForRedos ignores safe patterns and honours a zero finding budget", () => {
   const safe = ["@@ -1 +1,1 @@", "+const re = /(abc)+/;"].join("\n");
   assert.deepEqual(scanPatchForRedos("src/x.ts", safe), []);


### PR DESCRIPTION
## Summary
A `\ No newline at end of file` marker is not a new-file line, but the ReDoS patch walker advanced the cursor past it and cited findings **one line too high**.

## Scope
Skip lines starting with `\` when advancing the new-file cursor — same class as the existing `iac-misconfig` / `undocumented-export` fix.

## Test plan
- [x] Regression: marker between a removed line and an added catastrophic literal cites line **2**, not 3.
- [x] `node --test test/redos.test.ts` — 6 passed.

## No linked issue
Self-contained line-citation fix; no tracking issue. Touches only `redos.ts` and its test.

Made with [Cursor](https://cursor.com)