### PR TITLE
fix(review): cap patch-less secret scan fetches

### DIFF
--- a/src/queue/patchless-secret-scan.ts
+++ b/src/queue/patchless-secret-scan.ts
@@ -9,6 +9,8 @@ export const SECRET_SCAN_PATCH_FALLBACK_MAX_CHARS = 512_000;
 const SECRET_SCAN_FETCH_PROBE_CHARS = SECRET_SCAN_PATCH_FALLBACK_MAX_CHARS + 1;
 /** Bound concurrent Contents API reads during patch-less secret-scan enrichment. */
 const SECRET_SCAN_PATCH_FALLBACK_MAX_CONCURRENT = 4;
+/** Aggregate Contents API read budget for one PR secret-scan fallback pass. */
+export const SECRET_SCAN_PATCH_FALLBACK_MAX_FETCHES = 100;
 /** Max patch-less paths listed in the fail-closed advisory detail (title still reports the full count). */
 export const INCOMPLETE_PATCH_LESS_PATH_DETAIL_MAX = 5;
 
@@ -68,6 +70,29 @@ export function hasPatchLessSecretScanCandidates(
   });
 }
 
+function patchLessSecretScanFetchCost(
+  file: PullRequestFileRecord,
+  baseSha?: string | null | undefined,
+): number {
+  const existingPatch = typeof file.payload?.patch === "string" ? file.payload.patch : "";
+  if (existingPatch) return 0;
+  const status = file.status ?? "modified";
+  if (!shouldAttemptPatchLessSecretScan(file, status, baseSha)) return 0;
+  return status === "added" ? 1 : 2;
+}
+
+function patchLessSecretScanFetchCostExceedsBudget(
+  files: PullRequestFileRecord[],
+  baseSha?: string | null | undefined,
+): boolean {
+  let fetches = 0;
+  for (const file of files) {
+    fetches += patchLessSecretScanFetchCost(file, baseSha);
+    if (fetches > SECRET_SCAN_PATCH_FALLBACK_MAX_FETCHES) return true;
+  }
+  return false;
+}
+
 export function markEligiblePatchLessFilesIncomplete(
   files: PullRequestFileRecord[],
   baseSha?: string | null | undefined,
@@ -89,6 +114,8 @@ export const patchlessSecretScanInternals = {
   syntheticSecretScanPatch,
   isOverSecretScanContentLimit,
   markPatchLessSecretScanIncomplete,
+  patchLessSecretScanFetchCost,
+  patchLessSecretScanFetchCostExceedsBudget,
 };
 
 export function incompletePatchLessSecretScanFinding(
@@ -146,6 +173,9 @@ export async function enrichSecretScanFilesWithPatchFallback(
 ): Promise<PullRequestFileRecord[]> {
   const headSha = args.headSha?.trim();
   if (!headSha) return files;
+  if (patchLessSecretScanFetchCostExceedsBudget(files, args.baseSha)) {
+    return markEligiblePatchLessFilesIncomplete(files, args.baseSha);
+  }
   return mapPatchLessSecretScanFilesWithConcurrency(
     files,
     SECRET_SCAN_PATCH_FALLBACK_MAX_CONCURRENT,

--- a/test/unit/patchless-secret-scan.test.ts
+++ b/test/unit/patchless-secret-scan.test.ts
@@ -4,6 +4,7 @@ import {
   addedLinesForSecretScan,
   enrichSecretScanFilesWithPatchFallback,
   incompletePatchLessSecretScanFinding,
+  SECRET_SCAN_PATCH_FALLBACK_MAX_FETCHES,
   markEligiblePatchLessFilesIncomplete,
   patchlessSecretScanInternals,
 } from "../../src/queue/patchless-secret-scan";
@@ -556,6 +557,63 @@ describe("enrichSecretScanFilesWithPatchFallback", () => {
     expect(secretLeakFinding(buildSecretScanDiff(enriched))?.code).toBe("secret_leak");
   });
 
+  it("fails closed without fetching when patch-less files exceed the aggregate fetch budget", async () => {
+    let fetches = 0;
+    const fetcher: FileFetcher = {
+      async getFileContent() {
+        fetches += 1;
+        return "const ok = 1;\n";
+      },
+    };
+    const files = Array.from({ length: SECRET_SCAN_PATCH_FALLBACK_MAX_FETCHES + 1 }, (_, index) => ({
+      repoFullName: "acme/widgets",
+      pullNumber: 7,
+      path: `bulk-${index}.env`,
+      status: "added" as const,
+      additions: 1,
+      deletions: 0,
+      changes: 1,
+      payload: {},
+    }));
+    const enriched = await enrichSecretScanFilesWithPatchFallback(files, {
+      headSha: "head-sha",
+      fetcher,
+    });
+    expect(fetches).toBe(0);
+    expect(enriched.every((file) => file.payload.secretScanIncomplete === true)).toBe(true);
+    expect(incompletePatchLessSecretScanFinding(enriched)?.title).toContain(
+      `(${SECRET_SCAN_PATCH_FALLBACK_MAX_FETCHES + 1})`,
+    );
+  });
+
+  it("allows patch-less files at the aggregate fetch budget", async () => {
+    let fetches = 0;
+    const fetcher: FileFetcher = {
+      async getFileContent(path, ref) {
+        fetches += 1;
+        if (ref === "head-sha") return `const ok = "${path}";`;
+        return null;
+      },
+    };
+    const files = Array.from({ length: SECRET_SCAN_PATCH_FALLBACK_MAX_FETCHES }, (_, index) => ({
+      repoFullName: "acme/widgets",
+      pullNumber: 7,
+      path: `bulk-${index}.env`,
+      status: "added" as const,
+      additions: 1,
+      deletions: 0,
+      changes: 1,
+      payload: {},
+    }));
+    const enriched = await enrichSecretScanFilesWithPatchFallback(files, {
+      headSha: "head-sha",
+      fetcher,
+    });
+    expect(fetches).toBe(SECRET_SCAN_PATCH_FALLBACK_MAX_FETCHES);
+    expect(enriched.every((file) => typeof file.payload.patch === "string")).toBe(true);
+    expect(incompletePatchLessSecretScanFinding(enriched)).toBeNull();
+  });
+
   it("synthesizes a scannable patch for a patch-less renamed file with a newly added secret", async () => {
     const fetcher: FileFetcher = {
       async getFileContent(path, ref) {
@@ -832,6 +890,8 @@ describe("patchlessSecretScanInternals", () => {
     syntheticSecretScanPatch,
     isOverSecretScanContentLimit,
     markPatchLessSecretScanIncomplete,
+    patchLessSecretScanFetchCost,
+    patchLessSecretScanFetchCostExceedsBudget,
   } = patchlessSecretScanInternals;
 
   it("hasPatchLessSecretScanCandidates ignores inline patches and ineligible statuses", () => {
@@ -868,6 +928,22 @@ describe("patchlessSecretScanInternals", () => {
       },
     ];
     expect(hasPatchLessSecretScanCandidates(files, null)).toBe(true);
+    expect(
+      hasPatchLessSecretScanCandidates(
+        [
+          {
+            repoFullName: "acme/widgets",
+            pullNumber: 7,
+            path: "default-status.ts",
+            additions: 1,
+            deletions: 0,
+            changes: 1,
+            payload: {},
+          },
+        ] as Parameters<typeof hasPatchLessSecretScanCandidates>[0],
+        "base-sha",
+      ),
+    ).toBe(true);
     expect(
       hasPatchLessSecretScanCandidates(
         [
@@ -918,6 +994,34 @@ describe("patchlessSecretScanInternals", () => {
       path: "secrets.env",
     } as Parameters<typeof markPatchLessSecretScanIncomplete>[0]);
     expect(incomplete.payload?.secretScanIncomplete).toBe(true);
+  });
+
+  it("counts aggregate fetch budget by patch-less status and eligibility", () => {
+    const added = {
+      repoFullName: "acme/widgets",
+      pullNumber: 7,
+      path: "added.env",
+      status: "added",
+      additions: 1,
+      deletions: 0,
+      changes: 1,
+      payload: {},
+    };
+    const modified = { ...added, path: "modified.env", status: "modified" };
+    const inline = { ...added, path: "inline.env", payload: { patch: "+ok" } };
+    const removed = { ...added, path: "removed.env", status: "removed" };
+    expect(patchLessSecretScanFetchCost(added, null)).toBe(1);
+    expect(patchLessSecretScanFetchCost(modified, "base-sha")).toBe(2);
+    expect(patchLessSecretScanFetchCost(modified, null)).toBe(0);
+    expect(patchLessSecretScanFetchCost(inline, null)).toBe(0);
+    expect(patchLessSecretScanFetchCost(removed, "base-sha")).toBe(0);
+    expect(patchLessSecretScanFetchCostExceedsBudget([added], null)).toBe(false);
+    expect(
+      patchLessSecretScanFetchCostExceedsBudget(
+        Array.from({ length: SECRET_SCAN_PATCH_FALLBACK_MAX_FETCHES + 1 }, () => added),
+        null,
+      ),
+    ).toBe(true);
   });
 
   it("addedLinesForSecretScan handles identical content and multiset decrements", () => {


### PR DESCRIPTION
### Motivation

- The patch-less secret-scan fallback could issue a Contents API read for every eligible file in a PR with no aggregate budget, allowing an attacker-controlled PR to exhaust worker time and GitHub rate limits.  
- The change bounds aggregate work so a pathological PR fails closed before any Contents API fetches are issued, preserving the existing hard-block advisory path.

### Description

- Add an aggregate fetch budget constant `SECRET_SCAN_PATCH_FALLBACK_MAX_FETCHES = 100` to limit total Contents API reads per PR fallback pass.  
- Implement `patchLessSecretScanFetchCost` and `patchLessSecretScanFetchCostExceedsBudget` to count per-file fetch cost (1 for `added`, 2 for `modified`/`renamed`) and detect budget exceedance.  
- Make `enrichSecretScanFilesWithPatchFallback` fail-closed by returning `markEligiblePatchLessFilesIncomplete(...)` when the aggregate budget would be exceeded instead of issuing any fetches.  
- Export and wire the new helpers into `patchlessSecretScanInternals` and add unit tests covering over-budget fail-closed behavior, exact-budget acceptance, fetch-cost accounting, and default-status candidate handling.

### Testing

- Ran the focused unit suite: `npm test -- --run test/unit/patchless-secret-scan.test.ts` — all tests passed (47 tests).  
- Typecheck: `npx tsc --noEmit` — passed.  
- Targeted per-file coverage: ran `npx vitest run test/unit/patchless-secret-scan.test.ts --coverage --coverage.include=src/queue/patchless-secret-scan.ts` and observed 100% coverage for the modified file and its branches.  
- Full local gate (`npm run test:coverage` / `npm run test:ci`) and `npm audit --audit-level=moderate` could not be completed to finalization in this environment (the full unsharded coverage/gate run did not finish here and the npm audit endpoint returned `403 Forbidden`), so broader CI-level checks remain to be run in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a8c35e994832c977913ee127dc36f)