### PR TITLE
fix(ci): build engine package before running backend tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -265,6 +265,16 @@ jobs:
       - name: Typecheck
         if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' }}
         run: npm run typecheck
+      # Moved ahead of "Test with coverage" (#ci-engine-build-order): src/mcp/find-opportunities.ts (root
+      # backend, since #2281/#3985) imports packages/gittensory-miner/lib/opportunity-fanout.js -- committed,
+      # pre-built JS -- which itself imports @jsonbored/gittensory-engine. That package's dist/ is gitignored
+      # and only exists after this build step, so ANY backend test run needs it built first, not just a PR
+      # that happens to touch packages/gittensory-engine/** directly (this step's original, too-narrow
+      # trigger, back when the two packages were still independent). Running late (its original position,
+      # after coverage) meant test:coverage failed to resolve the package on every PR that didn't touch it.
+      - name: Build engine package
+        if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.engine == 'true' }}
+        run: npm run build --workspace @jsonbored/gittensory-engine
       - name: Prepare test reports dir
         if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' }}
         run: mkdir -p reports/junit
@@ -392,9 +402,6 @@ jobs:
       - name: MCP package check
         if: ${{ github.event_name == 'push' || needs.changes.outputs.mcp == 'true' }}
         run: npm run test:mcp-pack
-      - name: Build engine package
-        if: ${{ github.event_name == 'push' || needs.changes.outputs.engine == 'true' }}
-        run: npm run build --workspace @jsonbored/gittensory-engine
       - name: Build miner CLI
         if: ${{ github.event_name == 'push' || needs.changes.outputs.miner == 'true' }}
         run: npm run build:miner


### PR DESCRIPTION
## Summary
- `src/mcp/find-opportunities.ts` (root backend file) imports `packages/gittensory-miner/lib/opportunity-fanout.js` (committed, pre-built JS), which itself imports `@jsonbored/gittensory-engine`.
- `@jsonbored/gittensory-engine`'s `dist/` output is gitignored and only exists after the "Build engine package" CI step runs.
- That step ran **after** `Test with coverage` and was gated only on the narrow `packages/gittensory-engine/**` path filter — so any ordinary backend PR that didn't touch the engine package directly failed with `Failed to resolve entry for package "@jsonbored/gittensory-engine"` across ~48 test suites.
- Moved the build step to run right after `Typecheck` (before test execution) and widened its trigger to also fire on any `backend` path change, in addition to `push` and the existing `engine` path filter.

## Test plan
- [x] `npm run actionlint` — clean
- [x] Reproduced the failure locally: `rm -rf packages/gittensory-engine/dist && npx vitest run test/unit/mcp-server-telemetry.test.ts` failed identically to the CI log
- [x] Built the engine package and re-ran the same test — passed (3/3)