### PR TITLE
feat(enrichment): flag pending review-request staleness

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,7 +66,7 @@ GITTENSORY_REVIEW_ENRICHMENT=false
 # dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol,redos
 # provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild
 # history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity,ciCheckSignals
-# undocumentedExport,staleBranch,commitHygiene
+# undocumentedExport,staleBranch,commitHygiene,pendingReviewRequests
 #
 # Profile defaults:
 # fast: dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol
@@ -75,10 +75,11 @@ GITTENSORY_REVIEW_ENRICHMENT=false
 # actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature
 # iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink
 # approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene
+# pendingReviewRequests
 # deep: dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol
 # redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig
 # nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity
-# ciCheckSignals,undocumentedExport,staleBranch,commitHygiene
+# ciCheckSignals,undocumentedExport,staleBranch,commitHygiene,pendingReviewRequests
 # END GENERATED REES ANALYZERS
 
 # Submitter-reputation spend control (internal-only): downgrades new/burst/low-rep

--- a/apps/gittensory-ui/src/lib/rees-analyzers.ts
+++ b/apps/gittensory-ui/src/lib/rees-analyzers.ts
@@ -703,6 +703,30 @@ export const REES_ANALYZERS = [
         "Structured-fields-only: reads commit.message and parents, matched one line at a time, never cross-line state. Fail-safe on missing token/fetch error.",
     },
   },
+  {
+    name: "pendingReviewRequests",
+    title: "Pending review-request staleness",
+    category: "history",
+    cost: "github-light",
+    defaultEnabled: true,
+    profiles: ["balanced", "deep"],
+    requires: ["github-token"],
+    limits: {
+      staleThresholdHours: 48,
+      maxTimelinePages: 5,
+    },
+    docs: {
+      summary:
+        "Flags a reviewer or team whose review request has been outstanding 48+ hours with no response yet.",
+      looksAt:
+        "The PR's currently pending requested reviewers/teams, matched against the issue timeline's review_requested events (bounded, page-confirmed complete).",
+      reports: "The reviewer login (or team:slug) and hours pending — never review content.",
+      network:
+        "Calls the GitHub requested-reviewers API once and the issue-timeline API, paginated and bounded to a fixed page cap.",
+      notes:
+        "Structured-fields-only: reads user.login/team.slug/event/created_at, never diff or comment text. Fail-safe on missing token/fetch error/an unconfirmed-complete timeline.",
+    },
+  },
 ] as const satisfies readonly ReesAnalyzerDoc[];
 
 export const REES_ANALYZER_NAMES = REES_ANALYZERS.map((analyzer) => analyzer.name);

--- a/review-enrichment/analyzer-metadata.json
+++ b/review-enrichment/analyzer-metadata.json
@@ -791,6 +791,31 @@
         "network": "Calls the GitHub PR-commits API once, bounded to one page.",
         "notes": "Structured-fields-only: reads commit.message and parents, matched one line at a time, never cross-line state. Fail-safe on missing token/fetch error."
       }
+    },
+    {
+      "name": "pendingReviewRequests",
+      "title": "Pending review-request staleness",
+      "category": "history",
+      "cost": "github-light",
+      "defaultEnabled": true,
+      "profiles": [
+        "balanced",
+        "deep"
+      ],
+      "requires": [
+        "github-token"
+      ],
+      "limits": {
+        "staleThresholdHours": 48,
+        "maxTimelinePages": 5
+      },
+      "docs": {
+        "summary": "Flags a reviewer or team whose review request has been outstanding 48+ hours with no response yet.",
+        "looksAt": "The PR's currently pending requested reviewers/teams, matched against the issue timeline's review_requested events (bounded, page-confirmed complete).",
+        "reports": "The reviewer login (or team:slug) and hours pending — never review content.",
+        "network": "Calls the GitHub requested-reviewers API once and the issue-timeline API, paginated and bounded to a fixed page cap.",
+        "notes": "Structured-fields-only: reads user.login/team.slug/event/created_at, never diff or comment text. Fail-safe on missing token/fetch error/an unconfirmed-complete timeline."
+      }
     }
   ]
 }

