### PR TITLE
fix(ci): harden observability validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,8 @@ jobs:
           # Full history so Codecov can resolve the merge base for patch coverage.
           fetch-depth: 0
           ref: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+      - name: Neutralize untrusted npm config
+        run: rm -f .npmrc
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -205,7 +207,9 @@ jobs:
         run: npm run cf-typegen:check
       - name: Validate observability configs
         if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.observability == 'true' }}
-        run: npm run selfhost:validate-observability
+        env:
+          NODE_OPTIONS: ""
+        run: node scripts/validate-observability-configs.mjs
       - name: Typecheck
         if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' }}
         run: npm run typecheck

--- a/test/unit/observability-ci.test.ts
+++ b/test/unit/observability-ci.test.ts
@@ -33,6 +33,7 @@ describe("observability config CI guard", () => {
 
     const validateCode = nestedRecord(workflow, ["jobs", "validate-code"]);
     const validateSteps = recordArray(validateCode.steps, "jobs.validate-code.steps");
+    const neutralizeStep = validateSteps.find((step) => step.name === "Neutralize untrusted npm config");
     const validateStep = validateSteps.find((step) => step.name === "Validate observability configs");
 
     expect(outputs.observability).toBe("${{ steps.filter.outputs.observability }}");
@@ -41,10 +42,13 @@ describe("observability config CI guard", () => {
     expect(filters).toContain("observability:");
     expect(filters).toContain("grafana/dashboards/**");
     expect(filters).toContain("prometheus/rules/**");
+    expect(neutralizeStep).toBeDefined();
+    expect(neutralizeStep!.run).toBe("rm -f .npmrc");
     expect(validateStep).toBeDefined();
     expect(String(validateStep!.if)).toBe(
       "${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.observability == 'true' }}",
     );
-    expect(validateStep!.run).toBe("npm run selfhost:validate-observability");
+    expect(record(validateStep!.env, "validateStep.env").NODE_OPTIONS).toBe("");
+    expect(validateStep!.run).toBe("node scripts/validate-observability-configs.mjs");
   });
 });


### PR DESCRIPTION
### Motivation
- Observability-only PRs ran an `npm` script against the full untrusted checkout which allowed a malicious root `.npmrc` to inject `NODE_OPTIONS=--require=...` and preload attacker-controlled code before the validator ran, enabling CI-context code execution and forged validation results.

### Description
- Remove any repo-root `.npmrc` immediately after checkout by adding a `rm -f .npmrc` step so untrusted npm project configuration cannot influence the job. 
- Run the observability validator directly with `node scripts/validate-observability-configs.mjs` and an explicit empty `NODE_OPTIONS` instead of invoking it via `npm run`, preventing npm from propagating project `node-options` into the validator process. 
- Update `test/unit/observability-ci.test.ts` to assert the new `Neutralize untrusted npm config` step and the direct `node` invocation with `NODE_OPTIONS` pinned to an empty string. 
- Preserve the existing path filter behavior and other `validate-code` steps; this change only hardens how the validator is invoked.

### Testing
- Ran `npm run actionlint` which completed successfully. 
- Ran `npx vitest run test/unit/observability-ci.test.ts` which passed. 
- Ran `git diff --check` which passed. 
- Attempted `npm audit --audit-level=moderate` but it failed due to the registry returning `403 Forbidden` in this environment (audit could not be completed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a495cdb0a74832c8be347727dcb6da7)