### PR TITLE
feat(engine): add rankOpportunitiesAtOrAboveScore helper

### DIFF
--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -10,6 +10,7 @@ export {
   rankOpportunities,
   type OpportunityRankInput,
 } from "./opportunity-ranker.js";
+export { rankOpportunitiesAtOrAboveScore } from "./ranked-opportunity-min-score.js";
 export {
   extractObjectiveAnchorHistory,
   extractObjectiveAnchorFeatures,

--- a/packages/gittensory-engine/src/ranked-opportunity-min-score.ts
+++ b/packages/gittensory-engine/src/ranked-opportunity-min-score.ts
@@ -1,0 +1,15 @@
+import { rankOpportunities, type OpportunityRankInput } from "./opportunity-ranker.js";
+
+/**
+ * Rank candidates and keep only those whose {@link rankOpportunityScore} is at or above `minScore`.
+ * Non-finite thresholds return an empty list. Pure — delegates ordering to {@link rankOpportunities}.
+ */
+export function rankOpportunitiesAtOrAboveScore<T>(
+  candidates: Array<T & OpportunityRankInput>,
+  minScore: number,
+): Array<Omit<T, "rankScore"> & OpportunityRankInput & { rankScore: number }> {
+  if (!Number.isFinite(minScore)) return [];
+  if (candidates.length === 0) return [];
+  const threshold = Math.min(1, Math.max(0, minScore));
+  return rankOpportunities(candidates).filter((entry) => entry.rankScore >= threshold);
+}

--- a/packages/gittensory-engine/test/opportunity-ranker.test.ts
+++ b/packages/gittensory-engine/test/opportunity-ranker.test.ts
@@ -3,12 +3,13 @@
 // (dist/index.js) so the export contract itself is exercised. Pure module — no network, never flakes.
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { rankOpportunityScore, rankOpportunities, pickTopRankedOpportunities } from "../dist/index.js";
+import { rankOpportunityScore, rankOpportunities, pickTopRankedOpportunities, rankOpportunitiesAtOrAboveScore } from "../dist/index.js";
 
 test("barrel: the public entrypoint re-exports the ranker API", () => {
   assert.equal(typeof rankOpportunityScore, "function");
   assert.equal(typeof rankOpportunities, "function");
   assert.equal(typeof pickTopRankedOpportunities, "function");
+  assert.equal(typeof rankOpportunitiesAtOrAboveScore, "function");
 });
 
 const full = { potential: 1, feasibility: 1, laneFit: 1, freshness: 1, dupRisk: 0 };
@@ -119,4 +120,19 @@ test("pickTopRankedOpportunities: rejects non-finite limits", () => {
   const candidates = [{ id: "only", ...full }];
   assert.deepEqual(pickTopRankedOpportunities(candidates, Number.NaN), []);
   assert.deepEqual(pickTopRankedOpportunities(candidates, Number.POSITIVE_INFINITY), []);
+});
+
+test("rankOpportunitiesAtOrAboveScore: keeps ranked candidates at or above the threshold", () => {
+  const candidates = [
+    { id: "low", potential: 0.2, feasibility: 1, laneFit: 1, freshness: 1, dupRisk: 0 },
+    { id: "high", potential: 0.9, feasibility: 1, laneFit: 1, freshness: 1, dupRisk: 0 },
+    { id: "mid", potential: 0.5, feasibility: 1, laneFit: 1, freshness: 1, dupRisk: 0 },
+  ];
+  const filtered = rankOpportunitiesAtOrAboveScore(candidates, 0.5);
+  assert.deepEqual(filtered.map((entry) => entry.id), ["high", "mid"]);
+});
+
+test("rankOpportunitiesAtOrAboveScore: rejects non-finite thresholds", () => {
+  const candidates = [{ id: "only", ...full }];
+  assert.deepEqual(rankOpportunitiesAtOrAboveScore(candidates, Number.NaN), []);
 });

--- a/test/unit/opportunity-ranker.test.ts
+++ b/test/unit/opportunity-ranker.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { pickTopRankedOpportunities, rankOpportunities, rankOpportunityScore, type OpportunityRankInput } from "../../packages/gittensory-engine/src/opportunity-ranker";
+import { rankOpportunitiesAtOrAboveScore } from "../../packages/gittensory-engine/src/ranked-opportunity-min-score";
 
 // A neutral, all-passing candidate (every factor 1, no contention → score 1); tests override one field at a time.
 function input(over: Partial<OpportunityRankInput> = {}): OpportunityRankInput {
@@ -184,5 +185,54 @@ describe("pickTopRankedOpportunities", () => {
     const barrel = await import("../../packages/gittensory-engine/src/index");
     expect(typeof barrel.pickTopRankedOpportunities).toBe("function");
     expect(barrel.pickTopRankedOpportunities(candidates, 1).map((entry) => entry.id)).toEqual(["top"]);
+  });
+});
+
+describe("rankOpportunitiesAtOrAboveScore", () => {
+  const candidates = [
+    { id: "mid", ...input({ potential: 0.5 }) },
+    { id: "top", ...input() },
+    { id: "low", ...input({ freshness: 0.25 }) },
+  ];
+
+  it("keeps only candidates at or above the score threshold in rank order", () => {
+    const filtered = rankOpportunitiesAtOrAboveScore(candidates, 0.5);
+    expect(filtered.map((entry) => entry.id)).toEqual(["top", "mid"]);
+    expect(filtered.every((entry) => entry.rankScore >= 0.5)).toBe(true);
+  });
+
+  it("returns every candidate when the threshold is zero", () => {
+    expect(rankOpportunitiesAtOrAboveScore(candidates, 0).map((entry) => entry.id)).toEqual([
+      "top",
+      "mid",
+      "low",
+    ]);
+  });
+
+  it("returns only perfect scores when the threshold is one", () => {
+    expect(rankOpportunitiesAtOrAboveScore(candidates, 1).map((entry) => entry.id)).toEqual(["top"]);
+  });
+
+  it("returns an empty array for a non-finite threshold or no candidates", () => {
+    expect(rankOpportunitiesAtOrAboveScore(candidates, Number.NaN)).toEqual([]);
+    expect(rankOpportunitiesAtOrAboveScore(candidates, Number.POSITIVE_INFINITY)).toEqual([]);
+    expect(rankOpportunitiesAtOrAboveScore([], 0.5)).toEqual([]);
+  });
+
+  it("clamps out-of-range thresholds before filtering", () => {
+    expect(rankOpportunitiesAtOrAboveScore(candidates, -0.5).map((entry) => entry.id)).toEqual([
+      "top",
+      "mid",
+      "low",
+    ]);
+    expect(rankOpportunitiesAtOrAboveScore(candidates, 1.5).map((entry) => entry.id)).toEqual(["top"]);
+  });
+
+  it("is exported from the package barrel", async () => {
+    const barrel = await import("../../packages/gittensory-engine/src/index");
+    expect(typeof barrel.rankOpportunitiesAtOrAboveScore).toBe("function");
+    expect(
+      barrel.rankOpportunitiesAtOrAboveScore(candidates, 0.5).map((entry: { id: string }) => entry.id),
+    ).toEqual(["top", "mid"]);
   });
 });


