### PR TITLE
feat(engine): add hasPlanRunningSteps

### DIFF
--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -123,6 +123,7 @@ export { countPlanStepsByStatus } from "./plan-step-stats.js";
 export { isPlanFullyCompleted } from "./plan-completion.js";
 export { hasPlanFailedSteps } from "./plan-failure.js";
 export { hasPlanPendingSteps } from "./plan-pending.js";
+export { hasPlanRunningSteps } from "./plan-running.js";
 export * from "./plan-templates.js";
 export * from "./portfolio/queue.js";
 export {

--- a/packages/gittensory-engine/src/plan-running.ts
+++ b/packages/gittensory-engine/src/plan-running.ts
@@ -1,0 +1,8 @@
+import type { PlanDag } from "./plan-export.js";
+
+/**
+ * Return whether any step in the plan is currently running. Pure — reads the plan DAG only.
+ */
+export function hasPlanRunningSteps(plan: PlanDag): boolean {
+  return plan.steps.some((step) => step.status === "running");
+}

--- a/test/unit/plan-running.test.ts
+++ b/test/unit/plan-running.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { hasPlanRunningSteps } from "../../packages/gittensory-engine/src/plan-running";
+import type { PlanStep } from "../../packages/gittensory-engine/src/plan-export";
+
+function step(over: Partial<PlanStep> & { id: string; title: string }): PlanStep {
+  return {
+    actionClass: undefined,
+    dependsOn: [],
+    status: "pending",
+    attempts: 0,
+    maxAttempts: 3,
+    lastError: null,
+    ...over,
+  };
+}
+
+describe("hasPlanRunningSteps", () => {
+  it("returns false for an empty plan", () => {
+    expect(hasPlanRunningSteps({ steps: [] })).toBe(false);
+  });
+
+  it("returns false when no step is running", () => {
+    expect(
+      hasPlanRunningSteps({
+        steps: [
+          step({ id: "a", title: "Build", status: "completed" }),
+          step({ id: "b", title: "Test", status: "pending" }),
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true when at least one step is running", () => {
+    expect(
+      hasPlanRunningSteps({
+        steps: [
+          step({ id: "a", title: "Build", status: "completed" }),
+          step({ id: "b", title: "Deploy", status: "running", attempts: 1 }),
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("is exported from the package barrel", async () => {
+    const barrel = await import("../../packages/gittensory-engine/src/index");
+    expect(typeof barrel.hasPlanRunningSteps).toBe("function");
+    expect(
+      barrel.hasPlanRunningSteps({
+        steps: [step({ id: "a", title: "A", status: "running", attempts: 1 })],
+      }),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `hasPlanRunningSteps` in `@jsonbored/gittensory-engine` — returns whether any step in a plan DAG is currently running.
- Pure helper alongside `hasPlanPendingSteps`, `hasPlanFailedSteps`, and `isPlanFullyCompleted` for miner and dashboard status checks.
- Vitest coverage at 100% patch on the new helper.

## Test plan
- [x] `COVERAGE_NO_THRESHOLDS=1 npx vitest run test/unit/plan-running.test.ts --coverage`
- [x] `npx diff-cover coverage/lcov.info --compare-branch=main --fail-under=99` → 100%
- [x] `npm run build --workspace @jsonbored/gittensory-engine && npm run build:miner`


Made with [Cursor](https://cursor.com)