### PR TITLE
docs(selfhost): document a git-pull-safe path to enabling Alertmanager notifications

### DIFF
--- a/apps/gittensory-ui/src/routes/docs.self-hosting-operations.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-operations.tsx
@@ -125,16 +125,35 @@ docker compose --profile postgres --profile observability --profile backup up -d
         <code>docker compose --profile observability up -d</code> always starts clean even before
         you've configured anywhere to send notifications. This is intentional — the shipped config
         can&apos;t bake in a Slack/Discord/email destination that works for everyone — but it means
-        nothing pages anyone until you edit <code>alertmanager/alertmanager.yml</code> yourself.
-        Treat this as a required step, not an optional one, for any deployment you expect to run
-        unattended.
+        nothing pages anyone until you enable a real receiver. Treat this as a required step, not an
+        optional one, for any deployment you expect to run unattended.
       </p>
       <p>
-        The fastest verified path: create a Discord channel webhook (channel settings → Integrations
-        → Webhooks → New Webhook), then uncomment the <code>discord</code> receiver block in{" "}
-        <code>alertmanager/alertmanager.yml</code> and point the root route at it. Slack, email, and
-        a generic webhook receiver (for PagerDuty or a custom handler) are also ready to uncomment
-        in the same file.
+        Don&apos;t edit the committed <code>alertmanager/alertmanager.yml</code> in place — deploys
+        <code>git pull</code> this repo, so a local edit to a tracked file either blocks the next
+        pull or gets silently overwritten by it. Instead, copy it to a gitignored{" "}
+        <code>alertmanager/alertmanager.local</code> (matches the existing <code>*.local</code>{" "}
+        ignore rule) and make your receiver/route changes there — the fastest verified path is
+        uncommenting the <code>discord</code> receiver block and pointing the root route at it,
+        using <code>webhook_url_file: /etc/alertmanager/discord_url</code> so the webhook URL itself
+        lives in its own gitignored file next to it, never in a file docker-compose.yml or git ever
+        tracks. Slack, email, and a generic webhook receiver (for PagerDuty or a custom handler) are
+        also ready to uncomment in the same template. Then point Alertmanager at your local copy via{" "}
+        <code>docker-compose.override.yml</code>:
+      </p>
+      <CodeBlock
+        lang="yaml"
+        code={`services:
+  alertmanager:
+    command:
+      - "--config.file=/etc/alertmanager/alertmanager.local"
+      - "--storage.path=/alertmanager"`}
+      />
+      <p>
+        Restart with <code>docker compose up -d --no-deps alertmanager</code> to pick up both files.
+        The whole <code>alertmanager/</code> directory is mounted read-only into the container, so
+        any gitignored file you add there (the local config, a secret file it references) shows up
+        at the same path with no docker-compose.yml edit required.
       </p>
       <p>
         Until you do, alerts are still visible without any extra setup: open Grafana and check the{" "}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -520,7 +520,12 @@ services:
     expose:
       - "9093" # in-network only; reach the UI/API via `docker compose port` or a tunnel
     volumes:
-      - ./alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
+      # Mounts the whole host directory (not just the yml) so an operator's private overrides are visible
+      # inside the container at the same paths, with no docker-compose.yml edit needed per file added:
+      # a real receiver config (e.g. ./alertmanager/alertmanager.local, gitignored via the *.local rule
+      # above -- point docker-compose.override.yml's alertmanager `command:` at it) and/or a secret file a
+      # local config's webhook_url_file /etc/alertmanager/<name> references.
+      - ./alertmanager:/etc/alertmanager:ro
       - alertmanager-data:/alertmanager
     command:
       - "--config.file=/etc/alertmanager/alertmanager.yml"


### PR DESCRIPTION
## Summary

- `alertmanager/alertmanager.yml` ships with every alert routed to a silent `"null"` receiver by design (so a fresh `docker compose --profile observability up -d` always comes up green), but the existing docs told operators to enable a real receiver by editing that committed file in place. Self-host operators `git pull` this repo to deploy, so a local edit to a tracked file either blocks the next pull or gets silently discarded by it — this was a real, live gap: on our own self-hosted instance, `GittensoryQueueBacklogHigh` and other alert rules fired continuously for ~9 hours during a queue-stall incident with zero notification, because the receiver was never actually wired up.
- Documents copying the template to a gitignored `alertmanager/alertmanager.local` (already covered by the existing `*.local` ignore rule, so no `.gitignore` change needed) and pointing Alertmanager at it via `docker-compose.override.yml`'s `command:` override — the same pattern this repo already uses for other per-operator customization (co-located CPU tuning, runner registration).
- Mounts the whole `alertmanager/` directory (not just `alertmanager.yml`) into the container, so an operator's local config and any secret file it references (e.g. a Discord `webhook_url_file`) are visible inside the container without a `docker-compose.yml` edit.
- No linked issue: found and fixed while investigating why a live incident's alerts never reached a human; small, self-contained docs + mount fix.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — no `src/**` logic changed (docs + a compose volume mount only), so no new coverage surface.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate` (0 vulnerabilities)
- [x] Full `npm run test:ci` gate run locally end-to-end (green)

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — no API/OpenAPI/MCP surface touched.
- [ ] UI changes use live API data or real empty/error/loading states. — N/A, docs-only text/code-sample change, no data-driven UI.
- [ ] Visible UI changes include a `UI Evidence` section. — N/A, plain docs prose/code-block change, not a visual/layout change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Verified live on edge-us-01: applied the documented `alertmanager.local` + `docker-compose.override.yml` pattern, confirmed Alertmanager successfully delivered a Discord notification for an active alert after the change (reusing the existing gittensory Discord channel webhook already configured for this repo's per-PR notifications).