### PR TITLE
feat(enrichment): flag more TLS/certificate-verification bypass forms in iac-misconfig

### DIFF
--- a/review-enrichment/src/analyzers/iac-misconfig.ts
+++ b/review-enrichment/src/analyzers/iac-misconfig.ts
@@ -73,6 +73,18 @@ const HARDCODED_BUILD_SECRET_RE =
 // A package installer pointed at a plaintext-HTTP index (dependency-download MITM).
 const INSECURE_PIP_INDEX_RE = /--(?:extra-)?index-url[=\s]+http:\/\//i;
 
+// TLS / certificate-verification bypass across ecosystems. In every case the MATCHED VALUE is the bypass
+// action itself (disabling verification / trusting any certificate), so there is no "safe value" form of the
+// same line — the secure setting uses a different value the regex never matches. Complements the existing
+// `tls-verification-disabled` rule with database-, Go-, Git-, SSH-, PHP-, .NET-, and Kubernetes-specific forms.
+const DB_SSL_DISABLED_RE = /\bssl[_-]?mode\s*[=:]\s*["']?(?:disable|disabled|none)\b/i;
+const GIT_SSL_NO_VERIFY_RE = /\bGIT_SSL_NO_VERIFY\b[\s"'=:,-]*["']?(?:1|true|yes)\b/i;
+const SSH_HOST_KEY_OFF_RE = /\bStrictHostKeyChecking\b[\s"'=:,-]*["']?(?:no|false)\b/i;
+const VERIFY_SSL_OFF_RE = /\bverify[_-]?(?:ssl|certs?|certificate)\b[\s"'=:,-]*["']?(?:false|no|0)\b/i;
+const VALIDATE_CERTS_OFF_RE = /\bvalidate_certs\b[\s"'=:,-]*["']?(?:no|false)\b/i;
+const TLS_SKIP_VERIFY_RE = /\b(?:tls_skip_verify|insecure_skip_verify)\b[\s"'=:,-]*true\b/i;
+const TRUST_ALL_CERTS_RE = /\bTrustServerCertificate\s*=\s*["']?true\b/i;
+
 function* patchLines(patch: string): Generator<string> {
   let start = 0;
   for (let i = 0; i <= patch.length; i++) {
@@ -396,6 +408,48 @@ export function scanPatchForIacMisconfig(
     if (
       INSECURE_PIP_INDEX_RE.test(body) &&
       pushFinding(findings, seen, path, newLine, "insecure-pip-index", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      DB_SSL_DISABLED_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "db-ssl-disabled", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      GIT_SSL_NO_VERIFY_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "git-ssl-no-verify", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      SSH_HOST_KEY_OFF_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "ssh-host-key-check-off", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      VERIFY_SSL_OFF_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "verify-ssl-off", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      VALIDATE_CERTS_OFF_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "validate-certs-off", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      TLS_SKIP_VERIFY_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "tls-skip-verify", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      TRUST_ALL_CERTS_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "trust-all-server-certs", maxFindings)
     ) {
       return findings;
     }

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -325,6 +325,20 @@ export function renderBrief(
           return "hardcodes a credential-shaped value into an image layer via `ENV`/`ARG`; build secrets persist in the image history";
         case "insecure-pip-index":
           return "points a package installer at a plaintext-HTTP index; dependency downloads can be intercepted";
+        case "db-ssl-disabled":
+          return "disables TLS on the database connection (`sslmode=disable`); traffic and credentials travel in plaintext";
+        case "git-ssl-no-verify":
+          return "sets `GIT_SSL_NO_VERIFY`, so Git skips TLS certificate verification for remote operations";
+        case "ssh-host-key-check-off":
+          return "sets `StrictHostKeyChecking no`, so SSH accepts an unknown host key and permits man-in-the-middle";
+        case "verify-ssl-off":
+          return "disables TLS certificate verification (`verify_ssl: false`); this permits man-in-the-middle interception";
+        case "validate-certs-off":
+          return "sets `validate_certs: no`, so the client accepts any TLS certificate (Ansible/HTTP module)";
+        case "tls-skip-verify":
+          return "sets `tls_skip_verify`/`insecure_skip_verify: true`, so TLS certificate verification is skipped";
+        case "trust-all-server-certs":
+          return "sets `TrustServerCertificate=true`, so the client trusts any database server certificate";
       }
     };
 

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -243,7 +243,14 @@ export interface IacMisconfigFinding {
     | "npm-unsafe-perm"
     | "sudo-in-build"
     | "hardcoded-build-secret"
-    | "insecure-pip-index";
+    | "insecure-pip-index"
+    | "db-ssl-disabled"
+    | "git-ssl-no-verify"
+    | "ssh-host-key-check-off"
+    | "verify-ssl-off"
+    | "validate-certs-off"
+    | "tls-skip-verify"
+    | "trust-all-server-certs";
 }
 
 /** A newly-added dependency whose install compiles native code (npm node-gyp addon) or has no prebuilt wheel

--- a/review-enrichment/test/iac-misconfig.test.ts
+++ b/review-enrichment/test/iac-misconfig.test.ts
@@ -352,3 +352,47 @@ test("scanPatchForIacMisconfig does not flag the safe counterpart of each Docker
     );
   }
 });
+
+test("scanPatchForIacMisconfig flags TLS/certificate-verification bypass across ecosystems", () => {
+  // In each case the matched VALUE is the bypass action itself, so there is no safe-value form of the line.
+  const cases = [
+    ["+DATABASE_URL=postgres://u:p@h/db?sslmode=disable", "db-ssl-disabled"],
+    ["+  GIT_SSL_NO_VERIFY: true", "git-ssl-no-verify"],
+    ["+  StrictHostKeyChecking no", "ssh-host-key-check-off"],
+    ["+  verify_ssl: false", "verify-ssl-off"],
+    ["+  validate_certs: no", "validate-certs-off"],
+    ["+  insecure_skip_verify = true", "tls-skip-verify"],
+    ["+  ConnectionString: Server=db;TrustServerCertificate=true", "trust-all-server-certs"],
+  ];
+  for (const [added, kind] of cases) {
+    const findings = scanPatchForIacMisconfig(
+      "config.yaml",
+      ["@@ -1,0 +1,1 @@", added].join("\n"),
+    );
+    assert.deepEqual(
+      findings,
+      [{ file: "config.yaml", line: 1, kind }],
+      `${kind}: expected exactly one finding of that kind, got ${JSON.stringify(findings)}`,
+    );
+  }
+});
+
+test("scanPatchForIacMisconfig does not flag the secure counterpart of each TLS-bypass setting", () => {
+  // The secure value uses a different token the regex never matches (verification stays ON).
+  const safe = [
+    "+DATABASE_URL=postgres://u:p@h/db?sslmode=require",
+    "+  GIT_SSL_NO_VERIFY: false",
+    "+  StrictHostKeyChecking yes",
+    "+  verify_ssl: true",
+    "+  validate_certs: yes",
+    "+  insecure_skip_verify = false",
+    "+  ConnectionString: Server=db;TrustServerCertificate=false",
+  ];
+  for (const added of safe) {
+    assert.deepEqual(
+      scanPatchForIacMisconfig("config.yaml", ["@@ -1,0 +1,1 @@", added].join("\n")),
+      [],
+      `should not flag: ${added.trim()}`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

The IaC-misconfig analyzer already flags a few TLS-verification-disabled forms (`rejectUnauthorized: false`,
`NODE_TLS_REJECT_UNAUTHORIZED=0`, `insecureSkipTLSVerify`, `verify=False`, …). This extends that coverage with
**7 more TLS / certificate-verification bypass forms** that appear in the config files the analyzer already
scans (`.env`, YAML, Terraform/HCL, JSON, `.conf`, Dockerfile), across databases, Git, SSH, Ansible, Terraform,
and .NET clients:

| kind | fires on | ecosystem |
|---|---|---|
| `db-ssl-disabled` | `sslmode=disable` / `ssl-mode=DISABLED` | Postgres/MySQL connection string |
| `git-ssl-no-verify` | `GIT_SSL_NO_VERIFY=1` | Git env var |
| `ssh-host-key-check-off` | `StrictHostKeyChecking no` | SSH client config |
| `verify-ssl-off` | `verify_ssl: false` / `verify_certs: false` | generic client config |
| `validate-certs-off` | `validate_certs: no` | Ansible HTTP modules |
| `tls-skip-verify` | `insecure_skip_verify = true` / `tls_skip_verify` | Terraform/Consul/Vault |
| `trust-all-server-certs` | `TrustServerCertificate=true` | .NET/SQL Server connection string |

> Supersedes the closed #3226, which additionally proposed a `--insecure-skip-tls-verify` flag rule. That
> review correctly noted the bare-flag form also matched the safe `--insecure-skip-tls-verify=false`; because
> the value-less flag form overlaps the analyzer's existing `verify=False` matcher too, that rule is dropped
> here rather than special-cased. The 7 rules below all key on an explicit insecure *value*.

**Why these are false-positive-safe:** in every rule the *matched value is the bypass action itself* —
disabling verification or trusting any certificate. There is no "safe value" form of the same line: the secure
setting uses a *different* value the regex never matches (`sslmode=require`, `validate_certs: yes`,
`insecure_skip_verify = false`, `TrustServerCertificate=false`, `StrictHostKeyChecking yes`, …). The negative
test asserts each of those secure counterparts produces no finding. Each token is also ecosystem-specific
(`sslmode`, `GIT_SSL_NO_VERIFY`, `StrictHostKeyChecking`, `TrustServerCertificate`,
…), so there is no cross-context match — and each pattern occurs in the config-file types this analyzer scans,
not only in application source, so the rules are reachable in production.

No existing rule is modified, and the analyzer's finding schema is `{file, line, kind}` — the `kind` union is
not part of the analyzer descriptor, so `analyzer-metadata.json` and the generated UI mirror are **unchanged**.
The render-brief switch is TypeScript-exhaustive, so each new kind is compiler-forced to have a public-safe
explanation.

No linked issue: additive detection-coverage that extends an existing analyzer along its own established lines
(it already detects disabled TLS verification); each rule is a self-evident, named verification-bypass with no
public API/schema/deploy surface change — fits the repo's `preferred` (not required) linked-issue policy.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run typecheck`
- [x] `npm run rees:test` — the review-enrichment build + analyzer suite (see note below)
- [ ] `npm run test:coverage` (N/A — this analyzer is in `review-enrichment/`, outside the root `src/**` Codecov scope)
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran locally: `git diff --check` (clean), the review-enrichment TypeScript build (exit 0 — which proves the
  render switch is exhaustive over the 7 new kinds), and the analyzer suite via `node --test`. The
  iac-misconfig file passes 17/17: a table test asserting each of the 7 bypass forms produces exactly one
  finding of its own kind, and a negative test asserting the secure counterpart of each produces none. The
  full `node --test` run's only failures are the two `upload-sourcemaps` tests (they shell out to the Sentry
  CLI, absent on this dev box), which fail identically on unmodified `main`.
- Not run locally: the UI, root typecheck, and the `metadata:check` step of `rees:test`. This change adds only
  finding kinds and rules, not any analyzer descriptor field, so the committed `analyzer-metadata.json` / UI
  mirror are unchanged (a local regeneration produces a zero-content diff) and `metadata:check` passes on CI
  (Linux). On this Windows dev box `metadata:check` reports a spurious line-ending difference; it fails
  identically on unmodified `main`. `analyzer-metadata.json` was NOT modified.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Detection-only additions: 7 new stateless rules following the existing single-line pattern; no existing rule,
  threshold, or descriptor changed, so current findings and `analyzer-metadata.json` are unaffected. Each new
  kind reports only `file:line` + the public-safe kind, never the matched line content.
- These complement, and do not overlap, the existing `tls-verification-disabled` rule — they key on different,
  ecosystem-specific tokens (database DSNs, Git/SSH/Ansible/Terraform/.NET) that it does not cover.
