### PR TITLE
feat(enrichment): detect console.group/count/dirxml debug leftovers

### DIFF
--- a/review-enrichment/src/analyzers/debug-leftover.ts
+++ b/review-enrichment/src/analyzers/debug-leftover.ts
@@ -11,7 +11,7 @@ const MAX_FINDINGS = 25;
 const MAX_LINE_CHARS = 2000;
 
 const DEBUGGER_RE = /\bdebugger\s*;/;
-const CONSOLE_RE = /\bconsole\s*\.\s*(?:log|debug|info|warn|error|trace|dir|table)\s*\(/;
+const CONSOLE_RE = /\bconsole\s*\.\s*(?:log|debug|info|warn|error|trace|dir|dirxml|table|count|countReset|group|groupCollapsed|groupEnd)\s*\(/;
 const PRINT_RE = /(?<![\w.])print\s*\(/;
 
 /** Classify one added line for a debug leftover, or null. Pure. */

--- a/review-enrichment/test/debug-leftover.test.ts
+++ b/review-enrichment/test/debug-leftover.test.ts
@@ -16,6 +16,11 @@ test("detectDebugLeftover: recognizes debugger, console sinks, and print()", () 
   assert.equal(detectDebugLeftover("  debugger;"), "debugger");
   assert.equal(detectDebugLeftover("console.log('hi')"), "console");
   assert.equal(detectDebugLeftover("  console.debug(state)"), "console");
+  // Additional console inspection/debug sinks left in code.
+  assert.equal(detectDebugLeftover("console.group('scope')"), "console");
+  assert.equal(detectDebugLeftover("  console.groupCollapsed('x')"), "console");
+  assert.equal(detectDebugLeftover("console.count('hits')"), "console");
+  assert.equal(detectDebugLeftover("console.dirxml(node)"), "console");
   assert.equal(detectDebugLeftover("print('debug')", "lib/b.py"), "print");
 });
 


### PR DESCRIPTION
CONSOLE_RE caught log/debug/info/warn/error/trace/dir/table but not the other inspection/debug sinks console.group/groupCollapsed/groupEnd/count/countReset/dirxml — so those left-in debug calls slipped through. Adds them + extends the test. rees green (1026).