### PR TITLE
feat(enrichment): expand migration-safety for TRUNCATE, SET NOT NULL, and blocking indexes

### DIFF
--- a/apps/gittensory-ui/src/lib/rees-analyzers.ts
+++ b/apps/gittensory-ui/src/lib/rees-analyzers.ts
@@ -765,7 +765,7 @@ export const REES_ANALYZERS = [
     },
     docs: {
       summary:
-        "Flags risky schema operations in added migration SQL: drops, renames, non-nullable columns without a default, and blocking table rewrites.",
+        "Flags risky schema operations in added migration SQL: drops, truncates, renames, non-nullable columns without a default, SET NOT NULL on existing columns, blocking table rewrites, and non-concurrent index builds.",
       looksAt: "Added lines in migration paths (migrations/, db/migrate/, *.sql).",
       reports: "File, line, and public-safe rule kind — never SQL content.",
       network: "Pure local analyzer. No external network call.",

--- a/review-enrichment/analyzer-metadata.json
+++ b/review-enrichment/analyzer-metadata.json
@@ -862,7 +862,7 @@
         "maxLineChars": 2000
       },
       "docs": {
-        "summary": "Flags risky schema operations in added migration SQL: drops, renames, non-nullable columns without a default, and blocking table rewrites.",
+        "summary": "Flags risky schema operations in added migration SQL: drops, truncates, renames, non-nullable columns without a default, SET NOT NULL on existing columns, blocking table rewrites, and non-concurrent index builds.",
         "looksAt": "Added lines in migration paths (migrations/, db/migrate/, *.sql).",
         "reports": "File, line, and public-safe rule kind — never SQL content.",
         "network": "Pure local analyzer. No external network call.",

--- a/review-enrichment/src/analyzers/migration-safety.ts
+++ b/review-enrichment/src/analyzers/migration-safety.ts
@@ -1,7 +1,8 @@
 // SQL migration-safety linter (#2022). Flags risky schema operations in ADDED migration SQL — the changes that
-// can break running deployments mid-rollout: dropping tables/columns the old code still reads, renames (the old
-// code's names disappear), non-nullable columns added without a DEFAULT (inserts from old code fail), and
-// column-type changes that force a blocking table rewrite. Pure compute over added patch lines in migration
+// can break running deployments mid-rollout: dropping/truncating tables or columns the old code still reads,
+// renames (the old code's names disappear), non-nullable columns added without a DEFAULT (inserts from old code
+// fail), SET NOT NULL on existing nullable columns without a same-line DEFAULT, column-type changes that force
+// a blocking table rewrite, and non-concurrent index builds that lock writers. Pure compute over added patch lines in migration
 // paths — no network, no SQL parsing beyond single-line statement shapes. Detection is deliberately
 // line-anchored: a statement split across lines is missed (fail-quiet) rather than tracked with cross-line
 // state, and each shape is a finite, documented DDL form — never a general SQL grammar.
@@ -16,6 +17,8 @@ const MIGRATION_PATH_RE = /(?:^|\/)(?:migrations?|db\/migrate)\/|\.sql$/i;
 
 // Dropping a table or column breaks any still-deployed reader/writer of the old schema.
 const DROP_RE = /\bDROP\s+(?:TABLE|COLUMN)\b/i;
+// TRUNCATE wipes live rows; still-running code that reads the table sees empty data mid-rollout.
+const TRUNCATE_RE = /\bTRUNCATE\b/i;
 // Renames remove the old name in one step; running code that still uses it fails immediately. Covers the
 // standard forms: `ALTER TABLE a RENAME TO b`, `… RENAME [COLUMN] x TO y` (PostgreSQL/SQLite treat the
 // COLUMN keyword as optional), and MySQL's `RENAME TABLE a TO b`.
@@ -27,10 +30,44 @@ const ADD_COLUMN_RE =
   /\bADD\s+(?!CONSTRAINT\b|PRIMARY\b|FOREIGN\b|UNIQUE\b|CHECK\b|INDEX\b|KEY\b)(?:COLUMN\s+)?\S/i;
 const NOT_NULL_RE = /\bNOT\s+NULL\b/i;
 const DEFAULT_RE = /\bDEFAULT\b/i;
+// Promoting an existing nullable column to NOT NULL without a same-line DEFAULT/backfill: rows that still
+// contain NULL fail the constraint check when the migration runs.
+const SET_NOT_NULL_RE = /\bSET\s+NOT\s+NULL\b/i;
 // Column-type changes rewrite (and lock) the whole table in most engines: Postgres
 // `ALTER COLUMN x [SET DATA] TYPE …` and MySQL `MODIFY [COLUMN] …`.
 const BLOCKING_REWRITE_RE =
   /\bALTER\s+COLUMN\s+\S+\s+(?:SET\s+DATA\s+)?TYPE\b|\bMODIFY\s+(?:COLUMN\s+)?\S/i;
+// A non-concurrent index build locks the table for writes (and often reads) until it finishes.
+const CREATE_INDEX_RE = /\bCREATE\s+(?:UNIQUE\s+)?INDEX\b/i;
+const CONCURRENTLY_RE = /\bCONCURRENTLY\b/i;
+
+/** Classify one added migration-SQL line (after `--` comment stripping). Pure. */
+export function classifyMigrationLine(
+  body: string,
+): MigrationSafetyFinding["kind"] | null {
+  if (DROP_RE.test(body)) return "drop";
+  if (RENAME_RE.test(body)) return "rename";
+  if (TRUNCATE_RE.test(body)) return "truncate";
+  if (
+    ADD_COLUMN_RE.test(body) &&
+    NOT_NULL_RE.test(body) &&
+    !DEFAULT_RE.test(body)
+  ) {
+    return "not-null-no-default";
+  }
+  if (
+    SET_NOT_NULL_RE.test(body) &&
+    !ADD_COLUMN_RE.test(body) &&
+    !DEFAULT_RE.test(body)
+  ) {
+    return "set-not-null";
+  }
+  if (BLOCKING_REWRITE_RE.test(body)) return "blocking-rewrite";
+  if (CREATE_INDEX_RE.test(body) && !CONCURRENTLY_RE.test(body)) {
+    return "blocking-index";
+  }
+  return null;
+}
 
 function* patchLines(patch: string): Generator<string> {
   let start = 0;
@@ -108,31 +145,8 @@ export function scanPatchForMigrationSafety(
     // the statement either (`ADD COLUMN age INTEGER NOT NULL; -- DEFAULT later` has no real DEFAULT).
     // Block comments are not tracked (no cross-line state by design).
     const body = rawBody.replace(/--.*$/, "");
-
-    if (
-      DROP_RE.test(body) &&
-      pushFinding(findings, seen, path, newLine, "drop", maxFindings)
-    ) {
-      return findings;
-    }
-    if (
-      RENAME_RE.test(body) &&
-      pushFinding(findings, seen, path, newLine, "rename", maxFindings)
-    ) {
-      return findings;
-    }
-    if (
-      ADD_COLUMN_RE.test(body) &&
-      NOT_NULL_RE.test(body) &&
-      !DEFAULT_RE.test(body) &&
-      pushFinding(findings, seen, path, newLine, "not-null-no-default", maxFindings)
-    ) {
-      return findings;
-    }
-    if (
-      BLOCKING_REWRITE_RE.test(body) &&
-      pushFinding(findings, seen, path, newLine, "blocking-rewrite", maxFindings)
-    ) {
+    const kind = classifyMigrationLine(body);
+    if (kind && pushFinding(findings, seen, path, newLine, kind, maxFindings)) {
       return findings;
     }
 

--- a/review-enrichment/src/analyzers/migration-safety.ts
+++ b/review-enrichment/src/analyzers/migration-safety.ts
@@ -30,8 +30,9 @@ const ADD_COLUMN_RE =
   /\bADD\s+(?!CONSTRAINT\b|PRIMARY\b|FOREIGN\b|UNIQUE\b|CHECK\b|INDEX\b|KEY\b)(?:COLUMN\s+)?\S/i;
 const NOT_NULL_RE = /\bNOT\s+NULL\b/i;
 const DEFAULT_RE = /\bDEFAULT\b/i;
-// Promoting an existing nullable column to NOT NULL without a same-line DEFAULT/backfill: rows that still
-// contain NULL fail the constraint check when the migration runs.
+// Promoting an existing nullable column to NOT NULL: existing NULL rows fail the constraint check when the
+// migration runs. A same-line DEFAULT does not backfill existing rows in PostgreSQL, so every standalone
+// SET NOT NULL (anything that is not an ADD COLUMN) is flagged.
 const SET_NOT_NULL_RE = /\bSET\s+NOT\s+NULL\b/i;
 // Column-type changes rewrite (and lock) the whole table in most engines: Postgres
 // `ALTER COLUMN x [SET DATA] TYPE …` and MySQL `MODIFY [COLUMN] …`.
@@ -57,8 +58,7 @@ export function classifyMigrationLine(
   }
   if (
     SET_NOT_NULL_RE.test(body) &&
-    !ADD_COLUMN_RE.test(body) &&
-    !DEFAULT_RE.test(body)
+    !ADD_COLUMN_RE.test(body)
   ) {
     return "set-not-null";
   }

--- a/review-enrichment/src/analyzers/registry.ts
+++ b/review-enrichment/src/analyzers/registry.ts
@@ -721,7 +721,7 @@ export const ANALYZER_DESCRIPTORS = [
     limits: { maxFindings: 20, maxLineChars: 2000 },
     docs: {
       summary:
-        "Flags risky schema operations in added migration SQL: drops, renames, non-nullable columns without a default, and blocking table rewrites.",
+        "Flags risky schema operations in added migration SQL: drops, truncates, renames, non-nullable columns without a default, SET NOT NULL on existing columns, blocking table rewrites, and non-concurrent index builds.",
       looksAt: "Added lines in migration paths (migrations/, db/migrate/, *.sql).",
       reports: "File, line, and public-safe rule kind — never SQL content.",
       network: "Pure local analyzer. No external network call.",
@@ -740,6 +740,12 @@ export const ANALYZER_DESCRIPTORS = [
             return "adds a NOT NULL column without a DEFAULT; inserts from not-yet-updated code omit it and fail";
           case "blocking-rewrite":
             return "changes a column type, which rewrites (and locks) the table in most engines while it runs";
+          case "truncate":
+            return "truncates a table, wiping live rows while older deployments may still read it";
+          case "set-not-null":
+            return "sets NOT NULL on an existing column without a same-line DEFAULT; rows still containing NULL fail the check";
+          case "blocking-index":
+            return "creates an index without CONCURRENTLY, which locks the table for writes until the build finishes";
         }
       };
       const lines = ["### SQL migration safety (deploy-breaking schema changes)"];

--- a/review-enrichment/src/analyzers/registry.ts
+++ b/review-enrichment/src/analyzers/registry.ts
@@ -743,7 +743,7 @@ export const ANALYZER_DESCRIPTORS = [
           case "truncate":
             return "truncates a table, wiping live rows while older deployments may still read it";
           case "set-not-null":
-            return "sets NOT NULL on an existing column without a same-line DEFAULT; rows still containing NULL fail the check";
+            return "sets NOT NULL on an existing column; rows still containing NULL fail the constraint check";
           case "blocking-index":
             return "creates an index without CONCURRENTLY, which locks the table for writes until the build finishes";
         }

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -406,7 +406,7 @@ export interface TestRatioFinding {
 export interface MigrationSafetyFinding {
   file: string;
   line: number;
-  kind: "drop" | "rename" | "not-null-no-default" | "blocking-rewrite";
+  kind: "drop" | "rename" | "not-null-no-default" | "blocking-rewrite" | "truncate" | "set-not-null" | "blocking-index";
 }
 
 /** A newly-added/changed npm dependency whose version specifier is dangerously loose — a wildcard, the

--- a/review-enrichment/test/migration-safety.test.ts
+++ b/review-enrichment/test/migration-safety.test.ts
@@ -3,6 +3,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
+  classifyMigrationLine,
   isMigrationPath,
   scanPatchForMigrationSafety,
   scanMigrationSafety,
@@ -19,6 +20,148 @@ test("isMigrationPath: recognizes migrations/, db/migrate/, and bare .sql paths"
   assert.equal(isMigrationPath("schema.sql"), true);
   assert.equal(isMigrationPath("src/services/scoring.ts"), false);
   assert.equal(isMigrationPath("docs/migrations.md"), false);
+});
+
+test("classifyMigrationLine: maps each risky DDL shape to its kind", () => {
+  assert.equal(classifyMigrationLine("DROP TABLE legacy_events;"), "drop");
+  assert.equal(classifyMigrationLine("TRUNCATE TABLE legacy_events;"), "truncate");
+  assert.equal(
+    classifyMigrationLine("ALTER TABLE users ADD COLUMN age INTEGER NOT NULL;"),
+    "not-null-no-default",
+  );
+  assert.equal(
+    classifyMigrationLine("ALTER TABLE users ALTER COLUMN email SET NOT NULL;"),
+    "set-not-null",
+  );
+  assert.equal(
+    classifyMigrationLine("CREATE INDEX idx_users_email ON users(email);"),
+    "blocking-index",
+  );
+  assert.equal(classifyMigrationLine("SELECT 1;"), null);
+});
+
+test("scanPatchForMigrationSafety: flags TRUNCATE as truncate", () => {
+  const findings = scanPatchForMigrationSafety(
+    "migrations/0015_truncate.sql",
+    patchOf(["TRUNCATE TABLE legacy_events;", "TRUNCATE users;"]),
+  );
+  assert.deepEqual(
+    findings.map((f) => f.kind),
+    ["truncate", "truncate"],
+  );
+});
+
+test("scanPatchForMigrationSafety: flags ALTER COLUMN SET NOT NULL without a DEFAULT as set-not-null", () => {
+  const findings = scanPatchForMigrationSafety(
+    "migrations/0016_set_not_null.sql",
+    patchOf([
+      "ALTER TABLE users ALTER COLUMN email SET NOT NULL;",
+      "ALTER TABLE users ALTER COLUMN phone SET NOT NULL;",
+    ]),
+  );
+  assert.deepEqual(
+    findings.map((f) => f.kind),
+    ["set-not-null", "set-not-null"],
+  );
+});
+
+test("scanPatchForMigrationSafety: SET DEFAULT and SET NOT NULL on one line is safe", () => {
+  const findings = scanPatchForMigrationSafety(
+    "migrations/0017_safe_set_not_null.sql",
+    patchOf([
+      "ALTER TABLE users ALTER COLUMN email SET DEFAULT '', ALTER COLUMN email SET NOT NULL;",
+    ]),
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanPatchForMigrationSafety: SET NOT NULL on a later line is flagged even when DEFAULT is set earlier", () => {
+  const findings = scanPatchForMigrationSafety(
+    "migrations/0017_split_set_not_null.sql",
+    patchOf([
+      "ALTER TABLE users ALTER COLUMN email SET DEFAULT '';",
+      "ALTER TABLE users ALTER COLUMN email SET NOT NULL;",
+    ]),
+  );
+  assert.deepEqual(findings, [
+    { file: "migrations/0017_split_set_not_null.sql", line: 2, kind: "set-not-null" },
+  ]);
+});
+
+test("scanPatchForMigrationSafety: ADD COLUMN NOT NULL stays not-null-no-default, not set-not-null", () => {
+  const findings = scanPatchForMigrationSafety(
+    "migrations/0018_add_not_null.sql",
+    patchOf(["ALTER TABLE users ADD COLUMN status TEXT NOT NULL;"]),
+  );
+  assert.deepEqual(findings, [
+    { file: "migrations/0018_add_not_null.sql", line: 1, kind: "not-null-no-default" },
+  ]);
+});
+
+test("scanPatchForMigrationSafety: flags CREATE INDEX without CONCURRENTLY as blocking-index", () => {
+  const findings = scanPatchForMigrationSafety(
+    "migrations/0019_index.sql",
+    patchOf([
+      "CREATE INDEX idx_users_email ON users(email);",
+      "CREATE UNIQUE INDEX idx_users_email_unique ON users(email);",
+    ]),
+  );
+  assert.deepEqual(
+    findings.map((f) => f.kind),
+    ["blocking-index", "blocking-index"],
+  );
+});
+
+test("scanPatchForMigrationSafety: CREATE INDEX CONCURRENTLY is not flagged", () => {
+  const findings = scanPatchForMigrationSafety(
+    "migrations/0020_concurrent_index.sql",
+    patchOf([
+      "CREATE INDEX CONCURRENTLY idx_users_email ON users(email);",
+      "CREATE UNIQUE INDEX CONCURRENTLY idx_users_email_unique ON users(email);",
+    ]),
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanPatchForMigrationSafety: a -- comment line mentioning TRUNCATE is not flagged", () => {
+  const findings = scanPatchForMigrationSafety(
+    "migrations/0021_commented_truncate.sql",
+    patchOf(["-- TRUNCATE TABLE users (deferred)", "SELECT 1;"]),
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("classifyMigrationLine: DROP NOT NULL and CONCURRENTLY index builds are not flagged", () => {
+  assert.equal(classifyMigrationLine("ALTER TABLE users ALTER COLUMN email DROP NOT NULL;"), null);
+  assert.equal(
+    classifyMigrationLine("CREATE INDEX CONCURRENTLY idx_users_email ON users(email);"),
+    null,
+  );
+});
+
+test("scanMigrationSafety: mixed new kinds across migration files are collected up to the cap", async () => {
+  const findings = await scanMigrationSafety({
+    repoFullName: "octo/repo",
+    prNumber: 1,
+    files: [
+      {
+        path: "migrations/0100_truncate.sql",
+        patch: patchOf(["TRUNCATE TABLE staging_events;"]),
+      },
+      {
+        path: "migrations/0101_set_not_null.sql",
+        patch: patchOf(["ALTER TABLE users ALTER COLUMN email SET NOT NULL;"]),
+      },
+      {
+        path: "migrations/0102_index.sql",
+        patch: patchOf(["CREATE INDEX idx_users_email ON users(email);"]),
+      },
+    ],
+  });
+  assert.deepEqual(
+    findings.map((f) => f.kind),
+    ["truncate", "set-not-null", "blocking-index"],
+  );
 });
 
 test("scanPatchForMigrationSafety: flags DROP TABLE and DROP COLUMN as drop", () => {
@@ -70,7 +213,7 @@ test("scanPatchForMigrationSafety: a NOT NULL column WITH a DEFAULT on the same 
     patchOf([
       "ALTER TABLE users ADD COLUMN age INTEGER NOT NULL DEFAULT 0;",
       "ALTER TABLE users ADD COLUMN bio TEXT;",
-      "CREATE INDEX idx_users_age ON users(age);",
+      "CREATE INDEX CONCURRENTLY idx_users_age ON users(age);",
     ]),
   );
   assert.deepEqual(findings, []);
@@ -182,9 +325,15 @@ test("renderBrief: migration-safety findings render location plus a public-safe 
     migrationSafety: [
       { file: "migrations/0002_cleanup.sql", line: 1, kind: "drop" },
       { file: "migrations/0004_add.sql", line: 3, kind: "not-null-no-default" },
+      { file: "migrations/0015_truncate.sql", line: 1, kind: "truncate" },
+      { file: "migrations/0016_set_not_null.sql", line: 2, kind: "set-not-null" },
+      { file: "migrations/0019_index.sql", line: 1, kind: "blocking-index" },
     ],
   });
   assert.match(promptSection, /SQL migration safety/);
   assert.match(promptSection, /migrations\/0002_cleanup\.sql:1/);
   assert.match(promptSection, /NOT NULL column without a DEFAULT/);
+  assert.match(promptSection, /truncates a table/);
+  assert.match(promptSection, /sets NOT NULL on an existing column/);
+  assert.match(promptSection, /creates an index without CONCURRENTLY/);
 });

--- a/review-enrichment/test/migration-safety.test.ts
+++ b/review-enrichment/test/migration-safety.test.ts
@@ -65,14 +65,20 @@ test("scanPatchForMigrationSafety: flags ALTER COLUMN SET NOT NULL without a DEF
   );
 });
 
-test("scanPatchForMigrationSafety: SET DEFAULT and SET NOT NULL on one line is safe", () => {
+test("scanPatchForMigrationSafety: SET DEFAULT and SET NOT NULL on one line is still flagged as set-not-null", () => {
   const findings = scanPatchForMigrationSafety(
-    "migrations/0017_safe_set_not_null.sql",
+    "migrations/0017_combined_set_not_null.sql",
     patchOf([
       "ALTER TABLE users ALTER COLUMN email SET DEFAULT '', ALTER COLUMN email SET NOT NULL;",
     ]),
   );
-  assert.deepEqual(findings, []);
+  assert.deepEqual(findings, [
+    {
+      file: "migrations/0017_combined_set_not_null.sql",
+      line: 1,
+      kind: "set-not-null",
+    },
+  ]);
 });
 
 test("scanPatchForMigrationSafety: SET NOT NULL on a later line is flagged even when DEFAULT is set earlier", () => {


### PR DESCRIPTION
## Summary
- Extend the SQL migration-safety linter with three new deploy-breaking rules: `TRUNCATE`, `ALTER COLUMN … SET NOT NULL` on existing columns, and `CREATE INDEX` without `CONCURRENTLY`.
- Extract a shared `classifyMigrationLine()` helper so rule ordering stays explicit and unit-testable.
- **Orb fix (follow-up to closed #3258):** flag every standalone `SET NOT NULL` that is not an `ADD COLUMN` case — a same-line `SET DEFAULT` does not backfill existing NULL rows in PostgreSQL.

## Motivation
Mid-rollout schema migrations often fail from data wipes, nullable-to-NOT-NULL promotions on live rows, and index builds that lock writers. The existing linter covered drops/renames/add-column NOT NULL/type rewrites but missed these common failure modes.

## Test plan
- [x] `classifyMigrationLine` — each new kind plus safe negatives (`DROP NOT NULL`, `CREATE INDEX CONCURRENTLY`)
- [x] `scanPatchForMigrationSafety` — TRUNCATE, SET NOT NULL (including combined SET DEFAULT + SET NOT NULL on one line), blocking indexes, comment boundaries
- [x] `scanMigrationSafety` — mixed new kinds across files
- [x] `renderBrief` — public-safe explanations for all new kinds
- [x] `npm run build` in `review-enrichment/`


Made with [Cursor](https://cursor.com)