### PR TITLE
docs(self-hosting): document backpressure, orb, and config-as-code gaps

### DIFF
--- a/apps/gittensory-ui/src/routes/docs.self-hosting-ai-providers.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-ai-providers.tsx
@@ -69,6 +69,28 @@ function SelfHostingAiProviders() {
 ANTHROPIC_API_KEY=<provider-key>
 ANTHROPIC_AI_MODEL=claude-sonnet-4-6`}
       />
+      <p>
+        <code>ANTHROPIC_AI_BASE_URL</code> defaults to <code>https://api.anthropic.com</code> — set
+        it only to route through a gateway or proxy in front of the real Anthropic API.
+      </p>
+
+      <h2>OpenAI API</h2>
+      <p>
+        Distinct from OpenAI-compatible below: this is the native OpenAI API path (
+        <code>AI_PROVIDER=openai</code>), for when you have an OpenAI account key rather than a
+        gateway or local endpoint.
+      </p>
+      <CodeBlock
+        filename=".env"
+        code={`AI_PROVIDER=openai
+OPENAI_API_KEY=<provider-key>
+OPENAI_AI_BASE_URL=https://api.openai.com/v1
+OPENAI_AI_MODEL=gpt-5.5`}
+      />
+      <p>
+        <code>OPENAI_AI_BASE_URL</code> and <code>OPENAI_AI_MODEL</code> already default to the
+        values shown — set them only to override the endpoint or model.
+      </p>
 
       <h2>OpenAI-compatible endpoint</h2>
       <CodeBlock
@@ -78,6 +100,26 @@ OPENAI_COMPATIBLE_AI_BASE_URL=http://ollama:11434/v1
 OPENAI_COMPATIBLE_AI_API_KEY=
 OPENAI_COMPATIBLE_AI_MODEL=llama3.1`}
       />
+
+      <h2>Ollama (dedicated provider)</h2>
+      <p>
+        <code>AI_PROVIDER=ollama</code> is a separate provider id from routing Ollama through{" "}
+        <code>openai-compatible</code> above — use whichever matches how you want
+        fallback/dual-review chains to identify it. Defaults to a local Ollama at{" "}
+        <code>http://localhost:11434/v1</code> with no API key.
+      </p>
+      <CodeBlock
+        filename=".env"
+        code={`AI_PROVIDER=ollama
+OLLAMA_AI_BASE_URL=http://ollama:11434/v1
+OLLAMA_AI_API_KEY=
+OLLAMA_AI_MODEL=llama3.1`}
+      />
+      <p>
+        Set <code>OLLAMA_AI_BASE_URL</code> to <code>http://ollama:11434/v1</code> when using the
+        compose <code>ollama</code> profile; <code>OLLAMA_AI_API_KEY</code> is normally left blank
+        for a local, unauthenticated Ollama instance.
+      </p>
 
       <h2>Fallback and dual review</h2>
       <p>

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-configuration.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-configuration.tsx
@@ -65,6 +65,41 @@ function SelfHostingConfiguration() {
         ]}
       />
 
+      <h2>Precedence</h2>
+      <p>
+        Where policy for a given repo can live is one question; which layer wins when more than one
+        is set is another. Most specific wins, in this order:
+      </p>
+      <ul>
+        <li>
+          the repo&apos;s <code>.gittensory.yml</code> (public repo config, or the mounted private
+          per-repo config file below if <code>GITTENSORY_REPO_CONFIG_DIR</code> is set), then
+        </li>
+        <li>the per-repo database settings (the dashboard), then</li>
+        <li>built-in safe defaults.</li>
+      </ul>
+      <p>
+        Within <code>.gittensory.yml</code> itself, the typed <code>gate:</code> block is an alias
+        for the gate-related fields and wins over the generic <code>settings:</code> block for those
+        same fields — so a value written under both <code>gate.duplicates</code> and{" "}
+        <code>settings.duplicates</code> resolves to whatever <code>gate.duplicates</code> says. One
+        exception to the whole precedence chain: hard path guardrails (
+        <code>settings.hardGuardrailGlobs</code>) are config-as-code only — omitted or empty means
+        no path guardrails, never a hidden engine fallback, regardless of what the database row or
+        defaults would otherwise imply.
+      </p>
+      <p>
+        This page covers the environment layer and the shape of the config file. For the full field
+        list — every <code>gate:</code> and <code>settings:</code> key, its default, and what it
+        does — see <Link to="/docs/tuning">Tuning your reviews</Link>, and for a complete,
+        commented, copy-pasteable manifest see{" "}
+        <a href="https://github.com/JSONbored/gittensory/blob/main/.gittensory.yml.example">
+          <code>.gittensory.yml.example</code>
+        </a>{" "}
+        in the repo — the authoritative reference for every field, including several documented only
+        in its comments (see below).
+      </p>
+
       <h2>Required baseline env</h2>
       <CodeBlock
         filename=".env"
