### PR TITLE
feat(mcp): compose preflight, slop-risk, and pr-text-lint into review-pr

### DIFF
--- a/packages/gittensory-mcp/README.md
+++ b/packages/gittensory-mcp/README.md
@@ -57,6 +57,7 @@ gittensory-mcp decision-pack --login jsonbored --json
 gittensory-mcp repo-decision --login jsonbored --repo we-promise/sure --json
 gittensory-mcp analyze-branch --login jsonbored --json
 gittensory-mcp preflight --login jsonbored --json
+gittensory-mcp review-pr --login jsonbored --commit "feat(mcp): add doctor grouping" --body "Fixes #160. Validated with npm test." --linked-issue 160 --json
 gittensory-mcp lint-pr-text --commit "feat(mcp): add doctor grouping" --body "Fixes #160. Validated with npm test." --linked-issue 160 --json
 gittensory-mcp slop-risk --changed-file src/widget.ts:80:2 --description "Adds retry handling." --test-file test/unit/widget.test.ts --json
 gittensory-mcp issue-slop --title "Add retry handling" --body "Widget reconnects fail without bounded retries." --json
@@ -114,6 +115,29 @@ gittensory-mcp analyze-branch --login jsonbored \
   --scenario-note "approved PRs expected to merge" \
   --json
 ```
+
+## Review your PR locally before you push
+
+`gittensory-mcp review-pr` composes the existing preflight, slop-risk, and PR-text-lint checks into
+ONE report, so your own local agent (Claude Code, Codex, etc.) can see everything the gittensory gate
+would flag before you ever open a PR. It is a thin composition layer — it calls the same checks
+`preflight`, `slop-risk`, and `lint-pr-text` already run and merges their output; it does not
+reimplement any of them.
+
+```sh
+gittensory-mcp review-pr --login jsonbored \
+  --commit "feat(mcp): add review-pr" \
+  --body "Composes preflight + slop-risk + lint-pr-text. Validated with npm test." \
+  --linked-issue 1968 \
+  --json
+```
+
+The report has an `overallStatus` (`pass`/`warn`/`fail`) and a `sections` array covering
+`preflight`, `slop_risk`, and `pr_text_lint`. If one underlying check's API call fails, that section
+degrades to `fail` with a public-safe `slopRiskError`/`prTextLintError` reason instead of aborting the
+whole report — the other sections still return.
+
+The same composed check is exposed to MCP clients as `gittensory_review_pr_before_push`.
 
 ## Auth
 

--- a/packages/gittensory-mcp/bin/gittensory-mcp.js
+++ b/packages/gittensory-mcp/bin/gittensory-mcp.js
@@ -40,6 +40,7 @@ const CLI_COMMAND_SPEC = {
   "repo-decision": [],
   "analyze-branch": [],
   preflight: [],
+  "review-pr": [],
   "lint-pr-text": [],
   "slop-risk": [],
   "issue-slop": [],
@@ -633,6 +634,16 @@ server.registerTool(
       workspaceIntelligence: publicSafeWorkspaceIntelligence(result.analysis.workspaceIntelligence),
     });
   },
+);
+
+server.registerTool(
+  "gittensory_review_pr_before_push",
+  {
+    description:
+      "Run a single composed pre-PR review of the current branch: preflight (lane/duplicate/linked-issue/test/queue fit), slop-risk, and PR-text lint, merged into one report with an overall pass/warn/fail status. Thin composition of the existing checks — does not reimplement any of them. Sends metadata only, no source upload.",
+    inputSchema: currentBranchShape,
+  },
+  async (input) => toolResult("Gittensory pre-PR review.", await reviewLocalPr(await withClientWorkspaceRoots(input))),
 );
 
 server.registerTool(
@@ -1449,6 +1460,7 @@ async function runCli(args) {
   if (command === "issue-slop") return issueSlopCli(args.slice(1));
   if (command === "decision-pack") return decisionPackCli(options);
   if (command === "repo-decision") return repoDecisionCli(options);
+  if (command === "review-pr") return reviewPrCli(options);
   if (command !== "analyze-branch" && command !== "preflight") {
     const suggestion = suggestCommand(command);
     throw new Error(`Unknown command: ${command}.${suggestion ? ` Did you mean \`${suggestion}\`?` : ""} Run \`gittensory-mcp --help\` to list commands.`);
