### PR TITLE
feat(enrichment): flag committed ML checkpoint files in provenance scan

### DIFF
--- a/review-enrichment/src/analyzers/provenance.ts
+++ b/review-enrichment/src/analyzers/provenance.ts
@@ -19,9 +19,11 @@ const MAX_FINDINGS = 30; // keep the brief bounded
 
 // Compiled/non-source binary artifact extensions. `node` is a compiled Node native addon (matching the
 // binary set in asset-weight.ts) and `pyd` is a Windows Python extension DLL (the sibling of the pyc/pyo/so
-// entries) — both are unauditable prebuilt binaries a PR should not check in without source.
+// entries) — both are unauditable prebuilt binaries a PR should not check in without source. ML checkpoint
+// formats (`safetensors`, `gguf`, `onnx`, `pt`, `pth`, `ckpt`) mirror asset-weight.ts — unauditable weight
+// blobs a PR should not commit without reproducible training source.
 const BINARY_EXT_RE =
-  /\.(exe|dll|so|dylib|bin|pyc|pyo|pyd|class|jar|war|ear|wasm|node|o|a)$/i;
+  /\.(?:exe|dll|so|dylib|bin|pyc|pyo|pyd|class|jar|war|ear|wasm|node|o|a|safetensors|gguf|onnx|pt|pth|ckpt)$/i;
 // Vendored / embedded third-party source trees. bower_components (Bower) and jspm_packages (JSPM) are
 // installed-dependency directories — the same vendored case as node_modules — so a committed tree under either
 // is a vendored artifact, not contributor source (mirrors src/signals/path-matchers.ts's vendored classifier).

--- a/review-enrichment/test/provenance.test.ts
+++ b/review-enrichment/test/provenance.test.ts
@@ -33,3 +33,21 @@ test("classifyAddedFile flags prebuilt native-addon binaries (.node/.pyd) as bin
   assert.equal(classifyAddedFile("src/node.ts"), null);
   assert.equal(classifyAddedFile("app/foo.node.js"), null);
 });
+
+test("classifyAddedFile flags committed ML checkpoint files as binary artifacts", () => {
+  // Serialized model weights are unauditable prebuilt blobs — the same category asset-weight.ts flags for
+  // size bloat. A committed checkpoint must ship with reproducible training source, not as opaque binary.
+  for (const path of [
+    "models/llama/model.gguf",
+    "weights/model.safetensors",
+    "export/model.onnx",
+    "checkpoints/epoch_3.pt",
+    "checkpoints/best.pth",
+    "checkpoints/final.ckpt",
+  ]) {
+    assert.equal(classifyAddedFile(path), "binary", path);
+  }
+  // Extension is `$`-anchored: source files merely named like a checkpoint stay ordinary source.
+  assert.equal(classifyAddedFile("src/model.pt.ts"), null);
+  assert.equal(classifyAddedFile("lib/onnx.ts"), null);
+});


### PR DESCRIPTION
## Summary
- Classify ML checkpoint extensions (`safetensors`, `gguf`, `onnx`, `pt`, `pth`, `ckpt`) as binary artifacts in the provenance analyzer, mirroring asset-weight.
- Helps catch unauditable model weight blobs committed without reproducible training source.

## Test plan
- [x] Positive tests for each checkpoint extension
- [x] Negative tests for source files merely named like checkpoints
- [ ] CI green


Made with [Cursor](https://cursor.com)