@@ -82,6 +117,11 @@ INTERNAL_JOB_TOKEN=<random-32-byte-token>`}
       <p>
         Any <code>FOO_FILE</code> is loaded into <code>FOO</code> at startup. Explicit{" "}
         <code>FOO</code> wins over the file variant.
+      </p>
+      <p>
+        Every command example on these docs pages hardcodes <code>:8787</code> — that&apos;s the
+        default, not a fixed port. Set <code>PORT</code> to listen on something else; update your
+        compose port mapping and any <code>curl</code>/health-check commands to match.
       </p>
       <Callout variant="warn" title="MCP_ACTUATION_REPO_ALLOWLIST">
         <code>GITTENSORY_MCP_TOKEN</code> is a shared, end-user-obtainable CLI credential (the
@@ -109,6 +149,33 @@ MCP_ACTUATION_REPO_ALLOWLIST=owner/repo-one, owner/repo-two
         contributor/operator tools.
       </p>
 
+      <h2>Data paths</h2>
+      <ul>
+        <li>
+          <code>MIGRATIONS_DIR</code> (default <code>migrations</code>) — where the self-host
+          runtime looks for SQL migration files to auto-apply at boot. Only relevant for a custom
+          build that ships migrations somewhere other than the default in-image location.
+        </li>
+        <li>
+          <code>REVIEW_AUDIT_DIR</code> — when set, persists visual-review screenshot PNGs to this
+          filesystem path so they're served from cache instead of re-rendered on every request.
+          Unset means each screenshot is re-rendered on demand. Only relevant when{" "}
+          <code>BROWSER_WS_ENDPOINT</code> (see{" "}
+          <Link to="/docs/self-hosting-rees">REES enrichment</Link>) is also set — visual review is
+          fully inert without it.
+        </li>
+        <li>
+          <code>CODEX_HOME</code> — do not set this for the app container. The Codex provider
+          rejects a container-set <code>CODEX_HOME</code> outright (fails closed with{" "}
+          <code>codex_credential_isolation_required</code>) because <code>codex exec</code> reads
+          attacker-controlled PR title/body/diff text, and a mounted OAuth home on the same
+          filesystem could otherwise leak into review output via prompt injection. This is why the
+          Codex subscription path additionally requires the explicit{" "}
+          <code>GITTENSORY_ENABLE_UNSAFE_CODEX_REVIEWER=1</code> opt-in — see{" "}
+          <Link to="/docs/self-hosting-ai-providers">AI providers</Link>.
+        </li>
+      </ul>
+
       <h2>GitHub API cache</h2>
       <p>
         Redis backs shared caching for stable GitHub GET responses, including repeated installation,
@@ -131,6 +198,101 @@ GITHUB_METADATA_CACHE_TTL_SECONDS=600`}
         Prometheus exports <code>gittensory_github_response_cache_total</code>, and the bundled
         self-host Grafana dashboard includes the hit/miss/coalesced/error breakdown.
       </Callout>
