### PR TITLE
feat(enrichment): accessibility regression detector analyzer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,27 +68,27 @@ GITTENSORY_REVIEW_ENRICHMENT=false
 # commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot
 # blameLink,approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene
 # pendingReviewRequests,testRatio,migrationSafety,looseRange,terminology,todoMarker,magicNumber
-# conflictMarker,debugLeftover,sizeSmell,floatingPromise,deepNesting,errorSwallow,i18n
+# conflictMarker,debugLeftover,sizeSmell,floatingPromise,deepNesting,errorSwallow,i18n,a11y
 # commitLint
 #
 # Profile defaults:
 # fast: dependency,dependencyDiff,lockfileDrift,secret,license,installScript,heavyDependency
 # hardcodedUrl,actionPin,eol,redos,provenance,secretLog,typosquat,iacMisconfig,nativeBuild
 # testRatio,migrationSafety,looseRange,terminology,todoMarker,magicNumber,conflictMarker
-# debugLeftover,sizeSmell,floatingPromise,deepNesting,errorSwallow,i18n
+# debugLeftover,sizeSmell,floatingPromise,deepNesting,errorSwallow,i18n,a11y
 # balanced (default): dependency,dependencyDiff,lockfileDrift,secret,license,installScript
 # heavyDependency,hardcodedUrl,actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight
 # typosquat,commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift,duplication
 # churnHotspot,blameLink,approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch
 # commitHygiene,pendingReviewRequests,testRatio,migrationSafety,looseRange,terminology
 # todoMarker,magicNumber,conflictMarker,debugLeftover,sizeSmell,floatingPromise,deepNesting
-# errorSwallow,i18n,commitLint
+# errorSwallow,i18n,a11y,commitLint
 # deep: dependency,dependencyDiff,lockfileDrift,secret,license,installScript,heavyDependency
 # hardcodedUrl,actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat
 # commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot
 # blameLink,approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene
 # pendingReviewRequests,testRatio,migrationSafety,looseRange,terminology,todoMarker,magicNumber
-# conflictMarker,debugLeftover,sizeSmell,floatingPromise,deepNesting,errorSwallow,i18n
+# conflictMarker,debugLeftover,sizeSmell,floatingPromise,deepNesting,errorSwallow,i18n,a11y
 # commitLint
 # END GENERATED REES ANALYZERS
 

