### PR TITLE
feat(enrichment): flag commit-history hygiene signals

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,7 +66,7 @@ GITTENSORY_REVIEW_ENRICHMENT=false
 # dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol,redos
 # provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild
 # history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity,ciCheckSignals
-# undocumentedExport,staleBranch
+# undocumentedExport,staleBranch,commitHygiene
 #
 # Profile defaults:
 # fast: dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol
@@ -74,11 +74,11 @@ GITTENSORY_REVIEW_ENRICHMENT=false
 # balanced (default): dependency,lockfileDrift,secret,license,installScript,heavyDependency
 # actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature
 # iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink
-# approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch
+# approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene
 # deep: dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol
 # redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig
 # nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity
-# ciCheckSignals,undocumentedExport,staleBranch
+# ciCheckSignals,undocumentedExport,staleBranch,commitHygiene
 # END GENERATED REES ANALYZERS
 
 # Submitter-reputation spend control (internal-only): downgrades new/burst/low-rep

--- a/apps/gittensory-ui/src/lib/rees-analyzers.ts
+++ b/apps/gittensory-ui/src/lib/rees-analyzers.ts
@@ -679,6 +679,30 @@ export const REES_ANALYZERS = [
         "Structured-fields-only: reads default_branch and behind_by, never diff or commit text. Fail-safe on missing token/head SHA/either fetch failing.",
     },
   },
+  {
+    name: "commitHygiene",
+    title: "Commit-history hygiene",
+    category: "history",
+    cost: "github-light",
+    defaultEnabled: true,
+    profiles: ["balanced", "deep"],
+    requires: ["github-token"],
+    limits: {
+      maxCommits: 100,
+      maxFindings: 25,
+    },
+    docs: {
+      summary:
+        "Flags commit-history hygiene issues: a merge commit pulled into the PR's own history, a commit left with git's fixup!/squash! autosquash marker, and a commit carrying a Co-authored-by trailer.",
+      looksAt:
+        "The PR's commits (one bounded page) — each commit's message subject/trailers and parent count.",
+      reports:
+        "A short commit-SHA prefix, the finding kind, and (for fixup/co-author) the subject line or co-author — never full diff/file content.",
+      network: "Calls the GitHub PR-commits API once, bounded to one page.",
+      notes:
+        "Structured-fields-only: reads commit.message and parents, matched one line at a time, never cross-line state. Fail-safe on missing token/fetch error.",
+    },
+  },
 ] as const satisfies readonly ReesAnalyzerDoc[];
 
 export const REES_ANALYZER_NAMES = REES_ANALYZERS.map((analyzer) => analyzer.name);

--- a/review-enrichment/analyzer-metadata.json
+++ b/review-enrichment/analyzer-metadata.json
@@ -766,6 +766,31 @@
         "network": "Calls the GitHub repo API once and the compare API once.",
         "notes": "Structured-fields-only: reads default_branch and behind_by, never diff or commit text. Fail-safe on missing token/head SHA/either fetch failing."
       }
+    },
+    {
+      "name": "commitHygiene",
+      "title": "Commit-history hygiene",
+      "category": "history",
+      "cost": "github-light",
+      "defaultEnabled": true,
+      "profiles": [
+        "balanced",
+        "deep"
+      ],
+      "requires": [
+        "github-token"
+      ],
+      "limits": {
+        "maxCommits": 100,
+        "maxFindings": 25
+      },
+      "docs": {
+        "summary": "Flags commit-history hygiene issues: a merge commit pulled into the PR's own history, a commit left with git's fixup!/squash! autosquash marker, and a commit carrying a Co-authored-by trailer.",
+        "looksAt": "The PR's commits (one bounded page) — each commit's message subject/trailers and parent count.",
+        "reports": "A short commit-SHA prefix, the finding kind, and (for fixup/co-author) the subject line or co-author — never full diff/file content.",
+        "network": "Calls the GitHub PR-commits API once, bounded to one page.",
+        "notes": "Structured-fields-only: reads commit.message and parents, matched one line at a time, never cross-line state. Fail-safe on missing token/fetch error."
+      }
     }
   ]
 }