+
+      <h2>Queue cadence and startup</h2>
+      <p>
+        <code>CRON_INTERVAL_MS</code> (default <code>120000</code>, ~2 minutes) is the tick that
+        drives the maintain/sweep and sync cadence — contributor evidence, burden forecasts, RAG
+        re-indexing, drift scans, and notifications all fan out from it.{" "}
+        <code>QUEUE_BACKGROUND_CONCURRENCY</code> (default <code>1</code>) caps how many
+        low-priority background jobs may occupy a <code>QUEUE_CONCURRENCY</code> slot at once,
+        independent of live webhook/review work.
+      </p>
+      <p>
+        <code>QUEUE_STARTUP_JITTER_MIN_JOBS</code> (default <code>8</code>) sets the pending-job
+        count below which the queue skips its startup jitter delay — useful on a small instance
+        where you'd rather a handful of jobs start processing immediately after boot than wait out a
+        jitter window meant to stagger many instances restarting at once.
+      </p>
+
+      <h2>Maintenance and installation backpressure</h2>
+      <p>
+        Two independent, opt-out admission checks run at queue-claim time, on top of GitHub
+        rate-limit deferral, so background work never starves live PR review or overloads the host.
+        Both grew out of real production incidents — an un-jittered cron enqueue and an unbounded
+        per-installation background fan-out — and every value below is optional with a sane default.
+      </p>
+      <FeatureRow
+        items={[
+          {
+            title: "MAINTENANCE_ADMISSION_* — host/lane pressure",
+            description:
+              "Defers a periodic maintenance job (contributor evidence, burden forecasts, RAG re-index, drift scans, notifications) when live jobs are backed up or host load is high, so maintenance never competes with live webhook/review work for CPU or DB time. A denied job is deferred with jitter, never dropped.",
+          },
+          {
+            title: "GITHUB_INSTALLATION_CONCURRENCY_* — per-install fan-out",
+            description:
+              "Caps how many GitHub-fetching background jobs one installation may run at once, so one installation's sweep or backfill can't claim every background slot and starve every other installation, even when neither is near GitHub's own rate limit.",
+          },
+        ]}
+      />
+      <p>
+        Tune <code>MAINTENANCE_ADMISSION_MAX_LIVE_PENDING</code> (default <code>5</code>),{" "}
+        <code>MAINTENANCE_ADMISSION_MAX_LIVE_AGE_MS</code> (default <code>120000</code>),{" "}
+        <code>MAINTENANCE_ADMISSION_MAX_PENDING</code> (default <code>15</code>),{" "}
+        <code>MAINTENANCE_ADMISSION_MAX_HOST_LOAD</code> (default <code>1.5</code>, a 1-minute
+        load-average-per-core ceiling), and{" "}
+        <code>MAINTENANCE_ADMISSION_MAX_BACKLOG_CONVERGENCE_PENDING</code> (default <code>10</code>)
+        if you register many repos or run a busy instance and see maintenance sweeps lagging behind
+        where you'd like. A denial backs off by <code>MAINTENANCE_ADMISSION_DEFER_MS</code> (default{" "}
+        <code>180000</code>, 3 minutes) before jitter, but two escape hatches stop a deferral from
+        becoming a starve: <code>MAINTENANCE_ADMISSION_MAX_DEFER_AGE_MS</code> (default{" "}
+        <code>14400000</code>, 4 hours) force-admits any maintenance job that has waited this long
+        regardless of pressure, and the shorter <code>MAINTENANCE_ADMISSION_DRAIN_AGE_MS</code>{" "}
+        (default <code>600000</code>, 10 minutes, clamped to the 4-hour ceiling) specifically drains
+        the oldest jobs in a backed-up <code>maintenance_pending_high</code> lane so it can actually
+        shrink instead of denying every claim for hours. Set{" "}
+        <code>MAINTENANCE_ADMISSION_ENABLED=false</code> to fully disable the policy and return to
+        the old always-run behavior.
+      </p>
+      <p>
+        <code>GITHUB_INSTALLATION_CONCURRENCY_LIMIT</code> (default <code>2</code>) is the per-
+        installation ceiling; <code>GITHUB_INSTALLATION_CONCURRENCY_DEFER_MS</code> (default{" "}
+        <code>15000</code>, 15 seconds) is its base backoff before jitter. Raise the limit if a
+        single large installation's background work is being throttled and you have GitHub
+        rate-limit and host headroom to spare; set{" "}
+        <code>GITHUB_INSTALLATION_CONCURRENCY_ENABLED=false</code> to disable the check entirely.
+        This check only applies to background jobs that call GitHub — live PR review (
+        <code>github-webhook</code>/<code>agent-regate-pr</code>) is never subject to it.
+      </p>
+      <Callout variant="note" title="FOREGROUND_LIVENESS_* — the other direction">
+        Where the two backpressure checks above defer background work, foreground liveness protects
+        live PR-review work FROM unbounded rate-limit deferral (its own worst case is up to ~65
+        minutes per defer under sustained pressure, e.g. right after a deploy floods a shared REST
+        budget). A periodic sweep force-releases any foreground-priority job that has genuinely
+        waited past <code>FOREGROUND_LIVENESS_MAX_DEFER_MS</code> (default <code>600000</code>, 10
+        minutes), checked every <code>FOREGROUND_LIVENESS_CHECK_INTERVAL_MS</code> (default{" "}
+        <code>60000</code>, 1 minute — deliberately not the 1-second poll tick, so a job that is
+        still genuinely rate-limited waits for the next sweep instead of busy-looping), releasing at
+        most <code>FOREGROUND_LIVENESS_MAX_RELEASE_PER_SWEEP</code> jobs per tick (default{" "}
+        <code>25</code>, oldest first, so a large inherited backlog ramps up gradually instead of
+        every released job re-tripping the same rate-limit bucket at once). It also runs once at
+        boot, so a restart self-heals inherited over-deferral. Set{" "}
+        <code>FOREGROUND_LIVENESS_ENABLED=false</code> to disable the sweep.
+      </Callout>
+
+      <h2>Tracing and telemetry env</h2>
+      <p>
+        <code>OTEL_EXPORTER_OTLP_ENDPOINT</code> overrides the OpenTelemetry collector target only
+        if you're routing to an external collector instead of the bundled one (default{" "}
+        <code>http://otel-collector:4318</code> under the <code>observability</code> profile).{" "}
+        <code>OTEL_SERVICE_NAME</code> (default <code>gittensory-selfhost</code>) is the service
+        name traces and metrics are tagged with — set a distinct value per instance if you run more
+        than one and want to tell them apart in Grafana/Tempo. <code>OTEL_TRACES_SAMPLER</code>{" "}
+        (default <code>parentbased_traceidratio</code>) picks the sampling strategy for app
+        job/provider traces; pair it with <code>OTEL_TRACES_SAMPLER_ARG</code> (for example{" "}
+        <code>0.05</code> to sample 5% of root traces).
+      </p>
 
       <h2>Generated env reference</h2>
       <p>
