### PR TITLE
fix(enrichment): flag .node and .pyd native-addon binaries in provenance

### DIFF
--- a/review-enrichment/src/analyzers/provenance.ts
+++ b/review-enrichment/src/analyzers/provenance.ts
@@ -17,9 +17,11 @@ import { boundedFetchJson } from "../external-fetch.js";
 const MAX_ATTESTATION_CHECKS = 20; // bound network round-trips
 const MAX_FINDINGS = 30; // keep the brief bounded
 
-// Compiled/non-source binary artifact extensions.
+// Compiled/non-source binary artifact extensions. `node` is a compiled Node native addon (matching the
+// binary set in asset-weight.ts) and `pyd` is a Windows Python extension DLL (the sibling of the pyc/pyo/so
+// entries) — both are unauditable prebuilt binaries a PR should not check in without source.
 const BINARY_EXT_RE =
-  /\.(exe|dll|so|dylib|bin|pyc|pyo|class|jar|war|ear|wasm|o|a)$/i;
+  /\.(exe|dll|so|dylib|bin|pyc|pyo|pyd|class|jar|war|ear|wasm|node|o|a)$/i;
 // Vendored / embedded third-party source trees. bower_components (Bower) and jspm_packages (JSPM) are
 // installed-dependency directories — the same vendored case as node_modules — so a committed tree under either
 // is a vendored artifact, not contributor source (mirrors src/signals/path-matchers.ts's vendored classifier).

--- a/review-enrichment/test/provenance.test.ts
+++ b/review-enrichment/test/provenance.test.ts
@@ -22,3 +22,14 @@ test("classifyAddedFile treats bower_components and jspm_packages as vendored, l
   assert.equal(classifyAddedFile("src/bower_components.ts"), null);
   assert.equal(classifyAddedFile("src/app.ts"), null);
 });
+
+test("classifyAddedFile flags prebuilt native-addon binaries (.node/.pyd) as binary artifacts", () => {
+  // Compiled Node native addons and Windows Python extension DLLs are unauditable prebuilt binaries — the
+  // same category as the exe/dll/so/wasm entries already flagged. A committed `*.node` fell through to null.
+  for (const path of ["build/Release/bcrypt_lib.node", "prebuilds/darwin-x64/foo.node", "native/mod.pyd"]) {
+    assert.equal(classifyAddedFile(path), "binary", path);
+  }
+  // Extension is `$`-anchored: a source file merely named like one is still ordinary source (null).
+  assert.equal(classifyAddedFile("src/node.ts"), null);
+  assert.equal(classifyAddedFile("app/foo.node.js"), null);
+});


### PR DESCRIPTION
## Summary

The provenance analyzer's `classifyAddedFile` (`review-enrichment/src/analyzers/provenance.ts`) flags a
PR that commits an unauditable prebuilt binary, matching an extension allowlist:

```ts
const BINARY_EXT_RE =
  /\.(exe|dll|so|dylib|bin|pyc|pyo|class|jar|war|ear|wasm|o|a)$/i;
```

The list is missing **`.node`** — a compiled Node native addon — and **`.pyd`** (a Windows Python
extension DLL). Committing a prebuilt native addon is a common supply-chain artifact (e.g. a checked-in
`build/Release/*.node` or a vendored `prebuilds/<platform>/*.node`), and it is exactly the "binary files
committed without an auditable source" category this analyzer exists to surface.

Concrete false negative (input as `scanProvenance` receives it):

```js
files = [{ path: "build/Release/bcrypt_lib.node", status: "added" }]
// classifyAddedFile("build/Release/bcrypt_lib.node")
// before: null   → no finding; the reviewer is never told a compiled binary was added
// after:  "binary" → { kind: "binary", file: "build/Release/bcrypt_lib.node" }
```

This is a clear inconsistency, not a judgment call: the sibling `asset-weight.ts` already lists `node` in
its `BINARY_EXTS` set, so the codebase already treats `.node` as a genuine binary, and `.pyd` is the direct
sibling of the `pyc`/`pyo`/`so`/`dll` entries already present.

Fix: add `node` and `pyd` to the extension alternation. Additive with zero false-positive risk — no text
format uses `.node` or `.pyd`, and the `$` anchor keeps names like `foo.node.js` from matching.

No linked issue: small, self-evident detection-coverage fix (two additive extensions) aligning provenance
with `asset-weight`'s binary set and its own existing compiled-artifact entries; no schema/config/deploy
change — fits the repo's `preferred` (not required) linked-issue policy.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run typecheck`
- [x] `npm run rees:test` — the review-enrichment build + analyzer suite (see note below)
- [ ] `npm run test:coverage` (N/A — this file is in `review-enrichment/`, outside the `src/**` Codecov scope)
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran locally: `git diff --check` (clean), the review-enrichment TypeScript build (`npm --prefix
  review-enrichment run build`, clean), and the provenance analyzer test via `node --test` — **2/2 tests
  pass**, including the new `.node`/`.pyd` regression and its `$`-anchor control cases. The change is
  confined to `review-enrichment/`, outside the `src/**` Codecov scope, so `test:coverage` does not apply.
- Not run locally: the UI, root typecheck, and the `metadata:check` step of `rees:test`. `metadata:check`
  compares the committed `analyzer-metadata.json` (generated on CI/Linux) against a local regeneration and
  reports a spurious byte difference on this Windows dev box (it fails identically on unmodified `main`);
  this change touches only the binary-extension regex, not any analyzer descriptor, so the committed
  metadata is unchanged and `metadata:check` passes on CI (Linux). `analyzer-metadata.json` was NOT modified.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Detection-only widening: this adds two unambiguous compiled-binary extensions so a committed native addon
  is surfaced as a `binary` provenance finding instead of being silently treated as source. No analyzer
  descriptor changes, so `analyzer-metadata.json` is intentionally untouched.
- Regression test added in `review-enrichment/test/provenance.test.ts`: `*.node` and `*.pyd` added files now
  classify as `binary`, while `src/node.ts` and `app/foo.node.js` stay `null` (the `$` anchor). Existing
  vendored/source assertions are unchanged.
