### PR TITLE
fix(db): dedupe focus manifest snapshots

### DIFF
--- a/src/db/retention.ts
+++ b/src/db/retention.ts
@@ -94,7 +94,12 @@ export async function pruneExpiredRecords(
 
 export type SignalSnapshotDedupeResult = { signalType: string; deleted: number };
 
-const LATEST_ONLY_SIGNAL_SNAPSHOT_TYPES = ["repo-culture-profile", "repo-doc-refresh-attempt"] as const;
+const LATEST_ONLY_SIGNAL_SNAPSHOT_TYPES = [
+  "repo-culture-profile",
+  "repo-doc-refresh-attempt",
+  "repo-focus-manifest",
+  "repo-public-focus-manifest",
+] as const;
 
 /**
  * signal_snapshots has no dedup: `generate-signal-snapshots` inserts a NEW row per (signal_type,

--- a/test/unit/retention.test.ts
+++ b/test/unit/retention.test.ts
@@ -4,6 +4,7 @@ import { getDb } from "../../src/db/client";
 import { dedupeSignalSnapshots, pruneExpiredRecords, RETENTION_POLICY } from "../../src/db/retention";
 import { agentContextSnapshots, aiUsageEvents, webhookEvents } from "../../src/db/schema";
 import { processJob, runRetentionPrune } from "../../src/queue/processors";
+import { REPO_FOCUS_MANIFEST_SIGNAL, REPO_PUBLIC_FOCUS_MANIFEST_SIGNAL } from "../../src/signals/focus-manifest-loader";
 import { createTestEnv } from "../helpers/d1";
 
 const NOW = Date.parse("2026-06-13T00:00:00.000Z");
@@ -159,6 +160,25 @@ describe("dedupeSignalSnapshots", () => {
     expect(await countSignalSnapshots(env, "queue-health")).toBe(1);
     const remaining = await env.DB.prepare("SELECT id FROM signal_snapshots WHERE signal_type = ?").bind("repo-culture-profile").first<{ id: string }>();
     expect(remaining?.id).toBe("s-3");
+  });
+
+  it("dedupes private and public focus-manifest cache snapshots (regression for storage exhaustion)", async () => {
+    const env = createTestEnv();
+    await insertSignalSnapshot(env, "private-old", REPO_FOCUS_MANIFEST_SIGNAL, "JSONbored/gittensory", "2026-06-01T00:00:00.000Z");
+    await insertSignalSnapshot(env, "private-latest", REPO_FOCUS_MANIFEST_SIGNAL, "JSONbored/gittensory", "2026-06-02T00:00:00.000Z");
+    await insertSignalSnapshot(env, "public-old", REPO_PUBLIC_FOCUS_MANIFEST_SIGNAL, "JSONbored/gittensory", "2026-06-01T00:00:00.000Z");
+    await insertSignalSnapshot(env, "public-latest", REPO_PUBLIC_FOCUS_MANIFEST_SIGNAL, "JSONbored/gittensory", "2026-06-02T00:00:00.000Z");
+
+    const results = await dedupeSignalSnapshots(env);
+
+    expect(results).toEqual([
+      { signalType: REPO_FOCUS_MANIFEST_SIGNAL, deleted: 1 },
+      { signalType: REPO_PUBLIC_FOCUS_MANIFEST_SIGNAL, deleted: 1 },
+    ]);
+    expect(await countSignalSnapshots(env, REPO_FOCUS_MANIFEST_SIGNAL)).toBe(1);
+    expect(await countSignalSnapshots(env, REPO_PUBLIC_FOCUS_MANIFEST_SIGNAL)).toBe(1);
+    const rows = await env.DB.prepare("SELECT id FROM signal_snapshots ORDER BY signal_type, id").all<{ id: string }>();
+    expect(rows.results.map((row) => row.id)).toEqual(["private-latest", "public-latest"]);
   });
 
   it("preserves bounded history for signal types read as historical series", async () => {


### PR DESCRIPTION
### Motivation
- Prevent storage exhaustion by restoring latest-only deduplication for focus-manifest cache snapshots so repeated private/public focus-manifest writes do not accumulate as superseded rows.

### Description
- Add `repo-focus-manifest` and `repo-public-focus-manifest` to the `LATEST_ONLY_SIGNAL_SNAPSHOT_TYPES` allowlist in `src/db/retention.ts` so they are included in the per-type latest-only dedupe pass.
- Add a regression unit test in `test/unit/retention.test.ts` that seeds duplicate private and public focus-manifest snapshots, runs `dedupeSignalSnapshots`, and asserts only the latest snapshot for each signal type remains.

### Testing
- Ran `npx vitest run test/unit/retention.test.ts`, and the modified retention unit tests passed.
- Ran `npm run typecheck`, which succeeded with no TypeScript errors.
- Attempted `npm run test:coverage -- test/unit/retention.test.ts`, where the unit tests passed but coverage remapping failed with `TypeError: jsTokens is not a function` (coverage tool error unrelated to the logic change).
- Attempted the full local gate with `npm run test:ci`, which did not complete in this environment due to a longer-running coverage/worker test run that was terminated; prerequisite checks (typecheck) had passed earlier.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4cc34f101c832c909c50731c024b91)