### PR TITLE
fix(integrations): reject blank project IDs before GitHub calls

### DIFF
--- a/src/integrations/project-tracker-adapter.ts
+++ b/src/integrations/project-tracker-adapter.ts
@@ -166,6 +166,7 @@ type PullRequestNodeIdResponse = {
  * custom field are two independent GraphQL mutations, and this PR only needs the first).
  */
 export async function resolveProjectV2Fields(ctx: ProjectTrackerContext, projectId: string): Promise<ProjectV2Field[]> {
+  if (typeof projectId !== "string" || projectId.trim().length === 0) return [];
   const token = await createInstallationToken(ctx.env, ctx.installationId);
   const octokit = makeInstallationOctokit(ctx.env, token, "live", githubRateLimitAdmissionKeyForInstallation(ctx.installationId));
   const response = await octokit.graphql<ProjectFieldsGraphQlResponse>(
@@ -226,6 +227,7 @@ export class GitHubProjectsAdapter implements ProjectTrackerAdapter {
   }
 
   async attachToProject(ctx: ProjectTrackerContext, pullNumber: number, projectId: string): Promise<ProjectTrackerAttachResult> {
+    if (typeof projectId !== "string" || projectId.trim().length === 0) return { attached: false };
     const { owner, repo } = parseRepoFullName(ctx.repoFullName);
     const token = await createInstallationToken(ctx.env, ctx.installationId);
     const octokit = makeInstallationOctokit(ctx.env, token, "live", githubRateLimitAdmissionKeyForInstallation(ctx.installationId));

--- a/test/unit/project-tracker-adapter.test.ts
+++ b/test/unit/project-tracker-adapter.test.ts
@@ -294,6 +294,20 @@ describe("GitHubProjectsAdapter (#3184)", () => {
     expect(mutationVariables).toEqual({ projectId: "PVT_1", contentId: "PR_kwABC" });
   });
 
+  it("attachToProject rejects a blank projectId without calling GitHub", async () => {
+    let called = false;
+    vi.stubGlobal("fetch", async () => {
+      called = true;
+      return new Response("unexpected", { status: 500 });
+    });
+    const adapter = new GitHubProjectsAdapter();
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem() });
+    for (const projectId of ["", "   "]) {
+      await expect(adapter.attachToProject({ env, installationId: 123, repoFullName: "some-org/gittensory" }, 4, projectId)).resolves.toEqual({ attached: false });
+    }
+    expect(called).toBe(false);
+  });
+
   it("attachToProject reports not-attached when GitHub returns no item (e.g. a permission/visibility gap)", async () => {
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = input.toString();
@@ -350,6 +364,19 @@ describe("resolveProjectV2Fields (#3184)", () => {
       { id: "F_1", name: "Title" },
       { id: "F_2", name: "Status", options: [{ id: "O_1", name: "Todo" }, { id: "O_2", name: "Done" }] },
     ]);
+  });
+
+  it("returns an empty list when projectId is blank without calling GitHub", async () => {
+    let called = false;
+    vi.stubGlobal("fetch", async () => {
+      called = true;
+      return new Response("unexpected", { status: 500 });
+    });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem() });
+    for (const projectId of ["", "   "]) {
+      await expect(resolveProjectV2Fields({ env, installationId: 123, repoFullName: "some-org/gittensory" }, projectId)).resolves.toEqual([]);
+    }
+    expect(called).toBe(false);
   });
 
   it("returns an empty list when the project node has no fields (e.g. not found / inaccessible)", async () => {


### PR DESCRIPTION
## Summary

- `GitHubProjectsAdapter.attachToProject` and `resolveProjectV2Fields` now return early when `projectId` is empty or whitespace-only.
- Avoids wasted installation-token round-trips and GraphQL errors when auto-apply (#3185) receives malformed tracker IDs from upstream config or fuzzy-match wiring.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` — no workflow changes
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers` — no worker/runtime changes
- [ ] `npm run build:mcp` — no MCP changes
- [ ] `npm run test:mcp-pack` — no MCP changes
- [ ] `npm run ui:openapi:check` — no UI/API changes
- [ ] `npm run ui:lint` — no UI changes
- [ ] `npm run ui:typecheck` — no UI changes
- [ ] `npm run ui:build` — no UI changes
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Skipped UI/MCP/worker/actionlint checks: integrations-only bug fix with no surface-area changes outside `src/integrations` and its unit tests.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [ ] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — no UI changes.

## Notes

- Touches `src/integrations/**` only (not a guarded path); intended for auto-merge eligibility once gates pass.

Made with [Cursor](https://cursor.com)