### PR TITLE
feat(review): add auto_pause_after_reviewed_commits knob (#2042)

### DIFF
--- a/.gittensory.yml.example
+++ b/.gittensory.yml.example
@@ -587,6 +587,7 @@ settings:
 #     base_branches:
 #       - main
 #       - release/**
+#     auto_pause_after_reviewed_commits: 3  # after 3 published AI reviews on this PR, pause further re-reviews (0/unset = off)
 
 # Per-repo activation overrides for the converged review features that ship behind a deployment-wide
 # GITTENSORY_REVIEW_* env kill-switch (rag/reputation/unifiedComment/safety). Each key is `true` (force on

--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -4101,6 +4101,16 @@ export async function getLatestPublishedAiReview(
   };
 }
 
+/** Count distinct PR head SHAs that already received a published AI review — used by `review.auto_review.auto_pause_after_reviewed_commits`. (#2042) */
+export async function countPublishedAiReviewHeads(env: Env, repoFullName: string, pullNumber: number): Promise<number> {
+  const row = await env.DB.prepare(
+    "SELECT COUNT(DISTINCT head_sha) AS cnt FROM ai_review_cache WHERE repo_full_name = ? AND pull_number = ? AND published_at IS NOT NULL",
+  )
+    .bind(repoFullName, pullNumber)
+    .first<{ cnt: number }>();
+  return row?.cnt ?? 0;
+}
+
 /** Upsert the AI review for (repo, pull, head SHA). A nullish head SHA is a no-op.
  *  #regate-churn: `review.cacheable === false` still PERSISTS the attempt (so a repeated scheduled sweep pass at
  *  the identical head+fingerprint can find it via getCachedAiReview's bounded allowNonCacheable lookup) but marks

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -46,6 +46,7 @@ import {
   persistAdvisory,
   getCachedAiReview,
   getLatestPublishedAiReview,
+  countPublishedAiReviewHeads,
   putCachedAiReview,
   markAiReviewPublished,
   markPullRequestsRegated,
@@ -6283,6 +6284,7 @@ export async function resolveAutoReviewSkipForPullRequest(
     return { skipReason: null, reviewManifest: null };
   }
   const reviewManifest = await loadRepoFocusManifest(env, args.repoFullName).catch(() => null);
+  const reviewedCommitCount = await countPublishedAiReviewHeads(env, args.repoFullName, args.pr.number).catch(() => 0);
   const skipReason = resolvePullRequestAutoReviewSkipReason({
     forceAiReview: args.forceAiReview,
     manifest: reviewManifest,
@@ -6290,6 +6292,7 @@ export async function resolveAutoReviewSkipForPullRequest(
     author: args.author,
     title: args.pr.title,
     baseRef: args.pr.baseRef ?? null,
+    reviewedCommitCount,
   });
   if (skipReason) {
     await auditPullRequestAutoReviewSkip(env, {

--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -349,6 +349,9 @@ export type AutoReviewConfig = {
   ignoreTitleKeywords: string[];
   /** `review.auto_review.base_branches`: base-ref globs whose PRs ARE reviewed; empty/unset ⇒ every base. (#2041) */
   baseBranches: string[];