@@ -199,12 +361,212 @@ features:
   rag: false
   reputation: false`}
       />
+      <p>
+        The <code>features:</code> block above overrides a deployment-wide{" "}
+        <code>GITTENSORY_REVIEW_*</code> flag (rag, reputation, unifiedComment, safety) for this one
+        repo, with three states per key: <code>true</code> forces the capability on for this repo
+        (still subject to the env flag itself being enabled — it can never turn on a capability the
+        operator has fully disabled at the deployment level); <code>false</code> forces it off for
+        this repo regardless of the env flag; and omitting the key entirely falls back to the{" "}
+        <code>GITTENSORY_REVIEW_REPOS</code> allowlist default, i.e. today's behavior for an
+        operator who hasn't set anything here. See{" "}
+        <Link to="/docs/tuning">Tuning your reviews</Link> for the full{" "}
+        <code>GITTENSORY_REVIEW_*</code> flag list this overrides.
+      </p>
 
-      <h2>Instance-wide write switches</h2>
+      <h2>Config-as-code blocks with no dashboard equivalent</h2>
+      <p>
+        Everything above has a dashboard row it mirrors. The fields below exist{" "}
+        <strong>only</strong> in <code>.gittensory.yml</code> — there is no DB column or dashboard
+        toggle for them, so a self-host operator who never reads the example file may not know they
+        exist.
+      </p>
+      <h3>gate.checkMode</h3>
+      <p>
+        Controls only whether/how the required <code>Gittensory Orb Review Agent</code> check-run is
+        published — it never affects gate evaluation, comments, labels, audit records, or autonomous
+        merge/close, all of which run identically in every mode. Takes precedence over the legacy{" "}
+        <code>gate.enabled</code> boolean when both are set.
+      </p>
       <FeatureRow
         items={[
           {
-            title: "Unset",
+            title: "required",
+            description:
+              "Publish/update the check exactly as before. Use if you keep it as a required branch-protection status check.",
+          },
+          {
+            title: "visible",
+            description:
+              "Publish/update the same check-run for UI visibility only. Never add it to branch protection as required.",
+          },
+          {
+            title: "disabled",
+            description:
+              "Never create/update the check-run. Recommended for high-volume autonomous self-hosting — avoids a perpetually-pending status and cuts GitHub API calls.",
+          },
+        ]}
+      />
+      <Callout variant="warn" title="Remove the branch-protection requirement first">
+        Before switching to <code>disabled</code>, remove <code>Gittensory Orb Review Agent</code>{" "}
+        from this repo&apos;s branch-protection or ruleset required-status-checks list — Gittensory
+        cannot do this on your behalf, and leaving it required with nothing to satisfy it means
+        GitHub shows a pending status forever. Keep your real CI/Codecov/security checks required;
+        this setting only ever affects Gittensory&apos;s own check-run.
+      </Callout>
+      <p>
+        For a repo that has never been configured, the default is <code>disabled</code>; an
+        already-configured repo keeps its current effective behavior. Self-hosters running
+        high-volume autonomous review should prefer <code>visible</code> or <code>disabled</code>{" "}
+        over <code>required</code> — Gittensory&apos;s own merge/close decisions never depend on
+        this check either way.
+      </p>
+
+      <h3>Other gate-only fields</h3>
+      <ul>
+        <li>
+          <code>gate.cla</code> — sub-object for the CLA gate (<code>gate.claMode</code>, documented
+          on <Link to="/docs/tuning">Tuning your reviews</Link>): <code>consentPhrase</code> (a
+          case-insensitive substring gittensory looks for in the PR description),{" "}
+          <code>checkRunName</code> (an existing CLA-bot check-run name that also satisfies
+          consent), and <code>checkRunAppSlug</code> (the trusted App slug required to have produced
+          that check-run, so a contributor-controlled same-name check can&apos;t satisfy a blocking
+          legal gate). Either detection method is enough; both may be set. All default to{" "}
+          <code>null</code> (not configured).
+        </li>
+        <li>
+          <code>gate.expectedCiContexts</code> — CI check/status context names to treat as required
+          when GitHub branch protection returns no readable required-status-checks (unconfigured, or
+          a 403 from a token lacking <code>administration:read</code> — common for GitHub App
+          installations, especially self-host). Merged with branch-protection contexts when both are
+          readable; used alone when branch protection is null/empty. Default: not configured, which
+          keeps the fold-all fail-closed behavior when branch protection is also unreadable.
+        </li>
+        <li>
+          <code>gate.premergeContentRecheck</code> — when <code>true</code>, a PR touching{" "}
+          <code>migrations/**</code> gets a fresh GitHub read of the base branch&apos;s current
+          migration filenames immediately before an agent-driven merge, catching a different PR that
+          merged a same-numbered migration in the meantime. A live collision holds the PR instead of
+          merging blind. Default <code>false</code> — costs one extra GitHub API call per
+          migrations-touching PR.
+        </li>
+        <li>
+          <code>gate.requireFreshRebaseWindow</code> — when the base branch has advanced within this
+          many minutes of the actual merge decision, forces an <code>update_branch</code> + fresh CI
+          recheck before merging, instead of trusting a possibly-stale{" "}
+          <code>mergeable_state: clean</code> read. A bounded retry cap prevents a fast-moving base
+          from live-locking the PR. Default <code>null</code> (never force).
+        </li>
+        <li>
+          <code>gate.dryRun</code> — when <code>true</code>, the posted check conclusion remains the
+          real non-enforcing verdict while comments/check text may also show the would-be stricter
+          verdict for AI-review blocker mode. It does not disable downstream merge/close planning
+          for failures from already-enforced gates. Default <code>false</code>.
+        </li>
+        <li>
+          <code>gate.firstTimeContributorGrace</code> — reserved and currently inert: parsed and
+          stored, but the gate does not read it. A first-time contributor with a real blocker is
+          one-shot closed the same as a repeat contributor. Kept for potential future use.
+        </li>
+      </ul>
+
+      <h3>settings.closeOwnerAuthors and blockedPaths</h3>
+      <p>
+        <code>settings.closeOwnerAuthors</code> — by default, the repo owner&apos;s own PRs (and{" "}
+        <code>ADMIN_GITHUB_LOGINS</code> fleet-operator PRs) are never auto-closed; they may still
+        auto-merge when clean and passing, or fall to a manual hold. Set <code>true</code> to make
+        owner/admin-authored PRs eligible for auto-close like a contributor&apos;s, still gated by
+        the close autonomy class and adverse-signal conditions. Automation-bot PRs stay exempt
+        regardless of this setting. Default <code>false</code>.
+      </p>
+      <p>
+        <code>blockedPaths</code> (top-level, alongside <code>wantedPaths</code>) — globs off-limits
+        to contributors. Touching one yields a <code>manifest_blocked_path</code> finding,
+        enforceable when <code>gate.manifestPolicy: block</code> is set. Default <code>[]</code>{" "}
+        (nothing blocked).
+      </p>
+
+      <h3>settings anti-abuse block</h3>
+      <p>
+        A cluster of contributor-abuse guardrails, all config-as-code only, all off/unset by
+        default:
+      </p>
+      <ul>
+        <li>
+          <strong>Open-item caps</strong> — <code>contributorOpenPrCap</code> and{" "}
+          <code>contributorOpenIssueCap</code> bound how many PRs/issues a single non-owner/
+          non-admin/non-bot contributor may have open at once; a contributor&apos;s newest item
+          above the cap is closed with a clear reason, their oldest items up to the cap stay open.
+          Both are unset (no cap) by default. <code>contributorCapLabel</code> (default{" "}
+          <code>over-contributor-limit</code>) is the label applied on close — set it to explicit{" "}
+          <code>null</code> to close silently. <code>contributorCapCancelCi</code> cancels in-flight
+          CI runs on a cap-triggered close (requires the <code>actions: write</code> App permission;
+          degrades gracefully without it) and falls back to the{" "}
+          <code>CONTRIBUTOR_CAP_CANCEL_CI_DEFAULT</code> env var when unset.
+        </li>
+        <li>
+          <strong>Review-nag cooldown</strong> — <code>reviewNagPolicy</code> (<code>off</code>/
+          <code>hold</code>/<code>close</code>, default <code>off</code>) throttles a contributor
+          who repeatedly pings <code>@gittensory</code> for review on the same PR/issue, once they
+          exceed <code>reviewNagMaxPings</code> (default <code>3</code>) within{" "}
+          <code>reviewNagCooldownDays</code> (default <code>5</code>). <code>reviewNagLabel</code>{" "}
+          (default <code>review-nag-cooldown</code>) is applied alongside the hold/close action.{" "}
+          <code>reviewNagMonitoredMentions</code> extends the same cooldown to specific maintainer
+          logins a contributor keeps tagging directly instead of (or in addition to){" "}
+          <code>@gittensory</code>.
+        </li>
+        <li>
+          <strong>Exemptions and account age</strong> — <code>autoCloseExemptLogins</code> is a
+          shared, repo-scoped list of logins never throttled or closed by these deterministic
+          mechanisms, on top of the standing owner/admin/bot exemption.{" "}
+          <code>accountAgeThresholdDays</code> (default <code>null</code>, off) applies{" "}
+          <code>newAccountLabel</code> (default <code>new-account</code>) to a PR from a
+          below-threshold-age account — friction/visibility only, never an automatic close on
+          account age alone, and never for the owner, admins, or bots.
+        </li>
+        <li>
+          <strong>Command rate limit</strong> — <code>commandRateLimitPolicy</code> (
+          <code>off</code>/<code>hold</code>, default <code>off</code>) generalizes the review-nag
+          pattern to every <code>@gittensory</code> command, not just review-request pings.{" "}
+          <code>commandRateLimitMaxPerWindow</code> (default <code>20</code>) bounds cheap,
+          cache-only commands; <code>commandRateLimitAiMaxPerWindow</code> (default <code>5</code>)
+          is the tighter limit for AI-cost-bearing commands (ask/blockers/preflight/etc.);{" "}
+          <code>commandRateLimitWindowHours</code> (default <code>24</code>) is the rolling window
+          both limits count against.
+        </li>
+      </ul>
+
+      <h3>contentLane</h3>
+      <p>
+        Lets a self-hosted maintainer point Gittensory at their own structured registry (a
+        subnet/plugin/package catalog, for example) without a Gittensory code change — reviewing
+        additions to a data file the same way it reviews code. Unconfigured by default; uncomment
+        and set at least <code>entryFileGlob</code> and <code>collectionField</code> (both required
+        — the whole block is ignored with a warning if either is missing).
+      </p>
+      <CodeBlock
+        filename=".gittensory.yml"
+        lang="yaml"
+        code={`contentLane:
+  entryFileGlob: registry/*.json      # Glob for the structured entry files this lane reviews. Required.
+  collectionField: entries            # The JSON field holding the collection this lane diffs. Required.
+  providerFileGlob: providers/*.ts    # Optional glob for source files the entries are validated against.
+  artifactGlob: dist/registry.json    # Optional glob for a generated/build artifact to cross-check.
+  maxAppendedEntries: 1               # Positive integer cap on new entries per PR. Default: unbounded.
+  duplicateKeyFields: [slug]          # Field name(s) used to detect a duplicate entry. Default: [] (no dedup check).
+  validatorId: my-registry-validator  # Optional identifier for a custom per-entry validator. Default: none.`}
+      />
+
+      <h2>Instance-wide write switches (SELFHOST_DEPLOYMENT_MODE)</h2>
+      <p>
+        <code>SELFHOST_DEPLOYMENT_MODE</code> forces write suppression for the whole instance,
+        regardless of per-repo autonomy — useful for running a self-host in parallel with the live
+        cloud App on the same webhooks, provably posting nothing until an explicit cutover.
+      </p>
+      <FeatureRow
+        items={[
+          {
+            title: "Unset (default)",
             description:
               "Normal mode. Per-repo autonomy and GitHub permissions decide what can be written.",
           },
@@ -226,7 +588,9 @@ features:
         <Link to="/docs/self-hosting-github-app">GitHub App and Orb</Link>, then add optional
         context through <Link to="/docs/self-hosting-ai-providers">AI providers</Link>,{" "}
         <Link to="/docs/self-hosting-rees">REES</Link>, or{" "}
-        <Link to="/docs/self-hosting-rag">RAG</Link>.
+        <Link to="/docs/self-hosting-rag">RAG</Link>. For the full gate-mode and per-repo settings
+        reference — including the AI-review combine modes and a complete worked manifest — see{" "}
+        <Link to="/docs/tuning">Tuning your reviews</Link>.
       </p>
     </DocsPage>
   );

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-github-app.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-github-app.tsx
@@ -175,7 +175,7 @@ GITHUB_WEBHOOK_SECRET=<same-secret-configured-on-the-app>`}
           {
             title: "What's never exported",
             description:
-              "Repo/owner/PR names, commit SHAs, source code, diffs, comments, or logins. Repo/PR identifiers are HMAC-anonymized with a per-instance secret gittensory's own collector never holds.",
+              "Repo/owner/PR names, commit SHAs, source code, diffs, comments, or logins. Repo/PR identifiers are HMAC-anonymized by default with a per-instance secret gittensory's own collector never holds.",
           },
           {
             title: "Disabling it",
@@ -184,6 +184,22 @@ GITHUB_WEBHOOK_SECRET=<same-secret-configured-on-the-app>`}
           },
         ]}
       />
+      <Callout variant="warn" title="ORB_ANONYMIZE">
+        Repo/PR identifiers are HMAC-anonymized by <strong>default</strong> (
+        <code>ORB_ANONYMIZE=true</code>), not unconditionally — an operator can set{" "}
+        <code>ORB_ANONYMIZE=false</code> to export raw repo/PR names instead. There's no scenario
+        where gittensory's own hosted collector needs raw names; the toggle exists for an operator
+        running their <strong>own</strong> collector (see <code>ORB_COLLECTOR_URL</code> below) who
+        wants readable identifiers in their own infrastructure. Leave this at the default unless you
+        control the collector end.
+      </Callout>
+      <p>
+        <code>ORB_COLLECTOR_URL</code> overrides the export endpoint — default gittensory's hosted
+        collector, or point it at your own private collector if you're aggregating telemetry
+        yourself instead of sending it to gittensory. <code>ORB_COLLECTOR_TOKEN</code> is the bearer
+        credential for that private collector; leave it unset when using gittensory's own hosted
+        collector, which accepts unauthenticated, rate-limited, aggregate-only exports.
+      </p>
 
       <h2>Brokered Orb env</h2>
       <CodeBlock
@@ -192,6 +208,14 @@ GITHUB_WEBHOOK_SECRET=<same-secret-configured-on-the-app>`}
 ORB_BROKER_URL=https://gittensory-api.aethereal.dev
 ORB_RELAY_MODE=pull  # or omit for push (the default) -- see "Choosing a relay mode" below`}
       />
+      <p>
+        <code>ORB_APP_ID</code> overrides the seed used to derive this instance&apos;s stable,
+        anonymous <code>instance_id</code> in telemetry exports — normally derived from{" "}
+        <code>GITHUB_APP_ID</code>. A brokered instance holds no App ID of its own (it uses the
+        broker&apos;s tokens instead), so its identity falls back to the export secret unless you
+        set <code>ORB_APP_ID</code> explicitly. Most operators never need to set this; it exists so
+        a brokered instance's telemetry identity can be pinned independent of any App ID.
+      </p>
 
       <h2>Choosing a relay mode: pull vs. push</h2>
       <p>

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-operations.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-operations.tsx
@@ -133,6 +133,42 @@ docker compose --profile postgres --profile observability --profile backup up -d
         watching for.
       </p>
 
+      <h2>Two different Discord/Slack integrations</h2>
+      <p>
+        Don&apos;t confuse these — they're unrelated features that happen to share the same two chat
+        platforms:
+      </p>
+      <FeatureRow
+        items={[
+          {
+            title: "Alertmanager → Discord/Slack (infra alerts)",
+            description:
+              "Covered above. System/stack health: dead jobs, queue backlog, Postgres pressure, and similar operational alerts, routed by alertmanager/alertmanager.yml.",
+          },
+          {
+            title: "DISCORD_WEBHOOK_URL / SLACK_WEBHOOK_URL (per-PR outcomes)",
+            description:
+              "A .env-configured webhook the review engine itself posts to whenever it publishes a review outcome (merged, closed, manual hold) on any repo you review — a product notification, not an infra alert.",
+          },
+        ]}
+      />
+      <p>
+        <code>DISCORD_WEBHOOK_URL</code> is a global fallback Discord channel for any repo without
+        its own webhook. <code>DISCORD_REPO_WEBHOOKS</code> is a per-repo override — a JSON map of{" "}
+        <code>owner/repo</code> to a webhook URL — for routing different repos' notifications to
+        different channels. Both are unset (no Discord notifications) by default.
+      </p>
+      <CodeBlock
+        filename=".env"
+        code={`DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/...
+DISCORD_REPO_WEBHOOKS={"owner/repoA":"https://discord.com/api/webhooks/...","owner/repoB":"https://..."}`}
+      />
+      <p>
+        <code>SLACK_WEBHOOK_URL</code> posts the same per-action events (merged/closed/manual) as a
+        Block Kit section to one Slack channel. Unlike Discord there is no per-repo map today —
+        every repo shares this one webhook. Unset means no Slack notifications.
+      </p>
+
       <h2>Resource profiles</h2>
       <p>
         <strong>Measured</strong> rows below come from a real production instance running the full
@@ -419,6 +455,14 @@ services:
 volumes:
   runner-work-2:`}
       />
+
+      <h2>Sentry server name</h2>
+      <p>
+        <code>SENTRY_SERVER_NAME</code> sets a clean, human name for this instance in Sentry (for
+        example <code>gittensory-us-east</code>). Unset defaults to the OS hostname — never the
+        public-origin URL. Set this explicitly if you run more than one instance and want to tell
+        their Sentry events apart at a glance instead of matching container hostnames.
+      </p>
 
       <h2>Sentry tracing</h2>
       <p>

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-rag.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-rag.tsx
@@ -53,6 +53,17 @@ function SelfHostingRag() {
         ]}
       />
 
+      <h2>Choosing a vector backend</h2>
+      <p>
+        SQLite vectors are the default and need no extra service — fine for a small instance or
+        getting started. Qdrant (<code>QDRANT_URL</code>, <code>--profile qdrant</code>) is the
+        preferred dedicated vector store for review context at scale. A third option,{" "}
+        <code>PGVECTOR_ENABLED=true</code>, uses the Postgres pgvector table instead — only relevant
+        if you're already running the <code>postgres</code> profile and want to avoid standing up a
+        separate Qdrant service. Leave it <code>false</code> (the default) when{" "}
+        <code>QDRANT_URL</code> is set; Qdrant remains preferred for RAG at scale.
+      </p>
+
       <h2>Qdrant and Ollama example</h2>
       <CodeBlock
         filename=".env"
@@ -72,6 +83,13 @@ docker compose exec ollama ollama pull nomic-embed-text:latest`}
         Use <code>QDRANT_DIM=1024</code> for 1024-dimensional models such as <code>bge-m3</code> or{" "}
         <code>mxbai-embed-large</code>. If a Qdrant collection already exists, recreate it before
         changing dimensions.
+      </p>
+      <p>
+        <code>AI_EMBED_API_KEY</code> is the bearer credential for <code>AI_EMBED_BASE_URL</code>,
+        if that endpoint requires one — a local Ollama typically doesn't, but a hosted
+        OpenAI-compatible embeddings endpoint usually does. Setting <code>AI_EMBED_MODEL</code>{" "}
+        alone does nothing without <code>AI_EMBED_BASE_URL</code> also set; unset, embeddings use
+        the same provider as the rest of the review chain.
       </p>
 
       <h2>Indexing</h2>

--- a/apps/gittensory-ui/src/routes/docs.tuning.tsx
+++ b/apps/gittensory-ui/src/routes/docs.tuning.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { createFileRoute, Link } from "@tanstack/react-router";
 
 import { DocsPage } from "@/components/site/docs-page";
 import { CodeBlock, Callout } from "@/components/site/primitives";
@@ -57,6 +57,13 @@ function Tuning() {
         read exactly how a verdict is reached. The settings above sit <em>on top</em> of that open
         algorithm and never reveal review <em>direction</em>, so a contributor cannot read them and
         game the gate.
+      </p>
+      <p>
+        This page covers those fields in depth, for the cloud service or a self-host alike. If
+        you're running your own instance, see{" "}
+        <Link to="/docs/self-hosting-configuration">Self-host configuration</Link> for the
+        environment layer (deployment-wide flags, secrets, and where config files can live) that
+        sits underneath everything below.
       </p>
 
       <Callout variant="safety" title="Defaults are safe and conservative">
@@ -494,7 +501,10 @@ settings:
       <p>
         For the privacy guarantees behind these surfaces, see{" "}
         <a href="/docs/privacy-security">Privacy &amp; security</a>. For the maintainer install and
-        trust flow, see <a href="/docs/maintainer-install-trust">Install &amp; trust</a>.
+        trust flow, see <a href="/docs/maintainer-install-trust">Install &amp; trust</a>. If you're
+        self-hosting, see <Link to="/docs/self-hosting-configuration">Self-host configuration</Link>{" "}
+        for the environment layer these settings sit on top of, plus the config-precedence rules and
+        a link to the fully-commented <code>.gittensory.yml.example</code>.
       </p>
     </DocsPage>
   );


### PR DESCRIPTION
## Summary

- Fills a self-hosting documentation audit's confirmed gaps in `docs.self-hosting-configuration.tsx` and `docs.tuning.tsx`, plus the pages those gaps point at (`docs.self-hosting-github-app.tsx`, `docs.self-hosting-ai-providers.tsx`, `docs.self-hosting-rag.tsx`, `docs.self-hosting-operations.tsx`).
- Adds prose for ~25 previously-undocumented operator-relevant env vars: the maintenance-admission and per-installation-concurrency backpressure cluster (tied to a real past production incident — un-jittered cron enqueue), `FOREGROUND_LIVENESS_*`, `OTEL_*`, `MIGRATIONS_DIR`/`REVIEW_AUDIT_DIR`/`CODEX_HOME`, `PORT`, `ORB_ANONYMIZE`/`ORB_COLLECTOR_URL`/`ORB_COLLECTOR_TOKEN`/`ORB_APP_ID`, per-provider AI base-URL siblings (`OPENAI_AI_*`, `OLLAMA_AI_*`, `ANTHROPIC_AI_BASE_URL`, `AI_EMBED_API_KEY`), `PGVECTOR_ENABLED`, `SENTRY_SERVER_NAME`, and the per-PR `DISCORD_WEBHOOK_URL`/`DISCORD_REPO_WEBHOOKS`/`SLACK_WEBHOOK_URL` notification webhooks (explicitly distinguished from the existing Alertmanager infra-alert Discord/Slack wiring).
- Documents `.gittensory.yml` blocks that had zero website coverage anywhere: `gate.checkMode`, the `gate.cla` sub-object, `gate.expectedCiContexts`, `gate.premergeContentRecheck`, `gate.requireFreshRebaseWindow`, `gate.dryRun`, `gate.firstTimeContributorGrace`, `settings.closeOwnerAuthors`, top-level `blockedPaths`, the ~20-field anti-abuse `settings` cluster, the `features:` 3-state (true/false/omitted) fallback semantics, and the entire `contentLane:` block.
- Adds explicit config precedence (`.gittensory.yml` > per-repo DB settings > built-in defaults, with the `gate:` alias overriding `settings:` for the same fields) and a link to `.gittensory.yml.example` as the authoritative reference, plus two-way cross-links between `docs.self-hosting-configuration.tsx` and `docs.tuning.tsx` (previously zero links existed between them despite `docs.tuning.tsx` holding the best `gate:`/`settings:` field explanations).
- Fixes the one confirmed accuracy defect: the "Instance-wide write switches" section described three modes but never named the env var controlling them. Now names `SELFHOST_DEPLOYMENT_MODE` explicitly (verified live at `src/github/client.ts:613-631`, `src/env.d.ts:148`).
- Every fact was cross-checked against the source that actually reads the variable (not just the `.env.example` comment) — for example `ORB_APP_ID` had zero prior mention anywhere; reading `src/selfhost/orb-collector.ts:59` shows it overrides the seed used to derive a brokered instance's stable anonymous `instance_id`, which is what's documented here.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed. — Advances #1819 (self-host production-readiness roadmap); this is documentation-depth work, not a single tracked issue, so it's a non-closing reference.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` — not applicable, no workflow changes.
- [x] `npm run typecheck` — n/a to `src/**` (no backend changes); ran `npm run ui:typecheck` instead (clean).
- [ ] `npm run test:coverage` — not applicable: docs-only change under `apps/gittensory-ui/**`, which Codecov does not measure (no `src/**` touched).
- [ ] `npm run test:workers` — not applicable, no backend/worker code changed.
- [ ] `npm run build:mcp` / `npm run test:mcp-pack` — not applicable, no MCP package changes.
- [ ] `npm run ui:openapi:check` — not applicable, no API/schema changes.
- [x] `npm run ui:lint` (clean; ran `npm --workspace @jsonbored/gittensory-ui run format` first to fix prose line-wrap formatting)
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm run docs:drift-check`
- [ ] `npm audit --audit-level=moderate` — not run standalone; no dependency changes in this PR.
- [ ] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — not applicable, no `src/**` behavior changed.

If any required check was skipped, explain why:

- This is a docs-only change confined to `apps/gittensory-ui/src/routes/docs.*.tsx`. No `src/**`, workflow, MCP, OpenAPI, or dependency files changed, so the Codecov/coverage/worker/MCP/audit checks above don't apply. Ran the docs-specific gate instead: `ui:lint`, `ui:typecheck`, `ui:build`, `docs:drift-check`, all green.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — not applicable, no code changed.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — not applicable.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — not applicable, static prose only.
- [ ] Visible UI changes include a `UI Evidence` section below — see note below.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs (not touched here).

## UI Evidence

This is prose-only content added inside existing, already-styled doc pages, using only components already in use throughout those same pages (`Callout`, `CodeBlock`, `FeatureRow`, `Link`) — no new visual components, layout, or styling. The local preview tooling in this environment resolved to a different worktree's unmodified files, so rather than capture a screenshot of the wrong content, verification was done directly against this branch's production build output:

```
npm run ui:build
grep -o "SELFHOST_DEPLOYMENT_MODE\|Precedence\|contentLane\|checkMode" \
  apps/gittensory-ui/dist/client/assets/docs.self-hosting-configuration-*.js
# => Precedence / SELFHOST_DEPLOYMENT_MODE / checkMode / contentLane all present
```

The same check was repeated for all six touched pages, confirming every new string (`ORB_ANONYMIZE`, `ORB_APP_ID`, `OLLAMA_AI_BASE_URL`, `PGVECTOR_ENABLED`, `SENTRY_SERVER_NAME`, `DISCORD_REPO_WEBHOOKS`, etc.) compiles into the correct route's client bundle.

## Notes

- Scope was intentionally limited to `docs.self-hosting-configuration.tsx` and `docs.tuning.tsx` per the audit, plus the specific named cross-links into `docs.self-hosting-github-app.tsx`, `docs.self-hosting-ai-providers.tsx`, `docs.self-hosting-rag.tsx`, and `docs.self-hosting-operations.tsx` where the audit called out exact existing sections to extend.
- Intentionally skipped per the audit's own carve-out: `OBSERVABILITY_SMOKE_POLL_MS`, `OBSERVABILITY_SMOKE_TIMEOUT_MS`, `SELFHOST_SERVICE` (smoke-test-script-only), `SELFHOST_BUNDLE_ALL`, and `HOME` — none are real operator configuration surfaces.