### PR TITLE
fix(review): clamp visual route capture limit

### DIFF
--- a/src/review/visual/capture.ts
+++ b/src/review/visual/capture.ts
@@ -28,6 +28,7 @@ const DEFAULT_ROUTE_FILE = /apps\/gittensory-ui\/src\/routes\/(.+?)\.(?:tsx|jsx)
 // Each route renders desktop + mobile for before + after (up to 4 PNGs). Cap routes to bound browser-render
 // wall-clock — Browser Rendering is the costliest binding.
 const MAX_ROUTES = 2;
+const MAX_CONFIGURED_ROUTES = 5;
 
 /** A single captured route's before/after shot URLs (desktop + mobile), plus an optional pixel-diff overlay
  *  per viewport (#3674) — self-host only (isVisualDiffAvailable), and only when the diff clears the visual-
@@ -115,7 +116,7 @@ export type VisualRoutesInput = { paths?: readonly string[] | null | undefined; 
  * `maxRoutes` applies to either path — an explicit list is capped too, not just inferred routes.
  */
 export function resolveVisualRoutes(files: string[], config?: VisualRoutesInput | null): string[] {
-  const maxRoutes = config?.maxRoutes && config.maxRoutes > 0 ? config.maxRoutes : MAX_ROUTES;
+  const maxRoutes = config?.maxRoutes && config.maxRoutes > 0 ? Math.min(config.maxRoutes, MAX_CONFIGURED_ROUTES) : MAX_ROUTES;
   if (config?.paths && config.paths.length > 0) return [...config.paths].slice(0, maxRoutes);
   return mapFilesToRoutes(files, DEFAULT_ROUTE_FILE, maxRoutes);
 }

--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -1069,6 +1069,16 @@ function normalizeOptionalPositiveInteger(value: JsonValue | undefined, field: s
   return null;
 }
 
