### PR TITLE
fix(selfhost): bound foreground-liveness sweeps and cache rate-limit checks

### DIFF
--- a/src/selfhost/pg-queue.ts
+++ b/src/selfhost/pg-queue.ts
@@ -708,18 +708,38 @@ export function createPgQueue(
    *  maxReleasePerSweep allows, selectForegroundDeferralsToRelease picks the oldest first -- a large inherited
    *  backlog drains gradually over several sweep ticks instead of flooding GitHub with every re-attempt at once.
    *  Logs + records a metric ONCE per sweep (aggregate count), not per row, so a large release batch cannot spam
-   *  the log. */
+   *  the log.
+   *
+   *  Candidate selection queries an OLDEST window AND a NEWEST window (#selfhost-queue-liveness clear-bucket
+   *  starvation fix), not just one oldest-first window. A single `ORDER BY created_at ASC LIMIT` window can be
+   *  filled ENTIRELY by older still-rate-limited jobs once the backlog exceeds the limit -- selectForegroundDeferralsToRelease's
+   *  clear-bucket-priority sort can only prioritize candidates it is actually shown, so a large-enough glut of
+   *  older blocked jobs would permanently hide every newer, already-admittable candidate from it, defeating the
+   *  whole point of the clear-bucket check. The newest window guarantees a fresh clear-bucket candidate is
+   *  always represented in `eligible` regardless of how large the older-blocked backlog grows, at the same
+   *  total worst-case row/admission-check budget as before (still `maxReleasePerSweep * 2` candidates, just
+   *  split fairly across both ends of the age spectrum instead of packed entirely into the oldest end). */
   async function releaseStaleForegroundDeferrals(): Promise<number> {
     if (!foregroundLivenessConfig.enabled) return 0;
     const now = Date.now();
-    const candidateLimit = foregroundLivenessConfig.maxReleasePerSweep * 2;
-    const res = await pool.query(
-      `SELECT id, payload, created_at FROM ${TABLE} WHERE status='pending' AND priority>=$1 AND run_after>$2 ORDER BY created_at ASC, id ASC LIMIT $3`,
-      [FOREGROUND_QUEUE_PRIORITY_FLOOR, now, candidateLimit],
-    );
+    const candidateLimit = foregroundLivenessConfig.maxReleasePerSweep;
+    const [oldestRes, newestRes] = await Promise.all([
+      pool.query(
+        `SELECT id, payload, created_at FROM ${TABLE} WHERE status='pending' AND priority>=$1 AND run_after>$2 ORDER BY created_at ASC, id ASC LIMIT $3`,
+        [FOREGROUND_QUEUE_PRIORITY_FLOOR, now, candidateLimit],
+      ),
+      pool.query(
+        `SELECT id, payload, created_at FROM ${TABLE} WHERE status='pending' AND priority>=$1 AND run_after>$2 ORDER BY created_at DESC, id DESC LIMIT $3`,
+        [FOREGROUND_QUEUE_PRIORITY_FLOOR, now, candidateLimit],
+      ),
+    ]);
+    const candidateRowsById = new Map<string, { id: string; payload: string; created_at: number | string }>();
+    for (const row of [...oldestRes.rows, ...newestRes.rows] as Array<{ id: string; payload: string; created_at: number | string }>) {
+      candidateRowsById.set(row.id, row);
+    }
     const eligible: Array<{ id: string; pendingSinceMs: number; ageStale: boolean; rateLimitClear: boolean }> = [];
     const admissionCache = new Map<string, Promise<boolean>>();
-    for (const row of res.rows as Array<{ id: string; payload: string; created_at: number | string }>) {
+    for (const row of candidateRowsById.values()) {
       const pendingSinceMs = Number(row.created_at);
       const ageStale = isForegroundDeferralStale(foregroundLivenessConfig, pendingSinceMs, now);
       const rateLimitClear = await isRateLimitAdmissionNowClear(row.payload, admissionCache);

--- a/src/selfhost/pg-queue.ts
+++ b/src/selfhost/pg-queue.ts
@@ -676,14 +676,22 @@ export function createPgQueue(
    *  against CURRENT observations, independent of how long ago it was deferred. Returns true when it would be
    *  admitted right now (no longer blocked); false when still blocked OR the payload is unparseable (best-
    *  effort -- an unparseable payload is left for the normal dead-letter path, never force-released here). */
-  async function isRateLimitAdmissionNowClear(payload: string): Promise<boolean> {
+  async function isRateLimitAdmissionNowClear(payload: string, admissionCache: Map<string, Promise<boolean>>): Promise<boolean> {
     let message: JobMessage;
     try {
       message = JSON.parse(payload) as JobMessage;
     } catch {
       return false;
     }
-    return (await rateLimitAdmissionDelayMs(message)) === null;
+    const target = githubRateLimitAdmissionTargetForJob(message);
+    if (target === null) return true;
+    const cacheKey = `${target.kind}:${target.admissionKey ?? ""}`;
+    let cached = admissionCache.get(cacheKey);
+    if (cached === undefined) {
+      cached = rateLimitAdmissionDelayMs(message).then((delay) => delay === null);
+      admissionCache.set(cacheKey, cached);
+    }
+    return cached;
   }
 
   /** See foreground-liveness.ts for the full rationale. A bounded candidate SELECT (foreground-priority, pending,
@@ -704,15 +712,17 @@ export function createPgQueue(
   async function releaseStaleForegroundDeferrals(): Promise<number> {
     if (!foregroundLivenessConfig.enabled) return 0;
     const now = Date.now();
+    const candidateLimit = foregroundLivenessConfig.maxReleasePerSweep * 2;
     const res = await pool.query(
-      `SELECT id, payload, created_at FROM ${TABLE} WHERE status='pending' AND priority>=$1 AND run_after>$2`,
-      [FOREGROUND_QUEUE_PRIORITY_FLOOR, now],
+      `SELECT id, payload, created_at FROM ${TABLE} WHERE status='pending' AND priority>=$1 AND run_after>$2 ORDER BY created_at ASC, id ASC LIMIT $3`,
+      [FOREGROUND_QUEUE_PRIORITY_FLOOR, now, candidateLimit],
     );
     const eligible: Array<{ id: string; pendingSinceMs: number; ageStale: boolean; rateLimitClear: boolean }> = [];
+    const admissionCache = new Map<string, Promise<boolean>>();
     for (const row of res.rows as Array<{ id: string; payload: string; created_at: number | string }>) {
       const pendingSinceMs = Number(row.created_at);
       const ageStale = isForegroundDeferralStale(foregroundLivenessConfig, pendingSinceMs, now);
-      const rateLimitClear = await isRateLimitAdmissionNowClear(row.payload);
+      const rateLimitClear = await isRateLimitAdmissionNowClear(row.payload, admissionCache);
       if (!ageStale && !rateLimitClear) continue;
       eligible.push({ id: row.id, pendingSinceMs, ageStale, rateLimitClear });
     }

--- a/src/selfhost/sqlite-queue.ts
+++ b/src/selfhost/sqlite-queue.ts
@@ -396,18 +396,36 @@ export function createSqliteQueue(
    *  allows, selectForegroundDeferralsToRelease picks the oldest first -- a large inherited backlog drains
    *  gradually over several sweep ticks instead of flooding GitHub with every re-attempt at once. Logs +
    *  records a metric ONCE per sweep (aggregate count), not per row, so a large release batch cannot spam the
-   *  log. */
+   *  log.
+   *
+   *  Candidate selection queries an OLDEST window AND a NEWEST window (#selfhost-queue-liveness clear-bucket
+   *  starvation fix), not just one oldest-first window. A single `ORDER BY created_at ASC LIMIT` window can be
+   *  filled ENTIRELY by older still-rate-limited jobs once the backlog exceeds the limit -- selectForegroundDeferralsToRelease's
+   *  clear-bucket-priority sort can only prioritize candidates it is actually shown, so a large-enough glut of
+   *  older blocked jobs would permanently hide every newer, already-admittable candidate from it, defeating the
+   *  whole point of the clear-bucket check. The newest window guarantees a fresh clear-bucket candidate is
+   *  always represented in `eligible` regardless of how large the older-blocked backlog grows, at the same
+   *  total worst-case row/admission-check budget as before (still `maxReleasePerSweep * 2` candidates, just
+   *  split fairly across both ends of the age spectrum instead of packed entirely into the oldest end). */
   function releaseStaleForegroundDeferrals(): number {
     if (!foregroundLivenessConfig.enabled) return 0;
     const now = Date.now();
-    const candidateLimit = foregroundLivenessConfig.maxReleasePerSweep * 2;
-    const { rows } = driver.query(
+    const candidateLimit = foregroundLivenessConfig.maxReleasePerSweep;
+    const oldest = driver.query(
       `SELECT id, payload, created_at FROM ${TABLE} WHERE status='pending' AND priority>=? AND run_after>? ORDER BY created_at ASC, id ASC LIMIT ?`,
       [FOREGROUND_QUEUE_PRIORITY_FLOOR, now, candidateLimit],
-    );
+    ).rows;
+    const newest = driver.query(
+      `SELECT id, payload, created_at FROM ${TABLE} WHERE status='pending' AND priority>=? AND run_after>? ORDER BY created_at DESC, id DESC LIMIT ?`,
+      [FOREGROUND_QUEUE_PRIORITY_FLOOR, now, candidateLimit],
+    ).rows;
+    const candidateRowsById = new Map<number, { id: number; payload: string; created_at: number }>();
+    for (const row of [...oldest, ...newest] as Array<{ id: number; payload: string; created_at: number }>) {
+      candidateRowsById.set(row.id, row);
+    }
     const eligible: Array<{ id: number; pendingSinceMs: number; ageStale: boolean; rateLimitClear: boolean }> = [];
     const admissionCache = new Map<string, boolean>();
-    for (const row of rows as Array<{ id: number; payload: string; created_at: number }>) {
+    for (const row of candidateRowsById.values()) {
       const ageStale = isForegroundDeferralStale(foregroundLivenessConfig, row.created_at, now);
       const rateLimitClear = isRateLimitAdmissionNowClear(row.payload, admissionCache);
       if (!ageStale && !rateLimitClear) continue;

--- a/src/selfhost/sqlite-queue.ts
+++ b/src/selfhost/sqlite-queue.ts
@@ -365,14 +365,21 @@ export function createSqliteQueue(
    *  against CURRENT observations, independent of how long ago it was deferred. Returns true when it would be
    *  admitted right now (no longer blocked); false when still blocked OR the payload is unparseable (best-
    *  effort -- an unparseable payload is left for the normal dead-letter path, never force-released here). */
-  function isRateLimitAdmissionNowClear(payload: string): boolean {
+  function isRateLimitAdmissionNowClear(payload: string, admissionCache: Map<string, boolean>): boolean {
     let message: JobMessage;
     try {
       message = JSON.parse(payload) as JobMessage;
     } catch {
       return false;
     }
-    return rateLimitAdmissionDelayMs(driver, message) === null;
+    const target = githubRateLimitAdmissionTargetForJob(message);
+    if (target === null) return true;
+    const cacheKey = `${target.kind}:${target.admissionKey ?? ""}`;
+    const cached = admissionCache.get(cacheKey);
+    if (cached !== undefined) return cached;
+    const clear = rateLimitAdmissionDelayMs(driver, message) === null;
+    admissionCache.set(cacheKey, clear);
+    return clear;
   }
 
   /** See foreground-liveness.ts for the full rationale. A bounded candidate SELECT (foreground-priority, pending,
@@ -393,14 +400,16 @@ export function createSqliteQueue(
   function releaseStaleForegroundDeferrals(): number {
     if (!foregroundLivenessConfig.enabled) return 0;
     const now = Date.now();
+    const candidateLimit = foregroundLivenessConfig.maxReleasePerSweep * 2;
     const { rows } = driver.query(
-      `SELECT id, payload, created_at FROM ${TABLE} WHERE status='pending' AND priority>=? AND run_after>?`,
-      [FOREGROUND_QUEUE_PRIORITY_FLOOR, now],
+      `SELECT id, payload, created_at FROM ${TABLE} WHERE status='pending' AND priority>=? AND run_after>? ORDER BY created_at ASC, id ASC LIMIT ?`,
+      [FOREGROUND_QUEUE_PRIORITY_FLOOR, now, candidateLimit],
     );
     const eligible: Array<{ id: number; pendingSinceMs: number; ageStale: boolean; rateLimitClear: boolean }> = [];
+    const admissionCache = new Map<string, boolean>();
     for (const row of rows as Array<{ id: number; payload: string; created_at: number }>) {
       const ageStale = isForegroundDeferralStale(foregroundLivenessConfig, row.created_at, now);
-      const rateLimitClear = isRateLimitAdmissionNowClear(row.payload);
+      const rateLimitClear = isRateLimitAdmissionNowClear(row.payload, admissionCache);
       if (!ageStale && !rateLimitClear) continue;
       eligible.push({ id: row.id, pendingSinceMs: row.created_at, ageStale, rateLimitClear });
     }

--- a/test/unit/selfhost-pg-queue.test.ts
+++ b/test/unit/selfhost-pg-queue.test.ts
@@ -81,17 +81,30 @@ interface MockPool {
     backlogConvergence?: { cnt: number };
     freshIntake?: { cnt: number };
   }): void;
-  /** Programs the exact rows returned by releaseStaleForegroundDeferrals' candidate SELECT
-   *  (`WHERE status='pending' AND priority>=$1 AND run_after>$2`), and the per-row rowCount its conditional
-   *  UPDATE reports (defaults to 1 -- the row still matched at UPDATE time -- when not otherwise queued).
-   *  `payload` defaults to a "recapture-preview" message -- a foreground type NOT in
-   *  GITHUB_BUDGET_BACKGROUND_TYPES / not "github-webhook"/"agent-regate-pr" -- so
+  /** Programs the exact rows returned by releaseStaleForegroundDeferrals' candidate SELECT (both the oldest-
+   *  and newest-ordered windows, see setForegroundLivenessCandidatesByWindow's doc comment for why there are
+   *  two), and the per-row rowCount its conditional UPDATE reports (defaults to 1 -- the row still matched at
+   *  UPDATE time -- when not otherwise queued). `payload` defaults to a "recapture-preview" message -- a
+   *  foreground type NOT in GITHUB_BUDGET_BACKGROUND_TYPES / not "github-webhook"/"agent-regate-pr" -- so
    *  githubRateLimitAdmissionTargetForJob returns null for it and the rate-limit-clear OR-condition is
    *  trivially/always true, isolating the AGE condition cleanly for tests that aren't specifically about
    *  rate-limit clearing. Pass an explicit `payload` (e.g. a github-webhook message) plus `setRateLimitRows`
    *  to test the rate-limit-clear condition itself, or "not valid json" to test the unparseable-payload path. */
   setForegroundLivenessCandidates(
     rows: Array<{ id: string; created_at: number; payload?: string }>,
+    updateRowCounts?: number[],
+  ): void;
+  /** Like setForegroundLivenessCandidates, but programs the OLDEST-ordered and NEWEST-ordered candidate windows
+   *  independently (#selfhost-queue-liveness clear-bucket starvation fix) -- releaseStaleForegroundDeferrals now
+   *  issues two real, differently-bounded queries (`ORDER BY created_at ASC LIMIT` and `... DESC LIMIT`) so a
+   *  large glut of older still-blocked rows can never fill the ONLY candidate window and hide a newer
+   *  clear-bucket row from it. This mock doesn't apply real SQL LIMIT/ORDER BY semantics (setForegroundLivenessCandidates
+   *  above just returns the same configured array for both windows), so a test that needs to prove the two
+   *  windows are genuinely independent -- i.e. a candidate present in one window but not the other -- must use
+   *  this instead. */
+  setForegroundLivenessCandidatesByWindow(
+    oldestRows: Array<{ id: string; created_at: number; payload?: string }>,
+    newestRows: Array<{ id: string; created_at: number; payload?: string }>,
     updateRowCounts?: number[],
   ): void;
 }
@@ -108,7 +121,8 @@ function makePool(): MockPool {
   let pressureMaintenance: { cnt: number; oldest: number | null } = { cnt: 0, oldest: null };
   let pressureBacklogConvergence: { cnt: number } = { cnt: 0 };
   let pressureFreshIntake: { cnt: number } = { cnt: 0 };
-  let foregroundLivenessCandidates: Array<{ id: string; created_at: number; payload?: string }> = [];
+  let foregroundLivenessOldestCandidates: Array<{ id: string; created_at: number; payload?: string }> = [];
+  let foregroundLivenessNewestCandidates: Array<{ id: string; created_at: number; payload?: string }> = [];
   const foregroundLivenessUpdateRowCounts: number[] = [];
   const DEFAULT_FOREGROUND_LIVENESS_PAYLOAD = JSON.stringify({
     type: "recapture-preview",
@@ -120,13 +134,18 @@ function makePool(): MockPool {
   const fn = vi.fn().mockImplementation(async (sql: unknown, params?: unknown[]) => {
     const q = String(sql);
     if (q.includes("SELECT id, payload, created_at FROM") && q.includes("priority>=$1 AND run_after>$2")) {
+      // #selfhost-queue-liveness clear-bucket starvation fix: releaseStaleForegroundDeferrals issues an OLDEST-
+      // ordered window and a NEWEST-ordered window as two independent queries -- match on ORDER BY direction so
+      // setForegroundLivenessCandidatesByWindow can program them differently (setForegroundLivenessCandidates
+      // programs both windows identically, matching this repo's other tests that don't care about the split).
+      const rows = q.includes("ORDER BY created_at DESC") ? foregroundLivenessNewestCandidates : foregroundLivenessOldestCandidates;
       return {
-        rows: foregroundLivenessCandidates.map((row) => ({
+        rows: rows.map((row) => ({
           id: row.id,
           payload: row.payload ?? DEFAULT_FOREGROUND_LIVENESS_PAYLOAD,
           created_at: row.created_at,
         })),
-        rowCount: foregroundLivenessCandidates.length,
+        rowCount: rows.length,
       };
     }
     if (q.includes("SET run_after=$1 WHERE id=$2 AND status='pending' AND run_after>$1")) {
@@ -225,7 +244,14 @@ function makePool(): MockPool {
       rateLimitRows = rows;
     },
     setForegroundLivenessCandidates(rows, updateRowCounts) {
-      foregroundLivenessCandidates = rows;
+      foregroundLivenessOldestCandidates = rows;
+      foregroundLivenessNewestCandidates = rows;
+      foregroundLivenessUpdateRowCounts.length = 0;
+      if (updateRowCounts) foregroundLivenessUpdateRowCounts.push(...updateRowCounts);
+    },
+    setForegroundLivenessCandidatesByWindow(oldestRows, newestRows, updateRowCounts) {
+      foregroundLivenessOldestCandidates = oldestRows;
+      foregroundLivenessNewestCandidates = newestRows;
       foregroundLivenessUpdateRowCounts.length = 0;
       if (updateRowCounts) foregroundLivenessUpdateRowCounts.push(...updateRowCounts);
     },
@@ -2367,9 +2393,17 @@ describe("createPgQueue (durable #977)", () => {
       const released = await q.releaseStaleForegroundDeferrals();
 
       expect(released).toBe(2);
+      // candidateLimit is now maxReleasePerSweep itself (2), not maxReleasePerSweep * 2 -- the query is issued
+      // TWICE (an oldest-ordered window and a newest-ordered window, #selfhost-queue-liveness clear-bucket
+      // starvation fix), each individually bounded to maxReleasePerSweep so the combined worst-case candidate
+      // budget is unchanged.
       expect(m.fn).toHaveBeenCalledWith(
-        expect.stringContaining("LIMIT $3"),
-        expect.arrayContaining([8, 4]),
+        expect.stringContaining("ORDER BY created_at ASC, id ASC LIMIT $3"),
+        expect.arrayContaining([8, 2]),
+      );
+      expect(m.fn).toHaveBeenCalledWith(
+        expect.stringContaining("ORDER BY created_at DESC, id DESC LIMIT $3"),
+        expect.arrayContaining([8, 2]),
       );
       for (const id of ["oldest", "second-oldest"]) {
         expect(m.fn).toHaveBeenCalledWith(
@@ -2412,6 +2446,64 @@ describe("createPgQueue (durable #977)", () => {
         { id: "blocked-second", created_at: now - 9 * 60_000, payload: payload("blocked-second", 111) },
         { id: "clear-newer", created_at: now - 5 * 60_000, payload: payload("clear-newer", 222) },
       ]);
+      const q = createPgQueue(m.pool, async () => undefined);
+
+      const released = await q.releaseStaleForegroundDeferrals();
+
+      expect(released).toBe(2);
+      for (const id of ["clear-newer", "blocked-oldest"]) {
+        expect(m.fn).toHaveBeenCalledWith(
+          expect.stringContaining("SET run_after=$1 WHERE id=$2 AND status='pending' AND run_after>$1"),
+          expect.arrayContaining([id]),
+        );
+      }
+      expect(m.fn).not.toHaveBeenCalledWith(
+        expect.stringContaining("SET run_after=$1 WHERE id=$2 AND status='pending' AND run_after>$1"),
+        expect.arrayContaining(["blocked-second"]),
+      );
+    });
+
+    // REGRESSION (#selfhost-queue-liveness clear-bucket starvation): the test above never exceeds the OLD
+    // single-window candidateLimit (maxReleasePerSweep * 2 = 4 for 3 seeded rows), so it can't actually catch a
+    // regression to the old single-`ORDER BY created_at ASC LIMIT` query -- that window would still have
+    // included "clear-newer" by coincidence. This test uses setForegroundLivenessCandidatesByWindow to program
+    // the OLDEST window as entirely older still-blocked rows (as a real oldest-first LIMIT query against a
+    // large glut would return) and the NEWEST window as containing the newer clear-bucket row (as a real
+    // newest-first LIMIT query would), proving the two windows are queried and merged independently -- a single
+    // bounded oldest-first query would have hidden "clear-newer" from `eligible` entirely.
+    it("REGRESSION: releases a newer clear-bucket row even when the oldest-ordered window is entirely older still-blocked rows", async () => {
+      process.env.FOREGROUND_LIVENESS_MAX_DEFER_MS = "60000";
+      process.env.FOREGROUND_LIVENESS_MAX_RELEASE_PER_SWEEP = "2";
+      const m = makePool();
+      const now = Date.now();
+      m.setRateLimitRows([
+        {
+          admission_key: "installation:111",
+          remaining: 1,
+          reset_at: new Date(now + 30 * 60_000).toISOString(),
+          observed_at: new Date(now).toISOString(),
+        },
+      ]);
+      const payload = (deliveryId: string, installationId: number) =>
+        JSON.stringify({
+          type: "github-webhook",
+          deliveryId,
+          eventName: "x",
+          payload: { installation: { id: installationId } },
+        });
+      m.setForegroundLivenessCandidatesByWindow(
+        // The oldest-ordered window: a large glut of older still-blocked rows (installation 111 is exhausted
+        // above) is ALL a real "ORDER BY created_at ASC LIMIT" query would ever return once the backlog exceeds
+        // the limit -- "clear-newer" never appears here.
+        [
+          { id: "blocked-oldest", created_at: now - 20 * 60_000, payload: payload("blocked-oldest", 111) },
+          { id: "blocked-second", created_at: now - 19 * 60_000, payload: payload("blocked-second", 111) },
+        ],
+        // The newest-ordered window: the fix's whole point -- a real "ORDER BY created_at DESC LIMIT" query
+        // always surfaces the most-recently-enqueued pending rows regardless of how large the older-blocked
+        // backlog is, so "clear-newer" (a different, non-exhausted admission target) is always represented.
+        [{ id: "clear-newer", created_at: now - 5_000, payload: payload("clear-newer", 222) }],
+      );
       const q = createPgQueue(m.pool, async () => undefined);
 
       const released = await q.releaseStaleForegroundDeferrals();

--- a/test/unit/selfhost-pg-queue.test.ts
+++ b/test/unit/selfhost-pg-queue.test.ts
@@ -2205,6 +2205,38 @@ describe("createPgQueue (durable #977)", () => {
       expect(await renderMetrics()).not.toContain("gittensory_jobs_foreground_liveness_released_total");
     });
 
+    it("caches foreground-liveness admission reads for candidates sharing the same rate-limit target", async () => {
+      process.env.FOREGROUND_LIVENESS_MAX_DEFER_MS = "600000";
+      const m = makePool();
+      const now = Date.now();
+      m.setRateLimitRows([
+        {
+          admission_key: "installation:123",
+          remaining: 1,
+          reset_at: new Date(now + 30 * 60_000).toISOString(),
+          observed_at: new Date(now).toISOString(),
+        },
+      ]);
+      const payload = (deliveryId: string) =>
+        JSON.stringify({
+          type: "github-webhook",
+          deliveryId,
+          eventName: "x",
+          payload: { installation: { id: 123 } },
+        });
+      m.setForegroundLivenessCandidates([
+        { id: "fg-fresh-1", created_at: now - 1_000, payload: payload("fg-fresh-1") },
+        { id: "fg-fresh-2", created_at: now - 1_000, payload: payload("fg-fresh-2") },
+      ]);
+      const q = createPgQueue(m.pool, async () => undefined);
+
+      const released = await q.releaseStaleForegroundDeferrals();
+
+      expect(released).toBe(0);
+      const admissionReads = (m.fn as unknown as ReturnType<typeof vi.fn>).mock.calls.filter(([sql]: unknown[]) => String(sql).includes("FROM github_rate_limit_observations"));
+      expect(admissionReads).toHaveLength(1);
+    });
+
     // CONDITION-BASED recovery (the second OR arm): a foreground job whose created_at is nowhere near stale but
     // whose rate-limit observation has since cleared (no blocking observation seeded here) is released anyway --
     // the whole point of pairing the age floor with a rate-limit-aware re-check (see the source's own doc
@@ -2335,6 +2367,10 @@ describe("createPgQueue (durable #977)", () => {
       const released = await q.releaseStaleForegroundDeferrals();
 
       expect(released).toBe(2);
+      expect(m.fn).toHaveBeenCalledWith(
+        expect.stringContaining("LIMIT $3"),
+        expect.arrayContaining([8, 4]),
+      );
       for (const id of ["oldest", "second-oldest"]) {
         expect(m.fn).toHaveBeenCalledWith(
           expect.stringContaining("SET run_after=$1 WHERE id=$2 AND status='pending' AND run_after>$1"),

--- a/test/unit/selfhost-sqlite-queue.test.ts
+++ b/test/unit/selfhost-sqlite-queue.test.ts
@@ -2435,6 +2435,52 @@ describe("createSqliteQueue (durable #980)", () => {
       expect(releasedIds).toEqual(["blocked-oldest", "clear-newer"]);
     });
 
+    // REGRESSION (#selfhost-queue-liveness clear-bucket starvation): the test above only seeds 3 rows, well
+    // under the OLD single-window candidateLimit (maxReleasePerSweep * 2 = 4), so it can't actually distinguish
+    // "the fix" from "the bug" -- a single `ORDER BY created_at ASC LIMIT 4` query would have returned all 3
+    // rows there too. This test seeds MORE older still-blocked rows than that old limit, against a REAL SQLite
+    // engine (not a mock), so the candidate query genuinely truncates. Under the pre-fix single-window query,
+    // "clear-newer" (the single newest pending row) would never even be SELECTed into `eligible` -- proving the
+    // starvation this fix closes, not just describing it.
+    it("REGRESSION: a large glut of older still-blocked rows does not hide a newer clear-bucket row from the candidate window", async () => {
+      process.env.FOREGROUND_LIVENESS_MAX_DEFER_MS = "60000";
+      process.env.FOREGROUND_LIVENESS_MAX_RELEASE_PER_SWEEP = "2"; // old candidateLimit would have been 4
+      const driver = makeDriver();
+      const now = Date.now();
+      seedExhaustedRateLimitObservation(driver, "installation:111", new Date(now + 30 * 60_000).toISOString());
+      const q = createSqliteQueue(driver, async () => undefined);
+      const farFuture = now + 60 * 60_000;
+      // 6 older still-blocked rows -- more than the old single-window candidateLimit of 4, so a naive
+      // "oldest N" window is entirely consumed by these and never reaches the newer row below.
+      for (let i = 0; i < 6; i += 1) {
+        driver.query(
+          `INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at, priority, job_key, is_maintenance)
+           VALUES (?, 'pending', 0, ?, ?, 10, NULL, 0)`,
+          [
+            JSON.stringify({ type: "github-webhook", deliveryId: `blocked-${i}`, eventName: "x", payload: { installation: { id: 111 } } }),
+            farFuture,
+            now - (20 - i) * 60_000, // ages 20m down to 15m, oldest first
+          ],
+        );
+      }
+      // The single newest pending row, on a different (clear) admission target.
+      driver.query(
+        `INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at, priority, job_key, is_maintenance)
+         VALUES (?, 'pending', 0, ?, ?, 10, NULL, 0)`,
+        [JSON.stringify({ type: "github-webhook", deliveryId: "clear-newer", eventName: "x", payload: { installation: { id: 222 } } }), farFuture, now - 1_000],
+      );
+
+      const released = q.releaseStaleForegroundDeferrals();
+
+      const releasedIds = driver.query(`SELECT payload FROM _selfhost_jobs WHERE run_after<?`, [farFuture]).rows.map((row) =>
+        JSON.parse((row as { payload: string }).payload).deliveryId,
+      );
+      expect(released).toBe(2);
+      // clear-newer wins a release slot despite the 6-row older-blocked glut; the remaining slot goes to the
+      // single oldest age-stale row, exactly matching selectForegroundDeferralsToRelease's own ordering.
+      expect(releasedIds.sort()).toEqual(["blocked-0", "clear-newer"]);
+    });
+
     // Mirrors reviveDeadLetterJobsSafely's own regression test: the foreground-liveness interval had no error
     // handler of its own, so a thrown driver/metric failure on that tick would surface as an uncaught exception
     // and could terminate the process -- exactly the failure mode pump()'s own try/catch already guards against

--- a/test/unit/selfhost-sqlite-queue.test.ts
+++ b/test/unit/selfhost-sqlite-queue.test.ts
@@ -2219,6 +2219,39 @@ describe("createSqliteQueue (durable #980)", () => {
       expect(await renderMetrics()).not.toContain("gittensory_jobs_foreground_liveness_released_total");
     });
 
+    it("caches foreground-liveness admission reads for candidates sharing the same rate-limit target", async () => {
+      process.env.FOREGROUND_LIVENESS_MAX_DEFER_MS = "600000";
+      const driver = makeDriver();
+      const now = Date.now();
+      seedExhaustedRateLimitObservation(driver, "installation:123", new Date(now + 30 * 60_000).toISOString());
+      const realQuery = driver.query.bind(driver);
+      const querySpy = vi.spyOn(driver, "query").mockImplementation((sql: string, params: unknown[]) => realQuery(sql, params));
+      const q = createSqliteQueue(driver, async () => undefined);
+      const futureRunAfter = now + 60 * 60_000;
+      for (const deliveryId of ["fg-fresh-1", "fg-fresh-2"]) {
+        driver.query(
+          `INSERT INTO _selfhost_jobs (payload, status, attempts, run_after, created_at, priority, job_key, is_maintenance)
+           VALUES (?, 'pending', 0, ?, ?, 10, NULL, 0)`,
+          [
+            JSON.stringify({
+              type: "github-webhook",
+              deliveryId,
+              eventName: "x",
+              payload: { installation: { id: 123 } },
+            }),
+            futureRunAfter,
+            now - 1_000,
+          ],
+        );
+      }
+
+      const released = q.releaseStaleForegroundDeferrals();
+
+      expect(released).toBe(0);
+      const admissionReads = querySpy.mock.calls.filter(([sql]) => String(sql).includes("FROM github_rate_limit_observations"));
+      expect(admissionReads).toHaveLength(1);
+    });
+
     // CONDITION-BASED recovery (the second OR arm): a foreground job whose created_at is nowhere near stale but
     // whose rate-limit observation has since cleared (no blocking observation at all here) is released anyway --
     // this is the whole point of pairing the age floor with a rate-limit-aware re-check (see the source's own


### PR DESCRIPTION
### Motivation
- The foreground-liveness sweep previously selected every deferred foreground job and rechecked GitHub admission per-row, producing an unbounded N+1 work pattern that can exhaust DB connections and CPU under large deferred backlogs. 
- The change limits per-sweep work and avoids repeated admission queries for candidates that share the same GitHub rate-limit target, preventing attacker-sized backlogs from stalling the queue.

### Description
- Cap candidate selection per sweep by ordering deferred foreground candidates and adding a `LIMIT` (uses `foregroundLivenessConfig.maxReleasePerSweep` to compute a bounded `candidateLimit`) in the Postgres and SQLite backends (`src/selfhost/pg-queue.ts`, `src/selfhost/sqlite-queue.ts`).
- Introduce a per-sweep admission cache keyed by the GitHub admission target so `rateLimitAdmissionDelayMs` is only invoked once per distinct target for that sweep, and thread the cache into the admission helper (`isRateLimitAdmissionNowClear`).
- Keep the existing ramp-up / release cap and selection logic (`selectForegroundDeferralsToRelease`) so behavior is unchanged for small backlogs while large backlogs drain in bounded batches.
- Add regression tests that assert the candidate query is bounded and that admission observations are cached per-sweep for both Postgres and SQLite (`test/unit/selfhost-pg-queue.test.ts`, `test/unit/selfhost-sqlite-queue.test.ts`).

### Testing
- Ran the targeted unit tests for the foreground-liveness sweep with `npx vitest run test/unit/selfhost-pg-queue.test.ts test/unit/selfhost-sqlite-queue.test.ts -t "releaseStaleForegroundDeferrals"`, and the modified tests passed. 
- Ran type checking with `npm run typecheck -- --pretty false`, which passed.
- Attempted a full coverage run `npm run test:coverage`, which exercised many suites; it was started but the long-running unrelated `test/unit/queue.test.ts` activity caused the run to be interrupted/extended and was not used as the final green signal here. 
- Attempted `npm audit --audit-level=moderate`; the registry audit endpoint returned `403 Forbidden` so the local audit step could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a495d5bc984832c96db34471436c596)