### PR TITLE
feat(miner): add track record summary

### DIFF
--- a/packages/gittensory-engine/README.md
+++ b/packages/gittensory-engine/README.md
@@ -244,6 +244,59 @@ rejected because the repo was not opted in, had invalid ids, or exposed no recog
 component scores, effective weights, contributing repos, dimension tables, rejected rows, and a contributing-repo
 summary. All caller-supplied ids and repo names are Markdown-escaped and newline-collapsed before rendering.
 
+## Track-record summary
+
+`computeTrackRecordSummary()` and `renderTrackRecordSummaryMarkdown()` provide a portable first-contact summary for a
+miner identity. The summary is computed client-side from already-public PR outcomes plus public conduct/moderation
+records, then rendered as a short Markdown block for a PR body or first comment.
+
+The feature is default-off and must be enabled explicitly:
+
+```yaml
+miner:
+  trackRecordSummary:
+    enabled: true
+```
+
+The computation only counts resolved PR outcomes attributable to the requested login. Merged PRs contribute to the
+numerator, closed-without-merge PRs contribute to the denominator, and open PRs are reported as ignored so in-flight
+work cannot inflate or deflate the public rate. Tenure is derived from the earliest observed public PR timestamp, and a
+clean conduct line is emitted only when no active public incident record is present for the login.
+
+```ts
+import {
+  computeTrackRecordSummary,
+  renderTrackRecordSummaryMarkdown,
+  resolveTrackRecordSummaryConfig,
+} from "@jsonbored/gittensory-engine";
+
+const config = resolveTrackRecordSummaryConfig({
+  miner: { trackRecordSummary: { enabled: true } },
+});
+
+const summary = computeTrackRecordSummary({
+  login: "octo-miner",
+  config,
+  now: "2026-07-04T18:00:00Z",
+  outcomes: [
+    {
+      repoFullName: "JSONbored/gittensory",
+      authorLogin: "octo-miner",
+      state: "merged",
+      createdAt: "2026-06-01T00:00:00Z",
+      mergedAt: "2026-06-02T00:00:00Z",
+    },
+  ],
+  incidents: [],
+});
+
+const markdown = renderTrackRecordSummaryMarkdown(summary);
+```
+
+The rendered block is intentionally narrow: login, resolved public PR counts, public merge rate, public tenure, conduct
+status, and optional public evidence URLs for active incidents. Caller-provided ids, PR URLs, and arbitrary metadata are
+never copied into the Markdown, and the renderer fails closed if a blocked private-field name is introduced.
+
 ## Plan templates
 
 `plan-templates.ts` exports one builder per miner lifecycle stage (`analyze`, `plan`, `prepare`, `create`, `manage`).

--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -53,6 +53,24 @@ export {
   type GateVerdictCalibrationWeights,
   type GateVerdictCompositeCalibrationScore,
 } from "./gate-verdict-calibration.js";
