### PR TITLE
fix(review-enrichment): schedule model weight assets

### DIFF
--- a/review-enrichment/src/analysis-context.ts
+++ b/review-enrichment/src/analysis-context.ts
@@ -19,6 +19,7 @@ import {
 } from "./external-fetch.js";
 import { isWorkflowPath } from "./workflow-path.js";
 import { isSupportedLockfile } from "./lockfile-path.js";
+import { isBinaryFileExtension } from "./analyzers/binary-extensions.js";
 
 type ChangedFile = NonNullable<EnrichRequest["files"]>[number];
 
@@ -451,7 +452,8 @@ function categorizeFile(path: string): FileCategory {
   if (
     [".png", ".jpg", ".jpeg", ".gif", ".webp", ".svg", ".pdf", ".zip", ".gz", ".zst"].includes(
       extension,
-    )
+    ) ||
+    isBinaryFileExtension(extension.slice(1))
   ) {
     return { path, extension, category: "asset" };
   }

--- a/review-enrichment/test/analysis-context.test.ts
+++ b/review-enrichment/test/analysis-context.test.ts
@@ -545,6 +545,53 @@ test("createAnalysisContext classifies Zstandard archives as assets for schedule
   assert.deepEqual(plan.skipped.map((item) => [item.name, item.skipReason]), []);
 });
 
+test("createAnalysisContext classifies ML model weights as assets for scheduler gating", () => {
+  const context = createAnalysisContext({
+    repoFullName: "JSONbored/gittensory",
+    prNumber: 3301,
+    headSha: "abcdef1234567890",
+    githubToken: "github_pat_test",
+    analyzers: ["assetWeight"],
+    files: [
+      { path: "models/llama.safetensors", patch: null, status: "added" },
+      { path: "models/llama.gguf", patch: null, status: "added" },
+      { path: "models/resnet.onnx", patch: null, status: "added" },
+      { path: "weights/adapter.PT", patch: null, status: "added" },
+      { path: "checkpoints/state.pth", patch: null, status: "added" },
+      { path: "checkpoints/final.ckpt", patch: null, status: "added" },
+    ],
+  });
+
+  assert.deepEqual(
+    context.fileCategories.map((file) => [file.path, file.extension, file.category]),
+    [
+      ["models/llama.safetensors", ".safetensors", "asset"],
+      ["models/llama.gguf", ".gguf", "asset"],
+      ["models/resnet.onnx", ".onnx", "asset"],
+      ["weights/adapter.PT", ".pt", "asset"],
+      ["checkpoints/state.pth", ".pth", "asset"],
+      ["checkpoints/final.ckpt", ".ckpt", "asset"],
+    ],
+  );
+
+  const plan = planAnalyzers(
+    {
+      repoFullName: "JSONbored/gittensory",
+      prNumber: 3301,
+      headSha: "abcdef1234567890",
+      githubToken: "github_pat_test",
+      analyzers: ["assetWeight"],
+      files: context.changedFiles,
+    },
+    { assetWeight: async () => [] },
+    context,
+    { budgetMs: 5_000, startedAtMs: 0 },
+  );
+
+  assert.deepEqual(plan.runnable.map((item) => item.name), ["assetWeight"]);
+  assert.deepEqual(plan.skipped.map((item) => [item.name, item.skipReason]), []);
+});
+
 test("createAnalysisContext classifies long-form doc extensions as docs", () => {
   const context = createAnalysisContext({
     repoFullName: "JSONbored/gittensory",


### PR DESCRIPTION
### Motivation
- The asset-weight analyzer was extended to treat ML model/checkpoint formats as binary, but scheduler gating only looked at a separate hard-coded asset extension list and therefore skipped the analyzer for PRs that only added ML weight files.
- Align the scheduler's file categorization with the shared binary-extension inventory so large ML artifacts trigger the `assetWeight` analyzer as intended.

### Description
- Import and use the shared `isBinaryFileExtension` predicate inside `createAnalysisContext`'s `categorizeFile` so paths whose extension appears in `BINARY_FILE_EXTENSIONS` are categorized as `asset` in addition to the explicit asset extension list (`review-enrichment/src/analysis-context.ts`).
- Preserve the existing explicit asset list while adding the centralized check, avoiding removals or behavior changes for previously-covered extensions.
- Add a regression test that asserts `.safetensors`, `.gguf`, `.onnx`, `.pt`, `.pth`, and `.ckpt` files are classified as `asset` and that `assetWeight` is scheduled (not skipped) when those files are present (`review-enrichment/test/analysis-context.test.ts`).

### Testing
- Ran `git diff --check` with no issues reported.
- Built and ran targeted tests with `npm run build && node --test --experimental-strip-types test/analysis-context.test.ts test/asset-weight.test.ts test/scheduler.test.ts` inside `review-enrichment/` and the added regression passed alongside existing tests.
- Ran the full package test suite with `npm test` inside `review-enrichment/` and observed all tests passing locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a9279d800832ca4173b91c8d27fe4)