### PR TITLE
fix(signals): classify Java gRPC service stubs as generated

### DIFF
--- a/src/signals/path-matchers.ts
+++ b/src/signals/path-matchers.ts
@@ -56,11 +56,13 @@ function isGeneratedFileFrom(parts: NormalizedPath): boolean {
     // the Elixir plugin emits `.pb.ex`, the Erlang gpb plugin emits `.pb.erl` / `.pb.hrl`, the Crystal
     // plugin emits `.pb.cr`, the Haskell plugin emits `.pb.hs`, and the Objective-C plugin emits
     // `.pbobjc.{h,m}` plus gRPC `.pbrpc.{h,m}` service stubs. Swift gRPC emits sibling `.grpc.swift`
-    // service stubs; grpc-kotlin emits sibling `*GrpcKt.kt` coroutine service stubs.
+    // service stubs; grpc-kotlin emits sibling `*GrpcKt.kt` coroutine service stubs; grpc-java emits
+    // sibling `*Grpc.java` service stubs.
     // `.pb.dart`/`.pb.kt`/`.pb.cs` (the `.pb` infix keeps hand-written sources from matching).
     /\.pb\.(go|ts|js|cc|h|swift|dart|kt|cs|rs|ex|erl|hrl|cr|hs)$/.test(norm) ||
     /\.grpc\.swift$/.test(norm) ||
     /grpckt\.kt$/.test(norm) ||
+    /grpc\.java$/.test(norm) ||
     /\.pbobjc\.(h|m)$/.test(norm) ||
     /\.pbrpc\.(h|m)$/.test(norm) ||
     // Python protobuf: message stubs are `*_pb2.py[i]`; the gRPC plugin emits sibling

--- a/test/unit/path-matchers.test.ts
+++ b/test/unit/path-matchers.test.ts
@@ -144,6 +144,12 @@ describe("isGeneratedFile", () => {
     expect(classifyChangedFile("gen/GreeterGrpcKt.kt")).toBe("generated");
   });
 
+  it("matches Java gRPC service stubs alongside the other protoc plugins", () => {
+    expect(isGeneratedFile("gen/GreeterGrpc.java")).toBe(true);
+    expect(isGeneratedFile("src/Greeter.java")).toBe(false);
+    expect(classifyChangedFile("gen/GreeterGrpc.java")).toBe("generated");
+  });
+
   it("matches JavaScript and TypeScript grpc-node protobuf stubs alongside the other protoc plugins", () => {
     expect(isGeneratedFile("gen/service_pb.js")).toBe(true);
     expect(isGeneratedFile("gen/service_grpc_pb.js")).toBe(true);
@@ -488,6 +494,7 @@ describe("classifyChangedFile", () => {
       ["gen/service_pb.nim", "generated"],
       ["gen/service_pb.lua", "generated"],
       ["gen/GreeterGrpcKt.kt", "generated"],
+      ["gen/GreeterGrpc.java", "generated"],
       ["gen/service_grpc_pb.js", "generated"],
       ["gen/service_pb.d.ts", "generated"],
       ["vendor/lib.go", "vendored"],


### PR DESCRIPTION
## Summary

Extend `isGeneratedFile` to recognize grpc-java service stubs (`*Grpc.java`), matching the existing Swift `.grpc.swift` and Kotlin `GrpcKt.kt` conventions. Includes positive/negative `isGeneratedFile` / `classifyChangedFile` assertions and a classification-table entry.

Fixes #1957

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an open issue (#1957 changed-files summary depends on accurate `path-matchers` classification).

## Validation

- [x] `git diff --check`
- [x] `npm run test:ci` on Node 22
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] Unit tests cover `isGeneratedFile`, `classifyChangedFile`, and the representative cases table

If any required check was skipped, explain why:

- None skipped.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] No auth, cookie, CORS, GitHub App, Cloudflare, or session changes.
- [x] N/A for UI Evidence.

## UI Evidence

N/A — signals-only change with no visible UI.

## Notes

Incremental **path-matcher parity** for #1957 (group changed files by `source/test/docs/config/generated` via `path-matchers`). Does not deliver the summary-table renderer — only closes a generated-classification gap for grpc-java stubs.

**Conflict avoidance:** Touches only `src/signals/path-matchers.ts` and `test/unit/path-matchers.test.ts`. Zero overlap with open PRs (#3595 pg-queue, #3594 enrichment exhaustiveness-drift).

Made with [Cursor](https://cursor.com)