### PR TITLE
feat(health): expose SQLite backup acknowledgment as a Prometheus gauge

### DIFF
--- a/src/selfhost/health.ts
+++ b/src/selfhost/health.ts
@@ -150,3 +150,8 @@ export function sqliteBackupAdvisory(opts: { usingSqlite: boolean; backupAcknowl
   if (!opts.usingSqlite || opts.backupAcknowledged) return null;
   return "Running on a single SQLite file with no acknowledged backup — if the volume is lost, ALL review state is lost. Enable the Litestream sidecar (see the maintainer self-hosting docs) to stream the WAL to S3/B2/MinIO, then set BACKUP_ACKNOWLEDGED=true to silence this warning. (Multi-instance: use DATABASE_URL=postgres://… instead.)";
 }
+
+/** Prometheus gauge value mirroring {@link sqliteBackupAdvisory}: 1 when Postgres or backup is acknowledged, 0 when the advisory would fire. */
+export function backupAcknowledgedGaugeValue(opts: { usingSqlite: boolean; backupAcknowledged: boolean }): 0 | 1 {
+  return sqliteBackupAdvisory(opts) === null ? 1 : 0;
+}

--- a/src/selfhost/metrics.ts
+++ b/src/selfhost/metrics.ts
@@ -52,6 +52,7 @@ const DEFAULT_METRIC_META: readonly (readonly [string, MetricMeta])[] = [
   ["gittensory_github_rest_rate_limit_remaining", { help: "Newest observed GitHub REST rate-limit remaining count, by key scope.", type: "gauge" }],
   ["gittensory_host_load_avg1_per_core", { help: "One-minute host load average normalized by CPU core count.", type: "gauge" }],
   ["gittensory_uptime_seconds", { help: "Self-host process uptime in seconds.", type: "gauge" }],
+  ["gittensory_backup_acknowledged", { help: "1 when SQLite backup is acknowledged or Postgres is in use; 0 when the boot backup advisory would fire.", type: "gauge" }],
   ["gittensory_http_requests_total", { help: "HTTP app requests by response status class.", type: "counter" }],
   ["gittensory_http_request_duration_seconds", { help: "HTTP app request duration in seconds.", type: "histogram" }],
   ["gittensory_webhook_dedup_total", { help: "Webhook deliveries deduplicated before enqueue.", type: "counter" }],

--- a/src/server.ts
+++ b/src/server.ts
@@ -43,6 +43,7 @@ import { createOrbRelayRegistrationState, isOrbBrokerMode, registerOrbRelayTarge
 import { exportOrbBatch } from "./selfhost/orb-collector";
 import { createD1Adapter, nodeSqliteDriver } from "./selfhost/d1-adapter";
 import {
+  backupAcknowledgedGaugeValue,
   buildHealthBody,
   codexAuthReadinessProbe,
   githubAppReadinessProbe,
@@ -375,10 +376,11 @@ async function main(): Promise<void> {
   );
   // Data-safety advisory (#8): warn LOUDLY at boot if running on a single SQLite file with no acknowledged backup,
   // so an operator doesn't run with zero durability while /ready answers 200.
-  const backupAdvisory = sqliteBackupAdvisory({
+  const sqliteBackupOpts = {
     usingSqlite: !usePostgres,
     backupAcknowledged: process.env.BACKUP_ACKNOWLEDGED === "true",
-  });
+  };
+  const backupAdvisory = sqliteBackupAdvisory(sqliteBackupOpts);
   if (backupAdvisory)
     console.warn(
       JSON.stringify({
@@ -688,6 +690,7 @@ async function main(): Promise<void> {
   gauge("gittensory_uptime_seconds", () =>
     Math.floor((Date.now() - startedAt) / 1000),
   );
+  gauge("gittensory_backup_acknowledged", () => backupAcknowledgedGaugeValue(sqliteBackupOpts));
   // Pre-initialize job counters to 0 so they appear in the first Prometheus scrape (lazy counters
   // created on first use would otherwise cause "No data" in Grafana until the first job event).
   for (const c of [

--- a/test/unit/selfhost-health.test.ts
+++ b/test/unit/selfhost-health.test.ts
@@ -5,6 +5,7 @@ import { join } from "node:path";
 import { describe, expect, it, vi } from "vitest";
 import { createD1Adapter, nodeSqliteDriver } from "../../src/selfhost/d1-adapter";
 import {
+  backupAcknowledgedGaugeValue,
   buildHealthBody,
   codexAuthReadinessProbe,
   githubAppReadinessProbe,
@@ -207,6 +208,14 @@ describe("sqliteBackupAdvisory (#8 data-safety)", () => {
     expect(sqliteBackupAdvisory({ usingSqlite: true, backupAcknowledged: false })).toMatch(/single SQLite file with no acknowledged backup/);
     expect(sqliteBackupAdvisory({ usingSqlite: true, backupAcknowledged: true })).toBeNull(); // operator acknowledged
     expect(sqliteBackupAdvisory({ usingSqlite: false, backupAcknowledged: false })).toBeNull(); // Postgres
+  });
+});
+
+describe("backupAcknowledgedGaugeValue (#2089)", () => {
+  it("mirrors the advisory: 0 only when SQLite has no acknowledged backup", () => {
+    expect(backupAcknowledgedGaugeValue({ usingSqlite: true, backupAcknowledged: false })).toBe(0);
+    expect(backupAcknowledgedGaugeValue({ usingSqlite: true, backupAcknowledged: true })).toBe(1);
+    expect(backupAcknowledgedGaugeValue({ usingSqlite: false, backupAcknowledged: false })).toBe(1);
   });
 });
 


### PR DESCRIPTION
Fixes #2089

## Summary
- Add `backupAcknowledgedGaugeValue()` in `health.ts` — returns `1` when Postgres is in use or backup is acknowledged, `0` when the boot SQLite backup advisory would fire
- Register `gittensory_backup_acknowledged` gauge at server boot (mirrors existing `sqliteBackupAdvisory` inputs)
- Add metric metadata in `metrics.ts`
- Unit tests for all three input combinations

## Test plan
- [x] `backupAcknowledgedGaugeValue` unit tests in `selfhost-health.test.ts`
- [x] CI `validate-code`

Made with [Cursor](https://cursor.com)