### PR TITLE
feat(enrichment): unsafe-`any` (TS) counter analyzer (#2017)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,23 +67,24 @@ GITTENSORY_REVIEW_ENRICHMENT=false
 # provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig,nativeBuild
 # history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity,ciCheckSignals
 # undocumentedExport,staleBranch,commitHygiene,pendingReviewRequests,testRatio,migrationSafety
-# looseRange,terminology,todoMarker,magicNumber,conflictMarker,commitLint
+# looseRange,terminology,todoMarker,magicNumber,conflictMarker,commitLint,unsafeAny
 #
 # Profile defaults:
 # fast: dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol
 # redos,provenance,secretLog,typosquat,iacMisconfig,nativeBuild,testRatio,migrationSafety
-# looseRange,terminology,todoMarker,magicNumber,conflictMarker
+# looseRange,terminology,todoMarker,magicNumber,conflictMarker,unsafeAny
 # balanced (default): dependency,lockfileDrift,secret,license,installScript,heavyDependency
 # actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature
 # iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink
 # approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene
 # pendingReviewRequests,testRatio,migrationSafety,looseRange,terminology,todoMarker,magicNumber
-# conflictMarker,commitLint
+# conflictMarker,commitLint,unsafeAny
 # deep: dependency,lockfileDrift,secret,license,installScript,heavyDependency,actionPin,eol
 # redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature,iacMisconfig
 # nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity
 # ciCheckSignals,undocumentedExport,staleBranch,commitHygiene,pendingReviewRequests,testRatio
 # migrationSafety,looseRange,terminology,todoMarker,magicNumber,conflictMarker,commitLint
+# unsafeAny
 # END GENERATED REES ANALYZERS
 
 # Submitter-reputation spend control (internal-only): downgrades new/burst/low-rep

--- a/apps/gittensory-ui/src/lib/rees-analyzers.ts
+++ b/apps/gittensory-ui/src/lib/rees-analyzers.ts
@@ -909,6 +909,30 @@ export const REES_ANALYZERS = [
         "Structured-fields-only: reads commit.message subjects, linted independently, never cross-line state. Fail-safe on missing token/fetch error.",
     },
   },
+  {
+    name: "unsafeAny",
+    title: "Unsafe `any` usage",
+    category: "quality",
+    cost: "local",
+    defaultEnabled: true,
+    profiles: ["fast", "balanced", "deep"],
+    requires: ["files"],
+    limits: {
+      maxFindings: 50,
+      maxLineChars: 2000,
+    },
+    docs: {
+      summary:
+        "Counts and locates explicit `any` usages (`: any`, `as any`, `<any>`) newly added in TypeScript diffs.",
+      looksAt:
+        "Added lines of changed .ts/.tsx files (ambient .d.ts skipped); string- and comment-only occurrences are stripped.",
+      reports:
+        "File, line, and the `any` kind (annotation / cast / assertion) — never surrounding contents.",
+      network: "Pure local analyzer. No external network call.",
+      notes:
+        "Structural regex only — no type-checker — so it is a type-safety-erosion hint, not a definitive count.",
+    },
+  },
 ] as const satisfies readonly ReesAnalyzerDoc[];
 
 export const REES_ANALYZER_NAMES = REES_ANALYZERS.map((analyzer) => analyzer.name);

--- a/review-enrichment/analyzer-metadata.json
+++ b/review-enrichment/analyzer-metadata.json
@@ -1023,6 +1023,32 @@
         "network": "Calls the GitHub PR-commits API once, bounded to one page.",
         "notes": "Structured-fields-only: reads commit.message subjects, linted independently, never cross-line state. Fail-safe on missing token/fetch error."
       }
+    },
+    {
+      "name": "unsafeAny",
+      "title": "Unsafe `any` usage",
+      "category": "quality",
+      "cost": "local",
+      "defaultEnabled": true,
+      "profiles": [
+        "fast",
+        "balanced",
+        "deep"
+      ],
+      "requires": [
+        "files"
+      ],
+      "limits": {
+        "maxFindings": 50,
+        "maxLineChars": 2000
+      },
+      "docs": {
+        "summary": "Counts and locates explicit `any` usages (`: any`, `as any`, `<any>`) newly added in TypeScript diffs.",
+        "looksAt": "Added lines of changed .ts/.tsx files (ambient .d.ts skipped); string- and comment-only occurrences are stripped.",
+        "reports": "File, line, and the `any` kind (annotation / cast / assertion) — never surrounding contents.",
+        "network": "Pure local analyzer. No external network call.",
+        "notes": "Structural regex only — no type-checker — so it is a type-safety-erosion hint, not a definitive count."
+      }
     }
   ]
 }

