### PR TITLE
fix(enrichment): detect lowercase Dockerfile instructions

### DIFF
--- a/review-enrichment/src/analyzers/iac-misconfig.ts
+++ b/review-enrichment/src/analyzers/iac-misconfig.ts
@@ -49,23 +49,23 @@ const IMDS_V1_RE = /\bhttp_tokens\b[\s"'=:,-]*["']?optional\b/i;
 // (`chmod 1777`) does not match because the value must begin at the optional `0` then `777`.
 const WORLD_WRITABLE_RE = /\b(?:chmod\s+|(?:file_)?mode[\s"'=:,-]*["']?)0?777\b/i;
 
-// Dockerfile build-security hardening (hadolint / checkov CKV_DOCKER_*). The uppercase instruction keywords
-// (ADD/FROM/USER/EXPOSE) are Dockerfile-specific, so they do not fire on lowercase YAML/JSON keys; the
-// flag/shell shapes are risky in any build/config file the path gate already admits.
-const DOCKER_ADD_REMOTE_RE = /\bADD\s+(?:--\S+\s+)*https?:\/\/\S/;
-const DOCKER_LATEST_TAG_RE = /\bFROM\s+(?:--\S+\s+)*\S+:latest\b/;
-const DOCKER_ROOT_USER_RE = /\bUSER\s+(?:root|0)\b/;
+// Dockerfile build-security hardening (hadolint / checkov CKV_DOCKER_*). Dockerfile instruction
+// keywords are case-insensitive, so match ADD/FROM/USER/EXPOSE/RUN without relying on casing.
+// The flag/shell shapes are risky in any build/config file the path gate already admits.
+const DOCKER_ADD_REMOTE_RE = /\bADD\s+(?:--\S+\s+)*https?:\/\/\S/i;
+const DOCKER_LATEST_TAG_RE = /\bFROM\s+(?:--\S+\s+)*\S+:latest\b/i;
+const DOCKER_ROOT_USER_RE = /\bUSER\s+(?:root|0)\b/i;
 // A remote download piped straight into a shell — the classic `curl … | sh` run-remote-code-at-build shape.
 const REMOTE_SHELL_PIPE_RE =
   /\b(?:curl|wget)\b[^\n]*?\|\s*(?:sudo\s+)?(?:bash|zsh|ksh|dash|ash|sh)\b/;
 // Build flags that disable download / TLS certificate verification (wget/apt/curl/pip).
 const INSECURE_DOWNLOAD_FLAG_RE =
   /--(?:no-check-certificate|allow-unauthenticated|force-yes|trusted-host)\b/;
-const SSH_PORT_EXPOSED_RE = /\bEXPOSE\s+(?:\d+(?:\/\w+)?\s+)*22(?:\/tcp)?\b/;
+const SSH_PORT_EXPOSED_RE = /\bEXPOSE\s+(?:\d+(?:\/\w+)?\s+)*22(?:\/tcp)?\b/i;
 const NPM_UNSAFE_PERM_RE = /--unsafe-perm\b/;
 // `sudo` invoked inside a RUN layer (privilege elevation during build). `RUN apt-get install sudo` does NOT
 // match because sudo does not immediately follow `RUN`/`&&`.
-const SUDO_IN_BUILD_RE = /\bRUN\s+sudo\s|&&\s*sudo\s/;
+const SUDO_IN_BUILD_RE = /\bRUN\s+sudo\s|&&\s*sudo\s/i;
 // A credential-shaped value hardcoded into an image layer via ENV/ARG WITH a value (build secrets persist in
 // the image history). A bare `ARG DB_PASSWORD` (no `=value`) is a legitimate build-arg declaration and is skipped.
 const HARDCODED_BUILD_SECRET_RE =

--- a/review-enrichment/test/iac-misconfig.test.ts
+++ b/review-enrichment/test/iac-misconfig.test.ts
@@ -301,6 +301,30 @@ test("scanPatchForIacMisconfig flags insecure Dockerfile build instructions", ()
   }
 });
 
+test("scanPatchForIacMisconfig treats Dockerfile instruction keywords case-insensitively", () => {
+  // Dockerfile instructions are case-insensitive, so lowercase instructions must not bypass
+  // the build-hardening findings that the uppercase forms already produce.
+  const cases = [
+    ["+add https://example.com/app.tar.gz /app/", "docker-add-remote-url"],
+    ["+from node:latest", "docker-image-latest-tag"],
+    ["+user root", "docker-root-user"],
+    ["+expose 22", "ssh-port-exposed"],
+    ["+run sudo apt-get update", "sudo-in-build"],
+  ];
+
+  for (const [added, kind] of cases) {
+    const findings = scanPatchForIacMisconfig(
+      "Dockerfile",
+      ["@@ -1,0 +1,1 @@", added].join("\n"),
+    );
+    assert.deepEqual(
+      findings,
+      [{ file: "Dockerfile", line: 1, kind }],
+      `${kind}: expected lowercase Dockerfile instruction to be detected, got ${JSON.stringify(findings)}`,
+    );
+  }
+});
+
 test("scanPatchForIacMisconfig does not flag the safe counterpart of each Dockerfile instruction", () => {
   // Safe/near-miss forms: a local ADD source, a pinned image tag, a non-root user (incl. a non-zero uid), a
   // curl without a shell pipe, a wget without the insecure flag, a non-SSH port (incl. 2222), npm without


### PR DESCRIPTION
### Motivation
- Prevent a scanner bypass where Dockerfile instruction checks only matched uppercase keywords and allowed semantically-equivalent lowercase instructions to evade IaC misconfiguration findings.

### Description
- Make Dockerfile instruction regexes case-insensitive by adding the `/i` flag to `DOCKER_ADD_REMOTE_RE`, `DOCKER_LATEST_TAG_RE`, `DOCKER_ROOT_USER_RE`, `SSH_PORT_EXPOSED_RE`, and `SUDO_IN_BUILD_RE` in `review-enrichment/src/analyzers/iac-misconfig.ts`.
- Add a regression test `scanPatchForIacMisconfig treats Dockerfile instruction keywords case-insensitively` to `review-enrichment/test/iac-misconfig.test.ts` that verifies lowercase `add/from/user/expose/run` lines produce the same findings as uppercase equivalents.
- Preserve existing behavior for safe/near-miss patterns and do not change public interfaces or outputs beyond fixing detection correctness.

### Testing
- Ran `npm test` in `review-enrichment/`, and the test suite passed with the new regression test included.
- Ran `git diff --check` with no issues reported.
- Attempted `npm run test:ci`, but execution was blocked by a stale generated file `apps/gittensory-ui/src/lib/selfhost-env-reference.ts` (pre-existing repository state), so the full CI gate was not completed locally.
- `npm audit --audit-level=moderate` could not complete due to the registry audit endpoint returning `403`, so the dependency-review step was not finished locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4957813198832c865dca947672d69a)