### PR TITLE
fix(selfhost): redact backlog repo metrics

### DIFF
--- a/src/selfhost/metrics.ts
+++ b/src/selfhost/metrics.ts
@@ -126,10 +126,9 @@ const DEFAULT_METRIC_META: readonly (readonly [string, MetricMeta])[] = [
 const metricMeta = new Map<string, MetricMeta>(DEFAULT_METRIC_META);
 
 // These public counters are scraped without auth on the shared CLOUD worker, so redact repo labels at the
-// counter call-site there. A self-hosted instance's /metrics endpoint is the operator's own Prometheus/Grafana
-// scrape target, not a publicly reachable one -- there is no other-tenant repo name to protect from itself, and
-// redacting `repo` there just breaks the operator's own per-repo dashboards (#terminal-outcome-audit gap: the
-// one label gittensory_gate_decisions_total carried was being dropped even for self-host, with no bypass).
+// counter call-site there. Self-hosted instances can opt out for established per-repo counters, but metrics
+// with labels derived from private queue internals stay redacted because /metrics may be exposed by an
+// operator's reverse proxy before application/session authentication.
 let selfHostedMetricsMode = false;
 
 /** Call ONCE at boot (self-host entrypoint only) to stop redacting `repo` from PRIVATE_REPO_LABEL_METRICS.
@@ -143,9 +142,21 @@ const PRIVATE_REPO_LABEL_METRICS = new Set([
   "gittensory_reviews_published_total",
   "gittensory_agent_disposition_total",
 ]);
+const ALWAYS_REDACT_REPO_LABEL_METRICS = new Set(["gittensory_queue_backlog_by_repo"]);
+const redactedRepoLabels = new Map<string, string>();
+
+function redactedRepoLabel(repo: string): string {
+  const existing = redactedRepoLabels.get(repo);
+  if (existing) return existing;
+  const label = `redacted-${redactedRepoLabels.size + 1}`;
+  redactedRepoLabels.set(repo, label);
+  return label;
+}
 
 function publicLabelsForMetric(name: string, labels?: Labels): Labels | undefined {
-  if (!labels || selfHostedMetricsMode || !PRIVATE_REPO_LABEL_METRICS.has(name) || !("repo" in labels)) return labels;
+  if (!labels || !("repo" in labels)) return labels;
+  if (ALWAYS_REDACT_REPO_LABEL_METRICS.has(name)) return { ...labels, repo: redactedRepoLabel(labels.repo) };
+  if (selfHostedMetricsMode || !PRIVATE_REPO_LABEL_METRICS.has(name)) return labels;
   const publicLabels = { ...labels };
   delete publicLabels.repo;
   return Object.keys(publicLabels).length > 0 ? publicLabels : undefined;
@@ -250,7 +261,7 @@ export async function renderMetrics(): Promise<string> {
       // it sees "no data" (not present) rather than a stale metric name lingering with no TYPE line at all.
       pushMetricMeta(lines, emittedMeta, name);
       for (const { labels, value } of values) {
-        lines.push(`${seriesKey(name, labels)} ${value}`);
+        lines.push(`${seriesKey(name, publicLabelsForMetric(name, labels))} ${value}`);
       }
     } catch {
       /* a failing sampler must not break the scrape */
@@ -276,5 +287,6 @@ export function resetMetrics(): void {
   gaugeVectors.clear();
   histograms.clear();
   metricMeta.clear();
+  redactedRepoLabels.clear();
   for (const [name, meta] of DEFAULT_METRIC_META) metricMeta.set(name, meta);
 }

--- a/test/unit/selfhost-metrics.test.ts
+++ b/test/unit/selfhost-metrics.test.ts
@@ -199,6 +199,17 @@ describe("gaugeVector (#selfhost-lane-observability)", () => {
     expect(out).not.toContain("owner/repo");
   });
 
+  it("reuses the same redacted label for a repo across repeated scrapes, without resetting", async () => {
+    gaugeVector("gittensory_queue_backlog_by_repo", () => [
+      { labels: { rank: "1", repo: "owner/repo" }, value: 2 },
+    ]);
+
+    const first = await renderMetrics();
+    const second = await renderMetrics();
+    expect(first).toContain('gittensory_queue_backlog_by_repo{rank="1",repo="redacted-1"} 2');
+    expect(second).toContain('gittensory_queue_backlog_by_repo{rank="1",repo="redacted-1"} 2');
+  });
+
   it("supports an async sampler", async () => {
     gaugeVector("async_v", async () => [{ labels: { key_scope: "public" }, value: 42 }]);
     expect(await renderMetrics()).toContain('async_v{key_scope="public"} 42');

--- a/test/unit/selfhost-metrics.test.ts
+++ b/test/unit/selfhost-metrics.test.ts
@@ -170,6 +170,35 @@ describe("gaugeVector (#selfhost-lane-observability)", () => {
     expect(out).toContain('v{repo="owner/b"} 5');
   });
 
+  it("redacts repository labels from the public backlog-by-repo gauge vector", async () => {
+    gaugeVector("gittensory_queue_backlog_by_repo", () => [
+      { labels: { rank: "1", repo: "private-owner/secret-repo" }, value: 3 },
+      { labels: { rank: "2", repo: "other-org/confidential" }, value: 1 },
+    ]);
+
+    const out = await renderMetrics();
+    expect(out).toContain('gittensory_queue_backlog_by_repo{rank="1",repo="redacted-1"} 3');
+    expect(out).toContain('gittensory_queue_backlog_by_repo{rank="2",repo="redacted-2"} 1');
+    resetMetrics();
+    gaugeVector("gittensory_queue_backlog_by_repo", () => [
+      { labels: { repo: "private-owner/secret-repo" }, value: 4 },
+    ]);
+    expect(await renderMetrics()).toContain('gittensory_queue_backlog_by_repo{repo="redacted-1"} 4');
+    expect(out).not.toContain("private-owner/secret-repo");
+    expect(out).not.toContain("other-org/confidential");
+  });
+
+  it("keeps backlog-by-repo redacted even in self-hosted metrics mode", async () => {
+    setSelfHostedMetricsMode(true);
+    gaugeVector("gittensory_queue_backlog_by_repo", () => [
+      { labels: { rank: "1", repo: "owner/repo" }, value: 2 },
+    ]);
+
+    const out = await renderMetrics();
+    expect(out).toContain('gittensory_queue_backlog_by_repo{rank="1",repo="redacted-1"} 2');
+    expect(out).not.toContain("owner/repo");
+  });
+
   it("supports an async sampler", async () => {
     gaugeVector("async_v", async () => [{ labels: { key_scope: "public" }, value: 42 }]);
     expect(await renderMetrics()).toContain('async_v{key_scope="public"} 42');


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated /metrics scrapes from exposing raw private repository names via the `gittensory_queue_backlog_by_repo` gauge vector.
- Preserve the existing ability to show repo labels for established per-repo counters while ensuring queue-derived labels (top-N backlog) cannot leak private repo identifiers.

### Description
- Add an allowlist/denylist approach in `src/selfhost/metrics.ts` that marks `gittensory_queue_backlog_by_repo` as always-redacted and supplies stable per-process redacted labels (`redacted-1`, `redacted-2`, …) instead of raw repo names.
- Apply `publicLabelsForMetric()` to gauge-vector rendering so vector samples’ labels are passed through the redaction helper before being emitted.
- Clear the redaction mapping from `resetMetrics()` so tests and fresh registries do not reuse prior redaction state.
- Add regression tests in `test/unit/selfhost-metrics.test.ts` that verify the backlog gauge vector redacts repo labels and remains redacted even when self-host mode would otherwise preserve repo labels.

### Testing
- Ran the metrics unit suite with `npx vitest run test/unit/selfhost-metrics.test.ts`, and the file-level tests passed (30/30).
- Ran type checking with `npm run typecheck`, which succeeded with no errors.
- Attempted the full local gate `npm run test:ci` and `npm run test:coverage`, but those runs were blocked/incomplete in this environment due to unrelated repo-generated artifact drift and external registry/audit issues; the focused unit+typecheck validation for the changed code passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48d502d1e4832c960dd235e7337199)