### PR TITLE
fix(ci): build engine package before the release self-host bundle

### DIFF
--- a/.github/workflows/release-selfhost.yml
+++ b/.github/workflows/release-selfhost.yml
@@ -99,6 +99,14 @@ jobs:
       - name: Install deps
         run: npm ci --ignore-scripts
 
+      # #ci-engine-build-order (release pipeline): --all bundles EVERYTHING self-contained, including
+      # packages/gittensory-miner/lib/*.js (committed, pre-built) which imports @jsonbored/gittensory-engine.
+      # That package's dist/ is gitignored and only exists after this build step -- the regular CI smoke
+      # test's narrower (non --all) build never hits this import chain, so it never caught the gap that
+      # ci.yml's own validate-code job hit for ordinary backend PRs (fixed there separately).
+      - name: Build engine package
+        run: npm run build --workspace @jsonbored/gittensory-engine
+
       - name: Build self-host bundle for release
         run: node scripts/build-selfhost.mjs --all
 


### PR DESCRIPTION
## Summary

No issue: this is a maintainer-authored release-engineering fix for a live release failure (cutting orb-v0.4.0-beta.2), not a pre-planned feature — filing a tracking issue for a one-line CI fix already reproduced and verified below didn't seem warranted.

- `release-selfhost.yml`'s `--all` bundle mode (the self-contained Docker image build) hit the same `@jsonbored/gittensory-engine` resolution gap that `ci.yml`'s `validate-code` job was fixed for earlier today (#4036): `packages/gittensory-miner/lib/*.js` (committed, pre-built) imports the engine package, whose `dist/` is gitignored and only exists after an explicit build step.
- The regular `selfhost.yml` smoke test's narrower (non `--all`) build never touches that import chain, so it never caught this — only the release pipeline's full self-contained bundle does.
- Discovered when cutting `orb-v0.4.0-beta.2` failed with `Could not resolve "@jsonbored/gittensory-engine"` on `node scripts/build-selfhost.mjs --all`.

## Test plan
- [x] `npm run actionlint` — clean
- [x] Reproduced the failure locally: `rm -rf packages/gittensory-engine/dist && node scripts/build-selfhost.mjs --all` fails identically to the release run
- [x] Built the engine package and re-ran the same command — succeeds