### PR TITLE
feat(enrichment): add test-to-code ratio analyzer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,20 +66,20 @@ GITTENSORY_REVIEW_ENRICHMENT=false
 # dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol,redos
 # provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild
 # history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity,ciCheckSignals
-# undocumentedExport,staleBranch,commitHygiene,pendingReviewRequests
+# undocumentedExport,staleBranch,commitHygiene,pendingReviewRequests,testRatio
 #
 # Profile defaults:
 # fast: dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol
-# redos,provenance,secretLog,typosquat,iacMisconfig,nativeBuild
+# redos,provenance,secretLog,typosquat,iacMisconfig,nativeBuild,testRatio
 # balanced (default): dependency,lockfileDrift,secret,license,installScript,heavyDependency
 # actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature
 # iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink
 # approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene
-# pendingReviewRequests
+# pendingReviewRequests,testRatio
 # deep: dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol
 # redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig
 # nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity
-# ciCheckSignals,undocumentedExport,staleBranch,commitHygiene,pendingReviewRequests
+# ciCheckSignals,undocumentedExport,staleBranch,commitHygiene,pendingReviewRequests,testRatio
 # END GENERATED REES ANALYZERS
 
 # Submitter-reputation spend control (internal-only): downgrades new/burst/low-rep

--- a/apps/gittensory-ui/src/lib/rees-analyzers.ts
+++ b/apps/gittensory-ui/src/lib/rees-analyzers.ts
@@ -727,6 +727,30 @@ export const REES_ANALYZERS = [
         "Structured-fields-only: reads user.login/team.slug/event/created_at, never diff or comment text. Fail-safe on missing token/fetch error/an unconfirmed-complete timeline.",
     },
   },
+  {
+    name: "testRatio",
+    title: "Test-to-code ratio",
+    category: "quality",
+    cost: "local",
+    defaultEnabled: true,
+    profiles: ["fast", "balanced", "deep"],
+    requires: ["files"],
+    limits: {
+      materialSourceLines: 20,
+      ratioThreshold: 0.3,
+    },
+    docs: {
+      summary:
+        "Flags a PR whose source change is material but ships with disproportionately little (or zero) accompanying test change.",
+      looksAt:
+        "Each changed file's path (classified source vs test by naming convention) and added-line count.",
+      reports:
+        "Source/test added-line and file counts and the resulting ratio — never file content.",
+      network: "Pure local analyzer. No external network call.",
+      notes:
+        "A cheap, always-available complement to the coverage-delta analyzer: works even when no CI coverage artifact exists.",
+    },
+  },
 ] as const satisfies readonly ReesAnalyzerDoc[];
 
 export const REES_ANALYZER_NAMES = REES_ANALYZERS.map((analyzer) => analyzer.name);

--- a/review-enrichment/analyzer-metadata.json
+++ b/review-enrichment/analyzer-metadata.json
@@ -816,6 +816,32 @@
         "network": "Calls the GitHub requested-reviewers API once and the issue-timeline API, paginated and bounded to a fixed page cap.",
         "notes": "Structured-fields-only: reads user.login/team.slug/event/created_at, never diff or comment text. Fail-safe on missing token/fetch error/an unconfirmed-complete timeline."
       }
+    },
+    {
+      "name": "testRatio",
+      "title": "Test-to-code ratio",
+      "category": "quality",
+      "cost": "local",
+      "defaultEnabled": true,
+      "profiles": [
+        "fast",
+        "balanced",
+        "deep"
+      ],
+      "requires": [
+        "files"
+      ],
+      "limits": {
+        "materialSourceLines": 20,
+        "ratioThreshold": 0.3
+      },
+      "docs": {
+        "summary": "Flags a PR whose source change is material but ships with disproportionately little (or zero) accompanying test change.",
+        "looksAt": "Each changed file's path (classified source vs test by naming convention) and added-line count.",
+        "reports": "Source/test added-line and file counts and the resulting ratio — never file content.",
+        "network": "Pure local analyzer. No external network call.",
+        "notes": "A cheap, always-available complement to the coverage-delta analyzer: works even when no CI coverage artifact exists."
+      }
     }
   ]
 }

--- a/review-enrichment/src/analyzers/registry.ts
+++ b/review-enrichment/src/analyzers/registry.ts
@@ -24,6 +24,7 @@ import { scanRedos } from "./redos.js";
 import { secretAnalyzer } from "./secret/descriptor.js";
 import { scanSecretLog } from "./secret-log.js";
 import { scanStaleBranch } from "./stale-branch.js";
