### PR TITLE
test(queue): stop asserting configuration has no dispatch handler

### DIFF
--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -22797,13 +22797,15 @@ describe("queue processors", () => {
         installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
         repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
         issue: { number: 93, title: "Not yet wired", state: "open", user: { login: "contributor" }, pull_request: {} },
-        comment: { id: 900, body: "@gittensory configuration", author_association: "OWNER", user: { login: "maintainer", type: "User" } },
+        comment: { id: 900, body: "@gittensory pause", author_association: "OWNER", user: { login: "maintainer", type: "User" } },
         sender: { login: "maintainer", type: "User" },
       },
     });
 
-    // No handler claims a bare "configuration" comment yet (its dispatch lands in a follow-up bounty), so the Q&A
-    // answer-card path must bail rather than post a stray "help" card or any other Q&A comment.
+    // "pause" is a recognized action-command (GITTENSORY_ACTION_COMMAND_CATALOG) but has no maybeProcess*Command
+    // dispatch handler wired yet, unlike gate-override/resolve/configuration/plan -- its dispatch lands in a
+    // follow-up bounty, so the Q&A answer-card path must bail rather than post a stray "help" card or any other
+    // Q&A comment.
     expect(calls.comments).toBe(0);
     const feedback = await env.DB.prepare("select id from audit_events where event_type = ?").bind("github_app.agent_command_feedback_prompted").first<{ id: string }>();
     expect(feedback ?? null).toBeNull();


### PR DESCRIPTION
## Summary
- Main is currently red: `test/unit/queue.test.ts`'s "a #1960 action-command verb with no dispatch handler wired yet ... is bailed out of the Q&A answer-card path" test used `@gittensory configuration` as its example of an unwired verb, but #3983 (merged since) wired a real `maybeProcessConfigurationCommand` handler for it — so a bare "configuration" comment now correctly gets a real response, and the test's `expect(calls.comments).toBe(0)` assertion no longer holds.
- Switches the test's example to `@gittensory pause` — `pause` is defined in `GITTENSORY_ACTION_COMMAND_CATALOG` but, unlike `gate-override`/`resolve`/`configuration`/`plan`, has no `maybeProcess*Command` dispatch handler wired into `processors.ts`'s webhook chain yet, so it's still a valid example of the behavior this test actually verifies.

## Scope
- [x] Test-only change, one file, one assertion's example input.

## Validation
- `npx tsc --noEmit` — clean.
- `npx vitest run test/unit/queue.test.ts` — 659/659 pass.

## Safety
- [x] No secrets/wallets/hotkeys/trust-scores/reward-values touched.
- [x] No changelog edit; no `site/`/`CNAME`/`lovable` changes.