### PR TITLE
fix(enrichment): treat .php-version as a PHP runtime pin for EOL checks

### DIFF
--- a/review-enrichment/src/analyzers/eol-check.ts
+++ b/review-enrichment/src/analyzers/eol-check.ts
@@ -100,6 +100,10 @@ export function extractVersionPins(
         // rbenv/asdf pin file — same leading-version format, product is Ruby.
         const version = leadingVersion(line);
         if (version) pins.push({ file: file.path, product: "ruby", version });
+      } else if (base === ".php-version") {
+        // phpenv/asdf pin file — same leading-version format, product is PHP.
+        const version = leadingVersion(line);
+        if (version) pins.push({ file: file.path, product: "php", version });
       } else if (base === "go.mod") {
         const match = /^go\s+(\d+\.\d+)/.exec(line);
         if (match)

--- a/review-enrichment/src/scheduler.ts
+++ b/review-enrichment/src/scheduler.ts
@@ -404,13 +404,14 @@ function isRuntimePinPath(path: string): boolean {
   // Share the eol analyzer's own Dockerfile predicate so the gate can't skip a file the analyzer would
   // parse. The prior bespoke `/^Dockerfile(?:\..*)?$/` missed `*.dockerfile` (e.g. web.dockerfile), silently
   // dropping eol analysis for it even though isDockerfile() handles it.
-  // `.node-version` / `.python-version` / `.ruby-version` are version-manager pin files the eol analyzer parses.
+  // Version-manager pin files (nodenv/pyenv/rbenv/phpenv and asdf) the eol analyzer parses.
   return (
     isDockerfile(path) ||
     basename === ".nvmrc" ||
     basename === ".node-version" ||
     basename === ".python-version" ||
     basename === ".ruby-version" ||
+    basename === ".php-version" ||
     basename === "go.mod"
   );
 }

--- a/review-enrichment/test/eol-check.test.ts
+++ b/review-enrichment/test/eol-check.test.ts
@@ -65,6 +65,13 @@ test("extractVersionPins reads .ruby-version pins as Ruby", () => {
   ]);
 });
 
+test("extractVersionPins reads .php-version pins as PHP", () => {
+  // phpenv/asdf use `.php-version` with the same leading-version format.
+  assert.deepEqual(extractVersionPins([added(".php-version", "8.2.0")]), [
+    { file: ".php-version", product: "php", version: "8.2.0" },
+  ]);
+});
+
 test("extractVersionPins ignores removed/context lines and files with no patch", () => {
   const patch = ["@@ -1 +1,2 @@", "-FROM python:3.7", " FROM python:3.9"].join(
     "\n",


### PR DESCRIPTION
## Summary
The EOL analyzer and its scheduler runtime-pin gate recognized Node/Python/Ruby pin files but not **phpenv/asdf's `.php-version`**. PRs that pin PHP that way silently skipped EOL analysis.

## Scope
- `extractVersionPins` treats `.php-version` as product `php` (same leading-version format as the other pin files).
- `isRuntimePinPath` in the scheduler admits `.php-version` so the gate cannot skip a file the analyzer would parse.

## Test plan
- [x] `extractVersionPins` on `.php-version` with `8.2.0` → `{ product: "php", version: "8.2.0" }`.
- [x] `node --test test/eol-check.test.ts` — 12 passed.
- [x] Analyzer metadata check clean.

## No linked issue
Self-contained detection-coverage fix; no tracking issue. Touches `eol-check.ts`, `scheduler.ts`, and the eol test.

Made with [Cursor](https://cursor.com)