### PR TITLE
fix(manifest): preserve legacy blocked path holds

### DIFF
--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -316,9 +316,9 @@ const MAX_PATH_INSTRUCTIONS = 50;
 
 /**
  * Normalized maintainer focus manifest. Repo owners declare which work areas are wanted,
- * preferred, and how PRs should present validation. Path-based manual review is intentionally
- * not part of this manifest anymore; use `settings.hardGuardrailGlobs` for that single
- * authoritative control. `maintainerNotes` are private review context and must never reach a public
+ * preferred, and how PRs should present validation. Path-based manual review is configured through
+ * `settings.hardGuardrailGlobs`; legacy top-level `blockedPaths` is accepted as a compatibility
+ * alias when the settings field is absent. `maintainerNotes` are private review context and must never reach a public
  * GitHub surface; `publicNotes` are explicitly opted into public output by the maintainer.
  */
 export type FocusManifest = {
@@ -1754,6 +1754,16 @@ export function parseFocusManifest(raw: unknown, source?: FocusManifestSource): 
   }
   const record = raw as Record<string, JsonValue>;
   const warnings: string[] = [];
+  const settings = parseSettingsOverride(record.settings, warnings);
+  const hasSettingsHardGuardrails =
+    record.settings !== null &&
+    typeof record.settings === "object" &&
+    !Array.isArray(record.settings) &&
+    Object.prototype.hasOwnProperty.call(record.settings, "hardGuardrailGlobs");
+  if (!hasSettingsHardGuardrails && Array.isArray(record.blockedPaths)) {
+    const legacyGuardrails = normalizeStringList(record.blockedPaths, "blockedPaths", warnings);
+    if (legacyGuardrails.length > 0) settings.hardGuardrailGlobs = legacyGuardrails;
+  }
   const manifest: FocusManifest = {
     present: true,
     source: normalizeSource(source, record.source, warnings),
@@ -1765,7 +1775,7 @@ export function parseFocusManifest(raw: unknown, source?: FocusManifestSource): 
     maintainerNotes: normalizeStringList(record.maintainerNotes, "maintainerNotes", warnings),
     publicNotes: normalizeStringList(record.publicNotes, "publicNotes", warnings).filter(isFocusManifestPublicSafe),
     gate: parseGateConfig(record.gate, warnings),
-    settings: parseSettingsOverride(record.settings, warnings),
+    settings,
     review: parseReviewConfig(record.review, warnings),
     features: parseFeaturesConfig(record.features, warnings),
     contentLane: parseContentLaneConfig(record.contentLane, warnings),

--- a/test/fixtures/engine-parity/predicted-gate/README.md
+++ b/test/fixtures/engine-parity/predicted-gate/README.md
@@ -10,7 +10,7 @@ surface it should produce today. The follow-up parity runner can reuse the same 
 | `clean-pass-oss-anti-slop.ts` | Clean pass under `oss-anti-slop`, including the public funnel | `success` | none |
 | `duplicate-pr-block.ts` | Open sibling PR sharing the linked issue | `failure` | `duplicate_pr_risk` |
 | `missing-linked-issue-block.ts` | `linkedIssue:block` with no linked issue in the body or metadata | `failure` | `missing_linked_issue` |
-| `manifest-blocked-path.ts` | Legacy `blockedPaths` with `manifestPolicy:block` are ignored | `success` | none |
+| `manifest-blocked-path.ts` | Legacy `blockedPaths` with `manifestPolicy:block` produce a guardrail hold | `neutral` | none |
 | `readiness-warning.ts` | `gate.readiness.mode=advisory` with a threshold above the public readiness score | `success` | `readiness_score_below_threshold` |
 | `path-gated-check-with-paths.ts` | Enforced `review.pre_merge_checks` rule once matching `changedPaths` are supplied | `failure` | `pre_merge_check_required` |
 | `path-gated-check-without-paths.ts` | The same path-gated pre-merge rule before `changedPaths` are known | `success` | none |

--- a/test/fixtures/engine-parity/predicted-gate/manifest-blocked-path.ts
+++ b/test/fixtures/engine-parity/predicted-gate/manifest-blocked-path.ts
@@ -1,10 +1,9 @@
 import { BASE_INPUT, BASE_REPO, definePredictedGateFixture, openIssue, parseManifest } from "./_shared";
 
-// Legacy focus-manifest blockedPaths are inert. Path holds are configured through
-// settings.hardGuardrailGlobs, not manifestPolicy.
+// Legacy focus-manifest blockedPaths remain a compatibility alias for hard guardrail holds.
 export default definePredictedGateFixture({
   id: "manifest-blocked-path",
-  title: "Legacy blocked manifest path is ignored",
+  title: "Legacy blocked manifest path is held",
   branch: "legacy blockedPaths with changedPaths supplied and manifestPolicy:block",
   input: BASE_INPUT,
   manifest: parseManifest({ gate: { manifestPolicy: "block" }, blockedPaths: ["dist/**"] }),
@@ -13,10 +12,10 @@ export default definePredictedGateFixture({
   pullRequests: [],
   changedPaths: ["dist/bundle.js"],
   expected: {
-    conclusion: "success",
+    conclusion: "neutral",
     pack: "gittensor",
     blockerCodes: [],
-    warningCodes: [],
+    warningCodes: ["guardrail_hold"],
     funnelPresent: false,
     noteExcludes: ["Provide the PR's changed paths"],
   },

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -467,10 +467,12 @@ describe("compileFocusManifestPolicy", () => {
     expect(guidance).not.toMatch(/ranking/i);
   });
 
-  it("treats legacy blockedPaths-only manifests as absent", () => {
-    const policy = compileFocusManifestPolicy(REPO, parseFocusManifest({ blockedPaths: ["infra/"] }), opts);
-    expect(policy.present).toBe(false);
-    expect(policy.publicSafe.readinessWarnings).toEqual([]);
+  it("treats legacy blockedPaths-only manifests as guardrail settings", () => {
+    const manifest = parseFocusManifest({ blockedPaths: ["infra/"] });
+    const policy = compileFocusManifestPolicy(REPO, manifest, opts);
+    expect(manifest.present).toBe(true);
+    expect(manifest.settings.hardGuardrailGlobs).toEqual(["infra/"]);
+    expect(policy.present).toBe(true);
   });
 
   it("emits a readiness warning when no wanted paths or preferred labels are declared", () => {
@@ -1572,6 +1574,12 @@ describe("parseFocusManifest settings override + resolveEffectiveSettings", () =
 
     const omitted = resolveEffectiveSettings({ hardGuardrailGlobs: ["db-default/**"] } as unknown as RepositorySettings, parseFocusManifest({}));
     expect(omitted.hardGuardrailGlobs).toEqual(["db-default/**"]);
+
+    const legacy = resolveEffectiveSettings({ hardGuardrailGlobs: ["db-default/**"] } as unknown as RepositorySettings, parseFocusManifest({ blockedPaths: ["legacy/**"] }));
+    expect(legacy.hardGuardrailGlobs).toEqual(["legacy/**"]);
+
+    const explicitBeatsLegacy = resolveEffectiveSettings({ hardGuardrailGlobs: ["db-default/**"] } as unknown as RepositorySettings, parseFocusManifest({ blockedPaths: ["legacy/**"], settings: { hardGuardrailGlobs: ["modern/**"] } }));
+    expect(explicitBeatsLegacy.hardGuardrailGlobs).toEqual(["modern/**"]);
 
     const malformed = parseFocusManifest({ settings: { hardGuardrailGlobs: "src/**" as never } });
     expect(malformed.settings.hardGuardrailGlobs).toBeUndefined();

--- a/test/unit/mcp-predict-gate.test.ts
+++ b/test/unit/mcp-predict-gate.test.ts
@@ -60,7 +60,7 @@ describe("MCP gittensory_predict_gate", () => {
     expect(JSON.stringify(result.content)).toContain("Too big");
   });
 
-  it("ignores legacy focus-manifest blockedPaths when changedPaths are supplied (#11-13/#18)", async () => {
+  it("maps legacy focus-manifest blockedPaths to a guardrail hold when changedPaths are supplied (#11-13/#18)", async () => {
     const env = createTestEnv();
     await upsertRepositoryFromGitHub(env, { name: "widgets", full_name: "acme/widgets" });
     // Public config: oss-anti-slop (no account needed), manifest policy in block mode, legacy dist/** blocked.
@@ -74,9 +74,10 @@ describe("MCP gittensory_predict_gate", () => {
     });
     expect(result.isError).toBeFalsy();
     const data = result.structuredContent as { conclusion: string; blockers: Array<{ code: string }>; warnings: Array<{ code: string }>; note: string };
-    expect(data.conclusion).toBe("success");
+    expect(data.conclusion).toBe("neutral");
     expect(data.blockers.some((b) => b.code === "manifest_blocked_path")).toBe(false);
     expect(data.warnings.some((w) => w.code === "manifest_blocked_path")).toBe(false);
+    expect(data.warnings.some((w) => w.code === "guardrail_hold")).toBe(true);
     // With paths supplied the note drops the "provide changed paths" disclaimer but still disclaims slop.
     expect(data.note).not.toContain("Provide the PR's changed paths");
     expect(data.note.toLowerCase()).toContain("slop");

--- a/test/unit/predicted-gate.test.ts
+++ b/test/unit/predicted-gate.test.ts
@@ -336,29 +336,27 @@ describe("buildPredictedGateVerdict", () => {
     expect(result.conclusion).toBe("neutral");
   });
 
-  it("ignores legacy blockedPaths even when manifestPolicy:block is enabled (#12)", () => {
+  it("maps legacy blockedPaths to a guardrail hold even when manifestPolicy:block is enabled (#12)", () => {
     const result = verdict({
       gate: { manifestPolicy: "block" },
       manifestExtra: { blockedPaths: ["dist/**"] },
       changedPaths: ["dist/bundle.js"],
     });
-    expect(result.conclusion).toBe("success");
+    expect(result.conclusion).toBe("neutral");
+    expect(result.warnings.some((w) => w.code === "guardrail_hold")).toBe(true);
     expect(result.blockers.some((b) => b.code === "manifest_blocked_path")).toBe(false);
-    expect(result.warnings.some((w) => w.code === "manifest_blocked_path")).toBe(false);
-    // The note no longer disclaims path-policy once paths are supplied, but slop stays disclaimed.
     expect(result.note).not.toContain("Provide the PR's changed paths");
     expect(result.note.toLowerCase()).toContain("slop");
   });
 
-  it("manifestPolicy:advisory does NOT block on legacy blockedPaths (parity with the live advisory gate) (#12)", () => {
-    // Path holds are configured through settings.hardGuardrailGlobs, not manifest blockedPaths.
+  it("maps legacy blockedPaths to a guardrail hold under manifestPolicy:advisory (#12)", () => {
     const result = verdict({
       gate: { manifestPolicy: "advisory" },
       manifestExtra: { blockedPaths: ["dist/**"] },
       changedPaths: ["dist/bundle.js"],
     });
-    expect(result.conclusion).not.toBe("failure");
-    expect(result.blockers.some((b) => b.code === "manifest_blocked_path")).toBe(false);
+    expect(result.conclusion).toBe("neutral");
+    expect(result.warnings.some((w) => w.code === "guardrail_hold")).toBe(true);
   });
 
   it("manifestPolicy:off (default) emits NO manifest finding for legacy blockedPaths", () => {
@@ -369,6 +367,7 @@ describe("buildPredictedGateVerdict", () => {
     });
     expect(result.blockers.some((b) => b.code === "manifest_blocked_path")).toBe(false);
     expect(result.warnings.some((w) => w.code === "manifest_blocked_path")).toBe(false);
+    expect(result.warnings.some((w) => w.code === "guardrail_hold")).toBe(true);
   });
 
   it("ignores non-policy guidance findings (e.g. off-focus) — only enforceable policy codes are threaded (#12)", () => {


### PR DESCRIPTION
### Motivation

- Restore runtime compatibility for legacy top-level `blockedPaths` so repositories that relied on that field continue to be held for manual review when appropriate, avoiding the regression where those paths were silently ignored at runtime.
- Keep the modern `settings.hardGuardrailGlobs` field authoritative while providing a compatibility alias for older manifests, preventing accidental bypass of guardrail holds on production repos with automation.

### Description

- Parse the manifest `settings` block first and, when `settings.hardGuardrailGlobs` is not explicitly present, map a normalized top-level `blockedPaths` array into `settings.hardGuardrailGlobs` in `parseFocusManifest` (`src/signals/focus-manifest.ts`).
- Preserve precedence so an explicit `settings.hardGuardrailGlobs` continues to win over legacy `blockedPaths` when both are present.
- Update the focus-manifest doc comment to describe `blockedPaths` as a compatibility alias and adjust the engine-parity fixture and predictor/unit tests to expect a guardrail hold for legacy blocked paths (`test/unit/*`, `test/fixtures/engine-parity/*`).

### Testing

- Ran `git diff --check` and `npx tsc --noEmit --pretty false`, both succeeded.
- Ran targeted unit tests with `npx vitest run test/unit/focus-manifest.test.ts test/unit/predicted-gate.test.ts test/unit/mcp-predict-gate.test.ts` and they all passed.
- Attempted `npm run test:coverage` but the full coverage run timed out / did not complete due to long-running existing suites; coverage was not produced in this environment.
- Attempted `npm audit --audit-level=moderate` but the registry audit endpoint returned `403 Forbidden`, so the audit step could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4937c107f8832c879b546b2d620a09)