### PR TITLE
feat(enrichment): flag deployment-trigger and webhook URLs in secret-scan

### DIFF
--- a/review-enrichment/src/analyzers/secret-scan.ts
+++ b/review-enrichment/src/analyzers/secret-scan.ts
@@ -956,6 +956,52 @@ const RULES: Rule[] = [
     confidence: "high",
   },
   {
+    // Netlify build-hook URL — the trailing id triggers a production build, like the webhook rules above.
+    kind: "netlify_build_hook_url",
+    re: /https:\/\/api\.netlify\.com\/build_hooks\/[0-9a-f]{24}/,
+    confidence: "high",
+  },
+  {
+    // Vercel deploy-hook URL — `.../deploy/prj_<id>/<token>`; the trailing token triggers a deployment.
+    kind: "vercel_deploy_hook_url",
+    re: /https:\/\/api\.vercel\.com\/v1\/integrations\/deploy\/prj_[A-Za-z0-9]+\/[A-Za-z0-9]+/,
+    confidence: "high",
+  },
+  {
+    // Render deploy-hook URL — `.../deploy/srv-<id>?key=<key>`; the `key` query param triggers a deployment.
+    kind: "render_deploy_hook_url",
+    re: /https:\/\/api\.render\.com\/deploy\/srv-[A-Za-z0-9]+\?key=[A-Za-z0-9_-]+/,
+    confidence: "high",
+  },
+  {
+    // Healthchecks.io ping URL — the UUID is the check's secret address; a leak lets anyone suppress its alerts.
+    // Case-insensitive hex, since the UUID may be written in either case.
+    kind: "healthchecks_ping_url",
+    re: /https:\/\/hc-ping\.com\/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/,
+    confidence: "high",
+  },
+  {
+    // Pipedream workflow trigger — the subdomain of `.m.pipedream.net` is the endpoint's secret address. The
+    // negative lookahead rejects ANY hostname-continuation char (`.`, `-`, or alphanumeric) so a look-alike
+    // suffix domain — `.m.pipedream.net.evil.com` OR `.m.pipedream.net-evil.com` — is not matched.
+    kind: "pipedream_webhook_url",
+    re: /https:\/\/[a-z0-9]+\.m\.pipedream\.net(?![A-Za-z0-9.-])/,
+    confidence: "high",
+  },
+  {
+    // Azure Logic App callback URL — the `sig=` query param is a SAS that authorizes triggering the workflow.
+    kind: "azure_logic_app_url",
+    re: /https:\/\/[a-z0-9.-]+\.logic\.azure\.com(?::443)?\/workflows\/[^\s"']*sig=/,
+    confidence: "high",
+  },
+  {
+    // Google Apps Script web-app URL — the `/macros/s/<deployment-id>/exec` id is a capability address for the
+    // deployed script (anyone with the URL can invoke it).
+    kind: "google_apps_script_url",
+    re: /https:\/\/script\.google\.com\/macros\/s\/[A-Za-z0-9_-]{30,}\/exec/,
+    confidence: "high",
+  },
+  {
     kind: "private_key",
     re: /-----BEGIN (?:RSA |EC |OPENSSH |DSA |PGP )?PRIVATE KEY-----/,
     confidence: "high",

--- a/review-enrichment/test/secret-scan.test.ts
+++ b/review-enrichment/test/secret-scan.test.ts
@@ -1573,3 +1573,45 @@ test("scanPatch does not flag near-misses of the webhook-URL and token formats",
     assert.equal(findings.length, 0, `near-miss should not match: ${nm}`);
   }
 });
+
+test("scanPatch flags deployment-trigger and webhook URLs that embed a secret", () => {
+  const uuid = [hex(8), hex(4), hex(4), hex(4), hex(12)].join("-");
+  const cases = [
+    ["netlify_build_hook_url", "https://api.netlify.com/build_hooks/" + hex(24)],
+    ["vercel_deploy_hook_url", "https://api.vercel.com/v1/integrations/deploy/prj_" + b62(12) + "/" + b62(24)],
+    ["render_deploy_hook_url", "https://api.render.com/deploy/srv-" + b62(20) + "?key=" + b62(20)],
+    ["healthchecks_ping_url", "https://hc-ping.com/" + uuid],
+    // Healthchecks accepts the UUID in upper case too — the rule matches it case-insensitively.
+    ["healthchecks_ping_url", "https://hc-ping.com/" + uuid.toUpperCase()],
+    ["pipedream_webhook_url", "https://" + b62(12).toLowerCase() + ".m.pipedream.net"],
+    [
+      "azure_logic_app_url",
+      "https://prod-01.westus.logic.azure.com/workflows/" + hex(32) + "/triggers/manual/paths/invoke?sig=" + b62(24),
+    ],
+    ["google_apps_script_url", "https://script.google.com/macros/s/" + b62(40) + "/exec"],
+  ];
+  for (const [kind, secret] of cases) {
+    const findings = scanPatch("src/config.ts", hunk([`const c = "${secret}";`]));
+    assert.equal(findings.length, 1, `${kind}: expected exactly one finding, got ${JSON.stringify(findings)}`);
+    assert.equal(findings[0].kind, kind, `${kind}: wrong kind`);
+    assert.equal(findings[0].confidence, "high", `${kind}: wrong confidence`);
+  }
+});
+
+test("scanPatch does not flag near-misses of the deployment-hook URL formats", () => {
+  const nearMisses = [
+    // Vendor API/docs/dashboard URLs that carry no secret path segment — nothing to leak.
+    "https://api.netlify.com/api/v1/sites",
+    "https://vercel.com/docs/deploy-hooks",
+    "https://render.com/docs/deploy-hooks",
+    // A Render deploy URL WITHOUT the `key` query param is not the triggerable secret URL.
+    "https://api.render.com/deploy/srv-" + b62(20),
+    // A look-alike host is not the real Pipedream endpoint host — neither a dot- nor a hyphen-joined suffix.
+    "https://example.m.pipedream.net.evil.com/path",
+    "https://example.m.pipedream.net-evil.com/path",
+  ];
+  for (const nm of nearMisses) {
+    const findings = scanPatch("src/config.ts", hunk([`const c = "${nm}";`]));
+    assert.equal(findings.length, 0, `near-miss should not match: ${nm}`);
+  }
+});


