### PR TITLE
feat(enrichment): scan Terraform .tfvars and HCL files for IaC misconfig

### DIFF
--- a/review-enrichment/src/analyzers/iac-misconfig.ts
+++ b/review-enrichment/src/analyzers/iac-misconfig.ts
@@ -4,7 +4,7 @@ const MAX_FINDINGS = 25;
 const MAX_LINE_CHARS = 2000;
 
 const CONFIG_PATH_RE =
-  /(?:^|\/)(?:docker-compose[^/]*\.ya?ml|compose[^/]*\.ya?ml|values(?:\.[^/]+)?\.ya?ml|.*\.(?:tf|ya?ml|json|toml|ini|conf|env)|Dockerfile(?:\.[^/]+)?|nginx[^/]*\.conf)$/i;
+  /(?:^|\/)(?:docker-compose[^/]*\.ya?ml|compose[^/]*\.ya?ml|values(?:\.[^/]+)?\.ya?ml|.*\.(?:tf|tfvars|hcl|ya?ml|json|toml|ini|conf|env)|Dockerfile(?:\.[^/]+)?|nginx[^/]*\.conf)$/i;
 
 const CORS_ORIGIN_RE =
   /\b(?:access-control-allow-origin|allow_origin|cors_origin|origin)\b[\s"'=:,\[\]-]*\*/i;

--- a/review-enrichment/test/iac-misconfig.test.ts
+++ b/review-enrichment/test/iac-misconfig.test.ts
@@ -1,7 +1,17 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { scanPatchForIacMisconfig } from "../dist/analyzers/iac-misconfig.js";
+import { isRelevantConfigPath, scanPatchForIacMisconfig } from "../dist/analyzers/iac-misconfig.js";
+
+test("isRelevantConfigPath recognizes Terraform .tfvars and HCL files (siblings of .tf)", () => {
+  // `.tf` was already scanned; `.tfvars` and `.hcl` end after `tf`, so the extension
+  // group missed them and scanIacMisconfig skipped these canonical IaC files entirely.
+  assert.ok(isRelevantConfigPath("infra/terraform.tfvars"));
+  assert.ok(isRelevantConfigPath("env/prod.auto.tfvars"));
+  assert.ok(isRelevantConfigPath("packer/build.pkr.hcl"));
+  assert.ok(isRelevantConfigPath("infra/main.tf")); // the pre-existing sibling still matches
+  assert.equal(isRelevantConfigPath("src/app.ts"), false); // a non-config source file does not
+});
 
 test("scanPatchForIacMisconfig flags hostNetwork and compose host network mode", () => {
   const k8s = scanPatchForIacMisconfig(


### PR DESCRIPTION
CONFIG_PATH_RE already scanned .tf, but its extension group is end-anchored so .tfvars (terraform.tfvars / *.auto.tfvars) and .hcl (Packer/Nomad/Consul/Terraform) files ended after `tf` and never matched — scanIacMisconfig skipped these canonical IaC files entirely, so their CORS/TLS/open-ingress checks never ran. Adds tfvars + hcl to the group + extends the test with isRelevantConfigPath assertions. rees green (532).