### PR TITLE
test(review): add multi-file band-5 case for estimateReviewEffort (#2151)

### DIFF
--- a/test/unit/review-effort.test.ts
+++ b/test/unit/review-effort.test.ts
@@ -10,7 +10,7 @@ function file(path: string, added: number): ReviewEffortFile {
   return { path, patch: srcPatch(added) };
 }
 
-describe("estimateReviewEffort", () => {
+describe("estimateReviewEffort (#2151)", () => {
   it("returns band 1 and a floored minute for an empty change set", () => {
     expect(estimateReviewEffort([])).toEqual({ band: 1, minutes: 1 });
   });
@@ -48,5 +48,11 @@ describe("estimateReviewEffort", () => {
     const effort = estimateReviewEffort([file("src/a.ts", 10), file("src/b.ts", 10)]); // (10+10) + 2*3 = 26 -> band 2
     expect(effort.band).toBe(2);
     expect(effort.minutes).toBe(13);
+  });
+
+  it("maps a multi-file change above the band-4 ceiling to band 5 (#2151)", () => {
+    // BAND_MAX top tier is 300; 5×100 source lines + 5×3 per-file overhead = 515 → band 5
+    const files = Array.from({ length: 5 }, (_, i) => file(`src/pkg${i}/mod.ts`, 100));
+    expect(estimateReviewEffort(files)).toEqual({ band: 5, minutes: 258 });
   });
 });


### PR DESCRIPTION
Closes #2151

## Summary
- Add the missing multi-file → band-5 case for the shipped `estimateReviewEffort` pure module (#2151 deliverable: large multi-file diff lands in band 5).

## Validation
- `npm run typecheck`
- `npx vitest run test/unit/review-effort.test.ts`

## UI Evidence
N/A — test-only.
