### PR TITLE
fix(miner): avoid PATH helper in docker doctor

### DIFF
--- a/packages/gittensory-miner/lib/laptop-init.d.ts
+++ b/packages/gittensory-miner/lib/laptop-init.d.ts
@@ -17,6 +17,7 @@ export function initLaptopState(env?: Record<string, string | undefined>): Lapto
 export function checkLaptopStateSqlite(env?: Record<string, string | undefined>): DoctorCheck;
 
 export function checkDockerPresent(options?: {
+  env?: Record<string, string | undefined>;
   resolveDockerPath?: () => string | null;
 }): DoctorCheck;
 

--- a/packages/gittensory-miner/lib/laptop-init.js
+++ b/packages/gittensory-miner/lib/laptop-init.js
@@ -1,7 +1,6 @@
-import { execFileSync } from "node:child_process";
-import { chmodSync, existsSync, mkdirSync } from "node:fs";
+import { accessSync, chmodSync, constants, existsSync, mkdirSync } from "node:fs";
 import { homedir } from "node:os";
-import { dirname, join } from "node:path";
+import { delimiter, join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 
 const defaultDbFileName = "laptop-state.sqlite3";
@@ -69,18 +68,25 @@ export function checkLaptopStateSqlite(env = process.env) {
   }
 }
 
+function findExecutableOnPath(name, env = process.env) {
+  const pathValue = typeof env.PATH === "string" ? env.PATH : "";
+  for (const pathEntry of pathValue.split(delimiter)) {
+    if (!pathEntry) continue;
+    const candidate = join(pathEntry, name);
+    try {
+      accessSync(candidate, constants.X_OK);
+      return candidate;
+    } catch {
+      // Keep scanning: PATH often contains missing or unreadable entries.
+    }
+  }
+  return null;
+}
+
 /** Informational only — Docker is never required for laptop mode. */
 export function checkDockerPresent(options = {}) {
-  const resolveDockerPath = options.resolveDockerPath ?? (() => {
-    try {
-      return execFileSync("which", ["docker"], {
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "ignore"],
-      }).trim() || null;
-    } catch {
-      return null;
-    }
-  });
+  const resolveDockerPath = options.resolveDockerPath
+    ?? (() => findExecutableOnPath("docker", options.env));
   const dockerPath = resolveDockerPath();
   return {
     name: "docker-present",

--- a/test/unit/miner-laptop-init.test.ts
+++ b/test/unit/miner-laptop-init.test.ts
@@ -1,6 +1,14 @@
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   checkDockerPresent,
@@ -91,10 +99,32 @@ describe("gittensory-miner laptop init (#2329)", () => {
     expect(check.detail).toContain("optional");
   });
 
-  it("doctor reports Docker when which finds it", () => {
+  it("doctor reports Docker when the injected resolver finds it", () => {
     const check = checkDockerPresent({ resolveDockerPath: () => "/usr/bin/docker" });
     expect(check.ok).toBe(true);
     expect(check.detail).toContain("/usr/bin/docker");
+  });
+
+  it("doctor finds Docker from PATH without executing a PATH-controlled which", () => {
+    const root = tempRoot();
+    const attackerDir = join(root, "attacker-bin");
+    const dockerDir = join(root, "docker-bin");
+    const marker = join(root, "which-ran");
+    mkdirSync(attackerDir, { recursive: true });
+    mkdirSync(dockerDir, { recursive: true });
+    writeFileSync(
+      join(attackerDir, "which"),
+      `#!/bin/sh\necho pwned > "${marker}"\necho /attacker/docker\n`,
+    );
+    writeFileSync(join(dockerDir, "docker"), "#!/bin/sh\nexit 0\n");
+    chmodSync(join(attackerDir, "which"), 0o700);
+    chmodSync(join(dockerDir, "docker"), 0o700);
+
+    const check = checkDockerPresent({ env: { PATH: `${attackerDir}${delimiter}${dockerDir}` } });
+
+    expect(check.ok).toBe(true);
+    expect(check.detail).toContain(join(dockerDir, "docker"));
+    expect(existsSync(marker)).toBe(false);
   });
 
   it("runInit notes when sqlite already existed", () => {


### PR DESCRIPTION
### Motivation
- Prevent local PATH hijack and arbitrary code execution when running the miner `doctor` Docker presence check by avoiding execution of an unqualified `which` helper.
- Keep the check informational and offline-safe while preserving testability and injectable resolvers.

### Description
- Replace the `execFileSync("which", ["docker"])` call with an in-process `findExecutableOnPath()` that scans `PATH` and validates candidate executables via `fs.accessSync(..., constants.X_OK)`.
- Preserve an injectable `resolveDockerPath` for callers/tests and add an optional `env` parameter to the `checkDockerPresent` type signature so callers can exercise PATH discovery without mutating global state.
- Add a regression unit test that puts a malicious `which` earlier in `PATH` and asserts the check finds a real `docker` binary without executing the PATH-controlled `which`.
- Files changed: `packages/gittensory-miner/lib/laptop-init.js`, `packages/gittensory-miner/lib/laptop-init.d.ts`, and `test/unit/miner-laptop-init.test.ts`.

### Testing
- Ran the focused unit suite with `npx vitest run test/unit/miner-laptop-init.test.ts`, and the test file passed locally (`11 tests`).
- Ran `npm run build:miner`, which succeeded (type checks and runtime `node --check` passed for miner lib files).
- Started the full gate `npm run test:ci`; it surfaced unrelated environment/network issues (actionlint fallback due to `github.com` DNS failures and long-running existing tests during `test:coverage`) so the run was not completed in this environment.
- `npm audit --audit-level=moderate` could not complete in this environment (npm registry audit endpoint returned `403 Forbidden`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b0b8cfe5c832c96bf3389783d81d1)