### PR TITLE
feat(enrichment): detect more SaaS/cloud/CI credential formats in secret-scan

### DIFF
--- a/review-enrichment/src/analyzers/secret-scan.ts
+++ b/review-enrichment/src/analyzers/secret-scan.ts
@@ -170,6 +170,108 @@ const RULES: Rule[] = [
     confidence: "high",
   },
   {
+    // Google OAuth 2.0 client secret: `GOCSPX-` + 28 base64url chars.
+    kind: "google_oauth_client_secret",
+    re: /\bGOCSPX-[A-Za-z0-9_-]{28}\b/,
+    confidence: "high",
+  },
+  {
+    // Stripe webhook signing secret: `whsec_` + >=32 base62.
+    kind: "stripe_webhook_secret",
+    re: /\bwhsec_[A-Za-z0-9]{32,}\b/,
+    confidence: "high",
+  },
+  {
+    // Databricks personal access token: `dapi` + 32 hex.
+    kind: "databricks_pat",
+    re: /\bdapi[0-9a-f]{32}\b/,
+    confidence: "high",
+  },
+  {
+    // Telegram bot token: an 8-10 digit bot id, `:`, then 35 base64url chars.
+    kind: "telegram_bot_token",
+    re: /\b\d{8,10}:[A-Za-z0-9_-]{35}\b/,
+    confidence: "high",
+  },
+  {
+    // RubyGems API key: `rubygems_` + 48 hex.
+    kind: "rubygems_api_key",
+    re: /\brubygems_[a-f0-9]{48}\b/,
+    confidence: "high",
+  },
+  {
+    // Terraform Cloud/Enterprise API token: 14 base62 + the `.atlasv1.` marker + >=60 base62/._- body.
+    kind: "terraform_cloud_token",
+    re: /\b[A-Za-z0-9]{14}\.atlasv1\.[A-Za-z0-9._-]{60,}/,
+    confidence: "high",
+  },
+  {
+    // PlanetScale database password: `pscale_pw_` + >=32 base62/._- (may end in `-`/`_`/`.`, so lookahead terminator).
+    kind: "planetscale_password",
+    re: /\bpscale_pw_[A-Za-z0-9._-]{32,}(?![A-Za-z0-9._-])/,
+    confidence: "high",
+  },
+  {
+    // PlanetScale service token: `pscale_tkn_` + >=32 base62/._- (lookahead terminator).
+    kind: "planetscale_token",
+    re: /\bpscale_tkn_[A-Za-z0-9._-]{32,}(?![A-Za-z0-9._-])/,
+    confidence: "high",
+  },
+  {
+    // Prefect Cloud API key: `pnu_` + 36 base62.
+    kind: "prefect_api_key",
+    re: /\bpnu_[A-Za-z0-9]{36}\b/,
+    confidence: "high",
+  },
+  {
+    // HashiCorp Vault service (`hvs.`) or batch (`hvb.`) token + >=24 base64url (lookahead terminator).
+    kind: "vault_service_token",
+    re: /\bhv[sb]\.[A-Za-z0-9_-]{24,}(?![A-Za-z0-9_-])/,
+    confidence: "high",
+  },
+  {
+    // Mailchimp API key: 32 hex + `-us` + a 1-2 digit datacenter suffix (the suffix disambiguates it from a bare hash).
+    kind: "mailchimp_api_key",
+    re: /\b[0-9a-f]{32}-us[0-9]{1,2}\b/,
+    confidence: "high",
+  },
+  {
+    // Slack incoming-webhook URL (hooks.slack.com/services/T…/B…/…): a postable message-egress secret endpoint.
+    kind: "slack_webhook_url",
+    re: /\bhttps:\/\/hooks\.slack\.com\/services\/T[A-Za-z0-9_]{8,}\/B[A-Za-z0-9_]{8,}\/[A-Za-z0-9_]{24}\b/,
+    confidence: "high",
+  },
+  {
+    // Airtable personal access token: `pat` + 14 base62 + `.` + 64 hex.
+    kind: "airtable_pat",
+    re: /\bpat[A-Za-z0-9]{14}\.[a-f0-9]{64}\b/,
+    confidence: "high",
+  },
+  {
+    // GitLab pipeline trigger token: `glptt-` + 40 hex.
+    kind: "gitlab_pipeline_trigger_token",
+    re: /\bglptt-[0-9a-f]{40}\b/,
+    confidence: "high",
+  },
+  {
+    // GitLab runner authentication token: `glrt-` + 20 base64url (distinct from the `glpat-` personal token above).
+    kind: "gitlab_runner_token",
+    re: /\bglrt-[0-9A-Za-z_-]{20}\b/,
+    confidence: "high",
+  },
+  {
+    // Shippo API token: `shippo_live_`/`shippo_test_` + 40 hex.
+    kind: "shippo_api_token",
+    re: /\bshippo_(?:live|test)_[a-f0-9]{40}\b/,
+    confidence: "high",
+  },
+  {
+    // Fly.io API token: `fo1_` + 43 base64url.
+    kind: "flyio_token",
+    re: /\bfo1_[A-Za-z0-9_-]{43}\b/,
+    confidence: "high",
+  },
+  {
     kind: "private_key",
     re: /-----BEGIN (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----/,
     confidence: "high",

--- a/review-enrichment/test/secret-scan.test.ts
+++ b/review-enrichment/test/secret-scan.test.ts
@@ -396,3 +396,49 @@ test("scanPatch does not flag a Mailgun-shaped key with an invalid body characte
   const findings = scanPatch("src/config.ts", hunk([`const mg = "${invalid}";`]));
   assert.equal(findings.length, 0);
 });
+
+test("scanPatch flags additional high-confidence SaaS/cloud/CI credential formats", () => {
+  const cases = [
+    ["google_oauth_client_secret", "GOCSPX-" + b62(28)],
+    ["stripe_webhook_secret", "whsec_" + b62(32)],
+    ["databricks_pat", "dapi" + hex(32)],
+    ["telegram_bot_token", "1234567890" + ":" + b62(35)],
+    ["rubygems_api_key", "rubygems_" + hex(48)],
+    ["terraform_cloud_token", b62(14) + ".atlasv1." + b62(60)],
+    ["planetscale_password", "pscale_pw_" + b62(32)],
+    ["planetscale_token", "pscale_tkn_" + b62(32)],
+    ["prefect_api_key", "pnu_" + b62(36)],
+    ["vault_service_token", "hvs." + b62(24)],
+    ["mailchimp_api_key", hex(32) + "-us12"],
+    ["slack_webhook_url", "https://hooks.slack.com/services/T" + b62(8) + "/B" + b62(8) + "/" + b62(24)],
+    ["airtable_pat", "pat" + b62(14) + "." + hex(64)],
+    ["gitlab_pipeline_trigger_token", "glptt-" + hex(40)],
+    ["gitlab_runner_token", "glrt-" + b62(20)],
+    ["shippo_api_token", "shippo_live_" + hex(40)],
+    ["flyio_token", "fo1_" + b62(43)],
+  ];
+  for (const [kind, secret] of cases) {
+    const findings = scanPatch("src/config.ts", hunk([`const c = "${secret}";`]));
+    assert.equal(findings.length, 1, `${kind}: expected exactly one finding, got ${JSON.stringify(findings)}`);
+    assert.equal(findings[0].kind, kind, `${kind}: wrong kind`);
+    assert.equal(findings[0].confidence, "high", `${kind}: wrong confidence`);
+  }
+});
+
+test("scanPatch does not flag near-miss variants of the new SaaS/cloud credential formats", () => {
+  // One char short of the fixed length (or missing a required disambiguator) must produce no finding.
+  const nearMisses = [
+    "GOCSPX-" + b62(27),
+    "dapi" + hex(31),
+    "rubygems_" + hex(47),
+    "pnu_" + b62(35),
+    hex(32) + "-us", // Mailchimp shape without the datacenter digits
+    "glptt-" + hex(39),
+    "fo1_" + b62(42),
+    "airtable_" + b62(20), // no Airtable pat<id>.<hex> shape
+  ];
+  for (const nm of nearMisses) {
+    const findings = scanPatch("src/config.ts", hunk([`const c = "${nm}";`]));
+    assert.equal(findings.length, 0, `near-miss should not match: ${nm}`);
+  }
+});


### PR DESCRIPTION
## Summary

The secret-scan analyzer (`review-enrichment/src/analyzers/secret-scan.ts`) flags credentials committed in a
PR diff, citing `file:line` + kind only (never the value). This adds **17 more widely-used SaaS / cloud / CI
credential formats** the scanner currently misses, continuing the recently-merged secret-format additions
(Anthropic, Slack enterprise/cookie, GitHub fine-grained PAT, DigitalOcean, Shopify, Notion, Mailgun, my
earlier cloud/SaaS batch, …).

Each new rule is a high-confidence, gitleaks/trufflehog-standard shape with a **distinctive multi-character
literal prefix (or fixed marker) and a fixed/tightly-bounded length + charset**, so the false-positive rate
against ordinary source, base64 blobs, hex hashes, and UUIDs is effectively zero:

| kind | shape |
|---|---|
| `google_oauth_client_secret` | `GOCSPX-` + 28 base64url |
| `stripe_webhook_secret` | `whsec_` + ≥32 base62 |
| `databricks_pat` | `dapi` + 32 hex |
| `telegram_bot_token` | 8–10 digit bot id + `:` + 35 base64url |
| `rubygems_api_key` | `rubygems_` + 48 hex |
| `terraform_cloud_token` | 14 base62 + `.atlasv1.` + ≥60 body |
| `planetscale_password` | `pscale_pw_` + ≥32 |
| `planetscale_token` | `pscale_tkn_` + ≥32 |
| `prefect_api_key` | `pnu_` + 36 base62 |
| `vault_service_token` | `hvs.`/`hvb.` + ≥24 base64url |
| `mailchimp_api_key` | 32 hex + `-us` + datacenter digits |
| `slack_webhook_url` | `hooks.slack.com/services/T…/B…/…` |
| `airtable_pat` | `pat` + 14 base62 + `.` + 64 hex |
| `gitlab_pipeline_trigger_token` | `glptt-` + 40 hex |
| `gitlab_runner_token` | `glrt-` + 20 base64url |
| `shippo_api_token` | `shippo_{live,test}_` + 40 hex |
| `flyio_token` | `fo1_` + 43 base64url |

No existing rule is modified, so current findings are unchanged, and no analyzer descriptor changes (the
finding schema is unchanged) — so `analyzer-metadata.json` and the generated UI mirror are untouched.

No linked issue: additive detection-coverage for well-known credential formats, matching the established
`feat(enrichment)` secret-format additions; each rule is a self-evident real token shape with no public
API/schema/deploy surface change — fits the repo's `preferred` (not required) linked-issue policy.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run typecheck`
- [x] `npm run rees:test` — the review-enrichment build + analyzer suite (see note below)
- [ ] `npm run test:coverage` (N/A — this file is in `review-enrichment/`, outside the root `src/**` Codecov scope)
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran locally: `git diff --check` (clean), the review-enrichment TypeScript build (exit 0), and the secret-scan
  analyzer test via `node --test` — **42/42 pass**, including a new table case that flags each of the 17
  formats at high confidence, plus a near-miss case asserting that one-character-short tokens (and a
  datacenter-less Mailchimp shape) produce no finding — proving the prefixes/lengths are specific, not broad.
  All fixtures are assembled from string fragments so the test file never contains a contiguous secret literal.
  The change is confined to `review-enrichment/`, outside the `src/**` Codecov scope.
- Not run locally: the UI, root typecheck, and the `metadata:check` step of `rees:test`. This change only adds
  scan rules, not any analyzer descriptor, so the committed `analyzer-metadata.json`/UI mirror are unchanged
  (a local regeneration produces a zero-content diff) and `metadata:check` passes on CI (Linux). On this
  Windows dev box `metadata:check` reports a spurious line-ending difference; it fails identically on
  unmodified `main`. `analyzer-metadata.json` was NOT modified.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Detection-only additions: 17 new high-confidence rules; no existing rule, threshold, or descriptor changed,
  so current findings and `analyzer-metadata.json` are unaffected. The scanner still returns only `file:line`
  + `kind`, never the matched secret value.
- Each regex uses `\b` boundaries (or a negative-lookahead terminator where the body can end in `-`/`_`/`.`,
  as the existing SendGrid/Anthropic/Square rules already do), and was vetted to match a correct-length token
  and reject a one-char-short near-miss. The `mailchimp_api_key` rule is anchored by its `-us<datacenter>`
  suffix so a bare 32-hex hash cannot match it.
