### PR TITLE
fix(integrations): strict milestone IDs and blank Linear PR URLs

### DIFF
--- a/src/integrations/linear-adapter.ts
+++ b/src/integrations/linear-adapter.ts
@@ -111,6 +111,7 @@ export type LinearNativeLinkResult = {
  */
 export async function findLinearNativeLink(ctx: ProjectTrackerContext, prUrl: string): Promise<LinearNativeLinkResult> {
   const none: LinearNativeLinkResult = { project: null, milestone: null };
+  if (typeof prUrl !== "string" || prUrl.trim().length === 0) return none;
   const apiKey = await getDecryptedRepositoryLinearKey(ctx.env, ctx.repoFullName);
   if (!apiKey) return none;
   const data = await linearGraphQl<AttachmentsForUrlResponse>(

--- a/src/integrations/project-tracker-adapter.ts
+++ b/src/integrations/project-tracker-adapter.ts
@@ -3,7 +3,7 @@ import { githubRateLimitAdmissionKeyForInstallation, makeInstallationOctokit } f
 import { createIssueComment } from "../github/pr-actions";
 import { findLinearNativeLink, LinearAdapter } from "./linear-adapter";
 import { termOverlap, tokenize, type CollisionTerms } from "../signals/engine";
-import { errorMessage } from "../utils/json";
+import { errorMessage, parsePositiveInt } from "../utils/json";
 
 /** Repo-scoped context shared by every ProjectTrackerAdapter call (#3183). */
 export type ProjectTrackerContext = {
@@ -55,13 +55,6 @@ type GitHubMilestone = {
 // any realistic open-milestone/open-project/PR-comment count, while still bounding worst-case API calls.
 const GITHUB_LIST_PAGE_LIMIT = 3;
 
-/** A positive-integer milestone/issue number as a string, or null if `value` isn't one. Guards against a
- *  malformed/forged `milestoneId` reaching GitHub's PATCH as `NaN` or a negative/zero number. */
-function parsePositiveIntegerId(value: string): number | null {
-  const parsed = Number(value);
-  return Number.isInteger(parsed) && parsed > 0 ? parsed : null;
-}
-
 /** GitHub REST implementation of {@link ProjectTrackerAdapter}. Only the Milestone half is real (#3183) --
  *  Projects v2 lives in the separate {@link GitHubProjectsAdapter} (#3184), so those two methods are inert here. */
 export class GitHubMilestonesAdapter implements ProjectTrackerAdapter {
@@ -96,7 +89,7 @@ export class GitHubMilestonesAdapter implements ProjectTrackerAdapter {
   }
 
   async attachToMilestone(ctx: ProjectTrackerContext, pullNumber: number, milestoneId: string): Promise<ProjectTrackerAttachResult> {
-    const milestoneNumber = parsePositiveIntegerId(milestoneId);
+    const milestoneNumber = parsePositiveInt(milestoneId);
     if (milestoneNumber === null) return { attached: false };
     const { owner, repo } = parseRepoFullName(ctx.repoFullName);
     const token = await createInstallationToken(ctx.env, ctx.installationId);

--- a/test/unit/linear-adapter.test.ts
+++ b/test/unit/linear-adapter.test.ts
@@ -117,6 +117,20 @@ describe("findLinearNativeLink (#3186)", () => {
     expect(result).toEqual({ project: null, milestone: null });
   });
 
+  it("returns nulls for a blank PR URL without calling Linear", async () => {
+    let called = false;
+    vi.stubGlobal("fetch", async () => {
+      called = true;
+      return new Response("unexpected", { status: 500 });
+    });
+    const env = createTestEnv({ TOKEN_ENCRYPTION_SECRET: SECRET });
+    await upsertRepositoryLinearKey(env, { repoFullName: "acme/widgets", key: "lin_api_test_key" });
+    for (const prUrl of ["", "   "]) {
+      await expect(findLinearNativeLink({ env, installationId: 123, repoFullName: "acme/widgets" }, prUrl)).resolves.toEqual({ project: null, milestone: null });
+    }
+    expect(called).toBe(false);
+  });
+
   it("finds a native-linked issue's project and milestone via attachmentsForURL", async () => {
     const env = createTestEnv({ TOKEN_ENCRYPTION_SECRET: SECRET });
     await upsertRepositoryLinearKey(env, { repoFullName: "acme/widgets", key: "lin_api_test_key" });

--- a/test/unit/project-tracker-adapter.test.ts
+++ b/test/unit/project-tracker-adapter.test.ts
@@ -118,7 +118,7 @@ describe("GitHubMilestonesAdapter (#3183)", () => {
     });
     const adapter = new GitHubMilestonesAdapter();
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem() });
-    for (const invalidId of ["not-a-number", "0", "-5", "3.5", ""]) {
+    for (const invalidId of ["not-a-number", "0", "-5", "3.5", "", " 14", "1e2"]) {
       const result = await adapter.attachToMilestone({ env, installationId: 123, repoFullName: "JSONbored/gittensory" }, 4, invalidId);
       expect(result).toEqual({ attached: false });
     }


### PR DESCRIPTION
## Summary

- `GitHubMilestonesAdapter.attachToMilestone` now uses strict digit-only `parsePositiveInt` parsing instead of `Number()`, so whitespace-padded or scientific-notation milestone IDs (e.g. `" 14"`, `"1e2"`) cannot attach the wrong GitHub milestone.
- `findLinearNativeLink` returns early when `prUrl` is empty or whitespace-only, avoiding a wasted Linear GraphQL round-trip.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` — no workflow changes
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers` — no worker/runtime changes
- [ ] `npm run build:mcp` — no MCP changes
- [ ] `npm run test:mcp-pack` — no MCP changes
- [ ] `npm run ui:openapi:check` — no UI/API changes
- [ ] `npm run ui:lint` — no UI changes
- [ ] `npm run ui:typecheck` — no UI changes
- [ ] `npm run ui:build` — no UI changes
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Skipped UI/MCP/worker/actionlint checks: integrations-only validation hardening with no surface-area changes outside `src/integrations` and unit tests.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [ ] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — no UI changes.

## Notes

- Touches `src/integrations/**` only (not a guarded path).

Made with [Cursor](https://cursor.com)