### PR TITLE
feat(enrichment): detect DigitalOcean personal access tokens in secret-scan

### DIFF
--- a/review-enrichment/src/analyzers/secret-scan.ts
+++ b/review-enrichment/src/analyzers/secret-scan.ts
@@ -76,6 +76,12 @@ const RULES: Rule[] = [
     confidence: "high",
   },
   {
+    // DigitalOcean personal access token: `dop_v1_` + 64 hex chars (case-insensitive).
+    kind: "digitalocean_token",
+    re: /\bdop_v1_[a-f0-9]{64}\b/i,
+    confidence: "high",
+  },
+  {
     kind: "private_key",
     re: /-----BEGIN (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----/,
     confidence: "high",

--- a/review-enrichment/test/secret-scan.test.ts
+++ b/review-enrichment/test/secret-scan.test.ts
@@ -234,3 +234,27 @@ test("scanPatch still flags classic Slack bot tokens", () => {
   assert.equal(findings.length, 1);
   assert.equal(findings[0].kind, "slack_token");
 });
+
+test("scanPatch flags a DigitalOcean personal access token with high confidence", () => {
+  // `dop_v1_` + 64 hex chars. Built from fragments so push protection never sees a contiguous literal.
+  const token = ["dop_v1_", "a".repeat(64)].join("");
+  const findings = scanPatch("src/config.ts", hunk([`const doToken = "${token}";`]));
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "digitalocean_token");
+  assert.equal(findings[0].confidence, "high");
+});
+
+test("scanPatch flags an uppercase-hex DigitalOcean token", () => {
+  // Hex body is case-insensitive (same class as action SHA pins).
+  const token = ["dop_v1_", "A".repeat(64)].join("");
+  const findings = scanPatch("src/config.ts", hunk([`const doToken = "${token}";`]));
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "digitalocean_token");
+});
+
+test("scanPatch does not flag a truncated DigitalOcean token", () => {
+  // Body must be exactly 64 hex chars — shorter prefixes must not false-positive.
+  // Variable name avoids the generic `token`/`secret` assignment rule.
+  const short = ["dop_v1_", "a".repeat(32)].join("");
+  assert.equal(scanPatch("src/config.ts", hunk([`const doCred = "${short}";`])).length, 0);
+});


### PR DESCRIPTION
## Summary
The secret-scan analyzer recognizes many high-confidence credential prefixes but **missed DigitalOcean personal access tokens** (`dop_v1_` + 64 hex chars), so those credentials went unflagged in PR diffs.

## Scope
Adds one high-confidence rule:
```
/\bdop_v1_[a-f0-9]{64}\b/i
```
- Hex body is case-insensitive (same class as action SHA pins).
- Truncated bodies (e.g. 32 hex chars) do **not** match.
- No value is returned — only kind/confidence/file/line.

## Test plan
- [x] Lowercase and uppercase-hex positives (built from fragments).
- [x] Truncated body negative (variable name avoids the generic `token` assignment rule).
- [x] `node --test test/secret-scan.test.ts` — 26 passed.

## No linked issue
Self-contained detection-coverage improvement; no tracking issue. Touches only `secret-scan.ts` and additive tests.

Made with [Cursor](https://cursor.com)