### PR TITLE
feat(enrichment): flaky-test history annotator analyzer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,7 +69,7 @@ GITTENSORY_REVIEW_ENRICHMENT=false
 # blameLink,approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene
 # pendingReviewRequests,testRatio,migrationSafety,looseRange,terminology,todoMarker,magicNumber
 # conflictMarker,debugLeftover,sizeSmell,floatingPromise,deepNesting,errorSwallow,unsafeAny,a11y
-# i18n,unusedExport,exhaustiveness,commitLint
+# i18n,unusedExport,exhaustiveness,flakyTest,commitLint
 #
 # Profile defaults:
 # fast: dependency,dependencyDiff,lockfileDrift,secret,license,installScript,heavyDependency
@@ -82,14 +82,14 @@ GITTENSORY_REVIEW_ENRICHMENT=false
 # churnHotspot,blameLink,approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch
 # commitHygiene,pendingReviewRequests,testRatio,migrationSafety,looseRange,terminology
 # todoMarker,magicNumber,conflictMarker,debugLeftover,sizeSmell,floatingPromise,deepNesting
-# errorSwallow,unsafeAny,a11y,i18n,unusedExport,exhaustiveness,commitLint
+# errorSwallow,unsafeAny,a11y,i18n,unusedExport,exhaustiveness,flakyTest,commitLint
 # deep: dependency,dependencyDiff,lockfileDrift,secret,license,installScript,heavyDependency
 # hardcodedUrl,actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat
 # commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot
 # blameLink,approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene
 # pendingReviewRequests,testRatio,migrationSafety,looseRange,terminology,todoMarker,magicNumber
 # conflictMarker,debugLeftover,sizeSmell,floatingPromise,deepNesting,errorSwallow,unsafeAny,a11y
-# i18n,unusedExport,exhaustiveness,commitLint
+# i18n,unusedExport,exhaustiveness,flakyTest,commitLint
 # END GENERATED REES ANALYZERS
 
 # Submitter-reputation spend control (internal-only): downgrades new/burst/low-rep

