### PR TITLE
fix(selfhost): surface failed orb relay drains

### DIFF
--- a/src/orb/broker-client.ts
+++ b/src/orb/broker-client.ts
@@ -231,7 +231,8 @@ export async function registerOrbRelayTargetWithRetry(
 
 /** Pull-mode drain (#secure-relay): fetch this install's queued events from the Orb, acking the previous batch's
  *  delivery ids so the Orb deletes them. Lets a NAT/tailnet engine receive events WITHOUT exposing an inbound
- *  endpoint. BEST-EFFORT — returns [] on a non-broker / unsafe-URL / non-ok / thrown case; the next tick retries. */
+ *  endpoint. BEST-EFFORT at the scheduler boundary — returns [] only when broker mode is off, and throws
+ *  on broker communication failures so monitoring does not record false drain progress. */
 export async function drainOrbRelay(
   env: { ORB_ENROLLMENT_SECRET?: string | undefined; ORB_BROKER_URL?: string | undefined },
   ack: string[] = [],
@@ -246,7 +247,7 @@ export async function drainOrbRelay(
       body: JSON.stringify({ ack }),
       signal: AbortSignal.timeout(15_000),
     });
-    if (!res.ok) return [];
+    if (!res.ok) throw new Error(`orb_relay_drain_http_${res.status}`);
     const body = (await res.json()) as { events?: Array<{ deliveryId?: unknown; eventName?: unknown; rawBody?: unknown }> };
     const out: { deliveryId: string; eventName: string; rawBody: string }[] = [];
     for (const e of body.events ?? []) {
@@ -255,7 +256,8 @@ export async function drainOrbRelay(
       }
     }
     return out;
-  } catch {
-    return [];
+  } catch (error) {
+    if (error instanceof Error) throw error;
+    throw new Error("orb_relay_drain_failed");
   }
 }

--- a/test/unit/orb-broker-client.test.ts
+++ b/test/unit/orb-broker-client.test.ts
@@ -382,10 +382,14 @@ describe("drainOrbRelay (pull-mode drain)", () => {
     expect(JSON.parse(String(calls[0]?.init?.body))).toEqual({ ack: ["prev-1"] });
   });
 
-  it("tolerates a missing events array (?? [] arm) and returns [] on non-ok / thrown / unsafe-URL", async () => {
+  it("tolerates a missing events array (?? [] arm)", async () => {
     expect(await drainOrbRelay({ ORB_ENROLLMENT_SECRET: "s" }, [], (async () => Response.json({})) as typeof fetch)).toEqual([]);
-    expect(await drainOrbRelay({ ORB_ENROLLMENT_SECRET: "s" }, [], (async () => new Response("no", { status: 403 })) as typeof fetch)).toEqual([]);
-    expect(await drainOrbRelay({ ORB_ENROLLMENT_SECRET: "s" }, [], (async () => { throw new Error("down"); }) as typeof fetch)).toEqual([]);
-    expect(await drainOrbRelay({ ORB_ENROLLMENT_SECRET: "s", ORB_BROKER_URL: "http://broker.example" }, [], (async () => { throw new Error("unsafe should not fetch"); }) as typeof fetch)).toEqual([]);
+  });
+
+  it("throws on non-ok / thrown / unsafe-URL so the monitor does not record false progress", async () => {
+    await expect(drainOrbRelay({ ORB_ENROLLMENT_SECRET: "s" }, [], (async () => new Response("no", { status: 403 })) as typeof fetch)).rejects.toThrow("orb_relay_drain_http_403");
+    await expect(drainOrbRelay({ ORB_ENROLLMENT_SECRET: "s" }, [], (async () => { throw new Error("down"); }) as typeof fetch)).rejects.toThrow("down");
+    await expect(drainOrbRelay({ ORB_ENROLLMENT_SECRET: "s", ORB_BROKER_URL: "http://broker.example" }, [], (async () => { throw new Error("unsafe should not fetch"); }) as typeof fetch)).rejects.toThrow(/must use https/);
+    await expect(drainOrbRelay({ ORB_ENROLLMENT_SECRET: "s" }, [], (async () => Promise.reject("down")) as typeof fetch)).rejects.toThrow("orb_relay_drain_failed");
   });
 });

--- a/test/unit/selfhost-monitored-work.test.ts
+++ b/test/unit/selfhost-monitored-work.test.ts
@@ -20,7 +20,7 @@ import {
   runScheduledLoopWithMonitor,
   type OrbRelayDrainState,
 } from "../../src/selfhost/monitored-work";
-import type { OrbRelayRegistrationState } from "../../src/orb/broker-client";
+import { drainOrbRelay, type OrbRelayRegistrationState } from "../../src/orb/broker-client";
 import { renderMetrics, resetMetrics } from "../../src/selfhost/metrics";
 
 beforeEach(() => {
@@ -185,6 +185,24 @@ describe("self-host monitored recurring work", () => {
     });
 
     expect(state.lastDrainAtMs).toBeGreaterThanOrEqual(before);
+  });
+
+  it("does not stamp drain progress when the production broker drain gets a non-ok response", async () => {
+    const state: OrbRelayDrainState = { pendingAck: ["previous-delivery"], lastDrainAtMs: 1_000 };
+
+    await expect(
+      drainOrbRelayWithMonitor({
+        state,
+        relayEnv: { ORB_ENROLLMENT_SECRET: "s" },
+        env: {} as Env,
+        drain: (relayEnv, ack) => drainOrbRelay(relayEnv, ack, (async () => new Response("down", { status: 503 })) as typeof fetch),
+        enqueue: vi.fn(),
+        nowMs: 5_000,
+      }),
+    ).rejects.toThrow("orb_relay_drain_http_503");
+
+    expect(state.pendingAck).toEqual(["previous-delivery"]);
+    expect(state.lastDrainAtMs).toBe(1_000);
   });
 
   it("preserves pending Orb relay acks and skips the drain-progress stamp when the broker drain throws", async () => {


### PR DESCRIPTION
### Motivation

- The pull-mode drain path treated any resolved `drain` result (including `[]`) as proof of broker progress, but the production `drainOrbRelay` collapsed non-OK HTTP responses and caught errors into `[]`, making broker failures indistinguishable from successful empty polls. 
- This caused the no-progress monitoring gauge/alert to be falsely healthy during broker outages, delaying operator detection of a stuck pull-mode relay.

### Description

- Change `drainOrbRelay` in `src/orb/broker-client.ts` to throw on non-OK broker responses and propagate thrown/rejected errors instead of returning `[]`, while preserving the `[]` no-op when not in broker mode. 
- Add unit tests in `test/unit/orb-broker-client.test.ts` to assert the new `drainOrbRelay` behavior for non-OK responses, thrown errors, and unsafe URLs. 
- Add a regression test in `test/unit/selfhost-monitored-work.test.ts` that wires the real `drainOrbRelay` through `drainOrbRelayWithMonitor` and verifies a 503 broker response does not stamp `lastDrainAtMs` or clear pending acks.

### Testing

- Ran `npm run typecheck` and it completed without type errors. 
- Ran the targeted unit tests with `npm test -- --run test/unit/orb-broker-client.test.ts test/unit/selfhost-monitored-work.test.ts` and all tests passed (55 tests across the two files). 
- Attempted a full unsharded coverage run with `npm run test:coverage`; the full coverage job was observed to take an extended time and was terminated to keep the submit cycle bounded, so a complete unsharded coverage report was not included in this PR submission.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b6dd4c040832cb6d6c6b6fd2b3bcb)