### PR TITLE
test(miner-discovery): AI-policy-map fixture corpus + hard-skip integration test

### DIFF
--- a/test/fixtures/ai-policy/allowed-encourages-ai.md
+++ b/test/fixtures/ai-policy/allowed-encourages-ai.md
@@ -1,0 +1,13 @@
+# AI Usage Policy
+
+We embrace modern tooling. AI-assisted pull requests are welcome here, provided the author
+stands behind the change and it meets our quality bar.
+
+## Our stance
+
+- You are encouraged to use AI assistants to draft, refactor, or document code.
+- You remain responsible for reviewing and understanding everything you submit.
+- Tests and a clear description are required, exactly as they are for any other PR.
+
+We would rather have a well-tested change that had some machine help than a sloppy one that
+did not. Ship good work, however you got there.

--- a/test/fixtures/ai-policy/allowed-silent.md
+++ b/test/fixtures/ai-policy/allowed-silent.md
@@ -1,0 +1,18 @@
+# Contributing
+
+We welcome contributions of all sizes. This guide covers how to get set up and what we
+look for in a pull request.
+
+## Getting started
+
+1. Fork the repository and create a feature branch.
+2. Install dependencies and run the test suite.
+3. Make your change with accompanying tests.
+
+## Pull request checklist
+
+- Keep the diff focused on a single concern.
+- Add or update tests for the behavior you change.
+- Write a clear description explaining the why, not just the what.
+
+We aim to review new pull requests within a few days. Thanks for helping out!

--- a/test/fixtures/ai-policy/ambiguous-mentions-ai-tools.md
+++ b/test/fixtures/ai-policy/ambiguous-mentions-ai-tools.md
@@ -1,0 +1,17 @@
+# Contributing
+
+Please read this guide before opening a pull request.
+
+## Review process
+
+We use AI-assisted code review to triage incoming pull requests and flag common issues early,
+but a human maintainer makes the final call on every change. Mentioning our tooling here does
+not imply any restriction on how you write your own contributions.
+
+## Expectations
+
+- Follow the existing code style.
+- Include tests for new behavior.
+- Be responsive to review feedback.
+
+Automation helps us keep the queue moving; it never merges anything on its own.

--- a/test/fixtures/ai-policy/banned-ai-usage.md
+++ b/test/fixtures/ai-policy/banned-ai-usage.md
@@ -1,0 +1,15 @@
+# AI Usage Policy
+
+This document describes how automated and AI tooling may (and may not) be used when
+contributing to this repository.
+
+## Pull requests
+
+AI-generated PRs are rejected by the maintainers. We have spent too much time triaging
+low-quality machine-authored changes, so any contribution that is produced end-to-end by a
+model will be closed without review.
+
+## What is still allowed
+
+Using an editor with autocomplete for your own work is fine. The line we draw is at whole
+pull requests authored by a model on your behalf.

--- a/test/fixtures/ai-policy/banned-explicit.md
+++ b/test/fixtures/ai-policy/banned-explicit.md
@@ -1,0 +1,16 @@
+# Contributing to Widgets
+
+Thanks for your interest in improving Widgets! We review every pull request by hand and
+value small, well-tested changes.
+
+## Human review only
+
+This project does not accept AI-generated pull requests. No AI-generated pull requests will
+be reviewed or merged, regardless of how well they are formatted. If you use an assistant to
+learn the codebase that is fine, but the code you submit must be understood and written by you.
+
+## Before you open a PR
+
+- Open an issue describing the change.
+- Include tests and a clear description.
+- Keep the diff focused.

