### PR TITLE
fix(test): decouple miner workspace-discoverability check from npm ls exit code

### DIFF
--- a/test/unit/miner-package-skeleton.test.ts
+++ b/test/unit/miner-package-skeleton.test.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "node:child_process";
+import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
@@ -47,12 +47,16 @@ describe("gittensory-miner package skeleton (#2287)", () => {
   });
 
   it("is discoverable from the repo root workspace", () => {
-    const listing = execFileSync(
+    // `npm ls` exits non-zero whenever ANY package anywhere in the WHOLE resolved tree is extraneous/invalid,
+    // even though `--workspace` only scopes the DISPLAYED subtree -- unrelated tree-wide dependency drift
+    // elsewhere in the monorepo (#3663) would otherwise fail this assertion via execFileSync's throw-on-nonzero
+    // behavior. spawnSync never throws; assert on stdout content directly, decoupled from the exit code.
+    const result = spawnSync(
       "npm",
       ["ls", "--workspace", "@jsonbored/gittensory-miner", "--depth=0"],
       { cwd: process.cwd(), encoding: "utf8" },
     );
-    expect(listing).toContain("@jsonbored/gittensory-miner@");
+    expect(result.stdout).toContain("@jsonbored/gittensory-miner@");
   });
 
   it("serves --help and --version from the bin entry", () => {


### PR DESCRIPTION
## Summary

- `test/unit/miner-package-skeleton.test.ts`'s "is discoverable from the repo root workspace" test used `execFileSync`, which throws on a non-zero child exit. `npm ls` exits non-zero whenever any package anywhere in the whole resolved dependency tree is extraneous/invalid, even though `--workspace` only scopes the *displayed* subtree — so this test fails on tree-wide dependency drift that has nothing to do with the miner package's own health.
- Confirmed failing on `main` itself in CI (Linux runner), not just a PR branch — commit `5c16be36`'s own CI run hit the identical `ELSPROBLEMS` (`extraneous: @emnapi/runtime`, `invalid: @types/node@24.13.2`), neither of which belongs to the miner package's own subtree. Not reproducible via a fresh `npm ci` on macOS — confirmed environment-specific, not a real regression (typecheck and all 9787 other tests passed in the same CI run).
- Swapped `execFileSync` for `spawnSync` (never throws, returns `{ stdout, stderr, status }`) and assert on `stdout` content directly — decoupled from the exit code, matching the test's actual intent ("is the workspace discoverable"), which doesn't require the rest of the monorepo's tree to be perfectly clean.

Closes #3663

## Scope

- [x] `test/unit/miner-package-skeleton.test.ts` only — no `src/**` changes, no application behavior change

## Validation

- `npx vitest run test/unit/miner-package-skeleton.test.ts` — 5/5 passing
- `npm run typecheck` — clean
- Verified `spawnSync`'s never-throws / stdout-always-captured behavior directly (`node -e` repro) before relying on it
- No coverage obligation: this file is under `test/**`, which Codecov ignores per this repo's patch-coverage config

## Safety

- [x] No secrets, wallet/hotkey/trust-score/reward terms introduced
- [x] Test-infrastructure-only change; does not touch any `src/**` review/gate logic