### PR TITLE
feat(miner): add structured finding-severity calibration signal

### DIFF
--- a/packages/gittensory-engine/README.md
+++ b/packages/gittensory-engine/README.md
@@ -376,6 +376,72 @@ The rendered block is intentionally narrow: login, resolved public PR counts, pu
 status, and optional public evidence URLs for active incidents. Caller-provided ids, PR URLs, and arbitrary metadata are
 never copied into the Markdown, and the renderer fails closed if a blocked private-field name is introduced.
 
+## Structured finding-severity calibration
+
+`resolveFindingSeverityCalibrationConfig()`, `ingestFindingSeverityCalibrationSignals()`, and
+`computeFindingSeverityCompositeCalibrationScore()` provide the pure engine contract for the opt-in finding-severity
+calibration signal. It sits in the same family as objective-anchor and pairwise-judge: the hosted review stack decides
+whether a repo is opted in from its resolved `.gittensory.yml`/private config, and the engine contract is deliberately
+default-off and safe to call at ingestion time.
+
+The preferred config-as-code surface is:
+
+```yaml
+miner:
+  calibration:
+    shareStructuredFindingSeverity: true
+    structuredFindingSeverityWeight: 0.2
+```
+
+Only `shareStructuredFindingSeverity: true` enables ingestion. Missing, malformed, or falsey values all fail closed to
+no sharing. `calibration.shareStructuredFindingSeverity` is accepted as a narrow top-level alias. The optional weight is
+non-negative and finite; malformed values fall back to the default.
+
+The accepted signal is intentionally narrow: repo/run ids plus, per severity tier (`blocker`, `warning`, `advisory`,
+`nit`), how many findings the review raised and how many were subsequently CONFIRMED (true positives). It has no fields
+for raw review text, secrets, trust scores, reward values, private rankings, or maintainer evidence.
+
+```ts
+import {
+  computeFindingSeverityCompositeCalibrationScore,
+  ingestFindingSeverityCalibrationSignals,
+} from "@jsonbored/gittensory-engine";
+
+const findingSeverity = ingestFindingSeverityCalibrationSignals([
+  {
+    repoFullName: "jsonbored/gittensory",
+    replayRunId: "replay-2026-07-04",
+    reviewRunId: "review-123",
+    optedIn: true,
+    tiers: [
+      { tier: "blocker", total: 2, confirmed: 2 },
+      { tier: "warning", total: 5, confirmed: 3 },
+      { tier: "nit", total: 9, confirmed: 1 },
+    ],
+  },
+]);
+
+const score = computeFindingSeverityCompositeCalibrationScore({
+  objectiveAnchor: 0.65,
+  pairwise: 0.8,
+  findingSeverity,
+});
+```
+
+The per-PR score is the severity-and-volume-weighted mean of the per-tier confirmation rates, so a confirmed blocker
+moves calibration far more than a confirmed nit, and a review that raises blockers which are then dismissed (false
+positives at the most disruptive tier) calibrates poorly. Each tier's `confirmed` count is clamped to its `total` and
+discounted by an optional per-tier `confidence`, so an unverified "all confirmed" claim cannot inflate the score.
+
+The composite scorer renormalizes weights when a signal is absent: if a repo opts out or no tier survives
+normalization, the structured finding-severity weight drops to zero and the objective/pairwise signals are
+renormalized. The returned audit trail records which opted-in repos contributed and which rows were rejected because the
+repo was not opted in, had invalid ids, or exposed no recognized non-empty tiers.
+
+`renderFindingSeverityCalibrationAuditMarkdown(result)` turns the composite result into a deterministic local artifact
+with component scores, effective weights, contributing repos, per-tier tables, rejected rows, and a contributing-repo
+summary. All caller-supplied ids and repo names are Markdown-escaped and newline-collapsed before rendering.
+
 ## Plan templates
 
 `plan-templates.ts` exports one builder per miner lifecycle stage (`analyze`, `plan`, `prepare`, `create`, `manage`).

