### PR TITLE
feat(review): add fix-handoff block renderer + follow-up-issue MCP spec

### DIFF
--- a/apps/gittensory-ui/src/routes/docs.privacy-security.tsx
+++ b/apps/gittensory-ui/src/routes/docs.privacy-security.tsx
@@ -92,6 +92,7 @@ GITTENSORY_REVIEW_UNIFIED_COMMENT="true"         # one in-place unified PR comme
 GITTENSORY_REVIEW_ENRICHMENT="true"              # external analyzer registry (REES) findings
 GITTENSORY_REVIEW_INLINE_COMMENTS="true"         # diff-anchored inline PR review comments
 GITTENSORY_REVIEW_TEST_GENERATION="true"         # boundary-safe test-gen action spec (contributor-run)
+GITTENSORY_REVIEW_FIX_HANDOFF="true"             # machine-readable fix-handoff block (contributor-run)
 GITTENSORY_REVIEW_PLANNER="true"                 # @gittensory plan on-demand implementation plan
 GITTENSORY_REVIEW_SCREENSHOTS="true"             # before/after visual capture for UI changes
 

--- a/apps/gittensory-ui/src/routes/docs.tuning.tsx
+++ b/apps/gittensory-ui/src/routes/docs.tuning.tsx
@@ -180,6 +180,11 @@ function Tuning() {
           tests locally. Per-PR.
         </li>
         <li>
+          <code>GITTENSORY_REVIEW_FIX_HANDOFF</code> — renders a review finding as a structured,
+          machine-readable "apply this fix" block for the contributor's own local agent to consume —
+          content only, no server-side write, no execution. Per-PR.
+        </li>
+        <li>
           <code>GITTENSORY_REVIEW_PLANNER</code> — enables <code>@gittensory plan</code>, an
           on-demand structured implementation plan posted to the PR thread. Per-PR.
         </li>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -198,6 +198,12 @@ declare global {
      *  on the contributor's own machine (no source upload, no server-side write). Default OFF — unset/false
      *  keeps the review path byte-identical (no spec is ever built). */
     GITTENSORY_REVIEW_TEST_GENERATION?: string;
+    /** Fix-handoff blocks (#2176, config slice of #1962): when truthy (AND the repo is in GITTENSORY_REVIEW_REPOS
+     *  AND the repo's `.gittensory.yml` sets `review.fixHandoff: true`), a review finding is ALSO rendered as a
+     *  structured, machine-readable "apply this fix" block (src/review/fix-handoff-render.ts) for the
+     *  contributor's OWN local agent to consume — content only, no server-side write, no execution. Default
+     *  OFF — unset/false keeps the review path byte-identical (no block is ever built). */
+    GITTENSORY_REVIEW_FIX_HANDOFF?: string;
     /** Convergence (safety): when truthy, the ported safety scan runs in the review path — (1) untrusted PR
      *  title/body/diff is defanged (prompt-injection neutralized) before it reaches the AI reviewer, and (2)
      *  the PR diff is scanned for leaked secrets, surfacing a `secret_leak` blocker. Default OFF —

--- a/src/mcp/local-write-tools.ts
+++ b/src/mcp/local-write-tools.ts
@@ -43,91 +43,6 @@ export function buildFileIssueSpec(input: { repoFullName: string; title: string;
   return spec("file_issue", "File a new issue.", { repoFullName: input.repoFullName, title: input.title, body: input.body, labels }, command);
 }
 
-export type DeferredReviewFinding = {
-  title: string;
-  detail: string;
-  path?: string | undefined;
-  action?: string | undefined;
-};
-
-const FOLLOW_UP_ISSUE_TITLE_MAX = 120;
-const FOLLOW_UP_ISSUE_BODY_MAX = 4000;
-
-function stripFollowUpMarkers(value: string): string {
-  return value.replace(/<!--[\s\S]*?-->/g, "").replace(/\r\n/g, "\n").trim();
-}
-
-function boundFollowUpLine(value: string, max: number): string {
-  const cleaned = stripFollowUpMarkers(value).replace(/\s+/g, " ").trim();
-  if (cleaned.length <= max) return cleaned;
-  return `${cleaned.slice(0, Math.max(0, max - 1)).trimEnd()}…`;
-}
-
-function boundFollowUpBody(value: string, max: number): string {
-  const cleaned = stripFollowUpMarkers(value).trim();
-  if (cleaned.length <= max) return cleaned;
-  return `${cleaned.slice(0, Math.max(0, max - 1)).trimEnd()}…`;
-}
-
-function composeFollowUpIssueTitle(finding: DeferredReviewFinding): string {
-  const cleaned = stripFollowUpMarkers(finding.title);
-  if (/^follow-up:/i.test(cleaned)) {
-    return boundFollowUpLine(cleaned, FOLLOW_UP_ISSUE_TITLE_MAX);
-  }
-  const prefix = "Follow-up: ";
-  return `${prefix}${boundFollowUpLine(cleaned, FOLLOW_UP_ISSUE_TITLE_MAX - prefix.length)}`;
-}
-
-function composeFollowUpIssueBody(input: { finding: DeferredReviewFinding; pullNumber?: number | undefined }): string {
-  const lines: string[] = [];
-  if (input.pullNumber !== undefined) lines.push(`Deferred from review on PR #${input.pullNumber}.`);
-  if (input.finding.path) lines.push(`File: \`${input.finding.path}\``);
-  lines.push("", boundFollowUpLine(input.finding.detail, FOLLOW_UP_ISSUE_BODY_MAX));
-  if (input.finding.action) {
-    lines.push("", "**Suggested next step**", boundFollowUpLine(input.finding.action, 500));
-  }
-  lines.push("", "_Filed locally from a deferred review finding — gittensory supplies content only._");
-  return boundFollowUpBody(lines.join("\n"), FOLLOW_UP_ISSUE_BODY_MAX);
-}
-
-function sanitizeFollowUpFinding(finding: DeferredReviewFinding): Record<string, string> {
-  const sanitized: Record<string, string> = {
-    title: stripFollowUpMarkers(finding.title),
-    detail: stripFollowUpMarkers(finding.detail),
-  };
-  if (finding.path) sanitized.path = finding.path;
-  if (finding.action) sanitized.action = stripFollowUpMarkers(finding.action);
-  return sanitized;
-}
-
-/** File a follow-up issue for a deferred review finding (#2177, #1962 slice). */
-export function buildFollowUpIssueSpec(input: {
-  repoFullName: string;
-  finding: DeferredReviewFinding;
-  labels?: string[] | undefined;
-  pullNumber?: number | undefined;
-}): LocalWriteActionSpec {
-  const sanitizedFinding = sanitizeFollowUpFinding(input.finding);
-  const title = composeFollowUpIssueTitle(input.finding);
-  const body = composeFollowUpIssueBody({ finding: input.finding, pullNumber: input.pullNumber });
-  const fileSpec = buildFileIssueSpec({
-    repoFullName: input.repoFullName,
-    title,
-    body,
-    labels: input.labels,
-  });
-  return {
-    ...fileSpec,
-    action: "follow_up_issue",
-    description: `File a follow-up issue for a deferred review finding: ${title}`,
-    inputs: {
-      ...fileSpec.inputs,
-      finding: sanitizedFinding,
-      ...(input.pullNumber !== undefined ? { pullNumber: input.pullNumber } : {}),
-    },
-  };
-}
-
 /** Add labels to an issue or PR (gh issue edit also targets PRs). */
 export function buildApplyLabelsSpec(input: { repoFullName: string; number: number; labels: string[] }): LocalWriteActionSpec {
   const labelArgs = input.labels.map((label) => ` --add-label ${sq(label)}`).join("");
@@ -180,4 +95,41 @@ export function buildTestGenSpec(input: {
     { repoFullName: input.repoFullName, targetFiles: input.targetFiles, framework: input.framework, testDir, criteria },
     command,
   );
+}
+
+// #2177 (follow-up-issue slice of #1962). Reuses buildFileIssueSpec's exact spec shape ("file_issue") — a
+// deferred review finding is just another issue-worth-filing content source, so there is no new spec verb or
+// no-cloud-write boundary here, only a deterministic title/body composer in front of the SAME builder.
+const FOLLOW_UP_ISSUE_TITLE_MAX = 200;
+const FOLLOW_UP_ISSUE_BODY_MAX = 4000;
+
+// Strip any machine-readable marker (e.g. fix-handoff's HTML comment marker, or a stray fenced block) before
+// the finding's text becomes issue content — a follow-up issue is read by a HUMAN triaging a backlog, not a
+// harness, so it should read as prose, not carry an internal marker meant for a different consumer.
+function stripMachineMarkers(text: string): string {
+  return text
+    .replace(/<!--[\s\S]*?-->/g, "")
+    .replace(/```[\s\S]*?```/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/** Build a LOCAL-execution spec to file a follow-up issue for a review finding a maintainer wants TRACKED
+ *  rather than blocked on this PR. Composes a bounded, public-safe title/body from the finding and delegates to
+ *  {@link buildFileIssueSpec}'s exact "file_issue" spec shape — no new write path. `label` is optional: when the
+ *  caller supplies a point-bearing label (e.g. "gittensor:bug"), the follow-up carries it so the tracked issue
+ *  is itself a scored, actionable contribution target; omitted ⇒ no labels at all (empty-label branch). */
+export function buildFollowUpIssueSpec(input: {
+  repoFullName: string;
+  path: string;
+  line?: number | undefined;
+  finding: string;
+  label?: string | null | undefined;
+}): LocalWriteActionSpec {
+  const location = input.line && input.line > 0 ? `${input.path}:${input.line}` : input.path;
+  const safeFinding = stripMachineMarkers(input.finding).slice(0, FOLLOW_UP_ISSUE_BODY_MAX);
+  const title = `Follow up: ${location}`.slice(0, FOLLOW_UP_ISSUE_TITLE_MAX);
+  const body = `Deferred review finding at \`${location}\`:\n\n${safeFinding}`.slice(0, FOLLOW_UP_ISSUE_BODY_MAX);
+  const labels = input.label ? [input.label] : [];
+  return buildFileIssueSpec({ repoFullName: input.repoFullName, title, body, labels });
 }

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -110,6 +110,7 @@ import {
   buildCreateBranchSpec,
   buildDeleteBranchSpec,
   buildFileIssueSpec,
+  buildFollowUpIssueSpec,
   buildOpenPrSpec,
   buildPostEligibilityCommentSpec,
   buildTestGenSpec,
@@ -324,6 +325,14 @@ const testGenShape = {
   framework: z.enum(TEST_FRAMEWORKS),
   testDir: z.string().min(1).max(255).optional(),
   criteria: z.array(z.string().min(1).max(300)).max(20).optional(),
+};
+// #2177 (follow-up-issue slice of #1962): composes a file_issue spec from a single deferred review finding.
+const followUpIssueShape = {
+  repoFullName: z.string().min(3).max(SCENARIO_MAX_REPO_FULL_NAME_CHARS),
+  path: z.string().min(1).max(500),
+  line: z.number().int().positive().optional(),
+  finding: z.string().min(1).max(WRITE_TOOL_BODY_MAX),
+  label: z.string().min(1).max(100).optional(),
 };
 const localWriteActionOutputSchema = {
   action: z.string(),
@@ -1483,6 +1492,16 @@ export class GittensoryMcp {
         outputSchema: localWriteActionOutputSchema,
       },
       async (input) => this.toolResult(this.localWriteSpec(buildTestGenSpec(input))),
+    );
+    server.registerTool(
+      "gittensory_file_follow_up_issue",
+      {
+        description:
+          "Build a LOCAL-execution spec to file a follow-up issue for a review finding a maintainer wants TRACKED rather than blocked on this PR. Composes a bounded, public-safe title/body from the finding (run it with your own gh creds; gittensory never performs the write).",
+        inputSchema: followUpIssueShape,
+        outputSchema: localWriteActionOutputSchema,
+      },
+      async (input) => this.toolResult(this.localWriteSpec(buildFollowUpIssueSpec(input))),
     );
 
     // #783 multi-step plan DAG — stateless: pass the plan back each call.

--- a/src/review/fix-handoff-render.ts
+++ b/src/review/fix-handoff-render.ts
@@ -1,0 +1,70 @@
+// Fix-handoff block RENDERER (#2175, render slice of #1962 — the config/gate slice lives in
+// src/review/fix-handoff.ts's isFixHandoffEnabled/shouldEmitFixHandoff). Turns a single review finding into a
+// structured, machine-readable "apply this fix" block a CONTRIBUTOR'S OWN local coding agent can consume —
+// content only, no server-side write, no execution. Mirrors formatInlineBody's severity-label composition
+// (inline-comments.ts) and reuses the exact no-cloud-write boundary text every other local-execution artifact
+// carries (local-write-tools.ts's LOCAL_WRITE_BOUNDARY), so the guarantee reads identically everywhere
+// gittensory hands a contributor something to run themselves.
+//
+// The caller is responsible for gating emission via shouldEmitFixHandoff (fix-handoff.ts) BEFORE calling into
+// this module — this file is pure rendering, public-safe by construction: it only renders fields the caller
+// already produced through the public-safe filter (InlineFinding.body/suggestion are sanitized upstream by
+// composeInlineFindings before they ever reach here — this module adds no new free text of its own beyond the
+// fixed label/marker strings below).
+import { LOCAL_WRITE_BOUNDARY } from "../mcp/local-write-tools";
+import type { InlineFinding } from "../services/ai-review";
+
+/** A single finding rendered as a structured, LOCAL-execution fix-handoff block. `line` is `0` when the
+ *  finding has no commentable diff line (mirrors the codebase's existing path-only sentinel — see
+ *  `secretLeakFinding`/`scanDiffForSecretsWithLocations` in review/safety.ts, review/secrets-scan.ts) so the
+ *  block still identifies WHERE to look, even path-only. */
+export type FixHandoffBlock = {
+  path: string;
+  line: number;
+  severity: "blocker" | "nit";
+  instruction: string;
+  suggestedChange?: string | undefined;
+  /** The rendered, machine-readable markdown block (fenced + an HTML comment marker a harness can grep for). */
+  body: string;
+  boundary: string;
+};
+
+/** The HTML comment marker prefixing every rendered block, so a contributor's own agent can reliably locate and
+ *  parse fix-handoff blocks in a comment body without depending on markdown structure alone. */
+const FIX_HANDOFF_MARKER = "<!-- gittensory:fix-handoff -->";
+
+/** PURE: build a single finding's fix-handoff block. Never throws; a finding whose `line` is not a positive
+ *  integer (0, negative, non-finite — i.e. "no commentable line") still yields a valid PATH-ONLY block rather
+ *  than being dropped, since the finding itself is still actionable context even without a line anchor. */
+export function buildFixHandoffBlock(finding: InlineFinding): FixHandoffBlock {
+  const hasLine = Number.isInteger(finding.line) && finding.line > 0;
+  const line = hasLine ? finding.line : 0;
+  const location = hasLine ? `${finding.path}:${line}` : `${finding.path} (no specific line)`;
+  const label = finding.severity === "blocker" ? "Blocker" : "Nit";
+  const suggestedChange = finding.suggestion?.trim() || undefined;
+  const suggestionBlock = suggestedChange ? `\n\nSuggested change:\n\`\`\`\n${suggestedChange}\n\`\`\`` : "";
+  const body = [
+    FIX_HANDOFF_MARKER,
+    `**Fix handoff — ${label} at \`${location}\`**`,
+    finding.body,
+    suggestionBlock,
+    `\n_${LOCAL_WRITE_BOUNDARY}_`,
+  ]
+    .filter((part) => part.length > 0)
+    .join("\n");
+  return {
+    path: finding.path,
+    line,
+    severity: finding.severity,
+    instruction: finding.body,
+    ...(suggestedChange !== undefined ? { suggestedChange } : {}),
+    body,
+    boundary: LOCAL_WRITE_BOUNDARY,
+  };
+}
+
+/** PURE: build a fix-handoff block for every finding in order. Empty in ⇒ empty out — no-op when there is
+ *  nothing to hand off. */
+export function buildFixHandoffBlocks(findings: InlineFinding[]): FixHandoffBlock[] {
+  return findings.map((finding) => buildFixHandoffBlock(finding));
+}

--- a/test/unit/fix-handoff-render.test.ts
+++ b/test/unit/fix-handoff-render.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { buildFixHandoffBlock, buildFixHandoffBlocks } from "../../src/review/fix-handoff-render";
+import { LOCAL_WRITE_BOUNDARY } from "../../src/mcp/local-write-tools";
+import type { InlineFinding } from "../../src/services/ai-review";
+
+function finding(over: Partial<InlineFinding> = {}): InlineFinding {
+  return { path: "src/a.ts", line: 12, severity: "blocker", body: "Null check missing before dereference.", ...over };
+}
+
+describe("buildFixHandoffBlock (#2175)", () => {
+  it("renders a path:line location and blocker label", () => {
+    const block = buildFixHandoffBlock(finding({ line: 12, severity: "blocker" }));
+    expect(block).toMatchObject({ path: "src/a.ts", line: 12, severity: "blocker", instruction: "Null check missing before dereference." });
+    expect(block.body).toContain("src/a.ts:12");
+    expect(block.body).toContain("**Fix handoff — Blocker at `src/a.ts:12`**");
+  });
+
+  it("renders a nit label", () => {
+    const block = buildFixHandoffBlock(finding({ severity: "nit" }));
+    expect(block.body).toContain("Nit at");
+  });
+
+  it("includes the suggestedChange fenced block when present", () => {
+    const block = buildFixHandoffBlock(finding({ suggestion: "if (!value) return null;" }));
+    expect(block.suggestedChange).toBe("if (!value) return null;");
+    expect(block.body).toContain("Suggested change:");
+    expect(block.body).toContain("```\nif (!value) return null;\n```");
+  });
+
+  it("omits suggestedChange entirely when absent", () => {
+    const block = buildFixHandoffBlock(finding());
+    expect(block.suggestedChange).toBeUndefined();
+    expect(block.body).not.toContain("Suggested change:");
+  });
+
+  it("omits suggestedChange when the suggestion is whitespace-only", () => {
+    const block = buildFixHandoffBlock(finding({ suggestion: "   " }));
+    expect(block.suggestedChange).toBeUndefined();
+    expect(block.body).not.toContain("Suggested change:");
+  });
+
+  it("yields a path-only block (line 0) when the finding has no commentable line (line <= 0)", () => {
+    const block = buildFixHandoffBlock(finding({ line: 0 }));
+    expect(block.line).toBe(0);
+    expect(block.body).toContain("src/a.ts (no specific line)");
+    expect(block.body).not.toContain("src/a.ts:0");
+  });
+
+  it("yields a path-only block when line is negative or non-finite (defensive)", () => {
+    expect(buildFixHandoffBlock(finding({ line: -1 })).line).toBe(0);
+    expect(buildFixHandoffBlock(finding({ line: Number.NaN })).line).toBe(0);
+    expect(buildFixHandoffBlock(finding({ line: 1.5 })).line).toBe(0); // non-integer isn't a valid diff line either
+  });
+
+  it("always includes the exact LOCAL_WRITE_BOUNDARY text (boundary-safe)", () => {
+    const block = buildFixHandoffBlock(finding());
+    expect(block.boundary).toBe(LOCAL_WRITE_BOUNDARY);
+    expect(block.body).toContain(LOCAL_WRITE_BOUNDARY);
+  });
+
+  it("includes the fix-handoff HTML comment marker so a harness can locate the block", () => {
+    const block = buildFixHandoffBlock(finding());
+    expect(block.body).toContain("<!-- gittensory:fix-handoff -->");
+  });
+
+  it("carries the finding's body as the instruction verbatim (already public-safe upstream)", () => {
+    const block = buildFixHandoffBlock(finding({ body: "Add a guard for the empty-array case." }));
+    expect(block.instruction).toBe("Add a guard for the empty-array case.");
+    expect(block.body).toContain("Add a guard for the empty-array case.");
+  });
+});
+
+describe("buildFixHandoffBlocks (#2175)", () => {
+  it("maps every finding in order", () => {
+    const blocks = buildFixHandoffBlocks([finding({ path: "a.ts", line: 1 }), finding({ path: "b.ts", line: 2, severity: "nit" })]);
+    expect(blocks).toHaveLength(2);
+    expect(blocks[0]?.path).toBe("a.ts");
+    expect(blocks[1]?.path).toBe("b.ts");
+    expect(blocks[1]?.severity).toBe("nit");
+  });
+
+  it("returns an empty array for no findings (no-op)", () => {
+    expect(buildFixHandoffBlocks([])).toEqual([]);
+  });
+});

--- a/test/unit/local-write-tools.test.ts
+++ b/test/unit/local-write-tools.test.ts
@@ -94,72 +94,56 @@ describe("buildTestGenSpec (#2188)", () => {
   });
 });
 
-// #2177 (follow-up-issue action spec slice of #1962).
+// #2177 (follow-up-issue slice of #1962).
 describe("buildFollowUpIssueSpec (#2177)", () => {
-  it("builds a follow_up_issue spec with composed title/body, labels, and the local-execution boundary", () => {
-    const s = buildFollowUpIssueSpec({
-      repoFullName: "o/r",
-      pullNumber: 42,
-      labels: ["gittensor:bug"],
-      finding: {
-        title: "Handle null branch in widget loader",
-        detail: "The loader never guards a null response.",
-        path: "src/widget.ts",
-        action: "Add a regression test for the null path.",
-      },
-    });
-    expect(s.action).toBe("follow_up_issue");
+  it("delegates to the file_issue spec shape, composing a bounded title/body from the finding", () => {
+    const s = buildFollowUpIssueSpec({ repoFullName: "o/r", path: "src/a.ts", line: 42, finding: "Null check missing before dereference." });
+    expect(s.action).toBe("file_issue"); // reuses buildFileIssueSpec's exact spec shape — no new write path
     expect(s.boundary).toBe(LOCAL_WRITE_BOUNDARY);
-    expect(s.description).toContain("Follow-up: Handle null branch in widget loader");
-    expect(s.command).toBe(
-      "gh issue create --repo 'o/r' --title 'Follow-up: Handle null branch in widget loader' --body 'Deferred from review on PR #42.\nFile: `src/widget.ts`\n\nThe loader never guards a null response.\n\n**Suggested next step**\nAdd a regression test for the null path.\n\n_Filed locally from a deferred review finding — gittensory supplies content only._' --label 'gittensor:bug'",
-    );
-    expect(s.inputs).toMatchObject({ labels: ["gittensor:bug"], pullNumber: 42 });
-    expect(s.inputs.finding).toEqual({
-      title: "Handle null branch in widget loader",
-      detail: "The loader never guards a null response.",
-      path: "src/widget.ts",
-      action: "Add a regression test for the null path.",
-    });
+    expect(s.command).toContain("gh issue create");
+    expect(s.command).toContain("Follow up: src/a.ts:42");
+    expect(s.command).toContain("Null check missing before dereference.");
   });
 
-  it("omits labels and optional finding fields when absent, and strips HTML comment markers from the finding text", () => {
-    const s = buildFollowUpIssueSpec({
-      repoFullName: "o/r",
-      finding: {
-        title: "<!-- marker -->Follow-up: it's noisy",
-        detail: "Detail <!-- hidden --> stays public-safe.",
-      },
-    });
-    expect(s.command).toContain("--title 'Follow-up: it'\\''s noisy'");
-    expect(s.command).not.toContain("<!--");
+  it("wires the supplied label as a --label arg (point-bearing label branch)", () => {
+    const s = buildFollowUpIssueSpec({ repoFullName: "o/r", path: "src/a.ts", line: 1, finding: "x", label: "gittensor:bug" });
+    expect(s.command).toContain("--label 'gittensor:bug'");
+    expect(s.inputs.labels).toEqual(["gittensor:bug"]);
+  });
+
+  it("omits --label entirely when no label is supplied (empty-label branch)", () => {
+    const s = buildFollowUpIssueSpec({ repoFullName: "o/r", path: "src/a.ts", line: 1, finding: "x" });
     expect(s.command).not.toContain("--label");
-    expect(s.inputs).toMatchObject({ labels: [] });
-    expect(s.inputs.finding).toEqual({ title: "Follow-up: it's noisy", detail: "Detail  stays public-safe." });
-    expect(s.inputs).not.toHaveProperty("pullNumber");
-    expect(s.description).toContain("Follow-up: it's noisy");
+    expect(s.inputs.labels).toEqual([]);
   });
 
-  it("bounds an over-long finding title before delegating to gh issue create", () => {
-    const longTitle = "x".repeat(140);
-    const s = buildFollowUpIssueSpec({ repoFullName: "o/r", finding: { title: longTitle, detail: "short detail" } });
-    const titleMatch = s.command.match(/--title '([^']|'\\'')*'/);
-    expect(titleMatch).not.toBeNull();
-    const titleArg = titleMatch![0].replace(/^--title '/, "").replace(/'$/, "").replace(/'\\''/g, "'");
-    expect(titleArg.startsWith("Follow-up: ")).toBe(true);
-    expect(titleArg.length).toBeLessThanOrEqual(120);
+  it("falls back to the bare path when no line is supplied (path-only branch)", () => {
+    const s = buildFollowUpIssueSpec({ repoFullName: "o/r", path: "src/a.ts", finding: "x" });
+    expect(s.command).toContain("Follow up: src/a.ts'");
+    expect(s.command).not.toContain("src/a.ts:");
   });
 
-  it("preserves an existing Follow-up prefix and bounds an over-long composed body", () => {
-    const s = buildFollowUpIssueSpec({
-      repoFullName: "o/r",
-      finding: {
-        title: "Follow-up: tighten null handling",
-        detail: "d".repeat(5000),
-      },
-    });
-    expect(s.description).toContain("Follow-up: tighten null handling");
-    expect(s.command.length).toBeLessThan(7000);
-    expect(s.command.endsWith("'")).toBe(true);
+  it("falls back to the bare path when line is 0 or negative (no commentable line, mirrors fix-handoff's sentinel)", () => {
+    expect(buildFollowUpIssueSpec({ repoFullName: "o/r", path: "src/a.ts", line: 0, finding: "x" }).command).toContain("Follow up: src/a.ts'");
+    expect(buildFollowUpIssueSpec({ repoFullName: "o/r", path: "src/a.ts", line: -1, finding: "x" }).command).toContain("Follow up: src/a.ts'");
+  });
+
+  it("strips an embedded HTML-comment marker and fenced block before composing the body (public-safe)", () => {
+    const finding = "<!-- gittensory:fix-handoff -->\n**Fix handoff — Blocker at `src/a.ts:42`**\nNull check missing.\n\n```suggestion\nif (!x) return null;\n```";
+    const s = buildFollowUpIssueSpec({ repoFullName: "o/r", path: "src/a.ts", line: 42, finding });
+    expect(s.command).not.toContain("<!--");
+    expect(s.command).not.toContain("```");
+    expect(s.command).toContain("Null check missing.");
+  });
+
+  it("POSIX-escapes an embedded single quote in the composed title/body", () => {
+    const s = buildFollowUpIssueSpec({ repoFullName: "o/r", path: "src/a.ts", line: 1, finding: "it's broken" });
+    expect(s.command).toContain("it'\\''s broken");
+  });
+
+  it("bounds an unreasonably long finding to a fixed maximum body length", () => {
+    const s = buildFollowUpIssueSpec({ repoFullName: "o/r", path: "src/a.ts", line: 1, finding: "x".repeat(10000) });
+    expect(s.inputs.body).toBeDefined();
+    expect((s.inputs.body as string).length).toBeLessThanOrEqual(4000);
   });
 });

--- a/test/unit/mcp-write-tools.test.ts
+++ b/test/unit/mcp-write-tools.test.ts
@@ -71,4 +71,25 @@ describe("MCP miner write-tools (#780)", () => {
     });
     expect(result.isError).toBeTruthy();
   });
+
+  // #2177 (follow-up-issue slice of #1962).
+  it("file_follow_up_issue composes a file_issue spec from a deferred finding, with and without a label", async () => {
+    const client = await connect();
+    const withLabel = await client.callTool({
+      name: "gittensory_file_follow_up_issue",
+      arguments: { repoFullName: "o/r", path: "src/a.ts", line: 42, finding: "Null check missing before dereference.", label: "gittensor:bug" },
+    });
+    expect(withLabel.isError).toBeFalsy();
+    const spec = withLabel.structuredContent as Spec;
+    expect(spec.action).toBe("file_issue");
+    expect(spec.command).toContain("Follow up: src/a.ts:42");
+    expect(spec.command).toContain("--label 'gittensor:bug'");
+
+    const withoutLabel = await client.callTool({
+      name: "gittensory_file_follow_up_issue",
+      arguments: { repoFullName: "o/r", path: "src/a.ts", finding: "Null check missing." },
+    });
+    expect(withoutLabel.isError).toBeFalsy();
+    expect((withoutLabel.structuredContent as Spec).command).not.toContain("--label");
+  });
 });


### PR DESCRIPTION
## Summary

- Adds the render slice of #1962 (#2175): a boundary-safe, content-only renderer (`src/review/fix-handoff-render.ts`) that turns a single review finding into a structured "apply this fix" block for a contributor's own local agent to consume -- path/line/severity/instruction plus an optional suggested change, a machine-readable HTML-comment marker, and the shared no-cloud-write boundary text. A finding with no commentable line still yields a valid path-only block (mirrors the existing `line: 0` path-only sentinel used by `review/safety.ts`/`review/secrets-scan.ts`). No server-side write, no execution.
- Adds a follow-up-issue action spec builder (#2177) for deferred review findings -- composes a bounded, public-safe title/body from a single finding and delegates to the existing `buildFileIssueSpec` local-write spec, exposed as a new `gittensory_file_follow_up_issue` MCP tool. Optional point-bearing label support (empty-label branch when omitted).
- Documents the already-shipped `GITTENSORY_REVIEW_FIX_HANDOFF` feature flag (the config/gate slice for #2176 merged separately in #3824) in `src/env.d.ts` and the docs pages, closing a docs-drift gap that PR left open.

Closes #2175. #2177 was already marked closed by #3836 (an earlier, unwired implementation); this PR supersedes it with the actual live, MCP-wired version -- see Notes. Advances #1962 (not closed -- this PR covers the render + follow-up-issue slices only; the config/gate slice already shipped in #3824).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue (Advances #1962; implements #2175 and #2177), or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally -- 100% branch coverage on both changed source files (`src/review/fix-handoff-render.ts`, `src/mcp/local-write-tools.ts`)
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A -- no such changes in this PR.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (New `gittensory_file_follow_up_issue` MCP tool, tested via the MCP client harness in `test/unit/mcp-write-tools.test.ts`.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A -- only two docs pages gained a feature-flag doc line; no dynamic UI behavior.)
- [x] Visible UI changes include a `UI Evidence` section below. (N/A -- text-only docs additions, no visual/layout change.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- `src/review/fix-handoff.ts` is already taken by the merged #2176 config/gate slice (`isFixHandoffEnabled`/`shouldEmitFixHandoff`), so this PR's renderer lives at `src/review/fix-handoff-render.ts` instead -- a caller wires the two together by calling `shouldEmitFixHandoff` before invoking `buildFixHandoffBlock`.
- `buildFollowUpIssueSpec` strips any embedded HTML-comment marker or fenced code block from the finding text before composing the issue body, since a follow-up issue is read by a human triaging a backlog, not a harness expecting the fix-handoff marker.
