### PR TITLE
docs(gittensor): add impact badge, CI card job, and contributing disclosure

### DIFF
--- a/.github/workflows/gittensor-impact.yml
+++ b/.github/workflows/gittensor-impact.yml
@@ -1,0 +1,23 @@
+name: Gittensor Impact
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "40 5 * * 1"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: gittensor-impact
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Generate and publish Gittensor impact card
+        uses: matthewevans/gittensor-impact-action@397fd470899cba47367458289a374eea9cb0d76a # main, 2026-07-06 (#1 per-repo API endpoint)
+        with:
+          title: Gittensory

--- a/.github/workflows/gittensor-impact.yml
+++ b/.github/workflows/gittensor-impact.yml
@@ -21,6 +21,9 @@ jobs:
     # `gittensor-impact` release via matthewevans/gittensor-impact-action.
     permissions:
       contents: write
+    # matthewevans/gittensor-impact-action is a ~1.5-day-old repo; require a
+    # human approval before it runs with contents:write, on top of the SHA pin.
+    environment: gittensor-impact
     steps:
       - name: Generate and publish Gittensor impact card
         uses: matthewevans/gittensor-impact-action@397fd470899cba47367458289a374eea9cb0d76a # main, 2026-07-06 (#1 per-repo API endpoint)

--- a/.github/workflows/gittensor-impact.yml
+++ b/.github/workflows/gittensor-impact.yml
@@ -6,7 +6,7 @@ on:
     - cron: "40 5 * * 1"
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
   group: gittensor-impact
@@ -16,6 +16,11 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Scoped here rather than at workflow level (defense-in-depth): this is the
+    # only job that needs write access, to publish SVG assets to the pinned
+    # `gittensor-impact` release via matthewevans/gittensor-impact-action.
+    permissions:
+      contents: write
     steps:
       - name: Generate and publish Gittensor impact card
         uses: matthewevans/gittensor-impact-action@397fd470899cba47367458289a374eea9cb0d76a # main, 2026-07-06 (#1 per-repo API endpoint)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,10 @@ a third.
 the subnet's on-chain hyperparameters and validators, not by this repo. Merging a PR is not a promise of
 score, ranking, or compensation, and all review decisions are at maintainer discretion and final.
 
+**This repository is itself Gittensor-listed.** PRs merged here by registered miners may earn TAO
+under the subnet's own rules — see the badge in `README.md` for a live, aggregate merged-PR/line-count
+summary. That eligibility and scoring is Gittensor's, not ours, and does not change the bar above.
+
 ## What We Accept
 
 Focused contributions are welcome in these areas:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
   <a href="https://www.npmjs.com/package/@jsonbored/gittensory-mcp"><img alt="MCP package" src="https://img.shields.io/npm/v/@jsonbored/gittensory-mcp?label=mcp" /></a>
   <a href="https://github.com/JSONbored/gittensory/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/github/license/JSONbored/gittensory" /></a>
   <a href="https://gittensory.aethereal.dev/docs"><img alt="Docs" src="https://img.shields.io/badge/docs-gittensory.aethereal.dev-0b6bcb" /></a>
+  <a href="https://gittensor.io/miners/repository?name=JSONbored/gittensory"><img alt="Gittensor impact" src="https://api.gittensor.io/repos/JSONbored%2Fgittensory/badge.svg" /></a>
 </p>
 
 Gittensory is a deterministic control plane for Gittensor OSS contribution work.


### PR DESCRIPTION
## Summary

- Gittensory is itself a Gittensor-listed repo (SN74 whitelisted). Adds the live `api.gittensor.io` impact badge to the top README badge row, linking to the repo's Gittensor dashboard.
- Adds a short disclosure to `CONTRIBUTING.md` noting the repo is Gittensor-listed and that scoring/rewards are Gittensor's, not ours (mirrors the existing "Scoring and rewards are not ours to grant" paragraph right above it).
- Adds `.github/workflows/gittensor-impact.yml`, a weekly + manually-dispatchable job that publishes a fuller SVG contributor-impact card (Gittensor vs. non-Gittensor PR/LOC share) via `matthewevans/gittensor-impact-action`, pinned to commit SHA `397fd470899cba47367458289a374eea9cb0d76a` (not a floating tag) with `contents: write` scoped to just that job.

Security review of the action (all 4 of its Python scripts): zero third-party pip deps, no shell-injection-prone subprocess calls (list-form args throughout), one outbound GET to `api.gittensor.io` wrapped in try/except with graceful degradation, HTML-escaped SVG text output, tokens never logged, `gh release create ... --latest=false` so it never hijacks the repo's real "Latest release". Caveat: the action repo is ~1.5 days old (7 commits, 2 contributors) — young, but the code itself is clean and narrowly scoped.

The bigger rendered picture-card is intentionally **not** wired into the README yet — its release assets don't exist until the workflow runs once post-merge, and a dead image link is worse than not having it yet. Planned as a fast-follow once the first scheduled/dispatched run is confirmed to have published the SVGs.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue this PR resolves — no linked issue: this is an owner-initiated docs/CI change made in direct response to the Gittensor ecosystem's own badge announcement, not tracked as a GitHub issue.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` — not applicable, no `src/**` lines changed (README/CONTRIBUTING/workflow only, not Codecov-measured)
- [ ] `npm run test:workers` — not applicable, no worker code changed
- [ ] `npm run build:mcp` / `npm run test:mcp-pack` — not applicable, no MCP code changed
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [ ] New or changed behavior has unit/integration tests — not applicable, no testable logic added (docs + declarative CI workflow only)

Full `npm run test:ci` ran green once already on this branch before rebasing onto latest `main` (which only moved by unrelated `fix(review): ...` commits); re-ran `actionlint` + `typecheck` after the rebase to confirm.

If any required check was skipped, explain why:

- Coverage/worker/MCP/miner test steps skipped as genuinely not applicable — this diff touches only `README.md`, `CONTRIBUTING.md`, and one new declarative GitHub Actions workflow file, no `src/**`/`packages/**` code.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics (the badge reports only aggregate merged-PR/line counts, matching the existing "scoring and rewards are not ours to grant" framing).
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — not applicable, no such changes.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — not applicable.
- [ ] UI changes use live API data or real empty/error/loading states — not applicable, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section — not applicable; the only visible change is a new badge image in `README.md` (a static markdown link, not an app UI surface).
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs (not touched here).