### PR TITLE
fix(review): ignore absent bot-owned required checks

### DIFF
--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -2485,6 +2485,10 @@ function isOwnGitHubAppCheckRun(env: Env, run: { name: string; app?: { slug?: st
   return ownSlug.length > 0 && appSlug === ownSlug && BOT_OWNED_CHECK_NAMES.has(run.name);
 }
 
+function isBotOwnedRequiredContextName(name: string): boolean {
+  return BOT_OWNED_CHECK_NAMES.has(name);
+}
+
 function normalizeCiContextName(name: string): string {
   const trimmed = name.trim();
   const slashIndex = trimmed.lastIndexOf("/");
@@ -2813,6 +2817,9 @@ async function reduceLiveCiAggregate(
   // A required context that never appeared in any result is not safe to treat as passed — count it as pending.
   if (enforceRequiredOnly) {
     for (const ctx of requiredContexts!) {
+      // The app creates these check-runs as part of review/public-surface publication. If branch protection
+      // requires one before the first run exists, treating its absence as CI to wait on self-deadlocks the review.
+      if (isBotOwnedRequiredContextName(ctx)) continue;
       if (!seenContextNames.has(ctx)) {
         anyPending = true;
         anyMissingRequiredContext = true;

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -57,6 +57,7 @@ import {
   setGitHubResponseCache,
   type CachedGitHubResponse,
 } from "../../src/github/client";
+import { GITTENSORY_CONTEXT_CHECK_NAME, GITTENSORY_GATE_CHECK_NAME, GITTENSORY_LEGACY_GATE_CHECK_NAME } from "../../src/review/check-names";
 import { normalizeRegistryPayload } from "../../src/registry/normalize";
 import { persistRegistrySnapshot } from "../../src/registry/sync";
 import { renderMetrics, resetMetrics } from "../../src/selfhost/metrics";
@@ -4740,6 +4741,29 @@ describe("GitHub backfill", () => {
         // observed activity — distinct from hasVisiblePending, which stays false here (nothing is actively
         // queued/in_progress; the context simply never posted at all).
         expect(aggregate.hasMissingRequiredContext).toBe(true);
+        expect(aggregate.hasVisiblePending).toBe(false);
+      });
+
+      it("does not wait for absent bot-owned required contexts before the app can publish them", async () => {
+        const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+        vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+          const url = input.toString();
+          if (url.includes("/check-runs?")) return Response.json({ check_runs: [{ name: "build", status: "completed", conclusion: "success" }] });
+          if (url.includes("/status?")) return Response.json({ statuses: [] });
+          return new Response("not found", { status: 404 });
+        });
+
+        const requiredContexts = mergeRequiredCiContexts(null, [
+          "build",
+          GITTENSORY_GATE_CHECK_NAME,
+          GITTENSORY_LEGACY_GATE_CHECK_NAME,
+          GITTENSORY_CONTEXT_CHECK_NAME,
+        ]);
+        const aggregate = await fetchLiveCiAggregate(env, "JSONbored/gittensory", "abc123", "public-token", requiredContexts);
+
+        expect(aggregate.ciState).toBe("passed");
+        expect(aggregate.hasPending).toBe(false);
+        expect(aggregate.hasMissingRequiredContext).toBe(false);
         expect(aggregate.hasVisiblePending).toBe(false);
       });
 


### PR DESCRIPTION
### Motivation
- Prevent a self-deadlock where branch-protection can list the Gittensory gate/context checks as required and the review flow then waits forever for checks the app itself posts only later.
- Ensure the readiness/gating logic does not treat the app's own required contexts as missing external CI that must settle before the app can publish its pending Gate check.

### Description
- Added `isBotOwnedRequiredContextName` to recognize bot-owned required-context names (`Gittensory Orb Review Agent`, legacy gate, and `Gittensory Context`).
- In `reduceLiveCiAggregate` (REST aggregate), skip bot-owned required context names when classifying a required context that "never appeared" so they are not counted as `hasMissingRequiredContext` or held as `anyPending`.
- Added a regression unit test in `test/unit/backfill.test.ts` that asserts an otherwise-green required-CI set passes when only bot-owned required checks are absent.

### Testing
- Ran `npx vitest run test/unit/backfill.test.ts -t "expectedCiContexts fallback" --reporter=verbose` and the focused backfill tests (including the new regression) passed.
- Ran `npx vitest run test/unit/graphql-status-rollup.test.ts --reporter=verbose` and it passed.
- Ran `npx vitest run test/unit/backfill.test.ts -t "fetchLiveCiAggregate" --reporter=dot` and the targeted suite passed.
- Ran `npm run typecheck` which failed due to pre-existing TypeScript syntax errors in `src/queue/processors.ts` unrelated to this change (the semantic/typecheck failure is external to this patch).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4cd55538bc832cbfd4ec5766aff347)