### PR TITLE
test(review): cover the markAiReviewPublished write-failure fail-open path

### DIFF
--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -2985,7 +2985,7 @@ describe("queue processors", () => {
     ).resolves.toBeUndefined();
 
     expect(commentPosted).toBe(true); // the surface published despite the ai_review_cache marker write throwing
-    expect(markSpy).toHaveBeenCalled();
+    expect(markSpy).toHaveBeenCalledWith(env, "JSONbored/gittensory", 7, "a7"); // ties this regression to the real write path, not any call
     markSpy.mockRestore();
   });
 

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -2949,6 +2949,46 @@ describe("queue processors", () => {
     stampSpy.mockRestore();
   });
 
+  it("#regate-churn: a failing markAiReviewPublished stamp is swallowed (fail-open) — the publish still completes", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", commentMode: "all_prs", publicSurface: "comment_only", autoLabelEnabled: false, checkRunMode: "off", gateCheckMode: "enabled", aiReviewMode: "off", gatePack: "oss-anti-slop" });
+    const markSpy = vi.spyOn(repositoriesModule, "markAiReviewPublished").mockRejectedValueOnce(new Error("D1 stamp failed"));
+    let commentPosted = false;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/pulls/7/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+export const ok = true;" }]);
+      if (url.endsWith("/pulls/7")) return Response.json({ number: 7, title: "Clean PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "Closes #1" });
+      if (url.includes("/commits/a7/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/commits/a7/status")) return Response.json({ state: "success", statuses: [] });
+      if (url.includes("/issues/1")) return Response.json({ number: 1, title: "Issue", state: "open", labels: [], user: { login: "reporter" } });
+      if (url.includes("/issues/7/comments") && method === "GET") return Response.json([]);
+      if (url.includes("/issues/7/comments") && method === "POST") { commentPosted = true; return Response.json({ id: 1 }, { status: 201 }); }
+      if (url.includes("/branches/")) return Response.json({ protected: false, protection: { required_status_checks: { contexts: [] } } });
+      return Response.json({});
+    });
+
+    await expect(
+      processJob(env, {
+        type: "github-webhook",
+        deliveryId: "ai-review-published-stamp-failopen",
+        eventName: "pull_request",
+        payload: {
+          action: "opened",
+          installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+          repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+          pull_request: { number: 7, title: "Clean PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "Closes #1" },
+        },
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(commentPosted).toBe(true); // the surface published despite the ai_review_cache marker write throwing
+    expect(markSpy).toHaveBeenCalled();
+    markSpy.mockRestore();
+  });
+
   describe("#regate-churn: scheduled re-gate idempotency", () => {
     async function seedRegateChurnRepo(env: Env, overrides: Partial<Parameters<typeof upsertRepositorySettings>[1]> = {}) {
       await persistRegistrySnapshot(


### PR DESCRIPTION
## Summary

Follow-up to #3461. That PR added `markAiReviewPublished` (`src/db/repositories.ts`) alongside the pre-existing `markPullRequestSurfacePublished` stamp in the finalize step of `maybePublishPrPublicSurface`, but only carried a regression test for the sibling call's write-failure path — `codecov/patch` flagged the new call's own `.catch()`/`console.error` branch as uncovered after merge (96.77% vs the 99% target, 1 missing line). This adds the matching test, mirroring the existing "#4 over-publish dedup" test for `markPullRequestSurfacePublished`.

Test-only change; no production code touched.

No linked issue — direct coverage follow-up to #3461's post-merge Codecov finding.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — confirmed the previously-uncovered line (`src/queue/processors.ts`'s `markAiReviewPublished` catch handler) is now exercised; full unsharded suite green
- [ ] `npm run actionlint` / `test:workers` / `build:mcp` / `test:mcp-pack` / `ui:*` (not re-run — test-only change under `test/unit/`, none of these are affected)
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities (no dependency changes)
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — this PR *is* the missing fallback-path test

If any required check was skipped, explain why:

- Test-only diff under `test/unit/queue.test.ts`; no source, workflow, MCP, or UI files touched.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — test-only.)
- [x] UI changes use live API data or real empty/error/loading states. (N/A)
- [x] Visible UI changes include a `UI Evidence` section. (N/A — no UI change.)
- [x] Public docs/changelogs are updated where needed. (N/A)