### PR TITLE
feat(enrichment): flag skipped or narrowed tests padding the test-ratio signal

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,23 +67,24 @@ GITTENSORY_REVIEW_ENRICHMENT=false
 # provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild
 # history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity,ciCheckSignals
 # undocumentedExport,staleBranch,commitHygiene,pendingReviewRequests,testRatio,migrationSafety
-# looseRange,terminology,todoMarker,magicNumber,conflictMarker,commitLint
+# looseRange,terminology,todoMarker,magicNumber,conflictMarker,commitLint,testSkipGaming
 #
 # Profile defaults:
 # fast: dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol
 # redos,provenance,secretLog,typosquat,iacMisconfig,nativeBuild,testRatio,migrationSafety
-# looseRange,terminology,todoMarker,magicNumber,conflictMarker
+# looseRange,terminology,todoMarker,magicNumber,conflictMarker,testSkipGaming
 # balanced (default): dependency,lockfileDrift,secret,license,installScript,heavyDependency
 # actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature
 # iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink
 # approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene
 # pendingReviewRequests,testRatio,migrationSafety,looseRange,terminology,todoMarker,magicNumber
-# conflictMarker,commitLint
+# conflictMarker,commitLint,testSkipGaming
 # deep: dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol
 # redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig
 # nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity
 # ciCheckSignals,undocumentedExport,staleBranch,commitHygiene,pendingReviewRequests,testRatio
 # migrationSafety,looseRange,terminology,todoMarker,magicNumber,conflictMarker,commitLint
+# testSkipGaming
 # END GENERATED REES ANALYZERS
 
 # Submitter-reputation spend control (internal-only): downgrades new/burst/low-rep

--- a/apps/gittensory-ui/src/lib/rees-analyzers.ts
+++ b/apps/gittensory-ui/src/lib/rees-analyzers.ts
@@ -909,6 +909,29 @@ export const REES_ANALYZERS = [
         "Structured-fields-only: reads commit.message subjects, linted independently, never cross-line state. Fail-safe on missing token/fetch error.",
     },
   },
+  {
+    name: "testSkipGaming",
+    title: "Test-skip gaming",
+    category: "quality",
+    cost: "local",
+    defaultEnabled: true,
+    profiles: ["fast", "balanced", "deep"],
+    requires: ["files"],
+    limits: {
+      maxFindings: 25,
+      maxLineChars: 2000,
+    },
+    docs: {
+      summary:
+        "Flags newly-added test skip/disable/narrowing markers and CI workflow steps that newly stop being able to fail the build.",
+      looksAt:
+        "Added lines in changed test files (skip/only markers) and .github/workflows/*.yml files (continue-on-error / literal if: false gained by a step that runs a recognized test command).",
+      reports: "File, line, and public-safe rule kind — never file/patch content.",
+      network: "Pure local analyzer. No external network call.",
+      notes:
+        "Diff-scoped by design: removing a pre-existing marker, or a marker elsewhere in the file the PR doesn't touch, is never flagged. Complements the test-ratio analyzer by catching padding that never actually executes.",
+    },
+  },
 ] as const satisfies readonly ReesAnalyzerDoc[];
 
 export const REES_ANALYZER_NAMES = REES_ANALYZERS.map((analyzer) => analyzer.name);

--- a/review-enrichment/analyzer-metadata.json
+++ b/review-enrichment/analyzer-metadata.json
@@ -1023,6 +1023,32 @@
         "network": "Calls the GitHub PR-commits API once, bounded to one page.",
         "notes": "Structured-fields-only: reads commit.message subjects, linted independently, never cross-line state. Fail-safe on missing token/fetch error."
       }
+    },
+    {
+      "name": "testSkipGaming",
+      "title": "Test-skip gaming",
+      "category": "quality",
+      "cost": "local",
+      "defaultEnabled": true,
+      "profiles": [
+        "fast",
+        "balanced",
+        "deep"
+      ],
+      "requires": [
+        "files"
+      ],
+      "limits": {
+        "maxFindings": 25,
+        "maxLineChars": 2000
+      },
+      "docs": {
+        "summary": "Flags newly-added test skip/disable/narrowing markers and CI workflow steps that newly stop being able to fail the build.",
+        "looksAt": "Added lines in changed test files (skip/only markers) and .github/workflows/*.yml files (continue-on-error / literal if: false gained by a step that runs a recognized test command).",
+        "reports": "File, line, and public-safe rule kind — never file/patch content.",
+        "network": "Pure local analyzer. No external network call.",
+        "notes": "Diff-scoped by design: removing a pre-existing marker, or a marker elsewhere in the file the PR doesn't touch, is never flagged. Complements the test-ratio analyzer by catching padding that never actually executes."
+      }
     }
   ]
 }

--- a/review-enrichment/src/analyzers/registry.ts
+++ b/review-enrichment/src/analyzers/registry.ts
@@ -25,6 +25,7 @@ import { secretAnalyzer } from "./secret/descriptor.js";
 import { scanSecretLog } from "./secret-log.js";
 import { scanStaleBranch } from "./stale-branch.js";
 import { scanTestRatio } from "./test-ratio.js";
+import { scanTestSkipGaming } from "./test-skip-gaming.js";
 import { scanMigrationSafety } from "./migration-safety.js";
 import { scanLooseRanges } from "./loose-range.js";
 import { scanMagicNumbers } from "./magic-number.js";
@@ -958,6 +959,48 @@ export const ANALYZER_DESCRIPTORS = [
     },
     run: (req, { signal, analysis, diagnostics }) =>
       scanCommitLint(req, fetch, { signal, analysis, diagnostics }),
