### PR TITLE
test(config): lock in includeMaintainerAuthors manifest resolver parity

### DIFF
--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -2332,6 +2332,28 @@ describe("parseFocusManifest settings override + resolveEffectiveSettings", () =
     expect(eff.badgeEnabled).toBe(true); // settings: override wins over the DB-stored value
   });
 
+  it("wires settings.includeMaintainerAuthors into the manifest parser and resolver (#2052)", () => {
+    const parsedTrue = parseFocusManifest({ settings: { includeMaintainerAuthors: true } });
+    expect(parsedTrue.settings.includeMaintainerAuthors).toBe(true);
+    expect(parsedTrue.warnings).toEqual([]);
+    const parsedFalse = parseFocusManifest({ settings: { includeMaintainerAuthors: false } });
+    expect(parsedFalse.settings.includeMaintainerAuthors).toBe(false);
+
+    const invalid = parseFocusManifest({ settings: { includeMaintainerAuthors: "yes" } });
+    expect(invalid.settings.includeMaintainerAuthors).toBeUndefined();
+    expect(invalid.warnings.some((w) => /settings\.includeMaintainerAuthors/.test(w))).toBe(true);
+
+    const db = { includeMaintainerAuthors: false } as unknown as RepositorySettings;
+    const eff = resolveEffectiveSettings(db, parseFocusManifest({ settings: { includeMaintainerAuthors: true } }));
+    expect(eff.includeMaintainerAuthors).toBe(true);
+
+    const noOverride = resolveEffectiveSettings({ includeMaintainerAuthors: true } as unknown as RepositorySettings, parseFocusManifest({}));
+    expect(noOverride.includeMaintainerAuthors).toBe(true);
+
+    const reparsed = parseFocusManifest({ settings: settingsOverrideToJson(parsedTrue.settings) });
+    expect(reparsed.settings.includeMaintainerAuthors).toBe(true);
+  });
+
   it("wires settings.publicQualityMetrics into the manifest parser and lets it override the DB value (#2568)", () => {
     const parsedTrue = parseFocusManifest({ settings: { publicQualityMetrics: true } });
     expect(parsedTrue.settings.publicQualityMetrics).toBe(true);


### PR DESCRIPTION
## Summary

Closes the remaining deliverable for #2052: resolver coverage for `settings.includeMaintainerAuthors`.

The parser key, `settingsOverrideToJson` round-trip, and `.gittensory.yml.example` documentation were already present on `main`; this PR adds the missing unit tests proving manifest override wins over DB, unset falls back, and wrong-type values warn.

Closes #2052

## Validation

```sh
npm test -- test/unit/focus-manifest.test.ts
```

Focused test: `wires settings.includeMaintainerAuthors into the manifest parser and resolver (#2052)` — 521 tests in file pass.