### PR TITLE
fix(review): handle terminal basename punctuation

### DIFF
--- a/src/signals/unlinked-issue-candidates.ts
+++ b/src/signals/unlinked-issue-candidates.ts
@@ -68,7 +68,7 @@ function tokenize(text: string): Set<string> {
  *  `reader.ts` match inside an unrelated, longer filename such as `csv-reader.ts`. */
 function issueMentionsChangedPath(issueBody: string, changedPaths: string[]): boolean {
   const lowerBody = issueBody.toLowerCase();
-  const bodyPathTokens = lowerBody.match(/[a-z0-9_\-./]+/g) ?? [];
+  const bodyPathTokens = (lowerBody.match(/[a-z0-9_\-./]+/g) ?? []).map((token) => token.replace(/\.+$/g, ""));
   return changedPaths.some((path) => {
     const lowerPath = path.toLowerCase();
     if (lowerBody.includes(lowerPath)) return true;

--- a/test/unit/unlinked-issue-candidates.test.ts
+++ b/test/unit/unlinked-issue-candidates.test.ts
@@ -57,6 +57,17 @@ describe("findUnlinkedIssueCandidates", () => {
     expect(result[0]?.pathMentioned).toBe(true);
   });
 
+  it("qualifies via a basename-only mention followed by a sentence period", () => {
+    const result = findUnlinkedIssueCandidates({
+      prTitle: "xyz",
+      prBody: "abc",
+      changedPaths: ["src/utils/reader.ts"],
+      openIssues: [issue({ number: 10, title: "bug", body: "Please fix reader.ts." })],
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0]?.pathMentioned).toBe(true);
+  });
+
   it("does NOT false-positive when a basename is a substring of a longer, unrelated filename (#boundary-matching)", () => {
     // "reader.ts" must not match merely because it is a substring of "csv-reader.ts" -- a different file.
     const result = findUnlinkedIssueCandidates({


### PR DESCRIPTION
### Motivation
- Fix a regression where path-like tokens extracted from issue bodies could include trailing sentence punctuation (e.g. `reader.ts.`) and therefore fail the basename match, allowing an unlinked PR that resolved an open issue to bypass the unlinked-issue guardrail.

### Description
- Strip trailing dots from path-like tokens before doing basename or `/basename` suffix comparisons in `issueMentionsChangedPath` (in `src/signals/unlinked-issue-candidates.ts`) and add a regression test exercising a basename followed by a period in `test/unit/unlinked-issue-candidates.test.ts`.

### Testing
- Ran `npx vitest run test/unit/unlinked-issue-candidates.test.ts`, which passed; a full `npm run test:coverage` attempt did not complete due to unrelated long-running suites/timeouts in the broader test matrix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b00925c74832ca10f22bcbaaafa5b)