### PR TITLE
refactor(signals): extract gate:-to-settings override mapping into its own function

### DIFF
--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -1742,6 +1742,63 @@ export function excludeReviewPaths<T extends { path: string }>(files: T[], exclu
 }
 
 /**
+ * Apply the typed `gate:` alias's overrides onto already-spread effective settings, mutating `effective` in
+ * place. Split out of resolveEffectiveSettings purely for readability — this stays the ONLY place a `gate.*`
+ * field maps onto its `RepositorySettings` counterpart. `gate:` still WINS over an overlapping `settings:`
+ * value (the caller runs this AFTER the `{ ...dbSettings, ...manifest.settings }` spread), matching the
+ * documented precedence (self-hosting-configuration docs: "the typed gate: block ... wins over the generic
+ * settings: block for those same fields"). Every field here is independently null-gated — a `gate:` field
+ * absent from the parsed manifest is `null` (see parseGateConfig below) and leaves `effective` untouched, so a
+ * repo with no `gate:` block resolves byte-identically to before this was split out.
+ */
+function applyGateConfigOverrides(effective: RepositorySettings, gate: FocusManifestGateConfig): void {
+  if (gate.enabled !== null) effective.gateCheckMode = gate.enabled ? "enabled" : "off";
+  // reviewCheckMode (#2852) resolution: explicit `gate.checkMode` is the most-specific signal and always wins
+  // when set. Otherwise fall back to the legacy `gate.enabled` boolean alias, mapped symmetrically so it keeps
+  // its historical effect (true -> the check publishes and may be required; false -> it never publishes) even
+  // though it no longer drives `gateCheckMode` alone. When NEITHER is set, `effective.reviewCheckMode` already
+  // holds `settings.reviewCheckMode` (yml `settings:` override, else the DB value) from the caller's spread.
+  if (gate.checkMode !== null) effective.reviewCheckMode = gate.checkMode;
+  else if (gate.enabled !== null) effective.reviewCheckMode = gate.enabled ? "required" : "disabled";
+  if (gate.pack !== null) effective.gatePack = gate.pack;
+  if (gate.linkedIssue !== null) effective.linkedIssueGateMode = gate.linkedIssue;
+  if (gate.duplicates !== null) effective.duplicatePrGateMode = gate.duplicates;
+  if (gate.readinessMode !== null) effective.qualityGateMode = gate.readinessMode;
+  if (gate.readinessMinScore !== null) effective.qualityGateMinScore = gate.readinessMinScore;
+  if (gate.sizeMode !== null) effective.sizeGateMode = gate.sizeMode;
+  if (gate.lockfileIntegrityMode !== null) effective.lockfileIntegrityGateMode = gate.lockfileIntegrityMode;
+  if (gate.slopMode !== null) effective.slopGateMode = gate.slopMode;
+  if (gate.slopMinScore !== null) effective.slopGateMinScore = gate.slopMinScore;
+  if (gate.slopAiAdvisory !== null) effective.slopAiAdvisory = gate.slopAiAdvisory;
+  if (gate.aiReviewMode !== null) effective.aiReviewMode = gate.aiReviewMode;
+  if (gate.aiReviewByok !== null) effective.aiReviewByok = gate.aiReviewByok;
+  if (gate.aiReviewProvider !== null) effective.aiReviewProvider = gate.aiReviewProvider;
+  if (gate.aiReviewModel !== null) effective.aiReviewModel = gate.aiReviewModel;
+  if (gate.aiReviewAllAuthors !== null) effective.aiReviewAllAuthors = gate.aiReviewAllAuthors;
+  if (gate.aiReviewCloseConfidence !== null) effective.aiReviewCloseConfidence = gate.aiReviewCloseConfidence;
+  // Dual-AI combine/onMerge/reviewers overrides (#2567) are projected onto `effective` unclamped here — they are
+  // a REFINEMENT of the operator's AI_REVIEW_PLAN, not a replacement for it, so the actual operator-floor clamp
+  // (onMerge can only TIGHTEN, never loosen) happens where both the per-repo value AND the operator's plan are
+  // visible: `resolveEffectiveAiReviewOnMerge` in services/ai-review.ts, called from the review call site. This
+  // resolver has no access to `env.AI_REVIEW_PLAN`, so it cannot itself enforce the floor.
+  if (gate.aiReviewCombine !== null) effective.aiReviewCombine = gate.aiReviewCombine;
+  if (gate.aiReviewOnMerge !== null) effective.aiReviewOnMerge = gate.aiReviewOnMerge;
+  if (gate.aiReviewReviewers !== null) effective.aiReviewReviewers = gate.aiReviewReviewers;
+  if (gate.mergeReadiness !== null) effective.mergeReadinessGateMode = gate.mergeReadiness;
+  if (gate.manifestPolicy !== null) effective.manifestPolicyGateMode = gate.manifestPolicy;
+  if (gate.selfAuthoredLinkedIssue !== null) effective.selfAuthoredLinkedIssueGateMode = gate.selfAuthoredLinkedIssue;
+  if (gate.dryRun !== null) effective.gateDryRun = gate.dryRun;
+  if (gate.firstTimeContributorGrace !== null) effective.firstTimeContributorGrace = gate.firstTimeContributorGrace;
+  if (gate.premergeContentRecheck !== null) effective.premergeContentRecheck = gate.premergeContentRecheck;
+  if (gate.requireFreshRebaseWindowMinutes !== null) effective.requireFreshRebaseWindowMinutes = gate.requireFreshRebaseWindowMinutes;
+  if (gate.claMode !== null) effective.claGateMode = gate.claMode;
+  if (gate.claConsentPhrase !== null) effective.claConsentPhrase = gate.claConsentPhrase;
+  if (gate.claCheckRunName !== null) effective.claCheckRunName = gate.claCheckRunName;
+  if (gate.claCheckRunAppSlug !== null) effective.claCheckRunAppSlug = gate.claCheckRunAppSlug;
+  if (gate.expectedCiContexts !== null) effective.expectedCiContexts = gate.expectedCiContexts;
+}
+
+/**
  * Resolve the EFFECTIVE repository settings a webhook should act on: `.gittensory.yml` > DB settings >
  * safe defaults. The generic `settings:` override applies first; the friendly `gate:` alias then wins
  * for its fields. This single resolver makes the whole gittensory configuration — gate on/off, blocker
@@ -1803,51 +1860,7 @@ export function resolveEffectiveSettings(
       closeDelaySeconds: linkedIssueHardRulesOverride.closeDelaySeconds ?? base.closeDelaySeconds,
     };
   }
-  const gate = manifest.gate;
-  if (gate.enabled !== null) effective.gateCheckMode = gate.enabled ? "enabled" : "off";
-  // reviewCheckMode (#2852) resolution: explicit `gate.checkMode` is the most-specific signal and always wins
-  // when set. Otherwise fall back to the legacy `gate.enabled` boolean alias, mapped symmetrically so it keeps
-  // its historical effect (true -> the check publishes and may be required; false -> it never publishes) even
-  // though it no longer drives `gateCheckMode` alone. When NEITHER is set, `effective.reviewCheckMode` already
-  // holds `settings.reviewCheckMode` (yml `settings:` override, else the DB value) from the spread above.
-  if (gate.checkMode !== null) effective.reviewCheckMode = gate.checkMode;
-  else if (gate.enabled !== null) effective.reviewCheckMode = gate.enabled ? "required" : "disabled";
-  if (gate.pack !== null) effective.gatePack = gate.pack;
-  if (gate.linkedIssue !== null) effective.linkedIssueGateMode = gate.linkedIssue;
-  if (gate.duplicates !== null) effective.duplicatePrGateMode = gate.duplicates;
-  if (gate.readinessMode !== null) effective.qualityGateMode = gate.readinessMode;
-  if (gate.readinessMinScore !== null) effective.qualityGateMinScore = gate.readinessMinScore;
-  if (gate.sizeMode !== null) effective.sizeGateMode = gate.sizeMode;
-  if (gate.lockfileIntegrityMode !== null) effective.lockfileIntegrityGateMode = gate.lockfileIntegrityMode;
-  if (gate.slopMode !== null) effective.slopGateMode = gate.slopMode;
-  if (gate.slopMinScore !== null) effective.slopGateMinScore = gate.slopMinScore;
-  if (gate.slopAiAdvisory !== null) effective.slopAiAdvisory = gate.slopAiAdvisory;
-  if (gate.aiReviewMode !== null) effective.aiReviewMode = gate.aiReviewMode;
-  if (gate.aiReviewByok !== null) effective.aiReviewByok = gate.aiReviewByok;
-  if (gate.aiReviewProvider !== null) effective.aiReviewProvider = gate.aiReviewProvider;
-  if (gate.aiReviewModel !== null) effective.aiReviewModel = gate.aiReviewModel;
-  if (gate.aiReviewAllAuthors !== null) effective.aiReviewAllAuthors = gate.aiReviewAllAuthors;
-  if (gate.aiReviewCloseConfidence !== null) effective.aiReviewCloseConfidence = gate.aiReviewCloseConfidence;
-  // Dual-AI combine/onMerge/reviewers overrides (#2567) are projected onto `effective` unclamped here — they are
-  // a REFINEMENT of the operator's AI_REVIEW_PLAN, not a replacement for it, so the actual operator-floor clamp
-  // (onMerge can only TIGHTEN, never loosen) happens where both the per-repo value AND the operator's plan are
-  // visible: `resolveEffectiveAiReviewOnMerge` in services/ai-review.ts, called from the review call site. This
-  // resolver has no access to `env.AI_REVIEW_PLAN`, so it cannot itself enforce the floor.
-  if (gate.aiReviewCombine !== null) effective.aiReviewCombine = gate.aiReviewCombine;
-  if (gate.aiReviewOnMerge !== null) effective.aiReviewOnMerge = gate.aiReviewOnMerge;
-  if (gate.aiReviewReviewers !== null) effective.aiReviewReviewers = gate.aiReviewReviewers;
-  if (gate.mergeReadiness !== null) effective.mergeReadinessGateMode = gate.mergeReadiness;
-  if (gate.manifestPolicy !== null) effective.manifestPolicyGateMode = gate.manifestPolicy;
-  if (gate.selfAuthoredLinkedIssue !== null) effective.selfAuthoredLinkedIssueGateMode = gate.selfAuthoredLinkedIssue;
-  if (gate.dryRun !== null) effective.gateDryRun = gate.dryRun;
-  if (gate.firstTimeContributorGrace !== null) effective.firstTimeContributorGrace = gate.firstTimeContributorGrace;
-  if (gate.premergeContentRecheck !== null) effective.premergeContentRecheck = gate.premergeContentRecheck;
-  if (gate.requireFreshRebaseWindowMinutes !== null) effective.requireFreshRebaseWindowMinutes = gate.requireFreshRebaseWindowMinutes;
-  if (gate.claMode !== null) effective.claGateMode = gate.claMode;
-  if (gate.claConsentPhrase !== null) effective.claConsentPhrase = gate.claConsentPhrase;
-  if (gate.claCheckRunName !== null) effective.claCheckRunName = gate.claCheckRunName;
-  if (gate.claCheckRunAppSlug !== null) effective.claCheckRunAppSlug = gate.claCheckRunAppSlug;
-  if (gate.expectedCiContexts !== null) effective.expectedCiContexts = gate.expectedCiContexts;
+  applyGateConfigOverrides(effective, manifest.gate);
   // The dashboard "Require linked issue" toggle must not silently diverge from gate blocking: when the
   // boolean is on but linkedIssueGateMode is still off, treat it as a block requirement (#797).
   if (effective.requireLinkedIssue && effective.linkedIssueGateMode === "off") {


### PR DESCRIPTION
## Summary

- `resolveEffectiveSettings` (`src/signals/focus-manifest.ts`) inlined a ~40-line chain of individual `if (gate.field !== null) effective.otherFieldName = gate.field;` mappings, mixed together with the settings spread, the sparse `typeLabels`/`linkedIssueLabelPropagation`/`linkedIssueHardRules` merges, and the post-merge normalization safety nets (the `requireLinkedIssue`-implies-`block` rule, the `qualityGateMode: "block"` downgrade). Extracted the gate-mapping chain into its own named function, `applyGateConfigOverrides(effective, gate)`, so `resolveEffectiveSettings` itself now reads as a short, linear sequence: spread settings → apply sparse overrides → apply gate overrides → normalize.
- **Zero behavior change.** This is pure code-quality cleanup — no bug, no config-resolution difference. `FocusManifestGateConfig`'s shape is completely untouched, so every existing direct consumer of `manifest.gate.*` (`src/rules/predicted-gate.ts` — the engine behind the `predict_gate` MCP tool contributors run pre-push — and `src/mcp/server.ts`) needed zero changes. `gate:` still wins over an overlapping `settings:` value for the same field (the extracted function still runs after the settings spread), matching the documented precedence in the self-hosting-configuration docs.
- **Why this scope, not a bigger one:** the original idea was to eliminate the mapping entirely by having the parser emit settings-shaped keys directly. Investigated that further and found it would require restructuring `FocusManifestGateConfig`'s field names, which are read directly (by the OLD names) in `predicted-gate.ts` (~15 references) and `mcp/server.ts` — i.e. it would mean rewriting the gate-prediction engine itself for a purely non-functional cleanup. Not worth that risk for no behavior gain, so this PR does the safe, contained version: same names, same shape, same precedence, just a named extraction.
- No issue filed — pure internal refactor, no user-facing or config-schema change.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes. (Single file, single extraction.)
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (clean)
- [x] `npx vitest run test/unit/focus-manifest.test.ts test/unit/focus-manifest-loader.test.ts test/unit/selftune-readback.test.ts test/unit/repository-settings-enforcement.test.ts` (300/300 passing, unchanged)
- [x] `npx vitest run test/unit/predicted-gate.test.ts` (44/44 passing, unchanged — confirms zero impact on the untouched gate-prediction consumer)
- [x] `npx vitest run test/unit/queue.test.ts` (483/483 passing — full end-to-end review-pipeline regression check, since this function sits on the hot settings-resolution path)
- [ ] `npm run test:workers` / `npm run build:mcp` / `npm run test:mcp-pack` / `npm run ui:openapi:check` / `npm run ui:build` — not run individually this PR; no worker/MCP/OpenAPI/UI surface touched (this PR moves existing lines within one `src/` file; `FocusManifestGateConfig`'s public shape and every serializer/consumer are unchanged). Ran the full `npm run test:ci` gate once already this session (PR #3363) with no relevant failures.
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — N/A here: no new branches or logic were introduced, only relocated; the existing 255-case `focus-manifest.test.ts` suite already exercises every line of the extracted function via its existing calls into `resolveEffectiveSettings`, and continues to pass unchanged.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no API/OpenAPI/MCP surface changed; `predicted-gate.ts`/`mcp/server.ts` consumers verified unaffected (see Validation).
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI change.
- [ ] Visible UI changes include a `UI Evidence` section below. — N/A, no visible UI change.
- [ ] Public docs/changelogs are updated where needed. — N/A, no behavior or schema change to document.

## Notes

- PR 5 of a small sequence auditing repo-policy config consistency (see PR #3363, #3364, #3366, #3369 for PRs 1-4). This one touches `src/signals/focus-manifest.ts` (the core review engine), so I'd expect the gate to hold it for owner review regardless of CI outcome — that's the correct, expected disposition for a change to this file, not a signal anything is wrong.