### PR TITLE
feat(enrichment): flag more Kubernetes Pod Security Standards violations in iac-misconfig

### DIFF
--- a/review-enrichment/src/analyzers/iac-misconfig.ts
+++ b/review-enrichment/src/analyzers/iac-misconfig.ts
@@ -73,6 +73,20 @@ const HARDCODED_BUILD_SECRET_RE =
 // A package installer pointed at a plaintext-HTTP index (dependency-download MITM).
 const INSECURE_PIP_INDEX_RE = /--(?:extra-)?index-url[=\s]+http:\/\//i;
 
+// More Kubernetes Pod Security Standards (restricted profile) controls, completing the securityContext set
+// above. Each is a single `key: <insecure-value>` line (or, for capabilities, an unambiguous capability name).
+const HOST_PORT_RE = /\bhostPort\b[\s"'=:,-]*\d/;
+// `hostPath` volume mount (restricted PSS forbids it). `\bhostPath\b` does NOT match the `hostPathType` sub-field
+// (word boundary fails before `Type`); it matches the `hostPath:` volume key that maps a host directory in.
+const HOST_PATH_RE = /\bhostPath\b\s*:/;
+const SHARE_PROCESS_NS_RE = /\bshareProcessNamespace\b[\s"'=:,-]*true\b/;
+const RUN_AS_GID_ZERO_RE = /\brunAsGroup\b[\s"'=:,-]*0\b/;
+const FS_GROUP_ZERO_RE = /\bfsGroup\b[\s"'=:,-]*0\b/;
+const WINDOWS_HOST_PROCESS_RE = /\bhostProcess\b[\s"'=:,-]*true\b/;
+// seccompProfile `type: Unconfined` disables syscall filtering. The `Unconfined` value is k8s-specific
+// (seccomp/AppArmor), so keying the generic `type` field on it does not over-match ordinary config.
+const SECCOMP_UNCONFINED_RE = /\btype\b[\s"'=:,-]*["']?Unconfined\b/;
+
 function* patchLines(patch: string): Generator<string> {
   let start = 0;
   for (let i = 0; i <= patch.length; i++) {
@@ -396,6 +410,48 @@ export function scanPatchForIacMisconfig(
     if (
       INSECURE_PIP_INDEX_RE.test(body) &&
       pushFinding(findings, seen, path, newLine, "insecure-pip-index", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      HOST_PORT_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "host-port", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      HOST_PATH_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "host-path-volume", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      SHARE_PROCESS_NS_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "share-process-namespace", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      RUN_AS_GID_ZERO_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "run-as-root-group", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      FS_GROUP_ZERO_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "root-fs-group", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      WINDOWS_HOST_PROCESS_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "windows-host-process", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      SECCOMP_UNCONFINED_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "seccomp-unconfined", maxFindings)
     ) {
       return findings;
     }

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -325,6 +325,20 @@ export function renderBrief(
           return "hardcodes a credential-shaped value into an image layer via `ENV`/`ARG`; build secrets persist in the image history";
         case "insecure-pip-index":
           return "points a package installer at a plaintext-HTTP index; dependency downloads can be intercepted";
+        case "host-port":
+          return "binds a container port to the host node (`hostPort`); it constrains scheduling and exposes the port on the node";
+        case "host-path-volume":
+          return "mounts a host filesystem path into the pod (`hostPath` volume); host files become reachable from the container";
+        case "share-process-namespace":
+          return "shares the process namespace across the pod's containers; each can see and signal the others' processes";
+        case "run-as-root-group":
+          return "runs the container with the root group GID 0 (`runAsGroup: 0`); prefer a dedicated non-root group";
+        case "root-fs-group":
+          return "sets the volume ownership group to GID 0 (`fsGroup: 0`); prefer a dedicated non-root group";
+        case "windows-host-process":
+          return "runs a Windows HostProcess container (`hostProcess: true`), which has host-level privileges";
+        case "seccomp-unconfined":
+          return "sets the seccomp profile to `Unconfined`, disabling syscall filtering for the container";
       }
     };
 

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -243,7 +243,14 @@ export interface IacMisconfigFinding {
     | "npm-unsafe-perm"
     | "sudo-in-build"
     | "hardcoded-build-secret"
-    | "insecure-pip-index";
+    | "insecure-pip-index"
+    | "host-port"
+    | "host-path-volume"
+    | "share-process-namespace"
+    | "run-as-root-group"
+    | "root-fs-group"
+    | "windows-host-process"
+    | "seccomp-unconfined";
 }
 
 /** A newly-added dependency whose install compiles native code (npm node-gyp addon) or has no prebuilt wheel

--- a/review-enrichment/test/iac-misconfig.test.ts
+++ b/review-enrichment/test/iac-misconfig.test.ts
@@ -328,3 +328,49 @@ test("scanPatchForIacMisconfig does not flag the safe counterpart of each Docker
     );
   }
 });
+
+test("scanPatchForIacMisconfig flags more Kubernetes Pod Security Standards violations", () => {
+  // Each added line is a recognized PSS-restricted violation not covered by the earlier securityContext set,
+  // and must produce exactly one finding of its own kind.
+  const cases = [
+    ["+      hostPort: 8080", "host-port"],
+    ["+      hostPath:", "host-path-volume"],
+    ["+  shareProcessNamespace: true", "share-process-namespace"],
+    ["+      runAsGroup: 0", "run-as-root-group"],
+    ["+      fsGroup: 0", "root-fs-group"],
+    ["+      hostProcess: true", "windows-host-process"],
+    ["+        type: Unconfined", "seccomp-unconfined"],
+  ];
+  for (const [added, kind] of cases) {
+    const findings = scanPatchForIacMisconfig(
+      "deploy/pod.yaml",
+      ["@@ -1,0 +1,1 @@", added].join("\n"),
+    );
+    assert.deepEqual(
+      findings,
+      [{ file: "deploy/pod.yaml", line: 1, kind }],
+      `${kind}: expected exactly one finding of that kind, got ${JSON.stringify(findings)}`,
+    );
+  }
+});
+
+test("scanPatchForIacMisconfig does not flag the safe counterpart of each PSS control", () => {
+  // Safe/near-miss forms: a container (not host) port, the `hostPathType` sub-field (word boundary must not
+  // fire the `hostPath` volume rule), and the non-root/non-zero/secure values.
+  const safe = [
+    "+      containerPort: 8080",
+    "+      hostPathType: Directory",
+    "+  shareProcessNamespace: false",
+    "+      runAsGroup: 1000",
+    "+      fsGroup: 2000",
+    "+      hostProcess: false",
+    "+        type: RuntimeDefault",
+  ];
+  for (const added of safe) {
+    assert.deepEqual(
+      scanPatchForIacMisconfig("deploy/pod.yaml", ["@@ -1,0 +1,1 @@", added].join("\n")),
+      [],
+      `should not flag: ${added.trim()}`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

The IaC-misconfig analyzer already covers a subset of container `securityContext` hardening. This completes the
**Kubernetes Pod Security Standards (restricted profile)** coverage with **7 more controls** it was missing —
host namespaces/paths/ports and seccomp — each following the analyzer's existing stateless single-line pattern
(regex const → `pushFinding` branch → kind → render case):

| kind | fires on | control |
|---|---|---|
| `host-port` | `hostPort: <n>` | Host Ports |
| `host-path-volume` | `hostPath:` volume | HostPath Volumes |
| `share-process-namespace` | `shareProcessNamespace: true` | Host Namespaces |
| `run-as-root-group` | `runAsGroup: 0` | Running as Non-root |
| `root-fs-group` | `fsGroup: 0` | CIS / Running as Non-root |
| `windows-host-process` | `hostProcess: true` | Windows HostProcess |
| `seccomp-unconfined` | seccompProfile `type: Unconfined` | Seccomp |

> Supersedes the closed #3194. That review correctly flagged that a stateless capability rule (`SYS_ADMIN`,
> `NET_RAW`, …) cannot tell `capabilities.add` from `capabilities.drop`, so a safe hardening diff like
> `drop:\n  - NET_RAW` would be a false positive. Rather than track the surrounding capability block
> statefully, this version **drops the capability rule entirely** and ships only the 7 rules whose insecure
> value is unambiguous on a single line.

Every rule is airtight. `\bhostPath\b` deliberately does **not** fire on the benign `hostPathType`
sub-field (the word boundary fails before `Type`); and `run-as-root-group`/`root-fs-group` reuse the exact
`… 0` value shape already proven by the existing `run-as-root-uid` rule (a non-zero GID like `1000` cannot
match). The tests assert each safe counterpart — a container (not host) port, `hostPathType: Directory`,
`shareProcessNamespace: false`, non-zero GIDs, `hostProcess: false`, and `type: RuntimeDefault` — produces no
finding.

No existing rule is modified, and the analyzer's finding schema is `{file, line, kind}` — the `kind` union is
not part of the analyzer descriptor, so `analyzer-metadata.json` and the generated UI mirror are **unchanged**.
The render-brief switch is TypeScript-exhaustive, so each new kind is compiler-forced to have a public-safe
explanation.

No linked issue: additive detection-coverage that extends an existing multi-domain analyzer along its own
established lines; each rule is a self-evident, named industry (PSS/CIS) check with no public API/schema/deploy
surface change — fits the repo's `preferred` (not required) linked-issue policy.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run typecheck`
- [x] `npm run rees:test` — the review-enrichment build + analyzer suite (see note below)
- [ ] `npm run test:coverage` (N/A — this analyzer is in `review-enrichment/`, outside the root `src/**` Codecov scope)
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran locally: `git diff --check` (clean), the review-enrichment TypeScript build (exit 0 — which proves the
  render switch is exhaustive over the 7 new kinds), and the analyzer suite via `node --test`. The
  iac-misconfig file passes 16/16: a table test asserting each of the 7 PSS violations produces exactly one
  finding of its own kind, and a negative test asserting the safe/near-miss counterpart of each produces none.
  The full `node --test` run's only failures are the two `upload-sourcemaps` tests (they shell out to the
  Sentry CLI, absent on this dev box), which fail identically on unmodified `main`.
- Not run locally: the UI, root typecheck, and the `metadata:check` step of `rees:test`. This change adds only
  finding kinds and rules, not any analyzer descriptor field, so the committed `analyzer-metadata.json` / UI
  mirror are unchanged (a local regeneration produces a zero-content diff) and `metadata:check` passes on CI
  (Linux). On this Windows dev box `metadata:check` reports a spurious line-ending difference; it fails
  identically on unmodified `main`. `analyzer-metadata.json` was NOT modified.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Detection-only additions: 7 new stateless rules following the existing single-line pattern; no existing rule,
  threshold, or descriptor changed, so current findings and `analyzer-metadata.json` are unaffected. Each new
  kind reports only `file:line` + the public-safe kind, never the matched line content.
- Every rule's insecure value is unambiguous on a single line, so no surrounding-block state is required; a
  capability rule (which would need to distinguish `capabilities.add` from `capabilities.drop`) was
  deliberately left out rather than shipped as an FP-prone stateless match.
