### PR TITLE
fix(review): require linked issue ownership for label propagation

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -7457,6 +7457,7 @@ async function maybePublishPrPublicSurface(
               repoFullName,
               linkedIssues: pr.linkedIssues,
               installationId,
+              prAuthorLogin: pr.authorLogin,
             })
           : [];
       const decisionResult = resolvePrTypeLabel({

--- a/src/review/linked-issue-label-propagation-fetch.ts
+++ b/src/review/linked-issue-label-propagation-fetch.ts
@@ -38,11 +38,41 @@ export async function fetchLinkedIssueLabelsForPropagation(args: {
   repoFullName: string;
   linkedIssues: number[];
   installationId: number;
+  prAuthorLogin: string | null | undefined;
 }): Promise<string[]> {
   if (args.linkedIssues.length === 0) return [];
   const linkedIssues = args.linkedIssues.slice(0, MAX_LINKED_ISSUES_TO_FETCH);
-  const token = (await createInstallationToken(args.env, args.installationId).catch(() => undefined)) ?? args.env.GITHUB_PUBLIC_TOKEN;
-  const admissionKey = githubRateLimitAdmissionKeyForToken(args.env, token, args.installationId);
-  const results = await Promise.all(linkedIssues.map((issueNumber) => fetchLinkedIssueFacts(args.env, args.repoFullName, issueNumber, token, admissionKey)));
-  return results.flatMap((result) => (result.status === "found" && result.facts.state === "open" ? result.facts.labels : []));
+  const token =
+    (await createInstallationToken(args.env, args.installationId).catch(
+      () => undefined,
+    )) ?? args.env.GITHUB_PUBLIC_TOKEN;
+  const admissionKey = githubRateLimitAdmissionKeyForToken(
+    args.env,
+    token,
+    args.installationId,
+  );
+  const results = await Promise.all(
+    linkedIssues.map((issueNumber) =>
+      fetchLinkedIssueFacts(
+        args.env,
+        args.repoFullName,
+        issueNumber,
+        token,
+        admissionKey,
+      ),
+    ),
+  );
+  return results.flatMap((result) => {
+    if (result.status !== "found" || result.facts.state !== "open") return [];
+    const prAuthorLogin = args.prAuthorLogin?.toLowerCase();
+    if (!prAuthorLogin) return [];
+    const issueAuthorLogin = result.facts.authorLogin?.toLowerCase();
+    const assignees = result.facts.assignees.map((login) =>
+      login.toLowerCase(),
+    );
+    return issueAuthorLogin === prAuthorLogin ||
+      assignees.includes(prAuthorLogin)
+      ? result.facts.labels
+      : [];
+  });
 }

--- a/test/unit/linked-issue-label-propagation-fetch.test.ts
+++ b/test/unit/linked-issue-label-propagation-fetch.test.ts
@@ -9,57 +9,120 @@ describe("fetchLinkedIssueLabelsForPropagation (#priority-linked-issue-gate)", (
     vi.restoreAllMocks();
   });
 
-  function stubFetch(handler: (url: string, method: string) => Response | Promise<Response>) {
-    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => handler(input.toString(), init?.method ?? "GET"));
+  function stubFetch(
+    handler: (url: string, method: string) => Response | Promise<Response>,
+  ) {
+    vi.stubGlobal(
+      "fetch",
+      async (input: RequestInfo | URL, init?: RequestInit) =>
+        handler(input.toString(), init?.method ?? "GET"),
+    );
   }
 
   it("returns [] and fetches nothing when there are no linked issues", async () => {
     const fetchSpy = vi.fn();
     vi.stubGlobal("fetch", fetchSpy);
     const env = createTestEnv({});
-    const result = await fetchLinkedIssueLabelsForPropagation({ env, repoFullName: "owner/repo", linkedIssues: [], installationId: 123 });
+    const result = await fetchLinkedIssueLabelsForPropagation({
+      env,
+      repoFullName: "owner/repo",
+      linkedIssues: [],
+      installationId: 123,
+      prAuthorLogin: "contrib",
+    });
     expect(result).toEqual([]);
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it("returns the flattened labels for a single found linked issue", async () => {
     stubFetch((url) => {
-      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
-      if (url.endsWith("/issues/1")) return Response.json({ number: 1, state: "open", user: { login: "contrib" }, labels: ["gittensor:priority", "help wanted"] });
+      if (url.includes("/access_tokens"))
+        return Response.json({ token: "installation-token" });
+      if (url.endsWith("/issues/1"))
+        return Response.json({
+          number: 1,
+          state: "open",
+          user: { login: "contrib" },
+          labels: ["gittensor:priority", "help wanted"],
+        });
       return new Response("not found", { status: 404 });
     });
     const env = createTestEnv({});
-    const result = await fetchLinkedIssueLabelsForPropagation({ env, repoFullName: "owner/repo", linkedIssues: [1], installationId: 123 });
+    const result = await fetchLinkedIssueLabelsForPropagation({
+      env,
+      repoFullName: "owner/repo",
+      linkedIssues: [1],
+      installationId: 123,
+      prAuthorLogin: "contrib",
+    });
     expect(result).toEqual(["gittensor:priority", "help wanted"]);
   });
 
   it("surfaces only the successful issue's labels when one of several linked issues fails to fetch (partial fail-open)", async () => {
     stubFetch((url) => {
-      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
-      if (url.endsWith("/issues/1")) return Response.json({ number: 1, state: "open", assignees: [{ login: "contrib" }], labels: ["gittensor:priority"] });
-      if (url.endsWith("/issues/2")) return new Response("server error", { status: 500 });
+      if (url.includes("/access_tokens"))
+        return Response.json({ token: "installation-token" });
+      if (url.endsWith("/issues/1"))
+        return Response.json({
+          number: 1,
+          state: "open",
+          assignees: [{ login: "contrib" }],
+          labels: ["gittensor:priority"],
+        });
+      if (url.endsWith("/issues/2"))
+        return new Response("server error", { status: 500 });
       return new Response("not found", { status: 404 });
     });
     const env = createTestEnv({});
-    const result = await fetchLinkedIssueLabelsForPropagation({ env, repoFullName: "owner/repo", linkedIssues: [1, 2], installationId: 123 });
+    const result = await fetchLinkedIssueLabelsForPropagation({
+      env,
+      repoFullName: "owner/repo",
+      linkedIssues: [1, 2],
+      installationId: 123,
+      prAuthorLogin: "contrib",
+    });
     expect(result).toEqual(["gittensor:priority"]);
   });
 
   it("returns [] when every linked issue fails to fetch (fully fail-open — never applies a sensitive label without a verified source)", async () => {
     stubFetch((url) => {
-      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/access_tokens"))
+        return Response.json({ token: "installation-token" });
       return new Response("server error", { status: 500 });
     });
     const env = createTestEnv({});
-    const result = await fetchLinkedIssueLabelsForPropagation({ env, repoFullName: "owner/repo", linkedIssues: [1, 2], installationId: 123 });
+    const result = await fetchLinkedIssueLabelsForPropagation({
+      env,
+      repoFullName: "owner/repo",
+      linkedIssues: [1, 2],
+      installationId: 123,
+      prAuthorLogin: "contrib",
+    });
     expect(result).toEqual([]);
   });
 
   it("falls back to the public token and still fails open (never throws) when the installation-token mint fails", async () => {
-    const spy = vi.spyOn(appModule, "createInstallationToken").mockRejectedValue(new Error("mint failed"));
-    stubFetch((url) => (url.endsWith("/issues/1") ? Response.json({ number: 1, state: "open", user: { login: "contrib" }, labels: ["gittensor:priority"] }) : new Response("not found", { status: 404 })));
+    const spy = vi
+      .spyOn(appModule, "createInstallationToken")
+      .mockRejectedValue(new Error("mint failed"));
+    stubFetch((url) =>
+      url.endsWith("/issues/1")
+        ? Response.json({
+            number: 1,
+            state: "open",
+            user: { login: "contrib" },
+            labels: ["gittensor:priority"],
+          })
+        : new Response("not found", { status: 404 }),
+    );
     const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
-    const result = await fetchLinkedIssueLabelsForPropagation({ env, repoFullName: "owner/repo", linkedIssues: [1], installationId: 123 });
+    const result = await fetchLinkedIssueLabelsForPropagation({
+      env,
+      repoFullName: "owner/repo",
+      linkedIssues: [1],
+      installationId: 123,
+      prAuthorLogin: "contrib",
+    });
     expect(result).toEqual(["gittensor:priority"]);
     spy.mockRestore();
   });
@@ -67,51 +130,127 @@ describe("fetchLinkedIssueLabelsForPropagation (#priority-linked-issue-gate)", (
   it("caps the number of linked issues fetched at 50, ignoring any beyond the cap (defense in depth against an unbounded parallel fan-out)", async () => {
     let issueFetchCount = 0;
     stubFetch((url) => {
-      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/access_tokens"))
+        return Response.json({ token: "installation-token" });
       if (/\/issues\/\d+$/.test(url)) {
         issueFetchCount += 1;
-        return Response.json({ number: 1, state: "open", user: { login: "contrib" }, labels: ["gittensor:priority"] });
+        return Response.json({
+          number: 1,
+          state: "open",
+          user: { login: "contrib" },
+          labels: ["gittensor:priority"],
+        });
       }
       return new Response("not found", { status: 404 });
     });
     const env = createTestEnv({});
     const manyIssues = Array.from({ length: 75 }, (_, i) => i + 1);
-    const result = await fetchLinkedIssueLabelsForPropagation({ env, repoFullName: "owner/repo", linkedIssues: manyIssues, installationId: 123 });
+    const result = await fetchLinkedIssueLabelsForPropagation({
+      env,
+      repoFullName: "owner/repo",
+      linkedIssues: manyIssues,
+      installationId: 123,
+      prAuthorLogin: "contrib",
+    });
     expect(issueFetchCount).toBe(50);
     expect(result).toEqual(Array(50).fill("gittensor:priority"));
   });
 
-  it("trusts a priority label on any verified open linked issue, independent of PR author ownership", async () => {
+  it("ignores a priority label on an open linked issue when the PR author neither opened nor is assigned to it", async () => {
     stubFetch((url) => {
-      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
-      if (url.endsWith("/issues/777")) return Response.json({ number: 777, state: "open", user: { login: "maintainer" }, assignees: [], labels: ["gittensor:priority"] });
+      if (url.includes("/access_tokens"))
+        return Response.json({ token: "installation-token" });
+      if (url.endsWith("/issues/777"))
+        return Response.json({
+          number: 777,
+          state: "open",
+          user: { login: "maintainer" },
+          assignees: [],
+          labels: ["gittensor:priority"],
+        });
       return new Response("not found", { status: 404 });
     });
     const env = createTestEnv({});
-    const result = await fetchLinkedIssueLabelsForPropagation({ env, repoFullName: "owner/repo", linkedIssues: [777], installationId: 123 });
-    expect(result).toEqual(["gittensor:priority"]);
+    const result = await fetchLinkedIssueLabelsForPropagation({
+      env,
+      repoFullName: "owner/repo",
+      linkedIssues: [777],
+      installationId: 123,
+      prAuthorLogin: "attacker",
+    });
+    expect(result).toEqual([]);
   });
 
   it("ignores a priority label on a closed linked issue, even when the PR author is tied to it", async () => {
     stubFetch((url) => {
-      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
-      if (url.endsWith("/issues/777")) return Response.json({ number: 777, state: "closed", user: { login: "contrib" }, labels: ["gittensor:priority"] });
+      if (url.includes("/access_tokens"))
+        return Response.json({ token: "installation-token" });
+      if (url.endsWith("/issues/777"))
+        return Response.json({
+          number: 777,
+          state: "closed",
+          user: { login: "contrib" },
+          labels: ["gittensor:priority"],
+        });
       return new Response("not found", { status: 404 });
     });
     const env = createTestEnv({});
-    const result = await fetchLinkedIssueLabelsForPropagation({ env, repoFullName: "owner/repo", linkedIssues: [777], installationId: 123 });
+    const result = await fetchLinkedIssueLabelsForPropagation({
+      env,
+      repoFullName: "owner/repo",
+      linkedIssues: [777],
+      installationId: 123,
+      prAuthorLogin: "contrib",
+    });
     expect(result).toEqual([]);
   });
 
-  it("does not require a PR author to propagate labels from a verified open linked issue", async () => {
+  it("does not propagate labels when the PR author is missing", async () => {
     stubFetch((url) => {
-      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
-      if (url.endsWith("/issues/1")) return Response.json({ number: 1, state: "open", user: { login: "contrib" }, labels: ["gittensor:priority"] });
+      if (url.includes("/access_tokens"))
+        return Response.json({ token: "installation-token" });
+      if (url.endsWith("/issues/1"))
+        return Response.json({
+          number: 1,
+          state: "open",
+          user: { login: "contrib" },
+          labels: ["gittensor:priority"],
+        });
       return new Response("not found", { status: 404 });
     });
     const env = createTestEnv({});
-    const result = await fetchLinkedIssueLabelsForPropagation({ env, repoFullName: "owner/repo", linkedIssues: [1], installationId: 123 });
-    expect(result).toEqual(["gittensor:priority"]);
+    const result = await fetchLinkedIssueLabelsForPropagation({
+      env,
+      repoFullName: "owner/repo",
+      linkedIssues: [1],
+      installationId: 123,
+      prAuthorLogin: null,
+    });
+    expect(result).toEqual([]);
   });
 
+  it("propagates labels when the PR author is assigned to the open linked issue", async () => {
+    stubFetch((url) => {
+      if (url.includes("/access_tokens"))
+        return Response.json({ token: "installation-token" });
+      if (url.endsWith("/issues/9"))
+        return Response.json({
+          number: 9,
+          state: "open",
+          user: { login: "maintainer" },
+          assignees: [{ login: "contrib" }],
+          labels: ["gittensor:priority"],
+        });
+      return new Response("not found", { status: 404 });
+    });
+    const env = createTestEnv({});
+    const result = await fetchLinkedIssueLabelsForPropagation({
+      env,
+      repoFullName: "owner/repo",
+      linkedIssues: [9],
+      installationId: 123,
+      prAuthorLogin: "Contrib",
+    });
+    expect(result).toEqual(["gittensor:priority"]);
+  });
 });


### PR DESCRIPTION
### Motivation

- Prevent attackers from spoofing sensitive PR labels by referencing arbitrary open issues in PR body text; linked-issue label propagation must only trust verified authority when the PR author is the issue author or an assignee.

### Description

- Require the PR author in the propagation call by adding a `prAuthorLogin` parameter to `fetchLinkedIssueLabelsForPropagation` and passing `pr.authorLogin` from the public-surface orchestration path in `maybePublishPrPublicSurface`.
- Filter fetched linked-issue labels so only labels from verified OPEN issues authored by, or assigned to, the PR author are returned; other open issues are ignored.
- Update unit tests in `test/unit/linked-issue-label-propagation-fetch.test.ts` to cover ownership-guarded propagation, missing PR author behavior, and assignee-based propagation, replacing the previous vulnerable expectations.

### Testing

- Ran `npx vitest run test/unit/linked-issue-label-propagation-fetch.test.ts test/unit/pr-type-label.test.ts` and both targeted test files passed.
- Ran `npm run typecheck` which completed successfully.
- Attempted full coverage with `npm run test:coverage`; the targeted suites used by this change passed, but the full coverage run could not complete in this environment due to long-running/unrelated test timeouts in larger suites, so full `codecov/patch` verification was not completed here.
- Ran `git diff --check` which reported no whitespace/conflict issues, and `npm audit --audit-level=moderate` which failed due to an npm registry audit endpoint `403 Forbidden` response in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a92650ac4832c8201345955acd0a2)