### PR TITLE
fix(enrichment): detect GitHub fine-grained PATs in secret-scan

### DIFF
--- a/review-enrichment/src/analyzers/secret-scan.ts
+++ b/review-enrichment/src/analyzers/secret-scan.ts
@@ -21,6 +21,13 @@ const RULES: Rule[] = [
     confidence: "high",
   },
   {
+    // GitHub fine-grained personal access token (GitHub's recommended default): `github_pat_` + 82
+    // base62/underscore chars. The classic `gh[pousr]_` rule above never matches this prefix.
+    kind: "github_pat",
+    re: /\bgithub_pat_[0-9A-Za-z_]{82}\b/,
+    confidence: "high",
+  },
+  {
     kind: "slack_token",
     re: /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/,
     confidence: "high",

--- a/review-enrichment/test/secret-scan.test.ts
+++ b/review-enrichment/test/secret-scan.test.ts
@@ -21,6 +21,9 @@ const fakeHuggingfaceToken = "hf_" + "a".repeat(34);
 const fakeAnthropicKey = ["sk-ant-", "api03-", "a".repeat(20)].join("");
 const fakeGitlabToken = "glpat-" + "aBcDeFgHiJkLmNoPqRsT"; // 20 chars after the prefix
 const fakeNpmToken = "npm_" + "a".repeat(36);
+// GitHub fine-grained PAT: `github_pat_` + 82 base62/underscore chars (fragments only — never a contiguous
+// literal in source, so push protection doesn't flag this fixture).
+const fakeGithubPat = "github" + "_pat_" + "1".repeat(11) + "_" + "a".repeat(70);
 // A high-entropy value that matches NO format-specific rule, so it only trips the
 // generic keyword-assignment rule (built from fragments, never a contiguous literal).
 const fakeGenericValue = "aK9xQ2mZw7Ln" + "4Rv8Pt3Bh6Tc";
@@ -51,6 +54,14 @@ test("scanPatch flags an npm token with high confidence", () => {
   const findings = scanPatch("src/config.ts", hunk([`const registryAuth = "${fakeNpmToken}";`]));
   assert.equal(findings.length, 1);
   assert.equal(findings[0].kind, "npm_token");
+  assert.equal(findings[0].confidence, "high");
+});
+
+test("scanPatch flags a GitHub fine-grained PAT with high confidence", () => {
+  // `gh` var name avoids the generic keyword rule, so the fine-grained-PAT rule is the only match.
+  const findings = scanPatch("src/config.ts", hunk([`const gh = "${fakeGithubPat}";`]));
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "github_pat");
   assert.equal(findings[0].confidence, "high");
 });
 


### PR DESCRIPTION
## Summary

The secret scanner's `RULES` in `review-enrichment/src/analyzers/secret-scan.ts` detects the classic GitHub
token family but not GitHub **fine-grained personal access tokens** — which are now GitHub's recommended
default token type. The existing GitHub rule:

```ts
{ kind: "github_token", re: /\bgh[pousr]_[A-Za-z0-9]{36,}\b/, confidence: "high" },
```

only matches the `ghp_`/`gho_`/`ghu_`/`ghs_`/`ghr_` prefixes. A fine-grained PAT has the shape
`github_pat_` + 82 base62/underscore characters — the letters `g-i-t-h-u-b…` never contain a `gh[pousr]_`
pair, so that rule never matches it, and no other rule has a `github_pat_` prefix.

Concrete false negative (a leaked token in a PR diff, as `scanPatch` receives it):

```
+GITHUB_TOKEN=github_pat_11ABCDE3Y0…_LmNoPqRsTuVwXyZ…            (github_pat_ + 82 chars)
```

- **Actual:** no finding — the token passes the scanner unflagged. The generic keyword-assignment fallback
  only fires on a `keyword = "quoted value"` shape and would at best report a low-value generic "verify",
  never a GitHub credential; a bare `KEY=github_pat_…` env/CI line is missed entirely.
- **Correct:** flagged as a GitHub credential (high confidence).

Fix: add one rule for `github_pat_` + 82 `[0-9A-Za-z_]` chars — the standard fine-grained-PAT shape,
mirroring the existing fixed-length format rules (`npm_{36}`, `hf_{34}`, `glpat-{20}`). Zero false-positive
risk: the 11-char literal prefix followed by exactly 82 token chars is not a shape ordinary prose, base64
blobs, or hex hashes produce, and it cannot collide with the existing `github_token` rule.

No linked issue: small, self-evident detection-coverage fix (one additive rule) closing a false-negative
for the current GitHub-recommended credential format, alongside the token families already covered; no
schema/config/deploy change — fits the repo's `preferred` (not required) linked-issue policy.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run typecheck`
- [x] `npm run rees:test` — the review-enrichment build + analyzer suite (see note below)
- [ ] `npm run test:coverage` (N/A — this file is in `review-enrichment/`, outside the `src/**` Codecov scope)
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran locally: `git diff --check` (clean), the review-enrichment TypeScript build (`npm --prefix
  review-enrichment run build`, clean), and the secret-scan analyzer test via `node --test` — **21/21 tests
  pass**, including the new fine-grained-PAT case (asserts `kind: "github_pat"`, `confidence: "high"`, single
  finding). The change is confined to `review-enrichment/`, outside the `src/**` Codecov scope, so
  `test:coverage` does not apply. The fixture is assembled from fragments so it is never a contiguous secret
  literal in source.
- Not run locally: the UI, root typecheck, and the `metadata:check` step of `rees:test`. `metadata:check`
  compares the committed `analyzer-metadata.json` (generated on CI/Linux) against a local regeneration and
  reports a spurious byte difference on this Windows dev box (it fails identically on unmodified `main`);
  this change adds a scan rule, not any analyzer descriptor, so the committed metadata is unchanged and
  `metadata:check` passes on CI (Linux). `analyzer-metadata.json` was NOT modified.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Detection-only addition: this adds one high-confidence rule for a real credential format and changes no
  existing rule, so it cannot alter current findings; no analyzer descriptor changes, so
  `analyzer-metadata.json` is intentionally untouched. The regression fixture is built from string fragments
  (never a contiguous secret literal), matching the convention the test file already uses.
- Regression test added in `review-enrichment/test/secret-scan.test.ts`: a `github_pat_` + 82-char token is
  now flagged `kind: "github_pat"` at high confidence. All existing token-format assertions are unchanged.
