### PR TITLE
feat(enrichment): recognize more binary formats (audio/video/disk/ML)

### DIFF
--- a/review-enrichment/src/analyzers/binary-extensions.ts
+++ b/review-enrichment/src/analyzers/binary-extensions.ts
@@ -88,6 +88,22 @@ export const BINARY_FILE_EXTENSIONS = [
   "arrow",
   "orc",
   "msgpack",
+  // More common binary formats: audio/video containers, disk images, and ML artifacts.
+  "m4a",
+  "m4v",
+  "aac",
+  "opus",
+  "wma",
+  "aiff",
+  "flv",
+  "wmv",
+  "iso",
+  "dmg",
+  "pkl",
+  "pickle",
+  "joblib",
+  "tflite",
+  "keras",
 ] as const;
 
 const BINARY_EXT_SET = new Set<string>(BINARY_FILE_EXTENSIONS);

--- a/review-enrichment/test/binary-extensions.test.ts
+++ b/review-enrichment/test/binary-extensions.test.ts
@@ -28,6 +28,13 @@ test("isBinaryFileExtension and BINARY_EXT_RE agree on known binary paths", () =
     "wire/msg.msgpack",
     "native/mod.pyd",
     "build/Release/addon.node",
+    "audio/track.m4a",
+    "audio/sound.opus",
+    "video/clip.flv",
+    "release/app.dmg",
+    "release/image.iso",
+    "models/scaler.pkl",
+    "models/model.tflite",
   ]) {
     const ext = path.slice(path.lastIndexOf(".") + 1);
     assert.equal(isBinaryFileExtension(ext), true, path);


### PR DESCRIPTION
BINARY_FILE_EXTENSIONS covered many formats but missed common audio/video containers (m4a, m4v, aac, opus, wma, aiff, flv, wmv), disk images (iso, dmg), and ML artifacts (pkl, pickle, joblib, tflite, keras) — so a committed file of those types was treated as reviewable source. Adds them + extends the test. rees green (1026).