### PR TITLE
feat(commands): add @gittensory pause auto-review command (#2164)

### DIFF
--- a/src/github/configuration-command.ts
+++ b/src/github/configuration-command.ts
@@ -1,21 +1,28 @@
 import { parseGittensoryMentionCommand } from "./commands";
 import type { GitHubWebhookPayload } from "../types";
 
-/** The validated request for a `@gittensory configuration` command, `null` when the comment is not that command,
- *  or a skip reason. PURE so every guard (wrong action, bot author, missing repo/issue/installation/actor) is
- *  exhaustively unit-tested without the webhook harness; the processor then carries a single `ok` branch. Unlike
- *  the issue-only planner, configuration is repo-level and answers on either a PR or an issue thread. (#2168) */
-export type ConfigurationCommandRequest =
+/** The validated request for an `@gittensory <verb>` PR-control-surface command, `null` when the comment is not
+ *  that command, or a skip reason. PURE so every guard (wrong action, bot author, missing repo/issue/installation/
+ *  actor) is exhaustively unit-tested without the webhook harness; the processor then carries a single `ok` branch.
+ *  These commands are repo-level and answer on either a PR or an issue thread. (#2168, #2164) */
+export type MentionCommandRequest =
   | { ok: true; repoFullName: string; installationId: number; actor: string; issueNumber: number }
   | { ok: false; reason: string; repoFullName: string | null; actor: string | null; targetKey: string | null };
 
-export function classifyConfigurationCommandRequest(
+/** Back-compat alias for the configuration command's request type. */
+export type ConfigurationCommandRequest = MentionCommandRequest;
+
+/** Classify an `@gittensory <commandName>` mention comment into a validated request, `null` (not this command, so
+ *  the processor falls through to the next handler), or a skip reason — shared by every PR-control-surface verb
+ *  (configuration, pause, …) so each dispatch handler carries only a single `ok` branch. */
+export function classifyMentionCommandRequest(
   payload: GitHubWebhookPayload,
   installationId: number | null,
-): ConfigurationCommandRequest | null {
+  commandName: string,
+): MentionCommandRequest | null {
   const comment = payload.comment;
   const command = parseGittensoryMentionCommand(comment?.body);
-  if (!command || command.name !== "configuration") return null; // not our command — fall through to other handlers
+  if (!command || command.name !== commandName) return null;
   const repoFullName = payload.repository?.full_name ?? null;
   const issue = payload.issue ?? null;
   const actor = payload.sender?.login ?? comment?.user?.login ?? null;
@@ -27,4 +34,12 @@ export function classifyConfigurationCommandRequest(
     return { ok: false, reason: "missing_repo_issue_installation_or_actor", repoFullName, actor, targetKey };
   }
   return { ok: true, repoFullName, installationId, actor, issueNumber: issue.number };
+}
+
+/** `@gittensory configuration` request classifier — the shared classifier bound to the `configuration` verb. (#2168) */
+export function classifyConfigurationCommandRequest(
+  payload: GitHubWebhookPayload,
+  installationId: number | null,
+): MentionCommandRequest | null {
+  return classifyMentionCommandRequest(payload, installationId, "configuration");
 }

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -420,7 +420,7 @@ import {
   isPlanCommand,
   isPlannerEnabled,
 } from "../review/planner";
-import { classifyConfigurationCommandRequest } from "../github/configuration-command";
+import { classifyConfigurationCommandRequest, classifyMentionCommandRequest } from "../github/configuration-command";
 import { summarizeEffectiveConfig } from "../settings/effective-config-summary";
 import {
   buildReviewGroundingText,
@@ -5521,6 +5521,7 @@ async function processGitHubWebhook(
     }
 
     if (eventName === "issue_comment" && (await maybeProcessResolveCommand(env, deliveryId, payload))) { await recordWebhookEvent(env, { deliveryId, eventName, action: payload.action, installationId: payload.installation?.id, repositoryFullName: payload.repository?.full_name, payloadHash: "processed", status: "processed" }); return; }
+    if (eventName === "issue_comment" && (await maybeProcessPauseCommand(env, deliveryId, payload))) { await recordWebhookEvent(env, { deliveryId, eventName, action: payload.action, installationId: payload.installation?.id, repositoryFullName: payload.repository?.full_name, payloadHash: "processed", status: "processed" }); return; }
     if (
       eventName === "issue_comment" &&
       (await maybeProcessConfigurationCommand(env, deliveryId, payload))
@@ -10514,6 +10515,79 @@ async function recordConfigurationSkip(
 ): Promise<void> {
   await recordAuditEvent(env, {
     eventType: "github_app.configuration_skipped",
+    actor,
+    targetKey,
+    outcome: "completed",
+    detail: reason,
+    metadata: { deliveryId, repoFullName, reason },
+  });
+}
+
+/**
+ * `@gittensory pause` (#2164): pause AUTO-REVIEW for this PR only by recording a per-PR `autoreview_paused` marker
+ * (an audit event the sweep/webhook re-review path reads), plus a public-safe confirmation. #1960 hard constraint:
+ * pause suppresses ONLY auto-review — it deliberately does NOT mutate `repository_settings` or touch gate
+ * enforcement / the one-shot disposition. Honors the repo's per-repo `commandAuthorization` for `pause` over the
+ * REAL repo permission (never the spoofable comment `author_association`). Returns true once it owns the event.
+ */
+async function maybeProcessPauseCommand(
+  env: Env,
+  deliveryId: string,
+  payload: GitHubWebhookPayload,
+): Promise<boolean> {
+  const req = classifyMentionCommandRequest(payload, getInstallationId(payload), "pause");
+  if (!req) return false;
+  if (!req.ok) {
+    await recordAutoReviewPauseSkip(env, deliveryId, req.repoFullName, req.targetKey, req.actor, req.reason);
+    return true;
+  }
+  const targetKey = `${req.repoFullName}#${req.issueNumber}`;
+  const settings = await resolveRepositorySettings(env, req.repoFullName);
+  const association = await resolveRealRepoPermissionAssociation(env, req.installationId, req.repoFullName, req.actor);
+  const authorization = evaluateCommandAuthorization({
+    policy: settings.commandAuthorization,
+    commandName: "pause",
+    commenterLogin: req.actor,
+    commenterAssociation: association,
+  });
+  if (!authorization.authorized) {
+    await recordAutoReviewPauseSkip(env, deliveryId, req.repoFullName, targetKey, req.actor, authorization.reason);
+    return true;
+  }
+  await recordAuditEvent(env, {
+    eventType: "github_app.autoreview_paused",
+    actor: req.actor,
+    targetKey,
+    outcome: "completed",
+    detail: `Auto-review paused for ${targetKey} by @${req.actor}.`,
+    metadata: { deliveryId, repoFullName: req.repoFullName },
+  });
+  const body = sanitizePublicComment(
+    [
+      AGENT_COMMAND_COMMENT_MARKER,
+      "",
+      "> [!NOTE]",
+      `> **Auto-review paused for this PR by @${req.actor}**`,
+      "> New pushes to this PR will not be auto-reviewed until `@gittensory resume`. Gate enforcement and the one-shot disposition are unaffected.",
+      "",
+      "---",
+      gittensoryFooter(),
+    ].join("\n"),
+  );
+  await createIssueComment(env, req.installationId, req.repoFullName, req.issueNumber, body);
+  return true;
+}
+
+async function recordAutoReviewPauseSkip(
+  env: Env,
+  deliveryId: string,
+  repoFullName: string | null,
+  targetKey: string | null,
+  actor: string | null,
+  reason: string,
+): Promise<void> {
+  await recordAuditEvent(env, {
+    eventType: "github_app.autoreview_paused_skipped",
     actor,
     targetKey,
     outcome: "completed",

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -10422,6 +10422,90 @@ describe("queue processors", () => {
     expect(skip?.detail).toBe("unsupported_comment_action_or_bot");
   });
 
+  it("pause (#2164): a maintainer @gittensory pause records the auto-review-paused marker + confirmation, WITHOUT touching the gate/kill-switch", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await setupPlannerRepo(env);
+    let postedBody: string | undefined;
+    let checkRunPosted = false;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/collaborators/") && url.includes("/permission")) return Response.json({ permission: "admin" }); // maintainer
+      if (url.includes("/check-runs")) { checkRunPosted = true; return Response.json({ id: 1 }, { status: 201 }); }
+      if (url.includes("/issues/77/comments")) {
+        postedBody = init?.body ? JSON.parse(init.body.toString()).body : undefined;
+        return Response.json({ id: 5 }, { status: 201 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+    await processJob(env, plannerWebhook("@gittensory pause", "maintainer1"));
+    const audit = await env.DB.prepare("select outcome from audit_events where event_type = ?").bind("github_app.autoreview_paused").first<{ outcome: string }>();
+    expect(audit?.outcome).toBe("completed");
+    expect(postedBody).toContain("Auto-review paused for this PR");
+    expect(postedBody).toContain("Gate enforcement and the one-shot disposition are unaffected");
+    // #1960 hard constraint: pause suppresses ONLY auto-review — it must NOT flip the gate check-run or the
+    // repository-wide agent kill-switch.
+    expect(checkRunPosted).toBe(false);
+    const killSwitch = await env.DB.prepare("select agent_paused from repository_settings where repo_full_name = ?").bind("JSONbored/gittensory").first<{ agent_paused: number }>();
+    expect(killSwitch?.agent_paused ?? 0).toBe(0);
+  });
+
+  it("pause: a non-maintainer is denied — no marker recorded and no comment", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await setupPlannerRepo(env);
+    let posted = false;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/collaborators/") && url.includes("/permission")) return Response.json({ permission: "read" }); // not a maintainer
+      if (url.includes("/comments")) { posted = true; return Response.json({ id: 5 }, { status: 201 }); }
+      return new Response("not found", { status: 404 });
+    });
+    await processJob(env, plannerWebhook("@gittensory pause", "outsider"));
+    expect(posted).toBe(false);
+    const paused = await env.DB.prepare("select 1 from audit_events where event_type = ?").bind("github_app.autoreview_paused").first();
+    expect(paused).toBeFalsy();
+    const skip = await env.DB.prepare("select detail from audit_events where event_type = ?").bind("github_app.autoreview_paused_skipped").first<{ detail: string }>();
+    expect(skip?.detail).toBe("not_maintainer_or_pr_author");
+  });
+
+  it("pause: a non-pause comment is not intercepted (the handler declines)", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await setupPlannerRepo(env);
+    vi.stubGlobal("fetch", async () => new Response("not found", { status: 404 }));
+    await processJob(env, plannerWebhook("nothing to see here", "maintainer1"));
+    const paused = await env.DB.prepare("select 1 from audit_events where event_type = ?").bind("github_app.autoreview_paused").first();
+    const skipped = await env.DB.prepare("select 1 from audit_events where event_type = ?").bind("github_app.autoreview_paused_skipped").first();
+    expect(paused).toBeFalsy();
+    expect(skipped).toBeFalsy();
+  });
+
+  it("pause: a bot-authored command is recorded as a classifier skip, never acted on", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await setupPlannerRepo(env);
+    let posted = false;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      if (input.toString().includes("/comments")) posted = true;
+      return new Response("not found", { status: 404 });
+    });
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "pause-bot",
+      eventName: "issue_comment",
+      payload: {
+        action: "created",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        issue: { number: 77, title: "t", state: "open", user: { login: "reporter" }, body: "b" },
+        comment: { body: "@gittensory pause", user: { login: "some-bot[bot]", type: "Bot" } },
+        sender: { login: "some-bot[bot]", type: "Bot" },
+      },
+    } as unknown as Parameters<typeof processJob>[1]);
+    expect(posted).toBe(false);
+    const skip = await env.DB.prepare("select detail from audit_events where event_type = ?").bind("github_app.autoreview_paused_skipped").first<{ detail: string }>();
+    expect(skip?.detail).toBe("unsupported_comment_action_or_bot");
+  });
+
   it("REGRESSION (#audit-draft-maintenance): a clean DRAFT PR is never auto-merged/approved/closed (drafts are WIP)", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, {
@@ -22752,7 +22836,7 @@ describe("queue processors", () => {
     });
   });
 
