### PR TITLE
fix(review): prioritize manifest/config files in RAG indexing before the chunk cap

### DIFF
--- a/src/review/rag-index.ts
+++ b/src/review/rag-index.ts
@@ -15,8 +15,11 @@
 //      Vectorize/AI binding, a GitHub error, an oversized repo, or a partial batch degrades to "indexed less /
 //      nothing" rather than failing the job. `upsertChunks` itself already no-ops to 0 when infra is absent.
 //   2. FREE-TIER — `isIndexablePath` filters the tree to CODE (not the content/data corpus), source is
-//      prioritized, and a hard MAX_CHUNKS_PER_REPO cap bounds stored vectors per repo (the same cap retrieval
-//      assumes). We stop fetching once the cap is reached.
+//      prioritized ahead of docs, manifest/config files (package.json, tsconfig*.json, wrangler.*,
+//      pnpm-workspace.yaml, go.mod, Cargo.toml, pyproject.toml, ...) are prioritized ahead of THAT
+//      (manifestPriority — on a repo over the cap they'd otherwise tie every other source file and lose
+//      the alphabetical tiebreaker), and a hard MAX_CHUNKS_PER_REPO cap bounds stored vectors per repo
+//      (the same cap retrieval assumes). We stop fetching once the cap is reached.
 //
 // GATING — the caller (processors.ts) only DISPATCHES indexing when `isRagEnabled(env)` is true, and the cron
 // only ENQUEUES the fan-out under the same flag; flag-OFF (the default) this module is never invoked, makes no
@@ -24,6 +27,7 @@
 
 import { createInstallationToken } from "../github/app";
 import { githubRateLimitAdmissionKeyForInstallation, timeoutFetch, type GitHubRateLimitAdmissionKey } from "../github/client";
