### PR TITLE
fix(webhook): omit repo names from enqueue error logs

### DIFF
--- a/src/github/webhook.ts
+++ b/src/github/webhook.ts
@@ -179,13 +179,13 @@ export async function enqueueWebhookByEnv(env: Env, deliveryId: string, eventNam
     recordWebhookEnqueueMetric(eventName, payload.action, "enqueue_failed");
     // Missing binding is a deploy-ordering defect (the WEBHOOKS queue isn't provisioned yet), not a transient
     // blip — an operator needs to SEE it, not infer it from a metric dip. ERROR level so the central Sentry
-    // forwarder captures it (#1824); repository/installation stay out of the tags (webhook ingest observability).
+    // forwarder captures it (#1824); repository/installation stay out of the forwarded log because
+    // Sentry indexes common repo fields as tags (webhook ingest observability).
     console.error(
       JSON.stringify({
         level: "error",
         event: "selfhost_webhook_enqueue_binding_missing",
         eventName,
-        repository: eventRow.repositoryFullName,
       }),
     );
     return "enqueue_failed";
@@ -205,14 +205,13 @@ export async function enqueueWebhookByEnv(env: Env, deliveryId: string, eventNam
     await recordWebhookEvent(env, { ...eventRow, status: "error" });
     recordWebhookEnqueueMetric(eventName, payload.action, "enqueue_failed");
     // ERROR level so the central Sentry forwarder captures a failing webhook enqueue (#1824) — previously only a
-    // Prometheus counter moved, which an operator would only notice by comparing dashboards. Never logs rawBody or
-    // the parsed payload (secret-scrub boundary); only the delivery's routing metadata.
+    // Prometheus counter moved, which an operator would only notice by comparing dashboards. Never logs rawBody,
+    // parsed payload, or repository/installation metadata (secret-scrub boundary).
     console.error(
       JSON.stringify({
         level: "error",
         event: "selfhost_webhook_enqueue_failed",
         eventName,
-        repository: eventRow.repositoryFullName,
         error: error instanceof Error ? error.message : String(error),
       }),
     );

--- a/test/unit/webhook.test.ts
+++ b/test/unit/webhook.test.ts
@@ -88,7 +88,7 @@ describe("github webhook enqueue failure (#786)", () => {
         return (
           line.includes("selfhost_webhook_enqueue_binding_missing") &&
           line.includes('"eventName":"pull_request"') &&
-          line.includes("JSONbored/gittensory")
+          !line.includes("JSONbored/gittensory")
         );
       }),
     ).toBe(true);
@@ -131,15 +131,15 @@ describe("github webhook enqueue failure (#786)", () => {
     const event = await getWebhookEvent(env, "enqueue-fail-1");
     expect(event?.status).toBe("error");
     expect(await renderMetrics()).toContain('gittensory_webhook_enqueue_total{action="opened",event="pull_request",result="enqueue_failed"} 1');
-    // ERROR level so the central Sentry forwarder captures a failing webhook enqueue (#1824). Never logs rawBody
-    // or the parsed payload -- only delivery routing metadata + the thrown error's message.
+    // ERROR level so the central Sentry forwarder captures a failing webhook enqueue (#1824). Never logs rawBody,
+    // parsed payload, or repository metadata -- only the event kind + the thrown error's message.
     expect(
       errorSpy.mock.calls.some((c) => {
         const line = String(c[0]);
         return (
           line.includes("selfhost_webhook_enqueue_failed") &&
           line.includes('"eventName":"pull_request"') &&
-          line.includes("JSONbored/gittensory") &&
+          !line.includes("JSONbored/gittensory") &&
           line.includes("queue unavailable")
         );
       }),
@@ -184,6 +184,7 @@ describe("github webhook enqueue failure (#786)", () => {
     await handleGitHubWebhook(context);
     const logged = errorSpy.mock.calls.map((c) => String(c[0])).join("\n");
     expect(logged).toContain("selfhost_webhook_enqueue_failed");
+    expect(logged).not.toContain("JSONbored/gittensory");
     expect(logged).not.toContain("raw diff");
     expect(logged).not.toContain("UNIQUE-PAYLOAD-MARKER-THAT-MUST-NEVER-LEAK");
     errorSpy.mockRestore();


### PR DESCRIPTION
### Motivation
- Prevent private repository full names from being forwarded to Sentry tags/titles by removing `repository` from structured enqueue-failure logs so self-host telemetry does not leak repo metadata.

### Description
- Remove `repository: eventRow.repositoryFullName` from the missing-WEBHOOKS-binding and queue-send failure `console.error` JSON payloads in `enqueueWebhookByEnv` and update the corresponding unit tests to assert repository names are not emitted.

### Testing
- Ran `npx vitest run test/unit/webhook.test.ts --reporter=verbose` and the webhook unit tests passed (1 file, 20 tests all green).
- Attempted the full local gate via `git diff --check && npm run test:ci`, but the run did not complete here due to long-running suites and existing unrelated timeouts / failures observed in `test/unit/queue.test.ts` and `test/unit/backfill.test.ts`, so the end-to-end CI gate could not be finalized in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a937adf04832c8c42c3ba4a91f3c4)