### PR TITLE
fix(enrichment): avoid i18n JSX text ReDoS

### DIFF
--- a/review-enrichment/src/analyzers/i18n-regression.ts
+++ b/review-enrichment/src/analyzers/i18n-regression.ts
@@ -23,8 +23,6 @@ const I18N_CONVENTION_RES = [
 const USER_FACING_PROP_RE =
   /\b(?:title|label|placeholder|aria-label|helperText|message|description|heading|tooltip|hint|alt|caption|subtitle|confirmText|cancelText|buttonText|emptyText)\s*=\s*["']([^"']+)["']/gi;
 
-const JSX_TEXT_RE = />\s*([^<{][^<]*?[A-Za-z][^<]*?)\s*</g;
-
 /** True when a line shows the repo uses an i18n/translation call convention. Pure. */
 export function detectI18nConvention(line: string): boolean {
   return I18N_CONVENTION_RES.some((re) => {
@@ -49,6 +47,24 @@ function isCommentOrImportLine(line: string): boolean {
   return /^(?:\/\/|\/\*|\*|<!--|import\b|from\b)/.test(trimmed);
 }
 
+function hasUserFacingJsxText(line: string): boolean {
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+    if (char !== ">") continue;
+
+    const textStart = i + 1;
+    const next = line[textStart];
+    if (next === undefined || next === "<" || next === "{") continue;
+
+    const close = line.indexOf("<", textStart);
+    if (close === -1) return false;
+    if (looksLikeUserFacingLiteral(line.slice(textStart, close))) return true;
+    i = close - 1;
+  }
+
+  return false;
+}
+
 /** True when one added UI line adds a hardcoded user-facing string, or null. Pure. */
 export function detectHardcodedUiString(line: string): boolean {
   if (isCommentOrImportLine(line)) return false;
@@ -59,12 +75,7 @@ export function detectHardcodedUiString(line: string): boolean {
     if (looksLikeUserFacingLiteral(propMatch[1] ?? "")) return true;
   }
 
-  JSX_TEXT_RE.lastIndex = 0;
-  let textMatch: RegExpExecArray | null;
-  while ((textMatch = JSX_TEXT_RE.exec(line))) {
-    const text = (textMatch[1] ?? "").trim();
-    if (looksLikeUserFacingLiteral(text)) return true;
-  }
+  if (hasUserFacingJsxText(line)) return true;
 
   return false;
 }

--- a/review-enrichment/test/i18n-regression.test.ts
+++ b/review-enrichment/test/i18n-regression.test.ts
@@ -34,6 +34,15 @@ test("detectHardcodedUiString: flags JSX text and user-facing props", () => {
   assert.equal(detectHardcodedUiString('<input className="w-full" />'), false);
 });
 
+test("detectHardcodedUiString: scans malformed JSX text in linear time", () => {
+  const craftedLine = ">a".repeat(1000);
+  const startedAt = performance.now();
+
+  assert.equal(detectHardcodedUiString(craftedLine), false);
+
+  assert.ok(performance.now() - startedAt < 100);
+});
+
 test("scanPatchForI18nRegression: flags hardcoded UI strings when i18n is in use", () => {
   const findings = scanPatchForI18nRegression(
     "src/Widget.tsx",


### PR DESCRIPTION
### Motivation
- The i18n regression analyzer used a global, backtracking-prone regex to extract JSX text nodes which can catastrophically backtrack on attacker-controlled long lines and block the event loop. 
- Replace the vulnerable pattern with a bounded, linear-time scan so added diff lines cannot cause CPU stalls or bypass the analyzer timeout.

### Description
- Remove the global `JSX_TEXT_RE` usage and add a small linear scanner `hasUserFacingJsxText(line: string)` that locates `>`→`<` text spans with `indexOf` and applies `looksLikeUserFacingLiteral` to the slice. 
- Wire the new scanner into `detectHardcodedUiString` so prop-literal scanning remains but JSX-text detection uses the linear routine instead of a regex. 
- Add a unit regression test that exercises malformed JSX-like input (`">a".repeat(1000)`) to assert the scanner returns quickly and does not produce a false positive.

### Testing
- Ran `npm --prefix review-enrichment test` and the review-enrichment test suite passed (all tests succeeded). 
- Ran `npm audit --audit-level=moderate` which failed due to the registry audit endpoint returning `403 Forbidden` (audit could not complete).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ac21a4870832caa28388cf27baccd)