### PR TITLE
ci(workflows): enforce generated-artifact drift checks in CI, not just locally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,19 +209,25 @@ jobs:
       # firstReference line numbers point into src/selfhost/ai.ts, so any backend change that shifts those
       # lines (not just one that adds/removes an env var) can make it stale. Was previously enforced ONLY by
       # the local `npm run test:ci` aggregate script, never by this workflow -- went stale twice in one day
-      # (2026-07-04) with zero CI signal until someone happened to run the full local script.
+      # (2026-07-04) with zero CI signal until someone happened to run the full local script. Gated on `ui`
+      # too, not just `backend`: the generated file itself lives under apps/gittensory-ui/**, so a PR that
+      # hand-edits it (or a docs page docs:drift-check below cross-checks) without touching backend source
+      # would otherwise never re-run this check.
       - name: Selfhost env-reference drift check
-        if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' }}
+        if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.ui == 'true' }}
         run: npm run selfhost:env-reference:check
       # Same generated-artifact-drift class, extracted from src/github/commands.ts's command catalogs (#3046).
-      # Also local-only until now.
+      # Also local-only until now; same backend-or-ui gating rationale as the step above.
       - name: Command reference drift check
-        if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' }}
+        if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.ui == 'true' }}
         run: npm run command-reference:check
       # Cross-checks docs pages against source-of-truth enumerable surfaces (feature flags, commands, gate
-      # modes) -- see the script's own header comment. Also local-only until now.
+      # modes) -- see the script's own header comment. Also local-only until now; gated on `ui` as well as
+      # `backend` since the docs pages it validates are themselves UI-side content that can drift on their
+      # own (a docs-only edit that renames/drops a documented flag/command/gate-mode) with no backend change
+      # to trigger a re-check otherwise.
       - name: Docs drift check
-        if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' }}
+        if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.ui == 'true' }}
         run: npm run docs:drift-check
       - name: Validate observability configs
         if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.observability == 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,6 +205,24 @@ jobs:
       - name: cf-typegen drift check
         if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' }}
         run: npm run cf-typegen:check
+      # Same drift class as cf-typegen/schema-drift above, just a different generated artifact: this file's
+      # firstReference line numbers point into src/selfhost/ai.ts, so any backend change that shifts those
+      # lines (not just one that adds/removes an env var) can make it stale. Was previously enforced ONLY by
+      # the local `npm run test:ci` aggregate script, never by this workflow -- went stale twice in one day
+      # (2026-07-04) with zero CI signal until someone happened to run the full local script.
+      - name: Selfhost env-reference drift check
+        if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' }}
+        run: npm run selfhost:env-reference:check
+      # Same generated-artifact-drift class, extracted from src/github/commands.ts's command catalogs (#3046).
+      # Also local-only until now.
+      - name: Command reference drift check
+        if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' }}
+        run: npm run command-reference:check
+      # Cross-checks docs pages against source-of-truth enumerable surfaces (feature flags, commands, gate
+      # modes) -- see the script's own header comment. Also local-only until now.
+      - name: Docs drift check
+        if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' }}
+        run: npm run docs:drift-check
       - name: Validate observability configs
         if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.observability == 'true' }}
         env:

