### PR TITLE
docs(selfhost): document the real update and rollback flow

### DIFF
--- a/apps/gittensory-ui/src/routes/docs.self-hosting-operations.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-operations.tsx
@@ -278,12 +278,16 @@ volumes:
       <h2>Updating and rolling back</h2>
       <p>
         Both update paths below only ever restart the <code>gittensory</code> app service (
-        <code>--no-deps</code>) — they never touch other compose-profile services (Postgres, Redis,
-        Qdrant, Grafana, and friends), and they never touch <code>.env</code> keys other than the
-        one they persist for next time. That means <code>.env</code>, the{" "}
-        <code>gittensory-config/</code> mount, every data volume, and any{" "}
-        <code>docker-compose.override.yml</code> are preserved automatically across an update — you
-        don&apos;t need to back those up or re-supply them just to run either script.
+        <code>--no-deps</code>) — they never touch other compose-profile services or their state
+        (Postgres, Redis, Qdrant, and Grafana&apos;s own <code>grafana-data</code> volume), and they
+        never touch <code>.env</code> keys other than the one they persist for next time. That means{" "}
+        <code>.env</code>, the <code>gittensory-config/</code> mount, every data volume — including
+        the app&apos;s own <code>/data</code> volume where Codex/Claude Code auth material lives —
+        and any <code>docker-compose.override.yml</code> are preserved automatically across an
+        update. You don&apos;t need to back those up or re-supply them just to run either script,
+        and you only need to recreate a profile service yourself if you&apos;re deliberately
+        upgrading that service (its own image tag in <code>docker-compose.yml</code>, or a
+        Postgres/Redis/Qdrant major-version bump) rather than the app.
       </p>
 
       <h3>Path 1: pull a published image</h3>
@@ -384,6 +388,17 @@ GITTENSORY_IMAGE=ghcr.io/jsonbored/gittensory-selfhost@sha256:... ./scripts/depl
         <code>healthy</code>, and tail recent logs for startup errors or an unexpected absence of{" "}
         <code>selfhost_listening</code> / <code>selfhost_migrations_applied</code>.
       </p>
+      <p>
+        Neither <code>/health</code> nor <code>/ready</code> reports a version, so confirm the
+        deployed release directly — <code>GITTENSORY_IMAGE</code> or <code>SENTRY_RELEASE</code> in{" "}
+        <code>.env</code> records what the deploy script just resolved, and{" "}
+        <code>docker inspect</code> confirms what the running container actually has:
+      </p>
+      <CodeBlock
+        lang="bash"
+        code={`grep -E '^(GITTENSORY_IMAGE|GITTENSORY_VERSION|SENTRY_RELEASE)=' .env
+docker inspect --format '{{.Config.Image}}' "$(docker compose ps -q gittensory)"`}
+      />
 
       <p>
         If an operating check fails, go to{" "}

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-operations.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-operations.tsx
@@ -1,7 +1,7 @@
 import { createFileRoute, Link } from "@tanstack/react-router";
 
 import { DocsPage } from "@/components/site/docs-page";
