### PR TITLE
feat(commands): wire @gittensory pause auto-review dispatch (#2164)

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -5489,6 +5489,22 @@ async function processGitHubWebhook(
 
     if (
       eventName === "issue_comment" &&
+      (await maybeProcessPauseCommand(env, deliveryId, payload))
+    ) {
+      await recordWebhookEvent(env, {
+        deliveryId,
+        eventName,
+        action: payload.action,
+        installationId: payload.installation?.id,
+        repositoryFullName: payload.repository?.full_name,
+        payloadHash: "processed",
+        status: "processed",
+      });
+      return;
+    }
+
+    if (
+      eventName === "issue_comment" &&
       (await maybeProcessPlanCommand(env, deliveryId, payload))
     ) {
       await recordWebhookEvent(env, {
@@ -10293,6 +10309,231 @@ async function maybeProcessGateOverrideCommand(
     });
   }
   return true;
+}
+
+/**
+ * Handle `@gittensory pause [reason]` on a PR thread. Records a per-PR auto-review-paused marker
+ * (`github_app.autoreview_paused`) for the re-review/sweep path to honor. #1960 hard constraint: this
+ * affects ONLY auto-review scheduling — it must never flip the gate to advisory, patch gate check-runs,
+ * or mutate repository_settings.agent_paused (the repo-wide kill-switch is separate).
+ */
+async function maybeProcessPauseCommand(
+  env: Env,
+  deliveryId: string,
+  payload: GitHubWebhookPayload,
+): Promise<boolean> {
+  const comment = payload.comment;
+  const command = parseGittensoryMentionCommand(comment?.body);
+  if (!command || command.name !== "pause") return false;
+
+  const repoFullName = payload.repository?.full_name;
+  const issue = payload.issue;
+  const installationId = getInstallationId(payload);
+  const actor = payload.sender?.login ?? comment?.user?.login ?? null;
+  const targetKey =
+    repoFullName && issue ? `${repoFullName}#${issue.number}` : repoFullName;
+  if (payload.action !== "created") {
+    await recordAutoreviewPauseSkip(
+      env,
+      deliveryId,
+      repoFullName,
+      targetKey,
+      actor,
+      "unsupported_comment_action",
+    );
+    return true;
+  }
+  if (
+    comment?.user?.type === "Bot" ||
+    payload.sender?.type === "Bot" ||
+    /\[bot\]$/i.test(actor ?? "")
+  ) {
+    await recordAutoreviewPauseSkip(
+      env,
+      deliveryId,
+      repoFullName,
+      targetKey,
+      actor,
+      "bot_author",
+    );
+    return true;
+  }
+  if (!repoFullName || !issue?.pull_request || !installationId || !actor) {
+    await recordAutoreviewPauseSkip(
+      env,
+      deliveryId,
+      repoFullName,
+      targetKey,
+      actor,
+      "missing_repo_pr_installation_or_actor",
+    );
+    return true;
+  }
+  const [pr, settings] = await Promise.all([
+    getPullRequest(env, repoFullName, issue.number),
+    resolveRepositorySettings(env, repoFullName),
+  ]);
+  if (!pr) {
+    await recordAutoreviewPauseSkip(
+      env,
+      deliveryId,
+      repoFullName,
+      targetKey,
+      actor,
+      "cached_pr_missing",
+    );
+    return true;
+  }
+
+  const { authorization } = await authorizePrActionActor({
+    env,
+    deliveryId,
+    installationId,
+    repoFullName,
+    issue,
+    actor,
+    commandName: "pause" as GittensoryMentionCommandName,
+    settings,
+    pr,
+  });
+  if (!authorization.authorized) {
+    await recordAuditEvent(env, {
+      eventType: "github_app.autoreview_paused_denied",
+      actor,
+      targetKey: `${repoFullName}#${pr.number}`,
+      outcome: "denied",
+      detail: authorization.reason,
+      metadata: {
+        deliveryId,
+        repoFullName,
+        allowedRoles: commandAuthorizationAllowedRoles(
+          settings.commandAuthorization,
+          "pause",
+        ),
+      },
+    });
+    await recordGithubProductUsage(env, "autoreview_paused_denied", {
+      actor,
+      repoFullName,
+      targetKey: `${repoFullName}#${pr.number}`,
+      outcome: "denied",
+      metadata: {
+        reason: authorization.reason,
+        actorKind: authorization.actorKind,
+        allowedRoles: commandAuthorizationAllowedRoles(
+          settings.commandAuthorization,
+          "pause",
+        ),
+      },
+    });
+    return true;
+  }
+
+  const mode = resolveAgentActionMode({
+    globalPaused: isGlobalAgentPause(env) || (await isGlobalAgentFrozen(env)),
+    agentPaused: settings.agentPaused,
+    agentDryRun: settings.agentDryRun,
+  });
+  const safeReason = sanitizePublicComment(
+    (command.reason ?? "").trim() || "No reason provided.",
+  );
+  const confirmation = sanitizePublicComment(
+    [
+      AGENT_COMMAND_COMMENT_MARKER,
+      "",
+      "> [!NOTE]",
+      `> **Auto-review paused by @${actor}**`,
+      "> Auto-review is paused for this pull request only. The one-shot gate disposition is unchanged — pause never makes review advisory or bypasses the gate.",
+      "",
+      `- Reason: ${safeReason}`,
+      "",
+      "---",
+      gittensoryFooter(),
+    ].join("\n"),
+  );
+  await createOrUpdateAgentCommandComment(
+    env,
+    installationId,
+    repoFullName,
+    issue.number,
+    confirmation,
+    mode,
+  );
+  if (mode === "live") {
+    await recordAuditEvent(env, {
+      eventType: "github_app.autoreview_paused",
+      actor,
+      targetKey: `${repoFullName}#${pr.number}`,
+      outcome: "completed",
+      detail: safeReason,
+      metadata: {
+        deliveryId,
+        repoFullName,
+        headSha: pr.headSha ?? null,
+      },
+    });
+    await recordGithubProductUsage(env, "autoreview_paused", {
+      actor,
+      repoFullName,
+      targetKey: `${repoFullName}#${pr.number}`,
+      outcome: "completed",
+      metadata: {
+        actorKind: authorization.actorKind,
+        headSha: pr.headSha ?? null,
+      },
+    });
+  } else {
+    await recordAuditEvent(env, {
+      eventType: "github_app.autoreview_paused_skipped",
+      actor,
+      targetKey: `${repoFullName}#${pr.number}`,
+      outcome: "completed",
+      detail: mode === "dry_run" ? "dry_run" : "agent_paused",
+      metadata: {
+        deliveryId,
+        repoFullName,
+        headSha: pr.headSha ?? null,
+        mode,
+      },
+    });
+    await recordGithubProductUsage(env, "autoreview_paused_skipped", {
+      actor,
+      repoFullName,
+      targetKey: `${repoFullName}#${pr.number}`,
+      outcome: "skipped",
+      metadata: {
+        actorKind: authorization.actorKind,
+        headSha: pr.headSha ?? null,
+        mode,
+      },
+    });
+  }
+  return true;
+}
+
+async function recordAutoreviewPauseSkip(
+  env: Env,
+  deliveryId: string,
+  repoFullName: string | null | undefined,
+  targetKey: string | null | undefined,
+  actor: string | null,
+  reason: string,
+): Promise<void> {
+  await recordAuditEvent(env, {
+    eventType: "github_app.autoreview_paused_skipped",
+    actor,
+    targetKey,
+    outcome: "completed",
+    detail: reason,
+    metadata: { deliveryId, repoFullName: repoFullName ?? null, reason },
+  });
+  await recordGithubProductUsage(env, "autoreview_paused_skipped", {
+    actor,
+    repoFullName,
+    targetKey,
+    outcome: "skipped",
+    metadata: { reason },
+  });
 }
 
 async function recordGateOverrideSkip(

--- a/test/helpers/d1.ts
+++ b/test/helpers/d1.ts
@@ -3,6 +3,20 @@ import { DatabaseSync } from "node:sqlite";
 
 type BoundValue = string | number | null | Uint8Array;
 
+/** D1 uses `?1`, `?2`, … numbered placeholders (and may repeat an index). Node 22's experimental
+ *  `node:sqlite` only accepts anonymous `?` markers, so expand numbered placeholders to anonymous ones
+ *  and remap `.bind(a, b, …)` to the per-`?` argument order SQLite expects. */
+function normalizeD1SqlForNodeSqlite(sql: string): { sql: string; placeholderArgIndexes: number[] | null } {
+  const placeholderArgIndexes: number[] = [];
+  let sawNumbered = false;
+  const normalized = sql.replace(/\?(\d+)/g, (_, digits: string) => {
+    sawNumbered = true;
+    placeholderArgIndexes.push(Number(digits) - 1);
+    return "?";
+  });
+  return { sql: normalized, placeholderArgIndexes: sawNumbered ? placeholderArgIndexes : null };
+}
+
 // Listing + reading migrations/*.sql (~90 files) on every TestD1Database construction (~1500 call sites
 // across the suite) is pure overhead: the file list and contents never change within a worker process's
 // lifetime. Cache the concatenated SQL once per process instead of re-reading it every call.
@@ -33,11 +47,15 @@ export class TestD1Database {
 
   prepare(sql: string) {
     const database = this.db;
-    const statement = database.prepare(sql);
+    const { sql: normalizedSql, placeholderArgIndexes } = normalizeD1SqlForNodeSqlite(sql);
+    const statement = database.prepare(normalizedSql);
     let bound: BoundValue[] = [];
     const api = {
       bind(...values: BoundValue[]) {
-        bound = values;
+        bound =
+          placeholderArgIndexes === null
+            ? values
+            : placeholderArgIndexes.map((index) => values[index] as BoundValue);
         return api;
       },
       async first<T = unknown>() {

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -22065,7 +22065,315 @@ describe("queue processors", () => {
     expect(overridden ?? null).toBeNull();
   });
 
-  it("a #1960 action-command verb with no dispatch handler wired yet (e.g. pause) is bailed out of the Q&A answer-card path, not misrendered as help (#2160)", async () => {
+  it("records a per-PR auto-review pause marker when an authorized maintainer runs @gittensory pause (#2164)", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      commentMode: "off",
+      publicSurface: "off",
+      autoLabelEnabled: false,
+      checkRunMode: "off",
+      gateCheckMode: "enabled",
+      linkedIssueGateMode: "off",
+    });
+    await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
+      number: 95,
+      title: "Pause auto-review",
+      state: "open",
+      user: { login: "contributor" },
+      author_association: "CONTRIBUTOR",
+      head: { sha: "pause-sha" },
+      labels: [],
+      body: "Validation: npm test",
+    });
+    const calls = { permission: 0, checkPatches: 0, commentPosts: 0 };
+    let confirmationBody = "";
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/collaborators/maintainer/permission")) {
+        calls.permission += 1;
+        return Response.json({ permission: "admin" });
+      }
+      if (url.includes("/check-runs") && method === "PATCH") {
+        calls.checkPatches += 1;
+        return Response.json({ id: 1 });
+      }
+      if (url.includes("/issues/95/comments") && method === "GET") return Response.json([]);
+      if (url.includes("/issues/95/comments") && method === "POST") {
+        calls.commentPosts += 1;
+        confirmationBody = String((JSON.parse(String(init?.body ?? "{}")) as { body?: string }).body ?? "");
+        return Response.json({ id: 9200 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "pause-allow",
+      eventName: "issue_comment",
+      payload: {
+        action: "created",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        issue: { number: 95, title: "Pause auto-review", state: "open", user: { login: "contributor" }, pull_request: {} },
+        comment: { id: 820, body: "@gittensory pause waiting on design sign-off", author_association: "NONE", user: { login: "maintainer", type: "User" } },
+        sender: { login: "maintainer", type: "User" },
+      },
+    });
+
+    expect(calls.permission).toBe(1);
+    expect(calls.checkPatches).toBe(0);
+    expect(calls.commentPosts).toBe(1);
+    expect(confirmationBody).toContain("Auto-review paused by @maintainer");
+    expect(confirmationBody).toContain("gate disposition is unchanged");
+    const paused = await env.DB.prepare("select event_type, actor, target_key, outcome, detail from audit_events where event_type = ?")
+      .bind("github_app.autoreview_paused")
+      .first<{ event_type: string; actor: string; target_key: string; outcome: string; detail: string }>();
+    expect(paused).toMatchObject({
+      event_type: "github_app.autoreview_paused",
+      actor: "maintainer",
+      target_key: "JSONbored/gittensory#95",
+      outcome: "completed",
+      detail: "waiting on design sign-off",
+    });
+    const usageEvents = await listProductUsageEvents(env, { limit: 10 });
+    expect(usageEvents).toEqual(expect.arrayContaining([expect.objectContaining({ eventName: "autoreview_paused", outcome: "completed" })]));
+    const settingsAfter = await env.DB.prepare("select gate_check_mode, agent_paused from repository_settings where repo_full_name = ?").bind("JSONbored/gittensory").first<{ gate_check_mode: string; agent_paused: number | null }>();
+    expect(settingsAfter?.gate_check_mode).toBe("enabled");
+    expect(settingsAfter?.agent_paused).toBeFalsy();
+    const gateOverridden = await env.DB.prepare("select id from audit_events where event_type = ?").bind("github_app.gate_overridden").first<{ id: string }>();
+    expect(gateOverridden ?? null).toBeNull();
+  });
+
+  it("denies @gittensory pause for an unauthorized actor without mutating gate state (#2164)", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      commentMode: "off",
+      publicSurface: "off",
+      autoLabelEnabled: false,
+      checkRunMode: "off",
+      gateCheckMode: "enabled",
+      linkedIssueGateMode: "off",
+    });
+    await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
+      number: 96,
+      title: "Cannot pause",
+      state: "open",
+      user: { login: "contributor" },
+      author_association: "CONTRIBUTOR",
+      head: { sha: "pause-deny-sha" },
+      labels: [],
+      body: "Validation: npm test",
+    });
+    const calls = { permission: 0, comments: 0, checkPatches: 0 };
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/collaborators/org-member/permission")) {
+        calls.permission += 1;
+        return Response.json({ permission: "read" });
+      }
+      if (url.includes("/check-runs") && method === "PATCH") {
+        calls.checkPatches += 1;
+        return Response.json({ id: 1 });
+      }
+      if (url.includes("/comments")) {
+        calls.comments += 1;
+        return Response.json([]);
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "pause-deny",
+      eventName: "issue_comment",
+      payload: {
+        action: "created",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        issue: { number: 96, title: "Cannot pause", state: "open", user: { login: "contributor" }, pull_request: {} },
+        comment: { id: 821, body: "@gittensory pause trust me", author_association: "MEMBER", user: { login: "org-member", type: "User" } },
+        sender: { login: "org-member", type: "User" },
+      },
+    });
+
+    expect(calls.permission).toBe(1);
+    expect(calls.checkPatches).toBe(0);
+    expect(calls.comments).toBe(0);
+    const denied = await env.DB.prepare("select event_type, actor, outcome, detail from audit_events where event_type = ?")
+      .bind("github_app.autoreview_paused_denied")
+      .first<{ event_type: string; actor: string; outcome: string; detail: string }>();
+    expect(denied).toMatchObject({ event_type: "github_app.autoreview_paused_denied", actor: "org-member", outcome: "denied", detail: "not_maintainer_or_pr_author" });
+    const paused = await env.DB.prepare("select id from audit_events where event_type = ?").bind("github_app.autoreview_paused").first<{ id: string }>();
+    expect(paused ?? null).toBeNull();
+  });
+
+  it("@gittensory pause respects agentPaused — records skipped, not a completed pause marker (#2164)", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      commentMode: "off",
+      publicSurface: "off",
+      autoLabelEnabled: false,
+      checkRunMode: "off",
+      gateCheckMode: "enabled",
+      linkedIssueGateMode: "off",
+      agentPaused: true,
+    });
+    await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
+      number: 97,
+      title: "Pause while repo agent paused",
+      state: "open",
+      user: { login: "contributor" },
+      author_association: "CONTRIBUTOR",
+      head: { sha: "pause-repo-paused-sha" },
+      labels: [],
+      body: "Validation: npm test",
+    });
+    const calls = { commentPosts: 0, checkPatches: 0 };
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/collaborators/maintainer/permission")) return Response.json({ permission: "admin" });
+      if (url.includes("/check-runs") && method === "PATCH") {
+        calls.checkPatches += 1;
+        return Response.json({ id: 1 });
+      }
+      if (url.includes("/issues/97/comments") && method === "GET") return Response.json([]);
+      if (url.includes("/issues/97/comments") && method === "POST") {
+        calls.commentPosts += 1;
+        return Response.json({ id: 9201 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "pause-repo-agent-paused",
+      eventName: "issue_comment",
+      payload: {
+        action: "created",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        issue: { number: 97, title: "Pause while repo agent paused", state: "open", user: { login: "contributor" }, pull_request: {} },
+        comment: { id: 822, body: "@gittensory pause please", author_association: "NONE", user: { login: "maintainer", type: "User" } },
+        sender: { login: "maintainer", type: "User" },
+      },
+    });
+
+    expect(calls.commentPosts).toBe(0);
+    expect(calls.checkPatches).toBe(0);
+    const completed = await env.DB.prepare("select id from audit_events where event_type = ?").bind("github_app.autoreview_paused").first<{ id: string }>();
+    expect(completed ?? null).toBeNull();
+    const skipped = await env.DB.prepare("select outcome, detail from audit_events where event_type = ?").bind("github_app.autoreview_paused_skipped").first<{ outcome: string; detail: string }>();
+    expect(skipped).toMatchObject({ outcome: "completed", detail: "agent_paused" });
+  });
+
+  it("@gittensory pause respects agentDryRun — records dry_run skipped, not a completed pause marker (#2164)", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      commentMode: "off",
+      publicSurface: "off",
+      autoLabelEnabled: false,
+      checkRunMode: "off",
+      gateCheckMode: "enabled",
+      linkedIssueGateMode: "off",
+      agentDryRun: true,
+    });
+    await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
+      number: 99,
+      title: "Pause dry-run",
+      state: "open",
+      user: { login: "contributor" },
+      author_association: "CONTRIBUTOR",
+      head: { sha: "pause-dry-run-sha" },
+      labels: [],
+      body: "Validation: npm test",
+    });
+    const calls = { commentPosts: 0 };
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/collaborators/maintainer/permission")) return Response.json({ permission: "admin" });
+      if (url.includes("/issues/99/comments") && method === "GET") return Response.json([]);
+      if (url.includes("/issues/99/comments") && method === "POST") {
+        calls.commentPosts += 1;
+        return Response.json({ id: 9202 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "pause-dry-run",
+      eventName: "issue_comment",
+      payload: {
+        action: "created",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        issue: { number: 99, title: "Pause dry-run", state: "open", user: { login: "contributor" }, pull_request: {} },
+        comment: { id: 824, body: "@gittensory pause", author_association: "NONE", user: { login: "maintainer", type: "User" } },
+        sender: { login: "maintainer", type: "User" },
+      },
+    });
+
+    expect(calls.commentPosts).toBe(0);
+    const skipped = await env.DB.prepare("select detail, metadata_json from audit_events where event_type = ?")
+      .bind("github_app.autoreview_paused_skipped")
+      .first<{ detail: string; metadata_json: string }>();
+    expect(skipped?.detail).toBe("dry_run");
+    expect(JSON.parse(skipped?.metadata_json ?? "{}")).toMatchObject({ mode: "dry_run" });
+    const completed = await env.DB.prepare("select id from audit_events where event_type = ?").bind("github_app.autoreview_paused").first<{ id: string }>();
+    expect(completed ?? null).toBeNull();
+  });
+
+  it("skips @gittensory pause on a non-created comment action (#2164)", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
+      number: 98,
+      title: "Edited pause",
+      state: "open",
+      user: { login: "contributor" },
+      author_association: "CONTRIBUTOR",
+      head: { sha: "pause-edited-sha" },
+      labels: [],
+      body: "Validation: npm test",
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "pause-edited",
+      eventName: "issue_comment",
+      payload: {
+        action: "edited",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        issue: { number: 98, title: "Edited pause", state: "open", user: { login: "contributor" }, pull_request: {} },
+        comment: { id: 823, body: "@gittensory pause edited", author_association: "NONE", user: { login: "maintainer", type: "User" } },
+        sender: { login: "maintainer", type: "User" },
+      },
+    });
+
+    const skipped = await env.DB.prepare("select detail from audit_events where event_type = ?").bind("github_app.autoreview_paused_skipped").first<{ detail: string }>();
+    expect(skipped?.detail).toBe("unsupported_comment_action");
+    const paused = await env.DB.prepare("select id from audit_events where event_type = ?").bind("github_app.autoreview_paused").first<{ id: string }>();
+    expect(paused ?? null).toBeNull();
+  });
+
+  it("a #1960 action-command verb with no dispatch handler wired yet (e.g. configuration) is bailed out of the Q&A answer-card path, not misrendered as help (#2160)", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
     await upsertRepositorySettings(env, {
@@ -22114,12 +22422,12 @@ describe("queue processors", () => {
         installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
         repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
         issue: { number: 93, title: "Not yet wired", state: "open", user: { login: "contributor" }, pull_request: {} },
-        comment: { id: 900, body: "@gittensory pause waiting on design sign-off", author_association: "OWNER", user: { login: "maintainer", type: "User" } },
+        comment: { id: 900, body: "@gittensory configuration show me settings", author_association: "OWNER", user: { login: "maintainer", type: "User" } },
         sender: { login: "maintainer", type: "User" },
       },
     });
 
-    // No handler claims a bare "pause" comment yet (its dispatch lands in a follow-up bounty), so the Q&A
+    // No handler claims a bare "configuration" comment yet (its dispatch lands in a follow-up bounty), so the Q&A
     // answer-card path must bail rather than post a stray "help" card or any other Q&A comment.
     expect(calls.comments).toBe(0);
     const feedback = await env.DB.prepare("select id from audit_events where event_type = ?").bind("github_app.agent_command_feedback_prompted").first<{ id: string }>();

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -22549,6 +22549,116 @@ describe("queue processors", () => {
     expect(paused ?? null).toBeNull();
   });
 
+  it("skips @gittensory pause when sender is a bot or login ends with [bot] (#2164)", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
+      number: 104,
+      title: "Pause bot skip paths",
+      state: "open",
+      user: { login: "contributor" },
+      author_association: "CONTRIBUTOR",
+      head: { sha: "pause-bot-skip-sha" },
+      labels: [],
+      body: "Validation: npm test",
+    });
+    vi.stubGlobal("fetch", async () => new Response("not found", { status: 404 }));
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "pause-sender-bot-skip",
+      eventName: "issue_comment",
+      payload: {
+        action: "created",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        issue: { number: 104, title: "Pause bot skip paths", state: "open", user: { login: "contributor" }, pull_request: {} },
+        comment: { id: 830, body: "@gittensory pause", user: { login: "maintainer", type: "User" } },
+        sender: { login: "gittensory[bot]", type: "Bot" },
+      },
+    });
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "pause-bot-suffix-skip",
+      eventName: "issue_comment",
+      payload: {
+        action: "created",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        issue: { number: 104, title: "Pause bot skip paths", state: "open", user: { login: "contributor" }, pull_request: {} },
+        comment: { id: 831, body: "@gittensory pause", user: { login: "dependabot[bot]", type: "User" } },
+        sender: { login: "dependabot[bot]", type: "User" },
+      },
+    });
+
+    const skips = await env.DB.prepare("select detail from audit_events where event_type = ? order by detail")
+      .bind("github_app.autoreview_paused_skipped")
+      .all<{ detail: string }>();
+    expect(skips.results.map((event) => event.detail)).toEqual(["bot_author", "bot_author"]);
+    const paused = await env.DB.prepare("select id from audit_events where event_type = ?").bind("github_app.autoreview_paused").first<{ id: string }>();
+    expect(paused ?? null).toBeNull();
+  });
+
+  it("@gittensory pause respects the DB global-agent-frozen kill-switch (#2164)", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    await repositoriesModule.setGlobalAgentFrozen(env, true, "test");
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      commentMode: "off",
+      publicSurface: "off",
+      autoLabelEnabled: false,
+      checkRunMode: "off",
+      gateCheckMode: "enabled",
+      linkedIssueGateMode: "off",
+    });
+    await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
+      number: 105,
+      title: "Pause while globally frozen",
+      state: "open",
+      user: { login: "contributor" },
+      author_association: "CONTRIBUTOR",
+      head: { sha: "pause-global-frozen-sha" },
+      labels: [],
+      body: "Validation: npm test",
+    });
+    const calls = { commentPosts: 0 };
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/collaborators/maintainer/permission")) return Response.json({ permission: "admin" });
+      if (url.includes("/issues/105/comments") && method === "GET") return Response.json([]);
+      if (url.includes("/issues/105/comments") && method === "POST") {
+        calls.commentPosts += 1;
+        return Response.json({ id: 9205 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "pause-global-frozen",
+      eventName: "issue_comment",
+      payload: {
+        action: "created",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        issue: { number: 105, title: "Pause while globally frozen", state: "open", user: { login: "contributor" }, pull_request: {} },
+        comment: { id: 832, body: "@gittensory pause fleet frozen", author_association: "NONE", user: { login: "maintainer", type: "User" } },
+        sender: { login: "maintainer", type: "User" },
+      },
+    });
+
+    expect(calls.commentPosts).toBe(0);
+    const skipped = await env.DB.prepare("select detail from audit_events where event_type = ?")
+      .bind("github_app.autoreview_paused_skipped")
+      .first<{ detail: string }>();
+    expect(skipped?.detail).toBe("agent_paused");
+    const paused = await env.DB.prepare("select id from audit_events where event_type = ?").bind("github_app.autoreview_paused").first<{ id: string }>();
+    expect(paused ?? null).toBeNull();
+  });
+
   it("a #1960 action-command verb with no dispatch handler wired yet (e.g. configuration) is bailed out of the Q&A answer-card path, not misrendered as help (#2160)", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -22373,6 +22373,182 @@ describe("queue processors", () => {
     expect(paused ?? null).toBeNull();
   });
 
+  it("skips @gittensory pause for bot authors, missing context, and uncached PRs (#2164)", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
+      number: 100,
+      title: "Cached pause target",
+      state: "open",
+      user: { login: "contributor" },
+      author_association: "CONTRIBUTOR",
+      head: { sha: "pause-cached-sha" },
+      labels: [],
+      body: "Validation: npm test",
+    });
+    vi.stubGlobal("fetch", async () => new Response("not found", { status: 404 }));
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "pause-bot-skip",
+      eventName: "issue_comment",
+      payload: {
+        action: "created",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        issue: { number: 100, title: "Cached pause target", state: "open", user: { login: "contributor" }, pull_request: {} },
+        comment: { id: 825, body: "@gittensory pause", user: { login: "gittensory[bot]", type: "Bot" } },
+        sender: { login: "gittensory[bot]", type: "Bot" },
+      },
+    });
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "pause-missing-context",
+      eventName: "issue_comment",
+      payload: {
+        action: "created",
+        comment: { id: 826, body: "@gittensory pause", user: { login: "maintainer", type: "User" } },
+        sender: { login: "maintainer", type: "User" },
+      },
+    });
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "pause-missing-cache",
+      eventName: "issue_comment",
+      payload: {
+        action: "created",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        issue: { number: 101, title: "Uncached pause target", state: "open", user: { login: "contributor" }, pull_request: {} },
+        comment: { id: 827, body: "@gittensory pause", user: { login: "maintainer", type: "User" } },
+        sender: { login: "maintainer", type: "User" },
+      },
+    });
+
+    const skips = await env.DB.prepare("select detail from audit_events where event_type = ? order by detail")
+      .bind("github_app.autoreview_paused_skipped")
+      .all<{ detail: string }>();
+    expect(skips.results.map((event) => event.detail)).toEqual([
+      "bot_author",
+      "cached_pr_missing",
+      "missing_repo_pr_installation_or_actor",
+    ]);
+    const paused = await env.DB.prepare("select id from audit_events where event_type = ?").bind("github_app.autoreview_paused").first<{ id: string }>();
+    expect(paused ?? null).toBeNull();
+  });
+
+  it("records a default reason when @gittensory pause has no trailing text (#2164)", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      commentMode: "off",
+      publicSurface: "off",
+      autoLabelEnabled: false,
+      checkRunMode: "off",
+      gateCheckMode: "enabled",
+      linkedIssueGateMode: "off",
+    });
+    await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
+      number: 102,
+      title: "Pause without reason",
+      state: "open",
+      user: { login: "contributor" },
+      author_association: "CONTRIBUTOR",
+      head: {},
+      labels: [],
+      body: "Validation: npm test",
+    });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/collaborators/maintainer/permission")) return Response.json({ permission: "admin" });
+      if (url.includes("/issues/102/comments") && method === "GET") return Response.json([]);
+      if (url.includes("/issues/102/comments") && method === "POST") return Response.json({ id: 9203 });
+      return new Response("not found", { status: 404 });
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "pause-default-reason",
+      eventName: "issue_comment",
+      payload: {
+        action: "created",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        issue: { number: 102, title: "Pause without reason", state: "open", user: { login: "contributor" }, pull_request: {} },
+        comment: { id: 828, body: "@gittensory pause", author_association: "NONE", user: { login: "maintainer", type: "User" } },
+        sender: { login: "maintainer", type: "User" },
+      },
+    });
+
+    const paused = await env.DB.prepare("select detail, metadata_json from audit_events where event_type = ?")
+      .bind("github_app.autoreview_paused")
+      .first<{ detail: string; metadata_json: string }>();
+    expect(paused?.detail).toBe("No reason provided.");
+    expect(JSON.parse(paused?.metadata_json ?? "{}")).toMatchObject({ headSha: null });
+  });
+
+  it("@gittensory pause respects the global AGENT_ACTIONS_PAUSED kill-switch (#2164)", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), AGENT_ACTIONS_PAUSED: "true" });
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      commentMode: "off",
+      publicSurface: "off",
+      autoLabelEnabled: false,
+      checkRunMode: "off",
+      gateCheckMode: "enabled",
+      linkedIssueGateMode: "off",
+    });
+    await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", {
+      number: 103,
+      title: "Pause while globally paused",
+      state: "open",
+      user: { login: "contributor" },
+      author_association: "CONTRIBUTOR",
+      head: { sha: "pause-global-paused-sha" },
+      labels: [],
+      body: "Validation: npm test",
+    });
+    const calls = { commentPosts: 0 };
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/collaborators/maintainer/permission")) return Response.json({ permission: "admin" });
+      if (url.includes("/issues/103/comments") && method === "GET") return Response.json([]);
+      if (url.includes("/issues/103/comments") && method === "POST") {
+        calls.commentPosts += 1;
+        return Response.json({ id: 9204 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "pause-global-paused",
+      eventName: "issue_comment",
+      payload: {
+        action: "created",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        issue: { number: 103, title: "Pause while globally paused", state: "open", user: { login: "contributor" }, pull_request: {} },
+        comment: { id: 829, body: "@gittensory pause fleet brake", author_association: "NONE", user: { login: "maintainer", type: "User" } },
+        sender: { login: "maintainer", type: "User" },
+      },
+    });
+
+    expect(calls.commentPosts).toBe(0);
+    const skipped = await env.DB.prepare("select detail from audit_events where event_type = ?")
+      .bind("github_app.autoreview_paused_skipped")
+      .first<{ detail: string }>();
+    expect(skipped?.detail).toBe("agent_paused");
+    const paused = await env.DB.prepare("select id from audit_events where event_type = ?").bind("github_app.autoreview_paused").first<{ id: string }>();
+    expect(paused ?? null).toBeNull();
+  });
+
   it("a #1960 action-command verb with no dispatch handler wired yet (e.g. configuration) is bailed out of the Q&A answer-card path, not misrendered as help (#2160)", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);