+export {
+  computeTrackRecordSummary,
+  renderTrackRecordSummaryMarkdown,
+  resolveTrackRecordSummaryConfig,
+  shouldIncludeTrackRecordSummary,
+  type TrackRecordIncidentKind,
+  type TrackRecordIncidentRecord,
+  type TrackRecordIncidentStatus,
+  type TrackRecordMergeRate,
+  type TrackRecordPullRequestOutcome,
+  type TrackRecordPullRequestState,
+  type TrackRecordSummary,
+  type TrackRecordSummaryAudit,
+  type TrackRecordSummaryConfig,
+  type TrackRecordSummaryManifest,
+  type TrackRecordSummaryOutcomeCounts,
+  type TrackRecordTenure,
+} from "./track-record-summary.js";
 export * from "./governor/rate-limit.js";
 export {
   GOVERNOR_LEDGER_EVENT_TYPES,

--- a/packages/gittensory-engine/src/track-record-summary.ts
+++ b/packages/gittensory-engine/src/track-record-summary.ts
@@ -1,0 +1,416 @@
+// Portable first-contact track-record summary (#3008).
+//
+// The miner runtime can render this block locally from public PR outcomes and public moderation records. The type
+// surface intentionally has no score/ranking fields, and the formatter renders from computed fields only so arbitrary
+// caller metadata cannot cross the public boundary.
+
+export type TrackRecordPullRequestState = "merged" | "closed" | "open";
+
+export type TrackRecordPullRequestOutcome = {
+  id?: string | number | undefined;
+  repoFullName: string;
+  authorLogin: string;
+  state: TrackRecordPullRequestState | string;
+  createdAt?: string | Date | null | undefined;
+  closedAt?: string | Date | null | undefined;
+  mergedAt?: string | Date | null | undefined;
+  url?: string | null | undefined;
+};
+
+export type TrackRecordIncidentKind =
+  | "ban"
+  | "moderation"
+  | "code_of_conduct"
+  | "abuse"
+  | "spam"
+  | "unknown";
+
+export type TrackRecordIncidentRecord = {
+  login: string;
+  kind: TrackRecordIncidentKind | string;
+  active?: boolean | null | undefined;
+  recordedAt?: string | Date | null | undefined;
+  publicEvidenceUrl?: string | null | undefined;
+};
+
+export type TrackRecordSummaryManifest = {
+  miner?: {
+    trackRecordSummary?: {
+      enabled?: unknown;
+    } | null;
+  } | null;
+  trackRecordSummary?: {
+    enabled?: unknown;
+  } | null;
+};
+
+export type TrackRecordSummaryConfig = {
+  includeTrackRecordSummary: boolean;
+  warnings: string[];
+};
+
+export type TrackRecordSummaryOutcomeCounts = {
+  merged: number;
+  closedWithoutMerge: number;
+  resolved: number;
+  openIgnored: number;
+  ignored: number;
+};
+
+export type TrackRecordTenure = {
+  firstObservedAt: string | null;
+  days: number | null;
+  label: string;
+};
+
+export type TrackRecordMergeRate = {
+  numerator: number;
+  denominator: number;
+  ratio: number | null;
+  percent: number | null;
+  label: string;
+};
+
+export type TrackRecordIncidentStatus = {
+  hasPublicIncident: boolean;
+  checkedPublicRecords: number;
+  activePublicRecords: number;
+  label: string;
+  evidenceUrls: string[];
+};
+
+export type TrackRecordSummaryAudit = {
+  normalizedLogin: string;
+  consideredOutcomeIds: string[];
+  ignoredOutcomeIds: string[];
+  firstObservedCandidates: string[];
+};
+
+export type TrackRecordSummary = {
+  enabled: boolean;
+  login: string;
+  mergeRate: TrackRecordMergeRate;
+  tenure: TrackRecordTenure;
+  incidents: TrackRecordIncidentStatus;
+  outcomes: TrackRecordSummaryOutcomeCounts;
+  audit: TrackRecordSummaryAudit;
+};
+
+const DEFAULT_TRACK_RECORD_CONFIG: TrackRecordSummaryConfig = {
+  includeTrackRecordSummary: false,
+  warnings: [],
+};
+
+const BOOLEAN_TRUE = new Set(["1", "true", "yes", "y", "on", "enabled", "include"]);
+const BOOLEAN_FALSE = new Set(["0", "false", "no", "n", "off", "disabled", "exclude"]);
+const RESOLVED_MERGED_STATES = new Set(["merged", "merge", "accepted"]);
+const RESOLVED_CLOSED_STATES = new Set(["closed", "declined", "rejected", "closed_unmerged", "not_merged"]);
+const OPEN_STATES = new Set(["open", "draft", "pending", "ready_for_review"]);
+const INCIDENT_KINDS = new Set(["ban", "moderation", "code_of_conduct", "abuse", "spam"]);
+const PUBLIC_FIELD_BLOCKLIST = [
+  /\btrust\s*score\b/iu,
+  /\btrustscore\b/iu,
+  /\bscoreability\b/iu,
+  /\breward\b/iu,
+  /\bpayout\b/iu,
+  /\branking\b/iu,
+  /\bprivate\s*scor/iu,
+  /\bwallet\b/iu,
+  /\bhotkey\b/iu,
+  /\bcoldkey\b/iu,
+];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function normalizeBoolean(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") {
+    if (value === 1) return true;
+    if (value === 0) return false;
+    return undefined;
+  }
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (BOOLEAN_TRUE.has(normalized)) return true;
+  if (BOOLEAN_FALSE.has(normalized)) return false;
+  return undefined;
+}
+
+function normalizeLogin(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function normalizeId(value: string | number | undefined, fallbackIndex: number): string {
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed) return collapseInline(trimmed);
+  }
+  return `row-${fallbackIndex + 1}`;
+}
+
+function normalizeState(value: string): TrackRecordPullRequestState | "ignored" {
+  const normalized = value.trim().toLowerCase().replace(/[\s-]+/gu, "_");
+  if (RESOLVED_MERGED_STATES.has(normalized)) return "merged";
+  if (RESOLVED_CLOSED_STATES.has(normalized)) return "closed";
+  if (OPEN_STATES.has(normalized)) return "open";
+  return "ignored";
+}
+
+function normalizeIncidentKind(value: string): TrackRecordIncidentKind {
+  const normalized = value.trim().toLowerCase().replace(/[\s-]+/gu, "_");
+  if (INCIDENT_KINDS.has(normalized)) return normalized as TrackRecordIncidentKind;
+  return "unknown";
+}
+
+function parseInstant(value: string | Date | null | undefined): string | null {
+  if (value === null || value === undefined) return null;
+  const ms = value instanceof Date ? value.getTime() : Date.parse(value);
+  if (!Number.isFinite(ms)) return null;
+  return new Date(ms).toISOString();
+}
+
+function parseNow(value: string | Date | null | undefined): Date {
+  const parsed = parseInstant(value ?? undefined);
+  return parsed ? new Date(parsed) : new Date();
+}
+
+function clampWholeDays(startIso: string, now: Date): number {
+  const deltaMs = now.getTime() - new Date(startIso).getTime();
+  if (!Number.isFinite(deltaMs) || deltaMs <= 0) return 0;
+  return Math.floor(deltaMs / 86_400_000);
+}
+
+function collapseInline(value: string): string {
+  return value.replace(/[\r\n\t]+/gu, " ").replace(/\s{2,}/gu, " ").trim();
+}
+
+function markdownSafe(value: string): string {
+  return collapseInline(value).replace(/[\\`*_[\]<>|]/gu, "\\$&");
+}
+
+function normalizeEvidenceUrl(value: string | null | undefined): string | null {
+  if (!value) return null;
+  const collapsed = collapseInline(value);
+  if (!collapsed) return null;
+  if (!/^https?:\/\/[^\s<>"`|\\]+$/iu.test(collapsed)) return null;
+  return collapsed;
+}
+
+function firstPresentInstant(values: readonly (string | Date | null | undefined)[]): string | null {
+  const parsed = values.flatMap((value) => {
+    const instant = parseInstant(value);
+    return instant ? [instant] : [];
+  });
+  if (parsed.length === 0) return null;
+  parsed.sort();
+  return parsed[0]!;
+}
+
+function formatPercent(ratio: number | null): { percent: number | null; label: string } {
+  if (ratio === null) return { percent: null, label: "not enough resolved public PR history" };
+  const percent = Math.round(ratio * 100);
+  return { percent, label: `${percent}%` };
+}
+
+function formatTenure(days: number | null): string {
+  if (days === null) return "not enough public history";
+  if (days === 0) return "less than 1 day";
+  if (days === 1) return "1 day";
+  if (days < 30) return `${days} days`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return months === 1 ? "1 month" : `${months} months`;
+  const years = Math.floor(days / 365);
+  const remainderMonths = Math.floor((days % 365) / 30);
+  if (remainderMonths === 0) return years === 1 ? "1 year" : `${years} years`;
+  return `${years}y ${remainderMonths}m`;
+}
+
+function assertPublicSummaryText(text: string): void {
+  for (const pattern of PUBLIC_FIELD_BLOCKLIST) {
+    if (pattern.test(text)) {
+      throw new Error("Track-record summary attempted to render a blocked public field.");
+    }
+  }
+}
+
+function summarizeIncidents(
+  login: string,
+  incidents: readonly TrackRecordIncidentRecord[],
+): TrackRecordIncidentStatus {
+  const normalizedLogin = normalizeLogin(login);
+  const matching = incidents.filter((incident) => normalizeLogin(incident.login) === normalizedLogin);
+  const active = matching.filter((incident) => incident.active !== false);
+  const activeKnown = active.filter((incident) => normalizeIncidentKind(incident.kind) !== "unknown");
+  const evidenceUrls = Array.from(
+    new Set(
+      activeKnown.flatMap((incident) => {
+        const url = normalizeEvidenceUrl(incident.publicEvidenceUrl);
+        return url ? [url] : [];
+      }),
+    ),
+  ).sort();
+  const hasPublicIncident = activeKnown.length > 0;
+  return {
+    hasPublicIncident,
+    checkedPublicRecords: matching.length,
+    activePublicRecords: activeKnown.length,
+    label: hasPublicIncident ? "public conduct incident present" : "no public conduct incidents found",
+    evidenceUrls,
+  };
+}
+
+/**
+ * Resolve the explicit miner-side opt-in. Missing and malformed values fail closed so operators must choose to include
+ * a public first-contact summary.
+ */
+export function resolveTrackRecordSummaryConfig(
+  manifest: TrackRecordSummaryManifest | Record<string, unknown> | null | undefined,
+): TrackRecordSummaryConfig {
+  const root = isRecord(manifest) ? manifest : {};
+  const miner = isRecord(root.miner) ? root.miner : {};
+  const minerConfig = isRecord(miner.trackRecordSummary) ? miner.trackRecordSummary : {};
+  const topConfig = isRecord(root.trackRecordSummary) ? root.trackRecordSummary : {};
+  const raw = minerConfig.enabled ?? topConfig.enabled ?? undefined;
+  const normalized = normalizeBoolean(raw);
+  const warnings: string[] = [];
+  if (raw !== undefined && normalized === undefined) {
+    warnings.push("miner.trackRecordSummary.enabled must be a boolean-like value; defaulting to false.");
+  }
+  return {
+    includeTrackRecordSummary: normalized ?? DEFAULT_TRACK_RECORD_CONFIG.includeTrackRecordSummary,
+    warnings,
+  };
+}
+
+export function computeTrackRecordSummary(input: {
+  login: string;
+  outcomes: readonly TrackRecordPullRequestOutcome[];
+  incidents?: readonly TrackRecordIncidentRecord[] | undefined;
+  now?: string | Date | null | undefined;
+  config?: TrackRecordSummaryConfig | TrackRecordSummaryManifest | Record<string, unknown> | null | undefined;
+}): TrackRecordSummary {
+  const config =
+    input.config && "includeTrackRecordSummary" in input.config
+      ? (input.config as TrackRecordSummaryConfig)
+      : resolveTrackRecordSummaryConfig(input.config);
+  const normalizedLogin = normalizeLogin(input.login);
+  const now = parseNow(input.now);
+  const outcomes: TrackRecordSummaryOutcomeCounts = {
+    merged: 0,
+    closedWithoutMerge: 0,
+    resolved: 0,
+    openIgnored: 0,
+    ignored: 0,
+  };
+  const consideredOutcomeIds: string[] = [];
+  const ignoredOutcomeIds: string[] = [];
+  const firstObservedCandidates: string[] = [];
+
+  input.outcomes.forEach((outcome, index) => {
+    const id = normalizeId(outcome.id, index);
+    if (normalizeLogin(outcome.authorLogin) !== normalizedLogin) {
+      outcomes.ignored += 1;
+      ignoredOutcomeIds.push(id);
+      return;
+    }
+
+    const mergedAt = parseInstant(outcome.mergedAt);
+    const state = mergedAt ? "merged" : normalizeState(outcome.state);
+    const firstObserved = firstPresentInstant([outcome.createdAt, outcome.closedAt, outcome.mergedAt]);
+    if (firstObserved) firstObservedCandidates.push(firstObserved);
+
+    if (state === "merged") {
+      outcomes.merged += 1;
+      outcomes.resolved += 1;
+      consideredOutcomeIds.push(id);
+      return;
+    }
+    if (state === "closed") {
+      outcomes.closedWithoutMerge += 1;
+      outcomes.resolved += 1;
+      consideredOutcomeIds.push(id);
+      return;
+    }
+    if (state === "open") {
+      outcomes.openIgnored += 1;
+      ignoredOutcomeIds.push(id);
+      return;
+    }
+
+    outcomes.ignored += 1;
+    ignoredOutcomeIds.push(id);
+  });
+
+  const ratio = outcomes.resolved === 0 ? null : outcomes.merged / outcomes.resolved;
+  const formattedRate = formatPercent(ratio);
+  const firstObservedAt = firstObservedCandidates.length === 0 ? null : [...firstObservedCandidates].sort()[0]!;
+  const tenureDays = firstObservedAt ? clampWholeDays(firstObservedAt, now) : null;
+  const incidents = summarizeIncidents(input.login, input.incidents ?? []);
+
+  return {
+    enabled: config.includeTrackRecordSummary,
+    login: normalizedLogin,
+    mergeRate: {
+      numerator: outcomes.merged,
+      denominator: outcomes.resolved,
+      ratio,
+      percent: formattedRate.percent,
+      label: formattedRate.label,
+    },
+    tenure: {
+      firstObservedAt,
+      days: tenureDays,
+      label: formatTenure(tenureDays),
+    },
+    incidents,
+    outcomes,
+    audit: {
+      normalizedLogin,
+      consideredOutcomeIds: consideredOutcomeIds.sort(),
+      ignoredOutcomeIds: ignoredOutcomeIds.sort(),
+      firstObservedCandidates: firstObservedCandidates.sort(),
+    },
+  };
+}
+
+export function shouldIncludeTrackRecordSummary(
+  config: TrackRecordSummaryConfig | TrackRecordSummaryManifest | Record<string, unknown> | null | undefined,
+): boolean {
+  if (config && "includeTrackRecordSummary" in config) {
+    return (config as TrackRecordSummaryConfig).includeTrackRecordSummary === true;
+  }
+  return resolveTrackRecordSummaryConfig(config).includeTrackRecordSummary;
+}
+
+/**
+ * Render a deterministic Markdown block suitable for a PR body or first comment. Disabled summaries render to an empty
+ * string so caller code can concatenate safely without adding extra blank lines.
+ */
+export function renderTrackRecordSummaryMarkdown(summary: TrackRecordSummary): string {
+  if (!summary.enabled) return "";
+  const lines = [
+    "### Public contributor record",
+    "",
+    `- GitHub login: ${markdownSafe(summary.login)}`,
+    `- Resolved public PRs: ${summary.outcomes.resolved} (${summary.outcomes.merged} merged, ${summary.outcomes.closedWithoutMerge} closed without merge)`,
+    `- Public merge rate: ${summary.mergeRate.label}`,
+    `- Public tenure: ${summary.tenure.label}`,
+    `- Public conduct record: ${summary.incidents.label}`,
+  ];
+
+  if (summary.outcomes.openIgnored > 0) {
+    lines.push(`- Open PRs ignored for rate: ${summary.outcomes.openIgnored}`);
+  }
+  if (summary.incidents.hasPublicIncident && summary.incidents.evidenceUrls.length > 0) {
+    lines.push(
+      `- Public evidence: ${summary.incidents.evidenceUrls.map((url) => markdownSafe(url)).join(", ")}`,
+    );
+  }
+
+  const rendered = `${lines.join("\n")}\n`;
+  assertPublicSummaryText(rendered);
+  return rendered;
+}