### PR DESCRIPTION
## Summary

Extends the secret-scan analyzer with **7 new high-confidence rules** for deployment-trigger and webhook URLs
that embed a secret. These follow the existing URL-credential rules (`slack_webhook_url` / `discord_webhook_url`
/ `teams_webhook_url` / `zapier_webhook_url` / `google_chat_webhook_url`): a committed URL of this shape leaks a
capability — anyone who has it can trigger a production deploy or suppress a monitor's alerts.

| kind | matches | leaked capability |
|---|---|---|
| `netlify_build_hook_url` | `api.netlify.com/build_hooks/<id>` | triggers a production build |
| `vercel_deploy_hook_url` | `api.vercel.com/v1/integrations/deploy/prj_<id>/<token>` | triggers a deployment |
| `render_deploy_hook_url` | `api.render.com/deploy/srv-<id>?key=<key>` | triggers a deployment |
| `healthchecks_ping_url` | `hc-ping.com/<uuid>` | lets anyone suppress the check's alerts |
| `pipedream_webhook_url` | `<endpoint>.m.pipedream.net` | invokes the workflow |
| `azure_logic_app_url` | `<host>.logic.azure.com/workflows/…?sig=<sas>` | triggers the workflow (SAS in `sig=`) |
| `google_apps_script_url` | `script.google.com/macros/s/<deployment-id>/exec` | invokes the deployed script |

> Supersedes the closed prior revision, whose Pipedream terminator `(?![a-z0-9.])` rejected a dot-joined
> look-alike suffix but still matched a **hyphen**-joined one (`…m.pipedream.net-evil.com`). This revision uses
> `(?![A-Za-z0-9.-])` — rejecting every hostname-continuation character — and adds that exact near-miss to the
> negative test. Also applies the review nit to match the Healthchecks UUID case-insensitively (with an
> uppercase positive case).

**Why these are false-positive-safe.** Every match is a **full vendor-specific URL** (host + the secret
path/param), so an ordinary string can't trip them, and there is no length to guess (the precision class that has
caused past regressions doesn't apply — the host anchors the match). The negative test asserts that vendor
API/docs/dashboard URLs with no secret segment produce nothing, that a Render deploy URL **without** the `key`
query param is not flagged, and that **both** a dot-joined and a hyphen-joined look-alike suffix host
(`…m.pipedream.net.evil.com`, `…m.pipedream.net-evil.com`) do not match — the Pipedream rule is the only one whose
match ends at the host, so its terminator rejects every hostname-continuation character.

All 7 are **new** kinds (verified against the analyzer's current rule kinds — no duplicate) and inserted before
the generic-assignment rule so the specific kind wins. `SecretFinding.kind` is a free-form `string`, so there is
**no `types.ts`/`render.ts`/`analyzer-metadata.json` change** — a two-file, rules-only diff.

No linked issue: additive detection-coverage extending an existing analyzer along its own established lines; each
rule is a self-evident, industry-standard credential URL with no public API/schema/deploy surface change — fits
the repo's `preferred` (not required) linked-issue policy.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run typecheck`
- [x] `npm run rees:test` — the review-enrichment build + analyzer suite (see note below)
- [ ] `npm run test:coverage` (N/A — this analyzer is in `review-enrichment/`, outside the root `src/**` Codecov scope)
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran locally: `git diff --check` (clean), the review-enrichment TypeScript build (exit 0), and the secret-scan
  suite via `node --test` — **104/104 pass**, including a table test asserting each of the 7 new URL formats
  produces exactly one finding of its own kind at high confidence, and a negative test asserting non-secret
  vendor URLs, a param-less Render URL, and a look-alike suffix host produce none.
- Not run locally: the UI, root typecheck, and the `metadata:check` step of `rees:test`. This change adds only
  RULES entries (no analyzer descriptor field), so the committed `analyzer-metadata.json` / UI mirror are
  unchanged (a local regeneration produces a zero-content diff) and `metadata:check` passes on CI (Linux). On
  this Windows dev box `metadata:check` reports a spurious line-ending difference; it fails identically on
  unmodified `main`. `analyzer-metadata.json` was NOT modified.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Detection-only additions: 7 new stateless RULES following the existing specific→generic pattern; no existing
  rule or the analyzer descriptor changed, so current findings and `analyzer-metadata.json` are unaffected. Each
  new kind reports only `file:line` + the public-safe kind, never the matched value.
- Test fixtures are assembled from fragments at run time (never a contiguous secret-shaped literal in source),
  so GitHub push protection does not flag this fixture file.
