### PR TITLE
fix(review): avoid caching unresolved CI requirements

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -2541,6 +2541,7 @@ export async function fetchRequiredStatusContexts(
   baseRef: string | null | undefined,
   token: string | undefined,
   admissionKey?: GitHubRateLimitAdmissionKey,
+  onFetchFailure: (error: unknown) => void = () => undefined,
 ): Promise<Set<string> | null> {
   if (!baseRef) return null;
   const result = await githubJsonWithHeaders<{ contexts?: Array<string | null> | null; checks?: Array<{ context?: string | null }> | null }>(
@@ -2551,6 +2552,7 @@ export async function fetchRequiredStatusContexts(
     githubRateLimitOptions(admissionKey),
   ).catch((error) => {
     recordBranchProtectionFetchFailure(error);
+    onFetchFailure(error);
     return undefined;
   });
   if (!result) return null; // 404 / 403 (no admin:read) / error → conservative fold-all.

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -477,8 +477,10 @@ const PR_PUBLIC_SURFACE_ACTIONS = new Set([
 const PR_GATE_CLOSED_ACTIONS = new Set(["closed"]);
 const ISSUE_PLAN_COOLDOWN_MS = 10 * 60 * 1000;
 
+type RequiredStatusContextsLookup = { requiredContexts: Set<string> | null; resolved: boolean };
+
 interface LiveGithubFacts {
-  requiredContexts: Map<string, Promise<Set<string> | null>>;
+  requiredContexts: Map<string, Promise<RequiredStatusContextsLookup>>;
   ciAggregates: Map<string, Promise<LiveCiAggregate>>;
   mergeStates: Map<string, Promise<string | undefined>>;
 }
@@ -559,16 +561,20 @@ function cachedRequiredStatusContexts(
   token: string | undefined,
   expectedCiContexts: ReadonlyArray<string> | null | undefined,
   admissionKey?: GitHubRateLimitAdmissionKey,
-): Promise<Set<string> | null> {
+): Promise<RequiredStatusContextsLookup> {
   const key = liveFactKey(repoFullName, baseRef, liveFactTokenPart(token), expectedCiContextsKeyPart(expectedCiContexts));
   const cached = facts.requiredContexts.get(key);
   if (cached) return cached;
+  let branchProtectionFetchFailed = false;
   const next = evictLiveFactOnReject(
     facts.requiredContexts,
     key,
-    fetchRequiredStatusContexts(env, repoFullName, baseRef, token, admissionKey).then((branchProtectionContexts) =>
-      mergeRequiredCiContexts(branchProtectionContexts, expectedCiContexts),
-    ),
+    fetchRequiredStatusContexts(env, repoFullName, baseRef, token, admissionKey, () => {
+      branchProtectionFetchFailed = true;
+    }).then((branchProtectionContexts) => ({
+      requiredContexts: mergeRequiredCiContexts(branchProtectionContexts, expectedCiContexts),
+      resolved: !branchProtectionFetchFailed,
+    })),
   );
   facts.requiredContexts.set(key, next);
   return next;
@@ -660,7 +666,6 @@ function fetchLiveCiAggregateWithRequiredContexts(
   // cachedFetchLiveCiAggregate (#selfhost-ci-verification) is the durable, cross-job snapshot cache sibling to
   // this request-scoped LiveGithubFacts memo -- it is only ever consulted here, on a LiveGithubFacts miss.
   return cachedRequiredStatusContexts(env, repoFullName, facts, baseRef, token, expectedCiContexts, admissionKey)
-    .then((requiredContexts) => ({ requiredContexts, resolved: true }))
     .catch(() => ({ requiredContexts: null, resolved: false }))
     .then(({ requiredContexts, resolved }) =>
       cachedFetchLiveCiAggregate(env, repoFullName, prNumber, headSha, token, requiredContexts, resolvedRequiredContextsKeyPart(requiredContexts), forceRefresh, resolved, admissionKey),
@@ -2199,7 +2204,7 @@ async function runAgentMaintenancePlanAndExecute(
   const hardGuardrailGlobs = resolveHardGuardrailGlobs(settings);
   const [
     changedFiles,
-    requiredContexts,
+    requiredContextsLookup,
     liveMergeState,
     liveReviewDecision,
   ] = await Promise.all([
@@ -2228,6 +2233,7 @@ async function runAgentMaintenancePlanAndExecute(
     // is not re-reviewed for the same state.
     fetchLivePullRequestReviewDecision(env, repoFullName, pr.number, token, admissionKey),
   ]);
+  const requiredContexts = requiredContextsLookup.requiredContexts;
   const ciAggregate = await refreshLiveCiAggregate(
     env,
     repoFullName,

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -1923,9 +1923,8 @@ describe("queue processors", () => {
       }
     });
 
-    it("REGRESSION (#selfhost-ci-verification gate review): a required-context lookup failure never writes the fail-open aggregate through to the durable cache", async () => {
+    it("REGRESSION (#selfhost-ci-verification gate review): a swallowed branch-protection read failure never writes the fail-open aggregate through to the durable cache", async () => {
       const { env } = await seedRepoAndPr("a7");
-      const requiredContextsSpy = vi.spyOn(backfillModule, "fetchRequiredStatusContexts").mockRejectedValue(new Error("branch protection unavailable"));
       const liveCiSpy = vi.spyOn(backfillModule, "fetchLiveCiAggregatePreferGraphQl").mockResolvedValue({
         ciState: "passed",
         hasPending: false,
@@ -1935,9 +1934,13 @@ describe("queue processors", () => {
         nonRequiredFailingDetails: [],
         ciCompletenessWarning: null,
       });
+      let branchProtectionReadable = false;
       vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
         const url = input.toString();
         const method = (init?.method ?? "GET").toUpperCase();
+        if (url.includes("/branches/main/protection/required_status_checks")) {
+          return branchProtectionReadable ? Response.json({ contexts: ["trusted-required-ci"], checks: [] }) : new Response("forbidden", { status: 403 });
+        }
         if (url === "https://api.gittensor.io/miners") return Response.json([]);
         if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
         if (/\/pulls\/7(?:\?|$)/.test(url) && method === "GET") return Response.json({ number: 7, title: "Cross-job CI cache", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, mergeable_state: "clean", labels: [], body: "Closes #1" });
@@ -1952,8 +1955,8 @@ describe("queue processors", () => {
         await expect(
           processJob(env, { type: "agent-regate-pr", deliveryId: "required-contexts-lookup-fails", repoFullName: "owner/agent-repo", prNumber: 7, installationId: 9001 }),
         ).resolves.toBeUndefined();
-        expect(requiredContextsSpy).toHaveBeenCalled();
-        expect(liveCiSpy).toHaveBeenCalled();
+        const liveReadsAfterFailedLookup = liveCiSpy.mock.calls.length;
+        expect(liveReadsAfterFailedLookup).toBeGreaterThan(0);
 
         // Nothing was ever persisted under this PR's row -- ciState stays absent, not the fail-open "passed".
         const row = await getPullRequestDetailSyncState(env, "owner/agent-repo", 7);
@@ -1961,14 +1964,14 @@ describe("queue processors", () => {
 
         // A subsequent pass (required-context lookup now succeeds) still correctly misses the cache and re-fetches
         // live -- proving the earlier failed pass left no stale/poisoned entry behind for this reader either.
-        requiredContextsSpy.mockResolvedValue(null);
+        branchProtectionReadable = true;
         resetMetrics();
         await processJob(env, { type: "agent-regate-pr", deliveryId: "required-contexts-lookup-recovers", repoFullName: "owner/agent-repo", prNumber: 7, installationId: 9001 });
+        expect(liveCiSpy.mock.calls.length).toBeGreaterThan(liveReadsAfterFailedLookup);
         expect(await renderMetrics()).toContain('gittensory_ci_state_cache_total{field="aggregate",result="miss"} 1');
-        expect(await getPullRequestDetailSyncState(env, "owner/agent-repo", 7)).toMatchObject({ ciState: "passed" });
+        expect(await getPullRequestDetailSyncState(env, "owner/agent-repo", 7)).toMatchObject({ ciState: "passed", ciRequiredContextsKey: "trusted-required-ci" });
       } finally {
         liveCiSpy.mockRestore();
-        requiredContextsSpy.mockRestore();
       }
     });
 


### PR DESCRIPTION
### Motivation

- Prevent durable CI-state cache poisoning when a branch-protection required-context lookup fails but is swallowed as a `null` result, which could allow a fail-open CI aggregate to be persisted and reused until TTL expiry. 

### Description

- Add an optional failure callback `onFetchFailure` to `fetchRequiredStatusContexts` so callers can observe when the branch-protection REST read errored versus legitimately returning no required contexts (`src/github/backfill.ts`).
- Change the request-scoped required-context memo to return both the merged `requiredContexts` and a `resolved` flag (`RequiredStatusContextsLookup`) so callers can tell whether branch-protection was readable (`src/queue/processors.ts`).
- Thread the `resolved` signal into the durable CI-state cache path so `cachedFetchLiveCiAggregate` skips write-throughs when the required-context lookup was unreadable while still returning the live aggregate for the current pass (`src/queue/processors.ts`).
- Update the maintenance planner callsite to consume the new lookup wrapper without changing planner inputs, and strengthen the regression test to exercise the real swallowed 403 branch-protection path rather than only mocking a rejected helper (`src/queue/processors.ts`, `test/unit/queue.test.ts`).

### Testing

- Ran typecheck with `npm run typecheck -- --pretty false`, which succeeded.
- Ran targeted unit tests: `npx vitest run test/unit/queue.test.ts -t "swallowed branch-protection read failure"`, `npx vitest run test/unit/backfill.test.ts -t "fetchRequiredStatusContexts"`, and `npx vitest run test/unit/queue.test.ts -t "durable CI-state snapshot cache"`, and the targeted suites passed.
- Verified `git diff --check` produced no issues.
- Attempted the full gate with `npm run test:ci`, but the run encountered unrelated long-running/backfill queue tests and was terminated before completion; no failures attributable to this change were observed in the targeted unit suites.
- Attempted `npm audit --audit-level=moderate`, but the npm registry audit endpoint returned `403 Forbidden` so the audit could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4953509210832cbfd24323ce03257e)