### PR TITLE
fix(signals): classify Ruby and Rust protobuf stubs as generated

### DIFF
--- a/src/signals/path-matchers.ts
+++ b/src/signals/path-matchers.ts
@@ -52,15 +52,17 @@ function isGeneratedFileFrom(parts: NormalizedPath): boolean {
     /\.(generated|gen)\.[^/]+$/.test(norm) ||
     // protoc output: Go/TS/JS plugins emit `.pb.{go,ts,js}`, the reference C++ plugin emits
     // `.pb.cc` / `.pb.h`, the Swift plugin emits `.pb.swift`, the Dart plugin emits `.pb.dart`,
-    // the Kotlin plugin emits `.pb.kt`, the C# plugin emits `.pb.cs`, and the Objective-C plugin
-    // emits `.pbobjc.{h,m}` plus gRPC `.pbrpc.{h,m}` service stubs.
+    // the Kotlin plugin emits `.pb.kt`, the C# plugin emits `.pb.cs`, the Rust plugin emits `.pb.rs`,
+    // and the Objective-C plugin emits `.pbobjc.{h,m}` plus gRPC `.pbrpc.{h,m}` service stubs.
     // `.pb.dart`/`.pb.kt`/`.pb.cs` (the `.pb` infix keeps hand-written sources from matching).
-    /\.pb\.(go|ts|js|cc|h|swift|dart|kt|cs)$/.test(norm) ||
+    /\.pb\.(go|ts|js|cc|h|swift|dart|kt|cs|rs)$/.test(norm) ||
     /\.pbobjc\.(h|m)$/.test(norm) ||
     /\.pbrpc\.(h|m)$/.test(norm) ||
     // Python protobuf: message stubs are `*_pb2.py[i]`; the gRPC plugin emits sibling
     // `*_pb2_grpc.py[i]` service stubs, which are the same machine-generated output.
     /_pb2(_grpc)?\.pyi?$/.test(norm) ||
+    // Ruby protobuf: message stubs are `*_pb.rb`; the gRPC plugin emits sibling `*_services_pb.rb`.
+    /_pb\.rb$/.test(norm) ||
     // Dart codegen: build_runner (`.g.dart`), freezed (`.freezed.dart`), and
     // retrofit/injectable (`.gr.dart`) all emit generated part files.
     /\.(g|freezed|gr)\.dart$/.test(norm) ||

--- a/test/unit/path-matchers.test.ts
+++ b/test/unit/path-matchers.test.ts
@@ -77,6 +77,15 @@ describe("isGeneratedFile", () => {
     }
   });
 
+  it("matches Ruby protobuf and gRPC stubs alongside the other protoc plugins", () => {
+    for (const path of ["gen/service_pb.rb", "gen/service_services_pb.rb", "proto/messages.pb.rs"]) {
+      expect(isGeneratedFile(path)).toBe(true);
+    }
+    for (const path of ["lib/service.rb", "src/main.rs"]) {
+      expect(isGeneratedFile(path)).toBe(false);
+    }
+  });
+
   it("matches Swift protobuf, Dart freezed/retrofit, C# designer/XAML, and Objective-C protoc output", () => {
     for (const path of [
       "proto/messages.pb.swift",


### PR DESCRIPTION
## Summary

Extend `isGeneratedFile` to recognize grpc-ruby message/service stubs (`*_pb.rb`, including `*_services_pb.rb`) and protoc Rust output (`.pb.rs`), matching the existing `.pb.*` / `_pb2` protobuf plugin coverage.

Fixes #561

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- None skipped.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — signals-only change with no visible UI.

## Notes

Incremental **maintenance** parity for the path-matcher slop signals from #561. Supports generated-file classification work tracked in #2143.

Made with [Cursor](https://cursor.com)