### PR TITLE
fix(signals): classify C# protobuf stubs as generated

### DIFF
--- a/src/signals/path-matchers.ts
+++ b/src/signals/path-matchers.ts
@@ -51,9 +51,10 @@ function isGeneratedFileFrom(parts: NormalizedPath): boolean {
     /(^|\/)(__generated__|generated)\//.test(norm) ||
     /\.(generated|gen)\.[^/]+$/.test(norm) ||
     // protoc output: Go/TS/JS plugins emit `.pb.{go,ts,js}`, the reference C++ plugin emits
-    // `.pb.cc` / `.pb.h`, the Swift plugin emits `.pb.swift`, and the Dart plugin emits
-    // `.pb.dart` (the `.pb` infix keeps hand-written `.dart`/`.kt` from matching).
-    /\.pb\.(go|ts|js|cc|h|swift|dart|kt)$/.test(norm) ||
+    // `.pb.cc` / `.pb.h`, the Swift plugin emits `.pb.swift`, the Dart plugin emits `.pb.dart`,
+    // the Kotlin plugin emits `.pb.kt`, and the C# plugin emits `.pb.cs`.
+    // `.pb.dart`/`.pb.kt`/`.pb.cs` (the `.pb` infix keeps hand-written sources from matching).
+    /\.pb\.(go|ts|js|cc|h|swift|dart|kt|cs)$/.test(norm) ||
     // Python protobuf: message stubs are `*_pb2.py[i]`; the gRPC plugin emits sibling
     // `*_pb2_grpc.py[i]` service stubs, which are the same machine-generated output.
     /_pb2(_grpc)?\.pyi?$/.test(norm) ||

--- a/test/unit/path-matchers.test.ts
+++ b/test/unit/path-matchers.test.ts
@@ -78,6 +78,7 @@ describe("isGeneratedFile", () => {
       "proto/messages.pb.swift",
       "proto/messages.pb.dart",
       "proto/messages.pb.kt",
+      "proto/messages.pb.cs",
       "lib/user.freezed.dart",
       "lib/api_client.gr.dart",
       "ui/MainForm.Designer.cs",


### PR DESCRIPTION
## Summary

- Extend `isGeneratedFile` in `path-matchers.ts` to treat `.pb.cs` as protoc-generated output, matching the existing `.pb.go`/`.pb.kt`/`.pb.dart` handling (#3412, #3424).
- The C# protoc plugin emits `messages.pb.cs` stubs; without this, `classifyChangedFile` miscounted them as substantive source. Hand-written `.cs` is unaffected — the `.pb` infix is required (distinct from `.Designer.cs`/`.g.cs` codegen already recognized).

## Scope

- [x] Conventional Commit title format.
- [x] Focused — path-matchers + unit tests only.
- [x] Follows `CONTRIBUTING.md`.
- [x] No linked issue needed.

## Validation

- [x] `git diff --check`
- [x] `npm run test:ci` on Node 22
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] Unit test covers `proto/messages.pb.cs` as generated and `src/MainForm.cs` as non-generated

## Safety

- [x] No secrets, auth, or UI changes.
- [x] N/A for UI Evidence.

## UI Evidence

N/A — backend path classifier only.

## Notes

**Conflict avoidance:** Touches only `src/signals/path-matchers.ts` and `test/unit/path-matchers.test.ts`. Zero overlap with open PRs (#3435/#3406 engine, #3434 enrichment, #3433 integrations, #3432 repo-policy tests, #3431 rees release, #3429 release workflow, #3414 review-evasion, #3314 miner, #3305 enrichment-wire, #3304 queue/gate). Merges cleanly after any of those land without rebase.

Made with [Cursor](https://cursor.com)