### PR TITLE
fix(signals): move isTestFile/isCodeFile out of local-branch.ts to unbreak ui:typecheck

### DIFF
--- a/src/signals/local-branch.ts
+++ b/src/signals/local-branch.ts
@@ -26,7 +26,7 @@ import { deriveEligibilityPlan } from "../services/eligibility-plan";
 import { scenarioInputFromLocalBranchMetadata } from "../scenarios/input-model";
 import { renderPublicScenarioSummary, type PublicScenarioSummary, type ScenarioSummaryInput } from "../scenarios/scenario-summary";
 import { simulateOpenPrPressure } from "../services/open-pr-pressure-scenarios";
-import { isTestPath } from "./test-evidence";
+import { isCodeFile, isTestFile } from "./path-matchers";
 
 export type LocalBranchChangedFile = {
   path: string;
@@ -1261,26 +1261,12 @@ function safeRepoPath(path: string): string {
   return PUBLIC_LOCAL_PATH_PREFIX_PATTERN.test(String(path).replace(/\\/g, "/")) ? "[local path hidden]" : String(path || "(unknown path)").replace(/\\/g, "/");
 }
 
-export function isTestFile(file: string): boolean {
-  // Keep local scoring aligned with slop/test-evidence matchers (#561 / #1046).
-  return isTestPath(file);
-}
-
-export function isCodeFile(file: string): boolean {
-  // cs/swift/groovy/php plus C/C++/Objective-C round out the native/JVM/.NET/Swift/PHP set: isTestPath already
-  // recognizes their `SomethingTest(s)`/`Spec` test files, so their source must
-  // count as code too — otherwise a C#/Swift/Groovy/PHP/native source file is neither test
-  // nor code in the local scorer. vue/svelte/astro align with review/rag.ts CODE_EXT_RE,
-  // review/visual/paths.ts, and rules/advisory.ts isCodePath so every classifier agrees.
-  // cc/hpp round out the C++ set alongside cpp/c/h (rag.ts already indexes all four).
-  // dart aligns with rag.ts and test-evidence's *_test.dart convention (hand-authored
-  // .dart is source; generated .g.dart/.freezed.dart stay non-code via isGeneratedFile).
-  return (
-    /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy|php|cpp|cc|c|h|hpp|m|vue|svelte|astro|dart)$/i.test(
-      file,
-    ) && !isTestFile(file)
-  );
-}
+// isTestFile/isCodeFile now live in path-matchers.ts (#3690-followup: path-matchers.ts must never import
+// FROM local-branch.ts -- it is reachable from apps/gittensory-ui/src/lib/registration-workspace.ts via
+// focus-manifest.ts, and local-branch.ts pulls in the whole review-scoring/Gittensor-API subsystem, which
+// breaks `ui:typecheck` under the UI's tsconfig (no Workers ambient types there). Re-exported here so this
+// file's own many existing importers of isTestFile/isCodeFile don't need to change their import path.
+export { isCodeFile, isTestFile };
 
 function sameRepo(left: string, right: string): boolean {
   return left.toLowerCase() === right.toLowerCase();

--- a/src/signals/path-matchers.ts
+++ b/src/signals/path-matchers.ts
@@ -1,10 +1,34 @@
-import { isCodeFile, isTestFile } from "./local-branch";
 import { isTestPath } from "./test-evidence";
 
 // Pure, deterministic path matchers for slop classification (#561). Siblings to `isTestFile` /
 // `isTestPath`: they identify changed files that are NOT genuine hand-authored effort — machine-
 // generated output, vendored/imported third-party code, minified bundles, dependency lockfiles, and
 // docs — so slop signals can tell a padded diff from real work. Path-only and side-effect-free.
+//
+// MUST NOT import from local-branch.ts (#3690-followup): this file is reachable from
+// apps/gittensory-ui/src/lib/registration-workspace.ts via focus-manifest.ts, and local-branch.ts pulls in
+// the whole review-scoring/Gittensor-API subsystem, which breaks `ui:typecheck` under the UI's tsconfig (no
+// Workers ambient types there). local-branch.ts imports isTestFile/isCodeFile back FROM here instead.
+
+/** Keep local scoring aligned with slop/test-evidence matchers (#561 / #1046). */
+export function isTestFile(file: string): boolean {
+  return isTestPath(file);
+}
+
+/** cs/swift/groovy/php plus C/C++/Objective-C round out the native/JVM/.NET/Swift/PHP set: isTestPath already
+ *  recognizes their `SomethingTest(s)`/`Spec` test files, so their source must count as code too —
+ *  otherwise a C#/Swift/Groovy/PHP/native source file is neither test nor code in the local scorer.
+ *  vue/svelte/astro align with review/rag.ts CODE_EXT_RE, review/visual/paths.ts, and rules/advisory.ts
+ *  isCodePath so every classifier agrees. cc/hpp round out the C++ set alongside cpp/c/h (rag.ts already
+ *  indexes all four). dart aligns with rag.ts and test-evidence's *_test.dart convention (hand-authored
+ *  .dart is source; generated .g.dart/.freezed.dart stay non-code via isGeneratedFile). */
+export function isCodeFile(file: string): boolean {
+  return (
+    /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy|php|cpp|cc|c|h|hpp|m|vue|svelte|astro|dart)$/i.test(
+      file,
+    ) && !isTestFile(file)
+  );
+}
 
 function normalize(path: string): string {
   return String(path ?? "")

--- a/test/unit/path-matchers.test.ts
+++ b/test/unit/path-matchers.test.ts
@@ -1,3 +1,6 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
   classifyChangedFile,
@@ -10,6 +13,18 @@ import {
   isNonSubstantivePaddingFile,
   isVendoredFile,
 } from "../../src/signals/path-matchers";
+
+// Structural guard (#3690-followup): this file is reachable from apps/gittensory-ui/src/lib/
+// registration-workspace.ts via focus-manifest.ts's classifyChangedFile import. local-branch.ts pulls in
+// the whole review-scoring/Gittensor-API subsystem, so an import from it here breaks `ui:typecheck` under
+// the UI's tsconfig (no Workers ambient types there) -- confirmed by a real ~35-file "Cannot find name
+// Env/D1Database" break when path-matchers.ts briefly imported isCodeFile/isTestFile from local-branch.ts.
+describe("path-matchers.ts never imports from local-branch.ts", () => {
+  it("has no import statement referencing ./local-branch", () => {
+    const source = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "../../src/signals/path-matchers.ts"), "utf8");
+    expect(source).not.toMatch(/from\s+["']\.\/local-branch["']/);
+  });
+});
 
 describe("isGeneratedFile", () => {
   it("matches generated output by directory, suffix, codegen, and source maps", () => {


### PR DESCRIPTION
## Summary

- PR #3690 (\`review.auto_review.skip_docs_only\`) added \`import { classifyChangedFile } from "./path-matchers";\` to \`src/signals/focus-manifest.ts\`. \`path-matchers.ts\` itself imports \`isCodeFile\`/\`isTestFile\` from \`./local-branch\` — a large module pulling in the whole review-scoring/Gittensor-API subsystem.
- \`focus-manifest.ts\` is reachable from \`apps/gittensory-ui/src/lib/registration-workspace.ts\` via a long-standing cross-boundary import (present since #390). This means \`npm run ui:typecheck\` started transitively type-checking the entire \`local-branch.ts\` import graph, including files using Cloudflare Workers ambient types (\`Env\`, \`D1Database\`) the UI's tsconfig has no way to resolve.
- Confirmed via direct bisection (checkout + fresh reproduction at each commit, not just CI timestamp order, which can be misleading when runs complete out of sequence): broke exactly at commit \`525be40a\`, persists on every subsequent main commit, ~35 files' worth of \`Cannot find name 'Env'\`/\`'D1Database'\` errors.
- \`isTestFile\`/\`isCodeFile\` were only ever thin, self-contained path-matching helpers incidentally defined in \`local-branch.ts\` (\`isTestFile\` is a 1-line wrapper around the already-dependency-free \`isTestPath\`; \`isCodeFile\` is a pure regex check). Moved both into \`path-matchers.ts\`, with \`local-branch.ts\` importing them back and re-exporting for its ~9 existing importers. \`path-matchers.ts\` now has zero dependency on \`local-branch.ts\` — permanently, not just for this one feature.
- Added a structural regression test asserting \`path-matchers.ts\`'s source never contains an import from \`./local-branch\`, so this exact regression class fails fast locally instead of silently breaking \`ui:typecheck\`.

Closes #3708

## Scope

- \`src/signals/path-matchers.ts\` — gains \`isTestFile\`/\`isCodeFile\`, loses the \`local-branch\` import
- \`src/signals/local-branch.ts\` — imports + re-exports both from \`path-matchers.ts\` instead of defining them
- \`test/unit/path-matchers.test.ts\` — new structural guard test

No behavior change: both functions' bodies are byte-identical, just relocated.

## Validation

- \`npm run typecheck\` — clean
- \`npm run ui:typecheck\` — clean (was failing with ~35 files of Env/D1Database errors before this fix)
- \`npx vitest run test/unit/path-matchers.test.ts test/unit/local-branch.test.ts test/unit/local-branch-file-classifiers.test.ts test/unit/changed-files-classify.test.ts test/unit/focus-manifest.test.ts test/unit/auto-review-wiring.test.ts test/unit/auto-review-config-matrix.test.ts test/unit/queue.test.ts test/unit/signals-coverage.test.ts test/unit/finding-category-classify.test.ts test/unit/slop.test.ts test/unit/local-scorer.test.ts test/unit/engine.test.ts test/unit/contributor-open-pr-monitor.test.ts\` (every existing importer of \`isCodeFile\`/\`isTestFile\`, plus everything downstream of \`focus-manifest.ts\`'s \`skip_docs_only\`) — 1333/1333 passing
- Diffed my changed hunk (\`git diff main -- src/signals/path-matchers.ts\`) against the coverage report to confirm 100% of the actual diff is covered; the only file-level "uncovered" lines reported are pre-existing, untouched helper functions outside my diff range

## Safety

- No secrets, wallet/hotkey/trust-score/reward terms introduced
- No behavior change to any classifier's output — confirmed by the full existing test suite for every consumer passing unchanged