### PR TITLE
feat(selfhost): persist actual ai usage for orb reviews

### DIFF
--- a/migrations/0109_ai_usage_actual_tokens.sql
+++ b/migrations/0109_ai_usage_actual_tokens.sql
@@ -1,0 +1,9 @@
+ALTER TABLE ai_usage_events ADD COLUMN provider TEXT;
+ALTER TABLE ai_usage_events ADD COLUMN effort TEXT;
+ALTER TABLE ai_usage_events ADD COLUMN input_tokens INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE ai_usage_events ADD COLUMN output_tokens INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE ai_usage_events ADD COLUMN total_tokens INTEGER NOT NULL DEFAULT 0;
+ALTER TABLE ai_usage_events ADD COLUMN cost_usd REAL NOT NULL DEFAULT 0;
+
+CREATE INDEX IF NOT EXISTS ai_usage_events_provider_created_idx
+  ON ai_usage_events(provider, created_at);

--- a/scripts/export-grafana-reporting-db.sh
+++ b/scripts/export-grafana-reporting-db.sh
@@ -159,14 +159,21 @@ CREATE INDEX review_targets_verdict_idx ON review_targets(verdict);
 CREATE TABLE ai_usage_events (
   feature TEXT NOT NULL,
   model TEXT NOT NULL,
+  provider TEXT,
+  effort TEXT,
   status TEXT NOT NULL,
   estimated_neurons INTEGER NOT NULL DEFAULT 0,
+  input_tokens INTEGER NOT NULL DEFAULT 0,
+  output_tokens INTEGER NOT NULL DEFAULT 0,
+  total_tokens INTEGER NOT NULL DEFAULT 0,
+  cost_usd REAL NOT NULL DEFAULT 0,
   detail TEXT,
   metadata_json TEXT NOT NULL DEFAULT '{}',
   created_at TEXT NOT NULL
 );
 CREATE INDEX ai_usage_events_feature_created_idx ON ai_usage_events(feature, created_at);
 CREATE INDEX ai_usage_events_model_created_idx ON ai_usage_events(model, created_at);
+CREATE INDEX ai_usage_events_provider_created_idx ON ai_usage_events(provider, created_at);
 SQL
 
 if pg_enabled; then
@@ -281,12 +288,24 @@ WHERE t.kind = 'pull_request'
     else
       ESTIMATED_NEURONS_EXPR="0"
     fi
+    if pg_column_exists "ai_usage_events" "provider"; then PROVIDER_EXPR="provider"; else PROVIDER_EXPR="NULL"; fi
+    if pg_column_exists "ai_usage_events" "effort"; then EFFORT_EXPR="effort"; else EFFORT_EXPR="NULL"; fi
+    if pg_column_exists "ai_usage_events" "input_tokens"; then INPUT_TOKENS_EXPR="COALESCE(input_tokens, 0)"; else INPUT_TOKENS_EXPR="0"; fi
+    if pg_column_exists "ai_usage_events" "output_tokens"; then OUTPUT_TOKENS_EXPR="COALESCE(output_tokens, 0)"; else OUTPUT_TOKENS_EXPR="0"; fi
+    if pg_column_exists "ai_usage_events" "total_tokens"; then TOTAL_TOKENS_EXPR="COALESCE(total_tokens, 0)"; else TOTAL_TOKENS_EXPR="0"; fi
+    if pg_column_exists "ai_usage_events" "cost_usd"; then COST_USD_EXPR="COALESCE(cost_usd, 0)"; else COST_USD_EXPR="0"; fi
     pg_copy_csv "
 SELECT
   feature,
   model,
+  $PROVIDER_EXPR AS provider,
+  $EFFORT_EXPR AS effort,
   status,
   $ESTIMATED_NEURONS_EXPR AS estimated_neurons,
