### PR TITLE
feat(enrichment): detect Baseten federated and Laminar API keys

### DIFF
--- a/review-enrichment/src/analyzers/secret-scan.ts
+++ b/review-enrichment/src/analyzers/secret-scan.ts
@@ -296,6 +296,18 @@ const RULES: Rule[] = [
     confidence: "high",
   },
   {
+    // Baseten federated API key: `sky_{prefix}.{secret}` (prefix is 9-16 chars after `sky_`).
+    kind: "baseten_federated_api_key",
+    re: /\bsky_[A-Za-z0-9]{9,16}\.[A-Za-z0-9+/=_-]{20,}(?![A-Za-z0-9+/=_.-])/,
+    confidence: "high",
+  },
+  {
+    // Laminar project API key: `lmnr_` + base62 body.
+    kind: "laminar_api_key",
+    re: /\blmnr_[A-Za-z0-9]{20,}(?![A-Za-z0-9_-])/,
+    confidence: "high",
+  },
+  {
     // Google OAuth 2.0 client secret: `GOCSPX-` + 28 base64url chars.
     kind: "google_oauth_client_secret",
     re: /\bGOCSPX-[A-Za-z0-9_-]{28}\b/,

--- a/review-enrichment/test/secret-scan.test.ts
+++ b/review-enrichment/test/secret-scan.test.ts
@@ -802,6 +802,55 @@ test("scanPatch does not flag truncated Cartesia/Apify tokens or identifier cont
   );
 });
 
+test("scanPatch flags Baseten federated and Laminar API keys with high confidence", () => {
+  const fakeBasetenKey = ["sky_", "sCqhBwEy4kPd", ".", "a".repeat(20)].join("");
+  const basetenFindings = scanPatch("src/config.ts", hunk([`const baseten = "${fakeBasetenKey}";`]));
+  assert.equal(basetenFindings.length, 1);
+  assert.equal(basetenFindings[0].kind, "baseten_federated_api_key");
+  assert.equal(basetenFindings[0].confidence, "high");
+
+  for (const prefixLen of [9, 16]) {
+    const boundaryKey = ["sky_", "a".repeat(prefixLen), ".", "b".repeat(20)].join("");
+    const boundaryFindings = scanPatch("src/config.ts", hunk([`const baseten = "${boundaryKey}";`]));
+    assert.equal(boundaryFindings.length, 1, `expected match for ${prefixLen}-char Baseten prefix`);
+    assert.equal(boundaryFindings[0].kind, "baseten_federated_api_key");
+  }
+
+  const fakeLaminarKey = "lmnr_" + "b".repeat(20);
+  const laminarFindings = scanPatch("src/config.ts", hunk([`const laminar = "${fakeLaminarKey}";`]));
+  assert.equal(laminarFindings.length, 1);
+  assert.equal(laminarFindings[0].kind, "laminar_api_key");
+  assert.equal(laminarFindings[0].confidence, "high");
+});
+
+test("scanPatch does not flag truncated Baseten/Laminar keys or identifier continuation", () => {
+  for (const prefixLen of [8, 17]) {
+    const shortPrefixKey = ["sky_", "a".repeat(prefixLen), ".", "b".repeat(20)].join("");
+    assert.equal(
+      scanPatch("src/config.ts", hunk([`const baseten = "${shortPrefixKey}";`])).some((f) => f.kind === "baseten_federated_api_key"),
+      false,
+      `expected no match for ${prefixLen}-char Baseten prefix`,
+    );
+  }
+  const shortBasetenSecret = ["sky_", "sCqhBwEy4kPd", ".", "a".repeat(19)].join("");
+  assert.equal(scanPatch("src/config.ts", hunk([`const baseten = "${shortBasetenSecret}";`])).length, 0);
+  const basetenDotSuffix = ["sky_", "sCqhBwEy4kPd", ".", "a".repeat(20), ".suffix"].join("");
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const baseten = "${basetenDotSuffix}";`])).some((f) => f.kind === "baseten_federated_api_key"),
+    false,
+  );
+
+  assert.equal(scanPatch("src/config.ts", hunk([`const laminar = "lmnr_${"b".repeat(19)}";`])).length, 0);
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const laminar = "lmnr_${"b".repeat(20)}_suffix";`])).some((f) => f.kind === "laminar_api_key"),
+    false,
+  );
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const laminar = "lmnr_${"b".repeat(20)}-suffix";`])).some((f) => f.kind === "laminar_api_key"),
+    false,
+  );
+});
+
 test("scanPatch flags additional high-confidence SaaS/cloud/CI credential formats", () => {
   const cases = [
     ["google_oauth_client_secret", "GOCSPX-" + b62(28)],


### PR DESCRIPTION
## Summary
- Add `baseten_federated_api_key` rule for Baseten `sky_{prefix}.{secret}` federated API keys (9–16 char prefix after `sky_`)
- Add `laminar_api_key` rule for Laminar `lmnr_` project tokens
- Include positive, prefix boundary (8/9/16/17), truncation, and identifier-continuation negative tests

## Test plan
- [x] `cd review-enrichment && npm run build && node --test test/secret-scan.test.ts` (82 passing)


Made with [Cursor](https://cursor.com)