### PR TITLE
feat(engine): add organic AI-fatigue signal to policy map

### DIFF
--- a/packages/gittensory-engine/README.md
+++ b/packages/gittensory-engine/README.md
@@ -403,9 +403,35 @@ injected-clock semantics for local miners.
 
 ## AI Policy Map
 
-`scanAiPolicyText` and `resolveAiPolicyVerdict` provide the deterministic policy gate used by miner discovery.
-They only deny on small, explicit AI-contribution ban phrases in `AI-USAGE.md` or `CONTRIBUTING.md`; ambiguous,
-missing, or empty policy text stays allowed so discovery does not invent a ban.
+`scanAiPolicyText`, `resolveAiPolicyVerdict`, and `resolveAiPolicyAssessment` provide the deterministic policy gate
+used by miner discovery. They only hard-skip on small, explicit AI-contribution ban phrases in `AI-USAGE.md` or
+`CONTRIBUTING.md`; ambiguous, missing, or empty policy text stays allowed so discovery does not invent a ban.
+
+`resolveAiPolicyAssessment()` adds a separate organic AI-fatigue tier (#3009) derived from metadata only:
+
+- concentrated terse rejections on AI-attributed closed PRs
+- recency-weighted AI/automation language added to contributing docs without matching a formal ban phrase
+
+Fatigue never overrides or promotes into the hard-skip boolean. Instead it emits a priority adjustment
+(`deprioritize` or `defer`) that `rankMetadataOpportunities()` can apply via `aiPolicyFatigueByRepo`. Per-repo cache
+helpers use a shorter TTL for fatigue signals than for formal bans.
+
+```ts
+import {
+  resolveAiPolicyAssessment,
+  applyAiPolicyFatigueToRankScore,
+  writeAiPolicyVerdictCache,
+} from "@jsonbored/gittensory-engine";
+
+const verdict = resolveAiPolicyAssessment({
+  docs: { aiUsage: null, contributing: "Please disclose AI-assisted contributions." },
+  closedPullRequests: [
+    { number: 1, state: "closed", merged: false, aiAttributed: true, terseRejection: true },
+  ],
+});
+
+applyAiPolicyFatigueToRankScore(0.82, verdict.fatigue, Date.now());
+```
 
 ## Governor ledger
 

--- a/packages/gittensory-engine/src/ai-policy-map.ts
+++ b/packages/gittensory-engine/src/ai-policy-map.ts
@@ -1,9 +1,90 @@
+// AI policy map (#2305) with organic AI-fatigue tier (#3009).
+//
+// Formal ban phrases hard-skip a repo. Fatigue is a separate, lower-confidence metadata signal that deprioritizes
+// or defers mining before a maintainer writes an outright ban — never conflated with or promoted to the hard-skip.
+
 export type AiPolicySource = "AI-USAGE.md" | "CONTRIBUTING.md" | "none";
+
+export type AiPolicyFatigueTier = "none" | "elevated" | "high";
+
+export type AiPolicyPriorityAdjustment = "none" | "deprioritize" | "defer";
+
+export type AiPolicyFatigueEvidenceKind = "terse_rejection_pattern" | "contributing_doc_language";
+
+export type AiPolicyFatigueEvidence = {
+  kind: AiPolicyFatigueEvidenceKind;
+  detail: string;
+  weight: number;
+};
+
+export type AiPolicyFatigueSignal = {
+  tier: AiPolicyFatigueTier;
+  priorityAdjustment: AiPolicyPriorityAdjustment;
+  /** Multiplier applied to opportunity rank scores in (0, 1]; 1 means no adjustment. */
+  priorityFactor: number;
+  deferRecheckUntil: string | null;
+  evidence: AiPolicyFatigueEvidence[];
+};
 
 export type AiPolicyVerdict = {
   allowed: boolean;
   matchedPhrase: string | null;
   source: AiPolicySource;
+  fatigue: AiPolicyFatigueSignal;
+};
+
+export type AiAttributedPullRequestMetadata = {
+  number: number;
+  state: "closed" | "open" | string;
+  merged?: boolean | undefined;
+  closedAt?: string | null | undefined;
+  labels?: readonly string[] | undefined;
+  authorLogin?: string | null | undefined;
+  /** Caller-provided hint when metadata already identified AI/automation attribution. */
+  aiAttributed?: boolean | undefined;
+  /** Caller-provided hint when metadata shows a terse close/rejection without merge. */
+  terseRejection?: boolean | undefined;
+};
+
+export type AiPolicyAssessmentInput = {
+  docs: {
+    aiUsage: string | null | undefined;
+    contributing: string | null | undefined;
+  };
+  previousContributing?: string | null | undefined;
+  contributingObservedAt?: string | null | undefined;
+  closedPullRequests?: readonly AiAttributedPullRequestMetadata[] | undefined;
+  nowMs?: number | undefined;
+};
+
+export type AiPolicyVerdictCacheEntry = {
+  repoFullName: string;
+  verdict: AiPolicyVerdict;
+  cachedAtMs: number;
+  expiresAtMs: number;
+  cacheKind: "formal_ban" | "fatigue" | "clean";
+};
+
+/** Formal-ban policy docs change slowly; cache longer. */
+export const AI_POLICY_FORMAL_BAN_CACHE_TTL_MS = 7 * 24 * 60 * 60 * 1000;
+/** Fatigue metadata is time-sensitive; recheck sooner. */
+export const AI_POLICY_FATIGUE_CACHE_TTL_MS = 6 * 60 * 60 * 1000;
+/** Defer window before a repo with a high fatigue signal may be reconsidered. */
+export const AI_POLICY_FATIGUE_DEFER_RECHECK_MS = 48 * 60 * 60 * 1000;
+
+const AI_POLICY_FATIGUE_NONE: AiPolicyFatigueSignal = {
+  tier: "none",
+  priorityAdjustment: "none",
+  priorityFactor: 1,
+  deferRecheckUntil: null,
+  evidence: [],
+};
+
+const AI_POLICY_ALLOWED: AiPolicyVerdict = {
+  allowed: true,
+  matchedPhrase: null,
+  source: "none",
+  fatigue: AI_POLICY_FATIGUE_NONE,
 };
 
 type BanPhrase = {
@@ -11,10 +92,9 @@ type BanPhrase = {
   pattern: RegExp;
 };
 
-const AI_POLICY_ALLOWED: AiPolicyVerdict = {
-  allowed: true,
-  matchedPhrase: null,
-  source: "none",
+type FatiguePhrase = {
+  phrase: string;
+  pattern: RegExp;
 };
 
 const BAN_PHRASES: BanPhrase[] = [
@@ -37,6 +117,272 @@ const BAN_PHRASES: BanPhrase[] = [
   },
 ];
 
+const FATIGUE_LANGUAGE_PHRASES: FatiguePhrase[] = [
+  { phrase: "ai-assisted contributions", pattern: /\bai[-\s]+assisted\s+(?:contributions|pull\s+requests|prs)\b/i },
+  { phrase: "automated pull requests", pattern: /\bautomated\s+(?:pull\s+requests|prs|contributions)\b/i },
+  { phrase: "copilot contributions", pattern: /\bcopilot\b/i },
+  { phrase: "large language model tooling", pattern: /\b(?:large\s+language\s+model|llm)\b/i },
+  { phrase: "ai tooling policy", pattern: /\bai\s+tools?\b/i },
+  { phrase: "automation policy", pattern: /\bautomation\s+(?:policy|contributions|pull\s+requests)\b/i },
+  { phrase: "review ai-generated work carefully", pattern: /\breview\s+ai[-\s]+generated\b/i },
+];
+
+const AI_ATTRIBUTION_LABELS = new Set([
+  "automated",
+  "automation",
+  "bot",
+  "ai",
+  "copilot",
+  "llm",
+  "generated",
+]);
+
+const MIN_AI_ATTRIBUTED_CLOSED_PRS = 3;
+const TERSE_REJECTION_ELEVATED_RATE = 0.55;
+const TERSE_REJECTION_HIGH_RATE = 0.75;
+
+function roundWeight(value: number): number {
+  return Math.round(Math.min(1, Math.max(0, value)) * 1_000_000) / 1_000_000;
+}
+
+function normalizeRepoKey(repoFullName: string): string {
+  const trimmed = repoFullName.trim().toLowerCase();
+  const [owner, repo, extra] = trimmed.split("/");
+  if (!owner || !repo || extra !== undefined) return trimmed;
+  return `${owner}/${repo}`;
+}
+
+function normalizeLabels(labels: readonly string[] | undefined): string[] {
+  if (!labels) return [];
+  return labels
+    .filter((label): label is string => typeof label === "string")
+    .map((label) => label.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+function matchesBanPhrase(text: string): BanPhrase | null {
+  for (const ban of BAN_PHRASES) {
+    if (ban.pattern.test(text)) return ban;
+  }
+  return null;
+}
+
+function matchesFatiguePhrase(text: string): FatiguePhrase | null {
+  for (const phrase of FATIGUE_LANGUAGE_PHRASES) {
+    if (phrase.pattern.test(text) && !matchesBanPhrase(text)) return phrase;
+  }
+  return null;
+}
+
+function parseInstantMs(value: string | null | undefined): number | null {
+  if (!value) return null;
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+function recencyWeight(observedAtMs: number | null, nowMs: number): number {
+  if (observedAtMs === null || !Number.isFinite(nowMs)) return 0.5;
+  const ageDays = Math.max(0, (nowMs - observedAtMs) / 86_400_000);
+  if (ageDays <= 7) return 1;
+  if (ageDays <= 30) return 0.75;
+  if (ageDays <= 90) return 0.5;
+  return 0.25;
+}
+
+/**
+ * Infer AI/automation attribution from metadata markers only — never from PR source content.
+ */
+export function inferAiAttributionFromPrMetadata(pr: {
+  labels?: readonly string[] | undefined;
+  authorLogin?: string | null | undefined;
+  aiAttributed?: boolean | undefined;
+}): boolean {
+  if (pr.aiAttributed === true) return true;
+  if (pr.aiAttributed === false) return false;
+  const login = typeof pr.authorLogin === "string" ? pr.authorLogin.trim().toLowerCase() : "";
+  if (login.endsWith("[bot]") || login.endsWith("-bot") || login.endsWith("bot")) return true;
+  return normalizeLabels(pr.labels).some((label) => AI_ATTRIBUTION_LABELS.has(label));
+}
+
+function isClosedWithoutMerge(pr: AiAttributedPullRequestMetadata): boolean {
+  const state = typeof pr.state === "string" ? pr.state.trim().toLowerCase() : "";
+  if (pr.merged === true) return false;
+  if (pr.merged === false) return true;
+  return state === "closed";
+}
+
+function isTerseRejection(pr: AiAttributedPullRequestMetadata): boolean {
+  if (pr.terseRejection === true) return true;
+  if (pr.terseRejection === false) return false;
+  return isClosedWithoutMerge(pr);
+}
+
+/**
+ * Detect concentrated terse rejections on AI-attributed PRs from metadata-only rows.
+ */
+export function detectTerseRejectionFatigue(
+  pullRequests: readonly AiAttributedPullRequestMetadata[],
+): { score: number; evidence: AiPolicyFatigueEvidence[] } {
+  const aiAttributedClosed = pullRequests.filter(
+    (pr) => inferAiAttributionFromPrMetadata(pr) && isClosedWithoutMerge(pr),
+  );
+  if (aiAttributedClosed.length < MIN_AI_ATTRIBUTED_CLOSED_PRS) {
+    return { score: 0, evidence: [] };
+  }
+  const terseRejections = aiAttributedClosed.filter((pr) => isTerseRejection(pr)).length;
+  const rate = terseRejections / aiAttributedClosed.length;
+  if (rate < TERSE_REJECTION_ELEVATED_RATE) return { score: 0, evidence: [] };
+  const score = roundWeight(Math.min(1, rate));
+  return {
+    score,
+    evidence: [
+      {
+        kind: "terse_rejection_pattern",
+        detail: `${terseRejections}/${aiAttributedClosed.length} recent AI-attributed PRs closed without merge`,
+        weight: score,
+      },
+    ],
+  };
+}
+
+/**
+ * Scan contributing/policy doc text for AI/automation language that stops short of an explicit ban phrase.
+ */
+export function scanContributingDocFatigueLanguage(
+  content: string | null | undefined,
+  source: AiPolicySource,
+): AiPolicyFatigueEvidence[] {
+  const text = content ?? "";
+  if (source === "none" || text.trim().length === 0) return [];
+  const evidence: AiPolicyFatigueEvidence[] = [];
+  for (const phrase of FATIGUE_LANGUAGE_PHRASES) {
+    if (phrase.pattern.test(text) && !matchesBanPhrase(text)) {
+      evidence.push({
+        kind: "contributing_doc_language",
+        detail: `${phrase.phrase} (${source})`,
+        weight: 0.5,
+      });
+    }
+  }
+  return evidence;
+}
+
+/**
+ * Detect newly added AI/automation language in a contributing doc revision without matching a formal ban phrase.
+ */
+export function detectContributingDocFatigueRevision(input: {
+  previous: string | null | undefined;
+  current: string | null | undefined;
+  source: AiPolicySource;
+  observedAt?: string | null | undefined;
+  nowMs?: number | undefined;
+}): { score: number; evidence: AiPolicyFatigueEvidence[] } {
+  const current = input.current ?? "";
+  const previous = input.previous ?? "";
+  if (input.source === "none" || current.trim().length === 0) return { score: 0, evidence: [] };
+
+  const currentMatches = scanContributingDocFatigueLanguage(current, input.source);
+  const previousPhrases = new Set(
+    scanContributingDocFatigueLanguage(previous, input.source).map((item) => item.detail),
+  );
+  const freshEvidence = currentMatches.filter((item) => !previousPhrases.has(item.detail));
+  if (freshEvidence.length === 0 && previous.trim().length > 0) return { score: 0, evidence: [] };
+
+  const evidence =
+    previous.trim().length === 0
+      ? currentMatches
+      : freshEvidence.length > 0
+        ? freshEvidence
+        : currentMatches;
+  if (evidence.length === 0) return { score: 0, evidence: [] };
+
+  const weight = recencyWeight(parseInstantMs(input.observedAt), input.nowMs ?? Date.now());
+  const score = roundWeight(Math.min(1, 0.35 + evidence.length * 0.15) * weight);
+  return {
+    score,
+    evidence: evidence.map((item) => ({ ...item, weight: roundWeight(item.weight * weight) })),
+  };
+}
+
+function composeFatigueSignal(input: {
+  terseScore: number;
+  terseEvidence: AiPolicyFatigueEvidence[];
+  docScore: number;
+  docEvidence: AiPolicyFatigueEvidence[];
+  nowMs: number;
+}): AiPolicyFatigueSignal {
+  const combinedScore = roundWeight(Math.max(input.terseScore, input.docScore * 0.85));
+  const evidence = [...input.terseEvidence, ...input.docEvidence];
+  if (combinedScore <= 0 || evidence.length === 0) return { ...AI_POLICY_FATIGUE_NONE };
+
+  if (combinedScore >= 0.65 || input.terseScore >= TERSE_REJECTION_HIGH_RATE) {
+    return {
+      tier: "high",
+      priorityAdjustment: "defer",
+      priorityFactor: 0.15,
+      deferRecheckUntil: new Date(input.nowMs + AI_POLICY_FATIGUE_DEFER_RECHECK_MS).toISOString(),
+      evidence,
+    };
+  }
+
+  return {
+    tier: "elevated",
+    priorityAdjustment: "deprioritize",
+    priorityFactor: 0.55,
+    deferRecheckUntil: null,
+    evidence,
+  };
+}
+
+function resolveFormalBanVerdict(docs: AiPolicyAssessmentInput["docs"]): Pick<AiPolicyVerdict, "allowed" | "matchedPhrase" | "source"> {
+  if (docs.aiUsage !== null && docs.aiUsage !== undefined && docs.aiUsage.trim().length > 0) {
+    return scanAiPolicyText(docs.aiUsage, "AI-USAGE.md");
+  }
+  if (docs.contributing !== null && docs.contributing !== undefined) {
+    return scanAiPolicyText(docs.contributing, "CONTRIBUTING.md");
+  }
+  return { allowed: true, matchedPhrase: null, source: "none" };
+}
+
+/**
+ * Resolve formal-ban and organic-fatigue signals together. Fatigue never overrides a formal ban and is never
+ * promoted into one — the hard-skip boolean stays authoritative for fan-out skip decisions.
+ */
+export function resolveAiPolicyAssessment(input: AiPolicyAssessmentInput): AiPolicyVerdict {
+  const formal = resolveFormalBanVerdict(input.docs);
+  if (!formal.allowed) {
+    return { ...formal, fatigue: AI_POLICY_FATIGUE_NONE };
+  }
+  const nowMs = Number.isFinite(input.nowMs) ? (input.nowMs as number) : Date.now();
+  const policySource =
+    formal.source !== "none"
+      ? formal.source
+      : input.docs.contributing && input.docs.contributing.trim().length > 0
+        ? "CONTRIBUTING.md"
+        : input.docs.aiUsage && input.docs.aiUsage.trim().length > 0
+          ? "AI-USAGE.md"
+          : "none";
+
+  const terse = detectTerseRejectionFatigue(input.closedPullRequests ?? []);
+  const doc = detectContributingDocFatigueRevision({
+    previous: input.previousContributing,
+    current: input.docs.contributing,
+    source: policySource === "none" ? "CONTRIBUTING.md" : policySource,
+    observedAt: input.contributingObservedAt,
+    nowMs,
+  });
+
+  const fatigue = composeFatigueSignal({
+    terseScore: terse.score,
+    terseEvidence: terse.evidence,
+    docScore: doc.score,
+    docEvidence: doc.evidence,
+    nowMs,
+  });
+
+  return { ...formal, fatigue };
+}
+
 /**
  * Conservative by design (#2305): explicit ban phrases deny a repo, but ambiguous or absent policy text stays
  * allowed. False negatives can be tightened with new literal phrases; false positives would hide valid work.
@@ -44,28 +390,115 @@ const BAN_PHRASES: BanPhrase[] = [
 export function scanAiPolicyText(content: string | null | undefined, source: AiPolicySource): AiPolicyVerdict {
   const text = content ?? "";
   if (source === "none" || text.trim().length === 0) {
-    return { allowed: true, matchedPhrase: null, source };
+    return { allowed: true, matchedPhrase: null, source, fatigue: AI_POLICY_FATIGUE_NONE };
   }
-  for (const ban of BAN_PHRASES) {
-    if (ban.pattern.test(text)) {
-      return { allowed: false, matchedPhrase: ban.phrase, source };
-    }
+  const ban = matchesBanPhrase(text);
+  if (ban) {
+    return { allowed: false, matchedPhrase: ban.phrase, source, fatigue: AI_POLICY_FATIGUE_NONE };
   }
-  return { allowed: true, matchedPhrase: null, source };
+  return { allowed: true, matchedPhrase: null, source, fatigue: AI_POLICY_FATIGUE_NONE };
 }
 
 export function resolveAiPolicyVerdict(docs: {
   aiUsage: string | null | undefined;
   contributing: string | null | undefined;
 }): AiPolicyVerdict {
-  // An empty or whitespace-only AI-USAGE.md carries no policy and must fall through to CONTRIBUTING.md,
-  // exactly as an absent (null/undefined) file does — otherwise a stub AI-USAGE.md silently fails open and
-  // swallows a real ban declared in CONTRIBUTING.md (#2305).
-  if (docs.aiUsage !== null && docs.aiUsage !== undefined && docs.aiUsage.trim().length > 0) {
-    return scanAiPolicyText(docs.aiUsage, "AI-USAGE.md");
-  }
-  if (docs.contributing !== null && docs.contributing !== undefined) {
-    return scanAiPolicyText(docs.contributing, "CONTRIBUTING.md");
-  }
-  return { ...AI_POLICY_ALLOWED };
+  return resolveAiPolicyAssessment({ docs });
 }
+
+/** Cache TTL depends on whether the repo is formally banned or carrying a fatigue signal. Pure. */
+export function aiPolicyVerdictCacheTtlMs(verdict: AiPolicyVerdict): number {
+  if (!verdict.allowed) return AI_POLICY_FORMAL_BAN_CACHE_TTL_MS;
+  if (verdict.fatigue.tier !== "none") return AI_POLICY_FATIGUE_CACHE_TTL_MS;
+  return AI_POLICY_FORMAL_BAN_CACHE_TTL_MS;
+}
+
+export function readAiPolicyVerdictCache(
+  cache: ReadonlyMap<string, AiPolicyVerdictCacheEntry> | Readonly<Record<string, AiPolicyVerdictCacheEntry>>,
+  repoFullName: string,
+  nowMs: number,
+): AiPolicyVerdictCacheEntry | null {
+  const key = normalizeRepoKey(repoFullName);
+  let entry: AiPolicyVerdictCacheEntry | undefined;
+  if (cache instanceof Map) {
+    entry = cache.get(key);
+  } else {
+    entry = (cache as Record<string, AiPolicyVerdictCacheEntry>)[key];
+  }
+  if (!entry) return null;
+  if (!Number.isFinite(nowMs) || nowMs >= entry.expiresAtMs) return null;
+  return entry;
+}
+
+export function writeAiPolicyVerdictCache(
+  cache: Map<string, AiPolicyVerdictCacheEntry>,
+  repoFullName: string,
+  verdict: AiPolicyVerdict,
+  nowMs: number,
+): AiPolicyVerdictCacheEntry {
+  const ttl = aiPolicyVerdictCacheTtlMs(verdict);
+  const entry: AiPolicyVerdictCacheEntry = {
+    repoFullName: normalizeRepoKey(repoFullName),
+    verdict,
+    cachedAtMs: nowMs,
+    expiresAtMs: nowMs + ttl,
+    cacheKind: !verdict.allowed ? "formal_ban" : verdict.fatigue.tier !== "none" ? "fatigue" : "clean",
+  };
+  cache.set(entry.repoFullName, entry);
+  return entry;
+}
+
+/** Apply fatigue priority adjustment to an opportunity rank score. Deferred repos score to zero until recheck. */
+export function applyAiPolicyFatigueToRankScore(
+  rankScore: number,
+  fatigue: AiPolicyFatigueSignal,
+  nowMs: number,
+): { rankScore: number; deferred: boolean } {
+  if (!Number.isFinite(rankScore) || rankScore <= 0) return { rankScore: 0, deferred: false };
+  if (fatigue.priorityAdjustment === "none") return { rankScore, deferred: false };
+  const deferUntilMs = parseInstantMs(fatigue.deferRecheckUntil);
+  if (fatigue.priorityAdjustment === "defer" && deferUntilMs !== null && nowMs < deferUntilMs) {
+    return { rankScore: 0, deferred: true };
+  }
+  const factor = Number.isFinite(fatigue.priorityFactor) ? Math.min(1, Math.max(0, fatigue.priorityFactor)) : 1;
+  return { rankScore: roundWeight(rankScore * factor), deferred: false };
+}
+
+function markdownSafe(value: string): string {
+  return value.replace(/[\r\n]+/gu, " ").replace(/[\\`*_[\]<>|]/gu, "\\$&");
+}
+
+/** Render a deterministic audit block for hard-skip and fatigue decisions. */
+export function renderAiPolicyAssessmentMarkdown(repoFullName: string, verdict: AiPolicyVerdict): string {
+  const lines = [
+    `# AI policy assessment — ${markdownSafe(repoFullName)}`,
+    "",
+    `- hard skip: ${!verdict.allowed}`,
+    `- matched ban phrase: ${verdict.matchedPhrase ? markdownSafe(verdict.matchedPhrase) : "none"}`,
+    `- policy source: ${verdict.source}`,
+    `- fatigue tier: ${verdict.fatigue.tier}`,
+    `- priority adjustment: ${verdict.fatigue.priorityAdjustment}`,
+    `- priority factor: ${verdict.fatigue.priorityFactor.toFixed(6)}`,
+    `- defer recheck until: ${verdict.fatigue.deferRecheckUntil ?? "n/a"}`,
+    "",
+    "## Fatigue evidence",
+    "",
+  ];
+  if (verdict.fatigue.evidence.length === 0) {
+    lines.push("- none");
+  } else {
+    lines.push(
+      "| Kind | Detail | Weight |",
+      "| --- | --- | ---: |",
+      ...verdict.fatigue.evidence.map(
+        (item) => `| ${markdownSafe(item.kind)} | ${markdownSafe(item.detail)} | ${item.weight.toFixed(6)} |`,
+      ),
+    );
+  }
+  return `${lines.join("\n")}\n`;
+}
+
+export const aiPolicyMapInternals = {
+  AI_POLICY_FATIGUE_NONE,
+  AI_POLICY_ALLOWED,
+};

--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -101,10 +101,31 @@ export * from "./plan-export.js";
 export * from "./plan-templates.js";
 export * from "./portfolio/queue.js";
 export {
+  AI_POLICY_FATIGUE_CACHE_TTL_MS,
+  AI_POLICY_FATIGUE_DEFER_RECHECK_MS,
+  AI_POLICY_FORMAL_BAN_CACHE_TTL_MS,
+  applyAiPolicyFatigueToRankScore,
+  aiPolicyVerdictCacheTtlMs,
+  detectContributingDocFatigueRevision,
+  detectTerseRejectionFatigue,
+  inferAiAttributionFromPrMetadata,
+  readAiPolicyVerdictCache,
+  renderAiPolicyAssessmentMarkdown,
+  resolveAiPolicyAssessment,
   resolveAiPolicyVerdict,
   scanAiPolicyText,
+  scanContributingDocFatigueLanguage,
+  writeAiPolicyVerdictCache,
+  type AiAttributedPullRequestMetadata,
+  type AiPolicyAssessmentInput,
+  type AiPolicyFatigueEvidence,
+  type AiPolicyFatigueEvidenceKind,
+  type AiPolicyFatigueSignal,
+  type AiPolicyFatigueTier,
+  type AiPolicyPriorityAdjustment,
   type AiPolicySource,
   type AiPolicyVerdict,
+  type AiPolicyVerdictCacheEntry,
 } from "./ai-policy-map.js";
 export {
   DEFAULT_MINER_GOAL_SPEC,

--- a/packages/gittensory-engine/src/opportunity-metadata.ts
+++ b/packages/gittensory-engine/src/opportunity-metadata.ts
@@ -1,3 +1,4 @@
+import { applyAiPolicyFatigueToRankScore, type AiPolicyFatigueSignal } from "./ai-policy-map.js";
 import { computeMinerGoalLaneFit, isMinerRepoTargetable } from "./miner-goal-lane-fit.js";
 import { DEFAULT_MINER_GOAL_SPEC, type MinerGoalSpec } from "./miner-goal-spec.js";
 import { computeOpportunityCompetition } from "./opportunity-competition.js";
@@ -23,6 +24,8 @@ export type MetadataRankContext = {
   highRiskDuplicateClusters?: number | undefined;
   openPullRequests?: number | undefined;
   goalSpecsByRepo?: Readonly<Record<string, MinerGoalSpec>> | undefined;
+  /** Optional per-repo AI-fatigue signals (#3009) keyed by repo full name. */
+  aiPolicyFatigueByRepo?: Readonly<Record<string, AiPolicyFatigueSignal>> | undefined;
 };
 
 const POSITIVE_LABELS = Object.freeze([
@@ -218,11 +221,20 @@ export function buildMetadataRankInput(
   };
 }
 
+function resolveFatigueSignal(repoFullName: string, context: MetadataRankContext): AiPolicyFatigueSignal | null {
+  const target = repoFullName.trim().toLowerCase();
+  const entries = context.aiPolicyFatigueByRepo ? Object.entries(context.aiPolicyFatigueByRepo) : [];
+  for (const [repo, signal] of entries) {
+    if (repo.trim().toLowerCase() === target) return signal;
+  }
+  return null;
+}
+
 /** Rank metadata-only candidates with the shared opportunity ranker. Pure. */
 export function rankMetadataOpportunities<T extends MetadataCandidateIssue>(
   candidates: readonly T[],
   context: MetadataRankContext,
-): Array<T & OpportunityRankInput & { rankScore: number }> {
+): Array<T & OpportunityRankInput & { rankScore: number; aiPolicyDeferred?: boolean }> {
   const targetableCandidates = candidates.filter((candidate) =>
     isMinerRepoTargetable(resolveGoalSpec(candidate.repoFullName, context)),
   );
@@ -231,6 +243,16 @@ export function rankMetadataOpportunities<T extends MetadataCandidateIssue>(
     ...buildMetadataRankInput(candidate, targetableCandidates, context),
   }));
   /* v8 ignore next */
-  return rankOpportunities(annotated) as Array<T & OpportunityRankInput & { rankScore: number }>;
+  const ranked = rankOpportunities(annotated) as Array<T & OpportunityRankInput & { rankScore: number }>;
+  return ranked.map((candidate) => {
+    const fatigue = resolveFatigueSignal(candidate.repoFullName, context);
+    if (!fatigue || fatigue.priorityAdjustment === "none") return candidate;
+    const adjusted = applyAiPolicyFatigueToRankScore(candidate.rankScore, fatigue, context.nowMs);
+    return {
+      ...candidate,
+      rankScore: adjusted.rankScore,
+      ...(adjusted.deferred ? { aiPolicyDeferred: true as const } : {}),
+    };
+  });
 }
 /* v8 ignore stop */

--- a/packages/gittensory-engine/test/ai-policy-map.test.ts
+++ b/packages/gittensory-engine/test/ai-policy-map.test.ts
@@ -1,0 +1,237 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  AI_POLICY_FATIGUE_CACHE_TTL_MS,
+  AI_POLICY_FORMAL_BAN_CACHE_TTL_MS,
+  applyAiPolicyFatigueToRankScore,
+  aiPolicyVerdictCacheTtlMs,
+  detectContributingDocFatigueRevision,
+  detectTerseRejectionFatigue,
+  inferAiAttributionFromPrMetadata,
+  readAiPolicyVerdictCache,
+  renderAiPolicyAssessmentMarkdown,
+  resolveAiPolicyAssessment,
+  resolveAiPolicyVerdict,
+  scanAiPolicyText,
+  scanContributingDocFatigueLanguage,
+  writeAiPolicyVerdictCache,
+} from "../dist/index.js";
+
+const NOW_MS = Date.parse("2026-07-04T18:00:00.000Z");
+const FATIGUE_NONE = {
+  tier: "none" as const,
+  priorityAdjustment: "none" as const,
+  priorityFactor: 1,
+  deferRecheckUntil: null,
+  evidence: [],
+};
+
+function closedAiPr(number: number, terseRejection = true) {
+  return {
+    number,
+    state: "closed" as const,
+    merged: false,
+    aiAttributed: true,
+    terseRejection,
+  };
+}
+
+test("barrel: exports AI policy fatigue APIs (#3009)", () => {
+  assert.equal(AI_POLICY_FATIGUE_CACHE_TTL_MS < AI_POLICY_FORMAL_BAN_CACHE_TTL_MS, true);
+  assert.equal(typeof resolveAiPolicyAssessment, "function");
+  assert.equal(typeof detectTerseRejectionFatigue, "function");
+  assert.equal(typeof applyAiPolicyFatigueToRankScore, "function");
+  assert.equal(typeof writeAiPolicyVerdictCache, "function");
+});
+
+test("scanAiPolicyText keeps fatigue distinct from the hard-skip boolean", () => {
+  assert.deepEqual(scanAiPolicyText("Please include tests.", "CONTRIBUTING.md"), {
+    allowed: true,
+    matchedPhrase: null,
+    source: "CONTRIBUTING.md",
+    fatigue: FATIGUE_NONE,
+  });
+  assert.deepEqual(scanAiPolicyText("No AI-generated pull requests.", "CONTRIBUTING.md"), {
+    allowed: false,
+    matchedPhrase: "no ai-generated pull requests",
+    source: "CONTRIBUTING.md",
+    fatigue: FATIGUE_NONE,
+  });
+});
+
+test("resolveAiPolicyVerdict remains backward compatible with a default fatigue tier", () => {
+  assert.deepEqual(resolveAiPolicyVerdict({ aiUsage: null, contributing: null }), {
+    allowed: true,
+    matchedPhrase: null,
+    source: "none",
+    fatigue: FATIGUE_NONE,
+  });
+});
+
+test("detectTerseRejectionFatigue ignores repos without enough AI-attributed closed PRs", () => {
+  assert.deepEqual(detectTerseRejectionFatigue([closedAiPr(1), closedAiPr(2)]), {
+    score: 0,
+    evidence: [],
+  });
+});
+
+test("detectTerseRejectionFatigue flags concentrated terse rejections on AI-attributed PRs", () => {
+  const result = detectTerseRejectionFatigue([
+    closedAiPr(1),
+    closedAiPr(2),
+    closedAiPr(3),
+    closedAiPr(4, false),
+  ]);
+  assert.ok(result.score >= 0.55);
+  assert.equal(result.evidence[0]?.kind, "terse_rejection_pattern");
+});
+
+test("inferAiAttributionFromPrMetadata uses bot markers and labels without reading source", () => {
+  assert.equal(inferAiAttributionFromPrMetadata({ authorLogin: "dependabot[bot]" }), true);
+  assert.equal(inferAiAttributionFromPrMetadata({ labels: ["copilot"] }), true);
+  assert.equal(inferAiAttributionFromPrMetadata({ labels: ["bug"] }), false);
+});
+
+test("scanContributingDocFatigueLanguage detects AI/automation language short of a ban phrase", () => {
+  const evidence = scanContributingDocFatigueLanguage(
+    "Please disclose AI-assisted contributions in your PR description.",
+    "CONTRIBUTING.md",
+  );
+  assert.ok(evidence.some((item) => item.kind === "contributing_doc_language"));
+});
+
+test("detectContributingDocFatigueRevision weights newly added AI language more heavily", () => {
+  const result = detectContributingDocFatigueRevision({
+    previous: "Please include tests.",
+    current: "Please disclose AI-assisted contributions in your PR description.",
+    source: "CONTRIBUTING.md",
+    observedAt: "2026-07-04T12:00:00.000Z",
+    nowMs: NOW_MS,
+  });
+  assert.ok(result.score > 0);
+  assert.ok(result.evidence.length > 0);
+});
+
+test("resolveAiPolicyAssessment combines fatigue-only and formal-ban paths independently", () => {
+  const fatigueOnly = resolveAiPolicyAssessment({
+    docs: {
+      aiUsage: null,
+      contributing: "Please disclose AI-assisted contributions in your PR description.",
+    },
+    closedPullRequests: [closedAiPr(1), closedAiPr(2), closedAiPr(3)],
+    nowMs: NOW_MS,
+  });
+  assert.equal(fatigueOnly.allowed, true);
+  assert.notEqual(fatigueOnly.fatigue.tier, "none");
+
+  const formalBan = resolveAiPolicyAssessment({
+    docs: {
+      aiUsage: null,
+      contributing: "No AI-generated pull requests.",
+    },
+    closedPullRequests: [closedAiPr(1), closedAiPr(2), closedAiPr(3)],
+    nowMs: NOW_MS,
+  });
+  assert.equal(formalBan.allowed, false);
+  assert.equal(formalBan.fatigue.tier, "none");
+});
+
+test("applyAiPolicyFatigueToRankScore deprioritizes and defers without hard-skipping", () => {
+  const deprioritized = applyAiPolicyFatigueToRankScore(
+    0.8,
+    {
+      tier: "elevated",
+      priorityAdjustment: "deprioritize",
+      priorityFactor: 0.55,
+      deferRecheckUntil: null,
+      evidence: [],
+    },
+    NOW_MS,
+  );
+  assert.equal(deprioritized.rankScore, 0.44);
+  assert.equal(deprioritized.deferred, false);
+
+  const deferred = applyAiPolicyFatigueToRankScore(
+    0.8,
+    {
+      tier: "high",
+      priorityAdjustment: "defer",
+      priorityFactor: 0.15,
+      deferRecheckUntil: "2026-07-06T00:00:00.000Z",
+      evidence: [],
+    },
+    NOW_MS,
+  );
+  assert.equal(deferred.rankScore, 0);
+  assert.equal(deferred.deferred, true);
+});
+
+test("writeAiPolicyVerdictCache uses a shorter TTL for fatigue than formal bans", () => {
+  const cache = new Map();
+  const fatigueEntry = writeAiPolicyVerdictCache(
+    cache,
+    "acme/widgets",
+    resolveAiPolicyAssessment({
+      docs: {
+        aiUsage: null,
+        contributing: "Please disclose AI-assisted contributions in your PR description.",
+      },
+      closedPullRequests: [closedAiPr(1), closedAiPr(2), closedAiPr(3)],
+      nowMs: NOW_MS,
+    }),
+    NOW_MS,
+  );
+  assert.equal(fatigueEntry.cacheKind, "fatigue");
+  assert.equal(fatigueEntry.expiresAtMs - NOW_MS, AI_POLICY_FATIGUE_CACHE_TTL_MS);
+
+  const banEntry = writeAiPolicyVerdictCache(
+    cache,
+    "acme/banned",
+    resolveAiPolicyAssessment({
+      docs: { aiUsage: null, contributing: "No AI-generated pull requests." },
+      nowMs: NOW_MS,
+    }),
+    NOW_MS,
+  );
+  assert.equal(banEntry.cacheKind, "formal_ban");
+  assert.equal(aiPolicyVerdictCacheTtlMs(banEntry.verdict), AI_POLICY_FORMAL_BAN_CACHE_TTL_MS);
+});
+
+test("readAiPolicyVerdictCache returns null after expiry", () => {
+  const cache = new Map();
+  writeAiPolicyVerdictCache(
+    cache,
+    "acme/widgets",
+    resolveAiPolicyVerdict({ aiUsage: null, contributing: null }),
+    NOW_MS,
+  );
+  assert.ok(readAiPolicyVerdictCache(cache, "acme/widgets", NOW_MS));
+  assert.equal(readAiPolicyVerdictCache(cache, "acme/widgets", NOW_MS + AI_POLICY_FORMAL_BAN_CACHE_TTL_MS + 1), null);
+});
+
+test("renderAiPolicyAssessmentMarkdown renders hard-skip and fatigue evidence for observability", () => {
+  const verdict = resolveAiPolicyAssessment({
+    docs: {
+      aiUsage: null,
+      contributing: "Please disclose AI-assisted contributions in your PR description.",
+    },
+    closedPullRequests: [closedAiPr(1), closedAiPr(2), closedAiPr(3)],
+    nowMs: NOW_MS,
+  });
+  const markdown = renderAiPolicyAssessmentMarkdown("acme/widgets", verdict);
+  assert.match(markdown, /hard skip: false/u);
+  assert.match(markdown, /fatigue tier:/u);
+  assert.match(markdown, /Fatigue evidence/u);
+});
+
+test("REGRESSION (#3009): formal-ban repos still hard-skip and fatigue never promotes into a ban", () => {
+  const verdict = resolveAiPolicyAssessment({
+    docs: { aiUsage: null, contributing: "AI-generated PRs are rejected by maintainers." },
+    closedPullRequests: [closedAiPr(1), closedAiPr(2), closedAiPr(3), closedAiPr(4)],
+    nowMs: NOW_MS,
+  });
+  assert.equal(verdict.allowed, false);
+  assert.equal(verdict.matchedPhrase, "ai-generated prs are rejected");
+  assert.equal(verdict.fatigue.tier, "none");
+});

--- a/packages/gittensory-miner/lib/opportunity-fanout.d.ts
+++ b/packages/gittensory-miner/lib/opportunity-fanout.d.ts
@@ -1,6 +1,21 @@
+import type {
+  AiAttributedPullRequestMetadata,
+  AiPolicyFatigueSignal,
+} from "@jsonbored/gittensory-engine";
+
 export type FanoutTarget = {
   owner: string;
   repo: string;
+};
+
+export type FanoutOptions = {
+  apiBaseUrl?: string;
+  concurrency?: number;
+  perPage?: number;
+  nowMs?: number;
+  closedPullRequestsByRepo?: Record<string, readonly AiAttributedPullRequestMetadata[]>;
+  previousContributingByRepo?: Record<string, string | null>;
+  contributingObservedAtByRepo?: Record<string, string | null>;
 };
 
 export type RawCandidateIssue = {
@@ -16,6 +31,7 @@ export type RawCandidateIssue = {
   htmlUrl: string | null;
   aiPolicyAllowed: true;
   aiPolicySource: "AI-USAGE.md" | "CONTRIBUTING.md" | "none";
+  aiPolicyFatigue: AiPolicyFatigueSignal;
 };
 
 export type CandidateIssueWarning = {
@@ -34,39 +50,23 @@ export type CandidateIssueSummary = {
 export function fetchCandidateIssuesWithSummary(
   targets: FanoutTarget[],
   githubToken: string,
-  options?: {
-    apiBaseUrl?: string;
-    concurrency?: number;
-    perPage?: number;
-  },
+  options?: FanoutOptions,
 ): Promise<CandidateIssueSummary>;
 
 export function fetchCandidateIssues(
   targets: FanoutTarget[],
   githubToken: string,
-  options?: {
-    apiBaseUrl?: string;
-    concurrency?: number;
-    perPage?: number;
-  },
+  options?: FanoutOptions,
 ): Promise<RawCandidateIssue[]>;
 
 export function searchCandidateIssuesWithSummary(
   searchQuery: string,
   githubToken: string,
-  options?: {
-    apiBaseUrl?: string;
-    concurrency?: number;
-    perPage?: number;
-  },
+  options?: FanoutOptions,
 ): Promise<CandidateIssueSummary>;
 
 export function searchCandidateIssues(
   searchQuery: string,
   githubToken: string,
-  options?: {
-    apiBaseUrl?: string;
-    concurrency?: number;
-    perPage?: number;
-  },
+  options?: FanoutOptions,
 ): Promise<RawCandidateIssue[]>;

--- a/packages/gittensory-miner/lib/opportunity-fanout.js
+++ b/packages/gittensory-miner/lib/opportunity-fanout.js
@@ -147,16 +147,16 @@ async function fetchRepoDoc(target, path, githubToken, options, summary, warning
 
 async function resolveRepoAiPolicy(target, githubToken, options, summary, warnings) {
   const aiUsage = await fetchRepoDoc(target, "AI-USAGE.md", githubToken, options, summary, warnings);
-  // Short-circuit only on AI-USAGE.md that has real content. A present-but-blank AI-USAGE.md must still fall
-  // through to CONTRIBUTING.md — otherwise a stub AI-USAGE.md silently fails open and swallows a ban declared in
-  // CONTRIBUTING.md (the exact case resolveAiPolicyVerdict was fixed to handle in #2900, which can only fire if
-  // both docs reach it).
-  if (aiUsage !== null && aiUsage.trim().length > 0) {
-    return resolveAiPolicyAssessment({
+  const hasAiUsage = aiUsage !== null && aiUsage.trim().length > 0;
+  // Short-circuit only on AI-USAGE.md that declares a formal ban. A present-but-permissive AI-USAGE.md must still
+  // fall through to CONTRIBUTING.md so metadata-derived fatigue (doc revision + closed-PR signals) can attach.
+  if (hasAiUsage) {
+    const preliminary = resolveAiPolicyAssessment({
       docs: { aiUsage, contributing: null },
       closedPullRequests: options.closedPullRequestsByRepo?.[target.repoFullName] ?? [],
       nowMs: options.nowMs,
     });
+    if (!preliminary.allowed) return preliminary;
   }
   const contributing = await fetchRepoDoc(
     target,
@@ -167,7 +167,7 @@ async function resolveRepoAiPolicy(target, githubToken, options, summary, warnin
     warnings,
   );
   return resolveAiPolicyAssessment({
-    docs: { aiUsage: null, contributing },
+    docs: { aiUsage: hasAiUsage ? aiUsage : null, contributing },
     previousContributing: options.previousContributingByRepo?.[target.repoFullName] ?? null,
     contributingObservedAt: options.contributingObservedAtByRepo?.[target.repoFullName] ?? null,
     closedPullRequests: options.closedPullRequestsByRepo?.[target.repoFullName] ?? [],
@@ -303,6 +303,10 @@ function normalizeOptions(options = {}) {
         : defaultApiBaseUrl,
     concurrency: normalizeLimit(options.concurrency, defaultConcurrency, 1, 10),
     perPage: normalizeLimit(options.perPage, defaultPerPage, 1, 100),
+    nowMs: options.nowMs,
+    closedPullRequestsByRepo: options.closedPullRequestsByRepo ?? {},
+    previousContributingByRepo: options.previousContributingByRepo ?? {},
+    contributingObservedAtByRepo: options.contributingObservedAtByRepo ?? {},
   };
 }
 

--- a/packages/gittensory-miner/lib/opportunity-fanout.js
+++ b/packages/gittensory-miner/lib/opportunity-fanout.js
@@ -1,5 +1,5 @@
 import { Buffer } from "node:buffer";
-import { resolveAiPolicyVerdict } from "@jsonbored/gittensory-engine";
+import { resolveAiPolicyAssessment } from "@jsonbored/gittensory-engine";
 
 const defaultApiBaseUrl = "https://api.github.com";
 const defaultConcurrency = 5;
@@ -152,7 +152,11 @@ async function resolveRepoAiPolicy(target, githubToken, options, summary, warnin
   // CONTRIBUTING.md (the exact case resolveAiPolicyVerdict was fixed to handle in #2900, which can only fire if
   // both docs reach it).
   if (aiUsage !== null && aiUsage.trim().length > 0) {
-    return resolveAiPolicyVerdict({ aiUsage, contributing: null });
+    return resolveAiPolicyAssessment({
+      docs: { aiUsage, contributing: null },
+      closedPullRequests: options.closedPullRequestsByRepo?.[target.repoFullName] ?? [],
+      nowMs: options.nowMs,
+    });
   }
   const contributing = await fetchRepoDoc(
     target,
@@ -162,7 +166,13 @@ async function resolveRepoAiPolicy(target, githubToken, options, summary, warnin
     summary,
     warnings,
   );
-  return resolveAiPolicyVerdict({ aiUsage: null, contributing });
+  return resolveAiPolicyAssessment({
+    docs: { aiUsage: null, contributing },
+    previousContributing: options.previousContributingByRepo?.[target.repoFullName] ?? null,
+    contributingObservedAt: options.contributingObservedAtByRepo?.[target.repoFullName] ?? null,
+    closedPullRequests: options.closedPullRequestsByRepo?.[target.repoFullName] ?? [],
+    nowMs: options.nowMs,
+  });
 }
 
 function labelNames(labels) {
@@ -176,7 +186,7 @@ function labelNames(labels) {
     .filter((name) => name.length > 0);
 }
 
-function normalizeIssue(target, issue, policySource) {
+function normalizeIssue(target, issue, policyVerdict) {
   if (!issue || typeof issue !== "object" || issue.pull_request) return null;
   if (!Number.isInteger(issue.number) || issue.number <= 0) return null;
   if (typeof issue.title !== "string" || issue.title.trim().length === 0) return null;
@@ -191,8 +201,9 @@ function normalizeIssue(target, issue, policySource) {
     createdAt: typeof issue.created_at === "string" ? issue.created_at : null,
     updatedAt: typeof issue.updated_at === "string" ? issue.updated_at : null,
     htmlUrl: typeof issue.html_url === "string" ? issue.html_url : null,
-    aiPolicyAllowed: true,
-    aiPolicySource: policySource,
+    aiPolicyAllowed: policyVerdict.allowed,
+    aiPolicySource: policyVerdict.source,
+    aiPolicyFatigue: policyVerdict.fatigue,
   };
 }
 
@@ -222,7 +233,7 @@ async function fetchTargetIssues(target, githubToken, options, summary, warnings
       return [];
     }
     return payload
-      .map((issue) => normalizeIssue(target, issue, verdict.source))
+      .map((issue) => normalizeIssue(target, issue, verdict))
       .filter((issue) => issue !== null);
   } catch (error) {
     warnings.push(
@@ -354,7 +365,7 @@ export async function searchCandidateIssuesWithSummary(searchQuery, githubToken,
     if (!target) continue;
     const policy = policiesByKey.get(targetKey(target));
     if (!policy?.allowed) continue;
-    const normalizedIssue = normalizeIssue(target, item, policy.source);
+    const normalizedIssue = normalizeIssue(target, item, policy);
     if (normalizedIssue) issues.push(normalizedIssue);
   }
 

--- a/packages/gittensory-miner/lib/opportunity-ranker.js
+++ b/packages/gittensory-miner/lib/opportunity-ranker.js
@@ -46,6 +46,9 @@ function normalizeCandidate(candidate) {
       candidate.aiPolicySource === "none"
         ? candidate.aiPolicySource
         : "none",
+    ...(candidate.aiPolicyFatigue && typeof candidate.aiPolicyFatigue === "object"
+      ? { aiPolicyFatigue: candidate.aiPolicyFatigue }
+      : {}),
   };
 }
 
@@ -59,12 +62,26 @@ function buildGoalSpecsByRepo(options = {}) {
   return goalSpecsByRepo;
 }
 
-function buildRankContext(options = {}) {
+function buildAiPolicyFatigueByRepo(candidates) {
+  const fatigueByRepo = {};
+  for (const candidate of Array.isArray(candidates) ? candidates : []) {
+    const repoFullName = typeof candidate?.repoFullName === "string" ? candidate.repoFullName.trim() : "";
+    if (!repoFullName || !candidate?.aiPolicyFatigue) continue;
+    fatigueByRepo[repoFullName] = candidate.aiPolicyFatigue;
+  }
+  return fatigueByRepo;
+}
+
+function buildRankContext(candidates, options = {}) {
   return {
     nowMs: finiteEpochMs(options.nowMs),
     highRiskDuplicateClusters: finiteNonNegativeInt(options.highRiskDuplicateClusters),
     openPullRequests: finiteNonNegativeInt(options.openPullRequests),
     goalSpecsByRepo: buildGoalSpecsByRepo(options),
+    aiPolicyFatigueByRepo: {
+      ...buildAiPolicyFatigueByRepo(candidates),
+      ...(options.aiPolicyFatigueByRepo ?? {}),
+    },
   };
 }
 
@@ -103,12 +120,12 @@ function rankedUsesDefaultGoalSpec(ranked, options = {}) {
  */
 export function rankCandidateIssues(candidates, options = {}) {
   const { normalized } = collectCandidates(candidates);
-  return rankMetadataOpportunities(normalized, buildRankContext(options));
+  return rankMetadataOpportunities(normalized, buildRankContext(normalized, options));
 }
 
 export function rankCandidateIssuesWithSummary(candidates, options = {}) {
   const { normalized, skippedInvalid } = collectCandidates(candidates);
-  const ranked = rankMetadataOpportunities(normalized, buildRankContext(options));
+  const ranked = rankMetadataOpportunities(normalized, buildRankContext(normalized, options));
   return {
     issues: ranked,
     skippedInvalid,

--- a/test/unit/miner-ai-policy-map.test.ts
+++ b/test/unit/miner-ai-policy-map.test.ts
@@ -1,7 +1,19 @@
 import { describe, expect, it } from "vitest";
-import { resolveAiPolicyVerdict, scanAiPolicyText } from "../../packages/gittensory-engine/src/ai-policy-map";
+import {
+  resolveAiPolicyAssessment,
+  resolveAiPolicyVerdict,
+  scanAiPolicyText,
+} from "../../packages/gittensory-engine/src/ai-policy-map";
 
-describe("miner AI policy map (#2305)", () => {
+const FATIGUE_NONE = {
+  tier: "none" as const,
+  priorityAdjustment: "none" as const,
+  priorityFactor: 1,
+  deferRecheckUntil: null,
+  evidence: [],
+};
+
+describe("miner AI policy map (#2305, #3009)", () => {
   it.each([
     ["We allow bug fixes, but no AI-generated pull requests.", "no ai-generated pull requests"],
     ["AI-generated PRs are rejected by maintainers.", "ai-generated prs are rejected"],
@@ -12,6 +24,7 @@ describe("miner AI policy map (#2305)", () => {
       allowed: false,
       matchedPhrase: phrase,
       source: "CONTRIBUTING.md",
+      fatigue: FATIGUE_NONE,
     });
   });
 
@@ -20,21 +33,25 @@ describe("miner AI policy map (#2305)", () => {
       allowed: true,
       matchedPhrase: null,
       source: "CONTRIBUTING.md",
+      fatigue: FATIGUE_NONE,
     });
     expect(scanAiPolicyText("", "AI-USAGE.md")).toEqual({
       allowed: true,
       matchedPhrase: null,
       source: "AI-USAGE.md",
+      fatigue: FATIGUE_NONE,
     });
     expect(scanAiPolicyText(null, "CONTRIBUTING.md")).toEqual({
       allowed: true,
       matchedPhrase: null,
       source: "CONTRIBUTING.md",
+      fatigue: FATIGUE_NONE,
     });
     expect(scanAiPolicyText(undefined, "none")).toEqual({
       allowed: true,
       matchedPhrase: null,
       source: "none",
+      fatigue: FATIGUE_NONE,
     });
   });
 
@@ -48,6 +65,7 @@ describe("miner AI policy map (#2305)", () => {
       allowed: true,
       matchedPhrase: null,
       source: "AI-USAGE.md",
+      fatigue: FATIGUE_NONE,
     });
   });
 
@@ -56,20 +74,43 @@ describe("miner AI policy map (#2305)", () => {
       allowed: false,
       matchedPhrase: "ai-generated prs are rejected",
       source: "CONTRIBUTING.md",
+      fatigue: FATIGUE_NONE,
     });
     expect(resolveAiPolicyVerdict({ aiUsage: null, contributing: null })).toEqual({
       allowed: true,
       matchedPhrase: null,
       source: "none",
+      fatigue: FATIGUE_NONE,
     });
   });
 
   it("treats an empty, whitespace-only, or undefined AI-USAGE.md as absent and falls back to CONTRIBUTING.md", () => {
-    const banned = { allowed: false, matchedPhrase: "ai-generated prs are rejected", source: "CONTRIBUTING.md" } as const;
+    const banned = {
+      allowed: false,
+      matchedPhrase: "ai-generated prs are rejected",
+      source: "CONTRIBUTING.md",
+      fatigue: FATIGUE_NONE,
+    } as const;
     const contributing = "AI-generated PRs are not accepted.";
-    // A stub AI-USAGE.md carries no policy and must not fail open over a real ban in CONTRIBUTING.md.
     expect(resolveAiPolicyVerdict({ aiUsage: "", contributing })).toEqual(banned);
     expect(resolveAiPolicyVerdict({ aiUsage: "   \n  ", contributing })).toEqual(banned);
     expect(resolveAiPolicyVerdict({ aiUsage: undefined, contributing })).toEqual(banned);
+  });
+
+  it("detects organic AI-fatigue without promoting it to a hard skip (#3009)", () => {
+    const verdict = resolveAiPolicyAssessment({
+      docs: {
+        aiUsage: null,
+        contributing: "Please disclose AI-assisted contributions in your PR description.",
+      },
+      closedPullRequests: [
+        { number: 1, state: "closed", merged: false, aiAttributed: true, terseRejection: true },
+        { number: 2, state: "closed", merged: false, aiAttributed: true, terseRejection: true },
+        { number: 3, state: "closed", merged: false, aiAttributed: true, terseRejection: true },
+      ],
+    });
+    expect(verdict.allowed).toBe(true);
+    expect(verdict.fatigue.tier).not.toBe("none");
+    expect(verdict.fatigue.priorityAdjustment).not.toBe("none");
   });
 });

--- a/test/unit/miner-opportunity-fanout.test.ts
+++ b/test/unit/miner-opportunity-fanout.test.ts
@@ -315,4 +315,62 @@ describe("fetchCandidateIssues (#2307)", () => {
       { repoFullName: "*", stage: "search", message: "GitHub returned 502" },
     ]);
   });
+
+  it("passes closed-PR fatigue metadata through normalizeOptions to candidate issues (#3009)", async () => {
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/contents/AI-USAGE.md")) return jsonResponse({}, { status: 404 });
+      if (url.endsWith("/contents/CONTRIBUTING.md")) return contentResponse("Contributions welcome.");
+      if (url.includes("/issues?")) return jsonResponse([issue(7)]);
+      return jsonResponse({}, { status: 404 });
+    });
+
+    const closedPullRequestsByRepo = {
+      "acme/widgets": [
+        { number: 1, state: "closed", merged: false, aiAttributed: true, terseRejection: true },
+        { number: 2, state: "closed", merged: false, aiAttributed: true, terseRejection: true },
+        { number: 3, state: "closed", merged: false, aiAttributed: true, terseRejection: true },
+      ],
+    };
+
+    const result = await fetchCandidateIssues([{ owner: "acme", repo: "widgets" }], "", {
+      apiBaseUrl: API,
+      nowMs: Date.parse("2026-07-04T12:00:00.000Z"),
+      closedPullRequestsByRepo,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]?.aiPolicyAllowed).toBe(true);
+    expect(result[0]?.aiPolicyFatigue.tier).not.toBe("none");
+    expect(result[0]?.aiPolicyFatigue.priorityAdjustment).not.toBe("none");
+  });
+
+  it("fetches CONTRIBUTING.md for fatigue when AI-USAGE.md is permissive (#3009)", async () => {
+    const calls: string[] = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      calls.push(url);
+      if (url.endsWith("/contents/AI-USAGE.md")) {
+        return contentResponse("AI-assisted contributions are allowed when reviewed.");
+      }
+      if (url.endsWith("/contents/CONTRIBUTING.md")) {
+        return contentResponse("Please disclose AI-assisted contributions in your PR description.");
+      }
+      if (url.includes("/issues?")) return jsonResponse([issue(9)]);
+      return jsonResponse({}, { status: 404 });
+    });
+
+    const result = await fetchCandidateIssues([{ owner: "acme", repo: "widgets" }], "", {
+      apiBaseUrl: API,
+      nowMs: Date.parse("2026-07-04T12:00:00.000Z"),
+      previousContributingByRepo: { "acme/widgets": "Please include tests." },
+      contributingObservedAtByRepo: { "acme/widgets": "2026-07-04T12:00:00.000Z" },
+    });
+
+    expect(calls.some((url) => url.endsWith("/contents/CONTRIBUTING.md"))).toBe(true);
+    expect(result).toHaveLength(1);
+    expect(result[0]?.aiPolicySource).toBe("AI-USAGE.md");
+    expect(result[0]?.aiPolicyAllowed).toBe(true);
+    expect(result[0]?.aiPolicyFatigue.tier).not.toBe("none");
+  });
 });

--- a/test/unit/miner-opportunity-fanout.test.ts
+++ b/test/unit/miner-opportunity-fanout.test.ts
@@ -87,6 +87,13 @@ describe("fetchCandidateIssues (#2307)", () => {
         htmlUrl: "https://github.com/acme/widgets/issues/7",
         aiPolicyAllowed: true,
         aiPolicySource: "CONTRIBUTING.md",
+        aiPolicyFatigue: {
+          tier: "none",
+          priorityAdjustment: "none",
+          priorityFactor: 1,
+          deferRecheckUntil: null,
+          evidence: [],
+        },
       },
     ]);
     expect(calls.every((call) => call.method === "GET")).toBe(true);

--- a/test/unit/miner-opportunity-ranker.test.ts
+++ b/test/unit/miner-opportunity-ranker.test.ts
@@ -11,6 +11,14 @@ import {
 
 const NOW = Date.parse("2026-07-03T12:00:00.000Z");
 
+const FATIGUE_NONE = {
+  tier: "none" as const,
+  priorityAdjustment: "none" as const,
+  priorityFactor: 1,
+  deferRecheckUntil: null,
+  evidence: [],
+};
+
 function rawIssue(overrides: Record<string, unknown> = {}) {
   return {
     owner: "acme",
@@ -25,6 +33,7 @@ function rawIssue(overrides: Record<string, unknown> = {}) {
     htmlUrl: "https://github.com/acme/widgets/issues/42",
     aiPolicyAllowed: true as const,
     aiPolicySource: "CONTRIBUTING.md" as const,
+    aiPolicyFatigue: FATIGUE_NONE,
     ...overrides,
   };
 }

--- a/test/unit/miner-opportunity-ranker.test.ts
+++ b/test/unit/miner-opportunity-ranker.test.ts
@@ -273,4 +273,24 @@ describe("rankCandidateIssues (#2302 follow-up)", () => {
     expect(ranked[0]?.freshness).toBeGreaterThan(0);
     vi.useRealTimers();
   });
+
+  it("deprioritizes candidates carrying an AI-fatigue signal without hard-skipping them (#3009)", () => {
+    const baseline = rankCandidateIssues([rawIssue()], { nowMs: NOW })[0]?.rankScore ?? 0;
+    const fatigued = rankCandidateIssues(
+      [
+        rawIssue({
+          aiPolicyFatigue: {
+            tier: "elevated",
+            priorityAdjustment: "deprioritize",
+            priorityFactor: 0.55,
+            deferRecheckUntil: null,
+            evidence: [{ kind: "terse_rejection_pattern", detail: "3/3 terse", weight: 1 }],
+          },
+        }),
+      ],
+      { nowMs: NOW },
+    )[0]?.rankScore;
+    expect(fatigued).toBeLessThan(baseline);
+    expect(fatigued).toBeGreaterThan(0);
+  });
 });


### PR DESCRIPTION
## Summary

Closes #3009.

Extends `@jsonbored/gittensory-engine`'s AI policy map with a distinct organic AI-fatigue tier alongside the existing hard-skip boolean. Fatigue is derived from metadata only — concentrated terse rejections on AI-attributed closed PRs and recency-weighted AI/automation language in contributing docs that stops short of a formal ban phrase — and never promotes into or overrides the hard-skip path.

The engine exposes priority-adjustment output (`deprioritize` / `defer`), per-repo cache helpers with a shorter recheck window for fatigue than formal bans, audit markdown for observability, and ranking integration via `aiPolicyFatigueByRepo`. The miner fan-out/ranker passes fatigue verdicts through to candidate ranking without hard-skipping fatigued repos.

## Changed files

| File | Change |
| ---- | ------ |
| `packages/gittensory-engine/src/ai-policy-map.ts` | Fatigue tier on `AiPolicyVerdict`, metadata detectors, cache, rank adjustment, audit markdown. |
| `packages/gittensory-engine/src/opportunity-metadata.ts` | Apply fatigue priority factor during `rankMetadataOpportunities()`. |
| `packages/gittensory-engine/src/index.ts` | Export new AI policy fatigue APIs. |
| `packages/gittensory-engine/test/ai-policy-map.test.ts` | Engine unit/regression tests. |
| `packages/gittensory-engine/README.md` | Document fatigue tier and usage. |
| `packages/gittensory-miner/lib/opportunity-fanout.js` | Resolve full assessments and attach fatigue to fan-out candidates. |
| `packages/gittensory-miner/lib/opportunity-ranker.js` | Pass per-repo fatigue into rank context. |
| `test/unit/miner-ai-policy-map.test.ts` | Updated verdict shape + fatigue regression. |
| `test/unit/miner-opportunity-ranker.test.ts` | Deprioritize-without-skip ranking test. |

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

Linked issue: #3009.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:ci` — run before push (~8 min).
- [x] `npm audit --audit-level=moderate`