### PR TITLE
test(enrichment): cover extractFunctionParams multi-line and TS param shapes

### DIFF
--- a/review-enrichment/test/doc-comment-drift.test.ts
+++ b/review-enrichment/test/doc-comment-drift.test.ts
@@ -45,6 +45,26 @@ test("extractFunctionParams: excludes a name declared more than once (overload/d
   assert.deepEqual([...map.get("other")], ["z"]);
 });
 
+test("extractFunctionParams: extracts params from a multi-line signature", () => {
+  const map = extractFunctionParams("function foo(\n  a,\n  b\n) {}\n");
+  assert.deepEqual([...map.get("foo")], ["a", "b"]);
+});
+
+test("extractFunctionParams: a rest parameter keeps its name without the `...` marker", () => {
+  const map = extractFunctionParams("function bar(...rest) {}\n");
+  assert.deepEqual([...map.get("bar")], ["rest"]);
+});
+
+test("extractFunctionParams: strips a TS type annotation and a default value from each name", () => {
+  const map = extractFunctionParams("function baz(a: string, b = 5): void {}\n");
+  assert.deepEqual([...map.get("baz")], ["a", "b"]);
+});
+
+test("extractFunctionParams: skips a TS `this` pseudo-parameter, keeping the real args", () => {
+  const map = extractFunctionParams("function qux(this: T, a) {}\n");
+  assert.deepEqual([...map.get("qux")], ["a"]);
+});
+
 test("reconstructOldContent: bails (null) when the patch context does not match the head content", () => {
   // The context line ` other` doesn't exist in newContent → misaligned patch → fail closed.
   assert.equal(reconstructOldContent(`a\nb\n`, `@@ -1,2 +1,2 @@\n-x\n+a\n other`), null);


### PR DESCRIPTION
## Summary

Hardens unit coverage for the `doc-comment-drift` analyzer's pure `extractFunctionParams` helper. Its two existing tests only feed single-line signatures, leaving several real branches uncovered — this adds four:

- a **multi-line signature** (exercises `extractParamSource`'s line-walking) → params still extracted
- a **rest parameter** (`...rest`) → the `...` marker is stripped, the name kept
- **TS type annotations and default values** (`a: string, b = 5`) → stripped down to the plain names
- a **TS `this` pseudo-parameter** → skipped, keeping the real args

Test-only, against the compiled `dist/`, in the analyzer's own test file. No source or shared-registry change.

_No linked issue — branch-coverage hardening of a pure function; no runtime behavior change._

## Scope
- [x] Conventional Commit; focused; touches only `review-enrichment/test/doc-comment-drift.test.ts`. No `site/`/`CNAME`/`**/lovable/**`; no `CHANGELOG.md`.

## Validation
- [x] `npm --prefix review-enrichment test` — full suite green (build + sourcemap validate + `metadata --check` + node tests; exactly CI). Each new assertion was traced against `extractParamSource`/`parseFunctionParams` and confirmed.
- [x] `git diff --check` clean.

## Safety
- [x] Test-only, no runtime change. No secrets/wallets/hotkeys/trust/reward terms.
