### PR TITLE
feat(enrichment): deep-nesting / arrow-anti-pattern heuristic analyzer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,24 +68,25 @@ GITTENSORY_REVIEW_ENRICHMENT=false
 # nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink,approvalIntegrity
 # ciCheckSignals,undocumentedExport,staleBranch,commitHygiene,pendingReviewRequests,testRatio
 # migrationSafety,looseRange,terminology,todoMarker,magicNumber,conflictMarker,debugLeftover
-# commitLint
+# deepNesting,commitLint
 #
 # Profile defaults:
 # fast: dependency,lockfileDrift,secret,license,installScript,heavyDependency,hardcodedUrl
 # actionPin,eol,redos,provenance,secretLog,typosquat,iacMisconfig,nativeBuild,testRatio
 # migrationSafety,looseRange,terminology,todoMarker,magicNumber,conflictMarker,debugLeftover
+# deepNesting
 # balanced (default): dependency,lockfileDrift,secret,license,installScript,heavyDependency
 # hardcodedUrl,actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat
 # commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot
 # blameLink,approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene
 # pendingReviewRequests,testRatio,migrationSafety,looseRange,terminology,todoMarker,magicNumber
-# conflictMarker,debugLeftover,commitLint
+# conflictMarker,debugLeftover,deepNesting,commitLint
 # deep: dependency,lockfileDrift,secret,license,installScript,heavyDependency,hardcodedUrl
 # actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat,commitSignature
 # iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot,blameLink
 # approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene
 # pendingReviewRequests,testRatio,migrationSafety,looseRange,terminology,todoMarker,magicNumber
-# conflictMarker,debugLeftover,commitLint
+# conflictMarker,debugLeftover,deepNesting,commitLint
 # END GENERATED REES ANALYZERS
 
 # Submitter-reputation spend control (internal-only): downgrades new/burst/low-rep

