### PR TITLE
docs(observability): point alertmanager template at the real Alerting doc

### DIFF
--- a/alertmanager/alertmanager.yml
+++ b/alertmanager/alertmanager.yml
@@ -8,11 +8,16 @@
 # means `docker compose --profile observability up -d` always comes up green.
 #
 # THIS IS A REQUIRED STEP for any deployment you expect to run unattended, not an
-# optional one — see the self-hosting Operations doc's "Alerting" section for the
-# fastest verified path (a Discord webhook, uncomment the block below) and for the
-# Grafana "Active Alerts" panel you can check manually until you do. Until a real
-# receiver is wired up, every rule in prometheus/rules/alerts.yml can fire and nobody
-# will be notified — only an operator who opens Grafana will see it.
+# optional one — see https://gittensory.aethereal.dev/docs/self-hosting-operations
+# (apps/gittensory-ui/src/routes/docs.self-hosting-operations.tsx), "Alerting — required
+# for a 24/7 deployment" section, for the fastest verified path (a Discord webhook via
+# webhook_url_file, uncomment the block below) and for the Grafana "Alerts" row you can
+# check manually until you do. Until a real receiver is wired up, every rule in
+# prometheus/rules/alerts.yml can fire and nobody will be notified — only an operator
+# who opens Grafana will see it. A "real" receiver differs from this file's "null"
+# receiver only in having an integration block (slack_configs / discord_configs /
+# email_configs / webhook_configs / …) and a route pointed at it — the null receiver is
+# just a name with no integration, so it always matches and always discards.
 
 global:
   # How long to wait before declaring a firing alert "resolved" once it stops arriving.


### PR DESCRIPTION
## Summary

- Point `alertmanager/alertmanager.yml`'s top-of-file warning comment at the actual self-hosting Operations doc (`https://gittensory.aethereal.dev/docs/self-hosting-operations`, source at `apps/gittensory-ui/src/routes/docs.self-hosting-operations.tsx`) instead of a vague "see the docs" reference, naming its existing "Alerting — required for a 24/7 deployment" section directly.
- Spell out what distinguishes a real receiver from the shipped `null` one (an integration block — `slack_configs`/`discord_configs`/`email_configs`/`webhook_configs`/etc. — plus a route pointed at it) directly in the template comment, so an operator doesn't have to leave the file to understand the gap.
- No behavior change: the default route still points at the `name`-only `null` receiver, so `docker compose --profile observability up -d` still comes up green with zero configuration. This is documentation-only.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` (not run — no workflow files touched)
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` (not run — no `src/**` files changed; `alertmanager/alertmanager.yml` is not part of the Codecov patch surface and has no existing test coverage referencing it)
- [ ] `npm run test:workers` (not run — no worker code touched)
- [ ] `npm run build:mcp` (not run — no MCP package touched)
- [ ] `npm run test:mcp-pack` (not run — no MCP package touched)
- [ ] `npm run ui:openapi:check` (not run — no OpenAPI/schema touched)
- [ ] `npm run ui:lint` (not run — no UI files touched)
- [ ] `npm run ui:typecheck` (not run — no UI files touched)
- [ ] `npm run ui:build` (not run — no UI files touched)
- [ ] `npm audit --audit-level=moderate` (not run — no dependency changes)
- [x] `node scripts/validate-observability-configs.mjs` — confirms the edited `alertmanager.yml` still parses and validates against the shipped Prometheus rules/dashboards
- [x] `node scripts/check-docs-drift.mjs` — confirms no doc/flag/command drift introduced
- [ ] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — N/A, this PR changes only YAML comments (no code, no new branches, no existing test references `alertmanager.yml`)

If any required check was skipped, explain why:

- This is a comment-only change inside `alertmanager/alertmanager.yml` (a packaged self-host template, not application source under `src/`). It touches no TypeScript, no route/API/MCP surface, no dependency, and no workflow file, so the UI/worker/MCP/OpenAPI/audit checks above don't apply to this diff. I instead ran the two checks that actually exercise this file: the repo's own observability-config validator and the docs-drift checker, plus `npm run typecheck` to confirm nothing else regressed.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no such changes.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no such changes.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section below with screenshots. — N/A, no visible UI change (this is a YAML comment in a self-host config template, not a UI surface).
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (The linked self-hosting Operations doc already documents Alerting fully; this PR only makes the config template point at it correctly. `CHANGELOG.md` is untouched.)

## UI Evidence

N/A — no visible UI, frontend, or docs-route change. This PR edits comments inside `alertmanager/alertmanager.yml` only; the doc page it now references already exists and is unchanged.

## Notes

- Closes #4002 (scoped narrowly to that issue's item 2/3 — documenting the exact receiver-setup path and pointing the template at the real doc section; item 1's startup-WARN alternative and item 3's edge-us-01 confirmation are left for a follow-up since they're behavioral, not documentation, changes).
