### PR TITLE
test(review): close e2e gaps for review.tone and review.exclude_paths

### DIFF
--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -18241,6 +18241,172 @@ describe("queue processors", () => {
     }
   });
 
+  // #2044: `.gittensory.yml` `review.tone` is folded into the AI reviewer's system prompt by
+  // composeManifestReviewInstructions (src/signals/focus-manifest.ts), consumed by
+  // src/queue/processors.ts's aiReviewCacheReadDecideAndRun. That composition is unit-tested in isolation
+  // (focus-manifest.test.ts), but nothing previously drove the full webhook -> processJob -> runGittensoryAiReview
+  // pipeline to confirm the resolved tone text actually reaches env.AI.run's system message. Mirrors the
+  // changed_files_summary/effort_score tests above but captures the AI system prompt instead of the posted body.
+  it("threads review.tone from .gittensory.yml into the AI reviewer's system prompt (#2044)", async () => {
+    let capturedSystem = "";
+    const env = createTestEnv({
+      GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(),
+      AI: {
+        run: async (_model: string, options: { messages: Array<{ role: string; content: string }> }) => {
+          capturedSystem = options.messages[0]?.content ?? "";
+          return { response: JSON.stringify({ assessment: "Looks fine.", blockers: [], nits: [], suggestions: [] }) };
+        },
+      } as unknown as Ai,
+      AI_SUMMARIES_ENABLED: "true",
+      AI_PUBLIC_COMMENTS_ENABLED: "true",
+      AI_DAILY_NEURON_BUDGET: "100000",
+    });
+    await persistRegistrySnapshot(
+      env,
+      normalizeRegistryPayload(
+        { "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } },
+        { kind: "raw-github", url: "https://example.test" },
+        "2026-05-23T00:00:00.000Z",
+      ),
+    );
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      commentMode: "all_prs",
+      publicSurface: "comment_only",
+      autoLabelEnabled: false,
+      checkRunMode: "off",
+      gateCheckMode: "enabled",
+      aiReviewMode: "block",
+      gatePack: "oss-anti-slop",
+    });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/pulls/7/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+export const ok = true;" }]);
+      if (url.endsWith("/pulls/7")) return Response.json({ number: 7, title: "Clean PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "Closes #1" });
+      if (url.includes("/commits/a7/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/commits/a7/status")) return Response.json({ state: "success", statuses: [] });
+      if (url.includes("/issues/1")) return Response.json({ number: 1, title: "Issue", state: "open", labels: [], user: { login: "reporter" } });
+      if (url.includes("/issues/7/comments") && method === "GET") return Response.json([]);
+      if (url.includes("/issues/7/comments") && method === "POST") return Response.json({ id: 1 }, { status: 201 });
+      if (url.includes("/branches/")) return Response.json({ protected: false, protection: { required_status_checks: { contexts: [] } } });
+      // The repo's own review.tone opt-in (#2044) -- a maintainer voice brief, distinct from review.instructions.
+      if (url === "https://raw.githubusercontent.com/JSONbored/gittensory/HEAD/.gittensory.yml") {
+        return new Response("review:\n  tone: Keep findings terse and skip pleasantries\n");
+      }
+      return Response.json({});
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "review-tone-system-prompt",
+      eventName: "pull_request",
+      payload: {
+        action: "opened",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        pull_request: { number: 7, title: "Clean PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "Closes #1" },
+      },
+    });
+
+    // The composed tone section (composeManifestReviewInstructions) really reached env.AI.run's system message --
+    // not just the pure-function assertion in focus-manifest.test.ts.
+    expect(capturedSystem).toContain(
+      "Review tone (maintainer voice brief — complements review.profile): Keep findings terse and skip pleasantries",
+    );
+  });
+
+  // #review-exclude-paths / #2043: `review.exclude_paths`/`review.path_filters` are resolved by
+  // resolveReviewPromptOverrides and applied by filterReviewFilesForAi (src/signals/focus-manifest.ts), consumed
+  // by src/queue/processors.ts's runAiReviewForAdvisory -- but ONLY in advisory mode (block mode intentionally
+  // reviews the full diff so a filtered path can never bypass an AI consensus blocker). filterReviewFilesForAi
+  // itself is unit-tested as a pure function (focus-manifest.test.ts); every existing e2e assertion of this field
+  // elsewhere in this file only ever passes EMPTY excludePaths/pathFilters arrays (cache-fingerprint checks), so
+  // nothing previously proved a NON-EMPTY glob genuinely removes a matching file from what the AI reviewer sees.
+  it("genuinely removes a review.exclude_paths match from the AI reviewer's diff in advisory mode (#review-exclude-paths)", async () => {
+    let capturedUser = "";
+    const env = createTestEnv({
+      GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(),
+      AI: {
+        run: async (_model: string, options: { messages: Array<{ role: string; content: string }> }) => {
+          capturedUser = options.messages[1]?.content ?? "";
+          return { response: JSON.stringify({ assessment: "Looks fine.", blockers: [], nits: [], suggestions: [] }) };
+        },
+      } as unknown as Ai,
+      AI_SUMMARIES_ENABLED: "true",
+      AI_PUBLIC_COMMENTS_ENABLED: "true",
+      AI_DAILY_NEURON_BUDGET: "100000",
+    });
+    await persistRegistrySnapshot(
+      env,
+      normalizeRegistryPayload(
+        { "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } },
+        { kind: "raw-github", url: "https://example.test" },
+        "2026-05-23T00:00:00.000Z",
+      ),
+    );
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      commentMode: "all_prs",
+      publicSurface: "comment_only",
+      autoLabelEnabled: false,
+      checkRunMode: "off",
+      gateCheckMode: "enabled",
+      // advisory (NOT block): block mode always reviews the full diff, ignoring exclude_paths/path_filters, so
+      // only advisory mode exercises the filterReviewFilesForAi branch (src/queue/processors.ts).
+      aiReviewMode: "advisory",
+      // The PR author below is an unconfirmed contributor; aiReviewAllAuthors is the documented per-repo opt-in
+      // that widens the AI-spend gate to every author (already unit-tested in ai-review-advisory.test.ts) so this
+      // test doesn't also have to stand up the full miner-confirmation registry mocks just to reach the AI call.
+      aiReviewAllAuthors: true,
+    });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/pulls/7/files"))
+        return Response.json([
+          { filename: "src/real-change.ts", status: "modified", additions: 3, deletions: 0, patch: "@@ -1,1 +1,4 @@\n+export const real = 1;\n+export const two = 2;\n+export const three = 3;" },
+          { filename: "src/schema.generated.ts", status: "modified", additions: 1, deletions: 0, patch: "@@ -1,1 +1,2 @@\n+export const generatedMarker = true;" },
+        ]);
+      if (url.endsWith("/pulls/7")) return Response.json({ number: 7, title: "Clean PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "Closes #1" });
+      if (url.includes("/commits/a7/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/commits/a7/status")) return Response.json({ state: "success", statuses: [] });
+      if (url.includes("/issues/1")) return Response.json({ number: 1, title: "Issue", state: "open", labels: [], user: { login: "reporter" } });
+      if (url.includes("/issues/7/comments") && method === "GET") return Response.json([]);
+      if (url.includes("/issues/7/comments") && method === "POST") return Response.json({ id: 1 }, { status: 201 });
+      if (url.includes("/branches/")) return Response.json({ protected: false, protection: { required_status_checks: { contexts: [] } } });
+      // The repo's own review.exclude_paths opt-in -- a NON-EMPTY glob (#review-exclude-paths), unlike every
+      // existing fingerprint-only assertion of this field elsewhere in this file.
+      if (url === "https://raw.githubusercontent.com/JSONbored/gittensory/HEAD/.gittensory.yml") {
+        return new Response('review:\n  exclude_paths:\n    - "**/*.generated.ts"\n');
+      }
+      return Response.json({});
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "review-exclude-paths-ai-diff",
+      eventName: "pull_request",
+      payload: {
+        action: "opened",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        pull_request: { number: 7, title: "Clean PR", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, labels: [], body: "Closes #1" },
+      },
+    });
+
+    // The non-excluded file's diff genuinely reached the AI reviewer's user prompt...
+    expect(capturedUser).toContain("src/real-change.ts");
+    // ...but the exclude_paths match is genuinely ABSENT -- not merely uncounted -- from what the AI reviewer
+    // sees: neither its path nor its patch content leaked into the prompt.
+    expect(capturedUser).not.toContain("schema.generated.ts");
+    expect(capturedUser).not.toContain("generatedMarker");
+  });
+
   // #2049: with the unified comment on AND `.gittensory.yml` setting `review.max_findings`, the processor wires
   // manifest caps into `buildUnifiedCommentBody` and the renderer truncates blocker/nit lists with a "+N more"
   // footer. Mirrors the effort_score test above but asserts display-only truncation instead.


