### PR TITLE
feat(enrichment): flag managed-database connection strings in secret-scan

### DIFF
--- a/review-enrichment/src/analyzers/secret-scan.ts
+++ b/review-enrichment/src/analyzers/secret-scan.ts
@@ -956,6 +956,47 @@ const RULES: Rule[] = [
     confidence: "high",
   },
   {
+    // Managed-database connection strings that embed credentials, like the `cloudinary_url` rule above:
+    // `scheme://<user>:<password>@<host>`. Each requires a NON-empty user:password pair (so an angle-bracket
+    // `<user>:<password>` docs placeholder does not match — `<`/`>` are excluded) AND a distinctive provider
+    // host, so an ordinary `postgres://user:pass@localhost` (no managed host) is never flagged. The host is
+    // followed by a negative lookahead so a look-alike suffix host (`…mongodb.net.evil.com`) can't match.
+    kind: "mongodb_atlas_uri",
+    re: /\bmongodb(?:\+srv)?:\/\/[^\s:/<>]+:[^\s@/<>]+@[a-z0-9.-]+\.mongodb\.net(?![a-z0-9.-])/i,
+    confidence: "high",
+  },
+  {
+    // Neon serverless-Postgres connection string (`…@<host>.neon.tech`).
+    kind: "neon_postgres_uri",
+    re: /\bpostgres(?:ql)?:\/\/[^\s:/<>]+:[^\s@/<>]+@[a-z0-9.-]+\.neon\.tech(?![a-z0-9.-])/i,
+    confidence: "high",
+  },
+  {
+    // Supabase Postgres connection string (`…@db.<ref>.supabase.co`).
+    kind: "supabase_postgres_uri",
+    re: /\bpostgres(?:ql)?:\/\/[^\s:/<>]+:[^\s@/<>]+@[a-z0-9.-]+\.supabase\.co(?![a-z0-9.-])/i,
+    confidence: "high",
+  },
+  {
+    // Upstash Redis connection string (`rediss://default:<password>@<host>.upstash.io`). Upstash uses the
+    // default user, so the user segment may be empty.
+    kind: "upstash_redis_uri",
+    re: /\brediss?:\/\/[^\s:/<>]*:[^\s@/<>]+@[a-z0-9.-]+\.upstash\.io(?![a-z0-9.-])/i,
+    confidence: "high",
+  },
+  {
+    // PlanetScale MySQL connection string (`…@<region>.connect.psdb.cloud`).
+    kind: "planetscale_mysql_uri",
+    re: /\bmysql:\/\/[^\s:/<>]+:[^\s@/<>]+@[a-z0-9.-]+\.psdb\.cloud(?![a-z0-9.-])/i,
+    confidence: "high",
+  },
+  {
+    // CockroachDB Cloud connection string (`…@<host>.cockroachlabs.cloud`).
+    kind: "cockroachdb_uri",
+    re: /\bpostgres(?:ql)?:\/\/[^\s:/<>]+:[^\s@/<>]+@[a-z0-9.-]+\.cockroachlabs\.cloud(?![a-z0-9.-])/i,
+    confidence: "high",
+  },
+  {
     // Netlify build-hook URL — the trailing id triggers a production build, like the webhook rules above.
     kind: "netlify_build_hook_url",
     re: /https:\/\/api\.netlify\.com\/build_hooks\/[0-9a-f]{24}/,

--- a/review-enrichment/test/secret-scan.test.ts
+++ b/review-enrichment/test/secret-scan.test.ts
@@ -1615,3 +1615,41 @@ test("scanPatch does not flag near-misses of the deployment-hook URL formats", (
     assert.equal(findings.length, 0, `near-miss should not match: ${nm}`);
   }
 });
+
+test("scanPatch flags managed-database connection strings that embed credentials", () => {
+  // `<user>:<password>` fragments joined into a URI at test time — never a contiguous real secret in source.
+  const u = "dbuser";
+  const p = "s3cr3tP" + "w0rd1234";
+  const cases = [
+    ["mongodb_atlas_uri", "mongodb+srv://" + u + ":" + p + "@cluster0.ab12c.mongodb.net/mydb"],
+    ["neon_postgres_uri", "postgresql://" + u + ":" + p + "@ep-cool-name-123.us-east-2.aws.neon.tech/neondb"],
+    ["supabase_postgres_uri", "postgres://" + u + ":" + p + "@db.abcdefghij.supabase.co:5432/postgres"],
+    ["upstash_redis_uri", "rediss://default:" + p + "@apn1-cool-cat-12345.upstash.io:6379"],
+    ["planetscale_mysql_uri", "mysql://" + u + ":" + p + "@aws.connect.psdb.cloud/mydb"],
+    ["cockroachdb_uri", "postgresql://" + u + ":" + p + "@cool-cluster-123.abc.cockroachlabs.cloud:26257/defaultdb"],
+  ];
+  for (const [kind, secret] of cases) {
+    const findings = scanPatch("src/config.ts", hunk([`const c = "${secret}";`]));
+    assert.equal(findings.length, 1, `${kind}: expected exactly one finding, got ${JSON.stringify(findings)}`);
+    assert.equal(findings[0].kind, kind, `${kind}: wrong kind`);
+    assert.equal(findings[0].confidence, "high", `${kind}: wrong confidence`);
+  }
+});
+
+test("scanPatch does not flag connection-string placeholders or non-managed hosts", () => {
+  const p = "s3cr3tP" + "w0rd1234";
+  const nearMisses = [
+    // Angle-bracket docs placeholders — `<user>`/`<password>` are excluded by the rule's charset.
+    "mongodb+srv://<user>:<password>@cluster0.ab12c.mongodb.net/mydb",
+    "postgresql://<user>:<password>@ep-x.neon.tech/db",
+    // A plain local/self-hosted host is not a managed provider, so nothing is flagged.
+    "postgres://dbuser:" + p + "@localhost:5432/postgres",
+    "redis://default:" + p + "@127.0.0.1:6379",
+    // A look-alike suffix host must not match via the provider host prefix.
+    "mongodb+srv://dbuser:" + p + "@cluster0.ab12c.mongodb.net.evil.com/mydb",
+  ];
+  for (const nm of nearMisses) {
+    const findings = scanPatch("src/config.ts", hunk([`const c = "${nm}";`]));
+    assert.equal(findings.length, 0, `near-miss should not match: ${nm}`);
+  }
+});


