### PR TITLE
fix(review): exclude current head from auto-pause count

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -4119,12 +4119,21 @@ export async function getLatestPublishedAiReview(
   };
 }
 
-/** Count distinct PR head SHAs that already received a published AI review — used by `review.auto_review.auto_pause_after_reviewed_commits`. (#2042) */
-export async function countPublishedAiReviewHeads(env: Env, repoFullName: string, pullNumber: number): Promise<number> {
-  const row = await env.DB.prepare(
-    "SELECT COUNT(DISTINCT head_sha) AS cnt FROM ai_review_cache WHERE repo_full_name = ? AND pull_number = ? AND published_at IS NOT NULL",
-  )
-    .bind(repoFullName, pullNumber)
+/** Count distinct prior PR head SHAs that already received a published AI review — used by `review.auto_review.auto_pause_after_reviewed_commits`. (#2042) */
+export async function countPublishedAiReviewHeads(
+  env: Env,
+  repoFullName: string,
+  pullNumber: number,
+  currentHeadSha?: string | null | undefined,
+): Promise<number> {
+  const currentHeadClause = currentHeadSha ? " AND head_sha != ?" : "";
+  const row = await env.DB
+    .prepare(
+      `SELECT COUNT(DISTINCT head_sha) AS cnt FROM ai_review_cache WHERE repo_full_name = ? AND pull_number = ? AND published_at IS NOT NULL${currentHeadClause}`,
+    )
+    .bind(
+      ...(currentHeadSha ? [repoFullName, pullNumber, currentHeadSha] : [repoFullName, pullNumber]),
+    )
     .first<{ cnt: number }>();
   /* v8 ignore next -- SQL aggregate count always returns one row; fallback protects D1 driver anomalies. */
   return row?.cnt ?? 0;

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -6352,7 +6352,7 @@ export async function resolveAutoReviewSkipForPullRequest(
   if (args.authorBlacklisted || args.isFrozenForManualReview) {
     return { skipReason: null, reviewManifest };
   }
-  const reviewedCommitCount = await countPublishedAiReviewHeads(env, args.repoFullName, args.pr.number).catch(() => 0);
+  const reviewedCommitCount = await countPublishedAiReviewHeads(env, args.repoFullName, args.pr.number, args.headSha).catch(() => 0);
   const skipReason = resolvePullRequestAutoReviewSkipReason({
     forceAiReview: args.forceAiReview,
     manifest: reviewManifest,

--- a/test/unit/ai-review-cache.test.ts
+++ b/test/unit/ai-review-cache.test.ts
@@ -485,6 +485,17 @@ describe("AI review cache (#1)", () => {
       expect(await countPublishedAiReviewHeads(env, "o/r", 61)).toBe(2);
     });
 
+    it("excludes the current published head from the pause threshold (regression for cached blocker suppression)", async () => {
+      const env = createTestEnv();
+      await putCachedAiReview(env, "o/r", 63, "sha1", "block", { notes: "first", reviewerCount: 1 });
+      await markAiReviewPublished(env, "o/r", 63, "sha1");
+      await putCachedAiReview(env, "o/r", 63, "sha2", "block", { notes: "current", reviewerCount: 1 });
+      await markAiReviewPublished(env, "o/r", 63, "sha2");
+
+      expect(await countPublishedAiReviewHeads(env, "o/r", 63, "sha2")).toBe(1);
+      expect(await countPublishedAiReviewHeads(env, "o/r", 63, null)).toBe(2);
+    });
+
     it("returns 0 when the count query yields no row (fail-safe)", async () => {
       const env = createTestEnv();
       const prepareSpy = vi.spyOn(env.DB, "prepare").mockReturnValue({

--- a/test/unit/auto-review-wiring.test.ts
+++ b/test/unit/auto-review-wiring.test.ts
@@ -352,7 +352,7 @@ describe("review.auto_review wiring (#1954)", () => {
         headSha: "sha5",
       }),
     ).resolves.toEqual({ skipReason: "review paused (commit threshold)", reviewManifest: manifest });
-    expect(countSpy).toHaveBeenCalledWith(expect.anything(), "acme/widgets", 5);
+    expect(countSpy).toHaveBeenCalledWith(expect.anything(), "acme/widgets", 5, "sha5");
     expect(auditSpy).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ detail: "review paused (commit threshold)" }),


### PR DESCRIPTION
### Motivation

- Prevent a regression where the auto-pause threshold for AI reviews counted the current head and thereby skipped reuse of already-published cached AI findings, which could remove blockers from later gate evaluations.

### Description

- Change `countPublishedAiReviewHeads` to accept an optional `currentHeadSha` and exclude it from the SQL `COUNT(DISTINCT head_sha)` so the threshold only counts prior published heads.  
- Wire the current advisory head (`headSha`) into `resolveAutoReviewSkipForPullRequest` so the helper can exclude the active head when deciding a pause.  
- Add a regression unit test that asserts the current published head is excluded from the pause threshold and retain the old null/no-current-head behavior.  
- Update an existing auto-review-wiring test to expect the current head SHA is forwarded to the count helper.

### Testing

- Ran the targeted unit tests with `npx vitest run test/unit/ai-review-cache.test.ts test/unit/auto-review-wiring.test.ts`, and all tests in those files passed.  
- Ran TypeScript typecheck with `npm run typecheck`, which passed.  
- Attempted a full coverage run (`npm run test:coverage`) and a coverage-enabled run of the two targeted tests; the targeted tests ran cleanly but a full global coverage run was not completed in this environment (global coverage threshold check did not finish here).  
- `npm audit --audit-level=moderate` could not complete due to the registry returning `403 Forbidden` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b3d2d75dc832c90661342be24c293)