### PR TITLE
feat(signals): recognize Dart's *_test.dart test convention

### DIFF
--- a/src/signals/test-evidence.ts
+++ b/src/signals/test-evidence.ts
@@ -2,7 +2,7 @@ export function isTestPath(file: string): boolean {
   return (
     /(^|\/)(test|tests|spec|__tests__)\//i.test(file) ||
     /(^|\/)src\/test\//i.test(file) ||
-    /(^|\/)[^/]+_test\.(go|py|rb)$/i.test(file) ||
+    /(^|\/)[^/]+_test\.(go|py|rb|dart)$/i.test(file) || // Dart/Flutter's `*_test.dart` (dart test / flutter test), the analogue of Go's `_test.go`
     /(^|\/)test_[^/]*\.py$/i.test(file) || // pytest's default `test_*.py` prefix convention (the suffix rule above only catches `*_test.py`)
     /(^|\/)[^/]+_spec\.rb$/i.test(file) ||
     /\.(test|spec)\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs)$/i.test(file) ||

--- a/test/unit/test-evidence.test.ts
+++ b/test/unit/test-evidence.test.ts
@@ -4,6 +4,7 @@ import { classifyTestCoverage, hasLocalTestEvidence, isTestPath } from "../../sr
 describe("test evidence helpers", () => {
   it("detects common test path conventions", () => {
     expect(isTestPath("pkg/foo_test.go")).toBe(true);
+    expect(isTestPath("lib/widget_test.dart")).toBe(true); // Dart/Flutter *_test.dart
     expect(isTestPath("spec/models/widget_spec.rb")).toBe(true);
     expect(isTestPath("src/test/helpers.ts")).toBe(true);
     expect(isTestPath("tests/integration/api.test.ts")).toBe(true);


### PR DESCRIPTION
isTestPath detected _test.go/_test.py/_test.rb but not Dart/Flutter's canonical *_test.dart (discovered by `dart test`/`flutter test`), the direct analogue of Go's _test.go on the same line. Add `dart` to that suffix alternation so a PR's Dart tests count as local test evidence.

Safe re: the code/test parity concern that recently closed another PR: .dart is not in isCodeFile, so nothing flips code<->test — main.dart stays unclassified and only *_test.dart becomes a test. Extends the isTestPath unit test. tsc + tests green.