### PR TITLE
fix(miner): narrow generateReplayScoringKey's rejection type

### DIFF
--- a/packages/gittensory-miner/lib/replay-task-generation.d.ts
+++ b/packages/gittensory-miner/lib/replay-task-generation.d.ts
@@ -80,6 +80,15 @@ export type ReplayScoringKey = {
   groundTruth: unknown;
 };
 
+// generateReplayScoringKey never lints/scrubs frozen context (it doesn't touch context text at all), so
+// unlike ReplayTaskRejected it can only ever reject on selection -- narrower than reusing ReplayTaskRejected,
+// which would advertise an "unscrubbable_forward_reference" branch this function can never actually produce.
+export type ReplayScoringKeyRejected = {
+  eligible: false;
+  rejected: "selection";
+  reasons: string[];
+};
+
 export function detectForwardReferences(
   text: unknown,
   context: ForwardRefContext | null | undefined,
@@ -114,4 +123,4 @@ export function generateReplayTask(
 export function generateReplayScoringKey(
   candidate: FreezePointCandidate | null | undefined,
   options: ReplayTaskOptions | null | undefined,
-): ReplayScoringKey | ReplayTaskRejected;
+): ReplayScoringKey | ReplayScoringKeyRejected;

--- a/test/unit/miner-replay-task-generation.test.ts
+++ b/test/unit/miner-replay-task-generation.test.ts
@@ -222,5 +222,27 @@ describe("gittensory-miner leakage-safe replay task generation (#3011)", () => {
         reasons: ["insufficient_prior_history", "insufficient_revealed_history"],
       });
     });
+
+    // REGRESSION: pins the intentional eligibility asymmetry documented on generateReplayScoringKey itself --
+    // it never lints/scrubs frozen context, so a candidate generateReplayTask rejects for an unscrubbable
+    // forward reference still yields a scoring key here. A caller must not assume the two are a matched pair
+    // without checking generateReplayTask's own result (see the same candidate's rejection above).
+    it("still returns a scoring key for a candidate whose frozen context generateReplayTask rejects as unscrubbable", () => {
+      const candidate = { ...eligible, frozenContextTexts: ["the tally hit 250 last month"] };
+
+      const replayTask = generateReplayTask(candidate, CONTEXT, options);
+      expect(replayTask).toEqual({
+        eligible: false,
+        rejected: "unscrubbable_forward_reference",
+        residual: [{ kind: "bare-issue-number", value: 250 }],
+      });
+
+      const scoringKey = generateReplayScoringKey(candidate, options);
+      expect(scoringKey).toEqual({
+        eligible: true,
+        commitCount: 10,
+        groundTruth: { merged: true, approach: "refactor" },
+      });
+    });
   });
 });


### PR DESCRIPTION
## Summary
Follow-up to #3235's review nits. `generateReplayScoringKey` never lints or scrubs frozen context text, so it can only ever reject with `rejected: "selection"`. Its return type previously reused `ReplayTaskRejected`, which also advertises an `unscrubbable_forward_reference` branch that this function can never actually produce -- misleading callers into thinking they need to handle a case that doesn't exist. This narrows the type to a new `ReplayScoringKeyRejected` and adds a regression test pinning the documented eligibility asymmetry: a candidate whose frozen context `generateReplayTask` rejects as unscrubbable still yields a valid scoring key from `generateReplayScoringKey`.

Addresses the remaining 2 code-level nits from #3235's review; the other 2 were prose/comment-placement suggestions judged as non-actionable.

## Scope
- [x] `packages/gittensory-miner/lib/replay-task-generation.d.ts` -- new `ReplayScoringKeyRejected` type, narrowed `generateReplayScoringKey` signature
- [x] `test/unit/miner-replay-task-generation.test.ts` -- regression test for the eligibility asymmetry
- [x] No runtime (`.js`) change needed -- the implementation already only ever produces the narrower shape

## Validation
- [x] `npm run typecheck`
- [x] `npx vitest run test/unit/miner-replay-task-generation.test.ts` (20 passed)
- [x] `npm run test:ci` (full local gate, green)
- [x] Rebased onto latest `main`

## Safety
- [x] Type-only change plus a test; no behavior change, no secrets/private terms touched