--- a/packages/gittensory-engine/test/track-record-summary.test.ts
+++ b/packages/gittensory-engine/test/track-record-summary.test.ts
@@ -1,0 +1,662 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  computeTrackRecordSummary,
+  renderTrackRecordSummaryMarkdown,
+  resolveTrackRecordSummaryConfig,
+  shouldIncludeTrackRecordSummary,
+} from "../dist/index.js";
+
+const NOW = "2026-07-04T18:00:00.000Z";
+
+test("barrel: exports track-record summary APIs (#3008)", () => {
+  assert.equal(typeof resolveTrackRecordSummaryConfig, "function");
+  assert.equal(typeof computeTrackRecordSummary, "function");
+  assert.equal(typeof renderTrackRecordSummaryMarkdown, "function");
+  assert.equal(typeof shouldIncludeTrackRecordSummary, "function");
+});
+
+test("resolveTrackRecordSummaryConfig defaults to disabled", () => {
+  assert.deepEqual(resolveTrackRecordSummaryConfig(undefined), {
+    includeTrackRecordSummary: false,
+    warnings: [],
+  });
+  assert.deepEqual(resolveTrackRecordSummaryConfig({}), {
+    includeTrackRecordSummary: false,
+    warnings: [],
+  });
+});
+
+test("resolveTrackRecordSummaryConfig honors the miner opt-in path", () => {
+  const result = resolveTrackRecordSummaryConfig({
+    miner: {
+      trackRecordSummary: {
+        enabled: true,
+      },
+    },
+  });
+
+  assert.deepEqual(result, {
+    includeTrackRecordSummary: true,
+    warnings: [],
+  });
+});
+
+test("resolveTrackRecordSummaryConfig accepts boolean-like strings and numbers", () => {
+  assert.equal(
+    resolveTrackRecordSummaryConfig({ miner: { trackRecordSummary: { enabled: "yes" } } })
+      .includeTrackRecordSummary,
+    true,
+  );
+  assert.equal(
+    resolveTrackRecordSummaryConfig({ miner: { trackRecordSummary: { enabled: "off" } } })
+      .includeTrackRecordSummary,
+    false,
+  );
+  assert.equal(
+    resolveTrackRecordSummaryConfig({ miner: { trackRecordSummary: { enabled: 1 } } }).includeTrackRecordSummary,
+    true,
+  );
+  assert.equal(
+    resolveTrackRecordSummaryConfig({ miner: { trackRecordSummary: { enabled: 0 } } }).includeTrackRecordSummary,
+    false,
+  );
+});
+
+test("resolveTrackRecordSummaryConfig keeps a top-level alias but prefers miner config", () => {
+  assert.equal(
+    resolveTrackRecordSummaryConfig({
+      trackRecordSummary: { enabled: "include" },
+    }).includeTrackRecordSummary,
+    true,
+  );
+  assert.equal(
+    resolveTrackRecordSummaryConfig({
+      miner: { trackRecordSummary: { enabled: false } },
+      trackRecordSummary: { enabled: true },
+    }).includeTrackRecordSummary,
+    false,
+  );
+});
+
+test("resolveTrackRecordSummaryConfig warns and fails closed on malformed values", () => {
+  const result = resolveTrackRecordSummaryConfig({
+    miner: { trackRecordSummary: { enabled: "maybe" } },
+  });
+
+  assert.deepEqual(result, {
+    includeTrackRecordSummary: false,
+    warnings: ["miner.trackRecordSummary.enabled must be a boolean-like value; defaulting to false."],
+  });
+});
+
+test("shouldIncludeTrackRecordSummary accepts resolved config and manifest input", () => {
+  assert.equal(shouldIncludeTrackRecordSummary({ includeTrackRecordSummary: true, warnings: [] }), true);
+  assert.equal(shouldIncludeTrackRecordSummary({ includeTrackRecordSummary: false, warnings: [] }), false);
+  assert.equal(
+    shouldIncludeTrackRecordSummary({ miner: { trackRecordSummary: { enabled: "enabled" } } }),
+    true,
+  );
+  assert.equal(shouldIncludeTrackRecordSummary(null), false);
+});
+
+test("computeTrackRecordSummary derives a positive public record from matching outcomes", () => {
+  const summary = computeTrackRecordSummary({
+    login: "MinerOne",
+    now: NOW,
+    config: { includeTrackRecordSummary: true, warnings: [] },
+    outcomes: [
+      {
+        id: 11,
+        repoFullName: "jsonbored/gittensory",
+        authorLogin: "minerone",
+        state: "merged",
+        createdAt: "2026-06-01T00:00:00Z",
+        mergedAt: "2026-06-02T00:00:00Z",
+      },
+      {
+        id: "pr-12",
+        repoFullName: "owner/repo",
+        authorLogin: "MinerOne",
+        state: "closed",
+        createdAt: "2026-06-03T00:00:00Z",
+        closedAt: "2026-06-04T00:00:00Z",
+      },
+      {
+        id: "pr-13",
+        repoFullName: "owner/repo",
+        authorLogin: "MINERONE",
+        state: "accepted",
+        createdAt: "2026-06-05T00:00:00Z",
+      },
+      {
+        id: "open-1",
+        repoFullName: "owner/repo",
+        authorLogin: "MinerOne",
+        state: "open",
+        createdAt: "2026-07-01T00:00:00Z",
+      },
+    ],
+    incidents: [],
+  });
+
+  assert.equal(summary.enabled, true);
+  assert.equal(summary.login, "minerone");
+  assert.deepEqual(summary.outcomes, {
+    merged: 2,
+    closedWithoutMerge: 1,
+    resolved: 3,
+    openIgnored: 1,
+    ignored: 0,
+  });
+  assert.equal(summary.mergeRate.ratio, 2 / 3);
+  assert.equal(summary.mergeRate.percent, 67);
+  assert.equal(summary.mergeRate.label, "67%");
+  assert.equal(summary.tenure.firstObservedAt, "2026-06-01T00:00:00.000Z");
+  assert.equal(summary.tenure.days, 33);
+  assert.equal(summary.tenure.label, "1 month");
+  assert.deepEqual(summary.audit.consideredOutcomeIds, ["11", "pr-12", "pr-13"]);
+  assert.deepEqual(summary.audit.ignoredOutcomeIds, ["open-1"]);
+});
+
+test("computeTrackRecordSummary treats a merged timestamp as authoritative", () => {
+  const summary = computeTrackRecordSummary({
+    login: "miner",
+    now: NOW,
+    config: { includeTrackRecordSummary: true, warnings: [] },
+    outcomes: [
+      {
+        id: "squashed",
+        repoFullName: "owner/repo",
+        authorLogin: "miner",
+        state: "closed",
+        createdAt: "2026-06-01T00:00:00Z",
+        closedAt: "2026-06-03T00:00:00Z",
+        mergedAt: "2026-06-03T00:00:00Z",
+      },
+    ],
+  });
+
+  assert.equal(summary.outcomes.merged, 1);
+  assert.equal(summary.outcomes.closedWithoutMerge, 0);
+  assert.equal(summary.mergeRate.label, "100%");
+});
+
+test("computeTrackRecordSummary ignores other authors and unknown states", () => {
+  const summary = computeTrackRecordSummary({
+    login: "target",
+    now: NOW,
+    config: { includeTrackRecordSummary: true, warnings: [] },
+    outcomes: [
+      {
+        id: "other",
+        repoFullName: "owner/repo",
+        authorLogin: "someone-else",
+        state: "merged",
+        createdAt: "2026-06-01T00:00:00Z",
+        mergedAt: "2026-06-02T00:00:00Z",
+      },
+      {
+        id: "unknown",
+        repoFullName: "owner/repo",
+        authorLogin: "target",
+        state: "queued",
+        createdAt: "2026-06-02T00:00:00Z",
+      },
+    ],
+  });
+
+  assert.equal(summary.outcomes.resolved, 0);
+  assert.equal(summary.outcomes.ignored, 2);
+  assert.deepEqual(summary.audit.ignoredOutcomeIds, ["other", "unknown"]);
+});
+
+test("computeTrackRecordSummary normalizes public outcome state aliases", () => {
+  const summary = computeTrackRecordSummary({
+    login: "alias",
+    now: NOW,
+    config: { includeTrackRecordSummary: true, warnings: [] },
+    outcomes: [
+      {
+        id: "merge",
+        repoFullName: "owner/repo",
+        authorLogin: "alias",
+        state: "merge",
+        createdAt: "2026-06-01T00:00:00Z",
+      },
+      {
+        id: "declined",
+        repoFullName: "owner/repo",
+        authorLogin: "alias",
+        state: "declined",
+        createdAt: "2026-06-02T00:00:00Z",
+      },
+      {
+        id: "not-merged",
+        repoFullName: "owner/repo",
+        authorLogin: "alias",
+        state: "not-merged",
+        createdAt: "2026-06-03T00:00:00Z",
+      },
+      {
+        id: "draft",
+        repoFullName: "owner/repo",
+        authorLogin: "alias",
+        state: "draft",
+        createdAt: "2026-06-04T00:00:00Z",
+      },
+    ],
+  });
+
+  assert.deepEqual(summary.outcomes, {
+    merged: 1,
+    closedWithoutMerge: 2,
+    resolved: 3,
+    openIgnored: 1,
+    ignored: 0,
+  });
+  assert.equal(summary.mergeRate.label, "33%");
+});
+
+test("computeTrackRecordSummary falls back to the current clock only when now is malformed", () => {
+  const before = Date.now();
+  const summary = computeTrackRecordSummary({
+    login: "clock",
+    now: "not-a-date",
+    config: { includeTrackRecordSummary: true, warnings: [] },
+    outcomes: [
+      {
+        id: "old",
+        repoFullName: "owner/repo",
+        authorLogin: "clock",
+        state: "merged",
+        createdAt: "1970-01-01T00:00:00Z",
+      },
+    ],
+  });
+  const after = Date.now();
+  const lowerBoundDays = Math.floor((before - Date.parse("1970-01-01T00:00:00Z")) / 86_400_000);
+  const upperBoundDays = Math.floor((after - Date.parse("1970-01-01T00:00:00Z")) / 86_400_000);
+
+  assert.ok(summary.tenure.days !== null);
+  assert.ok(summary.tenure.days >= lowerBoundDays);
+  assert.ok(summary.tenure.days <= upperBoundDays);
+});
+
+test("computeTrackRecordSummary keeps http evidence and rejects unsafe schemes", () => {
+  const summary = computeTrackRecordSummary({
+    login: "miner",
+    now: NOW,
+    config: { includeTrackRecordSummary: true, warnings: [] },
+    outcomes: [],
+    incidents: [
+      { login: "miner", kind: "moderation", publicEvidenceUrl: "http://example.test/public-record" },
+      { login: "miner", kind: "moderation", publicEvidenceUrl: "ftp://example.test/not-public" },
+      { login: "miner", kind: "moderation", publicEvidenceUrl: "https://example.test/bad path" },
+    ],
+  });
+
+  assert.deepEqual(summary.incidents.evidenceUrls, ["http://example.test/public-record"]);
+  assert.match(renderTrackRecordSummaryMarkdown(summary), /http:\/\/example\.test\/public-record/u);
+});
+
+test("computeTrackRecordSummary returns neutral zero-history values for a new miner", () => {
+  const summary = computeTrackRecordSummary({
+    login: "new-miner",
+    outcomes: [],
+    incidents: [],
+    now: NOW,
+    config: { includeTrackRecordSummary: true, warnings: [] },
+  });
+
+  assert.equal(summary.mergeRate.ratio, null);
+  assert.equal(summary.mergeRate.percent, null);
+  assert.equal(summary.mergeRate.label, "not enough resolved public PR history");
+  assert.equal(summary.tenure.firstObservedAt, null);
+  assert.equal(summary.tenure.days, null);
+  assert.equal(summary.tenure.label, "not enough public history");
+  assert.equal(summary.incidents.hasPublicIncident, false);
+  assert.equal(summary.incidents.label, "no public conduct incidents found");
+});
+
+test("computeTrackRecordSummary clamps future tenure to less than one day", () => {
+  const summary = computeTrackRecordSummary({
+    login: "future",
+    now: NOW,
+    config: { includeTrackRecordSummary: true, warnings: [] },
+    outcomes: [
+      {
+        id: "future-pr",
+        repoFullName: "owner/repo",
+        authorLogin: "future",
+        state: "merged",
+        createdAt: "2026-08-01T00:00:00Z",
+        mergedAt: "2026-08-02T00:00:00Z",
+      },
+    ],
+  });
+
+  assert.equal(summary.tenure.days, 0);
+  assert.equal(summary.tenure.label, "less than 1 day");
+});
+
+test("computeTrackRecordSummary handles date objects, invalid dates, and generated row ids", () => {
+  const summary = computeTrackRecordSummary({
+    login: "dates",
+    now: new Date(NOW),
+    config: { includeTrackRecordSummary: true, warnings: [] },
+    outcomes: [
+      {
+        repoFullName: "owner/repo",
+        authorLogin: "dates",
+        state: "merged",
+        createdAt: new Date("2025-07-04T18:00:00Z"),
+        mergedAt: "not a date",
+      },
+      {
+        repoFullName: "owner/repo",
+        authorLogin: "dates",
+        state: "closed",
+        createdAt: "not a date",
+        closedAt: null,
+      },
+    ],
+  });
+
+  assert.equal(summary.tenure.days, 365);
+  assert.equal(summary.tenure.label, "1 year");
+  assert.deepEqual(summary.audit.consideredOutcomeIds, ["row-1", "row-2"]);
+  assert.deepEqual(summary.audit.firstObservedCandidates, ["2025-07-04T18:00:00.000Z"]);
+});
+
+test("computeTrackRecordSummary renders month and year tenure labels deterministically", () => {
+  const tenures = [
+    ["2026-07-03T18:00:00Z", "1 day"],
+    ["2026-06-25T18:00:00Z", "9 days"],
+    ["2026-03-01T18:00:00Z", "4 months"],
+    ["2024-12-01T18:00:00Z", "1y 7m"],
+  ].map(([createdAt, expected]) => {
+    const summary = computeTrackRecordSummary({
+      login: "tenure",
+      now: NOW,
+      config: { includeTrackRecordSummary: true, warnings: [] },
+      outcomes: [
+        {
+          id: createdAt,
+          repoFullName: "owner/repo",
+          authorLogin: "tenure",
+          state: "merged",
+          createdAt,
+          mergedAt: createdAt,
+        },
+      ],
+    });
+    return [createdAt, summary.tenure.label, expected];
+  });
+
+  assert.deepEqual(tenures, [
+    ["2026-07-03T18:00:00Z", "1 day", "1 day"],
+    ["2026-06-25T18:00:00Z", "9 days", "9 days"],
+    ["2026-03-01T18:00:00Z", "4 months", "4 months"],
+    ["2024-12-01T18:00:00Z", "1y 7m", "1y 7m"],
+  ]);
+});
+
+test("computeTrackRecordSummary detects a prior public incident and avoids a clean claim", () => {
+  const summary = computeTrackRecordSummary({
+    login: "MinerOne",
+    now: NOW,
+    config: { includeTrackRecordSummary: true, warnings: [] },
+    outcomes: [
+      {
+        id: "pr-1",
+        repoFullName: "owner/repo",
+        authorLogin: "minerone",
+        state: "merged",
+        createdAt: "2026-06-01T00:00:00Z",
+      },
+    ],
+    incidents: [
+      {
+        login: "minerone",
+        kind: "code-of-conduct",
+        active: true,
+        recordedAt: "2026-06-10T00:00:00Z",
+        publicEvidenceUrl: "https://example.test/moderation/minerone",
+      },
+    ],
+  });
+
+  assert.equal(summary.incidents.hasPublicIncident, true);
+  assert.equal(summary.incidents.checkedPublicRecords, 1);
+  assert.equal(summary.incidents.activePublicRecords, 1);
+  assert.equal(summary.incidents.label, "public conduct incident present");
+  assert.deepEqual(summary.incidents.evidenceUrls, ["https://example.test/moderation/minerone"]);
+});
+
+test("computeTrackRecordSummary ignores inactive, unknown, mismatched, and invalid-url incident rows", () => {
+  const summary = computeTrackRecordSummary({
+    login: "miner",
+    now: NOW,
+    config: { includeTrackRecordSummary: true, warnings: [] },
+    outcomes: [],
+    incidents: [
+      { login: "miner", kind: "moderation", active: false, publicEvidenceUrl: "https://example.test/inactive" },
+      { login: "miner", kind: "unknown-thing", active: true, publicEvidenceUrl: "https://example.test/unknown" },
+      { login: "other", kind: "ban", active: true, publicEvidenceUrl: "https://example.test/other" },
+      { login: "miner", kind: "ban", active: true, publicEvidenceUrl: "javascript:alert(1)" },
+    ],
+  });
+
+  assert.equal(summary.incidents.checkedPublicRecords, 3);
+  assert.equal(summary.incidents.activePublicRecords, 1);
+  assert.equal(summary.incidents.hasPublicIncident, true);
+  assert.deepEqual(summary.incidents.evidenceUrls, []);
+});
+
+test("computeTrackRecordSummary deduplicates and sorts public evidence URLs", () => {
+  const summary = computeTrackRecordSummary({
+    login: "miner",
+    now: NOW,
+    config: { includeTrackRecordSummary: true, warnings: [] },
+    outcomes: [],
+    incidents: [
+      { login: "miner", kind: "ban", publicEvidenceUrl: "https://example.test/z" },
+      { login: "miner", kind: "ban", publicEvidenceUrl: "https://example.test/a" },
+      { login: "miner", kind: "ban", publicEvidenceUrl: "https://example.test/z" },
+    ],
+  });
+
+  assert.deepEqual(summary.incidents.evidenceUrls, ["https://example.test/a", "https://example.test/z"]);
+});
+
+test("renderTrackRecordSummaryMarkdown renders nothing when disabled", () => {
+  const summary = computeTrackRecordSummary({
+    login: "miner",
+    now: NOW,
+    config: { includeTrackRecordSummary: false, warnings: [] },
+    outcomes: [
+      {
+        id: "pr-1",
+        repoFullName: "owner/repo",
+        authorLogin: "miner",
+        state: "merged",
+        createdAt: "2026-06-01T00:00:00Z",
+      },
+    ],
+  });
+
+  assert.equal(renderTrackRecordSummaryMarkdown(summary), "");
+});
+
+test("renderTrackRecordSummaryMarkdown renders a short deterministic public block", () => {
+  const summary = computeTrackRecordSummary({
+    login: "Miner_Name",
+    now: NOW,
+    config: { includeTrackRecordSummary: true, warnings: [] },
+    outcomes: [
+      {
+        id: "pr-1",
+        repoFullName: "owner/repo",
+        authorLogin: "miner_name",
+        state: "merged",
+        createdAt: "2026-06-01T00:00:00Z",
+      },
+      {
+        id: "pr-2",
+        repoFullName: "owner/repo",
+        authorLogin: "miner_name",
+        state: "open",
+        createdAt: "2026-07-01T00:00:00Z",
+      },
+    ],
+  });
+  const markdown = renderTrackRecordSummaryMarkdown(summary);
+
+  assert.equal(
+    markdown,
+    [
+      "### Public contributor record",
+      "",
+      "- GitHub login: miner\\_name",
+      "- Resolved public PRs: 1 (1 merged, 0 closed without merge)",
+      "- Public merge rate: 100%",
+      "- Public tenure: 1 month",
+      "- Public conduct record: no public conduct incidents found",
+      "- Open PRs ignored for rate: 1",
+      "",
+    ].join("\n"),
+  );
+});
+
+test("renderTrackRecordSummaryMarkdown includes public incident evidence only when present", () => {
+  const summary = computeTrackRecordSummary({
+    login: "miner",
+    now: NOW,
+    config: { includeTrackRecordSummary: true, warnings: [] },
+    outcomes: [],
+    incidents: [
+      {
+        login: "miner",
+        kind: "ban",
+        publicEvidenceUrl: "https://example.test/moderation/miner",
+      },
+    ],
+  });
+  const markdown = renderTrackRecordSummaryMarkdown(summary);
+
+  assert.match(markdown, /Public conduct record: public conduct incident present/u);
+  assert.match(markdown, /Public evidence: https:\/\/example\.test\/moderation\/miner/u);
+  assert.doesNotMatch(markdown, /no public conduct incidents found/u);
+});
+
+test("renderTrackRecordSummaryMarkdown escapes markdown controls and collapses newlines", () => {
+  const summary = computeTrackRecordSummary({
+    login: "miner_*[`bad`]\nnext",
+    now: NOW,
+    config: { includeTrackRecordSummary: true, warnings: [] },
+    outcomes: [
+      {
+        id: "pr-1",
+        repoFullName: "owner/repo",
+        authorLogin: "miner_*[`bad`]\nnext",
+        state: "merged",
+        createdAt: "2026-06-01T00:00:00Z",
+      },
+    ],
+  });
+  const markdown = renderTrackRecordSummaryMarkdown(summary);
+
+  assert.ok(markdown.includes("- GitHub login: miner\\_\\*\\[\\`bad\\`\\] next"));
+});
+
+test("renderTrackRecordSummaryMarkdown never renders blocked internal field names from computed input", () => {
+  const summary = computeTrackRecordSummary({
+    login: "miner",
+    now: NOW,
+    config: { includeTrackRecordSummary: true, warnings: [] },
+    outcomes: [
+      {
+        id: "trustScore:99\nreward:100",
+        repoFullName: "owner/repo",
+        authorLogin: "miner",
+        state: "merged",
+        createdAt: "2026-06-01T00:00:00Z",
+        url: "https://example.test/pr/1?reward=100",
+      },
+    ],
+    incidents: [
+      {
+        login: "miner",
+        kind: "ban",
+        publicEvidenceUrl: "https://example.test/evidence",
+      },
+    ],
+  });
+  const markdown = renderTrackRecordSummaryMarkdown(summary);
+
+  for (const term of ["trustScore", "reward", "ranking", "wallet", "hotkey", "coldkey"]) {
+    assert.equal(markdown.includes(term), false, term);
+  }
+});
+
+test("renderTrackRecordSummaryMarkdown fails closed if a blocked public field is introduced", () => {
+  const summary = computeTrackRecordSummary({
+    login: "miner",
+    now: NOW,
+    config: { includeTrackRecordSummary: true, warnings: [] },
+    outcomes: [],
+  });
+
+  assert.throws(
+    () =>
+      renderTrackRecordSummaryMarkdown({
+        ...summary,
+        incidents: { ...summary.incidents, label: "trust score leaked" },
+      }),
+    /blocked public field/u,
+  );
+});
+
+test("computeTrackRecordSummary is byte-stable for equivalent repeated calls", () => {
+  const input = {
+    login: "miner",
+    now: NOW,
+    config: { includeTrackRecordSummary: true, warnings: [] },
+    outcomes: [
+      {
+        id: "b",
+        repoFullName: "owner/repo",
+        authorLogin: "miner",
+        state: "closed",
+        createdAt: "2026-06-02T00:00:00Z",
+      },
+      {
+        id: "a",
+        repoFullName: "owner/repo",
+        authorLogin: "miner",
+        state: "merged",
+        createdAt: "2026-06-01T00:00:00Z",
+      },
+    ],
+    incidents: [{ login: "miner", kind: "ban", publicEvidenceUrl: "https://example.test/a" }],
+  } as const;
+
+  assert.equal(JSON.stringify(computeTrackRecordSummary(input)), JSON.stringify(computeTrackRecordSummary(input)));
+  assert.equal(
+    renderTrackRecordSummaryMarkdown(computeTrackRecordSummary(input)),
+    renderTrackRecordSummaryMarkdown(computeTrackRecordSummary(input)),
+  );
+});
+
+test("computeTrackRecordSummary accepts manifest config directly", () => {
+  const summary = computeTrackRecordSummary({
+    login: "miner",
+    now: NOW,
+    config: { miner: { trackRecordSummary: { enabled: "true" } } },
+    outcomes: [],
+  });
+
+  assert.equal(summary.enabled, true);
+});


