### PR TITLE
feat(engine): add hasPlanCompletedSteps and document packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ See [Tuning your reviews](https://gittensory.aethereal.dev/docs/tuning) for the 
 | Website           | [gittensory.aethereal.dev](https://gittensory.aethereal.dev/)                                                                      |
 | Docs              | [gittensory.aethereal.dev/docs](https://gittensory.aethereal.dev/docs)                                                             |
 | MCP package       | [@jsonbored/gittensory-mcp](https://www.npmjs.com/package/@jsonbored/gittensory-mcp)                                               |
+| Engine package    | [`@jsonbored/gittensory-engine`](packages/gittensory-engine/README.md) — shared deterministic logic for the review stack and miner |
+| Miner package     | [`@jsonbored/gittensory-miner`](packages/gittensory-miner/README.md) — local foundation CLI for the autonomous miner runtime        |
 | API               | [API browser](https://gittensory.aethereal.dev/api) and [OpenAPI JSON](https://gittensory-api.aethereal.dev/openapi.json)          |
 | GitHub App        | [Install](https://github.com/apps/gittensory/installations/new) and [setup docs](https://gittensory.aethereal.dev/docs/github-app) |
 | Browser extension | [Extension page](https://gittensory.aethereal.dev/extension)                                                                       |

--- a/packages/gittensory-engine/README.md
+++ b/packages/gittensory-engine/README.md
@@ -535,6 +535,7 @@ dashboard progress summaries:
 - `hasPlanPendingSteps(plan)` — any step is `pending`
 - `hasPlanRunningSteps(plan)` — any step is `running`
 - `hasPlanSkippedSteps(plan)` — any step is `skipped`
+- `hasPlanCompletedSteps(plan)` — any step is `completed`
 
 ## Opportunity competition
 

--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -145,6 +145,7 @@ export { hasPlanFailedSteps } from "./plan-failure.js";
 export { hasPlanPendingSteps } from "./plan-pending.js";
 export { hasPlanRunningSteps } from "./plan-running.js";
 export { hasPlanSkippedSteps } from "./plan-skipped.js";
+export { hasPlanCompletedSteps } from "./plan-completed.js";
 export * from "./plan-templates.js";
 export * from "./portfolio/queue.js";
 export {

--- a/packages/gittensory-engine/src/plan-completed.ts
+++ b/packages/gittensory-engine/src/plan-completed.ts
@@ -1,0 +1,8 @@
+import type { PlanDag } from "./plan-export.js";
+
+/**
+ * Return whether any step in the plan is completed. Pure — reads the plan DAG only.
+ */
+export function hasPlanCompletedSteps(plan: PlanDag): boolean {
+  return plan.steps.some((step) => step.status === "completed");
+}

--- a/test/unit/plan-completed.test.ts
+++ b/test/unit/plan-completed.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "vitest";
+
+import { hasPlanCompletedSteps } from "../../packages/gittensory-engine/src/plan-completed";
+import type { PlanStep } from "../../packages/gittensory-engine/src/plan-export";
+
+function step(over: Partial<PlanStep> & { id: string; title: string }): PlanStep {
+  return {
+    actionClass: undefined,
+    dependsOn: [],
+    status: "pending",
+    attempts: 0,
+    maxAttempts: 3,
+    lastError: null,
+    ...over,
+  };
+}
+
+describe("hasPlanCompletedSteps", () => {
+  it("returns false for an empty plan", () => {
+    expect(hasPlanCompletedSteps({ steps: [] })).toBe(false);
+  });
+
+  it("returns false when no step is completed", () => {
+    expect(
+      hasPlanCompletedSteps({
+        steps: [
+          step({ id: "a", title: "Build", status: "pending" }),
+          step({ id: "b", title: "Test", status: "running" }),
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true when at least one step is completed", () => {
+    expect(
+      hasPlanCompletedSteps({
+        steps: [
+          step({ id: "a", title: "Build", status: "completed" }),
+          step({ id: "b", title: "Test", status: "pending" }),
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("is exported from the package barrel", async () => {
+    const barrel = await import("../../packages/gittensory-engine/src/index");
+    expect(typeof barrel.hasPlanCompletedSteps).toBe("function");
+    expect(
+      barrel.hasPlanCompletedSteps({
+        steps: [step({ id: "a", title: "A", status: "completed" })],
+      }),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #2298

## Summary
- Add `hasPlanCompletedSteps` in `@jsonbored/gittensory-engine` — returns whether any step in a plan DAG is completed (partial-progress gating alongside `isPlanFullyCompleted`).
- Document the helper in `packages/gittensory-engine/README.md` under Plan DAG status helpers (advances the engine README export-list deliverable in #2298).
- Add `gittensory-engine` and `gittensory-miner` rows to the root `README.md` Surfaces table (remaining #2298 deliverable).

## Conflict avoidance
Touches only `packages/gittensory-engine/src/plan-completed.ts` (new), one export line in `index.ts`, one engine README bullet, `test/unit/plan-completed.test.ts` (new), and two root README table rows. No overlap with open PRs #3513, #3523, #3535, #3539.

## Test plan
- [x] `COVERAGE_NO_THRESHOLDS=1 npx vitest run test/unit/plan-completed.test.ts --coverage`
- [x] `npx diff-cover coverage/lcov.info --compare-branch=main --fail-under=99` → 100%
- [x] `npm run build --workspace @jsonbored/gittensory-engine && npm run build:miner`


Made with [Cursor](https://cursor.com)