### PR TITLE
feat(enrichment): flag accessibility regressions in added markup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,25 +68,25 @@ GITTENSORY_REVIEW_ENRICHMENT=false
 # commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot
 # blameLink,approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene
 # pendingReviewRequests,testRatio,migrationSafety,looseRange,terminology,todoMarker,magicNumber
-# conflictMarker,debugLeftover,sizeSmell,commitLint
+# conflictMarker,debugLeftover,sizeSmell,commitLint,a11y
 #
 # Profile defaults:
 # fast: dependency,dependencyDiff,lockfileDrift,secret,license,installScript,heavyDependency
 # hardcodedUrl,actionPin,eol,redos,provenance,secretLog,typosquat,iacMisconfig,nativeBuild
 # testRatio,migrationSafety,looseRange,terminology,todoMarker,magicNumber,conflictMarker
-# debugLeftover,sizeSmell
+# debugLeftover,sizeSmell,a11y
 # balanced (default): dependency,dependencyDiff,lockfileDrift,secret,license,installScript
 # heavyDependency,hardcodedUrl,actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight
 # typosquat,commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift,duplication
 # churnHotspot,blameLink,approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch
 # commitHygiene,pendingReviewRequests,testRatio,migrationSafety,looseRange,terminology
-# todoMarker,magicNumber,conflictMarker,debugLeftover,sizeSmell,commitLint
+# todoMarker,magicNumber,conflictMarker,debugLeftover,sizeSmell,commitLint,a11y
 # deep: dependency,dependencyDiff,lockfileDrift,secret,license,installScript,heavyDependency
 # hardcodedUrl,actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat
 # commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot
 # blameLink,approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene
 # pendingReviewRequests,testRatio,migrationSafety,looseRange,terminology,todoMarker,magicNumber
-# conflictMarker,debugLeftover,sizeSmell,commitLint
+# conflictMarker,debugLeftover,sizeSmell,commitLint,a11y
 # END GENERATED REES ANALYZERS
 
 # Submitter-reputation spend control (internal-only): downgrades new/burst/low-rep

--- a/apps/gittensory-ui/src/lib/rees-analyzers.ts
+++ b/apps/gittensory-ui/src/lib/rees-analyzers.ts
@@ -1004,6 +1004,29 @@ export const REES_ANALYZERS = [
         "Structured-fields-only: reads commit.message subjects, linted independently, never cross-line state. Fail-safe on missing token/fetch error.",
     },
   },
+  {
+    name: "a11y",
+    title: "Accessibility regressions",
+    category: "quality",
+    cost: "local",
+    defaultEnabled: true,
+    profiles: ["fast", "balanced", "deep"],
+    requires: ["files"],
+    limits: {
+      maxFindings: 25,
+      maxLineChars: 2000,
+    },
+    docs: {
+      summary:
+        "Flags common accessibility regressions in added JSX/HTML markup: an <img> without alt, a clickable non-interactive element with no keyboard handler or role, a form control with no label association, and a positive tabindex.",
+      looksAt:
+        "Self-contained added tags (open through close on one line) in .jsx, .tsx, .html, and .vue files.",
+      reports: "File, line, and public-safe rule kind — never markup content.",
+      network: "Pure local analyzer. No external network call.",
+      notes:
+        "Only matches tags whose full opening tag appears on a single added line; multi-line attribute lists are not scanned.",
+    },
+  },
 ] as const satisfies readonly ReesAnalyzerDoc[];
 
 export const REES_ANALYZER_NAMES = REES_ANALYZERS.map((analyzer) => analyzer.name);

--- a/review-enrichment/analyzer-metadata.json
+++ b/review-enrichment/analyzer-metadata.json
@@ -1131,6 +1131,32 @@
         "network": "Calls the GitHub PR-commits API once, bounded to one page.",
         "notes": "Structured-fields-only: reads commit.message subjects, linted independently, never cross-line state. Fail-safe on missing token/fetch error."
       }
