### PR TITLE
test(enrichment): unit coverage for the lockfile-drift change extractor

### DIFF
--- a/review-enrichment/test/lockfile-drift.test.ts
+++ b/review-enrichment/test/lockfile-drift.test.ts
@@ -132,3 +132,123 @@ test("extractLockfileChanges still reports a PyPI lockfile-only package", () => 
     },
   ]);
 });
+
+test("extractLockfileChanges reports an upgraded resolved version (from -> to) in each supported lockfile format", () => {
+  // The existing cases above only exercise ADDED entries (from: null). An upgrade renders as a `-` old
+  // version plus a `+` new version under a CONTEXT package header — the header itself is unchanged.
+  const changes = extractLockfileChanges([
+    {
+      path: "package-lock.json",
+      patch: [
+        "@@ -10,2 +10,2 @@",
+        '     "node_modules/lodash": {',
+        '-      "version": "4.17.20",',
+        '+      "version": "4.17.21",',
+      ].join("\n"),
+    },
+    {
+      path: "yarn.lock",
+      patch: [
+        "@@ -5,2 +5,2 @@",
+        " axios@^1.6.0:",
+        '-  version "1.6.0"',
+        '+  version "1.6.1"',
+      ].join("\n"),
+    },
+    {
+      path: "poetry.lock",
+      patch: [
+        "@@ -1,3 +1,3 @@",
+        " [[package]]",
+        ' name = "requests"',
+        '-version = "2.31.0"',
+        '+version = "2.32.0"',
+      ].join("\n"),
+    },
+  ]);
+
+  assert.deepEqual(changes, [
+    { file: "package-lock.json", line: 11, ecosystem: "npm", package: "lodash", from: "4.17.20", to: "4.17.21" },
+    { file: "yarn.lock", line: 6, ecosystem: "npm", package: "axios", from: "1.6.0", to: "1.6.1" },
+    { file: "poetry.lock", line: 3, ecosystem: "PyPI", package: "requests", from: "2.31.0", to: "2.32.0" },
+  ]);
+});
+
+test("extractLockfileChanges resolves a scoped npm package from a multi-descriptor yarn header, deduped", () => {
+  const changes = extractLockfileChanges([
+    {
+      path: "yarn.lock",
+      patch: [
+        "@@ -1,0 +1,2 @@",
+        '+"@babel/core@^7.0.0", "@babel/core@^7.1.0":',
+        '+  version "7.2.0"',
+      ].join("\n"),
+    },
+  ]);
+
+  // Both descriptors name the same scoped package — one change, not two.
+  assert.deepEqual(changes, [
+    { file: "yarn.lock", line: 2, ecosystem: "npm", package: "@babel/core", from: null, to: "7.2.0" },
+  ]);
+});
+
+test("extractLockfileChanges: removed-only and unchanged lockfile entries produce no drift", () => {
+  const changes = extractLockfileChanges([
+    {
+      // Removed-only: the package leaves the lockfile — there is no new resolved version to query.
+      path: "package-lock.json",
+      patch: [
+        "@@ -10,2 +10,1 @@",
+        '     "node_modules/lodash": {',
+        '-      "version": "4.17.20",',
+      ].join("\n"),
+    },
+    {
+      // Same-version rewrite (formatting churn): from === to is not drift.
+      path: "yarn.lock",
+      patch: [
+        "@@ -5,2 +5,2 @@",
+        " axios@^1.6.0:",
+        '-  version "1.6.1"',
+        '+  version "1.6.1"',
+      ].join("\n"),
+    },
+    {
+      // Purely-context hunk: nothing added or removed at all.
+      path: "poetry.lock",
+      patch: [
+        "@@ -1,3 +1,3 @@",
+        " [[package]]",
+        ' name = "requests"',
+        ' version = "2.31.0"',
+      ].join("\n"),
+    },
+  ]);
+
+  assert.deepEqual(changes, []);
+});
+
+test("extractLockfileChanges skips malformed/partial lockfile hunks rather than throwing", () => {
+  // A version line with no preceding package header (a truncated hunk) has no package to attribute the
+  // version to — in every format it must be dropped, and never throw.
+  const changes = extractLockfileChanges([
+    {
+      path: "package-lock.json",
+      patch: [
+        "@@ -1,0 +1,2 @@",
+        '+      "version": "4.17.21",',
+        "+  garbage { not json",
+      ].join("\n"),
+    },
+    {
+      path: "yarn.lock",
+      patch: ["@@ -1,0 +1,1 @@", '+  version "1.0.0"'].join("\n"),
+    },
+    {
+      path: "poetry.lock",
+      patch: ["@@ -1,0 +1,2 @@", '+version = "1.0"', "+[[package]]"].join("\n"),
+    },
+  ]);
+
+  assert.deepEqual(changes, []);
+});


### PR DESCRIPTION
Closes #2099

## Summary

-

## Scope

- [ ] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [ ] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [ ] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [ ] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [ ] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

-

## Safety

- [ ] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [ ] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [ ] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Required for visible UI, frontend, docs, or extension changes. Attach GitHub-hosted JPG/JPEG or PNG screenshots here; SVG screenshots are not accepted as review evidence. Use a compact table/grid of clickable thumbnails with a short state/title such as "Loaded state", "Empty state", "Error state", "Mobile layout", or "PR sidebar". Prefer annotated screenshots with a colored box, outline, arrow, or highlighter showing what changed. Recordings can be supplemental, but screenshots are still expected for visual review. Do not commit review-only screenshots, recordings, or `docs/review-evidence/**` files.

| State / title                         | JPG/PNG evidence                                                                     |
| ------------------------------------- | ------------------------------------------------------------------------------------ |
| Loaded state                          | `<a href="FULL_URL.png"><img src="FULL_URL.png" alt="Loaded state" width="240"></a>` |
| Empty/error/mobile state, if relevant |                                                                                      |

## Notes

-
