### PR TITLE
feat(enrichment): unsafe-`any` (TS) counter analyzer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,20 +66,20 @@ GITTENSORY_REVIEW_ENRICHMENT=false
 # dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol,redos
 # provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild
 # history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity,ciCheckSignals
-# undocumentedExport,staleBranch,commitHygiene,pendingReviewRequests
+# undocumentedExport,staleBranch,commitHygiene,pendingReviewRequests,unsafeAny
 #
 # Profile defaults:
 # fast: dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol
-# redos,provenance,secretLog,typosquat,iacMisconfig,nativeBuild
+# redos,provenance,secretLog,typosquat,iacMisconfig,nativeBuild,unsafeAny
 # balanced (default): dependency,lockfileDrift,secret,license,installScript,heavyDependency
 # actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature
 # iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink
 # approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene
-# pendingReviewRequests
+# pendingReviewRequests,unsafeAny
 # deep: dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol
 # redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig
 # nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity
-# ciCheckSignals,undocumentedExport,staleBranch,commitHygiene,pendingReviewRequests
+# ciCheckSignals,undocumentedExport,staleBranch,commitHygiene,pendingReviewRequests,unsafeAny
 # END GENERATED REES ANALYZERS
 
 # Submitter-reputation spend control (internal-only): downgrades new/burst/low-rep

--- a/apps/gittensory-ui/src/lib/rees-analyzers.ts
+++ b/apps/gittensory-ui/src/lib/rees-analyzers.ts
@@ -727,6 +727,28 @@ export const REES_ANALYZERS = [
         "Structured-fields-only: reads user.login/team.slug/event/created_at, never diff or comment text. Fail-safe on missing token/fetch error/an unconfirmed-complete timeline.",
     },
   },
+  {
+    name: "unsafeAny",
+    title: "Unsafe `any` usage",
+    category: "quality",
+    cost: "local",
+    defaultEnabled: true,
+    profiles: ["fast", "balanced", "deep"],
+    requires: ["files"],
+    limits: {
+      maxFindings: 25,
+    },
+    docs: {
+      summary:
+        "Flags explicit `any` type usages newly introduced in TypeScript diffs, which opt out of type checking.",
+      looksAt:
+        "Added lines in .ts/.tsx files for a `: any` annotation, an `as any` cast, or an `<any>` assertion.",
+      reports: "File, line, and which of the three `any` shapes was introduced.",
+      network: "None — pure local diff analysis.",
+      notes:
+        "Structural regex only, no type-checker; best-effort comment handling skips comment lines but does not parse string literals, and generated `.d.ts` files are excluded.",
+    },
+  },
 ] as const satisfies readonly ReesAnalyzerDoc[];
 
 export const REES_ANALYZER_NAMES = REES_ANALYZERS.map((analyzer) => analyzer.name);

--- a/review-enrichment/analyzer-metadata.json
+++ b/review-enrichment/analyzer-metadata.json
@@ -816,6 +816,31 @@
         "network": "Calls the GitHub requested-reviewers API once and the issue-timeline API, paginated and bounded to a fixed page cap.",
         "notes": "Structured-fields-only: reads user.login/team.slug/event/created_at, never diff or comment text. Fail-safe on missing token/fetch error/an unconfirmed-complete timeline."
       }
+    },
+    {
+      "name": "unsafeAny",
+      "title": "Unsafe `any` usage",
+      "category": "quality",
+      "cost": "local",
+      "defaultEnabled": true,
+      "profiles": [
+        "fast",
+        "balanced",
+        "deep"
+      ],
+      "requires": [
+        "files"
+      ],
+      "limits": {
+        "maxFindings": 25
+      },
+      "docs": {
+        "summary": "Flags explicit `any` type usages newly introduced in TypeScript diffs, which opt out of type checking.",
+        "looksAt": "Added lines in .ts/.tsx files for a `: any` annotation, an `as any` cast, or an `<any>` assertion.",
+        "reports": "File, line, and which of the three `any` shapes was introduced.",
+        "network": "None — pure local diff analysis.",
+        "notes": "Structural regex only, no type-checker; best-effort comment handling skips comment lines but does not parse string literals, and generated `.d.ts` files are excluded."
+      }
     }
   ]
 }

