### PR TITLE
fix(selfhost): recognize repoDocGeneration in the config-lint allowlist

### DIFF
--- a/apps/gittensory-ui/src/routes/docs.self-hosting-configuration.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-configuration.tsx
@@ -480,10 +480,16 @@ features:
         regardless of this setting. Default <code>false</code>.
       </p>
       <p>
-        <code>blockedPaths</code> (top-level, alongside <code>wantedPaths</code>) — globs off-limits
-        to contributors. Touching one yields a <code>manifest_blocked_path</code> finding,
-        enforceable when <code>gate.manifestPolicy: block</code> is set. Default <code>[]</code>{" "}
-        (nothing blocked).
+        <code>blockedPaths</code> (top-level, alongside <code>wantedPaths</code>) is{" "}
+        <strong>contributor-facing guidance only</strong> — it never blocks, holds, or produces a
+        gate finding. A touched path surfaces in contributor onboarding guidance and in
+        gittensory&apos;s own risk-reason commentary, but the gate itself never enforces it.{" "}
+        <strong>The only mechanism that actually holds a PR for a touched path</strong> is{" "}
+        <code>settings.hardGuardrailGlobs</code> (config-as-code only, described above) — a
+        would-merge PR that touches a configured guardrail glob is held for manual review regardless
+        of <code>blockedPaths</code>. A legacy top-level <code>blockedPaths</code> that once acted
+        as an enforcement mechanism is retired; setting it produces a migration warning pointing at{" "}
+        <code>settings.hardGuardrailGlobs</code>. Default <code>[]</code> (nothing listed).
       </p>
 
       <h3>settings anti-abuse block</h3>
@@ -555,6 +561,23 @@ features:
   maxAppendedEntries: 1               # Positive integer cap on new entries per PR. Default: unbounded.
   duplicateKeyFields: [slug]          # Field name(s) used to detect a duplicate entry. Default: [] (no dedup check).
   validatorId: my-registry-validator  # Optional identifier for a custom per-entry validator. Default: none.`}
+      />
+
+      <h3>repoDocGeneration</h3>
+      <p>
+        Lets gittensory open a pull request that refreshes this repo&apos;s own{" "}
+        <code>AGENTS.md</code>/<code>CLAUDE.md</code> (and, additively, a skill file) on a schedule
+        — never a direct commit. Disabled by default: an unconfigured repo, or an explicit{" "}
+        <code>enabled: false</code>, means no repo-doc refresh ever runs for it.
+      </p>
+      <CodeBlock
+        filename=".gittensory.yml"
+        lang="yaml"
+        code={`repoDocGeneration:
+  enabled: true                       # Opt in. Default: false (fully disabled).
+  scope: [agents]                     # "agents" (AGENTS.md/CLAUDE.md) and/or "skills". Default: [agents].
+  allowOverwriteExisting: false       # Refresh a file that needs manual review to change. Default: false.
+  refreshIntervalDays: 7              # Minimum days between refreshes. Default: 7.`}
       />
 
       <h2>Instance-wide write switches (SELFHOST_DEPLOYMENT_MODE)</h2>

--- a/src/selfhost/config-lint.ts
+++ b/src/selfhost/config-lint.ts
@@ -15,6 +15,7 @@ const TOP_LEVEL_FIELDS = [
   "review",
   "features",
   "contentLane",
+  "repoDocGeneration",
 ] as const;
 
 const TOP_LEVEL_FIELD_SET = new Set<string>(TOP_LEVEL_FIELDS);

