### PR TITLE
fix(miner): sanitize reviewer consensus ingestion

### DIFF
--- a/packages/gittensory-engine/src/reviewer-consensus-calibration.ts
+++ b/packages/gittensory-engine/src/reviewer-consensus-calibration.ts
@@ -306,6 +306,86 @@ function isReviewerConsensusCalibrationIngestion(value: unknown): value is Revie
   return isRecord(value) && Array.isArray(value.accepted) && Array.isArray(value.rejected);
 }
 
+function sanitizeReviewerConsensusCalibrationIngestion(
+  ingestion: ReviewerConsensusCalibrationIngestion,
+): ReviewerConsensusCalibrationIngestion {
+  const accepted: ReviewerConsensusCalibrationSignal[] = [];
+  const rejected: ReviewerConsensusCalibrationIngestion["rejected"] = [];
+
+  for (const signal of ingestion.accepted) {
+    if (!isRecord(signal) || !Array.isArray(signal.dimensions)) continue;
+    const repoFullName = typeof signal.repoFullName === "string" ? normalizeRepoFullName(signal.repoFullName) : null;
+    const replayRunId = typeof signal.replayRunId === "string" ? normalizeId(signal.replayRunId) : null;
+    const reviewRunId = typeof signal.reviewRunId === "string" ? normalizeId(signal.reviewRunId) : null;
+    if (!repoFullName || !replayRunId || !reviewRunId) continue;
+    const dimensions = signal.dimensions.flatMap((dimension): ReviewerConsensusDimensionSignal[] => {
+      if (
+        !isRecord(dimension) ||
+        typeof dimension.dimension !== "string" ||
+        typeof dimension.voteCount !== "number" ||
+        typeof dimension.majorityOutcome !== "string" ||
+        typeof dimension.agreement !== "number"
+      ) {
+        return [];
+      }
+      const normalizedDimension = normalizeDimension(dimension.dimension);
+      const majorityOutcome = normalizeVote(dimension.majorityOutcome);
+      if (
+        !normalizedDimension ||
+        !majorityOutcome ||
+        !Number.isFinite(dimension.voteCount) ||
+        dimension.voteCount <= 0 ||
+        !Number.isInteger(dimension.voteCount) ||
+        !Number.isFinite(dimension.agreement)
+      ) {
+        return [];
+      }
+      const agreement = roundScore(dimension.agreement);
+      return [
+        {
+          dimension: normalizedDimension,
+          voteCount: dimension.voteCount,
+          majorityOutcome,
+          agreement,
+          score: agreement,
+        },
+      ];
+    });
+    const score = scoreDimensions(dimensions);
+    if (dimensions.length === 0 || score === null) continue;
+    accepted.push({
+      repoFullName,
+      replayRunId,
+      reviewRunId,
+      observedAt: typeof signal.observedAt === "string" ? normalizeObservedAt(signal.observedAt) : null,
+      dimensions,
+      score,
+    });
+  }
+
+  for (const row of ingestion.rejected) {
+    if (!isRecord(row)) continue;
+    const repoFullName =
+      typeof row.repoFullName === "string"
+        ? (normalizeRepoFullName(row.repoFullName) ?? normalizeId(row.repoFullName))
+        : null;
+    const replayRunId = typeof row.replayRunId === "string" ? normalizeId(row.replayRunId) : null;
+    const reviewRunId = typeof row.reviewRunId === "string" ? normalizeId(row.reviewRunId) : null;
+    const reason = row.reason;
+    if (
+      !repoFullName ||
+      !replayRunId ||
+      !reviewRunId ||
+      !["not_opted_in", "empty_dimensions", "invalid_repo", "invalid_run_id"].includes(reason as string)
+    ) {
+      continue;
+    }
+    rejected.push({ repoFullName, replayRunId, reviewRunId, reason });
+  }
+
+  return { accepted, rejected };
+}
+
 function normalizeCompositeWeights(weights: ReviewerConsensusCalibrationWeights | undefined): {
   objectiveAnchor: number;
   pairwiseJudge: number;
@@ -472,7 +552,7 @@ export function computeReviewerConsensusCompositeCalibrationScore(input: {
   weights?: ReviewerConsensusCalibrationWeights | undefined;
 }): ReviewerConsensusCompositeCalibrationScore {
   const ingestion = isReviewerConsensusCalibrationIngestion(input.reviewerConsensus)
-    ? input.reviewerConsensus
+    ? sanitizeReviewerConsensusCalibrationIngestion(input.reviewerConsensus)
     : ingestReviewerConsensusCalibrationSignals(input.reviewerConsensus);
   const objectiveAnchorScore =
     typeof input.objectiveAnchor === "number" ? roundScore(input.objectiveAnchor) : input.objectiveAnchor.score;

--- a/packages/gittensory-engine/test/reviewer-consensus-calibration.test.ts
+++ b/packages/gittensory-engine/test/reviewer-consensus-calibration.test.ts
@@ -309,6 +309,111 @@ test("composite honors custom weights and falls back to objective-only when all 
   assert.equal(allZero.compositeScore, 0.4);
 });
 
+test("composite sanitizes pre-ingested reviewer-consensus rows before auditing", () => {
+  const poisoned = {
+    accepted: [
+      {
+        repoFullName: "ACME/Widgets",
+        replayRunId: " replay-1 ",
+        reviewRunId: "review-1",
+        observedAt: "2026-07-04T00:00:00Z",
+        score: 0,
+        privateMetadata: "do-not-leak",
+        dimensions: [
+          {
+            dimension: "coverage",
+            voteCount: 2,
+            majorityOutcome: "success",
+            agreement: 1,
+            score: 0,
+            rawReviewText: "do-not-leak",
+          },
+          {
+            dimension: "security",
+            voteCount: 2,
+            majorityOutcome: "fail",
+            agreement: "not-a-number",
+            rawReviewText: "do-not-leak",
+          },
+        ],
+      },
+    ],
+    rejected: [
+      {
+        repoFullName: "ACME/Widgets",
+        replayRunId: "replay-2",
+        reviewRunId: "review-2",
+        reason: "not_opted_in",
+        privateMetadata: "do-not-leak",
+      },
+      {
+        repoFullName: "bad",
+        replayRunId: "replay-3",
+        reviewRunId: "review-3",
+        reason: "invalid_repo",
+        privateMetadata: "do-not-leak",
+      },
+      {
+        repoFullName: "ACME/Widgets",
+        replayRunId: "replay-4",
+        reviewRunId: "review-4",
+        reason: "private_reason",
+        privateMetadata: "do-not-leak",
+      },
+    ],
+  };
+
+  const result = computeReviewerConsensusCompositeCalibrationScore({
+    objectiveAnchor: 0.5,
+    pairwise: null,
+    reviewerConsensus: poisoned as never,
+  });
+
+  assert.equal(result.structuredReviewerConsensusScore, 1);
+  assert.deepEqual(result.audit.contributingRepos, [
+    {
+      repoFullName: "acme/widgets",
+      replayRunId: "replay-1",
+      reviewRunId: "review-1",
+      observedAt: "2026-07-04T00:00:00.000Z",
+      score: 1,
+      dimensions: [{ dimension: "tests", voteCount: 2, majorityOutcome: "pass", agreement: 1, score: 1 }],
+    },
+  ]);
+  assert.deepEqual(result.audit.rejected, [
+    { repoFullName: "acme/widgets", replayRunId: "replay-2", reviewRunId: "review-2", reason: "not_opted_in" },
+    { repoFullName: "bad", replayRunId: "replay-3", reviewRunId: "review-3", reason: "invalid_repo" },
+  ]);
+  assert.ok(!JSON.stringify(result).includes("do-not-leak"));
+});
+
+test("composite drops malformed pre-ingested rows instead of rendering invalid dimensions", () => {
+  const result = computeReviewerConsensusCompositeCalibrationScore({
+    objectiveAnchor: 0.5,
+    pairwise: 0.7,
+    reviewerConsensus: {
+      accepted: [
+        {
+          repoFullName: "acme/widgets",
+          replayRunId: "replay-1",
+          reviewRunId: "review-1",
+          observedAt: null,
+          score: 1,
+          dimensions: [
+            { dimension: "correctness", voteCount: 1, majorityOutcome: "pass", agreement: "1", score: 1 },
+          ],
+        },
+      ],
+      rejected: [{ repoFullName: "acme/widgets", replayRunId: "replay-2", reviewRunId: "review-2" }],
+    } as never,
+  });
+
+  assert.equal(result.structuredReviewerConsensusScore, null);
+  assert.deepEqual(result.audit.contributingRepos, []);
+  assert.deepEqual(result.audit.rejected, []);
+  assert.doesNotThrow(() => renderReviewerConsensusCalibrationAuditMarkdown(result));
+});
+
 test("renderAuditMarkdown is deterministic, public-safe, and reports contributors and rejections", () => {
   const ingestion = ingestReviewerConsensusCalibrationSignals([
     signal({ repoFullName: "acme/widgets", observedAt: "2026-07-04T00:00:00Z" }),


### PR DESCRIPTION
### Motivation

- A pre-ingested `ReviewerConsensusCalibrationIngestion` object was previously trusted verbatim, allowing unexpected/private fields (e.g. `rawReviewText`, `privateMetadata`, `trustScore`) or malformed dimension rows to survive into audit output and later rendering.
- The change aims to close this privacy/integrity gap by normalizing and validating pre-ingested rows the same way raw signal inputs are normalized before scoring or audit rendering.

### Description

- Added `sanitizeReviewerConsensusCalibrationIngestion()` which validates and normalizes `accepted` rows (normalizes repo/run ids, observedAt, dimensions, recomputes per-signal `score`) and sanitizes `rejected` rows, dropping malformed entries and stripping unexpected fields.
- Updated `computeReviewerConsensusCompositeCalibrationScore()` to call the sanitizer when the input is already a pre-ingested object, while keeping the existing raw-input path via `ingestReviewerConsensusCalibrationSignals()` unchanged.
- Added regression unit tests that pass a poisoned pre-ingested object and a malformed pre-ingested row to assert private fields are not leaked and malformed dimensions are dropped instead of breaking rendering.

### Testing

- Ran `npm --workspace @jsonbored/gittensory-engine run build`, which completed successfully.
- Ran the package unit tests via `node --test packages/gittensory-engine/test/reviewer-consensus-calibration.test.ts`, and the suite passed (new regression tests included).
- Ran `npm run typecheck` (`tsc --noEmit`) which succeeded.
- Attempted `npm run test:coverage` and `npm audit --audit-level=moderate`; `test:coverage` was started but did not complete within the session window, and `npm audit` failed due to a remote 403 response (network/audit endpoint), so full workspace-wide coverage and audit checks were not completed in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a8af0b55c832cb1d67bb43ee7614d)