### PR TITLE
feat(review): render single-line ```suggestion block on inline comments (#2139)

### DIFF
--- a/src/review/inline-comments.ts
+++ b/src/review/inline-comments.ts
@@ -92,7 +92,7 @@ export type ReviewInlineComment = {
  *  {@link anchoredSuggestionBlock} for anchor-safety and fence validation (#2140 / #1956). */
 
 /** The inline comment body: a compact severity (+ optional category) label + the finding, plus a one-click GitHub
- *  suggested-change block when the finding carries a `suggestion` AND the caller has suggestions enabled (#1956).
+ *  suggested-change block when the finding carries a `suggestion` AND the caller has suggestions enabled (#1956 / #2139).
  *  When `categoriesEnabled` (#1958 / #2149), the label carries a title-cased category tag (`Blocker · Security`) —
  *  the model's own `category` when it emitted one in the fixed enum, else the deterministic fallback
  *  (`classifyFindingCategory`), so the tag is never sometimes-present. Public-safe by construction — both the body

--- a/test/unit/inline-comments.test.ts
+++ b/test/unit/inline-comments.test.ts
@@ -132,7 +132,7 @@ describe("selectInlineComments (#inline-comments)", () => {
     expect(selectInlineComments(many, bigFiles)).toHaveLength(10);
   });
 
-  describe("suggestion blocks (#1956)", () => {
+  describe("suggestion blocks (#1956 / #2139)", () => {
     const withSuggestion: InlineFinding = { path: "src/a.ts", line: 2, severity: "nit", body: "Use const.", suggestion: "const x = 1;" };
 
     it("defaults to OFF (backward compatible) — a suggestion is never rendered when the third argument is omitted", () => {
@@ -148,6 +148,21 @@ describe("selectInlineComments (#inline-comments)", () => {
     it("renders a GitHub-native suggested-change block when enabled and the finding carries a suggestion", () => {
       const out = selectInlineComments([withSuggestion], files, true);
       expect(out[0]?.body).toBe("**Nit:** Use const.\n\n```suggestion\nconst x = 1;\n```");
+    });
+
+    it("preserves multi-line suggestion text verbatim inside the fence and keeps the severity label first (#2139)", () => {
+      const multiLine: InlineFinding = {
+        path: "src/a.ts",
+        line: 2,
+        severity: "blocker",
+        body: "Split this statement.",
+        suggestion: "const x = 1;\nconst y = 2;",
+      };
+      const out = selectInlineComments([multiLine], files, true);
+      expect(out[0]?.body).toBe(
+        "**Blocker:** Split this statement.\n\n```suggestion\nconst x = 1;\nconst y = 2;\n```",
+      );
+      expect(out[0]?.body.startsWith("**Blocker:**")).toBe(true);
     });
 
     it("renders no suggestion block (finding text only) when enabled but the finding has none", () => {

--- a/test/unit/inline-suggestion-anchor.test.ts
+++ b/test/unit/inline-suggestion-anchor.test.ts
@@ -90,5 +90,10 @@ describe("anchoredSuggestionBlock (#2140)", () => {
       anchoredSuggestionBlock({ ...withSuggestion, suggestion: "```\nescape\n```" }, true, addedLines),
     ).toBe("");
     expect(safeSuggestionBlock(undefined)).toBe("");
+    expect(safeSuggestionBlock("")).toBe("");
+  });
+
+  it("preserves multi-line suggestion text verbatim inside the fence (#2139)", () => {
+    expect(safeSuggestionBlock("line1\nline2")).toBe("\n\n```suggestion\nline1\nline2\n```");
   });
 });


### PR DESCRIPTION
## Summary

Closes #2139. The `formatInlineBody` → `anchoredSuggestionBlock` → `safeSuggestionBlock` pipeline already renders GitHub-native ` ```suggestion ` fences when `review.suggestions` is enabled (landed via #1956 / #3577, with added-line anchor safety via #2140). This PR completes the remaining #2139 acceptance criteria:

- Adds explicit tests that **multi-line suggestion text is preserved verbatim** inside the fence (single-line anchor only; multi-line *ranges* remain out of scope per the issue).
- Adds an empty-string guard regression on `safeSuggestionBlock`.
- Cross-references #2139 in `formatInlineBody` docs and the inline-comment test suite.

## Deliverables checklist (#2139)

- [x] `formatInlineBody` appends a fenced ` ```suggestion ` block when `finding.suggestion` is set and suggestions are enabled
- [x] Public-safe by construction (suggestion filtered upstream by `composeInlineFindings`)
- [x] No block when suggestion is absent (byte-identical to pre-suggestion behavior)
- [x] Tests: with/without suggestion, fence formatting, multi-line text verbatim, severity label leads the body

## Test plan

- [x] `npx vitest run test/unit/inline-comments.test.ts test/unit/inline-suggestion-anchor.test.ts`
- [x] `npx tsc --noEmit`
- [x] 100% line/branch coverage on `inline-comments.ts` + `inline-suggestion-anchor.ts` (patch-local)
