### PR TITLE
fix(config): preserve explicit `review` overrides (null/non-mapping) when merging private layers

### DIFF
--- a/src/selfhost/private-config.ts
+++ b/src/selfhost/private-config.ts
@@ -126,6 +126,10 @@ function stripReviewKey(mapping: Record<string, unknown>): Record<string, unknow
   return rest;
 }
 
+function hasReviewKey(mapping: Record<string, unknown>): boolean {
+  return Object.prototype.hasOwnProperty.call(mapping, "review");
+}
+
 function extractReviewMapping(mapping: Record<string, unknown>): Record<string, unknown> | null {
   const { review } = mapping;
   if (review === undefined || review === null) return null;
@@ -207,10 +211,10 @@ function combineConfigLayersWithMeta(
 
   let mergedReview: unknown;
   for (const layer of parsedLayers) {
-    const review = extractReviewMapping(layer.mapping);
-    if (review === null) continue;
+    if (!hasReviewKey(layer.mapping)) continue;
+    const { review } = layer.mapping;
     mergedReview = mergedReview === undefined ? review : mergeConfigOverlay(mergedReview, review);
-    if (layer.kind === "shared" && layer.sourcePath) sharedConfigSource = layer.sourcePath;
+    if (layer.kind === "shared" && extractReviewMapping(layer.mapping) && layer.sourcePath) sharedConfigSource = layer.sourcePath;
   }
   if (mergedReview !== undefined) mergedBody.review = mergedReview;
 

--- a/test/unit/private-config.test.ts
+++ b/test/unit/private-config.test.ts
@@ -429,6 +429,33 @@ describe("makeLocalManifestReader — review.shared_config overlay (#2046)", () 
     expect(manifest.review.securityFocus).toBe(true);
   });
 
+  it("lets a higher-priority review null clear an inherited shared review block", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "gt-repo-config-"));
+    mkdirSync(join(dir, "_shared"));
+    writeFileSync(join(dir, "_shared", ".gittensory.yml"), "review:\n  footer:\n    text: shared footer\n  tone: house-tone\n");
+    mkdirSync(join(dir, "repo"));
+    writeFileSync(join(dir, "repo", ".gittensory.yml"), "review: null\n");
+    const loaded = await readLocalManifestLoad(makeLocalManifestReader(dir)!, "owner/repo");
+    const manifest = parseFocusManifestContent(loaded!.content!);
+    expect(manifest.review.present).toBe(false);
+    expect(manifest.review.footerText).toBeNull();
+    expect(manifest.review.tone).toBeNull();
+  });
+
+  it("lets a higher-priority non-mapping review value replace an inherited shared review block", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "gt-repo-config-"));
+    mkdirSync(join(dir, "_shared"));
+    writeFileSync(join(dir, "_shared", ".gittensory.yml"), "review:\n  footer:\n    text: shared footer\n  tone: house-tone\n");
+    mkdirSync(join(dir, "repo"));
+    writeFileSync(join(dir, "repo", ".gittensory.yml"), "review: false\n");
+    const loaded = await readLocalManifestLoad(makeLocalManifestReader(dir)!, "owner/repo");
+    const manifest = parseFocusManifestContent(loaded!.content!);
+    expect(manifest.review.present).toBe(false);
+    expect(manifest.review.footerText).toBeNull();
+    expect(manifest.review.tone).toBeNull();
+    expect(manifest.warnings).toContain('Manifest field "review" must be a mapping; ignoring it.');
+  });
+
   it("sets sharedConfigSource when only the shared base is present for a repo", async () => {
     const dir = mkdtempSync(join(tmpdir(), "gt-repo-config-"));
     mkdirSync(join(dir, "_shared"));


### PR DESCRIPTION
### Motivation
- The private-config merge special-cased `review` and treated `review: null` or other non-mapping values as if the key were absent, which allowed a lower-priority shared `review` block to survive a higher-priority explicit clear/replace signal.
- This could expose shared review output (e.g. custom footer text) on a repo where an operator intended to opt out at a higher-priority layer.

### Description
- Change `combineConfigLayersWithMeta` to detect the presence of the top-level `review` key and preserve its explicit override (including `null` and non-mapping values) when folding layers, by adding `hasReviewKey` and using it when iterating layers.
- Keep `sharedConfigSource` provenance only when the shared layer actually contributes a mapping-shaped `review` (use `extractReviewMapping` to confirm contribution).
- Add two regression unit tests in `test/unit/private-config.test.ts` to assert that `review: null` clears an inherited shared review block and that a non-mapping `review` (e.g. `false`) replaces/blocks the shared review while emitting the expected warning.
- Files modified: `src/selfhost/private-config.ts` and `test/unit/private-config.test.ts`.

### Testing
- Ran the focused unit suite: `npx vitest run test/unit/private-config.test.ts`, and the updated tests passed (62 tests passed).
- Ran `git diff --check` which reported no whitespace/conflict issues.
- Ran `npm run typecheck` which failed due to unrelated existing syntax errors in `src/queue/processors.ts` outside the changed files, not introduced by this change.
- Ran a targeted coverage run `npm run test:coverage -- --run test/unit/private-config.test.ts` where tests passed but coverage remapping failed with `TypeError: jsTokens is not a function` (coverage toolchain remap issue, unrelated to logic change); `npm audit --audit-level=moderate` hit a registry `403 Forbidden` during the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4cd5552a34832cb0e96fd85e145dcd)