### PR TITLE
feat(enrichment): detect Notion internal integration secrets in secret-scan

### DIFF
--- a/review-enrichment/src/analyzers/secret-scan.ts
+++ b/review-enrichment/src/analyzers/secret-scan.ts
@@ -158,6 +158,12 @@ const RULES: Rule[] = [
     confidence: "high",
   },
   {
+    // Notion internal integration secret: `secret_` + 43 base62 chars (50 chars total).
+    kind: "notion_integration_secret",
+    re: /\bsecret_[A-Za-z0-9]{43}\b/,
+    confidence: "high",
+  },
+  {
     kind: "private_key",
     re: /-----BEGIN (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----/,
     confidence: "high",

--- a/review-enrichment/test/secret-scan.test.ts
+++ b/review-enrichment/test/secret-scan.test.ts
@@ -361,3 +361,17 @@ test("scanPatch does not classify Anthropic sk-ant- keys as OpenAI project keys"
   assert.equal(findings.length, 1);
   assert.equal(findings[0].kind, "anthropic_api_key");
 });
+
+test("scanPatch flags a Notion internal integration secret with high confidence", () => {
+  const fakeNotionSecret = "secret_" + "a".repeat(43);
+  const findings = scanPatch("src/config.ts", hunk([`const notion = "${fakeNotionSecret}";`]));
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "notion_integration_secret");
+  assert.equal(findings[0].confidence, "high");
+});
+
+test("scanPatch does not flag a truncated Notion integration secret", () => {
+  const truncated = "secret_" + "a".repeat(42);
+  const findings = scanPatch("src/config.ts", hunk([`const notion = "${truncated}";`]));
+  assert.equal(findings.length, 0);
+});


### PR DESCRIPTION
## Summary
- Add a high-confidence secret-scan rule for Notion internal integration secrets (`secret_` + 43 base62 chars).
- Includes a negative test for truncated tokens that must not match.

## Test plan
- [x] Positive test for a synthetic Notion integration secret
- [x] Negative test for a truncated `secret_` value
- [ ] CI green


Made with [Cursor](https://cursor.com)