### PR TITLE
feat(review): anchor-safety validation drops un-commentable suggested changes

### DIFF
--- a/src/review/inline-comments.ts
+++ b/src/review/inline-comments.ts
@@ -65,6 +65,27 @@ export type ReviewInlineComment = { path: string; line: number; side: "RIGHT"; b
  *  wall (the model is also asked to be selective, and composeInlineFindings already caps at 10). */
 const MAX_INLINE_COMMENTS = 10;
 
+/** PURE (#2140): the subset of {@link rightSideLinesFromPatch} that are genuinely ADDED ("+") lines — GitHub
+ *  suggested-change blocks 422 unless the anchor is an added line; context (" ") lines may still take a plain
+ *  inline comment. */
+export function addedLinesFromPatch(patch: string): Set<number> {
+  const lines = new Set<number>();
+  let right = 0;
+  for (const raw of patch.split("\n")) {
+    const header = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(raw);
+    if (header?.[1]) {
+      right = Number.parseInt(header[1], 10);
+      continue;
+    }
+    if (right === 0) continue;
+    const marker = raw[0];
+    if (marker === undefined || marker === "-" || marker === "\\") continue;
+    if (marker === "+") lines.add(right);
+    right += 1;
+  }
+  return lines;
+}
+
 /** PURE: the set of NEW-file (RIGHT-side) line numbers a unified-diff patch makes commentable — every added
  *  ("+") and context (" ") line inside a hunk. GitHub 422s an inline comment whose line is NOT one of these, so
  *  {@link selectInlineComments} validates each finding against this set. Deleted ("-") lines are LEFT-side only
@@ -130,9 +151,13 @@ export function selectInlineComments(
   minFindingSeverity: ReviewFindingSeverity | null | undefined = null,
 ): ReviewInlineComment[] {
   const rightLinesByPath = new Map<string, Set<number>>();
+  const addedLinesByPath = new Map<string, Set<number>>();
   for (const file of files) {
     const patch = typeof file.payload?.patch === "string" ? file.payload.patch : "";
-    if (patch) rightLinesByPath.set(file.path, rightSideLinesFromPatch(patch));
+    if (patch) {
+      rightLinesByPath.set(file.path, rightSideLinesFromPatch(patch));
+      addedLinesByPath.set(file.path, addedLinesFromPatch(patch));
+    }
   }
   const out: ReviewInlineComment[] = [];
   const seen = new Set<string>();
@@ -144,7 +169,15 @@ export function selectInlineComments(
     const key = `${finding.path}:${finding.line}`;
     if (seen.has(key)) continue;
     seen.add(key);
-    out.push({ path: finding.path, line: finding.line, side: "RIGHT", body: formatInlineBody(finding, suggestionsEnabled, categoriesEnabled) });
+    const suggestionAnchorable = Boolean(
+      suggestionsEnabled && finding.suggestion && addedLinesByPath.get(finding.path)?.has(finding.line),
+    );
+    out.push({
+      path: finding.path,
+      line: finding.line,
+      side: "RIGHT",
+      body: formatInlineBody(finding, suggestionAnchorable, categoriesEnabled),
+    });
   }
   return out;
 }

--- a/test/unit/inline-comments.test.ts
+++ b/test/unit/inline-comments.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { generateKeyPairSync } from "node:crypto";
 import type { InlineFinding } from "../../src/services/ai-review";
-import { isInlineCommentsEnabled, maybePostInlineComments, postInlineReviewComments, rightSideLinesFromPatch, selectInlineComments, shouldRenderFindingCategories, shouldRenderSuggestions, shouldRequestInlineFindings } from "../../src/review/inline-comments";
+import { isInlineCommentsEnabled, maybePostInlineComments, postInlineReviewComments, addedLinesFromPatch, rightSideLinesFromPatch, selectInlineComments, shouldRenderFindingCategories, shouldRenderSuggestions, shouldRequestInlineFindings } from "../../src/review/inline-comments";
 import { createTestEnv } from "../helpers/d1";
 
 function envWithKey() {
@@ -70,6 +70,13 @@ describe("rightSideLinesFromPatch (#inline-comments)", () => {
   it("does NOT add a spurious line for a trailing newline (regression — would 422 a finding anchored past the hunk)", () => {
     // The trailing "\n" makes split() emit a final "" element; it must be ignored, not counted as line 3.
     expect([...rightSideLinesFromPatch("@@ -1,1 +1,2 @@\n ctx\n+added2\n")].sort((a, b) => a - b)).toEqual([1, 2]);
+  });
+});
+
+describe("addedLinesFromPatch (#2140)", () => {
+  it("returns only ADDED (+) line numbers, excluding context lines", () => {
+    const patch = "@@ -1,3 +1,4 @@\n ctx1\n-removed\n+added2\n+added3\n ctx4\n\\ No newline at end of file";
+    expect([...addedLinesFromPatch(patch)].sort((a, b) => a - b)).toEqual([2, 3]);
   });
 });
 
@@ -150,6 +157,25 @@ describe("selectInlineComments (#inline-comments)", () => {
       const out = selectInlineComments([breaksFence], files, true);
       expect(out[0]?.body).toBe("**Blocker:** Fix this.");
       expect(out[0]?.body).not.toContain("escape attempt");
+    });
+
+    it("keeps a plain inline comment but strips an un-anchorable suggestion on a context line (#2140)", () => {
+      const contextPatch = "@@ -1,1 +1,2 @@\n ctx\n+added2";
+      const contextFiles = [fileWith("src/a.ts", contextPatch)];
+      const onContext: InlineFinding = { path: "src/a.ts", line: 1, severity: "nit", body: "Context note.", suggestion: "const x = 1;" };
+      const out = selectInlineComments([onContext], contextFiles, true);
+      expect(out).toEqual([{ path: "src/a.ts", line: 1, side: "RIGHT", body: "**Nit:** Context note." }]);
+      expect(out[0]?.body).not.toContain("```suggestion");
+    });
+
+    it("keeps both comment and suggestion when the anchor is an added line (#2140)", () => {
+      const out = selectInlineComments([withSuggestion], files, true);
+      expect(out[0]?.body).toContain("```suggestion");
+    });
+
+    it("never emits a suggestion on a file with no usable patch (#2140)", () => {
+      const out = selectInlineComments([withSuggestion], [{ path: "src/a.ts", payload: {} }], true);
+      expect(out).toEqual([]);
     });
   });
 

--- a/test/unit/inline-comments.test.ts
+++ b/test/unit/inline-comments.test.ts
@@ -78,6 +78,20 @@ describe("addedLinesFromPatch (#2140)", () => {
     const patch = "@@ -1,3 +1,4 @@\n ctx1\n-removed\n+added2\n+added3\n ctx4\n\\ No newline at end of file";
     expect([...addedLinesFromPatch(patch)].sort((a, b) => a - b)).toEqual([2, 3]);
   });
+
+  it("handles multiple hunks and ignores preamble before the first hunk header", () => {
+    const patch = "preamble line\n@@ -10,1 +10,2 @@\n ctx10\n+add11\n@@ -50,0 +60,1 @@\n+add60";
+    expect([...addedLinesFromPatch(patch)].sort((a, b) => a - b)).toEqual([11, 60]);
+  });
+
+  it("returns an empty set when there is no hunk header (or an empty patch)", () => {
+    expect(addedLinesFromPatch("no hunks here").size).toBe(0);
+    expect(addedLinesFromPatch("").size).toBe(0);
+  });
+
+  it("does not add a spurious line for a trailing newline split artifact", () => {
+    expect([...addedLinesFromPatch("@@ -1,1 +1,2 @@\n ctx\n+added2\n")].sort((a, b) => a - b)).toEqual([2]);
+  });
 });
 
 describe("selectInlineComments (#inline-comments)", () => {


### PR DESCRIPTION
## Summary

- Add `addedLinesFromPatch` and only render GitHub suggested-change blocks on ADDED ("+") diff lines.
- Plain inline comments still work on context lines; files without a patch never emit suggestions.
- 100% patch coverage on the changed lines/branches (prior #3837 closed on codecov/patch at 95%).

Fixes #2140

## Validation

- [x] `npx vitest run test/unit/inline-comments.test.ts` — 39 passed
- [x] Local v8 coverage on `inline-comments.ts`: 100% statements/branches/lines

## Conflict avoidance

Only `src/review/inline-comments.ts` + tests. No file overlap with open PRs #3823–#3836.

Made with [Cursor](https://cursor.com)