--- a/test/unit/ai-policy-map.test.ts
+++ b/test/unit/ai-policy-map.test.ts
@@ -1,0 +1,86 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { resolveAiPolicyVerdict } from "../../packages/gittensory-engine/src/ai-policy-map";
+
+// Fixture-corpus companion to miner-ai-policy-map.test.ts (#2306). The sibling test exercises the
+// scanner with inline strings; this one drives resolveAiPolicyVerdict over real .md documents on disk
+// (varied real-world phrasings of AI-PR bans, plus near-miss non-bans) to prove the verdict is stable
+// against realistic file content, not just hand-tuned one-liners.
+
+const fixtureDir = join(dirname(fileURLToPath(import.meta.url)), "../fixtures/ai-policy");
+
+function readFixture(name: string): string {
+  return readFileSync(join(fixtureDir, name), "utf8");
+}
+
+type DocKind = "AI-USAGE.md" | "CONTRIBUTING.md";
+
+type FixtureCase = {
+  file: string;
+  docKind: DocKind;
+  allowed: boolean;
+  matchedPhrase: string | null;
+};
+
+// The source column mirrors how the fan-out loads each doc: an AI-USAGE.md fixture is passed as
+// { aiUsage, contributing: null }, a CONTRIBUTING.md fixture as { aiUsage: null, contributing }.
+const cases: FixtureCase[] = [
+  {
+    file: "banned-explicit.md",
+    docKind: "CONTRIBUTING.md",
+    allowed: false,
+    matchedPhrase: "no ai-generated pull requests",
+  },
+  {
+    file: "banned-ai-usage.md",
+    docKind: "AI-USAGE.md",
+    allowed: false,
+    matchedPhrase: "ai-generated prs are rejected",
+  },
+  {
+    file: "allowed-silent.md",
+    docKind: "CONTRIBUTING.md",
+    allowed: true,
+    matchedPhrase: null,
+  },
+  {
+    file: "allowed-encourages-ai.md",
+    docKind: "AI-USAGE.md",
+    allowed: true,
+    matchedPhrase: null,
+  },
+  {
+    file: "ambiguous-mentions-ai-tools.md",
+    docKind: "CONTRIBUTING.md",
+    allowed: true,
+    matchedPhrase: null,
+  },
+];
+
+describe("AI policy fixture corpus (#2306)", () => {
+  it.each(cases)(
+    "resolves $file ($docKind) to allowed=$allowed",
+    ({ file, docKind, allowed, matchedPhrase }) => {
+      const content = readFixture(file);
+      const docs =
+        docKind === "AI-USAGE.md"
+          ? { aiUsage: content, contributing: null }
+          : { aiUsage: null, contributing: content };
+
+      expect(resolveAiPolicyVerdict(docs)).toEqual({
+        allowed,
+        matchedPhrase,
+        source: docKind,
+      });
+    },
+  );
+
+  it("denies every banned-* fixture and allows every allowed-*/ambiguous-* fixture", () => {
+    for (const testCase of cases) {
+      const expectedAllowed = !testCase.file.startsWith("banned-");
+      expect(testCase.allowed).toBe(expectedAllowed);
+    }
+  });
+});

