### PR TITLE
feat(enrichment): empty-catch / error-swallow analyzer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,26 +68,26 @@ GITTENSORY_REVIEW_ENRICHMENT=false
 # commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot
 # blameLink,approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene
 # pendingReviewRequests,testRatio,migrationSafety,looseRange,terminology,todoMarker,magicNumber
-# conflictMarker,debugLeftover,sizeSmell,floatingPromise,deepNesting,commitLint
+# conflictMarker,debugLeftover,sizeSmell,floatingPromise,deepNesting,errorSwallow,commitLint
 #
 # Profile defaults:
 # fast: dependency,dependencyDiff,lockfileDrift,secret,license,installScript,heavyDependency
 # hardcodedUrl,actionPin,eol,redos,provenance,secretLog,typosquat,iacMisconfig,nativeBuild
 # testRatio,migrationSafety,looseRange,terminology,todoMarker,magicNumber,conflictMarker
-# debugLeftover,sizeSmell,floatingPromise,deepNesting
+# debugLeftover,sizeSmell,floatingPromise,deepNesting,errorSwallow
 # balanced (default): dependency,dependencyDiff,lockfileDrift,secret,license,installScript
 # heavyDependency,hardcodedUrl,actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight
 # typosquat,commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift,duplication
 # churnHotspot,blameLink,approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch
 # commitHygiene,pendingReviewRequests,testRatio,migrationSafety,looseRange,terminology
 # todoMarker,magicNumber,conflictMarker,debugLeftover,sizeSmell,floatingPromise,deepNesting
-# commitLint
+# errorSwallow,commitLint
 # deep: dependency,dependencyDiff,lockfileDrift,secret,license,installScript,heavyDependency
 # hardcodedUrl,actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat
 # commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot
 # blameLink,approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene
 # pendingReviewRequests,testRatio,migrationSafety,looseRange,terminology,todoMarker,magicNumber
-# conflictMarker,debugLeftover,sizeSmell,floatingPromise,deepNesting,commitLint
+# conflictMarker,debugLeftover,sizeSmell,floatingPromise,deepNesting,errorSwallow,commitLint
 # END GENERATED REES ANALYZERS
 
 # Submitter-reputation spend control (internal-only): downgrades new/burst/low-rep

