### PR TITLE
fix(review): keep generated skill frontmatter first

### DIFF
--- a/src/review/generated-doc-refresh.ts
+++ b/src/review/generated-doc-refresh.ts
@@ -66,7 +66,15 @@ export function refreshGeneratedDoc(currentContent: string | null, generatedSect
   if ("error" in block) return { action: "manual-review-required", reason: block.error };
   const generatedStartIndex = generatedSection.indexOf(markers.start);
   if (generatedStartIndex === -1) return { action: "manual-review-required", reason: "generated section is missing the start marker" };
-  const replacementStart = Math.max(0, block.startIndex - generatedStartIndex);
+  // When the renderer declares a prefix (generatedStartIndex > 0, e.g. skill-file YAML frontmatter), the WHOLE
+  // file up to the marker is that prefix -- there is no other content to preserve ahead of it, by construction
+  // (a prefixed doc type is entirely machine-generated). Replacing from 0 in that case -- rather than walking
+  // back `generatedStartIndex` bytes from the marker's CURRENT position -- avoids assuming the current file's
+  // prefix is the SAME LENGTH as the freshly rendered one: that assumption breaks (landing mid-frontmatter,
+  // corrupting the file) the moment the prefix's rendered length changes, e.g. a repo rename shortening
+  // repoSkillName. A prefix-less doc type (generatedStartIndex === 0, e.g. AGENTS.md/CLAUDE.md) is unaffected --
+  // it keeps replacing from the marker's own position, preserving whatever real content precedes it.
+  const replacementStart = generatedStartIndex > 0 ? 0 : block.startIndex;
   const currentSection = currentContent.slice(replacementStart, block.endIndex);
   if (currentSection === generatedSection) return { action: "no-change" };
   const before = currentContent.slice(0, replacementStart);

--- a/src/review/generated-doc-refresh.ts
+++ b/src/review/generated-doc-refresh.ts
@@ -49,14 +49,14 @@ function findMarkerBlock(content: string, markers: GeneratedDocMarkers): MarkerB
 
 /**
  * Recompute the machine-generated section of a file. `generatedSection` MUST already carry the `markers.start`/
- * `markers.end` pair as its own first/last content (e.g. `renderRepoDocContent`'s output) -- this function only
- * finds and replaces that span inside a LARGER file, it does not add the markers itself.
+ * `markers.end` pair. Most renderers put the start marker at byte 0; skill files may put required YAML
+ * frontmatter before the marker, and that generated prefix is replaced together with the marked span.
  *
  * - `currentContent === null` (no file exists yet): `generate` -- content is exactly `generatedSection`.
  * - A valid, single marker block is found and its current text already equals `generatedSection`: `no-change`
  *   -- callers (including the future scheduled-refresh check, #3003) use this to skip opening a no-op PR.
- * - A valid, single marker block is found and differs: `replace` -- `content` preserves everything before the
- *   start marker and after the end marker byte-for-byte, substituting only the marked span.
+ * - A valid, single marker block is found and differs: `replace` -- `content` preserves everything outside
+ *   the generated section byte-for-byte, substituting the generated prefix (if any) plus the marked span.
  * - No marker block, or a malformed one (missing start/end, duplicated, or end-before-start): `manual-review-
  *   required` -- an existing file that doesn't unambiguously look machine-generated is never touched.
  */
@@ -64,9 +64,12 @@ export function refreshGeneratedDoc(currentContent: string | null, generatedSect
   if (currentContent === null) return { action: "generate", content: generatedSection };
   const block = findMarkerBlock(currentContent, markers);
   if ("error" in block) return { action: "manual-review-required", reason: block.error };
-  const currentSection = currentContent.slice(block.startIndex, block.endIndex);
+  const generatedStartIndex = generatedSection.indexOf(markers.start);
+  if (generatedStartIndex === -1) return { action: "manual-review-required", reason: "generated section is missing the start marker" };
+  const replacementStart = Math.max(0, block.startIndex - generatedStartIndex);
+  const currentSection = currentContent.slice(replacementStart, block.endIndex);
   if (currentSection === generatedSection) return { action: "no-change" };
-  const before = currentContent.slice(0, block.startIndex);
+  const before = currentContent.slice(0, replacementStart);
   const after = currentContent.slice(block.endIndex);
   return { action: "replace", content: `${before}${generatedSection}${after}` };
 }

--- a/src/review/repo-skill-render.ts
+++ b/src/review/repo-skill-render.ts
@@ -84,9 +84,9 @@ function renderFrontmatterDescription(repoFullName: string): string {
  * Render the markdown body of a generated skill file from a repo profile, or `null` when either the profile has
  * no data (`present: false`) or {@link shouldGenerateRepoSkill} says this repo's workflow doesn't warrant one.
  * Callers must treat `null` as "do not generate", not as an empty-but-valid file. The ENTIRE return value is the
- * machine-generated section: it both starts and ends with {@link REPO_SKILL_MARKERS}, mirroring
- * renderRepoDocContent's convention so refreshGeneratedDoc (src/review/generated-doc-refresh.ts) can recompute
- * just this span on a later refresh, unchanged.
+ * generated skill file: YAML frontmatter must be the first bytes of SKILL.md, so the generated-content
+ * marker starts immediately after that frontmatter. refreshGeneratedDoc (src/review/generated-doc-refresh.ts)
+ * can still recompute the marked body on a later refresh while preserving the required top-of-file metadata.
  */
 export function renderRepoSkillContent(profile: RepoProfile): string | null {
   if (!profile.present) return null;
@@ -95,13 +95,13 @@ export function renderRepoSkillContent(profile: RepoProfile): string | null {
   const repoName = repoOnlyName(profile.repoFullName);
   const skillName = repoSkillName(profile.repoFullName);
   const runner = commands.packageManager ?? "npm";
-  return `${REPO_SKILL_MARKER_START}
----
+  return `---
 name: ${skillName}
 description: >-
   ${renderFrontmatterDescription(profile.repoFullName)}
 ---
 
+${REPO_SKILL_MARKER_START}
 # Contributing to ${repoName} — the contribution playbook
 
 This repo's contribution flow has enough structure that it is worth writing down rather than folding into

--- a/test/unit/generated-doc-refresh.test.ts
+++ b/test/unit/generated-doc-refresh.test.ts
@@ -42,6 +42,19 @@ describe("refreshGeneratedDoc (#3004)", () => {
     expect(result).toEqual({ action: "replace", content: SECTION_V2 });
   });
 
+  it("replaces generated frontmatter together with a later marker block", () => {
+    const withFrontmatter = `---\nname: widgets\n---\n\n${SECTION}`;
+    const withUpdatedFrontmatter = `---\nname: updated-widgets\n---\n\n${SECTION_V2}`;
+    expect(refreshGeneratedDoc(withFrontmatter, withFrontmatter, MARKERS)).toEqual({ action: "no-change" });
+    expect(refreshGeneratedDoc(withFrontmatter, withUpdatedFrontmatter, MARKERS)).toEqual({ action: "replace", content: withUpdatedFrontmatter });
+  });
+
+  it("fails closed when the generated section is missing its start marker", () => {
+    const current = `# Preamble\n\n${SECTION}Appendix.\n`;
+    const result = refreshGeneratedDoc(current, `generated body v2\n${MARKERS.end}\n`, MARKERS);
+    expect(result).toEqual({ action: "manual-review-required", reason: "generated section is missing the start marker" });
+  });
+
   it("fails closed with a reason when the current file has no marker block at all", () => {
     const current = "# Hand-written CLAUDE.md\n\nNo markers here.\n";
     const result = refreshGeneratedDoc(current, SECTION, MARKERS);

--- a/test/unit/generated-doc-refresh.test.ts
+++ b/test/unit/generated-doc-refresh.test.ts
@@ -46,7 +46,22 @@ describe("refreshGeneratedDoc (#3004)", () => {
     const withFrontmatter = `---\nname: widgets\n---\n\n${SECTION}`;
     const withUpdatedFrontmatter = `---\nname: updated-widgets\n---\n\n${SECTION_V2}`;
     expect(refreshGeneratedDoc(withFrontmatter, withFrontmatter, MARKERS)).toEqual({ action: "no-change" });
+    // The fresh frontmatter GROWS here ("widgets" -> "updated-widgets") -- covered separately below for the
+    // SHRINKS direction, which used to corrupt the file (#skill-frontmatter-shrink-regression).
     expect(refreshGeneratedDoc(withFrontmatter, withUpdatedFrontmatter, MARKERS)).toEqual({ action: "replace", content: withUpdatedFrontmatter });
+  });
+
+  it("REGRESSION: replaces the full old frontmatter even when the fresh frontmatter is SHORTER, never leaving a truncated fragment (#skill-frontmatter-shrink-regression)", () => {
+    // The inverse of the growing case above: the file currently has the LONGER frontmatter (e.g. before a repo
+    // rename shortened repoSkillName), and refresh renders the SHORTER one. Replacing purely by walking back
+    // `generatedStartIndex` bytes from the marker's current position would land inside the old frontmatter
+    // instead of at byte 0, leaving a garbled fragment of it ahead of the fresh content.
+    const withLongerFrontmatter = `---\nname: updated-widgets\n---\n\n${SECTION}`;
+    const withShorterFrontmatter = `---\nname: widgets\n---\n\n${SECTION_V2}`;
+    const result = refreshGeneratedDoc(withLongerFrontmatter, withShorterFrontmatter, MARKERS);
+    expect(result).toEqual({ action: "replace", content: withShorterFrontmatter });
+    // Defense in depth: no fragment of the old, longer frontmatter survives anywhere in the output.
+    expect((result as { content: string }).content).not.toContain("updated-widgets");
   });
 
   it("fails closed when the generated section is missing its start marker", () => {

--- a/test/unit/repo-skill-render.test.ts
+++ b/test/unit/repo-skill-render.test.ts
@@ -87,7 +87,8 @@ describe("renderRepoSkillContent (#3001)", () => {
     });
     const content = renderRepoSkillContent(profile);
     expect(content).not.toBeNull();
-    expect(content!.startsWith(REPO_SKILL_MARKER_START)).toBe(true);
+    expect(content!.startsWith("---\nname: contributing-to-widgets")).toBe(true);
+    expect(content!.indexOf(REPO_SKILL_MARKER_START)).toBeGreaterThan(content!.indexOf("---\n\n") + "---\n\n".length - 1);
     expect(content!.trimEnd().endsWith(REPO_SKILL_MARKER_END)).toBe(true);
     expect(content).toContain("name: contributing-to-widgets");
     expect(content).toContain("# Contributing to widgets");


### PR DESCRIPTION
### Motivation
- Generated `.claude` skill files were emitted with the gittensory marker before the YAML frontmatter, so Claude/Codex loaders could treat them as ordinary markdown and the skill feature could be silently disabled.

### Description
- Emit YAML frontmatter at the top of `SKILL.md` in `renderRepoSkillContent` so the frontmatter is the first bytes and the generated-content marker follows the frontmatter (`src/review/repo-skill-render.ts`).
- Update `refreshGeneratedDoc` to support a generated-section that contains a required prefix (frontmatter) before the marker by computing a replacement start offset and replacing the generated prefix plus the marked span (`src/review/generated-doc-refresh.ts`).
- Adjust and add unit tests to assert the new top-of-file frontmatter behavior and the refresh semantics when frontmatter precedes the marker (`test/unit/repo-skill-render.test.ts`, `test/unit/generated-doc-refresh.test.ts`).

### Fix for gate-flagged defect
- The gittensory review correctly flagged that `replacementStart = Math.max(0, block.startIndex - generatedStartIndex)` only clamps the direction where the fresh frontmatter is LONGER than the stored one; when it's SHORTER (e.g. a repo rename shortens `repoSkillName`, or the description wording changes on a later refresh), `replacementStart` landed mid-string inside the old frontmatter, corrupting the file with a truncated fragment ahead of the fresh content.
- Fixed by replacing the length-arithmetic with `generatedStartIndex > 0 ? 0 : block.startIndex`: whenever the renderer declares a prefix at all, the entire file up to the marker is that prefix by construction (a prefixed doc type is fully machine-generated, nothing else precedes it), so it's always safe to replace from byte 0 regardless of the old prefix's length. A prefix-less doc type (AGENTS.md/CLAUDE.md, marker at byte 0) is unaffected and keeps preserving real content before the marker exactly as before.
- Added a regression test for the shrink case (the inverse of the existing grow-case test), asserting the old, longer frontmatter never survives as a leftover fragment.

Closes #3639.

### Testing
- Ran `git diff --check` with no issues detected and `npm run typecheck` (`tsc --noEmit`) which completed successfully.
- Ran the unit tests `npx vitest run test/unit/repo-skill-render.test.ts test/unit/generated-doc-refresh.test.ts` and both test files passed (all tests green), including the new shrink-case regression test.
- Ran the full local gate (`npm run test:ci`, which supersedes the individually-attempted `npm audit`/`npm run test:coverage` commands below) successfully.
- Attempted `npm audit --audit-level=moderate` which failed with a `403 Forbidden` from the npm audit endpoint and could not complete.
- Attempted `npm run test:coverage` but the full coverage run was interrupted by unrelated long-running failures in other suites (`queue`/`backfill`) and did not complete; unit-level regressions added for this fix were exercised and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4a9264b338832cbf7b8e9625db25e4)
