### PR TITLE
feat(engine): add bestMetadataOpportunity

### DIFF
--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -168,3 +168,4 @@ export {
 export { pickTopMetadataOpportunities } from "./metadata-top-pick.js";
 export { rankMetadataOpportunitiesAtOrAboveScore } from "./metadata-min-score.js";
 export { pickTopMetadataOpportunitiesAtOrAboveScore } from "./metadata-top-min-score.js";
+export { bestMetadataOpportunity } from "./metadata-best-pick.js";

--- a/packages/gittensory-engine/src/metadata-best-pick.ts
+++ b/packages/gittensory-engine/src/metadata-best-pick.ts
@@ -1,0 +1,18 @@
+import {
+  rankMetadataOpportunities,
+  type MetadataCandidateIssue,
+  type MetadataRankContext,
+} from "./opportunity-metadata.js";
+import type { OpportunityRankInput } from "./opportunity-ranker.js";
+
+/**
+ * Return the highest-scoring metadata candidate, or `null` when none are targetable/ranked.
+ * Pure — delegates to {@link rankMetadataOpportunities} for scoring and tie-breaking.
+ */
+export function bestMetadataOpportunity<T extends MetadataCandidateIssue>(
+  candidates: readonly T[],
+  context: MetadataRankContext,
+): (T & OpportunityRankInput & { rankScore: number }) | null {
+  const ranked = rankMetadataOpportunities(candidates, context);
+  return ranked[0] ?? null;
+}

--- a/test/unit/metadata-best-pick.test.ts
+++ b/test/unit/metadata-best-pick.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+
+import { DEFAULT_MINER_GOAL_SPEC } from "../../packages/gittensory-engine/src/miner-goal-spec";
+import { bestMetadataOpportunity } from "../../packages/gittensory-engine/src/metadata-best-pick";
+
+const NOW = Date.parse("2026-07-03T12:00:00.000Z");
+
+const base = {
+  repoFullName: "acme/widgets",
+  issueNumber: 10,
+  title: "Improve queue retry semantics",
+  labels: ["help wanted"],
+  commentsCount: 2,
+  createdAt: "2026-07-01T00:00:00.000Z",
+  updatedAt: "2026-07-02T12:00:00.000Z",
+};
+
+describe("bestMetadataOpportunity", () => {
+  it("returns null for an empty candidate list", () => {
+    expect(bestMetadataOpportunity([], { nowMs: NOW })).toBeNull();
+  });
+
+  it("returns the highest-scoring metadata candidate", () => {
+    const best = bestMetadataOpportunity(
+      [
+        { ...base, issueNumber: 1, labels: ["wontfix"] },
+        { ...base, issueNumber: 2, labels: ["help wanted"] },
+        { ...base, issueNumber: 3, labels: ["help wanted", "bug"] },
+      ],
+      { nowMs: NOW },
+    );
+    expect(best?.issueNumber).toBe(3);
+    expect(best?.rankScore).toBeGreaterThan(0);
+  });
+
+  it("returns null when every candidate is miner-disabled", () => {
+    expect(
+      bestMetadataOpportunity(
+        [{ ...base, issueNumber: 1, repoFullName: "acme/disabled" }],
+        {
+          nowMs: NOW,
+          goalSpecsByRepo: {
+            "acme/disabled": { ...DEFAULT_MINER_GOAL_SPEC, minerEnabled: false },
+          },
+        },
+      ),
+    ).toBeNull();
+  });
+
+  it("breaks score ties by input order", () => {
+    const tie = { potential: 0.8, feasibility: 0.8, laneFit: 1, freshness: 1, dupRisk: 0 };
+    const best = bestMetadataOpportunity(
+      [
+        { ...base, issueNumber: 1, ...tie },
+        { ...base, issueNumber: 2, ...tie },
+      ],
+      { nowMs: NOW },
+    );
+    expect(best?.issueNumber).toBe(1);
+  });
+
+  it("is exported from the package barrel", async () => {
+    const barrel = await import("../../packages/gittensory-engine/src/index");
+    expect(typeof barrel.bestMetadataOpportunity).toBe("function");
+    expect(
+      barrel.bestMetadataOpportunity([{ ...base, issueNumber: 9, labels: ["help wanted"] }], { nowMs: NOW })
+        ?.issueNumber,
+    ).toBe(9);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `bestMetadataOpportunity` in `@jsonbored/gittensory-engine` — returns the highest-scoring metadata candidate or `null` when none qualify.
- Thin wrapper over `rankMetadataOpportunities` for miner discovery flows that only need a single pick.
- Vitest coverage at 100% patch on the new helper.

## Test plan
- [x] `COVERAGE_NO_THRESHOLDS=1 npx vitest run test/unit/metadata-best-pick.test.ts --coverage`
- [x] `npx diff-cover coverage/lcov.info --compare-branch=main --fail-under=99` → 100%
- [x] `npm run build --workspace @jsonbored/gittensory-engine && npm run build:miner`


Made with [Cursor](https://cursor.com)