### PR TITLE
fix(signals): classify Erlang gpb protobuf stubs as generated

### DIFF
--- a/src/signals/path-matchers.ts
+++ b/src/signals/path-matchers.ts
@@ -53,10 +53,11 @@ function isGeneratedFileFrom(parts: NormalizedPath): boolean {
     // protoc output: Go/TS/JS plugins emit `.pb.{go,ts,js}`, the reference C++ plugin emits
     // `.pb.cc` / `.pb.h`, the Swift plugin emits `.pb.swift`, the Dart plugin emits `.pb.dart`,
     // the Kotlin plugin emits `.pb.kt`, the C# plugin emits `.pb.cs`, the Rust plugin emits `.pb.rs`,
-    // the Elixir plugin emits `.pb.ex`, and the Objective-C plugin emits `.pbobjc.{h,m}` plus gRPC
-    // `.pbrpc.{h,m}` service stubs. Swift gRPC emits sibling `.grpc.swift` service stubs.
+    // the Elixir plugin emits `.pb.ex`, the Erlang gpb plugin emits `.pb.erl` / `.pb.hrl`, and the
+    // Objective-C plugin emits `.pbobjc.{h,m}` plus gRPC `.pbrpc.{h,m}` service stubs. Swift gRPC
+    // emits sibling `.grpc.swift` service stubs.
     // `.pb.dart`/`.pb.kt`/`.pb.cs` (the `.pb` infix keeps hand-written sources from matching).
-    /\.pb\.(go|ts|js|cc|h|swift|dart|kt|cs|rs|ex)$/.test(norm) ||
+    /\.pb\.(go|ts|js|cc|h|swift|dart|kt|cs|rs|ex|erl|hrl)$/.test(norm) ||
     /\.grpc\.swift$/.test(norm) ||
     /\.pbobjc\.(h|m)$/.test(norm) ||
     /\.pbrpc\.(h|m)$/.test(norm) ||

--- a/test/unit/path-matchers.test.ts
+++ b/test/unit/path-matchers.test.ts
@@ -97,6 +97,17 @@ describe("isGeneratedFile", () => {
     expect(classifyChangedFile("proto/service.grpc.swift")).toBe("generated");
   });
 
+  it("matches Erlang gpb protobuf output alongside the other protoc plugins", () => {
+    for (const path of ["proto/messages.pb.erl", "proto/messages.pb.hrl"]) {
+      expect(isGeneratedFile(path)).toBe(true);
+    }
+    for (const path of ["src/server.erl", "include/records.hrl"]) {
+      expect(isGeneratedFile(path)).toBe(false);
+    }
+    expect(classifyChangedFile("proto/messages.pb.erl")).toBe("generated");
+    expect(classifyChangedFile("proto/messages.pb.hrl")).toBe("generated");
+  });
+
   it("matches Swift protobuf, Dart freezed/retrofit, C# designer/XAML, and Objective-C protoc output", () => {
     for (const path of [
       "proto/messages.pb.swift",
@@ -419,6 +430,8 @@ describe("classifyChangedFile", () => {
       ["gen/service_grpc_pb.php", "generated"],
       ["lib/my_proto.pb.ex", "generated"],
       ["proto/service.grpc.swift", "generated"],
+      ["proto/messages.pb.erl", "generated"],
+      ["proto/messages.pb.hrl", "generated"],
       ["vendor/lib.go", "vendored"],
       ["package-lock.json", "lockfile"],
       ["bun.lock", "lockfile"],


### PR DESCRIPTION
## Summary

Extend `isGeneratedFile` to recognize Erlang gpb protobuf output (`.pb.erl` / `.pb.hrl`), matching the existing `.pb.*` protoc plugin coverage. Includes direct `classifyChangedFile` assertions and hand-authored Erlang negative cases.

Fixes #561

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- None skipped.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — signals-only change with no visible UI.

## Notes

Incremental **maintenance** parity for the path-matcher slop signals from #561. Supports generated-file classification work tracked in #2143.

Made with [Cursor](https://cursor.com)