### PR TITLE
fix(engine): validate metadata candidate paths

### DIFF
--- a/packages/gittensory-engine/src/miner-goal-lane-fit.ts
+++ b/packages/gittensory-engine/src/miner-goal-lane-fit.ts
@@ -55,8 +55,8 @@ export function computeMinerGoalLaneFit(
   return clamp01(score);
 }
 
-function normalizeCandidatePaths(paths: readonly string[] | undefined): string[] {
-  if (!paths) return [];
+function normalizeCandidatePaths(paths: unknown): string[] {
+  if (!Array.isArray(paths)) return [];
   const normalized: string[] = [];
   for (const path of paths) {
     if (typeof path !== "string") continue;

--- a/packages/gittensory-engine/test/miner-goal-lane-fit.test.ts
+++ b/packages/gittensory-engine/test/miner-goal-lane-fit.test.ts
@@ -95,11 +95,30 @@ test("computeMetadataLaneFit returns 0 when candidatePaths hit blockedPaths", ()
   );
 });
 
-test("computeMetadataLaneFit ignores blank or malformed candidatePaths entries", () => {
-  const spec = { ...DEFAULT_MINER_GOAL_SPEC, preferredLabels: ["bug"] };
+test("computeMetadataLaneFit ignores malformed candidatePaths values", () => {
+  const spec = {
+    ...DEFAULT_MINER_GOAL_SPEC,
+    blockedPaths: ["src/**"],
+    preferredLabels: ["bug"],
+    wantedPaths: ["src/**"],
+  };
   assert.equal(
     computeMetadataLaneFit(
       { labels: ["bug"], candidatePaths: ["", "  ", 42 as unknown as string] },
+      spec,
+    ),
+    1,
+  );
+  assert.equal(
+    computeMetadataLaneFit(
+      { labels: ["bug"], candidatePaths: { path: "src/app.ts" } as unknown as string[] },
+      spec,
+    ),
+    1,
+  );
+  assert.equal(
+    computeMetadataLaneFit(
+      { labels: ["bug"], candidatePaths: "src/app.ts" as unknown as string[] },
       spec,
     ),
     1,

--- a/test/unit/miner-goal-lane-fit.test.ts
+++ b/test/unit/miner-goal-lane-fit.test.ts
@@ -43,11 +43,28 @@ describe("computeMetadataLaneFit", () => {
     ).toBe(0);
   });
 
-  it("ignores non-string candidatePaths entries before scoring", () => {
-    const spec = { ...DEFAULT_MINER_GOAL_SPEC, preferredLabels: ["bug"] };
+  it("ignores malformed candidatePaths values before scoring", () => {
+    const spec = {
+      ...DEFAULT_MINER_GOAL_SPEC,
+      blockedPaths: ["src/**"],
+      preferredLabels: ["bug"],
+      wantedPaths: ["src/**"],
+    };
     expect(
       computeMetadataLaneFit(
         { labels: ["bug"], candidatePaths: [42 as unknown as string, ""] },
+        spec,
+      ),
+    ).toBe(1);
+    expect(
+      computeMetadataLaneFit(
+        { labels: ["bug"], candidatePaths: { path: "src/app.ts" } as unknown as string[] },
+        spec,
+      ),
+    ).toBe(1);
+    expect(
+      computeMetadataLaneFit(
+        { labels: ["bug"], candidatePaths: "src/app.ts" as unknown as string[] },
         spec,
       ),
     ).toBe(1);


### PR DESCRIPTION
### Motivation
- Prevent runtime crashes and incorrect per-character path scoring when `candidatePaths` metadata is malformed or non-array by applying the repository's usual array guard pattern.
- Keep path-aware lane-fit behavior when callers supply a proper string-array while ensuring malformed inputs gracefully fall back to label-only scoring.

### Description
- Change `normalizeCandidatePaths` in `packages/gittensory-engine/src/miner-goal-lane-fit.ts` to accept `unknown` and return `[]` when `!Array.isArray(paths)`, preserving trimming and skipping of non-string/blank entries.
- Route `computeMetadataLaneFit` through the revised normalizer so non-array `candidatePaths` no longer throw or iterate strings character-by-character.
- Add regression tests covering malformed inputs (non-string entries, object value, and string value) in `packages/gittensory-engine/test/miner-goal-lane-fit.test.ts` and the root unit test `test/unit/miner-goal-lane-fit.test.ts` to ensure malformed metadata falls back to label-only scoring.

### Testing
- Ran `npx vitest run test/unit/miner-goal-lane-fit.test.ts`, which passed locally.
- Ran `npm --workspace @jsonbored/gittensory-engine run build`, which completed successfully.
- Running `npm --workspace @jsonbored/gittensory-engine test -- miner-goal-lane-fit.test.ts` hit unrelated package test type-check failures in other tests (pre-existing) before the targeted package test could complete.
- Running the full gate with `npm run test:ci` progressed to coverage but was interrupted by an existing `RangeError: Maximum call stack size exceeded` coming from unrelated `test/unit/queue.test.ts`, so the full CI run could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ca39113e0832c93c3dfe8f402c30b)