### PR TITLE
feat(enrichment): detect webhook-URL and CI/CD credential formats in secret-scan

### DIFF
--- a/review-enrichment/src/analyzers/secret-scan.ts
+++ b/review-enrichment/src/analyzers/secret-scan.ts
@@ -357,6 +357,84 @@ const RULES: Rule[] = [
     confidence: "high",
   },
   {
+    // Discord webhook URL: discord.com/api/webhooks/<id>/<token>. Base64url token, lookahead terminator.
+    kind: "discord_webhook_url",
+    re: /\bhttps:\/\/(?:ptb\.|canary\.)?discord(?:app)?\.com\/api\/webhooks\/\d{17,20}\/[A-Za-z0-9_-]{60,}(?![A-Za-z0-9_-])/,
+    confidence: "high",
+  },
+  {
+    // Microsoft Teams incoming-webhook URL (webhook.office.com): a postable message-egress secret endpoint.
+    kind: "teams_webhook_url",
+    re: /\bhttps:\/\/[a-z0-9-]+\.webhook\.office\.com\/webhookb2\/[A-Za-z0-9@-]+\/IncomingWebhook\/[A-Za-z0-9]+\/[A-Za-z0-9-]+/,
+    confidence: "high",
+  },
+  {
+    // Figma personal access token: `figd_` + >=40 base64url (lookahead terminator).
+    kind: "figma_pat",
+    re: /\bfigd_[A-Za-z0-9_-]{40,}(?![A-Za-z0-9_-])/,
+    confidence: "high",
+  },
+  {
+    // Docker Hub personal access token: `dckr_pat_` + 27 base64url (lookahead terminator).
+    kind: "dockerhub_pat",
+    re: /\bdckr_pat_[A-Za-z0-9_-]{27}(?![A-Za-z0-9_-])/,
+    confidence: "high",
+  },
+  {
+    // GitLab feed token: `glft-` + 20 hex.
+    kind: "gitlab_feed_token",
+    re: /\bglft-[0-9a-f]{20}\b/,
+    confidence: "high",
+  },
+  {
+    // GitLab deploy token: `gldt-` + 20 base64url (lookahead terminator).
+    kind: "gitlab_deploy_token",
+    re: /\bgldt-[A-Za-z0-9_-]{20}(?![A-Za-z0-9_-])/,
+    confidence: "high",
+  },
+  {
+    // Razorpay key id/secret: `rzp_test_`/`rzp_live_` + 14 base62.
+    kind: "razorpay_key",
+    re: /\brzp_(?:test|live)_[A-Za-z0-9]{14}\b/,
+    confidence: "high",
+  },
+  {
+    // Supabase access token: `sbp_` + 40 hex.
+    kind: "supabase_token",
+    re: /\bsbp_[a-f0-9]{40}\b/,
+    confidence: "high",
+  },
+  {
+    // Cloudinary URL: `cloudinary://<api-key>:<api-secret>@<cloud>` — the secret is embedded in the URL.
+    kind: "cloudinary_url",
+    re: /\bcloudinary:\/\/\d{15}:[A-Za-z0-9_-]{20,}@[A-Za-z0-9_-]+/,
+    confidence: "high",
+  },
+  {
+    // Brevo (Sendinblue) API key: `xkeysib-` + 64 hex + `-` + 16 base62.
+    kind: "brevo_api_key",
+    re: /\bxkeysib-[a-f0-9]{64}-[A-Za-z0-9]{16}\b/,
+    confidence: "high",
+  },
+  {
+    // Buildkite agent token: `bkua_` + 40 lowercase-hex/base36.
+    kind: "buildkite_token",
+    re: /\bbkua_[a-z0-9]{40}\b/,
+    confidence: "high",
+  },
+  {
+    // NuGet API key: `oy2` + 43 lowercase base36.
+    kind: "nuget_api_key",
+    re: /\boy2[a-z0-9]{43}\b/,
+    confidence: "high",
+  },
+  {
+    // HubSpot private-app access token: `pat-na1-`/`pat-eu1-` + a UUID (distinct from the Airtable `pat<id>.` shape).
+    kind: "hubspot_pat",
+    re: /\bpat-(?:na|eu)1-[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}\b/,
+    confidence: "high",
+  },
+  {
     kind: "private_key",
     re: /-----BEGIN (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----/,
     confidence: "high",

--- a/review-enrichment/test/secret-scan.test.ts
+++ b/review-enrichment/test/secret-scan.test.ts
@@ -487,3 +487,46 @@ test("scanPatch does not flag near-miss variants of the new AI/SaaS credential f
     assert.equal(findings.length, 0, `near-miss should not match: ${nm}`);
   }
 });
