### PR TITLE
test(config): lock in review.test_generation manifest plumbing

### DIFF
--- a/test/unit/config-templates.test.ts
+++ b/test/unit/config-templates.test.ts
@@ -101,6 +101,21 @@ describe("config/examples review templates (#1682)", () => {
     expect(resolveReviewPromptOverrides(off).effortScore).toBe(false);
   });
 
+  it("locks in review.test_generation via manifest parse + JSON round-trip and documents it in gittensory.full.yml (#2189)", () => {
+    // test_generation is a kill-switch that gates the boundary-safe test-generation advisory (#1972); it is NOT a
+    // review prompt override, so it is exercised through the manifest parse + reviewConfigToJson round-trip rather
+    // than resolveReviewPromptOverrides (which does not surface it).
+    const full = readConfigExample("gittensory.full.yml");
+    expect(full).toMatch(/# test_generation:/);
+    expect(parseFocusManifest({}).review.testGeneration).toBeNull();
+    const on = parseFocusManifest({ review: { test_generation: true } });
+    expect(on.review.testGeneration).toBe(true);
+    expect(reviewConfigToJson(on.review)).toEqual({ test_generation: true });
+    const off = parseFocusManifest({ review: { test_generation: false } });
+    expect(off.review.testGeneration).toBe(false);
+    expect(reviewConfigToJson(off.review)).toEqual({ test_generation: false });
+  });
+
   it("parses gittensory.minimal.yml with zero warnings and enables no agent actions", () => {
     const manifest = parseFocusManifestContent(readConfigExample("gittensory.minimal.yml"), "repo_file");
     expect(manifest.warnings).toEqual([]);


### PR DESCRIPTION
## Summary

The `review.test_generation` kill-switch (#2189, the config slice of the boundary-safe test-generation advisory #1972) shipped and is documented in `config/examples/gittensory.full.yml`, but the config-templates inventory test — which locks in the plumbing for the sibling review toggles (`changed_files_summary`, `effort_score`) — never covered it. A regression that dropped its `gittensory.full.yml` docs entry or broke its manifest parse/round-trip would slip through here.

This adds a focused case asserting `review.test_generation`:
- is **documented** in `gittensory.full.yml` (`# test_generation:`),
- parses through `parseFocusManifest` (unset → `null`, `true`/`false` preserved),
- **round-trips** through `reviewConfigToJson` (`{ test_generation: true/false }`).

`test_generation` gates the test-generation advisory rather than a review *prompt*, so — unlike `effort_score` — it is exercised via the JSON round-trip rather than `resolveReviewPromptOverrides` (which does not surface it). Verified against the shipped `focus-manifest` (`normalizeOptionalBoolean(r.test_generation, "review.test_generation", …)`, the `testGeneration` field, and the `reviewConfigToJson` `test_generation` emit).

Closes #2189.

## Scope
- [x] Conventional Commit title; focused, test-only (a single case in `test/unit/config-templates.test.ts`), no source change.
- [x] Follows `CONTRIBUTING.md`; no `site/`/`CNAME`/`lovable` changes.
- [x] Closes an open, eligible, unassigned issue (#2189) that this test resolves.

## Validation
- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npx vitest run test/unit/config-templates.test.ts` — 10 passed (incl. the new `test_generation` case).
- [x] Test-only change (no `src/**` lines), so `codecov/patch` has no diff to gate.

## Safety
- [x] No secrets/wallets/hotkeys/trust-scores/reward values. No auth/CORS/DB/API/UI changes (N/A — one inventory test case).
