### PR TITLE
fix(review): wire category tally into unified comments

### DIFF
--- a/src/review/unified-comment-bridge.ts
+++ b/src/review/unified-comment-bridge.ts
@@ -666,6 +666,7 @@ export function buildUnifiedCommentBody(args: UnifiedCommentBridgeArgs): string 
     ...(args.merged !== undefined ? { merged: args.merged } : {}),
     ...(args.reviewEffort !== undefined ? { reviewEffort: args.reviewEffort } : {}),
     ...(args.maxFindingsCaps !== undefined ? { maxFindingsCaps: args.maxFindingsCaps } : {}),
+    ...(args.findingCategories !== undefined ? { inlineFindings: args.findingCategories } : {}),
   });
   // The gate already produced 0/1 reviewer notes from a synthesis of the model pair; reflect the caller's
   // actual reviewer count (for the chip + the "N reviewers, synthesized" evidence) without re-deriving it.

--- a/src/review/unified-comment.ts
+++ b/src/review/unified-comment.ts
@@ -701,6 +701,7 @@ export function buildUnifiedReviewInput(opts: {
   reviewEffort?: { band: 1 | 2 | 3 | 4 | 5; minutes: number };
   maxFindingsCaps?: { blockers: number | null; nits: number | null };
   linkedIssueSatisfaction?: { status: "addressed" | "partial" | "unaddressed"; rationale: string };
+  inlineFindings?: ReadonlyArray<{ category?: UnifiedFindingCategory | undefined }>;
 }): UnifiedReviewInput {
   const ex = extractReviewSummary(opts.reviews);
   const changedFiles = typeof opts.changedFiles === "number" ? opts.changedFiles : opts.changedFiles.length;
@@ -720,6 +721,7 @@ export function buildUnifiedReviewInput(opts: {
     ...(opts.reviewEffort !== undefined ? { reviewEffort: opts.reviewEffort } : {}),
     ...(opts.maxFindingsCaps !== undefined ? { maxFindingsCaps: opts.maxFindingsCaps } : {}),
     ...(opts.linkedIssueSatisfaction !== undefined ? { linkedIssueSatisfaction: opts.linkedIssueSatisfaction } : {}),
+    ...(opts.inlineFindings !== undefined ? { inlineFindings: opts.inlineFindings } : {}),
   };
 }
 

--- a/test/unit/finding-category-collapsible.test.ts
+++ b/test/unit/finding-category-collapsible.test.ts
@@ -86,19 +86,22 @@ describe("buildUnifiedCommentBody findingCategories wiring (#1958)", () => {
     footerMarkdown: footer,
   };
 
-  it("appends the Finding categories section when findingCategories is present + non-empty", () => {
+  it("appends both category summaries when findingCategories is present + non-empty", () => {
     const body = buildUnifiedCommentBody({ ...base, findingCategories: findings });
+    expect(body).toContain("**Findings by category:** 1 security");
     expect(body).toContain("Finding categories");
     expect(body).toContain("| Security | 1 |");
   });
 
-  it("does NOT add a Finding categories section when findingCategories is absent (flag-OFF parity)", () => {
+  it("does NOT add category summaries when findingCategories is absent (flag-OFF parity)", () => {
     const body = buildUnifiedCommentBody(base);
+    expect(body).not.toContain("Findings by category");
     expect(body).not.toContain("Finding categories");
   });
 
-  it("does NOT add a Finding categories section when findingCategories is empty", () => {
+  it("does NOT add category summaries when findingCategories is empty", () => {
     const body = buildUnifiedCommentBody({ ...base, findingCategories: [] });
+    expect(body).not.toContain("Findings by category");
     expect(body).not.toContain("Finding categories");
   });
 


### PR DESCRIPTION
### Motivation
- The renderer emits the compact category-tally line only when `UnifiedReviewInput.inlineFindings` is present, but the live bridge built the renderer input via `buildUnifiedReviewInput` without supplying `inlineFindings`, so production unified comments omitted the new one-line tally. 
- Bridge-side category data already exists as `findingCategories`, so the live path should reuse that data to enable the tally without changing rendering semantics.

### Description
- Add an optional `inlineFindings` option to `buildUnifiedReviewInput` and preserve it on the returned `UnifiedReviewInput` so renderers can read line-anchored finding categories. (file: `src/review/unified-comment.ts`)
- Wire the bridge to pass `args.findingCategories` into `buildUnifiedReviewInput` as `inlineFindings` when present so the live unified comment path can render the compact category tally. (file: `src/review/unified-comment-bridge.ts`)
- Update unit test expectations to assert that the live `buildUnifiedCommentBody` produces both the one-line `**Findings by category:**` summary and the existing "Finding categories" collapsible when category data is supplied, and that both are absent when the input is missing or empty. (file: `test/unit/finding-category-collapsible.test.ts`)
- Preserve byte-identical/flag-OFF parity: absent or empty category inputs continue to omit the new tally line and the collapsible.

### Testing
- Ran the focused unit tests with `npx vitest run test/unit/finding-category-collapsible.test.ts test/unit/finding-category-tally.test.ts`, and both test files passed. 
- Ran `npm run typecheck` and it completed successfully. 
- Ran `git diff --check` to validate whitespace/conflict hygiene and it passed. 
- `npm audit --audit-level=moderate` failed due to an external registry `403 Forbidden` (audit endpoint), so dependency-audit could not be completed locally. 
- Attempted `npm run test:coverage`; the full coverage run did not complete in time in this environment due to long-running pre-existing queue-suite output and was interrupted, so a full unsharded coverage run should be verified before pushing to ensure patch-coverage requirements are met.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4caab6a584832c9b144051a0735402)