### PR TITLE
feat(enrichment): add a merge-conflict-marker analyzer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,19 +66,19 @@ GITTENSORY_REVIEW_ENRICHMENT=false
 # dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol,redos
 # provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild
 # history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity,ciCheckSignals
-# undocumentedExport
+# undocumentedExport,conflictMarker
 #
 # Profile defaults:
 # fast: dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol
-# redos,provenance,secretLog,typosquat,iacMisconfig,nativeBuild
+# redos,provenance,secretLog,typosquat,iacMisconfig,nativeBuild,conflictMarker
 # balanced (default): dependency,lockfileDrift,secret,license,installScript,heavyDependency
 # actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature
 # iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink
-# approvalIntegrity,ciCheckSignals,undocumentedExport
+# approvalIntegrity,ciCheckSignals,undocumentedExport,conflictMarker
 # deep: dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol
 # redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig
 # nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity
-# ciCheckSignals,undocumentedExport
+# ciCheckSignals,undocumentedExport,conflictMarker
 # END GENERATED REES ANALYZERS
 
 # Submitter-reputation spend control (internal-only): downgrades new/burst/low-rep

--- a/apps/gittensory-ui/src/lib/rees-analyzers.ts
+++ b/apps/gittensory-ui/src/lib/rees-analyzers.ts
@@ -657,6 +657,28 @@ export const REES_ANALYZERS = [
         "Conservative: re-export lists (`export { x }`) and `export *` are ignored; a preceding `//` line (except tool directives like `eslint-disable`) or a real JSDoc `/**` block counts as documented (a plain `/* … */` block does not).",
     },
   },
+  {
+    name: "conflictMarker",
+    title: "Merge-conflict markers",
+    category: "quality",
+    cost: "local",
+    defaultEnabled: true,
+    profiles: ["fast", "balanced", "deep"],
+    requires: ["files"],
+    limits: {
+      maxFindings: 25,
+    },
+    docs: {
+      summary:
+        "Flags leftover VCS merge-conflict markers accidentally committed in a PR's added lines.",
+      looksAt:
+        "Added lines matching the seven-character git conflict markers: <<<<<<<, |||||||, =======, and >>>>>>>.",
+      reports: "File, line, and which conflict marker was left in place.",
+      network: "Pure local analyzer. No external network call.",
+      notes:
+        "The ambiguous ======= separator is not flagged in Markdown/AsciiDoc files, where a bare ======= line is a valid setext heading underline or section rule; the unambiguous <<<<<<< / >>>>>>> markers are flagged everywhere.",
+    },
+  },
 ] as const satisfies readonly ReesAnalyzerDoc[];
 
 export const REES_ANALYZER_NAMES = REES_ANALYZERS.map((analyzer) => analyzer.name);

--- a/review-enrichment/analyzer-metadata.json
+++ b/review-enrichment/analyzer-metadata.json
@@ -741,6 +741,31 @@
         "network": "One GitHub contents fetch per changed entrypoint (at headSha). Requires GitHub token forwarding for private repos.",
         "notes": "Conservative: re-export lists (`export { x }`) and `export *` are ignored; a preceding `//` line (except tool directives like `eslint-disable`) or a real JSDoc `/**` block counts as documented (a plain `/* … */` block does not)."
       }
+    },
+    {
+      "name": "conflictMarker",
+      "title": "Merge-conflict markers",
+      "category": "quality",
+      "cost": "local",
+      "defaultEnabled": true,
+      "profiles": [
+        "fast",
+        "balanced",
+        "deep"
+      ],
+      "requires": [
+        "files"
+      ],
+      "limits": {
+        "maxFindings": 25
+      },
+      "docs": {
+        "summary": "Flags leftover VCS merge-conflict markers accidentally committed in a PR's added lines.",
+        "looksAt": "Added lines matching the seven-character git conflict markers: <<<<<<<, |||||||, =======, and >>>>>>>.",
+        "reports": "File, line, and which conflict marker was left in place.",
+        "network": "Pure local analyzer. No external network call.",
+        "notes": "The ambiguous ======= separator is not flagged in Markdown/AsciiDoc files, where a bare ======= line is a valid setext heading underline or section rule; the unambiguous <<<<<<< / >>>>>>> markers are flagged everywhere."
+      }
     }
   ]
 }

--- a/review-enrichment/src/analyzers/conflict-marker.ts
+++ b/review-enrichment/src/analyzers/conflict-marker.ts
@@ -1,0 +1,84 @@
+// Merge-conflict-marker analyzer (#2032). Flags leftover VCS conflict markers (`<<<<<<<`, `|||||||`,
+// `=======`, `>>>>>>>`) accidentally committed in the ADDED lines of a PR diff — a mechanical, near-zero
+// false-positive catch that should block a merge. Pure compute, no network. Line-cited via the hunk headers.
+import type { EnrichRequest, ConflictMarkerFinding } from "../types.js";
+
+const MAX_FINDINGS = 25;
+
+// Git writes conflict markers as EXACTLY seven identical characters at column 0. The ours/base/theirs markers
+// may be followed by a space + label (branch/commit); the separator is a bare seven `=`. Matching exactly
+// seven (not six or eight) keeps the ours/base/theirs markers unambiguous — seven `<`/`|`/`>` at the start of
+// a line is never valid prose or code.
+const OURS_RE = /^<{7}(?: .*)?$/; // <<<<<<< HEAD
+const BASE_RE = /^\|{7}(?: .*)?$/; // ||||||| merged common ancestors (diff3 conflict style)
+const THEIRS_RE = /^>{7}(?: .*)?$/; // >>>>>>> feature-branch
+const SEP_RE = /^={7}$/; // =======  (bare seven; guarded in markup files — see below)
+
+// A bare `=======` line is legitimate in Markdown (a setext H1 underline) and AsciiDoc (a section rule), so the
+// ambiguous separator marker is NOT flagged in those files. The ours/base/theirs markers are still flagged in
+// every file type, so a real conflict landing in a Markdown file is still caught by its `<<<<<<<`/`>>>>>>>`.
+const MARKUP_PATH_RE = /\.(?:md|markdown|mdx|rst|adoc|asciidoc|textile)$/i;
+
+/** Scan one file's unified-diff patch for conflict markers on added lines, line-cited via hunk headers. Pure. */
+export function scanPatchForConflictMarkers(
+  path: string,
+  patch: string,
+  maxFindings: number = MAX_FINDINGS,
+): ConflictMarkerFinding[] {
+  const findings: ConflictMarkerFinding[] = [];
+  if (maxFindings <= 0) return findings;
+  const allowSeparator = !MARKUP_PATH_RE.test(path);
+  let newLine = 0;
+  let inHunk = false;
+  for (const line of patch.split("\n")) {
+    const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
+    if (hunk) {
+      newLine = Number(hunk[1]);
+      inHunk = true;
+      continue;
+    }
+    // Skip the pre-hunk preamble; inside a hunk `+++x`/`+++ x` is added content, not a header.
+    if (!inHunk) continue;
+    if (line.startsWith("+")) {
+      const body = line.slice(1);
+      const marker = OURS_RE.test(body)
+        ? "<<<<<<<"
+        : BASE_RE.test(body)
+          ? "|||||||"
+          : THEIRS_RE.test(body)
+            ? ">>>>>>>"
+            : allowSeparator && SEP_RE.test(body)
+              ? "======="
+              : null;
+      if (marker) {
+        findings.push({ file: path, line: newLine, marker });
+        if (findings.length >= maxFindings) return findings;
+      }
+      newLine++;
+    } else if (!line.startsWith("-") && !line.startsWith("\\")) {
+      // A context line advances the new-file cursor; a removed line and a `\ No newline at end of file`
+      // marker do not (same class as the actions-pin / iac-misconfig / secret-scan line-number fix).
+      newLine++;
+    }
+  }
+  return findings;
+}
+
+/** Analyzer entrypoint: scan every changed file's patch for leftover conflict markers. Pure, no network. */
+export async function scanConflictMarkers(
+  req: EnrichRequest,
+): Promise<ConflictMarkerFinding[]> {
+  const findings: ConflictMarkerFinding[] = [];
+  for (const file of req.files ?? []) {
+    if (!file.patch) continue;
+    for (const finding of scanPatchForConflictMarkers(
+      file.path,
+      file.patch,
+      MAX_FINDINGS - findings.length,
+    )) {
+      findings.push(finding);
+      if (findings.length >= MAX_FINDINGS) return findings;
+    }
+  }
+  return findings;
+}

--- a/review-enrichment/src/analyzers/registry.ts
+++ b/review-enrichment/src/analyzers/registry.ts
@@ -6,6 +6,7 @@ import { scanBlameLink } from "./blame-link.js";
 import { scanCiCheckSignals } from "./ci-check-signals.js";
 import { scanCodeowners } from "./codeowners.js";
 import { scanCommitSignature } from "./commit-signature.js";
+import { scanConflictMarkers } from "./conflict-marker.js";
 import { dependencyAnalyzer } from "./dependency/descriptor.js";
 import { scanDocCommentDrift } from "./doc-comment-drift.js";
 import { scanDuplication } from "./duplication-scan.js";
@@ -584,6 +585,38 @@ export const ANALYZER_DESCRIPTORS = [
       return lines;
     },
     run: (req, { signal }) => scanUndocumentedExport(req, fetch, { signal }),
+  }),
+  descriptor({
+    name: "conflictMarker",
+    title: "Merge-conflict markers",
+    category: "quality",
+    cost: "local",
+    defaultEnabled: true,
+    requires: ["files"],
+    limits: { maxFindings: 25 },
+    docs: {
+      summary:
+        "Flags leftover VCS merge-conflict markers accidentally committed in a PR's added lines.",
+      looksAt:
+        "Added lines matching the seven-character git conflict markers: <<<<<<<, |||||||, =======, and >>>>>>>.",
+      reports: "File, line, and which conflict marker was left in place.",
+      network: "Pure local analyzer. No external network call.",
+      notes:
+        "The ambiguous ======= separator is not flagged in Markdown/AsciiDoc files, where a bare ======= line is a valid setext heading underline or section rule; the unambiguous <<<<<<< / >>>>>>> markers are flagged everywhere.",
+    },
+    render: (findings, helpers) => {
+      if (!findings.length) return [];
+      const lines = [
+        "### Merge-conflict markers (unresolved merge/rebase leftovers — resolve before merging)",
+      ];
+      for (const item of findings) {
+        lines.push(
+          `- ${helpers.safeCodeSpan(`${item.file}:${item.line}`)} leaves a ${helpers.safeCodeSpan(item.marker)} conflict marker in place`,
+        );
+      }
+      return lines;
+    },
+    run: (req) => scanConflictMarkers(req),
   }),
 ] as const satisfies readonly AnyAnalyzerDescriptor[];
 

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -111,6 +111,14 @@ export interface HeavyDependencyFinding {
   dependencyCount: number | null;
 }
 
