### PR TITLE
fix(review): clear stale disposition labels once the underlying hold resolves

### DIFF
--- a/src/settings/agent-actions.ts
+++ b/src/settings/agent-actions.ts
@@ -767,6 +767,22 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
     : ciUnverified
       ? "CI could not be verified"
       : "";
+  // Hoisted above section 1 (#stale-disposition-label-cleanup) so the review_state_label sibling-label
+  // cleanup below can tell whether the owner/automation "not reviewGood" fallback hold (below, #1089) still
+  // wants `labels.manualReview` this same pass, even when this ternary's own choice picks a different label
+  // (e.g. ciUnverified: reviewGood is false, so the ternary below picks changesRequested, but the fallback
+  // still separately wants manualReview) — without this, the cleanup would remove a label the fallback is
+  // about to re-add later in this same pass. See its own doc comment at the (former) point of use below.
+  const manualHoldReason =
+    guardrailHit
+      ? `verdict=${conclusion}; ${guardrailReason}`
+      : ciUnverified
+        ? "CI could not be verified"
+        : conclusion === "action_required"
+          ? "review requires maintainer action"
+          : !reviewGood && !willClose && (!closeEligible || acting("close"))
+            ? `verdict=${conclusion}${ciReason ? `; ${ciReason}` : ""}`
+            : null;
 
   // 1) manual-review label — a configurable, single-purpose label for guardrail holds. This is intentionally
   // separate from review_state_label so a one-shot repo can opt into `manual-review` without also enabling the
@@ -888,6 +904,29 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
             : !linkedIssueCloseInFlight && !unlinkedIssueMatchViolated && reviewGood && input.unlinkedIssueMatchClose !== undefined
               ? { comment: sanitizePublicComment(input.unlinkedIssueMatchClose.comment) }
               : {}),
+      });
+    }
+    // Stale disposition-label cleanup (#stale-disposition-label-cleanup): the four states above
+    // (readyToMerge/manualReview/migrationCollision/changesRequested) are mutually exclusive — a PR should
+    // carry exactly one. But the ternary above only ever ADDS the current one; a label from a PRIOR pass
+    // (e.g. changesRequested while CI was red) never got removed once the PR became healthy again, so it sat
+    // on the PR forever alongside whatever the bot added next. Clear every OTHER configured sibling that is
+    // still live on the PR. `manualReview` is excluded from this pass's removal when `manualHoldReason` is
+    // non-null even though it isn't this ternary's own `label` choice (e.g. ciUnverified: reviewGood is false
+    // so the ternary picks changesRequested here, but the separate owner/automation fallback below still
+    // independently wants manualReview and may re-add it later in this SAME pass) — removing it here would
+    // race against that later add.
+    const dispositionLabelSiblings = [labels.readyToMerge, labels.manualReview, labels.migrationCollision, labels.changesRequested];
+    for (const stale of dispositionLabelSiblings) {
+      if (stale === null || stale === label || !hasLabel(input.pr.labels, stale)) continue;
+      if (stale === labels.manualReview && manualHoldReason !== null) continue;
+      actions.push({
+        actionClass: "label",
+        autonomyClass: "review_state_label",
+        requiresApproval: approval("review_state_label"),
+        reason: `disposition resolved — clearing the stale "${stale}" label`,
+        label: stale,
+        labelOp: "remove",
       });
     }
     // Flag-then-close double-check, Pass 1: add the pending-closure label + a warning comment citing the specific
@@ -1076,16 +1115,7 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
   // below) so a repo with every relevant class off stays fully quiescent — see "plans nothing when every class is
   // at a non-acting level". For the owner/admin/automation-bot branch (`!closeEligible`) this is unchanged: those
   // authors are never close-eligible regardless of the `close` autonomy dial, so the hold must still surface.
-  const manualHoldReason =
-    guardrailHit
-      ? `verdict=${conclusion}; ${guardrailReason}`
-      : ciUnverified
-        ? "CI could not be verified"
-        : conclusion === "action_required"
-          ? "review requires maintainer action"
-          : !reviewGood && !willClose && (!closeEligible || acting("close"))
-            ? `verdict=${conclusion}${ciReason ? `; ${ciReason}` : ""}`
-            : null;
+  // (manualHoldReason itself is now computed earlier, above section 1 — see its doc comment there.)
   if (
     manualHoldReason !== null &&
     labels.manualReview !== null &&

--- a/test/unit/agent-actions.test.ts
+++ b/test/unit/agent-actions.test.ts
@@ -120,6 +120,66 @@ describe("planAgentMaintenanceActions (#778)", () => {
     ]);
   });
 