--- a/test/unit/selfhost-config-lint.test.ts
+++ b/test/unit/selfhost-config-lint.test.ts
@@ -32,11 +32,13 @@ features:
 contentLane:
   entryFileGlob: data/*.json
   collectionField: records
+repoDocGeneration:
+  enabled: true
 `);
 
     expect(result.ok).toBe(true);
     expect(result.warnings).toEqual([]);
-    expect(result.summary).toBe("Manifest parsed 12 recognized fields.");
+    expect(result.summary).toBe("Manifest parsed 13 recognized fields.");
     expect(result.recognizedFields).toEqual([
       "wantedPaths",
       "preferredLabels",
@@ -50,9 +52,21 @@ contentLane:
       "review",
       "features",
       "contentLane",
+      "repoDocGeneration",
     ]);
     expect(JSON.stringify(result)).not.toContain("private maintainer note");
     expect(JSON.stringify(result)).not.toContain("operator-only");
+  });
+
+  it("REGRESSION: recognizes a standalone repoDocGeneration: block instead of flagging it as unknown", () => {
+    // repoDocGeneration is a fully real, actively-parsed top-level manifest field (#3002) that was missing from
+    // this linter's TOP_LEVEL_FIELDS allowlist -- a self-host operator using it got a false "unknown top-level
+    // field" warning even though the field works correctly.
+    const result = lintManifestText("repoDocGeneration:\n  enabled: true\n  scope: [agents]\n");
+
+    expect(result.ok).toBe(true);
+    expect(result.warnings).toEqual([]);
+    expect(result.recognizedFields).toEqual(["repoDocGeneration"]);
   });
 
   it("flags legacy blockedPaths with a migration-specific warning, not the generic unknown-field message", () => {


### PR DESCRIPTION
## Summary

- `src/selfhost/config-lint.ts`'s `TOP_LEVEL_FIELDS` allowlist (used to tell a self-host operator which `.gittensory.yml` top-level keys are recognized vs. unknown) lists `gate`, `settings`, `review`, `features`, `contentLane` — but not `repoDocGeneration`, even though it's a fully real, documented, actively-parsed top-level field (#3002). An operator who sets `repoDocGeneration:` got a false "Manifest contains unknown top-level field: repoDocGeneration" warning even though the field works correctly. Fix: add it to the allowlist.
- While auditing this doc surface, found the self-hosting-configuration docs page describes `blockedPaths` as enforced via a `manifest_blocked_path` finding gated by `gate.manifestPolicy: block` — that finding code does not exist anywhere in the codebase (confirmed by grep), and `rules/advisory.ts`'s own comment states path holds are "intentionally separate and configured via hardGuardrailGlobs." Corrected that paragraph, and added the missing `repoDocGeneration` doc section (mirroring the existing `contentLane` one) since it wasn't documented on this page at all.
- No issue filed — small, self-evident config-as-code parity fix plus a docs accuracy correction, found via direct investigation, not a reported incident.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes. (One coherent change: repoDocGeneration parity across the linter and the docs page.)
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (backend, clean)
- [x] `npx tsc --noEmit` in `apps/gittensory-ui` (clean)
- [x] `npx eslint src/routes/docs.self-hosting-configuration.tsx` in `apps/gittensory-ui` (only the pre-existing, repo-wide `react-refresh/only-export-components` warning shared by every doc route file; 0 errors)
- [x] `npx prettier --write` on the edited docs file
- [x] `npx vitest run test/unit/selfhost-config-lint.test.ts` (16/16 passing, including 2 new/updated cases)
- [ ] `npm run test:workers` / `npm run build:mcp` / `npm run test:mcp-pack` / `npm run ui:openapi:check` / `npm run ui:build` — not run individually this PR; no worker/MCP/OpenAPI/schema surface touched. Ran the full `npm run test:ci` gate once already this session on the sibling PR #3363 from the same branch point with no relevant failures; this PR's diff is strictly narrower (no `src/settings` or executor changes).
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — added a dedicated regression test for `repoDocGeneration:` alone, and extended the "recognizes every field" exhaustive test to include it.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no API/OpenAPI/MCP surface changed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, static docs copy only.
- [ ] Visible UI changes include a `UI Evidence` section below. — Text-only docs copy edit on an existing page (no layout/component change), so no screenshot table; happy to add one if requested.
- [x] Public docs/changelogs are updated where needed — this PR *is* the docs correction (not a changelog edit).

## Notes

- PR 2 of a small sequence auditing repo-policy config consistency (see PR #3363 for PR 1). The rest of the originally-suspected drift items were verified against current source and are not actually drift — documented separately rather than acted on.