### PR TITLE
docs(miner): clarify claim ledger is local bookkeeping only

### DIFF
--- a/packages/gittensory-miner/lib/claim-ledger.js
+++ b/packages/gittensory-miner/lib/claim-ledger.js
@@ -78,6 +78,9 @@ export function openClaimLedger(dbPath = resolveClaimLedgerDbPath()) {
   const db = new DatabaseSync(resolvedPath);
   chmodSync(resolvedPath, 0o600);
   db.exec("PRAGMA busy_timeout = 5000");
+  // LOCAL bookkeeping only: this table records which issues this miner instance has soft-claimed on this
+  // machine. It does NOT adjudicate contested duplicates — sibling miners claiming the same issue are
+  // resolved elsewhere via `isDuplicateClusterWinnerByClaim` from `@jsonbored/gittensory-engine` (#3355).
   db.exec(`
     CREATE TABLE IF NOT EXISTS miner_claims (
       id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/test/unit/miner-claim-ledger.test.ts
+++ b/test/unit/miner-claim-ledger.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, statSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -119,5 +119,21 @@ describe("gittensory-miner claim ledger (#2314)", () => {
     expect(() => ledger.recordClaim({ repoFullName: "o/a", issueNumber: 0 })).toThrow("invalid_issue_number");
     expect(() => ledger.recordClaim({ repoFullName: "o/a", issueNumber: 1.5 })).toThrow("invalid_issue_number");
     expect(() => ledger.listClaims({ status: "bogus" as never })).toThrow("invalid_status");
+  });
+
+  it("claim-then-list, then release, excludes released rows from the active-only filter (#3354)", () => {
+    const ledger = tempLedger();
+    ledger.recordClaim({ repoFullName: "o/a", issueNumber: 10 });
+    expect(ledger.listClaims({ status: "active" }).map((c) => c.issueNumber)).toEqual([10]);
+    ledger.releaseClaim("o/a", 10);
+    expect(ledger.listClaims({ status: "active" })).toEqual([]);
+    expect(ledger.listClaims()).toHaveLength(1);
+  });
+
+  it("documents that miner_claims is local bookkeeping only, not duplicate adjudication (#3355)", () => {
+    const source = readFileSync("packages/gittensory-miner/lib/claim-ledger.js", "utf8");
+    expect(source).toContain("LOCAL bookkeeping only");
+    expect(source).toContain("does NOT adjudicate contested duplicates");
+    expect(source).toContain("isDuplicateClusterWinnerByClaim");
   });
 });


### PR DESCRIPTION
## Summary
- Document that `miner_claims` is a **local bookkeeping primitive only** — it records soft claims on this machine and does **not** adjudicate duplicate winners (that belongs to `isDuplicateClusterWinnerByClaim` in `@jsonbored/gittensory-engine`).
- Add regression tests: explicit claim→release→active-filter coverage and a source-doc assertion so the disclaimer cannot drift.

Closes #3355
Closes #3354

## Test plan
- [x] `test/unit/miner-claim-ledger.test.ts` — new #3354 and #3355 cases
- [x] `npm run build --workspace @jsonbored/gittensory-miner`


Made with [Cursor](https://cursor.com)