### PR TITLE
feat(signals): recognize CMake/Meson/Bazel files as config

### DIFF
--- a/src/signals/path-matchers.ts
+++ b/src/signals/path-matchers.ts
@@ -264,6 +264,11 @@ const CONFIG_FILE_NAMES: ReadonlySet<string> = new Set([
   "azure-pipelines.yml",
   "buf.yaml",
   "buf.gen.yaml",
+  // Native/C++ build system definitions (siblings to Makefile/Dockerfile above).
+  "cmakelists.txt",
+  "meson.build",
+  "build.bazel",
+  "module.bazel",
 ]);
 
 // Filename prefixes that identify build, lint, test-runner, and environment config files.

--- a/test/unit/path-matchers.test.ts
+++ b/test/unit/path-matchers.test.ts
@@ -320,6 +320,10 @@ describe("isConfigFile", () => {
       ".github/workflows/ci.yml",
       ".github/workflows/release.yaml",
       ".circleci/config.yml",
+      "native/CMakeLists.txt",
+      "libs/core/meson.build",
+      "services/api/BUILD.bazel",
+      "MODULE.bazel",
     ]) {
       expect(isConfigFile(path)).toBe(true);
     }
@@ -410,6 +414,10 @@ describe("classifyChangedFile", () => {
       ["skaffold.yaml", "config"],
       ["Earthfile", "config"],
       ["Procfile", "config"],
+      ["native/CMakeLists.txt", "config"],
+      ["libs/meson.build", "config"],
+      ["services/BUILD.bazel", "config"],
+      ["MODULE.bazel", "config"],
       [".codecov.yml", "config"],
       ["codecov.yml", "config"],
       ["codecov.yaml", "config"],


### PR DESCRIPTION
## Summary

Native build definitions (`CMakeLists.txt`, `meson.build`, `BUILD.bazel`, `MODULE.bazel`) were not recognized by `isConfigFile` / `classifyChangedFile`, so PRs that only touched native build metadata could be miscounted as substantive source effort in slop signals.

This PR adds those basenames to `CONFIG_FILE_NAMES` in `path-matchers.ts`, alongside existing entries like `Makefile` and `Dockerfile`.

No linked issue — small slop-classifier improvement with clear product impact.

**Conflict avoidance:** Touches only `src/signals/path-matchers.ts` and `test/unit/path-matchers.test.ts`. None of the ten currently open PRs (#3306, #3305, #3304, #3303, #3298, #3295, #3290, #3289, #3281, #3255) modify these paths — including #3304 which edits `engine.ts` but not `path-matchers.ts`.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- None skipped. Full `npm run test:ci` and `npm audit --audit-level=moderate` both passed locally on latest `main` (commit 14c00f99).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — no visible UI change.

## Notes

- Basenames are matched case-insensitively via the existing `normalizeForMatch` lowercasing (`CMakeLists.txt` → `cmakelists.txt`).
- `classifyChangedFile` regression cases cover all four new build-system filenames.
