### PR TITLE
docs(ui): stop describing workers-ai as the live default reviewer

### DIFF
--- a/apps/gittensory-ui/src/components/site/app-panels/ai-review-settings.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/ai-review-settings.tsx
@@ -176,9 +176,9 @@ export function AiReviewSettings({ reviewability }: { reviewability: Array<{ pr:
             AI review &amp; BYOK
           </h2>
           <p className="mt-1 text-token-xs text-muted-foreground">
-            Free Cloudflare Workers AI by default. Bring your own Anthropic/OpenAI key for a
-            frontier-quality advisory write-up — your key, your provider account. Consensus blocking
-            always uses the free models and only applies to confirmed contributors.
+            Uses the operator's default reviewer by default. Bring your own Anthropic/OpenAI key for
+            a frontier-quality advisory write-up — your key, your provider account. Consensus
+            blocking always uses the default reviewer and only applies to confirmed contributors.
           </p>
         </div>
         <StatusPill status={mode === "off" ? "info" : mode === "block" ? "warn" : "ready"}>

--- a/apps/gittensory-ui/src/routes/docs.ai-summaries.tsx
+++ b/apps/gittensory-ui/src/routes/docs.ai-summaries.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, Link } from "@tanstack/react-router";
 
 import { DocsPage } from "@/components/site/docs-page";
 import { Callout } from "@/components/site/primitives";
@@ -73,9 +73,10 @@ function AiSummariesDoc() {
 
       <h2>Model choice</h2>
       <p>
-        There is no per-user or per-session model picker. The self-hosted or hosted operator
-        configures one fixed Cloudflare Workers AI model (<code>WORKERS_AI_SUMMARY_MODEL</code>,
-        default a small Llama instruct model) for the whole instance. Summaries are off by default (
+        There is no per-user or per-session model picker. The operator configures one AI provider
+        for the whole instance — see{" "}
+        <Link to="/docs/self-hosting-ai-providers">self-hosting AI providers</Link> for the
+        Codex/Claude Code/Ollama/OpenAI-compatible/Anthropic options. Summaries are off by default (
         <code>AI_SUMMARIES_ENABLED</code>); public-comment rewriting is a separate,
         also-off-by-default switch (<code>AI_PUBLIC_COMMENTS_ENABLED</code>).
       </p>


### PR DESCRIPTION
## Summary

- Follow-up to #3270/#3274. The AI review settings panel subtitle (`apps/gittensory-ui/src/components/site/app-panels/ai-review-settings.tsx`) said "Free Cloudflare Workers AI by default... Consensus blocking always uses the free models", and the AI summaries docs page (`apps/gittensory-ui/src/routes/docs.ai-summaries.tsx`) told operators they configure "one fixed Cloudflare Workers AI model (`WORKERS_AI_SUMMARY_MODEL`)". Workers AI has no live binding anywhere today — hosted or self-host (see `CONVERGENCE_RUNBOOK.md`).
- Reworded both to describe the operator's configured default reviewer generically instead of naming Workers AI specifically, and added a cross-link from the AI summaries docs page to the existing `/docs/self-hosting-ai-providers` page, which already accurately documents the real Codex/Claude Code/Ollama/OpenAI-compatible/Anthropic options.
- Copy-only change; no logic touched. The `AiProvider = "anthropic" | "openai"` selector in the settings panel is intentionally scoped to the separate hosted BYOK feature and was left as-is.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] No issue linked — copy-only follow-up to #3270, self-evident in scope.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint` (via `npm run test:ci`)
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — `apps/**` is not measured by Codecov; full suite green (8807 passed)
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:test` — 64 passed, including the existing `ai-review-settings.test.tsx` suite (had to reword my first draft of the subtitle copy since "operator-configured" collided with an existing `getByText(/configured/)` assertion elsewhere on the panel)
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] Ran the full `npm run test:ci` gate locally — green

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no API/OpenAPI/MCP changes.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — text-only copy change, no data-fetching behavior touched.
- [ ] Visible UI changes include a `UI Evidence` section with hosted screenshots. — Verified both changes live in a local browser preview (the docs page render and the settings-panel unit test's rendered DOM), but could not produce a GitHub-hosted image URL to embed here (no `gh` command uploads an arbitrary attachment, and committing screenshots to the repo is against house rules). Happy to attach via a follow-up comment if there's a preferred upload path.
- [ ] Public docs/changelogs are updated where needed. — N/A, no changelog edit.