### PR TITLE
feat(enrichment): detect Resend API keys and Mapbox secret tokens in secret-scan

### DIFF
--- a/review-enrichment/src/analyzers/secret-scan.ts
+++ b/review-enrichment/src/analyzers/secret-scan.ts
@@ -188,6 +188,18 @@ const RULES: Rule[] = [
     confidence: "high",
   },
   {
+    // Resend API key: `re_` + >=24 base62 chars.
+    kind: "resend_api_key",
+    re: /\bre_[A-Za-z0-9]{24,}(?![A-Za-z0-9])/,
+    confidence: "high",
+  },
+  {
+    // Mapbox secret access token: `sk.eyJ` JWT-shaped token (distinct from Stripe `sk_live_` / `sk_test_`).
+    kind: "mapbox_secret_token",
+    re: /\bsk\.eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}(?![A-Za-z0-9_-])/,
+    confidence: "high",
+  },
+  {
     // Google OAuth 2.0 client secret: `GOCSPX-` + 28 base64url chars.
     kind: "google_oauth_client_secret",
     re: /\bGOCSPX-[A-Za-z0-9_-]{28}\b/,

--- a/review-enrichment/test/secret-scan.test.ts
+++ b/review-enrichment/test/secret-scan.test.ts
@@ -471,6 +471,30 @@ test("scanPatch does not flag truncated Twilio SIDs or identifier continuation p
   );
 });
 
+test("scanPatch flags Resend and Mapbox secret tokens with high confidence", () => {
+  const fakeResendKey = "re_" + "a".repeat(32);
+  const resendFindings = scanPatch("src/config.ts", hunk([`const resend = "${fakeResendKey}";`]));
+  assert.equal(resendFindings.length, 1);
+  assert.equal(resendFindings[0].kind, "resend_api_key");
+  assert.equal(resendFindings[0].confidence, "high");
+
+  const fakeMapboxSecret = ["sk.", "eyJ", "a".repeat(20), ".", "b".repeat(20)].join("");
+  const mapboxFindings = scanPatch("src/config.ts", hunk([`const mapbox = "${fakeMapboxSecret}";`]));
+  assert.equal(mapboxFindings.length, 1);
+  assert.equal(mapboxFindings[0].kind, "mapbox_secret_token");
+  assert.equal(mapboxFindings[0].confidence, "high");
+});
+
+test("scanPatch does not flag truncated Resend keys or classify Mapbox secrets as Stripe keys", () => {
+  const truncatedResend = "re_" + "a".repeat(23);
+  assert.equal(scanPatch("src/config.ts", hunk([`const resend = "${truncatedResend}";`])).length, 0);
+
+  const fakeMapboxSecret = ["sk.", "eyJ", "c".repeat(20), ".", "d".repeat(20)].join("");
+  const findings = scanPatch("src/config.ts", hunk([`const mapbox = "${fakeMapboxSecret}";`]));
+  assert.equal(findings.some((f) => f.kind === "stripe_secret_key"), false);
+  assert.equal(findings.some((f) => f.kind === "mapbox_secret_token"), true);
+});
+
 test("scanPatch flags additional high-confidence SaaS/cloud/CI credential formats", () => {
   const cases = [
     ["google_oauth_client_secret", "GOCSPX-" + b62(28)],


### PR DESCRIPTION
## Summary
- Add high-confidence secret-scan rules for **Resend API keys** (`re_` + base62) and **Mapbox secret access tokens** (`sk.eyJ` JWT-shaped tokens).
- Mapbox rule is distinct from Stripe `sk_live_` / `sk_test_` prefixes via the `sk.eyJ` anchor.

## Motivation
Resend and Mapbox credentials are commonly leaked in env files and deployment configs. The secret-scan analyzer already covers many email/maps SaaS tokens but missed these formats.

## Test plan
- [x] Resend API key — positive match and truncated negative
- [x] Mapbox secret token — positive match, not classified as Stripe secret key
- [x] Fragment-based fixtures (no contiguous fake secrets in committed source)
- [x] Full `secret-scan.test.ts` suite passes (59 tests)
- [x] `npm run build` in `review-enrichment/`


Made with [Cursor](https://cursor.com)