### PR TITLE
feat(enrichment): add overly-broad dependency version-range analyzer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,20 +67,22 @@ GITTENSORY_REVIEW_ENRICHMENT=false
 # provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild
 # history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity,ciCheckSignals
 # undocumentedExport,staleBranch,commitHygiene,pendingReviewRequests,testRatio,migrationSafety
+# looseRange
 #
 # Profile defaults:
 # fast: dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol
 # redos,provenance,secretLog,typosquat,iacMisconfig,nativeBuild,testRatio,migrationSafety
+# looseRange
 # balanced (default): dependency,lockfileDrift,secret,license,installScript,heavyDependency
 # actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature
 # iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink
 # approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene
-# pendingReviewRequests,testRatio,migrationSafety
+# pendingReviewRequests,testRatio,migrationSafety,looseRange
 # deep: dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol
 # redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig
 # nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity
 # ciCheckSignals,undocumentedExport,staleBranch,commitHygiene,pendingReviewRequests,testRatio
-# migrationSafety
+# migrationSafety,looseRange
 # END GENERATED REES ANALYZERS
 
 # Submitter-reputation spend control (internal-only): downgrades new/burst/low-rep

--- a/apps/gittensory-ui/src/lib/rees-analyzers.ts
+++ b/apps/gittensory-ui/src/lib/rees-analyzers.ts
@@ -773,6 +773,28 @@ export const REES_ANALYZERS = [
         "Detection is line-anchored single-statement shapes only; statements split across lines are skipped rather than tracked with cross-line state.",
     },
   },
+  {
+    name: "looseRange",
+    title: "Loose dependency version range",
+    category: "supply-chain",
+    cost: "local",
+    defaultEnabled: true,
+    profiles: ["fast", "balanced", "deep"],
+    requires: ["files"],
+    limits: {
+      maxFindings: 20,
+      maxLineChars: 2000,
+    },
+    docs: {
+      summary:
+        "Flags newly-added npm dependency specifiers that use dangerously loose ranges instead of a pinned/caret/tilde range.",
+      looksAt: "Added specifier lines in package.json patches.",
+      reports: "Manifest file, line, package, raw specifier, and loose-range kind.",
+      network: "Pure local analyzer. No external network call.",
+      notes:
+        "Judges only the version specifier, never the package; wildcard, latest, unbounded >=, and bare-major ranges let any future publish flow into the next install.",
+    },
+  },
 ] as const satisfies readonly ReesAnalyzerDoc[];
 
 export const REES_ANALYZER_NAMES = REES_ANALYZERS.map((analyzer) => analyzer.name);

--- a/review-enrichment/analyzer-metadata.json
+++ b/review-enrichment/analyzer-metadata.json
@@ -868,6 +868,32 @@
         "network": "Pure local analyzer. No external network call.",
         "notes": "Detection is line-anchored single-statement shapes only; statements split across lines are skipped rather than tracked with cross-line state."
       }
+    },
+    {
+      "name": "looseRange",
+      "title": "Loose dependency version range",
+      "category": "supply-chain",
+      "cost": "local",
+      "defaultEnabled": true,
+      "profiles": [
+        "fast",
+        "balanced",
+        "deep"
+      ],
+      "requires": [
+        "files"
+      ],
+      "limits": {
+        "maxFindings": 20,
+        "maxLineChars": 2000
+      },
+      "docs": {
+        "summary": "Flags newly-added npm dependency specifiers that use dangerously loose ranges instead of a pinned/caret/tilde range.",
+        "looksAt": "Added specifier lines in package.json patches.",
+        "reports": "Manifest file, line, package, raw specifier, and loose-range kind.",
+        "network": "Pure local analyzer. No external network call.",
+        "notes": "Judges only the version specifier, never the package; wildcard, latest, unbounded >=, and bare-major ranges let any future publish flow into the next install."
+      }
     }
   ]
 }

