### PR TITLE
fix(signals): classify PHP protobuf stubs as generated

### DIFF
--- a/src/signals/path-matchers.ts
+++ b/src/signals/path-matchers.ts
@@ -63,6 +63,8 @@ function isGeneratedFileFrom(parts: NormalizedPath): boolean {
     /_pb2(_grpc)?\.pyi?$/.test(norm) ||
     // Ruby protobuf: message stubs are `*_pb.rb`; the gRPC plugin emits sibling `*_services_pb.rb`.
     /_pb\.rb$/.test(norm) ||
+    // PHP protobuf: message stubs are `*_pb.php`; the gRPC plugin emits sibling `*_grpc_pb.php`.
+    /_pb\.php$/.test(norm) ||
     // Dart codegen: build_runner (`.g.dart`), freezed (`.freezed.dart`), and
     // retrofit/injectable (`.gr.dart`) all emit generated part files.
     /\.(g|freezed|gr)\.dart$/.test(norm) ||

--- a/test/unit/path-matchers.test.ts
+++ b/test/unit/path-matchers.test.ts
@@ -77,11 +77,17 @@ describe("isGeneratedFile", () => {
     }
   });
 
-  it("matches Ruby protobuf and gRPC stubs alongside the other protoc plugins", () => {
-    for (const path of ["gen/service_pb.rb", "gen/service_services_pb.rb", "proto/messages.pb.rs"]) {
+  it("matches Ruby, PHP, and Rust protobuf stubs alongside the other protoc plugins", () => {
+    for (const path of [
+      "gen/service_pb.rb",
+      "gen/service_services_pb.rb",
+      "gen/service_pb.php",
+      "gen/service_grpc_pb.php",
+      "proto/messages.pb.rs",
+    ]) {
       expect(isGeneratedFile(path)).toBe(true);
     }
-    for (const path of ["lib/service.rb", "src/main.rs"]) {
+    for (const path of ["lib/service.rb", "src/api.php", "src/main.rs"]) {
       expect(isGeneratedFile(path)).toBe(false);
     }
   });


### PR DESCRIPTION
## Summary

Extend `isGeneratedFile` to recognize grpc-php message stubs (`*_pb.php`) and gRPC service stubs (`*_grpc_pb.php`), matching the existing `_pb.rb` / `_pb2` protobuf plugin coverage.

Fixes #561

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- None skipped.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — signals-only change with no visible UI.

## Notes

Incremental **maintenance** parity for the path-matcher slop signals from #561. Supports generated-file classification work tracked in #2143.

Made with [Cursor](https://cursor.com)