### PR TITLE
feat(enrichment): detect Knock service and Sourcegraph access tokens

### DIFF
--- a/review-enrichment/src/analyzers/secret-scan.ts
+++ b/review-enrichment/src/analyzers/secret-scan.ts
@@ -380,6 +380,18 @@ const RULES: Rule[] = [
     confidence: "high",
   },
   {
+    // Knock management API service token: `knock_st_` + base62 body.
+    kind: "knock_service_token",
+    re: /\bknock_st_[A-Za-z0-9]{20,}(?![A-Za-z0-9_-])/,
+    confidence: "high",
+  },
+  {
+    // Sourcegraph access token: `sgp_` + 16 hex + `_` + 40 hex (distinct from generic hex blobs).
+    kind: "sourcegraph_access_token",
+    re: /\bsgp_[a-fA-F0-9]{16}_[a-fA-F0-9]{40}(?![A-Za-z0-9_-])/,
+    confidence: "high",
+  },
+  {
     // Google OAuth 2.0 client secret: `GOCSPX-` + 28 base64url chars.
     kind: "google_oauth_client_secret",
     re: /\bGOCSPX-[A-Za-z0-9_-]{28}\b/,

--- a/review-enrichment/test/secret-scan.test.ts
+++ b/review-enrichment/test/secret-scan.test.ts
@@ -1093,6 +1093,53 @@ test("scanPatch does not flag truncated Axiom tokens or identifier continuation"
   );
 });
 
+test("scanPatch flags Knock service and Sourcegraph access tokens with high confidence", () => {
+  const fakeKnockToken = "knock_st_" + "a".repeat(20);
+  const knockFindings = scanPatch("src/config.ts", hunk([`const knock = "${fakeKnockToken}";`]));
+  assert.equal(knockFindings.length, 1);
+  assert.equal(knockFindings[0].kind, "knock_service_token");
+  assert.equal(knockFindings[0].confidence, "high");
+
+  const fakeSourcegraphToken = "sgp_" + hex(16) + "_" + hex(40);
+  const sourcegraphFindings = scanPatch("src/config.ts", hunk([`const sg = "${fakeSourcegraphToken}";`]));
+  assert.equal(sourcegraphFindings.length, 1);
+  assert.equal(sourcegraphFindings[0].kind, "sourcegraph_access_token");
+  assert.equal(sourcegraphFindings[0].confidence, "high");
+});
+
+test("scanPatch does not flag truncated Knock/Sourcegraph tokens or identifier continuation", () => {
+  assert.equal(scanPatch("src/config.ts", hunk([`const knock = "knock_st_${"a".repeat(19)}";`])).length, 0);
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const knock = "knock_st_${"a".repeat(20)}_suffix";`])).some((f) => f.kind === "knock_service_token"),
+    false,
+  );
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const knock = "knock_st_${"a".repeat(20)}-suffix";`])).some((f) => f.kind === "knock_service_token"),
+    false,
+  );
+
+  const shortSourcegraphToken = "sgp_" + hex(16) + "_" + hex(39);
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const sg = "${shortSourcegraphToken}";`])).some((f) => f.kind === "sourcegraph_access_token"),
+    false,
+  );
+  const sourcegraphSuffixToken = "sgp_" + hex(16) + "_" + hex(40) + "-suffix";
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const sg = "${sourcegraphSuffixToken}";`])).some((f) => f.kind === "sourcegraph_access_token"),
+    false,
+  );
+  const sourcegraphUnderscoreToken = "sgp_" + hex(16) + "_" + hex(40) + "_suffix";
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const sg = "${sourcegraphUnderscoreToken}";`])).some((f) => f.kind === "sourcegraph_access_token"),
+    false,
+  );
+  const sourcegraphAlphaSuffixToken = "sgp_" + hex(16) + "_" + hex(40) + "z";
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const sg = "${sourcegraphAlphaSuffixToken}";`])).some((f) => f.kind === "sourcegraph_access_token"),
+    false,
+  );
+});
+
 test("scanPatch flags additional high-confidence SaaS/cloud/CI credential formats", () => {
   const cases = [
     ["google_oauth_client_secret", "GOCSPX-" + b62(28)],


### PR DESCRIPTION
## Summary
- Add `knock_service_token` rule for Knock `knock_st_` management API service tokens
- Add `sourcegraph_access_token` rule for Sourcegraph `sgp_` + 16 hex + `_` + 40 hex access tokens
- Include positive, truncation, and identifier-continuation negative tests (`-suffix`, `_suffix`, alpha)

## Test plan
- [x] `cd review-enrichment && npm run build && node --test test/secret-scan.test.ts` (96 passing)


Made with [Cursor](https://cursor.com)