### PR TITLE
fix(enrichment): bound caller-impact import parsing

### DIFF
--- a/review-enrichment/src/analyzers/caller-impact.ts
+++ b/review-enrichment/src/analyzers/caller-impact.ts
@@ -128,15 +128,51 @@ export function importBindsSymbol(body: string, symbol: string): boolean {
  *  same-named import from a third-party package). Conservative by design: a caller reaching the symbol only
  *  through a barrel re-export, a namespace member access, or a bare package path is not matched — a false
  *  NEGATIVE only suppresses a finding, which is always fail-safe. Pure. */
+const MAX_IMPORT_STATEMENT_CHARS = 8192;
+
+function isStatementBoundary(source: string, index: number): boolean {
+  let cursor = index - 1;
+  while (cursor >= 0) {
+    const prev = source.charCodeAt(cursor);
+    if (prev !== 9 && prev !== 32) return prev === 10 || prev === 59; // newline or ;
+    cursor -= 1;
+  }
+  return true;
+}
+
+function findStatementEnd(source: string, start: number): number {
+  const limit = Math.min(source.length, start + MAX_IMPORT_STATEMENT_CHARS);
+  let braceDepth = 0;
+  for (let index = start; index < limit; index += 1) {
+    const code = source.charCodeAt(index);
+    if (code === 123) braceDepth += 1; // {
+    else if (code === 125 && braceDepth > 0) braceDepth -= 1; // }
+    else if (code === 59 || (code === 10 && braceDepth === 0)) return index; // ; or statement-ending newline
+  }
+  return limit;
+}
+
+function parseImportFromStatement(statement: string): { body: string; modulePath: string } | null {
+  const from = /\bfrom[ \t]*(['"])([^'"]+)\1/.exec(statement);
+  if (!from?.index) return null;
+  const modulePath = from[2] ?? "";
+  return { body: statement.slice(0, from.index), modulePath };
+}
+
 export function fileImportsSymbol(source: string, symbol: string): boolean {
   if (!source.includes(symbol)) return false;
-  const stmtRe = /(?:^|[\n;])[ \t]*(?:import|export)\b([\s\S]*?)\bfrom[ \t]*(['"])([^'"]+)\2/g;
-  let match: RegExpExecArray | null;
-  while ((match = stmtRe.exec(source)) !== null) {
-    const body = match[1] ?? "";
-    const modulePath = match[3] ?? "";
-    if (!isInternalModulePath(modulePath)) continue;
-    if (importBindsSymbol(body, symbol)) return true;
+  for (const keyword of ["import", "export"] as const) {
+    let cursor = 0;
+    while (cursor < source.length) {
+      const found = source.indexOf(keyword, cursor);
+      if (found === -1) break;
+      cursor = found + keyword.length;
+      const after = source.charCodeAt(cursor);
+      if (!isStatementBoundary(source, found) || !/\s/.test(String.fromCharCode(after))) continue;
+      const parsed = parseImportFromStatement(source.slice(cursor, findStatementEnd(source, cursor)));
+      if (!parsed || !isInternalModulePath(parsed.modulePath)) continue;
+      if (importBindsSymbol(parsed.body, symbol)) return true;
+    }
   }
   return false;
 }

--- a/review-enrichment/test/caller-impact.test.ts
+++ b/review-enrichment/test/caller-impact.test.ts
@@ -91,13 +91,19 @@ test("importBindsSymbol: named (incl. alias), default, and namespace bindings", 
 
 test("fileImportsSymbol: only a real internal import counts; text/property/bare-pkg do not", () => {
   assert.equal(fileImportsSymbol(`import { foo } from "./m";\nfoo();`, "foo"), true);
-  assert.equal(fileImportsSymbol(`import { foo as f } from "../m";`, "foo"), true);
+  assert.equal(fileImportsSymbol(`  import { foo as f } from "../m";`, "foo"), true);
   assert.equal(fileImportsSymbol(`export { foo } from "@/m";`, "foo"), true);
   assert.equal(fileImportsSymbol(`import foo from "#internal";`, "foo"), true);
+  assert.equal(fileImportsSymbol(`import {\n  foo,\n} from "~/m";`, "foo"), true);
   assert.equal(fileImportsSymbol(`import { foo } from "third-party";`, "foo"), false); // bare package
   assert.equal(fileImportsSymbol(`// foo is used elsewhere\nconst x = obj.foo;`, "foo"), false); // comment/property
   assert.equal(fileImportsSymbol(`const foo = 1;`, "foo"), false); // local declaration
   assert.equal(fileImportsSymbol(`import { bar } from "./m";`, "foo"), false);
+});
+
+test("fileImportsSymbol: pathological import-like text is scanned in linear time", () => {
+  const source = `${"; import anything\n".repeat(55_000)}Victim`;
+  assert.equal(fileImportsSymbol(source, "Victim"), false);
 });
 
 test("collectRemovedExports: removed export keyed to old-file line", () => {


### PR DESCRIPTION
### Motivation
- The caller-impact analyzer used an unbounded lazy regexp over whole fetched files, allowing pathological import-like text to cause severe superlinear CPU usage and block the event loop for long-running fetches.
- Limit parsing work per fetched file so a malicious or accidental large unchanged file cannot exhaust CPU despite the existing byte cap.

### Description
- Replace the global whole-file `stmtRe` regexp with a bounded, statement-oriented scanner in `review-enrichment/src/analyzers/caller-impact.ts` that: limits each import/export statement to `8192` chars, detects statement boundaries by newline/semicolon, and tracks brace depth to support multiline named imports.
- Add `parseImportFromStatement`, `findStatementEnd`, and `isStatementBoundary` helpers and update `fileImportsSymbol` to scan by keyword (`import`/`export`) and parse only the bounded statement slice.
- Preserve existing semantics (internal-only module path check, named/default/namespace bindings) and keep fail-safe behavior when a candidate file cannot be read or parsed.
- Add a regression test in `review-enrichment/test/caller-impact.test.ts` that verifies pathological import-like input is scanned in linear/bounded time and update a few existing expectations for indented/multiline imports.

### Testing
- Ran `git diff --check` (clean) and `npm --prefix review-enrichment run test:node`, and all REES unit tests passed (1183 tests, 0 failures).
- Ran the full REES integration runner via `npm run rees:test` which built, validated sourcemaps, generated metadata, and all tests passed locally (no failing tests).
- Attempted `npm audit --audit-level=moderate` but the registry audit endpoint returned `403 Forbidden` in this environment, so audit could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b34ea387c832c9aba9e6c49b65d45)