### PR TITLE
feat(enrichment): detect Shopify Admin API and shared-secret tokens

### DIFF
--- a/review-enrichment/src/analyzers/secret-scan.ts
+++ b/review-enrichment/src/analyzers/secret-scan.ts
@@ -82,6 +82,12 @@ const RULES: Rule[] = [
     confidence: "high",
   },
   {
+    // Shopify Admin API access token (`shpat_`) or app shared secret (`shpss_`) + 32 hex chars.
+    kind: "shopify_token",
+    re: /\bshp(?:at|ss)_[a-f0-9]{32}\b/i,
+    confidence: "high",
+  },
+  {
     kind: "private_key",
     re: /-----BEGIN (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----/,
     confidence: "high",

--- a/review-enrichment/test/secret-scan.test.ts
+++ b/review-enrichment/test/secret-scan.test.ts
@@ -258,3 +258,22 @@ test("scanPatch does not flag a truncated DigitalOcean token", () => {
   const short = ["dop_v1_", "a".repeat(32)].join("");
   assert.equal(scanPatch("src/config.ts", hunk([`const doCred = "${short}";`])).length, 0);
 });
+
+test("scanPatch flags Shopify Admin API and shared-secret tokens", () => {
+  // `shpat_` (Admin API access) and `shpss_` (app shared secret) + 32 hex chars.
+  const admin = ["shpat_", "a".repeat(32)].join("");
+  const shared = ["shpss_", "b".repeat(32)].join("");
+  const adminFindings = scanPatch("src/config.ts", hunk([`const shopify = "${admin}";`]));
+  assert.equal(adminFindings.length, 1);
+  assert.equal(adminFindings[0].kind, "shopify_token");
+  assert.equal(adminFindings[0].confidence, "high");
+  const sharedFindings = scanPatch("src/config.ts", hunk([`const shopify = "${shared}";`]));
+  assert.equal(sharedFindings.length, 1);
+  assert.equal(sharedFindings[0].kind, "shopify_token");
+});
+
+test("scanPatch does not flag a truncated Shopify token", () => {
+  // Body must be exactly 32 hex chars.
+  const short = ["shpat_", "a".repeat(16)].join("");
+  assert.equal(scanPatch("src/config.ts", hunk([`const shop = "${short}";`])).length, 0);
+});


### PR DESCRIPTION
## Summary
The secret-scan analyzer recognizes many high-confidence credential prefixes but **missed Shopify tokens**: `shpat_` (Admin API access) and `shpss_` (app shared secret), each followed by 32 hex chars.

## Scope
Adds one high-confidence rule:
```
/\bshp(?:at|ss)_[a-f0-9]{32}\b/i
```
- Hex body is case-insensitive.
- Truncated bodies (e.g. 16 hex chars) do **not** match.
- No value is returned — only kind/confidence/file/line.

## Test plan
- [x] `shpat_` and `shpss_` positives (built from fragments).
- [x] Truncated body negative.
- [x] `node --test test/secret-scan.test.ts` — 28 passed.

## No linked issue
Self-contained detection-coverage improvement; no tracking issue. Touches only `secret-scan.ts` and additive tests.

Made with [Cursor](https://cursor.com)