### PR TITLE
feat(enrichment): detect Infracost and ClickHouse Cloud secret keys

### DIFF
--- a/review-enrichment/src/analyzers/secret-scan.ts
+++ b/review-enrichment/src/analyzers/secret-scan.ts
@@ -416,6 +416,18 @@ const RULES: Rule[] = [
     confidence: "high",
   },
   {
+    // Infracost API token: `ico-` + 32 base62 chars.
+    kind: "infracost_api_token",
+    re: /\bico-[a-zA-Z0-9]{32}(?![A-Za-z0-9_-])/,
+    confidence: "high",
+  },
+  {
+    // ClickHouse Cloud API secret key: `4b1d` + 38 base62 chars.
+    kind: "clickhouse_cloud_api_secret_key",
+    re: /\b4b1d[A-Za-z0-9]{38}(?![A-Za-z0-9_-])/,
+    confidence: "high",
+  },
+  {
     // Google OAuth 2.0 client secret: `GOCSPX-` + 28 base64url chars.
     kind: "google_oauth_client_secret",
     re: /\bGOCSPX-[A-Za-z0-9_-]{28}\b/,

--- a/review-enrichment/test/secret-scan.test.ts
+++ b/review-enrichment/test/secret-scan.test.ts
@@ -1245,6 +1245,50 @@ test("scanPatch does not flag truncated Mixedbread/Sourcegraph local tokens or i
   );
 });
 
+test("scanPatch flags Infracost and ClickHouse Cloud API secret keys with high confidence", () => {
+  const fakeInfracostToken = ["ico-", b62(32)].join("");
+  const infracostFindings = scanPatch("src/config.ts", hunk([`const ico = "${fakeInfracostToken}";`]));
+  assert.equal(infracostFindings.length, 1);
+  assert.equal(infracostFindings[0].kind, "infracost_api_token");
+  assert.equal(infracostFindings[0].confidence, "high");
+
+  const fakeClickhouseKey = ["4b1d", b62(38)].join("");
+  const clickhouseFindings = scanPatch("src/config.ts", hunk([`const ch = "${fakeClickhouseKey}";`]));
+  assert.equal(clickhouseFindings.length, 1);
+  assert.equal(clickhouseFindings[0].kind, "clickhouse_cloud_api_secret_key");
+  assert.equal(clickhouseFindings[0].confidence, "high");
+});
+
+test("scanPatch does not flag truncated Infracost/ClickHouse keys or identifier continuation", () => {
+  assert.equal(scanPatch("src/config.ts", hunk([`const ico = "ico-${b62(31)}";`])).length, 0);
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const ico = "ico-${b62(32)}-suffix";`])).some((f) => f.kind === "infracost_api_token"),
+    false,
+  );
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const ico = "ico-${b62(32)}_suffix";`])).some((f) => f.kind === "infracost_api_token"),
+    false,
+  );
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const ico = "ico-${b62(32)}z";`])).some((f) => f.kind === "infracost_api_token"),
+    false,
+  );
+
+  assert.equal(scanPatch("src/config.ts", hunk([`const ch = "4b1d${b62(37)}";`])).length, 0);
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const ch = "4b1d${b62(38)}-suffix";`])).some((f) => f.kind === "clickhouse_cloud_api_secret_key"),
+    false,
+  );
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const ch = "4b1d${b62(38)}_suffix";`])).some((f) => f.kind === "clickhouse_cloud_api_secret_key"),
+    false,
+  );
+  assert.equal(
+    scanPatch("src/config.ts", hunk([`const ch = "4b1d${b62(38)}z";`])).some((f) => f.kind === "clickhouse_cloud_api_secret_key"),
+    false,
+  );
+});
+
 test("scanPatch flags additional high-confidence SaaS/cloud/CI credential formats", () => {
   const cases = [
     ["google_oauth_client_secret", "GOCSPX-" + b62(28)],


### PR DESCRIPTION
## Summary
- Add `infracost_api_token` for `ico-` + 32 base62 chars (Infracost cloud cost API)
- Add `clickhouse_cloud_api_secret_key` for `4b1d` + 38 base62 chars (ClickHouse Cloud API secret)
- Both rules use broad tail guard `(?![A-Za-z0-9_-])` with truncation, `-suffix`, `_suffix`, and alpha continuation negatives

## Test plan
- [x] `cd review-enrichment && npm run build && node --test test/secret-scan.test.ts` (104 passing)

Made with [Cursor](https://cursor.com)