### PR TITLE
test(config): lock in review.max_findings plumbing (#2049)

### DIFF
--- a/test/unit/config-templates.test.ts
+++ b/test/unit/config-templates.test.ts
@@ -101,6 +101,21 @@ describe("config/examples review templates (#1682)", () => {
     expect(resolveReviewPromptOverrides(off).effortScore).toBe(false);
   });
 
+  it("resolves review.max_findings via manifest parse + helper (#2049)", () => {
+    const full = readConfigExample("gittensory.full.yml");
+    expect(full).toMatch(/# max_findings:/);
+    const empty = { blockers: null, nits: null };
+    expect(parseFocusManifest({}).review.maxFindings).toEqual(empty);
+    expect(resolveReviewPromptOverrides(parseFocusManifest({})).maxFindings).toEqual(empty);
+    const on = parseFocusManifest({ review: { max_findings: { blockers: 5, nits: 8 } } });
+    expect(on.review.maxFindings).toEqual({ blockers: 5, nits: 8 });
+    expect(resolveReviewPromptOverrides(on).maxFindings).toEqual({ blockers: 5, nits: 8 });
+    expect(reviewConfigToJson(on.review)).toEqual({ max_findings: { blockers: 5, nits: 8 } });
+    const blockersOnly = parseFocusManifest({ review: { max_findings: { blockers: 3 } } });
+    expect(blockersOnly.review.maxFindings).toEqual({ blockers: 3, nits: null });
+    expect(reviewConfigToJson(blockersOnly.review)).toEqual({ max_findings: { blockers: 3 } });
+  });
+
   it("parses gittensory.minimal.yml with zero warnings and enables no agent actions", () => {
     const manifest = parseFocusManifestContent(readConfigExample("gittensory.minimal.yml"), "repo_file");
     expect(manifest.warnings).toEqual([]);


### PR DESCRIPTION
Closes #2049

## Summary
- Add a config-templates inventory test that locks in the shipped `review.max_findings` plumbing: docs entry in `gittensory.full.yml`, manifest parse round-trip, and `resolveReviewPromptOverrides` helper (unset → null caps).

## Validation
- `npm run typecheck`
- `npx vitest run test/unit/config-templates.test.ts`

## UI Evidence
N/A — test-only.
