### PR TITLE
fix(engine): reject malformed historical replay calibration scores

### DIFF
--- a/packages/gittensory-engine/src/phase7-calibration-loop.ts
+++ b/packages/gittensory-engine/src/phase7-calibration-loop.ts
@@ -331,9 +331,11 @@ export function shouldScheduleHistoricalReplayRun(input: {
 
 function extractHistoricalReplayScore(
   compositeScore: number | GateVerdictCompositeCalibrationScore,
-): number {
-  if (typeof compositeScore === "number") return roundScore(compositeScore);
-  return roundScore(compositeScore.compositeScore);
+): number | null {
+  const rawScore =
+    typeof compositeScore === "number" ? compositeScore : compositeScore.compositeScore;
+  if (!Number.isFinite(rawScore)) return null;
+  return roundScore(rawScore);
 }
 
 /**
@@ -423,6 +425,10 @@ export function computePhase7CalibrationLoop(input: {
       replayHarnessHold = true;
       holdReasons.push("replay_run_stale");
       rejectedSources.push({ source: "historical_replay", reason: "replay_run_stale" });
+    } else if (accuracy === null) {
+      replayHarnessHold = true;
+      holdReasons.push("invalid_replay_score");
+      rejectedSources.push({ source: "historical_replay", reason: "invalid_replay_score" });
     } else {
       contributingSources.push("historical_replay");
     }

--- a/packages/gittensory-engine/test/phase7-calibration-loop.test.ts
+++ b/packages/gittensory-engine/test/phase7-calibration-loop.test.ts
@@ -345,6 +345,28 @@ test("computePhase7CalibrationLoop fails closed when the replay harness is degra
   }
 });
 
+test("REGRESSION: malformed historical replay scores fail closed instead of permitting autonomy increases", () => {
+  for (const compositeScore of [{} as never, Number.NaN, Number.POSITIVE_INFINITY] as const) {
+    const result = computePhase7CalibrationLoop({
+      config: enabledConfig({ autonomyIncreaseMinAccuracy: 0.99 }),
+      prOutcome: sufficientPrOutcome(1),
+      historicalReplay: {
+        ...healthyReplay(0.82),
+        compositeScore,
+      },
+      now: NOW,
+    });
+
+    assert.equal(result.bySource.historical_replay.accuracy, null);
+    assert.equal(result.combinedAccuracy, 1);
+    assert.equal(result.replayHarnessHold, true);
+    assert.equal(result.autonomyIncreasePermitted, false);
+    assert.ok(result.holdReasons.includes("invalid_replay_score"));
+    assert.ok(!result.audit.contributingSources.includes("historical_replay"));
+    assert.ok(result.audit.rejectedSources.some((row) => row.reason === "invalid_replay_score"));
+  }
+});
+
 test("computePhase7CalibrationLoop fails closed on stale replay rather than silently using pr_outcome only", () => {
   const result = computePhase7CalibrationLoop({
     config: enabledConfig(),


### PR DESCRIPTION
### Motivation
- A malformed or non-finite historical replay `compositeScore` could propagate `NaN` into the combined calibration accuracy and allow the autonomy-increase gate to fail open, violating the intended fail-closed behavior. 
- The code previously accepted history replay inputs based only on metadata/freshness and harness status without validating that the extracted score is a finite number.

### Description
- Change `extractHistoricalReplayScore` to return `null` for missing/non-finite values and to return a `number | null` so malformed scores are explicitly rejected instead of producing `NaN` via `roundScore`.
- When a historical replay `accuracy` is `null`, mark the replay as held (`replayHarnessHold = true`), record the hold reason `invalid_replay_score`, and add a rejected source entry so malformed replay signals cannot contribute to `contributingSources`.
- Add a regression test that exercises object-shaped/malformed, `NaN`, and `Infinity` `compositeScore` inputs and asserts the replay source is rejected, `autonomyIncreasePermitted` remains `false`, and the `invalid_replay_score` hold is recorded.

### Testing
- Ran the package build with `npm --workspace @jsonbored/gittensory-engine run build`, which completed successfully. 
- Executed the Phase 7 unit file with `node --test packages/gittensory-engine/test/phase7-calibration-loop.test.ts`, and all tests in that file passed (new regression included). 
- Attempted the full coverage run with `npm run test:coverage`, but the unsharded full test suite did not complete due to unrelated timeouts/failures in other tests during this environment run; therefore full-coverage validation in this environment did not finish.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a090b6e4c832c843b82c152fd4571)