+  /** `review.auto_review.auto_pause_after_reviewed_commits`: after N published AI reviews on this PR, pause further
+   *  re-reviews. null/0 ⇒ byte-identical (re-review every sync). (#2042) */
+  autoPauseAfterReviewedCommits: number | null;
 };
 
 export const EMPTY_AUTO_REVIEW_CONFIG: AutoReviewConfig = {
@@ -356,6 +359,7 @@ export const EMPTY_AUTO_REVIEW_CONFIG: AutoReviewConfig = {
   ignoreAuthors: [],
   ignoreTitleKeywords: [],
   baseBranches: [],
+  autoPauseAfterReviewedCommits: null,
 };
 
 /** One `review.path_instructions[]` entry: a manifest path glob + the public-safe instructions to apply when a
@@ -647,6 +651,15 @@ function normalizeOptionalScore(value: JsonValue | undefined, field: string, war
     return null;
   }
   return Math.max(0, Math.min(100, Math.round(value)));
+}
+
+function normalizeOptionalNonNegativeInt(value: JsonValue | undefined, field: string, warnings: string[]): number | null {
+  if (value === undefined || value === null) return null;
+  if (typeof value !== "number" || !Number.isFinite(value) || !Number.isInteger(value) || value < 0) {
+    warnings.push(`Manifest field "${field}" must be a non-negative integer; ignoring it.`);
+    return null;
+  }
+  return value;
 }
 
 /** Normalize an optional confidence threshold in [0,1] (#7) — a fractional value (NOT a 0-100 score), so it is
@@ -1527,7 +1540,13 @@ function parseReviewConfig(value: JsonValue | undefined, warnings: string[]): Fo
 }
 
 function autoReviewPresent(config: AutoReviewConfig): boolean {
-  return config.skipDrafts !== null || config.ignoreAuthors.length > 0 || config.ignoreTitleKeywords.length > 0 || config.baseBranches.length > 0;
+  return (
+    config.skipDrafts !== null ||
+    config.ignoreAuthors.length > 0 ||
+    config.ignoreTitleKeywords.length > 0 ||
+    config.baseBranches.length > 0 ||
+    config.autoPauseAfterReviewedCommits !== null
+  );
 }
 
 /** Parse `review.auto_review` — deterministic AI review eligibility filters. (#1954 / #2038–#2041) */
@@ -1543,6 +1562,11 @@ function parseAutoReviewConfig(value: JsonValue | undefined, warnings: string[])
     ignoreAuthors: parseManifestGlobList(record.ignore_authors, "review.auto_review.ignore_authors", warnings),
     ignoreTitleKeywords: parseAutoReviewTitleKeywords(record.ignore_title_keywords, warnings),
     baseBranches: parseManifestGlobList(record.base_branches, "review.auto_review.base_branches", warnings),
+    autoPauseAfterReviewedCommits: normalizeOptionalNonNegativeInt(
+      record.auto_pause_after_reviewed_commits,
+      "review.auto_review.auto_pause_after_reviewed_commits",
+      warnings,
+    ),
   };
 }
 
@@ -1752,6 +1776,9 @@ export function reviewConfigToJson(review: FocusManifestReviewConfig): JsonValue
     if (review.autoReview.ignoreAuthors.length > 0) autoReview.ignore_authors = [...review.autoReview.ignoreAuthors];
     if (review.autoReview.ignoreTitleKeywords.length > 0) autoReview.ignore_title_keywords = [...review.autoReview.ignoreTitleKeywords];
     if (review.autoReview.baseBranches.length > 0) autoReview.base_branches = [...review.autoReview.baseBranches];
+    if (review.autoReview.autoPauseAfterReviewedCommits !== null) {
+      autoReview.auto_pause_after_reviewed_commits = review.autoReview.autoPauseAfterReviewedCommits;
+    }
     out.auto_review = autoReview;
   }
   if (review.preMergeChecks.length > 0) {
@@ -1793,6 +1820,7 @@ export type AutoReviewEligibilityInput = {
   author: string | null;
   title: string;
   baseRef: string | null;
+  reviewedCommitCount: number;
 };
 
 /** Evaluate `review.auto_review` eligibility. Returns a quiet skip reason string, or null when AI review should proceed. (#1954) */
@@ -1816,6 +1844,11 @@ export function evaluateAutoReviewSkipReason(config: AutoReviewConfig, input: Au
       return "review skipped (base branch out of scope)";
     }
   }
+  if (config.autoPauseAfterReviewedCommits !== null && config.autoPauseAfterReviewedCommits > 0) {
+    if (input.reviewedCommitCount >= config.autoPauseAfterReviewedCommits) {
+      return "review paused (commit threshold)";
+    }
+  }
   return null;
 }
 
