### PR TITLE
fix(review): skip additional binary extensions in full-file grounding

### DIFF
--- a/src/review/review-grounding.ts
+++ b/src/review/review-grounding.ts
@@ -51,7 +51,7 @@ export interface ReviewGrounding {
 const FILE_CONTENT_BUDGET = 60_000; // total chars inlined across all changed files
 const MAX_SINGLE_FILE = 24_000; // a file larger than this is marked truncated (review it from the diff)
 // Binary / generated / lockfile paths carry no review signal as full text — skip inlining them.
-const SKIP_EXT = /\.(png|jpe?g|gif|webp|svg|ico|pdf|lock|min\.js|min\.css|map|woff2?|ttf|eot|mp4|webm|zip|gz|wasm)$/i;
+const SKIP_EXT = /\.(png|jpe?g|gif|webp|avif|bmp|heic|svg|ico|pdf|lock|min\.js|min\.css|map|woff2?|ttf|eot|mp4|webm|zip|gz|tgz|wasm)$/i;
 
 /** The grounding feature flags (subset of reviewbot's FeatureToggles). */
 export interface GroundingFlags {

--- a/test/unit/review-grounding.test.ts
+++ b/test/unit/review-grounding.test.ts
@@ -156,11 +156,11 @@ describe("review-grounding: fetchFullFileContents (injected FileFetcher, fail-sa
     const out = await fetchFullFileContents(
       { ciGrounding: false, fullFileContext: true },
       "sha",
-      files(["README.md"], ["src/a.ts"], ["logo.png"], ["old.ts", "removed"]),
+      files(["README.md"], ["src/a.ts"], ["logo.png"], ["assets/photo.avif"], ["assets/poster.bmp"], ["assets/icon.heic"], ["dist/pkg.tgz"], ["old.ts", "removed"]),
       fetcher,
     );
     expect(out).toBeDefined();
-    // source (priority 0) before docs (priority 2); png + removed excluded
+    // source (priority 0) before docs (priority 2); binary + removed excluded
     expect(out?.map((f) => f.path)).toEqual(["src/a.ts", "README.md"]);
   });
 


### PR DESCRIPTION
## Summary

- Extend `SKIP_EXT` in `review-grounding.ts` so `fetchFullFileContents` skips `.avif`, `.bmp`, `.heic`, and `.tgz` paths (alongside existing png/webp/pdf/etc.).
- These binary/archive blobs carry no review signal as inlined text; fetching them wasted the full-file grounding budget on unreadable content.

## Scope

- [x] Conventional Commit title format.
- [x] Focused — review grounding + unit tests only.
- [x] Follows `CONTRIBUTING.md`.
- [x] No linked issue needed.

## Validation

- [x] `git diff --check`
- [x] `npm run test:ci` on Node 22
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] Unit test proves avif/bmp/heic/tgz are excluded from inlined files

## Safety

- [x] No secrets, auth, or UI changes.
- [x] N/A for UI Evidence.

## UI Evidence

N/A — backend review grounding only.

## Notes

**Conflict avoidance:** Touches only `src/review/review-grounding.ts` and `test/unit/review-grounding.test.ts`. Zero overlap with open PRs (#3381 engine, #3380 enrichment, #3379 selfhost config-lint, #3378 dependency-scan tests, #3314 miner, #3373/#3304 focus-manifest, #3372/#3304 test-evidence, #3305 enrichment-wire, #3361 enrichment). Merges cleanly after any of those land without rebase.

Made with [Cursor](https://cursor.com)