### PR TITLE
fix(review): preserve manual review holds during cleanup

### DIFF
--- a/src/settings/agent-actions.ts
+++ b/src/settings/agent-actions.ts
@@ -906,17 +906,15 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
               : {}),
       });
     }
-    // Stale disposition-label cleanup (#stale-disposition-label-cleanup): the four states above
-    // (readyToMerge/manualReview/migrationCollision/changesRequested) are mutually exclusive — a PR should
-    // carry exactly one. But the ternary above only ever ADDS the current one; a label from a PRIOR pass
+    // Stale disposition-label cleanup (#stale-disposition-label-cleanup): the review-state labels below
+    // (readyToMerge/migrationCollision/changesRequested) are mutually exclusive bot dispositions — a PR should
+    // carry at most one. But the ternary above only ever ADDS the current one; a label from a PRIOR pass
     // (e.g. changesRequested while CI was red) never got removed once the PR became healthy again, so it sat
     // on the PR forever alongside whatever the bot added next. Clear every OTHER configured sibling that is
-    // still live on the PR. `manualReview` is excluded from this pass's removal when `manualHoldReason` is
-    // non-null even though it isn't this ternary's own `label` choice (e.g. ciUnverified: reviewGood is false
-    // so the ternary picks changesRequested here, but the separate owner/automation fallback below still
-    // independently wants manualReview and may re-add it later in this SAME pass) — removing it here would
-    // race against that later add.
-    const dispositionLabelSiblings = [labels.readyToMerge, labels.manualReview, labels.migrationCollision, labels.changesRequested];
+    // still live on the PR. Intentionally do NOT remove `manualReview` here: that same label is also the live
+    // maintainer safety hold/freeze, and the planner has no provenance bit proving it was only a stale bot
+    // disposition rather than a human-applied hold. Only a maintainer removing the label should lift it.
+    const dispositionLabelSiblings = [labels.readyToMerge, labels.migrationCollision, labels.changesRequested];
     const livePrLabels = new Set(input.pr.labels.map((l) => l.toLowerCase()));
     // Dedupe defensively: if a repo ever misconfigures two of the four settings to the identical label
     // string, only clear it once (still correct — the label either belongs here or it doesn't — just
@@ -926,7 +924,6 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
       if (stale === null || stale === label) continue;
       const staleLower = stale.toLowerCase();
       if (alreadyHandled.has(staleLower) || !livePrLabels.has(staleLower)) continue;
-      if (stale === labels.manualReview && manualHoldReason !== null) continue;
       alreadyHandled.add(staleLower);
       actions.push({
         actionClass: "label",

--- a/test/unit/agent-actions.test.ts
+++ b/test/unit/agent-actions.test.ts
@@ -127,12 +127,14 @@ describe("planAgentMaintenanceActions (#778)", () => {
       expect(plan).toContainEqual(expect.objectContaining({ actionClass: "label", label: AGENT_LABEL_CHANGES, labelOp: "remove" }));
     });
 
-    it("clears a stale manual-review label once the guardrail no longer hits", () => {
-      // No guardrailHit this pass (changedPaths/hardGuardrailGlobs empty, the default) — a prior pass's
-      // manual-review hold has resolved, so it must not linger once the PR is genuinely ready-to-merge.
-      const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { review_state_label: "auto" }, pr: { labels: [AGENT_LABEL_NEEDS_REVIEW] } }));
+    it("does NOT clear manual-review when the PR becomes healthy because it may be a maintainer safety hold", () => {
+      // No guardrailHit this pass (changedPaths/hardGuardrailGlobs empty, the default), but the planner has no
+      // provenance bit proving manual-review was bot-owned rather than a maintainer-applied hold. It may still
+      // add the ready label, but it must not lift the live hold before approve/merge actions run.
+      const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { approve: "auto", merge: "auto", review_state_label: "auto" }, autoMaintain: { requireApprovals: 0, mergeMethod: "squash" }, pr: { labels: [AGENT_LABEL_NEEDS_REVIEW], mergeableState: "clean" } }));
       expect(plan).toContainEqual(expect.objectContaining({ actionClass: "label", label: AGENT_LABEL_READY }));
-      expect(plan).toContainEqual(expect.objectContaining({ actionClass: "label", label: AGENT_LABEL_NEEDS_REVIEW, labelOp: "remove" }));
+      expect(plan.some((a) => a.actionClass === "label" && a.label === AGENT_LABEL_NEEDS_REVIEW && a.labelOp === "remove")).toBe(false);
+      expect(classes(plan)).toEqual(["label", "approve", "merge"]);
     });
 
     it("clears a stale ready-to-merge label when the PR newly becomes guarded", () => {


### PR DESCRIPTION
### Motivation
- Fix a security/regression where the planner could remove the configured `manualReview` label as a "stale" disposition and then approve/merge in the same planned batch, bypassing the maintainer-applied safety hold.
- The `manualReview` label is used both as a bot disposition and as a live maintainer freeze, so planner actions must not remove maintainer-owned holds without provenance.

### Description
- Stop including the configured `manualReview` label in the stale disposition sibling cleanup in `src/settings/agent-actions.ts` so automation no longer emits a remove action for that label.
- Update the cleanup comment to document that `manualReview` is a maintainer safety hold and must not be removed by the planner.
- Replace the previous unit test that expected stale manual-review removal with a regression test in `test/unit/agent-actions.test.ts` that asserts the planner does not emit a `labelOp: "remove"` for `manual-review` while still allowing `ready`/`approve`/`merge` to be planned for executor-side live hold enforcement.
- Minor formatting/typing tidy in the same module while editing (no behavior change beyond the manual-review exclusion).

### Testing
- Ran the modified unit test file with `npx vitest run test/unit/agent-actions.test.ts --reporter=verbose` and the local suite covering that file passed (`230` tests in the file passed). 
- Verified `git diff --check` and local `npx vitest` runs for the targeted tests (no failing assertions in the changed tests). 
- Full gate `npm run test:ci` did not complete green in this environment because an unrelated long-running coverage run surfaced other existing test failures and the job was terminated; the change itself is covered by the updated unit tests. 
- `npm audit --audit-level=moderate` was blocked by the environment (registry/audit endpoint returned `403`), so dependency-audit could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ab66b31b4832c8c897e99f31d4594)