### PR TITLE
docs(miner): document miner_claims schema in claim ledger

### DIFF
--- a/packages/gittensory-miner/lib/claim-ledger.js
+++ b/packages/gittensory-miner/lib/claim-ledger.js
@@ -81,6 +81,14 @@ export function openClaimLedger(dbPath = resolveClaimLedgerDbPath()) {
   // LOCAL bookkeeping only: this table records which issues this miner instance has soft-claimed on this
   // machine. It does NOT adjudicate contested duplicates — sibling miners claiming the same issue are
   // resolved elsewhere via `isDuplicateClusterWinnerByClaim` from `@jsonbored/gittensory-engine` (#3355).
+  //
+  // miner_claims schema (#3352):
+  //   repo_full_name TEXT NOT NULL,
+  //   issue_number   INTEGER NOT NULL,
+  //   claimed_at     TEXT NOT NULL,
+  //   status         TEXT NOT NULL CHECK(status IN ('active','released','expired')),
+  //   UNIQUE (repo_full_name, issue_number) — one row per claimed issue (id is the surrogate primary key).
+  // Release/expire moments are recorded via status transitions, not a separate released_at column.
   db.exec(`
     CREATE TABLE IF NOT EXISTS miner_claims (
       id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/test/unit/miner-claim-ledger.test.ts
+++ b/test/unit/miner-claim-ledger.test.ts
@@ -141,6 +141,17 @@ describe("gittensory-miner claim ledger (#2314)", () => {
     expect(source).toContain("isDuplicateClusterWinnerByClaim");
   });
 
+  it("documents the miner_claims schema columns and uniqueness constraint (#3352)", () => {
+    const source = readFileSync("packages/gittensory-miner/lib/claim-ledger.js", "utf8");
+    expect(source).toContain("miner_claims schema (#3352)");
+    expect(source).toContain("repo_full_name TEXT NOT NULL");
+    expect(source).toContain("issue_number   INTEGER NOT NULL");
+    expect(source).toContain("claimed_at     TEXT NOT NULL");
+    expect(source).toContain("status         TEXT NOT NULL CHECK(status IN ('active','released','expired'))");
+    expect(source).toContain("UNIQUE (repo_full_name, issue_number)");
+    expect(source).toContain("not a separate released_at column");
+  });
+
   it("claimIssue and listActiveClaims expose the foundation-phase API surface (#3351)", () => {
     const ledger = tempLedger();
     const claim = ledger.claimIssue("o/a", 42, "via-alias");


### PR DESCRIPTION
## Summary
- Document the foundation-phase `miner_claims` schema inline above the `CREATE TABLE`: `repo_full_name`, `issue_number`, `claimed_at`, `status` CHECK (`active`/`released`/`expired`), and `UNIQUE (repo_full_name, issue_number)`.
- Note that release/expire timing is captured via status transitions rather than a separate `released_at` column (the shipped schema extends the original sketch with `expired` for TTL expiry).
- Add a source-doc regression test so the schema comment cannot drift silently.

Closes #3352

## Test plan
- [x] `test/unit/miner-claim-ledger.test.ts` — #3352 schema doc assertion (15 tests total)
- [x] `npm run build --workspace @jsonbored/gittensory-miner`


Made with [Cursor](https://cursor.com)