### PR TITLE
feat(review): capture full-page screenshots for before/after evidence

### DIFF
--- a/src/review/visual/shot.ts
+++ b/src/review/visual/shot.ts
@@ -161,7 +161,12 @@ export async function captureShot(env: Env, url: string, viewport: Viewport = VI
       console.log(JSON.stringify({ ev: "render_screenshot_auth_walled", url, final: page.url().slice(0, 200) }));
       return { png: null, authWalled: true };
     }
-    const shot = (await page.screenshot({ type: "png", fullPage: false })) as Uint8Array;
+    // Full-page (not just the viewport): before/after must show the SAME position on the page for any
+    // change, however far down it is. A viewport-only shot only captures whatever happens to be in frame at
+    // load time, which for a change midway down a long page would silently miss it in both cells. Capturing
+    // the whole scrollable height means the changed region is always present in both images at the same
+    // relative offset, with no need to locate/scroll to it first.
+    const shot = (await page.screenshot({ type: "png", fullPage: true })) as Uint8Array;
     return { png: shot, authWalled: false };
   } catch (error) {
     // Log before degrading to null — otherwise a networkidle0 timeout, a binding quota error, or a render

--- a/test/unit/visual-shot.test.ts
+++ b/test/unit/visual-shot.test.ts
@@ -112,6 +112,14 @@ describe("visual screenshot on-demand SSRF guard", () => {
     expect(mocks.screenshot).toHaveBeenCalled();
   });
 
+  it("captures the FULL page, not just the viewport — before/after must show the same page position for a change however far down it is", async () => {
+    mocks.finalUrl = "https://preview.pages.dev/page";
+
+    await handleShot(request("https://preview.pages.dev/page"), env());
+
+    expect(mocks.screenshot).toHaveBeenCalledWith({ type: "png", fullPage: true });
+  });
+
   it("captureShot rejects an unsafe target before launching the browser (defense-in-depth)", async () => {
     const result = await captureShot(env(), "http://127.0.0.1/admin");
     expect(result).toEqual({ png: null, authWalled: false });


### PR DESCRIPTION
## Summary

- `src/review/visual/shot.ts`'s `captureShot` switches from a viewport-only render (`fullPage: false`, fixed 1440×900/390×844) to a full-page render (`fullPage: true`). Before/after screenshots now always show the same position on the page for any change, however far down it is — previously a change midway down a long page fell outside the fixed viewport and was silently absent from both cells.
- No config knob needed — this is a correctness fix to the existing capture, not a new opt-in feature.
- First phase of a larger visual-evidence upgrade (pixel-diff overlay, theme matrix, GIF capture, AI vision analysis) — see issue #3667 and epic #3607 for the full roadmap.

Closes #3667. Part of #3607.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint` (not run — no workflow files changed)
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers` (not run — no Worker-runtime-specific code touched beyond the existing shot.ts module)
- [x] `npm run build:mcp` (not run — no MCP package changes)
- [x] `npm run test:mcp-pack` (not run — no MCP package changes)
- [x] `npm run ui:openapi:check` (not run — no API/OpenAPI changes)
- [x] `npm run ui:lint` (not run — no `apps/gittensory-ui/**` changes)
- [x] `npm run ui:typecheck` (not run — no `apps/gittensory-ui/**` changes)
- [x] `npm run ui:build` (not run — no `apps/gittensory-ui/**` changes)
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Only `src/review/visual/shot.ts` and its direct test changed — no UI, MCP, wrangler binding, OpenAPI, or workflow files touched, so those checks have no surface to exercise. Ran `npx tsc --noEmit -p .` (full project, clean) and the full `visual-*` test suite (75 tests across 7 files, all passing) locally.
- **Real end-to-end verification beyond unit tests**: built a standalone script using `puppeteer-core` connecting to a real `browserless/chromium` container (the same self-host infra shipped in #3608/#3633) and navigated a real headless Chrome to a deliberately long (7300px) local test page with a marker div placed roughly 3800px down. Confirmed `page.screenshot({ fullPage: false })` produces a 1440×900 PNG that never shows the marker, while `page.screenshot({ fullPage: true })` — the exact call this PR makes — produces a 1440×7300 PNG (`file` command confirmed exact pixel dimensions) with the marker visible at its correct position (screenshot inspected visually, not just checked by byte size). This is the real mechanism the code change relies on, not a mock.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session/CORS changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP surface touched.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes.)
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots. (N/A — this changes the review-engine's OWN screenshot-capture mechanism, not a UI surface of gittensory itself; the real-render verification screenshot is described above rather than committed, per house rules against committing review-only evidence.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (No docs changes needed — this is an internal capture-quality fix with no new configurable surface.)

## Notes

- Part of a larger visual-evidence upgrade plan (full-page + pixel-diff overlay, theme matrix, scroll-through GIF capture, gated AI vision analysis, retention cleanup) — this PR is deliberately scoped to just the full-page switch as the foundation the rest builds on. Follow-up phases will be filed as separate sub-issues under epic #3607.