### PR TITLE
feat(enrichment): flag COOP/COEP unsafe-none in iac-misconfig

### DIFF
--- a/review-enrichment/src/analyzers/iac-misconfig.ts
+++ b/review-enrichment/src/analyzers/iac-misconfig.ts
@@ -112,6 +112,10 @@ const DOCKER_SOCKET_MOUNT_RE =
 const HSTS_DISABLED_RE = /\bStrict-Transport-Security\b[^\n]*\bmax-age\s*=\s*0\b/i;
 const REFERRER_UNSAFE_URL_RE = /\bReferrer-Policy\b[^\n]*\bunsafe-url\b/i;
 const COOKIE_NOT_HTTPONLY_RE = /\bhttp[_-]?only\b[\s"'=:,-]*false\b/i;
+const COOP_UNSAFE_NONE_RE =
+  /\bCross-Origin-Opener-Policy\b[^\n]*\bunsafe-none\b/i;
+const COEP_UNSAFE_NONE_RE =
+  /\bCross-Origin-Embedder-Policy\b[^\n]*\bunsafe-none\b/i;
 
 function* patchLines(patch: string): Generator<string> {
   let start = 0;
@@ -538,6 +542,18 @@ export function scanPatchForIacMisconfig(
     if (
       COOKIE_NOT_HTTPONLY_RE.test(body) &&
       pushFinding(findings, seen, path, newLine, "cookie-not-httponly", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      COOP_UNSAFE_NONE_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "coop-unsafe-none", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      COEP_UNSAFE_NONE_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "coep-unsafe-none", maxFindings)
     ) {
       return findings;
     }

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -360,6 +360,10 @@ export function renderBrief(
           return "sets `Referrer-Policy: unsafe-url`, leaking the full URL (path and query) to cross-origin destinations";
         case "cookie-not-httponly":
           return "sets `httpOnly: false` on a cookie, exposing it to JavaScript so an XSS can read it";
+        case "coop-unsafe-none":
+          return "sets `Cross-Origin-Opener-Policy: unsafe-none`, allowing cross-origin pages to retain opener access";
+        case "coep-unsafe-none":
+          return "sets `Cross-Origin-Embedder-Policy: unsafe-none`, disabling cross-origin isolation requirements for embedded resources";
       }
     };
 

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -270,7 +270,9 @@ export interface IacMisconfigFinding {
     | "docker-socket-mount"
     | "hsts-disabled"
     | "referrer-policy-leak"
-    | "cookie-not-httponly";
+    | "cookie-not-httponly"
+    | "coop-unsafe-none"
+    | "coep-unsafe-none";
 }
 
 /** A newly-added dependency whose install compiles native code (npm node-gyp addon) or has no prebuilt wheel

--- a/review-enrichment/test/iac-misconfig.test.ts
+++ b/review-enrichment/test/iac-misconfig.test.ts
@@ -461,6 +461,8 @@ test("scanPatchForIacMisconfig flags insecure HTTP security-header settings", ()
     ["+    add_header Strict-Transport-Security \"max-age=0\";", "hsts-disabled"],
     ["+    add_header Referrer-Policy \"unsafe-url\";", "referrer-policy-leak"],
     ["+    httpOnly: false", "cookie-not-httponly"],
+    ["+    add_header Cross-Origin-Opener-Policy \"unsafe-none\";", "coop-unsafe-none"],
+    ["+    add_header Cross-Origin-Embedder-Policy \"unsafe-none\";", "coep-unsafe-none"],
   ];
   for (const [added, kind] of cases) {
     const findings = scanPatchForIacMisconfig(
@@ -482,6 +484,10 @@ test("scanPatchForIacMisconfig does not flag secure HTTP header values (incl. Ca
     "+    add_header Cache-Control \"max-age=0\";",
     "+    add_header Referrer-Policy \"strict-origin-when-cross-origin\";",
     "+    httpOnly: true",
+    "+    add_header Cross-Origin-Opener-Policy \"same-origin\";",
+    "+    add_header Cross-Origin-Embedder-Policy \"require-corp\";",
+    // A bare `unsafe-none` config key without a COOP/COEP header token must NOT fire either rule.
+    "+    unsafe-none = false",
   ];
   for (const added of safe) {
     assert.deepEqual(


### PR DESCRIPTION
## Summary

Extends the existing `iac-misconfig` HTTP security-header rules (merged in #3387) with **two zero-FP isolation-header checks**, addressing #3538 review feedback by **dropping** the `X-XSS-Protection: 0` and `X-Frame-Options: ALLOWALL` rules (modern guidance treats `0` as hardening; `ALLOWALL` is non-standard/low-signal).

| kind | Trigger | risk |
| --- | --- | --- |
| `coop-unsafe-none` | `Cross-Origin-Opener-Policy … unsafe-none` | cross-origin documents can retain `window.opener` access |
| `coep-unsafe-none` | `Cross-Origin-Embedder-Policy … unsafe-none` | disables cross-origin isolation requirements for embedded resources |

Each rule requires its own header token on the same line as the weakening value, so unrelated lines (e.g. `Cache-Control: max-age=0`, bare `unsafe-none = false`) are not flagged.

Fixes #2096

Follow-up to the IaC-misconfig test-scaffold issue: the original deliverable (pure-scanner unit tests) landed in #2096; this PR completes the next slice of analyzer coverage requested in [#2096#issuecomment-4886736482](https://github.com/JSONbored/gittensory/issues/2096#issuecomment-4886736482). If maintainers prefer a fresh open tracking issue instead of the closed parent, happy to retarget the closing reference.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` — not applicable (review-enrichment only)
- [ ] `npm run typecheck` — not applicable (review-enrichment only)
- [ ] `npm run test:coverage` — not applicable (review-enrichment only)
- [ ] `npm run test:workers` — not applicable
- [ ] `npm run build:mcp` — not applicable
- [ ] `npm run test:mcp-pack` — not applicable
- [ ] `npm run ui:openapi:check` — not applicable
- [ ] `npm run ui:lint` — not applicable
- [ ] `npm run ui:typecheck` — not applicable
- [ ] `npm run ui:build` — not applicable
- [ ] `npm audit --audit-level=moderate` — not applicable
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Review-enrichment-only change; validated with `npm --prefix review-enrichment run build` and `node --test review-enrichment/test/iac-misconfig.test.ts` (22/22 pass). `analyzer-metadata.json` unchanged (no registry descriptor changes).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — no UI changes.

## Notes

- Supersedes closed #3538 with a narrower, review-aligned rule set (COOP/COEP only).
- Negative tests cover secure header counterparts and near-misses (`Cache-Control max-age=0`, bare `unsafe-none` config key).
