### PR TITLE
fix(signals): classify Kotlin protobuf stubs as generated

### DIFF
--- a/src/signals/path-matchers.ts
+++ b/src/signals/path-matchers.ts
@@ -52,8 +52,8 @@ function isGeneratedFileFrom(parts: NormalizedPath): boolean {
     /\.(generated|gen)\.[^/]+$/.test(norm) ||
     // protoc output: Go/TS/JS plugins emit `.pb.{go,ts,js}`, the reference C++ plugin emits
     // `.pb.cc` / `.pb.h`, the Swift plugin emits `.pb.swift`, and the Dart plugin emits
-    // `.pb.dart` (the `.pb` infix keeps hand-written `.dart` from matching).
-    /\.pb\.(go|ts|js|cc|h|swift|dart)$/.test(norm) ||
+    // `.pb.dart` (the `.pb` infix keeps hand-written `.dart`/`.kt` from matching).
+    /\.pb\.(go|ts|js|cc|h|swift|dart|kt)$/.test(norm) ||
     // Python protobuf: message stubs are `*_pb2.py[i]`; the gRPC plugin emits sibling
     // `*_pb2_grpc.py[i]` service stubs, which are the same machine-generated output.
     /_pb2(_grpc)?\.pyi?$/.test(norm) ||

--- a/test/unit/path-matchers.test.ts
+++ b/test/unit/path-matchers.test.ts
@@ -77,6 +77,7 @@ describe("isGeneratedFile", () => {
     for (const path of [
       "proto/messages.pb.swift",
       "proto/messages.pb.dart",
+      "proto/messages.pb.kt",
       "lib/user.freezed.dart",
       "lib/api_client.gr.dart",
       "ui/MainForm.Designer.cs",
@@ -85,7 +86,7 @@ describe("isGeneratedFile", () => {
       expect(isGeneratedFile(path)).toBe(true);
     }
     // hand-written siblings must NOT match (the codegen infix is required).
-    for (const path of ["src/MainForm.cs", "lib/user.dart", "net/message.swift"]) {
+    for (const path of ["src/MainForm.cs", "lib/user.dart", "src/service.kt", "net/message.swift"]) {
       expect(isGeneratedFile(path)).toBe(false);
     }
   });


### PR DESCRIPTION
## Summary

- Extend `isGeneratedFile` in `path-matchers.ts` to treat `.pb.kt` as protoc-generated output, matching the existing `.pb.go`/`.pb.dart`/`.pb.swift` handling (#3412).
- The Kotlin protoc plugin emits `messages.pb.kt` stubs; without this, `classifyChangedFile` miscounted them as substantive source. Hand-written `.kt` is unaffected — the `.pb` infix is required.

## Scope

- [x] Conventional Commit title format.
- [x] Focused — path-matchers + unit tests only.
- [x] Follows `CONTRIBUTING.md`.
- [x] No linked issue needed.

## Validation

- [x] `git diff --check`
- [x] `npm run test:ci` on Node 22
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] Unit test covers `proto/messages.pb.kt` as generated and `src/service.kt` as non-generated

## Safety

- [x] No secrets, auth, or UI changes.
- [x] N/A for UI Evidence.

## UI Evidence

N/A — backend path classifier only.

## Notes

**Conflict avoidance:** Touches only `src/signals/path-matchers.ts` and `test/unit/path-matchers.test.ts`. Zero overlap with open PRs (#3419 integrations, #3418 orb-broker, #3417/#3415 selfhost, #3414 review-evasion, #3413/#3406 engine, #3379 selfhost, #3314 miner, #3305 enrichment-wire, #3304 queue/gate). Merges cleanly after any of those land without rebase.

Made with [Cursor](https://cursor.com)