+import { isConfigFile, isDependencyManifestFile } from "../signals/path-matchers";
 import { repoParts } from "../utils/json";
 import { createReviewAdapters } from "./adapters";
 import {
@@ -41,6 +45,23 @@ import {
 
 /** A single indexable entry from the repo git tree (path + size, used by isIndexablePath's size guard). */
 type TreeEntry = { path: string; size?: number | undefined };
+
+/**
+ * Sort key that puts small, high-value manifest/config files (package.json, tsconfig*.json,
+ * wrangler.jsonc, pnpm-workspace.yaml, go.mod, Cargo.toml, pyproject.toml, requirements*.txt, ...)
+ * AHEAD of filePriority's code/doc split. On a repo whose file count exceeds MAX_CHUNKS_PER_REPO,
+ * `indexRepo`'s per-file loop stops once the cap is hit — with only `filePriority` (code=0, doc=1)
+ * as the sort key, a manifest file ties every other source file at priority 0 and then loses on the
+ * alphabetical tiebreaker, so it can be starved out entirely by volume (verified in prod: gittensory's
+ * own package.json never got indexed). These files are already indexable code (JSON/TOML/YAML all
+ * match CODE_EXT_RE in `./rag`) — this only reorders them, it does not change what's included.
+ * Reuses the same "manifest-like filename" classifiers signals/path-matchers.ts already exports for
+ * slop classification (isDependencyManifestFile / isConfigFile) rather than inventing a second
+ * filename vocabulary.
+ */
+function manifestPriority(path: string): number {
+  return isDependencyManifestFile(path) || isConfigFile(path) ? -1 : filePriority(path);
+}
 
 /** Cap on how many chunks we upsert per Vectorize/D1 write batch (bounds the bound-param + neuron cost per call;
  *  embedTexts itself batches the AI calls at EMBED_BATCH internally). */
@@ -230,8 +251,9 @@ export type IndexRepoResult = { indexed: number; files: number; capped: boolean 
 
 /**
  * FULL (re)index of a repo's CODE into the RAG index. Fetches the git tree at the default branch, filters to
- * indexable code/docs (isIndexablePath), prioritizes source over docs, fetches each file's content, chunks it
- * (chunkFile), and upserts (embed + Vectorize + repo_chunks via upsertChunks) up to MAX_CHUNKS_PER_REPO.
+ * indexable code/docs (isIndexablePath), prioritizes manifest/config files first, then source over docs
+ * (manifestPriority), fetches each file's content, chunks it (chunkFile), and upserts (embed + Vectorize +
+ * repo_chunks via upsertChunks) up to MAX_CHUNKS_PER_REPO.
  *
  * Idempotent: chunk ids are stable (namespace|path::idx) so re-running upserts (ON CONFLICT updates) the same
  * rows rather than duplicating. Fully FAIL-SAFE — any error (no infra, GitHub down, bad file) degrades to
@@ -263,7 +285,7 @@ export async function indexRepo(
     if (rawTree === null) return empty;
     const tree = rawTree
       .filter((entry) => isIndexablePath(entry.path, entry.size))
-      .sort((a, b) => filePriority(a.path) - filePriority(b.path) || a.path.localeCompare(b.path));
+      .sort((a, b) => manifestPriority(a.path) - manifestPriority(b.path) || a.path.localeCompare(b.path));
     await pruneMissingPaths(infra, project, repoName, new Set(tree.map((entry) => entry.path)));
     if (tree.length === 0) return empty;
 

--- a/src/review/rag.ts
+++ b/src/review/rag.ts
@@ -133,7 +133,10 @@ const CODE_EXT_RE =
 // spellings were missing here, so e.g. NOTES.markdown / guide.asciidoc were
 // misclassified as skip instead of doc.
 const DOC_EXT_RE = /\.(md|mdx|markdown|rst|adoc|asciidoc|txt)$/i;
-const ALLOW_EXTLESS_RE = /(^|\/)(Dockerfile|Makefile|Justfile|Procfile)$/i;
+// `go.mod`/`go.work` (Go's extensionless dependency manifests) belong here for the same reason as
+// Dockerfile/Makefile: no recognized extension, but a real, high-value source file that must not
+// fall through to "skip" (go.sum/go.work.sum are resolved-tree lockfiles, already excluded above).
+const ALLOW_EXTLESS_RE = /(^|\/)(Dockerfile|Makefile|Justfile|Procfile|go\.mod|go\.work)$/i;
 
 /** code | doc | skip. Skips dependency/build/content/data/binary paths — RAG indexes code for code
  *  review, not the (potentially huge) submission/content corpus. */

--- a/test/unit/rag-index.test.ts
+++ b/test/unit/rag-index.test.ts
@@ -302,6 +302,85 @@ describe("indexRepo: MAX_CHUNKS_PER_REPO cap holds", () => {
     expect(await countChunks(env, PROJECT, "gittensory")).toBeLessThanOrEqual(MAX_CHUNKS_PER_REPO);
     expect(result.indexed).toBe(MAX_CHUNKS_PER_REPO);
   });
+
+  it("still indexes package.json (and other root manifest/config files) on a repo whose file count exceeds the cap (regression: manifestPriority)", async () => {
+    const { env } = indexEnv();
+    // Alphabetically, "package.json" sorts AFTER most of "src/f0.ts".."src/f<N>.ts" — so without
+    // manifest-first prioritization it would be starved out once the cap is reached, exactly as it
+    // was in prod for gittensory's own repo (#confirmed via repo_chunks query).
+    const overCap = MAX_CHUNKS_PER_REPO + 25;
+    const tree: Array<{ path: string; size: number }> = [
+      { path: "package.json", size: 20 },
+      { path: "tsconfig.json", size: 20 },
+      { path: "pnpm-workspace.yaml", size: 20 },
+      { path: "go.mod", size: 20 },
+      { path: "Cargo.toml", size: 20 },
+      { path: "pyproject.toml", size: 20 },
+      { path: "requirements.txt", size: 20 },
+      { path: "wrangler.jsonc", size: 20 },
+      ...Array.from({ length: overCap }, (_, i) => ({ path: `src/f${i}.ts`, size: 20 })),
+    ];
+    const files: Record<string, string> = {
+      "package.json": '{"name":"gittensory"}\n',
+      "tsconfig.json": "{}\n",
+      "pnpm-workspace.yaml": "packages:\n",
+      "go.mod": "module example.com/foo\n",
+      "Cargo.toml": "[package]\n",
+      "pyproject.toml": "[project]\n",
+      "requirements.txt": "flask\n",
+      "wrangler.jsonc": "{}\n",
+    };
+    for (let i = 0; i < overCap; i++) files[`src/f${i}.ts`] = `export const f${i} = ${i};\n`;
+    stubGithub({ tree, files });
+
+    const result = await indexRepo(env, PROJECT, REPO);
+
+    expect(result.capped).toBe(true);
+    expect(result.indexed).toBe(MAX_CHUNKS_PER_REPO);
+    const indexedPaths = await pathsFor(env, PROJECT, "gittensory");
+    for (const manifest of [
+      "package.json",
+      "tsconfig.json",
+      "pnpm-workspace.yaml",
+      "go.mod",
+      "Cargo.toml",
+      "pyproject.toml",
+      "requirements.txt",
+      "wrangler.jsonc",
+    ]) {
+      expect(indexedPaths).toContain(manifest);
+    }
+  });
+});
+
+describe("manifestPriority ordering (via indexRepo, well under the cap)", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  it("orders manifest/config files first, then other code, then docs — byte-identical file SET to before when the cap never matters", async () => {
+    const { env } = indexEnv();
+    stubGithub({
+      tree: [
+        { path: "README.md", size: 10 },
+        { path: "src/z.ts", size: 10 },
+        { path: "package.json", size: 10 },
+        { path: "src/a.ts", size: 10 },
+      ],
+      files: {
+        "README.md": "# Title\n",
+        "src/z.ts": "export const z = 1;\n",
+        "package.json": '{"name":"x"}\n',
+        "src/a.ts": "export const a = 1;\n",
+      },
+    });
+
+    const result = await indexRepo(env, PROJECT, REPO);
+
+    // Nowhere near the cap: every indexable file is still indexed (same SET as filePriority alone
+    // would have produced) — only the ORDER of indexing/upsert changed, not the outcome.
+    expect(result.capped).toBe(false);
+    expect(result.files).toBe(4);
+    expect(await pathsFor(env, PROJECT, "gittensory")).toEqual(["README.md", "package.json", "src/a.ts", "src/z.ts"]);
+  });
 });
 
 describe("reindexChangedPaths: delete + re-upsert only the changed paths", () => {

--- a/test/unit/rag.test.ts
+++ b/test/unit/rag.test.ts
@@ -66,6 +66,12 @@ describe("rag: code-not-content filtering (free-tier cost guard)", () => {
     ]) {
       expect(classifyRepoFile(p)).toBe("code");
     }
+    // Go's extensionless dependency manifests (go.mod/go.work) are real, high-value source — same
+    // extensionless-allowlist treatment as Dockerfile/Makefile. Their resolved-tree lockfile
+    // siblings (go.sum/go.work.sum) stay excluded via SKIP_FILE_RE below.
+    expect(classifyRepoFile("go.mod")).toBe("code");
+    expect(classifyRepoFile("go.work")).toBe("code");
+    expect(classifyRepoFile("nested/module/go.mod")).toBe("code");
     expect(classifyRepoFile("README.md")).toBe("doc");
     expect(classifyRepoFile("docs/architecture.mdx")).toBe("doc");
     // long-form doc spellings (parity with signals/path-matchers DOCS_EXTENSIONS)
@@ -78,6 +84,9 @@ describe("rag: code-not-content filtering (free-tier cost guard)", () => {
     expect(classifyRepoFile("dist/bundle.js")).toBe("skip");
     expect(classifyRepoFile("package-lock.json")).toBe("skip");
     expect(classifyRepoFile("pnpm-lock.yaml")).toBe("skip");
+    // go.sum stays skipped despite go.mod/go.work now being recognized — SKIP_FILE_RE's lockfile
+    // check runs before ALLOW_EXTLESS_RE, so the resolved-tree lockfile never becomes indexable.
+    expect(classifyRepoFile("go.sum")).toBe("skip");
     expect(classifyRepoFile("public/logo.png")).toBe("skip");
     expect(classifyRepoFile("app.min.js")).toBe("skip");
     // more binary blobs: media/archives/fonts/compiled artifacts and ML model weights


### PR DESCRIPTION
## Summary

- Found via direct production investigation: `repoDocGeneration` (a self-hosted repo-doc generation feature) reported "Package manager: not detected / Build: none detected / Test: none detected / Lint: none detected" for `JSONbored/gittensory` in its generated `AGENTS.md`, while a sibling repo with the same npm setup detected correctly. Root cause traced to a missing `package.json` row in `repo_chunks` (confirmed via direct DB query) — gittensory's RAG index hit the hard `MAX_CHUNKS_PER_REPO = 1500` cap exactly, and `package.json` never made it in.
- `indexRepo`'s pre-cap sort (`src/review/rag-index.ts`) only used `filePriority` (code=0 vs doc=1) — every source file, including `package.json`, ties at priority 0 and falls to an alphabetical tiebreaker, so on a repo over the cap, alphabetically-late root manifests lose to the sheer volume of `src/**`/`test/**` files. This isn't just a repo-doc-generation bug — it means RAG-grounded AI review *context* for the same large repo is also missing its own manifest/config files.
- Fix: added a `manifestPriority` sort key that puts small, high-value manifest/config files (`package.json`, `tsconfig*.json`, `wrangler.*`, `pnpm-workspace.yaml`, `go.mod`, `Cargo.toml`, `pyproject.toml`, `requirements*.txt`, etc.) ahead of the existing code/doc split — reusing the same `isDependencyManifestFile`/`isConfigFile` classifiers `src/signals/path-matchers.ts` already exports for slop classification, rather than inventing a second filename vocabulary. This only reorders indexing priority; it doesn't change what's eligible (these are already indexable — JSON/TOML/YAML match `CODE_EXT_RE`).
- Also closed a related, compounding gap found while tracing this: `go.mod`/`go.work` (extensionless, like `Dockerfile`/`Makefile`) were missing from `ALLOW_EXTLESS_RE` and were unconditionally skipped regardless of repo size or cap — added them (their lockfile siblings `go.sum`/`go.work.sum` remain excluded via the existing lockfile skip rule, which runs first).
- No issue filed — found via direct investigation of a live production symptom, not a report.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (clean)
- [x] `npx vitest run test/unit/rag-index.test.ts test/unit/rag.test.ts test/unit/path-matchers.test.ts` — 157/157 passing
- [ ] `npm run test:workers` / `npm run build:mcp` / `npm run test:mcp-pack` / `npm run ui:openapi:check` / `npm run ui:build` — not run individually this PR; no worker/MCP/OpenAPI/UI surface touched.
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — added: a repo whose file count exceeds `MAX_CHUNKS_PER_REPO` still gets every manifest file (8 distinct manifest/config filenames tested) indexed under the cap; an under-cap repo shows byte-identical existing behavior when the cap never matters; `go.mod`/`go.work` (including nested paths) classify as indexable code while `go.sum` still correctly skips (precedence check).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no API/OpenAPI/MCP surface changed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI change.
- [ ] Visible UI changes include a `UI Evidence` section below. — N/A, no visible UI change.
- [ ] Public docs/changelogs are updated where needed. — N/A, internal indexing-priority fix, no documented behavior change (indexing eligibility/output shape is unchanged, only order).

## Notes

- One of five fixes from a live stack-health pass (Sentry + Loki audit on the self-hosted deployment); see the sibling PRs for the PR-publish silent-drop retry, REES `safeCodeSpan` TypeError, codex hang-detection, and Sentry release-validation strict-mode fixes.