### PR TITLE
fix(signals): classify .cc and .hpp C++ source across all classifiers

### DIFF
--- a/packages/gittensory-mcp/lib/local-branch.js
+++ b/packages/gittensory-mcp/lib/local-branch.js
@@ -610,7 +610,7 @@ export function isTestFile(file) {
 }
 
 export function isCodeFile(file) {
-  return /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy|php|cpp|c|h|m|vue|svelte|astro)$/i.test(file) && !isTestFile(file);
+  return /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy|php|cpp|cc|c|h|hpp|m|vue|svelte|astro)$/i.test(file) && !isTestFile(file);
 }
 
 function numberValue(value) {

--- a/packages/gittensory-mcp/scripts/gittensor-score-preview.mjs
+++ b/packages/gittensory-mcp/scripts/gittensor-score-preview.mjs
@@ -19,7 +19,7 @@ function isTestFile(file) {
 }
 
 function isCodeFile(file) {
-  return /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy|php|cpp|c|h|m|vue|svelte|astro)$/i.test(file) && !isTestFile(file);
+  return /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy|php|cpp|cc|c|h|hpp|m|vue|svelte|astro)$/i.test(file) && !isTestFile(file);
 }
 
 function lineCount(file) {

--- a/packages/gittensory-mcp/scripts/gittensor-score-preview.py
+++ b/packages/gittensory-mcp/scripts/gittensor-score-preview.py
@@ -142,7 +142,7 @@ def metadata_fallback(metadata: dict) -> dict:
         lines = max(int(entry.get("additions") or 0) + int(entry.get("deletions") or 0), 0)
         if is_test_file(path):
             tests += lines
-        elif lower_path.endswith((".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs", ".py", ".rb", ".rs", ".go", ".java", ".kt", ".scala", ".sql", ".cs", ".swift", ".groovy", ".php", ".cpp", ".c", ".h", ".m", ".vue", ".svelte", ".astro")):
+        elif lower_path.endswith((".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs", ".py", ".rb", ".rs", ".go", ".java", ".kt", ".scala", ".sql", ".cs", ".swift", ".groovy", ".php", ".cpp", ".cc", ".c", ".h", ".hpp", ".m", ".vue", ".svelte", ".astro")):
             source += lines
         else:
             non_code += lines

--- a/src/rules/advisory.ts
+++ b/src/rules/advisory.ts
@@ -290,7 +290,7 @@ function severityToAnnotationLevel(severity: AdvisorySeverity): CheckRunAnnotati
 }
 
 function isCodePath(path: string): boolean {
-  return /\.(ts|tsx|js|jsx|py|go|rs|java|rb|php|cs|cpp|c|h|swift|kt|m|sql|yaml|yml|json|toml|md|vue|svelte|astro)$/i.test(path);
+  return /\.(ts|tsx|js|jsx|py|go|rs|java|rb|php|cs|cpp|cc|c|h|hpp|swift|kt|m|sql|yaml|yml|json|toml|md|vue|svelte|astro)$/i.test(path);
 }
 
 function collisionClustersForPull(collisions: CollisionReport, pullNumber: number): CollisionCluster[] {

--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -5538,9 +5538,10 @@ function sanitizeOutcomeDimensionKey(key: string): string {
 function isCodeFile(file: string): boolean {
   // Mirrors isCodeFile in local-branch.ts — kept in sync (cs/swift/groovy/php and C/C++/Objective-C added
   // so native/C#/Swift/Groovy/PHP source counts as code, matching the test conventions
-  // isTestPath already recognizes; vue/svelte/astro match rag.ts, visual paths, and isCodePath).
+  // isTestPath already recognizes; vue/svelte/astro match rag.ts, visual paths, and isCodePath;
+  // cc/hpp complete the C++ extension set alongside cpp/c/h).
   return (
-    /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy|php|cpp|c|h|m|vue|svelte|astro)$/i.test(
+    /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy|php|cpp|cc|c|h|hpp|m|vue|svelte|astro)$/i.test(
       file,
     ) && !isTestFile(file)
   );

--- a/src/signals/local-branch.ts
+++ b/src/signals/local-branch.ts
@@ -1272,8 +1272,9 @@ export function isCodeFile(file: string): boolean {
   // count as code too — otherwise a C#/Swift/Groovy/PHP/native source file is neither test
   // nor code in the local scorer. vue/svelte/astro align with review/rag.ts CODE_EXT_RE,
   // review/visual/paths.ts, and rules/advisory.ts isCodePath so every classifier agrees.
+  // cc/hpp round out the C++ set alongside cpp/c/h (rag.ts already indexes all four).
   return (
-    /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy|php|cpp|c|h|m|vue|svelte|astro)$/i.test(
+    /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy|php|cpp|cc|c|h|hpp|m|vue|svelte|astro)$/i.test(
       file,
     ) && !isTestFile(file)
   );

--- a/test/unit/local-branch-file-classifiers.test.ts
+++ b/test/unit/local-branch-file-classifiers.test.ts
@@ -131,6 +131,9 @@ describe("isCodeFile", () => {
       "src/native/add.cpp",
       "include/native/add.h",
       "src/objc/View.m",
+      // Alternate C++ spellings indexed by rag.ts but previously missing here.
+      "native/src/parser.cc",
+      "libs/core/types.hpp",
       // Front-end framework source — already indexed as code by rag.ts and flagged
       // as visual paths, but must count as code for slop/missing-tests signals.
       "src/App.vue",

--- a/test/unit/local-branch.test.ts
+++ b/test/unit/local-branch.test.ts
@@ -1779,6 +1779,11 @@ describe("local MCP git metadata collection", () => {
       expect(isTestFile(file)).toBe(false);
       expect(isCodeFile(file)).toBe(true);
     }
+    // Alternate C++ spellings (.cc/.hpp) must mirror server isCodeFile too.
+    for (const file of ["native/src/parser.cc", "libs/core/types.hpp"]) {
+      expect(isTestFile(file)).toBe(false);
+      expect(isCodeFile(file)).toBe(true);
+    }
   });
 
   it("extracts linked issues only from standalone closing keywords, not keyword substrings", async () => {

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -812,6 +812,27 @@ describe("advisory rules", () => {
     }
   });
 
+  it("flags Missing test evidence for .cc/.hpp C++ source via isCodePath + isCodeFile parity", () => {
+    const advisory = buildPullRequestAdvisory(repo, {
+      repoFullName: repo.fullName, number: 24, title: "Add C++ modules without tests", state: "open",
+      authorLogin: "contributor", authorAssociation: "NONE", labels: [], linkedIssues: [],
+    });
+    const sourcePaths = ["native/src/parser.cc", "libs/core/types.hpp"];
+    const files: PullRequestFileRecord[] = sourcePaths.map((path) => ({
+      repoFullName: repo.fullName, pullNumber: 24, path, additions: 10, deletions: 0, changes: 10, payload: {},
+    }));
+    const collisions: CollisionReport = {
+      repoFullName: repo.fullName, generatedAt: "2026-06-10T00:00:00.000Z",
+      summary: { clusterCount: 0, highRiskCount: 0, itemsReviewed: 0 }, clusters: [],
+    };
+
+    const { annotations } = buildCheckRunAnnotations(advisory, { files, collisions, pullNumber: 24 }, "standard");
+
+    for (const path of sourcePaths) {
+      expect(annotations.some((entry) => entry.title === "Missing test evidence" && entry.path === path)).toBe(true);
+    }
+  });
+
   it("buildCheckRunAnnotations uses notice level for medium-risk collisions and critical public finding text", () => {
     const advisory = {
       ...buildPullRequestAdvisory(repo, null),

--- a/test/unit/score-preview-script.test.ts
+++ b/test/unit/score-preview-script.test.ts
@@ -41,9 +41,11 @@ describe("gittensor-score-preview.mjs classifier parity with the server", () => 
       { path: "src/native/add.c", additions: 2, deletions: 0 },
       { path: "src/native/add.cpp", additions: 3, deletions: 0 },
       { path: "include/native/add.h", additions: 4, deletions: 0 },
+      { path: "native/src/parser.cc", additions: 5, deletions: 0 },
+      { path: "libs/core/types.hpp", additions: 7, deletions: 0 },
       { path: "src/objc/View.m", additions: 6, deletions: 0 },
     ]);
-    expect(out.sourceTokenScore).toBe(25); // src/loader.mts + native source extensions
+    expect(out.sourceTokenScore).toBe(37); // src/loader.mts + native source extensions
     expect(out.testTokenScore).toBe(SAMPLE_TEST_LINES + 7); // cy + pytest + root snapshot + JVM tests
     expect(out.nonCodeTokenScore).toBe(0); // the .mts is no longer misfiled as non-code
   });
@@ -73,6 +75,8 @@ describe("gittensor-score-preview.mjs classifier parity with the server", () => 
       { path: "src/native/add.c", additions: 2, deletions: 0 },
       { path: "src/native/add.cpp", additions: 3, deletions: 0 },
       { path: "include/native/add.h", additions: 4, deletions: 0 },
+      { path: "native/src/parser.cc", additions: 5, deletions: 0 },
+      { path: "libs/core/types.hpp", additions: 7, deletions: 0 },
       { path: "src/objc/View.m", additions: 6, deletions: 0 },
     ];
     const env = { ...process.env };
@@ -80,7 +84,7 @@ describe("gittensor-score-preview.mjs classifier parity with the server", () => 
     const res = spawnSync(python, [scriptPy], { input: JSON.stringify({ changedFiles: nativeFiles }), encoding: "utf8", env });
     expect(res.status, res.stderr).toBe(0);
     const out = JSON.parse(res.stdout);
-    expect(out.sourceTokenScore).toBe(15); // 2 + 3 + 4 + 6
+    expect(out.sourceTokenScore).toBe(27); // 2 + 3 + 4 + 5 + 7 + 6
     expect(out.testTokenScore).toBe(0);
     expect(out.nonCodeTokenScore).toBe(0);
   });
@@ -92,9 +96,11 @@ describe("gittensor-score-preview.mjs classifier parity with the server", () => 
     const upperCaseFiles = [
       { path: "src/native/Foo.C", additions: 2, deletions: 0 },
       { path: "include/native/Foo.H", additions: 4, deletions: 0 },
+      { path: "native/src/Parser.CC", additions: 5, deletions: 0 },
+      { path: "libs/core/Types.HPP", additions: 3, deletions: 0 },
     ];
     const mjs = runPreview(upperCaseFiles);
-    expect(mjs.sourceTokenScore).toBe(6);
+    expect(mjs.sourceTokenScore).toBe(14);
     expect(mjs.nonCodeTokenScore).toBe(0);
 
     const python = findPython();
@@ -104,7 +110,7 @@ describe("gittensor-score-preview.mjs classifier parity with the server", () => 
     const res = spawnSync(python, [scriptPy], { input: JSON.stringify({ changedFiles: upperCaseFiles }), encoding: "utf8", env });
     expect(res.status, res.stderr).toBe(0);
     const py = JSON.parse(res.stdout);
-    expect(py.sourceTokenScore).toBe(6);
+    expect(py.sourceTokenScore).toBe(14);
     expect(py.nonCodeTokenScore).toBe(0);
   });
 


### PR DESCRIPTION
## Summary

The RAG indexer (`review/rag.ts`) already treats `.cc` and `.hpp` as code, but `isCodeFile` and `isCodePath` only recognized `.cpp`, `.c`, and `.h`. PRs touching only `.cc`/`.hpp` native sources could be misclassified as non-code in slop signals, missing-tests checks, and check-run annotations.

This PR extends **both** `isCodeFile` and `isCodePath` (plus MCP score-preview mirrors) to include `.cc` and `.hpp`, following the same all-classifier parity pattern as #3292.

No linked issue — small classifier parity fix with clear product impact.

**Conflict avoidance:** Touches `src/signals/`, `src/rules/advisory.ts`, MCP score-preview mirrors, and unit tests. None of the ten currently open PRs (#3299, #3298, #3297, #3295, #3294, #3291, #3290, #3289, #3281, #3255) modify these paths.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- None skipped. Full `npm run test:ci` and `npm audit --audit-level=moderate` both passed locally on latest `main` (commit cc278278).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — no visible UI change.

## Notes

- Updates `isCodeFile`, `isCodePath`, and MCP mirrors in the same PR so no classifier drifts.
- Regression tests in `rules.test.ts` assert `.cc`/`.hpp` files receive missing-test annotations.
