### PR TITLE
fix(review): persist merge train settings paths

### DIFF
--- a/packages/gittensory-engine/src/focus-manifest.ts
+++ b/packages/gittensory-engine/src/focus-manifest.ts
@@ -323,6 +323,7 @@ export type FocusManifestSettings = Partial<
     | "reviewEvasionProtection"
     | "reviewEvasionLabel"
     | "reviewEvasionComment"
+    | "mergeTrainMode"
   >
 > & {
   // `typeLabels`/`linkedIssueLabelPropagation`/`linkedIssueHardRules` are declared PARTIAL here (not via the `Pick<RepositorySettings,
@@ -1867,6 +1868,8 @@ function parseSettingsOverride(value: JsonValue | undefined, warnings: string[])
   }
   const reviewEvasionComment = normalizeOptionalBoolean(r.reviewEvasionComment, "settings.reviewEvasionComment", warnings);
   if (reviewEvasionComment !== null) out.reviewEvasionComment = reviewEvasionComment;
+  const mergeTrainMode = normalizeOptionalEnum(r.mergeTrainMode, "settings.mergeTrainMode", ["off", "audit", "enforce"] as const, warnings);
+  if (mergeTrainMode !== null) out.mergeTrainMode = mergeTrainMode;
   return out;
 }
 

