### PR TITLE
test(enrichment): complete provenance classifier coverage for minified and manifest paths

### DIFF
--- a/review-enrichment/test/provenance.test.ts
+++ b/review-enrichment/test/provenance.test.ts
@@ -72,3 +72,13 @@ test("classifyAddedFile flags committed scientific data and columnar artifacts a
   assert.equal(classifyAddedFile("src/parquet.ts"), null);
   assert.equal(classifyAddedFile("lib/npy_utils.py"), null);
 });
+
+test("classifyAddedFile treats minified bundles as vendored and leaves manifest/source paths as ordinary (#2098)", () => {
+  for (const path of ["dist/app.min.js", "static/lib.min.mjs", "assets/vendor.min.css"]) {
+    assert.equal(classifyAddedFile(path), "vendored", path);
+  }
+  // Dependency manifests and normal source are not binary/vendored by path — attestation checks handle them separately.
+  for (const path of ["package.json", "package-lock.json", "requirements.txt", "pyproject.toml", "src/index.ts"]) {
+    assert.equal(classifyAddedFile(path), null, path);
+  }
+});


### PR DESCRIPTION
Fixes #2098

## Summary
Completes the remaining `classifyAddedFile` coverage for the provenance analyzer pure classifiers:

- Minified bundles (`.min.js`, `.min.mjs`, `.min.css`) classify as `vendored`
- Dependency manifests and ordinary source paths (`package.json`, lockfiles, `requirements.txt`, `src/index.ts`) stay `null`

`isSafeToCheck` and `matchesPypiVersion` are already covered in `provenance-version-matcher.test.ts`.

## Test plan
- [x] `cd review-enrichment && npm run build && node --test test/provenance.test.ts test/provenance-version-matcher.test.ts` (10 passing)

Made with [Cursor](https://cursor.com)