--- a/apps/gittensory-ui/src/lib/rees-analyzers.ts
+++ b/apps/gittensory-ui/src/lib/rees-analyzers.ts
@@ -1169,6 +1169,34 @@ export const REES_ANALYZERS = [
     },
   },
   {
+    name: "flakyTest",
+    title: "Flaky-test history",
+    category: "history",
+    cost: "github-heavy",
+    defaultEnabled: true,
+    profiles: ["balanced", "deep"],
+    requires: ["files", "github-token"],
+    limits: {
+      maxFilesProbed: 6,
+      maxCommitsPerFile: 5,
+      maxCheckRunFetches: 12,
+      windowDays: 30,
+      maxFindings: 25,
+    },
+    docs: {
+      summary:
+        "For test files this PR touches, surfaces recent default-branch CI test-check failures that reference each file.",
+      looksAt:
+        "Changed test paths, then bounded default-branch commits per file and their check-runs (structured output fields only).",
+      reports:
+        "Test file path, failure-event count, and lookback window — never check logs or output text.",
+      network:
+        "Calls GitHub repo, commits, and check-runs APIs with strict fanout caps. Requires GitHub token forwarding for private repos.",
+      notes:
+        "Conservative: only test-named checks whose output references the file; requires at least two failure events in the window. Emits partial status when the probe budget is exhausted.",
+    },
+  },
+  {
     name: "commitLint",
     title: "Conventional-commit subjects",
     category: "quality",

--- a/review-enrichment/analyzer-metadata.json
+++ b/review-enrichment/analyzer-metadata.json
@@ -1322,6 +1322,35 @@
       }
     },
     {
+      "name": "flakyTest",
+      "title": "Flaky-test history",
+      "category": "history",
+      "cost": "github-heavy",
+      "defaultEnabled": true,
+      "profiles": [
+        "balanced",
+        "deep"
+      ],
+      "requires": [
+        "files",
+        "github-token"
+      ],
+      "limits": {
+        "maxFilesProbed": 6,
+        "maxCommitsPerFile": 5,
+        "maxCheckRunFetches": 12,
+        "windowDays": 30,
+        "maxFindings": 25
+      },
+      "docs": {
+        "summary": "For test files this PR touches, surfaces recent default-branch CI test-check failures that reference each file.",
+        "looksAt": "Changed test paths, then bounded default-branch commits per file and their check-runs (structured output fields only).",
+        "reports": "Test file path, failure-event count, and lookback window — never check logs or output text.",
+        "network": "Calls GitHub repo, commits, and check-runs APIs with strict fanout caps. Requires GitHub token forwarding for private repos.",
+        "notes": "Conservative: only test-named checks whose output references the file; requires at least two failure events in the window. Emits partial status when the probe budget is exhausted."
+      }
+    },
+    {
       "name": "commitLint",
       "title": "Conventional-commit subjects",
       "category": "quality",

--- a/review-enrichment/src/analyzers/flaky-test.ts
+++ b/review-enrichment/src/analyzers/flaky-test.ts
@@ -1,0 +1,214 @@
+// Flaky-test history annotator (#2033). For test files a PR touches, probes bounded recent default-branch commit +
+// check-run history and counts CI test-check failures whose output references that file — a signal the change
+// lands on historically flaky coverage. Structured GitHub API fields only in findings (counts + window, never
+// logs). Bounded file/commit/check-run fanout; marks partial status when the probe budget is exhausted. Fail-safe
+// without a token, bad slug, or fetch errors.
+import type {
+  AnalyzerDiagnostics,
+  EnrichRequest,
+  FlakyTestFinding,
+} from "../types.js";
+import type { AnalysisContext } from "../analysis-context.js";
+import { boundedFetchJson } from "../external-fetch.js";
+import { isTestPath } from "./test-ratio.js";
+
+const GITHUB_API = "https://api.github.com";
+const SLUG_RE = /^[A-Za-z0-9._-]+$/;
+const WINDOW_DAYS = 30;
+const WINDOW_LABEL = "30d";
+const MAX_FILES_PROBED = 6;
+const MAX_COMMITS_PER_FILE = 5;
+const MAX_CHECK_RUN_FETCHES = 12;
+const MAX_FINDINGS = 25;
+const MIN_FAILURE_EVENTS = 2;
+const COMMITS_PER_PAGE = 20;
+
+const FAILURE_CONCLUSIONS = new Set(["failure", "timed_out", "cancelled", "action_required"]);
+const TEST_CHECK_RE =
+  /test|jest|vitest|pytest|mocha|rspec|unittest|validate-code|go test|cargo test|npm test|yarn test|pnpm test/i;
+
+interface ScanOptions {
+  signal?: AbortSignal;
+  analysis?: Pick<AnalysisContext, "fetchJson">;
+  diagnostics?: AnalyzerDiagnostics;
+}
+
+interface CommitItem {
+  sha?: string;
+}
+
+interface CheckRunItem {
+  name?: string;
+  status?: string;
+  conclusion?: string | null;
+  output?: { title?: string | null; summary?: string | null; text?: string | null };
+}
+
+interface CheckRunsResponse {
+  check_runs?: CheckRunItem[];
+}
+
+interface RepoInfo {
+  default_branch?: string;
+}
+
+function githubHeaders(token: string): Record<string, string> {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+}
+
+function markPartial(diagnostics: AnalyzerDiagnostics | undefined, reason: string): void {
+  if (!diagnostics) return;
+  diagnostics.partialStatus = "partial";
+  diagnostics.partialReason ??= reason;
+}
+
+/** True when a check-run name looks like a test/CI test job rather than lint/build-only. Pure. */
+export function isTestCheckName(name: string): boolean {
+  return TEST_CHECK_RE.test(name);
+}
+
+/** True when structured check-run output references the test file path or its basename. Pure. */
+export function referencesTestFile(
+  output: { title?: string | null; summary?: string | null; text?: string | null } | undefined,
+  filePath: string,
+): boolean {
+  if (!output) return false;
+  const haystack = `${output.title ?? ""}\n${output.summary ?? ""}\n${output.text ?? ""}`;
+  if (haystack.includes(filePath)) return true;
+  const base = filePath.split("/").pop() ?? filePath;
+  if (base && haystack.includes(base)) return true;
+  const stem = base.replace(/\.[^.]+$/, "");
+  return Boolean(stem && stem.length >= 3 && haystack.includes(stem));
+}
+
+/** Count completed test-check failures on one commit's runs that reference `filePath`. Pure. */
+export function countCommitTestFailures(runs: CheckRunItem[], filePath: string): number {
+  let failures = 0;
+  for (const run of runs) {
+    if (run.status !== "completed" || !run.name || !run.conclusion) continue;
+    if (!FAILURE_CONCLUSIONS.has(run.conclusion)) continue;
+    if (!isTestCheckName(run.name)) continue;
+    if (!referencesTestFile(run.output, filePath)) continue;
+    failures += 1;
+  }
+  return failures;
+}
+
+async function fetchJson<T>(
+  url: string,
+  token: string,
+  fetchFn: typeof fetch,
+  options: ScanOptions,
+  endpointCategory: string,
+  phase: string,
+  subcall: string,
+  maxCallsPerCategory?: number,
+): Promise<T | null> {
+  const fetchOptions = {
+    endpointCategory,
+    headers: githubHeaders(token),
+    signal: options.signal,
+    fetchImpl: fetchFn,
+    diagnostics: options.diagnostics,
+    phase,
+    subcall,
+    maxBytes: 512 * 1024,
+    maxCallsPerCategory,
+  };
+  const response = options.analysis
+    ? await options.analysis.fetchJson<T>(url, fetchOptions)
+    : await boundedFetchJson<T>(url, fetchOptions);
+  return response.ok ? response.data : null;
+}
+
+/** Analyzer entrypoint. Fail-safe — returns no finding without a token or on fetch errors. */
+export async function scanFlakyTest(
+  req: EnrichRequest,
+  fetchFn: typeof fetch = fetch,
+  options: ScanOptions = {},
+): Promise<FlakyTestFinding[]> {
+  const { repoFullName, githubToken, files = [] } = req;
+  if (!githubToken) return [];
+  const parts = repoFullName.split("/");
+  if (parts.length !== 2) return [];
+  const [owner, repo] = parts;
+  if (!owner || !repo || !SLUG_RE.test(owner) || !SLUG_RE.test(repo)) return [];
+
+  const testPaths = [...new Set(files.filter((f) => isTestPath(f.path)).map((f) => f.path))].slice(
+    0,
+    MAX_FILES_PROBED,
+  );
+  if (!testPaths.length) return [];
+
+  const repoInfo = await fetchJson<RepoInfo>(
+    `${GITHUB_API}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`,
+    githubToken,
+    fetchFn,
+    options,
+    "github-repo-info",
+    "flaky-test",
+    "default-branch",
+    1,
+  );
+  const defaultBranch = repoInfo?.default_branch;
+  if (!defaultBranch) return [];
+
+  const since = new Date(Date.now() - WINDOW_DAYS * 86_400_000).toISOString();
+  const findings: FlakyTestFinding[] = [];
+  let checkRunFetches = 0;
+  let capped = false;
+
+  for (const path of testPaths) {
+    if (options.signal?.aborted) break;
+    if (findings.length >= MAX_FINDINGS) break;
+
+    const commits = await fetchJson<CommitItem[]>(
+      `${GITHUB_API}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/commits` +
+        `?sha=${encodeURIComponent(defaultBranch)}&path=${encodeURIComponent(path)}` +
+        `&since=${encodeURIComponent(since)}&per_page=${COMMITS_PER_PAGE}`,
+      githubToken,
+      fetchFn,
+      options,
+      "github-commits",
+      "flaky-test",
+      "file-commits",
+      MAX_FILES_PROBED,
+    );
+    if (!commits?.length) continue;
+
+    let failureEvents = 0;
+    for (const commit of commits.slice(0, MAX_COMMITS_PER_FILE)) {
+      if (!commit.sha) continue;
+      if (checkRunFetches >= MAX_CHECK_RUN_FETCHES) {
+        capped = true;
+        break;
+      }
+      checkRunFetches += 1;
+      const checkData = await fetchJson<CheckRunsResponse>(
+        `${GITHUB_API}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/commits/` +
+          `${encodeURIComponent(commit.sha)}/check-runs?per_page=100&filter=all`,
+        githubToken,
+        fetchFn,
+        options,
+        "github-check-runs",
+        "flaky-test",
+        "commit-check-runs",
+        MAX_CHECK_RUN_FETCHES,
+      );
+      const runs = checkData?.check_runs ?? [];
+      if (countCommitTestFailures(runs, path) > 0) failureEvents += 1;
+    }
+
+    if (failureEvents >= MIN_FAILURE_EVENTS) {
+      findings.push({ file: path, recentFailures: failureEvents, window: WINDOW_LABEL });
+    }
+    if (capped) break;
+  }
+
+  if (capped) markPartial(options.diagnostics, "flaky_test_probe_cap");
+  return findings;
+}

--- a/review-enrichment/src/analyzers/registry.ts
+++ b/review-enrichment/src/analyzers/registry.ts
@@ -46,6 +46,7 @@ import { scanTyposquat } from "./typosquat.js";
 import { scanUndocumentedExport } from "./undocumented-export.js";
 import { scanUnusedExport } from "./unused-export.js";
 import { scanExhaustivenessDrift } from "./exhaustiveness-drift.js";
+import { scanFlakyTest } from "./flaky-test.js";
 import type {
   AnalyzerDescriptor,
   AnalyzerFn,
@@ -1293,6 +1294,44 @@ export const ANALYZER_DESCRIPTORS = [
       return lines;
     },
     run: (req, { signal }) => scanExhaustivenessDrift(req, fetch, { signal }),
+  }),
+  descriptor({
+    name: "flakyTest",
+    title: "Flaky-test history",
+    category: "history",
+    cost: "github-heavy",
+    defaultEnabled: true,
+    requires: ["files", "github-token"],
+    limits: {
+      maxFilesProbed: 6,
+      maxCommitsPerFile: 5,
+      maxCheckRunFetches: 12,
+      windowDays: 30,
+      maxFindings: 25,
+    },
+    docs: {
+      summary:
+        "For test files this PR touches, surfaces recent default-branch CI test-check failures that reference each file.",
+      looksAt:
+        "Changed test paths, then bounded default-branch commits per file and their check-runs (structured output fields only).",
+      reports: "Test file path, failure-event count, and lookback window — never check logs or output text.",
+      network:
+        "Calls GitHub repo, commits, and check-runs APIs with strict fanout caps. Requires GitHub token forwarding for private repos.",
+      notes:
+        "Conservative: only test-named checks whose output references the file; requires at least two failure events in the window. Emits partial status when the probe budget is exhausted.",
+    },
+    render: (findings, helpers) => {
+      if (!findings.length) return [];
+      const lines = ["### Flaky-test history (recent CI test failures referencing changed tests)"];
+      for (const item of findings) {
+        lines.push(
+          `- ${helpers.safeCodeSpan(item.file)} — ${item.recentFailures} failure event${item.recentFailures === 1 ? "" : "s"} in the last ${helpers.safeCodeSpan(item.window)}`,
+        );
+      }
+      return lines;
+    },
+    run: (req, { signal, analysis, diagnostics }) =>
+      scanFlakyTest(req, fetch, { signal, analysis, diagnostics }),
   }),
   descriptor({
     name: "commitLint",

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -495,6 +495,7 @@ export function renderBrief(
   lines.push(...renderDescriptorSection("i18n", findings.i18n));
   lines.push(...renderDescriptorSection("unusedExport", findings.unusedExport));
   lines.push(...renderDescriptorSection("exhaustiveness", findings.exhaustiveness));
+  lines.push(...renderDescriptorSection("flakyTest", findings.flakyTest));
   lines.push(...renderDescriptorSection("hardcodedUrl", findings.hardcodedUrl));
   lines.push(...renderDescriptorSection("commitLint", findings.commitLint));
 

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -378,6 +378,14 @@ export interface ExhaustivenessFinding {
   consumerFile?: string;
 }
 
+/** A changed test file that appears in recent default-branch CI test-check failure history. Counts only — never
+ *  logs or output text. (#2033) */
+export interface FlakyTestFinding {
+  file: string;
+  recentFailures: number;
+  window: string;
+}
+
 /** A review/approval integrity signal, read from structured PR-reviews API fields only (state, commit_id,
  *  user.login, submitted_at) — never diff/file content. `stale-approval`: the reviewer's latest APPROVED review
  *  predates the PR's current head commit. `self-approval`: the PR author approved their own PR.
@@ -631,6 +639,7 @@ export interface BriefFindings {
   i18n?: I18nFinding[];
   unusedExport?: UnusedExportFinding[];
   exhaustiveness?: ExhaustivenessFinding[];
+  flakyTest?: FlakyTestFinding[];
   hardcodedUrl?: HardcodedUrlFinding[];
   commitLint?: CommitLintFinding[];
 }

--- a/review-enrichment/test/analyzer-registry.test.ts
+++ b/review-enrichment/test/analyzer-registry.test.ts
@@ -57,6 +57,7 @@ const EXPECTED_ANALYZERS = [
   "i18n",
   "unusedExport",
   "exhaustiveness",
+  "flakyTest",
   "commitLint",
 ];
 

--- a/review-enrichment/test/flaky-test.test.ts
+++ b/review-enrichment/test/flaky-test.test.ts
@@ -1,0 +1,164 @@
+// Units for the flaky-test history annotator (#2033). Own file (not enrichment.test.ts) so concurrent analyzer PRs
+// don't collide. All network is mocked. Runs against the compiled dist/.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  isTestCheckName,
+  referencesTestFile,
+  countCommitTestFailures,
+  scanFlakyTest,
+} from "../dist/analyzers/flaky-test.js";
+import { renderBrief } from "../dist/render.js";
+
+const jsonResponse = (body, code = 200) =>
+  new Response(JSON.stringify(body), { status: code });
+
+const req = (files, extra = {}) => ({
+  repoFullName: "octo/repo",
+  prNumber: 1,
+  githubToken: "ghp_test",
+  files,
+  ...extra,
+});
+
+test("isTestCheckName: matches common test job names", () => {
+  assert.equal(isTestCheckName("validate-code"), true);
+  assert.equal(isTestCheckName("jest / unit"), true);
+  assert.equal(isTestCheckName("build"), false);
+});
+
+test("referencesTestFile: matches full path, basename, or stem in structured output", () => {
+  assert.equal(
+    referencesTestFile({ summary: "FAIL src/foo/bar.test.ts" }, "src/foo/bar.test.ts"),
+    true,
+  );
+  assert.equal(referencesTestFile({ title: "bar.test.ts failed" }, "src/foo/bar.test.ts"), true);
+  assert.equal(referencesTestFile({ summary: "unrelated failure" }, "src/foo/bar.test.ts"), false);
+});
+
+test("countCommitTestFailures: counts only failed test checks referencing the file", () => {
+  const runs = [
+    {
+      name: "validate-code",
+      status: "completed",
+      conclusion: "failure",
+      output: { summary: "FAIL src/app.test.ts" },
+    },
+    {
+      name: "build",
+      status: "completed",
+      conclusion: "failure",
+      output: { summary: "src/app.test.ts compile error" },
+    },
+    {
+      name: "jest",
+      status: "completed",
+      conclusion: "success",
+      output: { summary: "src/app.test.ts" },
+    },
+  ];
+  assert.equal(countCommitTestFailures(runs, "src/app.test.ts"), 1);
+});
+
+test("scanFlakyTest: flags a changed test file with repeated recent CI failures", async () => {
+  const fetchFn = async (url) => {
+    if (url.includes("/repos/octo/repo") && !url.includes("/commits")) {
+      return jsonResponse({ default_branch: "main" });
+    }
+    if (url.includes("path=src%2Fapp.test.ts") && !url.includes("/check-runs")) {
+      return jsonResponse([{ sha: "aaa" }, { sha: "bbb" }, { sha: "ccc" }]);
+    }
+    if (url.includes("/check-runs")) {
+      return jsonResponse({
+        check_runs: [
+          {
+            name: "validate-code",
+            status: "completed",
+            conclusion: "failure",
+            output: { summary: "FAIL src/app.test.ts" },
+          },
+        ],
+      });
+    }
+    return new Response("", { status: 404 });
+  };
+  const findings = await scanFlakyTest(
+    req([{ path: "src/app.test.ts", status: "modified" }]),
+    fetchFn,
+  );
+  assert.deepEqual(findings, [{ file: "src/app.test.ts", recentFailures: 3, window: "30d" }]);
+  const brief = renderBrief({ flakyTest: findings }).promptSection;
+  assert.match(brief, /Flaky-test history/i);
+});
+
+test("scanFlakyTest: does not flag when recent test checks are clean", async () => {
+  const fetchFn = async (url) => {
+    if (url.includes("/repos/octo/repo") && !url.includes("/commits")) {
+      return jsonResponse({ default_branch: "main" });
+    }
+    if (url.includes("path=src%2Fclean.test.ts")) {
+      return jsonResponse([{ sha: "aaa" }, { sha: "bbb" }]);
+    }
+    if (url.includes("/check-runs")) {
+      return jsonResponse({
+        check_runs: [
+          {
+            name: "validate-code",
+            status: "completed",
+            conclusion: "success",
+            output: { summary: "ok src/clean.test.ts" },
+          },
+        ],
+      });
+    }
+    return new Response("", { status: 404 });
+  };
+  const findings = await scanFlakyTest(
+    req([{ path: "src/clean.test.ts", status: "modified" }]),
+    fetchFn,
+  );
+  assert.deepEqual(findings, []);
+});
+
+test("scanFlakyTest: marks partial status when the check-run probe cap is hit", async () => {
+  const files = Array.from({ length: 8 }, (_, i) => ({
+    path: `src/t${i}.test.ts`,
+    status: "modified",
+  }));
+  let checkRunCalls = 0;
+  const diagnostics = {};
+  const fetchFn = async (url) => {
+    if (url.includes("/repos/octo/repo") && !url.includes("/commits")) {
+      return jsonResponse({ default_branch: "main" });
+    }
+    if (url.includes("/commits?") && url.includes("path=")) {
+      return jsonResponse([{ sha: "aaa" }, { sha: "bbb" }, { sha: "ccc" }]);
+    }
+    if (url.includes("/check-runs")) {
+      checkRunCalls += 1;
+      return jsonResponse({
+        check_runs: [
+          {
+            name: "validate-code",
+            status: "completed",
+            conclusion: "failure",
+            output: { summary: "FAIL src/t0.test.ts" },
+          },
+        ],
+      });
+    }
+    return new Response("", { status: 404 });
+  };
+  await scanFlakyTest(req(files), fetchFn, { diagnostics });
+  assert.equal(checkRunCalls, 12);
+  assert.equal(diagnostics.partialStatus, "partial");
+  assert.equal(diagnostics.partialReason, "flaky_test_probe_cap");
+});
+
+test("scanFlakyTest: returns no findings without a GitHub token", async () => {
+  const findings = await scanFlakyTest(
+    req([{ path: "src/app.test.ts", status: "modified" }], { githubToken: undefined }),
+    async () => jsonResponse({}),
+  );
+  assert.deepEqual(findings, []);
+});

--- a/src/review/enrichment-analyzer-names.ts
+++ b/src/review/enrichment-analyzer-names.ts
@@ -51,6 +51,7 @@ export const REES_ANALYZER_NAMES = [
   "i18n",
   "unusedExport",
   "exhaustiveness",
+  "flakyTest",
   "commitLint",
 ] as const;
 


### PR DESCRIPTION
## Summary
- Adds `flakyTest` github-heavy analyzer that flags changed test files appearing in recent default-branch CI test-check failure history.
- Probes bounded default-branch commits per test file and their check-runs; counts failure events where structured output references the file (never logs in findings).
- Strict fanout caps with partial status on budget exhaustion; fail-safe without token or fetch errors.

Fixes #2033

## Test plan
- [x] `cd review-enrichment && npm run build && npm run metadata`
- [x] `node --test review-enrichment/test/flaky-test.test.ts review-enrichment/test/analyzer-registry.test.ts`
- [ ] CI green + Gittensory Orb approval


Made with [Cursor](https://cursor.com)