--- a/review-enrichment/src/analyzers/pending-review-requests.ts
+++ b/review-enrichment/src/analyzers/pending-review-requests.ts
@@ -1,0 +1,209 @@
+// Pending review-request staleness, read from structured GitHub API fields only — no diff/text/YAML parsing.
+// Surfaces a reviewer or team whose review request has been outstanding a long time with no response yet — a
+// PR's own page shows WHO was requested, but not HOW LONG they've been waiting. Combines the requested-reviewers
+// endpoint (the current pending set) with the issue-timeline API (each `review_requested` event's timestamp) to
+// compute how long the most recent request to each still-pending reviewer has been open. Reads only documented
+// fields (user.login, team.slug, event, created_at) and compares them — no ambiguous-syntax parsing, so it
+// cannot suffer a patch scanner's edge cases. Pure GitHub-metadata read, no repo content. Fail-safe: no token, a
+// bad repo slug, either fetch failing, or an unconfirmed-complete timeline (still-full last page) all yield no
+// finding — like approval-integrity, this reports on CURRENT state, so incomplete history must fail closed
+// rather than risk understating (and thus mis-reporting) how long a request has actually been pending.
+import type {
+  AnalyzerDiagnostics,
+  EnrichRequest,
+  PendingReviewRequestFinding,
+} from "../types.js";
+import type { AnalysisContext } from "../analysis-context.js";
+import { boundedFetchJson } from "../external-fetch.js";
+
+const GITHUB_API = "https://api.github.com";
+const SLUG_RE = /^[A-Za-z0-9._-]+$/;
+const TIMELINE_PER_PAGE = 100;
+const MAX_TIMELINE_PAGES = 5;
+const STALE_THRESHOLD_MS = 48 * 60 * 60 * 1000; // 48 hours
+
+interface ScanOptions {
+  signal?: AbortSignal;
+  analysis?: Pick<AnalysisContext, "fetchJson">;
+  diagnostics?: AnalyzerDiagnostics;
+  /** Injectable clock so staleness math is deterministic in tests; defaults to Date.now(). */
+  now?: number;
+}
+
+interface RequestedReviewers {
+  users?: Array<{ login?: string }>;
+  teams?: Array<{ slug?: string }>;
+}
+
+interface TimelineEvent {
+  event?: string;
+  created_at?: string;
+  requested_reviewer?: { login?: string };
+  requested_team?: { slug?: string };
+}
+
+function githubHeaders(token: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+}
+
+async function fetchRequestedReviewers(
+  owner: string,
+  repo: string,
+  prNumber: number,
+  headers: Record<string, string>,
+  fetchFn: typeof fetch,
+  signal: AbortSignal | undefined,
+  options: Pick<ScanOptions, "analysis" | "diagnostics">,
+): Promise<RequestedReviewers | null> {
+  const url =
+    `${GITHUB_API}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/pulls/` +
+    `${encodeURIComponent(String(prNumber))}/requested_reviewers`;
+  const fetchOptions = {
+    endpointCategory: "github-requested-reviewers",
+    headers,
+    signal,
+    fetchImpl: fetchFn,
+    diagnostics: options.diagnostics,
+    phase: "pending-review-requests",
+    subcall: "github-requested-reviewers",
+    maxBytes: 256 * 1024,
+  };
+  const response = options.analysis
+    ? await options.analysis.fetchJson<RequestedReviewers>(url, fetchOptions)
+    : await boundedFetchJson<RequestedReviewers>(url, fetchOptions);
+  return response.ok ? response.data : null;
+}
+
+async function fetchTimelinePage(
+  owner: string,
+  repo: string,
+  prNumber: number,
+  page: number,
+  headers: Record<string, string>,
+  fetchFn: typeof fetch,
+  signal: AbortSignal | undefined,
+  options: Pick<ScanOptions, "analysis" | "diagnostics">,
+): Promise<TimelineEvent[] | null> {
+  const url =
+    `${GITHUB_API}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues/` +
+    `${encodeURIComponent(String(prNumber))}/timeline?per_page=${TIMELINE_PER_PAGE}&page=${page}`;
+  const fetchOptions = {
+    endpointCategory: "github-issue-timeline",
+    headers,
+    signal,
+    fetchImpl: fetchFn,
+    diagnostics: options.diagnostics,
+    phase: "pending-review-requests",
+    subcall: "github-issue-timeline",
+    maxBytes: 512 * 1024,
+  };
+  const response = options.analysis
+    ? await options.analysis.fetchJson<TimelineEvent[]>(url, fetchOptions)
+    : await boundedFetchJson<TimelineEvent[]>(url, fetchOptions);
+  return response.ok && Array.isArray(response.data) ? response.data : null;
+}
+
+/** Walks timeline pages up to MAX_TIMELINE_PAGES. Like approval-integrity's review pagination, a short page
+ *  (< TIMELINE_PER_PAGE items) is the only way to confirm there is nothing further; any page failure, or
+ *  exhausting the page cap while the last page was still full, fails the whole call closed (null) — this
+ *  analyzer reports how long a request has been pending, so an incomplete timeline could understate that
+ *  duration and report a fresher request as stale, or hide a truly stale one behind a later re-request event. */
+async function fetchFullTimeline(
+  owner: string,
+  repo: string,
+  prNumber: number,
+  headers: Record<string, string>,
+  fetchFn: typeof fetch,
+  signal: AbortSignal | undefined,
+  options: Pick<ScanOptions, "analysis" | "diagnostics">,
+): Promise<TimelineEvent[] | null> {
+  const events: TimelineEvent[] = [];
+  for (let page = 1; page <= MAX_TIMELINE_PAGES; page += 1) {
+    const pageEvents = await fetchTimelinePage(owner, repo, prNumber, page, headers, fetchFn, signal, options);
+    if (!pageEvents) return null;
+    events.push(...pageEvents);
+    if (pageEvents.length < TIMELINE_PER_PAGE) return events;
+  }
+  return null;
+}
+
+/** Pure: the latest `review_requested` timestamp (ISO string) per reviewer login (lowercased) and per team slug
+ *  (lowercased, keyed as `team:slug`), from timeline events in API (oldest-first) order — a later event of the
+ *  same reviewer/team always overwrites an earlier one, so this is always each one's MOST RECENT request. */
+export function latestReviewRequestTimes(events: TimelineEvent[]): Map<string, string> {
+  const latest = new Map<string, string>();
+  for (const event of events) {
+    if (event.event !== "review_requested" || !event.created_at) continue;
+    const userKey = event.requested_reviewer?.login?.toLowerCase();
+    const teamKey = event.requested_team?.slug ? `team:${event.requested_team.slug.toLowerCase()}` : undefined;
+    const key = userKey ?? teamKey;
+    if (!key) continue;
+    latest.set(key, event.created_at);
+  }
+  return latest;
+}
+
+/** Pure reduction: the current pending-reviewer set + the timeline's latest-request timestamps → staleness
+ *  findings. A pending reviewer/team with no matching `review_requested` event in the (confirmed-complete)
+ *  timeline is skipped, not guessed at. Pure. */
+export function evaluatePendingReviewRequests(
+  requested: RequestedReviewers,
+  requestTimes: Map<string, string>,
+  now: number,
+): PendingReviewRequestFinding[] {
+  const findings: PendingReviewRequestFinding[] = [];
+
+  for (const user of requested.users ?? []) {
+    const login = user.login;
+    if (!login) continue;
+    const requestedAt = requestTimes.get(login.toLowerCase());
+    if (!requestedAt) continue;
+    const hoursPending = (now - Date.parse(requestedAt)) / (60 * 60 * 1000);
+    if (Number.isFinite(hoursPending) && hoursPending * 60 * 60 * 1000 >= STALE_THRESHOLD_MS) {
+      findings.push({ reviewer: login, hoursPending: Math.round(hoursPending) });
+    }
+  }
+
+  for (const team of requested.teams ?? []) {
+    const slug = team.slug;
+    if (!slug) continue;
+    const requestedAt = requestTimes.get(`team:${slug.toLowerCase()}`);
+    if (!requestedAt) continue;
+    const hoursPending = (now - Date.parse(requestedAt)) / (60 * 60 * 1000);
+    if (Number.isFinite(hoursPending) && hoursPending * 60 * 60 * 1000 >= STALE_THRESHOLD_MS) {
+      findings.push({ reviewer: `team:${slug}`, hoursPending: Math.round(hoursPending) });
+    }
+  }
+
+  return findings;
+}
+
+/** Analyzer entrypoint: a PR's pending review requests + timeline → staleness findings. Fail-safe — no token, a
+ *  bad repo slug, either fetch failing, or an unconfirmed-complete timeline all yield no finding. */
+export async function scanPendingReviewRequests(
+  req: EnrichRequest,
+  fetchFn: typeof fetch = fetch,
+  options: ScanOptions = {},
+): Promise<PendingReviewRequestFinding[]> {
+  const { repoFullName, githubToken, prNumber } = req;
+  if (!githubToken) return [];
+  const parts = repoFullName.split("/");
+  const owner = parts[0];
+  const repo = parts[1];
+  if (parts.length !== 2 || !owner || !repo || !SLUG_RE.test(owner) || !SLUG_RE.test(repo)) return [];
+
+  const headers = githubHeaders(githubToken);
+  const requested = await fetchRequestedReviewers(owner, repo, prNumber, headers, fetchFn, options.signal, options);
+  if (!requested) return [];
+  if (!requested.users?.length && !requested.teams?.length) return [];
+
+  const timeline = await fetchFullTimeline(owner, repo, prNumber, headers, fetchFn, options.signal, options);
+  if (!timeline) return [];
+
+  const requestTimes = latestReviewRequestTimes(timeline);
+  return evaluatePendingReviewRequests(requested, requestTimes, options.now ?? Date.now());
+}