+  $INPUT_TOKENS_EXPR AS input_tokens,
+  $OUTPUT_TOKENS_EXPR AS output_tokens,
+  $TOTAL_TOKENS_EXPR AS total_tokens,
+  $COST_USD_EXPR AS cost_usd,
   detail,
   json_build_object(
     'repoFullName', metadata_json::jsonb ->> 'repoFullName',
@@ -442,14 +461,32 @@ if source_table_exists "ai_usage_events"; then
   if source_column_exists "ai_usage_events" "estimated_neurons"; then
     ESTIMATED_NEURONS_EXPR="estimated_neurons"
   fi
+  PROVIDER_EXPR=NULL
+  if source_column_exists "ai_usage_events" "provider"; then PROVIDER_EXPR="provider"; fi
+  EFFORT_EXPR=NULL
+  if source_column_exists "ai_usage_events" "effort"; then EFFORT_EXPR="effort"; fi
+  INPUT_TOKENS_EXPR=0
+  if source_column_exists "ai_usage_events" "input_tokens"; then INPUT_TOKENS_EXPR="input_tokens"; fi
+  OUTPUT_TOKENS_EXPR=0
+  if source_column_exists "ai_usage_events" "output_tokens"; then OUTPUT_TOKENS_EXPR="output_tokens"; fi
+  TOTAL_TOKENS_EXPR=0
+  if source_column_exists "ai_usage_events" "total_tokens"; then TOTAL_TOKENS_EXPR="total_tokens"; fi
+  COST_USD_EXPR=0
+  if source_column_exists "ai_usage_events" "cost_usd"; then COST_USD_EXPR="cost_usd"; fi
 
   sqlite3 -cmd ".timeout 5000" "$APP_DB" "
 ATTACH '$TMP_DB_SQL' AS report;
 INSERT INTO report.ai_usage_events (
   feature,
   model,
+  provider,
+  effort,
   status,
   estimated_neurons,
+  input_tokens,
+  output_tokens,
+  total_tokens,
+  cost_usd,
   detail,
   metadata_json,
   created_at
@@ -457,8 +494,14 @@ INSERT INTO report.ai_usage_events (
 SELECT
   feature,
   model,
+  $PROVIDER_EXPR,
+  $EFFORT_EXPR,
   status,
   COALESCE($ESTIMATED_NEURONS_EXPR, 0),
+  COALESCE($INPUT_TOKENS_EXPR, 0),
+  COALESCE($OUTPUT_TOKENS_EXPR, 0),
+  COALESCE($TOTAL_TOKENS_EXPR, 0),
+  COALESCE($COST_USD_EXPR, 0),
   detail,
   json_object(
     'repoFullName', json_extract(metadata_json, '$.repoFullName'),

--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -2933,8 +2933,14 @@ export async function recordAiUsageEvent(
     actor?: string | null | undefined;
     route?: string | null | undefined;
     model: string;
+    provider?: string | null | undefined;
+    effort?: string | null | undefined;
     status: string;
     estimatedNeurons: number;
+    inputTokens?: number | null | undefined;
+    outputTokens?: number | null | undefined;
+    totalTokens?: number | null | undefined;
+    costUsd?: number | null | undefined;
     detail?: string | null | undefined;
     metadata?: Record<string, unknown> | undefined;
   },
@@ -2946,8 +2952,14 @@ export async function recordAiUsageEvent(
     actor: event.actor ?? null,
     route: event.route ?? null,
     model: event.model,
+    provider: event.provider?.trim() || null,
+    effort: event.effort?.trim() || null,
     status: event.status,
     estimatedNeurons: Math.max(0, Math.round(event.estimatedNeurons)),
+    inputTokens: Math.max(0, Math.round(finiteNumber(event.inputTokens))),
+    outputTokens: Math.max(0, Math.round(finiteNumber(event.outputTokens))),
+    totalTokens: Math.max(0, Math.round(finiteNumber(event.totalTokens))),
+    costUsd: Math.max(0, finiteNumber(event.costUsd)),
     detail: event.detail ?? null,
     metadataJson: jsonString(event.metadata ?? {}),
     createdAt: nowIso(),

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1222,8 +1222,14 @@ export const aiUsageEvents = sqliteTable(
     actor: text("actor"),
     route: text("route"),
     model: text("model").notNull(),
+    provider: text("provider"),
+    effort: text("effort"),
     status: text("status").notNull(),
     estimatedNeurons: integer("estimated_neurons").notNull().default(0),
+    inputTokens: integer("input_tokens").notNull().default(0),
+    outputTokens: integer("output_tokens").notNull().default(0),
+    totalTokens: integer("total_tokens").notNull().default(0),
+    costUsd: real("cost_usd").notNull().default(0),
     detail: text("detail"),
     metadataJson: text("metadata_json").notNull().default("{}"),
     createdAt: text("created_at").notNull().$defaultFn(() => nowIso()),
@@ -1231,6 +1237,7 @@ export const aiUsageEvents = sqliteTable(
   (table) => ({
     featureCreated: index("ai_usage_events_feature_created_idx").on(table.feature, table.createdAt),
     actorCreated: index("ai_usage_events_actor_created_idx").on(table.actor, table.createdAt),
+    providerCreated: index("ai_usage_events_provider_created_idx").on(table.provider, table.createdAt),
     // Covers the daily-budget query (sumAiEstimatedNeuronsSince): WHERE status='ok' AND created_at >= ?.
     // Without it that aggregate full-scans ai_usage_events, which runs on every AI review/summary.
     statusCreated: index("ai_usage_events_status_created_idx").on(table.status, table.createdAt),

--- a/src/selfhost/ai.ts
+++ b/src/selfhost/ai.ts
@@ -449,14 +449,14 @@ export function extractCliUsage(stdout: string): CliUsage {
   return usage;
 }
 
-function cliUsageFromStdout(provider: string, model: string, effort: string, stdout: string): AiUsage {
+function cliUsageFromStdout(provider: string, model: string, effort: string, stdout: string): AiUsage & { model: string } {
   const usage = extractCliUsage(stdout);
   return { ...usage, provider, model: usage.model ?? (model || "default"), effort };
 }
 
-function recordCliUsageMetrics(provider: string, model: string, effort: string, stdout: string): AiUsage {
+function recordCliUsageMetrics(provider: string, model: string, effort: string, stdout: string): AiUsage & { model: string } {
   const usage = cliUsageFromStdout(provider, model, effort, stdout);
-  const labels = { provider, model: usage.model ?? "default", effort };
+  const labels = { provider, model: usage.model, effort };
   incr("gittensory_ai_requests_total", labels);
   incr("gittensory_ai_cost_usd_total", { provider: labels.provider }, usage.costUsd ?? 0);
   if (usage.inputTokens !== undefined) incr("gittensory_ai_input_tokens_total", { ...labels, kind: "review" }, usage.inputTokens);

--- a/src/selfhost/ai.ts
+++ b/src/selfhost/ai.ts
@@ -22,8 +22,10 @@ interface AiRunOptions {
   temperature?: number;
 }
 /** A chat completion (`response`) or an embedding result (`data`). Both optional: the core reads whichever it
- *  asked for (extractAiText → `response`, embedTexts → `data`), each defensive about the other being absent. */
-export type AiResult = { response?: string; data?: number[][] };
+ *  asked for (extractAiText → `response`, embedTexts → `data`), each defensive about the other being absent.
+ *  `usage` is best-effort local accounting for self-host operators; callers must never make review decisions
+ *  from it because provider envelopes are not uniform. */
+export type AiResult = { response?: string; data?: number[][]; usage?: AiUsage };
 export interface SelfHostAi {
   run(model: string, options: AiRunOptions): Promise<AiResult>;
 }
@@ -165,11 +167,12 @@ export function createOpenAiCompatibleAi(opts: {
         const json = (await res.json()) as { data?: Array<{ embedding: number[] }> };
         return { data: (json.data ?? []).map((d) => d.embedding) };
       }
+      const resolvedModel = resolveModel(opts.model, model, opts.defaultModel ?? DEFAULT_OPENAI_COMPATIBLE_CHAT_MODEL);
       const res = await fetch(`${base}/chat/completions`, {
         method: "POST",
         headers: headers(),
         body: JSON.stringify({
-          model: resolveModel(opts.model, model, opts.defaultModel ?? DEFAULT_OPENAI_COMPATIBLE_CHAT_MODEL),
+          model: resolvedModel,
           messages: toMessages(options),
           max_tokens: options.max_tokens,
           temperature: options.temperature,
@@ -178,7 +181,8 @@ export function createOpenAiCompatibleAi(opts: {
       });
       if (!res.ok) throw new Error(`ai_http_${res.status}`);
       const data = (await res.json()) as { choices?: Array<{ message?: { content?: string } }> };
-      return { response: data.choices?.[0]?.message?.content ?? "" };
+      const usage = extractCliUsage(JSON.stringify(data));
+      return { response: data.choices?.[0]?.message?.content ?? "", usage: { ...usage, model: usage.model ?? resolvedModel } };
     },
   };
 }
@@ -196,19 +200,22 @@ export function createAnthropicAi(opts: { apiKey: string; model?: string | undef
           .map((m) => m.content)
           .join("\n\n") || undefined;
       const messages = msgs.filter((m) => m.role !== "system").map((m) => ({ role: m.role === "assistant" ? "assistant" : "user", content: m.content }));
+      const resolvedModel = resolveModel(opts.model, model, "claude-sonnet-4-6");
       const res = await fetch(`${base}/v1/messages`, {
         method: "POST",
         headers: { "content-type": "application/json", "x-api-key": opts.apiKey, "anthropic-version": "2023-06-01" },
-        body: JSON.stringify({ model: resolveModel(opts.model, model, "claude-sonnet-4-6"), max_tokens: options.max_tokens ?? 1024, ...(system ? { system } : {}), messages }),
+        body: JSON.stringify({ model: resolvedModel, max_tokens: options.max_tokens ?? 1024, ...(system ? { system } : {}), messages }),
         signal: AbortSignal.timeout(120_000),
       });
       if (!res.ok) throw new Error(`anthropic_http_${res.status}`);
       const data = (await res.json()) as { content?: Array<{ type: string; text?: string }> };
+      const usage = extractCliUsage(JSON.stringify(data));
       return {
         response: (data.content ?? [])
           .filter((c) => c.type === "text")
           .map((c) => c.text ?? "")
           .join(""),
+        usage: { ...usage, model: usage.model ?? resolvedModel },
       };
     },
   };
@@ -370,6 +377,11 @@ export type CliUsage = {
   model?: string;
 };
 
+export type AiUsage = CliUsage & {
+  provider?: string;
+  effort?: string;
+};
+
 const INPUT_TOKEN_KEYS = ["input_tokens", "inputTokens", "prompt_tokens", "promptTokens"] as const;
 const OUTPUT_TOKEN_KEYS = ["output_tokens", "outputTokens", "completion_tokens", "completionTokens"] as const;
 const TOTAL_TOKEN_KEYS = ["total_tokens", "totalTokens"] as const;
@@ -437,14 +449,20 @@ export function extractCliUsage(stdout: string): CliUsage {
   return usage;
 }
 
-function recordCliUsageMetrics(provider: string, model: string, effort: string, stdout: string): void {
+function cliUsageFromStdout(provider: string, model: string, effort: string, stdout: string): AiUsage {
   const usage = extractCliUsage(stdout);
-  const labels = { provider, model: usage.model ?? (model || "default"), effort };
+  return { ...usage, provider, model: usage.model ?? (model || "default"), effort };
+}
+
+function recordCliUsageMetrics(provider: string, model: string, effort: string, stdout: string): AiUsage {
+  const usage = cliUsageFromStdout(provider, model, effort, stdout);
+  const labels = { provider, model: usage.model ?? "default", effort };
   incr("gittensory_ai_requests_total", labels);
   incr("gittensory_ai_cost_usd_total", { provider: labels.provider }, usage.costUsd ?? 0);
   if (usage.inputTokens !== undefined) incr("gittensory_ai_input_tokens_total", { ...labels, kind: "review" }, usage.inputTokens);
   if (usage.outputTokens !== undefined) incr("gittensory_ai_output_tokens_total", { ...labels, kind: "review" }, usage.outputTokens);
   if (usage.totalTokens !== undefined) incr("gittensory_ai_total_tokens_total", labels, usage.totalTokens);
+  return usage;
 }
 
 /** Claude Code's `--output-format json` exits 0 even on an API/auth error, returning {is_error:true,result:"<msg>"}.
@@ -616,7 +634,7 @@ export function createClaudeCodeAi(parentEnv: Record<string, string | undefined>
         if (code !== 0) throw new Error(`claude_code_exit_${code ?? "null"}: ${redactSecrets(stderr ?? "", [token]).slice(0, 500)}`);
         const text = extractCliText(stdout);
         if (!text) throw new Error("claude_code_empty_output");
-        return { response: text };
+        return { response: text, usage: cliUsageFromStdout("claude-code", claudeModel, effort, stdoutForMetrics) };
       } catch (error) {
         logSelfHostAiProviderFailed({ provider: "claude-code", model: claudeModel, effort, timeoutMs, error, knownSecrets: token ? [token] : [] });
         throw error;
@@ -688,7 +706,7 @@ export function createCodexAi(
         }
         const text = extractCliText(stdout);
         if (!text) throw new Error("codex_empty_output");
-        return { response: text };
+        return { response: text, usage: cliUsageFromStdout("codex", codexModel, effort, stdoutForMetrics) };
       } catch (error) {
         logSelfHostAiProviderFailed({ provider: "codex", model: codexModel, effort, timeoutMs, error });
         throw error;
@@ -834,6 +852,16 @@ async function runProviderWithOtel(
       () => provider.ai.run(model, options),
     );
     aiProviderCircuits.delete(provider.name);
+    if (result.usage) {
+      return {
+        ...result,
+        usage: {
+          ...result.usage,
+          provider: result.usage.provider ?? provider.name,
+          model: result.usage.model ?? (model || "default"),
+        },
+      };
+    }
     return result;
   } catch (error) {
     if (isExpectedEmbeddingRoutingError(options, error)) throw error;

--- a/src/services/ai-review.ts
+++ b/src/services/ai-review.ts
@@ -339,6 +339,17 @@ export type AiReviewDiagnostic = {
   responseChars?: number | undefined;
   hasJsonObject?: boolean | undefined;
   error?: string | undefined;
+  usage?: AiReviewActualUsage | undefined;
+};
+
+export type AiReviewActualUsage = {
+  provider?: string | undefined;
+  model?: string | undefined;
+  effort?: string | undefined;
+  inputTokens?: number | undefined;
+  outputTokens?: number | undefined;
+  totalTokens?: number | undefined;
+  costUsd?: number | undefined;
 };
 
 type ReviewerOpinionOutcome = {
@@ -449,6 +460,35 @@ export function coerceAiText(result: unknown): string {
       return obj.output_text;
   }
   return "";
+}
+
+function finiteUsageNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+function finiteUsageInteger(value: unknown): number | undefined {
+  const n = finiteUsageNumber(value);
+  return n === undefined ? undefined : Math.max(0, Math.round(n));
+}
+
+function stringField(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function coerceAiUsage(result: unknown): AiReviewActualUsage | undefined {
+  if (!result || typeof result !== "object") return undefined;
+  const usage = (result as Record<string, unknown>).usage;
+  if (!usage || typeof usage !== "object" || Array.isArray(usage)) return undefined;
+  const record = usage as Record<string, unknown>;
+  return {
+    provider: stringField(record.provider),
+    model: stringField(record.model),
+    effort: stringField(record.effort),
+    inputTokens: finiteUsageInteger(record.inputTokens),
+    outputTokens: finiteUsageInteger(record.outputTokens),
+    totalTokens: finiteUsageInteger(record.totalTokens),
+    costUsd: finiteUsageNumber(record.costUsd),
+  };
 }
 
 /**
@@ -716,14 +756,16 @@ async function runWorkersOpinion(
           extra,
         );
         const text = coerceAiText(result);
+        const usage = coerceAiUsage(result);
+        const usageFields = usage ? { usage } : {};
         const parsed = parseModelReview(text);
         if (parsed) {
-          diagnostics.push({ model, attempt, status: "parsed", responseChars: text.length, hasJsonObject: Boolean(extractLastJsonObject(text)) });
+          diagnostics.push({ model, attempt, status: "parsed", responseChars: text.length, hasJsonObject: Boolean(extractLastJsonObject(text)), ...usageFields });
           return { review: parsed };
         }
         const hasJsonObject = Boolean(extractLastJsonObject(text));
         const status = text.trim() ? "unparseable_output" : "empty_output";
-        diagnostics.push({ model, attempt, status, responseChars: text.length, hasJsonObject });
+        diagnostics.push({ model, attempt, status, responseChars: text.length, hasJsonObject, ...usageFields });
         if (text.trim()) {
           lastUnparseable = { model, attempt, responseChars: text.length, hasJsonObject };
           console.warn(
@@ -1423,6 +1465,7 @@ export async function runGittensoryAiReview(
       inconclusive,
       ...(byokFailure ? { byokFailure } : {}),
     },
+    aggregateActualUsage(reviewDiagnostics),
   );
   return {
     status: "ok",
@@ -1452,6 +1495,54 @@ function reviewerModelLabel(env: Env, input: GittensoryAiReviewInput): string {
   return BEST_REVIEW_MODELS.join("+");
 }
 
+function joinedUnique(values: Iterable<string | undefined>): string | undefined {
+  const unique = [...new Set([...values].filter((value): value is string => Boolean(value)))];
+  return unique.length > 0 ? unique.join("+") : undefined;
+}
+
+function sumUsageField(
+  usages: readonly AiReviewActualUsage[],
+  key: "inputTokens" | "outputTokens" | "totalTokens" | "costUsd",
+): number | undefined {
+  let sawValue = false;
+  let total = 0;
+  for (const usage of usages) {
+    const value = usage[key];
+    if (value === undefined) continue;
+    sawValue = true;
+    total += value;
+  }
+  return sawValue ? total : undefined;
+}
+
+function aggregateActualUsage(diagnostics: readonly AiReviewDiagnostic[]): AiReviewActualUsage | undefined {
+  const usages = diagnostics.map((diagnostic) => diagnostic.usage).filter((usage): usage is AiReviewActualUsage => Boolean(usage));
+  if (usages.length === 0) return undefined;
+  const inputTokens = sumUsageField(usages, "inputTokens");
+  const outputTokens = sumUsageField(usages, "outputTokens");
+  let sawTotalTokens = false;
+  let totalTokensSum = 0;
+  for (const usage of usages) {
+    const total =
+      usage.totalTokens ??
+      (usage.inputTokens !== undefined || usage.outputTokens !== undefined
+        ? (usage.inputTokens ?? 0) + (usage.outputTokens ?? 0)
+        : undefined);
+    if (total === undefined) continue;
+    sawTotalTokens = true;
+    totalTokensSum += total;
+  }
+  return {
+    provider: joinedUnique(usages.map((usage) => usage.provider)),
+    model: joinedUnique(usages.map((usage) => usage.model)),
+    effort: joinedUnique(usages.map((usage) => usage.effort)),
+    inputTokens,
+    outputTokens,
+    totalTokens: sawTotalTokens ? totalTokensSum : undefined,
+    costUsd: sumUsageField(usages, "costUsd"),
+  };
+}
+
 async function record(
   env: Env,
   input: GittensoryAiReviewInput,
@@ -1459,6 +1550,7 @@ async function record(
   estimatedNeurons: number,
   detail: string,
   metadata?: Record<string, unknown>,
+  actualUsage?: AiReviewActualUsage | undefined,
 ): Promise<void> {
   // NEVER include provider key material in usage/audit metadata.
   await recordAiUsageEvent(env, {
@@ -1470,6 +1562,12 @@ async function record(
       : reviewerModelLabel(env, input),
     status,
     estimatedNeurons,
+    provider: actualUsage?.provider,
+    effort: actualUsage?.effort,
+    inputTokens: actualUsage?.inputTokens,
+    outputTokens: actualUsage?.outputTokens,
+    totalTokens: actualUsage?.totalTokens,
+    costUsd: actualUsage?.costUsd,
     detail,
     metadata: {
       repoFullName: input.repoFullName,
@@ -1492,4 +1590,6 @@ export const __aiReviewInternals = {
   toPublicSafe,
   estimateNeurons,
   runWorkersOpinion,
+  coerceAiUsage,
+  aggregateActualUsage,
 };

--- a/test/unit/ai-review.test.ts
+++ b/test/unit/ai-review.test.ts
@@ -954,6 +954,19 @@ describe("runGittensoryAiReview self-host dual-AI plan (#dual-ai-combiner)", () 
       totalTokens: undefined,
       costUsd: undefined,
     });
+    expect(
+      coerceAiUsage({
+        usage: { provider: "   ", model: "\t", inputTokens: 3 },
+      }),
+    ).toEqual({
+      provider: undefined,
+      model: undefined,
+      effort: undefined,
+      inputTokens: 3,
+      outputTokens: undefined,
+      totalTokens: undefined,
+      costUsd: undefined,
+    });
     expect(aggregateActualUsage([{ model: "codex", attempt: 0, status: "parsed" }])).toBeUndefined();
     expect(
       aggregateActualUsage([
@@ -990,6 +1003,22 @@ describe("runGittensoryAiReview self-host dual-AI plan (#dual-ai-combiner)", () 
       inputTokens: undefined,
       outputTokens: undefined,
       totalTokens: undefined,
+      costUsd: undefined,
+    });
+    // Each diagnostic reports only ONE side of input/output (no totalTokens), so the per-usage
+    // total falls back to `(inputTokens ?? 0) + (outputTokens ?? 0)` from BOTH directions.
+    expect(
+      aggregateActualUsage([
+        { model: "a", attempt: 0, status: "parsed", usage: { inputTokens: 10 } },
+        { model: "b", attempt: 0, status: "parsed", usage: { outputTokens: 4 } },
+      ]),
+    ).toEqual({
+      provider: undefined,
+      model: undefined,
+      effort: undefined,
+      inputTokens: 10,
+      outputTokens: 4,
+      totalTokens: 14,
       costUsd: undefined,
     });
   });

--- a/test/unit/ai-review.test.ts
+++ b/test/unit/ai-review.test.ts
@@ -22,6 +22,8 @@ const {
   synthesizeDefect,
   toPublicSafe,
   runWorkersOpinion,
+  coerceAiUsage,
+  aggregateActualUsage,
 } = __aiReviewInternals;
 
 type InlineFinding = {
@@ -865,6 +867,132 @@ describe("runGittensoryAiReview self-host dual-AI plan (#dual-ai-combiner)", () 
       AI_DAILY_NEURON_BUDGET: "100000",
       AI_REVIEW_PLAN: plan as never,
     });
+
+  it("records actual self-host provider token usage on the durable per-PR audit row", async () => {
+    const env = planEnv(
+      { reviewers: [{ model: "codex" }], combine: "single" },
+      async () => ({
+        response: reviewJson({ present: false, nits: [], suggestions: [] }),
+        usage: {
+          provider: "codex",
+          model: "gpt-5.5",
+          effort: "medium",
+          inputTokens: 101.2,
+          outputTokens: 9.6,
+          costUsd: 0.03,
+        },
+      }),
+    );
+    const result = await runGittensoryAiReview(env, baseInput);
+    if (result.status !== "ok") throw new Error("expected ok");
+    expect(result.reviewDiagnostics).toEqual([
+      expect.objectContaining({
+        usage: expect.objectContaining({
+          provider: "codex",
+          model: "gpt-5.5",
+          effort: "medium",
+          inputTokens: 101,
+          outputTokens: 10,
+          totalTokens: undefined,
+          costUsd: 0.03,
+        }),
+      }),
+    ]);
+    const row = await env.DB.prepare(
+      `select provider, effort, input_tokens, output_tokens, total_tokens, cost_usd, metadata_json
+       from ai_usage_events
+       where feature = ?
+       order by rowid desc
+       limit 1`,
+    )
+      .bind("ai_review_pr")
+      .first<{
+        provider: string | null;
+        effort: string | null;
+        input_tokens: number;
+        output_tokens: number;
+        total_tokens: number;
+        cost_usd: number;
+        metadata_json: string;
+      }>();
+    expect(row).toMatchObject({
+      provider: "codex",
+      effort: "medium",
+      input_tokens: 101,
+      output_tokens: 10,
+      total_tokens: 111,
+      cost_usd: 0.03,
+    });
+    expect(JSON.parse(row?.metadata_json ?? "{}")).toMatchObject({
+      repoFullName: baseInput.repoFullName,
+      pullNumber: baseInput.prNumber,
+    });
+  });
+
+  it("normalizes usage envelopes and aggregates mixed provider totals without affecting verdicts", () => {
+    expect(coerceAiUsage(undefined)).toBeUndefined();
+    expect(coerceAiUsage({ usage: null })).toBeUndefined();
+    expect(coerceAiUsage({ usage: [] })).toBeUndefined();
+    expect(
+      coerceAiUsage({
+        usage: {
+          provider: "  claude-code ",
+          model: " claude-sonnet-4-6 ",
+          effort: " low ",
+          inputTokens: -1,
+          outputTokens: 2.4,
+          totalTokens: Number.NaN,
+          costUsd: "0.4",
+        },
+      }),
+    ).toEqual({
+      provider: "claude-code",
+      model: "claude-sonnet-4-6",
+      effort: "low",
+      inputTokens: undefined,
+      outputTokens: 2,
+      totalTokens: undefined,
+      costUsd: undefined,
+    });
+    expect(aggregateActualUsage([{ model: "codex", attempt: 0, status: "parsed" }])).toBeUndefined();
+    expect(
+      aggregateActualUsage([
+        {
+          model: "codex",
+          attempt: 0,
+          status: "parsed",
+          usage: { provider: "codex", model: "gpt-5.5", effort: "medium", totalTokens: 30, costUsd: 0.02 },
+        },
+        {
+          model: "claude-code",
+          attempt: 0,
+          status: "parsed",
+          usage: { provider: "claude-code", model: "claude-sonnet-4-6", effort: "medium", inputTokens: 5, outputTokens: 7, costUsd: 0.04 },
+        },
+      ]),
+    ).toEqual({
+      provider: "codex+claude-code",
+      model: "gpt-5.5+claude-sonnet-4-6",
+      effort: "medium",
+      inputTokens: 5,
+      outputTokens: 7,
+      totalTokens: 42,
+      costUsd: 0.06,
+    });
+    expect(
+      aggregateActualUsage([
+        { model: "unknown", attempt: 0, status: "parsed", usage: {} },
+      ]),
+    ).toEqual({
+      provider: undefined,
+      model: undefined,
+      effort: undefined,
+      inputTokens: undefined,
+      outputTokens: undefined,
+      totalTokens: undefined,
+      costUsd: undefined,
+    });
+  });
 
   it("single provider: runs ONE named reviewer and its blocker IS the decision", async () => {
     const seen: string[] = [];

--- a/test/unit/selfhost-ai.test.ts
+++ b/test/unit/selfhost-ai.test.ts
@@ -529,6 +529,21 @@ describe("routeProviders (#dual-ai-combiner — address one provider by name for
     });
   });
 
+  it("provider routing falls back to \"default\" when both the adapter's usage AND the requested model are empty", async () => {
+    const ai = createChainAi([
+      {
+        name: "codex",
+        ai: {
+          run: async () => ({ response: "ok", usage: { inputTokens: 3 } }),
+        },
+      },
+    ]);
+    await expect(ai.run("", { prompt: "x" })).resolves.toMatchObject({
+      response: "ok",
+      usage: { provider: "codex", model: "default", inputTokens: 3 },
+    });
+  });
+
   it("createSelfHostAi routes a SINGLE provider through the router too — a name address yields the provider default, never `--model <provider>` (#1610)", async () => {
     // Regression (#1610): a single-provider self-host returned env.AI as the BARE provider, so the reviewer plan's
     // name address ({ model: "openai-compatible" } — or "claude-code") reached it as a model id. `claude --model

--- a/test/unit/selfhost-ai.test.ts
+++ b/test/unit/selfhost-ai.test.ts
@@ -90,11 +90,12 @@ describe("createOpenAiCompatibleAi (#979)", () => {
     const calls: Array<{ url: string; body: { model: string } }> = [];
     vi.stubGlobal("fetch", vi.fn(async (url: string, init: { body: string }) => {
       calls.push({ url, body: JSON.parse(init.body) });
-      return new Response(JSON.stringify({ choices: [{ message: { content: "hi there" } }] }), { status: 200 });
+      return new Response(JSON.stringify({ choices: [{ message: { content: "hi there" } }], usage: { prompt_tokens: 12, completion_tokens: 4, total_tokens: 16 } }), { status: 200 });
     }));
     const ai = createOpenAiCompatibleAi({ baseUrl: "http://ollama:11434/v1/", apiKey: "k" });
     const out = await ai.run("llama3.1", { messages: [{ role: "user", content: "x" }], max_tokens: 100 });
     expect(out.response).toBe("hi there");
+    expect(out.usage).toMatchObject({ model: "llama3.1", inputTokens: 12, outputTokens: 4, totalTokens: 16 });
     const first = calls[0];
     expect(first?.url).toBe("http://ollama:11434/v1/chat/completions"); // trailing slash trimmed
     expect(first?.body.model).toBe("llama3.1");
@@ -506,6 +507,26 @@ describe("routeProviders (#dual-ai-combiner — address one provider by name for
   it("createSelfHostAi wires routing for a 2+ provider AI_PROVIDER (addressable by name)", async () => {
     const ai = createSelfHostAi({ AI_PROVIDER: "anthropic,ollama", ANTHROPIC_API_KEY: "sk-ant", OLLAMA_AI_BASE_URL: "http://o/v1" });
     expect(typeof ai?.run).toBe("function");
+  });
+
+  it("provider routing labels usage with the selected provider when the adapter omits it", async () => {
+    const ai = createChainAi([
+      {
+        name: "codex",
+        ai: {
+          run: async () => ({ response: "ok", usage: { inputTokens: 3, outputTokens: 2 } }),
+        },
+      },
+    ]);
+    await expect(ai.run("gpt-5.5", { prompt: "x" })).resolves.toMatchObject({
+      response: "ok",
+      usage: {
+        provider: "codex",
+        model: "gpt-5.5",
+        inputTokens: 3,
+        outputTokens: 2,
+      },
+    });
   });
 
   it("createSelfHostAi routes a SINGLE provider through the router too — a name address yields the provider default, never `--model <provider>` (#1610)", async () => {
@@ -1165,7 +1186,8 @@ describe("subscription CLI helpers + fail-safe", () => {
       JSON.stringify({ type: "result", result: "review" }),
     ].join("\n");
     const ok: StubSpawn = async () => ({ stdout, code: 0 });
-    await createCodexAi({ GITTENSORY_ENABLE_UNSAFE_CODEX_REVIEWER: "1", CODEX_AI_EFFORT: "medium" }, ok, noAuthCheck).run("", { prompt: "x" });
+    const result = await createCodexAi({ GITTENSORY_ENABLE_UNSAFE_CODEX_REVIEWER: "1", CODEX_AI_EFFORT: "medium" }, ok, noAuthCheck).run("", { prompt: "x" });
+    expect(result.usage).toMatchObject({ provider: "codex", model: "gpt-5-codex", effort: "medium", inputTokens: 20, outputTokens: 7, totalTokens: 27 });
     const metrics = await renderMetrics();
     expect(metrics).toContain('gittensory_ai_requests_total{effort="medium",model="gpt-5-codex",provider="codex"} 1');
     expect(metrics).toContain('gittensory_ai_input_tokens_total{effort="medium",kind="review",model="gpt-5-codex",provider="codex"} 20');

--- a/test/unit/selfhost-grafana-reporting.test.ts
+++ b/test/unit/selfhost-grafana-reporting.test.ts
@@ -74,7 +74,13 @@ case "$args" in
   *"information_schema.tables"*"pull_requests"*|*"information_schema.tables"*"advisories"*|*"information_schema.tables"*"review_targets"*|*"information_schema.tables"*"ai_usage_events"*)
     printf '1\\n'
     ;;
-  *"information_schema.columns"*"ai_usage_events"*"estimated_neurons"*)
+  *"information_schema.columns"*"ai_usage_events"*"estimated_neurons"*|\
+  *"information_schema.columns"*"ai_usage_events"*"provider"*|\
+  *"information_schema.columns"*"ai_usage_events"*"effort"*|\
+  *"information_schema.columns"*"ai_usage_events"*"input_tokens"*|\
+  *"information_schema.columns"*"ai_usage_events"*"output_tokens"*|\
+  *"information_schema.columns"*"ai_usage_events"*"total_tokens"*|\
+  *"information_schema.columns"*"ai_usage_events"*"cost_usd"*)
     printf '1\\n'
     ;;
   *"FROM current_pull_requests"*)
@@ -85,7 +91,7 @@ case "$args" in
     printf '"JSONbored/gittensory",1049,bohdansolovie,closed,close,"historical PR",2026-06-22T17:28:56Z,2026-06-22T17:28:56Z\\n'
     ;;
   *"FROM ai_usage_events"*)
-    printf 'ai_review_pr,codex:gpt-5.5,ok,42,done,"{""repoFullName"" : ""JSONbored/gittensory"", ""pullNumber"" : 1678}",2026-06-28T00:00:00Z\\n'
+    printf 'ai_review_pr,codex:gpt-5.5,codex,medium,ok,42,120,15,135,0.25,done,"{""repoFullName"" : ""JSONbored/gittensory"", ""pullNumber"" : 1678}",2026-06-28T00:00:00Z\\n'
     ;;
 esac
 `,
@@ -293,20 +299,27 @@ esac
       CREATE TABLE ai_usage_events (
         feature TEXT NOT NULL,
         model TEXT NOT NULL,
+        provider TEXT,
+        effort TEXT,
         status TEXT NOT NULL,
         estimated_neurons INTEGER NOT NULL DEFAULT 0,
+        input_tokens INTEGER NOT NULL DEFAULT 0,
+        output_tokens INTEGER NOT NULL DEFAULT 0,
+        total_tokens INTEGER NOT NULL DEFAULT 0,
+        cost_usd REAL NOT NULL DEFAULT 0,
         detail TEXT,
         metadata_json TEXT NOT NULL DEFAULT '{}',
         created_at TEXT NOT NULL
       );
-      INSERT INTO ai_usage_events (feature, model, status, estimated_neurons, detail, metadata_json, created_at)
-      VALUES ('ai_review_pr', 'codex:gpt-5.5', 'ok', 42, 'done', '{"repoFullName":"JSONbored/gittensory","pullNumber":1678,"private":"drop"}', '2026-06-28T00:00:00Z');
+      INSERT INTO ai_usage_events (feature, model, provider, effort, status, estimated_neurons, input_tokens, output_tokens, total_tokens, cost_usd, detail, metadata_json, created_at)
+      VALUES ('ai_review_pr', 'codex:gpt-5.5', 'codex', 'medium', 'ok', 42, 120, 15, 135, 0.25, 'done', '{"repoFullName":"JSONbored/gittensory","pullNumber":1678,"private":"drop"}', '2026-06-28T00:00:00Z');
     `);
 
     runExporter(root, appDb, outDb);
 
     expect(sqlite(outDb, "PRAGMA quick_check;")).toBe("ok");
     expect(sqlite(outDb, "SELECT estimated_neurons FROM ai_usage_events;")).toBe("42");
+    expect(sqlite(outDb, "SELECT provider || '|' || effort || '|' || input_tokens || '|' || output_tokens || '|' || total_tokens || '|' || cost_usd FROM ai_usage_events;")).toBe("codex|medium|120|15|135|0.25");
     expect(sqlite(outDb, "SELECT json_extract(metadata_json, '$.repoFullName') FROM ai_usage_events;")).toBe("JSONbored/gittensory");
     expect(sqlite(outDb, "SELECT json_extract(metadata_json, '$.private') IS NULL FROM ai_usage_events;")).toBe("1");
     expect(sqlite(outDb, "SELECT sum(estimated_neurons) FROM ai_usage_events WHERE feature = 'ai_review_pr' AND (('+' || model || '+') LIKE '%+codex+%' OR ('+' || model || '+') LIKE '%+codex:%');")).toBe("42");
@@ -333,6 +346,7 @@ esac
 
     expect(sqlite(outDb, "PRAGMA quick_check;")).toBe("ok");
     expect(sqlite(outDb, "SELECT estimated_neurons FROM ai_usage_events;")).toBe("0");
+    expect(sqlite(outDb, "SELECT provider IS NULL, effort IS NULL, input_tokens, output_tokens, total_tokens, cost_usd FROM ai_usage_events;")).toBe("1|1|0|0|0|0.0");
   });
 
   it("exports the same redacted dashboard snapshot from Postgres", () => {
@@ -355,6 +369,7 @@ esac
     );
     expect(sqlite(outDb, "SELECT title FROM review_targets WHERE repo='JSONbored/gittensory' AND number=1049;")).toBe("historical PR");
     expect(sqlite(outDb, "SELECT estimated_neurons FROM ai_usage_events;")).toBe("42");
+    expect(sqlite(outDb, "SELECT provider || '|' || effort || '|' || input_tokens || '|' || output_tokens || '|' || total_tokens || '|' || cost_usd FROM ai_usage_events;")).toBe("codex|medium|120|15|135|0.25");
     expect(sqlite(outDb, "SELECT json_extract(metadata_json, '$.repoFullName') FROM ai_usage_events;")).toBe("JSONbored/gittensory");
     expect(sqlite(outDb, "SELECT json_extract(metadata_json, '$.private') IS NULL FROM ai_usage_events;")).toBe("1");
     expect(readdirSync(csvTmp)).toEqual([]);


### PR DESCRIPTION
## Summary
- Persist best-effort actual self-host AI provider usage on existing per-PR `ai_usage_events` rows.
- Thread CLI/API token usage through the self-host AI adapters and review diagnostics without affecting review decisions.
- Include the new usage fields in the redacted Grafana reporting export with old-schema fallbacks.

## What changed
- Added provider, effort, input/output/total token, and cost columns to `ai_usage_events`.
- Parsed usage envelopes from Codex, Claude Code, OpenAI-compatible, and Anthropic provider paths.
- Aggregated multi-reviewer usage into the durable per-PR audit row.
- Updated the reporting export and regression tests for current and older source schemas.

## Why
Operators need a local way to separate ORB review usage from total account-level AI usage, especially when subscription accounts are shared with manual development work.

## Validation
- `npm run test:coverage`
- `npm run typecheck`
- `npm run db:migrations:check`
- `npm audit --audit-level=moderate`
- `npx vitest run test/unit/selfhost-ai.test.ts test/unit/ai-review.test.ts test/unit/selfhost-grafana-reporting.test.ts`
- Local changed executable line coverage: 51/51 (100.00%)