### PR TITLE
fix(enrichment): treat .go-version as a Go runtime pin for EOL checks

### DIFF
--- a/review-enrichment/src/analyzers/eol-check.ts
+++ b/review-enrichment/src/analyzers/eol-check.ts
@@ -104,6 +104,10 @@ export function extractVersionPins(
         // phpenv/asdf pin file — same leading-version format, product is PHP.
         const version = leadingVersion(line);
         if (version) pins.push({ file: file.path, product: "php", version });
+      } else if (base === ".go-version") {
+        // goenv/asdf pin file — same leading-version format, product is Go.
+        const version = leadingVersion(line);
+        if (version) pins.push({ file: file.path, product: "go", version });
       } else if (base === "go.mod") {
         const match = /^go\s+(\d+\.\d+)/.exec(line);
         if (match)

--- a/review-enrichment/src/scheduler.ts
+++ b/review-enrichment/src/scheduler.ts
@@ -404,7 +404,7 @@ function isRuntimePinPath(path: string): boolean {
   // Share the eol analyzer's own Dockerfile predicate so the gate can't skip a file the analyzer would
   // parse. The prior bespoke `/^Dockerfile(?:\..*)?$/` missed `*.dockerfile` (e.g. web.dockerfile), silently
   // dropping eol analysis for it even though isDockerfile() handles it.
-  // Version-manager pin files (nodenv/pyenv/rbenv/phpenv and asdf) the eol analyzer parses.
+  // Version-manager pin files (nodenv/pyenv/rbenv/phpenv/goenv and asdf) the eol analyzer parses.
   return (
     isDockerfile(path) ||
     basename === ".nvmrc" ||
@@ -412,6 +412,7 @@ function isRuntimePinPath(path: string): boolean {
     basename === ".python-version" ||
     basename === ".ruby-version" ||
     basename === ".php-version" ||
+    basename === ".go-version" ||
     basename === "go.mod"
   );
 }

--- a/review-enrichment/test/eol-check.test.ts
+++ b/review-enrichment/test/eol-check.test.ts
@@ -72,6 +72,13 @@ test("extractVersionPins reads .php-version pins as PHP", () => {
   ]);
 });
 
+test("extractVersionPins reads .go-version pins as Go", () => {
+  // goenv/asdf use `.go-version` with the same leading-version format.
+  assert.deepEqual(extractVersionPins([added(".go-version", "1.22.0")]), [
+    { file: ".go-version", product: "go", version: "1.22.0" },
+  ]);
+});
+
 test("extractVersionPins ignores removed/context lines and files with no patch", () => {
   const patch = ["@@ -1 +1,2 @@", "-FROM python:3.7", " FROM python:3.9"].join(
     "\n",


### PR DESCRIPTION
## Summary
The EOL analyzer and its scheduler runtime-pin gate recognized `go.mod` and other version-manager pin files but not **goenv/asdf's `.go-version`**. PRs that pin Go that way silently skipped EOL analysis.

## Scope
- `extractVersionPins` treats `.go-version` as product `go` (same leading-version format as the other pin files).
- `isRuntimePinPath` in the scheduler admits `.go-version` so the gate cannot skip a file the analyzer would parse.

## Test plan
- [x] `extractVersionPins` on `.go-version` with `1.22.0` → `{ product: "go", version: "1.22.0" }`.
- [x] `node --test test/eol-check.test.ts` — 13 passed.
- [x] Analyzer metadata check clean.

## No linked issue
Self-contained detection-coverage fix; no tracking issue. Touches `eol-check.ts`, `scheduler.ts`, and the eol test.

Made with [Cursor](https://cursor.com)