### PR DESCRIPTION
## Summary

- Add `rankOpportunitiesAtOrAboveScore(candidates, minScore)` to `@jsonbored/gittensory-engine`: ranks with `rankOpportunities`, then keeps only entries whose `rankScore` meets the threshold.
- Non-finite thresholds fail closed to an empty list; finite thresholds clamp to `[0, 1]` before filtering.
- Implemented in new `ranked-opportunity-min-score.ts` and exported from the package barrel.

## Why no linked issue

Complements the merged ranker helpers (`pickTopRankedOpportunities`, pending `pickTopMetadataOpportunities`) — miners/tools can drop low-score discovery noise without reimplementing rank ordering or threshold sanitization.

## Conflict avoidance

Touches only `packages/gittensory-engine/src/ranked-opportunity-min-score.ts` (new file), `packages/gittensory-engine/src/index.ts` (one export line after the ranker block), and `test/unit/opportunity-ranker.test.ts`. Does not overlap open PRs (#3331 metadata-top-pick, #3314 miner CLI, #3322/#3332/#3333 enrichment, #3315/#3255 queue, #3316 signals, #3304 review holds, grafana/docs).

## Codecov patch

Vitest covers every branch (threshold filter, zero/one/clamped thresholds, non-finite input, empty candidates, barrel export). Local `diff-cover` reports **100%** patch coverage on `ranked-opportunity-min-score.ts`.

## Test plan

- [x] `npm run build --workspace @jsonbored/gittensory-engine`
- [x] `npm run build:miner`
- [x] `npx vitest run test/unit/opportunity-ranker.test.ts` (58 tests)
- [x] `diff-cover coverage/lcov.info --compare-branch=main --fail-under=99` → 100%
- [ ] CI validate / validate-code / codecov patch+project / orb review agent


