### PR TITLE
fix(api): gate HTTP intelligence on MCP_READ_REPO_ALLOWLIST

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -2116,6 +2116,8 @@ export function createApp() {
 
   app.get("/v1/repos/:owner/:repo/intelligence", async (c) => {
     const fullName = `${c.req.param("owner")}/${c.req.param("repo")}`;
+    const identity = await authenticateRequestIdentity(c);
+    if (identity?.kind === "static" && identity.actor === "mcp" && !(await import("../auth/security")).isMcpReadRepoAllowed(c.env.MCP_READ_REPO_ALLOWLIST, fullName)) return c.json({ error: "forbidden_repo" }, 403);
     return c.json(await buildRepoIntelligenceResponse(c.env, fullName));
   });
 

--- a/test/integration/routes-errors.test.ts
+++ b/test/integration/routes-errors.test.ts
@@ -341,6 +341,30 @@ describe("api route guards and error branches", () => {
     await expect(denied.json()).resolves.toMatchObject({ error: "forbidden_repo" });
   });
 
+  it("blocks the shared MCP token from reading intelligence outside MCP_READ_REPO_ALLOWLIST (#2455 HTTP parity)", async () => {
+    const app = createApp();
+    const scopedEnv = createTestEnv({ MCP_READ_REPO_ALLOWLIST: "owner/private-repo" });
+    await upsertRepositoryFromGitHub(scopedEnv, { name: "private-repo", full_name: "owner/private-repo", private: true, owner: { login: "owner" } });
+    await upsertRepositoryFromGitHub(scopedEnv, { name: "other-repo", full_name: "other/other-repo", private: false, owner: { login: "other" } });
+    const mcpHeaders = { authorization: `Bearer ${scopedEnv.GITTENSORY_MCP_TOKEN}` };
+
+    const forbidden = await app.request("/v1/repos/other/other-repo/intelligence", { headers: mcpHeaders }, scopedEnv);
+    expect(forbidden.status).toBe(403);
+    await expect(forbidden.json()).resolves.toMatchObject({ error: "forbidden_repo" });
+
+    const allowlisted = await app.request("/v1/repos/owner/private-repo/intelligence", { headers: mcpHeaders }, scopedEnv);
+    expect(allowlisted.status).not.toBe(403);
+
+    const operator = await app.request("/v1/repos/other/other-repo/intelligence", { headers: apiHeaders(scopedEnv) }, scopedEnv);
+    expect(operator.status).not.toBe(403);
+
+    const denyEnv = createTestEnv({ MCP_READ_REPO_ALLOWLIST: "" });
+    await upsertRepositoryFromGitHub(denyEnv, { name: "demo", full_name: "octo/demo", private: false, owner: { login: "octo" } });
+    const denied = await app.request("/v1/repos/octo/demo/intelligence", { headers: { authorization: `Bearer ${denyEnv.GITTENSORY_MCP_TOKEN}` } }, denyEnv);
+    expect(denied.status).toBe(403);
+    await expect(denied.json()).resolves.toMatchObject({ error: "forbidden_repo" });
+  });
+
   it("keeps OAuth setup, CORS, and rate limits explicit", async () => {
     const app = createApp();
     const env = createTestEnv();


### PR DESCRIPTION
## Summary

`GET /v1/repos/:owner/:repo/intelligence` returned queue health, label audit, burden forecast, and other maintainer analytics with **no repo-scoped auth** in the handler — only generic bearer middleware. Any holder of `GITTENSORY_MCP_TOKEN` could read intelligence for **any** installed repo, bypassing `MCP_READ_REPO_ALLOWLIST` that MCP repo tools enforce via `canAccessRepo` (#2455).

This PR authenticates the caller and denies the static `mcp` identity when `!isMcpReadRepoAllowed(MCP_READ_REPO_ALLOWLIST, repo)` before building the response. Operator-only `api` / `internal` tokens remain trusted.

## Changed files

| File | Change |
| ---- | ------ |
| `src/api/routes.ts` | MCP allowlist guard on the intelligence handler (inline dynamic import, same pattern as issue-quality). |
| `test/integration/routes-errors.test.ts` | Regression: scoped MCP token 403 on non-allowlisted repo; allowlisted + operator paths unchanged. |

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

No linked issue — #2455 HTTP/MCP parity gap on a repo-scoped maintainer read route; behavior is fully described here and covered by regression tests.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally on changed tests; **`codecov/patch` 100% (7/7)** on measured `src/api/routes.ts` diff
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries