### PR TITLE
docs(selfhost): redact restore drill metadata

### DIFF
--- a/apps/gittensory-ui/src/routes/docs.self-hosting-backup-scaling.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-backup-scaling.tsx
@@ -183,15 +183,13 @@ docker compose --profile backup run --rm backup sh /verify-backup.sh /backups/po
 
       <h2>Restore drill: what "restore-tested" actually verifies</h2>
       <p>
-        This exact flow was run against a real production backup on a live instance on 2026-07-04
-        (backup <code>gittensory-20260704T090939Z.dump</code>): the dump was restored into a
-        throwaway, network-isolated scratch database (a separate container, never the live one),
-        which the script's own identity check confirmed was distinct from the backup source before
-        touching anything. The restore completed cleanly and, at the time of this drill, repopulated
-        all 84 application tables, including the largest operational tables with their full row
-        counts intact (hundreds of thousands of rows in the biggest tables) — not just an empty
-        schema. Table and row counts will grow over time; treat them as a point-in-time result, not
-        an invariant.
+        This exact flow has been run against a real production backup on a live instance: the dump
+        was restored into a throwaway, network-isolated scratch database (a separate container,
+        never the live one), which the script's own identity check confirmed was distinct from the
+        backup source before touching anything. The restore completed cleanly and repopulated the
+        application tables with representative production-scale data — not just an empty schema.
+        Table and row counts will grow over time; treat restore-drill observations as point-in-time
+        results, not invariants.
       </p>
       <p>
         This proves the backup content and the restore path both work end-to-end against real data.


### PR DESCRIPTION
### Motivation

- Remove an information-disclosure risk from public docs by redacting the exact production backup filename, drill date, table count, and row-volume language while preserving the restore/verification guidance.

### Description

- Replace the restore-drill paragraph in `apps/gittensory-ui/src/routes/docs.self-hosting-backup-scaling.tsx` with generalized wording that removes the concrete backup artifact name/date and numeric table/row counts and instead describes that representative production-scale data was used and that observations are point-in-time.

### Testing

- Ran `git diff --check`, verified the sensitive strings are absent with `rg`, ran `npm --workspace @jsonbored/gittensory-ui exec prettier -- --check src/routes/docs.self-hosting-backup-scaling.tsx`, and ran `npm run ui:lint` (ESLint produced warnings only and no errors); the checks relevant to this UI-only documentation change passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49dfca2bb8832c9a8bf3c76c156d34)