### PR TITLE
docs(self-hosting): correct Grafana exposure claim, document Caddy/Tailscale TLS profiles

### DIFF
--- a/apps/gittensory-ui/src/routes/docs.self-hosting-github-app.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-github-app.tsx
@@ -78,11 +78,15 @@ SELFHOST_SETUP_TOKEN=change-this-long-random-value  # unlocks /setup for a fresh
       </p>
       <Callout variant="note">
         <code>https://reviews.example.com</code> above is a placeholder — it assumes you already
-        have a real domain terminating TLS. If you don't yet, see{" "}
-        <Link to="/docs/self-hosting-security">Security</Link>'s TLS termination section for the two
-        shipped ways to get one: the <code>caddy</code> profile (a public domain with automatic
-        Let's Encrypt certs) or the <code>tailscale</code> profile (a private tailnet address, no
-        public port needed).
+        have a real domain terminating TLS. GitHub delivers webhooks to whatever{" "}
+        <code>PUBLIC_API_ORIGIN</code> you set here, so it must be an address GitHub's servers can
+        actually reach: the <code>caddy</code> profile (see{" "}
+        <Link to="/docs/self-hosting-security">Security</Link>'s TLS termination section) is the
+        shipped way to get one, or bring your own public reverse proxy. The <code>tailscale</code>{" "}
+        profile's private tailnet address does <strong>not</strong> work here — GitHub cannot
+        deliver webhooks to it. A Tailscale-only instance should use brokered pull mode instead (it
+        polls for work rather than receiving pushed webhooks) — see "Pull vs. push relay mode"
+        below.
       </Callout>
       <Callout variant="note">
         Manual App creation (below) is still fully supported — for an air-gapped instance, a
@@ -305,22 +309,28 @@ ORB_RELAY_MODE=pull  # or omit for push (the default) -- see "Choosing a relay m
         scenario for the smoke tests that exercise both relay modes.
       </p>
 
-      <h2>Webhook checks</h2>
+      <h2>Connectivity checks</h2>
+      <p>
+        Confirm you can reach the instance at all before checking GitHub's own webhook delivery:
+      </p>
       <CodeBlock
         lang="bash"
         code={`curl https://reviews.example.com/health
 curl https://reviews.example.com/ready`}
       />
       <p>
-        <code>reviews.example.com</code> here stands in for whatever fronts the app on real HTTPS —
-        the <code>caddy</code> profile's domain, an existing reverse proxy, or (for Tailscale
-        instances) the tailnet address on port 8787 instead of a public domain at all. See{" "}
-        <Link to="/docs/self-hosting-security">Security</Link>'s TLS termination section if you
-        haven't set one of those up yet.
+        <code>reviews.example.com</code> here stands in for whatever you're checking from — the{" "}
+        <code>caddy</code> profile's domain, an existing reverse proxy, or (if you're on the same
+        tailnet) a Tailscale instance's tailnet address on port 8787. This only confirms{" "}
+        <em>you</em> can reach the instance, not that <em>GitHub</em> can — a Tailscale-only
+        instance in push mode will pass this check and still never receive a real webhook, since
+        GitHub itself cannot reach a private tailnet address (see the callout above on{" "}
+        <code>PUBLIC_API_ORIGIN</code>).
       </p>
       <p>
         After installing the App on a test repo, open a small PR and confirm the webhook delivery
-        appears in GitHub and a job appears in self-host logs. Continue with{" "}
+        appears in GitHub and a job appears in self-host logs — this is the check that actually
+        proves GitHub can reach you. Continue with{" "}
         <Link to="/docs/self-hosting-operations">Operations</Link> for log and metric checks.
       </p>
     </DocsPage>

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-github-app.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-github-app.tsx
@@ -77,6 +77,14 @@ SELFHOST_SETUP_TOKEN=change-this-long-random-value  # unlocks /setup for a fresh
         header instead; never place the setup token in the URL.
       </p>
       <Callout variant="note">
+        <code>https://reviews.example.com</code> above is a placeholder — it assumes you already
+        have a real domain terminating TLS. If you don't yet, see{" "}
+        <Link to="/docs/self-hosting-security">Security</Link>'s TLS termination section for the two
+        shipped ways to get one: the <code>caddy</code> profile (a public domain with automatic
+        Let's Encrypt certs) or the <code>tailscale</code> profile (a private tailnet address, no
+        public port needed).
+      </Callout>
+      <Callout variant="note">
         Manual App creation (below) is still fully supported — for an air-gapped instance, a
         stricter change-review process, or simply a preference for reviewing every permission by
         hand before it exists. Whichever path you take, the resulting App needs the SAME
