### PR TITLE
test(enrichment): unit coverage for the heavy-dependency pure helpers

### DIFF
--- a/review-enrichment/test/heavy-dependency.test.ts
+++ b/review-enrichment/test/heavy-dependency.test.ts
@@ -5,6 +5,8 @@ import {
   queryPackageWeight,
   resetWeightCacheForTest,
   weightCacheSizeForTest,
+  countPackagePatchUsages,
+  isHeavyPackageWeight,
 } from "../dist/analyzers/heavy-dependency.js";
 
 beforeEach(() => {
@@ -161,4 +163,83 @@ test("queryPackageWeight: the cache is bounded, evicting the oldest entry once a
   };
   await queryPackageWeight("pkg-0", "1.0.0", countingFetch);
   assert.equal(calls, 1, "the oldest entry (pkg-0) should have been evicted and require a real re-fetch");
+});
+
+const patchFile = (path, lines) => ({
+  path,
+  patch: `@@ -1,1 +1,${lines.length} @@\n${lines.map((l) => `+${l}`).join("\n")}`,
+});
+
+test("countPackagePatchUsages: counts multiple require/import occurrences of the same package", () => {
+  const files = [
+    patchFile("src/a.ts", [`const x = require("left-pad");`, `import y from "left-pad";`]),
+  ];
+  const usage = countPackagePatchUsages(files, "left-pad");
+  assert.equal(usage.usageCount, 2);
+  assert.deepEqual(usage.usageLocations, [
+    { file: "src/a.ts", line: 1 },
+    { file: "src/a.ts", line: 2 },
+  ]);
+});
+
+test("countPackagePatchUsages: a package with no added-line usage returns zero and an empty location list", () => {
+  const files = [patchFile("src/a.ts", [`const x = require("other-pkg");`])];
+  assert.deepEqual(countPackagePatchUsages(files, "left-pad"), { usageCount: 0, usageLocations: [] });
+});
+
+test("countPackagePatchUsages: an empty files array returns zero usage", () => {
+  assert.deepEqual(countPackagePatchUsages([], "left-pad"), { usageCount: 0, usageLocations: [] });
+});
+
+test("countPackagePatchUsages: usageLocations caps at TRIVIAL_USAGE_MAX (2) but usageCount keeps counting past it", () => {
+  const files = [
+    patchFile("src/a.ts", [`require("left-pad");`, `require("left-pad");`, `require("left-pad");`]),
+  ];
+  const usage = countPackagePatchUsages(files, "left-pad");
+  assert.equal(usage.usageCount, 3);
+  assert.equal(usage.usageLocations.length, 2);
+});
+
+test("countPackagePatchUsages: an identical import line repeated across files counts each occurrence independently, not deduped", () => {
+  const files = [patchFile("src/a.ts", [`import "left-pad";`]), patchFile("src/b.ts", [`import "left-pad";`])];
+  const usage = countPackagePatchUsages(files, "left-pad");
+  assert.equal(usage.usageCount, 2);
+  assert.deepEqual(usage.usageLocations, [
+    { file: "src/a.ts", line: 1 },
+    { file: "src/b.ts", line: 1 },
+  ]);
+});
+
+test("countPackagePatchUsages: resolves a deep subpath import and a scoped package to their package root", () => {
+  const files = [
+    patchFile("src/a.ts", [`import debounce from "lodash/debounce";`, `import z from "@scope/pkg/sub/path";`]),
+  ];
+  assert.equal(countPackagePatchUsages(files, "lodash").usageCount, 1);
+  assert.equal(countPackagePatchUsages(files, "@scope/pkg").usageCount, 1);
+});
+
+test("isHeavyPackageWeight: flags at-or-above each individual threshold (install, bundle, gzip)", () => {
+  assert.equal(
+    isHeavyPackageWeight({ installSizeBytes: 500_000, bundleSizeBytes: null, gzipSizeBytes: null, dependencyCount: null }),
+    true,
+  );
+  assert.equal(
+    isHeavyPackageWeight({ installSizeBytes: null, bundleSizeBytes: 80_000, gzipSizeBytes: null, dependencyCount: null }),
+    true,
+  );
+  assert.equal(
+    isHeavyPackageWeight({ installSizeBytes: null, bundleSizeBytes: null, gzipSizeBytes: 25_000, dependencyCount: null }),
+    true,
+  );
+});
+
+test("isHeavyPackageWeight: does not flag just below every threshold, or all-null weights", () => {
+  assert.equal(
+    isHeavyPackageWeight({ installSizeBytes: 499_999, bundleSizeBytes: 79_999, gzipSizeBytes: 24_999, dependencyCount: null }),
+    false,
+  );
+  assert.equal(
+    isHeavyPackageWeight({ installSizeBytes: null, bundleSizeBytes: null, gzipSizeBytes: null, dependencyCount: null }),
+    false,
+  );
 });


### PR DESCRIPTION
Closes #2100

## Summary

-

## Scope

- [ ] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [ ] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [ ] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [ ] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [ ] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

-

## Safety

- [ ] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [ ] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [ ] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Required for visible UI, frontend, docs, or extension changes. Attach GitHub-hosted JPG/JPEG or PNG screenshots here; SVG screenshots are not accepted as review evidence. Use a compact table/grid of clickable thumbnails with a short state/title such as "Loaded state", "Empty state", "Error state", "Mobile layout", or "PR sidebar". Prefer annotated screenshots with a colored box, outline, arrow, or highlighter showing what changed. Recordings can be supplemental, but screenshots are still expected for visual review. Do not commit review-only screenshots, recordings, or `docs/review-evidence/**` files.

| State / title                         | JPG/PNG evidence                                                                     |
| ------------------------------------- | ------------------------------------------------------------------------------------ |
| Loaded state                          | `<a href="FULL_URL.png"><img src="FULL_URL.png" alt="Loaded state" width="240"></a>` |
| Empty/error/mobile state, if relevant |                                                                                      |

## Notes

-
