### PR TITLE
fix(install-scripts): flag oversized npm metadata as capped install-script finding

### DIFF
--- a/review-enrichment/src/analyzers/install-scripts.ts
+++ b/review-enrichment/src/analyzers/install-scripts.ts
@@ -139,7 +139,18 @@ export async function scanInstallScripts(
     const response = options.analysis
       ? await options.analysis.fetchJson<NpmVersionMetadata | NpmPackumentMetadata>(url, fetchOptions)
       : await boundedFetchJson<NpmVersionMetadata | NpmPackumentMetadata>(url, fetchOptions);
-    if (!response.ok) continue;
+    if (!response.ok) {
+      if (response.reason === "response_too_large") {
+        findings.push({
+          package: change.package,
+          version: change.to,
+          hooks: [],
+          publishedAt: null,
+          metadataCapped: true,
+        });
+      }
+      continue;
+    }
     const data = response.data;
     const version = versionMetadata(data, change.to);
     const scripts = version?.scripts ?? {};

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -73,6 +73,12 @@ export function renderBrief(
       "### Dependency install scripts (supply-chain risk — review before merging)",
     );
     for (const dep of installScripts) {
+      if (dep.metadataCapped) {
+        lines.push(
+          `- ${safeCodeSpan(`${dep.package}@${dep.version}`)} registry metadata exceeded the scan cap; manually inspect lifecycle scripts before merging`,
+        );
+        continue;
+      }
       const when = dep.publishedAt
         ? ` (published ${dep.publishedAt.slice(0, 10)})`
         : "";

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -103,6 +103,7 @@ export interface InstallScriptFinding {
   version: string;
   hooks: string[];
   publishedAt: string | null;
+  metadataCapped?: true;
 }
 
 /** A newly-added/upgraded npm package that is materially heavy but only directly imported/required a few times

--- a/review-enrichment/test/install-scripts.test.ts
+++ b/review-enrichment/test/install-scripts.test.ts
@@ -89,3 +89,45 @@ test("scanInstallScripts treats version-identifying exact metadata as top-level 
 
   assert.deepEqual(findings, []);
 });
+
+test("scanInstallScripts reports capped npm metadata for manual lifecycle review", async () => {
+  const findings = await scanInstallScripts(npmAdd("evilpkg"), undefined, {
+    analysis: {
+      fetchJson: async () => ({
+        ok: false,
+        reason: "response_too_large",
+        bytes: null,
+        elapsedMs: 5,
+        endpointCategory: "npm-version",
+        capped: true,
+      }),
+    },
+  });
+
+  assert.deepEqual(findings, [
+    {
+      package: "evilpkg",
+      version: "1.0.0",
+      hooks: [],
+      publishedAt: null,
+      metadataCapped: true,
+    },
+  ]);
+});
+
+test("scanInstallScripts keeps non-size registry failures silent", async () => {
+  const findings = await scanInstallScripts(npmAdd("missingpkg"), undefined, {
+    analysis: {
+      fetchJson: async () => ({
+        ok: false,
+        reason: "http_error",
+        status: 404,
+        bytes: null,
+        elapsedMs: 5,
+        endpointCategory: "npm-version",
+      }),
+    },
+  });
+
+  assert.deepEqual(findings, []);
+});

--- a/review-enrichment/test/render-contract.test.ts
+++ b/review-enrichment/test/render-contract.test.ts
@@ -50,6 +50,25 @@ test("renderBrief omits descriptor-owned and fallback sections for empty finding
   assert.equal(systemSuffix, "");
 });
 
+test("renderBrief reports capped install-script metadata without claiming hooks", () => {
+  const { promptSection } = renderBrief({
+    installScript: [
+      {
+        package: "evilpkg",
+        version: "1.0.0",
+        hooks: [],
+        publishedAt: null,
+        metadataCapped: true,
+      },
+    ],
+  });
+
+  assert.match(promptSection, /Dependency install scripts/);
+  assert.match(promptSection, /evilpkg@1\.0\.0/);
+  assert.match(promptSection, /metadata exceeded the scan cap/);
+  assert.doesNotMatch(promptSection, /runs\s+\s*on install/);
+});
+
 test("buildBrief reports partial analyzer results as degraded", async () => {
   const analyzers: AnalyzerRegistry = {
     dependency: async () => [


### PR DESCRIPTION
### Motivation
- Reduce a supply-chain false-negative window introduced when the npm metadata cap was lowered by treating "response_too_large" as a silent non-finding; oversized exact-version metadata should surface a manual-review signal instead of being omitted. 
- Ensure the install-script analyzer still protects reviewer intent (flag packages that may run lifecycle hooks) while keeping timeout/DoS protections intact.

### Description
- When the registry fetch returns a bounded-fetch failure with `reason === "response_too_large"`, emit an `InstallScriptFinding` with `metadataCapped: true` instead of silently continuing. The detection point is in `scanInstallScripts` (`review-enrichment/src/analyzers/install-scripts.ts`).
- Extend the `InstallScriptFinding` type with an optional `metadataCapped` marker (`review-enrichment/src/types.ts`) and update brief rendering to show a clear manual-inspection line for capped metadata without claiming specific hooks (`review-enrichment/src/render.ts`).
- Add regression tests that cover capped-metadata behavior and ensure non-size failures remain silent (`review-enrichment/test/install-scripts.test.ts` and `review-enrichment/test/render-contract.test.ts`).

### Testing
- Ran the targeted unit tests for the changed analyzers and renderers with `node --test --experimental-strip-types --test-name-pattern='scanInstallScripts|capped install-script' review-enrichment/test/install-scripts.test.ts review-enrichment/test/render-contract.test.ts`, and they passed. 
- Built the review-enrichment package with `npm --prefix review-enrichment run build`, and the build succeeded. 
- Ran the review-enrichment test suite via `npm run rees:test`; it completed successfully in this environment. 
- Attempted the full local gate via `npm run test:ci`; early checks ran but the coverage run hung in an unrelated existing `test/unit/queue.test.ts` with repeated `RangeError: Maximum call stack size exceeded`, so the full `test:ci` run was terminated; also `npm audit --audit-level=moderate` could not complete here due to the npm audit endpoint returning `403 Forbidden` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ca38da59c832c9ea8a82da62ec007)