### PR TITLE
fix(review): count additions for auto-review size caps

### DIFF
--- a/src/review/review-diff.ts
+++ b/src/review/review-diff.ts
@@ -35,15 +35,25 @@ export function addedLineCount(patch: string | undefined): number {
   return n;
 }
 
+function numericAddedLineCount(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
 /** Sum added-line counts across a PR file list — used by auto-review size-cap eligibility (#2065). */
 export function totalAddedLineCount(
-  files: readonly { patch?: string | null | undefined; payload?: { patch?: unknown } | null | undefined }[],
+  files: readonly {
+    additions?: number | null | undefined;
+    patch?: string | null | undefined;
+    payload?: { additions?: unknown; patch?: unknown } | null | undefined;
+  }[],
 ): number {
   let total = 0;
   for (const file of files) {
+    const metadataCount =
+      numericAddedLineCount(file.additions) ?? numericAddedLineCount(file.payload?.additions);
     const patch =
       file.patch ?? (typeof file.payload?.patch === "string" ? file.payload.patch : undefined);
-    total += addedLineCount(patch);
+    total += metadataCount ?? addedLineCount(patch);
   }
   return total;
 }

--- a/test/unit/review-diff.test.ts
+++ b/test/unit/review-diff.test.ts
@@ -58,16 +58,27 @@ describe("addedLineCount — counts +lines, ignores +++ header", () => {
 });
 
 describe("totalAddedLineCount — sums added lines across PR files (#2065)", () => {
-  it("aggregates patch counts and treats missing patches as zero", () => {
+  it("uses GitHub additions metadata for patchless files so oversized diffs cannot bypass caps", () => {
     expect(totalAddedLineCount([
       { patch: "@@\n+a\n+b" },
-      { patch: "@@\n+c" },
+      { additions: 5, patch: null },
+      { payload: { additions: 7 } },
+      { payload: { patch: "@@\n+c" } },
       { patch: null },
-      { payload: { patch: "@@\n+d" } },
       { payload: {} },
       {},
-    ])).toBe(4);
+    ])).toBe(15);
     expect(totalAddedLineCount([])).toBe(0);
+  });
+
+  it("falls back to patches when additions metadata is absent or non-numeric", () => {
+    expect(totalAddedLineCount([
+      { additions: null, patch: "@@\n+a" },
+      { additions: Number.NaN, patch: "@@\n+b" },
+      { additions: Number.POSITIVE_INFINITY, patch: "@@\n+c" },
+      { payload: { additions: "4", patch: "@@\n+d" } },
+      { payload: { additions: null, patch: "@@\n+e" } },
+    ])).toBe(5);
   });
 });
 


### PR DESCRIPTION
### Motivation
- Auto-review size-cap enforcement used patch-derived added-line counts only, which treats patchless or too-large file diffs as 0 and can let oversized PRs bypass configured `max_added_lines` caps. 
- The GitHub file payload already preserves authoritative `additions` metadata that should be used when available to ensure the size guard is enforced correctly.

### Description
- Add a `numericAddedLineCount` helper and change `totalAddedLineCount` to prefer stored `additions` (from `file.additions` or `file.payload.additions`) and fall back to patch-derived counts only when metadata is absent or invalid. 
- Broaden the `totalAddedLineCount` input shape to accept `additions` and `payload.additions` and use the metadata when numeric and finite. 
- Add regression unit tests that cover patchless/metadata-backed file records and the fallback behavior in `test/unit/review-diff.test.ts`. 
- Modified files: `src/review/review-diff.ts`, `test/unit/review-diff.test.ts`.

### Testing
- Ran `npx vitest run test/unit/review-diff.test.ts` and the updated unit suite passed. 
- Ran `npx tsc --noEmit --pretty false` and the TypeScript typecheck passed. 
- Ran `git diff --check` which reported no issues. 
- Attempted the full local gate with `npm run test:ci`; it progressed through early checks (typecheck, migration/schema/selfhost checks, etc.) but was terminated during the long unsharded coverage phase in this environment; `npm audit --audit-level=moderate` could not complete here due to the registry returning HTTP 403.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b7b2836d8832c940634d92425595d)