### PR TITLE
feat(enrichment): detect AI-provider and more SaaS/CI credential formats in secret-scan

### DIFF
--- a/review-enrichment/src/analyzers/secret-scan.ts
+++ b/review-enrichment/src/analyzers/secret-scan.ts
@@ -272,6 +272,102 @@ const RULES: Rule[] = [
     confidence: "high",
   },
   {
+    // Dropbox short-lived access token: `sl.` + 130-152 base64url chars.
+    kind: "dropbox_token",
+    re: /\bsl\.[A-Za-z0-9_-]{130,152}\b/,
+    confidence: "high",
+  },
+  {
+    // JFrog Artifactory API key: `AKCp8` + >=69 base62 (lookahead terminator — the body has no fixed end).
+    kind: "jfrog_api_key",
+    re: /\bAKCp8[A-Za-z0-9]{69,}(?![A-Za-z0-9])/,
+    confidence: "high",
+  },
+  {
+    // Duffel API token: `duffel_test_`/`duffel_live_` + 43 base64url.
+    kind: "duffel_token",
+    re: /\bduffel_(?:test|live)_[A-Za-z0-9_-]{43}\b/,
+    confidence: "high",
+  },
+  {
+    // EasyPost API key: `EZAK` (production) / `EZTK` (test) + 54 base62.
+    kind: "easypost_key",
+    re: /\bEZ[AT]K[A-Za-z0-9]{54}\b/,
+    confidence: "high",
+  },
+  {
+    // Frame.io developer token: `fio-u-` + 64 base64url.
+    kind: "frameio_token",
+    re: /\bfio-u-[A-Za-z0-9_-]{64}\b/,
+    confidence: "high",
+  },
+  {
+    // Contentful personal access token: `CFPAT-` + 43 base64url.
+    kind: "contentful_token",
+    re: /\bCFPAT-[A-Za-z0-9_-]{43}\b/,
+    confidence: "high",
+  },
+  {
+    // SonarQube token: `sqa_`/`sqp_`/`squ_` (analysis/project/user) + 40 hex.
+    kind: "sonarqube_token",
+    re: /\bsq[apu]_[a-f0-9]{40}\b/,
+    confidence: "high",
+  },
+  {
+    // Pulumi access token: `pul-` + 40 hex.
+    kind: "pulumi_token",
+    re: /\bpul-[a-f0-9]{40}\b/,
+    confidence: "high",
+  },
+  {
+    // Adafruit IO key: `aio_` + 28 base62.
+    kind: "adafruit_io_key",
+    re: /\baio_[A-Za-z0-9]{28}\b/,
+    confidence: "high",
+  },
+  {
+    // ReadMe API key: `rdme_` + >=70 lowercase-hex-ish body (lookahead terminator).
+    kind: "readme_api_key",
+    re: /\brdme_[a-z0-9]{70,}(?![a-z0-9])/,
+    confidence: "high",
+  },
+  {
+    // Typeform personal access token: `tfp_` + >=40 base62/._- (lookahead terminator).
+    kind: "typeform_token",
+    re: /\btfp_[A-Za-z0-9._-]{40,}(?![A-Za-z0-9._-])/,
+    confidence: "high",
+  },
+  {
+    // Sentry DSN: an ingest URL embedding a 32-hex public key against a *.sentry.io host + project id.
+    kind: "sentry_dsn",
+    re: /\bhttps:\/\/[a-f0-9]{32}@[a-z0-9.-]*sentry\.io\/[0-9]+\b/,
+    confidence: "high",
+  },
+  {
+    // New Relic license/ingest key: 40 hex with the `NRAL` suffix (distinct from the `NRAK-` user key above).
+    kind: "newrelic_license_key",
+    re: /\b[a-f0-9]{40}NRAL\b/,
+    confidence: "high",
+  },
+  {
+    // Replicate API token: `r8_` + 37 base62.
+    kind: "replicate_token",
+    re: /\br8_[A-Za-z0-9]{37}\b/,
+    confidence: "high",
+  },
+  {
+    // Groq API key: `gsk_` + 52 base62.
+    kind: "groq_api_key",
+    re: /\bgsk_[A-Za-z0-9]{52}\b/,
+    confidence: "high",
+  },
+  {
+    // Perplexity API key: `pplx-` + >=40 base62 (lookahead terminator).
+    kind: "perplexity_api_key",
+    re: /\bpplx-[A-Za-z0-9]{40,}(?![A-Za-z0-9])/,
+    confidence: "high",
+  },
+  {
     kind: "private_key",
     re: /-----BEGIN (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----/,
     confidence: "high",

--- a/review-enrichment/test/secret-scan.test.ts
+++ b/review-enrichment/test/secret-scan.test.ts
@@ -442,3 +442,49 @@ test("scanPatch does not flag near-miss variants of the new SaaS/cloud credentia
     assert.equal(findings.length, 0, `near-miss should not match: ${nm}`);
   }
 });
