### PR TITLE
feat(review): add maintainer review recap digest builder + Discord delivery

### DIFF
--- a/.gittensory.yml.example
+++ b/.gittensory.yml.example
@@ -929,3 +929,13 @@ settings:
 #   allowOverwriteExisting: false  # Bool. Opt-in to propose overwriting a hand-maintained, non-generated
 #                                   # AGENTS.md/CLAUDE.md. Default: false (left alone if not recognizably generated).
 #   refreshIntervalDays: 7   # Positive integer. Minimum days between scheduled refresh attempts. Default: 7.
+
+# Maintainer review recap digest (#1963): opt-in only, off by default. Uncomment to let Gittensory build a
+# periodic summary of recent review activity (PRs merged/closed, gate merge precision) for this repo. Discord
+# delivery only for now (reuses the same per-repo webhook resolution as the per-PR notifier); Slack is a
+# follow-up. There is no DB-backed dashboard counterpart -- precedence is simply this manifest value, or
+# fully disabled when the block (or `enabled`) is absent. This PR ships the builder + a manually-triggerable
+# delivery only -- the scheduled cron trigger is a scoped follow-up.
+# reviewRecap:
+#   enabled: true    # Bool. Default: false (no recap is ever built or posted).
+#   cadenceDays: 7   # Positive integer. Days of activity each recap covers. Default: 7 (weekly).

--- a/apps/gittensory-ui/public/openapi.json
+++ b/apps/gittensory-ui/public/openapi.json
@@ -16494,6 +16494,29 @@
           }
         ]
       }
+    },
+    "/v1/internal/jobs/generate-review-recap": {
+      "post": {
+        "responses": {
+          "202": {
+            "description": "Maintainer review recap digest queued (#1963)"
+          },
+          "400": {
+            "description": "Missing repoFullName"
+          },
+          "401": {
+            "description": "Invalid internal token"
+          }
+        },
+        "security": [
+          {
+            "GittensoryBearer": []
+          },
+          {
+            "GittensorySessionCookie": []
+          }
+        ]
+      }
     }
   },
   "servers": [

--- a/config/examples/gittensory.full.yml
+++ b/config/examples/gittensory.full.yml
@@ -942,3 +942,13 @@ settings:
 #   allowOverwriteExisting: false  # Bool. Opt-in to propose overwriting a hand-maintained, non-generated
 #                                   # AGENTS.md/CLAUDE.md. Default: false (left alone if not recognizably generated).
 #   refreshIntervalDays: 7   # Positive integer. Minimum days between scheduled refresh attempts. Default: 7.
+
+# Maintainer review recap digest (#1963): opt-in only, off by default. Uncomment to let Gittensory build a
+# periodic summary of recent review activity (PRs merged/closed, gate merge precision) for this repo. Discord
+# delivery only for now (reuses the same per-repo webhook resolution as the per-PR notifier); Slack is a
+# follow-up. There is no DB-backed dashboard counterpart -- precedence is simply this manifest value, or
+# fully disabled when the block (or `enabled`) is absent. This PR ships the builder + a manually-triggerable
+# delivery only -- the scheduled cron trigger is a scoped follow-up.
+# reviewRecap:
+#   enabled: true    # Bool. Default: false (no recap is ever built or posted).
+#   cadenceDays: 7   # Positive integer. Days of activity each recap covers. Default: 7 (weekly).

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -195,6 +195,7 @@ import {
   generateWeeklyValueReport,
   loadWeeklyValueReport,
 } from "../services/weekly-value-report";
+import { generateAndSendReviewRecap } from "../services/review-recap";
 import { loadOrComputeIssueQualityResponse } from "../services/issue-quality";
 import { loadOrComputeBurdenForecastResponse } from "../services/burden-forecast";
 import { buildUnavailableQueueTrendReport } from "../services/queue-trends";
@@ -3588,6 +3589,19 @@ export function createApp() {
     return c.json({ ok: true, status: "queued", variant, days }, 202);
   });
 
