### PR TITLE
feat(engine): add isPlanFullyCompleted

### DIFF
--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -120,6 +120,7 @@ export {
 } from "./governor-ledger.js";
 export * from "./plan-export.js";
 export { countPlanStepsByStatus } from "./plan-step-stats.js";
+export { isPlanFullyCompleted } from "./plan-completion.js";
 export * from "./plan-templates.js";
 export * from "./portfolio/queue.js";
 export {

--- a/packages/gittensory-engine/src/plan-completion.ts
+++ b/packages/gittensory-engine/src/plan-completion.ts
@@ -1,0 +1,9 @@
+import type { PlanDag } from "./plan-export.js";
+
+/**
+ * Return whether every step in the plan is completed. Empty plans are not considered complete.
+ * Pure — reads the plan DAG only.
+ */
+export function isPlanFullyCompleted(plan: PlanDag): boolean {
+  return plan.steps.length > 0 && plan.steps.every((step) => step.status === "completed");
+}

--- a/test/unit/plan-completion.test.ts
+++ b/test/unit/plan-completion.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+
+import { isPlanFullyCompleted } from "../../packages/gittensory-engine/src/plan-completion";
+import type { PlanStep } from "../../packages/gittensory-engine/src/plan-export";
+
+function step(over: Partial<PlanStep> & { id: string; title: string }): PlanStep {
+  return {
+    actionClass: undefined,
+    dependsOn: [],
+    status: "pending",
+    attempts: 0,
+    maxAttempts: 3,
+    lastError: null,
+    ...over,
+  };
+}
+
+describe("isPlanFullyCompleted", () => {
+  it("returns false for an empty plan", () => {
+    expect(isPlanFullyCompleted({ steps: [] })).toBe(false);
+  });
+
+  it("returns true when every step is completed", () => {
+    expect(
+      isPlanFullyCompleted({
+        steps: [
+          step({ id: "a", title: "Build", status: "completed" }),
+          step({ id: "b", title: "Test", status: "completed" }),
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false when any step is not completed", () => {
+    expect(
+      isPlanFullyCompleted({
+        steps: [
+          step({ id: "a", title: "Build", status: "completed" }),
+          step({ id: "b", title: "Test", status: "pending" }),
+        ],
+      }),
+    ).toBe(false);
+    expect(
+      isPlanFullyCompleted({
+        steps: [step({ id: "a", title: "Deploy", status: "failed" })],
+      }),
+    ).toBe(false);
+  });
+
+  it("is exported from the package barrel", async () => {
+    const barrel = await import("../../packages/gittensory-engine/src/index");
+    expect(typeof barrel.isPlanFullyCompleted).toBe("function");
+    expect(
+      barrel.isPlanFullyCompleted({
+        steps: [step({ id: "a", title: "A", status: "completed" })],
+      }),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `isPlanFullyCompleted` in `@jsonbored/gittensory-engine` — returns whether every step in a plan DAG is completed (empty plans are not complete).
- Pure helper alongside `plan-export` and `countPlanStepsByStatus` for miner and dashboard completion checks.
- Vitest coverage at 100% patch on the new helper.

## Test plan
- [x] `COVERAGE_NO_THRESHOLDS=1 npx vitest run test/unit/plan-completion.test.ts --coverage`
- [x] `npx diff-cover coverage/lcov.info --compare-branch=main --fail-under=99` → 100%
- [x] `npm run build --workspace @jsonbored/gittensory-engine && npm run build:miner`


Made with [Cursor](https://cursor.com)