### PR TITLE
fix(selfhost): use own-property check for retired config-lint fields

### DIFF
--- a/src/selfhost/config-lint.ts
+++ b/src/selfhost/config-lint.ts
@@ -73,8 +73,13 @@ function unknownTopLevelWarnings(text: string | null | undefined): string[] {
   const parsed = parseTopLevelObject(trimmed);
   if (parsed === null) return [];
   const keys = Object.keys(parsed).filter((key) => !TOP_LEVEL_FIELD_SET.has(key));
-  const retiredWarnings = keys.filter((key) => key in RETIRED_FIELD_MIGRATION_WARNINGS).map((key) => RETIRED_FIELD_MIGRATION_WARNINGS[key]!);
-  const unknown = keys.filter((key) => !(key in RETIRED_FIELD_MIGRATION_WARNINGS)).map(formatFieldName);
+  // `hasOwnProperty.call`, NOT `key in`: a manifest field named like an Object.prototype member
+  // (`constructor`, `toString`, `hasOwnProperty`, ...) would otherwise test true for the inherited
+  // property and resolve to the prototype's function instead of a real retired-field warning string,
+  // corrupting the string[] result and suppressing the genuine unknown-field warning.
+  const isRetired = (key: string): boolean => Object.prototype.hasOwnProperty.call(RETIRED_FIELD_MIGRATION_WARNINGS, key);
+  const retiredWarnings = keys.filter(isRetired).map((key) => RETIRED_FIELD_MIGRATION_WARNINGS[key]!);
+  const unknown = keys.filter((key) => !isRetired(key)).map(formatFieldName);
   return [
     ...retiredWarnings,
     ...(unknown.length > 0 ? [`Manifest contains unknown top-level field${unknown.length === 1 ? "" : "s"}: ${unknown.join(", ")}.`] : []),

--- a/test/unit/selfhost-config-lint.test.ts
+++ b/test/unit/selfhost-config-lint.test.ts
@@ -159,6 +159,16 @@ unknownSecretKey: super-secret-value
     expect(JSON.stringify(result)).not.toContain("/tmp/private");
   });
 
+  it("treats a field named like an Object.prototype member as unknown, not retired", () => {
+    const result = lintManifestText("wantedPaths: [src/]\nconstructor: whatever\n");
+
+    expect(result.ok).toBe(false);
+    expect(result.recognizedFields).toEqual(["wantedPaths"]);
+    expect(result.warnings).toEqual(["Manifest contains unknown top-level field: constructor."]);
+    // Every warning must be a real string — a prototype-name collision must never leak a function.
+    expect(result.warnings.every((warning) => typeof warning === "string")).toBe(true);
+  });
+
   it("uses singular wording for one unknown top-level field", () => {
     const result = lintManifestText("wantedPaths: [src/]\nunknownSecretKey: super-secret-value\n");
 


### PR DESCRIPTION
## Summary

`unknownTopLevelWarnings()` in `src/selfhost/config-lint.ts` splits unknown top-level manifest fields into "retired" (with a migration warning) vs genuinely "unknown", using the JavaScript `in` operator:

```ts
const retiredWarnings = keys.filter((key) => key in RETIRED_FIELD_MIGRATION_WARNINGS).map((key) => RETIRED_FIELD_MIGRATION_WARNINGS[key]!);
const unknown = keys.filter((key) => !(key in RETIRED_FIELD_MIGRATION_WARNINGS)).map(formatFieldName);
```

`RETIRED_FIELD_MIGRATION_WARNINGS` is a plain object literal, so `in` walks the prototype chain: `"constructor" in obj`, `"toString" in obj`, `"hasOwnProperty" in obj`, `"valueOf" in obj`, etc. are all `true`. A manifest with a field named like an `Object.prototype` member is therefore **misclassified as retired**, and `RETIRED_FIELD_MIGRATION_WARNINGS["constructor"]` resolves to the inherited `Object` **function**, which is pushed into a declared `string[]`. Because `JSON.stringify` drops function values, that warning serializes to `null` over any API — and the genuine `"Manifest contains unknown top-level field: constructor."` warning is silently suppressed, so the suspicious unknown field disappears from operator-facing output.

The sibling `recognizedFieldsFor` in the same file already does this correctly with `Object.prototype.hasOwnProperty.call(...)`; this call site was the inconsistent one. The fix uses an own-property check. Adds a regression test that lints a `constructor:` field and asserts the correct unknown-field warning plus that every warning is a string.

No linked issue: issue creation on this repo is restricted to collaborators, and this is a small, self-contained correctness fix (own-property check, matching the sibling in the same file) whose rationale is self-evident from the diff.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- The full `npm run test:ci` aggregate ran green plus `npm audit --audit-level=moderate` (0 vulnerabilities). The changed lines are exercised by the existing retired/unknown-field tests plus the new constructor-named-field regression test (which fails on the old `in` operator and passes with `hasOwnProperty`), so `codecov/patch` is 100% for the diff.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

Pure config-lint logic; it makes operator-facing manifest linting correct for prototype-named fields and exposes no secrets. No auth/CORS/session surface, no API/OpenAPI shape change, no UI.

## Notes

- Three-line change (own-property predicate) plus a regression test. No schema, migration, OpenAPI, wrangler, or generated-artifact impact.
