### PR TITLE
feat(enrichment): detect observability and CI/identity credential formats in secret-scan

### DIFF
--- a/review-enrichment/src/analyzers/secret-scan.ts
+++ b/review-enrichment/src/analyzers/secret-scan.ts
@@ -603,6 +603,54 @@ const RULES: Rule[] = [
     confidence: "high",
   },
   {
+    // New Relic insights insert key: `NRII-` + 32 base64url.
+    kind: "newrelic_insights_key",
+    re: /\bNRII-[A-Za-z0-9_-]{32}(?![A-Za-z0-9_-])/,
+    confidence: "high",
+  },
+  {
+    // New Relic REST API key: `NRRA-` + 42 hex.
+    kind: "newrelic_rest_key",
+    re: /\bNRRA-[a-f0-9]{42}\b/,
+    confidence: "high",
+  },
+  {
+    // Sentry organization auth token: `sntrys_` + base64url body (distinct from the `sntryu_` user token above).
+    kind: "sentry_org_token",
+    re: /\bsntrys_[A-Za-z0-9_=-]{40,}(?![A-Za-z0-9_=-])/,
+    confidence: "high",
+  },
+  {
+    // OpenAI service-account key: `sk-svcacct-` + base64url body (distinct from the `sk-proj-`/`sk-ant-` keys).
+    kind: "openai_service_account_key",
+    re: /\bsk-svcacct-[A-Za-z0-9_-]{20,}(?![A-Za-z0-9_-])/,
+    confidence: "high",
+  },
+  {
+    // Google OAuth 2.0 access token: `ya29.` + base64url body.
+    kind: "google_oauth_access_token",
+    re: /\bya29\.[A-Za-z0-9_-]{20,}(?![A-Za-z0-9_-])/,
+    confidence: "high",
+  },
+  {
+    // Persona API key: `persona_sandbox_`/`persona_production_` + >=24 base62.
+    kind: "persona_api_key",
+    re: /\bpersona_(?:sandbox|production)_[A-Za-z0-9]{24,}(?![A-Za-z0-9])/,
+    confidence: "high",
+  },
+  {
+    // Depot API token: `depot_project_`/`depot_org_`/`depot_user_` + >=20 base62.
+    kind: "depot_token",
+    re: /\bdepot_(?:project|org|user)_[A-Za-z0-9]{20,}(?![A-Za-z0-9])/,
+    confidence: "high",
+  },
+  {
+    // Octopus Deploy API key: `API-` + 26 uppercase base36.
+    kind: "octopus_deploy_key",
+    re: /\bAPI-[A-Z0-9]{26}\b/,
+    confidence: "high",
+  },
+  {
     kind: "private_key",
     re: /-----BEGIN (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----/,
     confidence: "high",

--- a/review-enrichment/test/secret-scan.test.ts
+++ b/review-enrichment/test/secret-scan.test.ts
@@ -719,3 +719,39 @@ test("scanPatch does not flag near-miss variants of the infra/AI credential form
     assert.equal(findings.length, 0, `near-miss should not match: ${nm}`);
   }
 });
+
+test("scanPatch flags observability and CI/identity credential formats", () => {
+  const cases = [
+    ["newrelic_insights_key", "NRII-" + b62(32)],
+    ["newrelic_rest_key", "NRRA-" + hex(42)],
+    ["sentry_org_token", "sntrys_" + b62(40)],
+    ["openai_service_account_key", "sk-svcacct-" + b62(40)],
+    ["google_oauth_access_token", "ya29." + b62(40)],
+    ["persona_api_key", "persona_sandbox_" + b62(24)],
+    ["depot_token", "depot_project_" + b62(20)],
+    ["octopus_deploy_key", "API-" + b62(26)],
+  ];
+  for (const [kind, secret] of cases) {
+    const findings = scanPatch("src/config.ts", hunk([`const c = "${secret}";`]));
+    assert.equal(findings.length, 1, `${kind}: expected exactly one finding, got ${JSON.stringify(findings)}`);
+    assert.equal(findings[0].kind, kind, `${kind}: wrong kind`);
+    assert.equal(findings[0].confidence, "high", `${kind}: wrong confidence`);
+  }
+});
+
+test("scanPatch does not flag near-miss variants of the observability/CI formats", () => {
+  const nearMisses = [
+    "NRII-" + b62(31),
+    "NRRA-" + hex(41),
+    "sntrys_" + b62(39),
+    "sk-svcacct-" + b62(19),
+    "ya29." + b62(19),
+    "persona_sandbox_" + b62(23),
+    "depot_project_" + b62(19),
+    "API-" + b62(25),
+  ];
+  for (const nm of nearMisses) {
+    const findings = scanPatch("src/config.ts", hunk([`const c = "${nm}";`]));
+    assert.equal(findings.length, 0, `near-miss should not match: ${nm}`);
+  }
+});


