### PR TITLE
feat(enrichment): add non-inclusive terminology analyzer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,22 +67,22 @@ GITTENSORY_REVIEW_ENRICHMENT=false
 # provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild
 # history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity,ciCheckSignals
 # undocumentedExport,staleBranch,commitHygiene,pendingReviewRequests,testRatio,migrationSafety
-# looseRange
+# looseRange,terminology
 #
 # Profile defaults:
 # fast: dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol
 # redos,provenance,secretLog,typosquat,iacMisconfig,nativeBuild,testRatio,migrationSafety
-# looseRange
+# looseRange,terminology
 # balanced (default): dependency,lockfileDrift,secret,license,installScript,heavyDependency
 # actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature
 # iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink
 # approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene
-# pendingReviewRequests,testRatio,migrationSafety,looseRange
+# pendingReviewRequests,testRatio,migrationSafety,looseRange,terminology
 # deep: dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol
 # redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig
 # nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity
 # ciCheckSignals,undocumentedExport,staleBranch,commitHygiene,pendingReviewRequests,testRatio
-# migrationSafety,looseRange
+# migrationSafety,looseRange,terminology
 # END GENERATED REES ANALYZERS
 
 # Submitter-reputation spend control (internal-only): downgrades new/burst/low-rep

--- a/apps/gittensory-ui/src/lib/rees-analyzers.ts
+++ b/apps/gittensory-ui/src/lib/rees-analyzers.ts
@@ -796,6 +796,29 @@ export const REES_ANALYZERS = [
         "Judges only the version specifier, never the package; wildcard, latest, unbounded >=, and bare-major ranges let any future publish flow into the next install.",
     },
   },
+  {
+    name: "terminology",
+    title: "Non-inclusive terminology",
+    category: "quality",
+    cost: "local",
+    defaultEnabled: true,
+    profiles: ["fast", "balanced", "deep"],
+    requires: ["files"],
+    limits: {
+      maxFindings: 25,
+      maxLineChars: 2000,
+    },
+    docs: {
+      summary:
+        "Flags non-inclusive terms newly added in identifiers or comments (whitelist/blacklist, master/slave) and suggests the neutral replacement.",
+      looksAt:
+        "Added lines in any changed file, tokenized on camelCase/snake_case/word boundaries.",
+      reports: "File, line, the matched term, and the suggested replacement.",
+      network: "Pure local analyzer. No external network call.",
+      notes:
+        "Token-based matching avoids substring false positives (masterclass/postmaster are never flagged), and URLs are skipped. The term→suggestion table is a bounded in-file policy.",
+    },
+  },
 ] as const satisfies readonly ReesAnalyzerDoc[];
 
 export const REES_ANALYZER_NAMES = REES_ANALYZERS.map((analyzer) => analyzer.name);

--- a/review-enrichment/analyzer-metadata.json
+++ b/review-enrichment/analyzer-metadata.json
@@ -894,6 +894,32 @@
         "network": "Pure local analyzer. No external network call.",
         "notes": "Judges only the version specifier, never the package; wildcard, latest, unbounded >=, and bare-major ranges let any future publish flow into the next install."
       }
+    },
+    {
+      "name": "terminology",
+      "title": "Non-inclusive terminology",
+      "category": "quality",
+      "cost": "local",
+      "defaultEnabled": true,
+      "profiles": [
+        "fast",
+        "balanced",
+        "deep"
+      ],
+      "requires": [
+        "files"
+      ],
+      "limits": {
+        "maxFindings": 25,
+        "maxLineChars": 2000
+      },
+      "docs": {
+        "summary": "Flags non-inclusive terms newly added in identifiers or comments (whitelist/blacklist, master/slave) and suggests the neutral replacement.",
+        "looksAt": "Added lines in any changed file, tokenized on camelCase/snake_case/word boundaries.",
+        "reports": "File, line, the matched term, and the suggested replacement.",
+        "network": "Pure local analyzer. No external network call.",
+        "notes": "Token-based matching avoids substring false positives (masterclass/postmaster are never flagged), and URLs are skipped. The term→suggestion table is a bounded in-file policy."
+      }
     }
   ]
 }

