### PR TITLE
feat(enrichment): detect Slack enterprise and cookie tokens in secret-scan

### DIFF
--- a/review-enrichment/src/analyzers/secret-scan.ts
+++ b/review-enrichment/src/analyzers/secret-scan.ts
@@ -28,8 +28,9 @@ const RULES: Rule[] = [
     confidence: "high",
   },
   {
+    // Slack tokens: bot/user/app/refresh/session (`baprs`) plus enterprise (`e`) and cookie (`c`).
     kind: "slack_token",
-    re: /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/,
+    re: /\bxox[baprsec]-[A-Za-z0-9-]{10,}\b/,
     confidence: "high",
   },
   {

--- a/review-enrichment/test/secret-scan.test.ts
+++ b/review-enrichment/test/secret-scan.test.ts
@@ -213,3 +213,24 @@ test("scanPatch does not let a no-newline marker skew the line number", () => {
   assert.equal(findings[0].kind, "aws_access_key_id");
   assert.equal(findings[0].line, 2);
 });
+
+test("scanPatch flags Slack enterprise and cookie tokens", () => {
+  // `xoxe-` (enterprise) and `xoxc-` (cookie) were missing from `xox[baprs]`.
+  // Built from fragments so push protection never sees a contiguous secret-shaped literal.
+  const enterprise = ["xoxe", "1234567890", "ABCDEFabcdef"].join("-");
+  const cookie = ["xoxc", "1234567890", "ABCDEFabcdef"].join("-");
+  const entFindings = scanPatch("src/config.ts", hunk([`const slack = "${enterprise}";`]));
+  assert.equal(entFindings.length, 1);
+  assert.equal(entFindings[0].kind, "slack_token");
+  assert.equal(entFindings[0].confidence, "high");
+  const cookieFindings = scanPatch("src/config.ts", hunk([`const slack = "${cookie}";`]));
+  assert.equal(cookieFindings.length, 1);
+  assert.equal(cookieFindings[0].kind, "slack_token");
+});
+
+test("scanPatch still flags classic Slack bot tokens", () => {
+  const bot = ["xoxb", "1234567890", "ABCDEFabcdef"].join("-");
+  const findings = scanPatch("src/config.ts", hunk([`const slack = "${bot}";`]));
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "slack_token");
+});


### PR DESCRIPTION
## Summary
The `slack_token` rule matched `xoxb` / `xoxp` / `xoxa` / `xoxr` / `xoxs` but **missed `xoxe` (enterprise) and `xoxc` (cookie)** tokens, so those credentials went unflagged in PR diffs.

## Scope
Extends the type character class from `xox[baprs]` to `xox[baprsec]`. Classic bot tokens still match. No value is returned — only kind/confidence/file/line.

## Test plan
- [x] `xoxe-…` and `xoxc-…` positives (built from fragments).
- [x] Classic `xoxb-…` still flagged.
- [x] `node --test test/secret-scan.test.ts` — 23 passed.

## No linked issue
Self-contained detection-coverage improvement; no tracking issue. Touches only `secret-scan.ts` and additive tests.

Made with [Cursor](https://cursor.com)