### PR TITLE
feat(review): show configured review effort

### DIFF
--- a/.gittensory.yml.example
+++ b/.gittensory.yml.example
@@ -597,6 +597,8 @@ settings:
 #     - "!src/generated/**"
 #   # Public-safe voice brief complementing review.profile (e.g. concise, cite line numbers). null/unset ⇒ byte-identical prompt.
 #   tone: "Be concise and cite line numbers."
+#   # Show a deterministic "review effort: N/5 (~M min)" line in the unified review comment. Default: false/unset.
+#   effort_score: true
 #   # Deterministic AI review eligibility filters — skipped PRs never fail the gate. (#1954)
 #   auto_review:
 #     skip_drafts: true

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -335,6 +335,7 @@ import {
 } from "../signals/engine";
 import { isDuplicateClusterWinnerByClaim } from "../signals/duplicate-winner";
 import { buildUnifiedReviewDiff } from "../review/review-diff";
+import { estimateReviewEffort } from "../review/review-effort";
 import { buildUnifiedCommentBody } from "../review/unified-comment-bridge";
 import { randomUUID } from "node:crypto";
 import { isRetryableJobError, RetryableJobError } from "./retryable";
@@ -9195,6 +9196,16 @@ async function maybePublishPrPublicSurface(
           : {}),
         readinessTotal,
         changedFiles: unifiedFiles.length,
+        ...(reviewConfig?.effortScore === true
+          ? {
+              reviewEffort: estimateReviewEffort(
+                unifiedFiles.map((file) => ({
+                  path: file.path,
+                  patch: typeof file.payload?.patch === "string" ? file.payload.patch : undefined,
+                })),
+              ),
+            }
+          : {}),
         ...(aiReview?.reviewerCount !== undefined
           ? { reviewerCount: aiReview.reviewerCount }
           : {}),

--- a/src/review/unified-comment-bridge.ts
+++ b/src/review/unified-comment-bridge.ts
@@ -35,6 +35,7 @@ import {
   type ReviewNotes,
   type ReviewRecommendation,
   type UnifiedCollapsible,
+  type UnifiedReviewEffort,
   type UnifiedSignalRow,
   type Verdict,
 } from "./unified-comment";
