### PR TITLE
fix(selfhost): catch startup orb relay drain failures

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -1026,7 +1026,9 @@ async function main(): Promise<void> {
         drainInFlight = false;
       }
     };
-    void drainRelay();
+    void drainRelay().catch((error) =>
+      captureError(error, { kind: "orb_relay_drain" }),
+    );
     // 30s matches broker-client's request timeout so a slow/degraded broker's in-flight drain has fully
     // timed out (or completed) before the next tick would otherwise pile another request on top of it.
     setInterval(


### PR DESCRIPTION
### Motivation
- Prevent an unhandled promise rejection at startup when `drainOrbRelay` now throws on broker/fetch failures, which can crash the self-host process in `ORB_RELAY_MODE=pull` instead of recording the failure and retrying.

### Description
- Add a `.catch(...)` to the initial `drainRelay()` invocation in `src/server.ts` that reports the error via `captureError(error, { kind: "orb_relay_drain" })`, matching the recurring interval handler and preserving the existing retry behavior.

### Testing
- Ran `git diff --check`, `npx vitest run test/unit/selfhost-monitored-work.test.ts test/unit/orb-broker-client.test.ts`, and `npm run typecheck`, and all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4cba67f9e8832cb06461232d1910e1)