### PR TITLE
test(queue): update a now-stale unhandled-verb test

### DIFF
--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -22797,13 +22797,14 @@ describe("queue processors", () => {
         installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
         repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
         issue: { number: 93, title: "Not yet wired", state: "open", user: { login: "contributor" }, pull_request: {} },
-        comment: { id: 900, body: "@gittensory configuration", author_association: "OWNER", user: { login: "maintainer", type: "User" } },
+        comment: { id: 900, body: "@gittensory pause", author_association: "OWNER", user: { login: "maintainer", type: "User" } },
         sender: { login: "maintainer", type: "User" },
       },
     });
 
-    // No handler claims a bare "configuration" comment yet (its dispatch lands in a follow-up bounty), so the Q&A
-    // answer-card path must bail rather than post a stray "help" card or any other Q&A comment.
+    // No handler claims a bare "pause" comment yet (its dispatch lands in a follow-up bounty -- unlike
+    // "resolve"/"configuration", which now have their own handlers), so the Q&A answer-card path must bail
+    // rather than post a stray "help" card or any other Q&A comment.
     expect(calls.comments).toBe(0);
     const feedback = await env.DB.prepare("select id from audit_events where event_type = ?").bind("github_app.agent_command_feedback_prompted").first<{ id: string }>();
     expect(feedback ?? null).toBeNull();


### PR DESCRIPTION
## Summary

- A test asserting `@gittensory configuration` has no dispatch handler yet went stale once #3983 wired one up (found while shipping an unrelated PR whose CI happened to run against this). Swapped the test's example verb to `pause`, which still has no handler, matching the test's own stated title/intent.
- Unrelated moderation-decay-days clamp bug (also found in the same CI run) was already fixed independently by another concurrent PR by the time I got to it -- nothing further needed there.

## Scope

- [x] Conventional Commit title, tiny isolated fix.

## Validation

- [x] `npm run typecheck`
- [x] `npx vitest run test/unit/queue.test.ts` -- 659/659 pass.

## Safety

- [x] Test-only change, no production code touched.