--- a/review-enrichment/src/analyzers/loose-range.ts
+++ b/review-enrichment/src/analyzers/loose-range.ts
@@ -1,0 +1,199 @@
+// Overly-broad dependency version-range analyzer (#2036). Flags newly-added/changed npm dependency specifiers
+// that use dangerously loose ranges — `*`/`x` wildcards, the `latest` dist-tag, unbounded `>=`/`>` ranges, and
+// bare-major ranges (`18`, `18.x`) — instead of a pinned/caret/tilde range. A loose range lets any future
+// publish (including a compromised one) flow into the next install: a reproducibility and supply-chain drift
+// risk. Distinct from the vuln/typosquat analyzers: this judges only the SPECIFIER, never the package. Pure
+// compute over added package.json patch lines, no registry call. Like the sibling dependency-scan.ts, parsing
+// is a line-based heuristic (not a full manifest parse) — good enough to classify the specifiers a PR adds
+// without resolving the whole tree.
+import type { EnrichRequest, LooseRangeFinding } from "../types.js";
+import { isDiffFileHeaderLine } from "./diff-lines.js";
+
+const MAX_FINDINGS = 20;
+const MAX_LINE_CHARS = 2000;
+
+// `"name": "spec"` on an added line, same shape the sibling dependency-scan.ts keys on.
+const NPM_LINE_RE = /^"([^"]+)"\s*:\s*"([^"]+)"/;
+// An `npm:pkg@range` alias — classify the range part, exactly as dependency-scan.ts unwraps it.
+const NPM_ALIAS_RE = /^npm:(?:@[^/]+\/[^@]+|[^@]+)@(.+)$/;
+
+// A `"section": {` object header — the lightweight per-hunk section state that decides whether a
+// `"name": "spec"` line is a dependency entry at all.
+const SECTION_HEADER_RE = /^"([^"]+)"\s*:\s*\{/;
+// The manifest blocks whose entries ARE dependency specifiers. Inside these, every entry is classified with
+// no suppression — a real dependency named `npm` or `node` is still a dependency.
+const DEPENDENCY_SECTIONS = new Set([
+  "dependencies",
+  "devDependencies",
+  "peerDependencies",
+  "optionalDependencies",
+]);
+// Fallback for hunks where no section header is visible (a diff that starts mid-block): keys whose values
+// LOOK like ranges but are usually not dependency specifiers — the manifest's own `version`, engine
+// constraints (`"node": ">=18"` in engines is legitimate and extremely common), and publishConfig's
+// dist-tag. Only consulted when the enclosing section is UNKNOWN; when the section is visible, membership
+// in DEPENDENCY_SECTIONS decides instead, so `"dependencies": { "npm": "*" }` is still flagged.
+const NON_DEPENDENCY_KEYS = new Set([
+  "version",
+  "node",
+  "npm",
+  "yarn",
+  "pnpm",
+  "bun",
+  "vscode",
+  "tag",
+  "access",
+]);
+
+const UNBOUNDED_GTE_RE = /^>=?\s*\d/;
+const UPPER_BOUND_RE = /<\s*=?\s*\d/;
+const BARE_MAJOR_RE = /^\d+(?:\.[xX*])?(?:\.[xX*])?$/;
+
+/** Classify one raw npm version specifier; null when the range is not one of the loose kinds. Pure. */
+export function classifyRange(spec: string): LooseRangeFinding["kind"] | null {
+  const alias = NPM_ALIAS_RE.exec(spec);
+  const range = (alias ? alias[1]! : spec).trim();
+  if (range === "*" || range === "x" || range === "X") return "wildcard";
+  if (range === "latest") return "latest";
+  if (UNBOUNDED_GTE_RE.test(range) && !UPPER_BOUND_RE.test(range)) {
+    return "unbounded-gte";
+  }
+  if (BARE_MAJOR_RE.test(range)) return "bare";
+  return null;
+}
+
+function* patchLines(patch: string): Generator<string> {
+  let start = 0;
+  for (let i = 0; i <= patch.length; i++) {
+    if (i === patch.length || patch[i] === "\n") {
+      yield patch.slice(start, i);
+      start = i + 1;
+    }
+  }
+}
+
+type ScanLimits = {
+  maxFindings?: number;
+  signal?: AbortSignal;
+};
+
+/** Scan one package.json patch for loose specifiers on ADDED lines. Pure. */
+export function scanPatchForLooseRanges(
+  path: string,
+  patch: string,
+  limits: ScanLimits = {},
+): LooseRangeFinding[] {
+  const maxFindings = limits.maxFindings ?? MAX_FINDINGS;
+  if (maxFindings <= 0) return [];
+
+  const findings: LooseRangeFinding[] = [];
+  let newLine = 0;
+  let inHunk = false;
+  // The enclosing manifest section, tracked from added AND context lines (both describe the new file).
+  // null = unknown (top level, or a hunk that starts mid-block without its section header in view).
+  let section: string | null = null;
+
+  for (const line of patchLines(patch)) {
+    if (limits.signal?.aborted) throw new Error("analyzer_aborted");
+    const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
+    if (hunk) {
+      newLine = Number(hunk[1]);
+      inHunk = true;
+      // Hunks can jump anywhere in the file — section state from a previous hunk must never leak into
+      // the next one, or a hunk starting inside engines could inherit a stale "dependencies" state.
+      section = null;
+      continue;
+    }
+    // Skip pre-hunk preamble; inside a hunk `+++x`/`+++ x` is added content, not a header.
+    if (!inHunk) continue;
+
+    const isAddedContent = line.startsWith("+") && !isDiffFileHeaderLine(line);
+    const isContext =
+      !line.startsWith("+") && !line.startsWith("-") && !line.startsWith("\\");
+
+    if (isContext) {
+      const trimmed = line.slice(1).trim();
+      const header = SECTION_HEADER_RE.exec(trimmed);
+      if (header) section = header[1]!;
+      else if (trimmed.startsWith("}")) section = null;
+      newLine++;
+      continue;
+    }
+    if (!isAddedContent) {
+      // A `\ No newline at end of file` marker and a removed line are not new-file content lines, so they
+      // must not advance the new-file line counter — mirrors the sibling analyzers (e.g. iac-misconfig.ts).
+      // Removed lines describe the OLD file only, so they never touch section state either.
+      if (!line.startsWith("-") && !line.startsWith("\\")) newLine++;
+      continue;
+    }
+
+    const body = line.slice(1);
+    if (body.length > MAX_LINE_CHARS) {
+      newLine++;
+      continue;
+    }
+
+    const trimmed = body.trim();
+    const header = SECTION_HEADER_RE.exec(trimmed);
+    if (header) {
+      section = header[1]!;
+      newLine++;
+      continue;
+    }
+    if (trimmed.startsWith("}")) {
+      section = null;
+      newLine++;
+      continue;
+    }
+
+    const match = NPM_LINE_RE.exec(trimmed);
+    if (match) {
+      // Section-aware suppression: inside a known dependency block, EVERY entry is a dependency (a package
+      // really named `npm` or `node` included). Inside any other known block (engines, publishConfig,
+      // scripts, …) nothing is a dependency. Only when the section is unknown does the key-name fallback
+      // heuristic apply.
+      const suppressed =
+        section !== null
+          ? !DEPENDENCY_SECTIONS.has(section)
+          : NON_DEPENDENCY_KEYS.has(match[1]!);
+      if (!suppressed) {
+        const kind = classifyRange(match[2]!);
+        if (kind) {
+          findings.push({
+            file: path,
+            line: newLine,
+            package: match[1]!,
+            range: match[2]!,
+            kind,
+          });
+          if (findings.length >= maxFindings) return findings;
+        }
+      }
+    }
+
+    newLine++;
+  }
+
+  return findings;
+}
+
+/** Analyzer entrypoint: added package.json specifier lines → loose-range findings. No network. */
+export async function scanLooseRanges(
+  req: EnrichRequest,
+  signal?: AbortSignal,
+): Promise<LooseRangeFinding[]> {
+  const findings: LooseRangeFinding[] = [];
+  for (const file of req.files ?? []) {
+    if (signal?.aborted) throw new Error("analyzer_aborted");
+    const basename = file.path.split("/").pop() ?? file.path;
+    if (!file.patch || basename !== "package.json") continue;
+    for (const finding of scanPatchForLooseRanges(file.path, file.patch, {
+      maxFindings: MAX_FINDINGS - findings.length,
+      signal,
+    })) {
+      findings.push(finding);
+      if (findings.length >= MAX_FINDINGS) return findings;
+    }
+  }
+  return findings;
+}

