### PR TITLE
fix(db): preserve linked-issue claim on a sparse PR sync payload

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -320,15 +320,23 @@ export async function upsertPullRequestFromGitHub(
   const db = getDb(env.DB);
   const syncedAt = nowIso();
   const lastSeenOpenAt = pr.state === "open" ? (options.seenOpenAt ?? syncedAt) : null;
-  const linkedIssuesJson = jsonString(record.linkedIssues);
-  const observedLinkedIssueClaimedAt = record.linkedIssues.length > 0 ? syncedAt : null;
   const existingClaimRows = await db
     .select({ linkedIssuesJson: pullRequests.linkedIssuesJson, linkedIssueClaimedAt: pullRequests.linkedIssueClaimedAt })
     .from(pullRequests)
     .where(and(eq(pullRequests.repoFullName, repoFullName), eq(pullRequests.number, pr.number)))
     .limit(1);
+  // A sparse GitHub payload (e.g. a narrower webhook event's embedded pull_request sub-object, as opposed to a
+  // full `GET /pulls/{n}` read) can omit `body` entirely (`undefined`) rather than reporting it as explicitly
+  // empty (`null`/`""`) — `GitHubPullRequestPayload.body` is typed `string | null` precisely because a caller
+  // may not have it at all. Re-deriving linked issues from an ABSENT body would silently wipe an
+  // already-correctly-claimed linked issue (and reset its claim timestamp via resolveLinkedIssueClaimedAt's own
+  // `linkedIssues.length === 0` branch) on any such upsert. Fall back to whatever is already stored in that
+  // case; only a genuinely observed (possibly empty) body updates the claim. (#linked-issue-sparse-payload-preserve)
+  const linkedIssues = pr.body === undefined && existingClaimRows[0] ? parseLinkedIssuesJson(existingClaimRows[0].linkedIssuesJson) : record.linkedIssues;
+  const linkedIssuesJson = pr.body === undefined && existingClaimRows[0] ? existingClaimRows[0].linkedIssuesJson : jsonString(linkedIssues);
+  const observedLinkedIssueClaimedAt = linkedIssues.length > 0 ? syncedAt : null;
   const linkedIssueClaimedAt = resolveLinkedIssueClaimedAt(
-    record.linkedIssues,
+    linkedIssues,
     linkedIssuesJson,
     existingClaimRows[0],
     observedLinkedIssueClaimedAt,
@@ -375,7 +383,7 @@ export async function upsertPullRequestFromGitHub(
         updatedAt: syncedAt,
       },
     });