--- a/review-enrichment/src/analyzers/registry.ts
+++ b/review-enrichment/src/analyzers/registry.ts
@@ -26,6 +26,7 @@ import { scanSecretLog } from "./secret-log.js";
 import { scanStaleBranch } from "./stale-branch.js";
 import { scanTyposquat } from "./typosquat.js";
 import { scanUndocumentedExport } from "./undocumented-export.js";
+import { scanUnsafeAny } from "./unsafe-any.js";
 import type {
   AnalyzerDescriptor,
   AnalyzerFn,
@@ -679,6 +680,36 @@ export const ANALYZER_DESCRIPTORS = [
     },
     run: (req, { signal, analysis, diagnostics }) =>
       scanPendingReviewRequests(req, fetch, { signal, analysis, diagnostics }),
+  }),
+  descriptor({
+    name: "unsafeAny",
+    title: "Unsafe `any` usage",
+    category: "quality",
+    cost: "local",
+    defaultEnabled: true,
+    requires: ["files"],
+    limits: { maxFindings: 25 },
+    docs: {
+      summary:
+        "Flags explicit `any` type usages newly introduced in TypeScript diffs, which opt out of type checking.",
+      looksAt:
+        "Added lines in .ts/.tsx files for a `: any` annotation, an `as any` cast, or an `<any>` assertion.",
+      reports: "File, line, and which of the three `any` shapes was introduced.",
+      network: "None — pure local diff analysis.",
+      notes:
+        "Structural regex only, no type-checker; best-effort comment handling skips comment lines but does not parse string literals, and generated `.d.ts` files are excluded.",
+    },
+    render: (findings, helpers) => {
+      if (!findings.length) return [];
+      const lines = ["### Unsafe `any` usage"];
+      for (const item of findings) {
+        lines.push(
+          `- ${helpers.safeCodeSpan(`${item.file}:${item.line}`)} introduces an \`${item.kind}\` \`any\` usage`,
+        );
+      }
+      return lines;
+    },
+    run: (req) => scanUnsafeAny(req),
   }),
 ] as const satisfies readonly AnyAnalyzerDescriptor[];
 

