### PR TITLE
feat(enrichment): unsafe-`any` (TS) counter analyzer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,27 +68,27 @@ GITTENSORY_REVIEW_ENRICHMENT=false
 # commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot
 # blameLink,approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene
 # pendingReviewRequests,testRatio,migrationSafety,looseRange,terminology,todoMarker,magicNumber
-# conflictMarker,debugLeftover,sizeSmell,floatingPromise,deepNesting,errorSwallow,i18n
+# conflictMarker,debugLeftover,sizeSmell,floatingPromise,deepNesting,errorSwallow,i18n,unsafeAny
 # commitLint
 #
 # Profile defaults:
 # fast: dependency,dependencyDiff,lockfileDrift,secret,license,installScript,heavyDependency
 # hardcodedUrl,actionPin,eol,redos,provenance,secretLog,typosquat,iacMisconfig,nativeBuild
 # testRatio,migrationSafety,looseRange,terminology,todoMarker,magicNumber,conflictMarker
-# debugLeftover,sizeSmell,floatingPromise,deepNesting,errorSwallow,i18n
+# debugLeftover,sizeSmell,floatingPromise,deepNesting,errorSwallow,i18n,unsafeAny
 # balanced (default): dependency,dependencyDiff,lockfileDrift,secret,license,installScript
 # heavyDependency,hardcodedUrl,actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight
 # typosquat,commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift,duplication
 # churnHotspot,blameLink,approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch
 # commitHygiene,pendingReviewRequests,testRatio,migrationSafety,looseRange,terminology
 # todoMarker,magicNumber,conflictMarker,debugLeftover,sizeSmell,floatingPromise,deepNesting
-# errorSwallow,i18n,commitLint
+# errorSwallow,i18n,unsafeAny,commitLint
 # deep: dependency,dependencyDiff,lockfileDrift,secret,license,installScript,heavyDependency
 # hardcodedUrl,actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat
 # commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot
 # blameLink,approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene
 # pendingReviewRequests,testRatio,migrationSafety,looseRange,terminology,todoMarker,magicNumber
-# conflictMarker,debugLeftover,sizeSmell,floatingPromise,deepNesting,errorSwallow,i18n
+# conflictMarker,debugLeftover,sizeSmell,floatingPromise,deepNesting,errorSwallow,i18n,unsafeAny
 # commitLint
 # END GENERATED REES ANALYZERS
 

