### PR TITLE
docs(contributing): document every test:ci check, not just three

### DIFF
--- a/.claude/skills/contributing-to-gittensory/SKILL.md
+++ b/.claude/skills/contributing-to-gittensory/SKILL.md
@@ -201,6 +201,8 @@ Run the matching command(s) and **commit the regenerated file(s)** — CI fails 
 | A Cloudflare binding/var in `wrangler.jsonc` | `npm run cf-typegen` | `worker-configuration.d.ts` |
 | Drizzle schema (`src/db/schema.ts`) | `npm run drizzle:generate` | the new `migrations/NNNN_*.sql` |
 | Added a raw-SQL migration | (none — just author it) | next **contiguous** `migrations/NNNN_snake.sql` |
+| `src/selfhost/**` (or a few other scanned files — see `scripts/gen-selfhost-env-reference.mjs`'s `DEFAULT_SOURCE_ROOTS`) touching an `env.SOMETHING` read | `npm run selfhost:env-reference` | `apps/gittensory-ui/src/lib/selfhost-env-reference.ts` — the doc embeds `file:line` citations, so even an edit that only shifts line numbers (no var added/removed) goes stale |
+| CLI command surface | `npm run command-reference` | the generated command-reference doc |
 | UI files (`apps/gittensory-ui/**`) | `npm --workspace @jsonbored/gittensory-ui run format` | formatted files |
 
 Migrations must use the **next free number** (contiguous, no gaps, no reuse) and match
@@ -216,10 +218,14 @@ npm run test:ci                           # the entire CI gate, in one command (
 npm audit --audit-level=moderate          # the dependency-review job's local equivalent
 ```
 
-`npm run test:ci` runs, and must pass, **all of**: `actionlint`, `db:migrations:check`, `typecheck`,
-`test:coverage`, `test:workers`, `build:mcp`, `test:mcp-pack`, `ui:openapi:check`, `ui:version-audit`,
-`ui:lint`, `ui:typecheck`, `ui:test`, `ui:build`. If any step fails, fix it and re-run — do not push a
-red tree. (Full per-check table in `reference.md`.)
+`npm run test:ci` runs, and must pass, **all of**: `actionlint`, `db:migrations:check`,
+`db:schema-drift:check`, `selfhost:env-reference:check`, `selfhost:validate-observability`,
+`cf-typegen:check`, `typecheck`, `test:coverage`, `test:workers`, `build:mcp`, `test:mcp-pack`,
+`build:miner`, `test:miner-pack`, `rees:test`, `ui:openapi:check`, `ui:openapi:settings-parity`,
+`ui:version-audit`, `docs:drift-check`, `command-reference:check`, `ui:lint`, `ui:typecheck`,
+`ui:test`, `ui:build`. If any step fails, fix it and re-run — do not push a red tree. (Full
+per-check table in `reference.md`; check `package.json`'s own `test:ci` script if this list and
+that script ever disagree — the script is the source of truth.)
 
 If `ui:lint` fails on formatting, run `npm --workspace @jsonbored/gittensory-ui run format`. If
 `ui:openapi:check` fails, you forgot Phase 4's `ui:openapi`.

--- a/.claude/skills/contributing-to-gittensory/reference.md
+++ b/.claude/skills/contributing-to-gittensory/reference.md
@@ -27,14 +27,22 @@ path filter matched; on push to `main`, everything runs.
 | lint → actionlint | workflow lint | `npm run actionlint` | any `.github/workflows/*.yml` violation |
 | lint → migrations | migration guard | `npm run db:migrations:check` | duplicate/gap/misnamed migration number |
 | lint → cf-typegen | worker types drift | `npm run cf-typegen:check` | committed `worker-configuration.d.ts` is stale (run `npm run cf-typegen`) |
+| lint → schema-drift | `src/db/schema.ts` vs `migrations/` | `npm run db:schema-drift:check` | a Drizzle table's schema doesn't match the migration history |
+| lint → selfhost-env-reference | self-host env-var doc drift | `npm run selfhost:env-reference:check` | committed `apps/gittensory-ui/src/lib/selfhost-env-reference.ts` is stale (run `npm run selfhost:env-reference`) — triggers on ANY edit to `src/selfhost/**` (+ a few other scanned files) that adds/removes an env var read OR just shifts line numbers of an existing one, since the doc embeds `file:line` citations |
+| lint → observability | Grafana/Prometheus/alert config validation | `npm run selfhost:validate-observability` | a self-host observability config (dashboard/rule/datasource) is malformed |
 | lint → typecheck | `tsc --noEmit` | `npm run typecheck` | any backend type error |
 | test (1/2) | sharded vitest + coverage | `npm run test:coverage` (unsharded) | any failing `test/**/*.test.ts` (excl. `test/workers/**`) |
 | workers | workers-pool vitest | `npm run test:workers` | any failing `test/workers/**` |
 | mcp → build | MCP pkg build | `npm run build:mcp` | MCP package build error |
 | mcp → pack | tarball hygiene | `npm run test:mcp-pack` | unexpected/forbidden file or stale README in the npm tarball |
+| miner → build | miner engine/pkg build | `npm run build:miner` | `@jsonbored/gittensory-{engine,miner}` build error |
+| miner → pack | tarball hygiene | `npm run test:miner-pack` | unexpected/forbidden file in the miner npm tarball |
+| rees → test | review-enrichment-service's own suite | `npm run rees:test` | any failing test under `review-enrichment/` |
 | ui → openapi drift | spec check | `npm run ui:openapi:check` | committed `openapi.json` is stale (run `npm run ui:openapi`) |
 | ui → openapi settings-parity | schema/type structural diff | `npm run ui:openapi:settings-parity` | `RepositorySettingsSchema` (src/openapi/schemas.ts) is missing a field the `RepositorySettings` type has |
 | ui → version audit | MCP version copy | `npm run ui:version-audit` | stale MCP version strings / non-`@latest` install copy (hits npm registry) |
+| docs → drift | doc/code claim checker | `npm run docs:drift-check` | a doc makes a claim the mechanical lint can verify is now false |
+| docs → command-reference | generated CLI reference drift | `npm run command-reference:check` | committed command-reference doc is stale (run `npm run command-reference`) |
 | ui → lint | `eslint .` (UI) | `npm run ui:lint` | ESLint **incl. Prettier formatting** + design-token rules |
 | ui → typecheck | `tsc --noEmit` (UI) | `npm run ui:typecheck` | UI type error |
 | ui → tests | vitest jsdom (UI) | `npm run ui:test` | failing UI component test |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,8 +25,10 @@ process evolves — edits to those files improve both Claude Code and Codex.
    Measure coverage **unsharded** with `npm run test:coverage` (CI shards + merges, so a single shard
    under-reports).
 4. **Regenerate and commit generated artifacts:** `npm run ui:openapi` (API/schema changes),
-   `npm run cf-typegen` (wrangler binding/var changes), and a contiguous `migrations/NNNN_*.sql`
-   (DB changes). Stale generated files fail CI.
+   `npm run cf-typegen` (wrangler binding/var changes), `npm run selfhost:env-reference` (any
+   `env.SOMETHING` read added/removed/line-shifted under `src/selfhost/**`), and a contiguous
+   `migrations/NNNN_*.sql` (DB changes). Stale generated files fail CI (see `reference.md`'s full
+   check table for the complete list — `test:ci` runs more drift checks than these three).
 5. **House rules:** Conventional Commits, **no AI/Claude/agent attribution** in commits or PR text;
    no secrets / wallets / hotkeys / trust scores / reward values anywhere; stay inside `wantedPaths`
    and out of `site/`, `CNAME`, `**/lovable/**`; never edit `CHANGELOG.md` in a normal PR.


### PR DESCRIPTION
## Summary
- `.claude/skills/contributing-to-gittensory/{SKILL.md,reference.md}` and `AGENTS.md`'s
  "regenerate generated artifacts" guidance only named `ui:openapi`/`cf-typegen`/migrations.
  `package.json`'s actual `test:ci` script runs eight more checks that weren't documented anywhere
  in the skill: `db:schema-drift:check`, `selfhost:env-reference:check`,
  `selfhost:validate-observability`, `build:miner`, `test:miner-pack`, `rees:test`,
  `docs:drift-check`, `command-reference:check`.
- Added rows for all of them to `reference.md`'s check table, added `selfhost:env-reference` and
  `command-reference` to `SKILL.md`'s artifact-regeneration table, corrected `SKILL.md`'s `test:ci`
  enumeration to match the real script, and pointed `AGENTS.md`'s "five things" #4 at the full list.

## Test plan
- [x] Docs-only change under `.claude/skills/**` and `AGENTS.md`; no `src/**` impact.
- [x] Cross-checked every added command name against `package.json`'s actual script definitions.