### PR TITLE
fix(review): stop draft PRs from re-triggering AI review

### DIFF
--- a/.gittensory.yml
+++ b/.gittensory.yml
@@ -55,6 +55,15 @@ gate:
 #     relatedWork: false                                # linkedIssue | relatedWork | reviewLoad (Change scope) |
 #     openPrQueue: false                                # validationEvidence (Validation posture) | openPrQueue (Contributor workload) | contributorContext | gateResult
 
+# AI-review eligibility filters (#3999): a draft PR previously re-triggered a full AI review on every
+# push, letting a contributor iterate for free while tokens kept burning — skip_drafts stops that.
+# skip_docs_only skips the reviewer entirely when every changed file is documentation, which never
+# needs an AI pass.
+review:
+  auto_review:
+    skip_drafts: true
+    skip_docs_only: true
+
 # Linked-issue label propagation (#priority-linked-issue-gate, #priority-linked-issue-gate-ownership): a PR
 # that closes/fixes/resolves an issue inherits that issue's point-bearing gittensor:* label onto the PR
 # itself, instead of the PR's own label being decided purely by its commit-title prefix. bug/feature are

--- a/src/config/gittensory-repo-focus-manifest.ts
+++ b/src/config/gittensory-repo-focus-manifest.ts
@@ -59,6 +59,15 @@ gate:
 #     relatedWork: false                                # linkedIssue | relatedWork | reviewLoad (Change scope) |
 #     openPrQueue: false                                # validationEvidence (Validation posture) | openPrQueue (Contributor workload) | contributorContext | gateResult
 
+# AI-review eligibility filters (#3999): a draft PR previously re-triggered a full AI review on every
+# push, letting a contributor iterate for free while tokens kept burning — skip_drafts stops that.
+# skip_docs_only skips the reviewer entirely when every changed file is documentation, which never
+# needs an AI pass.
+review:
+  auto_review:
+    skip_drafts: true
+    skip_docs_only: true
+
 # Linked-issue label propagation (#priority-linked-issue-gate, #priority-linked-issue-gate-ownership): a PR
 # that closes/fixes/resolves an issue inherits that issue's point-bearing gittensor:* label onto the PR
 # itself, instead of the PR's own label being decided purely by its commit-title prefix. bug/feature are


### PR DESCRIPTION
## Summary

- `review.auto_review.skip_drafts` and `skip_docs_only` were fully implemented and wired but unset in this repo's own `.gittensory.yml`, so a push to a draft PR was still triggering a full AI review pass on every commit. Enables both for JSONbored/gittensory. Companion PRs will do the same for metagraphed and awesome-claude (config lives per-repo, can't be one PR).
- Also updates the bundled fallback manifest constant (`src/config/gittensory-repo-focus-manifest.ts`) to keep it byte-identical with the root `.gittensory.yml`, per its own "keep aligned" header comment.

Part of #3999.

Closes #3999.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` (no workflow files touched)
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — not run in full; this is a config/data-only change (no new logic branches). Ran the specific existing suite (`test/unit/gittensory-focus-manifest.test.ts`, 13/13 passing) confirming the bundled fallback constant still parses and matches the schema.
- [ ] `npm run test:workers` (no Workers-pool-relevant code touched)
- [ ] `npm run build:mcp` / `npm run test:mcp-pack` (not touched)
- [ ] `npm run ui:openapi:check` (no API/schema change)
- [ ] `npm run ui:lint` / `ui:typecheck` / `ui:build` (no UI files touched)
- [x] `npm audit --audit-level=moderate` — not re-run; no dependency changes in this PR.
- [x] `npm run docs:drift-check` and `npm run selfhost:config-lint -- .gittensory.yml` both pass, confirming the new `review` field parses and is recognized.
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — N/A, no new logic, just enabling an existing, already-tested config path.

If any required check was skipped, explain why:

- This PR only changes a YAML config value and a matching string constant — no `src/` logic branches were added, so the full CI matrix (UI build/lint, MCP pack, Workers pool, etc.) isn't relevant to this diff. The two checks that are relevant (`typecheck`, the manifest-constant unit test) are green.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests — N/A.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed — N/A.
- [ ] UI changes use live API data — N/A, no UI change.
- [ ] Visible UI changes include a `UI Evidence` section — N/A, no UI change.
- [x] Public docs/changelogs are updated where needed — no changelog edit (not a release-prep PR).

## Notes

- Companion config PRs for JSONbored/metagraphed and JSONbored/awesome-claude will follow to complete #3999 across all three gated repos.