### PR TITLE
test(enrichment): cover codeOnly escape and nested-interpolation branches

### DIFF
--- a/review-enrichment/test/secret-log.test.ts
+++ b/review-enrichment/test/secret-log.test.ts
@@ -88,6 +88,23 @@ test("codeOnly strips string messages but keeps interpolation bodies as code", (
   );
 });
 
+test("codeOnly: an escaped quote does not end a string early", () => {
+  // If the `\"` were treated as a real closing quote, `secret" + tail` would leak as code.
+  const out = codeOnly('a = "x\\"secret" + tail');
+  assert.equal(out.includes("secret"), false); // whole string body (incl. the escaped quote) is stripped
+  assert.equal(out.includes("+ tail"), true); // code after the string survives
+});
+
+test("codeOnly: a `${…}` interpolation body is kept even with nested braces", () => {
+  // Depth tracking must not stop at the inner object literal's `}`.
+  assert.equal(codeOnly("`${ {k: 1} }`").includes("{k: 1}"), true);
+});
+
+test("codeOnly: an escaped `\\${` in a template is not treated as an interpolation", () => {
+  // `\${b}` is an escaped literal, so `b` is dropped like any other template char (not kept as code).
+  assert.equal(codeOnly("`a\\${b}c`").includes("b"), false);
+});
+
 test("scanPatchForSecretLog cites the added line via the hunk header", () => {
   const patch = [
     "@@ -1,0 +42,2 @@",


### PR DESCRIPTION
## Summary

Hardens unit coverage for the `secret-log` analyzer's `codeOnly` string/template state machine. The existing tests only cover a plain string blank and a simple `${…}` interpolation; this adds three uncovered branches:

- **an escaped quote** (`\"`) must not end a string early (else the tail leaks as code)
- **nested braces inside `${…}`** — the depth tracking must not stop at an inner object literal's `}`
- **an escaped `\${`** in a template is a literal, not an interpolation, so its body is dropped like any other template char

Property-based assertions (robust to exact spacing). Test-only, against the compiled `dist/`, in the analyzer's own test file. No source or shared-registry change.

_No linked issue — branch-coverage hardening of a pure function; no runtime behavior change._

## Scope
- [x] Conventional Commit; focused; touches only `review-enrichment/test/secret-log.test.ts`. No `site/`/`CNAME`/`**/lovable/**`; no `CHANGELOG.md`.

## Validation
- [x] `npm --prefix review-enrichment test` — full suite green (build + sourcemap validate + `metadata --check` + node tests; exactly CI). Each assertion was traced through the state machine and confirmed.
- [x] `git diff --check` clean.

## Safety
- [x] Test-only, no runtime change. No secrets/wallets/hotkeys/trust/reward terms.
