### PR TITLE
fix(api): restrict approval decisions to server auth

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -5057,7 +5057,7 @@ function canSessionAccessPath(env: Env, identity: Extract<AuthIdentity, { kind: 
   if (isRepoCheckBeforeStartPath(path)) return true;
   if (isRepoValidateLinkedIssuePath(path)) return true;
   if (isRepoAgentAuditFeedPath(path)) return true; // route's requireRepoMaintainer enforces per-repo authority (contributors → 403)
-  if (isRepoAgentPendingActionsPath(path)) return true; // list: requireRepoMaintainer; decide: requireRepoWriteAccess
+  if (isRepoAgentPendingActionsPath(path)) return true; // list-only: requireRepoMaintainer; decision POSTs require server tokens
   if (isRepoContributorIssueDraftGeneratePath(path)) return true;
   if (path === LINT_PR_TEXT_PATH || path === LINT_SLOP_RISK_PATH || path === LINT_ISSUE_SLOP_PATH) return true;
   if (path === EXTENSION_PULL_CONTEXT_PATH && isExtensionScopedSession(identity)) return true;
@@ -5107,7 +5107,7 @@ function isRepoAgentAuditFeedPath(path: string): boolean {
   return /^\/v1\/repos\/[^/]+\/[^/]+\/agent\/audit-feed$/.test(path);
 }
 
-function isRepoAgentPendingActionsPath(path: string): boolean { return /^\/v1\/repos\/[^/]+\/[^/]+\/agent\/pending-actions(?:\/[^/]+\/(?:accept|reject))?$/.test(path); }
+function isRepoAgentPendingActionsPath(path: string): boolean { return /^\/v1\/repos\/[^/]+\/[^/]+\/agent\/pending-actions$/.test(path); }
 function isIssueQualityPath(path: string): boolean {
   return /^\/v1\/repos\/[^/]+\/[^/]+\/issue-quality$/.test(path);
 }

--- a/test/unit/routes-agent-approval.test.ts
+++ b/test/unit/routes-agent-approval.test.ts
@@ -153,6 +153,24 @@ describe("agent approval-queue routes (#779)", () => {
     await expect(list.json()).resolves.toMatchObject({ repoFullName: "owner/repo", pendingActions: [{ actionClass: "merge", status: "pending" }] });
   });
 
+  it("forbids repository owner browser sessions from deciding pending actions", async () => {
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
+    await upsertInstallation(env, {
+      installation: { id: 5, account: { login: "owner", id: 1, type: "User" }, repository_selection: "selected", permissions: { metadata: "read", contents: "write", pull_requests: "write", issues: "write" }, events: ["pull_request"] },
+      repositories: [{ name: "repo", full_name: "owner/repo", private: false, owner: { login: "owner" } }],
+    });
+    await upsertRepositoryFromGitHub(env, { name: "repo", full_name: "owner/repo", private: false, owner: { login: "owner" } }, 5);
+    const action = await seedPending(env);
+    const { token } = await createSessionForGitHubUser(env, { login: "owner", id: 1 });
+
+    const res = await app.request(`/v1/repos/owner/repo/agent/pending-actions/${action.id}/accept`, { method: "POST", headers: { cookie: `gittensory_session=${token}`, origin: "https://preview.example" } }, env);
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toMatchObject({ error: "insufficient_role" });
+    expect(mergePullRequest).not.toHaveBeenCalled();
+    expect((await getPendingAgentAction(env, action.id))?.status).toBe("pending");
+  });
+
   it("forbids a contributor (non-maintainer) session even though the coarse allowlist permits the path", async () => {
     const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
     await upsertInstallation(env, {


### PR DESCRIPTION
### Motivation
- Prevent cookie-backed browser OAuth sessions from reaching the state-changing agent pending-action decision endpoints (`/accept` / `/reject`) which opened a CSRF-exploitable path by coarse allowlisting the whole pending-actions family.

### Description
- Narrow the `isRepoAgentPendingActionsPath` regex in `src/api/routes.ts` so it matches only the read-only list endpoint (`/v1/repos/:owner/:repo/agent/pending-actions`) and no longer admits `/:id/accept` or `/:id/reject` for session auth.
- Clarify the allowlist comment to document that decision POSTs require server (bearer) auth while the list remains reachable to maintainer sessions.
- Add a regression unit test in `test/unit/routes-agent-approval.test.ts` asserting that a repository-owner browser session receives `403` and does not execute an approval POST, leaving the queued action pending.

### Testing
- Ran targeted unit tests with `npx vitest run test/unit/routes-agent-approval.test.ts test/unit/access-boundary.test.ts` and both suites passed.
- Ran `npm run ui:openapi:check` which succeeded to confirm OpenAPI parity.
- Attempted a full coverage run with `npm run test:coverage` but the local unsharded run could not be completed in this environment due to long-running suites/timeouts, so a complete coverage report was not produced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49ae4a1200832ca73721dbfaa021da)