### PR TITLE
docs(miner): document append-only event ledger in README (#2322)

### DIFF
--- a/packages/gittensory-miner/README.md
+++ b/packages/gittensory-miner/README.md
@@ -32,6 +32,10 @@ The package also includes a local soft-claim ledger: `openClaimLedger` / `claimI
 `listActiveClaims` persist which issues this miner instance has claimed on this machine. The table is local
 bookkeeping only — duplicate winners are adjudicated elsewhere via `@jsonbored/gittensory-engine`. (#2291)
 
+The package also includes an append-only event ledger: `initEventLedger` / `appendEvent` / `readEvents` persist
+immutable miner-loop events in local SQLite for contributor audit. Insert-only — rows are never updated or
+deleted. (#2322)
+
 ## Install
 
 See [`docs/miner-goal-spec.md`](docs/miner-goal-spec.md) for the `.gittensory-miner.yml` field reference and [`.gittensory-miner.yml.example`](../../.gittensory-miner.yml.example) at the repo root.

--- a/test/unit/miner-event-ledger-readme.test.ts
+++ b/test/unit/miner-event-ledger-readme.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const readmePath = join(process.cwd(), "packages/gittensory-miner/README.md");
+
+describe("gittensory-miner event ledger README (#2322)", () => {
+  it("documents the append-only event ledger API surface", () => {
+    const readme = readFileSync(readmePath, "utf8");
+    expect(readme).toContain("initEventLedger");
+    expect(readme).toContain("appendEvent");
+    expect(readme).toContain("readEvents");
+    expect(readme).toContain("append-only");
+    expect(readme).toContain("Insert-only");
+  });
+});


### PR DESCRIPTION
## Summary
- Document the append-only event ledger in the miner README (`initEventLedger`, `appendEvent`, `readEvents`) and note it is insert-only local audit storage.
- Add a README contract test so the documented API surface stays in sync.

Closes #2322

## Conflict avoidance
Touches only `packages/gittensory-miner/README.md` and `test/unit/miner-event-ledger-readme.test.ts`. No overlap with open PRs #3671, #3688, or #3691.

## Test plan
- [x] `test/unit/miner-event-ledger-readme.test.ts`
- [x] `npm run typecheck`
- [x] `npm run build --workspace @jsonbored/gittensory-miner`


Made with [Cursor](https://cursor.com)