### PR TITLE
feat(selfhost): add optional REES self-hosting via docker-compose profile

### DIFF
--- a/apps/gittensory-ui/src/routes/docs.self-hosting-rees.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-rees.tsx
@@ -115,6 +115,34 @@ REES_ANALYZERS=all`}
         ]}
       />
 
+      <h2>Self-hosting REES</h2>
+      <p>
+        The docker-compose stack in the repo root can run REES for you instead of pointing{" "}
+        <code>REES_URL</code> at a managed or external instance. Start it alongside the engine with
+        the <code>rees</code> profile:
+      </p>
+      <CodeBlock lang="bash" code={`docker compose --profile rees up -d`} />
+      <p>
+        REES is not published to the host — the engine reaches it only over the compose network.
+        Point the engine at it and generate a fresh shared secret; do not reuse a secret from any
+        other REES instance (for example a managed Railway deployment) you also run:
+      </p>
+      <CodeBlock
+        filename=".env"
+        code={`GITTENSORY_REVIEW_ENRICHMENT=true
+REES_URL=http://rees:8080
+REES_SHARED_SECRET=<generate-a-new-shared-secret>`}
+      />
+      <p>
+        No <code>SENTRY_*</code> variables are required for a working local REES. Set them only if
+        you want REES error reporting — see "Service configuration" below for the variables REES
+        reads, and add them for the <code>rees</code> service through a{" "}
+        <code>docker-compose.override.yml</code> rather than the root <code>.env</code>: REES reads
+        the same <code>SENTRY_DSN</code> name the main engine uses, so forwarding the whole{" "}
+        <code>.env</code> file would point REES's error reporting at the engine's Sentry project
+        instead of a dedicated one.
+      </p>
+
       <h2>Disable cleanly</h2>
       <p>
         Set <code>GITTENSORY_REVIEW_ENRICHMENT=false</code> to turn off REES for the whole instance.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,7 @@
 #   --profile qdrant        Qdrant vector database for RAG
 #   --profile ollama        Local Ollama AI backend
 #   --profile visual-review Headless Chromium (browserless) for before/after PR screenshot capture
+#   --profile rees          Review-enrichment service (REES) for heavier PR analysis, in-network only
 #   --profile litestream    Continuous SQLite backup to S3/B2/R2 via Litestream
 #   --profile caddy         Caddy HTTPS terminator with auto-TLS (set DOMAIN= in .env)
 #   --profile observability Prometheus + Alertmanager + Loki + Promtail + Grafana (pre-wired)
@@ -27,6 +28,7 @@
 #   docker compose up --build                                    # SQLite + Redis, build from source
 #   docker compose --profile postgres --profile caddy up -d     # Postgres + HTTPS
 #   docker compose --profile observability up -d                 # metrics + logs + dashboards
+#   docker compose --profile rees up -d                           # local REES review enrichment
 #   docker compose --profile tailscale --profile runners up -d   # tailnet + CI runners
 
 # Bounded container logging (#audit-rate-headroom): every service below defaults to Docker's
@@ -146,6 +148,13 @@ services:
       # (a network error just degrades to a placeholder, never a thrown error). This dependency exists
       # purely so `docker compose --profile visual-review up` starts services in a sensible order.
       browserless:
+        condition: service_healthy
+        required: false
+      # Same "start-order convenience only, not a crash-loop guard" reasoning as browserless above: REES
+      # enrichment runs per-PR-review, long after boot, and is already fully fail-safe end to end (any
+      # timeout/error just means the review proceeds without the brief -- src/review/enrichment-wire.ts).
+      # required:false keeps every deployment not using --profile rees unaffected.
+      rees:
         condition: service_healthy
         required: false
     # Sane defaults so a runaway optional service (below) can't OOM-kill or starve the core review pipeline;
@@ -376,6 +385,58 @@ services:
       timeout: 5s
       start_period: 15s
       retries: 5
+
+  # ── REES / review-enrichment (--profile rees) ──────────────────────────────
+  # Self-hosted alternative to pointing REES_URL at a managed/external instance (see the self-hosting docs).
+  # REES runs the heavier PR analysis (dependency CVEs, secret scan, license, EOL runtime, lockfile drift, IaC
+  # misconfig, ...) that the no-checkout `claude --print` reviewer can't do inline; the engine splices its
+  # brief into the AI review prompt and treats any REES timeout/error as "no brief" and proceeds regardless
+  # (src/review/enrichment-wire.ts) -- this whole service is optional end to end, same as browserless above.
+  # After `docker compose --profile rees up -d`, set in .env: GITTENSORY_REVIEW_ENRICHMENT=true,
+  # REES_URL=http://rees:8080, and a freshly generated REES_SHARED_SECRET -- do not reuse a secret from any
+  # other REES instance (e.g. a managed Railway deployment) you also point at (#1667).
+  rees:
+    build:
+      context: review-enrichment
+    restart: unless-stopped
+    <<: *default-logging
+    profiles: ["rees"]
+    # Deliberately NOT `env_file: .env` like the gittensory service above: that would also hand this
+    # analyzer service every unrelated secret in .env, and REES reads the same SENTRY_DSN key name the main
+    # app uses (src/selfhost/sentry.ts) -- blanket-forwarding .env would silently point REES's error reporting
+    # at the main app's Sentry project instead of a dedicated one. Add REES-specific Sentry vars via
+    # docker-compose.override.yml if you want REES error reporting (see review-enrichment/README.md).
+    environment:
+      PORT: "8080"
+      # Soft default, not ":?required" -- compose interpolates every service's env vars for the whole file
+      # even when --profile rees isn't active, so a hard-required var here would break `docker compose up`
+      # for every self-hoster not using this profile (same reasoning as BROWSERLESS_TOKEN below). Unset means
+      # REES fails closed (503) on every /v1/enrich call instead of running unauthenticated.
+      REES_SHARED_SECRET: ${REES_SHARED_SECRET:-}
+    # Never published to the host -- reached only over the internal docker network at http://rees:8080, same
+    # in-network-only posture as postgres/redis/qdrant/browserless.
+    expose:
+      - "8080"
+    deploy:
+      resources:
+        limits:
+          memory: "${REES_MEM_LIMIT:-512m}"
+    # /health and /ready are both unconditional no-ops (REES has no DB/queue to probe), so unlike the
+    # gittensory service above there's no deeper readiness signal to prefer here; /health also matches
+    # Railway's own healthcheckPath for this service. `node -e fetch(...)` avoids assuming curl/wget exist --
+    # review-enrichment/Dockerfile's runtime stage is node:22-slim, which installs neither.
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "node",
+          "-e",
+          "fetch('http://127.0.0.1:8080/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))",
+        ]
+      interval: 30s
+      timeout: 5s
+      start_period: 20s
+      retries: 3
 
   # ── Litestream (--profile litestream) ─────────────────────────────────────
   # Continuous WAL backup of the SQLite DB to S3/B2/R2. Copy litestream.yml.example


### PR DESCRIPTION
## Summary

- Adds an opt-in `rees` service to the root `docker-compose.yml` (behind `--profile rees`) so a self-hosted deployment can run REES locally instead of depending on the maintainer's Railway-hosted instance for PR enrichment. Wires `gittensory`'s `depends_on` to it with `condition: service_healthy, required: false` (start-order convenience only; REES is already fully fail-safe end to end).
- Documents the new option in `docs/self-hosting-rees` under a new "Self-hosting REES" section. The existing "point REES_URL at a managed/external instance" instructions are unchanged and remain the default/alternative path.
- No issue link: this is a small, self-evident additive change (`linkedIssuePolicy: preferred`, not required). Context: #1667 (self-host hardening / reduce-hosted-cost roadmap) and #1669 (evaluate hosted features to move into the stack) are the closest related maintainer roadmap issues.

**Architectural check performed first (per the task):** confirmed REES is not meant to stay centralized the way Orb is. `src/review/enrichment-wire.ts` documents REES as self-host-only runtime env (the hosted Worker sets neither `GITTENSORY_REVIEW_ENRICHMENT` nor `REES_URL`), the existing self-hosting docs already treat `REES_URL` as fully operator-configurable against a generic placeholder domain (unlike Orb's docs, which name the concrete central endpoint as the default), and REES has no broker/shared-telemetry role — it's a stateless per-PR analyzer call. No issue/PR history proposes and rejects self-hosting REES.

**Design notes:**
- The `rees` service deliberately does NOT reuse the core `gittensory` service's `env_file: .env` pattern: REES reads the same `SENTRY_DSN` key name the main app uses (`src/selfhost/sentry.ts`), so blanket-forwarding `.env` would silently point REES's error reporting at the engine's Sentry project. Only `PORT` and `REES_SHARED_SECRET` are wired; Sentry is opt-in via `docker-compose.override.yml`.
- REES's port is `expose`d, not `ports`-published — unreachable from the host, matching browserless/postgres/qdrant.
- Healthcheck probes `/health` via `node -e fetch(...)` (no curl/wget in the `node:22-slim` runtime stage), matching Railway's own `healthcheckPath`. `/health` and `/ready` are both unconditional no-ops in this service today, so there's no deeper readiness signal to prefer here (unlike the core `gittensory` service's DB-backed `/ready`).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally (see note below)
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate` (0 vulnerabilities)
- [x] `docker compose --profile rees config` validates; `docker compose --profile rees build rees` builds cleanly with zero changes to `review-enrichment/`; booted the built image standalone and confirmed `/health` resolves over the compose network at `http://rees:8080` and the healthcheck reports `healthy`
- [ ] This change touches no `src/**`, so it owes zero Codecov patch coverage.

