### PR TITLE
test(enrichment): directly cover parseCompleteCatchLine binding/body contract

### DIFF
--- a/review-enrichment/test/error-swallow.test.ts
+++ b/review-enrichment/test/error-swallow.test.ts
@@ -3,6 +3,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
   detectErrorSwallow,
+  parseCompleteCatchLine,
   scanErrorSwallow,
   scanPatchForErrorSwallow,
 } from "../dist/analyzers/error-swallow.js";
@@ -32,6 +33,20 @@ test("detectErrorSwallow: brace-balances nested blocks on one line", () => {
 
 test("detectErrorSwallow: flags unused bindings on single-line catches", () => {
   assert.equal(detectErrorSwallow("try { f(); } catch (err) { cleanup(); }"), "unused-binding");
+});
+
+test("parseCompleteCatchLine: returns the binding and the brace-delimited body", () => {
+  assert.deepEqual(parseCompleteCatchLine("catch (e) {}"), { binding: "e", body: "" });
+  assert.deepEqual(parseCompleteCatchLine("catch (err) { log(err) }"), { binding: "err", body: " log(err) " });
+});
+
+test("parseCompleteCatchLine: a binding-less (optional) catch yields a null binding, not the empty string", () => {
+  assert.deepEqual(parseCompleteCatchLine("catch {}"), { binding: null, body: "" });
+});
+
+test("parseCompleteCatchLine: returns null for a non-catch line and for an unbalanced (unclosed) body", () => {
+  assert.equal(parseCompleteCatchLine("if (x) { y(); }"), null); // not a catch
+  assert.equal(parseCompleteCatchLine("catch (e) { doThing();"), null); // never returns to brace depth 0
 });
 
 test("scanPatchForErrorSwallow: flags added lines with correct locations", () => {


### PR DESCRIPTION
## Summary

Adds direct unit coverage for the `error-swallow` analyzer's exported `parseCompleteCatchLine` helper, which had none (it's exercised only indirectly through `detectErrorSwallow`, whose findings-level tests never pin the parser's raw `{ binding, body }` output). Covers:

- **binding + body extraction** — `catch (e) {}` → `{ binding: "e", body: "" }`, and a non-empty body is returned verbatim between the braces
- **binding-less (optional) catch** — `catch {}` → `binding: null` (distinct from an empty-string binding)
- **null returns** — a non-catch line, and an unbalanced/unclosed body (never returns to brace depth 0)

Test-only, against the compiled `dist/`, in the analyzer's own test file. No source or shared-registry change.

_No linked issue — direct-unit coverage of a previously-untested exported pure helper; no runtime behavior change._

## Scope
- [x] Conventional Commit; focused; touches only `review-enrichment/test/error-swallow.test.ts`. No `site/`/`CNAME`/`**/lovable/**`; no `CHANGELOG.md`.

## Validation
- [x] `npm --prefix review-enrichment test` — full suite green (build + sourcemap validate + `metadata --check` + node tests; exactly CI). Each assertion was traced through `parseCompleteCatchLine` and confirmed.
- [x] `git diff --check` clean.

## Safety
- [x] Test-only, no runtime change. No secrets/wallets/hotkeys/trust/reward terms.
