### PR TITLE
feat(review): merge identical inline findings across dual reviewers (#2158)

### DIFF
--- a/src/services/ai-review.ts
+++ b/src/services/ai-review.ts
@@ -1231,18 +1231,37 @@ const INLINE_FINDINGS_LIMIT = 10;
 /** Compose the public-safe, deduped, capped inline findings from one or two model reviews — the line-anchored
  *  counterpart of {@link composeAdvisoryNotes}. Dedupes by path+line (first wins), drops any body that fails the
  *  public-safe filter, and caps the total. Empty array when there is nothing safe to anchor. (#inline-comments) */
+const INLINE_SEVERITY_ORDER: Record<InlineFinding["severity"], number> = { nit: 0, blocker: 1 };
+
+/** Merge two inline findings anchored to the SAME (path, line) — dual reviewers often flag one line twice. The
+ *  higher-severity finding supplies the severity + body (ties keep the first-seen one); a suggestion/category is
+ *  carried from whichever finding has one, preferring the higher-severity finding's. Pure. (#2158) */
+function mergeSameLineFindings(first: InlineFinding, next: InlineFinding): InlineFinding {
+  const nextStronger = INLINE_SEVERITY_ORDER[next.severity] > INLINE_SEVERITY_ORDER[first.severity];
+  const strong = nextStronger ? next : first;
+  const weak = nextStronger ? first : next;
+  const suggestion = strong.suggestion ?? weak.suggestion;
+  const category = strong.category ?? weak.category;
+  return {
+    path: first.path,
+    line: first.line,
+    severity: strong.severity,
+    body: strong.body,
+    ...(suggestion ? { suggestion } : {}),
+    ...(category ? { category } : {}),
+  };
+}
+
 export function composeInlineFindings(reviews: ModelReview[]): InlineFinding[] {
-  const seen = new Set<string>();
-  const out: InlineFinding[] = [];
+  // MERGE (not drop) findings that two reviewers anchored to the same (path, line): keep the max severity and any
+  // suggestion/category, so a consensus line surfaces once with the strongest note instead of silently losing the
+  // second reviewer's detail (#2158). Map insertion order = first-seen order; the cap bounds DISTINCT lines.
+  const byLine = new Map<string, InlineFinding>();
   for (const finding of reviews.flatMap((r) => r.inlineFindings)) {
-    if (out.length >= INLINE_FINDINGS_LIMIT) break;
-    const key = `${finding.path}:${finding.line}`;
-    if (seen.has(key)) continue;
     const safeBody = toPublicSafe(finding.body);
     if (!safeBody) continue;
     const safeSuggestion = toPublicSafe(finding.suggestion);
-    seen.add(key);
-    out.push({
+    const candidate: InlineFinding = {
       path: finding.path,
       line: finding.line,
       severity: finding.severity,
@@ -1251,9 +1270,16 @@ export function composeInlineFindings(reviews: ModelReview[]): InlineFinding[] {
       // `category` is a fixed enum literal (never free text), so it carries through as-is — no public-safe
       // scrubbing needed, unlike body/suggestion.
       ...(finding.category ? { category: finding.category } : {}),
-    });
+    };
+    const key = `${finding.path}:${finding.line}`;
+    const existing = byLine.get(key);
+    if (existing) {
+      byLine.set(key, mergeSameLineFindings(existing, candidate));
+    } else if (byLine.size < INLINE_FINDINGS_LIMIT) {
+      byLine.set(key, candidate);
+    }
   }
-  return out;
+  return [...byLine.values()];
 }
 
 /** A CONSENSUS defect = BOTH reviews independently name at least one concrete blocker (the severity-disciplined

--- a/test/unit/ai-review.test.ts
+++ b/test/unit/ai-review.test.ts
@@ -3038,41 +3038,52 @@ describe("pure helpers", () => {
     ).toEqual([]);
   });
 
-  it("composeInlineFindings dedupes by path+line (first wins) and keeps safe suggestions (#inline-comments)", () => {
+  it("composeInlineFindings MERGES same-(path,line) findings across reviewers: max severity, suggestion carried from whichever had it; distinct lines untouched (#2158)", () => {
     const out = composeInlineFindings([
       reviewWithFindings([
         {
           path: "src/a.ts",
           line: 1,
           severity: "nit",
-          body: "First.",
-          suggestion: "  const renamed = first;  ",
+          body: "Rename this.",
+          suggestion: "  const renamed = x;  ", // the nit carries the only suggestion
         },
         {
           path: "src/a.ts",
           line: 1,
-          severity: "blocker",
-          body: "Duplicate line — dropped.",
-          suggestion: "const duplicate = true;",
+          severity: "blocker", // stronger → supplies severity + body; has no suggestion of its own
+          body: "This is a security hole.",
         },
         {
           path: "src/a.ts",
           line: 2,
           severity: "nit",
-          body: "reward payout farming",
+          body: "reward payout farming", // public-unsafe body → dropped, as before
         },
-        { path: "src/b.ts", line: 9, severity: "blocker", body: "Keep me." },
+        { path: "src/b.ts", line: 9, severity: "blocker", body: "Keep me." }, // distinct line untouched
       ]),
     ]);
     expect(out).toEqual([
       {
         path: "src/a.ts",
         line: 1,
-        severity: "nit",
-        body: "First.",
-        suggestion: "const renamed = first;",
+        severity: "blocker", // max of nit + blocker
+        body: "This is a security hole.", // from the higher-severity finding
+        suggestion: "const renamed = x;", // carried in from the nit (the only one with a suggestion), trimmed
       },
       { path: "src/b.ts", line: 9, severity: "blocker", body: "Keep me." },
+    ]);
+  });
+
+  it("composeInlineFindings merge keeps the first-seen on a severity TIE, and carries category + suggestion from either reviewer (#2158)", () => {
+    const out = composeInlineFindings([
+      reviewWithFindings([
+        { path: "src/a.ts", line: 5, severity: "blocker", body: "Blocker first.", category: "security" },
+        { path: "src/a.ts", line: 5, severity: "nit", body: "Nit second.", suggestion: "const y = 1;" }, // weaker; contributes only the suggestion
+      ]),
+    ]);
+    expect(out).toEqual([
+      { path: "src/a.ts", line: 5, severity: "blocker", body: "Blocker first.", category: "security", suggestion: "const y = 1;" },
     ]);
   });
 


### PR DESCRIPTION
Closes #2158.

In dual/consensus review the two models often anchor the **same** line. Today `composeInlineFindings` dedupes by `path+line` and **drops the second silently** (first wins), losing the other reviewer's detail. This **merges** same-`(path,line)` findings instead: keep the **max severity** + the higher-severity body, and carry a **suggestion/category from whichever reviewer had one** — so a consensus line surfaces once with the strongest note.

## What's here
- **`ai-review.ts`** — `composeInlineFindings` rebuilt around a `Map` keyed by `path:line` (insertion order = first-seen order preserved; the cap now bounds **distinct** lines) + a pure `mergeSameLineFindings(first, next)` helper: max severity, body from the stronger finding (ties keep first-seen), suggestion/category preferring the stronger then falling back to the weaker. **Advisory-only** — no gate behavior change.
- **Tests** — same line, different severity → merged max severity with the suggestion carried in from the nit; distinct lines untouched; severity tie keeps the first-seen body + carries category/suggestion from either reviewer.

## Validation
Full suite (`npm run test`), including the pre-existing `composeInlineFindings` + inline-comment suites:

```
Test Files  531 passed | 2 skipped (533)
     Tests  10572 passed | 7 skipped   (0 failed)
```
Typecheck clean.