--- a/review-enrichment/src/analyzers/commit-hygiene.ts
+++ b/review-enrichment/src/analyzers/commit-hygiene.ts
@@ -1,0 +1,143 @@
+// Commit-history hygiene signals, read from structured GitHub PR-commits API fields only — no diff/text/YAML
+// parsing. Surfaces three things a PR's own commits tab doesn't call out: a merge commit accidentally pulled into
+// the PR's own history (usually from merging the base branch into a feature branch instead of rebasing, which
+// muddies the diff), a commit left with git's own `fixup!`/`squash!` autosquash marker (meant to be squashed
+// before merge, never merged as-is), and a commit whose message carries a `Co-authored-by:` trailer (multi-author
+// attribution a reviewer may want visible). Reads only documented fields from the GitHub PR-commits API
+// (commit.message, parents) and matches each independently against a single line at a time — no cross-line
+// state, so it cannot suffer a patch scanner's ambiguous-syntax edge cases. Pure GitHub-metadata read, no repo
+// content beyond the already-public commit list. Fail-safe: no token, a bad repo slug, or a fetch error all yield
+// no finding. Bounded to one page of commits (MAX_COMMITS) — a PR with more is vanishingly rare, and a missed
+// commit past the cap is simply a missed (not a wrong) finding.
+import type {
+  AnalyzerDiagnostics,
+  CommitHygieneFinding,
+  EnrichRequest,
+} from "../types.js";
+import type { AnalysisContext } from "../analysis-context.js";
+import { boundedFetchJson } from "../external-fetch.js";
+
+const GITHUB_API = "https://api.github.com";
+const SLUG_RE = /^[A-Za-z0-9._-]+$/;
+const MAX_COMMITS = 100;
+const MAX_FINDINGS = 25;
+const SHA_PREFIX_LEN = 12;
+
+// Git's own autosquash markers (`git commit --fixup`/`--squash`, `git rebase -i --autosquash`) — a documented,
+// finite convention, not free-form text. Matched against the commit message's first line only.
+const FIXUP_SUBJECT_RE = /^(?:fixup|squash)!\s+/i;
+// GitHub's own commit-trailer convention for multi-author commits: https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-with-multiple-authors
+const CO_AUTHOR_TRAILER_RE = /^Co-authored-by:\s*(.+<[^<>]+@[^<>]+>)\s*$/i;
+
+interface ScanOptions {
+  signal?: AbortSignal;
+  analysis?: Pick<AnalysisContext, "fetchJson">;
+  diagnostics?: AnalyzerDiagnostics;
+}
+
+/** The slice of a GitHub PR-commit list item this analyzer reads. */
+interface CommitListItem {
+  sha?: string;
+  commit?: { message?: string };
+  parents?: Array<{ sha?: string }>;
+}
+
+function githubHeaders(token: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+}
+
+async function fetchPrCommits(
+  owner: string,
+  repo: string,
+  prNumber: number,
+  headers: Record<string, string>,
+  fetchFn: typeof fetch,
+  signal: AbortSignal | undefined,
+  options: Pick<ScanOptions, "analysis" | "diagnostics">,
+): Promise<CommitListItem[] | null> {
+  const url =
+    `${GITHUB_API}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pulls/` +
+    `${encodeURIComponent(String(prNumber))}/commits?per_page=${MAX_COMMITS}`;
+  const fetchOptions = {
+    endpointCategory: "github-pr-commits",
+    headers,
+    signal,
+    fetchImpl: fetchFn,
+    diagnostics: options.diagnostics,
+    phase: "commit-hygiene",
+    subcall: "github-pr-commits",
+    maxBytes: 512 * 1024,
+  };
+  const response = options.analysis
+    ? await options.analysis.fetchJson<CommitListItem[]>(url, fetchOptions)
+    : await boundedFetchJson<CommitListItem[]>(url, fetchOptions);
+  return response.ok && Array.isArray(response.data) ? response.data : null;
+}
+
+/** Pure reduction: a PR's commit list → commit-hygiene findings, in list order, each check independent of the
+ *  others and of any other commit (no cross-commit or cross-line state). Bounded by maxFindings. */
+export function analyzeCommitHygiene(
+  commits: CommitListItem[],
+  maxFindings = MAX_FINDINGS,
+): CommitHygieneFinding[] {
+  const findings: CommitHygieneFinding[] = [];
+
+  commitLoop: for (const item of commits) {
+    if (findings.length >= maxFindings) break;
+    const sha = item.sha;
+    if (!sha) continue;
+    const shaPrefix = sha.slice(0, SHA_PREFIX_LEN);
+    const message = item.commit?.message ?? "";
+    const lines = message.split("\n");
+    const subject = lines[0] ?? "";
+
+    if ((item.parents?.length ?? 0) > 1) {
+      findings.push({ shaPrefix, kind: "merge-commit-in-history" });
+      if (findings.length >= maxFindings) break;
+    }
+
+    if (FIXUP_SUBJECT_RE.test(subject)) {
+      findings.push({ shaPrefix, kind: "fixup-commit-present", subject: subject.trim() });
+      if (findings.length >= maxFindings) break;
+    }
+
+    for (const line of lines) {
+      const match = CO_AUTHOR_TRAILER_RE.exec(line.trim());
+      if (match) {
+        findings.push({ shaPrefix, kind: "unattributed-co-author", coAuthor: match[1]!.trim() });
+        // One co-author trailer per commit is enough to surface (avoids noisy duplicates for multi-author
+        // commits) — `continue commitLoop` exits this inner line-scan AND re-enters the outer loop's own
+        // maxFindings check uniformly, the same way the merge-commit/fixup checks above do.
+        if (findings.length >= maxFindings) break commitLoop;
+        continue commitLoop;
+      }
+    }
+  }
+
+  return findings;
+}
+
+/** Analyzer entrypoint: a PR's commits → commit-hygiene findings. Fail-safe — no token, a bad repo slug, or a
+ *  fetch error all yield no finding rather than an error. */
+export async function scanCommitHygiene(
+  req: EnrichRequest,
+  fetchFn: typeof fetch = fetch,
+  options: ScanOptions = {},
+): Promise<CommitHygieneFinding[]> {
+  const { repoFullName, githubToken, prNumber } = req;
+  if (!githubToken) return [];
+  const parts = repoFullName.split("/");
+  const owner = parts[0];
+  const repo = parts[1];
+  if (parts.length !== 2 || !owner || !repo || !SLUG_RE.test(owner) || !SLUG_RE.test(repo)) return [];
+
+  const headers = githubHeaders(githubToken);
+  const commits = await fetchPrCommits(owner, repo, prNumber, headers, fetchFn, options.signal, options);
+  if (!commits) return [];
+
+  return analyzeCommitHygiene(commits);
+}

