### PR TITLE
fix(signals): hold PR readiness only after the registry has actually synced

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -188,7 +188,7 @@ import { DEFAULT_TYPE_LABELS, resolvePrTypeLabel } from "../settings/pr-type-lab
 import { fetchLinkedIssueLabelsForPropagation } from "../review/linked-issue-label-propagation-fetch";
 import { shouldPublishReviewCheck } from "../review/check-names";
 import { fetchPublicContributorProfile } from "../github/public";
-import { refreshRegistry } from "../registry/sync";
+import { getLatestRegistrySnapshot, refreshRegistry } from "../registry/sync";
 import {
   buildIssueAdvisory,
   buildPullRequestAdvisory,
@@ -7963,11 +7963,16 @@ async function maybePublishPrPublicSurface(
     return gateEvaluation;
   };
   try {
-    const [repoIssues, repoPullRequests, repoBounties] = await Promise.all([
+    const [repoIssues, repoPullRequests, repoBounties, latestRegistrySnapshot] = await Promise.all([
       listIssues(env, repoFullName),
       listPullRequests(env, repoFullName),
       listBountiesByRepo(env, repoFullName),
+      getLatestRegistrySnapshot(env),
     ]);
+    // An unregistered repo is only a meaningful preflight signal once the registry sync has actually
+    // produced at least one snapshot (see buildPreflightResult's registryEverSynced param) -- otherwise every
+    // PR on a self-host instance whose registry feed has never succeeded gets held for no reason tied to the PR.
+    const registryEverSynced = latestRegistrySnapshot !== null;
     // Open-PR file-path collision (#2653): flag-gated, byte-identical when OFF (see enrichOpenPullRequestsWithChangedFiles).
     // Scoped to collision/preflight/queue-health inputs only — every OTHER use of repoPullRequests below (e.g. the
     // duplicate-winner adjudication, which is same-linked-issue-based, not path-based) keeps reading the un-enriched array.
@@ -8000,6 +8005,8 @@ async function maybePublishPrPublicSurface(
       repoIssues,
       collisionPullRequests,
       repoBounties,
+      undefined,
+      registryEverSynced,
     );
     // Duplicate-winner adjudication (#dup-winner): compute the winner ONCE for this review run from the SAME
     // open-only sibling source the gate uses, and thread the flag/result consistently into readiness, the slop

--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -2508,6 +2508,8 @@ export function buildPreflightResult(
   pullRequests: PullRequestRecord[],
   bounties: BountyRecord[] = [],
   issueQuality?: IssueQualityReport | null | undefined,
+  // Default true so every existing caller (which predates this param) keeps its exact prior behavior.
+  registryEverSynced = true,
 ): PreflightResult {
   const lane = buildLaneAdvice(repo, input.repoFullName);
   const linkedIssues = [...new Set([...(input.linkedIssues ?? []), ...extractLinkedIssueNumbers(truncateText(input.body ?? "", PREFLIGHT_LIMITS.bodyChars), input.repoFullName)])].sort(
@@ -2535,7 +2537,13 @@ export function buildPreflightResult(
     }),
   );
   const findings: SignalFinding[] = [];
-  const laneUnavailable = lane.lane === "unknown" || lane.lane === "inactive";
+  // An "unknown" lane means "not found in the local registry cache", which is genuinely ambiguous: it's the
+  // same result whether this repo simply isn't registered in a WORKING snapshot, or the registry sync has
+  // never once succeeded (a self-host connectivity/config problem with no bearing on this PR at all). Only
+  // treat "unknown" as a real signal once we know the sync mechanism itself has produced at least one
+  // snapshot; "inactive" (zero emission share) is unambiguous either way -- it is only reachable from real
+  // synced data.
+  const laneUnavailable = (lane.lane === "unknown" && registryEverSynced) || lane.lane === "inactive";
   const maintainerAuthored = isMaintainerAssociation(input.authorAssociation);
   if (laneUnavailable) {
     findings.push({

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -2952,6 +2952,121 @@ describe("queue processors", () => {
     stampSpy.mockRestore();
   });
 
+  it("REGRESSION (registry-never-synced lane fix): a contributor PR panel does not show the lane-unavailable hold when no registry snapshot has ever synced", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", commentMode: "all_prs", publicSurface: "comment_only", autoLabelEnabled: false, checkRunMode: "off", gateCheckMode: "enabled", aiReviewMode: "off", gatePack: "oss-anti-slop" });
+    let commentBody = "";
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      // A confirmed official Gittensor contributor renders the FULL readiness panel (with the Validation
+      // posture row this test is about) instead of the minimal first-timer invite comment.
+      if (url === "https://api.gittensor.io/miners") {
+        return Response.json([
+          { uid: 7, githubUsername: "contributor", githubId: "123", totalPrs: 4, totalMergedPrs: 3, totalOpenPrs: 1, totalClosedPrs: 0, totalOpenIssues: 0, totalClosedIssues: 0, totalSolvedIssues: 0, totalValidSolvedIssues: 0, isEligible: true, credibility: 1, eligibleRepoCount: 1 },
+        ]);
+      }
+      if (url === "https://api.gittensor.io/miners/123") {
+        return Response.json({ repositories: [{ repositoryFullName: "JSONbored/gittensory", totalPrs: "4", totalMergedPrs: "3", totalOpenPrs: "1", totalClosedPrs: "0", totalOpenIssues: "0", totalClosedIssues: "0", isEligible: true, credibility: "1.000000" }] });
+      }
+      if (url === "https://api.gittensor.io/miners/123/prs") return Response.json([]);
+      if (url === "https://mirror.gittensor.io/api/v1/miners/123/issues") return Response.json({ issues: [] });
+      if (url.endsWith("/users/contributor")) return Response.json({ login: "contributor", public_repos: 2, followers: 1 });
+      if (url.includes("/users/contributor/repos")) return Response.json([]);
+      if (url.includes("/pulls/95/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+export const ok = true;" }]);
+      if (url.endsWith("/pulls/95")) return Response.json({ number: 95, title: "Clean PR", state: "open", user: { login: "contributor" }, head: { sha: "a95" }, labels: [], body: "Closes #1" });
+      if (url.includes("/commits/a95/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/commits/a95/status")) return Response.json({ state: "success", statuses: [] });
+      if (url.includes("/issues/1")) return Response.json({ number: 1, title: "Issue", state: "open", labels: [], user: { login: "reporter" } });
+      if (url.includes("/issues/95/comments") && method === "GET") return Response.json([]);
+      if (url.includes("/issues/95/comments") && method === "POST") {
+        commentBody = String((JSON.parse(String(init?.body ?? "{}")) as { body?: string }).body ?? "");
+        return Response.json({ id: 1 }, { status: 201 });
+      }
+      if (url.includes("/branches/")) return Response.json({ protected: false, protection: { required_status_checks: { contexts: [] } } });
+      return Response.json({});
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "no-registry-sync",
+      eventName: "pull_request",
+      payload: {
+        action: "opened",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        pull_request: { number: 95, title: "Clean PR", state: "open", user: { login: "contributor" }, head: { sha: "a95" }, labels: [], body: "Closes #1" },
+      },
+    });
+
+    expect(commentBody).toContain("gittensory-pr-panel");
+    expect(commentBody).not.toContain("the review lane is unavailable");
+  });
+
+  it("REGRESSION (registry-never-synced lane fix): the SAME setup still shows the lane-unavailable hold once a registry snapshot has synced at least once", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    // A real snapshot exists, but it does not list THIS repo -- a genuine "unregistered" signal, unlike the
+    // companion test above where no snapshot has EVER been produced.
+    await persistRegistrySnapshot(
+      env,
+      normalizeRegistryPayload(
+        { "some-other/repo": { emission_share: 0.01, issue_discovery_share: 0 } },
+        { kind: "raw-github", url: "https://example.test" },
+        "2026-05-23T00:00:00.000Z",
+      ),
+    );
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", commentMode: "all_prs", publicSurface: "comment_only", autoLabelEnabled: false, checkRunMode: "off", gateCheckMode: "enabled", aiReviewMode: "off", gatePack: "oss-anti-slop" });
+    let commentBody = "";
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      // A confirmed official Gittensor contributor renders the FULL readiness panel (with the Validation
+      // posture row this test is about) instead of the minimal first-timer invite comment.
+      if (url === "https://api.gittensor.io/miners") {
+        return Response.json([
+          { uid: 7, githubUsername: "contributor", githubId: "123", totalPrs: 4, totalMergedPrs: 3, totalOpenPrs: 1, totalClosedPrs: 0, totalOpenIssues: 0, totalClosedIssues: 0, totalSolvedIssues: 0, totalValidSolvedIssues: 0, isEligible: true, credibility: 1, eligibleRepoCount: 1 },
+        ]);
+      }
+      if (url === "https://api.gittensor.io/miners/123") {
+        return Response.json({ repositories: [{ repositoryFullName: "JSONbored/gittensory", totalPrs: "4", totalMergedPrs: "3", totalOpenPrs: "1", totalClosedPrs: "0", totalOpenIssues: "0", totalClosedIssues: "0", isEligible: true, credibility: "1.000000" }] });
+      }
+      if (url === "https://api.gittensor.io/miners/123/prs") return Response.json([]);
+      if (url === "https://mirror.gittensor.io/api/v1/miners/123/issues") return Response.json({ issues: [] });
+      if (url.endsWith("/users/contributor")) return Response.json({ login: "contributor", public_repos: 2, followers: 1 });
+      if (url.includes("/users/contributor/repos")) return Response.json([]);
+      if (url.includes("/pulls/96/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+export const ok = true;" }]);
+      if (url.endsWith("/pulls/96")) return Response.json({ number: 96, title: "Clean PR", state: "open", user: { login: "contributor" }, head: { sha: "a96" }, labels: [], body: "Closes #1" });
+      if (url.includes("/commits/a96/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/commits/a96/status")) return Response.json({ state: "success", statuses: [] });
+      if (url.includes("/issues/1")) return Response.json({ number: 1, title: "Issue", state: "open", labels: [], user: { login: "reporter" } });
+      if (url.includes("/issues/96/comments") && method === "GET") return Response.json([]);
+      if (url.includes("/issues/96/comments") && method === "POST") {
+        commentBody = String((JSON.parse(String(init?.body ?? "{}")) as { body?: string }).body ?? "");
+        return Response.json({ id: 1 }, { status: 201 });
+      }
+      if (url.includes("/branches/")) return Response.json({ protected: false, protection: { required_status_checks: { contexts: [] } } });
+      return Response.json({});
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "registry-synced-unregistered",
+      eventName: "pull_request",
+      payload: {
+        action: "opened",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        pull_request: { number: 96, title: "Clean PR", state: "open", user: { login: "contributor" }, head: { sha: "a96" }, labels: [], body: "Closes #1" },
+      },
+    });
+
+    expect(commentBody).toContain("the review lane is unavailable");
+  });
+
   it("#regate-churn: a failing markAiReviewPublished stamp is swallowed (fail-open) — the publish still completes", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);

