### PR TITLE
fix(mcp): sanitize validate-config terminal output

### DIFF
--- a/packages/gittensory-mcp/bin/gittensory-mcp.js
+++ b/packages/gittensory-mcp/bin/gittensory-mcp.js
@@ -1632,6 +1632,12 @@ async function lintPrTextCli(args) {
   for (const fix of payload.fixes ?? []) process.stdout.write(`- ${fix}\n`);
 }
 
+function sanitizePlainTextTerminalOutput(value) {
+  return String(value)
+    .replace(/\x1b(?:\[[0-?]*[ -/]*[@-~]|\][^\x07\x1b]*(?:\x07|\x1b\\)|[PX^_][^\x1b]*(?:\x1b\\)|[@-_])/g, "")
+    .replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]/g, "");
+}
+
 function printValidateConfigHelp() {
   process.stdout.write(
     [
@@ -1664,7 +1670,7 @@ async function validateConfigCli(args) {
   }
   process.stdout.write(`Manifest validation: ${payload.status}\n`);
   process.stdout.write(`present=${payload.present}\n`);
-  for (const warning of payload.warnings ?? []) process.stdout.write(`- ${warning}\n`);
+  for (const warning of payload.warnings ?? []) process.stdout.write(`- ${sanitizePlainTextTerminalOutput(warning)}\n`);
 }
 
 function printSlopRiskHelp() {

--- a/test/unit/mcp-cli-validate-config.test.ts
+++ b/test/unit/mcp-cli-validate-config.test.ts
@@ -13,9 +13,9 @@ describe("gittensory-mcp CLI — validate-config", () => {
     tempDir = null;
   });
 
-  async function env() {
+  async function env(options: Parameters<typeof startFixtureServer>[0] = {}) {
     tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
-    const url = await startFixtureServer();
+    const url = await startFixtureServer(options);
     return { GITTENSORY_API_URL: url, GITTENSORY_TOKEN: "session-token", GITTENSORY_CONFIG_DIR: tempDir, GITTENSORY_API_TIMEOUT_MS: "1000" };
   }
 
@@ -34,6 +34,24 @@ describe("gittensory-mcp CLI — validate-config", () => {
       normalized: { wantedPaths: string[] };
     };
     expect(json).toMatchObject({ status: "ok", present: true, normalized: { wantedPaths: ["src/"] } });
+  });
+
+  it("strips terminal control sequences from plain warning output only", async () => {
+    const warning = 'Manifest gate field "gate.linkedIssue" must be one of off, advisory, block; ignoring "\u001b]52;c;QUJD\u0007BAD\u001b[31m".';
+    const e = await env({ validateConfigWarnings: [warning] });
+    const manifestPath = join(tempDir!, "manifest.yml");
+    writeFileSync(manifestPath, `gate:
+  linkedIssue: bad
+`, "utf8");
+
+    const plain = await runAsync(["validate-config", "--file", manifestPath], e);
+    expect(plain).toContain('ignoring "BAD"');
+    expect(plain).not.toContain("\u001b]52");
+    expect(plain).not.toContain("\u0007");
+    expect(plain).not.toContain("\u001b[31m");
+
+    const json = JSON.parse(await runAsync(["validate-config", "--file", manifestPath, "--json"], e)) as { warnings: string[] };
+    expect(json.warnings.join("\n")).toContain("\u001b]52;c;QUJD\u0007BAD\u001b[31m");
   });
 
   it("rejects missing --file and prints help", async () => {

--- a/test/unit/support/mcp-cli-harness.ts
+++ b/test/unit/support/mcp-cli-harness.ts
@@ -114,6 +114,7 @@ export async function startFixtureServer(
     prTextLintStatus?: number;
     onPacketRequest?: (body: unknown) => void;
     onApiRequest?: (request: IncomingMessage) => void;
+    validateConfigWarnings?: string[];
   } = {},
 ) {
   server = createServer(async (request, response) => {
@@ -250,7 +251,7 @@ export async function startFixtureServer(
         JSON.stringify(
           malformed
             ? { present: false, status: "error", warnings: ["Manifest content was not valid JSON; ignoring it and falling back to deterministic signals."], normalized: { present: false, source: "repo_file" } }
-            : { present: true, status: "ok", warnings: [], normalized: { present: true, source: "repo_file", wantedPaths: ["src/"] } },
+            : { present: true, status: "ok", warnings: options.validateConfigWarnings ?? [], normalized: { present: true, source: "repo_file", wantedPaths: ["src/"] } },
         ),
       );
       return;


### PR DESCRIPTION
### Motivation
- The `validate-config` CLI printed parser warnings from untrusted repository manifests directly to stdout, allowing ANSI/OSC and C0/C1 control bytes from manifest values to reach a user's terminal and potentially manipulate terminal state or clipboard.

### Description
- Add `sanitizePlainTextTerminalOutput` in `packages/gittensory-mcp/bin/gittensory-mcp.js` and apply it to plain-text warning output emitted by the `validate-config` CLI so ANSI/OSC and C0/C1 control bytes are stripped before writing to stdout.
- Preserve machine-readable behaviour by leaving `--json` output untouched (the raw warnings remain in JSON responses).
- Extend the test fixture server in `test/unit/support/mcp-cli-harness.ts` with a `validateConfigWarnings` injection point so tests can exercise API-returned warnings.
- Add a regression unit test in `test/unit/mcp-cli-validate-config.test.ts` that asserts terminal sequences (OSC 52, BEL, ANSI) are removed from plain output but preserved in `--json` output.

### Testing
- Ran `npx vitest run test/unit/mcp-cli-validate-config.test.ts`, which passed (3 tests passed). 
- Ran `npm run build:mcp`, which completed successfully (`node --check` verification passed). 
- Ran `npm run command-reference:check` and `npm run typecheck`, both of which completed successfully. 
- Attempted `npm run test:ci`, which did not complete because `cf-typegen` drift was detected by the local check (generated Cloudflare types reported stale), preventing the full suite from finishing. 
- Attempted `npm audit --audit-level=moderate`, which could not complete due to the registry audit endpoint returning `403 Forbidden` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d8b560dcc832cadef3f7c57b1ad25)