### PR TITLE
feat(enrichment): add leftover console.log / debugger analyzer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,22 +67,22 @@ GITTENSORY_REVIEW_ENRICHMENT=false
 # provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild
 # history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity,ciCheckSignals
 # undocumentedExport,staleBranch,commitHygiene,pendingReviewRequests,testRatio,migrationSafety
-# looseRange
+# looseRange,debugLeftover
 #
 # Profile defaults:
 # fast: dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol
 # redos,provenance,secretLog,typosquat,iacMisconfig,nativeBuild,testRatio,migrationSafety
-# looseRange
+# looseRange,debugLeftover
 # balanced (default): dependency,lockfileDrift,secret,license,installScript,heavyDependency
 # actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature
 # iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink
 # approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene
-# pendingReviewRequests,testRatio,migrationSafety,looseRange
+# pendingReviewRequests,testRatio,migrationSafety,looseRange,debugLeftover
 # deep: dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol
 # redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig
 # nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity
 # ciCheckSignals,undocumentedExport,staleBranch,commitHygiene,pendingReviewRequests,testRatio
-# migrationSafety,looseRange
+# migrationSafety,looseRange,debugLeftover
 # END GENERATED REES ANALYZERS
 
 # Submitter-reputation spend control (internal-only): downgrades new/burst/low-rep

--- a/apps/gittensory-ui/src/lib/rees-analyzers.ts
+++ b/apps/gittensory-ui/src/lib/rees-analyzers.ts
@@ -795,6 +795,28 @@ export const REES_ANALYZERS = [
         "Judges only the version specifier, never the package; wildcard, latest, unbounded >=, and bare-major ranges let any future publish flow into the next install.",
     },
   },
+  {
+    name: "debugLeftover",
+    title: "Leftover debug statements",
+    category: "quality",
+    cost: "local",
+    defaultEnabled: true,
+    profiles: ["fast", "balanced", "deep"],
+    requires: ["files"],
+    limits: {
+      maxFindings: 25,
+      maxLineChars: 2000,
+    },
+    docs: {
+      summary:
+        "Flags debugging leftovers a PR adds to non-test source: `debugger;`, bare `console.log`/`console.debug`, or a bare Python `print(...)`.",
+      looksAt: "Added lines in non-test JS/TS and Python source files.",
+      reports: "File, line, and leftover kind — never line content.",
+      network: "Pure local analyzer. No external network call.",
+      notes:
+        "String-literal messages and comments are stripped before matching, and detection is gated by file extension, so a `console.log` in prose or a `print(` in a non-Python file is never flagged.",
+    },
+  },
 ] as const satisfies readonly ReesAnalyzerDoc[];
 
 export const REES_ANALYZER_NAMES = REES_ANALYZERS.map((analyzer) => analyzer.name);

--- a/review-enrichment/analyzer-metadata.json
+++ b/review-enrichment/analyzer-metadata.json
@@ -894,6 +894,32 @@
         "network": "Pure local analyzer. No external network call.",
         "notes": "Judges only the version specifier, never the package; wildcard, latest, unbounded >=, and bare-major ranges let any future publish flow into the next install."
       }
+    },
+    {
+      "name": "debugLeftover",
+      "title": "Leftover debug statements",
+      "category": "quality",
+      "cost": "local",
+      "defaultEnabled": true,
+      "profiles": [
+        "fast",
+        "balanced",
+        "deep"
+      ],
+      "requires": [
+        "files"
+      ],
+      "limits": {
+        "maxFindings": 25,
+        "maxLineChars": 2000
+      },
+      "docs": {
+        "summary": "Flags debugging leftovers a PR adds to non-test source: `debugger;`, bare `console.log`/`console.debug`, or a bare Python `print(...)`.",
+        "looksAt": "Added lines in non-test JS/TS and Python source files.",
+        "reports": "File, line, and leftover kind — never line content.",
+        "network": "Pure local analyzer. No external network call.",
+        "notes": "String-literal messages and comments are stripped before matching, and detection is gated by file extension, so a `console.log` in prose or a `print(` in a non-Python file is never flagged."
+      }
     }
   ]
 }