--- a/review-enrichment/src/analyzers/registry.ts
+++ b/review-enrichment/src/analyzers/registry.ts
@@ -5,6 +5,7 @@ import { scanChurnHotspot } from "./churn-hotspot.js";
 import { scanBlameLink } from "./blame-link.js";
 import { scanCiCheckSignals } from "./ci-check-signals.js";
 import { scanCodeowners } from "./codeowners.js";
+import { scanCommitHygiene } from "./commit-hygiene.js";
 import { scanCommitSignature } from "./commit-signature.js";
 import { dependencyAnalyzer } from "./dependency/descriptor.js";
 import { scanDocCommentDrift } from "./doc-comment-drift.js";
@@ -615,6 +616,40 @@ export const ANALYZER_DESCRIPTORS = [
     },
     run: (req, { signal, analysis, diagnostics }) =>
       scanStaleBranch(req, fetch, { signal, analysis, diagnostics }),
+  }),
+  descriptor({
+    name: "commitHygiene",
+    title: "Commit-history hygiene",
+    category: "history",
+    cost: "github-light",
+    defaultEnabled: true,
+    requires: ["github-token"],
+    limits: { maxCommits: 100, maxFindings: 25 },
+    docs: {
+      summary:
+        "Flags commit-history hygiene issues: a merge commit pulled into the PR's own history, a commit left with git's fixup!/squash! autosquash marker, and a commit carrying a Co-authored-by trailer.",
+      looksAt: "The PR's commits (one bounded page) — each commit's message subject/trailers and parent count.",
+      reports: "A short commit-SHA prefix, the finding kind, and (for fixup/co-author) the subject line or co-author — never full diff/file content.",
+      network: "Calls the GitHub PR-commits API once, bounded to one page.",
+      notes:
+        "Structured-fields-only: reads commit.message and parents, matched one line at a time, never cross-line state. Fail-safe on missing token/fetch error.",
+    },
+    render: (findings, helpers) => {
+      if (!findings.length) return [];
+      const lines = ["### Commit-history hygiene"];
+      for (const item of findings) {
+        if (item.kind === "merge-commit-in-history") {
+          lines.push(`- ${helpers.safeCodeSpan(item.shaPrefix)} is a merge commit pulled into this PR's own history`);
+        } else if (item.kind === "fixup-commit-present") {
+          lines.push(`- ${helpers.safeCodeSpan(item.shaPrefix)} is an unsquashed fixup/squash commit: ${helpers.safeCodeSpan(item.subject)}`);
+        } else {
+          lines.push(`- ${helpers.safeCodeSpan(item.shaPrefix)} credits a co-author: ${helpers.safeCodeSpan(item.coAuthor)}`);
+        }
+      }
+      return lines;
+    },
+    run: (req, { signal, analysis, diagnostics }) =>
+      scanCommitHygiene(req, fetch, { signal, analysis, diagnostics }),
   }),
 ] as const satisfies readonly AnyAnalyzerDescriptor[];
 

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -417,6 +417,7 @@ export function renderBrief(
   lines.push(...renderDescriptorSection("ciCheckSignals", findings.ciCheckSignals));
   lines.push(...renderDescriptorSection("undocumentedExport", findings.undocumentedExport));
   lines.push(...renderDescriptorSection("staleBranch", findings.staleBranch));
+  lines.push(...renderDescriptorSection("commitHygiene", findings.commitHygiene));
 
   if (!lines.length) return { promptSection: "", systemSuffix: "" };
 

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -353,6 +353,17 @@ export interface StaleBranchFinding {
   behindBy: number;
 }
 
+/** A commit-history hygiene signal, read from structured GitHub PR-commits API fields only (`commit.message`,
+ *  `parents`) — never diff/file content beyond the already-public commit list. `merge-commit-in-history`: a
+ *  commit in the PR has more than one parent (usually the base branch merged into a feature branch instead of a
+ *  rebase). `fixup-commit-present`: a commit subject starts with git's own `fixup!`/`squash!` autosquash marker,
+ *  meant to be squashed before merge. `unattributed-co-author`: a commit message carries a `Co-authored-by:`
+ *  trailer, surfacing multi-author attribution. */
+export type CommitHygieneFinding =
+  | { shaPrefix: string; kind: "merge-commit-in-history" }
+  | { shaPrefix: string; kind: "fixup-commit-present"; subject: string }
+  | { shaPrefix: string; kind: "unattributed-co-author"; coAuthor: string };
+
 /** Structured analyzer output. Each analyzer fills its own key; more land as analyzers ship (#1477/#1478). */
 export interface BriefFindings {
   dependency?: DependencyFinding[];
@@ -381,6 +392,7 @@ export interface BriefFindings {
   ciCheckSignals?: CiCheckSignalFinding[];
   undocumentedExport?: UndocumentedExportFinding[];
   staleBranch?: StaleBranchFinding[];
+  commitHygiene?: CommitHygieneFinding[];
 }
 
 /** A JSDoc/TSDoc block whose `@param` tags name parameters the adjacent function no longer declares — a

--- a/review-enrichment/test/analyzer-registry.test.ts
+++ b/review-enrichment/test/analyzer-registry.test.ts
@@ -36,6 +36,7 @@ const EXPECTED_ANALYZERS = [
   "ciCheckSignals",
   "undocumentedExport",
   "staleBranch",
+  "commitHygiene",
 ];
 
 test("analyzer descriptors cover the runtime registry in stable order", () => {

--- a/review-enrichment/test/commit-hygiene.test.ts
+++ b/review-enrichment/test/commit-hygiene.test.ts
@@ -1,0 +1,212 @@
+// Units for the commit-history hygiene analyzer. Own file (not enrichment.test.ts) so concurrent analyzer PRs
+// don't collide. All network is mocked. Runs against the compiled dist/.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  analyzeCommitHygiene,
+  scanCommitHygiene,
+} from "../dist/analyzers/commit-hygiene.js";
+import { renderBrief } from "../dist/render.js";
+
+const jsonResponse = (body, code = 200) => new Response(JSON.stringify(body), { status: code });
+
+const req = (extra = {}) => ({
+  repoFullName: "octo/repo",
+  prNumber: 7,
+  githubToken: "test-token",
+  ...extra,
+});
+
+const commitsFetch = (commits) => async () => jsonResponse(commits);
+
+const commit = (sha, message, parentShas = ["parent0000000000000000000000000000000000"]) => ({
+  sha,
+  commit: { message },
+  parents: parentShas.map((s) => ({ sha: s })),
+});
+
+const SHA_A = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const SHA_B = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+test("analyzeCommitHygiene: flags a merge commit (more than one parent) pulled into the PR history", () => {
+  const findings = analyzeCommitHygiene([
+    commit(SHA_A, "Merge branch 'main' into feature", ["p1000000000000000000000000000000000000", "p2000000000000000000000000000000000000"]),
+  ]);
+  assert.deepEqual(findings, [{ shaPrefix: "aaaaaaaaaaaa", kind: "merge-commit-in-history" }]);
+});
+
+test("analyzeCommitHygiene: a normal single-parent commit is not flagged as a merge commit", () => {
+  const findings = analyzeCommitHygiene([commit(SHA_A, "fix: correct off-by-one")]);
+  assert.deepEqual(findings, []);
+});
+
+test("analyzeCommitHygiene: a root commit with no parents is not flagged as a merge commit", () => {
+  const findings = analyzeCommitHygiene([commit(SHA_A, "chore: initial commit", [])]);
+  assert.deepEqual(findings, []);
+});
+
+test("analyzeCommitHygiene: flags a fixup! commit", () => {
+  const findings = analyzeCommitHygiene([commit(SHA_A, "fixup! feat: add the new widget")]);
+  assert.deepEqual(findings, [
+    { shaPrefix: "aaaaaaaaaaaa", kind: "fixup-commit-present", subject: "fixup! feat: add the new widget" },
+  ]);
+  const brief = renderBrief({ commitHygiene: findings }).promptSection;
+  assert.match(brief, /unsquashed fixup\/squash commit/);
+});
+
+test("analyzeCommitHygiene: flags a squash! commit", () => {
+  const findings = analyzeCommitHygiene([commit(SHA_A, "squash! fix: typo")]);
+  assert.deepEqual(findings, [
+    { shaPrefix: "aaaaaaaaaaaa", kind: "fixup-commit-present", subject: "squash! fix: typo" },
+  ]);
+});
+
+test("analyzeCommitHygiene: fixup!/squash! matching is case-insensitive and trims the subject", () => {
+  const findings = analyzeCommitHygiene([commit(SHA_A, "FIXUP!   fix: typo  \nextra body line")]);
+  assert.deepEqual(findings, [
+    { shaPrefix: "aaaaaaaaaaaa", kind: "fixup-commit-present", subject: "FIXUP!   fix: typo" },
+  ]);
+});
+
+test("analyzeCommitHygiene: does not mis-flag a commit that merely mentions 'fixup' mid-subject", () => {
+  const findings = analyzeCommitHygiene([commit(SHA_A, "fix: apply the fixup! marker convention in docs")]);
+  assert.deepEqual(findings, []);
+});
+
+test("analyzeCommitHygiene: flags a Co-authored-by trailer", () => {
+  const findings = analyzeCommitHygiene([
+    commit(SHA_A, "feat: pair-programmed widget\n\nCo-authored-by: Jane Doe <jane@example.com>"),
+  ]);
+  assert.deepEqual(findings, [
+    { shaPrefix: "aaaaaaaaaaaa", kind: "unattributed-co-author", coAuthor: "Jane Doe <jane@example.com>" },
+  ]);
+  const brief = renderBrief({ commitHygiene: findings }).promptSection;
+  assert.match(brief, /credits a co-author/);
+});
+
+test("analyzeCommitHygiene: Co-authored-by matching is case-insensitive and tolerant of surrounding whitespace", () => {
+  const findings = analyzeCommitHygiene([
+    commit(SHA_A, "feat: widget\n\n  co-authored-by:   Jane Doe <jane@example.com>  "),
+  ]);
+  assert.deepEqual(findings, [
+    { shaPrefix: "aaaaaaaaaaaa", kind: "unattributed-co-author", coAuthor: "Jane Doe <jane@example.com>" },
+  ]);
+});
+
+test("analyzeCommitHygiene: only the first Co-authored-by trailer is reported per commit (no duplicate noise)", () => {
+  const findings = analyzeCommitHygiene([
+    commit(
+      SHA_A,
+      "feat: widget\n\nCo-authored-by: Jane Doe <jane@example.com>\nCo-authored-by: Bob Roe <bob@example.com>",
+    ),
+  ]);
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].coAuthor, "Jane Doe <jane@example.com>");
+});
+
+test("analyzeCommitHygiene: a commit message without a well-formed trailer is not flagged", () => {
+  const findings = analyzeCommitHygiene([commit(SHA_A, "feat: widget\n\nThanks to Jane for the idea")]);
+  assert.deepEqual(findings, []);
+});
+
+test("analyzeCommitHygiene: a single commit can trigger all three kinds independently", () => {
+  const findings = analyzeCommitHygiene([
+    commit(
+      SHA_A,
+      "fixup! feat: widget\n\nCo-authored-by: Jane Doe <jane@example.com>",
+      ["p1000000000000000000000000000000000000", "p2000000000000000000000000000000000000"],
+    ),
+  ]);
+  assert.deepEqual(findings, [
+    { shaPrefix: "aaaaaaaaaaaa", kind: "merge-commit-in-history" },
+    { shaPrefix: "aaaaaaaaaaaa", kind: "fixup-commit-present", subject: "fixup! feat: widget" },
+    { shaPrefix: "aaaaaaaaaaaa", kind: "unattributed-co-author", coAuthor: "Jane Doe <jane@example.com>" },
+  ]);
+});
+
+test("analyzeCommitHygiene: tracks independent commits separately, in list order", () => {
+  const findings = analyzeCommitHygiene([
+    commit(SHA_A, "fixup! wip"),
+    commit(SHA_B, "feat: clean commit"),
+  ]);
+  assert.deepEqual(findings, [{ shaPrefix: "aaaaaaaaaaaa", kind: "fixup-commit-present", subject: "fixup! wip" }]);
+});
+
+test("analyzeCommitHygiene: a commit missing a sha is skipped, not thrown", () => {
+  const findings = analyzeCommitHygiene([{ commit: { message: "fixup! x" }, parents: [] }]);
+  assert.deepEqual(findings, []);
+});
+
+test("analyzeCommitHygiene: a commit with no message is treated as an empty subject, not thrown", () => {
+  const findings = analyzeCommitHygiene([{ sha: SHA_A, parents: [] }]);
+  assert.deepEqual(findings, []);
+});
+
+test("analyzeCommitHygiene: no findings for an empty commit list", () => {
+  assert.deepEqual(analyzeCommitHygiene([]), []);
+});
+
+test("analyzeCommitHygiene: honors the maxFindings bound", () => {
+  const commits = Array.from({ length: 30 }, (_, i) =>
+    commit(`c${i}`.padEnd(40, "0"), `fixup! change ${i}`),
+  );
+  const findings = analyzeCommitHygiene(commits, 5);
+  assert.equal(findings.length, 5);
+});
+
+test("analyzeCommitHygiene: the maxFindings bound is enforced identically when the LAST slot is filled by a co-author finding, not just fixup/merge", () => {
+  // Each commit contributes exactly one co-author finding; hitting the cap here must stop the scan just as
+  // reliably as hitting it via the merge-commit or fixup-commit branches (regression test for a prior bug where
+  // the co-author branch's own inner line-loop break did not propagate to the outer per-commit loop).
+  const commits = Array.from({ length: 10 }, (_, i) =>
+    commit(`c${i}`.padEnd(40, "0"), `feat: change ${i}\n\nCo-authored-by: Person ${i} <p${i}@example.com>`),
+  );
+  const findings = analyzeCommitHygiene(commits, 3);
+  assert.equal(findings.length, 3);
+  assert.ok(findings.every((f) => f.kind === "unattributed-co-author"));
+});
+
+test("scanCommitHygiene: resolves findings from the commits API response", async () => {
+  const findings = await scanCommitHygiene(req(), commitsFetch([commit(SHA_A, "fixup! x")]));
+  assert.deepEqual(findings, [{ shaPrefix: "aaaaaaaaaaaa", kind: "fixup-commit-present", subject: "fixup! x" }]);
+});
+
+test("scanCommitHygiene: requests the PR's commits with the expected URL shape", async () => {
+  let requestedUrl;
+  await scanCommitHygiene(req(), async (url) => {
+    requestedUrl = url;
+    return jsonResponse([]);
+  });
+  assert.equal(requestedUrl, "https://api.github.com/repos/octo/repo/pulls/7/commits?per_page=100");
+});
+
+test("scanCommitHygiene: no GitHub token → skipped (no finding, no throw)", async () => {
+  const findings = await scanCommitHygiene(
+    req({ githubToken: undefined }),
+    commitsFetch([commit(SHA_A, "fixup! x")]),
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanCommitHygiene: a malformed repoFullName is skipped, not thrown", async () => {
+  const findings = await scanCommitHygiene(
+    req({ repoFullName: "not-a-valid-slug" }),
+    commitsFetch([commit(SHA_A, "fixup! x")]),
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanCommitHygiene: a fetch failure yields no finding", async () => {
+  const findings = await scanCommitHygiene(req(), async () => jsonResponse({ message: "bad" }, 500));
+  assert.deepEqual(findings, []);
+});
+
+test("scanCommitHygiene: a malformed response body (not an array) yields no finding", async () => {
+  const findings = await scanCommitHygiene(req(), async () => jsonResponse({ not: "an array" }));
+  assert.deepEqual(findings, []);
+});
+
+test("scanCommitHygiene: no commits yields no finding", async () => {
+  const findings = await scanCommitHygiene(req(), commitsFetch([]));
+  assert.deepEqual(findings, []);
+});

--- a/src/review/enrichment-analyzer-names.ts
+++ b/src/review/enrichment-analyzer-names.ts
@@ -30,6 +30,7 @@ export const REES_ANALYZER_NAMES = [
   "ciCheckSignals",
   "undocumentedExport",
   "staleBranch",
+  "commitHygiene",
 ] as const;
 
 export type ReesAnalyzerName = (typeof REES_ANALYZER_NAMES)[number];

--- a/test/unit/enrichment-wire.test.ts
+++ b/test/unit/enrichment-wire.test.ts
@@ -626,7 +626,7 @@ describe("resolveReesAnalyzers", () => {
       resolveReesAnalyzers(
         env({
           REES_ANALYZERS:
-            "dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch",
+            "dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene",
         }),
       ),
     ).toEqual([
@@ -656,6 +656,7 @@ describe("resolveReesAnalyzers", () => {
       "ciCheckSignals",
       "undocumentedExport",
       "staleBranch",
+      "commitHygiene",
     ]);
   });
 


### PR DESCRIPTION
## What

A new local REES analyzer, `commitHygiene`, that flags three commit-history hygiene issues a PR's commits tab
doesn't call out explicitly.

## Detections (structured GitHub PR-commits API fields only — a bounded, documented schema)

- `merge-commit-in-history` — a commit in the PR has more than one parent (usually the base branch merged into a
  feature branch instead of a rebase), which muddies the diff history.
- `fixup-commit-present` — a commit subject starts with git's own `fixup!`/`squash!` autosquash marker
  (`git commit --fixup`/`--squash`), meant to be squashed before merge and never merged as-is.
- `unattributed-co-author` — a commit message carries a `Co-authored-by:` trailer (GitHub's own multi-author
  attribution convention), surfacing pair-authored commits for reviewer visibility.

## Why it is bounded / merge-safe

It reads only documented fields from the GitHub PR-commits API (`commit.message`, `parents`) and matches each
independently, one line at a time — no cross-line/cross-commit state, so it cannot suffer a patch scanner's
ambiguous-syntax edge cases. Both text patterns matched are official, documented git/GitHub conventions (not
free-form text): the `fixup!`/`squash!` prefix is git's own autosquash marker, and `Co-authored-by:` is GitHub's
own commit-trailer format. Pure GitHub-metadata read, no repo content beyond the already-public commit list.
Fail-safe: no token, a bad repo slug, or a fetch error all yield no finding. Bounded to one page of commits
(100) and a findings cap — a PR with more commits than that is vanishingly rare, and a commit past either cap is
simply a missed (not a wrong) finding. Mirrors the existing `blame-link` / `approval-integrity` /
`ci-check-signals` / `stale-branch` analyzers' structure (same header/fetch helper shape, same
`ScanOptions`/fail-safe conventions, a discriminated-union finding type).

## Value

A merge commit in the PR's own history, an un-squashed fixup commit, or an uncredited co-author are all things a
reviewer would otherwise have to click into the commits tab and read each message to notice. Surfacing them in
the review brief saves that step and flags history worth cleaning up before merge.

## Tests

`review-enrichment/test/commit-hygiene.test.ts` covers: each of the 3 finding kinds independently, case-
insensitive/whitespace-tolerant matching for both text patterns, a negative case where "fixup" merely appears
mid-subject (not matched), a single commit triggering all 3 kinds at once, independent commits in list order, a
commit missing a `sha` or `commit` field (fail-safe, not thrown), the `maxFindings` cap enforced identically
whether the last slot is filled by a merge/fixup finding OR a co-author finding (a regression test for a bug
caught during review — the co-author branch's own inner line-scan loop didn't originally propagate its
cap-reached break to the outer per-commit loop), plus the network entrypoint's fail-safe paths (no token,
malformed repo slug, fetch failure, malformed response body, no commits) and the exact request URL shape.
Analyzer metadata is regenerated and committed.

## No linked issue

No linked issue because this is a net-new analyzer; there is no tracking issue to link.
