### PR TITLE
fix(review): preserve safe enrichment lines when sanitizer finds forbidden terms

### DIFF
--- a/src/review/enrichment-wire.ts
+++ b/src/review/enrichment-wire.ts
@@ -166,10 +166,28 @@ function sanitizeEnrichmentPromptSection(value: unknown): string | undefined {
   const trimmed = value.trim();
   if (!trimmed) return undefined;
   const defanged = neutralizePromptInjection(trimmed).text;
-  return sanitizePublicComment(defanged).slice(
-    0,
-    MAX_ENRICHMENT_PROMPT_SECTION_CHARS,
-  );
+  try {
+    return sanitizePublicComment(defanged).slice(
+      0,
+      MAX_ENRICHMENT_PROMPT_SECTION_CHARS,
+    );
+  } catch {
+    const safeLines = defanged
+      .split("\n")
+      .filter((line) => {
+        try {
+          sanitizePublicComment(line);
+          return true;
+        } catch {
+          return false;
+        }
+      })
+      .join("\n")
+      .trim();
+    return safeLines
+      ? safeLines.slice(0, MAX_ENRICHMENT_PROMPT_SECTION_CHARS)
+      : undefined;
+  }
 }
 
 export function resolveReesTransportTimeoutMs(value: string | undefined): number {

--- a/test/unit/enrichment-wire.test.ts
+++ b/test/unit/enrichment-wire.test.ts
@@ -490,6 +490,36 @@ describe("buildReviewEnrichment", () => {
     ).resolves.toBeUndefined();
   });
 
+  it("drops non-public-safe enrichment lines without discarding the rest of the brief", async () => {
+    globalThis.fetch = vi.fn(
+      async () =>
+        ({
+          ok: true,
+          json: async () => ({
+            promptSection: [
+              "## EXTERNAL REVIEW BRIEF",
+              "### Non-conforming commit subjects",
+              "- abc123 — unrecognized commit type: unsafe subject mentions wallet",
+              "### Dependency advisory",
+              "- package left-pad has CVE-2099-0001",
+            ].join("\n"),
+            systemSuffix: "verified CVE context",
+          }),
+        }) as Response,
+    ) as unknown as typeof fetch;
+
+    const result = await buildReviewEnrichment(
+      env({ REES_URL: "https://r" }),
+      input,
+    );
+
+    expect(result?.promptSection).toContain("## EXTERNAL REVIEW BRIEF");
+    expect(result?.promptSection).toContain("### Dependency advisory");
+    expect(result?.promptSection).toContain("CVE-2099-0001");
+    expect(result?.promptSection).not.toContain("unsafe subject");
+    expect(result?.systemSuffix).toContain("untrusted advisory context");
+  });
+
   it("undefined on a fetch throw (timeout/network) — fail-safe", async () => {
     globalThis.fetch = vi.fn(async () => {
       throw new Error("timeout");


### PR DESCRIPTION
### Motivation

- A single non-public-safe line in a REES brief could cause `sanitizePublicComment` to throw and the engine to drop the entire enrichment prompt, allowing a malicious commit subject to suppress unrelated security findings.
- The goal is to make sanitization fail-safe at line granularity so unsafe lines are removed while preserving the rest of the brief.

### Description

- Update `sanitizeEnrichmentPromptSection` in `src/review/enrichment-wire.ts` to first attempt sanitizing the whole defanged brief and, if that throws, fall back to per-line sanitization that keeps only lines which individually pass `sanitizePublicComment` and then truncates to `MAX_ENRICHMENT_PROMPT_SECTION_CHARS`.
- Preserve existing `neutralizePromptInjection` defanging step and ensure the function returns `undefined` when no safe lines remain.
- Add a regression unit test in `test/unit/enrichment-wire.test.ts` that simulates a brief containing an unsafe commit-lint line plus an independent dependency advisory and asserts the advisory is preserved while the unsafe line is dropped.

### Testing

- Ran `npx vitest run test/unit/enrichment-wire.test.ts`, and the new test (and the file's suite) passed.  
- Ran `npm run typecheck`, which completed with no type errors.  
- Ran `git diff --check`, which reported no whitespace/conflict issues.  
- Attempted `npm run test:coverage` (full coverage gate) in this environment but the global coverage threshold run did not succeed (the repository-wide coverage thresholds were not met when running the local coverage job here).  
- Attempted `npm audit --audit-level=moderate` but the npm registry audit endpoint returned `403 Forbidden` in this environment, so the dependency-review step could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b47993624832c8d13d0f0f5f40ef0)