### PR TITLE
fix(selfhost): build gittensory-engine before bundling the self-host image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,17 @@ ARG GITTENSORY_VERSION=
 # ECR Public Gallery mirrors Docker Official Images with no rate limits and no auth.
 FROM public.ecr.aws/docker/library/node:24-slim AS build
 WORKDIR /app
-COPY package*.json ./
+# The full source must land BEFORE `npm ci`, not after: this is an npm-workspaces monorepo
+# (workspaces: apps/*, packages/*), and `npm ci` only symlinks node_modules/<pkg> to a workspace whose
+# directory already exists on disk. Copying just the root package*.json first (the usual dependency-layer
+# caching trick) left every workspace package.json missing at `npm ci` time, so npm silently skipped every
+# internal symlink -- @jsonbored/gittensory-engine (a workspace dependency of gittensory-miner's checked-in
+# lib/*.js artifacts, #2281) then couldn't be resolved by esbuild no matter how/when its own dist/ was built.
+COPY . .
 # --ignore-scripts: no native builds are needed (SQLite is the built-in node:sqlite; @hono/node-server is
 # pure JS; esbuild ships its binary as an optional dependency, not a script).
 RUN npm ci --ignore-scripts
-COPY . .
+RUN npm --workspace @jsonbored/gittensory-engine run build
 # --all: bundle every dependency into one self-contained dist/server.mjs, so the runtime image needs no
 # node_modules (≈10× smaller). The bundle has zero `cloudflare:*` imports (stubbed at build), so no loader.
 RUN node scripts/build-selfhost.mjs --all


### PR DESCRIPTION
## Summary
- The self-host Docker build (`build + boot smoke test` CI job) is currently failing for every open PR: esbuild can't resolve `@jsonbored/gittensory-engine` while bundling `gittensory-miner`'s checked-in `lib/*.js` artifacts (#2281 extracted their reward-risk scoring into this workspace package).
- Two compounding problems, confirmed by reproducing the exact failure both locally and via `docker build`:
  1. `gittensory-engine` ships no committed `dist/` — nothing built it before the self-host bundle step ran.
  2. The Dockerfile copied only the root `package*.json` before `npm ci` (the usual dependency-layer caching trick), so no workspace `package.json` existed yet for npm to resolve — it silently skipped every workspace symlink under `node_modules`, including `gittensory-engine`'s. Building the engine afterward alone wasn't enough: esbuild couldn't find the module at all (not just its `dist/`), since the symlink itself never existed.
- Fix: copy the full source before `npm ci` so workspace symlinks resolve correctly, then explicitly build `gittensory-engine` before the self-host bundle step runs.

## Scope
- [x] Single-purpose, `Dockerfile`-only
- [x] Not `wantedPaths`-restricted (build config)

## Validation
- Reproduced the exact CI failure locally and via `docker build --target build` on a clean checkout of `origin/main`
- `docker build --target build --no-cache` — now succeeds (engine builds, self-host bundle builds, sourcemap validates)
- Full multi-stage `docker build` (build + runtime-base + runtime) — succeeds end to end
- `npm run typecheck` — clean

## Safety
- [x] No secrets/private terms introduced
- [x] No changes to `site/`, `CNAME`, `lovable/`, or the changelog