+  describe("stale disposition-label cleanup (#stale-disposition-label-cleanup)", () => {
+    it("clears a stale changes-requested label once the PR becomes healthy again", () => {
+      const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { review_state_label: "auto" }, pr: { labels: [AGENT_LABEL_CHANGES] } }));
+      expect(plan).toContainEqual(expect.objectContaining({ actionClass: "label", label: AGENT_LABEL_READY }));
+      expect(plan).toContainEqual(expect.objectContaining({ actionClass: "label", label: AGENT_LABEL_CHANGES, labelOp: "remove" }));
+    });
+
+    it("clears a stale manual-review label once the guardrail no longer hits", () => {
+      // No guardrailHit this pass (changedPaths/hardGuardrailGlobs empty, the default) — a prior pass's
+      // manual-review hold has resolved, so it must not linger once the PR is genuinely ready-to-merge.
+      const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { review_state_label: "auto" }, pr: { labels: [AGENT_LABEL_NEEDS_REVIEW] } }));
+      expect(plan).toContainEqual(expect.objectContaining({ actionClass: "label", label: AGENT_LABEL_READY }));
+      expect(plan).toContainEqual(expect.objectContaining({ actionClass: "label", label: AGENT_LABEL_NEEDS_REVIEW, labelOp: "remove" }));
+    });
+
+    it("clears a stale ready-to-merge label when the PR newly becomes guarded", () => {
+      const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { merge: "auto", review_state_label: "auto" }, changedPaths: ["src/settings/agent-actions.ts"], hardGuardrailGlobs: ["src/settings/**"], pr: { labels: [AGENT_LABEL_READY], mergeableState: "clean" } }));
+      expect(plan).toContainEqual(expect.objectContaining({ actionClass: "label", label: AGENT_LABEL_NEEDS_REVIEW, labelOp: "add" }));
+      expect(plan).toContainEqual(expect.objectContaining({ actionClass: "label", label: AGENT_LABEL_READY, labelOp: "remove" }));
+    });
+
+    it("clears every stale sibling at once when more than one lingers from prior passes", () => {
+      const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { review_state_label: "auto" }, pr: { labels: [AGENT_LABEL_CHANGES, AGENT_LABEL_MIGRATION_COLLISION] } }));
+      expect(plan).toContainEqual(expect.objectContaining({ actionClass: "label", label: AGENT_LABEL_READY }));
+      expect(plan).toContainEqual(expect.objectContaining({ actionClass: "label", label: AGENT_LABEL_CHANGES, labelOp: "remove" }));
+      expect(plan).toContainEqual(expect.objectContaining({ actionClass: "label", label: AGENT_LABEL_MIGRATION_COLLISION, labelOp: "remove" }));
+    });
+
+    it("is idempotent — no remove actions when the PR already carries only the correct label", () => {
+      const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { review_state_label: "auto" }, pr: { labels: [AGENT_LABEL_READY] } }));
+      expect(plan.filter((a) => a.actionClass === "label" && a.labelOp === "remove")).toEqual([]);
+    });
+
+    it("never emits a remove for a sibling label that is configured OFF (null)", () => {
+      // readyToMergeLabel disabled entirely: nothing gets ADDED for the healthy verdict, but a stale
+      // changes-requested label from before must still be cleared -- disabling the "success" label must not
+      // suppress cleanup of a now-wrong one.
+      const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { review_state_label: "auto" }, readyToMergeLabel: null, pr: { labels: [AGENT_LABEL_CHANGES] } }));
+      expect(plan.some((a) => a.actionClass === "label" && a.label === AGENT_LABEL_READY)).toBe(false);
+      expect(plan).toContainEqual(expect.objectContaining({ actionClass: "label", label: AGENT_LABEL_CHANGES, labelOp: "remove" }));
+    });
+
+    it("does NOT clear manual-review when the owner/automation CI-unverified fallback still wants it, even though this ternary picked changes-requested", () => {
+      // ciUnverified makes reviewGood false, so the review_state_label ternary picks changes-requested here --
+      // but the separate manualHoldReason fallback (ciUnverified branch) still independently wants
+      // manual-review and may re-add it later in this same pass; the cleanup must not race against that.
+      const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { review_state_label: "auto" }, ciState: "unverified", pr: { labels: [AGENT_LABEL_NEEDS_REVIEW] } }));
+      expect(plan.some((a) => a.actionClass === "label" && a.label === AGENT_LABEL_NEEDS_REVIEW && a.labelOp === "remove")).toBe(false);
+      expect(plan).toContainEqual(expect.objectContaining({ actionClass: "label", label: AGENT_LABEL_CHANGES }));
+    });
+
+    it("never touches the pending-closure label, which has its own dedicated clear path", () => {
+      const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { review_state_label: "auto" }, linkedIssueHardRule: { violated: false, reason: null }, pr: { labels: [AGENT_LABEL_PENDING_CLOSURE] } }));
+      expect(plan.some((a) => a.label === AGENT_LABEL_PENDING_CLOSURE && a.labelOp === "remove")).toBe(true);
+      // exactly one remove for it (from the existing dedicated clearLinkedIssueFlag path), not a duplicate from
+      // the new sibling-cleanup loop (which does not include pendingClosure in its sibling set at all).
+      expect(plan.filter((a) => a.label === AGENT_LABEL_PENDING_CLOSURE && a.labelOp === "remove")).toHaveLength(1);
+    });
+  });
+
   it("approves a passing verdict and never re-approves; a failing one closes (never approves, never requests changes)", () => {
     expect(classes(planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { approve: "auto" } })))).toContain("approve");
     expect(classes(planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { approve: "auto" }, pr: { labels: [], reviewDecision: "APPROVED" } })))).not.toContain("approve");