@@ -243,7 +251,11 @@ ORB_RELAY_MODE=pull  # or omit for push (the default) -- see "Choosing a relay m
         outage more gracefully (see the release checklist's known-warnings table below). Use push
         only once you already have a stable, publicly reachable HTTPS origin for this instance — the
         Direct App setup wizard, for instance, always requires one anyway, so an operator running
-        Direct App today has it available for brokered push mode too.
+        Direct App today has it available for brokered push mode too. See{" "}
+        <Link to="/docs/self-hosting-security">Security</Link>'s TLS termination section for how to
+        stand one up: the <code>caddy</code> profile for a public domain, or note that{" "}
+        <code>tailscale</code>'s private tailnet address does not satisfy push mode's
+        internet-reachable requirement — pull mode is the right fit for a Tailscale-only instance.
       </Callout>
       <Callout variant="warn" title="Brokered mode operational risks">
         Before enabling this for anyone outside a controlled managed-beta cohort, weigh: (1){" "}
@@ -299,6 +311,13 @@ ORB_RELAY_MODE=pull  # or omit for push (the default) -- see "Choosing a relay m
         code={`curl https://reviews.example.com/health
 curl https://reviews.example.com/ready`}
       />
+      <p>
+        <code>reviews.example.com</code> here stands in for whatever fronts the app on real HTTPS —
+        the <code>caddy</code> profile's domain, an existing reverse proxy, or (for Tailscale
+        instances) the tailnet address on port 8787 instead of a public domain at all. See{" "}
+        <Link to="/docs/self-hosting-security">Security</Link>'s TLS termination section if you
+        haven't set one of those up yet.
+      </p>
       <p>
         After installing the App on a test repo, open a small PR and confirm the webhook delivery
         appears in GitHub and a job appears in self-host logs. Continue with{" "}

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-quickstart.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-quickstart.tsx
@@ -213,6 +213,13 @@ OPT-IN, NOT REQUIRED FOR A TRIAL INSTANCE
         contract, not a flag you turn on. The one way to disable it is the explicit air-gap flag:
         set <code>ORB_AIR_GAP=true</code> for an instance that sends nothing.
       </Callout>
+      <p>
+        <code>--profile caddy</code> and <code>--profile tailscale</code> are the two shipped ways
+        to get real HTTPS or a private, no-public-port address — see{" "}
+        <Link to="/docs/self-hosting-security">Security</Link>'s TLS termination section for the
+        full walkthrough of each (Caddyfile setup, DNS prerequisites, and when to pick one over the
+        other).
+      </p>
     </DocsPage>
   );
 }

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-quickstart.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-quickstart.tsx
@@ -214,11 +214,11 @@ OPT-IN, NOT REQUIRED FOR A TRIAL INSTANCE
         set <code>ORB_AIR_GAP=true</code> for an instance that sends nothing.
       </Callout>
       <p>
