### PR TITLE
feat(enrichment): categorize the full binary inventory as assets

### DIFF
--- a/review-enrichment/src/analysis-context.ts
+++ b/review-enrichment/src/analysis-context.ts
@@ -19,6 +19,7 @@ import {
 } from "./external-fetch.js";
 import { isWorkflowPath } from "./workflow-path.js";
 import { isSupportedLockfile } from "./lockfile-path.js";
+import { BINARY_EXT_RE } from "./analyzers/binary-extensions.js";
 
 type ChangedFile = NonNullable<EnrichRequest["files"]>[number];
 
@@ -448,11 +449,10 @@ function categorizeFile(path: string): FileCategory {
   ) {
     return { path, extension, category: "docs" };
   }
-  if (
-    [".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".pdf", ".zip", ".gz", ".zst"].includes(
-      extension,
-    )
-  ) {
+  // Binary assets — delegate to the shared binary-extension inventory (used by asset-weight/provenance) so any
+  // media/font/archive/model-weight blob categorizes as an asset instead of falling through to `source`.
+  // `.svg` is text, so it is not in BINARY_EXT_RE, but categorization still treats it as an asset.
+  if (BINARY_EXT_RE.test(path) || extension === ".svg") {
     return { path, extension, category: "asset" };
   }
   if (extension) return { path, extension, category: "source" };

--- a/review-enrichment/test/analysis-context.test.ts
+++ b/review-enrichment/test/analysis-context.test.ts
@@ -570,6 +570,39 @@ test("createAnalysisContext classifies long-form doc extensions as docs", () => 
   );
 });
 
+test("createAnalysisContext categorizes shared binary inventory entries as assets", () => {
+  const context = createAnalysisContext({
+    repoFullName: "JSONbored/gittensory",
+    prNumber: 3359,
+    files: [
+      // A legacy image extension that was already an asset before this change.
+      { path: "ui/logo.png", patch: null, status: "added" },
+      // Binaries beyond the original narrow image/archive list — now recognized via the shared inventory.
+      { path: "media/demo.mp4", patch: null, status: "added" },
+      { path: "fonts/Inter.woff2", patch: null, status: "added" },
+      { path: "vendor/lib.wasm", patch: null, status: "added" },
+      { path: "models/llama.safetensors", patch: null, status: "added" },
+      // .svg is text but still an asset for categorization (kept explicitly).
+      { path: "icons/logo.svg", patch: "@@ -1,0 +1,1 @@\n+<svg/>" },
+      // A real source file is unaffected.
+      { path: "src/index.ts", patch: "@@ -1,0 +1,1 @@\n+export {};" },
+    ],
+  });
+
+  assert.deepEqual(
+    context.fileCategories.map((file) => [file.path, file.category]),
+    [
+      ["ui/logo.png", "asset"],
+      ["media/demo.mp4", "asset"],
+      ["fonts/Inter.woff2", "asset"],
+      ["vendor/lib.wasm", "asset"],
+      ["models/llama.safetensors", "asset"],
+      ["icons/logo.svg", "asset"],
+      ["src/index.ts", "source"],
+    ],
+  );
+});
+
 test("createAnalysisContext classifies lockfile paths case-insensitively", () => {
   const context = createAnalysisContext({
     repoFullName: "JSONbored/gittensory",


### PR DESCRIPTION
## Summary

`categorizeFile` (in `review-enrichment/src/analysis-context.ts`) assigns each changed file a category used for review scheduling/scope. Its `asset` check used a **narrow hand-listed set** of binary extensions — `png`/`jpg`/`jpeg`/`gif`/`webp`/`pdf`/`zip`/`gz`/`zst` — so every other binary the shared inventory already knows (`mp4`, `mov`, `webm`, `woff2`, `ttf`, `wasm`, `node`, `safetensors`, `gguf`, `onnx`, …) fell through to `source`, mislabeling a media / font / model-weight change as a source change.

This delegates the check to the shared binary-extension inventory:

- **Consistency anchor:** `BINARY_EXT_RE` (from `analyzers/binary-extensions`) is the **same inventory** `asset-weight` and `provenance` already use; this replaces the duplicated list with it, matching the #3252 unification (and the same consolidation direction as the merged #3359).
- **`.svg` preserved:** `.svg` is text (deliberately *not* in the binary inventory) but is still an `asset` for categorization, so it is kept explicitly.
- **Purely additive:** only binaries that were previously `source` become `asset`; every one of the original 9 extensions is in the inventory, so no file that was `asset` changes, and no other category is affected. The full existing test suite (1034 tests) passes unchanged, confirming nothing relied on a binary being `source`.

## No linked issue

This is a self-contained classification-coverage fix + de-duplication touching only `review-enrichment/`. It broadens the `asset` category to the shared inventory and removes a hand-maintained list; no new external behavior beyond correctly categorizing more binaries. It mirrors the accepted no-issue precedent for the same kind of enrichment change (e.g. the merged #3329 and #3359).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] No linked issue — see the **No linked issue** section above.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — no `src/**` lines changed (this change is under `review-enrichment/`, which Codecov does not measure), so `codecov/patch` has no diff to gate; suite is green.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New behavior has tests — a case in `review-enrichment/test/analysis-context.test.ts` drives `createAnalysisContext` and asserts `.png` (legacy), `.mp4`/`.woff2`/`.wasm`/`.safetensors` (newly covered) categorize as `asset`, `.svg` stays `asset`, and `.ts` stays `source`. `npm run rees:test` passes (1034 tests; analyzer-metadata check clean).

Validated green against the full GitHub CI `validate-code` check set — `actionlint`, `db:migrations:check`, `db:schema-drift:check`, `cf-typegen:check`, `selfhost:validate-observability`, `typecheck`, `test:coverage`, `test:workers`, `build:mcp`, `test:mcp-pack`, `build:miner`, `rees:test`, `ui:openapi:check`, `ui:openapi:settings-parity`, `ui:version-audit`, `ui:lint`, `ui:typecheck`, `ui:test`, `ui:build`. Branch rebased on latest `main`.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] No auth, cookie, CORS, GitHub App, Cloudflare, or session changes (N/A — internal categorization only).
- [x] No API/OpenAPI/MCP behavior change (N/A).
- [x] No UI changes (N/A — review-enrichment helper).
- [x] No visible UI change, so no UI Evidence section is required.
- [x] No docs/changelog changes needed.

## Notes

Analogues followed end-to-end: the existing category tests in `analysis-context.test.ts` (the `.zst` asset, long-form docs, and case-insensitive lockfile cases), and the merged consolidation PRs #3329 and #3359. The `.svg` special-case preserves the pre-existing behavior exactly (svg was already an `asset` here); only genuinely-binary extensions are newly recognized.
