### PR TITLE
feat(miner-foundation): extract predicted-gate types into gittensory-engine (#2276)

### DIFF
--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -231,3 +231,13 @@ export {
   resolveDuplicateClusterWinnerNumber,
   type DuplicateClaimMember,
 } from "./duplicate-winner.js";
+// Predicted-gate type surface + pure helpers (#2276): a miner models its own gate verdict with the same
+// shapes the maintainer gate uses; buildPredictedGateVerdict itself follows in #2283.
+export {
+  predictedGateNote,
+  publicSafeFinding,
+  type GateCheckConclusion,
+  type GatePolicyPack,
+  type PredictedGateInput,
+  type PredictedGateVerdict,
+} from "./predicted-gate.js";

--- a/packages/gittensory-engine/src/predicted-gate.ts
+++ b/packages/gittensory-engine/src/predicted-gate.ts
@@ -1,0 +1,109 @@
+// Predicted-gate type surface + pure helpers, extracted to `@jsonbored/gittensory-engine` (#2276) so a miner can
+// model its own "will my PR pass the gate?" verdict locally with the same shapes the maintainer gate uses. This is
+// the TYPES-AND-PURE-HELPERS-FIRST slice; `buildPredictedGateVerdict` itself moves in the follow-up keystone
+// (#2283) once its signal dependencies are also extracted. `src/rules/predicted-gate.ts` re-exports these so
+// there is exactly one definition.
+//
+// The engine package stays isolated from `src/` (see this package's tsconfig: `rootDir: "src"`, `types: []`), so
+// the two small union shapes this surface needs from `src/types.ts` (`GatePolicyPack`) and
+// `src/rules/advisory.ts` (`GateCheckConclusion`) are mirrored here rather than imported across the boundary —
+// `src/` stays canonical, keep these in sync by hand (mirrors the `scoring/types.ts` convention from #2282).
+// Likewise `publicSafeFinding` takes its redaction function as an argument so the engine never reaches back into
+// `src/github/commands` for `sanitizePublicComment` (that sanitizer moves to the engine with
+// `buildPredictedGateVerdict` in #2283).
+
+/** Which policy pack a repo's public config selects. Local mirror of `src/types.ts`'s `GatePolicyPack` — keep in sync. */
+export type GatePolicyPack = "gittensor" | "oss-anti-slop";
+
+/** Gate check-run conclusion. Local mirror of `src/rules/advisory.ts`'s `GateCheckConclusion` — keep in sync. */
+export type GateCheckConclusion = "success" | "failure" | "action_required" | "neutral" | "skipped";
+
+/**
+ * Pre-submission "will my PR pass the gate?" prediction for a MINER, computed BEFORE a PR exists.
+ *
+ * Parity: it runs the EXACT same engine the maintainer PR pipeline runs — buildPullRequestAdvisory +
+ * evaluateGateCheck over a synthetic PR built from the contributor's local branch metadata. The verdict a
+ * miner sees pre-submission is therefore the same verdict the gate would compute post-submission.
+ *
+ * Boundary: the gate POLICY is sourced ONLY from the repo's PUBLIC `.gittensory.yml` (`manifest.gate`) +
+ * safe defaults — never the maintainer's private dashboard/DB settings. The `.gittensory.yml` is in the
+ * repo and publicly viewable, so this leaks nothing a contributor could not already read. The result is
+ * explicitly labelled "predicted" and notes that private overrides and AI-consensus blockers are not
+ * evaluated pre-submission.
+ */
+export type PredictedGateVerdict = {
+  predicted: true;
+  basis: "public_config";
+  /** Which policy pack the repo's public config selects (#692/#693). Under `oss-anti-slop` the predicted
+   *  verdict applies to ANY author (no confirmed-contributor gate) — so an agent on a non-Gittensor repo
+   *  gets a meaningful "will this pass?" answer with no Gittensor account. */
+  pack: GatePolicyPack;
+  conclusion: GateCheckConclusion;
+  title: string;
+  summary: string;
+  readinessScore: number | null;
+  confirmedContributor: boolean | undefined;
+  blockers: Array<{ code: string; title: string; detail: string; action?: string | undefined }>;
+  warnings: Array<{ code: string; title: string; detail: string; action?: string | undefined }>;
+  /** Opt-in conversion funnel (#694): present only under the `oss-anti-slop` pack — a non-Gittensor
+   *  adopter's path to "earn on Gittensor". `null` under `gittensor` (the contributor is already there). */
+  funnel: { message: string; registerUrl: string } | null;
+  note: string;
+};
+
+const PREDICTED_GATE_NOTE_BASE =
+  "Predicted from the repo's public .gittensory.yml gate config + safe defaults. The maintainer may have " +
+  "private dashboard overrides not reflected here, and the dual-model AI-consensus blocker is only " +
+  "evaluated on a real PR. ";
+// The slop score is ALWAYS disclaimed: it needs the diff CONTENT, which the metadata-only oracle never receives.
+const PREDICTED_GATE_NOTE_SLOP = "The slop score is NOT evaluated pre-submission (it needs the diff content) and may still fail the real gate. ";
+// Disclaimed only when the caller did NOT supply changed paths — then path-dependent gates can't be predicted.
+const PREDICTED_GATE_NOTE_NO_PATHS =
+  "Provide the PR's changed paths to also predict the focus-manifest path policy, the size/guardrail hold, and " +
+  "any pre-merge check scoped to changed paths; without them only path-independent title/description/label " +
+  "pre-merge checks are predicted. ";
+// Shown instead of NO_PATHS once changed paths ARE supplied (#2458): the size hold can now be predicted, but only
+// from file COUNT — line-diff stats are never sent to this metadata-only predictor, so a PR with many changed
+// LINES across few files can still under-predict the hold the live gate would actually apply.
+const PREDICTED_GATE_NOTE_SIZE_FILES_ONLY =
+  "The size-hold prediction uses changed FILE count only, not changed LINE count (line-diff stats are not " +
+  "available pre-submission), so it may under-predict a hold for a PR with many changed lines across few files. ";
+const PREDICTED_GATE_NOTE_GATE_EQUALITY =
+  "Every author is gated the same: a configured hard blocker fails the gate regardless of confirmed-contributor " +
+  "status (which affects only on-chain scoring).";
+
+/** Compose the predicted-gate note. Slop is always disclaimed; the path-policy/path-gated disclaimer drops once
+ *  the caller supplies changed paths (#11-13/#18), replaced by the size-prediction file-count-only caveat (#2458). */
+export function predictedGateNote(hasChangedPaths: boolean): string {
+  return (
+    PREDICTED_GATE_NOTE_BASE +
+    PREDICTED_GATE_NOTE_SLOP +
+    (hasChangedPaths ? PREDICTED_GATE_NOTE_SIZE_FILES_ONLY : PREDICTED_GATE_NOTE_NO_PATHS) +
+    PREDICTED_GATE_NOTE_GATE_EQUALITY
+  );
+}
+
+export type PredictedGateInput = {
+  repoFullName: string;
+  contributorLogin: string;
+  title: string;
+  body?: string | undefined;
+  labels?: string[] | undefined;
+  linkedIssues?: number[] | undefined;
+  authorAssociation?: string | undefined;
+};
+
+/** Redact a gate finding's public-facing text for a predicted verdict. The `sanitize` function is injected
+ *  (rather than imported) so this engine module stays isolated from `src/github/commands`; the backend binds it
+ *  to `sanitizePublicComment`. */
+export function publicSafeFinding(
+  finding: { code: string; title: string; detail: string; action?: string | undefined },
+  sanitize: (value: string) => string,
+) {
+  return {
+    code: finding.code,
+    title: sanitize(finding.title),
+    detail: sanitize(finding.detail),
+    action: finding.action ? sanitize(finding.action) : undefined,
+  };
+}

--- a/src/rules/predicted-gate.ts
+++ b/src/rules/predicted-gate.ts
@@ -19,94 +19,29 @@ const OSS_ANTI_SLOP_FUNNEL = {
   message: "This repo runs the Gittensor anti-slop gate. Gittensor lets GitHub contributors earn for open-source work like this — register to start earning.",
   registerUrl: GITTENSOR_HOME_URL,
 } as const;
-import { buildPullRequestAdvisory, evaluateGateCheck, type GateCheckConclusion } from "./advisory";
+import { buildPullRequestAdvisory, evaluateGateCheck } from "./advisory";
 import { hasValidationNote, isTestPath } from "../signals/test-evidence";
 import { evaluateClaCheck } from "../review/cla-check";
 import { evaluatePreMergeChecks } from "../review/pre-merge-checks";
 
-/**
- * Pre-submission "will my PR pass the gate?" prediction for a MINER, computed BEFORE a PR exists.
- *
- * Parity: it runs the EXACT same engine the maintainer PR pipeline runs — buildPullRequestAdvisory +
- * evaluateGateCheck over a synthetic PR built from the contributor's local branch metadata. The verdict a
- * miner sees pre-submission is therefore the same verdict the gate would compute post-submission.
- *
- * Boundary: the gate POLICY is sourced ONLY from the repo's PUBLIC `.gittensory.yml` (`manifest.gate`) +
- * safe defaults — never the maintainer's private dashboard/DB settings. The `.gittensory.yml` is in the
- * repo and publicly viewable, so this leaks nothing a contributor could not already read. The result is
- * explicitly labelled "predicted" and notes that private overrides and AI-consensus blockers are not
- * evaluated pre-submission.
- */
-export type PredictedGateVerdict = {
-  predicted: true;
-  basis: "public_config";
-  /** Which policy pack the repo's public config selects (#692/#693). Under `oss-anti-slop` the predicted
-   *  verdict applies to ANY author (no confirmed-contributor gate) — so an agent on a non-Gittensor repo
-   *  gets a meaningful "will this pass?" answer with no Gittensor account. */
-  pack: GatePolicyPack;
-  conclusion: GateCheckConclusion;
-  title: string;
-  summary: string;
-  readinessScore: number | null;
-  confirmedContributor: boolean | undefined;
-  blockers: Array<{ code: string; title: string; detail: string; action?: string | undefined }>;
-  warnings: Array<{ code: string; title: string; detail: string; action?: string | undefined }>;
-  /** Opt-in conversion funnel (#694): present only under the `oss-anti-slop` pack — a non-Gittensor
-   *  adopter's path to "earn on Gittensor". `null` under `gittensor` (the contributor is already there). */
-  funnel: { message: string; registerUrl: string } | null;
-  note: string;
-};
+// PredictedGateVerdict/PredictedGateInput and the predictedGateNote/publicSafeFinding pure helpers now live in
+// `@jsonbored/gittensory-engine` (#2276) so a miner can model the gate locally with the same shapes;
+// buildPredictedGateVerdict itself follows in the keystone issue (#2283). Imported via the relative source path
+// — this repo's engine-consumption convention (see src/scoring/preview.ts) — so `typecheck`/`test:coverage` do
+// not depend on the engine's built `dist/`, which is not guaranteed present when they run in CI.
+import {
+  predictedGateNote,
+  publicSafeFinding as buildPublicSafeFinding,
+} from "../../packages/gittensory-engine/src/predicted-gate";
+import type { PredictedGateInput, PredictedGateVerdict } from "../../packages/gittensory-engine/src/predicted-gate";
 
-const PREDICTED_GATE_NOTE_BASE =
-  "Predicted from the repo's public .gittensory.yml gate config + safe defaults. The maintainer may have " +
-  "private dashboard overrides not reflected here, and the dual-model AI-consensus blocker is only " +
-  "evaluated on a real PR. ";
-// The slop score is ALWAYS disclaimed: it needs the diff CONTENT, which the metadata-only oracle never receives.
-const PREDICTED_GATE_NOTE_SLOP = "The slop score is NOT evaluated pre-submission (it needs the diff content) and may still fail the real gate. ";
-// Disclaimed only when the caller did NOT supply changed paths — then path-dependent gates can't be predicted.
-const PREDICTED_GATE_NOTE_NO_PATHS =
-  "Provide the PR's changed paths to also predict the focus-manifest path policy, the size/guardrail hold, and " +
-  "any pre-merge check scoped to changed paths; without them only path-independent title/description/label " +
-  "pre-merge checks are predicted. ";
-// Shown instead of NO_PATHS once changed paths ARE supplied (#2458): the size hold can now be predicted, but only
-// from file COUNT — line-diff stats are never sent to this metadata-only predictor, so a PR with many changed
-// LINES across few files can still under-predict the hold the live gate would actually apply.
-const PREDICTED_GATE_NOTE_SIZE_FILES_ONLY =
-  "The size-hold prediction uses changed FILE count only, not changed LINE count (line-diff stats are not " +
-  "available pre-submission), so it may under-predict a hold for a PR with many changed lines across few files. ";
-const PREDICTED_GATE_NOTE_GATE_EQUALITY =
-  "Every author is gated the same: a configured hard blocker fails the gate regardless of confirmed-contributor " +
-  "status (which affects only on-chain scoring).";
+// Re-export the types so existing importers (test fixtures, engine-parity suites) keep resolving them here.
+export type { PredictedGateInput, PredictedGateVerdict };
 
-/** Compose the predicted-gate note. Slop is always disclaimed; the path-policy/path-gated disclaimer drops once
- *  the caller supplies changed paths (#11-13/#18), replaced by the size-prediction file-count-only caveat (#2458). */
-function predictedGateNote(hasChangedPaths: boolean): string {
-  return (
-    PREDICTED_GATE_NOTE_BASE +
-    PREDICTED_GATE_NOTE_SLOP +
-    (hasChangedPaths ? PREDICTED_GATE_NOTE_SIZE_FILES_ONLY : PREDICTED_GATE_NOTE_NO_PATHS) +
-    PREDICTED_GATE_NOTE_GATE_EQUALITY
-  );
-}
-
-export type PredictedGateInput = {
-  repoFullName: string;
-  contributorLogin: string;
-  title: string;
-  body?: string | undefined;
-  labels?: string[] | undefined;
-  linkedIssues?: number[] | undefined;
-  authorAssociation?: string | undefined;
-};
-
-function publicSafeFinding(finding: { code: string; title: string; detail: string; action?: string | undefined }) {
-  return {
-    code: finding.code,
-    title: sanitizePublicComment(finding.title),
-    detail: sanitizePublicComment(finding.detail),
-    action: finding.action ? sanitizePublicComment(finding.action) : undefined,
-  };
-}
+// publicSafeFinding lives in the engine but takes the redaction fn as an argument so the engine stays isolated from
+// src/github/commands' sanitizePublicComment. Bind the canonical sanitizer here so the call sites below are unchanged.
+const publicSafeFinding = (finding: { code: string; title: string; detail: string; action?: string | undefined }) =>
+  buildPublicSafeFinding(finding, sanitizePublicComment);
 
 /** GitHub full names are case-insensitive — mirror `sameRepo` in the live gate paths. */
 function sameRepoFullName(left: string | null | undefined, right: string | null | undefined): boolean {


### PR DESCRIPTION
Closes #2276

## What

Moves the pure, dependency-light predicted-gate surface out of `src/rules/predicted-gate.ts` into a new `packages/gittensory-engine/src/predicted-gate.ts`, re-exported from the engine barrel, so a miner can model its own "will my PR pass the gate?" verdict locally with the exact shapes the maintainer gate uses. This is the types-and-pure-helpers-first slice; `buildPredictedGateVerdict` itself follows in the keystone (#2283).

Moved (ported verbatim):
- `PredictedGateVerdict`, `PredictedGateInput` types
- `predictedGateNote` (+ its `PREDICTED_GATE_NOTE_*` constants)
- `publicSafeFinding`

`src/rules/predicted-gate.ts` now re-exports the two types and imports the helpers instead of defining them, so there is exactly one definition. `buildPredictedGateVerdict` stays in `src/` and calls the imported/bound helpers unchanged.

## Boundary wiring (please read — deviates slightly from the issue text)

The issue text suggests importing from the bare specifier `@jsonbored/gittensory-engine` and adding it to root `package.json`. I followed the **already-merged convention** from the scoring extraction (#2282, `src/scoring/preview.ts`) and the duplicate-winner extraction (#2278) instead, because it is what actually keeps CI green:

- **Relative source path, not the bare specifier.** `src/rules/predicted-gate.ts` imports `../../packages/gittensory-engine/src/predicted-gate`. The engine's `package.json` `exports` resolve to its built `dist/`, which is **not** guaranteed to exist when root `typecheck`/`test:coverage` run in CI (the engine is built later in the job). The relative source path avoids that ordering dependency with zero config changes — no root dep, no `tsconfig` `paths`, no `vitest` alias — exactly matching the two prior extractions. I verified typecheck exits 0 with the engine `dist/` moved aside.
- **Two small union mirrors.** `PredictedGateVerdict` needs `GatePolicyPack` (`src/types.ts`) and `GateCheckConclusion` (`src/rules/advisory.ts`). The engine package is isolated (`rootDir: "src"`, `types: []`) and cannot import across into `src/`, so these two-/five-member unions are mirrored engine-side with `src/` kept canonical — mirroring the `scoring/types.ts` convention from #2282.
- **`publicSafeFinding` takes its redaction fn as an argument.** The original `publicSafeFinding` calls `sanitizePublicComment` (which lives in `src/github/commands.ts` and has ~145 call sites across `src/`). Rather than relocate that core sanitizer here (out of scope for a "keep the surface small" slice), the engine helper accepts `sanitize` as a parameter and `src/` binds the canonical `sanitizePublicComment`. The sanitizer can move to the engine alongside `buildPredictedGateVerdict` in #2283, where it is actually needed engine-side.

## Verification

- `npm run typecheck` → exit 0 (also verified exit 0 with `packages/gittensory-engine/dist` moved aside — the source-path shim resolves without the built engine)
- `npm run build --workspace @jsonbored/gittensory-engine` → exit 0 (new module compiles under the engine's isolated tsconfig)
- The existing `predicted-gate` suite + engine-parity fixtures + contract parity pass **unmodified**
- `npm run test:coverage` → exit 0; `src/rules/predicted-gate.ts` at 100% (statements/branches/functions/lines)
- `ui:typecheck` / `ui:lint` (0 errors) / `ui:test`, `rees:test` all green
- `git diff --check` clean