--- a/test/unit/opportunity-fanout-ai-policy.test.ts
+++ b/test/unit/opportunity-fanout-ai-policy.test.ts
@@ -1,0 +1,106 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Route the miner's bare "@jsonbored/gittensory-engine" import at the engine source (mirrors
+// miner-opportunity-fanout.test.ts) so the fan-out uses the real resolveAiPolicyVerdict.
+vi.mock("@jsonbored/gittensory-engine", async () => {
+  return import("../../packages/gittensory-engine/src/index");
+});
+
+import { fetchCandidateIssuesWithSummary } from "../../packages/gittensory-miner/lib/opportunity-fanout.js";
+
+const API = "https://api.test";
+
+const fixtureDir = join(dirname(fileURLToPath(import.meta.url)), "../fixtures/ai-policy");
+
+function readFixture(name: string): string {
+  return readFileSync(join(fixtureDir, name), "utf8");
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}) {
+  return Response.json(body, {
+    ...init,
+    headers: {
+      "x-ratelimit-remaining": "42",
+      "x-ratelimit-reset": "1800000000",
+      ...(init.headers ?? {}),
+    },
+  });
+}
+
+function contentResponse(content: string) {
+  return jsonResponse({
+    type: "file",
+    encoding: "base64",
+    content: Buffer.from(content, "utf8").toString("base64"),
+  });
+}
+
+const issue = (number: number) => ({
+  number,
+  title: `Issue ${number}`,
+  labels: ["good first issue"],
+  comments: 1,
+  created_at: "2026-07-01T00:00:00Z",
+  updated_at: "2026-07-01T01:00:00Z",
+  html_url: `https://github.com/acme/allowed/issues/${number}`,
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("opportunity fan-out AI-policy hard-skip (#2306)", () => {
+  // The hard-skip must run as a PRE-FILTER: a repo whose banned AI-USAGE.md/CONTRIBUTING.md yields
+  // allowed === false is dropped BEFORE any per-issue GitHub call for that repo. A banned repo therefore
+  // costs exactly one policy-doc fetch and zero issue-listing quota — never a post-hoc annotation on a
+  // list that was already built by hitting the issues endpoint.
+  it("excludes a banned repo before any per-issue GitHub work, at the cost of one policy fetch", async () => {
+    const bannedPolicy = readFixture("banned-ai-usage.md");
+    const allowedPolicy = readFixture("allowed-silent.md");
+
+    const calls: string[] = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      calls.push(url);
+      // Banned repo declares its AI ban in AI-USAGE.md, which short-circuits before CONTRIBUTING.md.
+      if (url.includes("/repos/acme/banned/contents/AI-USAGE.md")) {
+        return contentResponse(bannedPolicy);
+      }
+      // Any issue listing for the banned repo means the hard-skip failed to pre-filter it.
+      if (url.includes("/repos/acme/banned/issues?")) {
+        throw new Error("banned repo must be hard-skipped before its issues are listed");
+      }
+      // Allowed repo: no AI-USAGE.md, a silent CONTRIBUTING.md, then one open issue.
+      if (url.includes("/repos/acme/allowed/contents/AI-USAGE.md")) return jsonResponse({}, { status: 404 });
+      if (url.includes("/repos/acme/allowed/contents/CONTRIBUTING.md")) return contentResponse(allowedPolicy);
+      if (url.includes("/repos/acme/allowed/issues?")) return jsonResponse([issue(7)]);
+      return jsonResponse({}, { status: 404 });
+    });
+
+    const result = await fetchCandidateIssuesWithSummary(
+      [
+        { owner: "acme", repo: "banned" },
+        { owner: "acme", repo: "allowed" },
+      ],
+      "placeholder-token",
+      { apiBaseUrl: API },
+    );
+
+    // Only the allowed repo's issue survives; the banned repo contributes nothing and no warning.
+    expect(result.issues.map((entry) => entry.repoFullName)).toEqual(["acme/allowed"]);
+    expect(result.issues.map((entry) => entry.issueNumber)).toEqual([7]);
+    expect(result.warnings).toEqual([]);
+
+    // The banned repo cost exactly one GitHub call — its single policy-doc fetch — and no issues call.
+    const bannedCalls = calls.filter((url) => url.includes("/repos/acme/banned/"));
+    expect(bannedCalls).toHaveLength(1);
+    expect(bannedCalls[0]).toContain("/repos/acme/banned/contents/AI-USAGE.md");
+    expect(calls.some((url) => url.includes("/repos/acme/banned/issues?"))).toBe(false);
+
+    // The allowed repo was fanned out normally (policy fetch + issue listing).
+    expect(calls.some((url) => url.includes("/repos/acme/allowed/issues?"))).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds the AI-policy fixture corpus + hard-skip test suite (Closes #2306).

The AI-policy scanner (`resolveAiPolicyVerdict` / `scanAiPolicyText` in `packages/gittensory-engine/src/ai-policy-map.ts`) is exercised today only by inline one-liners in `miner-ai-policy-map.test.ts`. This adds:

- **`test/fixtures/ai-policy/`** — 5 realistic `.md` documents (verified against the real `BAN_PHRASES` list, not guessed): `banned-explicit.md` (CONTRIBUTING with "No AI-generated pull requests…"), `banned-ai-usage.md` (AI-USAGE with "AI-generated PRs are rejected…"), `allowed-silent.md` (normal CONTRIBUTING, no AI mention), `allowed-encourages-ai.md` (welcomes *AI-assisted* PRs — proves no false-positive on "assisted"), and `ambiguous-mentions-ai-tools.md` (neutral AI-tooling mention).
- **`test/unit/ai-policy-map.test.ts`** — a table-driven test reading each fixture from disk and asserting the full `{allowed, matchedPhrase, source}` verdict (AI-USAGE.md fixtures via `{aiUsage, contributing:null}`, CONTRIBUTING.md via `{aiUsage:null, contributing}`), proving the verdict is stable against realistic file content, not just hand-tuned strings. Does not duplicate the sibling inline cases.
- **`test/unit/opportunity-fanout-ai-policy.test.ts`** — a focused integration test proving the AI-policy **hard-skip is a pre-filter**: a banned repo is dropped from the fan-out output **before** any per-issue GitHub call. The fetch stub *throws* if the banned repo's issues endpoint is hit, and the test asserts the banned repo cost exactly one policy-doc fetch and zero issue-listing quota (per the issue's "zero extra API quota" requirement).

Test-only — only `test/fixtures/ai-policy/**` and `test/unit/**` added. No `src/**` / `packages/**` source or shared-registry change.

## Scope
- [x] Conventional Commit; focused; **Closes #2306**; test-only. No `site/`/`CNAME`/`**/lovable/**`; no `CHANGELOG.md`.

## Validation
- [x] `npx vitest run test/unit/ai-policy-map.test.ts test/unit/opportunity-fanout-ai-policy.test.ts` — 7 pass / 0 fail (7 total).
- [x] `npm run typecheck` clean; `git diff --check` clean.

## Safety
- [x] Test-only, no runtime change. No secrets/wallets/hotkeys/trust/reward terms.
