### PR TITLE
fix(selfhost): stop deploy-selfhost-image.sh silently losing to a build: override

### DIFF
--- a/scripts/deploy-selfhost-image.sh
+++ b/scripts/deploy-selfhost-image.sh
@@ -97,6 +97,12 @@ cat >"$override_file" <<YAML
 services:
   $SERVICE:
     image: "$IMAGE"
+    # An operator's own docker-compose.override.yml may define a \`build:\` block for this service (e.g. a
+    # local INSTALL_AI_CLIS customization) -- when BOTH build and image are present, \`up --no-build\` still
+    # prefers a pre-existing project-scoped build artifact over the pulled image, silently ignoring it. Reset
+    # unsets any build config from every earlier -f file so the pulled image always wins. Harmless no-op when
+    # no build: block exists at all.
+    build: !reset null
 YAML
 
 mapfile -t compose_args < <(compose_file_args)

--- a/test/unit/selfhost-image-deploy.test.ts
+++ b/test/unit/selfhost-image-deploy.test.ts
@@ -49,7 +49,7 @@ if [ "$1" = "compose" ]; then
         prev="$arg"
       done
       if [ -n "$last_file" ]; then
-        grep 'image:' "$last_file" >> "$DOCKER_IMAGES"
+        cat "$last_file" >> "$DOCKER_IMAGES"
       fi
       exit 0
       ;;
@@ -153,6 +153,9 @@ describe("self-host image deploy script", () => {
       expect(result.status, result.stderr).toBe(0);
       expect(readFileSync(harness.envPath, "utf8")).toContain(`GITTENSORY_IMAGE=${expected}`);
       expect(harness.readImages()).toContain(`image: "${expected}"`);
+      // REGRESSION: without this reset, an operator's own docker-compose.override.yml build: block for this
+      // service silently wins over the pulled image at `up --no-build` time (found deploying live).
+      expect(harness.readImages()).toContain("build: !reset null");
       expect(harness.readCalls()).toContain("up -d --no-build --no-deps gittensory");
       expect(harness.readCalls()).not.toContain(" build ");
     } finally {


### PR DESCRIPTION
## Summary

- `scripts/deploy-selfhost-image.sh`'s generated temp compose override only set `image:` for the target service. When an operator's own `docker-compose.override.yml` also defines a `build:` block for that same service (a sanctioned self-host customization -- e.g. the documented local `INSTALL_AI_CLIS` install pattern), `docker compose up --no-build --no-deps` still preferred the pre-existing project-scoped build artifact over the freshly pulled image, silently. The script reports success, the container recreates and passes health checks, but keeps running the stale locally-built image.
- Reproduced live while deploying `orb-v0.3.0`: `docker compose pull` correctly fetched the new image (confirmed present via `docker images`), the script reported `gittensory is healthy`, but `docker inspect`'s `Image` field showed the container was still running the old local build -- missing a since-added migration and reporting a stale `GITTENSORY_VERSION`.
- Fix: add `build: !reset null` to the generated override so the pulled `image:` always wins regardless of what the base/override compose files define. Verified locally with real `docker compose config` against both a no-`build:`-block case (no-op, confirmed harmless) and a merged-`build:`-across-two-files case (matches the VPS scenario, confirmed the reset works).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed. — small, self-contained shell-script fix with a direct regression test; no `src/**` surface touched.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:ci` (full local gate, green -- 540 test files / 10,762 tests passed, 2 files / 7 tests skipped)
- [x] `npm audit --audit-level=moderate` (0 vulnerabilities)
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries -- extended `test/unit/selfhost-image-deploy.test.ts`'s fake-docker harness to capture the full generated override content (previously only grepped the `image:` line) and added a regression assertion that `build: !reset null` is present in every image-precedence scenario.
- [x] No `src/**` files touched, so `codecov/patch` is not applicable to this PR.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — no API/OpenAPI/MCP surface touched.
- [ ] UI changes use live API data or real empty/error/loading states. — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section. — N/A, no UI changes.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — N/A, no changelog-worthy public surface change (the existing self-hosting-operations docs already reference this script generically).