### PR TITLE
docs(miner): document the full CLI, local boundary, and engine version-pin

### DIFF
--- a/packages/gittensory-engine/README.md
+++ b/packages/gittensory-engine/README.md
@@ -11,6 +11,18 @@ The logic is extracted from the app's `src/` in follow-up issues; this skeleton 
 the meantime. The root `package.json` already globs `packages/*` in its `workspaces` field, so `npm ci`
 discovers this package with no additional wiring.
 
+## Audience & versioning
+
+This is an **internal dependency**, not a package end users install directly. It is consumed by two callers only —
+the hosted Gittensory review-stack backend and the local [`@jsonbored/gittensory-miner`](../gittensory-miner) — so
+that a single, shared, deterministic implementation runs identically in both. Contributors interact with it only
+transitively (through the review backend or the miner CLI).
+
+Because both callers depend on the exact same logic, the engine is **version-pinned**: `gittensory-miner` pins an
+exact `@jsonbored/gittensory-engine` version in its `dependencies` (not a range), and that pinned version is what
+the miner is built and validated against. The package is versioned independently of the app and follows semver, so
+a caller upgrades deliberately rather than drifting onto new engine behavior implicitly.
+
 ## Build
 
 ```

--- a/packages/gittensory-miner/README.md
+++ b/packages/gittensory-miner/README.md
@@ -2,50 +2,105 @@
 
 Foundation CLI for the local Gittensory miner runtime.
 
-This package is the future home of the autonomous discover → analyze → plan → prepare → create → manage miner workflow. In this foundation phase it provides the package scaffold, a minimal CLI surface for `--help` and `--version`, and a non-blocking npm registry version nudge on startup.
+This package is the future home of the autonomous discover → analyze → plan → prepare → create → manage miner
+workflow. It is currently in its **foundation phase**: the local state stores, the read-only `status`/`doctor`
+commands, the deny-hook safety primitive, and the metadata-only discovery/ranking primitives exist, but there is
+no live coding-agent loop yet — nothing scans source, invokes a coding agent, or writes to GitHub.
+
+## 100% local
+
+Everything this package does is client-side and offline by default:
+
+- The run-state, portfolio/queue, claim ledger, event ledger, plan store, and governor ledger are **local SQLite
+  files** created owner-only (`0o600`) under your config directory — they never upload, sync, or phone home.
+- `status` and `doctor` make **no network calls at all**.
+- The metadata-only discovery primitives make GitHub **GET** requests only — they never clone source, never upload
+  source, and never write to GitHub, and they hard-skip repos whose `AI-USAGE.md`/`CONTRIBUTING.md` ban AI PRs.
+- The miner **never holds shared credentials**: any future write action runs through your own harness with your
+  own GitHub credentials.
 
 ## Status
 
-Current scope is intentionally small:
+Implemented so far (foundation phase):
 
-- workspace package wiring
-- CLI entry point
-- `--help` and `version` commands
-- startup npm version nudge (override with `--no-update-check` or `GITTENSORY_MINER_NO_UPDATE_CHECK=1`)
+- **Commands:** `status`, `doctor`, `manage status`/`manage poll`, `queue list`/`next`/`done`, `ledger list`,
+  `plan list`/`show`, `governor list`, `hooks check`, `state get`/`state set`, plus `--help`/`--version` and a
+  non-blocking startup npm version nudge (override with `--no-update-check` or `GITTENSORY_MINER_NO_UPDATE_CHECK=1`).
+- **Local state stores (SQLite):** run-state, portfolio/queue, claim ledger, append-only event ledger, plan store,
+  and an append-only governor decision ledger — each a separate owner-only file with a resolved config path,
+  surfaced read-only through the `queue`/`ledger`/`plan`/`governor`/`manage` commands.
+- **Deny-hook primitive:** `evaluateDenyHooks` + a built-in house-rule set, surfaced via `hooks check`.
+- **Metadata-only discovery:** `fetchCandidateIssues`/`searchCandidateIssues` list open issue metadata across
+  target repos (GitHub GETs only), hard-skipping AI-banning repos.
+- **Metadata-only ranker:** `rankCandidateIssues` composes deterministic engine signals (potential, feasibility,
+  lane fit, freshness, dup risk) and returns fan-out candidates sorted by `rankScore`.
 
-Real miner commands land in follow-up issues.
-
-The package also includes the first metadata-only discovery primitive: `fetchCandidateIssues` lists open issue
-metadata across target repos, and `searchCandidateIssues` does the same from a GitHub issue-search query. Both
-paths hard-skip repos whose `AI-USAGE.md` or `CONTRIBUTING.md` explicitly bans AI-generated PRs. They perform
-GitHub GET requests only, never clone source, never upload source, and never write to GitHub.
-
-The package also includes a metadata-only ranker: `rankCandidateIssues` composes deterministic engine signals
-(potential, feasibility, lane fit, freshness, dup risk) and returns fan-out candidates sorted by `rankScore`.
-It never clones source and never writes to GitHub.
-
-The package also includes an append-only governor decision ledger: `initGovernorLedger` / `appendGovernorEvent`
-persist structured allow/deny/throttle/kill-switch outcomes in local SQLite for contributor audit. Insert-only —
-no enforcement wiring yet. (#2328)
+The live discover → analyze → plan → prepare → create → manage loop lands in follow-up issues.
 
 ## Install
 
-From a local checkout:
+Public npm (once published):
+
+```sh
+npm install -g @jsonbored/gittensory-miner
+```
+
+From a local checkout of this repo:
 
 ```sh
 npm install
