### PR TITLE
fix(observability): export all ai_usage_events into Grafana reporting DB

### DIFF
--- a/scripts/export-grafana-reporting-db.sh
+++ b/scripts/export-grafana-reporting-db.sh
@@ -321,7 +321,6 @@ SELECT
   )::text AS metadata_json,
   created_at
 FROM ai_usage_events
-WHERE feature = 'ai_review_pr'
 " "$AI_CSV"
     sqlite_import_csv "$AI_CSV" "ai_usage_events"
   fi
@@ -519,8 +518,7 @@ SELECT
     'pullNumber', json_extract(metadata_json, '$.pullNumber')
   ) AS metadata_json,
   created_at
-FROM main.ai_usage_events
-WHERE feature = 'ai_review_pr';
+FROM main.ai_usage_events;
 DETACH report;
 "
 fi

--- a/test/unit/selfhost-grafana-reporting.test.ts
+++ b/test/unit/selfhost-grafana-reporting.test.ts
@@ -92,6 +92,7 @@ case "$args" in
     ;;
   *"FROM ai_usage_events"*)
     printf 'ai_review_pr,codex:gpt-5.5,codex,medium,ok,42,120,15,135,0.25,done,"{""repoFullName"" : ""JSONbored/gittensory"", ""pullNumber"" : 1678}",2026-06-28T00:00:00Z\\n'
+    printf 'issue_plan,codex:gpt-5.5,codex,medium,ok,8,50,10,60,0.05,done,"{""repoFullName"" : ""JSONbored/gittensory"", ""pullNumber"" : null}",2026-06-28T00:01:00Z\\n'
     ;;
 esac
 `,
@@ -488,16 +489,18 @@ esac
         created_at TEXT NOT NULL
       );
       INSERT INTO ai_usage_events (feature, model, provider, effort, status, estimated_neurons, input_tokens, output_tokens, total_tokens, cost_usd, detail, metadata_json, created_at)
-      VALUES ('ai_review_pr', 'codex:gpt-5.5', 'codex', 'medium', 'ok', 42, 120, 15, 135, 0.25, 'done', '{"repoFullName":"JSONbored/gittensory","pullNumber":1678,"private":"drop"}', '2026-06-28T00:00:00Z');
+      VALUES
+        ('ai_review_pr', 'codex:gpt-5.5', 'codex', 'medium', 'ok', 42, 120, 15, 135, 0.25, 'done', '{"repoFullName":"JSONbored/gittensory","pullNumber":1678,"private":"drop"}', '2026-06-28T00:00:00Z'),
+        ('ai_slop_pr', 'claude-code', 'claude-code', 'default', 'ok', 7, 200, 25, 225, 0.5, 'done', '{"repoFullName":"JSONbored/sidequest","pullNumber":42,"private":"drop"}', '2026-06-28T00:01:00Z');
     `);
 
     runExporter(root, appDb, outDb);
 
     expect(sqlite(outDb, "PRAGMA quick_check;")).toBe("ok");
-    expect(sqlite(outDb, "SELECT estimated_neurons FROM ai_usage_events;")).toBe("42");
-    expect(sqlite(outDb, "SELECT provider || '|' || effort || '|' || input_tokens || '|' || output_tokens || '|' || total_tokens || '|' || cost_usd FROM ai_usage_events;")).toBe("codex|medium|120|15|135|0.25");
-    expect(sqlite(outDb, "SELECT json_extract(metadata_json, '$.repoFullName') FROM ai_usage_events;")).toBe("JSONbored/gittensory");
-    expect(sqlite(outDb, "SELECT json_extract(metadata_json, '$.private') IS NULL FROM ai_usage_events;")).toBe("1");
+    expect(sqlite(outDb, "SELECT feature || '|' || estimated_neurons FROM ai_usage_events ORDER BY created_at;")).toBe("ai_review_pr|42\nai_slop_pr|7");
+    expect(sqlite(outDb, "SELECT provider || '|' || effort || '|' || input_tokens || '|' || output_tokens || '|' || total_tokens || '|' || cost_usd FROM ai_usage_events ORDER BY created_at;")).toBe("codex|medium|120|15|135|0.25\nclaude-code|default|200|25|225|0.5");
+    expect(sqlite(outDb, "SELECT json_extract(metadata_json, '$.repoFullName') FROM ai_usage_events ORDER BY created_at;")).toBe("JSONbored/gittensory\nJSONbored/sidequest");
+    expect(sqlite(outDb, "SELECT group_concat(json_extract(metadata_json, '$.private') IS NULL, '|') FROM ai_usage_events;")).toBe("1|1");
     expect(sqlite(outDb, "SELECT sum(estimated_neurons) FROM ai_usage_events WHERE feature = 'ai_review_pr' AND (('+' || model || '+') LIKE '%+codex+%' OR ('+' || model || '+') LIKE '%+codex:%');")).toBe("42");
   });
 
