### PR TITLE
feat(miner): document claim ledger and verify schema via PRAGMA

### DIFF
--- a/packages/gittensory-miner/README.md
+++ b/packages/gittensory-miner/README.md
@@ -28,6 +28,10 @@ The package also includes an append-only governor decision ledger: `initGovernor
 persist structured allow/deny/throttle/kill-switch outcomes in local SQLite for contributor audit. Insert-only —
 no enforcement wiring yet. (#2328)
 
+The package also includes a local soft-claim ledger: `openClaimLedger` / `claimIssue` / `releaseClaim` /
+`listActiveClaims` persist which issues this miner instance has claimed on this machine. The table is local
+bookkeeping only — duplicate winners are adjudicated elsewhere via `@jsonbored/gittensory-engine`. (#2291)
+
 ## Install
 
 See [`docs/miner-goal-spec.md`](docs/miner-goal-spec.md) for the `.gittensory-miner.yml` field reference and [`.gittensory-miner.yml.example`](../../.gittensory-miner.yml.example) at the repo root.

--- a/test/unit/miner-claim-ledger-readme.test.ts
+++ b/test/unit/miner-claim-ledger-readme.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const readmePath = join(process.cwd(), "packages/gittensory-miner/README.md");
+
+describe("gittensory-miner claim ledger README (#2291)", () => {
+  it("documents the foundation claim ledger API surface", () => {
+    const readme = readFileSync(readmePath, "utf8");
+    expect(readme).toContain("claimIssue");
+    expect(readme).toContain("releaseClaim");
+    expect(readme).toContain("listActiveClaims");
+    expect(readme).toContain("bookkeeping only");
+    expect(readme).toContain("@jsonbored/gittensory-engine");
+  });
+});

--- a/test/unit/miner-claim-ledger.test.ts
+++ b/test/unit/miner-claim-ledger.test.ts
@@ -1,6 +1,7 @@
 import { mkdtempSync, readFileSync, rmSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   CLAIM_STATUSES,
@@ -174,6 +175,49 @@ describe("gittensory-miner claim ledger (#2314)", () => {
     expect(listActiveClaims()).toEqual([claim]);
     expect(listActiveClaims("o/a")).toEqual([claim]);
     expect(listActiveClaims("o/missing")).toEqual([]);
+  });
+
+  it("creates miner_claims with the foundation schema (#3352)", () => {
+    const ledger = tempLedger();
+    const db = new DatabaseSync(ledger.dbPath, { readonly: true });
+    type TableColumn = { name: string; notnull: number; dflt_value: string | null; pk: number };
+    const columns = db.prepare("PRAGMA table_info(miner_claims)").all() as TableColumn[];
+    expect(columns.map((column) => column.name)).toEqual([
+      "id",
+      "repo_full_name",
+      "issue_number",
+      "claimed_at",
+      "status",
+      "note",
+    ]);
+    for (const name of ["repo_full_name", "issue_number", "claimed_at", "status"]) {
+      expect(columns.find((column) => column.name === name)?.notnull).toBe(1);
+    }
+    expect(columns.find((column) => column.name === "status")?.dflt_value).toBe("'active'");
+    expect(columns.find((column) => column.name === "id")?.pk).toBe(1);
+
+    const uniqueIndexes = (db.prepare("PRAGMA index_list(miner_claims)").all() as Array<{ name: string; unique: number }>)
+      .filter((index) => index.unique === 1);
+    expect(uniqueIndexes.length).toBeGreaterThan(0);
+    const indexCols = db.prepare(`PRAGMA index_info('${uniqueIndexes[0]!.name}')`).all() as Array<{ name: string }>;
+    expect(indexCols.map((column) => column.name).sort()).toEqual(["issue_number", "repo_full_name"]);
+    db.close();
+
+    const writable = new DatabaseSync(ledger.dbPath);
+    expect(() =>
+      writable.exec(
+        "INSERT INTO miner_claims (repo_full_name, issue_number, claimed_at, status) VALUES ('o/a', 1, '2026-01-01T00:00:00.000Z', 'bogus')",
+      ),
+    ).toThrow();
+    writable.close();
+  });
+
+  it("scopes active claims per repo (#3354)", () => {
+    const ledger = tempLedger();
+    ledger.claimIssue("o/a", 1);
+    ledger.claimIssue("o/b", 2);
+    expect(ledger.listActiveClaims("o/a").map((claim) => claim.issueNumber)).toEqual([1]);
+    expect(ledger.listActiveClaims("o/b").map((claim) => claim.issueNumber)).toEqual([2]);
   });
 });
 


### PR DESCRIPTION
## Summary
- Document the foundation claim ledger in the miner README (`openClaimLedger`, `claimIssue`, `releaseClaim`, `listActiveClaims`) and note it is local bookkeeping only.
- Add PRAGMA-based regression tests that verify the live `miner_claims` columns, NOT NULL constraints, default `active` status, UNIQUE `(repo_full_name, issue_number)`, and CHECK rejection of invalid statuses (#3352).
- Add explicit cross-repo `listActiveClaims` scoping coverage (#3354).

Closes #2291
Closes #3352

## Test plan
- [x] `test/unit/miner-claim-ledger.test.ts` — PRAGMA schema + repo scoping (16 tests)
- [x] `test/unit/miner-claim-ledger-readme.test.ts` — README API surface
- [x] `npm run build --workspace @jsonbored/gittensory-miner`


Made with [Cursor](https://cursor.com)