### PR TITLE
fix(review): make resolved CI context cache key unambiguous

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -543,7 +543,7 @@ function expectedCiContextsKeyPart(expectedCiContexts: ReadonlyArray<string> | n
 // on the unchanged config would keep serving an aggregate computed against the old required-context set.
 function resolvedRequiredContextsKeyPart(requiredContexts: ReadonlySet<string> | null | undefined): string {
   if (!requiredContexts || requiredContexts.size === 0) return "";
-  return [...requiredContexts].sort().join(" ");
+  return JSON.stringify([...requiredContexts].sort());
 }
 
 // RC2 + #selfhost-ci-verification: the EFFECTIVE required-status-check contexts for this repo/baseRef, merging

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -2228,6 +2228,51 @@ describe("queue processors", () => {
     expect(rowAfterPass2?.ciState).toBe("pending");
   });
 
+  it("REGRESSION (#selfhost-ci-verification): the durable CI-state cache key does not collide for required context names containing spaces", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: { pull_requests: "write", checks: "write" }, events: [] } });
+    await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", gateCheckMode: "enabled", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Spaced context drift", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, base: { ref: "main" }, labels: [], body: "Closes #1" });
+    await upsertRepoFocusManifest(env, "owner/agent-repo", { gate: { expectedCiContexts: ["lint"] } });
+    let requiredContextsFromBranchProtection: Array<string | null> = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (/\/pulls\/7(?:\?|$)/.test(url) && method === "GET") return Response.json({ number: 7, title: "Spaced context drift", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, mergeable_state: "clean", labels: [], body: "Closes #1" });
+      if (url.includes("/pulls/7/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+export const ok = true;" }]);
+      if (url.includes("/commits/a7/check-runs")) {
+        return Response.json({
+          total_count: 3,
+          check_runs: [
+            { name: "lint", status: "completed", conclusion: "success", app: { slug: "github-actions" } },
+            { name: "a b", status: "completed", conclusion: "success", app: { slug: "github-actions" } },
+            { name: "c", status: "completed", conclusion: "success", app: { slug: "github-actions" } },
+          ],
+        });
+      }
+      if (url.includes("/commits/a7/status")) return Response.json({ state: "success", statuses: [] });
+      if (url.includes("/issues/1")) return Response.json({ number: 1, title: "Issue", state: "open", labels: [], user: { login: "reporter" } });
+      if (url.includes("/branches/")) return Response.json({ contexts: requiredContextsFromBranchProtection });
+      return Response.json({});
+    });
+
+    requiredContextsFromBranchProtection = ["a b", "c"];
+    await processJob(env, { type: "agent-regate-pr", deliveryId: "spaced-contexts-before", repoFullName: "owner/agent-repo", prNumber: 7, installationId: 9001 });
+    const rowAfterPass1 = await getPullRequestDetailSyncState(env, "owner/agent-repo", 7);
+    expect(rowAfterPass1?.ciState).toBe("passed");
+    const keyAfterPass1 = rowAfterPass1?.ciRequiredContextsKey ?? null;
+
+    requiredContextsFromBranchProtection = ["a", "b c"];
+    await processJob(env, { type: "agent-regate-pr", deliveryId: "spaced-contexts-after", repoFullName: "owner/agent-repo", prNumber: 7, installationId: 9001 });
+    const rowAfterPass2 = await getPullRequestDetailSyncState(env, "owner/agent-repo", 7);
+    const keyAfterPass2 = rowAfterPass2?.ciRequiredContextsKey ?? null;
+
+    expect(keyAfterPass2).not.toBe(keyAfterPass1);
+    expect(rowAfterPass2?.ciState).toBe("pending");
+  });
+
   it("#sweep-resync: a failing resync upsert is swallowed (fail-open) — the sweep never throws", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });


### PR DESCRIPTION
### Motivation
- The durable CI-state cache key previously serialized the resolved required-contexts set with `join(" ")`, which collides when context names contain spaces and can cause stale CI aggregates to be treated as fresh.

### Description
- Replace the ambiguous space-delimited serializer with `JSON.stringify([...requiredContexts].sort())` in `resolvedRequiredContextsKeyPart` so keys are unambiguous regardless of spaces in context names (`src/queue/processors.ts`).
- Add a regression unit test that reproduces the collision case (`["a b","c"]` vs `["a","b c"]`) and asserts the durable cache no longer collides and the second pass produces a miss and correct pending state (`test/unit/queue.test.ts`).

### Testing
- Ran the targeted test suite with `npx vitest run test/unit/queue.test.ts -t "durable CI-state cache key"`, and the new regression plus related durable-cache CI-state tests passed.
- Attempted full gate with `npm run test:ci`, but unrelated `test/unit/backfill.test.ts` cases timed out during coverage; those timeouts are not caused by this change and were reproducible when re-running the same backfill tests locally.
- `npm audit --audit-level=moderate` could not complete in this environment due to the npm registry audit endpoint returning `403 Forbidden`, so the audit step was not verified here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a495dfa3510832cb9fe147b9561c8f3)