+    },
+    {
+      "name": "a11y",
+      "title": "Accessibility regressions",
+      "category": "quality",
+      "cost": "local",
+      "defaultEnabled": true,
+      "profiles": [
+        "fast",
+        "balanced",
+        "deep"
+      ],
+      "requires": [
+        "files"
+      ],
+      "limits": {
+        "maxFindings": 25,
+        "maxLineChars": 2000
+      },
+      "docs": {
+        "summary": "Flags common accessibility regressions in added JSX/HTML markup: an <img> without alt, a clickable non-interactive element with no keyboard handler or role, a form control with no label association, and a positive tabindex.",
+        "looksAt": "Self-contained added tags (open through close on one line) in .jsx, .tsx, .html, and .vue files.",
+        "reports": "File, line, and public-safe rule kind — never markup content.",
+        "network": "Pure local analyzer. No external network call.",
+        "notes": "Only matches tags whose full opening tag appears on a single added line; multi-line attribute lists are not scanned."
+      }
     }
   ]
 }

--- a/review-enrichment/src/analyzers/a11y-regression.ts
+++ b/review-enrichment/src/analyzers/a11y-regression.ts
@@ -1,0 +1,160 @@
+// Accessibility-regression analyzer (#2026, the a11y half of the #1499 epic 'accessibility and i18n regression'
+// idea; the i18n half is a separate bounty). Flags common accessibility regressions in added JSX/HTML markup:
+// an <img> without alt, an onClick handler added to a non-interactive element without a keyboard handler or
+// role, a form control with no way to associate a label, and a positive tabindex (which breaks natural tab
+// order). Pure compute over added diff lines, no network. Only self-contained tags (opening `<` through closing
+// `>` on the same added line) are matched, so a tag whose attributes wrap across lines is not scanned — this
+// keeps the analyzer diff-local and free of false positives from partial tags.
+import type { A11yFinding, EnrichRequest } from "../types.js";
+import { isTestPath } from "./test-ratio.js";
+
+const MAX_FINDINGS = 25;
+const MAX_LINE_CHARS = 2000;
+
+const MARKUP_PATH_RE = /\.(?:jsx|tsx|html?|vue)$/i;
+
+// Elements with built-in interactive semantics — an onClick here needs no extra keyboard wiring.
+const INTERACTIVE_TAGS = new Set([
+  "a",
+  "button",
+  "input",
+  "select",
+  "option",
+  "textarea",
+  "summary",
+  "label",
+  "audio",
+  "video",
+  "details",
+  "dialog",
+  "menuitem",
+]);
+
+// <input> types that are never associated with a visible label (hidden fields, buttons that carry their own text).
+const LABELLESS_INPUT_TYPES = new Set(["hidden", "submit", "button", "reset", "image"]);
+
+const TAG_RE = /<([a-zA-Z][\w-]*)\b([^>]*)>/g;
+const ALT_RE = /\balt\s*=/i;
+const ONCLICK_RE = /\bonClick\s*=/;
+const KEY_HANDLER_OR_ROLE_RE = /\bonKeyDown\s*=|\bonKeyUp\s*=|\bonKeyPress\s*=|\brole\s*=/;
+const TYPE_ATTR_RE = /\btype\s*=\s*["']?(\w+)/i;
+const LABEL_ASSOC_RE = /\bid\s*=|\baria-label\s*=|\baria-labelledby\s*=/i;
+const TABINDEX_RE = /\btabindex\s*=\s*["'{]?\s*(-?\d+)/i;
+
+function isCommentLine(line: string): boolean {
+  const trimmed = line.trimStart();
+  return /^(?:\/\/|\/\*|\*|<!--|\{\/\*)/.test(trimmed);
+}
+
+function isMarkupPath(path: string): boolean {
+  return MARKUP_PATH_RE.test(path) && !isTestPath(path);
+}
+
+/** Classify one self-contained `<tag ...>` opening tag for a11y regressions. Pure. Returns every rule the tag
+ *  trips (a single tag can trip more than one, e.g. a clickable div with a positive tabindex). */
+export function detectA11yIssues(
+  tagName: string,
+  attrs: string,
+): Array<A11yFinding["rule"]> {
+  const tag = tagName.toLowerCase();
+  const rules: Array<A11yFinding["rule"]> = [];
+
+  if (tag === "img" && !ALT_RE.test(attrs)) {
+    rules.push("img-alt");
+  }
+
+  if (
+    ONCLICK_RE.test(attrs) &&
+    !INTERACTIVE_TAGS.has(tag) &&
+    !KEY_HANDLER_OR_ROLE_RE.test(attrs)
+  ) {
+    rules.push("click-events-have-key-events");
+  }
+
+  if (tag === "input" || tag === "textarea" || tag === "select") {
+    const typeMatch = TYPE_ATTR_RE.exec(attrs);
+    const type = typeMatch?.[1]?.toLowerCase();
+    const skippable = tag === "input" && type !== undefined && LABELLESS_INPUT_TYPES.has(type);
+    if (!skippable && !LABEL_ASSOC_RE.test(attrs)) {
+      rules.push("label-control");
+    }
+  }
+
+  const tabindexMatch = TABINDEX_RE.exec(attrs);
+  if (tabindexMatch && Number(tabindexMatch[1]) > 0) {
+    rules.push("positive-tabindex");
+  }
+
+  return rules;
+}
+
+type ScanLimits = {
+  maxFindings?: number;
+  signal?: AbortSignal;
+};
+
+/** Scan one file patch's added lines for accessibility regressions, line-cited via hunk headers. Pure. */
+export function scanPatchForA11y(
+  path: string,
+  patch: string,
+  limits: ScanLimits = {},
+): A11yFinding[] {
+  const maxFindings = limits.maxFindings ?? MAX_FINDINGS;
+  if (maxFindings <= 0 || !isMarkupPath(path)) return [];
+
+  const findings: A11yFinding[] = [];
+  let newLine = 0;
+  let inHunk = false;
+
+  for (const line of patch.split("\n")) {
+    if (limits.signal?.aborted) throw new Error("analyzer_aborted");
+    const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
+    if (hunk) {
+      newLine = Number(hunk[1]);
+      inHunk = true;
+      continue;
+    }
+    if (!inHunk) continue;
+    if (!line.startsWith("+")) {
+      if (!line.startsWith("-") && !line.startsWith("\\")) newLine++;
+      continue;
+    }
+
+    const body = line.slice(1);
+    if (body.length <= MAX_LINE_CHARS && !isCommentLine(body)) {
+      TAG_RE.lastIndex = 0;
+      let match: RegExpExecArray | null;
+      while ((match = TAG_RE.exec(body)) !== null) {
+        const [, tagName, attrs] = match;
+        if (tagName === undefined || attrs === undefined) continue;
+        for (const rule of detectA11yIssues(tagName, attrs)) {
+          findings.push({ file: path, line: newLine, rule });
+          if (findings.length >= maxFindings) return findings;
+        }
+      }
+    }
+    newLine++;
+  }
+
+  return findings;
+}
+
+/** Analyzer entrypoint: scan every changed markup file's added lines for accessibility regressions. */
+export async function scanA11y(
+  req: EnrichRequest,
+  signal?: AbortSignal,
+): Promise<A11yFinding[]> {
+  const findings: A11yFinding[] = [];
+  for (const file of req.files ?? []) {
+    if (signal?.aborted) throw new Error("analyzer_aborted");
+    if (!file.patch) continue;
+    for (const finding of scanPatchForA11y(file.path, file.patch, {
+      maxFindings: MAX_FINDINGS - findings.length,
+      signal,
+    })) {
+      findings.push(finding);
+      if (findings.length >= MAX_FINDINGS) return findings;
+    }
+  }
+  return findings;
+}

--- a/review-enrichment/src/analyzers/registry.ts
+++ b/review-enrichment/src/analyzers/registry.ts
@@ -1,3 +1,4 @@
+import { scanA11y } from "./a11y-regression.js";
 import { scanActionPins } from "./actions-pin.js";
 import { scanApprovalIntegrity } from "./approval-integrity.js";
 import { scanAssetWeight } from "./asset-weight.js";
@@ -1087,6 +1088,47 @@ export const ANALYZER_DESCRIPTORS = [
     },
     run: (req, { signal, analysis, diagnostics }) =>
       scanCommitLint(req, fetch, { signal, analysis, diagnostics }),
+  }),
+  descriptor({
+    name: "a11y",
+    title: "Accessibility regressions",
+    category: "quality",
+    cost: "local",
+    defaultEnabled: true,
+    requires: ["files"],
+    limits: { maxFindings: 25, maxLineChars: 2000 },
+    docs: {
+      summary:
+        "Flags common accessibility regressions in added JSX/HTML markup: an <img> without alt, a clickable non-interactive element with no keyboard handler or role, a form control with no label association, and a positive tabindex.",
+      looksAt: "Self-contained added tags (open through close on one line) in .jsx, .tsx, .html, and .vue files.",
+      reports: "File, line, and public-safe rule kind — never markup content.",
+      network: "Pure local analyzer. No external network call.",
+      notes:
+        "Only matches tags whose full opening tag appears on a single added line; multi-line attribute lists are not scanned.",
+    },
+    render: (findings, helpers) => {
+      if (!findings.length) return [];
+      const explain = (rule: (typeof findings)[number]["rule"]): string => {
+        switch (rule) {
+          case "img-alt":
+            return "<img> missing alt text";
+          case "click-events-have-key-events":
+            return "onClick on a non-interactive element with no keyboard handler or role";
+          case "label-control":
+            return "form control with no way to associate a label";
+          case "positive-tabindex":
+            return "positive tabindex breaks natural tab order";
+        }
+      };
+      const lines = ["### Accessibility regressions (added markup)"];
+      for (const item of findings) {
+        lines.push(
+          `- ${helpers.safeCodeSpan(`${item.file}:${item.line}`)} — ${explain(item.rule)}`,
+        );
+      }
+      return lines;
+    },
+    run: (req, { signal }) => scanA11y(req, signal),
   }),
 ] as const satisfies readonly AnyAnalyzerDescriptor[];
 

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -485,6 +485,7 @@ export function renderBrief(
   lines.push(...renderDescriptorSection("sizeSmell", findings.sizeSmell));
   lines.push(...renderDescriptorSection("hardcodedUrl", findings.hardcodedUrl));
   lines.push(...renderDescriptorSection("commitLint", findings.commitLint));
+  lines.push(...renderDescriptorSection("a11y", findings.a11y));
 
   if (!lines.length) return { promptSection: "", systemSuffix: "" };
 

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -511,6 +511,18 @@ export interface CommitLintFinding {
   reason: "bad-type" | "missing-colon" | "too-long" | "empty";
 }
 
+/** An accessibility regression in added JSX/HTML markup — the a11y half of the #1499 epic 'accessibility and i18n
+ *  regression' idea (#2026, part of #1499). Reports location + rule only, never markup content. */
+export interface A11yFinding {
+  file: string;
+  line: number;
+  rule:
+    | "img-alt"
+    | "click-events-have-key-events"
+    | "label-control"
+    | "positive-tabindex";
+}
+
 /** Structured analyzer output. Each analyzer fills its own key; more land as analyzers ship (#1477/#1478). */
 export interface BriefFindings {
   dependency?: DependencyFinding[];
@@ -553,6 +565,7 @@ export interface BriefFindings {
   sizeSmell?: SizeSmellFinding[];
   hardcodedUrl?: HardcodedUrlFinding[];
   commitLint?: CommitLintFinding[];
+  a11y?: A11yFinding[];
 }
 
 /** A JSDoc/TSDoc block whose `@param` tags name parameters the adjacent function no longer declares — a

--- a/review-enrichment/test/a11y-regression.test.ts
+++ b/review-enrichment/test/a11y-regression.test.ts
@@ -1,0 +1,148 @@
+// Units for the accessibility-regression analyzer (#2026). Own file so concurrent analyzer PRs don't collide.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  detectA11yIssues,
+  scanPatchForA11y,
+  scanA11y,
+} from "../dist/analyzers/a11y-regression.js";
+import { renderBrief } from "../dist/render.js";
+
+const patchOf = (lines: string[]) =>
+  `@@ -1,0 +1,${lines.length} @@\n${lines.map((l) => `+${l}`).join("\n")}`;
+
+// --- detectA11yIssues (pure per-tag rule unit) ---
+
+test("detectA11yIssues: flags <img> without alt", () => {
+  assert.deepEqual(detectA11yIssues("img", ' src="x.png"'), ["img-alt"]);
+});
+
+test("detectA11yIssues: does not flag <img> with alt", () => {
+  assert.deepEqual(detectA11yIssues("img", ' src="x.png" alt="a cat"'), []);
+});
+
+test("detectA11yIssues: flags onClick on a non-interactive element with no keyboard handler or role", () => {
+  assert.deepEqual(detectA11yIssues("div", ' onClick={handleClick}'), [
+    "click-events-have-key-events",
+  ]);
+});
+
+test("detectA11yIssues: does not flag onClick when a keyboard handler is present", () => {
+  assert.deepEqual(
+    detectA11yIssues("div", ' onClick={handleClick} onKeyDown={handleKey}'),
+    [],
+  );
+});
+
+test("detectA11yIssues: does not flag onClick when a role is present", () => {
+  assert.deepEqual(detectA11yIssues("span", ' onClick={handleClick} role="button"'), []);
+});
+
+test("detectA11yIssues: does not flag onClick on an inherently interactive element", () => {
+  assert.deepEqual(detectA11yIssues("button", ' onClick={handleClick}'), []);
+});
+
+test("detectA11yIssues: flags a form control with no label association", () => {
+  assert.deepEqual(detectA11yIssues("input", ' type="text"'), ["label-control"]);
+});
+
+test("detectA11yIssues: does not flag a form control with an id", () => {
+  assert.deepEqual(detectA11yIssues("input", ' type="text" id="name"'), []);
+});
+
+test("detectA11yIssues: does not flag a form control with aria-label", () => {
+  assert.deepEqual(detectA11yIssues("textarea", ' aria-label="Comments"'), []);
+});
+
+test("detectA11yIssues: does not flag labelless input types", () => {
+  assert.deepEqual(detectA11yIssues("input", ' type="hidden" value="1"'), []);
+  assert.deepEqual(detectA11yIssues("input", ' type="submit" value="Go"'), []);
+});
+
+test("detectA11yIssues: flags a positive tabindex", () => {
+  assert.deepEqual(detectA11yIssues("div", ' tabIndex={2}'), ["positive-tabindex"]);
+  assert.deepEqual(detectA11yIssues("div", ' tabindex="1"'), ["positive-tabindex"]);
+});
+
+test("detectA11yIssues: does not flag tabindex 0 or -1", () => {
+  assert.deepEqual(detectA11yIssues("div", ' tabIndex={0}'), []);
+  assert.deepEqual(detectA11yIssues("div", ' tabindex="-1"'), []);
+});
+
+test("detectA11yIssues: a single tag can trip more than one rule", () => {
+  assert.deepEqual(
+    detectA11yIssues("div", ' onClick={go} tabIndex={3}'),
+    ["click-events-have-key-events", "positive-tabindex"],
+  );
+});
+
+// --- scanPatchForA11y (diff-line scanning) ---
+
+test("scanPatchForA11y: reports file/line for a flagged tag", () => {
+  const patch = patchOf(['<img src="x.png" />']);
+  assert.deepEqual(scanPatchForA11y("src/Widget.tsx", patch), [
+    { file: "src/Widget.tsx", line: 1, rule: "img-alt" },
+  ]);
+});
+
+test("scanPatchForA11y: a compliant element yields no findings", () => {
+  const patch = patchOf(['<img src="x.png" alt="a cat" />']);
+  assert.deepEqual(scanPatchForA11y("src/Widget.tsx", patch), []);
+});
+
+test("scanPatchForA11y: skips non-markup file extensions", () => {
+  const patch = patchOf(['<img src="x.png" />']);
+  assert.deepEqual(scanPatchForA11y("src/widget.ts", patch), []);
+});
+
+test("scanPatchForA11y: skips test paths even for markup extensions", () => {
+  const patch = patchOf(['<img src="x.png" />']);
+  assert.deepEqual(scanPatchForA11y("src/Widget.test.tsx", patch), []);
+});
+
+test("scanPatchForA11y: skips commented-out markup", () => {
+  const patch = patchOf(['{/* <img src="x.png" /> */}']);
+  assert.deepEqual(scanPatchForA11y("src/Widget.jsx", patch), []);
+});
+
+test("scanPatchForA11y: respects the maxFindings cap", () => {
+  const lines = Array.from({ length: 5 }, (_, i) => `<img src="${i}.png" />`);
+  const patch = patchOf(lines);
+  assert.equal(scanPatchForA11y("src/Widget.tsx", patch, { maxFindings: 2 }).length, 2);
+});
+
+test("scanPatchForA11y: line numbers advance correctly across a hunk", () => {
+  const patch = [
+    "@@ -1,2 +1,3 @@",
+    " <div>",
+    '+  <img src="x.png" />',
+    " </div>",
+  ].join("\n");
+  assert.deepEqual(scanPatchForA11y("src/Widget.html", patch), [
+    { file: "src/Widget.html", line: 2, rule: "img-alt" },
+  ]);
+});
+
+// --- scanA11y (analyzer entrypoint) ---
+
+test("scanA11y: aggregates findings across files and respects the global cap", async () => {
+  const patch = patchOf(['<img src="x.png" />']);
+  const findings = await scanA11y({
+    files: Array.from({ length: 30 }, (_, i) => ({ path: `src/W${i}.tsx`, patch })),
+  });
+  assert.equal(findings.length, 25);
+});
+
+test("scanA11y: renders a public-safe brief", async () => {
+  const findings = await scanA11y({
+    files: [{ path: "src/Widget.tsx", patch: patchOf(['<img src="x.png" />']) }],
+  });
+  assert.equal(findings[0]?.rule, "img-alt");
+  const { promptSection } = renderBrief({ a11y: findings });
+  assert.match(promptSection, /Accessibility regressions/);
+  assert.match(promptSection, /src\/Widget\.tsx:1/);
+});
+
+test("scanA11y: no files yields no findings", async () => {
+  assert.deepEqual(await scanA11y({}), []);
+});