+
+test("scanPatch flags webhook-URL, CI/CD, and payment/SaaS credential formats", () => {
+  // base64url-body formats deliberately END IN `-` to prove the rule terminates on a negative-lookahead, not `\b`.
+  const cases = [
+    ["discord_webhook_url", "https://discord.com/api/webhooks/123456789012345678/" + b62(69) + "-"],
+    ["teams_webhook_url", "https://acme.webhook.office.com/webhookb2/" + b62(20) + "@" + b62(20) + "/IncomingWebhook/" + b62(32) + "/" + b62(20)],
+    ["figma_pat", "figd_" + b62(42) + "-"],
+    ["dockerhub_pat", "dckr_pat_" + b62(26) + "-"],
+    ["gitlab_feed_token", "glft-" + hex(20)],
+    ["gitlab_deploy_token", "gldt-" + b62(19) + "-"],
+    ["razorpay_key", "rzp_test_" + b62(14)],
+    ["supabase_token", "sbp_" + hex(40)],
+    ["cloudinary_url", "cloudinary://123456789012345:" + b62(25) + "@mycloud"],
+    ["brevo_api_key", "xkeysib-" + hex(64) + "-" + b62(16)],
+    ["buildkite_token", "bkua_" + hex(40)],
+    ["nuget_api_key", "oy2" + hex(43)],
+    ["hubspot_pat", "pat-na1-" + hex(8) + "-" + hex(4) + "-" + hex(4) + "-" + hex(4) + "-" + hex(12)],
+  ];
+  for (const [kind, secret] of cases) {
+    const findings = scanPatch("src/config.ts", hunk([`const c = "${secret}";`]));
+    assert.equal(findings.length, 1, `${kind}: expected exactly one finding, got ${JSON.stringify(findings)}`);
+    assert.equal(findings[0].kind, kind, `${kind}: wrong kind`);
+    assert.equal(findings[0].confidence, "high", `${kind}: wrong confidence`);
+  }
+});
+
+test("scanPatch does not flag near-miss variants of the webhook/CI/SaaS formats", () => {
+  const nearMisses = [
+    "figd_" + b62(39),
+    "dckr_pat_" + b62(26),
+    "gldt-" + b62(19),
+    "glft-" + hex(19),
+    "sbp_" + hex(39),
+    "bkua_" + hex(39),
+    "oy2" + hex(42),
+    "rzp_test_" + b62(13),
+    "xkeysib-" + hex(63) + "-" + b62(16),
+  ];
+  for (const nm of nearMisses) {
+    const findings = scanPatch("src/config.ts", hunk([`const c = "${nm}";`]));
+    assert.equal(findings.length, 0, `near-miss should not match: ${nm}`);
+  }
+});


### PR DESCRIPTION
## Summary

The secret-scan analyzer (`review-enrichment/src/analyzers/secret-scan.ts`) flags credentials committed in a
PR diff, citing `file:line` + kind only (never the value). This adds **13 more credential formats** the scanner
currently misses — postable **webhook URLs**, **CI/CD** tokens, and **payment / SaaS** keys — continuing the
established `feat(enrichment)` secret-format additions.

