### PR TITLE
test(config): lock in review.impact_map manifest plumbing

### DIFF
--- a/test/unit/config-templates.test.ts
+++ b/test/unit/config-templates.test.ts
@@ -101,6 +101,20 @@ describe("config/examples review templates (#1682)", () => {
     expect(resolveReviewPromptOverrides(off).effortScore).toBe(false);
   });
 
+  it("locks in review.impact_map via manifest parse + JSON round-trip and documents it in gittensory.full.yml (part of #1971)", () => {
+    // impact_map gates the deterministic impact-map computation/render (not a prompt override), so it is
+    // exercised through the manifest parse + reviewConfigToJson round-trip rather than resolveReviewPromptOverrides.
+    const full = readConfigExample("gittensory.full.yml");
+    expect(full).toMatch(/# impact_map:/);
+    expect(parseFocusManifest({}).review.impactMap).toBeNull();
+    const on = parseFocusManifest({ review: { impact_map: true } });
+    expect(on.review.impactMap).toBe(true);
+    expect(reviewConfigToJson(on.review)).toEqual({ impact_map: true });
+    const off = parseFocusManifest({ review: { impact_map: false } });
+    expect(off.review.impactMap).toBe(false);
+    expect(reviewConfigToJson(off.review)).toEqual({ impact_map: false });
+  });
+
   it("parses gittensory.minimal.yml with zero warnings and enables no agent actions", () => {
     const manifest = parseFocusManifestContent(readConfigExample("gittensory.minimal.yml"), "repo_file");
     expect(manifest.warnings).toEqual([]);


### PR DESCRIPTION
## Summary

The `review.impact_map` config toggle (#2184, the config slice of the deterministic impact-map work under #1971) shipped and is documented in `config/examples/gittensory.full.yml`, but the **config-templates inventory test never covered it**. That test locks in the plumbing for the sibling display toggles (`changed_files_summary`, `effort_score`, `min_finding_severity`, `inline_comments`, …), so a regression that dropped `impact_map`'s `gittensory.full.yml` docs entry or broke its manifest parse/round-trip would slip through here.

This adds a focused case asserting `review.impact_map`:

- is **documented** in `gittensory.full.yml` (`# impact_map:`),
- parses through `parseFocusManifest` (unset → `null`, `true`/`false` preserved),
- and **round-trips** through `reviewConfigToJson` (`{ impact_map: true }` / `{ impact_map: false }`).

`impact_map` gates the deterministic impact-map computation rather than a review *prompt*, so — unlike `effort_score` — it is exercised via the JSON round-trip rather than `resolveReviewPromptOverrides`, matching how the analogous non-prompt toggles are covered. Verified against the shipped `focus-manifest` (`normalizeOptionalBoolean(r.impact_map, "review.impact_map", …)`, `impactMap` field, and the `reviewConfigToJson` `impact_map` emit).

**Part of #1971** (Deterministic architecture / impact map) — this locks in the config plumbing for the shipped `review.impact_map` toggle; it does not close the epic.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] Focused — a single test case in `test/unit/config-templates.test.ts`; test-only, no source change.
- [x] Follows `CONTRIBUTING.md`; no `site/`/`CNAME`/`lovable` changes.
- [x] Linked to an open, eligible issue (#1971) that this test advances.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — **test-only change (no `src/**` lines added)**, so `codecov/patch` has no diff to gate; the full suite is green.
- [x] `npx vitest run test/unit/config-templates.test.ts` — 10 passed (incl. the new `impact_map` case).
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run rees:test`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`

Validated green against the full GitHub CI `validate-code` check set. Branch rebased on latest `main`.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, private keys, raw trust scores, private rankings, or reward values exposed.
- [x] No auth, cookie, CORS, GitHub App, Cloudflare, DB, API/OpenAPI/MCP, or UI changes (N/A — a single inventory test case).
- [x] No docs/changelog changes needed.

## Notes

Mirrors the existing sibling cases in the same file — `resolves review.effort_score via manifest parse + boolean helper (#2152)` and the `documents shipped … toggles` inventory tests — extending the same lock-in coverage to the newly-shipped `review.impact_map` toggle.
