### PR TITLE
fix(signals): classify Objective-C protobuf stubs as generated

### DIFF
--- a/src/signals/path-matchers.ts
+++ b/src/signals/path-matchers.ts
@@ -52,9 +52,12 @@ function isGeneratedFileFrom(parts: NormalizedPath): boolean {
     /\.(generated|gen)\.[^/]+$/.test(norm) ||
     // protoc output: Go/TS/JS plugins emit `.pb.{go,ts,js}`, the reference C++ plugin emits
     // `.pb.cc` / `.pb.h`, the Swift plugin emits `.pb.swift`, the Dart plugin emits `.pb.dart`,
-    // the Kotlin plugin emits `.pb.kt`, and the C# plugin emits `.pb.cs`.
+    // the Kotlin plugin emits `.pb.kt`, the C# plugin emits `.pb.cs`, and the Objective-C plugin
+    // emits `.pbobjc.{h,m}` plus gRPC `.pbrpc.{h,m}` service stubs.
     // `.pb.dart`/`.pb.kt`/`.pb.cs` (the `.pb` infix keeps hand-written sources from matching).
     /\.pb\.(go|ts|js|cc|h|swift|dart|kt|cs)$/.test(norm) ||
+    /\.pbobjc\.(h|m)$/.test(norm) ||
+    /\.pbrpc\.(h|m)$/.test(norm) ||
     // Python protobuf: message stubs are `*_pb2.py[i]`; the gRPC plugin emits sibling
     // `*_pb2_grpc.py[i]` service stubs, which are the same machine-generated output.
     /_pb2(_grpc)?\.pyi?$/.test(norm) ||
@@ -63,9 +66,9 @@ function isGeneratedFileFrom(parts: NormalizedPath): boolean {
     /\.(g|freezed|gr)\.dart$/.test(norm) ||
     // C# codegen: WinForms/WPF designer partials (`.designer.cs`) and XAML/T4 output (`.g.cs`).
     /\.(designer|g)\.cs$/.test(norm) ||
-    // Source maps for every first-class JS/TS bundle extension. `.mjs`/`.cjs` are already
-    // recognized code extensions (isCodeFile), so their bundlers' `.mjs.map` / `.cjs.map`
-    // maps are generated output too — the same as `.js.map`.
+    // Source maps for bundler/front-end output across JS/TS, frameworks, stylesheets, HTML, and SVG.
+    // `.mjs`/`.cjs` are already recognized code extensions (isCodeFile), so their bundlers'
+    // `.mjs.map` / `.cjs.map` maps are generated output too — the same as `.js.map`.
     /\.(js|jsx|mjs|cjs|ts|tsx|mts|cts|vue|svelte|astro|mdx|scss|sass|less|html|svg|css)\.map$/.test(norm) ||
     base === "worker-configuration.d.ts"
   );

--- a/test/unit/path-matchers.test.ts
+++ b/test/unit/path-matchers.test.ts
@@ -77,12 +77,16 @@ describe("isGeneratedFile", () => {
     }
   });
 
-  it("matches Swift protobuf, Dart freezed/retrofit, and C# designer/XAML codegen", () => {
+  it("matches Swift protobuf, Dart freezed/retrofit, C# designer/XAML, and Objective-C protoc output", () => {
     for (const path of [
       "proto/messages.pb.swift",
       "proto/messages.pb.dart",
       "proto/messages.pb.kt",
       "proto/messages.pb.cs",
+      "proto/messages.pbobjc.h",
+      "proto/messages.pbobjc.m",
+      "proto/messages.pbrpc.h",
+      "proto/messages.pbrpc.m",
       "lib/user.freezed.dart",
       "lib/api_client.gr.dart",
       "ui/MainForm.Designer.cs",
@@ -91,7 +95,7 @@ describe("isGeneratedFile", () => {
       expect(isGeneratedFile(path)).toBe(true);
     }
     // hand-written siblings must NOT match (the codegen infix is required).
-    for (const path of ["src/MainForm.cs", "lib/user.dart", "src/service.kt", "net/message.swift"]) {
+    for (const path of ["src/MainForm.cs", "lib/user.dart", "src/service.kt", "net/message.swift", "src/App.h", "src/App.m"]) {
       expect(isGeneratedFile(path)).toBe(false);
     }
   });


### PR DESCRIPTION
## Summary

Extend `isGeneratedFile` to recognize protoc Objective-C output (`.pbobjc.h` / `.pbobjc.m`) and gRPC Objective-C service stubs (`.pbrpc.h` / `.pbrpc.m`), matching the existing `.pb.*` plugin coverage for Go/TS/JS/C++/Swift/Dart/Kotlin/C#.

Fixes #561

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- None skipped.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — signals-only change with no visible UI.

## Notes

Incremental **maintenance** parity for the path-matcher slop signals from #561. Supports generated-file classification work tracked in #2143.

Made with [Cursor](https://cursor.com)