### PR TITLE
perf(selfhost): document retention/concurrency sizing, fix stale runner docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -298,11 +298,21 @@ REDIS_URL=redis://redis:6379                # REQUIRED for the self-host review 
 #                                            #   a moderate-load instance (several active repos / a steady
 #                                            #   contributor-PR stream) on a host with a few spare cores -- review
 #                                            #   jobs are I/O-bound (GitHub + AI awaits dominate), so raising this
-#                                            #   mostly buys parallelism, not CPU. Watch gittensory_queue_live_pending
+#                                            #   mostly buys parallelism, not CPU. As a core-count anchor (#1828):
+#                                            #   a 2-vCPU host is comfortable around the default of 4; a 4+ vCPU
+#                                            #   host can reasonably go to 8-12 before the loops' own CPU work
+#                                            #   (JSON parsing, diff rendering, AI-response handling) starts
+#                                            #   competing for the cycles the I/O awaits were supposed to free up.
+#                                            #   Watch gittensory_queue_live_pending
 #                                            #   / gittensory_queue_oldest_live_pending_age_seconds after raising it;
 #                                            #   if those stay high, the bottleneck is elsewhere (GitHub rate limit,
 #                                            #   AI latency, Postgres pool -- see PGPOOL_MAX above), not concurrency.
 # QUEUE_BACKGROUND_CONCURRENCY=1             # max low-priority/background jobs allowed to occupy QUEUE_CONCURRENCY slots
