### PR TITLE
fix(review): hold required automated-review skips from PR metadata

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -363,6 +363,7 @@ import {
   filterReviewFilesForAi,
   resolvePullRequestAutoReviewSkipReason,
   resolveAutoReviewSkipSummary,
+  isContributorControlledAutoReviewSkipReason,
   resolveRepoEnrichmentToggles,
   resolveReviewAutoReviewConfig,
   resolveReviewPathInstructions,
@@ -6339,6 +6340,36 @@ export async function shouldStartAiReviewForAdvisory(
   return !(isReputationEnabled(env) && isConvergenceRepoAllowed(env, args.repoFullName) && (await shouldSkipAiForReputation(env, { project: args.repoFullName, submitter: args.author })));
 }
 
+export function maybeAddRequiredAutoReviewSkipHold(
+  env: Env,
+  args: {
+    settings: RepositorySettings;
+    advisory: Pick<Awaited<ReturnType<typeof buildPullRequestAdvisory>>, "headSha" | "findings">;
+    repoFullName: string;
+    author: string | null;
+    confirmedContributor: boolean;
+    skipAiReview?: boolean | undefined;
+    autoReviewSkipReason: string | null;
+  },
+): boolean {
+  if (
+    args.autoReviewSkipReason === null ||
+    !isContributorControlledAutoReviewSkipReason(args.autoReviewSkipReason) ||
+    !shouldRequirePublicAiReviewForAdvisory(env, args)
+  ) {
+    return false;
+  }
+  args.advisory.findings.push({
+    code: "ai_review_inconclusive",
+    severity: "warning",
+    title: "Required AI review was skipped by contributor-controlled metadata",
+    detail:
+      "The repository requires blocking AI review, but review.auto_review matched the PR title or base branch. The gate is held for human review instead of passing automatically.",
+    action: "Run AI review with a trusted override or remove the contributor-controlled auto_review match before merging.",
+  });
+  return true;
+}
+
 export function shouldRequirePublicAiReviewForAdvisory(
   env: Env,
   args: {
@@ -8265,6 +8296,15 @@ async function maybePublishPrPublicSurface(
     changedFilesSummaryEnabledForReview = deterministicReviewOverrides.changedFilesSummary;
     effortScoreEnabledForReview = deterministicReviewOverrides.effortScore;
     minFindingSeverityForReview = deterministicReviewOverrides.minFindingSeverity;
+    maybeAddRequiredAutoReviewSkipHold(env, {
+      settings,
+      advisory,
+      repoFullName,
+      author,
+      confirmedContributor,
+      skipAiReview: webhook.skipAiReview,
+      autoReviewSkipReason,
+    });
     const aiReviewWillRun =
       !authorBlacklisted &&
       !isFrozenForManualReview &&

--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -2373,6 +2373,10 @@ export const AUTO_REVIEW_SKIP_SUMMARY: Record<AutoReviewSkipReason, string> = {
   "review paused (commit threshold)": "Published AI review count reached review.auto_review.auto_pause_after_reviewed_commits, so further AI review is paused.",
 };
 
+export function isContributorControlledAutoReviewSkipReason(skipReason: string): boolean {
+  return skipReason === "review skipped (WIP title)" || skipReason === "review skipped (base branch out of scope)";
+}
+
 export function resolveAutoReviewSkipSummary(skipReason: string): string {
   if (Object.prototype.hasOwnProperty.call(AUTO_REVIEW_SKIP_SUMMARY, skipReason)) {
     return AUTO_REVIEW_SKIP_SUMMARY[skipReason as AutoReviewSkipReason];

--- a/test/unit/auto-review-wiring.test.ts
+++ b/test/unit/auto-review-wiring.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   auditPullRequestAutoReviewSkip,
+  maybeAddRequiredAutoReviewSkipHold,
   resolveAutoReviewSkipForPullRequest,
   resolveReviewManifestForAiReview,
 } from "../../src/queue/processors";
@@ -404,4 +405,54 @@ describe("review.auto_review wiring (#1954)", () => {
 
     loadSpy.mockRestore();
   });
+  it("holds instead of quietly skipping when contributor-controlled metadata suppresses required AI review", () => {
+    const advisory = { headSha: "sha", findings: [] };
+    const added = maybeAddRequiredAutoReviewSkipHold(
+      { AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true", AI: {} } as Env,
+      {
+        settings: { gatePack: "oss-anti-slop", aiReviewMode: "block", aiReviewAllAuthors: false } as any,
+        advisory,
+        repoFullName: "acme/widgets",
+        author: "alice",
+        confirmedContributor: false,
+        autoReviewSkipReason: "review skipped (WIP title)",
+      },
+    );
+
+    expect(added).toBe(true);
+    expect(advisory.findings).toEqual([
+      expect.objectContaining({
+        code: "ai_review_inconclusive",
+        severity: "warning",
+        title: "Required AI review was skipped by contributor-controlled metadata",
+      }),
+    ]);
+
+    const trustedSkip = { headSha: "sha", findings: [] };
+    expect(
+      maybeAddRequiredAutoReviewSkipHold({ AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true", AI: {} } as Env, {
+        settings: { gatePack: "oss-anti-slop", aiReviewMode: "block", aiReviewAllAuthors: false } as any,
+        advisory: trustedSkip,
+        repoFullName: "acme/widgets",
+        author: "alice",
+        confirmedContributor: false,
+        autoReviewSkipReason: "review skipped (label)",
+      }),
+    ).toBe(false);
+    expect(trustedSkip.findings).toEqual([]);
+
+    const disabledAi = { headSha: "sha", findings: [] };
+    expect(
+      maybeAddRequiredAutoReviewSkipHold({ AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true", AI: {} } as Env, {
+        settings: { gatePack: "oss-anti-slop", aiReviewMode: "off", aiReviewAllAuthors: false } as any,
+        advisory: disabledAi,
+        repoFullName: "acme/widgets",
+        author: "alice",
+        confirmedContributor: false,
+        autoReviewSkipReason: "review skipped (base branch out of scope)",
+      }),
+    ).toBe(false);
+    expect(disabledAi.findings).toEqual([]);
+  });
+
 });

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -23,6 +23,7 @@ import {
   evaluateAutoReviewSkipReason,
   resolveAutoReviewSkipSummary,
   AUTO_REVIEW_SKIP_SUMMARY,
+  isContributorControlledAutoReviewSkipReason,
   resolveAutoReviewConfig,
   resolveReviewPromptOverrides,
   composeManifestReviewInstructions,
@@ -3189,6 +3190,15 @@ describe("review.auto_review (#1954 / #2038–#2041)", () => {
       expect(summary.length).toBeGreaterThan(0);
     }
     expect(resolveAutoReviewSkipSummary("review skipped (unknown)")).toBe("review skipped (unknown)");
+  });
+
+  it("marks only contributor-controlled auto_review skip reasons as requiring a hold", () => {
+    expect(isContributorControlledAutoReviewSkipReason("review skipped (WIP title)")).toBe(true);
+    expect(isContributorControlledAutoReviewSkipReason("review skipped (base branch out of scope)")).toBe(true);
+    expect(isContributorControlledAutoReviewSkipReason("review skipped (draft)")).toBe(false);
+    expect(isContributorControlledAutoReviewSkipReason("review skipped (ignored author)")).toBe(false);
+    expect(isContributorControlledAutoReviewSkipReason("review skipped (label)")).toBe(false);
+    expect(isContributorControlledAutoReviewSkipReason("review skipped (unknown)")).toBe(false);
   });
 
   it("parses auto_pause_after_reviewed_commits with bounds validation (#2042)", () => {


### PR DESCRIPTION
### Motivation
- Prevent contributor-controlled PR metadata (title keywords or base-branch selection) from quietly suppressing a configured blocking automated review and allowing an automatic merge path. 
- Treat metadata-driven skips that would otherwise bypass an enforced automated-review gate as a human-review hold so the gate cannot be silently bypassed.

### Description
- Add a classifier `isContributorControlledAutoReviewSkipReason` that marks title-keyword and base-branch skip reasons as contributor-controlled. 
- Add `maybeAddRequiredAutoReviewSkipHold` in the review processor to append an inconclusive, non-blocking hold finding when a contributor-controlled skip occurs while the repository requires a blocking automated review. 
- Wire the hold helper into the PR processing flow before the automated-review-run decision so the gate sees the hold (and becomes neutral/held) instead of passing. 
- Add unit tests covering the new classifier and the required-review hold wiring and update manifest tests to exercise the new behavior.

### Testing
- Ran `git diff --check` with no errors. 
- Ran the targeted unit tests with `npx vitest run test/unit/focus-manifest.test.ts test/unit/auto-review-wiring.test.ts --reporter=dot`, and all exercised tests passed (2 files, 470 tests). 
- Ran type checks with `npm run typecheck`, which completed successfully. 
- Attempted a full gate run with `npm run test:ci`, which started but was not completed locally due to transient network/setup and a long coverage phase; `actionlint` fell back and the coverage phase was terminated in this environment. 
- `npm audit --audit-level=moderate` could not complete here due to the registry audit endpoint returning 403 Forbidden.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b3d7d33a8832ca258023a8ef1c487)