### PR TITLE
fix(enrichment): guard intercom token suffixes

### DIFF
--- a/review-enrichment/src/analyzers/secret-scan.ts
+++ b/review-enrichment/src/analyzers/secret-scan.ts
@@ -208,7 +208,7 @@ const RULES: Rule[] = [
   {
     // Intercom access token: base64 `tok:` prefix (`dG9rOm`) + opaque body.
     kind: "intercom_access_token",
-    re: /\bdG9rOm[A-Za-z0-9+/=]{30,}(?![A-Za-z0-9+/=])/,
+    re: /\bdG9rOm[A-Za-z0-9+/=]{30,}(?![A-Za-z0-9_+/=])/,
     confidence: "high",
   },
   {

--- a/review-enrichment/test/secret-scan.test.ts
+++ b/review-enrichment/test/secret-scan.test.ts
@@ -526,6 +526,12 @@ test("scanPatch does not flag truncated Cohere/Intercom tokens or identifier con
     false,
   );
   assert.equal(scanPatch("src/config.ts", hunk([`const intercom = "dG9rOm${"a".repeat(29)}";`])).length, 0);
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const intercom = "dG9rOm${"a".repeat(30)}_suffix";`])).some(
+      (f) => f.kind === "intercom_access_token",
+    ),
+    false,
+  );
 });
 
 test("scanPatch flags Together AI and Fireworks API keys with high confidence", () => {


### PR DESCRIPTION
### Motivation
- Fix a false-positive in the Intercom secret-scan rule where underscore continuation after an Intercom-like prefix could be misclassified as a high-confidence token.

### Description
- Tighten the Intercom regex tail guard from `(?![A-Za-z0-9+/=])` to `(?![A-Za-z0-9_+/=])` and add a regression assertion that a `dG9rOm..._suffix` string is not flagged.

### Testing
- Ran `npm --prefix review-enrichment test`, which completed successfully and covers the added regression assertion.
- Ran `git diff --check`, which passed locally.
- Attempted `npm run test:ci` and `npm audit --audit-level=moderate` as part of validation; `test:ci` timed out / encountered unrelated long-running suites in the root run and `npm audit` returned a 403 from the registry, so those end-to-end checks were not completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49b65fac58832c91281f9b63185672)