### PR TITLE
fix(signals): classify scss and less source maps as generated

### DIFF
--- a/src/signals/path-matchers.ts
+++ b/src/signals/path-matchers.ts
@@ -65,7 +65,7 @@ function isGeneratedFileFrom(parts: NormalizedPath): boolean {
     // Source maps for every first-class JS/TS bundle extension. `.mjs`/`.cjs` are already
     // recognized code extensions (isCodeFile), so their bundlers' `.mjs.map` / `.cjs.map`
     // maps are generated output too — the same as `.js.map`.
-    /\.(js|jsx|mjs|cjs|ts|tsx|mts|cts|vue|svelte|astro|css)\.map$/.test(norm) ||
+    /\.(js|jsx|mjs|cjs|ts|tsx|mts|cts|vue|svelte|astro|scss|less|css)\.map$/.test(norm) ||
     base === "worker-configuration.d.ts"
   );
 }

--- a/test/unit/path-matchers.test.ts
+++ b/test/unit/path-matchers.test.ts
@@ -50,6 +50,8 @@ describe("isGeneratedFile", () => {
       "dist/App.vue.map",
       "dist/Card.svelte.map",
       "dist/page.astro.map",
+      "dist/styles.scss.map",
+      "dist/theme.less.map",
     ]) {
       expect(isGeneratedFile(path)).toBe(true);
     }


### PR DESCRIPTION
## Summary

- Extend `isGeneratedFile` in `path-matchers.ts` to treat `.scss.map` and `.less.map` as generated output, matching the existing `.css.map` handling (#3357).
- Sass/Less bundler source-map siblings were still miscounted as substantive source in `classifyChangedFile`.

## Scope

- [x] Conventional Commit title format.
- [x] Focused — path-matchers + unit tests only.
- [x] Follows `CONTRIBUTING.md`.
- [x] No linked issue needed.

## Validation

- [x] `git diff --check`
- [x] `npm run test:ci` on Node 22
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] Unit tests cover `.scss.map` and `.less.map`

## Safety

- [x] No secrets, auth, or UI changes.
- [x] N/A for UI Evidence.

## UI Evidence

N/A — backend path classifier only.

## Notes

**Conflict avoidance:** Touches only `src/signals/path-matchers.ts` and `test/unit/path-matchers.test.ts`. Zero overlap with open PRs (#3373 focus-manifest, #3372/#3304 test-evidence, #3368 engine, #3361 enrichment, #3314 miner, #3305 enrichment-wire, #3304 queue/gate). Merges cleanly after any of those land without rebase.

Made with [Cursor](https://cursor.com)