--- a/test/unit/signals-v2.test.ts
+++ b/test/unit/signals-v2.test.ts
@@ -746,6 +746,31 @@ describe("v2 signal builders", () => {
     expect(large.findings.map((finding) => finding.code)).toEqual(expect.arrayContaining(["large_local_diff", "local_diff_missing_tests"]));
   });
 
+  it("REGRESSION (registry-never-synced lane fix): an unavailable lane only holds a PR once the registry has actually synced at least once", () => {
+    // Before this fix, an "unknown" lane (repo not found in the local registry cache) held EVERY non-maintainer
+    // PR the same way, whether the repo genuinely isn't registered in a WORKING snapshot, or the registry sync
+    // has never once succeeded -- a self-host connectivity/config problem with no bearing on the PR at all.
+    const cleanInput = { repoFullName: "unknown/repo", title: "Docs-only change", body: "Fixes #1", changedFiles: ["docs/guide.md"], tests: ["manual docs check"] };
+    const neverSynced = buildPreflightResult(cleanInput, null, [], [], [], undefined, false);
+    expect(neverSynced.status).toBe("ready");
+    expect(neverSynced.findings.map((finding) => finding.code)).not.toContain("lane_not_recommended");
+
+    // Once the registry HAS synced at least once, an unregistered repo is a real signal again -- same as
+    // omitting the new param, which defaults to true (every pre-existing caller keeps its old behavior).
+    const syncedButUnregistered = buildPreflightResult(cleanInput, null, [], [], [], undefined, true);
+    expect(syncedButUnregistered.status).toBe("hold");
+    expect(syncedButUnregistered.findings.map((finding) => finding.code)).toContain("lane_not_recommended");
+
+    // An "inactive" lane (registered, but zero emission share) is never ambiguous -- it is only reachable from
+    // real synced registry data -- so it stays hold-worthy regardless of the never-synced flag.
+    const inactiveRepo: RepositoryRecord = {
+      ...repo,
+      registryConfig: { repo: repo.fullName, emissionShare: 0, issueDiscoveryShare: 0, labelMultipliers: {}, trustedLabelPipeline: true, maintainerCut: 0, raw: {} },
+    };
+    const inactiveNeverSynced = buildPreflightResult(cleanInput, inactiveRepo, [], [], [], undefined, false);
+    expect(inactiveNeverSynced.status).toBe("hold");
+  });
+
   it("builds clean, missing, and watch PR maintainer packets", () => {
     const cleanPr = { ...pullRequests[0]!, linkedIssues: [1], body: "Fixes #1" };
     const cleanPacket = buildPullRequestMaintainerPacket({


### PR DESCRIPTION
## Summary

- `buildPreflightResult` (`src/signals/engine.ts`) treats a repo's "unknown" registry lane as hold-worthy for every non-maintainer PR whenever the local registry cache can't place the repo. That's ambiguous: the exact same "unknown" result also fires when the registry sync mechanism itself has never produced a single snapshot — a self-host connectivity/config problem with zero bearing on the PR being reviewed.
- Confirmed live: a self-hosted instance's `registry_snapshots` table had 0 rows ever, and every `refresh-registry` attempt failed with "No registry source returned usable data" — every non-maintainer PR across all 4 repos it reviews was showing a misleading `Validation posture: ... the review lane is unavailable` hold, unrelated to PR quality.
- Fix: `buildPreflightResult` now takes a `registryEverSynced` flag (default `true`, so every existing caller keeps its exact prior behavior). The live PR-panel caller computes it from `getLatestRegistrySnapshot`. An "unknown" lane is only hold-worthy once the registry has actually synced at least once; "inactive" (registered, zero emission share) is unaffected since it's only reachable from real synced data.
- Separately, as an ops/config fix (not part of this PR): the affected instance's `GITTENSOR_REGISTRY_URL` was pointed at an endpoint that returns 401 without auth; corrected to the same public raw-GitHub source production uses successfully, and its registry now syncs.

Closes #3750

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

No UI changes in this PR — backend signals/queue fix only, so the UI Evidence section below is not applicable.

## Notes

- Root cause, live confirmation, and the separate ops-side registry-URL correction are documented in #3750.
