### PR TITLE
fix(github): stop unattributed rate-limit observations from starving the shared public-token bucket

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -4266,6 +4266,15 @@ async function recordGitHubResponse(
   resource: "rest" | "graphql",
   admissionKey?: GitHubRateLimitAdmissionKey,
 ): Promise<void> {
+  // #rate-limit-admission-attribution: a response with no resolvable admission key (a genuinely tokenless /
+  // unauthenticated request -- GitHub's unauthenticated REST bucket is a separate, always-tiny 60/hour-per-IP
+  // cap -- or a token whose installation can't be determined) draws from a bucket this table has no way to name.
+  // Persisting it as a NULL-keyed row would let the admission-check fallback (fallbackObservationCanOverrideExact,
+  // selfhost/queue-common.ts) misattribute that unrelated, much-smaller bucket's exhaustion onto the shared
+  // public-token bucket every OTHER unkeyed job's admission decision depends on, permanently starving them even
+  // when the public-token bucket itself has headroom. Mirrors the equivalent `if (admissionKey)` guard already
+  // applied to the in-memory cache write (observeGitHubRestRateLimit, github/client.ts).
+  if (!admissionKey) return;
   const resetHeader = response.headers.get("x-ratelimit-reset");
   const resetAt = resetHeader && Number.isFinite(Number(resetHeader)) ? new Date(Number(resetHeader) * 1000).toISOString() : undefined;
   await recordGitHubRateLimitObservation(env, {

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -1618,6 +1618,7 @@ async function maybeEnqueueRagReindexForMergedPr(
   pullNumber: number,
   action: string | undefined,
   mergedAt: string | null | undefined,
+  installationId: number,
 ): Promise<void> {
   if (!(await convergedFeatureActive(env, repoFullName, "rag"))) return;
   // A PR that merged: closed action + a merged_at timestamp. (A closed-unmerged PR changed nothing on the base.)
@@ -1633,6 +1634,11 @@ async function maybeEnqueueRagReindexForMergedPr(
     requestedBy: "webhook",
     repoFullName,
     paths,
+    // #rate-limit-admission-attribution: without this, the queue's admission check has no installationId to key
+    // off (githubRateLimitAdmissionKeyForJob), so it falls back to the shared public-token bucket instead of this
+    // repo's own (usually healthy) installation bucket -- starving an installed repo's re-index behind unrelated
+    // public-token traffic even though its own budget has headroom.
+    installationId,
   });
 }
 
@@ -5926,6 +5932,7 @@ async function processGitHubWebhook(
           pr.number,
           payload.action,
           payload.pull_request.merged_at,
+          installationId,
         ).catch((error) => {
           /* v8 ignore next -- best-effort: a RAG re-index enqueue failure is logged, never surfaced to the gate. */
           console.error(

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -5603,8 +5603,12 @@ describe("GitHub backfill", () => {
         );
       });
 
-      const first = await fetchRequiredStatusContexts(env, "JSONbored/gittensory", "main", "public-token");
-      const second = await fetchRequiredStatusContexts(env, "JSONbored/gittensory", "main", "public-token");
+      // admissionKey mirrors the real caller (processors.ts), which always resolves + passes its own admission
+      // key -- omitting it here would exercise the (deliberately unpersisted) no-attribution path instead of
+      // this test's actual point: that a cache hit does not double-record telemetry for the SAME bucket.
+      const admissionKey = githubRateLimitAdmissionKeyForPublicToken();
+      const first = await fetchRequiredStatusContexts(env, "JSONbored/gittensory", "main", "public-token", admissionKey);
+      const second = await fetchRequiredStatusContexts(env, "JSONbored/gittensory", "main", "public-token", admissionKey);
 
       expect([...(first as Set<string>)]).toEqual(["validate"]);
       expect([...(second as Set<string>)]).toEqual(["validate"]);
@@ -5618,6 +5622,7 @@ describe("GitHub backfill", () => {
         path: "/branches/main/protection/required_status_checks",
         statusCode: 200,
         remaining: 4999,
+        admissionKey,
       });
     });
 

--- a/test/unit/rag-index.test.ts
+++ b/test/unit/rag-index.test.ts
@@ -783,10 +783,13 @@ describe("merged-PR incremental re-index trigger (webhook)", () => {
     return sent.filter((m) => m.type === "rag-index-repo");
   }
 
-  it("a MERGED PR into an allowlisted repo enqueues a rag-index-repo job with the changed paths", async () => {
+  it("a MERGED PR into an allowlisted repo enqueues a rag-index-repo job with the changed paths and installationId", async () => {
     const ragJobs = await runMergedPrWebhook({});
+    // REGRESSION (#rate-limit-admission-attribution): installationId must be threaded through so the queue's
+    // admission check attributes this job to the repo's OWN installation bucket, not the shared public-token
+    // bucket -- omitting it starves an installed repo's re-index behind unrelated public-token traffic.
     expect(ragJobs).toEqual([
-      { type: "rag-index-repo", requestedBy: "webhook", repoFullName: "JSONbored/gittensory", paths: ["src/a.ts", "README.md"] },
+      { type: "rag-index-repo", requestedBy: "webhook", repoFullName: "JSONbored/gittensory", paths: ["src/a.ts", "README.md"], installationId: 123 },
     ]);
   });
 


### PR DESCRIPTION
## Summary

- The self-hosted queue's background-job admission check was permanently deferring installation-less jobs (`rag-index-repo`, `agent-regate-sweep`, `backfill-*`) because GitHub responses made with no resolvable admission key (a genuinely tokenless/unauthenticated fallback request, or a token whose installation couldn't be determined) were still persisted into `github_rate_limit_observations` with a NULL `admission_key`. The admission-check fallback logic treats a NULL-keyed row as a stand-in for any unspecified bucket, including the shared `public-token` sentinel every installation-less job resolves to — and since GitHub's unauthenticated REST cap (60/hour) sits well below the background admission floor, one uninstalled repo's anonymous traffic could permanently stall unrelated background work even while the real public-token bucket had headroom.
- `recordGitHubResponse` now skips persisting an observation entirely when no admission key was resolved, mirroring the equivalent `if (admissionKey)` guard already applied to the in-memory rate-limit cache write (`observeGitHubRestRateLimit`).
- Separately, the merged-PR incremental RAG re-index enqueue (`maybeEnqueueRagReindexForMergedPr`) never threaded its webhook's `installationId` through to the enqueued `rag-index-repo` job, so it always fell back to the shared bucket instead of the repo's own (usually healthy) installation bucket — starving an installed repo's own re-index behind unrelated public-token traffic.
- No linked issue: found and root-caused live on the self-hosted instance while investigating a stalled job queue; small, self-contained fix.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; both branches of the new `recordGitHubResponse` guard are covered (verified via lcov), plus updated/new regression tests in `test/unit/backfill.test.ts` and `test/unit/rag-index.test.ts`.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate` (0 vulnerabilities)
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries
- [x] Full `npm run test:ci` gate run locally end-to-end (green)

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no auth/session/CORS changes.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — no API/OpenAPI/MCP surface touched.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section below. — N/A, no visible UI changes.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — N/A.

## Notes

- Root-caused live on the self-hosted instance: a stuck ~150-job backlog was traced to this exact mechanism (confirmed via direct inspection of `github_rate_limit_observations` and the live admission-check code path) before being reproduced and fixed here.