### PR TITLE
feat(enrichment): i18n hardcoded-string regression analyzer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,26 +68,28 @@ GITTENSORY_REVIEW_ENRICHMENT=false
 # commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot
 # blameLink,approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene
 # pendingReviewRequests,testRatio,migrationSafety,looseRange,terminology,todoMarker,magicNumber
-# conflictMarker,debugLeftover,sizeSmell,floatingPromise,deepNesting,errorSwallow,commitLint
+# conflictMarker,debugLeftover,sizeSmell,floatingPromise,deepNesting,errorSwallow,i18n
+# commitLint
 #
 # Profile defaults:
 # fast: dependency,dependencyDiff,lockfileDrift,secret,license,installScript,heavyDependency
 # hardcodedUrl,actionPin,eol,redos,provenance,secretLog,typosquat,iacMisconfig,nativeBuild
 # testRatio,migrationSafety,looseRange,terminology,todoMarker,magicNumber,conflictMarker
-# debugLeftover,sizeSmell,floatingPromise,deepNesting,errorSwallow
+# debugLeftover,sizeSmell,floatingPromise,deepNesting,errorSwallow,i18n
 # balanced (default): dependency,dependencyDiff,lockfileDrift,secret,license,installScript
 # heavyDependency,hardcodedUrl,actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight
 # typosquat,commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift,duplication
 # churnHotspot,blameLink,approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch
 # commitHygiene,pendingReviewRequests,testRatio,migrationSafety,looseRange,terminology
 # todoMarker,magicNumber,conflictMarker,debugLeftover,sizeSmell,floatingPromise,deepNesting
-# errorSwallow,commitLint
+# errorSwallow,i18n,commitLint
 # deep: dependency,dependencyDiff,lockfileDrift,secret,license,installScript,heavyDependency
 # hardcodedUrl,actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat
 # commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot
 # blameLink,approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene
 # pendingReviewRequests,testRatio,migrationSafety,looseRange,terminology,todoMarker,magicNumber
-# conflictMarker,debugLeftover,sizeSmell,floatingPromise,deepNesting,errorSwallow,commitLint
+# conflictMarker,debugLeftover,sizeSmell,floatingPromise,deepNesting,errorSwallow,i18n
+# commitLint
 # END GENERATED REES ANALYZERS
 
 # Submitter-reputation spend control (internal-only): downgrades new/burst/low-rep

