### PR TITLE
fix(selfhost): ignore Alertmanager webhook files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ output/
 docker-compose.override.yml
 !docker-compose.override.yml.example
 *.local
+# Alertmanager receiver webhook files used by self-host local configs.
+alertmanager/*_url
+alertmanager/*_url_file
 # Private self-host operator config. Root AGENTS.md/CLAUDE.md are public project docs;
 # repo-scoped review instructions live under this ignored mount.
 gittensory-config/


### PR DESCRIPTION
### Motivation
- The self-hosting docs recommend storing webhook secrets under `alertmanager/` (e.g. `alertmanager/discord_url`) and state those files are gitignored, but the repo only ignored `*.local`, which lets an operator accidentally stage/commit webhook credentials.

### Description
- Update `.gitignore` to add `alertmanager/*_url` and `alertmanager/*_url_file` patterns so common Alertmanager webhook secret filenames under `alertmanager/` remain untracked while preserving the existing `*.local` ignore for local configs.

### Testing
- Verified with `git check-ignore -v alertmanager/discord_url alertmanager/slack_url_file alertmanager/alertmanager.local` and `git status --short --ignored alertmanager` that the new patterns match and the `.local` file remains ignored, and ran `git diff --check` which passed; `npm run test:ci` was started but was terminated during `test:coverage` due to an unrelated existing `test/unit/queue.test.ts` recursion producing `RangeError: Maximum call stack size exceeded`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ca38d4d4c832c85d74c27a28c4a15)