### PR TITLE
fix(enrichment): treat .ruby-version as a Ruby runtime pin for EOL checks

### DIFF
--- a/review-enrichment/src/analyzers/eol-check.ts
+++ b/review-enrichment/src/analyzers/eol-check.ts
@@ -96,6 +96,10 @@ export function extractVersionPins(
         // pyenv/asdf pin file — same leading-version format, product is Python.
         const version = leadingVersion(line);
         if (version) pins.push({ file: file.path, product: "python", version });
+      } else if (base === ".ruby-version") {
+        // rbenv/asdf pin file — same leading-version format, product is Ruby.
+        const version = leadingVersion(line);
+        if (version) pins.push({ file: file.path, product: "ruby", version });
       } else if (base === "go.mod") {
         const match = /^go\s+(\d+\.\d+)/.exec(line);
         if (match)

--- a/review-enrichment/src/scheduler.ts
+++ b/review-enrichment/src/scheduler.ts
@@ -404,12 +404,13 @@ function isRuntimePinPath(path: string): boolean {
   // Share the eol analyzer's own Dockerfile predicate so the gate can't skip a file the analyzer would
   // parse. The prior bespoke `/^Dockerfile(?:\..*)?$/` missed `*.dockerfile` (e.g. web.dockerfile), silently
   // dropping eol analysis for it even though isDockerfile() handles it.
-  // `.node-version` / `.python-version` are nodenv/pyenv (and asdf) pin files the eol analyzer parses.
+  // `.node-version` / `.python-version` / `.ruby-version` are version-manager pin files the eol analyzer parses.
   return (
     isDockerfile(path) ||
     basename === ".nvmrc" ||
     basename === ".node-version" ||
     basename === ".python-version" ||
+    basename === ".ruby-version" ||
     basename === "go.mod"
   );
 }

--- a/review-enrichment/test/eol-check.test.ts
+++ b/review-enrichment/test/eol-check.test.ts
@@ -58,6 +58,13 @@ test("extractVersionPins reads .python-version pins as Python", () => {
   ]);
 });
 
+test("extractVersionPins reads .ruby-version pins as Ruby", () => {
+  // rbenv/asdf use `.ruby-version` with the same leading-version format.
+  assert.deepEqual(extractVersionPins([added(".ruby-version", "3.2.2")]), [
+    { file: ".ruby-version", product: "ruby", version: "3.2.2" },
+  ]);
+});
+
 test("extractVersionPins ignores removed/context lines and files with no patch", () => {
   const patch = ["@@ -1 +1,2 @@", "-FROM python:3.7", " FROM python:3.9"].join(
     "\n",


### PR DESCRIPTION
## Summary
The EOL analyzer and its scheduler runtime-pin gate recognized Node (`.nvmrc`, `.node-version`) and Python (`.python-version`) pin files but not **rbenv/asdf's `.ruby-version`**. PRs that pin Ruby that way silently skipped EOL analysis.

## Scope
- `extractVersionPins` treats `.ruby-version` as product `ruby` (same leading-version format as the other pin files).
- `isRuntimePinPath` in the scheduler admits `.ruby-version` so the gate cannot skip a file the analyzer would parse.

## Test plan
- [x] `extractVersionPins` on `.ruby-version` with `3.2.2` → `{ product: "ruby", version: "3.2.2" }`.
- [x] `node --test test/eol-check.test.ts` — 11 passed.
- [x] Analyzer metadata check clean.

## No linked issue
Self-contained detection-coverage fix; no tracking issue. Touches `eol-check.ts`, `scheduler.ts`, and the eol test.

Made with [Cursor](https://cursor.com)