### PR TITLE
fix(selfhost): stop logging routine maintenance-admission backpressure as a warning

### DIFF
--- a/grafana/dashboards/gittensory.json
+++ b/grafana/dashboards/gittensory.json
@@ -2433,8 +2433,35 @@
       ]
     },
     {
+      "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "lineWidth": 2, "fillOpacity": 10 },
+          "unit": "ops"
+        }
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 157 },
+      "id": 158,
+      "options": {
+        "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" },
+        "tooltip": { "mode": "multi", "sort": "desc" }
+      },
+      "title": "Maintenance Admission Deferrals (total)",
+      "description": "Aggregate rate of maintenance jobs deferred by admission gating, regardless of reason -- routine backpressure behavior logged at info level, not an error. Break down by reason in 'Maintenance Admission Deferrals by Reason' above.",
+      "type": "timeseries",
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
+          "expr": "sum(rate(gittensory_jobs_maintenance_admission_deferred_total[5m])) or vector(0)",
+          "legendFormat": "deferred",
+          "refId": "A"
+        }
+      ]
+    },
+    {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 157 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 165 },
       "id": 138,
       "title": "Self-Host Runtime Drift Signals",
       "type": "row"
@@ -2454,7 +2481,7 @@
           "unit": "short"
         }
       },
-      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 158 },
+      "gridPos": { "h": 4, "w": 6, "x": 0, "y": 166 },
       "id": 139,
       "options": {
         "colorMode": "background",
@@ -2489,7 +2516,7 @@
           "unit": "short"
         }
       },
-      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 158 },
+      "gridPos": { "h": 4, "w": 6, "x": 6, "y": 166 },
       "id": 140,
       "options": {
         "colorMode": "background",
@@ -2524,7 +2551,7 @@
           "unit": "short"
         }
       },
-      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 158 },
+      "gridPos": { "h": 4, "w": 6, "x": 12, "y": 166 },
       "id": 141,
       "options": {
         "colorMode": "background",
@@ -2559,7 +2586,7 @@
           "unit": "short"
         }
       },
-      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 158 },
+      "gridPos": { "h": 4, "w": 6, "x": 18, "y": 166 },
       "id": 142,
       "options": {
         "colorMode": "background",
@@ -2588,7 +2615,7 @@
           "unit": "ops"
         }
       },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 162 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 170 },
       "id": 143,
       "options": {
         "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" },
@@ -2620,7 +2647,7 @@
           "unit": "ops"
         }
       },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 162 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 170 },
       "id": 144,
       "options": {
         "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" },
@@ -2639,7 +2666,7 @@
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 171 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 179 },
       "id": 145,
       "panels": [],
       "title": "Foreground Liveness (#selfhost-queue-liveness)",
@@ -2648,7 +2675,7 @@
     {
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "unit": "short" } },
-      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 172 },
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 180 },
       "id": 146,
       "options": {
         "colorMode": "background",
@@ -2671,7 +2698,7 @@
     {
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "unit": "short" } },
-      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 172 },
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 180 },
       "id": 147,
       "options": {
         "colorMode": "background",
@@ -2694,7 +2721,7 @@
     {
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "unit": "short" } },
-      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 172 },
+      "gridPos": { "h": 4, "w": 4, "x": 8, "y": 180 },
       "id": 148,
       "options": {
         "colorMode": "background",
@@ -2730,7 +2757,7 @@
           "unit": "s"
         }
       },
-      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 172 },
+      "gridPos": { "h": 4, "w": 4, "x": 12, "y": 180 },
       "id": 149,
       "options": {
         "colorMode": "background",
@@ -2753,7 +2780,7 @@
     {
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "fieldConfig": { "defaults": { "color": { "mode": "thresholds" }, "unit": "short" } },
-      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 172 },
+      "gridPos": { "h": 4, "w": 4, "x": 16, "y": 180 },
       "id": 150,
       "options": {
         "colorMode": "background",
@@ -2778,7 +2805,7 @@
       "fieldConfig": {
         "defaults": { "color": { "mode": "palette-classic" }, "custom": { "lineWidth": 2, "fillOpacity": 10 }, "unit": "short" }
       },
-      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 176 },
+      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 184 },
       "id": 151,
       "options": {
         "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" },
