### PR TITLE
fix(signals): classify Java protobuf message stubs as generated

### DIFF
--- a/src/signals/path-matchers.ts
+++ b/src/signals/path-matchers.ts
@@ -76,7 +76,7 @@ function isGeneratedFileFrom(parts: NormalizedPath): boolean {
     /\.(generated|gen)\.[^/]+$/.test(norm) ||
     // protoc output: Go/TS/JS plugins emit `.pb.{go,ts,js}`, the reference C++ plugin emits
     // `.pb.cc` / `.pb.h`, the Swift plugin emits `.pb.swift`, the Dart plugin emits `.pb.dart`,
-    // the Kotlin plugin emits `.pb.kt`, the C# plugin emits `.pb.cs`, the Rust plugin emits `.pb.rs`,
+    // the Kotlin plugin emits `.pb.kt`, the Java plugin emits `.pb.java`, the C# plugin emits `.pb.cs`, the Rust plugin emits `.pb.rs`,
     // the Elixir plugin emits `.pb.ex`, the Erlang gpb plugin emits `.pb.erl` / `.pb.hrl`, the Crystal
     // plugin emits `.pb.cr`, the Haskell plugin emits `.pb.hs`, the Scala plugin emits `.pb.scala`, and the Objective-C plugin emits
     // `.pbobjc.{h,m}` plus gRPC `.pbrpc.{h,m}` service stubs. Swift gRPC emits sibling `.grpc.swift`
@@ -84,7 +84,7 @@ function isGeneratedFileFrom(parts: NormalizedPath): boolean {
     // sibling `*Grpc.java` service stubs; grpc-dotnet emits sibling `*Grpc.cs` service stubs; the Dart
     // gRPC plugin emits sibling `.pbgrpc.dart` service stubs.
     // `.pb.dart`/`.pb.kt`/`.pb.cs` (the `.pb` infix keeps hand-written sources from matching).
-    /\.pb\.(go|ts|js|cc|h|swift|dart|kt|cs|rs|ex|erl|hrl|cr|hs|scala)$/.test(norm) ||
+    /\.pb\.(go|ts|js|cc|h|swift|dart|kt|cs|rs|ex|erl|hrl|cr|hs|scala|java)$/.test(norm) ||
     /\.grpc\.swift$/.test(norm) ||
     /grpckt\.kt$/.test(norm) ||
     /grpc\.java$/.test(norm) ||

--- a/test/unit/path-matchers.test.ts
+++ b/test/unit/path-matchers.test.ts
@@ -180,6 +180,12 @@ describe("isGeneratedFile", () => {
     expect(classifyChangedFile("lib/foo.pbgrpc.dart")).toBe("generated");
   });
 
+  it("matches Java protobuf message stubs alongside the other protoc plugins", () => {
+    expect(isGeneratedFile("proto/messages.pb.java")).toBe(true);
+    expect(isGeneratedFile("src/Main.java")).toBe(false);
+    expect(classifyChangedFile("proto/messages.pb.java")).toBe("generated");
+  });
+
   it("matches Java gRPC service stubs alongside the other protoc plugins", () => {
     expect(isGeneratedFile("gen/GreeterGrpc.java")).toBe(true);
     expect(isGeneratedFile("src/Greeter.java")).toBe(false);
@@ -533,6 +539,7 @@ describe("classifyChangedFile", () => {
       ["proto/messages.pb.scala", "generated"],
       ["gen/GreeterGrpcKt.kt", "generated"],
       ["gen/GreeterGrpc.java", "generated"],
+      ["proto/messages.pb.java", "generated"],
       ["gen/GreeterGrpc.cs", "generated"],
       ["lib/foo.pbgrpc.dart", "generated"],
       ["gen/service_grpc_pb.js", "generated"],


### PR DESCRIPTION
## Summary

Extend `isGeneratedFile` to recognize protoc Java message stubs (`.pb.java`), complementing the existing grpc-java `*Grpc.java` service-stub matcher. Includes positive/negative `isGeneratedFile` / `classifyChangedFile` assertions and a classification-table entry.

Fixes #3006

## Scope

- [x] Conventional Commit title format.
- [x] Focused — path-matchers + unit tests only.
- [x] Follows `CONTRIBUTING.md`.
- [x] Linked open, unassigned issue (#3006: slop-at-scale risk requires distinguishing generated padding from substantive source).

## Validation

- [x] `git diff --check`
- [x] `npm run test:ci` on Node 22
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] Unit tests cover `isGeneratedFile`, `classifyChangedFile`, and the representative cases table

If any required check was skipped, explain why:

- None skipped.

## Safety

- [x] No secrets, auth, or UI changes.
- [x] N/A for UI Evidence.

## UI Evidence

N/A — signals-only change with no visible UI.

## Notes

Incremental **path-matcher parity** for #3006: Java `.pb.java` protobuf output now classifies as `generated` via `classifyChangedFile`, so slop signals and candidate-diff heuristics do not treat machine-generated protoc Java as hand-authored source when comparing iteration attempts.

Does not deliver the pairwise candidate-selection slice — only closes a generated-classification gap in the shared path-matcher module.

**Conflict avoidance:** Touches only `src/signals/path-matchers.ts` and `test/unit/path-matchers.test.ts`. Zero overlap with open PRs (#3738 enrichment auth circuit-break, #3737 changed_files_summary config test, #3724 local-branch Dart scoring, #3721 automated-review skip hold, #3712 visual shot bounds, #3704 miner calibration types, #3702 miner README, #3698 ignored-author gate).

Made with [Cursor](https://cursor.com)