### PR TITLE
docs(selfhost): document hosted/self-host migration and decommissioning

### DIFF
--- a/apps/gittensory-ui/src/routes/docs.maintainer-self-hosting.tsx
+++ b/apps/gittensory-ui/src/routes/docs.maintainer-self-hosting.tsx
@@ -203,6 +203,94 @@ function MaintainerSelfHosting() {
         <Link to="/docs/tuning">Tuning your reviews</Link> for gate semantics and this section for
         running the service yourself.
       </p>
+
+      <h2>Moving a repo between hosted and self-host</h2>
+      <p>
+        &quot;Hosted&quot; here means the private managed-beta shared <code>gittensory</code> App
+        described in <Link to="/docs/github-app">GitHub App configuration</Link> — a repo installed
+        there is reviewed by gittensory&apos;s own cloud Worker and its own database.
+        &quot;Self-host&quot; means your own container from{" "}
+        <Link to="/docs/self-hosting-quickstart">Quickstart</Link>, with its own GitHub App (or
+        brokered Orb enrollment) and its own data store. There is{" "}
+        <strong>no automated migration path between the two</strong> today — moving a repo is a
+        manual App swap plus re-creating whatever settings you had, not a toggle.
+      </p>
+
+      <h3>Switching a repo from hosted to self-host</h3>
+      <ol>
+        <li>
+          Stand up your self-host instance first and confirm <code>/ready</code> is healthy — see{" "}
+          <Link to="/docs/self-hosting-quickstart">Quickstart</Link> — before touching the hosted
+          install, so the repo is never briefly reviewed by nothing.
+        </li>
+        <li>
+          Create <strong>your own</strong> GitHub App via the self-host{" "}
+          <Link to="/docs/self-hosting-github-app">setup wizard</Link> (or brokered Orb enrollment).
+          You cannot repoint the existing shared hosted App at your self-host container — the shared
+          App&apos;s credentials belong to gittensory&apos;s cloud Worker, and{" "}
+          <code>src/selfhost/setup-wizard.ts</code> always mints a distinct App tied to your
+          instance&apos;s own webhook URL.
+        </li>
+        <li>
+          Install your new self-host App on the repo, choosing only that repo (or the org, if you're
+          migrating several at once).
+        </li>
+        <li>
+          Uninstall the shared hosted App from that repo (repo Settings → Integrations → GitHub Apps
+          → gittensory → Uninstall, or the equivalent org-level App settings page) once you&apos;ve
+          confirmed the self-host App is reviewing PRs correctly. Leaving both installed means two
+          reviewers post competing checks and comments on the same PRs.
+        </li>
+      </ol>
+
+      <h3>What does not carry over automatically</h3>
+      <p>
+        Hosted-side settings live in gittensory&apos;s own cloud database, keyed by repo full name —{" "}
+        <code>resolveRepositorySettings</code> (<code>src/settings/repository-settings.ts</code>)
+        reads them from <code>env.DB</code>, which is a completely different database instance than
+        your self-host container&apos;s. A self-host instance has no access to, and no import path
+        for, whatever thresholds, gate modes, or review-mode settings you configured on the hosted
+        side through the control panel or API. If you want the same behavior, you have to
+        re-configure it on the new instance from scratch — there is no export/import tool for this
+        today.
+      </p>
+      <p>
+        <strong>
+          One thing genuinely does carry over: a repo&apos;s own <code>.gittensory.yml</code>
+        </strong>{" "}
+        (config-as-code), because it lives in the repository&apos;s git history, not in either
+        service&apos;s database. <code>resolveRepositorySettings</code> overlays it on top of
+        whatever DB settings exist, on either hosted or self-host — so gate-mode overrides,
+        thresholds, and other settings expressed in that file apply identically the moment the new
+        App starts reviewing, with nothing to re-enter.
+      </p>
+      <Callout variant="warn" title="Review history does not move">
+        Past review comments, check-run history, and any per-PR state gittensory recorded while the
+        hosted App was active stay wherever they were created — GitHub comments and check runs are
+        never deleted or copied by an uninstall/install, but nothing in the self-host database is
+        backfilled from the hosted side. A migrated repo starts its self-host review history from
+        zero.
+      </Callout>
+      <p>
+        What stays identical for contributors either way: the review still posts as a{" "}
+        <code>gittensory[bot]</code>-style comment (under your own App&apos;s slug once you migrate,
+        not literally <code>gittensory[bot]</code>) plus the same check-run shape, and the gate
+        semantics in <Link to="/docs/tuning">Tuning your reviews</Link> and{" "}
+        <Link to="/docs/how-reviews-work">How reviews work</Link> are unchanged — only the
+        infrastructure and the settings storage location differ.
+      </p>
+
+      <h3>Switching a repo from self-host back to hosted</h3>
+      <p>
+        The reverse migration has the same shape and the same gap: uninstall your self-host App from
+        the repo, install the shared hosted App (if you have managed-beta access — see{" "}
+        <Link to="/docs/github-app">GitHub App configuration</Link>), and re-create any DB-backed
+        settings on the hosted side. <code>.gittensory.yml</code> again carries over for free since
+        it travels with the repo; nothing else does. Your self-host instance&apos;s data volumes are
+        untouched by this — see{" "}
+        <Link to="/docs/self-hosting-operations">Uninstalling and decommissioning</Link> if you also
+        intend to shut the instance down rather than keep it idle or reuse it for other repos.
+      </p>
     </DocsPage>
   );
 }

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-operations.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-operations.tsx
@@ -10,13 +10,13 @@ export const Route = createFileRoute("/docs/self-hosting-operations")({
       {
         name: "description",
         content:
-          "Operate the self-hosted Gittensory review service: readiness, metrics, logs, dashboards, jobs, queues, routine checks, and safe updates/rollback.",
+          "Operate the self-hosted Gittensory review service: readiness, metrics, logs, dashboards, jobs, queues, routine checks, safe updates/rollback, and clean uninstall/decommissioning.",
       },
       { property: "og:title", content: "Self-host operations — Gittensory docs" },
       {
         property: "og:description",
         content:
-          "Operate the self-hosted Gittensory review service: readiness, metrics, logs, dashboards, jobs, queues, routine checks, and safe updates/rollback.",
+          "Operate the self-hosted Gittensory review service: readiness, metrics, logs, dashboards, jobs, queues, routine checks, safe updates/rollback, and clean uninstall/decommissioning.",
       },
       { property: "og:url", content: "/docs/self-hosting-operations" },
     ],
@@ -609,6 +609,117 @@ docker inspect --format '{{.Config.Image}}' "$(docker compose ps -q gittensory)"
       <p>
         If an operating check fails, go to{" "}
         <Link to="/docs/self-hosting-troubleshooting">Self-host troubleshooting</Link>.
+      </p>
+
+      <h2>Uninstalling and decommissioning</h2>
+      <p>
+        Tearing an instance down cleanly touches four independent things: the GitHub App
+        installation, the data volumes, brokered-mode enrollment, and control-panel access. None of
+        this is scripted today — do each step deliberately, in this order, and decide what to keep
+        before you delete anything.
+      </p>
+
+      <h3>1. Revoke the GitHub App installation</h3>
+      <p>
+        Uninstalling stops GitHub from sending any further webhook events and immediately revokes
+        the App&apos;s installation tokens — nothing on the self-host side needs to be told; there
+        is no <code>installation</code> <code>deleted</code> webhook handler to run first. From the
+        repo or org: Settings → Integrations → GitHub Apps → your App → Uninstall. Do this before
+        stopping the container so you are not left with a dangling install pointed at a dead webhook
+        URL.
+      </p>
+      <p>
+        If you only want to pause reviews without losing the App&apos;s configuration (permissions,
+        webhook URL, private key), suspend the installation instead of uninstalling it — GitHub
+        stops delivering events to a suspended install but keeps everything else intact for a later
+        resume.
+      </p>
+
+      <h3>2. Decide what happens to the data volumes</h3>
+      <p>
+        Stopping the container does not delete anything — <code>docker compose stop</code> or{" "}
+        <code>docker compose down</code> (without <code>-v</code>) leaves every named volume (
+        <code>gittensory-data</code>, <code>gittensory-pg</code>, <code>qdrant-data</code>,{" "}
+        <code>gittensory-backups</code>, <code>grafana-data</code>, and the rest declared in{" "}
+        <code>docker-compose.yml</code>) on disk, along with the <code>./gittensory-config</code>{" "}
+        host directory (a bind mount, not a named volume, so it is never affected by <code>-v</code>{" "}
+        either way). Pick one:
+      </p>
+      <FeatureRow
+        items={[
+          {
+            title: "Keep (pause, don't decommission)",
+            description:
+              "docker compose stop. Volumes and .env stay as-is; restarting later resumes with the same data. Use this if you might come back.",
+          },
+          {
+            title: "Export, then delete",
+            description:
+              "Run the backup profile one last time (docker compose --profile backup up -d, then confirm with verify-backup.sh — see Backup and scaling) and copy the resulting archive off-host before removing anything.",
+          },
+          {
+            title: "Delete everything",
+            description:
+              "docker compose down -v removes every named volume permanently — the review database, vector index, Grafana dashboards state, and any local backup archives in gittensory-backups go with it. This does not touch ./gittensory-config (delete that host directory yourself if it should go too).",
+          },
+        ]}
+      />
+      <Callout variant="warn" title="down -v is irreversible without an existing backup">
+        If you have not exported a backup off-host first, <code>docker compose down -v</code>{" "}
+        permanently destroys review history, settings, and the vector index with no recovery path —
+        the volumes are the only copy. See{" "}
+        <Link to="/docs/self-hosting-backup-scaling">Backup and scaling</Link> before running it on
+        an instance you care about.
+      </Callout>
+
+      <h3>3. Deregister from the Orb broker (brokered mode only)</h3>
+      <p>
+        If this instance runs in brokered mode (<code>ORB_ENROLLMENT_SECRET</code> is set — see{" "}
+        <Link to="/docs/self-hosting-github-app">GitHub App and Orb</Link>), be aware there is{" "}
+        <strong>no self-service revocation endpoint today</strong> — the &quot;Minimum broker
+        safeguards&quot; checklist on that page lists a revocation path as a prerequisite for a
+        public brokered rollout that has not shipped yet. An enrollment record (
+        <code>orb_enrollments</code>) lives in gittensory&apos;s own central database, not your
+        container, and nothing in this codebase writes a <code>revoked_at</code> value to it outside
+        of tests. Practical steps until that exists:
+      </p>
+      <ul>
+        <li>
+          Uninstalling the GitHub App (step 1) stops new webhook traffic and installation-token
+          issuance from reaching your instance in practice, even though the enrollment row itself
+          stays marked enrolled centrally.
+        </li>
+        <li>
+          Stop the container and let <code>ORB_ENROLLMENT_SECRET</code> go with it — with nothing
+          polling or listening, the secret is inert even if it still resolves to a valid enrollment.
+        </li>
+        <li>
+          If the secret may have leaked or you want it invalidated outright rather than just
+          orphaned, treat this the same as any other suspected credential compromise: contact the
+          Orb operator to have the enrollment revoked centrally, since there is no in-product way to
+          do it yourself yet.
+        </li>
+      </ul>
+
+      <h3>4. Remove ADMIN_GITHUB_LOGINS access</h3>
+      <p>
+        <code>ADMIN_GITHUB_LOGINS</code> is read fresh from the environment on every control-panel
+        request (<code>isAuthorizedGitHubSessionLogin</code> in <code>src/auth/security.ts</code>) —
+        it is never cached at startup or baked into an issued session. To remove someone&apos;s
+        operator access, delete their login from the comma/whitespace-separated list in{" "}
+        <code>.env</code> and restart the <code>gittensory</code> service so the process picks up
+        the new value:
+      </p>
+      <CodeBlock
+        lang="bash"
+        code={`$EDITOR .env   # remove the login from ADMIN_GITHUB_LOGINS
+docker compose up -d --no-deps gittensory`}
+      />
+      <p>
+        This takes effect on their very next control-panel request after the restart — no signed-in
+        session is grandfathered in, because authorization is re-checked against the current
+        allowlist every time, not read from the session itself. If you are decommissioning the whole
+        instance rather than removing one operator, this step is moot once the container is stopped.
       </p>
     </DocsPage>
   );


