### PR TITLE
feat(enrichment): detect OpenAI project-scoped API keys in secret-scan

### DIFF
--- a/review-enrichment/src/analyzers/secret-scan.ts
+++ b/review-enrichment/src/analyzers/secret-scan.ts
@@ -77,6 +77,13 @@ const RULES: Rule[] = [
     confidence: "high",
   },
   {
+    // OpenAI project-scoped API key: `sk-proj-` + base64url body. Distinct from Anthropic `sk-ant-`
+    // and Stripe `sk_live_`/`sk_test_`. Negative-lookahead terminator for bodies ending in `-`/`_`.
+    kind: "openai_project_key",
+    re: /\bsk-proj-[A-Za-z0-9_-]{20,}(?![A-Za-z0-9_-])/,
+    confidence: "high",
+  },
+  {
     // DigitalOcean personal access token: `dop_v1_` + 64 hex chars (case-insensitive).
     kind: "digitalocean_token",
     re: /\bdop_v1_[a-f0-9]{64}\b/i,

--- a/review-enrichment/test/secret-scan.test.ts
+++ b/review-enrichment/test/secret-scan.test.ts
@@ -19,6 +19,8 @@ const fakeSendgridKey = ["SG.", "a".repeat(22), ".", "b".repeat(43)].join("");
 const fakeHuggingfaceToken = "hf_" + "a".repeat(34);
 // Anthropic keys are `sk-ant-` + a long base64url body (fragments only — never a contiguous literal in source).
 const fakeAnthropicKey = ["sk-ant-", "api03-", "a".repeat(20)].join("");
+// OpenAI project-scoped key: `sk-proj-` + base64url body (fragments only — never a contiguous literal).
+const fakeOpenAiProjKey = ["sk-proj-", "T3BlbkFJ", "a".repeat(20)].join("");
 const fakeGitlabToken = "glpat-" + "aBcDeFgHiJkLmNoPqRsT"; // 20 chars after the prefix
 const fakeNpmToken = "npm_" + "a".repeat(36);
 // GitHub fine-grained PAT: `github_pat_` + 82 base62/underscore chars (fragments only — never a contiguous
@@ -338,4 +340,24 @@ test("scanPatch still flags Stripe live-mode keys", () => {
   const findings = scanPatch("src/config.ts", hunk([`const key = "${fakeStripeKey}";`]));
   assert.equal(findings.length, 1);
   assert.equal(findings[0].kind, "stripe_secret_key");
+});
+
+test("scanPatch flags an OpenAI project API key with high confidence", () => {
+  const findings = scanPatch("src/config.ts", hunk([`const key = "${fakeOpenAiProjKey}";`]));
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "openai_project_key");
+  assert.equal(findings[0].confidence, "high");
+});
+
+test("scanPatch flags an OpenAI project key whose final body character is a hyphen", () => {
+  const key = fakeOpenAiProjKey + "-";
+  const findings = scanPatch("src/config.ts", hunk([`const key = "${key}";`]));
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "openai_project_key");
+});
+
+test("scanPatch does not classify Anthropic sk-ant- keys as OpenAI project keys", () => {
+  const findings = scanPatch("src/config.ts", hunk([`const key = "${fakeAnthropicKey}";`]));
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "anthropic_api_key");
 });


### PR DESCRIPTION
## Summary
- Add a high-confidence secret-scan rule for OpenAI project API keys (`sk-proj-` prefix).
- Uses a negative-lookahead terminator so keys ending in `-`/`_` still match, and stays distinct from Anthropic `sk-ant-` and Stripe `sk_live_`/`sk_test_` rules.

## Test plan
- [x] Positive test for a synthetic `sk-proj-` key
- [x] Hyphen-tail boundary regression
- [x] Negative classification test ensuring `sk-ant-` still maps to `anthropic_api_key`
- [ ] CI green


Made with [Cursor](https://cursor.com)