### PR TITLE
docs(selfhost): document measured resource profiles and trim image bloat

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -12,6 +12,12 @@ dist-ssr
 coverage
 .git
 .claude
+# The self-host bundle's only entry point is src/server.ts (scripts/build-selfhost.mjs) and `npm ci`
+# only ever sees the root package*.json (copied before the rest of the tree) — the gittensory-ui
+# workspace app and the test suite are never read during the image build, so keep both out of the
+# build context entirely (measured: ~11MB of this repo's ~22MB tracked-file footprint).
+apps
+test
 # Runtime-only private review config and subscription CLI auth must never enter image layers.
 gittensory-config
 **/gittensory-config

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,8 +45,12 @@ RUN mkdir -p /home/node/.npm-global /home/node/.npm \
     && ln -s /data/codex /home/node/.codex \
     && chown -h node:node /home/node/.codex \
     && chown -R node:node /home/node/.npm-global /home/node/.npm
+# `npm install -g` populates ~/.npm/_cacache (the download cache) as a side effect, but nothing at
+# runtime ever reads it -- left alone it becomes ~180MB of dead weight baked permanently into this
+# layer (measured: node_modules for both CLIs together is ~465MB, the npm cache adds another ~180MB
+# on top for zero runtime benefit). `npm cache clean --force` after the install trims that for free.
 USER node
-RUN if [ "$INSTALL_AI_CLIS" = "true" ]; then npm install -g --foreground-scripts @anthropic-ai/claude-code@2.1.187 @openai/codex@0.142.0; fi
+RUN if [ "$INSTALL_AI_CLIS" = "true" ]; then npm install -g --foreground-scripts @anthropic-ai/claude-code@2.1.187 @openai/codex@0.142.0 && npm cache clean --force; fi
 USER root
 # Optional: enable visual review via an external Chrome sidecar (e.g. `browserless/chrome:latest`).
 # Build with `--build-arg INSTALL_VISUAL_REVIEW=true` then set BROWSER_WS_ENDPOINT=<ws-url> at runtime.

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-operations.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-operations.tsx
@@ -131,12 +131,203 @@ docker compose --profile postgres --profile observability --profile backup up -d
         watching for.
       </p>
 
-      <h2>Docker resource hygiene</h2>
+      <h2>Resource profiles</h2>
       <p>
