### PR TITLE
fix(db): reject code-span linked issue matches

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -7379,18 +7379,24 @@ export function extractLinkedIssueNumbersWithOverflow(text: string, repoFullName
   const normalizedLimit = Math.max(0, Math.floor(limit));
   const target = repoFullName.toLowerCase();
 
-  // Strip inline code spans before scanning: GitHub's own native closing-keyword linker does not treat
-  // backtick-wrapped text as a real "Closes #N" directive, and this repo's own PR template checklist item
-  // contains the literal example text "(e.g. `Closes #123`)" -- without this, every PR that keeps the
-  // unmodified template checklist would spuriously link to issue #123.
-  const withoutCodeSpans = text.replace(/`[^`\n]*`/g, " ");
+  // GitHub's native closing-keyword linker does not treat backtick-wrapped text as a real
+  // "Closes #N" directive, and this repo's own PR template contains "(e.g. `Closes #123`)".
+  // Keep the original text while rejecting regex hits that occur inside inline code spans; replacing
+  // spans with whitespace would let text on either side combine into a fake closing reference.
+  const inlineCodeSpanRanges = [...text.matchAll(/`[^`\n]*`/g)].map((match) => ({
+    start: match.index!,
+    end: match.index! + match[0].length,
+  }));
 
   const linkedIssues: number[] = [];
   const seen = new Set<number>();
   // Matches both GitHub's bare `KEYWORD #N` and fully-qualified `KEYWORD owner/repo#N` closing syntax (#3862) --
   // the qualified form only counts when owner/repo case-insensitively matches THIS repo; a reference to a
   // different repo closes an issue there, not here, and must not spoof a same-repo linked-issue match.
-  for (const match of withoutCodeSpans.matchAll(/\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+(?:([\w.-]+\/[\w.-]+)#|#)(\d+)\b/gi)) {
+  for (const match of text.matchAll(/\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+(?:([\w.-]+\/[\w.-]+)#|#)(\d+)\b/gi)) {
+    const matchStart = match.index!;
+    const matchEnd = matchStart + match[0].length;
+    if (inlineCodeSpanRanges.some((range) => matchStart < range.end && matchEnd > range.start)) continue;
     const owner = match[1];
     if (owner && owner.toLowerCase() !== target) continue;
     const value = Number(match[2]);

--- a/test/unit/db-parsers.test.ts
+++ b/test/unit/db-parsers.test.ts
@@ -68,6 +68,12 @@ describe("database row parser hardening", () => {
     expect(extractLinkedIssueNumbers(`Closes #42\n\n${templateLine}`, "owner/repo")).toEqual([42]);
   });
 
+  it("REGRESSION: does not join closing keywords to issue references across inline code spans", () => {
+    expect(extractLinkedIssueNumbers("Fixes `not a directive` #42", "owner/repo")).toEqual([]);
+    expect(extractLinkedIssueNumbers("Resolves `not a directive` owner/repo#43", "owner/repo")).toEqual([]);
+    expect(extractLinkedIssueNumbers("Fixes #7, not `Fixes #8`, and closes #9", "owner/repo")).toEqual([7, 9]);
+  });
+
   it("recognizes the fully-qualified `Fixes owner/repo#N` closing syntax when owner/repo matches this repo (#3862)", () => {
     expect(extractLinkedIssueNumbers("Closes owner/repo#42", "owner/repo")).toEqual([42]);
     // Case-insensitive, matching GitHub's own repo-name matching.


### PR DESCRIPTION
### Motivation

- Prevent inline code spans from bridging a closing keyword and a later issue number so malformed Markdown like `Fixes `not a directive` #42` cannot be treated as a valid linked-issue reference.  
- Preserve the intended behavior of ignoring code-span-contained examples (e.g. the PR template `(e.g. `Closes #123`)`) while avoiding the new false-positive introduced by whitespace replacement.

### Description

- Update `extractLinkedIssueNumbersWithOverflow` to scan the original `text` and compute inline code-span ranges (regex: ``/`[^`\n]*`/g``) and skip any closing-keyword regex match that overlaps a code span; the closing-keyword regex remains the same. (file: `src/db/repositories.ts`)
- Add regression unit tests that assert closing keywords separated from issue references by inline code spans are not joined into valid matches and that valid references outside code spans continue to extract. (file: `test/unit/db-parsers.test.ts`)
- Regenerate Cloudflare worker runtime types to satisfy local drift checks (`worker-configuration.d.ts`).

### Testing

- Ran `npm run typecheck` which completed successfully (no TypeScript errors).  
- Ran `npx vitest run test/unit/db-parsers.test.ts` and the updated unit tests passed (`45 tests` passed).  
- Attempted the full local gate via `npm run test:ci`; it initially reported stale `worker-configuration.d.ts` (fixed by regenerating types), then the full coverage run stalled in unrelated queue test output and was interrupted (not a regression in the linked-issue change).  
- Running coverage for the single test file with `--coverage` exercised the tests but the coverage remapping failed downstream with `TypeError: jsTokens is not a function` (an unrelated coverage remapping/tooling issue).  
- `npm audit --audit-level=moderate` could not complete in this environment (npm audit endpoint returned `403 Forbidden`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d8b562630832c9acd8a1fda438820)