### PR TITLE
fix(selfhost): restore backlog repo round robin

### DIFF
--- a/src/selfhost/queue-fairness.ts
+++ b/src/selfhost/queue-fairness.ts
@@ -71,25 +71,16 @@ export function nextForegroundLane(
 export type BacklogRepoCandidate = { repo: string; oldestPendingAgeMs: number };
 
 /**
- * Per-repo round-robin for the backlog lane: pick the repo whose oldest pending backlog job is stalest,
- * EXCEPT when that repo was also the last one served — in that case, rotate to the next-stalest so a single
- * repo with a deep backlog cannot monopolize every backlog-lane claim and starve every other repo's backlog.
- * A `lastClaimedRepo` no longer present in `candidates` (its backlog fully drained since) falls back to the
- * stalest overall, same as a first-ever pick. Pure.
+ * Per-repo round-robin for the backlog lane: sort repos by their oldest pending backlog job, then pick the
+ * successor of the last served repo in that deterministic order. The first-ever pick, or a drained
+ * `lastClaimedRepo` no longer present in `candidates`, starts at the stalest repo. Pure.
  */
 export function pickBacklogRepo(candidates: readonly BacklogRepoCandidate[], lastClaimedRepo: string | null): string | null {
   if (candidates.length === 0) return null;
   const sorted = [...candidates].sort((a, b) => b.oldestPendingAgeMs - a.oldestPendingAgeMs || a.repo.localeCompare(b.repo));
-  // sorted.length is provably >0 past the early return above, so every index below is in bounds.
-  const stalest = sorted[0] as BacklogRepoCandidate;
-  // Serve the stalest repo, EXCEPT when it is the one served last cycle — only then rotate to the
-  // next-stalest, so a single deep-backlog repo cannot monopolize the lane. When `lastClaimedRepo` is null,
-  // has since drained, or is simply some OTHER (less-stale) repo, the stalest was NOT just served, so it is
-  // served now — anything else would skip past the oldest backlog the lane exists to drain. (A positional
-  // "successor of the last-claimed repo" rotation would instead skip the stalest whenever the last-claimed
-  // repo sat at a middle rank, starving the very repo this mechanism is meant to protect.)
-  if (stalest.repo !== lastClaimedRepo) return stalest.repo;
-  return (sorted[1] ?? stalest).repo;
+  const lastIndex = lastClaimedRepo === null ? -1 : sorted.findIndex((candidate) => candidate.repo === lastClaimedRepo);
+  const next = sorted[(lastIndex + 1) % sorted.length] as BacklogRepoCandidate;
+  return next.repo;
 }
 
 // Exported so the queue backends' own topBacklogRepos SQL (COUNT/GROUP BY/ORDER BY/LIMIT pushed into the

--- a/test/unit/selfhost-queue-fairness.test.ts
+++ b/test/unit/selfhost-queue-fairness.test.ts
@@ -122,15 +122,33 @@ describe("pickBacklogRepo (#selfhost-backlog-convergence)", () => {
     expect(pickBacklogRepo(candidates, "owner/a")).toBe("owner/b");
   });
 
-  it("serves the stalest repo (not the successor of the last-claimed one) when the last-claimed repo is not itself the stalest", () => {
+  it("advances to the successor of the last-claimed repo even when older repos remain pending", () => {
     const candidates = [
       { repo: "owner/a", oldestPendingAgeMs: 5000 },
       { repo: "owner/b", oldestPendingAgeMs: 3000 },
       { repo: "owner/c", oldestPendingAgeMs: 1000 },
     ];
-    // sorted stalest-first: a(5000), b(3000), c(1000). Last-claimed b was NOT the stalest, so the stalest (a)
-    // was not just served and must be served now — rotation only applies when the stalest itself was last served.
-    expect(pickBacklogRepo(candidates, "owner/b")).toBe("owner/a");
+    // sorted stalest-first: a(5000), b(3000), c(1000) — last-claimed b -> rotate to c.
+    expect(pickBacklogRepo(candidates, "owner/b")).toBe("owner/c");
+  });
+
+  it("visits every repo under sustained backlog instead of alternating between the top two", () => {
+    const candidates = [
+      { repo: "owner/a", oldestPendingAgeMs: 5000 },
+      { repo: "owner/b", oldestPendingAgeMs: 3000 },
+      { repo: "owner/c", oldestPendingAgeMs: 1000 },
+    ];
+    const claimed: string[] = [];
+    let lastClaimedRepo: string | null = null;
+
+    for (let claim = 0; claim < 6; claim += 1) {
+      const repo = pickBacklogRepo(candidates, lastClaimedRepo);
+      expect(repo).not.toBeNull();
+      claimed.push(repo as string);
+      lastClaimedRepo = repo;
+    }
+
+    expect(claimed).toEqual(["owner/a", "owner/b", "owner/c", "owner/a", "owner/b", "owner/c"]);
   });
 
   it("re-serves the only candidate even when it was the last-claimed repo (nothing else to rotate to)", () => {


### PR DESCRIPTION
### Motivation
- The backlog repo picker regressed to only choosing the stalest or second-stalest repo, allowing sustained backlog in two repos to starve later candidates and breaking the documented per-repo round-robin behavior.
- Restore deterministic successor rotation so every candidate is eventually served under sustained backlog.

### Description
- Reimplemented `pickBacklogRepo` in `src/selfhost/queue-fairness.ts` to sort candidates stalest-first and return the successor of the `lastClaimedRepo` in that order (first-ever or drained `lastClaimedRepo` starts at the stalest).
- Replaced the previous conditional that toggled only between the stalest and second-stalest with a full successor-rotation modulo the candidate list.
- Updated and extended unit tests in `test/unit/selfhost-queue-fairness.test.ts` to assert the successor behavior and added a regression test that simulates repeated claims over three repos to verify no starvation occurs.

### Testing
- Ran `npx vitest run test/unit/selfhost-queue-fairness.test.ts` and the targeted unit test file passed (32 tests).
- Ran `npm run test:coverage -- --run test/unit/selfhost-queue-fairness.test.ts`; the targeted tests passed but the global coverage threshold check failed when evaluated against the repository-wide coverage policy.
- Attempted `npm run test:ci` and `npm audit --audit-level=moderate`; both were blocked by repository/environment issues (stale generated UI artifact and registry audit endpoint), so full CI could not be completed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4958813070832ca1bb87c589e1d050)