### PR TITLE
fix(review): skip open-PR refresh for uninstalled registry repos in the regate sweep

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -1332,7 +1332,14 @@ async function refreshOpenPullRequestsForScheduledSweep(
   requestedBy: "schedule" | "api" | "test",
 ): Promise<void> {
   if (requestedBy !== "schedule") return;
-  if (!repo || !sweepOpenPullRequestSyncCredentialAvailable(env, repo)) return;
+  // No installation -> no per-PR regate fan-out will ever happen for this repo (the candidate-selection
+  // gate below only dispatches agent-regate-pr jobs for installed repos), so refreshing its open-PR list
+  // here only spends the shared GITHUB_PUBLIC_TOKEN budget on data nothing in THIS sweep will use. A
+  // registry-only repo (registry/sync.ts, isRegistered) still gets its own data kept fresh by the
+  // dedicated backfill-registered-repos/refresh-registry jobs, so skipping here is pure waste removal,
+  // not a functionality gap (#audit-rate-headroom, #sweep-uninstalled-budget-waste).
+  if (!repo?.installationId) return;
+  if (!sweepOpenPullRequestSyncCredentialAvailable(env, repo)) return;
   const segment = await getRepoSyncSegment(
     env,
     repo.fullName,

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -6737,6 +6737,54 @@ describe("queue processors", () => {
     warn.mockRestore();
   });
 
+  it("REGRESSION (#sweep-uninstalled-budget-waste): a scheduled sweep never refreshes open PRs (via the shared GITHUB_PUBLIC_TOKEN) for a registered-but-uninstalled repo, since no per-PR fan-out will ever follow", async () => {
+    const sent: import("../../src/types").JobMessage[] = [];
+    const env = createTestEnv({
+      GITHUB_PUBLIC_TOKEN: "public-token",
+      JOBS: {
+        async send(m: import("../../src/types").JobMessage) {
+          sent.push(m);
+        },
+      } as unknown as Queue,
+    });
+    // Registered (e.g. via the subnet registry sync) but NOT installed — no installationId.
+    await upsertRepositoryFromGitHub(env, { name: "no-install", full_name: "owner/no-install", private: false, owner: { login: "owner" } });
+    await upsertRepositorySettings(env, { repoFullName: "owner/no-install", autonomy: { merge: "auto" } });
+    const segmentSpy = vi.spyOn(repositoriesModule, "getRepoSyncSegment");
+    const backfillSpy = vi.spyOn(backfillModule, "backfillRepositorySegment");
+    vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
+
+    await processJob(env, { type: "agent-regate-sweep", requestedBy: "schedule", repoFullName: "owner/no-install" });
+
+    expect(segmentSpy).not.toHaveBeenCalled();
+    expect(backfillSpy).not.toHaveBeenCalled();
+    expect(sent.filter((job) => job.type === "agent-regate-pr")).toEqual([]);
+    segmentSpy.mockRestore();
+    backfillSpy.mockRestore();
+  });
+
+  it("scheduled sweeps DO still refresh open PRs for an installed repo even when GITHUB_PUBLIC_TOKEN is also configured (installation presence gates the skip, not credential kind)", async () => {
+    const sent: import("../../src/types").JobMessage[] = [];
+    const env = createTestEnv({
+      GITHUB_PUBLIC_TOKEN: "public-token",
+      JOBS: {
+        async send(m: import("../../src/types").JobMessage) {
+          sent.push(m);
+        },
+      } as unknown as Queue,
+    });
+    await upsertInstallation(env, { action: "created", installation: { id: 9405, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: {}, events: [] } });
+    await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9405);
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto" }, gateCheckMode: "off", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    const backfillSpy = vi.spyOn(backfillModule, "backfillRepositorySegment").mockResolvedValueOnce(undefined as never);
+    vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
+
+    await processJob(env, { type: "agent-regate-sweep", requestedBy: "schedule", repoFullName: "owner/agent-repo" });
+
+    expect(backfillSpy).toHaveBeenCalledWith(env, expect.objectContaining({ segment: "open_pull_requests", mode: "light", force: true }));
+    backfillSpy.mockRestore();
+  });
+
   it("scheduled sweeps refresh incomplete open-PR sync segments", async () => {
     const sent: import("../../src/types").JobMessage[] = [];
     const env = createTestEnv({


### PR DESCRIPTION
## Summary

- The scheduled `agent-regate-sweep` refreshed open-PR data via the shared `GITHUB_PUBLIC_TOKEN` for every repo in the subnet registry (`registry/sync.ts`, `isRegistered`), including repos with no installed GitHub App at all. The per-PR re-review fan-out already skips uninstalled repos entirely (existing, unchanged behavior, covered by pre-existing tests), so this refresh was pure waste: it burned real, shared REST budget on data nothing downstream would use.
- Confirmed live in production: dozens of registered-but-uninstalled repos (no `installationId`) were refreshing their open-PR lists on every sweep tick, draining the shared public-token budget. Combined with the sweep's staggered per-repo dispatch (`delaySeconds = index * 10`, up to 10 minutes), repos dispatched later in a rollout — including this instance's own actively-installed repos — could see an already-drained shared budget, causing real contributor PRs to go unreviewed for hours.
- Fix: `refreshOpenPullRequestsForScheduledSweep` now returns early when the repo has no `installationId`, before touching the shared credential/segment-refresh path at all.

No issue link: small, self-evident production-driven fix; root-caused today via live audit-log investigation (git history for `src/queue/processors.ts` shows same-day narrow fixes without an issue link are an established pattern here).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally (full unsharded run: 93.52% stmts / 92.46% branches / 92.8% funcs / 94.19% lines — all above threshold; new/changed lines in `processors.ts` covered by 2 new regression tests, one per branch of the new conditional)
- [ ] `npm run test:workers` — not re-run locally this pass (no Workers-pool-specific code touched); CI will run it
- [ ] `npm run build:mcp` — not re-run locally this pass (no MCP package touched); CI will run it
- [ ] `npm run test:mcp-pack` — not re-run locally this pass; CI will run it
- [ ] `npm run ui:openapi:check` — not re-run locally this pass (no API/schema change); CI will run it
- [x] `npm run ui:lint` — N/A, no UI files touched
- [x] `npm run ui:typecheck` — N/A, no UI files touched
- [x] `npm run ui:build` — N/A, no UI files touched
- [x] `npm audit --audit-level=moderate` — not re-run this pass; no dependency changes in this diff
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This is a live production-incident fix pushed under time pressure with real contributor PRs stuck unreviewed. Ran the checks most relevant to this diff's actual surface (typecheck, targeted + full-suite coverage, actionlint, git diff --check) rather than the full `test:ci` chain; the untouched areas above (MCP, UI, Workers pool, OpenAPI) have zero overlap with this change (`src/queue/processors.ts` + `test/unit/queue.test.ts` only) and CI will run them regardless.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no such changes)
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — internal scheduling logic only)
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A)
- [ ] Visible UI changes include a `UI Evidence` section below. (N/A — no UI/visual change)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- A second, related fix (scoping the shared rate-limit admission check per-installation instead of grabbing the globally-latest observation) is still in progress as a follow-up — this PR addresses the primary driver of the shared-budget drain but the admission check itself remains unscoped as defense-in-depth.