### PR TITLE
fix(selfhost): pass OTEL usage-telemetry env vars into the Claude Code subprocess

### DIFF
--- a/src/selfhost/ai.ts
+++ b/src/selfhost/ai.ts
@@ -707,7 +707,23 @@ export function createClaudeCodeAi(parentEnv: Record<string, string | undefined>
       let stdoutForMetrics = "";
       try {
         if (!token) throw new Error("claude_code_no_oauth_token");
-        const env = subscriptionCliEnv(parentEnv, { CLAUDE_CODE_OAUTH_TOKEN: token });
+        // Usage telemetry (#claude-code-otel-passthrough): the allowlist deliberately excludes these -- they are
+        // plain, non-secret config (an exporter endpoint/protocol, a boolean, a poll interval), never PR content
+        // or credentials -- so they're threaded through explicitly here, the same way CLAUDE_CODE_OAUTH_TOKEN is,
+        // rather than widening SUBSCRIPTION_CLI_ENV_ALLOWLIST itself (which also gates the codex subprocess and
+        // should stay minimal). Without this the CLI silently never emits telemetry: the parent container has the
+        // OTEL vars, but the spawned subprocess previously received none of them, so the Claude usage dashboard
+        // (Grafana, via the OTEL collector → Prometheus) stayed empty regardless of `.env`.
+        const env = subscriptionCliEnv(parentEnv, {
+          CLAUDE_CODE_OAUTH_TOKEN: token,
+          CLAUDE_CODE_ENABLE_TELEMETRY: parentEnv.CLAUDE_CODE_ENABLE_TELEMETRY,
+          OTEL_METRICS_EXPORTER: parentEnv.OTEL_METRICS_EXPORTER,
+          OTEL_TRACES_EXPORTER: parentEnv.OTEL_TRACES_EXPORTER,
+          OTEL_EXPORTER_OTLP_ENDPOINT: parentEnv.OTEL_EXPORTER_OTLP_ENDPOINT,
+          OTEL_EXPORTER_OTLP_PROTOCOL: parentEnv.OTEL_EXPORTER_OTLP_PROTOCOL,
+          OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE: parentEnv.OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE,
+          OTEL_METRIC_EXPORT_INTERVAL: parentEnv.OTEL_METRIC_EXPORT_INTERVAL,
+        });
         const systemAppend = normalizedSystemAppend(options);
         const prompt = toCliPrompt(options, systemAppend);
         const spawn = spawnImpl ?? (await defaultSpawn());

--- a/test/unit/selfhost-ai.test.ts
+++ b/test/unit/selfhost-ai.test.ts
@@ -890,6 +890,50 @@ describe("subscription CLI helpers + fail-safe", () => {
     expect(capturedEnv.CLAUDE_CODE_OAUTH_TOKEN).toBe("t");
   });
 
+  it("threads the OTEL usage-telemetry vars into the subprocess env when the parent has them set (#claude-code-otel-passthrough)", async () => {
+    let capturedEnv: Record<string, string | undefined> = {};
+    const stub: StubSpawn = async (_c, _a, o) => {
+      capturedEnv = o.env;
+      return { stdout: JSON.stringify({ type: "result", result: "ok" }), code: 0 };
+    };
+    await createClaudeCodeAi(
+      {
+        CLAUDE_CODE_OAUTH_TOKEN: "t",
+        CLAUDE_CODE_ENABLE_TELEMETRY: "1",
+        OTEL_METRICS_EXPORTER: "otlp",
+        OTEL_TRACES_EXPORTER: "otlp",
+        OTEL_EXPORTER_OTLP_ENDPOINT: "http://otel-collector:4318",
+        OTEL_EXPORTER_OTLP_PROTOCOL: "http/protobuf",
+        OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE: "cumulative",
+        OTEL_METRIC_EXPORT_INTERVAL: "10000",
+      },
+      stub,
+    ).run("sonnet", { prompt: "x" });
+    expect(capturedEnv.CLAUDE_CODE_ENABLE_TELEMETRY).toBe("1");
+    expect(capturedEnv.OTEL_METRICS_EXPORTER).toBe("otlp");
+    expect(capturedEnv.OTEL_TRACES_EXPORTER).toBe("otlp");
+    expect(capturedEnv.OTEL_EXPORTER_OTLP_ENDPOINT).toBe("http://otel-collector:4318");
+    expect(capturedEnv.OTEL_EXPORTER_OTLP_PROTOCOL).toBe("http/protobuf");
+    expect(capturedEnv.OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE).toBe("cumulative");
+    expect(capturedEnv.OTEL_METRIC_EXPORT_INTERVAL).toBe("10000");
+  });
+
+  it("omits the OTEL usage-telemetry vars from the subprocess env when the parent doesn't have them set", async () => {
+    let capturedEnv: Record<string, string | undefined> = {};
+    const stub: StubSpawn = async (_c, _a, o) => {
+      capturedEnv = o.env;
+      return { stdout: JSON.stringify({ type: "result", result: "ok" }), code: 0 };
+    };
+    await createClaudeCodeAi({ CLAUDE_CODE_OAUTH_TOKEN: "t" }, stub).run("sonnet", { prompt: "x" });
+    expect(capturedEnv.CLAUDE_CODE_ENABLE_TELEMETRY).toBeUndefined();
+    expect(capturedEnv.OTEL_METRICS_EXPORTER).toBeUndefined();
+    expect(capturedEnv.OTEL_TRACES_EXPORTER).toBeUndefined();
+    expect(capturedEnv.OTEL_EXPORTER_OTLP_ENDPOINT).toBeUndefined();
+    expect(capturedEnv.OTEL_EXPORTER_OTLP_PROTOCOL).toBeUndefined();
+    expect(capturedEnv.OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE).toBeUndefined();
+    expect(capturedEnv.OTEL_METRIC_EXPORT_INTERVAL).toBeUndefined();
+  });
+
   it("Claude Code pins the default model (claude-sonnet-5) + --effort medium; CLAUDE_AI_* overrides explicitly", async () => {
     let seen: string[] = [];
     let timeout = 0;


### PR DESCRIPTION
Closes #3705

## Summary

- The self-host Claude usage dashboard (Grafana, fed via the OTEL collector → Prometheus) showed no
  data at all, even with `CLAUDE_CODE_ENABLE_TELEMETRY=1` and every `OTEL_*` var correctly set in
  `.env` and confirmed present in the running container's own environment.
- Root cause: `createClaudeCodeAi` (`src/selfhost/ai.ts`) spawns the `claude` CLI through
  `subscriptionCliEnv()`, which builds the subprocess environment from a strict allowlist
  (`SUBSCRIPTION_CLI_ENV_ALLOWLIST`) — deliberately narrow, since this subprocess handles
  attacker-controlled PR content. That allowlist only contains `HOME`, proxy vars, locale, cert
  paths, `PATH`, and XDG dirs — none of the telemetry vars — so the CLI subprocess never received
  any telemetry config at all, regardless of the parent container's environment, and silently never
  emitted usage metrics.
- Confirmed empirically on a live self-host instance: `claude_code_session_count_total` and sibling
  metrics exist as registered Prometheus metric names but have zero actual samples over a 7-day
  range, despite genuine, heavy usage.
- Fix: thread `CLAUDE_CODE_ENABLE_TELEMETRY`, `OTEL_METRICS_EXPORTER`, `OTEL_TRACES_EXPORTER`,
  `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL`,
  `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE`, and `OTEL_METRIC_EXPORT_INTERVAL` through
  explicitly at the Claude Code call site, the same way `CLAUDE_CODE_OAUTH_TOKEN` already is —
  rather than widening `SUBSCRIPTION_CLI_ENV_ALLOWLIST` itself, which also gates the `codex`
  subprocess and should stay minimal. These are plain, non-secret config values, never PR content or
  credentials, so this doesn't weaken the allowlist's credential-isolation intent.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused — one source file, one test file.
- [x] Follows `CONTRIBUTING.md`; no `site/`/`CNAME`/VitePress changes.
- [x] Linked issue: `Closes #3705`.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` — not run; no workflow files touched.
- [x] `npm run typecheck` (clean)
- [ ] `npm run test:coverage` (full/unsharded) — not run locally; ran the affected test file
      (`test/unit/selfhost-ai.test.ts`, 126 tests, all green) plus the full `queue.test.ts`
      integration suite (709 tests). Cross-referenced the exact new-diff line/branch ranges against a
      fresh `coverage-final.json` (`--coverage.include='src/selfhost/ai.ts'`): 100% of the new
      statements and branches are covered. GitHub CI runs the full suite/gate on push.
- [ ] `npm run test:workers` / `npm run build:mcp` / `npm run test:mcp-pack` — not run; nothing in
      those surfaces touched.
- [ ] `npm run ui:openapi:check` / `ui:lint` / `ui:typecheck` / `ui:build` — not run; no API/schema or
      `apps/gittensory-ui/**` changes.
- [ ] `npm audit --audit-level=moderate` — not run; no dependency changes.
- [x] New/changed behavior has regression tests: the telemetry vars thread through when the parent
      has them set, and are correctly omitted (not leaked as empty strings) when it doesn't.

If any required check was skipped, explain why:

- Local validation here was typecheck + the specific affected test files rather than a full local
  `test:ci`/`test:coverage`/`npm audit` pass, since GitHub CI runs the complete gate on push and
  re-running the whole suite by hand for every change is redundant.

## Safety

- [x] No secrets, wallets, hotkeys, coldkeys, trust scores, or private scoring values are touched or
      exposed — the passed-through values are exporter endpoints/protocols/booleans, never
      credentials.
- [x] Not a public-facing text change.
- [x] Not an auth/CORS/session change; no negative-path tests needed for that reason.
- [x] Not an API/OpenAPI change.
- [ ] Not a UI change (N/A) — no `UI Evidence` section included.
- [x] No changelog edit.