### PR TITLE
feat(engine): add bestRankedOpportunityAtOrAboveScore

### DIFF
--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -13,6 +13,7 @@ export {
 export { rankOpportunitiesAtOrAboveScore } from "./ranked-opportunity-min-score.js";
 export { pickTopRankedOpportunitiesAtOrAboveScore } from "./ranked-opportunity-top-min-score.js";
 export { bestRankedOpportunity } from "./ranked-opportunity-best-pick.js";
+export { bestRankedOpportunityAtOrAboveScore } from "./ranked-opportunity-best-min-score.js";
 export {
   extractObjectiveAnchorHistory,
   extractObjectiveAnchorFeatures,

--- a/packages/gittensory-engine/src/ranked-opportunity-best-min-score.ts
+++ b/packages/gittensory-engine/src/ranked-opportunity-best-min-score.ts
@@ -1,0 +1,14 @@
+import { rankOpportunitiesAtOrAboveScore } from "./ranked-opportunity-min-score.js";
+import type { OpportunityRankInput } from "./opportunity-ranker.js";
+
+/**
+ * Return the highest-scoring candidate at or above `minScore`, or `null` when none qualify.
+ * Non-finite thresholds return `null`. Pure — delegates to {@link rankOpportunitiesAtOrAboveScore}.
+ */
+export function bestRankedOpportunityAtOrAboveScore<T>(
+  candidates: Array<T & OpportunityRankInput>,
+  minScore: number,
+): (Omit<T, "rankScore"> & OpportunityRankInput & { rankScore: number }) | null {
+  const survivors = rankOpportunitiesAtOrAboveScore(candidates, minScore);
+  return survivors[0] ?? null;
+}

--- a/test/unit/ranked-opportunity-best-min-score.test.ts
+++ b/test/unit/ranked-opportunity-best-min-score.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+
+import { bestRankedOpportunityAtOrAboveScore } from "../../packages/gittensory-engine/src/ranked-opportunity-best-min-score";
+import type { OpportunityRankInput } from "../../packages/gittensory-engine/src/opportunity-ranker";
+
+function input(over: Partial<OpportunityRankInput> = {}): OpportunityRankInput {
+  return { potential: 1, feasibility: 1, laneFit: 1, freshness: 1, dupRisk: 0, ...over };
+}
+
+describe("bestRankedOpportunityAtOrAboveScore", () => {
+  const candidates = [
+    { id: "low", ...input({ potential: 0.2 }) },
+    { id: "mid", ...input({ potential: 0.5 }) },
+    { id: "top", ...input() },
+    { id: "weak", ...input({ potential: 0.5, feasibility: 0.5, laneFit: 0.5 }) },
+  ];
+
+  it("returns null for an empty candidate list", () => {
+    expect(bestRankedOpportunityAtOrAboveScore([], 0.5)).toBeNull();
+  });
+
+  it("returns null when the score threshold excludes every candidate", () => {
+    expect(
+      bestRankedOpportunityAtOrAboveScore(
+        [
+          { id: "a", ...input({ potential: 0.2 }) },
+          { id: "b", ...input({ potential: 0.3 }) },
+        ],
+        0.5,
+      ),
+    ).toBeNull();
+  });
+
+  it("returns null for a non-finite threshold", () => {
+    expect(bestRankedOpportunityAtOrAboveScore(candidates, Number.NaN)).toBeNull();
+    expect(bestRankedOpportunityAtOrAboveScore(candidates, Number.POSITIVE_INFINITY)).toBeNull();
+  });
+
+  it("returns the highest-scoring survivor at or above the threshold", () => {
+    const best = bestRankedOpportunityAtOrAboveScore(candidates, 0.5);
+    expect(best?.id).toBe("top");
+    expect(best?.rankScore).toBeGreaterThanOrEqual(0.5);
+  });
+
+  it("breaks score ties by input order among qualifying candidates", () => {
+    const tie = input({ potential: 0.5, feasibility: 0.5, laneFit: 0.5, freshness: 0.5 });
+    const best = bestRankedOpportunityAtOrAboveScore(
+      [
+        { id: "first", ...tie },
+        { id: "second", ...tie },
+      ],
+      0.05,
+    );
+    expect(best?.id).toBe("first");
+  });
+
+  it("is exported from the package barrel", async () => {
+    const barrel = await import("../../packages/gittensory-engine/src/index");
+    expect(typeof barrel.bestRankedOpportunityAtOrAboveScore).toBe("function");
+    expect(barrel.bestRankedOpportunityAtOrAboveScore(candidates, 0.5)?.id).toBe("top");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `bestRankedOpportunityAtOrAboveScore` in `@jsonbored/gittensory-engine` — returns the highest-scoring generic ranked candidate at or above `minScore`, or `null` when none qualify.
- Thin wrapper over `rankOpportunitiesAtOrAboveScore` for miner discovery flows that need a single thresholded pick.
- Vitest coverage at 100% patch on the new helper.

## Test plan
- [x] `COVERAGE_NO_THRESHOLDS=1 npx vitest run test/unit/ranked-opportunity-best-min-score.test.ts --coverage`
- [x] `npx diff-cover coverage/lcov.info --compare-branch=main --fail-under=99` → 100%
- [x] `npm run build --workspace @jsonbored/gittensory-engine && npm run build:miner`


Made with [Cursor](https://cursor.com)