### PR TITLE
feat(selfhost): add retention for agent_context_snapshots

### DIFF
--- a/src/db/retention.ts
+++ b/src/db/retention.ts
@@ -21,6 +21,9 @@ export const RETENTION_POLICY: readonly RetentionRule[] = [
   { table: "signal_snapshots", column: "generated_at", days: 90 },
   { table: "score_previews", column: "generated_at", days: 90 },
   { table: "repo_snapshots", column: "fetched_at", days: 90 },
+  // One payloadJson blob per agent run (#3896); a per-run diagnostic snapshot with no cross-run rollup
+  // depending on it, so a shorter window than the audit/usage-log tables above is appropriate.
+  { table: "agent_context_snapshots", column: "created_at", days: 30 },
 ];
 
 export type PruneResult = { table: string; column: string; cutoff: string; deleted: number };

--- a/test/unit/retention.test.ts
+++ b/test/unit/retention.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { createApp } from "../../src/api/routes";
 import { getDb } from "../../src/db/client";
 import { dedupeSignalSnapshots, pruneExpiredRecords, RETENTION_POLICY } from "../../src/db/retention";
-import { aiUsageEvents, webhookEvents } from "../../src/db/schema";
+import { agentContextSnapshots, aiUsageEvents, webhookEvents } from "../../src/db/schema";
 import { processJob, runRetentionPrune } from "../../src/queue/processors";
 import { createTestEnv } from "../helpers/d1";
 
@@ -100,6 +100,24 @@ describe("pruneExpiredRecords", () => {
   it("rejects an unsafe table/column identifier (defensive guard)", async () => {
     const env = createTestEnv();
     await expect(pruneExpiredRecords(env, { policy: [{ table: "webhook_events; DROP TABLE x", column: "received_at", days: 1 }] })).rejects.toThrow("Unsafe retention identifier");
+  });
+
+  it("prunes agent_context_snapshots older than its window and keeps recent runs (#3896)", async () => {
+    const env = createTestEnv();
+    const db = getDb(env.DB);
+    await db.insert(agentContextSnapshots).values([
+      { id: "ctx-old", runId: "run-old", createdAt: daysAgo(40) },
+      { id: "ctx-recent", runId: "run-recent", createdAt: daysAgo(2) },
+    ]);
+
+    const results = await pruneExpiredRecords(env, {
+      nowMs: NOW,
+      policy: [{ table: "agent_context_snapshots", column: "created_at", days: 30 }],
+    });
+
+    expect(results[0]?.deleted).toBe(1);
+    const rows = await env.DB.prepare("SELECT id FROM agent_context_snapshots").all<{ id: string }>();
+    expect(rows.results.map((row) => row.id)).toEqual(["ctx-recent"]);
   });
 
   it("the policy only targets append-only/log/snapshot tables (no current-state tables)", () => {


### PR DESCRIPTION
## Summary
This narrows significantly from the original issue after implementation research:

- **audit_events, ai_usage_events, product_usage_events** already have working, cron-scheduled retention via `RETENTION_POLICY` in `src/db/retention.ts` (`pruneExpiredRecords`, dispatched by the `prune-retention` job type enqueued daily from `src/index.ts`). The original audit's `grep -rn ".delete("` check missed this because the deletes are dynamic SQL strings (`DELETE FROM ${rule.table} WHERE ...`), not literal Drizzle `.delete(table)` calls.
- **webhook_events** is *deliberately* excluded from retention by a prior fix (commit `67c11f2e`, "fix(db): preserve webhook replay cache during retention" #666) — GitHub can redeliver a webhook long after the original event, and this table is the idempotency/dedup record that detects that. There's a dedicated regression test (`test/unit/retention.test.ts`, "the policy only targets append-only/log/snapshot tables") asserting `webhook_events` is never in `RETENTION_POLICY`. Adding it back would reintroduce that fixed bug — so I did NOT touch it.
- **agent_context_snapshots** (one `payloadJson` blob per agent run, capped only by a per-runId `.limit(50)` *read*, never deleted) was the one table genuinely still unaddressed. Added it to `RETENTION_POLICY` with a 30-day window (shorter than the audit/usage-log tables since it's a per-run diagnostic blob with no cross-run rollup depending on it), reusing the existing generic prune mechanism — no new code path, no new risk surface.

Posted a correction comment on #3896 before implementing so the tracking issue reflects this.

Found via a fresh performance/scalability/accuracy hardening audit of the self-host ORB stack. Tracked under #1667.

## Scope
- [x] `src/db/retention.ts` — one new `RETENTION_POLICY` entry
- [x] `test/unit/retention.test.ts` — new test covering the prune behavior for `agent_context_snapshots`

## Validation
- `npm run typecheck`
- `npm run test:coverage` (full unsharded) — 560 files / 11067 tests passed
- `git diff --check` clean

## Safety
- Reuses the existing, already-tested `pruneExpiredRecords` mechanism verbatim — no new deletion code path. Explicitly did NOT touch `webhook_events`, avoiding a regression of a previously-fixed bug.

Closes #3896