### PR TITLE
feat(engine): add isPlanProgressComplete plan DAG helper

### DIFF
--- a/packages/gittensory-engine/README.md
+++ b/packages/gittensory-engine/README.md
@@ -537,6 +537,7 @@ dashboard progress summaries:
 - `hasPlanSkippedSteps(plan)` — any step is `skipped`
 - `hasPlanCompletedSteps(plan)` — any step is `completed`
 - `isPlanBlocked(plan)` — pending steps remain but none are runnable (deadlock; mirrors `planProgress`'s `blocked` status)
+- `isPlanProgressComplete(plan)` — every step is `completed` or `skipped` (empty plans are not complete; mirrors `planProgress`'s `completed` status)
 
 ## Opportunity competition
 

--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -147,6 +147,7 @@ export { hasPlanRunningSteps } from "./plan-running.js";
 export { hasPlanSkippedSteps } from "./plan-skipped.js";
 export { hasPlanCompletedSteps } from "./plan-completed.js";
 export { isPlanBlocked } from "./plan-blocked.js";
+export { isPlanProgressComplete } from "./plan-progress-complete.js";
 export * from "./plan-templates.js";
 export * from "./portfolio/queue.js";
 export {

--- a/packages/gittensory-engine/src/plan-progress-complete.ts
+++ b/packages/gittensory-engine/src/plan-progress-complete.ts
@@ -1,0 +1,11 @@
+import type { PlanDag } from "./plan-export.js";
+
+/**
+ * Return whether every step is terminal success (`completed` or `skipped`). Empty plans are not complete. Mirrors
+ * the `completed` branch of hosted `planProgress` (distinct from `isPlanFullyCompleted`, which requires every
+ * step to be `completed`). Pure — reads the plan DAG only.
+ */
+export function isPlanProgressComplete(plan: PlanDag): boolean {
+  if (plan.steps.length === 0) return false;
+  return plan.steps.every((step) => step.status === "completed" || step.status === "skipped");
+}

--- a/test/unit/plan-progress-complete.test.ts
+++ b/test/unit/plan-progress-complete.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import { isPlanProgressComplete } from "../../packages/gittensory-engine/src/plan-progress-complete";
+import type { PlanStep } from "../../packages/gittensory-engine/src/plan-export";
+
+function step(over: Partial<PlanStep> & { id: string; title: string }): PlanStep {
+  return {
+    actionClass: undefined,
+    dependsOn: [],
+    status: "pending",
+    attempts: 0,
+    maxAttempts: 3,
+    lastError: null,
+    ...over,
+  };
+}
+
+describe("isPlanProgressComplete", () => {
+  it("returns false for an empty plan", () => {
+    expect(isPlanProgressComplete({ steps: [] })).toBe(false);
+  });
+
+  it("returns false when any step is still in flight", () => {
+    expect(
+      isPlanProgressComplete({
+        steps: [
+          step({ id: "a", title: "Build", status: "completed" }),
+          step({ id: "b", title: "Test", status: "pending" }),
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when any step failed", () => {
+    expect(
+      isPlanProgressComplete({
+        steps: [
+          step({ id: "a", title: "Build", status: "completed" }),
+          step({ id: "b", title: "Deploy", status: "failed" }),
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true when every step is completed", () => {
+    expect(
+      isPlanProgressComplete({
+        steps: [
+          step({ id: "a", title: "Build", status: "completed" }),
+          step({ id: "b", title: "Test", status: "completed" }),
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true when steps are completed or skipped", () => {
+    expect(
+      isPlanProgressComplete({
+        steps: [
+          step({ id: "a", title: "Build", status: "completed" }),
+          step({ id: "b", title: "Deploy", status: "skipped" }),
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("is exported from the package barrel", async () => {
+    const barrel = await import("../../packages/gittensory-engine/src/index");
+    expect(typeof barrel.isPlanProgressComplete).toBe("function");
+    expect(
+      barrel.isPlanProgressComplete({
+        steps: [
+          step({ id: "a", title: "A", status: "completed" }),
+          step({ id: "b", title: "B", status: "skipped" }),
+        ],
+      }),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `isPlanProgressComplete(plan)` — returns true when every step is `completed` or `skipped` (empty plans return false)
- Mirrors hosted `planProgress`'s `completed` status (distinct from strict `isPlanFullyCompleted`)
- Export from `@jsonbored/gittensory-engine` barrel with unit tests and README bullet

Closes #2298

## Test plan
- [x] `npx vitest run test/unit/plan-progress-complete.test.ts --coverage` (100% patch via diff-cover)
- [x] `npm run build --workspace @jsonbored/gittensory-engine && npm run build:miner`


Made with [Cursor](https://cursor.com)