### PR TITLE
perf(review): skip duplicate full-file grounding fetch for added files

### DIFF
--- a/src/review/review-grounding.ts
+++ b/src/review/review-grounding.ts
@@ -135,8 +135,11 @@ export async function fetchFullFileContents(
 ): Promise<ChangedFileContent[] | undefined> {
   if (!flags.fullFileContext || !ref) return undefined;
   // Source-first ordering (the diff's own priority) so the most-relevant files are inlined before the budget runs out.
+  // A newly ADDED file is excluded here (#3897): every line of it is already a `+` line in the diff itself
+  // (sent in the same prompt), so fetching + inlining its full content again is a byte-for-byte duplicate --
+  // wasted GitHub API round-trip and wasted prompt budget that a genuinely modified file needs more.
   const candidates = files
-    .filter((file) => file.status !== "removed" && !SKIP_EXT.test(file.filename))
+    .filter((file) => file.status !== "removed" && file.status !== "added" && !SKIP_EXT.test(file.filename))
     .sort((a, b) => diffFilePriority(a.filename) - diffFilePriority(b.filename));
   const out: ChangedFileContent[] = [];
   let used = 0;

--- a/test/unit/review-grounding.test.ts
+++ b/test/unit/review-grounding.test.ts
@@ -174,13 +174,17 @@ describe("review-grounding: fetchFullFileContents (injected FileFetcher, fail-sa
         ["assets/icon.heic"],
         ["dist/pkg.tgz"],
         ["old.ts", "removed"],
+        ["src/new.ts", "added"],
       ),
       fetcher,
     );
     expect(out).toBeDefined();
-    // source (priority 0) before docs (priority 2); binary + removed excluded before fetch
+    // source (priority 0) before docs (priority 2); binary + removed + added excluded before fetch
     expect(out?.map((f) => f.path)).toEqual(["src/a.ts", "README.md"]);
     expect(reads).toEqual(["src/a.ts", "README.md"]);
+    // #3897: an ADDED file's entire body is already every `+` line of the diff -- fetching it again
+    // would duplicate that content in the prompt, so it's excluded the same way "removed" is.
+    expect(reads).not.toContain("src/new.ts");
     for (const path of binary) expect(reads).not.toContain(path);
   });
 


### PR DESCRIPTION
## Summary
- `fetchFullFileContents` (grounding, on by default in the self-host starter env via `GITTENSORY_REVIEW_GROUNDING=true`) fetched and inlined the full post-change content of every changed file whose `status !== "removed"`, including newly ADDED files.
- Every line of a newly added file is already a `+` line in the diff, which is sent in the same prompt (up to 120,000 chars). So the full-file fetch for an added file was a byte-for-byte duplicate of content already present — a wasted GitHub Contents API round-trip and wasted prompt budget on every AI-reviewed PR under the recommended grounding config.
- Added `status !== "added"` to the existing candidate filter (same treatment as `"removed"`), and extended the existing "skips removed/binary" test to also assert an added file is excluded and never fetched.
- Left modified-file grounding untouched — `PullRequestFile` doesn't currently carry patch/line-count data, so a "skip when the diff already covers most of a modified file" refinement would need a bigger interface change; out of scope here.

Found via a fresh performance/scalability/accuracy hardening audit of the self-host ORB stack. Tracked under #1667.

## Scope
- [x] `src/review/review-grounding.ts` — exclude `status === "added"` from the full-file-content candidate filter
- [x] `test/unit/review-grounding.test.ts` — cover the new exclusion

## Validation
- `npm run typecheck`
- `npx vitest run test/unit/review-grounding.test.ts --coverage` — 20/20 passing; 100% line coverage, changed lines fully covered (remaining uncovered branches are pre-existing and untouched by this diff)
- `git diff --check` clean

## Safety
- No behavior change for modified/removed files. An added file's content still reaches the reviewer in full via the diff — this only removes the duplicate second copy.

Closes #3897