### PR TITLE
fix(selfhost): recognize review_audit in the exporter's no-source-tables guard

### DIFF
--- a/scripts/export-grafana-reporting-db.sh
+++ b/scripts/export-grafana-reporting-db.sh
@@ -187,7 +187,8 @@ if pg_enabled; then
   if ! pg_table_exists "pull_requests" &&
      ! pg_table_exists "advisories" &&
      ! pg_table_exists "review_targets" &&
-     ! pg_table_exists "ai_usage_events"; then
+     ! pg_table_exists "ai_usage_events" &&
+     ! pg_table_exists "review_audit"; then
     if [ -s "$OUT_DB" ]; then
       rm -f "$TMP_DB" "$TMP_DB-wal" "$TMP_DB-shm"
       echo "reporting export skipped: no reporting source tables in Postgres; preserving last good $OUT_DB" >&2
@@ -349,7 +350,8 @@ fi
 if ! source_table_exists "pull_requests" &&
    ! source_table_exists "advisories" &&
    ! source_table_exists "review_targets" &&
-   ! source_table_exists "ai_usage_events"; then
+   ! source_table_exists "ai_usage_events" &&
+   ! source_table_exists "review_audit"; then
   if [ -s "$OUT_DB" ]; then
     rm -f "$TMP_DB" "$TMP_DB-wal" "$TMP_DB-shm"
     echo "reporting export skipped: no reporting source tables in $APP_DB; preserving last good $OUT_DB" >&2

--- a/test/unit/selfhost-grafana-reporting.test.ts
+++ b/test/unit/selfhost-grafana-reporting.test.ts
@@ -394,6 +394,51 @@ esac
     expect(sqlite(outDb, "SELECT status || '|' || (verdict IS NULL) FROM review_targets WHERE repo='JSONbored/gittensory' AND number=4001;")).toBe("manual|1");
   });
 
+  it("a source DB with ONLY review_audit (no pull_requests/review_targets/ai_usage_events) is recognized as having real data -- the exporter runs a fresh pass instead of preserving a stale last-good snapshot", () => {
+    const root = tmpRoot();
+    const appDb = join(root, "app.sqlite");
+    const outDb = join(root, "reporting.sqlite");
+
+    // Seed a legitimate "last good" output from a normal run, so a wrongly-triggered skip would be observable
+    // (the old snapshot would survive untouched instead of being replaced by a fresh, empty pass).
+    sqlite(appDb, `
+      CREATE TABLE pull_requests (
+        repo_full_name TEXT NOT NULL, number INTEGER NOT NULL, title TEXT NOT NULL, state TEXT NOT NULL,
+        author_login TEXT, merged_at TEXT, created_at TEXT NOT NULL, updated_at TEXT NOT NULL
+      );
+      INSERT INTO pull_requests (repo_full_name, number, title, state, author_login, merged_at, created_at, updated_at)
+      VALUES ('JSONbored/gittensory', 9001, 'stale last-good PR', 'open', 'JSONbored', NULL, '2026-07-01T00:00:00Z', '2026-07-01T00:00:00Z');
+
+      CREATE TABLE review_audit (
+        id TEXT NOT NULL, target_id TEXT NOT NULL, event_type TEXT NOT NULL, decision TEXT,
+        source TEXT NOT NULL, created_at TEXT NOT NULL
+      );
+      INSERT INTO review_audit (id, target_id, event_type, decision, source, created_at)
+      VALUES ('g0', 'JSONbored/gittensory#9001', 'gate_decision', 'hold', 'gittensory-native', '2026-07-01T00:00:00Z');
+    `);
+    runExporter(root, appDb, outDb);
+    expect(sqlite(outDb, "SELECT count(*) FROM review_targets;")).toBe("1");
+
+    // Now point at a fresh source DB containing ONLY review_audit -- no pull_requests, review_targets, or
+    // ai_usage_events at all.
+    const onlyAuditDb = join(root, "only-audit.sqlite");
+    sqlite(onlyAuditDb, `
+      CREATE TABLE review_audit (
+        id TEXT NOT NULL, target_id TEXT NOT NULL, event_type TEXT NOT NULL, decision TEXT,
+        source TEXT NOT NULL, created_at TEXT NOT NULL
+      );
+      INSERT INTO review_audit (id, target_id, event_type, decision, source, created_at)
+      VALUES ('g1', 'JSONbored/gittensory#9002', 'gate_decision', 'hold', 'gittensory-native', '2026-07-05T00:00:00Z');
+    `);
+    // Must not throw: a wrongly-triggered "no reporting source tables" skip exits non-zero when a last-good
+    // snapshot already exists (see the seeded run above).
+    expect(() => runExporter(root, onlyAuditDb, outDb)).not.toThrow();
+
+    // The stale PR from the seeded run is GONE -- proving this was a genuine fresh pass (pull_requests doesn't
+    // exist in the only-review_audit source, so nothing populates review_targets), not a preserved snapshot.
+    expect(sqlite(outDb, "SELECT count(*) FROM review_targets;")).toBe("0");
+  });
+
   it("falls back to legacy review_targets when the current PR cache is absent", () => {
     const root = tmpRoot();
     const appDb = join(root, "app.sqlite");


### PR DESCRIPTION
Closes #3554

## Summary

- Small follow-up to #3535, addressing a non-blocking nit flagged on that PR's own review: the exporter's "does this database have any reporting signal at all" fail-safe guard (`scripts/export-grafana-reporting-db.sh`) still only listed `pull_requests`/`advisories`/`review_targets`/`ai_usage_events` — stale since #3535 made `review_audit` a genuine dependency of the still-open-PR verdict computation.
- Not a live bug: `pull_requests` already dominates the OR-condition on any real deployment, so the guard was never actually wrong in practice — just an inaccurate list for an operator reading it to understand what the script depends on. The only theoretical gap it left: a database with *only* `review_audit` present would have been misclassified as empty and skipped.
- Fix: add `review_audit` to both the Postgres and SQLite variants of the guard. No issue filed — this is small enough, self-evident from the PR description, and directly traceable to the reviewer comment it addresses (`this repo's linkedIssuePolicy is "preferred", not required`).
- Added a regression test proving the specific new branch: a source DB containing only `review_audit` is recognized as having real data (the exporter runs a fresh pass) rather than triggering the "preserve the last-good snapshot" fail-safe.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (clean — no TypeScript files changed)
- [x] `shellcheck scripts/export-grafana-reporting-db.sh` (clean)
- [x] `npx vitest run test/unit/selfhost-grafana-reporting.test.ts` — 14/14 passing (13 existing + 1 new)
- [ ] `npm run test:workers` / `npm run build:mcp` / `npm run test:mcp-pack` / `npm run ui:openapi:check` / `npm run ui:build` — not run individually; no worker/MCP/OpenAPI/UI surface touched.
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — new test covers the specific new OR-branch (a source DB with only `review_audit`), asserting a fresh pass runs instead of the last-good snapshot being wrongly preserved.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A; no auth/session/CORS surface touched.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no request/response contract change.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI change.
- [ ] Visible UI changes include a `UI Evidence` section below. — N/A, not an `apps/gittensory-ui` change.
- [ ] Public docs/changelogs are updated where needed. — N/A, internal reliability fix, no documented/user-facing behavior change.
