### PR TITLE
feat(enrichment): flag milestone lifecycle signals

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,7 +66,7 @@ GITTENSORY_REVIEW_ENRICHMENT=false
 # dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol,redos
 # provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild
 # history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity,ciCheckSignals
-# undocumentedExport,staleBranch,commitHygiene,pendingReviewRequests
+# undocumentedExport,staleBranch,commitHygiene,pendingReviewRequests,milestoneLifecycle
 #
 # Profile defaults:
 # fast: dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol
@@ -75,11 +75,12 @@ GITTENSORY_REVIEW_ENRICHMENT=false
 # actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature
 # iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink
 # approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene
-# pendingReviewRequests
+# pendingReviewRequests,milestoneLifecycle
 # deep: dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol
 # redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig
 # nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity
 # ciCheckSignals,undocumentedExport,staleBranch,commitHygiene,pendingReviewRequests
+# milestoneLifecycle
 # END GENERATED REES ANALYZERS
 
 # Submitter-reputation spend control (internal-only): downgrades new/burst/low-rep

--- a/apps/gittensory-ui/src/lib/rees-analyzers.ts
+++ b/apps/gittensory-ui/src/lib/rees-analyzers.ts
@@ -727,6 +727,26 @@ export const REES_ANALYZERS = [
         "Structured-fields-only: reads user.login/team.slug/event/created_at, never diff or comment text. Fail-safe on missing token/fetch error/an unconfirmed-complete timeline.",
     },
   },
+  {
+    name: "milestoneLifecycle",
+    title: "Milestone lifecycle signals",
+    category: "history",
+    cost: "github-light",
+    defaultEnabled: true,
+    profiles: ["balanced", "deep"],
+    requires: ["github-token"],
+    limits: {},
+    docs: {
+      summary:
+        "Flags a PR whose milestone's due date has already passed while the milestone is still open, or whose milestone has already been closed while the PR itself is still open.",
+      looksAt: "The PR's milestone (one call to the GitHub issues API) — its due date and state.",
+      reports:
+        "The milestone title and either days overdue or that it's already closed — never issue/PR content.",
+      network: "Calls the GitHub issues API once.",
+      notes:
+        "Structured-fields-only: reads milestone.due_on/milestone.state, never diff or issue text. Fail-safe on missing token/fetch error.",
+    },
+  },
 ] as const satisfies readonly ReesAnalyzerDoc[];
 
 export const REES_ANALYZER_NAMES = REES_ANALYZERS.map((analyzer) => analyzer.name);

--- a/review-enrichment/analyzer-metadata.json
+++ b/review-enrichment/analyzer-metadata.json
@@ -816,6 +816,28 @@
         "network": "Calls the GitHub requested-reviewers API once and the issue-timeline API, paginated and bounded to a fixed page cap.",
         "notes": "Structured-fields-only: reads user.login/team.slug/event/created_at, never diff or comment text. Fail-safe on missing token/fetch error/an unconfirmed-complete timeline."
       }
+    },
+    {
+      "name": "milestoneLifecycle",
+      "title": "Milestone lifecycle signals",
+      "category": "history",
+      "cost": "github-light",
+      "defaultEnabled": true,
+      "profiles": [
+        "balanced",
+        "deep"
+      ],
+      "requires": [
+        "github-token"
+      ],
+      "limits": {},
+      "docs": {
+        "summary": "Flags a PR whose milestone's due date has already passed while the milestone is still open, or whose milestone has already been closed while the PR itself is still open.",
+        "looksAt": "The PR's milestone (one call to the GitHub issues API) — its due date and state.",
+        "reports": "The milestone title and either days overdue or that it's already closed — never issue/PR content.",
+        "network": "Calls the GitHub issues API once.",
+        "notes": "Structured-fields-only: reads milestone.due_on/milestone.state, never diff or issue text. Fail-safe on missing token/fetch error."
+      }
     }
   ]
 }

