### PR TITLE
fix(review): meter tie-break judge budget

### DIFF
--- a/src/services/ai-review.ts
+++ b/src/services/ai-review.ts
@@ -1729,12 +1729,21 @@ export async function runGittensoryAiReview(
   const dual = combine !== "single" && (!configured || configured.length > 1);
   const freeAiCalls =
     (input.mode === "block" ? (dual ? 2 : 1) : 0) + (input.providerKey ? 0 : 1);
+  // Consensus disagreements may spend extra free calls on the order-swapped tie-break judge. Reserve the
+  // worst-case retry budget up front so the daily limiter remains a hard cap even when judge output is unstable.
+  const tieBreakAiCalls =
+    input.mode === "block" && dual && combine === "consensus"
+      ? 2 * 3 * (primaryFallback && primaryFallback !== primary.model ? 2 : 1)
+      : 0;
   // Estimate against the EFFECTIVE system prompt (`system`) so grounding's extra context is billed against the
   // budget. Flag-OFF, `system === REVIEW_SYSTEM_PROMPT`, so the estimate is byte-identical to today.
   const estimatedNeurons =
-    freeAiCalls === 0
+    (freeAiCalls === 0
       ? 0
-      : estimateNeurons(system.length + user.length, maxTokens, freeAiCalls);
+      : estimateNeurons(system.length + user.length, maxTokens, freeAiCalls)) +
+    (tieBreakAiCalls === 0
+      ? 0
+      : estimateNeurons(system.length + user.length, 512, tieBreakAiCalls));
   // FAIL-SAFE default (#budget-no-starve): the daily neuron budget is a runaway-LOOP backstop, not a normal-
   // operation gate. An absent/empty/non-numeric env var must default HIGH (the clamp max), never to a tiny value
   // that silently starves every dual-AI review into quota_exceeded — that exact misconfig (the deployed worker

--- a/test/unit/ai-review.test.ts
+++ b/test/unit/ai-review.test.ts
@@ -158,6 +158,25 @@ describe("runGittensoryAiReview gating", () => {
     expect(run).not.toHaveBeenCalled();
   });
 
+  it("still reserves the tie-break budget (at the x1 fallback multiplier) when a configured reviewer has no distinct fallback model", async () => {
+    // A self-host pair with no explicit `fallback` reuses its own model (primaryFallback === primary.model),
+    // so the worst-case tie-break reservation must fall back to the x1 multiplier instead of x2 -- still
+    // non-zero, still enforced against the shared daily budget.
+    const run = vi.fn();
+    const env = createTestEnv({
+      AI: { run } as unknown as Ai,
+      AI_SUMMARIES_ENABLED: "true",
+      AI_PUBLIC_COMMENTS_ENABLED: "true",
+      AI_DAILY_NEURON_BUDGET: "600",
+    });
+    await expect(
+      runGittensoryAiReview(env, { ...baseInput, mode: "block", reviewers: [{ model: "claude-code" }, { model: "codex" }] }),
+    ).resolves.toMatchObject({
+      status: "quota_exceeded",
+    });
+    expect(run).not.toHaveBeenCalled();
+  });
+
   it("clamps a non-numeric AI_MAX_OUTPUT_TOKENS back to the default", async () => {
     const run = vi.fn(async () => ({ response: reviewJson() }));
     const env = createTestEnv({

--- a/test/unit/ai-review.test.ts
+++ b/test/unit/ai-review.test.ts
@@ -142,6 +142,22 @@ describe("runGittensoryAiReview gating", () => {
     expect(run).not.toHaveBeenCalled();
   });
 
+  it("reserves consensus tie-break judge retries in the shared daily neuron budget", async () => {
+    const run = vi.fn();
+    const env = createTestEnv({
+      AI: { run } as unknown as Ai,
+      AI_SUMMARIES_ENABLED: "true",
+      AI_PUBLIC_COMMENTS_ENABLED: "true",
+      AI_DAILY_NEURON_BUDGET: "600",
+    });
+    await expect(
+      runGittensoryAiReview(env, { ...baseInput, mode: "block" }),
+    ).resolves.toMatchObject({
+      status: "quota_exceeded",
+    });
+    expect(run).not.toHaveBeenCalled();
+  });
+
   it("clamps a non-numeric AI_MAX_OUTPUT_TOKENS back to the default", async () => {
     const run = vi.fn(async () => ({ response: reviewJson() }));
     const env = createTestEnv({


### PR DESCRIPTION
Closes #3679

## Summary

- The order-swapped dual-AI tie-break path (#2997) performs additional judge calls — with retries and
  per-model fallback — that were never counted against the free daily AI neuron budget, letting a
  contributor spend extra provider usage beyond the configured limit by triggering repeated consensus
  disagreements.
- Reserves a worst-case `tieBreakAiCalls` budget (2 judge calls x up to 3 attempts x a per-model
  fallback multiplier) and adds it to `estimatedNeurons` in `runGittensoryAiReview`
  (`src/services/ai-review.ts`), gated on `mode === "block" && dual && combine === "consensus"` — the
  only path that can actually reach the tie-break judge.
- Two regression tests: the default two-distinct-models fallback multiplier (x2), and a self-host
  single-model configuration where a reviewer has no distinct fallback (`primaryFallback ===
  primary.model`), exercising the x1 multiplier branch.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused — one source file, one test file.
- [x] Follows `CONTRIBUTING.md`; no `site/`/`CNAME`/VitePress changes.
- [x] Linked issue: `Closes #3679`.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` — not run; no workflow files touched.
- [x] `npm run typecheck` (clean)
- [ ] `npm run test:coverage` (full/unsharded) — not run locally; ran the affected test file
      (`test/unit/ai-review.test.ts`, 153 tests, all green) plus the full `queue.test.ts` integration
      suite (732 tests). Cross-referenced the exact new-diff line/branch ranges against a fresh
      `coverage-final.json` (`--coverage.include='src/services/ai-review.ts'`): 100% of the new
      statements and branches are covered (the original patch was missing the x1-fallback-multiplier
      branch; closed with a second new test). GitHub CI runs the full suite/gate on push.
- [ ] `npm run test:workers` / `npm run build:mcp` / `npm run test:mcp-pack` — not run; nothing in
      those surfaces touched.
- [ ] `npm run ui:openapi:check` / `ui:lint` / `ui:typecheck` / `ui:build` — not run; no API/schema or
      `apps/gittensory-ui/**` changes.
- [ ] `npm audit --audit-level=moderate` — not run; no dependency changes.
- [x] New/changed behavior has regression tests for both branches of the new fallback-multiplier
      ternary, plus the existing quota-exceeded assertion pattern already used elsewhere in this file.

If any required check was skipped, explain why:

- Local validation here was typecheck + the specific affected test files rather than a full local
  `test:ci`/`test:coverage`/`npm audit` pass, since GitHub CI runs the complete gate on push and
  re-running the whole suite by hand for every change is redundant.

## Safety

- [x] No secrets, wallets, hotkeys, coldkeys, trust scores, or private scoring values are touched or
      exposed.
- [x] Not a public-facing text change (internal budget/neuron-estimation logic only).
- [x] Not an auth/CORS/session change; no negative-path tests needed for that reason.
- [x] Not an API/OpenAPI change.
- [ ] Not a UI change (N/A) — no `UI Evidence` section included.
- [x] No changelog edit.