-        <code>--profile caddy</code> and <code>--profile tailscale</code> are the two shipped ways
-        to get real HTTPS or a private, no-public-port address — see{" "}
-        <Link to="/docs/self-hosting-security">Security</Link>'s TLS termination section for the
-        full walkthrough of each (Caddyfile setup, DNS prerequisites, and when to pick one over the
-        other).
+        <code>--profile caddy</code> gets you real public HTTPS; <code>--profile tailscale</code>{" "}
+        adds private tailnet reachability (it does not remove the default public port on its own —
+        see the callout below) — see <Link to="/docs/self-hosting-security">Security</Link>'s TLS
+        termination section for the full walkthrough of each (Caddyfile setup, DNS prerequisites,
+        hardening Tailscale for real isolation, and when to pick one over the other).
       </p>
     </DocsPage>
   );

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-security.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-security.tsx
@@ -129,22 +129,26 @@ function SelfHostingSecurity() {
 
       <h2>TLS termination</h2>
       <p>
-        A webhook endpoint and a stable <code>PUBLIC_API_ORIGIN</code> (see{" "}
-        <Link to="/docs/self-hosting-github-app">GitHub App and Orb</Link>) both need real HTTPS.
-        The compose file ships two ways to get it without hand-rolling a reverse proxy, plus a third
-        option if you already run one.
+        These are the three shipped ways to get real HTTPS without hand-rolling a reverse proxy —
+        but only Caddy and bring-your-own-proxy give you a <em>publicly reachable</em> origin. If
+        GitHub itself needs to reach this instance (a direct App in push mode, per{" "}
+        <Link to="/docs/self-hosting-github-app">GitHub App and Orb</Link>), Tailscale's private
+        tailnet address does not satisfy that — GitHub's servers can't reach it. Tailscale is the
+        right fit when only your own team/CI needs access, or as the transport for a{" "}
+        <Link to="/docs/self-hosting-github-app">brokered, pull-mode</Link> instance that never
+        needs to receive an inbound webhook at all.
       </p>
       <FeatureRow
         items={[
           {
             title: "Caddy (--profile caddy)",
             description:
-              "A public HTTPS terminator with automatic Let's Encrypt certificates. Use this when the instance needs a real internet-facing domain.",
+              "A public HTTPS terminator with automatic Let's Encrypt certificates. Required for a direct App in push mode; use this when the instance needs a real internet-facing domain.",
           },
           {
             title: "Tailscale (--profile tailscale)",
             description:
-              "A private-network sidecar — no public port at all. Use this when only your own team needs to reach the instance.",
+              "A private-network sidecar — no public port at all, but also not reachable by GitHub's own webhook delivery. Use this for team/CI-only access, or alongside brokered pull mode.",
           },
           {
             title: "Bring your own reverse proxy",
@@ -208,9 +212,10 @@ function SelfHostingSecurity() {
       <Callout variant="warn" title="Remove the app's own port mapping">
         The <code>gittensory</code> service's compose entry has a direct{" "}
         <code>{`ports: ["\${PORT:-8787}:8787"]`}</code> mapping with a comment marking exactly this:
-        remove it once Caddy (or Tailscale, below) is your public listener, or the app stays
-        reachable on <code>:8787</code> with no TLS, bypassing the proxy entirely and defeating the
-        whole point of adding it.
+        remove it once Caddy is your public listener, or the app stays reachable on{" "}
+        <code>:8787</code> with no TLS, bypassing the proxy entirely and defeating the whole point
+        of adding it. (This rule is Caddy-specific — the Tailscale profile below needs the{" "}
+        <em>opposite</em> treatment; see its own callout.)
       </Callout>
       <p>
         Prefer certificates you already manage — an internal CA, a wildcard cert issued elsewhere —

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-security.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-security.tsx
@@ -160,8 +160,13 @@ function SelfHostingSecurity() {
         terminating TLS on <code>80</code>/<code>443</code>/<code>443/udp</code> (the last for
         HTTP/3) and obtaining a Let's Encrypt certificate automatically for whatever domain you set.
         It needs a real DNS record: point <code>DOMAIN</code> at this host's public IP{" "}
-        <em>before</em> starting the profile, or the ACME HTTP-01 challenge Caddy runs on port 80
-        fails and it falls back to a self-signed cert.
+        <em>before</em> starting the profile. The shipped Caddyfile has no fallback TLS directive,
+        so if the ACME HTTP-01 challenge fails (DNS not propagated yet, port 80 unreachable), Caddy
+        does <strong>not</strong> silently substitute a self-signed cert for a real domain — it logs
+        the failure and retries with backoff, and the site has no working HTTPS until DNS and ACME
+        both succeed. (A recognized non-public hostname like <code>localhost</code>, below, is a
+        deliberately different case — Caddy issues its own internal-CA cert for those automatically,
+        since it can never get a real one.)
       </p>
       <CodeBlock filename=".env" code={`DOMAIN=reviews.yourcompany.com`} />
       <p>
@@ -236,21 +241,39 @@ function SelfHostingSecurity() {
       <p>
         The <code>tailscale</code> profile joins the stack to your tailnet instead of exposing
         anything to the public internet. It runs with <code>network_mode: host</code> — Tailscale
-        needs host networking to advertise this machine's address on the tailnet — so once it's up,
-        the <code>gittensory</code> service is reachable at this host's tailnet IP on port{" "}
-        <code>8787</code>, with no port published to the public internet at all.
+        needs host networking to advertise this machine's address on the tailnet.
       </p>
       <CodeBlock
         filename=".env"
         code={`TS_AUTHKEY=            # generate at tailscale.com/admin/settings/keys
 TS_EXTRA_ARGS=          # optional, e.g. --advertise-tags=tag:self-host`}
       />
+      <Callout variant="warn" title="Unlike Caddy, keep the app's port mapping">
+        Tailscale doesn't replace the <code>gittensory</code> service's listener the way Caddy does
+        — it adds a new network interface to the <em>host</em>. Docker's default{" "}
+        <code>{`ports: ["\${PORT:-8787}:8787"]`}</code> mapping publishes to all of the host's
+        interfaces, so once Tailscale is up, that same mapping is what makes port <code>8787</code>{" "}
+        reachable at the host's tailnet IP too —{" "}
+        <strong>
+          removing it, as you would for Caddy, makes the app unreachable everywhere, tailnet
+          included.
+        </strong>
+      </Callout>
       <p>
-        As with Caddy, remove the <code>gittensory</code> service's own <code>ports:</code> mapping
-        — with the sidecar on host networking, GitHub webhook delivery and any operator access
-        should go through the tailnet address, not a publicly bound port left over from the default
-        stack. This is the right choice when the instance only needs to be reachable by your own
-        team or CI, and you'd rather not manage a domain or certificate at all.
+        The tradeoff: leaving the default <code>0.0.0.0</code>-bound mapping in place means{" "}
+        <code>8787</code> is also still reachable from your LAN, and from the public internet if
+        this host has a public interface at all — Tailscale doesn't narrow that on its own. If you
+        want the instance reachable <em>only</em> via the tailnet, either firewall the host to allow{" "}
+        <code>8787</code> solely from your tailnet's address range, or bind the app's mapping to{" "}
+        <code>127.0.0.1:8787:8787</code> and use{" "}
+        <a href="https://tailscale.com/kb/1242/tailscale-serve" target="_blank" rel="noreferrer">
+          <code>tailscale serve</code>
+        </a>{" "}
+        inside the <code>tailscale</code> container (it shares the host's loopback under{" "}
+        <code>network_mode: host</code>) to proxy that localhost-only port onto the tailnet — check
+        the pinned image's <code>tailscale serve --help</code> for the exact current flags. This
+        profile is the right choice when the instance only needs to be reachable by your own team or
+        CI, and you'd rather not manage a domain or certificate at all.
       </p>
 
       <h2>Public output boundary</h2>

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-security.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-security.tsx
@@ -62,13 +62,37 @@ function SelfHostingSecurity() {
 
       <h2>Network exposure</h2>
       <ul>
-        <li>Expose the webhook endpoint only through TLS.</li>
-        <li>Keep Prometheus, Grafana, Qdrant, Ollama, and database ports private by default.</li>
+        <li>
+          Expose the webhook endpoint only through TLS — see "TLS termination" below for the two
+          shipped ways to get there.
+        </li>
+        <li>
+          Prometheus, Qdrant, Ollama, and the database ports are private by default (bound to{" "}
+          <code>127.0.0.1</code> or only reachable on the compose network) — but{" "}
+          <strong>Grafana is the exception</strong>. Its compose entry publishes{" "}
+          <code>3000:3000</code>, which binds every interface, not just localhost. Bind it yourself
+          (<code>127.0.0.1:3000:3000</code> in a compose override) or put it behind the Caddy or
+          Tailscale profile described below before running the <code>observability</code> profile
+          anywhere it isn't already firewalled.
+        </li>
         <li>Put an auth layer in front of dashboards and internal admin routes.</li>
         <li>
           Use <code>/ready</code> for orchestrators, not as a public status surface.
         </li>
       </ul>
+      <p>
+        The <code>observability</code> profile also runs a <code>docker-proxy</code> service that
+        never appears in any dashboard or metric. It fronts the Docker socket for Promtail's
+        container log discovery: a plain <code>:ro</code> bind-mount of{" "}
+        <code>/var/run/docker.sock</code> only protects the socket inode, not the Docker API behind
+        it, so handing Promtail the raw socket is effectively host root — enumerate every container,
+        read each one's environment and secrets, tail every log, or start a privileged container and
+        escape to the host. <code>docker-proxy</code> is the only container that touches the socket,
+        exposes just the read-only <code>/containers/*</code> and <code>/networks/*</code> endpoints
+        Promtail's service discovery needs, denies every mutating call outright, and sits alone on
+        its own Docker network shared only with Promtail — publishing no host port isn't enough on
+        its own, since the default compose network is reachable by every other service in the stack.
+      </p>
 
       <h2>Control-panel access</h2>
       <p>
@@ -101,6 +125,132 @@ function SelfHostingSecurity() {
         REES receives PR diff and file metadata. Use a private network URL when possible, require
         <code>REES_SHARED_SECRET</code>, and remember that the engine treats REES output as
         untrusted advisory context.
+      </p>
+
+      <h2>TLS termination</h2>
+      <p>
+        A webhook endpoint and a stable <code>PUBLIC_API_ORIGIN</code> (see{" "}
+        <Link to="/docs/self-hosting-github-app">GitHub App and Orb</Link>) both need real HTTPS.
+        The compose file ships two ways to get it without hand-rolling a reverse proxy, plus a third
+        option if you already run one.
+      </p>
+      <FeatureRow
+        items={[
+          {
+            title: "Caddy (--profile caddy)",
+            description:
+              "A public HTTPS terminator with automatic Let's Encrypt certificates. Use this when the instance needs a real internet-facing domain.",
+          },
+          {
+            title: "Tailscale (--profile tailscale)",
+            description:
+              "A private-network sidecar — no public port at all. Use this when only your own team needs to reach the instance.",
+          },
+          {
+            title: "Bring your own reverse proxy",
+            description:
+              "Skip both profiles and put an existing nginx/Traefik/ALB in front of the gittensory service's own port instead.",
+          },
+        ]}
+      />
+
+      <h3>Caddy: automatic HTTPS with Let's Encrypt</h3>
+      <p>
+        The <code>caddy</code> profile runs Caddy 2 in front of the <code>gittensory</code> service,
+        terminating TLS on <code>80</code>/<code>443</code>/<code>443/udp</code> (the last for
+        HTTP/3) and obtaining a Let's Encrypt certificate automatically for whatever domain you set.
+        It needs a real DNS record: point <code>DOMAIN</code> at this host's public IP{" "}
+        <em>before</em> starting the profile, or the ACME HTTP-01 challenge Caddy runs on port 80
+        fails and it falls back to a self-signed cert.
+      </p>
+      <CodeBlock filename=".env" code={`DOMAIN=reviews.yourcompany.com`} />
+      <p>
+        The shipped <code>caddy/Caddyfile</code> reverse-proxies to <code>gittensory:8787</code> on
+        the compose network, forwards the real client IP, enables compression, sets standard
+        security headers (HSTS, <code>X-Content-Type-Options</code>, <code>X-Frame-Options</code>, a
+        strict referrer policy), and logs as JSON to stderr:
+      </p>
+      <CodeBlock
+        filename="caddy/Caddyfile"
+        code={`{$DOMAIN} {
+	reverse_proxy gittensory:8787 {
+		header_up X-Forwarded-For {remote_host}
+		header_up X-Real-IP {remote_host}
+	}
+
+	encode zstd gzip
+
+	header {
+		Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+		X-Content-Type-Options "nosniff"
+		X-Frame-Options "DENY"
+		Referrer-Policy "strict-origin-when-cross-origin"
+		-Server
+	}
+
+	log {
+		output stderr
+		format json
+	}
+}`}
+      />
+      <p>
+        Edit this file directly if you need a different upstream, extra headers, or a second site
+        block — Caddy re-reads it on container restart. For local testing without a real domain, set{" "}
+        <code>DOMAIN=localhost</code>; Caddy issues a self-signed cert and your browser will warn
+        about it, which is expected.
+      </p>
+      <Callout variant="warn" title="Remove the app's own port mapping">
+        The <code>gittensory</code> service's compose entry has a direct{" "}
+        <code>{`ports: ["\${PORT:-8787}:8787"]`}</code> mapping with a comment marking exactly this:
+        remove it once Caddy (or Tailscale, below) is your public listener, or the app stays
+        reachable on <code>:8787</code> with no TLS, bypassing the proxy entirely and defeating the
+        whole point of adding it.
+      </Callout>
+      <p>
+        Prefer certificates you already manage — an internal CA, a wildcard cert issued elsewhere —
+        instead of Let's Encrypt? Mount your own cert and key into the container and point the{" "}
+        <code>{`{$DOMAIN}`}</code> block at a file-based TLS directive (
+        <code>tls /path/to/cert /path/to/key</code>) instead of the automatic-HTTPS default; see{" "}
+        <a
+          href="https://caddyserver.com/docs/caddyfile/directives/tls"
+          target="_blank"
+          rel="noreferrer"
+        >
+          Caddy's <code>tls</code> directive docs
+        </a>{" "}
+        for the syntax.
+      </p>
+
+      <h3>Already run a reverse proxy or load balancer?</h3>
+      <p>
+        Skip the <code>caddy</code> profile entirely. Remove the same direct <code>ports:</code>{" "}
+        mapping from the <code>gittensory</code> service, keep it on the compose network (or publish{" "}
+        <code>8787</code> bound to a private interface your existing proxy can reach), and terminate
+        TLS the way you already do for everything else — nginx, Traefik, an AWS ALB, a Cloudflare
+        Tunnel. Whatever fronts it just needs to forward to port <code>8787</code> and preserve the
+        client IP the same way the shipped Caddyfile does.
+      </p>
+
+      <h3>Tailscale: private-network access, no public port</h3>
+      <p>
+        The <code>tailscale</code> profile joins the stack to your tailnet instead of exposing
+        anything to the public internet. It runs with <code>network_mode: host</code> — Tailscale
+        needs host networking to advertise this machine's address on the tailnet — so once it's up,
+        the <code>gittensory</code> service is reachable at this host's tailnet IP on port{" "}
+        <code>8787</code>, with no port published to the public internet at all.
+      </p>
+      <CodeBlock
+        filename=".env"
+        code={`TS_AUTHKEY=            # generate at tailscale.com/admin/settings/keys
+TS_EXTRA_ARGS=          # optional, e.g. --advertise-tags=tag:self-host`}
+      />
+      <p>
+        As with Caddy, remove the <code>gittensory</code> service's own <code>ports:</code> mapping
+        — with the sidecar on host networking, GitHub webhook delivery and any operator access
+        should go through the tailnet address, not a publicly bound port left over from the default
+        stack. This is the right choice when the instance only needs to be reachable by your own
+        team or CI, and you'd rather not manage a domain or certificate at all.
       </p>
 
       <h2>Public output boundary</h2>

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-security.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-security.tsx
@@ -71,9 +71,11 @@ function SelfHostingSecurity() {
           <code>127.0.0.1</code> or only reachable on the compose network) — but{" "}
           <strong>Grafana is the exception</strong>. Its compose entry publishes{" "}
           <code>3000:3000</code>, which binds every interface, not just localhost. Bind it yourself
-          (<code>127.0.0.1:3000:3000</code> in a compose override) or put it behind the Caddy or
-          Tailscale profile described below before running the <code>observability</code> profile
-          anywhere it isn't already firewalled.
+          (<code>127.0.0.1:3000:3000</code> in a compose override) — the reliable fix — before
+          running the <code>observability</code> profile anywhere it isn't already firewalled.
+          Running Tailscale alongside it does <strong>not</strong> narrow this on its own (see "TLS
+          termination" below); combining the two safely still needs the same firewall or{" "}
+          <code>tailscale serve</code> step.
         </li>
         <li>Put an auth layer in front of dashboards and internal admin routes.</li>
         <li>
@@ -148,7 +150,7 @@ function SelfHostingSecurity() {
           {
             title: "Tailscale (--profile tailscale)",
             description:
-              "A private-network sidecar — no public port at all, but also not reachable by GitHub's own webhook delivery. Use this for team/CI-only access, or alongside brokered pull mode.",
+              "Adds private tailnet reachability, but with the default port mapping left in place (required — see below), the app stays reachable on every host interface too, not just the tailnet; firewall the host or use tailscale serve for real no-public-port isolation. Also not reachable by GitHub's own webhook delivery — use this for team/CI-only access, or alongside brokered pull mode.",
           },
           {
             title: "Bring your own reverse proxy",
@@ -242,11 +244,12 @@ function SelfHostingSecurity() {
         client IP the same way the shipped Caddyfile does.
       </p>
 
-      <h3>Tailscale: private-network access, no public port</h3>
+      <h3>Tailscale: adds tailnet reachability</h3>
       <p>
-        The <code>tailscale</code> profile joins the stack to your tailnet instead of exposing
-        anything to the public internet. It runs with <code>network_mode: host</code> — Tailscale
-        needs host networking to advertise this machine's address on the tailnet.
+        The <code>tailscale</code> profile joins the stack to your tailnet. It runs with{" "}
+        <code>network_mode: host</code> — Tailscale needs host networking to advertise this
+        machine's address on the tailnet. On its own, this only <em>adds</em> a reachable address;
+        see the callout below before assuming it also removes public reachability.
       </p>
       <CodeBlock
         filename=".env"


### PR DESCRIPTION
## Summary

- Fixes a confirmed factual inaccuracy: `docs.self-hosting-security.tsx` claimed Grafana's port was private by default alongside Prometheus/Qdrant/Ollama, but `docker-compose.yml`'s `grafana` service publishes `ports: ["3000:3000"]` (every interface), unlike Qdrant's confirmed `127.0.0.1:6333:6333` binding. Corrected the claim and added the mitigation (bind it yourself, or front it with Caddy/Tailscale).
- Adds a full "TLS termination" walkthrough to the security page for the `caddy` and `tailscale` compose profiles, which previously had exactly one line of documentation each (a table entry on the quickstart page): the shipped `caddy/Caddyfile` contents, DNS prerequisites for Let's Encrypt, the requirement to remove the `gittensory` service's own `ports:` mapping when fronting it with either profile (per the compose file's own comments at lines 72 and 349), bringing your own certs, running behind an existing reverse proxy/load balancer, and Tailscale's `TS_AUTHKEY`/`network_mode: host`/tailnet-`:8787` reachability as the no-public-port alternative.
- Names and explains `docker-proxy`, the read-only Docker-socket proxy inside the `observability` profile that isolates Promtail's container-log service discovery from the raw Docker socket — previously never named on any docs page.
- Cross-links the new TLS termination section from `docs.self-hosting-github-app.tsx`'s `PUBLIC_API_ORIGIN` setup, its pull/push relay-mode explanation, and its webhook-check `curl` example (all of which assumed a `https://reviews.example.com` origin already exists), and from the quickstart profile table.

Advances #1819.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes — docs-only, three files in `apps/gittensory-ui/src/routes/`.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] No specific tracked issue to close — this advances the self-host production-readiness roadmap (#1819) as documentation-depth work; see Summary for rationale.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` — not applicable, no workflow changes
- [x] `npm run typecheck` (ran `npm run ui:typecheck`; no backend/`src/**` changes)
- [ ] `npm run test:coverage` — not applicable, docs-only change with no `src/**` lines touched (no Codecov obligation)
- [ ] `npm run test:workers` — not applicable, no worker code changed
- [ ] `npm run build:mcp` — not applicable, no MCP changes
- [ ] `npm run test:mcp-pack` — not applicable, no MCP changes
- [ ] `npm run ui:openapi:check` — not applicable, no API/schema changes
- [x] `npm run ui:lint` (plus `npm --workspace @jsonbored/gittensory-ui run format` to fix prettier prose wrapping)
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm run docs:drift-check`
- [ ] `npm audit --audit-level=moderate` — not applicable, no dependency changes
- [ ] New or changed behavior has unit/integration tests — not applicable, prose-only docs content

If any required check was skipped, explain why:

- This is a documentation-only change confined to `apps/gittensory-ui/src/routes/*.tsx` prose/JSX content. No `src/**`, worker, MCP, API, or dependency files changed, so the backend/coverage/audit/openapi/actionlint checks don't apply. Ran the full applicable subset (lint, typecheck, build, docs-drift-check) plus `git diff --check`, all green.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests — not applicable, no such changes.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed — not applicable.
- [ ] UI changes use live API data or real empty/error/loading states — not applicable, static docs prose only.
- [ ] Visible UI changes include a `UI Evidence` section — this is docs prose/code-sample content on existing pages using existing components (`Callout`, `CodeBlock`, `FeatureRow`, `Link`), not a new visual surface; verified locally via `npm run ui:build` (clean SSR+client build) and a rendered dev-server check confirming the new "TLS termination" section and its subheadings appear correctly in the page's auto-generated on-this-page navigation.
- [x] Public docs/changelogs are updated where needed; changelog itself not touched (not a release-prep PR).

## Notes

- Verified the Grafana port claim directly against `docker-compose.yml:419-420` (`ports: ["3000:3000"]`) vs. Qdrant's `docker-compose.yml:277` (`127.0.0.1:6333:6333`).
- The Caddyfile walkthrough quotes the actual shipped `caddy/Caddyfile` verbatim rather than inventing an example.
- The `docker-proxy` rationale is drawn from the compose file's own comment at `docker-compose.yml:517-526`, not paraphrased from an external source.