### PR TITLE
fix(review): skip bytecode and JAR paths in grounding fetch

### DIFF
--- a/src/review/review-grounding.ts
+++ b/src/review/review-grounding.ts
@@ -51,7 +51,7 @@ export interface ReviewGrounding {
 const FILE_CONTENT_BUDGET = 60_000; // total chars inlined across all changed files
 const MAX_SINGLE_FILE = 24_000; // a file larger than this is marked truncated (review it from the diff)
 // Binary / generated / lockfile paths carry no review signal as full text — skip inlining them.
-const SKIP_EXT = /\.(png|jpe?g|gif|webp|avif|bmp|heic|svg|ico|pdf|lock|min\.js|min\.css|map|woff2?|ttf|eot|mp4|webm|zip|gz|tgz|wasm)$/i;
+const SKIP_EXT = /\.(png|jpe?g|gif|webp|avif|bmp|heic|svg|ico|pdf|lock|min\.js|min\.css|map|woff2?|ttf|eot|mp4|webm|zip|gz|tgz|wasm|class|jar|pyc|pyo)$/i;
 
 /** The grounding feature flags (subset of reviewbot's FeatureToggles). */
 export interface GroundingFlags {

--- a/test/unit/review-grounding.test.ts
+++ b/test/unit/review-grounding.test.ts
@@ -161,7 +161,17 @@ describe("review-grounding: fetchFullFileContents (injected FileFetcher, fail-sa
         return "SHOULD_NOT_FETCH";
       },
     };
-    const binary = ["logo.png", "assets/photo.avif", "assets/poster.bmp", "assets/icon.heic", "dist/pkg.tgz"];
+    const binary = [
+      "logo.png",
+      "assets/photo.avif",
+      "assets/poster.bmp",
+      "assets/icon.heic",
+      "dist/pkg.tgz",
+      "build/App.class",
+      "lib/service.jar",
+      "__pycache__/mod.pyc",
+      "gen/stub.pyo",
+    ];
     const out = await fetchFullFileContents(
       { ciGrounding: false, fullFileContext: true },
       "sha",
@@ -173,6 +183,10 @@ describe("review-grounding: fetchFullFileContents (injected FileFetcher, fail-sa
         ["assets/poster.bmp"],
         ["assets/icon.heic"],
         ["dist/pkg.tgz"],
+        ["build/App.class"],
+        ["lib/service.jar"],
+        ["__pycache__/mod.pyc"],
+        ["gen/stub.pyo"],
         ["old.ts", "removed"],
       ),
       fetcher,


### PR DESCRIPTION
## Summary

- Extend `SKIP_EXT` in `review-grounding.ts` so `fetchFullFileContents` skips Java bytecode (`.class`, `.jar`) and Python bytecode (`.pyc`, `.pyo`) alongside existing binary/lockfile extensions.
- Unit test records `getFileContent` calls and asserts these paths are **never requested** — same proven pattern as #3404.

## Scope

- [x] Conventional Commit title format.
- [x] Focused — review grounding + unit tests only.
- [x] Follows `CONTRIBUTING.md`.
- [x] Small incremental parity fix; no open issue required.

## Validation

- [x] `git diff --check`
- [x] `npm run test:ci` on Node 22
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] Unit test asserts `reads` excludes all binary paths before fetch

## Safety

- [x] No secrets, auth, or UI changes.
- [x] N/A for UI Evidence.

## UI Evidence

N/A — backend review grounding only.

## Notes

**Conflict avoidance:** Touches only `src/review/review-grounding.ts` and `test/unit/review-grounding.test.ts`. Zero overlap with open PRs (#3580 path-matchers Java gRPC, #3585 enrichment binary-extensions, #3586 hardcoded-URL, #3584/#3582 unused-export, #3577 suggested-change blocks, #3550 manual-review label).

Made with [Cursor](https://cursor.com)