### PR TITLE
feat(enrichment): flag insecure Dockerfile build instructions in iac-misconfig

### DIFF
--- a/review-enrichment/src/analyzers/iac-misconfig.ts
+++ b/review-enrichment/src/analyzers/iac-misconfig.ts
@@ -49,6 +49,30 @@ const IMDS_V1_RE = /\bhttp_tokens\b[\s"'=:,-]*["']?optional\b/i;
 // (`chmod 1777`) does not match because the value must begin at the optional `0` then `777`.
 const WORLD_WRITABLE_RE = /\b(?:chmod\s+|(?:file_)?mode[\s"'=:,-]*["']?)0?777\b/i;
 
+// Dockerfile build-security hardening (hadolint / checkov CKV_DOCKER_*). The uppercase instruction keywords
+// (ADD/FROM/USER/EXPOSE) are Dockerfile-specific, so they do not fire on lowercase YAML/JSON keys; the
+// flag/shell shapes are risky in any build/config file the path gate already admits.
+const DOCKER_ADD_REMOTE_RE = /\bADD\s+(?:--\S+\s+)*https?:\/\/\S/;
+const DOCKER_LATEST_TAG_RE = /\bFROM\s+(?:--\S+\s+)*\S+:latest\b/;
+const DOCKER_ROOT_USER_RE = /\bUSER\s+(?:root|0)\b/;
+// A remote download piped straight into a shell — the classic `curl … | sh` run-remote-code-at-build shape.
+const REMOTE_SHELL_PIPE_RE =
+  /\b(?:curl|wget)\b[^\n]*?\|\s*(?:sudo\s+)?(?:bash|zsh|ksh|dash|ash|sh)\b/;
+// Build flags that disable download / TLS certificate verification (wget/apt/curl/pip).
+const INSECURE_DOWNLOAD_FLAG_RE =
+  /--(?:no-check-certificate|allow-unauthenticated|force-yes|trusted-host)\b/;
+const SSH_PORT_EXPOSED_RE = /\bEXPOSE\s+(?:\d+(?:\/\w+)?\s+)*22(?:\/tcp)?\b/;
+const NPM_UNSAFE_PERM_RE = /--unsafe-perm\b/;
+// `sudo` invoked inside a RUN layer (privilege elevation during build). `RUN apt-get install sudo` does NOT
+// match because sudo does not immediately follow `RUN`/`&&`.
+const SUDO_IN_BUILD_RE = /\bRUN\s+sudo\s|&&\s*sudo\s/;
+// A credential-shaped value hardcoded into an image layer via ENV/ARG WITH a value (build secrets persist in
+// the image history). A bare `ARG DB_PASSWORD` (no `=value`) is a legitimate build-arg declaration and is skipped.
+const HARDCODED_BUILD_SECRET_RE =
+  /\b(?:ENV|ARG)\s+\w*(?:PASSWORD|PASSWD|SECRET|TOKEN|API[_-]?KEY|ACCESS[_-]?KEY|PRIVATE[_-]?KEY)\w*\s*=\s*\S/i;
+// A package installer pointed at a plaintext-HTTP index (dependency-download MITM).
+const INSECURE_PIP_INDEX_RE = /--(?:extra-)?index-url[=\s]+http:\/\//i;
+
 function* patchLines(patch: string): Generator<string> {
   let start = 0;
   for (let i = 0; i <= patch.length; i++) {
@@ -312,6 +336,66 @@ export function scanPatchForIacMisconfig(
         "world-writable-permissions",
         maxFindings,
       )
+    ) {
+      return findings;
+    }
+    if (
+      DOCKER_ADD_REMOTE_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "docker-add-remote-url", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      DOCKER_LATEST_TAG_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "docker-image-latest-tag", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      DOCKER_ROOT_USER_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "docker-root-user", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      REMOTE_SHELL_PIPE_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "remote-shell-pipe", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      INSECURE_DOWNLOAD_FLAG_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "insecure-download-flag", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      SSH_PORT_EXPOSED_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "ssh-port-exposed", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      NPM_UNSAFE_PERM_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "npm-unsafe-perm", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      SUDO_IN_BUILD_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "sudo-in-build", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      HARDCODED_BUILD_SECRET_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "hardcoded-build-secret", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      INSECURE_PIP_INDEX_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "insecure-pip-index", maxFindings)
     ) {
       return findings;
     }

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -305,6 +305,26 @@ export function renderBrief(
           return "allows IMDSv1 (`http_tokens: optional`); prefer IMDSv2 to mitigate SSRF credential theft";
         case "world-writable-permissions":
           return "grants world-writable `0777` permissions; restrict to the least access the workload needs";
+        case "docker-add-remote-url":
+          return "uses `ADD` with a remote URL; prefer `COPY` or a verified download so the fetched content stays auditable";
+        case "docker-image-latest-tag":
+          return "pins a base image to the mutable `:latest` tag; pin a specific version or digest for reproducible, reviewable builds";
+        case "docker-root-user":
+          return "runs the image as `root` (`USER root`/`USER 0`); switch to a dedicated non-root user";
+        case "remote-shell-pipe":
+          return "pipes a remote download straight into a shell (`curl … | sh`); this runs unreviewed remote code at build time";
+        case "insecure-download-flag":
+          return "disables download or TLS certificate verification with an insecure build flag; this permits man-in-the-middle tampering";
+        case "ssh-port-exposed":
+          return "exposes SSH port 22 from the image; containers should not ship an SSH daemon";
+        case "npm-unsafe-perm":
+          return "runs npm with `--unsafe-perm`, executing package lifecycle scripts as root";
+        case "sudo-in-build":
+          return "invokes `sudo` in a build layer; run the build step as the needed user instead of elevating";
+        case "hardcoded-build-secret":
+          return "hardcodes a credential-shaped value into an image layer via `ENV`/`ARG`; build secrets persist in the image history";
+        case "insecure-pip-index":
+          return "points a package installer at a plaintext-HTTP index; dependency downloads can be intercepted";
       }
     };
 

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -233,7 +233,17 @@ export interface IacMisconfigFinding {
     | "unencrypted-storage"
     | "publicly-accessible-database"
     | "imdsv1-allowed"
-    | "world-writable-permissions";
+    | "world-writable-permissions"
+    | "docker-add-remote-url"
+    | "docker-image-latest-tag"
+    | "docker-root-user"
+    | "remote-shell-pipe"
+    | "insecure-download-flag"
+    | "ssh-port-exposed"
+    | "npm-unsafe-perm"
+    | "sudo-in-build"
+    | "hardcoded-build-secret"
+    | "insecure-pip-index";
 }
 
 /** A newly-added dependency whose install compiles native code (npm node-gyp addon) or has no prebuilt wheel

--- a/review-enrichment/test/iac-misconfig.test.ts
+++ b/review-enrichment/test/iac-misconfig.test.ts
@@ -272,3 +272,59 @@ test("scanPatchForIacMisconfig does not flag the secure counterpart of each cont
     );
   }
 });
+
+test("scanPatchForIacMisconfig flags insecure Dockerfile build instructions", () => {
+  // Each added line is a recognized hadolint/checkov Dockerfile-hardening violation and must produce
+  // exactly one finding of its own kind.
+  const cases = [
+    ["+ADD https://example.com/app.tar.gz /app/", "docker-add-remote-url"],
+    ["+FROM node:latest", "docker-image-latest-tag"],
+    ["+USER root", "docker-root-user"],
+    ["+RUN curl -fsSL https://get.example.com | sh", "remote-shell-pipe"],
+    ["+RUN wget --no-check-certificate https://example.com/x -O /x", "insecure-download-flag"],
+    ["+EXPOSE 22", "ssh-port-exposed"],
+    ["+RUN npm install --unsafe-perm", "npm-unsafe-perm"],
+    ["+RUN sudo apt-get update", "sudo-in-build"],
+    ["+ENV DB_PASSWORD=hunter2", "hardcoded-build-secret"],
+    ["+RUN pip install --index-url http://pypi.internal/simple foo", "insecure-pip-index"],
+  ];
+  for (const [added, kind] of cases) {
+    const findings = scanPatchForIacMisconfig(
+      "Dockerfile",
+      ["@@ -1,0 +1,1 @@", added].join("\n"),
+    );
+    assert.deepEqual(
+      findings,
+      [{ file: "Dockerfile", line: 1, kind }],
+      `${kind}: expected exactly one finding of that kind, got ${JSON.stringify(findings)}`,
+    );
+  }
+});
+
+test("scanPatchForIacMisconfig does not flag the safe counterpart of each Dockerfile instruction", () => {
+  // Safe/near-miss forms: a local ADD source, a pinned image tag, a non-root user (incl. a non-zero uid), a
+  // curl without a shell pipe, a wget without the insecure flag, a non-SSH port (incl. 2222), npm without
+  // --unsafe-perm, `apt-get install sudo` (installing, not invoking), a bare ARG declaration, and an HTTPS index.
+  const safe = [
+    "+ADD ./local.tar.gz /app/",
+    "+FROM node:20.11.0",
+    "+USER appuser",
+    "+USER 1000",
+    "+RUN curl -fsSL https://example.com/x -o /tmp/x",
+    "+RUN wget https://example.com/x",
+    "+EXPOSE 8080",
+    "+EXPOSE 2222",
+    "+RUN npm install",
+    "+RUN apt-get install -y sudo",
+    "+ARG DB_PASSWORD",
+    "+ENV APP_NAME=myapp",
+    "+RUN pip install --index-url https://pypi.internal/simple foo",
+  ];
+  for (const added of safe) {
+    assert.deepEqual(
+      scanPatchForIacMisconfig("Dockerfile", ["@@ -1,0 +1,1 @@", added].join("\n")),
+      [],
+      `should not flag: ${added.trim()}`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

The IaC-misconfig analyzer (`review-enrichment/src/analyzers/iac-misconfig.ts`) flags risky infrastructure /
config lines an added diff introduces. It already covers CORS, open ingress, public buckets, insecure cookies,
disabled TLS verification, prod-debug, hardcoded URLs, and Kubernetes/cloud `securityContext` hardening — but
has **no coverage of the Dockerfile build layer itself**, one of the most common sources of container security
findings.

This adds **10 new high-precision Dockerfile build-security rules** (hadolint / checkov `CKV_DOCKER_*`
standards), each following the analyzer's existing stateless single-line pattern (regex const → `pushFinding`
branch → kind → render case):

| kind | fires on | check |
|---|---|---|
| `docker-add-remote-url` | `ADD https://…` | prefer `COPY`/verified download (DL3020) |
| `docker-image-latest-tag` | `FROM img:latest` | pin a version/digest (DL3007 / CKV_DOCKER_7) |
| `docker-root-user` | `USER root` / `USER 0` | run as non-root (DL3002 / CKV_DOCKER_8) |
| `remote-shell-pipe` | `curl … \| sh` | unreviewed remote code at build time |
| `insecure-download-flag` | `--no-check-certificate` / `--allow-unauthenticated` / `--force-yes` / `--trusted-host` | verification bypass |
| `ssh-port-exposed` | `EXPOSE 22` | no SSH daemon in images (CKV_DOCKER_1) |
| `npm-unsafe-perm` | `--unsafe-perm` | npm lifecycle scripts as root |
| `sudo-in-build` | `RUN sudo …` | privilege elevation in build (DL3004) |
| `hardcoded-build-secret` | `ENV`/`ARG NAME=<value>` with a credential-shaped name | secrets persist in image history |
| `insecure-pip-index` | `--index-url http://…` | plaintext-HTTP dependency index (MITM) |

The uppercase Dockerfile instruction keywords (`ADD`/`FROM`/`USER`/`EXPOSE`) are Dockerfile-specific, so they
do not fire on lowercase YAML/JSON keys; the flag/shell shapes are genuinely risky in any build/config file the
analyzer's path gate already admits. Every rule is airtight — the tests prove each safe/near-miss form produces
no finding: `ADD ./local.tar.gz`, `FROM node:20.11.0`, `USER appuser`/`USER 1000`, `curl … -o file` (no shell
pipe), `wget …` (no insecure flag), `EXPOSE 8080`/`EXPOSE 2222`, `npm install`, `apt-get install sudo`
(installing, not invoking), a bare `ARG DB_PASSWORD` declaration, and an HTTPS package index.

No existing rule is modified, and the analyzer's finding schema is `{file, line, kind}` — the `kind` union is
not part of the analyzer descriptor, so `analyzer-metadata.json` and the generated UI mirror are **unchanged**.
The render-brief switch is TypeScript-exhaustive, so each new kind is compiler-forced to have a public-safe
explanation.

No linked issue: additive detection-coverage that extends an existing multi-domain analyzer along its own
established lines (it already spans Docker/Terraform/Kubernetes/YAML config); each rule is a self-evident,
named industry check with no public API/schema/deploy surface change — fits the repo's `preferred` (not
required) linked-issue policy.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run typecheck`
- [x] `npm run rees:test` — the review-enrichment build + analyzer suite (see note below)
- [ ] `npm run test:coverage` (N/A — this analyzer is in `review-enrichment/`, outside the root `src/**` Codecov scope)
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran locally: `git diff --check` (clean), the review-enrichment TypeScript build (exit 0 — which proves the
  render switch is exhaustive over the 10 new kinds), and the analyzer suite via `node --test`. The
  iac-misconfig file passes 14/14: a table test asserting each of the 10 insecure Dockerfile lines produces
  exactly one finding of its own kind, and a negative test asserting the safe/near-miss counterpart of each
  produces none. The full `node --test` run's only failures are the two `upload-sourcemaps` tests (they shell
  out to the Sentry CLI, absent on this dev box) which fail identically on unmodified `main`.
- Not run locally: the UI, root typecheck, and the `metadata:check` step of `rees:test`. This change adds only
  finding kinds and rules, not any analyzer descriptor field, so the committed `analyzer-metadata.json` / UI
  mirror are unchanged (a local regeneration produces a zero-content diff) and `metadata:check` passes on CI
  (Linux). On this Windows dev box `metadata:check` reports a spurious line-ending difference; it fails
  identically on unmodified `main`. `analyzer-metadata.json` was NOT modified.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Detection-only additions: 10 new stateless rules following the existing single-line pattern; no existing
  rule, threshold, or descriptor changed, so current findings and `analyzer-metadata.json` are unaffected. Each
  new kind reports only `file:line` + the public-safe kind, never the matched line content.
- Each regex is anchored to keep it precise: the Dockerfile-instruction rules require the uppercase keyword +
  whitespace; `remote-shell-pipe` requires a real `| sh`/`| bash` (so `| grep`/`ssh` do not match);
  `hardcoded-build-secret` requires an `=<value>` (a bare declaration is skipped); `insecure-pip-index` and
  `insecure-download-flag` require the specific insecure flag/scheme.
