### PR TITLE
feat(ui): add maintainer activation preview card

### DIFF
--- a/apps/gittensory-ui/src/components/site/app-panels/activation-preview.test.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/activation-preview.test.tsx
@@ -1,0 +1,159 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// Mock the API layer so the component never touches the network.
+const { apiFetch } = vi.hoisted(() => ({ apiFetch: vi.fn() }));
+vi.mock("@/lib/api/request", () => ({ apiFetch: (...args: unknown[]) => apiFetch(...args) }));
+vi.mock("@/lib/api/origin", () => ({ getApiOrigin: () => "https://api.test" }));
+
+import { ActivationPreview } from "@/components/site/app-panels/activation-preview";
+
+const REVIEWABILITY = [{ pr: "acme/widgets#1" }];
+
+const BASE_PREVIEW = {
+  repoFullName: "acme/widgets",
+  generatedAt: "2026-07-05T00:00:00.000Z",
+  currentGateMode: "off" as const,
+  aiReviewConfigured: false,
+  evaluatedCount: 3,
+  withFindingsCount: 2,
+  findingCodeCounts: [{ code: "missing_tests", count: 2 }],
+  samples: [
+    {
+      number: 12,
+      title: "Add cursor pagination",
+      severity: "warning" as const,
+      findingCount: 1,
+      findings: [],
+    },
+    {
+      number: 11,
+      title: "Fix flaky test",
+      severity: "info" as const,
+      findingCount: 0,
+      findings: [],
+    },
+  ],
+  recommendedAction: "enable_advisory" as const,
+  summary:
+    "Gittensory reviewed your 3 most recent pull request(s) and would have surfaced guidance on 2 of them.",
+};
+
+describe("ActivationPreview", () => {
+  beforeEach(() => {
+    apiFetch.mockReset();
+  });
+
+  it("shows a loading state, then renders the real preview data on load", async () => {
+    apiFetch.mockResolvedValue({ ok: true, data: BASE_PREVIEW });
+    render(<ActivationPreview reviewability={REVIEWABILITY} />);
+
+    expect(screen.getByText(/Building activation preview/i)).toBeTruthy();
+    await waitFor(() => expect(screen.getByText(BASE_PREVIEW.summary)).toBeTruthy());
+    expect(screen.getByText("Add cursor pagination")).toBeTruthy();
+    expect(screen.getByText("missing_tests × 2")).toBeTruthy();
+    expect(apiFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/v1/repos/acme/widgets/activation-preview"),
+      expect.objectContaining({ label: "Activation preview" }),
+    );
+  });
+
+  it("renders an error state with the failure message when the preview fails to load", async () => {
+    apiFetch.mockResolvedValue({ ok: false, message: "503 Service Unavailable" });
+    render(<ActivationPreview reviewability={REVIEWABILITY} />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/Couldn't load the activation preview/i)).toBeTruthy(),
+    );
+    expect(screen.getByText("503 Service Unavailable")).toBeTruthy();
+  });
+
+  it("renders an empty state when zero pull requests have been evaluated", async () => {
+    apiFetch.mockResolvedValue({
+      ok: true,
+      data: {
+        ...BASE_PREVIEW,
+        evaluatedCount: 0,
+        withFindingsCount: 0,
+        samples: [],
+        findingCodeCounts: [],
+        recommendedAction: null,
+      },
+    });
+    render(<ActivationPreview reviewability={REVIEWABILITY} />);
+
+    await waitFor(() => expect(screen.getByText(/No recent pull requests yet/i)).toBeTruthy());
+  });
+
+  it("shows the enable-advisory action, posts activation, and reflects the enabled state after the round-trip", async () => {
+    apiFetch.mockResolvedValueOnce({ ok: true, data: BASE_PREVIEW });
+    render(<ActivationPreview reviewability={REVIEWABILITY} />);
+    await waitFor(() => expect(screen.getByText(BASE_PREVIEW.summary)).toBeTruthy());
+
+    const activateButton = screen.getByRole("button", { name: /enable advisory mode/i });
+
+    apiFetch.mockResolvedValueOnce({
+      ok: true,
+      data: {
+        repoFullName: "acme/widgets",
+        gateCheckMode: "enabled",
+        reviewCheckMode: "required",
+        checkRunMode: "enabled",
+        linkedIssueGateMode: "advisory",
+        duplicatePrGateMode: "advisory",
+        qualityGateMode: "advisory",
+      },
+    });
+    // Reload after activation reports the gate is now on — the button should disappear.
+    apiFetch.mockResolvedValueOnce({
+      ok: true,
+      data: { ...BASE_PREVIEW, currentGateMode: "enabled", recommendedAction: null },
+    });
+
+    fireEvent.click(activateButton);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(/Advisory mode enabled\. Gittensory will now surface guidance/i),
+      ).toBeTruthy(),
+    );
+    await waitFor(() => expect(screen.getByText(/Advisory mode is already enabled/i)).toBeTruthy());
+    expect(screen.queryByRole("button", { name: /enable advisory mode/i })).toBeNull();
+
+    const postCall = apiFetch.mock.calls.find(
+      ([, opts]) => (opts as { method?: string })?.method === "POST",
+    );
+    expect(postCall?.[0]).toContain("/v1/repos/acme/widgets/activation");
+  });
+
+  it("surfaces the error message inline when activation fails, without touching the preview data", async () => {
+    apiFetch.mockResolvedValueOnce({ ok: true, data: BASE_PREVIEW });
+    render(<ActivationPreview reviewability={REVIEWABILITY} />);
+    await waitFor(() => expect(screen.getByText(BASE_PREVIEW.summary)).toBeTruthy());
+
+    apiFetch.mockResolvedValueOnce({ ok: false, message: "403 Forbidden" });
+
+    fireEvent.click(screen.getByRole("button", { name: /enable advisory mode/i }));
+
+    await waitFor(() => expect(screen.getByText("403 Forbidden")).toBeTruthy());
+    // Still showing the previously-loaded preview, unchanged.
+    expect(screen.getByText(BASE_PREVIEW.summary)).toBeTruthy();
+  });
+
+  it("falls back to a manual owner/repo entry when no repos are registered yet", () => {
+    render(<ActivationPreview reviewability={[]} />);
+    expect(screen.getByText(/No registered repositories detected yet/i)).toBeTruthy();
+    expect(screen.getByText(/Enter an installed repository to preview activation\./i)).toBeTruthy();
+  });
+
+  it("shows the 'settings unavailable' copy for a typed repo string that doesn't parse as owner\\/repo", async () => {
+    apiFetch.mockResolvedValue({ ok: true, data: BASE_PREVIEW });
+    render(<ActivationPreview reviewability={REVIEWABILITY} />);
+    await waitFor(() => expect(screen.getByText(BASE_PREVIEW.summary)).toBeTruthy());
+
+    fireEvent.change(screen.getByPlaceholderText("owner/repo"), {
+      target: { value: "not-a-valid-slug" },
+    });
+    expect(screen.getByText(/Settings are unavailable for this repository\./i)).toBeTruthy();
+  });
+});

