### PR TITLE
fix(enrichment): do not let no-newline markers skew secret-log line numbers

### DIFF
--- a/review-enrichment/src/analyzers/secret-log.ts
+++ b/review-enrichment/src/analyzers/secret-log.ts
@@ -148,7 +148,9 @@ export function scanPatchForSecretLog(
         }
       }
       newLine++;
-    } else if (!line.startsWith("-")) {
+    } else if (!line.startsWith("-") && !line.startsWith("\\")) {
+      // A `\ No newline at end of file` marker is not a new-file line — do not advance the cursor
+      // (same class as the iac-misconfig / redos fix).
       newLine++;
     }
   }

--- a/review-enrichment/test/secret-log.test.ts
+++ b/review-enrichment/test/secret-log.test.ts
@@ -104,6 +104,26 @@ test("scanPatchForSecretLog cites the added line via the hunk header", () => {
   ]);
 });
 
+test("scanPatchForSecretLog does not let a no-newline marker skew the line number", () => {
+  // `\ No newline at end of file` is not a new-file line; advancing past it would cite the
+  // sink one line too high (same class as the iac-misconfig / redos regression).
+  const patch = [
+    "@@ -1,1 +1,2 @@",
+    "-const x = 1;",
+    "\\ No newline at end of file",
+    "+const x = 1;",
+    "+console.dir(req.headers)",
+  ].join("\n");
+  assert.deepEqual(scanPatchForSecretLog("src/app.ts", patch), [
+    {
+      file: "src/app.ts",
+      line: 2,
+      sink: "console.dir",
+      category: "request-object",
+    },
+  ]);
+});
+
 test("scanPatchForSecretLog ignores context and removed lines", () => {
   const patch = [
     "@@ -1,2 +1,1 @@",


### PR DESCRIPTION
## Summary
A `\ No newline at end of file` marker is not a new-file line, but the secret-log patch walker advanced the cursor past it and cited findings **one line too high**.

## Scope
Skip lines starting with `\` when advancing the new-file cursor — same class as the existing `iac-misconfig` / `redos` fix.

## Test plan
- [x] Regression: marker between a removed line and an added `console.dir(req.headers)` cites line **2**, not 3.
- [x] `node --test test/secret-log.test.ts` — 12 passed.

## No linked issue
Self-contained line-citation fix; no tracking issue. Touches only `secret-log.ts` and its test.

Made with [Cursor](https://cursor.com)