### PR TITLE
fix(scoring): reject non-positive or non-finite label multipliers before they reach the score formula

### DIFF
--- a/src/registry/normalize.ts
+++ b/src/registry/normalize.ts
@@ -53,12 +53,15 @@ function extractRepoEntries(payload: unknown): Array<[string, RawRepoConfig]> {
 }
 
 function normalizeRepo(repo: string, config: RawRepoConfig): RegistryRepoConfig {
+  // Same finiteness bar as numberValue() below (typeof "number" alone lets NaN/Infinity through) -- a label
+  // multiplier reaches scoring.preview's selectLabelMultiplier as a raw map value, never through numberValue,
+  // so this is the only place a non-finite entry could otherwise slip past this repo's own boundary.
   const rawLabelMultipliers = config.label_multipliers;
   const labelMultipliers =
     rawLabelMultipliers && typeof rawLabelMultipliers === "object" && !Array.isArray(rawLabelMultipliers)
       ? Object.fromEntries(
           Object.entries(rawLabelMultipliers).flatMap(([key, value]) =>
-            typeof value === "number" ? [[key, value] as [string, number]] : [],
+            typeof value === "number" && Number.isFinite(value) ? [[key, value] as [string, number]] : [],
           ),
         )
       : {};

--- a/src/scoring/preview.ts
+++ b/src/scoring/preview.ts
@@ -908,13 +908,26 @@ function deltaExplanationFor(core: ScoreCore, blockedBy: ScoreGateBlocker[]): st
   return `Effective score ${core.scoreEstimate.estimatedMergedScore}; underlying potential ${core.scoreEstimate.pendingSaturationScore}; blocked or reduced by ${blockedBy.map((blocker) => blocker.code).join(", ")}.`;
 }
 
