### PR TITLE
fix(api): gate HTTP issue-quality on MCP_READ_REPO_ALLOWLIST

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -2129,6 +2129,7 @@ export function createApp() {
       const forbidden = await requireSessionRepoAccess(c, identity, fullName, repo);
       if (forbidden) return forbidden;
     }
+    if (identity.kind === "static" && identity.actor === "mcp" && !(await import("../auth/security")).isMcpReadRepoAllowed(c.env.MCP_READ_REPO_ALLOWLIST, fullName)) return c.json({ error: "forbidden_repo" }, 403);
     const response = await buildIssueQualityResponse(c.env, fullName);
     if (!response) return c.json({ error: "issue_quality_not_found", repoFullName: fullName }, 404);
     return c.json(response);

--- a/test/integration/routes-errors.test.ts
+++ b/test/integration/routes-errors.test.ts
@@ -317,6 +317,30 @@ describe("api route guards and error branches", () => {
     await expect(wildcardDecisionPack.json()).resolves.toMatchObject({ login: "victim", summary: "private advisory summary" });
   });
 
+  it("blocks the shared MCP token from reading issue-quality outside MCP_READ_REPO_ALLOWLIST (#2455 HTTP parity)", async () => {
+    const app = createApp();
+    const scopedEnv = createTestEnv({ MCP_READ_REPO_ALLOWLIST: "owner/private-repo" });
+    await upsertRepositoryFromGitHub(scopedEnv, { name: "private-repo", full_name: "owner/private-repo", private: true, owner: { login: "owner" } });
+    await upsertRepositoryFromGitHub(scopedEnv, { name: "other-repo", full_name: "other/other-repo", private: false, owner: { login: "other" } });
+    const mcpHeaders = { authorization: `Bearer ${scopedEnv.GITTENSORY_MCP_TOKEN}` };
+
+    const forbidden = await app.request("/v1/repos/other/other-repo/issue-quality", { headers: mcpHeaders }, scopedEnv);
+    expect(forbidden.status).toBe(403);
+    await expect(forbidden.json()).resolves.toMatchObject({ error: "forbidden_repo" });
+
+    const allowlisted = await app.request("/v1/repos/owner/private-repo/issue-quality", { headers: mcpHeaders }, scopedEnv);
+    expect(allowlisted.status).not.toBe(403);
+
+    const operator = await app.request("/v1/repos/other/other-repo/issue-quality", { headers: apiHeaders(scopedEnv) }, scopedEnv);
+    expect(operator.status).not.toBe(403);
+
+    const denyEnv = createTestEnv({ MCP_READ_REPO_ALLOWLIST: "" });
+    await upsertRepositoryFromGitHub(denyEnv, { name: "demo", full_name: "octo/demo", private: false, owner: { login: "octo" } });
+    const denied = await app.request("/v1/repos/octo/demo/issue-quality", { headers: { authorization: `Bearer ${denyEnv.GITTENSORY_MCP_TOKEN}` } }, denyEnv);
+    expect(denied.status).toBe(403);
+    await expect(denied.json()).resolves.toMatchObject({ error: "forbidden_repo" });
+  });
+
   it("keeps OAuth setup, CORS, and rate limits explicit", async () => {
     const app = createApp();
     const env = createTestEnv();


### PR DESCRIPTION
## Summary

`GET /v1/repos/:owner/:repo/issue-quality` enforced `requireSessionRepoAccess` for browser sessions but let the static `mcp` identity (`GITTENSORY_MCP_TOKEN`) through without checking `MCP_READ_REPO_ALLOWLIST`. The MCP tool `gittensory_get_issue_quality` uses `canAccessRepo`, which scopes the shared token to the operator-configured allowlist (#2455). Any holder of the MCP token could therefore read issue-quality reports for arbitrary installed repos over HTTP while the MCP surface denied the same call.

This PR adds an inline MCP allowlist guard in the issue-quality handler (dynamic import of `isMcpReadRepoAllowed`, matching the contributor-route pattern). Operator-only `api` / `internal` tokens remain trusted; session callers are unchanged.

## Changed files

| File | Change |
| ---- | ------ |
| `src/api/routes.ts` | Deny `mcp` identity when `!isMcpReadRepoAllowed(MCP_READ_REPO_ALLOWLIST, repo)` before loading issue-quality data. |
| `test/integration/routes-errors.test.ts` | Regression: scoped MCP token 403 on non-allowlisted repo; allowlisted + operator paths unchanged. |

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

No linked issue — #2455 HTTP/MCP parity gap on a repo-scoped read route; behavior is fully described here and covered by regression tests.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally on changed tests; **`codecov/patch` 100% (6/6)** on measured `src/api/routes.ts` diff
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries
