### PR TITLE
fix(api): gate HTTP reviewability behind static tokens and MCP allowlist

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -2580,7 +2580,11 @@ export function createApp() {
   });
 
   app.get("/v1/repos/:owner/:repo/pulls/:number/reviewability", async (c) => {
+    const unauthorized = await requireStaticProtectedApiToken(c);
+    if (unauthorized) return unauthorized;
     const fullName = `${c.req.param("owner")}/${c.req.param("repo")}`;
+    const identity = await authenticateRequestIdentity(c);
+    if (identity?.kind === "static" && identity.actor === "mcp" && !(await import("../auth/security")).isMcpReadRepoAllowed(c.env.MCP_READ_REPO_ALLOWLIST, fullName)) return c.json({ error: "forbidden_repo" }, 403);
     const number = Number(c.req.param("number"));
     if (!Number.isInteger(number) || number <= 0) return c.json({ error: "invalid_pull_number" }, 400);
     const [repo, pullRequest, issues, pullRequests, files, reviews, checks, recentMergedPullRequests] = await Promise.all([

--- a/test/integration/routes-errors.test.ts
+++ b/test/integration/routes-errors.test.ts
@@ -231,6 +231,10 @@ describe("api route guards and error branches", () => {
     expect(maintainerPacket.status).toBe(403);
     await expect(maintainerPacket.json()).resolves.toMatchObject({ error: "static_token_required" });
 
+    const reviewability = await app.request("/v1/repos/owner/private-repo/pulls/1/reviewability", { headers: sessionHeaders }, env);
+    expect(reviewability.status).toBe(403);
+    await expect(reviewability.json()).resolves.toMatchObject({ error: "static_token_required" });
+
     const staticTokenDecisionPack = await app.request("/v1/contributors/victim/decision-pack", { headers: apiHeaders(env) }, env);
     expect(staticTokenDecisionPack.status).toBe(200);
     await expect(staticTokenDecisionPack.json()).resolves.toMatchObject({ login: "victim", summary: "private advisory summary" });
@@ -337,6 +341,30 @@ describe("api route guards and error branches", () => {
     const denyEnv = createTestEnv({ MCP_READ_REPO_ALLOWLIST: "" });
     await upsertRepositoryFromGitHub(denyEnv, { name: "demo", full_name: "octo/demo", private: false, owner: { login: "octo" } });
     const denied = await app.request("/v1/repos/octo/demo/issue-quality", { headers: { authorization: `Bearer ${denyEnv.GITTENSORY_MCP_TOKEN}` } }, denyEnv);
+    expect(denied.status).toBe(403);
+    await expect(denied.json()).resolves.toMatchObject({ error: "forbidden_repo" });
+  });
+
+  it("blocks the shared MCP token from reading reviewability outside MCP_READ_REPO_ALLOWLIST (#2455 HTTP parity)", async () => {
+    const app = createApp();
+    const scopedEnv = createTestEnv({ MCP_READ_REPO_ALLOWLIST: "owner/private-repo" });
+    await upsertRepositoryFromGitHub(scopedEnv, { name: "private-repo", full_name: "owner/private-repo", private: true, owner: { login: "owner" } });
+    await upsertRepositoryFromGitHub(scopedEnv, { name: "other-repo", full_name: "other/other-repo", private: false, owner: { login: "other" } });
+    const mcpHeaders = { authorization: `Bearer ${scopedEnv.GITTENSORY_MCP_TOKEN}` };
+
+    const forbidden = await app.request("/v1/repos/other/other-repo/pulls/1/reviewability", { headers: mcpHeaders }, scopedEnv);
+    expect(forbidden.status).toBe(403);
+    await expect(forbidden.json()).resolves.toMatchObject({ error: "forbidden_repo" });
+
+    const allowlisted = await app.request("/v1/repos/owner/private-repo/pulls/1/reviewability", { headers: mcpHeaders }, scopedEnv);
+    expect(allowlisted.status).not.toBe(403);
+
+    const operator = await app.request("/v1/repos/other/other-repo/pulls/1/reviewability", { headers: apiHeaders(scopedEnv) }, scopedEnv);
+    expect(operator.status).not.toBe(403);
+
+    const denyEnv = createTestEnv({ MCP_READ_REPO_ALLOWLIST: "" });
+    await upsertRepositoryFromGitHub(denyEnv, { name: "demo", full_name: "octo/demo", private: false, owner: { login: "octo" } });
+    const denied = await app.request("/v1/repos/octo/demo/pulls/1/reviewability", { headers: { authorization: `Bearer ${denyEnv.GITTENSORY_MCP_TOKEN}` } }, denyEnv);
     expect(denied.status).toBe(403);
     await expect(denied.json()).resolves.toMatchObject({ error: "forbidden_repo" });
   });


### PR DESCRIPTION
## Summary

`GET /v1/repos/:owner/:repo/pulls/:number/reviewability` builds and persists `privateSummary`, outcome context, and maintainer next steps with **no** auth guard beyond generic bearer middleware. The sibling `maintainer-packet` route calls `requireStaticProtectedApiToken`, but reviewability allowed browser sessions and the shared `GITTENSORY_MCP_TOKEN` to read private maintainer signals for arbitrary repos/PRs.

This PR adds `requireStaticProtectedApiToken` and an MCP `MCP_READ_REPO_ALLOWLIST` check (inline dynamic import, same pattern as issue-quality/intelligence) before loading PR data. Operator-only `api` / `internal` tokens remain trusted.

## Changed files

| File | Change |
| ---- | ------ |
| `src/api/routes.ts` | `requireStaticProtectedApiToken` + MCP allowlist guard on reviewability. |
| `test/integration/routes-errors.test.ts` | Session → `static_token_required`; MCP scoped/empty allowlist → `forbidden_repo`; operator unchanged. |

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

No linked issue — auth regression on a maintainer-only PR signal route; behavior is fully described here and covered by regression tests.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally on `test/integration/routes-errors.test.ts`; **`codecov/patch` 100% (11/11)** on measured `src/api/routes.ts` diff
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries
