### PR TITLE
fix(orb): fail safe on a stream read error in readOrbRelayRegisterBody

### DIFF
--- a/src/orb/relay.ts
+++ b/src/orb/relay.ts
@@ -163,7 +163,13 @@ function parseContentLength(header: string | null | undefined): number | null {
   return Number.isInteger(n) && n >= 0 ? n : null;
 }
 
-/** Read the relay-registration JSON with a small hard ceiling; returns null when the sender exceeds it. */
+/** Read the relay-registration JSON with a small hard ceiling; returns null when the sender exceeds it OR when
+ *  the underlying stream itself errors (a dropped connection / network reset mid-read, #orb-broker-500 — every
+ *  caller already treats null identically to "reject this request", so a transient read failure degrades the
+ *  same way an oversized payload does, instead of throwing UNCAUGHT out of this function. Each of this
+ *  function's three route call sites (POST /v1/orb/token, /v1/orb/relay/register, /v1/orb/relay pull) calls it
+ *  BEFORE its own try/catch, so an uncaught throw here previously escaped as a bare framework 500 instead of the
+ *  route's own clean 4xx/503 JSON error response — fixed once here rather than wrapping all three callers. */
 export async function readOrbRelayRegisterBody(request: Request, contentLengthHeader: string | null | undefined): Promise<string | null> {
   const declared = parseContentLength(contentLengthHeader);
   if (declared !== null && declared > MAX_ORB_RELAY_REGISTER_BODY_BYTES) return null;
@@ -174,17 +180,21 @@ export async function readOrbRelayRegisterBody(request: Request, contentLengthHe
   const decoder = new TextDecoder();
   let total = 0;
   let out = "";
-  for (;;) {
-    const { done, value } = await reader.read();
-    if (done) break;
-    total += value.byteLength;
-    if (total > MAX_ORB_RELAY_REGISTER_BODY_BYTES) {
-      await reader.cancel();
-      return null;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > MAX_ORB_RELAY_REGISTER_BODY_BYTES) {
+        await reader.cancel();
+        return null;
+      }
+      out += decoder.decode(value, { stream: true });
     }
-    out += decoder.decode(value, { stream: true });
+    return out + decoder.decode();
+  } catch {
+    return null;
   }
-  return out + decoder.decode();
 }
 
 export type RelayEnrollment = { enrollId: string; installationId: number };

--- a/test/integration/orb-relay.test.ts
+++ b/test/integration/orb-relay.test.ts
@@ -141,6 +141,22 @@ describe("readOrbRelayRegisterBody", () => {
     const req = new Request("http://localhost/r", { method: "POST", body: "x".repeat(MAX_ORB_RELAY_REGISTER_BODY_BYTES + 1) });
     expect(await readOrbRelayRegisterBody(req, null)).toBeNull();
   });
+
+  it("REGRESSION (#orb-broker-500): returns null instead of throwing when the underlying stream errors mid-read", async () => {
+    // Simulates a dropped connection / network reset while GitHub Sentry observed as "Orb broker token exchange
+    // failed (500)" (GITTENSORY-J) — this function is called BEFORE each of its three route call sites' own
+    // try/catch, so an uncaught throw here previously escaped as a bare framework 500 rather than the route's
+    // own clean 4xx/503 JSON response. A first successful chunk (some bytes already arrived) followed by a
+    // stream error is the realistic shape of a mid-read network drop, not an error on the very first read.
+    const stream = new ReadableStream<Uint8Array>({
+      pull(controller) {
+        controller.enqueue(new TextEncoder().encode('{"relayUrl":'));
+        controller.error(new Error("simulated network reset"));
+      },
+    });
+    const req = new Request("http://localhost/r", { method: "POST", body: stream, duplex: "half" } as RequestInit);
+    await expect(readOrbRelayRegisterBody(req, null)).resolves.toBeNull();
+  });
 });
 
 describe("relaySignature", () => {


### PR DESCRIPTION
Closes #3460

## Summary

- Found via Sentry (issue GITTENSORY-J, 79 occurrences, regressed): `orb_broker_unavailable: Orb broker token exchange failed (500).` Seer's suggested framing ("wrap the entire handler in a top-level try-catch") turned out to be imprecise — the `/v1/orb/token` route (`src/api/routes.ts:3175`) already wraps its actual token-minting call (`brokerOrbToken`) in a try/catch that correctly returns a clean `503`. The real gap: `readOrbRelayRegisterBody` (`src/orb/relay.ts`), which reads the raw request body via a `ReadableStream` reader, is called **before** that try/catch at all three of its call sites (`POST /v1/orb/token`, `/v1/orb/relay/register`, `/v1/orb/relay` pull). A dropped connection or network reset mid-read throws uncaught out of this function, escaping as a bare framework 500 instead of any route's own clean 4xx/503 JSON response — exactly matching the observed "(500)" in the error text.
- Fix: wrap the read loop in `readOrbRelayRegisterBody` itself and return `null` on any stream error — the same sentinel already used uniformly by all three callers for "payload too large." This is a single-point fix (the function, not each call site) since all three routes already handle the `null` case identically.
- Closes #3460.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (clean)
- [x] `npx vitest run test/integration/orb-relay.test.ts` — 77/77 passing
- [x] Scoped coverage check (`vitest --coverage --coverage.include=src/orb/relay.ts`): 100% line coverage on the changed function; the one pre-existing uncovered branch (in an unrelated function, `shouldPersistRelayFailure`) is untouched by this change.
- [ ] `npm run test:workers` / `npm run build:mcp` / `npm run test:mcp-pack` / `npm run ui:openapi:check` / `npm run ui:build` — not run individually this PR; no worker/MCP/OpenAPI/UI surface touched.
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — added a regression test constructing a `ReadableStream` that enqueues a partial chunk then errors (simulating a realistic mid-read network drop), asserting `readOrbRelayRegisterBody` resolves to `null` instead of rejecting.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A; this is a body-parsing robustness fix, not an auth-boundary change (auth on these routes is unaffected and unconditioned on this function's return value beyond the existing null-check).
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no request/response contract change (the `413` response for `null` already existed at every call site; this only prevents an additional failure mode from bypassing it as an uncaught exception).
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI change.
- [ ] Visible UI changes include a `UI Evidence` section below. — N/A, no visible UI change.
- [ ] Public docs/changelogs are updated where needed. — N/A, internal reliability fix, no documented/user-facing behavior change.

## Notes

- Sixth fix from the live stack-health pass (Sentry + Loki audit on the self-hosted deployment); see PRs #3431, #3438, #3440, #3441, #3443 for the sibling fixes.
