### PR TITLE
fix(review): hard-block Voyage and Firecrawl secrets

### DIFF
--- a/src/review/safety.ts
+++ b/src/review/safety.ts
@@ -34,6 +34,8 @@ const HARD_SECRET_KINDS = new Set([
   "stripe_secret_key",
   "sendgrid_key",
   "huggingface_token",
+  "voyage_api_key",
+  "firecrawl_api_key",
   "jwt",
   "generic_secret_assignment",
 ]);

--- a/src/review/secrets-scan.ts
+++ b/src/review/secrets-scan.ts
@@ -28,6 +28,10 @@ const SECRET_PATTERNS: Array<{ name: string; re: RegExp }> = [
   { name: "sendgrid_key", re: /\bSG\.[A-Za-z0-9_-]{22}\.[A-Za-z0-9_-]{43}(?![A-Za-z0-9_-])/ },
   // Hugging Face user access token: `hf_` + 34 base62 chars.
   { name: "huggingface_token", re: /\bhf_[A-Za-z0-9]{34}\b/ },
+  // Voyage AI API key: `pa-` (platform) or `al-` (MongoDB Atlas) + base62 body.
+  { name: "voyage_api_key", re: /\b(?:pa|al)-[A-Za-z0-9]{20,}(?![A-Za-z0-9_-])/ },
+  // Firecrawl API key: `fc-` + base62 body (alnum only; reject hyphen-continued identifiers).
+  { name: "firecrawl_api_key", re: /\bfc-[A-Za-z0-9]{16,}(?![A-Za-z0-9_-])/ },
   { name: "jwt", re: /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/ },
   { name: "seed_or_mnemonic", re: /\b(?:seed phrase|mnemonic)\b/i },
   { name: "bittensor_key", re: /\b(?:hot|cold)key\b\s*[:=]/i },

--- a/test/unit/safety-wiring.test.ts
+++ b/test/unit/safety-wiring.test.ts
@@ -475,6 +475,8 @@ describe("gate treats secret_leak as a hard blocker", () => {
       `### src/config.ts (modified) +1/-0\n@@\n+const jwt = "${"eyJhbGciOiJIUzI1NiJ9" + "." + "eyJzdWIiOiIxMjM0NTY3ODkwIn0" + "." + "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"}";`,
     ],
     ["generic_secret_assignment", `### src/config.ts (modified) +1/-0\n@@\n+secret = "${"sk_live_" + "aK9xQ2mZw7Ln4Rv8Pt3Bh6"}"`],
+    ["voyage_api_key", `### src/config.ts (modified) +1/-0\n@@\n+const voyage = "${"pa-" + "aK9xQ2mZw7Ln4Rv8Pt3B"}";`],
+    ["firecrawl_api_key", `### src/config.ts (modified) +1/-0\n@@\n+const firecrawl = "${"fc-" + "aK9xQ2mZw7Ln4Rv8"}";`],
   ])("hard-blocks a %s finding", (kind, diff) => {
     const finding = secretLeakFinding(diff);
     expect(finding?.code).toBe("secret_leak");

--- a/test/unit/secrets-scan.test.ts
+++ b/test/unit/secrets-scan.test.ts
@@ -97,6 +97,26 @@ describe("scanForSecrets — deterministic secret-pattern scanner", () => {
     expect(scanForSecrets(fakeToken).kinds).toContain("huggingface_token");
   });
 
+  it("flags Voyage AI API keys", () => {
+    expect(scanForSecrets("pa-" + "aK9xQ2mZw7Ln4Rv8Pt3B").kinds).toContain("voyage_api_key");
+    expect(scanForSecrets("al-" + "mN4pL8sT2vW6xY0A1qZ5").kinds).toContain("voyage_api_key");
+  });
+
+  it("does not flag Voyage AI-shaped values below the length floor or with identifier continuation", () => {
+    expect(scanForSecrets("pa-" + "a".repeat(19)).kinds).not.toContain("voyage_api_key");
+    expect(scanForSecrets("pa-" + "a".repeat(20) + "-suffix").kinds).not.toContain("voyage_api_key");
+    expect(scanForSecrets("al-" + "b".repeat(20) + "_suffix").kinds).not.toContain("voyage_api_key");
+  });
+
+  it("flags a Firecrawl API key", () => {
+    expect(scanForSecrets("fc-" + "aK9xQ2mZw7Ln4Rv8").kinds).toContain("firecrawl_api_key");
+  });
+
+  it("does not flag Firecrawl-shaped values below the length floor or with identifier continuation", () => {
+    expect(scanForSecrets("fc-" + "c".repeat(15)).kinds).not.toContain("firecrawl_api_key");
+    expect(scanForSecrets("fc-" + "c".repeat(16) + "-suffix").kinds).not.toContain("firecrawl_api_key");
+  });
+
   it("flags a JWT", () => {
     const fakeJwt = "eyJhbGciOiJIUzI1NiJ9" + "." + "eyJzdWIiOiIxMjM0NTY3ODkwIn0" + "." + "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
     expect(scanForSecrets(fakeJwt).kinds).toContain("jwt");


### PR DESCRIPTION
### Motivation
- Ensure parity between the REES advisory secret scanner and the repository's deterministic PR hard-blocking path so newly-detected high-confidence credentials cannot be merged when enrichment is disabled. 
- Close a security-control gap where `voyage_api_key` / `firecrawl_api_key` were detected only by optional enrichment and not by the unconditional `secret_leak` gate.

### Description
- Add `voyage_api_key` and `firecrawl_api_key` regex patterns to the deterministic scanner in `src/review/secrets-scan.ts` using the same length and continuation boundaries as the REES rules. 
- Add `"voyage_api_key"` and `"firecrawl_api_key"` to the hard-block allowlist `HARD_SECRET_KINDS` in `src/review/safety.ts` so `secretLeakFinding` produces the `secret_leak` blocker for those matches. 
- Add unit tests in `test/unit/secrets-scan.test.ts` covering positive matches and negative cases (length floor and hyphen/underscore continuation) and extend `test/unit/safety-wiring.test.ts` to assert gate hard-block parity for the new kinds. 

### Testing
- Ran `git diff --check` which produced no whitespace/conflict errors. 
- Executed the unit tests with `npx vitest run test/unit/secrets-scan.test.ts test/unit/safety-wiring.test.ts` and those tests passed. 
- Ran the TypeScript typecheck with `npm run typecheck` and it passed. 
- Attempted coverage run `npx vitest run --coverage test/unit/secrets-scan.test.ts test/unit/safety-wiring.test.ts` which executed the tests but failed during coverage remapping with `TypeError: jsTokens is not a function` in `ast-v8-to-istanbul`; the failure is in coverage post-processing, not in the test assertions themselves.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4cb1d70b30832cae47538b73d27c6e)