### PR TITLE
feat(enrichment): treat ML model/checkpoint weights as binary assets

### DIFF
--- a/review-enrichment/src/analyzers/asset-weight.ts
+++ b/review-enrichment/src/analyzers/asset-weight.ts
@@ -72,6 +72,14 @@ const BINARY_EXTS = new Set([
   "node",
   "jar",
   "class",
+  // Serialized ML model / checkpoint weight formats — routinely hundreds of MB to multi-GB, the heaviest
+  // binary blobs a PR can commit, and their bytes never appear in the textual diff.
+  "safetensors",
+  "gguf",
+  "onnx",
+  "pt",
+  "pth",
+  "ckpt",
 ]);
 
 interface ScanOptions {

--- a/review-enrichment/test/asset-weight.test.ts
+++ b/review-enrichment/test/asset-weight.test.ts
@@ -28,6 +28,19 @@ test("isBinaryAsset flags genuine binary extensions and ignores text/case", () =
   assert.equal(isBinaryAsset("cache/model.zst"), true);
   assert.equal(isBinaryAsset("dist/bundle.tar.zst"), true);
   assert.equal(isBinaryAsset("cache/model.ZST"), true);
+  // Serialized ML model / checkpoint weight formats are heavy binary blobs (siblings of the other binaries),
+  // and the match stays case-insensitive.
+  for (const p of [
+    "models/llama.safetensors",
+    "models/llama.gguf",
+    "models/resnet.onnx",
+    "models/model.pt",
+    "checkpoints/epoch10.pth",
+    "checkpoints/state.ckpt",
+    "models/LLAMA.SAFETENSORS",
+  ]) {
+    assert.equal(isBinaryAsset(p), true, p);
+  }
   // Extension match is case-insensitive.
   assert.equal(isBinaryAsset("assets/HERO.PNG"), true);
   // Text formats whose bytes are already in the diff are NOT binary assets.


### PR DESCRIPTION
## Summary

The `asset-weight` analyzer flags heavy binary blobs whose byte sizes never appear in the textual diff (they show as "Binary files differ"). Its extension set already covers images, fonts, media, and archives, but **missed serialized ML model and checkpoint weight formats** — `safetensors`, `gguf`, `onnx`, `pt`, `pth`, `ckpt`. These are among the **heaviest artifacts a PR can commit** (routinely hundreds of MB to multi-GB), so a PR that added or grew one slipped past the size-bloat signal entirely.

This adds the six formats as one centralized group in `BINARY_EXTS`:

- The lookup already lowercases and matches only the **final** extension, so casing (`.SAFETENSORS`) and compound names are handled by the existing path — no new logic.
- Additive-only: six set entries plus test cases; no existing behavior changes.
- **Consistency anchor:** `src/review/rag.ts`'s `BINARY_EXT_RE` already classifies all six as binary, so the repo already treats them as binary assets — this brings the size analyzer in line with that existing decision.
- **`.pth` safety:** `.pth` is normally a PyTorch weight file but can also be a small Python site-packages path-config (text). The analyzer only flags blobs **≥ 100 KB**, so a tiny text `.pth` is never weighed — including it cannot produce a false finding, and it matches `rag.ts`.

## No linked issue

This is a **no-issue PR** by design: a self-contained detection-coverage improvement that adds six related extensions to the `asset-weight` analyzer's `BINARY_EXTS` set plus unit tests, touching only `review-enrichment/`. There is no behavior change beyond recognizing the new extensions, so no tracking issue is needed. It mirrors the accepted no-issue precedent for the very same file — `webp`/`avif`/`heic`/`heif` and the recently-merged `zst` (#3128).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] No linked issue — see the **No linked issue** section above.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — no `src/**` lines changed (this change is under `review-enrichment/`, which Codecov does not measure), so `codecov/patch` has no diff to gate; suite is green.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New behavior has tests — positive cases for `.safetensors`/`.gguf`/`.onnx`/`.pt`/`.pth`/`.ckpt` and an uppercase `.SAFETENSORS` case are added to the `isBinaryAsset` unit test, in the same assertion cluster; `npm run rees:test` passes (all review-enrichment tests green, analyzer-metadata check clean).

Validated green against the full GitHub CI `validate-code` check set — `actionlint`, `db:migrations:check`, `db:schema-drift:check`, `cf-typegen:check`, `selfhost:validate-observability`, `typecheck`, `test:coverage`, `test:workers`, `build:mcp`, `test:mcp-pack`, `build:miner`, `rees:test` (689 tests pass, analyzer-metadata check clean), `ui:openapi:check`, `ui:openapi:settings-parity`, `ui:version-audit`, `ui:lint`, `ui:typecheck`, `ui:test`, `ui:build`. Branch rebased on latest `main`.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] No auth, cookie, CORS, GitHub App, Cloudflare, or session changes (N/A — pure extension-set addition).
- [x] No API/OpenAPI/MCP behavior change (N/A).
- [x] No UI changes (N/A — this is a review-enrichment analyzer).
- [x] No visible UI change, so no UI Evidence section is required.
- [x] No docs/changelog changes needed.

## Notes

Analogues followed end-to-end: the merged `feat(enrichment): treat HEIC/HEIF images as binary assets` (#3089), `feat(enrichment): treat Zstandard (.zst) archives as binary assets` (#3128), and the original asset-weight analyzer (#1621) — same file, same additive shape, same test pattern. Data/array formats (`npy`/`npz`/`parquet`/`sqlite`) are intentionally left out of scope here as a separate concern.
