### PR TITLE
feat(selfhost): add a live dead-letter-rate gauge sampled from the audit ledger

### DIFF
--- a/src/selfhost/dlq-recent.ts
+++ b/src/selfhost/dlq-recent.ts
@@ -1,0 +1,22 @@
+import { countRecentDeadLetters } from "../db/repositories";
+
+// Trailing window for the "is the DLQ dead-lettering right now?" gauge (#2083). Operators alert on the RATE of
+// recent DLQ-consumer drops, which the cumulative `gittensory_dlq_dead_lettered_total` counter and the point-in-time
+// `gittensory_queue_dead` depth gauge can't express on their own.
+export const DLQ_RECENT_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
+
+/** ISO-8601 timestamp `windowMs` before `now` (default: current time). Pure given `now`; the injectable clock keeps
+ *  the window math deterministic in tests, and matches the ISO-compare convention used by the queue reliability work. */
+export function isoNowMinus(windowMs: number, now: number = Date.now()): string {
+  return new Date(now - windowMs).toISOString();
+}
+
+/** Scrape-time sample of DLQ dead-letters within the trailing window. Swallows a query error so a transient DB
+ *  hiccup degrades the sample to 0 rather than rejecting and breaking the whole `/metrics` scrape. */
+export async function sampleRecentDeadLetters(env: Env, now: number = Date.now()): Promise<number> {
+  try {
+    return await countRecentDeadLetters(env, isoNowMinus(DLQ_RECENT_WINDOW_MS, now));
+  } catch {
+    return 0;
+  }
+}

