### PR TITLE
fix(db): preserve sparse PR body evidence

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -321,7 +321,7 @@ export async function upsertPullRequestFromGitHub(
   const syncedAt = nowIso();
   const lastSeenOpenAt = pr.state === "open" ? (options.seenOpenAt ?? syncedAt) : null;
   const existingClaimRows = await db
-    .select({ linkedIssuesJson: pullRequests.linkedIssuesJson, linkedIssueClaimedAt: pullRequests.linkedIssueClaimedAt })
+    .select({ linkedIssuesJson: pullRequests.linkedIssuesJson, linkedIssueClaimedAt: pullRequests.linkedIssueClaimedAt, payloadJson: pullRequests.payloadJson })
     .from(pullRequests)
     .where(and(eq(pullRequests.repoFullName, repoFullName), eq(pullRequests.number, pr.number)))
     .limit(1);
@@ -332,13 +332,19 @@ export async function upsertPullRequestFromGitHub(
   // already-correctly-claimed linked issue (and reset its claim timestamp via resolveLinkedIssueClaimedAt's own
   // `linkedIssues.length === 0` branch) on any such upsert. Fall back to whatever is already stored in that
   // case; only a genuinely observed (possibly empty) body updates the claim. (#linked-issue-sparse-payload-preserve)
-  const linkedIssues = pr.body === undefined && existingClaimRows[0] ? parseLinkedIssuesJson(existingClaimRows[0].linkedIssuesJson) : record.linkedIssues;
-  const linkedIssuesJson = pr.body === undefined && existingClaimRows[0] ? existingClaimRows[0].linkedIssuesJson : jsonString(linkedIssues);
+  const existingClaimRow = existingClaimRows[0];
+  const preserveSparseBody = pr.body === undefined && existingClaimRow !== undefined;
+  const existingPayload = preserveSparseBody ? parseJson<{ body?: string | null }>(existingClaimRow.payloadJson, {}) : undefined;
+  const existingBody = existingPayload?.body ?? null;
+  const body = preserveSparseBody ? existingBody : record.body;
+  const payload = preserveSparseBody ? compactGitHubPayload({ ...pr, body: existingBody }) : compactGitHubPayload(pr);
+  const linkedIssues = preserveSparseBody ? parseLinkedIssuesJson(existingClaimRow.linkedIssuesJson) : record.linkedIssues;
+  const linkedIssuesJson = preserveSparseBody ? existingClaimRow.linkedIssuesJson : jsonString(linkedIssues);
   const observedLinkedIssueClaimedAt = linkedIssues.length > 0 ? syncedAt : null;
   const linkedIssueClaimedAt = resolveLinkedIssueClaimedAt(
     linkedIssues,
     linkedIssuesJson,
-    existingClaimRows[0],
+    existingClaimRow,
     observedLinkedIssueClaimedAt,
   );
   await db
@@ -360,7 +366,7 @@ export async function upsertPullRequestFromGitHub(
       linkedIssuesJson,
       linkedIssueClaimedAt,
       lastSeenOpenAt,
-      payloadJson: jsonString(compactGitHubPayload(pr)),
+      payloadJson: jsonString(payload),
       updatedAt: syncedAt,
     })
     .onConflictDoUpdate({
@@ -379,11 +385,11 @@ export async function upsertPullRequestFromGitHub(
         linkedIssuesJson,
         linkedIssueClaimedAt,
         lastSeenOpenAt,
-        payloadJson: jsonString(compactGitHubPayload(pr)),
+        payloadJson: jsonString(payload),
         updatedAt: syncedAt,
       },
     });
-  return { ...record, linkedIssues, linkedIssueClaimedAt };
+  return { ...record, body, linkedIssues, linkedIssueClaimedAt };
 }
 
 function resolveLinkedIssueClaimedAt(

--- a/test/unit/db-parsers.test.ts
+++ b/test/unit/db-parsers.test.ts
@@ -380,8 +380,28 @@ describe("database row parser hardening", () => {
     expect(resynced.linkedIssueClaimedAt).toBe(claimed?.linkedIssueClaimedAt); // claim timestamp is untouched
 
     const stored = await getPullRequest(env, "owner/repo", 7);
+    expect(stored?.body).toBe("Closes #42");
     expect(stored?.linkedIssues).toEqual([42]);
     expect(stored?.linkedIssueClaimedAt).toBe(claimed?.linkedIssueClaimedAt);
+  });
+
+  it("REGRESSION: a sparse sync preserves cached body evidence for linked-issue overflow checks", async () => {
+    const env = createTestEnv();
+    const body = Array.from({ length: MAX_LINKED_ISSUE_NUMBERS + 1 }, (_, index) => `Fixes #${index + 1}`).join("\n");
+
+    await upsertPullRequestFromGitHub(env, "owner/repo", { number: 10, title: "Too many claims", state: "open", user: { login: "bob" }, head: { sha: "a1" }, labels: [], body });
+    const claimed = await getPullRequest(env, "owner/repo", 10);
+    expect(claimed?.linkedIssues).toHaveLength(MAX_LINKED_ISSUE_NUMBERS);
+    expect(extractLinkedIssueNumbersWithOverflow(claimed?.body ?? "").overflow).toBe(true);
+
+    const resynced = await upsertPullRequestFromGitHub(env, "owner/repo", { number: 10, title: "Too many claims", state: "open", user: { login: "bob" }, head: { sha: "a1" }, labels: [] });
+    expect(resynced.body).toBe(body);
+    expect(resynced.linkedIssues).toHaveLength(MAX_LINKED_ISSUE_NUMBERS);
+
+    const stored = await getPullRequest(env, "owner/repo", 10);
+    expect(stored?.body).toBe(body);
+    expect(extractLinkedIssueNumbersWithOverflow(stored?.body ?? "").overflow).toBe(true);
+    expect(stored?.linkedIssues).toHaveLength(MAX_LINKED_ISSUE_NUMBERS);
   });
 
   it("a genuinely empty body (explicit null/\"\", not absent) DOES clear a previously-claimed linked issue", async () => {


### PR DESCRIPTION
### Motivation
- Fix a security-relevant sparse-payload regression where preserving cached `linkedIssues` while discarding the cached PR `body` allowed linked-issue overflow checks to be bypassed after a narrow webhook sync.
- Ensure persisted payload evidence and the in-memory return value remain consistent so downstream hard-rule checks that reparse `body` still see overflow evidence.

### Description
- When upserting a PR in `upsertPullRequestFromGitHub`, load the existing row's `payloadJson` and, for sparse payloads where `pr.body === undefined`, preserve the stored `body` and use it when computing the `payloadJson` written to the DB.
- Return the preserved `body` on the function result so callers see the same `body` that was persisted instead of `undefined`.
- Continue to preserve `linkedIssuesJson` behavior for sparse payloads; wire the preserved `body` through `compactGitHubPayload` so overflow evidence is retained in persisted payloads.
- Add/strengthen regression tests in `test/unit/db-parsers.test.ts` to assert that a sparse sync does not erase cached `body` evidence and that overflow detection still reports `overflow` when applicable.

### Testing
- Ran the unit regression file: `npx vitest run test/unit/db-parsers.test.ts`, and the modified unit tests (including the new sparse-sync regression) passed locally.
- Ran type checking: `npm run typecheck`, which completed successfully with no type errors.
- Attempted the full local gate `npm run test:ci`; execution began but the run encountered environment DNS/audit issues (actionlint fallback) and long-running/integration/backfill test activity which produced unrelated failures/timeouts in the running CI invocation, so the full gate was not completed end-to-end in this session.
- Noted `npm audit --audit-level=moderate` returned a registry `403 Forbidden` during the run (external environment artifact) and did not block the unit-level verification performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b3d2d1ad4832c9b0572b7278ed5b0)