@@ -1826,6 +1859,7 @@ export function resolvePullRequestAutoReviewSkipReason(args: {
   author: string | null;
   title: string;
   baseRef: string | null;
+  reviewedCommitCount?: number | undefined;
 }): string | null {
   if (args.forceAiReview === true) return null;
   return evaluateAutoReviewSkipReason(resolveAutoReviewConfig(args.manifest), {
@@ -1833,6 +1867,7 @@ export function resolvePullRequestAutoReviewSkipReason(args: {
     author: args.author,
     title: args.title,
     baseRef: args.baseRef,
+    reviewedCommitCount: args.reviewedCommitCount ?? 0,
   });
 }
 

--- a/test/unit/ai-review-cache.test.ts
+++ b/test/unit/ai-review-cache.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { getCachedAiReview, getLatestPublishedAiReview, markAiReviewPublished, putCachedAiReview } from "../../src/db/repositories";
+import { countPublishedAiReviewHeads, getCachedAiReview, getLatestPublishedAiReview, markAiReviewPublished, putCachedAiReview } from "../../src/db/repositories";
 import { aiReviewCacheInputFingerprint, type AiReviewCacheInput } from "../../src/review/ai-review-cache-input";
 import { createTestEnv } from "../helpers/d1";
 
@@ -463,6 +463,25 @@ describe("AI review cache (#1)", () => {
       } finally {
         vi.useRealTimers();
       }
+    });
+  });
+
+  describe("countPublishedAiReviewHeads — auto_pause_after_reviewed_commits (#2042)", () => {
+    it("returns 0 when no published reviews exist for the PR", async () => {
+      const env = createTestEnv();
+      await putCachedAiReview(env, "o/r", 60, "sha1", "block", { notes: "unpublished", reviewerCount: 1 });
+      expect(await countPublishedAiReviewHeads(env, "o/r", 60)).toBe(0);
+      expect(await countPublishedAiReviewHeads(env, "o/r", 99)).toBe(0);
+    });
+
+    it("counts distinct published head SHAs and ignores unpublished rows", async () => {
+      const env = createTestEnv();
+      await putCachedAiReview(env, "o/r", 61, "sha1", "block", { notes: "first", reviewerCount: 1 });
+      await markAiReviewPublished(env, "o/r", 61, "sha1");
+      await putCachedAiReview(env, "o/r", 61, "sha2", "block", { notes: "second", reviewerCount: 1 });
+      await markAiReviewPublished(env, "o/r", 61, "sha2");
+      await putCachedAiReview(env, "o/r", 61, "sha3", "block", { notes: "pending", reviewerCount: 1 });
+      expect(await countPublishedAiReviewHeads(env, "o/r", 61)).toBe(2);
     });
   });
 });

--- a/test/unit/auto-review-wiring.test.ts
+++ b/test/unit/auto-review-wiring.test.ts
@@ -10,7 +10,7 @@ import * as repositoriesModule from "../../src/db/repositories";
 
 describe("review.auto_review wiring (#1954)", () => {
   it("resolvePullRequestAutoReviewSkipReason: forceAiReview bypasses every filter", () => {
-    const manifest = parseFocusManifest({ review: { auto_review: { skip_drafts: true } } });
+    const manifest = parseFocusManifest({ review: { auto_review: { skip_drafts: true, auto_pause_after_reviewed_commits: 1 } } });
     expect(
       resolvePullRequestAutoReviewSkipReason({
         forceAiReview: true,
@@ -19,6 +19,7 @@ describe("review.auto_review wiring (#1954)", () => {
         author: "dependabot[bot]",
         title: "WIP: bump",
         baseRef: "develop",
+        reviewedCommitCount: 99,
       }),
     ).toBeNull();
   });
@@ -129,6 +130,59 @@ describe("review.auto_review wiring (#1954)", () => {
     ).resolves.toEqual({ skipReason: null, reviewManifest: null });
 
     loadSpy.mockRestore();
+  });
+
+  it("resolveAutoReviewSkipForPullRequest pauses when published review count reaches the commit threshold (#2042)", async () => {
+    const manifest = parseFocusManifest({ review: { auto_review: { auto_pause_after_reviewed_commits: 2 } } });
+    const loadSpy = vi.spyOn(focusManifestLoader, "loadRepoFocusManifest").mockResolvedValue(manifest);
+    const countSpy = vi.spyOn(repositoriesModule, "countPublishedAiReviewHeads").mockResolvedValue(2);
+    const auditSpy = vi.spyOn(repositoriesModule, "recordAuditEvent").mockResolvedValue(undefined);
+
+    await expect(
+      resolveAutoReviewSkipForPullRequest({} as Env, {
+        authorBlacklisted: false,
+        isFrozenForManualReview: false,
+        repoFullName: "acme/widgets",
+        pr: { number: 5, title: "feat", baseRef: "main", isDraft: false },
+        author: "alice",
+        deliveryId: "d5",
+        headSha: "sha5",
+      }),
+    ).resolves.toEqual({ skipReason: "review paused (commit threshold)", reviewManifest: manifest });
+    expect(countSpy).toHaveBeenCalledWith(expect.anything(), "acme/widgets", 5);
+    expect(auditSpy).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ detail: "review paused (commit threshold)" }),
+    );
+
+    countSpy.mockResolvedValueOnce(1);
+    await expect(
+      resolveAutoReviewSkipForPullRequest({} as Env, {
+        authorBlacklisted: false,
+        isFrozenForManualReview: false,
+        repoFullName: "acme/widgets",
+        pr: { number: 6, title: "feat", baseRef: "main", isDraft: false },
+        author: "alice",
+        deliveryId: "d6",
+        headSha: "sha6",
+      }),
+    ).resolves.toEqual({ skipReason: null, reviewManifest: manifest });
+
+    countSpy.mockRejectedValueOnce(new Error("DB down"));
+    await expect(
+      resolveAutoReviewSkipForPullRequest({} as Env, {
+        authorBlacklisted: false,
+        isFrozenForManualReview: false,
+        repoFullName: "acme/widgets",
+        pr: { number: 7, title: "feat", baseRef: "main", isDraft: false },
+        author: "alice",
+        deliveryId: "d7",
+        headSha: "sha7",
+      }),
+    ).resolves.toEqual({ skipReason: null, reviewManifest: manifest });
+
+    loadSpy.mockRestore();
+    countSpy.mockRestore();
     auditSpy.mockRestore();
   });
 

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -2667,6 +2667,7 @@ describe("review.auto_review (#1954 / #2038–#2041)", () => {
       ignoreAuthors: ["*[bot]", "dependabot[bot]"],
       ignoreTitleKeywords: ["WIP", "draft"],
       baseBranches: ["main", "release/**"],
+      autoPauseAfterReviewedCommits: null,
     });
     expect(m.review.present).toBe(true);
     expect(parseFocusManifest({ review: reviewConfigToJson(m.review) }).review.autoReview).toEqual(m.review.autoReview);
