### PR TITLE
fix(agent): preserve staged assign assignees

### DIFF
--- a/src/services/agent-action-executor.ts
+++ b/src/services/agent-action-executor.ts
@@ -762,6 +762,7 @@ export function actionParams(action: PlannedAgentAction): AgentPendingActionPara
     ...(action.comment !== undefined ? { comment: action.comment } : {}),
     ...(action.reviewBody !== undefined ? { reviewBody: action.reviewBody } : {}),
     ...(action.mergeMethod !== undefined ? { mergeMethod: action.mergeMethod } : {}),
+    ...(action.assignee !== undefined ? { assignee: action.assignee } : {}),
     ...(action.closeComment !== undefined ? { closeComment: action.closeComment } : {}),
     ...(action.closeReasons !== undefined ? { closeReasons: [...boundStructuredCloseReasonsForPersistence(action.closeReasons)] } : {}),
     ...(action.expectedHeadSha !== undefined ? { expectedHeadSha: action.expectedHeadSha } : {}),

--- a/src/types.ts
+++ b/src/types.ts
@@ -1055,6 +1055,8 @@ export type AgentPendingActionParams = {
   comment?: string;
   reviewBody?: string;
   mergeMethod?: AutoMergeMethod;
+  // For an `assign` action (#3182): the GitHub login to assign when a staged action is accepted.
+  assignee?: string;
   closeComment?: string;
   // Individual close reasons, persisted for approval-queue replay so the eventual audit row keeps the structured
   // reason list rather than only the flattened `reason` field.

--- a/test/unit/agent-action-executor.test.ts
+++ b/test/unit/agent-action-executor.test.ts
@@ -121,6 +121,16 @@ describe("executeAgentMaintenanceActions (#778 gate stack)", () => {
     expect(replayed).toMatchObject({ actionClass: "label", autonomyClass: "close", requiresApproval: false, reason: "blacklisted contributor", label: "slop", labelOp: "add" });
   });
 
+  it("REGRESSION: actionParams round-trips assign assignees through approval replay", () => {
+    const assign: PlannedAgentAction = { actionClass: "assign", requiresApproval: true, reason: "auto-assign PR opener", assignee: "alice" };
+
+    const persisted = actionParams(assign);
+    const replayed = pendingActionToPlanned({ actionClass: "assign", params: persisted, reason: assign.reason });
+
+    expect(persisted).toEqual({ assignee: "alice" });
+    expect(replayed).toMatchObject({ actionClass: "assign", requiresApproval: false, reason: "auto-assign PR opener", assignee: "alice" });
+  });
+
   it("actionParams round-trips structured closeReasons so approval replay preserves every close cause", () => {
     const closeWithReasons: PlannedAgentAction = {
       actionClass: "close",

--- a/test/unit/agent-approval-queue.test.ts
+++ b/test/unit/agent-approval-queue.test.ts
@@ -1211,6 +1211,7 @@ describe("agent approval queue (#779)", () => {
     expect(actionParams({ actionClass: "label", autonomyClass: "review_state_label", requiresApproval: false, reason: "x", label: "L" })).toEqual({ autonomyClass: "review_state_label", label: "L" });
     expect(actionParams({ actionClass: "request_changes", requiresApproval: false, reason: "x", reviewBody: "B" })).toEqual({ reviewBody: "B" });
     expect(actionParams({ actionClass: "merge", requiresApproval: false, reason: "x", mergeMethod: "rebase" })).toEqual({ mergeMethod: "rebase" });
+    expect(actionParams({ actionClass: "assign", requiresApproval: false, reason: "x", assignee: "alice" })).toEqual({ assignee: "alice" });
     expect(actionParams({ actionClass: "close", requiresApproval: false, reason: "x", closeComment: "C", closeReasons: ["x"] })).toEqual({ closeComment: "C", closeReasons: ["x"] });
     // closeKind must round-trip through staging — without it the close-precision breaker could never match a
     // staged close as heuristic on accept (#2127).
@@ -1232,6 +1233,7 @@ describe("agent approval queue (#779)", () => {
   it("pendingActionToPlanned clears requiresApproval and defaults the reason", () => {
     expect(pendingActionToPlanned({ actionClass: "merge", params: { mergeMethod: "squash" } })).toMatchObject({ actionClass: "merge", requiresApproval: false, reason: "maintainer-approved", mergeMethod: "squash" });
     expect(pendingActionToPlanned({ actionClass: "label", params: { label: "L" }, reason: "explicit" }).reason).toBe("explicit");
+    expect(pendingActionToPlanned({ actionClass: "assign", params: { assignee: "alice" }, reason: "auto-assign PR opener" })).toMatchObject({ actionClass: "assign", requiresApproval: false, reason: "auto-assign PR opener", assignee: "alice" });
     expect(pendingActionToPlanned({ actionClass: "close", params: { closeReasons: ["ci failed", "blocker"] }, reason: "ci failed; blocker" })).toMatchObject({
       actionClass: "close",
       requiresApproval: false,


### PR DESCRIPTION
### Motivation

- An `assign` action staged as `auto_with_approval` lost its target login because the approval-queue serialization omitted `assignee`, so accept-time replay reconstructed an assign with no `assignee` and the executor no-oped while still recording the action as completed.

### Description

- Include `assignee` when serializing a `PlannedAgentAction` in `actionParams()` so staged assign actions persist the target login.  
- Add `assignee?: string` to `AgentPendingActionParams` to match the persisted payload shape.  
- Add regression unit tests that verify an `assign` action round-trips through `actionParams()` → DB params → `pendingActionToPlanned()` and preserves `assignee`.  

### Testing

- Ran focused unit tests for the modified paths: `test/unit/agent-action-executor.test.ts` (assign round-trip) and `test/unit/agent-approval-queue.test.ts` (params/replay coverage), and the targeted tests passed.  
- Type checking (`tsc --noEmit`) completed successfully.  
- A full `npm run test:coverage` run was started but did not complete in the available session time; focused unit runs were used as regression validation for this targeted fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a49fdc2b18c832c982d29a2287fb344)