### PR TITLE
fix(commands): honor pause for configuration comments

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -11113,14 +11113,14 @@ async function maybeProcessConfigurationCommand(
     return true;
   }
   const mode = resolveAgentActionMode({
-    globalPaused: isGlobalAgentPause(env),
+    globalPaused: isGlobalAgentPause(env) || (await isGlobalAgentFrozen(env)),
     agentPaused: settings.agentPaused,
     agentDryRun: settings.agentDryRun,
   });
   const body = sanitizePublicComment(
     [AGENT_COMMAND_COMMENT_MARKER, "", summarizeEffectiveConfig(settings, mode), "", "---", gittensoryFooter()].join("\n"),
   );
-  await createIssueComment(env, req.installationId, req.repoFullName, req.issueNumber, body);
+  await createOrUpdateAgentCommandComment(env, req.installationId, req.repoFullName, req.issueNumber, body, mode);
   await recordAuditEvent(env, {
     eventType: "github_app.configuration_posted",
     actor: req.actor,

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -53,6 +53,7 @@ import {
   markAiReviewPublished,
   recordReviewSuppression,
   listReviewSuppressions,
+  setGlobalAgentFrozen,
 } from "../../src/db/repositories";
 import { agentMaintenanceHeadMatchesGate, changedPathsForGuardrail, claimAiReviewLock, claimPrActuationLock, contributorEvidenceBatchSize, enrichOpenPullRequestsWithChangedFiles, processJob, reconcileLiveDuplicateSiblings, releaseAiReviewLock, releasePrActuationLock, SWEEP_FANOUT_RESOLUTION_CONCURRENCY } from "../../src/queue/processors";
 import type { PullRequestRecord } from "../../src/types";
@@ -10752,9 +10753,11 @@ describe("queue processors", () => {
     let postedBody: string | undefined;
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = input.toString();
+      const method = init?.method ?? "GET";
       if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
       if (url.includes("/collaborators/") && url.includes("/permission")) return Response.json({ permission: "admin" }); // maintainer
-      if (url.includes("/issues/77/comments")) {
+      if (url.includes("/issues/77/comments") && method === "GET") return Response.json([]);
+      if (url.includes("/issues/77/comments") && method === "POST") {
         postedBody = init?.body ? JSON.parse(init.body.toString()).body : undefined;
         return Response.json({ id: 5 }, { status: 201 });
       }
@@ -10768,6 +10771,36 @@ describe("queue processors", () => {
     expect(postedBody?.toLowerCase()).not.toMatch(/reward|wallet|hotkey|coldkey|trustscore/);
     const audit = await env.DB.prepare("select outcome from audit_events where event_type = ?").bind("github_app.configuration_posted").first<{ outcome: string }>();
     expect(audit?.outcome).toBe("completed");
+  });
+
+  it.each([
+    ["env pause", async (env: Env) => { (env as Env & { AGENT_ACTIONS_PAUSED: string }).AGENT_ACTIONS_PAUSED = "true"; }, "paused"],
+    ["repo pause", async (env: Env) => { await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", agentPaused: true }); }, "paused"],
+    ["repo dry-run", async (env: Env) => { await upsertRepositorySettings(env, { repoFullName: "JSONbored/gittensory", agentDryRun: true }); }, "dry_run"],
+    ["DB global freeze", async (env: Env) => { await setGlobalAgentFrozen(env, true); }, "paused"],
+  ] as const)("configuration respects %s — never posts the effective-config comment live", async (_label, applyPause, expectedMode) => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await setupPlannerRepo(env);
+    await applyPause(env);
+    const calls = { commentPosts: 0 };
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/collaborators/") && url.includes("/permission")) return Response.json({ permission: "admin" });
+      if (url.includes("/issues/77/comments") && method === "GET") return Response.json([]);
+      if (url.includes("/issues/77/comments") && method === "POST") {
+        calls.commentPosts += 1;
+        return Response.json({ id: 5 }, { status: 201 });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    await processJob(env, plannerWebhook("@gittensory configuration", "maintainer1"));
+
+    expect(calls.commentPosts).toBe(0);
+    const audit = await env.DB.prepare("select json_extract(metadata_json, '$.mode') as mode from audit_events where event_type = ?").bind("github_app.configuration_posted").first<{ mode: string }>();
+    expect(audit?.mode).toBe(expectedMode);
   });
 
   it("configuration: a non-maintainer is denied — nothing is posted and a skip is recorded", async () => {


### PR DESCRIPTION
### Motivation
- Prevent the `@gittensory configuration` handler from performing a live GitHub comment when agent actions are paused, in dry-run, or globally frozen by the DB.
- Ensure the displayed/audited mode reflects the DB-backed global freeze in addition to env/repo pause/dry-run settings.
- Restore a few malformed regate/queue wiring sites that broke typechecking and test loading.

### Description
- In `src/queue/processors.ts` the effective `mode` is now resolved with `globalPaused: isGlobalAgentPause(env) || (await isGlobalAgentFrozen(env))` and the handler routes the response through the mode-aware `createOrUpdateAgentCommandComment(..., mode)` instead of the live-only `createIssueComment`.
- Fixed several regate/fan-out call-site wiring issues so the per-PR job payload and retry metadata are correctly constructed and the function signatures are ordered to satisfy TypeScript.
- Updated `test/unit/queue.test.ts` to account for the marker-search `GET` probe in the mode-aware helper and added regression tests (`it.each`) that assert env pause, repo pause, repo `agentDryRun`, and DB global freeze prevent live comment posts while preserving the audited `mode` metadata.
- Added an import/use of `setGlobalAgentFrozen` in tests to exercise the DB freeze path.

### Testing
- Ran `git diff --check` which produced no whitespace/conflict issues and was successful.
- Ran targeted tests with `npx vitest run test/unit/queue.test.ts -t "configuration"` and the modified unit tests passed (the test file ran and the configuration-related tests succeeded).
- Ran type checking with `npm run typecheck` and it completed with no TypeScript errors.
- Attempted `npm audit --audit-level=moderate` but the npm audit endpoint returned `403 Forbidden` in this environment so the audit could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4cd5552cf4832cab397170b78afa5c)