### PR TITLE
feat(enrichment): scan .cxx/.hxx/.hh C++ files for magic numbers

### DIFF
--- a/review-enrichment/src/analyzers/magic-number.ts
+++ b/review-enrichment/src/analyzers/magic-number.ts
@@ -37,6 +37,9 @@ const SOURCE_EXTS = new Set([
   "cpp",
   "h",
   "hpp",
+  "cxx",
+  "hxx",
+  "hh",
 ]);
 
 const NAMED_CONST_RE =

--- a/review-enrichment/test/magic-number.test.ts
+++ b/review-enrichment/test/magic-number.test.ts
@@ -43,6 +43,9 @@ test("isMagicNumberSourcePath: accepts non-test source extensions used by REES a
     "src/app.cpp",
     "src/app.h",
     "src/app.hpp",
+    "src/app.cxx",
+    "src/app.hxx",
+    "src/app.hh",
   ]) {
     assert.equal(isMagicNumberSourcePath(path), true, path);
   }


### PR DESCRIPTION
SOURCE_EXTS included c/cc/cpp/h/hpp but not the equally-standard C++ alternate extensions cxx/hxx/hh, so magic numbers in those files were never flagged (and via the shared source-path gate, hardcoded-URL skipped them too). Adds the three extensions + extends the source-path test. rees green (1026).