### PR TITLE
fix(signals): classify Dart protobuf stubs as generated

### DIFF
--- a/src/signals/path-matchers.ts
+++ b/src/signals/path-matchers.ts
@@ -51,9 +51,9 @@ function isGeneratedFileFrom(parts: NormalizedPath): boolean {
     /(^|\/)(__generated__|generated)\//.test(norm) ||
     /\.(generated|gen)\.[^/]+$/.test(norm) ||
     // protoc output: Go/TS/JS plugins emit `.pb.{go,ts,js}`, the reference C++ plugin emits
-    // `.pb.cc` / `.pb.h`, and the Swift plugin emits `.pb.swift` (the `.pb` infix keeps a
-    // hand-written `.h`/`.cc`/`.swift` from matching).
-    /\.pb\.(go|ts|js|cc|h|swift)$/.test(norm) ||
+    // `.pb.cc` / `.pb.h`, the Swift plugin emits `.pb.swift`, and the Dart plugin emits
+    // `.pb.dart` (the `.pb` infix keeps hand-written `.dart` from matching).
+    /\.pb\.(go|ts|js|cc|h|swift|dart)$/.test(norm) ||
     // Python protobuf: message stubs are `*_pb2.py[i]`; the gRPC plugin emits sibling
     // `*_pb2_grpc.py[i]` service stubs, which are the same machine-generated output.
     /_pb2(_grpc)?\.pyi?$/.test(norm) ||

--- a/test/unit/path-matchers.test.ts
+++ b/test/unit/path-matchers.test.ts
@@ -76,6 +76,7 @@ describe("isGeneratedFile", () => {
   it("matches Swift protobuf, Dart freezed/retrofit, and C# designer/XAML codegen", () => {
     for (const path of [
       "proto/messages.pb.swift",
+      "proto/messages.pb.dart",
       "lib/user.freezed.dart",
       "lib/api_client.gr.dart",
       "ui/MainForm.Designer.cs",


### PR DESCRIPTION
## Summary

- Extend `isGeneratedFile` in `path-matchers.ts` to treat `.pb.dart` as protoc-generated output, matching the existing `.pb.go`/`.pb.swift`/`.pb.cc` handling.
- The Dart protoc plugin emits `messages.pb.dart` stubs; without this, `classifyChangedFile` miscounted them as substantive source (hand-written `.dart` is unaffected — the `.pb` infix is required).

## Scope

- [x] Conventional Commit title format.
- [x] Focused — path-matchers + unit tests only.
- [x] Follows `CONTRIBUTING.md`.
- [x] No linked issue needed.

## Validation

- [x] `git diff --check`
- [x] `npm run test:ci` on Node 22
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] Unit test covers `proto/messages.pb.dart` as generated and `lib/user.dart` as non-generated

## Safety

- [x] No secrets, auth, or UI changes.
- [x] N/A for UI Evidence.

## UI Evidence

N/A — backend path classifier only.

## Notes

**Conflict avoidance:** Touches only `src/signals/path-matchers.ts` and `test/unit/path-matchers.test.ts`. Zero overlap with open PRs (#3408/#3406 engine, #3407 enrichment tests, #3379 selfhost, #3314 miner, #3305 enrichment-wire, #3304 queue/gate). Merges cleanly after any of those land without rebase.

Made with [Cursor](https://cursor.com)