### PR TITLE
fix(enrichment): PEP 503–normalize PyPI names for lockfile-drift exclusion

### DIFF
--- a/review-enrichment/src/analyzers/lockfile-drift.ts
+++ b/review-enrichment/src/analyzers/lockfile-drift.ts
@@ -349,13 +349,23 @@ function parseLockfile(path: string, patch: string, maxLines: number): LockfileC
   return [];
 }
 
+/** Stable key for direct-dep exclusion. PyPI names are PEP 503–normalized (case-insensitive;
+ *  `-` / `_` / `.` equivalent) so `Django` in requirements.txt matches `django` in poetry.lock.
+ *  npm keys stay exact — registry names are case-sensitive / enforced-lowercase. */
+function packageKey(ecosystem: string, pkg: string): string {
+  if (ecosystem === "PyPI") {
+    return `PyPI::${pkg.toLowerCase().replace(/[-_.]+/g, "-")}`;
+  }
+  return `${ecosystem}::${pkg}`;
+}
+
 /** Extract lockfile-only resolved package changes. Top-level manifest changes are excluded as direct deps. */
 export function extractLockfileChanges(
   files: NonNullable<EnrichRequest["files"]>,
   limits: ScanLimits = {},
 ): LockfileChange[] {
   const direct = new Set(
-    extractDependencyChanges(files).map((dep) => `${dep.ecosystem}::${dep.package}`),
+    extractDependencyChanges(files).map((dep) => packageKey(dep.ecosystem, dep.package)),
   );
   const maxFiles = limits.maxLockfileFiles ?? MAX_LOCKFILE_FILES;
   const maxLines = limits.maxPatchLinesPerFile ?? MAX_PATCH_LINES_PER_FILE;
@@ -366,7 +376,7 @@ export function extractLockfileChanges(
     scannedFiles += 1;
     if (scannedFiles > maxFiles) break;
     for (const change of parseLockfile(file.path, file.patch, maxLines)) {
-      if (direct.has(`${change.ecosystem}::${change.package}`)) continue;
+      if (direct.has(packageKey(change.ecosystem, change.package))) continue;
       if (!isSafeQuery(change.package, change.to)) continue;
       changes.push(change);
     }

--- a/review-enrichment/test/lockfile-drift.test.ts
+++ b/review-enrichment/test/lockfile-drift.test.ts
@@ -83,3 +83,52 @@ test("extractLockfileChanges does not let unparsed lockfiles consume the scan bu
     },
   ]);
 });
+
+test("extractLockfileChanges excludes PyPI direct deps under PEP 503 name normalization", () => {
+  // Manifests often use `Django` / `PyYAML` while poetry.lock stores `django` / `pyyaml`.
+  // Without PEP 503 normalization those were treated as lockfile-only transitive drift.
+  const changes = extractLockfileChanges([
+    {
+      path: "requirements.txt",
+      patch: ["@@ -1,0 +1,2 @@", "+Django==4.2.0", "+PyYAML==6.0"].join("\n"),
+    },
+    {
+      path: "poetry.lock",
+      patch: [
+        "@@ -1,0 +1,6 @@",
+        "+[[package]]",
+        '+name = "django"',
+        '+version = "4.2.0"',
+        "+[[package]]",
+        '+name = "pyyaml"',
+        '+version = "6.0"',
+      ].join("\n"),
+    },
+  ]);
+  assert.deepEqual(changes, []);
+});
+
+test("extractLockfileChanges still reports a PyPI lockfile-only package", () => {
+  // A package present only in poetry.lock (no manifest entry) remains lockfile drift.
+  const changes = extractLockfileChanges([
+    {
+      path: "poetry.lock",
+      patch: [
+        "@@ -1,0 +1,3 @@",
+        "+[[package]]",
+        '+name = "requests"',
+        '+version = "2.31.0"',
+      ].join("\n"),
+    },
+  ]);
+  assert.deepEqual(changes, [
+    {
+      file: "poetry.lock",
+      line: 3,
+      ecosystem: "PyPI",
+      package: "requests",
+      from: null,
+      to: "2.31.0",
+    },
+  ]);
+});


### PR DESCRIPTION
## Summary
Lockfile-drift excludes packages already named in the manifest as direct deps. It compared names **exactly**, so `Django` in `requirements.txt` did not match `django` in `poetry.lock` and was misreported as lockfile-only transitive drift.

## Scope
Adds a `packageKey` helper: PyPI names are PEP 503–normalized (case-insensitive; `-` / `_` / `.` equivalent). npm keys stay exact (registry names are case-sensitive / enforced-lowercase).

## Test plan
- [x] `Django` + `PyYAML` in requirements with `django` / `pyyaml` in poetry.lock → no lockfile-only findings.
- [x] Lockfile-only `requests` still reported.
- [x] `node --test test/lockfile-drift.test.ts` — 5 passed.

## No linked issue
Self-contained exclusion precision fix; no tracking issue. Touches only `lockfile-drift.ts` and its test.

Made with [Cursor](https://cursor.com)