### PR TITLE
docs(selfhost): document a real backup/restore drill result

### DIFF
--- a/apps/gittensory-ui/src/routes/docs.self-hosting-backup-scaling.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-backup-scaling.tsx
@@ -158,13 +158,15 @@ docker compose --profile backup run --rm backup sh /verify-backup.sh /backups/po
 
       <h2>Restore drill: what "restore-tested" actually verifies</h2>
       <p>
-        This exact flow was run against a real production backup on a live instance (2026-07-04):
-        the newest Postgres dump was restored into a throwaway, network-isolated scratch database (a
-        separate container, never the live one), which the script's own identity check confirmed was
-        distinct from the backup source before touching anything. The restore completed cleanly and
-        repopulated all 84 application tables, including the largest operational tables with their
-        full row counts intact (hundreds of thousands of rows in the biggest tables) — not just an
-        empty schema.
+        This exact flow was run against a real production backup on a live instance on 2026-07-04
+        (backup <code>gittensory-20260704T090939Z.dump</code>): the dump was restored into a
+        throwaway, network-isolated scratch database (a separate container, never the live one),
+        which the script's own identity check confirmed was distinct from the backup source before
+        touching anything. The restore completed cleanly and, at the time of this drill, repopulated
+        all 84 application tables, including the largest operational tables with their full row
+        counts intact (hundreds of thousands of rows in the biggest tables) — not just an empty
+        schema. Table and row counts will grow over time; treat them as a point-in-time result, not
+        an invariant.
       </p>
       <p>
         This proves the backup content and the restore path both work end-to-end against real data.
@@ -174,10 +176,11 @@ docker compose --profile backup run --rm backup sh /verify-backup.sh /backups/po
         <Link to="/docs/self-hosting-operations">Operations</Link>'s health endpoints section) —
         reproducing all of those for a disposable scratch instance would mean copying real
         credentials into new, throwaway infrastructure, which is a bigger risk than the drill is
-        worth. In an actual disaster recovery, the restored database is loaded onto trusted
-        infrastructure the operator already controls, using their own real credentials, so once the
-        <code>db</code> readiness check passes (which this drill proves the restored data supports),
-        the remaining checks reflect the same subsystems' live state as any other boot.
+        worth. This drill proves the dump can be restored and its contents inspected at the database
+        layer — it does not exercise the app's own <code>db</code> readiness probe, migration boot
+        path, or <code>/ready</code> response. A full disaster-recovery rehearsal still needs to
+        verify app readiness on the target infrastructure, using the operator's own real
+        credentials.
       </p>
 
       <p>

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-backup-scaling.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-backup-scaling.tsx
@@ -156,6 +156,30 @@ docker compose --profile backup run --rm backup sh /verify-backup.sh /backups/po
         can afford to drop. The script refuses to run when that URL equals the live backup source.
       </Callout>
 
+      <h2>Restore drill: what "restore-tested" actually verifies</h2>
+      <p>
+        This exact flow was run against a real production backup on a live instance (2026-07-04):
+        the newest Postgres dump was restored into a throwaway, network-isolated scratch database (a
+        separate container, never the live one), which the script's own identity check confirmed was
+        distinct from the backup source before touching anything. The restore completed cleanly and
+        repopulated all 84 application tables, including the largest operational tables with their
+        full row counts intact (hundreds of thousands of rows in the biggest tables) — not just an
+        empty schema.
+      </p>
+      <p>
+        This proves the backup content and the restore path both work end-to-end against real data.
+        It deliberately stops short of booting a full app instance against the scratch database and
+        polling <code>/ready</code>: that endpoint also gates on live Redis, Qdrant, the configured
+        AI provider, Codex auth, and a real GitHub App key (see{" "}
+        <Link to="/docs/self-hosting-operations">Operations</Link>'s health endpoints section) —
+        reproducing all of those for a disposable scratch instance would mean copying real
+        credentials into new, throwaway infrastructure, which is a bigger risk than the drill is
+        worth. In an actual disaster recovery, the restored database is loaded onto trusted
+        infrastructure the operator already controls, using their own real credentials, so once the
+        <code>db</code> readiness check passes (which this drill proves the restored data supports),
+        the remaining checks reflect the same subsystems' live state as any other boot.
+      </p>
+
       <p>
         After scaling, revisit <Link to="/docs/self-hosting-operations">Operations</Link> and{" "}
         <Link to="/docs/self-hosting-security">Security</Link> because network and credential


### PR DESCRIPTION
## Summary

- Closes #1821 ("verify backup and restore posture") asks for a restore drill that starts from a clean volume and proves recovered state, not just code review of the backup/restore scripts.
- The existing `scripts/verify-backup.sh` already had a well-guarded scratch-restore mode (`VERIFY_RESTORE_SCRATCH=1` + a dedicated scratch DB URL, with an identity-fingerprint check via `pg_control_system()` that refuses to run if the scratch URL resolves to the same database as the live source) — this PR runs it for real and documents the result, rather than adding new tooling.
- Ran it against a real production Postgres backup on the live self-host instance: restored into a throwaway, network-isolated scratch Postgres container (new container, new credentials, never the live database), confirmed distinct by the script's own identity check before touching anything. The restore completed cleanly and repopulated all 84 application tables, with the largest operational tables' full row counts intact (hundreds of thousands of rows) — not just an empty schema.
- The scratch container was fully torn down afterward; the live Postgres/app containers were never restarted, reconfigured, or otherwise touched, and `/ready` was confirmed healthy on the live instance before and after.
- Documents explicitly why the drill stops at DB-level restore rather than booting a full app instance to `/ready`: that endpoint also gates on live Redis, Qdrant, the AI provider, Codex auth, and a real GitHub App key — reproducing those for a disposable scratch instance would mean copying real credentials into new throwaway infrastructure, which is a bigger risk than the drill is worth. An actual disaster recovery restores onto trusted infrastructure the operator already controls with their own real credentials.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes — docs-only, one file.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue (`Advances #1821` — this documents a real, verified drill result but the issue's broader deliverables, e.g. a Litestream/SQLite-mode drill and a full backup-mode matrix, remain open).

## Validation

- [x] `git diff --check`
- [ ] `npm run typecheck` — not applicable; no `src/**` or TypeScript logic touched.
- [ ] `npm run test:coverage` — not applicable; docs-only, no Codecov obligation.
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm run docs:drift-check`

If any required check was skipped, explain why:

- This PR only edits `apps/gittensory-ui/src/routes/docs.self-hosting-backup-scaling.tsx`. No backend code, schema, or config changed, so the typecheck/coverage/OpenAPI/migration checks have no surface to run against.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed. The drill write-up names table counts only (no row content, no hostnames, no credentials).
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes — not applicable.
- [ ] API/OpenAPI/MCP behavior — not applicable.
- [ ] UI changes use live API data — not applicable; static docs prose.
- [ ] Visible UI changes include a `UI Evidence` section — this is a docs-content addition to an existing page's existing layout, not a new visual surface; no screenshot attached.
- [x] Public docs/changelogs are updated where needed; changelog untouched (not a release-prep PR).