+import { scanTestRatio } from "./test-ratio.js";
 import { scanTyposquat } from "./typosquat.js";
 import { scanUndocumentedExport } from "./undocumented-export.js";
 import type {
@@ -679,6 +680,34 @@ export const ANALYZER_DESCRIPTORS = [
     },
     run: (req, { signal, analysis, diagnostics }) =>
       scanPendingReviewRequests(req, fetch, { signal, analysis, diagnostics }),
+  }),
+  descriptor({
+    name: "testRatio",
+    title: "Test-to-code ratio",
+    category: "quality",
+    cost: "local",
+    defaultEnabled: true,
+    requires: ["files"],
+    limits: { materialSourceLines: 20, ratioThreshold: 0.3 },
+    docs: {
+      summary: "Flags a PR whose source change is material but ships with disproportionately little (or zero) accompanying test change.",
+      looksAt: "Each changed file's path (classified source vs test by naming convention) and added-line count.",
+      reports: "Source/test added-line and file counts and the resulting ratio — never file content.",
+      network: "Pure local analyzer. No external network call.",
+      notes:
+        "A cheap, always-available complement to the coverage-delta analyzer: works even when no CI coverage artifact exists.",
+    },
+    render: (findings, helpers) => {
+      if (!findings.length) return [];
+      const lines = ["### Test-to-code ratio"];
+      for (const item of findings) {
+        lines.push(
+          `- ${helpers.safeCodeSpan(`+${item.sourceAdded} source`)} vs ${helpers.safeCodeSpan(`+${item.testAdded} test`)} added lines (ratio ${item.ratio.toFixed(2)}) across ${item.sourceFiles} source file(s) and ${item.testFiles} test file(s)`,
+        );
+      }
+      return lines;
+    },
+    run: (req) => scanTestRatio(req),
   }),
 ] as const satisfies readonly AnyAnalyzerDescriptor[];
 

