### PR TITLE
test(enrichment): unit coverage for the codeowners analyzer pure parser

### DIFF
--- a/review-enrichment/test/codeowners-pure-parser.test.ts
+++ b/review-enrichment/test/codeowners-pure-parser.test.ts
@@ -1,0 +1,106 @@
+// Units for the CODEOWNERS analyzer's pure glob/parser/ownership helpers (#2094). Own file (next to
+// codeowners.test.ts, which covers the scanCodeowners async wiring) so concurrent analyzer PRs don't collide.
+// No network involved — these four exports are deterministic. Runs against the compiled dist/.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  patternToRegex,
+  parseCodeowners,
+  findOwners,
+  authorMatchesOwner,
+} from "../dist/analyzers/codeowners.js";
+
+test("patternToRegex: a leading slash anchors the pattern to the repo root", () => {
+  const re = patternToRegex("/docs/readme.md");
+  assert.equal(re.test("docs/readme.md"), true);
+  assert.equal(re.test("packages/docs/readme.md"), false);
+});
+
+test("patternToRegex: a bare filename pattern is unanchored and matches at any depth", () => {
+  const re = patternToRegex("*.md");
+  assert.equal(re.test("readme.md"), true);
+  assert.equal(re.test("docs/deep/readme.md"), true);
+  // The `.` in the extension is a literal, not a regex wildcard.
+  assert.equal(re.test("readmeXmd"), false);
+});
+
+test("patternToRegex: a trailing-slash directory pattern owns everything under the directory", () => {
+  const re = patternToRegex("apps/");
+  assert.equal(re.test("apps/web/index.ts"), true);
+  assert.equal(re.test("apps/api/deep/nested/file.ts"), true);
+  assert.equal(re.test("apps"), false); // the directory itself is not a file under it
+});
+
+test("patternToRegex: a single star stays within one path segment; a globstar crosses segments", () => {
+  const single = patternToRegex("docs/*.md");
+  assert.equal(single.test("docs/guide.md"), true);
+  assert.equal(single.test("docs/sub/guide.md"), false);
+
+  const globstar = patternToRegex("docs/**/*.md");
+  assert.equal(globstar.test("docs/guide.md"), true);
+  assert.equal(globstar.test("docs/sub/deep/guide.md"), true);
+});
+
+test("patternToRegex: literal segments match exactly, and ? matches exactly one non-slash character", () => {
+  const literal = patternToRegex("/package.json");
+  assert.equal(literal.test("package.json"), true);
+  assert.equal(literal.test("packageXjson"), false);
+
+  const question = patternToRegex("/file?.ts");
+  assert.equal(question.test("file1.ts"), true);
+  assert.equal(question.test("file.ts"), false);
+  assert.equal(question.test("file/x.ts"), false);
+});
+
+test("parseCodeowners: skips comment lines and blank lines, keeping only real rules", () => {
+  const rules = parseCodeowners("# top comment\n\n   \n*.js @alice\n# tail comment\n");
+  assert.equal(rules.length, 1);
+  assert.deepEqual(rules[0].owners, ["@alice"]);
+});
+
+test("parseCodeowners: a rule keeps every owner listed after its pattern", () => {
+  const rules = parseCodeowners("src/ @alice @org/team dev@example.com\n");
+  assert.equal(rules.length, 1);
+  assert.deepEqual(rules[0].owners, ["@alice", "@org/team", "dev@example.com"]);
+});
+
+test("parseCodeowners: a malformed line (pattern with no valid owners) is skipped, not parsed", () => {
+  // `bob` has no leading @ and is not an email — the pattern is unowned and must not produce a rule.
+  const rules = parseCodeowners("src/ bob\ndocs/ @alice\n");
+  assert.equal(rules.length, 1);
+  assert.deepEqual(rules[0].owners, ["@alice"]);
+});
+
+test("parseCodeowners: an overlong pattern is skipped rather than compiled", () => {
+  const rules = parseCodeowners(`/${"a".repeat(600)} @alice\n*.ts @bob\n`);
+  assert.equal(rules.length, 1);
+  assert.deepEqual(rules[0].owners, ["@bob"]);
+});
+
+test("findOwners: the LAST matching rule wins, per CODEOWNERS semantics", () => {
+  const rules = parseCodeowners("* @global\ndocs/ @docs-team\n");
+  assert.deepEqual(findOwners(rules, "docs/guide.md"), ["@docs-team"]);
+  assert.deepEqual(findOwners(rules, "src/app.ts"), ["@global"]);
+
+  // Reversed order: the broad rule now comes last and overrides the specific one.
+  const reversed = parseCodeowners("docs/ @docs-team\n* @global\n");
+  assert.deepEqual(findOwners(reversed, "docs/guide.md"), ["@global"]);
+});
+
+test("findOwners: a path matching no rule returns an empty owner list", () => {
+  const rules = parseCodeowners("docs/ @docs-team\n");
+  assert.deepEqual(findOwners(rules, "src/app.ts"), []);
+  assert.deepEqual(findOwners([], "src/app.ts"), []);
+});
+
+test("authorMatchesOwner: matches a @user owner with or without the author's leading @, case-insensitively", () => {
+  assert.equal(authorMatchesOwner("alice", ["@alice"]), true);
+  assert.equal(authorMatchesOwner("@alice", ["@alice"]), true);
+  assert.equal(authorMatchesOwner("Alice", ["@ALICE"]), true);
+  assert.equal(authorMatchesOwner("carol", ["@alice", "@bob"]), false);
+});
+
+test("authorMatchesOwner: a user login does not match a @org/team owner", () => {
+  assert.equal(authorMatchesOwner("team", ["@org/team"]), false);
+  assert.equal(authorMatchesOwner("org/team", ["@org/team"]), true);
+});


### PR DESCRIPTION
Closes #2094

## Summary

-

## Scope

- [ ] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [ ] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [ ] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [ ] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [ ] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

-

## Safety

- [ ] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [ ] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [ ] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Required for visible UI, frontend, docs, or extension changes. Attach GitHub-hosted JPG/JPEG or PNG screenshots here; SVG screenshots are not accepted as review evidence. Use a compact table/grid of clickable thumbnails with a short state/title such as "Loaded state", "Empty state", "Error state", "Mobile layout", or "PR sidebar". Prefer annotated screenshots with a colored box, outline, arrow, or highlighter showing what changed. Recordings can be supplemental, but screenshots are still expected for visual review. Do not commit review-only screenshots, recordings, or `docs/review-evidence/**` files.

| State / title                         | JPG/PNG evidence                                                                     |
| ------------------------------------- | ------------------------------------------------------------------------------------ |
| Loaded state                          | `<a href="FULL_URL.png"><img src="FULL_URL.png" alt="Loaded state" width="240"></a>` |
| Empty/error/mobile state, if relevant |                                                                                      |

## Notes

-
