### PR TITLE
fix(signals): classify vue/svelte/astro source maps as generated

### DIFF
--- a/src/signals/path-matchers.ts
+++ b/src/signals/path-matchers.ts
@@ -65,7 +65,7 @@ function isGeneratedFileFrom(parts: NormalizedPath): boolean {
     // Source maps for every first-class JS/TS bundle extension. `.mjs`/`.cjs` are already
     // recognized code extensions (isCodeFile), so their bundlers' `.mjs.map` / `.cjs.map`
     // maps are generated output too — the same as `.js.map`.
-    /\.(js|jsx|mjs|cjs|ts|tsx|mts|cts|css)\.map$/.test(norm) ||
+    /\.(js|jsx|mjs|cjs|ts|tsx|mts|cts|vue|svelte|astro|css)\.map$/.test(norm) ||
     base === "worker-configuration.d.ts"
   );
 }

--- a/test/unit/path-matchers.test.ts
+++ b/test/unit/path-matchers.test.ts
@@ -38,10 +38,19 @@ describe("isGeneratedFile", () => {
     }
   });
 
-  it("matches source maps for every first-class JS/TS bundle extension", () => {
+  it("matches source maps for every first-class JS/TS and front-end framework extension", () => {
     // `.mjs`/`.cjs` are recognized code extensions (isCodeFile), so their bundlers' source
     // maps are generated output too — the same as `.js.map` / `.tsx.map`.
-    for (const path of ["dist/bundle.mjs.map", "dist/bundle.cjs.map", "lib/index.jsx.map", "dist/loader.mts.map", "dist/setup.cts.map"]) {
+    for (const path of [
+      "dist/bundle.mjs.map",
+      "dist/bundle.cjs.map",
+      "lib/index.jsx.map",
+      "dist/loader.mts.map",
+      "dist/setup.cts.map",
+      "dist/App.vue.map",
+      "dist/Card.svelte.map",
+      "dist/page.astro.map",
+    ]) {
       expect(isGeneratedFile(path)).toBe(true);
     }
   });


### PR DESCRIPTION
## Summary

- Extend `isGeneratedFile` in `path-matchers.ts` to treat `.vue.map`, `.svelte.map`, and `.astro.map` as generated output, matching the existing `.ts.map`/`.mts.map` handling (#3347).
- After vue/svelte/astro became first-class code extensions (#3292), bundler source-map siblings were still miscounted as substantive source in `classifyChangedFile`.

## Scope

- [x] Conventional Commit title format.
- [x] Focused — path-matchers + unit tests only.
- [x] Follows `CONTRIBUTING.md`.
- [x] No linked issue needed.

## Validation

- [x] `git diff --check`
- [x] `npm run test:ci` on Node 22
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] Unit tests cover `.vue.map`, `.svelte.map`, `.astro.map`

## Safety

- [x] No secrets, auth, or UI changes.
- [x] N/A for UI Evidence.

## UI Evidence

N/A — backend path classifier only.

## Notes

**Conflict avoidance:** Touches only `src/signals/path-matchers.ts` and `test/unit/path-matchers.test.ts`. Zero overlap with open PRs (#3316 dart, #3304 review holds, #3350 api auth, #3340 engine, #3339 enrichment, #3314 miner, #3305 enrichment-wire, #3281 grafana). Merges cleanly after any of those land without rebase.

Made with [Cursor](https://cursor.com)