+
+test("scanPatch flags additional high-confidence AI-provider and SaaS/CI credential formats", () => {
+  const cases = [
+    ["dropbox_token", "sl." + b62(140)],
+    ["jfrog_api_key", "AKCp8" + b62(70)],
+    ["duffel_token", "duffel_test_" + b62(43)],
+    ["easypost_key", "EZAK" + b62(54)],
+    ["frameio_token", "fio-u-" + b62(64)],
+    ["contentful_token", "CFPAT-" + b62(43)],
+    ["sonarqube_token", "sqp_" + hex(40)],
+    ["pulumi_token", "pul-" + hex(40)],
+    ["adafruit_io_key", "aio_" + b62(28)],
+    ["readme_api_key", "rdme_" + hex(70)],
+    ["typeform_token", "tfp_" + b62(40)],
+    ["sentry_dsn", "https://" + hex(32) + "@o0.ingest.sentry.io/12345"],
+    ["newrelic_license_key", hex(40) + "NRAL"],
+    ["replicate_token", "r8_" + b62(37)],
+    ["groq_api_key", "gsk_" + b62(52)],
+    ["perplexity_api_key", "pplx-" + b62(40)],
+  ];
+  for (const [kind, secret] of cases) {
+    const findings = scanPatch("src/config.ts", hunk([`const c = "${secret}";`]));
+    assert.equal(findings.length, 1, `${kind}: expected exactly one finding, got ${JSON.stringify(findings)}`);
+    assert.equal(findings[0].kind, kind, `${kind}: wrong kind`);
+    assert.equal(findings[0].confidence, "high", `${kind}: wrong confidence`);
+  }
+});
+
+test("scanPatch does not flag near-miss variants of the new AI/SaaS credential formats", () => {
+  // One char short of the fixed/minimum length must produce no finding.
+  const nearMisses = [
+    "AKCp8" + b62(68),
+    "duffel_test_" + b62(42),
+    "EZAK" + b62(53),
+    "CFPAT-" + b62(42),
+    "pul-" + hex(39),
+    "aio_" + b62(27),
+    "r8_" + b62(36),
+    "gsk_" + b62(51),
+    "sqp_" + hex(39),
+  ];
+  for (const nm of nearMisses) {
+    const findings = scanPatch("src/config.ts", hunk([`const c = "${nm}";`]));
+    assert.equal(findings.length, 0, `near-miss should not match: ${nm}`);
+  }
+});


### PR DESCRIPTION
## Summary

The secret-scan analyzer (`review-enrichment/src/analyzers/secret-scan.ts`) flags credentials committed in a
PR diff, citing `file:line` + kind only (never the value). This adds **16 more credential formats** the scanner
currently misses — the current wave of **AI-provider keys** plus widely-used SaaS/CI tokens — continuing the
established `feat(enrichment)` secret-format additions.

Each new rule is a high-confidence, gitleaks/trufflehog-standard shape with a **distinctive multi-character
literal prefix (or fixed marker/host) and a fixed or tightly-bounded length + charset**, so the false-positive
rate against ordinary source, base64 blobs, hex hashes, and UUIDs is effectively zero:

| kind | shape |
|---|---|
| `groq_api_key` | `gsk_` + 52 base62 |
| `replicate_token` | `r8_` + 37 base62 |
| `perplexity_api_key` | `pplx-` + ≥40 base62 |
| `dropbox_token` | `sl.` + 130–152 base64url |
| `jfrog_api_key` | `AKCp8` + ≥69 base62 |
| `duffel_token` | `duffel_{test,live}_` + 43 |
| `easypost_key` | `EZAK`/`EZTK` + 54 base62 |
| `frameio_token` | `fio-u-` + 64 base64url |
| `contentful_token` | `CFPAT-` + 43 base64url |
| `sonarqube_token` | `sqa_`/`sqp_`/`squ_` + 40 hex |
| `pulumi_token` | `pul-` + 40 hex |
| `adafruit_io_key` | `aio_` + 28 base62 |
| `readme_api_key` | `rdme_` + ≥70 |
| `typeform_token` | `tfp_` + ≥40 |
| `sentry_dsn` | ingest URL: 32-hex key `@…sentry.io/<project id>` |
| `newrelic_license_key` | 40 hex + `NRAL` suffix |

No existing rule is modified, so current findings are unchanged, and no analyzer descriptor changes (the
finding schema is unchanged) — so `analyzer-metadata.json` and the generated UI mirror are untouched.

No linked issue: additive detection-coverage for well-known credential formats, matching the established
`feat(enrichment)` secret-format additions; each rule is a self-evident real token shape with no public
API/schema/deploy surface change — fits the repo's `preferred` (not required) linked-issue policy.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run typecheck`
- [x] `npm run rees:test` — the review-enrichment build + analyzer suite (see note below)
- [ ] `npm run test:coverage` (N/A — this file is in `review-enrichment/`, outside the root `src/**` Codecov scope)
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran locally: `git diff --check` (clean), the review-enrichment TypeScript build (exit 0), and the secret-scan
  analyzer test via `node --test` — **44/44 pass**, including a new table case that flags each of the 16
  formats at high confidence, plus a near-miss case asserting that one-character-short tokens produce no
  finding — proving the prefixes/lengths are specific, not broad. All fixtures are assembled from string
  fragments so the test file never contains a contiguous secret literal. The change is confined to
  `review-enrichment/`, outside the `src/**` Codecov scope.
- Not run locally: the UI, root typecheck, and the `metadata:check` step of `rees:test`. This change only adds
  scan rules, not any analyzer descriptor, so the committed `analyzer-metadata.json`/UI mirror are unchanged (a
  local regeneration produces a zero-content diff) and `metadata:check` passes on CI (Linux). On this Windows
  dev box `metadata:check` reports a spurious line-ending difference; it fails identically on unmodified
  `main`. `analyzer-metadata.json` was NOT modified.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Detection-only additions: 16 new high-confidence rules; no existing rule, threshold, or descriptor changed,
  so current findings and `analyzer-metadata.json` are unaffected. The scanner still returns only `file:line` +
  `kind`, never the matched secret value.
- Each regex uses `\b` boundaries (or a negative-lookahead terminator where the body has no fixed end, as the
  existing SendGrid/Anthropic/Square rules already do). `newrelic_license_key` is anchored by its `NRAL`
  suffix and `sentry_dsn` by its `sentry.io` host, so neither can match a bare hash/URL.