+#                                            #   (default 1 reserves the rest of even a small 2-vCPU host's default
+#                                            #   4 slots for live review work). Scale it WITH QUEUE_CONCURRENCY, not
+#                                            #   independently -- keep it to roughly a quarter to a third of
+#                                            #   QUEUE_CONCURRENCY (e.g. 2-3 of a 4+ vCPU host's 8-12) so background
+#                                            #   maintenance can never crowd out every live-review slot.
 # CONTRIBUTOR_EVIDENCE_BATCH_SIZE=150        # logins per build-contributor-evidence job; the scheduled run fans out into
 #                                            #   per-batch jobs above this so the per-login GitHub reads spread across the
 #                                            #   queue instead of bursting. Set 0 to disable the fan-out (single job).

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-operations.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-operations.tsx
@@ -328,16 +328,20 @@ DISCORD_REPO_WEBHOOKS={"owner/repoA":"https://discord.com/api/webhooks/...","own
                 + <code>--profile runners</code>
               </td>
               <td className="py-2 pr-4 align-top text-muted-foreground">
-                Unbounded by default — can starve the app under CI load
+                Unbounded by default — can still starve the app under CI load
               </td>
-              <td className="py-2 pr-4 align-top text-muted-foreground">Unbounded by default</td>
+              <td className="py-2 pr-4 align-top text-muted-foreground">
+                Bounded by <code>RUNNER_MEM_LIMIT</code> (default 2g) per replica
+              </td>
               <td className="py-2 align-top text-muted-foreground">
-                Estimated, and explicitly a known risk, not a guess about typical usage: the{" "}
-                <code>runner</code> service ships with no CPU/memory limit at all. Production
-                experience already documented in <code>docker-compose.override.yml.example</code>{" "}
-                found 3 uncapped runner containers starving the app for CPU on an 8-vCPU box under
-                real CI load — see that file for the <code>cpu_shares</code>/<code>cpus</code>{" "}
-                mitigation before co-locating runners with the review stack.
+                Estimated, and explicitly a known risk on the CPU side, not a guess about typical
+                usage: the <code>runner</code> service ships with a default memory ceiling (
+                <code>RUNNER_MEM_LIMIT</code>, default 2g, added by #3893) but no CPU limit.
+                Production experience already documented in{" "}
+                <code>docker-compose.override.yml.example</code> found 3 uncapped runner containers
+                starving the app for CPU on an 8-vCPU box under real CI load — see that file for the{" "}
+                <code>cpu_shares</code>/<code>cpus</code> mitigation before co-locating runners with
+                the review stack.
               </td>
             </tr>
             <tr>
@@ -402,10 +406,11 @@ DISCORD_REPO_WEBHOOKS={"owner/repoA":"https://discord.com/api/webhooks/...","own
         and still has real headroom), and nothing is so oversized relative to plausible usage that
         it should be lowered — including Ollama&apos;s comparatively large 8GiB ceiling, which is
         sized for holding one quantized model in memory, not idle overhead. The one real gap is{" "}
-        <code>--profile runners</code>, which ships with no limit at all; that is a known,
-        documented tradeoff (see the table above and{" "}
+        <code>--profile runners</code>&apos;s CPU side: the service has a default memory ceiling (
+        <code>RUNNER_MEM_LIMIT</code>, default 2g) but ships with no CPU limit at all; that is a
+        known, documented tradeoff (see the table above and{" "}
         <code>docker-compose.override.yml.example</code>) rather than an oversight, since the right
-        ceiling depends entirely on the host's core count and how many runner replicas you run.
+        CPU ceiling depends entirely on the host's core count and how many runner replicas you run.
       </p>
 
       <h3>Capacity planning: how much disk for N repos at M PRs/month</h3>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -510,7 +510,15 @@ services:
     command:
       - "--config.file=/etc/prometheus/prometheus.yml"
       - "--storage.tsdb.path=/prometheus"
-      - "--storage.tsdb.retention.time=${PROMETHEUS_RETENTION_TIME:-180d}"
+      # 90d, not the 336h/14d of Loki or 168h/7d of Tempo below (#1828): that gap is deliberate, not an
+      # oversight — Prometheus's TSDB compresses numeric samples to ~1-2 bytes each after compaction, so
+      # metrics cost far less disk per retained day than Loki's raw log lines or Tempo's full span trees,
+      # and the self-hosting-operations docs' own capacity-planning guidance wants a multi-week/month
+      # trend window for metrics specifically. That said, 180d (six months) had no sizing rationale of
+      # its own — it silently replaced a deliberate 30d default when this became an override-able var in
+      # #1678 — so 90d is the considered number here: a full quarter of history for trend/capacity
+      # review, without defaulting a small self-host box to open-ended, unbounded-looking retention.
+      - "--storage.tsdb.retention.time=${PROMETHEUS_RETENTION_TIME:-90d}"
     deploy:
       resources:
         limits:


### PR DESCRIPTION
## Summary

**Behavior change, not just documentation:** the Prometheus retention default drops from `180d` to
`90d`. Any fresh self-host deployment that has not set `PROMETHEUS_RETENTION_TIME` explicitly will get
90 days of metrics history instead of 180 on its next `docker compose up` for that service. Existing
running deployments are unaffected until the `prometheus` container is recreated with the new image
(Prometheus does not retroactively delete data on a live container from a compose-file-only change);
recreation will prune anything older than 90 days. Operators who want to keep 180d (or any other
value) can set `PROMETHEUS_RETENTION_TIME=180d` in their `.env` to opt back in — the var was already
override-able before this PR, only the unset-fallback value changes.

Issue #1828's earlier work already shipped the per-service memory limits, the resource-profile
matrix, the image-size audit, the dashboard, and the Redis/Loki/Tempo sizing. This closes out the
three remaining gaps found on a direct re-check of the current `docker-compose.yml`/`.env.example`/docs:

- `docker-compose.yml`'s Prometheus `--storage.tsdb.retention.time=${PROMETHEUS_RETENTION_TIME:-180d}`
  had no sizing-rationale comment, unlike the sibling Loki (`336h`/14d) and Tempo (`168h`/7d) settings.
  Rather than just add a comment defending 180d as-is, I traced its history
  (`git log -S "PROMETHEUS_RETENTION_TIME" -- docker-compose.yml`): it was a deliberate `30d` default
  until #1678 silently turned it into an override-able var defaulted to `180d` with zero rationale.
  Metrics genuinely can justify outliving logs/traces — Prometheus's TSDB compresses numeric samples
  to ~1-2 bytes each after compaction, so retaining them longer costs far less disk per day than
  Loki's raw log lines or Tempo's full span trees — but six months with no stated reasoning is drift,
  not a decision. Lowered the default to `90d` (a full quarter for the capacity-planning trend window
  the docs already describe) and added a comment explaining both the "why longer than Loki/Tempo" and
  the "why not 180d" reasoning.
- `.env.example`'s `QUEUE_CONCURRENCY` (`src/selfhost/sqlite-queue.ts`, `src/selfhost/pg-queue.ts`,
  fallback 4) and `QUEUE_BACKGROUND_CONCURRENCY` (`src/selfhost/queue-common.ts`,
  `DEFAULT_BACKGROUND_CONCURRENCY = 1`) had no core-count-based sizing guidance, unlike the existing
  `PGPOOL_MAX` comment. Added guidance anchored to vCPU count (a 2-vCPU host is comfortable around the
  default of 4; 4+ vCPUs can reasonably go to 8-12) and scaled `QUEUE_BACKGROUND_CONCURRENCY` relative
  to `QUEUE_CONCURRENCY` (roughly a quarter to a third of it) rather than as an independent number.
- `apps/gittensory-ui/src/routes/docs.self-hosting-operations.tsx` claimed in two places that the
  `runner` service "ships with no CPU/memory limit at all." That became false once `RUNNER_MEM_LIMIT`
  (default `2g`, docker-compose.yml line ~820) was added for #3893. Fixed both occurrences plus a
  third, directly adjacent table cell making the same now-stale claim ("Unbounded by default" in the
  Memory column) so the row is internally consistent — all three now correctly describe a default
  memory ceiling with CPU-priority pinning remaining opt-in via `docker-compose.override.yml.example`.

This is a docs + config-comment change; no `src/**`/`packages/**` lines were touched, so there is no
Codecov obligation on this diff (verified: `git diff --name-only` against `origin/main` shows only
`docker-compose.yml`, `.env.example`, and the one `apps/gittensory-ui` route file).

Closes #1828.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #1828`) — verified open/unassigned via `gh issue view 1828 --json state,assignees`.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint` (via `npm run test:ci`; no workflow files touched, ran anyway as part of the full gate)
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — 582 passed / 2 skipped, unsharded. No `src/**`/`packages/**` lines changed, so no new coverage obligation; ran it anyway to confirm nothing broke.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [ ] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — not applicable: no `src/**`/`packages/**` code changed, only prose/comments in `docker-compose.yml`, `.env.example`, and one docs route.

Additionally ran the full `npm run test:ci` gate (all steps: `db:migrations:check`, `db:schema-drift:check`,
`selfhost:env-reference:check`, `selfhost:validate-observability`, `cf-typegen:check`, `test:coverage`,
`test:workers`, `build:mcp`/`test:mcp-pack`, `build:miner`/`test:miner-pack`, `rees:test`,
`ui:openapi:check`/`ui:openapi:settings-parity`, `ui:version-audit`, `docs:drift-check`,
`command-reference:check`, `ui:lint`/`ui:typecheck`/`ui:test`/`ui:build`) — all green. Also validated
`docker-compose.yml` directly with `docker compose -f docker-compose.yml config --quiet` (exit 0) and
confirmed `.env.example`'s new comment lines don't collide with `selfhost:env-reference:check`'s
96-reference count (unchanged — these are comment-only edits to already-documented vars).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no such changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no such changes; `ui:openapi:check` confirms no drift.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — static docs prose only.)
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository. (No visual/layout change — corrected prose within an existing table cell and an existing paragraph; see UI Evidence below.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable: this PR only corrects prose text inside an existing table cell and an existing
paragraph on an already-shipped docs page (`docs.self-hosting-operations.tsx`) — no new component,
layout, or styling. The rendered structure is identical to what is already live; only the words
describing the runner service's memory/CPU limits changed to match current behavior.

## Notes

- Verified against source, not restated from comments: `docker-compose.yml`'s `runner` service
  (`RUNNER_MEM_LIMIT` default `2g`, added for #3893) and `docker-compose.override.yml.example`'s
  `cpu_shares`/`cpus` CPU-priority mitigation (confirms CPU pinning is still opt-in); `.env.example`'s
  existing `PGPOOL_MAX` comment (the style mirrored for the new `QUEUE_CONCURRENCY`/
  `QUEUE_BACKGROUND_CONCURRENCY` guidance); `src/selfhost/sqlite-queue.ts` and
  `src/selfhost/pg-queue.ts` (`QUEUE_CONCURRENCY` fallback of 4) and `src/selfhost/queue-common.ts`
  (`DEFAULT_BACKGROUND_CONCURRENCY = 1`); `loki/loki-config.yml` (`retention_period: 336h`) and
  `tempo/tempo.yaml` (`block_retention: 168h`) for the sibling retention comparison; and
  `git log -S "PROMETHEUS_RETENTION_TIME" -- docker-compose.yml` for the 30d→180d history behind the
  new 90d default.
- No script or test asserts a specific Prometheus retention value (checked
  `scripts/validate-observability-configs.mjs` and `test/`), so lowering the default to `90d` needed no
  test updates. Operators who want the old 180d (or the original 30d) can still set
  `PROMETHEUS_RETENTION_TIME` explicitly.
- Double-checked both historical issue/PR numbers cited in this PR's comments, since they're asserted
  as fact in shipped docs/config: `#3893` (`docker-compose.yml`'s pre-existing `RUNNER_MEM_LIMIT`
  comment, which this PR does not change, only mirrors into the docs route) is a closed issue —
  `gh api graphql` confirms `closedByPullRequestsReferences` points at merged PR #3913, "add default
  memory limit to the runner compose service." `#1678` is merged PR "wire Codex reviews and secure
  observability" — `git show` on its `docker-compose.yml` hunk confirms it is the exact commit that
  changed the hardcoded `30d` to `${PROMETHEUS_RETENTION_TIME:-180d}`. Both check out.
