### PR TITLE
fix(enrichment): bound malformed switch scans

### DIFF
--- a/review-enrichment/src/analyzers/exhaustiveness-drift.ts
+++ b/review-enrichment/src/analyzers/exhaustiveness-drift.ts
@@ -14,6 +14,7 @@ const MAX_FILES = 10;
 const MAX_FETCHES = 10;
 const MAX_FINDINGS = 25;
 const MAX_FETCH_BYTES = 1_000_000;
+const MAX_SWITCH_HEADER_LINES = 25;
 const SOURCE_RE = /\.(?:ts|tsx|mts|cts|js|jsx|mjs|cjs)$/;
 const SKIP_RE = /(?:\.d\.ts$|\.min\.|(?:^|\/)(?:dist|build|vendor)\/)/;
 
@@ -230,6 +231,7 @@ function extractSwitchBlock(lines: string[], switchLine: number): string[] | nul
   let started = false;
   const block: string[] = [];
   for (let i = switchLine; i < lines.length; i++) {
+    if (!started && i - switchLine >= MAX_SWITCH_HEADER_LINES) return null;
     const line = lines[i]!;
     block.push(line);
     for (const ch of line) {

--- a/review-enrichment/test/exhaustiveness-drift.test.ts
+++ b/review-enrichment/test/exhaustiveness-drift.test.ts
@@ -66,6 +66,17 @@ test("findExhaustivenessGap: does not flag when the switch already covers the ne
   assert.equal(findExhaustivenessGap(covered, "enum", "Status", oldMembers, "Archived"), null);
 });
 
+test("findExhaustivenessGap: bounds malformed switch headers before EOF", () => {
+  const oldMembers = new Set(["Active", "Pending"]);
+  const malformedSwitches = Array.from({ length: 5000 }, (_, i) => `switch (status${i})`).join("\n");
+  const started = performance.now();
+  assert.equal(
+    findExhaustivenessGap(malformedSwitches, "enum", "Status", oldMembers, "Archived"),
+    null,
+  );
+  assert.ok(performance.now() - started < 500);
+});
+
 test("extractUnionMembers: reads string-literal union members from a type alias", () => {
   const src = 'export type Role = "admin" | "user";';
   assert.deepEqual([...extractUnionMembers(src, "Role")!], ["admin", "user"]);


### PR DESCRIPTION
### Motivation

- Prevent an analyzer-driven CPU DoS where many attacker-controlled lines beginning with `switch (` but missing a `{` cause repeated long scans and O(n^2) work.  
- Limit how far the switch extractor scans before giving up so a malformed header cannot force scanning the rest of a fetched file.  
- Add a regression that ensures malformed switch headers are bounded and the scan returns promptly.

### Description

- Add a `MAX_SWITCH_HEADER_LINES` constant and set it to `25` to bound lookahead while searching for the switch block opener.  
- Short-circuit `extractSwitchBlock(lines, switchLine)` to return `null` when no `{` is found within the permitted header line window.  
- Add a unit regression test `findExhaustivenessGap: bounds malformed switch headers before EOF` in `review-enrichment/test/exhaustiveness-drift.test.ts` that generates thousands of malformed `switch (` lines and asserts the scan completes quickly and returns `null`.  
- Change is limited to `review-enrichment/` source and tests and preserves existing analyzer behavior for normal switch blocks.

### Testing

- Ran the targeted unit file with `npm --prefix review-enrichment run build && node --test --experimental-strip-types review-enrichment/test/exhaustiveness-drift.test.ts` and the exhaustiveness-drift tests passed.  
- Ran the REES suite with `npm run rees:test` and the review-enrichment test suite passed (no failures in the altered tests).  
- Attempted the full local gate `npm run test:ci`; started but encountered pre-existing, unrelated timeouts during the `test:coverage` run (some long-running integration/backfill tests) so the full gate did not complete in this environment.  
- `npm audit --audit-level=moderate` could not complete due to a registry/audit endpoint `403 Forbidden` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b47982f7c832cac28b5ba366a46d1)