### PR TITLE
chore(ci): wire gittensory-engine and gittensory-miner path filters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
       uiContract: ${{ steps.filter.outputs.uiContract }}
       mcp: ${{ steps.filter.outputs.mcp }}
       mcpCliHarness: ${{ steps.filter.outputs.mcpCliHarness }}
+      engine: ${{ steps.filter.outputs.engine }}
+      miner: ${{ steps.filter.outputs.miner }}
       rees: ${{ steps.filter.outputs.rees }}
       observability: ${{ steps.filter.outputs.observability }}
     steps:
@@ -86,6 +88,13 @@ jobs:
               - 'packages/gittensory-mcp/**'
               - 'scripts/check-mcp-package.mjs'
               - 'package-lock.json'
+            engine:
+              - 'packages/gittensory-engine/**'
+              - 'package-lock.json'
+            miner:
+              - 'packages/gittensory-miner/**'
+              - 'scripts/check-miner-package.mjs'
+              - 'package-lock.json'
             # 6 of the 7 MCP CLI-cluster test files, and ONLY these 6, are truly self-contained w.r.t. root
             # src/**: verified by direct-import inspection that test/unit/mcp-cli-*.test.ts (5 files) and
             # their shared test/unit/support/mcp-cli-harness.ts import nothing but node:* builtins + vitest,
@@ -125,7 +134,7 @@ jobs:
   validate-code:
     name: validate-code
     needs: changes
-    if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.mcp == 'true' || needs.changes.outputs.rees == 'true' || needs.changes.outputs.ui == 'true' || needs.changes.outputs.observability == 'true' }}
+    if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.mcp == 'true' || needs.changes.outputs.engine == 'true' || needs.changes.outputs.miner == 'true' || needs.changes.outputs.rees == 'true' || needs.changes.outputs.ui == 'true' || needs.changes.outputs.observability == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
@@ -350,6 +359,15 @@ jobs:
       - name: MCP package check
         if: ${{ github.event_name == 'push' || needs.changes.outputs.mcp == 'true' }}
         run: npm run test:mcp-pack
+      - name: Build engine package
+        if: ${{ github.event_name == 'push' || needs.changes.outputs.engine == 'true' }}
+        run: npm run build --workspace @jsonbored/gittensory-engine
+      - name: Build miner CLI
+        if: ${{ github.event_name == 'push' || needs.changes.outputs.miner == 'true' }}
+        run: npm run build:miner
+      - name: Miner package check
+        if: ${{ github.event_name == 'push' || needs.changes.outputs.miner == 'true' }}
+        run: npm run test:miner-pack
       # review-enrichment is not an npm workspace member (its own package-lock.json), so it needs its own
       # cache entry -- same restore/save-after-success pattern and fork/trusted key split as the root
       # install above, for the same reasons.

--- a/test/unit/ci-engine-miner-filters.test.ts
+++ b/test/unit/ci-engine-miner-filters.test.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const CI_PATH = join(process.cwd(), ".github/workflows/ci.yml");
+
+describe("CI engine/miner path filters", () => {
+  it("declares engine and miner filters with package paths", () => {
+    const ci = readFileSync(CI_PATH, "utf8");
+    expect(ci).toMatch(/engine:\s*\n\s*- 'packages\/gittensory-engine\/\*\*'/);
+    expect(ci).toMatch(/miner:\s*\n\s*- 'packages\/gittensory-miner\/\*\*'/);
+    expect(ci).toContain("scripts/check-miner-package.mjs");
+    expect(ci).toContain("needs.changes.outputs.engine");
+    expect(ci).toContain("needs.changes.outputs.miner");
+    expect(ci).toContain("name: Build engine package");
+    expect(ci).toContain("name: Build miner CLI");
+    expect(ci).toContain("name: Miner package check");
+    expect(ci).toContain("npm run build --workspace @jsonbored/gittensory-engine");
+    expect(ci).toContain("npm run build:miner");
+    expect(ci).toContain("npm run test:miner-pack");
+  });
+});


### PR DESCRIPTION
## Summary
- Add `engine` and `miner` path filters to the CI `changes` job
- Run engine build, miner build, and miner pack check when those paths change (or on push to main)
- Extend `validate-code` job gating so engine/miner-only PRs still enter the workflow
- Add a regression test asserting the workflow declares the expected filters and steps

Closes #2297

## Test plan
- [x] `npx vitest run test/unit/ci-engine-miner-filters.test.ts`
- [x] `npm run actionlint`


Made with [Cursor](https://cursor.com)