### PR TITLE
feat(enrichment): detect developer-platform credential formats in secret-scan

### DIFF
--- a/review-enrichment/src/analyzers/secret-scan.ts
+++ b/review-enrichment/src/analyzers/secret-scan.ts
@@ -663,6 +663,49 @@ const RULES: Rule[] = [
     confidence: "high",
   },
   {
+    // Inngest signing key: `signkey-prod-`/`signkey-test-` + 64 hex.
+    kind: "inngest_signing_key",
+    re: /\bsignkey-(?:prod|test)-[a-f0-9]{64}\b/,
+    confidence: "high",
+  },
+  {
+    // Trigger.dev API key: `tr_prod_`/`tr_dev_` + >=20 base62 (word-char body → `\b` terminator).
+    kind: "trigger_dev_key",
+    re: /\btr_(?:prod|dev)_[A-Za-z0-9]{20,}\b/,
+    confidence: "high",
+  },
+  {
+    // Cal.com API key: `cal_live_`/`cal_test_` + >=20 hex (word-char body → `\b` terminator).
+    kind: "cal_com_api_key",
+    re: /\bcal_(?:live|test)_[a-f0-9]{20,}\b/,
+    confidence: "high",
+  },
+  {
+    // Cerebras API key: `csk-` + >=40 base62 (word-char body → `\b` terminator).
+    kind: "cerebras_api_key",
+    re: /\bcsk-[A-Za-z0-9]{40,}\b/,
+    confidence: "high",
+  },
+  {
+    // Helicone API key: `sk-helicone-` + a UUID-shaped body (distinct from the OpenAI/Anthropic `sk-` keys).
+    // Body can end in `-`, so a negative-lookahead terminator (not `\b`), matching the SendGrid/Anthropic rules.
+    kind: "helicone_api_key",
+    re: /\bsk-helicone-[A-Za-z0-9_-]{20,}(?![A-Za-z0-9_-])/,
+    confidence: "high",
+  },
+  {
+    // Langfuse secret key: `sk-lf-` + a UUID-shaped body (lookahead terminator, as above).
+    kind: "langfuse_secret_key",
+    re: /\bsk-lf-[A-Za-z0-9_-]{20,}(?![A-Za-z0-9_-])/,
+    confidence: "high",
+  },
+  {
+    // Neon API key: `napi_` + >=40 base62 (word-char body → `\b` terminator).
+    kind: "neon_api_key",
+    re: /\bnapi_[A-Za-z0-9]{40,}\b/,
+    confidence: "high",
+  },
+  {
     kind: "private_key",
     re: /-----BEGIN (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----/,
     confidence: "high",

--- a/review-enrichment/test/secret-scan.test.ts
+++ b/review-enrichment/test/secret-scan.test.ts
@@ -778,3 +778,41 @@ test("scanPatch does not flag near-miss variants of the observability/CI formats
     assert.equal(findings.length, 0, `near-miss should not match: ${nm}`);
   }
 });
+
+test("scanPatch flags developer-platform (CI/AI/DB) credential formats", () => {
+  const cases = [
+    ["inngest_signing_key", "signkey-prod-" + hex(64)],
+    ["trigger_dev_key", "tr_prod_" + b62(20)],
+    ["cal_com_api_key", "cal_live_" + hex(20)],
+    ["cerebras_api_key", "csk-" + b62(40)],
+    ["helicone_api_key", "sk-helicone-" + b62(20)],
+    ["langfuse_secret_key", "sk-lf-" + b62(20)],
+    ["neon_api_key", "napi_" + b62(40)],
+  ];
+  for (const [kind, secret] of cases) {
+    const findings = scanPatch("src/config.ts", hunk([`const c = "${secret}";`]));
+    assert.equal(findings.length, 1, `${kind}: expected exactly one finding, got ${JSON.stringify(findings)}`);
+    assert.equal(findings[0].kind, kind, `${kind}: wrong kind`);
+    assert.equal(findings[0].confidence, "high", `${kind}: wrong confidence`);
+  }
+});
+
+test("scanPatch does not flag near-miss variants of the developer-platform formats", () => {
+  const nearMisses = [
+    "signkey-prod-" + hex(63),
+    "tr_prod_" + b62(19),
+    "cal_live_" + hex(19),
+    "csk-" + b62(39),
+    "sk-helicone-" + b62(19),
+    "sk-lf-" + b62(19),
+    "napi_" + b62(39),
+    // A hex/base62 run that continues into a non-hex word char is NOT a completed token: the `\b` terminator
+    // must reject the embedded prefix (a `(?![a-f0-9])`-style lookahead would wrongly flag it).
+    "cal_live_" + hex(20) + "g",
+    "napi_" + b62(40) + "_extra",
+  ];
+  for (const nm of nearMisses) {
+    const findings = scanPatch("src/config.ts", hunk([`const c = "${nm}";`]));
+    assert.equal(findings.length, 0, `near-miss should not match: ${nm}`);
+  }
+});


