### PR TITLE
fix(review): harden impact map path markdown

### DIFF
--- a/src/review/unified-comment-bridge.ts
+++ b/src/review/unified-comment-bridge.ts
@@ -571,17 +571,19 @@ export type ImpactMapSummaryInput = { changedModule: string; affectedModules: st
  *  as a trailing "+N more" instead of silently truncating with no indication more exist. */
 const MAX_RENDERED_AFFECTED_MODULES = 5;
 
-/** Public-safe inline-code escaping for a file path cell — mirrors `buildBeforeAfterCollapsible`'s
- *  `markdownCode`: backtick/backslash/pipe/angle-bracket neutralized so an adversarial path can't break out of
- *  the table or the inline-code span. Impact-map paths originate from the repo's own RAG-indexed file tree
- *  (never raw user input), but this is defense-in-depth, matching the discipline every other path-rendering
- *  helper in this file already applies. */
+/** Public-safe inline-code rendering for a file path table cell. Impact-map paths can include
+ *  contributor-controlled filenames, so choose a code-span delimiter longer than any run inside the
+ *  value instead of trying to backslash-escape backticks (Markdown does not honor that inside code spans).
+ *  Normalize row-breaking controls and entity-escape table/HTML metacharacters before wrapping. */
 function markdownPathCode(value: string): string {
-  return `\`${value
-    .replace(/\\/g, "\\\\")
-    .replace(/`/g, "\\`")
-    .replace(/\|/g, "\\|")
-    .replace(/[<>]/g, (char) => (char === "<" ? "&lt;" : "&gt;"))}\``;
+  const safeValue = value
+    .replace(/[\r\n]+/g, " ")
+    .replace(/[\u0000-\u0008\u000B\u000C\u000E-\u001F\u007F]/g, " ")
+    .replace(/\|/g, "&#124;")
+    .replace(/[<>]/g, (char) => (char === "<" ? "&lt;" : "&gt;"));
+  const longestBacktickRun = Math.max(0, ...Array.from(safeValue.matchAll(/`+/g), (match) => match[0].length));
+  const delimiter = "`".repeat(longestBacktickRun + 1);
+  return `${delimiter} ${safeValue} ${delimiter}`;
 }
 
 /**

--- a/test/unit/impact-map-collapsible.test.ts
+++ b/test/unit/impact-map-collapsible.test.ts
@@ -30,24 +30,24 @@ describe("buildImpactMapCollapsible (#2185)", () => {
     expect(c).not.toBeNull();
     expect(c?.title).toBe("Impact map");
     expect(c?.body).toContain("| Changed module | Symbols | Plausibly affected |");
-    expect(c?.body).toContain("`src/review/impact-map.ts`");
+    expect(c?.body).toContain("` src/review/impact-map.ts `");
     expect(c?.body).toContain("computeImpactMap");
-    expect(c?.body).toContain("`src/review/impact-map-wire.ts`");
-    expect(c?.body).toContain("`src/queue/processors.ts`");
+    expect(c?.body).toContain("` src/review/impact-map-wire.ts `");
+    expect(c?.body).toContain("` src/queue/processors.ts `");
   });
 
   it("renders a dash for callers when a row somehow has none", () => {
     const c = buildImpactMapCollapsible([{ changedModule: "src/a.ts", affectedModules: ["src/b.ts"], callers: [] }]);
-    expect(c?.body).toContain("| `src/a.ts` | — |");
+    expect(c?.body).toContain("| ` src/a.ts ` | — |");
   });
 
   it("caps rendered affected modules with a '+N more' overflow line", () => {
     const many = Array.from({ length: 8 }, (_, i) => `src/caller${i}.ts`);
     const c = buildImpactMapCollapsible([{ changedModule: "src/a.ts", affectedModules: many, callers: ["a"] }]);
     const body = c?.body ?? "";
-    expect(body).toContain("`src/caller0.ts`");
-    expect(body).toContain("`src/caller4.ts`");
-    expect(body).not.toContain("`src/caller5.ts`");
+    expect(body).toContain("` src/caller0.ts `");
+    expect(body).toContain("` src/caller4.ts `");
+    expect(body).not.toContain("src/caller5.ts");
     expect(body).toContain("(+3 more)");
   });
 
@@ -58,7 +58,23 @@ describe("buildImpactMapCollapsible (#2185)", () => {
 
   it("escapes a hostile-looking path so it can't break out of the table/inline-code span", () => {
     const c = buildImpactMapCollapsible([{ changedModule: "src/`weird|<path>.ts", affectedModules: ["src/b.ts"], callers: ["a"] }]);
-    expect(c?.body).toContain("src/\\`weird\\|&lt;path&gt;.ts");
+    expect(c?.body).toContain("`` src/`weird&#124;&lt;path&gt;.ts ``");
+  });
+
+  it("normalizes path newlines so attacker markdown stays in the impact-map table row", () => {
+    const c = buildImpactMapCollapsible([
+      {
+        changedModule: "src/safe`\r\n\n### fake bot guidance\n[run patch](https://evil.example/pwn).ts",
+        affectedModules: ["src/also`unsafe\n|spoof.ts"],
+        callers: ["a"],
+      },
+    ]);
+    const body = c?.body ?? "";
+
+    expect(body).toContain("`` src/safe` ### fake bot guidance [run patch](https://evil.example/pwn).ts ``");
+    expect(body).toContain("`` src/also`unsafe &#124;spoof.ts ``");
+    expect(body).not.toContain("\n### fake bot guidance");
+    expect(body).not.toContain("\n|spoof.ts");
   });
 
   it("returns null for an empty entry list (no empty table)", () => {


### PR DESCRIPTION
### Motivation

- The impact-map rows previously wrapped contributor-controlled file paths in single-backtick code spans and attempted to backslash-escape embedded backticks, which is insufficient to prevent Markdown breakout and allowed attacker-crafted filenames to inject Markdown into trusted PR comments.
- Filenames can include CR/LF and other control characters that break table rows and permit content injection unless normalized and rendered defensively.

### Description

- Replaced the prior backslash-escaping strategy with a safe renderer that normalizes CR/LF and other control characters, entity-escapes table/HTML metacharacters, computes the longest run of backticks in the value, and uses a code-span delimiter of length `longestBacktickRun + 1` so embedded backticks cannot close the span (see `markdownPathCode` in `src/review/unified-comment-bridge.ts`).
- Continued to use the hardened `markdownPathCode` for both changed-module and affected-module cells so all impact-map paths are consistently protected.
- Added regression tests in `test/unit/impact-map-collapsible.test.ts` that assert safe rendering for hostile filenames containing backticks, pipes, angle-brackets, and newline-separated Markdown content.

### Testing

- Ran `npx vitest run test/unit/impact-map-collapsible.test.ts` and the unit suite passed (15 tests passed).
- Ran `npm run typecheck` (i.e., `tsc --noEmit`) and type checking passed without errors.
- `git diff --check` was run and returned no issues.
- Attempted coverage with `npx vitest run ... --coverage` and the tests executed but coverage remapping failed with `TypeError: jsTokens is not a function` (coverage remapping error outside this change); and `npm audit --audit-level=moderate` failed due to the registry audit endpoint returning `403 Forbidden` (environmental/registry issue rather than a code regression).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d88b03cd8832cbb75e6ff4a4f7ef2)