+const REVIEW_VISUAL_MAX_ROUTES_LIMIT = 5;
+
+function normalizeOptionalVisualMaxRoutes(value: JsonValue | undefined, warnings: string[]): number | null {
+  const maxRoutes = normalizeOptionalPositiveInteger(value, "review.visual.routes.max_routes", warnings);
+  if (maxRoutes === null) return null;
+  if (maxRoutes <= REVIEW_VISUAL_MAX_ROUTES_LIMIT) return maxRoutes;
+  warnings.push(`Manifest field "review.visual.routes.max_routes" must be at most ${REVIEW_VISUAL_MAX_ROUTES_LIMIT}; clamping it.`);
+  return REVIEW_VISUAL_MAX_ROUTES_LIMIT;
+}
+
 /** Normalize + bound a maintainer-supplied glob string: trims/length-caps like any other string field, AND
  *  rejects one globToRegExp (review/content-lane/spec-resolver.ts's reuse of the guardrail-path compiler) would
  *  itself refuse to compile safely. Reuses `hasUnsafeWildcardCount` — globToRegExp's OWN safety predicate —
@@ -1860,7 +1870,7 @@ function parseVisualConfig(value: JsonValue | undefined, warnings: string[]): Vi
     warnings.push(`Manifest "review.visual.routes" must be a mapping; ignoring it.`);
   }
   const paths = routesRecord ? parseManifestGlobList(routesRecord.paths, "review.visual.routes.paths", warnings) : [];
-  const maxRoutes = routesRecord ? normalizeOptionalPositiveInteger(routesRecord.max_routes, "review.visual.routes.max_routes", warnings) : null;
+  const maxRoutes = routesRecord ? normalizeOptionalVisualMaxRoutes(routesRecord.max_routes, warnings) : null;
 
   return { preview: { urlTemplate }, routes: { paths, maxRoutes } };
 }

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -3318,6 +3318,13 @@ describe("review.visual (#3609 preview.url_template / #3610 routes)", () => {
     expect(negative.review.visual.routes.maxRoutes).toBeNull();
   });
 
+  it("clamps max_routes above the safe visual route limit with a warning", () => {
+    const m = parseFocusManifest({ review: { visual: { routes: { max_routes: 1000 } } } });
+    expect(m.review.visual.routes.maxRoutes).toBe(5);
+    expect(m.warnings.some((w) => /review\.visual\.routes\.max_routes.*at most 5/.test(w))).toBe(true);
+    expect(reviewConfigToJson(m.review)).toEqual({ visual: { routes: { max_routes: 5 } } });
+  });
+
   it("marks present via routes.paths alone (preview + max_routes both empty)", () => {
     const m = parseFocusManifest({ review: { visual: { routes: { paths: ["/app"] } } } });
     expect(m.review.present).toBe(true);

--- a/test/unit/visual-capture.test.ts
+++ b/test/unit/visual-capture.test.ts
@@ -347,6 +347,23 @@ describe("resolveVisualRoutes (#3610)", () => {
     expect(resolveVisualRoutes(manyFiles, { paths: ["/a", "/b", "/c"], maxRoutes: 2 })).toEqual(["/a", "/b"]);
   });
 
+  it("clamps oversized configured maxRoutes to the safe visual route limit", () => {
+    const sixFiles = [
+      ...manyFiles,
+      "apps/gittensory-ui/src/routes/app.settings.tsx",
+      "apps/gittensory-ui/src/routes/app.usage.tsx",
+      "apps/gittensory-ui/src/routes/app.users.tsx",
+    ];
+    expect(resolveVisualRoutes(sixFiles, { maxRoutes: 1000 })).toEqual([
+      "/app",
+      "/app/analytics",
+      "/app/billing",
+      "/app/settings",
+      "/app/usage",
+    ]);
+    expect(resolveVisualRoutes(sixFiles, { paths: ["/a", "/b", "/c", "/d", "/e", "/f"], maxRoutes: 1000 })).toEqual(["/a", "/b", "/c", "/d", "/e"]);
+  });
+
   it("a maxRoutes of zero or negative falls back to the built-in default cap", () => {
     expect(resolveVisualRoutes(manyFiles, { maxRoutes: 0 })).toEqual(["/app", "/app/analytics"]);
     expect(resolveVisualRoutes(manyFiles, { maxRoutes: -1 })).toEqual(["/app", "/app/analytics"]);


### PR DESCRIPTION
### Motivation
- Prevent an unbounded `review.visual.routes.max_routes` from enabling excessive screenshot work and DoS-like resource consumption by clamping maintainer-provided values to a safe upper bound.

### Description
- Add `REVIEW_VISUAL_MAX_ROUTES_LIMIT = 5` and a new `normalizeOptionalVisualMaxRoutes` parser that clamps oversized `max_routes` with a warning in `src/signals/focus-manifest.ts`.
- Add `MAX_CONFIGURED_ROUTES = 5` and apply `Math.min(..., MAX_CONFIGURED_ROUTES)` in `resolveVisualRoutes` to enforce a defense-in-depth cap before route selection in `src/review/visual/capture.ts`.
- Replace the manifest parsing call to use the new clamping helper so stored configs are bounded.
- Add regression tests covering manifest-level clamping and route-resolution clamping in `test/unit/focus-manifest.test.ts` and `test/unit/visual-capture.test.ts`.

### Testing
- Ran the focused unit tests `npx vitest run test/unit/focus-manifest.test.ts test/unit/visual-capture.test.ts` and they passed.
- Ran `git diff --check` and `npm run typecheck` which succeeded locally.
- Attempted full coverage with `npm run test:coverage` but the full suite did not complete cleanly due to unrelated existing `test/unit/backfill.test.ts` timeouts in this environment, so full `codecov` measurement was not produced here.
- Attempted `npm audit --audit-level=moderate`, but the registry audit endpoint returned `403 Forbidden` in this environment so audit could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b0b838144832c98c1b7a2a1e05094)