### PR TITLE
feat(enrichment): exported-API breaking-change detector

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,7 +66,7 @@ GITTENSORY_REVIEW_ENRICHMENT=false
 # dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol,redos
 # provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild
 # history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity,ciCheckSignals
-# undocumentedExport,staleBranch,commitHygiene
+# undocumentedExport,staleBranch,commitHygiene,apiBreakingChange
 #
 # Profile defaults:
 # fast: dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol
@@ -75,10 +75,11 @@ GITTENSORY_REVIEW_ENRICHMENT=false
 # actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature
 # iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink
 # approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene
+# apiBreakingChange
 # deep: dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol
 # redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig
 # nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity
-# ciCheckSignals,undocumentedExport,staleBranch,commitHygiene
+# ciCheckSignals,undocumentedExport,staleBranch,commitHygiene,apiBreakingChange
 # END GENERATED REES ANALYZERS
 
 # Submitter-reputation spend control (internal-only): downgrades new/burst/low-rep

--- a/apps/gittensory-ui/src/lib/rees-analyzers.ts
+++ b/apps/gittensory-ui/src/lib/rees-analyzers.ts
@@ -703,6 +703,31 @@ export const REES_ANALYZERS = [
         "Structured-fields-only: reads commit.message and parents, matched one line at a time, never cross-line state. Fail-safe on missing token/fetch error.",
     },
   },
+  {
+    name: "apiBreakingChange",
+    title: "Exported-API breaking changes",
+    category: "supply-chain",
+    cost: "github-heavy",
+    defaultEnabled: true,
+    profiles: ["balanced", "deep"],
+    requires: ["files", "github-token", "head-sha", "public-network"],
+    limits: {
+      maxFiles: 10,
+      maxFindings: 30,
+    },
+    docs: {
+      summary:
+        "Flags an exported symbol removed or signature-changed at a package's public TypeScript entrypoint that is still part of the currently-published npm type surface — a downstream break.",
+      looksAt:
+        "Removed/added `export` declarations in changed `index.*` or `.d.ts` entrypoints, the owning package.json resolved at headSha, and the latest published `.d.ts` from npm + unpkg.",
+      reports:
+        "The entrypoint file, symbol, change kind (removed or signature-changed), and the package name + currently-published version — never file contents.",
+      network:
+        "One GitHub contents fetch per candidate to resolve the package.json (requires headSha and token forwarding for private repos), plus the npm registry and unpkg for the published type surface.",
+      notes:
+        "Conservative: a symbol removed AND re-added with an identical declaration is not a break; only symbols still present in the published surface are reported. Fail-safe on any missing input or fetch error.",
+    },
+  },
 ] as const satisfies readonly ReesAnalyzerDoc[];
 
 export const REES_ANALYZER_NAMES = REES_ANALYZERS.map((analyzer) => analyzer.name);

--- a/review-enrichment/analyzer-metadata.json
+++ b/review-enrichment/analyzer-metadata.json
@@ -791,6 +791,34 @@
         "network": "Calls the GitHub PR-commits API once, bounded to one page.",
         "notes": "Structured-fields-only: reads commit.message and parents, matched one line at a time, never cross-line state. Fail-safe on missing token/fetch error."
       }
+    },
+    {
+      "name": "apiBreakingChange",
+      "title": "Exported-API breaking changes",
+      "category": "supply-chain",
+      "cost": "github-heavy",
+      "defaultEnabled": true,
+      "profiles": [
+        "balanced",
+        "deep"
+      ],
+      "requires": [
+        "files",
+        "github-token",
+        "head-sha",
+        "public-network"
+      ],
+      "limits": {
+        "maxFiles": 10,
+        "maxFindings": 30
+      },
+      "docs": {
+        "summary": "Flags an exported symbol removed or signature-changed at a package's public TypeScript entrypoint that is still part of the currently-published npm type surface — a downstream break.",
+        "looksAt": "Removed/added `export` declarations in changed `index.*` or `.d.ts` entrypoints, the owning package.json resolved at headSha, and the latest published `.d.ts` from npm + unpkg.",
+        "reports": "The entrypoint file, symbol, change kind (removed or signature-changed), and the package name + currently-published version — never file contents.",
+        "network": "One GitHub contents fetch per candidate to resolve the package.json (requires headSha and token forwarding for private repos), plus the npm registry and unpkg for the published type surface.",
+        "notes": "Conservative: a symbol removed AND re-added with an identical declaration is not a break; only symbols still present in the published surface are reported. Fail-safe on any missing input or fetch error."
+      }
     }
   ]
 }