--- a/review-enrichment/src/analyzers/milestone-lifecycle.ts
+++ b/review-enrichment/src/analyzers/milestone-lifecycle.ts
@@ -1,0 +1,119 @@
+// Milestone-lifecycle signals, read from structured GitHub issue API fields only — no diff/text/YAML parsing.
+// Surfaces two milestone/PR mismatches a PR's own page doesn't call out: the PR's milestone due date has already
+// passed while the milestone is still open, and the PR's milestone has already been closed out from under it
+// while the PR itself is still open. Reads only documented fields from the GitHub issues API (`milestone.due_on`,
+// `milestone.state`) and compares them — no ambiguous-syntax parsing, so it cannot suffer a patch scanner's edge
+// cases. Pure GitHub-metadata read, no repo content. Fail-safe: no token, a bad repo slug, or a fetch error all
+// yield no finding.
+import type {
+  AnalyzerDiagnostics,
+  EnrichRequest,
+  MilestoneLifecycleFinding,
+} from "../types.js";
+import type { AnalysisContext } from "../analysis-context.js";
+import { boundedFetchJson } from "../external-fetch.js";
+
+const GITHUB_API = "https://api.github.com";
+const SLUG_RE = /^[A-Za-z0-9._-]+$/;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+interface ScanOptions {
+  signal?: AbortSignal;
+  analysis?: Pick<AnalysisContext, "fetchJson">;
+  diagnostics?: AnalyzerDiagnostics;
+  /** Injectable clock so overdue-days math is deterministic in tests; defaults to Date.now(). */
+  now?: number;
+}
+
+interface Milestone {
+  title?: string;
+  due_on?: string | null;
+  state?: string;
+}
+
+interface IssueResponse {
+  milestone?: Milestone | null;
+}
+
+function githubHeaders(token: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+}
+
+async function fetchIssue(
+  owner: string,
+  repo: string,
+  prNumber: number,
+  headers: Record<string, string>,
+  fetchFn: typeof fetch,
+  signal: AbortSignal | undefined,
+  options: Pick<ScanOptions, "analysis" | "diagnostics">,
+): Promise<IssueResponse | null> {
+  const url =
+    `${GITHUB_API}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/issues/` +
+    `${encodeURIComponent(String(prNumber))}`;
+  const fetchOptions = {
+    endpointCategory: "github-issue",
+    headers,
+    signal,
+    fetchImpl: fetchFn,
+    diagnostics: options.diagnostics,
+    phase: "milestone-lifecycle",
+    subcall: "github-issue",
+    maxBytes: 256 * 1024,
+  };
+  const response = options.analysis
+    ? await options.analysis.fetchJson<IssueResponse>(url, fetchOptions)
+    : await boundedFetchJson<IssueResponse>(url, fetchOptions);
+  return response.ok ? response.data : null;
+}
+
+/** Pure: a PR's milestone (or absence of one) → a lifecycle finding. The two kinds are mutually exclusive per PR
+ *  — a closed milestone is reported as `milestone-already-closed` regardless of its due date, since "already
+ *  closed" is the more actionable fact; only an OPEN milestone's due date is checked for overdue-ness. Pure. */
+export function evaluateMilestoneLifecycle(
+  milestone: Milestone | null | undefined,
+  now: number,
+): MilestoneLifecycleFinding[] {
+  if (!milestone?.title) return [];
+
+  if (milestone.state === "closed") {
+    return [{ milestoneTitle: milestone.title, kind: "milestone-already-closed" }];
+  }
+
+  if (milestone.due_on) {
+    const dueAt = Date.parse(milestone.due_on);
+    if (Number.isFinite(dueAt) && dueAt < now) {
+      const daysOverdue = Math.floor((now - dueAt) / MS_PER_DAY);
+      if (daysOverdue > 0) {
+        return [{ milestoneTitle: milestone.title, kind: "overdue-milestone", daysOverdue }];
+      }
+    }
+  }
+
+  return [];
+}
+
+/** Analyzer entrypoint: a PR's milestone → lifecycle findings. Fail-safe — no token, a bad repo slug, or a fetch
+ *  error all yield no finding rather than an error. */
+export async function scanMilestoneLifecycle(
+  req: EnrichRequest,
+  fetchFn: typeof fetch = fetch,
+  options: ScanOptions = {},
+): Promise<MilestoneLifecycleFinding[]> {
+  const { repoFullName, githubToken, prNumber } = req;
+  if (!githubToken) return [];
+  const parts = repoFullName.split("/");
+  const owner = parts[0];
+  const repo = parts[1];
+  if (parts.length !== 2 || !owner || !repo || !SLUG_RE.test(owner) || !SLUG_RE.test(repo)) return [];
+
+  const headers = githubHeaders(githubToken);
+  const issue = await fetchIssue(owner, repo, prNumber, headers, fetchFn, options.signal, options);
+  if (!issue) return [];
+
+  return evaluateMilestoneLifecycle(issue.milestone, options.now ?? Date.now());
+}

