### PR TITLE
feat(miner): add ai fatigue signal

### DIFF
--- a/packages/gittensory-engine/README.md
+++ b/packages/gittensory-engine/README.md
@@ -407,6 +407,60 @@ injected-clock semantics for local miners.
 They only deny on small, explicit AI-contribution ban phrases in `AI-USAGE.md` or `CONTRIBUTING.md`; ambiguous,
 missing, or empty policy text stays allowed so discovery does not invent a ban.
 
+`resolveAiPolicyFatigueVerdict()` adds a softer metadata-only tier for repos that show signs of AI-contribution
+fatigue before a formal ban lands. It keeps the hard-ban verdict authoritative and attaches a separate `fatigue`
+object instead of changing `allowed`:
+
+```ts
+import { resolveAiPolicyFatigueVerdict } from "@jsonbored/gittensory-engine";
+
+const verdict = resolveAiPolicyFatigueVerdict({
+  now: "2026-07-05T00:00:00Z",
+  docs: {
+    aiUsage: null,
+    contributing: "Please keep pull requests focused.",
+  },
+  pullRequests: [
+    {
+      state: "closed",
+      title: "AI-assisted parser cleanup",
+      labels: ["ai-generated"],
+      closedAt: "2026-07-04T00:00:00Z",
+      reviewDecision: "changes_requested",
+      maintainerResponse: "terse_rejection",
+    },
+  ],
+  docChanges: [
+    {
+      path: "CONTRIBUTING.md",
+      changedAt: "2026-07-04T12:00:00Z",
+      addedPhrases: ["Disclose AI or automation assistance."],
+    },
+  ],
+});
+```
+
+The fatigue verdict has four levels:
+
+- `none` leaves ranking unchanged and uses a long recheck interval.
+- `watch` and `deprioritize` return `priorityAdjustment: "deprioritize"` so miners can rank the repo lower without
+  treating it as banned.
+- `defer` returns `priorityAdjustment: "defer"` with a short recheck interval for stronger but still reversible
+  signals.
+
+Evidence is deliberately metadata-only: AI-attributed closed PR rows, terse/template rejection metadata, and recent
+AI/automation language added to policy docs that does not match a formal ban phrase. `renderAiPolicyFatigueMarkdown()`
+turns the verdict into a deterministic observability artifact. Fresh cache entries can be passed back through
+`cache`; expired entries are recomputed.
+
+Miner ranking/fanout code can pass the verdict to `applyAiPolicyFatigueToRankInput()`. Formal bans still zero the
+candidate, but fatigue-only verdicts merely reduce `potential` (`watch` = 0.7x, `deprioritize` = 0.35x, `defer` =
+0.05x) and carry a `deferUntilHours` hint when the repo should be revisited later.
+
+`createAiPolicyFatigueCacheEntry()` and `describeAiPolicyFatigueCache()` provide the cache surface for the miner's
+shorter fatigue recheck interval. Cache keys normalize repo names to lowercase `owner/name`, record an ISO
+`computedAt`, and are considered fresh for 24 hours.
+
 ## Governor ledger
 
 `normalizeGovernorLedgerEvent` validates append-only governor decision rows before the local miner persists them.

--- a/packages/gittensory-engine/src/ai-policy-map.ts
+++ b/packages/gittensory-engine/src/ai-policy-map.ts
@@ -1,9 +1,35 @@
 export type AiPolicySource = "AI-USAGE.md" | "CONTRIBUTING.md" | "none";
 
