### PR TITLE
fix(enrichment): do not let no-newline markers skew collectAddedLines

### DIFF
--- a/review-enrichment/src/analysis-context.ts
+++ b/review-enrichment/src/analysis-context.ts
@@ -328,7 +328,9 @@ export function collectAddedLines(
         }
         addedLines.push({ file: file.path, line: newLine, text: line.slice(1) });
         newLine += 1;
-      } else if (!line.startsWith("-")) {
+      } else if (!line.startsWith("-") && !line.startsWith("\\")) {
+        // A `\ No newline at end of file` marker is not a new-file line — do not advance the cursor
+        // (same class as the iac-misconfig / redos / secret-scan fix).
         newLine += 1;
       }
     }

--- a/review-enrichment/test/analysis-context.test.ts
+++ b/review-enrichment/test/analysis-context.test.ts
@@ -42,6 +42,30 @@ test("collectAddedLines keeps added lines whose content starts with ++ (rendered
   );
 });
 
+test("collectAddedLines does not let a no-newline marker skew line numbers", () => {
+  // `\ No newline at end of file` is not a new-file line; advancing past it would cite every
+  // subsequent added line one too high (same class as the iac-misconfig / redos regression).
+  const files = [
+    {
+      path: "src/app.ts",
+      patch: [
+        "@@ -1,1 +1,2 @@",
+        "-const x = 1;",
+        "\\ No newline at end of file",
+        "+const x = 1;",
+        "+const y = 2;",
+      ].join("\n"),
+    },
+  ];
+  assert.deepEqual(
+    collectAddedLines(files).map((added) => [added.line, added.text]),
+    [
+      [1, "const x = 1;"],
+      [2, "const y = 2;"],
+    ],
+  );
+});
+
 test("createAnalysisContext parses common PR state once", () => {
   let now = 130;
   const syntheticGithubToken = ["ghp", "abcdefghijklmnopqrstuvwxyz1234567890"].join("_");


### PR DESCRIPTION
## Summary
A `\ No newline at end of file` marker is not a new-file line, but the shared `collectAddedLines` walker advanced the cursor past it and cited **every subsequent added line one too high** for every analyzer that uses the shared analysis context.

## Scope
Skip lines starting with `\` when advancing the new-file cursor — same class as the existing `iac-misconfig` / `redos` / `secret-scan` fix. This is the shared helper, so one fix covers all context consumers.

## Test plan
- [x] Regression: marker between a removed line and two added lines cites lines **1** and **2**, not 2 and 3.
- [x] `node --test test/analysis-context.test.ts` — 15 passed.

## No linked issue
Self-contained line-citation fix; no tracking issue. Touches only `analysis-context.ts` and its test.

Made with [Cursor](https://cursor.com)