### PR TITLE
test(review): lock in public-stats per-PR effort ROI (#2070)

### DIFF
--- a/test/unit/public-stats.test.ts
+++ b/test/unit/public-stats.test.ts
@@ -149,6 +149,30 @@ describe("getPublicStats — live aggregate over the review ledger", () => {
     expect(out.totals.minutesSaved).toBe(2742 * MINUTES_SAVED_PER_PR);
   });
 
+  it("implements the #2070 ROI contract: real estimate, flat fallback, empty ledger → 0", async () => {
+    const estimate = await getPublicStats(
+      stubEnv((sql) => {
+        if (isEffort(sql)) return [{ avgMinutes: 12 }];
+        return ledger(sql);
+      }),
+      NOW,
+    );
+    expect(estimate.totals.minutesSaved).toBe(Math.round(2742 * 12));
+    expect(estimate.totals.minutesSaved).not.toBe(2742 * MINUTES_SAVED_PER_PR);
+
+    const fallback = await getPublicStats(
+      stubEnv((sql) => {
+        if (isEffort(sql)) return [{ avgMinutes: null }];
+        return ledger(sql);
+      }),
+      NOW,
+    );
+    expect(fallback.totals.minutesSaved).toBe(2742 * MINUTES_SAVED_PER_PR);
+
+    const empty = await getPublicStats(stubEnv(() => []), NOW);
+    expect(empty.totals.minutesSaved).toBe(0);
+  });
+
   it("breaks byProject ties on project name so equal-reviewed repos keep a deterministic order", async () => {
     // Two repos share reviewed=10, fed in reverse-alphabetical input order; the busier repo
     // still leads and the tied pair must come out alphabetically, not in arbitrary SQL order.


### PR DESCRIPTION
Closes #2070

## Summary
- Add a consolidated public-stats test locking in the shipped per-PR effort ROI: real `reviewEffortMinutes` average, `MINUTES_SAVED_PER_PR` fallback when SQL returns NULL, and `minutesSaved: 0` on an empty ledger.

## Validation
- `npm run typecheck`
- `npx vitest run test/unit/public-stats.test.ts`

## UI Evidence
N/A — test-only.