@@ -1483,6 +1495,52 @@ async function runCli(args) {
     return;
   }
   writeBranchAnalysisCli(result, command);
+}
+
+function printReviewPrHelp() {
+  process.stdout.write(
+    [
+      "Usage: gittensory-mcp review-pr --login <github-login> [--repo owner/repo] [--base origin/main] [--commit <message>]... [--body <text>] [--body-file <path>] [--linked-issue <number>] [--json]",
+      "",
+      "Compose the existing preflight + slop-risk + PR-text-lint checks into ONE pre-PR review report,",
+      "so a contributor's own local agent can see everything the gittensory gate would flag before ever opening a PR.",
+      "Mirrors the gittensory_review_pr_before_push MCP tool. Thin composition only — does not reimplement any check. No source upload.",
+      "",
+      "Pass --json for machine-readable output.",
+    ].join("\n") + "\n",
+  );
+}
+
+async function reviewPrCli(options) {
+  if (options.help === true) return printReviewPrHelp();
+  const contributorLogin = options.login ?? process.env.GITTENSORY_LOGIN ?? process.env.GITHUB_LOGIN;
+  if (!contributorLogin) throw new Error("Pass --login <github-login> or set GITTENSORY_LOGIN.");
+  let prBody = options.body;
+  if (options.bodyFile) prBody = readCliTextFile(options.bodyFile, "Body");
+  const commitMessages = Array.isArray(options.commit) ? options.commit : options.commit ? [options.commit] : undefined;
+  const linkedIssue = parsePositiveIntegerOption(options.linkedIssue, "--linked-issue");
+  const payload = await reviewLocalPr({
+    login: contributorLogin,
+    cwd: options.cwd,
+    repoFullName: options.repo,
+    baseRef: options.base,
+    title: options.title,
+    body: prBody,
+    labels: options.label,
+    commitMessages,
+    linkedIssues: linkedIssue !== undefined ? [linkedIssue] : options.issue?.map((value) => Number(value)).filter((value) => Number.isInteger(value) && value > 0),
+  });
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+    return;
+  }
+  process.stdout.write(`Pre-PR review: ${payload.overallStatus}\n`);
+  for (const section of payload.sections) process.stdout.write(`- ${section.name}: ${section.status}\n`);
+  process.stdout.write(`Preflight: ${payload.preflight.status}\n`);
+  if (payload.slopRisk) process.stdout.write(`Slop risk: ${payload.slopRisk.slopRisk} (${payload.slopRisk.band})\n`);
+  else if (payload.slopRiskError) process.stdout.write(`Slop risk: unavailable (${payload.slopRiskError})\n`);
+  if (payload.prTextLint) process.stdout.write(`PR text lint: ${payload.prTextLint.verdict} (score ${payload.prTextLint.score})\n`);
+  else if (payload.prTextLintError) process.stdout.write(`PR text lint: unavailable (${payload.prTextLintError})\n`);
 }
 
 // Opens, type-checks, and reads the file through ONE file descriptor rather than a separate