--- a/apps/gittensory-ui/src/lib/rees-analyzers.ts
+++ b/apps/gittensory-ui/src/lib/rees-analyzers.ts
@@ -1028,6 +1028,28 @@ export const REES_ANALYZERS = [
     },
   },
   {
+    name: "errorSwallow",
+    title: "Swallowed errors",
+    category: "quality",
+    cost: "local",
+    defaultEnabled: true,
+    profiles: ["fast", "balanced", "deep"],
+    requires: ["files"],
+    limits: {
+      maxFindings: 25,
+      maxLineChars: 2000,
+    },
+    docs: {
+      summary:
+        "Flags newly-added catch/except blocks that swallow the error — empty body, unused binding, or a bare `return null`.",
+      looksAt: "Added lines in changed non-test JS/TS/Python source files.",
+      reports: "File, line, and kind: empty-catch, unused-binding, or return-null.",
+      network: "Pure local analyzer. No external network call.",
+      notes:
+        "Multiline catch bodies are collected with brace balance. Catches that log, rethrow, or reference the binding are not flagged. Brace counting is character-level (string literals are not stripped).",
+    },
+  },
+  {
     name: "commitLint",
     title: "Conventional-commit subjects",
     category: "quality",

--- a/review-enrichment/analyzer-metadata.json
+++ b/review-enrichment/analyzer-metadata.json
@@ -1162,6 +1162,32 @@
       }
     },
     {
+      "name": "errorSwallow",
+      "title": "Swallowed errors",
+      "category": "quality",
+      "cost": "local",
+      "defaultEnabled": true,
+      "profiles": [
+        "fast",
+        "balanced",
+        "deep"
+      ],
+      "requires": [
+        "files"
+      ],
+      "limits": {
+        "maxFindings": 25,
+        "maxLineChars": 2000
+      },
+      "docs": {
+        "summary": "Flags newly-added catch/except blocks that swallow the error — empty body, unused binding, or a bare `return null`.",
+        "looksAt": "Added lines in changed non-test JS/TS/Python source files.",
+        "reports": "File, line, and kind: empty-catch, unused-binding, or return-null.",
+        "network": "Pure local analyzer. No external network call.",
+        "notes": "Multiline catch bodies are collected with brace balance. Catches that log, rethrow, or reference the binding are not flagged. Brace counting is character-level (string literals are not stripped)."
+      }
+    },
+    {
       "name": "commitLint",
       "title": "Conventional-commit subjects",
       "category": "quality",

--- a/review-enrichment/src/analyzers/error-swallow.ts
+++ b/review-enrichment/src/analyzers/error-swallow.ts
@@ -1,0 +1,214 @@
+// Empty-catch / error-swallow analyzer (#2014). Flags newly-added catch/except blocks that swallow the error
+// (empty body, unused binding, or a bare `return null`) — a top source of silent failures. Pure compute over
+// added diff lines, no network. Scoped to JS/TS/Python source files; Python `except: pass` is included.
+import type { EnrichRequest, ErrorSwallowFinding } from "../types.js";
+import { isTestPath } from "./test-ratio.js";
+
+const MAX_FINDINGS = 25;
+const MAX_LINE_CHARS = 2000;
+
+const SOURCE_EXTS = new Set(["ts", "tsx", "js", "jsx", "mjs", "cjs", "mts", "cts", "py"]);
+
+const CATCH_OPEN_RE = /catch\s*(?:\(\s*([\w$]+)?\s*\))?\s*\{/;
+const PY_EXCEPT_PASS_RE = /^\s*except(?:\s+[\w.]+\s*(?:as\s+(\w+))?)?\s*:\s*pass\s*(?:#.*)?$/;
+
+function isScannablePath(path: string): boolean {
+  const ext = /\.([^.]+)$/.exec(path)?.[1]?.toLowerCase();
+  return Boolean(ext && SOURCE_EXTS.has(ext) && !isTestPath(path));
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[$.*+?^{}()|[\]\\]/g, "\\$&");
+}
+
+function referencesBinding(body: string, binding: string): boolean {
+  const escaped = escapeRegExp(binding);
+  const bindingRe = new RegExp(`(?<![A-Za-z0-9_$])${escaped}(?![A-Za-z0-9_$])`);
+  return bindingRe.test(body);
+}
+
+function bodySwallowsError(body: string, binding: string | null): ErrorSwallowFinding["kind"] | null {
+  const trimmed = body.trim();
+  if (!trimmed) return "empty-catch";
+  if (/^return\s+null\s*;?$/.test(trimmed)) return "return-null";
+  if (!binding) return null;
+  if (/\bthrow\b/.test(trimmed)) return null;
+  if (/\b(?:console|logger|log|winston|pino|bunyan)\s*[.(]/.test(trimmed)) return null;
+  if (/\bprint\s*\(/.test(trimmed)) return null;
+  if (!referencesBinding(trimmed, binding)) return "unused-binding";
+  return null;
+}
+
+function braceBalanceFrom(line: string, openBrace: number): number {
+  let depth = 0;
+  for (let i = openBrace; i < line.length; i++) {
+    const ch = line[i]!;
+    if (ch === "{") depth++;
+    else if (ch === "}") depth--;
+  }
+  return depth;
+}
+
+/** Extract a complete JS/TS catch block from one line using brace balance, or null if incomplete. Pure. */
+export function parseCompleteCatchLine(
+  line: string,
+): { binding: string | null; body: string } | null {
+  const open = CATCH_OPEN_RE.exec(line);
+  if (!open) return null;
+  const braceStart = line.indexOf("{", open.index ?? 0);
+  if (braceStart < 0) return null;
+
+  let depth = 0;
+  for (let i = braceStart; i < line.length; i++) {
+    const ch = line[i]!;
+    if (ch === "{") depth++;
+    else if (ch === "}") depth--;
+    if (depth === 0) {
+      return {
+        binding: open[1] ?? null,
+        body: line.slice(braceStart + 1, i),
+      };
+    }
+  }
+  return null;
+}
+
+/** Classify one source line for an error-swallow pattern, or null. Pure. */
+export function detectErrorSwallow(line: string): ErrorSwallowFinding["kind"] | null {
+  const pyMatch = PY_EXCEPT_PASS_RE.exec(line);
+  if (pyMatch) {
+    return pyMatch[1] ? "unused-binding" : "empty-catch";
+  }
+
+  const complete = parseCompleteCatchLine(line);
+  if (complete) {
+    return bodySwallowsError(complete.body, complete.binding);
+  }
+
+  return null;
+}
+
+type PendingCatch = {
+  startLine: number;
+  binding: string | null;
+  body: string;
+  depth: number;
+};
+
+function updatePending(pending: PendingCatch, line: string): PendingCatch {
+  let depth = pending.depth;
+  for (const ch of line) {
+    if (ch === "{") depth++;
+    else if (ch === "}") depth--;
+  }
+  return { ...pending, body: `${pending.body}\n${line}`, depth };
+}
+
+function flushPending(pending: PendingCatch): ErrorSwallowFinding["kind"] | null {
+  const body = pending.body.replace(/^\s*\{/, "").replace(/\}\s*$/, "");
+  return bodySwallowsError(body, pending.binding);
+}
+
+type ScanLimits = {
+  maxFindings?: number;
+  signal?: AbortSignal;
+};
+
+/** Scan one file patch's added lines for swallowed errors, line-cited via hunk headers. Pure. */
+export function scanPatchForErrorSwallow(
+  path: string,
+  patch: string,
+  limits: ScanLimits = {},
+): ErrorSwallowFinding[] {
+  const maxFindings = limits.maxFindings ?? MAX_FINDINGS;
+  if (maxFindings <= 0 || !isScannablePath(path)) return [];
+  const findings: ErrorSwallowFinding[] = [];
+  let newLine = 0;
+  let inHunk = false;
+  let pending: PendingCatch | null = null;
+
+  const pushFinding = (line: number, kind: ErrorSwallowFinding["kind"]) => {
+    findings.push({ file: path, line, kind });
+  };
+
+  for (const line of patch.split("\n")) {
+    if (limits.signal?.aborted) throw new Error("analyzer_aborted");
+    const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
+    if (hunk) {
+      newLine = Number(hunk[1]);
+      inHunk = true;
+      pending = null;
+      continue;
+    }
+    if (!inHunk) continue;
+
+    if (line.startsWith("+")) {
+      const body = line.slice(1);
+      if (body.length <= MAX_LINE_CHARS) {
+        if (pending) {
+          pending = updatePending(pending, body);
+          if (pending.depth <= 0) {
+            const kind = flushPending(pending);
+            if (kind) {
+              pushFinding(pending.startLine, kind);
+              if (findings.length >= maxFindings) return findings;
+            }
+            pending = null;
+          }
+        } else {
+          const kind = detectErrorSwallow(body);
+          if (kind) {
+            pushFinding(newLine, kind);
+            if (findings.length >= maxFindings) return findings;
+          } else {
+            const open = CATCH_OPEN_RE.exec(body);
+            if (open) {
+              const braceIndex = body.indexOf("{", open.index ?? 0);
+              if (braceIndex >= 0) {
+                const depth = braceBalanceFrom(body, braceIndex);
+                if (depth > 0) {
+                  pending = {
+                    startLine: newLine,
+                    binding: open[1] ?? null,
+                    body: body.slice(braceIndex),
+                    depth,
+                  };
+                }
+              }
+            }
+          }
+        }
+      }
+      newLine++;
+    } else if (!line.startsWith("-") && !line.startsWith("\\")) {
+      pending = null;
+      newLine++;
+    } else {
+      pending = null;
+    }
+
+    if (findings.length >= maxFindings) return findings;
+  }
+
+  return findings;
+}
+
+/** Analyzer entrypoint: scan every changed scannable file's added lines for swallowed errors. */
+export async function scanErrorSwallow(
+  req: EnrichRequest,
+  signal?: AbortSignal,
+): Promise<ErrorSwallowFinding[]> {
+  const findings: ErrorSwallowFinding[] = [];
+  for (const file of req.files ?? []) {
+    if (signal?.aborted) throw new Error("analyzer_aborted");
+    if (!file.patch) continue;
+    for (const finding of scanPatchForErrorSwallow(file.path, file.patch, {
+      maxFindings: MAX_FINDINGS - findings.length,
+      signal,
+    })) {
+      findings.push(finding);
+      if (findings.length >= MAX_FINDINGS) return findings;
+    }
+  }
+  return findings;
+}

--- a/review-enrichment/src/analyzers/registry.ts
+++ b/review-enrichment/src/analyzers/registry.ts
@@ -33,6 +33,7 @@ import { scanMagicNumbers } from "./magic-number.js";
 import { scanConflictMarkers } from "./conflict-marker.js";
 import { scanDebugLeftover } from "./debug-leftover.js";
 import { scanDeepNesting } from "./deep-nesting.js";
+import { scanErrorSwallow } from "./error-swallow.js";
 import { scanFloatingPromise } from "./floating-promise.js";
 import { scanSizeSmell } from "./size-smell.js";
 import { scanCommitLint } from "./commit-lint.js";
@@ -1105,6 +1106,35 @@ export const ANALYZER_DESCRIPTORS = [
       return lines;
     },
     run: (req, { signal }) => scanDeepNesting(req, signal),
+  }),
+  descriptor({
+    name: "errorSwallow",
+    title: "Swallowed errors",
+    category: "quality",
+    cost: "local",
+    defaultEnabled: true,
+    requires: ["files"],
+    limits: { maxFindings: 25, maxLineChars: 2000 },
+    docs: {
+      summary:
+        "Flags newly-added catch/except blocks that swallow the error — empty body, unused binding, or a bare `return null`.",
+      looksAt: "Added lines in changed non-test JS/TS/Python source files.",
+      reports: "File, line, and kind: empty-catch, unused-binding, or return-null.",
+      network: "Pure local analyzer. No external network call.",
+      notes:
+        "Multiline catch bodies are collected with brace balance. Catches that log, rethrow, or reference the binding are not flagged. Brace counting is character-level (string literals are not stripped).",
+    },
+    render: (findings, helpers) => {
+      if (!findings.length) return [];
+      const lines = ["### Swallowed errors (empty catch / unused binding / return null)"];
+      for (const item of findings) {
+        lines.push(
+          `- ${helpers.safeCodeSpan(`${item.file}:${item.line}`)} — ${helpers.safeCodeSpan(item.kind)}`,
+        );
+      }
+      return lines;
+    },
+    run: (req, { signal }) => scanErrorSwallow(req, signal),
   }),
   descriptor({
     name: "commitLint",

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -485,6 +485,7 @@ export function renderBrief(
   lines.push(...renderDescriptorSection("sizeSmell", findings.sizeSmell));
   lines.push(...renderDescriptorSection("floatingPromise", findings.floatingPromise));
   lines.push(...renderDescriptorSection("deepNesting", findings.deepNesting));
+  lines.push(...renderDescriptorSection("errorSwallow", findings.errorSwallow));
   lines.push(...renderDescriptorSection("hardcodedUrl", findings.hardcodedUrl));
   lines.push(...renderDescriptorSection("commitLint", findings.commitLint));
 

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -494,6 +494,14 @@ export interface SizeSmellFinding {
   name?: string;
 }
 
+/** A swallowed-error catch/except block newly added in the diff (#2014, part of #1499).
+ *  Reports file, line, and kind only — never catch body content. */
+export interface ErrorSwallowFinding {
+  file: string;
+  line: number;
+  kind: "empty-catch" | "unused-binding" | "return-null";
+}
+
 /** Deep control-flow nesting newly added in the diff (#2030, part of #1499).
  *  Reports file, line, measured depth, and threshold — never source content. */
 export interface DeepNestingFinding {
@@ -570,6 +578,7 @@ export interface BriefFindings {
   sizeSmell?: SizeSmellFinding[];
   floatingPromise?: FloatingPromiseFinding[];
   deepNesting?: DeepNestingFinding[];
+  errorSwallow?: ErrorSwallowFinding[];
   hardcodedUrl?: HardcodedUrlFinding[];
   commitLint?: CommitLintFinding[];
 }

--- a/review-enrichment/test/analyzer-registry.test.ts
+++ b/review-enrichment/test/analyzer-registry.test.ts
@@ -51,6 +51,7 @@ const EXPECTED_ANALYZERS = [
   "sizeSmell",
   "floatingPromise",
   "deepNesting",
+  "errorSwallow",
   "commitLint",
 ];
 

--- a/review-enrichment/test/error-swallow.test.ts
+++ b/review-enrichment/test/error-swallow.test.ts
@@ -1,0 +1,93 @@
+// Units for the error-swallow analyzer (#2014). Own file so concurrent analyzer PRs don't collide.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  detectErrorSwallow,
+  scanErrorSwallow,
+  scanPatchForErrorSwallow,
+} from "../dist/analyzers/error-swallow.js";
+import { renderBrief } from "../dist/render.js";
+
+const patchOf = (lines: string[]) =>
+  `@@ -1,0 +1,${lines.length} @@\n${lines.map((l) => `+${l}`).join("\n")}`;
+
+test("detectErrorSwallow: flags empty catches and return-null handlers", () => {
+  assert.equal(detectErrorSwallow("try { f(); } catch (e) {}"), "empty-catch");
+  assert.equal(detectErrorSwallow("try { f(); } catch {}"), "empty-catch");
+  assert.equal(detectErrorSwallow("try { f(); } catch (e) { return null; }"), "return-null");
+  assert.equal(detectErrorSwallow("except ValueError: pass"), "empty-catch");
+  assert.equal(detectErrorSwallow("except ValueError as err: pass"), "unused-binding");
+});
+
+test("detectErrorSwallow: does not flag catches that log, rethrow, or use the binding", () => {
+  assert.equal(detectErrorSwallow("try { f(); } catch (e) { console.error(e); }"), null);
+  assert.equal(detectErrorSwallow("try { f(); } catch (e) { throw e; }"), null);
+  assert.equal(detectErrorSwallow("try { f(); } catch (e) { cleanup(e); }"), null);
+  assert.equal(detectErrorSwallow("try { f(); } catch ($err) { handle($err); }"), null);
+});
+
+test("detectErrorSwallow: brace-balances nested blocks on one line", () => {
+  assert.equal(detectErrorSwallow("try { f(); } catch (e) { if (x) {} handle(e); }"), null);
+});
+
+test("detectErrorSwallow: flags unused bindings on single-line catches", () => {
+  assert.equal(detectErrorSwallow("try { f(); } catch (err) { cleanup(); }"), "unused-binding");
+});
+
+test("scanPatchForErrorSwallow: flags added lines with correct locations", () => {
+  const findings = scanPatchForErrorSwallow(
+    "src/worker.ts",
+    patchOf([
+      "export async function run() {",
+      "  try {",
+      "    await load();",
+      "  } catch (e) {}",
+      "}",
+    ]),
+  );
+  assert.deepEqual(findings, [{ file: "src/worker.ts", line: 4, kind: "empty-catch" }]);
+});
+
+test("scanPatchForErrorSwallow: supports multi-line catch blocks on added lines", () => {
+  const patch = [
+    "@@ -1,0 +1,5 @@",
+    "+try {",
+    "+  await load();",
+    "+} catch (err) {",
+    "+  return null;",
+    "+}",
+  ].join("\n");
+  assert.deepEqual(scanPatchForErrorSwallow("src/worker.ts", patch), [
+    { file: "src/worker.ts", line: 3, kind: "return-null" },
+  ]);
+});
+
+test("scanPatchForErrorSwallow: skips test files", () => {
+  assert.deepEqual(
+    scanPatchForErrorSwallow("src/worker.test.ts", patchOf(["catch (e) {}"])),
+    [],
+  );
+});
+
+test("scanPatchForErrorSwallow: respects the findings cap", () => {
+  const lines = Array.from({ length: 30 }, () => "catch (e) {}");
+  assert.equal(scanPatchForErrorSwallow("src/a.ts", patchOf(lines), { maxFindings: 3 }).length, 3);
+});
+
+test("scanErrorSwallow: aggregates across files and renders a public-safe brief", async () => {
+  const findings = await scanErrorSwallow({
+    files: [
+      { path: "src/a.ts", patch: patchOf(["catch (e) {}"]) },
+      { path: "lib/b.py", patch: patchOf(["except RuntimeError: pass"]) },
+    ],
+  });
+  assert.deepEqual(findings, [
+    { file: "src/a.ts", line: 1, kind: "empty-catch" },
+    { file: "lib/b.py", line: 1, kind: "empty-catch" },
+  ]);
+
+  const { promptSection } = renderBrief({ errorSwallow: findings });
+  assert.match(promptSection, /Swallowed errors/);
+  assert.match(promptSection, /src\/a\.ts:1/);
+  assert.doesNotMatch(promptSection, /catch \(e\)/);
+});

--- a/src/review/enrichment-analyzer-names.ts
+++ b/src/review/enrichment-analyzer-names.ts
@@ -45,6 +45,7 @@ export const REES_ANALYZER_NAMES = [
   "sizeSmell",
   "floatingPromise",
   "deepNesting",
+  "errorSwallow",
   "commitLint",
 ] as const;
 


### PR DESCRIPTION
## Summary
Fixes #2014

- Add `ErrorSwallowFinding` and a local `errorSwallow` analyzer that flags newly-added catch/except blocks that swallow errors: empty body, unused binding, or bare `return null`
- Brace-balanced catch-body extraction for single-line and multi-line added hunks; JS/TS optional-binding `catch {}` and Python `except: pass` supported
- Binding references use identifier-boundary lookarounds (including `$` in valid JS identifiers), not `\b` word boundaries
- Register the analyzer in the REES registry with render/docs/metadata; sync `src/review/enrichment-analyzer-names.ts` and generated `.env.example` / UI metadata
- Add `review-enrichment/test/error-swallow.test.ts` covering empty/return-null/unused-binding cases, log/rethrow/$-binding/nested-brace non-flags, multiline catches, cap, and public-safe brief rendering

## Test plan
- [x] `cd review-enrichment && npm run build && npm run metadata && node --test test/error-swallow.test.ts test/analyzer-registry.test.ts`
- [ ] CI `validate-code`

Made with [Cursor](https://cursor.com)