--- a/apps/gittensory-ui/src/lib/rees-analyzers.ts
+++ b/apps/gittensory-ui/src/lib/rees-analyzers.ts
@@ -1073,6 +1073,28 @@ export const REES_ANALYZERS = [
     },
   },
   {
+    name: "unsafeAny",
+    title: "Unsafe `any` usage",
+    category: "quality",
+    cost: "local",
+    defaultEnabled: true,
+    profiles: ["fast", "balanced", "deep"],
+    requires: ["files"],
+    limits: {
+      maxFindings: 25,
+      maxLineChars: 2000,
+    },
+    docs: {
+      summary:
+        "Counts explicit `: any` annotations, `as any` casts, and `<any>` assertions newly added in TypeScript diffs.",
+      looksAt: "Added lines in changed non-test .ts/.tsx/.mts/.cts files.",
+      reports: "File, line, and kind: annotation, cast, or assertion.",
+      network: "Pure local analyzer. No external network call.",
+      notes:
+        "Structural regex only — string literals and block comments are stripped; multi-line block comments opened on context lines are tracked across the hunk.",
+    },
+  },
+  {
     name: "commitLint",
     title: "Conventional-commit subjects",
     category: "quality",

--- a/review-enrichment/analyzer-metadata.json
+++ b/review-enrichment/analyzer-metadata.json
@@ -1214,6 +1214,32 @@
       }
     },
     {
+      "name": "unsafeAny",
+      "title": "Unsafe `any` usage",
+      "category": "quality",
+      "cost": "local",
+      "defaultEnabled": true,
+      "profiles": [
+        "fast",
+        "balanced",
+        "deep"
+      ],
+      "requires": [
+        "files"
+      ],
+      "limits": {
+        "maxFindings": 25,
+        "maxLineChars": 2000
+      },
+      "docs": {
+        "summary": "Counts explicit `: any` annotations, `as any` casts, and `<any>` assertions newly added in TypeScript diffs.",
+        "looksAt": "Added lines in changed non-test .ts/.tsx/.mts/.cts files.",
+        "reports": "File, line, and kind: annotation, cast, or assertion.",
+        "network": "Pure local analyzer. No external network call.",
+        "notes": "Structural regex only — string literals and block comments are stripped; multi-line block comments opened on context lines are tracked across the hunk."
+      }
+    },
+    {
       "name": "commitLint",
       "title": "Conventional-commit subjects",
       "category": "quality",

--- a/review-enrichment/src/analyzers/registry.ts
+++ b/review-enrichment/src/analyzers/registry.ts
@@ -34,6 +34,7 @@ import { scanConflictMarkers } from "./conflict-marker.js";
 import { scanDebugLeftover } from "./debug-leftover.js";
 import { scanDeepNesting } from "./deep-nesting.js";
 import { scanI18nRegression } from "./i18n-regression.js";
+import { scanUnsafeAny } from "./unsafe-any.js";
 import { scanErrorSwallow } from "./error-swallow.js";
 import { scanFloatingPromise } from "./floating-promise.js";
 import { scanSizeSmell } from "./size-smell.js";
@@ -1163,6 +1164,35 @@ export const ANALYZER_DESCRIPTORS = [
       return lines;
     },
     run: (req, { signal }) => scanI18nRegression(req, signal),
+  }),
+  descriptor({
+    name: "unsafeAny",
+    title: "Unsafe `any` usage",
+    category: "quality",
+    cost: "local",
+    defaultEnabled: true,
+    requires: ["files"],
+    limits: { maxFindings: 25, maxLineChars: 2000 },
+    docs: {
+      summary:
+        "Counts explicit `: any` annotations, `as any` casts, and `<any>` assertions newly added in TypeScript diffs.",
+      looksAt: "Added lines in changed non-test .ts/.tsx/.mts/.cts files.",
+      reports: "File, line, and kind: annotation, cast, or assertion.",
+      network: "Pure local analyzer. No external network call.",
+      notes:
+        "Structural regex only — string literals and block comments are stripped; multi-line block comments opened on context lines are tracked across the hunk.",
+    },
+    render: (findings, helpers) => {
+      if (!findings.length) return [];
+      const lines = ["### Unsafe `any` (annotation / cast / assertion added by this PR)"];
+      for (const item of findings) {
+        lines.push(
+          `- ${helpers.safeCodeSpan(`${item.file}:${item.line}`)} — ${helpers.safeCodeSpan(item.kind)}`,
+        );
+      }
+      return lines;
+    },
+    run: (req, { signal }) => scanUnsafeAny(req, signal),
   }),
   descriptor({
     name: "commitLint",

--- a/review-enrichment/src/analyzers/unsafe-any.ts
+++ b/review-enrichment/src/analyzers/unsafe-any.ts
@@ -1,0 +1,164 @@
+// Unsafe-`any` counter analyzer (#2017). Flags explicit `any` type annotations, `as any` casts, and `<any>`
+// assertions newly introduced in TypeScript diffs — a type-safety erosion signal for the reviewer. Pure compute
+// over added lines in .ts/.tsx files, no network. Structural regex only (no type-checker), fail-safe.
+import type { EnrichRequest, UnsafeAnyFinding } from "../types.js";
+import { codeOnly } from "./secret-log.js";
+import { isTestPath } from "./test-ratio.js";
+
+const MAX_FINDINGS = 25;
+const MAX_LINE_CHARS = 2000;
+
+const TS_EXTS = new Set(["ts", "tsx", "mts", "cts"]);
+
+const CAST_RE = /\bas\s+any\b/;
+const ASSERTION_RE = /<\s*any\s*>/;
+const ANNOTATION_RE = /:\s*any\b/;
+
+function isTypeScriptPath(path: string): boolean {
+  const ext = /\.([^.]+)$/.exec(path)?.[1]?.toLowerCase();
+  return Boolean(ext && TS_EXTS.has(ext) && !isTestPath(path));
+}
+
+function stripLineComments(code: string): string {
+  const noBlock = code.replace(/\/\*[\s\S]*?\*\//g, " ");
+  const slash = noBlock.indexOf("//");
+  return slash >= 0 ? noBlock.slice(0, slash) : noBlock;
+}
+
+function isFullLineComment(line: string): boolean {
+  const trimmed = line.trimStart();
+  if (trimmed.startsWith("//")) return true;
+  return /^\s*\/\*[\s\S]*\*\/\s*$/.test(line);
+}
+
+type BlockCommentState = { open: boolean };
+
+/** Advance multi-line block-comment state across one hunk line body. Pure aside from state. */
+export function advanceBlockCommentState(line: string, state: BlockCommentState): void {
+  let scanLine = line;
+  if (state.open) {
+    const end = scanLine.indexOf("*/");
+    if (end < 0) return;
+    state.open = false;
+    scanLine = scanLine.slice(end + 2);
+  }
+  while (true) {
+    const start = scanLine.indexOf("/*");
+    if (start < 0) break;
+    const end = scanLine.indexOf("*/", start + 2);
+    if (end < 0) {
+      state.open = true;
+      return;
+    }
+    scanLine = scanLine.slice(end + 2);
+  }
+}
+
+/** Remove block-comment spans from one added line, tracking multi-line comment state. Pure aside from state. */
+export function stripBlockCommentsFromAddedLine(
+  line: string,
+  state: BlockCommentState,
+): string | null {
+  let scanLine = line;
+  if (state.open) {
+    const end = scanLine.indexOf("*/");
+    if (end < 0) return null;
+    state.open = false;
+    scanLine = scanLine.slice(end + 2);
+  }
+  while (true) {
+    const start = scanLine.indexOf("/*");
+    if (start < 0) break;
+    const end = scanLine.indexOf("*/", start + 2);
+    if (end < 0) {
+      scanLine = scanLine.slice(0, start);
+      state.open = true;
+      break;
+    }
+    scanLine = `${scanLine.slice(0, start)} ${scanLine.slice(end + 2)}`;
+  }
+  return scanLine;
+}
+
+/** Classify one added TS line for an unsafe-`any` pattern, or null. Pure. */
+export function detectUnsafeAny(line: string): UnsafeAnyFinding["kind"] | null {
+  if (isFullLineComment(line)) return null;
+  const code = stripLineComments(codeOnly(line));
+  if (CAST_RE.test(code)) return "cast";
+  if (ASSERTION_RE.test(code)) return "assertion";
+  if (ANNOTATION_RE.test(code)) return "annotation";
+  return null;
+}
+
+type ScanLimits = {
+  maxFindings?: number;
+  signal?: AbortSignal;
+};
+
+/** Scan one file patch's added lines for unsafe `any`, line-cited via hunk headers. Pure. */
+export function scanPatchForUnsafeAny(
+  path: string,
+  patch: string,
+  limits: ScanLimits = {},
+): UnsafeAnyFinding[] {
+  const maxFindings = limits.maxFindings ?? MAX_FINDINGS;
+  if (maxFindings <= 0 || !isTypeScriptPath(path)) return [];
+  const findings: UnsafeAnyFinding[] = [];
+  let newLine = 0;
+  let inHunk = false;
+  const blockComment: BlockCommentState = { open: false };
+
+  for (const line of patch.split("\n")) {
+    if (limits.signal?.aborted) throw new Error("analyzer_aborted");
+    const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
+    if (hunk) {
+      newLine = Number(hunk[1]);
+      inHunk = true;
+      blockComment.open = false;
+      continue;
+    }
+    if (!inHunk) continue;
+
+    if (line.startsWith("+")) {
+      const body = line.slice(1);
+      if (body.length <= MAX_LINE_CHARS) {
+        const scanLine = stripBlockCommentsFromAddedLine(body, blockComment);
+        if (scanLine !== null) {
+          const kind = detectUnsafeAny(scanLine);
+          if (kind) {
+            findings.push({ file: path, line: newLine, kind });
+            if (findings.length >= maxFindings) return findings;
+          }
+        }
+      }
+      newLine++;
+    } else if (line.startsWith("-")) {
+      advanceBlockCommentState(line.slice(1), blockComment);
+    } else if (!line.startsWith("\\")) {
+      advanceBlockCommentState(line, blockComment);
+      newLine++;
+    }
+  }
+
+  return findings;
+}
+
+/** Analyzer entrypoint: scan every changed TS file's added lines for unsafe `any`. */
+export async function scanUnsafeAny(
+  req: EnrichRequest,
+  signal?: AbortSignal,
+): Promise<UnsafeAnyFinding[]> {
+  const findings: UnsafeAnyFinding[] = [];
+  for (const file of req.files ?? []) {
+    if (signal?.aborted) throw new Error("analyzer_aborted");
+    if (!file.patch) continue;
+    for (const finding of scanPatchForUnsafeAny(file.path, file.patch, {
+      maxFindings: MAX_FINDINGS - findings.length,
+      signal,
+    })) {
+      findings.push(finding);
+      if (findings.length >= MAX_FINDINGS) return findings;
+    }
+  }
+  return findings;
+}

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -491,6 +491,7 @@ export function renderBrief(
   lines.push(...renderDescriptorSection("deepNesting", findings.deepNesting));
   lines.push(...renderDescriptorSection("errorSwallow", findings.errorSwallow));
   lines.push(...renderDescriptorSection("i18n", findings.i18n));
+  lines.push(...renderDescriptorSection("unsafeAny", findings.unsafeAny));
   lines.push(...renderDescriptorSection("hardcodedUrl", findings.hardcodedUrl));
   lines.push(...renderDescriptorSection("commitLint", findings.commitLint));
 

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -496,6 +496,14 @@ export interface SizeSmellFinding {
   name?: string;
 }
 
+/** An explicit `any` annotation, cast, or assertion newly added in a TS diff (#2017, part of #1499).
+ *  Reports file, line, and kind only — never source content. */
+export interface UnsafeAnyFinding {
+  file: string;
+  line: number;
+  kind: "annotation" | "cast" | "assertion";
+}
+
 /** A user-facing string literal added without the repo's i18n convention (#2029, part of #1499).
  *  Reports file and line only — never string content. */
 export interface I18nFinding {
@@ -589,6 +597,7 @@ export interface BriefFindings {
   deepNesting?: DeepNestingFinding[];
   errorSwallow?: ErrorSwallowFinding[];
   i18n?: I18nFinding[];
+  unsafeAny?: UnsafeAnyFinding[];
   hardcodedUrl?: HardcodedUrlFinding[];
   commitLint?: CommitLintFinding[];
 }

--- a/review-enrichment/test/analyzer-registry.test.ts
+++ b/review-enrichment/test/analyzer-registry.test.ts
@@ -53,6 +53,7 @@ const EXPECTED_ANALYZERS = [
   "deepNesting",
   "errorSwallow",
   "i18n",
+  "unsafeAny",
   "commitLint",
 ];
 

--- a/review-enrichment/test/unsafe-any.test.ts
+++ b/review-enrichment/test/unsafe-any.test.ts
@@ -1,0 +1,87 @@
+// Units for the unsafe-any analyzer (#2017). Own file so concurrent analyzer PRs don't collide.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  detectUnsafeAny,
+  scanPatchForUnsafeAny,
+  scanUnsafeAny,
+} from "../dist/analyzers/unsafe-any.js";
+import { renderBrief } from "../dist/render.js";
+
+const patchOf = (lines: string[]) =>
+  `@@ -1,0 +1,${lines.length} @@\n${lines.map((l) => `+${l}`).join("\n")}`;
+
+test("detectUnsafeAny: flags annotation, cast, and assertion shapes", () => {
+  assert.equal(detectUnsafeAny("const x: any = 1;"), "annotation");
+  assert.equal(detectUnsafeAny("function f(v: any | null) {}"), "annotation");
+  assert.equal(detectUnsafeAny("return payload as any;"), "cast");
+  assert.equal(detectUnsafeAny("const rows = <any>data;"), "assertion");
+});
+
+test("detectUnsafeAny: prefers cast over annotation on the same line", () => {
+  assert.equal(detectUnsafeAny("const x: any = value as any;"), "cast");
+});
+
+test("detectUnsafeAny: ignores any inside strings and full-line comments", () => {
+  assert.equal(detectUnsafeAny('const s = ": any"'), null);
+  assert.equal(detectUnsafeAny('log(`typed as any inside`);'), null);
+  assert.equal(detectUnsafeAny("// const x: any"), null);
+});
+
+test("detectUnsafeAny: ignores inline block comments after real code", () => {
+  assert.equal(detectUnsafeAny("const x = 1; /* as any */"), null);
+  assert.equal(detectUnsafeAny("/* @internal */ const value: any = input;"), "annotation");
+});
+
+test("scanPatchForUnsafeAny: flags added lines with correct locations", () => {
+  const findings = scanPatchForUnsafeAny(
+    "src/widget.ts",
+    patchOf(["function load(): any {", "  return data as any;", "}"]),
+  );
+  assert.deepEqual(findings, [
+    { file: "src/widget.ts", line: 1, kind: "annotation" },
+    { file: "src/widget.ts", line: 2, kind: "cast" },
+  ]);
+});
+
+test("scanPatchForUnsafeAny: ignores multi-line block comments on added lines", () => {
+  const patch = ["@@ -1,0 +1,3 @@", "+/*", "+ * const x: any = 1;", "+ */"].join("\n");
+  assert.deepEqual(scanPatchForUnsafeAny("src/a.ts", patch), []);
+});
+
+test("scanPatchForUnsafeAny: ignores added lines inside a context-opened block comment", () => {
+  const patch = [
+    "@@ -1,3 +1,4 @@",
+    " function foo() {",
+    " /*",
+    "+ * value: any",
+    " */",
+  ].join("\n");
+  assert.deepEqual(scanPatchForUnsafeAny("src/a.ts", patch), []);
+});
+
+test("scanPatchForUnsafeAny: skips non-TS files, test paths, and respects the cap", () => {
+  assert.deepEqual(scanPatchForUnsafeAny("src/widget.js", patchOf(["const x: any = 1;"])), []);
+  assert.deepEqual(
+    scanPatchForUnsafeAny("src/widget.test.ts", patchOf(["const x: any = 1;"])),
+    [],
+  );
+  const lines = Array.from({ length: 30 }, () => "const x: any = 1;");
+  assert.equal(scanPatchForUnsafeAny("src/a.ts", patchOf(lines), { maxFindings: 3 }).length, 3);
+});
+
+test("scanUnsafeAny: aggregates across files and renders a public-safe brief", async () => {
+  const findings = await scanUnsafeAny({
+    files: [
+      { path: "src/a.ts", patch: patchOf(["const x: any = 1;"]) },
+      { path: "lib/b.tsx", patch: patchOf(["return value as any;"]) },
+    ],
+  });
+  assert.deepEqual(findings, [
+    { file: "src/a.ts", line: 1, kind: "annotation" },
+    { file: "lib/b.tsx", line: 1, kind: "cast" },
+  ]);
+  const { promptSection } = renderBrief({ unsafeAny: findings });
+  assert.match(promptSection, /Unsafe `any`/);
+  assert.match(promptSection, /src\/a\.ts:1/);
+});

--- a/src/review/enrichment-analyzer-names.ts
+++ b/src/review/enrichment-analyzer-names.ts
@@ -47,6 +47,7 @@ export const REES_ANALYZER_NAMES = [
   "deepNesting",
   "errorSwallow",
   "i18n",
+  "unsafeAny",
   "commitLint",
 ] as const;
 


### PR DESCRIPTION
## Summary
Fixes #2017

- Add `UnsafeAnyFinding` and a local `unsafeAny` analyzer that flags newly-added `: any` annotations, `as any` casts, and `<any>` assertions in TypeScript diffs
- Strips string literals and block/line comments before matching; tracks multi-line block comments across context and removed hunk lines so added lines inside an existing `/* … */` are not reported
- Register the analyzer in the REES registry with render/docs/metadata; sync `src/review/enrichment-analyzer-names.ts` and generated `.env.example` / UI metadata
- Add `review-enrichment/test/unsafe-any.test.ts` covering annotation/cast/assertion shapes, comment/string skips, context-opened block comments, path/cap skips, and brief rendering

## Test plan
- [x] `cd review-enrichment && npm run build && npm run metadata && node --test test/unsafe-any.test.ts test/analyzer-registry.test.ts`
- [ ] CI `validate-code`

Made with [Cursor](https://cursor.com)