### PR TITLE
fix(enrichment): read go.mod toolchain directives for EOL checks

### DIFF
--- a/review-enrichment/src/analyzers/eol-check.ts
+++ b/review-enrichment/src/analyzers/eol-check.ts
@@ -109,9 +109,14 @@ export function extractVersionPins(
         const version = leadingVersion(line);
         if (version) pins.push({ file: file.path, product: "go", version });
       } else if (base === "go.mod") {
+        // Module language version (`go 1.21`) and optional toolchain pin (`toolchain go1.22.0`).
         const match = /^go\s+(\d+\.\d+)/.exec(line);
         if (match)
           pins.push({ file: file.path, product: "go", version: match[1]! });
+        // `toolchain go1.22.0` — no space after `go`; capture full leading version (may include patch).
+        const toolchain = /^toolchain\s+go(\d+(?:\.\d+)*)/.exec(line);
+        if (toolchain)
+          pins.push({ file: file.path, product: "go", version: toolchain[1]! });
       }
     }
   }

--- a/review-enrichment/test/eol-check.test.ts
+++ b/review-enrichment/test/eol-check.test.ts
@@ -44,6 +44,17 @@ test("extractVersionPins reads .nvmrc and go.mod pins", () => {
   ]);
 });
 
+test("extractVersionPins reads go.mod toolchain directives", () => {
+  // Go 1.21+ `toolchain go1.22.0` pins the toolchain independently of the `go` language line.
+  assert.deepEqual(
+    extractVersionPins([added("go.mod", "go 1.21", "toolchain go1.22.0")]),
+    [
+      { file: "go.mod", product: "go", version: "1.21" },
+      { file: "go.mod", product: "go", version: "1.22.0" },
+    ],
+  );
+});
+
 test("extractVersionPins reads .node-version pins like .nvmrc", () => {
   // nodenv/asdf use `.node-version` with the same leading-version format as `.nvmrc`.
   assert.deepEqual(extractVersionPins([added(".node-version", "20.11.0")]), [


### PR DESCRIPTION
## Summary
The EOL analyzer only parsed the `go 1.x` language line in `go.mod`. Go 1.21+ also supports an optional **`toolchain go1.22.0`** directive that pins the toolchain independently — those pins silently skipped EOL analysis.

## Scope
In `extractVersionPins` for `go.mod`, also match `^toolchain\s+go(\d+(?:\.\d+)*)` and emit a `go` product pin. The existing `go 1.x` language-line match is unchanged; both may appear in one file.

## Test plan
- [x] `go 1.21` + `toolchain go1.22.0` → pins for `1.21` and `1.22.0`.
- [x] `node --test test/eol-check.test.ts` — 14 passed.

## No linked issue
Self-contained detection-coverage fix; no tracking issue. Touches only `eol-check.ts` and its test.

Made with [Cursor](https://cursor.com)