--- a/review-enrichment/src/analyzers/registry.ts
+++ b/review-enrichment/src/analyzers/registry.ts
@@ -27,6 +27,7 @@ import { scanStaleBranch } from "./stale-branch.js";
 import { scanTestRatio } from "./test-ratio.js";
 import { scanMigrationSafety } from "./migration-safety.js";
 import { scanLooseRanges } from "./loose-range.js";
+import { scanTerminology } from "./terminology.js";
 import { scanTyposquat } from "./typosquat.js";
 import { scanUndocumentedExport } from "./undocumented-export.js";
 import type {
@@ -793,6 +794,35 @@ export const ANALYZER_DESCRIPTORS = [
       return lines;
     },
     run: (req, { signal }) => scanLooseRanges(req, signal),
+  }),
+  descriptor({
+    name: "terminology",
+    title: "Non-inclusive terminology",
+    category: "quality",
+    cost: "local",
+    defaultEnabled: true,
+    requires: ["files"],
+    limits: { maxFindings: 25, maxLineChars: 2000 },
+    docs: {
+      summary:
+        "Flags non-inclusive terms newly added in identifiers or comments (whitelist/blacklist, master/slave) and suggests the neutral replacement.",
+      looksAt: "Added lines in any changed file, tokenized on camelCase/snake_case/word boundaries.",
+      reports: "File, line, the matched term, and the suggested replacement.",
+      network: "Pure local analyzer. No external network call.",
+      notes:
+        "Token-based matching avoids substring false positives (masterclass/postmaster are never flagged), and URLs are skipped. The term→suggestion table is a bounded in-file policy.",
+    },
+    render: (findings, helpers) => {
+      if (!findings.length) return [];
+      const lines = ["### Non-inclusive terminology (suggested neutral replacements)"];
+      for (const item of findings) {
+        lines.push(
+          `- ${helpers.safeCodeSpan(`${item.file}:${item.line}`)} — ${helpers.safeCodeSpan(item.term)} → ${helpers.safeCodeSpan(item.suggestion)}`,
+        );
+      }
+      return lines;
+    },
+    run: (req, { signal }) => scanTerminology(req, signal),
   }),
 ] as const satisfies readonly AnyAnalyzerDescriptor[];
 

