### PR TITLE
fix(review): make review.impactMap fully control activation once the kill-switch is on

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -261,10 +261,11 @@ declare global {
      *  unreachable when off). Even when ON, retrieval is INERT until the self-host vector index is populated for
      *  the repo (a cold/missing index degrades to no context). */
     GITTENSORY_REVIEW_RAG?: string;
-    /** Deterministic impact map (#2184, part of #1971): operator-level kill-switch, ANDed with the per-repo
-     *  `.gittensory.yml review.impact_map` opt-in (see review/impact-map-wire's isImpactMapEnabled /
-     *  shouldComputeImpactMap). Default OFF — unset/false performs NO symbol extraction, NO RAG query, and adds
-     *  NO comment/prompt section, byte-identical to today. */
+    /** Deterministic impact map (#2184, part of #1971): operator-level master kill-switch; the per-repo
+     *  `.gittensory.yml review.impact_map` opt-in fully decides once this is on (#4102 precedence — see
+     *  review/impact-map-wire's isImpactMapEnabled / shouldComputeImpactMap). Default OFF — unset/false
+     *  performs NO symbol extraction, NO RAG query, and adds NO comment/prompt section, byte-identical to
+     *  today. */
     GITTENSORY_REVIEW_IMPACT_MAP?: string;
     /** Repo quality-culture profile (#2995): when truthy, the AI reviewer prompt gains an ADDITIVE "REPO
      *  QUALITY-CULTURE PROFILE" reference block — typical merged-PR size + common accepted labels, derived

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -6934,10 +6934,11 @@ export async function runAiReviewForAdvisory(
     // manifest. Self-host only — overrides that repo's claude-code/codex model+effort, taking priority over the
     // operator's global env vars. Absent/all-null ⇒ byte-identical (global env var, then provider default).
     reviewSelfHostAiModel?: SelfHostAiModelConfig | undefined;
-    // `.gittensory.yml` review.impact_map (#2184/#2186), resolved by the caller from the cached manifest. ANDed
-    // here with the operator's GITTENSORY_REVIEW_IMPACT_MAP flag (shouldComputeImpactMap) to decide whether to
-    // compute the deterministic impact map and splice it into the reviewer prompt as additive reference
-    // context. Absent/false ⇒ byte-identical reviewer prompt (no impact-map computation, no RAG query for it).
+    // `.gittensory.yml` review.impact_map (#2184/#2186), resolved by the caller from the cached manifest.
+    // Precedence (#4102): the operator's GITTENSORY_REVIEW_IMPACT_MAP flag is a master kill-switch, never
+    // bypassable by config (shouldComputeImpactMap); an explicit true/false here then fully controls whether to
+    // compute the deterministic impact map and splice it into the reviewer prompt. Absent ⇒ byte-identical
+    // reviewer prompt (no impact-map computation, no RAG query for it).
     reviewImpactMap?: boolean | undefined;
     // `.gittensory.yml` review.culture_profile (#2995), resolved by the caller from the cached manifest. ANDed
     // here with the GITTENSORY_REVIEW_CULTURE_PROFILE global flag to decide whether to append the repo's
@@ -7136,16 +7137,17 @@ export async function runAiReviewForAdvisory(
       : undefined;
     const ragTelemetry =
       ragContextResult?.telemetry ?? emptyReviewRagTelemetry(false);
-    // Deterministic impact map (#2184/#2186), ANDed operator env flag + per-repo review.impact_map opt-in
-    // (shouldComputeImpactMap). Reuses the SAME changed files this pass already resolved — no extra fetch.
-    // Flag-OFF (default) → NO new branch: no symbol extraction, no RAG query, and `impactMapContext` is left
-    // undefined so the prompt is byte-identical to today. Fully fail-safe (computeImpactMap never throws; a
-    // missing/cold RAG index degrades to an empty impact map, which formats to "" and appends nothing).
+    // Deterministic impact map (#2184/#2186): operator env kill-switch + per-repo review.impact_map opt-in
+    // (shouldComputeImpactMap, #4102 precedence). Reuses the SAME changed files this pass already resolved — no
+    // extra fetch. Flag-OFF (default) → NO new branch: no symbol extraction, no RAG query, and
+    // `impactMapContext` is left undefined so the prompt is byte-identical to today. Fully fail-safe
+    // (computeImpactMap never throws; a missing/cold RAG index degrades to an empty impact map, which formats
+    // to "" and appends nothing).
     let impactMapContext: string | undefined;
     // The computed entries are ALSO threaded out of this function (#1971) so the publish site can render the
     // "Impact map" collapsible from the exact same array — no second RAG query. Empty when the feature is off.
     let impactMapEntries: ImpactMapEntry[] = [];
-    if (shouldComputeImpactMap(env, args.reviewImpactMap === true)) {
+    if (shouldComputeImpactMap(env, args.reviewImpactMap)) {
       const [impactMapProject, impactMapRepo] = splitRepoForRag(args.repoFullName);
       const changedSymbols = extractChangedSymbols(
         files.map((file) => ({
@@ -9299,7 +9301,7 @@ async function maybePublishPrPublicSurface(
             // Impact map (#2182-#2186): queries the SAME live vector index RAG does (computeImpactMap issues
             // its own retrieveContextWithMetrics calls), so it can go stale for the SAME head SHA exactly like
             // RAG — a repo with it active also bypasses the AI-review result cache.
-            impactMap: shouldComputeImpactMap(env, reviewImpactMap === true),
+            impactMap: shouldComputeImpactMap(env, reviewImpactMap),
           };
           const dynamicReviewContextActive =
             dynamicReviewFeatures.grounding ||

--- a/src/review/impact-map-wire.ts
+++ b/src/review/impact-map-wire.ts
@@ -1,9 +1,11 @@
-// Impact-map activation wiring (#2184, config slice of #1971). Mirrors rag-wire.ts's isRagEnabled: a single
-// GLOBAL env kill-switch the self-host operator controls, ANDed with the per-repo `.gittensory.yml
-// review.impact_map` manifest toggle (resolved via `resolveReviewPromptOverrides`'s `impactMap` field) — so a
-// repo can only ever NARROW what the operator has already turned on, never widen it. Both OFF by default:
-// with the env flag unset, impact-map computation is never invoked from the review path at all (the caller
-// guards on this flag before doing any RAG query or rendering), so the review stays byte-identical to today.
+// Impact-map activation wiring (#2184, config slice of #1971; activation precedence fixed for #4102). Default
+// OFF: the operator flag GITTENSORY_REVIEW_IMPACT_MAP is a master kill-switch, and the per-repo `.gittensory.yml
+// review.impactMap` toggle (resolved via `resolveReviewPromptOverrides`'s `impactMap` field) fully controls
+// activation by itself when explicitly set — impact-map has never had a `GITTENSORY_REVIEW_REPOS` cutover
+// allowlist fallback (unlike rag/reputation/grounding/safety/unifiedComment), so there is nothing for a repo
+// toggle to bypass. With the env flag unset, impact-map computation is never invoked from the review path at
+// all (the caller guards on this flag before doing any RAG query or rendering), so the review stays
+// byte-identical to today.
 //
 // Also hosts the AI-review grounding formatter (#2186): `formatImpactMapPromptSection` turns
 // `computeImpactMap`'s output into the bounded "IMPACT MAP" block spliced into the reviewer's user prompt via
@@ -20,14 +22,23 @@ export function isImpactMapEnabled(env: { GITTENSORY_REVIEW_IMPACT_MAP?: string 
   return /^(1|true|yes|on)$/i.test(env.GITTENSORY_REVIEW_IMPACT_MAP ?? "");
 }
 
-/** Resolve whether impact-map computation should run for THIS repo/PR: the operator's global env kill-switch
- *  AND the per-repo manifest opt-in. Neither alone is sufficient — mirrors every other converged-feature gate
- *  in this codebase (env kill-switch first, then the manifest narrows it further). */
+/** PURE (#4102): should impact-map computation run for THIS repo/PR? (1) The operator's
+ *  GITTENSORY_REVIEW_IMPACT_MAP flag is an absolute MASTER KILL-SWITCH — off ⇒ always false, regardless of the
+ *  manifest, and no per-repo config can bypass it (consistent with every other converged feature — see
+ *  `resolveConvergedFeature` in `feature-activation.ts`). (2) An explicit per-repo `.gittensory.yml`
+ *  `review.impactMap` override (`true`/`false`) FULLY controls the feature by itself once the kill-switch is
+ *  on — impact-map has never had a `GITTENSORY_REVIEW_REPOS` cutover-allowlist fallback, so there is no
+ *  allowlist for a repo toggle to bypass. (3) `manifestToggle` unset (`undefined`) preserves this feature's
+ *  ORIGINAL always-off-unless-both-set default exactly: with no allowlist to fall back to, an unset manifest
+ *  toggle stays `false`, byte-identical to every repo's behavior before this change. Exactly mirrors
+ *  `shouldRequestInlineFindings`/`shouldEmitFixHandoff`'s shape and precedence (src/review/inline-comments.ts,
+ *  src/review/fix-handoff.ts). */
 export function shouldComputeImpactMap(
   env: { GITTENSORY_REVIEW_IMPACT_MAP?: string | undefined },
-  manifestImpactMapEnabled: boolean,
+  manifestToggle: boolean | undefined,
 ): boolean {
-  return isImpactMapEnabled(env) && manifestImpactMapEnabled;
+  if (!isImpactMapEnabled(env)) return false;
+  return manifestToggle === true;
 }
 
 /** Hard cap on entries actually formatted into the AI-review prompt section — bounds prompt-token cost

--- a/test/unit/impact-map-wire.test.ts
+++ b/test/unit/impact-map-wire.test.ts
@@ -13,21 +13,33 @@ describe("isImpactMapEnabled", () => {
   });
 });
 
-describe("shouldComputeImpactMap", () => {
-  it("requires BOTH the operator env flag AND the per-repo manifest opt-in", () => {
+describe("shouldComputeImpactMap (#4102 precedence: env kill-switch, then manifestToggle === true fully decides)", () => {
+  it("is ON when the operator flag is on and the manifest explicitly opted in", () => {
     expect(shouldComputeImpactMap({ GITTENSORY_REVIEW_IMPACT_MAP: "true" }, true)).toBe(true);
   });
 
-  it("is OFF when the operator flag is on but the manifest didn't opt in", () => {
+  it("is OFF when the operator flag is on but the manifest explicitly opted out", () => {
     expect(shouldComputeImpactMap({ GITTENSORY_REVIEW_IMPACT_MAP: "true" }, false)).toBe(false);
   });
 
-  it("is OFF when the manifest opted in but the operator flag is off (repo cannot self-enable)", () => {
+  it("is OFF when the operator flag is on but the manifest toggle is unset (regression: preserves the ORIGINAL always-off default — there is no allowlist fallback for impactMap)", () => {
+    expect(shouldComputeImpactMap({ GITTENSORY_REVIEW_IMPACT_MAP: "true" }, undefined)).toBe(false);
+  });
+
+  it("is OFF when the manifest opted in but the operator flag is off — the env flag is an absolute master kill-switch no per-repo config can bypass", () => {
     expect(shouldComputeImpactMap({ GITTENSORY_REVIEW_IMPACT_MAP: "false" }, true)).toBe(false);
+  });
+
+  it("is OFF when the operator flag is unset and the manifest opted in — the kill-switch still wins", () => {
+    expect(shouldComputeImpactMap({}, true)).toBe(false);
   });
 
   it("is OFF when both are off", () => {
     expect(shouldComputeImpactMap({}, false)).toBe(false);
+  });
+
+  it("is OFF when both are unset", () => {
+    expect(shouldComputeImpactMap({}, undefined)).toBe(false);
   });
 });
 

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -6247,10 +6247,10 @@ describe("queue processors", () => {
       AI_SUMMARIES_ENABLED: "true",
       AI_PUBLIC_COMMENTS_ENABLED: "true",
       AI_DAILY_NEURON_BUDGET: "100000",
-      // Both gates on: the global capability switch, and (like culture-profile above, unlike
+      // Both gates on: the global kill-switch, and (like culture-profile above, unlike
       // grounding/enrichment/RAG/reputation which are env-only) the per-repo `.gittensory.yml` opt-in mocked
       // below, so `dynamicReviewFeatures.impactMap` (src/queue/processors.ts) actually evaluates
-      // shouldComputeImpactMap's `&&` right-hand side true, not just short-circuits.
+      // shouldComputeImpactMap's `manifestToggle === true` arm true, not just the kill-switch short-circuit.
       GITTENSORY_REVIEW_IMPACT_MAP: "true",
     });
     await persistRegistrySnapshot(


### PR DESCRIPTION
## Summary

- `shouldComputeImpactMap` (`src/review/impact-map-wire.ts`) previously required `isImpactMapEnabled(env) && manifestImpactMapEnabled` — a required AND where every call site had to pre-collapse the manifest's `boolean | undefined` toggle to a strict `boolean` (`args.reviewImpactMap === true`) before calling in.
- Migrated it onto the same precedence shape `inlineComments`/`fixHandoff` already use (#4099, PR #4116): the operator's `GITTENSORY_REVIEW_IMPACT_MAP` flag is an absolute master kill-switch (off ⇒ always false, no per-repo bypass), and once it's on, the manifest's `review.impactMap` toggle (`manifestToggle: boolean | undefined`) fully decides via `manifestToggle === true`. impact-map has never had a `GITTENSORY_REVIEW_REPOS` cutover-allowlist fallback, so there was nothing to "bypass" in that dimension — this PR closes the config-as-code gap by moving the `=== true` collapse into the single resolver instead of leaving it scattered at each call site.
- Updated both call sites in `src/queue/processors.ts` (the AI-review prompt gate and the cache-bypass `dynamicReviewFeatures.impactMap` gate) to pass the raw manifest value straight through instead of pre-coercing it.
- Behavior is byte-identical for every existing repo: given the same `(env, manifestValue)` pair, the old and new resolvers compute the exact same boolean (verified with a regression test asserting an unset manifest toggle still resolves to `false` even with the env flag on).
- `src/review/ai-review-cache-input.ts` and `src/review/unified-comment-bridge.ts` were checked and need no changes — both consume the already-resolved boolean/array *after* activation, not the activation decision itself.

Closes #4102

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This is a backend-only `src/review` + `src/queue` change with no UI/MCP/OpenAPI/wrangler surface touched, so `ui:*`, `build:mcp`/`test:mcp-pack`, `test:workers`, and `ui:openapi:check` were not run locally (nothing in the diff can affect them). `npm run actionlint` was not run locally (no `.github/workflows/**` changes in this diff). Coverage was measured via `npx vitest run --coverage --pool=forks test/unit/impact-map-wire.test.ts test/unit/queue.test.ts` (targeted, not the full unsharded suite) — `src/review/impact-map-wire.ts`'s `shouldComputeImpactMap` shows 100% line/branch coverage (`LF:19 LH:19`, `BRF:12 BRH:12` in `coverage/lcov.info`), and the two `src/queue/processors.ts` call-site lines are executed on every AI-review pass (verified hit counts in the same lcov output). The full `test/unit/queue.test.ts` suite (697 tests) was run in full and passes, both before and after rebasing onto `origin/main`.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP surface touched.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes.)
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository. (N/A — no visible UI change.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (N/A — no docs/changelog change needed.)

## UI Evidence

N/A — backend-only change, no visible UI/frontend/docs/extension surface touched.

## Notes

- This mirrors the exact fix shape used for `inlineComments`/`fixHandoff` (#4099, merged as PR #4116) and is one of a set of sibling issues in the same epic (#4101 for `reviewMemory`, #4103) applying the same precedence pattern to other standalone review-feature toggles.
