### PR TITLE
feat(enrichment): flag PYTHONHTTPSVERIFY=0 as TLS verification disabled

### DIFF
--- a/review-enrichment/src/analyzers/iac-misconfig.ts
+++ b/review-enrichment/src/analyzers/iac-misconfig.ts
@@ -19,7 +19,7 @@ const PUBLIC_BUCKET_RE =
 const SAME_SITE_NONE_RE = /\bsameSite\b[\s"'=:,-]*["']?none["']?\b/i;
 const SECURE_FALSE_RE = /\bsecure\b[\s"'=:,-]*false\b/i;
 const TLS_DISABLED_RE =
-  /\brejectUnauthorized\b[\s"'=:,-]*false\b|\bverify\s*=\s*False\b|\bssl_verify\b[\s"'=:,-]*false\b|\binsecureSkipTLSVerify\b[\s"'=:,-]*true\b|\bskipTLSVerify\b[\s"'=:,-]*true\b|\bNODE_TLS_REJECT_UNAUTHORIZED\b[\s"'=:,-]*["']?0\b/i;
+  /\brejectUnauthorized\b[\s"'=:,-]*false\b|\bverify\s*=\s*False\b|\bssl_verify\b[\s"'=:,-]*false\b|\binsecureSkipTLSVerify\b[\s"'=:,-]*true\b|\bskipTLSVerify\b[\s"'=:,-]*true\b|\bNODE_TLS_REJECT_UNAUTHORIZED\b[\s"'=:,-]*["']?0\b|\bPYTHONHTTPSVERIFY\b[\s"'=:,-]*["']?0\b/i;
 const PROD_RE =
   /\b(?:NODE_ENV|ENVIRONMENT|APP_ENV)\b[\s"'=:,-]*production\b|\bproduction\s*:/i;
 const DEBUG_TRUE_RE = /\bdebug\b[\s"'=:,-]*true\b|\bDEBUG\b[\s"'=:,-]*true\b/i;

--- a/review-enrichment/test/iac-misconfig.test.ts
+++ b/review-enrichment/test/iac-misconfig.test.ts
@@ -90,6 +90,45 @@ test("scanPatchForIacMisconfig does not flag NODE_TLS_REJECT_UNAUTHORIZED when T
   );
 });
 
+test("scanPatchForIacMisconfig flags PYTHONHTTPSVERIFY=0 as TLS verification disabled", () => {
+  // Python's stdlib `urllib`/`requests` honor this env var; `0` disables certificate verification
+  // process-wide — the Python equivalent of `NODE_TLS_REJECT_UNAUTHORIZED=0`.
+  const dotenv = scanPatchForIacMisconfig(
+    ".env.production",
+    ["@@ -1,0 +7,1 @@", "+PYTHONHTTPSVERIFY=0"].join("\n"),
+  );
+  assert.deepEqual(dotenv, [
+    { file: ".env.production", line: 7, kind: "tls-verification-disabled" },
+  ]);
+
+  const dockerfile = scanPatchForIacMisconfig(
+    "Dockerfile",
+    ["@@ -1,0 +3,1 @@", "+ENV PYTHONHTTPSVERIFY 0"].join("\n"),
+  );
+  assert.deepEqual(dockerfile, [
+    { file: "Dockerfile", line: 3, kind: "tls-verification-disabled" },
+  ]);
+
+  const quoted = scanPatchForIacMisconfig(
+    "compose.yaml",
+    ["@@ -1,0 +9,1 @@", '+      PYTHONHTTPSVERIFY: "0"'].join("\n"),
+  );
+  assert.deepEqual(quoted, [
+    { file: "compose.yaml", line: 9, kind: "tls-verification-disabled" },
+  ]);
+});
+
+test("scanPatchForIacMisconfig does not flag PYTHONHTTPSVERIFY when verification stays on", () => {
+  // Only the value `0` disables verification; `1` (verification on) must not be flagged.
+  assert.deepEqual(
+    scanPatchForIacMisconfig(
+      ".env",
+      "@@ -1,0 +1,1 @@\n+PYTHONHTTPSVERIFY=1",
+    ),
+    [],
+  );
+});
+
 test("isRelevantConfigPath recognizes environment-specific dotenv files", async () => {
   // The path gate must admit mode-suffixed dotenv files (`.env.production`, `.env.local`,
   // `apps/api/.env.staging`) — the canonical home of `NODE_TLS_REJECT_UNAUTHORIZED=0` — not only a bare `.env`.


### PR DESCRIPTION
## Summary
- Extend the IaC misconfig TLS-disabled detector to flag `PYTHONHTTPSVERIFY=0`, the Python stdlib equivalent of `NODE_TLS_REJECT_UNAUTHORIZED=0`.
- Covers dotenv, Dockerfile `ENV`, and quoted YAML/JSON forms already handled for the Node var.

## Test plan
- [x] Regression tests for positive `.env`, Dockerfile, and compose YAML forms
- [x] Negative test confirming `PYTHONHTTPSVERIFY=1` is not flagged
- [ ] CI green


Made with [Cursor](https://cursor.com)