### PR TITLE
fix(selfhost): canonicalize repo-doc refresh repos

### DIFF
--- a/src/github/repo-doc-refresh-runner.ts
+++ b/src/github/repo-doc-refresh-runner.ts
@@ -9,7 +9,7 @@
 // this, matching #3002's own "manifest-only, no DB layer" precedent for this whole feature. The marker is
 // recorded here (not in the sweep itself) so a MANUAL trigger also resets that clock, keeping the sweep from
 // immediately re-checking a repo an operator just refreshed by hand.
-import { getRepositorySettings, listLatestSignalSnapshotsForTargets, listSignalSnapshots, persistSignalSnapshot } from "../db/repositories";
+import { getRepository, getRepositorySettings, listLatestSignalSnapshotsForTargets, listSignalSnapshots, persistSignalSnapshot } from "../db/repositories";
 import { resolveRepoActionMode } from "./client";
 import { openRepoDocPullRequest, type RepoDocPullRequestResult } from "./repo-doc-pr";
 import { nowIso } from "../utils/json";
@@ -52,9 +52,11 @@ async function recordRepoDocRefreshAttempt(env: Env, repoFullName: string): Prom
  * scheduled sweep doesn't re-check this repo again until its own configured interval elapses.
  */
 export async function performRepoDocRefresh(env: Env, repoFullName: string): Promise<RepoDocPullRequestResult> {
-  const settings = await getRepositorySettings(env, repoFullName);
+  const repository = await getRepository(env, repoFullName);
+  const canonicalRepoFullName = repository?.fullName ?? repoFullName;
+  const settings = await getRepositorySettings(env, canonicalRepoFullName);
   const mode = await resolveRepoActionMode(env, settings);
-  const result = await openRepoDocPullRequest(env, repoFullName, mode);
-  await recordRepoDocRefreshAttempt(env, repoFullName);
+  const result = await openRepoDocPullRequest(env, canonicalRepoFullName, mode);
+  await recordRepoDocRefreshAttempt(env, canonicalRepoFullName);
   return result;
 }

--- a/test/unit/repo-doc-refresh-runner.test.ts
+++ b/test/unit/repo-doc-refresh-runner.test.ts
@@ -87,6 +87,15 @@ describe("performRepoDocRefresh (#3003)", () => {
     expect(Number.isFinite(Date.parse(attemptedAt!))).toBe(true);
   });
 
+  it("uses the requested repo name when no installed repository can be canonicalized", async () => {
+    const env = createTestEnv();
+
+    const result = await performRepoDocRefresh(env, "Owner/Missing");
+
+    expect(result).toEqual({ opened: false, reason: "repository is not installed" });
+    expect(await getLastRepoDocRefreshAttemptedAt(env, "Owner/Missing")).not.toBeNull();
+  });
+
   it("records an attempt even when the repo declines (e.g. generation disabled)", async () => {
     const env = envWithKey();
     await upsertRepositoryFromGitHub(env, { name: "widgets", full_name: REPO, private: false, owner: { login: "owner" } }, 555);
@@ -109,5 +118,24 @@ describe("performRepoDocRefresh (#3003)", () => {
     const result = await performRepoDocRefresh(env, REPO);
     expect(result).toEqual({ opened: false, reason: 'repo-doc pull request not opened: action mode is "paused"' });
     expect(tokenMinted).toBe(false);
+  });
+
+  it("uses the stored repository casing for settings before opening repo-doc pull requests", async () => {
+    const env = envWithKey();
+    await seedInstalledEnabledRepo(env);
+    await upsertRepositorySettings(env, { repoFullName: REPO, agentPaused: true });
+    let tokenMinted = false;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (TOKEN_URL.test(url)) tokenMinted = true;
+      return new Response("unexpected", { status: 500 });
+    });
+
+    const result = await performRepoDocRefresh(env, "Owner/Widgets");
+
+    expect(result).toEqual({ opened: false, reason: 'repo-doc pull request not opened: action mode is "paused"' });
+    expect(tokenMinted).toBe(false);
+    expect(await getLastRepoDocRefreshAttemptedAt(env, REPO)).not.toBeNull();
+    expect(await getLastRepoDocRefreshAttemptedAt(env, "Owner/Widgets")).toBeNull();
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent mixed-case owner/repo names from bypassing per-repository pause/dry-run settings when performing on-demand repo-doc refreshes by ensuring the stored repository canonical name is used for settings and write operations.

### Description
- Resolve the stored repository record with `getRepository` and derive a `canonicalRepoFullName` before calling `getRepositorySettings`, `openRepoDocPullRequest`, or recording attempt snapshots in `performRepoDocRefresh` (`src/github/repo-doc-refresh-runner.ts`).
- Import `getRepository` alongside existing DB helpers and use the canonical name for settings lookup, PR-opening, and attempt recording to avoid casing mismatches. 
- Add regression tests in `test/unit/repo-doc-refresh-runner.test.ts` that cover the uninstalled-repo fallback and a mixed-case caller path that must respect the stored `agentPaused` setting.

### Testing
- Ran `npm run typecheck` which succeeded with no TypeScript errors. 
- Ran the targeted unit tests with `npx vitest run test/unit/repo-doc-refresh-runner.test.ts` and all tests in that file passed. 
- Attempted the full local gate with `npm run test:ci`, but the run was interrupted/blocked by unrelated long-running failures/timeouts in existing test suites (`test/unit/queue.test.ts` and `test/unit/backfill.test.ts`) in the local environment, so the full gate was not completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a9279cac0832c810c26bfec0f58e2)