### PR TITLE
test(enrichment): cover requirementTokens dedup, stopword, and alnum branches

### DIFF
--- a/review-enrichment/test/history.test.ts
+++ b/review-enrichment/test/history.test.ts
@@ -322,6 +322,20 @@ test("requirementTokens drops short words and stopwords", () => {
   ]);
 });
 
+test("requirementTokens deduplicates case-insensitively", () => {
+  // Repeated words (any case) collapse to one token — the existing test has no repeats.
+  assert.deepEqual(requirementTokens("Cache cache CACHE storage"), ["cache", "storage"]);
+});
+
+test("requirementTokens drops a long-enough stopword via the stopword set, not the length floor", () => {
+  // `feature`/`should`/`support` are >= the 4-char floor, so they're dropped by the stopword check itself.
+  assert.deepEqual(requirementTokens("this feature should support caching"), ["caching"]);
+});
+
+test("requirementTokens keeps alphanumeric tokens and splits on punctuation", () => {
+  assert.deepEqual(requirementTokens("oauth2 retry-loop"), ["oauth2", "retry", "loop"]);
+});
+
 test("classifyCoverage thresholds", () => {
   assert.equal(classifyCoverage("history analyzer enrichment", "history analyzer enrichment"), "full");
   assert.equal(classifyCoverage("history analyzer enrichment", "history only"), "partial");


### PR DESCRIPTION
## Summary

Hardens unit coverage for the `history` analyzer's pure `requirementTokens` tokenizer. Its single existing test only exercises **length-based** drops (its dropped words are all under the 4-char floor), leaving three branches uncovered:

- **case-insensitive deduplication** — repeated words (any case) collapse to one token
- **the stopword set** — a word at/above the length floor (e.g. `feature`/`should`/`support`) is dropped by the stopword check itself, not the length floor
- **alphanumeric tokens + punctuation splitting** — digits are kept within a token; `/`, `-`, `.`, space are split points

Test-only, against the compiled `dist/`, in the analyzer's own test file. No source or shared-registry change.

_No linked issue — branch-coverage hardening of a pure function; no runtime behavior change._

## Scope
- [x] Conventional Commit; focused; touches only `review-enrichment/test/history.test.ts`. No `site/`/`CNAME`/`**/lovable/**`; no `CHANGELOG.md`.

## Validation
- [x] `npm --prefix review-enrichment test` — full suite green (build + sourcemap validate + `metadata --check` + node tests; exactly CI).
- [x] `git diff --check` clean.

## Safety
- [x] Test-only, no runtime change. No secrets/wallets/hotkeys/trust/reward terms.
