### PR TITLE
fix(rees): gate the expected-commit check on SENTRY_REQUIRE_COMMITS

### DIFF
--- a/review-enrichment/scripts/validate-sentry-release.mjs
+++ b/review-enrichment/scripts/validate-sentry-release.mjs
@@ -197,7 +197,13 @@ export async function validateSentryRelease(env = process.env, fetchImpl = globa
   }
 
   let commits = [];
-  if (config.requireCommits || config.expectedCommitSha) {
+  // Gated on requireCommits ALONE (not `|| config.expectedCommitSha`): upload-sourcemaps.ts always passes
+  // SENTRY_COMMIT_SHA (the deploy's actual git SHA, not itself a strictness signal), so expectedCommitSha is
+  // essentially always set -- fetching here whenever it was merely present, independent of requireCommits, meant
+  // a non-strict deploy still depended on the /commits/ endpoint being reachable (sentryJson throws on any non-OK
+  // response) even though the checks that consume the result are now all requireCommits-gated below. Skipping the
+  // fetch entirely in non-strict mode is the only way "non-strict" actually means "commits don't matter."
+  if (config.requireCommits) {
     commits = asArray(
       await sentryJson(
         config,
@@ -211,10 +217,10 @@ export async function validateSentryRelease(env = process.env, fetchImpl = globa
       ...commitIdsFrom(release),
       ...commits.flatMap((commit) => commitIdsFrom(commit)),
     ];
-    if (config.requireCommits && commitCount <= 0 && commitIds.length === 0) {
+    if (commitCount <= 0 && commitIds.length === 0) {
       failures.push("release has no associated commits");
     }
-    if (config.requireCommits && config.expectedCommitSha && !commitMatches(config.expectedCommitSha, commitIds)) {
+    if (config.expectedCommitSha && !commitMatches(config.expectedCommitSha, commitIds)) {
       failures.push(`release commits do not include expected commit ${config.expectedCommitSha}`);
     }
   }

--- a/review-enrichment/scripts/validate-sentry-release.mjs
+++ b/review-enrichment/scripts/validate-sentry-release.mjs
@@ -214,7 +214,7 @@ export async function validateSentryRelease(env = process.env, fetchImpl = globa
     if (config.requireCommits && commitCount <= 0 && commitIds.length === 0) {
       failures.push("release has no associated commits");
     }
-    if (config.expectedCommitSha && !commitMatches(config.expectedCommitSha, commitIds)) {
+    if (config.requireCommits && config.expectedCommitSha && !commitMatches(config.expectedCommitSha, commitIds)) {
       failures.push(`release commits do not include expected commit ${config.expectedCommitSha}`);
     }
   }

--- a/review-enrichment/test/sentry-release-validation.test.ts
+++ b/review-enrichment/test/sentry-release-validation.test.ts
@@ -125,9 +125,37 @@ test("REGRESSION: validateSentryRelease does NOT enforce the expected-commit mat
   // "true" : "false"). SENTRY_COMMIT_SHA is still passed unconditionally (it's the deploy's actual git SHA, not
   // itself a strictness signal), so expectedCommitSha stays set -- the bug this guards was that the match check
   // read only `config.expectedCommitSha`, never `config.requireCommits`, so it fired regardless of strict mode.
+  const calls: string[] = [];
   const fetchImpl = async (input: string | URL | Request): Promise<Response> => {
     const path = new URL(String(input)).pathname;
+    calls.push(path);
     if (path.endsWith("/commits/")) return response([{ id: "def456" }]);
+    if (path.endsWith("/deploys/")) return response([{ name: "deploy-1", environment: "production" }]);
+    return response({
+      version: "gittensory-rees@abc123",
+      dateReleased: "2026-06-29T00:00:00Z",
+      commitCount: 1,
+      deployCount: 1,
+      projects: [{ slug: "gittensory" }],
+    });
+  };
+
+  const result = await validateSentryRelease(validationEnv({ SENTRY_REQUIRE_COMMITS: "false" }), fetchImpl);
+  assert.equal(result.release, "gittensory-rees@abc123");
+  // Non-strict mode must not even CALL the commits endpoint -- confirmed below with a second regression pinning
+  // this exact call-skip, since a real Sentry API hiccup on /commits/ would otherwise still fail a non-strict
+  // deploy (sentryJson throws on any non-OK response) even though no commit check would run on the result.
+  assert.equal(calls.includes("/api/0/organizations/jsonbored/releases/gittensory-rees%40abc123/commits/"), false);
+});
+
+test("REGRESSION: validateSentryRelease never calls the commits endpoint at all when SENTRY_REQUIRE_COMMITS=false, even if that endpoint is unhealthy", async () => {
+  // The specific gap the AI reviewer caught on the first pass of this fix: gating only the FAILURE pushes on
+  // requireCommits, while leaving the fetch itself conditioned on `requireCommits || expectedCommitSha`, meant a
+  // non-strict deploy still depended on /commits/ succeeding even though nothing would ever fail from its result.
+  // Prove it directly: the endpoint returns a hard 500, and non-strict validation must still succeed.
+  const fetchImpl = async (input: string | URL | Request): Promise<Response> => {
+    const path = new URL(String(input)).pathname;
+    if (path.endsWith("/commits/")) return response({ detail: "internal error" }, 500);
     if (path.endsWith("/deploys/")) return response([{ name: "deploy-1", environment: "production" }]);
     return response({
       version: "gittensory-rees@abc123",

--- a/review-enrichment/test/sentry-release-validation.test.ts
+++ b/review-enrichment/test/sentry-release-validation.test.ts
@@ -119,6 +119,29 @@ test("validateSentryRelease rejects a release missing the expected commit", asyn
   );
 });
 
+test("REGRESSION: validateSentryRelease does NOT enforce the expected-commit match when SENTRY_REQUIRE_COMMITS=false", async () => {
+  // Same mismatched-commit fixture as the strict-mode test above ("def456" vs the expected "abc123"), but with
+  // requireCommits off (upload-sourcemaps.ts's non-strict deploy path: SENTRY_REQUIRE_COMMITS: fields.strict ?
+  // "true" : "false"). SENTRY_COMMIT_SHA is still passed unconditionally (it's the deploy's actual git SHA, not
+  // itself a strictness signal), so expectedCommitSha stays set -- the bug this guards was that the match check
+  // read only `config.expectedCommitSha`, never `config.requireCommits`, so it fired regardless of strict mode.
+  const fetchImpl = async (input: string | URL | Request): Promise<Response> => {
+    const path = new URL(String(input)).pathname;
+    if (path.endsWith("/commits/")) return response([{ id: "def456" }]);
+    if (path.endsWith("/deploys/")) return response([{ name: "deploy-1", environment: "production" }]);
+    return response({
+      version: "gittensory-rees@abc123",
+      dateReleased: "2026-06-29T00:00:00Z",
+      commitCount: 1,
+      deployCount: 1,
+      projects: [{ slug: "gittensory" }],
+    });
+  };
+
+  const result = await validateSentryRelease(validationEnv({ SENTRY_REQUIRE_COMMITS: "false" }), fetchImpl);
+  assert.equal(result.release, "gittensory-rees@abc123");
+});
+
 test("validateSentryRelease rejects a release missing the required deploy", async () => {
   const fetchImpl = async (input: string | URL | Request): Promise<Response> => {
     const path = new URL(String(input)).pathname;


### PR DESCRIPTION
## Summary

- Found via Sentry (issue GITTENSORY-X, 9 occurrences, regressed): `Error: Sentry release validation failed (1): ...["release commits do not include expected commit ..."]`, culprit `runReleaseValidation(upload-sourcemaps)`.
- `review-enrichment/scripts/validate-sentry-release.mjs`'s `validateSentryRelease` has two commit-related checks gated on `config.requireCommits` (mirroring `SENTRY_REQUIRE_COMMITS`/the `strict` deploy flag): "release has no associated commits" correctly checks `config.requireCommits`, but the sibling "release commits do not include expected commit" check only tested `config.expectedCommitSha` — never `config.requireCommits`. Since `upload-sourcemaps.ts` always passes `SENTRY_COMMIT_SHA` (the deploy's actual git SHA — not itself a strictness signal) regardless of the `strict` flag, `expectedCommitSha` is essentially always set, so this specific check fired unconditionally even on a deploy that explicitly requested non-strict validation (`SENTRY_REQUIRE_COMMITS=false`), causing spurious release-validation failures.
- Fix: add the same `config.requireCommits &&` guard already used by the sibling check, so both commit-related checks consistently respect strict mode.
- No issue filed — small, self-evident bug found via direct Sentry investigation.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (repo root, clean)
- [x] `node --test --experimental-strip-types test/sentry-release-validation.test.ts` (run from `review-enrichment/`) — 5/5 passing, including the new regression test
- [ ] `npm run test:workers` / `npm run build:mcp` / `npm run test:mcp-pack` / `npm run ui:openapi:check` / `npm run ui:build` — not run individually this PR; this change is entirely within `review-enrichment/`, a separately-deployed sub-package with its own test runner, and doesn't touch the Worker/MCP/UI/OpenAPI surface.
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — added a regression test exercising the exact previously-broken case (mismatched commit SHA + `SENTRY_REQUIRE_COMMITS=false`), which now resolves successfully instead of throwing; the existing strict-mode test (mismatched commit SHA with default `requireCommits: true`) is untouched and still correctly rejects.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no API/OpenAPI/MCP surface changed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI change.
- [ ] Visible UI changes include a `UI Evidence` section below. — N/A, no visible UI change.
- [ ] Public docs/changelogs are updated where needed. — N/A, internal deploy-tooling fix, no documented/user-facing behavior change.

## Notes

- Part of a stack-health pass triggered by a live Sentry audit on the self-hosted deployment; see the parallel fixes for the RAG chunk-cap, PR-publish silent-drop, REES `safeCodeSpan` TypeError, and codex hang-detection issues found in the same pass.