### PR TITLE
feat(enrichment): treat a vendored/ directory as vendored in provenance

### DIFF
--- a/review-enrichment/src/analyzers/provenance.ts
+++ b/review-enrichment/src/analyzers/provenance.ts
@@ -25,7 +25,7 @@ const MAX_FINDINGS = 30; // keep the brief bounded
 // installed-dependency directories — the same vendored case as node_modules — so a committed tree under either
 // is a vendored artifact, not contributor source (mirrors src/signals/path-matchers.ts's vendored classifier).
 const VENDORED_PATH_RE =
-  /(?:^|\/)(?:vendor|vendors|node_modules|bower_components|jspm_packages|third[_-]party)\//;
+  /(?:^|\/)(?:vendor|vendored|vendors|node_modules|bower_components|jspm_packages|third[_-]party)\//;
 // Minified files carry no reviewable source in the diff (effectively vendored).
 const MINIFIED_RE = /\.min\.[cm]?[jt]s$|\.min\.css$/i;
 

--- a/review-enrichment/test/provenance.test.ts
+++ b/review-enrichment/test/provenance.test.ts
@@ -15,7 +15,7 @@ test("classifyAddedFile treats bower_components and jspm_packages as vendored, l
     assert.equal(classifyAddedFile(path), "vendored", path);
   }
   // Existing vendored directories still classify (control).
-  for (const path of ["node_modules/x/index.js", "vendor/foo.rb", "third_party/lib.c", "third-party/lib.c", "vendors/a.js"]) {
+  for (const path of ["node_modules/x/index.js", "vendor/foo.rb", "third_party/lib.c", "third-party/lib.c", "vendors/a.js", "vendored/dep.js"]) {
     assert.equal(classifyAddedFile(path), "vendored", path);
   }
   // Directory-segment anchored: a source file merely NAMED like the dir is not vendored; plain source is null.


### PR DESCRIPTION
provenances VENDORED_PATH_RE says it mirrors src/signals/path-matchers.tss vendored classifier, but that classifier matches a vendored/ directory while provenance did not — so a committed vendored/ tree fell through to ordinary source. Adds vendored to the alternation for parity + extends the test. rees green (1026).