### PR TITLE
docs(selfhost): align release upgrade/rollback docs with deploy scripts

### DIFF
--- a/apps/gittensory-ui/src/routes/docs.self-hosting-releases.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-releases.tsx
@@ -82,18 +82,35 @@ docker pull ghcr.io/jsonbored/gittensory-selfhost:latest`}
       <ol>
         <li>Read release notes for env, migration, or behavior changes.</li>
         <li>Back up the database or confirm Litestream health.</li>
-        <li>Pull the new image tag.</li>
-        <li>Recreate the app container.</li>
+        <li>
+          Pull and restart with <code>scripts/deploy-selfhost-image.sh</code> (or rebuild the
+          checkout with <code>scripts/deploy-selfhost-prebuilt.sh</code>) — both restart only the{" "}
+          <code>gittensory</code> service (<code>--no-deps</code>) and wait for it to report{" "}
+          <code>healthy</code> before returning, instead of a bare <code>docker compose up -d</code>{" "}
+          that returns as soon as the container starts.
+        </li>
         <li>
           Check <code>/ready</code>, logs, queue metrics, and one test PR.
         </li>
       </ol>
       <CodeBlock
         lang="bash"
-        code={`docker compose pull gittensory
-docker compose up -d gittensory
-curl http://localhost:8787/ready`}
+        code={`# Recommended: pull a published tag, restart, wait for healthy
+./scripts/deploy-selfhost-image.sh ghcr.io/jsonbored/gittensory-selfhost:orb-v0.1.0
+curl http://localhost:8787/ready
+
+# Building from the current checkout instead of pulling
+./scripts/deploy-selfhost-prebuilt.sh`}
       />
+      <Callout variant="note">
+        Both scripts pin a version: the image script accepts a tag/digest argument or{" "}
+        <code>GITTENSORY_IMAGE</code>; the prebuilt script derives <code>SENTRY_RELEASE</code>/
+        <code>GITTENSORY_VERSION</code> from the checked-out commit (
+        <code>git rev-parse --short=8 HEAD</code>) unless you set <code>SENTRY_RELEASE</code>{" "}
+        yourself. A plain{" "}
+        <code>docker compose pull gittensory &amp;&amp; docker compose up -d gittensory</code> still
+        works, but skips the health-check wait loop and input validation both scripts provide.
+      </Callout>
 
       <h2>Custom images</h2>
       <p>
