### PR TITLE
fix(queue): re-gate every PR linked to changed issue

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -4102,8 +4102,8 @@ async function maybeInvalidateCiCacheOnLegacyCiEvent(
  * Wake linked PRs on an issue-side signal (#2259). Labeling/unlabeling (e.g. maintainer-only) or
  * assigning/unassigning on a linked ISSUE can flip a linked-issue hard-rule verdict, but that only gets
  * re-evaluated when the PR ITSELF receives a webhook or the staleness-ordered sweep eventually reaches it —
- * which can lag for many cycles on a repo with more than a few open PRs. Enqueue a bounded, staggered batch of
- * per-PR re-gate jobs for OPEN PRs that link this issue instead of doing the expensive live re-review inline.
+ * which can lag for many cycles on a repo with more than a few open PRs. Enqueue staggered per-PR re-gate jobs
+ * for EVERY open PR that links this issue instead of doing the expensive live re-review inline.
  * Uses its OWN coalesce window (issueLinkedPrReReviewCoalesced,
  * DISTINCT from CI-completion's — #2371): the two triggers are not interchangeable, so a shared window let an
  * unrelated CI re-review silently suppress a genuinely different issue-side signal. Within the issue-side
@@ -4132,12 +4132,11 @@ async function maybeReReviewOnLinkedIssueChange(
   if (isConvergenceRepoAllowed(env, repoFullName)) {
     const openPullRequests = await listOpenPullRequests(env, repoFullName);
     // Issue-side label/assignment changes can flip linked-issue hard-rule verdicts from mergeable to close.
-    // Wake a rate-aware leading batch promptly; the staleness-ordered sweep still converges any linked tail
-    // without letting one issue webhook fan out unbounded foreground re-gates. Stagger the jobs so the expensive
-    // re-gates do not run inline or stampede the queue consumer.
+    // Wake every linked PR promptly: a silent tail can keep stale passing gate/check state after the issue flips
+    // to an ineligible hard-rule state. Stagger the jobs so the expensive re-gates do not run inline or stampede
+    // the queue consumer.
     const linkingPrs = openPullRequests
       .filter((pr) => pr.linkedIssues.includes(issueNumber))
-      .slice(0, SWEEP_MAX_PRS)
       .map((pr) => ({ number: pr.number, createdAt: pr.createdAt ?? null }));
     for (const [index, pr] of linkingPrs.entries()) {
       const prNumber = pr.number;

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -2661,7 +2661,7 @@ describe("queue processors", () => {
     ]);
   });
 
-  it("REGRESSION: issue-side linked PR wake caps linked PR fanout to the sweep budget", async () => {
+  it("REGRESSION: issue-side linked PR wake re-gates every linked PR instead of leaving a stale tail", async () => {
     const sent: Array<{ message: import("../../src/types").JobMessage; options?: QueueSendOptions }> = [];
     const env = createTestEnv({
       GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(),
@@ -2686,7 +2686,7 @@ describe("queue processors", () => {
 
     await processJob(env, {
       type: "github-webhook",
-      deliveryId: "issue-label-capped-fanout",
+      deliveryId: "issue-label-all-linked-fanout",
       eventName: "issues",
       payload: {
         action: "labeled",
@@ -2698,13 +2698,13 @@ describe("queue processors", () => {
     });
 
     expect(fetchCount).toBe(0);
-    expect(sent).toHaveLength(SWEEP_MAX_PRS);
+    expect(sent).toHaveLength(SWEEP_MAX_PRS + 2);
     expect(sent.map(({ message }) => message)).toEqual(
-      Array.from({ length: SWEEP_MAX_PRS }, (_, index) =>
+      Array.from({ length: SWEEP_MAX_PRS + 2 }, (_, index) =>
         expect.objectContaining({ type: "agent-regate-pr", repoFullName: "owner/agent-repo", prNumber: index + 1, installationId: 9001 }),
       ),
     );
-    expect(sent.map(({ options }) => options)).toEqual([undefined, { delaySeconds: 10 }, { delaySeconds: 20 }]);
+    expect(sent.map(({ options }) => options)).toEqual([undefined, { delaySeconds: 10 }, { delaySeconds: 20 }, { delaySeconds: 30 }, { delaySeconds: 40 }]);
   });
 
   it("REGRESSION (#2371): a coalesced issue-side signal schedules a trailing re-review so an add-then-remove sequence is never lost", async () => {


### PR DESCRIPTION
### Motivation
- Issue-side label/assignment changes can flip deterministic linked-issue hard rules and must promptly re-evaluate all linked PRs to avoid stale passing gate state that could permit an ineligible contributor PR to merge.
- The previous implementation capped the immediate wake at `SWEEP_MAX_PRS`, leaving a tail of linked PRs un-re-gated until a later staleness sweep and creating a security-relevant race window.

### Description
- Remove the `slice(0, SWEEP_MAX_PRS)` cap in `maybeReReviewOnLinkedIssueChange` so every open PR that links the changed issue is enqueued for a staggered `agent-regate-pr` job (preserves the per-PR delay staggering behavior).
- Update the doc comment above the function to reflect that every linked PR is woken promptly (still coalesced per-PR where appropriate).
- Update the regression test in `test/unit/queue.test.ts` to seed more than `SWEEP_MAX_PRS` linked PRs and assert that all linked PRs are enqueued with the expected staggered `delaySeconds` values.

### Testing
- Ran the focused unit test: `npx vitest run test/unit/queue.test.ts -t "issue-side linked PR wake re-gates every linked PR"`, and the targeted test passed.
- Ran type checking with `npm run typecheck`, which succeeded.
- Ran the full coverage job `npm run test:coverage`; the run produced coverage output but failed the repository global coverage thresholds (this is a global-suite result, not a regression of the focused change).
- `git diff --check` was validated locally (no diff-check errors reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b77405cc4832c885ca2f6ec6661ee)