Each new rule is a high-confidence, gitleaks/trufflehog-standard shape with a **distinctive literal prefix (or
host/URL structure) and a fixed or tightly-bounded length + charset**, so the false-positive rate against
ordinary source, base64 blobs, hex hashes, and UUIDs is effectively zero:

| kind | shape |
|---|---|
| `discord_webhook_url` | `discord.com/api/webhooks/<id>/<token>` |
| `teams_webhook_url` | `<tenant>.webhook.office.com/webhookb2/…` |
| `figma_pat` | `figd_` + ≥40 base64url |
| `dockerhub_pat` | `dckr_pat_` + 27 base64url |
| `gitlab_feed_token` | `glft-` + 20 hex |
| `gitlab_deploy_token` | `gldt-` + 20 base64url |
| `razorpay_key` | `rzp_{test,live}_` + 14 base62 |
| `supabase_token` | `sbp_` + 40 hex |
| `cloudinary_url` | `cloudinary://<key>:<secret>@<cloud>` |
| `brevo_api_key` | `xkeysib-` + 64 hex + `-` + 16 base62 |
| `buildkite_token` | `bkua_` + 40 base36 |
| `nuget_api_key` | `oy2` + 43 base36 |
| `hubspot_pat` | `pat-{na,eu}1-` + UUID |

Terminators are chosen for correctness: rules whose body is hex/base62 (word characters) end on `\b`, while
rules whose body is **base64url** (which can legitimately end in `-`, a non-word char) end on a negative
lookahead `(?![A-Za-z0-9_-])` — the same terminator the existing SendGrid/Anthropic/Square rules use — so a
real token ending in `-` is not missed. The tests exercise this: the base64url fixtures deliberately end in
`-` (failing a `\b` terminator, passing the lookahead), and a near-miss case asserts one-char-short tokens
produce no finding.

No existing rule is modified, so current findings are unchanged, and no analyzer descriptor changes (the
finding schema is unchanged) — so `analyzer-metadata.json` and the generated UI mirror are untouched.

No linked issue: additive detection-coverage for well-known credential formats, matching the established
`feat(enrichment)` secret-format additions; each rule is a self-evident real token shape with no public
API/schema/deploy surface change — fits the repo's `preferred` (not required) linked-issue policy.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run typecheck`
- [x] `npm run rees:test` — the review-enrichment build + analyzer suite (see note below)
- [ ] `npm run test:coverage` (N/A — this file is in `review-enrichment/`, outside the root `src/**` Codecov scope)
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran locally: `git diff --check` (clean), the review-enrichment TypeScript build (exit 0), and the secret-scan
  analyzer test via `node --test` — **46/46 pass**, including a table case that flags each of the 13 formats at
  high confidence (the base64url fixtures end in `-` to guard the lookahead terminators) plus a near-miss case
  asserting one-char-short tokens produce no finding. All fixtures are assembled from string fragments so the
  test file never contains a contiguous secret literal. The change is confined to `review-enrichment/`, outside
  the `src/**` Codecov scope.
- Not run locally: the UI, root typecheck, and the `metadata:check` step of `rees:test`. This change only adds
  scan rules, not any analyzer descriptor, so the committed `analyzer-metadata.json`/UI mirror are unchanged (a
  local regeneration produces a zero-content diff) and `metadata:check` passes on CI (Linux). On this Windows
  dev box `metadata:check` reports a spurious line-ending difference; it fails identically on unmodified
  `main`. `analyzer-metadata.json` was NOT modified.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Detection-only additions: 13 new high-confidence rules; no existing rule, threshold, or descriptor changed,
  so current findings and `analyzer-metadata.json` are unaffected. The scanner still returns only `file:line` +
  `kind`, never the matched secret value.
- `hubspot_pat` matches `pat-na1-`/`pat-eu1-` + a UUID, which is disjoint from the existing `airtable_pat`
  (`pat` + 14 base62 + `.` + 64 hex) shape, so the two never collide.
