### PR TITLE
fix(selfhost): keep Claude review instructions out of argv

### DIFF
--- a/src/selfhost/ai.ts
+++ b/src/selfhost/ai.ts
@@ -75,7 +75,7 @@ function toCliPrompt(options: AiRunOptions, systemAppend: string | undefined): s
     .join("\n\n");
 }
 
-function prependCodexSystemAppend(prompt: string, systemAppend: string | undefined): string {
+function prependCliSystemAppend(prompt: string, systemAppend: string | undefined): string {
   return systemAppend
     ? `ADDITIONAL SYSTEM INSTRUCTIONS:\n${systemAppend}\n\n${prompt}`
     : prompt;
@@ -736,10 +736,9 @@ export function createClaudeCodeAi(parentEnv: Record<string, string | undefined>
           OTEL_METRIC_EXPORT_INTERVAL: parentEnv.OTEL_METRIC_EXPORT_INTERVAL,
         });
         const systemAppend = normalizedSystemAppend(options);
-        const prompt = toCliPrompt(options, systemAppend);
+        const prompt = prependCliSystemAppend(toCliPrompt(options, systemAppend), systemAppend);
         const spawn = spawnImpl ?? (await defaultSpawn());
         const args = ["--print", "--output-format", "json", "--model", claudeModel, "--permission-mode", "plan", "--effort", effort, "--disallowedTools", "Bash,Edit,Write,WebFetch,WebSearch"];
-        if (systemAppend) args.push("--append-system-prompt", systemAppend);
         attempted = true;
         const { stdout, code, stderr, timedOut } = await spawn(
           "claude",
@@ -808,7 +807,7 @@ export function createCodexAi(
         await authCheckImpl(parentEnv);
         const env = codexCliEnv(parentEnv);
         const systemAppend = normalizedSystemAppend(options);
-        const prompt = prependCodexSystemAppend(toCliPrompt(options, systemAppend), systemAppend);
+        const prompt = prependCliSystemAppend(toCliPrompt(options, systemAppend), systemAppend);
         const spawn = spawnImpl ?? (await defaultSpawn());
         const args = ["exec", "--json", "--skip-git-repo-check", "--sandbox", "read-only"];
         if (codexModel) args.push("--model", codexModel);

--- a/test/unit/selfhost-ai.test.ts
+++ b/test/unit/selfhost-ai.test.ts
@@ -979,7 +979,7 @@ describe("subscription CLI helpers + fail-safe", () => {
     expect(seen[seen.indexOf("--effort") + 1]).toBe("medium");
   });
 
-  it("Claude Code passes systemAppend through --append-system-prompt and strips the duplicate stdin copy (#1471)", async () => {
+  it("Claude Code keeps systemAppend out of argv and supplies it through stdin once (#1471)", async () => {
     const systemAppend = "REPOSITORY REVIEW INSTRUCTIONS: Follow async-error conventions.";
     let seen: string[] = [];
     let capturedInput = "";
@@ -995,10 +995,11 @@ describe("subscription CLI helpers + fail-safe", () => {
       ],
       systemAppend,
     });
-    expect(seen[seen.indexOf("--append-system-prompt") + 1]).toBe(systemAppend);
+    expect(seen).not.toContain("--append-system-prompt");
+    expect(seen).not.toContain(systemAppend);
     expect(capturedInput).toContain("Base system.");
     expect(capturedInput).toContain("Review this diff.");
-    expect(capturedInput).not.toContain(systemAppend);
+    expect(countOccurrences(capturedInput, systemAppend)).toBe(1);
 
     await createClaudeCodeAi({ CLAUDE_CODE_OAUTH_TOKEN: "t" }, cap).run("", {
       prompt: "Review this diff.",


### PR DESCRIPTION
### Motivation
- Prevent disclosure of private per-repo review instructions by stopping their placement in child-process argv where `ps`/`/proc` can expose them.
- The prior flow put `repoInstructions` into a `--append-system-prompt` flag for the Claude CLI, exposing container-local review guides and skills loaded from `GITTENSORY_REPO_CONFIG_DIR`.
- Route the instructions through the existing stdin prompt path so the text remains in the subprocess input stream (not visible in argv) while preserving the duplicate-strip behavior.

### Description
- Stop adding `--append-system-prompt <systemAppend>` for Claude Code CLI invocations and instead prepend the `systemAppend` into the CLI stdin prompt path using a shared helper. (`src/selfhost/ai.ts`)
- Rename and generalize the Codex-only helper `prependCodexSystemAppend` to `prependCliSystemAppend` and use it for both Claude Code and Codex so CLI providers share the same stdin-prepend behavior. (`src/selfhost/ai.ts`)
- Preserve the existing logic that strips duplicate `system` messages before prepending so the prompt contains the `systemAppend` exactly once. (`src/selfhost/ai.ts`)
- Update the regression test to assert that Claude Code no longer places the appended instructions in argv and that stdin contains the appended instructions exactly once. (`test/unit/selfhost-ai.test.ts`)

### Testing
- Ran targeted unit tests: `npx vitest run test/unit/selfhost-ai.test.ts` and the focused tests matching `Claude Code keeps systemAppend|Codex prepends systemAppend`, which passed locally.
- Ran `npm run typecheck` which completed successfully.
- Ran `npm run selfhost:env-reference:check` which completed successfully.
- Attempted full local gate `npm run test:ci`, but it could not complete in this environment due to unrelated environmental/test failures (transient `actionlint` setup network errors and a pre-existing `test/unit/queue.test.ts` recursive mock stack overflow encountered during coverage collection), so the full gate was not finished here.
- Ran `npx vitest run test/unit/selfhost-ai.test.ts --coverage` where the tests passed but coverage report generation failed with `TypeError: jsTokens is not a function` (coverage tooling issue in this environment).
- Note: all automated tests run above that exercised the changed paths passed; broader CI coverage/gate should be re-run in the repository CI environment to validate the full suite and Codecov patch coverage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ca38d96a4832c87beed5311aab25a)