### PR TITLE
fix(mcp): sync score-preview isCodeFile mirrors with isSourcePath (.kts)

### DIFF
--- a/packages/gittensory-mcp/lib/local-branch.js
+++ b/packages/gittensory-mcp/lib/local-branch.js
@@ -614,7 +614,7 @@ function isGeneratedCodeFile(file) {
 }
 
 export function isCodeFile(file) {
-  return /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy|php|cpp|cc|c|h|hpp|m|vue|svelte|astro|dart)$/i.test(file) && !isTestFile(file) && !isGeneratedCodeFile(file);
+  return /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|kts|scala|java|go|sql|cs|swift|groovy|php|cpp|cc|c|h|hpp|m|vue|svelte|astro|dart)$/i.test(file) && !isTestFile(file) && !isGeneratedCodeFile(file);
 }
 
 function numberValue(value) {

--- a/packages/gittensory-mcp/scripts/gittensor-score-preview.mjs
+++ b/packages/gittensory-mcp/scripts/gittensor-score-preview.mjs
@@ -23,7 +23,7 @@ function isGeneratedCodeFile(file) {
 }
 
 function isCodeFile(file) {
-  return /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|scala|java|go|sql|cs|swift|groovy|php|cpp|cc|c|h|hpp|m|vue|svelte|astro|dart)$/i.test(file) && !isTestFile(file) && !isGeneratedCodeFile(file);
+  return /\.(ts|tsx|mts|cts|js|jsx|mjs|cjs|py|rb|rs|kt|kts|scala|java|go|sql|cs|swift|groovy|php|cpp|cc|c|h|hpp|m|vue|svelte|astro|dart)$/i.test(file) && !isTestFile(file) && !isGeneratedCodeFile(file);
 }
 
 function lineCount(file) {

--- a/packages/gittensory-mcp/scripts/gittensor-score-preview.py
+++ b/packages/gittensory-mcp/scripts/gittensor-score-preview.py
@@ -146,7 +146,7 @@ def metadata_fallback(metadata: dict) -> dict:
         lines = max(int(entry.get("additions") or 0) + int(entry.get("deletions") or 0), 0)
         if is_test_file(path):
             tests += lines
-        elif lower_path.endswith((".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs", ".py", ".rb", ".rs", ".go", ".java", ".kt", ".scala", ".sql", ".cs", ".swift", ".groovy", ".php", ".cpp", ".cc", ".c", ".h", ".hpp", ".m", ".vue", ".svelte", ".astro", ".dart")) and not is_generated_code_file(lower_path):
+        elif lower_path.endswith((".ts", ".tsx", ".mts", ".cts", ".js", ".jsx", ".mjs", ".cjs", ".py", ".rb", ".rs", ".go", ".java", ".kt", ".kts", ".scala", ".sql", ".cs", ".swift", ".groovy", ".php", ".cpp", ".cc", ".c", ".h", ".hpp", ".m", ".vue", ".svelte", ".astro", ".dart")) and not is_generated_code_file(lower_path):
             source += lines
         else:
             non_code += lines

--- a/test/unit/local-branch.test.ts
+++ b/test/unit/local-branch.test.ts
@@ -1792,6 +1792,10 @@ describe("local MCP git metadata collection", () => {
       expect(isTestFile(file)).toBe(false);
       expect(isCodeFile(file)).toBe(false);
     }
+    // #3889 follow-up: .kts source must count as code in the MCP copy now that isSourcePath knows it.
+    expect(isCodeFile("app/Build.kts")).toBe(true);
+    expect(isTestFile("build/SettingsTests.kts")).toBe(true);
+    expect(isCodeFile("build/SettingsTests.kts")).toBe(false);
   });
 
   it("extracts linked issues only from standalone closing keywords, not keyword substrings", async () => {

--- a/test/unit/path-matchers.test.ts
+++ b/test/unit/path-matchers.test.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 import {
   classifyChangedFile,
+  isCodeFile,
   isDependencyManifestFile,
   isConfigFile,
   isDocsFile,
@@ -23,6 +24,25 @@ describe("path-matchers.ts never imports from local-branch.ts", () => {
   it("has no import statement referencing ./local-branch", () => {
     const source = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "../../src/signals/path-matchers.ts"), "utf8");
     expect(source).not.toMatch(/from\s+["']\.\/local-branch["']/);
+  });
+});
+
+describe("isCodeFile extension sets", () => {
+  it("keeps isSourcePath core extensions and EXTENDED_SOURCE_EXTENSION disjoint", () => {
+    const testEvidenceSource = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "../../src/signals/test-evidence.ts"), "utf8");
+    const pathMatchersSource = readFileSync(join(dirname(fileURLToPath(import.meta.url)), "../../src/signals/path-matchers.ts"), "utf8");
+    const coreMatch = testEvidenceSource.match(/SOURCE_FILE_EXTENSION = \/\\\.\(([^)]+)\)\$\/i/);
+    const extendedMatch = pathMatchersSource.match(/EXTENDED_SOURCE_EXTENSION = \/\\\.\(([^)]+)\)\$\/i/);
+    expect(coreMatch).not.toBeNull();
+    expect(extendedMatch).not.toBeNull();
+    const coreExts = new Set(coreMatch![1]!.split("|"));
+    const extendedExts = new Set(extendedMatch![1]!.split("|"));
+    expect([...coreExts].filter((ext) => extendedExts.has(ext))).toEqual([]);
+  });
+
+  it("classifies .kts Gradle Kotlin-script source as code via the core matcher", () => {
+    expect(isCodeFile("app/Build.kts")).toBe(true);
+    expect(isCodeFile("build/SettingsTests.kts")).toBe(false);
   });
 });
 

