### PR TITLE
feat(enrichment): detect Stripe test-mode secret keys in secret-scan

### DIFF
--- a/review-enrichment/src/analyzers/secret-scan.ts
+++ b/review-enrichment/src/analyzers/secret-scan.ts
@@ -51,9 +51,10 @@ const RULES: Rule[] = [
     confidence: "high",
   },
   {
-    // Stripe live secret / restricted key: `sk_live_` / `rk_live_` + >=24 base62.
+    // Stripe secret / restricted key: `sk_`/`rk_` + `live` or `test` + >=24 base62.
+    // Test-mode keys (`sk_test_` / `rk_test_`) are still credentials and must not be committed.
     kind: "stripe_secret_key",
-    re: /\b(?:sk|rk)_live_[0-9A-Za-z]{24,}\b/,
+    re: /\b(?:sk|rk)_(?:live|test)_[0-9A-Za-z]{24,}\b/,
     confidence: "high",
   },
   {

--- a/review-enrichment/test/secret-scan.test.ts
+++ b/review-enrichment/test/secret-scan.test.ts
@@ -320,3 +320,22 @@ test("scanPatch does not flag near-miss tokens with the wrong length as the new 
     assert.equal(findings.length, 0, `near-miss should not match: ${nm}`);
   }
 });
+
+test("scanPatch flags Stripe test-mode secret and restricted keys", () => {
+  // `sk_test_` / `rk_test_` are still credentials — the prior rule only matched `*_live_*`.
+  const skTest = ["sk_test_", "abcdefghijklmnop1234567890"].join("");
+  const rkTest = ["rk_test_", "abcdefghijklmnop1234567890"].join("");
+  const skFindings = scanPatch("src/config.ts", hunk([`const key = "${skTest}";`]));
+  assert.equal(skFindings.length, 1);
+  assert.equal(skFindings[0].kind, "stripe_secret_key");
+  assert.equal(skFindings[0].confidence, "high");
+  const rkFindings = scanPatch("src/config.ts", hunk([`const key = "${rkTest}";`]));
+  assert.equal(rkFindings.length, 1);
+  assert.equal(rkFindings[0].kind, "stripe_secret_key");
+});
+
+test("scanPatch still flags Stripe live-mode keys", () => {
+  const findings = scanPatch("src/config.ts", hunk([`const key = "${fakeStripeKey}";`]));
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "stripe_secret_key");
+});


### PR DESCRIPTION
## Summary
The `stripe_secret_key` rule only matched **live-mode** keys (`sk_live_` / `rk_live_`). Stripe **test-mode** keys (`sk_test_` / `rk_test_`) are still credentials that must not be committed, but went unflagged.

## Scope
Extends the mode alternation from `_live_` to `_(?:live|test)_`. Live-mode keys still match. No value is returned — only kind/confidence/file/line.

## Test plan
- [x] `sk_test_` and `rk_test_` positives.
- [x] Existing `sk_live_` still flagged.
- [x] `node --test test/secret-scan.test.ts` — 32 passed.

## No linked issue
Self-contained detection-coverage improvement; no tracking issue. Touches only `secret-scan.ts` and additive tests.

Made with [Cursor](https://cursor.com)