### PR TITLE
feat(engine): add countPlanReadySteps plan DAG helper

### DIFF
--- a/packages/gittensory-engine/README.md
+++ b/packages/gittensory-engine/README.md
@@ -540,6 +540,7 @@ dashboard progress summaries:
 - `isPlanProgressComplete(plan)` — every step is `completed` or `skipped` (empty plans are not complete; mirrors `planProgress`'s `completed` status)
 - `resolvePlanOverallStatus(plan)` — coarse status (`pending` | `running` | `completed` | `failed` | `blocked`); mirrors `planProgress`'s `status`
 - `hasPlanReadySteps(plan)` — any step is runnable now (`pending` with satisfied dependencies; mirrors `nextReadySteps(plan).length > 0`)
+- `countPlanReadySteps(plan)` — number of runnable steps now (mirrors `nextReadySteps(plan).length`)
 - `isPlanTerminated(plan)` — plan reached a terminal outcome (`failed` step or every step `completed`/`skipped`; empty plans are not terminated)
 
 ## Opportunity competition

--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -149,7 +149,7 @@ export { hasPlanCompletedSteps } from "./plan-completed.js";
 export { isPlanBlocked } from "./plan-blocked.js";
 export { isPlanProgressComplete } from "./plan-progress-complete.js";
 export { resolvePlanOverallStatus, type PlanOverallStatus } from "./plan-overall-status.js";
-export { hasPlanReadySteps } from "./plan-ready.js";
+export { hasPlanReadySteps, countPlanReadySteps } from "./plan-ready.js";
 export { isPlanTerminated } from "./plan-terminated.js";
 export * from "./plan-templates.js";
 export * from "./portfolio/queue.js";

--- a/packages/gittensory-engine/src/plan-ready.ts
+++ b/packages/gittensory-engine/src/plan-ready.ts
@@ -16,3 +16,11 @@ function nextReadySteps(plan: PlanDag): PlanStep[] {
 export function hasPlanReadySteps(plan: PlanDag): boolean {
   return nextReadySteps(plan).length > 0;
 }
+
+/**
+ * Count steps runnable now: `pending` with every dependency `completed` or `skipped`. Mirrors hosted
+ * `nextReadySteps(plan).length`. Pure.
+ */
+export function countPlanReadySteps(plan: PlanDag): number {
+  return nextReadySteps(plan).length;
+}

--- a/test/unit/plan-ready-count.test.ts
+++ b/test/unit/plan-ready-count.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from "vitest";
+
+import { countPlanReadySteps, hasPlanReadySteps } from "../../packages/gittensory-engine/src/plan-ready";
+import type { PlanStep } from "../../packages/gittensory-engine/src/plan-export";
+import { nextReadySteps } from "../../src/services/plan-dag";
+
+function step(over: Partial<PlanStep> & { id: string; title: string }): PlanStep {
+  return {
+    actionClass: undefined,
+    dependsOn: [],
+    status: "pending",
+    attempts: 0,
+    maxAttempts: 3,
+    lastError: null,
+    ...over,
+  };
+}
+
+describe("countPlanReadySteps", () => {
+  it("returns zero for an empty plan", () => {
+    expect(countPlanReadySteps({ steps: [] })).toBe(0);
+    expect(hasPlanReadySteps({ steps: [] })).toBe(false);
+  });
+
+  it("returns one when a single pending step has no dependencies", () => {
+    const plan = { steps: [step({ id: "a", title: "Build", status: "pending" })] };
+    expect(countPlanReadySteps(plan)).toBe(1);
+    expect(hasPlanReadySteps(plan)).toBe(true);
+  });
+
+  it("returns two when two independent pending steps are ready", () => {
+    const plan = {
+      steps: [
+        step({ id: "a", title: "Build", status: "pending" }),
+        step({ id: "b", title: "Lint", status: "pending" }),
+      ],
+    };
+    expect(countPlanReadySteps(plan)).toBe(2);
+  });
+
+  it("returns one when only the root pending step is ready in a chain", () => {
+    const plan = {
+      steps: [
+        step({ id: "a", title: "Build", status: "pending" }),
+        step({ id: "b", title: "Test", status: "pending", dependsOn: ["a"] }),
+      ],
+    };
+    expect(countPlanReadySteps(plan)).toBe(1);
+  });
+
+  it("returns one when a pending step's dependencies are satisfied", () => {
+    const plan = {
+      steps: [
+        step({ id: "a", title: "Build", status: "completed" }),
+        step({ id: "b", title: "Test", status: "pending", dependsOn: ["a"] }),
+      ],
+    };
+    expect(countPlanReadySteps(plan)).toBe(1);
+  });
+
+  it("returns zero for a cyclic deadlock with no ready steps", () => {
+    const plan = {
+      steps: [
+        step({ id: "a", title: "A", dependsOn: ["b"] }),
+        step({ id: "b", title: "B", dependsOn: ["a"] }),
+      ],
+    };
+    expect(countPlanReadySteps(plan)).toBe(0);
+    expect(hasPlanReadySteps(plan)).toBe(false);
+  });
+
+  it("returns zero when a pending step depends on a missing step id", () => {
+    const plan = { steps: [step({ id: "a", title: "A", dependsOn: ["ghost"] })] };
+    expect(countPlanReadySteps(plan)).toBe(0);
+  });
+
+  it("returns zero when every step is completed or skipped", () => {
+    const plan = {
+      steps: [
+        step({ id: "a", title: "Build", status: "completed" }),
+        step({ id: "b", title: "Deploy", status: "skipped" }),
+      ],
+    };
+    expect(countPlanReadySteps(plan)).toBe(0);
+  });
+
+  it("returns zero when only running or failed steps remain", () => {
+    const plan = {
+      steps: [
+        step({ id: "a", title: "Build", status: "running" }),
+        step({ id: "b", title: "Deploy", status: "failed" }),
+      ],
+    };
+    expect(countPlanReadySteps(plan)).toBe(0);
+  });
+
+  it("matches hosted nextReadySteps(plan).length on shared fixtures", () => {
+    const plan = {
+      steps: [
+        step({ id: "a", title: "Build", status: "completed" }),
+        step({ id: "b", title: "Test", status: "pending", dependsOn: ["a"] }),
+        step({ id: "c", title: "Deploy", status: "pending", dependsOn: ["b"] }),
+      ],
+    };
+    expect(countPlanReadySteps(plan)).toBe(nextReadySteps(plan).length);
+  });
+
+  it("is exported from the package barrel", async () => {
+    const barrel = await import("../../packages/gittensory-engine/src/index");
+    expect(typeof barrel.countPlanReadySteps).toBe("function");
+    expect(
+      barrel.countPlanReadySteps({
+        steps: [step({ id: "a", title: "A", status: "pending" })],
+      }),
+    ).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `countPlanReadySteps(plan)` — returns how many steps are runnable now (`pending` with satisfied dependencies).
- Mirrors hosted `nextReadySteps(plan).length`; includes a parity assertion against `src/services/plan-dag`.
- Document the helper in the engine README export list.

Closes #2298

## Test plan
- [x] `test/unit/plan-ready-count.test.ts` — counts, edge cases, hosted parity, barrel export
- [x] `npm run build --workspace @jsonbored/gittensory-engine && npm run build:miner`


Made with [Cursor](https://cursor.com)