### PR TITLE
fix(enrichment): treat .python-version as a Python runtime pin for EOL checks

### DIFF
--- a/review-enrichment/src/analyzers/eol-check.ts
+++ b/review-enrichment/src/analyzers/eol-check.ts
@@ -92,6 +92,10 @@ export function extractVersionPins(
         // `.node-version` (nodenv/asdf) carries the same leading-version pin as `.nvmrc`.
         const version = leadingVersion(line);
         if (version) pins.push({ file: file.path, product: "nodejs", version });
+      } else if (base === ".python-version") {
+        // pyenv/asdf pin file — same leading-version format, product is Python.
+        const version = leadingVersion(line);
+        if (version) pins.push({ file: file.path, product: "python", version });
       } else if (base === "go.mod") {
         const match = /^go\s+(\d+\.\d+)/.exec(line);
         if (match)

--- a/review-enrichment/src/scheduler.ts
+++ b/review-enrichment/src/scheduler.ts
@@ -404,11 +404,12 @@ function isRuntimePinPath(path: string): boolean {
   // Share the eol analyzer's own Dockerfile predicate so the gate can't skip a file the analyzer would
   // parse. The prior bespoke `/^Dockerfile(?:\..*)?$/` missed `*.dockerfile` (e.g. web.dockerfile), silently
   // dropping eol analysis for it even though isDockerfile() handles it.
-  // `.node-version` is the nodenv/asdf pin file; the eol analyzer parses it like `.nvmrc`.
+  // `.node-version` / `.python-version` are nodenv/pyenv (and asdf) pin files the eol analyzer parses.
   return (
     isDockerfile(path) ||
     basename === ".nvmrc" ||
     basename === ".node-version" ||
+    basename === ".python-version" ||
     basename === "go.mod"
   );
 }

--- a/review-enrichment/test/eol-check.test.ts
+++ b/review-enrichment/test/eol-check.test.ts
@@ -51,6 +51,13 @@ test("extractVersionPins reads .node-version pins like .nvmrc", () => {
   ]);
 });
 
+test("extractVersionPins reads .python-version pins as Python", () => {
+  // pyenv/asdf use `.python-version` with the same leading-version format.
+  assert.deepEqual(extractVersionPins([added(".python-version", "3.11.0")]), [
+    { file: ".python-version", product: "python", version: "3.11.0" },
+  ]);
+});
+
 test("extractVersionPins ignores removed/context lines and files with no patch", () => {
   const patch = ["@@ -1 +1,2 @@", "-FROM python:3.7", " FROM python:3.9"].join(
     "\n",


### PR DESCRIPTION
## Summary
The EOL analyzer and its scheduler runtime-pin gate recognized Node pin files (`.nvmrc`, `.node-version`) but not **pyenv/asdf's `.python-version`**. PRs that pin Python that way silently skipped EOL analysis.

## Scope
- `extractVersionPins` treats `.python-version` as product `python` (same leading-version format as `.nvmrc`).
- `isRuntimePinPath` in the scheduler admits `.python-version` so the gate cannot skip a file the analyzer would parse.

## Test plan
- [x] `extractVersionPins` on `.python-version` with `3.11.0` → `{ product: "python", version: "3.11.0" }`.
- [x] `node --test test/eol-check.test.ts` — 10 passed.
- [x] Analyzer metadata check clean.

## No linked issue
Self-contained detection-coverage fix; no tracking issue. Touches `eol-check.ts`, `scheduler.ts`, and the eol test.

Made with [Cursor](https://cursor.com)