### PR TITLE
feat(engine): add hasPlanPendingSteps

### DIFF
--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -122,6 +122,7 @@ export * from "./plan-export.js";
 export { countPlanStepsByStatus } from "./plan-step-stats.js";
 export { isPlanFullyCompleted } from "./plan-completion.js";
 export { hasPlanFailedSteps } from "./plan-failure.js";
+export { hasPlanPendingSteps } from "./plan-pending.js";
 export * from "./plan-templates.js";
 export * from "./portfolio/queue.js";
 export {

--- a/packages/gittensory-engine/src/plan-pending.ts
+++ b/packages/gittensory-engine/src/plan-pending.ts
@@ -1,0 +1,8 @@
+import type { PlanDag } from "./plan-export.js";
+
+/**
+ * Return whether any step in the plan is still pending. Pure — reads the plan DAG only.
+ */
+export function hasPlanPendingSteps(plan: PlanDag): boolean {
+  return plan.steps.some((step) => step.status === "pending");
+}

--- a/test/unit/plan-pending.test.ts
+++ b/test/unit/plan-pending.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { hasPlanPendingSteps } from "../../packages/gittensory-engine/src/plan-pending";
+import type { PlanStep } from "../../packages/gittensory-engine/src/plan-export";
+
+function step(over: Partial<PlanStep> & { id: string; title: string }): PlanStep {
+  return {
+    actionClass: undefined,
+    dependsOn: [],
+    status: "pending",
+    attempts: 0,
+    maxAttempts: 3,
+    lastError: null,
+    ...over,
+  };
+}
+
+describe("hasPlanPendingSteps", () => {
+  it("returns false for an empty plan", () => {
+    expect(hasPlanPendingSteps({ steps: [] })).toBe(false);
+  });
+
+  it("returns false when no step is pending", () => {
+    expect(
+      hasPlanPendingSteps({
+        steps: [
+          step({ id: "a", title: "Build", status: "completed" }),
+          step({ id: "b", title: "Deploy", status: "failed" }),
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true when at least one step is pending", () => {
+    expect(
+      hasPlanPendingSteps({
+        steps: [
+          step({ id: "a", title: "Build", status: "completed" }),
+          step({ id: "b", title: "Test", status: "pending" }),
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("is exported from the package barrel", async () => {
+    const barrel = await import("../../packages/gittensory-engine/src/index");
+    expect(typeof barrel.hasPlanPendingSteps).toBe("function");
+    expect(
+      barrel.hasPlanPendingSteps({
+        steps: [step({ id: "a", title: "A", status: "pending" })],
+      }),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `hasPlanPendingSteps` in `@jsonbored/gittensory-engine` — returns whether any step in a plan DAG is still pending.
- Pure helper alongside `hasPlanFailedSteps` and `isPlanFullyCompleted` for miner and dashboard status checks.
- Vitest coverage at 100% patch on the new helper.

## Test plan
- [x] `COVERAGE_NO_THRESHOLDS=1 npx vitest run test/unit/plan-pending.test.ts --coverage`
- [x] `npx diff-cover coverage/lcov.info --compare-branch=main --fail-under=99` → 100%
- [x] `npm run build --workspace @jsonbored/gittensory-engine && npm run build:miner`


Made with [Cursor](https://cursor.com)