### PR TITLE
fix(selfhost): give verdict the same state/merged_at precedence status has

### DIFF
--- a/scripts/export-grafana-reporting-db.sh
+++ b/scripts/export-grafana-reporting-db.sh
@@ -223,12 +223,17 @@ current_pull_requests AS (
       WHEN a.conclusion IS NOT NULL THEN 'commented'
       ELSE 'manual'
     END AS status,
-    CASE a.conclusion
-      WHEN 'success' THEN 'merge'
-      WHEN 'failure' THEN 'close'
-      WHEN 'action_required' THEN 'manual'
-      WHEN 'neutral' THEN 'manual'
-      WHEN 'skipped' THEN 'ignore'
+    -- The terminal PR outcome (state/merged_at) is the source of truth and takes precedence, exactly like
+    -- status above -- otherwise a merged/closed PR whose advisories.conclusion happens to read
+    -- neutral/action_required (the only two values GitHub Checks reports for the gate's own check run today)
+    -- reports verdict='manual' forever, even though the PR is long since merged/closed (#3511 dashboard bug).
+    CASE
+      WHEN lower(p.state) = 'closed' AND p.merged_at IS NOT NULL THEN 'merge'
+      WHEN lower(p.state) = 'closed' THEN 'close'
+      WHEN a.conclusion = 'success' THEN 'merge'
+      WHEN a.conclusion = 'failure' THEN 'close'
+      WHEN a.conclusion IN ('action_required', 'neutral') THEN 'manual'
+      WHEN a.conclusion = 'skipped' THEN 'ignore'
       ELSE NULL
     END AS verdict,
     p.title AS title,
@@ -378,12 +383,16 @@ current_pull_requests AS (
       WHEN a.conclusion IS NOT NULL THEN 'commented'
       ELSE 'manual'
     END AS status,
-    CASE a.conclusion
-      WHEN 'success' THEN 'merge'
-      WHEN 'failure' THEN 'close'
-      WHEN 'action_required' THEN 'manual'
-      WHEN 'neutral' THEN 'manual'
-      WHEN 'skipped' THEN 'ignore'
+    -- Mirrors status's precedence above (see the matching comment in the Postgres-source block): the terminal
+    -- PR outcome wins over advisories.conclusion, or a merged/closed PR reports verdict='manual' forever
+    -- (#3511).
+    CASE
+      WHEN lower(p.state) = 'closed' AND p.merged_at IS NOT NULL THEN 'merge'
+      WHEN lower(p.state) = 'closed' THEN 'close'
+      WHEN a.conclusion = 'success' THEN 'merge'
+      WHEN a.conclusion = 'failure' THEN 'close'
+      WHEN a.conclusion IN ('action_required', 'neutral') THEN 'manual'
+      WHEN a.conclusion = 'skipped' THEN 'ignore'
       ELSE NULL
     END AS verdict,
     p.title AS title,

--- a/test/unit/selfhost-grafana-reporting.test.ts
+++ b/test/unit/selfhost-grafana-reporting.test.ts
@@ -263,6 +263,54 @@ esac
     expect(sqlite(outDb, "SELECT title FROM review_targets WHERE repo='JSONbored/gittensory' AND number=1049;")).toBe("historical PR");
   });
 
+  it("REGRESSION (#3511 dashboard bug): a merged/closed PR reports its OWN verdict, not 'manual', even though advisories.conclusion is stuck at neutral/action_required", () => {
+    const root = tmpRoot();
+    const appDb = join(root, "app.sqlite");
+    const outDb = join(root, "reporting.sqlite");
+    sqlite(appDb, `
+      CREATE TABLE pull_requests (
+        repo_full_name TEXT NOT NULL,
+        number INTEGER NOT NULL,
+        title TEXT NOT NULL,
+        state TEXT NOT NULL,
+        author_login TEXT,
+        merged_at TEXT,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+      INSERT INTO pull_requests (repo_full_name, number, title, state, author_login, merged_at, created_at, updated_at)
+      VALUES
+        ('JSONbored/gittensory', 2001, 'merged despite a stuck neutral advisory', 'closed', 'JSONbored', '2026-07-05T09:43:12Z', '2026-07-05T09:30:00Z', '2026-07-05T09:43:12Z'),
+        ('JSONbored/gittensory', 2002, 'closed (not merged) despite a stuck action_required advisory', 'closed', 'JSONbored', NULL, '2026-07-05T09:30:00Z', '2026-07-05T09:43:12Z'),
+        ('JSONbored/gittensory', 2003, 'still open, genuinely held for manual review', 'open', 'JSONbored', NULL, '2026-07-05T09:30:00Z', '2026-07-05T09:43:12Z');
+
+      CREATE TABLE advisories (
+        repo_full_name TEXT NOT NULL,
+        pull_number INTEGER,
+        conclusion TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
+      INSERT INTO advisories (repo_full_name, pull_number, conclusion, updated_at)
+      VALUES
+        -- Reproduces the live production data: the gate's own advisories.conclusion is stuck at
+        -- neutral/action_required for every PR (a separate, unrelated pipeline gap) -- a merged/closed PR must
+        -- not be forced through those branches into verdict='manual' just because this column never resolved.
+        ('JSONbored/gittensory', 2001, 'neutral', '2026-07-05T09:31:00Z'),
+        ('JSONbored/gittensory', 2002, 'action_required', '2026-07-05T09:31:00Z'),
+        ('JSONbored/gittensory', 2003, 'neutral', '2026-07-05T09:31:00Z');
+    `);
+
+    runExporter(root, appDb, outDb);
+
+    expect(sqlite(outDb, "PRAGMA quick_check;")).toBe("ok");
+    expect(sqlite(outDb, "SELECT status || '|' || verdict FROM review_targets WHERE repo='JSONbored/gittensory' AND number=2001;")).toBe("merged|merge");
+    expect(sqlite(outDb, "SELECT status || '|' || verdict FROM review_targets WHERE repo='JSONbored/gittensory' AND number=2002;")).toBe("closed|close");
+    // A genuinely still-open PR is unaffected by the fix -- it has no terminal state/merged_at to take
+    // precedence, so it still falls through to the (separately broken, out of scope here) advisories.conclusion
+    // mapping, exactly as before.
+    expect(sqlite(outDb, "SELECT status || '|' || verdict FROM review_targets WHERE repo='JSONbored/gittensory' AND number=2003;")).toBe("manual|manual");
+  });
+
   it("falls back to legacy review_targets when the current PR cache is absent", () => {
     const root = tmpRoot();
     const appDb = join(root, "app.sqlite");


### PR DESCRIPTION
Closes #3511

## Summary

- **Bug:** the Grafana "Reviews & PRs (maintainer)" dashboard's "Manual review" stat matched "PRs tracked" exactly (472/472) — every PR, including merged/closed ones, showed `verdict=manual`.
- **Root cause:** `scripts/export-grafana-reporting-db.sh` builds the reporting-database `verdict` column purely from `advisories.conclusion`, unlike the `status` column right above it (which checks `p.state`/`p.merged_at` FIRST). Verified against live production Postgres: `advisories.conclusion` is stuck at only `neutral`/`action_required` for every row (a separate, pre-existing gap — `persistAdvisory` in `src/db/repositories.ts` has zero callers anywhere in `src/`, confirmed by grep, so nothing ever writes a `success`/`failure`/`skipped` row for a live gate evaluation). Since both surviving values map to `'manual'`, `verdict` was mathematically forced to `'manual'` regardless of the PR's real outcome.
- **Fix:** mirror `status`'s own precedence into `verdict`'s `CASE` (both the Postgres-source and SQLite-source blocks): check `p.state`/`p.merged_at` first, and only fall back to `a.conclusion` for a PR that's still open. Verified against live production data for the exact 5 PRs visible in the reported dashboard screenshot (gittensory#3503/#3505/#3506, metagraphed#3646, awesome-claude#4409) — all now resolve to `merge`/`close` instead of `manual`.
- Still-open PRs are intentionally unaffected — they still resolve `verdict` from the same (separately broken) `advisories.conclusion` column as before. Wiring up `persistAdvisory` into the live gate-evaluation path is a bigger, separate application-code change; not bundled into this reporting-script fix.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (clean)
- [x] `shellcheck scripts/export-grafana-reporting-db.sh` (clean, no CI step requires this but ran it as extra diligence on a shell-script change)
- [x] `npx vitest run test/unit/selfhost-grafana-reporting.test.ts` — 11/11 passing (10 existing + 1 new regression test)
- [x] Verified the exact fixed SQL directly against live production Postgres (read-only) for the 5 known-wrong PRs from the reported dashboard screenshot — all resolve correctly now.
- [ ] `npm run test:workers` / `npm run build:mcp` / `npm run test:mcp-pack` / `npm run ui:openapi:check` / `npm run ui:build` — not run individually; no worker/MCP/OpenAPI/UI surface touched.
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — added a regression test reproducing the exact production bug shape (a merged PR and a closed-not-merged PR, each with `advisories.conclusion` stuck at `neutral`/`action_required`), asserting the correct verdict now surfaces, plus a control case confirming a genuinely still-open PR's behavior is unchanged.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A; no auth/session/CORS surface touched.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no request/response contract change.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI change (this is an internal maintainer-only Grafana dashboard, not the product UI).
- [ ] Visible UI changes include a `UI Evidence` section below. — N/A, not a `apps/gittensory-ui` change.
- [ ] Public docs/changelogs are updated where needed. — N/A, internal reporting-pipeline fix, no documented/user-facing behavior change.

## Notes

Root-caused via a 3-way parallel investigation (dashboard JSON, live production DB, application source code) after the user reported the dashboard symptom directly. All three independently converged on the same file/root cause, then independently cross-verified against live Postgres before implementing.