### PR TITLE
test(enrichment): cover extractDependencyChanges edge cases in dependency-scan

### DIFF
--- a/review-enrichment/test/dependency-scan.test.ts
+++ b/review-enrichment/test/dependency-scan.test.ts
@@ -26,3 +26,57 @@ test("extractDependencyChanges skips real file headers via the shared discrimina
     { ecosystem: "npm", package: "lodash", from: "4.17.20", to: "4.17.21" },
   ]);
 });
+
+test("extractDependencyChanges reports a newly ADDED dependency with a null `from`", () => {
+  const changes = extractDependencyChanges([
+    {
+      path: "package.json",
+      patch: ["@@ -1,1 +1,2 @@", '     "dependencies": {', '+    "left-pad": "1.3.0",'].join("\n"),
+    },
+  ]);
+  assert.deepEqual(changes, [{ ecosystem: "npm", package: "left-pad", from: null, to: "1.3.0" }]);
+});
+
+test("extractDependencyChanges ignores a removed-only dependency (nothing present after the change)", () => {
+  const changes = extractDependencyChanges([
+    { path: "package.json", patch: ["@@ -1,2 +1,1 @@", '-    "left-pad": "1.3.0",'].join("\n") },
+  ]);
+  assert.deepEqual(changes, []);
+});
+
+test("extractDependencyChanges ignores an unchanged version (added === removed)", () => {
+  // A line reformatted/moved but whose version is identical must NOT surface as a change.
+  const changes = extractDependencyChanges([
+    {
+      path: "package.json",
+      patch: ["@@ -1,2 +1,2 @@", '-    "lodash": "4.17.21",', '+    "lodash": "4.17.21",'].join("\n"),
+    },
+  ]);
+  assert.deepEqual(changes, []);
+});
+
+test("extractDependencyChanges skips a non-manifest file", () => {
+  const changes = extractDependencyChanges([
+    { path: "src/index.ts", patch: ["@@ -1 +1,1 @@", '+    "lodash": "4.17.21",'].join("\n") },
+  ]);
+  assert.deepEqual(changes, []);
+});
+
+test("extractDependencyChanges extracts multiple version bumps from one manifest, in order", () => {
+  const changes = extractDependencyChanges([
+    {
+      path: "package.json",
+      patch: [
+        "@@ -1,4 +1,4 @@",
+        '-    "react": "18.2.0",',
+        '+    "react": "18.3.0",',
+        '-    "lodash": "4.17.20",',
+        '+    "lodash": "4.17.21",',
+      ].join("\n"),
+    },
+  ]);
+  assert.deepEqual(changes, [
+    { ecosystem: "npm", package: "react", from: "18.2.0", to: "18.3.0" },
+    { ecosystem: "npm", package: "lodash", from: "4.17.20", to: "4.17.21" },
+  ]);
+});


### PR DESCRIPTION
## Summary

Hardens unit coverage for the `dependency-scan` analyzer's pure `extractDependencyChanges` parser, which previously had a single test case (a version bump). Adds five focused cases for its real branches:

- a newly **added** dependency → `from: null`, `to: <version>`
- a **removed-only** dependency → no change (nothing present after the change)
- an **unchanged** version (`added === removed`) → no change
- a **non-manifest** file (e.g. `src/index.ts`) → skipped
- **multiple** version bumps in one manifest → extracted in order

Test-only, all against the compiled `dist/`, following the existing file's style. `fixedOf`/`severityOf` are deliberately left alone — they're already covered by `osv-fixed-version.test.ts` / `osv-severity.test.ts`, so this adds no duplicate coverage.

_No linked issue — this is straightforward test-coverage hardening of an under-tested pure function (the parser had 1 case for its several branches); it changes no runtime behavior._

## Scope
- [x] Conventional Commit; focused; touches only `review-enrichment/test/dependency-scan.test.ts`. No `site/`/`CNAME`/`**/lovable/**`; no `CHANGELOG.md`; no source or shared-registry change.

## Validation
- [x] `npm --prefix review-enrichment test` — **722 pass / 0 fail** (build + sourcemap validate + `metadata --check` + node tests; exactly CI). The 5 new cases assert `extractDependencyChanges`'s documented behavior on inputs its single prior test didn't exercise.
- [x] `npm run typecheck` clean; `git diff --check` clean.

## Safety
- [x] Test-only, no runtime change. No secrets/wallets/hotkeys/trust/reward terms.