### PR DESCRIPTION
## Summary

- Add `maybeProcessPauseCommand` to parse `@gittensory pause [reason]`, authorize the actor, record a per-PR `github_app.autoreview_paused` audit marker on live mode, and post a public-safe confirmation without mutating gate check-runs or `repository_settings.agent_paused`.
- Cover all skip/deny/mode branches including bot detection (`comment.user.type`, `sender.type`, `[bot]` login suffix), `isGlobalAgentFrozen`, and missing-context paths so `codecov/patch` meets the 99% gate.
- Fix `test/helpers/d1.ts` to normalize D1 `?N` placeholders for Node 22 `node:sqlite`.

Fixes #2164

## Test plan

- [x] `npm run test:ci` (exit 0 locally)
- [x] Pause handler patch in `src/queue/processors.ts` — 0 uncovered lines/branches in local `lcov` after unsharded `test:coverage`
- [x] Authorized maintainer pause records audit marker + comment, gate unchanged
- [x] Unauthorized actor → denied path
- [x] `agentPaused` / `agentDryRun` / `AGENT_ACTIONS_PAUSED` / `setGlobalAgentFrozen` → skipped
- [x] Non-`created` action, bot author (all three OR arms), missing context, uncached PR → skipped
- [x] Default reason when no trailing text


Made with [Cursor](https://cursor.com)