+export type AiPolicyFatigueLevel = "none" | "watch" | "deprioritize" | "defer";
+export type AiPolicyPriorityAdjustment = "none" | "deprioritize" | "defer";
+
+export type AiPolicyFatigueEvidenceKind =
+  | "terse_ai_attributed_rejection_cluster"
+  | "recent_ai_doc_language"
+  | "ai_attributed_closed_pr"
+  | "cache_fresh"
+  | "formal_ban_overrides";
+
+export type AiPolicyFatigueEvidence = {
+  kind: AiPolicyFatigueEvidenceKind;
+  weight: number;
+  summary: string;
+  observedAt: string | null;
+};
+
+export type AiPolicyFatigueVerdict = {
+  level: AiPolicyFatigueLevel;
+  priorityAdjustment: AiPolicyPriorityAdjustment;
+  score: number;
+  recheckAfterHours: number;
+  evidence: AiPolicyFatigueEvidence[];
+};
+
 export type AiPolicyVerdict = {
   allowed: boolean;
   matchedPhrase: string | null;
   source: AiPolicySource;
+  fatigue?: AiPolicyFatigueVerdict | undefined;
 };
 
 type BanPhrase = {
@@ -11,10 +37,80 @@ type BanPhrase = {
   pattern: RegExp;
 };
 
+export type AiFatiguePullRequestMetadata = {
+  id?: string | number | undefined;
+  state: "open" | "closed" | "merged" | string;
+  authorLogin?: string | undefined;
+  title?: string | undefined;
+  labels?: readonly string[] | undefined;
+  createdAt?: string | Date | null | undefined;
+  closedAt?: string | Date | null | undefined;
+  mergedAt?: string | Date | null | undefined;
+  reviewDecision?: "approved" | "changes_requested" | "commented" | "none" | string | undefined;
+  closeReason?: "not_planned" | "completed" | "duplicate" | "spam" | string | undefined;
+  maintainerResponse?: "terse_rejection" | "template_rejection" | "neutral" | "helpful" | string | undefined;
+};
+
+export type AiFatigueDocLanguageChange = {
+  path: "AI-USAGE.md" | "CONTRIBUTING.md" | string;
+  changedAt?: string | Date | null | undefined;
+  addedText?: string | undefined;
+  addedPhrases?: readonly string[] | undefined;
+};
+
+export type AiPolicyFatigueCacheEntry = {
+  repoFullName: string;
+  computedAt: string | Date;
+  verdict: AiPolicyFatigueVerdict;
+};
+
+export type AiPolicyFatigueCacheState = {
+  repoFullName: string;
+  computedAt: string | null;
+  expiresAt: string | null;
+  ageHours: number | null;
+  fresh: boolean;
+};
+
+export type AiPolicyFatigueInput = {
+  docs: {
+    aiUsage: string | null | undefined;
+    contributing: string | null | undefined;
+  };
+  pullRequests?: readonly AiFatiguePullRequestMetadata[] | undefined;
+  docChanges?: readonly AiFatigueDocLanguageChange[] | undefined;
+  now?: string | Date | undefined;
+  cache?: AiPolicyFatigueCacheEntry | null | undefined;
+};
+
+export type AiPolicyFatigueRankInput = {
+  potential: number;
+  feasibility: number;
+  laneFit: number;
+  freshness: number;
+  dupRisk: number;
+};
+
+export type AiPolicyFatigueRankAdjustment = AiPolicyFatigueRankInput & {
+  fatigueLevel: AiPolicyFatigueLevel;
+  priorityAdjustment: AiPolicyPriorityAdjustment;
+  fatigueMultiplier: number;
+  deferUntilHours: number | null;
+  reasons: string[];
+};
+
 const AI_POLICY_ALLOWED: AiPolicyVerdict = {
   allowed: true,
   matchedPhrase: null,
   source: "none",
+};
+
+const AI_FATIGUE_NONE: AiPolicyFatigueVerdict = {
+  level: "none",
+  priorityAdjustment: "none",
+  score: 0,
+  recheckAfterHours: 168,
+  evidence: [],
 };
 
 const BAN_PHRASES: BanPhrase[] = [
@@ -36,6 +132,177 @@ const BAN_PHRASES: BanPhrase[] = [
     pattern: /\b(?:ai|llm)[-\s]+generated\s+code\s+(?:is|will\s+be)\s+(?:rejected|not\s+accepted)\b/i,
   },
 ];
+
+const AI_ATTRIBUTION_PATTERNS = [
+  /\bai[-\s]?(?:generated|assisted|authored)\b/iu,
+  /\b(?:llm|chatgpt|copilot|codex|claude)[-\s]?(?:generated|assisted|authored)?\b/iu,
+  /\b(?:automation|bot)[-\s]?(?:generated|submitted|authored)\b/iu,
+];
+
+const AI_DOC_LANGUAGE_PATTERNS = [
+  /\bai\b/iu,
+  /\bllm\b/iu,
+  /\bautomation\b/iu,
+  /\bautomated\s+(?:prs?|pull\s+requests|contributions?)\b/iu,
+  /\bgenerated\s+(?:code|prs?|pull\s+requests|contributions?)\b/iu,
+];
+
+const Terse_REJECTION_RESPONSES = new Set(["terse_rejection", "template_rejection"]);
+const FATIGUE_CACHE_TTL_HOURS = 24;
+
+function parseInstant(value: string | Date | null | undefined): string | null {
+  if (value === null || value === undefined) return null;
+  const ms = value instanceof Date ? value.getTime() : Date.parse(value);
+  if (!Number.isFinite(ms)) return null;
+  return new Date(ms).toISOString();
+}
+
+function requireNow(value: string | Date | undefined): Date {
+  const parsed = parseInstant(value);
+  return parsed ? new Date(parsed) : new Date();
+}
+
+function hoursBetween(left: string, right: Date): number {
+  return Math.max(0, (right.getTime() - new Date(left).getTime()) / 3_600_000);
+}
+
+function recencyWeight(observedAt: string | null, now: Date, halfLifeDays: number): number {
+  if (!observedAt) return 0.35;
+  const ageDays = hoursBetween(observedAt, now) / 24;
+  return Math.exp(-ageDays / halfLifeDays);
+}
+
+function roundScore(value: number): number {
+  return Math.round(Math.min(1, Math.max(0, value)) * 1_000_000) / 1_000_000;
+}
+
+function roundHours(value: number): number {
+  return Math.round(Math.max(0, value) * 1_000_000) / 1_000_000;
+}
+
+function collapseInline(value: string): string {
+  return value.replace(/[\r\n\t]+/gu, " ").replace(/\s{2,}/gu, " ").trim();
+}
+
+function metadataText(pr: AiFatiguePullRequestMetadata): string {
+  return [pr.title, ...(pr.labels ?? []), pr.authorLogin].filter((value): value is string => Boolean(value)).join(" ");
+}
+
+function isAiAttributed(pr: AiFatiguePullRequestMetadata): boolean {
+  const text = metadataText(pr);
+  return AI_ATTRIBUTION_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+function isClosedWithoutMerge(pr: AiFatiguePullRequestMetadata): boolean {
+  const state = pr.state.trim().toLowerCase();
+  if (state === "merged") return false;
+  if (parseInstant(pr.mergedAt)) return false;
+  return state === "closed" || state === "rejected" || state === "declined";
+}
+
+function isTerseRejection(pr: AiFatiguePullRequestMetadata): boolean {
+  const response = pr.maintainerResponse?.trim().toLowerCase();
+  const reviewDecision = pr.reviewDecision?.trim().toLowerCase();
+  const closeReason = pr.closeReason?.trim().toLowerCase();
+  return (
+    (response ? Terse_REJECTION_RESPONSES.has(response) : false) ||
+    reviewDecision === "changes_requested" ||
+    closeReason === "spam" ||
+    closeReason === "not_planned"
+  );
+}
+
+function docText(change: AiFatigueDocLanguageChange): string {
+  return [change.addedText, ...(change.addedPhrases ?? [])].filter((value): value is string => Boolean(value)).join(" ");
+}
+
+function isAiDocLanguage(change: AiFatigueDocLanguageChange): boolean {
+  const text = docText(change);
+  if (!text.trim()) return false;
+  if (!scanAiPolicyText(text, change.path === "AI-USAGE.md" ? "AI-USAGE.md" : "CONTRIBUTING.md").allowed) {
+    return false;
+  }
+  return AI_DOC_LANGUAGE_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+function evidence(kind: AiPolicyFatigueEvidenceKind, weight: number, summary: string, observedAt: string | null): AiPolicyFatigueEvidence {
+  return {
+    kind,
+    weight: roundScore(weight),
+    summary: collapseInline(summary),
+    observedAt,
+  };
+}
+
+function fatigueLevel(score: number, hasCluster: boolean): AiPolicyFatigueLevel {
+  if (score >= 0.72 || (hasCluster && score >= 0.58)) return "defer";
+  if (score >= 0.4) return "deprioritize";
+  if (score >= 0.18) return "watch";
+  return "none";
+}
+
+function priorityAdjustment(level: AiPolicyFatigueLevel): AiPolicyPriorityAdjustment {
+  if (level === "defer") return "defer";
+  if (level === "deprioritize" || level === "watch") return "deprioritize";
+  return "none";
+}
+
+function recheckAfterHours(level: AiPolicyFatigueLevel): number {
+  if (level === "defer") return 12;
+  if (level === "deprioritize") return 24;
+  if (level === "watch") return 48;
+  return 168;
+}
+
+function fatigueMultiplier(level: AiPolicyFatigueLevel): number {
+  if (level === "defer") return 0.05;
+  if (level === "deprioritize") return 0.35;
+  if (level === "watch") return 0.7;
+  return 1;
+}
+
+function finiteScore(value: number, fallback: number): number {
+  if (!Number.isFinite(value)) return fallback;
+  return Math.min(1, Math.max(0, value));
+}
+
+function isCacheFresh(cache: AiPolicyFatigueCacheEntry | null | undefined, now: Date): boolean {
+  const computedAt = parseInstant(cache?.computedAt);
+  if (!cache || !computedAt) return false;
+  return hoursBetween(computedAt, now) <= FATIGUE_CACHE_TTL_HOURS;
+}
+
+function normalizeRepoFullName(value: string): string {
+  const normalized = value.trim().toLowerCase();
+  if (!/^[a-z0-9_.-]+\/[a-z0-9_.-]+$/u.test(normalized)) {
+    throw new Error("AI policy fatigue cache entries require a repo full name in owner/name form.");
+  }
+  return normalized;
+}
+
+function addHours(instant: string, hours: number): string {
+  return new Date(new Date(instant).getTime() + hours * 3_600_000).toISOString();
+}
+
+function cacheVerdict(cache: AiPolicyFatigueCacheEntry, now: Date): AiPolicyFatigueVerdict {
+  const computedAt = parseInstant(cache.computedAt);
+  return {
+    ...cache.verdict,
+    evidence: [
+      evidence("cache_fresh", 0, `cached fatigue verdict reused from ${computedAt ?? "unknown time"}`, computedAt),
+      ...cache.verdict.evidence,
+    ],
+  };
+}
+
+function markdownSafe(value: string): string {
+  return collapseInline(value).replace(/[\\`*_[\]<>|]/gu, "\\$&");
+}
+
+function renderEvidenceItem(item: AiPolicyFatigueEvidence): string {
+  const observed = item.observedAt ? ` (${item.observedAt})` : "";
+  return `- ${markdownSafe(item.kind)}: ${item.weight.toFixed(6)}${observed} - ${markdownSafe(item.summary)}`;
+}
 
 /**
  * Conservative by design (#2305): explicit ban phrases deny a repo, but ambiguous or absent policy text stays
@@ -68,4 +335,185 @@ export function resolveAiPolicyVerdict(docs: {
     return scanAiPolicyText(docs.contributing, "CONTRIBUTING.md");
   }
   return { ...AI_POLICY_ALLOWED };
+}
+
+export function resolveAiPolicyFatigueVerdict(input: AiPolicyFatigueInput): AiPolicyVerdict {
+  const hardPolicy = resolveAiPolicyVerdict(input.docs);
+  const now = requireNow(input.now);
+  if (!hardPolicy.allowed) {
+    return {
+      ...hardPolicy,
+      fatigue: {
+        level: "none",
+        priorityAdjustment: "none",
+        score: 0,
+        recheckAfterHours: 168,
+        evidence: [
+          evidence(
+            "formal_ban_overrides",
+            0,
+            `formal AI policy ban from ${hardPolicy.source} remains authoritative`,
+            null,
+          ),
+        ],
+      },
+    };
+  }
+  if (isCacheFresh(input.cache, now)) {
+    return {
+      ...hardPolicy,
+      fatigue: cacheVerdict(input.cache!, now),
+    };
+  }
+
+  const evidenceItems: AiPolicyFatigueEvidence[] = [];
+  const aiAttributedClosed = (input.pullRequests ?? []).filter((pr) => isAiAttributed(pr) && isClosedWithoutMerge(pr));
+  const terseRejected = aiAttributedClosed.filter(isTerseRejection);
+  if (aiAttributedClosed.length > 0) {
+    const newest = aiAttributedClosed
+      .map((pr) => parseInstant(pr.closedAt) ?? parseInstant(pr.createdAt))
+      .filter((value): value is string => Boolean(value))
+      .sort()
+      .at(-1) ?? null;
+    evidenceItems.push(
+      evidence(
+        "ai_attributed_closed_pr",
+        Math.min(0.35, 0.18 + aiAttributedClosed.length / 20),
+        `${aiAttributedClosed.length} closed AI-attributed PR metadata row(s) observed`,
+        newest,
+      ),
+    );
+  }
+  if (terseRejected.length >= 2) {
+    const newest = terseRejected
+      .map((pr) => parseInstant(pr.closedAt) ?? parseInstant(pr.createdAt))
+      .filter((value): value is string => Boolean(value))
+      .sort()
+      .at(-1) ?? null;
+    const ratio = terseRejected.length / Math.max(1, aiAttributedClosed.length);
+    evidenceItems.push(
+      evidence(
+        "terse_ai_attributed_rejection_cluster",
+        Math.min(0.62, ratio * 0.45 + Math.min(0.17, terseRejected.length / 20)),
+        `${terseRejected.length}/${aiAttributedClosed.length} AI-attributed closed PRs have terse or templated rejection metadata`,
+        newest,
+      ),
+    );
+  }
+
+  for (const change of input.docChanges ?? []) {
+    if (!isAiDocLanguage(change)) continue;
+    const observedAt = parseInstant(change.changedAt);
+    const weight = 0.28 * recencyWeight(observedAt, now, 30);
+    evidenceItems.push(
+      evidence(
+        "recent_ai_doc_language",
+        weight,
+        `${change.path} added AI/automation language short of a formal ban phrase`,
+        observedAt,
+      ),
+    );
+  }
+
+  const totalScore = roundScore(evidenceItems.reduce((sum, item) => sum + item.weight, 0));
+  const hasCluster = evidenceItems.some((item) => item.kind === "terse_ai_attributed_rejection_cluster");
+  const level = fatigueLevel(totalScore, hasCluster);
+  const fatigue: AiPolicyFatigueVerdict = {
+    level,
+    priorityAdjustment: priorityAdjustment(level),
+    score: totalScore,
+    recheckAfterHours: recheckAfterHours(level),
+    evidence: evidenceItems,
+  };
+  return {
+    ...hardPolicy,
+    fatigue: fatigue.evidence.length === 0 ? { ...AI_FATIGUE_NONE } : fatigue,
+  };
+}
+
+export function renderAiPolicyFatigueMarkdown(verdict: AiPolicyVerdict): string {
+  const fatigue = verdict.fatigue ?? AI_FATIGUE_NONE;
+  const lines = [
+    "# AI Policy Fatigue",
+    "",
+    `Hard policy allowed: ${verdict.allowed ? "yes" : "no"}`,
+    `Policy source: ${markdownSafe(verdict.source)}`,
+    `Fatigue level: ${fatigue.level}`,
+    `Priority adjustment: ${fatigue.priorityAdjustment}`,
+    `Fatigue score: ${fatigue.score.toFixed(6)}`,
+    `Recheck after: ${fatigue.recheckAfterHours}h`,
+    "",
+    "## Evidence",
+    "",
+    fatigue.evidence.length === 0 ? "- none" : fatigue.evidence.map(renderEvidenceItem).join("\n"),
+  ];
+  return `${lines.join("\n")}\n`;
+}
+
+export function applyAiPolicyFatigueToRankInput(
+  rankInput: AiPolicyFatigueRankInput,
+  verdict: AiPolicyVerdict,
+): AiPolicyFatigueRankAdjustment {
+  const fatigue = verdict.fatigue ?? AI_FATIGUE_NONE;
+  const multiplier = verdict.allowed ? fatigueMultiplier(fatigue.level) : 0;
+  const reasons: string[] = [];
+  if (!verdict.allowed) {
+    reasons.push(`formal AI policy denial from ${verdict.source}`);
+  }
+  if (fatigue.priorityAdjustment !== "none") {
+    reasons.push(`AI-fatigue ${fatigue.priorityAdjustment} signal (${fatigue.level})`);
+  }
+  for (const item of fatigue.evidence.slice(0, 3)) {
+    reasons.push(item.summary);
+  }
+  return {
+    potential: roundScore(finiteScore(rankInput.potential, 0) * multiplier),
+    feasibility: finiteScore(rankInput.feasibility, 0),
+    laneFit: finiteScore(rankInput.laneFit, 0),
+    freshness: finiteScore(rankInput.freshness, 0),
+    dupRisk: verdict.allowed ? finiteScore(rankInput.dupRisk, 1) : 1,
+    fatigueLevel: fatigue.level,
+    priorityAdjustment: verdict.allowed ? fatigue.priorityAdjustment : "defer",
+    fatigueMultiplier: multiplier,
+    deferUntilHours: verdict.allowed && fatigue.priorityAdjustment === "defer" ? fatigue.recheckAfterHours : null,
+    reasons,
+  };
+}
+
+export function createAiPolicyFatigueCacheEntry(input: {
+  repoFullName: string;
+  verdict: AiPolicyFatigueVerdict;
+  computedAt?: string | Date | undefined;
+}): AiPolicyFatigueCacheEntry {
+  return {
+    repoFullName: normalizeRepoFullName(input.repoFullName),
+    computedAt: requireNow(input.computedAt).toISOString(),
+    verdict: input.verdict,
+  };
+}
+
+export function describeAiPolicyFatigueCache(
+  cache: AiPolicyFatigueCacheEntry | null | undefined,
+  now?: string | Date | undefined,
+): AiPolicyFatigueCacheState {
+  const computedAt = parseInstant(cache?.computedAt);
+  const current = requireNow(now);
+  if (!cache || !computedAt) {
+    return {
+      repoFullName: cache?.repoFullName ? collapseInline(cache.repoFullName).toLowerCase() : "unknown",
+      computedAt: null,
+      expiresAt: null,
+      ageHours: null,
+      fresh: false,
+    };
+  }
+  const ageHours = roundHours(hoursBetween(computedAt, current));
+  const expiresAt = addHours(computedAt, FATIGUE_CACHE_TTL_HOURS);
+  return {
+    repoFullName: normalizeRepoFullName(cache.repoFullName),
+    computedAt,
+    expiresAt,
+    ageHours,
+    fresh: ageHours <= FATIGUE_CACHE_TTL_HOURS,
+  };
 }

--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -101,8 +101,25 @@ export * from "./plan-export.js";
 export * from "./plan-templates.js";
 export * from "./portfolio/queue.js";
 export {
+  applyAiPolicyFatigueToRankInput,
+  createAiPolicyFatigueCacheEntry,
+  describeAiPolicyFatigueCache,
+  renderAiPolicyFatigueMarkdown,
+  resolveAiPolicyFatigueVerdict,
   resolveAiPolicyVerdict,
   scanAiPolicyText,
+  type AiFatigueDocLanguageChange,
+  type AiFatiguePullRequestMetadata,
+  type AiPolicyFatigueRankAdjustment,
+  type AiPolicyFatigueRankInput,
+  type AiPolicyFatigueCacheEntry,
+  type AiPolicyFatigueCacheState,
+  type AiPolicyFatigueEvidence,
+  type AiPolicyFatigueEvidenceKind,
+  type AiPolicyFatigueInput,
+  type AiPolicyFatigueLevel,
+  type AiPolicyFatigueVerdict,
+  type AiPolicyPriorityAdjustment,
   type AiPolicySource,
   type AiPolicyVerdict,
 } from "./ai-policy-map.js";

--- a/packages/gittensory-engine/test/ai-policy-map.test.ts
+++ b/packages/gittensory-engine/test/ai-policy-map.test.ts
@@ -1,0 +1,561 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  applyAiPolicyFatigueToRankInput,
+  createAiPolicyFatigueCacheEntry,
+  describeAiPolicyFatigueCache,
+  renderAiPolicyFatigueMarkdown,
+  resolveAiPolicyFatigueVerdict,
+  resolveAiPolicyVerdict,
+  scanAiPolicyText,
+} from "../dist/index.js";
+
+const NOW = "2026-07-05T00:00:00.000Z";
+
+function aiPr(overrides = {}) {
+  return {
+    id: "pr-ai",
+    state: "closed",
+    authorLogin: "dependabot-ai",
+    title: "AI-assisted fix for flaky tests",
+    labels: ["ai-generated"],
+    createdAt: "2026-07-01T00:00:00Z",
+    closedAt: "2026-07-02T00:00:00Z",
+    reviewDecision: "changes_requested",
+    closeReason: "not_planned",
+    maintainerResponse: "terse_rejection",
+    ...overrides,
+  };
+}
+
+test("barrel: exports AI policy fatigue APIs (#3009)", () => {
+  assert.equal(typeof scanAiPolicyText, "function");
+  assert.equal(typeof resolveAiPolicyVerdict, "function");
+  assert.equal(typeof resolveAiPolicyFatigueVerdict, "function");
+  assert.equal(typeof renderAiPolicyFatigueMarkdown, "function");
+  assert.equal(typeof applyAiPolicyFatigueToRankInput, "function");
+  assert.equal(typeof createAiPolicyFatigueCacheEntry, "function");
+  assert.equal(typeof describeAiPolicyFatigueCache, "function");
+});
+
+test("legacy scanAiPolicyText still returns the original hard-ban shape", () => {
+  assert.deepEqual(scanAiPolicyText("Please include tests.", "CONTRIBUTING.md"), {
+    allowed: true,
+    matchedPhrase: null,
+    source: "CONTRIBUTING.md",
+  });
+  assert.deepEqual(scanAiPolicyText("No AI-generated pull requests.", "AI-USAGE.md"), {
+    allowed: false,
+    matchedPhrase: "no ai-generated pull requests",
+    source: "AI-USAGE.md",
+  });
+});
+
+test("resolveAiPolicyVerdict still lets non-empty AI-USAGE.md take precedence", () => {
+  assert.deepEqual(
+    resolveAiPolicyVerdict({
+      aiUsage: "Please disclose automation usage.",
+      contributing: "AI-generated PRs are rejected.",
+    }),
+    { allowed: true, matchedPhrase: null, source: "AI-USAGE.md" },
+  );
+});
+
+test("resolveAiPolicyFatigueVerdict returns no fatigue signal for quiet metadata", () => {
+  const verdict = resolveAiPolicyFatigueVerdict({
+    now: NOW,
+    docs: { aiUsage: null, contributing: "Please write tests and keep PRs focused." },
+    pullRequests: [
+      {
+        id: "human-pr",
+        state: "closed",
+        title: "Fix typo",
+        labels: ["docs"],
+        authorLogin: "maintainer",
+        closedAt: "2026-07-01T00:00:00Z",
+        maintainerResponse: "helpful",
+      },
+    ],
+  });
+
+  assert.equal(verdict.allowed, true);
+  assert.deepEqual(verdict.fatigue, {
+    level: "none",
+    priorityAdjustment: "none",
+    score: 0,
+    recheckAfterHours: 168,
+    evidence: [],
+  });
+});
+
+test("resolveAiPolicyFatigueVerdict detects fatigue-only metadata without hard skipping", () => {
+  const verdict = resolveAiPolicyFatigueVerdict({
+    now: NOW,
+    docs: { aiUsage: null, contributing: "Please keep changes focused." },
+    pullRequests: [
+      aiPr({ id: "pr-1", closedAt: "2026-07-04T00:00:00Z" }),
+      aiPr({ id: "pr-2", title: "LLM generated parser cleanup", closedAt: "2026-07-03T00:00:00Z" }),
+      aiPr({ id: "pr-3", title: "Codex authored refactor", closedAt: "2026-07-02T00:00:00Z" }),
+    ],
+    docChanges: [
+      {
+        path: "CONTRIBUTING.md",
+        changedAt: "2026-07-04T12:00:00Z",
+        addedPhrases: ["Please disclose AI or automation assistance in pull requests."],
+      },
+    ],
+  });
+
+  assert.equal(verdict.allowed, true);
+  assert.equal(verdict.matchedPhrase, null);
+  assert.equal(verdict.fatigue?.level, "defer");
+  assert.equal(verdict.fatigue?.priorityAdjustment, "defer");
+  assert.equal(verdict.fatigue?.recheckAfterHours, 12);
+  assert.ok((verdict.fatigue?.score ?? 0) >= 0.72);
+  assert.deepEqual(
+    verdict.fatigue?.evidence.map((item) => item.kind),
+    ["ai_attributed_closed_pr", "terse_ai_attributed_rejection_cluster", "recent_ai_doc_language"],
+  );
+});
+
+test("resolveAiPolicyFatigueVerdict treats watch-level evidence as deprioritize, not skip", () => {
+  const verdict = resolveAiPolicyFatigueVerdict({
+    now: NOW,
+    docs: { aiUsage: null, contributing: "Normal contribution guide." },
+    pullRequests: [aiPr({ id: "single", maintainerResponse: "neutral", reviewDecision: "none" })],
+  });
+
+  assert.equal(verdict.allowed, true);
+  assert.equal(verdict.fatigue?.level, "watch");
+  assert.equal(verdict.fatigue?.priorityAdjustment, "deprioritize");
+  assert.equal(verdict.fatigue?.recheckAfterHours, 48);
+  assert.equal(verdict.fatigue?.evidence[0]?.kind, "ai_attributed_closed_pr");
+});
+
+test("resolveAiPolicyFatigueVerdict keeps formal bans authoritative over fatigue", () => {
+  const verdict = resolveAiPolicyFatigueVerdict({
+    now: NOW,
+    docs: { aiUsage: "AI-generated PRs are rejected.", contributing: null },
+    pullRequests: [
+      aiPr({ id: "pr-1" }),
+      aiPr({ id: "pr-2" }),
+      aiPr({ id: "pr-3" }),
+    ],
+    docChanges: [
+      {
+        path: "CONTRIBUTING.md",
+        changedAt: "2026-07-04T00:00:00Z",
+        addedText: "AI automation language",
+      },
+    ],
+  });
+
+  assert.equal(verdict.allowed, false);
+  assert.equal(verdict.matchedPhrase, "ai-generated prs are rejected");
+  assert.equal(verdict.fatigue?.level, "none");
+  assert.equal(verdict.fatigue?.priorityAdjustment, "none");
+  assert.equal(verdict.fatigue?.score, 0);
+  assert.deepEqual(verdict.fatigue?.evidence.map((item) => item.kind), ["formal_ban_overrides"]);
+});
+
+test("resolveAiPolicyFatigueVerdict ignores doc changes that are already formal ban phrases", () => {
+  const verdict = resolveAiPolicyFatigueVerdict({
+    now: NOW,
+    docs: { aiUsage: null, contributing: "Current policy has no formal ban." },
+    docChanges: [
+      {
+        path: "CONTRIBUTING.md",
+        changedAt: "2026-07-04T00:00:00Z",
+        addedText: "No AI-generated pull requests.",
+      },
+    ],
+  });
+
+  assert.equal(verdict.allowed, true);
+  assert.equal(verdict.fatigue?.level, "none");
+  assert.deepEqual(verdict.fatigue?.evidence, []);
+});
+
+test("resolveAiPolicyFatigueVerdict recency-weights doc language", () => {
+  const fresh = resolveAiPolicyFatigueVerdict({
+    now: NOW,
+    docs: { aiUsage: null, contributing: "Normal guide." },
+    docChanges: [
+      {
+        path: "CONTRIBUTING.md",
+        changedAt: "2026-07-04T00:00:00Z",
+        addedPhrases: ["automation-assisted changes should be disclosed"],
+      },
+    ],
+  });
+  const stale = resolveAiPolicyFatigueVerdict({
+    now: NOW,
+    docs: { aiUsage: null, contributing: "Normal guide." },
+    docChanges: [
+      {
+        path: "CONTRIBUTING.md",
+        changedAt: "2026-01-01T00:00:00Z",
+        addedPhrases: ["automation-assisted changes should be disclosed"],
+      },
+    ],
+  });
+
+  assert.equal(fresh.fatigue?.level, "watch");
+  assert.equal(stale.fatigue?.level, "none");
+  assert.ok((fresh.fatigue?.score ?? 0) > (stale.fatigue?.score ?? 0));
+});
+
+test("resolveAiPolicyFatigueVerdict reuses fresh cache entries", () => {
+  const cache = createAiPolicyFatigueCacheEntry({
+    repoFullName: "JSONbored/Gittensory",
+    computedAt: "2026-07-04T12:00:00Z",
+    verdict: {
+      level: "deprioritize",
+      priorityAdjustment: "deprioritize",
+      score: 0.5,
+      recheckAfterHours: 24,
+      evidence: [
+        {
+          kind: "recent_ai_doc_language",
+          weight: 0.5,
+          summary: "cached evidence",
+          observedAt: "2026-07-04T00:00:00.000Z",
+        },
+      ],
+    },
+  });
+  const verdict = resolveAiPolicyFatigueVerdict({
+    now: NOW,
+    docs: { aiUsage: null, contributing: "Normal guide." },
+    cache,
+    pullRequests: [aiPr({ id: "ignored-by-cache" })],
+  });
+
+  assert.equal(cache.repoFullName, "jsonbored/gittensory");
+  assert.equal(cache.computedAt, "2026-07-04T12:00:00.000Z");
+  assert.equal(verdict.fatigue?.level, "deprioritize");
+  assert.equal(verdict.fatigue?.score, 0.5);
+  assert.deepEqual(
+    verdict.fatigue?.evidence.map((item) => item.kind),
+    ["cache_fresh", "recent_ai_doc_language"],
+  );
+});
+
+test("describeAiPolicyFatigueCache reports fresh, expired, missing, and malformed entries", () => {
+  const cache = createAiPolicyFatigueCacheEntry({
+    repoFullName: "JSONbored/Gittensory",
+    computedAt: "2026-07-04T12:00:00Z",
+    verdict: {
+      level: "watch",
+      priorityAdjustment: "deprioritize",
+      score: 0.25,
+      recheckAfterHours: 48,
+      evidence: [],
+    },
+  });
+
+  assert.deepEqual(describeAiPolicyFatigueCache(cache, NOW), {
+    repoFullName: "jsonbored/gittensory",
+    computedAt: "2026-07-04T12:00:00.000Z",
+    expiresAt: "2026-07-05T12:00:00.000Z",
+    ageHours: 12,
+    fresh: true,
+  });
+  assert.deepEqual(describeAiPolicyFatigueCache(cache, "2026-07-06T00:00:00Z"), {
+    repoFullName: "jsonbored/gittensory",
+    computedAt: "2026-07-04T12:00:00.000Z",
+    expiresAt: "2026-07-05T12:00:00.000Z",
+    ageHours: 36,
+    fresh: false,
+  });
+  assert.deepEqual(describeAiPolicyFatigueCache(null, NOW), {
+    repoFullName: "unknown",
+    computedAt: null,
+    expiresAt: null,
+    ageHours: null,
+    fresh: false,
+  });
+  assert.deepEqual(
+    describeAiPolicyFatigueCache(
+      {
+        repoFullName: "owner/repo",
+        computedAt: "not a date",
+        verdict: { level: "none", priorityAdjustment: "none", score: 0, recheckAfterHours: 168, evidence: [] },
+      },
+      NOW,
+    ),
+    {
+      repoFullName: "owner/repo",
+      computedAt: null,
+      expiresAt: null,
+      ageHours: null,
+      fresh: false,
+    },
+  );
+});
+
+test("createAiPolicyFatigueCacheEntry rejects malformed repo keys", () => {
+  assert.throws(
+    () =>
+      createAiPolicyFatigueCacheEntry({
+        repoFullName: "not a repo",
+        computedAt: NOW,
+        verdict: { level: "none", priorityAdjustment: "none", score: 0, recheckAfterHours: 168, evidence: [] },
+      }),
+    /owner\/name/u,
+  );
+});
+
+test("resolveAiPolicyFatigueVerdict recomputes expired cache entries", () => {
+  const verdict = resolveAiPolicyFatigueVerdict({
+    now: NOW,
+    docs: { aiUsage: null, contributing: "Normal guide." },
+    cache: {
+      repoFullName: "jsonbored/gittensory",
+      computedAt: "2026-07-01T00:00:00Z",
+      verdict: {
+        level: "defer",
+        priorityAdjustment: "defer",
+        score: 1,
+        recheckAfterHours: 12,
+        evidence: [],
+      },
+    },
+    pullRequests: [],
+  });
+
+  assert.equal(verdict.fatigue?.level, "none");
+  assert.equal(verdict.fatigue?.score, 0);
+  assert.deepEqual(verdict.fatigue?.evidence, []);
+});
+
+test("resolveAiPolicyFatigueVerdict recognizes AI-attribution aliases from metadata only", () => {
+  const verdict = resolveAiPolicyFatigueVerdict({
+    now: NOW,
+    docs: { aiUsage: null, contributing: "Normal guide." },
+    pullRequests: [
+      aiPr({ id: "llm", title: "LLM assisted docs update", labels: [], authorLogin: "alice" }),
+      aiPr({ id: "claude", title: "Refactor parser", labels: ["claude generated"], authorLogin: "bob" }),
+      aiPr({ id: "automation", title: "Parser cleanup", labels: ["automation submitted"], authorLogin: "carol" }),
+      aiPr({ id: "human", title: "Manual parser cleanup", labels: [], authorLogin: "dave" }),
+    ],
+  });
+
+  assert.equal(verdict.fatigue?.level, "defer");
+  assert.equal(verdict.fatigue?.evidence[0]?.summary, "3 closed AI-attributed PR metadata row(s) observed");
+  assert.match(verdict.fatigue?.evidence[1]?.summary ?? "", /^3\/3 AI-attributed/u);
+});
+
+test("resolveAiPolicyFatigueVerdict ignores open and merged AI-attributed PRs for rejection fatigue", () => {
+  const verdict = resolveAiPolicyFatigueVerdict({
+    now: NOW,
+    docs: { aiUsage: null, contributing: "Normal guide." },
+    pullRequests: [
+      aiPr({ id: "open", state: "open", closedAt: null }),
+      aiPr({ id: "merged", state: "closed", mergedAt: "2026-07-04T00:00:00Z" }),
+      aiPr({ id: "actual", state: "closed", mergedAt: null }),
+    ],
+  });
+
+  assert.equal(verdict.fatigue?.level, "watch");
+  assert.equal(verdict.fatigue?.evidence.length, 1);
+  assert.equal(verdict.fatigue?.evidence[0]?.summary, "1 closed AI-attributed PR metadata row(s) observed");
+});
+
+test("resolveAiPolicyFatigueVerdict handles malformed timestamps with conservative weights", () => {
+  const verdict = resolveAiPolicyFatigueVerdict({
+    now: "not a date",
+    docs: { aiUsage: null, contributing: "Normal guide." },
+    pullRequests: [aiPr({ closedAt: "not a date", createdAt: null })],
+    docChanges: [{ path: "AI-USAGE.md", changedAt: "not a date", addedText: "AI assistance should be disclosed" }],
+  });
+
+  assert.equal(verdict.allowed, true);
+  assert.ok((verdict.fatigue?.score ?? 0) > 0);
+  assert.equal(verdict.fatigue?.evidence[0]?.observedAt, null);
+});
+
+test("renderAiPolicyFatigueMarkdown renders deterministic observability output", () => {
+  const verdict = resolveAiPolicyFatigueVerdict({
+    now: NOW,
+    docs: { aiUsage: null, contributing: "Normal guide." },
+    pullRequests: [aiPr({ id: "pr-1" }), aiPr({ id: "pr-2" })],
+  });
+  const markdown = renderAiPolicyFatigueMarkdown(verdict);
+
+  assert.ok(markdown.startsWith("# AI Policy Fatigue\n\nHard policy allowed: yes"));
+  assert.match(markdown, /Policy source: CONTRIBUTING\.md/u);
+  assert.match(markdown, /Fatigue level: defer/u);
+  assert.match(markdown, /Priority adjustment: defer/u);
+  assert.match(markdown, /## Evidence\n\n- ai\\_attributed\\_closed\\_pr:/u);
+  assert.match(markdown, /terse\\_ai\\_attributed\\_rejection\\_cluster/u);
+});
+
+test("renderAiPolicyFatigueMarkdown renders none when no fatigue field is attached", () => {
+  const markdown = renderAiPolicyFatigueMarkdown({ allowed: true, matchedPhrase: null, source: "none" });
+
+  assert.match(markdown, /Fatigue level: none/u);
+  assert.match(markdown, /Priority adjustment: none/u);
+  assert.match(markdown, /## Evidence\n\n- none/u);
+});
+
+test("renderAiPolicyFatigueMarkdown escapes summaries and policy source fields", () => {
+  const markdown = renderAiPolicyFatigueMarkdown({
+    allowed: true,
+    matchedPhrase: null,
+    source: "CONTRIBUTING.md",
+    fatigue: {
+      level: "watch",
+      priorityAdjustment: "deprioritize",
+      score: 0.2,
+      recheckAfterHours: 48,
+      evidence: [
+        {
+          kind: "recent_ai_doc_language",
+          weight: 0.2,
+          summary: "AI note with `code` and *stars*\nnext",
+          observedAt: "2026-07-04T00:00:00.000Z",
+        },
+      ],
+    },
+  });
+
+  assert.ok(markdown.includes("CONTRIBUTING.md"));
+  assert.match(markdown, /AI note with \\+`code\\+` and \\+\*stars\\+\* next/u);
+});
+
+test("resolveAiPolicyFatigueVerdict is byte-stable for the same metadata", () => {
+  const input = {
+    now: NOW,
+    docs: { aiUsage: null, contributing: "Normal guide." },
+    pullRequests: [aiPr({ id: "a" }), aiPr({ id: "b" })],
+    docChanges: [{ path: "CONTRIBUTING.md", changedAt: "2026-07-04T00:00:00Z", addedText: "AI disclosure" }],
+  } as const;
+
+  assert.equal(JSON.stringify(resolveAiPolicyFatigueVerdict(input)), JSON.stringify(resolveAiPolicyFatigueVerdict(input)));
+});
+
+test("applyAiPolicyFatigueToRankInput leaves clean repos unchanged", () => {
+  const adjusted = applyAiPolicyFatigueToRankInput(
+    { potential: 0.8, feasibility: 0.7, laneFit: 1, freshness: 0.9, dupRisk: 0.1 },
+    { allowed: true, matchedPhrase: null, source: "none" },
+  );
+
+  assert.deepEqual(adjusted, {
+    potential: 0.8,
+    feasibility: 0.7,
+    laneFit: 1,
+    freshness: 0.9,
+    dupRisk: 0.1,
+    fatigueLevel: "none",
+    priorityAdjustment: "none",
+    fatigueMultiplier: 1,
+    deferUntilHours: null,
+    reasons: [],
+  });
+});
+
+test("applyAiPolicyFatigueToRankInput downranks watch and deprioritize verdicts", () => {
+  const watch = applyAiPolicyFatigueToRankInput(
+    { potential: 1, feasibility: 1, laneFit: 1, freshness: 1, dupRisk: 0 },
+    {
+      allowed: true,
+      matchedPhrase: null,
+      source: "CONTRIBUTING.md",
+      fatigue: {
+        level: "watch",
+        priorityAdjustment: "deprioritize",
+        score: 0.2,
+        recheckAfterHours: 48,
+        evidence: [{ kind: "ai_attributed_closed_pr", weight: 0.2, summary: "single AI-attributed closure", observedAt: null }],
+      },
+    },
+  );
+  const deprioritize = applyAiPolicyFatigueToRankInput(
+    { potential: 1, feasibility: 1, laneFit: 1, freshness: 1, dupRisk: 0 },
+    {
+      allowed: true,
+      matchedPhrase: null,
+      source: "CONTRIBUTING.md",
+      fatigue: {
+        level: "deprioritize",
+        priorityAdjustment: "deprioritize",
+        score: 0.5,
+        recheckAfterHours: 24,
+        evidence: [{ kind: "recent_ai_doc_language", weight: 0.5, summary: "recent doc language", observedAt: null }],
+      },
+    },
+  );
+
+  assert.equal(watch.potential, 0.7);
+  assert.equal(watch.fatigueMultiplier, 0.7);
+  assert.equal(watch.deferUntilHours, null);
+  assert.deepEqual(watch.reasons, ["AI-fatigue deprioritize signal (watch)", "single AI-attributed closure"]);
+  assert.equal(deprioritize.potential, 0.35);
+  assert.equal(deprioritize.fatigueMultiplier, 0.35);
+  assert.deepEqual(deprioritize.reasons, ["AI-fatigue deprioritize signal (deprioritize)", "recent doc language"]);
+});
+
+test("applyAiPolicyFatigueToRankInput defers strong fatigue without making it a hard ban", () => {
+  const adjusted = applyAiPolicyFatigueToRankInput(
+    { potential: 0.9, feasibility: 0.8, laneFit: 0.7, freshness: 0.6, dupRisk: 0.2 },
+    {
+      allowed: true,
+      matchedPhrase: null,
+      source: "CONTRIBUTING.md",
+      fatigue: {
+        level: "defer",
+        priorityAdjustment: "defer",
+        score: 0.9,
+        recheckAfterHours: 12,
+        evidence: [
+          { kind: "ai_attributed_closed_pr", weight: 0.3, summary: "closed rows", observedAt: null },
+          { kind: "terse_ai_attributed_rejection_cluster", weight: 0.5, summary: "terse cluster", observedAt: null },
+          { kind: "recent_ai_doc_language", weight: 0.1, summary: "doc language", observedAt: null },
+          { kind: "recent_ai_doc_language", weight: 0.1, summary: "extra evidence omitted", observedAt: null },
+        ],
+      },
+    },
+  );
+
+  assert.equal(adjusted.potential, 0.045);
+  assert.equal(adjusted.feasibility, 0.8);
+  assert.equal(adjusted.laneFit, 0.7);
+  assert.equal(adjusted.freshness, 0.6);
+  assert.equal(adjusted.dupRisk, 0.2);
+  assert.equal(adjusted.priorityAdjustment, "defer");
+  assert.equal(adjusted.deferUntilHours, 12);
+  assert.deepEqual(adjusted.reasons, [
+    "AI-fatigue defer signal (defer)",
+    "closed rows",
+    "terse cluster",
+    "doc language",
+  ]);
+});
+
+test("applyAiPolicyFatigueToRankInput still fails closed for formal hard bans", () => {
+  const adjusted = applyAiPolicyFatigueToRankInput(
+    { potential: 0.9, feasibility: 0.8, laneFit: 0.7, freshness: 0.6, dupRisk: 0.2 },
+    { allowed: false, matchedPhrase: "no ai-generated pull requests", source: "AI-USAGE.md" },
+  );
+
+  assert.equal(adjusted.potential, 0);
+  assert.equal(adjusted.dupRisk, 1);
+  assert.equal(adjusted.priorityAdjustment, "defer");
+  assert.equal(adjusted.deferUntilHours, null);
+  assert.deepEqual(adjusted.reasons, ["formal AI policy denial from AI-USAGE.md"]);
+});
+
+test("applyAiPolicyFatigueToRankInput clamps malformed rank inputs", () => {
+  const adjusted = applyAiPolicyFatigueToRankInput(
+    { potential: Number.POSITIVE_INFINITY, feasibility: -1, laneFit: 2, freshness: Number.NaN, dupRisk: -0.5 },
+    { allowed: true, matchedPhrase: null, source: "none" },
+  );
+
+  assert.equal(adjusted.potential, 0);
+  assert.equal(adjusted.feasibility, 0);
+  assert.equal(adjusted.laneFit, 1);
+  assert.equal(adjusted.freshness, 0);
+  assert.equal(adjusted.dupRisk, 0);
+});


### PR DESCRIPTION
## Summary

- Add an AI-fatigue policy signal for miner repo ranking that downgrades repositories showing organic AI-contribution fatigue without treating them as formal AI bans.
- Surface metadata-only fatigue evidence, deterministic cache summaries, markdown observability, and rank-input adjustments for issue #3009.

Fixes #3009

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires >=99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

Additional validation run:

- [x] `npm run build --workspace @jsonbored/gittensory-engine`
- [x] `npx tsx packages/gittensory-engine/test/ai-policy-map.test.ts`
- [x] `npm run build:miner`
- [x] `npm run db:migrations:check`

If any required check was skipped, explain why:

- `npm run test:coverage` timed out locally after 5 minutes while running the existing root Vitest suite; the new engine-focused test file passed directly.
- `npm run test:ci` currently stops before coverage on a local Wrangler typegen whitespace mismatch; the generated output that satisfies `cf-typegen:check` contains trailing whitespace on this Windows/Node 24 environment, so it was not committed.
- `npm run test:mcp-pack` fails locally before package checks because `scripts/check-mcp-package.mjs` calls `spawnSync("npm", ...)`, which returns no stdout/stderr on this Windows/Node 24 shell path.
- UI checks were not run because this change only touches the engine package and its package README.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

No visible UI changes.

## Notes

- Diff size: 4 files changed, 1,080 insertions.