### PR TITLE
feat(engine): add isPlanEmpty

### DIFF
--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -138,6 +138,7 @@ export {
 export * from "./plan-export.js";
 export { countPlanStepsByStatus } from "./plan-step-stats.js";
 export { countPlanSteps } from "./plan-step-count.js";
+export { isPlanEmpty } from "./plan-empty.js";
 export { isPlanFullyCompleted } from "./plan-completion.js";
 export { hasPlanFailedSteps } from "./plan-failure.js";
 export { hasPlanPendingSteps } from "./plan-pending.js";

--- a/packages/gittensory-engine/src/plan-empty.ts
+++ b/packages/gittensory-engine/src/plan-empty.ts
@@ -1,0 +1,8 @@
+import type { PlanDag } from "./plan-export.js";
+
+/**
+ * Return whether the plan has no steps. Pure — reads the plan DAG only.
+ */
+export function isPlanEmpty(plan: PlanDag): boolean {
+  return plan.steps.length === 0;
+}

--- a/test/unit/plan-empty.test.ts
+++ b/test/unit/plan-empty.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import { isPlanEmpty } from "../../packages/gittensory-engine/src/plan-empty";
+import type { PlanStep } from "../../packages/gittensory-engine/src/plan-export";
+
+function step(over: Partial<PlanStep> & { id: string; title: string }): PlanStep {
+  return {
+    actionClass: undefined,
+    dependsOn: [],
+    status: "pending",
+    attempts: 0,
+    maxAttempts: 3,
+    lastError: null,
+    ...over,
+  };
+}
+
+describe("isPlanEmpty", () => {
+  it("returns true when the plan has no steps", () => {
+    expect(isPlanEmpty({ steps: [] })).toBe(true);
+  });
+
+  it("returns false when the plan has at least one step", () => {
+    expect(isPlanEmpty({ steps: [step({ id: "a", title: "Build" })] })).toBe(false);
+    expect(
+      isPlanEmpty({
+        steps: [
+          step({ id: "a", title: "Build", status: "completed" }),
+          step({ id: "b", title: "Test", status: "pending" }),
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("is exported from the package barrel", async () => {
+    const barrel = await import("../../packages/gittensory-engine/src/index");
+    expect(typeof barrel.isPlanEmpty).toBe("function");
+    expect(barrel.isPlanEmpty({ steps: [] })).toBe(true);
+    expect(barrel.isPlanEmpty({ steps: [step({ id: "a", title: "A" })] })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `isPlanEmpty` in `@jsonbored/gittensory-engine` — returns whether a plan DAG has no steps.
- Pure helper alongside `countPlanSteps` and `isPlanFullyCompleted` for miner and dashboard gating.
- Vitest coverage at 100% patch on the new helper.

## Test plan
- [x] `COVERAGE_NO_THRESHOLDS=1 npx vitest run test/unit/plan-empty.test.ts --coverage`
- [x] `npx diff-cover coverage/lcov.info --compare-branch=main --fail-under=99` → 100%
- [x] `npm run build --workspace @jsonbored/gittensory-engine && npm run build:miner`


Made with [Cursor](https://cursor.com)