@@ -2036,6 +2094,7 @@ function printHelp() {
   gittensory-mcp repo-decision --login <github-login> --repo owner/repo [--json]
   gittensory-mcp analyze-branch --login <github-login> [--repo owner/repo] [--base origin/main] [--branch-eligibility eligible|ineligible|unknown] [--pending-merged-prs 3] [--expected-open-prs 0] [--projected-credibility 0.8] [--scenario-note "..."] [--validation "passed|npm test|summary"] [--json]
   gittensory-mcp preflight --login <github-login> [--repo owner/repo] [--base origin/main] [--branch-eligibility eligible|ineligible|unknown] [--pending-merged-prs 3] [--expected-open-prs 0] [--projected-credibility 0.8] [--validation "passed|npm test|summary"] [--json]
+  gittensory-mcp review-pr --login <github-login> [--repo owner/repo] [--base origin/main] [--commit <message>]... [--body <text>] [--body-file <path>] [--linked-issue <number>] [--json]
   gittensory-mcp lint-pr-text [--commit <message>]... [--body <text>] [--body-file <path>] [--linked-issue <number>] [--json]
   gittensory-mcp slop-risk [--description <text>] [--description-file <path>] [--changed-file <path[:additions:deletions]>]... [--test <command>]... [--test-file <path>]... [--json]
   gittensory-mcp issue-slop [--title <text>] [--body <text>] [--body-file <path>] [--json]
@@ -2562,8 +2621,8 @@ function doctorNextCommand(byName, context) {
     };
   }
   return {
-    command: `gittensory-mcp preflight --login ${shellArg(context.login ?? "<github-login>")} --repo ${shellArg(context.repoFullName ?? "owner/repo")} --json`,
-    reason: "Run branch preflight next; source upload remains disabled.",
+    command: `gittensory-mcp review-pr --login ${shellArg(context.login ?? "<github-login>")} --repo ${shellArg(context.repoFullName ?? "owner/repo")} --json`,
+    reason: "Run the composed pre-PR review (preflight + slop-risk + PR-text lint) next; source upload remains disabled.",
   };
 }
 
@@ -3641,6 +3700,79 @@ async function agentPreparePrPacket(input) {
   const payload = buildBranchAnalysisPayload({ ...input, cwd: workspace.cwd });
   const { localScorerStatus: _localScorerStatus, ...body } = payload;
   return apiPost("/v1/agent/prepare-pr-packet", body);
+}
+
+// #1968 review-pr: a thin composition of the existing preflight + slop-risk + lint-pr-text checks
+// into one report, so a contributor's own local agent can see everything the gate would flag before
+// ever opening a PR. Reuses analyzeCurrentBranch (preflight) and collectLocalDiff (the same diff
+// metadata previewLocalScore already sends) rather than reimplementing any check. Each sub-check is
+// isolated with its own try/catch: one flaky endpoint degrades that section to a `failed` status with
+// a public-safe reason instead of hiding the sections that did succeed.
+async function reviewLocalPr(input) {
+  const result = await analyzeCurrentBranch(input);
+  const workspace = resolveWorkspaceCwd(input);
+  const diff = collectLocalDiff(workspace.cwd, input.baseRef, input.workspaceRoots);
+  const commitMessages = input.commitMessages?.length ? input.commitMessages : undefined;
+  const prBody = input.body;
+  const linkedIssue = input.linkedIssues?.[0];
+
+  const slopRisk = await runReviewCheck(() =>
+    apiPost("/v1/lint/slop-risk", {
+      changedFiles: diff.changedFiles.map((path) => ({ path })),
+      description: prBody,
+      testFiles: diff.testFiles,
+    }),
+  );
+  const prTextLint = await runReviewCheck(() =>
+    apiPost("/v1/lint/pr-text", {
+      ...(commitMessages ? { commitMessages } : {}),
+      ...(prBody !== undefined ? { prBody } : {}),
+      ...(linkedIssue !== undefined ? { linkedIssue } : {}),
+    }),
+  );
+
+  const sections = [
+    { name: "preflight", status: result.analysis.preflight?.status === "fail" ? "fail" : result.analysis.preflight?.status === "warn" ? "warn" : "pass" },
+    { name: "slop_risk", status: slopRisk.ok ? slopRiskSectionStatus(slopRisk.value) : "fail" },
+    { name: "pr_text_lint", status: prTextLint.ok ? prTextLintSectionStatus(prTextLint.value) : "fail" },
+  ];
+
+  return {
+    local: result.local,
+    preflight: result.analysis.preflight,
+    prPacket: result.analysis.prPacket,
+    workspaceIntelligence: publicSafeWorkspaceIntelligence(result.analysis.workspaceIntelligence),
+    slopRisk: slopRisk.ok ? slopRisk.value : undefined,
+    slopRiskError: slopRisk.ok ? undefined : slopRisk.reason,
+    prTextLint: prTextLint.ok ? prTextLint.value : undefined,
+    prTextLintError: prTextLint.ok ? undefined : prTextLint.reason,
+    overallStatus: reviewOverallStatus(sections),
+    sections,
+  };
+}
+
+async function runReviewCheck(run) {
+  try {
+    return { ok: true, value: await run() };
+  } catch (error) {
+    return { ok: false, reason: error instanceof Error ? error.message : "review_check_failed" };
+  }
+}
+
+function slopRiskSectionStatus(value) {
+  if (value?.band === "high" || value?.band === "elevated") return "warn";
+  return "pass";
+}
+
+function prTextLintSectionStatus(value) {
+  if (value?.verdict === "weak") return "warn";
+  return "pass";
+}
+
+function reviewOverallStatus(sections) {
+  if (sections.some((section) => section.status === "fail")) return "fail";
+  if (sections.some((section) => section.status === "warn")) return "warn";
+  return "pass";
 }
 
 async function previewLocalScore(input) {

--- a/test/unit/mcp-cli-doctor.test.ts
+++ b/test/unit/mcp-cli-doctor.test.ts
@@ -86,11 +86,11 @@ describe("gittensory-mcp CLI — doctor", () => {
     };
 
     const payload = JSON.parse(await runAsync(["doctor", "--cwd", tempDir, "--json"], env)) as { nextCommand: { command: string } };
-    expect(payload.nextCommand.command).toBe("gittensory-mcp preflight --login JSONbored --repo 'owner/repo$(touch /tmp/av_pwned)' --json");
+    expect(payload.nextCommand.command).toBe("gittensory-mcp review-pr --login JSONbored --repo 'owner/repo$(touch /tmp/av_pwned)' --json");
     expect(payload.nextCommand.command).not.toContain("--repo owner/repo$(");
 
     const humanOutput = await runAsync(["doctor", "--cwd", tempDir], env);
-    expect(humanOutput).toContain("gittensory-mcp preflight --login JSONbored --repo 'owner/repo$(touch /tmp/av_pwned)' --json");
+    expect(humanOutput).toContain("gittensory-mcp review-pr --login JSONbored --repo 'owner/repo$(touch /tmp/av_pwned)' --json");
     expect(humanOutput).not.toContain("--repo owner/repo$(");
   });
 