@@ -544,10 +547,10 @@ esac
       "JSONbored|commented|comment",
     );
     expect(sqlite(outDb, "SELECT title FROM review_targets WHERE repo='JSONbored/gittensory' AND number=1049;")).toBe("historical PR");
-    expect(sqlite(outDb, "SELECT estimated_neurons FROM ai_usage_events;")).toBe("42");
-    expect(sqlite(outDb, "SELECT provider || '|' || effort || '|' || input_tokens || '|' || output_tokens || '|' || total_tokens || '|' || cost_usd FROM ai_usage_events;")).toBe("codex|medium|120|15|135|0.25");
-    expect(sqlite(outDb, "SELECT json_extract(metadata_json, '$.repoFullName') FROM ai_usage_events;")).toBe("JSONbored/gittensory");
-    expect(sqlite(outDb, "SELECT json_extract(metadata_json, '$.private') IS NULL FROM ai_usage_events;")).toBe("1");
+    expect(sqlite(outDb, "SELECT feature || '|' || estimated_neurons FROM ai_usage_events ORDER BY created_at;")).toBe("ai_review_pr|42\nissue_plan|8");
+    expect(sqlite(outDb, "SELECT provider || '|' || effort || '|' || input_tokens || '|' || output_tokens || '|' || total_tokens || '|' || cost_usd FROM ai_usage_events ORDER BY created_at;")).toBe("codex|medium|120|15|135|0.25\ncodex|medium|50|10|60|0.05");
+    expect(sqlite(outDb, "SELECT DISTINCT json_extract(metadata_json, '$.repoFullName') FROM ai_usage_events;")).toBe("JSONbored/gittensory");
+    expect(sqlite(outDb, "SELECT group_concat(json_extract(metadata_json, '$.private') IS NULL, '|') FROM ai_usage_events;")).toBe("1|1");
     expect(readdirSync(csvTmp)).toEqual([]);
   });
 
@@ -564,7 +567,7 @@ esac
 
     expect(sqlite(outDb, "PRAGMA quick_check;")).toBe("ok");
     expect(sqlite(outDb, "SELECT count(*) FROM review_targets;")).toBe("3");
-    expect(sqlite(outDb, "SELECT sum(estimated_neurons) FROM ai_usage_events;")).toBe("42");
+    expect(sqlite(outDb, "SELECT sum(estimated_neurons) FROM ai_usage_events;")).toBe("50");
   });
 
   it("REGRESSION (gate-flagged): a bracketed IPv6 Postgres host (postgres://u:p@[::1]:5432/db) is split correctly, not cut apart at the address's own internal colons", () => {


### PR DESCRIPTION
### Motivation

- The new ORB AI Grafana dashboard expects a provider-/feature‑neutral view of durable `ai_usage_events`, but the reporting exporter only copied `feature = 'ai_review_pr'`, causing non-review AI features to be omitted from the redacted reporting DB. This produces under-reported totals and missing-usage counts in self-hosted Grafana snapshots.

### Description

- Remove the hard `feature = 'ai_review_pr'` filter from both the Postgres and SQLite export SQL so every redacted `ai_usage_events` row is exported into the reporting DB (file: `scripts/export-grafana-reporting-db.sh`).
- Extend the exporter unit test fixtures to include non-review AI rows and update assertions so the redacted reporting snapshot verifies both review and non-review events (file: `test/unit/selfhost-grafana-reporting.test.ts`).
- This is a minimal, behavior-preserving change that makes the exported reporting DB match the dashboard's documented expectation (redacted metadata, but all features/providers exported).

### Testing

- Ran the focused unit test: `npx vitest run test/unit/selfhost-grafana-reporting.test.ts`, which passed after updating fixtures and expectations.
- Ran observability validation: `npm run selfhost:validate-observability`, which reported dashboards and rules valid.
- Ran the local gate command chain (`npm run test:ci`) but the full run was interrupted by unrelated long-running / coverage issues in other test suites; the change is covered by the targeted unit test above.
- Ran `git diff --check` (style/whitespace) with no issues and attempted `npm audit --audit-level=moderate`, which failed to reach the registry (403) in this environment (no dependency changes in this PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b3d7ead5c832cbbd0fc73a25bb687)