### PR TITLE
feat(enrichment): analyze .mts/.cts files for doc-comment drift

### DIFF
--- a/review-enrichment/src/analyzers/doc-comment-drift.ts
+++ b/review-enrichment/src/analyzers/doc-comment-drift.ts
@@ -11,7 +11,7 @@ const MAX_FILES = 20;
 const MAX_FINDINGS = 50;
 const MAX_SIGNATURE_LINES = 40;
 const MAX_FETCH_BYTES = 1_000_000;
-const SOURCE_RE = /\.(?:ts|tsx|js|jsx|mjs|cjs)$/;
+const SOURCE_RE = /\.(?:ts|tsx|mts|cts|js|jsx|mjs|cjs)$/;
 const SKIP_RE = /(?:\.d\.ts$|\.min\.|\.test\.|\.spec\.|__tests__\/|(?:^|\/)tests?\/)/;
 const SLUG_RE = /^[A-Za-z0-9._-]+$/;
 // Matches a named `function` declaration up to its parameter `(`. A single, non-nested generic clause is allowed;

--- a/review-enrichment/test/doc-comment-drift.test.ts
+++ b/review-enrichment/test/doc-comment-drift.test.ts
@@ -234,6 +234,17 @@ test("scanDocCommentDrift: fetches the file at headSha and reports drift", async
   assert.deepEqual(findings[0].staleParams, ["oldName"]);
 });
 
+test("scanDocCommentDrift: analyzes TypeScript .mts/.cts module files too", async () => {
+  // SOURCE_RE includes the .mjs/.cjs siblings, so their TypeScript counterparts must
+  // be scanned as well or drift in .mts/.cts files is silently missed.
+  for (const path of ["src/a.mts", "src/a.cts"]) {
+    const findings = await scanDocCommentDrift(baseReq([{ path, patch: DRIFT_PATCH }]), fileWith(DRIFTED));
+    assert.equal(findings.length, 1);
+    assert.equal(findings[0].file, path);
+    assert.deepEqual(findings[0].staleParams, ["oldName"]);
+  }
+});
+
 test("scanDocCommentDrift: skips oversized file responses before reading the body", async () => {
   let bodyAccessed = false;
   const out = await scanDocCommentDrift(


### PR DESCRIPTION
doc-comment-drift's SOURCE_RE gated on ts/tsx/js/jsx/mjs/cjs but omitted the TypeScript module extensions .mts/.cts, even though it already includes their JavaScript siblings .mjs/.cjs. So JSDoc/TSDoc @param drift in .mts/.cts files was never analyzed despite FUNC_DECL_RE parsing their signatures fine (the sibling undocumented-export analyzer already scans .mts/.cts). Adds both to SOURCE_RE + extends the drift test. rees build + node:test green (533).