### PR TITLE
fix(queue): keep gate enforcement while autoreview is paused

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -3246,7 +3246,7 @@ async function reReviewStoredPullRequest(
   ]);
   let pr = await getPullRequest(env, repoFullName, prNumber);
   if (!pr || pr.state !== "open") return;
-  if (await hasAutoreviewPausedMarker(env, repoFullName, prNumber)) return;
+  const autoreviewPaused = await hasAutoreviewPausedMarker(env, repoFullName, prNumber);
   const liveFacts = createLiveGithubFacts();
   // #sweep-resync: RESYNC the stored PR to its LIVE head before reviewing. The self-host relay can drop the
   // `synchronize` webhook (relay down), so a push/rebase never refreshes the stored head SHA + cached files; the
@@ -3381,7 +3381,7 @@ async function reReviewStoredPullRequest(
           baseSha: live?.base?.sha ?? null,
           liveFacts,
           ...(previewPollAttempt !== undefined ? { previewPollAttempt } : {}),
-          ...(options.skipAiReview ? { skipAiReview: true } : {}),
+          ...(options.skipAiReview || autoreviewPaused ? { skipAiReview: true } : {}),
           ...(options.force ? { forceAiReview: true } : {}),
           hasPendingRefreshSignal: otherRefreshReasons || reviewsCacheStale,
         },

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -4259,7 +4259,7 @@ describe("queue processors", () => {
       expect(skipAudit).toBeUndefined();
     });
 
-    it("does not publish the re-review surface once a PR has an autoreview pause marker (#2164 regression)", async () => {
+    it("skips AI review but still enforces the gate once a PR has an autoreview pause marker (#2164 regression)", async () => {
       let aiCalls = 0;
       let commentPosted = false;
       let checkRunWritten = false;
@@ -4318,7 +4318,7 @@ describe("queue processors", () => {
       ).resolves.toBeUndefined();
       expect(aiCalls).toBe(0);
       expect(commentPosted).toBe(false);
-      expect(checkRunWritten).toBe(false);
+      expect(checkRunWritten).toBe(true);
     });
 
     it("threads review.ai_model through the full webhook pipeline into ai.run's options (#selfhost-ai-model-override)", async () => {


### PR DESCRIPTION
### Motivation
- A recent change short-circuited `reReviewStoredPullRequest` when a `github_app.autoreview_paused` audit row existed, which skipped live resync, gate computation, and `maybeRunAgentMaintenance`, widening the pause beyond its intended AUTO-REVIEW scope.
- The goal is to preserve the documented pause semantics: suppress AI/public surface generation only, while still recomputing the gate and running maintenance/enforcement paths.

### Description
- Replace the early-return pause check in `reReviewStoredPullRequest` with a boolean flag: `const autoreviewPaused = await hasAutoreviewPausedMarker(...)` so the stored re-review continues through resync/readiness and maintenance.
- Thread the `autoreviewPaused` flag into the `maybePublishPrPublicSurface` call by setting `skipAiReview` when `options.skipAiReview || autoreviewPaused` so only AI/public-surface work is suppressed.
- Update the regression unit test in `test/unit/queue.test.ts` to assert that AI/comment output remains suppressed while the gate check-run is still written.
- Modified files: `src/queue/processors.ts` and `test/unit/queue.test.ts`.

### Testing
- Ran `git diff --check` which succeeded.
- Ran the targeted unit test with `npm test -- test/unit/queue.test.ts -t "skips AI review but still enforces the gate once a PR has an autoreview pause marker" --reporter=verbose` and it passed (`Tests 1 passed | 702 skipped`).
- Ran `npm run typecheck` which completed without errors.
- Ran the full gate `npm run test:ci` which aborted at `cf-typegen:check` due to a stale generated `worker-configuration.d.ts` unrelated to this change, so full CI remains blocked by that generated-artifact drift.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4dee1a07e0832cbf9398b6b7cc8677)