### PR TITLE
fix(enrichment): flag GFDL/CC-BY-SA/QPL/Sleepycat copyleft licenses

### DIFF
--- a/review-enrichment/src/analyzers/license-check.ts
+++ b/review-enrichment/src/analyzers/license-check.ts
@@ -14,8 +14,11 @@ import { boundedFetchJson } from "../external-fetch.js";
 // REES ecosystem label → deps.dev system path segment.
 const SYSTEM: Record<string, string> = { npm: "npm", PyPI: "pypi", Go: "go" };
 
-// Strong/weak copyleft families worth a compatibility check against a permissive project.
-const COPYLEFT = /^(A?GPL|LGPL|MPL|EPL|CDDL|EUPL|OSL|SSPL|CPAL|CECILL)/i;
+// Strong/weak copyleft families worth a compatibility check against a permissive project. GFDL (the GNU
+// documentation copyleft, sibling of the GPL/LGPL/AGPL families above), CC-BY-SA (Creative Commons
+// ShareAlike — the `-SA` variant is copyleft, unlike plain CC-BY/CC0), QPL, and Sleepycat are all
+// reciprocal/copyleft SPDX ids that were previously classified as permissive and slipped through unflagged.
+const COPYLEFT = /^(A?GPL|LGPL|MPL|EPL|CDDL|EUPL|OSL|SSPL|CPAL|CECILL|GFDL|CC-BY-SA|QPL|Sleepycat)/i;
 const MAX_LICENSE_LOOKUPS = 25;
 const LICENSE_LOOKUP_TIMEOUT_MS = 1500;
 

--- a/review-enrichment/test/license-check.test.ts
+++ b/review-enrichment/test/license-check.test.ts
@@ -75,6 +75,35 @@ test("scanLicenses flags copyleft and unknown licenses while ignoring permissive
   ]);
 });
 
+test("scanLicenses flags GFDL/CC-BY-SA/QPL/Sleepycat copyleft families but not permissive CC-BY", async () => {
+  const responses = new Map([
+    ["gfdl-lib", ["GFDL-1.3-or-later"]],
+    ["ccbysa-lib", ["CC-BY-SA-4.0"]],
+    ["qpl-lib", ["QPL-1.0"]],
+    ["sleepycat-lib", ["Sleepycat"]],
+    ["ccby-lib", ["CC-BY-4.0"]], // attribution-only, NOT ShareAlike → permissive, must stay unflagged
+  ]);
+
+  const findings = await scanLicenses(
+    req([npmAdd("gfdl-lib"), npmAdd("ccbysa-lib"), npmAdd("qpl-lib"), npmAdd("sleepycat-lib"), npmAdd("ccby-lib")]),
+    async (url) => {
+      const match = /\/packages\/([^/]+)\/versions\//.exec(String(url));
+      return jsonResponse({ licenses: responses.get(decodeURIComponent(match?.[1] ?? "")) ?? [] });
+    },
+  );
+
+  assert.deepEqual(
+    findings.map((finding) => [finding.package, finding.classification]),
+    [
+      ["gfdl-lib", "copyleft"],
+      ["ccbysa-lib", "copyleft"],
+      ["qpl-lib", "copyleft"],
+      ["sleepycat-lib", "copyleft"],
+    ],
+  );
+  assert.ok(!findings.some((finding) => finding.package === "ccby-lib"));
+});
+
 test("scanLicenses treats an empty or absent license list as unknown", async () => {
   const findings = await scanLicenses(
     req([npmAdd("mystery-lib"), npmAdd("empty-license-lib")]),


### PR DESCRIPTION
## Summary

The license analyzer's `classify` (`review-enrichment/src/analyzers/license-check.ts`) flags a changed
dependency whose deps.dev-resolved SPDX license matches a copyleft family, so a maintainer can eyeball
compatibility against a permissive project:

```ts
const COPYLEFT = /^(A?GPL|LGPL|MPL|EPL|CDDL|EUPL|OSL|SSPL|CPAL|CECILL)/i;
…
if (resolved.some((license) => COPYLEFT.test(license))) return "copyleft";
return null; // permissive / otherwise-known → not flagged
```

The list omits several genuine copyleft SPDX families, so a dependency licensed under them is classified
`null` (permissive) and **silently not flagged** — a false negative in a legal-compatibility detector:

- **`GFDL-*`** — the GNU Free Documentation License, the documentation-copyleft sibling of the GPL/LGPL/AGPL
  families already in the list.
- **`CC-BY-SA-*`** — Creative Commons **ShareAlike** (the `-SA` variant is reciprocal/copyleft, unlike plain
  `CC-BY` / `CC0`).
- **`QPL-1.0`** and **`Sleepycat`** — both reciprocal/copyleft.

Concrete false negative (input as `scanLicenses` receives it, deps.dev stubbed):

```js
classify(["CC-BY-SA-4.0"])   // before: null (unflagged) ;  after: "copyleft"
classify(["GFDL-1.3-or-later"]) // before: null ;  after: "copyleft"
```

Fix: add `GFDL`, `CC-BY-SA`, `QPL`, and `Sleepycat` to the alternation. Each is an unambiguous copyleft
prefix with zero false-positive risk — in particular `CC-BY-SA` (anchored at `^`) matches only ShareAlike,
never permissive `CC-BY` / `CC0`, and no permissive license begins with `GFDL` / `QPL` / `Sleepycat`.

No linked issue: small, self-evident detection-coverage fix (four additive copyleft SPDX families) that
closes a false-negative gap in the copyleft detector; no schema/config/deploy change — fits the repo's
`preferred` (not required) linked-issue policy.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run typecheck`
- [x] `npm run rees:test` — the review-enrichment build + analyzer suite (see note below)
- [ ] `npm run test:coverage` (N/A — this file is in `review-enrichment/`, outside the `src/**` Codecov scope)
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran locally: `git diff --check` (clean), the review-enrichment TypeScript build (`npm --prefix
  review-enrichment run build`, clean), and the license-check analyzer test via `node --test` — **6/6 tests
  pass**, including the new regression that flags `GFDL`/`CC-BY-SA`/`QPL`/`Sleepycat` as `copyleft` and
  asserts permissive `CC-BY-4.0` stays unflagged. The change is confined to `review-enrichment/`, outside
  the `src/**` Codecov scope, so `test:coverage` does not apply.
- Not run locally: the UI, root typecheck, and the `metadata:check` step of `rees:test`. `metadata:check`
  compares the committed `analyzer-metadata.json` (generated on CI/Linux) against a local regeneration and
  reports a spurious byte difference on this Windows dev box (it fails identically on unmodified `main`);
  this change touches only the copyleft regex, not any analyzer descriptor, so the committed metadata is
  unchanged and `metadata:check` passes on CI (Linux). `analyzer-metadata.json` was NOT modified.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Detection-only widening: this only makes four already-copyleft SPDX families classify as `copyleft` instead
  of slipping through as permissive. Permissive licenses (MIT/Apache/BSD/ISC/`CC-BY`/`CC0`) are unchanged, and
  no analyzer descriptor changes, so `analyzer-metadata.json` is intentionally untouched.
- Regression test added in `review-enrichment/test/license-check.test.ts`: `GFDL-1.3-or-later`,
  `CC-BY-SA-4.0`, `QPL-1.0`, and `Sleepycat` now classify as `copyleft`, while `CC-BY-4.0` stays unflagged.
  The existing GPL/MIT/NOASSERTION assertions are unchanged.
