### PR TITLE
fix(miner): accept lib/ subdirectory modules in the package checker

### DIFF
--- a/scripts/check-miner-package.mjs
+++ b/scripts/check-miner-package.mjs
@@ -6,7 +6,9 @@ import { fileURLToPath } from "node:url";
 
 const ALLOWED = [
   /^bin\/gittensory-miner\.js$/,
-  /^lib\/[a-z0-9-]+\.(js|d\.ts)$/,
+  // One optional level of subdirectory (e.g. lib/calibration/index.js, #2332) alongside the original flat
+  // lib/<name>.js layout -- both forms ship real runtime/type files, never build tooling or config.
+  /^lib\/([a-z0-9-]+\/)?[a-z0-9-]+\.(js|d\.ts)$/,
   /^package\.json$/,
   /^README\.md$/,
 ];
@@ -26,7 +28,7 @@ export function validateMinerPackFileList(files, readContent) {
   for (const required of REQUIRED) {
     if (!paths.includes(required)) throw new Error(`Miner package is missing required file: ${required}`);
   }
-  if (!paths.some((file) => /^lib\/[a-z0-9-]+\.js$/.test(file))) {
+  if (!paths.some((file) => /^lib\/([a-z0-9-]+\/)?[a-z0-9-]+\.js$/.test(file))) {
     throw new Error("Miner package is missing lib/*.js artifacts");
   }
   return paths;

--- a/test/unit/check-miner-package.test.ts
+++ b/test/unit/check-miner-package.test.ts
@@ -35,6 +35,33 @@ describe("check-miner-package script", () => {
     expect(result.out).toContain("Unexpected file in miner package: scripts/extra.mjs");
   });
 
+  it("REGRESSION (main was red after #3704): accepts a lib module split into a one-level subdirectory", () => {
+    const result = runChecker({
+      CHECK_MINER_PACK_TEST_FILES: JSON.stringify([
+        "package.json",
+        "bin/gittensory-miner.js",
+        "lib/calibration/index.js",
+        "lib/calibration/index.d.ts",
+      ]),
+      CHECK_MINER_PACK_TEST_CONTENT: "{}",
+    });
+    expect(result.status).toBe(0);
+    expect(result.out).toContain("lib/calibration/index.js");
+  });
+
+  it("still rejects a file nested two levels deep under lib/", () => {
+    const result = runChecker({
+      CHECK_MINER_PACK_TEST_FILES: JSON.stringify([
+        "package.json",
+        "bin/gittensory-miner.js",
+        "lib/cli.js",
+        "lib/calibration/nested/index.js",
+      ]),
+    });
+    expect(result.status).toBe(1);
+    expect(result.out).toContain("Unexpected file in miner package: lib/calibration/nested/index.js");
+  });
+
   it("rejects a package missing the CLI bin", () => {
     const result = runChecker({
       CHECK_MINER_PACK_TEST_FILES: JSON.stringify(["package.json", "lib/cli.js"]),


### PR DESCRIPTION
## Summary

- `scripts/check-miner-package.mjs`'s file-list validation only ever matched flat `lib/<name>.(js|d.ts)` files (both the `ALLOWED` allowlist regex and the "missing lib/*.js artifacts" check).
- #3704 (merged) added `packages/gittensory-miner/lib/calibration/{index,types}.{js,d.ts}` — a one-level subdirectory — which neither pattern accounts for, since they don't allow a `/` inside `lib/`.
- **Confirmed this is currently breaking `main`**: the latest push-triggered CI run on `origin/main` fails `validate-code` > "Test with coverage" on `test/unit/check-miner-package.test.ts > passes on the real miner workspace package`, meaning every PR rebased onto current main inherits this failure regardless of its own changes.
- Fix: widen both regexes to accept an optional one level of subdirectory under `lib/`, matching the existing flat-file convention otherwise.

Closes #3777

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

No UI changes in this PR — a build-tooling script fix only, so the UI Evidence section below is not applicable.

## Notes

- `scripts/**` is outside Codecov's `src/**`-only coverage measurement, so this PR owes no patch-coverage obligation, but regression tests are included anyway (one confirming the new subdirectory case passes, one confirming a file nested two levels deep is still rejected).