--- a/apps/gittensory-ui/src/lib/selfhost-env-reference.ts
+++ b/apps/gittensory-ui/src/lib/selfhost-env-reference.ts
@@ -15,11 +15,11 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "AI_EMBED_API_KEY",
-    firstReference: "src/server.ts:440",
+    firstReference: "src/server.ts:441",
   },
   {
     name: "AI_EMBED_BASE_URL",
-    firstReference: "src/server.ts:437",
+    firstReference: "src/server.ts:438",
   },
   {
     name: "AI_EMBED_MODEL",
@@ -47,7 +47,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "BACKUP_ACKNOWLEDGED",
-    firstReference: "src/server.ts:379",
+    firstReference: "src/server.ts:380",
   },
   {
     name: "BROWSER_WS_ENDPOINT",
@@ -83,11 +83,11 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "CRON_INTERVAL_MS",
-    firstReference: "src/server.ts:917",
+    firstReference: "src/server.ts:919",
   },
   {
     name: "DATABASE_PATH",
-    firstReference: "src/server.ts:249",
+    firstReference: "src/server.ts:250",
   },
   {
     name: "DATABASE_URL",
@@ -127,7 +127,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "GITHUB_CACHE_TTL_SECONDS",
-    firstReference: "src/server.ts:509",
+    firstReference: "src/server.ts:510",
   },
   {
     name: "GITHUB_INSTALLATION_CONCURRENCY_DEFER_MS",
@@ -143,7 +143,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "GITTENSORY_REPO_CONFIG_DIR",
-    firstReference: "src/server.ts:288",
+    firstReference: "src/server.ts:289",
   },
   {
     name: "GITTENSORY_VERSION",
@@ -187,7 +187,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "MIGRATIONS_DIR",
-    firstReference: "src/server.ts:392",
+    firstReference: "src/server.ts:393",
   },
   {
     name: "OBSERVABILITY_SMOKE_POLL_MS",
@@ -247,7 +247,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "ORB_BROKER_URL",
-    firstReference: "src/server.ts:966",
+    firstReference: "src/server.ts:968",
   },
   {
     name: "ORB_COLLECTOR_TOKEN",
@@ -263,7 +263,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "ORB_RELAY_MODE",
-    firstReference: "src/server.ts:968",
+    firstReference: "src/server.ts:970",
   },
   {
     name: "OTEL_EXPORTER_OTLP_ENDPOINT",
@@ -299,11 +299,11 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "PGVECTOR_ENABLED",
-    firstReference: "src/server.ts:229",
+    firstReference: "src/server.ts:230",
   },
   {
     name: "PORT",
-    firstReference: "src/server.ts:716",
+    firstReference: "src/server.ts:718",
   },
   {
     name: "PUBLIC_API_ORIGIN",
@@ -319,7 +319,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "QDRANT_URL",
-    firstReference: "src/server.ts:528",
+    firstReference: "src/server.ts:529",
   },
   {
     name: "QUEUE_BACKGROUND_CONCURRENCY",
@@ -343,7 +343,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "REVIEW_AUDIT_DIR",
-    firstReference: "src/server.ts:573",
+    firstReference: "src/server.ts:574",
   },
   {
     name: "SELFHOST_BUNDLE_ALL",
@@ -379,7 +379,7 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
   },
   {
     name: "SETUP_OUTPUT_PATH",
-    firstReference: "src/server.ts:833",
+    firstReference: "src/server.ts:835",
   },
   {
     name: "SLACK_WEBHOOK_URL",
@@ -392,15 +392,15 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| --- | --- |",
   "| `AI_COMBINE` | `src/selfhost/ai.ts:1028` |",
   "| `AI_DUAL_REVIEW` | `src/selfhost/ai.ts:1003` |",
-  "| `AI_EMBED_API_KEY` | `src/server.ts:440` |",
-  "| `AI_EMBED_BASE_URL` | `src/server.ts:437` |",
+  "| `AI_EMBED_API_KEY` | `src/server.ts:441` |",
+  "| `AI_EMBED_BASE_URL` | `src/server.ts:438` |",
   "| `AI_EMBED_MODEL` | `src/selfhost/ai.ts:900` |",
   "| `AI_ON_MERGE` | `src/selfhost/ai.ts:1030` |",
   "| `AI_PROVIDER` | `src/selfhost/ai-config.ts:43` |",
   "| `ANTHROPIC_AI_BASE_URL` | `src/selfhost/ai.ts:904` |",
   "| `ANTHROPIC_AI_MODEL` | `src/selfhost/ai.ts:87` |",
   "| `ANTHROPIC_API_KEY` | `src/selfhost/ai.ts:903` |",
-  "| `BACKUP_ACKNOWLEDGED` | `src/server.ts:379` |",
+  "| `BACKUP_ACKNOWLEDGED` | `src/server.ts:380` |",
   "| `BROWSER_WS_ENDPOINT` | `src/selfhost/stubs/puppeteer.ts:11` |",
   "| `CLAUDE_AI_EFFORT` | `src/selfhost/ai.ts:138` |",
   "| `CLAUDE_AI_MODEL` | `src/selfhost/ai.ts:79` |",
@@ -409,8 +409,8 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| `CODEX_AI_MODEL` | `src/selfhost/ai.ts:83` |",
   "| `CODEX_AI_TIMEOUT_MS` | `src/selfhost/ai.ts:142` |",
   "| `CODEX_HOME` | `src/selfhost/ai.ts:309` |",
-  "| `CRON_INTERVAL_MS` | `src/server.ts:917` |",
-  "| `DATABASE_PATH` | `src/server.ts:249` |",
+  "| `CRON_INTERVAL_MS` | `src/server.ts:919` |",
+  "| `DATABASE_PATH` | `src/server.ts:250` |",
   "| `DATABASE_URL` | `src/selfhost/preflight.ts:201` |",
   "| `DISCORD_REPO_WEBHOOKS` | `src/services/notify-discord.ts:41` |",
   "| `DISCORD_WEBHOOK_URL` | `src/services/notify-discord.ts:78` |",
@@ -420,11 +420,11 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| `FOREGROUND_LIVENESS_MAX_RELEASE_PER_SWEEP` | `src/selfhost/foreground-liveness.ts:53` |",
   "| `GITHUB_APP_ID` | `src/selfhost/orb-collector.ts:59` |",
   "| `GITHUB_APP_PRIVATE_KEY` | `src/selfhost/orb-collector.ts:166` |",
-  "| `GITHUB_CACHE_TTL_SECONDS` | `src/server.ts:509` |",
+  "| `GITHUB_CACHE_TTL_SECONDS` | `src/server.ts:510` |",
   "| `GITHUB_INSTALLATION_CONCURRENCY_DEFER_MS` | `src/selfhost/installation-concurrency-admission.ts:47` |",
   "| `GITHUB_INSTALLATION_CONCURRENCY_ENABLED` | `src/selfhost/installation-concurrency-admission.ts:34` |",
   "| `GITHUB_INSTALLATION_CONCURRENCY_LIMIT` | `src/selfhost/installation-concurrency-admission.ts:43` |",
-  "| `GITTENSORY_REPO_CONFIG_DIR` | `src/server.ts:288` |",
+  "| `GITTENSORY_REPO_CONFIG_DIR` | `src/server.ts:289` |",
   "| `GITTENSORY_VERSION` | `src/selfhost/otel.ts:62` |",
   "| `HOME` | `src/selfhost/ai.ts:309` |",
   "| `MAINTENANCE_ADMISSION_DEFER_MS` | `src/selfhost/maintenance-admission.ts:171` |",
@@ -435,7 +435,7 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| `MAINTENANCE_ADMISSION_MAX_LIVE_AGE_MS` | `src/selfhost/maintenance-admission.ts:155` |",
   "| `MAINTENANCE_ADMISSION_MAX_LIVE_PENDING` | `src/selfhost/maintenance-admission.ts:151` |",
   "| `MAINTENANCE_ADMISSION_MAX_PENDING` | `src/selfhost/maintenance-admission.ts:159` |",
-  "| `MIGRATIONS_DIR` | `src/server.ts:392` |",
+  "| `MIGRATIONS_DIR` | `src/server.ts:393` |",
   "| `OBSERVABILITY_SMOKE_POLL_MS` | `scripts/smoke-observability-traces.mjs:8` |",
   "| `OBSERVABILITY_SMOKE_TIMEOUT_MS` | `scripts/smoke-observability-traces.mjs:6` |",
   "| `OLLAMA_AI_API_KEY` | `src/selfhost/ai.ts:897` |",
@@ -450,11 +450,11 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| `ORB_AIR_GAP` | `src/selfhost/orb-collector.ts:161` |",
   "| `ORB_ANONYMIZE` | `src/selfhost/orb-collector.ts:174` |",
   "| `ORB_APP_ID` | `src/selfhost/orb-collector.ts:59` |",
-  "| `ORB_BROKER_URL` | `src/server.ts:966` |",
+  "| `ORB_BROKER_URL` | `src/server.ts:968` |",
   "| `ORB_COLLECTOR_TOKEN` | `src/selfhost/orb-collector.ts:205` |",
   "| `ORB_COLLECTOR_URL` | `src/selfhost/orb-collector.ts:172` |",
   "| `ORB_ENROLLMENT_SECRET` | `src/selfhost/orb-collector.ts:165` |",
-  "| `ORB_RELAY_MODE` | `src/server.ts:968` |",
+  "| `ORB_RELAY_MODE` | `src/server.ts:970` |",
   "| `OTEL_EXPORTER_OTLP_ENDPOINT` | `src/selfhost/otel.ts:47` |",
   "| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | `src/selfhost/otel.ts:45` |",
   "| `OTEL_SERVICE_ENVIRONMENT` | `src/selfhost/otel.ts:60` |",
@@ -463,18 +463,18 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| `OTEL_TRACES_SAMPLER` | `src/selfhost/otel.ts:74` |",
   "| `OTEL_TRACES_SAMPLER_ARG` | `src/selfhost/otel.ts:76` |",
   "| `PGPOOL_MAX` | `src/selfhost/queue-common.ts:713` |",
-  "| `PGVECTOR_ENABLED` | `src/server.ts:229` |",
-  "| `PORT` | `src/server.ts:716` |",
+  "| `PGVECTOR_ENABLED` | `src/server.ts:230` |",
+  "| `PORT` | `src/server.ts:718` |",
   "| `PUBLIC_API_ORIGIN` | `src/selfhost/preflight.ts:192` |",
   "| `QDRANT_API_KEY` | `src/selfhost/qdrant-vectorize.ts:50` |",
   "| `QDRANT_DIM` | `src/selfhost/qdrant-vectorize.ts:71` |",
-  "| `QDRANT_URL` | `src/server.ts:528` |",
+  "| `QDRANT_URL` | `src/server.ts:529` |",
   "| `QUEUE_BACKGROUND_CONCURRENCY` | `src/selfhost/queue-common.ts:130` |",
   "| `QUEUE_CONCURRENCY` | `src/selfhost/pg-queue.ts:286` |",
   "| `QUEUE_DEAD_LETTER_AUTO_RETRY_MAX_EXTRA_ATTEMPTS` | `src/selfhost/queue-common.ts:721` |",
   "| `QUEUE_STARTUP_JITTER_MIN_JOBS` | `src/selfhost/queue-common.ts:702` |",
   "| `REDIS_URL` | `src/selfhost/preflight.ts:144` |",
-  "| `REVIEW_AUDIT_DIR` | `src/server.ts:573` |",
+  "| `REVIEW_AUDIT_DIR` | `src/server.ts:574` |",
   "| `SELFHOST_BUNDLE_ALL` | `scripts/build-selfhost.mjs:13` |",
   "| `SELFHOST_SERVICE` | `scripts/smoke-observability-traces.mjs:5` |",
   "| `SELFHOST_SETUP_TOKEN` | `src/selfhost/preflight.ts:186` |",
@@ -483,6 +483,6 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| `SENTRY_RELEASE` | `src/selfhost/otel.ts:62` |",
   "| `SENTRY_SERVER_NAME` | `src/selfhost/sentry.ts:407` |",
   "| `SENTRY_TRACES_SAMPLE_RATE` | `src/selfhost/sentry.ts:195` |",
-  "| `SETUP_OUTPUT_PATH` | `src/server.ts:833` |",
+  "| `SETUP_OUTPUT_PATH` | `src/server.ts:835` |",
   "| `SLACK_WEBHOOK_URL` | `src/services/notify-discord.ts:173` |",
 ].join("\n");

