### PR TITLE
docs(readme): embed the live Gittensor contributor-impact card

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,20 @@ npm run ui:dev
 npm run ui:build
 ```
 
+## Gittensor Contributor Impact
+
+<p align="center">
+  <a href="https://gittensor.io/miners/repository?name=JSONbored/gittensory">
+    <picture>
+      <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/JSONbored/gittensory/gittensor-impact-assets/gittensor-impact-dark.svg">
+      <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/JSONbored/gittensory/gittensor-impact-assets/gittensor-impact-light.svg">
+      <img src="https://raw.githubusercontent.com/JSONbored/gittensory/gittensor-impact-assets/gittensor-impact-light.svg" alt="Gittensor contributor impact" width="600">
+    </picture>
+  </a>
+</p>
+
+Refreshed weekly by [`.github/workflows/gittensor-impact.yml`](.github/workflows/gittensor-impact.yml).
+
 ## Project Links
 
 | Need         | Link                               |


### PR DESCRIPTION
## Summary

Fast-follow to #4086 — the `gittensor-impact` workflow has now run successfully (after switching to branch-mode publishing to work around GitHub's new immutable-release restriction) and published `gittensor-impact-{dark,light}.svg` to the `gittensor-impact-assets` branch. This wires the actual rendered comparison card into the README, replacing the placeholder-only state where just the small text badge was live.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue this PR resolves — no linked issue, same rationale as #4086 (owner-initiated, ecosystem-driven change, not tracked as a GitHub issue).

## Validation

- [x] `git diff --check`
- [ ] `npm run test:coverage` / `test:workers` / `build:mcp` / etc. — not applicable, README-only change, no `src/**`/`packages/**` touched

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized; the embedded card reports only aggregate merged-PR/LOC-share stats.