### PR TITLE
feat(enrichment): treat .terraform-version as a Terraform runtime pin for EOL checks

### DIFF
--- a/review-enrichment/src/analyzers/eol-check.ts
+++ b/review-enrichment/src/analyzers/eol-check.ts
@@ -117,6 +117,10 @@ export function extractVersionPins(
         const version = leadingVersion(line);
         if (version)
           pins.push({ file: file.path, product: "oracle-jdk", version });
+      } else if (base === ".terraform-version") {
+        // tfenv/asdf pin file — same leading-version format, product is Terraform.
+        const version = leadingVersion(line);
+        if (version) pins.push({ file: file.path, product: "terraform", version });
       } else if (base === "go.mod") {
         // Module language version (`go 1.21`) and optional toolchain pin (`toolchain go1.22.0`).
         const match = /^go\s+(\d+\.\d+)/.exec(line);

--- a/review-enrichment/src/scheduler.ts
+++ b/review-enrichment/src/scheduler.ts
@@ -415,6 +415,7 @@ function isRuntimePinPath(path: string): boolean {
     basename === ".go-version" ||
     basename === ".rust-version" ||
     basename === ".java-version" ||
+    basename === ".terraform-version" ||
     basename === "go.mod"
   );
 }

--- a/review-enrichment/test/eol-check.test.ts
+++ b/review-enrichment/test/eol-check.test.ts
@@ -104,6 +104,13 @@ test("extractVersionPins reads .java-version pins as oracle-jdk", () => {
   ]);
 });
 
+test("extractVersionPins reads .terraform-version pins as Terraform", () => {
+  // tfenv/asdf use `.terraform-version` with the same leading-version format.
+  assert.deepEqual(extractVersionPins([added(".terraform-version", "1.5.7")]), [
+    { file: ".terraform-version", product: "terraform", version: "1.5.7" },
+  ]);
+});
+
 test("extractVersionPins ignores removed/context lines and files with no patch", () => {
   const patch = ["@@ -1 +1,2 @@", "-FROM python:3.7", " FROM python:3.9"].join(
     "\n",


### PR DESCRIPTION
## Summary
- Parse `.terraform-version` (tfenv/asdf) as a Terraform runtime pin for endoflife.date EOL analysis.
- Extend the scheduler runtime-pin gate so `.terraform-version` changes are not skipped.

## Test plan
- [x] Regression test verifying `.terraform-version` extracts `{ product: terraform, version }`
- [ ] CI green


Made with [Cursor](https://cursor.com)