### PR TITLE
fix(miner): allow nested lib/calibration paths in pack checker (#2332)

### DIFF
--- a/scripts/check-miner-package.mjs
+++ b/scripts/check-miner-package.mjs
@@ -6,7 +6,8 @@ import { fileURLToPath } from "node:url";
 
 const ALLOWED = [
   /^bin\/gittensory-miner\.js$/,
-  /^lib\/[a-z0-9-]+\.(js|d\.ts)$/,
+  // Nested subdirs (e.g. lib/calibration/* from #2332) must match npm pack output.
+  /^lib\/(?:[a-z0-9-]+\/)*[a-z0-9-]+\.(js|d\.ts)$/,
   /^package\.json$/,
   /^README\.md$/,
 ];

--- a/test/unit/check-miner-package.test.ts
+++ b/test/unit/check-miner-package.test.ts
@@ -23,6 +23,21 @@ describe("check-miner-package script", () => {
     expect(result.out).toContain("package.json");
   });
 
+  it("allows nested lib subdirectories such as lib/calibration/*.js (#2332)", () => {
+    const result = runChecker({
+      CHECK_MINER_PACK_TEST_FILES: JSON.stringify([
+        "package.json",
+        "bin/gittensory-miner.js",
+        "lib/cli.js",
+        "lib/calibration/index.js",
+        "lib/calibration/types.js",
+        "lib/calibration/types.d.ts",
+      ]),
+    });
+    expect(result.status).toBe(0);
+    expect(result.out).toContain("lib/calibration/index.js");
+  });
+
   it("rejects a forbidden path", () => {
     const result = runChecker({ CHECK_MINER_PACK_TEST_FILES: JSON.stringify([".env"]) });
     expect(result.status).toBe(1);


### PR DESCRIPTION
Follow-up to #2332

## Summary
- Fix CI `test:miner-pack` regression: the calibration scaffold added `lib/calibration/*` artifacts to `@jsonbored/gittensory-miner`, but `scripts/check-miner-package.mjs` only allowed flat `lib/*.js` paths.
- Widen the allowlist to nested `lib/<subdir>/` paths and add a regression test for the calibration layout.

## Validation
- `npm run typecheck`
- `npm run test:miner-pack`
- `npx vitest run test/unit/check-miner-package.test.ts`

## UI Evidence
N/A — CI/packaging fix only.