--- a/review-enrichment/src/analyzers/registry.ts
+++ b/review-enrichment/src/analyzers/registry.ts
@@ -18,6 +18,7 @@ import { scanInstallScripts } from "./install-scripts.js";
 import { scanLicenses } from "./license-check.js";
 import { scanLockfileDrift } from "./lockfile-drift.js";
 import { scanNativeBuild } from "./native-build.js";
+import { scanPendingReviewRequests } from "./pending-review-requests.js";
 import { scanProvenance } from "./provenance.js";
 import { scanRedos } from "./redos.js";
 import { secretAnalyzer } from "./secret/descriptor.js";
@@ -650,6 +651,34 @@ export const ANALYZER_DESCRIPTORS = [
     },
     run: (req, { signal, analysis, diagnostics }) =>
       scanCommitHygiene(req, fetch, { signal, analysis, diagnostics }),
+  }),
+  descriptor({
+    name: "pendingReviewRequests",
+    title: "Pending review-request staleness",
+    category: "history",
+    cost: "github-light",
+    defaultEnabled: true,
+    requires: ["github-token"],
+    limits: { staleThresholdHours: 48, maxTimelinePages: 5 },
+    docs: {
+      summary:
+        "Flags a reviewer or team whose review request has been outstanding 48+ hours with no response yet.",
+      looksAt: "The PR's currently pending requested reviewers/teams, matched against the issue timeline's review_requested events (bounded, page-confirmed complete).",
+      reports: "The reviewer login (or team:slug) and hours pending — never review content.",
+      network: "Calls the GitHub requested-reviewers API once and the issue-timeline API, paginated and bounded to a fixed page cap.",
+      notes:
+        "Structured-fields-only: reads user.login/team.slug/event/created_at, never diff or comment text. Fail-safe on missing token/fetch error/an unconfirmed-complete timeline.",
+    },
+    render: (findings, helpers) => {
+      if (!findings.length) return [];
+      const lines = ["### Pending review-request staleness"];
+      for (const item of findings) {
+        lines.push(`- ${helpers.safeCodeSpan(item.reviewer)}'s review request has been pending for ${item.hoursPending}h`);
+      }
+      return lines;
+    },
+    run: (req, { signal, analysis, diagnostics }) =>
+      scanPendingReviewRequests(req, fetch, { signal, analysis, diagnostics }),
   }),
 ] as const satisfies readonly AnyAnalyzerDescriptor[];
 

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -418,6 +418,7 @@ export function renderBrief(
   lines.push(...renderDescriptorSection("undocumentedExport", findings.undocumentedExport));
   lines.push(...renderDescriptorSection("staleBranch", findings.staleBranch));
   lines.push(...renderDescriptorSection("commitHygiene", findings.commitHygiene));
+  lines.push(...renderDescriptorSection("pendingReviewRequests", findings.pendingReviewRequests));
 
   if (!lines.length) return { promptSection: "", systemSuffix: "" };
 

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -364,6 +364,14 @@ export type CommitHygieneFinding =
   | { shaPrefix: string; kind: "fixup-commit-present"; subject: string }
   | { shaPrefix: string; kind: "unattributed-co-author"; coAuthor: string };
 
+/** A reviewer or team (`team:slug`) whose most recent `review_requested` event is still pending (no review
+ *  submitted) 48+ hours later, read from structured GitHub fields only (the requested-reviewers list and the
+ *  issue-timeline's `review_requested` events) — never diff/file content. */
+export interface PendingReviewRequestFinding {
+  reviewer: string;
+  hoursPending: number;
+}
+
 /** Structured analyzer output. Each analyzer fills its own key; more land as analyzers ship (#1477/#1478). */
 export interface BriefFindings {
   dependency?: DependencyFinding[];
@@ -393,6 +401,7 @@ export interface BriefFindings {
   undocumentedExport?: UndocumentedExportFinding[];
   staleBranch?: StaleBranchFinding[];
   commitHygiene?: CommitHygieneFinding[];
+  pendingReviewRequests?: PendingReviewRequestFinding[];
 }
 
 /** A JSDoc/TSDoc block whose `@param` tags name parameters the adjacent function no longer declares — a

--- a/review-enrichment/test/analyzer-registry.test.ts
+++ b/review-enrichment/test/analyzer-registry.test.ts
@@ -37,6 +37,7 @@ const EXPECTED_ANALYZERS = [
   "undocumentedExport",
   "staleBranch",
   "commitHygiene",
+  "pendingReviewRequests",
 ];
 
 test("analyzer descriptors cover the runtime registry in stable order", () => {

--- a/review-enrichment/test/pending-review-requests.test.ts
+++ b/review-enrichment/test/pending-review-requests.test.ts
@@ -1,0 +1,184 @@
+// Units for the pending review-request staleness analyzer. Own file (not enrichment.test.ts) so concurrent
+// analyzer PRs don't collide. All network is mocked. Runs against the compiled dist/.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  evaluatePendingReviewRequests,
+  latestReviewRequestTimes,
+  scanPendingReviewRequests,
+} from "../dist/analyzers/pending-review-requests.js";
+
+const jsonResponse = (body, code = 200) => new Response(JSON.stringify(body), { status: code });
+
+const req = (extra = {}) => ({
+  repoFullName: "octo/repo",
+  prNumber: 7,
+  githubToken: "test-token",
+  ...extra,
+});
+
+const NOW = Date.parse("2026-01-10T00:00:00Z");
+const hoursAgo = (h) => new Date(NOW - h * 60 * 60 * 1000).toISOString();
+
+const reviewRequestedEvent = (login, createdAt) => ({
+  event: "review_requested",
+  created_at: createdAt,
+  requested_reviewer: { login },
+});
+const teamRequestedEvent = (slug, createdAt) => ({
+  event: "review_requested",
+  created_at: createdAt,
+  requested_team: { slug },
+});
+
+test("latestReviewRequestTimes: keeps the LATEST review_requested timestamp per reviewer", () => {
+  const times = latestReviewRequestTimes([
+    reviewRequestedEvent("alice", "2026-01-01T00:00:00Z"),
+    reviewRequestedEvent("alice", "2026-01-05T00:00:00Z"),
+  ]);
+  assert.equal(times.get("alice"), "2026-01-05T00:00:00Z");
+});
+
+test("latestReviewRequestTimes: keys teams as team:slug (lowercased), independent of users", () => {
+  const times = latestReviewRequestTimes([
+    teamRequestedEvent("Backend", "2026-01-02T00:00:00Z"),
+    reviewRequestedEvent("alice", "2026-01-01T00:00:00Z"),
+  ]);
+  assert.equal(times.get("team:backend"), "2026-01-02T00:00:00Z");
+  assert.equal(times.get("alice"), "2026-01-01T00:00:00Z");
+});
+
+test("latestReviewRequestTimes: ignores non-review_requested events and events with no created_at", () => {
+  const times = latestReviewRequestTimes([
+    { event: "labeled", created_at: "2026-01-01T00:00:00Z" },
+    { event: "review_requested", requested_reviewer: { login: "alice" } }, // no created_at
+    { event: "review_requested", created_at: "2026-01-01T00:00:00Z" }, // no reviewer/team
+  ]);
+  assert.equal(times.size, 0);
+});
+
+test("evaluatePendingReviewRequests: flags a user request at/over the 48h threshold", () => {
+  const times = new Map([["alice", hoursAgo(48)]]);
+  const findings = evaluatePendingReviewRequests({ users: [{ login: "alice" }] }, times, NOW);
+  assert.deepEqual(findings, [{ reviewer: "alice", hoursPending: 48 }]);
+});
+
+test("evaluatePendingReviewRequests: does not flag a request just under the threshold", () => {
+  const times = new Map([["alice", hoursAgo(47)]]);
+  const findings = evaluatePendingReviewRequests({ users: [{ login: "alice" }] }, times, NOW);
+  assert.deepEqual(findings, []);
+});
+
+test("evaluatePendingReviewRequests: flags a stale team request, reported as team:slug", () => {
+  const times = new Map([["team:backend", hoursAgo(72)]]);
+  const findings = evaluatePendingReviewRequests({ teams: [{ slug: "backend" }] }, times, NOW);
+  assert.deepEqual(findings, [{ reviewer: "team:backend", hoursPending: 72 }]);
+});
+
+test("evaluatePendingReviewRequests: a pending reviewer with no matching timeline event is skipped, not guessed at", () => {
+  const findings = evaluatePendingReviewRequests({ users: [{ login: "alice" }] }, new Map(), NOW);
+  assert.deepEqual(findings, []);
+});
+
+test("evaluatePendingReviewRequests: reviewer lookup is case-insensitive", () => {
+  const times = new Map([["alice", hoursAgo(50)]]);
+  const findings = evaluatePendingReviewRequests({ users: [{ login: "Alice" }] }, times, NOW);
+  assert.deepEqual(findings, [{ reviewer: "Alice", hoursPending: 50 }]);
+});
+
+test("evaluatePendingReviewRequests: no findings when there are no pending users or teams", () => {
+  assert.deepEqual(evaluatePendingReviewRequests({}, new Map(), NOW), []);
+});
+
+test("scanPendingReviewRequests: end-to-end resolves a stale finding", async () => {
+  const findings = await scanPendingReviewRequests(req(), async (url) => {
+    if (url.includes("requested_reviewers")) return jsonResponse({ users: [{ login: "alice" }], teams: [] });
+    return jsonResponse([reviewRequestedEvent("alice", hoursAgo(60))]);
+  }, { now: NOW });
+  assert.deepEqual(findings, [{ reviewer: "alice", hoursPending: 60 }]);
+});
+
+test("scanPendingReviewRequests: no pending reviewers/teams short-circuits before fetching the timeline", async () => {
+  let timelineCalled = false;
+  const findings = await scanPendingReviewRequests(req(), async (url) => {
+    if (url.includes("requested_reviewers")) return jsonResponse({ users: [], teams: [] });
+    timelineCalled = true;
+    return jsonResponse([]);
+  });
+  assert.deepEqual(findings, []);
+  assert.equal(timelineCalled, false);
+});
+
+test("scanPendingReviewRequests: requests the expected URL shapes", async () => {
+  const urls = [];
+  await scanPendingReviewRequests(req(), async (url) => {
+    urls.push(url);
+    if (url.includes("requested_reviewers")) return jsonResponse({ users: [{ login: "alice" }], teams: [] });
+    return jsonResponse([reviewRequestedEvent("alice", hoursAgo(1))]);
+  });
+  assert.equal(urls[0], "https://api.github.com/repos/octo/repo/pulls/7/requested_reviewers");
+  assert.match(urls[1], /^https:\/\/api\.github\.com\/repos\/octo\/repo\/issues\/7\/timeline\?per_page=100&page=1$/);
+});
+
+test("scanPendingReviewRequests: a short timeline page (< per_page) stops pagination without a second request", async () => {
+  let calls = 0;
+  const findings = await scanPendingReviewRequests(req(), async (url) => {
+    if (url.includes("requested_reviewers")) return jsonResponse({ users: [{ login: "alice" }], teams: [] });
+    calls += 1;
+    return jsonResponse([reviewRequestedEvent("alice", hoursAgo(60))]);
+  }, { now: NOW });
+  assert.equal(calls, 1);
+  assert.deepEqual(findings, [{ reviewer: "alice", hoursPending: 60 }]);
+});
+
+test("scanPendingReviewRequests: walks a second timeline page to find a reviewer's true latest request", async () => {
+  const page1 = Array.from({ length: 100 }, () => ({ event: "labeled", created_at: hoursAgo(200) }));
+  const page2 = [reviewRequestedEvent("alice", hoursAgo(10))]; // fresh — request was recently re-issued
+  let calls = 0;
+  const findings = await scanPendingReviewRequests(req(), async (url) => {
+    if (url.includes("requested_reviewers")) return jsonResponse({ users: [{ login: "alice" }], teams: [] });
+    calls += 1;
+    return jsonResponse(url.includes("page=2") ? page2 : page1);
+  }, { now: NOW });
+  assert.equal(calls, 2);
+  assert.deepEqual(findings, []); // alice's true latest request is fresh (10h), not stale
+});
+
+test("scanPendingReviewRequests: an unconfirmed-complete timeline (still-full last page) fails closed", async () => {
+  const fullPage = Array.from({ length: 100 }, () => reviewRequestedEvent("alice", hoursAgo(200)));
+  let calls = 0;
+  const findings = await scanPendingReviewRequests(req(), async (url) => {
+    if (url.includes("requested_reviewers")) return jsonResponse({ users: [{ login: "alice" }], teams: [] });
+    calls += 1;
+    return jsonResponse(fullPage);
+  }, { now: NOW });
+  assert.equal(calls, 5); // MAX_TIMELINE_PAGES, not unbounded
+  assert.deepEqual(findings, []); // completeness unconfirmed -> fails closed, not a false-stale finding
+});
+
+test("scanPendingReviewRequests: a later-timeline-page fetch failure fails the whole call closed", async () => {
+  const findings = await scanPendingReviewRequests(req(), async (url) => {
+    if (url.includes("requested_reviewers")) return jsonResponse({ users: [{ login: "alice" }], teams: [] });
+    if (url.includes("page=2")) return jsonResponse({ message: "boom" }, 500);
+    return jsonResponse(Array.from({ length: 100 }, () => reviewRequestedEvent("alice", hoursAgo(200))));
+  }, { now: NOW });
+  assert.deepEqual(findings, []);
+});
+
+test("scanPendingReviewRequests: no GitHub token → skipped (no finding, no throw)", async () => {
+  const findings = await scanPendingReviewRequests(req({ githubToken: undefined }), async () => jsonResponse({}));
+  assert.deepEqual(findings, []);
+});
+
+test("scanPendingReviewRequests: a malformed repoFullName is skipped, not thrown", async () => {
+  const findings = await scanPendingReviewRequests(
+    req({ repoFullName: "not-a-valid-slug" }),
+    async () => jsonResponse({}),
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanPendingReviewRequests: the requested-reviewers fetch failing yields no finding", async () => {
+  const findings = await scanPendingReviewRequests(req(), async () => jsonResponse({ message: "bad" }, 500));
+  assert.deepEqual(findings, []);
+});

--- a/src/review/enrichment-analyzer-names.ts
+++ b/src/review/enrichment-analyzer-names.ts
@@ -31,6 +31,7 @@ export const REES_ANALYZER_NAMES = [
   "undocumentedExport",
   "staleBranch",
   "commitHygiene",
+  "pendingReviewRequests",
 ] as const;
 
 export type ReesAnalyzerName = (typeof REES_ANALYZER_NAMES)[number];

--- a/test/unit/enrichment-wire.test.ts
+++ b/test/unit/enrichment-wire.test.ts
@@ -626,7 +626,7 @@ describe("resolveReesAnalyzers", () => {
       resolveReesAnalyzers(
         env({
           REES_ANALYZERS:
-            "dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene",
+            "dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene,pendingReviewRequests",
         }),
       ),
     ).toEqual([
@@ -657,6 +657,7 @@ describe("resolveReesAnalyzers", () => {
       "undocumentedExport",
       "staleBranch",
       "commitHygiene",
+      "pendingReviewRequests",
     ]);
   });
 


### PR DESCRIPTION
## What

A new local REES analyzer, `pendingReviewRequests`, that flags a reviewer or team whose review request has been
outstanding 48+ hours with no response yet — a PR's own page shows WHO was requested, but not HOW LONG they've
been waiting.

## Detection (structured GitHub API fields only — a bounded, documented schema)

- Fetches the PR's currently pending requested reviewers/teams (`GET .../pulls/{n}/requested_reviewers`).
- Fetches the issue timeline (`GET .../issues/{n}/timeline`), reduces it to each reviewer/team's most recent
  `review_requested` event timestamp — a later re-request always supersedes an earlier one, the same semantics
  already used by the merged `approvalIntegrity` analyzer for reviews.
- Flags a pending reviewer/team whose latest request is 48+ hours old.

## Why it is bounded / merge-safe

It reads only documented fields from the GitHub API (`user.login`, `team.slug`, `event`, `created_at`) and
compares them — never diff, comment, or file content. There is no text/YAML/code parsing, so there are no
ambiguous-syntax edge cases. Fail-safe throughout: a missing token, malformed repo slug, either fetch failing, or
a missing timeline event for a pending reviewer (skipped, not guessed at) all yield no finding. Like
`approvalIntegrity`, this reports on **current** state (how long a request has been open), so an **incomplete**
timeline must fail closed rather than risk understating how long a request has actually been pending: pagination
is bounded (5 pages × 100 events) and a short page is the only way to confirm completeness — any page failure, or
exhausting the page cap while the last page was still full, yields no finding rather than a possibly-wrong one.
Mirrors the existing `blame-link` / `approval-integrity` / `ci-check-signals` / `stale-branch` /
`commit-hygiene` analyzers' structure (same header/fetch helper shape, fail-safe conventions, injectable clock
matching the existing `history` analyzer's pattern for deterministic tests).

## Value

A stale review request is easy to miss on a busy PR — the requested-reviewers list looks the same whether the
request is 10 minutes or 10 days old. Surfacing the wait time in the review brief gives a maintainer a concrete
signal for whether to ping/reassign a reviewer.

## Tests

`review-enrichment/test/pending-review-requests.test.ts` covers: the pure `latestReviewRequestTimes` reduction
(keeping the latest per reviewer, team keying, ignoring non-`review_requested`/malformed events), the pure
`evaluatePendingReviewRequests` reduction (the 48h threshold's boundary in both directions, team findings,
skipping a pending reviewer with no matching timeline event, case-insensitive login matching, the empty-input
case), and the network entrypoint's fail-safe paths (no token, malformed repo slug, the requested-reviewers fetch
failing, an empty pending set short-circuiting before the timeline is ever fetched, the exact two-endpoint URL
shapes, a short timeline page stopping pagination, walking a second page to find a reviewer's true latest
request, the pagination cap and an unconfirmed-complete timeline both failing closed, and a later-page fetch
failure also failing closed). Analyzer metadata is regenerated and committed.

## No linked issue

No linked issue because this is a net-new analyzer; there is no tracking issue to link.
