### PR TITLE
fix(miner): sanitize severity calibration ingestion

### DIFF
--- a/packages/gittensory-engine/src/finding-severity-calibration.ts
+++ b/packages/gittensory-engine/src/finding-severity-calibration.ts
@@ -284,6 +284,71 @@ function isFindingSeverityCalibrationIngestion(value: unknown): value is Finding
   return isRecord(value) && Array.isArray(value.accepted) && Array.isArray(value.rejected);
 }
 
+function sanitizeFindingSeverityCalibrationIngestion(
+  ingestion: FindingSeverityCalibrationIngestion,
+): FindingSeverityCalibrationIngestion {
+  const accepted: FindingSeverityCalibrationSignal[] = [];
+  const rejected: FindingSeverityCalibrationIngestion["rejected"] = [];
+
+  for (const signal of ingestion.accepted) {
+    if (!isRecord(signal) || !Array.isArray(signal.tiers)) continue;
+    const repoFullName = typeof signal.repoFullName === "string" ? normalizeRepoFullName(signal.repoFullName) : null;
+    const replayRunId = typeof signal.replayRunId === "string" ? normalizeId(signal.replayRunId) : null;
+    const reviewRunId = typeof signal.reviewRunId === "string" ? normalizeId(signal.reviewRunId) : null;
+    if (!repoFullName || !replayRunId || !reviewRunId) continue;
+    const tierInputs = signal.tiers.flatMap((tier): FindingSeverityTierInput[] => {
+      if (
+        !isRecord(tier) ||
+        typeof tier.tier !== "string" ||
+        typeof tier.total !== "number" ||
+        typeof tier.confirmed !== "number"
+      ) {
+        return [];
+      }
+      return [
+        {
+          tier: tier.tier,
+          total: tier.total,
+          confirmed: tier.confirmed,
+        },
+      ];
+    });
+    const tiers = normalizeTiers(tierInputs);
+    const score = scoreTiers(tiers);
+    if (tiers.length === 0 || score === null) continue;
+    accepted.push({
+      repoFullName,
+      replayRunId,
+      reviewRunId,
+      observedAt: typeof signal.observedAt === "string" ? normalizeObservedAt(signal.observedAt) : null,
+      tiers,
+      score,
+    });
+  }
+
+  for (const row of ingestion.rejected) {
+    if (!isRecord(row)) continue;
+    const repoFullName =
+      typeof row.repoFullName === "string"
+        ? (normalizeRepoFullName(row.repoFullName) ?? normalizeId(row.repoFullName))
+        : null;
+    const replayRunId = typeof row.replayRunId === "string" ? normalizeId(row.replayRunId) : null;
+    const reviewRunId = typeof row.reviewRunId === "string" ? normalizeId(row.reviewRunId) : null;
+    const reason = row.reason;
+    if (
+      !repoFullName ||
+      !replayRunId ||
+      !reviewRunId ||
+      !["not_opted_in", "empty_tiers", "invalid_repo", "invalid_run_id"].includes(reason as string)
+    ) {
+      continue;
+    }
+    rejected.push({ repoFullName, replayRunId, reviewRunId, reason });
+  }
+
+  return { accepted, rejected };
+}
+
 function normalizeCompositeWeights(weights: FindingSeverityCalibrationWeights | undefined): {
   objectiveAnchor: number;
   pairwiseJudge: number;
@@ -447,7 +512,7 @@ export function computeFindingSeverityCompositeCalibrationScore(input: {
   weights?: FindingSeverityCalibrationWeights | undefined;
 }): FindingSeverityCompositeCalibrationScore {
   const ingestion = isFindingSeverityCalibrationIngestion(input.findingSeverity)
-    ? input.findingSeverity
+    ? sanitizeFindingSeverityCalibrationIngestion(input.findingSeverity)
     : ingestFindingSeverityCalibrationSignals(input.findingSeverity);
   const objectiveAnchorScore =
     typeof input.objectiveAnchor === "number" ? roundScore(input.objectiveAnchor) : input.objectiveAnchor.score;

--- a/packages/gittensory-engine/test/finding-severity-calibration.test.ts
+++ b/packages/gittensory-engine/test/finding-severity-calibration.test.ts
@@ -381,3 +381,92 @@ test("renderAuditMarkdown handles the fully-empty case without throwing", () => 
   assert.ok(markdown.includes("## Rejected Rows\n\n- none"));
   assert.ok(markdown.includes("## Contributing Repo Summary\n\n- none"));
 });
+
+test("composite sanitizes pre-ingested finding-severity rows before scoring or auditing", () => {
+  const forgedTier = {
+    tier: "blocker",
+    total: 2,
+    confirmed: 99,
+    confirmationRate: 99,
+    weight: 99,
+    score: 99,
+    rawReviewText: "private review details",
+  };
+  const forged = {
+    accepted: [
+      {
+        repoFullName: "ACME/Widgets",
+        replayRunId: " replay-1 ",
+        reviewRunId: "review-1",
+        observedAt: "2026-07-04T00:00:00Z",
+        tiers: [forgedTier, { tier: "mystery", total: 5, confirmed: 5, rawReviewText: "private tier" }],
+        score: 999,
+        privateMetadata: { rawReviewText: "private accepted" },
+      },
+      {
+        repoFullName: "not-a-repo",
+        replayRunId: "bad replay",
+        reviewRunId: "review-2",
+        tiers: [forgedTier],
+        score: 999,
+      },
+    ],
+    rejected: [
+      {
+        repoFullName: "ACME/Widgets",
+        replayRunId: "replay-2",
+        reviewRunId: "review-2",
+        reason: "not_opted_in",
+        privateMetadata: { rawReviewText: "private rejected" },
+      },
+      {
+        repoFullName: "ACME/Widgets",
+        replayRunId: "replay-3",
+        reviewRunId: "review-3",
+        reason: "attacker|reason",
+      },
+    ],
+  };
+
+  const result = computeFindingSeverityCompositeCalibrationScore({
+    objectiveAnchor: 0,
+    pairwise: null,
+    findingSeverity: forged as never,
+    weights: { objectiveAnchor: 0, pairwiseJudge: 0, structuredFindingSeverity: 1 },
+  });
+
+  assert.equal(result.structuredFindingSeverityScore, 1);
+  assert.equal(result.compositeScore, 1);
+  assert.deepEqual(result.audit.contributingRepos, [
+    {
+      repoFullName: "acme/widgets",
+      replayRunId: "replay-1",
+      reviewRunId: "review-1",
+      observedAt: "2026-07-04T00:00:00.000Z",
+      score: 1,
+      tiers: [{ tier: "blocker", total: 2, confirmed: 2, confirmationRate: 1, weight: 1, score: 1 }],
+    },
+  ]);
+  assert.deepEqual(result.audit.rejected, [
+    { repoFullName: "acme/widgets", replayRunId: "replay-2", reviewRunId: "review-2", reason: "not_opted_in" },
+  ]);
+  assert.notEqual(result.audit.contributingRepos[0]!.tiers[0], forgedTier);
+  assert.ok(!JSON.stringify(result.audit).includes("private"));
+});
+
+test("renderAuditMarkdown tolerates malformed pre-ingested rejected rows after sanitizing", () => {
+  const result = computeFindingSeverityCompositeCalibrationScore({
+    objectiveAnchor: 0.5,
+    pairwise: null,
+    findingSeverity: {
+      accepted: [],
+      rejected: [
+        { repoFullName: 42, replayRunId: "replay-1", reviewRunId: "review-1", reason: "not_opted_in" },
+        { repoFullName: "acme/widgets", replayRunId: "replay-2", reviewRunId: "review-2", reason: "surprise" },
+      ],
+    } as never,
+  });
+
+  assert.deepEqual(result.audit.rejected, []);
+  assert.doesNotThrow(() => renderFindingSeverityCalibrationAuditMarkdown(result));
+});


### PR DESCRIPTION
### Motivation

- Close a validation/opt-in bypass in the structured finding-severity composite scorer where a weak runtime guard allowed caller-supplied pre-ingested objects to bypass normalization, clamping, opt-in enforcement, and sanitizer logic, enabling score manipulation and audit metadata leakage/crashes.

### Description

- Add `sanitizeFindingSeverityCalibrationIngestion` which validates and normalizes pre-ingested `accepted` and `rejected` rows (normalize repo/run IDs, normalize tiers, recompute per-PR tier scores, clamp/discount confirmed counts, and filter rejected reasons), and returns a safe `{ accepted, rejected }` shape.
- Change `computeFindingSeverityCompositeCalibrationScore` to route any caller-supplied ingestion object through the new `sanitizeFindingSeverityCalibrationIngestion` instead of trusting the minimal `accepted`/`rejected` shape guard.
- Add regression tests that submit forged pre-ingested accepted rows and malformed rejected rows to exercise sanitizer boundaries, ensure scores are recomputed, private fields are dropped, tiers are cloned (not aliased), and Markdown rendering no longer crashes on malformed rejected rows.
- Modified files: `packages/gittensory-engine/src/finding-severity-calibration.ts` and `packages/gittensory-engine/test/finding-severity-calibration.test.ts`.

### Testing

- Built the engine package with `npm run build --workspace @jsonbored/gittensory-engine` and ran the package tests for the affected file with `node --test packages/gittensory-engine/test/finding-severity-calibration.test.ts`; the target tests (including new regressions) passed.
- Ran `npm run build:miner` successfully to exercise the workspace build step that depends on the engine package.
- A full package test run `npm test --workspace @jsonbored/gittensory-engine` was attempted but failed due to unrelated TypeScript errors in other engine tests; these errors are outside the scope of this change.
- Coverage/audit commands were attempted but blocked in this environment (`vitest` filter/runtime limitations and `npm audit` returned `403 Forbidden`), so full CI-surface checks were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b3d2d086c832cbaba1336225fac19)