### PR TITLE
fix(enrichment): do not let no-newline markers skew secret-scan line numbers

### DIFF
--- a/review-enrichment/src/analyzers/secret-scan.ts
+++ b/review-enrichment/src/analyzers/secret-scan.ts
@@ -143,8 +143,10 @@ export function scanPatch(path: string, patch: string): SecretFinding[] {
       }
       previousLiterals = currentLiterals;
       newLine++;
-    } else if (!line.startsWith("-")) {
-      newLine++; // context line advances the new-file counter; removed lines do not
+    } else if (!line.startsWith("-") && !line.startsWith("\\")) {
+      // Context line advances the new-file counter; removed lines and `\ No newline at end of
+      // file` markers do not (same class as the iac-misconfig / redos / secret-log fix).
+      newLine++;
       previousLiterals = [];
     } else {
       previousLiterals = [];

--- a/review-enrichment/test/secret-scan.test.ts
+++ b/review-enrichment/test/secret-scan.test.ts
@@ -186,3 +186,19 @@ test("scanPatch flags an Anthropic key whose final body character is a hyphen", 
   assert.equal(findings[0].kind, "anthropic_api_key");
   assert.equal(findings[0].confidence, "high");
 });
+
+test("scanPatch does not let a no-newline marker skew the line number", () => {
+  // `\ No newline at end of file` is not a new-file line; advancing past it would cite the
+  // secret one line too high (same class as the iac-misconfig / redos / secret-log regression).
+  const patch = [
+    "@@ -1,1 +1,2 @@",
+    "-const x = 1;",
+    "\\ No newline at end of file",
+    "+const x = 1;",
+    `+const key = "${fakeAwsKey}";`,
+  ].join("\n");
+  const findings = scanPatch("src/config.ts", patch);
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "aws_access_key_id");
+  assert.equal(findings[0].line, 2);
+});


### PR DESCRIPTION
## Summary
A `\ No newline at end of file` marker is not a new-file line, but the secret-scan patch walker advanced the cursor past it and cited findings **one line too high**.

## Scope
Skip lines starting with `\` when advancing the new-file cursor — same class as the existing `iac-misconfig` / `redos` / `secret-log` fix. Removed-line handling and cross-line literal joining are unchanged.

## Test plan
- [x] Regression: marker between a removed line and an added AWS key cites line **2**, not 3.
- [x] `node --test test/secret-scan.test.ts` — 20 passed.

## No linked issue
Self-contained line-citation fix; no tracking issue. Touches only `secret-scan.ts` and an additive test.

Made with [Cursor](https://cursor.com)