--- a/test/unit/ci-generated-artifact-drift-checks.test.ts
+++ b/test/unit/ci-generated-artifact-drift-checks.test.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from "node:fs";
+import { parse } from "yaml";
+import { describe, expect, it } from "vitest";
+
+function readYaml(path: string): Record<string, unknown> {
+  return record(parse(readFileSync(path, "utf8")), path);
+}
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function recordArray(value: unknown, label: string): Array<Record<string, unknown>> {
+  if (!Array.isArray(value)) throw new Error(`${label} must be an array`);
+  return value.map((entry, index) => record(entry, `${label}[${index}]`));
+}
+
+// Generated-artifact drift guard: selfhost:env-reference:check, command-reference:check, and docs:drift-check
+// were each part of the local `npm run test:ci` aggregate script, but none were wired into
+// .github/workflows/ci.yml's validate-code job -- only local discipline enforced them, so a merged PR could (and
+// did, twice in one day) leave the corresponding generated reference file or docs page stale with zero CI
+// signal. Mirrors ci-cf-typegen-check.test.ts's own assertion shape for the same class of drift guard.
+describe("generated-artifact drift checks are wired into CI, not just local test:ci", () => {
+  const checks: Array<{ script: string; command: string; stepName: string }> = [
+    { script: "selfhost:env-reference:check", command: "npm run selfhost:env-reference:check", stepName: "Selfhost env-reference drift check" },
+    { script: "command-reference:check", command: "npm run command-reference:check", stepName: "Command reference drift check" },
+    { script: "docs:drift-check", command: "npm run docs:drift-check", stepName: "Docs drift check" },
+  ];
+
+  it.each(checks)("package.json defines $script and wires it into test:ci", ({ script, command }) => {
+    const pkg = record(JSON.parse(readFileSync("package.json", "utf8")), "package.json");
+    const scripts = record(pkg.scripts, "package.json.scripts");
+
+    expect(scripts[script]).toBeDefined();
+    expect(String(scripts["test:ci"])).toContain(command);
+  });
+
+  it.each(checks)("ci.yml's validate-code job runs a step for $script, gated on backend OR ui changes", ({ command, stepName }) => {
+    const workflow = readYaml(".github/workflows/ci.yml");
+    const validateCode = record(record(workflow.jobs, "workflow.jobs")["validate-code"], "workflow.jobs.validate-code");
+    const steps = recordArray(validateCode.steps, "jobs.validate-code.steps");
+
+    const step = steps.find((entry) => entry.name === stepName);
+    expect(step).toBeDefined();
+    expect(String(step!.run)).toBe(command);
+    // Gated on backend OR ui (not backend alone): the generated artifact each check validates lives under
+    // apps/gittensory-ui/**, so a UI-only edit that hand-desyncs it from its source of truth must still
+    // re-trigger the check, not just a backend source change (#gittensory-pr-3254-review).
+    const condition = String(step!.if);
+    expect(condition).toContain("needs.changes.outputs.backend == 'true'");
+    expect(condition).toContain("needs.changes.outputs.ui == 'true'");
+  });
+
+  it("all three drift-check steps share the exact same gating condition", () => {
+    const workflow = readYaml(".github/workflows/ci.yml");
+    const validateCode = record(record(workflow.jobs, "workflow.jobs")["validate-code"], "workflow.jobs.validate-code");
+    const steps = recordArray(validateCode.steps, "jobs.validate-code.steps");
+
+    const conditions = checks.map(({ stepName }) => {
+      const step = steps.find((entry) => entry.name === stepName);
+      expect(step).toBeDefined();
+      return String(step!.if);
+    });
+    expect(new Set(conditions).size).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

- `npm run selfhost:env-reference:check`, `npm run command-reference:check`, and `npm run docs:drift-check` are part of the local `npm run test:ci` aggregate script, but none of the three were wired into `.github/workflows/ci.yml`'s `validate-code` job — only local discipline enforced them.
- Found this the hard way: `apps/gittensory-ui/src/lib/selfhost-env-reference.ts` went stale from an unrelated `src/selfhost/ai.ts` change and merged clean with zero CI signal, then went stale AGAIN twice more the same day (2026-07-04) — discovered only by running the full local `test:ci` script, and reproduced again mid-review on this very PR after a rebase.
- Adds the same 3 checks to `validate-code`, gated on `backend || ui` (both the `db-schema-drift`/`cf-typegen` drift checks' `backend` filter, plus `ui` since the generated artifacts/docs pages these checks validate live under `apps/gittensory-ui/**` and can drift from a UI-only hand-edit too — this was a real gap the review on this PR correctly flagged and is now fixed).
- Verified all three checks currently pass clean at `main`'s tip, so this doesn't retroactively break anything — it only adds forward-going enforcement.
- Added `test/unit/ci-generated-artifact-drift-checks.test.ts`, mirroring the existing `ci-cf-typegen-check.test.ts` precedent for this exact class of change: asserts each check's npm script exists and is wired into `test:ci`, that `ci.yml`'s `validate-code` job runs a step for it with the right command, and that all three share the same gating condition.

Not included: `npm run build:miner` (builds `@jsonbored/gittensory-engine` + `@jsonbored/gittensory-miner`) is *also* absent from every workflow — but that's a full package build, not a lightweight drift-check script, and a different risk/cost profile (CI runtime, and it may already be a deliberate gap for a still-early package). Flagging it here rather than folding it into this PR; happy to add it in a follow-up if that's wanted.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused — one workflow file, three added steps, plus a workflow-structure test for them.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] No linked issue: this is a small, self-evident CI hygiene fix (closing a real, observed gap — see Summary) with no corresponding tracked issue; the rationale for skipping one is the Summary itself.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint` — passes on the modified workflow
- [x] `npm run typecheck` — passes
- [x] `npx vitest run test/unit/ci-generated-artifact-drift-checks.test.ts` — 7/7 passing
- [x] `npm run selfhost:env-reference:check`, `npm run command-reference:check`, `npm run docs:drift-check` — all three pass clean at current `main` tip (post-rebase)
- [x] `npm run test:ci` — ran the full local gate end to end, green
- No unrelated source/behavior changed, so `test:coverage`/`test:workers`/UI runtime checks are unaffected by the workflow YAML edit itself; CI's own `changes` path filter still runs the full `validate-code` job since this touches `.github/workflows/**`.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] No auth/cookie/CORS/GitHub App/Cloudflare/session changes.
- [x] N/A — no UI/API/OpenAPI behavior change.
- [x] N/A — no visible UI change.

## Notes

- This touches `.github/workflows/**`, a guarded path — expect this to be held for manual review/merge rather than auto-merged, which is appropriate for a CI config change.