### PR TITLE
feat(enrichment): treat scientific data artifacts as binary assets

### DIFF
--- a/review-enrichment/src/analyzers/asset-weight.ts
+++ b/review-enrichment/src/analyzers/asset-weight.ts
@@ -80,6 +80,14 @@ const BINARY_EXTS = new Set([
   "pt",
   "pth",
   "ckpt",
+  // Scientific / ML data artifacts — columnar, tensor, and HDF5 blobs whose bytes never appear in the diff.
+  "h5",
+  "hdf5",
+  "pb",
+  "npy",
+  "npz",
+  "parquet",
+  "feather",
 ]);
 
 interface ScanOptions {

--- a/review-enrichment/src/analyzers/provenance.ts
+++ b/review-enrichment/src/analyzers/provenance.ts
@@ -21,9 +21,10 @@ const MAX_FINDINGS = 30; // keep the brief bounded
 // binary set in asset-weight.ts) and `pyd` is a Windows Python extension DLL (the sibling of the pyc/pyo/so
 // entries) — both are unauditable prebuilt binaries a PR should not check in without source. ML checkpoint
 // formats (`safetensors`, `gguf`, `onnx`, `pt`, `pth`, `ckpt`) mirror asset-weight.ts — unauditable weight
-// blobs a PR should not commit without reproducible training source.
+// blobs a PR should not commit without reproducible training source. Scientific data artifacts (HDF5, NumPy,
+// TensorFlow SavedModel, Parquet/Feather) are likewise opaque binary payloads.
 const BINARY_EXT_RE =
-  /\.(?:exe|dll|so|dylib|bin|pyc|pyo|pyd|class|jar|war|ear|wasm|node|o|a|safetensors|gguf|onnx|pt|pth|ckpt)$/i;
+  /\.(?:exe|dll|so|dylib|bin|pyc|pyo|pyd|class|jar|war|ear|wasm|node|o|a|safetensors|gguf|onnx|pt|pth|ckpt|h5|hdf5|pb|npy|npz|parquet|feather)$/i;
 // Vendored / embedded third-party source trees. bower_components (Bower) and jspm_packages (JSPM) are
 // installed-dependency directories — the same vendored case as node_modules — so a committed tree under either
 // is a vendored artifact, not contributor source (mirrors src/signals/path-matchers.ts's vendored classifier).

--- a/review-enrichment/test/asset-weight.test.ts
+++ b/review-enrichment/test/asset-weight.test.ts
@@ -41,6 +41,19 @@ test("isBinaryAsset flags genuine binary extensions and ignores text/case", () =
   ]) {
     assert.equal(isBinaryAsset(p), true, p);
   }
+  // Scientific / ML data artifacts (HDF5, NumPy, TensorFlow, columnar) are heavy opaque binary blobs.
+  for (const p of [
+    "data/train.h5",
+    "data/features.hdf5",
+    "models/saved_model.pb",
+    "data/embeddings.npy",
+    "data/batch.npz",
+    "warehouse/events.parquet",
+    "warehouse/snapshot.feather",
+    "data/TRAIN.H5",
+  ]) {
+    assert.equal(isBinaryAsset(p), true, p);
+  }
   // Extension match is case-insensitive.
   assert.equal(isBinaryAsset("assets/HERO.PNG"), true);
   // Text formats whose bytes are already in the diff are NOT binary assets.

--- a/review-enrichment/test/provenance.test.ts
+++ b/review-enrichment/test/provenance.test.ts
@@ -51,3 +51,21 @@ test("classifyAddedFile flags committed ML checkpoint files as binary artifacts"
   assert.equal(classifyAddedFile("src/model.pt.ts"), null);
   assert.equal(classifyAddedFile("lib/onnx.ts"), null);
 });
+
+test("classifyAddedFile flags committed scientific data artifacts as binary", () => {
+  // HDF5, NumPy, TensorFlow SavedModel, and columnar data files are unauditable opaque payloads — the same
+  // category asset-weight.ts flags for size bloat. A committed dataset must ship with reproducible source.
+  for (const path of [
+    "data/train.h5",
+    "data/features.hdf5",
+    "models/saved_model.pb",
+    "data/embeddings.npy",
+    "data/batch.npz",
+    "warehouse/events.parquet",
+    "warehouse/snapshot.feather",
+  ]) {
+    assert.equal(classifyAddedFile(path), "binary", path);
+  }
+  assert.equal(classifyAddedFile("src/parquet.ts"), null);
+  assert.equal(classifyAddedFile("lib/npy_utils.py"), null);
+});


### PR DESCRIPTION
## Summary
- Extend asset-weight to flag HDF5, NumPy, TensorFlow SavedModel, Parquet, and Feather files as heavy binary assets.
- Mirror the same extensions in provenance so committed datasets/checkpoints are classified as unauditable binary artifacts.
- Keeps asset-weight and provenance extension sets aligned for ML/data-science workflows.

## Test plan
- [x] asset-weight positive/negative extension tests
- [x] provenance binary classification tests for each new format
- [ ] CI green


Made with [Cursor](https://cursor.com)