### PR TITLE
fix(selfhost): add default memory limit to the runner compose service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -394,6 +394,7 @@ REDIS_URL=redis://redis:6379                # REQUIRED for the self-host review 
 # RUNNER_SCOPE=repo                          # repo | org | enterprise
 # RUNNER_NAME=gittensory-runner
 # RUNNER_LABELS=self-hosted,linux
+# RUNNER_MEM_LIMIT=2g                        # per-runner-container memory ceiling; raise for memory-heavy CI jobs
 
 # --- Docker disk hygiene (#audit-rate-headroom / #selfhost-runtime-pressure) ---
 # Build cache and unused images accumulate fast on a box that builds from source or runs CI runners; a root

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -802,6 +802,15 @@ services:
       # /var/run/docker.sock grants container-escape risk and is intentionally omitted.
     volumes:
       - runner-work:/tmp/runner
+    # A memory ceiling so a single runaway CI job can't exhaust host RAM and take down the app alongside
+    # it (#3893) -- same universal-default treatment every other service in this file already has. This
+    # is independent of the CPU-priority tuning above: that's host-specific (vCPU count, replica count)
+    # and stays an opt-in docker-compose.override.yml pattern, but a memory cap needs no host-specific
+    # sizing to be a safe default.
+    deploy:
+      resources:
+        limits:
+          memory: "${RUNNER_MEM_LIMIT:-2g}"
 
   # ── Backups (--profile backup) ────────────────────────────────────────────
   # Active database backup (Postgres pg_dump or WAL-safe SQLite online backup) + a Qdrant snapshot, on a loop

--- a/test/unit/selfhost-compose-resource-limits.test.ts
+++ b/test/unit/selfhost-compose-resource-limits.test.ts
@@ -13,7 +13,7 @@ function readYaml(path: string): Record<string, unknown> {
 // Pure structural checks only (no `docker` CLI invocation): the self-hosted runner container this actually
 // runs on does not have Docker-in-Docker access, so a test that shells out to `docker compose config`
 // would be unreliable/environment-dependent here (same constraint as docker-compose-override-example.test.ts).
-describe("docker-compose.yml — per-service memory limits (#1828, #2495)", () => {
+describe("docker-compose.yml — per-service memory limits (#1828, #2495, #3893)", () => {
   const EXPECTED_LIMITS: Record<string, string> = {
     gittensory: "${GITTENSORY_MEM_LIMIT:-2g}",
     redis: "${REDIS_MEM_LIMIT:-512m}",
@@ -24,6 +24,7 @@ describe("docker-compose.yml — per-service memory limits (#1828, #2495)", () =
     loki: "${LOKI_MEM_LIMIT:-1g}",
     tempo: "${TEMPO_MEM_LIMIT:-1g}",
     grafana: "${GRAFANA_MEM_LIMIT:-512m}",
+    runner: "${RUNNER_MEM_LIMIT:-2g}",
   };
 
   it("caps the core app and every heavyweight optional service with an operator-overridable memory limit", () => {
@@ -51,6 +52,7 @@ describe("docker-compose.yml — per-service memory limits (#1828, #2495)", () =
       "LOKI_MEM_LIMIT",
       "TEMPO_MEM_LIMIT",
       "GRAFANA_MEM_LIMIT",
+      "RUNNER_MEM_LIMIT",
     ]) {
       expect(env, key).toContain(key);
     }


### PR DESCRIPTION
## Summary
- The `runner` service (`--profile runners`) was the sole service in `docker-compose.yml` with no `deploy.resources.limits` — every other resource-risky service (gittensory, redis, postgres, qdrant, ollama, browserless, rees, prometheus, grafana, loki, tempo) already has an operator-overridable memory default.
- The file's own comment on this service documents a confirmed production incident from exactly this gap: "3 uncapped runner containers on an 8-vCPU box left the app starved under load." The only existing mitigation is a manually-copied `docker-compose.override.yml` CPU-priority pattern — opt-in and CPU-only, never memory.
- Added `deploy.resources.limits.memory: "${RUNNER_MEM_LIMIT:-2g}"`, documented `RUNNER_MEM_LIMIT` in `.env.example`, and extended the resource-limits regression test's `EXPECTED_LIMITS` map so this can't silently regress again.
- Left the host-specific CPU-priority tuning (`cpu_shares`/`cpus`) as the existing opt-in override pattern — that genuinely needs per-host sizing (vCPU count, runner replica count), unlike memory, which can have a safe universal default like every sibling service.

Found via a fresh performance/scalability/accuracy hardening audit of the self-host ORB stack. Tracked under #1667.

## Scope
- [x] `docker-compose.yml` — memory limit for `runner`
- [x] `.env.example` — document `RUNNER_MEM_LIMIT`
- [x] `test/unit/selfhost-compose-resource-limits.test.ts` — cover `runner` in `EXPECTED_LIMITS`

## Validation
- `npm run typecheck`
- `npm run selfhost:env-reference:check`
- `npx vitest run test/unit/selfhost-compose-resource-limits.test.ts test/unit/docker-compose-override-example.test.ts` — all green
- `git diff --check` clean

## Safety
- No `src/**` change, no secrets. Default is additive-only (a cap that didn't exist before); existing deployments get a safe 2g ceiling they can raise via `.env` if needed.

Closes #3893