### PR TITLE
fix(enrichment): do not let no-newline markers skew actions-pin line numbers

### DIFF
--- a/review-enrichment/src/analyzers/actions-pin.ts
+++ b/review-enrichment/src/analyzers/actions-pin.ts
@@ -42,7 +42,9 @@ export function scanWorkflowPins(
         }
       }
       newLine++;
-    } else if (!line.startsWith("-")) {
+    } else if (!line.startsWith("-") && !line.startsWith("\\")) {
+      // A `\ No newline at end of file` marker is not a new-file line — do not advance the cursor
+      // (same class as the iac-misconfig / redos / secret-log / secret-scan fix).
       newLine++;
     }
   }

--- a/review-enrichment/test/actions-pin.test.ts
+++ b/review-enrichment/test/actions-pin.test.ts
@@ -99,6 +99,25 @@ test("scanWorkflowPins ignores patches without added mutable third-party uses", 
   );
 });
 
+test("scanWorkflowPins does not let a no-newline marker skew the line number", () => {
+  // `\ No newline at end of file` is not a new-file line; advancing past it would cite the
+  // mutable uses: one line too high (same class as the iac-misconfig / redos regression).
+  // First added line is an official action (not flagged) so only the third-party pin is asserted.
+  const findings = scanWorkflowPins(
+    workflowPath,
+    [
+      "@@ -1,1 +1,2 @@",
+      "-    - uses: actions/checkout@v3",
+      "\\ No newline at end of file",
+      "+    - uses: actions/checkout@v4",
+      "+    - uses: pnpm/action-setup@v3",
+    ].join("\n"),
+  );
+  assert.deepEqual(findings, [
+    { file: workflowPath, line: 2, action: "pnpm/action-setup", ref: "v3" },
+  ]);
+});
+
 test("scanWorkflowPins accepts uppercase and mixed-case 40-char SHA pins", () => {
   // Git SHAs are case-insensitive; an uppercase/mixed-case full SHA is still an immutable pin.
   const upperSha = "A".repeat(40);


### PR DESCRIPTION
## Summary
A `\ No newline at end of file` marker is not a new-file line, but the actions-pin patch walker advanced the cursor past it and cited findings **one line too high**.

## Scope
Skip lines starting with `\` when advancing the new-file cursor — same class as the existing `iac-misconfig` / `redos` / `secret-scan` fix.

## Test plan
- [x] Regression: marker between a removed line and an added mutable third-party `uses:` cites line **2**, not 3.
- [x] `node --test test/actions-pin.test.ts` — 8 passed.

## No linked issue
Self-contained line-citation fix; no tracking issue. Touches only `actions-pin.ts` and its test.
