### PR TITLE
test(enrichment): cover redos `{n,}` quantifier and escape branches

### DIFF
--- a/review-enrichment/test/redos.test.ts
+++ b/review-enrichment/test/redos.test.ts
@@ -38,6 +38,19 @@ test("hasCatastrophicBacktracking flags a nested unbounded quantifier and spares
   }
 });
 
+test("hasCatastrophicBacktracking handles the `{n,}` unbounded quantifier, not just `+`/`*`", () => {
+  // An open-ended `{2,}` inside a quantified group is catastrophic; a BOUNDED `{2,3}` is not.
+  assert.equal(hasCatastrophicBacktracking("(a{2,})+"), true);
+  assert.equal(hasCatastrophicBacktracking("(a{2,3})+"), false);
+});
+
+test("hasCatastrophicBacktracking treats escaped parens/quantifiers as literals, not structure", () => {
+  // `\(` / `\)` are escaped literals, not a real group — no catastrophic nesting exists here.
+  assert.equal(hasCatastrophicBacktracking("\\(a+\\)+"), false);
+  // A group whose inner `\+` is an escaped literal plus (not a quantifier) is linear.
+  assert.equal(hasCatastrophicBacktracking("(a\\+)+"), false);
+});
+
 test("scanPatchForRedos cites the added-line number of a catastrophic literal", () => {
   const patch = [
     "@@ -1,2 +1,3 @@",


### PR DESCRIPTION
## Summary

Hardens unit coverage for the `redos` analyzer's `hasCatastrophicBacktracking` state machine, whose single existing test only uses `+`/`*` quantifiers and never exercises two real branches:

- **The `{n,}` unbounded-quantifier branch** (`unboundedQuantifierAt`'s `{` case): `(a{2,})+` is catastrophic (open-ended `{2,}` inside a quantified group), while a **bounded** `(a{2,3})+` is not.
- **Escape (`\\`) handling**: `\(a+\)+` has escaped parens — no real group, so not catastrophic; and `(a\+)+`'s inner `\+` is an escaped literal, not a quantifier, so it's linear.

Test-only, against the compiled `dist/`, in the analyzer's own test file. No source or shared-registry change.

_No linked issue — edge/branch coverage hardening of a pure function; no runtime behavior change._

## Scope
- [x] Conventional Commit; focused; touches only `review-enrichment/test/redos.test.ts`. No `site/`/`CNAME`/`**/lovable/**`; no `CHANGELOG.md`.

## Validation
- [x] `npm --prefix review-enrichment test` — **970 pass / 0 fail** (build + sourcemap validate + `metadata --check` + node tests; exactly CI). The 4 new assertions were traced against the state machine and confirmed.
- [x] `git diff --check` clean.

## Safety
- [x] Test-only, no runtime change. No secrets/wallets/hotkeys/trust/reward terms.
