### PR TITLE
fix(selfhost): make orb-relay-drain resilient to broker degradation

### DIFF
--- a/src/orb/broker-client.ts
+++ b/src/orb/broker-client.ts
@@ -250,7 +250,7 @@ export async function drainOrbRelay(
       method: "POST",
       headers: { authorization: `Bearer ${env.ORB_ENROLLMENT_SECRET}`, "content-type": "application/json" },
       body: JSON.stringify({ ack }),
-      signal: AbortSignal.timeout(15_000),
+      signal: AbortSignal.timeout(30_000),
     });
     if (!res.ok) throw new Error(`orb_relay_drain_http_${res.status}`);
     const body = (await res.json()) as { events?: Array<{ deliveryId?: unknown; eventName?: unknown; rawBody?: unknown }> };

--- a/src/server.ts
+++ b/src/server.ts
@@ -1007,25 +1007,34 @@ async function main(): Promise<void> {
     const { drainOrbRelay } = await import("./orb/broker-client");
     const { enqueueWebhookByEnv } = await import("./github/webhook");
     /* v8 ignore start -- pull-mode relay loop is a live self-host timer; monitor semantics are covered in selfhost tests. */
+    let drainInFlight = false;
     const drainRelay = async (): Promise<void> => {
-      await drainOrbRelayWithMonitor({
-        state: relayDrainState,
-        relayEnv: {
-          ORB_ENROLLMENT_SECRET: process.env.ORB_ENROLLMENT_SECRET,
-          ORB_BROKER_URL: process.env.ORB_BROKER_URL,
-        },
-        env,
-        drain: drainOrbRelay,
-        enqueue: enqueueWebhookByEnv,
-      });
+      if (drainInFlight) return;
+      drainInFlight = true;
+      try {
+        await drainOrbRelayWithMonitor({
+          state: relayDrainState,
+          relayEnv: {
+            ORB_ENROLLMENT_SECRET: process.env.ORB_ENROLLMENT_SECRET,
+            ORB_BROKER_URL: process.env.ORB_BROKER_URL,
+          },
+          env,
+          drain: drainOrbRelay,
+          enqueue: enqueueWebhookByEnv,
+        });
+      } finally {
+        drainInFlight = false;
+      }
     };
     void drainRelay();
+    // 30s matches broker-client's request timeout so a slow/degraded broker's in-flight drain has fully
+    // timed out (or completed) before the next tick would otherwise pile another request on top of it.
     setInterval(
       () =>
         void drainRelay().catch((error) =>
           captureError(error, { kind: "orb_relay_drain" }),
         ),
-      15_000,
+      30_000,
     );
     /* v8 ignore stop */
   }


### PR DESCRIPTION
## Summary
- Replaces #3929, which was corrupted by a bad patch application: it deleted the `Authorization: Bearer` header on the Orb broker request entirely, left a duplicate `signal` key, and left `src/server.ts` in a state that wouldn't even parse (an orphaned `if`/`return` outside any function, an undefined `drainRelay` reference, dangling braces, and the intended `setInterval` frequency change landing inside the `.catch()` handler instead of the interval argument) — which is why every build/typecheck-dependent check on that PR was failing.
- The underlying issue is real: `drainOrbRelay`'s 15s `AbortSignal.timeout` matched the drain loop's 15s `setInterval`, so a degraded broker (slow responses or HTTP 500s) caused overlapping drain calls to pile up, plus immediate timeouts with no buffer.
- Fix: raise the request timeout to 30s (`src/orb/broker-client.ts`), add an in-flight guard around the drain call so a tick is skipped while the previous drain is still running, and match the poll interval to the new timeout (`src/server.ts`). The `Authorization` header and existing error handling are preserved untouched.

Fixes [GITTENSORY-1C](https://jsonbored.sentry.io/issues/7595882036/?seerDrawer=true).

## Scope
- [x] Two files, narrowly scoped to the drain-loop resilience fix.
- [x] `src/server.ts` is codecov-exempt (integration/smoke-tested); `src/orb/broker-client.ts`'s changed line was already covered and no test asserts the literal timeout value.

## Validation
- `npx tsc --noEmit` — clean.
- `npx vitest run test/unit/orb-broker-client.test.ts test/unit/selfhost-monitored-work.test.ts` — 57/57 pass.

## Safety
- [x] `Authorization: Bearer` header on the broker request is preserved (the prior automated PR had dropped it).
- [x] No secrets/wallets/hotkeys/trust-scores/reward-values touched.