### PR TITLE
feat(review): treat Azure App Service + Fly.io as multi-tenant suffixes

### DIFF
--- a/src/review/content-lane/registry-logic.ts
+++ b/src/review/content-lane/registry-logic.ts
@@ -200,6 +200,10 @@ const MULTI_TENANT_SUFFIXES = [
   "firebaseapp.com",
   "readthedocs.io",
   "gitbook.io",
+  // More multi-tenant PaaS hosts where each subdomain is a different party (peers of
+  // herokuapp.com/onrender.com): Azure App Service and Fly.io.
+  "azurewebsites.net",
+  "fly.dev",
 ];
 
 /** Heuristic registrable domain (eTLD+1 ≈ last two labels, with known multi-tenant suffixes kept one

--- a/test/unit/content-lane-registry-logic.test.ts
+++ b/test/unit/content-lane-registry-logic.test.ts
@@ -677,6 +677,10 @@ describe("registry-logic branch coverage (gap-filling)", () => {
   it("registrableDomain takes the deepest tenant label under a multi-tenant suffix", () => {
     // tenant is the LAST label before the suffix (a.b.github.io → b.github.io).
     expect(registrableDomain("https://a.b.github.io/x")).toBe("b.github.io");
+    // Azure App Service + Fly.io are multi-tenant too: distinct tenants must not
+    // collapse to the bare suffix (else two unrelated apps satisfy the same claim).
+    expect(registrableDomain("https://alice.azurewebsites.net/x")).toBe("alice.azurewebsites.net");
+    expect(registrableDomain("https://bob.fly.dev/")).toBe("bob.fly.dev");
   });
   it("registrableDomain returns a two-label apex directly (parts.length <= 2 branch)", () => {
     expect(registrableDomain("https://example.com")).toBe("example.com");


### PR DESCRIPTION
MULTI_TENANT_SUFFIXES keeps a tenant label deep for github.io/herokuapp.com/etc. so distinct tenants don't collapse to a shared registrable domain, but omitted `azurewebsites.net` (Azure App Service) and `fly.dev` (Fly.io). Without them, alice.azurewebsites.net and bob.azurewebsites.net both reduce to the bare suffix, letting two unrelated parties falsely satisfy the same host claim in hostMatchesClaim. Adds both (peers of herokuapp.com/onrender.com) + extends the registrableDomain multi-tenant test. tsc + tests green.