### PR TITLE
fix(signals): classify Perl and Scala protobuf stubs as generated

### DIFF
--- a/src/signals/path-matchers.ts
+++ b/src/signals/path-matchers.ts
@@ -78,12 +78,12 @@ function isGeneratedFileFrom(parts: NormalizedPath): boolean {
     // `.pb.cc` / `.pb.h`, the Swift plugin emits `.pb.swift`, the Dart plugin emits `.pb.dart`,
     // the Kotlin plugin emits `.pb.kt`, the C# plugin emits `.pb.cs`, the Rust plugin emits `.pb.rs`,
     // the Elixir plugin emits `.pb.ex`, the Erlang gpb plugin emits `.pb.erl` / `.pb.hrl`, the Crystal
-    // plugin emits `.pb.cr`, the Haskell plugin emits `.pb.hs`, and the Objective-C plugin emits
+    // plugin emits `.pb.cr`, the Haskell plugin emits `.pb.hs`, the Scala plugin emits `.pb.scala`, and the Objective-C plugin emits
     // `.pbobjc.{h,m}` plus gRPC `.pbrpc.{h,m}` service stubs. Swift gRPC emits sibling `.grpc.swift`
     // service stubs; grpc-kotlin emits sibling `*GrpcKt.kt` coroutine service stubs; grpc-java emits
     // sibling `*Grpc.java` service stubs.
     // `.pb.dart`/`.pb.kt`/`.pb.cs` (the `.pb` infix keeps hand-written sources from matching).
-    /\.pb\.(go|ts|js|cc|h|swift|dart|kt|cs|rs|ex|erl|hrl|cr|hs)$/.test(norm) ||
+    /\.pb\.(go|ts|js|cc|h|swift|dart|kt|cs|rs|ex|erl|hrl|cr|hs|scala)$/.test(norm) ||
     /\.grpc\.swift$/.test(norm) ||
     /grpckt\.kt$/.test(norm) ||
     /grpc\.java$/.test(norm) ||
@@ -100,6 +100,8 @@ function isGeneratedFileFrom(parts: NormalizedPath): boolean {
     /_pb\.nim$/.test(norm) ||
     // Lua protobuf: message stubs are `*_pb.lua`.
     /_pb\.lua$/.test(norm) ||
+    // Perl protobuf: message stubs are `*_pb.pm`.
+    /_pb\.pm$/.test(norm) ||
     // JavaScript/TypeScript grpc-node protobuf: message stubs are `*_pb.{js,ts,d.ts}`; gRPC emits
     // sibling `*_grpc_pb.{js,ts,d.ts}` service stubs (underscore form, not `.pb.js`).
     /_pb\.(js|ts)$/.test(norm) ||

--- a/test/unit/path-matchers.test.ts
+++ b/test/unit/path-matchers.test.ts
@@ -153,6 +153,18 @@ describe("isGeneratedFile", () => {
     expect(classifyChangedFile("gen/service_pb.lua")).toBe("generated");
   });
 
+  it("matches Perl protobuf output alongside the other protoc plugins", () => {
+    expect(isGeneratedFile("gen/service_pb.pm")).toBe(true);
+    expect(isGeneratedFile("lib/MyApp.pm")).toBe(false);
+    expect(classifyChangedFile("gen/service_pb.pm")).toBe("generated");
+  });
+
+  it("matches Scala protobuf output alongside the other protoc plugins", () => {
+    expect(isGeneratedFile("proto/messages.pb.scala")).toBe(true);
+    expect(isGeneratedFile("src/Main.scala")).toBe(false);
+    expect(classifyChangedFile("proto/messages.pb.scala")).toBe("generated");
+  });
+
   it("matches Kotlin gRPC coroutine stubs alongside the other protoc plugins", () => {
     expect(isGeneratedFile("gen/GreeterGrpcKt.kt")).toBe(true);
     expect(isGeneratedFile("src/Greeter.kt")).toBe(false);
@@ -508,6 +520,8 @@ describe("classifyChangedFile", () => {
       ["proto/messages.pb.hs", "generated"],
       ["gen/service_pb.nim", "generated"],
       ["gen/service_pb.lua", "generated"],
+      ["gen/service_pb.pm", "generated"],
+      ["proto/messages.pb.scala", "generated"],
       ["gen/GreeterGrpcKt.kt", "generated"],
       ["gen/GreeterGrpc.java", "generated"],
       ["gen/service_grpc_pb.js", "generated"],


### PR DESCRIPTION
## Summary

Extend `isGeneratedFile` to recognize protoc Perl message stubs (`*_pb.pm`) and Scala message stubs (`.pb.scala`), matching the existing `.pb.*` plugin coverage for Go/TS/JS/C++/Rust/Elixir/etc. Includes positive/negative `isGeneratedFile` / `classifyChangedFile` assertions and classification-table entries.

Fixes #2144

## Scope

- [x] Conventional Commit title format.
- [x] Focused — path-matchers + unit tests only.
- [x] Follows `CONTRIBUTING.md`.
- [x] Linked open issue (#2144 changed-files grouping depends on accurate `classifyChangedFile`).

## Validation

- [x] `git diff --check`
- [x] `npm run test:ci` on Node 22
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] Unit tests cover `isGeneratedFile`, `classifyChangedFile`, and the representative cases table

If any required check was skipped, explain why:

- None skipped.

## Safety

- [x] No secrets, auth, or UI changes.
- [x] N/A for UI Evidence.

## UI Evidence

N/A — signals-only change with no visible UI.

## Notes

Incremental **path-matcher parity** supporting the changed-files summary pipeline (#2144). Does not deliver `summarizeChangedFiles` grouping — only closes generated-classification gaps for Perl/Scala protoc output.

**Conflict avoidance:** Touches only `src/signals/path-matchers.ts` and `test/unit/path-matchers.test.ts`. Zero overlap with open PRs (#3714 config docs, #3712 visual shot bounds, #3704 miner calibration types, #3702 miner README, #3698 ignored-author gate, #3688 scroll GIF capture).

Made with [Cursor](https://cursor.com)