-        Every service in <code>docker-compose.yml</code> caps its own container logs (10MB × 3
-        rotated files) out of the box, so log growth alone won&apos;t fill your disk. Unused Docker
-        images and build cache are a separate, larger disk-growth vector on a host that rebuilds or
-        pulls images repeatedly over months — Docker does not reclaim either automatically.
+        <strong>Measured</strong> rows below come from a real production instance running the full
+        profile set (<code>qdrant</code> + <code>redis</code> + <code>observability</code> +{" "}
+        <code>backup</code> + <code>postgres</code> + <code>ollama</code>) at steady state —
+        <code>docker stats</code> and <code>docker system df</code> snapshots, not a lab benchmark.
+        <strong> Estimated</strong> rows are reasoned from that same baseline plus each
+        service&apos;s declared <code>deploy.resources.limits</code> and image size in{" "}
+        <code>docker-compose.yml</code> — they have not been measured directly and could be off,
+        especially for CPU under real load. Treat estimates as a starting point for capacity
+        planning, not a guarantee.
+      </p>
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse text-token-sm">
+          <thead>
+            <tr className="border-hairline text-left text-token-xs text-muted-foreground">
+              <th className="py-2 pr-4 font-medium">Profile</th>
+              <th className="py-2 pr-4 font-medium">CPU (steady state)</th>
+              <th className="py-2 pr-4 font-medium">Memory (steady state)</th>
+              <th className="py-2 font-medium">Basis</th>
+            </tr>
+          </thead>
+          <tbody className="divide-hairline">
+            <tr>
+              <td className="py-2 pr-4 align-top">
+                Minimal — app + <code>redis</code> only (no profile flags)
+              </td>
+              <td className="py-2 pr-4 align-top text-muted-foreground">~3% of one core</td>
+              <td className="py-2 pr-4 align-top text-muted-foreground">~400–600MiB</td>
+              <td className="py-2 align-top text-muted-foreground">
+                Estimated: app + redis measured in isolation from the full-profile snapshot (app
+                2.6% CPU / 365MiB; redis is idle-light and its 512MiB limit is never approached in
+                the full-profile run either).
+              </td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 align-top">
+                + <code>--profile postgres</code>
+              </td>
+              <td className="py-2 pr-4 align-top text-muted-foreground">
+                +14% of one core (highest single-service CPU consumer)
+              </td>
+              <td className="py-2 pr-4 align-top text-muted-foreground">+~200MiB</td>
+              <td className="py-2 align-top text-muted-foreground">
+                Measured: 14.24% CPU / 196MiB of its 2GiB limit — comfortable headroom on memory,
+                but the largest CPU line item in the whole stack.
+              </td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 align-top">
+                + <code>--profile qdrant</code>
+              </td>
+              <td className="py-2 pr-4 align-top text-muted-foreground">Low single-digit %</td>
+              <td className="py-2 pr-4 align-top text-muted-foreground">
+                Well under its 2GiB limit
+              </td>
+              <td className="py-2 align-top text-muted-foreground">
+                Measured (part of the full-profile snapshot's "everything else" low-CPU, under-limit
+                group). Grows with RAG corpus size — expect this to climb on installs with many
+                indexed repos.
+              </td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 align-top">
+                + <code>--profile observability</code>
+              </td>
+              <td className="py-2 pr-4 align-top text-muted-foreground">
+                Low single-digit % per service, except Grafana/Tempo below
+              </td>
+              <td className="py-2 pr-4 align-top text-muted-foreground">
+                Grafana ~305MiB (60% of 512MiB); Tempo ~209MiB (20% of 1GiB); Prometheus/Loki/
+                Alertmanager/Promtail/otel-collector each well under their limits
+              </td>
+              <td className="py-2 align-top text-muted-foreground">
+                Measured. Grafana is the closest any service comes to its ceiling in production —
+                worth watching if you add many custom dashboards or panels, but not currently a
+                problem (40% headroom remains).
+              </td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 align-top">
+                + <code>--profile ollama</code>
+              </td>
+              <td className="py-2 pr-4 align-top text-muted-foreground">
+                Near-zero idle; spikes hard during inference
+              </td>
+              <td className="py-2 pr-4 align-top text-muted-foreground">
+                Model-dependent, up to its 8GiB limit
+              </td>
+              <td className="py-2 align-top text-muted-foreground">
+                Estimated. Not part of the live production profile mix (that instance uses{" "}
+                <code>AI_PROVIDER=codex</code>, not Ollama) — the 8GiB default limit is sized for a
+                single loaded 7–8B quantized model per the compose comment, not measured against a
+                running model. Idle Ollama with no model pulled is cheap; a loaded model can
+                legitimately approach the limit, which is why it has the largest default ceiling in
+                the file.
+              </td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 align-top">
+                + <code>--profile backup</code>
+              </td>
+              <td className="py-2 pr-4 align-top text-muted-foreground">
+                Near-zero except during runs
+              </td>
+              <td className="py-2 pr-4 align-top text-muted-foreground">
+                Low, bursts during dump/restore
+              </td>
+              <td className="py-2 align-top text-muted-foreground">
+                Measured as part of the full-profile snapshot (no dedicated resource limit is set
+                for <code>backup</code>/<code>backup-exporter</code> — both are short-lived or
+                idle-polling processes, not sustained consumers).
+              </td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 align-top">
+                + <code>--profile runners</code>
+              </td>
+              <td className="py-2 pr-4 align-top text-muted-foreground">
+                Unbounded by default — can starve the app under CI load
+              </td>
+              <td className="py-2 pr-4 align-top text-muted-foreground">Unbounded by default</td>
+              <td className="py-2 align-top text-muted-foreground">
+                Estimated, and explicitly a known risk, not a guess about typical usage: the{" "}
+                <code>runner</code> service ships with no CPU/memory limit at all. Production
+                experience already documented in <code>docker-compose.override.yml.example</code>{" "}
+                found 3 uncapped runner containers starving the app for CPU on an 8-vCPU box under
+                real CI load — see that file for the <code>cpu_shares</code>/<code>cpus</code>{" "}
+                mitigation before co-locating runners with the review stack.
+              </td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 align-top">
+                Full profile set (<code>qdrant</code> + <code>redis</code> +{" "}
+                <code>observability</code> + <code>backup</code> + <code>postgres</code> +{" "}
+                <code>ollama</code>, no active inference, no runners)
+              </td>
+              <td className="py-2 pr-4 align-top text-muted-foreground">
+                Postgres (~14%) dominates; everything else low single-digit %
+              </td>
+              <td className="py-2 pr-4 align-top text-muted-foreground">
+                No service near its limit except Grafana (~60%)
+              </td>
+              <td className="py-2 align-top text-muted-foreground">
+                Measured, in full, on a real production instance.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+
+      <h3>Disk</h3>
+      <p>
+        Measured on the same production instance: 48GB of 151GB used on the host root volume (32%)
+        at steady state. <code>docker system df</code> breakdown:
+      </p>
+      <FeatureRow
+        items={[
+          {
+            title: "Images",
+            description: "22.59GB total, 19.24GB (85%) reclaimable via prune.",
+          },
+          {
+            title: "Volumes",
+            description:
+              "20.57GB total, 5.4GB (26%) reclaimable — this is real application state (databases, vector index, backups), so most of it is never pruned.",
+          },
+          {
+            title: "Build cache",
+            description: "6.39GB total, 3.55GB (56%) reclaimable.",
+          },
+        ]}
+      />
+      <p>
+        The reclaimable image and build-cache space here is{" "}
+        <strong>expected steady state, not a leak</strong> — this instance runs{" "}
+        <code>scripts/deploy-selfhost-prebuilt.sh</code>, which rebuilds the image from the current
+        git checkout on every deploy and intentionally keeps prior layers around in the build cache
+        for faster rebuilds. The <code>gittensory-docker-safe-prune</code> systemd timer (below)
+        already runs daily against this exact instance and reclaims it on a schedule, so this is not
+        a number to chase down manually.
+      </p>
+
+      <h3>When a compose default might need to change</h3>
+      <p>
+        Every <code>deploy.resources.limits.memory</code> in <code>docker-compose.yml</code> is
+        operator-overridable via <code>.env</code> (see the <code>*_MEM_LIMIT</code> variables in{" "}
+        <code>.env.example</code>). Against the measured full-profile data above, none of the
+        current defaults look miscalibrated enough to change: nothing sits consistently near its
+        limit in a way that risks an OOM kill under normal load (Grafana&apos;s ~60% is the closest
+        and still has real headroom), and nothing is so oversized relative to plausible usage that
+        it should be lowered — including Ollama&apos;s comparatively large 8GiB ceiling, which is
+        sized for holding one quantized model in memory, not idle overhead. The one real gap is{" "}
+        <code>--profile runners</code>, which ships with no limit at all; that is a known,
+        documented tradeoff (see the table above and{" "}
+        <code>docker-compose.override.yml.example</code>) rather than an oversight, since the right
+        ceiling depends entirely on the host's core count and how many runner replicas you run.
       </p>
       <p>
         Install the provided host-level timer to reclaim both on a schedule (anything unused for

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-operations.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-operations.tsx
@@ -329,6 +329,14 @@ docker compose --profile postgres --profile observability --profile backup up -d
         <code>docker-compose.override.yml.example</code>) rather than an oversight, since the right
         ceiling depends entirely on the host's core count and how many runner replicas you run.
       </p>
