### PR TITLE
feat(engine): add hasPlanSkippedSteps

### DIFF
--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -143,6 +143,7 @@ export { isPlanFullyCompleted } from "./plan-completion.js";
 export { hasPlanFailedSteps } from "./plan-failure.js";
 export { hasPlanPendingSteps } from "./plan-pending.js";
 export { hasPlanRunningSteps } from "./plan-running.js";
+export { hasPlanSkippedSteps } from "./plan-skipped.js";
 export * from "./plan-templates.js";
 export * from "./portfolio/queue.js";
 export {

--- a/packages/gittensory-engine/src/plan-skipped.ts
+++ b/packages/gittensory-engine/src/plan-skipped.ts
@@ -1,0 +1,8 @@
+import type { PlanDag } from "./plan-export.js";
+
+/**
+ * Return whether any step in the plan was skipped. Pure — reads the plan DAG only.
+ */
+export function hasPlanSkippedSteps(plan: PlanDag): boolean {
+  return plan.steps.some((step) => step.status === "skipped");
+}

--- a/test/unit/plan-skipped.test.ts
+++ b/test/unit/plan-skipped.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { hasPlanSkippedSteps } from "../../packages/gittensory-engine/src/plan-skipped";
+import type { PlanStep } from "../../packages/gittensory-engine/src/plan-export";
+
+function step(over: Partial<PlanStep> & { id: string; title: string }): PlanStep {
+  return {
+    actionClass: undefined,
+    dependsOn: [],
+    status: "pending",
+    attempts: 0,
+    maxAttempts: 3,
+    lastError: null,
+    ...over,
+  };
+}
+
+describe("hasPlanSkippedSteps", () => {
+  it("returns false for an empty plan", () => {
+    expect(hasPlanSkippedSteps({ steps: [] })).toBe(false);
+  });
+
+  it("returns false when no step was skipped", () => {
+    expect(
+      hasPlanSkippedSteps({
+        steps: [
+          step({ id: "a", title: "Build", status: "completed" }),
+          step({ id: "b", title: "Test", status: "pending" }),
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true when at least one step was skipped", () => {
+    expect(
+      hasPlanSkippedSteps({
+        steps: [
+          step({ id: "a", title: "Build", status: "completed" }),
+          step({ id: "b", title: "Deploy", status: "skipped" }),
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("is exported from the package barrel", async () => {
+    const barrel = await import("../../packages/gittensory-engine/src/index");
+    expect(typeof barrel.hasPlanSkippedSteps).toBe("function");
+    expect(
+      barrel.hasPlanSkippedSteps({
+        steps: [step({ id: "a", title: "A", status: "skipped" })],
+      }),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `hasPlanSkippedSteps` in `@jsonbored/gittensory-engine` — returns whether any step in a plan DAG was skipped.
- Pure helper completing the plan status surface alongside `hasPlanFailedSteps`, `hasPlanPendingSteps`, and `hasPlanRunningSteps`.
- Vitest coverage at 100% patch on the new helper.

## Test plan
- [x] `COVERAGE_NO_THRESHOLDS=1 npx vitest run test/unit/plan-skipped.test.ts --coverage`
- [x] `npx diff-cover coverage/lcov.info --compare-branch=main --fail-under=99` → 100%
- [x] `npm run build --workspace @jsonbored/gittensory-engine && npm run build:miner`


Made with [Cursor](https://cursor.com)