### PR TITLE
fix(engine): report below-baseline calibration delta as a signed negative

### DIFF
--- a/packages/gittensory-engine/src/phase7-calibration-loop.ts
+++ b/packages/gittensory-engine/src/phase7-calibration-loop.ts
@@ -118,6 +118,14 @@ function roundScore(value: number): number {
   return Math.round(Math.min(1, Math.max(0, value)) * 1_000_000) / 1_000_000;
 }
 
+/** Round a SIGNED value to 6 dp WITHOUT the [0, 1] clamp `roundScore` applies to accuracy scores. A baseline
+ *  delta legitimately ranges over [-baseline, 1 - baseline], so a below-baseline calibration run must surface as a
+ *  negative deviation — clamping it to 0 would report a regression as "on baseline" and defeat the whole point of
+ *  tracking accuracy against the documented baseline. */
+function roundDelta(value: number): number {
+  return Math.round(value * 1_000_000) / 1_000_000;
+}
+
 function finiteNonNegative(value: number | undefined, fallback: number): number {
   if (value === undefined) return fallback;
   if (!Number.isFinite(value) || value < 0) return 0;
@@ -462,7 +470,7 @@ export function computePhase7CalibrationLoop(input: {
         );
 
   const deltaFromBaseline =
-    combinedAccuracy === null ? null : roundScore(combinedAccuracy - DOCUMENTED_CALIBRATION_BASELINE);
+    combinedAccuracy === null ? null : roundDelta(combinedAccuracy - DOCUMENTED_CALIBRATION_BASELINE);
 
   const schedule = shouldScheduleHistoricalReplayRun({
     config,

--- a/packages/gittensory-engine/test/phase7-calibration-loop.test.ts
+++ b/packages/gittensory-engine/test/phase7-calibration-loop.test.ts
@@ -306,6 +306,22 @@ test("computePhase7CalibrationLoop combines historical-replay and pr_outcome sig
   assert.equal(result.bySource.pr_outcome.sampleSize, 20);
 });
 
+test("computePhase7CalibrationLoop reports a NEGATIVE delta when combined accuracy is below the documented baseline", () => {
+  // Both sources at 0.5 accuracy → combinedAccuracy 0.5, which is 0.12 BELOW the 0.62 documented baseline. The
+  // delta is a signed deviation, so a below-baseline regression must surface as -0.12, not be flattened to 0.
+  const result = computePhase7CalibrationLoop({
+    config: enabledConfig(),
+    prOutcome: sufficientPrOutcome(0.5),
+    historicalReplay: healthyReplay(0.5),
+    now: NOW,
+  });
+
+  assert.equal(result.combinedAccuracy, 0.5);
+  assert.equal(result.deltaFromBaseline, -0.12);
+  // The Markdown audit surfaces the signed magnitude, so the regression is visible to an operator.
+  assert.match(renderPhase7CalibrationAuditMarkdown(result), /delta from baseline: -12\.00 percentage points/);
+});
+
 test("computePhase7CalibrationLoop permits autonomy increases only when both sources meet the threshold", () => {
   const passing = computePhase7CalibrationLoop({
     config: enabledConfig({ autonomyIncreaseMinAccuracy: 0.7 }),

--- a/test/unit/phase7-calibration-delta.test.ts
+++ b/test/unit/phase7-calibration-delta.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from "vitest";
+import {
+  computePhase7CalibrationLoop,
+  renderPhase7CalibrationAuditMarkdown,
+  resolvePhase7CalibrationConfig,
+  DOCUMENTED_CALIBRATION_BASELINE,
+} from "../../packages/gittensory-engine/src/phase7-calibration-loop";
+
+const NOW = "2026-07-04T18:00:00.000Z";
+const FRESH_REPLAY_AT = "2026-07-04T12:00:00.000Z";
+
+function enabledConfig() {
+  return resolvePhase7CalibrationConfig({
+    miner: {
+      calibration: {
+        phase7LoopEnabled: true,
+        autonomyIncreaseMinAccuracy: 0.7,
+        replayFreshnessMaxAgeHours: 168,
+        historicalReplayWeight: 0.5,
+        prOutcomeWeight: 0.5,
+      },
+    },
+  });
+}
+
+// decided=20; correct=round(20*accuracy) → an exact 0.5 / 0.62 / above-baseline accuracy for the pr_outcome source.
+function prOutcome(accuracy: number) {
+  const decided = 20;
+  const correct = Math.round(decided * accuracy);
+  return { mergeConfirmed: correct, mergeFalse: decided - correct, closeConfirmed: 0, closeFalse: 0, observedAt: NOW };
+}
+
+function healthyReplay(compositeScore: number) {
+  return { compositeScore, replayRunId: "replay-1", observedAt: FRESH_REPLAY_AT, harnessStatus: "healthy" as const };
+}
+
+function loopWith(prAccuracy: number, replayAccuracy: number = prAccuracy) {
+  return computePhase7CalibrationLoop({
+    config: enabledConfig(),
+    prOutcome: prOutcome(prAccuracy),
+    historicalReplay: healthyReplay(replayAccuracy),
+    now: NOW,
+  });
+}
+
+describe("phase 7 calibration deltaFromBaseline sign", () => {
+  it("reports a NEGATIVE deviation when combined accuracy is below the documented baseline", () => {
+    // Both sources at 0.5 → combined 0.5, which is 0.12 below the 0.62 baseline. The delta is a signed deviation,
+    // so a below-baseline regression must surface as -0.12, not be clamped to 0 (which would hide the regression).
+    const result = loopWith(0.5);
+    expect(result.combinedAccuracy).toBe(0.5);
+    expect(result.deltaFromBaseline).toBe(-0.12);
+    expect(renderPhase7CalibrationAuditMarkdown(result)).toContain("delta from baseline: -12.00 percentage points");
+  });
+
+  it("reports a POSITIVE deviation when combined accuracy is above the baseline", () => {
+    // Both sources at 0.75 → combined 0.75, 0.13 above baseline; the above-baseline path was already correct.
+    const result = loopWith(0.75);
+    expect(result.combinedAccuracy).toBe(0.75);
+    expect(result.deltaFromBaseline).toBe(0.13);
+  });
+
+  it("reports a ZERO deviation exactly at the baseline", () => {
+    // pr_outcome 0.6 + replay 0.64 average to combined 0.62 === baseline → delta 0 (a genuine zero, distinct from
+    // a below-baseline value the old clamp would have flattened to 0).
+    const result = loopWith(0.6, 0.64);
+    expect(result.combinedAccuracy).toBe(DOCUMENTED_CALIBRATION_BASELINE);
+    expect(result.deltaFromBaseline).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

`computePhase7CalibrationLoop` (`packages/gittensory-engine/src/phase7-calibration-loop.ts`) computed `deltaFromBaseline` — the **signed** deviation of the combined calibration accuracy from the documented 62% baseline — by rounding through `roundScore`, which **clamps its input to `[0, 1]`**:

```ts
const deltaFromBaseline =
  combinedAccuracy === null ? null : roundScore(combinedAccuracy - DOCUMENTED_CALIBRATION_BASELINE);
```

`combinedAccuracy` is in `[0, 1]` and the baseline is `0.62`, so the true delta ranges over `[-0.62, +0.38]`. Every **below-baseline** run (a calibration *regression*) produced a negative delta that `roundScore` flattened to `0`, so a regression was reported as "on baseline / no deviation."

`deltaFromBaseline` is a signed field (`number | null`), the module tracks accuracy "against the documented 62% baseline," and the audit renderer prints it as a signed magnitude (`${(deltaFromBaseline * 100).toFixed(2)} percentage points`) — so surfacing below-baseline regressions is exactly its purpose. The sibling `combinedAccuracy` is a genuine `[0, 1]` score and correctly uses `roundScore`; only the signed delta was mis-clamped.

The fix rounds the signed difference without the `[0, 1]` clamp via a dedicated `roundDelta` helper.

Example: two sources at 0.5 accuracy → combined `0.5` (0.12 below baseline) now yields `deltaFromBaseline === -0.12` (rendered `-12.00 percentage points`) instead of `0`.

No linked issue: a small, self-contained correctness fix in pure engine logic; per this repo's `linkedIssuePolicy: preferred`, the defect is described in full above.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (green)
- [x] `npm run build:miner` builds + typechecks the engine package with the change (green)
- [x] New behavior has regression tests covering below / at / above baseline, added in both conventions: a root `test/unit/phase7-calibration-delta.test.ts` (vitest, run by `test:coverage`) and the engine `packages/gittensory-engine/test/phase7-calibration-loop.test.ts` (node:test).
- [x] Verified empirically: below-baseline combined accuracy `0.5` now reports `deltaFromBaseline === -0.12` (was `0`).

If any required check was skipped, explain why:

- The full `npm run test:ci` was not run in my local dev environment (several self-host suites require Linux/bash/Docker/Postgres and fail only on Windows). This change is confined to `packages/gittensory-engine` (a pure function, no `src/` app, API/OpenAPI, MCP, binding, DB, or migration surface), so no generated artifacts change; typecheck, the engine build, and the new regression tests are green, and the remaining CI runs on this PR.

## Safety

- [x] No secrets, wallets, hotkeys, coldkeys, PATs, private keys, trust scores, private rankings, or maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized and low-noise; no compensation/optimization implications.
- [x] No auth/cookie/CORS/GitHub App/Cloudflare/session changes.
- [x] No API/OpenAPI/MCP behavior changes.

## UI Evidence

N/A - pure backend engine logic; no UI, frontend, docs, or extension change.
