### PR TITLE
feat(enrichment): treat Zstandard (.zst) archives as binary assets

### DIFF
--- a/review-enrichment/src/analyzers/asset-weight.ts
+++ b/review-enrichment/src/analyzers/asset-weight.ts
@@ -55,6 +55,7 @@ const BINARY_EXTS = new Set([
   "7z",
   "rar",
   "xz",
+  "zst",
   "pdf",
   "psd",
   "ai",

--- a/review-enrichment/test/asset-weight.test.ts
+++ b/review-enrichment/test/asset-weight.test.ts
@@ -23,6 +23,11 @@ test("isBinaryAsset flags genuine binary extensions and ignores text/case", () =
   assert.equal(isBinaryAsset("photos/IMG_0001.heic"), true);
   assert.equal(isBinaryAsset("photos/scan.heif"), true);
   assert.equal(isBinaryAsset("photos/IMG_0001.HEIC"), true);
+  // Zstandard blobs are binary compressed assets (siblings of gz/bz2/xz) — only the last extension is matched,
+  // so a compound `.tar.zst` resolves to `zst`, and the match is case-insensitive.
+  assert.equal(isBinaryAsset("cache/model.zst"), true);
+  assert.equal(isBinaryAsset("dist/bundle.tar.zst"), true);
+  assert.equal(isBinaryAsset("cache/model.ZST"), true);
   // Extension match is case-insensitive.
   assert.equal(isBinaryAsset("assets/HERO.PNG"), true);
   // Text formats whose bytes are already in the diff are NOT binary assets.


### PR DESCRIPTION
## Summary

The `asset-weight` analyzer flags heavy binary blobs whose byte sizes never appear in the textual diff (they show as "Binary files differ"). Its extension set already covers the common archive/compression formats `gz` / `tgz` / `bz2` / `xz` / `7z` / `rar`, but **missed Zstandard (`.zst`)** — now a routinely-committed artifact (npm/cargo caches, CI caches, compressed model shards). A PR that added or grew a large `.zst` blob therefore slipped past the size-bloat signal.

This adds `"zst"` to `BINARY_EXTS`:

- Only the **final** extension is matched, so a compound name like `foo.tar.zst` correctly resolves to `zst`.
- The lookup stays **case-insensitive** (existing `toLowerCase()` path), so `.ZST` is covered.
- Text formats (`svg`/`json`/…) remain excluded — their bytes are already in the diff.
- Additive-only: one entry in the set plus test cases; no existing behavior changes.

**Consistency anchor:** `src/review/rag.ts`'s `BINARY_EXT_RE` already classifies `.zst` as binary, so the repo already treats `.zst` as a binary asset — this brings the size analyzer in line with that existing decision.

## No linked issue

This is a **no-issue PR** by design: a self-contained detection-coverage improvement that adds one archive extension (`.zst`) to the `asset-weight` analyzer's `BINARY_EXTS` set plus its unit test, touching only `review-enrichment/`. There is no behavior change beyond recognizing the new extension, so no tracking issue is needed. It mirrors the accepted no-issue precedent for the very same file — `webp`/`avif`/`heic`/`heif` (e.g. #3089).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] No linked issue — a self-contained detection-coverage improvement touching only `asset-weight.ts` and its unit test, mirroring the accepted precedent for `webp`/`avif`/`heic`/`heif`. The summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — no `src/**` lines changed (this change is under `review-enrichment/`, which Codecov does not measure), so `codecov/patch` has no diff to gate; suite is green.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New behavior has tests — the `.zst` positive, compound `.tar.zst`, and uppercase `.ZST` cases are added to the `isBinaryAsset` unit test; `npm run rees:test` passes (all review-enrichment tests green, analyzer-metadata check clean).

All of the above run as part of `npm run test:ci` (green).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] No auth, cookie, CORS, GitHub App, Cloudflare, or session changes (N/A — pure extension-set addition).
- [x] No API/OpenAPI/MCP behavior change (N/A).
- [x] No UI changes (N/A — this is a review-enrichment analyzer).
- [x] No visible UI change, so no UI Evidence section is required.
- [x] No docs/changelog changes needed.

## Notes

Analogues followed end-to-end: the merged `feat(enrichment): treat HEIC/HEIF images as binary assets` (#3089) and the original asset-weight analyzer (#1621) — same file, same additive shape, same test pattern.
