### PR TITLE
feat(enrichment): detect Browserbase and Modal tokens in secret-scan

### DIFF
--- a/review-enrichment/src/analyzers/secret-scan.ts
+++ b/review-enrichment/src/analyzers/secret-scan.ts
@@ -248,6 +248,18 @@ const RULES: Rule[] = [
     confidence: "high",
   },
   {
+    // Browserbase API key: `bb_` + base62 body (reject hyphen-continued identifiers).
+    kind: "browserbase_api_key",
+    re: /\bbb_[A-Za-z0-9]{20,}(?![A-Za-z0-9_-])/,
+    confidence: "high",
+  },
+  {
+    // Modal token ID/secret: `ak-` (ID) or `as-` (secret) + base62 body.
+    kind: "modal_token",
+    re: /\b(?:ak|as)-[A-Za-z0-9]{20,}(?![A-Za-z0-9_-])/,
+    confidence: "high",
+  },
+  {
     // Google OAuth 2.0 client secret: `GOCSPX-` + 28 base64url chars.
     kind: "google_oauth_client_secret",
     re: /\bGOCSPX-[A-Za-z0-9_-]{28}\b/,

--- a/review-enrichment/test/secret-scan.test.ts
+++ b/review-enrichment/test/secret-scan.test.ts
@@ -637,6 +637,48 @@ test("scanPatch does not flag truncated Voyage/Firecrawl keys or identifier cont
   );
 });
 
+test("scanPatch flags Browserbase and Modal API tokens with high confidence", () => {
+  const fakeBrowserbaseKey = "bb_" + "a".repeat(20);
+  const browserbaseFindings = scanPatch("src/config.ts", hunk([`const browserbase = "${fakeBrowserbaseKey}";`]));
+  assert.equal(browserbaseFindings.length, 1);
+  assert.equal(browserbaseFindings[0].kind, "browserbase_api_key");
+  assert.equal(browserbaseFindings[0].confidence, "high");
+
+  const fakeModalTokenId = "ak-" + "b".repeat(20);
+  const modalIdFindings = scanPatch("src/config.ts", hunk([`const modalId = "${fakeModalTokenId}";`]));
+  assert.equal(modalIdFindings.length, 1);
+  assert.equal(modalIdFindings[0].kind, "modal_token");
+  assert.equal(modalIdFindings[0].confidence, "high");
+
+  const fakeModalTokenSecret = "as-" + "c".repeat(20);
+  const modalSecretFindings = scanPatch("src/config.ts", hunk([`const modalSecret = "${fakeModalTokenSecret}";`]));
+  assert.equal(modalSecretFindings.length, 1);
+  assert.equal(modalSecretFindings[0].kind, "modal_token");
+  assert.equal(modalSecretFindings[0].confidence, "high");
+});
+
+test("scanPatch does not flag truncated Browserbase/Modal tokens or identifier continuation", () => {
+  assert.equal(scanPatch("src/config.ts", hunk([`const browserbase = "bb_${"a".repeat(19)}";`])).length, 0);
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const browserbase = "bb_${"a".repeat(20)}_suffix";`])).some((f) => f.kind === "browserbase_api_key"),
+    false,
+  );
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const browserbase = "bb_${"a".repeat(20)}-suffix";`])).some((f) => f.kind === "browserbase_api_key"),
+    false,
+  );
+
+  assert.equal(scanPatch("src/config.ts", hunk([`const modalId = "ak-${"b".repeat(19)}";`])).length, 0);
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const modalId = "ak-${"b".repeat(20)}-suffix";`])).some((f) => f.kind === "modal_token"),
+    false,
+  );
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const modalSecret = "as-${"c".repeat(20)}_suffix";`])).some((f) => f.kind === "modal_token"),
+    false,
+  );
+});
+
 test("scanPatch flags additional high-confidence SaaS/cloud/CI credential formats", () => {
   const cases = [
     ["google_oauth_client_secret", "GOCSPX-" + b62(28)],


### PR DESCRIPTION
## Summary
- Add `browserbase_api_key` rule for Browserbase keys (`bb_` prefix).
- Add `modal_token` rule for Modal token ID (`ak-`) and secret (`as-`).
- Include positive, truncation, and hyphen/underscore continuation negative tests (Browserbase tail guard uses `(?![A-Za-z0-9_-])`).

## Test plan
- [x] `npm run build && node --test test/secret-scan.test.ts` in `review-enrichment/` (74 passing)

Made with [Cursor](https://cursor.com)