--- a/review-enrichment/src/analyzers/unsafe-any.ts
+++ b/review-enrichment/src/analyzers/unsafe-any.ts
@@ -1,0 +1,135 @@
+// Unsafe `any` analyzer (#2017). Flags explicit `any` type usages INTRODUCED by the PR (added `+` diff lines) in
+// TypeScript sources — a `: any` type annotation, an `as any` cast, or an `<any>` angle-bracket assertion. Each
+// opts out of the type checker, and the no-checkout reviewer reading only the diff has to spot them by eye. Pure
+// compute, structural regex only (no type-checker), never throws (fail-safe → []). Line-cited via hunk headers,
+// mirroring the ReDoS analyzer's added-line scan.
+import type { EnrichRequest, UnsafeAnyFinding } from "../types.js";
+
+const MAX_FINDINGS = 25; // keep the brief bounded
+const MAX_LINE_CHARS = 2000; // skip matching on pathologically long lines (defensive)
+
+type UnsafeAnyScanLimits = {
+  maxFindings?: number;
+};
+
+// Only hand-authored TypeScript is scanned; a generated declaration file (`.d.ts`) is excluded, matching the
+// generated-output skips the sibling analyzers use.
+const TS_SOURCE_RE = /\.tsx?$/;
+const DECLARATION_RE = /\.d\.ts$/;
+
+function isScannableTsFile(path: string): boolean {
+  return TS_SOURCE_RE.test(path) && !DECLARATION_RE.test(path);
+}
+
+// The three explicit-`any` shapes, matched on an added line's CONTENT (the leading `+` already stripped):
+//   - `annotation`: a `: any` type annotation. The `\bany\b` word boundary keeps `: anyThing` / `: many` from matching.
+//   - `cast`: an `as any` assertion. The leading `\b` keeps `has any` from matching.
+//   - `assertion`: an `<any>` angle-bracket type assertion (`<any>value`). The leading negative lookbehind
+//     `(?<![\w$>])` requires the `<` NOT follow an identifier/`>`, so a GENERIC type argument (`Promise<any>`,
+//     `Array<any>`, `foo<any>()`) is deliberately NOT reported here — labeling those "assertion" would be wrong (a
+//     generic arg is not an assertion, and `<any>` assertions are not even legal syntax in `.tsx`). Missing them is
+//     a fail-safe under-report, precision over recall.
+const DETECTORS: ReadonlyArray<{
+  kind: UnsafeAnyFinding["kind"];
+  pattern: RegExp;
+}> = [
+  { kind: "annotation", pattern: /:\s*any\b/ },
+  { kind: "cast", pattern: /\bas\s+any\b/ },
+  { kind: "assertion", pattern: /(?<![\w$>])<\s*any\s*>/ },
+];
+
+function* patchLines(patch: string): Generator<string> {
+  let start = 0;
+  while (start <= patch.length) {
+    const end = patch.indexOf("\n", start);
+    if (end === -1) {
+      yield patch.slice(start);
+      return;
+    }
+    yield patch.slice(start, end);
+    start = end + 1;
+  }
+}
+
+// Best-effort string/comment avoidance — cheaply-detectable only, per the issue (NOT a full parser). A line whose
+// trimmed content OPENS a comment (`//`, `/*`, or a `*` JSDoc continuation) is skipped entirely; then single-line
+// string literals are blanked; then a trailing `// …` line-comment is stripped. Known scoped-out gaps (documented,
+// all fail-safe under-reports or rare): a string continued across diff lines (multi-line template / trailing `\`)
+// isn't reassembled, and regex literals aren't parsed.
+function contentToScan(content: string): string | null {
+  const trimmed = content.trimStart();
+  if (
+    trimmed.startsWith("//") ||
+    trimmed.startsWith("/*") ||
+    trimmed.startsWith("*")
+  ) {
+    return null;
+  }
+  // Cheap best-effort string-literal removal FIRST (before comment stripping, so a `//` inside a string can't
+  // truncate the line): blank out `"…"` / `'…'` / `` `…` `` bodies (honoring `\`-escapes) so an `any` token inside
+  // a string — e.g. `throw new Error("cast x as any")` — is never flagged. Not a full parser (a `` ` `` template
+  // with a newline spans diff lines, which we don't reassemble); it only ever REMOVES text, so it stays fail-safe.
+  const withoutStrings = content.replace(/(["'`])(?:\\.|(?!\1).)*?\1/g, "");
+  const comment = withoutStrings.indexOf("//");
+  return comment === -1 ? withoutStrings : withoutStrings.slice(0, comment);
+}
+
+/** Scan one file patch's added lines for explicit `any` usages, line-cited via hunk headers. One finding per matched
+ *  line per kind. Pure. */
+export function scanPatchForUnsafeAny(
+  path: string,
+  patch: string,
+  limits: UnsafeAnyScanLimits = {},
+): UnsafeAnyFinding[] {
+  const maxFindings = limits.maxFindings ?? MAX_FINDINGS;
+  if (maxFindings <= 0) return [];
+  const findings: UnsafeAnyFinding[] = [];
+  let newLine = 0;
+  let inHunk = false;
+  for (const line of patchLines(patch)) {
+    const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
+    if (hunk) {
+      newLine = Number(hunk[1]);
+      inHunk = true;
+      continue;
+    }
+    // Skip pre-hunk preamble (the file header lives there); inside a hunk `+++x`/`+++ x` is added content.
+    if (!inHunk) continue;
+    if (line.startsWith("+")) {
+      const content = line.slice(1);
+      const scannable =
+        content.length <= MAX_LINE_CHARS ? contentToScan(content) : null;
+      if (scannable !== null) {
+        for (const { kind, pattern } of DETECTORS) {
+          if (pattern.test(scannable)) {
+            findings.push({ file: path, line: newLine, kind });
+            if (findings.length >= maxFindings) return findings;
+          }
+        }
+      }
+      newLine++;
+    } else if (!line.startsWith("-") && !line.startsWith("\\")) {
+      // A `\ No newline at end of file` marker is not a new-file line — do not advance the cursor
+      // (same class as the redos / undocumented-export fix).
+      newLine++;
+    }
+  }
+  return findings;
+}
+
+/** Analyzer entrypoint: scan every changed `.ts`/`.tsx` file's added lines for explicit `any` usages. Pure. */
+export async function scanUnsafeAny(
+  req: EnrichRequest,
+): Promise<UnsafeAnyFinding[]> {
+  const findings: UnsafeAnyFinding[] = [];
+  for (const file of req.files ?? []) {
+    if (!file.patch || !isScannableTsFile(file.path)) continue;
+    for (const finding of scanPatchForUnsafeAny(file.path, file.patch, {
+      maxFindings: MAX_FINDINGS - findings.length,
+    })) {
+      findings.push(finding);
+      if (findings.length >= MAX_FINDINGS) return findings;
+    }
+  }
+  return findings;
+}

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -439,6 +439,7 @@ export function renderBrief(
   lines.push(...renderDescriptorSection("staleBranch", findings.staleBranch));
   lines.push(...renderDescriptorSection("commitHygiene", findings.commitHygiene));
   lines.push(...renderDescriptorSection("pendingReviewRequests", findings.pendingReviewRequests));
+  lines.push(...renderDescriptorSection("unsafeAny", findings.unsafeAny));
 
   if (!lines.length) return { promptSection: "", systemSuffix: "" };
 

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -137,6 +137,14 @@ export interface RedosFinding {
   pattern: string;
 }
 
+/** An explicit `any` type usage introduced by the PR in a `.ts`/`.tsx` diff — a `: any` annotation, an `as any`
+ *  cast, or an `<any>` assertion. Each opts out of the type checker. Reports the location + which shape only. (#2017) */
+export interface UnsafeAnyFinding {
+  file: string;
+  line: number;
+  kind: "annotation" | "cast" | "assertion";
+}
+
 /** A newly-added dependency (npm/PyPI) lacking a published provenance attestation, or a binary/vendored file
  *  committed without auditable source — supply-chain integrity risks the no-checkout reviewer cannot verify. */
 export interface ProvenanceFinding {
@@ -412,6 +420,7 @@ export interface BriefFindings {
   staleBranch?: StaleBranchFinding[];
   commitHygiene?: CommitHygieneFinding[];
   pendingReviewRequests?: PendingReviewRequestFinding[];
+  unsafeAny?: UnsafeAnyFinding[];
 }
 
 /** A JSDoc/TSDoc block whose `@param` tags name parameters the adjacent function no longer declares — a

--- a/review-enrichment/test/analyzer-registry.test.ts
+++ b/review-enrichment/test/analyzer-registry.test.ts
@@ -38,6 +38,7 @@ const EXPECTED_ANALYZERS = [
   "staleBranch",
   "commitHygiene",
   "pendingReviewRequests",
+  "unsafeAny",
 ];
 
 test("analyzer descriptors cover the runtime registry in stable order", () => {

--- a/review-enrichment/test/unsafe-any.test.ts
+++ b/review-enrichment/test/unsafe-any.test.ts
@@ -1,0 +1,131 @@
+// Units for the unsafe-`any` analyzer's pure detector + its rendering (#2017). Kept separate so analyzer PRs avoid
+// collisions.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { scanPatchForUnsafeAny, scanUnsafeAny } from "../dist/analyzers/unsafe-any.js";
+import { renderBrief } from "../dist/render.js";
+
+function patch(...lines) {
+  return lines.join("\n");
+}
+
+test("scanPatchForUnsafeAny flags a `: any` annotation with its new-file line", () => {
+  const findings = scanPatchForUnsafeAny(
+    "src/x.ts",
+    patch("@@ -1,1 +1,2 @@", " const a = 1;", "+let b: any = 2;"),
+  );
+  assert.deepEqual(findings, [{ file: "src/x.ts", line: 2, kind: "annotation" }]);
+});
+
+test("scanPatchForUnsafeAny flags an `as any` cast", () => {
+  const findings = scanPatchForUnsafeAny(
+    "src/x.ts",
+    patch("@@ -1 +1,1 @@", "+const y = value as any;"),
+  );
+  assert.deepEqual(findings, [{ file: "src/x.ts", line: 1, kind: "cast" }]);
+});
+
+test("scanPatchForUnsafeAny flags an `<any>` angle-bracket assertion", () => {
+  const findings = scanPatchForUnsafeAny(
+    "src/x.ts",
+    patch("@@ -1 +1,1 @@", "+const z = <any>value;"),
+  );
+  assert.deepEqual(findings, [{ file: "src/x.ts", line: 1, kind: "assertion" }]);
+});
+
+test("scanPatchForUnsafeAny does NOT mislabel a generic type argument as an `<any>` assertion", () => {
+  // `Promise<any>` / `Array<any>` are generic arguments, not `<any>value` assertions — reporting them "assertion"
+  // would be factually wrong (and `<any>` assertions aren't even legal in .tsx). Under-reporting them is fail-safe.
+  const generics = scanPatchForUnsafeAny(
+    "src/x.ts",
+    patch("@@ -1 +1,2 @@", "+function f(): Promise<any> { return g(); }", "+const xs: Array<any> = [];"),
+  );
+  // `Array<any>` is caught by its `: Array` … no `: any`; both `<any>` occurrences are generic args → no assertion.
+  assert.deepEqual(generics, []);
+  // A genuine prefix assertion IS still flagged.
+  const real = scanPatchForUnsafeAny("src/x.ts", patch("@@ -1 +1,1 @@", "+const z = <any>value;"));
+  assert.deepEqual(real, [{ file: "src/x.ts", line: 1, kind: "assertion" }]);
+});
+
+test("scanUnsafeAny skips a non-TS file and generated declarations", async () => {
+  const files = [
+    { path: "src/x.js", patch: patch("@@ -1 +1,1 @@", "+let b: any = 2;") },
+    { path: "src/x.d.ts", patch: patch("@@ -1 +1,1 @@", "+export let b: any;") },
+    { path: "src/x.ts", patch: patch("@@ -1 +1,1 @@", "+let b: any = 2;") },
+  ];
+  const findings = await scanUnsafeAny({
+    repoFullName: "JSONbored/gittensory",
+    prNumber: 1,
+    files,
+  });
+  assert.deepEqual(findings, [{ file: "src/x.ts", line: 1, kind: "annotation" }]);
+});
+
+test("scanPatchForUnsafeAny ignores comment lines and identifiers that merely contain `any` (best-effort)", () => {
+  const findings = scanPatchForUnsafeAny(
+    "src/x.ts",
+    patch(
+      "@@ -1 +1,5 @@",
+      "+// x: any goes here",
+      "+ * @returns any value",
+      "+let count: number = anyThing;",
+      "+const many = 3;",
+      "+let live: any = q; // as any",
+    ),
+  );
+  // Only the last line matches — its `: any` annotation; the trailing `// as any` comment is stripped, so the
+  // cast inside it is NOT counted.
+  assert.deepEqual(findings, [{ file: "src/x.ts", line: 5, kind: "annotation" }]);
+});
+
+test("scanPatchForUnsafeAny does not flag `any` tokens inside string literals (best-effort)", () => {
+  const findings = scanPatchForUnsafeAny(
+    "src/x.ts",
+    patch(
+      "@@ -1 +1,2 @@",
+      '+throw new Error("cast x as any");',
+      "+const label = 'value: any';",
+    ),
+  );
+  // Both `any` occurrences live inside string literals, which are blanked before matching → no findings.
+  assert.deepEqual(findings, []);
+});
+
+test("scanPatchForUnsafeAny honours the maxFindings cap", () => {
+  const findings = scanPatchForUnsafeAny(
+    "src/x.ts",
+    patch(
+      "@@ -1 +1,3 @@",
+      "+let a: any = 1;",
+      "+let b: any = 2;",
+      "+let c: any = 3;",
+    ),
+    { maxFindings: 2 },
+  );
+  assert.equal(findings.length, 2);
+});
+
+test("scanUnsafeAny returns no findings on clean input, and render emits nothing for empty", async () => {
+  const findings = await scanUnsafeAny({
+    repoFullName: "JSONbored/gittensory",
+    prNumber: 1,
+    files: [
+      { path: "src/x.ts", patch: patch("@@ -1 +1,1 @@", "+let n: number = 1;") },
+    ],
+  });
+  assert.deepEqual(findings, []);
+  assert.deepEqual(renderBrief({ unsafeAny: [] }), {
+    promptSection: "",
+    systemSuffix: "",
+  });
+});
+
+test("renderBrief renders the unsafe-`any` section from findings", () => {
+  const { promptSection } = renderBrief({
+    unsafeAny: [{ file: "src/x.ts", line: 2, kind: "annotation" }],
+  });
+  assert.match(promptSection, /Unsafe `any` usage/);
+  assert.match(promptSection, /src\/x\.ts:2/);
+  assert.match(promptSection, /annotation/);
+});


### PR DESCRIPTION
## Summary

Adds the `unsafeAny` REES analyzer (Closes #2017) — counts and locates explicit `any` usages newly introduced in TypeScript diffs, a type-safety-erosion signal the no-checkout reviewer can weigh. Pure compute over added `+` diff lines, **structural regex only** (no type-checker), fail-safe (returns `[]`, never throws). Mirrors the `redos.ts` local-analyzer template exactly.

**Three kinds, matched on each added line's content:**
- `annotation` — `: any` (the `\bany\b` boundary keeps `: anyThing` / `: many` out)
- `cast` — `as any` (the leading `\b` keeps `has any` out)
- `assertion` — a genuine `<any>value` prefix assertion. The negative lookbehind `(?<![\w$>])` deliberately **excludes generic type arguments** (`Promise<any>`, `Array<any>`, `foo<any>()`) — labeling those "assertion" would be factually wrong (a generic arg isn't an assertion, and `<any>` assertions aren't even legal in `.tsx`); missing them is a precision-first, fail-safe under-report.

**False-positive avoidance (best-effort, per the issue's "where cheaply detectable"):** comment lines (`//`, `/*`, `*`) are skipped; single-line string literals are blanked *before* matching (so `throw new Error("cast x as any")` isn't flagged); a trailing `// …` is stripped. Only `.ts`/`.tsx` (`.d.ts` excluded). Capped at `MAX_FINDINGS = 25`.

Wiring mirrors the sibling analyzers: `UnsafeAnyFinding` + `BriefFindings` key in `types.ts`, a `quality`/`local` descriptor with an inline value-safe `render` (`file:line` + kind, never code content), the render dispatch, the `analyzer-registry` invariant list, and the 3 generated parity files regenerated via `npm --prefix review-enrichment run metadata`.

## Scope
- [x] Conventional Commit; focused; linked issue #2017; all inside `review-enrichment/` + the generated parity files. No `site/`/`CNAME`/`**/lovable/**`; no `CHANGELOG.md`.

## Validation
- [x] `npm --prefix review-enrichment test` — **712 pass / 0 fail** (build + sourcemap validate + `metadata --check` + node tests; exactly CI). New tests cover: annotation/cast/assertion, **generic `<any>` NOT mislabeled as assertion** while a real `<any>value` is, non-TS + `.d.ts` skipped, comment + word-boundary + trailing-comment + **string-literal** false-positive avoidance, the cap, and empty render.
- [x] `npm run typecheck` clean; `git diff --check` clean.

## Safety
- [x] Reports `file:line` + kind only — never code content. Pure, no network, no token, fail-safe. No secrets/wallets/hotkeys/trust/reward terms.
