### PR TITLE
feat(enrichment): detect xAI and Deepgram API keys in secret-scan

### DIFF
--- a/review-enrichment/src/analyzers/secret-scan.ts
+++ b/review-enrichment/src/analyzers/secret-scan.ts
@@ -272,6 +272,18 @@ const RULES: Rule[] = [
     confidence: "high",
   },
   {
+    // xAI API key: `xai-` + base62 body (reject hyphen-continued identifiers).
+    kind: "xai_api_key",
+    re: /\bxai-[A-Za-z0-9]{16,}(?![A-Za-z0-9_-])/,
+    confidence: "high",
+  },
+  {
+    // Deepgram API key: `dg.` + base62 body (reject dot/hyphen-continued identifiers).
+    kind: "deepgram_api_key",
+    re: /\bdg\.[A-Za-z0-9]{20,}(?![A-Za-z0-9_.-])/,
+    confidence: "high",
+  },
+  {
     // Google OAuth 2.0 client secret: `GOCSPX-` + 28 base64url chars.
     kind: "google_oauth_client_secret",
     re: /\bGOCSPX-[A-Za-z0-9_-]{28}\b/,

--- a/review-enrichment/test/secret-scan.test.ts
+++ b/review-enrichment/test/secret-scan.test.ts
@@ -719,6 +719,46 @@ test("scanPatch does not flag truncated fal/W&B keys or identifier continuation"
   );
 });
 
+test("scanPatch flags xAI and Deepgram API keys with high confidence", () => {
+  const fakeXaiKey = "xai-" + "a".repeat(16);
+  const xaiFindings = scanPatch("src/config.ts", hunk([`const xai = "${fakeXaiKey}";`]));
+  assert.equal(xaiFindings.length, 1);
+  assert.equal(xaiFindings[0].kind, "xai_api_key");
+  assert.equal(xaiFindings[0].confidence, "high");
+
+  const fakeDeepgramKey = ["dg.", "b".repeat(20)].join("");
+  const deepgramFindings = scanPatch("src/config.ts", hunk([`const deepgram = "${fakeDeepgramKey}";`]));
+  assert.equal(deepgramFindings.length, 1);
+  assert.equal(deepgramFindings[0].kind, "deepgram_api_key");
+  assert.equal(deepgramFindings[0].confidence, "high");
+});
+
+test("scanPatch does not flag truncated xAI/Deepgram keys or identifier continuation", () => {
+  assert.equal(scanPatch("src/config.ts", hunk([`const xai = "xai-${"a".repeat(15)}";`])).length, 0);
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const xai = "xai-${"a".repeat(16)}_suffix";`])).some((f) => f.kind === "xai_api_key"),
+    false,
+  );
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const xai = "xai-${"a".repeat(16)}-suffix";`])).some((f) => f.kind === "xai_api_key"),
+    false,
+  );
+
+  assert.equal(scanPatch("src/config.ts", hunk([`const deepgram = "dg.${"b".repeat(19)}";`])).length, 0);
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const deepgram = "dg.${"b".repeat(20)}_suffix";`])).some((f) => f.kind === "deepgram_api_key"),
+    false,
+  );
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const deepgram = "dg.${"b".repeat(20)}-suffix";`])).some((f) => f.kind === "deepgram_api_key"),
+    false,
+  );
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const deepgram = "dg.${"b".repeat(20)}.suffix";`])).some((f) => f.kind === "deepgram_api_key"),
+    false,
+  );
+});
+
 test("scanPatch flags additional high-confidence SaaS/cloud/CI credential formats", () => {
   const cases = [
     ["google_oauth_client_secret", "GOCSPX-" + b62(28)],


### PR DESCRIPTION
## Summary
- Add `xai_api_key` rule for xAI keys (`xai-` prefix).
- Add `deepgram_api_key` rule for Deepgram keys (`dg.` prefix).
- Include positive, truncation, and hyphen/dot/underscore continuation negative tests.

## Test plan
- [x] `npm run build && node --test test/secret-scan.test.ts` in `review-enrichment/` (78 passing)

Made with [Cursor](https://cursor.com)