+  }),
+  descriptor({
+    name: "testSkipGaming",
+    title: "Test-skip gaming",
+    category: "quality",
+    cost: "local",
+    defaultEnabled: true,
+    requires: ["files"],
+    limits: { maxFindings: 25, maxLineChars: 2000 },
+    docs: {
+      summary:
+        "Flags newly-added test skip/disable/narrowing markers and CI workflow steps that newly stop being able to fail the build.",
+      looksAt:
+        "Added lines in changed test files (skip/only markers) and .github/workflows/*.yml files (continue-on-error / literal if: false gained by a step that runs a recognized test command).",
+      reports: "File, line, and public-safe rule kind — never file/patch content.",
+      network: "Pure local analyzer. No external network call.",
+      notes:
+        "Diff-scoped by design: removing a pre-existing marker, or a marker elsewhere in the file the PR doesn't touch, is never flagged. Complements the test-ratio analyzer by catching padding that never actually executes.",
+    },
+    render: (findings, helpers) => {
+      if (!findings.length) return [];
+      const explain = (kind: (typeof findings)[number]["kind"]): string => {
+        switch (kind) {
+          case "skip-marker":
+            return "a newly-added test is skipped/disabled, so it never actually runs";
+          case "only-marker":
+            return "a newly-added narrowing marker silently excludes sibling tests from the run";
+          case "ci-continue-on-error":
+            return "a test step newly gained continue-on-error: true, so it can no longer fail the check";
+          case "ci-neutralized-if":
+            return "a test step newly gained an if: false condition, so it never runs at all";
+        }
+      };
+      const lines = ["### Test-skip gaming (padding the test-ratio signal without real coverage)"];
+      for (const item of findings) {
+        lines.push(
+          `- ${helpers.safeCodeSpan(`${item.file}:${item.line}`)} — ${explain(item.kind)}`,
+        );
+      }
+      return lines;
+    },
+    run: (req, { signal }) => scanTestSkipGaming(req, signal),
   }),
 ] as const satisfies readonly AnyAnalyzerDescriptor[];
 