### PR DESCRIPTION
Closes #3573

## Summary

- The `review_state_label` disposition ternary (`ready-to-merge` / `manual-review` /
  `migration-collision` / `changes-requested`) in `planAgentMaintenanceActions`
  (`src/settings/agent-actions.ts`) only ever ADDED the currently-correct label — it
  never removed a sibling label left over from a prior pass. A PR held once (e.g.
  `changes-requested` while CI was red) kept that label forever, even after becoming
  healthy again, alongside whatever the bot added next.
- This has a real second-order effect: the AI-review freeze (`isFrozenForManualReview`
  in `src/queue/processors.ts`) checks whether the manual-review label is live on the
  PR to decide whether to reuse the last-published AI verdict instead of spending a
  fresh call. A manual-review label that never clears means that freeze can stay
  engaged indefinitely — producing a review comment whose deterministic parts (checks,
  gate result, linked-issue status) are fresh while the AI-authored "Review
  summary"/"Blockers" prose is stale, because the freeze never has a reason to lift.
  This is exactly what was observed on #3513 after its own blockers were fixed.
- Fix: add a cleanup pass, in the same `review_state_label`-gated section, that removes
  any of the three OTHER mutually-exclusive disposition labels still live on the PR
  once the ternary resolves to a different one this pass — mirroring the existing
  `clearLinkedIssueFlag` pattern already used for the pending-closure label.
  `manual-review` is excluded from this cleanup specifically when the separate
  owner/automation "not reviewGood" fallback hold (`manualHoldReason`, hoisted earlier
  in the function so this cleanup can see it) still independently wants it this same
  pass — that fallback can re-add the label later in the same call, and removing it
  here would race against that add.
- `manualHoldReason`'s computation was hoisted from the bottom of the function to
  right after `ciReason` (its own dependencies — `guardrailHit`, `ciUnverified`,
  `conclusion`, `reviewGood`, `willClose`, `closeEligible` — are all already available
  there); its later use is unchanged, just no longer redeclared.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused — one file changed (plus its test file), no `apps/gittensory-ui/**`,
      no generated-artifact changes needed (no OpenAPI/schema/migration/wrangler-binding
      changes).
- [x] Follows `CONTRIBUTING.md`; no `site/`/`CNAME`/VitePress changes.
- [x] Linked issue: `Closes #3573`.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` — not run; no workflow files touched.
- [x] `npm run typecheck` (clean)
- [ ] `npm run test:coverage` (full/unsharded) — not run locally; ran the specific
      affected files instead (`agent-actions.test.ts`, 229 tests; the full
      `queue.test.ts` integration suite, 572 tests) — all green. Cross-referenced the
      exact new-diff line/branch ranges against a fresh `coverage-final.json`
      (`--coverage.include='src/settings/agent-actions.ts'`): 100% of the new
      statements and branches are covered. GitHub CI runs the full suite/gate on push.
- [ ] `npm run test:workers` / `npm run build:mcp` / `npm run test:mcp-pack` — not run;
      nothing in those surfaces touched.
- [ ] `npm run ui:openapi:check` / `ui:lint` / `ui:typecheck` / `ui:build` — not run; no
      API/schema or `apps/gittensory-ui/**` changes.
- [ ] `npm audit --audit-level=moderate` — not run; no dependency changes.
- [x] New/changed behavior has unit tests for every new branch: clearing a stale
      `changes-requested`/`manual-review`/`ready-to-merge` label individually, clearing
      multiple stale siblings at once, idempotency (no remove when only the correct
      label is present), a null-configured sibling label never producing a remove, the
      `manualHoldReason`-still-warranted exclusion (ciUnverified case), and confirming
      the pending-closure label's own dedicated clear path is untouched (no duplicate
      remove from the new sibling-cleanup loop).

If any required check was skipped, explain why:

- Local validation here was typecheck + the specific affected test files (`agent-actions.test.ts`
  plus the full `queue.test.ts` integration suite) rather than a full local
  `test:ci`/`test:coverage`/`npm audit` pass, since GitHub CI runs the complete gate on
  push and re-running the whole suite by hand for every change is redundant.

## Safety

- [x] No secrets, wallets, hotkeys, coldkeys, trust scores, or private scoring values are
      touched or exposed.
- [x] Public-facing text (the new "clearing the stale ... label" reason string) stays
      factual, no compensation/optimization claims — it's a reason string on an internal
      label action, not posted as a PR comment.
- [x] Not an auth/CORS/session change; no negative-path tests needed for that reason.
- [x] Not an API/OpenAPI change.
- [ ] Not a UI change (N/A) — no `UI Evidence` section included.
- [x] No changelog edit.

## Notes

- This PR is stacked on `claude/zealous-herschel-f6bfba` (#3513) since it touches the
  same function and the same lines added there — it will retarget to `main`
  automatically once #3513 merges.