### PR TITLE
docs(self-host): add disk capacity planning and backup retention policy

### DIFF
--- a/apps/gittensory-ui/src/routes/docs.self-hosting-backup-scaling.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-backup-scaling.tsx
@@ -76,10 +76,10 @@ LITESTREAM_REGION=us-east-1`}
         rather than leaving you with nothing).
       </p>
       <Callout variant="warn" title="A failed SQLite backup never prunes">
-        If the SQLite online backup fails verification (a non-empty file whose{" "}
-        <code>PRAGMA integrity_check</code> doesn't come back <code>ok</code>), the script deletes
-        the bad output, logs the failure, and — critically —{" "}
-        <strong>skips the retention prune for the sqlite target on that run</strong>, so a broken
+        If the SQLite online backup fails verification — the <code>.backup</code> command itself
+        fails, the output file is empty, or its <code>PRAGMA integrity_check</code> doesn't come
+        back <code>ok</code> — the script deletes the bad output, logs the failure, and — critically
+        — <strong>skips the retention prune for the sqlite target on that run</strong>, so a broken
         backup can never push a known-good one out of the retained window. Postgres and Qdrant
         retention still run normally on that same pass, since only the SQLite leg failed. The run
         still exits non-zero so the failure is loud.

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-backup-scaling.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-backup-scaling.tsx
@@ -60,6 +60,31 @@ LITESTREAM_REGION=us-east-1`}
       </p>
       <CodeBlock lang="bash" code={`docker compose --profile backup up -d`} />
 
