### PR TITLE
fix(signals): classify Sass source maps as generated

### DIFF
--- a/src/signals/path-matchers.ts
+++ b/src/signals/path-matchers.ts
@@ -66,7 +66,7 @@ function isGeneratedFileFrom(parts: NormalizedPath): boolean {
     // Source maps for every first-class JS/TS bundle extension. `.mjs`/`.cjs` are already
     // recognized code extensions (isCodeFile), so their bundlers' `.mjs.map` / `.cjs.map`
     // maps are generated output too — the same as `.js.map`.
-    /\.(js|jsx|mjs|cjs|ts|tsx|mts|cts|vue|svelte|astro|mdx|scss|less|css)\.map$/.test(norm) ||
+    /\.(js|jsx|mjs|cjs|ts|tsx|mts|cts|vue|svelte|astro|mdx|scss|sass|less|css)\.map$/.test(norm) ||
     base === "worker-configuration.d.ts"
   );
 }

--- a/test/unit/path-matchers.test.ts
+++ b/test/unit/path-matchers.test.ts
@@ -38,7 +38,7 @@ describe("isGeneratedFile", () => {
     }
   });
 
-  it("matches source maps for every first-class JS/TS, MDX, and front-end framework extension", () => {
+  it("matches source maps for every first-class JS/TS, MDX, Sass/SCSS/Less, and front-end framework extension", () => {
     // `.mjs`/`.cjs` are recognized code extensions (isCodeFile), so their bundlers' source
     // maps are generated output too — the same as `.js.map` / `.tsx.map`.
     for (const path of [
@@ -52,6 +52,7 @@ describe("isGeneratedFile", () => {
       "dist/page.astro.map",
       "dist/page.mdx.map",
       "dist/styles.scss.map",
+      "dist/theme.sass.map",
       "dist/theme.less.map",
     ]) {
       expect(isGeneratedFile(path)).toBe(true);


### PR DESCRIPTION
## Summary

- Extend `isGeneratedFile` in `path-matchers.ts` to treat `.sass.map` as generated output, matching the existing `.scss.map`/`.less.map`/`.mdx.map` handling (#3376, #3446).
- Sass is a first-class front-end extension in `review/visual/paths.ts`; bundler source-map siblings were still miscounted as substantive source.

## Scope

- [x] Conventional Commit title format.
- [x] Focused — path-matchers + unit tests only.
- [x] Follows `CONTRIBUTING.md`.
- [x] No linked issue needed.

## Validation

- [x] `git diff --check`
- [x] `npm run test:ci` on Node 22
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] Unit test covers `dist/theme.sass.map` as generated via `isGeneratedFile`

## Safety

- [x] No secrets, auth, or UI changes.
- [x] N/A for UI Evidence.

## UI Evidence

N/A — backend path classifier only.

## Notes

**Conflict avoidance:** Touches only `src/signals/path-matchers.ts` and `test/unit/path-matchers.test.ts`. Zero overlap with open PRs (#3451 engine, #3450 enrichment provenance tests, #3443 selfhost, #3433 integrations, #3429 release workflow, #3414 review-evasion, #3314 miner, #3305 enrichment-wire, #3304 queue/gate). Merges cleanly after any of those land without rebase.

Made with [Cursor](https://cursor.com)