### PR TITLE
fix(signals): classify WASM source maps as generated

### DIFF
--- a/src/signals/path-matchers.ts
+++ b/src/signals/path-matchers.ts
@@ -73,10 +73,10 @@ function isGeneratedFileFrom(parts: NormalizedPath): boolean {
     /\.(g|freezed|gr)\.dart$/.test(norm) ||
     // C# codegen: WinForms/WPF designer partials (`.designer.cs`) and XAML/T4 output (`.g.cs`).
     /\.(designer|g)\.cs$/.test(norm) ||
-    // Source maps for bundler/front-end output across JS/TS, frameworks, stylesheets, HTML, and SVG.
+    // Source maps for bundler/front-end output across JS/TS, frameworks, stylesheets, HTML, SVG, and WASM.
     // `.mjs`/`.cjs` are already recognized code extensions (isCodeFile), so their bundlers'
     // `.mjs.map` / `.cjs.map` maps are generated output too — the same as `.js.map`.
-    /\.(js|jsx|mjs|cjs|ts|tsx|mts|cts|vue|svelte|astro|mdx|scss|sass|less|html|svg|css)\.map$/.test(norm) ||
+    /\.(js|jsx|mjs|cjs|ts|tsx|mts|cts|vue|svelte|astro|mdx|scss|sass|less|html|svg|css|wasm)\.map$/.test(norm) ||
     base === "worker-configuration.d.ts"
   );
 }

--- a/test/unit/path-matchers.test.ts
+++ b/test/unit/path-matchers.test.ts
@@ -38,7 +38,7 @@ describe("isGeneratedFile", () => {
     }
   });
 
-  it("matches source maps for every first-class JS/TS, MDX, HTML, SVG, Sass/SCSS/Less, and front-end framework extension", () => {
+  it("matches source maps for JS/TS, MDX, HTML, SVG, WASM, Sass/SCSS/Less, and front-end framework extensions", () => {
     // `.mjs`/`.cjs` are recognized code extensions (isCodeFile), so their bundlers' source
     // maps are generated output too — the same as `.js.map` / `.tsx.map`.
     for (const path of [
@@ -56,9 +56,11 @@ describe("isGeneratedFile", () => {
       "dist/theme.less.map",
       "dist/index.html.map",
       "dist/icon.svg.map",
+      "dist/pkg.wasm.map",
     ]) {
       expect(isGeneratedFile(path)).toBe(true);
     }
+    expect(classifyChangedFile("dist/pkg.wasm.map")).toBe("generated");
   });
 
   it("matches C++ protobuf output alongside the Go/TS/JS plugins", () => {
@@ -443,6 +445,7 @@ describe("classifyChangedFile", () => {
       ["proto/messages.pb.erl", "generated"],
       ["proto/messages.pb.hrl", "generated"],
       ["proto/messages.pb.cr", "generated"],
+      ["dist/pkg.wasm.map", "generated"],
       ["vendor/lib.go", "vendored"],
       ["package-lock.json", "lockfile"],
       ["bun.lock", "lockfile"],


### PR DESCRIPTION
## Summary

Extend `isGeneratedFile` source-map parity so bundler output like `dist/pkg.wasm.map` is classified as generated, matching existing JS/TS and front-end `.map` handling. Includes direct `classifyChangedFile` assertions for the hot-path category behavior.

Fixes #561

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- None skipped.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — signals-only change with no visible UI.

## Notes

Incremental **maintenance** parity for the path-matcher slop signals from #561. Supports generated-file classification work tracked in #2279.

Made with [Cursor](https://cursor.com)