### PR TITLE
docs(config): document shipped inline-comment review toggles in gittensory.full.yml

### DIFF
--- a/.gittensory.yml.example
+++ b/.gittensory.yml.example
@@ -401,6 +401,15 @@ review:
   # configured level are suppressed from inline comments — never from gate blockers. Default: null (show all).
   # min_finding_severity: major
 
+  # Inline-comment layer toggles (#1956 / #1958). Bool | null. Default: null/false — byte-identical.
+  # Requires operator flag GITTENSORY_REVIEW_INLINE_COMMENTS + cutover allowlist + review.inline_comments: true.
+  # inline_comments: false
+  # When true, the AI reviewer ALSO leaves quiet, non-blocking inline PR comments on specific changed lines.
+  # suggestions: false
+  # When true, inline findings with precise fixes render as one-click suggestion blocks (requires inline_comments).
+  # finding_categories: false
+  # When true, inline findings are tagged with a category label (requires inline_comments).
+
   # Deterministic label suggestions (#2045). Each rule SUGGESTS a non-scoring label when a PR matches ALL of the
   # `when` criteria it sets (at least one is required): when_paths (any changed path matches a glob), title_contains,
   # description_contains (both case-insensitive). Suggestions are advisory; they are auto-applied only when the repo's

--- a/config/examples/gittensory.full.yml
+++ b/config/examples/gittensory.full.yml
@@ -414,6 +414,15 @@ review:
   # configured level are suppressed from inline comments — never from gate blockers. Default: null (show all).
   # min_finding_severity: major
 
+  # Inline-comment layer toggles (#1956 / #1958). Bool | null. Default: null/false — byte-identical.
+  # Requires operator flag GITTENSORY_REVIEW_INLINE_COMMENTS + cutover allowlist + review.inline_comments: true.
+  # inline_comments: false
+  # When true, the AI reviewer ALSO leaves quiet, non-blocking inline PR comments on specific changed lines.
+  # suggestions: false
+  # When true, inline findings with precise fixes render as one-click suggestion blocks (requires inline_comments).
+  # finding_categories: false
+  # When true, inline findings are tagged with a category label (requires inline_comments).
+
   # Deterministic label suggestions (#2045). Each rule SUGGESTS a non-scoring label when a PR matches ALL of the
   # `when` criteria it sets (at least one is required): when_paths (any changed path matches a glob), title_contains,
   # description_contains (both case-insensitive). Suggestions are advisory; they are auto-applied only when the repo's

--- a/test/unit/config-templates.test.ts
+++ b/test/unit/config-templates.test.ts
@@ -64,6 +64,13 @@ describe("config/examples review templates (#1682)", () => {
     expect(full).not.toMatch(/Planned display toggle/);
   });
 
+  it("documents shipped inline-comment review toggles in gittensory.full.yml (#2156)", () => {
+    const full = readConfigExample("gittensory.full.yml");
+    for (const field of ["inline_comments", "suggestions", "finding_categories"]) {
+      expect(full, `missing review field ${field}`).toMatch(new RegExp(`# ${field}:`));
+    }
+  });
+
   it("parses gittensory.minimal.yml with zero warnings and enables no agent actions", () => {
     const manifest = parseFocusManifestContent(readConfigExample("gittensory.minimal.yml"), "repo_file");
     expect(manifest.warnings).toEqual([]);


### PR DESCRIPTION
Closes #2156

## Summary
- Document shipped `review.inline_comments`, `review.suggestions`, and `review.finding_categories` in the active `review:` section of `gittensory.full.yml`, alongside `effort_score` and `changed_files_summary`.
- Keep `.gittensory.yml.example` in sync and add a template-inventory test so the inline toggle docs cannot drift.

## Validation
- `npx vitest run test/unit/config-templates.test.ts`

## UI Evidence
N/A
