### PR TITLE
feat(enrichment): flag insecure HTTP security-header settings in iac-misconfig

### DIFF
--- a/review-enrichment/src/analyzers/iac-misconfig.ts
+++ b/review-enrichment/src/analyzers/iac-misconfig.ts
@@ -105,6 +105,16 @@ const NO_NEW_PRIVILEGES_OFF_RE = /\bno-new-privileges[=:]\s*["']?false\b/i;
 const DOCKER_SOCKET_MOUNT_RE =
   /\/var\/run\/docker\.sock:|\bsource\s*:\s*["']?\/var\/run\/docker\.sock\b/;
 
+// HTTP security-header misconfigurations (nginx/Apache/Caddy conf, Helm ingress annotations, netlify.toml
+// headers, …). Each rule requires ITS OWN header token to be present on the same line as the weakening value,
+// so an unrelated line that merely contains the value (a `Cache-Control: max-age=0` caching directive, or a
+// stray `unsafe-inline = false` config key) is NOT flagged — only a line that is actually setting that header.
+const CSP_UNSAFE_INLINE_RE = /\bContent-Security-Policy\b[^\n]*\bunsafe-inline\b/i;
+const CSP_UNSAFE_EVAL_RE = /\bContent-Security-Policy\b[^\n]*\bunsafe-eval\b/i;
+const HSTS_DISABLED_RE = /\bStrict-Transport-Security\b[^\n]*\bmax-age\s*=\s*0\b/i;
+const REFERRER_UNSAFE_URL_RE = /\bReferrer-Policy\b[^\n]*\bunsafe-url\b/i;
+const COOKIE_NOT_HTTPONLY_RE = /\bhttp[_-]?only\b[\s"'=:,-]*false\b/i;
+
 function* patchLines(patch: string): Generator<string> {
   let start = 0;
   for (let i = 0; i <= patch.length; i++) {
@@ -512,6 +522,36 @@ export function scanPatchForIacMisconfig(
     if (
       DOCKER_SOCKET_MOUNT_RE.test(body) &&
       pushFinding(findings, seen, path, newLine, "docker-socket-mount", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      CSP_UNSAFE_INLINE_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "csp-unsafe-inline", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      CSP_UNSAFE_EVAL_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "csp-unsafe-eval", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      HSTS_DISABLED_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "hsts-disabled", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      REFERRER_UNSAFE_URL_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "referrer-policy-leak", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      COOKIE_NOT_HTTPONLY_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "cookie-not-httponly", maxFindings)
     ) {
       return findings;
     }

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -353,6 +353,16 @@ export function renderBrief(
           return "disables the `no-new-privileges` protection, allowing setuid binaries to escalate privileges";
         case "docker-socket-mount":
           return "mounts the host Docker socket (`/var/run/docker.sock`) into the container — this grants host-level control";
+        case "csp-unsafe-inline":
+          return "uses `'unsafe-inline'` in a Content-Security-Policy, permitting inline scripts/styles and weakening XSS protection";
+        case "csp-unsafe-eval":
+          return "uses `'unsafe-eval'` in a Content-Security-Policy, permitting `eval()` and weakening XSS protection";
+        case "hsts-disabled":
+          return "disables HSTS with `Strict-Transport-Security` `max-age=0`, so browsers stop enforcing HTTPS for the host";
+        case "referrer-policy-leak":
+          return "sets `Referrer-Policy: unsafe-url`, leaking the full URL (path and query) to cross-origin destinations";
+        case "cookie-not-httponly":
+          return "sets `httpOnly: false` on a cookie, exposing it to JavaScript so an XSS can read it";
       }
     };
 

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -257,7 +257,12 @@ export interface IacMisconfigFinding {
     | "ipc-host"
     | "cap-add-all"
     | "no-new-privileges-off"
-    | "docker-socket-mount";
+    | "docker-socket-mount"
+    | "csp-unsafe-inline"
+    | "csp-unsafe-eval"
+    | "hsts-disabled"
+    | "referrer-policy-leak"
+    | "cookie-not-httponly";
 }
 
 /** A newly-added dependency whose install compiles native code (npm node-gyp addon) or has no prebuilt wheel

--- a/review-enrichment/test/iac-misconfig.test.ts
+++ b/review-enrichment/test/iac-misconfig.test.ts
@@ -444,3 +444,46 @@ test("scanPatchForIacMisconfig does not flag the secure counterpart of each cont
     );
   }
 });
+
+test("scanPatchForIacMisconfig flags insecure HTTP security-header settings", () => {
+  // Each matched value is the weakening itself, so there is no safe-value form of the same line.
+  const cases = [
+    ["+    add_header Content-Security-Policy \"script-src 'unsafe-inline'\";", "csp-unsafe-inline"],
+    ["+    Content-Security-Policy: script-src 'unsafe-eval'", "csp-unsafe-eval"],
+    ["+    add_header Strict-Transport-Security \"max-age=0\";", "hsts-disabled"],
+    ["+    add_header Referrer-Policy \"unsafe-url\";", "referrer-policy-leak"],
+    ["+    httpOnly: false", "cookie-not-httponly"],
+  ];
+  for (const [added, kind] of cases) {
+    const findings = scanPatchForIacMisconfig(
+      "nginx.conf",
+      ["@@ -1,0 +1,1 @@", added].join("\n"),
+    );
+    assert.deepEqual(
+      findings,
+      [{ file: "nginx.conf", line: 1, kind }],
+      `${kind}: expected exactly one finding of that kind, got ${JSON.stringify(findings)}`,
+    );
+  }
+});
+
+test("scanPatchForIacMisconfig does not flag secure HTTP header values (incl. Cache-Control max-age=0)", () => {
+  const safe = [
+    "+    Content-Security-Policy: script-src 'self'",
+    "+    add_header Strict-Transport-Security \"max-age=31536000; includeSubDomains\";",
+    // Cache-Control max-age=0 is a NORMAL caching directive and must NOT fire the HSTS rule.
+    "+    add_header Cache-Control \"max-age=0\";",
+    "+    add_header Referrer-Policy \"strict-origin-when-cross-origin\";",
+    "+    httpOnly: true",
+    // The CSP keywords must NOT fire without an actual Content-Security-Policy header on the same line.
+    "+    unsafe-inline = false",
+    "+    allowlist: [unsafe-eval]",
+  ];
+  for (const added of safe) {
+    assert.deepEqual(
+      scanPatchForIacMisconfig("nginx.conf", ["@@ -1,0 +1,1 @@", added].join("\n")),
+      [],
+      `should not flag: ${added.trim()}`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

The IaC-misconfig analyzer already covers Kubernetes, Dockerfile, Docker Compose, and TLS-bypass
misconfigurations. This adds **5 HTTP security-header rules** for insecure header values that appear in the
config files the analyzer already scans (`nginx*.conf`, `.conf`, YAML/Helm ingress annotations, `.toml`, `.json`):

| kind | fires on | risk |
|---|---|---|
| `csp-unsafe-inline` | `'unsafe-inline'` in a Content-Security-Policy | permits inline scripts/styles (weakens XSS defense) |
| `csp-unsafe-eval` | `'unsafe-eval'` in a Content-Security-Policy | permits `eval()` (weakens XSS defense) |
| `hsts-disabled` | `Strict-Transport-Security … max-age=0` | disables HSTS (browsers stop enforcing HTTPS) |
| `referrer-policy-leak` | `Referrer-Policy: unsafe-url` | leaks the full URL (path + query) cross-origin |
| `cookie-not-httponly` | `httpOnly: false` | exposes the cookie to JavaScript (XSS can read it) |

> Supersedes the closed #3370, whose CSP rules matched `unsafe-inline`/`unsafe-eval` anywhere and so could flag
> a non-CSP line such as `unsafe-inline = false`. This version anchors **every** rule to its own header token on
> the same line (the CSP rules now require `Content-Security-Policy`), with negative tests for a bare
> `unsafe-inline`/`unsafe-eval` line.

**Why these are false-positive-safe:** each rule requires its own header token on the same line as the
weakening value, so an unrelated line that merely contains the value is not flagged: a normal
`Cache-Control: max-age=0` caching directive does not fire the HSTS rule, and a stray `unsafe-inline = false`
config key does not fire the CSP rule (both asserted in the negative test). Within a header that IS being set,
the matched value is the weakening itself — the secure value uses a different token the regex never matches
(`'self'`, `max-age=31536000`, `strict-origin-when-cross-origin`, `httpOnly: true`), also asserted to produce
no finding.

No existing rule is modified, and the analyzer's finding schema is `{file, line, kind}` — the `kind` union is
not part of the analyzer descriptor, so `analyzer-metadata.json` and the generated UI mirror are **unchanged**.
The render-brief switch is TypeScript-exhaustive, so each new kind is compiler-forced to have a public-safe
explanation.

No linked issue: additive detection-coverage that extends an existing multi-domain analyzer along its own
established lines; each rule is a self-evident, named HTTP-hardening check (OWASP Secure Headers) with no public
API/schema/deploy surface change — fits the repo's `preferred` (not required) linked-issue policy.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run typecheck`
- [x] `npm run rees:test` — the review-enrichment build + analyzer suite (see note below)
- [ ] `npm run test:coverage` (N/A — this analyzer is in `review-enrichment/`, outside the root `src/**` Codecov scope)
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran locally: `git diff --check` (clean), the review-enrichment TypeScript build (exit 0 — which proves the
  render switch is exhaustive over the 5 new kinds), and the analyzer suite via `node --test`. The
  iac-misconfig file passes 21/21: a table test asserting each of the 5 settings produces exactly one finding
  of its own kind, and a negative test asserting the secure counterpart of each — including a normal
  `Cache-Control: max-age=0` (which must NOT fire the HSTS rule) — produces none. The full `node --test` run's
  only failures are the two `upload-sourcemaps` tests (they shell out to the Sentry CLI, absent on this dev
  box), which fail identically on unmodified `main`.
- Not run locally: the UI, root typecheck, and the `metadata:check` step of `rees:test`. This change adds only
  finding kinds and rules, not any analyzer descriptor field, so the committed `analyzer-metadata.json` / UI
  mirror are unchanged (a local regeneration produces a zero-content diff) and `metadata:check` passes on CI
  (Linux). On this Windows dev box `metadata:check` reports a spurious line-ending difference; it fails
  identically on unmodified `main`. `analyzer-metadata.json` was NOT modified.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Detection-only additions: 5 new stateless rules following the existing single-line pattern; no existing rule,
  threshold, or descriptor changed, so current findings and `analyzer-metadata.json` are unaffected. Each new
  kind reports only `file:line` + the public-safe kind, never the matched line content.
- The HSTS and Referrer-Policy rules are anchored to their own header token so an unrelated line carrying the
  same value (e.g. `Cache-Control: max-age=0`) is never flagged.