+  // Maintainer review recap digest (#1963): manually-triggerable only in this PR (no scheduled cron trigger
+  // yet -- see the queue processor's "generate-review-recap" case). Config-gated on reviewRecap.enabled at
+  // the processor, so queuing a job for a repo that hasn't opted in is a documented no-op, not an error.
+  app.post("/v1/internal/jobs/generate-review-recap", async (c) => {
+    const body = await c.req.json().catch(() => ({}));
+    const repoFullName = typeof body?.repoFullName === "string" ? body.repoFullName : undefined;
+    if (!repoFullName) return c.json({ ok: false, error: "repoFullName is required" }, 400);
+    const windowDays = Number.isFinite(Number(body?.windowDays)) ? Math.max(1, Math.min(90, Math.round(Number(body.windowDays)))) : undefined;
+    const message: JobMessage = { type: "generate-review-recap", requestedBy: "api", repoFullName, ...(windowDays === undefined ? {} : { windowDays }) };
+    await c.env.JOBS.send(message);
+    return c.json({ ok: true, status: "queued", repoFullName, windowDays }, 202);
+  });
+
   app.post("/v1/internal/jobs/repair-data-fidelity", async (c) => {
     const message: JobMessage = { type: "repair-data-fidelity", requestedBy: "api" };
     await c.env.JOBS.send(message);
@@ -3613,6 +3627,22 @@ export function createApp() {
     const days = Number.isFinite(Number(body?.days)) ? Math.max(1, Math.min(31, Math.round(Number(body.days)))) : undefined;
     const variant = body?.variant === "public" ? "public" : "operator";
     return c.json(await generateWeeklyValueReport(c.env, { variant, ...(days === undefined ? {} : { days }) }));
+  });
+
+  // Same reviewRecap.enabled gate as the queued path above (#1963) -- an immediate "/run" still respects the
+  // per-repo opt-in, since (unlike generate-weekly-value-report/run) this has a real side effect: posting to
+  // the repo's configured Discord channel.
+  app.post("/v1/internal/jobs/generate-review-recap/run", async (c) => {
+    const body = await c.req.json().catch(() => ({}));
+    const repoFullName = typeof body?.repoFullName === "string" ? body.repoFullName : undefined;
+    if (!repoFullName) return c.json({ ok: false, error: "repoFullName is required" }, 400);
+    const windowDays = Number.isFinite(Number(body?.windowDays)) ? Math.max(1, Math.min(90, Math.round(Number(body.windowDays)))) : undefined;
+    const manifest = await loadRepoFocusManifest(c.env, repoFullName).catch(() => null);
+    if (!manifest?.reviewRecap.enabled) {
+      return c.json({ ok: false, status: "skipped", reason: "reviewRecap is not enabled for this repository (.gittensory.yml reviewRecap.enabled)" }, 200);
+    }
+    const { recap, delivery } = await generateAndSendReviewRecap(c.env, repoFullName, { windowDays: windowDays ?? manifest.reviewRecap.cadenceDays });
+    return c.json({ ok: true, recap, delivery });
   });
 
   app.post("/v1/internal/jobs/refresh-installation-health/run", async (c) => {

--- a/src/openapi/spec.ts
+++ b/src/openapi/spec.ts
@@ -946,6 +946,15 @@ export function buildOpenApiSpec() {
       401: { description: "Invalid internal token" },
     },
   });
+  registry.registerPath({
+    method: "post",
+    path: "/v1/internal/jobs/generate-review-recap",
+    responses: {
+      202: { description: "Maintainer review recap digest queued (#1963)" },
+      400: { description: "Missing repoFullName" },
+      401: { description: "Invalid internal token" },
+    },
+  });
   for (const path of [
     "/v1/internal/jobs/refresh-scoring-model",
     "/v1/internal/jobs/refresh-upstream-drift",

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -289,6 +289,7 @@ import {
 import { processSubmitDraft } from "../services/draft";
 import { loadIssueQualityReportMap } from "../services/issue-quality";
 import { generateWeeklyValueReport } from "../services/weekly-value-report";
+import { generateAndSendReviewRecap } from "../services/review-recap";
 import {
   REPO_OUTCOME_PATTERNS_SIGNAL,
   computeRepoOutcomePatterns,
@@ -1022,6 +1023,9 @@ export async function processJob(env: Env, message: JobMessage): Promise<void> {
         variant: message.variant ?? "operator",
         ...(message.days === undefined ? {} : { days: message.days }),
       });
+      return;
+    case "generate-review-recap":
+      await runReviewRecapJob(env, message.repoFullName, message.windowDays);
       return;
     case "agent-regate-sweep":
       if (!message.repoFullName && message.requestedBy !== "test") {
@@ -1853,6 +1857,21 @@ async function fanOutBacklogConvergenceSweepJobs(
     eventType: "agent.sweep.backlog_convergence.fanout",
     outcome: "queued",
     metadata: { repoCount: configured.length, requestedBy },
+  });
+}
+
+// Maintainer review recap digest (#1963): build the recap for one repo and post it to Discord, gated on
+// this repo's `.gittensory.yml reviewRecap.enabled` (default OFF, mirrors repoDocGeneration.enabled below) --
+// fail-safe: a repo with no `reviewRecap:` block, or a manifest load failure, never posts. Config-gated at
+// THIS single call site (not inside generateAndSendReviewRecap itself) because this PR has no fan-out sweep
+// yet; the eventual scheduled trigger will enumerate opted-in repos the same way fanOutRepoDocRefreshSweepJobs
+// does, and can call generateAndSendReviewRecap directly since the enumeration step already filtered on
+// `.enabled` -- this per-call gate is what keeps a MANUAL trigger against a non-opted-in repo a no-op too.
+async function runReviewRecapJob(env: Env, repoFullName: string, windowDays: number | undefined): Promise<void> {
+  const manifest = await loadRepoFocusManifest(env, repoFullName).catch(() => null);
+  if (!manifest?.reviewRecap.enabled) return;
+  await generateAndSendReviewRecap(env, repoFullName, {
+    windowDays: windowDays ?? manifest.reviewRecap.cadenceDays,
   });
 }
 

--- a/src/selfhost/config-lint.ts
+++ b/src/selfhost/config-lint.ts
@@ -16,6 +16,7 @@ const TOP_LEVEL_FIELDS = [
   "features",
   "contentLane",
   "repoDocGeneration",
+  "reviewRecap",
 ] as const;
 
 const TOP_LEVEL_FIELD_SET = new Set<string>(TOP_LEVEL_FIELDS);

--- a/src/selfhost/maintenance-admission.ts
+++ b/src/selfhost/maintenance-admission.ts
@@ -52,6 +52,7 @@ export const MAINTENANCE_JOB_TYPES: ReadonlySet<string> = new Set([
   "rollup-product-usage",
   "prune-retention",
   "generate-weekly-value-report",
+  "generate-review-recap",
   "generate-signal-snapshots",
   "notify-evaluate",
   "notify-deliver",

--- a/src/services/review-recap.ts
+++ b/src/services/review-recap.ts
@@ -1,0 +1,203 @@
+// Maintainer review recap digest (#1963, Discord delivery only — Slack is a follow-up). A periodic AGGREGATE
+// summary of recent review activity (merged/closed PR counts + gate precision), distinct from
+// notify-discord.ts's PER-EVENT terminal-action notifier: this fires on a cadence, not once per PR outcome.
+//
+// Pure aggregation only — reuses already-computed stats instead of a new ledger: PR merged/closed counts come
+// straight from the `pull_requests` table (listPullRequests), and gate precision reuses computeGateEval
+// (src/review/parity.ts), which already scores the gate's `merge` predictions against the realized human
+// outcome (pr_outcome). No raw trust/reward/scoring internals are read or surfaced here.
+//
+// SCOPE (this PR, #1963): the pure builder (buildReviewRecap) + a manually-triggerable Discord delivery path
+// (generateAndSendReviewRecap, reusing resolveDiscordWebhook from notify-discord.ts — no second webhook
+// resolution mechanism). The scheduled cron trigger (mirroring the weekly-value-report cron wiring in
+// src/index.ts) is a clear, scoped follow-up — see the PR description.
+import { listPullRequests, recordAuditEvent } from "../db/repositories";
+import { computeGateEval } from "../review/parity";
+import { resolveDiscordWebhook } from "./notify-discord";
+import type { ReviewRecap } from "../types";
+import { errorMessage, nowIso } from "../utils/json";
+import { PUBLIC_LOCAL_PATH_SCRUB_PATTERN } from "../signals/redaction";
+
+const DEFAULT_WINDOW_DAYS = 7;
+const MIN_WINDOW_DAYS = 1;
+const MAX_WINDOW_DAYS = 90;
+
+/** Clamp an arbitrary window-days input to a sane range; non-finite/omitted falls back to the weekly default.
+ *  Mirrors normalizeReportDays in weekly-value-report.ts (same clamp shape, different bounds/default). */
+function normalizeWindowDays(value: number | null | undefined): number {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) return DEFAULT_WINDOW_DAYS;
+  return Math.max(MIN_WINDOW_DAYS, Math.min(MAX_WINDOW_DAYS, Math.round(numeric)));
+}
+
+/** Public-safe scrub for any free text pulled into the recap (defense in depth — repo full names and counts
+ *  are the only inputs today, but this keeps the surface honest if a future field adds free text). */
+function sanitizeRecapText(value: string): string {
+  return value.replace(PUBLIC_LOCAL_PATH_SCRUB_PATTERN, "<redacted-path>").slice(0, 240);
+}
+
+type ReviewRecapInputs = {
+  repoFullName: string;
+  generatedAt: string;
+  windowDays?: number | null | undefined;
+  pullRequests: Array<{
+    mergedAt?: string | null | undefined;
+    state: string;
+    closedAt?: string | null | undefined;
+    updatedAt?: string | null | undefined;
+  }>;
+  gateMergePrecision: number | null;
+  gateDecided: number;
+};
+
+/** The best-available terminal timestamp for a closed-unmerged PR: `closedAt` when GitHub's payload carried
+ *  one, else `updatedAt` (always populated on write — see toPullRequestRecordFromRow) as a fallback, since a
+ *  closed PR's last update IS effectively its close time absent a dedicated column. Returns NaN (never
+ *  counted as "in window") only when BOTH are missing/unparseable. */
+function closedAtMs(pr: { closedAt?: string | null | undefined; updatedAt?: string | null | undefined }): number {
+  const closed = pr.closedAt ? Date.parse(pr.closedAt) : Number.NaN;
+  if (Number.isFinite(closed)) return closed;
+  const updated = pr.updatedAt ? Date.parse(pr.updatedAt) : Number.NaN;
+  return updated;
+}
+
+/** Pure recap builder: fold already-loaded PR rows + a gate-eval row into a {@link ReviewRecap}. A PR counts
+ *  toward the window when its terminal timestamp (mergedAt for merged, {@link closedAtMs} for closed-unmerged)
+ *  falls inside it; a PR with neither (still open) is counted separately and never inflates merged/closed. */
+export function buildReviewRecap(args: ReviewRecapInputs): ReviewRecap {
+  const windowDays = normalizeWindowDays(args.windowDays);
+  const sinceMs = Date.parse(args.generatedAt) - windowDays * 24 * 60 * 60 * 1000;
+  let merged = 0;
+  let closed = 0;
+  let stillOpen = 0;
+  for (const pr of args.pullRequests) {
+    const mergedAtMs = pr.mergedAt ? Date.parse(pr.mergedAt) : Number.NaN;
+    if (pr.mergedAt && Number.isFinite(mergedAtMs) && mergedAtMs >= sinceMs) {
+      merged += 1;
+    } else if (pr.state === "closed" && !pr.mergedAt && Number.isFinite(closedAtMs(pr)) && closedAtMs(pr) >= sinceMs) {
+      closed += 1;
+    } else if (pr.state !== "closed") {
+      stillOpen += 1;
+    }
+  }
+  const repoFullName = sanitizeRecapText(args.repoFullName);
+  const precisionLine =
+    args.gateMergePrecision !== null
+      ? `Gate merge precision: ${Math.round(args.gateMergePrecision * 100)}% (${args.gateDecided} decided prediction(s)).`
+      : `Gate merge precision: not enough decided predictions yet to report.`;
+  const summary = [
+    `${repoFullName}: ${merged} merged, ${closed} closed, ${stillOpen} still open in the last ${windowDays} day(s).`,
+    precisionLine,
+  ].map(sanitizeRecapText);
+  return {
+    repoFullName,
+    generatedAt: args.generatedAt,
+    windowDays,
+    merged,
+    closed,
+    stillOpen,
+    gatePrecision: args.gateMergePrecision,
+    gateDecided: args.gateDecided,
+    summary,
+  };
+}
+
+/** Load the inputs (PR rows for this repo + the repo's gate-eval row) and build the recap. Pure read;
+ *  fail-safe defaults (empty PR list, null precision) if computeGateEval degrades (it already fails safe
+ *  to an empty report on a D1 read error — see review/parity.ts). */
+export async function loadReviewRecap(env: Env, repoFullName: string, options: { windowDays?: number; nowIso?: string } = {}): Promise<ReviewRecap> {
+  const generatedAt = options.nowIso ?? nowIso();
+  const windowDays = normalizeWindowDays(options.windowDays);
+  const nowMs = Date.parse(generatedAt);
+  const [pullRequests, gateEval] = await Promise.all([
+    listPullRequests(env, repoFullName),
+    computeGateEval(env, { days: windowDays, nowMs: Number.isFinite(nowMs) ? nowMs : Date.now() }),
+  ]);
+  const row = gateEval.rows.find((candidate) => candidate.project.toLowerCase() === repoFullName.toLowerCase());
+  return buildReviewRecap({
+    repoFullName,
+    generatedAt,
+    windowDays,
+    pullRequests,
+    gateMergePrecision: row?.mergePrecision ?? null,
+    gateDecided: row?.decided ?? 0,
+  });
+}
+
+/** Render the recap as a compact Discord embed description (reused by generateAndSendReviewRecap). */
+function formatRecapDescription(recap: ReviewRecap): string {
+  return recap.summary.join("\n").slice(0, 1800);
+}
+
+/** Post the recap to the repo's configured Discord webhook, reusing {@link resolveDiscordWebhook} — the SAME
+ *  per-repo resolution notify-discord.ts's per-event notifier uses. Best-effort: a delivery failure is
+ *  recorded to the audit ledger but never thrown (mirrors notifyActionToDiscord's fail-safe contract). */
+export async function sendReviewRecapToDiscord(env: Env, recap: ReviewRecap): Promise<{ sent: boolean; reason?: string }> {
+  const resolved = resolveDiscordWebhook(env, recap.repoFullName);
+  if (resolved.status !== "configured") {
+    await recordAuditEvent(env, {
+      eventType: "review_recap_notification.discord",
+      actor: "gittensory",
+      targetKey: `review-recap:${recap.repoFullName}:${recap.windowDays}`,
+      outcome: "denied",
+      detail: resolved.reason,
+      metadata: { repoFullName: recap.repoFullName, windowDays: recap.windowDays },
+    });
+    return { sent: false, reason: resolved.reason };
+  }
+  const body = {
+    username: "Gittensory",
+    embeds: [
+      {
+        title: `${recap.repoFullName} · review recap (${recap.windowDays}d)`,
+        description: formatRecapDescription(recap),
+        color: 0x5865f2,
+        fields: [
+          { name: "Merged", value: String(recap.merged), inline: true },
+          { name: "Closed", value: String(recap.closed), inline: true },
+          { name: "Still open", value: String(recap.stillOpen), inline: true },
+        ],
+        footer: { text: `Gittensory · ${recap.repoFullName}` },
+      },
+    ],
+  };
+  try {
+    const response = await fetch(resolved.url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!response.ok) throw new Error(`discord_webhook_http_${response.status}`);
+    await recordAuditEvent(env, {
+      eventType: "review_recap_notification.discord",
+      actor: "gittensory",
+      targetKey: `review-recap:${recap.repoFullName}:${recap.windowDays}`,
+      outcome: "completed",
+      detail: "sent",
+      metadata: { repoFullName: recap.repoFullName, windowDays: recap.windowDays, source: resolved.source },
+    });
+    return { sent: true };
+  } catch (error) {
+    const detail = errorMessage(error).slice(0, 160);
+    console.warn(JSON.stringify({ ev: "review_recap_discord_failed", repo: recap.repoFullName, message: detail }));
+    await recordAuditEvent(env, {
+      eventType: "review_recap_notification.discord",
+      actor: "gittensory",
+      targetKey: `review-recap:${recap.repoFullName}:${recap.windowDays}`,
+      outcome: "error",
+      detail,
+      metadata: { repoFullName: recap.repoFullName, windowDays: recap.windowDays },
+    });
+    return { sent: false, reason: detail };
+  }
+}
+
+/** Build the recap for one repo and deliver it to Discord in one call — the manual-trigger entry point
+ *  (`/v1/internal/jobs/generate-review-recap/run`). Always returns the recap even when delivery is denied
+ *  (e.g. no webhook configured), so the caller can inspect the computed numbers either way. */
+export async function generateAndSendReviewRecap(env: Env, repoFullName: string, options: { windowDays?: number; nowIso?: string } = {}): Promise<{ recap: ReviewRecap; delivery: { sent: boolean; reason?: string } }> {
+  const recap = await loadReviewRecap(env, repoFullName, options);
+  const delivery = await sendReviewRecapToDiscord(env, recap);
+  return { recap, delivery };
+}

--- a/src/signals/focus-manifest-loader.ts
+++ b/src/signals/focus-manifest-loader.ts
@@ -1,7 +1,7 @@
 import { listSignalSnapshots, persistSignalSnapshot } from "../db/repositories";
 import type { JsonValue } from "../types";
 import { nowIso } from "../utils/json";
-import { contentLaneConfigToJson, featuresConfigToJson, gateConfigToJson, MAX_FOCUS_MANIFEST_BYTES, parseFocusManifest, parseFocusManifestContent, repoDocGenerationConfigToJson, reviewConfigToJson, settingsOverrideToJson, type FocusManifest, type FocusManifestSource, type RepoReviewContext } from "./focus-manifest";
+import { contentLaneConfigToJson, featuresConfigToJson, gateConfigToJson, MAX_FOCUS_MANIFEST_BYTES, parseFocusManifest, parseFocusManifestContent, repoDocGenerationConfigToJson, reviewConfigToJson, reviewRecapConfigToJson, settingsOverrideToJson, type FocusManifest, type FocusManifestSource, type RepoReviewContext } from "./focus-manifest";
 import { GITTENSORY_REPO_FOCUS_MANIFEST_YAML, resolveGittensorySelfRepoFullName } from "../config/gittensory-repo-focus-manifest";
 
 export const REPO_FOCUS_MANIFEST_SIGNAL = "repo-focus-manifest";
@@ -284,6 +284,7 @@ function manifestToJson(manifest: FocusManifest): Record<string, JsonValue> {
     features: featuresConfigToJson(manifest.features),
     contentLane: contentLaneConfigToJson(manifest.contentLane),
     repoDocGeneration: repoDocGenerationConfigToJson(manifest.repoDocGeneration),
+    reviewRecap: reviewRecapConfigToJson(manifest.reviewRecap),
   };
 }
 

--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -180,6 +180,24 @@ export type FocusManifestRepoDocGenerationConfig = {
 };
 
 /**
+ * Per-repo opt-in for the periodic maintainer review-recap digest (#1963), declared as code under
+ * `reviewRecap:`. Mirrors `repoDocGeneration:` exactly: no DB-backed dashboard counterpart, so the parsed
+ * value (or the default below when unset) IS the effective value — there is no DB layer to overlay onto.
+ * Defaults to fully disabled: a repo with no `reviewRecap:` block, or an explicit `enabled: false`, never
+ * gets a recap posted. Discord delivery ONLY for now (reuses the SAME per-repo webhook resolution as the
+ * per-event notifier in notify-discord.ts, `resolveDiscordWebhook`) — Slack is a follow-up.
+ */
+export type FocusManifestReviewRecapConfig = {
+  present: boolean;
+  enabled: boolean;
+  /** How many days of review activity each recap covers, and (once the scheduler follow-up lands) how often
+   *  it is posted. Default 7 (weekly). A purely descriptive/rate-limiting knob today — this PR ships only
+   *  the manually-triggerable builder + delivery, so `cadenceDays` currently just sets the report WINDOW;
+   *  the scheduled cron trigger is a scoped follow-up (see the PR description). */
+  cadenceDays: number;
+};
+
+/**
  * Generic repository-settings override declared in `.gittensory.yml` under `settings:`. A partial of
  * {@link RepositorySettings} — every behaviour a maintainer can toggle in the dashboard can be set here
  * as code. Unset fields are omitted so the resolver layers it OVER the DB-backed settings
@@ -588,6 +606,7 @@ export type FocusManifest = {
   features: FocusManifestFeaturesConfig;
   contentLane: FocusManifestContentLaneConfig;
   repoDocGeneration: FocusManifestRepoDocGenerationConfig;
+  reviewRecap: FocusManifestReviewRecapConfig;
   warnings: string[];
 };
 
@@ -691,6 +710,14 @@ const EMPTY_REPO_DOC_GENERATION_CONFIG: FocusManifestRepoDocGenerationConfig = {
   refreshIntervalDays: DEFAULT_REPO_DOC_REFRESH_INTERVAL_DAYS,
 };
 
+const DEFAULT_REVIEW_RECAP_CADENCE_DAYS = 7;
+
+const EMPTY_REVIEW_RECAP_CONFIG: FocusManifestReviewRecapConfig = {
+  present: false,
+  enabled: false,
+  cadenceDays: DEFAULT_REVIEW_RECAP_CADENCE_DAYS,
+};
+
 const EMPTY_MANIFEST: FocusManifest = {
   present: false,
   source: "none",
@@ -707,6 +734,7 @@ const EMPTY_MANIFEST: FocusManifest = {
   features: { ...EMPTY_FEATURES_CONFIG },
   contentLane: { ...EMPTY_CONTENT_LANE_CONFIG },
   repoDocGeneration: { ...EMPTY_REPO_DOC_GENERATION_CONFIG },
+  reviewRecap: { ...EMPTY_REVIEW_RECAP_CONFIG },
   warnings: [],
 };
 
@@ -737,6 +765,7 @@ function emptyManifest(source: FocusManifestSource, warnings: string[] = []): Fo
     features: { ...EMPTY_FEATURES_CONFIG },
     contentLane: { ...EMPTY_CONTENT_LANE_CONFIG },
     repoDocGeneration: { ...EMPTY_REPO_DOC_GENERATION_CONFIG },
+    reviewRecap: { ...EMPTY_REVIEW_RECAP_CONFIG },
   };
 }
 
@@ -1266,6 +1295,29 @@ function parseRepoDocGenerationConfig(value: JsonValue | undefined, warnings: st
 export function repoDocGenerationConfigToJson(config: FocusManifestRepoDocGenerationConfig): JsonValue {
   if (!config.present) return null;
   return { enabled: config.enabled, scope: config.scope, allowOverwriteExisting: config.allowOverwriteExisting, refreshIntervalDays: config.refreshIntervalDays };
+}
+
+/**
+ * Parse the optional `reviewRecap:` mapping (#1963). Mirrors {@link parseRepoDocGenerationConfig}: every
+ * field has a concrete default (no DB layer to overlay onto), so the parsed value IS the effective value.
+ */
+function parseReviewRecapConfig(value: JsonValue | undefined, warnings: string[]): FocusManifestReviewRecapConfig {
+  if (value === undefined || value === null) return { ...EMPTY_REVIEW_RECAP_CONFIG };
+  if (typeof value !== "object" || Array.isArray(value)) {
+    warnings.push('Manifest field "reviewRecap" must be a mapping; ignoring it.');
+    return { ...EMPTY_REVIEW_RECAP_CONFIG };
+  }
+  const record = value as Record<string, JsonValue>;
+  const enabled = normalizeOptionalBoolean(record.enabled, "reviewRecap.enabled", warnings) ?? false;
+  const cadenceDays = normalizeOptionalPositiveInteger(record.cadenceDays, "reviewRecap.cadenceDays", warnings) ?? DEFAULT_REVIEW_RECAP_CADENCE_DAYS;
+  return { present: true, enabled, cadenceDays };
+}
+
+/** Serialize a reviewRecap config back into the parse-compatible shape so a cached snapshot round-trips
+ *  through {@link parseReviewRecapConfig} unchanged. Returns null when nothing is configured. */
+export function reviewRecapConfigToJson(config: FocusManifestReviewRecapConfig): JsonValue {
+  if (!config.present) return null;
+  return { enabled: config.enabled, cadenceDays: config.cadenceDays };
 }
 
 function normalizeOptionalEnum<T extends string>(value: JsonValue | undefined, field: string, allowed: readonly T[], warnings: string[]): T | null {
@@ -2801,6 +2853,7 @@ export function parseFocusManifest(raw: unknown, source?: FocusManifestSource): 
     features: parseFeaturesConfig(record.features, warnings),
     contentLane: parseContentLaneConfig(record.contentLane, warnings),
     repoDocGeneration: parseRepoDocGenerationConfig(record.repoDocGeneration, warnings),
+    reviewRecap: parseReviewRecapConfig(record.reviewRecap, warnings),
     warnings,
   };
   if (
@@ -2816,7 +2869,8 @@ export function parseFocusManifest(raw: unknown, source?: FocusManifestSource): 
     !manifest.review.present &&
     !manifest.features.present &&
     !manifest.contentLane.present &&
-    !manifest.repoDocGeneration.present
+    !manifest.repoDocGeneration.present &&
+    !manifest.reviewRecap.present
   ) {
     warnings.push("Manifest contained no recognized focus fields; falling back to deterministic signals.");
     manifest.present = false;

--- a/src/types.ts
+++ b/src/types.ts
@@ -144,6 +144,16 @@ export type JobMessage =
       days?: number;
     }
   | {
+      // Maintainer review recap digest (#1963): build the recap for one repo and post it to that repo's
+      // configured Discord webhook. Manually-triggerable only in this PR (`requestedBy: "api"`) -- the
+      // scheduled cron trigger ("schedule") is a scoped follow-up, listed here now so the union already
+      // documents the intended source without a later breaking change.
+      type: "generate-review-recap";
+      requestedBy: "schedule" | "api" | "test";
+      repoFullName: string;
+      windowDays?: number;
+    }
+  | {
       // Scheduled re-gate sweep (#777). No `repoFullName` = fan-out: enqueue one per agent-configured repo.
       // With `repoFullName` = recompute the gate verdict for that repo's stale open PRs (advisory/audit only).
       type: "agent-regate-sweep";
@@ -2174,4 +2184,22 @@ export type WeeklyValueReport = {
     }>;
     activation: ProductUsageActivationFunnel;
   };
+};
+
+/** One repo's periodic maintainer review-activity digest (#1963). Pure aggregate over already-computed
+ *  stats (pull-request outcomes + gate precision) — no new ledger, no raw trust/reward values. */
+export type ReviewRecap = {
+  repoFullName: string;
+  generatedAt: string;
+  windowDays: number;
+  /** Realized PR outcomes in the window, from the PR row's own state/mergedAt (ground truth, not a prediction). */
+  merged: number;
+  closed: number;
+  stillOpen: number;
+  /** Gate merge-precision for this repo over the SAME window, from {@link GateEvalRow.mergePrecision}.
+   *  null = no would-merge predictions with a known outcome yet (nothing to divide by). */
+  gatePrecision: number | null;
+  /** Total gate_decision predictions this report's precision rate was computed from (0 = no signal). */
+  gateDecided: number;
+  summary: string[];
 };

--- a/test/integration/routes-errors.test.ts
+++ b/test/integration/routes-errors.test.ts
@@ -6,6 +6,7 @@ import { persistSignalSnapshot, upsertInstallation, upsertRepositoryFromGitHub }
 import { handleMcpRequest } from "../../src/mcp/server";
 import { normalizeRegistryPayload } from "../../src/registry/normalize";
 import { persistRegistrySnapshot } from "../../src/registry/sync";
+import { upsertRepoFocusManifest } from "../../src/signals/focus-manifest-loader";
 import { createTestEnv } from "../helpers/d1";
 
 describe("api route guards and error branches", () => {
@@ -724,6 +725,8 @@ describe("api route guards and error branches", () => {
     expect((await app.request("/v1/internal/jobs/rollup-product-usage/run", { method: "POST" }, env)).status).toBe(401);
     expect((await app.request("/v1/internal/jobs/generate-weekly-value-report", { method: "POST" }, env)).status).toBe(401);
     expect((await app.request("/v1/internal/jobs/generate-weekly-value-report/run", { method: "POST" }, env)).status).toBe(401);
+    expect((await app.request("/v1/internal/jobs/generate-review-recap", { method: "POST" }, env)).status).toBe(401);
+    expect((await app.request("/v1/internal/jobs/generate-review-recap/run", { method: "POST" }, env)).status).toBe(401);
     expect((await app.request("/v1/internal/bounties/import", { method: "POST" }, env)).status).toBe(401);
     expect(
       (
@@ -776,6 +779,59 @@ describe("api route guards and error branches", () => {
     );
     expect(immediateWeeklyReport.status).toBe(200);
     await expect(immediateWeeklyReport.json()).resolves.toMatchObject({ variant: "operator", period: expect.objectContaining({ days: 1 }) });
+
+    // Maintainer review recap digest (#1963): repoFullName is required on both routes.
+    const missingRepo = await app.request("/v1/internal/jobs/generate-review-recap", { method: "POST", headers: internalHeaders(env), body: "{}" }, env);
+    expect(missingRepo.status).toBe(400);
+    const missingRepoRun = await app.request("/v1/internal/jobs/generate-review-recap/run", { method: "POST", headers: internalHeaders(env), body: "{}" }, env);
+    expect(missingRepoRun.status).toBe(400);
+
+    const queuedRecap = await app.request(
+      "/v1/internal/jobs/generate-review-recap",
+      { method: "POST", headers: internalHeaders(env), body: JSON.stringify({ repoFullName: "JSONbored/gittensory", windowDays: 999 }) },
+      env,
+    );
+    expect(queuedRecap.status).toBe(202);
+    await expect(queuedRecap.json()).resolves.toMatchObject({ status: "queued", repoFullName: "JSONbored/gittensory", windowDays: 90 });
+    expect(queued).toEqual(expect.arrayContaining([expect.objectContaining({ type: "generate-review-recap", repoFullName: "JSONbored/gittensory", windowDays: 90 })]));
+
+    const queuedRecapDefaultWindow = await app.request(
+      "/v1/internal/jobs/generate-review-recap",
+      { method: "POST", headers: internalHeaders(env), body: JSON.stringify({ repoFullName: "JSONbored/gittensory" }) },
+      env,
+    );
+    expect(queuedRecapDefaultWindow.status).toBe(202);
+    const queuedRecapDefaultWindowBody = await queuedRecapDefaultWindow.json();
+    expect(queuedRecapDefaultWindowBody).toMatchObject({ status: "queued", repoFullName: "JSONbored/gittensory" });
+    expect(queuedRecapDefaultWindowBody).not.toHaveProperty("windowDays");
+    expect(queued).toEqual(expect.arrayContaining([expect.objectContaining({ type: "generate-review-recap", repoFullName: "JSONbored/gittensory" })]));
+
+    // /run respects reviewRecap.enabled even for an explicit maintainer-triggered call (default-off, fail-safe).
+    const skippedRecapRun = await app.request(
+      "/v1/internal/jobs/generate-review-recap/run",
+      { method: "POST", headers: internalHeaders(env), body: JSON.stringify({ repoFullName: "JSONbored/gittensory" }) },
+      env,
+    );
+    expect(skippedRecapRun.status).toBe(200);
+    await expect(skippedRecapRun.json()).resolves.toMatchObject({ ok: false, status: "skipped" });
+
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { reviewRecap: { enabled: true, cadenceDays: 3 } });
+    const immediateRecapRun = await app.request(
+      "/v1/internal/jobs/generate-review-recap/run",
+      { method: "POST", headers: internalHeaders(env), body: JSON.stringify({ repoFullName: "JSONbored/gittensory" }) },
+      env,
+    );
+    expect(immediateRecapRun.status).toBe(200);
+    await expect(immediateRecapRun.json()).resolves.toMatchObject({ ok: true, recap: expect.objectContaining({ repoFullName: "JSONbored/gittensory", windowDays: 3 }), delivery: expect.objectContaining({ sent: false }) });
+
+    // An explicit windowDays on /run overrides the manifest's cadenceDays default.
+    const immediateRecapRunExplicitWindow = await app.request(
+      "/v1/internal/jobs/generate-review-recap/run",
+      { method: "POST", headers: internalHeaders(env), body: JSON.stringify({ repoFullName: "JSONbored/gittensory", windowDays: 14 }) },
+      env,
+    );
+    expect(immediateRecapRunExplicitWindow.status).toBe(200);
+    await expect(immediateRecapRunExplicitWindow.json()).resolves.toMatchObject({ ok: true, recap: expect.objectContaining({ repoFullName: "JSONbored/gittensory", windowDays: 14 }) });
 
     expect(
       (

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -35,6 +35,7 @@ import {
   resolveReviewVisualConfig,
   repoDocGenerationConfigToJson,
   reviewConfigToJson,
+  reviewRecapConfigToJson,
   settingsOverrideToJson,
   type FocusManifest,
   type FocusManifestContentLaneConfig,
@@ -42,6 +43,7 @@ import {
   type FocusManifestGateConfig,
   type FocusManifestRepoDocGenerationConfig,
   type FocusManifestReviewConfig,
+  type FocusManifestReviewRecapConfig,
   type FocusManifestSettings,
   type SelfHostAiModelConfig,
 } from "../../src/signals/focus-manifest";
@@ -411,6 +413,15 @@ describe(".gittensory.yml.example field-exhaustiveness (#1670)", () => {
   it.each(Object.entries(REPO_DOC_GENERATION_FIELD_TOKENS))("documents repoDocGeneration.%s", (_field, token) => {
     expect(exampleContent).toContain(token);
   });
+
+  const REVIEW_RECAP_FIELD_TOKENS = {
+    enabled: "enabled:",
+    cadenceDays: "cadenceDays:",
+  } satisfies Record<Exclude<keyof FocusManifestReviewRecapConfig, "present">, string>;
+
+  it.each(Object.entries(REVIEW_RECAP_FIELD_TOKENS))("documents reviewRecap.%s", (_field, token) => {
+    expect(exampleContent).toContain(token);
+  });
 });
 
 describe("matchesManifestPath", () => {
@@ -774,6 +785,7 @@ describe("compileFocusManifestPolicy", () => {
       features: { present: false, rag: null, reputation: null, unifiedComment: null, safety: null },
       contentLane: { present: false, entryFileGlob: null, providerFileGlob: null, artifactGlob: null, collectionField: null, maxAppendedEntries: null, duplicateKeyFields: [], validatorId: null },
       repoDocGeneration: { present: false, enabled: false, scope: ["agents"], allowOverwriteExisting: false, refreshIntervalDays: 7 },
+      reviewRecap: { present: false, enabled: false, cadenceDays: 7 },
       warnings: [],
     });
     expect(policy.publicSafe.entryGuidance).toContain("Keep PRs focused.");
@@ -1627,6 +1639,65 @@ describe("parseFocusManifest gate config", () => {
 
     it("repoDocGenerationConfigToJson returns null for an absent config", () => {
       expect(repoDocGenerationConfigToJson(parseFocusManifest(null).repoDocGeneration)).toBeNull();
+    });
+  });
+
+  describe("reviewRecap: (#1963, maintainer review recap digest config-as-code surface)", () => {
+    it("defaults to fully disabled and absent when the key is omitted, and does not make the manifest present on its own", () => {
+      const m = parseFocusManifest({});
+      expect(m.reviewRecap).toEqual({ present: false, enabled: false, cadenceDays: 7 });
+      expect(m.present).toBe(false);
+    });
+
+    it("treats an explicit null the same as an omitted key", () => {
+      expect(parseFocusManifest({ reviewRecap: null }).reviewRecap).toEqual({ present: false, enabled: false, cadenceDays: 7 });
+    });
+
+    it("warns and falls back to the default when the value is a non-mapping type (string or array)", () => {
+      const asString = parseFocusManifest({ reviewRecap: "nope" as never });
+      expect(asString.reviewRecap.present).toBe(false);
+      expect(asString.warnings.some((w) => /"reviewRecap" must be a mapping/.test(w))).toBe(true);
+      const asArray = parseFocusManifest({ reviewRecap: ["nope"] as never });
+      expect(asArray.reviewRecap.present).toBe(false);
+      expect(asArray.warnings.some((w) => /"reviewRecap" must be a mapping/.test(w))).toBe(true);
+    });
+
+    it("parses enabled: true and defaults cadenceDays, making the manifest present", () => {
+      const m = parseFocusManifest({ reviewRecap: { enabled: true } });
+      expect(m.reviewRecap).toEqual({ present: true, enabled: true, cadenceDays: 7 });
+      expect(m.present).toBe(true);
+    });
+
+    it("warns and defaults to false when enabled is a non-boolean value", () => {
+      const m = parseFocusManifest({ reviewRecap: { enabled: "yes" as unknown as boolean } });
+      expect(m.reviewRecap.enabled).toBe(false);
+      expect(m.warnings.some((w) => /reviewRecap\.enabled/.test(w))).toBe(true);
+    });
+
+    it("parses a valid cadenceDays and defaults to 7 (weekly) when omitted", () => {
+      const m = parseFocusManifest({ reviewRecap: { enabled: true, cadenceDays: 14 } });
+      expect(m.reviewRecap.cadenceDays).toBe(14);
+      const defaulted = parseFocusManifest({ reviewRecap: { enabled: true } });
+      expect(defaulted.reviewRecap.cadenceDays).toBe(7);
+    });
+
+    it("warns and defaults cadenceDays to 7 when the value is not a positive whole number", () => {
+      const zero = parseFocusManifest({ reviewRecap: { enabled: true, cadenceDays: 0 } });
+      expect(zero.reviewRecap.cadenceDays).toBe(7);
+      expect(zero.warnings.some((w) => /reviewRecap\.cadenceDays/.test(w))).toBe(true);
+      const fractional = parseFocusManifest({ reviewRecap: { enabled: true, cadenceDays: 2.5 } });
+      expect(fractional.reviewRecap.cadenceDays).toBe(7);
+      const negative = parseFocusManifest({ reviewRecap: { enabled: true, cadenceDays: -1 } });
+      expect(negative.reviewRecap.cadenceDays).toBe(7);
+    });
+
+    it("round-trips through reviewRecapConfigToJson → parseFocusManifest unchanged", () => {
+      const m = parseFocusManifest({ reviewRecap: { enabled: true, cadenceDays: 3 } });
+      expect(parseFocusManifest({ reviewRecap: reviewRecapConfigToJson(m.reviewRecap) }).reviewRecap).toEqual(m.reviewRecap);
+    });
+
+    it("reviewRecapConfigToJson returns null for an absent config", () => {
+      expect(reviewRecapConfigToJson(parseFocusManifest(null).reviewRecap)).toBeNull();
     });
   });
 

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -400,6 +400,52 @@ describe("queue processors", () => {
     expect(auditCount?.count).toBe(2);
   });
 
+  it("runs the review recap job through the queue processor when reviewRecap.enabled is true (#1963)", async () => {
+    const env = Object.assign(createTestEnv(), { GITTENSORY_DISCORD_WEBHOOK: "https://discord.com/api/webhooks/123/abc" }) as Env;
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { reviewRecap: { enabled: true, cadenceDays: 3 } });
+    vi.stubGlobal("fetch", async () => new Response(null, { status: 204 }));
+
+    await processJob(env, { type: "generate-review-recap", requestedBy: "test", repoFullName: "JSONbored/gittensory" });
+
+    const row = await env.DB.prepare("select outcome, detail from audit_events where event_type = ? order by created_at desc limit 1").bind("review_recap_notification.discord").first();
+    expect(row).toMatchObject({ outcome: "completed", detail: "sent" });
+    vi.unstubAllGlobals();
+  });
+
+  it("uses the job message's explicit windowDays over the manifest's cadenceDays default (#1963, nullish fallback present side)", async () => {
+    const env = Object.assign(createTestEnv(), { GITTENSORY_DISCORD_WEBHOOK: "https://discord.com/api/webhooks/123/abc" }) as Env;
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { reviewRecap: { enabled: true, cadenceDays: 3 } });
+    let capturedBody: string | undefined;
+    vi.stubGlobal("fetch", async (_url: RequestInfo | URL, init?: RequestInit) => {
+      capturedBody = String(init?.body ?? "");
+      return new Response(null, { status: 204 });
+    });
+
+    await processJob(env, { type: "generate-review-recap", requestedBy: "test", repoFullName: "JSONbored/gittensory", windowDays: 21 });
+
+    expect(capturedBody).toContain("(21d)");
+    vi.unstubAllGlobals();
+  });
+
+  it("skips the review recap job as a no-op when reviewRecap is NOT enabled for the repo (default-off, #1963)", async () => {
+    const env = Object.assign(createTestEnv(), { GITTENSORY_DISCORD_WEBHOOK: "https://discord.com/api/webhooks/123/abc" }) as Env;
+    // Prime an explicit, present-but-disabled manifest so loadRepoFocusManifest hits the cache instead of
+    // falling through to a live GitHub fetch for this repo's .gittensory.yml (there is none in this test env).
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { wantedPaths: ["src/"] });
+    let fetchCalled = false;
+    vi.stubGlobal("fetch", async () => {
+      fetchCalled = true;
+      return new Response(null, { status: 204 });
+    });
+
+    await processJob(env, { type: "generate-review-recap", requestedBy: "test", repoFullName: "JSONbored/gittensory" });
+
+    expect(fetchCalled).toBe(false);
+    const row = await env.DB.prepare("select count(*) as count from audit_events where event_type = ?").bind("review_recap_notification.discord").first<{ count: number }>();
+    expect(row?.count).toBe(0);
+    vi.unstubAllGlobals();
+  });
+
   it("routes upstream drift jobs through queue processors", async () => {
     const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {

--- a/test/unit/review-recap.test.ts
+++ b/test/unit/review-recap.test.ts
@@ -1,0 +1,310 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { buildReviewRecap, generateAndSendReviewRecap, loadReviewRecap, sendReviewRecapToDiscord } from "../../src/services/review-recap";
+import { createTestEnv } from "../helpers/d1";
+
+const NOW = "2026-07-06T00:00:00Z";
+const NOW_MS = Date.parse(NOW);
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("buildReviewRecap (#1963, pure aggregate)", () => {
+  it("counts a merged PR whose mergedAt falls inside the window", () => {
+    const recap = buildReviewRecap({
+      repoFullName: "JSONbored/gittensory",
+      generatedAt: NOW,
+      windowDays: 7,
+      pullRequests: [{ state: "closed", mergedAt: new Date(NOW_MS - 2 * DAY_MS).toISOString() }],
+      gateMergePrecision: null,
+      gateDecided: 0,
+    });
+    expect(recap.merged).toBe(1);
+    expect(recap.closed).toBe(0);
+    expect(recap.stillOpen).toBe(0);
+  });
+
+  it("excludes a merged PR whose mergedAt falls OUTSIDE the window (both sides of the >= sinceMs branch)", () => {
+    const recap = buildReviewRecap({
+      repoFullName: "JSONbored/gittensory",
+      generatedAt: NOW,
+      windowDays: 7,
+      pullRequests: [{ state: "closed", mergedAt: new Date(NOW_MS - 30 * DAY_MS).toISOString() }],
+      gateMergePrecision: null,
+      gateDecided: 0,
+    });
+    expect(recap.merged).toBe(0);
+    expect(recap.closed).toBe(0);
+    expect(recap.stillOpen).toBe(0);
+  });
+
+  it("counts a closed-unmerged PR using closedAt when present", () => {
+    const recap = buildReviewRecap({
+      repoFullName: "JSONbored/gittensory",
+      generatedAt: NOW,
+      windowDays: 7,
+      pullRequests: [{ state: "closed", mergedAt: null, closedAt: new Date(NOW_MS - 1 * DAY_MS).toISOString() }],
+      gateMergePrecision: null,
+      gateDecided: 0,
+    });
+    expect(recap.closed).toBe(1);
+    expect(recap.merged).toBe(0);
+  });
+
+  it("falls back to updatedAt for a closed-unmerged PR whose closedAt is absent (nullish fallback, present side)", () => {
+    const recap = buildReviewRecap({
+      repoFullName: "JSONbored/gittensory",
+      generatedAt: NOW,
+      windowDays: 7,
+      pullRequests: [{ state: "closed", mergedAt: null, closedAt: null, updatedAt: new Date(NOW_MS - 1 * DAY_MS).toISOString() }],
+      gateMergePrecision: null,
+      gateDecided: 0,
+    });
+    expect(recap.closed).toBe(1);
+  });
+
+  it("never counts a closed PR with NEITHER closedAt nor updatedAt parseable (nullish fallback, absent side)", () => {
+    const recap = buildReviewRecap({
+      repoFullName: "JSONbored/gittensory",
+      generatedAt: NOW,
+      windowDays: 7,
+      pullRequests: [{ state: "closed", mergedAt: null, closedAt: null, updatedAt: null }],
+      gateMergePrecision: null,
+      gateDecided: 0,
+    });
+    expect(recap.closed).toBe(0);
+    expect(recap.merged).toBe(0);
+    expect(recap.stillOpen).toBe(0);
+  });
+
+  it("counts an open PR toward stillOpen regardless of window", () => {
+    const recap = buildReviewRecap({
+      repoFullName: "JSONbored/gittensory",
+      generatedAt: NOW,
+      windowDays: 7,
+      pullRequests: [{ state: "open" }],
+      gateMergePrecision: null,
+      gateDecided: 0,
+    });
+    expect(recap.stillOpen).toBe(1);
+    expect(recap.merged).toBe(0);
+    expect(recap.closed).toBe(0);
+  });
+
+  it("clamps a non-finite windowDays to the 7-day default (nullish/non-finite side)", () => {
+    const recap = buildReviewRecap({
+      repoFullName: "JSONbored/gittensory",
+      generatedAt: NOW,
+      windowDays: undefined,
+      pullRequests: [],
+      gateMergePrecision: null,
+      gateDecided: 0,
+    });
+    expect(recap.windowDays).toBe(7);
+  });
+
+  it("clamps windowDays into [1, 90] on both sides", () => {
+    const low = buildReviewRecap({ repoFullName: "r", generatedAt: NOW, windowDays: -5, pullRequests: [], gateMergePrecision: null, gateDecided: 0 });
+    expect(low.windowDays).toBe(1);
+    const high = buildReviewRecap({ repoFullName: "r", generatedAt: NOW, windowDays: 999, pullRequests: [], gateMergePrecision: null, gateDecided: 0 });
+    expect(high.windowDays).toBe(90);
+  });
+
+  it("renders a gate-precision summary line when a precision value IS present (ternary present side)", () => {
+    const recap = buildReviewRecap({
+      repoFullName: "JSONbored/gittensory",
+      generatedAt: NOW,
+      windowDays: 7,
+      pullRequests: [],
+      gateMergePrecision: 0.9123,
+      gateDecided: 12,
+    });
+    expect(recap.gatePrecision).toBe(0.9123);
+    expect(recap.gateDecided).toBe(12);
+    expect(recap.summary.join(" ")).toMatch(/Gate merge precision: 91% \(12 decided prediction\(s\)\)\./);
+  });
+
+  it("renders a 'not enough data' line when gate precision is null (ternary absent side)", () => {
+    const recap = buildReviewRecap({
+      repoFullName: "JSONbored/gittensory",
+      generatedAt: NOW,
+      windowDays: 7,
+      pullRequests: [],
+      gateMergePrecision: null,
+      gateDecided: 0,
+    });
+    expect(recap.summary.join(" ")).toMatch(/not enough decided predictions yet to report/);
+  });
+
+  it("scrubs a local filesystem path out of the repo full name (defense-in-depth redaction)", () => {
+    const recap = buildReviewRecap({
+      repoFullName: "acme/widgets /Users/someone/leak",
+      generatedAt: NOW,
+      windowDays: 7,
+      pullRequests: [],
+      gateMergePrecision: null,
+      gateDecided: 0,
+    });
+    expect(recap.repoFullName).not.toMatch(/\/Users\//);
+    expect(recap.repoFullName).toContain("<redacted-path>");
+  });
+});
+
+describe("loadReviewRecap (#1963, D1-backed loader)", () => {
+  it("aggregates real pull_requests rows and a matching gate_decision/pr_outcome pair for the SAME repo", async () => {
+    const env = createTestEnv();
+    await env.DB.prepare(
+      `INSERT INTO pull_requests (id, repo_full_name, number, title, state, merged_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?, ?)`,
+    )
+      .bind(
+        "pr-1", "JSONbored/gittensory", 1, "merged pr", "closed", new Date(NOW_MS - 2 * DAY_MS).toISOString(), new Date(NOW_MS - 2 * DAY_MS).toISOString(),
+        "pr-2", "JSONbored/gittensory", 2, "closed pr", "closed", null, new Date(NOW_MS - 1 * DAY_MS).toISOString(),
+        "pr-3", "JSONbored/gittensory", 3, "open pr", "open", null, new Date(NOW_MS - 1 * DAY_MS).toISOString(),
+      )
+      .run();
+    const gd = new Date(NOW_MS - 3 * DAY_MS).toISOString();
+    await env.DB.prepare(
+      `INSERT INTO review_audit (id, project, target_id, event_type, decision, source, created_at)
+       VALUES (?, ?, ?, 'gate_decision', 'merge', 'gittensory-native', ?)`,
+    ).bind("ra-1", "JSONbored/gittensory", "JSONbored/gittensory#1", gd).run();
+    await env.DB.prepare(
+      `INSERT INTO review_audit (id, project, target_id, event_type, decision, source, created_at)
+       VALUES (?, ?, ?, 'pr_outcome', 'merged', 'gittensory-native', ?)`,
+    ).bind("ra-2", "JSONbored/gittensory", "JSONbored/gittensory#1", gd).run();
+
+    const recap = await loadReviewRecap(env, "JSONbored/gittensory", { windowDays: 7, nowIso: NOW });
+    expect(recap.merged).toBe(1);
+    expect(recap.closed).toBe(1);
+    expect(recap.stillOpen).toBe(1);
+    expect(recap.gateDecided).toBe(1);
+    expect(recap.gatePrecision).toBe(1);
+  });
+
+  it("returns null gate precision when this repo has no gate-eval row (project-lookup absent side)", async () => {
+    const env = createTestEnv();
+    const recap = await loadReviewRecap(env, "JSONbored/gittensory", { windowDays: 7, nowIso: NOW });
+    expect(recap.gatePrecision).toBeNull();
+    expect(recap.gateDecided).toBe(0);
+    expect(recap.merged).toBe(0);
+  });
+
+  it("matches the project column case-insensitively", async () => {
+    const env = createTestEnv();
+    const gd = new Date(NOW_MS - 1 * DAY_MS).toISOString();
+    await env.DB.prepare(
+      `INSERT INTO review_audit (id, project, target_id, event_type, decision, source, created_at)
+       VALUES (?, ?, ?, 'gate_decision', 'merge', 'gittensory-native', ?)`,
+    ).bind("ra-1", "jsonbored/gittensory", "jsonbored/gittensory#9", gd).run();
+    await env.DB.prepare(
+      `INSERT INTO review_audit (id, project, target_id, event_type, decision, source, created_at)
+       VALUES (?, ?, ?, 'pr_outcome', 'merged', 'gittensory-native', ?)`,
+    ).bind("ra-2", "jsonbored/gittensory", "jsonbored/gittensory#9", gd).run();
+
+    const recap = await loadReviewRecap(env, "JSONbored/Gittensory", { windowDays: 7, nowIso: NOW });
+    expect(recap.gateDecided).toBe(1);
+    expect(recap.gatePrecision).toBe(1);
+  });
+
+  it("falls back to Date.now() for computeGateEval's nowMs when nowIso is unparseable (ternary non-finite side)", async () => {
+    const env = createTestEnv();
+    // An unparseable nowIso still produces a usable recap: buildReviewRecap's OWN generatedAt/sinceMs math
+    // degrades separately (asserted by buildReviewRecap's own tests) -- this test isolates the OTHER
+    // consumer of generatedAt, computeGateEval's nowMs, which must fall back to Date.now() rather than NaN.
+    const recap = await loadReviewRecap(env, "JSONbored/gittensory", { windowDays: 7, nowIso: "not-a-real-date" });
+    expect(recap.gatePrecision).toBeNull();
+    expect(recap.gateDecided).toBe(0);
+  });
+
+  it("defaults nowIso/windowDays when omitted (invariant: never throws, always returns a shape)", async () => {
+    const env = createTestEnv();
+    const recap = await loadReviewRecap(env, "JSONbored/gittensory");
+    expect(recap.windowDays).toBe(7);
+    expect(typeof recap.generatedAt).toBe("string");
+  });
+});
+
+const HOOK = "https://discord.com/api/webhooks/123/abc";
+
+function envWithWebhook(): Env {
+  return Object.assign(createTestEnv(), { GITTENSORY_DISCORD_WEBHOOK: HOOK }) as Env;
+}
+
+async function auditRows(env: Env): Promise<Array<{ outcome: string; detail: string }>> {
+  const rows = await env.DB.prepare("select outcome, detail from audit_events where event_type = 'review_recap_notification.discord' order by created_at").all<{ outcome: string; detail: string }>();
+  return rows.results ?? [];
+}
+
+describe("sendReviewRecapToDiscord (#1963, reuses resolveDiscordWebhook)", () => {
+  const recap = buildReviewRecap({
+    repoFullName: "JSONbored/gittensory",
+    generatedAt: NOW,
+    windowDays: 7,
+    pullRequests: [],
+    gateMergePrecision: 0.95,
+    gateDecided: 20,
+  });
+
+  it("posts an embed and records a completed audit event when a webhook IS configured (resolved.status === configured side)", async () => {
+    const calls: Array<{ url: string; body: string }> = [];
+    vi.stubGlobal("fetch", async (url: RequestInfo | URL, init?: RequestInit) => {
+      calls.push({ url: String(url), body: String(init?.body ?? "") });
+      return new Response(null, { status: 204 });
+    });
+    const env = envWithWebhook();
+    const result = await sendReviewRecapToDiscord(env, recap);
+    expect(result.sent).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]?.url).toBe(HOOK);
+    expect(JSON.parse(calls[0]?.body ?? "{}").embeds[0].title).toContain("JSONbored/gittensory");
+    const rows = await auditRows(env);
+    expect(rows.some((r) => r.outcome === "completed")).toBe(true);
+  });
+
+  it("denies delivery and records it when NO webhook is configured (resolved.status !== configured side)", async () => {
+    const env = createTestEnv();
+    const result = await sendReviewRecapToDiscord(env, recap);
+    expect(result.sent).toBe(false);
+    expect(result.reason).toBe("missing_repo_webhook");
+    const rows = await auditRows(env);
+    expect(rows.some((r) => r.outcome === "denied")).toBe(true);
+  });
+
+  it("degrades to a recorded error result when the webhook POST throws (fail-safe path)", async () => {
+    vi.stubGlobal("fetch", async () => {
+      throw new Error("network down");
+    });
+    const env = envWithWebhook();
+    const result = await sendReviewRecapToDiscord(env, recap);
+    expect(result.sent).toBe(false);
+    expect(result.reason).toBe("network down");
+    const rows = await auditRows(env);
+    expect(rows.some((r) => r.outcome === "error")).toBe(true);
+  });
+
+  it("treats a non-2xx webhook response as a failure (mirrors notifyActionToDiscord's http-status guard)", async () => {
+    vi.stubGlobal("fetch", async () => new Response(null, { status: 429 }));
+    const env = envWithWebhook();
+    const result = await sendReviewRecapToDiscord(env, recap);
+    expect(result.sent).toBe(false);
+    expect(result.reason).toBe("discord_webhook_http_429");
+  });
+});
+
+describe("generateAndSendReviewRecap (#1963, manual-trigger entry point)", () => {
+  it("builds the recap and returns both the recap and the delivery result together", async () => {
+    vi.stubGlobal("fetch", async () => new Response(null, { status: 204 }));
+    const env = envWithWebhook();
+    const { recap, delivery } = await generateAndSendReviewRecap(env, "JSONbored/gittensory", { windowDays: 7, nowIso: NOW });
+    expect(recap.repoFullName).toBe("JSONbored/gittensory");
+    expect(delivery.sent).toBe(true);
+  });
+
+  it("still returns the computed recap when delivery is denied (no webhook configured)", async () => {
+    const env = createTestEnv();
+    const { recap, delivery } = await generateAndSendReviewRecap(env, "JSONbored/gittensory", { windowDays: 7, nowIso: NOW });
+    expect(recap.windowDays).toBe(7);
+    expect(delivery.sent).toBe(false);
+  });
+});

--- a/test/unit/selfhost-config-lint.test.ts
+++ b/test/unit/selfhost-config-lint.test.ts
@@ -34,11 +34,13 @@ contentLane:
   collectionField: records
 repoDocGeneration:
   enabled: true
+reviewRecap:
+  enabled: true
 `);
 
     expect(result.ok).toBe(true);
     expect(result.warnings).toEqual([]);
-    expect(result.summary).toBe("Manifest parsed 13 recognized fields.");
+    expect(result.summary).toBe("Manifest parsed 14 recognized fields.");
     expect(result.recognizedFields).toEqual([
       "wantedPaths",
       "preferredLabels",
@@ -53,6 +55,7 @@ repoDocGeneration:
       "features",
       "contentLane",
       "repoDocGeneration",
+      "reviewRecap",
     ]);
     expect(JSON.stringify(result)).not.toContain("private maintainer note");
     expect(JSON.stringify(result)).not.toContain("operator-only");
@@ -67,6 +70,14 @@ repoDocGeneration:
     expect(result.ok).toBe(true);
     expect(result.warnings).toEqual([]);
     expect(result.recognizedFields).toEqual(["repoDocGeneration"]);
+  });
+
+  it("recognizes a standalone reviewRecap: block instead of flagging it as unknown (#1963)", () => {
+    const result = lintManifestText("reviewRecap:\n  enabled: true\n  cadenceDays: 14\n");
+
+    expect(result.ok).toBe(true);
+    expect(result.warnings).toEqual([]);
+    expect(result.recognizedFields).toEqual(["reviewRecap"]);
   });
 
   it("flags legacy blockedPaths with a migration-specific warning, not the generic unknown-field message", () => {


### PR DESCRIPTION
## Summary

Adds the "Maintainer review recap digest" from #1963 — the pure aggregate builder plus a manually-triggerable
Discord delivery path. Per the issue's own suggested split (this is genuinely two natural PRs), this PR ships
**only** the builder + delivery half; the scheduled cron trigger is a scoped, documented follow-up (see Notes).

- **Investigation correction** (documented in the issue, confirmed here): the issue's cited prerequisite paths
  (`src/selfhost/discord-notify.ts`, `src/review/alerts.ts`) do not exist / are not the real Discord path. The
  actual per-PR terminal-action Discord notifier is `src/services/notify-discord.ts`
  (`resolveDiscordWebhook`), which is reused verbatim here — no second webhook-resolution mechanism.
- **New pure builder** `src/services/review-recap.ts`: `buildReviewRecap` aggregates a repo's merged/closed/
  still-open PR counts (from `listPullRequests`, `src/db/repositories.ts`) and gate merge precision (from
  `computeGateEval`, `src/review/parity.ts` — the existing gate-vs-realized-outcome accuracy harness) over a
  configurable window. `loadReviewRecap` wires the D1 reads; `sendReviewRecapToDiscord` posts the recap embed
  through `resolveDiscordWebhook`; `generateAndSendReviewRecap` is the one-call manual-trigger entry point.
- **Config knob** `.gittensory.yml reviewRecap: { enabled, cadenceDays }` — modeled directly on the existing
  `repoDocGeneration:` block (same present/enabled/no-DB-layer shape): default **off**, `cadenceDays` defaults
  to 7 (weekly). Wired through `src/signals/focus-manifest.ts` (parse/serialize/empty-manifest plumbing),
  `focus-manifest-loader.ts` (cache round-trip), and `src/selfhost/config-lint.ts` (recognized-field allowlist).
- **Manual-trigger API routes** (mirroring the existing `generate-weekly-value-report` job pattern):
  `POST /v1/internal/jobs/generate-review-recap` (queues a job) and `.../run` (builds + delivers immediately).
  Both require `repoFullName`; both — including the immediate `/run` path — respect `reviewRecap.enabled` as a
  fail-safe gate, since (unlike the weekly value report) this has a real side effect of posting to a repo's
  Discord channel.
- **Queue processor** `generate-review-recap` case in `src/queue/processors.ts`, added to the deferrable
  maintenance-job allowlist in `src/selfhost/maintenance-admission.ts`.
- Regenerated `apps/gittensory-ui/public/openapi.json` (`npm run ui:openapi`) for the new job route.

**Design decision (conservative default, noted per the task's ambiguity-resolution instruction):** the config
gate is enforced at the single processor/route call site rather than inside the reusable
`generateAndSendReviewRecap` function itself, because this PR has no fan-out/enumeration sweep yet. The
future scheduled trigger will enumerate opted-in repos up front (mirroring `fanOutRepoDocRefreshSweepJobs`)
and can call `generateAndSendReviewRecap` directly once that filtering has already happened.

**Deliberately out of scope for this PR** (per the issue's own two-PR split and the task's scope guardrail):
- The scheduled cron trigger. `src/index.ts`'s `enqueueScheduledJobs` already runs the weekly-value-report
  job on a similar cadence (Mondays at 12:00 UTC) — the follow-up PR should add an analogous
  `reviewRecap.enabled`-gated enumeration (mirroring `fanOutRepoDocRefreshSweepJobs`'s per-repo
  `refreshIntervalDays` due-check) instead of a single global cron entry, since recap cadence is per-repo.
- Slack delivery (issue explicitly allows deferring this; `notifyActionToSlack` already exists as the
  per-event analogue to reuse when that lands).
- "Top-N contributor summary" and "top findings" (no existing persisted aggregate for these; would need a new
  ledger/query, which is out of scope for a small PR reusing existing stats).
- Queue-health metrics (the issue mentions this; `src/review/ops.ts`'s `computeAgentHealth` is the natural
  source, but pulling it in would require threading agent-config through the recap path — left for a
  follow-up rather than growing this PR's surface).

No issue is auto-closed by this PR (issue #1963 is `Phase 2` scoped work under the #1953 epic; this PR
advances it but does not fully close it, since the scheduler half remains).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed. (Advances #1963, part of epic #1953 — builder+delivery half only; scheduler half is a documented follow-up, not this PR.)

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate. (New file `src/services/review-recap.ts` is 100% lines/branches; every changed line in shared files — `focus-manifest.ts`, `processors.ts`, `routes.ts`, `spec.ts` — was cross-checked line-by-line against the coverage report to confirm no uncovered branch falls on this diff.)
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

Also ran the full `npm run test:ci` gate (actionlint, migrations/schema-drift checks, cf-typegen:check,
typecheck, unsharded test:coverage, test:workers, mcp/miner build+pack, rees:test, openapi checks,
docs/command-reference drift checks, ui:lint/typecheck/test/build) — fully green, 0 failures across 10253+
tests, after a final rebase onto `origin/main`.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics. (Recap text is scrubbed through the same local-path/redaction pattern used elsewhere; no reward/trust/score terms anywhere in the recap output.)
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session/CORS surface touched; the new internal routes reuse the existing `/v1/internal/*` bearer-token middleware unchanged, and 401 is tested for both new routes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes in this PR.)
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots. (N/A — backend-only change, no visible UI.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (`.gittensory.yml.example` and `config/examples/gittensory.full.yml` document the new `reviewRecap:` block; `CHANGELOG.md` intentionally untouched.)

## UI Evidence

N/A — this is a backend-only change (new service, config knob, queue job, internal API routes). No visible UI surface.

## Notes

- Follow-up (separate PR, per the issue's own suggested two-PR split): wire a scheduled/cron enumeration of
  `reviewRecap.enabled` repos (mirroring `fanOutRepoDocRefreshSweepJobs`'s per-repo due-check on
  `cadenceDays`), plus Slack delivery, top-findings, and queue-health metrics as separately scoped additions.
