### PR TITLE
fix(enrichment): treat .node-version as a Node runtime pin for EOL checks

### DIFF
--- a/review-enrichment/src/analyzers/eol-check.ts
+++ b/review-enrichment/src/analyzers/eol-check.ts
@@ -88,7 +88,8 @@ export function extractVersionPins(
           if (product && version)
             pins.push({ file: file.path, product, version });
         }
-      } else if (base === ".nvmrc") {
+      } else if (base === ".nvmrc" || base === ".node-version") {
+        // `.node-version` (nodenv/asdf) carries the same leading-version pin as `.nvmrc`.
         const version = leadingVersion(line);
         if (version) pins.push({ file: file.path, product: "nodejs", version });
       } else if (base === "go.mod") {

--- a/review-enrichment/src/scheduler.ts
+++ b/review-enrichment/src/scheduler.ts
@@ -404,5 +404,11 @@ function isRuntimePinPath(path: string): boolean {
   // Share the eol analyzer's own Dockerfile predicate so the gate can't skip a file the analyzer would
   // parse. The prior bespoke `/^Dockerfile(?:\..*)?$/` missed `*.dockerfile` (e.g. web.dockerfile), silently
   // dropping eol analysis for it even though isDockerfile() handles it.
-  return isDockerfile(path) || basename === ".nvmrc" || basename === "go.mod";
+  // `.node-version` is the nodenv/asdf pin file; the eol analyzer parses it like `.nvmrc`.
+  return (
+    isDockerfile(path) ||
+    basename === ".nvmrc" ||
+    basename === ".node-version" ||
+    basename === "go.mod"
+  );
 }

--- a/review-enrichment/test/eol-check.test.ts
+++ b/review-enrichment/test/eol-check.test.ts
@@ -44,6 +44,13 @@ test("extractVersionPins reads .nvmrc and go.mod pins", () => {
   ]);
 });
 
+test("extractVersionPins reads .node-version pins like .nvmrc", () => {
+  // nodenv/asdf use `.node-version` with the same leading-version format as `.nvmrc`.
+  assert.deepEqual(extractVersionPins([added(".node-version", "20.11.0")]), [
+    { file: ".node-version", product: "nodejs", version: "20.11.0" },
+  ]);
+});
+
 test("extractVersionPins ignores removed/context lines and files with no patch", () => {
   const patch = ["@@ -1 +1,2 @@", "-FROM python:3.7", " FROM python:3.9"].join(
     "\n",


### PR DESCRIPTION
## Summary
The EOL analyzer and its scheduler runtime-pin gate only recognized `.nvmrc` for Node version pins. PRs that pin Node via **nodenv/asdf's `.node-version`** (same leading-version format) silently skipped EOL analysis.

## Scope
- `extractVersionPins` treats `.node-version` like `.nvmrc` (product `nodejs`).
- `isRuntimePinPath` in the scheduler admits `.node-version` so the gate cannot skip a file the analyzer would parse.

## Test plan
- [x] `extractVersionPins` on `.node-version` with `20.11.0` → `{ product: "nodejs", version: "20.11.0" }`.
- [x] `node --test test/eol-check.test.ts` — 9 passed.
- [x] Analyzer metadata check clean.

## No linked issue
Self-contained detection-coverage fix; no tracking issue. Touches `eol-check.ts`, `scheduler.ts`, and the eol test.
