### PR TITLE
fix(build): build gittensory-engine before the gittensory-api deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
-    "deploy:api": "wrangler d1 migrations apply gittensory --remote && wrangler deploy",
+    "deploy:api": "npm --workspace @jsonbored/gittensory-engine run build && wrangler d1 migrations apply gittensory --remote && wrangler deploy",
     "selfhost:postgres:migrate": "tsx scripts/migrate-selfhost-sqlite-to-postgres.ts",
     "selfhost:env-reference": "node scripts/gen-selfhost-env-reference.mjs",
     "selfhost:env-reference:check": "node scripts/gen-selfhost-env-reference.mjs --check",


### PR DESCRIPTION
## Summary

- The Cloudflare Workers Build for `gittensory-api` has failed on every push to `main` since `487d26ac` (PR #3986, 2026-07-07T09:36:46Z): `wrangler deploy`'s bundler can't resolve `@jsonbored/gittensory-engine` because `packages/gittensory-miner/lib/opportunity-fanout.js` (committed, pre-built, newly reachable from `src/mcp/find-opportunities.ts` since #3986) imports it, and that package's `dist/` is gitignored and only produced by an explicit build step that Cloudflare's `npm run deploy:api` never runs.
- Fixes it by building the engine package first, exactly mirroring the identical fix already applied to the self-host image build (#4034), the release build (#4063), and the backend test suite (#4036) for the same import chain.
- Reproduced locally (`mv packages/gittensory-engine/dist /tmp/... && wrangler deploy --dry-run` fails with `Could not resolve "@jsonbored/gittensory-engine"`) and confirmed the fix resolves it (same repro, now clean).
- Closes #4081.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — this is a one-line `package.json` script change with no `src/**` lines touched, so `codecov/patch` has nothing to measure here; ran the full suite anyway as part of `npm run test:ci`.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [ ] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- No new tests: this is a build/deploy-pipeline ordering fix (an `npm` script string in `package.json`), not application logic — nothing under `src/**` changed. Verified instead by direct reproduction of the actual failure and fix against `wrangler deploy --dry-run` (see Summary). Matches precedent: the three prior identical fixes (#4034, #4063, #4036) were also pure build-config changes with no test additions.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session/CORS logic touched; this only changes build ordering for an existing deploy command.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP behavior changed.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes.)
- [x] Visible UI changes include a `UI Evidence` section below with screenshots. (N/A — no visible UI change.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (N/A.)

## UI Evidence

N/A — no visible UI, frontend, docs, or extension changes.

## Notes

- Filed and root-caused as #4081, including the exact reproduction steps and a survey of the three prior PRs that fixed this identical class of bug for other pipelines.
- The hosted `gittensory-api` Worker is currently ~60 commits behind `main` (last successful deploy: 2026-07-07T09:33:24Z) as a result of this being broken; merging this should let the very next push to `main` redeploy it and catch back up automatically.
