### PR TITLE
feat(enrichment): classify long-form doc extensions as docs

### DIFF
--- a/review-enrichment/src/analysis-context.ts
+++ b/review-enrichment/src/analysis-context.ts
@@ -440,7 +440,12 @@ function categorizeFile(path: string): FileCategory {
   ) {
     return { path, extension, category: "config" };
   }
-  if ([".md", ".mdx", ".rst", ".txt"].includes(extension)) {
+  // Long-form doc spellings (.markdown/.adoc/.asciidoc) are docs too, matching the canonical
+  // DOCS_EXTENSIONS set in src/signals/path-matchers.ts and rag.ts's DOC_EXT_RE; without them a
+  // NOTES.markdown or guide.adoc file fell through to the source category.
+  if (
+    [".md", ".markdown", ".mdx", ".rst", ".adoc", ".asciidoc", ".txt"].includes(extension)
+  ) {
     return { path, extension, category: "docs" };
   }
   if (

--- a/review-enrichment/test/analysis-context.test.ts
+++ b/review-enrichment/test/analysis-context.test.ts
@@ -545,6 +545,31 @@ test("createAnalysisContext classifies Zstandard archives as assets for schedule
   assert.deepEqual(plan.skipped.map((item) => [item.name, item.skipReason]), []);
 });
 
+test("createAnalysisContext classifies long-form doc extensions as docs", () => {
+  const context = createAnalysisContext({
+    repoFullName: "JSONbored/gittensory",
+    prNumber: 3264,
+    files: [
+      { path: "GUIDE.markdown", patch: "@@ -1,0 +1,1 @@\n+# guide" },
+      { path: "docs/manual.adoc", patch: "@@ -1,0 +1,1 @@\n+= Manual" },
+      { path: "docs/spec.asciidoc", patch: "@@ -1,0 +1,1 @@\n+= Spec" },
+      { path: "README.ADOC", patch: "@@ -1,0 +1,1 @@\n+= Readme" },
+      { path: "src/index.ts", patch: "@@ -1,0 +1,1 @@\n+export {};" },
+    ],
+  });
+
+  assert.deepEqual(
+    context.fileCategories.map((file) => [file.path, file.category]),
+    [
+      ["GUIDE.markdown", "docs"],
+      ["docs/manual.adoc", "docs"],
+      ["docs/spec.asciidoc", "docs"],
+      ["README.ADOC", "docs"],
+      ["src/index.ts", "source"],
+    ],
+  );
+});
+
 test("createAnalysisContext classifies lockfile paths case-insensitively", () => {
   const context = createAnalysisContext({
     repoFullName: "JSONbored/gittensory",


### PR DESCRIPTION
## Summary

`categorizeFile` (in `review-enrichment/src/analysis-context.ts`) assigns each changed file a category (`docs`, `source`, `asset`, `lockfile`, …) used for review scheduling/scope. Its docs list recognized only `.md`/`.mdx`/`.rst`/`.txt`, so the **long-form doc spellings `.markdown`, `.adoc`, and `.asciidoc`** fell through to the `source` category — a `NOTES.markdown` or `guide.adoc` change was mischaracterized as a source change rather than documentation.

This adds the three spellings to the docs extension list:

- **Consistency anchor:** the canonical `DOCS_EXTENSIONS` set in `src/signals/path-matchers.ts` (`md, mdx, markdown, rst, adoc, asciidoc`) and `rag.ts`'s `DOC_EXT_RE` already classify all three as docs — `rag.ts` even carries a comment noting these long-form spellings were a known miss elsewhere. This brings the categorizer in line.
- **Case-insensitive:** matching uses the existing lowercased-extension path, so `README.ADOC` classifies as docs.
- **Additive-only:** three list entries plus a test; no existing category changes for any other extension.

## No linked issue

This is a **no-issue PR** by design: a self-contained classification-coverage fix that adds three doc extensions to `categorizeFile` plus a focused test, touching only `review-enrichment/`. There is no behavior change beyond correctly categorizing these docs, so no tracking issue is needed. It mirrors the accepted no-issue precedent for the same kind of classification-inventory change (e.g. the recently-merged `#3204` and `#3264`).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] No linked issue — see the **No linked issue** section above.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — no `src/**` lines changed (this change is under `review-enrichment/`, which Codecov does not measure), so `codecov/patch` has no diff to gate; suite is green.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New behavior has tests — a new case in `review-enrichment/test/analysis-context.test.ts` drives `createAnalysisContext` and asserts `.markdown`/`.adoc`/`.asciidoc` (and uppercase `.ADOC`) categorize as `docs`, while `.ts` stays `source`. `npm run rees:test` passes (863 tests; analyzer-metadata check clean).

Validated green against the full GitHub CI `validate-code` check set — `actionlint`, `db:migrations:check`, `db:schema-drift:check`, `cf-typegen:check`, `selfhost:validate-observability`, `typecheck`, `test:coverage`, `test:workers`, `build:mcp`, `test:mcp-pack`, `build:miner`, `rees:test`, `ui:openapi:check`, `ui:openapi:settings-parity`, `ui:version-audit`, `ui:lint`, `ui:typecheck`, `ui:test`, `ui:build`. Branch rebased on latest `main`.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] No auth, cookie, CORS, GitHub App, Cloudflare, or session changes (N/A — pure classification-list addition).
- [x] No API/OpenAPI/MCP behavior change (N/A).
- [x] No UI changes (N/A — this is a review-enrichment helper).
- [x] No visible UI change, so no UI Evidence section is required.
- [x] No docs/changelog changes needed.

## Notes

Analogues followed end-to-end: the existing category tests in `analysis-context.test.ts` (e.g. the `.zst` asset and case-insensitive lockfile cases), and the recently-merged classification-inventory PRs `#3204` and `#3264`. `.txt` is intentionally left in the docs list (it is not in the canonical `DOCS_EXTENSIONS` but is present in `rag.ts`'s `DOC_EXT_RE`) — this PR only adds the missing long-form spellings and changes nothing else.
