### PR TITLE
test(review): document the last unreachable review-evasion coverage branch

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -10652,11 +10652,16 @@ async function closeReviewEvasionSelfCloseIfActive(
     // this enforcement. Propagate so the queue's own retry/backoff re-processes this job; on retry, the live
     // freshness check earlier in this function will see the PR as open (current, since we just reopened it)
     // and this handler will attempt the re-close again, converging once closePullRequest actually succeeds.
-    // The `: new Error(...)` fallback is unreachable in practice -- closePullRequest's only failure path is
-    // Octokit's `request()` call, which always rejects with a RequestError (an Error subclass), never a raw
-    // thrown value -- but `closeError` is typed `unknown`, so the branch stays as a type-safe normalization.
-    /* v8 ignore next */
-    throw closeError instanceof Error ? closeError : new Error(errorMessage(closeError));
+    // The `else` (closeError NOT an Error, falling through to the normalization below) is unreachable in
+    // practice -- closePullRequest's only failure path is Octokit's `request()` call, which always rejects
+    // with a RequestError (an Error subclass), never a raw thrown value -- but `closeError` is typed
+    // `unknown`, so the fallback below stays as a type-safe normalization. The `if` body itself (the real
+    // rethrow) IS reachable and IS exercised by the existing re-close-failure tests -- only the else branch
+    // (this `if`'s implicit non-Error path) and the fallback statement below are ignored.
+    /* v8 ignore else */
+    if (closeError instanceof Error) throw closeError;
+    /* v8 ignore next -- unreachable, see above. */
+    throw new Error(errorMessage(closeError));
   }
 
   // The close succeeded: post the public explanation, apply the configured label, record the strike -- in

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -10652,6 +10652,10 @@ async function closeReviewEvasionSelfCloseIfActive(
     // this enforcement. Propagate so the queue's own retry/backoff re-processes this job; on retry, the live
     // freshness check earlier in this function will see the PR as open (current, since we just reopened it)
     // and this handler will attempt the re-close again, converging once closePullRequest actually succeeds.
+    // The `: new Error(...)` fallback is unreachable in practice -- closePullRequest's only failure path is
+    // Octokit's `request()` call, which always rejects with a RequestError (an Error subclass), never a raw
+    // thrown value -- but `closeError` is typed `unknown`, so the branch stays as a type-safe normalization.
+    /* v8 ignore next */
     throw closeError instanceof Error ? closeError : new Error(errorMessage(closeError));
   }
 

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -10657,7 +10657,10 @@ async function closeReviewEvasionSelfCloseIfActive(
     // with a RequestError (an Error subclass), never a raw thrown value -- but `closeError` is typed
     // `unknown`, so the fallback below stays as a type-safe normalization. The `if` body itself (the real
     // rethrow) IS reachable and IS exercised by the existing re-close-failure tests -- only the else branch
-    // (this `if`'s implicit non-Error path) and the fallback statement below are ignored.
+    // (this `if`'s implicit non-Error path) and the fallback statement below are ignored. Concretely: a 500
+    // from GitHub on the re-close PATCH makes closePullRequest reject with a RequestError, which is exactly
+    // what test/unit/queue.test.ts's "REGRESSION (gate-flagged): a retry after the re-close failure
+    // converges -- the PR ends up closed, and the strike is recorded exactly once" drives through this `if`.
     /* v8 ignore else */
     if (closeError instanceof Error) throw closeError;
     /* v8 ignore next -- unreachable, see above. */


### PR DESCRIPTION
## Summary

- Small follow-up to #3414 (review-evasion protection). Adds a `/* v8 ignore next */` annotation with an explanatory comment on the one remaining defensive fallback branch in `closeReviewEvasionSelfCloseIfActive`: `closeError instanceof Error ? closeError : new Error(errorMessage(closeError))`.
- `closePullRequest`'s only failure path is Octokit's `request()` call, which always rejects with a `RequestError` (an `Error` subclass) -- the `new Error(...)` normalization arm is a type-safety fallback for the `unknown`-typed catch, not a reachable runtime path. Documents that explicitly rather than leaving it silently uncovered.
- No functional change.
- Follow-up within this same PR: the ignore was initially placed on the whole ternary throw, which could have suppressed coverage for the REACHABLE `closeError instanceof Error` rethrow path too. Rewrote it as an `if` block (`if (closeError instanceof Error) throw closeError;`) with `/* v8 ignore else */` scoping the ignore to only the unreachable non-Error fallback, so the reachable rethrow stays fully subject to coverage.

No issue because this is a maintenance-only coverage annotation (chore): a one-line `v8 ignore` comment tightening patch coverage on an already-merged PR (#3414), with no functional or behavioral change to review against.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` (n/a -- no workflow changes)
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers` (n/a -- no workers-pool test changes)
- [ ] `npm run build:mcp` (n/a -- no MCP package changes)
- [ ] `npm run test:mcp-pack` (n/a -- no MCP package changes)
- [ ] `npm run ui:openapi:check` (n/a -- no OpenAPI/schema changes)
- [ ] `npm run ui:lint` (n/a -- no UI changes)
- [ ] `npm run ui:typecheck` (n/a -- no UI changes)
- [ ] `npm run ui:build` (n/a -- no UI changes)
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries (n/a -- a comment-only coverage annotation, no new behavior; existing review-evasion tests in `test/unit/queue.test.ts` re-run clean)

If any required check was skipped, explain why:

- This is a single-line comment addition inside one already-tested file (`src/queue/processors.ts`); the workers/mcp/ui suites are unaffected by a comment change, so only `typecheck` and the affected test file (`test/unit/queue.test.ts`, review-evasion suite) were re-run directly, per this repo's usual scoped-validation practice for small follow-ups.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (n/a)
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. (n/a)
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (n/a -- no UI changes)
- [ ] Visible UI changes include a `UI Evidence` section below with screenshots. (n/a -- no visible UI)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (n/a -- comment-only)

