### PR TITLE
feat(metrics): count Redis webhook dedup hits (#2075)

### DIFF
--- a/src/selfhost/redis-cache.ts
+++ b/src/selfhost/redis-cache.ts
@@ -4,6 +4,38 @@
 // ID after a successful processing attempt, the server can return 204 immediately on retries
 // without re-queuing the job. The self-host review runtime requires REDIS_URL.
 import type { Redis } from "ioredis";
+import { incr } from "./metrics";
+
+const WEBHOOK_DELIVERY_CACHE_PREFIX = "delivery:";
+
+export function webhookDeliveryCacheKey(deliveryId: string): string {
+  return `${WEBHOOK_DELIVERY_CACHE_PREFIX}${deliveryId}`;
+}
+
+/** Returns true when this GitHub webhook delivery ID was already processed (Redis dedup hit).
+ *  Increments `gittensory_webhook_dedup_total{backend="redis"}` on a hit. Does NOT mark the
+ *  delivery — the caller marks only after a successful response (#2506 / #2572). */
+export async function isWebhookDeliveryDuplicate(cache: RedisCache, deliveryId: string): Promise<boolean> {
+  try {
+    const seen = await cache.get(webhookDeliveryCacheKey(deliveryId));
+    if (seen) {
+      incr("gittensory_webhook_dedup_total", { backend: "redis" });
+      return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/** Best-effort: record a successfully processed webhook delivery for Redis dedup. */
+export async function rememberWebhookDelivery(cache: RedisCache, deliveryId: string, ttlSeconds = 300): Promise<void> {
+  try {
+    await cache.set(webhookDeliveryCacheKey(deliveryId), "1", ttlSeconds);
+  } catch {
+    // best-effort — never block the response on a cache write failure
+  }
+}
 
 export function createRedisCache(redis: Redis) {
   return {

--- a/src/server.ts
+++ b/src/server.ts
@@ -481,7 +481,7 @@ async function main(): Promise<void> {
   const { Redis } = await import("ioredis");
   const redisClient = new Redis(redisUrl);
   const { createRedisRateLimiter } = await import("./selfhost/redis-ratelimit");
-  const { createRedisCache, assertSelfhostTransientCacheOwnershipRelease } = await import("./selfhost/redis-cache");
+  const { createRedisCache, assertSelfhostTransientCacheOwnershipRelease, isWebhookDeliveryDuplicate, rememberWebhookDelivery } = await import("./selfhost/redis-cache");
   const rateLimiter = createRedisRateLimiter(redisClient);
   const webhookCache = createRedisCache(redisClient);
   assertSelfhostTransientCacheOwnershipRelease(webhookCache);
@@ -700,13 +700,13 @@ async function main(): Promise<void> {
     "gittensory_jobs_dead_total",
     "gittensory_jobs_rate_limit_deferred_total",
     "gittensory_jobs_recovered_total",
-    "gittensory_webhook_dedup_total",
     "gittensory_qdrant_queries_total",
     "gittensory_qdrant_upserts_total",
     "gittensory_orb_events_exported_total",
     "gittensory_orb_export_errors_total",
   ])
     incr(c, undefined, 0);
+  incr("gittensory_webhook_dedup_total", { backend: "redis" }, 0);
   // Seed gittensory_http_requests_total per status class so the breakdown panel has every series from the
   // first scrape (keeping the metric consistently labeled — never mix labeled and unlabeled samples).
   for (const status of ["2xx", "3xx", "4xx", "5xx"])
@@ -886,18 +886,13 @@ async function main(): Promise<void> {
                 ? request.headers.get("x-github-delivery")
                 : null;
               if (deliveryId) {
-                const seen = await webhookCache!.get(`delivery:${deliveryId}`);
-                if (seen) {
-                  incr("gittensory_webhook_dedup_total");
+                if (await isWebhookDeliveryDuplicate(webhookCache!, deliveryId)) {
                   return finish(new Response(null, { status: 204 }));
                 }
               }
               const response = await worker.fetch(request, env, ctx);
               if (deliveryId && response.ok) {
-                // Best-effort — never block the response on a cache write failure
-                void webhookCache!
-                  .set(`delivery:${deliveryId}`, "1", 300)
-                  .catch(() => undefined);
+                void rememberWebhookDelivery(webhookCache!, deliveryId);
               }
               return finish(response);
             } finally {

--- a/test/unit/selfhost-redis-cache.test.ts
+++ b/test/unit/selfhost-redis-cache.test.ts
@@ -1,6 +1,13 @@
 import type { Redis } from "ioredis";
-import { describe, expect, it } from "vitest";
-import { assertSelfhostTransientCacheOwnershipRelease, createRedisCache } from "../../src/selfhost/redis-cache";
+import { describe, expect, it, afterEach } from "vitest";
+import {
+  assertSelfhostTransientCacheOwnershipRelease,
+  createRedisCache,
+  isWebhookDeliveryDuplicate,
+  rememberWebhookDelivery,
+  webhookDeliveryCacheKey,
+} from "../../src/selfhost/redis-cache";
+import { renderMetrics, resetMetrics } from "../../src/selfhost/metrics";
 
 /** Minimal in-memory stand-in for the ioredis methods the cache uses. Emulates real Redis SET NX
  *  semantics (refuse + return null when NX is requested and the key already exists) so a test
@@ -95,5 +102,35 @@ describe("createRedisCache (#1216 webhook dedup cache)", () => {
       }),
     ).toThrow(/releaseIfValue/);
     expect(() => assertSelfhostTransientCacheOwnershipRelease(createRedisCache(fakeRedis()))).not.toThrow();
+  });
+});
+
+describe("isWebhookDeliveryDuplicate (#2075)", () => {
+  afterEach(() => resetMetrics());
+
+  it("returns false and does not increment on a first-time delivery", async () => {
+    const cache = createRedisCache(fakeRedis());
+    await expect(isWebhookDeliveryDuplicate(cache, "delivery-1")).resolves.toBe(false);
+    expect(await renderMetrics()).not.toContain('gittensory_webhook_dedup_total{backend="redis"}');
+  });
+
+  it("returns true and increments gittensory_webhook_dedup_total{backend=\"redis\"} when already seen", async () => {
+    const cache = createRedisCache(fakeRedis());
+    await cache.set(webhookDeliveryCacheKey("delivery-2"), "1", 300);
+    await expect(isWebhookDeliveryDuplicate(cache, "delivery-2")).resolves.toBe(true);
+    expect(await renderMetrics()).toContain('gittensory_webhook_dedup_total{backend="redis"} 1');
+  });
+
+  it("returns false without incrementing when Redis get throws", async () => {
+    const brokenRedis = { async get() { throw new Error("connection refused"); } } as unknown as Redis;
+    const cache = createRedisCache(brokenRedis);
+    await expect(isWebhookDeliveryDuplicate(cache, "delivery-3")).resolves.toBe(false);
+    expect(await renderMetrics()).not.toContain('gittensory_webhook_dedup_total{backend="redis"}');
+  });
+
+  it("rememberWebhookDelivery stores the delivery key for later dedup", async () => {
+    const cache = createRedisCache(fakeRedis());
+    await rememberWebhookDelivery(cache, "delivery-4");
+    expect(await cache.get(webhookDeliveryCacheKey("delivery-4"))).toBe("1");
   });
 });


### PR DESCRIPTION
## Summary

Closes #2075

- Adds `isWebhookDeliveryDuplicate` / `rememberWebhookDelivery` in `src/selfhost/redis-cache.ts` so Redis webhook dedup hits increment `gittensory_webhook_dedup_total{backend="redis"}`.
- Wires the self-host `/v1/github/webhook` path through those helpers instead of inline get/set.
- Preserves mark-after-success ordering from #2572: a delivery is remembered only after the worker returns `ok`, so failed webhooks stay retryable.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` — no workflow changes
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers` — no worker/runtime changes
- [ ] `npm run build:mcp` — no MCP changes
- [ ] `npm run test:mcp-pack` — no MCP changes
- [ ] `npm run ui:openapi:check` — no UI/API changes
- [ ] `npm run ui:lint` — no UI changes
- [ ] `npm run ui:typecheck` — no UI changes
- [ ] `npm run ui:build` — no UI changes
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Skipped UI/MCP/worker/actionlint checks: self-host metrics wiring only (`src/selfhost/**`, `src/server.ts`, unit tests).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [ ] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — no UI changes.

## Notes

- Touches `src/selfhost/**` and `src/server.ts` only (not guarded paths).
- Did not reintroduce the removed `checkAndMarkDelivery` helper (#2572); the new check-only helper keeps mark-after-success in the caller.

Made with [Cursor](https://cursor.com)