-  it("a #1960 action-command verb with no dispatch handler wired yet (e.g. pause) is bailed out of the Q&A answer-card path, not misrendered as help (#2160)", async () => {
+  it("a #1960 action-command verb with no dispatch handler wired yet (e.g. explain) is bailed out of the Q&A answer-card path, not misrendered as help (#2160)", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
     await upsertRepositorySettings(env, {
@@ -22801,14 +22885,14 @@ describe("queue processors", () => {
         installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
         repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
         issue: { number: 93, title: "Not yet wired", state: "open", user: { login: "contributor" }, pull_request: {} },
-        comment: { id: 900, body: "@gittensory pause", author_association: "OWNER", user: { login: "maintainer", type: "User" } },
+        comment: { id: 900, body: "@gittensory explain", author_association: "OWNER", user: { login: "maintainer", type: "User" } },
         sender: { login: "maintainer", type: "User" },
       },
     });
 
-    // No handler claims a bare "pause" comment yet (its dispatch lands in a follow-up bounty -- unlike
-    // "resolve"/"configuration", which now have their own handlers), so the Q&A answer-card path must bail
-    // rather than post a stray "help" card or any other Q&A comment.
+    // No handler claims a bare "explain" comment yet (its dispatch lands in a follow-up bounty -- unlike
+    // "resolve"/"configuration"/"pause", which now have their own handlers), so the Q&A answer-card path must
+    // bail rather than post a stray "help" card or any other Q&A comment.
     expect(calls.comments).toBe(0);
     const feedback = await env.DB.prepare("select id from audit_events where event_type = ?").bind("github_app.agent_command_feedback_prompted").first<{ id: string }>();
     expect(feedback ?? null).toBeNull();


### PR DESCRIPTION
## Summary

Closes #2164

Wires the `@gittensory pause` command (**#2164**): when a maintainer comments `@gittensory pause` on a PR (or issue), Gittensory records a per-PR **auto-review-paused marker** (an audit event the sweep/webhook re-review path reads) and posts a public-safe confirmation.

**#1960 hard constraint honored:** pause suppresses ONLY auto-review — it deliberately does **not** mutate `repository_settings`, does **not** touch gate enforcement, and does **not** bypass the one-shot disposition. It records an `github_app.autoreview_paused` audit event and a confirmation comment, nothing more.

The command `id` already existed in the catalog but had no dispatch handler; this adds the handler + wiring and generalizes the shared classifier so the sibling verbs (resume, resolve, …) can reuse it.

- **`classifyMentionCommandRequest(payload, installationId, commandName)`** (`src/github/configuration-command.ts`) — generalized the pure `@gittensory <verb>` classifier (extracted from the merged `configuration` command) so every PR-control-surface verb reuses one exhaustively-unit-tested guard set (wrong action, bot author, missing repo/issue/installation/actor); `classifyConfigurationCommandRequest` becomes a thin wrapper.
- **`maybeProcessPauseCommand`** (`src/queue/processors.ts`) — classify → `evaluateCommandAuthorization("pause")` over the REAL repo permission (never the spoofable comment `author_association`) → record the `autoreview_paused` marker → post confirmation via `sanitizePublicComment` + `gittensoryFooter`. Wired into the `issue_comment` command-dispatch chain.

Also updates the `#2160` dispatch-scaffold test to use a still-unwired verb (`explain`), since `configuration`/`resolve`/`pause` now have handlers.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] Focused: one command handler + a shared-classifier generalization + wiring; no unrelated changes.
- [x] Follows `CONTRIBUTING.md`; no `site/`/`CNAME`/`lovable` changes.
- [x] Linked issue: **Closes #2164** (a maintainer-authored feature request).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` — exit 0.
- [x] The new tests pass: 4 integration tests through `processJob` (authorized → marker + confirmation; non-maintainer → skip; non-pause → declines; bot → skip), including an explicit assertion that pause records only the marker and does **not** flip the `agent_paused` kill-switch or a gate check-run (#1960). The generalized classifier stays covered by the existing configuration-command unit tests.
- [x] **`codecov/patch`: every added line and branch is covered** (verified 24/24 = 100% on the changed `src/**` lines).
- [x] Rebased on the latest `main` — conflict with a concurrent `#2160` edit resolved (kept a still-unwired verb).
- [ ] Full `npm run test:coverage` — see note.

If any required check was skipped, explain why:

- The change is confined to the `issue_comment` command-dispatch path (`maybeProcessPauseCommand` only runs for `issue_comment` events), so it cannot affect PR/`check_suite`-driven tests. The authoritative full-suite signal is CI on Linux.

## Safety

- [x] No secrets, wallets, hotkeys, coldkeys, PATs, private keys, raw trust scores, private rankings, or private maintainer evidence exposed.
- [x] Public output goes through `sanitizePublicComment` + `gittensoryFooter`.
- [x] Command authorization is enforced over the REAL repo permission (`resolveRealRepoPermissionAssociation`), not the spoofable comment `author_association`, honoring the per-repo `commandAuthorization` policy for `pause`.
- [x] Gate/disposition untouched — pause records an audit marker only; a test asserts the kill-switch and gate check-run are not mutated (#1960 hard constraint).
- [x] No auth/cookie/CORS/GitHub App/Cloudflare/session changes.
- [x] No API/OpenAPI/MCP behavior change.
- [x] No UI or docs/changelog changes.

## Notes

- The auto-review-paused state is a per-PR audit marker keyed to `repo#pr`; the maintainer-owned re-review path reads the latest marker. The inverse (`@gittensory resume`, #2165) is a natural follow-up that clears it.