### PR DESCRIPTION
## Summary

The secret-scan analyzer (`review-enrichment/src/analyzers/secret-scan.ts`) flags credentials committed in a
PR diff, citing `file:line` + kind only (never the value). This adds **8 more credential formats** the scanner
currently misses — observability, CI/CD, and identity/OAuth tokens — continuing the established
`feat(enrichment)` secret-format additions:

| kind | shape |
|---|---|
| `newrelic_insights_key` | `NRII-` + 32 base64url |
| `newrelic_rest_key` | `NRRA-` + 42 hex |
| `sentry_org_token` | `sntrys_` + base64url |
| `openai_service_account_key` | `sk-svcacct-` + base64url |
| `google_oauth_access_token` | `ya29.` + base64url |
| `persona_api_key` | `persona_{sandbox,production}_` + base62 |
| `depot_token` | `depot_{project,org,user}_` + base62 |
| `octopus_deploy_key` | `API-` + 26 base36 |

Each rule keys on a **distinctive literal prefix**, so it has no "safe form" — the matched string is a
credential shape, not a value that is benign in some context. Two of these fill gaps the code already noted:
`newrelic_insights_key` (`NRII-`) is distinct from the existing `NRAK-` user key, and `sentry_org_token`
(`sntrys_`) is distinct from the existing `sntryu_` user token and the Sentry DSN. `openai_service_account_key`
(`sk-svcacct-`) and `google_oauth_access_token` (`ya29.`) use prefixes disjoint from the existing OpenAI
(`sk-proj-`), Anthropic (`sk-ant-`), and Google API-key (`AIza`) rules.

Terminators are chosen for correctness: hex/base62 bodies end on `\b`; base64url bodies (which can legitimately
end in `-`) end on a negative lookahead `(?![A-Za-z0-9_-])` — the terminator the existing
SendGrid/Anthropic/Square rules use. Bounded-length rules use a minimum (`{20,}`) rather than an exact count.
A near-miss test asserts one-char-short tokens produce no finding.

No existing rule is modified, so current findings are unchanged, and no analyzer descriptor changes — so
`analyzer-metadata.json` and the generated UI mirror are untouched.

No linked issue: additive detection-coverage for well-known credential formats, matching the established
`feat(enrichment)` secret-format additions; each rule is a self-evident real token shape with no public
API/schema/deploy surface change — fits the repo's `preferred` (not required) linked-issue policy.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run typecheck`
- [x] `npm run rees:test` — the review-enrichment build + analyzer suite (see note below)
- [ ] `npm run test:coverage` (N/A — this file is in `review-enrichment/`, outside the root `src/**` Codecov scope)
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran locally: `git diff --check` (clean), the review-enrichment TypeScript build (exit 0), and the secret-scan
  analyzer test via `node --test` — **62/62 pass**, including a table case that flags each of the 8 formats at
  high confidence plus a near-miss case asserting one-char-short tokens produce no finding. All fixtures are
  assembled from string fragments so the test file never contains a contiguous secret literal. The change is
  confined to `review-enrichment/`, outside the `src/**` Codecov scope.
- Not run locally: the UI, root typecheck, and the `metadata:check` step of `rees:test`. This change only adds
  scan rules, not any analyzer descriptor, so the committed `analyzer-metadata.json`/UI mirror are unchanged (a
  local regeneration produces a zero-content diff) and `metadata:check` passes on CI (Linux). On this Windows
  dev box `metadata:check` reports a spurious line-ending difference; it fails identically on unmodified
  `main`. `analyzer-metadata.json` was NOT modified.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Detection-only additions: 8 new high-confidence rules; no existing rule, threshold, or descriptor changed,
  so current findings and `analyzer-metadata.json` are unaffected. The scanner still returns only `file:line` +
  `kind`, never the matched secret value.
- Every rule keys on a provider-specific prefix, so — unlike a config-value check — there is no line on which
  the same shape is a safe value; the match itself is the credential shape.