--- a/review-enrichment/src/analyzers/test-ratio.ts
+++ b/review-enrichment/src/analyzers/test-ratio.ts
@@ -1,0 +1,87 @@
+// Test-to-code ratio analyzer (#2024). From the diff alone (no network, no repo checkout), computes how many
+// source lines/files a PR adds versus how many test lines/files it adds, and flags when a MATERIAL source change
+// ships with disproportionately little (or zero) accompanying test change. A cheap, always-available complement
+// to the coverage-delta analyzer (#1516) that works even when no CI coverage artifact exists. Pure compute over
+// `req.files` (path + additions, both already provided by the PR-files API) — no diff/patch parsing, so it
+// cannot suffer a patch scanner's edge cases. Fail-safe: no files yields no finding.
+import type { EnrichRequest, TestRatioFinding } from "../types.js";
+
+// A material source change below this many added lines isn't enough signal to judge test coverage by ratio —
+// a 3-line fix doesn't need a proportional test file.
+const MATERIAL_SOURCE_LINES = 20;
+// Below this fraction of test-added to source-added lines, the change is flagged as under-tested.
+const RATIO_THRESHOLD = 0.3;
+
+// Source-code extensions this ratio is meaningful for (mirrors duplication-scan.ts's SOURCE_EXTS) — docs,
+// config, and data files are neither "source" nor "test" for this analyzer and are excluded from both sums.
+const SOURCE_EXTS = new Set([
+  "ts", "tsx", "js", "jsx", "mjs", "cjs",
+  "py", "go", "rb", "java", "kt", "rs",
+  "c", "cc", "cpp", "h", "hpp", "cs", "php", "swift", "scala",
+]);
+
+// Test-path conventions across the languages SOURCE_EXTS covers (test/tests/spec directory, *.test.*/*.spec.*,
+// and the common per-language suffix conventions) — a finite, documented set of naming conventions, not a
+// heuristic guess.
+const TEST_PATH_RE =
+  /(^|\/)(test|tests|spec|__tests__)\//i;
+const TEST_SUFFIX_RE =
+  /\.(test|spec)\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs)$/i;
+const TEST_PY_PREFIX_RE = /(^|\/)test_[^/]*\.py$/i;
+const TEST_GO_RB_SUFFIX_RE = /(^|\/)[^/]+_(test\.go|spec\.rb)$/i;
+const TEST_JVM_CS_SUFFIX_RE = /(^|\/)\w*(Tests?|Spec)\.(java|kt|kts|scala|cs)$/;
+
+/** Whether `path` matches an established test-file naming convention. Pure. */
+export function isTestPath(path: string): boolean {
+  return (
+    TEST_PATH_RE.test(path) ||
+    TEST_SUFFIX_RE.test(path) ||
+    TEST_PY_PREFIX_RE.test(path) ||
+    TEST_GO_RB_SUFFIX_RE.test(path) ||
+    TEST_JVM_CS_SUFFIX_RE.test(path)
+  );
+}
+
+function sourceExtOf(path: string): string | null {
+  const match = /\.([A-Za-z0-9]+)$/.exec(path);
+  return match ? match[1]!.toLowerCase() : null;
+}
+
+/** Pure reduction: a PR's changed files → a test-to-code ratio finding, emitted only when the source change is
+ *  material (>= MATERIAL_SOURCE_LINES added) AND the test-to-source ratio is under RATIO_THRESHOLD. A docs/config-
+ *  only PR (no recognized source extension) is never material, regardless of how many lines it adds. Pure. */
+export function evaluateTestRatio(
+  files: Array<{ path: string; additions?: number }>,
+): TestRatioFinding[] {
+  let sourceAdded = 0;
+  let testAdded = 0;
+  let sourceFiles = 0;
+  let testFiles = 0;
+
+  for (const file of files) {
+    const additions = file.additions ?? 0;
+    if (isTestPath(file.path)) {
+      testAdded += additions;
+      testFiles += 1;
+      continue;
+    }
+    const ext = sourceExtOf(file.path);
+    if (ext && SOURCE_EXTS.has(ext)) {
+      sourceAdded += additions;
+      sourceFiles += 1;
+    }
+  }
+
+  if (sourceAdded < MATERIAL_SOURCE_LINES) return [];
+
+  const ratio = testAdded / sourceAdded;
+  if (ratio >= RATIO_THRESHOLD) return [];
+
+  return [{ sourceAdded, testAdded, sourceFiles, testFiles, ratio, belowThreshold: true }];
+}
+
+/** Analyzer entrypoint: a PR's changed files → a test-to-code ratio finding. No network — pure compute over
+ *  `req.files`. Fail-safe: no files yields no finding. */
+export async function scanTestRatio(req: EnrichRequest): Promise<TestRatioFinding[]> {
+  return evaluateTestRatio(req.files ?? []);
+}

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -439,6 +439,7 @@ export function renderBrief(
   lines.push(...renderDescriptorSection("staleBranch", findings.staleBranch));
   lines.push(...renderDescriptorSection("commitHygiene", findings.commitHygiene));
   lines.push(...renderDescriptorSection("pendingReviewRequests", findings.pendingReviewRequests));
+  lines.push(...renderDescriptorSection("testRatio", findings.testRatio));
 
   if (!lines.length) return { promptSection: "", systemSuffix: "" };
 

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -382,6 +382,18 @@ export interface PendingReviewRequestFinding {
   hoursPending: number;
 }
 
+/** How much test change accompanies a PR's source change, computed from `req.files` alone (path + additions) —
+ *  no network, no diff/patch parsing. Emitted only when the source change is material (>= a minimum added-line
+ *  floor) and the test-to-source line ratio is under a configurable threshold (#2024, part of #1499). */
+export interface TestRatioFinding {
+  sourceAdded: number;
+  testAdded: number;
+  sourceFiles: number;
+  testFiles: number;
+  ratio: number;
+  belowThreshold: boolean;
+}
+
 /** Structured analyzer output. Each analyzer fills its own key; more land as analyzers ship (#1477/#1478). */
 export interface BriefFindings {
   dependency?: DependencyFinding[];
@@ -412,6 +424,7 @@ export interface BriefFindings {
   staleBranch?: StaleBranchFinding[];
   commitHygiene?: CommitHygieneFinding[];
   pendingReviewRequests?: PendingReviewRequestFinding[];
+  testRatio?: TestRatioFinding[];
 }
 
 /** A JSDoc/TSDoc block whose `@param` tags name parameters the adjacent function no longer declares — a

--- a/review-enrichment/test/analyzer-registry.test.ts
+++ b/review-enrichment/test/analyzer-registry.test.ts
@@ -38,6 +38,7 @@ const EXPECTED_ANALYZERS = [
   "staleBranch",
   "commitHygiene",
   "pendingReviewRequests",
+  "testRatio",
 ];
 
 test("analyzer descriptors cover the runtime registry in stable order", () => {

--- a/review-enrichment/test/test-ratio.test.ts
+++ b/review-enrichment/test/test-ratio.test.ts
@@ -1,0 +1,134 @@
+// Units for the test-to-code ratio analyzer (#2024). No network involved — pure compute over req.files. Runs
+// against the compiled dist/.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  evaluateTestRatio,
+  isTestPath,
+  scanTestRatio,
+} from "../dist/analyzers/test-ratio.js";
+
+test("evaluateTestRatio: flags a source-heavy PR with little/no accompanying test change", () => {
+  const findings = evaluateTestRatio([
+    { path: "src/widget.ts", additions: 100 },
+    { path: "src/widget.test.ts", additions: 5 },
+  ]);
+  assert.deepEqual(findings, [
+    { sourceAdded: 100, testAdded: 5, sourceFiles: 1, testFiles: 1, ratio: 0.05, belowThreshold: true },
+  ]);
+});
+
+test("evaluateTestRatio: a well-tested PR (ratio at/above threshold) is not flagged", () => {
+  const findings = evaluateTestRatio([
+    { path: "src/widget.ts", additions: 100 },
+    { path: "src/widget.test.ts", additions: 40 },
+  ]);
+  assert.deepEqual(findings, []);
+});
+
+test("evaluateTestRatio: a docs-only PR is not flagged (no recognized source extension)", () => {
+  const findings = evaluateTestRatio([
+    { path: "README.md", additions: 500 },
+    { path: "docs/guide.md", additions: 200 },
+  ]);
+  assert.deepEqual(findings, []);
+});
+
+test("evaluateTestRatio: an immaterial source change is not flagged even with zero tests (below the material floor)", () => {
+  const findings = evaluateTestRatio([{ path: "src/widget.ts", additions: 10 }]);
+  assert.deepEqual(findings, []);
+});
+
+test("evaluateTestRatio: a source change exactly at the material floor with zero tests IS flagged", () => {
+  const findings = evaluateTestRatio([{ path: "src/widget.ts", additions: 20 }]);
+  assert.deepEqual(findings, [
+    { sourceAdded: 20, testAdded: 0, sourceFiles: 1, testFiles: 0, ratio: 0, belowThreshold: true },
+  ]);
+});
+
+test("evaluateTestRatio: a ratio exactly at the threshold is NOT flagged (>= threshold is fine)", () => {
+  const findings = evaluateTestRatio([
+    { path: "src/widget.ts", additions: 100 },
+    { path: "src/widget.test.ts", additions: 30 },
+  ]);
+  assert.deepEqual(findings, []); // 30/100 = 0.3, the exact threshold
+});
+
+test("evaluateTestRatio: a ratio just under the threshold IS flagged", () => {
+  const findings = evaluateTestRatio([
+    { path: "src/widget.ts", additions: 100 },
+    { path: "src/widget.test.ts", additions: 29 },
+  ]);
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].belowThreshold, true);
+});
+
+test("evaluateTestRatio: sums additions and counts files across multiple source and test files", () => {
+  const findings = evaluateTestRatio([
+    { path: "src/a.ts", additions: 50 },
+    { path: "src/b.ts", additions: 50 },
+    { path: "test/a.test.ts", additions: 3 },
+  ]);
+  assert.deepEqual(findings, [
+    { sourceAdded: 100, testAdded: 3, sourceFiles: 2, testFiles: 1, ratio: 0.03, belowThreshold: true },
+  ]);
+});
+
+test("evaluateTestRatio: a file with no additions field is treated as zero", () => {
+  const findings = evaluateTestRatio([{ path: "src/widget.ts" }, { path: "src/widget.ts", additions: 25 }]);
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0].sourceAdded, 25);
+});
+
+test("evaluateTestRatio: an empty file list yields no finding", () => {
+  assert.deepEqual(evaluateTestRatio([]), []);
+});
+
+test("isTestPath: recognizes the test/tests/spec/__tests__ directory convention", () => {
+  assert.equal(isTestPath("test/widget.ts"), true);
+  assert.equal(isTestPath("tests/widget.py"), true);
+  assert.equal(isTestPath("spec/widget.rb"), true);
+  assert.equal(isTestPath("src/__tests__/widget.js"), true);
+});
+
+test("isTestPath: recognizes the .test./.spec. suffix convention", () => {
+  assert.equal(isTestPath("src/widget.test.ts"), true);
+  assert.equal(isTestPath("src/widget.spec.js"), true);
+  assert.equal(isTestPath("src/widget.ts"), false);
+});
+
+test("isTestPath: recognizes pytest's test_*.py prefix and Go/Ruby suffix conventions", () => {
+  assert.equal(isTestPath("pkg/test_widget.py"), true);
+  assert.equal(isTestPath("pkg/widget_test.go"), true);
+  assert.equal(isTestPath("pkg/widget_spec.rb"), true);
+});
+
+test("isTestPath: recognizes the JVM/C# PascalCase Test(s)/Spec class-suffix convention", () => {
+  assert.equal(isTestPath("src/WidgetTest.java"), true);
+  assert.equal(isTestPath("src/WidgetTests.cs"), true);
+  assert.equal(isTestPath("src/WidgetSpec.kt"), true);
+  assert.equal(isTestPath("src/Latest.java"), false); // must not false-positive on words merely ending in "test"
+});
+
+test("isTestPath: an ordinary source file is not a test path", () => {
+  assert.equal(isTestPath("src/analyzers/widget.ts"), false);
+});
+
+test("scanTestRatio: end-to-end wraps evaluateTestRatio with no network involved", async () => {
+  const findings = await scanTestRatio({
+    repoFullName: "octo/repo",
+    prNumber: 1,
+    files: [
+      { path: "src/widget.ts", additions: 100 },
+      { path: "src/widget.test.ts", additions: 5 },
+    ],
+  });
+  assert.deepEqual(findings, [
+    { sourceAdded: 100, testAdded: 5, sourceFiles: 1, testFiles: 1, ratio: 0.05, belowThreshold: true },
+  ]);
+});
+
+test("scanTestRatio: no files yields no finding", async () => {
+  const findings = await scanTestRatio({ repoFullName: "octo/repo", prNumber: 1 });
+  assert.deepEqual(findings, []);
+});

--- a/src/review/enrichment-analyzer-names.ts
+++ b/src/review/enrichment-analyzer-names.ts
@@ -32,6 +32,7 @@ export const REES_ANALYZER_NAMES = [
   "staleBranch",
   "commitHygiene",
   "pendingReviewRequests",
+  "testRatio",
 ] as const;
 
 export type ReesAnalyzerName = (typeof REES_ANALYZER_NAMES)[number];

--- a/test/unit/enrichment-wire.test.ts
+++ b/test/unit/enrichment-wire.test.ts
@@ -626,7 +626,7 @@ describe("resolveReesAnalyzers", () => {
       resolveReesAnalyzers(
         env({
           REES_ANALYZERS:
-            "dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene,pendingReviewRequests",
+            "dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene,pendingReviewRequests,testRatio",
         }),
       ),
     ).toEqual([
@@ -658,6 +658,7 @@ describe("resolveReesAnalyzers", () => {
       "staleBranch",
       "commitHygiene",
       "pendingReviewRequests",
+      "testRatio",
     ]);
   });
 


### PR DESCRIPTION
Closes #2024

## What

A new local REES analyzer, `testRatio`, that computes — from the diff alone, no network, no repo checkout — how
many source lines/files a PR adds versus how many test lines/files it adds, and flags when a MATERIAL source
change ships with disproportionately little (or zero) accompanying test change.

## Detection (pure local compute over `req.files` — no network, no diff/patch parsing)

- Classifies each changed file as source (a recognized source-code extension, matching the existing
  `duplication-scan.ts` `SOURCE_EXTS` set) or test (an established naming convention across languages: a
  `test/tests/spec/__tests__` directory, a `.test.`/`.spec.` suffix, pytest's `test_*.py` prefix, Go/Ruby's
  `*_test.go`/`*_spec.rb` suffix, or the JVM/C# `*Test(s)`/`*Spec` class-suffix convention).
- Sums added lines and counts files for each bucket using the `additions` field the PR-files API already
  provides per file — no patch text parsing needed.
- Emits a single finding only when the source change is material (>= 20 added lines) **and** the
  test-to-source ratio is under 0.3 — a docs/config-only PR (no recognized source extension) is never material
  regardless of size, and a small source tweak isn't held to a proportional-test-file standard.

## Why it is bounded / merge-safe

Pure compute over already-structured `req.files[].path`/`.additions` — no network call, no diff/patch parsing,
so there is no ambiguous-syntax edge case to find. `cost: "local"`, `requires: ["files"]` only, matching the
existing `redos`/`secret-log` local-analyzer descriptor shape. The test-path patterns are the same finite,
documented per-language conventions already used elsewhere in this codebase.

## Value

A cheap, always-available complement to the coverage-delta analyzer (#1516) that works even when no CI coverage
artifact exists — surfaces under-tested substantive changes directly from PR metadata with no extra network
round-trip.

## Tests

`review-enrichment/test/test-ratio.test.ts` covers: a source-heavy PR flagged, a well-tested PR not flagged, a
docs-only PR not flagged, an immaterial source change not flagged even at zero tests, both sides of the
material-floor boundary, both sides of the ratio-threshold boundary, summing across multiple source/test files,
a missing `additions` field treated as zero, the empty-input case, each `isTestPath` naming convention
individually (including the JVM PascalCase suffix's own negative case — `Latest.java` must not false-positive on
a word that merely ends in "test"), and the network-free entrypoint's pass-through behavior. Analyzer metadata is
regenerated and committed.
