### PR TITLE
fix(signals): classify .mts and .cts source maps as generated

### DIFF
--- a/src/signals/path-matchers.ts
+++ b/src/signals/path-matchers.ts
@@ -65,7 +65,7 @@ function isGeneratedFileFrom(parts: NormalizedPath): boolean {
     // Source maps for every first-class JS/TS bundle extension. `.mjs`/`.cjs` are already
     // recognized code extensions (isCodeFile), so their bundlers' `.mjs.map` / `.cjs.map`
     // maps are generated output too — the same as `.js.map`.
-    /\.(js|jsx|mjs|cjs|ts|tsx|css)\.map$/.test(norm) ||
+    /\.(js|jsx|mjs|cjs|ts|tsx|mts|cts|css)\.map$/.test(norm) ||
     base === "worker-configuration.d.ts"
   );
 }

--- a/test/unit/path-matchers.test.ts
+++ b/test/unit/path-matchers.test.ts
@@ -41,7 +41,7 @@ describe("isGeneratedFile", () => {
   it("matches source maps for every first-class JS/TS bundle extension", () => {
     // `.mjs`/`.cjs` are recognized code extensions (isCodeFile), so their bundlers' source
     // maps are generated output too — the same as `.js.map` / `.tsx.map`.
-    for (const path of ["dist/bundle.mjs.map", "dist/bundle.cjs.map", "lib/index.jsx.map"]) {
+    for (const path of ["dist/bundle.mjs.map", "dist/bundle.cjs.map", "lib/index.jsx.map", "dist/loader.mts.map", "dist/setup.cts.map"]) {
       expect(isGeneratedFile(path)).toBe(true);
     }
   });


### PR DESCRIPTION
## Summary

- Extend `isGeneratedFile` in `path-matchers.ts` to treat `.mts.map` and `.cts.map` as generated output, matching the existing `.mjs.map`/`.cjs.map`/`.ts.map` handling.
- TypeScript module bundlers emit these source-map siblings; without this, slop `classifyChangedFile` miscounted them as substantive source effort.

## Scope

- [x] Conventional Commit title format.
- [x] Focused change — path-matchers + unit tests only.
- [x] Follows `CONTRIBUTING.md`.
- [x] No linked issue needed (small classifier parity fix).

## Validation

- [x] `git diff --check`
- [x] `npm run test:ci` on Node 22 (actionlint, typecheck, test:coverage, workers, MCP, UI)
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] Unit tests cover `.mts.map` and `.cts.map` in `isGeneratedFile`

## Safety

- [x] No secrets, auth, or UI changes.
- [x] N/A for UI Evidence.

## UI Evidence

N/A — backend path classifier only.

## Notes

**Conflict avoidance:** Touches only `src/signals/path-matchers.ts` and `test/unit/path-matchers.test.ts`. Zero overlap with open PRs (#3316 dart classifiers, #3304 review holds, #3344/#3343/#3339 enrichment, #3340 engine, #3314 miner, #3305 enrichment-wire, #3281 grafana, #3255 queue). Should merge cleanly after any of those land without rebase.

Made with [Cursor](https://cursor.com)