### PR TITLE
fix(signals): classify HTML source maps as generated

### DIFF
--- a/src/signals/path-matchers.ts
+++ b/src/signals/path-matchers.ts
@@ -66,7 +66,7 @@ function isGeneratedFileFrom(parts: NormalizedPath): boolean {
     // Source maps for every first-class JS/TS bundle extension. `.mjs`/`.cjs` are already
     // recognized code extensions (isCodeFile), so their bundlers' `.mjs.map` / `.cjs.map`
     // maps are generated output too — the same as `.js.map`.
-    /\.(js|jsx|mjs|cjs|ts|tsx|mts|cts|vue|svelte|astro|mdx|scss|sass|less|css)\.map$/.test(norm) ||
+    /\.(js|jsx|mjs|cjs|ts|tsx|mts|cts|vue|svelte|astro|mdx|scss|sass|less|html|css)\.map$/.test(norm) ||
     base === "worker-configuration.d.ts"
   );
 }

--- a/test/unit/path-matchers.test.ts
+++ b/test/unit/path-matchers.test.ts
@@ -38,7 +38,7 @@ describe("isGeneratedFile", () => {
     }
   });
 
-  it("matches source maps for every first-class JS/TS, MDX, Sass/SCSS/Less, and front-end framework extension", () => {
+  it("matches source maps for every first-class JS/TS, MDX, HTML, Sass/SCSS/Less, and front-end framework extension", () => {
     // `.mjs`/`.cjs` are recognized code extensions (isCodeFile), so their bundlers' source
     // maps are generated output too — the same as `.js.map` / `.tsx.map`.
     for (const path of [
@@ -54,6 +54,7 @@ describe("isGeneratedFile", () => {
       "dist/styles.scss.map",
       "dist/theme.sass.map",
       "dist/theme.less.map",
+      "dist/index.html.map",
     ]) {
       expect(isGeneratedFile(path)).toBe(true);
     }


### PR DESCRIPTION
## Summary

- Extend `isGeneratedFile` in `path-matchers.ts` to treat `.html.map` as generated output, matching the existing `.vue.map`/`.mdx.map`/`.sass.map` handling (#3357, #3446, #3453).
- HTML is a first-class front-end extension in `review/visual/paths.ts`; bundler source-map siblings were still miscounted as substantive source.

## Scope

- [x] Conventional Commit title format.
- [x] Focused — path-matchers + unit tests only.
- [x] Follows `CONTRIBUTING.md`.
- [x] No linked issue needed.

## Validation

- [x] `git diff --check`
- [x] `npm run test:ci` on Node 22
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] Unit test covers `dist/index.html.map` as generated via `isGeneratedFile`

## Safety

- [x] No secrets, auth, or UI changes.
- [x] N/A for UI Evidence.

## UI Evidence

N/A — backend path classifier only.

## Notes

**Conflict avoidance:** Touches only `src/signals/path-matchers.ts` and `test/unit/path-matchers.test.ts`. Zero overlap with open PRs (#3457 enrichment, #3456 orb relay, #3455/#3304 queue, #3454 review-eligibility, #3452 focus-manifest tests, #3451 engine, #3443 selfhost, #3433 integrations, #3414 review-evasion, #3314 miner, #3305 enrichment-wire). Merges cleanly after any of those land without rebase.

Made with [Cursor](https://cursor.com)