### PR TITLE
ci(workflows): skip miner-package tests when the miner package is untouched

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
       mcpCliHarness: ${{ steps.filter.outputs.mcpCliHarness }}
       engine: ${{ steps.filter.outputs.engine }}
       miner: ${{ steps.filter.outputs.miner }}
+      minerTestHarness: ${{ steps.filter.outputs.minerTestHarness }}
       rees: ${{ steps.filter.outputs.rees }}
       observability: ${{ steps.filter.outputs.observability }}
     steps:
@@ -127,6 +128,24 @@ jobs:
             rees:
               - 'review-enrichment/**'
               - '.github/workflows/ci.yml'
+            # Both miner-package test files are self-contained w.r.t. root src/**, the same trust boundary as
+            # mcpCliHarness above: check-miner-package.test.ts only spawns scripts/check-miner-package.mjs as a
+            # real subprocess (node:child_process + vitest, nothing else), and miner-calibration-types.test.ts
+            # only imports the scaffolded packages/gittensory-miner/lib/calibration.js -- neither ever loads
+            # root src/ in-process. Mirrors mcpCliHarness's filter shape for the same reason (tooling/config
+            # changes that could plausibly affect how these tests run, plus the miner package + the test files
+            # themselves), swapping in the miner-specific package and test files.
+            minerTestHarness:
+              - 'vitest*.config.ts'
+              - 'tsconfig*.json'
+              - 'package.json'
+              - 'package-lock.json'
+              - 'scripts/**'
+              - 'migrations/**'
+              - '.github/workflows/**'
+              - 'packages/gittensory-miner/**'
+              - 'test/unit/check-miner-package.test.ts'
+              - 'test/unit/miner-calibration-types.test.ts'
 
   # Path-aware validation. Keep this as one job so a PR uses one dependency
   # install and one coverage upload. Run on GitHub-hosted runners while the
@@ -259,15 +278,29 @@ jobs:
           # above) didn't change. mcp-output-schemas.test.ts is never in the exclude list -- see that filter's
           # comment for why it can't be safely narrowed.
           SKIP_MCP_CLI_HARNESS: ${{ github.event_name == 'pull_request' && needs.changes.outputs.mcpCliHarness != 'true' }}
+          # Same self-contained-test-file narrowing as SKIP_MCP_CLI_HARNESS above, for the miner-package tests
+          # (minerTestHarness filter). Before this, both miner test files ran on every PR that touched ANY
+          # backend path (virtually all of them, since test/** alone qualifies) even though neither depends on
+          # root src/** -- so an unrelated PR paid for a real `npm pack --dry-run` of packages/gittensory-miner
+          # every time, and a miner-only breakage (e.g. #3704's nested lib/calibration/ directory) blocked every
+          # subsequent unrelated PR's CI instead of staying contained to PRs that actually touch the package.
+          SKIP_MINER_TEST_HARNESS: ${{ github.event_name == 'pull_request' && needs.changes.outputs.minerTestHarness != 'true' }}
         # Pinned to the standard GitHub-hosted runner's effective CPU budget; keeping this explicit avoids
         # accidental worker-pool thrash if os.cpus() reports a larger host in a future runner image.
         run: |
           EXCLUDE_ARGS=()
           if [ "$SKIP_MCP_CLI_HARNESS" = "true" ]; then
             echo "Skipping the self-contained MCP CLI-harness tests (no packages/gittensory-mcp-relevant paths changed)."
-            EXCLUDE_ARGS=(
+            EXCLUDE_ARGS+=(
               --exclude "test/unit/mcp-cli-*.test.ts"
               --exclude "test/unit/mcp-discovery.test.ts"
+            )
+          fi
+          if [ "$SKIP_MINER_TEST_HARNESS" = "true" ]; then
+            echo "Skipping the self-contained miner-package tests (no packages/gittensory-miner-relevant paths changed)."
+            EXCLUDE_ARGS+=(
+              --exclude "test/unit/check-miner-package.test.ts"
+              --exclude "test/unit/miner-calibration-types.test.ts"
             )
           fi
           npm run test:coverage -- --maxWorkers=4 "${EXCLUDE_ARGS[@]}"


### PR DESCRIPTION
## Summary

- `test/unit/check-miner-package.test.ts` and `test/unit/miner-calibration-types.test.ts` are self-contained w.r.t. root `src/**` — the same trust boundary the existing `mcpCliHarness` filter already established for the MCP CLI test cluster — but ran unconditionally on every PR that touched *any* backend path (virtually all of them, since `test/**` alone qualifies for the `backend` filter).
- Every such PR was paying for a real `npm pack --dry-run` of `packages/gittensory-miner`, and — as just seen live — a miner-only breakage (#3704's nested `lib/calibration/` directory, fixed in #3772) blocked every subsequent *unrelated* PR's CI instead of staying contained to PRs that actually touch the miner package.
- Add a `minerTestHarness` paths-filter output and a `SKIP_MINER_TEST_HARNESS` exclude branch in the "Test with coverage" step of `.github/workflows/ci.yml`, mirroring the existing `SKIP_MCP_CLI_HARNESS` pattern exactly (same filter shape: tooling/config files + the package directory + the specific test files).
- The standalone "Miner package check" / "Build miner CLI" steps were already correctly gated on the narrower `miner` filter — untouched by this PR.
- Push events to `main` are unaffected: the full suite always runs there, keeping the coverage baseline solid.

No issue filed — small, mechanical, self-evident CI optimization matching an existing reviewed pattern.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused — one filter + one skip branch, mirroring an existing pattern, nothing else.
- [x] This follows `CONTRIBUTING.md` and does not touch `site/`, `CNAME`, or GitHub Pages.
- [x] No issue linked; the summary explains why (small, mechanical, self-evident).

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] YAML sanity-parsed with `pyyaml` to confirm both the new `changes` job output and the nested `filters:` block parse correctly
- [ ] `npm run typecheck` / `npm run test:coverage` — no `src/**` or test code changed, only `.github/workflows/ci.yml`; not run in full
- [x] `npm audit --audit-level=moderate`

If any required check was skipped, explain why:

- Typecheck/coverage steps skipped: this PR touches only `.github/workflows/ci.yml` (CI configuration), no application or test source.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] No auth/cookie/CORS/GitHub App/Cloudflare/session changes.
- [x] No API/OpenAPI/MCP behavior changed.
- [x] No UI changes.

## Notes

- Companion to #3772 (which fixes the actual miner-package break). This PR is the CI-optimization half: it does not fix the underlying bug, it fixes *blast radius* — a PR that never touches `packages/gittensory-miner/**` should never be blocked or slowed by a miner-package failure.