### PR TITLE
feat(github): recognize @gittensory action commands

### DIFF
--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -55,8 +55,9 @@ type SnapshotCommandName = Exclude<GittensoryMentionCommandName, "help" | "miner
 // than producing a public answer card. They are intentionally kept OUT of the Q&A catalog/unions so the
 // exhaustive Q&A switches stay total, but parseGittensoryMentionCommand still recognizes them (so a bare
 // @gittensory gate-override is not silently downgraded to "help").
-export const GITTENSORY_ACTION_COMMANDS = ["gate-override"] as const;
+export const GITTENSORY_ACTION_COMMANDS = ["gate-override", "review", "pause", "resume", "resolve", "configuration", "explain"] as const;
 export type GittensoryActionCommandName = (typeof GITTENSORY_ACTION_COMMANDS)[number];
+const GITTENSORY_ACTION_COMMAND_ALIASES = { "re-review": "review" } as const satisfies Record<string, GittensoryActionCommandName>;
 
 export type GittensoryMentionCommand = {
   name: GittensoryMentionCommandName | GittensoryActionCommandName;
@@ -82,6 +83,7 @@ export type AgentCommandFeedbackContext = {
 
 const COMMANDS = new Set<GittensoryMentionCommandName>(GITTENSORY_MENTION_COMMAND_CATALOG.map((command) => command.id));
 const ACTION_COMMANDS = new Set<GittensoryActionCommandName>(GITTENSORY_ACTION_COMMANDS);
+const ACTION_COMMAND_LOOKUP = new Set<string>([...GITTENSORY_ACTION_COMMANDS, ...Object.keys(GITTENSORY_ACTION_COMMAND_ALIASES)]);
 const MAINTAINER_QUEUE_DIGEST_COMMANDS = new Set<MaintainerQueueDigestCommandName>(MAINTAINER_QUEUE_DIGEST_COMMAND_CATALOG.map((command) => command.id));
 const MAINTAINER_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
 const AGENT_COMMAND_FEEDBACK_MARKER = "gittensory-agent-command-answer";
@@ -169,9 +171,10 @@ export function parseGittensoryMentionCommand(body: string | null | undefined): 
   const match = body.match(/(?:^|\s)@gittensory(?![\w-])(?:\s+([a-z-]+))?([^\n\r]*)/i);
   if (!match) return null;
   const requested = (match[1]?.toLowerCase() || "help") as GittensoryMentionCommandName | GittensoryActionCommandName;
-  if (ACTION_COMMANDS.has(requested as GittensoryActionCommandName)) {
+  if (ACTION_COMMAND_LOOKUP.has(requested)) {
+    const name = (GITTENSORY_ACTION_COMMAND_ALIASES[requested as keyof typeof GITTENSORY_ACTION_COMMAND_ALIASES] ?? requested) as GittensoryActionCommandName;
     const reason = (match[2] ?? "").trim();
-    return { name: requested as GittensoryActionCommandName, raw: match[0].trim(), reason: reason.length > 0 ? reason : undefined };
+    return { name, raw: match[0].trim(), reason: reason.length > 0 ? reason : undefined };
   }
   const name = COMMANDS.has(requested as GittensoryMentionCommandName) ? (requested as GittensoryMentionCommandName) : "help";
   const question = name === "ask" ? (match[2] ?? "").trim() : undefined;

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -12031,7 +12031,7 @@ async function maybeProcessGittensoryMentionCommand(
   if (!command) return false;
   // Action commands (e.g. gate-override) are handled by their own dispatch earlier in processGitHubWebhook;
   // they never produce a Q&A answer card here. Bail so the rest of this handler narrows to Q&A commands.
-  if (command.name === "gate-override") return false;
+  if (command.name === "gate-override" || command.name === "review" || command.name === "pause" || command.name === "resume" || command.name === "resolve" || command.name === "configuration" || command.name === "explain") return false;
   const repoFullName = payload.repository?.full_name;
   const issue = payload.issue;
   const installationId = getInstallationId(payload);

--- a/test/unit/github-commands.test.ts
+++ b/test/unit/github-commands.test.ts
@@ -47,6 +47,78 @@ describe("GitHub mention commands", () => {
     expect(isMaintainerOnlyCommand("preflight")).toBe(false);
   });
 
+  describe("@gittensory action commands (#2160)", () => {
+    it.each([
+      ["review", "review"],
+      ["re-review", "review"],
+      ["pause", "pause"],
+      ["resume", "resume"],
+      ["resolve", "resolve"],
+      ["configuration", "configuration"],
+      ["explain", "explain"],
+      ["gate-override", "gate-override"],
+    ] as const)("recognizes %s as canonical action command %s without trailing text", (verb, canonical) => {
+      expect(parseGittensoryMentionCommand(`@gittensory ${verb}`)).toMatchObject({
+        name: canonical,
+        reason: undefined,
+        raw: `@gittensory ${verb}`,
+      });
+    });
+
+    it("captures trailing free text as reason for explain and pause", () => {
+      expect(parseGittensoryMentionCommand("@gittensory explain finding-42")).toMatchObject({
+        name: "explain",
+        reason: "finding-42",
+        raw: "@gittensory explain finding-42",
+      });
+      expect(parseGittensoryMentionCommand("@gittensory pause maintainer vacation")).toMatchObject({
+        name: "pause",
+        reason: "maintainer vacation",
+        raw: "@gittensory pause maintainer vacation",
+      });
+    });
+
+    it("captures optional trailing reason for other action commands", () => {
+      expect(parseGittensoryMentionCommand("@gittensory review latest head")).toMatchObject({
+        name: "review",
+        reason: "latest head",
+      });
+      expect(parseGittensoryMentionCommand("@gittensory resolve stale thread")).toMatchObject({
+        name: "resolve",
+        reason: "stale thread",
+      });
+      expect(parseGittensoryMentionCommand("@gittensory configuration show")).toMatchObject({
+        name: "configuration",
+        reason: "show",
+      });
+      expect(parseGittensoryMentionCommand("@gittensory resume after deploy")).toMatchObject({
+        name: "resume",
+        reason: "after deploy",
+      });
+    });
+
+    it("leaves reason undefined when trailing text is whitespace only", () => {
+      expect(parseGittensoryMentionCommand("@gittensory explain   ")).toMatchObject({
+        name: "explain",
+        reason: undefined,
+      });
+      expect(parseGittensoryMentionCommand("@gittensory pause\t")).toMatchObject({
+        name: "pause",
+        reason: undefined,
+      });
+    });
+
+    it("still resolves unknown verbs and bare mentions to help", () => {
+      expect(parseGittensoryMentionCommand("@gittensory")).toMatchObject({ name: "help" });
+      expect(parseGittensoryMentionCommand("@gittensory unknown-verb")).toMatchObject({ name: "help" });
+    });
+
+    it("does not downgrade nearby Q&A commands that share the review prefix", () => {
+      expect(parseGittensoryMentionCommand("@gittensory reviewability")?.name).toBe("reviewability");
+      expect(parseGittensoryMentionCommand("@gittensory review-now")?.name).toBe("review-now");
+    });
+  });
+
   it("authorizes maintainers and confirmed miner PR authors only", () => {
     expect(isAuthorizedCommandActor({ commenterLogin: "reviewer", commenterAssociation: "OWNER" })).toMatchObject({
       authorized: true,

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -24602,6 +24602,27 @@ describe("recordAgentCommandUsage (signal-snapshot fail-safe)", () => {
     ).resolves.toBeUndefined();
   });
 
+  it("ignores newly-created @gittensory action commands — they never produce a Q&A answer card (#2160)", async () => {
+    const posts: string[] = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      if ((init?.method ?? "GET") === "POST" && url.includes("/comments")) posts.push(url);
+      if (url.includes("/access_tokens")) return Response.json({ token: "t" });
+      return new Response("not found", { status: 404 });
+    });
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+    const payload: any = {
+      action: "created",
+      installation: { id: 123 },
+      repository: { id: 1, name: "gittensory", full_name: "JSONbored/gittensory", private: false, default_branch: "main", owner: { login: "JSONbored" } },
+      sender: { login: "maintainer", type: "User" },
+      comment: { id: 999, body: "@gittensory resume after deploy", user: { login: "maintainer", type: "User" } },
+      issue: { id: 1, number: 77, title: "some issue", pull_request: { url: "https://api.github.com/repos/JSONbored/gittensory/pulls/77" } },
+    };
+    await processJob(env, { type: "github-webhook", deliveryId: "mention-resume-action", eventName: "issue_comment", payload });
+    expect(posts).toEqual([]);
+  });
+
   it("ignores a @gittensory mention on an EDITED comment — only newly-created comments are answered (#review-audit)", async () => {
     const posts: string[] = [];
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {


### PR DESCRIPTION
## Summary

- Extend `GITTENSORY_ACTION_COMMANDS` with six new self-host action verbs (`review`, `pause`, `resume`, `resolve`, `configuration`, `explain`) alongside existing `gate-override`.
- Teach `parseGittensoryMentionCommand` to resolve them via `ACTION_COMMAND_LOOKUP`, alias `re-review` → `review`, and capture trailing free text as `reason`.
- Bail all action commands out of `maybeProcessGittensoryMentionCommand` so they never hit the Q&A answer-card path (fixes typecheck when `command.name` widens beyond `GittensoryMentionCommandName`).
- Preserve existing behavior: unknown verbs and bare `@gittensory` still resolve to `help`; Q&A commands like `reviewability` / `review-now` are unchanged.

Closes #2160 

## Scope

- [x] Parsing-only — no dispatch, auth, or side effects beyond the existing Q&A bail-out
- [x] Pure extension of the action-command registry + parser + mention-handler guard
- [x] No changes to Q&A catalog or help card content
- [x] Focused PR — four files, no unrelated backend/UI/MCP/docs churn

## Changed files

| File | Change |
|------|--------|
| `src/github/commands.ts` | Action command registry, alias map, `ACTION_COMMAND_LOOKUP`, parser branch |
| `src/queue/processors.ts` | Bail all action verbs out of `maybeProcessGittensoryMentionCommand` |
| `test/unit/github-commands.test.ts` | Per-verb, alias, trailing-arg, whitespace-only reason, and fallback coverage |
| `test/unit/queue.test.ts` | `@gittensory resume` does not post a Q&A answer card |

## Validation

Pre-push gate (path-aware, unsharded `test:coverage`):

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — **codecov/patch 100%** on measured `src/**` changes
- [x] `npm run test:workers`
- [x] `npm run ui:openapi:check`
- [x] `npm audit --audit-level=moderate`

## Safety

- [x] No secrets, tokens, or private scoring in code, tests, or PR text
- [x] No auth/CORS/session changes — only parser + existing mention-handler guard
- [x] No OpenAPI/MCP/UI surface changes

## Notes

- Dispatch handlers for the new verbs are follow-up work under #1960; this PR only registers and parses them so `@gittensory resume` is not silently downgraded to `help`.
- `gate-override` dispatch remains unchanged; the processors bail-out now covers all registered action verbs consistently.

