### PR TITLE
fix(signals): classify Vue/Svelte/Astro source files as code

### DIFF
--- a/packages/gittensory-mcp/lib/local-branch.js
+++ b/packages/gittensory-mcp/lib/local-branch.js
@@ -610,7 +610,7 @@ export function isTestFile(file) {
 }
 
 export function isCodeFile(file) {
-  return /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy|php|cpp|c|h|m)$/i.test(file) && !isTestFile(file);
+  return /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy|php|cpp|c|h|m|vue|svelte|astro)$/i.test(file) && !isTestFile(file);
 }
 
 function numberValue(value) {

--- a/packages/gittensory-mcp/scripts/gittensor-score-preview.mjs
+++ b/packages/gittensory-mcp/scripts/gittensor-score-preview.mjs
@@ -19,7 +19,7 @@ function isTestFile(file) {
 }
 
 function isCodeFile(file) {
-  return /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy|php|cpp|c|h|m)$/i.test(file) && !isTestFile(file);
+  return /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy|php|cpp|c|h|m|vue|svelte|astro)$/i.test(file) && !isTestFile(file);
 }
 
 function lineCount(file) {

--- a/packages/gittensory-mcp/scripts/gittensor-score-preview.py
+++ b/packages/gittensory-mcp/scripts/gittensor-score-preview.py
@@ -142,7 +142,7 @@ def metadata_fallback(metadata: dict) -> dict:
         lines = max(int(entry.get("additions") or 0) + int(entry.get("deletions") or 0), 0)
         if is_test_file(path):
             tests += lines
-        elif lower_path.endswith((".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs", ".py", ".rb", ".rs", ".go", ".java", ".kt", ".scala", ".sql", ".cs", ".swift", ".groovy", ".php", ".cpp", ".c", ".h", ".m")):
+        elif lower_path.endswith((".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs", ".py", ".rb", ".rs", ".go", ".java", ".kt", ".scala", ".sql", ".cs", ".swift", ".groovy", ".php", ".cpp", ".c", ".h", ".m", ".vue", ".svelte", ".astro")):
             source += lines
         else:
             non_code += lines

--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -5538,10 +5538,11 @@ function sanitizeOutcomeDimensionKey(key: string): string {
 function isCodeFile(file: string): boolean {
   // Mirrors isCodeFile in local-branch.ts — kept in sync (cs/swift/groovy/php and C/C++/Objective-C added
   // so native/C#/Swift/Groovy/PHP source counts as code, matching the test conventions
-  // isTestPath already recognizes).
+  // isTestPath already recognizes; vue/svelte/astro match rag.ts + visual paths).
   return (
-    /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy|php|cpp|c|h|m)$/i.test(file) &&
-    !isTestFile(file)
+    /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy|php|cpp|c|h|m|vue|svelte|astro)$/i.test(
+      file,
+    ) && !isTestFile(file)
   );
 }
 

--- a/src/signals/local-branch.ts
+++ b/src/signals/local-branch.ts
@@ -1270,10 +1270,12 @@ export function isCodeFile(file: string): boolean {
   // cs/swift/groovy/php plus C/C++/Objective-C round out the native/JVM/.NET/Swift/PHP set: isTestPath already
   // recognizes their `SomethingTest(s)`/`Spec` test files, so their source must
   // count as code too — otherwise a C#/Swift/Groovy/PHP/native source file is neither test
-  // nor code in the local scorer.
+  // nor code in the local scorer. vue/svelte/astro align with review/rag.ts CODE_EXT_RE and
+  // review/visual/paths.ts so front-end framework source is not misclassified as "other".
   return (
-    /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy|php|cpp|c|h|m)$/i.test(file) &&
-    !isTestFile(file)
+    /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy|php|cpp|c|h|m|vue|svelte|astro)$/i.test(
+      file,
+    ) && !isTestFile(file)
   );
 }
 

--- a/test/unit/local-branch-file-classifiers.test.ts
+++ b/test/unit/local-branch-file-classifiers.test.ts
@@ -131,6 +131,11 @@ describe("isCodeFile", () => {
       "src/native/add.cpp",
       "include/native/add.h",
       "src/objc/View.m",
+      // Front-end framework source — already indexed as code by rag.ts and flagged
+      // as visual paths, but must count as code for slop/missing-tests signals.
+      "src/App.vue",
+      "src/Widget.svelte",
+      "src/pages/index.astro",
     ]) {
       expect(isCodeFile(path)).toBe(true);
     }