### PR DESCRIPTION
## Summary

Extends the secret-scan analyzer with **6 new high-confidence rules** for managed-database connection strings
that embed credentials. These follow the existing `cloudinary_url` rule (`scheme://<id>:<secret>@<host>`): a
committed connection string with an embedded password is a high-severity credential leak.

| kind | matches | provider |
|---|---|---|
| `mongodb_atlas_uri` | `mongodb+srv://<user>:<pass>@…mongodb.net` | MongoDB Atlas |
| `neon_postgres_uri` | `postgres://<user>:<pass>@…neon.tech` | Neon |
| `supabase_postgres_uri` | `postgres://<user>:<pass>@…supabase.co` | Supabase |
| `upstash_redis_uri` | `rediss://default:<pass>@…upstash.io` | Upstash |
| `planetscale_mysql_uri` | `mysql://<user>:<pass>@…psdb.cloud` | PlanetScale |
| `cockroachdb_uri` | `postgres://<user>:<pass>@…cockroachlabs.cloud` | CockroachDB Cloud |

**Why these are false-positive-safe.** Each rule requires **all three** of:
1. a **non-empty `user:password` pair** — the charset excludes `<` and `>`, so an angle-bracket docs placeholder
   (`<user>:<password>`, MongoDB's own documented format) does **not** match;
2. a **distinctive managed-provider host** (`mongodb.net`, `neon.tech`, `supabase.co`, `upstash.io`, `psdb.cloud`,
   `cockroachlabs.cloud`) — so an ordinary self-hosted/local URI (`postgres://user:pass@localhost`) is never
   flagged;
3. a **host-boundary terminator** `(?![a-z0-9.-])` — so a look-alike suffix host (`…mongodb.net.evil.com`) can't
   match via the provider-host prefix.

All three conditions are asserted in the negative test (angle-bracket placeholders, `localhost`/`127.0.0.1`
hosts, and a suffix-host look-alike all produce zero findings), and a positive test asserts each provider's real
connection-string shape produces exactly one finding of its own kind. This mirrors the merged `cloudinary_url`
rule, which already treats a credential-embedding URL as a high-confidence secret.

All 6 are **new** kinds (verified against the analyzer's current rule kinds — no duplicate) and inserted before
the generic-assignment rule so the specific kind wins. `SecretFinding.kind` is a free-form `string`, so there is
**no `types.ts`/`render.ts`/`analyzer-metadata.json` change** — a two-file, rules-only diff.

No linked issue: additive detection-coverage extending an existing analyzer along its own established lines; each
rule is a self-evident, industry-standard credential shape with no public API/schema/deploy surface change — fits
the repo's `preferred` (not required) linked-issue policy.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run typecheck`
- [x] `npm run rees:test` — the review-enrichment build + analyzer suite (see note below)
- [ ] `npm run test:coverage` (N/A — this analyzer is in `review-enrichment/`, outside the root `src/**` Codecov scope)
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran locally: `git diff --check` (clean), the review-enrichment TypeScript build (exit 0), and the secret-scan
  suite via `node --test` — **106/106 pass**, including a table test asserting each of the 6 new connection-string
  formats produces exactly one finding of its own kind at high confidence, and a negative test asserting
  angle-bracket placeholders, local/self-hosted hosts, and a suffix-host look-alike produce none.
- Not run locally: the UI, root typecheck, and the `metadata:check` step of `rees:test`. This change adds only
  RULES entries (no analyzer descriptor field), so the committed `analyzer-metadata.json` / UI mirror are
  unchanged (a local regeneration produces a zero-content diff) and `metadata:check` passes on CI (Linux). On
  this Windows dev box `metadata:check` reports a spurious line-ending difference; it fails identically on
  unmodified `main`. `analyzer-metadata.json` was NOT modified.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Detection-only additions: 6 new stateless RULES following the existing specific→generic pattern; no existing
  rule or the analyzer descriptor changed, so current findings and `analyzer-metadata.json` are unaffected. Each
  new kind reports only `file:line` + the public-safe kind, never the matched value.
- Test fixtures are assembled from fragments at run time (never a contiguous secret-shaped literal in source),
  so GitHub push protection does not flag this fixture file.
