### PR TITLE
fix(enrichment): classify .zst archives as assets

### DIFF
--- a/apps/gittensory-ui/src/lib/selfhost-env-reference.ts
+++ b/apps/gittensory-ui/src/lib/selfhost-env-reference.ts
@@ -359,7 +359,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "SENTRY_DSN",
-    firstReference: "src/selfhost/sentry.ts:365",
+    firstReference: "src/selfhost/sentry.ts:370",
   },
   {
     name: "SENTRY_ENVIRONMENT",
@@ -371,11 +371,11 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "SENTRY_SERVER_NAME",
-    firstReference: "src/selfhost/sentry.ts:383",
+    firstReference: "src/selfhost/sentry.ts:388",
   },
   {
     name: "SENTRY_TRACES_SAMPLE_RATE",
-    firstReference: "src/selfhost/sentry.ts:171",
+    firstReference: "src/selfhost/sentry.ts:176",
   },
   {
     name: "SETUP_OUTPUT_PATH",
@@ -478,11 +478,11 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| `SELFHOST_BUNDLE_ALL` | `scripts/build-selfhost.mjs:13` |",
   "| `SELFHOST_SERVICE` | `scripts/smoke-observability-traces.mjs:5` |",
   "| `SELFHOST_SETUP_TOKEN` | `src/selfhost/preflight.ts:186` |",
-  "| `SENTRY_DSN` | `src/selfhost/sentry.ts:365` |",
+  "| `SENTRY_DSN` | `src/selfhost/sentry.ts:370` |",
   "| `SENTRY_ENVIRONMENT` | `src/selfhost/otel.ts:60` |",
   "| `SENTRY_RELEASE` | `src/selfhost/otel.ts:62` |",
-  "| `SENTRY_SERVER_NAME` | `src/selfhost/sentry.ts:383` |",
-  "| `SENTRY_TRACES_SAMPLE_RATE` | `src/selfhost/sentry.ts:171` |",
+  "| `SENTRY_SERVER_NAME` | `src/selfhost/sentry.ts:388` |",
+  "| `SENTRY_TRACES_SAMPLE_RATE` | `src/selfhost/sentry.ts:176` |",
   "| `SETUP_OUTPUT_PATH` | `src/server.ts:833` |",
   "| `SLACK_WEBHOOK_URL` | `src/services/notify-discord.ts:173` |",
 ].join("\n");

--- a/review-enrichment/src/analysis-context.ts
+++ b/review-enrichment/src/analysis-context.ts
@@ -444,7 +444,7 @@ function categorizeFile(path: string): FileCategory {
     return { path, extension, category: "docs" };
   }
   if (
-    [".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".pdf", ".zip", ".gz"].includes(
+    [".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".pdf", ".zip", ".gz", ".zst"].includes(
       extension,
     )
   ) {

--- a/review-enrichment/test/analysis-context.test.ts
+++ b/review-enrichment/test/analysis-context.test.ts
@@ -7,6 +7,7 @@ import {
   createAnalysisContext,
   filesHaveAddedLines,
 } from "../dist/analysis-context.js";
+import { planAnalyzers } from "../dist/scheduler.js";
 import {
   queryOsvBatch,
   scanDependencyChanges,
@@ -495,6 +496,53 @@ test("createAnalysisContext classifies workflow paths case-insensitively", () =>
       ["docs/readme.md", "docs"],
     ],
   );
+});
+
+test("createAnalysisContext classifies Zstandard archives as assets for scheduler gating", () => {
+  const context = createAnalysisContext({
+    repoFullName: "JSONbored/gittensory",
+    prNumber: 3128,
+    headSha: "abcdef1234567890",
+    githubToken: "github_pat_test",
+    analyzers: ["assetWeight"],
+    files: [
+      {
+        path: "cache/model.zst",
+        patch: null,
+        status: "added",
+      },
+      {
+        path: "dist/bundle.tar.ZST",
+        patch: null,
+        status: "added",
+      },
+    ],
+  });
+
+  assert.deepEqual(
+    context.fileCategories.map((file) => [file.path, file.extension, file.category]),
+    [
+      ["cache/model.zst", ".zst", "asset"],
+      ["dist/bundle.tar.ZST", ".zst", "asset"],
+    ],
+  );
+
+  const plan = planAnalyzers(
+    {
+      repoFullName: "JSONbored/gittensory",
+      prNumber: 3128,
+      headSha: "abcdef1234567890",
+      githubToken: "github_pat_test",
+      analyzers: ["assetWeight"],
+      files: context.changedFiles,
+    },
+    { assetWeight: async () => [] },
+    context,
+    { budgetMs: 5_000, startedAtMs: 0 },
+  );
+
+  assert.deepEqual(plan.runnable.map((item) => item.name), ["assetWeight"]);
+  assert.deepEqual(plan.skipped.map((item) => [item.name, item.skipReason]), []);
 });
 
 test("createAnalysisContext classifies lockfile paths case-insensitively", () => {


### PR DESCRIPTION
### Motivation
- The asset-weight analyzer was updated to treat `.zst` as a binary asset, but the file categorizer did not include `.zst`, causing `.zst`-only PRs to be categorized as `source` and skipped by the scheduler precondition.

### Description
- Add `.zst` to the REES file categorizer asset allowlist so `.zst` and compound names like `.tar.zst` are classified as `asset` (`review-enrichment/src/analysis-context.ts`).
- Add a regression test that verifies `.zst` and mixed-case `.tar.ZST` files are categorized as assets and that `planAnalyzers` will schedule `assetWeight` rather than skipping it (`review-enrichment/test/analysis-context.test.ts`).
- Import `planAnalyzers` into the test suite to assert scheduler-facing behavior end-to-end (`review-enrichment/test/analysis-context.test.ts`).
- Regenerate and refresh the self-host env reference artifact required by the local gate (`apps/gittensory-ui/src/lib/selfhost-env-reference.ts`).

### Testing
- Ran `git diff --check` and `npm run selfhost:env-reference:check`, both succeeded. 
- Ran the targeted enrichment tests with `npm --prefix review-enrichment test`, and the modified REES test suite (including the new regression) passed. 
- Attempted full local gate with `npm run test:ci`, which timed out / flaked in unrelated long-running queue/backfill suites (root-level coverage run); this is an environment/timeout issue and unrelated to the change. 
- `npm audit --audit-level=moderate` failed due to the npm registry audit endpoint returning `403 Forbidden` (external network/audit endpoint issue), not a code vulnerability.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4966780d6c832c98e307d270bbdb71)