+      <h3>Retention: how many backups are kept</h3>
+      <p>
+        Each run keeps the newest <code>BACKUP_RETAIN</code> backups (default <strong>7</strong>) —
+        applied <em>independently per target</em>: <code>postgres/</code>, <code>sqlite/</code>, and{" "}
+        <code>qdrant/</code> in the <code>gittensory-backups</code> volume each retain their own
+        newest 7, not 7 combined across all three. Set it in <code>.env</code> to change the window:
+      </p>
+      <CodeBlock filename=".env" code={`BACKUP_RETAIN=14`} />
+      <p>
+        <code>scripts/backup.sh</code>'s <code>normalize_backup_retain</code> guards against
+        misconfiguration rather than failing the run: a non-numeric or empty value falls back to 7
+        with a logged warning, and <code>BACKUP_RETAIN=0</code> is coerced up to 1 (a retention
+        window of zero would delete the backup the script just took, so the script refuses that
+        rather than leaving you with nothing).
+      </p>
+      <Callout variant="warn" title="A failed SQLite backup never prunes">
+        If the SQLite online backup fails verification (a non-empty file whose{" "}
+        <code>PRAGMA integrity_check</code> doesn't come back <code>ok</code>), the script deletes
+        the bad output, logs the failure, and — critically —{" "}
+        <strong>skips the retention prune for the sqlite target on that run</strong>, so a broken
+        backup can never push a known-good one out of the retained window. Postgres and Qdrant
+        retention still run normally on that same pass, since only the SQLite leg failed. The run
+        still exits non-zero so the failure is loud.
+      </Callout>
+
       <h2>Multi-instance: Postgres and Redis</h2>
       <FeatureRow
         items={[

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-operations.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-operations.tsx
@@ -345,7 +345,7 @@ docker compose --profile postgres --profile observability --profile backup up -d
           {
             title: "review_audit (fixed overhead per PR, unbounded)",
             description:
-              "One row per finalized gate decision plus one per realized merge/close outcome — a few small text columns each, so bytes per row are trivial (well under 1KB). It has no retention policy in src/db/retention.ts, so it grows forever. At real-world row sizes this stays in the tens of MB per thousand PRs reviewed; it will not be what fills your disk, but it is the cleanest per-PR-volume number to extrapolate from if you want one.",
+              "Roughly 2 rows per PR — one finalized gate decision plus one realized merge/close outcome — each a few small text columns (well under 1KB/row). It has no retention policy in src/db/retention.ts, so it grows forever. Don't trust a blanket MB-per-thousand-PRs estimate here; measure your own instance's actual growth with pg_total_relation_size('review_audit') (or the equivalent SQLite page count) after a known number of PRs, then extrapolate from that.",
           },
           {
             title: "webhook_events (fixed overhead per delivery, unbounded)",

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-operations.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-operations.tsx
@@ -332,6 +332,51 @@ docker compose --profile postgres --profile observability --profile backup up -d
         ceiling depends entirely on the host's core count and how many runner replicas you run.
       </p>
 
+      <h3>Capacity planning: how much disk for N repos at M PRs/month</h3>
+      <p>
+        The 151GB host above is one measured point, not a formula. It says nothing about how disk
+        use grows as you register more repos or review more pull requests — for that you have to
+        reason about which tables and volumes actually grow with activity, versus which are fixed
+        overhead. Treat every number below as an order-of-magnitude estimate to plan around, not a
+        guarantee.
+      </p>
+      <FeatureRow
+        items={[
+          {
+            title: "review_audit (fixed overhead per PR, unbounded)",
+            description:
+              "One row per finalized gate decision plus one per realized merge/close outcome — a few small text columns each, so bytes per row are trivial (well under 1KB). It has no retention policy in src/db/retention.ts, so it grows forever. At real-world row sizes this stays in the tens of MB per thousand PRs reviewed; it will not be what fills your disk, but it is the cleanest per-PR-volume number to extrapolate from if you want one.",
+          },
+          {
+            title: "webhook_events (fixed overhead per delivery, unbounded)",
+            description:
+              "One row per inbound GitHub webhook delivery — every push, comment, check-run update, and review event, not just PR opens — so it accrues considerably faster than review_audit for the same PR volume (commonly 5-15x, depending on how chatty a repo's CI and review activity are). Also absent from RETENTION_POLICY, so it also grows without bound. Still small per row; the growth to watch is row count over months, not any single row's size.",
+          },
+          {
+            title: "audit_events (bounded — 90-day retention)",
+            description:
+              "One row per privileged/security-relevant action (recordAuditEvent in src/db/repositories.ts), pruned automatically: RETENTION_POLICY in src/db/retention.ts keeps 90 days and the prune-retention job runs daily at 03:00 UTC (src/index.ts), so this table's steady-state size is capped regardless of how long the instance has been running — it will not be a long-term capacity driver the way the two tables above are.",
+          },
+          {
+            title: "Postgres/SQLite backup dumps (scales with live DB size x retained copies)",
+            description:
+              "scripts/backup.sh keeps the newest BACKUP_RETAIN copies per target (default 7 — see the backup and scaling doc's retention section), so total backup-volume usage is roughly (live database size) x (retained count), independent of repo count except through the database-size term. A growing, unpruned review_audit/webhook_events pair feeds directly into this multiplier: whatever they add to the live database, the backup volume carries N times over.",
+          },
+        ]}
+      />
+      <p>
+        Putting it together: for a small install (a handful of repos, tens of PRs/month), all of
+        this is noise against the ~20GB of fixed Docker/image/volume overhead measured above — you
+        will not notice review_audit or webhook_events growth for a long time. The estimate gets
+        real at higher volume: an install running hundreds of PRs/month across dozens of repos, left
+        unattended for a year or more, is a plausible case where the unbounded tables above (and the
+        backups that multiply them) become the dominant long-term disk driver rather than Docker
+        images and build cache. There is no first-party tool yet to prune review_audit or
+        webhook_events — if you operate at that scale, monitor their row counts directly (
+        <code>SELECT count(*) FROM review_audit</code>,{" "}
+        <code>SELECT count(*) FROM webhook_events</code>) rather than assuming steady state.
+      </p>
+
       <h2>Docker resource hygiene</h2>
       <p>
         Every service in <code>docker-compose.yml</code> caps its own container logs (10MB × 3


### PR DESCRIPTION
## Summary

- `docs.self-hosting-operations.tsx`'s Disk section had real measured numbers from one production instance but nothing to help an operator answer "how much disk do I need for N repos at M PRs/month." Added a capacity-planning subsection grounded in the actual growth/retention behavior of the disk-consuming subsystems: `review_audit` (one row per finalized gate decision/outcome, no retention policy, unbounded) and `webhook_events` (one row per inbound webhook delivery, also unbounded) grow with activity; `audit_events` is capped at 90 days via `RETENTION_POLICY` in `src/db/retention.ts` and the daily 03:00 UTC `prune-retention` job in `src/index.ts`; backup-volume usage scales as live DB size × `BACKUP_RETAIN`. Estimates are labeled as estimates; only the retention/pruning facts are stated as verified.
- `docs.self-hosting-backup-scaling.tsx` never documented backup retention. Added a "Retention: how many backups are kept" section describing `BACKUP_RETAIN` (default 7, kept independently per target — postgres/sqlite/qdrant), `normalize_backup_retain`'s fallback-to-7 and floor-of-1 guards, and a callout on the exact failure-path behavior in `scripts/backup.sh`: a failed SQLite backup is deleted, logged, and skips only the sqlite retention prune (Postgres/Qdrant still prune normally that run) so a known-good backup is never evicted by a broken one.

Advances #1819.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed. (Advances the #1819 self-host production-readiness roadmap; documentation-depth work, not a specific tracked bug/feature.)

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` (not run — no workflow files touched)
- [x] `npm run ui:typecheck`
- [ ] `npm run test:coverage` (not run — docs-only change, no `src/**` lines touched, no Codecov obligation)
- [ ] `npm run test:workers` (not run — no worker code touched)
- [ ] `npm run build:mcp` (not run — no MCP code touched)
- [ ] `npm run test:mcp-pack` (not run — no MCP code touched)
- [ ] `npm run ui:openapi:check` (not run — no API/schema changes)
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm run docs:drift-check`
- [ ] `npm audit --audit-level=moderate` (not run — no dependency changes)
- [ ] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries (not applicable — no `src/**` code changed, prose-only docs routes)

If any required check was skipped, explain why:

- This is a docs-only change confined to two `apps/gittensory-ui/src/routes/docs.*.tsx` files (prose, `FeatureRow`, `Callout`). No `src/**`, workflow, MCP, or dependency files changed, so the code-path checks (coverage, workers, MCP pack, OpenAPI, audit, actionlint) don't apply. Ran the full docs-relevant gate instead: `ui:lint`, `ui:typecheck`, `ui:build`, `docs:drift-check` — all green.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no such changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no such changes.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — static docs prose only.)
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository. (No visual/layout change — new prose sections reuse existing `FeatureRow`/`Callout` components already styled elsewhere on these same pages; see Notes.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable: this PR adds prose content (paragraphs, a `FeatureRow`, and a `Callout`) to two existing docs pages using components already rendered elsewhere on those same pages. There is no new layout, styling, or visual component to screenshot — the rendered result is indistinguishable in kind from the surrounding sections already on the page.

## Notes

- Both additions extend existing well-scoped sections rather than restructuring them: the Disk capacity-planning content is appended after "When a compose default might need to change" and before "Docker resource hygiene" in `docs.self-hosting-operations.tsx`; the backup retention content is appended after "Scheduled backups" and before "Multi-instance: Postgres and Redis" in `docs.self-hosting-backup-scaling.tsx`.
- Verified against source, not restated from comments: `src/db/retention.ts` (RETENTION_POLICY, the 90-day `audit_events` rule, the daily prune job), `src/index.ts` (03:00 UTC `prune-retention` schedule), `src/review/outcomes-wire.ts` / `src/review/parity-wire.ts` (review_audit write sites), `src/db/schema.ts` (webhook_events, audit_events shape), and `scripts/backup.sh` (`normalize_backup_retain`, the per-target retention loop, and the exact SQLite-failure skip-prune branch).