### PR TITLE
fix(review): label manual-held pull requests

### DIFF
--- a/src/services/agent-approval-queue.ts
+++ b/src/services/agent-approval-queue.ts
@@ -291,7 +291,7 @@ export async function decidePendingAgentAction(env: Env, input: { id: string; de
   // still merge a now-ineligible PR. Mirrors the planner's own owner/automation exemption (closeEligible) so an
   // owner's staged merge, which the hard rule never blocks in the first place, is not wrongly denied here.
   // Gated on the POST-downgrade `plan`, not `pending.actionClass`: the precision-breaker downgrade immediately
-  // above can already have replaced a staged merge with a needs-human-review label (downgradeMergeToHold) — that
+  // above can already have replaced a staged merge with a manual-review label (downgradeMergeToHold) — that
   // downgraded plan isn't going to merge anything, so a stale linked-issue violation must not reject the whole
   // row and suppress the hold label; it only matters while a merge is still the thing about to execute.
   if (plan.some((action) => action.actionClass === "merge") && pr) {

--- a/src/settings/agent-actions.ts
+++ b/src/settings/agent-actions.ts
@@ -351,7 +351,7 @@ function resolveAgentDispositionLabels(settings: AgentDispositionLabelSettings):
 /**
  * Accuracy circuit-breaker (#self-improve / GAP-4): when auto-merge is DISABLED for a repo (the auto-tuner
  * engaged the holdonly flag after merge precision dropped, or a human set it), DOWNGRADE a would-MERGE into a
- * human HOLD — drop the `merge` action and surface the needs-human-review label so the PR is held for a person
+ * human HOLD — drop the `merge` action and surface the configured manual-review label so the PR is held for a person
  * instead of auto-merged. Mirrors reviewbot non-content-gate.ts (~212: a would-merge becomes a hold under the
  * breaker; close/label/approve are untouched).
  *
@@ -362,7 +362,7 @@ export function downgradeMergeToHold(planned: PlannedAgentAction[], holdOnly: bo
   if (!holdOnly || !planned.some((action) => action.actionClass === "merge")) return planned;
   const labels = resolveAgentDispositionLabels(labelSettings);
   const next = planned.filter((action) => action.actionClass !== "merge");
-  // The dropped merge implies the PR is review-good — re-label it needs-human-review (replacing a stale
+  // The dropped merge implies the PR is review-good — re-label it for manual review (replacing a stale
   // ready-to-merge promise) so the held PR is clearly flagged for a person. Idempotent: only add when absent.
   const alreadyNeedsReview = labels.manualReview !== null && next.some((action) => action.actionClass === "label" && action.label === labels.manualReview && action.labelOp !== "remove");
   const stagedMerge = planned.find((action) => action.actionClass === "merge");
@@ -383,7 +383,7 @@ export function downgradeMergeToHold(planned: PlannedAgentAction[], holdOnly: bo
 /**
  * CLOSE-precision circuit-breaker (the symmetric mirror of {@link downgradeMergeToHold}): when auto-CLOSE is
  * DISABLED for a repo (the auto-tuner engaged the `closehold` flag after CLOSE precision dropped, or a human set
- * it), DOWNGRADE a would-CLOSE into a human HOLD — drop the `close` action(s) and surface the needs-human-review
+ * it), DOWNGRADE a would-CLOSE into a human HOLD — drop the `close` action(s) and surface the configured manual-review
  * label so the PR is held for a person instead of auto-closed.
  *
  * TIGHTENING-ONLY in the close direction: it can ONLY remove a `close` action + ADD a label. It NEVER adds or
@@ -412,7 +412,7 @@ export function downgradeCloseToHold(planned: PlannedAgentAction[], closeHoldOnl
   const labels = resolveAgentDispositionLabels(labelSettings);
   // Drop ONLY the heuristic close(s); a deterministic linked-issue-hard-rule close (if any) is left intact.
   const next = planned.filter((action) => !isHeuristicClose(action));
-  // The dropped close means the PR is held for a person — surface needs-human-review. Idempotent: only add when
+  // The dropped close means the PR is held for a person — surface the manual-review label. Idempotent: only add when
   // absent (e.g. a guarded-but-passing plan may already carry it). NEVER adds a merge/approve.
   const alreadyNeedsReview = labels.manualReview !== null && next.some((action) => action.actionClass === "label" && action.label === labels.manualReview && action.labelOp !== "remove");
   const droppedClose = planned.find(isHeuristicClose);
@@ -694,7 +694,7 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
     });
   }
 
-  // 2) review_state_label (#label-scoping) — ready-to-merge (review-good, unguarded) / needs-human-review
+  // 2) review_state_label (#label-scoping) — ready-to-merge (review-good, unguarded) / manual-review
   // (review-good but guarded) / changes-requested (not review-good → will be closed for a contributor, held for
   // the owner). A pending linked-issue hard-rule close (flag OR close pass) forces the changes-requested label
   // regardless of the gate verdict (the PR is about to be closed for an ineligible linked issue). Idempotent.
@@ -882,8 +882,33 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
       closeRequiresMergeableState: isConflict,
     });
   }
-  // else: guarded → manual (needs-human/changes label above); not-good OWNER/automation → held
-  // (request-changes above); review-good-but-not-yet-mergeable → held briefly (rebase/approve resolves it next pass).
+  // else: guarded → manual; not-good OWNER/automation → manual; action-required/unverified → manual;
+  // review-good-but-not-yet-mergeable → held briefly (rebase/approve resolves it next pass).
+  const manualHoldReason =
+    guardrailHit
+      ? `verdict=${conclusion}; guarded path → manual review`
+      : ciUnverified
+        ? "CI could not be verified"
+        : conclusion === "action_required"
+          ? "review requires maintainer action"
+          : !reviewGood && !closeEligible
+            ? `verdict=${conclusion}${ciReason ? `; ${ciReason}` : ""}`
+            : null;
+  if (
+    manualHoldReason !== null &&
+    labels.manualReview !== null &&
+    !actions.some((action) => action.actionClass === "merge" || action.actionClass === "close") &&
+    !hasLabelOrPlanned(input.pr.labels, actions, labels.manualReview)
+  ) {
+    actions.push({
+      actionClass: "label",
+      autonomyClass: reviewGood ? "merge" : "close",
+      requiresApproval: false,
+      reason: manualHoldReason,
+      label: labels.manualReview,
+      labelOp: "add",
+    });
+  }
 
   return actions;
 }

--- a/src/settings/autonomy.ts
+++ b/src/settings/autonomy.ts
@@ -6,7 +6,7 @@ export const AUTONOMY_LEVELS = ["observe", "suggest", "propose", "auto_with_appr
 
 // The write-action classes the maintainer auto-maintain layer (#778) can take on a PR. `review_state_label`
 // (#label-scoping) is a separate class from `label`: it gates the planner's own disposition-communication
-// labels (ready-to-merge / changes-requested / needs-human-review / migration-collision / pending-closure /
+// labels (ready-to-merge / changes-requested / manual-review / migration-collision / pending-closure /
 // new-account), independent of the anti-abuse enforcement labels (blacklist/contributor-cap/review-nag), which
 // ride on `close` instead -- see agent-actions.ts.
 export const AGENT_ACTION_CLASSES = ["review", "request_changes", "approve", "merge", "close", "label", "review_state_label", "update_branch"] as const;

--- a/src/types.ts
+++ b/src/types.ts
@@ -982,7 +982,7 @@ export type AutonomyLevel = "observe" | "suggest" | "propose" | "auto_with_appro
  *  anti-abuse enforcement labels tied 1:1 to a `close` in the same disposition (blacklist/contributor-cap/
  *  review-nag) -- those additionally require `close` to be acting, so `label` alone can't apply them without a
  *  close. `review_state_label` is a SEPARATE, independent gate for the planner's own disposition-communication
- *  labels (ready-to-merge / changes-requested / needs-human-review / migration-collision / the linked-issue
+ *  labels (ready-to-merge / changes-requested / manual-review / migration-collision / the linked-issue
  *  pending-closure flag / the account-age new-account label) -- these are advisory signals about the bot's own
  *  verdict, not enforcement actions, and default OFF (`observe`) like every other class so a one-shot-mode repo
  *  never sees them without an explicit opt-in. */

--- a/test/unit/agent-actions.test.ts
+++ b/test/unit/agent-actions.test.ts
@@ -64,6 +64,14 @@ describe("planAgentMaintenanceActions (#778)", () => {
     expect(classes(collision)).not.toContain("merge");
   });
 
+  it("uses manualReviewLabel for manual holds without enabling ready/changes review-state labels", () => {
+    const guarded = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { merge: "auto" }, manualReviewLabel: "human-review", readyToMergeLabel: null, changesRequestedLabel: null, changedPaths: ["src/settings/agent-actions.ts"], hardGuardrailGlobs: ["src/settings/**"], pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED" } }));
+    expect(guarded.some((a) => a.actionClass === "label" && a.label === "human-review" && a.autonomyClass === "merge")).toBe(true);
+    expect(guarded.some((a) => a.actionClass === "label" && a.label === AGENT_LABEL_READY)).toBe(false);
+    expect(guarded.some((a) => a.actionClass === "label" && a.label === AGENT_LABEL_CHANGES)).toBe(false);
+    expect(classes(guarded)).not.toContain("merge");
+  });
+
   it("explicit null disables disposition labels without disabling the underlying decision", () => {
     expect(planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { review_state_label: "auto" }, readyToMergeLabel: null }))).toEqual([]);
     expect(planAgentMaintenanceActions(input({ conclusion: "failure", autonomy: { review_state_label: "auto" }, blockerTitles: ["x"], changesRequestedLabel: null }))).toEqual([]);
@@ -103,6 +111,13 @@ describe("planAgentMaintenanceActions (#778)", () => {
     // awaiting-action (e.g. a fork's CI awaiting approval) → HELD + labeled, NOT a one-shot close. (#harm-stop)
     expect(plan).not.toContain("close");
     expect(plan).toContain("label");
+  });
+
+  it("labels action-required manual holds even when review_state_label is off", () => {
+    const plan = planAgentMaintenanceActions(input({ conclusion: "action_required", autonomy: { close: "auto" }, manualReviewLabel: "human-review", readyToMergeLabel: null, changesRequestedLabel: null, blockerTitles: [] }));
+    expect(plan).toEqual([
+      expect.objectContaining({ actionClass: "label", autonomyClass: "close", label: "human-review", labelOp: "add" }),
+    ]);
   });
 
   it("approves a passing verdict and never re-approves; a failing one closes (never approves, never requests changes)", () => {
@@ -364,9 +379,9 @@ describe("planAgentMaintenanceActions (#778)", () => {
       expect(plan).not.toContain("merge");
     });
 
-    it("labels a guarded passing PR `needs-human-review` (NOT `ready-to-merge`) and still does not merge it", () => {
+    it("labels a guarded passing PR manual-review (NOT ready-to-merge) and still does not merge it", () => {
       // A guardrail-hit PR that otherwise passes is withheld from auto-merge → the `ready-to-merge` label
-      // would be misleading. It must carry the distinct `needs-human-review` label instead, and never merge.
+      // would be misleading. It must carry the distinct manual-review label instead, and never merge.
       const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { review_state_label: "auto", merge: "auto" }, ...guarded, pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED" } }));
       const label = plan.find((a) => a.actionClass === "label");
       expect(label?.label).toBe(AGENT_LABEL_NEEDS_REVIEW);
@@ -375,12 +390,12 @@ describe("planAgentMaintenanceActions (#778)", () => {
       expect(classes(plan)).not.toContain("merge");
     });
 
-    it("does not re-plan the needs-human-review label when the guarded PR already carries it (idempotent)", () => {
+    it("does not re-plan the manual-review label when the guarded PR already carries it (idempotent)", () => {
       const plan = classes(planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { review_state_label: "auto" }, ...guarded, pr: { labels: [AGENT_LABEL_NEEDS_REVIEW] } })));
       expect(plan).not.toContain("label");
     });
 
-    it("a guarded BLOCKING PR keeps the changes-requested label (not needs-human-review)", () => {
+    it("a guarded BLOCKING PR keeps the changes-requested label (not manual-review)", () => {
       const label = planAgentMaintenanceActions(input({ conclusion: "failure", autonomy: { review_state_label: "auto" }, blockerTitles: ["x"], ...guarded, pr: { labels: [] } })).find((a) => a.actionClass === "label");
       expect(label?.label).toBe(AGENT_LABEL_CHANGES);
     });
@@ -631,6 +646,13 @@ describe("planAgentMaintenanceActions (#778)", () => {
       expect(cls).not.toContain("close");
       expect(cls).not.toContain("request_changes"); // never a formal blocking review
       expect(plan.find((a) => a.actionClass === "label")?.label).toBe(AGENT_LABEL_CHANGES);
+    });
+
+    it("labels owner's red-CI manual hold with manualReviewLabel when ready/changes labels are disabled", () => {
+      const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { close: "auto" }, manualReviewLabel: "human-review", readyToMergeLabel: null, changesRequestedLabel: null, ciState: "failed", failingCheckNames: ["codecov/patch"], authorIsOwner: true, pr: { labels: [] } }));
+      expect(plan).toEqual([
+        expect.objectContaining({ actionClass: "label", autonomyClass: "close", label: "human-review", labelOp: "add" }),
+      ]);
     });
 
     it("CLOSES (never approves or requests changes) a contributor's red-CI PR and cites the failing check", () => {
@@ -949,7 +971,7 @@ describe("downgradeCloseToHold — close-precision circuit-breaker (#close-preci
       }),
     );
 
-  it("a real heuristic would-CLOSE plan drops the close + adds needs-human-review + KEEPS changes-requested", () => {
+  it("a real heuristic would-CLOSE plan drops the close + adds manual-review + KEEPS changes-requested", () => {
     const plan = heuristicClosePlan();
     // sanity: the planner really would heuristically close, with a changes-requested label, and the close
     // carries NO concrete evidence (so it stays subject to the breaker below).
@@ -974,7 +996,7 @@ describe("downgradeCloseToHold — close-precision circuit-breaker (#close-preci
     expect(held.some((a) => a.actionClass === "label" && a.label === AGENT_LABEL_NEEDS_REVIEW)).toBe(false);
   });
 
-  it("a deterministic linked-issue-hard-rule close is EXEMPT (NOT dropped, no needs-human-review added)", () => {
+  it("a deterministic linked-issue-hard-rule close is EXEMPT (NOT dropped, no manual-review added)", () => {
     const plan = linkedIssueClosePlan();
     expect(plan.some((a) => a.actionClass === "close" && a.closeKind === "linked-issue-hard-rule")).toBe(true);
     const held = downgradeCloseToHold(plan, true);
@@ -1006,7 +1028,7 @@ describe("downgradeCloseToHold — close-precision circuit-breaker (#close-preci
     expect(out.some((a) => a.actionClass === "merge")).toBe(true);
   });
 
-  it("does NOT re-add needs-human-review when it is already present (idempotent)", () => {
+  it("does NOT re-add manual-review when it is already present (idempotent)", () => {
     const needsReview: PlannedAgentAction = { actionClass: "label", requiresApproval: false, reason: "guarded", label: AGENT_LABEL_NEEDS_REVIEW, labelOp: "add" };
     const heuristicClose: PlannedAgentAction = { actionClass: "close", requiresApproval: false, reason: "CI failing", closeKind: "heuristic" };
     const held = downgradeCloseToHold([needsReview, heuristicClose], true);

--- a/test/unit/agent-approval-queue.test.ts
+++ b/test/unit/agent-approval-queue.test.ts
@@ -587,7 +587,7 @@ describe("agent approval queue (#779)", () => {
     expect(fetchLiveCiAggregate).toHaveBeenCalledTimes(2);
   });
 
-  it("accept downgrades a staged merge to a needs-human-review label when the precision breaker engaged after staging (#2127)", async () => {
+  it("accept downgrades a staged merge to a manual-review label when the precision breaker engaged after staging (#2127)", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: "x" });
     await upsertRepositorySettings(env, { repoFullName: "owner/repo", autonomy: { merge: "auto_with_approval", review_state_label: "auto" } });
     await seedInstallation(env);
@@ -604,7 +604,7 @@ describe("agent approval queue (#779)", () => {
 
   it("REGRESSION: a precision-breaker-downgraded merge still executes the hold/label plan even when the linked issue would now violate the hard rule", async () => {
     // Before the fix, the linked-issue recheck gated on pending.actionClass (the ORIGINAL staged class), not the
-    // post-downgrade plan -- so a merge already downgraded to a needs-human-review label by the #2127 precision
+    // post-downgrade plan -- so a merge already downgraded to a manual-review label by the #2127 precision
     // breaker above would still get its whole row rejected on a stale linked-issue violation, silently swallowing
     // the hold label the breaker was supposed to guarantee.
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: "x" });
@@ -946,7 +946,7 @@ describe("agent approval queue (#779)", () => {
     expect(closePullRequest).toHaveBeenCalledWith(env, 5, "owner/repo", 7);
   });
 
-  it("accept downgrades a staged heuristic close to a needs-human-review label when the close breaker engaged (#2127)", async () => {
+  it("accept downgrades a staged heuristic close to a manual-review label when the close breaker engaged (#2127)", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: "x" });
     await upsertRepositorySettings(env, { repoFullName: "owner/repo", autonomy: { close: "auto_with_approval", review_state_label: "auto" } });
     await seedInstallation(env);

--- a/test/unit/mcp-automation-state.test.ts
+++ b/test/unit/mcp-automation-state.test.ts
@@ -177,10 +177,10 @@ describe("MCP gittensory_propose_action (#784)", () => {
     const client = await connect(env);
     await client.callTool({
       name: "gittensory_propose_action",
-      arguments: { owner: "owner", repo: "repo", pullNumber: 9, actionClass: "close", label: "gittensory:blocked", reviewBody: "please fix", closeComment: "closing as noise" },
+      arguments: { owner: "owner", repo: "repo", pullNumber: 9, actionClass: "close", label: "custom-blocked", reviewBody: "please fix", closeComment: "closing as noise" },
     });
     const [staged] = await listPendingAgentActions(env, { repoFullName: "owner/repo", status: "pending" });
-    expect(staged?.params).toMatchObject({ label: "gittensory:blocked", reviewBody: "please fix", closeComment: "closing as noise" });
+    expect(staged?.params).toMatchObject({ label: "custom-blocked", reviewBody: "please fix", closeComment: "closing as noise" });
   });
 
   it("pins a proposed action to the PR's current head (expectedHeadSha) so the accept-time force-push guard can fire (#2255)", async () => {

--- a/test/unit/outcomes-wire.test.ts
+++ b/test/unit/outcomes-wire.test.ts
@@ -484,7 +484,7 @@ describe("downgradeMergeToHold (pure)", () => {
     expect(downgradeMergeToHold(plan, false)).toBe(plan);
   });
 
-  it("holdOnly=true + a planned merge → drops the merge + ready label, adds needs-human-review", () => {
+  it("holdOnly=true + a planned merge → drops the merge + ready label, adds manual-review", () => {
     const out = downgradeMergeToHold([readyLabel, mergeAction], true);
     expect(out.some((a) => a.actionClass === "merge")).toBe(false);
     expect(

--- a/test/unit/precision-breakers-chain.test.ts
+++ b/test/unit/precision-breakers-chain.test.ts
@@ -38,7 +38,7 @@ describe("applyPrecisionBreakers — chaining the merge + close precision breake
     expect(out.some((a) => a.actionClass === "close")).toBe(false);
     expect(out.some((a) => a.actionClass === "label" && a.label === AGENT_LABEL_READY)).toBe(false);
     expect(out.some((a) => a.actionClass === "label" && a.label === AGENT_LABEL_CHANGES)).toBe(true); // KEPT
-    // needs-human-review added exactly once (the second downgrade is idempotent on the label).
+    // manual-review is added exactly once (the second downgrade is idempotent on the label).
     expect(out.filter((a) => a.actionClass === "label" && a.label === AGENT_LABEL_NEEDS_REVIEW)).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary
- ensure manual-held PR outcomes receive the configured manual-review label even when ready/changes disposition labels are disabled
- clean stale legacy label wording from comments and test fixtures so config-driven labels remain clear

## What changed
- adds a final manual-hold label planning pass for guardrail, action-required, CI-unverified, and owner/automation hold outcomes
- preserves explicit null label settings and avoids adding labels when a terminal merge/close action is planned
- updates regression tests for custom manualReviewLabel behavior without enabling review_state_label

## Validation
- npm run test:coverage
- npm run typecheck
- npx vitest run test/unit/agent-actions.test.ts test/unit/mcp-automation-state.test.ts test/unit/outcomes-wire.test.ts test/unit/agent-approval-queue.test.ts test/unit/precision-breakers-chain.test.ts
- git diff --check