### PR TITLE
feat(enrichment): treat .rust-version as a Rust runtime pin for EOL checks

### DIFF
--- a/review-enrichment/src/analyzers/eol-check.ts
+++ b/review-enrichment/src/analyzers/eol-check.ts
@@ -108,6 +108,10 @@ export function extractVersionPins(
         // goenv/asdf pin file — same leading-version format, product is Go.
         const version = leadingVersion(line);
         if (version) pins.push({ file: file.path, product: "go", version });
+      } else if (base === ".rust-version") {
+        // rustup/asdf pin file — same leading-version format, product is Rust.
+        const version = leadingVersion(line);
+        if (version) pins.push({ file: file.path, product: "rust", version });
       } else if (base === "go.mod") {
         // Module language version (`go 1.21`) and optional toolchain pin (`toolchain go1.22.0`).
         const match = /^go\s+(\d+\.\d+)/.exec(line);

--- a/review-enrichment/src/scheduler.ts
+++ b/review-enrichment/src/scheduler.ts
@@ -413,6 +413,7 @@ function isRuntimePinPath(path: string): boolean {
     basename === ".ruby-version" ||
     basename === ".php-version" ||
     basename === ".go-version" ||
+    basename === ".rust-version" ||
     basename === "go.mod"
   );
 }

--- a/review-enrichment/test/eol-check.test.ts
+++ b/review-enrichment/test/eol-check.test.ts
@@ -90,6 +90,13 @@ test("extractVersionPins reads .go-version pins as Go", () => {
   ]);
 });
 
+test("extractVersionPins reads .rust-version pins as Rust", () => {
+  // rustup/asdf use `.rust-version` with the same leading-version format.
+  assert.deepEqual(extractVersionPins([added(".rust-version", "1.75.0")]), [
+    { file: ".rust-version", product: "rust", version: "1.75.0" },
+  ]);
+});
+
 test("extractVersionPins ignores removed/context lines and files with no patch", () => {
   const patch = ["@@ -1 +1,2 @@", "-FROM python:3.7", " FROM python:3.9"].join(
     "\n",


### PR DESCRIPTION
## Summary
- Parse `.rust-version` (rustup/asdf) as a Rust runtime pin for endoflife.date EOL analysis.
- Extend the scheduler runtime-pin gate so `.rust-version` changes are not skipped.

## Test plan
- [x] Regression test verifying `.rust-version` extracts `{ product: rust, version }`
- [ ] CI green


Made with [Cursor](https://cursor.com)