### PR TITLE
docs(selfhost): finalize first stable release checklist

### DIFF
--- a/apps/gittensory-ui/src/components/site/docs-nav.tsx
+++ b/apps/gittensory-ui/src/components/site/docs-nav.tsx
@@ -57,7 +57,7 @@ export const docsNav: DocsGroup[] = [
         title: "Self-hosting: release & security",
         items: [
           { to: "/docs/self-hosting-releases", label: "Releases & images" },
-          { to: "/docs/self-hosting-release-checklist", label: "Beta release checklist" },
+          { to: "/docs/self-hosting-release-checklist", label: "Release checklist" },
           { to: "/docs/self-hosting-security", label: "Security" },
         ],
       },

--- a/apps/gittensory-ui/src/routes/docs.maintainer-self-hosting.tsx
+++ b/apps/gittensory-ui/src/routes/docs.maintainer-self-hosting.tsx
@@ -83,9 +83,9 @@ const SECTION_LINKS = [
     to: "/docs/self-hosting-releases",
   },
   {
-    title: "Beta release checklist",
+    title: "Release checklist",
     description:
-      "The smoke matrix to run against a candidate image before tagging an orb-vX.Y.Z release.",
+      "Versioning, the smoke matrix, an image-contents audit, and release notes for an orb-vX.Y.Z release.",
     to: "/docs/self-hosting-release-checklist",
   },
   {
@@ -174,8 +174,8 @@ function MaintainerSelfHosting() {
           production traffic.
         </li>
         <li>
-          Run the <Link to="/docs/self-hosting-release-checklist">beta release checklist</Link>{" "}
-          before tagging or promoting a candidate image.
+          Run the <Link to="/docs/self-hosting-release-checklist">release checklist</Link> before
+          tagging or promoting a candidate image.
         </li>
       </ol>
 

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-github-app.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-github-app.tsx
@@ -265,8 +265,8 @@ ORB_RELAY_MODE=pull  # or omit for push (the default) -- see "Choosing a relay m
       <p>
         See <Link to="/docs/self-hosting-troubleshooting">Troubleshooting</Link> for what a degraded
         brokered relay looks like in logs today, and{" "}
-        <Link to="/docs/self-hosting-release-checklist">the beta release checklist</Link>'s
-        brokered-mode scenario for the smoke tests that exercise both relay modes.
+        <Link to="/docs/self-hosting-release-checklist">the release checklist</Link>'s brokered-mode
+        scenario for the smoke tests that exercise both relay modes.
       </p>
 
       <h2>Webhook checks</h2>

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-release-checklist.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-release-checklist.tsx
@@ -6,17 +6,17 @@ import { Callout, CodeBlock, FeatureRow } from "@/components/site/primitives";
 export const Route = createFileRoute("/docs/self-hosting-release-checklist")({
   head: () => ({
     meta: [
-      { title: "Beta release checklist — Gittensory docs" },
+      { title: "First release checklist — Gittensory docs" },
       {
         name: "description",
         content:
-          "The smoke matrix to run before publishing a self-host RC image: direct App, brokered, air-gapped, each AI provider, SQLite/Postgres, Redis/Qdrant. Portable commands, expected log events, known-warnings table.",
+          "Versioning and trigger for the first stable self-host image, the smoke-test matrix (direct App, brokered, air-gapped, each AI provider, SQLite/Postgres, Redis/Qdrant), an image-contents audit, the full-vs-minimal variant decision, and the GitHub Release notes template.",
       },
-      { property: "og:title", content: "Beta release checklist — Gittensory docs" },
+      { property: "og:title", content: "First release checklist — Gittensory docs" },
       {
         property: "og:description",
         content:
-          "The smoke matrix to run before publishing a self-host RC image: direct App, brokered, air-gapped, each AI provider, SQLite/Postgres, Redis/Qdrant.",
+          "Versioning, the smoke-test matrix, an image-contents audit, the image-variant decision, and the GitHub Release notes template for the first stable self-host image.",
       },
       { property: "og:url", content: "/docs/self-hosting-release-checklist" },
     ],
@@ -29,15 +29,271 @@ function SelfHostingReleaseChecklist() {
   return (
     <DocsPage
       eyebrow="Self-hosting"
-      title="Beta release checklist"
-      description="Run this smoke matrix against a candidate image before tagging it orb-vX.Y.Z or an -rc/-beta prerelease. Each scenario is a mode a real operator will run; CI only exercises the plain SQLite + Redis + direct-App default."
+      title="First release checklist"
+      description="Everything to confirm before cutting orb-v0.1.0 — the first stable (non-prerelease) self-host image — after two beta cuts already validated the pipeline end to end. Run the smoke matrix against a candidate image before tagging any orb-vX.Y.Z or -rc/-beta prerelease; CI only exercises the plain SQLite + Redis + direct-App default."
     >
+      <h2>Versioning and release trigger</h2>
+      <p>
+        <code>orb-v0.1.0-beta.1</code> and <code>orb-v0.1.0-beta.2</code> already exercised the full
+        release pipeline — multi-arch build, provenance, SBOM, Sentry source-map upload and release
+        validation, and GitHub Release creation — twice, successfully. Neither moved{" "}
+        <code>latest</code> or produced an unmarked GitHub Release, because{" "}
+        <Link to="/docs/self-hosting-releases">a prerelease tag never does</Link>. The natural next
+        step is <strong>not a third beta</strong>: it is <code>orb-v0.1.0</code>, a plain{" "}
+        <code>X.Y.Z</code> tag with no <code>-rc</code>/<code>-beta</code> suffix.
+      </p>
+      <p>
+        The release workflow (<code>.github/workflows/release-selfhost.yml</code>) resolves this
+        distinction itself from the tag text, not from a separate flag — pushing{" "}
+        <code>orb-v0.1.0</code> runs through the identical build/provenance/SBOM/Sentry steps the
+        two betas already proved out, but the <code>PRERELEASE</code> value it computes flips to{" "}
+        <code>false</code>, which (per the release-image-tags guard added for this exact reason) is
+        what allows the run to push the <code>latest</code> image tag and create a non-prerelease
+        GitHub Release:
+      </p>
+      <CodeBlock
+        lang="bash"
+        code={`git fetch origin main
+git tag orb-v0.1.0 origin/main   # only a commit reachable from main is accepted (verified in-workflow)
+git push origin orb-v0.1.0`}
+      />
+      <Callout variant="safety">
+        Only a non-prerelease <code>X.Y.Z</code> tag ever moves <code>latest</code> or the
+        repo&apos;s unmarked &quot;Latest release&quot; — a <code>-rc</code>/<code>-beta</code> tag
+        runs the same pipeline but is always excluded from both. Confirm the tag has no prerelease
+        suffix before pushing it; there is no undo for <code>latest</code> once an operator has
+        pulled it.
+      </Callout>
+      <p>
+        Going forward, the scheme is ordinary semver under the <code>orb-v</code> prefix:{" "}
+        <code>orb-v0.1.1</code> for a patch, <code>orb-v0.2.0</code> for a feature bump, and an{" "}
+        <code>-rc.N</code>/<code>-beta.N</code> suffix on any tag that should run the pipeline
+        without touching <code>latest</code> or the default GitHub Release. This checklist and the
+        smoke matrix below apply to every future cut, not just the first.
+      </p>
+
+      <h2>First-release checklist</h2>
+      <p>
+        Work through this list once, in order, before pushing the <code>orb-v0.1.0</code> tag.
+      </p>
+      <FeatureRow
+        items={[
+          {
+            title: "1. Smoke matrix green",
+            description:
+              "Every applicable scenario in the matrix below passes against a locally built candidate image (docker buildx build --load -t gittensory:rc-candidate .).",
+          },
+          {
+            title: "2. Image-contents audit reviewed",
+            description:
+              "The audit below (or a fresh re-read of the Dockerfile's runtime-prebuilt stage) confirms no source maps, .env, local auth, private config, secrets, or data volumes are baked in.",
+          },
+          {
+            title: "3. Sentry behavior confirmed",
+            description:
+              "SENTRY_DSN unset boots cleanly with zero Sentry activity (initSentry short-circuits before importing @sentry/node); the release workflow still uploads source maps and validates the Sentry release regardless of what any operator's runtime DSN is set to.",
+          },
+          {
+            title: "4. Variant decision applied",
+            description:
+              "Ship one default (full, INSTALL_AI_CLIS=true) image for this release — see the variant decision below.",
+          },
+          {
+            title: "5. Release notes drafted",
+            description:
+              "The GitHub Release template below is filled in with what's supported, experimental, optional, and operator-owned for this version.",
+          },
+          {
+            title: "6. Tag pushed from a commit on main",
+            description:
+              'git tag orb-v0.1.0 <sha-on-main> && git push origin orb-v0.1.0 — the workflow rejects any commit not reachable from main with "Self-host releases must be cut from a commit reachable from main."',
+          },
+          {
+            title: "7. Release environment approved",
+            description:
+              "The release job runs under the release GitHub Environment; if reviewer approval is configured, approve the pending run so the build/push/Sentry/notes steps proceed.",
+          },
+          {
+            title: "8. Post-publish verification",
+            description:
+              "docker pull the published orb-v0.1.0 and latest tags, confirm both resolve to the same digest, and re-run the fresh-install smoke scenario against the pulled (not locally built) image.",
+          },
+        ]}
+      />
+      <h2>Smoke-test matrix</h2>
       <p>
         Every scenario below shares the same core check — <code>scripts/smoke-selfhost.sh</code>{" "}
         boots one container against a fresh Redis on an isolated network, waits for it to become
         healthy, and asserts on <code>/health</code>, <code>/ready</code>, <code>/metrics</code>,
         and startup log events. What changes per scenario is the env you pass in and which events
         you expect (or forbid).
+      </p>
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse text-token-sm">
+          <thead>
+            <tr className="border-hairline text-left text-token-xs text-muted-foreground">
+              <th className="py-2 pr-4 font-medium">Scenario</th>
+              <th className="py-2 pr-4 font-medium">Steps</th>
+              <th className="py-2 font-medium">Pass criteria</th>
+            </tr>
+          </thead>
+          <tbody className="divide-hairline">
+            <tr>
+              <td className="py-2 pr-4 align-top">Direct GitHub App (default)</td>
+              <td className="py-2 pr-4 align-top text-muted-foreground">
+                Run the base smoke command with no <code>ORB_ENROLLMENT_SECRET</code>.
+              </td>
+              <td className="py-2 align-top text-muted-foreground">
+                <code>/health</code>, <code>/ready</code> ok;{" "}
+                <code>selfhost_migrations_applied</code> logged;{" "}
+                <code>selfhost_orb_relay_register</code> does NOT appear (relay is brokered-only).
+              </td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 align-top">Brokered — push mode</td>
+              <td className="py-2 pr-4 align-top text-muted-foreground">
+                Set <code>ORB_ENROLLMENT_SECRET</code> and a real, internet-reachable{" "}
+                <code>PUBLIC_API_ORIGIN</code>.
+              </td>
+              <td className="py-2 align-top text-muted-foreground">
+                <code>selfhost_orb_relay_register</code> logged;{" "}
+                <code>selfhost_orb_relay_register_failed</code> does NOT appear (failure here is{" "}
+                <code>error</code>-level and release-blocking).
+              </td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 align-top">Brokered — pull mode</td>
+              <td className="py-2 pr-4 align-top text-muted-foreground">
+                Set <code>ORB_ENROLLMENT_SECRET</code> and <code>ORB_RELAY_MODE=pull</code>, no
+                inbound origin needed.
+              </td>
+              <td className="py-2 align-top text-muted-foreground">
+                <code>selfhost_orb_relay_register</code> logged; a failed announce (
+                <code>warn</code>-level) is tolerated since the drain loop keeps retrying.
+              </td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 align-top">Air-gapped / no telemetry</td>
+              <td className="py-2 pr-4 align-top text-muted-foreground">
+                Set <code>ORB_AIR_GAP=true</code>.
+              </td>
+              <td className="py-2 align-top text-muted-foreground">
+                No export attempt or export error logged; no outbound request to the collector URL
+                at the network level.
+              </td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 align-top">AI provider (Claude Code / Codex / both)</td>
+              <td className="py-2 pr-4 align-top text-muted-foreground">
+                Set <code>AI_PROVIDER</code> to each supported value with real credentials.
+              </td>
+              <td className="py-2 align-top text-muted-foreground">
+                <code>selfhost_ai_provider</code> logged; <code>selfhost_ai_cli_missing</code> does
+                NOT appear (release-blocking if it does — the image was built without{" "}
+                <code>INSTALL_AI_CLIS=true</code>).
+              </td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 align-top">SQLite (default) / Postgres</td>
+              <td className="py-2 pr-4 align-top text-muted-foreground">
+                Base command covers SQLite; boot a Postgres container and set{" "}
+                <code>DATABASE_URL</code> for the Postgres path.
+              </td>
+              <td className="py-2 align-top text-muted-foreground">
+                Both boot healthy and apply migrations; note in release notes which mode beta
+                testers actually validated.
+              </td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 align-top">Redis (always-on) + optional Qdrant RAG</td>
+              <td className="py-2 pr-4 align-top text-muted-foreground">
+                Base command covers Redis; set <code>QDRANT_URL</code> against a booted Qdrant
+                container for the RAG path.
+              </td>
+              <td className="py-2 align-top text-muted-foreground">
+                <code>selfhost_redis_ready</code> always logged; <code>selfhost_vectorize</code>{" "}
+                logged only when <code>QDRANT_URL</code> is set.
+              </td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 align-top">Fresh install</td>
+              <td className="py-2 pr-4 align-top text-muted-foreground">
+                Pull the published <code>orb-v0.1.0</code> tag on a clean host (no prior volumes)
+                and boot via compose.
+              </td>
+              <td className="py-2 align-top text-muted-foreground">
+                Container reports <code>healthy</code>; <code>/ready</code> returns 200 without any
+                manual migration step.
+              </td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 align-top">Upgrade from a source-built deploy</td>
+              <td className="py-2 pr-4 align-top text-muted-foreground">
+                On an instance previously deployed via{" "}
+                <code>scripts/deploy-selfhost-prebuilt.sh</code>, run{" "}
+                <code>
+                  scripts/deploy-selfhost-image.sh
+                  ghcr.io/&lt;owner&gt;/gittensory-selfhost:orb-v0.1.0
+                </code>
+                .
+              </td>
+              <td className="py-2 align-top text-muted-foreground">
+                Only the <code>gittensory</code> service restarts (<code>--no-deps</code>);{" "}
+                <code>.env</code>, data volumes, and <code>gittensory-config/</code> are untouched;{" "}
+                <code>/ready</code> returns 200 after the health-check wait.
+              </td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 align-top">Rollback to prior tag</td>
+              <td className="py-2 pr-4 align-top text-muted-foreground">
+                Re-run <code>scripts/deploy-selfhost-image.sh</code> pinned to the prior tag/digest
+                (e.g. <code>orb-v0.1.0-beta.2</code>).
+              </td>
+              <td className="py-2 align-top text-muted-foreground">
+                Service restarts healthy on the older image; confirmed safe only when nothing since
+                the prior tag added a forward-only migration the older code can&apos;t tolerate (see{" "}
+                <Link to="/docs/self-hosting-operations">Updating and rolling back</Link>).
+              </td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 align-top">One-service app restart</td>
+              <td className="py-2 pr-4 align-top text-muted-foreground">
+                Re-run either deploy script against the same tag with other profile services
+                (Postgres, Redis, Qdrant, Grafana) already up.
+              </td>
+              <td className="py-2 align-top text-muted-foreground">
+                Only the <code>gittensory</code> container recreates; profile-service containers and
+                their volumes are never touched.
+              </td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 align-top">Sentry release validation</td>
+              <td className="py-2 pr-4 align-top text-muted-foreground">
+                Confirm the release workflow&apos;s &quot;Validate Sentry release&quot; step passed
+                for this tag (source maps uploaded, release finalized, commits attached).
+              </td>
+              <td className="py-2 align-top text-muted-foreground">
+                <code>review-enrichment/scripts/validate-sentry-release.mjs</code> exits 0 within
+                its 5-attempt retry-poll; the Sentry release id matches the baked{" "}
+                <code>GITTENSORY_VERSION</code>.
+              </td>
+            </tr>
+            <tr>
+              <td className="py-2 pr-4 align-top">Docs links resolve</td>
+              <td className="py-2 pr-4 align-top text-muted-foreground">
+                Follow every link in the release notes template below (setup guide, releases page,
+                this checklist) from the published GitHub Release.
+              </td>
+              <td className="py-2 align-top text-muted-foreground">
+                Every linked docs page loads and matches the version being released.
+              </td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <p>
+        The scenario-by-scenario commands below give exact env and expected/forbidden log events for
+        each row above.
       </p>
       <CodeBlock
         lang="bash"
@@ -46,7 +302,7 @@ docker buildx build --load -t gittensory:rc-candidate .
 ./scripts/smoke-selfhost.sh gittensory:rc-candidate`}
       />
 
-      <h2>1. Direct GitHub App mode (default)</h2>
+      <h3>Direct GitHub App mode (default)</h3>
       <p>
         No <code>ORB_ENROLLMENT_SECRET</code> — the container uses its own GitHub App private key.
         Telemetry export is always-on in this mode too; a clean run produces no export error.
@@ -68,7 +324,7 @@ SELFHOST_SMOKE_FORBID_EVENTS="selfhost_orb_export_error,selfhost_orb_relay_regis
         <Link to="/docs/self-hosting-github-app">GitHub App and Orb</Link>).
       </p>
 
-      <h2>2. Brokered mode (private / managed-beta only)</h2>
+      <h3>Brokered mode (private / managed-beta only)</h3>
       <p>
         <code>ORB_ENROLLMENT_SECRET</code> set — the container gets tokens from the central Orb
         instead of its own App key. Relay mode changes what "working" means: push mode (
@@ -99,7 +355,7 @@ SELFHOST_SMOKE_FORBID_EVENTS="selfhost_orb_relay_register_failed" \\
 ./scripts/smoke-selfhost.sh gittensory:rc-candidate`}
       />
 
-      <h2>3. Air-gapped / no-telemetry mode</h2>
+      <h3>Air-gapped / no-telemetry mode</h3>
       <p>
         <code>ORB_AIR_GAP=true</code> disables the fleet-calibration export entirely. There is no
         "air-gap confirmed" log event — the export function returns before doing anything, so
@@ -113,7 +369,7 @@ SELFHOST_SMOKE_FORBID_EVENTS="selfhost_orb_export_error,selfhost_orb_relay_regis
 ./scripts/smoke-selfhost.sh gittensory:rc-candidate`}
       />
 
-      <h2>4. AI provider: Claude Code / Codex / both</h2>
+      <h3>AI provider: Claude Code / Codex / both</h3>
       <p>
         Each provider choice must log <code>selfhost_ai_provider</code> and must NOT log{" "}
         <code>selfhost_ai_cli_missing</code> (a CLI-subscription provider whose binary isn't on{" "}
@@ -153,7 +409,7 @@ SELFHOST_SMOKE_FORBID_EVENTS="selfhost_ai_cli_missing" \\
         release-blocking case (image built without <code>INSTALL_AI_CLIS=true</code>).
       </Callout>
 
-      <h2>5. SQLite trial mode / Postgres production mode</h2>
+      <h3>SQLite trial mode / Postgres production mode</h3>
       <p>
         SQLite is the default — the base smoke command above already covers it (no{" "}
         <code>DATABASE_URL</code> set). For Postgres, boot a Postgres container on the same network
@@ -173,7 +429,7 @@ docker rm -f gt-pg && docker network rm gt-pg-smoke`}
         whenever this mode is what beta testers actually validated.
       </Callout>
 
-      <h2>6. Redis cache + optional Qdrant RAG</h2>
+      <h3>Redis cache + optional Qdrant RAG</h3>
       <p>
         Redis is always-on in every scenario above (the base script already boots it) — confirm{" "}
         <code>selfhost_redis_ready</code> appears with <code>githubResponseCacheEnabled</code>{" "}
@@ -249,6 +505,183 @@ docker rm -f gt-qdrant && docker network rm gt-rag-smoke`}
               "Acceptable in beta if transient (e.g. a single collector timeout) — the hourly retry recovers. Persistent recurrence across the whole smoke run is release-blocking.",
           },
         ]}
+      />
+
+      <h2>Image-contents audit</h2>
+      <p>
+        The <code>runtime-prebuilt</code> target — what the release workflow actually builds and
+        pushes (<code>docker/build-push-action</code> is invoked with{" "}
+        <code>target: runtime-prebuilt</code>) — copies exactly three things on top of the{" "}
+        <code>runtime-base</code> layer: the pre-bundled <code>dist/server.mjs</code>, the{" "}
+        <code>migrations/</code> SQL files, and <code>config/examples/</code> (generic, safe
+        reference templates — shipping them activates nothing, since{" "}
+        <code>GITTENSORY_REPO_CONFIG_DIR</code> still points at an operator-mounted{" "}
+        <code>/config</code>). Nothing else reaches that stage.
+      </p>
+      <FeatureRow
+        items={[
+          {
+            title: "Source maps — NOT included",
+            description:
+              "dist/server.mjs.map is produced during the build stage but only dist/server.mjs itself is COPYed into runtime-prebuilt (Dockerfile). The bundle's sourceMappingURL comment points at a file that does not exist in the image — the map is uploaded to Sentry in the release workflow instead and deliberately never ships.",
+          },
+          {
+            title: ".env / secrets — NOT included",
+            description:
+              ".dockerignore excludes .env, .env.*, and .dev.vars (with .env.example explicitly re-allowed as a template). The Dockerfile never COPYs an env file at all; every secret is supplied at container run time via docker-compose.yml's env_file: .env or a mounted *_FILE path.",
+          },
+          {
+            title: "Local auth / subscription-CLI credentials — NOT included",
+            description:
+              "The image bakes the Claude Code and Codex CLI binaries (when INSTALL_AI_CLIS=true) but no credentials. auth.json and **/.codex are in .dockerignore, and the Dockerfile symlinks /home/node/.codex to /data/codex — an operator-mounted volume — so any auth an operator sets up at runtime lands on their own persisted volume, never in an image layer.",
+          },
+          {
+            title: "Private repo config — NOT included",
+            description:
+              "gittensory-config and **/gittensory-config are excluded via .dockerignore; only the generic config/examples/ reference templates are copied, and GITTENSORY_REPO_CONFIG_DIR is resolved against an operator-mounted /config at runtime.",
+          },
+          {
+            title: "Data volumes — NOT included",
+            description:
+              "The SQLite database, Redis/Postgres/Qdrant data, and Grafana state are all named docker volumes declared in docker-compose.yml, mounted at runtime — none are part of the image's filesystem layers.",
+          },
+          {
+            title: "Deployment overrides — NOT included",
+            description:
+              "docker-compose.override.yml(.example) and any host-specific compose profile config live outside the image entirely; the image only ever contains the application bundle plus its declared runtime dependencies.",
+          },
+          {
+            title: "apps/ (gittensory-ui) and test/ — excluded from the build context",
+            description:
+              "Added to .dockerignore alongside the existing exclusions: the self-host bundle's only entry point is src/server.ts and npm ci only reads the root package*.json, so the UI workspace app and the test suite are never read during the image build (~11MB of this repo's ~22MB tracked-file footprint kept out).",
+          },
+          {
+            title: "npm install cache — trimmed",
+            description:
+              "npm cache clean --force now runs immediately after the AI-CLI global install in the same RUN layer, removing the ~180MB download cache (~/.npm/_cacache) that npm install -g leaves behind but nothing at runtime ever reads.",
+          },
+        ]}
+      />
+      <p>
+        Net effect of the two <code>.dockerignore</code>/Dockerfile changes above: the built image
+        measured <strong>754MB</strong>, down from 942MB before them. Re-verify the size on the
+        actual published <code>orb-v0.1.0</code> image as part of the checklist:
+      </p>
+      <CodeBlock
+        lang="bash"
+        code={`docker pull ghcr.io/jsonbored/gittensory-selfhost:orb-v0.1.0
+docker images ghcr.io/jsonbored/gittensory-selfhost:orb-v0.1.0 --format '{{.Size}}'`}
+      />
+      <Callout variant="note">
+        This audit is Dockerfile-derived, not a runtime scan. If a future dependency bump adds a
+        postinstall step that writes somewhere unexpected, re-check the{" "}
+        <code>runtime-prebuilt</code> stage's <code>COPY</code>/<code>RUN</code> steps directly
+        rather than assuming this list still holds.
+      </Callout>
+
+      <h2>One default image, not full/minimal variants</h2>
+      <p>
+        <code>INSTALL_AI_CLIS</code> is already a Dockerfile build-arg toggle (default{" "}
+        <code>true</code>), and <code>INSTALL_VISUAL_REVIEW</code> is a second, independent one
+        (default <code>false</code>) — see{" "}
+        <Link to="/docs/self-hosting-releases">custom images</Link>. That means the
+        &quot;minimal&quot; image the requirement asks about is already buildable today by anyone
+        who wants it, as a <em>custom</em> build.
+      </p>
+      <p>
+        For this first official release, publish only the one default (
+        <code>INSTALL_AI_CLIS=true</code>) image under <code>orb-v0.1.0</code>. Reasons:
+      </p>
+      <FeatureRow
+        items={[
+          {
+            title: "Every beta cut so far shipped this default",
+            description:
+              "Both orb-v0.1.0-beta.1 and orb-v0.1.0-beta.2 published the full image; a first stable release that changes what's default would be validating something the betas never tested.",
+          },
+          {
+            title: "A second published tag doubles release surface for no proven demand",
+            description:
+              "Publishing full and minimal both means twice the build/push/Sentry/SBOM matrix, twice the smoke-test matrix, and twice the tag-naming and docs surface to keep correct — before any operator has asked for a slimmer image.",
+          },
+          {
+            title: "The escape hatch already exists",
+            description:
+              "An operator who wants a smaller image without the AI CLIs can build it themselves today: docker compose build --build-arg INSTALL_AI_CLIS=false gittensory. Nothing about shipping one default image forecloses adding a published minimal tag later.",
+          },
+        ]}
+      />
+      <Callout variant="note">
+        Defer the full/minimal published-variant question, not the build-arg. If real operator
+        demand for a smaller published tag shows up post-release, it's a follow-up release-workflow
+        change (a second <code>docker/build-push-action</code> invocation with{" "}
+        <code>INSTALL_AI_CLIS=false</code> and its own tag suffix), not a blocker for cutting{" "}
+        <code>orb-v0.1.0</code>.
+      </Callout>
+
+      <h2>GitHub Release notes template</h2>
+      <p>
+        The release workflow&apos;s own &quot;GitHub Release&quot; step generates the notes body
+        programmatically (see <code>.github/workflows/release-selfhost.yml</code>) — it does not use{" "}
+        <code>--generate-notes</code>, specifically to avoid GitHub&apos;s 125,000-character
+        release-body limit on a large commit history. The template below matches that generated body
+        and extends it with the supported/experimental/optional/operator-owned breakdown this
+        checklist calls for. Paste it into the release description in addition to (or in place of)
+        the workflow-generated block when publishing <code>orb-v0.1.0</code>.
+      </p>
+      <CodeBlock
+        lang="markdown"
+        code={`Gittensory Orb container image:
+
+\`\`\`bash
+docker pull ghcr.io/jsonbored/gittensory-selfhost:orb-v0.1.0
+\`\`\`
+
+Multi-arch (linux/amd64 + linux/arm64). See https://gittensory.aethereal.dev/docs/maintainer-self-hosting for setup.
+Includes the Claude Code / Codex subscription CLIs by default; credentials stay runtime-only.
+Sentry release id baked into the image: \`gittensory-orb@0.1.0\`.
+
+## First stable release
+
+This is the first non-beta self-host image, following orb-v0.1.0-beta.1 and orb-v0.1.0-beta.2.
+The \`latest\` tag now points here.
+
+## Supported
+
+- Direct GitHub App mode (the container's own GitHub App private key).
+- SQLite (trial/single-node) and Postgres (production) database backends.
+- Redis cache (required in every mode).
+- Claude Code and Codex AI providers, including a provider chain with fallback.
+- Health/readiness endpoints (\`/health\`, \`/ready\`, \`/metrics\`) and the documented log-event contract.
+- Rollback to a prior image tag and one-service (\`gittensory\` only) restart, via
+  \`scripts/deploy-selfhost-image.sh\` / \`scripts/deploy-selfhost-prebuilt.sh\`.
+
+## Experimental
+
+- Brokered mode (\`ORB_ENROLLMENT_SECRET\`) — managed-beta / private use; both push and pull relay modes
+  are smoke-tested but see less real-world traffic than direct App mode.
+- Qdrant-backed RAG indexing.
+- Visual review via an external Chrome sidecar (\`INSTALL_VISUAL_REVIEW=true\`).
+
+## Optional
+
+- Sentry error tracking — OFF by default; set your own \`SENTRY_DSN\` to enable. Release source maps
+  are uploaded and validated for this image regardless of whether any operator enables runtime
+  reporting.
+- OpenTelemetry tracing/metrics export.
+- Discord/Slack review-outcome notifications.
+- The observability profile (Prometheus, Grafana, Loki, Alertmanager) and the backup profile.
+
+## Operator-owned
+
+- \`.env\`, \`gittensory-config/\`, and all data volumes (database, Redis, Qdrant, Grafana) — never
+  overwritten by an update and never baked into the image.
+- GitHub App credentials or \`ORB_ENROLLMENT_SECRET\`, AI-provider credentials, and any \`SENTRY_DSN\`.
+- Resource limits and profile selection — see [Resource profiles](/docs/self-hosting-operations)
+  for measured CPU/memory guidance per profile.
+- Backup and restore procedure — see [Backup and scaling](/docs/self-hosting-backup-scaling).
+
+Full changelog: compare against \`orb-v0.1.0-beta.2\`.`}
       />
 
       <p>

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-release-checklist.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-release-checklist.tsx
@@ -66,7 +66,7 @@ git push origin orb-v0.1.0`}
       </Callout>
       <p>
         Going forward, the scheme is ordinary semver under the <code>orb-v</code> prefix:{" "}
-        <code>orb-v0.1.1</code> for a patch, <code>orb-v0.2.0</code> for a feature bump, and an{" "}
+        <code>orb-v0.1.1</code> for a patch, the next minor version for a feature bump, and an{" "}
         <code>-rc.N</code>/<code>-beta.N</code> suffix on any tag that should run the pipeline
         without touching <code>latest</code> or the default GitHub Release. This checklist and the
         smoke matrix below apply to every future cut, not just the first.

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-release-checklist.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-release-checklist.tsx
@@ -553,19 +553,20 @@ docker rm -f gt-qdrant && docker network rm gt-rag-smoke`}
           {
             title: "apps/ (gittensory-ui) and test/ — excluded from the build context",
             description:
-              "Added to .dockerignore alongside the existing exclusions: the self-host bundle's only entry point is src/server.ts and npm ci only reads the root package*.json, so the UI workspace app and the test suite are never read during the image build (~11MB of this repo's ~22MB tracked-file footprint kept out).",
+              "Already in .dockerignore alongside the existing exclusions (shipped ahead of this checklist, in the same #1819 hardening pass): the self-host bundle's only entry point is src/server.ts and npm ci only reads the root package*.json, so the UI workspace app and the test suite are never read during the image build (~11MB of this repo's ~22MB tracked-file footprint kept out).",
           },
           {
             title: "npm install cache — trimmed",
             description:
-              "npm cache clean --force now runs immediately after the AI-CLI global install in the same RUN layer, removing the ~180MB download cache (~/.npm/_cacache) that npm install -g leaves behind but nothing at runtime ever reads.",
+              "npm cache clean --force already runs immediately after the AI-CLI global install in the same RUN layer, removing the ~180MB download cache (~/.npm/_cacache) that npm install -g leaves behind but nothing at runtime ever reads.",
           },
         ]}
       />
       <p>
-        Net effect of the two <code>.dockerignore</code>/Dockerfile changes above: the built image
-        measured <strong>754MB</strong>, down from 942MB before them. Re-verify the size on the
-        actual published <code>orb-v0.1.0</code> image as part of the checklist:
+        Net effect of the two <code>.dockerignore</code>/Dockerfile changes audited above (already
+        shipped, not part of this checklist itself): the built image measured <strong>754MB</strong>
+        , down from 942MB before them. Re-verify the size on the actual published{" "}
+        <code>orb-v0.1.0</code> image as part of the checklist:
       </p>
       <CodeBlock
         lang="bash"
@@ -677,9 +678,9 @@ The \`latest\` tag now points here.
 - \`.env\`, \`gittensory-config/\`, and all data volumes (database, Redis, Qdrant, Grafana) — never
   overwritten by an update and never baked into the image.
 - GitHub App credentials or \`ORB_ENROLLMENT_SECRET\`, AI-provider credentials, and any \`SENTRY_DSN\`.
-- Resource limits and profile selection — see [Resource profiles](/docs/self-hosting-operations)
+- Resource limits and profile selection — see [Resource profiles](https://gittensory.aethereal.dev/docs/self-hosting-operations)
   for measured CPU/memory guidance per profile.
-- Backup and restore procedure — see [Backup and scaling](/docs/self-hosting-backup-scaling).
+- Backup and restore procedure — see [Backup and scaling](https://gittensory.aethereal.dev/docs/self-hosting-backup-scaling).
 
 Full changelog: compare against \`orb-v0.1.0-beta.2\`.`}
       />

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-releases.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-releases.tsx
@@ -73,9 +73,9 @@ docker pull ghcr.io/jsonbored/gittensory-selfhost:latest`}
       </Callout>
       <Callout variant="safety">
         Before tagging any <code>orb-v*</code> release or prerelease, run the{" "}
-        <Link to="/docs/self-hosting-release-checklist">beta release checklist</Link> against the
-        built image — CI only smoke-tests the plain SQLite + Redis + direct-App default, not
-        brokered mode, air-gapped mode, or any AI provider.
+        <Link to="/docs/self-hosting-release-checklist">release checklist</Link> against the built
+        image — CI only smoke-tests the plain SQLite + Redis + direct-App default, not brokered
+        mode, air-gapped mode, or any AI provider.
       </Callout>
 
       <h2>Upgrade flow</h2>


### PR DESCRIPTION
## Summary

- Extends `docs.self-hosting-release-checklist.tsx` (previously the "Beta release checklist") to cover what Advances #1822 asks for on top of the existing beta smoke matrix: a versioning/trigger recommendation, a linear first-release checklist, a scenario/steps/pass-criteria smoke-test matrix table, a Dockerfile-derived image-contents audit, the full-vs-minimal-variant decision, and a GitHub Release notes template that mirrors the release workflow's own generated NOTES block.
- Renames the page/nav label to "Release checklist" (it's no longer beta-only) and updates the three other docs pages that linked to it under the old label.

**This is documentation only — it does not cut the `orb-v0.1.0` tag.** The maintainer still makes that go/no-go call themselves; this PR just finalizes the checklist so that call can be made against a written record instead of tribal knowledge.

### Versioning recommendation
`orb-v0.1.0-beta.1` and `orb-v0.1.0-beta.2` already ran the full release pipeline (multi-arch build, provenance, SBOM, Sentry source-map upload/validation, GitHub Release) successfully, twice. The natural next cut is `orb-v0.1.0` — a plain `X.Y.Z` tag with no prerelease suffix — because per the workflow's own guard (#1937/`release-selfhost.yml`'s "Resolve image tags" step), only a non-prerelease tag ever moves the `latest` image tag or produces an unmarked "Latest release." Documented as a rationale, not just the version number, plus a semver scheme for subsequent cuts.

### Image-contents audit (Dockerfile-derived, confirmed by reading the file — not assumed)
Read `Dockerfile`'s `runtime-prebuilt` target (what the release workflow actually builds via `docker/build-push-action`'s `target: runtime-prebuilt`) line by line. It `COPY`s exactly three things: `dist/server.mjs`, `migrations/`, and `config/examples/` (generic reference templates only). Confirmed:
- **No source maps**: `dist/server.mjs.map` is produced in the build stage but never `COPY`'d into `runtime-prebuilt` — only `dist/server.mjs` is. The map is uploaded to Sentry in the workflow instead.
- **No `.env`/secrets**: `.dockerignore` excludes `.env`, `.env.*`, `.dev.vars`; the Dockerfile never copies an env file — all secrets are runtime-supplied via `docker-compose.yml`'s `env_file`/`*_FILE` mounts.
- **No local auth**: `auth.json` and `**/.codex` are `.dockerignore`d; the image symlinks `/home/node/.codex` to an operator-mounted `/data/codex` volume, so any CLI auth an operator sets up lands on their own volume, never in an image layer.
- **No private repo config**: `gittensory-config`/`**/gittensory-config` are excluded; only `config/examples/` ships.
- **No data volumes / deployment overrides**: all declared as runtime docker-compose volumes/overrides, never part of the image filesystem.

No bug found here — the existing `.dockerignore`/Dockerfile boundary is already correct. Cited today's already-landed size improvement (942MB → 754MB from the `apps`/`test` dockerignore exclusions + `npm cache clean --force`) rather than re-doing that work.

### Sentry behavior (verified by reading `src/selfhost/sentry.ts`, not assumed)
`initSentry()` returns `false` immediately when `env.SENTRY_DSN` is unset (`src/selfhost/sentry.ts:365`), before `@sentry/node` is even imported — a complete no-op for any operator who doesn't set their own DSN. This is independent of the release workflow's own Sentry source-map upload/validation, which runs unconditionally for official images (gated on `SENTRY_AUTH_TOKEN` being configured in the `release` environment, not on any operator's runtime `SENTRY_DSN`).

### Image variant decision
`INSTALL_AI_CLIS` (default `true`) and `INSTALL_VISUAL_REVIEW` (default `false`) are already independent Dockerfile build-args, so a "minimal" image is already buildable today as a custom build. Recommendation: publish only the one default (full) image under `orb-v0.1.0` for this first release — both betas already shipped this default, and a second published variant doubles the release/smoke-test surface before any operator has asked for a slimmer tag. The build-arg escape hatch already covers the "minimal" need; only the *published, tagged* full/minimal question is deferred.

### GitHub Release notes template
Read the workflow's exact "GitHub Release" step (the `NOTES` heredoc and `gh release create`/`edit` invocation) and wrote a template that starts from that identical block, then extends it with the supported/experimental/optional/operator-owned breakdown the issue asks for — not an invented format.

No code changes were needed or made; this PR is docs-only.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed. (Advances #1822 — not a closing keyword; cutting the actual `orb-v0.1.0` tag is a separate, deliberate maintainer action after this checklist lands, so the issue should stay open until that happens.)

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` (not run — no workflow files changed)
- [x] `npm run typecheck` via `npm run ui:typecheck`
- [ ] `npm run test:coverage` (not run — docs-only change under `apps/gittensory-ui/**`, which Codecov does not measure; no `src/**` lines changed)
- [ ] `npm run test:workers` (not run — no worker/runtime code changed)
- [ ] `npm run build:mcp` (not run — no MCP code changed)
- [ ] `npm run test:mcp-pack` (not run — no MCP code changed)
- [ ] `npm run ui:openapi:check` (not run — no API/schema changed)
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate` (not run — no dependency changes)
- [x] `npm run docs:drift-check`
- [ ] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries (not applicable — no `src/**` behavior changed)

If any required check was skipped, explain why:

- This PR only touches `apps/gittensory-ui/src/**` docs/nav content. The skipped checks above (`test:coverage`, `test:workers`, `build:mcp`, `test:mcp-pack`, `ui:openapi:check`, `npm audit`, `actionlint`) all gate `src/**`, worker runtime, MCP packaging, API schema, or dependency surfaces, none of which changed. Ran the full set of checks that do apply to a UI/docs change: `ui:lint`, `ui:typecheck`, `ui:build`, and `docs:drift-check` (all green).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no such changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — none changed.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — static docs content only.)
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots. (Text-only docs content change — no new visual components, colors, or layout primitives introduced; verified render via local preview instead, see Notes.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (`CHANGELOG.md` untouched, as required for a normal PR.)

## Notes

- Verified the new page renders correctly in a local preview (all 8 new/updated `<h2>` sections present in order, the smoke-test matrix table renders with real content, and the GitHub Release notes markdown code block — including its nested ` ```bash ` fence — renders intact). Screenshots aren't attached here per the "no purely textual/structural docs change" carve-out implied by the evidence table's own scope (loaded/empty/error/mobile *states*) — there is no new visual state to capture, only new prose/table/code-block content on an existing page pattern already used elsewhere in this same docs section (e.g. the Resource-profiles table in `docs.self-hosting-operations.tsx`).
- What still requires the maintainer's own judgment call: the actual go/no-go moment to push the `orb-v0.1.0` tag, approval of the `release` GitHub Environment gate when that run fires, and confirming real-world operator demand (or lack of it) before ever publishing a second `minimal` image variant.