### PR TITLE
feat(review): expose real BYOK token/cost usage in ops stats

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -3244,6 +3244,49 @@ export async function countByokAiEventsForRepoSince(env: Env, repoFullName: stri
   return Number(row?.total ?? 0);
 }
 
+/**
+ * #hosted-ai-usage-observability: the ONLY AI activity the HOSTED gittensory-api Worker can ever have is a
+ * maintainer's own BYOK call (the legacy Workers-AI-binding path is retired; `env.AI` is undefined there) --
+ * yet nothing previously read back the real token/cost columns migration 0109 added to `ai_usage_events` for
+ * the hosted deployment specifically (the one dashboard built for this, orb-ai-usage.json, is wired
+ * exclusively to self-host's own local reporting-export SQLite mirror and cannot see the hosted D1 at all).
+ * Real, not estimated: sums the actual provider-reported input/output/total tokens and cost_usd, not the
+ * estimatedNeurons quota-proxy sumAiEstimatedNeuronsSince already tracks.
+ */
+export async function sumByokAiUsageForRepoSince(
+  env: Env,
+  repoFullName: string,
+  sinceIso: string,
+): Promise<{ calls: number; inputTokens: number; outputTokens: number; totalTokens: number; costUsd: number }> {
+  const db = getDb(env.DB);
+  const [row] = await db
+    .select({
+      calls: sql<number>`count(*)`,
+      inputTokens: sql<number>`coalesce(sum(${aiUsageEvents.inputTokens}), 0)`,
+      outputTokens: sql<number>`coalesce(sum(${aiUsageEvents.outputTokens}), 0)`,
+      totalTokens: sql<number>`coalesce(sum(${aiUsageEvents.totalTokens}), 0)`,
+      costUsd: sql<number>`coalesce(sum(${aiUsageEvents.costUsd}), 0)`,
+    })
+    .from(aiUsageEvents)
+    .where(
+      and(
+        gte(aiUsageEvents.createdAt, sinceIso),
+        eq(aiUsageEvents.status, "ok"),
+        sql`${aiUsageEvents.model} like 'byok:%'`,
+        sql`json_extract(${aiUsageEvents.metadataJson}, '$.repoFullName') = ${repoFullName}`,
+      ),
+    );
+  /* v8 ignore next -- SQL aggregate sum/count always returns one row; fallback protects D1 driver anomalies. */
+  if (!row) return { calls: 0, inputTokens: 0, outputTokens: 0, totalTokens: 0, costUsd: 0 };
+  return {
+    calls: Number(row.calls),
+    inputTokens: Number(row.inputTokens),
+    outputTokens: Number(row.outputTokens),
+    totalTokens: Number(row.totalTokens),
+    costUsd: Number(row.costUsd),
+  };
+}
+
 export async function upsertContributorScoringProfile(env: Env, profile: ContributorScoringProfileRecord): Promise<void> {
   const db = getDb(env.DB);
   await db

--- a/src/review/ops-wire.ts
+++ b/src/review/ops-wire.ts
@@ -30,7 +30,7 @@
 // `override_audit` D1 tables (none of which exist in gittensory's migrations yet) plus a careful soak/promote
 // design. This module is READ-ONLY observability: it reports drift; it never changes what blocks a live PR.
 
-import { findHottestInconclusiveReviewTargetForRepo, findHottestReviewTargetForRepo, listRepositories } from "../db/repositories";
+import { findHottestInconclusiveReviewTargetForRepo, findHottestReviewTargetForRepo, listRepositories, sumByokAiUsageForRepoSince } from "../db/repositories";
 import { isAgentConfigured } from "../settings/autonomy";
 import { resolveRepositorySettings } from "../settings/repository-settings";
 import { loadGatePrecisionReport, type GatePrecisionReport } from "../services/gate-precision";
@@ -68,6 +68,11 @@ const REVIEW_BURST_WINDOW_HOURS = 2;
  *  c7073949 (#3747) fixed. Lower than REVIEW_BURST_THRESHOLD on purpose: a failure burst is inherently rarer
  *  and more anomalous than a publish burst (normal iteration never produces repeated INCONCLUSIVE calls). */
 const REVIEW_FAILURE_BURST_THRESHOLD = 3;
+
+/** #hosted-ai-usage-observability: the trailing window computeOpsStats' byokUsage rollup covers. Wider than the
+ *  burst windows above on purpose -- this is a spend-visibility figure an operator checks periodically, not a
+ *  same-tick anomaly to alert on. */
+const BYOK_USAGE_WINDOW_HOURS = 24;
 
 /** One repo's outcome reports + the repo it covers — the input to the pure anomaly detector. `reviewBurst` and
  *  `reviewFailureBurst` are optional so existing snapshot-fixture tests need not be touched; absent/null means
@@ -209,6 +214,10 @@ export interface OpsStatsRepoRow {
   recommendations: { total: number; positive: number; negative: number; pending: number; positiveRate: number | null };
   /** The active anomaly lines for this repo (same as the cron alert), so the dashboard can flag drift. */
   anomalies: string[];
+  /** #hosted-ai-usage-observability: real (not estimated) BYOK token/cost usage over the trailing
+   *  BYOK_USAGE_WINDOW_HOURS -- the only AI activity the hosted Worker can ever have (the legacy Workers-AI
+   *  binding path is retired). Previously nothing exposed this for the hosted deployment at all. */
+  byokUsage: { calls: number; inputTokens: number; outputTokens: number; totalTokens: number; costUsd: number };
 }
 
 export interface OpsStatsPayload {
@@ -224,13 +233,15 @@ export async function computeOpsStats(env: Env): Promise<OpsStatsPayload> {
   const repos = await opsScanRepos(env);
   const rows: OpsStatsRepoRow[] = [];
   const reviewBurstSinceIso = new Date(Date.now() - REVIEW_BURST_WINDOW_HOURS * 60 * 60 * 1000).toISOString();
+  const byokUsageSinceIso = new Date(Date.now() - BYOK_USAGE_WINDOW_HOURS * 60 * 60 * 1000).toISOString();
   for (const repoFullName of repos) {
     try {
-      const [gatePrecision, calibration, reviewBurst, reviewFailureBurst] = await Promise.all([
+      const [gatePrecision, calibration, reviewBurst, reviewFailureBurst, byokUsage] = await Promise.all([
         loadGatePrecisionReport(env, repoFullName),
         buildRepoOutcomeCalibration(env, repoFullName),
         findHottestReviewTargetForRepo(env, repoFullName, reviewBurstSinceIso),
         findHottestInconclusiveReviewTargetForRepo(env, repoFullName, reviewBurstSinceIso),
+        sumByokAiUsageForRepoSince(env, repoFullName, byokUsageSinceIso),
       ]);
       rows.push({
         repoFullName,
@@ -246,6 +257,7 @@ export async function computeOpsStats(env: Env): Promise<OpsStatsPayload> {
         },
         recommendations: calibration.recommendations,
         anomalies: detectOutcomeAnomalies({ repoFullName, gatePrecision, calibration, reviewBurst, reviewFailureBurst }),
+        byokUsage,
       });
     } catch {
       /* a per-repo failure must not blank the whole feed */

--- a/test/unit/ops-wire.test.ts
+++ b/test/unit/ops-wire.test.ts
@@ -336,6 +336,48 @@ describe("computeOpsStats — cross-repo outcome aggregate", () => {
     // Privacy: aggregate only — never actor logins / trust internals.
     expect(JSON.stringify(payload)).not.toMatch(/login|actor|reward|payout|trust|wallet|hotkey|credibility/i);
   });
+
+  it("rolls up real BYOK token/cost usage over the trailing window (#hosted-ai-usage-observability)", async () => {
+    const env = createTestEnv();
+    await seedRegisteredRepo(env, "owner/repo");
+    await recordAiUsageEvent(env, {
+      feature: "ai_review_pr",
+      model: "byok:anthropic",
+      provider: "anthropic",
+      status: "ok",
+      estimatedNeurons: 0,
+      inputTokens: 1000,
+      outputTokens: 500,
+      totalTokens: 1500,
+      costUsd: 0.045,
+      metadata: { repoFullName: "owner/repo", pullNumber: 7, inconclusive: false },
+    });
+    await recordAiUsageEvent(env, {
+      feature: "ai_review_pr",
+      model: "byok:anthropic",
+      provider: "anthropic",
+      status: "ok",
+      estimatedNeurons: 0,
+      inputTokens: 2000,
+      outputTokens: 800,
+      totalTokens: 2800,
+      costUsd: 0.09,
+      metadata: { repoFullName: "owner/repo", pullNumber: 8, inconclusive: false },
+    });
+
+    const payload = await computeOpsStats(env);
+    const row = payload.repos.find((r) => r.repoFullName === "owner/repo");
+    expect(row?.byokUsage).toEqual({ calls: 2, inputTokens: 3000, outputTokens: 1300, totalTokens: 4300, costUsd: 0.135 });
+  });
+
+  it("reports zero BYOK usage for a repo with no BYOK calls in the window", async () => {
+    const env = createTestEnv();
+    await seedRegisteredRepo(env, "owner/repo");
+
+    const payload = await computeOpsStats(env);
+    const row = payload.repos.find((r) => r.repoFullName === "owner/repo");
+    expect(row?.byokUsage).toEqual({ calls: 0, inputTokens: 0, outputTokens: 0, totalTokens: 0, costUsd: 0 });
+  });
 });
 
 describe("GET /v1/internal/ops/stats — bearer-gated, flag-gated endpoint", () => {


### PR DESCRIPTION
## Summary

- Closes #3925 (rescoped after clarifying with the user: the hosted Worker's legacy Workers-AI-binding path is fully retired -- `env.AI` is undefined, no binding in wrangler.jsonc -- so BYOK is the ONLY AI activity a hosted deployment can ever have; currently zero repos have a BYOK key configured, so this reports all zeros today).
- Migration 0109 added real `input_tokens`/`output_tokens`/`total_tokens`/`cost_usd` columns to `ai_usage_events`, but nothing read them back for the hosted deployment -- the one dashboard built for this (`orb-ai-usage.json`) is wired exclusively to self-host's own local reporting-export SQLite mirror and cannot see the hosted D1's rows.
- Adds `sumByokAiUsageForRepoSince` (real, not estimated tokens/cost, trailing 24h window) and wires it into the existing `/v1/internal/ops/stats` payload as a new `byokUsage` field per repo.

## Scope

- [x] Conventional Commit title, focused single change.
- [ ] No issue-link checkbox in the template sense -- `Closes #3925` above.

## Validation

- [x] `npm run typecheck`
- [x] `npx vitest run test/unit/ops-wire.test.ts` -- 28/28 pass, including a real-usage rollup test and a zero-usage negative test.
- [x] 100% branch coverage on the changed lines (verified via lcov).

## Safety

- [x] No secrets/private data (aggregate counts/tokens/cost only, no PR content).
- [x] No auth/API-shape changes to the existing bearer-gated endpoint, additive field only.