### PR TITLE
fix(settings): bound the install-wide contributor open-item cap

### DIFF
--- a/src/settings/global-contributor-cap.ts
+++ b/src/settings/global-contributor-cap.ts
@@ -8,16 +8,20 @@
 // whole, mirroring how global_contributor_blacklist is a tenant-free singleton rather than a per-repo column.
 // Off by default (unset/invalid ⇒ null ⇒ no cap): zero behavior change for a single-repo install or one that
 // hasn't opted in.
+import { MAX_CONTRIBUTOR_OPEN_ITEM_CAP } from "../types";
+
 const GLOBAL_ENV_KEY = "GLOBAL_CONTRIBUTOR_OPEN_ITEM_CAP";
 
-/** Parse+validate the install-wide open-item cap from env. Same non-clamping, non-rounding shape as the
- *  per-repo caps' normalizeOpenItemCap (db/repositories.ts): a discrete count of open items, not a score, so a
+/** Parse+validate the install-wide open-item cap from env. Same non-rounding shape as the per-repo caps'
+ *  normalizeOpenItemCap (db/repositories.ts): a discrete count of open items, not a score, so a
  *  fractional/non-positive/non-numeric value is a malformed cap and is dropped to `null` (no cap) rather than
- *  coerced into a nonsensical threshold. Never throws. */
+ *  coerced into a nonsensical threshold. Never throws. Clamped to {@link MAX_CONTRIBUTOR_OPEN_ITEM_CAP} for the
+ *  same reason normalizeOpenItemCap is: live enforcement only ever samples a fixed 100-row budget, so a
+ *  configured value above that is silently unenforceable. */
 export function resolveGlobalContributorOpenItemCap(env: { GLOBAL_CONTRIBUTOR_OPEN_ITEM_CAP?: string | undefined }): number | null {
   const raw = env[GLOBAL_ENV_KEY];
   if (typeof raw !== "string" || raw.trim() === "") return null;
   const parsed = Number(raw);
   if (!Number.isFinite(parsed) || !Number.isInteger(parsed) || parsed <= 0) return null;
-  return parsed;
+  return Math.min(parsed, MAX_CONTRIBUTOR_OPEN_ITEM_CAP);
 }

--- a/test/unit/global-contributor-cap.test.ts
+++ b/test/unit/global-contributor-cap.test.ts
@@ -14,6 +14,13 @@ describe("resolveGlobalContributorOpenItemCap (#2562)", () => {
     expect(resolveGlobalContributorOpenItemCap({ GLOBAL_CONTRIBUTOR_OPEN_ITEM_CAP: "1" })).toBe(1);
   });
 
+  // Live enforcement only ever samples a fixed 100-row budget (MAX_CONTRIBUTOR_OPEN_ITEM_CAP), so a configured
+  // value above that is silently unenforceable -- mirrors normalizeOpenItemCap's own clamp (db/repositories.ts).
+  it("clamps a value above the live-check sample budget to 100, and preserves exactly 100 unclamped", () => {
+    expect(resolveGlobalContributorOpenItemCap({ GLOBAL_CONTRIBUTOR_OPEN_ITEM_CAP: "500" })).toBe(100);
+    expect(resolveGlobalContributorOpenItemCap({ GLOBAL_CONTRIBUTOR_OPEN_ITEM_CAP: "100" })).toBe(100);
+  });
+
   it("drops a fractional/non-positive/non-numeric value to null (no cap), never coerced", () => {
     expect(resolveGlobalContributorOpenItemCap({ GLOBAL_CONTRIBUTOR_OPEN_ITEM_CAP: "2.5" })).toBeNull();
     expect(resolveGlobalContributorOpenItemCap({ GLOBAL_CONTRIBUTOR_OPEN_ITEM_CAP: "0" })).toBeNull();


### PR DESCRIPTION
## Summary
- PR #3977 clamped the per-repo `contributorOpenPrCap`/`contributorOpenIssueCap` (`normalizeOpenItemCap` in `src/db/repositories.ts`), the `.gittensory.yml`-parsed equivalent, and the OpenAPI schema to `MAX_CONTRIBUTOR_OPEN_ITEM_CAP = 100`, since live enforcement only ever samples a fixed 100-row budget and a configured cap above that was silently unenforceable.
- `src/settings/global-contributor-cap.ts`'s `resolveGlobalContributorOpenItemCap` (#2562) — the install-wide, cross-repo sibling of those per-repo caps, read from `GLOBAL_CONTRIBUTOR_OPEN_ITEM_CAP` — has the identical vulnerability: it validates (numeric, finite, integer, positive) but never clamps, so a self-hosted install setting it above 100 remains just as bypassable as the per-repo caps were before #3977.
- Clamps the return value the same way (`Math.min(parsed, MAX_CONTRIBUTOR_OPEN_ITEM_CAP)`) and updates the doc comment, which incorrectly still claimed a "non-clamping" shape.

Refs #2562.

## Scope
- [x] Single file + its test, narrowly scoped; does not touch `src/db/repositories.ts` or the other files #3977 already fixed.

## Validation
- `npx tsc --noEmit` — clean.
- `npx vitest run test/unit/global-contributor-cap.test.ts` — 12/12 pass (2 new: clamps 500→100, preserves the 100 boundary unclamped).
- Scoped coverage on the changed file: 100% statements/branches/functions/lines.

## Safety
- [x] No secrets/wallets/hotkeys/trust-scores/reward-values touched.
- [x] No changelog edit; no `site/`/`CNAME`/`lovable` changes.