### PR TITLE
fix(selfhost): keep the backlog round-robin serving the stalest repo

### DIFF
--- a/src/selfhost/queue-fairness.ts
+++ b/src/selfhost/queue-fairness.ts
@@ -82,10 +82,14 @@ export function pickBacklogRepo(candidates: readonly BacklogRepoCandidate[], las
   const sorted = [...candidates].sort((a, b) => b.oldestPendingAgeMs - a.oldestPendingAgeMs || a.repo.localeCompare(b.repo));
   // sorted.length is provably >0 past the early return above, so every index below is in bounds.
   const stalest = sorted[0] as BacklogRepoCandidate;
-  if (!lastClaimedRepo) return stalest.repo;
-  const lastIndex = sorted.findIndex((candidate) => candidate.repo === lastClaimedRepo);
-  if (lastIndex === -1) return stalest.repo;
-  return (sorted[(lastIndex + 1) % sorted.length] as BacklogRepoCandidate).repo;
+  // Serve the stalest repo, EXCEPT when it is the one served last cycle — only then rotate to the
+  // next-stalest, so a single deep-backlog repo cannot monopolize the lane. When `lastClaimedRepo` is null,
+  // has since drained, or is simply some OTHER (less-stale) repo, the stalest was NOT just served, so it is
+  // served now — anything else would skip past the oldest backlog the lane exists to drain. (A positional
+  // "successor of the last-claimed repo" rotation would instead skip the stalest whenever the last-claimed
+  // repo sat at a middle rank, starving the very repo this mechanism is meant to protect.)
+  if (stalest.repo !== lastClaimedRepo) return stalest.repo;
+  return (sorted[1] ?? stalest).repo;
 }
 
 // Exported so the queue backends' own topBacklogRepos SQL (COUNT/GROUP BY/ORDER BY/LIMIT pushed into the

--- a/test/unit/selfhost-queue-fairness.test.ts
+++ b/test/unit/selfhost-queue-fairness.test.ts
@@ -122,6 +122,22 @@ describe("pickBacklogRepo (#selfhost-backlog-convergence)", () => {
     expect(pickBacklogRepo(candidates, "owner/a")).toBe("owner/b");
   });
 
+  it("serves the stalest repo (not the successor of the last-claimed one) when the last-claimed repo is not itself the stalest", () => {
+    const candidates = [
+      { repo: "owner/a", oldestPendingAgeMs: 5000 },
+      { repo: "owner/b", oldestPendingAgeMs: 3000 },
+      { repo: "owner/c", oldestPendingAgeMs: 1000 },
+    ];
+    // sorted stalest-first: a(5000), b(3000), c(1000). Last-claimed b was NOT the stalest, so the stalest (a)
+    // was not just served and must be served now — rotation only applies when the stalest itself was last served.
+    expect(pickBacklogRepo(candidates, "owner/b")).toBe("owner/a");
+  });
+
+  it("re-serves the only candidate even when it was the last-claimed repo (nothing else to rotate to)", () => {
+    const candidates = [{ repo: "owner/b", oldestPendingAgeMs: 5000 }];
+    expect(pickBacklogRepo(candidates, "owner/b")).toBe("owner/b");
+  });
+
   it("falls back to the stalest repo when the last-claimed repo has since drained (no longer a candidate)", () => {
     const candidates = [{ repo: "owner/b", oldestPendingAgeMs: 5000 }];
     expect(pickBacklogRepo(candidates, "owner/a")).toBe("owner/b");


### PR DESCRIPTION
## Summary

`pickBacklogRepo` in `src/selfhost/queue-fairness.ts` is the per-repo round-robin the SQLite/Postgres queue
backends use to decide which repo's backlog-convergence job to claim next. Its documented contract is:

> pick the repo whose oldest pending backlog job is **stalest**, EXCEPT when **that** repo was also the last
> one served — in that case, rotate to the next-stalest so a single repo with a deep backlog cannot monopolize
> every backlog-lane claim and starve every other repo's backlog.

The implementation instead rotated by **position of the last-claimed repo** in the staleness order:

```ts
const lastIndex = sorted.findIndex((candidate) => candidate.repo === lastClaimedRepo);
if (lastIndex === -1) return stalest.repo;
return (sorted[(lastIndex + 1) % sorted.length]).repo;
```

`sorted[(lastIndex + 1) % len]` only equals "the next-stalest" when the last-claimed repo **is** the stalest
(`lastIndex === 0`). When the last-claimed repo sits at a **middle rank** — which happens routinely, because a
repo that was just served is usually no longer the stalest on the next cycle while other repos have aged — the
code returns the repo *after it in the ordering* and **skips the actual stalest repo**, starving the very repo
the mechanism exists to protect.

### Concrete failure

Candidates (age ms): `a=5000`, `b=3000`, `c=1000` → staleness order `a, b, c`. Last claimed = `b` (not the
stalest).

- **Documented / correct:** `a` is stalest and was not just served → serve **`a`**.
- **Old code:** `lastIndex(b) = 1` → `sorted[(1 + 1) % 3] = sorted[2]` → serves **`c`**, skipping the stalest `a`.

### Fix

Serve the stalest repo unless it was the one served last cycle; only then rotate to the next-stalest. This also
subsumes the null / since-drained / different-repo cases (none of those is the stalest-just-served case, so the
stalest is served), and needs no positional index:

```ts
if (stalest.repo !== lastClaimedRepo) return stalest.repo;
return (sorted[1] ?? stalest).repo;
```

All five existing `pickBacklogRepo` tests still pass unchanged (their last-claimed repo is either the stalest,
the least-stale of two — where the old modulo happened to wrap to the stalest — absent, or since-drained). Two
regression tests are added: the middle-rank case above (which fails on the old code, returning `owner/c`
instead of `owner/a`), and a single-candidate re-serve case that covers the `sorted[1] ?? stalest` fallback.

No linked issue: a self-contained correctness fix to one pure function with full unit coverage; the summary
explains the defect and the fix, matching the repo's `preferred` (not required) linked-issue policy.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (`tsc --noEmit` — exit 0)
- [ ] `npm run rees:test` (N/A — no review-enrichment change)
- [x] `npm run test:coverage` (the changed lines are covered — see below)
- [ ] `npm run ui:build` (N/A — no UI change)
- [ ] `npm audit --audit-level=moderate` (N/A — no dependency change)
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran locally: `git diff --check` (clean), `tsc --noEmit` (exit 0), the unit suite for this module
  (`test/unit/selfhost-queue-fairness.test.ts` — 31/31 pass, including the two new regression tests), and the
  queue integration suite (`test/unit/selfhost-sqlite-queue.test.ts` — 138/138 pass, so the claim path is
  unaffected). Every changed line is exercised: the `stalest.repo !== lastClaimedRepo` true branch by the
  first-pick / least-stale / not-stalest / drained / tie cases, its false branch by the stalest-just-served
  and single-candidate cases, and the `sorted[1] ?? stalest` fallback by the single-candidate re-serve case.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Behavior change is confined to the previously-mishandled case (last-claimed repo present but not the
  stalest); every other input returns exactly what it did before, so no caller that relied on the correct
  cases is affected. The function remains pure and deterministic.
