### PR TITLE
feat(enrichment): detect Mailgun API keys in secret-scan

### DIFF
--- a/review-enrichment/src/analyzers/secret-scan.ts
+++ b/review-enrichment/src/analyzers/secret-scan.ts
@@ -164,6 +164,12 @@ const RULES: Rule[] = [
     confidence: "high",
   },
   {
+    // Mailgun private API key: `key-` + 32 hex chars (case-insensitive).
+    kind: "mailgun_api_key",
+    re: /\bkey-[0-9a-f]{32}\b/i,
+    confidence: "high",
+  },
+  {
     kind: "private_key",
     re: /-----BEGIN (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----/,
     confidence: "high",

--- a/review-enrichment/test/secret-scan.test.ts
+++ b/review-enrichment/test/secret-scan.test.ts
@@ -375,3 +375,17 @@ test("scanPatch does not flag a truncated Notion integration secret", () => {
   const findings = scanPatch("src/config.ts", hunk([`const notion = "${truncated}";`]));
   assert.equal(findings.length, 0);
 });
+
+test("scanPatch flags a Mailgun API key with high confidence", () => {
+  const fakeMailgunKey = "key-" + "a".repeat(32);
+  const findings = scanPatch("src/config.ts", hunk([`const mg = "${fakeMailgunKey}";`]));
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "mailgun_api_key");
+  assert.equal(findings[0].confidence, "high");
+});
+
+test("scanPatch does not flag a truncated Mailgun API key", () => {
+  const truncated = "key-" + "a".repeat(31);
+  const findings = scanPatch("src/config.ts", hunk([`const mg = "${truncated}";`]));
+  assert.equal(findings.length, 0);
+});


### PR DESCRIPTION
## Summary
- Add a high-confidence secret-scan rule for Mailgun private API keys (`key-` + 32 hex chars).
- Includes a negative test for truncated keys that must not match.

## Test plan
- [x] Positive test for a synthetic Mailgun API key
- [x] Negative test for a truncated `key-` value
- [ ] CI green


Made with [Cursor](https://cursor.com)