### PR TITLE
fix(review): rank long-form doc extensions in diffFilePriority

### DIFF
--- a/src/review/review-diff.ts
+++ b/src/review/review-diff.ts
@@ -22,7 +22,7 @@ export const DEFAULT_DIFF_BUDGET = 80_000;
 export function diffFilePriority(path: string): number {
   if (/(^|\/)(package-lock\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lockb|cargo\.lock|poetry\.lock|composer\.lock|go\.sum)$|\.(min\.(js|css)|map|snap)$/i.test(path)) return 4;
   if (/(^|\/)(dist|build|out|coverage|vendor|node_modules)\//i.test(path)) return 4;
-  if (/\.(md|mdx|rst|txt|adoc)$/i.test(path)) return 2;
+  if (/\.(md|mdx|markdown|rst|adoc|asciidoc|txt)$/i.test(path)) return 2;
   if (isTestPath(path)) return 1;
   return 0; // source code
 }

--- a/src/review/review-grounding.ts
+++ b/src/review/review-grounding.ts
@@ -112,7 +112,7 @@ export function buildGrounding(f: GroundingFlags, checks?: CheckAggregate, fileC
 export function diffFilePriority(path: string): number {
   if (/(^|\/)(package-lock\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lockb|cargo\.lock|poetry\.lock|composer\.lock|go\.sum)$|\.(min\.(js|css)|map|snap)$/i.test(path)) return 4;
   if (/(^|\/)(dist|build|out|coverage|vendor|node_modules)\//i.test(path)) return 4;
-  if (/\.(md|mdx|rst|txt|adoc)$/i.test(path)) return 2;
+  if (/\.(md|mdx|markdown|rst|adoc|asciidoc|txt)$/i.test(path)) return 2;
   if (isTestPath(path)) return 1;
   return 0; // source code
 }

--- a/test/unit/review-diff.test.ts
+++ b/test/unit/review-diff.test.ts
@@ -11,6 +11,13 @@ describe("diffFilePriority — source survives, noise drops first", () => {
     expect(diffFilePriority("app.min.css")).toBe(4);
   });
 
+  it("ranks long-form doc spellings as docs(2), matching rag.ts and path-matchers", () => {
+    for (const path of ["GUIDE.markdown", "docs/spec.asciidoc", "notes.ADOC"]) {
+      expect(diffFilePriority(path)).toBe(2);
+      expect(diffFilePriority(path)).toBeGreaterThan(diffFilePriority("src/a.ts"));
+    }
+  });
+
   it("ranks every canonical test convention as tests(1), not source(0)", () => {
     // These are all tests; before delegating to isTestPath the inline regex missed them and ranked
     // them SOURCE(0), so on a tight budget they could displace real source (the opposite of the goal).

--- a/test/unit/review-grounding.test.ts
+++ b/test/unit/review-grounding.test.ts
@@ -102,6 +102,13 @@ describe("review-grounding: diffFilePriority (source survives the budget first)"
     expect(diffFilePriority("src/a.ts")).toBeLessThan(diffFilePriority("README.md"));
   });
 
+  it("ranks long-form doc spellings as docs(2), matching rag.ts and path-matchers", () => {
+    for (const path of ["GUIDE.markdown", "docs/spec.asciidoc", "notes.ADOC"]) {
+      expect(diffFilePriority(path)).toBe(2);
+      expect(diffFilePriority(path)).toBeGreaterThan(diffFilePriority("src/a.ts"));
+    }
+  });
+
   it("ranks every canonical test convention as tests(1) so real source is inlined first", () => {
     for (const path of [
       "e2e/checkout.cy.ts", // Cypress


### PR DESCRIPTION
## Summary

- Extend `diffFilePriority` in `review-grounding.ts` and `review-diff.ts` to treat `.markdown` and `.asciidoc` (plus existing `.adoc`) as docs priority **2**, not source **0**.
- Mirrors the long-form doc spellings already recognized in `rag.ts`, `path-matchers.ts`, and review-enrichment `analysis-context.ts` (#3329).
- On large PRs with a tight diff budget, `GUIDE.markdown` or `docs/spec.asciidoc` no longer displace real source files.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint` (via `npm run test:ci`)
- [x] `npm run typecheck` (via `npm run test:ci`)
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers` (via `npm run test:ci`)
- [x] `npm run build:mcp` (via `npm run test:ci`)
- [x] `npm run test:mcp-pack` (via `npm run test:ci`)
- [x] `npm run ui:openapi:check` (via `npm run test:ci`)
- [x] `npm run ui:lint` (via `npm run test:ci`)
- [x] `npm run ui:typecheck` (via `npm run test:ci`)
- [x] `npm run ui:build` (via `npm run test:ci`)
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Full gate run as `npm run test:ci` on Node 22 before push.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — backend review diff ordering only; no visible UI change.

## Notes

**Conflict avoidance:** Touches only `src/review/review-grounding.ts`, `src/review/review-diff.ts`, and their unit tests. Verified zero file overlap with open PRs (#3316 dart classifiers, #3304 mega, #3333/#3332 secret-scan, #3322 unsafe-any, #3331 engine, #3314 miner, #3315/#3313/#3310 selfhost, #3305 enrichment-wire, #3281 grafana, #3255 queue). Should merge cleanly after any of those land without rebase.

Made with [Cursor](https://cursor.com)