### PR TITLE
feat(enrichment): flag insecure HTTP security-header settings in iac-misconfig

### DIFF
--- a/review-enrichment/src/analyzers/iac-misconfig.ts
+++ b/review-enrichment/src/analyzers/iac-misconfig.ts
@@ -112,6 +112,13 @@ const DOCKER_SOCKET_MOUNT_RE =
 const HSTS_DISABLED_RE = /\bStrict-Transport-Security\b[^\n]*\bmax-age\s*=\s*0\b/i;
 const REFERRER_UNSAFE_URL_RE = /\bReferrer-Policy\b[^\n]*\bunsafe-url\b/i;
 const COOKIE_NOT_HTTPONLY_RE = /\bhttp[_-]?only\b[\s"'=:,-]*false\b/i;
+const COOP_UNSAFE_NONE_RE =
+  /\bCross-Origin-Opener-Policy\b[^\n]*\bunsafe-none\b/i;
+// The value must be exactly `0` (filter off), not `10`/`01` — `(?![0-9])` rejects a digit continuation.
+// Accepts both `X-XSS-Protection: 0` and nginx `add_header X-XSS-Protection "0"`.
+const XSS_PROTECTION_OFF_RE =
+  /\bX-XSS-Protection\b(?:\s*:\s*|\s+)["']?0(?![0-9])/i;
+const FRAME_OPTIONS_ALLOWALL_RE = /\bX-Frame-Options\b[^\n]*\bALLOWALL\b/i;
 
 function* patchLines(patch: string): Generator<string> {
   let start = 0;
@@ -538,6 +545,24 @@ export function scanPatchForIacMisconfig(
     if (
       COOKIE_NOT_HTTPONLY_RE.test(body) &&
       pushFinding(findings, seen, path, newLine, "cookie-not-httponly", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      COOP_UNSAFE_NONE_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "coop-unsafe-none", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      XSS_PROTECTION_OFF_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "x-xss-protection-off", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      FRAME_OPTIONS_ALLOWALL_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "frame-options-allowall", maxFindings)
     ) {
       return findings;
     }

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -360,6 +360,12 @@ export function renderBrief(
           return "sets `Referrer-Policy: unsafe-url`, leaking the full URL (path and query) to cross-origin destinations";
         case "cookie-not-httponly":
           return "sets `httpOnly: false` on a cookie, exposing it to JavaScript so an XSS can read it";
+        case "coop-unsafe-none":
+          return "sets `Cross-Origin-Opener-Policy: unsafe-none`, allowing cross-origin pages to retain opener access";
+        case "x-xss-protection-off":
+          return "disables the legacy XSS filter with `X-XSS-Protection: 0`";
+        case "frame-options-allowall":
+          return "sets `X-Frame-Options: ALLOWALL`, permitting any site to embed this page in a frame (clickjacking risk)";
       }
     };
 

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -270,7 +270,10 @@ export interface IacMisconfigFinding {
     | "docker-socket-mount"
     | "hsts-disabled"
     | "referrer-policy-leak"
-    | "cookie-not-httponly";
+    | "cookie-not-httponly"
+    | "coop-unsafe-none"
+    | "x-xss-protection-off"
+    | "frame-options-allowall";
 }
 
 /** A newly-added dependency whose install compiles native code (npm node-gyp addon) or has no prebuilt wheel

--- a/review-enrichment/test/iac-misconfig.test.ts
+++ b/review-enrichment/test/iac-misconfig.test.ts
@@ -461,6 +461,9 @@ test("scanPatchForIacMisconfig flags insecure HTTP security-header settings", ()
     ["+    add_header Strict-Transport-Security \"max-age=0\";", "hsts-disabled"],
     ["+    add_header Referrer-Policy \"unsafe-url\";", "referrer-policy-leak"],
     ["+    httpOnly: false", "cookie-not-httponly"],
+    ["+    add_header Cross-Origin-Opener-Policy \"unsafe-none\";", "coop-unsafe-none"],
+    ["+    add_header X-XSS-Protection \"0\";", "x-xss-protection-off"],
+    ["+    add_header X-Frame-Options \"ALLOWALL\";", "frame-options-allowall"],
   ];
   for (const [added, kind] of cases) {
     const findings = scanPatchForIacMisconfig(
@@ -482,6 +485,11 @@ test("scanPatchForIacMisconfig does not flag secure HTTP header values (incl. Ca
     "+    add_header Cache-Control \"max-age=0\";",
     "+    add_header Referrer-Policy \"strict-origin-when-cross-origin\";",
     "+    httpOnly: true",
+    "+    add_header Cross-Origin-Opener-Policy \"same-origin\";",
+    "+    add_header X-XSS-Protection \"1; mode=block\";",
+    "+    add_header X-Frame-Options \"SAMEORIGIN\";",
+    // A bare `unsafe-none` config key without the COOP header token must NOT fire the COOP rule.
+    "+    unsafe-none = false",
   ];
   for (const added of safe) {
     assert.deepEqual(


### PR DESCRIPTION
## Summary

Adds three zero-FP HTTP security-header rules to the existing `iac-misconfig` analyzer (same pattern as #3387):

| kind | Trigger |
| --- | --- |
| `coop-unsafe-none` | `Cross-Origin-Opener-Policy` set to `unsafe-none` |
| `x-xss-protection-off` | `X-XSS-Protection` explicitly disabled (`0`) |
| `frame-options-allowall` | `X-Frame-Options` set to `ALLOWALL` |

Each rule requires its own header token on the same line as the weakening value, so unrelated lines (e.g. `Cache-Control: max-age=0`, bare `unsafe-none = false`) are not flagged.

No linked issue — small, self-contained enrichment rule batch on an existing analyzer with table + near-miss tests.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` — not applicable (review-enrichment only)
- [ ] `npm run typecheck` — not applicable (review-enrichment only)
- [ ] `npm run test:coverage` — not applicable (review-enrichment only)
- [ ] `npm run test:workers` — not applicable
- [ ] `npm run build:mcp` — not applicable
- [ ] `npm run test:mcp-pack` — not applicable
- [ ] `npm run ui:openapi:check` — not applicable
- [ ] `npm run ui:lint` — not applicable
- [ ] `npm run ui:typecheck` — not applicable
- [ ] `npm run ui:build` — not applicable
- [ ] `npm audit --audit-level=moderate` — not applicable
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Review-enrichment-only change; validated with `npm --prefix review-enrichment run build` and `node --test review-enrichment/test/iac-misconfig.test.ts` (22/22 pass). `analyzer-metadata.json` unchanged (no registry descriptor changes).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — no UI changes.

## Notes

- Negative tests cover secure header counterparts and near-misses (`Cache-Control max-age=0`, bare `unsafe-none` config key).
- `X-XSS-Protection` regex accepts both colon form (`X-XSS-Protection: 0`) and nginx `add_header` form (`add_header X-XSS-Protection "0"`).
