### PR TITLE
feat(enrichment): treat .java-version as an Oracle JDK runtime pin for EOL checks

### DIFF
--- a/review-enrichment/src/analyzers/eol-check.ts
+++ b/review-enrichment/src/analyzers/eol-check.ts
@@ -112,6 +112,11 @@ export function extractVersionPins(
         // rustup/asdf pin file — same leading-version format, product is Rust.
         const version = leadingVersion(line);
         if (version) pins.push({ file: file.path, product: "rust", version });
+      } else if (base === ".java-version") {
+        // jenv/asdf pin file — same leading-version format; endoflife.date slug is `oracle-jdk`.
+        const version = leadingVersion(line);
+        if (version)
+          pins.push({ file: file.path, product: "oracle-jdk", version });
       } else if (base === "go.mod") {
         // Module language version (`go 1.21`) and optional toolchain pin (`toolchain go1.22.0`).
         const match = /^go\s+(\d+\.\d+)/.exec(line);

--- a/review-enrichment/src/scheduler.ts
+++ b/review-enrichment/src/scheduler.ts
@@ -414,6 +414,7 @@ function isRuntimePinPath(path: string): boolean {
     basename === ".php-version" ||
     basename === ".go-version" ||
     basename === ".rust-version" ||
+    basename === ".java-version" ||
     basename === "go.mod"
   );
 }

--- a/review-enrichment/test/eol-check.test.ts
+++ b/review-enrichment/test/eol-check.test.ts
@@ -97,6 +97,13 @@ test("extractVersionPins reads .rust-version pins as Rust", () => {
   ]);
 });
 
+test("extractVersionPins reads .java-version pins as oracle-jdk", () => {
+  // jenv/asdf use `.java-version`; endoflife.date tracks Oracle JDK release cycles.
+  assert.deepEqual(extractVersionPins([added(".java-version", "21.0.2")]), [
+    { file: ".java-version", product: "oracle-jdk", version: "21.0.2" },
+  ]);
+});
+
 test("extractVersionPins ignores removed/context lines and files with no patch", () => {
   const patch = ["@@ -1 +1,2 @@", "-FROM python:3.7", " FROM python:3.9"].join(
     "\n",


### PR DESCRIPTION
## Summary
- Parse `.java-version` (jenv/asdf) as an Oracle JDK runtime pin for endoflife.date EOL analysis.
- Extend the scheduler runtime-pin gate so `.java-version` changes are not skipped.

## Test plan
- [x] Regression test verifying `.java-version` extracts `{ product: oracle-jdk, version }`
- [ ] CI green


Made with [Cursor](https://cursor.com)