### PR TITLE
feat(miner): add replay target snapshots

### DIFF
--- a/packages/gittensory-engine/README.md
+++ b/packages/gittensory-engine/README.md
@@ -297,6 +297,58 @@ The rendered block is intentionally narrow: login, resolved public PR counts, pu
 status, and optional public evidence URLs for active incidents. Caller-provided ids, PR URLs, and arbitrary metadata are
 never copied into the Markdown, and the renderer fails closed if a blocked private-field name is introduced.
 
+## Replay-target snapshots
+
+`createReplayTargetSnapshot()` provides the deterministic engine contract for historical replay target freezes. The
+miner/runtime layer remains responsible for reading git history and exporting the actual worktree, while the engine
+filters already-read commits, tags, releases, README data, tree-file metadata, and external references to the target
+commit boundary.
+
+```ts
+import { createReplayTargetSnapshot } from "@jsonbored/gittensory-engine";
+
+const snapshot = createReplayTargetSnapshot({
+  repo: "jsonbored/gittensory",
+  targetCommitSha: "2222222222222222222222222222222222222222",
+  commits: [
+    {
+      sha: "1111111111111111111111111111111111111111",
+      committedAt: "2026-06-01T00:00:00Z",
+      subject: "docs: initial readme",
+      paths: ["README.md"],
+    },
+    {
+      sha: "2222222222222222222222222222222222222222",
+      committedAt: "2026-06-02T00:00:00Z",
+      subject: "feat: add replay harness",
+      paths: ["packages/gittensory-engine/src/objective-anchor.ts"],
+    },
+  ],
+  tags: [{ name: "v0.1.0", targetSha: "1111111111111111111111111111111111111111" }],
+  readme: {
+    path: "README.md",
+    blobSha: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    observedAt: "2026-06-02T00:00:00Z",
+    text: "# Gittensory\n",
+  },
+});
+```
+
+The returned snapshot includes:
+
+- a `git-worktree` export plan with a content-addressed destination key;
+- a context bundle containing only commits/tags/releases/references knowable at or before the target commit;
+- normalized README and tree-file metadata for the target working tree;
+- objective-anchor history features derived through the same replay history extractor used by calibration scoring;
+- an excluded-artifact audit for post-target context that was intentionally withheld.
+
+`validateReplayTargetSnapshot()` and `assertReplayTargetSnapshotValid()` fail fast if a context artifact contains a
+timestamp after the target commit or if the target commit is missing from the exported history. Given the same repo,
+target commit, and context inputs, `JSON.stringify(snapshot)` is stable across repeated exports.
+
+`renderReplayTargetSnapshotManifestMarkdown()` turns the same snapshot into a deterministic audit manifest with included
+context, excluded post-target context, export paths, and validation findings for local replay artifacts.
+
 ## Plan templates
 
 `plan-templates.ts` exports one builder per miner lifecycle stage (`analyze`, `plan`, `prepare`, `create`, `manage`).

--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -71,6 +71,31 @@ export {
   type TrackRecordSummaryOutcomeCounts,
   type TrackRecordTenure,
 } from "./track-record-summary.js";