--- a/review-enrichment/src/analyzers/registry.ts
+++ b/review-enrichment/src/analyzers/registry.ts
@@ -34,6 +34,7 @@ import { scanTerminology } from "./terminology.js";
 import { scanTodoMarker } from "./todo-marker.js";
 import { scanTyposquat } from "./typosquat.js";
 import { scanUndocumentedExport } from "./undocumented-export.js";
+import { scanUnsafeAny } from "./unsafe-any.js";
 import type {
   AnalyzerDescriptor,
   AnalyzerFn,
@@ -958,6 +959,36 @@ export const ANALYZER_DESCRIPTORS = [
     },
     run: (req, { signal, analysis, diagnostics }) =>
       scanCommitLint(req, fetch, { signal, analysis, diagnostics }),
+  }),
+  descriptor({
+    name: "unsafeAny",
+    title: "Unsafe `any` usage",
+    category: "quality",
+    cost: "local",
+    defaultEnabled: true,
+    requires: ["files"],
+    limits: { maxFindings: 50, maxLineChars: 2000 },
+    docs: {
+      summary: "Counts and locates explicit `any` usages (`: any`, `as any`, `<any>`) newly added in TypeScript diffs.",
+      looksAt: "Added lines of changed .ts/.tsx files (ambient .d.ts skipped); string- and comment-only occurrences are stripped.",
+      reports: "File, line, and the `any` kind (annotation / cast / assertion) — never surrounding contents.",
+      network: "Pure local analyzer. No external network call.",
+      notes:
+        "Structural regex only — no type-checker — so it is a type-safety-erosion hint, not a definitive count.",
+    },
+    render: (findings, helpers) => {
+      if (!findings.length) return [];
+      const byKind = { annotation: 0, cast: 0, assertion: 0 };
+      for (const item of findings) byKind[item.kind] += 1;
+      const lines = [
+        `### New unsafe \`any\` usages (type-safety erosion) — ${byKind.annotation} \`: any\`, ${byKind.cast} \`as any\`, ${byKind.assertion} \`<any>\``,
+      ];
+      for (const item of findings) {
+        lines.push(`- ${helpers.safeCodeSpan(`${item.file}:${item.line}`)} — ${item.kind} \`any\``);
+      }
+      return lines;
+    },
+    run: (req) => scanUnsafeAny(req),
   }),
 ] as const satisfies readonly AnyAnalyzerDescriptor[];
 

