### PR TITLE
fix(review): dedupe public stats effort average

### DIFF
--- a/src/review/public-stats.ts
+++ b/src/review/public-stats.ts
@@ -245,18 +245,28 @@ export async function getPublicStats(
       ...projects,
     ),
     // review-effort minutes (#1955): a deterministic, no-AI per-PR estimate persisted at publish time
-    // (processors.ts's pr_public_surface_published metadata.reviewEffortMinutes). AVG over every published event
-    // in the allowlist gives a real per-review time figure; a published row that predates this feature (or a
-    // files-fetch failure at publish time) simply has no `reviewEffortMinutes` key, so json_extract returns SQL
-    // NULL for that row and SQLite's AVG silently skips it — an all-historical ledger degrades to a NULL average
-    // (handled below via `?? MINUTES_SAVED_PER_PR`), never a crash or a skewed zero.
+    // (processors.ts's pr_public_surface_published metadata.reviewEffortMinutes). Fold repeated publish events
+    // down to one sample per distinct PR before the global AVG, matching the distinct-PR reviewed denominator
+    // below; a published row that predates this feature (or a files-fetch failure at publish time) simply has no
+    // `reviewEffortMinutes` key, so json_extract returns SQL NULL for that row and SQLite's AVG silently skips it
+    // — an all-historical ledger degrades to a NULL average (handled below via `?? MINUTES_SAVED_PER_PR`), never a
+    // crash or a skewed zero.
     safeAll<{ avgMinutes: number | null }>(
       env,
-      `SELECT AVG(json_extract(metadata_json, '$.reviewEffortMinutes')) AS avgMinutes
-         FROM audit_events
-        WHERE event_type = 'github_app.pr_public_surface_published'
-          AND LOWER(substr(target_key, 1, instr(target_key, '#') - 1)) IN (${inList})
-          AND instr(target_key, '#') > 0`,
+      `SELECT AVG(minutes) AS avgMinutes
+         FROM (
+           SELECT repo, number, AVG(minutes) AS minutes
+             FROM (
+               SELECT LOWER(substr(target_key, 1, instr(target_key, '#') - 1)) AS repo,
+                      CAST(substr(target_key, instr(target_key, '#') + 1) AS INTEGER) AS number,
+                      json_extract(metadata_json, '$.reviewEffortMinutes') AS minutes
+                 FROM audit_events
+                WHERE event_type = 'github_app.pr_public_surface_published'
+                  AND LOWER(substr(target_key, 1, instr(target_key, '#') - 1)) IN (${inList})
+                  AND instr(target_key, '#') > 0
+             )
+            GROUP BY repo, number
+         )`,
       ...projects,
     ),
   ]);

--- a/test/unit/public-stats.test.ts
+++ b/test/unit/public-stats.test.ts
@@ -376,6 +376,67 @@ describe("getPublicStats — live aggregate over the review ledger", () => {
     expect(out.totals.minutesSaved).not.toBe(2 * MINUTES_SAVED_PER_PR);
   });
 
+  it("deduplicates repeated public-surface publishes before averaging reviewEffortMinutes (real D1)", async () => {
+    const env = createTestEnv({ GITTENSORY_PUBLIC_STATS_REPOS: "JSONbored/gittensory" });
+    const db = env.DB;
+
+    await db
+      .prepare(
+        `INSERT INTO pull_requests (id, repo_full_name, number, title, state, merged_at)
+         VALUES (?, ?, ?, ?, ?, ?), (?, ?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        "pr-republished",
+        "JSONbored/gittensory",
+        20,
+        "republished large review",
+        "closed",
+        "2026-06-01T00:00:00.000Z",
+        "pr-single",
+        "JSONbored/gittensory",
+        21,
+        "single tiny review",
+        "closed",
+        "2026-06-01T00:00:00.000Z",
+      )
+      .run();
+    await db
+      .prepare(
+        `INSERT INTO audit_events (id, event_type, target_key, outcome, metadata_json)
+         VALUES (?, ?, ?, ?, ?), (?, ?, ?, ?, ?), (?, ?, ?, ?, ?), (?, ?, ?, ?, ?)`,
+      )
+      .bind(
+        "published-republished-a",
+        "github_app.pr_public_surface_published",
+        "JSONbored/gittensory#20",
+        "completed",
+        JSON.stringify({ reviewEffortMinutes: 100 }),
+        "published-republished-b",
+        "github_app.pr_public_surface_published",
+        "JSONbored/gittensory#20",
+        "completed",
+        JSON.stringify({ reviewEffortMinutes: 100 }),
+        "published-republished-c",
+        "github_app.pr_public_surface_published",
+        "JSONbored/gittensory#20",
+        "completed",
+        JSON.stringify({ reviewEffortMinutes: 100 }),
+        "published-single",
+        "github_app.pr_public_surface_published",
+        "JSONbored/gittensory#21",
+        "completed",
+        JSON.stringify({ reviewEffortMinutes: 1 }),
+      )
+      .run();
+
+    const out = await getPublicStats(env, NOW);
+
+    expect(out.totals.reviewed).toBe(2);
+    // Per-PR average: avg(avg(100, 100, 100), 1) = 50.5; reviewed = 2 -> 101.
+    // A raw event-level average would skew this to round(2 * avg(100, 100, 100, 1)) = 151.
+    expect(out.totals.minutesSaved).toBe(101);
+  });
+
   it("skips the own-ledger queries but still queries the Orb aggregate when the allowlist is empty", async () => {
     const env = {
       DB: {


### PR DESCRIPTION
### Motivation
- The public stats `minutesSaved` metric mixed an event-level average of `reviewEffortMinutes` with a distinct-PR reviewed count, allowing repeated publishes of the same PR to skew the reported minutes saved.

### Description
- Change the effort-query in `src/review/public-stats.ts` to fold repeated `github_app.pr_public_surface_published` events into one per distinct `repo,number` before computing the global `AVG` of per-PR minutes.
- Update the comment explaining the behavior to document the per-PR deduplication and the null/legacy fallback to `MINUTES_SAVED_PER_PR`.
- Add a real D1 regression test in `test/unit/public-stats.test.ts` that inserts repeated publish events for one PR and a single publish for another, asserting the per-PR average is used and `minutesSaved` is not skewed by duplicate publishes.

### Testing
- Ran the affected unit suite with `npx vitest run test/unit/public-stats.test.ts` and the file's tests passed (including the new dedupe regression test).
- Ran `npm run typecheck` and TypeScript type checks completed with no errors.
- Attempted `npm run test:coverage` but the full-coverage run did not complete due to an unrelated test-suite recursion (`test/unit/queue.test.ts`) producing a `RangeError` during the repository-wide coverage run, so unsharded coverage could not be produced in this environment.
- Attempted `npm run test:coverage -- --runInBand` but that invocation failed due to an invalid Vitest CLI option before tests executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4bae4de580832cac6c2c22ddbf4287)