--- a/review-enrichment/test/analyzer-registry.test.ts
+++ b/review-enrichment/test/analyzer-registry.test.ts
@@ -50,6 +50,7 @@ const EXPECTED_ANALYZERS = [
   "debugLeftover",
   "sizeSmell",
   "commitLint",
+  "a11y",
 ];
 
 test("analyzer descriptors cover the runtime registry in stable order", () => {

--- a/src/review/enrichment-analyzer-names.ts
+++ b/src/review/enrichment-analyzer-names.ts
@@ -44,6 +44,7 @@ export const REES_ANALYZER_NAMES = [
   "debugLeftover",
   "sizeSmell",
   "commitLint",
+  "a11y",
 ] as const;
 
 export type ReesAnalyzerName = (typeof REES_ANALYZER_NAMES)[number];


### PR DESCRIPTION
## Summary

- Adds a new local REES analyzer (`a11y-regression`) that scans PR-added JSX/HTML/Vue markup for four common accessibility regressions the no-checkout reviewer otherwise misses: an `<img>` without `alt`, an `onClick` handler added to a non-interactive element with no keyboard handler or `role`, a form control with no way to associate a label, and a positive `tabindex` that breaks natural tab order.
- Pure diff-local compute (no network, no GitHub token) over self-contained added tags (open through close on one line), following the established local-analyzer descriptor pattern (`iac-misconfig.ts` / `size-smell.ts`).
- Reports only `{ file, line, rule }` — never markup content.

Fixes #2026

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

Also ran `npm run rees:test` (review-enrichment package's own node:test suite, 1049/1049 passing, including the new `test/a11y-regression.test.ts`) and regenerated `analyzer-metadata.json`, the UI's generated `rees-analyzers.ts`, and `.env.example`'s generated analyzer-list comments via `npm run rees:metadata`.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no auth/session/CORS surface touched.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — no OpenAPI/MCP-facing schema change; this is an internal analyzer registry addition.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI surface change beyond the generated analyzer-docs data file.
- [ ] Visible UI changes include a `UI Evidence` section below — N/A, no visible/UI change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — this PR only adds a backend REES analyzer and its generated metadata; there is no visible UI change.

## Notes

- Only self-contained tags (the full `<tag ...>` opening through its closing `>` on one added line) are scanned, so a tag whose attributes wrap across multiple lines is not matched — kept intentionally diff-local to avoid false positives from partial tags, matching the scope in the issue.
