### PR TITLE
fix(signals): classify Lua protobuf stubs as generated

### DIFF
--- a/src/signals/path-matchers.ts
+++ b/src/signals/path-matchers.ts
@@ -71,6 +71,8 @@ function isGeneratedFileFrom(parts: NormalizedPath): boolean {
     /_pb\.php$/.test(norm) ||
     // Nim protobuf: message stubs are `*_pb.nim`.
     /_pb\.nim$/.test(norm) ||
+    // Lua protobuf: message stubs are `*_pb.lua`.
+    /_pb\.lua$/.test(norm) ||
     // Dart codegen: build_runner (`.g.dart`), freezed (`.freezed.dart`), and
     // retrofit/injectable (`.gr.dart`) all emit generated part files.
     /\.(g|freezed|gr)\.dart$/.test(norm) ||

--- a/test/unit/path-matchers.test.ts
+++ b/test/unit/path-matchers.test.ts
@@ -132,6 +132,12 @@ describe("isGeneratedFile", () => {
     expect(classifyChangedFile("gen/service_pb.nim")).toBe("generated");
   });
 
+  it("matches Lua protobuf output alongside the other protoc plugins", () => {
+    expect(isGeneratedFile("gen/service_pb.lua")).toBe(true);
+    expect(isGeneratedFile("src/main.lua")).toBe(false);
+    expect(classifyChangedFile("gen/service_pb.lua")).toBe("generated");
+  });
+
   it("matches Swift protobuf, Dart freezed/retrofit, C# designer/XAML, and Objective-C protoc output", () => {
     for (const path of [
       "proto/messages.pb.swift",
@@ -460,6 +466,7 @@ describe("classifyChangedFile", () => {
       ["dist/pkg.wasm.map", "generated"],
       ["proto/messages.pb.hs", "generated"],
       ["gen/service_pb.nim", "generated"],
+      ["gen/service_pb.lua", "generated"],
       ["vendor/lib.go", "vendored"],
       ["package-lock.json", "lockfile"],
       ["bun.lock", "lockfile"],


### PR DESCRIPTION
## Summary

Extend `isGeneratedFile` to recognize lua-protobuf message stubs (`*_pb.lua`), matching the existing `_pb.rb` / `_pb.nim` protobuf plugin coverage. Includes direct `isGeneratedFile` / `classifyChangedFile` assertions and a hand-authored `.lua` negative case.

Fixes #561

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- None skipped.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — signals-only change with no visible UI.

## Notes

Incremental **maintenance** parity for the path-matcher slop signals from #561. Supports generated-file classification work tracked in #2279.

Made with [Cursor](https://cursor.com)