### PR TITLE
fix(queue): regate all PRs linked to an issue on issue-side signals

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -4011,12 +4011,12 @@ async function maybeReReviewOnLinkedIssueChange(
   if (isConvergenceRepoAllowed(env, repoFullName)) {
     const openPullRequests = await listOpenPullRequests(env, repoFullName);
     // Issue-side label/assignment changes can flip linked-issue hard-rule verdicts from mergeable to close.
-    // Keep this webhook-triggered wake bounded like the scheduled sweep: each re-gate is REST-expensive, and
-    // queued tail work is picked up by the normal stale-first sweep instead of letting one issue fan out widely.
+    // Wake every linked open PR immediately: silently dropping a tail here can leave stale passing gates on PRs
+    // that now violate deterministic issue hard rules. Stagger the jobs so the expensive re-gates do not run inline
+    // or stampede the queue consumer.
     const linkingPrs = openPullRequests
       .filter((pr) => pr.linkedIssues.includes(issueNumber))
-      .map((pr) => ({ number: pr.number, createdAt: pr.createdAt ?? null }))
-      .slice(0, SWEEP_MAX_PRS);
+      .map((pr) => ({ number: pr.number, createdAt: pr.createdAt ?? null }));
     for (const [index, pr] of linkingPrs.entries()) {
       const prNumber = pr.number;
       if (await issueLinkedPrReReviewCoalesced(env, repoFullName, prNumber)) {

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -2660,7 +2660,7 @@ describe("queue processors", () => {
     ]);
   });
 
-  it("REGRESSION: issue-side linked PR wake caps webhook fanout so one issue cannot flood the queue", async () => {
+  it("REGRESSION: issue-side linked PR wake queues every linked PR so hard-rule changes cannot leave stale passing gates", async () => {
     const sent: Array<{ message: import("../../src/types").JobMessage; options?: QueueSendOptions }> = [];
     const env = createTestEnv({
       GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(),
@@ -2697,13 +2697,13 @@ describe("queue processors", () => {
     });
 
     expect(fetchCount).toBe(0);
-    expect(sent).toHaveLength(SWEEP_MAX_PRS);
+    expect(sent).toHaveLength(SWEEP_MAX_PRS + 2);
     expect(sent.map(({ message }) => message)).toEqual(
-      Array.from({ length: SWEEP_MAX_PRS }, (_, index) =>
+      Array.from({ length: SWEEP_MAX_PRS + 2 }, (_, index) =>
         expect.objectContaining({ type: "agent-regate-pr", repoFullName: "owner/agent-repo", prNumber: index + 1, installationId: 9001 }),
       ),
     );
-    expect(sent.map(({ options }) => options)).toEqual([undefined, { delaySeconds: 10 }, { delaySeconds: 20 }]);
+    expect(sent.map(({ options }) => options)).toEqual([undefined, { delaySeconds: 10 }, { delaySeconds: 20 }, { delaySeconds: 30 }, { delaySeconds: 40 }]);
   });
 
   it("REGRESSION (#2371): a coalesced issue-side signal schedules a trailing re-review so an add-then-remove sequence is never lost", async () => {


### PR DESCRIPTION
### Motivation
- Issue-side label/assignment changes can flip deterministic linked-issue hard rules and must re-evaluate every linked open PR immediately to avoid leaving stale passing gates. 
- A recent change silently capped the webhook fanout to `SWEEP_MAX_PRS`, omitting a tail of linked PRs from immediate re-gating and creating a window where blocked PRs could appear mergeable. 
- The change restores correctness while keeping the webhook work off the inline path by staggering per-PR jobs.

### Description
- Remove the fanout cap in `maybeReReviewOnLinkedIssueChange` so the handler collects every open PR that links the affected issue instead of `.slice(0, SWEEP_MAX_PRS)`, and preserve the existing staggered enqueue delay. 
- Update the handler comment to explain why every linked PR is woken and why jobs remain staggered to avoid stampedes. 
- Update the regression unit test in `test/unit/queue.test.ts` to seed more linked PRs than the old cap and assert that all linked PRs are enqueued with the expected delays and job messages.

### Testing
- Ran `git diff --check` and it reported no whitespace/conflict problems. 
- Ran the focused unit test with `npx vitest run test/unit/queue.test.ts -t "issue-side linked PR wake"` and the updated regression test passed. 
- Ran `npm run typecheck` (`tsc --noEmit`) with no type errors. 
- `npm run test:ci` was started and reached the coverage step but was not completed in the interactive run; full CI should be executed on the CI runner. 
- `npm audit --audit-level=moderate` could not complete in this environment due to the registry audit endpoint returning `403 Forbidden`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a917bdc68832ca18f60f186c327fd)