### PR TITLE
fix(selfhost): redact Orb broker enrollment tokens from telemetry

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -6034,7 +6034,7 @@ const PRODUCT_USAGE_SENSITIVE_VALUE =
 // Compose from the canonical scrubber in redaction.ts so this surface cannot drift from the boundary;
 // it already covered /root/ and /var/, and now unifies the Windows form (also accepts `C:/Users/`).
 const PRODUCT_USAGE_LOCAL_PATH = PUBLIC_LOCAL_PATH_SCRUB_PATTERN;
-const PRODUCT_USAGE_TOKEN_VALUE = /\b(?:ghp_|github_pat_|gts_|glpat-|sk-)[A-Za-z0-9_=-]{8,}/g;
+const PRODUCT_USAGE_TOKEN_VALUE = /\b(?:ghp_|github_pat_|gts_|orbenr_|orbsec_|glpat-|sk-)[A-Za-z0-9_=-]{8,}/g;
 const PRODUCT_USAGE_BEARER_VALUE = /\bBearer\s+[A-Za-z0-9._~+/=-]{12,}/gi;
 
 function sanitizeProductUsageMetadata(value: Record<string, unknown> | null | undefined, actorRedactor: ProductUsageActorRedactor | null): Record<string, JsonValue> {

--- a/src/selfhost/sentry.ts
+++ b/src/selfhost/sentry.ts
@@ -40,6 +40,11 @@ const SECRET_VALUE = new RegExp(
     String.raw`gh[opsru]_[A-Za-z0-9_]{20,}`,
     String.raw`sk-[A-Za-z0-9_-]{20,}`,
     String.raw`xox[baprs]-[A-Za-z0-9-]+`,
+    // Gittensory's own opaque tokens (createOpaqueToken, src/auth/security.ts): gts_ is the default session-token
+    // prefix, orbenr_/orbsec_ are the Orb broker's enrollment id/secret (#1825) — a broker error message can quote
+    // these bare (no "secret"/"token"-named field for the key-based redaction above to catch), so the VALUE itself
+    // must be recognized here too.
+    String.raw`(?:gts|orbenr|orbsec)_[A-Za-z0-9_]{20,}`,
     String.raw`Bearer\s+[A-Za-z0-9._~+/=-]{12,}`,
     String.raw`-----BEGIN [^-]+ PRIVATE KEY-----[\s\S]*?-----END [^-]+ PRIVATE KEY-----`,
   ].join("|"),

--- a/src/services/control-panel-roles.ts
+++ b/src/services/control-panel-roles.ts
@@ -292,7 +292,7 @@ function isMaintainerAssociation(value: string | null | undefined): boolean {
 export function sanitizeRoleText(value: string): string {
   const redacted = value
     .replace(PUBLIC_LOCAL_PATH_SCRUB_PATTERN, "<redacted-path>")
-    .replace(/\b(?:ghp_|github_pat_|gts_|glpat-|sk-)[A-Za-z0-9_=-]{8,}/g, "<redacted-token>")
+    .replace(/\b(?:ghp_|github_pat_|gts_|orbenr_|orbsec_|glpat-|sk-)[A-Za-z0-9_=-]{8,}/g, "<redacted-token>")
     .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]{12,}/gi, "Bearer <redacted-token>");
   if (/\b(seed phrase|mnemonic|private key|raw trust|trust score|wallet|hotkey|coldkey|payout|reward estimate|farming|private reviewability|public score estimate)\b/i.test(redacted)) return "<redacted>";
   return redacted.slice(0, 200);

--- a/src/services/miner-dashboard-recommendations.ts
+++ b/src/services/miner-dashboard-recommendations.ts
@@ -46,7 +46,7 @@ const FORBIDDEN_PUBLIC_TEXT =
 // Compose the roots from the canonical PUBLIC_LOCAL_PATH_INLINE in redaction.ts (so this surface cannot drift)
 // while preserving this surface's own trailing class and its case-sensitive `/g` (Windows form via `[A-Z]`).
 const LOCAL_PATH = new RegExp(`(?:${PUBLIC_LOCAL_PATH_INLINE})[^\\s,;:)]+`, "g");
-const FORBIDDEN_TOKEN = /\b(?:ghp_|github_pat_|gts_|glpat-|sk-)[A-Za-z0-9_=-]{8,}/g;
+const FORBIDDEN_TOKEN = /\b(?:ghp_|github_pat_|gts_|orbenr_|orbsec_|glpat-|sk-)[A-Za-z0-9_=-]{8,}/g;
 
 export function previousDecisionPackFromSnapshots(currentPack: ContributorDecisionPack, snapshots: SignalSnapshotRecord[]): ContributorDecisionPack | undefined {
   const current = asRecord(currentPack);

--- a/src/services/weekly-value-report.ts
+++ b/src/services/weekly-value-report.ts
@@ -411,7 +411,7 @@ function normalizeReportDays(value: number | null | undefined): number {
 function sanitizeReportText(value: string): string {
   const redacted = value
     .replace(PUBLIC_LOCAL_PATH_SCRUB_PATTERN, "<redacted-path>")
-    .replace(/\b(?:ghp_|github_pat_|gts_|glpat-|sk-|xox[baprs]-)[A-Za-z0-9_=-]{8,}/g, "<redacted-token>")
+    .replace(/\b(?:ghp_|github_pat_|gts_|orbenr_|orbsec_|glpat-|sk-|xox[baprs]-)[A-Za-z0-9_=-]{8,}/g, "<redacted-token>")
     .replace(/\bBearer\s+[A-Za-z0-9._~+/=-]{12,}/gi, "Bearer <redacted-token>");
   if (
     /\b(seed phrase|mnemonic|private key|raw[-\s]?trust|trust[-\s]?score|wallet|hotkey|coldkey|payout|reward(?:[-\s]?(?:estimate|prediction|claim|score|payout|risk))?|farming|private[-\s]?reviewability|private[-\s]?scoreability|scoreability|public[-\s]?score[-\s]?(?:estimate|prediction|claim)|score[-\s]?(?:estimate|prediction|preview))\b/i.test(

--- a/test/unit/miner-dashboard-recommendations.test.ts
+++ b/test/unit/miner-dashboard-recommendations.test.ts
@@ -340,6 +340,33 @@ describe("miner dashboard recommendation metadata", () => {
     expect(JSON.stringify(enriched?.rerunReasons)).not.toMatch(/\/root\/work|\/var\/log|C:\/Users\/alice|c:\\Users\\bob/);
   });
 
+  // Regression (#1825): the Orb broker's enrollment id/secret (createOpaqueToken("orbenr"/"orbsec"),
+  // src/orb/broker.ts) are bare opaque tokens with no "token"/"secret"-named field to trip elsewhere — the
+  // rerun-reason text scrubber must recognize the orbenr_/orbsec_ shape too, not just ghp_/github_pat_/gts_.
+  it("redacts orbenr_/orbsec_ Orb broker tokens from rerun reasons (#1825)", () => {
+    const fakeEnrollId = `orbenr_${"a".repeat(20)}`;
+    const fakeSecret = `orbsec_${"b".repeat(20)}`;
+    const current = decisionPack({
+      generatedAt: "2026-06-02T00:00:00.000Z",
+      topActions: [action()],
+      actionPortfolio: {
+        topActions: [
+          {
+            repoFullName: "JSONbored/gittensory",
+            actionKind: "open_new_direct_pr",
+            rerunWhen: `Rerun once the broker recovers from enrollment ${fakeEnrollId} secret ${fakeSecret}.`,
+          },
+        ],
+      },
+    });
+
+    const [enriched] = buildMinerDashboardNextActions(current);
+    const repoStateReasons = enriched?.rerunReasons.find((group) => group.group === "repo_state")?.reasons.join(" ") ?? "";
+    expect(repoStateReasons).toContain("private context");
+    expect(JSON.stringify(enriched?.rerunReasons)).not.toContain(fakeEnrollId);
+    expect(JSON.stringify(enriched?.rerunReasons)).not.toContain(fakeSecret);
+  });
+
   it("selects the previous ready decision-pack snapshot", () => {
     const current = decisionPack({ generatedAt: "2026-06-02T00:00:00.000Z" });
     const previous = decisionPack({ generatedAt: "2026-06-01T00:00:00.000Z" });

--- a/test/unit/policy-sanitizer.test.ts
+++ b/test/unit/policy-sanitizer.test.ts
@@ -163,6 +163,13 @@ describe("sanitizeRoleText token redaction", () => {
     expect(sanitizeRoleText("key glpat-abcdefghij1234")).toContain("<redacted-token>");
   });
 
+  // Regression (#1825): the Orb broker's enrollment id/secret (createOpaqueToken("orbenr"/"orbsec"),
+  // src/orb/broker.ts) must be redacted like any other opaque token when it appears bare in role text.
+  it("redacts orbenr_ and orbsec_ prefixed Orb broker tokens", () => {
+    expect(sanitizeRoleText(`enrollment orbenr_${"a".repeat(20)}`)).toContain("<redacted-token>");
+    expect(sanitizeRoleText(`secret orbsec_${"b".repeat(20)}`)).toContain("<redacted-token>");
+  });
+
   it("redacts Bearer authorization tokens", () => {
     const result = sanitizeRoleText("Authorization: Bearer eyJhbGciOiJSUzI1NiJ9.abc");
     expect(result).toBe("Authorization: Bearer <redacted-token>");

--- a/test/unit/product-usage.test.ts
+++ b/test/unit/product-usage.test.ts
@@ -201,6 +201,33 @@ describe("product usage events", () => {
     expect(JSON.stringify(row.metadata)).not.toMatch(/\/Users|\/root\/|\/var\/|github_pat|ghp_|source code|private patch|trustScore|wallet/i);
   });
 
+  // Regression (#1825): the Orb broker's enrollment id/secret (createOpaqueToken("orbenr"/"orbsec"),
+  // src/orb/broker.ts) are bare opaque tokens with no "token"/"secret"-named field to trip the key-based
+  // redaction above when they appear as a plain VALUE (e.g. quoted inside an error-message string embedded
+  // in metadata) — PRODUCT_USAGE_TOKEN_VALUE must recognize the orbenr_/orbsec_ shape too, or it survives
+  // into persisted telemetry verbatim.
+  it("redacts bare Orb broker enrollment id/secret values from persisted telemetry", async () => {
+    const env = createTestEnv({ PRODUCT_USAGE_HASH_SALT: "fixed-test-salt" });
+    const fakeEnrollId = `orbenr_${"a".repeat(64)}`;
+    const fakeSecret = `orbsec_${"b".repeat(64)}`;
+
+    await recordProductUsageEvent(env, {
+      surface: "internal",
+      eventName: "command_previewed",
+      actor: "oktofeesh1",
+      metadata: {
+        note: `broker exchange failed for enrollment ${fakeEnrollId} secret ${fakeSecret}`,
+      },
+    });
+
+    const [row] = await listProductUsageEvents(env);
+    expect(row).toBeDefined();
+    if (!row) throw new Error("expected product usage event");
+    expect(row.metadata).toMatchObject({ note: "broker exchange failed for enrollment <redacted-token> secret <redacted-token>" });
+    expect(JSON.stringify(row.metadata)).not.toContain(fakeEnrollId);
+    expect(JSON.stringify(row.metadata)).not.toContain(fakeSecret);
+  });
+
   it("persists normalized role on the event row and strips private scoreability metadata", async () => {
     const env = createTestEnv({ PRODUCT_USAGE_HASH_SALT: "fixed-test-salt" });
 

--- a/test/unit/selfhost-sentry.test.ts
+++ b/test/unit/selfhost-sentry.test.ts
@@ -258,6 +258,23 @@ describe("scrubEvent — redact secrets before an event leaves the box", () => {
     expect(ev.exception.values[0].stacktrace.frames[0].vars.safe).toBe("value");
   });
 
+  // Regression (#1825): the Orb broker's enrollment id/secret (createOpaqueToken("orbenr"/"orbsec"),
+  // src/orb/broker.ts) are bare opaque tokens with no "secret"/"token"-NAMED field for the key-based redaction
+  // to catch when a broker error message quotes one directly (e.g. an error string embedding the failed
+  // Authorization value) — the VALUE-based SECRET_VALUE pattern must recognize the orbenr_/orbsec_ shape too.
+  it("redacts a bare Orb enrollment id/secret value from an exception message (#1825)", () => {
+    const fakeEnrollId = `orbenr_${"c".repeat(64)}`;
+    const fakeSecret = `orbsec_${"d".repeat(64)}`;
+    const ev = scrubbedEvent({
+      exception: {
+        values: [{ value: `Orb broker rejected enrollment ${fakeEnrollId} using secret ${fakeSecret}` }],
+      },
+    }) as any;
+    expect(ev.exception.values[0].value).not.toContain(fakeEnrollId);
+    expect(ev.exception.values[0].value).not.toContain(fakeSecret);
+    expect(ev.exception.values[0].value).toBe("Orb broker rejected enrollment [redacted] using secret [redacted]");
+  });
+
   it("scrubs transaction span descriptions and data before sending transaction events", () => {
     const queryTokenKey = fakeQueryTokenKey();
     const ev = scrubbedEvent({

--- a/test/unit/weekly-value-report.test.ts
+++ b/test/unit/weekly-value-report.test.ts
@@ -243,6 +243,40 @@ describe("weekly value reports", () => {
     expect(JSON.stringify(report)).not.toMatch(new RegExp(slackToken.slice(0, 4), "i"));
   });
 
+  // Regression (#1825): the Orb broker's enrollment id/secret (createOpaqueToken("orbenr"/"orbsec"),
+  // src/orb/broker.ts) are bare opaque tokens that must be redacted the same way ghp_/gts_/xoxb- tokens are.
+  it("redacts Orb broker enrollment id/secret tokens in operator rollup dimensions (#1825)", () => {
+    const orbSecret = `orbsec_${"e".repeat(20)}`;
+    const report = buildWeeklyValueReport({
+      generatedAt: "2026-06-01T12:00:00.000Z",
+      variant: "operator",
+      days: 7,
+      repositories: [repo("JSONbored/gittensory", true, true)],
+      installations: [installation(1)],
+      health: [health(1, "healthy")],
+      registry: registry([]),
+      scoring: scoring([]),
+      upstreamDrift: upstream({ status: "current", openReportCount: 0 }),
+      usageSummary: usageSummary({ totalEvents: 1, activeActors: 1 }),
+      usageRollups: [
+        rollup("2026-05-31", {
+          totalEvents: 1,
+          activeActors: 1,
+          activeRepos: 1,
+          repos: [{ key: orbSecret, count: 1 }],
+          events: [],
+          surfaces: [],
+          commands: [],
+          tools: [],
+        }),
+      ],
+      usageRollupStatus: rollupStatus({ status: "ready" }),
+    });
+
+    expect(report.operatorDetails?.topRepos).toEqual([{ key: "<redacted-token>", count: 1 }]);
+    expect(JSON.stringify(report)).not.toContain(orbSecret);
+  });
+
   it("keeps clean complete windows marked ready", () => {
     const report = buildWeeklyValueReport({
       generatedAt: "2026-06-01T12:00:00.000Z",


### PR DESCRIPTION
## Summary

- Advances #1825 (brokered self-host relay + telemetry audit). This PR is the **code-level audit** requested by the issue plus **one genuine, narrow fix** it turned up. It does not close #1825 — see "What's not done" below for the parts of the issue this PR does not cover.
- **Fix**: the Orb broker's enrollment id/secret (`createOpaqueToken("orbenr"/"orbsec")`, `src/orb/broker.ts`) are bare opaque tokens with no `token`/`secret`-named field to trip the existing *key*-based redaction when they appear as a plain *value* — e.g. quoted inside a broker error message. Five independent value-based token scrubbers across the codebase already recognized `ghp_`/`github_pat_`/`gts_`/`glpat-`/`sk-` (and `xoxb-` in one case) but missed the Orb broker's own prefixes:
  - `src/selfhost/sentry.ts` (`SECRET_VALUE`, the Sentry `beforeSend` scrubber)
  - `src/db/repositories.ts` (`PRODUCT_USAGE_TOKEN_VALUE`, persisted product-usage telemetry)
  - `src/services/control-panel-roles.ts` (`sanitizeRoleText`)
  - `src/services/miner-dashboard-recommendations.ts` (`FORBIDDEN_TOKEN`)
  - `src/services/weekly-value-report.ts` (`sanitizeReportText`)

  All five now also match `orbenr_`/`orbsec_`. Every fix is a one-line regex addition; each is covered by a new regression test that fails without the fix and passes with it (verified locally by reverting the five source lines and re-running the new tests — see Validation).

## End-to-end audit notes (#1825 deliverable)

Audited by reading the code end to end (no live broker access, so this is a rigorous static audit, not a live integration test — see "What still needs an operator to verify"). Production runs `ORB_RELAY_MODE=pull`, so the pull path got the primary focus; push-mode code was read too since the issue asks for both.

**Token broker (mint / cache / expiry / refresh / outage) — `src/orb/broker-client.ts`, `src/github/app.ts`, `src/orb/broker.ts`:**
- Minting: `fetchBrokeredInstallationToken` (`src/orb/broker-client.ts:53`) exchanges `ORB_ENROLLMENT_SECRET` for a token via `POST /v1/orb/token`, 25s timeout, throws on non-OK or a tokenless body.
- Caching: `mintInstallationToken` (`src/github/app.ts:223`) writes the brokered token into the same installation-token cache the App-key path uses (`installationTokenCache`, ~1h TTL, 2‑min safety margin), single-flighted via `inFlightMints` (`src/github/app.ts:130`) so a cold cache doesn't thundering-herd the broker.
- Expiry/refresh: an unparseable `expiresAt` falls back to a 50‑min default rather than propagating `NaN` into the cache (`src/orb/broker-client.ts:75-79`, with an explicit comment on why); `withInstallationTokenRetry` (`src/github/app.ts:176`) force-refreshes once on a 401/permission-scope rejection.
- Broker-outage behavior: **fails safe, not hammering the broker.** On a mint failure, `mintInstallationToken` serves the still-valid cached token if one exists ("stale-token grace", `src/github/app.ts:254-270`, already tested in `test/unit/github-app.test.ts:549` and `:572`); only when there is no valid cache does it rethrow (→ the queue's existing retry/DLQ handling). There is no busy-retry loop inside the mint path itself — already correct.
- Server-side (`src/orb/broker.ts`): `brokerOrbToken` caches the minted token encrypted-at-rest, re-checks install eligibility on every exchange (not just at issue time), and orders the misconfiguration check *after* the enrollment-secret check so an unauthenticated caller can't fingerprint broker misconfiguration (`#2710`, already fixed).
- **Verdict: already handled correctly.** No fix needed here.

**Webhook relay — registration, drain, ack, retry, stale-event handling — `src/orb/broker-client.ts`, `src/orb/relay.ts`, `src/selfhost/monitored-work.ts`, `src/server.ts`:**
- Registration: `registerOrbRelayTargetWithRetry` (`src/orb/broker-client.ts:195`) retries on a 1‑minute timer with a 5‑minute backoff (`ORB_RELAY_REGISTER_RETRY_BACKOFF_MS`) once registration fails, instead of the old one-shot boot-time attempt — already fixed for `#selfhost-runtime-drift`.
- **Pull-mode degraded registration does not page incorrectly** (explicit issue acceptance criterion): `registerOrbRelayWithMonitor` (`src/selfhost/monitored-work.ts:112`) logs a *warning*, not an *error*, for a pull-mode registration failure, because the drain loop still functions once a later attempt succeeds; push-mode failure is an *error* (the container is genuinely deaf with no fallback). Already tested (`test/unit/selfhost-monitored-work.test.ts:222` and `:243`).
- Drain (pull mode): `drainOrbRelay` (`src/orb/broker-client.ts:222`) POSTs the outstanding ack list and pulls the next batch every 15s (`src/server.ts:1003`); best-effort, returns `[]` on any failure so the next tick retries.
- Ack: acks are only added to the pending list once `enqueueWebhookByEnv` durably accepts the event (`drainOrbRelayWithMonitor`, `src/selfhost/monitored-work.ts:89`) — an enqueue failure is never acked, so it is redelivered on the next drain.
- Retry (push mode): `retryFailedRelays` (`src/orb/relay.ts:377`) runs off the `retry-orb-relay` cron, up to 5 attempts within a 1‑hour TTL, with a 5‑minute per-row backoff (`RELAY_RETRY_BACKOFF_MINUTES`) so a sustained outage doesn't re-hammer a down container or a degraded Orb every ~2‑minute tick.
- Stale-event handling: both the pull-mode pending queue (`orb_relay_pending`, 24h TTL, `RELAY_PENDING_TTL_HOURS`) and the push-mode failure queue (`orb_relay_failures`, 1h TTL / 5 attempts) prune and **emit an alertable `error`-level structured log** on drop (`orb_relay_pending_dropped` / `orb_relay_events_dropped`) so silent event loss is visible — already tested in `test/integration/orb-relay.test.ts:473` and `:790`.
- **Verdict: already handled correctly and already well-tested**, including the exact "pull-mode degraded registration must not page" acceptance criterion.

**Outcome telemetry export — `src/selfhost/orb-collector.ts`:**
- Anonymization default is `true` (`ORB_ANONYMIZE`), repo/PR identifiers are HMAC'd with a dedicated per-instance secret (never the App key or webhook secret) generated once and persisted in `system_flags`.
- Air-gap: `ORB_AIR_GAP=true` short-circuits the export to a no-op before any network call, including for brokered instances — already tested (`test/unit/selfhost-orb-collector.test.ts:92`, `:97`).
- Retry/failure visibility: a non-OK response or thrown fetch increments `gittensory_orb_export_errors_total` and returns 0 (no throw, no crash of the hourly export timer); the watermark cursor only advances on a confirmed 2xx, so a failed batch is retried whole on the next run — already tested (`test/unit/selfhost-orb-collector.test.ts:184`, `:192`).
- **Verdict: already handled correctly.** No fix needed here.

**Logging/Sentry context (the one gap found and fixed):**
- Key-based redaction (`SECRET_KEY` in `src/selfhost/sentry.ts`, matching `token|secret|key|password|...`) already catches any field literally *named* `secret`/`token`/etc. — confirmed still solid.
- The gap was **value**-based redaction of free-text strings (an `Error.message`, a log line) where a secret appears as a bare value with no matching field name. None of the current `throw new Error(...)` call sites in `src/orb/broker-client.ts` interpolate the raw enrollment secret directly, so this was not an active leak in the code paths I traced — it is a defense-in-depth gap: if a future broker error message (or an upstream broker's own error body, echoed via `safeOrbRelayRegisterErrorHint`) ever quoted the secret bare, it would have reached Sentry/telemetry unredacted. Fixed by adding `orbenr_|orbsec_` to the five value-scrubber regexes listed above.
- Raw webhook bodies: never logged; `enqueueWebhookByEnv` only records `deliveryId`/`eventName`/`action`/`installationId`/`repositoryFullName`/`payloadHash` (`src/db/repositories.ts` `recordWebhookEvent` call sites), never the body itself.
- Private repo config / unhashed identifiers: `hashedInstallationContext` (`src/selfhost/sentry.ts:231`) hashes `installation_id` before it reaches Sentry tags/context; `PAYLOAD_KEY` drops `body`/`payload`/`patch`/`diff`/`config`/`repoConfig`-named fields entirely rather than truncating them.

## What's not done (honest scope boundary)

This PR does **not** attempt:
- A reproducible pull-mode / push-mode smoke checklist (the issue's "Deliverables" ask) — that requires a live broker and is out of scope for a static-code-review PR.
- Website docs updates for GitHub App / Orb setup and troubleshooting (also listed under Deliverables) — a separate, larger docs PR.
- A "clear recommendation for stable ingress vs. pull-mode default for NAT/tailnet deployments" — the code already defaults sensibly (pull mode needs no public origin, push mode requires `PUBLIC_API_ORIGIN`), but a written operator-facing recommendation belongs in the docs PR above, not buried in a code-fix PR.

## What still needs an operator to verify live

- Actual broker behavior under a real network partition (DNS failure, TLS reset, slow-loris) versus the synthetic non-OK/timeout cases exercised in tests — static review can confirm the code *paths* exist and are exercised by unit tests, not that they behave identically against a real degraded broker.
- Whether the 15s pull-drain interval and 60s registration-retry interval are the right cadence under real fleet-wide broker load (both are currently fixed constants, not configurable).
- End-to-end confirmation that a push-mode relay target behind a real public ingress (TLS terminator, firewall, etc.) round-trips correctly — the code path is unit- and integration-tested against mocked fetch, not a live public endpoint.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue (Advances #1825); this PR is a partial, honest step, not a full close (see above).

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` (no workflow files touched; not run)
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` (not run in full locally per this repo's own guidance — CI already runs the full gate; ran the 5 directly affected test files plus `npm run test:changed`, both green, and verified revert-and-confirm-fails for each new test)
- [ ] `npm run test:workers` (no Worker-runtime code touched; not run)
- [ ] `npm run build:mcp` (no MCP code touched; not run)
- [ ] `npm run test:mcp-pack` (no MCP code touched; not run)
- [ ] `npm run ui:openapi:check` (no API/schema changes; not run)
- [ ] `npm run ui:lint` / `npm run ui:typecheck` / `npm run ui:build` (no `apps/gittensory-ui/**` changes; not run)
- [ ] `npm audit --audit-level=moderate` (no dependency changes; not run — CI's dependency-review job covers this)
- [x] New/changed behavior has tests: 5 new regression tests (one per fixed file), each verified to fail on the pre-fix code and pass on the post-fix code (`git stash` the 5 source-line fixes, re-run the 5 new tests → all 5 fail cleanly with no other regressions; restore, re-run → all pass). Also ran `npm run test:changed` against the full diff: 216 test files / 5477 tests passed, 0 failed.

If any required check was skipped, explain why:

- This is a `src/**`-only change with no UI, MCP, Worker-runtime, API/schema, or dependency surface touched, so the corresponding gate steps are inapplicable; `typecheck` plus the directly affected unit tests plus `test:changed` (full affected-test sweep) are the faithful local signal for a change this narrow, and CI runs the complete `test:ci` gate including `test:coverage` regardless.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed. (All new test fixtures use obviously-fake placeholder tokens, e.g. `orbsec_` + repeated filler characters — never real-looking secrets.)
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — this PR only extends existing redaction regexes, no auth/session logic changed; each extension has a positive-redaction regression test.)
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/MCP surface changed.)
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changed.)
- [ ] Visible UI changes include a `UI Evidence` section. (N/A — no visible UI changed.)
- [ ] Public docs/changelogs are updated where needed. (Docs updates are explicitly deferred to a follow-up PR per #1825's own Deliverables list — see "What's not done" above.)

## Notes

- Full audit trace (file:line) for anyone picking up the remaining #1825 work:
  - Broker client: `src/orb/broker-client.ts`
  - Broker server: `src/orb/broker.ts`
  - Relay (registration/drain/retry/stale-event): `src/orb/relay.ts`
  - Installation-token cache + brokered mint: `src/github/app.ts:132-331`
  - Server wiring (drain loop, registration retry loop): `src/server.ts:939-1011`
  - Monitored-work wrappers (Sentry cron monitors, pull/push logging asymmetry): `src/selfhost/monitored-work.ts`
  - Outcome telemetry exporter: `src/selfhost/orb-collector.ts`
  - Sentry scrubber (this PR's fix): `src/selfhost/sentry.ts:37-47`
