### PR TITLE
fix(review): persist culture profile total count

### DIFF
--- a/src/review/repo-culture-profile.ts
+++ b/src/review/repo-culture-profile.ts
@@ -284,8 +284,9 @@ export async function extractRepoCultureProfile(env: Env, repoFullName: string, 
   }
   try {
     const prs = await listRecentMergedPullRequests(env, repoFullName);
+    const sampleCountAtGeneration = await countRecentMergedPullRequests(env, repoFullName);
     const profile = deriveRepoCultureProfile(repoFullName, prs, generatedAt);
-    await persistCultureProfile(env, repoFullName, profile, prs.length);
+    await persistCultureProfile(env, repoFullName, profile, sampleCountAtGeneration);
     return profile;
   } catch {
     return insufficientData(repoFullName, generatedAt, "repo merged-pull-request history is unavailable (storage read failed)");

--- a/test/unit/repo-culture-profile.test.ts
+++ b/test/unit/repo-culture-profile.test.ts
@@ -194,6 +194,39 @@ describe("extractRepoCultureProfile: cache + invalidation", () => {
     expect(refreshed.generatedAt).toBe("2026-07-05T01:00:00.000Z");
   });
 
+  it("reuses a fresh culture-profile cache when a repo has more than the 200 sampled merged PRs", async () => {
+    const env = createTestEnv({});
+    for (let i = 1; i <= 201; i++) {
+      await seedMergedPr(env, {
+        number: i,
+        mergedAt: new Date(Date.UTC(2026, 5, i)).toISOString(),
+        labels: ["bug"],
+      });
+    }
+
+    const first = await extractRepoCultureProfile(env, REPO, {
+      now: "2026-07-05T00:00:00.000Z",
+      maxAgeMs: Number.POSITIVE_INFINITY,
+    });
+    expect(first.present).toBe(true);
+    if (!first.present) throw new Error("expected present profile");
+    expect(first.pullRequestNorms.sampleSize).toBe(200);
+
+    const second = await extractRepoCultureProfile(env, REPO, {
+      now: "2026-07-05T01:00:00.000Z",
+      maxAgeMs: Number.POSITIVE_INFINITY,
+    });
+    expect(second).toEqual(first);
+    expect(second.generatedAt).toBe("2026-07-05T00:00:00.000Z");
+
+    const snapshotCount = await env.DB.prepare(
+      "SELECT COUNT(*) AS count FROM signal_snapshots WHERE signal_type = ? AND target_key = ?",
+    )
+      .bind("repo-culture-profile", REPO)
+      .first<{ count: number }>();
+    expect(snapshotCount?.count).toBe(1);
+  });
+
   it("options.refresh forces a fresh derive even with a warm, non-stale cache", async () => {
     const env = createTestEnv({});
     for (let i = 1; i <= MIN_SAMPLE_PULL_REQUESTS; i++) await seedMergedPr(env, { number: i });


### PR DESCRIPTION
### Motivation

- A cache-invalidaton bug caused repo culture-profile snapshots to record the capped sample size (from `listRecentMergedPullRequests()` which limits to 200 rows) while cache validation compared against the uncapped total (`countRecentMergedPullRequests()`), making caches permanently stale for repos with >200 merged PRs. 
- The stale behavior causes repeated re-derivation and unbounded `signal_snapshots` writes under normal PR activity when the feature is enabled, increasing cost/storage pressure.

### Description

- Persist the uncapped merged-PR total when writing a culture-profile snapshot by computing `sampleCountAtGeneration = await countRecentMergedPullRequests(env, repoFullName)` and passing it to `persistCultureProfile` in `src/review/repo-culture-profile.ts` so the writer and validator use the same basis for invalidation. 
- Add a regression test in `test/unit/repo-culture-profile.test.ts` that seeds 201 merged PR records, verifies the derived profile uses the 200-row sample for statistics, and confirms a subsequent extraction reuses the cached snapshot (asserting only one `signal_snapshots` row was created). 
- This change preserves existing behavior for repos with ≤200 merged PRs and fails safe to the insufficient-data branch on storage errors.

### Testing

- `npm run typecheck` completed successfully with no type errors. 
- `npx vitest run test/unit/repo-culture-profile.test.ts` passed and the new regression test (201-PR case) succeeded. 
- Targeted run with the test name (`npx vitest -t "reuses a fresh culture-profile cache"`) also passed. 
- Attempted coverage reporting (`npm run test:coverage -- --run test/unit/repo-culture-profile.test.ts`) executed the tests but coverage remapping failed with `TypeError: jsTokens is not a function` due to a local dependency resolution mismatch in `ast-v8-to-istanbul`, and `npm audit --audit-level=moderate` could not complete in this environment (registry/auth error).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ca38cca38832cb46a6fec8e03b83a)