### PR TITLE
docs(miner): document claim ledger in README (#2291)

### DIFF
--- a/packages/gittensory-miner/README.md
+++ b/packages/gittensory-miner/README.md
@@ -28,6 +28,10 @@ The package also includes an append-only governor decision ledger: `initGovernor
 persist structured allow/deny/throttle/kill-switch outcomes in local SQLite for contributor audit. Insert-only —
 no enforcement wiring yet. (#2328)
 
+The package also includes a local soft-claim ledger: `openClaimLedger` / `claimIssue` / `releaseClaim` /
+`listActiveClaims` persist which issues this miner instance has claimed on this machine. The table is local
+bookkeeping only — duplicate winners are adjudicated elsewhere via `@jsonbored/gittensory-engine`. (#2291)
+
 ## Install
 
 See [`docs/miner-goal-spec.md`](docs/miner-goal-spec.md) for the `.gittensory-miner.yml` field reference and [`.gittensory-miner.yml.example`](../../.gittensory-miner.yml.example) at the repo root.

--- a/test/unit/miner-claim-ledger-readme.test.ts
+++ b/test/unit/miner-claim-ledger-readme.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const readmePath = join(process.cwd(), "packages/gittensory-miner/README.md");
+
+describe("gittensory-miner claim ledger README (#2291)", () => {
+  it("documents the foundation claim ledger API surface", () => {
+    const readme = readFileSync(readmePath, "utf8");
+    expect(readme).toContain("openClaimLedger");
+    expect(readme).toContain("claimIssue");
+    expect(readme).toContain("releaseClaim");
+    expect(readme).toContain("listActiveClaims");
+    expect(readme).toContain("bookkeeping only");
+    expect(readme).toContain("@jsonbored/gittensory-engine");
+  });
+});


### PR DESCRIPTION
## Summary
- Document the foundation claim ledger in the miner README (`openClaimLedger`, `claimIssue`, `releaseClaim`, `listActiveClaims`) and note it is local bookkeeping only.
- Add a README contract test so the documented API surface stays in sync.

Closes #2291

## Test plan
- [x] `test/unit/miner-claim-ledger-readme.test.ts` — README API surface
- [x] `npm run typecheck`
- [x] `npm run build --workspace @jsonbored/gittensory-miner`


Made with [Cursor](https://cursor.com)