### PR TITLE
fix(review): restore default path guardrails

### DIFF
--- a/.gittensory.yml.example
+++ b/.gittensory.yml.example
@@ -13,8 +13,8 @@
 #   this file  >  per-repo dashboard/API settings  >  built-in safe defaults
 #   The typed `gate:` block below is an alias for the gate fields and wins over
 #   the generic `settings:` block for those same fields.
-#   Hard path guardrails are an explicit config-as-code exception: omitted or
-#   [] means no path guardrails, never hidden engine defaults.
+#   Hard path guardrails keep built-in defense-in-depth defaults when omitted/null;
+#   [] is the explicit opt-out.
 #
 # SAFE BY DEFAULT: with no file and no dashboard row, a repo falls back to a
 # quiet, non-blocking profile — gate off, AI review off, slop scoring off,
@@ -392,9 +392,9 @@ settings:
   # of this setting. Bool. Default: false.
   closeOwnerAuthors: false
 
-  # Hard manual-review path guardrails are config-as-code only. Omit or use [] for no path guardrails;
-  # set concrete globs when otherwise-mergeable PRs touching those paths must be held for a person.
-  # This never falls back to hidden engine path defaults.
+  # Hard manual-review path guardrails have built-in defense-in-depth defaults when omitted/null;
+  # use [] only as an explicit opt-out. Set concrete globs to replace the default list when
+  # otherwise-mergeable PRs touching those paths must be held for a person.
   hardGuardrailGlobs: []
 
   # Require a linked issue on every PR (dashboard equivalent of the toggle that

