### PR TITLE
fix(ui): resolve backend-workspace typecheck break in apps/gittensory-ui

### DIFF
--- a/apps/gittensory-ui/src/lib/error-capture.ts
+++ b/apps/gittensory-ui/src/lib/error-capture.ts
@@ -9,9 +9,9 @@ function record(error: unknown) {
 }
 
 if (typeof globalThis.addEventListener === "function") {
-  globalThis.addEventListener("error", (event) => record((event as ErrorEvent).error ?? event));
-  globalThis.addEventListener("unhandledrejection", (event) =>
-    record((event as PromiseRejectionEvent).reason),
+  globalThis.addEventListener("error", (event: ErrorEvent) => record(event.error ?? event));
+  globalThis.addEventListener("unhandledrejection", (event: PromiseRejectionEvent) =>
+    record(event.reason),
   );
 }
 

--- a/apps/gittensory-ui/tsconfig.json
+++ b/apps/gittensory-ui/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "include": ["src/**/*.ts", "src/**/*.tsx", "vite.config.ts", "eslint.config.js"],
+  "include": ["src/**/*.ts", "src/**/*.tsx", "vite.config.ts", "eslint.config.js", "../../worker-configuration.d.ts", "../../src/env.d.ts"],
   "compilerOptions": {
     "target": "ES2022",
     "jsx": "react-jsx",

--- a/src/orb/relay.ts
+++ b/src/orb/relay.ts
@@ -148,7 +148,9 @@ export async function relayVerify(secret: string, body: string, header: string |
   const sigBytes = hexToBytes(hex);
   if (!sigBytes) return false;
   const key = await crypto.subtle.importKey("raw", new TextEncoder().encode(secret), { name: "HMAC", hash: "SHA-256" }, false, ["verify"]);
-  return crypto.subtle.verify("HMAC", key, sigBytes, new TextEncoder().encode(body));
+  // sigBytes is always a plain (never shared) ArrayBuffer view — the cast only narrows the TYPE for the
+  // UI workspace's stricter DOM-lib BufferSource, which excludes SharedArrayBuffer from ArrayBufferLike.
+  return crypto.subtle.verify("HMAC", key, sigBytes as Uint8Array<ArrayBuffer>, new TextEncoder().encode(body));
 }
 
 export type RegisterResult =

--- a/src/review/visual/shot.ts
+++ b/src/review/visual/shot.ts
@@ -231,7 +231,9 @@ export async function handleShot(request: Request, env: Env, opts: ShotOptions =
   const theme: ShotTheme | undefined = requestedTheme === "light" || requestedTheme === "dark" ? requestedTheme : undefined;
   const png = await renderScreenshot(env, target, viewport, { isAllowedUrl: (candidate) => isAllowedHost(candidate, env, opts.productionUrl), ...(theme ? { theme } : {}) });
   if (!png) return new Response("screenshot unavailable", { status: 502 });
-  return new Response(png, {
+  // png is always a plain (never shared) ArrayBuffer view — the cast only narrows the TYPE for the UI
+  // workspace's stricter DOM-lib BodyInit, which excludes SharedArrayBuffer from ArrayBufferLike.
+  return new Response(png as Uint8Array<ArrayBuffer>, {
     headers: { "content-type": "image/png", "cache-control": "public, max-age=300" },
   });
 }

--- a/src/utils/crypto.ts
+++ b/src/utils/crypto.ts
@@ -59,8 +59,10 @@ const SECRET_KEY_VERSION_CURRENT = 2;
 
 async function deriveSecretAesKey(keyMaterial: string, salt: Uint8Array): Promise<CryptoKey> {
   const baseKey = await crypto.subtle.importKey("raw", new TextEncoder().encode(keyMaterial), "PBKDF2", false, ["deriveKey"]);
+  // salt is always a plain (never shared) ArrayBuffer view — the cast only narrows the TYPE for the UI
+  // workspace's stricter DOM-lib Pbkdf2Params, which excludes SharedArrayBuffer from ArrayBufferLike.
   return crypto.subtle.deriveKey(
-    { name: "PBKDF2", salt, iterations: 100_000, hash: "SHA-256" },
+    { name: "PBKDF2", salt: salt as Uint8Array<ArrayBuffer>, iterations: 100_000, hash: "SHA-256" },
     baseKey,
     { name: "AES-GCM", length: 256 },
     false,
@@ -95,7 +97,9 @@ export async function decryptSecret(ciphertext: string, iv: string, keyMaterial:
   if (!keyMaterial) throw new Error("missing_encryption_secret");
   const saltBytes = salt ? base64ToBytes(salt) : SECRET_KDF_SALT_V1;
   const key = await deriveSecretAesKey(keyMaterial, saltBytes);
-  const decrypted = await crypto.subtle.decrypt({ name: "AES-GCM", iv: base64ToBytes(iv) }, key, base64ToBytes(ciphertext));
+  // These decoded byte arrays are always plain (never shared) ArrayBuffer views — the cast only narrows the
+  // TYPE for the UI workspace's stricter DOM-lib AesGcmParams, which excludes SharedArrayBuffer.
+  const decrypted = await crypto.subtle.decrypt({ name: "AES-GCM", iv: base64ToBytes(iv) as Uint8Array<ArrayBuffer> }, key, base64ToBytes(ciphertext) as Uint8Array<ArrayBuffer>);
   return new TextDecoder().decode(decrypted);
 }
 
@@ -122,8 +126,10 @@ function base64UrlDecode(value: string): Uint8Array {
 
 async function deriveDraftTokenAesKey(secret: string, salt: Uint8Array): Promise<CryptoKey> {
   const keyMaterial = await crypto.subtle.importKey("raw", new TextEncoder().encode(secret), "HKDF", false, ["deriveKey"]);
+  // salt is always a plain (never shared) ArrayBuffer view — the cast only narrows the TYPE for the UI
+  // workspace's stricter DOM-lib HkdfParams, which excludes SharedArrayBuffer from ArrayBufferLike.
   return crypto.subtle.deriveKey(
-    { name: "HKDF", hash: "SHA-256", salt, info: new TextEncoder().encode("gittensory:draft-user-token:v1") },
+    { name: "HKDF", hash: "SHA-256", salt: salt as Uint8Array<ArrayBuffer>, info: new TextEncoder().encode("gittensory:draft-user-token:v1") },
     keyMaterial,
     { name: "AES-GCM", length: 256 },
     false,
@@ -148,10 +154,12 @@ export async function decryptDraftToken(secret: string, encrypted: string): Prom
   const parts = encrypted.split(".");
   if (parts.length !== 3 || !parts[0] || !parts[1] || !parts[2]) throw new Error("Invalid encrypted payload.");
   try {
+    // These decoded byte arrays are always plain (never shared) ArrayBuffer views — the casts only narrow
+    // the TYPE for the UI workspace's stricter DOM-lib AesGcmParams, which excludes SharedArrayBuffer.
     const plaintext = await crypto.subtle.decrypt(
-      { name: "AES-GCM", iv: base64UrlDecode(parts[1]) },
+      { name: "AES-GCM", iv: base64UrlDecode(parts[1]) as Uint8Array<ArrayBuffer> },
       await deriveDraftTokenAesKey(secret, base64UrlDecode(parts[0])),
-      base64UrlDecode(parts[2]),
+      base64UrlDecode(parts[2]) as Uint8Array<ArrayBuffer>,
     );
     return new TextDecoder().decode(plaintext);
   } catch {
@@ -198,9 +206,11 @@ async function importPkcs8PrivateKey(privateKeyPem: string): Promise<CryptoKey> 
     .replace("-----END RSA PRIVATE KEY-----", "")
     .replace(/\s+/g, "");
   const bytes = isPkcs1Rsa ? wrapPkcs1RsaPrivateKey(base64ToBytes(base64)) : base64ToBytes(base64);
+  // bytes is always a plain (never shared) ArrayBuffer view — the cast only narrows the TYPE for the UI
+  // workspace's stricter DOM-lib importKey overload, which excludes SharedArrayBuffer from ArrayBufferLike.
   return crypto.subtle.importKey(
     "pkcs8",
-    bytes,
+    bytes as Uint8Array<ArrayBuffer>,
     { name: "RSASSA-PKCS1-v1_5", hash: "SHA-256" },
     false,
     ["sign"],


### PR DESCRIPTION
## Summary

Main's CI has been red on `validate-code` since commit d3334632 (bisected directly against main's own CI run history: `c4c977ba` was the last green run, `d3334632` the first red one, every commit since has stayed red), blocking every open PR — including PRs that never touched anything related to this.

**Root cause:** `apps/gittensory-ui/src/lib/registration-workspace.ts` has a long-standing import reaching directly into the backend — `import { isFocusManifestPublicSafe } from "../../../../src/signals/focus-manifest"`. This pulls `focus-manifest.ts` and its transitive dependencies into the UI package's own, separate `tsconfig.json`, which never loaded `worker-configuration.d.ts` or `src/env.d.ts` (the two files that together declare the global `Env` interface). Every backend file that transitively references `Env` failed to resolve it under the UI's compile unit.

## Fix

- `apps/gittensory-ui/tsconfig.json`: add `worker-configuration.d.ts` and `src/env.d.ts` to `include`. Both use `declare global { interface Env {...} }` and merge into one complete type — including only one left most fields missing (confirmed by testing each addition independently).
- `apps/gittensory-ui/src/lib/error-capture.ts`: explicitly type two `addEventListener` callback parameters. Loading `worker-configuration.d.ts` also introduces a global Workers-runtime `addEventListener` overload (keyed by `WorkerGlobalScopeEventMap`, which has no `"unhandledrejection"` key) that collided with DOM's own overload for that one call site, widening the inferred parameter to `any`.
- `src/utils/crypto.ts`, `src/orb/relay.ts`, `src/review/visual/shot.ts`: cast a handful of `Uint8Array` values to `Uint8Array<ArrayBuffer>` at their exact Web Crypto / `Response` call sites. These buffers are never actually `SharedArrayBuffer`-backed; DOM's `BufferSource`/`BodyInit` types (only reachable once the UI's DOM-lib tsconfig transitively reaches these files) exclude `SharedArrayBuffer` from the wider `ArrayBufferLike` default that a bare `Uint8Array` annotation carries.
  - These are deliberately **local casts at the call site**, not signature changes. I first tried narrowing the function *signatures* themselves (e.g. `salt: Uint8Array<ArrayBuffer>`), but that broke the **root** tsconfig's own typecheck in the opposite direction — the root config's own `crypto.getRandomValues` typing (from `worker-configuration.d.ts`, no DOM lib) doesn't narrow its return type to plain `ArrayBuffer` the way DOM's does, so a stricter parameter type rejected values that were previously accepted. Local casts avoid the ripple entirely.

## Validation

- [x] `npx tsc --noEmit` (root) clean.
- [x] `npx tsc --noEmit` inside `apps/gittensory-ui` — clean (was the failing job; verified with a real `npm ci`, not just a partial local check).
- [x] Full local suite: 498 files, 10041 passed / 7 skipped, 0 failed (`npx vitest run`) — including the specific test files covering every touched function (`crypto.test.ts`, `crypto-secret.test.ts`, `crypto-jwt.test.ts`, `orb-relay-policy.test.ts`, `visual-shot.test.ts`, `integration/orb-relay.test.ts`, 122 tests total), confirming the casts are purely type-level with zero runtime behavior change.
- [x] `git diff --check` clean.
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities.

No linked issue — this isn't a feature, it's restoring main to green.