### PR TITLE
feat(mcp): gittensory_validate_config tool for .gittensory.yml (#2057)

### DIFF
--- a/.claude/skills/contributing-to-gittensory/reference.md
+++ b/.claude/skills/contributing-to-gittensory/reference.md
@@ -146,6 +146,9 @@ All tools are metadata-only (no source upload). Run in this order:
    strong/adequate/weak + specific fixes.
 5. `gittensory_predict_gate` — `{login, owner, repo, title, body, labels, linkedIssues}` → predicted
    conclusion + blockers + warnings + readiness score.
+6. `gittensory_validate_config` — `{content}` → `{present, normalized, warnings, recognizedFields}` —
+   pre-validate a `.gittensory.yml` (or JSON) string against the SAME parser the review stack runs, before
+   pushing it. No repo context needed.
 
 (Auth'd extras: `gittensory_preflight_pr` / `…_local_diff` for lane fit + collision + queue health.)
 

--- a/packages/gittensory-engine/src/focus-manifest.ts
+++ b/packages/gittensory-engine/src/focus-manifest.ts
@@ -2607,6 +2607,32 @@ export function parseFocusManifestContent(content: string | null | undefined, so
 }
 
 /**
+ * Serialize a parsed manifest into its canonical, normalized JSON form (safe defaults applied, only the
+ * documented fields, `present`/`warnings` intentionally excluded). This is the single source of truth for the
+ * cache round-trip (`focus-manifest-loader`) and the `gittensory_validate_config` MCP predictor (#2057), so a
+ * validated manifest normalizes byte-identically to how it is persisted and re-read — no parallel serializer.
+ */
+export function focusManifestToJson(manifest: FocusManifest): Record<string, JsonValue> {
+  return {
+    source: manifest.source,
+    wantedPaths: manifest.wantedPaths,
+    preferredLabels: manifest.preferredLabels,
+    linkedIssuePolicy: manifest.linkedIssuePolicy,
+    testExpectations: manifest.testExpectations,
+    issueDiscoveryPolicy: manifest.issueDiscoveryPolicy,
+    maintainerNotes: manifest.maintainerNotes,
+    publicNotes: manifest.publicNotes,
+    gate: gateConfigToJson(manifest.gate),
+    settings: settingsOverrideToJson(manifest.settings),
+    review: reviewConfigToJson(manifest.review),
+    features: featuresConfigToJson(manifest.features),
+    contentLane: contentLaneConfigToJson(manifest.contentLane),
+    repoDocGeneration: repoDocGenerationConfigToJson(manifest.repoDocGeneration),
+    reviewRecap: reviewRecapConfigToJson(manifest.reviewRecap),
+  };
+}
+
+/**
  * Format a manifest's parse `warnings[]` into one grouped, deduped, order-preserving notice for the review
  * surface — an acceptance criterion of #1670: an invalid/malformed `.gittensory.yml` value should fail
  * clearly instead of silently falling back to a default. Empty/no warnings ⇒ `null` (byte-identical, no

--- a/packages/gittensory-mcp/bin/gittensory-mcp.js
+++ b/packages/gittensory-mcp/bin/gittensory-mcp.js
@@ -228,6 +228,10 @@ const checkIssueSlopShape = {
   body: z.string().max(40000).optional(),
 };
 
+const validateConfigShape = {
+  content: z.string().max(128 * 1024), // MAX_FOCUS_MANIFEST_BYTES — bound the payload before it reaches the API parser
+};
+
 const preflightShape = {
   repoFullName: z.string().min(3),
   contributorLogin: z.string().min(1).optional(),
@@ -449,6 +453,16 @@ server.registerTool(
     inputSchema: checkIssueSlopShape,
   },
   async (input) => toolResult("Gittensory issue-slop self-check.", await apiPost("/v1/lint/issue-slop", input)),
+);
+
+server.registerTool(
+  "gittensory_validate_config",
+  {
+    description:
+      "Validate a supplied .gittensory.yml (or JSON) manifest string BEFORE pushing it, using the exact same tolerant parser the review stack runs — no parallel schema. Returns the normalized config, every parse warning (invalid values, unknown fields), and whether any recognized field was present. Metadata only, no repo context.",
+    inputSchema: validateConfigShape,
+  },
+  async (input) => toolResult("Gittensory .gittensory.yml validation.", await apiPost("/v1/lint/validate-config", input)),
 );
 
 server.registerTool(

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -253,6 +253,7 @@ import { getPublicStats, isPublicStatsEnabled } from "../review/public-stats";
 import { buildMaintainerQualityDashboard, isMaintainerQualityDataStale } from "../services/maintainer-quality-dashboard";
 import { MAX_LOCAL_SCORER_WARNING_CHARS, MAX_LOCAL_SCORER_WARNING_COUNT } from "../signals/local-scorer-diagnostics";
 import { compileFocusManifestPolicy, MAX_FOCUS_MANIFEST_BYTES, normalizeReadinessGateMode } from "../signals/focus-manifest";
+import { validateManifestConfig } from "../selfhost/config-lint";
 import { resolveRepositorySettings } from "../settings/repository-settings";
 import { loadPublicRepoFocusManifest, loadRepoFocusManifest, upsertRepoFocusManifest } from "../signals/focus-manifest-loader";
 import { buildRepoOnboardingPackPreviewForRepo } from "../services/repo-onboarding-pack";
@@ -465,6 +466,12 @@ const slopRiskSchema = z.object({
 const issueSlopSchema = z.object({
   title: z.string().max(500).optional(),
   body: z.string().max(40000).optional(),
+});
+// Pre-submit .gittensory.yml validation (#2057): parse a supplied manifest STRING with the same tolerant parser
+// the review stack runs, so an operator/contributor can catch a typo or invalid value before pushing. Mirrors the
+// gittensory_validate_config MCP tool so the npm package can offer the same source-free self-check.
+const validateConfigSchema = z.object({
+  content: z.string().max(MAX_FOCUS_MANIFEST_BYTES),
 });
 
 const selfhostDeadLetterQueueQuerySchema = z
@@ -2779,6 +2786,15 @@ export function createApp() {
     const parsed = issueSlopSchema.safeParse(body);
     if (!parsed.success) return c.json({ error: "invalid_issue_slop_request", issues: parsed.error.issues }, 400);
     return c.json({ ...buildIssueSlopAssessment(parsed.data), rubric: ISSUE_SLOP_RUBRIC_MARKDOWN });
+  });
+
+  // Pre-submit .gittensory.yml validation (#2057): mirrors the gittensory_validate_config MCP tool. Reuses the
+  // review stack's own parser — no parallel schema — so the verdict matches what the gate will actually see.
+  app.post("/v1/lint/validate-config", async (c) => {
+    const body = await c.req.json().catch(() => null);
+    const parsed = validateConfigSchema.safeParse(body);
+    if (!parsed.success) return c.json({ error: "invalid_validate_config_request", issues: parsed.error.issues }, 400);
+    return c.json(validateManifestConfig(parsed.data.content));
   });
 
   app.post("/v1/preflight/pr", async (c) => {
@@ -5142,6 +5158,7 @@ const EXTENSION_PULL_CONTEXT_SCOPE = "extension:pull_context";
 const LINT_PR_TEXT_PATH = "/v1/lint/pr-text";
 const LINT_SLOP_RISK_PATH = "/v1/lint/slop-risk";
 const LINT_ISSUE_SLOP_PATH = "/v1/lint/issue-slop";
+const LINT_VALIDATE_CONFIG_PATH = "/v1/lint/validate-config";
 // Contributor (miner) side of the extension (#556). Minted for NON-maintainer sign-ins; strictly
 // self-only — a token may only reach `/v1/extension/contributors/<self>/*`, enforced by the coarse
 // path check below plus `requireContributorAccess` (actor === login) in every handler.
@@ -5205,7 +5222,7 @@ function canSessionAccessPath(env: Env, identity: Extract<AuthIdentity, { kind: 
   if (isRepoAgentAuditFeedPath(path)) return true; // route's requireRepoMaintainer enforces per-repo authority (contributors → 403)
   if (isRepoAgentPendingActionsPath(path)) return true; // list-only: requireRepoMaintainer; decision POSTs require server tokens
   if (isRepoContributorIssueDraftGeneratePath(path)) return true;
-  if (path === LINT_PR_TEXT_PATH || path === LINT_SLOP_RISK_PATH || path === LINT_ISSUE_SLOP_PATH) return true;
+  if (path === LINT_PR_TEXT_PATH || path === LINT_SLOP_RISK_PATH || path === LINT_ISSUE_SLOP_PATH || path === LINT_VALIDATE_CONFIG_PATH) return true;
   if (path === EXTENSION_PULL_CONTEXT_PATH && isExtensionScopedSession(identity)) return true;
   // Contributor extension scope reaches only `/v1/extension/contributors/<login>/*`; the handler's
   // requireContributorAccess then enforces actor === login (self-only).

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -122,6 +122,7 @@ import { isGlobalAgentPause, resolveAgentActionMode, resolveAgentPermissionReadi
 import { AGENT_ACTION_CLASSES, isActingAutonomyLevel, resolveAutonomy } from "../settings/autonomy";
 import { resolveRepositorySettings } from "../settings/repository-settings";
 import { MAX_FOCUS_MANIFEST_BYTES } from "../signals/focus-manifest";
+import { validateManifestConfig } from "../selfhost/config-lint";
 import { loadPublicRepoFocusManifest, loadRepoFocusManifest } from "../signals/focus-manifest-loader";
 import { buildPredictedGateVerdict } from "../rules/predicted-gate";
 import { buildIssueSlopAssessment, buildSlopAssessment } from "../signals/slop";
@@ -206,6 +207,10 @@ const lintPrTextShape = {
   commitMessages: z.array(z.string().max(PREFLIGHT_LIMITS.bodyChars)).max(50).optional(),
   prBody: z.string().max(PREFLIGHT_LIMITS.bodyChars).optional(),
   linkedIssue: z.number().int().positive().optional(),
+};
+
+const validateConfigShape = {
+  content: z.string().max(MAX_FOCUS_MANIFEST_BYTES),
 };
 
 const preflightShape = {
@@ -941,6 +946,13 @@ const lintPrTextOutputSchema = {
   summary: z.string().optional(),
   generatedAt: z.string().optional(),
 };
+const validateConfigOutputSchema = {
+  present: z.boolean().optional(),
+  normalized: z.unknown().optional(),
+  warnings: z.array(z.string()).optional(),
+  recognizedFields: z.array(z.string()).optional(),
+  summary: z.string().optional(),
+};
 // #550: output schemas for the remaining tools (preflight/score/local-branch/agent), so MCP clients can
 // machine-validate their results. Same lenient style as the schemas above — documented top-level keys,
 // all optional, complex values as z.unknown(). No behavior change; these mirror the existing payloads.
@@ -1419,6 +1431,17 @@ export class GittensoryMcp {
         outputSchema: lintPrTextOutputSchema,
       },
       async (input) => this.toolResult(this.lintPrText(input)),
+    );
+
+    server.registerTool(
+      "gittensory_validate_config",
+      {
+        description:
+          "Validate a supplied .gittensory.yml (or JSON) manifest string BEFORE pushing it, using the exact same tolerant parser the review stack runs — no parallel schema. Returns the normalized config, every parse warning (invalid values, unknown fields), and whether any recognized field was present. Metadata only; no repo context, no GitHub writes.",
+        inputSchema: validateConfigShape,
+        outputSchema: validateConfigOutputSchema,
+      },
+      async (input) => this.toolResult(await this.validateConfig(input)),
     );
 
     server.registerTool(
@@ -2281,6 +2304,23 @@ export class GittensoryMcp {
     return {
       summary: `Slop risk: ${assessment.band}.`,
       data: { band: assessment.band, findings: assessment.findings } as unknown as Record<string, unknown>,
+    };
+  }
+
+  private async validateConfig(input: z.infer<z.ZodObject<typeof validateConfigShape>>): Promise<ToolPayload> {
+    await this.enforceToolRateLimit("gittensory_validate_config");
+    const result = validateManifestConfig(input.content);
+    return {
+      summary:
+        result.warnings.length === 0
+          ? `Manifest valid: ${result.recognizedFields.length} recognized field${result.recognizedFields.length === 1 ? "" : "s"}, no warnings.`
+          : `Manifest has ${result.warnings.length} warning${result.warnings.length === 1 ? "" : "s"}.`,
+      data: {
+        present: result.present,
+        normalized: result.normalized,
+        warnings: result.warnings,
+        recognizedFields: result.recognizedFields,
+      } as unknown as Record<string, unknown>,
     };
   }
 

--- a/src/selfhost/config-lint.ts
+++ b/src/selfhost/config-lint.ts
@@ -1,5 +1,6 @@
 import { parse as parseYaml } from "yaml";
-import { MAX_FOCUS_MANIFEST_BYTES, parseFocusManifestContent } from "../signals/focus-manifest";
+import { focusManifestToJson, MAX_FOCUS_MANIFEST_BYTES, parseFocusManifestContent } from "../signals/focus-manifest";
+import type { JsonValue } from "../types";
 
 const TOP_LEVEL_FIELDS = [
   "source",
@@ -50,6 +51,32 @@ export function lintManifestText(text: string | null | undefined): SelfHostConfi
     summary: ok
       ? `Manifest parsed ${recognizedFields.length} recognized field${recognizedFields.length === 1 ? "" : "s"}.`
       : `Manifest has ${warnings.length} warning${warnings.length === 1 ? "" : "s"}.`,
+  };
+}
+
+export type ValidateManifestConfigResult = {
+  present: boolean;
+  normalized: Record<string, JsonValue>;
+  warnings: string[];
+  recognizedFields: string[];
+};
+
+/**
+ * Pre-validate a supplied `.gittensory.yml` string against the SAME tolerant parser the review stack runs
+ * (#2057, sibling of the MCP gate predictors) — never a parallel schema. Returns the manifest normalized to its
+ * canonical JSON form ({@link focusManifestToJson}), the parser's `warnings[]` (redacted + unknown-top-level
+ * warnings, via {@link lintManifestText}), and `present` (whether any recognized focus field survived parse), so
+ * a contributor/operator can catch a typo or invalid value before pushing. Malformed input degrades to
+ * `present: false` + a warning, exactly like the analysis path — this never throws.
+ */
+export function validateManifestConfig(text: string | null | undefined): ValidateManifestConfigResult {
+  const manifest = parseFocusManifestContent(text, "repo_file");
+  const { warnings, recognizedFields } = lintManifestText(text);
+  return {
+    present: manifest.present,
+    normalized: focusManifestToJson(manifest),
+    warnings,
+    recognizedFields,
   };
 }
 

--- a/src/signals/focus-manifest-loader.ts
+++ b/src/signals/focus-manifest-loader.ts
@@ -1,7 +1,7 @@
 import { listSignalSnapshots, persistSignalSnapshot } from "../db/repositories";
 import type { JsonValue } from "../types";
 import { nowIso } from "../utils/json";
-import { contentLaneConfigToJson, featuresConfigToJson, gateConfigToJson, MAX_FOCUS_MANIFEST_BYTES, parseFocusManifest, parseFocusManifestContent, repoDocGenerationConfigToJson, reviewConfigToJson, reviewRecapConfigToJson, settingsOverrideToJson, type FocusManifest, type FocusManifestSource, type RepoReviewContext } from "./focus-manifest";
+import { focusManifestToJson, MAX_FOCUS_MANIFEST_BYTES, parseFocusManifest, parseFocusManifestContent, type FocusManifest, type FocusManifestSource, type RepoReviewContext } from "./focus-manifest";
 import { GITTENSORY_REPO_FOCUS_MANIFEST_YAML, resolveGittensorySelfRepoFullName } from "../config/gittensory-repo-focus-manifest";
 
 export const REPO_FOCUS_MANIFEST_SIGNAL = "repo-focus-manifest";
@@ -270,23 +270,7 @@ async function persistRepoFocusManifest(env: Env, repoFullName: string, manifest
 }
 
 function manifestToJson(manifest: FocusManifest): Record<string, JsonValue> {
-  return {
-    source: manifest.source,
-    wantedPaths: manifest.wantedPaths,
-    preferredLabels: manifest.preferredLabels,
-    linkedIssuePolicy: manifest.linkedIssuePolicy,
-    testExpectations: manifest.testExpectations,
-    issueDiscoveryPolicy: manifest.issueDiscoveryPolicy,
-    maintainerNotes: manifest.maintainerNotes,
-    publicNotes: manifest.publicNotes,
-    gate: gateConfigToJson(manifest.gate),
-    settings: settingsOverrideToJson(manifest.settings),
-    review: reviewConfigToJson(manifest.review),
-    features: featuresConfigToJson(manifest.features),
-    contentLane: contentLaneConfigToJson(manifest.contentLane),
-    repoDocGeneration: repoDocGenerationConfigToJson(manifest.repoDocGeneration),
-    reviewRecap: reviewRecapConfigToJson(manifest.reviewRecap),
-  };
+  return focusManifestToJson(manifest);
 }
 
 function snapshotAgeMs(generatedAt: string | null | undefined): number {

--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -18,6 +18,7 @@ export {
   compileFocusManifestPolicy,
   contentLaneConfigToJson,
   featuresConfigToJson,
+  focusManifestToJson,
   formatManifestValidationNotice,
   gateConfigToJson,
   isFocusManifestPublicSafe,

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -1256,6 +1256,37 @@ describe("api routes", () => {
     const malformedIssueSlop = await app.request("/v1/lint/issue-slop", { method: "POST", headers: apiHeaders(env), body: "{not json" }, env);
     expect(malformedIssueSlop.status).toBe(400);
 
+    // Pre-submit .gittensory.yml validation (#2057): mirrors the gittensory_validate_config MCP tool, reusing the
+    // review stack's own parser (single source of truth).
+    const validateConfig = await app.request(
+      "/v1/lint/validate-config",
+      { method: "POST", headers: apiHeaders(env), body: JSON.stringify({ content: "gate:\n  enabled: true\nblockedPaths: [dist/]\n" }) },
+      env,
+    );
+    expect(validateConfig.status).toBe(200);
+    const validateConfigBody = await validateConfig.json();
+    expect(validateConfigBody).toMatchObject({
+      present: true,
+      recognizedFields: ["gate"],
+      warnings: ["blockedPaths is retired; use settings.hardGuardrailGlobs for path holds."],
+      normalized: expect.objectContaining({ source: "repo_file" }),
+    });
+
+    // Session identities can reach it — allowlisted like the other local self-checks.
+    const { token: validateConfigSessionToken } = await createSessionForGitHubUser(env, { login: "validate-config-user", id: 4545 });
+    const sessionValidateConfig = await app.request(
+      "/v1/lint/validate-config",
+      { method: "POST", headers: { authorization: `Bearer ${validateConfigSessionToken}`, "content-type": "application/json" }, body: JSON.stringify({ content: "wantedPaths: [src/]\n" }) },
+      env,
+    );
+    expect(sessionValidateConfig.status).toBe(200);
+
+    const invalidValidateConfig = await app.request("/v1/lint/validate-config", { method: "POST", headers: apiHeaders(env), body: JSON.stringify({}) }, env);
+    expect(invalidValidateConfig.status).toBe(400);
+
+    const malformedValidateConfig = await app.request("/v1/lint/validate-config", { method: "POST", headers: apiHeaders(env), body: "{not json" }, env);
+    expect(malformedValidateConfig.status).toBe(400);
+
     const queueIntelligence = await app.request(
       "/v1/internal/queue-intelligence",
       {

--- a/test/unit/mcp-validate-config.test.ts
+++ b/test/unit/mcp-validate-config.test.ts
@@ -1,0 +1,95 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { describe, expect, it } from "vitest";
+import { GittensoryMcp } from "../../src/mcp/server";
+import { createTestEnv } from "../helpers/d1";
+
+async function connect() {
+  const server = new GittensoryMcp(createTestEnv()).createServer();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  const client = new Client({ name: "gittensory-validate-config-test", version: "0.1.0" }, { capabilities: {} });
+  await client.connect(clientTransport);
+  return client;
+}
+
+type ValidateConfigData = {
+  present: boolean;
+  normalized: Record<string, unknown>;
+  warnings: string[];
+  recognizedFields: string[];
+  summary: string;
+};
+
+describe("MCP gittensory_validate_config (#2057)", () => {
+  it("validates a single-field manifest (no repo/auth needed) and normalizes it with no warnings", async () => {
+    const client = await connect();
+    const result = await client.callTool({
+      name: "gittensory_validate_config",
+      arguments: { content: "wantedPaths:\n  - src/\n" },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as ValidateConfigData;
+    expect(data.present).toBe(true);
+    expect(data.warnings).toEqual([]);
+    expect(data.recognizedFields).toEqual(["wantedPaths"]);
+    // normalized comes from the SAME parser/serializer the loader persists — single source of truth.
+    expect(data.normalized.source).toBe("repo_file");
+    expect(data.normalized.wantedPaths).toEqual(["src/"]);
+    expect((result.content as Array<{ text: string }>)[0]?.text).toContain(
+      "Manifest valid: 1 recognized field, no warnings.",
+    );
+  });
+
+  it("pluralizes the recognized-field count for a multi-field manifest", async () => {
+    const client = await connect();
+    const result = await client.callTool({
+      name: "gittensory_validate_config",
+      arguments: { content: "gate:\n  enabled: true\nreview:\n  profile: chill\n" },
+    });
+
+    const data = result.structuredContent as ValidateConfigData;
+    expect(data.present).toBe(true);
+    expect(data.warnings).toEqual([]);
+    expect(data.recognizedFields).toEqual(["gate", "review"]);
+    expect((result.content as Array<{ text: string }>)[0]?.text).toContain(
+      "Manifest valid: 2 recognized fields, no warnings.",
+    );
+  });
+
+  it("reports a single warning for malformed YAML without throwing", async () => {
+    const client = await connect();
+    const result = await client.callTool({
+      name: "gittensory_validate_config",
+      arguments: { content: "wantedPaths: [unterminated" },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as ValidateConfigData;
+    expect(data.present).toBe(false);
+    expect(data.recognizedFields).toEqual([]);
+    expect(data.warnings).toEqual([
+      "Manifest content was not valid YAML; ignoring it and falling back to deterministic signals.",
+    ]);
+    expect((result.content as Array<{ text: string }>)[0]?.text).toContain("Manifest has 1 warning.");
+  });
+
+  it("pluralizes multiple warnings and never echoes supplied values back", async () => {
+    const client = await connect();
+    const result = await client.callTool({
+      name: "gittensory_validate_config",
+      arguments: { content: "wantedPaths: [src/]\nblockedPaths: [dist/]\nunknownSecretKey: super-secret-value\n" },
+    });
+
+    const data = result.structuredContent as ValidateConfigData;
+    expect(data.present).toBe(true);
+    expect(data.recognizedFields).toEqual(["wantedPaths"]);
+    expect(data.warnings).toEqual([
+      "blockedPaths is retired; use settings.hardGuardrailGlobs for path holds.",
+      "Manifest contains unknown top-level field: unknownSecretKey.",
+    ]);
+    expect((result.content as Array<{ text: string }>)[0]?.text).toContain("Manifest has 2 warnings.");
+    expect(JSON.stringify(result)).not.toContain("super-secret-value");
+  });
+});

--- a/test/unit/selfhost-config-lint.test.ts
+++ b/test/unit/selfhost-config-lint.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { lintManifestText } from "../../src/selfhost/config-lint";
+import { lintManifestText, validateManifestConfig } from "../../src/selfhost/config-lint";
 import { MAX_FOCUS_MANIFEST_BYTES } from "../../src/signals/focus-manifest";
 
 describe("lintManifestText (#2079)", () => {
@@ -258,6 +258,54 @@ review:
       `Manifest content exceeded ${MAX_FOCUS_MANIFEST_BYTES} bytes; ignoring it and falling back to deterministic signals.`,
     ]);
     expect(JSON.stringify(result)).not.toContain("unknownSecretKey");
+    expect(JSON.stringify(result)).not.toContain("super-secret-value");
+  });
+});
+
+describe("validateManifestConfig (#2057)", () => {
+  it("normalizes a valid manifest, reports it present, and emits no warnings", () => {
+    const result = validateManifestConfig("wantedPaths:\n  - src/\n");
+
+    expect(result.present).toBe(true);
+    expect(result.warnings).toEqual([]);
+    expect(result.recognizedFields).toEqual(["wantedPaths"]);
+    // `normalized` is the canonical serialization the loader persists — safe defaults applied.
+    expect(result.normalized.source).toBe("repo_file");
+    expect(result.normalized.wantedPaths).toEqual(["src/"]);
+    expect(result.normalized.settings).toBeNull(); // no settings block → serializes to null, same as the cache round-trip
+  });
+
+  it("surfaces a redacted parser warning for an invalid value while still normalizing the field", () => {
+    const result = validateManifestConfig("wantedPaths: [src/]\nlinkedIssuePolicy: sometimes\n");
+
+    expect(result.present).toBe(true);
+    expect(result.recognizedFields).toEqual(["wantedPaths", "linkedIssuePolicy"]);
+    expect(result.warnings.length).toBeGreaterThan(0);
+    expect(result.warnings.join("\n")).toContain("falling back to the default");
+    // the invalid value fell back to a valid default rather than being echoed back
+    expect(result.normalized.linkedIssuePolicy).toBe("optional");
+    expect(JSON.stringify(result)).not.toContain("sometimes");
+  });
+
+  it("degrades malformed YAML to present:false with a warning, never throwing", () => {
+    const result = validateManifestConfig("wantedPaths: [unterminated");
+
+    expect(result.present).toBe(false);
+    expect(result.recognizedFields).toEqual([]);
+    expect(result.warnings).toEqual([
+      "Manifest content was not valid YAML; ignoring it and falling back to deterministic signals.",
+    ]);
+    // still returns a well-formed normalized empty manifest
+    expect(result.normalized.source).toBe("repo_file");
+    expect(result.normalized.wantedPaths).toEqual([]);
+  });
+
+  it("flags an unknown top-level field by name without echoing its value", () => {
+    const result = validateManifestConfig("wantedPaths: [src/]\nunknownSecretKey: super-secret-value\n");
+
+    expect(result.present).toBe(true);
+    expect(result.recognizedFields).toEqual(["wantedPaths"]);
+    expect(result.warnings).toEqual(["Manifest contains unknown top-level field: unknownSecretKey."]);
     expect(JSON.stringify(result)).not.toContain("super-secret-value");
   });
 });


### PR DESCRIPTION
## Summary

Closes #2057. Adds `gittensory_validate_config`, a pre-submit `.gittensory.yml` validator so contributors/operators can catch a typo or an invalid value **before** pushing — a source-free sibling of the existing MCP pre-submit predictors (`predict_gate`, `check_slop_risk`, `lint_pr_text`).

It reuses the review stack's **own** tolerant parser (`parseFocusManifestContent`) as the single source of truth — no parallel schema — so the verdict matches what the gate will actually see. Returns `{ present, normalized, warnings, recognizedFields }`.

## What changed

- **`packages/gittensory-engine`** — export a canonical `focusManifestToJson` serializer and dedupe the loader's private `manifestToJson` onto it, so a validated manifest normalizes byte-identically to how it's persisted/re-read (no duplicate serializer).
- **`src/selfhost/config-lint`** — `validateManifestConfig(text)` builds on the existing lint (redacted parser warnings + unknown-field detection + recognized fields) and adds the normalized config + `present`.
- **`src/mcp/server`** — register the `gittensory_validate_config` tool (remote `/mcp`), with input/output schemas.
- **`src/api/routes` + `packages/gittensory-mcp`** — a `/v1/lint/validate-config` route and the npm stdio tool that proxies to it, matching the existing `slop-risk` MCP-tool + REST-route + npm-proxy pattern.
- **Docs** — documented in the MCP tool reference (`.claude/skills/contributing-to-gittensory/reference.md` §5).

## Deliverables (from #2057)

- [x] `gittensory_validate_config` tool in the MCP surface (`packages/gittensory-mcp/**` + `src/mcp/**`) returning `{ normalized, warnings, present }`
- [x] Reuses the existing parser as the single source of truth (no parallel schema)
- [x] Unit tests: valid config, config with warnings, malformed YAML — branch coverage on the ok/warn/error arms
- [x] Documented in the MCP tool reference

## Test plan

- [x] `test/unit/mcp-validate-config.test.ts` — exercises the tool over the MCP client: single-field (valid), multi-field (plural), malformed YAML (one warning), multiple warnings, and public-safety (never echoes supplied values). Covers all four summary arms.
- [x] `test/unit/selfhost-config-lint.test.ts` — `validateManifestConfig` unit cases (present/normalized/warnings/recognizedFields, redaction, malformed).
- [x] `test/integration/api.test.ts` — `/v1/lint/validate-config` success (API token + session) + 400 arms (invalid schema, malformed JSON).
- [x] `npm run typecheck` clean; all new source lines and branches covered.

Made with [Cursor](https://cursor.com)