### PR TITLE
feat(enrichment): detect Mailgun API keys in secret-scan

### DIFF
--- a/review-enrichment/src/analyzers/secret-scan.ts
+++ b/review-enrichment/src/analyzers/secret-scan.ts
@@ -164,6 +164,12 @@ const RULES: Rule[] = [
     confidence: "high",
   },
   {
+    // Mailgun private API key: `key-` + 32 alphanumeric chars.
+    kind: "mailgun_api_key",
+    re: /\bkey-[0-9A-Za-z]{32}\b/,
+    confidence: "high",
+  },
+  {
     kind: "private_key",
     re: /-----BEGIN (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----/,
     confidence: "high",

--- a/review-enrichment/test/secret-scan.test.ts
+++ b/review-enrichment/test/secret-scan.test.ts
@@ -375,3 +375,24 @@ test("scanPatch does not flag a truncated Notion integration secret", () => {
   const findings = scanPatch("src/config.ts", hunk([`const notion = "${truncated}";`]));
   assert.equal(findings.length, 0);
 });
+
+test("scanPatch flags a Mailgun API key with high confidence", () => {
+  // Real Mailgun private keys use a 32-char alphanumeric body, not hex-only.
+  const fakeMailgunKey = ["key-", "3ax6xnjp29jd6fds4gc373sgvjxteol0"].join("");
+  const findings = scanPatch("src/config.ts", hunk([`const mg = "${fakeMailgunKey}";`]));
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].kind, "mailgun_api_key");
+  assert.equal(findings[0].confidence, "high");
+});
+
+test("scanPatch does not flag a truncated Mailgun API key", () => {
+  const truncated = "key-" + "a".repeat(31);
+  const findings = scanPatch("src/config.ts", hunk([`const mg = "${truncated}";`]));
+  assert.equal(findings.length, 0);
+});
+
+test("scanPatch does not flag a Mailgun-shaped key with an invalid body character", () => {
+  const invalid = "key-" + "a".repeat(31) + "_";
+  const findings = scanPatch("src/config.ts", hunk([`const mg = "${invalid}";`]));
+  assert.equal(findings.length, 0);
+});


### PR DESCRIPTION
## Summary
- Add a high-confidence secret-scan rule for Mailgun private API keys (`key-` + 32 alphanumeric chars).
- Uses the documented Mailgun key shape (alphanumeric body, not hex-only) with positive, truncated, and invalid-character boundary tests.

## Test plan
- [x] Positive test with a realistic alphanumeric Mailgun key fixture
- [x] Negative test for truncated keys
- [x] Negative test for underscore in the body
- [ ] CI green


Made with [Cursor](https://cursor.com)