-npm --workspace @jsonbored/gittensory-miner run build
+npm link --workspace @jsonbored/gittensory-miner
 ```
 
 ## Commands
 
 ```sh
-gittensory-miner --help
-gittensory-miner help
-gittensory-miner --version
-gittensory-miner version
+gittensory-miner status [--json]           # installed miner + engine version, Node, local-state dir, config file
+gittensory-miner doctor [--json]           # check Node version, engine resolves, state dir writable (non-zero on failure)
+
+gittensory-miner manage status [--json]                              # show managed PR rows from local portfolio + ledger
+gittensory-miner manage poll <owner/repo> <pr#> [--branch <name>] [--json]
+
+gittensory-miner queue list [--repo <owner/repo>] [--json]           # list portfolio backlog rows
+gittensory-miner queue next [--json]                                 # claim the highest-priority queued item
+gittensory-miner queue done <owner/repo> <identifier> [--json]       # mark a backlog item done
+
+gittensory-miner ledger list [--repo <owner/repo>] [--since <seq>] [--type <eventType>] [--json]   # read the event ledger
+gittensory-miner plan list [--status pending|running|completed|failed] [--json]                    # list stored plans
+gittensory-miner plan show <planId> [--json]                                                       # show one plan
+gittensory-miner governor list [--repo <owner/repo>] [--type allowed|denied|throttled|kill_switch] [--json]
+
+gittensory-miner hooks check --tool <name> --input <json> [--json]   # evaluate a tool call against the deny-hook house rules
+gittensory-miner state get <owner/repo> [--json]                     # read the local per-repo run-state
+gittensory-miner state set <owner/repo> <idle|discovering|planning|preparing> [--json]   # set it
+
+gittensory-miner --help        # or: help
+gittensory-miner --version     # or: version
 ```
+
+No command writes to GitHub or uploads source; the `set`/`done`/`next` variants mutate only local state. `status`
+and `doctor` are dispatched before the update check runs, so they stay fully offline.
+
+## Configuration — `.gittensory-miner.yml`
+
+A repo owner drops a `.gittensory-miner.yml` into their repo to tell an autonomous miner what to look for and how to
+behave when targeting it — the miner-side analogue of `.gittensory.yml` (the review-side focus manifest). Every
+field is optional with a safe default, and the file is parsed tolerantly (an unknown or malformed key falls back to
+its default with a warning; a broken file never hard-fails the miner). It is **opt-out**: a public repo with no file
+is still minable; set the enable flag to `false` to halt all miner targeting.
+
+Discovery order (first match wins):
+
+```
+.gittensory-miner.yml → .github/gittensory-miner.yml → .gittensory-miner.json → .github/gittensory-miner.json
+```
+
+See [`.gittensory-miner.yml.example`](../../.gittensory-miner.yml.example) for the full field reference (YAML or
+JSON are both accepted).
 
 ## Version check
 
-On every invocation the CLI starts an async npm registry lookup (5s timeout). When the installed package is behind `@jsonbored/gittensory-miner@latest`, it prints a one-line upgrade command to stderr without blocking or failing the requested command. Set `GITTENSORY_NPM_REGISTRY_URL` to point at a mirror, same as `@jsonbored/gittensory-mcp`.
+On every invocation the CLI starts an async npm-registry lookup (5s timeout). When the installed package is behind
+`@jsonbored/gittensory-miner@latest`, it prints a one-line upgrade command to stderr without blocking or failing
+the requested command. Set `GITTENSORY_NPM_REGISTRY_URL` to point at a mirror, same as `@jsonbored/gittensory-mcp`.
+The `status` and `doctor` commands skip this check entirely (they are strictly offline).


### PR DESCRIPTION
## Summary

Brings the two sibling-package READMEs current with the foundation phase (Closes #2298).

**`packages/gittensory-miner/README.md`** — the old README still described "a minimal CLI surface for `--help` and `--version`" with "real commands land in follow-up issues," which is now stale. Rewritten to document:
- the full current command surface — `status`, `doctor`, `manage status`/`manage poll`, `queue list`/`next`/`done`, `ledger list`, `plan list`/`show`, `governor list`, `hooks check`, `state get`/`state set`, `--help`/`--version` — mirrored exactly from the CLI's own `--help` output;
- a prominent **"100% local — never uploads source, never holds shared credentials"** boundary (the SQLite stores are owner-only `0o600`; no command writes to GitHub; `status`/`doctor` make no network calls);
- the two install paths (`npm install -g …` / `npm link --workspace`, mirroring `gittensory-mcp`);
- a **`.gittensory-miner.yml`** configuration section (opt-out default, discovery order) pointing at `.gittensory-miner.yml.example`.

**`packages/gittensory-engine/README.md`** — added an **Audience & versioning** section: it is an internal dependency of both the review-stack backend and `gittensory-miner` (not an end-user package), and it is **exact-version-pinned** by the miner so both callers run identical deterministic logic.

Docs-only, mirroring `packages/gittensory-mcp/README.md`'s Status/Install/Commands structure. No code, no dependency, no runtime surface changed.

## Scope
- [x] Conventional Commit title; focused; docs-only; linked issue #2298; no `site/`/`CNAME`/VitePress.

## Validation
- [x] `git diff --check`
- [x] `npm run typecheck` (unaffected — docs only)
- All command names, flags, the `state` states, and the config discovery order were verified against the current `packages/gittensory-miner/lib/cli.js` (`--help` output) and `.gittensory-miner.yml.example`.

## Safety
- [x] No secrets/wallets/hotkeys/trust/reward terms. n/a: docs only — no auth/API/UI/DB/network surface.
