### PR TITLE
feat(enrichment): allowlist 0.0.0.0 in the hardcoded-URL analyzer

### DIFF
--- a/review-enrichment/src/analyzers/hardcoded-url.ts
+++ b/review-enrichment/src/analyzers/hardcoded-url.ts
@@ -15,7 +15,12 @@ const CONFIG_PATH_RE =
 const HTTP_URL_RE = /https?:\/\/[^\s'"\`<>]+/gi;
 const IP_ENDPOINT_RE = /\b(?:\d{1,3}\.){3}\d{1,3}:\d{1,5}\b/g;
 
-const ALLOWLISTED_HOSTS = new Set(["localhost", "127.0.0.1", "example.com"]);
+const ALLOWLISTED_HOSTS = new Set([
+  "localhost",
+  "127.0.0.1",
+  "0.0.0.0",
+  "example.com",
+]);
 
 function isConfigPath(path: string): boolean {
   return CONFIG_PATH_RE.test(path);

--- a/review-enrichment/test/hardcoded-url.test.ts
+++ b/review-enrichment/test/hardcoded-url.test.ts
@@ -31,6 +31,8 @@ test("detectHardcodedUrl: allowlists localhost, 127.0.0.1, and example.com", () 
   assert.equal(detectHardcodedUrl("fetch('http://127.0.0.1:8080')"), null);
   assert.equal(detectHardcodedUrl("fetch('https://api.example.com/v1')"), null);
   assert.equal(detectHardcodedUrl("fetch('https://docs.staging.example.com')"), null);
+  // 0.0.0.0 is the unspecified/localhost bind address — a placeholder, not a real endpoint.
+  assert.equal(detectHardcodedUrl("fetch('http://0.0.0.0:8080')"), null);
 });
 
 test("detectHardcodedUrl: skips comment and import lines", () => {


### PR DESCRIPTION
ALLOWLISTED_HOSTS treated localhost/127.0.0.1/example.com as placeholders but not 0.0.0.0, the unspecified/localhost bind address — so http://0.0.0.0:PORT (a dev/bind placeholder, not a real endpoint) was flagged as a hardcoded URL. Adds it + extends the allowlist test. rees green (1026).