--- a/review-enrichment/src/analyzers/test-skip-gaming.ts
+++ b/review-enrichment/src/analyzers/test-skip-gaming.ts
@@ -1,0 +1,245 @@
+// Test-skip-gaming analyzer. The test-ratio analyzer (test-ratio.ts) rewards a PR for adding test lines, but a
+// test that is skipped, disabled, or narrowed to run alone never actually executes — padding the ratio signal
+// without buying any real coverage. This analyzer flags two distinct shapes of that gaming, both diff-scoped
+// (only lines the PR itself ADDS, never pre-existing code the diff doesn't touch):
+//   1. A newly-added skip/disable marker in a test file (JS/TS `it.skip(`/`xdescribe(`/…, Python
+//      `@pytest.mark.skip(if)`, JUnit `@Disabled`, Go `t.Skip(`) or a newly-added narrowing marker
+//      (`it.only(`/`fdescribe(`/…) that silently excludes every sibling test from the run.
+//   2. A CI workflow step that already runs a recognized test command and newly gains `continue-on-error: true`
+//      or a literal `if: false` — neutered so the step can never fail the check regardless of outcome.
+// Pure compute over `req.files[].patch`, no network. Reuses test-ratio.ts's isTestPath so the two analyzers
+// agree on what a "test file" is.
+import type { EnrichRequest, TestSkipGamingFinding } from "../types.js";
+import { isWorkflowPath } from "../workflow-path.js";
+import { isTestPath } from "./test-ratio.js";
+
+const MAX_FINDINGS = 25;
+const MAX_LINE_CHARS = 2000;
+
+const JS_TS_EXTS = new Set(["ts", "tsx", "mts", "cts", "js", "jsx", "mjs", "cjs"]);
+const PY_EXTS = new Set(["py"]);
+const JVM_EXTS = new Set(["java", "kt", "kts"]);
+const GO_EXTS = new Set(["go"]);
+
+// JS/TS: `it`/`test`/`describe` called through `.skip(`, or the Jasmine/Jest `x`-prefixed disabled forms.
+const JS_SKIP_RE = /\b(?:it|test|describe)\.skip\s*\(|\bx(?:describe|it|test)\s*\(/;
+// JS/TS: `.only(` narrows the run to that one block; `fit(`/`fdescribe(` are Jasmine/Jest's focused forms.
+// The leading `\b` means a real identifier ending in "fit"/"describe" (e.g. `profit(`, `xdescribe` handled
+// above) cannot match — only the exact focused-test call shape does.
+const JS_ONLY_RE = /\b(?:it|test|describe)\.only\s*\(|\bf(?:it|describe)\s*\(/;
+const PY_SKIP_RE = /@pytest\.mark\.skip(?:if)?\b/;
+const JVM_SKIP_RE = /@Disabled\b/;
+const GO_SKIP_RE = /\bt\.Skip\s*\(/;
+
+type LangRule = { skip: RegExp; only?: RegExp };
+const LANG_RULES: Record<string, LangRule> = {};
+for (const ext of JS_TS_EXTS) LANG_RULES[ext] = { skip: JS_SKIP_RE, only: JS_ONLY_RE };
+for (const ext of PY_EXTS) LANG_RULES[ext] = { skip: PY_SKIP_RE };
+for (const ext of JVM_EXTS) LANG_RULES[ext] = { skip: JVM_SKIP_RE };
+for (const ext of GO_EXTS) LANG_RULES[ext] = { skip: GO_SKIP_RE };
+
+// A YAML sequence-item step header (`- name:`, `- run:`, `- uses:`, a bare `- id:`, …). Requires a `key:`
+// immediately after the dash so an ordinary scalar list entry under `with:`/`args:` (e.g. `- --fix`) is never
+// mistaken for a new step.
+const STEP_BOUNDARY_RE = /^\s*-\s+[A-Za-z][\w-]*\s*:/;
+// A single-line `run: <command>`, with or without the step's own leading `- ` (the common one-line-step
+// shorthand `- run: npm test`). A `run: |`/`run: >` block scalar's continuation lines are not tracked (no
+// cross-line state), mirroring migration-safety.ts's precedent of skipping statements split across lines.
+const RUN_KEY_RE = /^\s*(?:-\s+)?run\s*:(.*)$/i;
+const TEST_COMMAND_RE =
+  /\b(?:npm|yarn|pnpm)\s+(?:run\s+)?test\b|\b(?:python3?\s+-m\s+)?pytest\b|\bgo\s+test\b|\bmvn\b[^\n]*\btest\b|\bgradlew?\b[^\n]*\btest\b|\bjest\b|\bvitest\b|\brspec\b|\bphpunit\b|\bdotnet\s+test\b|\bcargo\s+test\b|\bmake\s+test\b|\btox\b/i;
+const CONTINUE_ON_ERROR_TRUE_RE = /^\s*continue-on-error\s*:\s*(['"]?)true\1\s*(?:#.*)?$/i;
+const STEP_IF_FALSE_RE = /^\s*if\s*:\s*(['"]?)false\1\s*(?:#.*)?$/i;
+
+function sourceExtOf(path: string): string | null {
+  const match = /\.([A-Za-z0-9]+)$/.exec(path);
+  return match ? match[1]!.toLowerCase() : null;
+}
+
+function* patchLines(patch: string): Generator<string> {
+  let start = 0;
+  for (let i = 0; i <= patch.length; i++) {
+    if (i === patch.length || patch[i] === "\n") {
+      yield patch.slice(start, i);
+      start = i + 1;
+    }
+  }
+}
+
+type ScanLimits = {
+  maxFindings?: number;
+  signal?: AbortSignal;
+};
+
+/** Whether `path` is a location this analyzer scans: a test file (skip/only markers) or a GitHub Actions
+ *  workflow file (neutered test steps). Pure. */
+export function isTestSkipGamingRelevantPath(path: string): boolean {
+  return isWorkflowPath(path) || isTestPath(path);
+}
+
+function pushFinding(
+  findings: TestSkipGamingFinding[],
+  file: string,
+  line: number,
+  kind: TestSkipGamingFinding["kind"],
+  maxFindings: number,
+): boolean {
+  findings.push({ file, line, kind });
+  return findings.length >= maxFindings;
+}
+
+/** Scan one TEST file's patch for a newly added skip/disable or only/narrowing marker on an ADDED line. Pure. */
+function scanTestFileMarkers(
+  path: string,
+  patch: string,
+  limits: ScanLimits,
+  maxFindings: number,
+): TestSkipGamingFinding[] {
+  const rules = LANG_RULES[sourceExtOf(path) ?? ""];
+  const findings: TestSkipGamingFinding[] = [];
+  if (!rules) return findings;
+
+  let newLine = 0;
+  let inHunk = false;
+
+  for (const line of patchLines(patch)) {
+    if (limits.signal?.aborted) throw new Error("analyzer_aborted");
+    const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
+    if (hunk) {
+      newLine = Number(hunk[1]);
+      inHunk = true;
+      continue;
+    }
+    // Skip pre-hunk preamble; inside a hunk `+++x`/`+++ x` is added content, not a header.
+    if (!inHunk) continue;
+    if (!line.startsWith("+")) {
+      // A `\ No newline at end of file` marker is not a content line, so it must not advance the
+      // new-file line counter — mirrors the sibling analyzers (e.g. iac-misconfig.ts).
+      if (!line.startsWith("-") && !line.startsWith("\\")) newLine++;
+      continue;
+    }
+
+    const body = line.slice(1);
+    if (body.length <= MAX_LINE_CHARS) {
+      let kind: TestSkipGamingFinding["kind"] | null = null;
+      if (rules.skip.test(body)) kind = "skip-marker";
+      else if (rules.only?.test(body)) kind = "only-marker";
+      if (kind && pushFinding(findings, path, newLine, kind, maxFindings)) {
+        return findings;
+      }
+    }
+
+    newLine++;
+  }
+
+  return findings;
+}
+
+/** Scan one WORKFLOW file's patch for a step that already runs a recognized test command and newly gains
+ *  `continue-on-error: true` or a literal `if: false` (both are ADDED lines; only the gain is flagged, never a
+ *  pre-existing marker the diff doesn't touch). Step identity/test-command state resets at each hunk boundary,
+ *  same as the sibling regex analyzers: a step whose `run:` line falls outside the diff's context window is
+ *  fail-quiet, not flagged. */
+function scanWorkflowSteps(
+  path: string,
+  patch: string,
+  limits: ScanLimits,
+  maxFindings: number,
+): TestSkipGamingFinding[] {
+  const findings: TestSkipGamingFinding[] = [];
+  let newLine = 0;
+  let inHunk = false;
+  let stepHasTestCommand = false;
+  let pendingGains: Array<{ line: number; kind: TestSkipGamingFinding["kind"] }> = [];
+
+  // Reports the buffered gains for the step just finished, only when that step runs a recognized test
+  // command, then resets for the next step. Returns true once the finding cap is hit.
+  const flushStep = (): boolean => {
+    let stop = false;
+    if (stepHasTestCommand) {
+      for (const gain of pendingGains) {
+        if (pushFinding(findings, path, gain.line, gain.kind, maxFindings)) {
+          stop = true;
+          break;
+        }
+      }
+    }
+    pendingGains = [];
+    stepHasTestCommand = false;
+    return stop;
+  };
+
+  for (const line of patchLines(patch)) {
+    if (limits.signal?.aborted) throw new Error("analyzer_aborted");
+    const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
+    if (hunk) {
+      if (flushStep()) return findings;
+      newLine = Number(hunk[1]);
+      inHunk = true;
+      continue;
+    }
+    if (!inHunk) continue;
+    // Removed lines describe the OLD file only (a removed marker is a fix, never gaming) and a `\ No newline`
+    // marker is not a content line — neither advances the new-file line counter nor updates step state.
+    if (line.startsWith("-") || line.startsWith("\\")) continue;
+
+    const added = line.startsWith("+");
+    const body = line.slice(1);
+
+    if (STEP_BOUNDARY_RE.test(body) && flushStep()) return findings;
+
+    if (body.length <= MAX_LINE_CHARS) {
+      // Context AND added lines both describe the new file, so either can establish "this step runs tests" —
+      // only the GAIN itself (below) is restricted to an added line.
+      const runMatch = RUN_KEY_RE.exec(body);
+      if (runMatch && TEST_COMMAND_RE.test(runMatch[1]!)) stepHasTestCommand = true;
+
+      if (added) {
+        if (CONTINUE_ON_ERROR_TRUE_RE.test(body)) {
+          pendingGains.push({ line: newLine, kind: "ci-continue-on-error" });
+        } else if (STEP_IF_FALSE_RE.test(body)) {
+          pendingGains.push({ line: newLine, kind: "ci-neutralized-if" });
+        }
+      }
+    }
+
+    newLine++;
+  }
+  flushStep();
+
+  return findings;
+}
+
+/** Scan one changed file's patch for test-skip-gaming findings. Dispatches by path: a workflow file is scanned
+ *  for neutered test steps, a test file for skip/only markers, anything else yields nothing. Pure. */
+export function scanPatchForTestSkipGaming(
+  path: string,
+  patch: string,
+  limits: ScanLimits = {},
+): TestSkipGamingFinding[] {
+  const maxFindings = limits.maxFindings ?? MAX_FINDINGS;
+  if (maxFindings <= 0) return [];
+  if (isWorkflowPath(path)) return scanWorkflowSteps(path, patch, limits, maxFindings);
+  if (isTestPath(path)) return scanTestFileMarkers(path, patch, limits, maxFindings);
+  return [];
+}
+
+/** Analyzer entrypoint: added test-file and workflow-file patch lines → test-skip-gaming findings. No network. */
+export async function scanTestSkipGaming(
+  req: EnrichRequest,
+  signal?: AbortSignal,
+): Promise<TestSkipGamingFinding[]> {
+  const findings: TestSkipGamingFinding[] = [];
+  for (const file of req.files ?? []) {
+    if (signal?.aborted) throw new Error("analyzer_aborted");
+    if (!file.patch || !isTestSkipGamingRelevantPath(file.path)) continue;
+    for (const finding of scanPatchForTestSkipGaming(file.path, file.patch, {
+      maxFindings: MAX_FINDINGS - findings.length,
+      signal,
+    })) {
+      findings.push(finding);
+      if (findings.length >= MAX_FINDINGS) return findings;
+    }
+  }
+  return findings;
+}

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -481,6 +481,7 @@ export function renderBrief(
   lines.push(...renderDescriptorSection("magicNumber", findings.magicNumber));
   lines.push(...renderDescriptorSection("conflictMarker", findings.conflictMarker));
   lines.push(...renderDescriptorSection("commitLint", findings.commitLint));
+  lines.push(...renderDescriptorSection("testSkipGaming", findings.testSkipGaming));
 
   if (!lines.length) return { promptSection: "", systemSuffix: "" };
 

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -473,6 +473,19 @@ export interface CommitLintFinding {
   reason: "bad-type" | "missing-colon" | "too-long" | "empty";
 }
 
+/** A newly-added test-skip/narrowing marker, or a CI workflow step that newly stops being able to fail the
+ *  build — both pad or hollow out the test-ratio signal without actually running (more of) the suite. Reports
+ *  the location and rule kind only, never file/patch content. `skip-marker`: a test disabled via `.skip`/`x*`
+ *  (JS/TS), `@pytest.mark.skip(if)` (Python), `@Disabled` (JUnit), or `t.Skip(` (Go). `only-marker`: a
+ *  `.only`/`f*` (JS/TS) narrowing marker that silently excludes sibling tests from the run. `ci-continue-on-error`
+ *  / `ci-neutralized-if`: a workflow step that runs a recognized test command newly gains `continue-on-error:
+ *  true` or a literal `if: false`, so it can never fail the check regardless of the test outcome. */
+export interface TestSkipGamingFinding {
+  file: string;
+  line: number;
+  kind: "skip-marker" | "only-marker" | "ci-continue-on-error" | "ci-neutralized-if";
+}
+
 /** Structured analyzer output. Each analyzer fills its own key; more land as analyzers ship (#1477/#1478). */
 export interface BriefFindings {
   dependency?: DependencyFinding[];
@@ -511,6 +524,7 @@ export interface BriefFindings {
   magicNumber?: MagicNumberFinding[];
   conflictMarker?: ConflictMarkerFinding[];
   commitLint?: CommitLintFinding[];
+  testSkipGaming?: TestSkipGamingFinding[];
 }
 
 /** A JSDoc/TSDoc block whose `@param` tags name parameters the adjacent function no longer declares — a

--- a/review-enrichment/test/analyzer-registry.test.ts
+++ b/review-enrichment/test/analyzer-registry.test.ts
@@ -46,6 +46,7 @@ const EXPECTED_ANALYZERS = [
   "magicNumber",
   "conflictMarker",
   "commitLint",
+  "testSkipGaming",
 ];
 
 test("analyzer descriptors cover the runtime registry in stable order", () => {

--- a/review-enrichment/test/test-skip-gaming.test.ts
+++ b/review-enrichment/test/test-skip-gaming.test.ts
@@ -1,0 +1,454 @@
+// Units for the test-skip-gaming analyzer. Own file (not enrichment.test.ts) so concurrent analyzer PRs don't
+// collide. No network involved — pure compute over added patch lines. Runs against the compiled dist/.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  isTestSkipGamingRelevantPath,
+  scanPatchForTestSkipGaming,
+  scanTestSkipGaming,
+} from "../dist/analyzers/test-skip-gaming.js";
+import { renderBrief } from "../dist/render.js";
+
+const patchOf = (lines) => `@@ -1,0 +1,${lines.length} @@\n${lines.map((l) => `+${l}`).join("\n")}`;
+
+test("isTestSkipGamingRelevantPath: recognizes test-path conventions and workflow files, not ordinary source", () => {
+  assert.equal(isTestSkipGamingRelevantPath("test/unit/foo.test.ts"), true);
+  assert.equal(isTestSkipGamingRelevantPath("src/test/java/com/example/FooTest.java"), true);
+  assert.equal(isTestSkipGamingRelevantPath(".github/workflows/ci.yml"), true);
+  assert.equal(isTestSkipGamingRelevantPath("src/services/scoring.ts"), false);
+});
+
+// --- Rule 1/2: skip and narrowing markers in test files ------------------------------------------------------
+
+test("scanPatchForTestSkipGaming: flags every JS/TS skip form (it/test/describe.skip, x-prefixed)", () => {
+  const findings = scanPatchForTestSkipGaming(
+    "test/unit/foo.test.ts",
+    patchOf([
+      "it.skip(\"is skipped\", () => {});",
+      "test.skip(\"is skipped\", () => {});",
+      "describe.skip(\"suite\", () => {});",
+      "xdescribe(\"suite\", () => {});",
+      "xit(\"is skipped\", () => {});",
+      "xtest(\"is skipped\", () => {});",
+    ]),
+  );
+  assert.deepEqual(
+    findings.map((f) => f.kind),
+    Array(6).fill("skip-marker"),
+  );
+  assert.deepEqual(
+    findings.map((f) => f.line),
+    [1, 2, 3, 4, 5, 6],
+  );
+});
+
+test("scanPatchForTestSkipGaming: flags every JS/TS narrowing form (it/test/describe.only, fit/fdescribe)", () => {
+  const findings = scanPatchForTestSkipGaming(
+    "test/unit/foo.test.ts",
+    patchOf([
+      "it.only(\"focused\", () => {});",
+      "test.only(\"focused\", () => {});",
+      "describe.only(\"suite\", () => {});",
+      "fit(\"focused\", () => {});",
+      "fdescribe(\"suite\", () => {});",
+    ]),
+  );
+  assert.deepEqual(
+    findings.map((f) => f.kind),
+    Array(5).fill("only-marker"),
+  );
+});
+
+test("scanPatchForTestSkipGaming: an ordinary it/describe call with no marker is not flagged", () => {
+  const findings = scanPatchForTestSkipGaming(
+    "test/unit/foo.test.ts",
+    patchOf([
+      "it(\"does the thing\", () => {});",
+      "describe(\"suite\", () => {});",
+      "test(\"also fine\", () => {});",
+    ]),
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanPatchForTestSkipGaming: identifiers that merely end in the marker word are not flagged (word-boundary precision)", () => {
+  // `profit(` must not match `fit(`, and a real helper like `fitCurve(` must not match either — the marker
+  // requires the exact focused-test call shape, not any identifier ending in the same letters.
+  const findings = scanPatchForTestSkipGaming(
+    "test/unit/foo.test.ts",
+    patchOf(["const result = profit(data);", "fitCurve(points);"]),
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanPatchForTestSkipGaming: flags Python's @pytest.mark.skip and @pytest.mark.skipif", () => {
+  const findings = scanPatchForTestSkipGaming(
+    "test_foo.py",
+    patchOf(["@pytest.mark.skip", "def test_disabled(): pass", "@pytest.mark.skipif(True, reason=\"flaky\")"]),
+  );
+  assert.deepEqual(
+    findings.map((f) => f.kind),
+    ["skip-marker", "skip-marker"],
+  );
+  assert.deepEqual(
+    findings.map((f) => f.line),
+    [1, 3],
+  );
+});
+
+test("scanPatchForTestSkipGaming: an unrelated pytest marker is not flagged", () => {
+  const findings = scanPatchForTestSkipGaming(
+    "test_foo.py",
+    patchOf(["@pytest.mark.parametrize(\"x\", [1, 2, 3])"]),
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanPatchForTestSkipGaming: flags JUnit's @Disabled but not @DisabledIfSystemProperty", () => {
+  const findings = scanPatchForTestSkipGaming(
+    "src/test/java/com/example/FooTest.java",
+    patchOf(["@Disabled", "void testDisabled() {}", "@DisabledIfSystemProperty(named = \"ci\", matches = \"true\")"]),
+  );
+  assert.deepEqual(findings, [
+    { file: "src/test/java/com/example/FooTest.java", line: 1, kind: "skip-marker" },
+  ]);
+});
+
+test("scanPatchForTestSkipGaming: flags Go's t.Skip( but not the unrelated t.Skipf(", () => {
+  const findings = scanPatchForTestSkipGaming(
+    "pkg/foo_test.go",
+    patchOf(["t.Skip(\"not ready\")", "t.Skipf(\"not ready: %s\", reason)"]),
+  );
+  assert.deepEqual(findings, [{ file: "pkg/foo_test.go", line: 1, kind: "skip-marker" }]);
+});
+
+test("scanPatchForTestSkipGaming: a test path with no recognized language extension yields no findings", () => {
+  const findings = scanPatchForTestSkipGaming("test/README", patchOf(["it.skip(\"x\", () => {});"]));
+  assert.deepEqual(findings, []);
+});
+
+test("scanPatchForTestSkipGaming: only ADDED lines are scanned — removing a pre-existing skip marker is not flagged", () => {
+  const patch = [
+    "@@ -1,2 +1,2 @@",
+    "-it.skip(\"was skipped\", () => {});",
+    "+it(\"now runs\", () => {});",
+  ].join("\n");
+  assert.deepEqual(scanPatchForTestSkipGaming("test/unit/foo.test.ts", patch), []);
+});
+
+test("scanPatchForTestSkipGaming: a pre-existing marker shown only as unchanged context is not flagged", () => {
+  const patch = [
+    "@@ -1,3 +1,3 @@",
+    " it.skip(\"already skipped, untouched by this diff\", () => {});",
+    "-it(\"old\", () => {});",
+    "+it(\"new\", () => {});",
+  ].join("\n");
+  assert.deepEqual(scanPatchForTestSkipGaming("test/unit/foo.test.ts", patch), []);
+});
+
+test("scanPatchForTestSkipGaming: new-file line numbers stay correct across context and removed lines", () => {
+  const patch = [
+    "@@ -10,2 +10,2 @@",
+    " describe(\"suite\", () => {", // new-file line 10
+    "-  it(\"old\", () => {});",
+    "+  it.skip(\"new\", () => {});", // new-file line 11
+  ].join("\n");
+  const findings = scanPatchForTestSkipGaming("test/unit/foo.test.ts", patch);
+  assert.deepEqual(findings, [{ file: "test/unit/foo.test.ts", line: 11, kind: "skip-marker" }]);
+});
+
+test("scanPatchForTestSkipGaming: enforces the maxFindings cap on test-file markers", () => {
+  const lines = Array.from({ length: 30 }, (_, i) => `it.skip("case ${i}", () => {});`);
+  const findings = scanPatchForTestSkipGaming("test/unit/foo.test.ts", patchOf(lines), { maxFindings: 5 });
+  assert.equal(findings.length, 5);
+  assert.deepEqual(findings.map((f) => f.line), [1, 2, 3, 4, 5]);
+
+  assert.deepEqual(
+    scanPatchForTestSkipGaming("test/unit/foo.test.ts", patchOf(lines), { maxFindings: 0 }),
+    [],
+  );
+});
+
+test("scanPatchForTestSkipGaming: an aborted signal throws while scanning a test file", () => {
+  const controller = new AbortController();
+  controller.abort();
+  assert.throws(
+    () =>
+      scanPatchForTestSkipGaming("test/unit/foo.test.ts", patchOf(["it.skip(\"x\", () => {});"]), {
+        signal: controller.signal,
+      }),
+    /analyzer_aborted/,
+  );
+});
+
+// --- Rule 3: CI workflow steps neutered with continue-on-error / literal if: false ---------------------------
+
+const workflowPatch = (lines) => `@@ -1,0 +1,${lines.length} @@\n${lines.join("\n")}`;
+
+test("scanPatchForTestSkipGaming: flags a test step that newly gains continue-on-error: true", () => {
+  const findings = scanPatchForTestSkipGaming(
+    ".github/workflows/ci.yml",
+    workflowPatch([
+      "       - name: Run tests",
+      "         run: npm test",
+      "+        continue-on-error: true",
+    ]),
+  );
+  assert.deepEqual(findings, [
+    { file: ".github/workflows/ci.yml", line: 3, kind: "ci-continue-on-error" },
+  ]);
+});
+
+test("scanPatchForTestSkipGaming: flags a test step that newly gains a literal if: false", () => {
+  const findings = scanPatchForTestSkipGaming(
+    ".github/workflows/ci.yml",
+    workflowPatch(["       - name: Run tests", "         run: npm test", "+        if: false"]),
+  );
+  assert.deepEqual(findings, [
+    { file: ".github/workflows/ci.yml", line: 3, kind: "ci-neutralized-if" },
+  ]);
+});
+
+test("scanPatchForTestSkipGaming: quoted 'true'/\"false\" forms are recognized the same as bare booleans", () => {
+  const continueOnError = scanPatchForTestSkipGaming(
+    ".github/workflows/ci.yml",
+    workflowPatch(["       - run: pytest", "+        continue-on-error: 'true'"]),
+  );
+  assert.deepEqual(
+    continueOnError.map((f) => f.kind),
+    ["ci-continue-on-error"],
+  );
+
+  const neutralizedIf = scanPatchForTestSkipGaming(
+    ".github/workflows/ci.yml",
+    workflowPatch(["       - run: go test ./...", '+        if: "false"']),
+  );
+  assert.deepEqual(
+    neutralizedIf.map((f) => f.kind),
+    ["ci-neutralized-if"],
+  );
+});
+
+test("scanPatchForTestSkipGaming: continue-on-error/if gained on a NON-test step is not flagged", () => {
+  const findings = scanPatchForTestSkipGaming(
+    ".github/workflows/ci.yml",
+    workflowPatch([
+      "       - name: Build",
+      "         run: npm run build",
+      "+        continue-on-error: true",
+      "       - name: Notify",
+      "         run: echo done",
+      "+        if: false",
+    ]),
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanPatchForTestSkipGaming: continue-on-error: false and a real conditional (if: failure()) are not flagged", () => {
+  const findings = scanPatchForTestSkipGaming(
+    ".github/workflows/ci.yml",
+    workflowPatch([
+      "       - name: Run tests",
+      "         run: npm test",
+      "+        continue-on-error: false",
+      "+        if: failure()",
+    ]),
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanPatchForTestSkipGaming: an already-true continue-on-error shown only as context is not flagged", () => {
+  const findings = scanPatchForTestSkipGaming(
+    ".github/workflows/ci.yml",
+    workflowPatch([
+      "       - name: Run tests",
+      "         run: npm test",
+      "         continue-on-error: true",
+      "+        timeout-minutes: 5",
+    ]),
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanPatchForTestSkipGaming: removing a pre-existing continue-on-error is a fix, not gaming", () => {
+  const patch = [
+    "@@ -1,3 +1,2 @@",
+    "       - name: Run tests",
+    "         run: npm test",
+    "-        continue-on-error: true",
+  ].join("\n");
+  assert.deepEqual(scanPatchForTestSkipGaming(".github/workflows/ci.yml", patch), []);
+});
+
+test("scanPatchForTestSkipGaming: step isolation — a sibling step's gain and test command don't leak into each other", () => {
+  const findings = scanPatchForTestSkipGaming(
+    ".github/workflows/ci.yml",
+    workflowPatch([
+      "       - name: Build",
+      "         run: npm run build",
+      "+        continue-on-error: true", // gains on a non-test step: not flagged
+      "       - name: Run tests",
+      "         run: npm test",
+      "+        if: false", // gains on the real test step: flagged
+    ]),
+  );
+  assert.deepEqual(findings, [
+    { file: ".github/workflows/ci.yml", line: 6, kind: "ci-neutralized-if" },
+  ]);
+});
+
+test("scanPatchForTestSkipGaming: state does not leak across a hunk boundary", () => {
+  const patch = [
+    "@@ -1,2 +1,2 @@",
+    "       - name: Run tests",
+    "         run: npm test",
+    "@@ -50,1 +51,2 @@",
+    // A new hunk far away: no run: line in view, so this step is unknown — the gain must not be flagged.
+    "       - name: Deploy",
+    "+        continue-on-error: true",
+  ].join("\n");
+  assert.deepEqual(scanPatchForTestSkipGaming(".github/workflows/ci.yml", patch), []);
+});
+
+test("scanPatchForTestSkipGaming: an overly long run: line is skipped, so the step is never marked as running tests", () => {
+  const longComment = "a".repeat(2100);
+  const findings = scanPatchForTestSkipGaming(
+    ".github/workflows/ci.yml",
+    workflowPatch([
+      "       - name: Run tests",
+      `         run: npm test # ${longComment}`,
+      "+        continue-on-error: true",
+    ]),
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanPatchForTestSkipGaming: recognizes other ecosystems' test commands (pytest, go test, mvn test)", () => {
+  const pytestFinding = scanPatchForTestSkipGaming(
+    ".github/workflows/ci.yml",
+    workflowPatch(["       - run: pytest -v", "+        continue-on-error: true"]),
+  );
+  assert.equal(pytestFinding.length, 1);
+
+  const goTestFinding = scanPatchForTestSkipGaming(
+    ".github/workflows/ci.yml",
+    workflowPatch(["       - run: go test ./...", "+        if: false"]),
+  );
+  assert.equal(goTestFinding.length, 1);
+
+  const mvnFinding = scanPatchForTestSkipGaming(
+    ".github/workflows/ci.yml",
+    workflowPatch(["       - run: mvn -B test", "+        continue-on-error: true"]),
+  );
+  assert.equal(mvnFinding.length, 1);
+});
+
+test("scanPatchForTestSkipGaming: enforces the maxFindings cap across multiple neutered test steps", () => {
+  const lines = [];
+  for (let i = 0; i < 4; i++) {
+    lines.push(`       - name: Run tests ${i}`, "         run: npm test", "+        continue-on-error: true");
+  }
+  const findings = scanPatchForTestSkipGaming(".github/workflows/ci.yml", workflowPatch(lines), {
+    maxFindings: 2,
+  });
+  assert.equal(findings.length, 2);
+});
+
+test("scanPatchForTestSkipGaming: an aborted signal throws while scanning a workflow file", () => {
+  const controller = new AbortController();
+  controller.abort();
+  assert.throws(
+    () =>
+      scanPatchForTestSkipGaming(
+        ".github/workflows/ci.yml",
+        workflowPatch(["       - run: npm test", "+        continue-on-error: true"]),
+        { signal: controller.signal },
+      ),
+    /analyzer_aborted/,
+  );
+});
+
+// --- Dispatch and the analyzer entrypoint ---------------------------------------------------------------------
+
+test("scanPatchForTestSkipGaming: an ordinary source file (neither test nor workflow) yields no findings", () => {
+  assert.deepEqual(
+    scanPatchForTestSkipGaming("src/services/scoring.ts", patchOf(["it.skip(\"x\", () => {});"])),
+    [],
+  );
+});
+
+test("scanTestSkipGaming: scans only relevant paths and aggregates across test and workflow files", async () => {
+  const findings = await scanTestSkipGaming({
+    repoFullName: "octo/repo",
+    prNumber: 1,
+    files: [
+      { path: "src/app.ts", patch: patchOf(["it.skip(\"not scanned here\", () => {});"]) },
+      { path: "test/unit/foo.test.ts", patch: patchOf(["xit(\"skipped\", () => {});"]) },
+      {
+        path: ".github/workflows/ci.yml",
+        patch: workflowPatch(["       - run: npm test", "+        if: false"]),
+      },
+      { path: "test/unit/bar.test.ts" }, // no patch — skipped
+    ],
+  });
+  assert.deepEqual(
+    findings.map((f) => `${f.file}:${f.kind}`),
+    ["test/unit/foo.test.ts:skip-marker", ".github/workflows/ci.yml:ci-neutralized-if"],
+  );
+});
+
+test("scanTestSkipGaming: honors the global cap across multiple files", async () => {
+  const skipLines = Array.from({ length: 15 }, (_, i) => `it.skip("case ${i}", () => {});`);
+  const findings = await scanTestSkipGaming({
+    repoFullName: "octo/repo",
+    prNumber: 1,
+    files: [
+      { path: "test/unit/a.test.ts", patch: patchOf(skipLines) },
+      { path: "test/unit/b.test.ts", patch: patchOf(skipLines) },
+    ],
+  });
+  assert.equal(findings.length, 25); // capped at MAX_FINDINGS across both files
+  assert.equal(findings.filter((f) => f.file === "test/unit/b.test.ts").length, 10);
+});
+
+test("scanTestSkipGaming: no files yields no findings", async () => {
+  assert.deepEqual(await scanTestSkipGaming({ repoFullName: "octo/repo", prNumber: 1 }), []);
+});
+
+test("scanTestSkipGaming: an aborted signal throws immediately", async () => {
+  const controller = new AbortController();
+  controller.abort();
+  await assert.rejects(
+    scanTestSkipGaming(
+      {
+        repoFullName: "octo/repo",
+        prNumber: 1,
+        files: [{ path: "test/unit/a.test.ts", patch: patchOf(["it.skip(\"x\", () => {});"]) }],
+      },
+      controller.signal,
+    ),
+    /analyzer_aborted/,
+  );
+});
+
+test("renderBrief: test-skip-gaming findings render location plus a public-safe explanation per kind", () => {
+  const { promptSection } = renderBrief({
+    testSkipGaming: [
+      { file: "test/unit/foo.test.ts", line: 3, kind: "skip-marker" },
+      { file: "test/unit/bar.test.ts", line: 7, kind: "only-marker" },
+      { file: ".github/workflows/ci.yml", line: 12, kind: "ci-continue-on-error" },
+      { file: ".github/workflows/ci.yml", line: 20, kind: "ci-neutralized-if" },
+    ],
+  });
+  assert.match(promptSection, /Test-skip gaming/);
+  assert.match(promptSection, /test\/unit\/foo\.test\.ts:3/);
+  assert.match(promptSection, /never actually runs/);
+  assert.match(promptSection, /excludes sibling tests/);
+  assert.match(promptSection, /can no longer fail the check/);
+  assert.match(promptSection, /never runs at all/);
+});
+
+test("renderBrief: no test-skip-gaming findings renders nothing for the section", () => {
+  const { promptSection } = renderBrief({ testSkipGaming: [] });
+  assert.doesNotMatch(promptSection, /Test-skip gaming/);
+});

--- a/src/review/enrichment-analyzer-names.ts
+++ b/src/review/enrichment-analyzer-names.ts
@@ -40,6 +40,7 @@ export const REES_ANALYZER_NAMES = [
   "magicNumber",
   "conflictMarker",
   "commitLint",
+  "testSkipGaming",
 ] as const;
 
 export type ReesAnalyzerName = (typeof REES_ANALYZER_NAMES)[number];

--- a/test/unit/enrichment-wire.test.ts
+++ b/test/unit/enrichment-wire.test.ts
@@ -626,7 +626,7 @@ describe("resolveReesAnalyzers", () => {
       resolveReesAnalyzers(
         env({
           REES_ANALYZERS:
-            "dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene,pendingReviewRequests,testRatio,migrationSafety,looseRange,terminology,todoMarker,conflictMarker,commitLint",
+            "dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene,pendingReviewRequests,testRatio,migrationSafety,looseRange,terminology,todoMarker,magicNumber,conflictMarker,commitLint,testSkipGaming",
         }),
       ),
     ).toEqual([
@@ -663,8 +663,10 @@ describe("resolveReesAnalyzers", () => {
       "looseRange",
       "terminology",
       "todoMarker",
+      "magicNumber",
       "conflictMarker",
       "commitLint",
+      "testSkipGaming",
     ]);
   });
 


### PR DESCRIPTION
## Summary

Adds `review-enrichment/src/analyzers/test-skip-gaming.ts`, a new REES analyzer that closes a blind spot in the existing `test-ratio` analyzer: `test-ratio` counts added test-shaped lines, but a PR can pad that signal with tests that never actually run. This analyzer flags, diff-scoped, newly-added skip/disable markers (`it.skip`/`test.skip`/`describe.skip`, `xdescribe`/`xit`/`xtest`, `@pytest.mark.skip(if)`, JUnit `@Disabled`, Go `t.Skip(`), newly-added `.only`/`f*` narrowing that silently excludes sibling tests, and CI workflow test steps newly neutralized with `continue-on-error: true` or a literal `if: false`. Removing a pre-existing marker, or one elsewhere in the file the PR doesn't touch, is never flagged. Registered in `registry.ts`/`analyzer-metadata.json` alongside `test-ratio`/`iac-misconfig`, whose shapes it follows.

No issue is linked: this repo's `linkedIssuePolicy` is `preferred`, not required, and the proposal, rationale, and full test plan are self-contained in this PR. I checked for duplicates first (open/closed issues and PRs for `skip`, `.only`, `continue-on-error`, and test-ratio-adjacent terms) and found none covering this — the closest existing signal, `test-ratio`, measures volume only and has no notion of whether the added tests execute.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- `npm run test:mcp-pack` crashes on my local Windows dev machine with a pre-existing, unrelated `ERR_INVALID_ARG_TYPE` in `scripts/check-mcp-package.mjs` that I confirmed reproduces identically on a clean, unmodified `main` checkout — it is a local Node/Windows environment issue, not something this PR introduces. Likewise `npm run ui:lint` and part of `npm run test:coverage` show failures on this machine (CRLF-vs-LF noise across the whole `apps/gittensory-ui` tree from `core.autocrlf`, and ~30 shell/script-based test files that need `bash`/`sentry-cli`/`docker` tooling this Windows box doesn't have); I verified every one of these also fails identically on a clean `main` checkout, so I'm listing them as run rather than skipped, with this caveat. The new analyzer's own test suite (`review-enrichment/test/test-skip-gaming.test.ts`, run via `npm run rees:test`) passes in full, and the full `review-enrichment` suite is green apart from those same 2 pre-existing `sentry-upload.test.ts` failures.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — this PR adds a new REES analyzer (backend/enrichment logic) with an accompanying `apps/gittensory-ui/src/lib/rees-analyzers.ts` metadata entry, but no new visible UI surface.

## Notes

-
