### PR TITLE
feat(engine): add countPlanSteps

### DIFF
--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -137,6 +137,7 @@ export {
 } from "./governor-ledger.js";
 export * from "./plan-export.js";
 export { countPlanStepsByStatus } from "./plan-step-stats.js";
+export { countPlanSteps } from "./plan-step-count.js";
 export { isPlanFullyCompleted } from "./plan-completion.js";
 export { hasPlanFailedSteps } from "./plan-failure.js";
 export { hasPlanPendingSteps } from "./plan-pending.js";

--- a/packages/gittensory-engine/src/plan-step-count.ts
+++ b/packages/gittensory-engine/src/plan-step-count.ts
@@ -1,0 +1,8 @@
+import type { PlanDag } from "./plan-export.js";
+
+/**
+ * Return the total number of steps in the plan. Pure — reads the plan DAG only.
+ */
+export function countPlanSteps(plan: PlanDag): number {
+  return plan.steps.length;
+}

--- a/test/unit/plan-step-count.test.ts
+++ b/test/unit/plan-step-count.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { countPlanSteps } from "../../packages/gittensory-engine/src/plan-step-count";
+import type { PlanStep } from "../../packages/gittensory-engine/src/plan-export";
+
+function step(over: Partial<PlanStep> & { id: string; title: string }): PlanStep {
+  return {
+    actionClass: undefined,
+    dependsOn: [],
+    status: "pending",
+    attempts: 0,
+    maxAttempts: 3,
+    lastError: null,
+    ...over,
+  };
+}
+
+describe("countPlanSteps", () => {
+  it("returns zero for an empty plan", () => {
+    expect(countPlanSteps({ steps: [] })).toBe(0);
+  });
+
+  it("returns the total number of steps regardless of status", () => {
+    expect(
+      countPlanSteps({
+        steps: [
+          step({ id: "a", title: "Build", status: "completed" }),
+          step({ id: "b", title: "Test", status: "pending" }),
+          step({ id: "c", title: "Deploy", status: "failed" }),
+        ],
+      }),
+    ).toBe(3);
+  });
+
+  it("is exported from the package barrel", async () => {
+    const barrel = await import("../../packages/gittensory-engine/src/index");
+    expect(typeof barrel.countPlanSteps).toBe("function");
+    expect(
+      barrel.countPlanSteps({
+        steps: [step({ id: "a", title: "A" }), step({ id: "b", title: "B" })],
+      }),
+    ).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `countPlanSteps` in `@jsonbored/gittensory-engine` — returns the total number of steps in a plan DAG.
- Pure helper alongside `countPlanStepsByStatus` for miner and dashboard progress summaries.
- Vitest coverage at 100% patch on the new helper.

## Test plan
- [x] `COVERAGE_NO_THRESHOLDS=1 npx vitest run test/unit/plan-step-count.test.ts --coverage`
- [x] `npx diff-cover coverage/lcov.info --compare-branch=main --fail-under=99` → 100%
- [x] `npm run build --workspace @jsonbored/gittensory-engine && npm run build:miner`


Made with [Cursor](https://cursor.com)