### PR TITLE
fix(deploy): deploy worker before d1 migrations

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "dev": "wrangler dev",
     "deploy": "wrangler deploy",
-    "deploy:api": "npm --workspace @jsonbored/gittensory-engine run build && wrangler d1 migrations apply gittensory --remote && wrangler deploy",
+    "deploy:api": "npm --workspace @jsonbored/gittensory-engine run build && wrangler deploy && wrangler d1 migrations apply gittensory --remote",
     "selfhost:postgres:migrate": "tsx scripts/migrate-selfhost-sqlite-to-postgres.ts",
     "selfhost:env-reference": "node scripts/gen-selfhost-env-reference.mjs",
     "selfhost:env-reference:check": "node scripts/gen-selfhost-env-reference.mjs --check",


### PR DESCRIPTION
### Motivation
- The migrations added a destructive `ALTER TABLE ... DROP COLUMN private_trust_enabled` which creates a deployment-time window if remote D1 migrations are applied before the new Worker is active, causing older Worker code to crash when it still expects the dropped column. 
- The intent is to avoid that availability regression by ensuring the new Worker binary is deployed before applying destructive remote migrations.

### Description
- Change the `deploy:api` NPM script to run `wrangler deploy` before `wrangler d1 migrations apply ... --remote` so the Worker is upgraded prior to applying DB migrations. 
- Regenerate the Worker runtime type file (`worker-configuration.d.ts`) via the `cf-typegen` step so the local cf-typegen drift check remains green with the updated Wrangler/runtime output.

### Testing
- Ran `git diff --check`, which reported no whitespace/conflict issues. 
- Ran `npm run db:migrations:check`, which passed against the migration set (no gaps/duplicates). 
- Ran `npm run cf-typegen`, which regenerated `worker-configuration.d.ts` and made the `cf-typegen:check` parity pass locally. 
- Ran `npm run test:ci`, which exercised the CI gate but failed due to unrelated unit-test issues in `test/unit/queue.test.ts` (stack-depth/timeouts), not related to the deployment-sequencing script change, and `npm audit --audit-level=moderate` failed with a registry `403 Forbidden` from the audit endpoint.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d927355c4832cb544b64f8995cf2a)