### PR TITLE
fix(review): escape fix handoff paths

### DIFF
--- a/src/review/fix-handoff-render.ts
+++ b/src/review/fix-handoff-render.ts
@@ -33,13 +33,25 @@ export type FixHandoffBlock = {
  *  parse fix-handoff blocks in a comment body without depending on markdown structure alone. */
 const FIX_HANDOFF_MARKER = "<!-- gittensory:fix-handoff -->";
 
+/** Public-safe inline-code escaping for a finding path/location. GitHub comments still render markdown inside
+ *  collapsibles, so neutralize delimiters that can break out of the `...` span or table-like contexts before
+ *  composing the location label. */
+function markdownPathCodeText(value: string): string {
+  return value
+    .replace(/\\/g, "\\\\")
+    .replace(/`/g, "\\`")
+    .replace(/\|/g, "\\|")
+    .replace(/[<>]/g, (char) => (char === "<" ? "&lt;" : "&gt;"));
+}
+
 /** PURE: build a single finding's fix-handoff block. Never throws; a finding whose `line` is not a positive
  *  integer (0, negative, non-finite — i.e. "no commentable line") still yields a valid PATH-ONLY block rather
  *  than being dropped, since the finding itself is still actionable context even without a line anchor. */
 export function buildFixHandoffBlock(finding: InlineFinding): FixHandoffBlock {
   const hasLine = Number.isInteger(finding.line) && finding.line > 0;
   const line = hasLine ? finding.line : 0;
-  const location = hasLine ? `${finding.path}:${line}` : `${finding.path} (no specific line)`;
+  const safePath = markdownPathCodeText(finding.path);
+  const location = hasLine ? `${safePath}:${line}` : `${safePath} (no specific line)`;
   const label = finding.severity === "blocker" ? "Blocker" : "Nit";
   const suggestedChange = finding.suggestion?.trim() || undefined;
   const suggestionBlock = suggestedChange ? `\n\nSuggested change:\n\`\`\`\n${suggestedChange}\n\`\`\`` : "";

--- a/test/unit/fix-handoff-collapsible.test.ts
+++ b/test/unit/fix-handoff-collapsible.test.ts
@@ -44,6 +44,21 @@ describe("buildFixHandoffCollapsible (#1962)", () => {
     expect(c?.body).toContain("`src/b.ts (no specific line)`");
   });
 
+  it("escapes adversarial paths before rendering inline-code locations", () => {
+    const [block] = buildFixHandoffBlocks([
+      {
+        path: "src/x` [Review required](https://evil.example/phish) | <tag>",
+        line: 7,
+        severity: "blocker",
+        body: "Check the suspicious path rendering.",
+      },
+    ]);
+
+    expect(block?.path).toBe("src/x` [Review required](https://evil.example/phish) | <tag>");
+    expect(block?.body).toContain("`src/x\\` [Review required](https://evil.example/phish) \\| &lt;tag&gt;:7`");
+    expect(block?.body).not.toContain("`src/x` [Review required](https://evil.example/phish) | <tag>:7`");
+  });
+
   it("carries the no-server-side-write local-execution boundary on every block", () => {
     expect(buildFixHandoffCollapsible(blocks)?.body).toContain(LOCAL_WRITE_BOUNDARY);
   });


### PR DESCRIPTION
### Motivation

- The Fix handoff renderer interpolated `finding.path` directly into an inline-code markdown span, which allowed adversarial paths containing backticks, pipes, brackets, or markdown link syntax to inject rendered markdown into the public unified review comment.

### Description

- Add a path-specific escaping helper `markdownPathCodeText` in `src/review/fix-handoff-render.ts` that neutralizes backslashes, backticks, pipe characters, and angle brackets before composing the inline-code location label.
- Use the escaped path (`safePath`) when building the `location` string in `buildFixHandoffBlock` so the rendered `body` contains a markdown-safe inline-code span.
- Add a regression unit test in `test/unit/fix-handoff-collapsible.test.ts` that supplies an adversarial path with a backtick, markdown link, pipe, and angle brackets and asserts the rendered block body contains the escaped form while the raw structured `path` field remains unchanged.

### Testing

- Ran the focused unit tests: `npm test -- --run test/unit/fix-handoff-collapsible.test.ts`, all tests passed (11/11).
- Ran type checking: `npm run typecheck`, which succeeded with `tsc --noEmit`.
- Ran `git diff --check`, which reported no issues.
- Ran the full local gate: `npm run test:ci`, which did not fully complete due to environment/registry drift (the existing `cf-typegen:check` reported `worker-configuration.d.ts` stale); this is unrelated to the patch itself.
- Attempted coverage run: `npm run test:coverage -- --run test/unit/fix-handoff-collapsible.test.ts`, the unit tests passed but coverage tooling failed with `TypeError: jsTokens is not a function` in the environment.
- `npm audit --audit-level=moderate` failed due to a registry/network `403 Forbidden` from the audit endpoint in this environment; not related to the change.

Files changed: `src/review/fix-handoff-render.ts`, `test/unit/fix-handoff-collapsible.test.ts`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d8b54640c832cb25d3dcc8c6af717)