### PR TITLE
test(enrichment): cover churn-hotspot empty-list and threshold boundaries

### DIFF
--- a/review-enrichment/test/churn-hotspot.test.ts
+++ b/review-enrichment/test/churn-hotspot.test.ts
@@ -37,6 +37,18 @@ test("summarizeChurn + isHotspot: counts, fraction, and thresholds", () => {
   assert.equal(isHotspot({ commitCount: 20, fixFraction: 0.1 }), false); // too few fixes
 });
 
+test("summarizeChurn: an empty commit list is zero churn with no divide-by-zero", () => {
+  // The `commitCount ? fixCount / commitCount : 0` guard's else branch — fixFraction must be 0, not NaN.
+  assert.deepEqual(summarizeChurn([]), { commitCount: 0, fixCount: 0, fixFraction: 0 });
+});
+
+test("isHotspot: the `>=` thresholds are inclusive at the exact boundary (commits 8, fixFraction 0.3)", () => {
+  // Exactly at both thresholds → a hotspot (inclusive `>=`); one step below either → not.
+  assert.equal(isHotspot({ commitCount: 8, fixFraction: 0.3 }), true);
+  assert.equal(isHotspot({ commitCount: 7, fixFraction: 0.3 }), false); // one commit below the floor
+  assert.equal(isHotspot({ commitCount: 8, fixFraction: 0.29 }), false); // just under the fix-fraction floor
+});
+
 test("scanChurnHotspot: flags a high-churn, high-fix file", async () => {
   const findings = await scanChurnHotspot(req([{ path: "src/a.ts" }]), async () => jsonResponse(commits(12, 2)));
   assert.equal(findings.length, 1);


### PR DESCRIPTION
## Summary

Hardens unit coverage for the `churn-hotspot` analyzer's pure helpers with two edge cases the existing threshold test doesn't exercise:

- **`summarizeChurn([])`** — an empty commit list must be zero churn (`fixFraction: 0`), exercising the `commitCount ? fixCount / commitCount : 0` divide-by-zero guard's else branch (the existing test only feeds 10 commits).
- **`isHotspot` at the exact `>=` thresholds** — `{commitCount: 8, fixFraction: 0.3}` is inclusive (a hotspot), while one step below either floor (`7` commits, or `0.29` fix-fraction) is not. The existing test only checks values well above/below, not the boundary.

Test-only, against the compiled `dist/`, in the analyzer's own test file. No source or shared-registry change; the pure helpers are already imported by this file, so no new import surface.

_No linked issue — straightforward boundary/edge coverage hardening of pure functions; changes no runtime behavior._

## Scope
- [x] Conventional Commit; focused; touches only `review-enrichment/test/churn-hotspot.test.ts`. No `site/`/`CNAME`/`**/lovable/**`; no `CHANGELOG.md`.

## Validation
- [x] `npm --prefix review-enrichment test` — **966 pass / 0 fail** (build + sourcemap validate + `metadata --check` + node tests; exactly CI).
- [x] `git diff --check` clean.

## Safety
- [x] Test-only, no runtime change. No secrets/wallets/hotkeys/trust/reward terms.
