### PR TITLE
fix(selfhost): reserve shared config folder

### DIFF
--- a/src/selfhost/private-config.ts
+++ b/src/selfhost/private-config.ts
@@ -29,11 +29,8 @@
 // set degrades exactly like a single malformed manifest always has. The slug is lowercased (GitHub repo full-names
 // are case-insensitive; #1390 already lowercased).
 //
-// Known limitation (#1959): the shared-base folder name `_shared` could collide with a bare repo-name folder
-// (layer 2) for a real GitHub repo literally named `_shared` — `isSafeRepoSegment` permits `_` as an interior
-// character, so that repo name is technically valid. This is a deliberately accepted edge case; an operator
-// hosting a repo named exactly `_shared` should rename this folder via a private, documented convention rather
-// than relying on any automatic disambiguation.
+// The reserved shared-base folder `_shared` is never treated as a bare repo-name config folder for a real GitHub
+// repo named `_shared`; use the owner-qualified or flat owner__repo candidates for that repository instead.
 import { readFile, readdir } from "node:fs/promises";
 import { join, resolve } from "node:path";
 import { parse as parseYaml } from "yaml";
@@ -65,6 +62,7 @@ export const GLOBAL_CONFIG_CANDIDATES: string[] = [...CONFIG_BASENAMES];
  *  lowest-priority layer: a cross-repo "house policy" an operator running many repos writes once, deep-merged
  *  UNDER both the global default and any per-repo file (or applied alone, when neither of those exists). */
 export const SHARED_BASE_CONFIG_CANDIDATES: string[] = CONFIG_BASENAMES.map((base) => join("_shared", base));
+const SHARED_BASE_CONFIG_CANDIDATE_SET = new Set(SHARED_BASE_CONFIG_CANDIDATES);
 
 /** Per-repo private-config candidate paths (relative to GITTENSORY_REPO_CONFIG_DIR), in priority order:
  *  owner-qualified folder → bare repo-name folder → flat `owner__repo` file (the #1390 back-compat form). The slug
@@ -81,7 +79,9 @@ export function localConfigCandidates(repoFullName: string): string[] {
     // 1. owner-qualified folder — `{owner}__{repo}/.gittensory.{yml,yaml,json}`
     ...CONFIG_BASENAMES.map((base) => join(slug, base)),
     // 2. bare repo-name folder — `{repo}/.gittensory.{yml,yaml,json}`
-    ...CONFIG_BASENAMES.map((base) => join(repo, base)),
+    ...CONFIG_BASENAMES.map((base) => join(repo, base)).filter(
+      (candidate) => !SHARED_BASE_CONFIG_CANDIDATE_SET.has(candidate),
+    ),
     // 3. flat owner__repo file (#1390) — `{owner}__{repo}.{yml,yaml,json}`
     ...CONFIG_BASENAMES.map((base) => `${slug}${base.slice(".gittensory".length)}`),
   ];

--- a/test/unit/private-config.test.ts
+++ b/test/unit/private-config.test.ts
@@ -44,6 +44,17 @@ describe("localConfigCandidates (container-private config paths)", () => {
       join("_shared", ".gittensory.json"),
     ]);
   });
+
+  it("reserves the shared-base folder instead of treating it as the bare folder for a repo named _shared", () => {
+    expect(localConfigCandidates("owner/_shared")).toEqual([
+      join("owner___shared", ".gittensory.yml"),
+      join("owner___shared", ".gittensory.yaml"),
+      join("owner___shared", ".gittensory.json"),
+      "owner___shared.yml",
+      "owner___shared.yaml",
+      "owner___shared.json",
+    ]);
+  });
 });
 
 describe("mergeConfigOverlay (generic recursive deep-merge, no manifest-field-specific code)", () => {
@@ -325,6 +336,28 @@ describe("makeLocalManifestReader — shared base layer (#1959)", () => {
     writeFileSync(join(dir, "_shared", ".gittensory.json"), '{"gate":{"enabled":false}}');
     const reader = makeLocalManifestReader(dir);
     expect(await reader!("owner/repo")).toBe("gate:\n  enabled: true\n"); // .yaml found before .json is tried
+  });
+
+  it("keeps global precedence over the shared base for a repo named _shared", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "gt-repo-config-"));
+    mkdirSync(join(dir, "_shared"));
+    writeFileSync(join(dir, "_shared", ".gittensory.yml"), "gate:\n  enabled: true\nwantedPaths:\n  - '**/*'\n");
+    writeFileSync(join(dir, ".gittensory.yml"), "gate:\n  enabled: false\nwantedPaths:\n  - src/safe/**\n");
+    const reader = makeLocalManifestReader(dir);
+    const manifest = parseFocusManifestContent(await reader!("owner/_shared"));
+    expect(manifest.gate.enabled).toBe(false); // global still overlays the reserved shared-base folder
+    expect(manifest.wantedPaths).toEqual(["src/safe/**"]);
+  });
+
+  it("still supports owner-qualified config for a repo named _shared", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "gt-repo-config-"));
+    mkdirSync(join(dir, "_shared"));
+    writeFileSync(join(dir, "_shared", ".gittensory.yml"), "gate:\n  enabled: false\n");
+    mkdirSync(join(dir, "owner___shared"));
+    writeFileSync(join(dir, "owner___shared", ".gittensory.yml"), "gate:\n  enabled: true\n");
+    const reader = makeLocalManifestReader(dir);
+    const manifest = parseFocusManifestContent(await reader!("owner/_shared"));
+    expect(manifest.gate.enabled).toBe(true); // explicit owner-qualified per-repo file remains highest priority
   });
 
   it("does NOT serve the shared base to an invalid repo full name (no per-repo candidates)", async () => {


### PR DESCRIPTION
### Motivation
- Prevent a precedence inversion where the `_shared/.gittensory.*` shared-base file could also be treated as a bare per-repo candidate for a repository literally named `_shared`, causing the shared base to override the global default for `owner/_shared`.
- Preserve the documented precedence: shared base < global default < per-repo, while keeping owner-qualified and flat `owner__repo` candidates functional.

### Description
- Reserve the shared-base candidates by adding `SHARED_BASE_CONFIG_CANDIDATE_SET` and filtering bare repo-folder candidates so `_shared/.gittensory.*` is not treated as a `{repo}/.gittensory.*` candidate in `localConfigCandidates` (file: `src/selfhost/private-config.ts`).
- Update module commentary to document that `_shared` is reserved and should not collide with a bare repo folder.
- Add regression unit tests in `test/unit/private-config.test.ts` that assert `localConfigCandidates("owner/_shared")` omits `_shared` as a bare-folder candidate and that global config still overrides shared for `owner/_shared`, and that owner-qualified config remains highest-priority for `owner/_shared`.

### Testing
- Ran the unit suite for the modified file with `npx vitest run test/unit/private-config.test.ts`, and the tests passed (`54 tests` passed).
- Ran `npm run typecheck` and `npm run selfhost:env-reference:check`, both of which succeeded.
- Attempted `npm run test:coverage` for the file and the scoped invocation succeeded in running tests but the project-wide coverage thresholds failed when the global coverage step was enforced; this is unrelated to the change in `src/selfhost/private-config.ts` and stems from overall repo coverage requirements. 
- `npm run test:ci` was started but not completed due to long-running unrelated test shards; `npm audit --audit-level=moderate` could not complete because the npm audit endpoint returned `403 Forbidden`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b7d5dd970832c9d759881d0e5d3cb)