### PR TITLE
feat(enrichment): flag insecure Docker Compose / container-runtime settings in iac-misconfig

### DIFF
--- a/review-enrichment/src/analyzers/iac-misconfig.ts
+++ b/review-enrichment/src/analyzers/iac-misconfig.ts
@@ -85,6 +85,22 @@ const VALIDATE_CERTS_OFF_RE = /\bvalidate_certs\b[\s"'=:,-]*["']?(?:no|false)\b/
 const TLS_SKIP_VERIFY_RE = /\b(?:tls_skip_verify|insecure_skip_verify)\b[\s"'=:,-]*true\b/i;
 const TRUST_ALL_CERTS_RE = /\bTrustServerCertificate\s*=\s*["']?true\b/i;
 
+// Docker Compose / container-runtime hardening. In each case the MATCHED VALUE is the insecure action itself
+// (dropping a confinement, sharing a host namespace, granting all capabilities, or mounting the host Docker
+// socket), so there is no "safe value" form of the same line — the secure setting uses a different value the
+// regex never matches. `cap_add` is the ADD list specifically, so `cap_drop: [ALL]` (the safe hardening) is
+// never matched.
+const SECCOMP_UNCONFINED_RE = /\bseccomp[=:]\s*["']?unconfined\b/i;
+const APPARMOR_UNCONFINED_RE = /\bapparmor[=:]\s*["']?unconfined\b/i;
+const USERNS_HOST_RE = /\buserns_mode\s*:\s*["']?host\b/i;
+const IPC_HOST_RE = /\bipc\s*:\s*["']?host\b/i;
+const CAP_ADD_ALL_RE = /\bcap_add\b[^\n]*\bALL\b/;
+const NO_NEW_PRIVILEGES_OFF_RE = /\bno-new-privileges[=:]\s*["']?false\b/i;
+// Require the trailing `:` (the compose volume-mount source→target separator) so a plain reference such as
+// `DOCKER_HOST=unix:///var/run/docker.sock` — the normal way the CLI addresses the daemon, not a mount — is
+// NOT flagged; only a bind mount of the socket into a container is.
+const DOCKER_SOCKET_MOUNT_RE = /\/var\/run\/docker\.sock:/;
+
 function* patchLines(patch: string): Generator<string> {
   let start = 0;
   for (let i = 0; i <= patch.length; i++) {
@@ -450,6 +466,48 @@ export function scanPatchForIacMisconfig(
     if (
       TRUST_ALL_CERTS_RE.test(body) &&
       pushFinding(findings, seen, path, newLine, "trust-all-server-certs", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      SECCOMP_UNCONFINED_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "seccomp-unconfined-runtime", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      APPARMOR_UNCONFINED_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "apparmor-unconfined", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      USERNS_HOST_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "userns-host", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      IPC_HOST_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "ipc-host", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      CAP_ADD_ALL_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "cap-add-all", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      NO_NEW_PRIVILEGES_OFF_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "no-new-privileges-off", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      DOCKER_SOCKET_MOUNT_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "docker-socket-mount", maxFindings)
     ) {
       return findings;
     }

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -339,6 +339,20 @@ export function renderBrief(
           return "sets `tls_skip_verify`/`insecure_skip_verify: true`, so TLS certificate verification is skipped";
         case "trust-all-server-certs":
           return "sets `TrustServerCertificate=true`, so the client trusts any database server certificate";
+        case "seccomp-unconfined-runtime":
+          return "runs the container with `seccomp:unconfined`, disabling the syscall filter";
+        case "apparmor-unconfined":
+          return "runs the container with `apparmor:unconfined`, disabling the AppArmor profile";
+        case "userns-host":
+          return "sets `userns_mode: host`, disabling user-namespace remapping so container UID 0 is host root";
+        case "ipc-host":
+          return "sets `ipc: host`, sharing the host IPC namespace (host shared memory is reachable from the container)";
+        case "cap-add-all":
+          return "adds `ALL` Linux capabilities to the container (`cap_add: [ALL]`), which is close to privileged";
+        case "no-new-privileges-off":
+          return "disables the `no-new-privileges` protection, allowing setuid binaries to escalate privileges";
+        case "docker-socket-mount":
+          return "mounts the host Docker socket (`/var/run/docker.sock`) into the container — this grants host-level control";
       }
     };
 

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -250,7 +250,14 @@ export interface IacMisconfigFinding {
     | "verify-ssl-off"
     | "validate-certs-off"
     | "tls-skip-verify"
-    | "trust-all-server-certs";
+    | "trust-all-server-certs"
+    | "seccomp-unconfined-runtime"
+    | "apparmor-unconfined"
+    | "userns-host"
+    | "ipc-host"
+    | "cap-add-all"
+    | "no-new-privileges-off"
+    | "docker-socket-mount";
 }
 
 /** A newly-added dependency whose install compiles native code (npm node-gyp addon) or has no prebuilt wheel

--- a/review-enrichment/test/iac-misconfig.test.ts
+++ b/review-enrichment/test/iac-misconfig.test.ts
@@ -396,3 +396,50 @@ test("scanPatchForIacMisconfig does not flag the secure counterpart of each TLS-
     );
   }
 });
+
+test("scanPatchForIacMisconfig flags insecure Docker Compose / container-runtime settings", () => {
+  // In each case the matched VALUE is the insecure action itself, so there is no safe-value form of the line.
+  const cases = [
+    ["+    security_opt: [seccomp:unconfined]", "seccomp-unconfined-runtime"],
+    ["+      - apparmor:unconfined", "apparmor-unconfined"],
+    ["+    userns_mode: host", "userns-host"],
+    ["+    ipc: host", "ipc-host"],
+    ["+    cap_add: [ALL]", "cap-add-all"],
+    ["+      - no-new-privileges:false", "no-new-privileges-off"],
+    ["+      - /var/run/docker.sock:/var/run/docker.sock", "docker-socket-mount"],
+  ];
+  for (const [added, kind] of cases) {
+    const findings = scanPatchForIacMisconfig(
+      "docker-compose.yml",
+      ["@@ -1,0 +1,1 @@", added].join("\n"),
+    );
+    assert.deepEqual(
+      findings,
+      [{ file: "docker-compose.yml", line: 1, kind }],
+      `${kind}: expected exactly one finding of that kind, got ${JSON.stringify(findings)}`,
+    );
+  }
+});
+
+test("scanPatchForIacMisconfig does not flag the secure counterpart of each container-runtime setting", () => {
+  // The secure value uses a different token the regex never matches. `cap_drop: [ALL]` is the SAFE hardening
+  // (drop all caps) and must not fire the `cap_add: [ALL]` rule.
+  const safe = [
+    "+    security_opt: [seccomp:runtime-default]",
+    "+      - apparmor:docker-default",
+    "+    userns_mode: private",
+    "+    ipc: private",
+    "+    cap_drop: [ALL]",
+    "+      - no-new-privileges:true",
+    "+      - ./data:/app/data",
+    // Referencing the socket path (how the CLI addresses the daemon) is NOT a mount — must not be flagged.
+    "+    DOCKER_HOST: unix:///var/run/docker.sock",
+  ];
+  for (const added of safe) {
+    assert.deepEqual(
+      scanPatchForIacMisconfig("docker-compose.yml", ["@@ -1,0 +1,1 @@", added].join("\n")),
+      [],
+      `should not flag: ${added.trim()}`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

The IaC-misconfig analyzer already covers Kubernetes `securityContext`, Dockerfile, and TLS-bypass
misconfigurations. This adds **7 Docker Compose / container-runtime hardening rules** for insecure settings the
analyzer's config-file scan already sees (`docker-compose.yml`, `compose.yaml`, and similar):

| kind | fires on | risk |
|---|---|---|
| `seccomp-unconfined-runtime` | `security_opt: [seccomp:unconfined]` | disables the syscall filter |
| `apparmor-unconfined` | `apparmor:unconfined` | disables the AppArmor profile |
| `userns-host` | `userns_mode: host` | disables user-namespace remapping (container UID 0 = host root) |
| `ipc-host` | `ipc: host` | shares the host IPC namespace |
| `cap-add-all` | `cap_add: [ALL]` | grants all Linux capabilities (near-privileged) |
| `no-new-privileges-off` | `no-new-privileges:false` | allows setuid privilege escalation |
| `docker-socket-mount` | a bind mount of `/var/run/docker.sock` | grants host-level Docker control |

**Why these are false-positive-safe:** in every rule the *matched value is the insecure action itself* —
dropping a confinement, sharing a host namespace, granting all capabilities, or mounting the host Docker
socket. There is no "safe value" form of the same line: the secure setting uses a *different* value the regex
never matches (`seccomp:runtime-default`, `userns_mode: private`, `ipc: private`, `no-new-privileges:true`, …),
which the negative test asserts produces no finding. Two details worth calling out:

- `cap_add` is matched **specifically** (not `cap_drop`), so `cap_drop: [ALL]` — the safe hardening that drops
  every capability — is never flagged (asserted in the negative test).
- `docker-socket-mount` requires the trailing `:` of a compose volume mount, so a plain reference such as
  `DOCKER_HOST=unix:///var/run/docker.sock` (the normal way the CLI addresses the daemon — not a mount) is
  **not** flagged (asserted in the negative test).

No existing rule is modified, and the analyzer's finding schema is `{file, line, kind}` — the `kind` union is
not part of the analyzer descriptor, so `analyzer-metadata.json` and the generated UI mirror are **unchanged**.
The render-brief switch is TypeScript-exhaustive, so each new kind is compiler-forced to have a public-safe
explanation.

No linked issue: additive detection-coverage that extends an existing multi-domain analyzer along its own
established lines; each rule is a self-evident, named container-hardening check (hadolint/checkov/CIS Docker)
with no public API/schema/deploy surface change — fits the repo's `preferred` (not required) linked-issue policy.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run typecheck`
- [x] `npm run rees:test` — the review-enrichment build + analyzer suite (see note below)
- [ ] `npm run test:coverage` (N/A — this analyzer is in `review-enrichment/`, outside the root `src/**` Codecov scope)
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran locally: `git diff --check` (clean), the review-enrichment TypeScript build (exit 0 — which proves the
  render switch is exhaustive over the 7 new kinds), and the analyzer suite via `node --test`. The
  iac-misconfig file passes 19/19: a table test asserting each of the 7 settings produces exactly one finding
  of its own kind, and a negative test asserting the secure counterpart of each (including `cap_drop: [ALL]`
  and the `DOCKER_HOST` socket reference) produces none. The full `node --test` run's only failures are the two
  `upload-sourcemaps` tests (they shell out to the Sentry CLI, absent on this dev box), which fail identically
  on unmodified `main`.
- Not run locally: the UI, root typecheck, and the `metadata:check` step of `rees:test`. This change adds only
  finding kinds and rules, not any analyzer descriptor field, so the committed `analyzer-metadata.json` / UI
  mirror are unchanged (a local regeneration produces a zero-content diff) and `metadata:check` passes on CI
  (Linux). On this Windows dev box `metadata:check` reports a spurious line-ending difference; it fails
  identically on unmodified `main`. `analyzer-metadata.json` was NOT modified.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Detection-only additions: 7 new stateless rules following the existing single-line pattern; no existing rule,
  threshold, or descriptor changed, so current findings and `analyzer-metadata.json` are unaffected. Each new
  kind reports only `file:line` + the public-safe kind, never the matched line content.
- These are the Docker Compose equivalents of container-runtime hardening; they key on Compose-specific tokens
  (`security_opt`, `userns_mode`, `cap_add`, the socket bind mount) distinct from the Kubernetes forms the
  analyzer already covers.
