### PR TITLE
test(queue): assert repair-attempt recording at execution time, not dispatch

### DIFF
--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -6920,6 +6920,11 @@ describe("queue processors", () => {
 
     const fanned = sent.filter((job): job is Extract<import("../../src/types").JobMessage, { type: "agent-regate-pr" }> => job.type === "agent-regate-pr");
     expect(fanned.map((job) => job.deliveryId)).toContain("regate-repair:owner/agent-repo#2");
+    // #orb-retry-storm: the attempt is recorded at EXECUTION time (after rate-limit admission), not at
+    // dispatch time -- a queued-but-not-yet-run job must not count against the cap. Process the fanned-out
+    // job (simulating the queue consumer picking it up) before checking the recorded count.
+    const repairJob = fanned.find((job) => job.deliveryId === "regate-repair:owner/agent-repo#2");
+    await processJob(env, repairJob!);
     const attemptsAfterFirst = await env.DB.prepare("select count(*) as n from audit_events where event_type = ? and target_key = ?")
       .bind("agent.sweep.regate.repair_attempt", targetKey)
       .first<{ n: number }>();


### PR DESCRIPTION
## Summary
- The `#orb-retry-storm` regression test in `test/unit/queue.test.ts` checked the `repair_attempt` audit-event count immediately after `sweepRepoRegate` dispatched the fanned-out job — without ever processing it. That only passes under the OLD dispatch-time recording that #3998/#4023 deliberately replaced with execution-time recording (a queued-but-not-yet-run job must not count against `REGATE_REPAIR_MAX_ATTEMPTS_PER_SHA`).
- Found this while verifying an unrelated PR rebased onto post-#4023 `main`: the test was failing there, tracing back to this stale assumption, not a code regression.
- Fix: process the fanned-out `agent-regate-pr` job before asserting the count, matching the actual (and intended) execution-time design.

## Scope
- [x] Single-purpose, test-only change
- [x] In `wantedPaths` (`test/`)

## Validation
- `npm run typecheck` — clean
- `npx vitest run test/unit/queue.test.ts` — 661/661 passed (was 1 failing before this fix)

## Safety
- [x] No secrets/private terms introduced
- [x] No changes to `site/`, `CNAME`, `lovable/`, or the changelog