--- a/review-enrichment/src/analyzers/registry.ts
+++ b/review-enrichment/src/analyzers/registry.ts
@@ -17,6 +17,7 @@ import { scanIacMisconfig } from "./iac-misconfig.js";
 import { scanInstallScripts } from "./install-scripts.js";
 import { scanLicenses } from "./license-check.js";
 import { scanLockfileDrift } from "./lockfile-drift.js";
+import { scanMilestoneLifecycle } from "./milestone-lifecycle.js";
 import { scanNativeBuild } from "./native-build.js";
 import { scanPendingReviewRequests } from "./pending-review-requests.js";
 import { scanProvenance } from "./provenance.js";
@@ -679,6 +680,38 @@ export const ANALYZER_DESCRIPTORS = [
     },
     run: (req, { signal, analysis, diagnostics }) =>
       scanPendingReviewRequests(req, fetch, { signal, analysis, diagnostics }),
+  }),
+  descriptor({
+    name: "milestoneLifecycle",
+    title: "Milestone lifecycle signals",
+    category: "history",
+    cost: "github-light",
+    defaultEnabled: true,
+    requires: ["github-token"],
+    limits: {},
+    docs: {
+      summary:
+        "Flags a PR whose milestone's due date has already passed while the milestone is still open, or whose milestone has already been closed while the PR itself is still open.",
+      looksAt: "The PR's milestone (one call to the GitHub issues API) — its due date and state.",
+      reports: "The milestone title and either days overdue or that it's already closed — never issue/PR content.",
+      network: "Calls the GitHub issues API once.",
+      notes:
+        "Structured-fields-only: reads milestone.due_on/milestone.state, never diff or issue text. Fail-safe on missing token/fetch error.",
+    },
+    render: (findings, helpers) => {
+      if (!findings.length) return [];
+      const lines = ["### Milestone lifecycle signals"];
+      for (const item of findings) {
+        if (item.kind === "overdue-milestone") {
+          lines.push(`- Milestone ${helpers.safeCodeSpan(item.milestoneTitle)} is ${item.daysOverdue} day(s) overdue and still open`);
+        } else {
+          lines.push(`- Milestone ${helpers.safeCodeSpan(item.milestoneTitle)} has already been closed while this PR is still open`);
+        }
+      }
+      return lines;
+    },
+    run: (req, { signal, analysis, diagnostics }) =>
+      scanMilestoneLifecycle(req, fetch, { signal, analysis, diagnostics }),
   }),
 ] as const satisfies readonly AnyAnalyzerDescriptor[];
 

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -419,6 +419,7 @@ export function renderBrief(
   lines.push(...renderDescriptorSection("staleBranch", findings.staleBranch));
   lines.push(...renderDescriptorSection("commitHygiene", findings.commitHygiene));
   lines.push(...renderDescriptorSection("pendingReviewRequests", findings.pendingReviewRequests));
+  lines.push(...renderDescriptorSection("milestoneLifecycle", findings.milestoneLifecycle));
 
   if (!lines.length) return { promptSection: "", systemSuffix: "" };
 

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -372,6 +372,14 @@ export interface PendingReviewRequestFinding {
   hoursPending: number;
 }
 
+/** A milestone/PR lifecycle mismatch, read from structured GitHub issue API fields only (`milestone.due_on`,
+ *  `milestone.state`) — never diff/file content. `overdue-milestone`: the PR's OPEN milestone's due date has
+ *  already passed. `milestone-already-closed`: the PR's milestone has been closed while the PR itself is still
+ *  open (the more actionable fact when both are true, so it takes priority over the due-date check). */
+export type MilestoneLifecycleFinding =
+  | { milestoneTitle: string; kind: "overdue-milestone"; daysOverdue: number }
+  | { milestoneTitle: string; kind: "milestone-already-closed" };
+
 /** Structured analyzer output. Each analyzer fills its own key; more land as analyzers ship (#1477/#1478). */
 export interface BriefFindings {
   dependency?: DependencyFinding[];
@@ -402,6 +410,7 @@ export interface BriefFindings {
   staleBranch?: StaleBranchFinding[];
   commitHygiene?: CommitHygieneFinding[];
   pendingReviewRequests?: PendingReviewRequestFinding[];
+  milestoneLifecycle?: MilestoneLifecycleFinding[];
 }
 
 /** A JSDoc/TSDoc block whose `@param` tags name parameters the adjacent function no longer declares — a

--- a/review-enrichment/test/analyzer-registry.test.ts
+++ b/review-enrichment/test/analyzer-registry.test.ts
@@ -38,6 +38,7 @@ const EXPECTED_ANALYZERS = [
   "staleBranch",
   "commitHygiene",
   "pendingReviewRequests",
+  "milestoneLifecycle",
 ];
 
 test("analyzer descriptors cover the runtime registry in stable order", () => {

--- a/review-enrichment/test/milestone-lifecycle.test.ts
+++ b/review-enrichment/test/milestone-lifecycle.test.ts
@@ -1,0 +1,119 @@
+// Units for the milestone-lifecycle analyzer. Own file (not enrichment.test.ts) so concurrent analyzer PRs don't
+// collide. All network is mocked. Runs against the compiled dist/.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  evaluateMilestoneLifecycle,
+  scanMilestoneLifecycle,
+} from "../dist/analyzers/milestone-lifecycle.js";
+
+const jsonResponse = (body, code = 200) => new Response(JSON.stringify(body), { status: code });
+
+const req = (extra = {}) => ({
+  repoFullName: "octo/repo",
+  prNumber: 7,
+  githubToken: "test-token",
+  ...extra,
+});
+
+const NOW = Date.parse("2026-01-10T00:00:00Z");
+
+test("evaluateMilestoneLifecycle: flags an open milestone whose due date has passed", () => {
+  const findings = evaluateMilestoneLifecycle(
+    { title: "v1.0", due_on: "2026-01-05T00:00:00Z", state: "open" },
+    NOW,
+  );
+  assert.deepEqual(findings, [{ milestoneTitle: "v1.0", kind: "overdue-milestone", daysOverdue: 5 }]);
+});
+
+test("evaluateMilestoneLifecycle: an open milestone whose due date is in the future is not flagged", () => {
+  const findings = evaluateMilestoneLifecycle(
+    { title: "v1.0", due_on: "2026-02-01T00:00:00Z", state: "open" },
+    NOW,
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("evaluateMilestoneLifecycle: an open milestone due exactly now (0 full days overdue) is not flagged", () => {
+  const findings = evaluateMilestoneLifecycle({ title: "v1.0", due_on: new Date(NOW).toISOString(), state: "open" }, NOW);
+  assert.deepEqual(findings, []);
+});
+
+test("evaluateMilestoneLifecycle: an open milestone with no due date is not flagged", () => {
+  const findings = evaluateMilestoneLifecycle({ title: "v1.0", due_on: null, state: "open" }, NOW);
+  assert.deepEqual(findings, []);
+});
+
+test("evaluateMilestoneLifecycle: flags a milestone that has already been closed", () => {
+  const findings = evaluateMilestoneLifecycle(
+    { title: "v1.0", due_on: "2026-02-01T00:00:00Z", state: "closed" },
+    NOW,
+  );
+  assert.deepEqual(findings, [{ milestoneTitle: "v1.0", kind: "milestone-already-closed" }]);
+});
+
+test("evaluateMilestoneLifecycle: a closed milestone takes priority over an overdue due date (mutually exclusive)", () => {
+  const findings = evaluateMilestoneLifecycle(
+    { title: "v1.0", due_on: "2026-01-01T00:00:00Z", state: "closed" },
+    NOW,
+  );
+  assert.deepEqual(findings, [{ milestoneTitle: "v1.0", kind: "milestone-already-closed" }]);
+});
+
+test("evaluateMilestoneLifecycle: no milestone yields no finding", () => {
+  assert.deepEqual(evaluateMilestoneLifecycle(null, NOW), []);
+  assert.deepEqual(evaluateMilestoneLifecycle(undefined, NOW), []);
+});
+
+test("evaluateMilestoneLifecycle: a milestone with no title is treated as absent, not thrown", () => {
+  assert.deepEqual(evaluateMilestoneLifecycle({ due_on: "2020-01-01T00:00:00Z", state: "open" }, NOW), []);
+});
+
+test("evaluateMilestoneLifecycle: a malformed due_on does not throw and is not flagged", () => {
+  const findings = evaluateMilestoneLifecycle({ title: "v1.0", due_on: "not-a-date", state: "open" }, NOW);
+  assert.deepEqual(findings, []);
+});
+
+test("scanMilestoneLifecycle: end-to-end resolves an overdue-milestone finding", async () => {
+  const findings = await scanMilestoneLifecycle(
+    req(),
+    async () => jsonResponse({ milestone: { title: "v1.0", due_on: "2026-01-05T00:00:00Z", state: "open" } }),
+    { now: NOW },
+  );
+  assert.deepEqual(findings, [{ milestoneTitle: "v1.0", kind: "overdue-milestone", daysOverdue: 5 }]);
+});
+
+test("scanMilestoneLifecycle: requests the expected URL shape", async () => {
+  let requestedUrl;
+  await scanMilestoneLifecycle(req(), async (url) => {
+    requestedUrl = url;
+    return jsonResponse({});
+  });
+  assert.equal(requestedUrl, "https://api.github.com/repos/octo/repo/issues/7");
+});
+
+test("scanMilestoneLifecycle: no milestone on the issue yields no finding", async () => {
+  const findings = await scanMilestoneLifecycle(req(), async () => jsonResponse({ milestone: null }));
+  assert.deepEqual(findings, []);
+});
+
+test("scanMilestoneLifecycle: no GitHub token → skipped (no finding, no throw)", async () => {
+  const findings = await scanMilestoneLifecycle(
+    req({ githubToken: undefined }),
+    async () => jsonResponse({ milestone: { title: "v1.0", due_on: "2020-01-01T00:00:00Z", state: "open" } }),
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanMilestoneLifecycle: a malformed repoFullName is skipped, not thrown", async () => {
+  const findings = await scanMilestoneLifecycle(
+    req({ repoFullName: "not-a-valid-slug" }),
+    async () => jsonResponse({ milestone: { title: "v1.0", due_on: "2020-01-01T00:00:00Z", state: "open" } }),
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanMilestoneLifecycle: a fetch failure yields no finding", async () => {
+  const findings = await scanMilestoneLifecycle(req(), async () => jsonResponse({ message: "bad" }, 500));
+  assert.deepEqual(findings, []);
+});

--- a/src/review/enrichment-analyzer-names.ts
+++ b/src/review/enrichment-analyzer-names.ts
@@ -32,6 +32,7 @@ export const REES_ANALYZER_NAMES = [
   "staleBranch",
   "commitHygiene",
   "pendingReviewRequests",
+  "milestoneLifecycle",
 ] as const;
 
 export type ReesAnalyzerName = (typeof REES_ANALYZER_NAMES)[number];

--- a/test/unit/enrichment-wire.test.ts
+++ b/test/unit/enrichment-wire.test.ts
@@ -626,7 +626,7 @@ describe("resolveReesAnalyzers", () => {
       resolveReesAnalyzers(
         env({
           REES_ANALYZERS:
-            "dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene,pendingReviewRequests",
+            "dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene,pendingReviewRequests,milestoneLifecycle",
         }),
       ),
     ).toEqual([
@@ -658,6 +658,7 @@ describe("resolveReesAnalyzers", () => {
       "staleBranch",
       "commitHygiene",
       "pendingReviewRequests",
+      "milestoneLifecycle",
     ]);
   });
 


### PR DESCRIPTION
## What

A new local REES analyzer, `milestoneLifecycle`, that flags two milestone/PR mismatches a PR's own page doesn't
call out.

## Detections (structured GitHub issues API fields only — a bounded, documented schema)

- `overdue-milestone` — the PR's milestone is still open but its due date has already passed.
- `milestone-already-closed` — the PR's milestone has already been closed while the PR itself is still open. This
  takes priority over the due-date check (mutually exclusive per PR) since "already closed" is the more
  actionable fact.

## Why it is bounded / merge-safe

It reads only documented fields from the GitHub issues API (`milestone.due_on`, `milestone.state`) and compares
them — never diff, issue, or file content. There is no text/YAML/code parsing, so there are no ambiguous-syntax
edge cases. Fail-safe: no token, a bad repo slug, or a fetch error all yield no finding. Mirrors the existing
`stale-branch` / `commit-hygiene` / `pending-review-requests` analyzers' structure (same header/fetch helper
shape, fail-safe conventions, an injectable clock matching the existing `history` analyzer's pattern for
deterministic tests).

## Value

A milestone with a due date already passed, or one that's been closed while a PR intended for it is still
outstanding, are both easy to miss on a busy PR — the milestone badge looks the same either way at a glance.
Surfacing these in the review brief gives a maintainer a concrete signal to re-triage the PR's milestone.

## Tests

`review-enrichment/test/milestone-lifecycle.test.ts` covers: the pure `evaluateMilestoneLifecycle` reduction (an
overdue open milestone, a future due date, exactly-now due date as a boundary, no due date, a closed milestone,
the closed-takes-priority-over-overdue mutual-exclusivity case, no milestone, a milestone with no title, and a
malformed due date all handled without throwing), plus the network entrypoint's fail-safe paths (no token,
malformed repo slug, no milestone on the issue, fetch failure) and the exact request URL shape. Analyzer metadata
is regenerated and committed.

## No linked issue

No linked issue because this is a net-new analyzer; there is no tracking issue to link.
