### PR TITLE
docs(config): document shipped review.effort_score and changed_files_summary toggles

### DIFF
--- a/.gittensory.yml.example
+++ b/.gittensory.yml.example
@@ -390,9 +390,12 @@ review:
     # Default: 0 (no cap). (#2065)
     # max_files: 25
 
-  # Planned display toggle (#2069): when enabled, the unified review comment includes a
-  # `review effort: N/5 (~M min)` line derived from the per-PR effort estimate.
+  # Unified-comment display toggles (#1957 / #1955 / #2069). Bool | null. Default: null/false — byte-identical.
+  # Only take effect when the `features.unifiedComment` feature is enabled.
+  # changed_files_summary: false
+  # When true, the unified review comment gains a deterministic "Changed files" summary table.
   # effort_score: false
+  # When true, the unified review comment gains a compact "review effort: N/5 (~M min)" chip.
 
   # Deterministic label suggestions (#2045). Each rule SUGGESTS a non-scoring label when a PR matches ALL of the
   # `when` criteria it sets (at least one is required): when_paths (any changed path matches a glob), title_contains,

--- a/config/examples/gittensory.full.yml
+++ b/config/examples/gittensory.full.yml
@@ -403,9 +403,12 @@ review:
     # Default: 0 (no cap). (#2065)
     # max_files: 25
 
-  # Planned display toggle (#2069): when enabled, the unified review comment includes a
-  # `review effort: N/5 (~M min)` line derived from the per-PR effort estimate.
+  # Unified-comment display toggles (#1957 / #1955 / #2069). Bool | null. Default: null/false — byte-identical.
+  # Only take effect when the `features.unifiedComment` feature is enabled.
+  # changed_files_summary: false
+  # When true, the unified review comment gains a deterministic "Changed files" summary table.
   # effort_score: false
+  # When true, the unified review comment gains a compact "review effort: N/5 (~M min)" chip.
 
   # Deterministic label suggestions (#2045). Each rule SUGGESTS a non-scoring label when a PR matches ALL of the
   # `when` criteria it sets (at least one is required): when_paths (any changed path matches a glob), title_contains,

--- a/test/unit/config-templates.test.ts
+++ b/test/unit/config-templates.test.ts
@@ -56,6 +56,14 @@ describe("config/examples review templates (#1682)", () => {
     expect(full).not.toMatch(/not parsed yet/);
   });
 
+  it("documents shipped unified-comment display toggles in gittensory.full.yml (#2069)", () => {
+    const full = readConfigExample("gittensory.full.yml");
+    for (const field of ["changed_files_summary", "effort_score"]) {
+      expect(full, `missing review field ${field}`).toMatch(new RegExp(`# ${field}:`));
+    }
+    expect(full).not.toMatch(/Planned display toggle/);
+  });
+
   it("parses gittensory.minimal.yml with zero warnings and enables no agent actions", () => {
     const manifest = parseFocusManifestContent(readConfigExample("gittensory.minimal.yml"), "repo_file");
     expect(manifest.warnings).toEqual([]);


### PR DESCRIPTION
Closes #2069

## Summary
- Replace the stale "Planned display toggle" placeholder for `review.effort_score` with shipped documentation in `gittensory.full.yml` and keep `.gittensory.yml.example` in sync.
- Document `review.changed_files_summary` alongside `effort_score` as unified-comment display toggles (#1957 / #1955).

## Validation
- `npx vitest run test/unit/config-templates.test.ts`

## UI Evidence
N/A
