### PR TITLE
feat(enrichment): detect fal.ai and Weights & Biases API keys in secret-scan

### DIFF
--- a/review-enrichment/src/analyzers/secret-scan.ts
+++ b/review-enrichment/src/analyzers/secret-scan.ts
@@ -260,6 +260,18 @@ const RULES: Rule[] = [
     confidence: "high",
   },
   {
+    // fal.ai API key: `fal_sk_` + base62 body (reject hyphen-continued identifiers).
+    kind: "fal_api_key",
+    re: /\bfal_sk_[A-Za-z0-9]{20,}(?![A-Za-z0-9_-])/,
+    confidence: "high",
+  },
+  {
+    // Weights & Biases API key: `wandb_v1_` + 77 base62/underscore chars.
+    kind: "wandb_api_key",
+    re: /\bwandb_v1_[A-Za-z0-9_]{77}(?![A-Za-z0-9_])/,
+    confidence: "high",
+  },
+  {
     // Google OAuth 2.0 client secret: `GOCSPX-` + 28 base64url chars.
     kind: "google_oauth_client_secret",
     re: /\bGOCSPX-[A-Za-z0-9_-]{28}\b/,

--- a/review-enrichment/test/secret-scan.test.ts
+++ b/review-enrichment/test/secret-scan.test.ts
@@ -679,6 +679,42 @@ test("scanPatch does not flag truncated Browserbase/Modal tokens or identifier c
   );
 });
 
+test("scanPatch flags fal.ai and Weights & Biases API keys with high confidence", () => {
+  const fakeFalKey = "fal_sk_" + "a".repeat(20);
+  const falFindings = scanPatch("src/config.ts", hunk([`const fal = "${fakeFalKey}";`]));
+  assert.equal(falFindings.length, 1);
+  assert.equal(falFindings[0].kind, "fal_api_key");
+  assert.equal(falFindings[0].confidence, "high");
+
+  const fakeWandbKey = "wandb_v1_" + "a".repeat(77);
+  const wandbFindings = scanPatch("src/config.ts", hunk([`const wandb = "${fakeWandbKey}";`]));
+  assert.equal(wandbFindings.length, 1);
+  assert.equal(wandbFindings[0].kind, "wandb_api_key");
+  assert.equal(wandbFindings[0].confidence, "high");
+});
+
+test("scanPatch does not flag truncated fal/W&B keys or identifier continuation", () => {
+  assert.equal(scanPatch("src/config.ts", hunk([`const fal = "fal_sk_${"a".repeat(19)}";`])).length, 0);
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const fal = "fal_sk_${"a".repeat(20)}_suffix";`])).some((f) => f.kind === "fal_api_key"),
+    false,
+  );
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const fal = "fal_sk_${"a".repeat(20)}-suffix";`])).some((f) => f.kind === "fal_api_key"),
+    false,
+  );
+
+  assert.equal(scanPatch("src/config.ts", hunk([`const wandb = "wandb_v1_${"a".repeat(76)}";`])).length, 0);
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const wandb = "wandb_v1_${"a".repeat(77)}X";`])).some((f) => f.kind === "wandb_api_key"),
+    false,
+  );
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const wandb = "wandb_v1_${"a".repeat(77)}_suffix";`])).some((f) => f.kind === "wandb_api_key"),
+    false,
+  );
+});
+
 test("scanPatch flags additional high-confidence SaaS/cloud/CI credential formats", () => {
   const cases = [
     ["google_oauth_client_secret", "GOCSPX-" + b62(28)],


### PR DESCRIPTION
## Summary
- Add `fal_api_key` rule for fal.ai keys (`fal_sk_` prefix).
- Add `wandb_api_key` rule for Weights & Biases v1 keys (`wandb_v1_` + 77-char body).
- Include positive, truncation, and hyphen/underscore continuation negative tests.

## Test plan
- [x] `npm run build && node --test test/secret-scan.test.ts` in `review-enrichment/` (76 passing)

Made with [Cursor](https://cursor.com)