--- a/src/selfhost/metrics.ts
+++ b/src/selfhost/metrics.ts
@@ -36,6 +36,7 @@ const histograms = new Map<string, HistogramState>();
 const DEFAULT_METRIC_META: readonly (readonly [string, MetricMeta])[] = [
   ["gittensory_queue_pending", { help: "Current in-process queue depth.", type: "gauge" }],
   ["gittensory_queue_dead", { help: "Current in-process dead queue depth.", type: "gauge" }],
+  ["gittensory_dlq_dead_lettered_recent", { help: "DLQ messages dead-lettered within the recent trailing window, sampled at scrape.", type: "gauge" }],
   ["gittensory_queue_processing", { help: "Jobs currently claimed and mid-flight.", type: "gauge" }],
   ["gittensory_queue_runnable_now", { help: "Pending jobs, any priority, currently due (run_after<=now).", type: "gauge" }],
   ["gittensory_queue_live_pending", { help: "Current live-work queue depth.", type: "gauge" }],

--- a/src/server.ts
+++ b/src/server.ts
@@ -98,6 +98,7 @@ import {
   setLocalReviewContextReader,
 } from "./signals/focus-manifest-loader";
 import { probeReesSecretAtStartup } from "./review/enrichment-wire";
+import { sampleRecentDeadLetters } from "./selfhost/dlq-recent";
 import type { JobMessage } from "./types";
 
 /** Resolve `<NAME>_FILE` env vars (Docker secrets / multi-line keys) into `<NAME>` at startup. */
@@ -621,6 +622,7 @@ async function main(): Promise<void> {
 
   gauge("gittensory_queue_pending", () => backend.queue.size());
   gauge("gittensory_queue_dead", () => backend.queue.deadCount());
+  gauge("gittensory_dlq_dead_lettered_recent", () => sampleRecentDeadLetters(env));
   gauge("gittensory_queue_processing", () => backend.queue.processingCount());
   const durableJobMetric = async (name: string): Promise<number> =>
     Number((await backend.queue.stats())[name] ?? 0);

--- a/test/unit/dlq-recent.test.ts
+++ b/test/unit/dlq-recent.test.ts
@@ -1,0 +1,37 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import * as repositories from "../../src/db/repositories";
+import { DLQ_RECENT_WINDOW_MS, isoNowMinus, sampleRecentDeadLetters } from "../../src/selfhost/dlq-recent";
+
+describe("dlq-recent gauge helpers (#2083)", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  describe("isoNowMinus", () => {
+    it("returns the ISO timestamp windowMs before the injected now", () => {
+      const now = Date.parse("2026-07-04T12:00:00.000Z");
+      expect(isoNowMinus(15 * 60 * 1000, now)).toBe("2026-07-04T11:45:00.000Z");
+    });
+
+    it("defaults to the current clock when no now is given", () => {
+      // Default-parameter path: a window before "now" is always in the past.
+      expect(isoNowMinus(1000) <= new Date().toISOString()).toBe(true);
+    });
+
+    it("exposes a 15-minute default window", () => {
+      expect(DLQ_RECENT_WINDOW_MS).toBe(900_000);
+    });
+  });
+
+  describe("sampleRecentDeadLetters", () => {
+    it("returns the count over the trailing window, queried at the window start", async () => {
+      const now = Date.parse("2026-07-04T12:00:00.000Z");
+      const spy = vi.spyOn(repositories, "countRecentDeadLetters").mockResolvedValue(7);
+      expect(await sampleRecentDeadLetters({} as Env, now)).toBe(7);
+      expect(spy).toHaveBeenCalledWith({}, "2026-07-04T11:45:00.000Z");
+    });
+
+    it("degrades to 0 when the query throws, so a DB hiccup never breaks the scrape", async () => {
+      vi.spyOn(repositories, "countRecentDeadLetters").mockRejectedValue(new Error("db down"));
+      expect(await sampleRecentDeadLetters({} as Env)).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a live dead-letter-rate gauge sampled from the audit ledger (Closes #2083).

Operators can already see the durable queue's dead depth (`gittensory_queue_dead`) and the cumulative total (`gittensory_dlq_dead_lettered_total`), but neither answers "are jobs dead-lettering **right now**?". This registers **`gittensory_dlq_dead_lettered_recent`**, sampled at scrape time over a trailing 15-minute window via the existing `countRecentDeadLetters`, wired next to the sibling queue gauges.

- New `src/selfhost/dlq-recent.ts`:
  - `isoNowMinus(windowMs, now?)` — the pure window-start ISO timestamp, with an injectable clock so the window math is deterministic in tests.
  - `sampleRecentDeadLetters(env, now?)` — the scrape-time sample; swallows a query error so a transient DB hiccup degrades the sample to `0` rather than breaking the whole `/metrics` scrape.
- `src/selfhost/metrics.ts`: registers `gittensory_dlq_dead_lettered_recent` in `DEFAULT_METRIC_META`, next to the sibling `gittensory_queue_*` gauges.
- `src/server.ts`: wires the gauge callback alongside `gittensory_queue_pending`/`gittensory_queue_dead`.

## Why no linked issue

Linked: closes #2083.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Backend-only change, no API/OpenAPI/UI surface touched, so `ui:openapi:check`, `ui:lint`, `ui:typecheck`, and `ui:build` are not applicable.
- `npm run test:coverage` was run scoped to `test/unit/dlq-recent.test.ts` (`--coverage.include` on `src/selfhost/dlq-recent.ts`): 100% statements/branches/functions/lines. Also ran `test/unit/selfhost-metrics.test.ts` (31 tests) clean, since it exercises the metrics registry this PR adds one entry to. `src/server.ts` is in `codecov.yml`'s ignore list (`- "src/server.ts"`), consistent with the rest of that file's wiring. The full unsharded suite could not be run clean in my local Windows dev environment for unrelated reasons: several test files depend on tooling not present there (Docker daemon, Python, `sentry-cli`), and generated-file "stale" checks (openapi.json, cf-typegen, selfhost-env-reference) false-positive on this checkout's CRLF line endings vs. the repo's LF convention — confirmed unrelated to this diff on a clean, unmodified `main`.
- `npm run test:mcp-pack` hits a Windows-only `spawnSync("npm", ...)` resolution failure locally (no `shell: true`, `npm` resolves to `npm.cmd` on Windows) — unrelated to this diff, expected to run on the Linux CI runner.
- `npm run actionlint`, `npm run typecheck`, `npm run test:workers`, `npm run build:mcp`, and `npm audit` all ran clean.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no such changes.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, this is an operator-facing Prometheus metric, not a public API/MCP surface.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section below. — N/A, no UI changes.
- [ ] Public docs/changelogs are updated where needed. — N/A, no docs/changelog changes.

## UI Evidence

N/A — no UI/frontend/docs changes.

## Notes

- New tests: `test/unit/dlq-recent.test.ts` covers `isoNowMinus`'s window math (explicit clock + default-clock path), the documented 15-minute default window, `sampleRecentDeadLetters`'s success path (asserting the exact query args), and its fail-safe degrade-to-0 path on a query error.