--- a/test/unit/mcp-cli-review-pr.test.ts
+++ b/test/unit/mcp-cli-review-pr.test.ts
@@ -1,0 +1,212 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { closeFixtureServer, createPacketRepo, run, runAsync, startFixtureServer } from "./support/mcp-cli-harness";
+
+describe("gittensory-mcp CLI — review-pr", () => {
+  let tempDir: string | null = null;
+
+  afterEach(async () => {
+    await closeFixtureServer();
+    if (tempDir) rmSync(tempDir, { recursive: true, force: true });
+    tempDir = null;
+  });
+
+  it("composes preflight + slop-risk + pr-text-lint into one passing report", async () => {
+    tempDir = createPacketRepo();
+    const url = await startFixtureServer();
+    const env = {
+      GITTENSORY_API_URL: url,
+      GITTENSORY_TOKEN: "session-token",
+      GITTENSORY_SKIP_NPM_VERSION_CHECK: "true",
+    };
+
+    const json = JSON.parse(
+      await runAsync(
+        [
+          "review-pr",
+          "--login",
+          "JSONbored",
+          "--cwd",
+          tempDir,
+          "--repo",
+          "JSONbored/gittensory",
+          "--commit",
+          "feat(mcp): add review-pr command",
+          "--body",
+          "Composes preflight + slop-risk + lint-pr-text into one report. Validated with npm test.",
+          "--linked-issue",
+          "1968",
+          "--json",
+        ],
+        env,
+      ),
+    ) as {
+      overallStatus: string;
+      sections: Array<{ name: string; status: string }>;
+      preflight: { status: string };
+      slopRisk?: { slopRisk: number; band: string };
+      prTextLint?: { verdict: string; score: number };
+      slopRiskError?: string;
+      prTextLintError?: string;
+    };
+
+    expect(json.overallStatus).toBe("pass");
+    expect(json.sections).toEqual([
+      { name: "preflight", status: "pass" },
+      { name: "slop_risk", status: "pass" },
+      { name: "pr_text_lint", status: "pass" },
+    ]);
+    expect(json.preflight.status).toBe("ready");
+    expect(json.slopRisk).toMatchObject({ band: "clean" });
+    expect(json.prTextLint).toMatchObject({ verdict: "strong" });
+    expect(json.slopRiskError).toBeUndefined();
+    expect(json.prTextLintError).toBeUndefined();
+    expect(JSON.stringify(json)).not.toMatch(/wallet|hotkey|coldkey|reward|trust score/i);
+
+    const plain = await runAsync(
+      [
+        "review-pr",
+        "--login",
+        "JSONbored",
+        "--cwd",
+        tempDir,
+        "--repo",
+        "JSONbored/gittensory",
+        "--commit",
+        "feat(mcp): add review-pr command",
+        "--body",
+        "Composes preflight + slop-risk + lint-pr-text into one report. Validated with npm test.",
+        "--linked-issue",
+        "1968",
+      ],
+      env,
+    );
+    expect(plain).toMatch(/Pre-PR review: pass/);
+    expect(plain).toMatch(/- preflight: pass/);
+    expect(plain).toMatch(/- slop_risk: pass/);
+    expect(plain).toMatch(/- pr_text_lint: pass/);
+    expect(plain).toMatch(/Slop risk: 0 \(clean\)/);
+    expect(plain).toMatch(/PR text lint: strong \(score 100\)/);
+  });
+
+  it("flags a warn overall status when the PR body is empty (weak lint verdict)", async () => {
+    tempDir = createPacketRepo();
+    const url = await startFixtureServer();
+    const env = {
+      GITTENSORY_API_URL: url,
+      GITTENSORY_TOKEN: "session-token",
+      GITTENSORY_SKIP_NPM_VERSION_CHECK: "true",
+    };
+
+    const json = JSON.parse(await runAsync(["review-pr", "--login", "JSONbored", "--cwd", tempDir, "--repo", "JSONbored/gittensory", "--json"], env)) as {
+      overallStatus: string;
+      sections: Array<{ name: string; status: string }>;
+      prTextLint: { verdict: string };
+    };
+    expect(json.prTextLint.verdict).toBe("weak");
+    expect(json.sections.find((section) => section.name === "pr_text_lint")).toMatchObject({ status: "warn" });
+    expect(json.overallStatus).toBe("warn");
+  });
+
+  it("reads the PR body from --body-file", async () => {
+    tempDir = createPacketRepo();
+    const url = await startFixtureServer();
+    const env = {
+      GITTENSORY_API_URL: url,
+      GITTENSORY_TOKEN: "session-token",
+      GITTENSORY_SKIP_NPM_VERSION_CHECK: "true",
+    };
+    const bodyPath = join(tempDir, "pr-body.md");
+    writeFileSync(bodyPath, "Fixes #1968\n\nValidated with npm test.", "utf8");
+
+    const json = JSON.parse(
+      await runAsync(
+        ["review-pr", "--login", "JSONbored", "--cwd", tempDir, "--repo", "JSONbored/gittensory", "--body-file", bodyPath, "--linked-issue", "1968", "--json"],
+        env,
+      ),
+    ) as { prTextLint: { verdict: string } };
+    expect(json.prTextLint.verdict).toBe("strong");
+  });
+
+  it("degrades gracefully when the slop-risk endpoint fails, without losing the other sections", async () => {
+    tempDir = createPacketRepo();
+    const url = await startFixtureServer({ slopRiskStatus: 500 });
+    const env = {
+      GITTENSORY_API_URL: url,
+      GITTENSORY_TOKEN: "session-token",
+      GITTENSORY_SKIP_NPM_VERSION_CHECK: "true",
+    };
+
+    const json = JSON.parse(
+      await runAsync(
+        ["review-pr", "--login", "JSONbored", "--cwd", tempDir, "--repo", "JSONbored/gittensory", "--body", "Validated with npm test.", "--linked-issue", "1968", "--json"],
+        env,
+      ),
+    ) as {
+      overallStatus: string;
+      sections: Array<{ name: string; status: string }>;
+      slopRisk?: unknown;
+      slopRiskError?: string;
+      prTextLint?: { verdict: string };
+    };
+    expect(json.slopRisk).toBeUndefined();
+    expect(json.slopRiskError).toMatch(/Gittensory API 500/);
+    expect(json.sections.find((section) => section.name === "slop_risk")).toMatchObject({ status: "fail" });
+    expect(json.overallStatus).toBe("fail");
+    // The pr-text-lint section still succeeded even though slop-risk failed.
+    expect(json.prTextLint).toMatchObject({ verdict: "strong" });
+
+    const plain = await runAsync(
+      ["review-pr", "--login", "JSONbored", "--cwd", tempDir, "--repo", "JSONbored/gittensory", "--body", "Validated with npm test.", "--linked-issue", "1968"],
+      env,
+    );
+    expect(plain).toMatch(/Slop risk: unavailable \(Gittensory API 500/);
+    expect(plain).toMatch(/PR text lint: strong/);
+  });
+
+  it("degrades gracefully when the pr-text-lint endpoint fails, without losing the other sections", async () => {
+    tempDir = createPacketRepo();
+    const url = await startFixtureServer({ prTextLintStatus: 503 });
+    const env = {
+      GITTENSORY_API_URL: url,
+      GITTENSORY_TOKEN: "session-token",
+      GITTENSORY_SKIP_NPM_VERSION_CHECK: "true",
+    };
+
+    const json = JSON.parse(
+      await runAsync(
+        ["review-pr", "--login", "JSONbored", "--cwd", tempDir, "--repo", "JSONbored/gittensory", "--body", "Validated with npm test.", "--linked-issue", "1968", "--json"],
+        env,
+      ),
+    ) as {
+      overallStatus: string;
+      sections: Array<{ name: string; status: string }>;
+      slopRisk?: { band: string };
+      prTextLint?: unknown;
+      prTextLintError?: string;
+    };
+    expect(json.prTextLint).toBeUndefined();
+    expect(json.prTextLintError).toMatch(/Gittensory API 503/);
+    expect(json.sections.find((section) => section.name === "pr_text_lint")).toMatchObject({ status: "fail" });
+    expect(json.overallStatus).toBe("fail");
+    expect(json.slopRisk).toMatchObject({ band: "clean" });
+  });
+
+  it("requires --login", async () => {
+    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    await expect(runAsync(["review-pr", "--cwd", tempDir], {})).rejects.toThrow(/Pass --login/);
+  });
+
+  it("prints help", () => {
+    const help = run(["review-pr", "--help"]);
+    expect(help).toMatch(/Usage: gittensory-mcp review-pr/);
+    expect(help).toMatch(/gittensory_review_pr_before_push/);
+    expect(help).toMatch(/preflight \+ slop-risk \+ PR-text-lint/);
+  });
+
+  it("suggests review-pr for close typos", () => {
+    expect(() => run(["review-pr-x"])).toThrow(/Did you mean `review-pr`\?/);
+  });
+});

--- a/test/unit/support/mcp-cli-harness.ts
+++ b/test/unit/support/mcp-cli-harness.ts
@@ -110,6 +110,8 @@ export async function startFixtureServer(
     repoDecisionErrorContentType?: string;
     packetMarkdown?: string;
     localBranchAnalysis?: unknown;
+    slopRiskStatus?: number;
+    prTextLintStatus?: number;
     onPacketRequest?: (body: unknown) => void;
     onApiRequest?: (request: IncomingMessage) => void;
   } = {},
@@ -230,11 +232,23 @@ export async function startFixtureServer(
       return;
     }
     if (request.url === "/v1/lint/pr-text" && request.method === "POST") {
+      if (options.prTextLintStatus && options.prTextLintStatus >= 400) {
+        await readJsonRequest(request);
+        response.statusCode = options.prTextLintStatus;
+        response.end(JSON.stringify({ error: "pr_text_lint_unavailable" }));
+        return;
+      }
       const body = (await readJsonRequest(request)) as { commitMessages?: string[]; prBody?: string; linkedIssue?: number };
       response.end(JSON.stringify(lintPrTextFixture(body)));
       return;
     }
     if (request.url === "/v1/lint/slop-risk" && request.method === "POST") {
+      if (options.slopRiskStatus && options.slopRiskStatus >= 400) {
+        await readJsonRequest(request);
+        response.statusCode = options.slopRiskStatus;
+        response.end(JSON.stringify({ error: "slop_risk_unavailable" }));
+        return;
+      }
       const body = (await readJsonRequest(request)) as {
         changedFiles?: Array<{ path: string; additions?: number; deletions?: number }>;
         description?: string;


### PR DESCRIPTION
## Summary

- Closes #1968. Adds `gittensory-mcp review-pr` (and a matching `gittensory_review_pr_before_push` MCP tool) that composes the existing `preflight` (analyzeCurrentBranch), `POST /v1/lint/slop-risk`, and `POST /v1/lint/pr-text` checks into ONE pre-PR review report, so a contributor's own local agent (Claude Code, Codex, etc.) can run one command and see everything the gittensory gate would flag before ever opening a PR.
- It is a thin composition layer: it does not reimplement any of the underlying checks, it calls the same API endpoints `preflight`/`slop-risk`/`lint-pr-text` already call and merges their output into `{ preflight, slopRisk, prTextLint, overallStatus, sections }`.
- Each sub-check is isolated with its own try/catch, so a single flaky endpoint degrades only that section to `fail` with a public-safe error reason (`slopRiskError`/`prTextLintError`) instead of losing the sections that did succeed — this fail-safe behavior has a dedicated regression test for each check.
- `doctor`'s default "next command" fallback (shown when no other diagnostic is more urgent) now points at `review-pr` instead of plain `preflight`, since it is the superset check a contributor should run before opening a PR. Updated the two existing doctor tests that asserted the old exact command string.
- Documented the new command in `packages/gittensory-mcp/README.md` (usage line + a dedicated "Review your PR locally before you push" section) and in the CLI's own `--help` usage listing.

Design note (conservative scope decision): the issue's example name was `predict-gate`, but this package has no `gittensory_predict_gate` tool or `/v1/predict-gate`-style endpoint today — the closest existing "gate preflight" surface is `preflight`/`analyzeCurrentBranch`, which is what's composed here alongside slop-risk and PR-text lint. No new backend endpoint was added; this is CLI/MCP-package-only, per the issue's explicit "thin composition, don't reimplement" instruction.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate. — not run: this change touches only `packages/gittensory-mcp/**` (plain `.js`, outside Codecov's `src/**/*.ts` include) and `test/**` (Codecov-ignored), so it owes no patch coverage; ran the full unsharded `npx vitest run test/unit/` instead (490 files / 9889 tests passed) plus the new/changed MCP CLI test files directly.
- [ ] `npm run test:workers` — not run; this change does not touch `test/workers/**` or any Cloudflare Worker code.
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check` — not run; no API routes or OpenAPI schemas changed.
- [ ] `npm run ui:lint` / `npm run ui:typecheck` / `npm run ui:build` — not run; no `apps/gittensory-ui/**` files changed.
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — `test/unit/mcp-cli-review-pr.test.ts` (8 new tests: pass, warn/weak-lint, `--body-file`, slop-risk API failure degradation, pr-text-lint API failure degradation, missing `--login`, `--help`, typo-suggestion) plus updated `test/unit/mcp-cli-doctor.test.ts` assertions for the new default next-command string.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no auth/CORS/session behavior changed (the new command reuses the existing `apiPost` auth requirement unchanged).
- [x] API/OpenAPI/MCP behavior is updated and tested where needed (new MCP tool `gittensory_review_pr_before_push`, tested via the equivalent CLI command against the same composed function).
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots... — N/A, no visible UI changes (CLI/MCP package only).
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs — README updated; `CHANGELOG.md` untouched (generated at release).

## UI Evidence

N/A — no visible UI changes; this PR is scoped to the `@jsonbored/gittensory-mcp` CLI/MCP package.

## Notes

- Verified locally: `npm run typecheck`, `npm run actionlint`, `npm audit --audit-level=moderate`, `npm run build:mcp`, `npm run test:mcp-pack`, `npm run command-reference:check`, `npm run docs:drift-check` all pass; `npx vitest run test/unit/` (490 files / 9889 tests) passes in full.