### PR TITLE
fix(review): make review.memory a full config-as-code substitute

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -9033,8 +9033,9 @@ async function maybePublishPrPublicSurface(
     inlineCommentsPerCategoryForReview = deterministicReviewOverrides.inlineCommentsPerCategory;
     // review.memory (#2179, part of #1964): deterministic, no-AI -- resolved the same unconditional way as
     // changed_files_summary/effort_score above (must apply even when the AI review itself is skipped this
-    // pass). ANDed with the operator's GITTENSORY_REVIEW_MEMORY kill-switch at the actual apply site below
-    // (shouldApplyReviewMemory) — this flag alone only carries the per-repo manifest opt-in.
+    // pass). The operator's GITTENSORY_REVIEW_MEMORY kill-switch at the actual apply site below
+    // (shouldApplyReviewMemory) is absolute; an explicit `review.memory` manifest toggle then fully decides
+    // (#4101, same precedence as shouldEmitFixHandoff) — this flag alone only carries the per-repo manifest opt-in.
     reviewMemoryEnabledForReview = shouldApplyReviewMemory(env, resolveReviewMemoryManifestToggle(reviewManifestForAutoReview));
     // review.fixHandoff emission (#1962): resolved the same unconditional way as the deterministic sections above,
     // ANDing the per-repo `review.fixHandoff` manifest opt-in with the operator's GITTENSORY_REVIEW_FIX_HANDOFF

--- a/src/review/review-memory-wire.ts
+++ b/src/review/review-memory-wire.ts
@@ -1,10 +1,11 @@
-// Review-memory activation wiring (#2179, config slice of #1964). Mirrors impact-map-wire.ts's
-// isImpactMapEnabled: a single GLOBAL env kill-switch the self-host operator controls, ANDed with the per-repo
-// `.gittensory.yml review.memory` manifest toggle (resolved via `resolveReviewMemoryManifestToggle`,
-// src/signals/focus-manifest.ts) — so a repo can only ever NARROW what the operator has already turned on,
-// never widen it. Both OFF by default: with the env flag unset, the suppression store is never read from the
-// review path at all (the caller guards on this flag before doing any D1 read or matching), so the review
-// stays byte-identical to today.
+// Review-memory activation wiring (#2179, config slice of #1964). Default OFF: the operator flag
+// GITTENSORY_REVIEW_MEMORY is a master kill-switch, and the per-repo `.gittensory.yml` review.memory toggle
+// (#4101, same shape as inlineComments/fixHandoff, #4099) fully controls activation by itself when explicitly
+// set — there has never been a GITTENSORY_REVIEW_REPOS cutover allowlist for this feature (an unset manifest
+// toggle preserves the ORIGINAL always-off default; it was never sufficient to be allowlisted alone, and in
+// fact no allowlist fallback ever existed for review memory in the first place). With the env flag unset, the
+// suppression store is never read from the review path at all (the caller guards on this flag before doing any
+// D1 read or matching), so the review stays byte-identical to today.
 
 import { matchSuppressions, type ReviewMemoryFindingInput } from "./review-memory-match";
 import type { AdvisoryFinding, ReviewSuppressionRecord } from "../types";
@@ -17,14 +18,22 @@ export function isReviewMemoryEnabled(env: { GITTENSORY_REVIEW_MEMORY?: string |
   return /^(1|true|yes|on)$/i.test(env.GITTENSORY_REVIEW_MEMORY ?? "");
 }
 
-/** Resolve whether review-memory suppression should apply for THIS repo/PR: the operator's global env
- *  kill-switch AND the per-repo manifest opt-in. Neither alone is sufficient — mirrors every other
- *  converged-feature gate in this codebase (env kill-switch first, then the manifest narrows it further). */
+/** PURE (#4101): should review-memory suppression apply for THIS repo/PR? (1) The operator's
+ *  GITTENSORY_REVIEW_MEMORY flag is an absolute MASTER KILL-SWITCH — off ⇒ always false, regardless of the
+ *  manifest, and no per-repo config can bypass it (consistent with every other converged feature — see
+ *  `resolveConvergedFeature` in `feature-activation.ts`). (2) An explicit per-repo `.gittensory.yml`
+ *  `review.memory` override (`true`/`false`) now FULLY controls the feature by itself — a repo can turn this on
+ *  without needing any allowlist at all. (3) `manifestToggle` unset (`undefined`) preserves this feature's
+ *  ORIGINAL design exactly: review memory has never had a GITTENSORY_REVIEW_REPOS cutover allowlist to fall
+ *  back to (unlike rag/reputation/safety/unifiedComment/grounding), so this stays `false` regardless, byte-
+ *  identical to every repo's behavior before this change. Exactly mirrors `shouldEmitFixHandoff`'s shape and
+ *  precedence. */
 export function shouldApplyReviewMemory(
   env: { GITTENSORY_REVIEW_MEMORY?: string | undefined },
-  manifestReviewMemoryEnabled: boolean,
+  manifestToggle: boolean | undefined,
 ): boolean {
-  return isReviewMemoryEnabled(env) && manifestReviewMemoryEnabled;
+  if (!isReviewMemoryEnabled(env)) return false;
+  return manifestToggle === true;
 }
 const RESOLVE_FINDING_CODE = /^[a-z][a-z0-9_]{0,199}$/;
 export function normalizeResolveFindingRef(raw: string | null | undefined): { ok: true; scope: "whole_pr" } | { ok: true; scope: "single"; findingCode: string } | { ok: false; reason: "malformed_finding_id" } { const trimmed = (raw ?? "").trim(); if (trimmed.length === 0) return { ok: true, scope: "whole_pr" }; const normalized = trimmed.toLowerCase().replace(/^finding-/, ""); if (!RESOLVE_FINDING_CODE.test(normalized)) return { ok: false, reason: "malformed_finding_id" }; return { ok: true, scope: "single", findingCode: normalized }; }

--- a/test/unit/review-memory-wire.test.ts
+++ b/test/unit/review-memory-wire.test.ts
@@ -14,21 +14,25 @@ describe("isReviewMemoryEnabled", () => {
   });
 });
 
