### PR TITLE
feat(enrichment): detect Gladia and WorkOS legacy API keys

### DIFF
--- a/review-enrichment/src/analyzers/secret-scan.ts
+++ b/review-enrichment/src/analyzers/secret-scan.ts
@@ -344,6 +344,18 @@ const RULES: Rule[] = [
     confidence: "high",
   },
   {
+    // Gladia API key: `gla_` + base62 body.
+    kind: "gladia_api_key",
+    re: /\bgla_[A-Za-z0-9]{20,}(?![A-Za-z0-9_-])/,
+    confidence: "high",
+  },
+  {
+    // WorkOS legacy API key: `wos_api_key_` + base62 body.
+    kind: "workos_legacy_api_key",
+    re: /\bwos_api_key_[A-Za-z0-9]{20,}(?![A-Za-z0-9_-])/,
+    confidence: "high",
+  },
+  {
     // Google OAuth 2.0 client secret: `GOCSPX-` + 28 base64url chars.
     kind: "google_oauth_client_secret",
     re: /\bGOCSPX-[A-Za-z0-9_-]{28}\b/,

--- a/review-enrichment/test/secret-scan.test.ts
+++ b/review-enrichment/test/secret-scan.test.ts
@@ -963,6 +963,42 @@ test("scanPatch does not flag truncated Langfuse/Hyperbolic keys or identifier c
   );
 });
 
+test("scanPatch flags Gladia and WorkOS legacy API keys with high confidence", () => {
+  const fakeGladiaKey = "gla_" + "a".repeat(20);
+  const gladiaFindings = scanPatch("src/config.ts", hunk([`const gladia = "${fakeGladiaKey}";`]));
+  assert.equal(gladiaFindings.length, 1);
+  assert.equal(gladiaFindings[0].kind, "gladia_api_key");
+  assert.equal(gladiaFindings[0].confidence, "high");
+
+  const fakeWorkosKey = "wos_api_key_" + "b".repeat(20);
+  const workosFindings = scanPatch("src/config.ts", hunk([`const workos = "${fakeWorkosKey}";`]));
+  assert.equal(workosFindings.length, 1);
+  assert.equal(workosFindings[0].kind, "workos_legacy_api_key");
+  assert.equal(workosFindings[0].confidence, "high");
+});
+
+test("scanPatch does not flag truncated Gladia/WorkOS keys or identifier continuation", () => {
+  assert.equal(scanPatch("src/config.ts", hunk([`const gladia = "gla_${"a".repeat(19)}";`])).length, 0);
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const gladia = "gla_${"a".repeat(20)}_suffix";`])).some((f) => f.kind === "gladia_api_key"),
+    false,
+  );
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const gladia = "gla_${"a".repeat(20)}-suffix";`])).some((f) => f.kind === "gladia_api_key"),
+    false,
+  );
+
+  assert.equal(scanPatch("src/config.ts", hunk([`const workos = "wos_api_key_${"b".repeat(19)}";`])).length, 0);
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const workos = "wos_api_key_${"b".repeat(20)}_suffix";`])).some((f) => f.kind === "workos_legacy_api_key"),
+    false,
+  );
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const workos = "wos_api_key_${"b".repeat(20)}-suffix";`])).some((f) => f.kind === "workos_legacy_api_key"),
+    false,
+  );
+});
+
 test("scanPatch flags additional high-confidence SaaS/cloud/CI credential formats", () => {
   const cases = [
     ["google_oauth_client_secret", "GOCSPX-" + b62(28)],


### PR DESCRIPTION
## Summary
- Add `gladia_api_key` rule for Gladia `gla_` API keys
- Add `workos_legacy_api_key` rule for WorkOS legacy `wos_api_key_` tokens (avoids generic `sk_` conflict with current WorkOS keys)
- Include positive, truncation, and `_suffix`/`-suffix` identifier-continuation negative tests

## Test plan
- [x] `cd review-enrichment && npm run build && node --test test/secret-scan.test.ts` (90 passing)


Made with [Cursor](https://cursor.com)