### PR TITLE
feat(observability): add Sentry visibility to webhook enqueue and dead-letter revival

### DIFF
--- a/apps/gittensory-ui/src/routes/docs.self-hosting-operations.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-operations.tsx
@@ -70,7 +70,9 @@ selfhost_embed_provider
 selfhost_vectorize
 selfhost_job_dead
 selfhost_cron_error
-review_context_fetch_failed`}
+review_context_fetch_failed
+selfhost_webhook_enqueue_failed
+selfhost_webhook_enqueue_binding_missing`}
       />
 
       <h2>Observability profile</h2>
@@ -452,6 +454,11 @@ volumes:
             description:
               "The recurring retry loop that (re-)registers this instance with the relay broker.",
           },
+          {
+            title: "Queue dead-letter revive",
+            description:
+              "The 30-minute (by default) sweep that retries dead-lettered jobs still under the auto-retry ceiling.",
+          },
         ]}
       />
       <p>
@@ -464,7 +471,7 @@ volumes:
       <ul>
         <li>Queue pending count is not growing without processing.</li>
         <li>Dead jobs stay at zero or are investigated promptly.</li>
-        <li>Webhook deliveries are recent and have 2xx responses.</li>
+        <li>Webhook deliveries are recent and have 2xx responses, with no enqueue failures.</li>
         <li>AI usage matches expected review volume and model/effort choices.</li>
         <li>REES and RAG failures are visible and bounded.</li>
         <li>

