### PR TITLE
fix(review): forward REES file line counts

### DIFF
--- a/src/review/enrichment-wire.ts
+++ b/src/review/enrichment-wire.ts
@@ -358,6 +358,8 @@ export async function buildReviewEnrichment(
           path: file.path,
           status: file.status ?? undefined,
           previousPath: file.previousFilename ?? undefined,
+          additions: file.additions,
+          deletions: file.deletions,
           patch:
             typeof file.payload?.patch === "string"
               ? file.payload.patch

--- a/test/unit/enrichment-wiring.test.ts
+++ b/test/unit/enrichment-wiring.test.ts
@@ -46,9 +46,9 @@ async function seedRepoFile(env: Env, repo: string) {
       7,
       "src/a.ts",
       "modified",
-      1,
-      0,
-      1,
+      25,
+      3,
+      28,
       JSON.stringify({ patch: "@@\n+export const A = 1;" }),
     )
     .run();
@@ -107,6 +107,7 @@ describe("review-enrichment wired into the processors review (flag GITTENSORY_RE
         body?: string;
         githubToken?: string;
         linkedIssue?: { number: number; title?: string; body?: string };
+        files?: Array<{ path: string; additions?: number; deletions?: number; patch?: string }>;
       };
     } = {};
     const fetchSpy = vi
@@ -122,6 +123,7 @@ describe("review-enrichment wired into the processors review (flag GITTENSORY_RE
             body?: string;
             githubToken?: string;
             linkedIssue?: { number: number; title?: string; body?: string };
+            files?: Array<{ path: string; additions?: number; deletions?: number; patch?: string }>;
           };
           return new Response(
             JSON.stringify({
@@ -165,6 +167,15 @@ describe("review-enrichment wired into the processors review (flag GITTENSORY_RE
         title: "Linked bug",
         body: "Issue context for history analyzer.",
       });
+      expect(reesRequest.body?.files).toEqual([
+        {
+          path: "src/a.ts",
+          status: "modified",
+          additions: 25,
+          deletions: 3,
+          patch: "@@\n+export const A = 1;",
+        },
+      ]);
       // The brief's content flows into the user prompt, but the system prompt carries our FIXED
       // enrichment suffix — the REES-supplied systemSuffix is untrusted and is never spliced in.
       expect(seenUser[0] ?? "").toContain("## EXTERNAL REVIEW BRIEF");


### PR DESCRIPTION
### Motivation
- A recent analyzer (`testRatio`) requires per-file `additions` to compute source/test line ratios, but the Worker→REES request omitted line-count fields so `file.additions` was undefined and the analyzer never produced findings. 
- The change restores the intended signal flow so REES-run local analyzers receive accurate addition/deletion counts in the normal integration path.

### Description
- Forward `additions` and `deletions` on each file in the REES request payload by updating `src/review/enrichment-wire.ts` to include `additions: file.additions` and `deletions: file.deletions` in the `files` mapping. 
- Update the regression/unit test `test/unit/enrichment-wiring.test.ts` to seed non-zero line counts and assert the REES POST body contains the `files` array with `additions`/`deletions` and `patch` as expected. 
- Commit message: `fix(review): forward REES file line counts`.

### Testing
- Ran the targeted unit test with `npx vitest run test/unit/enrichment-wiring.test.ts`, and the test file passed. 
- Ran `npm run typecheck` and `git diff --check`, both succeeded. 
- Ran a scoped coverage run with `npm run test:coverage -- --run test/unit/enrichment-wiring.test.ts`, the test passed but the repository-wide coverage thresholds failed because only one test file was executed; a full `npm run test:ci` was not run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a93a2ac50832c8126b723ea850923)