### PR TITLE
feat(engine): add hasPlanFailedSteps

### DIFF
--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -121,6 +121,7 @@ export {
 export * from "./plan-export.js";
 export { countPlanStepsByStatus } from "./plan-step-stats.js";
 export { isPlanFullyCompleted } from "./plan-completion.js";
+export { hasPlanFailedSteps } from "./plan-failure.js";
 export * from "./plan-templates.js";
 export * from "./portfolio/queue.js";
 export {

--- a/packages/gittensory-engine/src/plan-failure.ts
+++ b/packages/gittensory-engine/src/plan-failure.ts
@@ -1,0 +1,8 @@
+import type { PlanDag } from "./plan-export.js";
+
+/**
+ * Return whether any step in the plan has failed. Pure — reads the plan DAG only.
+ */
+export function hasPlanFailedSteps(plan: PlanDag): boolean {
+  return plan.steps.some((step) => step.status === "failed");
+}

--- a/test/unit/plan-failure.test.ts
+++ b/test/unit/plan-failure.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { hasPlanFailedSteps } from "../../packages/gittensory-engine/src/plan-failure";
+import type { PlanStep } from "../../packages/gittensory-engine/src/plan-export";
+
+function step(over: Partial<PlanStep> & { id: string; title: string }): PlanStep {
+  return {
+    actionClass: undefined,
+    dependsOn: [],
+    status: "pending",
+    attempts: 0,
+    maxAttempts: 3,
+    lastError: null,
+    ...over,
+  };
+}
+
+describe("hasPlanFailedSteps", () => {
+  it("returns false for an empty plan", () => {
+    expect(hasPlanFailedSteps({ steps: [] })).toBe(false);
+  });
+
+  it("returns false when no step has failed", () => {
+    expect(
+      hasPlanFailedSteps({
+        steps: [
+          step({ id: "a", title: "Build", status: "completed" }),
+          step({ id: "b", title: "Test", status: "pending" }),
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true when at least one step has failed", () => {
+    expect(
+      hasPlanFailedSteps({
+        steps: [
+          step({ id: "a", title: "Build", status: "completed" }),
+          step({ id: "b", title: "Deploy", status: "failed" }),
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("is exported from the package barrel", async () => {
+    const barrel = await import("../../packages/gittensory-engine/src/index");
+    expect(typeof barrel.hasPlanFailedSteps).toBe("function");
+    expect(
+      barrel.hasPlanFailedSteps({
+        steps: [step({ id: "a", title: "A", status: "failed" })],
+      }),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `hasPlanFailedSteps` in `@jsonbored/gittensory-engine` — returns whether any step in a plan DAG has failed.
- Pure helper alongside `isPlanFullyCompleted` and `countPlanStepsByStatus` for miner and dashboard status checks.
- Vitest coverage at 100% patch on the new helper.

## Test plan
- [x] `COVERAGE_NO_THRESHOLDS=1 npx vitest run test/unit/plan-failure.test.ts --coverage`
- [x] `npx diff-cover coverage/lcov.info --compare-branch=main --fail-under=99` → 100%
- [x] `npm run build --workspace @jsonbored/gittensory-engine && npm run build:miner`


Made with [Cursor](https://cursor.com)