### PR TITLE
feat(enrichment): expand EOL runtime pin parsing for Swift, Perl, Erlang, and Heroku

### DIFF
--- a/apps/gittensory-ui/src/lib/rees-analyzers.ts
+++ b/apps/gittensory-ui/src/lib/rees-analyzers.ts
@@ -251,7 +251,8 @@ export const REES_ANALYZERS = [
     },
     docs: {
       summary: "Checks changed runtime and base-image pins against EOL calendars.",
-      looksAt: "Dockerfile FROM lines, .nvmrc, and go.mod runtime pins.",
+      looksAt:
+        "Dockerfile FROM lines, version-manager pin files (.nvmrc, .python-version, …), Heroku runtime.txt, Gemfile ruby directives, and go.mod runtime pins.",
       reports:
         "File, product, version, EOL date, and whether the release is already EOL or close to EOL.",
       network: "Calls endoflife.date. No GitHub token required.",

--- a/review-enrichment/analyzer-metadata.json
+++ b/review-enrichment/analyzer-metadata.json
@@ -281,7 +281,7 @@
       },
       "docs": {
         "summary": "Checks changed runtime and base-image pins against EOL calendars.",
-        "looksAt": "Dockerfile FROM lines, .nvmrc, and go.mod runtime pins.",
+        "looksAt": "Dockerfile FROM lines, version-manager pin files (.nvmrc, .python-version, …), Heroku runtime.txt, Gemfile ruby directives, and go.mod runtime pins.",
         "reports": "File, product, version, EOL date, and whether the release is already EOL or close to EOL.",
         "network": "Calls endoflife.date. No GitHub token required.",
         "notes": "Only changed pins are checked; existing old runtimes outside the PR are not reported."

--- a/review-enrichment/src/analyzers/eol-check.ts
+++ b/review-enrichment/src/analyzers/eol-check.ts
@@ -56,7 +56,72 @@ const TOOL_VERSION_PRODUCT: Record<string, string> = {
   terraform: "terraform",
   elixir: "elixir",
   kotlin: "kotlin",
+  swift: "swift",
+  perl: "perl",
+  erlang: "erlang",
 };
+
+// Heroku `runtime.txt` runtime prefix → endoflife.date product slug.
+const RUNTIME_TXT_PRODUCT: Record<string, string> = {
+  python: "python",
+  ruby: "ruby",
+  nodejs: "nodejs",
+  node: "nodejs",
+};
+
+/** Parse one Heroku `runtime.txt` line (`python-3.11.6`, `ruby-3.2.2`) into an EOL product + version. Pure. */
+export function parseRuntimeTxtLine(
+  line: string,
+): { product: string; version: string } | null {
+  const trimmed = line.trim();
+  if (!trimmed || trimmed.startsWith("#")) return null;
+  const match = /^([a-z]+)-(.+)$/.exec(trimmed);
+  if (!match) return null;
+  const product = RUNTIME_TXT_PRODUCT[match[1]!.toLowerCase()];
+  const version = leadingVersion(match[2]!);
+  if (!product || !version) return null;
+  return { product, version };
+}
+
+/** Parse one Gemfile `ruby` directive into an EOL product + version. Pure. */
+export function parseGemfileRubyLine(
+  line: string,
+): { product: string; version: string } | null {
+  const trimmed = line.trim();
+  if (!trimmed || trimmed.startsWith("#")) return null;
+  const match = /^ruby\s+["']([^"']+)["']/.exec(trimmed);
+  if (!match) return null;
+  const version = leadingVersion(match[1]!.replace(/^[^0-9v]+/, ""));
+  if (!version) return null;
+  return { product: "ruby", version };
+};
+
+/** Whether `path` is a runtime-pin location the EOL analyzer parses. Exported so the scheduler gate shares
+ *  ONE predicate and cannot drift from what this analyzer scans. */
+export function isRuntimePinPath(path: string): boolean {
+  const base = path.split("/").pop() ?? path;
+  return (
+    isDockerfile(path) ||
+    base === ".nvmrc" ||
+    base === ".node-version" ||
+    base === ".python-version" ||
+    base === ".ruby-version" ||
+    base === ".php-version" ||
+    base === ".go-version" ||
+    base === ".rust-version" ||
+    base === ".java-version" ||
+    base === ".terraform-version" ||
+    base === ".elixir-version" ||
+    base === ".kotlin-version" ||
+    base === ".swift-version" ||
+    base === ".perl-version" ||
+    base === ".erlang-version" ||
+    base === ".tool-versions" ||
+    base === "runtime.txt" ||
+    base === "Gemfile" ||
+    base === "go.mod"
+  );
+}
 
 /** Parse one asdf `.tool-versions` line (`tool version [system]`) into an EOL product + version. Pure. */
 export function parseToolVersionLine(
@@ -159,6 +224,36 @@ export function extractVersionPins(
         // asdf/kotlin pin file — same leading-version format, product is Kotlin.
         const version = leadingVersion(line);
         if (version) pins.push({ file: file.path, product: "kotlin", version });
+      } else if (base === ".swift-version") {
+        // swiftenv/asdf pin file — same leading-version format, product is Swift.
+        const version = leadingVersion(line);
+        if (version) pins.push({ file: file.path, product: "swift", version });
+      } else if (base === ".perl-version") {
+        // plenv/asdf pin file — same leading-version format, product is Perl.
+        const version = leadingVersion(line);
+        if (version) pins.push({ file: file.path, product: "perl", version });
+      } else if (base === ".erlang-version") {
+        // kerl/asdf pin file — same leading-version format, product is Erlang.
+        const version = leadingVersion(line);
+        if (version) pins.push({ file: file.path, product: "erlang", version });
+      } else if (base === "runtime.txt") {
+        // Heroku stack runtime pin — `python-3.11.6`, `ruby-3.2.2`, etc.
+        const parsed = parseRuntimeTxtLine(line);
+        if (parsed)
+          pins.push({
+            file: file.path,
+            product: parsed.product,
+            version: parsed.version,
+          });
+      } else if (base === "Gemfile") {
+        // Bundler `ruby "X.Y.Z"` directive — the repo's declared Ruby runtime.
+        const parsed = parseGemfileRubyLine(line);
+        if (parsed)
+          pins.push({
+            file: file.path,
+            product: parsed.product,
+            version: parsed.version,
+          });
       } else if (base === ".tool-versions") {
         // asdf multi-tool pin file — one `tool version` pair per line.
         const parsed = parseToolVersionLine(line);

--- a/review-enrichment/src/analyzers/registry.ts
+++ b/review-enrichment/src/analyzers/registry.ts
@@ -156,7 +156,8 @@ export const ANALYZER_DESCRIPTORS = [
     limits: { maxFiles: 40, maxPatchLines: 1000, maxPins: 80 },
     docs: {
       summary: "Checks changed runtime and base-image pins against EOL calendars.",
-      looksAt: "Dockerfile FROM lines, .nvmrc, and go.mod runtime pins.",
+      looksAt:
+        "Dockerfile FROM lines, version-manager pin files (.nvmrc, .python-version, …), Heroku runtime.txt, Gemfile ruby directives, and go.mod runtime pins.",
       reports:
         "File, product, version, EOL date, and whether the release is already EOL or close to EOL.",
       network: "Calls endoflife.date. No GitHub token required.",

--- a/review-enrichment/src/scheduler.ts
+++ b/review-enrichment/src/scheduler.ts
@@ -4,7 +4,7 @@ import {
   ANALYZER_NAMES,
   getAnalyzerDescriptor,
 } from "./analyzers/registry.js";
-import { isDockerfile } from "./analyzers/eol-check.js";
+import { isRuntimePinPath } from "./analyzers/eol-check.js";
 import type {
   AnalyzerCostClass,
   AnalyzerDescriptor,
@@ -397,28 +397,4 @@ function historyCanRunWithoutGitHub(
   name: AnalyzerName,
 ): boolean {
   return name === "history" && Boolean(req.linkedIssue && (req.diff || req.files?.length));
-}
-
-function isRuntimePinPath(path: string): boolean {
-  const basename = path.split("/").pop() ?? path;
-  // Share the eol analyzer's own Dockerfile predicate so the gate can't skip a file the analyzer would
-  // parse. The prior bespoke `/^Dockerfile(?:\..*)?$/` missed `*.dockerfile` (e.g. web.dockerfile), silently
-  // dropping eol analysis for it even though isDockerfile() handles it.
-  // Version-manager pin files (nodenv/pyenv/rbenv/phpenv/goenv and asdf) the eol analyzer parses.
-  return (
-    isDockerfile(path) ||
-    basename === ".nvmrc" ||
-    basename === ".node-version" ||
-    basename === ".python-version" ||
-    basename === ".ruby-version" ||
-    basename === ".php-version" ||
-    basename === ".go-version" ||
-    basename === ".rust-version" ||
-    basename === ".java-version" ||
-    basename === ".terraform-version" ||
-    basename === ".elixir-version" ||
-    basename === ".kotlin-version" ||
-    basename === ".tool-versions" ||
-    basename === "go.mod"
-  );
 }

--- a/review-enrichment/test/eol-check.test.ts
+++ b/review-enrichment/test/eol-check.test.ts
@@ -5,6 +5,9 @@ import assert from "node:assert/strict";
 import {
   extractVersionPins,
   isDockerfile,
+  isRuntimePinPath,
+  parseGemfileRubyLine,
+  parseRuntimeTxtLine,
   parseToolVersionLine,
 } from "../dist/analyzers/eol-check.js";
 
@@ -110,6 +113,99 @@ test("extractVersionPins reads .terraform-version pins as Terraform", () => {
   assert.deepEqual(extractVersionPins([added(".terraform-version", "1.5.7")]), [
     { file: ".terraform-version", product: "terraform", version: "1.5.7" },
   ]);
+});
+
+test("extractVersionPins reads .swift-version, .perl-version, and .erlang-version pins", () => {
+  assert.deepEqual(extractVersionPins([added(".swift-version", "5.9.2")]), [
+    { file: ".swift-version", product: "swift", version: "5.9.2" },
+  ]);
+  assert.deepEqual(extractVersionPins([added(".perl-version", "5.38.0")]), [
+    { file: ".perl-version", product: "perl", version: "5.38.0" },
+  ]);
+  assert.deepEqual(extractVersionPins([added(".erlang-version", "26.2.1")]), [
+    { file: ".erlang-version", product: "erlang", version: "26.2.1" },
+  ]);
+});
+
+test("parseRuntimeTxtLine maps Heroku runtime.txt prefixes to endoflife.date products", () => {
+  assert.deepEqual(parseRuntimeTxtLine("python-3.11.6"), {
+    product: "python",
+    version: "3.11.6",
+  });
+  assert.deepEqual(parseRuntimeTxtLine("ruby-3.2.2"), {
+    product: "ruby",
+    version: "3.2.2",
+  });
+  assert.deepEqual(parseRuntimeTxtLine("nodejs-18.17.0"), {
+    product: "nodejs",
+    version: "18.17.0",
+  });
+  assert.deepEqual(parseRuntimeTxtLine("node-20.11.0"), {
+    product: "nodejs",
+    version: "20.11.0",
+  });
+  assert.equal(parseRuntimeTxtLine("# python-3.10.0"), null);
+  assert.equal(parseRuntimeTxtLine("unknown-1.2.3"), null);
+  assert.equal(parseRuntimeTxtLine(""), null);
+});
+
+test("extractVersionPins reads Heroku runtime.txt pins from added lines", () => {
+  assert.deepEqual(
+    extractVersionPins([added("runtime.txt", "python-3.11.6", "# ruby-3.2.2")]),
+    [{ file: "runtime.txt", product: "python", version: "3.11.6" }],
+  );
+});
+
+test("parseGemfileRubyLine maps Bundler ruby directives to Ruby runtime pins", () => {
+  assert.deepEqual(parseGemfileRubyLine('ruby "3.2.2"'), {
+    product: "ruby",
+    version: "3.2.2",
+  });
+  assert.deepEqual(parseGemfileRubyLine("ruby '~> 3.2.2'"), {
+    product: "ruby",
+    version: "3.2.2",
+  });
+  assert.deepEqual(parseGemfileRubyLine('ruby ">= 3.2.0"'), {
+    product: "ruby",
+    version: "3.2.0",
+  });
+  assert.equal(parseGemfileRubyLine("# ruby \"2.7.0\""), null);
+  assert.equal(parseGemfileRubyLine('source "https://rubygems.org"'), null);
+});
+
+test("extractVersionPins reads Gemfile ruby directives from added lines", () => {
+  assert.deepEqual(
+    extractVersionPins([
+      added("Gemfile", 'source "https://rubygems.org"', 'ruby "3.2.2"'),
+    ]),
+    [{ file: "Gemfile", product: "ruby", version: "3.2.2" }],
+  );
+});
+
+test("parseToolVersionLine maps swift, perl, and erlang asdf plugin names", () => {
+  assert.deepEqual(parseToolVersionLine("swift 5.9.2"), {
+    product: "swift",
+    version: "5.9.2",
+  });
+  assert.deepEqual(parseToolVersionLine("perl 5.38.0"), {
+    product: "perl",
+    version: "5.38.0",
+  });
+  assert.deepEqual(parseToolVersionLine("erlang 26.2.1"), {
+    product: "erlang",
+    version: "26.2.1",
+  });
+});
+
+test("isRuntimePinPath recognizes new pin locations and rejects unrelated paths", () => {
+  assert.equal(isRuntimePinPath("runtime.txt"), true);
+  assert.equal(isRuntimePinPath("Gemfile"), true);
+  assert.equal(isRuntimePinPath(".swift-version"), true);
+  assert.equal(isRuntimePinPath(".perl-version"), true);
+  assert.equal(isRuntimePinPath(".erlang-version"), true);
+  assert.equal(isRuntimePinPath("deploy/runtime.txt"), true);
+  assert.equal(isRuntimePinPath("src/app.ts"), false);
+  assert.equal(isRuntimePinPath("Gemfile.lock"), false);
 });
 
 test("extractVersionPins reads .elixir-version and .kotlin-version pins", () => {

--- a/review-enrichment/test/scheduler.test.ts
+++ b/review-enrichment/test/scheduler.test.ts
@@ -327,3 +327,34 @@ test("eol runs for a *.dockerfile path (gate shares the analyzer's Dockerfile pr
   assert.equal(brief.analyzerStatus.eol, "ok");
   assert.notEqual(brief.telemetry.analyzers.eol.skipReason, "no_runtime_pin");
 });
+
+test("eol runs for runtime.txt and Gemfile paths (gate shares isRuntimePinPath)", async () => {
+  let eolRan = false;
+  const brief = await buildBrief(
+    {
+      repoFullName: "JSONbored/gittensory",
+      prNumber: 3253,
+      analyzers: ["eol"],
+      files: [
+        {
+          path: "runtime.txt",
+          patch: "@@ -1,0 +1,1 @@\n+python-3.11.6",
+        },
+        {
+          path: "Gemfile",
+          patch: '@@ -1,0 +1,1 @@\n+ruby "3.2.2"',
+        },
+      ],
+    },
+    {
+      eol: async () => {
+        eolRan = true;
+        return [];
+      },
+    },
+  );
+
+  assert.equal(eolRan, true);
+  assert.equal(brief.analyzerStatus.eol, "ok");
+  assert.notEqual(brief.telemetry.analyzers.eol.skipReason, "no_runtime_pin");
+});


### PR DESCRIPTION
## Summary
- Extend the EOL analyzer to parse Swift (`.swift-version`), Perl (`.perl-version`), and Erlang (`.erlang-version`) version-manager pin files, plus Heroku `runtime.txt` and Bundler `Gemfile` `ruby` directives.
- Export `isRuntimePinPath()` from `eol-check.ts` and wire the scheduler gate to it so new pin locations cannot silently skip EOL analysis.
- Add asdf plugin aliases for `swift`, `perl`, and `erlang` in `.tool-versions` parsing.

## Motivation
Teams deploying to Heroku or using swiftenv/plenv/kerl pin runtimes in files the EOL analyzer previously ignored. This closes that gap and keeps the scheduler gate aligned with the parser via a shared predicate.

## Test plan
- [x] `parseRuntimeTxtLine` — python/ruby/nodejs prefixes, comments, unknown runtimes
- [x] `parseGemfileRubyLine` — bare pins, `~>`, `>=` constraints, comment/source lines
- [x] `extractVersionPins` — `.swift-version`, `.perl-version`, `.erlang-version`, `runtime.txt`, `Gemfile`
- [x] `isRuntimePinPath` — positive/negative path coverage
- [x] Scheduler integration — EOL runs when only `runtime.txt` / `Gemfile` change
- [x] `npm run build` in `review-enrichment/`


Made with [Cursor](https://cursor.com)