--- a/packages/gittensory-engine/src/finding-severity-calibration.ts
+++ b/packages/gittensory-engine/src/finding-severity-calibration.ts
@@ -1,0 +1,552 @@
+// Opt-in structured finding-severity calibration signal (#1955 calibration family).
+//
+// This module is the pure engine half of finding-severity calibration. The hosted review stack decides whether a
+// repo is currently opted in from its resolved `.gittensory.yml`/private config; the miner replay harness can then
+// ingest only the structured per-severity-tier finding fields exposed here — how many findings the review raised at
+// each severity tier (blocker/warning/advisory/nit) and how many of those were subsequently CONFIRMED (a true
+// positive that pointed at a real, acted-on issue). No raw review text, secrets, trust values, rewards, rankings, or
+// maintainer evidence are represented in this type surface.
+//
+// The score measures how well-CALIBRATED a review's severity assignments are: a confirmed blocker is worth much more
+// than a confirmed nit, and a review that raises blockers which are then dismissed (false positives at the tier that
+// most interrupts a maintainer) calibrates poorly. It composes with the objective-anchor and pairwise-judge signals
+// exactly like the other calibration signals in this family.
+
+import type { ObjectiveAnchorScore } from "./objective-anchor.js";
+import type { PairwiseCalibrationScore } from "./pairwise-calibration.js";
+
+export type FindingSeverityTier = "blocker" | "warning" | "advisory" | "nit";
+
+export type FindingSeverityCalibrationManifest = {
+  miner?: {
+    calibration?: {
+      /** Explicit maintainer opt-in. Default false. */
+      shareStructuredFindingSeverity?: unknown;
+      /** Optional weight for the structured finding-severity signal when composed into a replay score. */
+      structuredFindingSeverityWeight?: unknown;
+    } | null;
+  } | null;
+  calibration?: {
+    /** Back-compat/future-friendly alias, still explicit and default-off. */
+    shareStructuredFindingSeverity?: unknown;
+    structuredFindingSeverityWeight?: unknown;
+  } | null;
+};
+
+export type FindingSeverityCalibrationConfig = {
+  shareStructuredFindingSeverity: boolean;
+  structuredFindingSeverityWeight: number;
+  warnings: string[];
+};
+
+export type FindingSeverityTierInput = {
+  tier: FindingSeverityTier | string;
+  /** Total findings the review raised at this tier. */
+  total: number;
+  /** How many of those were subsequently confirmed (true positives). Clamped to `[0, total]`. */
+  confirmed?: number | undefined;
+  /** Optional 0..1 confidence in the confirmation labelling for this tier. */
+  confidence?: number | undefined;
+};
+
+export type FindingSeverityCalibrationSignalInput = {
+  repoFullName: string;
+  replayRunId: string;
+  reviewRunId: string;
+  optedIn: boolean;
+  observedAt?: string | undefined;
+  tiers: readonly FindingSeverityTierInput[];
+};
+
+export type FindingSeverityTierSignal = {
+  tier: FindingSeverityTier;
+  total: number;
+  confirmed: number;
+  confirmationRate: number;
+  weight: number;
+  score: number;
+};
+
+export type FindingSeverityCalibrationSignal = {
+  repoFullName: string;
+  replayRunId: string;
+  reviewRunId: string;
+  observedAt: string | null;
+  tiers: FindingSeverityTierSignal[];
+  score: number;
+};
+
+export type FindingSeverityCalibrationIngestion = {
+  accepted: FindingSeverityCalibrationSignal[];
+  rejected: Array<{
+    repoFullName: string;
+    replayRunId: string;
+    reviewRunId: string;
+    reason: "not_opted_in" | "empty_tiers" | "invalid_repo" | "invalid_run_id";
+  }>;
+};
+
+export type FindingSeverityCalibrationWeights = {
+  objectiveAnchor?: number | undefined;
+  pairwiseJudge?: number | undefined;
+  structuredFindingSeverity?: number | undefined;
+};
+
+export type FindingSeverityCompositeCalibrationScore = {
+  compositeScore: number;
+  objectiveAnchorScore: number;
+  pairwiseJudgeScore: number | null;
+  structuredFindingSeverityScore: number | null;
+  weights: {
+    objectiveAnchor: number;
+    pairwiseJudge: number;
+    structuredFindingSeverity: number;
+  };
+  audit: {
+    contributingRepos: Array<{
+      repoFullName: string;
+      replayRunId: string;
+      reviewRunId: string;
+      observedAt: string | null;
+      score: number;
+      tiers: FindingSeverityTierSignal[];
+    }>;
+    rejected: FindingSeverityCalibrationIngestion["rejected"];
+  };
+};
+
+const TIER_ORDER: FindingSeverityTier[] = ["blocker", "warning", "advisory", "nit"];
+
+// Severity weight for scoring: a confirmed blocker is worth far more than a confirmed nit, and a dismissed blocker
+// (false positive at the most disruptive tier) is penalized far more than a dismissed nit.
+const TIER_WEIGHT: Record<FindingSeverityTier, number> = {
+  blocker: 1,
+  warning: 0.6,
+  advisory: 0.3,
+  nit: 0.1,
+};
+
+const DEFAULT_STRUCTURED_FINDING_SEVERITY_WEIGHT = 0.2;
+const DEFAULT_COMPOSITE_WEIGHTS = {
+  objectiveAnchor: 0.45,
+  pairwiseJudge: 0.35,
+  structuredFindingSeverity: 0.2,
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function finiteNonNegative(value: number | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+  if (!Number.isFinite(value) || value < 0) return 0;
+  return value;
+}
+
+function finiteNonNegativeInt(value: number | undefined): number {
+  if (value === undefined || !Number.isFinite(value) || value < 0) return 0;
+  return Math.floor(value);
+}
+
+function roundScore(value: number): number {
+  return Math.round(Math.min(1, Math.max(0, value)) * 1_000_000) / 1_000_000;
+}
+
+function normalizeRepoFullName(value: string): string | null {
+  const trimmed = value.trim().toLowerCase();
+  if (!/^[a-z0-9_.-]+\/[a-z0-9_.-]+$/u.test(trimmed)) return null;
+  return trimmed;
+}
+
+function normalizeId(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.length > 160 || /[\r\n\0]/u.test(trimmed)) return null;
+  return trimmed;
+}
+
+function normalizeObservedAt(value: string | undefined): string | null {
+  if (!value) return null;
+  const ms = Date.parse(value);
+  if (!Number.isFinite(ms)) return null;
+  return new Date(ms).toISOString();
+}
+
+function normalizeBoolean(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") return value;
+  if (typeof value !== "string") return undefined;
+  const normalized = value.trim().toLowerCase();
+  if (["true", "1", "yes", "on"].includes(normalized)) return true;
+  if (["false", "0", "no", "off"].includes(normalized)) return false;
+  return undefined;
+}
+
+function normalizeOptionalWeight(value: unknown): number | undefined {
+  if (value === undefined || value === null) return undefined;
+  const number = typeof value === "number" ? value : typeof value === "string" ? Number(value.trim()) : Number.NaN;
+  if (!Number.isFinite(number) || number < 0) return undefined;
+  return number;
+}
+
+function clampConfidence(value: number | undefined): number {
+  if (value === undefined) return 1;
+  if (!Number.isFinite(value)) return 0;
+  return Math.min(1, Math.max(0, value));
+}
+
+function normalizeTier(value: string): FindingSeverityTier | null {
+  const normalized = value.trim().toLowerCase().replace(/[_\s-]+/gu, "_");
+  if (normalized === "block" || normalized === "blocked" || normalized === "blocking" || normalized === "critical") {
+    return "blocker";
+  }
+  if (normalized === "warn" || normalized === "warnings" || normalized === "major") return "warning";
+  if (
+    normalized === "info" ||
+    normalized === "informational" ||
+    normalized === "suggestion" ||
+    normalized === "advice"
+  ) {
+    return "advisory";
+  }
+  if (normalized === "nitpick" || normalized === "minor" || normalized === "trivial" || normalized === "style") {
+    return "nit";
+  }
+  if ((TIER_ORDER as string[]).includes(normalized)) return normalized as FindingSeverityTier;
+  return null;
+}
+
+/**
+ * Aggregate raw per-tier inputs into one normalized signal per tier: sum totals, sum confirmed (each entry's
+ * confirmed is clamped to its own total), drop tiers whose total is zero, and derive the confirmation rate and the
+ * severity-weighted per-tier score. Confidence discounts the effective confirmation the same way it does for the
+ * gate-verdict signal. Deterministic and returned in TIER_ORDER.
+ */
+function normalizeTiers(tiers: readonly FindingSeverityTierInput[]): FindingSeverityTierSignal[] {
+  const byTier = new Map<FindingSeverityTier, { total: number; confirmed: number }>();
+  for (const item of tiers) {
+    const tier = normalizeTier(item.tier);
+    if (!tier) continue;
+    const total = finiteNonNegativeInt(item.total);
+    if (total <= 0) continue;
+    const confirmedRaw = Math.min(total, finiteNonNegativeInt(item.confirmed));
+    // A low confidence in the confirmation labelling shrinks the credited confirmations toward zero (never above the
+    // raw count), so an unverified "all confirmed" claim cannot inflate the calibration score.
+    const confirmed = Math.min(total, Math.round(confirmedRaw * clampConfidence(item.confidence)));
+    const existing = byTier.get(tier);
+    if (existing) {
+      existing.total += total;
+      existing.confirmed += confirmed;
+    } else {
+      byTier.set(tier, { total, confirmed });
+    }
+  }
+  return TIER_ORDER.flatMap((tier) => {
+    const bucket = byTier.get(tier);
+    if (!bucket) return [];
+    const confirmed = Math.min(bucket.total, bucket.confirmed);
+    const confirmationRate = roundScore(confirmed / bucket.total);
+    return [
+      {
+        tier,
+        total: bucket.total,
+        confirmed,
+        confirmationRate,
+        weight: TIER_WEIGHT[tier],
+        score: confirmationRate,
+      },
+    ];
+  });
+}
+
+/**
+ * The per-PR calibration score: the severity-and-volume-weighted mean of the per-tier confirmation rates, so a
+ * confirmed blocker moves the score far more than a confirmed nit, and a tier with more findings carries more weight
+ * than a tier with a single finding. Returns null when there is no weighted volume (which only happens for an empty
+ * tier list, already rejected upstream).
+ */
+function scoreTiers(tiers: readonly FindingSeverityTierSignal[]): number | null {
+  let weightedRate = 0;
+  let weightSum = 0;
+  for (const tier of tiers) {
+    const weight = tier.weight * tier.total;
+    weightedRate += weight * tier.confirmationRate;
+    weightSum += weight;
+  }
+  if (weightSum <= 0) return null;
+  return roundScore(weightedRate / weightSum);
+}
+
+function averageSignals(signals: readonly FindingSeverityCalibrationSignal[]): number | null {
+  if (signals.length === 0) return null;
+  return roundScore(signals.reduce((sum, signal) => sum + signal.score, 0) / signals.length);
+}
+
+function isFindingSeverityCalibrationIngestion(value: unknown): value is FindingSeverityCalibrationIngestion {
+  return isRecord(value) && Array.isArray(value.accepted) && Array.isArray(value.rejected);
+}
+
+function normalizeCompositeWeights(weights: FindingSeverityCalibrationWeights | undefined): {
+  objectiveAnchor: number;
+  pairwiseJudge: number;
+  structuredFindingSeverity: number;
+} {
+  const raw = {
+    objectiveAnchor: finiteNonNegative(weights?.objectiveAnchor, DEFAULT_COMPOSITE_WEIGHTS.objectiveAnchor),
+    pairwiseJudge: finiteNonNegative(weights?.pairwiseJudge, DEFAULT_COMPOSITE_WEIGHTS.pairwiseJudge),
+    structuredFindingSeverity: finiteNonNegative(
+      weights?.structuredFindingSeverity,
+      DEFAULT_COMPOSITE_WEIGHTS.structuredFindingSeverity,
+    ),
+  };
+  const total = raw.objectiveAnchor + raw.pairwiseJudge + raw.structuredFindingSeverity;
+  if (total <= 0) return DEFAULT_COMPOSITE_WEIGHTS;
+  return {
+    objectiveAnchor: raw.objectiveAnchor / total,
+    pairwiseJudge: raw.pairwiseJudge / total,
+    structuredFindingSeverity: raw.structuredFindingSeverity / total,
+  };
+}
+
+function markdownSafe(value: string): string {
+  return value.replace(/[\r\n]+/gu, " ").replace(/[\\`*_[\]<>|]/gu, "\\$&");
+}
+
+function markdownList(values: readonly string[]): string {
+  if (values.length === 0) return "- none";
+  return values.map((value) => `- ${markdownSafe(value)}`).join("\n");
+}
+
+function renderTierRows(tiers: readonly FindingSeverityTierSignal[]): string {
+  if (tiers.length === 0) return "| Tier | Total | Confirmed | Rate | Weight |\n| --- | ---: | ---: | ---: | ---: |\n";
+  return [
+    "| Tier | Total | Confirmed | Rate | Weight |",
+    "| --- | ---: | ---: | ---: | ---: |",
+    ...tiers.map(
+      (tier) =>
+        `| ${markdownSafe(tier.tier)} | ${tier.total} | ${tier.confirmed} | ${tier.confirmationRate.toFixed(
+          6,
+        )} | ${tier.weight.toFixed(6)} |`,
+    ),
+  ].join("\n");
+}
+
+function renderContributingRepo(
+  signal: FindingSeverityCompositeCalibrationScore["audit"]["contributingRepos"][number],
+): string {
+  return [
+    `### ${markdownSafe(signal.repoFullName)}`,
+    "",
+    `- replayRunId: ${markdownSafe(signal.replayRunId)}`,
+    `- reviewRunId: ${markdownSafe(signal.reviewRunId)}`,
+    `- observedAt: ${signal.observedAt ? markdownSafe(signal.observedAt) : "n/a"}`,
+    `- score: ${signal.score.toFixed(6)}`,
+    "",
+    renderTierRows(signal.tiers),
+  ].join("\n");
+}
+
+function renderRejectedRow(row: FindingSeverityCalibrationIngestion["rejected"][number]): string {
+  return `| ${markdownSafe(row.repoFullName)} | ${markdownSafe(row.replayRunId)} | ${markdownSafe(
+    row.reviewRunId,
+  )} | ${markdownSafe(row.reason)} |`;
+}
+
+/**
+ * Resolve the explicit per-repo opt-in from a parsed `.gittensory.yml`-style object. Default is opted out. The
+ * preferred path is `miner.calibration.shareStructuredFindingSeverity`; `calibration.shareStructuredFindingSeverity`
+ * is accepted as a narrow alias so private-config surfaces can place the field at top level if needed.
+ */
+export function resolveFindingSeverityCalibrationConfig(
+  manifest: FindingSeverityCalibrationManifest | Record<string, unknown> | null | undefined,
+): FindingSeverityCalibrationConfig {
+  const warnings: string[] = [];
+  const root = isRecord(manifest) ? manifest : {};
+  const miner = isRecord(root.miner) ? root.miner : {};
+  const minerCalibration = isRecord(miner.calibration) ? miner.calibration : {};
+  const topCalibration = isRecord(root.calibration) ? root.calibration : {};
+  const optInRaw =
+    minerCalibration.shareStructuredFindingSeverity ?? topCalibration.shareStructuredFindingSeverity ?? undefined;
+  const optIn = normalizeBoolean(optInRaw);
+  if (optInRaw !== undefined && optIn === undefined) {
+    warnings.push(
+      "miner.calibration.shareStructuredFindingSeverity must be a boolean-like value; defaulting to false.",
+    );
+  }
+  const weightRaw =
+    minerCalibration.structuredFindingSeverityWeight ?? topCalibration.structuredFindingSeverityWeight;
+  const weight = normalizeOptionalWeight(weightRaw);
+  if (weightRaw !== undefined && weight === undefined) {
+    warnings.push(
+      "miner.calibration.structuredFindingSeverityWeight must be a non-negative finite number; using default.",
+    );
+  }
+  return {
+    shareStructuredFindingSeverity: optIn === true,
+    structuredFindingSeverityWeight: weight ?? DEFAULT_STRUCTURED_FINDING_SEVERITY_WEIGHT,
+    warnings,
+  };
+}
+
+/**
+ * Ingest only currently opted-in structured finding-severity signals. The opt-in check happens at ingestion time, so
+ * a maintainer opt-out immediately prevents additional calibration rows from contributing even if older collected
+ * data exists elsewhere.
+ */
+export function ingestFindingSeverityCalibrationSignals(
+  signals: readonly FindingSeverityCalibrationSignalInput[],
+): FindingSeverityCalibrationIngestion {
+  const accepted: FindingSeverityCalibrationSignal[] = [];
+  const rejected: FindingSeverityCalibrationIngestion["rejected"] = [];
+  for (const signal of signals) {
+    const repoFullName = normalizeRepoFullName(signal.repoFullName);
+    const replayRunId = normalizeId(signal.replayRunId);
+    const reviewRunId = normalizeId(signal.reviewRunId);
+    if (!repoFullName) {
+      rejected.push({
+        repoFullName: signal.repoFullName,
+        replayRunId: signal.replayRunId,
+        reviewRunId: signal.reviewRunId,
+        reason: "invalid_repo",
+      });
+      continue;
+    }
+    if (!replayRunId || !reviewRunId) {
+      rejected.push({
+        repoFullName,
+        replayRunId: signal.replayRunId,
+        reviewRunId: signal.reviewRunId,
+        reason: "invalid_run_id",
+      });
+      continue;
+    }
+    if (!signal.optedIn) {
+      rejected.push({ repoFullName, replayRunId, reviewRunId, reason: "not_opted_in" });
+      continue;
+    }
+    const tiers = normalizeTiers(signal.tiers);
+    const score = scoreTiers(tiers);
+    if (tiers.length === 0 || score === null) {
+      rejected.push({ repoFullName, replayRunId, reviewRunId, reason: "empty_tiers" });
+      continue;
+    }
+    accepted.push({
+      repoFullName,
+      replayRunId,
+      reviewRunId,
+      observedAt: normalizeObservedAt(signal.observedAt),
+      tiers,
+      score,
+    });
+  }
+  return { accepted, rejected };
+}
+
+export function computeFindingSeverityCompositeCalibrationScore(input: {
+  objectiveAnchor: number | ObjectiveAnchorScore;
+  pairwise: number | PairwiseCalibrationScore | null;
+  findingSeverity: FindingSeverityCalibrationIngestion | readonly FindingSeverityCalibrationSignalInput[];
+  weights?: FindingSeverityCalibrationWeights | undefined;
+}): FindingSeverityCompositeCalibrationScore {
+  const ingestion = isFindingSeverityCalibrationIngestion(input.findingSeverity)
+    ? input.findingSeverity
+    : ingestFindingSeverityCalibrationSignals(input.findingSeverity);
+  const objectiveAnchorScore =
+    typeof input.objectiveAnchor === "number" ? roundScore(input.objectiveAnchor) : input.objectiveAnchor.score;
+  const pairwiseJudgeScore =
+    input.pairwise === null
+      ? null
+      : typeof input.pairwise === "number"
+        ? roundScore(input.pairwise)
+        : input.pairwise.pairwiseJudgeScore;
+  const structuredFindingSeverityScore = averageSignals(ingestion.accepted);
+  const rawWeights = normalizeCompositeWeights(input.weights);
+  const usableWeights = {
+    objectiveAnchor: rawWeights.objectiveAnchor,
+    pairwiseJudge: pairwiseJudgeScore === null ? 0 : rawWeights.pairwiseJudge,
+    structuredFindingSeverity: structuredFindingSeverityScore === null ? 0 : rawWeights.structuredFindingSeverity,
+  };
+  const total =
+    usableWeights.objectiveAnchor + usableWeights.pairwiseJudge + usableWeights.structuredFindingSeverity;
+  const weights =
+    total <= 0
+      ? { objectiveAnchor: 1, pairwiseJudge: 0, structuredFindingSeverity: 0 }
+      : {
+          objectiveAnchor: usableWeights.objectiveAnchor / total,
+          pairwiseJudge: usableWeights.pairwiseJudge / total,
+          structuredFindingSeverity: usableWeights.structuredFindingSeverity / total,
+        };
+  const compositeScore = roundScore(
+    objectiveAnchorScore * weights.objectiveAnchor +
+      (pairwiseJudgeScore ?? 0) * weights.pairwiseJudge +
+      (structuredFindingSeverityScore ?? 0) * weights.structuredFindingSeverity,
+  );
+  return {
+    compositeScore,
+    objectiveAnchorScore,
+    pairwiseJudgeScore,
+    structuredFindingSeverityScore,
+    weights,
+    audit: {
+      contributingRepos: ingestion.accepted.map((signal) => ({
+        repoFullName: signal.repoFullName,
+        replayRunId: signal.replayRunId,
+        reviewRunId: signal.reviewRunId,
+        observedAt: signal.observedAt,
+        score: signal.score,
+        tiers: signal.tiers,
+      })),
+      rejected: ingestion.rejected,
+    },
+  };
+}
+
+/**
+ * Render a deterministic, public-safe Markdown report for a structured finding-severity calibration result. The
+ * report is local-run evidence: it includes aggregate scores, normalized weights, opted-in contributors, and rejected
+ * rows, but never accepts or emits raw review text or private scoring fields.
+ */
+export function renderFindingSeverityCalibrationAuditMarkdown(
+  result: FindingSeverityCompositeCalibrationScore,
+): string {
+  const lines = [
+    "# Structured Finding-Severity Calibration",
+    "",
+    `Composite score: ${result.compositeScore.toFixed(6)}`,
+    "",
+    "## Component Scores",
+    "",
+    `- objectiveAnchor: ${result.objectiveAnchorScore.toFixed(6)}`,
+    `- pairwiseJudge: ${result.pairwiseJudgeScore === null ? "n/a" : result.pairwiseJudgeScore.toFixed(6)}`,
+    `- structuredFindingSeverity: ${
+      result.structuredFindingSeverityScore === null ? "n/a" : result.structuredFindingSeverityScore.toFixed(6)
+    }`,
+    "",
+    "## Effective Weights",
+    "",
+    `- objectiveAnchor: ${result.weights.objectiveAnchor.toFixed(6)}`,
+    `- pairwiseJudge: ${result.weights.pairwiseJudge.toFixed(6)}`,
+    `- structuredFindingSeverity: ${result.weights.structuredFindingSeverity.toFixed(6)}`,
+    "",
+    "## Contributing Repos",
+    "",
+    result.audit.contributingRepos.length === 0
+      ? "_No opted-in structured finding-severity signals contributed._"
+      : result.audit.contributingRepos.map(renderContributingRepo).join("\n\n"),
+    "",
+    "## Rejected Rows",
+    "",
+  ];
+
+  if (result.audit.rejected.length === 0) {
+    lines.push("- none");
+  } else {
+    lines.push(
+      "| Repo | Replay run | Review run | Reason |",
+      "| --- | --- | --- | --- |",
+      ...result.audit.rejected.map(renderRejectedRow),
+    );
+  }
+
+  const contributingRepos = result.audit.contributingRepos.map((repo) => repo.repoFullName);
+  lines.push("", "## Contributing Repo Summary", "", markdownList(contributingRepos));
+  return `${lines.join("\n")}\n`;
+}

--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -75,6 +75,22 @@ export {
   type ReplayHarnessStatus,
 } from "./phase7-calibration-loop.js";
 export {
+  computeFindingSeverityCompositeCalibrationScore,
+  ingestFindingSeverityCalibrationSignals,
+  renderFindingSeverityCalibrationAuditMarkdown,
+  resolveFindingSeverityCalibrationConfig,
+  type FindingSeverityCalibrationConfig,
+  type FindingSeverityCalibrationIngestion,
+  type FindingSeverityCalibrationManifest,
+  type FindingSeverityCalibrationSignal,
+  type FindingSeverityCalibrationSignalInput,
+  type FindingSeverityCalibrationWeights,
+  type FindingSeverityCompositeCalibrationScore,
+  type FindingSeverityTier,
+  type FindingSeverityTierInput,
+  type FindingSeverityTierSignal,
+} from "./finding-severity-calibration.js";
+export {
   computeTrackRecordSummary,
   renderTrackRecordSummaryMarkdown,
   resolveTrackRecordSummaryConfig,

--- a/packages/gittensory-engine/test/finding-severity-calibration.test.ts
+++ b/packages/gittensory-engine/test/finding-severity-calibration.test.ts
@@ -1,0 +1,383 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  computeFindingSeverityCompositeCalibrationScore,
+  ingestFindingSeverityCalibrationSignals,
+  renderFindingSeverityCalibrationAuditMarkdown,
+  resolveFindingSeverityCalibrationConfig,
+  type FindingSeverityCalibrationSignalInput,
+  type ObjectiveAnchorScore,
+  type PairwiseCalibrationScore,
+} from "../dist/index.js";
+
+function signal(
+  overrides: Partial<FindingSeverityCalibrationSignalInput> = {},
+): FindingSeverityCalibrationSignalInput {
+  return {
+    repoFullName: "acme/widgets",
+    replayRunId: "replay-1",
+    reviewRunId: "review-1",
+    optedIn: true,
+    tiers: [{ tier: "blocker", total: 2, confirmed: 2 }],
+    ...overrides,
+  };
+}
+
+test("barrel: exports structured finding-severity calibration APIs", () => {
+  assert.equal(typeof resolveFindingSeverityCalibrationConfig, "function");
+  assert.equal(typeof ingestFindingSeverityCalibrationSignals, "function");
+  assert.equal(typeof computeFindingSeverityCompositeCalibrationScore, "function");
+  assert.equal(typeof renderFindingSeverityCalibrationAuditMarkdown, "function");
+});
+
+test("resolveFindingSeverityCalibrationConfig defaults to opted out with the default structured weight", () => {
+  assert.deepEqual(resolveFindingSeverityCalibrationConfig(undefined), {
+    shareStructuredFindingSeverity: false,
+    structuredFindingSeverityWeight: 0.2,
+    warnings: [],
+  });
+  assert.deepEqual(resolveFindingSeverityCalibrationConfig(null), {
+    shareStructuredFindingSeverity: false,
+    structuredFindingSeverityWeight: 0.2,
+    warnings: [],
+  });
+  // A non-object manifest is treated as absent, not an error.
+  assert.deepEqual(resolveFindingSeverityCalibrationConfig("nope" as unknown as Record<string, unknown>), {
+    shareStructuredFindingSeverity: false,
+    structuredFindingSeverityWeight: 0.2,
+    warnings: [],
+  });
+});
+
+test("resolveFindingSeverityCalibrationConfig reads the preferred miner.calibration path", () => {
+  const config = resolveFindingSeverityCalibrationConfig({
+    miner: { calibration: { shareStructuredFindingSeverity: true, structuredFindingSeverityWeight: 0.5 } },
+  });
+  assert.equal(config.shareStructuredFindingSeverity, true);
+  assert.equal(config.structuredFindingSeverityWeight, 0.5);
+  assert.deepEqual(config.warnings, []);
+});
+
+test("resolveFindingSeverityCalibrationConfig accepts the top-level calibration alias and boolean-like strings", () => {
+  const config = resolveFindingSeverityCalibrationConfig({
+    calibration: { shareStructuredFindingSeverity: "yes" },
+  });
+  assert.equal(config.shareStructuredFindingSeverity, true);
+  // miner.calibration takes precedence over the top-level alias when both are present.
+  const both = resolveFindingSeverityCalibrationConfig({
+    miner: { calibration: { shareStructuredFindingSeverity: "off" } },
+    calibration: { shareStructuredFindingSeverity: "on" },
+  });
+  assert.equal(both.shareStructuredFindingSeverity, false);
+});
+
+test("resolveFindingSeverityCalibrationConfig warns on non-boolean opt-in and invalid weight, falling back safely", () => {
+  const config = resolveFindingSeverityCalibrationConfig({
+    miner: {
+      calibration: { shareStructuredFindingSeverity: "maybe", structuredFindingSeverityWeight: "heavy" },
+    },
+  });
+  assert.equal(config.shareStructuredFindingSeverity, false);
+  assert.equal(config.structuredFindingSeverityWeight, 0.2);
+  assert.equal(config.warnings.length, 2);
+  assert.ok(config.warnings.some((w) => w.includes("shareStructuredFindingSeverity")));
+  assert.ok(config.warnings.some((w) => w.includes("structuredFindingSeverityWeight")));
+});
+
+test("resolveFindingSeverityCalibrationConfig rejects a negative weight but keeps a zero weight", () => {
+  const negative = resolveFindingSeverityCalibrationConfig({
+    calibration: { structuredFindingSeverityWeight: -3 },
+  });
+  assert.equal(negative.structuredFindingSeverityWeight, 0.2);
+  assert.equal(negative.warnings.length, 1);
+  const zero = resolveFindingSeverityCalibrationConfig({ calibration: { structuredFindingSeverityWeight: 0 } });
+  assert.equal(zero.structuredFindingSeverityWeight, 0);
+  assert.deepEqual(zero.warnings, []);
+});
+
+test("ingest scores a confirmed blocker as fully calibrated and an unconfirmed one as zero", () => {
+  const confirmed = ingestFindingSeverityCalibrationSignals([signal()]);
+  assert.equal(confirmed.accepted.length, 1);
+  assert.equal(confirmed.accepted[0]!.score, 1);
+  assert.deepEqual(confirmed.accepted[0]!.tiers, [
+    { tier: "blocker", total: 2, confirmed: 2, confirmationRate: 1, weight: 1, score: 1 },
+  ]);
+
+  const dismissed = ingestFindingSeverityCalibrationSignals([
+    signal({ tiers: [{ tier: "blocker", total: 2, confirmed: 0 }] }),
+  ]);
+  assert.equal(dismissed.accepted[0]!.score, 0);
+  assert.equal(dismissed.accepted[0]!.tiers[0]!.confirmationRate, 0);
+});
+
+test("ingest weights severity and volume so a confirmed blocker outscores many confirmed nits", () => {
+  const blockerHeavy = ingestFindingSeverityCalibrationSignals([
+    signal({
+      tiers: [
+        { tier: "blocker", total: 2, confirmed: 2 },
+        { tier: "nit", total: 10, confirmed: 0 },
+      ],
+    }),
+  ]).accepted[0]!;
+  // weightedRate = (1*2)*1 + (0.1*10)*0 = 2 ; weightSum = 2 + 1 = 3 ; score = 2/3.
+  assert.equal(blockerHeavy.score, Math.round((2 / 3) * 1_000_000) / 1_000_000);
+  // Output preserves TIER_ORDER (blocker before nit).
+  assert.deepEqual(
+    blockerHeavy.tiers.map((tier) => tier.tier),
+    ["blocker", "nit"],
+  );
+
+  const nitHeavy = ingestFindingSeverityCalibrationSignals([
+    signal({
+      tiers: [
+        { tier: "blocker", total: 2, confirmed: 0 },
+        { tier: "nit", total: 10, confirmed: 10 },
+      ],
+    }),
+  ]).accepted[0]!;
+  // weightedRate = (1*2)*0 + (0.1*10)*1 = 1 ; weightSum = 3 ; score = 1/3.
+  assert.equal(nitHeavy.score, Math.round((1 / 3) * 1_000_000) / 1_000_000);
+  assert.ok(blockerHeavy.score > nitHeavy.score, "confirmed blockers must calibrate higher than confirmed nits");
+});
+
+test("ingest clamps confirmed to total and discounts by confidence", () => {
+  const clamped = ingestFindingSeverityCalibrationSignals([
+    signal({ tiers: [{ tier: "blocker", total: 2, confirmed: 9 }] }),
+  ]).accepted[0]!;
+  assert.equal(clamped.tiers[0]!.confirmed, 2);
+  assert.equal(clamped.tiers[0]!.confirmationRate, 1);
+
+  const discounted = ingestFindingSeverityCalibrationSignals([
+    signal({ tiers: [{ tier: "warning", total: 4, confirmed: 4, confidence: 0.5 }] }),
+  ]).accepted[0]!;
+  // confirmed = min(4, round(4 * 0.5)) = 2 ; rate = 0.5.
+  assert.equal(discounted.tiers[0]!.confirmed, 2);
+  assert.equal(discounted.tiers[0]!.confirmationRate, 0.5);
+
+  // Confidence 0 credits no confirmations regardless of the raw count.
+  const zeroConfidence = ingestFindingSeverityCalibrationSignals([
+    signal({ tiers: [{ tier: "warning", total: 4, confirmed: 4, confidence: 0 }] }),
+  ]).accepted[0]!;
+  assert.equal(zeroConfidence.tiers[0]!.confirmed, 0);
+});
+
+test("ingest aggregates repeated tiers and normalizes tier aliases", () => {
+  const aggregated = ingestFindingSeverityCalibrationSignals([
+    signal({
+      tiers: [
+        { tier: "critical", total: 1, confirmed: 1 }, // alias -> blocker
+        { tier: "blocker", total: 3, confirmed: 0 },
+        { tier: "suggestion", total: 2, confirmed: 1 }, // alias -> advisory
+      ],
+    }),
+  ]).accepted[0]!;
+  const blocker = aggregated.tiers.find((tier) => tier.tier === "blocker")!;
+  assert.equal(blocker.total, 4);
+  assert.equal(blocker.confirmed, 1);
+  assert.equal(blocker.confirmationRate, 0.25);
+  const advisory = aggregated.tiers.find((tier) => tier.tier === "advisory")!;
+  assert.equal(advisory.total, 2);
+  assert.equal(advisory.confirmed, 1);
+});
+
+test("ingest drops zero-total and unknown tiers, rejecting a signal left with no tiers", () => {
+  const mixed = ingestFindingSeverityCalibrationSignals([
+    signal({
+      tiers: [
+        { tier: "blocker", total: 0, confirmed: 0 }, // dropped (zero total)
+        { tier: "mystery", total: 5, confirmed: 5 }, // dropped (unknown tier)
+        { tier: "warning", total: 3, confirmed: 3 },
+      ],
+    }),
+  ]);
+  assert.equal(mixed.accepted.length, 1);
+  assert.deepEqual(
+    mixed.accepted[0]!.tiers.map((tier) => tier.tier),
+    ["warning"],
+  );
+
+  const empty = ingestFindingSeverityCalibrationSignals([
+    signal({ tiers: [{ tier: "blocker", total: 0 }, { tier: "nope", total: 4, confirmed: 4 }] }),
+  ]);
+  assert.equal(empty.accepted.length, 0);
+  assert.equal(empty.rejected[0]!.reason, "empty_tiers");
+});
+
+test("ingest rejects invalid repos, run ids, and non-opted-in signals with specific reasons", () => {
+  const result = ingestFindingSeverityCalibrationSignals([
+    signal({ repoFullName: "not-a-repo" }),
+    signal({ replayRunId: "  " }),
+    signal({ reviewRunId: "bad\nid" }),
+    signal({ optedIn: false }),
+    signal(),
+  ]);
+  assert.equal(result.accepted.length, 1);
+  assert.deepEqual(
+    result.rejected.map((row) => row.reason),
+    ["invalid_repo", "invalid_run_id", "invalid_run_id", "not_opted_in"],
+  );
+  // The invalid-repo rejection preserves the raw (un-normalized) repo string for the audit.
+  assert.equal(result.rejected[0]!.repoFullName, "not-a-repo");
+});
+
+test("ingest normalizes repo casing and observedAt to ISO, or null for an unparseable timestamp", () => {
+  const result = ingestFindingSeverityCalibrationSignals([
+    signal({ repoFullName: "ACME/Widgets", observedAt: "2026-07-04T00:00:00Z" }),
+    signal({ observedAt: "not-a-date" }),
+  ]);
+  assert.equal(result.accepted[0]!.repoFullName, "acme/widgets");
+  assert.equal(result.accepted[0]!.observedAt, "2026-07-04T00:00:00.000Z");
+  assert.equal(result.accepted[1]!.observedAt, null);
+});
+
+test("composite blends objective-anchor, pairwise, and finding-severity, accepting numbers or score objects", () => {
+  const ingestion = ingestFindingSeverityCalibrationSignals([signal()]); // structured score 1
+  const withNumbers = computeFindingSeverityCompositeCalibrationScore({
+    objectiveAnchor: 0.8,
+    pairwise: 0.6,
+    findingSeverity: ingestion,
+  });
+  // default weights 0.45 / 0.35 / 0.2, structured = 1
+  const expected =
+    Math.round((0.8 * 0.45 + 0.6 * 0.35 + 1 * 0.2) * 1_000_000) / 1_000_000;
+  assert.equal(withNumbers.compositeScore, expected);
+  assert.equal(withNumbers.structuredFindingSeverityScore, 1);
+  assert.equal(withNumbers.audit.contributingRepos.length, 1);
+
+  // Raw signal inputs are ingested inline when an ingestion object is not supplied.
+  const inline = computeFindingSeverityCompositeCalibrationScore({
+    objectiveAnchor: 0.8,
+    pairwise: 0.6,
+    findingSeverity: [signal()],
+  });
+  assert.equal(inline.compositeScore, withNumbers.compositeScore);
+
+  // Accepts objective-anchor / pairwise score objects: only their `.score` / `.pairwiseJudgeScore` fields are read.
+  const anchor = { score: 0.7 } as unknown as ObjectiveAnchorScore;
+  const pairwise = { pairwiseJudgeScore: 0.4 } as unknown as PairwiseCalibrationScore;
+  const withObjects = computeFindingSeverityCompositeCalibrationScore({
+    objectiveAnchor: anchor,
+    pairwise,
+    findingSeverity: ingestion,
+  });
+  assert.equal(withObjects.objectiveAnchorScore, 0.7);
+  assert.equal(withObjects.pairwiseJudgeScore, 0.4);
+});
+
+test("composite averages the structured score across multiple accepted signals", () => {
+  // Signal A: confirmed blocker -> score 1. Signal B: dismissed blocker -> score 0. Average -> 0.5.
+  const ingestion = ingestFindingSeverityCalibrationSignals([
+    signal({ repoFullName: "acme/a" }),
+    signal({ repoFullName: "acme/b", tiers: [{ tier: "blocker", total: 2, confirmed: 0 }] }),
+  ]);
+  assert.equal(ingestion.accepted.length, 2);
+  const result = computeFindingSeverityCompositeCalibrationScore({
+    objectiveAnchor: 0,
+    pairwise: null,
+    findingSeverity: ingestion,
+    weights: { objectiveAnchor: 0, pairwiseJudge: 0, structuredFindingSeverity: 1 },
+  });
+  assert.equal(result.structuredFindingSeverityScore, 0.5);
+  assert.equal(result.compositeScore, 0.5);
+  assert.equal(result.audit.contributingRepos.length, 2);
+});
+
+test("composite drops the pairwise weight when pairwise is null and redistributes it", () => {
+  const ingestion = ingestFindingSeverityCalibrationSignals([signal()]);
+  const result = computeFindingSeverityCompositeCalibrationScore({
+    objectiveAnchor: 0.8,
+    pairwise: null,
+    findingSeverity: ingestion,
+  });
+  assert.equal(result.pairwiseJudgeScore, null);
+  assert.equal(result.weights.pairwiseJudge, 0);
+  // Remaining weights renormalize to sum 1.
+  const sum = result.weights.objectiveAnchor + result.weights.pairwiseJudge + result.weights.structuredFindingSeverity;
+  assert.ok(Math.abs(sum - 1) < 1e-9);
+  // composite = 0.8 * (0.45/0.65) + 1 * (0.2/0.65)
+  const expected = Math.round((0.8 * (0.45 / 0.65) + 1 * (0.2 / 0.65)) * 1_000_000) / 1_000_000;
+  assert.equal(result.compositeScore, expected);
+});
+
+test("composite drops the structured weight when no signal contributes", () => {
+  const result = computeFindingSeverityCompositeCalibrationScore({
+    objectiveAnchor: 0.5,
+    pairwise: 0.9,
+    findingSeverity: [signal({ optedIn: false })], // all rejected -> structured score null
+  });
+  assert.equal(result.structuredFindingSeverityScore, null);
+  assert.equal(result.weights.structuredFindingSeverity, 0);
+  const expected = Math.round((0.5 * (0.45 / 0.8) + 0.9 * (0.35 / 0.8)) * 1_000_000) / 1_000_000;
+  assert.equal(result.compositeScore, expected);
+  assert.equal(result.audit.rejected.length, 1);
+});
+
+test("composite honors custom weights and falls back to objective-only when all weights are zero", () => {
+  const ingestion = ingestFindingSeverityCalibrationSignals([signal()]);
+  const weighted = computeFindingSeverityCompositeCalibrationScore({
+    objectiveAnchor: 0.4,
+    pairwise: 0.4,
+    findingSeverity: ingestion,
+    weights: { objectiveAnchor: 0, pairwiseJudge: 0, structuredFindingSeverity: 1 },
+  });
+  // Only the structured component is weighted, so the composite equals the structured score (1).
+  assert.equal(weighted.compositeScore, 1);
+
+  const allZero = computeFindingSeverityCompositeCalibrationScore({
+    objectiveAnchor: 0.4,
+    pairwise: 0.4,
+    findingSeverity: ingestion,
+    weights: { objectiveAnchor: 0, pairwiseJudge: 0, structuredFindingSeverity: 0 },
+  });
+  // Zero weights fall back to the default distribution, not a divide-by-zero.
+  assert.ok(allZero.compositeScore > 0 && allZero.compositeScore <= 1);
+});
+
+test("renderAuditMarkdown is deterministic, public-safe, and reports contributors and rejections", () => {
+  const ingestion = ingestFindingSeverityCalibrationSignals([
+    signal({ repoFullName: "acme/widgets", observedAt: "2026-07-04T00:00:00Z" }),
+    signal({ repoFullName: "bad", replayRunId: "r2", reviewRunId: "v2" }),
+  ]);
+  const result = computeFindingSeverityCompositeCalibrationScore({
+    objectiveAnchor: 0.8,
+    pairwise: null,
+    findingSeverity: ingestion,
+  });
+  const markdown = renderFindingSeverityCalibrationAuditMarkdown(result);
+  assert.equal(markdown, renderFindingSeverityCalibrationAuditMarkdown(result), "render must be deterministic");
+  assert.ok(markdown.startsWith("# Structured Finding-Severity Calibration\n"));
+  assert.ok(markdown.includes("Composite score: "));
+  assert.ok(markdown.includes("### acme/widgets"));
+  assert.ok(markdown.includes("| blocker | 2 | 2 |"));
+  assert.ok(markdown.includes("- pairwiseJudge: n/a"));
+  // Rejected rows table is rendered with the specific reason (underscore markdown-escaped).
+  assert.ok(markdown.includes("invalid\\_repo"));
+  assert.ok(markdown.endsWith("\n"));
+});
+
+test("renderAuditMarkdown escapes markdown metacharacters in identifiers", () => {
+  const ingestion = ingestFindingSeverityCalibrationSignals([
+    signal({ repoFullName: "acme/widgets", replayRunId: "run|with*meta_", reviewRunId: "v1" }),
+  ]);
+  const result = computeFindingSeverityCompositeCalibrationScore({
+    objectiveAnchor: 0.5,
+    pairwise: 0.5,
+    findingSeverity: ingestion,
+  });
+  const markdown = renderFindingSeverityCalibrationAuditMarkdown(result);
+  assert.ok(markdown.includes("run\\|with\\*meta\\_"), "pipe/asterisk/underscore must be escaped");
+  assert.ok(!markdown.includes("run|with*meta_"));
+});
+
+test("renderAuditMarkdown handles the fully-empty case without throwing", () => {
+  const result = computeFindingSeverityCompositeCalibrationScore({
+    objectiveAnchor: 0.5,
+    pairwise: null,
+    findingSeverity: [],
+  });
+  const markdown = renderFindingSeverityCalibrationAuditMarkdown(result);
+  assert.ok(markdown.includes("_No opted-in structured finding-severity signals contributed._"));
+  assert.ok(markdown.includes("## Rejected Rows\n\n- none"));
+  assert.ok(markdown.includes("## Contributing Repo Summary\n\n- none"));
+});


### PR DESCRIPTION
## Summary

Adds a new pure engine module, `packages/gittensory-engine/src/finding-severity-calibration.ts`, in the same opt-in calibration family as objective-anchor, pairwise-judge, and gate-verdict calibration. It gives the miner replay harness a structured, default-off signal for how well-**calibrated** a review's finding *severities* were.

The review engine buckets its findings by severity tier — `blocker` / `warning` / `advisory` / `nit`. This module ingests, per replayed PR, the per-tier **total** count and how many were subsequently **confirmed** (true positives that pointed at a real, acted-on issue), and scores the review's severity calibration:

- The per-PR score is the **severity-and-volume-weighted** mean of the per-tier confirmation rates, so a confirmed blocker moves calibration far more than a confirmed nit, and a review that raises blockers which are then dismissed (false positives at the most disruptive tier) calibrates poorly.
- Each tier's `confirmed` is clamped to its `total` and discounted by an optional per-tier `confidence`, so an unverified "all confirmed" claim can't inflate the score.
- It composes with the objective-anchor and pairwise signals via `computeFindingSeverityCompositeCalibrationScore`, renormalizing weights when a signal is absent (a repo opts out, or no non-empty tier survives normalization).

Exactly like the sibling calibration signals, the type surface is deliberately narrow — repo/run ids and per-tier counts only. **No** raw review text, secrets, trust scores, reward values, private rankings, or maintainer evidence is represented, and `renderFindingSeverityCalibrationAuditMarkdown` Markdown-escapes and newline-collapses every caller-supplied id before rendering a deterministic local artifact.

### Public API (exported from the package barrel)

- `resolveFindingSeverityCalibrationConfig(manifest)` — reads the default-off opt-in from `miner.calibration.shareStructuredFindingSeverity` (with a top-level `calibration.*` alias) plus an optional non-negative weight; malformed values fail closed with warnings.
- `ingestFindingSeverityCalibrationSignals(signals)` — validates + normalizes opted-in signals, rejecting with a specific reason (`not_opted_in` / `empty_tiers` / `invalid_repo` / `invalid_run_id`); aggregates repeated tiers and normalizes tier aliases (`critical`→`blocker`, `suggestion`→`advisory`, …).
- `computeFindingSeverityCompositeCalibrationScore(input)` — blends objective-anchor + pairwise + finding-severity (accepting numbers or the sibling score objects), renormalizing weights and falling back to objective-only when all weights are zero.
- `renderFindingSeverityCalibrationAuditMarkdown(result)` — deterministic, public-safe Markdown.

This is deliberately default-off and safe to call at ingestion time: the hosted review stack remains responsible for loading the repo's current config. No app routes, deploy config, or existing modules change — only the new module, its barrel export, its `README.md` section, and its unit test.

No linked issue: it sits in the established calibration-signal family (objective-anchor, pairwise-judge, gate-verdict) and is a self-contained, additive, default-off engine module whose rationale is fully described here.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- The full `npm run test:ci` aggregate ran green (including `build:miner`, which compiles the engine `src/` — the new module and barrel export type-check clean — and `typecheck`) plus `npm audit --audit-level=moderate` (0 vulnerabilities). A dedicated node:test suite (`packages/gittensory-engine/test/finding-severity-calibration.test.ts`, mirroring the sibling calibration tests) covers the config resolution, ingestion/rejection reasons, tier normalization + clamping + confidence discount, severity-and-volume weighting, composite weight renormalization, and the Markdown renderer. The module lives under `packages/` (outside the root `src/**` Codecov scope), so the 99% patch rule does not apply to it.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

The module's type surface is deliberately private-data-free (repo/run ids + per-tier counts only), it is default-off (ingestion requires an explicit `shareStructuredFindingSeverity: true` opt-in), and the renderer escapes and newline-collapses all caller-supplied ids. Pure and deterministic: no auth/CORS/session surface, no API/OpenAPI shape change, no UI.

## Notes

- New file `finding-severity-calibration.ts` + its barrel export + a `README.md` section + a `node:test` suite. No schema, migration, OpenAPI, wrangler, or generated-artifact impact.