--- a/review-enrichment/src/analyzers/debug-leftover.ts
+++ b/review-enrichment/src/analyzers/debug-leftover.ts
@@ -1,0 +1,153 @@
+// Leftover debug-statement analyzer (#2015). Flags debugging noise a PR ADDS to non-test source: a `debugger;`
+// statement, a bare `console.log`/`console.debug` call (JS/TS), or a bare `print(...)` call (Python). Distinct
+// from secret-log.ts, which only fires when a SENSITIVE value reaches a sink; this catches plain debug leftovers
+// regardless of payload. Pure compute, no network. Precision-first: string-literal messages are blanked (reusing
+// secret-log's codeOnly) and line/block comments are stripped before matching, so `"use console.log"` and
+// `// console.log(x)` are never flagged; detection is gated by file extension so a `print(` in a non-Python file
+// or a `console.log` mention in prose can't false-positive. Line-cited via hunk headers, mirroring the siblings.
+import type { EnrichRequest, DebugLeftoverFinding } from "../types.js";
+import { codeOnly } from "./secret-log.js";
+
+const MAX_FINDINGS = 25;
+const MAX_LINE_CHARS = 2000;
+
+// Test/spec/generated files are excluded — a `console.log` in a test is not a leftover. Mirrors the skip sets
+// already used by undocumented-export.ts / doc-comment-drift.ts.
+const SKIP_PATH_RE =
+  /(?:\.d\.ts$|\.min\.|\.test\.|\.spec\.|(?:^|\/)__tests__\/|(?:^|\/)tests?\/|(?:^|\/)(?:dist|build|vendor)\/)/i;
+
+const JS_EXTS = new Set(["ts", "tsx", "mts", "cts", "js", "jsx", "mjs", "cjs"]);
+const PY_EXTS = new Set(["py"]);
+
+// A `debugger` statement — required trailing `;` (a bare `debugger` keyword statement conventionally carries one,
+// and requiring it avoids matching a property access like `obj.debugger`). The leading class excludes `.debugger`.
+const DEBUGGER_RE = /(?:^|[^.\w])debugger\s*;/;
+// A bare `console.log`/`console.debug` CALL. The leading `[^.\w]` (or start) excludes `foo.console.log` (a
+// property named console) and `myconsole.log`; `console.info`/`.warn`/`.error` are intentional logging, not
+// debug leftovers, so they are deliberately NOT matched.
+const CONSOLE_RE = /(?:^|[^.\w])console\s*\.\s*(?:log|debug)\s*\(/;
+// A bare Python `print(...)` call. The leading class excludes `obj.print(` and keeps `pprint(`/`sprint(` out
+// (the char before `print` is a word char there, so the boundary fails).
+const PRINT_RE = /(?:^|[^.\w])print\s*\(/;
+
+/** The lowercased final path extension, or null. */
+function extOf(path: string): string | null {
+  const base = path.split("/").pop() ?? path;
+  const dot = base.lastIndexOf(".");
+  return dot > 0 ? base.slice(dot + 1).toLowerCase() : null;
+}
+
+/** Blank string literals (via codeOnly) then strip comments so only real code is matched. `lang` picks the
+ *  comment syntax: JS/TS use `//` and same-line `/* * /`; Python uses `#` (and must NOT strip `//`, which is
+ *  integer division). Pure. */
+function toCode(line: string, lang: "js" | "py"): string {
+  let code = codeOnly(line);
+  if (lang === "js") {
+    code = code.replace(/\/\*.*?\*\//g, " ").replace(/\/\/.*$/, "");
+  } else {
+    code = code.replace(/#.*$/, "");
+  }
+  return code;
+}
+
+/** Classify one added source line for a debug leftover, given its file's language. Returns the kind, or null. */
+export function detectDebugLeftover(
+  line: string,
+  lang: "js" | "py",
+): DebugLeftoverFinding["kind"] | null {
+  const code = toCode(line, lang);
+  // A JSDoc/block-comment continuation line (`* console.log(x)`) is documentation, not code.
+  if (code.trimStart().startsWith("*")) return null;
+  if (lang === "js") {
+    if (DEBUGGER_RE.test(code)) return "debugger";
+    if (CONSOLE_RE.test(code)) return "console";
+  } else {
+    if (PRINT_RE.test(code)) return "print";
+  }
+  return null;
+}
+
+type ScanLimits = {
+  maxFindings?: number;
+  signal?: AbortSignal;
+};
+
+function* patchLines(patch: string): Generator<string> {
+  let start = 0;
+  for (let i = 0; i <= patch.length; i++) {
+    if (i === patch.length || patch[i] === "\n") {
+      yield patch.slice(start, i);
+      start = i + 1;
+    }
+  }
+}
+
+/** Scan one file patch's added lines for debug leftovers, line-cited via hunk headers. Pure. */
+export function scanPatchForDebugLeftover(
+  path: string,
+  patch: string,
+  limits: ScanLimits = {},
+): DebugLeftoverFinding[] {
+  const maxFindings = limits.maxFindings ?? MAX_FINDINGS;
+  if (maxFindings <= 0) return [];
+  const ext = extOf(path);
+  const lang: "js" | "py" | null = ext
+    ? JS_EXTS.has(ext)
+      ? "js"
+      : PY_EXTS.has(ext)
+        ? "py"
+        : null
+    : null;
+  if (!lang) return [];
+
+  const findings: DebugLeftoverFinding[] = [];
+  let newLine = 0;
+  let inHunk = false;
+  for (const line of patchLines(patch)) {
+    if (limits.signal?.aborted) throw new Error("analyzer_aborted");
+    const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
+    if (hunk) {
+      newLine = Number(hunk[1]);
+      inHunk = true;
+      continue;
+    }
+    // Skip pre-hunk preamble; inside a hunk `+++x`/`+++ x` is added content, not a header.
+    if (!inHunk) continue;
+    if (line.startsWith("+")) {
+      const body = line.slice(1);
+      if (body.length <= MAX_LINE_CHARS) {
+        const kind = detectDebugLeftover(body, lang);
+        if (kind) {
+          findings.push({ file: path, line: newLine, kind });
+          if (findings.length >= maxFindings) return findings;
+        }
+      }
+      newLine++;
+    } else if (!line.startsWith("-") && !line.startsWith("\\")) {
+      // A `\ No newline at end of file` marker is not a new-file line — do not advance the cursor
+      // (same class as the iac-misconfig / secret-log fix).
+      newLine++;
+    }
+  }
+  return findings;
+}
+
+/** Analyzer entrypoint: scan every changed non-test source file's added lines for debug leftovers. */
+export async function scanDebugLeftover(
+  req: EnrichRequest,
+  signal?: AbortSignal,
+): Promise<DebugLeftoverFinding[]> {
+  const findings: DebugLeftoverFinding[] = [];
+  for (const file of req.files ?? []) {
+    if (signal?.aborted) throw new Error("analyzer_aborted");
+    if (!file.patch || SKIP_PATH_RE.test(file.path)) continue;
+    for (const finding of scanPatchForDebugLeftover(file.path, file.patch, {
+      maxFindings: MAX_FINDINGS - findings.length,
+      signal,
+    })) {
+      findings.push(finding);
+      if (findings.length >= MAX_FINDINGS) return findings;
+    }
+  }
+  return findings;
+}

--- a/review-enrichment/src/analyzers/registry.ts
+++ b/review-enrichment/src/analyzers/registry.ts
@@ -27,6 +27,7 @@ import { scanStaleBranch } from "./stale-branch.js";
 import { scanTestRatio } from "./test-ratio.js";
 import { scanMigrationSafety } from "./migration-safety.js";
 import { scanLooseRanges } from "./loose-range.js";
+import { scanDebugLeftover } from "./debug-leftover.js";
 import { scanTyposquat } from "./typosquat.js";
 import { scanUndocumentedExport } from "./undocumented-export.js";
 import type {
@@ -792,6 +793,45 @@ export const ANALYZER_DESCRIPTORS = [
       return lines;
     },
     run: (req, { signal }) => scanLooseRanges(req, signal),
+  }),
+  descriptor({
+    name: "debugLeftover",
+    title: "Leftover debug statements",
+    category: "quality",
+    cost: "local",
+    defaultEnabled: true,
+    requires: ["files"],
+    limits: { maxFindings: 25, maxLineChars: 2000 },
+    docs: {
+      summary:
+        "Flags debugging leftovers a PR adds to non-test source: `debugger;`, bare `console.log`/`console.debug`, or a bare Python `print(...)`.",
+      looksAt: "Added lines in non-test JS/TS and Python source files.",
+      reports: "File, line, and leftover kind — never line content.",
+      network: "Pure local analyzer. No external network call.",
+      notes:
+        "String-literal messages and comments are stripped before matching, and detection is gated by file extension, so a `console.log` in prose or a `print(` in a non-Python file is never flagged.",
+    },
+    render: (findings, helpers) => {
+      if (!findings.length) return [];
+      const explain = (kind: (typeof findings)[number]["kind"]): string => {
+        switch (kind) {
+          case "debugger":
+            return "a `debugger;` statement will halt execution under an attached debugger";
+          case "console":
+            return "a bare `console.log`/`console.debug` call looks like leftover debug output";
+          case "print":
+            return "a bare `print(...)` call looks like leftover debug output";
+        }
+      };
+      const lines = ["### Leftover debug statements (remove before merging)"];
+      for (const item of findings) {
+        lines.push(
+          `- ${helpers.safeCodeSpan(`${item.file}:${item.line}`)} — ${explain(item.kind)}`,
+        );
+      }
+      return lines;
+    },
+    run: (req, { signal }) => scanDebugLeftover(req, signal),
   }),
 ] as const satisfies readonly AnyAnalyzerDescriptor[];
 

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -456,6 +456,7 @@ export function renderBrief(
   lines.push(...renderDescriptorSection("testRatio", findings.testRatio));
   lines.push(...renderDescriptorSection("migrationSafety", findings.migrationSafety));
   lines.push(...renderDescriptorSection("looseRange", findings.looseRange));
+  lines.push(...renderDescriptorSection("debugLeftover", findings.debugLeftover));
 
   if (!lines.length) return { promptSection: "", systemSuffix: "" };
 

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -420,6 +420,15 @@ export interface LooseRangeFinding {
   kind: "wildcard" | "latest" | "unbounded-gte" | "bare";
 }
 
+/** A debugging leftover a PR added to non-test source — a `debugger;` statement, a bare `console.log`/
+ *  `console.debug` call, or a bare Python `print(...)` call (#2015, part of #1499). Reports the location +
+ *  kind only. */
+export interface DebugLeftoverFinding {
+  file: string;
+  line: number;
+  kind: "debugger" | "console" | "print";
+}
+
 /** Structured analyzer output. Each analyzer fills its own key; more land as analyzers ship (#1477/#1478). */
 export interface BriefFindings {
   dependency?: DependencyFinding[];
@@ -453,6 +462,7 @@ export interface BriefFindings {
   testRatio?: TestRatioFinding[];
   migrationSafety?: MigrationSafetyFinding[];
   looseRange?: LooseRangeFinding[];
+  debugLeftover?: DebugLeftoverFinding[];
 }
 
 /** A JSDoc/TSDoc block whose `@param` tags name parameters the adjacent function no longer declares — a

--- a/review-enrichment/test/analyzer-registry.test.ts
+++ b/review-enrichment/test/analyzer-registry.test.ts
@@ -41,6 +41,7 @@ const EXPECTED_ANALYZERS = [
   "testRatio",
   "migrationSafety",
   "looseRange",
+  "debugLeftover",
 ];
 
 test("analyzer descriptors cover the runtime registry in stable order", () => {

--- a/review-enrichment/test/debug-leftover.test.ts
+++ b/review-enrichment/test/debug-leftover.test.ts
@@ -1,0 +1,124 @@
+// Units for the leftover debug-statement analyzer (#2015). Own file (not enrichment.test.ts) so concurrent
+// analyzer PRs don't collide. No network — pure compute over added patch lines. Runs against the compiled dist/.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  detectDebugLeftover,
+  scanPatchForDebugLeftover,
+  scanDebugLeftover,
+} from "../dist/analyzers/debug-leftover.js";
+import { renderBrief } from "../dist/render.js";
+
+const patchOf = (lines) => `@@ -1,0 +1,${lines.length} @@\n${lines.map((l) => `+${l}`).join("\n")}`;
+
+test("detectDebugLeftover: flags a debugger statement and bare console.log/console.debug in JS/TS", () => {
+  assert.equal(detectDebugLeftover("  debugger;", "js"), "debugger");
+  assert.equal(detectDebugLeftover("  console.log(x);", "js"), "console");
+  assert.equal(detectDebugLeftover("  console.debug(x);", "js"), "console");
+  assert.equal(detectDebugLeftover("  console . log ( x );", "js"), "console");
+});
+
+test("detectDebugLeftover: intentional console methods and property-access lookalikes are not flagged", () => {
+  assert.equal(detectDebugLeftover("  console.error(err);", "js"), null);
+  assert.equal(detectDebugLeftover("  console.warn(msg);", "js"), null);
+  assert.equal(detectDebugLeftover("  console.info(msg);", "js"), null);
+  assert.equal(detectDebugLeftover("  logger.console.log(x);", "js"), null); // a property named console
+  assert.equal(detectDebugLeftover("  this.debugger = true;", "js"), null); // property, not a statement
+});
+
+test("detectDebugLeftover: a console.log/debugger inside a string or comment is not flagged", () => {
+  assert.equal(detectDebugLeftover('  throw new Error("do not use console.log");', "js"), null);
+  assert.equal(detectDebugLeftover("  // console.log(x) left as a note", "js"), null);
+  assert.equal(detectDebugLeftover("  foo(); /* console.log(x) */", "js"), null);
+  assert.equal(detectDebugLeftover("   * console.log(x) in a JSDoc line", "js"), null);
+  assert.equal(detectDebugLeftover("  const s = `use debugger; here`;", "js"), null);
+});
+
+test("detectDebugLeftover: flags a bare Python print() but not method/substring lookalikes", () => {
+  assert.equal(detectDebugLeftover("    print('hello')", "py"), "print");
+  assert.equal(detectDebugLeftover("    print(x, y)", "py"), "print");
+  assert.equal(detectDebugLeftover("    self.print(x)", "py"), null); // a method named print
+  assert.equal(detectDebugLeftover("    pprint(x)", "py"), null); // different function
+  assert.equal(detectDebugLeftover("    blueprint(x)", "py"), null);
+  assert.equal(detectDebugLeftover("    # print(x) commented out", "py"), null);
+  assert.equal(detectDebugLeftover('    msg = "print(x)"', "py"), null); // inside a string
+});
+
+test("detectDebugLeftover: language gating — console/debugger only in JS, print only in Python", () => {
+  assert.equal(detectDebugLeftover("  print(x)", "js"), null); // print is not a JS debug leftover
+  assert.equal(detectDebugLeftover("  console.log(x);", "py"), null); // console.log is not Python
+  assert.equal(detectDebugLeftover("  debugger;", "py"), null);
+});
+
+test("scanPatchForDebugLeftover: flags each kind on added lines with correct locations", () => {
+  const findings = scanPatchForDebugLeftover(
+    "src/widget.ts",
+    patchOf(["export function f() {", "  debugger;", "  console.log(value);", "  return value;", "}"]),
+  );
+  assert.deepEqual(findings, [
+    { file: "src/widget.ts", line: 2, kind: "debugger" },
+    { file: "src/widget.ts", line: 3, kind: "console" },
+  ]);
+});
+
+test("scanPatchForDebugLeftover: a non-JS/Python file is not scanned", () => {
+  assert.deepEqual(
+    scanPatchForDebugLeftover("config/notes.md", patchOf(["console.log(x); and print(y)"])),
+    [],
+  );
+});
+
+test("scanPatchForDebugLeftover: only ADDED lines are scanned; new-file line numbers stay correct", () => {
+  const patch = [
+    "@@ -10,2 +10,2 @@",
+    " function f() {", // context line 10
+    "-  console.log(old);", // removed, does not advance
+    "+  console.log(fresh);", // new-file line 11
+  ].join("\n");
+  assert.deepEqual(scanPatchForDebugLeftover("src/a.ts", patch), [
+    { file: "src/a.ts", line: 11, kind: "console" },
+  ]);
+});
+
+test("scanPatchForDebugLeftover: enforces the maxFindings cap", () => {
+  const lines = Array.from({ length: 30 }, () => "console.log(x);");
+  const findings = scanPatchForDebugLeftover("src/a.ts", patchOf(lines), { maxFindings: 5 });
+  assert.equal(findings.length, 5);
+  assert.deepEqual(
+    scanPatchForDebugLeftover("src/a.ts", patchOf(lines), { maxFindings: 0 }),
+    [],
+  );
+});
+
+test("scanDebugLeftover: skips test/spec files and honors the global cap across files", async () => {
+  const consoleLines = Array.from({ length: 30 }, () => "console.log(x);");
+  const findings = await scanDebugLeftover({
+    repoFullName: "octo/repo",
+    prNumber: 1,
+    files: [
+      { path: "src/widget.test.ts", patch: patchOf(["console.log(inTest);"]) }, // skipped
+      { path: "tests/helper.ts", patch: patchOf(["console.log(inTestsDir);"]) }, // skipped
+      { path: "src/widget.ts", patch: patchOf(consoleLines) }, // 25 (global cap)
+    ],
+  });
+  assert.equal(findings.length, 25);
+  assert.ok(findings.every((f) => f.file === "src/widget.ts"));
+});
+
+test("scanDebugLeftover: no files yields no findings", async () => {
+  assert.deepEqual(await scanDebugLeftover({ repoFullName: "octo/repo", prNumber: 1 }), []);
+});
+
+test("renderBrief: debug-leftover findings render location plus a public-safe explanation only", () => {
+  const { promptSection } = renderBrief({
+    debugLeftover: [
+      { file: "src/widget.ts", line: 2, kind: "debugger" },
+      { file: "src/app.py", line: 9, kind: "print" },
+    ],
+  });
+  assert.match(promptSection, /Leftover debug statements/);
+  assert.match(promptSection, /src\/widget\.ts:2/);
+  assert.match(promptSection, /debugger;` statement/);
+  assert.match(promptSection, /src\/app\.py:9/);
+  assert.match(promptSection, /bare `print/);
+});

--- a/src/review/enrichment-analyzer-names.ts
+++ b/src/review/enrichment-analyzer-names.ts
@@ -35,6 +35,7 @@ export const REES_ANALYZER_NAMES = [
   "testRatio",
   "migrationSafety",
   "looseRange",
+  "debugLeftover",
 ] as const;
 
 export type ReesAnalyzerName = (typeof REES_ANALYZER_NAMES)[number];

--- a/test/unit/enrichment-wire.test.ts
+++ b/test/unit/enrichment-wire.test.ts
@@ -626,7 +626,7 @@ describe("resolveReesAnalyzers", () => {
       resolveReesAnalyzers(
         env({
           REES_ANALYZERS:
-            "dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene,pendingReviewRequests,testRatio,migrationSafety,looseRange",
+            "dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene,pendingReviewRequests,testRatio,migrationSafety,looseRange,debugLeftover",
         }),
       ),
     ).toEqual([
@@ -661,6 +661,7 @@ describe("resolveReesAnalyzers", () => {
       "testRatio",
       "migrationSafety",
       "looseRange",
+      "debugLeftover",
     ]);
   });
 


### PR DESCRIPTION
Closes #2015

## What

A new local REES analyzer, `debugLeftover`, that flags debugging leftovers a PR ADDS to non-test source: a `debugger;` statement, a bare `console.log`/`console.debug` call (JS/TS), or a bare Python `print(...)` call. Distinct from `secret-log.ts`, which only fires when a SENSITIVE value reaches a sink — this catches plain debug noise regardless of payload. Pure compute, no network.

## Detection (precision-first)

- **Language-gated by file extension**: `debugger`/`console.*` are only detected in JS/TS files (`ts,tsx,mts,cts,js,jsx,mjs,cjs`); `print(` only in `.py`. So a `print(` in a C++ file or a `console.log` mention in a Markdown file can't false-positive.
- **String and comment stripping** before matching, reusing `secret-log.ts`'s `codeOnly()` to blank string-literal messages, then removing `//` + same-line `/* */` for JS and `#` for Python (Python keeps `//` — integer division — and JS keeps `#` — private fields). So `throw new Error("do not use console.log")` and `// console.log(x)` are never flagged, and a JSDoc continuation line (`* console.log(x)`) is skipped.
- **Only intentional-vs-leftover precision**: `console.info`/`.warn`/`.error` are legitimate logging and are NOT flagged; only `console.log`/`console.debug` are. Property/substring lookalikes (`foo.console.log`, `obj.print(`, `pprint(`, `this.debugger`) are excluded by the leading `[^.\w]` boundary. `debugger` requires a trailing `;` to read as a statement.
- Test/spec/generated files are skipped (`.test.`/`.spec.`/`__tests__/`/`tests/`/`.d.ts`/`.min.`/`dist|build|vendor/`), matching the skip sets in `undocumented-export.ts`/`doc-comment-drift.ts`. Added lines only, line-cited via hunk headers, with the shared `\ No newline` line-counter fix. Findings capped (`maxFindings: 25`) per file and globally.

## Registration

Registered as a local descriptor (category `quality`, cost `local`, requires `["files"]`) with an inline `render()`, following the `looseRange`/`migrationSafety` descriptor shape. All wiring updated: `types.ts` (`DebugLeftoverFinding` + `debugLeftover?` key), `render.ts`, `analyzer-registry.test.ts`, root `src/review/enrichment-analyzer-names.ts`, root `test/unit/enrichment-wire.test.ts`, and the generated `analyzer-metadata.json` / `rees-analyzers.ts` / `.env.example` via `node scripts/generate-analyzer-metadata.mjs`.

## Tests

`review-enrichment/test/debug-leftover.test.ts` (12 tests) covers: each kind detected (debugger, console.log, console.debug, whitespaced `console . log`, Python print with args), intentional console methods + property lookalikes not flagged, string/line-comment/block-comment/JSDoc/template-literal suppression, Python method/substring lookalikes (`self.print`, `pprint`, `blueprint`) not flagged, cross-language gating (print not flagged in JS, console/debugger not flagged in Python), each kind end-to-end with exact locations, a non-JS/Python file not scanned, added-lines-only with line-number accuracy across mixed hunks, the per-file cap + `maxFindings: 0`, the entrypoint's test-file skip + global cap across files, the no-files case, and the rendered brief section. Analyzer metadata is regenerated and committed.
