### PR TITLE
fix(miner): allow nested lib/ paths in miner package checker

### DIFF
--- a/scripts/check-miner-package.mjs
+++ b/scripts/check-miner-package.mjs
@@ -6,7 +6,7 @@ import { fileURLToPath } from "node:url";
 
 const ALLOWED = [
   /^bin\/gittensory-miner\.js$/,
-  /^lib\/[a-z0-9-]+\.(js|d\.ts)$/,
+  /^lib\/(?:[a-z0-9-]+\/)*[a-z0-9-]+\.(js|d\.ts)$/,
   /^package\.json$/,
   /^README\.md$/,
 ];
@@ -26,7 +26,7 @@ export function validateMinerPackFileList(files, readContent) {
   for (const required of REQUIRED) {
     if (!paths.includes(required)) throw new Error(`Miner package is missing required file: ${required}`);
   }
-  if (!paths.some((file) => /^lib\/[a-z0-9-]+\.js$/.test(file))) {
+  if (!paths.some((file) => /^lib\/(?:[a-z0-9-]+\/)*[a-z0-9-]+\.js$/.test(file))) {
     throw new Error("Miner package is missing lib/*.js artifacts");
   }
   return paths;


### PR DESCRIPTION
## Summary
- Update the miner pack allowlist regex to accept nested `lib/<subdir>/*.js` artifacts (e.g. `lib/calibration/index.js` added by the calibration scaffold).
- Without this, `check-miner-package` rejects the real workspace package and `validate-code` fails on `test/unit/check-miner-package.test.ts`.

## Test plan
- [x] `git diff --check`
- [x] `node scripts/check-miner-package.mjs` (passes on real miner package)
- [x] `npm run test:coverage -- test/unit/check-miner-package.test.ts`
