### PR TITLE
fix(miner): restore the strict flat-only pack-safety allowlist

### DIFF
--- a/scripts/check-miner-package.mjs
+++ b/scripts/check-miner-package.mjs
@@ -6,9 +6,7 @@ import { fileURLToPath } from "node:url";
 
 const ALLOWED = [
   /^bin\/gittensory-miner\.js$/,
-  // One optional level of subdirectory (e.g. lib/calibration/index.js, #2332) alongside the original flat
-  // lib/<name>.js layout -- both forms ship real runtime/type files, never build tooling or config.
-  /^lib\/([a-z0-9-]+\/)?[a-z0-9-]+\.(js|d\.ts)$/,
+  /^lib\/[a-z0-9-]+\.(js|d\.ts)$/,
   /^package\.json$/,
   /^README\.md$/,
 ];

--- a/test/unit/check-miner-package.test.ts
+++ b/test/unit/check-miner-package.test.ts
@@ -35,21 +35,20 @@ describe("check-miner-package script", () => {
     expect(result.out).toContain("Unexpected file in miner package: scripts/extra.mjs");
   });
 
-  it("REGRESSION (main was red after #3704): accepts a lib module split into a one-level subdirectory", () => {
+  it("REGRESSION (#3704 caused main to go red, fixed by flattening lib/ instead of widening this allowlist): rejects a lib module nested one level under a subdirectory", () => {
     const result = runChecker({
       CHECK_MINER_PACK_TEST_FILES: JSON.stringify([
         "package.json",
         "bin/gittensory-miner.js",
+        "lib/cli.js",
         "lib/calibration/index.js",
-        "lib/calibration/index.d.ts",
       ]),
-      CHECK_MINER_PACK_TEST_CONTENT: "{}",
     });
-    expect(result.status).toBe(0);
-    expect(result.out).toContain("lib/calibration/index.js");
+    expect(result.status).toBe(1);
+    expect(result.out).toContain("Unexpected file in miner package: lib/calibration/index.js");
   });
 
-  it("still rejects a file nested two levels deep under lib/", () => {
+  it("rejects a file nested two levels deep under lib/", () => {
     const result = runChecker({
       CHECK_MINER_PACK_TEST_FILES: JSON.stringify([
         "package.json",


### PR DESCRIPTION
## Summary

- #3778 widened `scripts/check-miner-package.mjs`'s `ALLOWED` regex to accept one level of subdirectory under `lib/`, to accommodate the calibration module's nested `lib/calibration/{index,types}.{js,d.ts}` layout added by #3704.
- #3772 (merged 4 minutes earlier, independently fixing the same main-red CI break) took the opposite approach: it flattened that module to `lib/calibration.js` + `lib/calibration-types.js`, matching every other module in `packages/gittensory-miner/lib/`.
- With the nested directory gone (verified: `git ls-tree -r origin/main -- packages/gittensory-miner/lib/` shows zero subdirectory entries), #3778's widening is now dead weight — it permanently weakens a security-relevant pack-safety allowlist (the only guard against an arbitrary nested file sneaking into the published npm package) for zero remaining benefit.
- Restore the strict flat-only pattern. Turn the now-obsolete "accepts a one-level subdirectory" test into a rejection test instead, so a future nested `lib/` file is caught here rather than requiring another regex widening.

No issue filed — small, self-evident cleanup of a redundant, just-merged change.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused — one regex revert + one test update, nothing else.
- [x] This follows `CONTRIBUTING.md` and does not touch `site/`, `CNAME`, or GitHub Pages.
- [x] No issue linked; the summary explains why.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npx vitest run test/unit/check-miner-package.test.ts` — 8/8 passed, including the real-workspace-package test and both rejection cases (one-level and two-level nesting)
- [x] `npm audit --audit-level=moderate`
- [ ] `npm run test:coverage` in full — not run; `scripts/**` is excluded from `codecov/patch` (only `src/**` is measured), and the directly affected test file was run in full above

If any required check was skipped, explain why:

- Full coverage run skipped: this PR only touches `scripts/check-miner-package.mjs` and its dedicated test file, neither under `src/**`.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] No auth/cookie/CORS/GitHub App/Cloudflare/session changes.
- [x] No API/OpenAPI/MCP behavior changed.
- [x] No UI changes.
- [x] This PR *tightens*, not weakens, a security-relevant allowlist.

## Notes

- Companion to #3772 and #3778. Two independently-authored fixes for the same bug landed within minutes of each other; this PR reconciles them by keeping the more conservative one (flatten the module, keep the allowlist strict) and removing the now-unnecessary permissiveness from the other.