--- a/review-enrichment/src/analyzers/unsafe-any.ts
+++ b/review-enrichment/src/analyzers/unsafe-any.ts
@@ -1,0 +1,78 @@
+// Unsafe-`any` counter (#2017, part of #1499). A LOCAL analyzer (no network) that counts and locates explicit `any`
+// usages NEWLY ADDED in a TypeScript diff — `: any` annotations, `as any` casts, and `<any>` assertions — a
+// type-safety-erosion signal a reviewer can weigh. Structural regex ONLY (no type-checker); occurrences inside
+// string literals or comments are cheaply stripped first to avoid false positives. Fail-safe and bounded
+// (maxFindings). Scans added lines of `.ts`/`.tsx` files only; ambient `.d.ts` declarations are skipped.
+import type { EnrichRequest, UnsafeAnyFinding } from "../types.js";
+
+const MAX_FINDINGS = 50;
+const MAX_LINE_CHARS = 2000; // skip pathologically long (e.g. minified) lines rather than scan them
+const TS_RE = /\.tsx?$/;
+const SKIP_RE = /\.d\.ts$/; // ambient declarations legitimately use `any`; not hand-authored surface
+
+// `cast`/`assertion` are matched before the broad `: any` so each syntactic form is labelled by its own pattern.
+const PATTERNS: ReadonlyArray<{ re: RegExp; kind: UnsafeAnyFinding["kind"] }> = [
+  { re: /\bas\s+any\b/g, kind: "cast" }, // `x as any`
+  { re: /<\s*any\s*>/g, kind: "assertion" }, // `<any>x` (and, structurally, `Array<any>` — still an unsafe any)
+  { re: /:\s*any\b/g, kind: "annotation" }, // `x: any`
+];
+
+/** Blank out string literals and comments so an `any` inside them is not counted. Cheap + line-local: a comment-only
+ *  line (`//`, `*`, `/*`) yields empty; inline strings, `/* … */` spans, and `// …` tails are removed. Pure. */
+export function stripStringsAndComments(line: string): string {
+  const trimmed = line.trimStart();
+  if (trimmed.startsWith("//") || trimmed.startsWith("*") || trimmed.startsWith("/*")) return "";
+  return line
+    .replace(/(['"`])(?:\\.|(?!\1)[^\\])*\1/g, "") // string / template literals
+    .replace(/\/\*.*?\*\//g, "") // inline block comments
+    .replace(/\/\/.*$/, ""); // trailing line comment
+}
+
+/** The unsafe-`any` kinds on a single added code line, one entry per occurrence. Pure. */
+export function findUnsafeAnyOnLine(line: string): Array<UnsafeAnyFinding["kind"]> {
+  if (line.length > MAX_LINE_CHARS) return [];
+  const code = stripStringsAndComments(line);
+  const kinds: Array<UnsafeAnyFinding["kind"]> = [];
+  for (const { re, kind } of PATTERNS) {
+    re.lastIndex = 0;
+    while (re.exec(code) !== null) kinds.push(kind);
+  }
+  return kinds;
+}
+
+/** Walk a unified-diff patch and report each unsafe-`any` on an ADDED line, with its new-file line number. Tracks
+ *  the new-file cursor via hunk headers; `-`/`\` lines never advance it, `+++`/`---` headers are ignored. Pure. */
+export function scanPatchForUnsafeAny(path: string, patch: string): UnsafeAnyFinding[] {
+  const findings: UnsafeAnyFinding[] = [];
+  let newLine = 0;
+  for (const raw of patch.split("\n")) {
+    const header = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(raw);
+    if (header) {
+      newLine = Number(header[1]);
+      continue;
+    }
+    if (raw.startsWith("+")) {
+      if (!raw.startsWith("+++")) {
+        for (const kind of findUnsafeAnyOnLine(raw.slice(1))) findings.push({ file: path, line: newLine, kind });
+        newLine += 1;
+      }
+    } else if (!raw.startsWith("-") && !raw.startsWith("\\")) {
+      newLine += 1; // context line advances the new-file cursor
+    }
+  }
+  return findings;
+}
+
+/** Analyzer entrypoint: added `any` usages across changed `.ts`/`.tsx` files. Local + fail-safe; bounded by
+ *  maxFindings. */
+export async function scanUnsafeAny(req: EnrichRequest): Promise<UnsafeAnyFinding[]> {
+  const findings: UnsafeAnyFinding[] = [];
+  for (const file of req.files ?? []) {
+    if (!file.patch || !TS_RE.test(file.path) || SKIP_RE.test(file.path)) continue;
+    for (const finding of scanPatchForUnsafeAny(file.path, file.patch)) {
+      findings.push(finding);
+      if (findings.length >= MAX_FINDINGS) return findings;
+    }
+  }
+  return findings;
+}

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -481,6 +481,7 @@ export function renderBrief(
   lines.push(...renderDescriptorSection("magicNumber", findings.magicNumber));
   lines.push(...renderDescriptorSection("conflictMarker", findings.conflictMarker));
   lines.push(...renderDescriptorSection("commitLint", findings.commitLint));
+  lines.push(...renderDescriptorSection("unsafeAny", findings.unsafeAny));
 
   if (!lines.length) return { promptSection: "", systemSuffix: "" };
 

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -348,6 +348,15 @@ export interface UndocumentedExportFinding {
   symbol: string;
 }
 
+/** An explicit `any` usage newly ADDED in a TypeScript diff — a type-safety-erosion signal. `annotation` = `: any`,
+ *  `cast` = `as any`, `assertion` = `<any>`. Structural (regex) only; reports the file + line + kind, never
+ *  surrounding contents. (#2017) */
+export interface UnsafeAnyFinding {
+  file: string;
+  line: number;
+  kind: "annotation" | "cast" | "assertion";
+}
+
 /** A review/approval integrity signal, read from structured PR-reviews API fields only (state, commit_id,
  *  user.login, submitted_at) — never diff/file content. `stale-approval`: the reviewer's latest APPROVED review
  *  predates the PR's current head commit. `self-approval`: the PR author approved their own PR.
@@ -511,6 +520,7 @@ export interface BriefFindings {
   magicNumber?: MagicNumberFinding[];
   conflictMarker?: ConflictMarkerFinding[];
   commitLint?: CommitLintFinding[];
+  unsafeAny?: UnsafeAnyFinding[];
 }
 
 /** A JSDoc/TSDoc block whose `@param` tags name parameters the adjacent function no longer declares — a

--- a/review-enrichment/test/analyzer-registry.test.ts
+++ b/review-enrichment/test/analyzer-registry.test.ts
@@ -46,6 +46,7 @@ const EXPECTED_ANALYZERS = [
   "magicNumber",
   "conflictMarker",
   "commitLint",
+  "unsafeAny",
 ];
 
 test("analyzer descriptors cover the runtime registry in stable order", () => {

--- a/review-enrichment/test/unsafe-any.test.ts
+++ b/review-enrichment/test/unsafe-any.test.ts
@@ -1,0 +1,82 @@
+// Units for the unsafe-`any` counter (#2017). Own file (not enrichment.test.ts) so concurrent analyzer PRs don't
+// collide. Pure local analyzer — no network. Runs against the compiled dist/.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  stripStringsAndComments,
+  findUnsafeAnyOnLine,
+  scanPatchForUnsafeAny,
+  scanUnsafeAny,
+} from "../dist/analyzers/unsafe-any.js";
+import { renderBrief } from "../dist/render.js";
+
+const req = (files) => ({ repoFullName: "octo/repo", prNumber: 1, files });
+
+test("findUnsafeAnyOnLine: classifies annotation, cast, and assertion (and multiples on one line)", () => {
+  assert.deepEqual(findUnsafeAnyOnLine("function f(x: any) {}"), ["annotation"]);
+  assert.deepEqual(findUnsafeAnyOnLine("const y = z as any;"), ["cast"]);
+  assert.deepEqual(findUnsafeAnyOnLine("const w = <any>v;"), ["assertion"]);
+  // both an annotation and a cast on the same line
+  assert.deepEqual(findUnsafeAnyOnLine("const a: any = b as any;").sort(), ["annotation", "cast"]);
+  assert.deepEqual(findUnsafeAnyOnLine("const clean = 1;"), []);
+});
+
+test("stripStringsAndComments: an `any` inside a string or comment is not counted", () => {
+  assert.deepEqual(findUnsafeAnyOnLine('const s = "not: any here";'), []); // inside a string literal
+  assert.deepEqual(findUnsafeAnyOnLine("const n = 1; // x: any in a comment"), []); // trailing line comment
+  assert.deepEqual(findUnsafeAnyOnLine("// : any comment-only line"), []); // comment-only line
+  assert.deepEqual(findUnsafeAnyOnLine(" * @param x: any (jsdoc body)"), []); // block-comment body line
+  // a REAL annotation still counts even with a decoy `any` inside a string on the same line
+  assert.deepEqual(findUnsafeAnyOnLine('const obj: any = "x: any";'), ["annotation"]);
+  assert.equal(stripStringsAndComments('x = "a: any"').includes("any"), false);
+});
+
+test("scanPatchForUnsafeAny: reports each added `any` with its new-file line number", () => {
+  const patch = [
+    "@@ -0,0 +1,4 @@",
+    "+function f(x: any) {}",
+    "+const y = z as any;",
+    "+const w = <any>v;",
+    '+const s = "not: any here";',
+  ].join("\n");
+  assert.deepEqual(scanPatchForUnsafeAny("src/a.ts", patch), [
+    { file: "src/a.ts", line: 1, kind: "annotation" },
+    { file: "src/a.ts", line: 2, kind: "cast" },
+    { file: "src/a.ts", line: 3, kind: "assertion" },
+  ]);
+});
+
+test("scanUnsafeAny: scans .ts/.tsx only — non-TS and .d.ts files are skipped", async () => {
+  const patch = "@@ -0,0 +1,1 @@\n+const x: any = 1;";
+  const findings = await scanUnsafeAny(
+    req([
+      { path: "src/a.ts", status: "modified", patch }, // scanned
+      { path: "src/b.tsx", status: "modified", patch }, // scanned
+      { path: "src/c.js", status: "modified", patch }, // skipped (not TS)
+      { path: "README.md", status: "modified", patch }, // skipped
+      { path: "src/types.d.ts", status: "modified", patch }, // skipped (ambient)
+    ]),
+  );
+  assert.deepEqual(findings, [
+    { file: "src/a.ts", line: 1, kind: "annotation" },
+    { file: "src/b.tsx", line: 1, kind: "annotation" },
+  ]);
+  const brief = renderBrief({ unsafeAny: findings }).promptSection;
+  assert.match(brief, /New unsafe .*any.* usages/i);
+  assert.match(brief, /src\/a\.ts:1/);
+});
+
+test("scanUnsafeAny: caps the number of findings", async () => {
+  const lines = ["@@ -0,0 +1,60 @@"];
+  for (let i = 0; i < 60; i++) lines.push("+const x: any = 1;");
+  const findings = await scanUnsafeAny(req([{ path: "src/a.ts", status: "modified", patch: lines.join("\n") }]));
+  assert.equal(findings.length, 50); // MAX_FINDINGS
+});
+
+test("scanUnsafeAny: a file with no patch or no `any` yields nothing", async () => {
+  assert.deepEqual(await scanUnsafeAny(req([{ path: "src/a.ts", status: "added" }])), []); // no patch
+  assert.deepEqual(
+    await scanUnsafeAny(req([{ path: "src/a.ts", status: "modified", patch: "@@ -0,0 +1,1 @@\n+const x = 1;" }])),
+    [],
+  );
+});


### PR DESCRIPTION
Closes #2017 (part of #1499).

New REES **local** analyzer (no network): counts and locates explicit `any` usages **newly added** in TypeScript diffs — `: any` annotations, `as any` casts, and `<any>` assertions — a type-safety-erosion signal a reviewer can weigh. **Structural regex only** (no type-checker), fail-safe.

## Deliverables
- **`types.ts`** — `UnsafeAnyFinding` (`{ file, line, kind: 'annotation' | 'cast' | 'assertion' }`) + `unsafeAny?` on `BriefFindings`.
- **`analyzers/unsafe-any.ts`**:
  - `stripStringsAndComments(line)` — blanks string literals, inline `/* */`, `//` tails, and comment-only lines so an `any` inside a string/comment isn't counted.
  - `findUnsafeAnyOnLine(line)` — one entry per occurrence, classified by pattern.
  - `scanPatchForUnsafeAny(path, patch)` — walks the diff, reporting each added-line `any` with its new-file line number.
  - `scanUnsafeAny(req)` — scans added lines of changed `.ts`/`.tsx` files (skips ambient `.d.ts`), bounded by `maxFindings` (50).
- **`registry.ts`** — descriptor (`category: quality`, `cost: local`, `requires: ['files']`) with an inline `render()` summarizing counts by kind.
- **`render.ts`** — dispatches the `unsafeAny` section.
- Regenerated `analyzer-metadata.json`, `.env.example`, and UI metadata; added `unsafeAny` to the registry meta-test's expected list.
- **`test/unsafe-any.test.ts`** — annotation vs cast vs assertion (+ multiples per line), string/comment false-positive avoidance, non-TS / `.d.ts` skip, new-file line numbers, and the cap.

## Validation
Full `review-enrichment` suite (build + sourcemaps + `metadata --check` + `node:test`):

```
ℹ tests 1001
ℹ pass 1001
ℹ fail 0
```

Includes the new unit tests and the "generated analyzer metadata matches the runtime registry" check, so the metadata/`.env`/UI regeneration stays consistent with the descriptor.