+// A label multiplier must be a positive, finite number (mirrors the validity rule signals/engine.ts's own
+// config-quality check already documents and enforces for its ADVISORY health score: "0, negative, NaN, or
+// Infinity are config errors that would silently misweight scoring"). That check only ever adjusted a
+// repo's informational config-quality score -- it never stopped an invalid value from reaching the REAL
+// scoring formula here, where `labelMultiplier` multiplies directly into `estimatedMergedScore`. A
+// registry-sourced label multiplier of 0 or a negative number is valid JSON and passed neither `numberValue`
+// (only applied to the scalar overrides, not this map) nor any check in this function, so it would zero out
+// or invert any PR/issue score for a matching label. Filtering here closes the gap where it actually matters.
+function isValidLabelMultiplier(value: number): boolean {
+  return typeof value === "number" && Number.isFinite(value) && value > 0;
+}
+
 function selectLabelMultiplier(labels: string[], multipliers: Record<string, number>, fallback: number): number {
   const normalized = labels.map((label) => label.toLowerCase());
   const matched = Object.entries(multipliers).flatMap(([pattern, multiplier]) => {
+    if (!isValidLabelMultiplier(multiplier)) return [];
     const matcher = labelPatternToRegExp(pattern.toLowerCase());
     return normalized.some((label) => matcher.test(label)) ? [multiplier] : [];
   });
-  return matched.length > 0 ? Math.max(...matched) : fallback || 1;
+  return matched.length > 0 ? Math.max(...matched) : isValidLabelMultiplier(fallback) ? fallback : 1;
 }
 
 /** True when `label` matches the configured multiplier `pattern` under the SAME case-insensitive fnmatch glob

--- a/test/unit/registry.test.ts
+++ b/test/unit/registry.test.ts
@@ -37,6 +37,20 @@ describe("registry normalization", () => {
     expect(snapshot.repositories[0]!.timeDecay ?? null).toBeNull();
   });
 
+  it("REGRESSION: drops non-finite label multiplier values (NaN/Infinity are typeof 'number' but not finite)", () => {
+    const snapshot = normalizeRegistryPayload(
+      {
+        "JSONbored/awesome-claude": {
+          label_multipliers: { bug: 1.2, broken: Number.NaN, unbounded: Number.POSITIVE_INFINITY },
+        },
+      },
+      { kind: "raw-github", url: "https://example.test/master_repositories.json" },
+      "2026-05-22T00:00:00.000Z",
+    );
+
+    expect(snapshot.repositories[0]!.labelMultipliers).toEqual({ bug: 1.2 });
+  });
+
   it("dedupes case-variant repo names so snapshot totals match the single row that persists", () => {
     const snapshot = normalizeRegistryPayload(
       {

--- a/test/unit/scoring.test.ts
+++ b/test/unit/scoring.test.ts
@@ -791,6 +791,50 @@ NOVELTY_BONUS_SCALAR = 3
     expect(preview.scoreEstimate.labelMultiplier).toBe(1);
   });
 
+  it("REGRESSION: ignores a non-positive or non-finite label multiplier instead of letting it corrupt the score", () => {
+    const baseInput: ScorePreviewInput = {
+      repoFullName: repo.fullName,
+      sourceTokenScore: 60,
+      totalTokenScore: 90,
+      sourceLines: 50,
+      openPrCount: 0,
+      credibility: 1,
+      linkedIssueMode: "none",
+    };
+    // A registry-sourced label multiplier of 0 or negative is valid JSON and previously reached
+    // Math.max(...) unfiltered, zeroing out or inverting the whole estimatedMergedScore for a matching label.
+    const zeroMultiplier = buildScorePreview({
+      repo: { ...repo, registryConfig: { ...repo.registryConfig!, labelMultipliers: { bug: 0 } } },
+      snapshot,
+      input: { ...baseInput, labels: ["bug"] },
+    });
+    const negativeMultiplier = buildScorePreview({
+      repo: { ...repo, registryConfig: { ...repo.registryConfig!, labelMultipliers: { bug: -2 } } },
+      snapshot,
+      input: { ...baseInput, labels: ["bug"] },
+    });
+    // An invalid entry alongside a valid one: the valid one still wins, the invalid one is simply excluded
+    // from the candidate set (not treated as 0 or as a Math.max(...) contender).
+    const mixedValidity = buildScorePreview({
+      repo: { ...repo, registryConfig: { ...repo.registryConfig!, labelMultipliers: { bug: -2, refactor: 1.4 } } },
+      snapshot,
+      input: { ...baseInput, labels: ["bug", "refactor"] },
+    });
+    // A negative fallback (defaultLabelMultiplier) is truthy in JS, so the old `fallback || 1` never caught it.
+    const negativeFallback = buildScorePreview({
+      repo: { ...repo, registryConfig: { ...repo.registryConfig!, defaultLabelMultiplier: -3, labelMultipliers: {} } },
+      snapshot,
+      input: { ...baseInput, labels: ["unmatched"] },
+    });
+
+    expect(zeroMultiplier.scoreEstimate.labelMultiplier).toBe(1);
+    expect(negativeMultiplier.scoreEstimate.labelMultiplier).toBe(1);
+    expect(mixedValidity.scoreEstimate.labelMultiplier).toBe(1.4);
+    expect(negativeFallback.scoreEstimate.labelMultiplier).toBe(1);
+    expect(zeroMultiplier.scoreEstimate.estimatedMergedScore).toBeGreaterThan(0);
+    expect(negativeMultiplier.scoreEstimate.estimatedMergedScore).toBeGreaterThan(0);
+  });
+
   it("applies penalty label multipliers instead of flooring them to 1 (#994)", () => {
     const baseInput: ScorePreviewInput = {
       repoFullName: repo.fullName,


### PR DESCRIPTION
## Summary

`labelMultiplier` multiplies directly into `estimatedMergedScore` (`src/scoring/preview.ts`):

```ts
const estimatedMergedScore = roundScore(
  baseScore * labelMultiplier * issueMultiplier * credibilityMultiplier * ...
);
```

`selectLabelMultiplier` resolved it with zero validation:

```ts
function selectLabelMultiplier(labels: string[], multipliers: Record<string, number>, fallback: number): number {
  const normalized = labels.map((label) => label.toLowerCase());
  const matched = Object.entries(multipliers).flatMap(([pattern, multiplier]) => {
    const matcher = labelPatternToRegExp(pattern.toLowerCase());
    return normalized.some((label) => matcher.test(label)) ? [multiplier] : [];
  });
  return matched.length > 0 ? Math.max(...matched) : fallback || 1;
}
```

`src/signals/engine.ts` already documents and enforces the exact validity rule this needs — for its own **advisory** config-quality health score, not the real scoring path:

> A label multiplier must be a positive, finite number — a penalty multiplier is below 1 but still positive, so it is valid; 0, negative, NaN, or Infinity are config errors that would silently misweight scoring.

That check only ever nudges a repo's informational quality score. It never stopped an invalid value from reaching `selectLabelMultiplier`, where it matters:

- A registry-sourced `label_multipliers` entry of `0` or a negative number is valid JSON, was never filtered anywhere in the real scoring path, and — if it's the `Math.max(...)` winner for a PR/issue's labels — zeroes out or inverts that PR's entire `estimatedMergedScore`.
- The `fallback || 1` guard on `defaultLabelMultiplier` only catches falsy values (`0`, `NaN`). A **negative** `defaultLabelMultiplier` is truthy in JS, so `-3 || 1` evaluates to `-3` — it slips straight through.
- Separately, `src/registry/normalize.ts`'s `label_multipliers` parsing only checked `typeof value === "number"`, unlike every other scalar override in the same file (`numberValue()`, used for `emission_share`, `fixed_base_score`, etc.), which also requires `Number.isFinite`. `NaN`/`Infinity` are `typeof "number"` too, so they passed this parser unfiltered even though they're rejected everywhere else in the same function.

## Fix

- `selectLabelMultiplier` now filters candidate multipliers (and the fallback) to positive, finite numbers before taking `Math.max(...)`, falling back to `1` when nothing valid remains — enforcing exactly the rule `engine.ts` already documents, in the place it actually needs to hold.
- `normalize.ts`'s `label_multipliers` parsing now requires `Number.isFinite` too, matching `numberValue()`'s bar for every other registry-sourced number in the same file.

## Why no linked issue

Self-contained fix mirroring a validity rule already documented and enforced elsewhere in the same codebase (`signals/engine.ts`'s `invalid_label_multipliers` check) — not a new invariant. This repo's `linkedIssuePolicy` is `preferred`, not required, for a change this scoped.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Backend-only change, no API/OpenAPI/UI surface touched, so `ui:openapi:check`, `ui:lint`, `ui:typecheck`, and `ui:build` are not applicable.
- `npm run test:coverage` was run scoped to `test/unit/scoring.test.ts` + `test/unit/registry.test.ts` (100 tests) with `--coverage.include` on both changed files: `src/registry/normalize.ts` is 100% (statements/branches/functions/lines); `src/scoring/preview.ts`'s changed lines are fully covered (the file's small pre-existing gaps at lines 1154-1156/1188-1204 are untouched by this diff). Also ran `test/unit/label-audit.test.ts`, `test/unit/upstream-ruleset.test.ts`, `test/unit/signals.test.ts`, `test/unit/decision-pack.test.ts`, and `test/unit/reward-risk-reports.test.ts` (161 tests) clean, since those exercise related label/registry/scoring paths. The full unsharded suite could not be run clean in my local Windows dev environment for unrelated reasons: several test files depend on tooling not present there (Docker daemon, Python, `sentry-cli`), and generated-file "stale" checks (openapi.json, cf-typegen, selfhost-env-reference) false-positive on this checkout's CRLF line endings vs. the repo's LF convention — confirmed unrelated to this diff on a clean, unmodified `main`.
- `npm run test:mcp-pack` hits a Windows-only `spawnSync("npm", ...)` resolution failure locally (no `shell: true`, `npm` resolves to `npm.cmd` on Windows) — unrelated to this diff, expected to run on the Linux CI runner.
- `npm run actionlint`, `npm run typecheck`, `npm run test:workers`, `npm run build:mcp`, and `npm audit` all ran clean.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no such changes.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no request/response schema changes.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section below. — N/A, no UI changes.
- [ ] Public docs/changelogs are updated where needed. — N/A, no docs/changelog changes.

## UI Evidence

N/A — no UI/frontend/docs changes.

## Notes

- New tests: `test/unit/scoring.test.ts` ("REGRESSION: ignores a non-positive or non-finite label multiplier...") and `test/unit/registry.test.ts` ("REGRESSION: drops non-finite label multiplier values...").
- Existing tests (zeroed fallback → neutral 1, penalty multipliers below 1, fnmatch pattern matching) all still pass unchanged — this only narrows what counts as a valid candidate, it doesn't change any currently-valid config's behavior.
