### PR TITLE
fix(review): drop unsafe enrichment sections

### DIFF
--- a/src/review/enrichment-wire.ts
+++ b/src/review/enrichment-wire.ts
@@ -161,6 +161,45 @@ const REES_PROFILE_NAMES = ["fast", "balanced", "deep"] as const;
 type ReesProfileName = (typeof REES_PROFILE_NAMES)[number];
 const REES_PROFILE_NAME_SET = new Set<string>(REES_PROFILE_NAMES);
 
+function markdownHeadingLevel(line: string): number | undefined {
+  const match = /^(#{1,6})\s+/.exec(line.trimStart());
+  return match?.[1]?.length;
+}
+
+function isPublicSafeEnrichmentLine(line: string): boolean {
+  try {
+    sanitizePublicComment(line);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function retainPublicSafeEnrichmentSections(
+  defanged: string,
+): string | undefined {
+  const lines = defanged.split("\n");
+  const safeLines: string[] = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index] ?? "";
+    const headingLevel = markdownHeadingLevel(line);
+    if (isPublicSafeEnrichmentLine(line)) {
+      safeLines.push(line);
+      continue;
+    }
+    if (headingLevel === undefined) continue;
+
+    while (index + 1 < lines.length) {
+      const nextLevel = markdownHeadingLevel(lines[index + 1] ?? "");
+      if (nextLevel !== undefined && nextLevel <= headingLevel) break;
+      index += 1;
+    }
+  }
+
+  const safeBlock = safeLines.join("\n").trim();
+  return safeBlock || undefined;
+}
+
 function sanitizeEnrichmentPromptSection(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
   const trimmed = value.trim();
@@ -172,21 +211,10 @@ function sanitizeEnrichmentPromptSection(value: unknown): string | undefined {
       MAX_ENRICHMENT_PROMPT_SECTION_CHARS,
     );
   } catch {
-    const safeLines = defanged
-      .split("\n")
-      .filter((line) => {
-        try {
-          sanitizePublicComment(line);
-          return true;
-        } catch {
-          return false;
-        }
-      })
-      .join("\n")
-      .trim();
-    return safeLines
-      ? safeLines.slice(0, MAX_ENRICHMENT_PROMPT_SECTION_CHARS)
-      : undefined;
+    return retainPublicSafeEnrichmentSections(defanged)?.slice(
+      0,
+      MAX_ENRICHMENT_PROMPT_SECTION_CHARS,
+    );
   }
 }
 

--- a/test/unit/enrichment-wire.test.ts
+++ b/test/unit/enrichment-wire.test.ts
@@ -520,6 +520,41 @@ describe("buildReviewEnrichment", () => {
     expect(result?.systemSuffix).toContain("untrusted advisory context");
   });
 
+  it("drops non-public-safe enrichment sections with adjacent unlabeled values", async () => {
+    globalThis.fetch = vi.fn(
+      async () =>
+        ({
+          ok: true,
+          json: async () => ({
+            promptSection: [
+              "## EXTERNAL REVIEW BRIEF",
+              "### Dependency advisory",
+              "- package left-pad has CVE-2099-0001",
+              "### wallet",
+              "- adjacent unlabeled identifier",
+              "extra evidence without a forbidden label",
+              "### Safe follow-up",
+              "- retain public context",
+            ].join("\n"),
+          }),
+        }) as Response,
+    ) as unknown as typeof fetch;
+
+    const result = await buildReviewEnrichment(
+      env({ REES_URL: "https://r" }),
+      input,
+    );
+
+    expect(result?.promptSection).toContain("## EXTERNAL REVIEW BRIEF");
+    expect(result?.promptSection).toContain("### Dependency advisory");
+    expect(result?.promptSection).toContain("### Safe follow-up");
+    expect(result?.promptSection).not.toContain("### wallet");
+    expect(result?.promptSection).not.toContain("adjacent unlabeled identifier");
+    expect(result?.promptSection).not.toContain(
+      "extra evidence without a forbidden label",
+    );
+  });
+
   it("undefined on a fetch throw (timeout/network) — fail-safe", async () => {
     globalThis.fetch = vi.fn(async () => {
       throw new Error("timeout");


### PR DESCRIPTION
### Motivation
- Prevent leaking sensitive values that can survive a line-based sanitizer by removing entire markdown sections when a heading is flagged non-public-safe. 
- Retain useful public-safe enrichment context where a single non-heading line is rejected so functionality and availability are preserved.

### Description
- Replace the line-only fallback in `sanitizeEnrichmentPromptSection` with a section-aware fallback that drops a heading's entire section when the heading fails `sanitizePublicComment`. 
- Add helpers `markdownHeadingLevel`, `isPublicSafeEnrichmentLine`, and `retainPublicSafeEnrichmentSections` in `src/review/enrichment-wire.ts` to detect markdown headings and retain only public-safe sections. 
- Keep the original behavior of preserving isolated safe lines when no heading structure is implicated. 
- Add a regression unit test `it("drops non-public-safe enrichment sections with adjacent unlabeled values")` to `test/unit/enrichment-wire.test.ts` that asserts unlabeled values adjacent to a forbidden heading are not retained.

### Testing
- Ran `npx vitest run test/unit/enrichment-wire.test.ts`, which passed (44 tests). 
- Ran `npm run typecheck` (`tsc --noEmit`), which passed with no type errors. 
- Coverage runs were attempted but blocked: `npx vitest run --coverage test/unit/enrichment-wire.test.ts` failed during coverage remapping with `TypeError: jsTokens is not a function`, and a full `npm run test:coverage` run encountered unrelated runtime coverage errors and was terminated. 
- `npm audit --audit-level=moderate` could not complete due to a registry `403 Forbidden` when hitting the audit endpoint.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ca38e9594832c8af71a67be53eb36)