@@ -2797,7 +2824,7 @@
     },
     {
       "collapsed": false,
-      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 182 },
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 190 },
       "id": 152,
       "title": "Backlog-vs-Fresh-Intake Lane Fairness (#selfhost-lane-observability)",
       "type": "row"
@@ -2818,7 +2845,7 @@
           "unit": "short"
         }
       },
-      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 183 },
+      "gridPos": { "h": 4, "w": 4, "x": 0, "y": 191 },
       "id": 153,
       "options": {
         "colorMode": "background",
@@ -2854,7 +2881,7 @@
           "unit": "short"
         }
       },
-      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 183 },
+      "gridPos": { "h": 4, "w": 4, "x": 4, "y": 191 },
       "id": 154,
       "options": {
         "colorMode": "background",
@@ -2879,7 +2906,7 @@
       "fieldConfig": {
         "defaults": { "color": { "mode": "palette-classic" }, "custom": { "lineWidth": 2, "fillOpacity": 10 }, "unit": "short" }
       },
-      "gridPos": { "h": 6, "w": 16, "x": 8, "y": 183 },
+      "gridPos": { "h": 6, "w": 16, "x": 8, "y": 191 },
       "id": 155,
       "options": {
         "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" },
@@ -2902,7 +2929,7 @@
       "fieldConfig": {
         "defaults": { "color": { "mode": "palette-classic" }, "custom": { "lineWidth": 2, "fillOpacity": 10 }, "unit": "ops" }
       },
-      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 189 },
+      "gridPos": { "h": 6, "w": 12, "x": 0, "y": 197 },
       "id": 156,
       "options": {
         "legend": { "calcs": ["lastNotNull"], "displayMode": "table", "placement": "bottom" },
@@ -2922,7 +2949,7 @@
     {
       "datasource": { "type": "prometheus", "uid": "${DS_PROMETHEUS}" },
       "fieldConfig": { "defaults": { "unit": "short" } },
-      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 189 },
+      "gridPos": { "h": 6, "w": 12, "x": 12, "y": 197 },
       "id": 157,
       "options": {
         "showHeader": true,

--- a/src/selfhost/pg-queue.ts
+++ b/src/selfhost/pg-queue.ts
@@ -1195,9 +1195,9 @@ export function createPgQueue(
                   reason: decision.reason,
                   job_type: message.type,
                 });
-                console.warn(
+                console.log(
                   JSON.stringify({
-                    level: "warn",
+                    level: "info",
                     event: "selfhost_queue_maintenance_admission_deferred",
                     jobType: message.type,
                     reason: decision.reason,

--- a/src/selfhost/sqlite-queue.ts
+++ b/src/selfhost/sqlite-queue.ts
@@ -924,9 +924,9 @@ export function createSqliteQueue(
                   reason: decision.reason,
                   job_type: message.type,
                 });
-                console.warn(
+                console.log(
                   JSON.stringify({
-                    level: "warn",
+                    level: "info",
                     event: "selfhost_queue_maintenance_admission_deferred",
                     jobType: message.type,
                     reason: decision.reason,

--- a/test/unit/selfhost-grafana-dashboard.test.ts
+++ b/test/unit/selfhost-grafana-dashboard.test.ts
@@ -151,6 +151,22 @@ describe("Gittensory Self-Host Grafana dashboard", () => {
     expect(alerts).toContain('time() - gittensory_backup_latest_timestamp_seconds{target=~"postgres|sqlite"} > 93600');
   });
 
+  it("surfaces a Maintenance Admission Deferrals (total) panel alongside the by-reason breakdown", () => {
+    const dashboard = readDashboard(selfhostDashboardPath);
+    const targets = dashboard.panels.flatMap((panel) => panel.targets ?? []);
+    const titles = dashboard.panels.map((panel) => panel.title);
+
+    expect(titles).toEqual(
+      expect.arrayContaining([
+        "Runtime Pressure & Maintenance",
+        "Maintenance Admission Deferrals by Reason",
+        "Maintenance Admission Deferrals (total)",
+      ]),
+    );
+    expect(targets.some((target) => target.expr === "sum by (reason, job_type) (rate(gittensory_jobs_maintenance_admission_deferred_by_reason_total[5m])) or vector(0)")).toBe(true);
+    expect(targets.some((target) => target.expr === "sum(rate(gittensory_jobs_maintenance_admission_deferred_total[5m])) or vector(0)")).toBe(true);
+  });
+
   it("surfaces self-host runtime-drift signal panels, every counter query fleet-aggregated", () => {
     const dashboard = readDashboard(selfhostDashboardPath);
     const targets = dashboard.panels.flatMap((panel) => panel.targets ?? []);

--- a/test/unit/selfhost-pg-queue.test.ts
+++ b/test/unit/selfhost-pg-queue.test.ts
@@ -3209,6 +3209,27 @@ describe("createPgQueue (durable #977)", () => {
       );
     });
 
+    it("logs a deferred maintenance admission at info level, not warn (#selfhost-backpressure-noise)", async () => {
+      const m = makePool();
+      m.setPressureSignals({ live: { cnt: 6, oldest: now } }); // default threshold is 5
+      m.enqueueResult({ rows: [], rowCount: 0 }); // empty foreground claim
+      m.enqueueResult({ rows: [maintenanceRow], rowCount: 1 }); // background claim
+      const logged = vi.spyOn(console, "log").mockImplementation(() => undefined);
+      const warned = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+      const q = createPgQueue(m.pool, async () => undefined);
+      await q.drain();
+
+      expect(warned).not.toHaveBeenCalled();
+      expect(logged).toHaveBeenCalledWith(
+        expect.stringContaining('"event":"selfhost_queue_maintenance_admission_deferred"'),
+      );
+      expect(JSON.parse(logged.mock.calls.at(-1)?.[0] as string)).toMatchObject({
+        level: "info",
+        event: "selfhost_queue_maintenance_admission_deferred",
+        reason: "live_pending_high",
+      });
+    });
+
     it("admits a maintenance job immediately when pressure is clear", async () => {
       const m = makePool();
       m.enqueueResult({ rows: [], rowCount: 0 }); // empty foreground claim

--- a/test/unit/selfhost-sqlite-queue.test.ts
+++ b/test/unit/selfhost-sqlite-queue.test.ts
@@ -3326,6 +3326,26 @@ describe("createSqliteQueue (durable #980)", () => {
       );
     });
 
+    it("logs a deferred maintenance admission at info level, not warn (#selfhost-backpressure-noise)", async () => {
+      const driver = makeDriver();
+      const logged = vi.spyOn(console, "log").mockImplementation(() => undefined);
+      const warned = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+      const q = createSqliteQueue(driver, async () => undefined);
+      seedLiveRows(driver, 6); // default threshold is 5
+      await q.binding.send(msg("build-contributor-evidence"));
+      await q.drain();
+
+      expect(warned).not.toHaveBeenCalled();
+      expect(logged).toHaveBeenCalledWith(
+        expect.stringContaining('"event":"selfhost_queue_maintenance_admission_deferred"'),
+      );
+      expect(JSON.parse(logged.mock.calls.at(-1)?.[0] as string)).toMatchObject({
+        level: "info",
+        event: "selfhost_queue_maintenance_admission_deferred",
+        reason: "live_pending_high",
+      });
+    });
+
     it("admits a maintenance job immediately when pressure is clear", async () => {
       const driver = makeDriver();
       const started: string[] = [];


### PR DESCRIPTION
## Summary

- `selfhost_queue_maintenance_admission_deferred` was logged at `console.warn` / `level: "warn"` in both the SQLite (`src/selfhost/sqlite-queue.ts`) and Postgres (`src/selfhost/pg-queue.ts`) queue drivers, even though it fires on ordinary, expected backpressure -- a maintenance-lane job getting pushed back because the live/maintenance/backlog lanes or host load are busy. That's routine steady-state behavior, not something worth flagging at warn severity next to real failures, so operators grepping warn-level logs see noise from a well-functioning system. This PR downgrades both call sites to `console.log` / `level: "info"`, matching how other routine/expected events in this codebase are leveled (e.g. `check_run_cross_app_repost` in `src/github/app.ts`, and the un-leveled `console.log` backfill/recovery events in `sqlite-queue.ts`). The metric-recording lines directly above each log call (`gittensory_jobs_maintenance_admission_deferred_total` and `gittensory_jobs_maintenance_admission_deferred_by_reason_total`) are untouched -- no new metric was needed, both already exist and are already asserted in the unit suites.
- **Confirmed clarification, not a dashboard bug fix:** the "Errors & failures" Loki panel (`grafana/dashboards/gittensory.json`) filters on a populated top-level JSON field literally named `error` (`| json eventf="event", errf="error" | errf != ""`). This log line never sets an `error` field -- only `event`/`jobType`/`reason`/`retry_after_ms` -- so it never actually matched that panel, even while it sat at warn. That panel was not polluted and is not being changed for that reason; the log-level change is about the log's own severity being wrong for raw log inspection (journalctl/docker logs/any warn-level grep), independent of that panel.
- Added a "Maintenance Admission Deferrals (total)" timeseries panel in the existing "Runtime Pressure & Maintenance" dashboard section, right next to "Maintenance Admission Deferrals by Reason", so the aggregate `gittensory_jobs_maintenance_admission_deferred_total` rate is visible alongside the by-reason breakdown that already existed. No new metric was added -- both panels chart counters the queue drivers already record.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed. (No issue linked -- this is a small, self-evident log-level fix plus a matching dashboard panel, in line with this repo's `preferred` linked-issue policy.)

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

Ran the full local gate via `npm run test:ci` (aggregates all of the above plus `db:migrations:check`, `test:coverage` unsharded, `ui:test`, `ui:openapi`, and more) -- fully green, plus `npm audit --audit-level=moderate` clean. Also confirmed via `npm run ui:openapi:check` and `npm run cf-typegen:check` that neither generated artifact needed regeneration (no API/schema or wrangler binding changes here), and `npm run db:migrations:check` confirms no DB migration was needed.

Added a targeted regression test in each of `test/unit/selfhost-sqlite-queue.test.ts` and `test/unit/selfhost-pg-queue.test.ts` that spies on `console.log`/`console.warn` and asserts the deferred-admission event is emitted at `level: "info"` via `console.log` and never via `console.warn`. Added a test in `test/unit/selfhost-grafana-dashboard.test.ts` asserting both the by-reason panel and the new total-deferrals panel are present with their expected PromQL expressions.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A -- no auth/cookie/CORS/session surface touched.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A -- no API/OpenAPI/MCP surface touched.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A -- no `apps/gittensory-ui` change; this is a Grafana dashboard JSON + backend log level.)
- [x] Visible UI changes include a `UI Evidence` section below with screenshots. (N/A -- this changes a Grafana dashboard definition file and a backend log statement, not the product UI; no screenshot evidence applies.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (No changelog edit in this PR.)

## Notes

- Both driver implementations (`sqlite-queue.ts` and `pg-queue.ts`) are parallel queue backends implementing the same admission logic, so the log-level change was made identically in both, mirroring the existing pattern where both files carry duplicated logging/metric blocks for the same events.