### PR DESCRIPTION
Closes #1681

## Summary

- Closes the two confirmed test gaps from the review-controls audit (#1681): `review.tone` and
  `review.exclude_paths`/`review.path_filters` were previously only proven at the pure-function level
  (`focus-manifest.test.ts`'s `composeManifestReviewInstructions`/`filterReviewFilesForAi` unit tests) or
  with empty-array fingerprint assertions in `queue.test.ts` — nothing drove the full
  webhook -> `processJob` -> `runGittensoryAiReview` pipeline to prove the resolved config actually
  reaches the AI reviewer.
- Added `threads review.tone from .gittensory.yml into the AI reviewer's system prompt (#2044)`: sets
  `review.tone` in a repo `.gittensory.yml` fixture (mirroring the `changed_files_summary`/`effort_score`
  tests' exact fixture pattern) and asserts the composed
  `Review tone (maintainer voice brief — complements review.profile): ...` section is present in the
  actual `env.AI.run` system message, not just in a pure-function return value.
- Added `genuinely removes a review.exclude_paths match from the AI reviewer's diff in advisory mode
  (#review-exclude-paths)`: sets a **non-empty** `review.exclude_paths` glob (every existing e2e
  assertion of this field only ever passes empty arrays) with two changed files, one matching the glob,
  and asserts the excluded file's path *and* patch content are genuinely absent from the AI reviewer's
  user prompt while the other file's diff is present. This is deliberately run in **advisory** mode:
  `runAiReviewForAdvisory` (`src/queue/processors.ts`) only calls `filterReviewFilesForAi` in advisory
  mode — block mode intentionally reviews the full diff so a filtered path can never be used to dodge an
  AI consensus blocker — so advisory mode is the only branch that actually exercises the filter.
- Sanity-checked both new tests are non-vacuous: temporarily changed the fixture's glob to a
  non-matching pattern locally and confirmed the exclude-paths test then fails (the excluded filename
  legitimately appears in the prompt), before reverting to the real assertion.
- No `src/**`/`packages/**` changes — this is a `test/**`-only PR (not Codecov-patch-measured), scoped
  narrowly to #1681's two named test gaps. No fixes for the docs-only fields below are included here —
  see the filed follow-ups.

## Review-controls wiring matrix (#1681 deliverable)

Every `review.*` field parsed from `.gittensory.yml`, its resolution path, and whether it actually
reaches a live code path (not just parsing/validation). "e2e" = covered by a full
`processJob`/webhook-level test; "unit" = covered only at the pure-function level before this PR.

| Field | Status | Resolved by | Consumed at |
|---|---|---|---|
| `review.tone` | **Wired** (e2e added this PR) | `resolveReviewPromptOverrides` (`src/signals/focus-manifest.ts:250`) + `composeManifestReviewInstructions` (`:236`) | `src/queue/processors.ts:9378-9388` (`reviewInstructions`) -> `buildSystemPrompt`'s `repoInstructions` append (`src/services/ai-review.ts:879-891`) |
| `review.profile` | Wired (unit: `ai-review.test.ts`) | `resolveReviewPromptOverrides` | `buildSystemPrompt`'s `REVIEW_PROFILE_SUFFIX` (`src/services/ai-review.ts:830-837, 869-872`) |
| `review.security_focus` | Wired (unit: `ai-review.test.ts`) | `resolveReviewPromptOverrides` | `buildSystemPrompt`'s `SECURITY_FOCUS_SUFFIX` (`src/services/ai-review.ts:843-844, 873`) |
| `review.instructions` | Wired | `resolveReviewPromptOverrides` | folded into `reviewInstructions` alongside tone (`src/queue/processors.ts:9378-9388`) |
| `review.path_instructions` | Wired | `resolveReviewPromptOverrides` | `resolveReviewPathInstructions` (`src/queue/processors.ts:7371-7374, 9459-9462`) -> `buildSystemPrompt`'s `pathGuidance` |
| `review.exclude_paths` | **Wired, advisory-only** (e2e added this PR) | `resolveReviewPromptOverrides` | `filterReviewFilesForAi` (`src/signals/focus-manifest.ts:379-385, 408-414`), applied only when `aiReviewMode !== "block"` (`src/queue/processors.ts:7201-7207`) |
| `review.path_filters` | **Wired, advisory-only** (e2e added this PR) | `resolveReviewPromptOverrides` | `applyReviewPathFilters` (`src/signals/focus-manifest.ts:389-405`), same gate as `exclude_paths` above |
| `review.inline_comments` | Wired | `resolveReviewPromptOverrides` | `shouldRequestInlineFindings` (`src/review/inline-comments.ts:43`), `src/queue/processors.ts:9358-9362` |
| `review.suggestions` | Wired | `resolveReviewPromptOverrides` | `shouldRenderSuggestions` (`src/review/inline-comments.ts:60`), ANDed with inline comments |
| `review.finding_categories` | Wired | `resolveReviewPromptOverrides` | `shouldRenderFindingCategories` (`src/review/inline-comments.ts:70`), ANDed with inline comments |
| `review.changed_files_summary` | Wired (e2e: existing `queue.test.ts` test) | `resolveReviewPromptOverrides` | `src/queue/processors.ts:9142, 10515-10522` |
| `review.effort_score` | Wired (e2e: existing `queue.test.ts` test) | `resolveReviewPromptOverrides` | `src/queue/processors.ts:9143, 10530` |
| `review.max_findings` | Wired (e2e: existing `queue.test.ts` test #2049) | `resolveReviewPromptOverrides` | `src/queue/processors.ts:10554` |
| `review.comment_verbosity` | Wired | `resolveReviewPromptOverrides` | `src/queue/processors.ts:10555` |
| `review.min_finding_severity` | Wired | `resolveReviewPromptOverrides` | `src/queue/processors.ts:9144, 10616` |
| `review.impact_map` | Wired | `resolveReviewPromptOverrides` | `shouldComputeImpactMap` (`src/review/impact-map-wire.ts:26`), `src/queue/processors.ts:7257, 9414` |
| `review.culture_profile` | Wired | `resolveReviewPromptOverrides` | ANDed with `GITTENSORY_REVIEW_CULTURE_PROFILE`, `src/queue/processors.ts:7278-7280, 9410` |
| `review.ai_model` | Wired (e2e: existing `queue.test.ts` test) | `resolveReviewSelfHostAiModel` (`src/signals/focus-manifest.ts:306`) | correlation fields, `src/queue/processors.ts:7357-7364` |
| `review.memory` | Wired | `resolveReviewMemoryManifestToggle` (`src/signals/focus-manifest.ts:281`) | `shouldApplyReviewMemory`, `src/queue/processors.ts:9150, 11043` |
| `review.pre_merge_checks` | Wired | `resolveReviewPreMergeChecks` (`src/signals/focus-manifest.ts:288`) | `src/queue/processors.ts:6573, 9023` |
| `review.auto_review` | Wired | `resolveReviewAutoReviewConfig` (`src/signals/focus-manifest.ts:298`) | `src/queue/processors.ts:8293` |
| `review.enrichment` (analyzer toggles) | Wired | `resolveRepoEnrichmentToggles` (`src/signals/focus-manifest.ts:326`) | `src/queue/processors.ts:7315` |
| `review.visual` | Wired | `resolveReviewVisualConfig` (`src/signals/focus-manifest.ts:314`) | `src/queue/processors.ts:6973` |

**Docs-only / phantom fields (parsed, never consumed) — follow-ups filed, not fixed in this PR:**

| Field | Status | Evidence |
|---|---|---|
| `review.labeling_rules` | **Docs-only** | Parsed + validated (`packages/gittensory-engine/src/focus-manifest.ts:2002, 2251`), but `grep -rn "LabelingRule" src/` outside the type re-export in `focus-manifest.ts` returns nothing — zero real consumer anywhere. Follow-up: #4146 |
| `review.auto_merge_summary` | **Docs-only** | The field itself has zero consumer in `src/`. Its render primitive `buildAutoMergeSummaryCollapsible` (`src/review/unified-comment.ts:229`, #2051) has its own pure-function unit test but is never called from `unified-comment-bridge.ts` or `processors.ts`. Follow-up: #4147 |
| `review.linked_issue_satisfaction` | **Docs-only** (distinct from `gate.linkedIssueSatisfaction`) | `src/types.ts:761-769` explicitly documents `linkedIssueSatisfactionGateMode` (the real, DB-backed field `.gittensory.yml gate.linkedIssueSatisfaction` overrides) as **distinct** from this `review.*` manifest field. Every real consumer in `src/queue/processors.ts` (e.g. `:6638, 7949, 8978`) reads `settings.linkedIssueSatisfactionGateMode`, never `manifest.review.linkedIssueSatisfaction` — confirmed still true after the recent #4069 merge, which deepened the `gate.*` field's wiring but never touched this one. Setting `review.linked_issue_satisfaction` in `.gittensory.yml` today does nothing. Follow-up: #4149 |

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes — it only adds two tests to `test/unit/queue.test.ts`.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (see "Closes #1681" at the top of this description).

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` (no workflow files changed)
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally, unsharded — full suite green: 582 files / 11899 tests passed, 0 failed, 0 uncovered patch lines (this PR touches only `test/**`, which Codecov does not measure).
- [ ] `npm run test:workers` (no `test/workers/**` files touched by this change)
- [ ] `npm run build:mcp` (no MCP package changes)
- [ ] `npm run test:mcp-pack` (no MCP package changes)
- [ ] `npm run ui:openapi:check` (no API/schema changes)
- [ ] `npm run ui:lint` (no `apps/gittensory-ui/**` changes)
- [ ] `npm run ui:typecheck` (no `apps/gittensory-ui/**` changes)
- [ ] `npm run ui:build` (no `apps/gittensory-ui/**` changes)
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] New behavior (the two new e2e tests) exercises both the "config set, matching" and (via a temporary local sanity check, since reverted) "config absent/non-matching" branches — see Summary.

If any required check was skipped, explain why:

- This PR only adds tests to `test/unit/queue.test.ts`; it does not touch `.github/workflows/**`, `test/workers/**`, any MCP package, any API/schema/OpenAPI surface, or `apps/gittensory-ui/**`, so the corresponding checks above are not applicable. `npm run typecheck` and the full unsharded `npm run test:coverage` both ran clean against the actual change.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session/CORS changes.)
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP changes.)
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes.)
- [ ] Visible UI changes include a `UI Evidence` section. (N/A — no UI changes; see below.)
- [ ] Public docs/changelogs are updated where needed. (N/A — no docs/changelog changes; `CHANGELOG.md` is not touched.)

## UI Evidence

N/A — this PR only adds backend test coverage (`test/unit/queue.test.ts`); there is no visible UI, frontend, or docs change.

## Notes

- Follow-up issues for the 3 confirmed docs-only fields above (each offering the maintainer a
  wire-or-deprecate choice, per #1681's request): #4146 (`review.labeling_rules`), #4147
  (`review.auto_merge_summary`), #4149 (`review.linked_issue_satisfaction`).
- Also commented on #1681 with the same follow-up links.
