### PR TITLE
feat(engine): add hasPlanReadySteps plan DAG helper

### DIFF
--- a/packages/gittensory-engine/README.md
+++ b/packages/gittensory-engine/README.md
@@ -539,6 +539,7 @@ dashboard progress summaries:
 - `isPlanBlocked(plan)` — pending steps remain but none are runnable (deadlock; mirrors `planProgress`'s `blocked` status)
 - `isPlanProgressComplete(plan)` — every step is `completed` or `skipped` (empty plans are not complete; mirrors `planProgress`'s `completed` status)
 - `resolvePlanOverallStatus(plan)` — coarse status (`pending` | `running` | `completed` | `failed` | `blocked`); mirrors `planProgress`'s `status`
+- `hasPlanReadySteps(plan)` — any step is runnable now (`pending` with satisfied dependencies; mirrors `nextReadySteps(plan).length > 0`)
 
 ## Opportunity competition
 

--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -149,6 +149,7 @@ export { hasPlanCompletedSteps } from "./plan-completed.js";
 export { isPlanBlocked } from "./plan-blocked.js";
 export { isPlanProgressComplete } from "./plan-progress-complete.js";
 export { resolvePlanOverallStatus, type PlanOverallStatus } from "./plan-overall-status.js";
+export { hasPlanReadySteps } from "./plan-ready.js";
 export * from "./plan-templates.js";
 export * from "./portfolio/queue.js";
 export {

--- a/packages/gittensory-engine/src/plan-ready.ts
+++ b/packages/gittensory-engine/src/plan-ready.ts
@@ -1,0 +1,18 @@
+import type { PlanDag, PlanStep, PlanStepStatus } from "./plan-export.js";
+
+const isDone = (status: PlanStepStatus): boolean => status === "completed" || status === "skipped";
+
+function nextReadySteps(plan: PlanDag): PlanStep[] {
+  const statusById = new Map(plan.steps.map((step) => [step.id, step.status]));
+  return plan.steps.filter(
+    (step) => step.status === "pending" && step.dependsOn.every((dep) => isDone(statusById.get(dep) ?? "pending")),
+  );
+}
+
+/**
+ * Return whether any step is runnable now: `pending` with every dependency `completed` or `skipped`. Mirrors hosted
+ * `nextReadySteps(plan).length > 0`. Pure.
+ */
+export function hasPlanReadySteps(plan: PlanDag): boolean {
+  return nextReadySteps(plan).length > 0;
+}

--- a/test/unit/plan-ready.test.ts
+++ b/test/unit/plan-ready.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+
+import { hasPlanReadySteps } from "../../packages/gittensory-engine/src/plan-ready";
+import type { PlanStep } from "../../packages/gittensory-engine/src/plan-export";
+
+function step(over: Partial<PlanStep> & { id: string; title: string }): PlanStep {
+  return {
+    actionClass: undefined,
+    dependsOn: [],
+    status: "pending",
+    attempts: 0,
+    maxAttempts: 3,
+    lastError: null,
+    ...over,
+  };
+}
+
+describe("hasPlanReadySteps", () => {
+  it("returns false for an empty plan", () => {
+    expect(hasPlanReadySteps({ steps: [] })).toBe(false);
+  });
+
+  it("returns true when a pending step has no dependencies", () => {
+    expect(
+      hasPlanReadySteps({
+        steps: [step({ id: "a", title: "Build", status: "pending" })],
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true when a pending step's dependencies are satisfied", () => {
+    expect(
+      hasPlanReadySteps({
+        steps: [
+          step({ id: "a", title: "Build", status: "completed" }),
+          step({ id: "b", title: "Test", status: "pending", dependsOn: ["a"] }),
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true when only the root pending step is ready in a chain", () => {
+    expect(
+      hasPlanReadySteps({
+        steps: [
+          step({ id: "a", title: "Build", status: "pending" }),
+          step({ id: "b", title: "Test", status: "pending", dependsOn: ["a"] }),
+        ],
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false for a cyclic deadlock with no ready steps", () => {
+    expect(
+      hasPlanReadySteps({
+        steps: [
+          step({ id: "a", title: "A", dependsOn: ["b"] }),
+          step({ id: "b", title: "B", dependsOn: ["a"] }),
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when a pending step depends on a missing step id", () => {
+    expect(
+      hasPlanReadySteps({
+        steps: [step({ id: "a", title: "A", dependsOn: ["ghost"] })],
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when every step is completed or skipped", () => {
+    expect(
+      hasPlanReadySteps({
+        steps: [
+          step({ id: "a", title: "Build", status: "completed" }),
+          step({ id: "b", title: "Deploy", status: "skipped" }),
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false when only running or failed steps remain", () => {
+    expect(
+      hasPlanReadySteps({
+        steps: [
+          step({ id: "a", title: "Build", status: "running" }),
+          step({ id: "b", title: "Deploy", status: "failed" }),
+        ],
+      }),
+    ).toBe(false);
+  });
+
+  it("is exported from the package barrel", async () => {
+    const barrel = await import("../../packages/gittensory-engine/src/index");
+    expect(typeof barrel.hasPlanReadySteps).toBe("function");
+    expect(
+      barrel.hasPlanReadySteps({
+        steps: [step({ id: "a", title: "A", status: "pending" })],
+      }),
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `hasPlanReadySteps(plan)` — returns true when any step is runnable (`pending` with satisfied dependencies)
- Mirrors hosted `nextReadySteps(plan).length > 0`
- Unit tests cover ready chains, cyclic deadlock, and dangling dependency ids

Closes #2298

## Test plan
- [x] `npx vitest run test/unit/plan-ready.test.ts --coverage` (100% patch via diff-cover)
- [x] `npm run build --workspace @jsonbored/gittensory-engine && npm run build:miner`


Made with [Cursor](https://cursor.com)