### PR TITLE
docs(config): dedupe review.test_generation example documentation

### DIFF
--- a/.gittensory.yml.example
+++ b/.gittensory.yml.example
@@ -403,13 +403,6 @@ review:
   # effort_score: false
   # When true, the unified review comment gains a compact "review effort: N/5 (~M min)" chip.
 
-  # Boundary-safe test-generation advisory (#1972). Bool | null. Default: null/false -- byte-identical (no
-  # boundary scan runs at all). When true, a diff that touches a small, precise set of boundary-condition
-  # patterns (off-by-one array/index bounds, null/undefined branches, empty-collection checks) with NO test
-  # evidence anywhere in the PR gets an advisory finding plus a LOCAL-execution test-generation action spec
-  # (criteria/hints for your OWN agent to scaffold tests with -- gittensory never writes or runs test code).
-  # test_generation: false
-
   # Bool | null. Default: null/false — byte-identical (#2184, part of #1971). Also requires the operator's
   # GITTENSORY_REVIEW_IMPACT_MAP env flag to be on — this manifest field alone cannot enable it. When both are
   # on, a deterministic impact map (which other repo files plausibly need re-checking, from the RAG index +
@@ -465,11 +458,14 @@ review:
   # (CI green, gate passing, mergeable-clean, valid linked issue). SURFACE ONLY — never changes the decision.
   # auto_merge_summary: false
 
-  # Boundary-safe test generation (#2189). Bool | null. Default: null/false — byte-identical.
-  # Requires operator flag GITTENSORY_REVIEW_TEST_GENERATION AND this toggle.
+  # Boundary-safe test-generation advisory (#1972, kill-switch config slice #2189). Bool | null. Default:
+  # null/false — byte-identical (no boundary scan runs at all). Requires the operator's
+  # GITTENSORY_REVIEW_TEST_GENERATION flag to be on AND this toggle. When both are on, a diff that touches a
+  # small, precise set of boundary-condition patterns (off-by-one array/index bounds, null/undefined branches,
+  # empty-collection checks) with NO test evidence anywhere in the PR gets an advisory finding plus a
+  # LOCAL-execution test-generation action spec (criteria/hints for your OWN agent to scaffold tests with —
+  # gittensory never writes or runs test code).
   # test_generation: false
-  # When true, a missing-test-evidence finding is ALSO accompanied by a local-write action spec (criteria
-  # supplied by gittensory; execution stays on the contributor's own machine — no source upload, no server write).
 
   # Deterministic label suggestions (#2045). Each rule SUGGESTS a non-scoring label when a PR matches ALL of the
   # `when` criteria it sets (at least one is required): when_paths (any changed path matches a glob), title_contains,
@@ -850,11 +846,6 @@ settings:
 #   # compact "review effort: N/5 (~M min)" chip -- a deterministic, no-AI complexity/time estimate from the
 #   # changed files' added-line volume and file-type mix. Bool or null. Default: null/false.
 #   effort_score: false
-#   # When true, a diff touching a small, precise set of boundary-condition patterns (off-by-one array/index
-#   # bounds, null/undefined branches, empty-collection checks) with no test evidence in the PR gets an
-#   # advisory finding plus a LOCAL-execution test-generation action spec (criteria/hints only -- never
-#   # generated test code; your own agent scaffolds it). Bool or null. Default: null/false.
-#   test_generation: false
 #   # When true (AND the operator's GITTENSORY_REVIEW_IMPACT_MAP env flag is also on), a deterministic
 #   # impact map -- which other repo files plausibly need re-checking, from the RAG index + changed
 #   # symbols -- is computed, rendered as a compact unified-comment section, and fed to the AI reviewer
@@ -876,10 +867,11 @@ settings:
 #   # fallback for whatever it omits. Only takes effect when inline_comments is already on. Bool or null.
 #   # Default: null/false.
 #   finding_categories: false
-#   # When true, a missing-test-evidence finding is ALSO accompanied by a local-write action spec describing
-#   # WHAT boundary-safe test cases should exist -- criteria/content supplied by gittensory, execution stays
-#   # on the contributor's own machine (no source upload, no server-side write). Also requires the operator
-#   # flag GITTENSORY_REVIEW_TEST_GENERATION. Bool or null. Default: null/false (byte-identical).
+#   # When true, a diff touching a small, precise set of boundary-condition patterns (off-by-one array/index
+#   # bounds, null/undefined branches, empty-collection checks) with no test evidence in the PR gets an
+#   # advisory finding plus a LOCAL-execution test-generation action spec (criteria/hints only -- never
+#   # generated test code; your own agent scaffolds it). Also requires the operator flag
+#   # GITTENSORY_REVIEW_TEST_GENERATION. Bool or null. Default: null/false (byte-identical).
 #   test_generation: false
 #   # How strictly a linked issue must actually be SATISFIED by the PR (distinct from linkedIssuePolicy,
 #   # which only checks a link EXISTS). off = not evaluated; advisory = surface a finding; block = can

