### PR TITLE
feat(enrichment): detect Braintrust and ScrapeGraphAI API keys

### DIFF
--- a/review-enrichment/src/analyzers/secret-scan.ts
+++ b/review-enrichment/src/analyzers/secret-scan.ts
@@ -320,6 +320,18 @@ const RULES: Rule[] = [
     confidence: "high",
   },
   {
+    // Braintrust service token: `bt-st-` + base62 body.
+    kind: "braintrust_service_token",
+    re: /\bbt-st-[A-Za-z0-9]{20,}(?![A-Za-z0-9_-])/,
+    confidence: "high",
+  },
+  {
+    // ScrapeGraphAI API key: `sgai-` + UUID-shaped body.
+    kind: "scrapegraphai_api_key",
+    re: /\bsgai-[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}(?![0-9a-fA-F-])/,
+    confidence: "high",
+  },
+  {
     // Google OAuth 2.0 client secret: `GOCSPX-` + 28 base64url chars.
     kind: "google_oauth_client_secret",
     re: /\bGOCSPX-[A-Za-z0-9_-]{28}\b/,

--- a/review-enrichment/test/secret-scan.test.ts
+++ b/review-enrichment/test/secret-scan.test.ts
@@ -894,6 +894,43 @@ test("scanPatch does not flag truncated Exa/Mem0 keys or identifier continuation
   );
 });
 
+test("scanPatch flags Braintrust and ScrapeGraphAI API keys with high confidence", () => {
+  const fakeBraintrustToken = "bt-st-" + "a".repeat(20);
+  const braintrustFindings = scanPatch("src/config.ts", hunk([`const bt = "${fakeBraintrustToken}";`]));
+  assert.equal(braintrustFindings.length, 1);
+  assert.equal(braintrustFindings[0].kind, "braintrust_service_token");
+  assert.equal(braintrustFindings[0].confidence, "high");
+
+  const fakeScrapeGraphKey = ["sgai-", "01234567", "-", "0123", "-", "4567", "-", "8901", "-", "012345678901"].join("");
+  const scrapeGraphFindings = scanPatch("src/config.ts", hunk([`const sgai = "${fakeScrapeGraphKey}";`]));
+  assert.equal(scrapeGraphFindings.length, 1);
+  assert.equal(scrapeGraphFindings[0].kind, "scrapegraphai_api_key");
+  assert.equal(scrapeGraphFindings[0].confidence, "high");
+});
+
+test("scanPatch does not flag truncated Braintrust/ScrapeGraphAI keys or identifier continuation", () => {
+  assert.equal(scanPatch("src/config.ts", hunk([`const bt = "bt-st-${"a".repeat(19)}";`])).length, 0);
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const bt = "bt-st-${"a".repeat(20)}-suffix";`])).some((f) => f.kind === "braintrust_service_token"),
+    false,
+  );
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const bt = "bt-st-${"a".repeat(20)}_suffix";`])).some((f) => f.kind === "braintrust_service_token"),
+    false,
+  );
+
+  const shortScrapeGraphKey = ["sgai-", "01234567", "-", "0123", "-", "4567", "-", "8901", "-", "01234567890"].join("");
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const sgai = "${shortScrapeGraphKey}";`])).some((f) => f.kind === "scrapegraphai_api_key"),
+    false,
+  );
+  const scrapeGraphSuffixKey = ["sgai-", "01234567", "-", "0123", "-", "4567", "-", "8901", "-", "012345678901", "-suffix"].join("");
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const sgai = "${scrapeGraphSuffixKey}";`])).some((f) => f.kind === "scrapegraphai_api_key"),
+    false,
+  );
+});
+
 test("scanPatch flags additional high-confidence SaaS/cloud/CI credential formats", () => {
   const cases = [
     ["google_oauth_client_secret", "GOCSPX-" + b62(28)],


### PR DESCRIPTION
## Summary
- Add `braintrust_service_token` rule for Braintrust `bt-st-` service tokens
- Add `scrapegraphai_api_key` rule for ScrapeGraphAI `sgai-` UUID-shaped keys
- Include positive, truncation, and identifier-continuation negative tests

## Test plan
- [x] `cd review-enrichment && npm run build && node --test test/secret-scan.test.ts` (86 passing)


Made with [Cursor](https://cursor.com)