### PR TITLE
feat(enrichment): flag insecure container and cloud IaC misconfigurations

### DIFF
--- a/review-enrichment/src/analyzers/iac-misconfig.ts
+++ b/review-enrichment/src/analyzers/iac-misconfig.ts
@@ -26,6 +26,29 @@ const DEBUG_TRUE_RE = /\bdebug\b[\s"'=:,-]*true\b|\bDEBUG\b[\s"'=:,-]*true\b/i;
 const HARDCODED_URL_RE =
   /\b(?:[A-Z][A-Z0-9_]*(?:URL|URI|ENDPOINT)|(?:api|base|service|backend|frontend|server|webhook)[_-]?(?:url|uri|endpoint)|baseUrl)\b[\s"'=:,-]*https?:\/\/[^\s"',#}]+/i;
 
+// Container securityContext / Kubernetes Pod Security Standards (restricted profile). Each matches a single
+// `key: <insecure-value>` line; the secure value (e.g. `privileged: false`) never matches. `\bprivileged\b`
+// deliberately does NOT fire on the safe `unprivileged: true` (word boundary fails after the `un` prefix).
+const PRIVILEGED_RE = /\bprivileged\b[\s"'=:,-]*true\b/i;
+const PRIVILEGE_ESCALATION_RE = /\ballowPrivilegeEscalation\b[\s"'=:,-]*true\b/i;
+const HOST_PID_RE = /\bhostPID\b[\s"'=:,-]*true\b/i;
+const HOST_IPC_RE = /\bhostIPC\b[\s"'=:,-]*true\b/i;
+const RUN_AS_ROOT_RE = /\brunAsNonRoot\b[\s"'=:,-]*false\b/i;
+// `runAsUser: 0` is root. The separators are zero-width-optional, so a non-zero uid like `runAsUser: 1000`
+// cannot match (the value must begin with a `0` immediately after the separators).
+const RUN_AS_UID_ZERO_RE = /\brunAsUser\b[\s"'=:,-]*0\b/i;
+const WRITABLE_ROOTFS_RE = /\breadOnlyRootFilesystem\b[\s"'=:,-]*false\b/i;
+const UNMASKED_PROC_RE = /\bprocMount\b[\s"'=:,-]*["']?Unmasked\b/i;
+
+// Cloud / Terraform resource hardening. `\b(?:storage_encrypted|encrypted)\b` matches the standalone
+// `encrypted` key and the `storage_encrypted` key, but never the `_encrypted` tail of an unrelated identifier.
+const UNENCRYPTED_STORAGE_RE = /\b(?:storage_encrypted|encrypted)\b[\s"'=:,-]*false\b/i;
+const PUBLIC_DB_RE = /\bpublicly_accessible\b[\s"'=:,-]*true\b/i;
+const IMDS_V1_RE = /\bhttp_tokens\b[\s"'=:,-]*["']?optional\b/i;
+// World-writable `0777`/`777` via `chmod`, a `mode:`/`file_mode` assignment. A leading sticky/setuid digit
+// (`chmod 1777`) does not match because the value must begin at the optional `0` then `777`.
+const WORLD_WRITABLE_RE = /\b(?:chmod\s+|(?:file_)?mode[\s"'=:,-]*["']?)0?777\b/i;
+
 function* patchLines(patch: string): Generator<string> {
   let start = 0;
   for (let i = 0; i <= patch.length; i++) {
@@ -194,6 +217,99 @@ export function scanPatchForIacMisconfig(
         path,
         newLine,
         "hardcoded-service-url",
+        maxFindings,
+      )
+    ) {
+      return findings;
+    }
+    if (
+      PRIVILEGED_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "privileged-container", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      PRIVILEGE_ESCALATION_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "privilege-escalation", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      HOST_PID_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "host-pid-namespace", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      HOST_IPC_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "host-ipc-namespace", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      RUN_AS_ROOT_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "run-as-root", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      RUN_AS_UID_ZERO_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "run-as-root-uid", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      WRITABLE_ROOTFS_RE.test(body) &&
+      pushFinding(
+        findings,
+        seen,
+        path,
+        newLine,
+        "writable-root-filesystem",
+        maxFindings,
+      )
+    ) {
+      return findings;
+    }
+    if (
+      UNMASKED_PROC_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "unmasked-proc-mount", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      UNENCRYPTED_STORAGE_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "unencrypted-storage", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      PUBLIC_DB_RE.test(body) &&
+      pushFinding(
+        findings,
+        seen,
+        path,
+        newLine,
+        "publicly-accessible-database",
+        maxFindings,
+      )
+    ) {
+      return findings;
+    }
+    if (
+      IMDS_V1_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "imdsv1-allowed", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      WORLD_WRITABLE_RE.test(body) &&
+      pushFinding(
+        findings,
+        seen,
+        path,
+        newLine,
+        "world-writable-permissions",
         maxFindings,
       )
     ) {

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -281,6 +281,30 @@ export function renderBrief(
           return "enables debug mode in production configuration; this can expose internals or sensitive data";
         case "hardcoded-service-url":
           return "hardcodes a service URL in config; prefer environment-specific injection or secrets-managed config";
+        case "privileged-container":
+          return "runs the container in privileged mode, granting near-unrestricted host device and kernel access";
+        case "privilege-escalation":
+          return "sets `allowPrivilegeEscalation: true`; the process can gain more privileges than its parent";
+        case "host-pid-namespace":
+          return "shares the host PID namespace; the container can see and signal processes on the host";
+        case "host-ipc-namespace":
+          return "shares the host IPC namespace; the container can reach host shared-memory segments";
+        case "run-as-root":
+          return "sets `runAsNonRoot: false`, permitting the container to run as the root user";
+        case "run-as-root-uid":
+          return "runs the container as UID 0 (root); prefer a dedicated non-root user";
+        case "writable-root-filesystem":
+          return "sets `readOnlyRootFilesystem: false`; a writable root filesystem eases tampering and persistence";
+        case "unmasked-proc-mount":
+          return "sets `procMount: Unmasked`, exposing masked `/proc` paths to the container";
+        case "unencrypted-storage":
+          return "disables storage encryption at rest; verify the stored data does not require encryption";
+        case "publicly-accessible-database":
+          return "marks the database instance as publicly accessible from the internet";
+        case "imdsv1-allowed":
+          return "allows IMDSv1 (`http_tokens: optional`); prefer IMDSv2 to mitigate SSRF credential theft";
+        case "world-writable-permissions":
+          return "grants world-writable `0777` permissions; restrict to the least access the workload needs";
       }
     };
 

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -221,7 +221,19 @@ export interface IacMisconfigFinding {
     | "insecure-cookie"
     | "tls-verification-disabled"
     | "prod-debug"
-    | "hardcoded-service-url";
+    | "hardcoded-service-url"
+    | "privileged-container"
+    | "privilege-escalation"
+    | "host-pid-namespace"
+    | "host-ipc-namespace"
+    | "run-as-root"
+    | "run-as-root-uid"
+    | "writable-root-filesystem"
+    | "unmasked-proc-mount"
+    | "unencrypted-storage"
+    | "publicly-accessible-database"
+    | "imdsv1-allowed"
+    | "world-writable-permissions";
 }
 
 /** A newly-added dependency whose install compiles native code (npm node-gyp addon) or has no prebuilt wheel

--- a/review-enrichment/test/iac-misconfig.test.ts
+++ b/review-enrichment/test/iac-misconfig.test.ts
@@ -171,3 +171,65 @@ test("scanPatchForIacMisconfig keeps line numbers correct across a no-newline ma
     { file: ".env.production", line: 2, kind: "tls-verification-disabled" },
   ]);
 });
+
+test("scanPatchForIacMisconfig flags container securityContext and cloud hardening misconfigurations", () => {
+  // Each added line is the insecure form of a recognized check (Kubernetes Pod Security Standards
+  // restricted profile + tfsec/checkov cloud rules) and must produce exactly one finding of its own kind.
+  const cases = [
+    ["+      privileged: true", "privileged-container"],
+    ["+      allowPrivilegeEscalation: true", "privilege-escalation"],
+    ["+      hostPID: true", "host-pid-namespace"],
+    ["+      hostIPC: true", "host-ipc-namespace"],
+    ["+      runAsNonRoot: false", "run-as-root"],
+    ["+      runAsUser: 0", "run-as-root-uid"],
+    ["+      readOnlyRootFilesystem: false", "writable-root-filesystem"],
+    ["+      procMount: Unmasked", "unmasked-proc-mount"],
+    ["+  storage_encrypted = false", "unencrypted-storage"],
+    ["+  publicly_accessible = true", "publicly-accessible-database"],
+    ['+    http_tokens = "optional"', "imdsv1-allowed"],
+    ["+RUN chmod 777 /app/entrypoint.sh", "world-writable-permissions"],
+  ];
+  for (const [added, kind] of cases) {
+    const findings = scanPatchForIacMisconfig(
+      "deploy/app.yaml",
+      ["@@ -1,0 +1,1 @@", added].join("\n"),
+    );
+    assert.deepEqual(
+      findings,
+      [{ file: "deploy/app.yaml", line: 1, kind }],
+      `${kind}: expected exactly one finding of that kind, got ${JSON.stringify(findings)}`,
+    );
+  }
+});
+
+test("scanPatchForIacMisconfig does not flag the secure counterpart of each container/cloud setting", () => {
+  // The safe value of every new rule, plus three deliberate near-misses: `unprivileged: true` (word boundary
+  // must not fire the `privileged` rule), `runAsUser: 1000` (a non-root uid must not match the `runAsUser: 0`
+  // rule), and `chmod 1777` (a sticky-bit dir must not match the world-writable `0777` rule).
+  const safe = [
+    "+      privileged: false",
+    "+      unprivileged: true",
+    "+      allowPrivilegeEscalation: false",
+    "+      hostPID: false",
+    "+      hostIPC: false",
+    "+      runAsNonRoot: true",
+    "+      runAsUser: 1000",
+    "+      readOnlyRootFilesystem: true",
+    "+      procMount: Default",
+    "+  storage_encrypted = true",
+    "+  publicly_accessible = false",
+    '+    http_tokens = "required"',
+    "+RUN chmod 750 /app/entrypoint.sh",
+    "+RUN chmod 1777 /tmp/scratch",
+  ];
+  for (const added of safe) {
+    assert.deepEqual(
+      scanPatchForIacMisconfig(
+        "deploy/app.yaml",
+        ["@@ -1,0 +1,1 @@", added].join("\n"),
+      ),
+      [],
+      `should not flag: ${added.trim()}`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

The IaC-misconfig analyzer (`review-enrichment/src/analyzers/iac-misconfig.ts`) flags risky infrastructure
/ config lines an added diff introduces (citing `file:line` + a public-safe rule kind). It already covers
wildcard CORS, open `0.0.0.0/0` ingress, public buckets, insecure cookies, disabled TLS verification, prod
debug, and hardcoded service URLs — but has **no coverage of container `securityContext` hardening**, the most
common source of Kubernetes/Docker security findings, and only partial cloud-resource coverage.

This adds **12 new high-precision rules**, each a single-line `key: <insecure-value>` check that mirrors the
existing stateless rule pattern (regex const → `pushFinding` branch), so its secure counterpart never matches:

**Container `securityContext` — Kubernetes Pod Security Standards (restricted profile):**

| kind | fires on | control |
|---|---|---|
| `privileged-container` | `privileged: true` | Privileged Containers |
| `privilege-escalation` | `allowPrivilegeEscalation: true` | Privilege Escalation |
| `host-pid-namespace` | `hostPID: true` | Host Namespaces |
| `host-ipc-namespace` | `hostIPC: true` | Host Namespaces |
| `run-as-root` | `runAsNonRoot: false` | Running as Non-root |
| `run-as-root-uid` | `runAsUser: 0` | Running as Non-root user |
| `writable-root-filesystem` | `readOnlyRootFilesystem: false` | CIS / kube-score |
| `unmasked-proc-mount` | `procMount: Unmasked` | `/proc` Mount Type |

**Cloud / Terraform resource hardening (tfsec / checkov standard checks):**

| kind | fires on | check |
|---|---|---|
| `unencrypted-storage` | `storage_encrypted = false` / `encrypted = false` | encryption at rest |
| `publicly-accessible-database` | `publicly_accessible = true` | public DB exposure |
| `imdsv1-allowed` | `http_tokens = "optional"` | IMDSv2 enforcement (SSRF) |
| `world-writable-permissions` | `chmod 777` / `mode: 0777` | least-privilege file mode |

Every rule is an established, named industry check (Kubernetes PSS, CIS, tfsec/checkov) with **no benign
form** of the flagged value, so the false-positive rate is near zero. Three deliberate near-misses are
covered by tests to prove the boundaries are tight: `unprivileged: true` does **not** fire the `privileged`
rule (word boundary after the `un` prefix), `runAsUser: 1000` does **not** fire the `runAsUser: 0` rule, and
`chmod 1777` (a sticky-bit dir) does **not** fire the world-writable `0777` rule.

The analyzer's finding schema is `{file, line, kind}` and the `kind` union is not part of the analyzer
descriptor, so `analyzer-metadata.json` is **unchanged**; the render-brief switch is TypeScript-exhaustive,
so each new kind is compiler-forced to have a public-safe explanation.

No linked issue: additive detection-coverage that extends an existing multi-domain analyzer along its own
established lines (it already spans Docker / Terraform / Kubernetes / YAML config), each rule a self-evident
standard check with no public API/schema/deploy surface change — fits the repo's `preferred` (not required)
linked-issue policy.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run typecheck`
- [x] `npm run rees:test` — the review-enrichment build + analyzer suite (see note below)
- [ ] `npm run test:coverage` (N/A — this change is in `review-enrichment/`, outside the root `src/**` Codecov scope)
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran locally: `git diff --check` (clean), the review-enrichment TypeScript build
  (`npm --prefix review-enrichment run build`, exit 0 — which also proves the render switch is exhaustive
  over the new kinds), and the analyzer test suite via `node --test`. The iac-misconfig file passes 10/10:
  a table test asserting each of the 12 insecure lines produces exactly one finding of its own kind, and a
  negative test asserting the secure counterpart of each (plus the three near-misses above) produces none.
- The two failing tests in the full `node --test` run are `upload-sourcemaps` (they shell out to the Sentry
  CLI, which is absent on this dev box) and fail identically on unmodified `main` — they are unrelated to
  this change, which touches only the IaC analyzer, its finding-kind union, and the render brief.
- Not run locally: the UI, root typecheck, and the `metadata:check` step of `rees:test`. `metadata:check`
  compares the committed `analyzer-metadata.json` (generated on CI/Linux) against a local regeneration and
  reports a spurious byte difference on this Windows dev box (it fails identically on unmodified `main`).
  This change adds only finding kinds and rules, not any analyzer descriptor field, so the committed
  metadata is unchanged and `metadata:check` passes on CI (Linux). `analyzer-metadata.json` was NOT modified.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Detection-only additions: 12 new stateless rules following the existing single-line pattern; no existing
  rule, threshold, or descriptor is changed, so current findings and `analyzer-metadata.json` are unaffected.
  Each new kind reports only `file:line` + the public-safe kind, never the matched config value.
- Each regex uses `\b` boundaries and the same `[\s"'=:,-]*` key/value separator class as the existing rules,
  and was vetted to match the insecure value, reject the secure value, and reject the near-miss forms tested.
