### PR TITLE
fix(api): allow maintainer OAuth sessions to reach the approval queue

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -5050,6 +5050,7 @@ function canSessionAccessPath(env: Env, identity: Extract<AuthIdentity, { kind: 
   if (isRepoCheckBeforeStartPath(path)) return true;
   if (isRepoValidateLinkedIssuePath(path)) return true;
   if (isRepoAgentAuditFeedPath(path)) return true; // route's requireRepoMaintainer enforces per-repo authority (contributors → 403)
+  if (isRepoAgentPendingActionsPath(path)) return true; // list: requireRepoMaintainer; decide: requireRepoWriteAccess
   if (isRepoContributorIssueDraftGeneratePath(path)) return true;
   if (path === LINT_PR_TEXT_PATH || path === LINT_SLOP_RISK_PATH || path === LINT_ISSUE_SLOP_PATH) return true;
   if (path === EXTENSION_PULL_CONTEXT_PATH && isExtensionScopedSession(identity)) return true;
@@ -5099,6 +5100,7 @@ function isRepoAgentAuditFeedPath(path: string): boolean {
   return /^\/v1\/repos\/[^/]+\/[^/]+\/agent\/audit-feed$/.test(path);
 }
 
+function isRepoAgentPendingActionsPath(path: string): boolean { return /^\/v1\/repos\/[^/]+\/[^/]+\/agent\/pending-actions(?:\/[^/]+\/(?:accept|reject))?$/.test(path); }
 function isIssueQualityPath(path: string): boolean {
   return /^\/v1\/repos\/[^/]+\/[^/]+\/issue-quality$/.test(path);
 }

--- a/test/unit/access-boundary.test.ts
+++ b/test/unit/access-boundary.test.ts
@@ -73,6 +73,15 @@ describe("access boundary: per-repo maintainer data is repo-scoped", () => {
     expect(await other.json()).toMatchObject({ error: "forbidden_repo" });
   });
 
+  it("a maintainer can REACH agent pending-actions on their OWN repo (allowlist parity with audit-feed)", async () => {
+    const { app, env } = await setup();
+    const { token } = await createSessionForGitHubUser(env, { login: "alice", id: 101 });
+    const cookie = `gittensory_session=${token}`;
+    const own = await app.request("/v1/repos/alice/repo-a/agent/pending-actions", { headers: { cookie } }, env);
+    expect(own.status).toBe(200);
+    await expect(own.json()).resolves.toMatchObject({ repoFullName: "alice/repo-a", pendingActions: [] });
+  });
+
   it("a pure miner (no maintainer role on any repo) cannot read ANY repo's maintainer settings", async () => {
     const { app, env } = await setup();
     const { token } = await createSessionForGitHubUser(env, { login: "miner-only", id: 900 });

--- a/test/unit/routes-agent-approval.test.ts
+++ b/test/unit/routes-agent-approval.test.ts
@@ -136,6 +136,38 @@ describe("agent approval-queue routes (#779)", () => {
     const again = await app.request(`/v1/repos/owner/repo/agent/pending-actions/${action.id}/accept`, { method: "POST", headers: headers(env) }, env);
     expect(again.status).toBe(409);
   });
+
+  it("allows a repository owner session to list the approval queue", async () => {
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
+    await upsertInstallation(env, {
+      installation: { id: 5, account: { login: "owner", id: 1, type: "User" }, repository_selection: "selected", permissions: { metadata: "read", contents: "write", pull_requests: "write", issues: "write" }, events: ["pull_request"] },
+      repositories: [{ name: "repo", full_name: "owner/repo", private: false, owner: { login: "owner" } }],
+    });
+    await upsertRepositoryFromGitHub(env, { name: "repo", full_name: "owner/repo", private: false, owner: { login: "owner" } }, 5);
+    await seedPending(env);
+    const { token } = await createSessionForGitHubUser(env, { login: "owner", id: 1 });
+
+    const list = await app.request("/v1/repos/owner/repo/agent/pending-actions", { headers: { cookie: `gittensory_session=${token}` } }, env);
+
+    expect(list.status).toBe(200);
+    await expect(list.json()).resolves.toMatchObject({ repoFullName: "owner/repo", pendingActions: [{ actionClass: "merge", status: "pending" }] });
+  });
+
+  it("forbids a contributor (non-maintainer) session even though the coarse allowlist permits the path", async () => {
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
+    await upsertInstallation(env, {
+      installation: { id: 5, account: { login: "owner", id: 1, type: "User" }, repository_selection: "selected", permissions: { metadata: "read" }, events: ["pull_request"] },
+    });
+    await upsertRepositoryFromGitHub(env, { name: "repo", full_name: "owner/repo", private: false, owner: { login: "owner" } }, 5);
+    await seedPending(env);
+    const { token } = await createSessionForGitHubUser(env, { login: "contributor", id: 999 });
+
+    const list = await app.request("/v1/repos/owner/repo/agent/pending-actions", { headers: { authorization: `Bearer ${token}` } }, env);
+    expect([401, 403]).toContain(list.status);
+
+    const decide = await app.request("/v1/repos/owner/repo/agent/pending-actions/x/reject", { method: "POST", headers: { authorization: `Bearer ${token}` } }, env);
+    expect([401, 403]).toContain(decide.status);
+  });
 });
 
 describe("agent audit-feed route (#784)", () => {


### PR DESCRIPTION
## Summary

`/v1/repos/:owner/:repo/agent/pending-actions` (GET list + POST accept/reject) already had correct per-route guards (`requireRepoMaintainer` / `requireRepoWriteAccess`), but maintainer browser sessions never reached them. Global middleware calls `canSessionAccessPath`, which whitelisted `agent/audit-feed` but not `agent/pending-actions`. Any non-`ADMIN_GITHUB_LOGINS` session received `403 insufficient_role` at middleware — including a repo owner who should be able to view and approve staged merges from the control panel.

This PR adds `isRepoAgentPendingActionsPath()` and one entry in `canSessionAccessPath`, mirroring the audit-feed pattern (#943). Handler guards continue to block contributors, cross-repo access, and unscoped callers.

## Changed files

| File | Change |
| ---- | ------ |
| `src/api/routes.ts` | Add `isRepoAgentPendingActionsPath`; whitelist pending-actions in `canSessionAccessPath`. |
| `test/unit/routes-agent-approval.test.ts` | Regression: repo-owner session lists pending actions; contributor session still 403 despite allowlist. |
| `test/unit/access-boundary.test.ts` | Coarse allowlist parity: maintainer session can REACH own-repo pending-actions (cookie auth). |

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

No linked issue — regression fix for a session allowlist gap on #779 approval-queue routes; behavior is fully described here and covered by regression tests.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check` (no API schema change — N/A diff)
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries


## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below — N/A (backend session allowlist only).
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.


## UI Evidence

N/A — backend session allowlist only. Control-panel approval UI uses these routes over OAuth; repo owners were blocked at middleware before this fix.

## Test plan

- [x] Repo-owner OAuth session (cookie) → GET pending-actions returns 200 with staged rows
- [x] Maintainer session (access-boundary fixture) → can REACH own-repo pending-actions (200, empty list OK)
- [x] Contributor OAuth session → list and decide still 403 (handler guard, not middleware-only)
- [x] Static API token paths unchanged (existing approval-queue suite)
- [x] Random non-maintainer session still 403 at middleware or handler (existing suite)
- [x] Existing approval-queue suite (20 tests) and access-boundary suite (9 tests) still pass
- [ ] Full `npm run test:ci` green before push

