### PR TITLE
fix(signals): classify Elixir and Swift gRPC protobuf stubs as generated

### DIFF
--- a/src/signals/path-matchers.ts
+++ b/src/signals/path-matchers.ts
@@ -53,9 +53,11 @@ function isGeneratedFileFrom(parts: NormalizedPath): boolean {
     // protoc output: Go/TS/JS plugins emit `.pb.{go,ts,js}`, the reference C++ plugin emits
     // `.pb.cc` / `.pb.h`, the Swift plugin emits `.pb.swift`, the Dart plugin emits `.pb.dart`,
     // the Kotlin plugin emits `.pb.kt`, the C# plugin emits `.pb.cs`, the Rust plugin emits `.pb.rs`,
-    // and the Objective-C plugin emits `.pbobjc.{h,m}` plus gRPC `.pbrpc.{h,m}` service stubs.
+    // the Elixir plugin emits `.pb.ex`, and the Objective-C plugin emits `.pbobjc.{h,m}` plus gRPC
+    // `.pbrpc.{h,m}` service stubs. Swift gRPC emits sibling `.grpc.swift` service stubs.
     // `.pb.dart`/`.pb.kt`/`.pb.cs` (the `.pb` infix keeps hand-written sources from matching).
-    /\.pb\.(go|ts|js|cc|h|swift|dart|kt|cs|rs)$/.test(norm) ||
+    /\.pb\.(go|ts|js|cc|h|swift|dart|kt|cs|rs|ex)$/.test(norm) ||
+    /\.grpc\.swift$/.test(norm) ||
     /\.pbobjc\.(h|m)$/.test(norm) ||
     /\.pbrpc\.(h|m)$/.test(norm) ||
     // Python protobuf: message stubs are `*_pb2.py[i]`; the gRPC plugin emits sibling

--- a/test/unit/path-matchers.test.ts
+++ b/test/unit/path-matchers.test.ts
@@ -77,19 +77,24 @@ describe("isGeneratedFile", () => {
     }
   });
 
-  it("matches Ruby, PHP, and Rust protobuf stubs alongside the other protoc plugins", () => {
+  it("matches Ruby, PHP, Rust, Elixir, and Swift gRPC protobuf stubs alongside the other protoc plugins", () => {
     for (const path of [
       "gen/service_pb.rb",
       "gen/service_services_pb.rb",
       "gen/service_pb.php",
       "gen/service_grpc_pb.php",
       "proto/messages.pb.rs",
+      "lib/my_proto.pb.ex",
+      "proto/service.grpc.swift",
     ]) {
       expect(isGeneratedFile(path)).toBe(true);
     }
-    for (const path of ["lib/service.rb", "src/api.php", "src/main.rs"]) {
+    for (const path of ["lib/service.rb", "src/api.php", "src/main.rs", "lib/my_app.ex"]) {
       expect(isGeneratedFile(path)).toBe(false);
     }
+    expect(classifyChangedFile("gen/service_grpc_pb.php")).toBe("generated");
+    expect(classifyChangedFile("lib/my_proto.pb.ex")).toBe("generated");
+    expect(classifyChangedFile("proto/service.grpc.swift")).toBe("generated");
   });
 
   it("matches Swift protobuf, Dart freezed/retrofit, C# designer/XAML, and Objective-C protoc output", () => {
@@ -411,6 +416,9 @@ describe("classifyChangedFile", () => {
     const cases: Array<[string, ReturnType<typeof classifyChangedFile>]> = [
       ["dist/app.min.js", "minified"],
       ["src/api.generated.ts", "generated"],
+      ["gen/service_grpc_pb.php", "generated"],
+      ["lib/my_proto.pb.ex", "generated"],
+      ["proto/service.grpc.swift", "generated"],
       ["vendor/lib.go", "vendored"],
       ["package-lock.json", "lockfile"],
       ["bun.lock", "lockfile"],


### PR DESCRIPTION
## Summary

Extend `isGeneratedFile` to recognize protobuf_elixir message stubs (`.pb.ex`) and grpc-swift service stubs (`.grpc.swift`), matching the existing protoc plugin coverage. Includes direct `classifyChangedFile` assertions for the hot-path category behavior.

Fixes #561

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- None skipped.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — signals-only change with no visible UI.

## Notes

Incremental **maintenance** parity for the path-matcher slop signals from #561. Supports generated-file classification work tracked in #2143.

Made with [Cursor](https://cursor.com)