--- a/apps/gittensory-ui/src/lib/rees-analyzers.ts
+++ b/apps/gittensory-ui/src/lib/rees-analyzers.ts
@@ -1073,6 +1073,29 @@ export const REES_ANALYZERS = [
     },
   },
   {
+    name: "a11y",
+    title: "Accessibility regressions",
+    category: "quality",
+    cost: "local",
+    defaultEnabled: true,
+    profiles: ["fast", "balanced", "deep"],
+    requires: ["files"],
+    limits: {
+      maxFindings: 25,
+      maxLineChars: 2000,
+    },
+    docs: {
+      summary:
+        "Flags common accessibility regressions in newly-added JSX/HTML markup: missing img alt, clickable non-interactive elements, unlabeled controls, positive tabindex.",
+      looksAt:
+        "Self-contained opening tags on added lines in changed non-test JSX/TSX/HTML/Vue files.",
+      reports: "File, line, and rule id — never markup content.",
+      network: "Pure local analyzer. No external network call.",
+      notes:
+        "Only tags fully contained on one added line are scanned. onKeyPress alone does not satisfy the keyboard-handler check.",
+    },
+  },
+  {
     name: "commitLint",
     title: "Conventional-commit subjects",
     category: "quality",

--- a/review-enrichment/analyzer-metadata.json
+++ b/review-enrichment/analyzer-metadata.json
@@ -1214,6 +1214,32 @@
       }
     },
     {
+      "name": "a11y",
+      "title": "Accessibility regressions",
+      "category": "quality",
+      "cost": "local",
+      "defaultEnabled": true,
+      "profiles": [
+        "fast",
+        "balanced",
+        "deep"
+      ],
+      "requires": [
+        "files"
+      ],
+      "limits": {
+        "maxFindings": 25,
+        "maxLineChars": 2000
+      },
+      "docs": {
+        "summary": "Flags common accessibility regressions in newly-added JSX/HTML markup: missing img alt, clickable non-interactive elements, unlabeled controls, positive tabindex.",
+        "looksAt": "Self-contained opening tags on added lines in changed non-test JSX/TSX/HTML/Vue files.",
+        "reports": "File, line, and rule id — never markup content.",
+        "network": "Pure local analyzer. No external network call.",
+        "notes": "Only tags fully contained on one added line are scanned. onKeyPress alone does not satisfy the keyboard-handler check."
+      }
+    },
+    {
       "name": "commitLint",
       "title": "Conventional-commit subjects",
       "category": "quality",

--- a/review-enrichment/src/analyzers/a11y-regression.ts
+++ b/review-enrichment/src/analyzers/a11y-regression.ts
@@ -1,0 +1,160 @@
+// Accessibility-regression analyzer (#2026, the a11y half of the #1499 epic 'accessibility and i18n regression'
+// idea; the i18n half is a separate bounty). Flags common accessibility regressions in added JSX/HTML markup:
+// an <img> without alt, an onClick handler added to a non-interactive element without a keyboard handler or
+// role, a form control with no way to associate a label, and a positive tabindex (which breaks natural tab
+// order). Pure compute over added diff lines, no network. Only self-contained tags (opening `<` through closing
+// `>` on the same added line) are matched, so a tag whose attributes wrap across lines is not scanned — this
+// keeps the analyzer diff-local and free of false positives from partial tags.
+import type { A11yFinding, EnrichRequest } from "../types.js";
+import { isTestPath } from "./test-ratio.js";
+
+export const MAX_FINDINGS = 25;
+export const MAX_LINE_CHARS = 2000;
+
+const MARKUP_PATH_RE = /\.(?:jsx|tsx|html?|vue)$/i;
+
+const INTERACTIVE_TAGS = new Set([
+  "a",
+  "button",
+  "input",
+  "select",
+  "option",
+  "textarea",
+  "summary",
+  "label",
+  "audio",
+  "video",
+  "details",
+  "dialog",
+  "menuitem",
+]);
+
+const LABELLESS_INPUT_TYPES = new Set(["hidden", "submit", "button", "reset", "image"]);
+
+const TAG_RE = /<([a-zA-Z][\w-]*)\b([^>]*)>/g;
+const ALT_RE = /\balt\s*=/i;
+const ONCLICK_RE = /\bonclick\s*=/i;
+// `onKeyPress` is deliberately NOT accepted — it is deprecated; only onKeyDown/onKeyUp/role satisfy the check.
+const KEY_HANDLER_OR_ROLE_RE = /\bonkeydown\s*=|\bonkeyup\s*=|\brole\s*=/i;
+const TYPE_ATTR_RE = /\btype\s*=\s*["']?(\w+)/i;
+const LABEL_ASSOC_RE = /\bid\s*=|\baria-label\s*=|\baria-labelledby\s*=/i;
+const TABINDEX_RE = /\btabindex\s*=\s*["'{]?\s*(-?\d+)/i;
+
+function isCommentLine(line: string): boolean {
+  const trimmed = line.trimStart();
+  return /^(?:\/\/|\/\*|\*|<!--|\{\/\*)/.test(trimmed);
+}
+
+function isMarkupPath(path: string): boolean {
+  return MARKUP_PATH_RE.test(path) && !isTestPath(path);
+}
+
+/** Classify one self-contained `<tag ...>` opening tag for a11y regressions. Pure. */
+export function detectA11yIssues(
+  tagName: string,
+  attrs: string,
+): Array<A11yFinding["rule"]> {
+  const tag = tagName.toLowerCase();
+  const rules: Array<A11yFinding["rule"]> = [];
+
+  if (tag === "img" && !ALT_RE.test(attrs)) {
+    rules.push("img-alt");
+  }
+
+  if (
+    ONCLICK_RE.test(attrs) &&
+    !INTERACTIVE_TAGS.has(tag) &&
+    !KEY_HANDLER_OR_ROLE_RE.test(attrs)
+  ) {
+    rules.push("click-events-have-key-events");
+  }
+
+  if (tag === "input" || tag === "textarea" || tag === "select") {
+    TYPE_ATTR_RE.lastIndex = 0;
+    const typeMatch = TYPE_ATTR_RE.exec(attrs);
+    const type = typeMatch?.[1]?.toLowerCase();
+    const skippable = tag === "input" && type !== undefined && LABELLESS_INPUT_TYPES.has(type);
+    if (!skippable && !LABEL_ASSOC_RE.test(attrs)) {
+      rules.push("label-control");
+    }
+  }
+
+  TABINDEX_RE.lastIndex = 0;
+  const tabindexMatch = TABINDEX_RE.exec(attrs);
+  if (tabindexMatch && Number(tabindexMatch[1]) > 0) {
+    rules.push("positive-tabindex");
+  }
+
+  return rules;
+}
+
+type ScanLimits = {
+  maxFindings?: number;
+  signal?: AbortSignal;
+};
+
+/** Scan one file patch's added lines for accessibility regressions, line-cited via hunk headers. Pure. */
+export function scanPatchForA11y(
+  path: string,
+  patch: string,
+  limits: ScanLimits = {},
+): A11yFinding[] {
+  const maxFindings = limits.maxFindings ?? MAX_FINDINGS;
+  if (maxFindings <= 0 || !isMarkupPath(path)) return [];
+
+  const findings: A11yFinding[] = [];
+  let newLine = 0;
+  let inHunk = false;
+
+  for (const line of patch.split("\n")) {
+    if (limits.signal?.aborted) throw new Error("analyzer_aborted");
+    const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
+    if (hunk) {
+      newLine = Number(hunk[1]);
+      inHunk = true;
+      continue;
+    }
+    if (!inHunk) continue;
+    if (!line.startsWith("+")) {
+      if (!line.startsWith("-") && !line.startsWith("\\")) newLine++;
+      continue;
+    }
+
+    const body = line.slice(1);
+    if (body.length <= MAX_LINE_CHARS && !isCommentLine(body)) {
+      TAG_RE.lastIndex = 0;
+      let match: RegExpExecArray | null;
+      while ((match = TAG_RE.exec(body)) !== null) {
+        const [, tagName, attrs] = match;
+        if (tagName === undefined || attrs === undefined) continue;
+        for (const rule of detectA11yIssues(tagName, attrs)) {
+          findings.push({ file: path, line: newLine, rule });
+          if (findings.length >= maxFindings) return findings;
+        }
+      }
+    }
+    newLine++;
+  }
+
+  return findings;
+}
+
+/** Analyzer entrypoint: scan every changed markup file's added lines for accessibility regressions. */
+export async function scanA11y(
+  req: EnrichRequest,
+  signal?: AbortSignal,
+): Promise<A11yFinding[]> {
+  const findings: A11yFinding[] = [];
+  for (const file of req.files ?? []) {
+    if (signal?.aborted) throw new Error("analyzer_aborted");
+    if (!file.patch) continue;
+    for (const finding of scanPatchForA11y(file.path, file.patch, {
+      maxFindings: MAX_FINDINGS - findings.length,
+      signal,
+    })) {
+      findings.push(finding);
+      if (findings.length >= MAX_FINDINGS) return findings;
+    }
+  }
+  return findings;
+}

--- a/review-enrichment/src/analyzers/registry.ts
+++ b/review-enrichment/src/analyzers/registry.ts
@@ -33,6 +33,7 @@ import { scanMagicNumbers } from "./magic-number.js";
 import { scanConflictMarkers } from "./conflict-marker.js";
 import { scanDebugLeftover } from "./debug-leftover.js";
 import { scanDeepNesting } from "./deep-nesting.js";
+import { scanA11y } from "./a11y-regression.js";
 import { scanI18nRegression } from "./i18n-regression.js";
 import { scanErrorSwallow } from "./error-swallow.js";
 import { scanFloatingPromise } from "./floating-promise.js";
@@ -1163,6 +1164,35 @@ export const ANALYZER_DESCRIPTORS = [
       return lines;
     },
     run: (req, { signal }) => scanI18nRegression(req, signal),
+  }),
+  descriptor({
+    name: "a11y",
+    title: "Accessibility regressions",
+    category: "quality",
+    cost: "local",
+    defaultEnabled: true,
+    requires: ["files"],
+    limits: { maxFindings: 25, maxLineChars: 2000 },
+    docs: {
+      summary:
+        "Flags common accessibility regressions in newly-added JSX/HTML markup: missing img alt, clickable non-interactive elements, unlabeled controls, positive tabindex.",
+      looksAt: "Self-contained opening tags on added lines in changed non-test JSX/TSX/HTML/Vue files.",
+      reports: "File, line, and rule id — never markup content.",
+      network: "Pure local analyzer. No external network call.",
+      notes:
+        "Only tags fully contained on one added line are scanned. onKeyPress alone does not satisfy the keyboard-handler check.",
+    },
+    render: (findings, helpers) => {
+      if (!findings.length) return [];
+      const lines = ["### Accessibility regressions (added markup)"];
+      for (const item of findings) {
+        lines.push(
+          `- ${helpers.safeCodeSpan(`${item.file}:${item.line}`)} — ${helpers.safeCodeSpan(item.rule)}`,
+        );
+      }
+      return lines;
+    },
+    run: (req, { signal }) => scanA11y(req, signal),
   }),
   descriptor({
     name: "commitLint",

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -491,6 +491,7 @@ export function renderBrief(
   lines.push(...renderDescriptorSection("deepNesting", findings.deepNesting));
   lines.push(...renderDescriptorSection("errorSwallow", findings.errorSwallow));
   lines.push(...renderDescriptorSection("i18n", findings.i18n));
+  lines.push(...renderDescriptorSection("a11y", findings.a11y));
   lines.push(...renderDescriptorSection("hardcodedUrl", findings.hardcodedUrl));
   lines.push(...renderDescriptorSection("commitLint", findings.commitLint));
 

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -496,6 +496,14 @@ export interface SizeSmellFinding {
   name?: string;
 }
 
+/** An accessibility regression in newly-added markup (#2026, part of #1499).
+ *  Reports file, line, and rule only — never markup content. */
+export interface A11yFinding {
+  file: string;
+  line: number;
+  rule: "img-alt" | "click-events-have-key-events" | "label-control" | "positive-tabindex";
+}
+
 /** A user-facing string literal added without the repo's i18n convention (#2029, part of #1499).
  *  Reports file and line only — never string content. */
 export interface I18nFinding {
@@ -589,6 +597,7 @@ export interface BriefFindings {
   deepNesting?: DeepNestingFinding[];
   errorSwallow?: ErrorSwallowFinding[];
   i18n?: I18nFinding[];
+  a11y?: A11yFinding[];
   hardcodedUrl?: HardcodedUrlFinding[];
   commitLint?: CommitLintFinding[];
 }

--- a/review-enrichment/test/a11y-regression.test.ts
+++ b/review-enrichment/test/a11y-regression.test.ts
@@ -1,0 +1,124 @@
+// Units for the accessibility-regression analyzer (#2026). Own file so concurrent analyzer PRs don't collide.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  detectA11yIssues,
+  scanA11y,
+  scanPatchForA11y,
+} from "../dist/analyzers/a11y-regression.js";
+import { renderBrief } from "../dist/render.js";
+
+const patchOf = (lines: string[]) =>
+  `@@ -1,0 +1,${lines.length} @@\n${lines.map((l) => `+${l}`).join("\n")}`;
+
+test("detectA11yIssues: flags <img> without alt", () => {
+  assert.deepEqual(detectA11yIssues("img", ' src="x.png"'), ["img-alt"]);
+});
+
+test("detectA11yIssues: does not flag <img> with alt", () => {
+  assert.deepEqual(detectA11yIssues("img", ' src="x.png" alt="a cat"'), []);
+});
+
+test("detectA11yIssues: flags onClick on a non-interactive element with no keyboard handler or role", () => {
+  assert.deepEqual(detectA11yIssues("div", ' onClick={handleClick}'), [
+    "click-events-have-key-events",
+  ]);
+  assert.deepEqual(detectA11yIssues("div", ' onclick="handleClick()"'), [
+    "click-events-have-key-events",
+  ]);
+});
+
+test("detectA11yIssues: does not flag onClick when a keyboard handler is present", () => {
+  assert.deepEqual(
+    detectA11yIssues("div", ' onClick={handleClick} onKeyDown={handleKey}'),
+    [],
+  );
+  assert.deepEqual(detectA11yIssues("div", ' onclick="x()" onkeydown="y()"'), []);
+});
+
+test("detectA11yIssues: onKeyPress alone does NOT satisfy the keyboard-accessible check", () => {
+  assert.deepEqual(
+    detectA11yIssues("div", ' onClick={handleClick} onKeyPress={handleKey}'),
+    ["click-events-have-key-events"],
+  );
+});
+
+test("detectA11yIssues: does not flag onClick when a role is present", () => {
+  assert.deepEqual(detectA11yIssues("span", ' onClick={handleClick} role="button"'), []);
+});
+
+test("detectA11yIssues: does not flag onClick on an inherently interactive element", () => {
+  assert.deepEqual(detectA11yIssues("button", ' onClick={handleClick}'), []);
+});
+
+test("detectA11yIssues: flags a form control with no label association", () => {
+  assert.deepEqual(detectA11yIssues("input", ' type="text"'), ["label-control"]);
+});
+
+test("detectA11yIssues: does not flag a form control with an id or aria-label", () => {
+  assert.deepEqual(detectA11yIssues("input", ' type="text" id="name"'), []);
+  assert.deepEqual(detectA11yIssues("textarea", ' aria-label="Comments"'), []);
+});
+
+test("detectA11yIssues: does not flag labelless input types", () => {
+  assert.deepEqual(detectA11yIssues("input", ' type="hidden" value="1"'), []);
+  assert.deepEqual(detectA11yIssues("input", ' type="submit" value="Go"'), []);
+});
+
+test("detectA11yIssues: flags a positive tabindex", () => {
+  assert.deepEqual(detectA11yIssues("div", ' tabIndex={2}'), ["positive-tabindex"]);
+  assert.deepEqual(detectA11yIssues("div", ' tabindex="1"'), ["positive-tabindex"]);
+});
+
+test("detectA11yIssues: does not flag tabindex 0 or -1", () => {
+  assert.deepEqual(detectA11yIssues("div", ' tabIndex={0}'), []);
+  assert.deepEqual(detectA11yIssues("div", ' tabindex="-1"'), []);
+});
+
+test("scanPatchForA11y: reports file/line for a flagged tag", () => {
+  assert.deepEqual(scanPatchForA11y("src/Widget.tsx", patchOf(['<img src="x.png" />'])), [
+    { file: "src/Widget.tsx", line: 1, rule: "img-alt" },
+  ]);
+});
+
+test("scanPatchForA11y: a compliant element yields no findings", () => {
+  assert.deepEqual(
+    scanPatchForA11y("src/Widget.tsx", patchOf(['<img src="x.png" alt="a cat" />'])),
+    [],
+  );
+});
+
+test("scanPatchForA11y: skips non-markup and test paths", () => {
+  const patch = patchOf(['<img src="x.png" />']);
+  assert.deepEqual(scanPatchForA11y("src/widget.ts", patch), []);
+  assert.deepEqual(scanPatchForA11y("src/Widget.test.tsx", patch), []);
+});
+
+test("scanPatchForA11y: skips commented-out markup", () => {
+  assert.deepEqual(
+    scanPatchForA11y("src/Widget.jsx", patchOf(['{/* <img src="x.png" /> */}'])),
+    [],
+  );
+});
+
+test("scanPatchForA11y: respects the maxFindings cap", () => {
+  const lines = Array.from({ length: 5 }, (_, i) => `<img src="${i}.png" />`);
+  assert.equal(scanPatchForA11y("src/Widget.tsx", patchOf(lines), { maxFindings: 2 }).length, 2);
+});
+
+test("scanPatchForA11y: line numbers advance correctly across a hunk", () => {
+  const patch = ["@@ -1,2 +1,3 @@", " <div>", '+  <img src="x.png" />', " </div>"].join("\n");
+  assert.deepEqual(scanPatchForA11y("src/Widget.html", patch), [
+    { file: "src/Widget.html", line: 2, rule: "img-alt" },
+  ]);
+});
+
+test("scanA11y: aggregates across files and renders a public-safe brief", async () => {
+  const findings = await scanA11y({
+    files: [{ path: "src/Widget.tsx", patch: patchOf(['<img src="x.png" />']) }],
+  });
+  assert.equal(findings[0]?.rule, "img-alt");
+  const { promptSection } = renderBrief({ a11y: findings });
+  assert.match(promptSection, /Accessibility regressions/);
+  assert.match(promptSection, /src\/Widget\.tsx:1/);
+});

--- a/review-enrichment/test/analyzer-registry.test.ts
+++ b/review-enrichment/test/analyzer-registry.test.ts
@@ -53,6 +53,7 @@ const EXPECTED_ANALYZERS = [
   "deepNesting",
   "errorSwallow",
   "i18n",
+  "a11y",
   "commitLint",
 ];
 

--- a/src/review/enrichment-analyzer-names.ts
+++ b/src/review/enrichment-analyzer-names.ts
@@ -47,6 +47,7 @@ export const REES_ANALYZER_NAMES = [
   "deepNesting",
   "errorSwallow",
   "i18n",
+  "a11y",
   "commitLint",
 ] as const;
 


### PR DESCRIPTION
## Summary
Fixes #2026

- Add `A11yFinding` and a local `a11y` analyzer that flags four common accessibility regressions in newly-added markup: missing `img` alt, clickable non-interactive elements without keyboard handler/role, unlabeled form controls, and positive `tabindex`
- Diff-local: only self-contained opening tags on one added line are scanned (JSX/TSX/HTML/Vue, non-test paths); reports file, line, and rule only — never markup content
- Case-insensitive `onclick` / `onkeydown` / `onkeyup` matching for HTML/Vue alongside JSX camelCase
- Register the analyzer in the REES registry with render/docs/metadata; sync `src/review/enrichment-analyzer-names.ts` and generated `.env.example` / UI metadata
- Add `review-enrichment/test/a11y-regression.test.ts` covering all four rules, compliant elements, path/comment skips, cap, hunk line numbers, and brief rendering

## Test plan
- [x] `cd review-enrichment && npm run build && npm run metadata && node --test test/a11y-regression.test.ts test/analyzer-registry.test.ts`
- [ ] CI `validate-code`

Made with [Cursor](https://cursor.com)