--- a/apps/gittensory-ui/src/components/site/app-panels/activation-preview.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/activation-preview.tsx
@@ -1,0 +1,315 @@
+import { CheckCircle2, Loader2, Rocket } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { StatusPill, type Status } from "@/components/site/control-primitives";
+import { StateBoundary } from "@/components/site/state-views";
+import { apiFetch } from "@/lib/api/request";
+import { getApiOrigin } from "@/lib/api/origin";
+import { extractPreviewRepoOptions, splitRepoFullName } from "@/lib/maintainer-settings-preview";
+
+type ActivationSeverity = "info" | "warning" | "critical";
+
+type ActivationFinding = { code: string; severity: ActivationSeverity; title: string };
+
+type ActivationSample = {
+  number: number;
+  title: string;
+  severity: ActivationSeverity;
+  findingCount: number;
+  findings: ActivationFinding[];
+};
+
+type ActivationPreviewResponse = {
+  repoFullName: string;
+  generatedAt: string;
+  currentGateMode: "off" | "enabled";
+  aiReviewConfigured: boolean;
+  evaluatedCount: number;
+  withFindingsCount: number;
+  findingCodeCounts: Array<{ code: string; count: number }>;
+  samples: ActivationSample[];
+  recommendedAction: "enable_advisory" | null;
+  summary: string;
+};
+
+type ActivationResponse = {
+  repoFullName: string;
+  gateCheckMode: string;
+  reviewCheckMode: string;
+  checkRunMode: string;
+  linkedIssueGateMode: string;
+  duplicatePrGateMode: string;
+  qualityGateMode: string;
+};
+
+type Message = { kind: "ok" | "err"; text: string };
+
+const SEVERITY_TONE: Record<ActivationSeverity, Status> = {
+  info: "info",
+  warning: "warn",
+  critical: "blocked",
+};
+
+function repoApiBase(repoFullName: string): string | null {
+  const target = splitRepoFullName(repoFullName);
+  if (!target) return null;
+  return `${getApiOrigin().replace(/\/$/, "")}/v1/repos/${encodeURIComponent(target.owner)}/${encodeURIComponent(target.repo)}`;
+}
+
+/**
+ * One-step maintainer activation demo (#701): loads GET /activation-preview for a repo (deterministic,
+ * no AI run) so a newly-installed maintainer sees concrete "here's what Gittensory would have surfaced"
+ * evidence, then a single action button posts /activation to turn on advisory mode. Mirrors the
+ * AiReviewSettings / MaintainerSettings repo-picker + load/save shape in this same file group.
+ */
+export function ActivationPreview({ reviewability }: { reviewability: Array<{ pr: string }> }) {
+  const repoOptions = useMemo(() => extractPreviewRepoOptions(reviewability), [reviewability]);
+  const [repoFullName, setRepoFullName] = useState(repoOptions[0] ?? "");
+  const [preview, setPreview] = useState<ActivationPreviewResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState<Message | null>(null);
+
+  const base = repoApiBase(repoFullName);
+  const hasRepos = repoOptions.length > 0;
+
+  const load = useCallback(async () => {
+    const apiBase = repoApiBase(repoFullName);
+    if (!apiBase) {
+      setPreview(null);
+      setLoadError(null);
+      return;
+    }
+    setMessage(null);
+    setLoadError(null);
+    setLoading(true);
+    const result = await apiFetch<ActivationPreviewResponse>(`${apiBase}/activation-preview`, {
+      label: "Activation preview",
+      credentials: "include",
+      silentStatus: true,
+    });
+    if (result.ok) {
+      setPreview(result.data);
+    } else {
+      setPreview(null);
+      setLoadError(result.message);
+    }
+    setLoading(false);
+  }, [repoFullName]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function activate() {
+    if (!base) return;
+    setBusy(true);
+    const result = await apiFetch<ActivationResponse>(`${base}/activation`, {
+      method: "POST",
+      label: "Enable advisory mode",
+      credentials: "include",
+      headers: { Accept: "application/json", "Content-Type": "application/json" },
+    });
+    setBusy(false);
+    if (result.ok) {
+      // Reload first — `load()` clears any prior message, so the success message must be set after it settles.
+      await load();
+      setMessage({
+        kind: "ok",
+        text: "Advisory mode enabled. Gittensory will now surface guidance on new PRs.",
+      });
+    } else {
+      setMessage({ kind: "err", text: result.message });
+    }
+  }
+
+  return (
+    <section
+      className="rounded-token border-hairline bg-card p-5"
+      aria-labelledby="activation-preview-title"
+    >
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h2 id="activation-preview-title" className="font-display text-token-lg font-semibold">
+            Instant activation preview
+          </h2>
+          <p className="mt-1 text-token-xs text-muted-foreground">
+            See what Gittensory would have surfaced on this repo's recent pull requests, then enable
+            advisory mode in one step. Deterministic — never runs AI, never blocks a merge.
+          </p>
+        </div>
+        {preview ? (
+          <StatusPill status={preview.recommendedAction === null ? "ready" : "info"}>
+            gate {preview.currentGateMode}
+          </StatusPill>
+        ) : null}
+      </div>
+
+      <label className="mt-4 block max-w-sm">
+        <span className="font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
+          Repository
+        </span>
+        <input
+          value={repoFullName}
+          onChange={(event) => setRepoFullName(event.target.value)}
+          list="activation-preview-repos"
+          placeholder="owner/repo"
+          className="mt-1 min-h-10 w-full rounded-token border border-border bg-background/70 px-3 py-2 font-mono text-token-sm text-foreground outline-none transition-colors focus:border-mint"
+        />
+        <datalist id="activation-preview-repos">
+          {repoOptions.map((repo) => (
+            <option key={repo} value={repo} />
+          ))}
+        </datalist>
+        {!hasRepos ? (
+          <span className="mt-1 block text-token-2xs text-muted-foreground">
+            No registered repositories detected yet — type an installed{" "}
+            <code className="font-mono">owner/repo</code>.
+          </span>
+        ) : null}
+      </label>
+
+      <div className="mt-6">
+        <StateBoundary
+          isLoading={Boolean(base) && loading}
+          isError={Boolean(base) && !loading && loadError !== null}
+          isEmpty={Boolean(base) && !loading && preview !== null && preview.evaluatedCount === 0}
+          onRetry={load}
+          onRefresh={load}
+          loadingTitle="Building activation preview…"
+          errorTitle="Couldn't load the activation preview"
+          errorDescription={loadError ?? undefined}
+          emptyTitle="No recent pull requests yet"
+          emptyDescription="Gittensory will start surfacing guidance once this repo has pull requests cached."
+        >
+          {!base ? (
+            <p className="text-token-sm text-muted-foreground">
+              {hasRepos
+                ? "Settings are unavailable for this repository."
+                : "Enter an installed repository to preview activation."}
+            </p>
+          ) : preview ? (
+            <ActivationPreviewBody
+              preview={preview}
+              busy={busy}
+              onActivate={() => void activate()}
+            />
+          ) : null}
+        </StateBoundary>
+      </div>
+
+      <span
+        role="status"
+        aria-live="polite"
+        className={`mt-4 block text-token-xs ${message ? (message.kind === "ok" ? "text-mint" : "text-warning") : "sr-only"}`}
+      >
+        {message?.text ?? ""}
+      </span>
+    </section>
+  );
+}
+
+function ActivationPreviewBody({
+  preview,
+  busy,
+  onActivate,
+}: {
+  preview: ActivationPreviewResponse;
+  busy: boolean;
+  onActivate: () => void;
+}) {
+  return (
+    <div className="space-y-4">
+      <p className="text-token-sm text-foreground/90">{preview.summary}</p>
+
+      <div className="grid gap-3 sm:grid-cols-3">
+        <MetricTile label="PRs evaluated" value={preview.evaluatedCount} />
+        <MetricTile label="Would flag" value={preview.withFindingsCount} />
+        <MetricTile
+          label="AI review"
+          value={preview.aiReviewConfigured ? "configured" : "not set"}
+        />
+      </div>
+
+      {preview.findingCodeCounts.length > 0 ? (
+        <div>
+          <div className="font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
+            Finding types seen
+          </div>
+          <div className="mt-2 flex flex-wrap gap-2">
+            {preview.findingCodeCounts.map((entry) => (
+              <span
+                key={entry.code}
+                className="rounded-token border-hairline bg-background/40 px-2 py-1 font-mono text-token-2xs text-muted-foreground"
+              >
+                {entry.code} × {entry.count}
+              </span>
+            ))}
+          </div>
+        </div>
+      ) : null}
+
+      {preview.samples.length > 0 ? (
+        <div className="overflow-hidden rounded-token border-hairline">
+          <table className="w-full text-left text-token-xs">
+            <thead className="border-b-hairline font-mono uppercase tracking-wider text-muted-foreground">
+              <tr>
+                <th className="px-3 py-2 font-normal">PR</th>
+                <th className="px-3 py-2 font-normal">Title</th>
+                <th className="px-3 py-2 font-normal">Severity</th>
+                <th className="px-3 py-2 font-normal">Findings</th>
+              </tr>
+            </thead>
+            <tbody>
+              {preview.samples.map((sample) => (
+                <tr key={sample.number} className="border-b-hairline last:border-b-0">
+                  <td className="px-3 py-2 font-mono text-foreground/90">#{sample.number}</td>
+                  <td className="px-3 py-2">{sample.title}</td>
+                  <td className="px-3 py-2">
+                    <StatusPill status={SEVERITY_TONE[sample.severity]}>
+                      {sample.severity}
+                    </StatusPill>
+                  </td>
+                  <td className="px-3 py-2 text-muted-foreground">{sample.findingCount}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      ) : null}
+
+      <div className="flex flex-wrap items-center gap-3">
+        {preview.recommendedAction === "enable_advisory" ? (
+          <button
+            type="button"
+            disabled={busy}
+            aria-busy={busy}
+            onClick={onActivate}
+            className="inline-flex items-center gap-2 rounded-token border border-mint/40 bg-mint px-3 py-2 text-token-xs font-medium text-primary-foreground transition-all hover:brightness-110 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {busy ? <Loader2 className="size-3.5 animate-spin" /> : <Rocket className="size-3.5" />}
+            Enable advisory mode
+          </button>
+        ) : (
+          <span className="inline-flex items-center gap-2 rounded-token border border-success/35 bg-success/10 px-3 py-2 text-token-xs text-success">
+            <CheckCircle2 className="size-3.5" /> Advisory mode is already enabled
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function MetricTile({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="rounded-token border-hairline bg-background/40 px-3 py-2">
+      <div className="font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
+        {label}
+      </div>
+      <div className="mt-1 flex items-center gap-2 text-token-sm font-medium text-foreground">
+        {value}
+      </div>
+    </div>
+  );
+}

--- a/apps/gittensory-ui/src/components/site/app-panels/maintainer-panel.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/maintainer-panel.tsx
@@ -17,6 +17,7 @@ import {
   StatusPill,
   type Status,
 } from "@/components/site/control-primitives";
+import { ActivationPreview } from "@/components/site/app-panels/activation-preview";
 import { AiReviewSettings } from "@/components/site/app-panels/ai-review-settings";
 import { MaintainerSettings } from "@/components/site/app-panels/maintainer-settings";
 import { StatCard } from "@/components/site/primitives";
@@ -350,6 +351,8 @@ function MaintainerDashboardView() {
               </tbody>
             </table>
           </section>
+
+          <ActivationPreview reviewability={data.reviewability} />
 
           <SurfacePreview reviewability={data.reviewability} />
 


### PR DESCRIPTION
## Summary

- Closes the remaining UI gap in #701 ("one-step maintainer activation / instant-value onboarding"). The backend (`buildMaintainerActivationPreview` in `src/services/maintainer-activation.ts`, `GET /v1/repos/:owner/:repo/activation-preview`, `POST .../activation`) shipped in PR #708, but there was no UI page or component that called it — only a docs page describing the API in prose.
- Adds `ActivationPreview` (`apps/gittensory-ui/src/components/site/app-panels/activation-preview.tsx`), a new card mounted in the existing maintainer console (`MaintainerPanel` → `apps/gittensory-ui/src/components/site/app-panels/maintainer-panel.tsx`). On mount it calls `GET /v1/repos/:owner/:repo/activation-preview` for the selected repo and renders the real returned preview (PRs evaluated, how many would have been flagged, finding-type breakdown, per-PR sample table). A single "Enable advisory mode" button posts `POST .../activation` and reflects success/failure inline, then reloads the preview so the button state (advisory already enabled vs. not) reflects the live result.
- Anchored on two existing analogues in the same file (`apps/gittensory-ui/src/components/site/app-panels/maintainer-panel.tsx`): `AiReviewSettings` and `MaintainerSettings` (both repo-picker + `apiFetch` load/save + inline `role="status"` message cards), plus `OwnerPanel` (`apps/gittensory-ui/src/components/site/app-panels/owner-panel.tsx`) for the `useApiResource`-style GET-on-mount + `StateBoundary` loading/error/empty pattern. The repo picker reuses the existing `extractPreviewRepoOptions`/`splitRepoFullName` helpers from `apps/gittensory-ui/src/lib/maintainer-settings-preview.ts` rather than inventing a new one.
- Design-ambiguity call (conservative, smallest scope): placed the new card as a section inside the existing `MaintainerPanel` (next to `SurfacePreview`/`MaintainerSettings`), rather than a new top-level route — this matches how every other per-repo maintainer surface in this codebase (AI review, repo settings, focus manifest) is already composed as a card within the same console, and keeps the PR to a UI-only diff with no routing changes.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed. (Closes #701 — the backend shipped in #708 and this PR adds the missing UI, together fully satisfying #701's acceptance criteria: a newly-installed maintainer sees a concrete repo-specific gate/AI preview in the first session and enables advisory mode in one action.)

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` (no workflow files touched by this PR; not run)
- [x] `npm run typecheck` (backend typecheck — no `src/**` changes in this PR, ran clean as a sanity check)
- [ ] `npm run test:coverage` (no `src/**` changes — this is a UI-only PR, so `codecov/patch` has no obligation here; not run since it is backend-only coverage)
- [ ] `npm run test:workers` (no Cloudflare Worker changes; not run)
- [ ] `npm run build:mcp` (no MCP changes; not run)
- [ ] `npm run test:mcp-pack` (no MCP changes; not run)
- [x] `npm run ui:openapi:check` (confirmed no drift — no API/schema changes in this PR)
- [x] `npm run ui:lint` — 0 errors, 87 pre-existing warnings unrelated to this diff (verified none are in the changed files)
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate` (no dependency changes; not run)
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — `activation-preview.test.tsx` covers loaded/error/empty states, the activate success + reload round-trip, the activate-failure inline error path (preview data untouched), the no-registered-repos fallback, and the invalid `owner/repo` input branch. `npm --workspace @jsonbored/gittensory-ui run test` → 71/71 passing (9 files, including the new one).

If any required check was skipped, explain why:

- This PR touches only `apps/gittensory-ui/**` (no `src/**`). Codecov's `codecov/patch` gate only covers `src/**`, so this diff owes no backend coverage; UI correctness is covered by the new component test file instead. Skipped checks above are backend/MCP/dependency-only gates that have nothing to validate for a UI-only change.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (No auth/CORS/session code changed; the existing `MaintainerPanel` role gate is unchanged and continues to gate this new card the same as every other maintainer-only card in the file.)
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. (No API/OpenAPI changes — this PR only consumes the two routes that already shipped in #708.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. The card calls the real `activation-preview`/`activation` endpoints via the existing `apiFetch` helper; loading/error/empty states are driven entirely by the live response, with no mock or demo data path.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. **Not satisfied — see UI Evidence section below for why.**
- [ ] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (No changelog edit, per house rules. `docs.self-hosting-configuration.tsx` already documents the underlying API in prose and needs no update for this UI-only consumption of it.)

## UI Evidence

**I could not capture real screenshots in this environment.** The new card only renders past the existing `MaintainerPanel` role gate (a real authenticated session with a `maintainer`/`owner`/`operator` role) and needs live backend data (a registered repo with cached pull requests) to show its loaded state — this sandboxed worktree has no deployed backend, no OAuth session, and no seeded repo/PR data to drive it, and fabricating a screenshot or mock data would violate this repo's no-mock-fallback-data rule. Rather than fabricate a placeholder, I'm flagging this honestly per the task instructions. The component's four real states (loading, error, empty, loaded-with-data) are instead exercised and asserted against in `activation-preview.test.tsx` via React Testing Library, which is the closest verifiable substitute available here.

## Notes

- Files touched: `apps/gittensory-ui/src/components/site/app-panels/activation-preview.tsx` (new), `apps/gittensory-ui/src/components/site/app-panels/activation-preview.test.tsx` (new), `apps/gittensory-ui/src/components/site/app-panels/maintainer-panel.tsx` (mounts the new card).
- No `src/**`, migration, OpenAPI, or Cloudflare-binding changes — nothing to regenerate.