-import { CodeBlock, FeatureRow } from "@/components/site/primitives";
+import { Callout, CodeBlock, FeatureRow } from "@/components/site/primitives";
 
 export const Route = createFileRoute("/docs/self-hosting-operations")({
   head: () => ({
@@ -10,13 +10,13 @@ export const Route = createFileRoute("/docs/self-hosting-operations")({
       {
         name: "description",
         content:
-          "Operate the self-hosted Gittensory review service: readiness, metrics, logs, dashboards, jobs, queues, and routine checks.",
+          "Operate the self-hosted Gittensory review service: readiness, metrics, logs, dashboards, jobs, queues, routine checks, and safe updates/rollback.",
       },
       { property: "og:title", content: "Self-host operations — Gittensory docs" },
       {
         property: "og:description",
         content:
-          "Operate the self-hosted Gittensory review service: readiness, metrics, logs, dashboards, jobs, queues, and routine checks.",
+          "Operate the self-hosted Gittensory review service: readiness, metrics, logs, dashboards, jobs, queues, routine checks, and safe updates/rollback.",
       },
       { property: "og:url", content: "/docs/self-hosting-operations" },
     ],
@@ -274,6 +274,116 @@ volumes:
         </li>
         <li>Backups are recent and restore-tested.</li>
       </ul>
+
+      <h2>Updating and rolling back</h2>
+      <p>
+        Both update paths below only ever restart the <code>gittensory</code> app service (
+        <code>--no-deps</code>) — they never touch other compose-profile services (Postgres, Redis,
+        Qdrant, Grafana, and friends), and they never touch <code>.env</code> keys other than the
+        one they persist for next time. That means <code>.env</code>, the{" "}
+        <code>gittensory-config/</code> mount, every data volume, and any{" "}
+        <code>docker-compose.override.yml</code> are preserved automatically across an update — you
+        don&apos;t need to back those up or re-supply them just to run either script.
+      </p>
+
+      <h3>Path 1: pull a published image</h3>
+      <p>
+        <code>scripts/deploy-selfhost-image.sh</code> pulls a tag or digest, restarts only the{" "}
+        <code>gittensory</code> service, waits for it to report <code>healthy</code> via{" "}
+        <code>docker inspect</code>&apos;s health status (configurable timeout, default 180s), and
+        then persists the resolved image reference back to <code>GITTENSORY_IMAGE</code> in{" "}
+        <code>.env</code> so the next plain invocation reuses it.
+      </p>
+      <CodeBlock
+        lang="bash"
+        code={`# Re-pull whatever GITTENSORY_IMAGE already resolves to (safe no-op restart if the tag is unchanged
+# and nothing new was pushed under it)
+./scripts/deploy-selfhost-image.sh
+
+# Pin an exact release tag or content digest
+./scripts/deploy-selfhost-image.sh ghcr.io/jsonbored/gittensory-selfhost:orb-v0.1.0
+GITTENSORY_IMAGE=ghcr.io/jsonbored/gittensory-selfhost@sha256:... ./scripts/deploy-selfhost-image.sh`}
+      />
+      <p>
+        The pull always runs with <code>--policy always</code>, so re-running the script against an
+        unchanged tag is safe: if the registry has nothing new, it just restarts the same image and
+        the health-check wait passes immediately.
+      </p>
+
+      <h3>Path 2: build from the current git checkout</h3>
+      <p>
+        <code>scripts/deploy-selfhost-prebuilt.sh</code> is for a source-based deploy (this is how{" "}
+        <code>GITTENSORY_VERSION</code> ends up as a short git SHA instead of an image tag). It
+        builds the bundle inside a Dockerized Node container — the host itself never needs Node or
+        npm installed — then restarts only the <code>gittensory</code> service the same way as the
+        image path.
+      </p>
+      <CodeBlock
+        lang="bash"
+        code={`git pull
+./scripts/deploy-selfhost-prebuilt.sh`}
+      />
+      <p>
+        <code>SENTRY_RELEASE</code> defaults to{" "}
+        <code>gittensory-selfhost@&lt;short git SHA of the current HEAD&gt;</code> unless you
+        override it, so each deploy from a new commit gets a distinct release id automatically. When{" "}
+        <code>SENTRY_AUTH_TOKEN</code>, <code>SENTRY_ORG</code>, and <code>SENTRY_PROJECT</code> are
+        all configured, the script also injects and uploads Sentry source maps for that release
+        before restarting the service (set <code>SELFHOST_SKIP_SENTRY_UPLOAD=1</code> to skip this
+        even when those three are present).
+      </p>
+
+      <h3>Rollback: no dedicated command today</h3>
+      <p>
+        There is no <code>rollback</code> script. Rolling back means re-running one of the two
+        scripts above pointed at an older target:
+      </p>
+      <ul>
+        <li>
+          Image-based: re-run <code>deploy-selfhost-image.sh</code> with the prior tag or digest (
+          <code>docker inspect</code> on the running container, or your own deploy log, has the
+          digest you were on before the update).
+        </li>
+        <li>
+          Source-based: <code>git checkout</code> the prior commit, then re-run{" "}
+          <code>deploy-selfhost-prebuilt.sh</code>.
+        </li>
+      </ul>
+      <Callout variant="warn" title="Migrations are forward-only">
+        This repo has no down-migration convention — <code>scripts/check-migrations.mjs</code> only
+        enforces a contiguous, non-colliding numbering, not a reverse path. If a migration has
+        already run forward against the live database, rolling back the app code is{" "}
+        <strong>not safe in general</strong>: older code can break against a newer schema (a
+        dropped/renamed column, a NOT NULL column it never writes, a changed constraint), even
+        though the migration itself succeeded. Before rolling back across a migration boundary,
+        check whether everything the newer migration(s) did is purely additive (new nullable column,
+        new table, new index) and, specifically, whether the code you're rolling back to actually
+        still runs against that schema — additive is usually fine; anything the old code can't
+        tolerate is not. Take a fresh backup first regardless — see{" "}
+        <Link to="/docs/self-hosting-backup-scaling">Backup and scaling</Link> — and if in doubt,
+        restore that backup to a scratch database and boot the older code against it before doing
+        the same on the live instance.
+      </Callout>
+
+      <h3>Before and after any update</h3>
+      <p>Before updating:</p>
+      <ul>
+        <li>
+          Source-based deploys: <code>git status</code> is clean (no uncommitted local changes the
+          build would silently pick up or drop).
+        </li>
+        <li>
+          A current, verified backup exists if the update includes schema changes — see{" "}
+          <Link to="/docs/self-hosting-backup-scaling">Backup and scaling</Link>.
+        </li>
+      </ul>
+      <p>
+        After updating, work through the same checks as any other health pass — see{" "}
+        <strong>Health endpoints</strong> and <strong>Useful commands</strong> above: confirm{" "}
+        <code>/ready</code> returns 200, <code>docker compose ps</code> shows the service{" "}
+        <code>healthy</code>, and tail recent logs for startup errors or an unexpected absence of{" "}
+        <code>selfhost_listening</code> / <code>selfhost_migrations_applied</code>.
+      </p>
 
       <p>
         If an operating check fails, go to{" "}


### PR DESCRIPTION
## Summary

- Adds an "Updating and rolling back" section to `apps/gittensory-ui/src/routes/docs.self-hosting-operations.tsx` (after the existing "Routine checks" section), grounded in the actual `scripts/deploy-selfhost-image.sh` and `scripts/deploy-selfhost-prebuilt.sh` (read both scripts in full before writing). Covers: what each script does and how it differs from a bare `docker compose pull/up` (restarts only the `gittensory` service via `--no-deps`, waits on `docker inspect` health status, persists the resolved image/version back to `.env`); how to pin an exact tag or digest; that both scripts leave `.env`, `gittensory-config/`, every data volume (including the app's own `/data` volume where Codex/Claude Code auth material lives), Grafana's `grafana-data` volume, and any `docker-compose.override.yml` untouched; that there is no dedicated rollback script today (rollback = re-running one of the two scripts pointed at an older tag/digest/checkout); the forward-only migration caveat (grounded in `scripts/check-migrations.mjs`, which has no down-migration concept) and what to check before rolling back across a schema boundary; and pre/post-update checks, including that neither `/health` nor `/ready` reports a version so the release id has to be confirmed via `.env` or `docker inspect` instead.
- Advances #1823.

**Note on scope vs. #1823's acceptance criteria:** while this PR was in flight, PR #3191 (for the sibling issue #1829) merged to `main` and independently fixed the same generic/inaccurate "Upgrade flow" and "Rollback" sections on `docs.self-hosting-releases.tsx` that I had also touched — so I dropped my redundant edits to that file during rebase and kept only the new Operations section, which is the actual scope of #1823. #1823 also asks for an "optional script or make target" for repeatability; I did not add one since the issue marks it optional and the two existing scripts already cover the repeatable path. Everything else in #1823's acceptance criteria (source-checkout path, image-tag path, what's preserved, restart-only-app-service vs. recreate-profile-service guidance, migration/rollback expectations, pre/post-update checks) is addressed here, so I'm calling this "Advances," not "Closes" — it's a real, substantial step, and I want a maintainer to confirm it's the last piece before actually closing the issue.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue (Advances #1823).

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` — not run standalone; no workflow files touched
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` — not run; this PR only touches `apps/gittensory-ui/**`, which Codecov does not gate (docs-only change, no `src/**` lines changed)
- [ ] `npm run test:workers` — not run; no Worker/backend code touched
- [ ] `npm run build:mcp` / `npm run test:mcp-pack` — not run; no MCP package code touched
- [ ] `npm run ui:openapi:check` — not run; no API/schema changes
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate` — not run standalone this pass; `npm ci` reported 0 vulnerabilities on install and no dependency changes are in this diff
- [x] Read `scripts/deploy-selfhost-image.sh`, `scripts/deploy-selfhost-prebuilt.sh`, `scripts/lib/selfhost-deploy-common.sh`, and `scripts/check-migrations.mjs` in full to ground every claim in the new section against actual script behavior (not guessed). No bug found in either deploy script during this read — this PR is documentation-only.
- [x] Rebased onto fresh `origin/main` immediately before pushing; resolved a real conflict in `docs.self-hosting-releases.tsx` against the concurrently-merged #3191 by taking main's version and dropping my duplicate edits there.

If any required check was skipped, explain why:

- This is a docs-only change confined to `apps/gittensory-ui/src/routes/docs.self-hosting-operations.tsx`. No `src/**`, `scripts/**`, `migrations/**`, or workflow files changed, so the backend/coverage/MCP/OpenAPI/audit checks above don't apply to this diff. I ran the UI-specific checks that do apply (`ui:lint`, `ui:typecheck`, `ui:build`) and the root `typecheck`, all green.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed. All example values (image tags/digests) are the same public placeholders already used elsewhere in these docs.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] N/A — no auth, cookie, CORS, GitHub App, Cloudflare, or session changes.
- [x] N/A — no API/OpenAPI/MCP behavior changes.
- [x] N/A — no UI component/state changes; prose-only additions using existing `DocsPage`/`CodeBlock`/`Callout`/`FeatureRow` primitives, no new components or layout.
- [ ] UI Evidence — see below.
- [x] Public docs updated (this PR is entirely a docs update); no changelog touched.

## UI Evidence

Not applicable — this PR is prose-only content added to an existing docs page using the page's existing components (`CodeBlock`, `Callout`, headings, lists) with no new layout, component, or visual styling changes. I built the UI (`npm run ui:build`, green) and spot-checked the rendered page in a local dev server: the new "Updating and rolling back" `h2` and its four `h3` subsections ("Path 1: pull a published image", "Path 2: build from the current git checkout", "Rollback: no dedicated command today", "Before and after any update") render correctly, appear in the page's auto-generated "On this page" table of contents with correct scroll-spy highlighting, and the `Callout` warning renders with the expected left-border styling — confirmed via the accessibility tree and DOM/style inspection rather than a screenshot (a full-page screenshot was also captured showing the section in context, but isn't committed per the review-evidence policy).

## Notes

- Also fixes the page's `<head>` meta description to mention updates/rollback (previously only listed readiness/metrics/logs/dashboards/jobs/queues/routine checks).