@@ -2696,7 +2697,7 @@ describe("review.auto_review (#1954 / #2038–#2041)", () => {
 
   it("evaluateAutoReviewSkipReason: byte-identical when unset; skips with deterministic reasons when configured", () => {
     const empty = { ...EMPTY_AUTO_REVIEW_CONFIG };
-    const input = { isDraft: true, author: "dependabot[bot]", title: "WIP: bump deps", baseRef: "develop" };
+    const input = { isDraft: true, author: "dependabot[bot]", title: "WIP: bump deps", baseRef: "develop", reviewedCommitCount: 0 };
     expect(evaluateAutoReviewSkipReason(empty, input)).toBeNull();
     expect(evaluateAutoReviewSkipReason({ ...empty, skipDrafts: true }, { ...input, isDraft: true })).toBe("review skipped (draft)");
     expect(evaluateAutoReviewSkipReason({ ...empty, skipDrafts: true }, { ...input, isDraft: false })).toBeNull();
@@ -2716,6 +2717,27 @@ describe("review.auto_review (#1954 / #2038–#2041)", () => {
     );
     expect(evaluateAutoReviewSkipReason({ ...empty, skipDrafts: false }, { ...input, isDraft: true })).toBeNull();
     expect(evaluateAutoReviewSkipReason({ ...empty, ignoreAuthors: ["*[bot]"] }, { ...input, author: null })).toBeNull();
+    expect(evaluateAutoReviewSkipReason({ ...empty, autoPauseAfterReviewedCommits: 2 }, { ...input, reviewedCommitCount: 1 })).toBeNull();
+    expect(evaluateAutoReviewSkipReason({ ...empty, autoPauseAfterReviewedCommits: 2 }, { ...input, reviewedCommitCount: 2 })).toBe(
+      "review paused (commit threshold)",
+    );
+    expect(evaluateAutoReviewSkipReason({ ...empty, autoPauseAfterReviewedCommits: 0 }, { ...input, reviewedCommitCount: 99 })).toBeNull();
+    expect(evaluateAutoReviewSkipReason({ ...empty, autoPauseAfterReviewedCommits: null }, { ...input, reviewedCommitCount: 99 })).toBeNull();
+  });
+
+  it("parses auto_pause_after_reviewed_commits with bounds validation (#2042)", () => {
+    const ok = parseFocusManifest({ review: { auto_review: { auto_pause_after_reviewed_commits: 3 } } });
+    expect(ok.review.autoReview.autoPauseAfterReviewedCommits).toBe(3);
+    expect(ok.review.present).toBe(true);
+    const zero = parseFocusManifest({ review: { auto_review: { auto_pause_after_reviewed_commits: 0 } } });
+    expect(zero.review.autoReview.autoPauseAfterReviewedCommits).toBe(0);
+    const bad = parseFocusManifest({ review: { auto_review: { auto_pause_after_reviewed_commits: -1 } } });
+    expect(bad.review.autoReview.autoPauseAfterReviewedCommits).toBeNull();
+    expect(bad.warnings.some((w) => /auto_pause_after_reviewed_commits.*non-negative integer/.test(w))).toBe(true);
+    const floatBad = parseFocusManifest({ review: { auto_review: { auto_pause_after_reviewed_commits: 1.5 } } });
+    expect(floatBad.review.autoReview.autoPauseAfterReviewedCommits).toBeNull();
+    expect(reviewConfigToJson(ok.review)).toEqual({ auto_review: { auto_pause_after_reviewed_commits: 3 } });
+    expect(reviewConfigToJson(zero.review)).toEqual({ auto_review: { auto_pause_after_reviewed_commits: 0 } });
   });
 
   it("serializes explicit skip_drafts: false and drops unsafe title keywords", () => {

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -2736,6 +2736,9 @@ describe("review.auto_review (#1954 / #2038–#2041)", () => {
     expect(bad.warnings.some((w) => /auto_pause_after_reviewed_commits.*non-negative integer/.test(w))).toBe(true);
     const floatBad = parseFocusManifest({ review: { auto_review: { auto_pause_after_reviewed_commits: 1.5 } } });
     expect(floatBad.review.autoReview.autoPauseAfterReviewedCommits).toBeNull();
+    const stringBad = parseFocusManifest({ review: { auto_review: { auto_pause_after_reviewed_commits: "3" } } });
+    expect(stringBad.review.autoReview.autoPauseAfterReviewedCommits).toBeNull();
+    expect(stringBad.warnings.some((w) => /auto_pause_after_reviewed_commits.*non-negative integer/.test(w))).toBe(true);
     expect(reviewConfigToJson(ok.review)).toEqual({ auto_review: { auto_pause_after_reviewed_commits: 3 } });
     expect(reviewConfigToJson(zero.review)).toEqual({ auto_review: { auto_pause_after_reviewed_commits: 0 } });
   });

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -3289,6 +3289,56 @@ describe("queue processors", () => {
       expect(skipAudit).toBeUndefined();
     });
 
+    it("pauses AI review when auto_pause_after_reviewed_commits threshold is reached (#2042)", async () => {
+      let aiCalls = 0;
+      const env = createTestEnv({
+        GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(),
+        AI: { run: async () => { aiCalls += 1; return { response: JSON.stringify({ assessment: "Looks fine.", blockers: [], nits: [], suggestions: [] }) }; } } as unknown as Ai,
+        AI_SUMMARIES_ENABLED: "true",
+        AI_PUBLIC_COMMENTS_ENABLED: "true",
+        AI_DAILY_NEURON_BUDGET: "100000",
+      });
+      await seedRegateChurnRepo(env);
+      await upsertRepoFocusManifest(env, "JSONbored/gittensory", { review: { auto_review: { auto_pause_after_reviewed_commits: 2 } } });
+      await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
+        number: 77,
+        title: "Churny feature",
+        state: "open",
+        draft: false,
+        user: { login: "contributor" },
+        head: { sha: "a77-v3" },
+        labels: [],
+        body: "Closes #1",
+      } as never);
+      await upsertPullRequestDetailSyncState(env, { repoFullName: "JSONbored/gittensory", pullNumber: 77, status: "complete", reviewsSyncedAt: new Date().toISOString() });
+      await putCachedAiReview(env, "JSONbored/gittensory", 77, "a77-v1", "block", { notes: "First.", reviewerCount: 1 });
+      await markAiReviewPublished(env, "JSONbored/gittensory", 77, "a77-v1");
+      await putCachedAiReview(env, "JSONbored/gittensory", 77, "a77-v2", "block", { notes: "Second.", reviewerCount: 1 });
+      await markAiReviewPublished(env, "JSONbored/gittensory", 77, "a77-v2");
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = input.toString();
+        const method = init?.method ?? "GET";
+        if (url.includes("/access_tokens")) return Response.json({ token: "fake-installation-token" });
+        if (url.includes("/pulls/77/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+export const ok = true;" }]);
+        if (url.endsWith("/pulls/77")) return Response.json({ number: 77, title: "Churny feature", state: "open", draft: false, user: { login: "contributor" }, head: { sha: "a77-v3" }, labels: [], body: "Closes #1", mergeable_state: "clean" });
+        if (url.includes("/commits/a77-v3/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+        if (url.includes("/commits/a77-v3/status")) return Response.json({ state: "success", statuses: [] });
+        if (url.includes("/issues/77/comments")) return method === "POST" ? Response.json({ id: 77 }, { status: 201 }) : Response.json([]);
+        if (url.includes("/issues/1")) return Response.json({ number: 1, title: "Issue", state: "open", labels: [], user: { login: "reporter" } });
+        if (url.includes("/branches/")) return Response.json({ protected: false, protection: { required_status_checks: { contexts: [] } } });
+        return Response.json({});
+      });
+
+      await expect(
+        processJob(env, { type: "agent-regate-pr", deliveryId: "auto-review-pause-threshold", repoFullName: "JSONbored/gittensory", prNumber: 77, installationId: 123 }),
+      ).resolves.toBeUndefined();
+      expect(aiCalls).toBe(0);
+      const audit = await env.DB.prepare("select detail from audit_events where event_type = ? and target_key = ?")
+        .bind("github_app.ai_review_auto_review_skipped", "JSONbored/gittensory#77")
+        .first<{ detail: string }>();
+      expect(audit?.detail).toBe("review paused (commit threshold)");
+    });
+
     it("#9: the public surface is not republished when already current at the head (check-run-only repo, req 6)", async () => {
       const env = createTestEnv({
         GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(),

--- a/test/unit/signals-coverage.test.ts
+++ b/test/unit/signals-coverage.test.ts
@@ -1127,7 +1127,7 @@ describe("signal coverage edge cases", () => {
       collisions: buildCollisionReport(directRepo.fullName, [], [currentPr]),
       preflight: buildPreflightResult({ repoFullName: directRepo.fullName, title: "Fix isolated issue", body: "Fixes #99", linkedIssues: [99] }, directRepo, [], [currentPr]),
       settings: gateSettings,
-      review: { present: true, footerText: "Reviewed by the Acme maintainer bot.", note: "Run npm test before pushing.", fields: { relatedWork: false }, enrichmentAnalyzers: {}, profile: null, securityFocus: null, inlineComments: null, pathInstructions: [], instructions: null, excludePaths: [], pathFilters: [], preMergeChecks: [], autoReview: { skipDrafts: null, ignoreAuthors: [], ignoreTitleKeywords: [], baseBranches: [] } },
+      review: { present: true, footerText: "Reviewed by the Acme maintainer bot.", note: "Run npm test before pushing.", fields: { relatedWork: false }, enrichmentAnalyzers: {}, profile: null, securityFocus: null, inlineComments: null, pathInstructions: [], instructions: null, excludePaths: [], pathFilters: [], preMergeChecks: [], autoReview: { skipDrafts: null, ignoreAuthors: [], ignoreTitleKeywords: [], baseBranches: [], autoPauseAfterReviewedCommits: null } },
       aiReview: { notes: "The change is focused.\n\n**Nits (2)**\n- Add a test for the </details> edge case.\n- Keep the validator helper scoped." },
     });
     expect(customizedComment).toContain("Reviewed by the Acme maintainer bot."); // custom footer lead


### PR DESCRIPTION
## Summary
- Add `review.auto_review.auto_pause_after_reviewed_commits` (non-negative int; `0`/unset = off) to cap AI re-review spend on churny PRs (#2042).
- When published review count on the PR reaches the threshold, skip AI review with audit event `review paused (commit threshold)` - never a gate failure; `forceAiReview` bypasses.
- Completes the last #1954 eligibility filter knob.

Closes #2042

Part of #1954. Supersedes closed #3501 (codecov patch fix).

## Test plan
- [x] `npm run typecheck`
- [x] Targeted vitest + `countPublishedAiReviewHeads` repository tests
- [ ] CI green including `codecov/patch` ?99%