### PR TITLE
fix(queue): cap linked issue regate fanout

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -3813,11 +3813,12 @@ async function maybeReReviewOnLinkedIssueChange(
   if (isConvergenceRepoAllowed(env, repoFullName)) {
     const openPullRequests = await listOpenPullRequests(env, repoFullName);
     // Issue-side label/assignment changes can flip linked-issue hard-rule verdicts from mergeable to close.
-    // Queue every linked open PR (bounded only by listOpenPullRequests' repo-wide DB limit) so the tail cannot
-    // retain a stale passing gate until the scheduled sweep happens to reach it.
+    // Keep this webhook-triggered wake bounded like the scheduled sweep: each re-gate is REST-expensive, and
+    // queued tail work is picked up by the normal stale-first sweep instead of letting one issue fan out widely.
     const linkingPrs = openPullRequests
       .filter((pr) => pr.linkedIssues.includes(issueNumber))
-      .map((pr) => ({ number: pr.number, createdAt: pr.createdAt ?? null }));
+      .map((pr) => ({ number: pr.number, createdAt: pr.createdAt ?? null }))
+      .slice(0, SWEEP_MAX_PRS);
     for (const [index, pr] of linkingPrs.entries()) {
       const prNumber = pr.number;
       if (await issueLinkedPrReReviewCoalesced(env, repoFullName, prNumber)) {

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -2608,7 +2608,7 @@ describe("queue processors", () => {
     ]);
   });
 
-  it("REGRESSION: issue-side linked PR wake queues every linked PR instead of dropping the capped tail", async () => {
+  it("REGRESSION: issue-side linked PR wake caps webhook fanout so one issue cannot flood the queue", async () => {
     const sent: Array<{ message: import("../../src/types").JobMessage; options?: QueueSendOptions }> = [];
     const env = createTestEnv({
       GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(),
@@ -2645,13 +2645,13 @@ describe("queue processors", () => {
     });
 
     expect(fetchCount).toBe(0);
-    expect(sent).toHaveLength(SWEEP_MAX_PRS + 2);
+    expect(sent).toHaveLength(SWEEP_MAX_PRS);
     expect(sent.map(({ message }) => message)).toEqual(
-      Array.from({ length: SWEEP_MAX_PRS + 2 }, (_, index) =>
+      Array.from({ length: SWEEP_MAX_PRS }, (_, index) =>
         expect.objectContaining({ type: "agent-regate-pr", repoFullName: "owner/agent-repo", prNumber: index + 1, installationId: 9001 }),
       ),
     );
-    expect(sent.map(({ options }) => options)).toEqual([undefined, { delaySeconds: 10 }, { delaySeconds: 20 }, { delaySeconds: 30 }, { delaySeconds: 40 }]);
+    expect(sent.map(({ options }) => options)).toEqual([undefined, { delaySeconds: 10 }, { delaySeconds: 20 }]);
   });
 
   it("REGRESSION (#2371): a coalesced issue-side signal schedules a trailing re-review so an add-then-remove sequence is never lost", async () => {


### PR DESCRIPTION
### Motivation

- A recent change removed the previous per-repo cap and allowed an issues webhook to enqueue every linked open PR (up to the DB limit), which can exhaust the shared JOBS queue and GitHub REST budget; the fix restores a bounded webhook fanout.

### Description

- Reintroduced a cap in `maybeReReviewOnLinkedIssueChange` by slicing the linked-PR list to `SWEEP_MAX_PRS` so issue-side wakes enqueue at most the configured number of `agent-regate-pr` jobs.
- Updated the regression unit test in `test/unit/queue.test.ts` to seed more linked PRs than the cap and assert that only `SWEEP_MAX_PRS` jobs are queued with the expected staggered delays.

### Testing

- Ran the focused unit test with `npx vitest run test/unit/queue.test.ts -t "issue-side linked PR wake caps" --reporter=verbose`, and the targeted test passed.
- Ran `npm run typecheck`, which completed successfully.
- Started the full `npm run test:coverage` run; the targeted regression is covered and passed, while the full suite run exposed long-running/backfill test segments and a small set of existing/unrelated failures/timeouts, so CI should be used to validate the full coverage gate.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48f5eafc84832c8396d20dd9639c5a)