### PR TITLE
feat(commands): unknown-@gittensory-verb did-you-mean in help fallback

### DIFF
--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -1607,4 +1607,5 @@ export const githubCommandsInternals = {
   snapshotFreshnessFromWarnings,
   refreshSections,
   askSections,
+  levenshteinDistance,
 };

--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -63,6 +63,8 @@ export type GittensoryMentionCommand = {
   raw: string;
   question?: string | undefined;
   reason?: string | undefined;
+  /** Present when the typed verb was non-empty but unrecognized and the parser downgraded to `help`. */
+  unknownVerb?: string | undefined;
 };
 
 type PublicAnswerCard = {
@@ -87,6 +89,48 @@ const MAINTAINER_ASSOCIATIONS = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
 const AGENT_COMMAND_FEEDBACK_MARKER = "gittensory-agent-command-answer";
 
 const COMMAND_TITLES = Object.fromEntries(GITTENSORY_MENTION_COMMAND_CATALOG.map((command) => [command.id, command.title])) as Record<GittensoryMentionCommandName, string>;
+
+const ALL_KNOWN_COMMAND_NAMES: readonly string[] = [
+  ...GITTENSORY_MENTION_COMMAND_CATALOG.map((command) => command.id),
+  ...GITTENSORY_ACTION_COMMANDS,
+];
+
+/** Max Levenshtein distance for a did-you-mean suggestion on an unrecognized verb. */
+const COMMAND_SUGGEST_MAX_DISTANCE = 2;
+
+function levenshteinDistance(a: string, b: string): number {
+  if (a === b) return 0;
+  if (a.length === 0) return b.length;
+  if (b.length === 0) return a.length;
+  const rows = a.length + 1;
+  const cols = b.length + 1;
+  const matrix: number[][] = Array.from({ length: rows }, () => Array<number>(cols).fill(0));
+  for (let i = 0; i < rows; i += 1) matrix[i]![0] = i;
+  for (let j = 0; j < cols; j += 1) matrix[0]![j] = j;
+  for (let i = 1; i < rows; i += 1) {
+    for (let j = 1; j < cols; j += 1) {
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+      matrix[i]![j] = Math.min(matrix[i - 1]![j]! + 1, matrix[i]![j - 1]! + 1, matrix[i - 1]![j - 1]! + cost);
+    }
+  }
+  return matrix[a.length]![b.length]!;
+}
+
+/** Pure nearest-command suggester for unrecognized @gittensory verbs (#2170). */
+export function suggestCommand(rawVerb: string | null | undefined): string | null {
+  const verb = String(rawVerb ?? "").trim().toLowerCase();
+  if (!verb || ALL_KNOWN_COMMAND_NAMES.includes(verb)) return null;
+  let best: string | null = null;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  for (const candidate of ALL_KNOWN_COMMAND_NAMES) {
+    const distance = levenshteinDistance(verb, candidate);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      best = candidate;
+    }
+  }
+  return bestDistance <= COMMAND_SUGGEST_MAX_DISTANCE ? best : null;
+}
 
 const REFRESH_SECTION_TITLES: Record<SnapshotCommandName, string> = {
   ask: "Contribution context snapshot refresh",
@@ -168,14 +212,16 @@ export function parseGittensoryMentionCommand(body: string | null | undefined): 
   // bare `@gittensory help` command. A space, end-of-string, or punctuation still matches.
   const match = body.match(/(?:^|\s)@gittensory(?![\w-])(?:\s+([a-z-]+))?([^\n\r]*)/i);
   if (!match) return null;
-  const requested = (match[1]?.toLowerCase() || "help") as GittensoryMentionCommandName | GittensoryActionCommandName;
+  const rawVerb = match[1]?.toLowerCase();
+  const requested = (rawVerb || "help") as GittensoryMentionCommandName | GittensoryActionCommandName;
   if (ACTION_COMMANDS.has(requested as GittensoryActionCommandName)) {
     const reason = (match[2] ?? "").trim();
     return { name: requested as GittensoryActionCommandName, raw: match[0].trim(), reason: reason.length > 0 ? reason : undefined };
   }
   const name = COMMANDS.has(requested as GittensoryMentionCommandName) ? (requested as GittensoryMentionCommandName) : "help";
   const question = name === "ask" ? (match[2] ?? "").trim() : undefined;
-  return { name, raw: match[0].trim(), question: question && question.length > 0 ? question : undefined };
+  const unknownVerb = rawVerb && name === "help" && rawVerb !== "help" ? rawVerb : undefined;
+  return { name, raw: match[0].trim(), question: question && question.length > 0 ? question : undefined, unknownVerb };
 }
 
 export function isMaintainerAssociation(association: string | null | undefined): boolean {
@@ -258,7 +304,10 @@ export function buildPublicAgentCommandComment(args: {
   // Action commands (e.g. gate-override) never reach this Q&A renderer — they are handled and short-circuited
   // earlier — so narrow the widened parse name back to a Q&A command name for the answer-card helpers.
   const commandName = args.command.name as GittensoryMentionCommandName;
-  const sections = commandSections(commandName, args.bundle, args.officialMiner, args.maintainerDigest, args.command.question);
+  const sections = commandSections(commandName, args.bundle, args.officialMiner, args.maintainerDigest, {
+    question: args.command.question,
+    unknownVerb: args.command.unknownVerb,
+  });
   const card = buildPublicAnswerCard({
     command: commandName,
     sections,
@@ -592,13 +641,13 @@ function commandSections(
   bundle: AgentRunBundle | null | undefined,
   officialMiner: GittensorContributorSnapshot | null | undefined,
   maintainerDigest: MaintainerQueueDigest | null | undefined,
-  question?: string | undefined,
+  options: { question?: string | undefined; unknownVerb?: string | undefined } = {},
 ): string[] {
   switch (command) {
     case "help":
-      return helpSections();
+      return helpSections(suggestCommand(options.unknownVerb));
     case "ask":
-      return askSections(bundle, question);
+      return askSections(bundle, options.question);
     case "miner-context":
       return minerContextSections(officialMiner);
     case "preflight":
@@ -628,10 +677,11 @@ function commandSections(
   }
 }
 
-function helpSections(): string[] {
+function helpSections(suggestion: string | null = null): string[] {
   return [
     "**Commands**",
     "",
+    ...(suggestion ? [`- Did you mean \`@gittensory ${suggestion}\`?`, ""] : []),
     "- `@gittensory help` shows this command list.",
     "- `@gittensory ask <question>` answers contribution-quality Q&A with source citations and freshness.",
     "- `@gittensory preflight` summarizes public PR hygiene.",

--- a/test/unit/github-commands.test.ts
+++ b/test/unit/github-commands.test.ts
@@ -1974,6 +1974,15 @@ describe("suggestCommand (#2170)", () => {
     expect(suggestCommand("prefligt")).toBe("preflight");
     expect(suggestCommand("zzzzzzzzzz")).toBeNull();
   });
+
+  it("exercises every levenshtein branch used by suggestCommand", () => {
+    const { levenshteinDistance } = githubCommandsInternals;
+    expect(levenshteinDistance("abc", "abc")).toBe(0);
+    expect(levenshteinDistance("", "abc")).toBe(3);
+    expect(levenshteinDistance("abc", "")).toBe(3);
+    expect(levenshteinDistance("kitten", "sitting")).toBe(3);
+    expect(levenshteinDistance("a", "b")).toBe(1);
+  });
 });
 
 describe("ask citation helpers", () => {

--- a/test/unit/github-commands.test.ts
+++ b/test/unit/github-commands.test.ts
@@ -8,6 +8,7 @@ import {
   parseAgentCommandFeedbackContext,
   parseGittensoryMentionCommand,
   sanitizePublicComment,
+  suggestCommand,
   githubCommandsInternals,
 } from "../../src/github/commands";
 
@@ -30,7 +31,7 @@ describe("GitHub mention commands", () => {
     expect(parseGittensoryMentionCommand("@gittensory review-now")?.name).toBe("review-now");
     expect(parseGittensoryMentionCommand("@gittensory needs-author")?.name).toBe("needs-author");
     expect(parseGittensoryMentionCommand("@gittensory duplicate-clusters")?.name).toBe("duplicate-clusters");
-    expect(parseGittensoryMentionCommand("@gittensory unknown")?.name).toBe("help");
+    expect(parseGittensoryMentionCommand("@gittensory unknown")).toMatchObject({ name: "help", unknownVerb: "unknown" });
     // gate-override is an action command: it must be recognized (NOT downgraded to "help") and carry the
     // trailing free text as its reason.
     expect(parseGittensoryMentionCommand("@gittensory gate-override")).toMatchObject({ name: "gate-override", reason: undefined });
@@ -45,6 +46,9 @@ describe("GitHub mention commands", () => {
     expect(parseGittensoryMentionCommand("@gittensory2 preflight")).toBeNull();
     expect(isMaintainerOnlyCommand("queue-summary")).toBe(true);
     expect(isMaintainerOnlyCommand("preflight")).toBe(false);
+    expect(parseGittensoryMentionCommand("@gittensory")?.unknownVerb).toBeUndefined();
+    expect(parseGittensoryMentionCommand("@gittensory help")?.unknownVerb).toBeUndefined();
+    expect(parseGittensoryMentionCommand("@gittensory preflight")?.unknownVerb).toBeUndefined();
   });
 
   it("authorizes maintainers and confirmed miner PR authors only", () => {
@@ -516,6 +520,25 @@ describe("GitHub mention commands", () => {
     expect(help).toContain("Freshness: shipped command list.");
     expect(help).toContain("<summary>Additional safe details</summary>");
     expect(help).toContain("@gittensory next-action");
+
+    const typoHelp = buildPublicAgentCommandComment({
+      command: parseGittensoryMentionCommand("@gittensory prefight")!,
+      repo: null,
+      issue: { number: 4, title: "PR", state: "open", pull_request: {} },
+      pullRequest: null,
+      actorKind: "maintainer",
+    });
+    expect(typoHelp).toContain("Did you mean `@gittensory preflight`?");
+    expect(help).not.toContain("Did you mean");
+
+    const gibberishHelp = buildPublicAgentCommandComment({
+      command: parseGittensoryMentionCommand("@gittensory xyzzyplugh")!,
+      repo: null,
+      issue: { number: 5, title: "PR", state: "open", pull_request: {} },
+      pullRequest: null,
+      actorKind: "maintainer",
+    });
+    expect(gibberishHelp).not.toContain("Did you mean");
 
     const minerFallback = buildPublicAgentCommandComment({
       command: parseGittensoryMentionCommand("@gittensory miner-context")!,
@@ -1929,6 +1952,27 @@ describe("GitHub mention commands", () => {
     expect(digest.repoFullName).toBe("this repository");
     expect(digest.reviewNowPullRequests).toHaveLength(0);
     expect(digest.needsAuthorPullRequests).toHaveLength(0);
+  });
+});
+
+describe("suggestCommand (#2170)", () => {
+  it("suggests the nearest known command for a close typo", () => {
+    expect(suggestCommand("prefight")).toBe("preflight");
+    expect(suggestCommand("blokcers")).toBe("blockers");
+    expect(suggestCommand("reveiw-now")).toBe("review-now");
+  });
+
+  it("returns null for gibberish, empty input, and already-known verbs", () => {
+    expect(suggestCommand("xyzzyplugh")).toBeNull();
+    expect(suggestCommand("")).toBeNull();
+    expect(suggestCommand(null)).toBeNull();
+    expect(suggestCommand("preflight")).toBeNull();
+    expect(suggestCommand("gate-override")).toBeNull();
+  });
+
+  it("respects the edit-distance threshold at the boundary", () => {
+    expect(suggestCommand("prefligt")).toBe("preflight");
+    expect(suggestCommand("zzzzzzzzzz")).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

- Add pure `suggestCommand(rawVerb)` that picks the nearest known mention/action verb by Levenshtein distance (threshold 2).
- Track `unknownVerb` when the parser downgrades an unrecognized non-empty verb to `help`.
- Render `Did you mean @gittensory <verb>?` in the help card only for that case; bare `@gittensory` and explicit `@gittensory help` stay unchanged.

Fixes #2170

## Scope

- [x] Conventional Commit title format.
- [x] Focused — `src/github/commands.ts` + unit tests only.
- [x] Linked open issue (#2170, unassigned, not maintainer-only).

## Validation

- [x] `git diff --check`
- [x] `npx vitest run test/unit/github-commands.test.ts` — 29 passed
- [x] Unit tests cover typo suggestion, gibberish, empty/known verbs, and help-card rendering

## Safety

- [x] Pure + public-safe (no network); suggestion only appears in help fallback.
- [x] N/A for UI Evidence.

## Conflict avoidance

Touches only `src/github/commands.ts` and `test/unit/github-commands.test.ts`. No open upstream PRs at submission time; isolated from review/signals/enrichment surfaces.

Made with [Cursor](https://cursor.com)