### PR TITLE
fix(signals): classify PHP gRPC service stubs as generated

### DIFF
--- a/src/signals/path-matchers.ts
+++ b/src/signals/path-matchers.ts
@@ -97,8 +97,11 @@ function isGeneratedFileFrom(parts: NormalizedPath): boolean {
     /_pb2(_grpc)?\.pyi?$/.test(norm) ||
     // Ruby protobuf: message stubs are `*_pb.rb`; the gRPC plugin emits sibling `*_services_pb.rb`.
     /_pb\.rb$/.test(norm) ||
-    // PHP protobuf: message stubs are `*_pb.php`; the gRPC plugin emits sibling `*_grpc_pb.php`.
+    // PHP protobuf: message stubs are `*_pb.php`; the gRPC plugin emits sibling `*_grpc_pb.php`
+    // and grpc-php service stubs (`*Grpc.php`, `*GrpcStub.php`).
     /_pb\.php$/.test(norm) ||
+    /grpc\.php$/.test(norm) ||
+    /grpcstub\.php$/i.test(norm) ||
     // Nim protobuf: message stubs are `*_pb.nim`.
     /_pb\.nim$/.test(norm) ||
     // Lua protobuf: message stubs are `*_pb.lua`.

--- a/test/unit/path-matchers.test.ts
+++ b/test/unit/path-matchers.test.ts
@@ -100,6 +100,8 @@ describe("isGeneratedFile", () => {
       "gen/service_services_pb.rb",
       "gen/service_pb.php",
       "gen/service_grpc_pb.php",
+      "gen/GreeterGrpc.php",
+      "gen/FooGrpcStub.php",
       "proto/messages.pb.rs",
       "lib/my_proto.pb.ex",
       "proto/service.grpc.swift",
@@ -110,6 +112,8 @@ describe("isGeneratedFile", () => {
       expect(isGeneratedFile(path)).toBe(false);
     }
     expect(classifyChangedFile("gen/service_grpc_pb.php")).toBe("generated");
+    expect(classifyChangedFile("gen/GreeterGrpc.php")).toBe("generated");
+    expect(classifyChangedFile("gen/FooGrpcStub.php")).toBe("generated");
     expect(classifyChangedFile("lib/my_proto.pb.ex")).toBe("generated");
     expect(classifyChangedFile("proto/service.grpc.swift")).toBe("generated");
   });
@@ -526,6 +530,8 @@ describe("classifyChangedFile", () => {
       ["dist/app.min.js", "minified"],
       ["src/api.generated.ts", "generated"],
       ["gen/service_grpc_pb.php", "generated"],
+      ["gen/GreeterGrpc.php", "generated"],
+      ["gen/FooGrpcStub.php", "generated"],
       ["lib/my_proto.pb.ex", "generated"],
       ["proto/service.grpc.swift", "generated"],
       ["proto/messages.pb.erl", "generated"],


### PR DESCRIPTION
## Summary

Extend `isGeneratedFile` to recognize grpc-php service stubs (`*Grpc.php`, `*GrpcStub.php`), matching the existing `*_pb.php` / `*_grpc_pb.php` protobuf matchers and the Java/C#/Dart gRPC stub conventions. Includes positive/negative `isGeneratedFile` / `classifyChangedFile` assertions and classification-table entries.

Fixes #3007

## Scope

- [x] Conventional Commit title format.
- [x] Focused — path-matchers + unit tests only.
- [x] Follows `CONTRIBUTING.md`.
- [x] Linked open, unassigned issue (#3007: miner write path needs accurate pre-submit diff understanding).

## Validation

- [x] `git diff --check`
- [x] `npm run test:ci` on Node 22
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] Unit tests cover `isGeneratedFile`, `classifyChangedFile`, and the representative cases table

If any required check was skipped, explain why:

- None skipped.

## Safety

- [x] No secrets, auth, or UI changes.
- [x] N/A for UI Evidence.

## UI Evidence

N/A — signals-only change with no visible UI.

## Notes

Incremental **path-matcher parity** for #3007: PHP gRPC service stubs now classify as `generated` via `classifyChangedFile`, so slop signals and pre-`open_pr` heuristics do not treat machine-generated grpc-php output as hand-authored source.

Does not deliver the late-binding freshness-check slice — only closes a generated-classification gap in the shared path-matcher module.

**Conflict avoidance:** Touches only `src/signals/path-matchers.ts` and `test/unit/path-matchers.test.ts`. Zero overlap with open PRs (#3748 changed-files summary test, #3741 deps, #3724 local-branch Dart scoring, #3721 automated-review skip hold, #3712 visual shot bounds, #3704 miner calibration types, #3698 ignored-author gate).

Made with [Cursor](https://cursor.com)