### PR TITLE
fix(settings): close assign and manual-review coverage gaps in agent-actions

### DIFF
--- a/src/settings/agent-actions.ts
+++ b/src/settings/agent-actions.ts
@@ -481,6 +481,24 @@ function reviewNagCloseMessage(authorLogin: string, pingCount: number, maxPings:
 }
 
 /**
+ * Plan best-effort assignment of the PR's opening contributor (#3182), independent of merge/close/CI outcome.
+ * MUST run before the CI-pending settle-before-decide return below (#assign-before-ci-pending) — a PR that has
+ * already been reviewed/evaluated (conclusion isn't "skipped") should get an assignee for triage even while an
+ * unrelated check is still pending; assign has no bearing on mergeability so it never needs CI to settle first.
+ * Gated purely on its own `assign` autonomy class, same as every other independent action here.
+ */
+function maybePlanAssign(actions: PlannedAgentAction[], input: AgentActionPlanInput): void {
+  const level = resolveAutonomy(input.autonomy, "assign");
+  if (!isActingAutonomyLevel(level) || !input.pr.authorLogin) return;
+  actions.push({
+    actionClass: "assign",
+    requiresApproval: autonomyRequiresApproval(level),
+    reason: "auto-assign PR opener",
+    assignee: input.pr.authorLogin,
+  });
+}
+
+/**
  * Plan the maintainer auto-maintain actions for one PR. Returns a COHERENT set (never both approve and
  * request-changes; never both merge and close), each entry already filtered to an acting autonomy class.
  * Ordered least → most irreversible: label, then the review, then the disposition.
@@ -584,6 +602,12 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
   // grace, or eval-not-ready while state is still syncing) is gate-NON-BLOCKING: it flows to the disposition so
   // the PR is merged (clean+green) or HELD with a label — never left silently undecided. (#harm-stop neutral-silent-stuck)
   if (input.conclusion === "skipped") return actions;
+
+  // #assign-before-ci-pending: plan the (best-effort, CI-independent) assignee BEFORE the pending-CI
+  // settle-before-decide return just below — a reviewed/evaluated PR must not sit unassigned while an unrelated
+  // check is still pending. Every deterministic no-review short-circuit above (blacklist/cap/review-nag) already
+  // returned before reaching this line, so none of them are affected.
+  maybePlanAssign(actions, input);
 
   // CI state over ALL of the PR's checks (required OR not — codecov/patch included) — reviewbot's ci_red
   // parity. A red CI is NEVER approved/merged and is itself a close-worthy signal (non-owner). While CI is
@@ -719,6 +743,26 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
     });
   }
 
+  // 1c) migration-collision manual-review fallback (#manual-review-coverage) — the migration-collision LABEL
+  // itself stays gated on review_state_label below (section 2, unchanged) so an operator's dedicated filter on
+  // that specific label is undisturbed. But when review_state_label is OFF (a one-shot repo that only configures
+  // manualReviewLabel), a live migration-collision hold previously suppressed the merge with NO visible label and
+  // NO comment at all — a would-merge PR silently stuck forever, with no signal that a human needs to look or why.
+  // Authorized by `merge` (the class actually suppressing the merge here), mirroring the guardrail-hold label
+  // immediately above. Fires ONLY as a fallback (review_state_label not acting), so it can never duplicate
+  // section 2's own migration-collision label + rebase comment.
+  if (reviewGood && input.migrationCollisionHold !== undefined && !acting("review_state_label") && labels.manualReview !== null && acting("merge") && !hasLabelOrPlanned(input.pr.labels, actions, labels.manualReview)) {
+    actions.push({
+      actionClass: "label",
+      autonomyClass: "merge",
+      requiresApproval: false,
+      reason: `verdict=${conclusion}; ${input.migrationCollisionHold.reason}`,
+      label: labels.manualReview,
+      labelOp: "add",
+      comment: sanitizePublicComment(input.migrationCollisionHold.comment),
+    });
+  }
+
   // 2) review_state_label (#label-scoping) — ready-to-merge (review-good, unguarded) / manual-review
   // (review-good but guarded) / changes-requested (not review-good → will be closed for a contributor, held for
   // the owner). A pending linked-issue hard-rule close (flag OR close pass) forces the changes-requested label
@@ -782,19 +826,6 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
         comment: "✓ The linked-issue hard-rule violation is resolved — this PR is no longer pending closure.",
       });
     }
-  }
-
-  // 2b) assign (#3182) — best-effort: set the PR's own opening contributor as its GitHub assignee, purely for
-  // triage (who is this PR's author, at a glance). Independent of merge/close/CI outcome, exactly like
-  // review_state_label above: gated on its own `assign` class (default OFF), not tied to any other disposition.
-  // Idempotent at the executor (a live GET before the POST), so replanning this every sweep is harmless.
-  if (acting("assign") && input.pr.authorLogin) {
-    actions.push({
-      actionClass: "assign",
-      requiresApproval: approval("assign"),
-      reason: "auto-assign PR opener",
-      assignee: input.pr.authorLogin,
-    });
   }
 
   // 3) review — APPROVE a review-good PR only when it is NOT on a guarded path; a guarded PR falls through to the
@@ -921,7 +952,17 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
     });
   }
   // else: guarded → manual; not-good OWNER/automation → manual; action-required/unverified → manual;
-  // review-good-but-not-yet-mergeable → held briefly (rebase/approve resolves it next pass).
+  // not-good CONTRIBUTOR whose verdict isn't adverse enough to close (e.g. a NEUTRAL gate with green CI and no
+  // conflict) → manual; review-good-but-not-yet-mergeable → held briefly (rebase/approve resolves it next pass).
+  // The CONTRIBUTOR branch (`!willClose`) closes a real reliability gap: previously this checked `!closeEligible`
+  // alone, so a not-review-good CONTRIBUTOR whose conclusion wasn't adverse enough to trip `willClose` (chiefly
+  // `neutral`) fell through with NO action and NO label at all whenever review_state_label was off — silently
+  // contradicting the neutral-verdict "never left silently undecided" invariant above (#harm-stop
+  // neutral-silent-stuck) for exactly the one-shot repos that configure manualReviewLabel without also enabling
+  // review_state_label. Requires `close` actually ACTING (mirroring the label's own `autonomyClass: "close"`
+  // below) so a repo with every relevant class off stays fully quiescent — see "plans nothing when every class is
+  // at a non-acting level". For the owner/admin/automation-bot branch (`!closeEligible`) this is unchanged: those
+  // authors are never close-eligible regardless of the `close` autonomy dial, so the hold must still surface.
   const manualHoldReason =
     guardrailHit
       ? `verdict=${conclusion}; ${guardrailReason}`
@@ -929,7 +970,7 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
         ? "CI could not be verified"
         : conclusion === "action_required"
           ? "review requires maintainer action"
-          : !reviewGood && !closeEligible
+          : !reviewGood && !willClose && (!closeEligible || acting("close"))
             ? `verdict=${conclusion}${ciReason ? `; ${ciReason}` : ""}`
             : null;
   if (

--- a/test/unit/agent-actions.test.ts
+++ b/test/unit/agent-actions.test.ts
@@ -512,6 +512,71 @@ describe("planAgentMaintenanceActions (#778)", () => {
     });
   });
 
+  describe("manual-review coverage for every real hold (#manual-review-coverage)", () => {
+    it("labels a NEUTRAL contributor PR manual-review when it isn't adverse enough to close and review_state_label is OFF", () => {
+      // Deliberately close-only autonomy — review_state_label is left unset (default OFF). Before the fix this
+      // fell through with NO action and NO label at all: not review-good (neutral != success) but also not
+      // adverse enough to trip willClose (no red CI, no conflict, conclusion isn't "failure") — a silently stuck
+      // PR, contradicting the neutral-verdict "never left silently undecided" invariant (#harm-stop
+      // neutral-silent-stuck) for exactly the repos that configure manualReviewLabel without review_state_label.
+      const plan = planAgentMaintenanceActions(input({ conclusion: "neutral", autonomy: { close: "auto" }, ciState: "passed", pr: { labels: [] } }));
+      expect(plan).toEqual([expect.objectContaining({ actionClass: "label", autonomyClass: "close", label: AGENT_LABEL_NEEDS_REVIEW, labelOp: "add" })]);
+    });
+
+    it("still plans nothing for the same NEUTRAL contributor PR when close is not acting (deny-by-default floor)", () => {
+      // Mirrors "plans nothing when every class is at a non-acting level" -- a repo that hasn't opted `close`
+      // into acting must stay fully quiescent; the manual-review fallback must not fire on its own.
+      expect(planAgentMaintenanceActions(input({ conclusion: "neutral", autonomy: {}, ciState: "passed", pr: { labels: [] } }))).toEqual([]);
+    });
+
+    it("does NOT label a CI-pending hold manual-review — pending CI is not a manual-review disposition", () => {
+      expect(planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { close: "auto", review_state_label: "auto", merge: "auto" }, ciState: "pending", pr: { labels: [], mergeableState: "clean" } }))).toEqual([]);
+    });
+
+    it("does NOT relabel a protected owner/admin/bot PR that's already covered by willClose's own guard (unaffected by the neutral-hold change)", () => {
+      // A conclusion of "failure" for a closeEligible contributor already trips willClose (and hence a real
+      // close action), so the manual-review fallback must not ALSO fire on top of it.
+      const plan = classes(planAgentMaintenanceActions(input({ conclusion: "failure", autonomy: { close: "auto" }, blockerTitles: ["x"], pr: { labels: [] } })));
+      expect(plan).toEqual(["close"]);
+    });
+
+    it("migration-collision hold: falls back to manual-review (+ the rebase comment) when review_state_label is OFF", () => {
+      // Before the fix, a migration-collision hold with review_state_label off produced NO action and NO label
+      // at all -- a would-merge PR silently stuck with no visible signal and no explanation posted.
+      const plan = planAgentMaintenanceActions(input({
+        conclusion: "success",
+        autonomy: { merge: "auto" },
+        migrationCollisionHold: { reason: "live migrations/** collision on main", comment: "Please rebase." },
+        pr: { labels: [], mergeableState: "clean" },
+      }));
+      expect(plan).toEqual([
+        expect.objectContaining({ actionClass: "label", autonomyClass: "merge", label: AGENT_LABEL_NEEDS_REVIEW, labelOp: "add", comment: "Please rebase." }),
+      ]);
+    });
+
+    it("migration-collision hold: does NOT duplicate manual-review alongside the dedicated label when review_state_label IS acting", () => {
+      const plan = planAgentMaintenanceActions(input({
+        conclusion: "success",
+        autonomy: { merge: "auto", review_state_label: "auto" },
+        migrationCollisionHold: { reason: "live migrations/** collision on main", comment: "Please rebase." },
+        pr: { labels: [], mergeableState: "clean" },
+      }));
+      expect(plan.filter((a) => a.actionClass === "label")).toHaveLength(1);
+      expect(plan.find((a) => a.actionClass === "label")?.label).toBe(AGENT_LABEL_MIGRATION_COLLISION);
+    });
+
+    it("migration-collision hold: an explicit null manualReviewLabel disables the fallback (respects the operator's own opt-out)", () => {
+      const plan = planAgentMaintenanceActions(input({
+        conclusion: "success",
+        autonomy: { merge: "auto" },
+        manualReviewLabel: null,
+        migrationCollisionHold: { reason: "live migrations/** collision on main", comment: "Please rebase." },
+        pr: { labels: [], mergeableState: "clean" },
+      }));
+      expect(plan).toEqual([]);
+    });
+  });
+
   describe("AI/review blockers remain blocking even when CI is green", () => {
     const merging = { aiCiRefutationEnabled: true, autonomy: { merge: "auto" as const, approve: "auto" as const, close: "auto" as const, review_state_label: "auto" as const }, ciState: "passed" as const, pr: { labels: [], mergeableState: "clean" as const, reviewDecision: "APPROVED" as const } };
 
@@ -950,6 +1015,20 @@ describe("assign — auto-assign PR opener (#3182)", () => {
   it("is independent of merge/close outcome — still plans assign on a failing verdict", () => {
     const plan = planAgentMaintenanceActions(input({ conclusion: "failure", autonomy: { assign: "auto" }, blockerTitles: ["x"], pr: { labels: [], authorLogin: "alice" } }));
     expect(classes(plan)).toContain("assign");
+  });
+
+  it("#assign-before-ci-pending: still plans assign while CI is pending — a reviewed PR must not sit unassigned behind an unrelated stuck check", () => {
+    const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { assign: "auto", approve: "auto", merge: "auto", close: "auto" }, ciState: "pending", pr: { labels: [], mergeableState: "clean", reviewDecision: "APPROVED", authorLogin: "alice" } }));
+    // Settle-before-decide still defers every success-path action...
+    expect(classes(plan)).not.toContain("approve");
+    expect(classes(plan)).not.toContain("merge");
+    // ...but assign, having no bearing on mergeability, fires anyway.
+    expect(plan).toEqual([expect.objectContaining({ actionClass: "assign", assignee: "alice" })]);
+  });
+
+  it("plans nothing while CI is pending for a SKIPPED gate — a genuinely-not-evaluated PR is not yet reviewed", () => {
+    const plan = planAgentMaintenanceActions(input({ conclusion: "skipped", autonomy: { assign: "auto" }, ciState: "pending", pr: { labels: [], authorLogin: "alice" } }));
+    expect(plan).toEqual([]);
   });
 
   it("is unaffected by the blacklist/cap/review-nag short-circuits not reaching this far — plans nothing for a blacklisted contributor even with assign acting", () => {


### PR DESCRIPTION
## Summary

Two reliability gaps in the self-host review automation's disposition planner (`src/settings/agent-actions.ts`), found while auditing `planAgentMaintenanceActions()` against a live deployment where `review_state_label` is disabled and only `manualReviewLabel` is configured:

1. **Assign was skipped whenever CI was still pending.** `assign` was planned *after* the CI-pending settle-before-decide early return, so a reviewed PR got zero actions (including no assignee) until CI settled, even though assignment has no bearing on mergeability. Fixed by extracting `maybePlanAssign()` and calling it right after the "skipped" gate check, before the CI-pending return.
2. **Two hold dispositions produced no label at all when `review_state_label` was off:**
   - A `neutral`-verdict contributor PR that isn't adverse enough to trip a close (no red CI, no conflict) previously fell through with no action and no label, contradicting the "never left silently undecided" invariant.
   - A live migration-collision hold (a would-merge PR suppressed by a rebase-needed migration-number collision) previously depended entirely on `review_state_label` for any visible signal, including the explanatory comment — so a repo running one-shot mode with only `manualReviewLabel` configured would see the PR silently stuck forever.

Both are fixed with the existing `manual-review` label mechanism, authorized by the same autonomy class (`close`/`merge`) that governs the underlying hold, independent of `review_state_label` (which stays optional/advisory, unchanged). No behavior changes for repos with `review_state_label` enabled — verified via new tests asserting no label duplication.

No linked issue — this is a small, self-contained reliability fix to the review-automation planner discovered during a live-config audit, not a user-facing feature change.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` (not run — no workflow files changed)
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — ran the focused suite (`test/unit/agent-actions.test.ts` + `test/unit/agent-action-executor.test.ts`, 321 passed) with `--coverage.include` scoped to the changed file: 100% of new branches covered (336/344 → 346/354; the 8 pre-existing uncovered branches are unrelated linked-issue-hard-rule arms, unchanged by this diff). Also ran the full unsharded suite once to confirm no regressions (8951 passed both before and after; the same 28 unrelated pre-existing failures on both, from a missing `tsx` binary in this fresh worktree).
- [ ] `npm run test:workers` (not run — no `test/workers/**` files touched)
- [ ] `npm run build:mcp` (not run — no MCP package changes)
- [ ] `npm run test:mcp-pack` (not run — no MCP package changes)
- [ ] `npm run ui:openapi:check` (not run — no OpenAPI/route changes)
- [ ] `npm run ui:lint` / `ui:typecheck` / `ui:build` (not run — no UI files touched)
- [ ] `npm audit --audit-level=moderate` (not run — no dependency changes)
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This PR only touches `src/settings/agent-actions.ts` and its unit test; skipped checks above are for subsystems (actionlint, workers, MCP, UI, dependency audit) with zero overlap with the diff. CI will still run and gate the full suite.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session/CORS changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no public API/schema changes.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes.)
- [x] Visible UI changes include a `UI Evidence` section below with screenshots. (N/A — backend-only change, no visible UI.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (N/A — no changelog edit.)

## Notes

- Pure logic + test change; no DB/migration, OpenAPI, or wrangler-binding changes, so no generated artifacts needed regeneration.