### PR TITLE
feat(enrichment): detect Cohere API keys and Intercom access tokens in secret-scan

### DIFF
--- a/review-enrichment/src/analyzers/secret-scan.ts
+++ b/review-enrichment/src/analyzers/secret-scan.ts
@@ -200,6 +200,18 @@ const RULES: Rule[] = [
     confidence: "high",
   },
   {
+    // Cohere API key: `co_` + 48 base62 chars.
+    kind: "cohere_api_key",
+    re: /\bco_[A-Za-z0-9]{48}(?![A-Za-z0-9_])/,
+    confidence: "high",
+  },
+  {
+    // Intercom access token: base64 `tok:` prefix (`dG9rOm`) + opaque body.
+    kind: "intercom_access_token",
+    re: /\bdG9rOm[A-Za-z0-9+/=]{30,}(?![A-Za-z0-9+/=])/,
+    confidence: "high",
+  },
+  {
     // Google OAuth 2.0 client secret: `GOCSPX-` + 28 base64url chars.
     kind: "google_oauth_client_secret",
     re: /\bGOCSPX-[A-Za-z0-9_-]{28}\b/,

--- a/review-enrichment/test/secret-scan.test.ts
+++ b/review-enrichment/test/secret-scan.test.ts
@@ -505,6 +505,29 @@ test("scanPatch does not flag truncated Mapbox secrets or public pk tokens", () 
   );
 });
 
+test("scanPatch flags Cohere and Intercom access tokens with high confidence", () => {
+  const fakeCohereKey = "co_" + "a".repeat(48);
+  const cohereFindings = scanPatch("src/config.ts", hunk([`const cohere = "${fakeCohereKey}";`]));
+  assert.equal(cohereFindings.length, 1);
+  assert.equal(cohereFindings[0].kind, "cohere_api_key");
+  assert.equal(cohereFindings[0].confidence, "high");
+
+  const fakeIntercomToken = "dG9rOm" + "a".repeat(30);
+  const intercomFindings = scanPatch("src/config.ts", hunk([`const intercom = "${fakeIntercomToken}";`]));
+  assert.equal(intercomFindings.length, 1);
+  assert.equal(intercomFindings[0].kind, "intercom_access_token");
+  assert.equal(intercomFindings[0].confidence, "high");
+});
+
+test("scanPatch does not flag truncated Cohere/Intercom tokens or identifier continuation", () => {
+  assert.equal(scanPatch("src/config.ts", hunk([`const cohere = "co_${"a".repeat(47)}";`])).length, 0);
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const cohere = "co_${"a".repeat(48)}_suffix";`])).some((f) => f.kind === "cohere_api_key"),
+    false,
+  );
+  assert.equal(scanPatch("src/config.ts", hunk([`const intercom = "dG9rOm${"a".repeat(29)}";`])).length, 0);
+});
+
 test("scanPatch flags additional high-confidence SaaS/cloud/CI credential formats", () => {
   const cases = [
     ["google_oauth_client_secret", "GOCSPX-" + b62(28)],


### PR DESCRIPTION
## Summary
- Add high-confidence secret-scan rules for **Cohere API keys** (`co_` + 48 base62 chars) and **Intercom access tokens** (`dG9rOm` + base64 body).
- Both rules use identifier-continuation tail guards (`(?![A-Za-z0-9_])` / `(?![A-Za-z0-9+/=])`) consistent with the Twilio/Mapbox patterns from merged #3263/#3267.

## Motivation
Cohere and Intercom credentials are commonly leaked in env files and backend configs. The secret-scan analyzer already covers many AI/SaaS tokens but missed these documented formats.

## Test plan
- [x] Cohere — positive match, truncated negative, `_suffix` identifier-continuation negative
- [x] Intercom — positive match and truncated negative
- [x] Fragment-based fixtures (no contiguous fake secrets in source)
- [x] Full `secret-scan.test.ts` suite passes (62 tests)


Made with [Cursor](https://cursor.com)