--- a/review-enrichment/src/analyzers/registry.ts
+++ b/review-enrichment/src/analyzers/registry.ts
@@ -26,6 +26,7 @@ import { scanSecretLog } from "./secret-log.js";
 import { scanStaleBranch } from "./stale-branch.js";
 import { scanTestRatio } from "./test-ratio.js";
 import { scanMigrationSafety } from "./migration-safety.js";
+import { scanLooseRanges } from "./loose-range.js";
 import { scanTyposquat } from "./typosquat.js";
 import { scanUndocumentedExport } from "./undocumented-export.js";
 import type {
@@ -750,6 +751,47 @@ export const ANALYZER_DESCRIPTORS = [
       return lines;
     },
     run: (req, { signal }) => scanMigrationSafety(req, signal),
+  }),
+  descriptor({
+    name: "looseRange",
+    title: "Loose dependency version range",
+    category: "supply-chain",
+    cost: "local",
+    defaultEnabled: true,
+    requires: ["files"],
+    limits: { maxFindings: 20, maxLineChars: 2000 },
+    docs: {
+      summary:
+        "Flags newly-added npm dependency specifiers that use dangerously loose ranges instead of a pinned/caret/tilde range.",
+      looksAt: "Added specifier lines in package.json patches.",
+      reports: "Manifest file, line, package, raw specifier, and loose-range kind.",
+      network: "Pure local analyzer. No external network call.",
+      notes:
+        "Judges only the version specifier, never the package; wildcard, latest, unbounded >=, and bare-major ranges let any future publish flow into the next install.",
+    },
+    render: (findings, helpers) => {
+      if (!findings.length) return [];
+      const explain = (kind: (typeof findings)[number]["kind"]): string => {
+        switch (kind) {
+          case "wildcard":
+            return "a wildcard range accepts ANY published version, including a compromised one";
+          case "latest":
+            return "the `latest` dist-tag floats to whatever is published next; installs are not reproducible";
+          case "unbounded-gte":
+            return "an unbounded `>=` range accepts every future major version, breaking changes included";
+          case "bare":
+            return "a bare-major range floats across every future minor/patch of the major line";
+        }
+      };
+      const lines = ["### Loose dependency version ranges (supply-chain drift risk)"];
+      for (const item of findings) {
+        lines.push(
+          `- ${helpers.safeCodeSpan(`${item.package}@"${item.range}"`)} (${helpers.safeCodeSpan(`${item.file}:${item.line}`)}) — ${explain(item.kind)}`,
+        );
+      }
+      return lines;
+    },
+    run: (req, { signal }) => scanLooseRanges(req, signal),
   }),
 ] as const satisfies readonly AnyAnalyzerDescriptor[];
 

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -441,6 +441,7 @@ export function renderBrief(
   lines.push(...renderDescriptorSection("pendingReviewRequests", findings.pendingReviewRequests));
   lines.push(...renderDescriptorSection("testRatio", findings.testRatio));
   lines.push(...renderDescriptorSection("migrationSafety", findings.migrationSafety));
+  lines.push(...renderDescriptorSection("looseRange", findings.looseRange));
 
   if (!lines.length) return { promptSection: "", systemSuffix: "" };
 

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -402,6 +402,17 @@ export interface MigrationSafetyFinding {
   kind: "drop" | "rename" | "not-null-no-default" | "blocking-rewrite";
 }
 
+/** A newly-added/changed npm dependency whose version specifier is dangerously loose — a wildcard, the
+ *  `latest` dist-tag, an unbounded `>=` range, or a bare major — letting any future publish flow into the
+ *  next install (#2036, part of #1499). Reports the manifest location, package, raw specifier, and kind. */
+export interface LooseRangeFinding {
+  file: string;
+  line: number;
+  package: string;
+  range: string;
+  kind: "wildcard" | "latest" | "unbounded-gte" | "bare";
+}
+
 /** Structured analyzer output. Each analyzer fills its own key; more land as analyzers ship (#1477/#1478). */
 export interface BriefFindings {
   dependency?: DependencyFinding[];
@@ -434,6 +445,7 @@ export interface BriefFindings {
   pendingReviewRequests?: PendingReviewRequestFinding[];
   testRatio?: TestRatioFinding[];
   migrationSafety?: MigrationSafetyFinding[];
+  looseRange?: LooseRangeFinding[];
 }
 
 /** A JSDoc/TSDoc block whose `@param` tags name parameters the adjacent function no longer declares — a

--- a/review-enrichment/test/analyzer-registry.test.ts
+++ b/review-enrichment/test/analyzer-registry.test.ts
@@ -40,6 +40,7 @@ const EXPECTED_ANALYZERS = [
   "pendingReviewRequests",
   "testRatio",
   "migrationSafety",
+  "looseRange",
 ];
 
 test("analyzer descriptors cover the runtime registry in stable order", () => {

--- a/review-enrichment/test/loose-range.test.ts
+++ b/review-enrichment/test/loose-range.test.ts
@@ -1,0 +1,200 @@
+// Units for the loose dependency version-range analyzer (#2036). Own file (not enrichment.test.ts) so
+// concurrent analyzer PRs don't collide. No network involved — pure compute over added package.json patch
+// lines. Runs against the compiled dist/.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  classifyRange,
+  scanPatchForLooseRanges,
+  scanLooseRanges,
+} from "../dist/analyzers/loose-range.js";
+import { renderBrief } from "../dist/render.js";
+
+const patchOf = (lines) => `@@ -1,0 +1,${lines.length} @@\n${lines.map((l) => `+${l}`).join("\n")}`;
+
+test("classifyRange: classifies each loose kind", () => {
+  assert.equal(classifyRange("*"), "wildcard");
+  assert.equal(classifyRange("x"), "wildcard");
+  assert.equal(classifyRange("X"), "wildcard");
+  assert.equal(classifyRange("latest"), "latest");
+  assert.equal(classifyRange(">=1.2.3"), "unbounded-gte");
+  assert.equal(classifyRange(">2.0.0"), "unbounded-gte");
+  assert.equal(classifyRange("18"), "bare");
+  assert.equal(classifyRange("18.x"), "bare");
+  assert.equal(classifyRange("18.x.x"), "bare");
+});
+
+test("classifyRange: pinned, caret, tilde, and bounded ranges are not loose", () => {
+  assert.equal(classifyRange("1.2.3"), null);
+  assert.equal(classifyRange("^1.2.3"), null);
+  assert.equal(classifyRange("~1.2.3"), null);
+  assert.equal(classifyRange(">=1.2.3 <2.0.0"), null); // upper bound present — bounded
+  assert.equal(classifyRange("18.2"), null); // minor given — not a bare major
+  assert.equal(classifyRange("beta"), null); // non-latest dist-tag is out of scope
+  assert.equal(classifyRange("workspace:*"), null); // workspace protocol, not an npm range
+});
+
+test("classifyRange: unwraps an npm: alias and classifies the aliased range", () => {
+  assert.equal(classifyRange("npm:left-pad@*"), "wildcard");
+  assert.equal(classifyRange("npm:@scope/pkg@latest"), "latest");
+  assert.equal(classifyRange("npm:left-pad@^1.3.0"), null);
+});
+
+test("scanPatchForLooseRanges: flags each loose kind on added dependency lines with correct locations", () => {
+  const findings = scanPatchForLooseRanges(
+    "package.json",
+    patchOf([
+      '"left-pad": "*",',
+      '"lodash": "latest",',
+      '"react": ">=18.0.0",',
+      '"express": "4",',
+    ]),
+  );
+  assert.deepEqual(findings, [
+    { file: "package.json", line: 1, package: "left-pad", range: "*", kind: "wildcard" },
+    { file: "package.json", line: 2, package: "lodash", range: "latest", kind: "latest" },
+    { file: "package.json", line: 3, package: "react", range: ">=18.0.0", kind: "unbounded-gte" },
+    { file: "package.json", line: 4, package: "express", range: "4", kind: "bare" },
+  ]);
+});
+
+test("scanPatchForLooseRanges: pinned/caret/tilde specifiers and non-range values are not flagged", () => {
+  const findings = scanPatchForLooseRanges(
+    "package.json",
+    patchOf([
+      '"left-pad": "1.3.0",',
+      '"lodash": "^4.17.21",',
+      '"react": "~18.2.0",',
+      '"main": "index.js",',
+      '"license": "MIT",',
+    ]),
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanPatchForLooseRanges: a dependency literally named npm/node/vscode is still flagged inside a dependency block", () => {
+  // Regression for the section-aware suppression: `npm`, `node`, and `vscode` are real, installable registry
+  // packages. When the enclosing `"dependencies"` block is visible, its entries are ALL dependencies — the
+  // engines/publishConfig key-name fallback must not suppress them.
+  const findings = scanPatchForLooseRanges(
+    "package.json",
+    patchOf(['"dependencies": {', '"npm": "*",', '"node": ">=18",', '"vscode": "latest",', "},"]),
+  );
+  assert.deepEqual(findings, [
+    { file: "package.json", line: 2, package: "npm", range: "*", kind: "wildcard" },
+    { file: "package.json", line: 3, package: "node", range: ">=18", kind: "unbounded-gte" },
+    { file: "package.json", line: 4, package: "vscode", range: "latest", kind: "latest" },
+  ]);
+});
+
+test("scanPatchForLooseRanges: entries inside a visible engines/publishConfig block are never dependencies", () => {
+  // `"node": ">=18"` inside engines is legitimate and extremely common; a publishConfig dist-tag is not a
+  // dependency either. With the section visible, EVERY entry in a non-dependency block is skipped.
+  const findings = scanPatchForLooseRanges(
+    "package.json",
+    patchOf([
+      '"engines": {',
+      '"node": ">=18.0.0",',
+      '"some-engine": "*",',
+      "},",
+      '"publishConfig": {',
+      '"tag": "latest",',
+      "},",
+    ]),
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanPatchForLooseRanges: without a visible section header, the well-known engines/publishConfig key names fall back to suppression", () => {
+  // A hunk that starts mid-block has no section context — the key-name fallback keeps the notorious
+  // engines/publishConfig shapes quiet rather than guessing.
+  const findings = scanPatchForLooseRanges(
+    "package.json",
+    patchOf(['"node": ">=18.0.0",', '"npm": ">=9",', '"tag": "latest",', '"version": "1",']),
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanPatchForLooseRanges: section state resets at each hunk boundary and is tracked from context lines too", () => {
+  const patch = [
+    "@@ -5,3 +5,3 @@",
+    ' "dependencies": {', // context line establishes the section for this hunk
+    '+"left-pad": "*",', // new-file line 6 — flagged (inside dependencies)
+    " },",
+    "@@ -20,2 +20,2 @@",
+    // New hunk: the dependencies state above must NOT leak here. No header visible → fallback applies.
+    '+"node": ">=18",', // suppressed by the key-name fallback
+    '+"some-lib": "latest",', // new-file line 21 — flagged (fallback does not know this key)
+  ].join("\n");
+  const findings = scanPatchForLooseRanges("package.json", patch);
+  assert.deepEqual(findings, [
+    { file: "package.json", line: 6, package: "left-pad", range: "*", kind: "wildcard" },
+    { file: "package.json", line: 21, package: "some-lib", range: "latest", kind: "latest" },
+  ]);
+});
+
+test("scanPatchForLooseRanges: only ADDED lines are scanned — removed and context lines are ignored", () => {
+  const patch = [
+    "@@ -1,2 +1,2 @@",
+    '-"left-pad": "*",',
+    ' "lodash": "latest",',
+    '+"react": "^18.2.0",',
+  ].join("\n");
+  assert.deepEqual(scanPatchForLooseRanges("package.json", patch), []);
+});
+
+test("scanPatchForLooseRanges: new-file line numbers stay correct across context and removed lines", () => {
+  const patch = [
+    "@@ -10,3 +10,3 @@",
+    ' "dependencies": {', // new-file line 10
+    '-"left-pad": "^1.3.0",', // removed, does not advance
+    '+"left-pad": "*",', // new-file line 11
+  ].join("\n");
+  assert.deepEqual(scanPatchForLooseRanges("package.json", patch), [
+    { file: "package.json", line: 11, package: "left-pad", range: "*", kind: "wildcard" },
+  ]);
+});
+
+test("scanPatchForLooseRanges: enforces the maxFindings cap", () => {
+  const lines = Array.from({ length: 30 }, (_, i) => `"pkg-${i}": "*",`);
+  const findings = scanPatchForLooseRanges("package.json", patchOf(lines), { maxFindings: 5 });
+  assert.equal(findings.length, 5);
+  assert.deepEqual(findings.map((f) => f.line), [1, 2, 3, 4, 5]);
+
+  assert.deepEqual(
+    scanPatchForLooseRanges("package.json", patchOf(lines), { maxFindings: 0 }),
+    [],
+  );
+});
+
+test("scanLooseRanges: scans only package.json files and honors the global cap across files", async () => {
+  const looseLines = Array.from({ length: 15 }, (_, i) => `"pkg-${i}": "latest",`);
+  const findings = await scanLooseRanges({
+    repoFullName: "octo/repo",
+    prNumber: 1,
+    files: [
+      { path: "config/settings.json", patch: patchOf(['"left-pad": "*",']) },
+      { path: "package.json", patch: patchOf(looseLines) },
+      { path: "apps/web/package.json", patch: patchOf(looseLines) },
+    ],
+  });
+  assert.equal(findings.length, 20); // 15 from the root manifest + capped 5 from the workspace one
+  assert.equal(findings.filter((f) => f.file === "apps/web/package.json").length, 5);
+});
+
+test("scanLooseRanges: no files yields no findings", async () => {
+  assert.deepEqual(await scanLooseRanges({ repoFullName: "octo/repo", prNumber: 1 }), []);
+});
+
+test("renderBrief: loose-range findings render package, specifier, location, and a public-safe explanation", () => {
+  const { promptSection } = renderBrief({
+    looseRange: [
+      { file: "package.json", line: 12, package: "left-pad", range: "*", kind: "wildcard" },
+      { file: "package.json", line: 13, package: "lodash", range: "latest", kind: "latest" },
+    ],
+  });
+  assert.match(promptSection, /Loose dependency version ranges/);
+  assert.match(promptSection, /left-pad@"\*"/);
+  assert.match(promptSection, /package\.json:12/);
+  assert.match(promptSection, /not reproducible/);
+});

--- a/src/review/enrichment-analyzer-names.ts
+++ b/src/review/enrichment-analyzer-names.ts
@@ -34,6 +34,7 @@ export const REES_ANALYZER_NAMES = [
   "pendingReviewRequests",
   "testRatio",
   "migrationSafety",
+  "looseRange",
 ] as const;
 
 export type ReesAnalyzerName = (typeof REES_ANALYZER_NAMES)[number];

--- a/test/unit/enrichment-wire.test.ts
+++ b/test/unit/enrichment-wire.test.ts
@@ -626,7 +626,7 @@ describe("resolveReesAnalyzers", () => {
       resolveReesAnalyzers(
         env({
           REES_ANALYZERS:
-            "dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene,pendingReviewRequests,testRatio,migrationSafety",
+            "dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene,pendingReviewRequests,testRatio,migrationSafety,looseRange",
         }),
       ),
     ).toEqual([
@@ -660,6 +660,7 @@ describe("resolveReesAnalyzers", () => {
       "pendingReviewRequests",
       "testRatio",
       "migrationSafety",
+      "looseRange",
     ]);
   });
 


### PR DESCRIPTION
Closes #2036

## What

A new local REES analyzer, `looseRange`, that flags newly-added/changed npm dependency specifiers using dangerously loose ranges instead of a pinned/caret/tilde range — a reproducibility and supply-chain drift risk, since a loose range lets any future publish (including a compromised one) flow into the next install:

- **wildcard** — `*` / `x`: accepts ANY published version
- **latest** — the `latest` dist-tag: floats to whatever is published next
- **unbounded-gte** — `>=x` / `>x` with no upper bound: accepts every future major, breaking changes included
- **bare** — a bare major (`18`, `18.x`): floats across the whole major line

Distinct from the vuln/typosquat analyzers: this judges only the SPECIFIER, never the package. Pure compute over added `package.json` patch lines — no registry call, no network.

## Detection

- Scans added lines in `package.json` patches only, with the shared hunk/line-counter conventions from the sibling local analyzers (pre-hunk preamble skipped, `+++x` added-content not mistaken for a header, `\ No newline` markers do not advance the counter, per-line char cap).
- Keys on the same `"name": "spec"` line shape as `dependency-scan.ts` and unwraps `npm:pkg@range` aliases exactly as it does; like that sibling, parsing is a documented line-based heuristic, not a full manifest parse.
- **Section-aware suppression**: lightweight `"section": {` state is tracked from added AND context lines (the same current-block state shape as `lockfile-drift.ts`'s package-lock parser) and reset at every hunk boundary so state never leaks across discontinuous hunks. Inside a visible `dependencies`/`devDependencies`/`peerDependencies`/`optionalDependencies` block every entry is classified with **no** suppression — a real dependency literally named `npm`, `node`, or `vscode` with a loose range is still flagged. Inside any other visible block (`engines`, `publishConfig`, `scripts`, …) nothing is a dependency, so the legitimate and extremely common `"node": ">=18"` in engines never fires. Only when a hunk starts mid-block with no section header in view does a finite key-name fallback (`version`, engines keys, publishConfig's `tag`/`access`) keep the notorious shapes quiet rather than guessing.
- Pinned/caret/tilde ranges, bounded ranges (`>=1 <2`), non-`latest` dist-tags, and `workspace:` protocol specifiers are never flagged. Findings capped (`maxFindings: 20`) per file and globally.

## Registration

Registered as a local descriptor (category `supply-chain`, cost `local`, requires `["files"]`) with an inline `render()`, following the `testRatio`/`migrationSafety` descriptor shape. All wiring updated: `types.ts` (`LooseRangeFinding` + `looseRange?` key), `render.ts`, `analyzer-registry.test.ts`, root `src/review/enrichment-analyzer-names.ts`, root `test/unit/enrichment-wire.test.ts`, and the generated `analyzer-metadata.json` / `rees-analyzers.ts` / `.env.example` via `node scripts/generate-analyzer-metadata.mjs`.

## Tests

`review-enrichment/test/loose-range.test.ts` (15 tests) covers: each loose kind via `classifyRange` (including `x`/`X` wildcards, `>` as well as `>=`, and `18.x.x`), pinned/caret/tilde/bounded/minor-given/dist-tag/`workspace:` specifiers not flagged, `npm:` alias unwrapping, each kind end-to-end with exact file/line locations, non-range manifest values not flagged, a dependency literally named `npm`/`node`/`vscode` still flagged inside a visible dependencies block (the name-collision regression), entries inside a visible engines/publishConfig block never flagged, the key-name fallback for hunks with no visible section header, section state reset at hunk boundaries with context-line tracking, removed/context lines ignored for classification, line-number accuracy across mixed hunks, the per-file cap + `maxFindings: 0`, the entrypoint's package.json-only gating + global cap across files, the no-files case, and the rendered brief section. Analyzer metadata is regenerated and committed.