--- a/apps/gittensory-ui/src/lib/rees-analyzers.ts
+++ b/apps/gittensory-ui/src/lib/rees-analyzers.ts
@@ -934,6 +934,30 @@ export const REES_ANALYZERS = [
     },
   },
   {
+    name: "deepNesting",
+    title: "Deep nesting",
+    category: "quality",
+    cost: "local",
+    defaultEnabled: true,
+    profiles: ["fast", "balanced", "deep"],
+    requires: ["files"],
+    limits: {
+      maxFindings: 25,
+      maxDepth: 4,
+      maxLineChars: 2000,
+    },
+    docs: {
+      summary:
+        "Flags newly-added control flow whose open-brace depth exceeds a threshold inside a contiguous run of added lines.",
+      looksAt:
+        "Added lines in changed non-test source files, tracking depth across contiguous added hunks.",
+      reports: "File, line, observed depth, and the configured threshold.",
+      network: "Pure local analyzer. No external network call.",
+      notes:
+        "Structural brace-depth only (string literals stripped). A context or removed line resets the contiguous run. Distinct from cyclomatic-complexity tooling.",
+    },
+  },
+  {
     name: "commitLint",
     title: "Conventional-commit subjects",
     category: "quality",

--- a/review-enrichment/analyzer-metadata.json
+++ b/review-enrichment/analyzer-metadata.json
@@ -1053,6 +1053,33 @@
       }
     },
     {
+      "name": "deepNesting",
+      "title": "Deep nesting",
+      "category": "quality",
+      "cost": "local",
+      "defaultEnabled": true,
+      "profiles": [
+        "fast",
+        "balanced",
+        "deep"
+      ],
+      "requires": [
+        "files"
+      ],
+      "limits": {
+        "maxFindings": 25,
+        "maxDepth": 4,
+        "maxLineChars": 2000
+      },
+      "docs": {
+        "summary": "Flags newly-added control flow whose open-brace depth exceeds a threshold inside a contiguous run of added lines.",
+        "looksAt": "Added lines in changed non-test source files, tracking depth across contiguous added hunks.",
+        "reports": "File, line, observed depth, and the configured threshold.",
+        "network": "Pure local analyzer. No external network call.",
+        "notes": "Structural brace-depth only (string literals stripped). A context or removed line resets the contiguous run. Distinct from cyclomatic-complexity tooling."
+      }
+    },
+    {
       "name": "commitLint",
       "title": "Conventional-commit subjects",
       "category": "quality",

--- a/review-enrichment/src/analyzers/deep-nesting.ts
+++ b/review-enrichment/src/analyzers/deep-nesting.ts
@@ -1,0 +1,112 @@
+// Deep-nesting / arrow-anti-pattern analyzer (#2030). Flags newly-added control flow whose brace depth
+// exceeds a threshold inside a contiguous run of added lines — a readability smell distinct from cyclomatic
+// complexity. Pure compute over added diff lines, no network. String literals are stripped before counting.
+import type { DeepNestingFinding, EnrichRequest } from "../types.js";
+import { codeOnly } from "./secret-log.js";
+import { isTestPath } from "./test-ratio.js";
+
+export const DEFAULT_MAX_DEPTH = 4;
+const MAX_FINDINGS = 25;
+const MAX_LINE_CHARS = 2000;
+
+/** Advance open-brace depth over one code fragment and return ending depth + peak. Pure. */
+export function advanceBraceDepth(
+  code: string,
+  depth: number,
+): { depth: number; peak: number } {
+  let peak = depth;
+  for (const ch of code) {
+    if (ch === "{") {
+      depth++;
+      peak = Math.max(peak, depth);
+    } else if (ch === "}") {
+      depth = Math.max(0, depth - 1);
+    }
+  }
+  return { depth, peak };
+}
+
+type ScanLimits = {
+  maxDepth?: number;
+  maxFindings?: number;
+  signal?: AbortSignal;
+};
+
+type RunState = {
+  depth: number;
+  flagged: boolean;
+};
+
+function resetRun(state: RunState): void {
+  state.depth = 0;
+  state.flagged = false;
+}
+
+/** Scan one file patch's added lines for deep nesting, line-cited via hunk headers. Pure. */
+export function scanPatchForDeepNesting(
+  path: string,
+  patch: string,
+  limits: ScanLimits = {},
+): DeepNestingFinding[] {
+  const maxDepth = limits.maxDepth ?? DEFAULT_MAX_DEPTH;
+  const maxFindings = limits.maxFindings ?? MAX_FINDINGS;
+  if (maxFindings <= 0 || isTestPath(path)) return [];
+  const findings: DeepNestingFinding[] = [];
+  const run: RunState = { depth: 0, flagged: false };
+  let newLine = 0;
+  let inHunk = false;
+
+  const maybeFlag = (line: number, depth: number) => {
+    if (run.flagged || depth <= maxDepth) return;
+    findings.push({ file: path, line, depth, threshold: maxDepth });
+    run.flagged = true;
+  };
+
+  for (const line of patch.split("\n")) {
+    if (limits.signal?.aborted) throw new Error("analyzer_aborted");
+    const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
+    if (hunk) {
+      newLine = Number(hunk[1]);
+      inHunk = true;
+      resetRun(run);
+      continue;
+    }
+    if (!inHunk) continue;
+    if (line.startsWith("+")) {
+      const body = line.slice(1);
+      if (body.length <= MAX_LINE_CHARS) {
+        const next = advanceBraceDepth(codeOnly(body), run.depth);
+        run.depth = next.depth;
+        maybeFlag(newLine, next.peak);
+        if (findings.length >= maxFindings) return findings;
+      }
+      newLine++;
+    } else {
+      resetRun(run);
+      if (!line.startsWith("-") && !line.startsWith("\\")) {
+        newLine++;
+      }
+    }
+  }
+  return findings;
+}
+
+/** Analyzer entrypoint: scan every changed non-test file's added lines for deep nesting. */
+export async function scanDeepNesting(
+  req: EnrichRequest,
+  signal?: AbortSignal,
+): Promise<DeepNestingFinding[]> {
+  const findings: DeepNestingFinding[] = [];
+  for (const file of req.files ?? []) {
+    if (signal?.aborted) throw new Error("analyzer_aborted");
+    if (!file.patch) continue;
+    for (const finding of scanPatchForDeepNesting(file.path, file.patch, {
+      maxFindings: MAX_FINDINGS - findings.length,
+      signal,
+    })) {
+      findings.push(finding);
+      if (findings.length >= MAX_FINDINGS) return findings;
+    }
+  }
+  return findings;
+}

--- a/review-enrichment/src/analyzers/registry.ts
+++ b/review-enrichment/src/analyzers/registry.ts
@@ -31,6 +31,7 @@ import { scanLooseRanges } from "./loose-range.js";
 import { scanMagicNumbers } from "./magic-number.js";
 import { scanConflictMarkers } from "./conflict-marker.js";
 import { scanDebugLeftover } from "./debug-leftover.js";
+import { scanDeepNesting } from "./deep-nesting.js";
 import { scanCommitLint } from "./commit-lint.js";
 import { scanTerminology } from "./terminology.js";
 import { scanTodoMarker } from "./todo-marker.js";
@@ -976,6 +977,35 @@ export const ANALYZER_DESCRIPTORS = [
       return lines;
     },
     run: (req, { signal }) => scanDebugLeftover(req, signal),
+  }),
+  descriptor({
+    name: "deepNesting",
+    title: "Deep nesting",
+    category: "quality",
+    cost: "local",
+    defaultEnabled: true,
+    requires: ["files"],
+    limits: { maxFindings: 25, maxDepth: 4, maxLineChars: 2000 },
+    docs: {
+      summary:
+        "Flags newly-added control flow whose open-brace depth exceeds a threshold inside a contiguous run of added lines.",
+      looksAt: "Added lines in changed non-test source files, tracking depth across contiguous added hunks.",
+      reports: "File, line, observed depth, and the configured threshold.",
+      network: "Pure local analyzer. No external network call.",
+      notes:
+        "Structural brace-depth only (string literals stripped). A context or removed line resets the contiguous run. Distinct from cyclomatic-complexity tooling.",
+    },
+    render: (findings, helpers) => {
+      if (!findings.length) return [];
+      const lines = ["### Deep nesting (added control-flow depth exceeds threshold)"];
+      for (const item of findings) {
+        lines.push(
+          `- ${helpers.safeCodeSpan(`${item.file}:${item.line}`)} — depth ${item.depth} (threshold ${item.threshold})`,
+        );
+      }
+      return lines;
+    },
+    run: (req, { signal }) => scanDeepNesting(req, signal),
   }),
   descriptor({
     name: "commitLint",

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -481,6 +481,7 @@ export function renderBrief(
   lines.push(...renderDescriptorSection("magicNumber", findings.magicNumber));
   lines.push(...renderDescriptorSection("conflictMarker", findings.conflictMarker));
   lines.push(...renderDescriptorSection("debugLeftover", findings.debugLeftover));
+  lines.push(...renderDescriptorSection("deepNesting", findings.deepNesting));
   lines.push(...renderDescriptorSection("hardcodedUrl", findings.hardcodedUrl));
   lines.push(...renderDescriptorSection("commitLint", findings.commitLint));
 

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -473,6 +473,15 @@ export interface DebugLeftoverFinding {
   kind: "debugger" | "console" | "print";
 }
 
+/** Deep brace nesting newly introduced in a contiguous added block (#2030, part of #1499).
+ *  Reports location, observed depth, and the configured threshold only. */
+export interface DeepNestingFinding {
+  file: string;
+  line: number;
+  depth: number;
+  threshold: number;
+}
+
 /** An absolute HTTP(S) URL or raw IP:port endpoint hardcoded in non-test, non-config source (#2027, part of #1499).
  *  Reports location, kind, and a redacted/truncated host — never full paths or query strings. */
 export interface HardcodedUrlFinding {
@@ -528,6 +537,7 @@ export interface BriefFindings {
   magicNumber?: MagicNumberFinding[];
   conflictMarker?: ConflictMarkerFinding[];
   debugLeftover?: DebugLeftoverFinding[];
+  deepNesting?: DeepNestingFinding[];
   hardcodedUrl?: HardcodedUrlFinding[];
   commitLint?: CommitLintFinding[];
 }

--- a/review-enrichment/test/analyzer-registry.test.ts
+++ b/review-enrichment/test/analyzer-registry.test.ts
@@ -47,6 +47,7 @@ const EXPECTED_ANALYZERS = [
   "magicNumber",
   "conflictMarker",
   "debugLeftover",
+  "deepNesting",
   "commitLint",
 ];
 

--- a/review-enrichment/test/deep-nesting.test.ts
+++ b/review-enrichment/test/deep-nesting.test.ts
@@ -1,0 +1,86 @@
+// Units for the deep-nesting analyzer (#2030). Own file so concurrent analyzer PRs don't collide.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  advanceBraceDepth,
+  DEFAULT_MAX_DEPTH,
+  scanDeepNesting,
+  scanPatchForDeepNesting,
+} from "../dist/analyzers/deep-nesting.js";
+import { renderBrief } from "../dist/render.js";
+
+const patchOf = (lines: string[]) =>
+  `@@ -1,0 +1,${lines.length} @@\n${lines.map((l) => `+${l}`).join("\n")}`;
+
+test("advanceBraceDepth: tracks open braces and never goes negative", () => {
+  assert.deepEqual(advanceBraceDepth("", 0), { depth: 0, peak: 0 });
+  assert.deepEqual(advanceBraceDepth("{", 0), { depth: 1, peak: 1 });
+  assert.deepEqual(advanceBraceDepth("}}", 1), { depth: 0, peak: 1 });
+  assert.deepEqual(advanceBraceDepth("{{", 0), { depth: 2, peak: 2 });
+  assert.deepEqual(advanceBraceDepth("{{}}", 0), { depth: 0, peak: 2 });
+});
+
+test("scanPatchForDeepNesting: flags a deeply nested added block", () => {
+  const lines = [
+    "function run() {",
+    "  if (a) {",
+    "    if (b) {",
+    "      if (c) {",
+    "        if (d) {",
+    "          return x;",
+    "        }",
+    "      }",
+    "    }",
+    "  }",
+    "}",
+  ];
+  const findings = scanPatchForDeepNesting("src/widget.ts", patchOf(lines));
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0]?.depth, DEFAULT_MAX_DEPTH + 1);
+  assert.equal(findings[0]?.threshold, DEFAULT_MAX_DEPTH);
+});
+
+test("scanPatchForDeepNesting: does not flag shallow nesting at the threshold", () => {
+  const lines = ["function run() {", "  if (a) {", "    if (b) {", "      return x;", "    }", "  }", "}"];
+  assert.deepEqual(scanPatchForDeepNesting("src/widget.ts", patchOf(lines)), []);
+});
+
+test("scanPatchForDeepNesting: respects a custom maxDepth limit", () => {
+  const lines = ["if (a) {", "  if (b) {", "    return x;", "  }", "}"];
+  assert.deepEqual(
+    scanPatchForDeepNesting("src/widget.ts", patchOf(lines), { maxDepth: 1 }),
+    [{ file: "src/widget.ts", line: 2, depth: 2, threshold: 1 }],
+  );
+  assert.deepEqual(scanPatchForDeepNesting("src/widget.ts", patchOf(lines), { maxDepth: 2 }), []);
+});
+
+test("scanPatchForDeepNesting: resets depth across context lines", () => {
+  const patch = [
+    "@@ -1,3 +1,4 @@",
+    " function outer() {",
+    "+  if (a) {",
+    "    return x;",
+    "+    if (b) { if (c) { if (d) { if (e) { if (f) { return y; } } } } }",
+  ].join("\n");
+  assert.equal(scanPatchForDeepNesting("src/widget.ts", patch).length, 1);
+});
+
+test("scanPatchForDeepNesting: skips test files and respects the cap", () => {
+  const deepLine = "{".repeat(DEFAULT_MAX_DEPTH + 2);
+  assert.deepEqual(scanPatchForDeepNesting("src/widget.test.ts", patchOf([deepLine])), []);
+  const patch = Array.from({ length: 30 }, (_, i) =>
+    [`@@ -${i},0 +${i + 1},1 @@`, `+${deepLine}`].join("\n"),
+  ).join("\n");
+  assert.equal(scanPatchForDeepNesting("src/a.ts", patch, { maxFindings: 2 }).length, 2);
+});
+
+test("scanDeepNesting: aggregates across files and renders a public-safe brief", async () => {
+  const deepBlock = ["if (a) {", "  if (b) {", "    if (c) {", "      if (d) {", "        if (e) {", "        }", "      }", "    }", "  }", "}"];
+  const findings = await scanDeepNesting({
+    files: [{ path: "src/a.ts", patch: patchOf(deepBlock) }],
+  });
+  assert.equal(findings.length, 1);
+  const { promptSection } = renderBrief({ deepNesting: findings });
+  assert.match(promptSection, /Deep nesting/);
+  assert.match(promptSection, /src\/a\.ts:/);
+});

--- a/src/review/enrichment-analyzer-names.ts
+++ b/src/review/enrichment-analyzer-names.ts
@@ -10,6 +10,7 @@ export const REES_ANALYZER_NAMES = [
   "license",
   "installScript",
   "heavyDependency",
+  "hardcodedUrl",
   "actionPin",
   "eol",
   "redos",
@@ -39,6 +40,8 @@ export const REES_ANALYZER_NAMES = [
   "todoMarker",
   "magicNumber",
   "conflictMarker",
+  "debugLeftover",
+  "deepNesting",
   "commitLint",
 ] as const;
 


### PR DESCRIPTION
## Summary
Fixes #2030

- Add `DeepNestingFinding` and a local `deepNesting` analyzer that flags newly-added open-brace depth exceeding a threshold (default 4) inside contiguous added-line runs
- Track peak depth per line (string literals stripped via `codeOnly`); reset on context/removed lines; cap at 25 findings; skip test paths
- Register the analyzer in the REES registry with render/docs/metadata; sync `src/review/enrichment-analyzer-names.ts` with the enrichment registry (`hardcodedUrl`, `debugLeftover`, `deepNesting`)
- Add `review-enrichment/test/deep-nesting.test.ts` covering over-threshold vs shallow blocks, custom maxDepth, context-line reset, cap, and brief rendering

## Test plan
- [x] `cd review-enrichment && npm run build && npm run metadata && node --test test/deep-nesting.test.ts test/analyzer-registry.test.ts`
- [ ] CI `validate-code`

Made with [Cursor](https://cursor.com)