### PR TITLE
feat(enrichment): classify Cargo/Composer/Bun lockfiles as lockfiles

### DIFF
--- a/review-enrichment/src/lockfile-path.ts
+++ b/review-enrichment/src/lockfile-path.ts
@@ -4,6 +4,12 @@ const LOCKFILE_NAMES = new Set([
   "pnpm-lock.yaml",
   "poetry.lock",
   "go.sum",
+  // Classification-only (not in the parseable set below): Rust, PHP, and Bun lockfiles, matching the
+  // lockfile inventory already recognized in src/review/rag.ts. Categorizing them keeps a Cargo/Composer/Bun
+  // lockfile bump from being mistaken for a source change.
+  "cargo.lock",
+  "composer.lock",
+  "bun.lockb",
 ]);
 
 /** Lockfiles the drift analyzer can actually parse today — narrower than categorization. */

--- a/review-enrichment/test/lockfile-path.test.ts
+++ b/review-enrichment/test/lockfile-path.test.ts
@@ -1,0 +1,42 @@
+// Units for the lockfile-path helpers — classification (isSupportedLockfile) is deliberately broader
+// than the parseable set, so ecosystem lockfiles are categorized even when the drift parser skips them.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { isSupportedLockfile, lockfileBasename } from "../dist/lockfile-path.js";
+
+test("isSupportedLockfile classifies the recognized ecosystem lockfiles", () => {
+  // Established set (npm / yarn / pnpm / poetry / go).
+  for (const p of [
+    "package-lock.json",
+    "app/yarn.lock",
+    "pkg/pnpm-lock.yaml",
+    "poetry.lock",
+    "svc/go.sum",
+  ]) {
+    assert.equal(isSupportedLockfile(p), true, p);
+  }
+  // Rust / PHP / Bun lockfiles — classification-only, matching src/review/rag.ts. Their bump should read as
+  // a lockfile change, not a source change.
+  assert.equal(isSupportedLockfile("Cargo.lock"), true);
+  assert.equal(isSupportedLockfile("crates/api/Cargo.lock"), true);
+  assert.equal(isSupportedLockfile("composer.lock"), true);
+  assert.equal(isSupportedLockfile("bun.lockb"), true);
+  // Basename match is case-insensitive and path-anchored (uses the last segment only).
+  assert.equal(isSupportedLockfile("services\\web\\CARGO.LOCK"), true);
+  // Non-lockfiles are not classified as lockfiles.
+  for (const p of [
+    "src/index.ts",
+    "Cargo.toml",
+    "package.json",
+    "notes/cargo.lock.md",
+  ]) {
+    assert.equal(isSupportedLockfile(p), false, p);
+  }
+});
+
+test("lockfileBasename returns the final path segment across separators", () => {
+  assert.equal(lockfileBasename("a/b/Cargo.lock"), "Cargo.lock");
+  assert.equal(lockfileBasename("a\\b\\bun.lockb"), "bun.lockb");
+  assert.equal(lockfileBasename("composer.lock"), "composer.lock");
+});


### PR DESCRIPTION
## Summary

`isSupportedLockfile` (in `review-enrichment/src/lockfile-path.ts`) drives file categorization in `analysis-context.ts` — a changed file matching it is categorized as `lockfile` rather than `source`. But its inventory only covered npm/yarn/pnpm/poetry/go, so a **Rust `Cargo.lock`, PHP `composer.lock`, or Bun `bun.lockb`** change fell through to the `source` category. A pure lockfile bump in those ecosystems was therefore mischaracterized as a source change in the review signal.

This adds the three basenames to the classification set:

- **Classification-only.** They stay out of the parseable set (`PARSEABLE_LOCKFILE_NAMES`) — parsing is separately gated by `isParseableLockfile` (`lockfile-drift.ts:375`), so **no parser is invoked** for them. This is exactly how the existing `pnpm-lock.yaml` and `go.sum` entries already behave (classified, not parsed).
- **Case/path-safe.** Matching uses the existing `lockfileBasename(path).toLowerCase()`, so `Cargo.lock` (capitalized) and nested paths resolve correctly; `bun.lockb` is binary and simply classified.
- **Additive-only:** three set entries plus a new unit test; no existing behavior changes.
- **Consistency anchor:** `src/review/rag.ts`'s lockfile inventory already recognizes `cargo.lock`, `composer.lock`, and `bun.lockb` — this brings the categorizer in line with that existing decision.

## No linked issue

This is a **no-issue PR** by design: a self-contained classification-coverage fix that adds three ecosystem lockfile basenames to `lockfile-path.ts` plus a focused unit test, touching only `review-enrichment/`. There is no behavior change beyond correctly categorizing these lockfiles, so no tracking issue is needed. It mirrors the accepted no-issue precedent for the same kind of detection-inventory change (e.g. the recently-merged `#3128` and `#3204`).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] No linked issue — see the **No linked issue** section above.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — no `src/**` lines changed (this change is under `review-enrichment/`, which Codecov does not measure), so `codecov/patch` has no diff to gate; suite is green.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New behavior has tests — a new `review-enrichment/test/lockfile-path.test.ts` covers `isSupportedLockfile` for the new `Cargo.lock`/`composer.lock`/`bun.lockb` cases (plus the established set, case-insensitivity, path-anchoring, and negatives like `Cargo.toml` and `cargo.lock.md`), and `lockfileBasename`. `npm run rees:test` passes (analyzer-metadata check clean).

Validated green against the full GitHub CI `validate-code` check set — `actionlint`, `db:migrations:check`, `db:schema-drift:check`, `cf-typegen:check`, `selfhost:validate-observability`, `typecheck`, `test:coverage`, `test:workers`, `build:mcp`, `test:mcp-pack`, `build:miner`, `rees:test`, `ui:openapi:check`, `ui:openapi:settings-parity`, `ui:version-audit`, `ui:lint`, `ui:typecheck`, `ui:test`, `ui:build`. Branch rebased on latest `main`.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] No auth, cookie, CORS, GitHub App, Cloudflare, or session changes (N/A — pure classification-set addition).
- [x] No API/OpenAPI/MCP behavior change (N/A).
- [x] No UI changes (N/A — this is a review-enrichment helper).
- [x] No visible UI change, so no UI Evidence section is required.
- [x] No docs/changelog changes needed.

## Notes

Analogues followed end-to-end: the existing `pnpm-lock.yaml`/`go.sum` classification-only entries in the same file, and the recently-merged detection-inventory PRs `#3128` and `#3204`. The parseable set is intentionally left unchanged — no text parser exists for these formats (and `bun.lockb` is binary), so they are classified but not parsed, consistent with the existing design.
