### PR TITLE
feat(enrichment): skip all binary + lockfile files in history analyzers

### DIFF
--- a/review-enrichment/src/analyzers/blame-link.ts
+++ b/review-enrichment/src/analyzers/blame-link.ts
@@ -12,15 +12,13 @@ import type {
 } from "../types.js";
 import type { AnalysisContext } from "../analysis-context.js";
 import { boundedFetchJson } from "../external-fetch.js";
+import { isHistoryUninformativePath } from "./history-path.js";
 
 const GITHUB_API = "https://api.github.com";
 const SLUG_RE = /^[A-Za-z0-9._-]+$/;
 const MAX_FILES_PROBED = 6; // bound the files we probe, matching the other history-class analyzers
 const MAX_LOOKUPS = 12; // hard cap on total GitHub round-trips (each file costs up to 2: commits + pulls)
 const SHA_PREFIX_LEN = 12;
-// Files whose commit history is not a useful "who introduced this" signal — lockfiles, generated output, binaries.
-const SKIP_RE =
-  /(?:^|\/)(?:package-lock\.json|yarn\.lock|pnpm-lock\.yaml|poetry\.lock|go\.sum)$|\.(?:lock|min\.js|map|snap|png|jpe?g|gif|svg|ico|pdf|zip|gz|woff2?)$|(?:^|\/)(?:dist|build|vendor)\//i;
 
 interface ScanOptions {
   signal?: AbortSignal;
@@ -159,7 +157,7 @@ export async function scanBlameLink(
   // additions (a patch with no deletion line has no prior author to attribute).
   const candidates: Array<{ lookupPath: string; displayPath: string; line: number }> = [];
   for (const file of files) {
-    if (file.status === "added" || SKIP_RE.test(file.path)) continue;
+    if (file.status === "added" || isHistoryUninformativePath(file.path)) continue;
     let line = file.patch ? firstTouchedOldLine(file.patch) : null;
     // A removed OR renamed file resolves against the base tree even without a usable patch (binary/truncated, or a
     // pure rename with no content change). Anchor to line 1 as the representative point.

--- a/review-enrichment/src/analyzers/churn-hotspot.ts
+++ b/review-enrichment/src/analyzers/churn-hotspot.ts
@@ -11,6 +11,7 @@ import type {
 } from "../types.js";
 import type { AnalysisContext } from "../analysis-context.js";
 import { boundedFetchJson } from "../external-fetch.js";
+import { isHistoryUninformativePath } from "./history-path.js";
 
 const GITHUB_API = "https://api.github.com";
 const SLUG_RE = /^[A-Za-z0-9._-]+$/;
@@ -19,9 +20,6 @@ const PER_PAGE = 100; // one page; a file with a full page of commits in the win
 const MAX_FILES_PROBED = 8; // bound the GitHub round-trips, matching the other history-class analyzers
 const MIN_COMMITS = 8; // a hotspot must change frequently within the window
 const MIN_FIX_FRACTION = 0.3; // and a meaningful share of those changes must be fixes/reverts
-// Files whose commit churn is not a useful code-fragility signal — lockfiles, generated output, and binaries.
-const SKIP_RE =
-  /(?:^|\/)(?:package-lock\.json|yarn\.lock|pnpm-lock\.yaml|poetry\.lock|go\.sum)$|\.(?:lock|min\.js|map|snap|png|jpe?g|gif|svg|ico|pdf|zip|gz|woff2?)$|(?:^|\/)(?:dist|build|vendor)\//i;
 // Defect-correcting commit subjects: fix/bugfix/hotfix/revert/regression (conventional-commit `fix:` included).
 const FIX_RE = /\b(?:fix(?:e[ds]|ing)?|bug ?fix|hotfix|revert(?:ed|s)?|regression)\b/i;
 
@@ -109,7 +107,7 @@ export async function scanChurnHotspot(
   const since = new Date(Date.now() - WINDOW_DAYS * 86_400_000).toISOString();
   // A newly-added file has no prior history; skip it (and non-code/generated files) before spending a round-trip.
   const paths = files
-    .filter((file) => file.status !== "added" && !SKIP_RE.test(file.path))
+    .filter((file) => file.status !== "added" && !isHistoryUninformativePath(file.path))
     .map((file) => file.path)
     .slice(0, MAX_FILES_PROBED);
 

--- a/review-enrichment/src/analyzers/history-path.ts
+++ b/review-enrichment/src/analyzers/history-path.ts
@@ -1,0 +1,20 @@
+// Shared skip predicate for the history-class analyzers (blame-link #2034, churn-hotspot #1513). A file whose
+// commit history carries no useful "who introduced this" / code-fragility signal — a lockfile, generated
+// output, or a binary blob — should be skipped by both, so the rule lives in one place instead of a duplicated
+// per-analyzer regex. Binary and lockfile recognition delegate to the unified inventories (binary-extensions,
+// lockfile-path) so this stays in sync as those grow, rather than a hand-maintained list.
+import { BINARY_EXT_RE } from "./binary-extensions.js";
+import { isSupportedLockfile } from "../lockfile-path.js";
+
+// Non-binary generated output (and the original narrow binary/lockfile set) — kept verbatim from the previous
+// per-analyzer SKIP_RE. Broader binary and lockfile coverage is added by the two shared inventories below.
+const SKIP_RE =
+  /(?:^|\/)(?:package-lock\.json|yarn\.lock|pnpm-lock\.yaml|poetry\.lock|go\.sum)$|\.(?:lock|min\.js|map|snap|png|jpe?g|gif|svg|ico|pdf|zip|gz|woff2?)$|(?:^|\/)(?:dist|build|vendor)\//i;
+
+/** True when a file's commit history is not a useful fragility/attribution signal — a lockfile, generated
+ *  output, or a binary blob. Additive over the original rule: it now also skips the full shared binary
+ *  inventory (e.g. webp/avif/heic/mp4/wasm/safetensors) and the full lockfile set (e.g. Cargo.lock,
+ *  composer.lock, bun.lockb), not just the original narrow list. Pure. */
+export function isHistoryUninformativePath(path: string): boolean {
+  return SKIP_RE.test(path) || BINARY_EXT_RE.test(path) || isSupportedLockfile(path);
+}

--- a/review-enrichment/test/churn-hotspot.test.ts
+++ b/review-enrichment/test/churn-hotspot.test.ts
@@ -61,7 +61,14 @@ test("scanChurnHotspot: marks the count capped when the page is full", async () 
 test("scanChurnHotspot: skips lockfiles, binaries, and newly-added files without fetching", async () => {
   let called = false;
   const out = await scanChurnHotspot(
-    req([{ path: "package-lock.json" }, { path: "assets/logo.png" }, { path: "src/new.ts", status: "added" }]),
+    req([
+      { path: "package-lock.json" },
+      { path: "assets/logo.png" },
+      // Broader shared-inventory skips: a heavy binary and a Cargo lockfile the original narrow regex missed.
+      { path: "models/llama.safetensors" },
+      { path: "crates/api/Cargo.lock" },
+      { path: "src/new.ts", status: "added" },
+    ]),
     async () => {
       called = true;
       return jsonResponse(commits(50, 2));

--- a/review-enrichment/test/history-path.test.ts
+++ b/review-enrichment/test/history-path.test.ts
@@ -1,0 +1,67 @@
+// Units for the shared history-class skip predicate used by blame-link and churn-hotspot.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { isHistoryUninformativePath } from "../dist/analyzers/history-path.js";
+
+test("isHistoryUninformativePath skips the original lockfile / generated / dir set", () => {
+  // Lockfiles from the original rule.
+  for (const p of [
+    "package-lock.json",
+    "app/yarn.lock",
+    "pkg/pnpm-lock.yaml",
+    "poetry.lock",
+    "svc/go.sum",
+  ]) {
+    assert.equal(isHistoryUninformativePath(p), true, p);
+  }
+  // Non-binary generated output and vendored/build directories.
+  for (const p of [
+    "flake.lock",
+    "app.min.js",
+    "bundle.js.map",
+    "__snapshots__/x.snap",
+    "icons/logo.svg",
+    "dist/app.js",
+    "build/out.js",
+    "vendor/pkg/mod.go",
+  ]) {
+    assert.equal(isHistoryUninformativePath(p), true, p);
+  }
+});
+
+test("isHistoryUninformativePath skips the full binary inventory, not just the original narrow list", () => {
+  // Original narrow binaries still skip.
+  for (const p of ["ui/logo.png", "fonts/Inter.woff2", "docs/spec.pdf"]) {
+    assert.equal(isHistoryUninformativePath(p), true, p);
+  }
+  // Newly-covered shared-inventory binaries (were NOT in the original per-analyzer regex).
+  for (const p of [
+    "media/demo.mp4",
+    "assets/hero.webp",
+    "assets/photo.heic",
+    "vendor/lib.wasm",
+    "models/llama.safetensors",
+    "models/model.gguf",
+  ]) {
+    assert.equal(isHistoryUninformativePath(p), true, p);
+  }
+});
+
+test("isHistoryUninformativePath skips the full lockfile inventory (Cargo/Composer/Bun)", () => {
+  for (const p of ["crates/api/Cargo.lock", "composer.lock", "bun.lockb"]) {
+    assert.equal(isHistoryUninformativePath(p), true, p);
+  }
+});
+
+test("isHistoryUninformativePath does not skip real source/doc files", () => {
+  for (const p of [
+    "src/index.ts",
+    "packages/app/main.rs",
+    "README.md",
+    "Cargo.toml",
+    "notes/cargo.lock.md",
+  ]) {
+    assert.equal(isHistoryUninformativePath(p), false, p);
+  }
+});


### PR DESCRIPTION
## Summary

The two history-class analyzers — `blame-link` (#2034) and `churn-hotspot` (#1513) — each carried an **identical, hand-maintained `SKIP_RE`** that skips files whose commit history is not a useful "who-introduced-this" / fragility signal (lockfiles, generated output, binaries). That regex only enumerated a narrow binary subset (`png`/`jpe?g`/`gif`/`svg`/`ico`/`pdf`/`zip`/`gz`/`woff2?`) and the five npm/yarn/pnpm/poetry/go lockfiles. So any binary it didn't list — `webp`, `avif`, `heic`, `mp4`, `wasm`, `safetensors`, and the rest of the shared inventory — plus Rust/PHP/Bun lockfiles were still treated as candidate history signals, producing noise on files that carry no code signal.

This change:

- **Extracts the rule** into a shared `isHistoryUninformativePath()` (new `analyzers/history-path.ts`). Both analyzers import it and drop their local copy, so the two **can no longer drift apart** (the duplicated regex was a latent desync hazard).
- **Broadens coverage** by delegating binary and lockfile recognition to the **unified inventories** — `binary-extensions`' `BINARY_EXT_RE` and `lockfile-path`'s `isSupportedLockfile` — instead of a hand-maintained list, so it stays in sync as those grow. This follows the same consolidation direction as #3252 (unified binary-extension inventory).
- **Purely additive:** the original regex is kept **verbatim** inside the shared helper and the two inventory checks are `OR`-ed on top, so it only ever skips **more** files, never fewer. No file that was analyzed before is newly skipped except genuine binaries/lockfiles that should have been skipped all along.

## No linked issue

This is a **no-issue PR** by design: a self-contained analyzer refactor + coverage fix touching only `review-enrichment/`. It removes a duplicated skip regex and broadens binary/lockfile coverage using existing shared helpers; no new external behavior beyond skipping more non-code files. It mirrors the accepted no-issue precedent for the same kind of enrichment change (e.g. the recently-merged `#3264` and `#3329`).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] No linked issue — see the **No linked issue** section above.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — no `src/**` lines changed (this change is under `review-enrichment/`, which Codecov does not measure), so `codecov/patch` has no diff to gate; suite is green.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New behavior has tests — a new `review-enrichment/test/history-path.test.ts` unit-covers `isHistoryUninformativePath` across every branch (original lockfile/generated/dir set, the broader shared binary inventory, the full lockfile inventory, and negatives like `Cargo.toml`/`cargo.lock.md`/source files); the existing `churn-hotspot` skip test is extended to prove a `.safetensors` blob and a `Cargo.lock` are now skipped without a fetch. `npm run rees:test` passes (929 tests; analyzer-metadata check clean).

Validated green against the full GitHub CI `validate-code` check set — `actionlint`, `db:migrations:check`, `db:schema-drift:check`, `cf-typegen:check`, `selfhost:validate-observability`, `typecheck`, `test:coverage`, `test:workers`, `build:mcp`, `test:mcp-pack`, `build:miner`, `rees:test`, `ui:openapi:check`, `ui:openapi:settings-parity`, `ui:version-audit`, `ui:lint`, `ui:typecheck`, `ui:test`, `ui:build`. Branch rebased on latest `main`.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] No auth, cookie, CORS, GitHub App, Cloudflare, or session changes (N/A — internal analyzer skip logic only).
- [x] No API/OpenAPI/MCP behavior change (N/A).
- [x] No UI changes (N/A — review-enrichment analyzers).
- [x] No visible UI change, so no UI Evidence section is required.
- [x] No docs/changelog changes needed.

## Notes

Both history analyzers are advisory, metadata-only (they surface a PR number / short SHA / counts from the public commit log, never file contents), and this change does not alter that — it only widens the set of non-code files they decline to spend a GitHub round-trip on. The original `SKIP_RE` is preserved verbatim inside the shared helper so its `.min.js`/`.map`/`.snap`/`.svg`/`dist|build|vendor` matches are unchanged; only binary and lockfile recognition is broadened via the shared inventories.