+export {
+  assertReplayTargetSnapshotValid,
+  createReplayTargetSnapshot,
+  renderReplayTargetSnapshotManifestMarkdown,
+  validateReplayTargetSnapshot,
+  type ReplayTargetCommitInput,
+  type ReplayTargetExternalReferenceInput,
+  type ReplayTargetReadmeInput,
+  type ReplayTargetReleaseInput,
+  type ReplayTargetRepoRef,
+  type ReplayTargetSnapshot,
+  type ReplayTargetSnapshotCommit,
+  type ReplayTargetSnapshotContext,
+  type ReplayTargetSnapshotExportPlan,
+  type ReplayTargetSnapshotInput,
+  type ReplayTargetSnapshotReadme,
+  type ReplayTargetSnapshotReference,
+  type ReplayTargetSnapshotRelease,
+  type ReplayTargetSnapshotTag,
+  type ReplayTargetSnapshotTreeFile,
+  type ReplayTargetSnapshotValidation,
+  type ReplayTargetSnapshotValidationViolation,
+  type ReplayTargetTagInput,
+  type ReplayTargetTreeFileInput,
+} from "./replay-target-snapshot.js";
 export * from "./governor/rate-limit.js";
 export {
   GOVERNOR_LEDGER_EVENT_TYPES,

--- a/packages/gittensory-engine/src/replay-target-snapshot.ts
+++ b/packages/gittensory-engine/src/replay-target-snapshot.ts
@@ -1,0 +1,625 @@
+// Deterministic replay-target snapshot contract (#3010).
+//
+// This module owns the pure planning/validation half of historical replay snapshots. Callers still perform the git
+// worktree export and history reads; the engine filters those already-read commit/tag/release records to the target
+// commit boundary, derives a stable snapshot key, and fails fast if any context artifact leaks post-target time.
+
+import { extractObjectiveAnchorHistory, type ObjectiveAnchorHistoryExtraction } from "./objective-anchor.js";
+
+export type ReplayTargetRepoRef = {
+  fullName: string;
+  remoteUrl?: string | undefined;
+  defaultBranch?: string | undefined;
+};
+
+export type ReplayTargetCommitInput = {
+  sha: string;
+  committedAt: string | Date;
+  subject?: string | undefined;
+  paths?: readonly string[] | undefined;
+  parents?: readonly string[] | undefined;
+};
+
+export type ReplayTargetTagInput = {
+  name: string;
+  targetSha?: string | undefined;
+  taggedAt?: string | Date | null | undefined;
+};
+
+export type ReplayTargetReleaseInput = {
+  name: string;
+  tagName: string;
+  publishedAt?: string | Date | null | undefined;
+};
+
+export type ReplayTargetReadmeInput = {
+  path: string;
+  blobSha: string;
+  text?: string | undefined;
+  observedAt?: string | Date | null | undefined;
+};
+
+export type ReplayTargetTreeFileInput = {
+  path: string;
+  blobSha?: string | undefined;
+  mode?: string | undefined;
+  size?: number | undefined;
+  observedAt?: string | Date | null | undefined;
+};
+
+export type ReplayTargetExternalReferenceInput = {
+  kind: "issue" | "pull_request" | "discussion" | "manual" | string;
+  id: string | number;
+  observedAt?: string | Date | null | undefined;
+};
+
+export type ReplayTargetSnapshotInput = {
+  repo: ReplayTargetRepoRef | string;
+  targetCommitSha: string;
+  targetCommittedAt?: string | Date | undefined;
+  exportRoot?: string | undefined;
+  commits: readonly ReplayTargetCommitInput[];
+  tags?: readonly ReplayTargetTagInput[] | undefined;
+  releases?: readonly ReplayTargetReleaseInput[] | undefined;
+  readme?: ReplayTargetReadmeInput | null | undefined;
+  treeFiles?: readonly ReplayTargetTreeFileInput[] | undefined;
+  externalReferences?: readonly ReplayTargetExternalReferenceInput[] | undefined;
+};
+
+export type ReplayTargetSnapshotCommit = {
+  sha: string;
+  committedAt: string;
+  subject: string | null;
+  paths: string[];
+  parents: string[];
+};
+
+export type ReplayTargetSnapshotTag = {
+  name: string;
+  targetSha: string | null;
+  taggedAt: string | null;
+};
+
+export type ReplayTargetSnapshotRelease = {
+  name: string;
+  tagName: string;
+  publishedAt: string | null;
+};
+
+export type ReplayTargetSnapshotReadme = {
+  path: string;
+  blobSha: string;
+  text: string | null;
+  observedAt: string | null;
+};
+
+export type ReplayTargetSnapshotTreeFile = {
+  path: string;
+  blobSha: string | null;
+  mode: string | null;
+  size: number | null;
+  observedAt: string | null;
+};
+
+export type ReplayTargetSnapshotReference = {
+  kind: string;
+  id: string;
+  observedAt: string | null;
+};
+
+export type ReplayTargetSnapshotExportPlan = {
+  strategy: "git-worktree";
+  sourceCommit: string;
+  destinationKey: string;
+  exportRoot: string;
+  worktreePath: string;
+  contextPath: string;
+};
+
+export type ReplayTargetSnapshotContext = {
+  commits: ReplayTargetSnapshotCommit[];
+  tags: ReplayTargetSnapshotTag[];
+  releases: ReplayTargetSnapshotRelease[];
+  readme: ReplayTargetSnapshotReadme | null;
+  treeFiles: ReplayTargetSnapshotTreeFile[];
+  externalReferences: ReplayTargetSnapshotReference[];
+  history: ObjectiveAnchorHistoryExtraction;
+};
+
+export type ReplayTargetSnapshotValidationViolation = {
+  artifact: string;
+  timestamp: string;
+  targetCommittedAt: string;
+  reason: "post_target_timestamp" | "missing_target_commit" | "invalid_timestamp";
+};
+
+export type ReplayTargetSnapshotValidation = {
+  ok: boolean;
+  violations: ReplayTargetSnapshotValidationViolation[];
+};
+
+export type ReplayTargetSnapshot = {
+  snapshotId: string;
+  repo: ReplayTargetRepoRef;
+  targetCommitSha: string;
+  targetCommittedAt: string;
+  exportPlan: ReplayTargetSnapshotExportPlan;
+  context: ReplayTargetSnapshotContext;
+  excluded: {
+    commits: ReplayTargetSnapshotCommit[];
+    tags: ReplayTargetSnapshotTag[];
+    releases: ReplayTargetSnapshotRelease[];
+    readme: ReplayTargetSnapshotReadme | null;
+    treeFiles: ReplayTargetSnapshotTreeFile[];
+    externalReferences: ReplayTargetSnapshotReference[];
+  };
+  validation: ReplayTargetSnapshotValidation;
+};
+
+const DEFAULT_EXPORT_ROOT = ".gittensory/replay-targets";
+const NULL_SHA = "0000000000000000000000000000000000000000";
+
+function normalizeRepo(repo: ReplayTargetRepoRef | string): ReplayTargetRepoRef {
+  const fullName = typeof repo === "string" ? repo : repo.fullName;
+  const normalizedFullName = fullName.trim().toLowerCase();
+  if (!/^[a-z0-9_.-]+\/[a-z0-9_.-]+$/u.test(normalizedFullName)) {
+    throw new Error("Replay target snapshot requires a repo full name in owner/name form.");
+  }
+  return typeof repo === "string"
+    ? { fullName: normalizedFullName }
+    : {
+        fullName: normalizedFullName,
+        ...(repo.remoteUrl?.trim() ? { remoteUrl: collapseInline(repo.remoteUrl) } : {}),
+        ...(repo.defaultBranch?.trim() ? { defaultBranch: collapseInline(repo.defaultBranch) } : {}),
+      };
+}
+
+function normalizeSha(value: string, field: string): string {
+  const normalized = value.trim().toLowerCase();
+  if (!/^[a-f0-9]{7,40}$/u.test(normalized)) {
+    throw new Error(`${field} must be a 7-40 character hex git SHA.`);
+  }
+  return normalized;
+}
+
+function normalizeOptionalSha(value: string | undefined): string | null {
+  if (!value) return null;
+  return normalizeSha(value, "targetSha");
+}
+
+function normalizePath(value: string): string {
+  const normalized = value.trim().replace(/\\/g, "/").replace(/\/+/g, "/").replace(/^\.\//u, "");
+  if (!normalized || normalized === "." || normalized.includes("\0") || normalized.startsWith("../")) {
+    throw new Error("Replay target snapshot paths must be relative, non-empty, and inside the export root.");
+  }
+  return normalized.toLowerCase();
+}
+
+function normalizeMode(value: string | undefined): string | null {
+  if (!value) return null;
+  const normalized = value.trim();
+  if (!normalized || normalized.length > 32 || /[\r\n\0]/u.test(normalized)) return null;
+  return normalized;
+}
+
+function normalizeSize(value: number | undefined): number | null {
+  if (value === undefined) return null;
+  if (!Number.isFinite(value) || value < 0) return null;
+  return Math.floor(value);
+}
+
+function collapseInline(value: string): string {
+  return value.replace(/[\r\n\t]+/gu, " ").replace(/\s{2,}/gu, " ").trim();
+}
+
+function parseInstant(value: string | Date | null | undefined): string | null {
+  if (value === null || value === undefined) return null;
+  const ms = value instanceof Date ? value.getTime() : Date.parse(value);
+  if (!Number.isFinite(ms)) return null;
+  return new Date(ms).toISOString();
+}
+
+function requireInstant(value: string | Date | undefined, field: string): string {
+  const parsed = parseInstant(value);
+  if (!parsed) throw new Error(`${field} must be a valid timestamp.`);
+  return parsed;
+}
+
+function compareIso(left: string | null, right: string | null): number {
+  if (left === right) return 0;
+  if (left === null) return 1;
+  if (right === null) return -1;
+  return left.localeCompare(right);
+}
+
+function isAtOrBefore(value: string | null, cutoff: string): boolean {
+  return value === null || value <= cutoff;
+}
+
+function stableHash(value: string): string {
+  let hash = 0x811c9dc5;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash.toString(16).padStart(8, "0");
+}
+
+function snapshotKey(repoFullName: string, targetCommitSha: string, targetCommittedAt: string, context: ReplayTargetSnapshotContext): string {
+  const payload = JSON.stringify({
+    repoFullName,
+    targetCommitSha,
+    targetCommittedAt,
+    commits: context.commits.map((commit) => [commit.sha, commit.committedAt]),
+    tags: context.tags.map((tag) => [tag.name, tag.targetSha, tag.taggedAt]),
+    releases: context.releases.map((release) => [release.name, release.tagName, release.publishedAt]),
+    readme: context.readme ? [context.readme.path, context.readme.blobSha, context.readme.observedAt] : null,
+    treeFiles: context.treeFiles.map((file) => [file.path, file.blobSha, file.mode, file.size]),
+    references: context.externalReferences.map((reference) => [reference.kind, reference.id, reference.observedAt]),
+  });
+  return `${repoFullName.replace("/", "__")}@${targetCommitSha}-${stableHash(payload)}`;
+}
+
+function normalizeCommit(input: ReplayTargetCommitInput): ReplayTargetSnapshotCommit {
+  return {
+    sha: normalizeSha(input.sha, "commit.sha"),
+    committedAt: requireInstant(input.committedAt, "commit.committedAt"),
+    subject: input.subject?.trim() ? collapseInline(input.subject) : null,
+    paths: uniqueSorted((input.paths ?? []).map(normalizePath)),
+    parents: uniqueSorted((input.parents ?? []).map((sha) => normalizeSha(sha, "commit.parents"))),
+  };
+}
+
+function normalizeTag(input: ReplayTargetTagInput): ReplayTargetSnapshotTag {
+  const name = collapseInline(input.name);
+  if (!name) throw new Error("tag.name must be non-empty.");
+  return {
+    name,
+    targetSha: normalizeOptionalSha(input.targetSha),
+    taggedAt: parseInstant(input.taggedAt),
+  };
+}
+
+function normalizeRelease(input: ReplayTargetReleaseInput): ReplayTargetSnapshotRelease {
+  const name = collapseInline(input.name);
+  const tagName = collapseInline(input.tagName);
+  if (!name || !tagName) throw new Error("release name and tagName must be non-empty.");
+  return {
+    name,
+    tagName,
+    publishedAt: parseInstant(input.publishedAt),
+  };
+}
+
+function normalizeReadme(input: ReplayTargetReadmeInput | null | undefined): ReplayTargetSnapshotReadme | null {
+  if (!input) return null;
+  return {
+    path: normalizePath(input.path),
+    blobSha: normalizeSha(input.blobSha, "readme.blobSha"),
+    text: input.text === undefined ? null : input.text.replace(/\r\n/gu, "\n"),
+    observedAt: parseInstant(input.observedAt),
+  };
+}
+
+function normalizeTreeFile(input: ReplayTargetTreeFileInput): ReplayTargetSnapshotTreeFile {
+  return {
+    path: normalizePath(input.path),
+    blobSha: normalizeOptionalSha(input.blobSha),
+    mode: normalizeMode(input.mode),
+    size: normalizeSize(input.size),
+    observedAt: parseInstant(input.observedAt),
+  };
+}
+
+function normalizeReference(input: ReplayTargetExternalReferenceInput): ReplayTargetSnapshotReference {
+  const kind = collapseInline(input.kind).toLowerCase().replace(/[\s-]+/gu, "_");
+  const id = collapseInline(String(input.id));
+  if (!kind || !id) throw new Error("external reference kind and id must be non-empty.");
+  return {
+    kind,
+    id,
+    observedAt: parseInstant(input.observedAt),
+  };
+}
+
+function uniqueSorted(values: Iterable<string>): string[] {
+  return [...new Set(values)].sort((a, b) => a.localeCompare(b));
+}
+
+function sortCommits(commits: readonly ReplayTargetSnapshotCommit[]): ReplayTargetSnapshotCommit[] {
+  return [...commits].sort((left, right) => left.committedAt.localeCompare(right.committedAt) || left.sha.localeCompare(right.sha));
+}
+
+function sortTags(tags: readonly ReplayTargetSnapshotTag[]): ReplayTargetSnapshotTag[] {
+  return [...tags].sort((left, right) => compareIso(left.taggedAt, right.taggedAt) || left.name.localeCompare(right.name));
+}
+
+function sortReleases(releases: readonly ReplayTargetSnapshotRelease[]): ReplayTargetSnapshotRelease[] {
+  return [...releases].sort((left, right) => compareIso(left.publishedAt, right.publishedAt) || left.name.localeCompare(right.name));
+}
+
+function sortTreeFiles(files: readonly ReplayTargetSnapshotTreeFile[]): ReplayTargetSnapshotTreeFile[] {
+  return [...files].sort((left, right) => left.path.localeCompare(right.path));
+}
+
+function sortReferences(references: readonly ReplayTargetSnapshotReference[]): ReplayTargetSnapshotReference[] {
+  return [...references].sort(
+    (left, right) => compareIso(left.observedAt, right.observedAt) || left.kind.localeCompare(right.kind) || left.id.localeCompare(right.id),
+  );
+}
+
+function buildHistoryExtraction(commits: readonly ReplayTargetSnapshotCommit[]): ObjectiveAnchorHistoryExtraction {
+  // Reuse objective-anchor's history extractor instead of inventing a second commit-feature path for replay context.
+  return extractObjectiveAnchorHistory(
+    commits.map((commit) => ({
+      id: `commit:${commit.sha}`,
+      source: "commit",
+      paths: commit.paths,
+      titles: commit.subject ? [commit.subject] : [],
+    })),
+  );
+}
+
+function markdownSafe(value: string): string {
+  return collapseInline(value).replace(/[\\`*_[\]<>|]/gu, "\\$&");
+}
+
+function markdownList(values: readonly string[]): string {
+  if (values.length === 0) return "- none";
+  return values.map((value) => `- ${markdownSafe(value)}`).join("\n");
+}
+
+function commitLine(commit: ReplayTargetSnapshotCommit): string {
+  const subject = commit.subject ? ` ${markdownSafe(commit.subject)}` : "";
+  return `${commit.sha.slice(0, 12)} ${commit.committedAt}${subject}`;
+}
+
+function tagLine(tag: ReplayTargetSnapshotTag): string {
+  const target = tag.targetSha ? ` -> ${tag.targetSha.slice(0, 12)}` : "";
+  const time = tag.taggedAt ? ` at ${tag.taggedAt}` : "";
+  return `${tag.name}${target}${time}`;
+}
+
+function releaseLine(release: ReplayTargetSnapshotRelease): string {
+  const time = release.publishedAt ? ` at ${release.publishedAt}` : "";
+  return `${release.name} (${release.tagName})${time}`;
+}
+
+function treeFileLine(file: ReplayTargetSnapshotTreeFile): string {
+  const size = file.size === null ? "size n/a" : `${file.size} bytes`;
+  const blob = file.blobSha ? ` ${file.blobSha.slice(0, 12)}` : "";
+  return `${file.path} (${size}${blob})`;
+}
+
+function referenceLine(reference: ReplayTargetSnapshotReference): string {
+  const time = reference.observedAt ? ` at ${reference.observedAt}` : "";
+  return `${reference.kind}:${reference.id}${time}`;
+}
+
+function createExportPlan(input: {
+  exportRoot: string;
+  snapshotId: string;
+  targetCommitSha: string;
+}): ReplayTargetSnapshotExportPlan {
+  const exportRoot = normalizePath(input.exportRoot);
+  const worktreePath = `${exportRoot}/${input.snapshotId}/tree`;
+  const contextPath = `${exportRoot}/${input.snapshotId}/context.json`;
+  return {
+    strategy: "git-worktree",
+    sourceCommit: input.targetCommitSha,
+    destinationKey: input.snapshotId,
+    exportRoot,
+    worktreePath,
+    contextPath,
+  };
+}
+
+function timestampViolations(input: {
+  targetCommittedAt: string;
+  commits: readonly ReplayTargetSnapshotCommit[];
+  tags: readonly ReplayTargetSnapshotTag[];
+  releases: readonly ReplayTargetSnapshotRelease[];
+  readme: ReplayTargetSnapshotReadme | null;
+  treeFiles: readonly ReplayTargetSnapshotTreeFile[];
+  externalReferences: readonly ReplayTargetSnapshotReference[];
+}): ReplayTargetSnapshotValidationViolation[] {
+  const violations: ReplayTargetSnapshotValidationViolation[] = [];
+  const pushIfPostTarget = (artifact: string, timestamp: string | null): void => {
+    if (timestamp && timestamp > input.targetCommittedAt) {
+      violations.push({
+        artifact,
+        timestamp,
+        targetCommittedAt: input.targetCommittedAt,
+        reason: "post_target_timestamp",
+      });
+    }
+  };
+  input.commits.forEach((commit) => pushIfPostTarget(`commit:${commit.sha}`, commit.committedAt));
+  input.tags.forEach((tag) => pushIfPostTarget(`tag:${tag.name}`, tag.taggedAt));
+  input.releases.forEach((release) => pushIfPostTarget(`release:${release.name}`, release.publishedAt));
+  pushIfPostTarget(input.readme ? `readme:${input.readme.path}` : "readme", input.readme?.observedAt ?? null);
+  input.treeFiles.forEach((file) => pushIfPostTarget(`tree:${file.path}`, file.observedAt));
+  input.externalReferences.forEach((reference) => pushIfPostTarget(`${reference.kind}:${reference.id}`, reference.observedAt));
+  return violations;
+}
+
+export function validateReplayTargetSnapshot(snapshot: ReplayTargetSnapshot): ReplayTargetSnapshotValidation {
+  const violations = timestampViolations({
+    targetCommittedAt: snapshot.targetCommittedAt,
+    commits: snapshot.context.commits,
+    tags: snapshot.context.tags,
+    releases: snapshot.context.releases,
+    readme: snapshot.context.readme,
+    treeFiles: snapshot.context.treeFiles,
+    externalReferences: snapshot.context.externalReferences,
+  });
+  if (!snapshot.context.commits.some((commit) => commit.sha === snapshot.targetCommitSha)) {
+    violations.push({
+      artifact: `commit:${snapshot.targetCommitSha}`,
+      timestamp: snapshot.targetCommittedAt,
+      targetCommittedAt: snapshot.targetCommittedAt,
+      reason: "missing_target_commit",
+    });
+  }
+  return { ok: violations.length === 0, violations };
+}
+
+export function assertReplayTargetSnapshotValid(snapshot: ReplayTargetSnapshot): ReplayTargetSnapshot {
+  const validation = validateReplayTargetSnapshot(snapshot);
+  if (!validation.ok) {
+    throw new Error(`Replay target snapshot contains post-target or incomplete artifacts: ${validation.violations[0]!.artifact}`);
+  }
+  return { ...snapshot, validation };
+}
+
+export function renderReplayTargetSnapshotManifestMarkdown(snapshot: ReplayTargetSnapshot): string {
+  const validation = validateReplayTargetSnapshot(snapshot);
+  const lines = [
+    "# Replay Target Snapshot",
+    "",
+    `Snapshot: ${markdownSafe(snapshot.snapshotId)}`,
+    `Repo: ${markdownSafe(snapshot.repo.fullName)}`,
+    `Target commit: ${markdownSafe(snapshot.targetCommitSha)}`,
+    `Target time: ${markdownSafe(snapshot.targetCommittedAt)}`,
+    "",
+    "## Export Plan",
+    "",
+    `- strategy: ${snapshot.exportPlan.strategy}`,
+    `- worktree: ${markdownSafe(snapshot.exportPlan.worktreePath)}`,
+    `- context: ${markdownSafe(snapshot.exportPlan.contextPath)}`,
+    "",
+    "## Included Context",
+    "",
+    "Commits:",
+    markdownList(snapshot.context.commits.map(commitLine)),
+    "",
+    "Tags:",
+    markdownList(snapshot.context.tags.map(tagLine)),
+    "",
+    "Releases:",
+    markdownList(snapshot.context.releases.map(releaseLine)),
+    "",
+    "README:",
+    snapshot.context.readme
+      ? `- ${markdownSafe(snapshot.context.readme.path)} ${snapshot.context.readme.blobSha.slice(0, 12)}`
+      : "- none",
+    "",
+    "Tree files:",
+    markdownList(snapshot.context.treeFiles.map(treeFileLine)),
+    "",
+    "External references:",
+    markdownList(snapshot.context.externalReferences.map(referenceLine)),
+    "",
+    "## Excluded Post-Target Context",
+    "",
+    "Commits:",
+    markdownList(snapshot.excluded.commits.map(commitLine)),
+    "",
+    "Tags:",
+    markdownList(snapshot.excluded.tags.map(tagLine)),
+    "",
+    "Releases:",
+    markdownList(snapshot.excluded.releases.map(releaseLine)),
+    "",
+    "README:",
+    snapshot.excluded.readme
+      ? `- ${markdownSafe(snapshot.excluded.readme.path)} ${snapshot.excluded.readme.blobSha.slice(0, 12)}`
+      : "- none",
+    "",
+    "Tree files:",
+    markdownList(snapshot.excluded.treeFiles.map(treeFileLine)),
+    "",
+    "External references:",
+    markdownList(snapshot.excluded.externalReferences.map(referenceLine)),
+    "",
+    "## Validation",
+    "",
+    validation.ok
+      ? "- ok"
+      : validation.violations
+          .map((violation) => `- ${markdownSafe(violation.artifact)}: ${markdownSafe(violation.reason)}`)
+          .join("\n"),
+  ];
+  return `${lines.join("\n")}\n`;
+}
+
+export function createReplayTargetSnapshot(input: ReplayTargetSnapshotInput): ReplayTargetSnapshot {
+  const repo = normalizeRepo(input.repo);
+  const requestedTargetCommitSha = normalizeSha(input.targetCommitSha, "targetCommitSha");
+  const commits = sortCommits(input.commits.map(normalizeCommit));
+  const targetCommit = commits.find(
+    (commit) => commit.sha === requestedTargetCommitSha || commit.sha.startsWith(requestedTargetCommitSha),
+  );
+  const targetCommitSha = targetCommit?.sha ?? requestedTargetCommitSha;
+  const targetCommittedAt = input.targetCommittedAt
+    ? requireInstant(input.targetCommittedAt, "targetCommittedAt")
+    : targetCommit?.committedAt;
+  if (!targetCommittedAt) {
+    throw new Error("targetCommittedAt is required when the target commit is absent from the commit history.");
+  }
+
+  const includedCommits = sortCommits(commits.filter((commit) => commit.committedAt <= targetCommittedAt));
+  const excludedCommits = sortCommits(commits.filter((commit) => commit.committedAt > targetCommittedAt));
+  const includedCommitShas = new Set(includedCommits.map((commit) => commit.sha));
+
+  const tags = (input.tags ?? []).map(normalizeTag);
+  const includedTags = sortTags(
+    tags.filter((tag) => (tag.taggedAt ? tag.taggedAt <= targetCommittedAt : tag.targetSha ? includedCommitShas.has(tag.targetSha) : false)),
+  );
+  const excludedTags = sortTags(tags.filter((tag) => !includedTags.includes(tag)));
+  const includedTagNames = new Set(includedTags.map((tag) => tag.name));
+
+  const releases = (input.releases ?? []).map(normalizeRelease);
+  const includedReleases = sortReleases(
+    releases.filter((release) =>
+      release.publishedAt ? release.publishedAt <= targetCommittedAt : includedTagNames.has(release.tagName),
+    ),
+  );
+  const excludedReleases = sortReleases(releases.filter((release) => !includedReleases.includes(release)));
+
+  const readme = normalizeReadme(input.readme);
+  const includedReadme = readme && isAtOrBefore(readme.observedAt, targetCommittedAt) ? readme : null;
+  const excludedReadme = readme && !includedReadme ? readme : null;
+
+  const treeFiles = sortTreeFiles((input.treeFiles ?? []).map(normalizeTreeFile));
+  const includedTreeFiles = sortTreeFiles(treeFiles.filter((file) => isAtOrBefore(file.observedAt, targetCommittedAt)));
+  const excludedTreeFiles = sortTreeFiles(treeFiles.filter((file) => !includedTreeFiles.includes(file)));
+
+  const externalReferences = sortReferences((input.externalReferences ?? []).map(normalizeReference));
+  const includedReferences = sortReferences(externalReferences.filter((reference) => isAtOrBefore(reference.observedAt, targetCommittedAt)));
+  const excludedReferences = sortReferences(externalReferences.filter((reference) => !includedReferences.includes(reference)));
+
+  const context: ReplayTargetSnapshotContext = {
+    commits: includedCommits,
+    tags: includedTags,
+    releases: includedReleases,
+    readme: includedReadme,
+    treeFiles: includedTreeFiles,
+    externalReferences: includedReferences,
+    history: buildHistoryExtraction(includedCommits),
+  };
+  const snapshotId = snapshotKey(repo.fullName, targetCommitSha, targetCommittedAt, context);
+  const exportPlan = createExportPlan({
+    exportRoot: input.exportRoot ?? DEFAULT_EXPORT_ROOT,
+    snapshotId,
+    targetCommitSha,
+  });
+  const snapshot: ReplayTargetSnapshot = {
+    snapshotId,
+    repo,
+    targetCommitSha,
+    targetCommittedAt,
+    exportPlan,
+    context,
+    excluded: {
+      commits: excludedCommits,
+      tags: excludedTags,
+      releases: excludedReleases,
+      readme: excludedReadme,
+      treeFiles: excludedTreeFiles,
+      externalReferences: excludedReferences,
+    },
+    validation: { ok: true, violations: [] },
+  };
+  return assertReplayTargetSnapshotValid(snapshot);
+}

--- a/packages/gittensory-engine/test/replay-target-snapshot.test.ts
+++ b/packages/gittensory-engine/test/replay-target-snapshot.test.ts
@@ -1,0 +1,476 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  assertReplayTargetSnapshotValid,
+  createReplayTargetSnapshot,
+  renderReplayTargetSnapshotManifestMarkdown,
+  validateReplayTargetSnapshot,
+} from "../dist/index.js";
+
+const FIRST = "1111111111111111111111111111111111111111";
+const SECOND = "2222222222222222222222222222222222222222";
+const THIRD = "3333333333333333333333333333333333333333";
+const README = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const PACKAGE = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+function baseInput() {
+  return {
+    repo: {
+      fullName: "JSONbored/Gittensory",
+      remoteUrl: "https://github.com/JSONbored/gittensory.git",
+      defaultBranch: "main",
+    },
+    targetCommitSha: SECOND,
+    exportRoot: ".gittensory/replay-targets",
+    commits: [
+      {
+        sha: FIRST,
+        committedAt: "2026-06-01T00:00:00Z",
+        subject: "docs: initial readme",
+        paths: ["README.md"],
+      },
+      {
+        sha: SECOND,
+        committedAt: "2026-06-02T00:00:00Z",
+        subject: "feat: add miner replay harness",
+        paths: ["packages/gittensory-engine/src/objective-anchor.ts", "README.md"],
+        parents: [FIRST],
+      },
+      {
+        sha: THIRD,
+        committedAt: "2026-06-03T00:00:00Z",
+        subject: "fix: later change",
+        paths: ["src/later.ts"],
+        parents: [SECOND],
+      },
+    ],
+    tags: [
+      { name: "v0.1.0", targetSha: FIRST, taggedAt: "2026-06-01T12:00:00Z" },
+      { name: "v0.2.0", targetSha: SECOND, taggedAt: "2026-06-02T12:00:00Z" },
+      { name: "v0.3.0", targetSha: THIRD, taggedAt: "2026-06-03T12:00:00Z" },
+    ],
+    releases: [
+      { name: "first", tagName: "v0.1.0", publishedAt: "2026-06-01T12:30:00Z" },
+      { name: "second", tagName: "v0.2.0", publishedAt: "2026-06-02T12:30:00Z" },
+      { name: "third", tagName: "v0.3.0", publishedAt: "2026-06-03T12:30:00Z" },
+    ],
+    readme: {
+      path: "README.md",
+      blobSha: README,
+      text: "# Gittensory\r\n\nReplay harness at T.\n",
+      observedAt: "2026-06-02T00:00:00Z",
+    },
+    treeFiles: [
+      { path: "README.md", blobSha: README, mode: "100644", size: 27, observedAt: "2026-06-02T00:00:00Z" },
+      {
+        path: "packages/gittensory-engine/package.json",
+        blobSha: PACKAGE,
+        mode: "100644",
+        size: 512.9,
+        observedAt: "2026-06-02T00:00:00Z",
+      },
+      {
+        path: "src/later.ts",
+        blobSha: "cccccccccccccccccccccccccccccccccccccccc",
+        mode: "100644",
+        size: 42,
+        observedAt: "2026-06-03T00:00:00Z",
+      },
+    ],
+    externalReferences: [
+      { kind: "issue", id: 3010, observedAt: "2026-06-02T00:00:00Z" },
+      { kind: "pull-request", id: 9999, observedAt: "2026-06-03T00:00:00Z" },
+    ],
+  } as const;
+}
+
+test("barrel: exports replay-target snapshot APIs (#3010)", () => {
+  assert.equal(typeof createReplayTargetSnapshot, "function");
+  assert.equal(typeof validateReplayTargetSnapshot, "function");
+  assert.equal(typeof assertReplayTargetSnapshotValid, "function");
+  assert.equal(typeof renderReplayTargetSnapshotManifestMarkdown, "function");
+});
+
+test("createReplayTargetSnapshot exports a commit-keyed worktree plan and knowable-at-T context", () => {
+  const snapshot = createReplayTargetSnapshot(baseInput());
+
+  assert.equal(snapshot.repo.fullName, "jsonbored/gittensory");
+  assert.equal(snapshot.repo.remoteUrl, "https://github.com/JSONbored/gittensory.git");
+  assert.equal(snapshot.targetCommitSha, SECOND);
+  assert.equal(snapshot.targetCommittedAt, "2026-06-02T00:00:00.000Z");
+  assert.match(snapshot.snapshotId, /^jsonbored__gittensory@2222222222222222222222222222222222222222-[a-f0-9]{8}$/u);
+  assert.equal(snapshot.exportPlan.strategy, "git-worktree");
+  assert.equal(snapshot.exportPlan.sourceCommit, SECOND);
+  assert.equal(snapshot.exportPlan.destinationKey, snapshot.snapshotId);
+  assert.equal(snapshot.exportPlan.worktreePath, `.gittensory/replay-targets/${snapshot.snapshotId}/tree`);
+  assert.equal(snapshot.exportPlan.contextPath, `.gittensory/replay-targets/${snapshot.snapshotId}/context.json`);
+  assert.deepEqual(snapshot.context.commits.map((commit) => commit.sha), [FIRST, SECOND]);
+  assert.deepEqual(snapshot.excluded.commits.map((commit) => commit.sha), [THIRD]);
+});
+
+test("createReplayTargetSnapshot includes tags and releases only at or before T", () => {
+  const snapshot = createReplayTargetSnapshot(baseInput());
+
+  assert.deepEqual(snapshot.context.tags.map((tag) => tag.name), ["v0.1.0"]);
+  assert.deepEqual(snapshot.excluded.tags.map((tag) => tag.name), ["v0.2.0", "v0.3.0"]);
+  assert.deepEqual(snapshot.context.releases.map((release) => release.name), ["first"]);
+  assert.deepEqual(snapshot.excluded.releases.map((release) => release.name), ["second", "third"]);
+});
+
+test("createReplayTargetSnapshot accepts undated tags when their target commit is included", () => {
+  const input = {
+    ...baseInput(),
+    tags: [
+      { name: "undated-first", targetSha: FIRST },
+      { name: "undated-third", targetSha: THIRD },
+      { name: "floating" },
+    ],
+    releases: [
+      { name: "from-included-tag", tagName: "undated-first" },
+      { name: "from-excluded-tag", tagName: "undated-third" },
+      { name: "floating-release", tagName: "floating" },
+    ],
+  };
+  const snapshot = createReplayTargetSnapshot(input);
+
+  assert.deepEqual(snapshot.context.tags.map((tag) => tag.name), ["undated-first"]);
+  assert.deepEqual(snapshot.excluded.tags.map((tag) => tag.name), ["floating", "undated-third"]);
+  assert.deepEqual(snapshot.context.releases.map((release) => release.name), ["from-included-tag"]);
+  assert.deepEqual(snapshot.excluded.releases.map((release) => release.name), [
+    "floating-release",
+    "from-excluded-tag",
+  ]);
+});
+
+test("createReplayTargetSnapshot supports a repo with no tags or releases", () => {
+  const snapshot = createReplayTargetSnapshot({
+    ...baseInput(),
+    tags: [],
+    releases: [],
+  });
+
+  assert.deepEqual(snapshot.context.tags, []);
+  assert.deepEqual(snapshot.context.releases, []);
+  assert.deepEqual(snapshot.excluded.tags, []);
+  assert.deepEqual(snapshot.excluded.releases, []);
+  assert.equal(snapshot.validation.ok, true);
+});
+
+test("createReplayTargetSnapshot handles the first commit of history", () => {
+  const snapshot = createReplayTargetSnapshot({
+    ...baseInput(),
+    targetCommitSha: FIRST,
+  });
+
+  assert.deepEqual(snapshot.context.commits.map((commit) => commit.sha), [FIRST]);
+  assert.deepEqual(snapshot.excluded.commits.map((commit) => commit.sha), [SECOND, THIRD]);
+  assert.equal(snapshot.context.history.items.length, 1);
+  assert.equal(snapshot.context.history.items[0]!.id, `commit:${FIRST}`);
+  assert.deepEqual(snapshot.context.history.features.paths, ["readme.md"]);
+  assert.deepEqual(snapshot.context.history.features.changeKinds, ["docs"]);
+});
+
+test("createReplayTargetSnapshot normalizes README text and filters a future README", () => {
+  const included = createReplayTargetSnapshot(baseInput());
+  const excluded = createReplayTargetSnapshot({
+    ...baseInput(),
+    readme: {
+      path: "./README.md",
+      blobSha: README,
+      text: "# Later\r\n",
+      observedAt: "2026-06-03T00:00:00Z",
+    },
+  });
+
+  assert.equal(included.context.readme?.text, "# Gittensory\n\nReplay harness at T.\n");
+  assert.equal(included.context.readme?.path, "readme.md");
+  assert.equal(excluded.context.readme, null);
+  assert.equal(excluded.excluded.readme?.path, "readme.md");
+});
+
+test("createReplayTargetSnapshot filters tree files and references with post-T timestamps", () => {
+  const snapshot = createReplayTargetSnapshot(baseInput());
+
+  assert.deepEqual(snapshot.context.treeFiles.map((file) => [file.path, file.size]), [
+    ["packages/gittensory-engine/package.json", 512],
+    ["readme.md", 27],
+  ]);
+  assert.deepEqual(snapshot.excluded.treeFiles.map((file) => file.path), ["src/later.ts"]);
+  assert.deepEqual(snapshot.context.externalReferences, [
+    { kind: "issue", id: "3010", observedAt: "2026-06-02T00:00:00.000Z" },
+  ]);
+  assert.deepEqual(snapshot.excluded.externalReferences, [
+    { kind: "pull_request", id: "9999", observedAt: "2026-06-03T00:00:00.000Z" },
+  ]);
+});
+
+test("createReplayTargetSnapshot derives objective-anchor history from included commits", () => {
+  const snapshot = createReplayTargetSnapshot(baseInput());
+
+  assert.deepEqual(
+    snapshot.context.history.items.map((item) => [item.id, item.source]),
+    [
+      [`commit:${FIRST}`, "commit"],
+      [`commit:${SECOND}`, "commit"],
+    ],
+  );
+  assert.deepEqual(snapshot.context.history.features.modules, [
+    "packages/gittensory-engine",
+    "readme.md",
+  ]);
+  assert.deepEqual(snapshot.context.history.features.changeKinds, ["feature", "docs"]);
+});
+
+test("createReplayTargetSnapshot is byte-stable for the same input", () => {
+  const left = createReplayTargetSnapshot(baseInput());
+  const right = createReplayTargetSnapshot(baseInput());
+
+  assert.equal(left.snapshotId, right.snapshotId);
+  assert.equal(JSON.stringify(left), JSON.stringify(right));
+});
+
+test("createReplayTargetSnapshot changes the snapshot id when context changes", () => {
+  const left = createReplayTargetSnapshot(baseInput());
+  const right = createReplayTargetSnapshot({
+    ...baseInput(),
+    treeFiles: [
+      ...(baseInput().treeFiles ?? []),
+      {
+        path: "packages/gittensory-engine/src/replay-target-snapshot.ts",
+        blobSha: "dddddddddddddddddddddddddddddddddddddddd",
+        observedAt: "2026-06-02T00:00:00Z",
+      },
+    ],
+  });
+
+  assert.notEqual(left.snapshotId, right.snapshotId);
+});
+
+test("validateReplayTargetSnapshot detects a post-target commit inserted after creation", () => {
+  const snapshot = createReplayTargetSnapshot(baseInput());
+  const invalid = {
+    ...snapshot,
+    context: {
+      ...snapshot.context,
+      commits: [
+        ...snapshot.context.commits,
+        {
+          sha: THIRD,
+          committedAt: "2026-06-03T00:00:00.000Z",
+          subject: "fix: post target",
+          paths: ["src/later.ts"],
+          parents: [SECOND],
+        },
+      ],
+    },
+  };
+  const validation = validateReplayTargetSnapshot(invalid);
+
+  assert.equal(validation.ok, false);
+  assert.deepEqual(validation.violations, [
+    {
+      artifact: `commit:${THIRD}`,
+      timestamp: "2026-06-03T00:00:00.000Z",
+      targetCommittedAt: "2026-06-02T00:00:00.000Z",
+      reason: "post_target_timestamp",
+    },
+  ]);
+  assert.throws(() => assertReplayTargetSnapshotValid(invalid), /post-target or incomplete artifacts/u);
+});
+
+test("validateReplayTargetSnapshot detects missing target commit", () => {
+  const snapshot = createReplayTargetSnapshot(baseInput());
+  const invalid = {
+    ...snapshot,
+    context: {
+      ...snapshot.context,
+      commits: snapshot.context.commits.filter((commit) => commit.sha !== SECOND),
+    },
+  };
+  const validation = validateReplayTargetSnapshot(invalid);
+
+  assert.equal(validation.ok, false);
+  assert.deepEqual(validation.violations, [
+    {
+      artifact: `commit:${SECOND}`,
+      timestamp: "2026-06-02T00:00:00.000Z",
+      targetCommittedAt: "2026-06-02T00:00:00.000Z",
+      reason: "missing_target_commit",
+    },
+  ]);
+});
+
+test("validateReplayTargetSnapshot checks every timestamp-bearing artifact", () => {
+  const snapshot = createReplayTargetSnapshot(baseInput());
+  const invalid = {
+    ...snapshot,
+    context: {
+      ...snapshot.context,
+      tags: [{ name: "bad-tag", targetSha: SECOND, taggedAt: "2026-06-03T00:00:00.000Z" }],
+      releases: [{ name: "bad-release", tagName: "bad-tag", publishedAt: "2026-06-03T01:00:00.000Z" }],
+      readme: { path: "readme.md", blobSha: README, text: null, observedAt: "2026-06-03T02:00:00.000Z" },
+      treeFiles: [{ path: "readme.md", blobSha: README, mode: null, size: null, observedAt: "2026-06-03T03:00:00.000Z" }],
+      externalReferences: [{ kind: "issue", id: "99", observedAt: "2026-06-03T04:00:00.000Z" }],
+    },
+  };
+  const validation = validateReplayTargetSnapshot(invalid);
+
+  assert.equal(validation.ok, false);
+  assert.deepEqual(
+    validation.violations.map((violation) => violation.artifact),
+    ["tag:bad-tag", "release:bad-release", "readme:readme.md", "tree:readme.md", "issue:99"],
+  );
+});
+
+test("renderReplayTargetSnapshotManifestMarkdown renders included and excluded context", () => {
+  const snapshot = createReplayTargetSnapshot(baseInput());
+  const markdown = renderReplayTargetSnapshotManifestMarkdown(snapshot);
+
+  assert.ok(markdown.startsWith("# Replay Target Snapshot\n\nSnapshot: jsonbored\\_\\_gittensory@"));
+  assert.match(markdown, /Repo: jsonbored\/gittensory/u);
+  assert.match(markdown, /Target commit: 2222222222222222222222222222222222222222/u);
+  assert.match(markdown, /## Export Plan\n\n- strategy: git-worktree/u);
+  assert.match(markdown, /Commits:\n- 111111111111 2026-06-01T00:00:00\.000Z docs: initial readme/u);
+  assert.match(markdown, /- 222222222222 2026-06-02T00:00:00\.000Z feat: add miner replay harness/u);
+  assert.match(markdown, /Tags:\n- v0\.1\.0 -\\> 111111111111/u);
+  assert.match(markdown, /Releases:\n- first \(v0\.1\.0\)/u);
+  assert.match(markdown, /README:\n- readme\.md aaaaaaaaaaaa/u);
+  assert.match(markdown, /Tree files:\n- packages\/gittensory-engine\/package\.json \(512 bytes bbbbbbbbbbbb\)/u);
+  assert.match(markdown, /External references:\n- issue:3010 at 2026-06-02T00:00:00\.000Z/u);
+  assert.match(markdown, /## Excluded Post-Target Context/u);
+  assert.match(markdown, /- 333333333333 2026-06-03T00:00:00\.000Z fix: later change/u);
+  assert.match(markdown, /- pull\\_request:9999 at 2026-06-03T00:00:00\.000Z/u);
+  assert.match(markdown, /## Validation\n\n- ok/u);
+});
+
+test("renderReplayTargetSnapshotManifestMarkdown reports empty optional sections as none", () => {
+  const snapshot = createReplayTargetSnapshot({
+    ...baseInput(),
+    tags: [],
+    releases: [],
+    readme: null,
+    treeFiles: [],
+    externalReferences: [],
+  });
+  const markdown = renderReplayTargetSnapshotManifestMarkdown(snapshot);
+
+  assert.match(markdown, /Tags:\n- none/u);
+  assert.match(markdown, /Releases:\n- none/u);
+  assert.match(markdown, /README:\n- none/u);
+  assert.match(markdown, /Tree files:\n- none/u);
+  assert.match(markdown, /External references:\n- none/u);
+});
+
+test("renderReplayTargetSnapshotManifestMarkdown escapes caller-supplied markdown controls", () => {
+  const snapshot = createReplayTargetSnapshot({
+    ...baseInput(),
+    exportRoot: "./snapshots/[audit]",
+    commits: [
+      {
+        sha: FIRST,
+        committedAt: "2026-06-01T00:00:00Z",
+        subject: "docs: `readme` *initial*\nnext",
+        paths: ["README.md"],
+      },
+    ],
+    targetCommitSha: FIRST,
+    tags: [{ name: "v_[one]", targetSha: FIRST }],
+    releases: [{ name: "release|one", tagName: "v_[one]" }],
+    externalReferences: [{ kind: "manual-note", id: "id_*one*", observedAt: "2026-06-01T00:00:00Z" }],
+  });
+  const markdown = renderReplayTargetSnapshotManifestMarkdown(snapshot);
+
+  assert.ok(markdown.includes("worktree: snapshots/\\[audit\\]/"));
+  assert.ok(markdown.includes("docs: \\\\\\`readme\\\\\\` \\\\\\*initial\\\\\\* next"));
+  assert.ok(markdown.includes("v\\_\\[one\\]"));
+  assert.ok(markdown.includes("release\\|one"));
+  assert.ok(markdown.includes("manual\\_note:id\\_\\*one\\*"));
+});
+
+test("renderReplayTargetSnapshotManifestMarkdown includes validation violations", () => {
+  const snapshot = createReplayTargetSnapshot(baseInput());
+  const invalid = {
+    ...snapshot,
+    context: {
+      ...snapshot.context,
+      tags: [{ name: "bad", targetSha: SECOND, taggedAt: "2026-06-03T00:00:00.000Z" }],
+    },
+  };
+  const markdown = renderReplayTargetSnapshotManifestMarkdown(invalid);
+
+  assert.match(markdown, /## Validation\n\n- tag:bad: post\\_target\\_timestamp/u);
+  assert.doesNotMatch(markdown, /- ok/u);
+});
+
+test("createReplayTargetSnapshot rejects invalid repo names, SHAs, timestamps, and paths", () => {
+  assert.throws(() => createReplayTargetSnapshot({ ...baseInput(), repo: "not-a-repo" }), /owner\/name/u);
+  assert.throws(() => createReplayTargetSnapshot({ ...baseInput(), targetCommitSha: "notsha" }), /targetCommitSha/u);
+  assert.throws(
+    () => createReplayTargetSnapshot({ ...baseInput(), targetCommittedAt: "not a date" }),
+    /targetCommittedAt/u,
+  );
+  assert.throws(
+    () =>
+      createReplayTargetSnapshot({
+        ...baseInput(),
+        treeFiles: [{ path: "../outside", blobSha: README }],
+      }),
+    /paths must be relative/u,
+  );
+});
+
+test("createReplayTargetSnapshot requires targetCommittedAt when target commit is absent", () => {
+  assert.throws(
+    () =>
+      createReplayTargetSnapshot({
+        ...baseInput(),
+        targetCommitSha: "4444444444444444444444444444444444444444",
+      }),
+    /targetCommittedAt is required/u,
+  );
+});
+
+test("createReplayTargetSnapshot fails fast when a timestamped absent target is not in context", () => {
+  assert.throws(
+    () =>
+      createReplayTargetSnapshot({
+        ...baseInput(),
+        targetCommitSha: "4444444444444444444444444444444444444444",
+        targetCommittedAt: "2026-06-02T00:00:00Z",
+      }),
+    /post-target or incomplete artifacts/u,
+  );
+});
+
+test("createReplayTargetSnapshot normalizes compact SHAs and custom export roots", () => {
+  const snapshot = createReplayTargetSnapshot({
+    ...baseInput(),
+    targetCommitSha: "2222222",
+    targetCommittedAt: "2026-06-02T00:00:00Z",
+    exportRoot: "./snapshots/custom",
+  });
+
+  assert.equal(snapshot.targetCommitSha, SECOND);
+  assert.equal(snapshot.exportPlan.exportRoot, "snapshots/custom");
+  assert.equal(snapshot.exportPlan.worktreePath, `snapshots/custom/${snapshot.snapshotId}/tree`);
+});
+
+test("createReplayTargetSnapshot sorts input records deterministically", () => {
+  const input = baseInput();
+  const snapshot = createReplayTargetSnapshot({
+    ...input,
+    commits: [...input.commits].reverse(),
+    tags: [...(input.tags ?? [])].reverse(),
+    releases: [...(input.releases ?? [])].reverse(),
+    treeFiles: [...(input.treeFiles ?? [])].reverse(),
+    externalReferences: [...(input.externalReferences ?? [])].reverse(),
+  });
+
+  assert.deepEqual(snapshot.context.commits.map((commit) => commit.sha), [FIRST, SECOND]);
+  assert.deepEqual(snapshot.context.treeFiles.map((file) => file.path), [
+    "packages/gittensory-engine/package.json",
+    "readme.md",
+  ]);
+  assert.deepEqual(snapshot.excluded.treeFiles.map((file) => file.path), ["src/later.ts"]);
+});


### PR DESCRIPTION
## Summary

- Adds a deterministic replay-target snapshot engine contract for freezing a repo at commit T from caller-provided git history inputs.
- Filters commits, tags, releases, README, tree-file metadata, and external references to knowable-at-T context, emits a git-worktree export plan, and validates that no post-target timestamps enter the snapshot.
- Adds a stable Markdown manifest renderer and package tests for tagged repos, no-tag repos, first-commit snapshots, post-target validation, short-SHA resolution, sorting, and sanitizer boundaries.
- Fixes #3010

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires >=99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [x] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This is isolated to `packages/gittensory-engine`; I ran `npm test --workspace @jsonbored/gittensory-engine` on the rebased branch, which builds the package and runs the package test suite (175 passing tests). Backend coverage and UI checks are not part of this package-only path.
- Also ran `npm run build:miner` and `npm run db:migrations:check`.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Required for visible UI, frontend, docs, or extension changes. Attach GitHub-hosted JPG/JPEG or PNG screenshots here; SVG screenshots are not accepted as review evidence. Use a compact table/grid of clickable thumbnails with a short state/title such as "Loaded state", "Empty state", "Error state", "Mobile layout", or "PR sidebar". Prefer annotated screenshots with a colored box, outline, arrow, or highlighter showing what changed. Recordings can be supplemental, but screenshots are still expected for visual review. Do not commit review-only screenshots, recordings, or `docs/review-evidence/**` files.

| State / title | JPG/PNG evidence |
| --- | --- |
| Not applicable | No visible UI change; package engine only. |

## Notes

- Diff size: 1,178 insertions across the engine source, package tests, README, and package barrel export.