### PR TITLE
feat(commands): did-you-mean hint for unknown @gittensory verbs (#2170)

### DIFF
--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -63,6 +63,8 @@ export type GittensoryMentionCommand = {
   raw: string;
   question?: string | undefined;
   reason?: string | undefined;
+  /** Present when a non-empty verb was unrecognized and downgraded to `help` (#2170). */
+  unknownVerb?: string | undefined;
 };
 
 type PublicAnswerCard = {
@@ -161,6 +163,51 @@ export type MaintainerQueueDigest = {
   controlPanelUrl?: string | null | undefined;
 };
 
+const ALL_KNOWN_COMMAND_NAMES = [...GITTENSORY_MENTION_COMMAND_CATALOG.map((command) => command.id), ...GITTENSORY_ACTION_COMMANDS] as const;
+
+/** Max Levenshtein distance for a did-you-mean suggestion on an unrecognized verb (#2170). */
+const COMMAND_SUGGEST_MAX_DISTANCE = 2;
+
+function levenshteinDistance(left: string, right: string): number {
+  if (left === right) return 0;
+  if (left.length === 0) return right.length;
+  if (right.length === 0) return left.length;
+  const rows = left.length + 1;
+  const cols = right.length + 1;
+  const matrix: number[][] = Array.from({ length: rows }, () => Array<number>(cols).fill(0));
+  for (let row = 0; row < rows; row++) matrix[row]![0] = row;
+  for (let col = 0; col < cols; col++) matrix[0]![col] = col;
+  for (let row = 1; row < rows; row++) {
+    for (let col = 1; col < cols; col++) {
+      const cost = left[row - 1] === right[col - 1] ? 0 : 1;
+      matrix[row]![col] = Math.min(
+        matrix[row - 1]![col]! + 1,
+        matrix[row]![col - 1]! + 1,
+        matrix[row - 1]![col - 1]! + cost,
+      );
+    }
+  }
+  return matrix[left.length]![right.length]!;
+}
+
+/** Pure did-you-mean suggester for unrecognized @gittensory verbs (#2170). */
+export function suggestCommand(rawVerb: string): string | null {
+  const verb = rawVerb.trim().toLowerCase();
+  if (!verb) return null;
+  if (COMMANDS.has(verb as GittensoryMentionCommandName) || ACTION_COMMANDS.has(verb as GittensoryActionCommandName)) {
+    return null;
+  }
+  let best: { name: string; distance: number } | null = null;
+  for (const name of ALL_KNOWN_COMMAND_NAMES) {
+    const distance = levenshteinDistance(verb, name);
+    if (best === null || distance < best.distance) {
+      best = { name, distance };
+    }
+  }
+  if (!best || best.distance === 0 || best.distance > COMMAND_SUGGEST_MAX_DISTANCE) return null;
+  return best.name;
+}
+
 export function parseGittensoryMentionCommand(body: string | null | undefined): GittensoryMentionCommand | null {
   if (!body) return null;
   // `(?![\w-])` requires the mention to end at a non-identifier char, so other usernames that merely
@@ -168,14 +215,25 @@ export function parseGittensoryMentionCommand(body: string | null | undefined): 
   // bare `@gittensory help` command. A space, end-of-string, or punctuation still matches.
   const match = body.match(/(?:^|\s)@gittensory(?![\w-])(?:\s+([a-z-]+))?([^\n\r]*)/i);
   if (!match) return null;
-  const requested = (match[1]?.toLowerCase() || "help") as GittensoryMentionCommandName | GittensoryActionCommandName;
+  const rawVerb = match[1]?.toLowerCase();
+  if (!rawVerb) {
+    return { name: "help", raw: match[0].trim() };
+  }
+  const requested = rawVerb as GittensoryMentionCommandName | GittensoryActionCommandName;
   if (ACTION_COMMANDS.has(requested as GittensoryActionCommandName)) {
     const reason = (match[2] ?? "").trim();
     return { name: requested as GittensoryActionCommandName, raw: match[0].trim(), reason: reason.length > 0 ? reason : undefined };
   }
-  const name = COMMANDS.has(requested as GittensoryMentionCommandName) ? (requested as GittensoryMentionCommandName) : "help";
-  const question = name === "ask" ? (match[2] ?? "").trim() : undefined;
-  return { name, raw: match[0].trim(), question: question && question.length > 0 ? question : undefined };
+  if (COMMANDS.has(requested as GittensoryMentionCommandName)) {
+    const name = requested as GittensoryMentionCommandName;
+    const question = name === "ask" ? (match[2] ?? "").trim() : undefined;
+    return {
+      name,
+      raw: match[0].trim(),
+      question: question && question.length > 0 ? question : undefined,
+    };
+  }
+  return { name: "help", raw: match[0].trim(), unknownVerb: rawVerb };
 }
 
 export function isMaintainerAssociation(association: string | null | undefined): boolean {
@@ -258,7 +316,7 @@ export function buildPublicAgentCommandComment(args: {
   // Action commands (e.g. gate-override) never reach this Q&A renderer — they are handled and short-circuited
   // earlier — so narrow the widened parse name back to a Q&A command name for the answer-card helpers.
   const commandName = args.command.name as GittensoryMentionCommandName;
-  const sections = commandSections(commandName, args.bundle, args.officialMiner, args.maintainerDigest, args.command.question);
+  const sections = commandSections(commandName, args.bundle, args.officialMiner, args.maintainerDigest, args.command.question, args.command.unknownVerb);
   const card = buildPublicAnswerCard({
     command: commandName,
     sections,
@@ -593,10 +651,11 @@ function commandSections(
   officialMiner: GittensorContributorSnapshot | null | undefined,
   maintainerDigest: MaintainerQueueDigest | null | undefined,
   question?: string | undefined,
+  unknownVerb?: string | undefined,
 ): string[] {
   switch (command) {
     case "help":
-      return helpSections();
+      return helpSections(unknownVerb);
     case "ask":
       return askSections(bundle, question);
     case "miner-context":
@@ -628,10 +687,16 @@ function commandSections(
   }
 }
 
-function helpSections(): string[] {
+function helpSections(unknownVerb?: string | undefined): string[] {
+  const suggestion = unknownVerb ? suggestCommand(unknownVerb) : null;
+  const didYouMean =
+    suggestion !== null
+      ? [`- Did you mean \`@gittensory ${suggestion}\`?`, ""]
+      : [];
   return [
     "**Commands**",
     "",
+    ...didYouMean,
     "- `@gittensory help` shows this command list.",
     "- `@gittensory ask <question>` answers contribution-quality Q&A with source citations and freshness.",
     "- `@gittensory preflight` summarizes public PR hygiene.",

--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -1622,4 +1622,7 @@ export const githubCommandsInternals = {
   snapshotFreshnessFromWarnings,
   refreshSections,
   askSections,
+  levenshteinDistance,
+  helpSections,
+  suggestCommand,
 };

--- a/test/unit/command-suggest.test.ts
+++ b/test/unit/command-suggest.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import { githubCommandsInternals, parseGittensoryMentionCommand, suggestCommand } from "../../src/github/commands";
+
+describe("command suggest coverage (#2170)", () => {
+  const { levenshteinDistance } = githubCommandsInternals;
+
+  it("exercises levenshtein insert, delete, and substitute branches", () => {
+    expect(levenshteinDistance("kitten", "sitting")).toBe(3);
+    expect(levenshteinDistance("ab", "a")).toBe(1);
+    expect(levenshteinDistance("a", "ab")).toBe(1);
+    expect(levenshteinDistance("abc", "axc")).toBe(1);
+  });
+
+  it("keeps the nearest command when later catalog entries are farther away", () => {
+    expect(suggestCommand("hel")).toBe("help");
+    expect(suggestCommand("gate-overrid")).toBe("gate-override");
+  });
+
+  it("returns null for action verbs that are already known", () => {
+    expect(suggestCommand("gate-override")).toBeNull();
+  });
+
+  it("records unknownVerb only when a non-empty verb fails lookup", () => {
+    expect(parseGittensoryMentionCommand(null)).toBeNull();
+    expect(parseGittensoryMentionCommand("@gittensory ask what now?")).toMatchObject({
+      name: "ask",
+      question: "what now?",
+      unknownVerb: undefined,
+    });
+  });
+});

--- a/test/unit/github-commands.test.ts
+++ b/test/unit/github-commands.test.ts
@@ -33,7 +33,8 @@ describe("GitHub mention commands", () => {
     expect(parseGittensoryMentionCommand("@gittensory duplicate-clusters")?.name).toBe("duplicate-clusters");
     expect(parseGittensoryMentionCommand("@gittensory unknown")?.name).toBe("help");
     expect(parseGittensoryMentionCommand("@gittensory unknown")).toMatchObject({ name: "help", unknownVerb: "unknown" });
-    expect(parseGittensoryMentionCommand("@gittensory")).toMatchObject({ name: "help", unknownVerb: undefined });
+    expect(parseGittensoryMentionCommand("@gittensory")?.name).toBe("help");
+    expect(parseGittensoryMentionCommand("@gittensory")?.unknownVerb).toBeUndefined();
     // gate-override is an action command: it must be recognized (NOT downgraded to "help") and carry the
     // trailing free text as its reason.
     expect(parseGittensoryMentionCommand("@gittensory gate-override")).toMatchObject({ name: "gate-override", reason: undefined });

--- a/test/unit/github-commands.test.ts
+++ b/test/unit/github-commands.test.ts
@@ -8,6 +8,7 @@ import {
   parseAgentCommandFeedbackContext,
   parseGittensoryMentionCommand,
   sanitizePublicComment,
+  suggestCommand,
   githubCommandsInternals,
 } from "../../src/github/commands";
 
@@ -31,6 +32,8 @@ describe("GitHub mention commands", () => {
     expect(parseGittensoryMentionCommand("@gittensory needs-author")?.name).toBe("needs-author");
     expect(parseGittensoryMentionCommand("@gittensory duplicate-clusters")?.name).toBe("duplicate-clusters");
     expect(parseGittensoryMentionCommand("@gittensory unknown")?.name).toBe("help");
+    expect(parseGittensoryMentionCommand("@gittensory unknown")).toMatchObject({ name: "help", unknownVerb: "unknown" });
+    expect(parseGittensoryMentionCommand("@gittensory")).toMatchObject({ name: "help", unknownVerb: undefined });
     // gate-override is an action command: it must be recognized (NOT downgraded to "help") and carry the
     // trailing free text as its reason.
     expect(parseGittensoryMentionCommand("@gittensory gate-override")).toMatchObject({ name: "gate-override", reason: undefined });
@@ -1929,6 +1932,61 @@ describe("GitHub mention commands", () => {
     expect(digest.repoFullName).toBe("this repository");
     expect(digest.reviewNowPullRequests).toHaveLength(0);
     expect(digest.needsAuthorPullRequests).toHaveLength(0);
+  });
+});
+
+describe("suggestCommand (#2170)", () => {
+  it("suggests the nearest known command for a close typo", () => {
+    expect(suggestCommand("prefliht")).toBe("preflight");
+    expect(suggestCommand("blokcers")).toBe("blockers");
+  });
+
+  it("returns null for gibberish beyond the edit-distance threshold", () => {
+    expect(suggestCommand("zzzz")).toBeNull();
+    expect(suggestCommand("xyzzyqwerty")).toBeNull();
+  });
+
+  it("returns null for empty or already-known verbs", () => {
+    expect(suggestCommand("")).toBeNull();
+    expect(suggestCommand("   ")).toBeNull();
+    expect(suggestCommand("help")).toBeNull();
+    expect(suggestCommand("preflight")).toBeNull();
+    expect(suggestCommand("gate-override")).toBeNull();
+  });
+
+  it("surfaces a did-you-mean line for unrecognized verbs but not for bare @gittensory", () => {
+    const typo = parseGittensoryMentionCommand("@gittensory prefliht")!;
+    const typoBody = buildPublicAgentCommandComment({
+      command: typo,
+      repo: null,
+      issue: { number: 1, title: "t", state: "open" },
+      pullRequest: null,
+      actorKind: "maintainer",
+    });
+    expect(typoBody).toContain("Did you mean `@gittensory preflight`?");
+
+    const bare = parseGittensoryMentionCommand("@gittensory")!;
+    const bareBody = buildPublicAgentCommandComment({
+      command: bare,
+      repo: null,
+      issue: { number: 1, title: "t", state: "open" },
+      pullRequest: null,
+      actorKind: "maintainer",
+    });
+    expect(bareBody).not.toContain("Did you mean");
+  });
+
+  it("does not suggest when the verb is recognized", () => {
+    const ok = parseGittensoryMentionCommand("@gittensory preflight")!;
+    expect(ok.unknownVerb).toBeUndefined();
+    const body = buildPublicAgentCommandComment({
+      command: ok,
+      repo: null,
+      issue: { number: 1, title: "t", state: "open" },
+      pullRequest: null,
+      actorKind: "maintainer",
+    });
+    expect(body).not.toContain("Did you mean");
   });
 });
 

--- a/test/unit/github-commands.test.ts
+++ b/test/unit/github-commands.test.ts
@@ -1989,6 +1989,30 @@ describe("suggestCommand (#2170)", () => {
     });
     expect(body).not.toContain("Did you mean");
   });
+
+  it("does not render did-you-mean when the typo is too far from any command", () => {
+    expect(suggestCommand("zzzz")).toBeNull();
+    const far = parseGittensoryMentionCommand("@gittensory zzzz")!;
+    expect(far).toMatchObject({ name: "help", unknownVerb: "zzzz" });
+    const body = buildPublicAgentCommandComment({
+      command: far,
+      repo: null,
+      issue: { number: 1, title: "t", state: "open" },
+      pullRequest: null,
+      actorKind: "maintainer",
+    });
+    expect(body).not.toContain("Did you mean");
+  });
+
+  it("covers levenshtein edge branches and the help-section no-suggestion arm", () => {
+    const { levenshteinDistance, helpSections } = githubCommandsInternals;
+    expect(levenshteinDistance("", "")).toBe(0);
+    expect(levenshteinDistance("", "help")).toBe(4);
+    expect(levenshteinDistance("help", "")).toBe(4);
+    expect(levenshteinDistance("help", "help")).toBe(0);
+    expect(helpSections("zzzz").join("\n")).not.toContain("Did you mean");
+    expect(helpSections("prefliht").join("\n")).toContain("Did you mean `@gittensory preflight`?");
+  });
 });
 
 describe("ask citation helpers", () => {


### PR DESCRIPTION
## Summary
- Add pure `suggestCommand(rawVerb)` (Levenshtein distance, threshold 2) over mention + action verbs
- Preserve unrecognized verbs on parse (`unknownVerb`) when downgrading to `help`
- Render `Did you mean @gittensory <command>?` only for close typos; bare `@gittensory` and known verbs unchanged

Fixes #2170

## Test plan
- [x] Typo, gibberish, empty, known verb, action-verb typo, levenshtein matrix branches
- [x] Help comment integration for typo vs bare/known/far-off verbs
- [x] `npx tsc -p tsconfig.json --noEmit` passes locally
- [ ] CI green including codecov/patch ≥99%


Made with [Cursor](https://cursor.com)