### PR TITLE
fix(config): restore main's typecheck and clear an injection-detector false positive

### DIFF
--- a/.gittensory.yml.example
+++ b/.gittensory.yml.example
@@ -310,7 +310,7 @@ gate:
     # only -- not floor-clamped like onMerge below, since the three strategies aren't
     # ordered by strictness.
     combine: null
-    # Per-repo override of the synthesis merge rule (#2567): "either" is STRICTER (any
+    # Per-repo override of the synthesis merge mode (#2567): "either" is STRICTER (any
     # one reviewer's blocker blocks/holds); "both" is more permissive (every reviewer
     # must agree). either | both, or null. Default: null (the operator's own plan). A
     # repo may only TIGHTEN the operator's floor -- it can never loosen "either" down
@@ -746,6 +746,11 @@ settings:
 #   # deterministic "Changed files" summary: one row per file category, with counts and +/- totals. Bool
 #   # or null. Default: null/false.
 #   changed_files_summary: false
+#   # When true, an inline finding is ALSO tagged with a category (security/correctness/performance/
+#   # maintainability/tests/style) -- the AI reviewer self-categorizes, with a deterministic path/keyword
+#   # fallback for whatever it omits. Only takes effect when inline_comments is already on. Bool or null.
+#   # Default: null/false.
+#   finding_categories: false
 #   # Maintainer-declared DETERMINISTIC content assertions (title/description must contain a phrase, a
 #   # label must be present), optionally gated to a path glob. A failed check is advisory by default;
 #   # `enforce: true` makes it a hard gate blocker. Empty/default ⇒ no finding (no AI judgment involved).

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -349,6 +349,7 @@ describe(".gittensory.yml.example field-exhaustiveness (#1670)", () => {
     inlineComments: "inline_comments:",
     suggestions: "suggestions:",
     changedFilesSummary: "changed_files_summary:",
+    findingCategories: "finding_categories:",
     pathInstructions: "path_instructions:",
     instructions: "instructions:",
     excludePaths: "exclude_paths:",


### PR DESCRIPTION
## Summary

- **`main` is currently broken**: #3635 (merged 2026-07-05T21:18Z) added a compile-time exhaustiveness map in `test/unit/focus-manifest.test.ts` (`REVIEW_FIELD_TOKENS satisfies Record<Exclude<keyof FocusManifestReviewConfig, "present">, string>`) that predates #1958's `review.finding_categories` field, which merged separately around the same time. The map is missing the `findingCategories` key the `satisfies` check now requires, so `npm run typecheck` currently fails on `main`. Fixed by documenting `review.finding_categories` in `.gittensory.yml.example` (mirroring the `review.changed_files_summary` entry immediately above it) and adding the corresponding map entry.
- **Injection-detector false positive**: also flagged by gittensory's own review on #3635 before it merged (the PR merged without addressing it). `.gittensory.yml.example`'s new `gate.aiReview.onMerge` comment says "Per-repo override of the synthesis merge rule" — this matches gittensory's own `INJECTION_SOURCE` pattern for "override ... the ... rule" (a prompt-manipulation heuristic in `src/review/prompt-injection.ts`), so the review pipeline redacted it to `[external-instruction-redacted]` before the AI reviewer ever saw it. Confirmed via a direct regex test that this is a genuine false positive (the text is ordinary config documentation, nothing resembling an actual instruction) and that no other phrase in the file matches. Reworded "rule" to "mode", preserving the exact meaning.

No linked issue — this is a direct fix restoring `main` to a working state plus a follow-up correction on an already-merged PR; both are evidenced above rather than tracked separately.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused: two small, independently-evidenced doc/test fixes in the same two files #3635 touched.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] No issue link — see Summary for the concrete evidence (a failing `npm run typecheck` and a reproduced regex match) in place of a tracked issue.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck` — confirmed FAILING on `main` before this change (missing `findingCategories` key), PASSING after.
- [x] `npm run test:coverage` — N/A, zero `src/**` lines changed (only `.gittensory.yml.example`, a doc/test file); confirmed no coverage obligation.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has tests: the exhaustiveness test itself (`test/unit/focus-manifest.test.ts`) now correctly asserts `review.finding_categories` is documented; ran the full affected suite (`test/unit/focus-manifest.test.ts`, 426 tests) plus `npm run test:changed` locally, all green.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — doc/test-only.)
- [x] UI changes use live API data or real empty/error/loading states. (N/A.)
- [x] Visible UI changes include a `UI Evidence` section. (N/A — no `apps/gittensory-ui` changes.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (This PR IS the doc fix; no changelog touched.)

## Notes

Verified the false-positive claim directly rather than assuming it:
```
node -e '... same INJECTION_SOURCE regex from src/review/prompt-injection.ts ...'
// -> "override of the synthesis merge rule" (1 match, now 0 after the reword)
```