### PR TITLE
feat(enrichment): detect MiniMax Token Plan and pay-per-token API keys

### DIFF
--- a/review-enrichment/src/analyzers/secret-scan.ts
+++ b/review-enrichment/src/analyzers/secret-scan.ts
@@ -356,6 +356,18 @@ const RULES: Rule[] = [
     confidence: "high",
   },
   {
+    // MiniMax Token Plan subscription key: `sk-cp-` + base62 body (distinct from OpenAI `sk-proj-`/`sk-ant-`).
+    kind: "minimax_token_plan_key",
+    re: /\bsk-cp-[A-Za-z0-9]{20,}(?![A-Za-z0-9_-])/,
+    confidence: "high",
+  },
+  {
+    // MiniMax pay-per-token API key: `sk-api-` + base62 body.
+    kind: "minimax_pay_per_token_key",
+    re: /\bsk-api-[A-Za-z0-9]{20,}(?![A-Za-z0-9_-])/,
+    confidence: "high",
+  },
+  {
     // Google OAuth 2.0 client secret: `GOCSPX-` + 28 base64url chars.
     kind: "google_oauth_client_secret",
     re: /\bGOCSPX-[A-Za-z0-9_-]{28}\b/,

--- a/review-enrichment/test/secret-scan.test.ts
+++ b/review-enrichment/test/secret-scan.test.ts
@@ -999,6 +999,42 @@ test("scanPatch does not flag truncated Gladia/WorkOS keys or identifier continu
   );
 });
 
+test("scanPatch flags MiniMax Token Plan and pay-per-token API keys with high confidence", () => {
+  const fakeMinimaxCpKey = "sk-cp-" + "a".repeat(20);
+  const minimaxCpFindings = scanPatch("src/config.ts", hunk([`const minimax = "${fakeMinimaxCpKey}";`]));
+  assert.equal(minimaxCpFindings.length, 1);
+  assert.equal(minimaxCpFindings[0].kind, "minimax_token_plan_key");
+  assert.equal(minimaxCpFindings[0].confidence, "high");
+
+  const fakeMinimaxApiKey = "sk-api-" + "b".repeat(20);
+  const minimaxApiFindings = scanPatch("src/config.ts", hunk([`const minimax = "${fakeMinimaxApiKey}";`]));
+  assert.equal(minimaxApiFindings.length, 1);
+  assert.equal(minimaxApiFindings[0].kind, "minimax_pay_per_token_key");
+  assert.equal(minimaxApiFindings[0].confidence, "high");
+});
+
+test("scanPatch does not flag truncated MiniMax keys or identifier continuation", () => {
+  assert.equal(scanPatch("src/config.ts", hunk([`const minimax = "sk-cp-${"a".repeat(19)}";`])).length, 0);
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const minimax = "sk-cp-${"a".repeat(20)}_suffix";`])).some((f) => f.kind === "minimax_token_plan_key"),
+    false,
+  );
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const minimax = "sk-cp-${"a".repeat(20)}-suffix";`])).some((f) => f.kind === "minimax_token_plan_key"),
+    false,
+  );
+
+  assert.equal(scanPatch("src/config.ts", hunk([`const minimax = "sk-api-${"b".repeat(19)}";`])).length, 0);
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const minimax = "sk-api-${"b".repeat(20)}_suffix";`])).some((f) => f.kind === "minimax_pay_per_token_key"),
+    false,
+  );
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const minimax = "sk-api-${"b".repeat(20)}-suffix";`])).some((f) => f.kind === "minimax_pay_per_token_key"),
+    false,
+  );
+});
+
 test("scanPatch flags additional high-confidence SaaS/cloud/CI credential formats", () => {
   const cases = [
     ["google_oauth_client_secret", "GOCSPX-" + b62(28)],


### PR DESCRIPTION
## Summary
- Add `minimax_token_plan_key` rule for MiniMax `sk-cp-` Token Plan subscription keys
- Add `minimax_pay_per_token_key` rule for MiniMax `sk-api-` pay-per-token keys
- Include positive, truncation, and identifier-continuation negative tests

## Test plan
- [x] `cd review-enrichment && npm run build && node --test test/secret-scan.test.ts` (92 passing)


Made with [Cursor](https://cursor.com)