### PR TITLE
docs(selfhost): add Claude Code + Codex token setup and rotation guide

### DIFF
--- a/apps/gittensory-ui/src/routes/docs.self-hosting-ai-providers.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-ai-providers.tsx
@@ -166,6 +166,74 @@ AI_ON_MERGE=either`}
         ]}
       />
 
+      <h2>Claude Code (subscription)</h2>
+      <p>
+        No API key — <code>claude-code</code> runs your existing Claude subscription through the{" "}
+        <code>claude</code> CLI. Generate a long-lived token once with{" "}
+        <code>claude setup-token</code> and store it as <code>CLAUDE_CODE_OAUTH_TOKEN</code>.
+      </p>
+      <CodeBlock
+        filename=".env"
+        code={`AI_PROVIDER=claude-code
+CLAUDE_CODE_OAUTH_TOKEN=<token from claude setup-token>
+CLAUDE_AI_EFFORT=medium`}
+      />
+      <p>
+        <strong>Rotating it:</strong> when the subscription's usage limit resets or the token needs
+        replacing, run <code>claude setup-token</code> again and paste the new value into{" "}
+        <code>.env</code>. <code>CLAUDE_CODE_OAUTH_TOKEN</code> is baked into the container at
+        creation time, so a plain restart keeps serving the old value — recreate the service
+        instead:
+      </p>
+      <CodeBlock code={`docker compose up -d --no-deps gittensory`} />
+
+      <h2>Codex (subscription)</h2>
+      <p>
+        Codex has no equivalent of <code>claude setup-token</code>. Instead of an environment
+        variable, it stores an OAuth credential file, <code>auth.json</code>. Authenticate against
+        the running container so the file lands on the volume the image expects (
+        <code>/data/codex</code>, mounted at <code>~/.codex</code>):
+      </p>
+      <CodeBlock code={`docker compose exec gittensory codex auth`} />
+      <p>
+        This also needs the explicit opt-in shown in the fallback example above (
+        <code>GITTENSORY_ENABLE_UNSAFE_CODEX_REVIEWER=1</code>) — see the Subscription CLI safety
+        note below for why it defaults to off.
+      </p>
+      <Callout variant="note" title="Rotating it needs no restart">
+        Codex reads <code>auth.json</code> fresh on every review — each review spawns a new{" "}
+        <code>codex</code> subprocess. Once <code>codex auth</code> succeeds, the very next review
+        authenticates correctly; there is no service to recreate and no env var to change.
+      </Callout>
+
+      <h2>Recognizing a stale or missing credential</h2>
+      <p>
+        Both subscription CLIs fail loudly in the self-host logs instead of silently degrading the
+        review:
+      </p>
+      <FeatureRow
+        items={[
+          {
+            title: "claude_code_no_oauth_token",
+            description:
+              "CLAUDE_CODE_OAUTH_TOKEN is unset. Add it to .env and recreate the service.",
+          },
+          {
+            title: "claude_code_error_401",
+            description: "The token was rejected. Generate a fresh one with claude setup-token.",
+          },
+          {
+            title: "codex_no_auth",
+            description: "auth.json is missing or expired. Re-run codex auth.",
+          },
+          {
+            title: "codex_credential_isolation_required",
+            description:
+              "GITTENSORY_ENABLE_UNSAFE_CODEX_REVIEWER is not set to 1, or CODEX_HOME was set on the app container. Remove CODEX_HOME so Codex reads the mounted volume's default path.",
+          },
+        ]}
+      />
+
       <h2>Subscription CLI safety</h2>
       <Callout variant="warn" title="Credential isolation matters">
         Subscription CLIs store credentials on disk. Do not mount a writable or prompt-readable CLI


### PR DESCRIPTION
## Summary

- Self-hosters running the AI review engine via the Claude Code (`CLAUDE_CODE_OAUTH_TOKEN`) or Codex (`auth.json`) subscription CLIs had no guidance for obtaining, wiring up, or rotating those credentials once a subscription's usage limit resets or a token needs replacing. Adds "Claude Code (subscription)", "Codex (subscription)", and "Recognizing a stale or missing credential" sections to the existing self-host AI providers doc, covering setup and the (very different) rotation procedure for each provider.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

Closes #4074

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` locally
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — N/A, static docs content with no logic branches

If any required check was skipped, explain why:

- Docs-only change to one `apps/gittensory-ui` route file — no `src/**`, `.github/workflows/**`, or MCP package files touched. `npm run test:changed` (Vitest's import-graph analysis against `origin/main`) confirms zero backend test files are affected, and `apps/**` is explicitly excluded from Codecov (`codecov.yml`), so there's no coverage obligation. Skipped `actionlint` (no workflow changes), `test:coverage`/`test:workers` (no `src/`/Worker changes), `build:mcp`/`test:mcp-pack` (no MCP package changes) as genuinely inapplicable rather than unverified. Also ran (though not on this checklist) `npm run docs:drift-check` (passes) and the UI's own suite (`ui:test`, 71/71 passing, unchanged by this diff).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed — every credential shown is an obviously-fake placeholder (e.g. `<token from claude setup-token>`), never a real value.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no such change.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no such change.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, static prose/code-block content, no data fetching.
- [ ] Visible UI changes include a `UI Evidence` section below with screenshots. — N/A for this owner-authored PR (see UI Evidence below).
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — this PR is the docs update itself; changelog untouched.

## UI Evidence

N/A — owner-authored PR (screenshot-hosting isn't wired up for non-interactive use yet). Verified the rendered page directly against the live dev server instead: all 11 page headings appear in the correct order, the 3 new sections' rendered text matches the source exactly, the "Rotating it needs no restart" callout renders with the correct `note` variant, and a full-page screenshot confirmed correct end-to-end dark-theme rendering with no layout breakage.

## Notes

- Codex's rotation story is the interesting asymmetry this doc didn't cover before: it has no equivalent of `claude setup-token` — the credential is a mounted `auth.json` file, re-read fresh on every review, so re-running `codex auth` takes effect on the very next review with no restart/recreate needed. Claude Code is the opposite: its token is injected via `env_file` at container-creation time, so rotating it needs `docker compose up -d --no-deps gittensory`, not a plain restart.