### PR TITLE
fix(services): bound PR-write denial cooldown

### DIFF
--- a/src/services/agent-action-executor.ts
+++ b/src/services/agent-action-executor.ts
@@ -87,6 +87,7 @@ export function clearInstallationHealthRefreshCooldownForTest(): void {
 // for one PR must never silently suppress the FIRST denial audit for a different PR in the same repo/window,
 // or that PR's maintainer never sees why it was denied.
 const PR_WRITE_DENIAL_COOLDOWN_MS = 15 * 60 * 1000;
+const PR_WRITE_DENIAL_COOLDOWN_MAX_ENTRIES = 1024;
 const writePermissionDenialCooldown = new Map<string, number>();
 
 function writePermissionDenialKey(installationId: number, repoFullName: string, pullNumber: number, actionClass: AgentActionClass): string {
@@ -99,7 +100,19 @@ function writePermissionDenialKey(installationId: number, repoFullName: string, 
  *  here -- arming the cooldown before that write lands would mean a transient audit DB failure on the first
  *  denial permanently swallows it (the retry within the window would see the cooldown already armed and never
  *  attempt the audit again). */
+function pruneWritePermissionDenialCooldown(nowMs: number): void {
+  for (const [key, lastDeniedMs] of writePermissionDenialCooldown) {
+    if (nowMs - lastDeniedMs >= PR_WRITE_DENIAL_COOLDOWN_MS) writePermissionDenialCooldown.delete(key);
+  }
+}
+
+function evictOldestWritePermissionDenialCooldownEntry(): void {
+  const oldestKey = writePermissionDenialCooldown.keys().next().value as string;
+  writePermissionDenialCooldown.delete(oldestKey);
+}
+
 function shouldSuppressWritePermissionDenial(key: string, nowMs: number): boolean {
+  pruneWritePermissionDenialCooldown(nowMs);
   const lastDeniedMs = writePermissionDenialCooldown.get(key);
   return lastDeniedMs !== undefined && nowMs - lastDeniedMs < PR_WRITE_DENIAL_COOLDOWN_MS;
 }
@@ -108,12 +121,19 @@ function shouldSuppressWritePermissionDenial(key: string, nowMs: number): boolea
  *  exact denial has actually succeeded, so a failed audit write is retried on the very next pass instead of
  *  being silently suppressed for the whole cooldown window. */
 function markWritePermissionDenialAudited(key: string, nowMs: number): void {
+  pruneWritePermissionDenialCooldown(nowMs);
+  if (writePermissionDenialCooldown.size >= PR_WRITE_DENIAL_COOLDOWN_MAX_ENTRIES) evictOldestWritePermissionDenialCooldownEntry();
   writePermissionDenialCooldown.set(key, nowMs);
 }
 
 /** Test-only: clear the module-level write-permission denial cooldown so each test starts fresh. */
 export function clearWritePermissionDenialCooldownForTest(): void {
   writePermissionDenialCooldown.clear();
+}
+
+/** Test-only: inspect the module-level write-permission denial cooldown size. */
+export function writePermissionDenialCooldownSizeForTest(): number {
+  return writePermissionDenialCooldown.size;
 }
 
 export type AgentActionExecutionContext = {
@@ -189,7 +209,7 @@ function coupledCloseOutcome(planned: PlannedAgentAction[], outcomes: AgentActio
  *   API budget) → label/close correlation → freshness → live-CI re-verification → the real mutation.
  * Only `live` mode performs a real mutation; `dry_run` records what it WOULD do. Every path writes one
  * `agent.action.<class>` audit record (#776) EXCEPT a write-permission denial repeated within
- * PR_WRITE_DENIAL_COOLDOWN_MS of the last one for the same installation/repo/action-class, which is counted but
+ * PR_WRITE_DENIAL_COOLDOWN_MS of the last one for the same installation/repo/PR/action-class, which is counted but
  * not re-audited (#selfhost-runtime-drift). A failed mutation is recorded as `error`, never swallowed.
  */
 export async function executeAgentMaintenanceActions(env: Env, ctx: AgentActionExecutionContext, planned: PlannedAgentAction[]): Promise<AgentActionOutcome[]> {

--- a/test/unit/agent-action-executor.test.ts
+++ b/test/unit/agent-action-executor.test.ts
@@ -45,6 +45,7 @@ import {
   actionParams,
   clearInstallationHealthRefreshCooldownForTest,
   clearWritePermissionDenialCooldownForTest,
+  writePermissionDenialCooldownSizeForTest,
   executeAgentMaintenanceActions,
   executeIssueMaintenanceActions,
   pendingActionToPlanned,
@@ -722,6 +723,46 @@ describe("executeAgentMaintenanceActions (#778 gate stack)", () => {
       expect(prA[0]).toMatchObject({ outcome: "denied", detail: "contents: write not granted — maintainer must re-consent" });
       expect(prB[0]).toMatchObject({ outcome: "denied", detail: "contents: write not granted — maintainer must re-consent" });
       expect(await auditCount(env, "merge")).toBe(2); // one audit row per PR, not one shared row
+    });
+
+    it("REGRESSION: prunes expired per-PR denial entries instead of retaining them for the process lifetime", async () => {
+      const env = createTestEnv({});
+      const perms = { pull_requests: "write" as const, contents: "read" as const, issues: "write" as const };
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-07-03T00:00:00Z"));
+      try {
+        await executeAgentMaintenanceActions(env, ctx({ installationId: 206, pullNumber: 601, installationPermissions: perms }), [merge]);
+        await executeAgentMaintenanceActions(env, ctx({ installationId: 206, pullNumber: 602, installationPermissions: perms }), [merge]);
+        expect(writePermissionDenialCooldownSizeForTest()).toBe(2);
+
+        vi.setSystemTime(new Date("2026-07-03T00:16:00Z"));
+        await executeAgentMaintenanceActions(env, ctx({ installationId: 206, pullNumber: 603, installationPermissions: perms }), [merge]);
+
+        expect(writePermissionDenialCooldownSizeForTest()).toBe(1);
+        expect(await auditCount(env, "merge")).toBe(3);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("REGRESSION: caps active denial cooldown entries so unique denied PRs cannot grow memory without bound", async () => {
+      const env = createTestEnv({});
+      const perms = { pull_requests: "write" as const, contents: "read" as const, issues: "write" as const };
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2026-07-03T01:00:00Z"));
+      try {
+        for (let pullNumber = 1; pullNumber <= 1025; pullNumber++) {
+          await executeAgentMaintenanceActions(env, ctx({ installationId: 207, pullNumber, installationPermissions: perms }), [merge]);
+        }
+
+        expect(writePermissionDenialCooldownSizeForTest()).toBe(1024);
+
+        const oldestPrRetry = await executeAgentMaintenanceActions(env, ctx({ installationId: 207, pullNumber: 1, installationPermissions: perms }), [merge]);
+        expect(oldestPrRetry[0]?.detail).toBe("contents: write not granted — maintainer must re-consent");
+        expect(writePermissionDenialCooldownSizeForTest()).toBe(1024);
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 


### PR DESCRIPTION
### Motivation
- A module-level Map storing per-installation/repo/PR/action cooldown entries could grow without bounds because expired keys were never removed and there was no size cap, allowing an attacker to force memory growth by creating many unique denied PRs.

### Description
- Prune expired cooldown entries before reads/writes and add a size cap constant `PR_WRITE_DENIAL_COOLDOWN_MAX_ENTRIES = 1024` to bound active entries in `src/services/agent-action-executor.ts`.
- Evict the oldest cooldown entry when the cap is reached and call `pruneWritePermissionDenialCooldown` from both the suppression check and the arm function so expired keys do not linger.
- Export a test-only accessor `writePermissionDenialCooldownSizeForTest()` and update comments to clarify the cooldown key scope (installation:repo:PR:action-class).
- Add regression unit tests in `test/unit/agent-action-executor.test.ts` that verify expired-entry pruning and the active-entry size cap behavior.

### Testing
- Ran the targeted unit tests: `npx vitest run test/unit/agent-action-executor.test.ts -t "write-permission denial cooldown"` and the full file `npx vitest run test/unit/agent-action-executor.test.ts`, both passed (added regression tests passed).
- Type checking with `npm run typecheck` succeeded.
- Full coverage / CI runs were attempted but blocked: `npm run test:coverage` / coverage enforcement failed due to global repo coverage thresholds (existing large uncovered areas), and `npm run test:ci` was blocked by unrelated generated artifact drift (`apps/gittensory-ui/src/lib/selfhost-env-reference.ts`) and network-dependent `actionlint` setup; `npm audit --audit-level=moderate` failed due to the npm registry audit endpoint returning `403` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a495ccaafb8832c83c359f7a7cf582a)