+/** A VCS merge-conflict marker (or diff3 base marker) left in an added diff line — an unresolved merge/rebase
+ *  leftover that should block a merge. `marker` is the seven-character marker token (e.g. `<<<<<<<`). */
+export interface ConflictMarkerFinding {
+  file: string;
+  line: number;
+  marker: string;
+}
+
 /** A third-party GitHub Action referenced by a mutable tag/branch instead of a pinned commit SHA. */
 export interface ActionPinFinding {
   file: string;
@@ -372,6 +380,7 @@ export interface BriefFindings {
   approvalIntegrity?: ApprovalIntegrityFinding[];
   ciCheckSignals?: CiCheckSignalFinding[];
   undocumentedExport?: UndocumentedExportFinding[];
+  conflictMarker?: ConflictMarkerFinding[];
 }
 
 /** A JSDoc/TSDoc block whose `@param` tags name parameters the adjacent function no longer declares — a

--- a/review-enrichment/test/analyzer-registry.test.ts
+++ b/review-enrichment/test/analyzer-registry.test.ts
@@ -35,6 +35,7 @@ const EXPECTED_ANALYZERS = [
   "approvalIntegrity",
   "ciCheckSignals",
   "undocumentedExport",
+  "conflictMarker",
 ];
 
 test("analyzer descriptors cover the runtime registry in stable order", () => {

--- a/review-enrichment/test/conflict-marker.test.ts
+++ b/review-enrichment/test/conflict-marker.test.ts
@@ -1,0 +1,83 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  scanConflictMarkers,
+  scanPatchForConflictMarkers,
+} from "../dist/analyzers/conflict-marker.js";
+
+const hunk = (lines) =>
+  `@@ -1,0 +1,${lines.length} @@\n${lines.map((l) => `+${l}`).join("\n")}`;
+
+test("scanPatchForConflictMarkers flags each git conflict marker on added lines", () => {
+  const findings = scanPatchForConflictMarkers(
+    "src/app.ts",
+    hunk([
+      "<<<<<<< HEAD",
+      "const a = 1;",
+      "||||||| merged common ancestors",
+      "const a = 0;",
+      "=======",
+      "const a = 2;",
+      ">>>>>>> feature-branch",
+    ]),
+  );
+  assert.deepEqual(findings, [
+    { file: "src/app.ts", line: 1, marker: "<<<<<<<" },
+    { file: "src/app.ts", line: 3, marker: "|||||||" },
+    { file: "src/app.ts", line: 5, marker: "=======" },
+    { file: "src/app.ts", line: 7, marker: ">>>>>>>" },
+  ]);
+});
+
+test("scanPatchForConflictMarkers does not flag a bare ======= line in Markdown (setext underline / rule)", () => {
+  assert.deepEqual(
+    scanPatchForConflictMarkers("docs/readme.md", hunk(["Title", "======="])),
+    [],
+  );
+  // ...but the unambiguous ours/theirs markers are still flagged even inside a Markdown file.
+  assert.deepEqual(
+    scanPatchForConflictMarkers("docs/readme.md", hunk(["<<<<<<< HEAD"])),
+    [{ file: "docs/readme.md", line: 1, marker: "<<<<<<<" }],
+  );
+});
+
+test("scanPatchForConflictMarkers only scans added lines and requires exactly seven characters", () => {
+  // A context line carrying a marker shape is not flagged (only added lines count).
+  assert.deepEqual(
+    scanPatchForConflictMarkers("src/app.ts", "@@ -1,1 +1,1 @@\n =======").length,
+    0,
+  );
+  // Six or eight characters is not a git conflict marker (git writes exactly seven).
+  assert.deepEqual(
+    scanPatchForConflictMarkers(
+      "src/app.ts",
+      hunk(["<<<<<<", "<<<<<<<<", "======", "========", ">>>>>>", ">>>>>>>>"]),
+    ),
+    [],
+  );
+});
+
+test("scanPatchForConflictMarkers honors the maxFindings cap", () => {
+  const findings = scanPatchForConflictMarkers(
+    "src/a.ts",
+    hunk(["<<<<<<< a", ">>>>>>> b", "<<<<<<< c"]),
+    2,
+  );
+  assert.equal(findings.length, 2);
+});
+
+test("scanConflictMarkers scans every changed file and skips the Markdown separator", async () => {
+  const findings = await scanConflictMarkers({
+    files: [
+      { path: "src/a.ts", patch: hunk(["<<<<<<< HEAD"]) },
+      { path: "docs/x.md", patch: hunk(["======="]) }, // markup separator: not flagged
+      { path: "src/b.ts", patch: hunk([">>>>>>> theirs"]) },
+      { path: "src/c.ts" }, // no patch: skipped
+    ],
+  });
+  assert.deepEqual(findings, [
+    { file: "src/a.ts", line: 1, marker: "<<<<<<<" },
+    { file: "src/b.ts", line: 1, marker: ">>>>>>>" },
+  ]);
+});


### PR DESCRIPTION
## Summary

Fixes #2032.

Adds a new REES local analyzer (`conflictMarker`) that flags leftover VCS **merge-conflict markers**
(`<<<<<<<`, `|||||||`, `=======`, `>>>>>>>`) accidentally committed in a PR's added diff lines — a mechanical,
near-zero-false-positive catch that should block a merge. Pure compute, no network. Implemented exactly to the
issue's deliverables:

- **`ConflictMarkerFinding`** (`{ file, line, marker }`) + a `conflictMarker?` key added to
  `BriefFindings` in `review-enrichment/src/types.ts`.
- **`review-enrichment/src/analyzers/conflict-marker.ts`** — walks each changed file's unified-diff hunks and
  matches conflict-marker shapes on **added lines only**, line-cited via the hunk headers, capped with
  `maxFindings`. It reuses the established added-line hunk-walk (the same `\ No newline at end of file` /
  removed-line cursor handling as `actions-pin.ts` / `iac-misconfig.ts`).
- **Local descriptor** registered in `review-enrichment/src/analyzers/registry.ts` (`category: "quality"`,
  `cost: "local"`, `requires: ["files"]`) with an **inline `render()`**.
- **`review-enrichment/test/conflict-marker.test.ts`** — covers each marker flagged, a Markdown
  bare-`=======` line **not** flagged, added-only scoping, the exactly-seven-character requirement, and the
  cap.

### Precision (near-zero false positive)

Git writes conflict markers as **exactly seven** identical characters at column 0, so the regexes require
exactly seven (six or eight never match). The ours/base/theirs markers (`<<<<<<<` / `|||||||` / `>>>>>>>`) are
unambiguous — seven `<`/`|`/`>` at the start of a line is never valid prose or code — and are flagged in every
file type. The **only** ambiguous marker is the bare `=======` separator, which is a legitimate Markdown setext
heading underline / AsciiDoc rule; it is therefore **not** flagged in Markdown/AsciiDoc files (`.md`, `.mdx`,
`.rst`, `.adoc`, …), while a real conflict landing in such a file is still caught by its `<<<<<<<`/`>>>>>>>`.

### Generated files

`analyzer-metadata.json`, the UI mirror `apps/gittensory-ui/src/lib/rees-analyzers.ts`, and the `.env.example`
REES-analyzer list were regenerated by `npm run metadata` (the repo's own generator) to include the new
descriptor — they are generated artifacts kept in sync, not hand-edited. The hardcoded expected-analyzer list
in `test/analyzer-registry.test.ts` was extended with `conflictMarker` (the registry's stable-order guard).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run typecheck`
- [x] `npm run rees:test` — the review-enrichment build + metadata check + analyzer suite (see note)
- [ ] `npm run test:coverage` (N/A — this analyzer is in `review-enrichment/`, outside the root `src/**` Codecov scope)
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran locally: `git diff --check` (clean), the review-enrichment TypeScript build (exit 0), the metadata
  generator + **`metadata:check` (exit 0 — the committed metadata matches a fresh regeneration)**, and the
  full analyzer `node --test` suite. The new `conflict-marker` file passes 5/5, and the registry stable-order
  and metadata-coverage tests pass with the new descriptor.
- The only failing tests in the full run are the two `upload-sourcemaps` tests, which shell out to the Sentry
  CLI (absent on this dev box) and fail identically on unmodified `main` — unrelated to this change.
- Not run locally: the root typecheck and the UI build. The UI mirror and `.env.example` changes are produced
  by the repo's `npm run metadata` generator (the same generator CI's `metadata:check` runs), so they match
  what CI regenerates.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- The only UI change is the auto-generated analyzer catalog mirror (`rees-analyzers.ts`), emitted by
  `npm run metadata` alongside `analyzer-metadata.json`; it carries no runtime UI behavior of its own.
- The analyzer reports only `file:line` + the seven-character marker token — never the surrounding code.
