### PR TITLE
fix(labels): bound custom type label cleanup

### DIFF
--- a/src/settings/pr-type-label.ts
+++ b/src/settings/pr-type-label.ts
@@ -6,7 +6,7 @@
 //              changed files, AI output, or existing PR labels.
 //   feature  — genuine NEW functionality only (conventional-commit `feat`/`feature`).
 //   bug      — EVERYTHING ELSE: fix, test, docs, chore, refactor, perf, ci, build, style, revert.
-// A self-hoster can register any number of ADDITIONAL categories in `typeLabels` beyond these three (e.g.
+// A self-hoster can register a bounded number of ADDITIONAL categories in `typeLabels` beyond these three (e.g.
 // `security: "area:security"`) — an extra category is never chosen by title-classification (only bug/
 // feature are), only ever by a configured `linkedIssueLabelPropagation` mapping's `prLabel` (which can
 // target ANY string, registered in `typeLabels` or not); registering it here just makes it participate
@@ -33,6 +33,9 @@ export const DEFAULT_TYPE_LABELS: PrTypeLabelSet = {
  *  property access here, a configured set can carry more or fewer categories than the default. */
 export const ALL_TYPE_LABELS: readonly string[] = Object.values(DEFAULT_TYPE_LABELS);
 
+export const MAX_TYPE_LABEL_CATEGORIES = 32;
+export const MAX_TYPE_LABEL_NAME_LENGTH = 50;
+
 const FEATURE_TITLE_ACTION_RE = /\b(add|adds|added|create|creates|created|enable|enables|enabled|implement|implements|implemented|integrate|integrates|integrated|introduce|introduces|introduced|launch|launches|launched|support|supports|supported|wire|wires|wired)\b/i;
 const FEATURE_TITLE_DOWNGRADE_RE = /\b(avoid|block|bug|bugfix|cache|classify|classifies|classifying|cleanup|clean-up|clean up|detect|detects|detecting|docs?|fix|format|guard|lint|normalize|recognize|recognizes|recognizing|refactor|regression|rename|test|tests|testing|tighten|typo)\b/i;
 
@@ -55,7 +58,8 @@ export function deriveKindFromTitle(title: string | undefined): "bug" | "feature
  *  back to the corresponding built-in default — so a repo can override just one built-in label name
  *  (e.g. only `priority`) and keep the others default. Any EXTRA key present in `input` beyond the
  *  built-in set (a self-hoster's own custom category, e.g. `security`) is included verbatim when
- *  valid; there is no built-in default for it to fall back to, so an invalid extra-category value is
+ *  valid, up to `MAX_TYPE_LABEL_CATEGORIES` total categories and GitHub's 50-character label-name
+ *  limit; there is no built-in default for it to fall back to, so an invalid extra-category value is
  *  dropped entirely (warned, not defaulted) rather than silently defaulted. A non-object input yields
  *  the full default set; omitted is normal (no warning), present-but-wrong-shaped warns. An input that
  *  IS a valid object but has zero own keys (`{}`) also yields the full default set here — this
@@ -78,16 +82,22 @@ export function normalizeTypeLabelSet(input: unknown, warnings: string[]): PrTyp
   const result: PrTypeLabelSet = {};
   for (const key of keys) {
     const value = record[key];
+    const wouldAddCategory = result[key] === undefined;
+    if (wouldAddCategory && Object.keys(result).length >= MAX_TYPE_LABEL_CATEGORIES) {
+      if (value !== undefined) warnings.push(`settings.typeLabels has more than ${MAX_TYPE_LABEL_CATEGORIES} categories; ignoring ${key}.`);
+      continue;
+    }
     const builtInDefault: string | undefined = DEFAULT_TYPE_LABELS[key];
-    if (typeof value === "string" && value.trim().length > 0) {
+    if (typeof value === "string" && value.trim().length > 0 && value.trim().length <= MAX_TYPE_LABEL_NAME_LENGTH) {
       result[key] = value.trim();
       continue;
     }
     if (value !== undefined) {
+      const reason = typeof value === "string" && value.trim().length > MAX_TYPE_LABEL_NAME_LENGTH ? `a non-empty string no longer than ${MAX_TYPE_LABEL_NAME_LENGTH} characters` : "a non-empty string";
       warnings.push(
         builtInDefault !== undefined
-          ? `settings.typeLabels.${key} must be a non-empty string; using the default "${builtInDefault}".`
-          : `settings.typeLabels.${key} must be a non-empty string; ignoring it.`,
+          ? `settings.typeLabels.${key} must be ${reason}; using the default "${builtInDefault}".`
+          : `settings.typeLabels.${key} must be ${reason}; ignoring it.`,
       );
     }
     // Reached for BOTH an invalid present value and an absent one -- a built-in category (bug/feature/
@@ -137,7 +147,7 @@ export function resolvePrTypeLabel(input: {
 }): PrTypeLabelDecision {
   const labels = input.labels ?? DEFAULT_TYPE_LABELS;
   const isRealLabel = (label: string | undefined): label is string => typeof label === "string" && label.length > 0;
-  const typeLabelSet = Object.values(labels).filter(isRealLabel);
+  const typeLabelSet = Object.values(labels).filter(isRealLabel).filter((label) => label.length <= MAX_TYPE_LABEL_NAME_LENGTH).slice(0, MAX_TYPE_LABEL_CATEGORIES);
   const titleLabel: string | undefined = labels[deriveKindFromTitle(input.title)];
   const decide = (applyLabels: ReadonlyArray<string | undefined>, source: PrTypeLabelDecision["source"]): PrTypeLabelDecision => {
     const apply = [...new Set(applyLabels.filter(isRealLabel))];

--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -4,7 +4,7 @@ import { normalizeAutonomyPolicy, normalizeAutoMaintainPolicy } from "../setting
 import { normalizeCommandAuthorizationPolicy } from "../settings/command-authorization";
 import { mergeContributorBlacklists, normalizeContributorBlacklist } from "../settings/contributor-blacklist";
 import { normalizeAutoCloseExemptLogins } from "../settings/auto-close-exempt";
-import { DEFAULT_TYPE_LABELS, normalizeTypeLabelSet } from "../settings/pr-type-label";
+import { DEFAULT_TYPE_LABELS, MAX_TYPE_LABEL_NAME_LENGTH, normalizeTypeLabelSet } from "../settings/pr-type-label";
 import { DEFAULT_LINKED_ISSUE_LABEL_PROPAGATION, normalizeLinkedIssueLabelPropagationConfig, VALID_LINKED_ISSUE_LABEL_PROPAGATION_MODES } from "../review/linked-issue-label-propagation";
 import { DEFAULT_LINKED_ISSUE_HARD_RULES, isLinkedIssueHardRuleMode, normalizeLinkedIssueHardRulesConfig } from "../review/linked-issue-hard-rules-config";
 import { normalizeModerationLabel, normalizeModerationRules } from "../settings/moderation-rules";
@@ -1154,7 +1154,8 @@ function parseSettingsOverride(value: JsonValue | undefined, warnings: string[])
   // that fallback into the sparse override would silently overwrite a DB-customized value with the
   // built-in default on a config typo, instead of leaving the DB value alone. The loop is generic over
   // whatever keys the raw object actually has (not hardcoded to bug/feature/priority), so an arbitrary
-  // custom category (e.g. `security`) sparse-overrides exactly like a built-in one.
+  // custom category (e.g. `security`) sparse-overrides exactly like a built-in one. The normalizer
+  // enforces the category-count and label-name caps before a sparse key can survive into the override.
   if (typeof r.typeLabels === "object" && r.typeLabels !== null && !Array.isArray(r.typeLabels)) {
     const rawTypeLabels = r.typeLabels as Record<string, unknown>;
     if (Object.keys(rawTypeLabels).length === 0) {
@@ -1166,10 +1167,10 @@ function parseSettingsOverride(value: JsonValue | undefined, warnings: string[])
       out.typeLabels = null;
     } else {
       const validated = normalizeTypeLabelSet(rawTypeLabels, warnings);
-      const isValidLabelName = (value: unknown): boolean => typeof value === "string" && value.trim().length > 0;
+      const isValidLabelName = (value: unknown): boolean => typeof value === "string" && value.trim().length > 0 && value.trim().length <= MAX_TYPE_LABEL_NAME_LENGTH;
       const sparseTypeLabels: Partial<PrTypeLabelSet> = {};
       for (const key of Object.keys(rawTypeLabels)) {
-        if (isValidLabelName(rawTypeLabels[key])) sparseTypeLabels[key] = validated[key];
+        if (isValidLabelName(rawTypeLabels[key]) && validated[key] !== undefined) sparseTypeLabels[key] = validated[key];
       }
       out.typeLabels = sparseTypeLabels;
     }

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -23,6 +23,7 @@ import {
   type FocusManifest,
 } from "../../src/signals/focus-manifest";
 import { DEFAULT_COMMAND_AUTHORIZATION_POLICY } from "../../src/settings/command-authorization";
+import { MAX_TYPE_LABEL_CATEGORIES, MAX_TYPE_LABEL_NAME_LENGTH } from "../../src/settings/pr-type-label";
 import type { RepositorySettings } from "../../src/types";
 
 const FULL_MANIFEST = {
@@ -2060,6 +2061,27 @@ describe("parseFocusManifest settings override + resolveEffectiveSettings", () =
       const db = { typeLabels: { bug: "kind:bug", feature: "kind:feature", priority: "kind:priority" } } as unknown as RepositorySettings;
       const eff = resolveEffectiveSettings(db, parseFocusManifest({ settings: { typeLabels: { security: "area:security" } } }));
       expect(eff.typeLabels).toEqual({ bug: "kind:bug", feature: "kind:feature", priority: "kind:priority", security: "area:security" });
+    });
+
+    it("caps a sparse manifest override before it reaches effective settings", () => {
+      const rawTypeLabels = Object.fromEntries(Array.from({ length: MAX_TYPE_LABEL_CATEGORIES + 5 }, (_, index) => [`custom${index}`, `area:${index}`]));
+
+      const parsed = parseFocusManifest({ settings: { typeLabels: rawTypeLabels } });
+      const eff = resolveEffectiveSettings({ typeLabels: {} } as unknown as RepositorySettings, parsed);
+
+      expect(Object.keys(parsed.settings.typeLabels ?? {})).toHaveLength(MAX_TYPE_LABEL_CATEGORIES - 3);
+      expect(eff.typeLabels).toEqual(Object.fromEntries(Array.from({ length: MAX_TYPE_LABEL_CATEGORIES - 3 }, (_, index) => [`custom${index}`, `area:${index}`])));
+      expect(parsed.warnings.some((w) => w.includes("more than 32 categories") && w.includes("custom29"))).toBe(true);
+    });
+
+    it("drops overlong labels from a sparse manifest override before merging with DB settings", () => {
+      const parsed = parseFocusManifest({ settings: { typeLabels: { security: "x".repeat(MAX_TYPE_LABEL_NAME_LENGTH + 1) } } });
+      const db = { typeLabels: { bug: "kind:bug" } } as unknown as RepositorySettings;
+      const eff = resolveEffectiveSettings(db, parsed);
+
+      expect(parsed.settings.typeLabels).toEqual({});
+      expect(eff.typeLabels).toEqual(db.typeLabels);
+      expect(parsed.warnings.some((w) => w.includes("settings.typeLabels.security") && w.includes("no longer than 50"))).toBe(true);
     });
 
     it("does not unexpectedly reset unrelated categories when a sparse override only adds a new one (invariant: sparse overrides layer correctly)", () => {

--- a/test/unit/pr-type-label.test.ts
+++ b/test/unit/pr-type-label.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { DEFAULT_TYPE_LABELS, deriveKindFromTitle, normalizeTypeLabelSet, resolvePrTypeLabel } from "../../src/settings/pr-type-label";
+import { DEFAULT_TYPE_LABELS, MAX_TYPE_LABEL_CATEGORIES, MAX_TYPE_LABEL_NAME_LENGTH, deriveKindFromTitle, normalizeTypeLabelSet, resolvePrTypeLabel } from "../../src/settings/pr-type-label";
 import type { LinkedIssueLabelPropagationConfig } from "../../src/types";
 
 describe("deriveKindFromTitle", () => {
@@ -159,6 +159,24 @@ describe("resolvePrTypeLabel (#priority-linked-issue-gate)", () => {
       expect(result).toEqual({ applyLabels: ["area:security"], removeLabels: [], source: "propagation_additive" });
     });
 
+    it("caps cleanup to the bounded type-label category set", () => {
+      const labels = Object.fromEntries(Array.from({ length: MAX_TYPE_LABEL_CATEGORIES + 20 }, (_, index) => [`custom${index}`, `area:${index}`]));
+
+      const result = resolvePrTypeLabel({ title: "fix: y", labels });
+
+      expect(result.applyLabels).toEqual([]);
+      expect(result.removeLabels).toHaveLength(MAX_TYPE_LABEL_CATEGORIES);
+      expect(result.removeLabels).toEqual(Array.from({ length: MAX_TYPE_LABEL_CATEGORIES }, (_, index) => `area:${index}`));
+    });
+
+    it("ignores overlong labels when computing cleanup", () => {
+      const overlong = "x".repeat(MAX_TYPE_LABEL_NAME_LENGTH + 1);
+
+      const result = resolvePrTypeLabel({ title: "fix: y", labels: { bug: "kind:bug", feature: overlong, priority: "kind:priority" } });
+
+      expect(result).toEqual({ applyLabels: ["kind:bug"], removeLabels: ["kind:priority"], source: "title" });
+    });
+
     it("only cleans up categories actually configured when a repo drops down to a subset of the built-in triad", () => {
       // A self-hoster who only wants a bug/feature split, no priority category at all.
       const result = resolvePrTypeLabel({ title: "feat: add provider fallback", labels: { bug: "gittensor:bug", feature: "gittensor:feature" } });
@@ -238,6 +256,31 @@ describe("normalizeTypeLabelSet (#priority-linked-issue-gate)", () => {
         security: "area:security",
         docs: "area:docs",
       });
+    });
+
+    it("caps custom categories to a bounded set and warns for overflow entries", () => {
+      const warnings: string[] = [];
+      const input = Object.fromEntries(Array.from({ length: MAX_TYPE_LABEL_CATEGORIES + 5 }, (_, index) => [`custom${index}`, `area:${index}`]));
+
+      const result = normalizeTypeLabelSet(input, warnings);
+
+      expect(Object.keys(result)).toHaveLength(MAX_TYPE_LABEL_CATEGORIES);
+      expect(result.custom28).toBe("area:28");
+      expect(result.custom29).toBeUndefined();
+      expect(warnings.some((w) => w.includes("more than 32 categories") && w.includes("custom29"))).toBe(true);
+    });
+
+    it("rejects overlong label names and warns", () => {
+      const warnings: string[] = [];
+      const overlong = "x".repeat(MAX_TYPE_LABEL_NAME_LENGTH + 1);
+
+      expect(normalizeTypeLabelSet({ security: overlong, bug: overlong }, warnings)).toEqual({
+        bug: DEFAULT_TYPE_LABELS.bug,
+        feature: DEFAULT_TYPE_LABELS.feature,
+        priority: DEFAULT_TYPE_LABELS.priority,
+      });
+      expect(warnings.some((w) => w.includes("settings.typeLabels.security") && w.includes("no longer than 50"))).toBe(true);
+      expect(warnings.some((w) => w.includes("settings.typeLabels.bug") && w.includes("no longer than 50") && w.includes(DEFAULT_TYPE_LABELS.bug!))).toBe(true);
     });
 
     it("drops an invalid custom category entirely (no built-in default to fall back to) and warns", () => {

--- a/test/unit/pr-type-label.test.ts
+++ b/test/unit/pr-type-label.test.ts
@@ -270,6 +270,21 @@ describe("normalizeTypeLabelSet (#priority-linked-issue-gate)", () => {
       expect(warnings.some((w) => w.includes("more than 32 categories") && w.includes("custom29"))).toBe(true);
     });
 
+    it("silently drops an overflow entry whose value is undefined, without warning", () => {
+      const warnings: string[] = [];
+      // 3 built-ins + 29 valid customs exactly fill the 32-category cap; a further key present with an
+      // explicit `undefined` value hits the overflow branch but must not warn, mirroring how an absent
+      // built-in value is dropped silently elsewhere in this function.
+      const input: Record<string, unknown> = Object.fromEntries(Array.from({ length: MAX_TYPE_LABEL_CATEGORIES - 3 }, (_, index) => [`custom${index}`, `area:${index}`]));
+      input.overflowUndefined = undefined;
+
+      const result = normalizeTypeLabelSet(input, warnings);
+
+      expect(Object.keys(result)).toHaveLength(MAX_TYPE_LABEL_CATEGORIES);
+      expect(result.overflowUndefined).toBeUndefined();
+      expect(warnings.some((w) => w.includes("overflowUndefined"))).toBe(false);
+    });
+
     it("rejects overlong label names and warns", () => {
       const warnings: string[] = [];
       const overlong = "x".repeat(MAX_TYPE_LABEL_NAME_LENGTH + 1);


### PR DESCRIPTION
### Motivation
- Prevent unbounded attacker-controlled amplification of outbound GitHub label-removal calls by capping the number and length of per-repo `typeLabels` so a malicious or compromised repo cannot cause hundreds/thousands of DELETE requests per PR webhook.

### Description
- Add `MAX_TYPE_LABEL_CATEGORIES = 32` and `MAX_TYPE_LABEL_NAME_LENGTH = 50` and document the bounds in `src/settings/pr-type-label.ts`.
- Enforce the caps in `normalizeTypeLabelSet` so oversized/overlong manifest entries are warned and ignored instead of being propagated into repository settings.
- Apply the same bounds when computing `removeLabels` in `resolvePrTypeLabel` to cap the cleanup list before webhook processing can perform per-label GitHub operations.
- Limit sparse manifest overrides in `src/signals/focus-manifest.ts` so only validated, in-range entries survive into the per-repo override, and update tests to cover overflow/overlong cases.

### Testing
- Ran targeted unit tests with `npx vitest run test/unit/pr-type-label.test.ts test/unit/focus-manifest.test.ts`, and the tests passed.
- Ran static type checks with `npm run typecheck`, which succeeded.
- Attempted the full coverage run with `npm run test:coverage`, but the environment hit long-running queue/backfill test time limits so the full suite did not complete here; the targeted unit regressions passed locally in the run above.
- `npm audit --audit-level=moderate` could not complete in this environment due to an npm registry `403 Forbidden` response.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a13c7c82c832c8920d96f02402eb8)