--- a/apps/gittensory-ui/src/lib/rees-analyzers.ts
+++ b/apps/gittensory-ui/src/lib/rees-analyzers.ts
@@ -1050,6 +1050,29 @@ export const REES_ANALYZERS = [
     },
   },
   {
+    name: "i18n",
+    title: "i18n regressions",
+    category: "quality",
+    cost: "local",
+    defaultEnabled: true,
+    profiles: ["fast", "balanced", "deep"],
+    requires: ["files"],
+    limits: {
+      maxFindings: 25,
+      maxLineChars: 2000,
+    },
+    docs: {
+      summary:
+        "When the diff shows a translation convention, flags newly-added user-facing JSX text or label/title props that bypass it.",
+      looksAt:
+        "Added lines in changed non-test TSX/JSX/Vue UI files where the same patch also adds i18n calls.",
+      reports: "File and line only — never string content.",
+      network: "Pure local analyzer. No external network call.",
+      notes:
+        "Inactive when the file's added lines show no t()/useTranslation/FormattedMessage-style convention. Skips technical props and dotted i18n-key-shaped literals.",
+    },
+  },
+  {
     name: "commitLint",
     title: "Conventional-commit subjects",
     category: "quality",

--- a/review-enrichment/analyzer-metadata.json
+++ b/review-enrichment/analyzer-metadata.json
@@ -1188,6 +1188,32 @@
       }
     },
     {
+      "name": "i18n",
+      "title": "i18n regressions",
+      "category": "quality",
+      "cost": "local",
+      "defaultEnabled": true,
+      "profiles": [
+        "fast",
+        "balanced",
+        "deep"
+      ],
+      "requires": [
+        "files"
+      ],
+      "limits": {
+        "maxFindings": 25,
+        "maxLineChars": 2000
+      },
+      "docs": {
+        "summary": "When the diff shows a translation convention, flags newly-added user-facing JSX text or label/title props that bypass it.",
+        "looksAt": "Added lines in changed non-test TSX/JSX/Vue UI files where the same patch also adds i18n calls.",
+        "reports": "File and line only — never string content.",
+        "network": "Pure local analyzer. No external network call.",
+        "notes": "Inactive when the file's added lines show no t()/useTranslation/FormattedMessage-style convention. Skips technical props and dotted i18n-key-shaped literals."
+      }
+    },
+    {
       "name": "commitLint",
       "title": "Conventional-commit subjects",
       "category": "quality",

--- a/review-enrichment/src/analyzers/i18n-regression.ts
+++ b/review-enrichment/src/analyzers/i18n-regression.ts
@@ -1,0 +1,146 @@
+// i18n regression analyzer (#2029). When added lines in a UI file show a translation convention
+// (t('…'), useTranslation, FormattedMessage, etc.), flags newly-added user-facing string literals that
+// bypass it — JSX text nodes and common label/title props. Inactive when the diff shows no i18n usage.
+// Pure compute over added lines, no network. Never returns string content in findings.
+import type { EnrichRequest, I18nFinding } from "../types.js";
+import { isTestPath } from "./test-ratio.js";
+
+const MAX_FINDINGS = 25;
+const MAX_LINE_CHARS = 2000;
+
+const UI_PATH_RE = /\.(?:tsx|jsx|vue)$/i;
+
+const I18N_CONVENTION_RES = [
+  /\bt\s*\(\s*['"`]/,
+  /\buseTranslation\s*\(/,
+  /<FormattedMessage\b/,
+  /\bformatMessage\s*\(/,
+  /\bi18n\.t\s*\(/,
+  /\bi18next\.t\s*\(/,
+  /\$t\s*\(/,
+];
+
+const USER_FACING_PROP_RE =
+  /\b(?:title|label|placeholder|aria-label|helperText|message|description|heading|tooltip|hint|alt|caption|subtitle|confirmText|cancelText|buttonText|emptyText)\s*=\s*["']([^"']+)["']/gi;
+
+const JSX_TEXT_RE = />\s*([^<{][^<]*?[A-Za-z][^<]*?)\s*</g;
+
+/** True when a line shows the repo uses an i18n/translation call convention. Pure. */
+export function detectI18nConvention(line: string): boolean {
+  return I18N_CONVENTION_RES.some((re) => {
+    re.lastIndex = 0;
+    return re.test(line);
+  });
+}
+
+/** True when a string literal looks like user-facing copy rather than a key/id. Pure. */
+export function looksLikeUserFacingLiteral(value: string): boolean {
+  const trimmed = value.trim();
+  if (!trimmed || !/[A-Za-z]/.test(trimmed)) return false;
+  if (/\s/.test(trimmed)) return true;
+  if (/^[a-z0-9_.-]+$/.test(trimmed) && trimmed.includes(".")) return false;
+  if (trimmed.length <= 3 && /^[a-z]+$/.test(trimmed)) return false;
+  if (/[A-Z]/.test(trimmed)) return true;
+  return trimmed.length >= 8;
+}
+
+function isCommentOrImportLine(line: string): boolean {
+  const trimmed = line.trimStart();
+  return /^(?:\/\/|\/\*|\*|<!--|import\b|from\b)/.test(trimmed);
+}
+
+/** True when one added UI line adds a hardcoded user-facing string, or null. Pure. */
+export function detectHardcodedUiString(line: string): boolean {
+  if (isCommentOrImportLine(line)) return false;
+
+  USER_FACING_PROP_RE.lastIndex = 0;
+  let propMatch: RegExpExecArray | null;
+  while ((propMatch = USER_FACING_PROP_RE.exec(line))) {
+    if (looksLikeUserFacingLiteral(propMatch[1] ?? "")) return true;
+  }
+
+  JSX_TEXT_RE.lastIndex = 0;
+  let textMatch: RegExpExecArray | null;
+  while ((textMatch = JSX_TEXT_RE.exec(line))) {
+    const text = (textMatch[1] ?? "").trim();
+    if (looksLikeUserFacingLiteral(text)) return true;
+  }
+
+  return false;
+}
+
+function isUiPath(path: string): boolean {
+  return UI_PATH_RE.test(path) && !isTestPath(path);
+}
+
+function patchShowsI18nConvention(patch: string): boolean {
+  for (const line of patch.split("\n")) {
+    if (!line.startsWith("+")) continue;
+    const body = line.slice(1);
+    if (body.length > MAX_LINE_CHARS) continue;
+    if (detectI18nConvention(body)) return true;
+  }
+  return false;
+}
+
+type ScanLimits = {
+  maxFindings?: number;
+  signal?: AbortSignal;
+};
+
+/** Scan one file patch for i18n regressions, line-cited via hunk headers. Pure. */
+export function scanPatchForI18nRegression(
+  path: string,
+  patch: string,
+  limits: ScanLimits = {},
+): I18nFinding[] {
+  const maxFindings = limits.maxFindings ?? MAX_FINDINGS;
+  if (maxFindings <= 0 || !isUiPath(path) || !patchShowsI18nConvention(patch)) return [];
+
+  const findings: I18nFinding[] = [];
+  let newLine = 0;
+  let inHunk = false;
+
+  for (const line of patch.split("\n")) {
+    if (limits.signal?.aborted) throw new Error("analyzer_aborted");
+    const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
+    if (hunk) {
+      newLine = Number(hunk[1]);
+      inHunk = true;
+      continue;
+    }
+    if (!inHunk) continue;
+    if (line.startsWith("+")) {
+      const body = line.slice(1);
+      if (body.length <= MAX_LINE_CHARS && detectHardcodedUiString(body)) {
+        findings.push({ file: path, line: newLine });
+        if (findings.length >= maxFindings) return findings;
+      }
+      newLine++;
+    } else if (!line.startsWith("-") && !line.startsWith("\\")) {
+      newLine++;
+    }
+  }
+
+  return findings;
+}
+
+/** Analyzer entrypoint: scan UI files whose diff shows an i18n convention. */
+export async function scanI18nRegression(
+  req: EnrichRequest,
+  signal?: AbortSignal,
+): Promise<I18nFinding[]> {
+  const findings: I18nFinding[] = [];
+  for (const file of req.files ?? []) {
+    if (signal?.aborted) throw new Error("analyzer_aborted");
+    if (!file.patch) continue;
+    for (const finding of scanPatchForI18nRegression(file.path, file.patch, {
+      maxFindings: MAX_FINDINGS - findings.length,
+      signal,
+    })) {
+      findings.push(finding);
+      if (findings.length >= MAX_FINDINGS) return findings;
+    }
+  }
+  return findings;
+}

--- a/review-enrichment/src/analyzers/registry.ts
+++ b/review-enrichment/src/analyzers/registry.ts
@@ -33,6 +33,7 @@ import { scanMagicNumbers } from "./magic-number.js";
 import { scanConflictMarkers } from "./conflict-marker.js";
 import { scanDebugLeftover } from "./debug-leftover.js";
 import { scanDeepNesting } from "./deep-nesting.js";
+import { scanI18nRegression } from "./i18n-regression.js";
 import { scanErrorSwallow } from "./error-swallow.js";
 import { scanFloatingPromise } from "./floating-promise.js";
 import { scanSizeSmell } from "./size-smell.js";
@@ -1135,6 +1136,33 @@ export const ANALYZER_DESCRIPTORS = [
       return lines;
     },
     run: (req, { signal }) => scanErrorSwallow(req, signal),
+  }),
+  descriptor({
+    name: "i18n",
+    title: "i18n regressions",
+    category: "quality",
+    cost: "local",
+    defaultEnabled: true,
+    requires: ["files"],
+    limits: { maxFindings: 25, maxLineChars: 2000 },
+    docs: {
+      summary:
+        "When the diff shows a translation convention, flags newly-added user-facing JSX text or label/title props that bypass it.",
+      looksAt: "Added lines in changed non-test TSX/JSX/Vue UI files where the same patch also adds i18n calls.",
+      reports: "File and line only — never string content.",
+      network: "Pure local analyzer. No external network call.",
+      notes:
+        "Inactive when the file's added lines show no t()/useTranslation/FormattedMessage-style convention. Skips technical props and dotted i18n-key-shaped literals.",
+    },
+    render: (findings, helpers) => {
+      if (!findings.length) return [];
+      const lines = ["### i18n regressions (hardcoded UI copy where translation is in use)"];
+      for (const item of findings) {
+        lines.push(`- ${helpers.safeCodeSpan(`${item.file}:${item.line}`)}`);
+      }
+      return lines;
+    },
+    run: (req, { signal }) => scanI18nRegression(req, signal),
   }),
   descriptor({
     name: "commitLint",

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -486,6 +486,7 @@ export function renderBrief(
   lines.push(...renderDescriptorSection("floatingPromise", findings.floatingPromise));
   lines.push(...renderDescriptorSection("deepNesting", findings.deepNesting));
   lines.push(...renderDescriptorSection("errorSwallow", findings.errorSwallow));
+  lines.push(...renderDescriptorSection("i18n", findings.i18n));
   lines.push(...renderDescriptorSection("hardcodedUrl", findings.hardcodedUrl));
   lines.push(...renderDescriptorSection("commitLint", findings.commitLint));
 

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -494,6 +494,13 @@ export interface SizeSmellFinding {
   name?: string;
 }
 
+/** A user-facing string literal added without the repo's i18n convention (#2029, part of #1499).
+ *  Reports file and line only — never string content. */
+export interface I18nFinding {
+  file: string;
+  line: number;
+}
+
 /** A swallowed-error catch/except block newly added in the diff (#2014, part of #1499).
  *  Reports file, line, and kind only — never catch body content. */
 export interface ErrorSwallowFinding {
@@ -579,6 +586,7 @@ export interface BriefFindings {
   floatingPromise?: FloatingPromiseFinding[];
   deepNesting?: DeepNestingFinding[];
   errorSwallow?: ErrorSwallowFinding[];
+  i18n?: I18nFinding[];
   hardcodedUrl?: HardcodedUrlFinding[];
   commitLint?: CommitLintFinding[];
 }

--- a/review-enrichment/test/analyzer-registry.test.ts
+++ b/review-enrichment/test/analyzer-registry.test.ts
@@ -52,6 +52,7 @@ const EXPECTED_ANALYZERS = [
   "floatingPromise",
   "deepNesting",
   "errorSwallow",
+  "i18n",
   "commitLint",
 ];
 

--- a/review-enrichment/test/i18n-regression.test.ts
+++ b/review-enrichment/test/i18n-regression.test.ts
@@ -1,0 +1,86 @@
+// Units for the i18n regression analyzer (#2029). Own file so concurrent analyzer PRs don't collide.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  detectHardcodedUiString,
+  detectI18nConvention,
+  looksLikeUserFacingLiteral,
+  scanI18nRegression,
+  scanPatchForI18nRegression,
+} from "../dist/analyzers/i18n-regression.js";
+import { renderBrief } from "../dist/render.js";
+
+const patchOf = (lines: string[]) =>
+  `@@ -1,0 +1,${lines.length} @@\n${lines.map((l) => `+${l}`).join("\n")}`;
+
+test("detectI18nConvention: recognizes common translation call patterns", () => {
+  assert.equal(detectI18nConvention("const label = t('common.save');"), true);
+  assert.equal(detectI18nConvention("const { t } = useTranslation();"), true);
+  assert.equal(detectI18nConvention("<FormattedMessage id='save' />"), true);
+  assert.equal(detectI18nConvention("<button>Save</button>"), false);
+});
+
+test("looksLikeUserFacingLiteral: distinguishes copy from keys and ids", () => {
+  assert.equal(looksLikeUserFacingLiteral("Save changes"), true);
+  assert.equal(looksLikeUserFacingLiteral("common.save"), false);
+  assert.equal(looksLikeUserFacingLiteral("btn"), false);
+  assert.equal(looksLikeUserFacingLiteral("Save"), true);
+});
+
+test("detectHardcodedUiString: flags JSX text and user-facing props", () => {
+  assert.equal(detectHardcodedUiString("<button>Save changes</button>"), true);
+  assert.equal(detectHardcodedUiString('<input placeholder="Enter your email" />'), true);
+  assert.equal(detectHardcodedUiString("<button>{t('save')}</button>"), false);
+  assert.equal(detectHardcodedUiString('<input className="w-full" />'), false);
+});
+
+test("scanPatchForI18nRegression: flags hardcoded UI strings when i18n is in use", () => {
+  const findings = scanPatchForI18nRegression(
+    "src/Widget.tsx",
+    patchOf([
+      "export function Widget() {",
+      "  const { t } = useTranslation();",
+      "  return <button>{t('save')}</button>;",
+      "}",
+      "export function Banner() {",
+      "  return <p>Welcome back</p>;",
+      "}",
+    ]),
+  );
+  assert.deepEqual(findings, [{ file: "src/Widget.tsx", line: 6 }]);
+});
+
+test("scanPatchForI18nRegression: inactive when the diff shows no i18n convention", () => {
+  assert.deepEqual(
+    scanPatchForI18nRegression("src/Widget.tsx", patchOf(["export function Widget() {", "  return <p>Hello</p>;", "}"])),
+    [],
+  );
+});
+
+test("scanPatchForI18nRegression: skips test files and respects the cap", () => {
+  assert.deepEqual(
+    scanPatchForI18nRegression("src/Widget.test.tsx", patchOf(["const { t } = useTranslation();", "<p>Hi</p>"])),
+    [],
+  );
+  const lines = [
+    "const { t } = useTranslation();",
+    ...Array.from({ length: 30 }, (_, i) => `<p>Message ${i}</p>`),
+  ];
+  assert.equal(scanPatchForI18nRegression("src/a.tsx", patchOf(lines), { maxFindings: 3 }).length, 3);
+});
+
+test("scanI18nRegression: aggregates across files and renders a public-safe brief", async () => {
+  const findings = await scanI18nRegression({
+    files: [
+      {
+        path: "src/a.tsx",
+        patch: patchOf(["const { t } = useTranslation();", "<span title=\"Save draft\">x</span>"]),
+      },
+    ],
+  });
+  assert.deepEqual(findings, [{ file: "src/a.tsx", line: 2 }]);
+  const { promptSection } = renderBrief({ i18n: findings });
+  assert.match(promptSection, /i18n regressions/);
+  assert.match(promptSection, /src\/a\.tsx:2/);
+  assert.doesNotMatch(promptSection, /Save draft/);
+});

--- a/src/review/enrichment-analyzer-names.ts
+++ b/src/review/enrichment-analyzer-names.ts
@@ -46,6 +46,7 @@ export const REES_ANALYZER_NAMES = [
   "floatingPromise",
   "deepNesting",
   "errorSwallow",
+  "i18n",
   "commitLint",
 ] as const;
 


### PR DESCRIPTION
## Summary
Fixes #2029

- Add `I18nFinding` and a local `i18n` analyzer that activates only when added lines in a UI file show a translation convention (`t()`, `useTranslation`, `FormattedMessage`, `i18n.t`, `$t`, etc.)
- Flags newly-added user-facing JSX text nodes and common label/title/placeholder props that bypass i18n; skips technical props, dotted key-shaped literals, and files with no i18n usage in the diff
- Pure compute over added TSX/JSX/Vue lines; reports file:line only (never string content); capped at 25 findings
- Register the analyzer in the REES registry with render/docs/metadata; sync `src/review/enrichment-analyzer-names.ts` and generated `.env.example` / UI metadata
- Add `review-enrichment/test/i18n-regression.test.ts` covering convention detection, hardcoded flag/inactive paths, cap, and public-safe brief rendering

## Test plan
- [x] `cd review-enrichment && npm run build && npm run metadata && node --test test/i18n-regression.test.ts test/analyzer-registry.test.ts`
- [ ] CI `validate-code`

Made with [Cursor](https://cursor.com)