### PR TITLE
fix(signals): classify Dart source across all code classifiers

### DIFF
--- a/packages/gittensory-mcp/lib/local-branch.js
+++ b/packages/gittensory-mcp/lib/local-branch.js
@@ -610,7 +610,7 @@ export function isTestFile(file) {
 }
 
 export function isCodeFile(file) {
-  return /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy|php|cpp|cc|c|h|hpp|m|vue|svelte|astro)$/i.test(file) && !isTestFile(file);
+  return /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy|php|cpp|cc|c|h|hpp|m|vue|svelte|astro|dart)$/i.test(file) && !isTestFile(file);
 }
 
 function numberValue(value) {

--- a/packages/gittensory-mcp/scripts/gittensor-score-preview.mjs
+++ b/packages/gittensory-mcp/scripts/gittensor-score-preview.mjs
@@ -19,7 +19,7 @@ function isTestFile(file) {
 }
 
 function isCodeFile(file) {
-  return /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy|php|cpp|cc|c|h|hpp|m|vue|svelte|astro)$/i.test(file) && !isTestFile(file);
+  return /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy|php|cpp|cc|c|h|hpp|m|vue|svelte|astro|dart)$/i.test(file) && !isTestFile(file);
 }
 
 function lineCount(file) {

--- a/packages/gittensory-mcp/scripts/gittensor-score-preview.py
+++ b/packages/gittensory-mcp/scripts/gittensor-score-preview.py
@@ -142,7 +142,7 @@ def metadata_fallback(metadata: dict) -> dict:
         lines = max(int(entry.get("additions") or 0) + int(entry.get("deletions") or 0), 0)
         if is_test_file(path):
             tests += lines
-        elif lower_path.endswith((".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs", ".py", ".rb", ".rs", ".go", ".java", ".kt", ".scala", ".sql", ".cs", ".swift", ".groovy", ".php", ".cpp", ".cc", ".c", ".h", ".hpp", ".m", ".vue", ".svelte", ".astro")):
+        elif lower_path.endswith((".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs", ".py", ".rb", ".rs", ".go", ".java", ".kt", ".scala", ".sql", ".cs", ".swift", ".groovy", ".php", ".cpp", ".cc", ".c", ".h", ".hpp", ".m", ".vue", ".svelte", ".astro", ".dart")):
             source += lines
         else:
             non_code += lines

--- a/src/rules/advisory.ts
+++ b/src/rules/advisory.ts
@@ -290,7 +290,7 @@ function severityToAnnotationLevel(severity: AdvisorySeverity): CheckRunAnnotati
 }
 
 function isCodePath(path: string): boolean {
-  return /\.(ts|tsx|js|jsx|py|go|rs|java|rb|php|cs|cpp|cc|c|h|hpp|swift|kt|m|sql|yaml|yml|json|toml|md|vue|svelte|astro)$/i.test(path);
+  return /\.(ts|tsx|js|jsx|py|go|rs|java|rb|php|cs|cpp|cc|c|h|hpp|swift|kt|m|sql|yaml|yml|json|toml|md|vue|svelte|astro|dart)$/i.test(path);
 }
 
 function collisionClustersForPull(collisions: CollisionReport, pullNumber: number): CollisionCluster[] {

--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -5539,9 +5539,10 @@ function isCodeFile(file: string): boolean {
   // Mirrors isCodeFile in local-branch.ts — kept in sync (cs/swift/groovy/php and C/C++/Objective-C added
   // so native/C#/Swift/Groovy/PHP source counts as code, matching the test conventions
   // isTestPath already recognizes; vue/svelte/astro match rag.ts, visual paths, and isCodePath;
-  // cc/hpp complete the C++ extension set alongside cpp/c/h).
+  // cc/hpp complete the C++ extension set alongside cpp/c/h; dart matches rag.ts and
+  // test-evidence's *_test.dart test convention).
   return (
-    /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy|php|cpp|cc|c|h|hpp|m|vue|svelte|astro)$/i.test(
+    /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy|php|cpp|cc|c|h|hpp|m|vue|svelte|astro|dart)$/i.test(
       file,
     ) && !isTestFile(file)
   );

--- a/src/signals/local-branch.ts
+++ b/src/signals/local-branch.ts
@@ -1273,8 +1273,10 @@ export function isCodeFile(file: string): boolean {
   // nor code in the local scorer. vue/svelte/astro align with review/rag.ts CODE_EXT_RE,
   // review/visual/paths.ts, and rules/advisory.ts isCodePath so every classifier agrees.
   // cc/hpp round out the C++ set alongside cpp/c/h (rag.ts already indexes all four).
+  // dart aligns with rag.ts and test-evidence's *_test.dart convention (hand-authored
+  // .dart is source; generated .g.dart/.freezed.dart stay non-code via isGeneratedFile).
   return (
-    /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy|php|cpp|cc|c|h|hpp|m|vue|svelte|astro)$/i.test(
+    /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy|php|cpp|cc|c|h|hpp|m|vue|svelte|astro|dart)$/i.test(
       file,
     ) && !isTestFile(file)
   );

--- a/test/unit/local-branch-file-classifiers.test.ts
+++ b/test/unit/local-branch-file-classifiers.test.ts
@@ -139,6 +139,9 @@ describe("isCodeFile", () => {
       "src/App.vue",
       "src/Widget.svelte",
       "src/pages/index.astro",
+      // Dart/Flutter hand-authored source — rag.ts indexes .dart; *_test.dart stays test.
+      "lib/models/user.dart",
+      "lib/widgets/card.dart",
     ]) {
       expect(isCodeFile(path)).toBe(true);
     }
@@ -160,6 +163,8 @@ describe("isCodeFile", () => {
       "AppTests/LoginTests.swift",
       // PHP class-suffix test file (PHPUnit) — code extension, but a test, not code.
       "app/Service/PaymentTest.php",
+      // Dart co-located *_test.dart is test evidence, not source.
+      "lib/models/user_test.dart",
     ]) {
       expect(isCodeFile(path)).toBe(false);
     }

--- a/test/unit/local-branch.test.ts
+++ b/test/unit/local-branch.test.ts
@@ -1784,6 +1784,10 @@ describe("local MCP git metadata collection", () => {
       expect(isTestFile(file)).toBe(false);
       expect(isCodeFile(file)).toBe(true);
     }
+    // Dart/Flutter hand-authored source; *_test.dart remains test-only.
+    expect(isCodeFile("lib/models/user.dart")).toBe(true);
+    expect(isTestFile("lib/models/user_test.dart")).toBe(true);
+    expect(isCodeFile("lib/models/user_test.dart")).toBe(false);
   });
 
   it("extracts linked issues only from standalone closing keywords, not keyword substrings", async () => {

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -833,6 +833,27 @@ describe("advisory rules", () => {
     }
   });
 
+  it("flags Missing test evidence for Dart source via isCodePath + isCodeFile parity", () => {
+    const advisory = buildPullRequestAdvisory(repo, {
+      repoFullName: repo.fullName, number: 25, title: "Add Dart widget without tests", state: "open",
+      authorLogin: "contributor", authorAssociation: "NONE", labels: [], linkedIssues: [],
+    });
+    const sourcePaths = ["lib/models/user.dart", "lib/widgets/card.dart"];
+    const files: PullRequestFileRecord[] = sourcePaths.map((path) => ({
+      repoFullName: repo.fullName, pullNumber: 25, path, additions: 10, deletions: 0, changes: 10, payload: {},
+    }));
+    const collisions: CollisionReport = {
+      repoFullName: repo.fullName, generatedAt: "2026-06-10T00:00:00.000Z",
+      summary: { clusterCount: 0, highRiskCount: 0, itemsReviewed: 0 }, clusters: [],
+    };
+
+    const { annotations } = buildCheckRunAnnotations(advisory, { files, collisions, pullNumber: 25 }, "standard");
+
+    for (const path of sourcePaths) {
+      expect(annotations.some((entry) => entry.title === "Missing test evidence" && entry.path === path)).toBe(true);
+    }
+  });
+
   it("buildCheckRunAnnotations uses notice level for medium-risk collisions and critical public finding text", () => {
     const advisory = {
       ...buildPullRequestAdvisory(repo, null),

--- a/test/unit/score-preview-script.test.ts
+++ b/test/unit/score-preview-script.test.ts
@@ -114,17 +114,17 @@ describe("gittensor-score-preview.mjs classifier parity with the server", () => 
     expect(py.nonCodeTokenScore).toBe(0);
   });
 
-  it("classifies Dart/Flutter *_test.dart as a test in both .mjs and .py previews", () => {
+  it("classifies Dart/Flutter source and *_test.dart tests in both .mjs and .py previews", () => {
     // Parity with src/signals/test-evidence.ts: co-located `foo_test.dart` must count as test evidence,
-    // not source/non-code, in every mirrored classifier.
+    // while hand-authored `.dart` source counts as code (rag.ts already indexes .dart).
     const files = [
       { path: "lib/models/user_test.dart", additions: 8, deletions: 0 },
-      { path: "lib/models/user.dart", additions: 3, deletions: 0 }, // non-code (dart not in isCodeFile)
+      { path: "lib/models/user.dart", additions: 3, deletions: 0 },
     ];
     const mjs = runPreview(files);
     expect(mjs.testTokenScore).toBe(8);
-    expect(mjs.sourceTokenScore).toBe(0);
-    expect(mjs.nonCodeTokenScore).toBe(3);
+    expect(mjs.sourceTokenScore).toBe(3);
+    expect(mjs.nonCodeTokenScore).toBe(0);
 
     const python = findPython();
     if (!python) return;
@@ -134,8 +134,8 @@ describe("gittensor-score-preview.mjs classifier parity with the server", () => 
     expect(res.status, res.stderr).toBe(0);
     const py = JSON.parse(res.stdout);
     expect(py.testTokenScore).toBe(8);
-    expect(py.sourceTokenScore).toBe(0);
-    expect(py.nonCodeTokenScore).toBe(3);
+    expect(py.sourceTokenScore).toBe(3);
+    expect(py.nonCodeTokenScore).toBe(0);
   });
 
   it("classifies Vue/Svelte/Astro source as code in both .mjs and .py previews", () => {


### PR DESCRIPTION
## Summary

Dart/Flutter hand-authored source (`.dart`) is already indexed as code by `review/rag.ts` and `test-evidence.ts` recognizes co-located `*_test.dart` files, but `isCodeFile` and `isCodePath` did not recognize `.dart`. Flutter-only PRs could be misclassified as non-code in slop signals, missing-tests checks, and check-run annotations.

This PR extends **both** `isCodeFile` and `isCodePath` (plus MCP score-preview mirrors), following the all-classifier parity pattern from #3292 and #3301. Generated Dart (`.g.dart`, `.freezed.dart`, `.gr.dart`) remains non-code via `isGeneratedFile`.

No linked issue — classifier parity fix with clear product impact.

**Conflict avoidance:** Touches `src/signals/local-branch.ts`, `src/signals/engine.ts` (only the `isCodeFile` mirror at ~L5538), `src/rules/advisory.ts`, MCP mirrors, and unit tests. Open PR #3304 also edits `engine.ts` but only around imports (~L29) and unrelated helpers (~L5012) — disjoint hunks, so this should merge cleanly after #3304 lands without rebase. Does not touch `test-evidence.ts` (which #3304 modifies). No other open PR overlaps these paths.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- None skipped. Full `npm run test:ci` and `npm audit --audit-level=moderate` both passed locally on latest `main` (commit 1e9284b0).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — no visible UI change.

## Notes

- Updates `isCodeFile`, `isCodePath`, and MCP mirrors in the same PR.
- `rules.test.ts` regression asserts `.dart` files receive missing-test annotations.
- `*_test.dart` remains classified as test, not source.
