### PR TITLE
fix(review): skip bytecode paths in grounding and diff priority

### DIFF
--- a/src/review/review-diff.ts
+++ b/src/review/review-diff.ts
@@ -20,7 +20,7 @@ export const DEFAULT_DIFF_BUDGET = 80_000;
  *  Cypress/Playwright `.cy`/`.e2e`, a bare `spec/` dir), so those tests were ranked as SOURCE(0) and
  *  could displace real source under a tight budget — the exact opposite of this function's job. */
 export function diffFilePriority(path: string): number {
-  if (/(^|\/)(package-lock\.json|npm-shrinkwrap\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lock|bun\.lockb|cargo\.lock|poetry\.lock|pipfile\.lock|composer\.lock|gemfile\.lock|go\.sum|go\.work\.sum|uv\.lock|packages\.lock\.json|flake\.lock|deno\.lock|pubspec\.lock|podfile\.lock|mix\.lock|package\.resolved|gradle\.lockfile|pdm\.lock|conan\.lock|pixi\.lock|cartfile\.resolved|gopkg\.lock|shard\.lock|rebar\.lock|renv\.lock|chart\.lock)$|\.(min\.(js|css)|map|snap)$/i.test(path)) return 4;
+  if (/(^|\/)(package-lock\.json|npm-shrinkwrap\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lock|bun\.lockb|cargo\.lock|poetry\.lock|pipfile\.lock|composer\.lock|gemfile\.lock|go\.sum|go\.work\.sum|uv\.lock|packages\.lock\.json|flake\.lock|deno\.lock|pubspec\.lock|podfile\.lock|mix\.lock|package\.resolved|gradle\.lockfile|pdm\.lock|conan\.lock|pixi\.lock|cartfile\.resolved|gopkg\.lock|shard\.lock|rebar\.lock|renv\.lock|chart\.lock)$|\.(min\.(js|css)|map|snap|class|jar|pyc|pyo)$/i.test(path)) return 4;
   if (/(^|\/)(dist|build|out|coverage|vendor|node_modules)\//i.test(path)) return 4;
   if (/\.(md|mdx|markdown|rst|adoc|asciidoc|txt)$/i.test(path)) return 2;
   if (isTestPath(path)) return 1;

--- a/src/review/review-grounding.ts
+++ b/src/review/review-grounding.ts
@@ -51,7 +51,7 @@ export interface ReviewGrounding {
 const FILE_CONTENT_BUDGET = 60_000; // total chars inlined across all changed files
 const MAX_SINGLE_FILE = 24_000; // a file larger than this is marked truncated (review it from the diff)
 // Binary / generated / lockfile paths carry no review signal as full text — skip inlining them.
-const SKIP_EXT = /\.(png|jpe?g|gif|webp|avif|bmp|heic|svg|ico|pdf|lock|min\.js|min\.css|map|woff2?|ttf|eot|mp4|webm|zip|gz|tgz|wasm)$/i;
+const SKIP_EXT = /\.(png|jpe?g|gif|webp|avif|bmp|heic|svg|ico|pdf|lock|min\.js|min\.css|map|woff2?|ttf|eot|mp4|webm|zip|gz|tgz|wasm|class|jar|pyc|pyo)$/i;
 
 /** The grounding feature flags (subset of reviewbot's FeatureToggles). */
 export interface GroundingFlags {

--- a/src/review/review-grounding.ts
+++ b/src/review/review-grounding.ts
@@ -110,7 +110,7 @@ export function buildGrounding(f: GroundingFlags, checks?: CheckAggregate, fileC
  *  copy missed pytest `test_*.py`, Go `*_test.go`, Ruby `*_spec.rb`, Cypress/Playwright `.cy`/`.e2e`, and a
  *  bare `spec/` dir — so those tests ranked as SOURCE(0) and were inlined ahead of real source). */
 export function diffFilePriority(path: string): number {
-  if (/(^|\/)(package-lock\.json|npm-shrinkwrap\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lock|bun\.lockb|cargo\.lock|poetry\.lock|pipfile\.lock|composer\.lock|gemfile\.lock|go\.sum|go\.work\.sum|uv\.lock|packages\.lock\.json|flake\.lock|deno\.lock|pubspec\.lock|podfile\.lock|mix\.lock|package\.resolved|gradle\.lockfile|pdm\.lock|conan\.lock|pixi\.lock|cartfile\.resolved|gopkg\.lock|shard\.lock|rebar\.lock|renv\.lock|chart\.lock)$|\.(min\.(js|css)|map|snap)$/i.test(path)) return 4;
+  if (/(^|\/)(package-lock\.json|npm-shrinkwrap\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lock|bun\.lockb|cargo\.lock|poetry\.lock|pipfile\.lock|composer\.lock|gemfile\.lock|go\.sum|go\.work\.sum|uv\.lock|packages\.lock\.json|flake\.lock|deno\.lock|pubspec\.lock|podfile\.lock|mix\.lock|package\.resolved|gradle\.lockfile|pdm\.lock|conan\.lock|pixi\.lock|cartfile\.resolved|gopkg\.lock|shard\.lock|rebar\.lock|renv\.lock|chart\.lock)$|\.(min\.(js|css)|map|snap|class|jar|pyc|pyo)$/i.test(path)) return 4;
   if (/(^|\/)(dist|build|out|coverage|vendor|node_modules)\//i.test(path)) return 4;
   if (/\.(md|mdx|markdown|rst|adoc|asciidoc|txt)$/i.test(path)) return 2;
   if (isTestPath(path)) return 1;

--- a/test/unit/review-diff.test.ts
+++ b/test/unit/review-diff.test.ts
@@ -18,6 +18,13 @@ describe("diffFilePriority — source survives, noise drops first", () => {
     }
   });
 
+  it("ranks bytecode and archive artifacts as noise(4), not source(0)", () => {
+    for (const path of ["build/App.class", "lib/service.jar", "__pycache__/mod.pyc", "gen/stub.pyo"]) {
+      expect(diffFilePriority(path)).toBe(4);
+      expect(diffFilePriority(path)).toBeGreaterThan(diffFilePriority("src/a.ts"));
+    }
+  });
+
   it("ranks every path-matchers lockfile as noise(4), not source(0)", () => {
     for (const path of ["bun.lock", "uv.lock", "deno.lock", "flake.lock", "mix.lock", "chart.lock"]) {
       expect(diffFilePriority(path)).toBe(4);

--- a/test/unit/review-grounding.test.ts
+++ b/test/unit/review-grounding.test.ts
@@ -161,7 +161,17 @@ describe("review-grounding: fetchFullFileContents (injected FileFetcher, fail-sa
         return "SHOULD_NOT_FETCH";
       },
     };
-    const binary = ["logo.png", "assets/photo.avif", "assets/poster.bmp", "assets/icon.heic", "dist/pkg.tgz"];
+    const binary = [
+      "logo.png",
+      "assets/photo.avif",
+      "assets/poster.bmp",
+      "assets/icon.heic",
+      "dist/pkg.tgz",
+      "build/App.class",
+      "lib/service.jar",
+      "__pycache__/mod.pyc",
+      "gen/stub.pyo",
+    ];
     const out = await fetchFullFileContents(
       { ciGrounding: false, fullFileContext: true },
       "sha",
@@ -173,6 +183,10 @@ describe("review-grounding: fetchFullFileContents (injected FileFetcher, fail-sa
         ["assets/poster.bmp"],
         ["assets/icon.heic"],
         ["dist/pkg.tgz"],
+        ["build/App.class"],
+        ["lib/service.jar"],
+        ["__pycache__/mod.pyc"],
+        ["gen/stub.pyo"],
         ["old.ts", "removed"],
       ),
       fetcher,

--- a/test/unit/review-grounding.test.ts
+++ b/test/unit/review-grounding.test.ts
@@ -102,6 +102,13 @@ describe("review-grounding: diffFilePriority (source survives the budget first)"
     expect(diffFilePriority("src/a.ts")).toBeLessThan(diffFilePriority("README.md"));
   });
 
+  it("ranks bytecode and archive artifacts as noise(4), not source(0)", () => {
+    for (const path of ["build/App.class", "lib/service.jar", "__pycache__/mod.pyc", "gen/stub.pyo"]) {
+      expect(diffFilePriority(path)).toBe(4);
+      expect(diffFilePriority(path)).toBeGreaterThan(diffFilePriority("src/a.ts"));
+    }
+  });
+
   it("ranks every path-matchers lockfile as noise(4), not source(0)", () => {
     for (const path of ["bun.lock", "uv.lock", "deno.lock", "flake.lock", "mix.lock", "chart.lock"]) {
       expect(diffFilePriority(path)).toBe(4);


### PR DESCRIPTION
## Summary

- Extend `SKIP_EXT` in `review-grounding.ts` so `fetchFullFileContents` skips Java bytecode (`.class`, `.jar`) and Python bytecode (`.pyc`, `.pyo`).
- Align `diffFilePriority` in `review-grounding.ts` and `review-diff.ts` so those paths rank as noise(4) under a tight diff budget — same tier as lockfiles/minified/source maps.
- Unit tests record `getFileContent` calls and assert bytecode paths are **never requested**, plus direct `diffFilePriority` assertions for all four extensions.

Fixes #561

## Scope

- [x] Conventional Commit title format.
- [x] Focused — review grounding/diff + unit tests only.
- [x] Follows `CONTRIBUTING.md`.
- [x] Linked issue for traceability (incremental slop/review-signal hygiene under the #561 epic).

## Validation

- [x] `git diff --check`
- [x] `npm run test:ci` on Node 22
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] Unit tests cover SKIP_EXT fetch skip + diffFilePriority noise ranking

## Safety

- [x] No secrets, auth, or UI changes.
- [x] N/A for UI Evidence.

## UI Evidence

N/A — backend review grounding only.

## Notes

**Conflict avoidance:** Touches only `src/review/review-grounding.ts`, `src/review/review-diff.ts`, and their unit tests. Zero overlap with open PRs (#3580 path-matchers Java gRPC, #3585 enrichment binary-extensions, #3586 hardcoded-URL, #3584/#3582 unused-export, #3577 suggested-change blocks, #3550 manual-review label).

Supersedes closed #3588 (same change; added linked issue + diffFilePriority parity per bot review).

Made with [Cursor](https://cursor.com)