### PR TITLE
feat(enrichment): detect Sourcegraph legacy and ClickHouse Cloud secret keys

### DIFF
--- a/review-enrichment/src/analyzers/secret-scan.ts
+++ b/review-enrichment/src/analyzers/secret-scan.ts
@@ -416,6 +416,18 @@ const RULES: Rule[] = [
     confidence: "high",
   },
   {
+    // Sourcegraph access token (v2, deprecated): `sgp_` + 40 hex (no middle segment).
+    kind: "sourcegraph_legacy_access_token",
+    re: /\bsgp_(?!local_)[a-fA-F0-9]{40}(?![A-Za-z0-9_-])/,
+    confidence: "high",
+  },
+  {
+    // ClickHouse Cloud API secret key: `4b1d` + 38 base62 chars.
+    kind: "clickhouse_cloud_api_secret_key",
+    re: /\b4b1d[A-Za-z0-9]{38}(?![A-Za-z0-9_-])/,
+    confidence: "high",
+  },
+  {
     // Google OAuth 2.0 client secret: `GOCSPX-` + 28 base64url chars.
     kind: "google_oauth_client_secret",
     re: /\bGOCSPX-[A-Za-z0-9_-]{28}\b/,

--- a/review-enrichment/test/secret-scan.test.ts
+++ b/review-enrichment/test/secret-scan.test.ts
@@ -1245,6 +1245,57 @@ test("scanPatch does not flag truncated Mixedbread/Sourcegraph local tokens or i
   );
 });
 
+test("scanPatch flags Sourcegraph legacy and ClickHouse Cloud API secret keys with high confidence", () => {
+  const fakeSourcegraphLegacyToken = ["sgp_", hex(40)].join("");
+  const legacyFindings = scanPatch("src/config.ts", hunk([`const sg = "${fakeSourcegraphLegacyToken}";`]));
+  assert.equal(legacyFindings.length, 1);
+  assert.equal(legacyFindings[0].kind, "sourcegraph_legacy_access_token");
+  assert.equal(legacyFindings[0].confidence, "high");
+
+  const fakeClickhouseKey = ["4b1d", b62(38)].join("");
+  const clickhouseFindings = scanPatch("src/config.ts", hunk([`const ch = "${fakeClickhouseKey}";`]));
+  assert.equal(clickhouseFindings.length, 1);
+  assert.equal(clickhouseFindings[0].kind, "clickhouse_cloud_api_secret_key");
+  assert.equal(clickhouseFindings[0].confidence, "high");
+});
+
+test("scanPatch does not flag truncated Sourcegraph legacy/ClickHouse keys or identifier continuation", () => {
+  const shortLegacyToken = ["sgp_", hex(39)].join("");
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const sg = "${shortLegacyToken}";`])).some((f) => f.kind === "sourcegraph_legacy_access_token"),
+    false,
+  );
+  const legacySuffixToken = ["sgp_", hex(40), "-suffix"].join("");
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const sg = "${legacySuffixToken}";`])).some((f) => f.kind === "sourcegraph_legacy_access_token"),
+    false,
+  );
+  const legacyUnderscoreToken = ["sgp_", hex(40), "_suffix"].join("");
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const sg = "${legacyUnderscoreToken}";`])).some((f) => f.kind === "sourcegraph_legacy_access_token"),
+    false,
+  );
+  const legacyAlphaSuffixToken = ["sgp_", hex(40), "z"].join("");
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const sg = "${legacyAlphaSuffixToken}";`])).some((f) => f.kind === "sourcegraph_legacy_access_token"),
+    false,
+  );
+
+  assert.equal(scanPatch("src/config.ts", hunk([`const ch = "4b1d${b62(37)}";`])).length, 0);
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const ch = "4b1d${b62(38)}-suffix";`])).some((f) => f.kind === "clickhouse_cloud_api_secret_key"),
+    false,
+  );
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const ch = "4b1d${b62(38)}_suffix";`])).some((f) => f.kind === "clickhouse_cloud_api_secret_key"),
+    false,
+  );
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const ch = "4b1d${b62(38)}z";`])).some((f) => f.kind === "clickhouse_cloud_api_secret_key"),
+    false,
+  );
+});
+
 test("scanPatch flags additional high-confidence SaaS/cloud/CI credential formats", () => {
   const cases = [
     ["google_oauth_client_secret", "GOCSPX-" + b62(28)],


### PR DESCRIPTION
## Summary
- Add `sourcegraph_legacy_access_token` for deprecated v2 format: `sgp_` + 40 hex (excludes `sgp_local_` and v3 `sgp_{16hex}_{40hex}` via shape)
- Add `clickhouse_cloud_api_secret_key` for ClickHouse Cloud API secrets: `4b1d` + 38 base62 chars
- Both rules use broad tail guard `(?![A-Za-z0-9_-])` with truncation, `-suffix`, `_suffix`, and alpha continuation negatives

## Test plan
- [x] `cd review-enrichment && npm run build && node --test test/secret-scan.test.ts` (104 passing)

Made with [Cursor](https://cursor.com)