### PR TITLE
feat(mcp): add follow-up issue local-write action spec (#2177)

### DIFF
--- a/src/mcp/local-write-tools.ts
+++ b/src/mcp/local-write-tools.ts
@@ -90,6 +90,16 @@ function composeFollowUpIssueBody(input: { finding: DeferredReviewFinding; pullN
   return boundFollowUpBody(lines.join("\n"), FOLLOW_UP_ISSUE_BODY_MAX);
 }
 
+function sanitizeFollowUpFinding(finding: DeferredReviewFinding): Record<string, string> {
+  const sanitized: Record<string, string> = {
+    title: stripFollowUpMarkers(finding.title),
+    detail: stripFollowUpMarkers(finding.detail),
+  };
+  if (finding.path) sanitized.path = finding.path;
+  if (finding.action) sanitized.action = stripFollowUpMarkers(finding.action);
+  return sanitized;
+}
+
 /** File a follow-up issue for a deferred review finding (#2177, #1962 slice). */
 export function buildFollowUpIssueSpec(input: {
   repoFullName: string;
@@ -97,6 +107,7 @@ export function buildFollowUpIssueSpec(input: {
   labels?: string[] | undefined;
   pullNumber?: number | undefined;
 }): LocalWriteActionSpec {
+  const sanitizedFinding = sanitizeFollowUpFinding(input.finding);
   const title = composeFollowUpIssueTitle(input.finding);
   const body = composeFollowUpIssueBody({ finding: input.finding, pullNumber: input.pullNumber });
   const fileSpec = buildFileIssueSpec({
@@ -111,12 +122,7 @@ export function buildFollowUpIssueSpec(input: {
     description: `File a follow-up issue for a deferred review finding: ${title}`,
     inputs: {
       ...fileSpec.inputs,
-      finding: {
-        title: input.finding.title,
-        detail: input.finding.detail,
-        ...(input.finding.path ? { path: input.finding.path } : {}),
-        ...(input.finding.action ? { action: input.finding.action } : {}),
-      },
+      finding: sanitizedFinding,
       ...(input.pullNumber !== undefined ? { pullNumber: input.pullNumber } : {}),
     },
   };

--- a/src/mcp/local-write-tools.ts
+++ b/src/mcp/local-write-tools.ts
@@ -43,6 +43,85 @@ export function buildFileIssueSpec(input: { repoFullName: string; title: string;
   return spec("file_issue", "File a new issue.", { repoFullName: input.repoFullName, title: input.title, body: input.body, labels }, command);
 }
 
+export type DeferredReviewFinding = {
+  title: string;
+  detail: string;
+  path?: string | undefined;
+  action?: string | undefined;
+};
+
+const FOLLOW_UP_ISSUE_TITLE_MAX = 120;
+const FOLLOW_UP_ISSUE_BODY_MAX = 4000;
+
+function stripFollowUpMarkers(value: string): string {
+  return value.replace(/<!--[\s\S]*?-->/g, "").replace(/\r\n/g, "\n").trim();
+}
+
+function boundFollowUpLine(value: string, max: number): string {
+  const cleaned = stripFollowUpMarkers(value).replace(/\s+/g, " ").trim();
+  if (cleaned.length <= max) return cleaned;
+  return `${cleaned.slice(0, Math.max(0, max - 1)).trimEnd()}…`;
+}
+
+function boundFollowUpBody(value: string, max: number): string {
+  const cleaned = stripFollowUpMarkers(value).trim();
+  if (cleaned.length <= max) return cleaned;
+  return `${cleaned.slice(0, Math.max(0, max - 1)).trimEnd()}…`;
+}
+
+function composeFollowUpIssueTitle(finding: DeferredReviewFinding): string {
+  const cleaned = stripFollowUpMarkers(finding.title);
+  if (/^follow-up:/i.test(cleaned)) {
+    return boundFollowUpLine(cleaned, FOLLOW_UP_ISSUE_TITLE_MAX);
+  }
+  const prefix = "Follow-up: ";
+  return `${prefix}${boundFollowUpLine(cleaned, FOLLOW_UP_ISSUE_TITLE_MAX - prefix.length)}`;
+}
+
+function composeFollowUpIssueBody(input: { finding: DeferredReviewFinding; pullNumber?: number | undefined }): string {
+  const lines: string[] = [];
+  if (input.pullNumber !== undefined) lines.push(`Deferred from review on PR #${input.pullNumber}.`);
+  if (input.finding.path) lines.push(`File: \`${input.finding.path}\``);
+  lines.push("", boundFollowUpLine(input.finding.detail, FOLLOW_UP_ISSUE_BODY_MAX));
+  if (input.finding.action) {
+    lines.push("", "**Suggested next step**", boundFollowUpLine(input.finding.action, 500));
+  }
+  lines.push("", "_Filed locally from a deferred review finding — gittensory supplies content only._");
+  return boundFollowUpBody(lines.join("\n"), FOLLOW_UP_ISSUE_BODY_MAX);
+}
+
+/** File a follow-up issue for a deferred review finding (#2177, #1962 slice). */
+export function buildFollowUpIssueSpec(input: {
+  repoFullName: string;
+  finding: DeferredReviewFinding;
+  labels?: string[] | undefined;
+  pullNumber?: number | undefined;
+}): LocalWriteActionSpec {
+  const title = composeFollowUpIssueTitle(input.finding);
+  const body = composeFollowUpIssueBody({ finding: input.finding, pullNumber: input.pullNumber });
+  const fileSpec = buildFileIssueSpec({
+    repoFullName: input.repoFullName,
+    title,
+    body,
+    labels: input.labels,
+  });
+  return {
+    ...fileSpec,
+    action: "follow_up_issue",
+    description: `File a follow-up issue for a deferred review finding: ${title}`,
+    inputs: {
+      ...fileSpec.inputs,
+      finding: {
+        title: input.finding.title,
+        detail: input.finding.detail,
+        ...(input.finding.path ? { path: input.finding.path } : {}),
+        ...(input.finding.action ? { action: input.finding.action } : {}),
+      },
+      ...(input.pullNumber !== undefined ? { pullNumber: input.pullNumber } : {}),
+    },
+  };
+}
+
 /** Add labels to an issue or PR (gh issue edit also targets PRs). */
 export function buildApplyLabelsSpec(input: { repoFullName: string; number: number; labels: string[] }): LocalWriteActionSpec {
   const labelArgs = input.labels.map((label) => ` --add-label ${sq(label)}`).join("");

--- a/test/unit/local-write-tools.test.ts
+++ b/test/unit/local-write-tools.test.ts
@@ -115,7 +115,7 @@ describe("buildFollowUpIssueSpec (#2177)", () => {
       "gh issue create --repo 'o/r' --title 'Follow-up: Handle null branch in widget loader' --body 'Deferred from review on PR #42.\nFile: `src/widget.ts`\n\nThe loader never guards a null response.\n\n**Suggested next step**\nAdd a regression test for the null path.\n\n_Filed locally from a deferred review finding — gittensory supplies content only._' --label 'gittensor:bug'",
     );
     expect(s.inputs).toMatchObject({ labels: ["gittensor:bug"], pullNumber: 42 });
-    expect(s.inputs.finding).toMatchObject({
+    expect(s.inputs.finding).toEqual({
       title: "Handle null branch in widget loader",
       detail: "The loader never guards a null response.",
       path: "src/widget.ts",
@@ -135,6 +135,7 @@ describe("buildFollowUpIssueSpec (#2177)", () => {
     expect(s.command).not.toContain("<!--");
     expect(s.command).not.toContain("--label");
     expect(s.inputs).toMatchObject({ labels: [] });
+    expect(s.inputs.finding).toEqual({ title: "Follow-up: it's noisy", detail: "Detail  stays public-safe." });
     expect(s.inputs).not.toHaveProperty("pullNumber");
     expect(s.description).toContain("Follow-up: it's noisy");
   });

--- a/test/unit/local-write-tools.test.ts
+++ b/test/unit/local-write-tools.test.ts
@@ -5,6 +5,7 @@ import {
   buildCreateBranchSpec,
   buildDeleteBranchSpec,
   buildFileIssueSpec,
+  buildFollowUpIssueSpec,
   buildOpenPrSpec,
   buildPostEligibilityCommentSpec,
   buildTestGenSpec,
@@ -90,5 +91,74 @@ describe("buildTestGenSpec (#2188)", () => {
     const s = buildTestGenSpec({ repoFullName: "o/r", targetFiles: ["src/a.ts", "src/b.ts"], framework: "vitest", criteria: ["handle it's edge case"] });
     expect(s.description).toContain("src/a.ts, src/b.ts");
     expect(s.command).toContain("it'\\''s edge case");
+  });
+});
+
+// #2177 (follow-up-issue action spec slice of #1962).
+describe("buildFollowUpIssueSpec (#2177)", () => {
+  it("builds a follow_up_issue spec with composed title/body, labels, and the local-execution boundary", () => {
+    const s = buildFollowUpIssueSpec({
+      repoFullName: "o/r",
+      pullNumber: 42,
+      labels: ["gittensor:bug"],
+      finding: {
+        title: "Handle null branch in widget loader",
+        detail: "The loader never guards a null response.",
+        path: "src/widget.ts",
+        action: "Add a regression test for the null path.",
+      },
+    });
+    expect(s.action).toBe("follow_up_issue");
+    expect(s.boundary).toBe(LOCAL_WRITE_BOUNDARY);
+    expect(s.description).toContain("Follow-up: Handle null branch in widget loader");
+    expect(s.command).toBe(
+      "gh issue create --repo 'o/r' --title 'Follow-up: Handle null branch in widget loader' --body 'Deferred from review on PR #42.\nFile: `src/widget.ts`\n\nThe loader never guards a null response.\n\n**Suggested next step**\nAdd a regression test for the null path.\n\n_Filed locally from a deferred review finding — gittensory supplies content only._' --label 'gittensor:bug'",
+    );
+    expect(s.inputs).toMatchObject({ labels: ["gittensor:bug"], pullNumber: 42 });
+    expect(s.inputs.finding).toMatchObject({
+      title: "Handle null branch in widget loader",
+      detail: "The loader never guards a null response.",
+      path: "src/widget.ts",
+      action: "Add a regression test for the null path.",
+    });
+  });
+
+  it("omits labels and optional finding fields when absent, and strips HTML comment markers from the finding text", () => {
+    const s = buildFollowUpIssueSpec({
+      repoFullName: "o/r",
+      finding: {
+        title: "<!-- marker -->Follow-up: it's noisy",
+        detail: "Detail <!-- hidden --> stays public-safe.",
+      },
+    });
+    expect(s.command).toContain("--title 'Follow-up: it'\\''s noisy'");
+    expect(s.command).not.toContain("<!--");
+    expect(s.command).not.toContain("--label");
+    expect(s.inputs).toMatchObject({ labels: [] });
+    expect(s.inputs).not.toHaveProperty("pullNumber");
+    expect(s.description).toContain("Follow-up: it's noisy");
+  });
+
+  it("bounds an over-long finding title before delegating to gh issue create", () => {
+    const longTitle = "x".repeat(140);
+    const s = buildFollowUpIssueSpec({ repoFullName: "o/r", finding: { title: longTitle, detail: "short detail" } });
+    const titleMatch = s.command.match(/--title '([^']|'\\'')*'/);
+    expect(titleMatch).not.toBeNull();
+    const titleArg = titleMatch![0].replace(/^--title '/, "").replace(/'$/, "").replace(/'\\''/g, "'");
+    expect(titleArg.startsWith("Follow-up: ")).toBe(true);
+    expect(titleArg.length).toBeLessThanOrEqual(120);
+  });
+
+  it("preserves an existing Follow-up prefix and bounds an over-long composed body", () => {
+    const s = buildFollowUpIssueSpec({
+      repoFullName: "o/r",
+      finding: {
+        title: "Follow-up: tighten null handling",
+        detail: "d".repeat(5000),
+      },
+    });
+    expect(s.description).toContain("Follow-up: tighten null handling");
+    expect(s.command.length).toBeLessThan(7000);
+    expect(s.command.endsWith("'")).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Closes #2177.

Adds `buildFollowUpIssueSpec` in `src/mcp/local-write-tools.ts` to compose a public-safe follow-up issue title/body from a deferred review finding, strip HTML comment markers, bound title/body length, and delegate to the existing `buildFileIssueSpec` / `gh issue create` shape with optional point-bearing labels. Structured `inputs.finding` is sanitized before return so harnesses cannot emit hidden comment text into public issues.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Prior attempt #3832 was auto-closed for missing `Closes #2177` wording and unsanitized `inputs.finding`; both are fixed here.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — backend-only MCP local-write helper; no visible UI change.

## Notes

- Conflict check: open PRs touch `commands.ts`, `processors.ts`, and `focus-manifest.ts`; this PR only changes `local-write-tools.ts` and its unit tests.


Made with [Cursor](https://cursor.com)