-  return { ...record, linkedIssueClaimedAt };
+  return { ...record, linkedIssues, linkedIssueClaimedAt };
 }
 
 function resolveLinkedIssueClaimedAt(

--- a/test/unit/db-parsers.test.ts
+++ b/test/unit/db-parsers.test.ts
@@ -9,6 +9,7 @@ import {
   getRepoAuthorPullRequestHistory,
   getLatestScoringModelSnapshot,
   getFreshOfficialMinerDetection,
+  getPullRequest,
   listPullRequests,
   listPullRequestDetailSyncStates,
   listRepoSyncSegments,
@@ -361,6 +362,47 @@ describe("database row parser hardening", () => {
     const resynced = (await listPullRequests(env, "owner/repo")).find((p) => p.number === 6);
     expect(resynced?.title).toBe("Synced again"); // the sync ran
     expect(resynced?.lastRegatedAt).toBe(stamped); // but the marker survived
+  });
+
+  it("REGRESSION: a sparse sync (payload.body absent) does NOT wipe an already-claimed linked issue (#linked-issue-sparse-payload-preserve)", async () => {
+    const env = createTestEnv();
+    // A full sync (e.g. pull_request.opened) correctly claims the linked issue.
+    await upsertPullRequestFromGitHub(env, "owner/repo", { number: 7, title: "Fix the bug", state: "open", user: { login: "bob" }, head: { sha: "a1" }, labels: [], body: "Closes #42" });
+    const claimed = await getPullRequest(env, "owner/repo", 7);
+    expect(claimed?.linkedIssues).toEqual([42]);
+    expect(typeof claimed?.linkedIssueClaimedAt).toBe("string");
+
+    // A NARROWER event's embedded pull_request sub-object (e.g. a pull_request_review payload shape) can omit
+    // `body` entirely -- `undefined`, not an explicit empty string/null. This upsert must not re-derive an
+    // empty linkedIssues from the absent body and clobber the already-correct claim.
+    const resynced = await upsertPullRequestFromGitHub(env, "owner/repo", { number: 7, title: "Fix the bug", state: "open", user: { login: "bob" }, head: { sha: "a1" }, labels: [] });
+    expect(resynced.linkedIssues).toEqual([42]); // the function's own return value is corrected too
+    expect(resynced.linkedIssueClaimedAt).toBe(claimed?.linkedIssueClaimedAt); // claim timestamp is untouched
+
+    const stored = await getPullRequest(env, "owner/repo", 7);
+    expect(stored?.linkedIssues).toEqual([42]);
+    expect(stored?.linkedIssueClaimedAt).toBe(claimed?.linkedIssueClaimedAt);
+  });
+
+  it("a genuinely empty body (explicit null/\"\", not absent) DOES clear a previously-claimed linked issue", async () => {
+    const env = createTestEnv();
+    await upsertPullRequestFromGitHub(env, "owner/repo", { number: 8, title: "Fix the bug", state: "open", user: { login: "bob" }, head: { sha: "a1" }, labels: [], body: "Closes #42" });
+    // The contributor genuinely deleted their PR description -- GitHub reports this as body: null, a real signal
+    // distinct from a sparse payload's absent field, and it must still update the stored claim.
+    const cleared = await upsertPullRequestFromGitHub(env, "owner/repo", { number: 8, title: "Fix the bug", state: "open", user: { login: "bob" }, head: { sha: "a1" }, labels: [], body: null });
+    expect(cleared.linkedIssues).toEqual([]);
+    const stored = await getPullRequest(env, "owner/repo", 8);
+    expect(stored?.linkedIssues).toEqual([]);
+    expect(stored?.linkedIssueClaimedAt).toBeNull();
+  });
+
+  it("a sparse sync on a brand-new PR (no existing row to preserve) falls through to the empty default", async () => {
+    const env = createTestEnv();
+    // No prior row exists for PR #9 -- the sparse-preserve branch has nothing to preserve, so this must behave
+    // exactly as it always has: derive from the (absent) body, yielding no linked issues.
+    const created = await upsertPullRequestFromGitHub(env, "owner/repo", { number: 9, title: "New PR", state: "open", user: { login: "bob" }, labels: [] });
+    expect(created.linkedIssues).toEqual([]);
+    expect(created.linkedIssueClaimedAt).toBeNull();
   });
 
   it("countRecentDeadLetters counts github_app.dlq_dead_lettered audits since a cutoff, independent of any ops flag (#1276)", async () => {


### PR DESCRIPTION
## Summary

- Fixes a real production incident on PR #3604: the review gate reported "No linked issue detected" as a concern even though the PR body clearly said "Closes #1957" and the panel's own "Linked issue" row in the *same* comment showed "✅ Linked #1957" — a direct contradiction within one evaluation pass. Confirmed via direct DB inspection that `pull_requests.linked_issues_json` was correctly `[1957]` from the moment the PR was created, and that this repo's `linkedIssueGateMode` is `advisory` (so the live open-reference fetch path never runs) — ruling out both a live-fetch bug and a genuinely-empty body as the cause.
- Root cause: `upsertPullRequestFromGitHub`'s `onConflictDoUpdate` unconditionally re-derives `linkedIssuesJson`/`linkedIssueClaimedAt` from the *current* payload's `body` on every sync. `GitHubPullRequestPayload.body` is typed `string | null` specifically because some callers legitimately don't have it — a narrower webhook event's embedded `pull_request` sub-object can omit `body` entirely (`undefined`), distinct from a genuinely empty description (`null`/`""`). Re-deriving from an absent body silently wiped an already-correctly-claimed linked issue (and reset its claim timestamp, since `resolveLinkedIssueClaimedAt` treats an empty `linkedIssues` array as "nothing claimed").
- Fix: when `pr.body === undefined` and a prior row already exists, fall back to the *already-stored* `linkedIssuesJson` instead of re-deriving from the absent body. An explicitly empty body (`null`/`""`) — a contributor genuinely clearing their PR description — still clears the claim exactly as before; this only guards the "field is absent" case the type system already models.

No linked issue for this one — it's a narrowly-scoped correctness fix for a confirmed production incident (evidence: the incident report, the DB query results, and the type signature all cited above); see the Notes section for the full investigation trail.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] No issue link — this is a small, well-evidenced bug fix; see the Summary for the concrete incident and root-cause trail in place of a tracked issue.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — 100% line + branch coverage on every changed line, verified via a targeted v8 coverage pass (both branches of the new `pr.body === undefined && existingClaimRows[0]` condition, in both its `linkedIssues` and `linkedIssuesJson` uses) in addition to the full unsharded run.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries: three new tests in `test/unit/db-parsers.test.ts` — (1) a sparse re-sync (`body` absent) preserves an already-claimed linked issue and its claim timestamp, including the function's own return value; (2) an explicit empty body (`null`) still clears the claim, proving the fix doesn't over-broaden; (3) a sparse sync on a brand-new PR (nothing to preserve) falls through to the pre-existing empty-default behavior. Also re-ran the full existing test suite affected by this widely-used function (`npm run test:changed`, 6000+ tests, 235+ files) with zero regressions.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session/CORS surface touched.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP schema change.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no `apps/gittensory-ui` changes.)
- [x] Visible UI changes include a `UI Evidence` section below with screenshots. (N/A — no visible UI change; this is an internal DB-write correctness fix.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (N/A — internal bug fix, no user-facing docs to update.)

## Notes

Investigation trail (for reviewer context, not part of the code change):
- Ruled out the live open-reference GitHub fetch (`resolveLinkedIssueHasOpenReference`/`fetchLinkedIssueFacts`) as the cause: `JSONbored/gittensory`'s own `linkedIssueGateMode` is `advisory`, so that fetch path is never invoked (`resolveLinkedIssueAdvisoryContext` short-circuits to `Promise.resolve(true)`).
- Ruled out the GitHub response cache (`src/github/client.ts`): `/issues/{number}` isn't classified into any cached class (`githubCacheClassForUrl` returns `null` for it), so it can't be served stale from Redis; the volatile single-flight coalescer that DOES apply cleans up its map entry synchronously on settle, so it can't replay a 19-minute-old result either.
- Confirmed via a direct query against the production D1 `pull_requests` table that `linked_issues_json` was `"[1957]"` essentially from the same instant as `created_at` — the correct value was captured and persisted immediately; something *later* wiped the in-memory read used for one evaluation pass, which is what led to the `upsertPullRequestFromGitHub` `onConflictDoUpdate` overwrite path above.