--- a/apps/gittensory-ui/src/routes/docs.tuning.tsx
+++ b/apps/gittensory-ui/src/routes/docs.tuning.tsx
@@ -78,9 +78,8 @@ function Tuning() {
         <li>built-in safe defaults.</li>
       </ul>
       <p>
-        Path holds are explicit config-as-code only: omitted or empty{" "}
-        <code>settings.hardGuardrailGlobs</code> means no path guardrails, not a hidden engine
-        fallback.
+        Path holds use defense-in-depth defaults when omitted or null; an explicit empty{" "}
+        <code>settings.hardGuardrailGlobs</code> list is the config-as-code opt-out.
       </p>
       <p>
         The friendly <code>gate:</code> block in <code>.gittensory.yml</code> is a typed alias for
@@ -468,7 +467,7 @@ settings:
   checkRunMode: enabled
   checkRunDetailLevel: standard
   badgeEnabled: true
-  # Optional path holds. Omitted or [] means no path guardrails.
+  # Optional path holds. Omitted keeps built-in guardrails; [] explicitly disables them.
   # hardGuardrailGlobs:
   #   - "src/selfhost/**"`}
       />

--- a/config/examples/README.md
+++ b/config/examples/README.md
@@ -130,9 +130,7 @@ Two `autonomy` classes govern every label the bot can apply, and they are **inde
   to `auto` only if you specifically want that commentary as GitHub labels too.
 
 All disposition labels are configurable under `settings.*Label`, and explicit `null` disables the
-label without disabling the underlying merge/close/hold decision. Hard path guardrails are
-config-as-code only: omitting `settings.hardGuardrailGlobs` or setting it to `[]` means no path
-guardrails, and a concrete list replaces any lower-layer private global default.
+label without disabling the underlying merge/close/hold decision. Hard path guardrails keep built-in defense-in-depth defaults when `settings.hardGuardrailGlobs` is omitted or null. Set `[]` only as an explicit opt-out, or set a concrete list to replace any lower-layer private global/default guardrails.
 
 ```yaml
 # .gittensory.yml (global default) — recommended one-shot baseline

--- a/config/examples/global.gittensory.yml
+++ b/config/examples/global.gittensory.yml
@@ -48,8 +48,9 @@ settings:
   autoCloseExemptLogins:
     - your-admin-login
 
-  # Hard manual-review path guardrails are config-as-code only. Omit or use [] for no path
-  # guardrails; set a concrete list when you want otherwise-mergeable PRs held for a person.
+  # Hard manual-review path guardrails have built-in defense-in-depth defaults when omitted/null;
+  # use [] only as an explicit opt-out, or set a concrete replacement list when you want
+  # otherwise-mergeable PRs held for a person.
   hardGuardrailGlobs: []
 
   # Disposition label names are config-as-code, not engine identity. Set any value to your repo's

--- a/src/review/guardrail-config.ts
+++ b/src/review/guardrail-config.ts
@@ -1,12 +1,72 @@
 import type { RepositorySettings } from "../types";
 
+// Built-in defense-in-depth defaults used when the operator has not configured guardrails at all.
+// A concrete `hardGuardrailGlobs: []` in private global or repo config remains the explicit opt-out.
+export const DEFAULT_CRUCIAL_GUARDRAIL_GLOBS = [
+  ".github/workflows/**",
+  "scripts/**",
+];
+
+export const CONFIG_AS_CODE_GUARDRAIL_GLOBS = [
+  ".gittensory.yml",
+  ".gittensory.yaml",
+  ".gittensory.json",
+  ".github/gittensory.yml",
+  ".github/gittensory.yaml",
+  ".github/gittensory.json",
+  "**/codecov.yml",
+  "**/codecov.yaml",
+  "**/.codecov.yml",
+];
+
+export const ENGINE_DECISION_GUARDRAIL_GLOBS = [
+  "src/rules/**",
+  "src/services/**",
+  "src/settings/agent-actions.ts",
+  "src/settings/agent-execution.ts",
+  "src/settings/agent-sweep.ts",
+  "src/settings/autonomy.ts",
+  "src/queue/**",
+  "src/github/pr-actions.ts",
+  "src/github/app.ts",
+  "src/github/backfill.ts",
+  "src/scoring/**",
+  "src/auth/**",
+  "src/review/safety.ts",
+  "src/review/guardrail-config.ts",
+  "src/review/cutover-gate.ts",
+  "src/review/linked-issue-hard-rules.ts",
+  "src/review/outcomes-wire.ts",
+];
+
+export const SELFHOST_RUNTIME_GUARDRAIL_GLOBS = [
+  "src/selfhost/**",
+  "src/server.ts",
+  "src/db/**",
+  "Dockerfile",
+  "docker-compose*.yml*",
+  "docker-compose*.yaml*",
+  "compose*.yml*",
+  "compose*.yaml*",
+  "systemd/**",
+];
+
+export const DEFAULT_HARD_GUARDRAIL_GLOBS = [
+  ...DEFAULT_CRUCIAL_GUARDRAIL_GLOBS,
+  ...CONFIG_AS_CODE_GUARDRAIL_GLOBS,
+  ...ENGINE_DECISION_GUARDRAIL_GLOBS,
+  ...SELFHOST_RUNTIME_GUARDRAIL_GLOBS,
+];
+
 /**
- * Resolve hard-guardrail path globs from the already-effective repo settings. Path holds are config-as-code only:
- * omitted/null settings mean no path guardrails, and arrays replace lower layers wholesale.
+ * Resolve hard-guardrail path globs from already-effective repo settings. Missing/null settings keep built-in
+ * safety defaults; a concrete list replaces them wholesale, and `[]` is the explicit opt-out.
  */
 export function resolveHardGuardrailGlobs(
   settings: Pick<RepositorySettings, "hardGuardrailGlobs"> | null | undefined,
 ): string[] {
   const configured = settings?.hardGuardrailGlobs;
-  return Array.isArray(configured) ? [...configured] : [];
+  return Array.isArray(configured)
+    ? [...configured]
+    : [...DEFAULT_HARD_GUARDRAIL_GLOBS];
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -823,9 +823,9 @@ export type RepositorySettings = {
    *  on top of the standing owner/admin/automation-bot exemption. Always populated by the DB layer (default
    *  `[]`); optional so existing settings fixtures/callers need not be touched. */
   autoCloseExemptLogins?: string[] | undefined;
-  /** Hard manual-review guardrail globs. Config-as-code only: set in private/global or per-repo
-   *  `.gittensory.yml` under `settings.hardGuardrailGlobs`. Absent means no path guardrails. Arrays are
-   *  replacement overlays, so a repo can clear a global default with `[]`. */
+  /** Hard manual-review guardrail globs. Set in private/global or per-repo `.gittensory.yml` under
+   *  `settings.hardGuardrailGlobs`. Absent/null settings keep built-in defense-in-depth guardrails. Arrays
+   *  are replacement overlays, so a repo can explicitly clear defaults with `[]`. */
   hardGuardrailGlobs?: string[] | null | undefined;
   /** Label applied when an otherwise-ready PR is held for manual review by a guardrail. Config-as-code only;
    *  `null` disables the label while keeping the hold. Distinct from `review_state_label`, so operators can

--- a/test/unit/guardrail-config.test.ts
+++ b/test/unit/guardrail-config.test.ts
@@ -1,17 +1,38 @@
 import { describe, expect, it } from "vitest";
-import { resolveHardGuardrailGlobs } from "../../src/review/guardrail-config";
+import {
+  DEFAULT_HARD_GUARDRAIL_GLOBS,
+  resolveHardGuardrailGlobs,
+} from "../../src/review/guardrail-config";
 
 describe("resolveHardGuardrailGlobs", () => {
-  it("does not invent path guardrails when effective settings omit hardGuardrailGlobs", () => {
-    expect(resolveHardGuardrailGlobs(undefined)).toEqual([]);
-    expect(resolveHardGuardrailGlobs(null)).toEqual([]);
-    expect(resolveHardGuardrailGlobs({})).toEqual([]);
-    expect(resolveHardGuardrailGlobs({ hardGuardrailGlobs: null })).toEqual([]);
+  it("falls back to built-in guardrails when effective settings omit hardGuardrailGlobs", () => {
+    expect(resolveHardGuardrailGlobs(undefined)).toEqual(
+      DEFAULT_HARD_GUARDRAIL_GLOBS,
+    );
+    expect(resolveHardGuardrailGlobs(null)).toEqual(
+      DEFAULT_HARD_GUARDRAIL_GLOBS,
+    );
+    expect(resolveHardGuardrailGlobs({})).toEqual(DEFAULT_HARD_GUARDRAIL_GLOBS);
+    expect(resolveHardGuardrailGlobs({ hardGuardrailGlobs: null })).toEqual(
+      DEFAULT_HARD_GUARDRAIL_GLOBS,
+    );
+  });
+
+  it("returns a clone of the built-in guardrail globs", () => {
+    const resolved = resolveHardGuardrailGlobs(undefined);
+
+    expect(resolved).toEqual(DEFAULT_HARD_GUARDRAIL_GLOBS);
+    expect(resolved).not.toBe(DEFAULT_HARD_GUARDRAIL_GLOBS);
+
+    resolved.push("mutated/**");
+    expect(DEFAULT_HARD_GUARDRAIL_GLOBS).not.toContain("mutated/**");
   });
 
   it("returns a clone of the configured guardrail globs", () => {
     const configured = ["src/settings/**", ".github/workflows/**"];
-    const resolved = resolveHardGuardrailGlobs({ hardGuardrailGlobs: configured });
+    const resolved = resolveHardGuardrailGlobs({
+      hardGuardrailGlobs: configured,
+    });
 
     expect(resolved).toEqual(configured);
     expect(resolved).not.toBe(configured);

--- a/test/unit/predicted-gate.test.ts
+++ b/test/unit/predicted-gate.test.ts
@@ -418,10 +418,10 @@ describe("buildPredictedGateVerdict", () => {
     expect(result.blockers).toHaveLength(0);
   });
 
-  it("does NOT predict a guardrail hold when hardGuardrailGlobs is omitted", () => {
+  it("predicts a guardrail hold when hardGuardrailGlobs is omitted and a built-in guarded path changes", () => {
     const result = verdict({ gate: { duplicates: "block" }, changedPaths: [".github/workflows/ci.yml"] });
-    expect(result.conclusion).toBe("success");
-    expect(result.warnings.some((w) => w.code === "guardrail_hold")).toBe(false);
+    expect(result.conclusion).toBe("neutral");
+    expect(result.warnings.some((w) => w.code === "guardrail_hold")).toBe(true);
   });
 
   it("does NOT predict a guardrail hold when hardGuardrailGlobs is explicitly empty", () => {


### PR DESCRIPTION
### Motivation

- A prior change made omitted/null `settings.hardGuardrailGlobs` resolve to an empty list, removing the built-in defense-in-depth guardrails and causing otherwise-ready PRs touching sensitive automation/security paths to be treated as unguarded (fail-open).
- Restore conservative, fail-closed behavior so repositories that have not explicitly opted-out still hold PRs touching crucial automation, CI, DB, auth, and engine decision paths.

### Description

- Reintroduced a built-in guardrail set by adding grouped constants and `DEFAULT_HARD_GUARDRAIL_GLOBS`, and changed `resolveHardGuardrailGlobs` to return the default set when settings are omitted/null while preserving explicit arrays and `[]` opt-out semantics (`src/review/guardrail-config.ts`).
- Updated `RepositorySettings` doc comments to document that absent/null settings keep the built-in defaults and that `[]` explicitly disables them (`src/types.ts`).
- Added and adjusted regression/unit tests to assert omitted/null fallbacks and the explicit-empty opt-out (`test/unit/guardrail-config.test.ts`, `test/unit/predicted-gate.test.ts`).
- Clarified docs and examples to reflect the restored default behavior (`.gittensory.yml.example`, `config/examples/README.md`, `config/examples/global.gittensory.yml`, `apps/gittensory-ui/src/routes/docs.tuning.tsx`).

### Testing

- Ran unit tests with `npx vitest run test/unit/guardrail-config.test.ts test/unit/predicted-gate.test.ts`, and all executed tests passed (48 tests across the two files).
- Ran `npm run typecheck` which completed successfully with no type errors.
- Ran `npm --workspace @jsonbored/gittensory-ui run lint` (invoked via `npm run ui:lint`) which exited 0; existing UI fast-refresh warnings were reported but lint returned success.
- Attempted `npm run test:coverage` but the full coverage run did not complete in this environment (hung and was interrupted), so the unsharded coverage job was not finished here.
- `npm audit --audit-level=moderate` failed due to the npm registry audit endpoint returning `403 Forbidden` in this environment and could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a493805fb44832c81a1822475f95170)