--- a/config/examples/gittensory.full.yml
+++ b/config/examples/gittensory.full.yml
@@ -416,13 +416,6 @@ review:
   # effort_score: false
   # When true, the unified review comment gains a compact "review effort: N/5 (~M min)" chip.
 
-  # Boundary-safe test-generation advisory (#1972). Bool | null. Default: null/false -- byte-identical (no
-  # boundary scan runs at all). When true, a diff that touches a small, precise set of boundary-condition
-  # patterns (off-by-one array/index bounds, null/undefined branches, empty-collection checks) with NO test
-  # evidence anywhere in the PR gets an advisory finding plus a LOCAL-execution test-generation action spec
-  # (criteria/hints for your OWN agent to scaffold tests with -- gittensory never writes or runs test code).
-  # test_generation: false
-
   # Bool | null. Default: null/false — byte-identical (#2184, part of #1971). Also requires the operator's
   # GITTENSORY_REVIEW_IMPACT_MAP env flag to be on — this manifest field alone cannot enable it. When both are
   # on, a deterministic impact map (which other repo files plausibly need re-checking, from the RAG index +
@@ -478,11 +471,14 @@ review:
   # (CI green, gate passing, mergeable-clean, valid linked issue). SURFACE ONLY — never changes the decision.
   # auto_merge_summary: false
 
-  # Boundary-safe test generation (#2189). Bool | null. Default: null/false — byte-identical.
-  # Requires operator flag GITTENSORY_REVIEW_TEST_GENERATION AND this toggle.
+  # Boundary-safe test-generation advisory (#1972, kill-switch config slice #2189). Bool | null. Default:
+  # null/false — byte-identical (no boundary scan runs at all). Requires the operator's
+  # GITTENSORY_REVIEW_TEST_GENERATION flag to be on AND this toggle. When both are on, a diff that touches a
+  # small, precise set of boundary-condition patterns (off-by-one array/index bounds, null/undefined branches,
+  # empty-collection checks) with NO test evidence anywhere in the PR gets an advisory finding plus a
+  # LOCAL-execution test-generation action spec (criteria/hints for your OWN agent to scaffold tests with —
+  # gittensory never writes or runs test code).
   # test_generation: false
-  # When true, a missing-test-evidence finding is ALSO accompanied by a local-write action spec (criteria
-  # supplied by gittensory; execution stays on the contributor's own machine — no source upload, no server write).
 
   # Deterministic label suggestions (#2045). Each rule SUGGESTS a non-scoring label when a PR matches ALL of the
   # `when` criteria it sets (at least one is required): when_paths (any changed path matches a glob), title_contains,
@@ -863,11 +859,6 @@ settings:
 #   # compact "review effort: N/5 (~M min)" chip -- a deterministic, no-AI complexity/time estimate from the
 #   # changed files' added-line volume and file-type mix. Bool or null. Default: null/false.
 #   effort_score: false
-#   # When true, a diff touching a small, precise set of boundary-condition patterns (off-by-one array/index
-#   # bounds, null/undefined branches, empty-collection checks) with no test evidence in the PR gets an
-#   # advisory finding plus a LOCAL-execution test-generation action spec (criteria/hints only -- never
-#   # generated test code; your own agent scaffolds it). Bool or null. Default: null/false.
-#   test_generation: false
 #   # When true (AND the operator's GITTENSORY_REVIEW_IMPACT_MAP env flag is also on), a deterministic
 #   # impact map -- which other repo files plausibly need re-checking, from the RAG index + changed
 #   # symbols -- is computed, rendered as a compact unified-comment section, and fed to the AI reviewer
@@ -889,10 +880,11 @@ settings:
 #   # fallback for whatever it omits. Only takes effect when inline_comments is already on. Bool or null.
 #   # Default: null/false.
 #   finding_categories: false
-#   # When true, a missing-test-evidence finding is ALSO accompanied by a local-write action spec describing
-#   # WHAT boundary-safe test cases should exist -- criteria/content supplied by gittensory, execution stays
-#   # on the contributor's own machine (no source upload, no server-side write). Also requires the operator
-#   # flag GITTENSORY_REVIEW_TEST_GENERATION. Bool or null. Default: null/false (byte-identical).
+#   # When true, a diff touching a small, precise set of boundary-condition patterns (off-by-one array/index
+#   # bounds, null/undefined branches, empty-collection checks) with no test evidence in the PR gets an
+#   # advisory finding plus a LOCAL-execution test-generation action spec (criteria/hints only -- never
+#   # generated test code; your own agent scaffolds it). Also requires the operator flag
+#   # GITTENSORY_REVIEW_TEST_GENERATION. Bool or null. Default: null/false (byte-identical).
 #   test_generation: false
 #   # How strictly a linked issue must actually be SATISFIED by the PR (distinct from linkedIssuePolicy,
 #   # which only checks a link EXISTS). off = not evaluated; advisory = surface a finding; block = can


