### PR TITLE
ci: bundle puppeteer-core in every official self-host release image

### DIFF
--- a/.github/workflows/release-selfhost.yml
+++ b/.github/workflows/release-selfhost.yml
@@ -213,8 +213,14 @@ jobs:
           target: runtime-prebuilt
           platforms: linux/amd64,linux/arm64
           push: true
+          # Visual-capture convergence (#3607/#4111): every official image ships puppeteer-core so a
+          # self-hoster can turn on before/after screenshot capture with just BROWSER_WS_ENDPOINT +
+          # GITTENSORY_REVIEW_SCREENSHOTS=true at runtime -- no custom image build required. Inert either
+          # way until those runtime flags are set (Dockerfile's INSTALL_VISUAL_REVIEW only controls
+          # whether the dependency is installed, never whether the feature runs).
           build-args: |
             GITTENSORY_VERSION=${{ steps.version.outputs.release }}
+            INSTALL_VISUAL_REVIEW=true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           provenance: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,11 @@ RUN if [ "$INSTALL_AI_CLIS" = "true" ]; then npm install -g --foreground-scripts
 USER root
 # Optional: enable visual review via an external Chrome sidecar (docker-compose --profile visual-review
 # bundles `ghcr.io/browserless/chromium:latest`, or point at your own browserless-compatible instance).
-# Build with `--build-arg INSTALL_VISUAL_REVIEW=true` then set BROWSER_WS_ENDPOINT=<ws-url> at runtime.
+# Every official release image ships with this dependency installed (release-selfhost.yml passes
+# --build-arg INSTALL_VISUAL_REVIEW=true) -- just set BROWSER_WS_ENDPOINT=<ws-url> at runtime to use it.
+# The default here stays `false` for a LOCAL/custom build (`docker build .` with no build-arg) so building
+# straight from this Dockerfile without the release workflow doesn't silently install an unrequested
+# dependency.
 ARG INSTALL_VISUAL_REVIEW=false
 COPY package*.json ./
 RUN if [ "$INSTALL_VISUAL_REVIEW" = "true" ]; then npm install puppeteer-core@22.13.1 --ignore-scripts; fi

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -361,9 +361,10 @@ services:
   # it in two places — the server reads TOKEN below, the app embeds the same value in the client URL):
   #   BROWSERLESS_TOKEN=<a-strong-random-value>
   #   BROWSER_WS_ENDPOINT=ws://browserless:3000?token=<the-same-value>
-  # Then rebuild the app image with --build-arg INSTALL_VISUAL_REVIEW=true (installs puppeteer-core;
-  # see Dockerfile) and set GITTENSORY_REVIEW_SCREENSHOTS=true. Unset/default = fully inert, no
-  # container, no screenshots, no error — this whole feature is opt-in end to end.
+  # Then set GITTENSORY_REVIEW_SCREENSHOTS=true. Official release images already have puppeteer-core
+  # installed (release-selfhost.yml builds with --build-arg INSTALL_VISUAL_REVIEW=true) — a rebuild is
+  # only needed for a LOCAL/custom image build from this Dockerfile directly (see Dockerfile). Unset/
+  # default = fully inert, no container, no screenshots, no error — this whole feature is opt-in end to end.
   browserless:
     image: ghcr.io/browserless/chromium:latest
     restart: unless-stopped


### PR DESCRIPTION
## Summary

- Part of the visual-capture convergence epic (#3607). `release-selfhost.yml`'s release build never passed `--build-arg INSTALL_VISUAL_REVIEW=true`, so puppeteer-core has never been installed in any officially published self-host image — a self-hoster who wants the automated before/after screenshot capture has had to build a custom image from the Dockerfile themselves, undocumented, to get a dependency the feature otherwise fully supports at runtime.
- Adds `INSTALL_VISUAL_REVIEW=true` to the release build-args, so every future official image ships with puppeteer-core installed. This changes nothing about default RUNTIME behavior — the feature stays fully gated by `BROWSER_WS_ENDPOINT` + `GITTENSORY_REVIEW_SCREENSHOTS=true`, both still unset by default. A self-hoster who never sets those two still gets a byte-identical, inert deploy; one who does can now just flip the runtime flags instead of also needing a custom image build.
- Updated the `Dockerfile` and `docker-compose.yml` comments accordingly — the `ARG INSTALL_VISUAL_REVIEW=false` default is unchanged (still correct for a bare `docker build .` with no build-arg, e.g. a local/custom build), only the *official release* build's own build-args changed.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] No single open issue this PR alone resolves. This is the image-level prerequisite for #3611's "flag enabled on edge-us-01" deliverable (enable + validate visual capture end-to-end for metagraphed) — #3611 also needs a real validated PR and a week of production observation before it's done, so this PR doesn't close it by itself. Part of the parent epic #3607.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint` — clean
- [x] `npm run typecheck` — clean (no `src/**` changes; workflow/Dockerfile/compose only)
- [x] Verified the resolved YAML directly (`yaml.safe_load` on the workflow file) to confirm `build-args` parses to exactly `GITTENSORY_VERSION=...\nINSTALL_VISUAL_REVIEW=true\n` with no stray content — a `build-args: |` block scalar treats every line as literal string content, including `#`-prefixed ones, so an inline explanatory comment inside it would have been silently embedded in the actual build-arg string rather than treated as a YAML comment; caught this while drafting and moved the comment above the key instead.
- [x] `docker-compose.yml` re-validated as parseable YAML after the comment-only edit.
- Not run: `test:coverage`/`test:workers`/`ui:*` (no `src/`, `test/`, or `apps/` files touched) and `npm audit` (no dependency manifest changed) — none apply to a workflow/Dockerfile/compose-comment-only change.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] N/A — no auth/cookie/CORS/GitHub App/Cloudflare/session changes.
- [x] N/A — no API/OpenAPI/MCP surface touched.
- [x] N/A — no UI changes.
- [x] N/A — no docs/changelog changes needed (this is the docs-equivalent comment update itself).
