### PR TITLE
fix(review): harden changed-files summary rendering

### DIFF
--- a/src/review/unified-comment-bridge.ts
+++ b/src/review/unified-comment-bridge.ts
@@ -460,12 +460,18 @@ export type ChangedFileSummaryInput = { path: string; additions: number; deletio
 /** Repo + PR coordinates for per-file "View diff" links on the changed-files table (#2157). */
 export type ChangedFilesSummaryContext = { repoFullName: string; pullNumber: number };
 
+const MAX_CHANGED_FILE_DIFF_ROWS = 200;
+const MAX_CHANGED_FILES_DIFF_BODY_LENGTH = 30_000;
+
 function markdownChangedFilePath(value: string): string {
-  return `\`${value
+  const safeValue = value
+    .replace(/[\u0000-\u001f\u007f]/g, "�")
     .replace(/\\/g, "\\\\")
-    .replace(/`/g, "\\`")
     .replace(/\|/g, "\\|")
-    .replace(/[<>]/g, (char) => (char === "<" ? "&lt;" : "&gt;"))}\``;
+    .replace(/[<>]/g, (char) => (char === "<" ? "&lt;" : "&gt;"));
+  const longestBacktickRun = safeValue.match(/`+/g)?.reduce((longest, run) => Math.max(longest, run.length), 0) ?? 0;
+  const fence = "`".repeat(longestBacktickRun + 1);
+  return `${fence}${safeValue}${fence}`;
 }
 
 /** Display order for the "Changed files" table — SOURCE FIRST, mirroring the same source-first priority this
@@ -492,7 +498,7 @@ export function buildChangedFilesSummaryCollapsible(
   context?: ChangedFilesSummaryContext | undefined,
 ): UnifiedCollapsible | null {
   if (files.length === 0) return null;
-  if (context) {
+  if (context && files.length <= MAX_CHANGED_FILE_DIFF_ROWS) {
     const sorted = [...files].sort((left, right) => {
       const leftCategory = CHANGED_FILE_CATEGORY_ORDER.indexOf(classifyChangedFile(left.path));
       const rightCategory = CHANGED_FILE_CATEGORY_ORDER.indexOf(classifyChangedFile(right.path));
@@ -505,7 +511,7 @@ export function buildChangedFilesSummaryCollapsible(
       return `| ${markdownChangedFilePath(file.path)} | +${file.additions} | -${file.deletions} | ${diffCell} |`;
     });
     const body = ["| File | Added | Removed | |", "| --- | --- | --- | --- |", ...rows].join("\n");
-    return { title: "Changed files", body };
+    if (body.length <= MAX_CHANGED_FILES_DIFF_BODY_LENGTH) return { title: "Changed files", body };
   }
   const totals = new Map<ReviewFileClass, { count: number; additions: number; deletions: number }>();
   for (const file of files) {

--- a/test/unit/changed-files-summary-collapsible.test.ts
+++ b/test/unit/changed-files-summary-collapsible.test.ts
@@ -59,9 +59,46 @@ describe("buildChangedFilesSummaryCollapsible per-file diff links (#2157)", () =
       context,
     );
     expect(c?.body).toContain("&lt;1&gt;");
-    expect(c?.body).toContain("\\`");
+    expect(c?.body).toContain("``src/weird");
+    expect(c?.body).toContain("file&lt;1&gt;.ts``");
     expect(c?.body).toContain("\\|");
     expect(c?.body).toContain("\\\\");
+  });
+
+  it("neutralizes line breaks in per-file paths before rendering public Markdown", () => {
+    const c = buildChangedFilesSummaryCollapsible(
+      [
+        {
+          path: "src/safe.ts\n@octocat\r\n[approve](mailto:attacker@example.com)",
+          additions: 1,
+          deletions: 0,
+        },
+      ],
+      context,
+    );
+    expect(c?.body).toContain("src/safe.ts�@octocat��[approve](mailto:attacker@example.com)");
+    expect(c?.body).not.toContain("\n@octocat");
+    expect(c?.body).not.toContain("\n[approve]");
+  });
+
+  it("falls back to grouped category totals when too many per-file rows would be rendered", () => {
+    const manyFiles = Array.from({ length: 201 }, (_, index) => ({
+      path: `src/file-${index}.ts`,
+      additions: 1,
+      deletions: 0,
+    }));
+    const c = buildChangedFilesSummaryCollapsible(manyFiles, context);
+    expect(c?.body).toContain("| Source | 201 | +201 | -0 |");
+    expect(c?.body).not.toContain("[View diff]");
+  });
+
+  it("falls back to grouped category totals when per-file rows would exceed the body budget", () => {
+    const c = buildChangedFilesSummaryCollapsible(
+      [{ path: `src/${"a".repeat(31_000)}.ts`, additions: 1, deletions: 0 }],
+      context,
+    );
+    expect(c?.body).toContain("| Source | 1 | +1 | -0 |");
+    expect(c?.body).not.toContain("[View diff]");
   });
 
   it("omits the View diff link when the path or repo context cannot be anchored", () => {


### PR DESCRIPTION
### Motivation
- The per-file changed-files table rendered untrusted PR filenames directly into a public Markdown table, allowing CR/LF and other control characters to break the table and inject attacker-controlled Markdown.
- Large PRs or long filenames could exceed GitHub comment size limits because there was no cap on per-file rows or rendered body length.

### Description
- Neutralize ASCII control characters (including CR/LF) in file paths by replacing them with a safe replacement character before rendering.
- Use a variable-length Markdown code-span fence computed from the longest backtick run in the filename so filenames containing backticks remain contained.
- Continue escaping backslash/pipe and angle brackets for table/HTML safety, and introduce constants `MAX_CHANGED_FILE_DIFF_ROWS` and `MAX_CHANGED_FILES_DIFF_BODY_LENGTH` to bound per-file rendering.
- When the per-file row count or rendered body would exceed caps, fall back to the grouped category summary (byte-identical former behavior) instead of emitting an oversized per-file table, and add regression tests covering CR/LF neutralization and the fallbacks.

### Testing
- Ran the focused unit suite `npx vitest run test/unit/changed-files-summary-collapsible.test.ts --pool=forks --reporter=dot` and the modified tests passed locally (21 tests passed in that file).
- Typecheck `npm run typecheck` completed successfully with no TypeScript errors.
- `git diff --check` produced no whitespace/conflict errors in the working tree.
- Full coverage run `npm run test:coverage` did not complete cleanly in this environment due to unrelated timeouts in other test suites, and a targeted coverage remapping run failed with a coverage tool error (`TypeError: jsTokens is not a function`) during report generation; these issues are external to the change and unrelated to the new logic.
- `npm audit --audit-level=moderate` could not reach the registry audit endpoint (received HTTP 403) in this environment, so the local audit did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4cb1d612b0832cbc8522aaa00fc7eb)