+
+      <h2>Docker resource hygiene</h2>
+      <p>
+        Every service in <code>docker-compose.yml</code> caps its own container logs (10MB × 3
+        rotated files) out of the box, so log growth alone won&apos;t fill your disk. Unused Docker
+        images and build cache are a separate, larger disk-growth vector on a host that rebuilds or
+        pulls images repeatedly over months — Docker does not reclaim either automatically.
+      </p>
       <p>
         Install the provided host-level timer to reclaim both on a schedule (anything unused for
         less than 7 days is left alone, so a recent deploy is never at risk):


### PR DESCRIPTION
## Summary

- Advances #1828 (profile stack resources and tune defaults). Adds a **Resource profiles** section to the self-host operations docs with a measured-vs-estimated CPU/memory matrix per `docker-compose.yml` profile, plus a disk breakdown, sourced from real `docker stats` / `docker system df` snapshots on a production instance running the full profile set (`qdrant` + `redis` + `observability` + `backup` + `postgres` + `ollama`).
- Audits every `deploy.resources.limits.memory` default against that measured data and documents the conclusion: none look miscalibrated enough to change right now (closest is Grafana at ~60% of its 512MiB limit, which still has real headroom). This is a **no-op on `docker-compose.yml` limits**, made explicit in the docs rather than guessed at.
- Trims the self-host runtime image by **188MB (942MB → 754MB, measured before/after with `docker build`/`docker images`)**: `npm install -g` for the bundled Claude Code / Codex CLIs was leaving ~180MB of npm download cache (`~/.npm/_cacache`) baked into the image with zero runtime use; `npm cache clean --force` after the install removes it. Also excludes the unused `apps/` (gittensory-ui) and `test/` directories from the Docker build context via `.dockerignore` — the self-host bundle's only entry point is `src/server.ts` and `npm ci` only ever sees the root `package*.json` (copied before the rest of the tree), so neither directory is ever read during the image build.

