### PR TITLE
fix(analyzer): bound native-build registry concurrency

### DIFF
--- a/review-enrichment/src/analyzers/native-build.ts
+++ b/review-enrichment/src/analyzers/native-build.ts
@@ -15,6 +15,7 @@ import { boundedFetchJson } from "../external-fetch.js";
 const MAX_QUERIES = 25;
 const MAX_NPM_VERSION_JSON_BYTES = 256 * 1024;
 const MAX_PYPI_VERSION_JSON_BYTES = 2 * 1024 * 1024;
+const MAX_CONCURRENT_REGISTRY_QUERIES = 4;
 const INSTALL_HOOKS = ["preinstall", "install", "postinstall"];
 // Tokens in an install-lifecycle script that indicate a native toolchain runs on install.
 const NATIVE_TOOL_RE =
@@ -175,6 +176,27 @@ async function fetchJson(
   return response.ok ? response.data : null;
 }
 
+async function mapWithConcurrency<T, U>(
+  items: T[],
+  concurrency: number,
+  fn: (item: T) => Promise<U>,
+): Promise<U[]> {
+  const results = new Array<U>(items.length);
+  let nextIndex = 0;
+
+  async function worker(): Promise<void> {
+    while (nextIndex < items.length) {
+      const index = nextIndex;
+      nextIndex += 1;
+      results[index] = await fn(items[index]!);
+    }
+  }
+
+  const workerCount = Math.min(concurrency, items.length);
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  return results;
+}
+
 /** Analyzer entrypoint: added/changed deps → registry metadata → only the versions with a native-build install cost. */
 export async function scanNativeBuild(
   req: EnrichRequest,
@@ -186,8 +208,10 @@ export async function scanNativeBuild(
   const changes = extractDependencyChanges(req.files ?? [])
     .filter(isQueryable)
     .slice(0, options.limits?.maxQueries ?? MAX_QUERIES);
-  const results = await Promise.all(
-    changes.map(async (change): Promise<NativeBuildFinding | null> => {
+  const results = await mapWithConcurrency(
+    changes,
+    MAX_CONCURRENT_REGISTRY_QUERIES,
+    async (change): Promise<NativeBuildFinding | null> => {
       if (options.signal?.aborted) return null;
 
       if (change.ecosystem === "npm") {
@@ -233,7 +257,7 @@ export async function scanNativeBuild(
         }
       }
       return null;
-    }),
+    },
   );
   const findings = results.filter((f): f is NativeBuildFinding => f !== null);
   return findings;

--- a/review-enrichment/test/native-build.test.ts
+++ b/review-enrichment/test/native-build.test.ts
@@ -29,6 +29,19 @@ const pypiAdd = (name, version = "1.0.0") => ({
     },
   ],
 });
+const pypiAdds = (count) => ({
+  repoFullName: "o/r",
+  prNumber: 1,
+  files: [
+    {
+      path: "requirements.txt",
+      patch: `@@ -1,0 +1,${count} @@\n${Array.from(
+        { length: count },
+        (_, i) => `+native${i}==1.0.0`,
+      ).join("\n")}`,
+    },
+  ],
+});
 const jsonResponse = (body, init) => new Response(JSON.stringify(body), init);
 const npmFetch = (meta) => async () =>
   jsonResponse({
@@ -225,6 +238,28 @@ test("scanNativeBuild: the query cap counts only queryable changes (skips don't 
   });
   assert.equal(findings.length, 1);
   assert.equal(findings[0].package, "bcrypt");
+});
+
+test("scanNativeBuild bounds concurrent registry fetches below the total query cap", async () => {
+  let active = 0;
+  let maxActive = 0;
+  let started = 0;
+  const findings = await scanNativeBuild(
+    pypiAdds(10),
+    async () => {
+      started += 1;
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await Promise.resolve();
+      active -= 1;
+      return jsonResponse({ urls: [{ packagetype: "sdist" }] });
+    },
+    { limits: { maxQueries: 10 } },
+  );
+
+  assert.equal(started, 10);
+  assert.equal(maxActive, 4);
+  assert.equal(findings.length, 10);
 });
 
 test("scanNativeBuild: a PyPI PEP 440 (non-semver) sdist-only version is flagged", async () => {


### PR DESCRIPTION
### Motivation
- Prevent the native-build analyzer from launching the entire capped set of registry fetches concurrently, which can cause large bursts of network/parse/memory work when many queryable dependency changes appear in a PR.
- Preserve the existing total query cap while limiting simultaneous outbound registry requests to a small, safe concurrency level.

### Description
- Add a new concurrency cap `MAX_CONCURRENT_REGISTRY_QUERIES = 4` in `review-enrichment/src/analyzers/native-build.ts` to limit simultaneous registry calls.
- Introduce an order-preserving bounded-concurrency helper `mapWithConcurrency` and replace the previous `Promise.all(changes.map(...))` fanout with `mapWithConcurrency(changes, MAX_CONCURRENT_REGISTRY_QUERIES, ...)` inside `scanNativeBuild` so lookups are throttled.
- Keep existing caps and byte limits (`MAX_QUERIES`, `MAX_NPM_VERSION_JSON_BYTES`, `MAX_PYPI_VERSION_JSON_BYTES`) unchanged and retain result ordering and behavior of `scanNativeBuild` and `npmNativeBuild`.
- Add a regression unit test in `review-enrichment/test/native-build.test.ts` that submits multiple PyPI additions and asserts that all are processed while the observed `maxActive` concurrent fetches never exceeds the concurrency cap.
- Small TypeScript typing adjustment to avoid `T | undefined` being passed into the worker (`items[index]!`) to satisfy the compiler.

### Testing
- Ran `npm --prefix review-enrichment run build` (REES build) — succeeded.
- Ran the native-build unit file with `node --test --experimental-strip-types review-enrichment/test/native-build.test.ts` — all tests in that file passed, including the new concurrency regression test.
- Ran the REES test suite via `npm run rees:test` — review-enrichment tests passed locally.
- Started the full local gate with `npm run test:ci`; the REES pieces passed but the full `test:ci` run failed in unrelated root-level coverage/unit shards (root `test:coverage` encountered timeouts / failures in `test/unit/queue.test.ts` unrelated to this change).
- `npm audit --audit-level=moderate` could not complete in this environment due to the registry returning `403 Forbidden` for the audit endpoint.
- The change is minimal and focused to bound concurrency without changing analyzer semantics; the added unit test exercises the new behavior and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4cb43be6a0832ca46cbd03361ccf30)