### PR TITLE
feat(settings): distinguish assign-fallback outcome in audit_events

### DIFF
--- a/src/services/agent-action-executor.ts
+++ b/src/services/agent-action-executor.ts
@@ -377,8 +377,8 @@ export async function executeAgentMaintenanceActions(env: Env, ctx: AgentActionE
     }
     // 9) live — perform the real mutation, recording success or the error.
     try {
-      await performAction(env, ctx, action);
-      await audit("completed", action.reason);
+      const detailOverride = await performAction(env, ctx, action);
+      await audit("completed", detailOverride ?? action.reason);
       // CI-run cancellation on a contributor_cap close (#2462, anti-abuse): stop burning CI minutes on a PR
       // that was just closed for exceeding the contributor cap. Best-effort, AFTER the close already
       // succeeded -- cancelInFlightWorkflowRunsForHeadSha never throws, so a missing actions:write grant (or
@@ -665,7 +665,12 @@ async function handleMergeFailure(env: Env, ctx: AgentActionExecutionContext, er
   }).catch(() => undefined);
 }
 
-async function performAction(env: Env, ctx: AgentActionExecutionContext, action: PlannedAgentAction): Promise<void> {
+/** Performs the action's real GitHub mutation. Returns an optional audit-detail override — used only by the
+ *  "assign" case (below) to distinguish a real assignee from the by:<login> fallback, since GitHub silently
+ *  drops an ineligible assignee rather than erroring, so the caller's generic `audit("completed", action.reason)`
+ *  would otherwise look identical for both outcomes. Every other case implicitly returns undefined, keeping the
+ *  caller's original `action.reason` detail. */
+async function performAction(env: Env, ctx: AgentActionExecutionContext, action: PlannedAgentAction): Promise<string | undefined> {
   switch (action.actionClass) {
     case "label":
       // Flag-then-close double-check: a `label` action may ADD (default) or REMOVE its label, and may carry an
@@ -729,7 +734,7 @@ async function performAction(env: Env, ctx: AgentActionExecutionContext, action:
     }
     case "assign": {
       const login = action.assignee ?? "";
-      if (!login) return;
+      if (!login) return undefined;
       const result = await ensurePullRequestAssignee(env, ctx.installationId, ctx.repoFullName, ctx.pullNumber, login);
       if (!result.applied) {
         // GitHub silently drops an assignee lacking push/triage access to the repo -- the common case for an
@@ -739,8 +744,11 @@ async function performAction(env: Env, ctx: AgentActionExecutionContext, action:
         // at 50, so a longer prefix can push a valid max-length login past the limit and fail this fallback for
         // exactly the contributors it exists to cover.
         await ensurePullRequestLabel(env, ctx.installationId, ctx.repoFullName, ctx.pullNumber, `by:${login}`, { createMissingLabel: true });
+        // Audit-visibility gap fix: without this override, "completed" always carries the planner's generic
+        // "auto-assign PR opener" reason, so audit_events can't distinguish a real assignee from this fallback.
+        return `assignee refused by GitHub — fell back to a by:${login} label`;
       }
-      return;
+      return undefined;
     }
   }
 }

--- a/test/unit/agent-action-executor.test.ts
+++ b/test/unit/agent-action-executor.test.ts
@@ -527,6 +527,10 @@ describe("executeAgentMaintenanceActions (#778 gate stack)", () => {
     expect(ensurePullRequestAssignee).toHaveBeenCalledWith(env, 123, "owner/repo", 7, "alice");
     expect(ensurePullRequestLabel).not.toHaveBeenCalled();
     expect(outcomes[0]?.outcome).toBe("completed");
+    // REGRESSION (#audit-assign-fallback-visibility): a real, sticking assignee keeps the planner's generic
+    // reason as the audit detail -- only the fallback path below overrides it.
+    const audit = await env.DB.prepare("select detail from audit_events where event_type = 'agent.action.assign' order by created_at desc limit 1").first<{ detail: string }>();
+    expect(audit?.detail).toBe("auto-assign PR opener");
   });
 
   it("LIVE assign (#3182): falls back to a per-login label when GitHub silently drops an ineligible assignee", async () => {
@@ -536,6 +540,11 @@ describe("executeAgentMaintenanceActions (#778 gate stack)", () => {
     const outcomes = await executeAgentMaintenanceActions(env, ctx({ autonomy: { assign: "auto" } }), [assign]);
     expect(ensurePullRequestLabel).toHaveBeenCalledWith(env, 123, "owner/repo", 7, "by:external-contributor", { createMissingLabel: true });
     expect(outcomes[0]?.outcome).toBe("completed");
+    // REGRESSION (#audit-assign-fallback-visibility): the audit detail must distinguish this fallback from a
+    // real applied assignee -- previously both cases recorded the identical generic planner reason, so
+    // audit_events had no way to tell a silently-refused assignee from a successful one.
+    const audit = await env.DB.prepare("select detail from audit_events where event_type = 'agent.action.assign' order by created_at desc limit 1").first<{ detail: string }>();
+    expect(audit?.detail).toBe("assignee refused by GitHub — fell back to a by:external-contributor label");
   });
 
   it("assign with no login is a no-op (defensive — the planner always sets it, but the executor must not call GitHub with an empty login)", async () => {


### PR DESCRIPTION
## Summary

- `src/services/agent-action-executor.ts`'s `"assign"` case (#3182) calls `ensurePullRequestAssignee`; when GitHub silently refuses the assignee (no push/triage access — the common case for an external contributor), it falls back to a `by:<login>` label. Both outcomes previously recorded the identical generic `"completed"` audit event with the planner's generic `"auto-assign PR opener"` reason, so `audit_events` had no way to tell whether a given PR actually got a real GitHub assignee or silently fell back to the label — the literal gap named in a recent repo-policy config audit ("auto-assign has unclear failure visibility when GitHub refuses assignees").
- Fix: `performAction` now returns an optional audit-detail override (`string | undefined`), used only by the assign fallback branch, so the caller's `audit("completed", detailOverride ?? action.reason)` records a distinct detail (`"assignee refused by GitHub — fell back to a by:<login> label"`) when the fallback fires, and the original generic reason otherwise. Every other action class is unaffected — they implicitly return `undefined`.
- No issue filed — small, self-evident audit-visibility gap, found via direct investigation rather than a reported incident.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (clean)
- [x] `npx vitest run test/unit/agent-action-executor.test.ts` (120/120 passing, including the 2 updated assign tests asserting the new audit detail)
- [x] `npx vitest run test/unit/agent-approval-queue.test.ts` (68/68 passing — this path also calls `performAction` on approval-queue accept)
- [ ] `npm run test:workers` / `npm run build:mcp` / `npm run test:mcp-pack` / `npm run ui:openapi:check` / `npm run ui:build` — not run individually this PR; no worker/MCP/OpenAPI/UI surface touched. Ran the full `npm run test:ci` gate once already this session (PR #3363, same branch point) with no relevant failures; this PR's diff is a small, isolated change to one function's return type plus its one call site.
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — both the "real assignee applied" and "GitHub refused, fell back to label" branches now assert their distinct `audit_events.detail` value directly.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics. (The new detail string is an internal `audit_events` row, never posted to GitHub.)
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no API/OpenAPI/MCP surface changed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI change.
- [ ] Visible UI changes include a `UI Evidence` section below. — N/A, no visible UI change (internal audit-log detail only).
- [ ] Public docs/changelogs are updated where needed. — N/A, internal audit-trail detail, no user-facing/documented behavior change.

## Notes

- PR 3 of a small sequence auditing repo-policy config consistency (see PR #3363 and PR #3364 for PRs 1-2).