If any required check was skipped, explain why:

- `npm run test:coverage` / `npm run test:miner-pack` currently fail on a **pre-existing, unrelated** bug on `main`: `scripts/check-miner-package.mjs`'s file-shape `ALLOWED` allowlist (a flat `^lib\/[a-z0-9-]+\.(js|d\.ts)$` regex) was never updated for the nested `lib/calibration/*` files added in `chore(miner): scaffold calibration module types (#2332) (#3704)`, so `npm pack --workspace @jsonbored/gittensory-miner --dry-run` now includes 4 files the checker rejects as "unexpected." Confirmed via `git diff origin/main -- scripts/check-miner-package.mjs packages/gittensory-miner/` (no diff) that this is byte-identical to `main`, not something this branch introduced. Every other step in `npm run test:ci`'s 23-step chain was run and passes. Flagging separately rather than folding a fix into this PR.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no such changes)
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/schema changes)
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — static docs prose only)
- [ ] Visible UI changes include a `UI Evidence` section below. (N/A — prose-only docs addition using existing, already-rendered components; no new visual state)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Deploy/verification on `edge-us-01` (generating a fresh `REES_SHARED_SECRET`, flipping `REES_URL` to `http://rees:8080`, confirming the local REES is actually used) will follow after this merges, per the task runbook.