--- a/src/github/webhook.ts
+++ b/src/github/webhook.ts
@@ -177,6 +177,17 @@ export async function enqueueWebhookByEnv(env: Env, deliveryId: string, eventNam
   if (!env.WEBHOOKS) {
     await recordWebhookEvent(env, { ...eventRow, status: "error" });
     recordWebhookEnqueueMetric(eventName, payload.action, "enqueue_failed");
+    // Missing binding is a deploy-ordering defect (the WEBHOOKS queue isn't provisioned yet), not a transient
+    // blip — an operator needs to SEE it, not infer it from a metric dip. ERROR level so the central Sentry
+    // forwarder captures it (#1824); repository/installation stay out of the tags (webhook ingest observability).
+    console.error(
+      JSON.stringify({
+        level: "error",
+        event: "selfhost_webhook_enqueue_binding_missing",
+        eventName,
+        repository: eventRow.repositoryFullName,
+      }),
+    );
     return "enqueue_failed";
   }
 
@@ -187,12 +198,24 @@ export async function enqueueWebhookByEnv(env: Env, deliveryId: string, eventNam
     // Send to the dedicated WEBHOOKS lane (not the shared JOBS queue) so a maintenance burst on JOBS can never
     // starve real GitHub events into the DLQ. (#audit-webhook-queue)
     await env.WEBHOOKS.send(message);
-  } catch {
+  } catch (error) {
     // Enqueue failed: flip the event to "error" so the dedup guard above lets GitHub redeliver / the next pull
     // re-deliver, instead of treating the webhook as handled (#786). Also covers the deploy-ordering case where
     // the WEBHOOKS queue is not yet provisioned — no event is lost.
     await recordWebhookEvent(env, { ...eventRow, status: "error" });
     recordWebhookEnqueueMetric(eventName, payload.action, "enqueue_failed");
+    // ERROR level so the central Sentry forwarder captures a failing webhook enqueue (#1824) — previously only a
+    // Prometheus counter moved, which an operator would only notice by comparing dashboards. Never logs rawBody or
+    // the parsed payload (secret-scrub boundary); only the delivery's routing metadata.
+    console.error(
+      JSON.stringify({
+        level: "error",
+        event: "selfhost_webhook_enqueue_failed",
+        eventName,
+        repository: eventRow.repositoryFullName,
+        error: error instanceof Error ? error.message : String(error),
+      }),
+    );
     return "enqueue_failed";
   }
 

--- a/src/selfhost/pg-queue.ts
+++ b/src/selfhost/pg-queue.ts
@@ -7,7 +7,7 @@ import { logAudit, extractPayloadType, extractPayloadContext } from "./audit";
 import { incr } from "./metrics";
 import { withReviewSpan } from "./tracing";
 import { withOtelSpan } from "./otel";
-import { captureError } from "./sentry";
+import { captureError, withSentryMonitor } from "./sentry";
 import {
   consumingRetryDelayMs,
   deterministicJitterMs,
@@ -646,10 +646,20 @@ export function createPgQueue(
    *  rejection and can terminate the process (fatal when SENTRY_DSN is unset, since server.ts only installs
    *  the handler when Sentry is configured), exactly the failure mode pump()'s own try/catch above guards
    *  against for the main poll loop. A failed revive tick just waits for the next interval, same as a failed
-   *  poll tick waits for the next poll. */
+   *  poll tick waits for the next poll.
+   *
+   *  Also wrapped in a Sentry cron monitor (#1824): dead-letter revival stopping SILENTLY (the timer never
+   *  fires again, e.g. after an unexpected process-level disruption) is worse than one throwing tick -- a
+   *  crashed tick self-reports via captureError below, but a stopped one reports nothing at all without a
+   *  monitor watching for the missed check-in. withSentryMonitor rethrows on failure so its own capture
+   *  fires; the outer try/catch (this function's actual job) still guards the setInterval callback. */
   async function reviveDeadLetterJobsSafely(): Promise<void> {
     try {
-      await reviveDeadLetterJobs();
+      await withSentryMonitor(
+        "queue-dead-letter-revive",
+        { jobType: "queue-dead-letter-revive" },
+        reviveDeadLetterJobs,
+      );
     } catch (error) {
       console.error(
         JSON.stringify({

--- a/src/selfhost/sentry.ts
+++ b/src/selfhost/sentry.ts
@@ -13,6 +13,7 @@ import {
   type OpenTelemetryBridge,
 } from "./otel";
 import { hashedInstallationIdWith } from "./review-tracing";
+import { queueDeadLetterReviveIntervalMs } from "./queue-common";
 
 type SentryNs = typeof import("@sentry/node");
 type SentryClient = NonNullable<ReturnType<SentryNs["init"]>>;
@@ -79,7 +80,7 @@ async function loadNodeHasher(): Promise<void> {
     createHash("sha256").update(input).digest("hex");
 }
 
-const SENTRY_MONITORS: Record<SentryMonitorName, { slug: string; config: SentryMonitorConfig }> = {
+const SENTRY_MONITORS: Record<SentryMonitorName, { slug: string; config: SentryMonitorConfig | (() => SentryMonitorConfig) }> = {
   "scheduled-loop": {
     slug: "scheduled-loop",
     config: {
@@ -120,19 +121,22 @@ const SENTRY_MONITORS: Record<SentryMonitorName, { slug: string; config: SentryM
       recoveryThreshold: 1,
     },
   },
-  // Matches the default QUEUE_DEAD_LETTER_REVIVE_INTERVAL_MS (30min, see queue-common.ts). A configured operator
-  // override still reports on this fixed schedule -- an operator who shortens the interval gets a monitor that
-  // checks in MORE often than it expects (never flagged missed), and one who lengthens it accepts a wider margin
-  // than strictly needed; both are safe, and matching the schedule to every possible override isn't worth the
-  // added surface. Silent stoppage here means dead jobs never retry again without manual intervention (#1824).
+  // Derived from the LIVE QUEUE_DEAD_LETTER_REVIVE_INTERVAL_MS override (default 30min, see queue-common.ts)
+  // rather than hard-coded: a static 30min schedule would report false missed check-ins for any operator who
+  // configures an interval longer than the schedule + margin window, even though the job is running exactly on
+  // its own configured cadence. Silent stoppage here means dead jobs never retry again without manual
+  // intervention (#1824), so the monitor must track whatever interval is actually in effect.
   "queue-dead-letter-revive": {
     slug: "queue-dead-letter-revive",
-    config: {
-      schedule: { type: "interval", value: 30, unit: "minute" },
-      checkinMargin: 10,
-      maxRuntime: 5,
-      failureIssueThreshold: 2,
-      recoveryThreshold: 1,
+    config: () => {
+      const intervalMinutes = Math.max(1, Math.round(queueDeadLetterReviveIntervalMs() / 60_000));
+      return {
+        schedule: { type: "interval", value: intervalMinutes, unit: "minute" },
+        checkinMargin: Math.max(5, Math.ceil(intervalMinutes / 3)),
+        maxRuntime: 5,
+        failureIssueThreshold: 2,
+        recoveryThreshold: 1,
+      };
     },
   },
 };
@@ -615,10 +619,9 @@ export async function withSentryMonitor<T>(
 ): Promise<T> {
   if (!active || !Sentry) return callback();
   const monitorSlug = resolveSentryMonitorSlug(name);
-  const checkInId = Sentry.captureCheckIn(
-    { monitorSlug, status: "in_progress" },
-    SENTRY_MONITORS[name].config,
-  );
+  const configOrResolver = SENTRY_MONITORS[name].config;
+  const resolvedConfig = typeof configOrResolver === "function" ? configOrResolver() : configOrResolver;
+  const checkInId = Sentry.captureCheckIn({ monitorSlug, status: "in_progress" }, resolvedConfig);
   const startedAt = Date.now();
   try {
     const result = await callback();

--- a/src/selfhost/sentry.ts
+++ b/src/selfhost/sentry.ts
@@ -17,7 +17,7 @@ import { hashedInstallationIdWith } from "./review-tracing";
 type SentryNs = typeof import("@sentry/node");
 type SentryClient = NonNullable<ReturnType<SentryNs["init"]>>;
 type SentryMonitorConfig = NonNullable<Parameters<SentryNs["captureCheckIn"]>[1]>;
-export type SentryMonitorName = "scheduled-loop" | "orb-export" | "orb-relay-drain" | "orb-relay-register";
+export type SentryMonitorName = "scheduled-loop" | "orb-export" | "orb-relay-drain" | "orb-relay-register" | "queue-dead-letter-revive";
 type SentryScope = {
   setContext(name: string, context: Record<string, unknown>): void;
   setTag(key: string, value: string): void;
@@ -117,6 +117,21 @@ const SENTRY_MONITORS: Record<SentryMonitorName, { slug: string; config: SentryM
       checkinMargin: 2,
       maxRuntime: 1,
       failureIssueThreshold: 3,
+      recoveryThreshold: 1,
+    },
+  },
+  // Matches the default QUEUE_DEAD_LETTER_REVIVE_INTERVAL_MS (30min, see queue-common.ts). A configured operator
+  // override still reports on this fixed schedule -- an operator who shortens the interval gets a monitor that
+  // checks in MORE often than it expects (never flagged missed), and one who lengthens it accepts a wider margin
+  // than strictly needed; both are safe, and matching the schedule to every possible override isn't worth the
+  // added surface. Silent stoppage here means dead jobs never retry again without manual intervention (#1824).
+  "queue-dead-letter-revive": {
+    slug: "queue-dead-letter-revive",
+    config: {
+      schedule: { type: "interval", value: 30, unit: "minute" },
+      checkinMargin: 10,
+      maxRuntime: 5,
+      failureIssueThreshold: 2,
       recoveryThreshold: 1,
     },
   },

--- a/src/selfhost/sqlite-queue.ts
+++ b/src/selfhost/sqlite-queue.ts
@@ -8,7 +8,7 @@ import { logAudit, extractPayloadType, extractPayloadContext } from "./audit";
 import { incr } from "./metrics";
 import { withReviewSpan } from "./tracing";
 import { withOtelSpan } from "./otel";
-import { captureError } from "./sentry";
+import { captureError, withSentryMonitor } from "./sentry";
 import {
   consumingRetryDelayMs,
   deterministicJitterMs,
@@ -334,10 +334,21 @@ export function createSqliteQueue(
    *  a transient driver/metric failure here would otherwise surface as an uncaught exception and can terminate
    *  the process (fatal when SENTRY_DSN is unset, since server.ts only installs the handler when Sentry is
    *  configured), exactly the failure mode pump()'s own try/catch above guards against for the main poll loop.
-   *  A failed revive tick just waits for the next interval, same as a failed poll tick waits for the next poll. */
-  function reviveDeadLetterJobsSafely(): void {
+   *  A failed revive tick just waits for the next interval, same as a failed poll tick waits for the next poll.
+   *
+   *  Also wrapped in a Sentry cron monitor (#1824): dead-letter revival stopping SILENTLY (the timer never fires
+   *  again) is worse than one throwing tick -- a crashed tick self-reports via captureError below, but a stopped
+   *  one reports nothing without a monitor watching for the missed check-in. withSentryMonitor rethrows on
+   *  failure so its own capture fires; the outer try/catch (this function's actual job) still guards the
+   *  setInterval callback. Async now (setInterval tolerates a Promise-returning callback the same as the
+   *  synchronous one it replaces -- see the call site). */
+  async function reviveDeadLetterJobsSafely(): Promise<void> {
     try {
-      reviveDeadLetterJobs();
+      await withSentryMonitor(
+        "queue-dead-letter-revive",
+        { jobType: "queue-dead-letter-revive" },
+        () => Promise.resolve(reviveDeadLetterJobs()),
+      );
     } catch (error) {
       console.error(
         JSON.stringify({
@@ -1169,7 +1180,7 @@ export function createSqliteQueue(
       // Separate, much slower interval than the poll tick above -- reviving a dead job every second would
       // recreate the retry storm this feature exists to bound. The interval itself is the cooldown between
       // auto-retry rounds for any one job.
-      deadLetterReviveTimer = setInterval(reviveDeadLetterJobsSafely, queueDeadLetterReviveIntervalMs());
+      deadLetterReviveTimer = setInterval(() => void reviveDeadLetterJobsSafely(), queueDeadLetterReviveIntervalMs());
       // Foreground-liveness sweep (#selfhost-queue-liveness): also a separate, slow interval -- see
       // foreground-liveness.ts for why a per-tick check would busy-loop under sustained rate-limit pressure.
       foregroundLivenessTimer = setInterval(releaseStaleForegroundDeferralsSafely, foregroundLivenessConfig.checkIntervalMs);

--- a/test/unit/selfhost-pg-queue.test.ts
+++ b/test/unit/selfhost-pg-queue.test.ts
@@ -7,6 +7,7 @@ import { queueSnapshotFromBinding } from "../../src/selfhost/queue-common";
 import { renderMetrics, resetMetrics } from "../../src/selfhost/metrics";
 import { RetryableJobError } from "../../src/queue/retryable";
 import { hostLoadAvg1PerCore } from "../../src/selfhost/host-pressure";
+import * as sentryModule from "../../src/selfhost/sentry";
 import type { JobMessage } from "../../src/types";
 
 // Real host CPU load is nondeterministic (and can legitimately spike on a busy CI runner), so every
@@ -2077,6 +2078,64 @@ describe("createPgQueue (durable #977)", () => {
         expect(logged.some((line) => line.includes("selfhost_queue_dead_letter_revive_crashed") && line.includes("connection terminated unexpectedly"))).toBe(true);
         await q.stop();
       } finally {
+        delete process.env.QUEUE_DEAD_LETTER_REVIVE_INTERVAL_MS;
+      }
+    });
+
+    // (#1824): dead-letter revival stopping SILENTLY is worse than one throwing tick -- a Sentry cron monitor
+    // now wraps every tick so a stopped timer shows up as a missed check-in, not silence.
+    it("wraps each revive tick in the queue-dead-letter-revive Sentry monitor", async () => {
+      process.env.QUEUE_DEAD_LETTER_REVIVE_INTERVAL_MS = "1000";
+      vi.useFakeTimers();
+      const monitorSpy = vi.spyOn(sentryModule, "withSentryMonitor");
+      try {
+        const m = makePool(); // default mock returns { rows: [], rowCount: 0 } for the dead-letter SELECT -- a no-op tick
+        const q = createPgQueue(m.pool, async () => undefined, { maxRetries: 1 });
+
+        q.start();
+        await vi.advanceTimersByTimeAsync(1000); // the revive interval fires once
+
+        expect(monitorSpy).toHaveBeenCalledWith(
+          "queue-dead-letter-revive",
+          { jobType: "queue-dead-letter-revive" },
+          expect.any(Function),
+        );
+        await q.stop();
+      } finally {
+        monitorSpy.mockRestore();
+        delete process.env.QUEUE_DEAD_LETTER_REVIVE_INTERVAL_MS;
+      }
+    });
+
+    // The monitor rethrows on failure (withSentryMonitor's own contract) -- confirms that rethrow is still caught
+    // by reviveDeadLetterJobsSafely's own try/catch, so a crashing tick behaves exactly as it did before the
+    // monitor was added: logged + captured, never an unhandled rejection.
+    it("still catches a revive crash after adding the Sentry monitor wrapper (no regression on #2581)", async () => {
+      process.env.QUEUE_DEAD_LETTER_REVIVE_INTERVAL_MS = "1000";
+      vi.useFakeTimers();
+      const monitorSpy = vi.spyOn(sentryModule, "withSentryMonitor");
+      try {
+        const fn = vi.fn().mockImplementation(async (sql: unknown) => {
+          if (String(sql).includes("WHERE status='dead' AND attempts<$1")) throw new Error("connection terminated unexpectedly");
+          return { rows: [], rowCount: 0 };
+        });
+        const pool = { query: fn } as unknown as Pool;
+        const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+        const q = createPgQueue(pool, async () => undefined, { maxRetries: 1 });
+
+        q.start();
+        await vi.advanceTimersByTimeAsync(1000);
+
+        expect(monitorSpy).toHaveBeenCalledWith(
+          "queue-dead-letter-revive",
+          { jobType: "queue-dead-letter-revive" },
+          expect.any(Function),
+        );
+        const logged = errorSpy.mock.calls.map(([line]) => String(line));
+        expect(logged.some((line) => line.includes("selfhost_queue_dead_letter_revive_crashed") && line.includes("connection terminated unexpectedly"))).toBe(true);
+        await q.stop();
+      } finally {
+        monitorSpy.mockRestore();
         delete process.env.QUEUE_DEAD_LETTER_REVIVE_INTERVAL_MS;
       }
     });

--- a/test/unit/selfhost-sentry.test.ts
+++ b/test/unit/selfhost-sentry.test.ts
@@ -594,6 +594,46 @@ describe("enabled when SENTRY_DSN is set", () => {
     expect(resolveSentryMonitorSlug("orb-relay-drain", "x".repeat(60))).toBe(
       `gittensory-selfhost-${"x".repeat(48)}-orb-relay-drain`,
     );
+    expect(resolveSentryMonitorSlug("queue-dead-letter-revive", "prod")).toBe(
+      "gittensory-selfhost-prod-queue-dead-letter-revive",
+    );
+  });
+
+  it("records dead-letter-revive check-ins on the 30-minute schedule (#1824)", async () => {
+    await initSentry({
+      SENTRY_DSN: "d",
+      SENTRY_ENVIRONMENT: "prod",
+    } as unknown as NodeJS.ProcessEnv);
+
+    await expect(
+      withSentryMonitor(
+        "queue-dead-letter-revive",
+        { jobType: "queue-dead-letter-revive" },
+        async () => 3,
+      ),
+    ).resolves.toBe(3);
+
+    expect(mocks.captureCheckIn).toHaveBeenNthCalledWith(
+      1,
+      { monitorSlug: "gittensory-selfhost-prod-queue-dead-letter-revive", status: "in_progress" },
+      expect.objectContaining({
+        schedule: { type: "interval", value: 30, unit: "minute" },
+        checkinMargin: 10,
+        maxRuntime: 5,
+        failureIssueThreshold: 2,
+        recoveryThreshold: 1,
+      }),
+    );
+    expect(mocks.captureCheckIn).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        monitorSlug: "gittensory-selfhost-prod-queue-dead-letter-revive",
+        status: "ok",
+        checkInId: "check-in-id",
+        duration: expect.any(Number),
+      }),
+    );
+    expect(mocks.captureException).not.toHaveBeenCalled();
   });
 
   it("records successful Sentry cron monitor check-ins with the configured schedule", async () => {

--- a/test/unit/selfhost-sentry.test.ts
+++ b/test/unit/selfhost-sentry.test.ts
@@ -636,6 +636,52 @@ describe("enabled when SENTRY_DSN is set", () => {
     expect(mocks.captureException).not.toHaveBeenCalled();
   });
 
+  it("derives the dead-letter-revive schedule from an operator's configured interval override (#1824 regression)", async () => {
+    process.env.QUEUE_DEAD_LETTER_REVIVE_INTERVAL_MS = String(90 * 60_000);
+    try {
+      await initSentry({
+        SENTRY_DSN: "d",
+        SENTRY_ENVIRONMENT: "prod",
+      } as unknown as NodeJS.ProcessEnv);
+
+      await withSentryMonitor("queue-dead-letter-revive", { jobType: "queue-dead-letter-revive" }, async () => 1);
+
+      expect(mocks.captureCheckIn).toHaveBeenNthCalledWith(
+        1,
+        { monitorSlug: "gittensory-selfhost-prod-queue-dead-letter-revive", status: "in_progress" },
+        expect.objectContaining({
+          schedule: { type: "interval", value: 90, unit: "minute" },
+          checkinMargin: 30,
+        }),
+      );
+    } finally {
+      delete process.env.QUEUE_DEAD_LETTER_REVIVE_INTERVAL_MS;
+    }
+  });
+
+  it("floors an operator's dead-letter-revive interval override to at least 1 minute for the monitor schedule", async () => {
+    process.env.QUEUE_DEAD_LETTER_REVIVE_INTERVAL_MS = "1000";
+    try {
+      await initSentry({
+        SENTRY_DSN: "d",
+        SENTRY_ENVIRONMENT: "prod",
+      } as unknown as NodeJS.ProcessEnv);
+
+      await withSentryMonitor("queue-dead-letter-revive", { jobType: "queue-dead-letter-revive" }, async () => 1);
+
+      expect(mocks.captureCheckIn).toHaveBeenNthCalledWith(
+        1,
+        { monitorSlug: "gittensory-selfhost-prod-queue-dead-letter-revive", status: "in_progress" },
+        expect.objectContaining({
+          schedule: { type: "interval", value: 1, unit: "minute" },
+          checkinMargin: 5,
+        }),
+      );
+    } finally {
+      delete process.env.QUEUE_DEAD_LETTER_REVIVE_INTERVAL_MS;
+    }
+  });
+
   it("records successful Sentry cron monitor check-ins with the configured schedule", async () => {
     await initSentry({
       SENTRY_DSN: "d",

--- a/test/unit/selfhost-sqlite-queue.test.ts
+++ b/test/unit/selfhost-sqlite-queue.test.ts
@@ -6,6 +6,7 @@ import { jobCoalesceKey, queueSnapshotFromBinding } from "../../src/selfhost/que
 import { renderMetrics, resetMetrics } from "../../src/selfhost/metrics";
 import { RetryableJobError } from "../../src/queue/retryable";
 import { hostLoadAvg1PerCore } from "../../src/selfhost/host-pressure";
+import * as sentryModule from "../../src/selfhost/sentry";
 import type { JobMessage } from "../../src/types";
 
 // Real host CPU load is nondeterministic (and can legitimately spike on a busy CI runner), so every
@@ -2052,6 +2053,63 @@ describe("createSqliteQueue (durable #980)", () => {
       const logged = errorSpy.mock.calls.map(([line]) => String(line));
       expect(logged.some((line) => line.includes("selfhost_queue_dead_letter_revive_crashed") && line.includes("disk I/O error"))).toBe(true);
       await q.stop();
+    });
+
+    // (#1824): dead-letter revival stopping SILENTLY is worse than one throwing tick -- a Sentry cron monitor
+    // now wraps every tick so a stopped timer shows up as a missed check-in, not silence.
+    it("wraps each revive tick in the queue-dead-letter-revive Sentry monitor", async () => {
+      process.env.QUEUE_DEAD_LETTER_REVIVE_INTERVAL_MS = "1000";
+      vi.useFakeTimers();
+      const monitorSpy = vi.spyOn(sentryModule, "withSentryMonitor");
+      try {
+        const driver = makeDriver();
+        const q = createSqliteQueue(driver, async () => undefined, { maxRetries: 1 });
+
+        q.start();
+        await vi.advanceTimersByTimeAsync(1000); // the revive interval fires once
+
+        expect(monitorSpy).toHaveBeenCalledWith(
+          "queue-dead-letter-revive",
+          { jobType: "queue-dead-letter-revive" },
+          expect.any(Function),
+        );
+        await q.stop();
+      } finally {
+        monitorSpy.mockRestore();
+      }
+    });
+
+    // The monitor rethrows on failure (withSentryMonitor's own contract) -- confirms that rethrow is still caught
+    // by reviveDeadLetterJobsSafely's own try/catch, so a crashing tick behaves exactly as it did before the
+    // monitor was added: logged + captured, never an uncaught exception.
+    it("still catches a revive crash after adding the Sentry monitor wrapper (no regression on #2581)", async () => {
+      process.env.QUEUE_DEAD_LETTER_REVIVE_INTERVAL_MS = "1000";
+      vi.useFakeTimers();
+      const monitorSpy = vi.spyOn(sentryModule, "withSentryMonitor");
+      try {
+        const driver = makeDriver();
+        const realQuery = driver.query.bind(driver);
+        vi.spyOn(driver, "query").mockImplementation((sql: string, params: unknown[]) => {
+          if (sql.includes("WHERE status='dead' AND attempts<?")) throw new Error("disk I/O error");
+          return realQuery(sql, params);
+        });
+        const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+        const q = createSqliteQueue(driver, async () => undefined, { maxRetries: 1 });
+
+        q.start();
+        await vi.advanceTimersByTimeAsync(1000);
+
+        expect(monitorSpy).toHaveBeenCalledWith(
+          "queue-dead-letter-revive",
+          { jobType: "queue-dead-letter-revive" },
+          expect.any(Function),
+        );
+        const logged = errorSpy.mock.calls.map(([line]) => String(line));
+        expect(logged.some((line) => line.includes("selfhost_queue_dead_letter_revive_crashed") && line.includes("disk I/O error"))).toBe(true);
+        await q.stop();
+      } finally {
+        monitorSpy.mockRestore();
+      }
     });
   });
 

--- a/test/unit/webhook.test.ts
+++ b/test/unit/webhook.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Context } from "hono";
 import { enqueueWebhookByEnv, handleGitHubWebhook, handleOrbRelay } from "../../src/github/webhook";
 import { getWebhookEvent, recordWebhookEvent } from "../../src/db/repositories";
@@ -73,12 +73,26 @@ describe("github webhook enqueue failure (#786)", () => {
       },
     } as unknown as Context<{ Bindings: Env }>;
 
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
     const response = await handleGitHubWebhook(context);
     expect(response.status).toBe(500);
     await expect(response.json()).resolves.toMatchObject({ error: "enqueue_failed" });
     const event = await getWebhookEvent(env, "enqueue-missing-binding-1");
     expect(event?.status).toBe("error");
     expect(await renderMetrics()).toContain('gittensory_webhook_enqueue_total{action="opened",event="pull_request",result="enqueue_failed"} 1');
+    // ERROR level so the central Sentry forwarder captures a missing-binding webhook ingest failure (#1824) --
+    // previously this only moved a Prometheus counter, invisible without comparing dashboards.
+    expect(
+      errorSpy.mock.calls.some((c) => {
+        const line = String(c[0]);
+        return (
+          line.includes("selfhost_webhook_enqueue_binding_missing") &&
+          line.includes('"eventName":"pull_request"') &&
+          line.includes("JSONbored/gittensory")
+        );
+      }),
+    ).toBe(true);
+    errorSpy.mockRestore();
   });
 
   it("flags the event 'error' and returns 500 when the queue send fails", async () => {
@@ -109,6 +123,7 @@ describe("github webhook enqueue failure (#786)", () => {
       },
     } as unknown as Context<{ Bindings: Env }>;
 
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
     const response = await handleGitHubWebhook(context);
     expect(response.status).toBe(500);
     await expect(response.json()).resolves.toMatchObject({ error: "enqueue_failed" });
@@ -116,6 +131,91 @@ describe("github webhook enqueue failure (#786)", () => {
     const event = await getWebhookEvent(env, "enqueue-fail-1");
     expect(event?.status).toBe("error");
     expect(await renderMetrics()).toContain('gittensory_webhook_enqueue_total{action="opened",event="pull_request",result="enqueue_failed"} 1');
+    // ERROR level so the central Sentry forwarder captures a failing webhook enqueue (#1824). Never logs rawBody
+    // or the parsed payload -- only delivery routing metadata + the thrown error's message.
+    expect(
+      errorSpy.mock.calls.some((c) => {
+        const line = String(c[0]);
+        return (
+          line.includes("selfhost_webhook_enqueue_failed") &&
+          line.includes('"eventName":"pull_request"') &&
+          line.includes("JSONbored/gittensory") &&
+          line.includes("queue unavailable")
+        );
+      }),
+    ).toBe(true);
+    errorSpy.mockRestore();
+  });
+
+  it("never logs the raw webhook body or parsed payload alongside an enqueue failure (secret-scrub boundary, #1824)", async () => {
+    const env = createTestEnv();
+    env.WEBHOOKS = {
+      send: async () => {
+        throw new Error("queue unavailable");
+      },
+    } as unknown as Queue;
+    const rawBody = JSON.stringify({
+      action: "opened",
+      repository: { full_name: "JSONbored/gittensory" },
+      installation: { id: 1 },
+      pull_request: { title: "raw diff with a secret token gho_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" },
+    });
+    const signature = await signWebhook(rawBody, env.GITHUB_WEBHOOK_SECRET);
+    const request = new Request("https://example.com/webhook", { method: "POST", body: rawBody });
+    const headers: Record<string, string> = {
+      "x-github-delivery": "enqueue-fail-scrub-1",
+      "x-github-event": "pull_request",
+      "x-hub-signature-256": signature,
+    };
+    const context = {
+      req: {
+        raw: request,
+        header(name: string) {
+          return headers[name.toLowerCase()] ?? null;
+        },
+      },
+      env,
+      json(payload: unknown, status?: number) {
+        return Response.json(payload, status === undefined ? undefined : { status });
+      },
+    } as unknown as Context<{ Bindings: Env }>;
+
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    await handleGitHubWebhook(context);
+    const logged = errorSpy.mock.calls.map((c) => String(c[0])).join("\n");
+    expect(logged).toContain("selfhost_webhook_enqueue_failed");
+    expect(logged).not.toContain("raw diff");
+    expect(logged).not.toContain("gho_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+    errorSpy.mockRestore();
+  });
+
+  it("stringifies a non-Error throw from WEBHOOKS.send in the Sentry-forwarded log (branch coverage)", async () => {
+    const env = createTestEnv();
+    env.WEBHOOKS = {
+      send: async () => {
+        throw "queue rejected: not an Error instance"; // non-Error throw, exercises the String(error) branch
+      },
+    } as unknown as Queue;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const result = await enqueueWebhookByEnv(
+      env,
+      "enqueue-fail-non-error-1",
+      "pull_request",
+      JSON.stringify({ action: "opened", repository: { full_name: "JSONbored/gittensory" }, installation: { id: 1 } }),
+    );
+
+    expect(result).toBe("enqueue_failed");
+    expect(
+      errorSpy.mock.calls.some((c) => {
+        const line = String(c[0]);
+        return (
+          line.includes("selfhost_webhook_enqueue_failed") &&
+          line.includes("queue rejected: not an Error instance")
+        );
+      }),
+    ).toBe(true);
+    errorSpy.mockRestore();
   });
 });
 

--- a/test/unit/webhook.test.ts
+++ b/test/unit/webhook.test.ts
@@ -158,7 +158,7 @@ describe("github webhook enqueue failure (#786)", () => {
       action: "opened",
       repository: { full_name: "JSONbored/gittensory" },
       installation: { id: 1 },
-      pull_request: { title: "raw diff with a secret token gho_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA" },
+      pull_request: { title: "raw diff with a secret token UNIQUE-PAYLOAD-MARKER-THAT-MUST-NEVER-LEAK" },
     });
     const signature = await signWebhook(rawBody, env.GITHUB_WEBHOOK_SECRET);
     const request = new Request("https://example.com/webhook", { method: "POST", body: rawBody });
@@ -185,7 +185,7 @@ describe("github webhook enqueue failure (#786)", () => {
     const logged = errorSpy.mock.calls.map((c) => String(c[0])).join("\n");
     expect(logged).toContain("selfhost_webhook_enqueue_failed");
     expect(logged).not.toContain("raw diff");
-    expect(logged).not.toContain("gho_AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA");
+    expect(logged).not.toContain("UNIQUE-PAYLOAD-MARKER-THAT-MUST-NEVER-LEAK");
     errorSpy.mockRestore();
   });
 


### PR DESCRIPTION
## Summary

Advances #1824. This PR expands the *existing* self-host Sentry instrumentation (`src/selfhost/sentry.ts`, already a mature no-op-when-unset system with scrubbing, structured-log forwarding, and four cron monitors) with two concrete, previously-missing pieces from the issue's coverage list:

1. **Webhook ingest failures are now Sentry-visible.** `enqueueWebhookByEnv` (`src/github/webhook.ts`) had two `enqueue_failed` branches — a missing `WEBHOOKS` binding, and `WEBHOOKS.send()` throwing — that only incremented a Prometheus counter. Both now emit a `level:"error"` structured log (`selfhost_webhook_enqueue_binding_missing` / `selfhost_webhook_enqueue_failed`) that the existing central Sentry forwarder (`forwardStructuredLogToSentry`, installed in `server.ts`) already picks up automatically. Only delivery routing metadata (event name, repo full name, error message) is logged — never the raw body or parsed payload.
2. **Dead-letter revival gets a Sentry cron monitor.** The 30-minute revive interval (both `pg-queue.ts` and `sqlite-queue.ts`) already logged + `captureError`'d a *crashing* tick, but a *silently stopped* timer (the interval never fires again) reported nothing at all — worse than a throwing tick, and exactly the gap the issue calls out for "scheduled sweep and dead-letter-queue paths." Added a new `queue-dead-letter-revive` monitor to `SENTRY_MONITORS`, wired into both backends' `reviveDeadLetterJobsSafely` via the same `withSentryMonitor` helper already used for `scheduled-loop`/`orb-export`/`orb-relay-drain`/`orb-relay-register`.

### What I checked against the issue's full list before making changes

Before writing anything I read `src/selfhost/sentry.ts` end-to-end plus every existing call site, and traced the issue's checklist against what's already wired:

- **Gate/check-run publish, comment publish, AI provider attempts** (`src/github/app.ts`, `src/review/inline-comments.ts`, `src/review/rag.ts`, `src/review/enrichment-wire.ts`, `src/selfhost/ai.ts`, `src/services/ai-review.ts`) — already emit structured `level:"error"` logs that the central forwarder captures. No gap found.
- **GitHub token/broker calls** (`src/github/app.ts` `mintInstallationToken`, `src/orb/broker-client.ts`) — `orb_broker_unavailable` / `github_app_jwt_rejected` / `orb_broker_degraded_serving_cached_token` are already structured `console.error`/`console.warn` logs, forwarded automatically. No gap found.
- **Queue claim/process** — already covered via `captureError` on lease-expiry / unparseable-payload / pump-crash paths in both queue backends.
- **Scheduled sweep** — already has its own `scheduled-loop` Sentry monitor (`monitored-work.ts`).
- **Backup/relay failures** — Litestream runs as a separate Docker sidecar, outside `src/` and outside this Node process's Sentry reach; the boot-time `selfhost_backup_advisory` warn is already forwarded. Orb relay (push/pull registration, drain) already has three dedicated monitors + `pruneRelayPending`'s alertable log. No further self-host-reachable gap found here.
- **Webhook ingest** and **dead-letter-queue silent stoppage** — genuine gaps, fixed in this PR.

### What remains (not done in this PR)

- I did not add any *new* scrub rules to `scrubEvent`/`shouldRedactKey` — the two new log sites reuse the existing convention (structured JSON via `console.error`, only routing metadata, no payload/body fields) and needed no new redaction surface.
- I did not touch Orb-side (`src/orb/*` cloud Worker) logging — that's a different runtime (Cloudflare Worker, not the self-host Node process `sentry.ts` targets) and out of scope for self-host observability.
- The issue's checklist is broad; this PR closes the two remaining self-host-reachable gaps I could find after auditing every existing capture site. I'm not marking this as closing #1824 outright since I can't rule out further gaps a maintainer might want covered (e.g. deeper AI-provider-attempt granularity, or additional monitor slugs) without more direction — hence "Advances," not "Closes."

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue (#1824) — see "What remains" above for why this doesn't use a closing keyword.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` (not run locally — no workflow files touched)
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — not run in full (per this repo's own guidance: full local `test:coverage`/`test:ci` duplicates what CI already runs); instead ran the specific affected files directly plus `test:changed` against `origin/main`, all green: `selfhost-sentry.test.ts`, `selfhost-sentry-release.test.ts`, `selfhost-pg-queue.test.ts`, `selfhost-sqlite-queue.test.ts`, `webhook.test.ts` (336 tests), and `npm run test:changed` (1918 tests across 61 files, 0 failures). New/changed lines in `src/github/webhook.ts`, `src/selfhost/pg-queue.ts`, `src/selfhost/sqlite-queue.ts`, `src/selfhost/sentry.ts` are covered on both the success and thrown-non-Error branches.
- [ ] `npm run test:workers` (not run locally — no Worker-specific paths touched; `src/index.ts` bundle untouched)
- [ ] `npm run build:mcp` (not run locally — no MCP package changes)
- [ ] `npm run test:mcp-pack` (not run locally — no MCP package changes)
- [ ] `npm run ui:openapi:check` (not run locally — no API/schema changes)
- [x] `npm run ui:lint` (0 errors; only the pre-existing repo-wide `react-refresh/only-export-components` route-metadata warning, present on every docs route file including the one touched)
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — see test list below

If any required check was skipped, explain why:

- CI's `validate` job runs the full `test:ci`/`test:coverage`/`test:workers`/MCP/OpenAPI suite unsharded; I ran targeted subsets locally (the affected test files + `test:changed`) per this repo's own documented practice of trusting CI for the full gate rather than duplicating it, since this PR touches neither Worker bindings, the MCP package, nor any OpenAPI-surfaced route.

### Tests added

- `test/unit/selfhost-sentry.test.ts` — new `queue-dead-letter-revive` monitor slug + successful check-in schedule assertions.
- `test/unit/selfhost-pg-queue.test.ts` / `test/unit/selfhost-sqlite-queue.test.ts` — each gets two new tests: the revive tick is wrapped in `withSentryMonitor` with the right monitor name/context (spied via the real `sentry` module, matching this repo's existing `vi.spyOn(sentryModule, "captureReviewFailure")` convention), and a crashing tick still gets caught/logged after adding the wrapper (no regression on the prior crash-safety fix).
- `test/unit/webhook.test.ts` — both existing enqueue-failure tests now also assert the new structured Sentry-forwarded log line; a new secret-scrub-boundary test proves a raw diff/token in the payload never reaches the log; a new branch-coverage test exercises a non-`Error` throw from `WEBHOOKS.send()`.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/cookie/CORS changes; SENTRY_DSN-unset no-op path is already covered by pre-existing generic tests in `selfhost-sentry.test.ts`, which I verified still pass unchanged.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP surface changed.)
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — docs-only prose change, no UI state.)
- [ ] Visible UI changes include a `UI Evidence` section. (N/A — text-only docs content added to an existing docs page structure, no new visual state; consistent with the immediately-prior same-day docs PR for #1829 on this same route family, which also shipped without screenshots.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. Updated `docs.self-hosting-operations.tsx`'s "Important log events," "Sentry cron monitors," and "Routine checks" sections to reflect the new coverage.

## Notes

- Ran `npm run typecheck`, the affected test files (336 tests), `npm run test:changed` (1918 tests, 0 failures), `npm run ui:typecheck`, `npm run ui:lint`, `npm run ui:build`, `npm run docs:drift-check`, `node scripts/validate-observability-configs.mjs`, and `npm audit --audit-level=moderate` — all green.
- Rebased onto fresh `origin/main` (currently at `c6aa58c7`) immediately before pushing; no migration or file conflicts.