### PR TITLE
feat(enrichment): flag EOL Postgres/MySQL/Redis/MariaDB/Mongo base images

### DIFF
--- a/review-enrichment/src/analyzers/eol-check.ts
+++ b/review-enrichment/src/analyzers/eol-check.ts
@@ -19,6 +19,15 @@ const DOCKER_PRODUCT: Record<string, string> = {
   debian: "debian",
   ubuntu: "ubuntu",
   alpine: "alpine",
+  // Common database/cache base images with real endoflife.date calendars. The
+  // official image name differs from the endoflife.date slug for postgres/mongo,
+  // so these are genuine mappings (not just new keys) needed to flag an EOL
+  // `FROM postgres:14` / `FROM mongo:5` base image.
+  postgres: "postgresql",
+  mysql: "mysql",
+  mariadb: "mariadb",
+  redis: "redis",
+  mongo: "mongodb",
 };
 
 interface VersionPin {

--- a/review-enrichment/test/eol-check.test.ts
+++ b/review-enrichment/test/eol-check.test.ts
@@ -1,0 +1,32 @@
+// Units for the EOL-check analyzer's Dockerfile FROM version-pin extraction. Own file (not
+// enrichment.test.ts) so concurrent analyzer PRs don't collide. Runs against the compiled dist/.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { extractVersionPins } from "../dist/analyzers/eol-check.js";
+
+const dockerfile = (from: string) => ({
+  path: "Dockerfile",
+  patch: `@@ -1,1 +1,2 @@\n FROM builder AS base\n+${from}`,
+});
+
+test("extractVersionPins: maps database/cache base images to their endoflife.date slugs", () => {
+  // The official image name differs from the endoflife.date slug for postgres (postgresql)
+  // and mongo (mongodb), so these are genuine mappings, not just new keys.
+  const cases: Array<[string, string, string]> = [
+    ["FROM postgres:14", "postgresql", "14"],
+    ["FROM mysql:8.0", "mysql", "8.0"],
+    ["FROM mariadb:11", "mariadb", "11"],
+    ["FROM redis:7", "redis", "7"],
+    ["FROM mongo:5", "mongodb", "5"],
+  ];
+  for (const [from, product, version] of cases) {
+    const pins = extractVersionPins([dockerfile(from)]);
+    const pin = pins.find((p) => p.product === product);
+    assert.ok(pin, `expected a ${product} pin from "${from}"`);
+    assert.equal(pin!.version, version);
+  }
+});
+
+test("extractVersionPins: still ignores an unknown base image", () => {
+  assert.deepEqual(extractVersionPins([dockerfile("FROM totallyunknownimage:1.2")]), []);
+});


### PR DESCRIPTION
DOCKER_PRODUCT mapped node/python/golang/ruby/php + OS bases to their endoflife.date slugs but omitted the common database/cache base images, so a `FROM postgres:14`/`mongo:5` pin was dropped and an end-of-life DB base image was never flagged. Adds postgres->postgresql, mongo->mongodb (image name differs from the endoflife.date slug, so genuine mappings) plus mysql, mariadb, redis. Adds a dedicated eol-check test (own file so concurrent analyzer PRs don't collide) covering each mapping + the unknown-image no-op. rees green (533).