### PR TITLE
fix(selfhost): ignore timestamped config/deploy backup directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,11 @@ docker-compose.override.yml
 # Private self-host operator config. Root AGENTS.md/CLAUDE.md are public project docs;
 # repo-scoped review instructions live under this ignored mount.
 gittensory-config/
+gittensory-config.backup-*/
+# Operator deploy-backup snapshots -- contains raw .env/.yml backups and config tarballs, same
+# exposure class as gittensory-config/ above (secrets + private review rules), just under a
+# different directory name that the pattern above does not match.
+.deploy-backups/
 # Codex/CLI auth state must only live in runtime volumes or operator home dirs.
 .codex/
 **/.codex/


### PR DESCRIPTION
## Summary
- `gittensory-config/` was ignored, but operator tooling can create sibling backup snapshots
  under different directory names (`gittensory-config.backup-<timestamp>/`, `.deploy-backups/`)
  that the existing pattern doesn't match, leaving them untracked and unignored.
- Adds both patterns alongside the existing `gittensory-config/` entry, same exposure class.

## Test plan
- [x] `.gitignore`-only change; no `src/**` impact, nothing to unit test.
- [x] Verified locally with `git status --porcelain` + a `git add -An` dry run that both
      directory shapes are now correctly ignored.