--- a/review-enrichment/src/analyzers/terminology.ts
+++ b/review-enrichment/src/analyzers/terminology.ts
@@ -1,0 +1,131 @@
+// Non-inclusive / banned-terminology analyzer (#2031). Flags non-inclusive terms newly added in identifiers or
+// comments (whitelist/blacklist, master/slave) and suggests the neutral replacement — a config-driven house-style
+// signal. Pure compute over added lines, no network. Stateless per line: each added line is tokenized on its own,
+// so there is no comment/string state to track. Precision-first: matching is TOKEN-based (camelCase + snake_case
+// + non-alphanumeric splits), so `masterclass`/`postmaster`/`mastermind` never match on a substring — only a real
+// `master` token (in `master`, `master_node`, `masterNode`, or a comment word) does. URLs are blanked first so a
+// link path segment cannot trip a finding. Line-cited via hunk headers, mirroring the sibling local analyzers.
+import type { EnrichRequest, TerminologyFinding } from "../types.js";
+
+const MAX_FINDINGS = 25;
+const MAX_LINE_CHARS = 2000;
+
+// A bounded, in-file term → neutral-suggestion table (self-host operators can read the whole policy here). Keys
+// are the exact lowercased TOKENS the tokenizer produces — inflections are listed explicitly rather than matched
+// by a fuzzy stem, so there is no accidental over-match. `master`/`slave` are intentionally exact singular/plural
+// only (no `mastered`/`slavery`, which are unrelated words).
+const TERMS: Record<string, string> = {
+  whitelist: "allowlist",
+  whitelists: "allowlists",
+  whitelisted: "allowlisted",
+  whitelisting: "allowlisting",
+  blacklist: "denylist",
+  blacklists: "denylists",
+  blacklisted: "denylisted",
+  blacklisting: "denylisting",
+  master: "main or primary",
+  slave: "replica or secondary",
+  slaves: "replicas or secondaries",
+};
+
+const URL_RE = /https?:\/\/\S+|\bwww\.\S+/gi;
+
+/** Split an identifier/word run into its constituent lowercased words at camelCase and acronym boundaries.
+ *  `masterNode` → [master, node]; `HTTPServer` → [http, server]; `whitelist` → [whitelist]. Pure. */
+function splitCamel(run: string): string[] {
+  return run
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2") // lower/digit → Upper: masterNode → master Node
+    .replace(/([A-Z]+)([A-Z][a-z])/g, "$1 $2") // acronym → Word: HTTPServer → HTTP Server
+    .toLowerCase()
+    .split(" ")
+    .filter(Boolean);
+}
+
+/** Tokenize a line into lowercased words: split on any non-alphanumeric run (so `master_node`, `"master"`, and
+ *  `master-branch` all separate), then split each run on camelCase boundaries. Pure. */
+export function tokenizeLine(line: string): string[] {
+  return line
+    .replace(URL_RE, " ")
+    .split(/[^A-Za-z0-9]+/)
+    .flatMap(splitCamel);
+}
+
+/** The banned terms present on a line, de-duplicated, each with its suggestion. Pure. */
+export function detectTerminology(
+  line: string,
+): Array<{ term: string; suggestion: string }> {
+  const seen = new Set<string>();
+  const hits: Array<{ term: string; suggestion: string }> = [];
+  for (const token of tokenizeLine(line)) {
+    const suggestion = TERMS[token];
+    if (suggestion && !seen.has(token)) {
+      seen.add(token);
+      hits.push({ term: token, suggestion });
+    }
+  }
+  return hits;
+}
+
+type ScanLimits = {
+  maxFindings?: number;
+  signal?: AbortSignal;
+};
+
+/** Scan one file patch's added lines for banned terminology, line-cited via hunk headers. Pure. */
+export function scanPatchForTerminology(
+  path: string,
+  patch: string,
+  limits: ScanLimits = {},
+): TerminologyFinding[] {
+  const maxFindings = limits.maxFindings ?? MAX_FINDINGS;
+  if (maxFindings <= 0) return [];
+  const findings: TerminologyFinding[] = [];
+  let newLine = 0;
+  let inHunk = false;
+  for (const line of patch.split("\n")) {
+    if (limits.signal?.aborted) throw new Error("analyzer_aborted");
+    const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
+    if (hunk) {
+      newLine = Number(hunk[1]);
+      inHunk = true;
+      continue;
+    }
+    // Skip pre-hunk preamble; inside a hunk `+++x`/`+++ x` is added content, not a header.
+    if (!inHunk) continue;
+    if (line.startsWith("+")) {
+      const body = line.slice(1);
+      if (body.length <= MAX_LINE_CHARS) {
+        for (const hit of detectTerminology(body)) {
+          findings.push({ file: path, line: newLine, term: hit.term, suggestion: hit.suggestion });
+          if (findings.length >= maxFindings) return findings;
+        }
+      }
+      newLine++;
+    } else if (!line.startsWith("-") && !line.startsWith("\\")) {
+      // A `\ No newline at end of file` marker is not a new-file line — do not advance the cursor
+      // (same class as the actions-pin / iac-misconfig fix).
+      newLine++;
+    }
+  }
+  return findings;
+}
+
+/** Analyzer entrypoint: scan every changed file's added lines for banned terminology. */
+export async function scanTerminology(
+  req: EnrichRequest,
+  signal?: AbortSignal,
+): Promise<TerminologyFinding[]> {
+  const findings: TerminologyFinding[] = [];
+  for (const file of req.files ?? []) {
+    if (signal?.aborted) throw new Error("analyzer_aborted");
+    if (!file.patch) continue;
+    for (const finding of scanPatchForTerminology(file.path, file.patch, {
+      maxFindings: MAX_FINDINGS - findings.length,
+      signal,
+    })) {
+      findings.push(finding);
+      if (findings.length >= MAX_FINDINGS) return findings;
+    }
+  }
+  return findings;
+}

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -456,6 +456,7 @@ export function renderBrief(
   lines.push(...renderDescriptorSection("testRatio", findings.testRatio));
   lines.push(...renderDescriptorSection("migrationSafety", findings.migrationSafety));
   lines.push(...renderDescriptorSection("looseRange", findings.looseRange));
+  lines.push(...renderDescriptorSection("terminology", findings.terminology));
 
   if (!lines.length) return { promptSection: "", systemSuffix: "" };
 

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -420,6 +420,15 @@ export interface LooseRangeFinding {
   kind: "wildcard" | "latest" | "unbounded-gte" | "bare";
 }
 
+/** A non-inclusive term a PR added in an identifier or comment, with the suggested neutral replacement
+ *  (#2031, part of #1499). Reports the location, the matched term, and the suggestion only. */
+export interface TerminologyFinding {
+  file: string;
+  line: number;
+  term: string;
+  suggestion: string;
+}
+
 /** Structured analyzer output. Each analyzer fills its own key; more land as analyzers ship (#1477/#1478). */
 export interface BriefFindings {
   dependency?: DependencyFinding[];
@@ -453,6 +462,7 @@ export interface BriefFindings {
   testRatio?: TestRatioFinding[];
   migrationSafety?: MigrationSafetyFinding[];
   looseRange?: LooseRangeFinding[];
+  terminology?: TerminologyFinding[];
 }
 
 /** A JSDoc/TSDoc block whose `@param` tags name parameters the adjacent function no longer declares — a

--- a/review-enrichment/test/analyzer-registry.test.ts
+++ b/review-enrichment/test/analyzer-registry.test.ts
@@ -41,6 +41,7 @@ const EXPECTED_ANALYZERS = [
   "testRatio",
   "migrationSafety",
   "looseRange",
+  "terminology",
 ];
 
 test("analyzer descriptors cover the runtime registry in stable order", () => {

--- a/review-enrichment/test/terminology.test.ts
+++ b/review-enrichment/test/terminology.test.ts
@@ -1,0 +1,121 @@
+// Units for the non-inclusive terminology analyzer (#2031). Own file (not enrichment.test.ts) so concurrent
+// analyzer PRs don't collide. No network — pure, stateless per-line tokenization. Runs against the compiled dist/.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  tokenizeLine,
+  detectTerminology,
+  scanPatchForTerminology,
+  scanTerminology,
+} from "../dist/analyzers/terminology.js";
+import { renderBrief } from "../dist/render.js";
+
+const patchOf = (lines) => `@@ -1,0 +1,${lines.length} @@\n${lines.map((l) => `+${l}`).join("\n")}`;
+
+test("tokenizeLine: splits on camelCase, snake_case, and non-alphanumeric runs; blanks URLs", () => {
+  assert.deepEqual(tokenizeLine("masterNode"), ["master", "node"]);
+  assert.deepEqual(tokenizeLine("master_key"), ["master", "key"]);
+  assert.deepEqual(tokenizeLine('"whitelist" the ip'), ["whitelist", "the", "ip"]);
+  assert.deepEqual(tokenizeLine("see https://example.com/master/x now"), ["see", "now"]);
+  assert.deepEqual(tokenizeLine("HTTPServer"), ["http", "server"]);
+});
+
+test("detectTerminology: flags each banned term with its neutral suggestion", () => {
+  assert.deepEqual(detectTerminology("add to the whitelist"), [
+    { term: "whitelist", suggestion: "allowlist" },
+  ]);
+  assert.deepEqual(detectTerminology("the blacklisted range"), [
+    { term: "blacklisted", suggestion: "denylisted" },
+  ]);
+  assert.deepEqual(detectTerminology("masterNode and slaveNode"), [
+    { term: "master", suggestion: "main or primary" },
+    { term: "slave", suggestion: "replica or secondary" },
+  ]);
+});
+
+test("detectTerminology: TOKEN-based — no substring false positives", () => {
+  assert.deepEqual(detectTerminology("register for the masterclass"), []);
+  assert.deepEqual(detectTerminology("email the postmaster"), []);
+  assert.deepEqual(detectTerminology("a mastermind plan"), []);
+  assert.deepEqual(detectTerminology("the word slavery here"), []);
+  assert.deepEqual(detectTerminology("enslaved is unrelated"), []);
+});
+
+test("detectTerminology: a term appearing twice on one line is reported once", () => {
+  assert.deepEqual(detectTerminology("whitelist plus another whitelist"), [
+    { term: "whitelist", suggestion: "allowlist" },
+  ]);
+});
+
+test("detectTerminology: a URL containing a banned word does not trip a finding", () => {
+  assert.deepEqual(detectTerminology("fetch http://host/master/list.json"), []);
+});
+
+test("detectTerminology: case-insensitive — Whitelist and WHITELIST both match", () => {
+  assert.deepEqual(detectTerminology("the Whitelist"), [{ term: "whitelist", suggestion: "allowlist" }]);
+  assert.deepEqual(detectTerminology("the WHITELIST"), [{ term: "whitelist", suggestion: "allowlist" }]);
+});
+
+test("scanPatchForTerminology: flags terms on added lines with correct locations", () => {
+  const findings = scanPatchForTerminology(
+    "src/net.ts",
+    patchOf(["const masterHost = cfg;", "// add ip to whitelist", "const ok = true;"]),
+  );
+  assert.deepEqual(findings, [
+    { file: "src/net.ts", line: 1, term: "master", suggestion: "main or primary" },
+    { file: "src/net.ts", line: 2, term: "whitelist", suggestion: "allowlist" },
+  ]);
+});
+
+test("scanPatchForTerminology: only ADDED lines are scanned; new-file line numbers stay correct", () => {
+  const patch = [
+    "@@ -10,2 +10,2 @@",
+    " function configure() {", // context line 10
+    "-  const whitelist = old;", // removed, does not advance
+    "+  const whitelist = fresh;", // new-file line 11
+  ].join("\n");
+  assert.deepEqual(scanPatchForTerminology("src/a.ts", patch), [
+    { file: "src/a.ts", line: 11, term: "whitelist", suggestion: "allowlist" },
+  ]);
+});
+
+test("scanPatchForTerminology: enforces the maxFindings cap", () => {
+  const lines = Array.from({ length: 30 }, (_, i) => `const blacklist${i} = whitelist;`);
+  const findings = scanPatchForTerminology("src/a.ts", patchOf(lines), { maxFindings: 5 });
+  assert.equal(findings.length, 5);
+  assert.deepEqual(
+    scanPatchForTerminology("src/a.ts", patchOf(lines), { maxFindings: 0 }),
+    [],
+  );
+});
+
+test("scanTerminology: scans every changed file and honors the global cap", async () => {
+  const wlLines = Array.from({ length: 30 }, () => "add to whitelist");
+  const findings = await scanTerminology({
+    repoFullName: "octo/repo",
+    prNumber: 1,
+    files: [
+      { path: "src/a.ts", patch: patchOf(["clean line"]) },
+      { path: "src/b.ts", patch: patchOf(wlLines) },
+    ],
+  });
+  assert.equal(findings.length, 25);
+  assert.ok(findings.every((f) => f.file === "src/b.ts"));
+});
+
+test("scanTerminology: no files yields no findings", async () => {
+  assert.deepEqual(await scanTerminology({ repoFullName: "octo/repo", prNumber: 1 }), []);
+});
+
+test("renderBrief: terminology findings render location, term, and suggestion", () => {
+  const { promptSection } = renderBrief({
+    terminology: [
+      { file: "src/net.ts", line: 1, term: "master", suggestion: "main or primary" },
+      { file: "src/net.ts", line: 2, term: "whitelist", suggestion: "allowlist" },
+    ],
+  });
+  assert.match(promptSection, /Non-inclusive terminology/);
+  assert.match(promptSection, /src\/net\.ts:1/);
+  assert.match(promptSection, /master/);
+  assert.match(promptSection, /allowlist/);
+});

--- a/src/review/enrichment-analyzer-names.ts
+++ b/src/review/enrichment-analyzer-names.ts
@@ -35,6 +35,7 @@ export const REES_ANALYZER_NAMES = [
   "testRatio",
   "migrationSafety",
   "looseRange",
+  "terminology",
 ] as const;
 
 export type ReesAnalyzerName = (typeof REES_ANALYZER_NAMES)[number];

--- a/test/unit/enrichment-wire.test.ts
+++ b/test/unit/enrichment-wire.test.ts
@@ -626,7 +626,7 @@ describe("resolveReesAnalyzers", () => {
       resolveReesAnalyzers(
         env({
           REES_ANALYZERS:
-            "dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene,pendingReviewRequests,testRatio,migrationSafety,looseRange",
+            "dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene,pendingReviewRequests,testRatio,migrationSafety,looseRange,terminology",
         }),
       ),
     ).toEqual([
@@ -661,6 +661,7 @@ describe("resolveReesAnalyzers", () => {
       "testRatio",
       "migrationSafety",
       "looseRange",
+      "terminology",
     ]);
   });
 


### PR DESCRIPTION
Closes #2031

## What

A new local REES analyzer, `terminology`, that flags non-inclusive terms a PR adds in identifiers or comments (`whitelist`/`blacklist`, `master`/`slave`) and suggests the neutral replacement — a config-driven house-style signal. Pure compute over added lines, no network.

## Detection (stateless, precision-first)

- **Token-based**, not substring: each added line is tokenized on camelCase + acronym boundaries, `snake_case`, and any non-alphanumeric run, then each lowercased token is matched against a bounded term→suggestion table. So `masterNode`, `master_key`, and a plain `master` comment word are flagged, while `masterclass`, `postmaster`, `mastermind`, `slavery`, and `enslaved` are **never** flagged (they tokenize to a single non-matching word — no substring false positive, which is the issue's explicit precision requirement).
- **URLs are blanked** before tokenizing, so a link path segment (`http://host/master/x`) cannot trip a finding.
- The term→suggestion table is a **bounded in-file policy** so a self-host operator can read the whole thing: `whitelist(+ed/+ing/+s) → allowlist…`, `blacklist(+ed/+ing/+s) → denylist…`, `master → main or primary`, `slave(+s) → replica or secondary`. Inflections are listed explicitly rather than fuzzy-stemmed (no accidental over-match); `master`/`slave` are exact singular/plural only, so unrelated words like `mastered`/`slavery` are out of scope.
- Added lines only, line-cited via hunk headers, with the shared `\ No newline` line-counter fix. Terms de-duplicated per line; findings capped (`maxFindings: 25`) per file and globally.

## Registration

Registered as a local descriptor (category `quality`, cost `local`, requires `["files"]`) with an inline `render()`, following the `looseRange` descriptor shape. All wiring updated: `types.ts` (`TerminologyFinding` + `terminology?` key), `render.ts`, `analyzer-registry.test.ts`, root `src/review/enrichment-analyzer-names.ts`, root `test/unit/enrichment-wire.test.ts`, and the generated `analyzer-metadata.json` / `rees-analyzers.ts` / `.env.example` via `node scripts/generate-analyzer-metadata.mjs`.

## Tests

`review-enrichment/test/terminology.test.ts` (12 tests) covers: tokenization across camelCase/snake_case/non-alphanumeric with URL blanking, each term flagged with its suggestion, token-based no-substring-false-positive cases (`masterclass`/`postmaster`/`mastermind`/`slavery`/`enslaved`), per-line de-duplication, URL suppression, case-insensitive matching, added-line scanning with exact locations, added-lines-only with line-number accuracy across mixed hunks, the per-file cap + `maxFindings: 0`, the entrypoint's global cap across files, the no-files case, and the rendered brief section. Analyzer metadata is regenerated and committed.
