### PR TITLE
docs(ai): document BYOK pricing table provenance and cross-file dependency

### DIFF
--- a/src/services/ai-review.ts
+++ b/src/services/ai-review.ts
@@ -887,7 +887,10 @@ type ProviderReviewOutcome = {
 /** Static USD-per-million-token pricing for BYOK models. Anthropic/OpenAI responses report token counts but
  *  never a dollar figure, so this table is the only source for a BYOK call's `costUsd`. A model absent here
  *  (e.g. a maintainer-configured override this table hasn't been updated for) leaves `costUsd` undefined —
- *  never fabricated — matching how every other unavailable usage field already degrades in this file. */
+ *  never fabricated — matching how every other unavailable usage field already degrades in this file.
+ *  Last verified 2026-07-05 against platform.claude.com/docs/en/about-claude/models/overview (Anthropic) and
+ *  platform.openai.com/docs/pricing (OpenAI) — re-verify against those pages before trusting this table for
+ *  billing reconciliation, since providers reprice and rename models without notice. */
 const BYOK_MODEL_PRICING_USD_PER_MTOK: Record<
   AiReviewProviderKey["provider"],
   Record<string, { input: number; output: number }>
@@ -927,7 +930,9 @@ function priceByokUsageUsd(
  *  the already-camelCase envelope `coerceAiUsage` reads from `env.AI.run()`. Anthropic's `usage` can also
  *  carry `cache_creation_input_tokens`/`cache_read_input_tokens`, priced differently than `input_tokens` —
  *  intentionally not read here, since `callAiProvider` never sends `cache_control`, so Anthropic never
- *  populates them on this path. */
+ *  populates them on this path. Private to this file, but not private in effect: `ai-slop.ts`'s BYOK branch
+ *  depends on this normalization too, indirectly, via `callAiProvider`'s returned `usage` field — if this
+ *  ever moves, update both call sites. */
 function coerceByokUsage(
   providerKey: AiReviewProviderKey,
   model: string,

--- a/test/unit/ai-review.test.ts
+++ b/test/unit/ai-review.test.ts
@@ -1054,6 +1054,44 @@ describe("BYOK provider dispatch", () => {
     ]);
   });
 
+  it("sums OpenAI's prompt_tokens + completion_tokens toward totalTokens when total_tokens is absent", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              choices: [{ message: { content: reviewJson({ assessment: "BYOK review." }) } }],
+              usage: { prompt_tokens: 60, completion_tokens: 15 },
+            }),
+            { status: 200 },
+          ),
+      ),
+    );
+    const env = createTestEnv({
+      AI: { run: vi.fn() } as unknown as Ai,
+      AI_SUMMARIES_ENABLED: "true",
+      AI_PUBLIC_COMMENTS_ENABLED: "true",
+      AI_DAILY_NEURON_BUDGET: "100000",
+    });
+    const result = await runGittensoryAiReview(env, {
+      ...baseInput,
+      providerKey: { provider: "openai", key: "sk-secret", model: "gpt-5.4" },
+    });
+    expect(result.status === "ok" && result.reviewDiagnostics).toEqual([
+      expect.objectContaining({
+        usage: {
+          provider: "openai",
+          model: "gpt-5.4",
+          inputTokens: 60,
+          outputTokens: 15,
+          totalTokens: 75,
+          costUsd: 0.000375,
+        },
+      }),
+    ]);
+  });
+
   it("treats a non-object BYOK response body as empty output with no usage", async () => {
     vi.stubGlobal("fetch", vi.fn(async () => new Response("null", { status: 200 })));
     const env = createTestEnv({


### PR DESCRIPTION
## Summary

Follow-up to #3382 addressing the 4 (non-blocking) nits raised by the gittensory-orb review on that PR:

1. `src/services/ai-review.ts:890` — the BYOK pricing table had no source/date note, so future maintainers couldn't tell when rates were last verified or whether a model rename needs an update. Added a "last verified 2026-07-05" note naming the exact pages checked.
2. `src/services/ai-review.ts:948` — `coerceByokUsage` is a private helper, but `ai-slop.ts`'s BYOK branch depends on it indirectly through `callAiProvider`'s returned `usage` field. Documented that cross-file dependency inline so a future mover of this function knows to check both call sites.
3. (duplicate of #1)
4. The BYOK partial-usage-field tests (`sums a lone output_tokens...`, `sums a lone input_tokens...`) only exercised Anthropic's field names for the shared `totalTokens` fallback. Added a test forcing that same fallback through OpenAI's `prompt_tokens`/`completion_tokens` specifically, since that's a distinct code path (`providerKey.provider === "openai"` branch) even though the fallback expression itself is shared.

No behavior change — comment-only edits plus one additional test. Codecov's patch gate doesn't apply here (comments aren't instrumented; the only line change in `src/**` is a doc comment).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed. (No issue: a direct, requested follow-up addressing review nits on #3382.)

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — no behavior change; the only `src/**` edit is comment-only.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities.
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries. (No new branches introduced; the added test increases directness of existing coverage.)

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no behavior change.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes.)
- [x] Visible UI changes include a `UI Evidence` section below with screenshots. (N/A — no visible UI changes.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (N/A.)