### PR TITLE
fix(signals): classify grpc-node JS/TS protobuf stubs as generated

### DIFF
--- a/src/signals/path-matchers.ts
+++ b/src/signals/path-matchers.ts
@@ -74,6 +74,9 @@ function isGeneratedFileFrom(parts: NormalizedPath): boolean {
     /_pb\.nim$/.test(norm) ||
     // Lua protobuf: message stubs are `*_pb.lua`.
     /_pb\.lua$/.test(norm) ||
+    // JavaScript/TypeScript grpc-node protobuf: message stubs are `*_pb.{js,ts}`; gRPC emits
+    // sibling `*_grpc_pb.{js,ts}` service stubs (underscore form, not `.pb.js`).
+    /_pb\.(js|ts)$/.test(norm) ||
     // Dart codegen: build_runner (`.g.dart`), freezed (`.freezed.dart`), and
     // retrofit/injectable (`.gr.dart`) all emit generated part files.
     /\.(g|freezed|gr)\.dart$/.test(norm) ||

--- a/test/unit/path-matchers.test.ts
+++ b/test/unit/path-matchers.test.ts
@@ -144,6 +144,17 @@ describe("isGeneratedFile", () => {
     expect(classifyChangedFile("gen/GreeterGrpcKt.kt")).toBe("generated");
   });
 
+  it("matches JavaScript and TypeScript grpc-node protobuf stubs alongside the other protoc plugins", () => {
+    expect(isGeneratedFile("gen/service_pb.js")).toBe(true);
+    expect(isGeneratedFile("gen/service_grpc_pb.js")).toBe(true);
+    expect(isGeneratedFile("gen/service_pb.ts")).toBe(true);
+    expect(isGeneratedFile("gen/service_grpc_pb.ts")).toBe(true);
+    expect(isGeneratedFile("src/app.js")).toBe(false);
+    expect(isGeneratedFile("src/app.ts")).toBe(false);
+    expect(classifyChangedFile("gen/service_grpc_pb.js")).toBe("generated");
+    expect(classifyChangedFile("gen/service_pb.ts")).toBe("generated");
+  });
+
   it("matches Swift protobuf, Dart freezed/retrofit, C# designer/XAML, and Objective-C protoc output", () => {
     for (const path of [
       "proto/messages.pb.swift",
@@ -474,6 +485,8 @@ describe("classifyChangedFile", () => {
       ["gen/service_pb.nim", "generated"],
       ["gen/service_pb.lua", "generated"],
       ["gen/GreeterGrpcKt.kt", "generated"],
+      ["gen/service_grpc_pb.js", "generated"],
+      ["gen/service_pb.ts", "generated"],
       ["vendor/lib.go", "vendored"],
       ["package-lock.json", "lockfile"],
       ["bun.lock", "lockfile"],


### PR DESCRIPTION
## Summary

Extend `isGeneratedFile` to recognize grpc-node message/service stubs (`*_pb.js`, `*_pb.ts`, `*_grpc_pb.js`, `*_grpc_pb.ts`), matching the existing `.pb.js` / `.pb.ts` dot-form protoc coverage. Includes direct `isGeneratedFile` / `classifyChangedFile` assertions and hand-authored `.js`/`.ts` negative cases.

Fixes #561

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- None skipped.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — signals-only change with no visible UI.

## Notes

Incremental **maintenance** parity for the path-matcher slop signals from #561. Supports generated-file classification work tracked in #2279.

Made with [Cursor](https://cursor.com)