### PR TITLE
fix(settings): authorize circuit-breaker hold labels via merge/close autonomy

### DIFF
--- a/src/settings/agent-actions.ts
+++ b/src/settings/agent-actions.ts
@@ -378,7 +378,10 @@ export function downgradeMergeToHold(planned: PlannedAgentAction[], holdOnly: bo
   if (labels.manualReview !== null && !alreadyNeedsReview) {
     next.push({
       actionClass: "label",
-      autonomyClass: "review_state_label",
+      // Authorized by `merge` (the class actually being downgraded here), NOT `review_state_label` — mirrors
+      // the guardrail-hold label above (#label-scoping) so this hold label posts whenever merge autonomy is
+      // acting, independent of whether the repo has separately opted into the advisory review_state_label class.
+      autonomyClass: "merge",
       requiresApproval: stagedMerge?.requiresApproval ?? false,
       reason: "accuracy circuit-breaker engaged (merge precision dropped) — would-merge held for human review",
       label: labels.manualReview,
@@ -428,7 +431,9 @@ export function downgradeCloseToHold(planned: PlannedAgentAction[], closeHoldOnl
   if (labels.manualReview !== null && !alreadyNeedsReview) {
     next.push({
       actionClass: "label",
-      autonomyClass: "review_state_label",
+      // Authorized by `close` (the class actually being downgraded here), NOT `review_state_label` — same
+      // reasoning as downgradeMergeToHold's own manual-review label above (#label-scoping).
+      autonomyClass: "close",
       requiresApproval: droppedClose?.requiresApproval ?? false,
       reason: "close-precision circuit-breaker engaged — would-close held for human review",
       label: labels.manualReview,

--- a/test/unit/agent-actions.test.ts
+++ b/test/unit/agent-actions.test.ts
@@ -981,6 +981,18 @@ describe("downgradeMergeToHold — accuracy circuit-breaker (#self-improve / GAP
     const plan = wouldMerge();
     expect(downgradeMergeToHold(plan, false)).toBe(plan);
   });
+
+  it("REGRESSION: the substitute manual-review label is authorized by `merge` autonomy, not `review_state_label` — it must still post when review_state_label is OFF (the default)", () => {
+    // Deliberately autonomy: { merge: "auto" } ONLY — review_state_label is left unset (default OFF), unlike
+    // every other test in this block. Before the fix, the pushed label carried autonomyClass: "review_state_label",
+    // so the executor's autonomy re-check (agent-action-executor.ts) would DENY it here even though merge autonomy
+    // is fully "auto" — the circuit breaker would correctly drop the merge but silently fail to label the PR.
+    const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { merge: "auto" }, autoMaintain: { requireApprovals: 0, mergeMethod: "squash" }, pr: { labels: [], mergeableState: "clean" } }));
+    expect(classes(plan)).toEqual(["merge"]); // sanity: review_state_label OFF means no disposition label is planned
+    const held = downgradeMergeToHold(plan, true);
+    const label = held.find((a) => a.actionClass === "label" && a.label === AGENT_LABEL_NEEDS_REVIEW && a.labelOp === "add");
+    expect(label?.autonomyClass).toBe("merge");
+  });
 });
 
 describe("downgradeCloseToHold — close-precision circuit-breaker (#close-precision-breaker)", () => {
@@ -1078,6 +1090,17 @@ describe("downgradeCloseToHold — close-precision circuit-breaker (#close-preci
     const nullishClose = { actionClass: "close", reason: "CI failing", closeKind: "heuristic" } as unknown as PlannedAgentAction;
     const heldNullish = downgradeCloseToHold([nullishClose], true);
     expect(heldNullish.find((a) => a.actionClass === "label" && a.label === AGENT_LABEL_NEEDS_REVIEW)?.requiresApproval).toBe(false);
+  });
+
+  it("REGRESSION: the substitute manual-review label is authorized by `close` autonomy, not `review_state_label` — it must still post when review_state_label is OFF (the default)", () => {
+    // Deliberately autonomy: { close: "auto" } ONLY — review_state_label is left unset (default OFF), mirroring
+    // downgradeMergeToHold's own regression test above. Before the fix, the pushed label carried
+    // autonomyClass: "review_state_label" and the executor would deny it even though `close` autonomy is "auto".
+    const plan = planAgentMaintenanceActions(input({ conclusion: "failure", autonomy: { close: "auto" }, ciState: "passed", blockerTitles: ["readiness score too low"], pr: { labels: [] } }));
+    expect(plan.some((a) => a.actionClass === "close" && a.closeKind === "heuristic")).toBe(true);
+    const held = downgradeCloseToHold(plan, true);
+    const label = held.find((a) => a.actionClass === "label" && a.label === AGENT_LABEL_NEEDS_REVIEW && a.labelOp === "add");
+    expect(label?.autonomyClass).toBe("close");
   });
 });
 


### PR DESCRIPTION
## Summary

- `downgradeMergeToHold` and `downgradeCloseToHold` (the accuracy/close-precision circuit breakers) drop a would-merge/would-close action and substitute a manual-review hold label. That substitute label was tagged `autonomyClass: "review_state_label"` — a separate, default-OFF autonomy class, independent of `merge`/`close`. The executor re-resolves autonomy per-action at execution time via `autonomyClass ?? actionClass` and denies the action if that class isn't acting.
- Net effect: a repo with only `merge`/`close` autonomy enabled (no explicit `review_state_label` opt-in, which is the documented minimal one-shot-mode config) hits the breaker, correctly drops the merge/close, but the substitute hold label is silently denied — the PR ends up unlabeled with no visible sign of why it stopped merging.
- Every other manual-review-label application in this same file already piggybacks on `merge`/`close` autonomy for exactly this reason (see the comment at `agent-actions.ts` around the guardrail-hold label) — the two circuit-breaker functions were the only ones that didn't follow that pattern. Fix: tag each breaker's substitute label with the disposition class it is actually downgrading (`merge` / `close`), matching every other call site.
- No issue filed — this is a small, self-evident, narrowly-scoped bug fix discovered via direct code investigation (tracing the executor's autonomy re-check into the two breaker functions and confirming the mismatch), not a reported incident.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint` (via `npm run test:ci`)
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally (via `npm run test:ci`); the two changed lines are plain object-literal field values with no new branches, and the two new regression tests in `test/unit/agent-actions.test.ts` exercise them directly.
- [x] `npm run test:workers` (via `npm run test:ci`)
- [x] `npm run build:mcp` (via `npm run test:ci`)
- [x] `npm run test:mcp-pack` (via `npm run test:ci`)
- [x] `npm run ui:openapi:check` (via `npm run test:ci`) — no API/schema change in this PR
- [x] `npm run ui:lint` (via `npm run test:ci`)
- [x] `npm run ui:typecheck` (via `npm run test:ci`)
- [x] `npm run ui:build` (via `npm run test:ci`)
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — added a regression test for `downgradeMergeToHold` and one for `downgradeCloseToHold`, both exercising the default (`review_state_label` unset) case where the bug previously manifested. Also ran the full `agent-approval-queue`, `agent-action-executor`, `precision-breakers-chain`, and `queue` suites directly since they exercise these two functions end to end — all pass unchanged.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no auth/session/CORS change.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no API/OpenAPI/MCP surface changed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI change.
- [ ] Visible UI changes include a `UI Evidence` section below. — N/A, no visible UI change.
- [ ] Public docs/changelogs are updated where needed. — N/A, no user-facing behavior change; internal-only labeling reliability fix.

## Notes

- This is PR 1 of a small sequence auditing repo-policy config consistency; the other items surfaced by that audit turned out not to be real drift (verified against the current source) and are documented separately rather than acted on.