-describe("shouldApplyReviewMemory", () => {
-  it("requires BOTH the operator env flag AND the per-repo manifest opt-in", () => {
-    expect(shouldApplyReviewMemory({ GITTENSORY_REVIEW_MEMORY: "true" }, true)).toBe(true);
-  });
-
-  it("is OFF when the operator flag is on but the manifest didn't opt in", () => {
-    expect(shouldApplyReviewMemory({ GITTENSORY_REVIEW_MEMORY: "true" }, false)).toBe(false);
-  });
-
-  it("is OFF when the manifest opted in but the operator flag is off (repo cannot self-enable)", () => {
+describe("shouldApplyReviewMemory (#4101)", () => {
+  it("operator flag is a master kill-switch — off ⇒ always false regardless of the manifest toggle", () => {
     expect(shouldApplyReviewMemory({ GITTENSORY_REVIEW_MEMORY: "false" }, true)).toBe(false);
   });
 
+  it("REGRESSION (#4101): unset manifest toggle stays false — byte-identical to the ORIGINAL required-AND behavior (review memory has never had a GITTENSORY_REVIEW_REPOS cutover allowlist to fall back to)", () => {
+    expect(shouldApplyReviewMemory({ GITTENSORY_REVIEW_MEMORY: "true" }, undefined)).toBe(false);
+  });
+
+  it("(#4101) an explicit manifest toggle: true fully controls the feature", () => {
+    expect(shouldApplyReviewMemory({ GITTENSORY_REVIEW_MEMORY: "true" }, true)).toBe(true);
+  });
+
+  it("(#4101) an explicit manifest toggle: false forces the feature off, even with the operator flag on", () => {
+    expect(shouldApplyReviewMemory({ GITTENSORY_REVIEW_MEMORY: "true" }, false)).toBe(false);
+  });
+
   it("is OFF when both are off", () => {
-    expect(shouldApplyReviewMemory({}, false)).toBe(false);
+    expect(shouldApplyReviewMemory({}, undefined)).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- `shouldApplyReviewMemory` (`src/review/review-memory-wire.ts`) required BOTH `GITTENSORY_REVIEW_MEMORY` AND an explicit `review.memory: true` manifest opt-in (`isReviewMemoryEnabled(env) && manifestReviewMemoryEnabled`) — a repo could only ever *narrow* what the operator already turned on, never fully control the feature through config.
- Rewired it to the `inlineComments`/`fixHandoff` shape shipped in #4116 (#4099): the operator's `GITTENSORY_REVIEW_MEMORY` flag remains an absolute master kill-switch (off ⇒ always false, regardless of the manifest), and an explicit per-repo `.gittensory.yml` `review.memory: true/false` now fully decides the outcome by itself.
- `review.memory` has never had a `GITTENSORY_REVIEW_REPOS` cutover allowlist (confirmed: not in `CONVERGED_FEATURE_KEYS`, and `env.d.ts`'s doc comment for `GITTENSORY_REVIEW_MEMORY` never mentioned one), so an unset manifest toggle stays `false` — byte-identical to the feature's original always-off default. `resolveReviewMemoryManifestToggle` (`src/signals/focus-manifest.ts`) already resolved the manifest correctly and needed no change.
- Both call sites in `src/queue/processors.ts` (the auto-review pass and the `@gittensory resolve` command handler) compile unchanged against the new `manifestToggle: boolean | undefined` parameter type since they already pass `resolveReviewMemoryManifestToggle(...)`'s resolved boolean through.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

Ran the full local gate: `npm run test:ci` (green — actionlint, migrations/schema-drift/env-reference/observability checks, cf-typegen, typecheck, unsharded `test:coverage`, `test:workers`, MCP/miner build+pack, `rees:test`, `ui:openapi`, `docs:drift-check`, `command-reference:check`, `ui:lint/typecheck/test/build`) plus `npm audit --audit-level=moderate` (0 vulnerabilities). Confirmed via `coverage/lcov.info` that `src/review/review-memory-wire.ts` is 21/21 lines and 22/22 branches covered (`LF:21 LH:21`, `BRF:22 BRH:22`), and the only hunk in `src/queue/processors.ts` is a doc-comment update (no coverable lines). Rebased onto `origin/main` after the local gate passed; re-ran `typecheck` plus the targeted `review-memory-wire`/`review-fix-handoff`/`worker-entry-boundary`/`queue.test.ts` (review-memory filter) suites post-rebase — all green.

If any required check was skipped, explain why:

- None skipped.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/cookie/CORS/session surface touched.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP surface changed; `ui:openapi:check` confirms no drift.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changed.)
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. (N/A — backend-only change, no visible UI.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (N/A — no changelog edit.)

## UI Evidence

N/A — backend-only change (`src/review/review-memory-wire.ts`, `src/queue/processors.ts` comment, tests). No visible UI/frontend/docs surface.

## Notes

- Closes #4101.
