### PR TITLE
fix(signals): classify C# and Dart gRPC service stubs as generated

### DIFF
--- a/src/signals/path-matchers.ts
+++ b/src/signals/path-matchers.ts
@@ -81,12 +81,15 @@ function isGeneratedFileFrom(parts: NormalizedPath): boolean {
     // plugin emits `.pb.cr`, the Haskell plugin emits `.pb.hs`, the Scala plugin emits `.pb.scala`, and the Objective-C plugin emits
     // `.pbobjc.{h,m}` plus gRPC `.pbrpc.{h,m}` service stubs. Swift gRPC emits sibling `.grpc.swift`
     // service stubs; grpc-kotlin emits sibling `*GrpcKt.kt` coroutine service stubs; grpc-java emits
-    // sibling `*Grpc.java` service stubs.
+    // sibling `*Grpc.java` service stubs; grpc-dotnet emits sibling `*Grpc.cs` service stubs; the Dart
+    // gRPC plugin emits sibling `.pbgrpc.dart` service stubs.
     // `.pb.dart`/`.pb.kt`/`.pb.cs` (the `.pb` infix keeps hand-written sources from matching).
     /\.pb\.(go|ts|js|cc|h|swift|dart|kt|cs|rs|ex|erl|hrl|cr|hs|scala)$/.test(norm) ||
     /\.grpc\.swift$/.test(norm) ||
     /grpckt\.kt$/.test(norm) ||
     /grpc\.java$/.test(norm) ||
+    /grpc\.cs$/.test(norm) ||
+    /\.pbgrpc\.dart$/.test(norm) ||
     /\.pbobjc\.(h|m)$/.test(norm) ||
     /\.pbrpc\.(h|m)$/.test(norm) ||
     // Python protobuf: message stubs are `*_pb2.py[i]`; the gRPC plugin emits sibling

--- a/test/unit/path-matchers.test.ts
+++ b/test/unit/path-matchers.test.ts
@@ -171,6 +171,15 @@ describe("isGeneratedFile", () => {
     expect(classifyChangedFile("gen/GreeterGrpcKt.kt")).toBe("generated");
   });
 
+  it("matches C# and Dart gRPC service stubs alongside the other protoc plugins", () => {
+    expect(isGeneratedFile("gen/GreeterGrpc.cs")).toBe(true);
+    expect(isGeneratedFile("lib/foo.pbgrpc.dart")).toBe(true);
+    expect(isGeneratedFile("src/Greeter.cs")).toBe(false);
+    expect(isGeneratedFile("lib/user.dart")).toBe(false);
+    expect(classifyChangedFile("gen/GreeterGrpc.cs")).toBe("generated");
+    expect(classifyChangedFile("lib/foo.pbgrpc.dart")).toBe("generated");
+  });
+
   it("matches Java gRPC service stubs alongside the other protoc plugins", () => {
     expect(isGeneratedFile("gen/GreeterGrpc.java")).toBe(true);
     expect(isGeneratedFile("src/Greeter.java")).toBe(false);
@@ -524,6 +533,8 @@ describe("classifyChangedFile", () => {
       ["proto/messages.pb.scala", "generated"],
       ["gen/GreeterGrpcKt.kt", "generated"],
       ["gen/GreeterGrpc.java", "generated"],
+      ["gen/GreeterGrpc.cs", "generated"],
+      ["lib/foo.pbgrpc.dart", "generated"],
       ["gen/service_grpc_pb.js", "generated"],
       ["gen/service_pb.d.ts", "generated"],
       ["vendor/lib.go", "vendored"],


### PR DESCRIPTION
## Summary

Extend `isGeneratedFile` to recognize grpc-dotnet service stubs (`*Grpc.cs`) and Dart gRPC service stubs (`.pbgrpc.dart`), matching the existing Java/Kotlin/Swift gRPC stub matchers. Accurate generated-file classification is a prerequisite for distinguishing generated-only diffs from hand-authored source when calibrating PR scope.

Fixes #3005

## Scope

- [x] Conventional Commit title format.
- [x] Focused — path-matchers + unit tests only.
- [x] Follows `CONTRIBUTING.md`.
- [x] Linked open, unassigned issue (#3005: calibrate generated PR scope requires correct generated/source classification).

## Validation

- [x] `git diff --check`
- [x] `npm run test:ci` on Node 22
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] Unit tests cover `isGeneratedFile`, `classifyChangedFile`, and the representative cases table

If any required check was skipped, explain why:

- None skipped.

## Safety

- [x] No secrets, auth, or UI changes.
- [x] N/A for UI Evidence.

## UI Evidence

N/A — signals-only change with no visible UI.

## Notes

Incremental **path-matcher parity** for #3005: grpc C#/Dart protobuf service stubs now classify as `generated` via `classifyChangedFile`, so slop signals and scope heuristics do not treat machine-generated gRPC output as substantive hand-authored source.

Does not deliver the miner driver prompt calibration slice — only closes a generated-classification gap in the shared path-matcher module.

**Conflict avoidance:** Touches only `src/signals/path-matchers.ts` and `test/unit/path-matchers.test.ts`. Zero overlap with open PRs (#3724 local-branch scoring, #3718 finding severity floor, #3712 visual shot bounds, #3704 miner calibration types, #3702 miner README, #3698 ignored-author gate).

Made with [Cursor](https://cursor.com)