### PR TITLE
fix(mcp): classify PHP preview tests

### DIFF
--- a/packages/gittensory-mcp/scripts/gittensor-score-preview.mjs
+++ b/packages/gittensory-mcp/scripts/gittensor-score-preview.mjs
@@ -11,9 +11,9 @@ function isTestFile(file) {
     /(^|\/)[^/]+_spec\.rb$/i.test(file) ||
     /\.(test|spec)\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs)$/i.test(file) ||
     /(^|\/)[^/]+\.(cy|e2e)\.(ts|tsx|mts|cts|js|jsx|mjs|cjs)$/i.test(file) ||
-    // JVM/.NET/Swift PascalCase test-class suffix (case-sensitive, matching the
-    // signal classifiers) so C#/Swift/Groovy tests aren't counted as source.
-    /(^|\/)\w*(Tests?|Spec)\.(java|kt|kts|scala|cs|swift|groovy)$/.test(file) ||
+    // JVM/.NET/Swift/PHP PascalCase test-class suffix (case-sensitive, matching the
+    // signal classifiers) so C#/Swift/Groovy/PHP tests aren't counted as source.
+    /(^|\/)\w*(Tests?|Spec)\.(java|kt|kts|scala|cs|swift|groovy|php)$/.test(file) ||
     /(^|\/)__snapshots__\//i.test(file)
   );
 }

--- a/packages/gittensory-mcp/scripts/gittensor-score-preview.py
+++ b/packages/gittensory-mcp/scripts/gittensor-score-preview.py
@@ -22,7 +22,7 @@ _TEST_PATH_RES = (
     re.compile(r"(?:^|/)[^/]+_spec\.rb$", re.IGNORECASE),  # RSpec *_spec.rb suffix
     re.compile(r"\.(?:test|spec)\.(?:ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs)$", re.IGNORECASE),  # .test/.spec.<ext>
     re.compile(r"(?:^|/)[^/]+\.(?:cy|e2e)\.(?:ts|tsx|mts|cts|js|jsx|mjs|cjs)$", re.IGNORECASE),  # Cypress/Playwright
-    re.compile(r"(?:^|/)\w*(?:Tests?|Spec)\.(?:java|kt|kts|scala|cs|swift|groovy)$"),  # JVM/.NET/Swift (case-sensitive)
+    re.compile(r"(?:^|/)\w*(?:Tests?|Spec)\.(?:java|kt|kts|scala|cs|swift|groovy|php)$"),  # JVM/.NET/Swift/PHP (case-sensitive)
 )
 
 

--- a/test/unit/score-preview-script.test.ts
+++ b/test/unit/score-preview-script.test.ts
@@ -132,6 +132,31 @@ describe("gittensor-score-preview.mjs classifier parity with the server", () => 
     expect(py.nonCodeTokenScore).toBe(3);
   });
 
+  it("classifies PascalCase PHP test files as tests in both .mjs and .py previews", () => {
+    // Parity with src/signals/test-evidence.ts: PHPUnit/PHPSpec class-suffix files must not be counted as
+    // PHP source simply because they live outside a conventional tests/ directory.
+    const files = [
+      { path: "app/Domain/FooTest.php", additions: 8, deletions: 0 },
+      { path: "app/Domain/FooSpec.php", additions: 5, deletions: 0 },
+      { path: "app/Domain/Latest.php", additions: 3, deletions: 0 }, // source control: suffix is not a test token
+    ];
+    const mjs = runPreview(files);
+    expect(mjs.testTokenScore).toBe(13);
+    expect(mjs.sourceTokenScore).toBe(3);
+    expect(mjs.nonCodeTokenScore).toBe(0);
+
+    const python = findPython();
+    if (!python) return;
+    const env = { ...process.env };
+    delete env.GITTENSOR_ROOT;
+    const res = spawnSync(python, [scriptPy], { input: JSON.stringify({ changedFiles: files }), encoding: "utf8", env });
+    expect(res.status, res.stderr).toBe(0);
+    const py = JSON.parse(res.stdout);
+    expect(py.testTokenScore).toBe(13);
+    expect(py.sourceTokenScore).toBe(3);
+    expect(py.nonCodeTokenScore).toBe(0);
+  });
+
   it("does not misclassify a *.test.mjs.map source-map as a test (extension anchored to end-of-path, matching the server)", () => {
     // A substring match on ".test.mjs" wrongly flagged non-tests like dist/widget.test.mjs.map; the rule must be
     // end-anchored like isTestPath. It's a source-map — neither test nor code — so it counts as non-code.


### PR DESCRIPTION
### Motivation

- The standalone score-preview scripts misclassified PascalCase PHP test-class files (e.g. `FooTest.php`) as source because their PascalCase test-file regex omitted `php` while the source-extension check included it.
- This created parity drift with the canonical server matcher and produced incorrect local preview source/test metrics for PHP projects.

### Description

- Add `php` to the PascalCase test-class suffix regex in the Node preview script at `packages/gittensory-mcp/scripts/gittensor-score-preview.mjs` so `FooTest.php`/`FooSpec.php` match as tests instead of falling through to source classification.  
- Mirror the same PascalCase `php` addition in the Python fallback classifier at `packages/gittensory-mcp/scripts/gittensor-score-preview.py` so both previews remain consistent with the server-side matcher.  
- Add a regression unit test `test/unit/score-preview-script.test.ts` that asserts both preview scripts classify PascalCase PHP test files as tests while preserving a non-test PHP control file.

### Testing

- Ran the targeted unit suite with `npx vitest run test/unit/score-preview-script.test.ts` and all tests passed.  
- Performed syntax checks with `node --check packages/gittensory-mcp/scripts/gittensor-score-preview.mjs` and `python3 -m py_compile packages/gittensory-mcp/scripts/gittensor-score-preview.py`, both of which succeeded.  
- Built the MCP package with `npm run build:mcp`, which completed the script checks used during the build.  
- Attempted the full local gate via `npm run test:ci`, but it stopped early due to a pre-existing generated-file drift reported by `selfhost:env-reference:check`, and `npm audit --audit-level=moderate` returned a registry `403 Forbidden` during the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a495ccfe3a4832cb4dfe913264dd09b)