### PR TITLE
chore(miner): add test:miner-pack publish-shape checker

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "build:mcp": "npm --workspace @jsonbored/gittensory-mcp run build",
     "build:miner": "npm --workspace @jsonbored/gittensory-engine run build && npm --workspace @jsonbored/gittensory-miner run build",
     "test:mcp-pack": "node scripts/check-mcp-package.mjs",
+    "test:miner-pack": "node scripts/check-miner-package.mjs",
     "rees:install": "npm ci --prefix review-enrichment --prefer-offline --no-audit --no-fund",
     "rees:test": "npm run rees:install && npm --prefix review-enrichment test",
     "rees:metadata": "npm --prefix review-enrichment run metadata",

--- a/scripts/check-miner-package.mjs
+++ b/scripts/check-miner-package.mjs
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const ALLOWED = [
+  /^bin\/gittensory-miner\.js$/,
+  /^lib\/[a-z0-9-]+\.(js|d\.ts)$/,
+  /^package\.json$/,
+  /^README\.md$/,
+];
+const FORBIDDEN_PATH = /(^|\/)(\.dev\.vars|\.env|\.npmrc|.*\.pem|.*private.*key.*|.*secret.*)$/i;
+const FORBIDDEN_CONTENT =
+  /(BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY|github_pat_[A-Za-z0-9_]+|gh[pousr]_[A-Za-z0-9_]+|gts_[0-9a-f]{64}|[A-Z0-9_]*(TOKEN|SECRET|PRIVATE_KEY)=)/;
+
+/** Validate an npm-pack file list for the miner package. Pure aside from readContent. */
+export function validateMinerPackFileList(files, readContent) {
+  const paths = files.map((file) => (typeof file === "string" ? file : file.path)).sort();
+  for (const file of paths) {
+    if (FORBIDDEN_PATH.test(file)) throw new Error(`Forbidden file in miner package: ${file}`);
+    if (!ALLOWED.some((pattern) => pattern.test(file))) throw new Error(`Unexpected file in miner package: ${file}`);
+    const content = readContent(file);
+    if (FORBIDDEN_CONTENT.test(content)) throw new Error(`Secret-like content found in miner package file: ${file}`);
+  }
+  return paths;
+}
+
+export function runMinerPackCheck(options = {}) {
+  const pack = options.pack ?? loadMinerPackFromNpm();
+  const packageRoot = options.packageRoot ?? join(process.cwd(), "packages/gittensory-miner");
+  const readContent = options.readContent ?? ((file) => readFileSync(join(packageRoot, file), "utf8"));
+  const paths = validateMinerPackFileList(pack.files, readContent);
+  return `Miner package dry-run ok: ${paths.join(", ")}\n`;
+}
+
+function loadMinerPackFromNpm() {
+  const result = spawnSync("npm", ["pack", "--workspace", "@jsonbored/gittensory-miner", "--dry-run", "--json"], {
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    const message = result.stderr || result.stdout || "npm pack failed";
+    throw new Error(message.trim());
+  }
+  return JSON.parse(result.stdout)[0];
+}
+
+function main() {
+  try {
+    process.stdout.write(runMinerPackCheck());
+  } catch (err) {
+    process.stderr.write(`${err instanceof Error ? err.message : String(err)}\n`);
+    process.exit(1);
+  }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) main();

--- a/test/unit/check-miner-package.test.ts
+++ b/test/unit/check-miner-package.test.ts
@@ -1,0 +1,47 @@
+import { execFileSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+import { runMinerPackCheck, validateMinerPackFileList } from "../../scripts/check-miner-package.mjs";
+
+describe("check-miner-package script", () => {
+  it("passes on the real miner workspace package", () => {
+    const output = execFileSync(process.execPath, ["scripts/check-miner-package.mjs"], { encoding: "utf8" });
+    expect(output).toMatch(/^Miner package dry-run ok:/);
+    expect(output).toContain("bin/gittensory-miner.js");
+    expect(output).toContain("package.json");
+  });
+
+  it("accepts a well-formed pack file list", () => {
+    const paths = validateMinerPackFileList(
+      ["package.json", "bin/gittensory-miner.js", "lib/cli.js", "README.md"],
+      () => "safe miner package content",
+    );
+    expect(paths).toEqual(["README.md", "bin/gittensory-miner.js", "lib/cli.js", "package.json"]);
+  });
+
+  it("rejects a forbidden path", () => {
+    expect(() =>
+      validateMinerPackFileList([".env"], () => ""),
+    ).toThrow("Forbidden file in miner package: .env");
+  });
+
+  it("rejects an unexpected file", () => {
+    expect(() =>
+      validateMinerPackFileList(["scripts/extra.mjs"], () => ""),
+    ).toThrow("Unexpected file in miner package: scripts/extra.mjs");
+  });
+
+  it("rejects secret-like content", () => {
+    expect(() =>
+      validateMinerPackFileList(["package.json"], () => "github_pat_abcdefghijklmnopqrstuvwxyz0123456789"),
+    ).toThrow("Secret-like content found in miner package file: package.json");
+  });
+
+  it("runMinerPackCheck can validate injected pack metadata without npm pack", () => {
+    const output = runMinerPackCheck({
+      pack: { files: [{ path: "package.json" }, { path: "bin/gittensory-miner.js" }] },
+      readContent: () => "{}",
+    });
+    expect(output).toBe("Miner package dry-run ok: bin/gittensory-miner.js, package.json\n");
+  });
+});


### PR DESCRIPTION
Closes #2310

## Summary
- Add `scripts/check-miner-package.mjs`, mirroring `check-mcp-package.mjs` for `@jsonbored/gittensory-miner` (npm pack dry-run, allowlist, secret scan).
- Wire `test:miner-pack` in root `package.json` (`build:miner` already exists).
- Vitest covers validation branches via exported pure helpers plus a live script invocation.

## Conflict avoidance
Touches only `scripts/check-miner-package.mjs` (new), `test/unit/check-miner-package.test.ts` (new), and one line in `package.json`. No overlap with open PR #3503.

## Test plan
- [x] `npm run test:miner-pack`
- [x] `COVERAGE_NO_THRESHOLDS=1 npx vitest run test/unit/check-miner-package.test.ts --coverage`
- [x] `npm run build --workspace @jsonbored/gittensory-engine && npm run build:miner`


Made with [Cursor](https://cursor.com)