### PR DESCRIPTION
## Summary

- #3794 and #3795 both implemented Related to #1972 (boundary-safe test generation) and merged into `main` within an hour of each other. The rebase collision at `src/signals/focus-manifest.ts` (both PRs added `review.test_generation`) was manually deduped for the code field/resolver, but the two YAML example files (`.gittensory.yml.example`, `config/examples/gittensory.full.yml`) each ended up with **two separate `test_generation: false` documentation blocks** — one per PR's framing — in both the canonical documented section and the full-worked-example section.
- This PR collapses each duplicate pair down to a single entry per file/section (4 sites total), keeping the more complete behavioral description (boundary-condition patterns + advisory finding + LOCAL-execution spec) together with the operator-flag callout (`GITTENSORY_REVIEW_TEST_GENERATION` AND the manifest toggle), matching how every other kill-switched `review.*` field (`inline_comments`, `fixHandoff`, `memory`, `impact_map`) documents itself exactly once.
- No behavior change: this is a documentation-only fix. `src/signals/focus-manifest.ts`'s `testGeneration` field, parser, serializer, and `resolveTestGenerationManifestToggle` resolver were already correctly deduped to one copy each (verified by re-reading the current `main` state and grepping for every call site — no leftover duplication in code, only in the example docs).

### Investigation notes (for context, no code change needed here)

Per the task that prompted this cleanup, I also verified whether the two MCP tools these PRs shipped (`gittensory_suggest_boundary_tests` from #3794, `gittensory_generate_tests` from #3795) are redundant, and whether any test-generation resolver is dead code that should be removed:

- The two MCP tools are genuinely complementary, not redundant: `gittensory_suggest_boundary_tests` detects specific risky code patterns in a diff (off-by-one/null-check/empty-collection) and returns criteria hints; `gittensory_generate_tests` detects the repo's test framework/convention and returns a scaffold spec parameterized by target files. Both are registered unconditionally in `src/mcp/server.ts`, matching the house convention that every MCP tool in that file is always available (no tool registration in the file is ever config-gated) — so there's no gating inconsistency between them to fix.
- `isTestGenerationEnabled` / `shouldOfferTestGenerationSpec` (`src/review/test-generation.ts`) and `resolveTestGenerationManifestToggle` (`src/signals/focus-manifest.ts`) have zero callers outside their own definitions today — but this mirrors an established, intentional repo pattern of shipping a config-gate slice ahead of its live-pipeline wiring (compare `src/review/fix-handoff.ts`'s `shouldEmitFixHandoff`, also currently unwired, whose parent epic #1962 stays open for exactly this reason). Removing it would go against that pattern and destroy already-tested plumbing a future PR needs. I did not remove it.
- Separately (a tracking-hygiene gap, not a code issue): PR #3795's body used the closing keyword ahead of #2187, #2188, #2189, but GitHub's closing-keyword parser only linked the first number in that list — `closingIssuesReferences` shows only #2187 was actually closed by #3795; #2188 is still open even though its checklist items are implemented in the merged code. Flagging for maintainer awareness; not something this PR changes.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed. (Docs-only cleanup following up on already-merged #3794/#3795; not re-closing #1972.)

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — this PR only touches two root-level YAML example files (not `src/**`), so Codecov `codecov/patch` has no coverage obligation here; ran the full unsharded suite anyway to confirm nothing broke, all green.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries. (N/A — no behavior change; `test/unit/config-templates.test.ts` and `test/unit/focus-manifest.test.ts` already assert `review.test_generation` is documented and round-trips correctly, and both still pass; also verified the two YAML files stay byte-identical from the `WHERE IT LIVES` marker onward, which `config-templates.test.ts` enforces.)

Also ran the full `npm run test:ci` (all jobs, including `db:migrations:check`, `db:schema-drift:check`, `selfhost:env-reference:check`, `cf-typegen:check`, `docs:drift-check`, `command-reference:check`, `ui:openapi:settings-parity`, `ui:version-audit`, `build:miner`, `test:miner-pack`, `rees:test`) green.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session/CORS/Cloudflare changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP behavior change; MCP tool registrations and schemas are untouched.)
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI code changes, only root-level YAML example docs.)
- [ ] Visible UI changes include a `UI Evidence` section below with screenshots. (N/A — no visible UI/frontend change.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (This PR IS the docs fix; did not touch `CHANGELOG.md`.)

## UI Evidence

N/A — no visible UI/frontend change; this PR only edits `.gittensory.yml.example` and `config/examples/gittensory.full.yml` prose/comments.

## Notes

- Related to #1972 — this is a documentation cleanup following up on the two PRs (#3794, #3795) that already shipped and closed out that epic's deliverables; not re-closing it here.
