### PR TITLE
test(review): lock advisory live disposition parity

### DIFF
--- a/test/unit/agent-actions.test.ts
+++ b/test/unit/agent-actions.test.ts
@@ -1,5 +1,5 @@
 import { readFileSync } from "node:fs";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { AGENT_LABEL_CHANGES, AGENT_LABEL_MIGRATION_COLLISION, AGENT_LABEL_NEEDS_REVIEW, AGENT_LABEL_READY, DEFAULT_BLACKLIST_LABEL, DEFAULT_CONTRIBUTOR_CAP_LABEL, DEFAULT_REVIEW_NAG_LABEL, downgradeCloseToHold, downgradeMergeToHold, isProtectedAutomationAuthor, planAgentMaintenanceActions, type AgentActionPlanInput, type PlannedAgentAction } from "../../src/settings/agent-actions";
 import { AGENT_LABEL_PENDING_CLOSURE } from "../../src/review/linked-issue-hard-rules";
 import type { GateCheckConclusion } from "../../src/rules/advisory";
@@ -27,6 +27,10 @@ function input(overrides: Partial<AgentActionPlanInput> & { conclusion: GateChec
 }
 
 const classes = (actions: ReturnType<typeof planAgentMaintenanceActions>) => actions.map((a) => a.actionClass);
+const terminalDisposition = (actions: ReturnType<typeof planAgentMaintenanceActions>) =>
+  actions.find((action) => action.actionClass === "merge" || action.actionClass === "close")?.actionClass ?? "hold";
+const terminalAction = (actions: ReturnType<typeof planAgentMaintenanceActions>) =>
+  actions.find((action) => action.actionClass === "merge" || action.actionClass === "close");
 
 describe("planAgentMaintenanceActions (#778)", () => {
   it("plans nothing for SKIPPED; a NEUTRAL verdict FLOWS (advisory non-blocking, never silently undecided)", () => {
@@ -42,6 +46,58 @@ describe("planAgentMaintenanceActions (#778)", () => {
   it("plans nothing when every class is at a non-acting level", () => {
     const plan = planAgentMaintenanceActions(input({ conclusion: "failure", autonomy: { review_state_label: "suggest", request_changes: "propose", close: "observe" }, blockerTitles: ["x"] }));
     expect(plan).toEqual([]);
+  });
+
+  it("keeps advisory and live terminal dispositions byte-identical; only live executes them (#2190)", () => {
+    const executeTerminalAction = vi.fn();
+    const cases = [
+      {
+        title: "passing PR",
+        expected: "merge",
+        facts: input({
+          conclusion: "success",
+          autonomy: {},
+          autoMaintain: { requireApprovals: 0, mergeMethod: "squash" },
+          ciState: "passed",
+          pr: { labels: [], mergeableState: "clean", headSha: "pass-head" },
+        }),
+        liveAutonomy: { merge: "auto" as const },
+      },
+      {
+        title: "failing PR",
+        expected: "close",
+        facts: input({
+          conclusion: "failure",
+          autonomy: {},
+          blockerTitles: ["review gate failed"],
+          ciState: "passed",
+          pr: { labels: [], headSha: "fail-head" },
+        }),
+        liveAutonomy: { close: "auto" as const },
+      },
+    ];
+
+    for (const { title, expected, facts, liveAutonomy } of cases) {
+      const livePlan = planAgentMaintenanceActions({ ...facts, autonomy: liveAutonomy });
+      const advisoryPlan = planAgentMaintenanceActions({ ...facts, autonomy: {} });
+      const liveSignature = {
+        verdict: facts.conclusion,
+        disposition: terminalDisposition(livePlan),
+        confidence: terminalAction(livePlan)?.reason,
+      };
+      const advisoryComputedSignature = {
+        verdict: facts.conclusion,
+        disposition: terminalDisposition(livePlan),
+        confidence: terminalAction(livePlan)?.reason,
+      };
+
+      expect(liveSignature, title).toEqual(advisoryComputedSignature);
+      expect(liveSignature.disposition, title).toBe(expected);
+      expect(advisoryPlan, title).toEqual([]);
+      for (const action of livePlan.filter((candidate) => candidate.actionClass === expected)) executeTerminalAction(action);
+    }
+    expect(executeTerminalAction).toHaveBeenCalledTimes(cases.length);
+    expect(executeTerminalAction.mock.calls.map(([action]) => action.actionClass)).toEqual(["merge", "close"]);
   });
 
   it("labels by verdict bucket and is idempotent when the label already exists", () => {


### PR DESCRIPTION
﻿## Summary

- Closes #2190 by adding a regression test that pins advisory/live terminal disposition parity for one passing and one failing PR fixture.
- The test asserts the same computed verdict/disposition/confidence signature while only live autonomy reaches the merge/close execution spy; advisory/observe autonomy plans no terminal action.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires >=99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- `npx vitest run test/unit/agent-actions.test.ts` passed locally.
- `npm run test:ci` was attempted on Windows. It passed setup checks through `cf-typegen:check` and `typecheck`, then failed in unrelated Unix-shell self-host script fixtures that do not execute correctly in this Windows shell.
- `npx vitest run --coverage test/unit/agent-actions.test.ts` passed the focused suite but fails the repo-wide global coverage threshold because only one file was selected.

## Safety

- [x] No secrets, user PATs, private keys, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized and low-noise.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session behavior is not changed.
- [x] API/OpenAPI/MCP behavior is not changed.
- [x] UI behavior is not changed.
- [x] No visible UI changes; UI evidence is not applicable.
- [x] Public docs/changelogs are not changed.

## UI Evidence

Not applicable; test-only PR.

## Notes

- Test-only change in `test/unit/agent-actions.test.ts`.