### What this PR does NOT do (remaining #1828 scope)

- No compose default changes — the audit concluded none were justified by the data in hand; this is stated explicitly in the docs rather than left implicit.
- `--profile runners` still ships with no CPU/memory limit (documented as a known, deliberate gap — see `docker-compose.override.yml.example` — rather than something this PR fixes, since the right ceiling is host-specific).
- No load-testing or synthetic benchmarking of Redis maxmemory policy, Prometheus/Loki/Tempo retention, or queue concurrency defaults under stress — the issue's "Review Redis maxmemory policy, Prometheus/Loki/Tempo retention..." requirement is not addressed here; this PR is scoped to the resource-profile/image-size half of the issue using data that was already available.
- No dashboard changes for inspecting resource pressure (the issue's "Dashboard or docs updates showing how to inspect resource pressure" deliverable) — Grafana/Prometheus dashboards already exist per the current operations docs; no new panel was added in this PR.

### Measured vs. estimated, explicitly

- **Measured** (real production `docker stats`/`docker system df` snapshot, full profile set, steady state): app 2.6% CPU / 365MiB of 2GiB; postgres 14.24% CPU / 196MiB of 2GiB (highest CPU); grafana 305MiB of 512MiB (~60%); tempo 209MiB of 1GiB (~20%); disk 48GB/151GB (32%) used, with `docker system df` Images/Volumes/Build-cache reclaimable percentages as reported.
- **Estimated** (reasoned from the measured baseline + each service's declared limit/image size, not measured directly): minimal (app+redis only) profile footprint, Ollama under active inference, and the `--profile runners` risk — each is called out in the docs table as estimated, with the reasoning shown.
- **Image-bloat measurement**: built the image locally (`docker build --target runtime`) before and after the fix, confirmed the size delta and inspected `/home/node/.npm/_cacache` (180M) and `/home/node/.npm-global` (465M) inside the built container directly.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes. (Docs + Dockerfile/.dockerignore are both part of the same #1828 profiling/tuning work.)
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue (#1828); see "What this PR does NOT do" above for exactly what remains of that issue's scope.

## Validation

- [ ] `git diff --check` — ran, clean.
- [ ] `npm run actionlint` — not run; no `.github/workflows/**` changes in this PR.
- [x] `npm run typecheck` — clean.
- [ ] `npm run test:coverage` locally — not run; this PR has zero `src/**` changes (docs + Dockerfile + .dockerignore only), so there is no Codecov patch obligation.
- [ ] `npm run test:workers` — not run for the same reason (no `src/**`/worker changes).
- [ ] `npm run build:mcp` / `npm run test:mcp-pack` — not run; no MCP package changes.
- [ ] `npm run ui:openapi:check` — not run; no API/OpenAPI schema changes.
- [x] `npm run ui:lint` — clean (0 errors; only the same pre-existing `react-refresh/only-export-components` warning every other route file in this directory already has).
- [x] `npm run ui:typecheck` — clean.
- [x] `npm run ui:build` — clean, `docs.self-hosting-operations` bundle built successfully.
- [ ] `npm audit --audit-level=moderate` — not run for this docs/Dockerfile-only change; no dependency changes.
- [ ] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — N/A, no `src/**` logic changed.

Additionally validated outside the standard checklist (Docker image change, not covered by the JS test suite):
- Built the runtime image locally with `docker build --target runtime` before and after the `Dockerfile` change; confirmed the final image shrank from 942MB to 754MB.
- Ran the built image's `claude --version` and `codex --version` inside the container to confirm the AI CLIs still work correctly after `npm cache clean --force`.
- Ran a full `docker build --no-cache` after the `.dockerignore` change to confirm `npm ci` and `scripts/build-selfhost.mjs` still succeed with `apps/` and `test/` excluded from the build context.
- Booted the built image standalone and confirmed it fails on the expected self-host preflight validation (missing `SELFHOST_SETUP_TOKEN`/`PUBLIC_API_ORIGIN`), i.e. the bundle executes correctly end-to-end.

If any required check was skipped, explain why:

- This PR touches zero files under `src/**` (only `apps/gittensory-ui/src/routes/**` docs, `Dockerfile`, and `.dockerignore`), so the Codecov-gated JS checks (`test:coverage`, `test:workers`, `build:mcp`, `test:mcp-pack`, `ui:openapi:check`, `npm audit`) don't apply — there is no changed `src/**` line for them to cover, and no dependency or OpenAPI change to check. `actionlint` doesn't apply because no workflow files changed.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed. (The production measurements included are aggregate resource numbers only — no repo names, tokens, or identifying data.)
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no such changes.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no such changes.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (This is a static docs page; no data fetching involved.)
- [x] Visible UI changes include a `UI Evidence` section below.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (`CHANGELOG.md` untouched.)

## UI Evidence

This is a docs-only content addition to an existing, unstyled prose page (new `<h2>`/`<h3>`/`<table>` content using the same `DocsPage`/`FeatureRow` primitives and `border-hairline`/`divide-hairline` design tokens already used elsewhere on this exact page) — no new components, layout, or visual design were introduced.

A full-page screenshot of the new section deep in the page could not be captured in this sandboxed environment: the preview tool's screenshot capture reproducibly returns a blank/black image at any non-zero scroll position on this route, and this reproduces identically on an *unmodified* sibling docs page (`self-hosting-backup-scaling`), confirming it is a pre-existing environment/tooling limitation and not caused by this change.

What was verified instead:
- The rendered SSR HTML (fetched directly from a local dev server running this exact branch) contains the full new section, correctly structured, with the table and all rows rendering as expected HTML (`<table class="w-full border-collapse ...">` etc.).
- The page's accessibility-tree snapshot and the right-hand "on this page" table of contents both show the new "Resource profiles" entry with its "Disk" and "When a compose default might need to change" sub-sections correctly nested, confirming the heading hierarchy renders correctly.
- `npm run ui:build` succeeds and produces the `docs.self-hosting-operations` route bundle with the new content included.

| State / title | Evidence |
| --- | --- |
| Top of page, loaded state (own local dev server, this branch) | Verified visually via preview tool at page top; TOC sidebar shows the new "Resource profiles" entry with nested "Disk" / "When a compose default might need to change" sub-items — screenshot capture below scroll position 0 is blocked by the environment limitation described above, not by this change. |

## Notes

- The npm-cache and `.dockerignore` findings were discovered by actually building the image locally (`docker build --target runtime -t ... .`) and inspecting the resulting layers with `docker history --no-trunc` and `docker run ... du -sh`, rather than guessed — see the Validation section above for the exact before/after numbers.
- A sibling PR (#3191, already merged to `main`) covers the update/rollback documentation gap called out in this issue's parent thread; this PR does not touch that file (`docs.self-hosting-releases.tsx`) and there is no overlap.