@@ -118,10 +135,20 @@ docker compose up -d gittensory`}
 
       <h2>Rollback</h2>
       <p>
-        Roll back by pinning the prior image tag and recreating the container. Database migrations
-        can make rollback harder, so keep backups and read release notes before upgrading a live
-        maintainer instance.
+        There is no dedicated rollback command. Roll back by re-running{" "}
+        <code>scripts/deploy-selfhost-image.sh</code> pinned to the prior image tag or digest (or{" "}
+        <code>scripts/deploy-selfhost-prebuilt.sh</code> against an older checkout) — the same
+        script you upgrade with, pointed backward.
       </p>
+      <Callout variant="warn" title="Migrations are forward-only">
+        This repo has no down-migration convention (<code>scripts/check-migrations.mjs</code> and{" "}
+        <code>migrations/</code> only ever add forward). If a migration already ran forward before
+        you need to roll back, reverting the app image does not revert the schema — the rolled-back
+        code now runs against a newer schema than it expects. Keep backups and read release notes
+        for migration changes before upgrading a live maintainer instance, and treat a
+        post-migration rollback as a case that needs a manual schema/data plan, not just an image
+        swap.
+      </Callout>
     </DocsPage>
   );
 }


### PR DESCRIPTION
## Summary

- Advances #1829 (docs(selfhost): audit website docs against runtime defaults). This is a scoped,
  honest slice of that issue, not the full audit — see "What remains" below.
- Systematically diffed every `apps/gittensory-ui/src/routes/docs.self-hosting-*.tsx` page (excluding
  `docs.self-hosting-rees-analyzers.tsx`, tracked separately per the issue) against
  `docker-compose.yml`, `.env.example`, `.env.selfhost.example`, `Dockerfile`,
  `.github/workflows/release-selfhost.yml`, `.github/workflows/selfhost.yml`,
  `scripts/deploy-selfhost-image.sh`, and `scripts/deploy-selfhost-prebuilt.sh`. For every env var,
  confirmed its stated default/behavior against `.env.example`'s actual default and the exact
  `process.env.NAME` read site in `src/`. For every compose service/profile mentioned, confirmed it
  still exists with the same name/behavior. For every release/deploy claim, confirmed it matches the
  actual workflow steps and the two deploy scripts.
- Result: 11 of 12 in-scope pages were already accurate against current runtime defaults (this repo
  already has `scripts/check-docs-drift.mjs` from #3059/#3047 catching flag/command/gate-field drift,
  and it's working). One confirmed, real gap found and fixed in `docs.self-hosting-releases.tsx`.

## Docs accuracy checklist (drift found and fixed)

| # | Location | Before | After |
|---|---|---|---|
| 1 | `docs.self-hosting-releases.tsx` — "Upgrade flow" | Told operators to run raw `docker compose pull gittensory && docker compose up -d gittensory`, which returns as soon as the container starts | Points at the actual `scripts/deploy-selfhost-image.sh` (pull + `--no-deps` restart + health-check wait loop + input validation) and `scripts/deploy-selfhost-prebuilt.sh` (build-from-checkout equivalent), matching what `docs.self-hosting-quickstart.tsx` already recommends for first boot; kept the raw compose command as a documented-but-inferior fallback |
| 2 | `docs.self-hosting-releases.tsx` — "Rollback" | "Roll back by pinning the prior image tag and recreating the container. Database migrations can make rollback harder..." — vague, and didn't name a mechanism | States plainly there is no dedicated rollback script/command (confirmed: neither deploy script nor any other script in `scripts/` implements one) and that rollback today means re-running `deploy-selfhost-image.sh`/`deploy-selfhost-prebuilt.sh` pointed at an older tag/checkout; added an explicit callout that migrations are forward-only (confirmed: no down-migration convention in `scripts/check-migrations.mjs` or `migrations/`), so a rollback after a forward migration leaves the schema ahead of the reverted code — a real, previously-undocumented risk |

## What remains for #1829

This PR only had one confirmed drift to fix — the other 11 self-hosting doc pages
(`ai-providers`, `backup-scaling`, `configuration`, `github-app`, `operations`, `quickstart`, `rag`,
`release-checklist`, `security`, `troubleshooting`, `maintainer-self-hosting`) checked out accurate
against current `docker-compose.yml` profiles/services, `.env.example` defaults, and the generated
`SELFHOST_ENV_REFERENCE_MARKDOWN` table (regenerated locally via `node
scripts/gen-selfhost-env-reference.mjs`; zero diff, so it's not stale either). I did not find
additional drift to fix in this pass. If the issue intends a broader net (e.g. extending
`check-docs-drift.mjs`'s automated coverage to catch this class of prose-vs-script drift going
forward, not just flag/command/gate-field drift), that is out of scope for this PR and would be a
good separate follow-up.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused: one docs page, two related sections (upgrade + rollback), no unrelated changes.
- [x] Follows `CONTRIBUTING.md`; no `site/`/`CNAME`/VitePress/Pages changes.
- [x] Advances #1829 (not a full close — see "What remains" above for why no closing keyword is used).

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` (N/A — no workflow files changed)
- [x] `npm run typecheck` — passes (ran via `npm run ui:typecheck`, the tsc project that covers this file; also confirmed the root install is current via `npm ci`)
- [ ] `npm run test:coverage` (N/A — no `src/**` lines changed; docs-only change under `apps/gittensory-ui/**`, which is not Codecov-scored)
- [ ] `npm run test:workers` (N/A — no worker code changed)
- [ ] `npm run build:mcp` (N/A — no MCP code changed)
- [ ] `npm run test:mcp-pack` (N/A — no MCP code changed)
- [ ] `npm run ui:openapi:check` (N/A — no API/schema changes)
- [x] `npm run ui:lint` — 0 errors (87 pre-existing `react-refresh/only-export-components` warnings unrelated to this file, same baseline as `main`)
- [x] `npm run ui:typecheck` — passes
- [x] `npm run ui:build` — succeeds
- [x] `npm run docs:drift-check` — passes (15 feature flags, 19 commands, 11 gate-mode fields all documented; this page isn't covered by that script's specific extractors, but ran it as a sanity check since it's the repo's docs-drift regression guard)
- [ ] `npm audit --audit-level=moderate` (not re-run standalone; `npm ci` during this session reported "found 0 vulnerabilities")
- [ ] New or changed behavior has unit/integration tests (N/A — prose-only change, no new code branches)

If any required check was skipped, explain why:

- This is a docs-only change (prose in one `.tsx` route file), so the backend-oriented checks
  (coverage/workers/mcp/openapi/actionlint) don't apply — matches the precedent in prior docs-only
  PRs on this repo (e.g. #2742, #3059).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed. All example values in the diff are pre-existing placeholders already in the file (`ghcr.io/jsonbored/gittensory-selfhost:orb-v0.1.0`, etc.) or references to script/file paths — no new example secrets were introduced.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no such change)
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP change)
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no data-fetching UI change, static docs prose only)
- [ ] Visible UI changes include a `UI Evidence` section... (N/A — no visual/layout/component change, text-only edit to existing prose sections; see UI Evidence section below)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs (`CHANGELOG.md` untouched, per house rule).

## UI Evidence

Not applicable — this changes prose text inside two existing `<h2>` sections (Upgrade flow,
Rollback) on an existing docs page. No layout, component, or visual change. Confirmed via
`npm run ui:build` that the route still builds; the rendered page structure (headings, callouts,
code blocks) is unchanged, only the text and one new `Callout` block inside the existing content
flow.

## Notes

- Live-system ground truth used to verify the rollback finding (from a separate read-only
  session against the production self-host deployment, not re-derived here): the live deployment
  runs `deploy-selfhost-prebuilt.sh` from a git checkout, and there is genuinely no rollback script
  in the repo today — this PR documents that gap honestly rather than implying a rollback command
  exists.