--- a/packages/gittensory-engine/src/types/manifest-deps-types.ts
+++ b/packages/gittensory-engine/src/types/manifest-deps-types.ts
@@ -479,6 +479,9 @@ export type RepositorySettings = {
   /** Review-evasion protection: whether to post the public explanation comment before the enforcement close.
    *  Default true. */
   reviewEvasionComment?: boolean | undefined;
+  /** Merge-train FIFO gate (#selfhost-merge-train): `"off"` keeps current behavior, `"audit"` logs would-hold
+   *  decisions, and `"enforce"` defers a merge behind a still-viable older sibling. */
+  mergeTrainMode?: "off" | "audit" | "enforce" | undefined;
   /** Config-driven before/after screenshot-table gate (#2006): a DETERMINISTIC check (no AI, zero hallucination
    *  risk) that a contributor visual/frontend PR's body contains a markdown table with before/after image
    *  markup, scoped to the repo's configured labels/paths (`whenLabels`/`whenPaths`, OR-matched). Off by

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -729,6 +729,7 @@ const maintainerSettingsSchema = z
     manifestPolicyGateMode: z.enum(["off", "advisory", "block"]),
     selfAuthoredLinkedIssueGateMode: z.enum(["off", "advisory", "block"]),
     linkedIssueSatisfactionGateMode: z.enum(["off", "advisory", "block"]),
+    mergeTrainMode: z.enum(["off", "audit", "enforce"]),
     firstTimeContributorGrace: z.boolean(),
     slopGateMode: z.enum(["off", "advisory", "block"]),
     slopGateMinScore: z.number().int().min(0).max(100).nullable(),

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -2448,7 +2448,7 @@ describe("api routes", () => {
         // #2267: qualityGateMode: "block" is downgraded to "advisory" on write — readiness/quality can never
         // hard-block a PR, so the dashboard/API save path can't persist a value implying enforcement it doesn't
         // have. slopGateMode: "block" is a DIFFERENT, legitimately-blockable dimension and is left untouched.
-        body: JSON.stringify({ gateCheckMode: "enabled", slopGateMode: "block", slopGateMinScore: 55, qualityGateMode: "block", autonomy: { merge: "auto_with_approval", deploy: "auto" }, autoMaintain: { requireApprovals: 2, mergeMethod: "rebase" }, agentPaused: true, agentDryRun: true }),
+        body: JSON.stringify({ gateCheckMode: "enabled", slopGateMode: "block", slopGateMinScore: 55, qualityGateMode: "block", mergeTrainMode: "enforce", autonomy: { merge: "auto_with_approval", deploy: "auto" }, autoMaintain: { requireApprovals: 2, mergeMethod: "rebase" }, agentPaused: true, agentDryRun: true }),
       },
       ownerEnv,
     );
@@ -2462,6 +2462,7 @@ describe("api routes", () => {
       slopGateMode: "block",
       slopGateMinScore: 55,
       qualityGateMode: "advisory", // #2267: downgraded, not persisted as "block"
+      mergeTrainMode: "enforce",
       autonomy: { merge: "auto_with_approval" }, // unknown action class dropped by the DB normalizer
       autoMaintain: { requireApprovals: 2, mergeMethod: "rebase" },
       agentPaused: true, // #776 kill-switch

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -342,6 +342,7 @@ describe(".gittensory.yml.example field-exhaustiveness (#1670)", () => {
     reviewEvasionProtection: "reviewEvasionProtection:",
     reviewEvasionLabel: "reviewEvasionLabel:",
     reviewEvasionComment: "reviewEvasionComment:",
+    mergeTrainMode: "mergeTrainMode:",
     typeLabels: "typeLabels:",
     linkedIssueLabelPropagation: "linkedIssueLabelPropagation:",
     linkedIssueHardRules: "linkedIssueHardRules:",
@@ -1786,13 +1787,14 @@ describe("parseFocusManifest settings override + resolveEffectiveSettings", () =
 
   it("drops invalid settings values with warnings and keeps the valid ones", () => {
     const m = parseFocusManifest({
-      settings: { commentMode: "loud", qualityGateMinScore: "high", autoLabelEnabled: "yes", gittensorLabel: "   ", publicSurface: "comment_only" },
+      settings: { commentMode: "loud", qualityGateMinScore: "high", autoLabelEnabled: "yes", gittensorLabel: "   ", mergeTrainMode: "later", publicSurface: "comment_only" },
     });
     expect(m.settings).toEqual({ publicSurface: "comment_only" });
     expect(m.warnings.some((w) => /settings\.commentMode/.test(w))).toBe(true);
     expect(m.warnings.some((w) => /settings\.qualityGateMinScore/.test(w))).toBe(true);
     expect(m.warnings.some((w) => /settings\.autoLabelEnabled/.test(w))).toBe(true);
     expect(m.warnings.some((w) => /settings\.gittensorLabel/.test(w))).toBe(true);
+    expect(m.warnings.some((w) => /settings\.mergeTrainMode/.test(w))).toBe(true);
   });
 
   it("ignores a non-mapping settings block and treats a settings-only manifest as present", () => {
@@ -1815,7 +1817,7 @@ describe("parseFocusManifest settings override + resolveEffectiveSettings", () =
   });
 
   it("round-trips settings through settingsOverrideToJson and serializes empty as null", () => {
-    const original = parseFocusManifest({ settings: { commentMode: "all_prs", qualityGateMinScore: 40 } });
+    const original = parseFocusManifest({ settings: { commentMode: "all_prs", qualityGateMinScore: 40, mergeTrainMode: "audit" } });
     const reparsed = parseFocusManifest({ settings: settingsOverrideToJson(original.settings) });
     expect(reparsed.settings).toEqual(original.settings);
     expect(settingsOverrideToJson(parseFocusManifest({}).settings)).toBeNull();


### PR DESCRIPTION
### Motivation

- The `mergeTrainMode` setting was normalized in-memory but was not accepted by the maintainer settings API, not parsed from `.gittensory.yml`, and not present in the engine settings type, so persisted rows kept the SQL default `off` and the merge-train gate could not be enabled.

### Description

- Add `mergeTrainMode` to the maintainer settings schema so the authenticated `PUT /v1/repos/:owner/:repo/settings` endpoint accepts `"off" | "audit" | "enforce"` (`src/api/routes.ts`).
- Parse and normalize `settings.mergeTrainMode` from focus-manifest overrides and include it in the focus-manifest allowlist so `.gittensory.yml` can override this setting (`packages/gittensory-engine/src/focus-manifest.ts`).
- Keep the engine-facing settings type in sync by adding `mergeTrainMode` to the manifest dependency types (`packages/gittensory-engine/src/types/manifest-deps-types.ts`).
- Update tests and examples to cover the end-to-end save/parse/round-trip behaviour and the maintainer API surface (`test/integration/api.test.ts`, `test/unit/focus-manifest.test.ts`).

### Testing

- Built the miner with `npm run build:miner` and the build succeeded.
- Ran unit and integration tests with `npx vitest run test/unit/repository-settings-merge-train-mode.test.ts test/unit/focus-manifest.test.ts test/integration/api.test.ts` and all tests passed (3 test files, 572 tests total passed).
- Ran `npm run typecheck` and `git diff --check` which both succeeded locally.
- Attempted `npm audit --audit-level=moderate` but the registry audit endpoint returned `403 Forbidden` in this environment so the audit could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d9ce0fe38832c86767bc9933aa08d)