### PR TITLE
fix(review): rank all path-matchers lockfiles in diffFilePriority

### DIFF
--- a/src/review/review-diff.ts
+++ b/src/review/review-diff.ts
@@ -20,7 +20,7 @@ export const DEFAULT_DIFF_BUDGET = 80_000;
  *  Cypress/Playwright `.cy`/`.e2e`, a bare `spec/` dir), so those tests were ranked as SOURCE(0) and
  *  could displace real source under a tight budget — the exact opposite of this function's job. */
 export function diffFilePriority(path: string): number {
-  if (/(^|\/)(package-lock\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lockb|cargo\.lock|poetry\.lock|composer\.lock|go\.sum)$|\.(min\.(js|css)|map|snap)$/i.test(path)) return 4;
+  if (/(^|\/)(package-lock\.json|npm-shrinkwrap\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lock|bun\.lockb|cargo\.lock|poetry\.lock|pipfile\.lock|composer\.lock|gemfile\.lock|go\.sum|go\.work\.sum|uv\.lock|packages\.lock\.json|flake\.lock|deno\.lock|pubspec\.lock|podfile\.lock|mix\.lock|package\.resolved|gradle\.lockfile|pdm\.lock|conan\.lock|pixi\.lock|cartfile\.resolved|gopkg\.lock|shard\.lock|rebar\.lock|renv\.lock|chart\.lock)$|\.(min\.(js|css)|map|snap)$/i.test(path)) return 4;
   if (/(^|\/)(dist|build|out|coverage|vendor|node_modules)\//i.test(path)) return 4;
   if (/\.(md|mdx|markdown|rst|adoc|asciidoc|txt)$/i.test(path)) return 2;
   if (isTestPath(path)) return 1;

--- a/src/review/review-grounding.ts
+++ b/src/review/review-grounding.ts
@@ -110,7 +110,7 @@ export function buildGrounding(f: GroundingFlags, checks?: CheckAggregate, fileC
  *  copy missed pytest `test_*.py`, Go `*_test.go`, Ruby `*_spec.rb`, Cypress/Playwright `.cy`/`.e2e`, and a
  *  bare `spec/` dir — so those tests ranked as SOURCE(0) and were inlined ahead of real source). */
 export function diffFilePriority(path: string): number {
-  if (/(^|\/)(package-lock\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lockb|cargo\.lock|poetry\.lock|composer\.lock|go\.sum)$|\.(min\.(js|css)|map|snap)$/i.test(path)) return 4;
+  if (/(^|\/)(package-lock\.json|npm-shrinkwrap\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lock|bun\.lockb|cargo\.lock|poetry\.lock|pipfile\.lock|composer\.lock|gemfile\.lock|go\.sum|go\.work\.sum|uv\.lock|packages\.lock\.json|flake\.lock|deno\.lock|pubspec\.lock|podfile\.lock|mix\.lock|package\.resolved|gradle\.lockfile|pdm\.lock|conan\.lock|pixi\.lock|cartfile\.resolved|gopkg\.lock|shard\.lock|rebar\.lock|renv\.lock|chart\.lock)$|\.(min\.(js|css)|map|snap)$/i.test(path)) return 4;
   if (/(^|\/)(dist|build|out|coverage|vendor|node_modules)\//i.test(path)) return 4;
   if (/\.(md|mdx|markdown|rst|adoc|asciidoc|txt)$/i.test(path)) return 2;
   if (isTestPath(path)) return 1;

--- a/test/unit/review-diff.test.ts
+++ b/test/unit/review-diff.test.ts
@@ -18,6 +18,13 @@ describe("diffFilePriority — source survives, noise drops first", () => {
     }
   });
 
+  it("ranks every path-matchers lockfile as noise(4), not source(0)", () => {
+    for (const path of ["bun.lock", "uv.lock", "deno.lock", "flake.lock", "mix.lock", "chart.lock"]) {
+      expect(diffFilePriority(path)).toBe(4);
+      expect(diffFilePriority(path)).toBeGreaterThan(diffFilePriority("src/a.ts"));
+    }
+  });
+
   it("ranks every canonical test convention as tests(1), not source(0)", () => {
     // These are all tests; before delegating to isTestPath the inline regex missed them and ranked
     // them SOURCE(0), so on a tight budget they could displace real source (the opposite of the goal).

--- a/test/unit/review-grounding.test.ts
+++ b/test/unit/review-grounding.test.ts
@@ -102,6 +102,13 @@ describe("review-grounding: diffFilePriority (source survives the budget first)"
     expect(diffFilePriority("src/a.ts")).toBeLessThan(diffFilePriority("README.md"));
   });
 
+  it("ranks every path-matchers lockfile as noise(4), not source(0)", () => {
+    for (const path of ["bun.lock", "uv.lock", "deno.lock", "flake.lock", "mix.lock", "chart.lock"]) {
+      expect(diffFilePriority(path)).toBe(4);
+      expect(diffFilePriority(path)).toBeGreaterThan(diffFilePriority("src/a.ts"));
+    }
+  });
+
   it("ranks long-form doc spellings as docs(2), matching rag.ts and path-matchers", () => {
     for (const path of ["GUIDE.markdown", "docs/spec.asciidoc", "notes.ADOC"]) {
       expect(diffFilePriority(path)).toBe(2);


### PR DESCRIPTION
## Summary

- Extend `diffFilePriority` in `review-grounding.ts` and `review-diff.ts` to recognize every lockfile basename from `path-matchers.ts` `LOCKFILE_NAMES` (e.g. `bun.lock`, `uv.lock`, `deno.lock`, `flake.lock`, `mix.lock`, `chart.lock`).
- Previously only a subset (npm/yarn/pnpm/cargo/poetry/composer/go.sum/bun.lockb) ranked as noise **4**; other lockfiles ranked as source **0** and could displace real code under a tight diff budget.

## Scope

- [x] Conventional Commit title format.
- [x] Focused — review diff priority + unit tests only.
- [x] Follows `CONTRIBUTING.md`.
- [x] No linked issue needed.

## Validation

- [x] `git diff --check`
- [x] `npm run test:ci` on Node 22
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] Unit tests cover representative new lockfile basenames

## Safety

- [x] No secrets, auth, or UI changes.
- [x] N/A for UI Evidence.

## UI Evidence

N/A — backend review diff ordering only.

## Notes

**Conflict avoidance:** Touches only `src/review/review-grounding.ts`, `src/review/review-diff.ts`, and their unit tests. Zero overlap with open PRs (#3368 engine, #3367/#3304 queue, #3366 agent-action-executor, #3361 enrichment, #3314 miner, #3305 enrichment-wire). Merges cleanly after any of those land without rebase.

Made with [Cursor](https://cursor.com)