--- a/test/unit/score-preview-script.test.ts
+++ b/test/unit/score-preview-script.test.ts
@@ -213,6 +213,28 @@ describe("gittensor-score-preview.mjs classifier parity with the server", () => 
     expect(py.nonCodeTokenScore).toBe(0);
   });
 
+  it("classifies Kotlin-script source and class-suffix .kts tests in both .mjs and .py previews", () => {
+    const files = [
+      { path: "app/Build.kts", additions: 9, deletions: 0 },
+      { path: "build/SettingsTests.kts", additions: 4, deletions: 0 },
+    ];
+    const mjs = runPreview(files);
+    expect(mjs.sourceTokenScore).toBe(9);
+    expect(mjs.testTokenScore).toBe(4);
+    expect(mjs.nonCodeTokenScore).toBe(0);
+
+    const python = findPython();
+    if (!python) return;
+    const env = { ...process.env };
+    delete env.GITTENSOR_ROOT;
+    const res = spawnSync(python, [scriptPy], { input: JSON.stringify({ changedFiles: files }), encoding: "utf8", env });
+    expect(res.status, res.stderr).toBe(0);
+    const py = JSON.parse(res.stdout);
+    expect(py.sourceTokenScore).toBe(9);
+    expect(py.testTokenScore).toBe(4);
+    expect(py.nonCodeTokenScore).toBe(0);
+  });
+
   it("does not misclassify a *.test.mjs.map source-map as a test (extension anchored to end-of-path, matching the server)", () => {
     // A substring match on ".test.mjs" wrongly flagged non-tests like dist/widget.test.mjs.map; the rule must be
     // end-anchored like isTestPath. It's a source-map — neither test nor code — so it counts as non-code.


### PR DESCRIPTION
## Summary

Follow-up to merged #3889: the server now recognizes `.kts` Gradle Kotlin-script source via `isSourcePath`, but the standalone MCP mirrors still omitted `.kts` from `isCodeFile` while `isTestPath` already knew `SomethingTests.kts`. That let local score previews misclassify Kotlin-script-only diffs as non-code.

This PR adds `.kts` to:
- `packages/gittensory-mcp/scripts/gittensor-score-preview.mjs`
- `packages/gittensory-mcp/scripts/gittensor-score-preview.py` (`metadata_fallback`)
- `packages/gittensory-mcp/lib/local-branch.js`

Also adds a structural guard that `isSourcePath` and `EXTENDED_SOURCE_EXTENSION` extension sets stay disjoint, plus regression tests in the MCP/score-preview suites.

Closes #2235

## Notes on scope

#2235 tracks the hosted `gittensory_check_test_evidence` MCP tool. This PR only lands the classifier parity prerequisite so local MCP previews agree with the server gate on `.kts` paths before that tool is built. If merge auto-closes #2235 with deliverables still open, please reopen it for the remaining tool/schema work.

## Validation

- [x] `npm test -- test/unit/path-matchers.test.ts test/unit/local-branch.test.ts test/unit/score-preview-script.test.ts` (120 tests passed locally)
- [ ] CI `validate-code` + `validate` green on this PR

## Safety

- [x] No secrets, auth, API, UI, or migration changes.
- [x] Classifier-only parity fix in MCP mirrors; behavior-preserving for previously-covered extensions.