### PR TITLE
fix(rag): index TypeScript .mts and .cts module sources

### DIFF
--- a/src/review/rag.ts
+++ b/src/review/rag.ts
@@ -127,7 +127,7 @@ const SKIP_FILE_RE =
 const BINARY_EXT_RE =
   /\.(png|jpe?g|gif|webp|avif|bmp|tiff?|heic|psd|svg|ico|pdf|zip|gz|tgz|tar|bz2|xz|zst|7z|rar|wasm|woff2?|otf|ttf|eot|mp4|mov|webm|mkv|mp3|wav|flac|ogg|opus|bin|exe|dll|so|dylib|node|class|jar|pyc|sqlite|db|parquet|onnx|gguf|safetensors|pt|pth|ckpt|npy|npz)$/i;
 const CODE_EXT_RE =
-  /\.(ts|tsx|js|jsx|mjs|cjs|py|go|rs|java|kt|kts|rb|php|c|h|cc|cpp|hpp|cs|swift|scala|sh|bash|zsh|sql|graphql|proto|toml|yaml|yml|json|jsonc|css|scss|less|vue|svelte|astro|tf|hcl|dart|lua|ex|exs|clj|cljs|cljc|hs|jl|nim|zig|groovy)$/i;
+  /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|go|rs|java|kt|kts|rb|php|c|h|cc|cpp|hpp|cs|swift|scala|sh|bash|zsh|sql|graphql|proto|toml|yaml|yml|json|jsonc|css|scss|less|vue|svelte|astro|tf|hcl|dart|lua|ex|exs|clj|cljs|cljc|hs|jl|nim|zig|groovy)$/i;
 // Doc extensions mirror the canonical DOCS_EXTENSIONS set in signals/path-matchers.ts
 // (md, mdx, markdown, rst, adoc, asciidoc); the long-form `markdown`/`asciidoc`
 // spellings were missing here, so e.g. NOTES.markdown / guide.asciidoc were

--- a/test/unit/rag.test.ts
+++ b/test/unit/rag.test.ts
@@ -45,6 +45,11 @@ describe("rag: code-not-content filtering (free-tier cost guard)", () => {
   it("indexes source code + docs, skips content/data/deps/binaries", () => {
     expect(classifyRepoFile("src/core/runtime.ts")).toBe("code");
     expect(classifyRepoFile("scripts/build.mjs")).toBe("code");
+    // TypeScript module extensions (parity with signals/local-branch isCodeFile)
+    expect(classifyRepoFile("src/loader.mts")).toBe("code");
+    expect(classifyRepoFile("src/setup.cts")).toBe("code");
+    expect(filePriority("src/loader.mts")).toBe(0);
+    expect(isIndexablePath("src/setup.cts")).toBe(true);
     // additional source languages (parity with the changed-file source classifiers)
     for (const p of [
       "lib/widget.dart",


### PR DESCRIPTION
## Summary

- Add `.mts` and `.cts` to `CODE_EXT_RE` in `src/review/rag.ts` so RAG indexes TypeScript module sources instead of skipping them.
- `isCodeFile` in `signals/local-branch.ts` already treats these as source; RAG was the outlier, so PRs touching only `.mts`/`.cts` files got no retrieved code context.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated changes.
- [x] This follows `CONTRIBUTING.md`.
- [x] Small enough that no linked issue is needed.

## Validation

- [x] `git diff --check`
- [x] `npm run test:ci` (includes actionlint, typecheck, test:coverage, workers, MCP, UI checks)
- [x] `npm audit --audit-level=moderate`
- [x] Unit tests cover `.mts`/`.cts` classification, `filePriority`, and `isIndexablePath`

If any required check was skipped, explain why:

- Full gate run as `npm run test:ci` on Node 22 before push.

## Safety

- [x] No secrets or private data exposed.
- [x] No auth/API/UI behavior changes.
- [x] N/A for UI Evidence — backend RAG classifier only.

## UI Evidence

N/A — no visible UI change.

## Notes

**Conflict avoidance:** Touches only `src/review/rag.ts` and `test/unit/rag.test.ts`. Zero file overlap with open PRs (#3316 dart classifiers, #3304 mega, #3340 engine, #3339/#3338/#3337/#3333 enrichment, #3315/#3313/#3310 selfhost, #3314 miner, #3305 enrichment-wire, #3281 grafana, #3255 queue). Should merge cleanly after any of those land without rebase.

Made with [Cursor](https://cursor.com)