### PR TITLE
fix(signals): classify Java gRPC service stubs as generated

### DIFF
--- a/src/signals/path-matchers.ts
+++ b/src/signals/path-matchers.ts
@@ -56,11 +56,13 @@ function isGeneratedFileFrom(parts: NormalizedPath): boolean {
     // the Elixir plugin emits `.pb.ex`, the Erlang gpb plugin emits `.pb.erl` / `.pb.hrl`, the Crystal
     // plugin emits `.pb.cr`, the Haskell plugin emits `.pb.hs`, and the Objective-C plugin emits
     // `.pbobjc.{h,m}` plus gRPC `.pbrpc.{h,m}` service stubs. Swift gRPC emits sibling `.grpc.swift`
-    // service stubs; grpc-kotlin emits sibling `*GrpcKt.kt` coroutine service stubs.
+    // service stubs; grpc-kotlin emits sibling `*GrpcKt.kt` coroutine service stubs; grpc-java emits
+    // sibling `*Grpc.java` service stubs.
     // `.pb.dart`/`.pb.kt`/`.pb.cs` (the `.pb` infix keeps hand-written sources from matching).
     /\.pb\.(go|ts|js|cc|h|swift|dart|kt|cs|rs|ex|erl|hrl|cr|hs)$/.test(norm) ||
     /\.grpc\.swift$/.test(norm) ||
     /grpckt\.kt$/.test(norm) ||
+    /grpc\.java$/.test(norm) ||
     /\.pbobjc\.(h|m)$/.test(norm) ||
     /\.pbrpc\.(h|m)$/.test(norm) ||
     // Python protobuf: message stubs are `*_pb2.py[i]`; the gRPC plugin emits sibling

--- a/test/unit/path-matchers.test.ts
+++ b/test/unit/path-matchers.test.ts
@@ -144,6 +144,12 @@ describe("isGeneratedFile", () => {
     expect(classifyChangedFile("gen/GreeterGrpcKt.kt")).toBe("generated");
   });
 
+  it("matches Java gRPC service stubs alongside the other protoc plugins", () => {
+    expect(isGeneratedFile("gen/GreeterGrpc.java")).toBe(true);
+    expect(isGeneratedFile("src/Greeter.java")).toBe(false);
+    expect(classifyChangedFile("gen/GreeterGrpc.java")).toBe("generated");
+  });
+
   it("matches Swift protobuf, Dart freezed/retrofit, C# designer/XAML, and Objective-C protoc output", () => {
     for (const path of [
       "proto/messages.pb.swift",
@@ -474,6 +480,7 @@ describe("classifyChangedFile", () => {
       ["gen/service_pb.nim", "generated"],
       ["gen/service_pb.lua", "generated"],
       ["gen/GreeterGrpcKt.kt", "generated"],
+      ["gen/GreeterGrpc.java", "generated"],
       ["vendor/lib.go", "vendored"],
       ["package-lock.json", "lockfile"],
       ["bun.lock", "lockfile"],


### PR DESCRIPTION
## Summary

Extend `isGeneratedFile` to recognize grpc-java service stubs (`*Grpc.java`), matching the existing `.pb.kt` message-stub and `*GrpcKt.kt` coroutine-stub coverage. Includes direct `isGeneratedFile` / `classifyChangedFile` assertions and a hand-authored `.java` negative case.

Fixes #561

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npx vitest run test/unit/path-matchers.test.ts` (45/45 pass)
- [ ] `npm run test:coverage` — changed lines covered by new positive/negative `isGeneratedFile` and `classifyChangedFile` cases
- [ ] `npm run test:workers` — not applicable (signals-only)
- [ ] `npm run build:mcp` — not applicable
- [ ] `npm run test:mcp-pack` — not applicable
- [ ] `npm run ui:openapi:check` — not applicable
- [ ] `npm run ui:lint` — not applicable
- [ ] `npm run ui:typecheck` — not applicable
- [ ] `npm run ui:build` — not applicable
- [ ] `npm audit --audit-level=moderate` — not applicable
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Signals-only two-file diff; full repo `test:coverage` runs on CI. Local validation: `npm run typecheck` + targeted vitest file above.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — signals-only change with no visible UI.

## Notes

- Incremental **maintenance** parity for the path-matcher slop signals from #561. Supports generated-file classification work tracked in #2279.
- Paths are normalized to lowercase before matching, so the matcher uses the `grpc.java` suffix (parallel to `grpckt.kt`).