### PR DESCRIPTION
## Summary

The secret-scan analyzer (`review-enrichment/src/analyzers/secret-scan.ts`) flags credentials committed in a
PR diff, citing `file:line` + kind only (never the value). This adds **7 more credential formats** the scanner
currently misses — current developer-platform (CI/CD, AI-gateway, and serverless-DB) tokens — continuing the
established `feat(enrichment)` secret-format additions:

| kind | shape |
|---|---|
| `inngest_signing_key` | `signkey-{prod,test}-` + 64 hex |
| `trigger_dev_key` | `tr_{prod,dev}_` + base62 |
| `cal_com_api_key` | `cal_{live,test}_` + hex |
| `cerebras_api_key` | `csk-` + base62 |
| `helicone_api_key` | `sk-helicone-` + UUID body |
| `langfuse_secret_key` | `sk-lf-` + UUID body |
| `neon_api_key` | `napi_` + base62 |

> Supersedes the closed #3276, which correctly flagged that a `(?![a-f0-9])`-style terminator on a hex/base62
> body only forbids the *next character being hex* — so `cal_live_<20 hex>g` (a hex run continuing into a
> non-hex word char) was wrongly reported. This version terminates every word-character body (hex/base62) on
> `\b` and every `-`-containing body on `(?![A-Za-z0-9_-])`, and adds regression cases (`cal_live_<20hex>g`,
> `napi_<40>_extra`) that must produce no finding.

Each rule keys on a **distinctive literal prefix**, so it has no "safe form" — the matched string is a
credential shape, not a value that is benign in some context. `helicone_api_key` (`sk-helicone-`) and
`langfuse_secret_key` (`sk-lf-`) use segments disjoint from the existing OpenAI (`sk-proj-`), Anthropic
(`sk-ant-`), and Mapbox (`sk.eyJ`) rules, so they never collide.

Terminators are chosen for correctness: hex/base62 (word-character) bodies end on `\b`, so a hex/base62 run
that continues into another word character is not treated as a completed token; bodies whose charset includes
`-` (UUID-shaped) end on `(?![A-Za-z0-9_-])` — the terminator the existing SendGrid/Anthropic/Square rules use.
Bounded-length rules use a minimum (`{20,}`) rather than an exact count. The near-miss test asserts one-char-
short tokens, and the two embedded-prefix cases above, produce no finding.

No existing rule is modified, so current findings are unchanged, and no analyzer descriptor changes — so
`analyzer-metadata.json` and the generated UI mirror are untouched.

No linked issue: additive detection-coverage for well-known credential formats, matching the established
`feat(enrichment)` secret-format additions; each rule is a self-evident real token shape with no public
API/schema/deploy surface change — fits the repo's `preferred` (not required) linked-issue policy.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run typecheck`
- [x] `npm run rees:test` — the review-enrichment build + analyzer suite (see note below)
- [ ] `npm run test:coverage` (N/A — this file is in `review-enrichment/`, outside the root `src/**` Codecov scope)
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran locally: `git diff --check` (clean), the review-enrichment TypeScript build (exit 0), and the secret-scan
  analyzer test via `node --test` — **66/66 pass**, including a table case that flags each of the 7 formats at
  high confidence plus a near-miss case asserting one-char-short tokens produce no finding. All fixtures are
  assembled from string fragments so the test file never contains a contiguous secret literal. The change is
  confined to `review-enrichment/`, outside the `src/**` Codecov scope.
- Not run locally: the UI, root typecheck, and the `metadata:check` step of `rees:test`. This change only adds
  scan rules, not any analyzer descriptor, so the committed `analyzer-metadata.json`/UI mirror are unchanged (a
  local regeneration produces a zero-content diff) and `metadata:check` passes on CI (Linux). On this Windows
  dev box `metadata:check` reports a spurious line-ending difference; it fails identically on unmodified
  `main`. `analyzer-metadata.json` was NOT modified.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Detection-only additions: 7 new high-confidence rules; no existing rule, threshold, or descriptor changed,
  so current findings and `analyzer-metadata.json` are unaffected. The scanner still returns only `file:line` +
  `kind`, never the matched secret value.
- Every rule keys on a provider-specific prefix, so — unlike a config-value check — there is no line on which
  the same shape is a safe value; the match itself is the credential shape.
