### PR TITLE
test(enrichment): cover reconstructOldContent multi-hunk and out-of-range paths

### DIFF
--- a/review-enrichment/test/doc-comment-drift.test.ts
+++ b/review-enrichment/test/doc-comment-drift.test.ts
@@ -70,6 +70,20 @@ test("reconstructOldContent: bails (null) when the patch context does not match 
   assert.equal(reconstructOldContent(`a\nb\n`, `@@ -1,2 +1,2 @@\n-x\n+a\n other`), null);
 });
 
+test("reconstructOldContent: rebuilds across MULTIPLE hunks, filling the unchanged gap between them", () => {
+  // new file: a / X / c / d. Hunk 1 changed Y→X (line 2); hunk 2 changed D→d (line 4); `c` is the untouched gap.
+  const old = reconstructOldContent(
+    `a\nX\nc\nd\n`,
+    `@@ -1,2 +1,2 @@\n a\n-Y\n+X\n@@ -4,1 +4,1 @@\n-D\n+d`,
+  );
+  assert.equal(old, `a\nY\nc\nD\n`);
+});
+
+test("reconstructOldContent: bails (null) when a hunk starts beyond the head content's length", () => {
+  // A hunk anchored at line 99 of a 2-line file can't align → fail closed rather than fabricate old content.
+  assert.equal(reconstructOldContent(`a\nb\n`, `@@ -99,1 +99,1 @@\n a`), null);
+});
+
 test("findDocCommentDrift: a duplicate-named function is skipped (no cross-declaration false positive)", () => {
   // Two `dup` declarations; a stale @param on the first must not borrow the other's old params.
   const content = `/**\n * @param gone\n */\nexport function dup(a) {}\nfunction dup(b) {}\n`;


### PR DESCRIPTION
## Summary

Hardens unit coverage for the `doc-comment-drift` analyzer's `reconstructOldContent` (reverse-applies a PR patch to rebuild the pre-PR file). The existing tests cover one single-hunk happy path and one context-mismatch bail; this adds two uncovered branches:

- **multi-hunk reconstruction** — rebuilds across two hunks and fills the untouched line gap between them (the `while cursor < hunkStart` catch-up + cross-hunk cursor continuity)
- **out-of-range-hunk bail** — a hunk anchored beyond the head content's length fails closed (null) rather than fabricating old content, exercising a distinct bail branch from the existing context-mismatch case

Property-checked / exact-output assertions, both traced through the reconstruction. Test-only, against the compiled `dist/`, in the analyzer's own test file. No source or shared-registry change.

_No linked issue — branch-coverage hardening of a pure function; no runtime behavior change._

## Scope
- [x] Conventional Commit; focused; touches only `review-enrichment/test/doc-comment-drift.test.ts`. No `site/`/`CNAME`/`**/lovable/**`; no `CHANGELOG.md`.

## Validation
- [x] `npm --prefix review-enrichment test` — full suite green (build + sourcemap validate + `metadata --check` + node tests; exactly CI). Both new assertions were traced through `reconstructOldContent` and confirmed.
- [x] `git diff --check` clean.

## Safety
- [x] Test-only, no runtime change. No secrets/wallets/hotkeys/trust/reward terms.
