### PR TITLE
feat(enrichment): flag CORP unsafe-none in iac-misconfig

### DIFF
--- a/review-enrichment/src/analyzers/iac-misconfig.ts
+++ b/review-enrichment/src/analyzers/iac-misconfig.ts
@@ -116,6 +116,8 @@ const COOP_UNSAFE_NONE_RE =
   /\bCross-Origin-Opener-Policy\b[^\n]*\bunsafe-none\b/i;
 const COEP_UNSAFE_NONE_RE =
   /\bCross-Origin-Embedder-Policy\b[^\n]*\bunsafe-none\b/i;
+const CORP_UNSAFE_NONE_RE =
+  /\bCross-Origin-Resource-Policy\b[^\n]*\bunsafe-none\b/i;
 
 function* patchLines(patch: string): Generator<string> {
   let start = 0;
@@ -554,6 +556,12 @@ export function scanPatchForIacMisconfig(
     if (
       COEP_UNSAFE_NONE_RE.test(body) &&
       pushFinding(findings, seen, path, newLine, "coep-unsafe-none", maxFindings)
+    ) {
+      return findings;
+    }
+    if (
+      CORP_UNSAFE_NONE_RE.test(body) &&
+      pushFinding(findings, seen, path, newLine, "corp-unsafe-none", maxFindings)
     ) {
       return findings;
     }

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -364,6 +364,8 @@ export function renderBrief(
           return "sets `Cross-Origin-Opener-Policy: unsafe-none`, allowing cross-origin pages to retain opener access";
         case "coep-unsafe-none":
           return "sets `Cross-Origin-Embedder-Policy: unsafe-none`, disabling cross-origin isolation requirements for embedded resources";
+        case "corp-unsafe-none":
+          return "sets `Cross-Origin-Resource-Policy: unsafe-none`, allowing any origin to load this resource without isolation";
       }
     };
 

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -272,7 +272,8 @@ export interface IacMisconfigFinding {
     | "referrer-policy-leak"
     | "cookie-not-httponly"
     | "coop-unsafe-none"
-    | "coep-unsafe-none";
+    | "coep-unsafe-none"
+    | "corp-unsafe-none";
 }
 
 /** A newly-added dependency whose install compiles native code (npm node-gyp addon) or has no prebuilt wheel

--- a/review-enrichment/test/iac-misconfig.test.ts
+++ b/review-enrichment/test/iac-misconfig.test.ts
@@ -463,6 +463,7 @@ test("scanPatchForIacMisconfig flags insecure HTTP security-header settings", ()
     ["+    httpOnly: false", "cookie-not-httponly"],
     ["+    add_header Cross-Origin-Opener-Policy \"unsafe-none\";", "coop-unsafe-none"],
     ["+    add_header Cross-Origin-Embedder-Policy \"unsafe-none\";", "coep-unsafe-none"],
+    ["+    add_header Cross-Origin-Resource-Policy \"unsafe-none\";", "corp-unsafe-none"],
   ];
   for (const [added, kind] of cases) {
     const findings = scanPatchForIacMisconfig(
@@ -486,7 +487,8 @@ test("scanPatchForIacMisconfig does not flag secure HTTP header values (incl. Ca
     "+    httpOnly: true",
     "+    add_header Cross-Origin-Opener-Policy \"same-origin\";",
     "+    add_header Cross-Origin-Embedder-Policy \"require-corp\";",
-    // A bare `unsafe-none` config key without a COOP/COEP header token must NOT fire either rule.
+    "+    add_header Cross-Origin-Resource-Policy \"same-origin\";",
+    // A bare `unsafe-none` config key without a COOP/COEP/CORP header token must NOT fire any of those rules.
     "+    unsafe-none = false",
   ];
   for (const added of safe) {


### PR DESCRIPTION
## Summary

Extend the IaC-misconfig HTTP security-header scanner with `Cross-Origin-Resource-Policy: unsafe-none`, matching the existing COOP/COEP `unsafe-none` rules. Includes positive/negative patch scans and render text.

Fixes #2096

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `review-enrichment`: build + `node --test test/iac-misconfig.test.ts` (22/22 pass)
- [ ] Full `npm run test:coverage` deferred to CI
- [x] New behavior has unit tests (positive case, secure counterpart, header-token boundary)

If any required check was skipped, explain why:

- Remaining validation runs in GitHub Actions.

## Safety

- [x] No secrets or private maintainer evidence exposed.
- [x] Public GitHub text stays sanitized and low-noise.
- [x] No auth/cookie/CORS/session changes.
- [x] No API/OpenAPI/MCP behavior changes.
- [x] No visible UI changes.

## UI Evidence

N/A — enrichment analyzer rule only.

## Notes

Incremental maintenance parity for the IaC-misconfig scanner (same 4-file shape as merged #3545). Avoids path-matcher / #561 duplicate churn.

Made with [Cursor](https://cursor.com)