### PR TITLE
fix(review): require distinct PR for unlinked repeat close

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -2513,6 +2513,16 @@ export async function hasRecentAuditEvent(env: Env, actor: string, eventType: st
   return rows.length > 0;
 }
 
+export async function hasRecentAuditEventForOtherTarget(env: Env, actor: string, eventType: string, currentTargetKey: string, sinceIso: string): Promise<boolean> {
+  const db = getDb(env.DB);
+  const rows = await db
+    .select({ id: auditEvents.id })
+    .from(auditEvents)
+    .where(and(eq(auditEvents.actor, actor), eq(auditEvents.eventType, eventType), not(eq(auditEvents.targetKey, currentTargetKey)), gte(auditEvents.createdAt, sinceIso)))
+    .limit(1);
+  return rows.length > 0;
+}
+
 /** Count-returning variant of {@link hasRecentAuditEvent}, additionally scoped to one `targetKey` (e.g. a single
  *  `owner/repo#123` PR/issue) rather than the actor's activity across the whole repo. Backs the review-request
  *  nagging cooldown (#2463): counting how many `@gittensory` pings a contributor has sent on ONE thread within

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -2504,6 +2504,7 @@ async function runAgentMaintenancePlanAndExecute(
     unlinkedIssueGuardrailConfig.mode === "hold" && pr.linkedIssues.length === 0
       ? await resolveUnlinkedIssueMatchDisposition(env, {
           repoFullName,
+          pullNumber: pr.number,
           config: unlinkedIssueGuardrailConfig,
           linkedIssueCount: pr.linkedIssues.length,
           prTitle: pr.title,

--- a/src/review/unlinked-issue-guardrail.ts
+++ b/src/review/unlinked-issue-guardrail.ts
@@ -13,7 +13,7 @@
 // repo that hasn't opted in (the default) or a PR that already links an issue (the common case) pays
 // nothing beyond two boolean checks.
 
-import { hasRecentAuditEvent, listOpenIssues, recordAuditEvent } from "../db/repositories";
+import { hasRecentAuditEventForOtherTarget, listOpenIssues, recordAuditEvent } from "../db/repositories";
 import { findUnlinkedIssueCandidates, type CandidateOpenIssue } from "../signals/unlinked-issue-candidates";
 import type { UnlinkedIssueGuardrailConfig } from "../types";
 import { verifyUnlinkedIssueMatch } from "./unlinked-issue-match";
@@ -32,6 +32,7 @@ export type ResolveUnlinkedIssueMatchDispositionInput = {
   /** The PR's OWN linked-issue count (already extracted by the caller) -- the guardrail only ever runs
    *  against a PR that links NOTHING; a PR linking a different issue is out of scope for this check. */
   linkedIssueCount: number;
+  pullNumber: number;
   prTitle: string;
   prBody: string | null | undefined;
   changedPaths: string[];
@@ -42,23 +43,28 @@ export type ResolveUnlinkedIssueMatchDispositionInput = {
   prAuthorLogin: string | null | undefined;
 };
 
