### PR TITLE
feat(review): add review.auto_review eligibility filters (#1954)

### DIFF
--- a/.gittensory.yml.example
+++ b/.gittensory.yml.example
@@ -576,6 +576,17 @@ settings:
 #   path_filters:
 #     - "src/**"
 #     - "!src/generated/**"
+#   # Deterministic AI review eligibility filters — skipped PRs never fail the gate. (#1954)
+#   auto_review:
+#     skip_drafts: true
+#     ignore_authors:
+#       - "*[bot]"
+#     ignore_title_keywords:
+#       - WIP
+#       - DRAFT
+#     base_branches:
+#       - main
+#       - release/**
 
 # Per-repo activation overrides for the converged review features that ship behind a deployment-wide
 # GITTENSORY_REVIEW_* env kill-switch (rag/reputation/unifiedComment/safety). Each key is `true` (force on

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -357,7 +357,9 @@ import { decidePublicSurface } from "../signals/settings-preview";
 import {
   buildFocusManifestGuidance,
   composeRepoReviewContext,
+  evaluateAutoReviewSkipReason,
   filterReviewFilesForAi,
+  resolveAutoReviewConfig,
   resolveRepoEnrichmentToggles,
   resolveReviewPathInstructions,
   resolveReviewPreMergeChecks,
@@ -7914,9 +7916,30 @@ async function maybePublishPrPublicSurface(
       !authorIsExemptFromFreeze &&
       manualReviewLabel !== null &&
       pr.labels.some((label) => label.toLowerCase() === manualReviewLabel.toLowerCase());
+    const reviewManifestForAutoReview = await loadRepoFocusManifest(env, repoFullName).catch(() => null);
+    const autoReviewSkipReason =
+      webhook.forceAiReview === true
+        ? null
+        : evaluateAutoReviewSkipReason(resolveAutoReviewConfig(reviewManifestForAutoReview), {
+            isDraft: pr.isDraft === true,
+            author,
+            title: pr.title,
+            baseRef: pr.baseRef ?? null,
+          });
+    if (autoReviewSkipReason) {
+      await recordAuditEvent(env, {
+        eventType: "github_app.ai_review_auto_review_skipped",
+        actor: author,
+        targetKey: `${repoFullName}#${pr.number}`,
+        outcome: "completed",
+        detail: autoReviewSkipReason,
+        metadata: { deliveryId: webhook.deliveryId, repoFullName, headSha: advisory.headSha ?? null },
+      }).catch(() => undefined);
+    }
     const aiReviewWillRun =
       !authorBlacklisted &&
       !isFrozenForManualReview &&
+      !autoReviewSkipReason &&
       (await shouldStartAiReviewForAdvisory(env, {
         settings,
         advisory,
@@ -8033,7 +8056,7 @@ async function maybePublishPrPublicSurface(
           agent: "dual-ai",
         },
         async () => {
-          const reviewManifest = await loadRepoFocusManifest(env, repoFullName).catch(() => null);
+          const reviewManifest = reviewManifestForAutoReview ?? (await loadRepoFocusManifest(env, repoFullName).catch(() => null));
           // `.gittensory.yml` review.profile + review.security_focus + review.path_instructions +
           // review.exclude_paths + review.path_filters (#review-profile / #review-security-focus /
           // #review-path-instructions / #review-exclude-paths / #2043): resolve from the manifest (cached from

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -357,14 +357,14 @@ import { decidePublicSurface } from "../signals/settings-preview";
 import {
   buildFocusManifestGuidance,
   composeRepoReviewContext,
-  evaluateAutoReviewSkipReason,
   filterReviewFilesForAi,
-  resolveAutoReviewConfig,
+  resolvePullRequestAutoReviewSkipReason,
   resolveRepoEnrichmentToggles,
   resolveReviewPathInstructions,
   resolveReviewPreMergeChecks,
   resolveReviewPromptOverrides,
   type FocusManifestFinding,
+  type FocusManifest,
   type ReviewPathInstruction,
   type ReviewProfile,
 } from "../signals/focus-manifest";
@@ -6243,6 +6243,28 @@ export function shouldRequirePublicAiReviewForAdvisory(
   return true;
 }
 
+/** Record a quiet auto-review skip (never a gate failure). Exported for unit tests. (#1954) */
+export async function auditPullRequestAutoReviewSkip(
+  env: Env,
+  args: {
+    actor: string | null;
+    repoFullName: string;
+    pullNumber: number;
+    deliveryId: string;
+    headSha: string | null | undefined;
+    skipReason: string;
+  },
+): Promise<void> {
+  await recordAuditEvent(env, {
+    eventType: "github_app.ai_review_auto_review_skipped",
+    actor: args.actor,
+    targetKey: `${args.repoFullName}#${args.pullNumber}`,
+    outcome: "completed",
+    detail: args.skipReason,
+    metadata: { deliveryId: args.deliveryId, repoFullName: args.repoFullName, headSha: args.headSha ?? null },
+  }).catch(() => undefined);
+}
+
 async function resolveReviewEnrichmentGithubToken(
   env: Env,
   repoFullName: string,
@@ -7916,25 +7938,28 @@ async function maybePublishPrPublicSurface(
       !authorIsExemptFromFreeze &&
       manualReviewLabel !== null &&
       pr.labels.some((label) => label.toLowerCase() === manualReviewLabel.toLowerCase());
-    const reviewManifestForAutoReview = await loadRepoFocusManifest(env, repoFullName).catch(() => null);
-    const autoReviewSkipReason =
-      webhook.forceAiReview === true
-        ? null
-        : evaluateAutoReviewSkipReason(resolveAutoReviewConfig(reviewManifestForAutoReview), {
-            isDraft: pr.isDraft === true,
-            author,
-            title: pr.title,
-            baseRef: pr.baseRef ?? null,
-          });
-    if (autoReviewSkipReason) {
-      await recordAuditEvent(env, {
-        eventType: "github_app.ai_review_auto_review_skipped",
-        actor: author,
-        targetKey: `${repoFullName}#${pr.number}`,
-        outcome: "completed",
-        detail: autoReviewSkipReason,
-        metadata: { deliveryId: webhook.deliveryId, repoFullName, headSha: advisory.headSha ?? null },
-      }).catch(() => undefined);
+    let reviewManifestForAutoReview: FocusManifest | null = null;
+    let autoReviewSkipReason: string | null = null;
+    if (!authorBlacklisted && !isFrozenForManualReview) {
+      reviewManifestForAutoReview = await loadRepoFocusManifest(env, repoFullName).catch(() => null);
+      autoReviewSkipReason = resolvePullRequestAutoReviewSkipReason({
+        forceAiReview: webhook.forceAiReview,
+        manifest: reviewManifestForAutoReview,
+        isDraft: pr.isDraft === true,
+        author,
+        title: pr.title,
+        baseRef: pr.baseRef ?? null,
+      });
+      if (autoReviewSkipReason) {
+        await auditPullRequestAutoReviewSkip(env, {
+          actor: author,
+          repoFullName,
+          pullNumber: pr.number,
+          deliveryId: webhook.deliveryId,
+          headSha: advisory.headSha ?? null,
+          skipReason: autoReviewSkipReason,
+        });
+      }
     }
     const aiReviewWillRun =
       !authorBlacklisted &&

--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -334,6 +334,28 @@ export type FocusManifestReviewConfig = {
    *  advisory finding; a check with `enforce: true` becomes a hard gate blocker. Empty (default) ⇒ no finding
    *  (byte-identical). No AI judgment is involved. (#review-pre-merge-checks) */
   preMergeChecks: PreMergeCheck[];
+  /** `review.auto_review`: deterministic eligibility filters that skip the AI review (never a gate failure).
+   *  Empty/default ⇒ every PR is reviewed (byte-identical). (#1954 / #2038–#2041) */
+  autoReview: AutoReviewConfig;
+};
+
+/** Per-repo AI review eligibility knobs under `review.auto_review`. Unset fields are byte-identical defaults. */
+export type AutoReviewConfig = {
+  /** `review.auto_review.skip_drafts`: when true, draft PRs skip AI review. null (default) ⇒ drafts reviewed as today. (#2038) */
+  skipDrafts: boolean | null;
+  /** `review.auto_review.ignore_authors`: author-login globs whose PRs skip AI review. Empty ⇒ every author. (#2039) */
+  ignoreAuthors: string[];
+  /** `review.auto_review.ignore_title_keywords`: case-insensitive title substrings that skip AI review. Empty ⇒ no skip. (#2040) */
+  ignoreTitleKeywords: string[];
+  /** `review.auto_review.base_branches`: base-ref globs whose PRs ARE reviewed; empty/unset ⇒ every base. (#2041) */
+  baseBranches: string[];
+};
+
+export const EMPTY_AUTO_REVIEW_CONFIG: AutoReviewConfig = {
+  skipDrafts: null,
+  ignoreAuthors: [],
+  ignoreTitleKeywords: [],
+  baseBranches: [],
 };
 
 /** One `review.path_instructions[]` entry: a manifest path glob + the public-safe instructions to apply when a
@@ -495,7 +517,7 @@ const EMPTY_MANIFEST: FocusManifest = {
   publicNotes: [],
   gate: { ...EMPTY_GATE_CONFIG },
   settings: {},
-  review: { present: false, footerText: null, note: null, fields: {}, enrichmentAnalyzers: {}, profile: null, securityFocus: null, inlineComments: null, pathInstructions: [], instructions: null, excludePaths: [], pathFilters: [], preMergeChecks: [] },
+  review: { present: false, footerText: null, note: null, fields: {}, enrichmentAnalyzers: {}, profile: null, securityFocus: null, inlineComments: null, pathInstructions: [], instructions: null, excludePaths: [], pathFilters: [], preMergeChecks: [], autoReview: { ...EMPTY_AUTO_REVIEW_CONFIG } },
   features: { ...EMPTY_FEATURES_CONFIG },
   contentLane: { ...EMPTY_CONTENT_LANE_CONFIG },
   repoDocGeneration: { ...EMPTY_REPO_DOC_GENERATION_CONFIG },
@@ -525,7 +547,7 @@ function emptyManifest(source: FocusManifestSource, warnings: string[] = []): Fo
     warnings,
     gate: { ...EMPTY_GATE_CONFIG },
     settings: {},
-    review: { present: false, footerText: null, note: null, fields: {}, enrichmentAnalyzers: {}, profile: null, securityFocus: null, inlineComments: null, pathInstructions: [], instructions: null, excludePaths: [], pathFilters: [], preMergeChecks: [] },
+    review: { present: false, footerText: null, note: null, fields: {}, enrichmentAnalyzers: {}, profile: null, securityFocus: null, inlineComments: null, pathInstructions: [], instructions: null, excludePaths: [], pathFilters: [], preMergeChecks: [], autoReview: { ...EMPTY_AUTO_REVIEW_CONFIG } },
     features: { ...EMPTY_FEATURES_CONFIG },
     contentLane: { ...EMPTY_CONTENT_LANE_CONFIG },
     repoDocGeneration: { ...EMPTY_REPO_DOC_GENERATION_CONFIG },
@@ -1431,7 +1453,7 @@ function parsePublicSafeText(value: JsonValue | undefined, field: string, warnin
  * throws; invalid/unsafe values are dropped with warnings.
  */
 function parseReviewConfig(value: JsonValue | undefined, warnings: string[]): FocusManifestReviewConfig {
-  const empty: FocusManifestReviewConfig = { present: false, footerText: null, note: null, fields: {}, enrichmentAnalyzers: {}, profile: null, securityFocus: null, inlineComments: null, pathInstructions: [], instructions: null, excludePaths: [], pathFilters: [], preMergeChecks: [] };
+  const empty: FocusManifestReviewConfig = { present: false, footerText: null, note: null, fields: {}, enrichmentAnalyzers: {}, profile: null, securityFocus: null, inlineComments: null, pathInstructions: [], instructions: null, excludePaths: [], pathFilters: [], preMergeChecks: [], autoReview: { ...EMPTY_AUTO_REVIEW_CONFIG } };
   if (value === undefined || value === null) return empty;
   if (typeof value !== "object" || Array.isArray(value)) {
     warnings.push(`Manifest field "review" must be a mapping; ignoring it.`);
@@ -1472,6 +1494,7 @@ function parseReviewConfig(value: JsonValue | undefined, warnings: string[]): Fo
   const excludePaths = parseReviewExcludePaths(r.exclude_paths, warnings);
   const pathFilters = parseReviewPathFilters(r.path_filters, warnings);
   const preMergeChecks = parseReviewPreMergeChecks(r.pre_merge_checks, warnings);
+  const autoReview = parseAutoReviewConfig(r.auto_review, warnings);
   return {
     present:
       footerText !== null ||
@@ -1484,6 +1507,7 @@ function parseReviewConfig(value: JsonValue | undefined, warnings: string[]): Fo
       excludePaths.length > 0 ||
       pathFilters.length > 0 ||
       preMergeChecks.length > 0 ||
+      autoReviewPresent(autoReview) ||
       Object.keys(fields).length > 0 ||
       Object.keys(enrichmentAnalyzers).length > 0,
     footerText,
@@ -1498,7 +1522,51 @@ function parseReviewConfig(value: JsonValue | undefined, warnings: string[]): Fo
     excludePaths,
     pathFilters,
     preMergeChecks,
+    autoReview,
   };
+}
+
+function autoReviewPresent(config: AutoReviewConfig): boolean {
+  return config.skipDrafts !== null || config.ignoreAuthors.length > 0 || config.ignoreTitleKeywords.length > 0 || config.baseBranches.length > 0;
+}
+
+/** Parse `review.auto_review` — deterministic AI review eligibility filters. (#1954 / #2038–#2041) */
+function parseAutoReviewConfig(value: JsonValue | undefined, warnings: string[]): AutoReviewConfig {
+  if (value === undefined || value === null) return { ...EMPTY_AUTO_REVIEW_CONFIG };
+  if (typeof value !== "object" || Array.isArray(value)) {
+    warnings.push(`Manifest field "review.auto_review" must be a mapping; ignoring it.`);
+    return { ...EMPTY_AUTO_REVIEW_CONFIG };
+  }
+  const record = value as Record<string, JsonValue>;
+  return {
+    skipDrafts: normalizeOptionalBoolean(record.skip_drafts, "review.auto_review.skip_drafts", warnings),
+    ignoreAuthors: parseManifestGlobList(record.ignore_authors, "review.auto_review.ignore_authors", warnings),
+    ignoreTitleKeywords: parseAutoReviewTitleKeywords(record.ignore_title_keywords, warnings),
+    baseBranches: parseManifestGlobList(record.base_branches, "review.auto_review.base_branches", warnings),
+  };
+}
+
+function parseAutoReviewTitleKeywords(value: JsonValue | undefined, warnings: string[]): string[] {
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value)) {
+    warnings.push(`Manifest "review.auto_review.ignore_title_keywords" must be a list of strings; ignoring it.`);
+    return [];
+  }
+  const out: string[] = [];
+  for (const [index, entry] of value.entries()) {
+    if (out.length >= MAX_PATH_INSTRUCTIONS) {
+      warnings.push(`Manifest "review.auto_review.ignore_title_keywords" is capped at ${MAX_PATH_INSTRUCTIONS} entries; dropping the rest.`);
+      break;
+    }
+    const raw = typeof entry === "string" ? entry.trim() : "";
+    if (!raw) {
+      warnings.push(`Manifest "review.auto_review.ignore_title_keywords[${index}]" must be a non-empty string; ignoring it.`);
+      continue;
+    }
+    const safe = parsePublicSafeText(raw, `review.auto_review.ignore_title_keywords[${index}]`, warnings);
+    if (safe !== null) out.push(safe);
+  }
+  return out;
 }
 
 /** Parse `review.pre_merge_checks` — an array of DETERMINISTIC pre-merge assertions. Each entry needs a non-empty
@@ -1678,6 +1746,14 @@ export function reviewConfigToJson(review: FocusManifestReviewConfig): JsonValue
   if (review.pathInstructions.length > 0) out.path_instructions = review.pathInstructions.map((entry) => ({ path: entry.path, instructions: entry.instructions }));
   if (review.excludePaths.length > 0) out.exclude_paths = [...review.excludePaths];
   if (review.pathFilters.length > 0) out.path_filters = [...review.pathFilters];
+  if (autoReviewPresent(review.autoReview)) {
+    const autoReview: Record<string, JsonValue> = {};
+    if (review.autoReview.skipDrafts !== null) autoReview.skip_drafts = review.autoReview.skipDrafts;
+    if (review.autoReview.ignoreAuthors.length > 0) autoReview.ignore_authors = [...review.autoReview.ignoreAuthors];
+    if (review.autoReview.ignoreTitleKeywords.length > 0) autoReview.ignore_title_keywords = [...review.autoReview.ignoreTitleKeywords];
+    if (review.autoReview.baseBranches.length > 0) autoReview.base_branches = [...review.autoReview.baseBranches];
+    out.auto_review = autoReview;
+  }
   if (review.preMergeChecks.length > 0) {
     out.pre_merge_checks = review.preMergeChecks.map((check) => {
       const entry: Record<string, JsonValue> = { name: check.name };
@@ -1706,6 +1782,41 @@ export function resolveReviewPathInstructions(pathInstructions: ReviewPathInstru
   if (applicable.length === 0) return "";
   const lines = applicable.map((entry) => `- \`${entry.path}\`: ${entry.instructions}`);
   return `\n\nPath-specific review instructions from the maintainer — apply these to the changed files that match each glob:\n${lines.join("\n")}`;
+}
+
+export function resolveAutoReviewConfig(manifest: FocusManifest | null): AutoReviewConfig {
+  return manifest?.review.autoReview ?? { ...EMPTY_AUTO_REVIEW_CONFIG };
+}
+
+export type AutoReviewEligibilityInput = {
+  isDraft: boolean;
+  author: string | null;
+  title: string;
+  baseRef: string | null;
+};
+
+/** Evaluate `review.auto_review` eligibility. Returns a quiet skip reason string, or null when AI review should proceed. (#1954) */
+export function evaluateAutoReviewSkipReason(config: AutoReviewConfig, input: AutoReviewEligibilityInput): string | null {
+  if (config.skipDrafts === true && input.isDraft) return "review skipped (draft)";
+  if (input.author && config.ignoreAuthors.length > 0) {
+    const author = input.author.toLowerCase();
+    if (config.ignoreAuthors.some((glob) => matchesManifestPath(author, glob))) {
+      return "review skipped (ignored author)";
+    }
+  }
+  if (config.ignoreTitleKeywords.length > 0) {
+    const titleLower = input.title.toLowerCase();
+    if (config.ignoreTitleKeywords.some((keyword) => titleLower.includes(keyword.toLowerCase()))) {
+      return "review skipped (WIP title)";
+    }
+  }
+  if (config.baseBranches.length > 0) {
+    const baseRef = input.baseRef?.trim() ?? "";
+    if (!baseRef || !config.baseBranches.some((glob) => matchesManifestPath(baseRef, glob))) {
+      return "review skipped (base branch out of scope)";
+    }
+  }
+  return null;
 }
 
 /** Resolve the AI-reviewer overrides (`review.profile` + `review.security_focus` + `review.path_instructions` +

--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -1800,7 +1800,7 @@ export function evaluateAutoReviewSkipReason(config: AutoReviewConfig, input: Au
   if (config.skipDrafts === true && input.isDraft) return "review skipped (draft)";
   if (input.author && config.ignoreAuthors.length > 0) {
     const author = input.author.toLowerCase();
-    if (config.ignoreAuthors.some((glob) => matchesManifestPath(author, glob))) {
+    if (config.ignoreAuthors.some((glob) => matchesManifestPath(author, glob.toLowerCase()))) {
       return "review skipped (ignored author)";
     }
   }
@@ -1817,6 +1817,23 @@ export function evaluateAutoReviewSkipReason(config: AutoReviewConfig, input: Au
     }
   }
   return null;
+}
+
+export function resolvePullRequestAutoReviewSkipReason(args: {
+  forceAiReview?: boolean | undefined;
+  manifest: FocusManifest | null;
+  isDraft: boolean;
+  author: string | null;
+  title: string;
+  baseRef: string | null;
+}): string | null {
+  if (args.forceAiReview === true) return null;
+  return evaluateAutoReviewSkipReason(resolveAutoReviewConfig(args.manifest), {
+    isDraft: args.isDraft,
+    author: args.author,
+    title: args.title,
+    baseRef: args.baseRef,
+  });
 }
 
 /** Resolve the AI-reviewer overrides (`review.profile` + `review.security_focus` + `review.path_instructions` +

--- a/test/unit/auto-review-wiring.test.ts
+++ b/test/unit/auto-review-wiring.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import { auditPullRequestAutoReviewSkip } from "../../src/queue/processors";
+import { parseFocusManifest, resolvePullRequestAutoReviewSkipReason } from "../../src/signals/focus-manifest";
+import * as repositoriesModule from "../../src/db/repositories";
+
+describe("review.auto_review wiring (#1954)", () => {
+  it("resolvePullRequestAutoReviewSkipReason: forceAiReview bypasses every filter", () => {
+    const manifest = parseFocusManifest({ review: { auto_review: { skip_drafts: true } } });
+    expect(
+      resolvePullRequestAutoReviewSkipReason({
+        forceAiReview: true,
+        manifest,
+        isDraft: true,
+        author: "dependabot[bot]",
+        title: "WIP: bump",
+        baseRef: "develop",
+      }),
+    ).toBeNull();
+  });
+
+  it("resolvePullRequestAutoReviewSkipReason: matches the documented *[bot] author glob", () => {
+    const manifest = parseFocusManifest({ review: { auto_review: { ignore_authors: ["*[bot]"] } } });
+    expect(
+      resolvePullRequestAutoReviewSkipReason({
+        manifest,
+        isDraft: false,
+        author: "dependabot[bot]",
+        title: "chore: bump deps",
+        baseRef: "main",
+      }),
+    ).toBe("review skipped (ignored author)");
+  });
+
+  it("auditPullRequestAutoReviewSkip records the skip reason and is fail-safe on audit errors", async () => {
+    const auditSpy = vi.spyOn(repositoriesModule, "recordAuditEvent").mockResolvedValue(undefined);
+    await auditPullRequestAutoReviewSkip({} as Env, {
+      actor: "dependabot[bot]",
+      repoFullName: "acme/widgets",
+      pullNumber: 7,
+      deliveryId: "delivery-1",
+      headSha: "abc123",
+      skipReason: "review skipped (ignored author)",
+    });
+    expect(auditSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        eventType: "github_app.ai_review_auto_review_skipped",
+        detail: "review skipped (ignored author)",
+        targetKey: "acme/widgets#7",
+      }),
+    );
+
+    auditSpy.mockRejectedValueOnce(new Error("audit DB down"));
+    await expect(
+      auditPullRequestAutoReviewSkip({} as Env, {
+        actor: "bot",
+        repoFullName: "acme/widgets",
+        pullNumber: 8,
+        deliveryId: "delivery-2",
+        headSha: null,
+        skipReason: "review skipped (draft)",
+      }),
+    ).resolves.toBeUndefined();
+    auditSpy.mockRestore();
+  });
+});

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -2701,6 +2701,9 @@ describe("review.auto_review (#1954 / #2038–#2041)", () => {
     expect(evaluateAutoReviewSkipReason({ ...empty, skipDrafts: true }, { ...input, isDraft: true })).toBe("review skipped (draft)");
     expect(evaluateAutoReviewSkipReason({ ...empty, skipDrafts: true }, { ...input, isDraft: false })).toBeNull();
     expect(evaluateAutoReviewSkipReason({ ...empty, ignoreAuthors: ["*[bot]"] }, input)).toBe("review skipped (ignored author)");
+    expect(evaluateAutoReviewSkipReason({ ...empty, ignoreAuthors: ["*[bot]"] }, { ...input, author: "Dependabot[bot]" })).toBe(
+      "review skipped (ignored author)",
+    );
     expect(evaluateAutoReviewSkipReason({ ...empty, ignoreAuthors: ["human"] }, input)).toBeNull();
     expect(evaluateAutoReviewSkipReason({ ...empty, ignoreTitleKeywords: ["wip"] }, { ...input, title: "Fix WIP regression" })).toBe("review skipped (WIP title)");
     expect(evaluateAutoReviewSkipReason({ ...empty, ignoreTitleKeywords: ["wip"] }, { ...input, title: "Fix regression" })).toBeNull();
@@ -2708,6 +2711,18 @@ describe("review.auto_review (#1954 / #2038–#2041)", () => {
       "review skipped (base branch out of scope)",
     );
     expect(evaluateAutoReviewSkipReason({ ...empty, baseBranches: ["main", "release/**"] }, { ...input, baseRef: "release/1.2" })).toBeNull();
+    expect(evaluateAutoReviewSkipReason({ ...empty, baseBranches: ["main"] }, { ...input, baseRef: null })).toBe(
+      "review skipped (base branch out of scope)",
+    );
+    expect(evaluateAutoReviewSkipReason({ ...empty, skipDrafts: false }, { ...input, isDraft: true })).toBeNull();
+  });
+
+  it("serializes explicit skip_drafts: false and drops unsafe title keywords", () => {
+    const m = parseFocusManifest({ review: { auto_review: { skip_drafts: false, ignore_title_keywords: ["WIP", "reward payout"] } } });
+    expect(m.review.autoReview.skipDrafts).toBe(false);
+    expect(m.review.autoReview.ignoreTitleKeywords).toEqual(["WIP"]);
+    expect(m.warnings.some((w) => /ignore_title_keywords\[1\]/.test(w))).toBe(true);
+    expect(parseFocusManifest({ review: reviewConfigToJson(m.review) }).review.autoReview.skipDrafts).toBe(false);
   });
 });
 

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -18,7 +18,10 @@ import {
   resolveReviewPathInstructions,
   resolveReviewPreMergeChecks,
   composeRepoReviewContext,
+  evaluateAutoReviewSkipReason,
+  resolveAutoReviewConfig,
   resolveReviewPromptOverrides,
+  EMPTY_AUTO_REVIEW_CONFIG,
   repoDocGenerationConfigToJson,
   reviewConfigToJson,
   settingsOverrideToJson,
@@ -543,7 +546,7 @@ describe("compileFocusManifestPolicy", () => {
       publicNotes: ["Keep PRs focused.", "Maximize your reward payout"],
       gate: { present: false, enabled: null, checkMode: null, pack: null, linkedIssue: null, duplicates: null, readinessMode: null, readinessMinScore: null, slopMode: null, slopMinScore: null, slopAiAdvisory: null, sizeMode: null, lockfileIntegrityMode: null, aiReviewMode: null, aiReviewByok: null, aiReviewProvider: null, aiReviewModel: null, aiReviewAllAuthors: null, aiReviewCloseConfidence: null, aiReviewCombine: null, aiReviewOnMerge: null, aiReviewReviewers: null, mergeReadiness: null, selfAuthoredLinkedIssue: null, manifestPolicy: null, dryRun: null, firstTimeContributorGrace: null, premergeContentRecheck: null, requireFreshRebaseWindowMinutes: null, claMode: null, claConsentPhrase: null, claCheckRunName: null, claCheckRunAppSlug: null, expectedCiContexts: null },
       settings: {},
-      review: { present: false, footerText: null, note: null, fields: {}, enrichmentAnalyzers: {}, profile: null, securityFocus: null, inlineComments: null, pathInstructions: [], instructions: null, excludePaths: [], pathFilters: [], preMergeChecks: [] },
+      review: { present: false, footerText: null, note: null, fields: {}, enrichmentAnalyzers: {}, profile: null, securityFocus: null, inlineComments: null, pathInstructions: [], instructions: null, excludePaths: [], pathFilters: [], preMergeChecks: [], autoReview: { ...EMPTY_AUTO_REVIEW_CONFIG } },
       features: { present: false, rag: null, reputation: null, unifiedComment: null, safety: null },
       contentLane: { present: false, entryFileGlob: null, providerFileGlob: null, artifactGlob: null, collectionField: null, maxAppendedEntries: null, duplicateKeyFields: [], validatorId: null },
       repoDocGeneration: { present: false, enabled: false, scope: ["agents"], allowOverwriteExisting: false, refreshIntervalDays: 7 },
@@ -2644,6 +2647,67 @@ describe("review.path_filters (#2043)", () => {
       { path: "src/a.ts" },
     ]);
     expect(filterReviewFilesForAi(files, [], [])).toBe(files);
+  });
+});
+
+describe("review.auto_review (#1954 / #2038–#2041)", () => {
+  it("parses auto_review knobs, marks present, and round-trips", () => {
+    const m = parseFocusManifest({
+      review: {
+        auto_review: {
+          skip_drafts: true,
+          ignore_authors: [" *[bot] ", "dependabot[bot]"],
+          ignore_title_keywords: [" WIP ", "draft"],
+          base_branches: ["main", "release/**"],
+        },
+      },
+    });
+    expect(m.review.autoReview).toEqual({
+      skipDrafts: true,
+      ignoreAuthors: ["*[bot]", "dependabot[bot]"],
+      ignoreTitleKeywords: ["WIP", "draft"],
+      baseBranches: ["main", "release/**"],
+    });
+    expect(m.review.present).toBe(true);
+    expect(parseFocusManifest({ review: reviewConfigToJson(m.review) }).review.autoReview).toEqual(m.review.autoReview);
+  });
+
+  it("ignores invalid auto_review entries with warnings", () => {
+    const bad = parseFocusManifest({ review: { auto_review: "nope" } });
+    expect(bad.review.autoReview).toEqual({ ...EMPTY_AUTO_REVIEW_CONFIG });
+    expect(bad.warnings.some((w) => /auto_review.*must be a mapping/.test(w))).toBe(true);
+    const skipDraftsBad = parseFocusManifest({ review: { auto_review: { skip_drafts: "yes" } } });
+    expect(skipDraftsBad.review.autoReview.skipDrafts).toBeNull();
+    expect(skipDraftsBad.warnings.some((w) => /skip_drafts.*boolean/.test(w))).toBe(true);
+    const keywordsBad = parseFocusManifest({ review: { auto_review: { ignore_title_keywords: ["", 42, "WIP"] } } });
+    expect(keywordsBad.review.autoReview.ignoreTitleKeywords).toEqual(["WIP"]);
+    expect(keywordsBad.warnings.some((w) => /ignore_title_keywords\[0\]/.test(w))).toBe(true);
+    expect(keywordsBad.warnings.some((w) => /ignore_title_keywords\[1\]/.test(w))).toBe(true);
+    const many = parseFocusManifest({
+      review: { auto_review: { ignore_authors: Array.from({ length: 60 }, (_, i) => `bot${i}`) } },
+    });
+    expect(many.review.autoReview.ignoreAuthors).toHaveLength(50);
+    expect(many.warnings.some((w) => /ignore_authors.*capped/.test(w))).toBe(true);
+  });
+
+  it("resolveAutoReviewConfig: null manifest yields empty defaults", () => {
+    expect(resolveAutoReviewConfig(null)).toEqual({ ...EMPTY_AUTO_REVIEW_CONFIG });
+  });
+
+  it("evaluateAutoReviewSkipReason: byte-identical when unset; skips with deterministic reasons when configured", () => {
+    const empty = { ...EMPTY_AUTO_REVIEW_CONFIG };
+    const input = { isDraft: true, author: "dependabot[bot]", title: "WIP: bump deps", baseRef: "develop" };
+    expect(evaluateAutoReviewSkipReason(empty, input)).toBeNull();
+    expect(evaluateAutoReviewSkipReason({ ...empty, skipDrafts: true }, { ...input, isDraft: true })).toBe("review skipped (draft)");
+    expect(evaluateAutoReviewSkipReason({ ...empty, skipDrafts: true }, { ...input, isDraft: false })).toBeNull();
+    expect(evaluateAutoReviewSkipReason({ ...empty, ignoreAuthors: ["*[bot]"] }, input)).toBe("review skipped (ignored author)");
+    expect(evaluateAutoReviewSkipReason({ ...empty, ignoreAuthors: ["human"] }, input)).toBeNull();
+    expect(evaluateAutoReviewSkipReason({ ...empty, ignoreTitleKeywords: ["wip"] }, { ...input, title: "Fix WIP regression" })).toBe("review skipped (WIP title)");
+    expect(evaluateAutoReviewSkipReason({ ...empty, ignoreTitleKeywords: ["wip"] }, { ...input, title: "Fix regression" })).toBeNull();
+    expect(evaluateAutoReviewSkipReason({ ...empty, baseBranches: ["main"] }, { ...input, baseRef: "develop" })).toBe(
+      "review skipped (base branch out of scope)",
+    );
+    expect(evaluateAutoReviewSkipReason({ ...empty, baseBranches: ["main", "release/**"] }, { ...input, baseRef: "release/1.2" })).toBeNull();
   });
 });
 

--- a/test/unit/signals-coverage.test.ts
+++ b/test/unit/signals-coverage.test.ts
@@ -1127,7 +1127,7 @@ describe("signal coverage edge cases", () => {
       collisions: buildCollisionReport(directRepo.fullName, [], [currentPr]),
       preflight: buildPreflightResult({ repoFullName: directRepo.fullName, title: "Fix isolated issue", body: "Fixes #99", linkedIssues: [99] }, directRepo, [], [currentPr]),
       settings: gateSettings,
-      review: { present: true, footerText: "Reviewed by the Acme maintainer bot.", note: "Run npm test before pushing.", fields: { relatedWork: false }, enrichmentAnalyzers: {}, profile: null, securityFocus: null, inlineComments: null, pathInstructions: [], instructions: null, excludePaths: [], pathFilters: [], preMergeChecks: [] },
+      review: { present: true, footerText: "Reviewed by the Acme maintainer bot.", note: "Run npm test before pushing.", fields: { relatedWork: false }, enrichmentAnalyzers: {}, profile: null, securityFocus: null, inlineComments: null, pathInstructions: [], instructions: null, excludePaths: [], pathFilters: [], preMergeChecks: [], autoReview: { skipDrafts: null, ignoreAuthors: [], ignoreTitleKeywords: [], baseBranches: [] } },
       aiReview: { notes: "The change is focused.\n\n**Nits (2)**\n- Add a test for the </details> edge case.\n- Keep the validator helper scoped." },
     });
     expect(customizedComment).toContain("Reviewed by the Acme maintainer bot."); // custom footer lead


### PR DESCRIPTION
## Summary

- Adds `review.auto_review` eligibility filters to `.gittensory.yml`: `skip_drafts`, `ignore_authors`, `ignore_title_keywords`, and `base_branches`.
- Parses/serializes via `FocusManifestReviewConfig.autoReview`, evaluates with `evaluateAutoReviewSkipReason`, and skips AI review at the processor entry point (audit event only - never a gate failure).
- `forceAiReview` bypasses auto-review skips (maintainer retrigger).

Supersedes closed #3495 (codecov patch follow-up).

Closes #2038
Closes #2039
Closes #2040
Closes #2041

Part of #1954

## Test plan

- [x] `npm run typecheck`
- [x] `vitest run test/unit/focus-manifest.test.ts test/unit/auto-review-wiring.test.ts`
- [ ] CI + codecov patch coverage on changed files