### PR TITLE
test(scoring): cover pure upstream-constant parsers in scoring/model.ts

### DIFF
--- a/test/unit/scoring-model.test.ts
+++ b/test/unit/scoring-model.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from "vitest";
 import {
-  DEFAULT_SCORING_CONSTANTS,
   detectActiveModel,
   findUnmodeledConstantKeys,
   findUnmodeledUpstreamConstants,
@@ -73,8 +72,8 @@ NOVELTY_BONUS_SCALAR = 3
     expect(detectActiveModel({ SRC_TOK_SATURATION_SCALE: 58 })).toBe("pending_saturation_model");
     expect(
       detectActiveModel({
-        MAX_CODE_DENSITY_MULTIPLIER: DEFAULT_SCORING_CONSTANTS.MAX_CODE_DENSITY_MULTIPLIER,
-        MIN_TOKEN_SCORE_FOR_BASE_SCORE: DEFAULT_SCORING_CONSTANTS.MIN_TOKEN_SCORE_FOR_BASE_SCORE,
+        MAX_CODE_DENSITY_MULTIPLIER: 1.15,
+        MIN_TOKEN_SCORE_FOR_BASE_SCORE: 5,
       }),
     ).toBe("current_density_model");
     expect(detectActiveModel({})).toBe("unknown");

--- a/test/unit/scoring-model.test.ts
+++ b/test/unit/scoring-model.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_SCORING_CONSTANTS,
+  detectActiveModel,
+  findUnmodeledConstantKeys,
+  findUnmodeledUpstreamConstants,
+  isTimeDecayEnabled,
+  parsePythonNumberConstants,
+  SCORING_SNAPSHOT_STALE_MS,
+  scoringSnapshotStalenessWarning,
+} from "../../src/scoring/model";
+
+describe("scoring/model pure exports", () => {
+  it("parsePythonNumberConstants parses underscore separators, exponents, and skips non-matching lines", () => {
+    const knownOnly = parsePythonNumberConstants(`
+# comment line
+ignored = "not a constant"
+MERGED_PR_BASE_SCORE = 1e-9
+CONTRIBUTION_SCORE_FOR_FULL_BONUS = 1_500_000
+SRC_TOK_SATURATION_SCALE = 5.8e1
+`);
+    expect(knownOnly).toEqual({
+      MERGED_PR_BASE_SCORE: 1e-9,
+      CONTRIBUTION_SCORE_FOR_FULL_BONUS: 1_500_000,
+      SRC_TOK_SATURATION_SCALE: 58,
+    });
+
+    const allNames = parsePythonNumberConstants(
+      `
+RATE = 0.000_001
+SCALE = 3.14_15
+VAL = 1_000.000_5
+BARE = .5_0
+CUSTOM = 42
+`,
+      { knownOnly: false },
+    );
+    expect(allNames).toEqual({
+      RATE: 0.000001,
+      SCALE: 3.1415,
+      VAL: 1000.0005,
+      BARE: 0.5,
+      CUSTOM: 42,
+    });
+  });
+
+  it("findUnmodeledConstantKeys excludes modeled and operational constants and sorts results", () => {
+    const allConstants = {
+      MERGED_PR_BASE_SCORE: 25,
+      EMISSION_SHARE_TOLERANCE: 1e-9,
+      DEFAULT_PROGRAMMING_LANGUAGE_WEIGHT: 0.12,
+      ZETA: 1,
+      ALPHA: 2,
+    };
+    expect(findUnmodeledConstantKeys(allConstants)).toEqual(["ALPHA", "ZETA"]);
+    expect(findUnmodeledConstantKeys(allConstants)).not.toContain("MERGED_PR_BASE_SCORE");
+    expect(findUnmodeledConstantKeys(allConstants)).not.toContain("EMISSION_SHARE_TOLERANCE");
+    expect(findUnmodeledConstantKeys(allConstants)).not.toContain("DEFAULT_PROGRAMMING_LANGUAGE_WEIGHT");
+  });
+
+  it("findUnmodeledUpstreamConstants delegates to the parser with knownOnly disabled", () => {
+    expect(
+      findUnmodeledUpstreamConstants(`
+MERGED_PR_BASE_SCORE = 25
+EMISSION_SHARE_TOLERANCE = 1e-9
+DEFAULT_PROGRAMMING_LANGUAGE_WEIGHT = 0.12
+NOVELTY_BONUS_SCALAR = 3
+`),
+    ).toEqual(["NOVELTY_BONUS_SCALAR"]);
+  });
+
+  it("detectActiveModel resolves saturation, density, and unknown branches", () => {
+    expect(detectActiveModel({ SRC_TOK_SATURATION_SCALE: 58 })).toBe("pending_saturation_model");
+    expect(
+      detectActiveModel({
+        MAX_CODE_DENSITY_MULTIPLIER: DEFAULT_SCORING_CONSTANTS.MAX_CODE_DENSITY_MULTIPLIER,
+        MIN_TOKEN_SCORE_FOR_BASE_SCORE: DEFAULT_SCORING_CONSTANTS.MIN_TOKEN_SCORE_FOR_BASE_SCORE,
+      }),
+    ).toBe("current_density_model");
+    expect(detectActiveModel({})).toBe("unknown");
+    expect(
+      detectActiveModel({
+        SRC_TOK_SATURATION_SCALE: 58,
+        MAX_CODE_DENSITY_MULTIPLIER: 1.15,
+        MIN_TOKEN_SCORE_FOR_BASE_SCORE: 5,
+      }),
+    ).toBe("pending_saturation_model");
+  });
+
+  it("scoringSnapshotStalenessWarning is null at the freshness boundary and warns past it", () => {
+    const now = Date.parse("2026-06-21T12:00:00.000Z");
+    const exactlyAtWindow = new Date(now - SCORING_SNAPSHOT_STALE_MS).toISOString();
+    const pastWindow = new Date(now - SCORING_SNAPSHOT_STALE_MS - 1).toISOString();
+
+    expect(scoringSnapshotStalenessWarning({ fetchedAt: exactlyAtWindow }, now)).toBeNull();
+    expect(scoringSnapshotStalenessWarning({ fetchedAt: pastWindow }, now)).toMatch(/stale/i);
+  });
+
+  it("isTimeDecayEnabled accepts explicit truthy tokens and rejects falsey values", () => {
+    const enabled = (value: string) => isTimeDecayEnabled({ SCORING_TIME_DECAY_ENABLED: value } as Env);
+
+    expect(isTimeDecayEnabled({} as Env)).toBe(false);
+    expect(enabled("")).toBe(false);
+    expect(enabled("false")).toBe(false);
+    expect(enabled("no")).toBe(false);
+    expect(enabled("off")).toBe(false);
+
+    expect(enabled("1")).toBe(true);
+    expect(enabled("true")).toBe(true);
+    expect(enabled("TRUE")).toBe(true);
+    expect(enabled("yes")).toBe(true);
+    expect(enabled("YES")).toBe(true);
+    expect(enabled("on")).toBe(true);
+    expect(enabled("ON")).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a focused unit test file for the pure exports in `src/scoring/model.ts` so parser/detector helpers reach dedicated branch coverage independent of fetch paths.

Closes #2091.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npx vitest run test/unit/scoring-model.test.ts`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Full `npm run test:ci` was started locally (~7 min); the new test file passes in isolation. Remaining unchecked boxes will be validated by CI on this PR (test-only diff under `test/**`, no `src/**` changes).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — test-only change.

## Notes

- Covers `parsePythonNumberConstants`, `findUnmodeledConstantKeys`, `findUnmodeledUpstreamConstants`, `detectActiveModel`, `scoringSnapshotStalenessWarning`, and `isTimeDecayEnabled` without exercising network fetch paths.

Made with [Cursor](https://cursor.com)