### PR TITLE
fix(agent): restrict tracker suggestions to PR lifecycle actions

### DIFF
--- a/src/integrations/project-tracker-adapter.ts
+++ b/src/integrations/project-tracker-adapter.ts
@@ -320,6 +320,12 @@ type IssueComment = {
   user?: { type?: string; login?: string } | null;
 };
 
+const PROJECT_TRACKER_PULL_REQUEST_ACTIONS = new Set(["opened", "edited", "reopened", "synchronize"]);
+
+function shouldSuggestProjectTrackerForWebhook(eventName: string, action: string | undefined): boolean {
+  return eventName === "pull_request" && action !== undefined && PROJECT_TRACKER_PULL_REQUEST_ACTIONS.has(action);
+}
+
 /** Only knows "github" vs. "linear" -- kept as a standalone alias (mirroring {@link ProjectMilestoneMatchModeInput}
  *  below) rather than importing RepositorySettings, so this integrations module has no dependency on the
  *  settings type. */
@@ -395,8 +401,9 @@ export async function maybeSuggestProjectOrMilestoneMatch(
 
 /**
  * Webhook-level entry point (#3183): folds the "should this even run" gating (installed app, PR still open,
- * feature opted in) AND the best-effort error logging into one call, so the PR-webhook handler in
- * processors.ts has a single, unconditional call site with no logic/logging body of its own -- everything
+ * feature opted in, and a PR lifecycle/title-body webhook) AND the best-effort error logging into one call, so
+ * the PR-webhook handler in processors.ts has a single, unconditional call site with no logic/logging body of
+ * its own -- everything
  * testable lives here, where it already has dedicated, isolated coverage, rather than in an inline closure
  * inside the huge webhook file that only a full pipeline test could exercise.
  */
@@ -412,7 +419,10 @@ export async function maybeSuggestMilestoneMatchForPr(args: {
   mode: ProjectMilestoneMatchModeInput;
   backend: ProjectMilestoneMatchBackendInput;
   deliveryId: string;
+  eventName: string;
+  action: string | undefined;
 }): Promise<void> {
+  if (!shouldSuggestProjectTrackerForWebhook(args.eventName, args.action)) return;
   if (!args.installationId) return;
   if (args.prState !== "open") return;
   if (!args.mode || args.mode === "off") return;

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -5383,6 +5383,8 @@ async function processGitHubWebhook(
         mode: settings.autoProjectMilestoneMatch,
         backend: settings.autoProjectMilestoneMatchBackend,
         deliveryId,
+        eventName,
+        action: payload.action,
       });
       // Draft-dodge guard (#converted-to-draft): a contributor converting an OPEN PR to draft cannot use
       // draft state to keep a gate-rejected PR alive. When a prior gate failure exists for the PR's current

--- a/test/unit/project-tracker-adapter.test.ts
+++ b/test/unit/project-tracker-adapter.test.ts
@@ -711,9 +711,31 @@ describe("maybeSuggestMilestoneMatchForPr (#3183 webhook-level gating)", () => {
       mode: "suggest" as const,
       backend: "github" as const,
       deliveryId: "test-delivery",
+      eventName: "pull_request",
+      action: "opened",
       ...overrides,
     };
   }
+
+  it("does nothing for review webhooks with pull_request payloads", async () => {
+    let called = false;
+    vi.stubGlobal("fetch", async () => {
+      called = true;
+      return new Response("unexpected", { status: 500 });
+    });
+    await maybeSuggestMilestoneMatchForPr(baseArgs({ eventName: "pull_request_review", action: "submitted" }));
+    expect(called).toBe(false);
+  });
+
+  it("does nothing for pull_request actions that do not change title/body matching inputs", async () => {
+    let called = false;
+    vi.stubGlobal("fetch", async () => {
+      called = true;
+      return new Response("unexpected", { status: 500 });
+    });
+    await maybeSuggestMilestoneMatchForPr(baseArgs({ action: "labeled" }));
+    expect(called).toBe(false);
+  });
 
   it("does nothing when installationId is falsy (never touches the network)", async () => {
     let called = false;


### PR DESCRIPTION
### Motivation
- Close a validated security issue where milestone/project suggestion work ran for any webhook payload containing `payload.pull_request`, allowing review/comment webhooks to trigger GitHub API work and token usage. 
- Suggestions should only run for lifecycle/title-body changes where matches can meaningfully change, avoiding amplification from attacker-triggerable review/comment events. 

### Description
- Add an allowlist of PR actions (`opened`, `edited`, `reopened`, `synchronize`) and a `shouldSuggestProjectTrackerForWebhook` guard to `src/integrations/project-tracker-adapter.ts`. 
- Thread `eventName` and `payload.action` into `maybeSuggestMilestoneMatchForPr` and short-circuit early when the webhook is not a targeted `pull_request` lifecycle action in `src/queue/processors.ts`. 
- Add unit regressions in `test/unit/project-tracker-adapter.test.ts` that assert review webhooks and non-matching `pull_request` actions do not perform network calls. 

### Testing
- Ran typecheck with `npm run typecheck -- --pretty false`, which succeeded. 
- Ran the focused unit suite `npx vitest run test/unit/project-tracker-adapter.test.ts`, which passed (42 tests). 
- Attempted the full local gate `npm run test:ci`, but the run could not be completed here because `test:coverage` surfaced unrelated/timeout failures in `test/unit/backfill.test.ts` and the job was terminated; the change is covered by targeted unit tests above. 
- `npm audit --audit-level=moderate` attempted and returned a `403 Forbidden` from the registry audit endpoint in this environment (audit not completed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49effcca40832cbfb0aed53ce6e378)