### PR TITLE
feat(enrichment): detect Exa and Mem0 API keys

### DIFF
--- a/review-enrichment/src/analyzers/secret-scan.ts
+++ b/review-enrichment/src/analyzers/secret-scan.ts
@@ -308,6 +308,18 @@ const RULES: Rule[] = [
     confidence: "high",
   },
   {
+    // Exa search API key: `exa_` + base62 body.
+    kind: "exa_api_key",
+    re: /\bexa_[A-Za-z0-9]{20,}(?![A-Za-z0-9_-])/,
+    confidence: "high",
+  },
+  {
+    // Mem0 API key: platform `m0-` or self-hosted `m0sk_` + body.
+    kind: "mem0_api_key",
+    re: /\bm0(?:sk_|-)[A-Za-z0-9_-]{20,}(?![A-Za-z0-9_.-])/,
+    confidence: "high",
+  },
+  {
     // Google OAuth 2.0 client secret: `GOCSPX-` + 28 base64url chars.
     kind: "google_oauth_client_secret",
     re: /\bGOCSPX-[A-Za-z0-9_-]{28}\b/,

--- a/review-enrichment/test/secret-scan.test.ts
+++ b/review-enrichment/test/secret-scan.test.ts
@@ -851,6 +851,49 @@ test("scanPatch does not flag truncated Baseten/Laminar keys or identifier conti
   );
 });
 
+test("scanPatch flags Exa and Mem0 API keys with high confidence", () => {
+  const fakeExaKey = "exa_" + "x".repeat(20);
+  const exaFindings = scanPatch("src/config.ts", hunk([`const exa = "${fakeExaKey}";`]));
+  assert.equal(exaFindings.length, 1);
+  assert.equal(exaFindings[0].kind, "exa_api_key");
+  assert.equal(exaFindings[0].confidence, "high");
+
+  const fakeMem0PlatformKey = "m0-" + "a".repeat(20);
+  const mem0PlatformFindings = scanPatch("src/config.ts", hunk([`const mem0 = "${fakeMem0PlatformKey}";`]));
+  assert.equal(mem0PlatformFindings.length, 1);
+  assert.equal(mem0PlatformFindings[0].kind, "mem0_api_key");
+  assert.equal(mem0PlatformFindings[0].confidence, "high");
+
+  const fakeMem0SelfHostedKey = "m0sk_" + "b".repeat(20);
+  const mem0SelfHostedFindings = scanPatch("src/config.ts", hunk([`const mem0Local = "${fakeMem0SelfHostedKey}";`]));
+  assert.equal(mem0SelfHostedFindings.length, 1);
+  assert.equal(mem0SelfHostedFindings[0].kind, "mem0_api_key");
+  assert.equal(mem0SelfHostedFindings[0].confidence, "high");
+});
+
+test("scanPatch does not flag truncated Exa/Mem0 keys or identifier continuation", () => {
+  assert.equal(scanPatch("src/config.ts", hunk([`const exa = "exa_${"x".repeat(19)}";`])).length, 0);
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const exa = "exa_${"x".repeat(20)}_suffix";`])).some((f) => f.kind === "exa_api_key"),
+    false,
+  );
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const exa = "exa_${"x".repeat(20)}-suffix";`])).some((f) => f.kind === "exa_api_key"),
+    false,
+  );
+
+  assert.equal(scanPatch("src/config.ts", hunk([`const mem0 = "m0-${"a".repeat(19)}";`])).length, 0);
+  assert.equal(scanPatch("src/config.ts", hunk([`const mem0Local = "m0sk_${"b".repeat(19)}";`])).length, 0);
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const mem0 = "m0-${"a".repeat(20)}.suffix";`])).some((f) => f.kind === "mem0_api_key"),
+    false,
+  );
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const mem0Local = "m0sk_${"b".repeat(20)}.suffix";`])).some((f) => f.kind === "mem0_api_key"),
+    false,
+  );
+});
+
 test("scanPatch flags additional high-confidence SaaS/cloud/CI credential formats", () => {
   const cases = [
     ["google_oauth_client_secret", "GOCSPX-" + b62(28)],


### PR DESCRIPTION
## Summary
- Add `exa_api_key` rule for Exa `exa_` search API keys
- Add `mem0_api_key` rule for Mem0 platform (`m0-`) and self-hosted (`m0sk_`) tokens
- Include positive, truncation, and identifier-continuation negative tests

## Test plan
- [x] `cd review-enrichment && npm run build && node --test test/secret-scan.test.ts` (84 passing)


Made with [Cursor](https://cursor.com)