### PR TITLE
fix(review): preserve repo manifest for AI-skipped reviews so changed-files summary still renders

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -6319,7 +6319,7 @@ export async function auditPullRequestAutoReviewSkip(
   }).catch(() => undefined);
 }
 
-/** Resolve auto-review eligibility for a PR, loading the manifest only when cheaper skip predicates pass. (#1954) */
+/** Resolve auto-review eligibility for a PR, loading the manifest for deterministic review surfaces before AI-only skips. (#1954) */
 export async function resolveAutoReviewSkipForPullRequest(
   env: Env,
   args: {
@@ -6333,10 +6333,10 @@ export async function resolveAutoReviewSkipForPullRequest(
     headSha: string | null | undefined;
   },
 ): Promise<{ skipReason: string | null; reviewManifest: FocusManifest | null }> {
-  if (args.authorBlacklisted || args.isFrozenForManualReview) {
-    return { skipReason: null, reviewManifest: null };
-  }
   const reviewManifest = await loadRepoFocusManifest(env, args.repoFullName).catch(() => null);
+  if (args.authorBlacklisted || args.isFrozenForManualReview) {
+    return { skipReason: null, reviewManifest };
+  }
   const reviewedCommitCount = await countPublishedAiReviewHeads(env, args.repoFullName, args.pr.number).catch(() => 0);
   const skipReason = resolvePullRequestAutoReviewSkipReason({
     forceAiReview: args.forceAiReview,

--- a/test/unit/auto-review-wiring.test.ts
+++ b/test/unit/auto-review-wiring.test.ts
@@ -70,8 +70,11 @@ describe("review.auto_review wiring (#1954)", () => {
     auditSpy.mockRestore();
   });
 
-  it("resolveAutoReviewSkipForPullRequest skips manifest load when author is blacklisted or frozen", async () => {
-    const loadSpy = vi.spyOn(focusManifestLoader, "loadRepoFocusManifest");
+  it("resolveAutoReviewSkipForPullRequest loads the manifest before blacklisted or frozen AI-only skips", async () => {
+    const manifest = parseFocusManifest({ review: { changed_files_summary: true } });
+    const loadSpy = vi.spyOn(focusManifestLoader, "loadRepoFocusManifest").mockResolvedValue(manifest);
+    const countSpy = vi.spyOn(repositoriesModule, "countPublishedAiReviewHeads");
+
     await expect(
       resolveAutoReviewSkipForPullRequest({} as Env, {
         authorBlacklisted: true,
@@ -82,7 +85,7 @@ describe("review.auto_review wiring (#1954)", () => {
         deliveryId: "d1",
         headSha: "sha1",
       }),
-    ).resolves.toEqual({ skipReason: null, reviewManifest: null });
+    ).resolves.toEqual({ skipReason: null, reviewManifest: manifest });
     await expect(
       resolveAutoReviewSkipForPullRequest({} as Env, {
         authorBlacklisted: false,
@@ -93,8 +96,11 @@ describe("review.auto_review wiring (#1954)", () => {
         deliveryId: "d2",
         headSha: "sha2",
       }),
-    ).resolves.toEqual({ skipReason: null, reviewManifest: null });
-    expect(loadSpy).not.toHaveBeenCalled();
+    ).resolves.toEqual({ skipReason: null, reviewManifest: manifest });
+    expect(loadSpy).toHaveBeenCalledTimes(2);
+    expect(countSpy).not.toHaveBeenCalled();
+
+    countSpy.mockRestore();
     loadSpy.mockRestore();
   });
 


### PR DESCRIPTION
### Motivation
- A repo opt-in for `review.changed_files_summary` was being lost when the AI review was skipped for blacklisted authors or maintainer-frozen PRs because the auto-review helper returned a `null` manifest before loading it.
- Deterministic review surfaces (like the Changed-files summary) must still render when the manifest opts in even if the AI review is intentionally skipped. 

### Description
- Load the repository focus manifest earlier in `resolveAutoReviewSkipForPullRequest` and return it in the early-skip return so deterministic review surfaces can consult the manifest even when AI is skipped. 
- Update the function-level comment for `resolveAutoReviewSkipForPullRequest` to reflect the new behavior. 
- Update `test/unit/auto-review-wiring.test.ts` to assert that blacklisted/frozen paths receive the loaded manifest and that `countPublishedAiReviewHeads` is not invoked in those early-skip cases. 
- The AI-review execution still remains skipped for blacklisted or frozen PRs; only the manifest load timing changed to preserve opt-ins.

### Testing
- Ran `npm test -- --run test/unit/auto-review-wiring.test.ts` and the updated unit file passed (all tests in that file succeeded). 
- Ran `npm run test:coverage -- --run test/unit/auto-review-wiring.test.ts`; the scoped test passed but the global coverage thresholds failed because only a single test file was executed. 
- Attempted `npm run test:ci`; the command proceeded through many checks but was interrupted after unrelated long-running/failed suites (not caused by these changes); the targeted unit assertions for this fix passed. 
- Attempted `npm audit --audit-level=moderate` and received a `403` from the registry audit endpoint, so the dependency-audit step could not complete locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4afc821ecc832c9dcfb38bdf4df4d3)