### PR TITLE
fix(selfhost): redact agent disposition metric repo labels

### DIFF
--- a/src/selfhost/metrics.ts
+++ b/src/selfhost/metrics.ts
@@ -147,9 +147,11 @@ export function setSelfHostedMetricsMode(isSelfHosted: boolean): void {
 const PRIVATE_REPO_LABEL_METRICS = new Set([
   "gittensory_gate_decisions_total",
   "gittensory_reviews_published_total",
-  "gittensory_agent_disposition_total",
 ]);
-const ALWAYS_REDACT_REPO_LABEL_METRICS = new Set(["gittensory_queue_backlog_by_repo"]);
+const ALWAYS_REDACT_REPO_LABEL_METRICS = new Set([
+  "gittensory_agent_disposition_total",
+  "gittensory_queue_backlog_by_repo",
+]);
 const redactedRepoLabels = new Map<string, string>();
 
 function redactedRepoLabel(repo: string): string {

--- a/test/unit/selfhost-metrics.test.ts
+++ b/test/unit/selfhost-metrics.test.ts
@@ -132,7 +132,6 @@ describe("metrics registry (#982)", () => {
     setSelfHostedMetricsMode(true);
     incr("gittensory_gate_decisions_total", { repo: "owner/repo", conclusion: "success" });
     incr("gittensory_reviews_published_total", { repo: "owner/repo" });
-    incr("gittensory_agent_disposition_total", { repo: "owner/repo", action_class: "hold", blocker_class: "none", autonomy_level: "auto" });
 
     const out = await renderMetrics();
     expect(out).toContain('gittensory_gate_decisions_total{conclusion="success",repo="owner/repo"} 1');
@@ -146,7 +145,25 @@ describe("metrics registry (#982)", () => {
 
     const out = await renderMetrics();
     expect(out).not.toContain("owner/repo");
-    expect(out).toContain('gittensory_agent_disposition_total{action_class="hold",autonomy_level="auto",blocker_class="none"} 1');
+    expect(out).toContain(
+      'gittensory_agent_disposition_total{action_class="hold",autonomy_level="auto",blocker_class="none",repo="redacted-1"} 1',
+    );
+  });
+
+  it("keeps agent disposition repository labels redacted in self-hosted metrics mode", async () => {
+    setSelfHostedMetricsMode(true);
+    incr("gittensory_agent_disposition_total", {
+      repo: "private-owner/secret-repo",
+      action_class: "hold",
+      blocker_class: "manifest_blocked",
+      autonomy_level: "auto",
+    });
+
+    const out = await renderMetrics();
+    expect(out).toContain(
+      'gittensory_agent_disposition_total{action_class="hold",autonomy_level="auto",blocker_class="manifest_blocked",repo="redacted-1"} 1',
+    );
+    expect(out).not.toContain("private-owner/secret-repo");
   });
 
   it("gauges sample at scrape time", async () => {


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated /metrics scrapes on self-hosted deployments from exposing private repository full names in the new disposition metric.
- Maintain the prior public/private boundary for sensitive metrics while keeping lower-risk counters sliceable by repo for operators where appropriate.

### Description
- Move `gittensory_agent_disposition_total` out of the self-host opt-out set and into the always-redact set in `src/selfhost/metrics.ts` so its `repo` label is never emitted verbatim.
- Adjust `publicLabelsForMetric` behavior implicitly by updating the metric classification sets so disposition metrics are redacted even when `setSelfHostedMetricsMode(true)` is called.
- Update `test/unit/selfhost-metrics.test.ts` to assert that disposition metrics use stable redacted repo labels in both default and self-hosted modes and to remove the previous expectation that disposition repos become visible in self-host mode.
- Commit message: `fix(selfhost): redact disposition metric repos`.

### Testing
- Ran unit metric tests with `npx vitest run test/unit/selfhost-metrics.test.ts`, which passed (`36 tests` passed).
- Ran static checks with `git diff --check` and `npm run typecheck`, both succeeded locally.
- Attempted coverage generation with `npm run test:coverage -- test/unit/selfhost-metrics.test.ts`; tests passed but coverage report generation failed locally due to `TypeError: jsTokens is not a function` in `ast-v8-to-istanbul` (environment-specific tooling error, tests themselves passed).
- `npm audit --audit-level=moderate` could not complete in the environment (npm audit endpoint returned HTTP 403).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ca3902a54832cb27a6a828e57eef4)