### PR DESCRIPTION
## Summary

- Adds a "Moving a repo between hosted and self-host" section to `apps/gittensory-ui/src/routes/docs.maintainer-self-hosting.tsx` (after the existing "How self-hosting fits with hosted docs" section). Grounded in reading `src/selfhost/setup-wizard.ts` and `src/settings/repository-settings.ts` (`resolveRepositorySettings`): a repo cannot be repointed between the shared hosted App and a self-host App (the wizard always mints a distinct App), settings resolve from `env.DB` which is a completely different database per deployment (so DB-backed settings do NOT carry over and must be re-created by hand — there is no export/import tool), while `.gittensory.yml` genuinely does carry over because it lives in the repo's own git history and `resolveRepositorySettings` overlays it identically on either side. Also documents that GitHub review-comment/check-run history is never migrated, and covers the reverse (self-host to hosted) direction the same way.
- Adds an "Uninstalling and decommissioning" section to `apps/gittensory-ui/src/routes/docs.self-hosting-operations.tsx` (after "Updating and rolling back", following the same placement pattern as PR #3195's update/rollback section). Covers, in order: (1) revoking the GitHub App installation — confirmed there is no `installation`/`deleted` webhook handler in `src/github/webhook.ts` to run first, so uninstalling on GitHub's side is sufficient; (2) what happens to the named Docker volumes vs. the `./gittensory-config` bind mount on `stop` / `down` / `down -v` (cross-checked against `docker-compose.yml`'s actual volume declarations), with keep/export/delete options and a link to the backup/restore flow before anything destructive; (3) brokered-mode (`ORB_ENROLLMENT_SECRET`/`ORB_BROKER_URL`) deregistration — verified there is genuinely **no revocation write path** in this codebase (grepped every `UPDATE orb_enrollments` statement; none sets `revoked_at` outside tests), which matches the existing "Minimum broker safeguards" checklist on `docs.self-hosting-github-app.tsx` that already lists a revocation path as a *missing* prerequisite for public brokered rollout — documented honestly as unsupported today rather than implying a self-serve revoke exists; (4) removing `ADMIN_GITHUB_LOGINS` access — confirmed via `src/auth/security.ts`'s `isAuthorizedGitHubSessionLogin` that the allowlist is re-read from env on every request (never cached, never baked into a session), so editing `.env` + restarting the app service is sufficient and takes effect immediately.
- Updated this page's `<head>` meta description to mention uninstall/decommissioning, matching PR #3195's precedent of updating the meta when a page's content materially expands.
- Advances #1819 (the self-host production-readiness roadmap). Not linked as a closing keyword: the parent issue covers backup/restore verification, release packaging, Sentry context, and Orb telemetry beyond this PR's two topics, and neither of the two sibling issues already filed against #1819 (#1823 update/rollback, merged; #1826 Cloudflare resource inventory) covers hosted/self-host migration or decommissioning — this is net-new depth work on a real, cited gap, not a specific tracked issue, consistent with how #1823 was scoped as its own PR earlier.

## Scope decision: existing pages, not new ones

Both additions are sections within the two pages named in the task (`docs.maintainer-self-hosting.tsx`, `docs.self-hosting-operations.tsx`) rather than new dedicated routes. Justification: each topic is a few hundred words that reads naturally as a subsection of an existing page a maintainer is already on (the migration content extends the page's own "how this fits with hosted" framing; decommissioning is the natural counterpart to "Updating and rolling back" on the Operations page, which a maintainer already visits for day-two operations). Neither topic is large enough on its own to justify a new route, sidebar entry, and `SECTION_LINKS` wiring — that would fragment two already-small topics across even more pages for a reader to discover.

## What this PR does NOT do (scope honesty)

- Does not add a migration *script* or *tool* — there isn't one today, and the docs say so rather than implying otherwise.
- Does not add a broker-secret revocation *feature* — there isn't one today (central-Orb-side, not self-host), and the docs say so rather than implying otherwise.
- Does not touch the other #1819 sibling concerns (backup/restore verification depth, release packaging, Sentry context expansion, Orb telemetry end-to-end verification, runner load).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes — two files, both docs-only.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue (Advances #1819).

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` — not run; no workflow files touched.
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` — not applicable; only `apps/gittensory-ui/**` changed, which Codecov does not gate (docs-only, no `src/**` lines changed).
- [ ] `npm run test:workers` — not applicable; no Worker/backend code touched.
- [ ] `npm run build:mcp` / `npm run test:mcp-pack` — not applicable; MCP package untouched.
- [ ] `npm run ui:openapi:check` — not applicable; no API/schema changes.
- [x] `npm run ui:lint` (required `npm --workspace @jsonbored/gittensory-ui run format` once to fix prettier JSX-prose wrapping, then clean)
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build` (confirmed both changed routes' SSR bundles built: `docs.maintainer-self-hosting-*.mjs`, `docs.self-hosting-operations-*.mjs`)
- [x] `npm run docs:drift-check`
- [ ] `npm audit --audit-level=moderate` — not run standalone; `npm ci` reported 0 vulnerabilities and no dependency changes are in this diff.
- [ ] New or changed behavior has unit/integration tests — not applicable; no runtime behavior changed.

If any required check was skipped, explain why:

- This is a docs-only change confined to two files under `apps/gittensory-ui/src/routes/`. No `src/**`, `scripts/**`, `migrations/**`, or workflow files changed, so the backend/coverage/MCP/OpenAPI/audit checks don't apply. I ran every UI-specific and root check that does apply (`ui:lint`, `ui:typecheck`, `ui:build`, `docs:drift-check`, root `typecheck`), all green, plus `git diff --check`.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed. All env var names and example values are already-public placeholders used elsewhere in these docs.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] N/A — no auth, cookie, CORS, GitHub App, Cloudflare, or session *code* changes (this documents existing GitHub App/auth behavior, doesn't change it).
- [x] N/A — no API/OpenAPI/MCP behavior changes.
- [x] N/A — no new UI component/state; prose-only additions using the pages' existing `DocsPage`/`Callout`/`FeatureRow`/`CodeBlock`/`Link` primitives, no new components or layout.
- [ ] UI Evidence — see below.
- [x] Public docs updated (this PR is entirely a docs update); `CHANGELOG.md` not touched.

## UI Evidence

Not applicable in the screenshot-table sense — this PR is prose-only content added to two existing docs pages using their existing components (`Callout`, `FeatureRow`, `CodeBlock`, headings, lists, links), no new layout or visual styling. Verified via `npm run ui:build` (green — both changed routes' SSR bundles compiled without error) and `npm run docs:drift-check` (green). Did not stand up a full local preview server for this pass since the `dist/server` module path didn't resolve cleanly for `vite preview` in this sandboxed worktree; the build output already confirms both pages compile and the JSX structure (headings, `<ol>`/`<ul>`, `Callout`, links) matches the existing rendered pattern used by every other section on both pages.

## Notes

- Confirmed via grep that `ADMIN_GITHUB_LOGINS`, `ORB_ENROLLMENT_SECRET`, `ORB_BROKER_URL`, and the GitHub App manifest/permissions had zero prior mentions of migration or uninstall/decommission anywhere in the self-hosting docs before this PR, matching the audit's claim.
- Read `src/selfhost/setup-wizard.ts`, `src/settings/repository-settings.ts`, `src/orb/relay.ts`, `src/orb/broker.ts`, `src/auth/security.ts`, `src/github/webhook.ts`, and `docker-compose.yml`'s volumes section in full before writing, rather than restating `.env.example` comments verbatim.
- Rebased onto fresh `origin/main` immediately before pushing (0 commits behind at push time).