--- a/review-enrichment/src/analyzers/api-breaking-change.ts
+++ b/review-enrichment/src/analyzers/api-breaking-change.ts
@@ -1,0 +1,321 @@
+// Exported-API breaking-change detector (#1510). Flags a PR that REMOVES or SIGNATURE-CHANGES an exported symbol from
+// a package's public TypeScript entrypoint (`index.*` barrel or a `.d.ts` surface) when that symbol is still part of
+// the package's CURRENTLY-PUBLISHED type surface — i.e. a downstream break for consumers on the latest npm release.
+// It reads removed/added export declarations from the diff, resolves the owning package.json at headSha (one authed
+// contents fetch, walking up to the nearest ancestor manifest), then fetches the latest published `.d.ts` from npm +
+// unpkg to confirm the symbol is public today. Deliberately conservative + fail-safe: a missing token/head-sha, an
+// unresolvable repo slug or package, or any fetch error yields no finding rather than an error. A symbol removed AND
+// re-added with an identical declaration is NOT a break; re-added with a changed declaration body is a signature change.
+import type { ApiBreakingChangeFinding, EnrichRequest } from "../types.js";
+import { isDiffFileHeaderLine } from "./diff-lines.js";
+import { exportedSymbols } from "./undocumented-export.js";
+
+const GITHUB_API = "https://api.github.com";
+const NPM_REGISTRY = "https://registry.npmjs.org";
+const UNPKG = "https://unpkg.com";
+const MAX_FILES = 10;
+const MAX_FINDINGS = 30;
+const MAX_FETCH_BYTES = 1_000_000;
+// How many ancestor directories above the entrypoint's own directory to probe for the owning package.json.
+const MAX_PACKAGE_ANCESTORS = 3;
+const SLUG_RE = /^[A-Za-z0-9._-]+$/;
+// A public TypeScript entrypoint: an `index.<ts/tsx/mts/cts>` barrel, or any declaration (`.d.ts`) surface. JS
+// entrypoints are excluded — this scan is about the TYPED public surface a `.d.ts` consumer sees.
+const ENTRYPOINT_RE = /(?:(?:^|\/)index\.(?:ts|tsx|mts|cts)$|\.d\.ts$)/;
+// Test, generated, vendored, and minified output are not the hand-authored public surface. (Unlike the sibling
+// undocumented-export scan, `.d.ts` is NOT skipped here — a published declaration file IS the entrypoint.)
+const SKIP_RE = /(?:\.min\.|\.test\.|\.spec\.|__tests__\/|(?:^|\/)(?:dist|build|vendor)\/)/;
+// A publishable npm package name (unscoped or `@scope/name`). Anything else can't be a real registry lookup → skip.
+const PACKAGE_NAME_RE = /^(?:@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/;
+
+interface ScanOptions {
+  signal?: AbortSignal;
+}
+
+/** Removed export declarations in a unified diff, each exported symbol with its OLD-file line number. Mirrors
+ *  `parseAddedExports` but for `-` lines, walking hunk headers to track the OLD-file cursor; only `-` lines that
+ *  declare a direct export are collected (`+`/`\` lines never advance the old cursor, `---`/`+++` headers are
+ *  ignored). A multi-declarator line yields one entry per binding, all sharing the same line. Pure. */
+export function parseRemovedExports(patch: string): Array<{ symbol: string; oldLine: number }> {
+  const out: Array<{ symbol: string; oldLine: number }> = [];
+  let oldLine = 0;
+  for (const raw of patch.split("\n")) {
+    const header = /^@@ -(\d+)(?:,\d+)? \+\d+(?:,\d+)? @@/.exec(raw);
+    if (header) {
+      oldLine = Number(header[1]);
+      continue;
+    }
+    if (raw.startsWith("-")) {
+      // Skip only a real unified-diff file header (`--- a/path`), not removed CONTENT that merely starts with
+      // `--` (git renders `--x;` as `---x;`); mirror the added-side guard so removed exports aren't mis-numbered.
+      if (!isDiffFileHeaderLine(raw)) {
+        for (const symbol of exportedSymbols(raw.slice(1))) out.push({ symbol, oldLine });
+        oldLine += 1;
+      }
+    } else if (!raw.startsWith("+") && !raw.startsWith("\\")) {
+      oldLine += 1; // context line advances the old-file cursor
+    }
+  }
+  return out;
+}
+
+/** Map each exported symbol to the trimmed body of the FIRST `prefix`-line (`+` or `-`) that declares it — used to
+ *  compare a removed-and-readded symbol's old vs new declaration and decide whether its signature changed. Pure. */
+function declarationBodies(patch: string, prefix: "+" | "-"): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const raw of patch.split("\n")) {
+    if (raw.startsWith("@@") || !raw.startsWith(prefix) || isDiffFileHeaderLine(raw)) continue;
+    const body = raw.slice(1);
+    for (const symbol of exportedSymbols(body)) {
+      if (!map.has(symbol)) map.set(symbol, body.trim());
+    }
+  }
+  return map;
+}
+
+/** Added export declarations in a unified diff — the SET of symbol names added on `+` lines. A local, allocation-
+ *  cheap mirror of the added-symbol half of `parseAddedExports` (we need only the names, not line numbers). Pure. */
+function addedExportSet(patch: string): Set<string> {
+  const set = new Set<string>();
+  for (const raw of patch.split("\n")) {
+    if (raw.startsWith("@@") || !raw.startsWith("+") || isDiffFileHeaderLine(raw)) continue;
+    for (const symbol of exportedSymbols(raw.slice(1))) set.add(symbol);
+  }
+  return set;
+}
+
+async function readBoundedText(resp: Response, signal?: AbortSignal): Promise<string | null> {
+  const length = Number(resp.headers.get("content-length"));
+  if (Number.isFinite(length) && length > MAX_FETCH_BYTES) return null;
+  if (!resp.body) return null;
+  const reader = resp.body.getReader();
+  const decoder = new TextDecoder();
+  let size = 0;
+  let text = "";
+  try {
+    while (true) {
+      if (signal?.aborted) return null;
+      const { done, value } = await reader.read();
+      if (done) break;
+      size += value.byteLength;
+      if (size > MAX_FETCH_BYTES) {
+        await reader.cancel();
+        return null;
+      }
+      text += decoder.decode(value, { stream: true });
+    }
+    text += decoder.decode();
+    return text;
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+/** The directory of `path`, then up to `MAX_PACKAGE_ANCESTORS` parent directories, from nearest to farthest — the
+ *  ordered set of directories to probe for the entrypoint's owning `package.json`. Repo root is the empty string. */
+function ancestorDirs(path: string): string[] {
+  const slash = path.lastIndexOf("/");
+  let dir = slash === -1 ? "" : path.slice(0, slash);
+  const dirs: string[] = [];
+  for (let i = 0; i <= MAX_PACKAGE_ANCESTORS; i++) {
+    dirs.push(dir);
+    if (dir === "") break;
+    const idx = dir.lastIndexOf("/");
+    dir = idx === -1 ? "" : dir.slice(0, idx);
+  }
+  return dirs;
+}
+
+/** Encode each path segment individually so an in-repo path with spaces/unicode still forms a valid URL while the
+ *  `/` separators are preserved (the sibling undocumented-export analyzer builds contents URLs the same way). */
+function encodePath(path: string): string {
+  return path.split("/").map(encodeURIComponent).join("/");
+}
+
+interface ResolvedPackage {
+  name: string;
+  /** The `types`/`typings` entry from the repo package.json, or the `index.d.ts` default. */
+  types: string;
+}
+
+/** Analyzer entrypoint: for each changed public entrypoint that REMOVES or signature-changes an export, resolve the
+ *  owning package and confirm the symbol is still in the CURRENTLY-PUBLISHED type surface. Fail-safe — returns no
+ *  finding on a missing token/head-sha, bad slug, unresolvable package, or any fetch error. */
+export async function scanApiBreakingChange(
+  req: EnrichRequest,
+  fetchFn: typeof fetch = fetch,
+  options: ScanOptions = {},
+): Promise<ApiBreakingChangeFinding[]> {
+  const { repoFullName, githubToken, headSha, files = [] } = req;
+  if (!githubToken || !headSha) return [];
+  // Require EXACTLY `owner/repo`: a 3+ segment value would otherwise query the wrong repo instead of failing safe.
+  const parts = repoFullName.split("/");
+  const [owner, repo] = parts;
+  if (parts.length !== 2 || !owner || !repo || !SLUG_RE.test(owner) || !SLUG_RE.test(repo)) return [];
+
+  const ghHeaders: Record<string, string> = {
+    Authorization: `Bearer ${githubToken}`,
+    Accept: "application/vnd.github.raw",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+
+  // Classify removed/signature-changed symbols per candidate entrypoint FIRST (cheap, pure), so the fetch budget is
+  // spent only on entrypoints that actually have breaking changes.
+  const candidates: Array<{
+    file: (typeof files)[number];
+    changed: Array<{ symbol: string; change: ApiBreakingChangeFinding["change"] }>;
+  }> = [];
+  for (const file of files) {
+    if (!file.patch || !ENTRYPOINT_RE.test(file.path) || SKIP_RE.test(file.path)) continue;
+    const removed = parseRemovedExports(file.patch);
+    if (!removed.length) continue;
+    const added = addedExportSet(file.patch);
+    const removedBodies = declarationBodies(file.patch, "-");
+    const addedBodies = declarationBodies(file.patch, "+");
+    const changed: Array<{ symbol: string; change: ApiBreakingChangeFinding["change"] }> = [];
+    const seen = new Set<string>();
+    for (const { symbol } of removed) {
+      if (seen.has(symbol)) continue;
+      seen.add(symbol);
+      if (!added.has(symbol)) {
+        changed.push({ symbol, change: "removed" });
+      } else {
+        // Removed AND re-added: an identical declaration is NOT a break; a changed declaration body is a signature
+        // change. Fall through silently when either body is missing (can't confirm a change) — conservative.
+        const before = removedBodies.get(symbol);
+        const after = addedBodies.get(symbol);
+        if (before !== undefined && after !== undefined && before !== after) {
+          changed.push({ symbol, change: "signature-changed" });
+        }
+      }
+    }
+    if (!changed.length) continue;
+    candidates.push({ file, changed });
+    if (candidates.length >= MAX_FILES) break;
+  }
+
+  const findings: ApiBreakingChangeFinding[] = [];
+  for (const { file, changed } of candidates) {
+    if (options.signal?.aborted) break;
+
+    const pkg = await resolvePackage(file.path, owner, repo, headSha, ghHeaders, fetchFn, options.signal);
+    if (!pkg) continue;
+    if (options.signal?.aborted) break;
+
+    const published = await fetchPublishedSurface(pkg, fetchFn, options.signal);
+    if (!published) continue;
+    if (options.signal?.aborted) break;
+
+    for (const { symbol, change } of changed) {
+      if (!published.exports.has(symbol)) continue;
+      findings.push({
+        file: file.path,
+        symbol,
+        change,
+        packageName: pkg.name,
+        publishedVersion: published.version,
+      });
+      if (findings.length >= MAX_FINDINGS) return findings;
+    }
+  }
+  return findings;
+}
+
+/** Walk the entrypoint path upward and return the first ancestor `package.json` (at headSha) that parses and has a
+ *  string `name`. One authed GitHub contents fetch per ancestor; a fetch error or a nameless manifest is skipped. */
+async function resolvePackage(
+  entrypointPath: string,
+  owner: string,
+  repo: string,
+  headSha: string,
+  headers: Record<string, string>,
+  fetchFn: typeof fetch,
+  signal?: AbortSignal,
+): Promise<ResolvedPackage | null> {
+  for (const dir of ancestorDirs(entrypointPath)) {
+    if (signal?.aborted) return null;
+    const manifestPath = dir ? `${dir}/package.json` : "package.json";
+    let text: string | null = null;
+    try {
+      const resp = await fetchFn(
+        `${GITHUB_API}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/contents/${encodePath(manifestPath)}?ref=${encodeURIComponent(headSha)}`,
+        { headers, signal },
+      );
+      if (resp.ok) text = await readBoundedText(resp, signal);
+    } catch {
+      text = null;
+    }
+    if (!text) continue;
+    let json: unknown;
+    try {
+      json = JSON.parse(text);
+    } catch {
+      continue;
+    }
+    if (!json || typeof json !== "object") continue;
+    const record = json as Record<string, unknown>;
+    if (typeof record.name !== "string" || !record.name) continue;
+    const types =
+      typeof record.types === "string"
+        ? record.types
+        : typeof record.typings === "string"
+          ? record.typings
+          : "index.d.ts";
+    return { name: record.name, types };
+  }
+  return null;
+}
+
+interface PublishedSurface {
+  version: string;
+  exports: Set<string>;
+}
+
+/** Fetch the package's CURRENTLY-PUBLISHED type surface: the latest npm version + its declaration file's exported
+ *  symbol names (from unpkg). Any fetch/parse failure returns null (the entrypoint is then skipped — no finding). */
+async function fetchPublishedSurface(
+  pkg: ResolvedPackage,
+  fetchFn: typeof fetch,
+  signal?: AbortSignal,
+): Promise<PublishedSurface | null> {
+  if (!PACKAGE_NAME_RE.test(pkg.name)) return null;
+  const encodedName = encodePath(pkg.name);
+
+  // 1. The latest published version + its declared types path (falling back to the repo manifest's, then the default).
+  let latest: Record<string, unknown> | null = null;
+  try {
+    const resp = await fetchFn(`${NPM_REGISTRY}/${encodedName}/latest`, { signal });
+    if (resp.ok) {
+      const text = await readBoundedText(resp, signal);
+      if (text) latest = JSON.parse(text) as Record<string, unknown>;
+    }
+  } catch {
+    latest = null;
+  }
+  if (!latest || typeof latest.version !== "string" || !latest.version) return null;
+  const version = latest.version;
+  const typesPath =
+    typeof latest.types === "string"
+      ? latest.types
+      : typeof latest.typings === "string"
+        ? latest.typings
+        : pkg.types || "index.d.ts";
+
+  // 2. The published declaration file's raw text (bounded), from unpkg pinned to the resolved version.
+  let dts: string | null = null;
+  try {
+    const resp = await fetchFn(`${UNPKG}/${encodedName}@${encodeURIComponent(version)}/${encodePath(typesPath)}`, {
+      signal,
+    });
+    if (resp.ok) dts = await readBoundedText(resp, signal);
+  } catch {
+    dts = null;
+  }
+  if (!dts) return null;
+
+  const exports = new Set<string>();
+  for (const line of dts.split("\n")) {
+    for (const symbol of exportedSymbols(line)) exports.add(symbol);
+  }
+  return { version, exports };
+}

--- a/review-enrichment/src/analyzers/registry.ts
+++ b/review-enrichment/src/analyzers/registry.ts
@@ -1,4 +1,5 @@
 import { scanActionPins } from "./actions-pin.js";
+import { scanApiBreakingChange } from "./api-breaking-change.js";
 import { scanApprovalIntegrity } from "./approval-integrity.js";
 import { scanAssetWeight } from "./asset-weight.js";
 import { scanChurnHotspot } from "./churn-hotspot.js";
@@ -650,6 +651,38 @@ export const ANALYZER_DESCRIPTORS = [
     },
     run: (req, { signal, analysis, diagnostics }) =>
       scanCommitHygiene(req, fetch, { signal, analysis, diagnostics }),
+  }),
+  descriptor({
+    name: "apiBreakingChange",
+    title: "Exported-API breaking changes",
+    category: "supply-chain",
+    cost: "github-heavy",
+    defaultEnabled: true,
+    requires: ["files", "github-token", "head-sha", "public-network"],
+    limits: { maxFiles: 10, maxFindings: 30 },
+    docs: {
+      summary:
+        "Flags an exported symbol removed or signature-changed at a package's public TypeScript entrypoint that is still part of the currently-published npm type surface — a downstream break.",
+      looksAt:
+        "Removed/added `export` declarations in changed `index.*` or `.d.ts` entrypoints, the owning package.json resolved at headSha, and the latest published `.d.ts` from npm + unpkg.",
+      reports:
+        "The entrypoint file, symbol, change kind (removed or signature-changed), and the package name + currently-published version — never file contents.",
+      network:
+        "One GitHub contents fetch per candidate to resolve the package.json (requires headSha and token forwarding for private repos), plus the npm registry and unpkg for the published type surface.",
+      notes:
+        "Conservative: a symbol removed AND re-added with an identical declaration is not a break; only symbols still present in the published surface are reported. Fail-safe on any missing input or fetch error.",
+    },
+    render: (findings, helpers) => {
+      if (!findings.length) return [];
+      const lines = ["### Exported-API breaking changes"];
+      for (const item of findings) {
+        lines.push(
+          `- ${helpers.safeCodeSpan(`${item.packageName}@${item.publishedVersion}`)} ${item.change} exported ${helpers.safeCodeSpan(item.symbol)} (${item.file})`,
+        );
+      }
+      return lines;
+    },
+    run: (req, { signal }) => scanApiBreakingChange(req, fetch, { signal }),
   }),
 ] as const satisfies readonly AnyAnalyzerDescriptor[];
 

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -418,6 +418,7 @@ export function renderBrief(
   lines.push(...renderDescriptorSection("undocumentedExport", findings.undocumentedExport));
   lines.push(...renderDescriptorSection("staleBranch", findings.staleBranch));
   lines.push(...renderDescriptorSection("commitHygiene", findings.commitHygiene));
+  lines.push(...renderDescriptorSection("apiBreakingChange", findings.apiBreakingChange));
 
   if (!lines.length) return { promptSection: "", systemSuffix: "" };
 

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -364,6 +364,17 @@ export type CommitHygieneFinding =
   | { shaPrefix: string; kind: "fixup-commit-present"; subject: string }
   | { shaPrefix: string; kind: "unattributed-co-author"; coAuthor: string };
 
+/** An exported symbol REMOVED or SIGNATURE-CHANGED at a package's public TypeScript entrypoint that is still part of
+ *  the package's currently-published type surface — a downstream break for consumers on the latest npm release.
+ *  Reports the entrypoint file, symbol, change kind, and the package name + published version only. (#1510) */
+export interface ApiBreakingChangeFinding {
+  file: string;
+  symbol: string;
+  change: "removed" | "signature-changed";
+  packageName: string;
+  publishedVersion: string;
+}
+
 /** Structured analyzer output. Each analyzer fills its own key; more land as analyzers ship (#1477/#1478). */
 export interface BriefFindings {
   dependency?: DependencyFinding[];
@@ -393,6 +404,7 @@ export interface BriefFindings {
   undocumentedExport?: UndocumentedExportFinding[];
   staleBranch?: StaleBranchFinding[];
   commitHygiene?: CommitHygieneFinding[];
+  apiBreakingChange?: ApiBreakingChangeFinding[];
 }
 
 /** A JSDoc/TSDoc block whose `@param` tags name parameters the adjacent function no longer declares — a

--- a/review-enrichment/test/analyzer-registry.test.ts
+++ b/review-enrichment/test/analyzer-registry.test.ts
@@ -37,6 +37,7 @@ const EXPECTED_ANALYZERS = [
   "undocumentedExport",
   "staleBranch",
   "commitHygiene",
+  "apiBreakingChange",
 ];
 
 test("analyzer descriptors cover the runtime registry in stable order", () => {

--- a/review-enrichment/test/api-breaking-change.test.ts
+++ b/review-enrichment/test/api-breaking-change.test.ts
@@ -1,0 +1,149 @@
+// Units for the exported-API breaking-change analyzer (#1510). Own file so concurrent analyzer PRs don't collide.
+// All network is mocked. Runs against the compiled dist/.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseRemovedExports,
+  scanApiBreakingChange,
+} from "../dist/analyzers/api-breaking-change.js";
+import { renderBrief } from "../dist/render.js";
+
+// A patch that REMOVES an exported `oldApi` from the entrypoint (old-file lines 1-2 held it).
+const REMOVE_PATCH = ["@@ -1,2 +1,1 @@", "-export function oldApi() {}", "-", "+export const kept = 1;"].join("\n");
+const PKG_JSON = JSON.stringify({ name: "mypkg", version: "2.0.0", types: "index.d.ts" });
+// The currently-published .d.ts surface still declares oldApi → removing it is a downstream break.
+const PUBLISHED_DTS = ["export declare function oldApi(): void;", "export declare const kept: number;"].join("\n");
+
+const rawResponse = (text) => new Response(text, { status: 200 });
+// A fetch stub that answers each host with the supplied text; anything else 404s.
+const stubFetch = ({ pkgJson = PKG_JSON, latest, dts = PUBLISHED_DTS } = {}) => {
+  const latestJson = latest ?? JSON.stringify({ version: "2.0.0", types: "index.d.ts" });
+  return async (url) => {
+    if (url.includes("/contents/") && url.includes("package.json")) return rawResponse(pkgJson);
+    if (url.startsWith("https://registry.npmjs.org/") && url.endsWith("/latest")) return rawResponse(latestJson);
+    if (url.startsWith("https://unpkg.com/")) return rawResponse(dts);
+    return new Response("", { status: 404 });
+  };
+};
+
+const req = (files, extra = {}) => ({
+  repoFullName: "octo/repo",
+  prNumber: 1,
+  githubToken: "ghp_test",
+  headSha: "abc123",
+  files,
+  ...extra,
+});
+
+test("parseRemovedExports: collects direct removed exports with old-file line numbers, ignores re-exports", () => {
+  assert.deepEqual(parseRemovedExports(REMOVE_PATCH), [{ symbol: "oldApi", oldLine: 1 }]);
+  // context/additions keep the old-line cursor aligned; `export { x }` / `export *` are not direct declarations
+  const mixed = ["@@ -5,3 +5,1 @@", " const keep = 1;", "-export type Gone = string;", "-export { Gone };", "+x"].join("\n");
+  assert.deepEqual(parseRemovedExports(mixed), [{ symbol: "Gone", oldLine: 6 }]);
+});
+
+test("scanApiBreakingChange: a removed published export → one 'removed' finding", async () => {
+  const findings = await scanApiBreakingChange(
+    req([{ path: "src/index.ts", status: "modified", patch: REMOVE_PATCH }]),
+    stubFetch(),
+  );
+  assert.deepEqual(findings, [
+    { file: "src/index.ts", symbol: "oldApi", change: "removed", packageName: "mypkg", publishedVersion: "2.0.0" },
+  ]);
+});
+
+test("scanApiBreakingChange: a removed export NOT in the published surface → no finding", async () => {
+  const findings = await scanApiBreakingChange(
+    req([{ path: "src/index.ts", status: "modified", patch: REMOVE_PATCH }]),
+    stubFetch({ dts: "export declare const kept: number;" }), // published surface no longer lists oldApi
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanApiBreakingChange: a removed-and-readded UNCHANGED export → no finding", async () => {
+  // oldApi is removed and re-added with an identical declaration body → not a break.
+  const patch = ["@@ -1,1 +1,1 @@", "-export function oldApi() {}", "+export function oldApi() {}"].join("\n");
+  const findings = await scanApiBreakingChange(
+    req([{ path: "src/index.ts", status: "modified", patch }]),
+    stubFetch(),
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanApiBreakingChange: a signature-changed published export → 'signature-changed' finding", async () => {
+  // oldApi is removed and re-added with a CHANGED declaration body → a signature change.
+  const patch = ["@@ -1,1 +1,1 @@", "-export function oldApi() {}", "+export function oldApi(x: number): void {}"].join("\n");
+  const findings = await scanApiBreakingChange(
+    req([{ path: "src/index.ts", status: "modified", patch }]),
+    stubFetch(),
+  );
+  assert.deepEqual(findings, [
+    { file: "src/index.ts", symbol: "oldApi", change: "signature-changed", packageName: "mypkg", publishedVersion: "2.0.0" },
+  ]);
+});
+
+test("scanApiBreakingChange: a .d.ts entrypoint is scanned and the package walk resolves an ancestor package.json", async () => {
+  // Removing a published symbol from a nested declaration file; package.json lives at the package root (2 levels up).
+  const patch = ["@@ -1,1 +1,0 @@", "-export declare function oldApi(): void;"].join("\n");
+  let manifestUrl = "";
+  const recording = async (url) => {
+    if (url.includes("/contents/") && url.includes("package.json")) {
+      manifestUrl = url;
+      // only the package-root manifest exists; the nested dir has none
+      return url.includes("packages/foo/package.json") ? rawResponse(PKG_JSON) : new Response("", { status: 404 });
+    }
+    if (url.startsWith("https://registry.npmjs.org/") && url.endsWith("/latest")) {
+      return rawResponse(JSON.stringify({ version: "2.0.0", types: "index.d.ts" }));
+    }
+    if (url.startsWith("https://unpkg.com/")) return rawResponse(PUBLISHED_DTS);
+    return new Response("", { status: 404 });
+  };
+  const findings = await scanApiBreakingChange(
+    req([{ path: "packages/foo/dts/api.d.ts", status: "modified", patch }]),
+    recording,
+  );
+  assert.deepEqual(findings, [
+    { file: "packages/foo/dts/api.d.ts", symbol: "oldApi", change: "removed", packageName: "mypkg", publishedVersion: "2.0.0" },
+  ]);
+  assert.match(manifestUrl, /packages\/foo\/package\.json\?ref=abc123$/);
+});
+
+test("scanApiBreakingChange: missing token or headSha → [] (no finding, no throw)", async () => {
+  const files = [{ path: "src/index.ts", status: "modified", patch: REMOVE_PATCH }];
+  assert.deepEqual(await scanApiBreakingChange(req(files, { githubToken: undefined }), stubFetch()), []);
+  assert.deepEqual(await scanApiBreakingChange(req(files, { headSha: undefined }), stubFetch()), []);
+});
+
+test("scanApiBreakingChange: a non-entrypoint / test file is skipped", async () => {
+  assert.deepEqual(
+    await scanApiBreakingChange(req([{ path: "src/helpers.ts", status: "modified", patch: REMOVE_PATCH }]), stubFetch()),
+    [],
+  );
+  assert.deepEqual(
+    await scanApiBreakingChange(req([{ path: "src/index.test.ts", status: "modified", patch: REMOVE_PATCH }]), stubFetch()),
+    [],
+  );
+});
+
+test("scanApiBreakingChange: a fetch error (or a package.json that never resolves) yields no finding (fail-safe)", async () => {
+  const files = [{ path: "src/index.ts", status: "modified", patch: REMOVE_PATCH }];
+  const rejecting = async () => {
+    throw new Error("network down");
+  };
+  assert.deepEqual(await scanApiBreakingChange(req(files), rejecting), []);
+  const allNotFound = async () => new Response("", { status: 404 });
+  assert.deepEqual(await scanApiBreakingChange(req(files), allNotFound), []);
+});
+
+test("scanApiBreakingChange: renders a header + a bullet; empty findings render nothing", async () => {
+  const findings = await scanApiBreakingChange(
+    req([{ path: "src/index.ts", status: "modified", patch: REMOVE_PATCH }]),
+    stubFetch(),
+  );
+  const brief = renderBrief({ apiBreakingChange: findings }).promptSection;
+  assert.match(brief, /Exported-API breaking changes/);
+  assert.match(brief, /mypkg@2\.0\.0/);
+  assert.match(brief, /oldApi/);
+  // empty findings → no section at all
+  assert.equal(renderBrief({ apiBreakingChange: [] }).promptSection, "");
+});


### PR DESCRIPTION
## Summary

Adds the **Exported-API breaking-change detector** REES analyzer (Closes #1510).

New `review-enrichment/src/analyzers/api-breaking-change.ts` flags a PR that **removes or signature-changes an exported symbol** at a package's public TypeScript entrypoint (an `index.*` barrel or a `.d.ts` surface) **when that symbol is still part of the package's currently-published npm type surface** — i.e. a semver-major break shipped as a patch/minor that breaks downstream consumers. This is heavy/external/historical analysis the no-checkout headless reviewer cannot do; the REES returns it as an additive, fail-safe brief block.

**Detection (deterministic, fail-safe — any missing input/bad slug/fetch error/abort → no finding, never throws):**
1. Reads removed vs. added `export` declarations from the diff of each changed entrypoint (reuses the sibling `undocumented-export.ts` `exportedSymbols`/`isDiffFileHeaderLine` helpers; adds a mirrored `parseRemovedExports` for the `-` side). A symbol removed **and** re-added with an identical declaration is **not** a break; re-added with a changed declaration body is a **signature change**.
2. Resolves the owning package by fetching the nearest ancestor `package.json` at `headSha` (one authed GitHub contents fetch, walking up to 3 levels).
3. Fetches the **currently-published** type surface — latest version from `registry.npmjs.org/<pkg>/latest`, then its `.d.ts` from `unpkg.com/<pkg>@<version>/<types>` — and parses its exported symbol set.
4. Emits `{file, symbol, change, packageName, publishedVersion}` only for removed/signature-changed symbols **still present in the published surface**. Caps: `MAX_FILES=10`, `MAX_FINDINGS=30`, `MAX_FETCH_BYTES=1MB`; honors `AbortSignal`.

Conservative by design (direct declarations only; re-export lists/`export *` ignored), so it under-reports rather than false-positives. Wiring: `ApiBreakingChangeFinding` + `BriefFindings` key in `types.ts`, descriptor in `registry.ts` (`supply-chain`, `github-heavy`, inline `safeCodeSpan` render), the render dispatch line, and the 3 generated files regenerated via `npm --prefix review-enrichment run metadata`.

## Scope
- [x] Conventional Commit; focused; linked issue #1510; all inside `review-enrichment/` + the required generated parity files. Outside the engine `tsc`/`vitest`/Codecov scope. No `site/`/`CNAME`/`**/lovable/**`; no `CHANGELOG.md`.

## Validation
- [x] `npm --prefix review-enrichment test` — **664 pass / 0 fail** (build + sourcemap validate + `metadata --check` + node tests; exactly what CI runs). 10 new tests: removed / not-published / re-added-unchanged / signature-changed / ancestor package.json walk / missing token+headSha / non-entrypoint skip / fetch-error fail-safe / render.
- [x] `npm run typecheck` clean; `git diff --check` clean; generated metadata/UI/env regenerated (parity `--check` passes).
- Live registry URL forms verified against the real npm registry (scoped + unscoped).

## Safety
- [x] Reports symbol names + package@version only — never file contents. No secrets/wallets/hotkeys/trust/reward terms. Fail-safe on every path.
