### PR TITLE
fix(enrichment): bound coverage artifact zip parsing

### DIFF
--- a/review-enrichment/src/analyzers/coverage-delta.ts
+++ b/review-enrichment/src/analyzers/coverage-delta.ts
@@ -21,6 +21,8 @@ const SLUG_RE = /^[A-Za-z0-9._-]+$/;
 const MAX_RUNS_PROBED = 5; // recent successful runs to search for a coverage artifact
 const MAX_ARTIFACT_BYTES = 8 * 1024 * 1024; // skip an artifact zip larger than this (bounded download)
 const MAX_ENTRY_BYTES = 4 * 1024 * 1024; // skip a single uncompressed zip entry larger than this
+const MAX_ZIP_ENTRIES = 64; // cap central-directory entries inspected from untrusted artifacts
+const MAX_TOTAL_ENTRY_BYTES = 8 * 1024 * 1024; // cap retained decompressed coverage-report bytes per artifact
 const MAX_FILES_REPORTED = 15; // cap findings so the brief stays bounded
 const MAX_LINES_PER_FILE = 20; // cap reported uncovered lines per file
 // Artifact names that plausibly hold a coverage report; matched case-insensitively against the artifact name.
@@ -184,7 +186,10 @@ export function readZipEntries(buf: Buffer): ZipEntry[] {
   const cdStart = buf.readUInt32LE(eocd + 16);
   if (cdStart + cdSize > buf.length) return entries;
   let pos = cdStart;
-  while (pos + 46 <= cdStart + cdSize) {
+  let inspected = 0;
+  let retainedBytes = 0;
+  while (pos + 46 <= cdStart + cdSize && inspected < MAX_ZIP_ENTRIES) {
+    inspected += 1;
     if (buf.readUInt32LE(pos) !== 0x02014b50) break; // central-directory file header
     const method = buf.readUInt16LE(pos + 10);
     const compressedSize = buf.readUInt32LE(pos + 20);
@@ -194,6 +199,7 @@ export function readZipEntries(buf: Buffer): ZipEntry[] {
     const localOffset = buf.readUInt32LE(pos + 42);
     const name = buf.toString("utf8", pos + 46, pos + 46 + nameLen);
     pos += 46 + nameLen + extraLen + commentLen;
+    if (!coverageFileKind(name)) continue;
     if (localOffset + 30 > buf.length) continue;
     const localNameLen = buf.readUInt16LE(localOffset + 26);
     const localExtraLen = buf.readUInt16LE(localOffset + 28);
@@ -201,13 +207,16 @@ export function readZipEntries(buf: Buffer): ZipEntry[] {
     if (dataStart + compressedSize > buf.length) continue;
     const chunk = buf.subarray(dataStart, dataStart + compressedSize);
     if (method === 0) {
-      if (chunk.length > MAX_ENTRY_BYTES) continue;
+      if (chunk.length > MAX_ENTRY_BYTES || retainedBytes + chunk.length > MAX_TOTAL_ENTRY_BYTES) continue;
       entries.push({ name, data: chunk });
+      retainedBytes += chunk.length;
     } else if (method === 8) {
       try {
-        entries.push({ name, data: inflateRawSync(chunk, { maxOutputLength: MAX_ENTRY_BYTES }) });
+        const data = inflateRawSync(chunk, { maxOutputLength: Math.min(MAX_ENTRY_BYTES, MAX_TOTAL_ENTRY_BYTES - retainedBytes) });
+        entries.push({ name, data });
+        retainedBytes += data.length;
       } catch {
-        continue; // corrupt deflate stream or output over the cap -> skip this entry
+        continue; // corrupt deflate stream or output over the remaining cap -> skip this entry
       }
     }
   }

--- a/review-enrichment/test/coverage-delta.test.ts
+++ b/review-enrichment/test/coverage-delta.test.ts
@@ -22,36 +22,47 @@ const jsonResponse = (body, code = 200) => new Response(JSON.stringify(body), { 
 const PR_PATCH = "@@ -10,3 +10,5 @@\n ctx1\n+add11\n keepctx\n+add13\n+add14\n ctx2";
 const LCOV = "SF:src/a.ts\nDA:11,0\nDA:13,5\nDA:14,0\nend_of_record\n";
 
-// Build a single-entry ZIP (central directory + EOCD) around `data` under `name`, deflated (method 8).
-function buildZip(name, data, { store = false } = {}) {
-  const nameBuf = Buffer.from(name, "utf8");
-  const raw = Buffer.from(data, "utf8");
-  const body = store ? raw : deflateRawSync(raw);
-  const method = store ? 0 : 8;
-  const local = Buffer.alloc(30);
-  local.writeUInt32LE(0x04034b50, 0);
-  local.writeUInt16LE(method, 8);
-  local.writeUInt32LE(body.length, 18);
-  local.writeUInt32LE(raw.length, 22);
-  local.writeUInt16LE(nameBuf.length, 26);
-  const localOffset = 0;
-  const localRecord = Buffer.concat([local, nameBuf, body]);
-  const central = Buffer.alloc(46);
-  central.writeUInt32LE(0x02014b50, 0);
-  central.writeUInt16LE(method, 10);
-  central.writeUInt32LE(body.length, 20);
-  central.writeUInt32LE(raw.length, 24);
-  central.writeUInt16LE(nameBuf.length, 28);
-  central.writeUInt32LE(localOffset, 42);
-  const centralRecord = Buffer.concat([central, nameBuf]);
-  const cdStart = localRecord.length;
+// Build a ZIP (central directory + EOCD) around entries, deflated (method 8) by default.
+function buildZipEntries(entries) {
+  const localRecords = [];
+  const centralRecords = [];
+  let offset = 0;
+  for (const { name, data, store = false } of entries) {
+    const nameBuf = Buffer.from(name, "utf8");
+    const raw = Buffer.from(data, "utf8");
+    const body = store ? raw : deflateRawSync(raw);
+    const method = store ? 0 : 8;
+    const local = Buffer.alloc(30);
+    local.writeUInt32LE(0x04034b50, 0);
+    local.writeUInt16LE(method, 8);
+    local.writeUInt32LE(body.length, 18);
+    local.writeUInt32LE(raw.length, 22);
+    local.writeUInt16LE(nameBuf.length, 26);
+    const localRecord = Buffer.concat([local, nameBuf, body]);
+    localRecords.push(localRecord);
+    const central = Buffer.alloc(46);
+    central.writeUInt32LE(0x02014b50, 0);
+    central.writeUInt16LE(method, 10);
+    central.writeUInt32LE(body.length, 20);
+    central.writeUInt32LE(raw.length, 24);
+    central.writeUInt16LE(nameBuf.length, 28);
+    central.writeUInt32LE(offset, 42);
+    centralRecords.push(Buffer.concat([central, nameBuf]));
+    offset += localRecord.length;
+  }
+  const centralDirectory = Buffer.concat(centralRecords);
   const eocd = Buffer.alloc(22);
   eocd.writeUInt32LE(0x06054b50, 0);
-  eocd.writeUInt16LE(1, 8);
-  eocd.writeUInt16LE(1, 10);
-  eocd.writeUInt32LE(centralRecord.length, 12);
-  eocd.writeUInt32LE(cdStart, 16);
-  return Buffer.concat([localRecord, centralRecord, eocd]);
+  eocd.writeUInt16LE(entries.length, 8);
+  eocd.writeUInt16LE(entries.length, 10);
+  eocd.writeUInt32LE(centralDirectory.length, 12);
+  eocd.writeUInt32LE(offset, 16);
+  return Buffer.concat([...localRecords, centralDirectory, eocd]);
+}
+
+// Build a single-entry ZIP around `data` under `name`.
+function buildZip(name, data, { store = false } = {}) {
+  return buildZipEntries([{ name, data, store }]);
 }
 
 const req = (files, over = {}) => ({
@@ -128,6 +139,20 @@ test("readZipEntries: reads a deflated and a stored entry; rejects a non-zip buf
   assert.equal(stored[0]?.data.toString("utf8"), LCOV);
   assert.deepEqual(readZipEntries(Buffer.from("not a zip file at all")), []);
   assert.deepEqual(readZipEntries(Buffer.alloc(4)), []); // shorter than the EOCD record
+});
+
+test("readZipEntries: skips non-coverage entries before inflation and bounds inspected entries", () => {
+  const junk = "x".repeat(1024 * 1024);
+  const manyJunkEntries = Array.from({ length: 70 }, (_, index) => ({ name: `junk-${index}.txt`, data: junk }));
+  assert.deepEqual(readZipEntries(buildZipEntries(manyJunkEntries)), []);
+
+  const entries = readZipEntries(
+    buildZipEntries([
+      ...manyJunkEntries.slice(0, 64),
+      { name: "lcov.info", data: LCOV },
+    ]),
+  );
+  assert.deepEqual(entries, []);
 });
 
 test("coverageFileKind: recognizes lcov / istanbul / cobertura names, else null", () => {


### PR DESCRIPTION
### Motivation

- Prevent a zip-bomb DoS when the `coverageDelta` analyzer downloads untrusted GitHub Actions artifact ZIPs by adding aggregate and early-filtering guardrails. 

### Description

- Add `MAX_ZIP_ENTRIES` and `MAX_TOTAL_ENTRY_BYTES` and pre-filter archive entries by `coverageFileKind` to avoid inflating/skipping non-coverage files before decompression in `readZipEntries` (`review-enrichment/src/analyzers/coverage-delta.ts`).
- Cap the number of central-directory entries inspected and the total retained decompressed bytes, and bound per-entry inflation with `Math.min(...)` to prevent aggregate OOM or excessive synchronous CPU work. 
- Update the ZIP test utilities to build multi-entry archives and add a regression test that verifies junk entries are skipped and late coverage entries past the inspection cap are not processed (`review-enrichment/test/coverage-delta.test.ts`).

### Testing

- Ran the review-enrichment unit suite and targeted ZIP tests: `npm --prefix review-enrichment run build` and the `readZipEntries` test case via `node --test --experimental-strip-types --test-name-pattern='readZipEntries' test/coverage-delta.test.ts`, and the tests passed.
- Ran the package-level REES test via `npm run rees:test`, which completed successfully for the touched package.
- Attempted the full local gate `npm run test:ci`, which progressed through early checks but stalled during `test:coverage` in this environment and was stopped (not completed).
- `npm audit --audit-level=moderate` could not complete in this environment due to the registry returning `403 Forbidden`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b0b838610832ca589e9dbfb7b8183)