@@ -287,6 +288,8 @@ export type UnifiedCommentBridgeArgs = {
   readinessTotal: number;
   /** Number of changed files reviewed. */
   changedFiles: number;
+  /** Optional deterministic review-effort estimate, present only when `.gittensory.yml review.effort_score` is true. */
+  reviewEffort?: UnifiedReviewEffort | undefined;
   /** Number of independent AI reviewers synthesized (0 hides the reviewer chip/row evidence count). */
   reviewerCount?: number | undefined;
   /** CI + merge-state readiness, when the caller resolved it (gittensory's panel omits it today). */
@@ -394,6 +397,7 @@ export function buildUnifiedCommentBody(args: UnifiedCommentBridgeArgs): string 
     changedFiles: args.changedFiles,
     reviews,
     decision: verdict,
+    ...(args.reviewEffort !== undefined ? { reviewEffort: args.reviewEffort } : {}),
     ...(verdictReason !== undefined ? { verdictReason } : {}),
     ...(args.mergeReadiness !== undefined ? { readiness: args.mergeReadiness } : {}),
     ...(args.merged !== undefined ? { merged: args.merged } : {}),

--- a/src/review/unified-comment.ts
+++ b/src/review/unified-comment.ts
@@ -139,6 +139,7 @@ export function extractReviewSummary(reviews: DualReviewNote[]): ExtractedReview
 
 /** The four visual states the comment recolors between (bar + GitHub alert sidebar together). */
 export type UnifiedCommentStatus = "ready" | "advisory" | "held" | "blocked";
+export type UnifiedReviewEffort = { band: 1 | 2 | 3 | 4 | 5; minutes: number };
 
 /** reviewbot's review side of the comment (mapped by the host/runtime from the gate decision + notes). */
 export interface UnifiedReviewInput {
@@ -162,6 +163,8 @@ export interface UnifiedReviewInput {
   merged?: boolean;
   /** Optional short reason appended to the verdict line. */
   verdictReason?: string;
+  /** Deterministic review-effort estimate shown only when the repo manifest enables it. */
+  reviewEffort?: UnifiedReviewEffort;
   /** Whether blocker(s) are a consensus (≥2 reviewers / sole reviewer) — drives blocked vs held. */
   consensusBlocker?: boolean;
   /** Reviewers that produced no parseable verdict (a partial review → held, not ready). */
@@ -493,6 +496,10 @@ export function renderUnifiedReviewComment(input: UnifiedReviewInput, ctx: Unifi
     verdictLine(status, input, ctx),
   ];
 
+  if (input.reviewEffort) {
+    blocks.push(`**review effort:** ${input.reviewEffort.band}/5 (~${input.reviewEffort.minutes} min)`);
+  }
+
   if (input.summary.trim()) blocks.push(`**Review summary**\n${escapePublicHtmlAngles(input.summary.trim())}`);
 
   const nits = dedupeLines(input.nits ?? []);
@@ -544,6 +551,7 @@ export function buildUnifiedReviewInput(opts: {
   decision?: Verdict;
   merged?: boolean;
   verdictReason?: string;
+  reviewEffort?: UnifiedReviewEffort;
 }): UnifiedReviewInput {
   const ex = extractReviewSummary(opts.reviews);
   const changedFiles = typeof opts.changedFiles === "number" ? opts.changedFiles : opts.changedFiles.length;
@@ -560,6 +568,7 @@ export function buildUnifiedReviewInput(opts: {
     ...(opts.decision !== undefined ? { decision: opts.decision } : {}),
     ...(opts.merged !== undefined ? { merged: opts.merged } : {}),
     ...(opts.verdictReason !== undefined ? { verdictReason: opts.verdictReason } : {}),
+    ...(opts.reviewEffort !== undefined ? { reviewEffort: opts.reviewEffort } : {}),
   };
 }
 

--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -304,6 +304,9 @@ export type FocusManifestReviewConfig = {
   /** `review.tone`: a bounded public-safe voice brief complementing `review.profile` (e.g. "concise, cite line numbers").
    *  Folded into the review-instructions slot at runtime. null (default, absent) ⇒ byte-identical prompt. (#2044) */
   tone: string | null;
+  /** `review.effort_score`: when true, include a compact deterministic review-effort line in the unified comment.
+   *  null/false (default, absent) = byte-identical public comment. (#2069) */
+  effortScore: boolean | null;
   /** `review.security_focus`: when true, the AI reviewer is told to prioritize a security-defect category
    *  (injection, authn/authz bypass, secret handling, unsafe deserialization, SSRF, path traversal) with
    *  elevated scrutiny, ON TOP OF whatever `profile` volume is set — an orthogonal "what to prioritize" axis,
@@ -524,7 +527,7 @@ const EMPTY_MANIFEST: FocusManifest = {
   publicNotes: [],
   gate: { ...EMPTY_GATE_CONFIG },
   settings: {},
-  review: { present: false, footerText: null, note: null, fields: {}, enrichmentAnalyzers: {}, profile: null, tone: null, securityFocus: null, inlineComments: null, pathInstructions: [], instructions: null, excludePaths: [], pathFilters: [], preMergeChecks: [], autoReview: { ...EMPTY_AUTO_REVIEW_CONFIG } },
+  review: { present: false, footerText: null, note: null, fields: {}, enrichmentAnalyzers: {}, profile: null, tone: null, effortScore: null, securityFocus: null, inlineComments: null, pathInstructions: [], instructions: null, excludePaths: [], pathFilters: [], preMergeChecks: [], autoReview: { ...EMPTY_AUTO_REVIEW_CONFIG } },
   features: { ...EMPTY_FEATURES_CONFIG },
   contentLane: { ...EMPTY_CONTENT_LANE_CONFIG },
   repoDocGeneration: { ...EMPTY_REPO_DOC_GENERATION_CONFIG },
@@ -554,7 +557,7 @@ function emptyManifest(source: FocusManifestSource, warnings: string[] = []): Fo
     warnings,
     gate: { ...EMPTY_GATE_CONFIG },
     settings: {},
-    review: { present: false, footerText: null, note: null, fields: {}, enrichmentAnalyzers: {}, profile: null, tone: null, securityFocus: null, inlineComments: null, pathInstructions: [], instructions: null, excludePaths: [], pathFilters: [], preMergeChecks: [], autoReview: { ...EMPTY_AUTO_REVIEW_CONFIG } },
+    review: { present: false, footerText: null, note: null, fields: {}, enrichmentAnalyzers: {}, profile: null, tone: null, effortScore: null, securityFocus: null, inlineComments: null, pathInstructions: [], instructions: null, excludePaths: [], pathFilters: [], preMergeChecks: [], autoReview: { ...EMPTY_AUTO_REVIEW_CONFIG } },
     features: { ...EMPTY_FEATURES_CONFIG },
     contentLane: { ...EMPTY_CONTENT_LANE_CONFIG },
     repoDocGeneration: { ...EMPTY_REPO_DOC_GENERATION_CONFIG },
@@ -1469,7 +1472,7 @@ function parsePublicSafeText(value: JsonValue | undefined, field: string, warnin
  * throws; invalid/unsafe values are dropped with warnings.
  */
 function parseReviewConfig(value: JsonValue | undefined, warnings: string[]): FocusManifestReviewConfig {
-  const empty: FocusManifestReviewConfig = { present: false, footerText: null, note: null, fields: {}, enrichmentAnalyzers: {}, profile: null, tone: null, securityFocus: null, inlineComments: null, pathInstructions: [], instructions: null, excludePaths: [], pathFilters: [], preMergeChecks: [], autoReview: { ...EMPTY_AUTO_REVIEW_CONFIG } };
+  const empty: FocusManifestReviewConfig = { present: false, footerText: null, note: null, fields: {}, enrichmentAnalyzers: {}, profile: null, tone: null, effortScore: null, securityFocus: null, inlineComments: null, pathInstructions: [], instructions: null, excludePaths: [], pathFilters: [], preMergeChecks: [], autoReview: { ...EMPTY_AUTO_REVIEW_CONFIG } };
   if (value === undefined || value === null) return empty;
   if (typeof value !== "object" || Array.isArray(value)) {
     warnings.push(`Manifest field "review" must be a mapping; ignoring it.`);
@@ -1504,6 +1507,7 @@ function parseReviewConfig(value: JsonValue | undefined, warnings: string[]): Fo
   const note = parsePublicSafeText(r.note, "review.note", warnings);
   const profile = parseReviewProfile(r.profile, warnings);
   const tone = parsePublicSafeText(r.tone, "review.tone", warnings);
+  const effortScore = normalizeOptionalBoolean(r.effort_score, "review.effort_score", warnings);
   const securityFocus = normalizeOptionalBoolean(r.security_focus, "review.security_focus", warnings);
   const inlineComments = normalizeOptionalBoolean(r.inline_comments, "review.inline_comments", warnings);
   const pathInstructions = parseReviewPathInstructions(r.path_instructions, warnings);
@@ -1518,6 +1522,7 @@ function parseReviewConfig(value: JsonValue | undefined, warnings: string[]): Fo
       note !== null ||
       profile !== null ||
       tone !== null ||
+      effortScore !== null ||
       securityFocus !== null ||
       inlineComments !== null ||
       pathInstructions.length > 0 ||
@@ -1535,6 +1540,7 @@ function parseReviewConfig(value: JsonValue | undefined, warnings: string[]): Fo
     enrichmentAnalyzers,
     profile,
     tone,
+    effortScore,
     securityFocus,
     inlineComments,
     pathInstructions,
@@ -1775,6 +1781,7 @@ export function reviewConfigToJson(review: FocusManifestReviewConfig): JsonValue
   if (review.note !== null) out.note = review.note;
   if (review.profile !== null) out.profile = review.profile;
   if (review.tone !== null) out.tone = review.tone;
+  if (review.effortScore !== null) out.effort_score = review.effortScore;
   if (review.securityFocus !== null) out.security_focus = review.securityFocus;
   if (review.inlineComments !== null) out.inline_comments = review.inlineComments;
   if (review.instructions !== null) out.instructions = review.instructions;

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -548,7 +548,7 @@ describe("compileFocusManifestPolicy", () => {
       publicNotes: ["Keep PRs focused.", "Maximize your reward payout"],
       gate: { present: false, enabled: null, checkMode: null, pack: null, linkedIssue: null, duplicates: null, readinessMode: null, readinessMinScore: null, slopMode: null, slopMinScore: null, slopAiAdvisory: null, sizeMode: null, lockfileIntegrityMode: null, aiReviewMode: null, aiReviewByok: null, aiReviewProvider: null, aiReviewModel: null, aiReviewAllAuthors: null, aiReviewCloseConfidence: null, aiReviewCombine: null, aiReviewOnMerge: null, aiReviewReviewers: null, mergeReadiness: null, selfAuthoredLinkedIssue: null, manifestPolicy: null, dryRun: null, firstTimeContributorGrace: null, premergeContentRecheck: null, requireFreshRebaseWindowMinutes: null, claMode: null, claConsentPhrase: null, claCheckRunName: null, claCheckRunAppSlug: null, expectedCiContexts: null },
       settings: {},
-      review: { present: false, footerText: null, note: null, fields: {}, enrichmentAnalyzers: {}, profile: null, tone: null, securityFocus: null, inlineComments: null, pathInstructions: [], instructions: null, excludePaths: [], pathFilters: [], preMergeChecks: [], autoReview: { ...EMPTY_AUTO_REVIEW_CONFIG } },
+      review: { present: false, footerText: null, note: null, fields: {}, enrichmentAnalyzers: {}, profile: null, tone: null, effortScore: null, securityFocus: null, inlineComments: null, pathInstructions: [], instructions: null, excludePaths: [], pathFilters: [], preMergeChecks: [], autoReview: { ...EMPTY_AUTO_REVIEW_CONFIG } },
       features: { present: false, rag: null, reputation: null, unifiedComment: null, safety: null },
       contentLane: { present: false, entryFileGlob: null, providerFileGlob: null, artifactGlob: null, collectionField: null, maxAppendedEntries: null, duplicateKeyFields: [], validatorId: null },
       repoDocGeneration: { present: false, enabled: false, scope: ["agents"], allowOverwriteExisting: false, refreshIntervalDays: 7 },
@@ -2438,6 +2438,26 @@ describe("parseFocusManifest review config", () => {
     expect(unsafe.warnings.some((w) => /review\.tone.*not public-safe/.test(w))).toBe(true);
     const long = parseFocusManifest({ review: { tone: "x".repeat(400) } });
     expect(long.review.tone).toHaveLength(300);
+  });
+
+  it("parses review.effort_score, marks present, round-trips, and rejects invalid values (#2069)", () => {
+    const on = parseFocusManifest({ review: { effort_score: true } });
+    expect(on.review.effortScore).toBe(true);
+    expect(on.review.present).toBe(true);
+    expect(reviewConfigToJson(on.review)).toEqual({ effort_score: true });
+    expect(parseFocusManifest({ review: reviewConfigToJson(on.review) }).review).toEqual(on.review);
+
+    const off = parseFocusManifest({ review: { effort_score: false } });
+    expect(off.review.effortScore).toBe(false);
+    expect(off.review.present).toBe(true);
+    expect(reviewConfigToJson(off.review)).toEqual({ effort_score: false });
+
+    const absent = parseFocusManifest({ review: { footer: { text: "Custom." } } });
+    expect(absent.review.effortScore).toBeNull();
+
+    const invalid = parseFocusManifest({ review: { effort_score: "yes" } });
+    expect(invalid.review.effortScore).toBeNull();
+    expect(invalid.warnings.some((w) => /review\.effort_score/.test(w))).toBe(true);
   });
 
   it("composeManifestReviewInstructions: null tone is byte-identical; tone folds ahead of instructions (#2044)", () => {

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -15070,6 +15070,7 @@ describe("queue processors", () => {
       privateTrustEnabled: true,
       autonomy: { update_branch: "auto" },
     });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { review: { effort_score: true } });
     let postedBody = "";
     const calls = { comments: 0, gateChecks: 0 };
     let gateFinalized = false;
@@ -15139,7 +15140,17 @@ describe("queue processors", () => {
         return Response.json({ token: "installation-token", expires_at: "2026-05-28T00:04:00.000Z" });
       }
       // PR files — the unified branch (re)fetches them to count changed files for the readiness chip.
-      if (url.includes("/pulls/3/files")) return Response.json([{ filename: "src/cache.ts", additions: 5, deletions: 1, status: "modified" }]);
+      if (url.includes("/pulls/3/files")) {
+        return Response.json([
+          {
+            filename: "src/cache.ts",
+            additions: 5,
+            deletions: 1,
+            status: "modified",
+            patch: "@@ -1 +1,5 @@\n+one\n+two\n+three\n+four\n+five",
+          },
+        ]);
+      }
       // #review-audit: the LIVE merge-state the comment now reads — the base just advanced with a conflict, so the
       // live state is `dirty` even though the stored mergeableState (unset on this payload) would not say so.
       if (/\/pulls\/3(?:\?|$)/.test(url)) return Response.json({ number: 3, mergeable_state: "dirty" });
@@ -15209,6 +15220,7 @@ describe("queue processors", () => {
       expect(postedBody).toMatch(/> \[!(TIP|NOTE|WARNING|CAUTION)\]/);
       // …and the renderer's synthesized "Code review" signal row (bold first table label).
       expect(postedBody).toContain("**Code review**");
+      expect(postedBody).toContain("**review effort:** 1/5 (~4 min)");
       // Public-safe by construction — no internal trust/economics fields leak through the unified renderer.
       expect(postedBody).not.toMatch(/wallet|hotkey|reward|trust score/i);
       // #review-audit (#4220): the comment reads the LIVE `dirty` merge-state (not the stale stored one), so it must

--- a/test/unit/signals-coverage.test.ts
+++ b/test/unit/signals-coverage.test.ts
@@ -1127,7 +1127,7 @@ describe("signal coverage edge cases", () => {
       collisions: buildCollisionReport(directRepo.fullName, [], [currentPr]),
       preflight: buildPreflightResult({ repoFullName: directRepo.fullName, title: "Fix isolated issue", body: "Fixes #99", linkedIssues: [99] }, directRepo, [], [currentPr]),
       settings: gateSettings,
-      review: { present: true, footerText: "Reviewed by the Acme maintainer bot.", note: "Run npm test before pushing.", fields: { relatedWork: false }, enrichmentAnalyzers: {}, profile: null, tone: null, securityFocus: null, inlineComments: null, pathInstructions: [], instructions: null, excludePaths: [], pathFilters: [], preMergeChecks: [], autoReview: { skipDrafts: null, ignoreAuthors: [], ignoreTitleKeywords: [], baseBranches: [], autoPauseAfterReviewedCommits: null } },
+      review: { present: true, footerText: "Reviewed by the Acme maintainer bot.", note: "Run npm test before pushing.", fields: { relatedWork: false }, enrichmentAnalyzers: {}, profile: null, tone: null, effortScore: null, securityFocus: null, inlineComments: null, pathInstructions: [], instructions: null, excludePaths: [], pathFilters: [], preMergeChecks: [], autoReview: { skipDrafts: null, ignoreAuthors: [], ignoreTitleKeywords: [], baseBranches: [], autoPauseAfterReviewedCommits: null } },
       aiReview: { notes: "The change is focused.\n\n**Nits (2)**\n- Add a test for the </details> edge case.\n- Keep the validator helper scoped." },
     });
     expect(customizedComment).toContain("Reviewed by the Acme maintainer bot."); // custom footer lead

--- a/test/unit/unified-comment-bridge.test.ts
+++ b/test/unit/unified-comment-bridge.test.ts
@@ -275,6 +275,19 @@ describe("buildUnifiedCommentBody", () => {
     expect(body).toContain("> [!TIP]"); // success → ready → TIP alert
   });
 
+  it("forwards an enabled review-effort estimate into the unified comment (#2069)", () => {
+    const body = buildUnifiedCommentBody({
+      gate: gate(),
+      aiReview: { notes: "Clean change." },
+      panelRows,
+      readinessTotal: 88,
+      changedFiles: 3,
+      reviewEffort: { band: 4, minutes: 42 },
+      footerMarkdown: footer,
+    });
+    expect(body).toContain("**review effort:** 4/5 (~42 min)");
+  });
+
   it("passes a public review update timestamp into the unified comment", () => {
     const body = buildUnifiedCommentBody({
       gate: gate(),

--- a/test/unit/unified-comment.test.ts
+++ b/test/unit/unified-comment.test.ts
@@ -161,6 +161,25 @@ describe("renderUnifiedReviewComment", () => {
     expect(md).not.toContain("1 reviewers, synthesized");
   });
 
+  it("renders the optional review effort line only when the host supplies an estimate (#2069)", () => {
+    const withEffort = renderUnifiedReviewComment({ ...base, reviewEffort: { band: 3, minutes: 18 } }, ctx);
+    expect(withEffort).toContain("**review effort:** 3/5 (~18 min)");
+    expect(withEffort.indexOf("review effort")).toBeLessThan(withEffort.indexOf("**Review summary**"));
+
+    const withoutEffort = renderUnifiedReviewComment(base, ctx);
+    expect(withoutEffort).not.toContain("review effort:");
+  });
+
+  it("buildUnifiedReviewInput carries the optional effort estimate without changing absent input (#2069)", () => {
+    const withEffort = buildUnifiedReviewInput({
+      changedFiles: ["a.ts"],
+      reviews: [reviewNote("merge")],
+      reviewEffort: { band: 2, minutes: 7 },
+    });
+    expect(withEffort.reviewEffort).toEqual({ band: 2, minutes: 7 });
+    expect(buildUnifiedReviewInput({ changedFiles: ["a.ts"], reviews: [reviewNote("merge")] }).reviewEffort).toBeUndefined();
+  });
+
   it("wraps the review body in the colored blockquote but renders the re-run checkbox OUTSIDE it (interactive)", () => {
     const md = renderUnifiedReviewComment({ ...base, decision: "merge" }, ctx);
     const lines = md.split("\n");


### PR DESCRIPTION
## Summary

- Add the `review.effort_score` manifest toggle for unified review comments.
- Render a deterministic `review effort: N/5 (~M min)` line when the toggle is enabled.
- Cover parsing, serialization, comment rendering, bridge forwarding, and queue integration.

Fixes #2069

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires >=99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

Additional focused validation:

- [x] `npm test -- --run test/unit/focus-manifest.test.ts test/unit/signals-coverage.test.ts test/unit/unified-comment.test.ts test/unit/unified-comment-bridge.test.ts test/unit/review-effort.test.ts`
- [x] `npm test -- --run test/unit/queue.test.ts -t "renders the unified PR-review comment"`
- [x] `npm run db:migrations:check`
- [x] `npm run selfhost:env-reference:check`
- [x] `npm pack --workspace @jsonbored/gittensory-mcp --dry-run --json`

If any required check was skipped, explain why:

- `npm run test:coverage` was not run locally due runtime; focused tests cover the changed parser, renderer, bridge, and queue paths.
- `npm run test:mcp-pack` was not run directly in this Windows/Node 24 environment; the package dry-run equivalent passed.
- `npm run ui:lint` fails locally on CRLF-only Prettier diagnostics across existing UI files in this Windows checkout; this PR does not modify UI source files.
- `npm run test:ci` was attempted after the branch was pushed; it progressed through early checks after refreshing line endings, but the local Windows checkout has the same CRLF-only `ui:lint` limitation noted above.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A - no visible UI, frontend, docs, or extension changes.

## Notes

-