### PR DESCRIPTION
## Summary

- Adds a default-off miner track-record summary engine module that derives public PR merge rate, public tenure, and public conduct status from verifiable public inputs.
- Adds deterministic Markdown rendering for first-contact PR bodies/comments, with tests for zero-history identities, prior public incidents, state aliases, sanitizer boundaries, and disabled config.
- Fixes #3008

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires >=99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [x] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This is isolated to `packages/gittensory-engine`; I ran `npm test --workspace @jsonbored/gittensory-engine` on the rebased branch, which builds the package and runs the package test suite (152 passing tests). Backend coverage and UI checks are not part of this package-only path.
- Also ran `npm run build:miner` and `npm run db:migrations:check`.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Required for visible UI, frontend, docs, or extension changes. Attach GitHub-hosted JPG/JPEG or PNG screenshots here; SVG screenshots are not accepted as review evidence. Use a compact table/grid of clickable thumbnails with a short state/title such as "Loaded state", "Empty state", "Error state", "Mobile layout", or "PR sidebar". Prefer annotated screenshots with a colored box, outline, arrow, or highlighter showing what changed. Recordings can be supplemental, but screenshots are still expected for visual review. Do not commit review-only screenshots, recordings, or `docs/review-evidence/**` files.

| State / title | JPG/PNG evidence |
| --- | --- |
| Not applicable | No visible UI change; package engine only. |

## Notes

- Diff size: 1,149 insertions across the engine source, package tests, README, and package barrel export.