### PR TITLE
fix(review): enforce same-head self-close evasion

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -10797,9 +10797,17 @@ async function closeReviewEvasionSelfCloseIfActive(
     );
     return;
   }
-  // Live re-check (#2130-style): the PR's live head/state may have moved since the webhook was ingested.
+  // Live re-check (#2130-style): the PR's live head may have moved since the webhook was ingested.
+  // A legitimate self-close webhook is already closed by definition, so allow that one stale reason only
+  // when GitHub still reports the same head SHA we started reviewing; every other stale result means the
+  // enforcement justification no longer matches the live PR.
   const freshness = await fetchPullRequestFreshness(env, { installationId, repoFullName, pullNumber: pr.number, expectedHeadSha: pr.headSha });
-  if (freshness.status !== "current") {
+  const sameHeadSelfClosed =
+    freshness.status === "stale" &&
+    freshness.reason === "closed" &&
+    freshness.liveHeadSha !== null &&
+    freshness.liveHeadSha.toLowerCase() === pr.headSha.toLowerCase();
+  if (freshness.status !== "current" && !sameHeadSelfClosed) {
     await recordAuditEvent(env, {
       eventType: REVIEW_EVASION_CLOSED_EVENT_TYPE,
       actor: "gittensory",

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -21744,6 +21744,32 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
       expect(strike?.outcome).toBe("completed");
     });
 
+    it("reopens and re-closes when the live self-closed PR is already closed on the reviewed head", async () => {
+      const calls: Array<{ url: string; method: string }> = [];
+      stubEvasionFetch(calls);
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      await setupEvasionRepo(env);
+      await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", authorLogin: "contributor", deliveryId: "review-start-1" });
+      await repositoriesModule.upsertGlobalModerationConfig(env, { enabled: true, rules: ["review_evasion"] });
+      vi.mocked(fetchPullRequestFreshness).mockResolvedValueOnce({
+        status: "stale",
+        reason: "closed",
+        expectedHeadSha: "abc123",
+        liveHeadSha: "ABC123",
+        liveState: "closed",
+      });
+
+      await processJob(env, { type: "github-webhook", deliveryId: "self-close-live-closed", eventName: "pull_request", payload: closedPayload("contributor") });
+
+      const patches = calls.filter((c) => c.method === "PATCH" && c.url.endsWith("/pulls/42"));
+      expect(patches.length).toBeGreaterThanOrEqual(2); // same-head closed is the normal self-close state: reopen then re-close
+      const audit = await env.DB.prepare("select outcome, detail from audit_events where event_type = ?").bind("github_app.review_evasion_closed").first<{ outcome: string; detail: string }>();
+      expect(audit?.outcome).toBe("completed");
+      expect(await repositoriesModule.hasActiveReviewForHeadSha(env, "JSONbored/gittensory", 42, "abc123")).toBe(false);
+      const strike = await env.DB.prepare("select outcome from audit_events where event_type = ?").bind("moderation.violation.review_evasion").first<{ outcome: string }>();
+      expect(strike?.outcome).toBe("completed");
+    });
+
     it("retries (via a thrown lock-contended error) when a concurrent delivery already holds the per-PR actuation lock", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
@@ -21922,13 +21948,13 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
       expect(audit?.detail).toContain("pull_requests: write not granted");
     });
 
-    it("denies enforcement when live PR state has moved since the webhook was received", async () => {
+    it("denies enforcement when the closed live PR is not on the reviewed head", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls);
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
       await setupEvasionRepo(env);
       await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
-      vi.mocked(fetchPullRequestFreshness).mockResolvedValueOnce({ status: "stale", reason: "head_changed", expectedHeadSha: "abc123", liveHeadSha: "def456", liveState: "closed" });
+      vi.mocked(fetchPullRequestFreshness).mockResolvedValueOnce({ status: "stale", reason: "closed", expectedHeadSha: "abc123", liveHeadSha: "def456", liveState: "closed" });
 
       await processJob(env, { type: "github-webhook", deliveryId: "self-close-stale", eventName: "pull_request", payload: closedPayload("contributor") });
 


### PR DESCRIPTION
### Motivation
- A contributor self-close during an active review was escaping enforcement because the freshness check returned non-current for a legitimately closed PR and the handler returned before reopening and re-closing. 
- The intent is to enforce review-evasion when the live PR is closed but still matches the reviewed head SHA, while continuing to deny enforcement for genuinely mismatched or otherwise stale live states.

### Description
- Adjusted the live freshness gate in `src/queue/processors.ts` to allow the single stale reason `closed` when `liveHeadSha` equals the reviewed `headSha` (case-insensitive), and to continue denying enforcement for any other stale result. 
- Retains the existing audit/deny semantics for non-current live states and preserves the error propagation behavior when reopen succeeds but the subsequent re-close fails. 
- Added a regression test covering the closed-but-same-head self-close path and the closed-but-different-head denial path in `test/unit/queue.test.ts`.

### Testing
- Ran `git diff --check` which succeeded locally. 
- Ran the targeted test group with `NO_COLOR=1 npx vitest run test/unit/queue.test.ts -t "self-close during an active review"` and the modified tests passed. 
- Attempted the full gate with `npm run test:ci` but the run hit unrelated long-running / flaky unit-suite timeouts in existing queue/backfill tests and did not complete successfully. 
- Attempted `npm audit --audit-level=moderate` and the registry audit endpoint returned `403 Forbidden`, so the audit step did not complete here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a9279d8b8832cabe67952ef2ee8fe)