--- a/test/unit/local-branch.test.ts
+++ b/test/unit/local-branch.test.ts
@@ -1774,6 +1774,11 @@ describe("local MCP git metadata collection", () => {
       expect(isTestFile(file)).toBe(false);
       expect(isCodeFile(file)).toBe(true);
     }
+    // Front-end framework source mirrors review/rag.ts and visual-path classifiers.
+    for (const file of ["src/App.vue", "src/Widget.svelte", "src/pages/index.astro"]) {
+      expect(isTestFile(file)).toBe(false);
+      expect(isCodeFile(file)).toBe(true);
+    }
   });
 
   it("extracts linked issues only from standalone closing keywords, not keyword substrings", async () => {

--- a/test/unit/score-preview-script.test.ts
+++ b/test/unit/score-preview-script.test.ts
@@ -132,6 +132,32 @@ describe("gittensor-score-preview.mjs classifier parity with the server", () => 
     expect(py.nonCodeTokenScore).toBe(3);
   });
 
+  it("classifies Vue/Svelte/Astro source as code in both .mjs and .py previews", () => {
+    // Parity with review/rag.ts CODE_EXT_RE and review/visual/paths.ts: front-end framework
+    // source must count as code, not non-code, in every mirrored classifier.
+    const files = [
+      { path: "src/App.vue", additions: 6, deletions: 0 },
+      { path: "src/Widget.svelte", additions: 4, deletions: 0 },
+      { path: "src/pages/index.astro", additions: 5, deletions: 0 },
+      { path: "README.md", additions: 2, deletions: 0 }, // non-code control
+    ];
+    const mjs = runPreview(files);
+    expect(mjs.sourceTokenScore).toBe(15);
+    expect(mjs.testTokenScore).toBe(0);
+    expect(mjs.nonCodeTokenScore).toBe(2);
+
+    const python = findPython();
+    if (!python) return;
+    const env = { ...process.env };
+    delete env.GITTENSOR_ROOT;
+    const res = spawnSync(python, [scriptPy], { input: JSON.stringify({ changedFiles: files }), encoding: "utf8", env });
+    expect(res.status, res.stderr).toBe(0);
+    const py = JSON.parse(res.stdout);
+    expect(py.sourceTokenScore).toBe(15);
+    expect(py.testTokenScore).toBe(0);
+    expect(py.nonCodeTokenScore).toBe(2);
+  });
+
   it("classifies PascalCase PHP test files as tests in both .mjs and .py previews", () => {
     // Parity with src/signals/test-evidence.ts: PHPUnit/PHPSpec class-suffix files must not be counted as
     // PHP source simply because they live outside a conventional tests/ directory.


### PR DESCRIPTION
## Summary

Vue, Svelte, and Astro source files were already treated as code by the RAG indexer (`review/rag.ts` `CODE_EXT_RE`) and the visual-path classifier (`review/visual/paths.ts`), but `isCodeFile` did not recognize them. That mismatch meant front-end framework changes could be misclassified as non-code in slop signals, missing-tests checks, and the MCP local score preview.

This PR extends `isCodeFile` (and the mirrored MCP classifiers) to include `.vue`, `.svelte`, and `.astro` extensions, with regression tests in the classifier suite, MCP parity test, and score-preview script tests.

No linked issue — small classifier parity fix with clear product impact.

**Conflict avoidance:** Touches only `src/signals/{local-branch,engine}.ts`, MCP score-preview mirrors, and related unit tests. None of the four currently open PRs (#3283, #3281, #3278, #3255) modify these paths, so this should merge cleanly even after those land.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- None skipped. Full `npm run test:ci` and `npm audit --audit-level=moderate` both passed locally on latest `main` (commit 344bd0e3).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — no visible UI change.

## Notes

- Keeps `isCodeFile` in `local-branch.ts`, `engine.ts`, and the MCP score-preview mirrors (`.mjs`, `.py`, `local-branch.js`) in sync.
- Added MCP parity coverage in `local-branch.test.ts` and `score-preview-script.test.ts` for both `.mjs` and `.py` paths.