-/** Has this contributor triggered a confirmed unlinked-issue match anywhere (any repo) within the recency
- *  window? Fail-safe: a read error resolves to "no prior match" (never wrongly escalates on a DB hiccup). */
-async function hasPriorUnlinkedIssueMatch(env: Env, authorLogin: string): Promise<boolean> {
+/** Has this contributor triggered a confirmed unlinked-issue match on another PR (any repo) within the
+ *  recency window? Fail-safe: a read error resolves to "no prior match" (never wrongly escalates on a DB hiccup). */
+function unlinkedIssueMatchTargetKey(repoFullName: string, pullNumber: number): string {
+  return `${repoFullName}#${pullNumber}`;
+}
+
+async function hasPriorUnlinkedIssueMatch(env: Env, authorLogin: string, currentTargetKey: string): Promise<boolean> {
   const sinceIso = new Date(Date.now() - UNLINKED_ISSUE_MATCH_REPEAT_WINDOW_MS).toISOString();
-  return hasRecentAuditEvent(env, authorLogin, UNLINKED_ISSUE_MATCH_AUDIT_EVENT_TYPE, sinceIso).catch(() => false);
+  return hasRecentAuditEventForOtherTarget(env, authorLogin, UNLINKED_ISSUE_MATCH_AUDIT_EVENT_TYPE, currentTargetKey, sinceIso).catch(() => false);
 }
 
 /** Record THIS occurrence so a later PR from the same contributor can be recognized as a repeat. Fire-and-
  *  forget: a write failure must never block the gate -- worst case, a future occurrence fails open to a hold
  *  instead of escalating, never the reverse. */
-async function recordUnlinkedIssueMatchOccurrence(env: Env, repoFullName: string, authorLogin: string, issueNumber: number): Promise<void> {
+async function recordUnlinkedIssueMatchOccurrence(env: Env, repoFullName: string, pullNumber: number, authorLogin: string, issueNumber: number): Promise<void> {
   await recordAuditEvent(env, {
     eventType: UNLINKED_ISSUE_MATCH_AUDIT_EVENT_TYPE,
     actor: authorLogin,
-    targetKey: `${repoFullName}#${issueNumber}`,
+    targetKey: unlinkedIssueMatchTargetKey(repoFullName, pullNumber),
     outcome: "completed",
     detail: `unlinked PR diff matched open issue #${issueNumber} without a linking reference`,
+    metadata: { issueNumber },
   }).catch(() => undefined);
 }
 
@@ -101,8 +107,9 @@ export async function resolveUnlinkedIssueMatchDisposition(env: Env, input: Reso
         comment: `This PR doesn't link an issue, but its diff appears to directly solve #${candidate.issue.number}. If that's right, please add a linking reference (e.g. \`Closes #${candidate.issue.number}\`) so it's credited correctly; if this is a coincidence, a maintainer will clear this hold shortly.`,
       };
     }
-    const isRepeat = await hasPriorUnlinkedIssueMatch(env, authorLogin);
-    await recordUnlinkedIssueMatchOccurrence(env, input.repoFullName, authorLogin, candidate.issue.number);
+    const currentTargetKey = unlinkedIssueMatchTargetKey(input.repoFullName, input.pullNumber);
+    const isRepeat = await hasPriorUnlinkedIssueMatch(env, authorLogin, currentTargetKey);
+    await recordUnlinkedIssueMatchOccurrence(env, input.repoFullName, input.pullNumber, authorLogin, candidate.issue.number);
     if (isRepeat) {
       return {
         kind: "close",

--- a/test/unit/unlinked-issue-guardrail.test.ts
+++ b/test/unit/unlinked-issue-guardrail.test.ts
@@ -18,6 +18,7 @@ async function seedIssue(env: Awaited<ReturnType<typeof createTestEnv>>, number:
 
 const BASE_INPUT = {
   repoFullName: "owner/repo",
+  pullNumber: 101,
   linkedIssueCount: 0,
   prTitle: "fix webhook retry duplicate bug",
   prBody: null as string | null,
@@ -119,7 +120,7 @@ describe("resolveUnlinkedIssueMatchDisposition", () => {
   });
 
   describe("repeat-offense escalation (#unlinked-issue-guardrail-followup)", () => {
-    it("escalates to a CLOSE on a second confirmed match by the SAME contributor", async () => {
+    it("escalates to a CLOSE on a second confirmed match by the SAME contributor on a different PR", async () => {
       const run = vi.fn(async () => ({ response: JSON.stringify(aiVerdict()) }));
       const env = createTestEnv({ AI: { run } as unknown as Ai });
       await seedIssue(env, 7, "webhook retry duplicate bug", "retries duplicate events under load, needs a dedup key");
@@ -127,11 +128,23 @@ describe("resolveUnlinkedIssueMatchDisposition", () => {
       const first = await resolveUnlinkedIssueMatchDisposition(env, { ...BASE_INPUT, config: config() });
       expect(first?.kind).toBe("hold");
 
-      const second = await resolveUnlinkedIssueMatchDisposition(env, { ...BASE_INPUT, config: config() });
+      const second = await resolveUnlinkedIssueMatchDisposition(env, { ...BASE_INPUT, pullNumber: 102, config: config() });
       expect(second?.kind).toBe("close");
       expect(second?.reason).toContain("#7");
       expect(second?.reason).toContain("repeat");
       expect(second?.comment).toContain("already flagged");
+    });
+
+    it("does NOT escalate when the same confirmed PR is reprocessed", async () => {
+      const run = vi.fn(async () => ({ response: JSON.stringify(aiVerdict()) }));
+      const env = createTestEnv({ AI: { run } as unknown as Ai });
+      await seedIssue(env, 7, "webhook retry duplicate bug", "retries duplicate events under load, needs a dedup key");
+
+      const first = await resolveUnlinkedIssueMatchDisposition(env, { ...BASE_INPUT, pullNumber: 101, config: config() });
+      expect(first?.kind).toBe("hold");
+
+      const replay = await resolveUnlinkedIssueMatchDisposition(env, { ...BASE_INPUT, pullNumber: 101, config: config() });
+      expect(replay?.kind).toBe("hold");
     });
 
     it("does NOT escalate a second match by a DIFFERENT contributor", async () => {
@@ -166,7 +179,7 @@ describe("resolveUnlinkedIssueMatchDisposition", () => {
       const first = await resolveUnlinkedIssueMatchDisposition(env, { ...BASE_INPUT, config: config() });
       expect(first?.kind).toBe("hold");
 
-      const second = await resolveUnlinkedIssueMatchDisposition(env, { ...BASE_INPUT, repoFullName: "owner/other-repo", config: config() });
+      const second = await resolveUnlinkedIssueMatchDisposition(env, { ...BASE_INPUT, repoFullName: "owner/other-repo", pullNumber: 101, config: config() });
       expect(second?.kind).toBe("close");
     });
 


### PR DESCRIPTION
### Motivation
- Prevent a first-offense unlinked-issue hold from being auto-closed when the same PR is reprocessed or retried by ensuring repeat-detection excludes the current PR target.
- Record occurrences in a way that distinguishes the PR target so only a later distinct PR by the same contributor can escalate to an automated close.

### Description
- Added `hasRecentAuditEventForOtherTarget` to `src/db/repositories.ts` to query recent audit events for an actor/event type while excluding a specific `targetKey`.
- Threaded `pullNumber` into the unlinked-issue guardrail (`src/review/unlinked-issue-guardrail.ts`) and changed audit `targetKey` to `repoFullName#pullNumber`; store the matched `issueNumber` in `metadata` when recording the occurrence.
- Changed repeat check to call the new DB helper with the current PR target before recording the current occurrence so the same-PR replay does not count as a prior occurrence.
- Passed `pullNumber` into the resolver from the queue processor (`src/queue/processors.ts`).
- Added/updated regression tests in `test/unit/unlinked-issue-guardrail.test.ts` to assert that reprocessing the same PR remains a `hold` while a later distinct PR by the same contributor escalates to `close`.

### Testing
- Ran `npx vitest run test/unit/unlinked-issue-guardrail.test.ts` and the suite passed (16 tests passed).
- Ran `npx vitest run test/unit/unlinked-issue-guardrail.test.ts test/unit/agent-actions.test.ts` and both files passed (246 tests total passed).
- `npm run typecheck` succeeded with `tsc --noEmit` (no type errors).
- `git diff --check` was clean.
- `npm run test:coverage` was started but the full coverage run was interrupted by unrelated long-running/timeout failures in other test files; the targeted unit tests above passed.
- `npm audit --audit-level=moderate` could not complete due to registry audit endpoint returning `403 Forbidden` (external).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ac16801d4832c8bee0b34cc586678)