### PR TITLE
feat(engine): add ENGINE_VERSION semver pin

### DIFF
--- a/packages/gittensory-engine/README.md
+++ b/packages/gittensory-engine/README.md
@@ -11,6 +11,11 @@ The logic is extracted from the app's `src/` in follow-up issues; this skeleton 
 the meantime. The root `package.json` already globs `packages/*` in its `workspaces` field, so `npm ci`
 discovers this package with no additional wiring.
 
+## Version pin
+
+`ENGINE_VERSION` mirrors `package.json`'s `version` field and is exported from the package barrel so consumers can
+log or assert which engine build produced a deterministic result.
+
 ## Build
 
 ```

--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -4,6 +4,7 @@
 // backend and the gittensory-miner (scoring preview/model, predicted-gate types, reward-risk, slop signals,
 // focus-manifest parse/compile core, duplicate-winner adjudication, and their engine-parity fixtures).
 // More modules land in follow-up issues.
+export { ENGINE_VERSION } from "./version.js";
 export {
   pickTopRankedOpportunities,
   rankOpportunityScore,

--- a/packages/gittensory-engine/src/version.ts
+++ b/packages/gittensory-engine/src/version.ts
@@ -1,0 +1,5 @@
+/**
+ * Published semver of `@jsonbored/gittensory-engine`. Keep in lockstep with `package.json` `version`
+ * (enforced by `test/unit/engine-version.test.ts`).
+ */
+export const ENGINE_VERSION = "0.1.0";

--- a/test/unit/engine-version.test.ts
+++ b/test/unit/engine-version.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+import { ENGINE_VERSION } from "../../packages/gittensory-engine/src/version";
+
+const pkgPath = join(dirname(fileURLToPath(import.meta.url)), "../../packages/gittensory-engine/package.json");
+
+describe("ENGINE_VERSION", () => {
+  it("matches packages/gittensory-engine/package.json version", () => {
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf8")) as { version: string };
+    expect(ENGINE_VERSION).toBe(pkg.version);
+  });
+
+  it("is exported from the package barrel", async () => {
+    const barrel = await import("../../packages/gittensory-engine/src/index");
+    expect(barrel.ENGINE_VERSION).toBe(ENGINE_VERSION);
+    expect(barrel.ENGINE_VERSION.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Closes #2284

## Summary
- Add `ENGINE_VERSION` in `@jsonbored/gittensory-engine`, kept in lockstep with `package.json` `version` via vitest.
- Document the version pin in `packages/gittensory-engine/README.md`.
- `PredictedGateVerdict.engineVersion` wiring is deferred until predicted-gate types land in the engine package (#2276).

## Test plan
- [x] `COVERAGE_NO_THRESHOLDS=1 npx vitest run test/unit/engine-version.test.ts --coverage`
- [x] `npx diff-cover coverage/lcov.info --compare-branch=main --fail-under=99` → 100%
- [x] `npm run build --workspace @jsonbored/gittensory-engine && npm run build:miner`


Made with [Cursor](https://cursor.com)