### PR TITLE
fix(review): avoid review effort boundary undercounts

### DIFF
--- a/src/review/review-effort.ts
+++ b/src/review/review-effort.ts
@@ -46,9 +46,10 @@ function bandForEffort(effort: number): 1 | 2 | 3 | 4 | 5 {
   return 5;
 }
 
-/** Map a persisted minutes estimate back to its complexity band (inverse of `estimateReviewEffort`'s minutes step). */
+/** Map a persisted rounded minutes estimate to the highest complexity band it could represent. */
 export function bandFromMinutes(minutes: number): 1 | 2 | 3 | 4 | 5 {
-  return bandForEffort(Math.max(0, minutes) / MINUTES_PER_EFFORT);
+  const maxRepresentedEffort = (Math.max(0, minutes) + 0.5) / MINUTES_PER_EFFORT;
+  return bandForEffort(maxRepresentedEffort);
 }
 
 /** Estimate the review effort of a change set. Pure and deterministic. */

--- a/test/unit/review-effort.test.ts
+++ b/test/unit/review-effort.test.ts
@@ -69,4 +69,11 @@ describe("bandFromMinutes (#2155)", () => {
       expect(bandFromMinutes(sample.minutes)).toBe(sample.band);
     }
   });
+
+  it("keeps rounded boundary minutes in the higher possible band (regression for #2155)", () => {
+    expect(bandFromMinutes(5)).toBe(2);
+    expect(bandFromMinutes(20)).toBe(3);
+    expect(bandFromMinutes(60)).toBe(4);
+    expect(bandFromMinutes(150)).toBe(5);
+  });
 });

--- a/test/unit/stats.test.ts
+++ b/test/unit/stats.test.ts
@@ -152,6 +152,10 @@ describe("aggregateReviewEffort — maintainer complexity fold (#2155)", () => {
     // minutes 4 -> band 1; minutes 96 -> band 4 -> rounded avg 3; total 100.
     expect(aggregateReviewEffort([4, 96])).toEqual({ avgBand: 3, totalEstimatedMinutes: 100 });
   });
+
+  it("keeps boundary-rounded minutes in the higher possible avgBand (regression for #2155)", () => {
+    expect(aggregateReviewEffort([5, 20, 60, 150])).toEqual({ avgBand: 4, totalEstimatedMinutes: 235 });
+  });
 });
 
 describe("computeStats — review-effort read is fail-safe", () => {


### PR DESCRIPTION
### Motivation
- Persisted review-effort minutes are stored rounded, and the prior `bandFromMinutes` reconstructed effort as `minutes / MINUTES_PER_EFFORT`, which can map rounded boundary minutes down into the previous complexity band. 
- This produced undercounted maintainer `avgBand` values when folding persisted minutes into aggregates, affecting analytics accuracy (non-security, correctness only).

### Description
- Update `bandFromMinutes` to treat a persisted rounded minutes value as representing any effort up to `minutes + 0.5`, computing `maxRepresentedEffort = (Math.max(0, minutes) + 0.5) / MINUTES_PER_EFFORT` and returning `bandForEffort(maxRepresentedEffort)`. 
- Add regression unit tests to `test/unit/review-effort.test.ts` and `test/unit/stats.test.ts` that assert boundary-rounded minutes map to the higher possible band and that aggregates reflect that. 
- Preserve existing `estimateReviewEffort` behavior and total minutes folding; this change only adjusts band reconstruction from persisted minutes.

### Testing
- Ran targeted unit tests with `npx vitest run test/unit/review-effort.test.ts test/unit/stats.test.ts --pool=forks`, and both test files passed (43 tests).
- Ran static typecheck with `npm run typecheck` and verified `git diff --check`, both succeeded locally.
- Attempted full coverage with `npm run test:coverage`, but coverage remapping failed during generation with `TypeError: jsTokens is not a function`, so an unsharded coverage report could not be completed in this environment despite the targeted tests passing.
- `npm audit --audit-level=moderate` could not complete due to the registry returning `403 Forbidden` from the audit endpoint in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4dee1c0f98832c8e9e9e6d8dbf1eb6)