### PR TITLE
feat(enrichment): detect Langfuse public and Hyperbolic API keys

### DIFF
--- a/review-enrichment/src/analyzers/secret-scan.ts
+++ b/review-enrichment/src/analyzers/secret-scan.ts
@@ -332,6 +332,18 @@ const RULES: Rule[] = [
     confidence: "high",
   },
   {
+    // Langfuse public API key: `pk-lf-` + UUID-shaped body (pairs with `sk-lf-` secret key).
+    kind: "langfuse_public_key",
+    re: /\bpk-lf-[A-Za-z0-9_-]{20,}(?![A-Za-z0-9_.-])/,
+    confidence: "high",
+  },
+  {
+    // Hyperbolic API key: `hb_` + base62 body.
+    kind: "hyperbolic_api_key",
+    re: /\bhb_[A-Za-z0-9]{20,}(?![A-Za-z0-9_-])/,
+    confidence: "high",
+  },
+  {
     // Google OAuth 2.0 client secret: `GOCSPX-` + 28 base64url chars.
     kind: "google_oauth_client_secret",
     re: /\bGOCSPX-[A-Za-z0-9_-]{28}\b/,

--- a/review-enrichment/test/secret-scan.test.ts
+++ b/review-enrichment/test/secret-scan.test.ts
@@ -931,6 +931,38 @@ test("scanPatch does not flag truncated Braintrust/ScrapeGraphAI keys or identif
   );
 });
 
+test("scanPatch flags Langfuse public and Hyperbolic API keys with high confidence", () => {
+  const fakeLangfusePublicKey = "pk-lf-" + "a".repeat(20);
+  const langfuseFindings = scanPatch("src/config.ts", hunk([`const langfuse = "${fakeLangfusePublicKey}";`]));
+  assert.equal(langfuseFindings.length, 1);
+  assert.equal(langfuseFindings[0].kind, "langfuse_public_key");
+  assert.equal(langfuseFindings[0].confidence, "high");
+
+  const fakeHyperbolicKey = "hb_" + "b".repeat(20);
+  const hyperbolicFindings = scanPatch("src/config.ts", hunk([`const hyperbolic = "${fakeHyperbolicKey}";`]));
+  assert.equal(hyperbolicFindings.length, 1);
+  assert.equal(hyperbolicFindings[0].kind, "hyperbolic_api_key");
+  assert.equal(hyperbolicFindings[0].confidence, "high");
+});
+
+test("scanPatch does not flag truncated Langfuse/Hyperbolic keys or identifier continuation", () => {
+  assert.equal(scanPatch("src/config.ts", hunk([`const langfuse = "pk-lf-${"a".repeat(19)}";`])).length, 0);
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const langfuse = "pk-lf-${"a".repeat(20)}.suffix";`])).some((f) => f.kind === "langfuse_public_key"),
+    false,
+  );
+
+  assert.equal(scanPatch("src/config.ts", hunk([`const hyperbolic = "hb_${"b".repeat(19)}";`])).length, 0);
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const hyperbolic = "hb_${"b".repeat(20)}_suffix";`])).some((f) => f.kind === "hyperbolic_api_key"),
+    false,
+  );
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const hyperbolic = "hb_${"b".repeat(20)}-suffix";`])).some((f) => f.kind === "hyperbolic_api_key"),
+    false,
+  );
+});
+
 test("scanPatch flags additional high-confidence SaaS/cloud/CI credential formats", () => {
   const cases = [
     ["google_oauth_client_secret", "GOCSPX-" + b62(28)],


### PR DESCRIPTION
## Summary
- Add `langfuse_public_key` rule for Langfuse `pk-lf-` public API keys (pairs with existing `sk-lf-` secret rule)
- Add `hyperbolic_api_key` rule for Hyperbolic `hb_` API tokens
- Include positive, truncation, and identifier-continuation negative tests

## Test plan
- [x] `cd review-enrichment && npm run build && node --test test/secret-scan.test.ts` (88 passing)


Made with [Cursor](https://cursor.com)