### PR TITLE
fix(observability): close two zero-trace webhook/relay loss points

### DIFF
--- a/src/github/webhook.ts
+++ b/src/github/webhook.ts
@@ -142,15 +142,20 @@ export async function enqueueWebhookByEnv(env: Env, deliveryId: string, eventNam
     return "review_unavailable";
   }
 
+  // #zero-trace-webhook-loss: hash the raw body (independent of whether it parses) BEFORE the parse attempt, so
+  // an unparseable delivery can still be durably recorded below instead of vanishing with no row anywhere.
+  const payloadHash = await sha256Hex(rawBody);
   let payload: GitHubWebhookPayload;
   try {
     payload = JSON.parse(rawBody) as GitHubWebhookPayload;
   } catch {
+    // installation/repository/action are unknown pre-parse; deliveryId + eventName + the hash are enough for an
+    // operator to trace this delivery instead of it being indistinguishable from "GitHub never sent it."
+    await recordWebhookEvent(env, { deliveryId, eventName, payloadHash, status: "error", errorSummary: "invalid_json" });
     recordWebhookEnqueueMetric(eventName, undefined, "invalid_json");
     return "invalid_json";
   }
 
-  const payloadHash = await sha256Hex(rawBody);
   const existingEvent = await getWebhookEvent(env, deliveryId);
   // Suppress redelivery of an already-processed event (on success its payloadHash is overwritten to a
   // "processed" sentinel, so a hash match alone misses it and the event re-runs its side effects) or one

--- a/src/orb/broker-client.ts
+++ b/src/orb/broker-client.ts
@@ -7,6 +7,8 @@
 // The signal is the ENROLLMENT SECRET's presence: a brokered self-host sets ORB_ENROLLMENT_SECRET (issued by the
 // operator), cloud never does — so this path is inert on cloud and the deploy is byte-identical there.
 
+import { incr } from "../selfhost/metrics";
+
 /** The Orb's hosted broker base; override (ORB_BROKER_URL) only to point at a private gittensory deployment. */
 const DEFAULT_BROKER_URL = "https://gittensory-api.aethereal.dev";
 // The broker's cold token mint can take many seconds when GitHub is throttling the App; allow headroom so the one
@@ -256,7 +258,20 @@ export async function drainOrbRelay(
     for (const e of body.events ?? []) {
       if (typeof e.deliveryId === "string" && typeof e.eventName === "string" && typeof e.rawBody === "string") {
         out.push({ deliveryId: e.deliveryId, eventName: e.eventName, rawBody: e.rawBody });
+        continue;
       }
+      // #zero-trace-webhook-loss: a batch entry missing/mistyping one of the three required fields was
+      // previously discarded with no record anywhere — indistinguishable from the Orb never having relayed it.
+      incr("gittensory_orb_relay_malformed_events_total");
+      console.error(
+        JSON.stringify({
+          level: "error",
+          event: "orb_relay_malformed_event_dropped",
+          hasDeliveryId: typeof e.deliveryId === "string",
+          hasEventName: typeof e.eventName === "string",
+          hasRawBody: typeof e.rawBody === "string",
+        }),
+      );
     }
     return out;
   } catch (error) {

--- a/test/unit/orb-broker-client.test.ts
+++ b/test/unit/orb-broker-client.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { counterValue, resetMetrics } from "../../src/selfhost/metrics";
 import {
   createOrbRelayRegistrationState,
   drainOrbRelay,
@@ -362,7 +363,9 @@ describe("drainOrbRelay (pull-mode drain)", () => {
     expect(await drainOrbRelay({})).toEqual([]);
   });
 
-  it("POSTs the ack list, parses returned events, and filters malformed ones", async () => {
+  it("POSTs the ack list, parses returned events, and filters malformed ones (#zero-trace-webhook-loss: logs + counts the drop)", async () => {
+    resetMetrics();
+    const errors = vi.spyOn(console, "error").mockImplementation(() => undefined);
     const { fetchImpl, calls } = captureFetch(
       Response.json({
         events: [
@@ -380,6 +383,11 @@ describe("drainOrbRelay (pull-mode drain)", () => {
     expect(calls[0]?.url).toBe("https://gittensory-api.aethereal.dev/v1/orb/relay/pull");
     expect((calls[0]?.init?.headers as Record<string, string>).authorization).toBe("Bearer s");
     expect(JSON.parse(String(calls[0]?.init?.body))).toEqual({ ack: ["prev-1"] });
+    expect(counterValue("gittensory_orb_relay_malformed_events_total")).toBe(1);
+    const logged = errors.mock.calls.map((c) => String(c[0])).find((line) => line.includes("orb_relay_malformed_event_dropped"));
+    expect(logged).toBeDefined();
+    expect(JSON.parse(logged!)).toMatchObject({ level: "error", event: "orb_relay_malformed_event_dropped", hasDeliveryId: true, hasEventName: true, hasRawBody: false });
+    errors.mockRestore();
   });
 
   it("tolerates a missing events array (?? [] arm)", async () => {

--- a/test/unit/webhook.test.ts
+++ b/test/unit/webhook.test.ts
@@ -285,6 +285,17 @@ describe("github webhook queue isolation (#audit-webhook-queue)", () => {
     expect(metrics).toContain('gittensory_webhook_enqueue_total{action="other",event="other",result="queued"} 1');
   });
 
+  it("REGRESSION (#zero-trace-webhook-loss): an unparseable delivery still gets a durable webhook_events row instead of vanishing with no trace", async () => {
+    const env = createTestEnv();
+    env.WEBHOOKS = { send: async () => undefined } as unknown as Queue;
+
+    await expect(enqueueWebhookByEnv(env, "invalid-json-trace", "pull_request", "{not json")).resolves.toBe("invalid_json");
+
+    const event = await getWebhookEvent(env, "invalid-json-trace");
+    expect(event).toMatchObject({ deliveryId: "invalid-json-trace", status: "error" });
+    expect(event?.payloadHash).toBeTruthy();
+  });
+
   it("rejects retired direct review-app webhooks when the self-host review runtime is absent", async () => {
     const env = createTestEnv();
     delete env.SELFHOST_TRANSIENT_CACHE;


### PR DESCRIPTION
## Summary

Part of #3812 — the two "adjacent zero-trace loss points on the same ingestion path" fixes it calls out. The new fast open-PR reconciliation job (the third deliverable) is a larger, separate change tracked in a follow-up PR so this one stays reviewable.

- **`src/github/webhook.ts`**: `enqueueWebhookByEnv` attempted `JSON.parse(rawBody)` before writing anything to `webhook_events`. An unparseable delivery returned `"invalid_json"` with **zero durable trace anywhere** — indistinguishable from GitHub never having sent it at all. Hoists the raw-body hash (independent of parse validity) above the parse attempt and writes a `webhook_events` row with `status: "error"` on a parse failure, so every delivery — parseable or not — leaves a trace an operator can find.
- **`src/orb/broker-client.ts`**: `drainOrbRelay`'s pull-mode batch parser silently dropped any relayed event missing/mistyping one of its three required fields (`deliveryId`/`eventName`/`rawBody`), with no log and no counter. Adds a structured `orb_relay_malformed_event_dropped` error log (Sentry-visible) and a `gittensory_orb_relay_malformed_events_total` counter on the drop, naming which of the three fields was missing.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session/CORS surface touched; this only adds a trace row and a log/counter on already-existing failure paths.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP surface changed.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — backend-only change, no UI touched.)
- [ ] Visible UI changes include a `UI Evidence` section below. (N/A — no visible UI change.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.
