### PR TITLE
feat(engine): add countPlanStepsByStatus

### DIFF
--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -119,6 +119,7 @@ export {
   type NormalizedGovernorLedgerEvent,
 } from "./governor-ledger.js";
 export * from "./plan-export.js";
+export { countPlanStepsByStatus } from "./plan-step-stats.js";
 export * from "./plan-templates.js";
 export * from "./portfolio/queue.js";
 export {

--- a/packages/gittensory-engine/src/plan-step-stats.ts
+++ b/packages/gittensory-engine/src/plan-step-stats.ts
@@ -1,0 +1,8 @@
+import type { PlanDag, PlanStepStatus } from "./plan-export.js";
+
+/**
+ * Count plan steps matching a given status. Pure — reads the plan DAG only.
+ */
+export function countPlanStepsByStatus(plan: PlanDag, status: PlanStepStatus): number {
+  return plan.steps.filter((step) => step.status === status).length;
+}

--- a/test/unit/plan-step-stats.test.ts
+++ b/test/unit/plan-step-stats.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { countPlanStepsByStatus } from "../../packages/gittensory-engine/src/plan-step-stats";
+import type { PlanStep } from "../../packages/gittensory-engine/src/plan-export";
+
+function step(over: Partial<PlanStep> & { id: string; title: string }): PlanStep {
+  return {
+    actionClass: undefined,
+    dependsOn: [],
+    status: "pending",
+    attempts: 0,
+    maxAttempts: 3,
+    lastError: null,
+    ...over,
+  };
+}
+
+describe("countPlanStepsByStatus", () => {
+  it("returns zero for an empty plan", () => {
+    expect(countPlanStepsByStatus({ steps: [] }, "pending")).toBe(0);
+  });
+
+  it("counts only steps that match the requested status", () => {
+    const plan = {
+      steps: [
+        step({ id: "a", title: "Build", status: "completed" }),
+        step({ id: "b", title: "Test", status: "pending" }),
+        step({ id: "c", title: "Deploy", status: "pending" }),
+        step({ id: "d", title: "Verify", status: "failed" }),
+      ],
+    };
+    expect(countPlanStepsByStatus(plan, "pending")).toBe(2);
+    expect(countPlanStepsByStatus(plan, "completed")).toBe(1);
+    expect(countPlanStepsByStatus(plan, "failed")).toBe(1);
+    expect(countPlanStepsByStatus(plan, "running")).toBe(0);
+  });
+
+  it("is exported from the package barrel", async () => {
+    const barrel = await import("../../packages/gittensory-engine/src/index");
+    expect(typeof barrel.countPlanStepsByStatus).toBe("function");
+    expect(
+      barrel.countPlanStepsByStatus(
+        { steps: [step({ id: "a", title: "A", status: "skipped" })] },
+        "skipped",
+      ),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `countPlanStepsByStatus` in `@jsonbored/gittensory-engine` — counts plan DAG steps matching a given status.
- Pure helper alongside `plan-export` for miner and dashboard progress summaries.
- Vitest coverage at 100% patch on the new helper.

## Test plan
- [x] `COVERAGE_NO_THRESHOLDS=1 npx vitest run test/unit/plan-step-stats.test.ts --coverage`
- [x] `npx diff-cover coverage/lcov.info --compare-branch=main --fail-under=99` → 100%
- [x] `npm run build --workspace @jsonbored/gittensory-engine && npm run build:miner`


Made with [Cursor](https://cursor.com)