### PR TITLE
feat(enrichment): expand EOL runtime pin parsing for asdf and BE languages

### DIFF
--- a/review-enrichment/src/analyzers/eol-check.ts
+++ b/review-enrichment/src/analyzers/eol-check.ts
@@ -42,6 +42,36 @@ function leadingVersion(value: string): string | null {
   return /^v?(\d+(?:\.\d+)*)/.exec(value.trim())?.[1] ?? null;
 }
 
+// asdf `.tool-versions` plugin name → endoflife.date product slug. Includes common aliases (`node`, `golang`).
+const TOOL_VERSION_PRODUCT: Record<string, string> = {
+  nodejs: "nodejs",
+  node: "nodejs",
+  python: "python",
+  ruby: "ruby",
+  golang: "go",
+  go: "go",
+  php: "php",
+  java: "oracle-jdk",
+  rust: "rust",
+  terraform: "terraform",
+  elixir: "elixir",
+  kotlin: "kotlin",
+};
+
+/** Parse one asdf `.tool-versions` line (`tool version [system]`) into an EOL product + version. Pure. */
+export function parseToolVersionLine(
+  line: string,
+): { product: string; version: string } | null {
+  const trimmed = line.trim();
+  if (!trimmed || trimmed.startsWith("#")) return null;
+  const match = /^([A-Za-z0-9_-]+)\s+(\S+)/.exec(trimmed);
+  if (!match) return null;
+  const product = TOOL_VERSION_PRODUCT[match[1]!.toLowerCase()];
+  const version = leadingVersion(match[2]!);
+  if (!product || !version) return null;
+  return { product, version };
+}
+
 /** True for a Dockerfile the FROM-pin parser understands: the bare name `Dockerfile` (any casing),
  *  a suffixed variant like `Dockerfile.prod` / `Dockerfile.dev` (the prior scheduler gate was
  *  `/^Dockerfile(?:\..*)?$/` and must not regress), or a `*.dockerfile` (e.g. `web.dockerfile`).
@@ -121,6 +151,23 @@ export function extractVersionPins(
         // tfenv/asdf pin file — same leading-version format, product is Terraform.
         const version = leadingVersion(line);
         if (version) pins.push({ file: file.path, product: "terraform", version });
+      } else if (base === ".elixir-version") {
+        // asdf/exenv pin file — same leading-version format, product is Elixir.
+        const version = leadingVersion(line);
+        if (version) pins.push({ file: file.path, product: "elixir", version });
+      } else if (base === ".kotlin-version") {
+        // asdf/kotlin pin file — same leading-version format, product is Kotlin.
+        const version = leadingVersion(line);
+        if (version) pins.push({ file: file.path, product: "kotlin", version });
+      } else if (base === ".tool-versions") {
+        // asdf multi-tool pin file — one `tool version` pair per line.
+        const parsed = parseToolVersionLine(line);
+        if (parsed)
+          pins.push({
+            file: file.path,
+            product: parsed.product,
+            version: parsed.version,
+          });
       } else if (base === "go.mod") {
         // Module language version (`go 1.21`) and optional toolchain pin (`toolchain go1.22.0`).
         const match = /^go\s+(\d+\.\d+)/.exec(line);

--- a/review-enrichment/src/scheduler.ts
+++ b/review-enrichment/src/scheduler.ts
@@ -416,6 +416,9 @@ function isRuntimePinPath(path: string): boolean {
     basename === ".rust-version" ||
     basename === ".java-version" ||
     basename === ".terraform-version" ||
+    basename === ".elixir-version" ||
+    basename === ".kotlin-version" ||
+    basename === ".tool-versions" ||
     basename === "go.mod"
   );
 }

--- a/review-enrichment/test/eol-check.test.ts
+++ b/review-enrichment/test/eol-check.test.ts
@@ -5,6 +5,7 @@ import assert from "node:assert/strict";
 import {
   extractVersionPins,
   isDockerfile,
+  parseToolVersionLine,
 } from "../dist/analyzers/eol-check.js";
 
 function added(path: string, ...lines: string[]) {
@@ -109,6 +110,69 @@ test("extractVersionPins reads .terraform-version pins as Terraform", () => {
   assert.deepEqual(extractVersionPins([added(".terraform-version", "1.5.7")]), [
     { file: ".terraform-version", product: "terraform", version: "1.5.7" },
   ]);
+});
+
+test("extractVersionPins reads .elixir-version and .kotlin-version pins", () => {
+  assert.deepEqual(extractVersionPins([added(".elixir-version", "1.16.2")]), [
+    { file: ".elixir-version", product: "elixir", version: "1.16.2" },
+  ]);
+  assert.deepEqual(extractVersionPins([added(".kotlin-version", "2.0.21")]), [
+    { file: ".kotlin-version", product: "kotlin", version: "2.0.21" },
+  ]);
+});
+
+test("parseToolVersionLine maps asdf plugin names to endoflife.date products", () => {
+  assert.deepEqual(parseToolVersionLine("python 3.11.0"), {
+    product: "python",
+    version: "3.11.0",
+  });
+  assert.deepEqual(parseToolVersionLine("nodejs 20.11.0"), {
+    product: "nodejs",
+    version: "20.11.0",
+  });
+  // Common asdf aliases.
+  assert.deepEqual(parseToolVersionLine("node 18.17.0"), {
+    product: "nodejs",
+    version: "18.17.0",
+  });
+  assert.deepEqual(parseToolVersionLine("golang 1.22.0"), {
+    product: "go",
+    version: "1.22.0",
+  });
+  assert.deepEqual(parseToolVersionLine("java 21.0.2"), {
+    product: "oracle-jdk",
+    version: "21.0.2",
+  });
+  // Optional trailing system column is ignored.
+  assert.deepEqual(parseToolVersionLine("ruby 3.2.2 linux"), {
+    product: "ruby",
+    version: "3.2.2",
+  });
+  // Comments and unknown tools are skipped.
+  assert.equal(parseToolVersionLine("# python 3.10.0"), null);
+  assert.equal(parseToolVersionLine("unknown-tool 1.2.3"), null);
+  assert.equal(parseToolVersionLine(""), null);
+});
+
+test("extractVersionPins reads multi-tool .tool-versions pins from added lines", () => {
+  assert.deepEqual(
+    extractVersionPins([
+      added(
+        ".tool-versions",
+        "python 3.11.0",
+        "nodejs 20.11.0",
+        "# elixir 1.15.0",
+        "terraform 1.5.7",
+        "kotlin 2.0.21",
+      ),
+    ]),
+    [
+      { file: ".tool-versions", product: "python", version: "3.11.0" },
+      { file: ".tool-versions", product: "nodejs", version: "20.11.0" },
+      { file: ".tool-versions", product: "terraform", version: "1.5.7" },
+      { file: ".tool-versions", product: "kotlin", version: "2.0.21" },
+    ],
+  );
 });
 
 test("extractVersionPins ignores removed/context lines and files with no patch", () => {


### PR DESCRIPTION
## Summary
- Parse asdf `.tool-versions` multi-tool pin files into endoflife.date product/version pairs.
- Add `.elixir-version` and `.kotlin-version` single-file runtime pins.
- Introduce a shared plugin-name → product map (including `node`/`golang` aliases).
- Extend the scheduler runtime-pin gate for all new pin file types.

## Test plan
- [x] Unit tests for `parseToolVersionLine` (aliases, comments, unknown tools)
- [x] Multi-line `.tool-versions` extraction regression
- [x] `.elixir-version` and `.kotlin-version` pin tests
- [ ] CI green


Made with [Cursor](https://cursor.com)