### PR TITLE
fix(mcp): sanitize follow-up issue paths

### DIFF
--- a/src/mcp/local-write-tools.ts
+++ b/src/mcp/local-write-tools.ts
@@ -126,7 +126,8 @@ export function buildFollowUpIssueSpec(input: {
   finding: string;
   label?: string | null | undefined;
 }): LocalWriteActionSpec {
-  const location = input.line && input.line > 0 ? `${input.path}:${input.line}` : input.path;
+  const safePath = stripMachineMarkers(input.path);
+  const location = input.line && input.line > 0 ? `${safePath}:${input.line}` : safePath;
   const safeFinding = stripMachineMarkers(input.finding).slice(0, FOLLOW_UP_ISSUE_BODY_MAX);
   const title = `Follow up: ${location}`.slice(0, FOLLOW_UP_ISSUE_TITLE_MAX);
   const body = `Deferred review finding at \`${location}\`:\n\n${safeFinding}`.slice(0, FOLLOW_UP_ISSUE_BODY_MAX);

--- a/test/unit/local-write-tools.test.ts
+++ b/test/unit/local-write-tools.test.ts
@@ -136,6 +136,18 @@ describe("buildFollowUpIssueSpec (#2177)", () => {
     expect(s.command).toContain("Null check missing.");
   });
 
+  it("strips embedded HTML-comment markers from the path before composing public issue content", () => {
+    const s = buildFollowUpIssueSpec({
+      repoFullName: "o/r",
+      path: "src/a<!-- hidden path payload -->.ts",
+      line: 42,
+      finding: "Null check missing.",
+    });
+    expect(s.command).not.toContain("<!--");
+    expect(s.inputs.title).toBe("Follow up: src/a.ts:42");
+    expect(s.inputs.body).toContain("Deferred review finding at `src/a.ts:42`");
+  });
+
   it("POSIX-escapes an embedded single quote in the composed title/body", () => {
     const s = buildFollowUpIssueSpec({ repoFullName: "o/r", path: "src/a.ts", line: 1, finding: "it's broken" });
     expect(s.command).toContain("it'\\''s broken");


### PR DESCRIPTION
### Motivation
- Prevent HTML-comment or fenced-block markers embedded in contributor-controlled file paths from surviving into follow-up issue titles, bodies, or structured inputs.

### Description
- Apply `stripMachineMarkers` to the supplied `input.path` in `buildFollowUpIssueSpec` so the composed `location` is sanitized, and add a unit test that exercises a path containing an embedded HTML-comment payload and asserts the generated `command`, `inputs.title`, and `inputs.body` do not include the marker.

### Testing
- Ran `npx vitest run test/unit/local-write-tools.test.ts` and the focused tests passed (19 tests); `npm run typecheck` passed; `git diff --check` reported no issues; a full `npm run test:coverage` attempt did not complete in this environment due to unrelated test-suite/coverage remapping failures (`TypeError: jsTokens is not a function`), while the targeted unit tests themselves passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4caab6de4c832cb793114d283b47fe)