### PR TITLE
chore(selfhost): script git-backed self-host updates, ignore stray backups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,10 @@ site/.vitepress/cache/
 !migrations/*.sql
 apps/gittensory-ui/public/downloads/gittensory-extension.zip
 .worker-configuration.gen-check.d.ts
+# Ad-hoc operator backup files (e.g. `cp file.yml file.yml.bak-notes-20260707`) -- general
+# catch-alls so a stray manual snapshot never dirties `git status` on a Git-backed self-host
+# checkout. Trailing on purpose: the narrower gittensory-config.backup-*/ and .deploy-backups/
+# rules above already cover their specific directories, and nothing tracked in the repo matches
+# either pattern (verified via `git ls-files | grep -E '\.bak-|\.backup-'`) (#1660).
+*.bak-*
+*.backup-*

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-operations.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-operations.tsx
@@ -882,8 +882,15 @@ SENTRY_RELEASE=gittensory-selfhost@2026.07.05
           <Link to="/docs/self-hosting-backup-scaling">Backup and scaling</Link>.
         </li>
         <li>
-          Source path only: <code>git pull</code> and confirm <code>git status</code> is clean (no
-          uncommitted local changes the build would silently pick up).
+          Source path only: confirm <code>git status</code> is clean (no uncommitted local changes
+          the build would silently pick up). An ad-hoc snapshot like{" "}
+          <code>cp docker-compose.yml docker-compose.yml.bak-notes-20260707</code> does not count
+          against this — the trailing <code>*.bak-*</code>/<code>*.backup-*</code> patterns in{" "}
+          <code>.gitignore</code> keep stray manual backups out of <code>git status</code> entirely,
+          on top of the narrower <code>gittensory-config.backup-*/</code> and{" "}
+          <code>.deploy-backups/</code> patterns that already covered those specific directories.
+          <code>scripts/selfhost-update.sh</code> (below) checks this for you and refuses to
+          continue on a dirty tree.
         </li>
         <li>
           Image path only: note the current tag or digest from <code>docker inspect</code> on the
@@ -921,19 +928,57 @@ GITTENSORY_IMAGE=ghcr.io/jsonbored/gittensory-selfhost@sha256:... ./scripts/depl
 
       <h3>Path 2: build from the current git checkout</h3>
       <p>
-        <code>scripts/deploy-selfhost-prebuilt.sh</code> is for a source-based deploy (this is how{" "}
-        <code>GITTENSORY_VERSION</code> ends up as a short git SHA instead of an image tag). It
-        builds the bundle inside a Dockerized Node container — the host itself never needs Node or
-        npm installed — then restarts only the <code>gittensory</code> service the same way as the
-        image path.
+        <code>scripts/selfhost-update.sh</code> is the recommended entry point for a Git-backed
+        source checkout (#1660) — it is the single command that turns <code>git fetch</code> +
+        fast-forward + rebuild + verify into one flow, instead of an operator having to remember the
+        right order:
+      </p>
+      <CodeBlock lang="bash" code={`./scripts/selfhost-update.sh`} />
+      <p>
+        It refuses to continue, with a clear error and no side effects, on any of the three things
+        that make a plain <code>git pull</code> unsafe to script blindly: the working tree is not
+        clean, the checkout is not on the expected branch (<code>main</code> by default), or local
+        history has diverged from <code>origin/main</code> in a way that is not a fast-forward (
+        <code>git merge --ff-only</code> — it never rebases, force-merges, or picks a side for you).
+        Only once the fast-forward succeeds does it call{" "}
+        <code>scripts/deploy-selfhost-prebuilt.sh</code> (below) to rebuild and restart, then{" "}
+        <code>scripts/selfhost-post-update-check.sh</code> to verify health — so a normal update is
+        one command and a failure at any step stops before the next one runs.
+      </p>
+      <p>
+        None of this touches operator-owned state: <code>.env</code>, the{" "}
+        <code>gittensory-config/</code> mount, <code>.deploy-backups/</code>, any{" "}
+        <code>*.local</code> compose override or Alertmanager file, and every named data volume are
+        already gitignored or outside the source tree entirely, so a fetch-and-rebuild never touches
+        them. See the <Link to="/docs/self-hosting-quickstart">Quickstart</Link> for the initial
+        clone; this script assumes that checkout already exists and already tracks{" "}
+        <code>origin/main</code>.
       </p>
       <CodeBlock
         lang="bash"
-        code={`git pull
+        code={`# Point at a fork remote or a non-default branch (e.g. testing a release candidate branch)
+SELFHOST_UPDATE_REMOTE=upstream SELFHOST_UPDATE_BRANCH=main ./scripts/selfhost-update.sh
+
+# Skip the health probe step (e.g. you'll run it yourself, or right after a schema-changing release
+# where you want to inspect logs before curling /ready)
+SELFHOST_SKIP_POST_UPDATE_CHECK=1 ./scripts/selfhost-update.sh`}
+      />
+      <p>
+        Want finer control — a pinned <code>SENTRY_RELEASE</code>, a Sentry source-map upload, or to
+        fetch and rebuild as separate manual steps? Call the two scripts it wraps directly:
+      </p>
+      <CodeBlock
+        lang="bash"
+        code={`git fetch origin
+git merge --ff-only origin/main
 ./scripts/deploy-selfhost-prebuilt.sh`}
       />
       <p>
-        <code>SENTRY_RELEASE</code> defaults to{" "}
+        <code>scripts/deploy-selfhost-prebuilt.sh</code> is the actual rebuild step (this is how{" "}
+        <code>GITTENSORY_VERSION</code> ends up as a short git SHA instead of an image tag). It
+        builds the bundle inside a Dockerized Node container — the host itself never needs Node or
+        npm installed — then restarts only the <code>gittensory</code> service the same way as the
+        image path. <code>SENTRY_RELEASE</code> defaults to{" "}
         <code>gittensory-selfhost@&lt;short git SHA of the current HEAD&gt;</code> unless you
         override it, so each deploy from a new commit gets a distinct release id automatically. When{" "}
         <code>SENTRY_AUTH_TOKEN</code>, <code>SENTRY_ORG</code>, and <code>SENTRY_PROJECT</code> are
@@ -943,6 +988,12 @@ GITTENSORY_IMAGE=ghcr.io/jsonbored/gittensory-selfhost@sha256:... ./scripts/depl
       </p>
 
       <h3>Post-update checklist</h3>
+      <p>
+        <code>scripts/selfhost-update.sh</code> already runs the health probe below for you unless
+        you set <code>SELFHOST_SKIP_POST_UPDATE_CHECK=1</code>. Run it manually after the image
+        path, after calling the two wrapped scripts directly, or after any manual{" "}
+        <code>docker compose</code> update.
+      </p>
       <ol>
         <li>
           Wait for the deploy script&apos;s health wait to finish (or run the helper below if you

--- a/scripts/selfhost-update.sh
+++ b/scripts/selfhost-update.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Git-backed self-host update flow: fetch, fast-forward-only, rebuild, verify (#1660).
+#
+# This is the single entry point for pulling upstream changes into a Git-backed self-host
+# checkout. Before this script, an operator had to remember to run `git pull`, then
+# deploy-selfhost-prebuilt.sh, then selfhost-post-update-check.sh, in that order, with no guard
+# against a diverged local history silently creating a merge commit. This wraps all three into one
+# command and refuses to proceed if the fast-forward is not clean:
+#
+#   ./scripts/selfhost-update.sh
+#
+# What this preserves untouched (all already gitignored -- see .gitignore):
+#   - .env and any *_FILE secret mounts
+#   - gittensory-config/ (private per-repo .gittensory.yml policy)
+#   - .deploy-backups/ (operator deploy-backup snapshots)
+#   - any *.local compose override or alertmanager config files
+#   - named data volumes (gittensory-data, gittensory-pg, qdrant-data, gittensory-backups,
+#     grafana-data) -- untouched because this script only fetches source and rebuilds the
+#     gittensory app image; it never runs `docker volume` commands or touches compose profiles.
+#
+# Optional knobs:
+#   SELFHOST_UPDATE_REMOTE=upstream SELFHOST_UPDATE_BRANCH=main ./scripts/selfhost-update.sh
+#   SELFHOST_SKIP_POST_UPDATE_CHECK=1 ./scripts/selfhost-update.sh   # skip the health probe step
+set -euo pipefail
+
+REMOTE="${SELFHOST_UPDATE_REMOTE:-origin}"
+BRANCH="${SELFHOST_UPDATE_BRANCH:-main}"
+SKIP_POST_UPDATE_CHECK="${SELFHOST_SKIP_POST_UPDATE_CHECK:-0}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "error: required command not found: $1" >&2
+    exit 1
+  fi
+}
+
+require_cmd git
+
+if ! git -C "$SCRIPT_DIR/.." rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  echo "error: run this script from the gittensory git checkout" >&2
+  exit 1
+fi
+
+cd "$SCRIPT_DIR/.."
+
+current_branch="$(git rev-parse --abbrev-ref HEAD)"
+if [ "$current_branch" != "$BRANCH" ]; then
+  echo "error: currently on '$current_branch', expected '$BRANCH' -- checkout $BRANCH first, or" \
+    "set SELFHOST_UPDATE_BRANCH=$current_branch if that is deliberate" >&2
+  exit 1
+fi
+
+if [ -n "$(git status --porcelain)" ]; then
+  echo "error: working tree is not clean -- commit, stash, or discard local changes before updating" >&2
+  git status --short >&2
+  exit 1
+fi
+
+echo "selfhost update: fetching $REMOTE"
+git fetch "$REMOTE"
+
+echo "selfhost update: fast-forwarding $BRANCH to $REMOTE/$BRANCH"
+if ! git merge --ff-only "$REMOTE/$BRANCH"; then
+  echo "error: $BRANCH could not be fast-forwarded to $REMOTE/$BRANCH -- local history has" \
+    "diverged (unpushed commits or a manual edit). Resolve manually; this script never rebases" \
+    "or force-merges for you." >&2
+  exit 1
+fi
+
+echo "selfhost update: rebuilding from the updated checkout"
+"$SCRIPT_DIR/deploy-selfhost-prebuilt.sh"
+
+if [ "$SKIP_POST_UPDATE_CHECK" = "1" ]; then
+  echo "selfhost update: skipping post-update health check (SELFHOST_SKIP_POST_UPDATE_CHECK=1)"
+else
+  echo "selfhost update: verifying health"
+  "$SCRIPT_DIR/selfhost-post-update-check.sh"
+fi
+
+echo "selfhost update: complete ($(git rev-parse --short=8 HEAD))"

--- a/test/unit/docs-selfhost-git-deploy-hygiene.test.ts
+++ b/test/unit/docs-selfhost-git-deploy-hygiene.test.ts
@@ -1,0 +1,88 @@
+import { readFileSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { describe, expect, it } from "vitest";
+
+// Drift guard (#1660): the Git-backed update flow -- the .gitignore backup-file catch-alls, the
+// scripts/selfhost-update.sh wrapper, and the operations docs describing it -- must stay aligned
+// so an operator following the docs actually gets the script's real safety behavior.
+
+const GITIGNORE = ".gitignore";
+const UPDATE_SCRIPT = "scripts/selfhost-update.sh";
+const PREBUILT_SCRIPT = "scripts/deploy-selfhost-prebuilt.sh";
+const POST_UPDATE_SCRIPT = "scripts/selfhost-post-update-check.sh";
+const OPERATIONS = "apps/gittensory-ui/src/routes/docs.self-hosting-operations.tsx";
+
+const gitignore = readFileSync(GITIGNORE, "utf8");
+const updateScript = readFileSync(UPDATE_SCRIPT, "utf8");
+const operations = readFileSync(OPERATIONS, "utf8");
+
+describe("self-host git-deploy hygiene (#1660)", () => {
+  it(".gitignore catches ad-hoc operator backup files as trailing patterns", () => {
+    expect(gitignore).toContain("*.bak-*");
+    expect(gitignore).toContain("*.backup-*");
+    // Trailing: the general catch-alls must come after the narrower, already-shipped patterns
+    // they generalize, so this test fails loudly if a future edit reorders them.
+    const deployBackupsIndex = gitignore.indexOf(".deploy-backups/");
+    const generalBakIndex = gitignore.indexOf("*.bak-*");
+    const generalBackupIndex = gitignore.indexOf("*.backup-*");
+    expect(deployBackupsIndex).toBeGreaterThan(-1);
+    expect(generalBakIndex).toBeGreaterThan(deployBackupsIndex);
+    expect(generalBackupIndex).toBeGreaterThan(deployBackupsIndex);
+  });
+
+  it("does not shadow any file actually tracked in the repo", () => {
+    // The real regression concern: a future PR could add a legitimately-tracked file whose name
+    // happens to match `*.bak-*` or `*.backup-*`, which would silently untrack it the moment
+    // someone re-clones. Ask git itself, rather than approximating the glob in JS, since git's
+    // own matcher is the one that actually enforces these patterns.
+    const result = spawnSync("git", ["ls-files"], { encoding: "utf8" });
+    expect(result.status).toBe(0);
+    const trackedFiles = result.stdout.split("\n").filter(Boolean);
+    const bakLikeGlob = /(^|\/)[^/]*\.(bak|backup)-[^/]*$/;
+    const shadowed = trackedFiles.filter((path) => bakLikeGlob.test(path));
+    expect(shadowed).toEqual([]);
+  });
+
+  it("wraps fetch, fast-forward-only merge, rebuild, and the post-update check", () => {
+    expect(updateScript).toContain("#!/usr/bin/env bash");
+    expect(updateScript).toContain("set -euo pipefail");
+    expect(updateScript).toContain("git fetch");
+    expect(updateScript).toContain("git merge --ff-only");
+    expect(updateScript).toContain(PREBUILT_SCRIPT.replace("scripts/", ""));
+    expect(updateScript).toContain(POST_UPDATE_SCRIPT.replace("scripts/", ""));
+  });
+
+  it("refuses to proceed on a dirty tree, the wrong branch, or a non-fast-forward", () => {
+    expect(updateScript).toContain("git status --porcelain");
+    expect(updateScript).toContain("current_branch");
+    expect(updateScript).toMatch(/if\s*\[\s*-n\s*"\$\(git status --porcelain\)"\s*\]/);
+  });
+
+  it("never force-pushes, hard-resets, or force-merges on the operator's behalf", () => {
+    expect(updateScript).not.toContain("git push");
+    expect(updateScript).not.toContain("reset --hard");
+    expect(updateScript).not.toContain("--force");
+    expect(updateScript).not.toContain("clean -f");
+    expect(updateScript).not.toContain("merge --no-ff");
+  });
+
+  it("supports overriding the remote/branch and skipping the health probe", () => {
+    expect(updateScript).toContain("SELFHOST_UPDATE_REMOTE");
+    expect(updateScript).toContain("SELFHOST_UPDATE_BRANCH");
+    expect(updateScript).toContain("SELFHOST_SKIP_POST_UPDATE_CHECK");
+  });
+
+  it("operations docs point operators at the wrapper script and its safety guarantees", () => {
+    expect(operations).toContain("scripts/selfhost-update.sh");
+    expect(operations).toContain("*.bak-*");
+    expect(operations).toContain("*.backup-*");
+    expect(operations).toContain("git merge --ff-only");
+    expect(operations).toContain("SELFHOST_SKIP_POST_UPDATE_CHECK");
+  });
+
+  it("operations docs still name every operator-owned path the script must never touch", () => {
+    expect(operations).toContain("gittensory-config/");
+    expect(operations).toContain(".deploy-backups/");
+    expect(operations).toContain("*.local");
+  });
+});

--- a/test/unit/selfhost-update-script.test.ts
+++ b/test/unit/selfhost-update-script.test.ts
@@ -1,0 +1,246 @@
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+import { afterEach, describe, expect, it } from "vitest";
+
+// Real end-to-end execution of scripts/selfhost-update.sh (#1660) against a throwaway git remote,
+// with deploy-selfhost-prebuilt.sh and selfhost-post-update-check.sh replaced by stubs that just
+// log a call marker -- this exercises the actual fetch/fast-forward/rebuild/verify control flow
+// (and its refusal paths) rather than only asserting on the script's source text.
+
+const REAL_SCRIPT = readFileSync(resolve("scripts/selfhost-update.sh"), "utf8");
+
+const GIT_ENV = {
+  GIT_AUTHOR_NAME: "test",
+  GIT_AUTHOR_EMAIL: "test@example.invalid",
+  GIT_COMMITTER_NAME: "test",
+  GIT_COMMITTER_EMAIL: "test@example.invalid",
+};
+
+const STUB_PREBUILT = `#!/usr/bin/env bash
+set -euo pipefail
+printf 'prebuilt-called\\n' >> "$CALL_LOG"
+exit "\${STUB_PREBUILT_EXIT:-0}"
+`;
+
+const STUB_POST_UPDATE = `#!/usr/bin/env bash
+set -euo pipefail
+printf 'post-update-called\\n' >> "$CALL_LOG"
+exit "\${STUB_POST_UPDATE_EXIT:-0}"
+`;
+
+function git(args: string[], cwd: string) {
+  const result = spawnSync("git", args, { cwd, encoding: "utf8", env: { ...process.env, ...GIT_ENV } });
+  if (result.status !== 0) {
+    throw new Error(`git ${args.join(" ")} failed in ${cwd}: ${result.stderr}`);
+  }
+  return result;
+}
+
+function headOf(cwd: string): string {
+  return git(["rev-parse", "HEAD"], cwd).stdout.trim();
+}
+
+const sandboxDirs: string[] = [];
+
+afterEach(() => {
+  while (sandboxDirs.length > 0) {
+    const dir = sandboxDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function createSandbox() {
+  const base = mkdtempSync(join(tmpdir(), "gittensory-selfhost-update-"));
+  sandboxDirs.push(base);
+
+  const originDir = join(base, "origin.git");
+  const seedDir = join(base, "seed");
+  const checkoutDir = join(base, "checkout");
+  const callLog = join(base, "calls.log");
+
+  // A bare "upstream" the seed repo pushes to and the checkout clones from. Forcing HEAD's symref
+  // to refs/heads/main before the first push means every later `git clone` of this bare repo
+  // checks out `main` directly -- no fallback branch-detection dance needed in the test itself.
+  git(["init", "-q", "--bare", originDir], base);
+  git(["symbolic-ref", "HEAD", "refs/heads/main"], originDir);
+
+  // The real script plus its two stubbed collaborators are committed in the SEED repo, before
+  // checkoutDir ever clones -- committing them into checkoutDir instead (after cloning) would
+  // advance checkoutDir's history one commit past origin/main, and every later advanceOrigin()
+  // push from seedDir would then be rejected as a non-fast-forward against its own history.
+  mkdirSync(seedDir, { recursive: true });
+  writeFileSync(join(seedDir, "README.md"), "seed\n");
+  mkdirSync(join(seedDir, "scripts"), { recursive: true });
+  writeFileSync(join(seedDir, "scripts", "selfhost-update.sh"), REAL_SCRIPT);
+  chmodSync(join(seedDir, "scripts", "selfhost-update.sh"), 0o755);
+  writeFileSync(join(seedDir, "scripts", "deploy-selfhost-prebuilt.sh"), STUB_PREBUILT);
+  chmodSync(join(seedDir, "scripts", "deploy-selfhost-prebuilt.sh"), 0o755);
+  writeFileSync(join(seedDir, "scripts", "selfhost-post-update-check.sh"), STUB_POST_UPDATE);
+  chmodSync(join(seedDir, "scripts", "selfhost-post-update-check.sh"), 0o755);
+  git(["init", "-q", "-b", "main", seedDir], base);
+  git(["remote", "add", "origin", originDir], seedDir);
+  git(["add", "-A"], seedDir);
+  git(["commit", "-q", "-m", "initial"], seedDir);
+  git(["push", "-q", "origin", "main"], seedDir);
+
+  git(["clone", "-q", originDir, checkoutDir], base);
+
+  return { base, originDir, seedDir, checkoutDir, callLog };
+}
+
+function advanceOrigin(seedDir: string, message: string) {
+  writeFileSync(join(seedDir, "README.md"), `${message}\n`, { flag: "a" });
+  git(["add", "-A"], seedDir);
+  git(["commit", "-q", "-m", message], seedDir);
+  git(["push", "-q", "origin", "main"], seedDir);
+}
+
+function readCallLog(callLog: string): string {
+  try {
+    return readFileSync(callLog, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function run(checkoutDir: string, callLog: string, env: Record<string, string> = {}) {
+  return spawnSync("bash", [join(checkoutDir, "scripts", "selfhost-update.sh")], {
+    cwd: checkoutDir,
+    encoding: "utf8",
+    env: { ...process.env, ...GIT_ENV, CALL_LOG: callLog, ...env },
+  });
+}
+
+describe("selfhost-update.sh", () => {
+  it("fetches, fast-forwards, rebuilds, and verifies health on a clean checkout", () => {
+    const { seedDir, checkoutDir, callLog } = createSandbox();
+    advanceOrigin(seedDir, "advance readme");
+
+    const result = run(checkoutDir, callLog);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(readCallLog(callLog)).toBe("prebuilt-called\npost-update-called\n");
+    expect(result.stdout).toContain("selfhost update: complete");
+    expect(headOf(checkoutDir)).toBe(headOf(seedDir));
+  });
+
+  it("is a safe no-op restart-equivalent when already up to date", () => {
+    const { checkoutDir, callLog } = createSandbox();
+
+    const result = run(checkoutDir, callLog);
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(readCallLog(callLog)).toBe("prebuilt-called\npost-update-called\n");
+  });
+
+  it("skips the health probe when SELFHOST_SKIP_POST_UPDATE_CHECK=1", () => {
+    const { seedDir, checkoutDir, callLog } = createSandbox();
+    advanceOrigin(seedDir, "advance for skip-check");
+
+    const result = run(checkoutDir, callLog, { SELFHOST_SKIP_POST_UPDATE_CHECK: "1" });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(readCallLog(callLog)).toBe("prebuilt-called\n");
+    expect(result.stdout).toContain("skipping post-update health check");
+  });
+
+  it("stops before the health check when the rebuild step fails", () => {
+    const { seedDir, checkoutDir, callLog } = createSandbox();
+    advanceOrigin(seedDir, "advance for rebuild-fail");
+
+    const result = run(checkoutDir, callLog, { STUB_PREBUILT_EXIT: "1" });
+
+    expect(result.status).not.toBe(0);
+    expect(readCallLog(callLog)).toBe("prebuilt-called\n");
+  });
+
+  it("refuses a dirty working tree and calls no script", () => {
+    const { seedDir, checkoutDir, callLog } = createSandbox();
+    advanceOrigin(seedDir, "advance for dirty-tree");
+    writeFileSync(join(checkoutDir, "README.md"), "local uncommitted edit\n");
+    const beforeHead = headOf(checkoutDir);
+
+    const result = run(checkoutDir, callLog);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("working tree is not clean");
+    expect(readCallLog(callLog)).toBe("");
+    expect(headOf(checkoutDir)).toBe(beforeHead);
+  });
+
+  it("refuses when the checkout is not on the expected branch and calls no script", () => {
+    const { seedDir, checkoutDir, callLog } = createSandbox();
+    advanceOrigin(seedDir, "advance for wrong-branch");
+    git(["checkout", "-q", "-b", "feature-x"], checkoutDir);
+
+    const result = run(checkoutDir, callLog);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("currently on 'feature-x', expected 'main'");
+    expect(readCallLog(callLog)).toBe("");
+  });
+
+  it("accepts a non-default branch when SELFHOST_UPDATE_BRANCH names it explicitly", () => {
+    const { seedDir, checkoutDir, callLog } = createSandbox();
+    git(["checkout", "-q", "-b", "release"], seedDir);
+    writeFileSync(join(seedDir, "README.md"), "release branch\n", { flag: "a" });
+    git(["add", "-A"], seedDir);
+    git(["commit", "-q", "-m", "release commit"], seedDir);
+    git(["push", "-q", "origin", "release"], seedDir);
+    git(["fetch", "-q", "origin"], checkoutDir);
+    git(["checkout", "-q", "-b", "release", "origin/release"], checkoutDir);
+
+    const result = run(checkoutDir, callLog, { SELFHOST_UPDATE_BRANCH: "release" });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(readCallLog(callLog)).toBe("prebuilt-called\npost-update-called\n");
+  });
+
+  it("refuses a non-fast-forward divergence, calls no script, and leaves HEAD untouched", () => {
+    const { seedDir, checkoutDir, callLog } = createSandbox();
+    advanceOrigin(seedDir, "advance for divergence");
+    writeFileSync(join(checkoutDir, "local-only.txt"), "local\n");
+    git(["add", "-A"], checkoutDir);
+    git(["commit", "-q", "-m", "local unpushed commit"], checkoutDir);
+    const beforeHead = headOf(checkoutDir);
+
+    const result = run(checkoutDir, callLog);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("could not be fast-forwarded");
+    expect(result.stderr).toContain("never rebases or force-merges");
+    expect(readCallLog(callLog)).toBe("");
+    expect(headOf(checkoutDir)).toBe(beforeHead);
+  });
+
+  it("supports a custom remote name via SELFHOST_UPDATE_REMOTE", () => {
+    const { seedDir, checkoutDir, callLog } = createSandbox();
+    git(["remote", "rename", "origin", "upstream"], checkoutDir);
+    advanceOrigin(seedDir, "advance for custom remote");
+
+    const result = run(checkoutDir, callLog, { SELFHOST_UPDATE_REMOTE: "upstream" });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(readCallLog(callLog)).toBe("prebuilt-called\npost-update-called\n");
+    expect(headOf(checkoutDir)).toBe(headOf(seedDir));
+  });
+
+  it("fails fast outside a git checkout", () => {
+    const outside = mkdtempSync(join(tmpdir(), "gittensory-selfhost-update-nogit-"));
+    sandboxDirs.push(outside);
+    mkdirSync(join(outside, "scripts"), { recursive: true });
+    writeFileSync(join(outside, "scripts", "selfhost-update.sh"), REAL_SCRIPT);
+    chmodSync(join(outside, "scripts", "selfhost-update.sh"), 0o755);
+
+    const result = spawnSync("bash", [join(outside, "scripts", "selfhost-update.sh")], {
+      cwd: outside,
+      encoding: "utf8",
+      env: { ...process.env, ...GIT_ENV },
+    });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("run this script from the gittensory git checkout");
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #1660's Git-backed conversion: the maintainer host deploy is already a clean checkout
tracking `origin/main` (done directly on the live host, outside this PR). Two gaps remained:

- **No general backup-file hygiene.** `.gitignore` already ignores `gittensory-config.backup-*/`
  and `.deploy-backups/` (specific, known backup locations), but nothing catches an arbitrary
  ad-hoc operator snapshot anywhere else in the tree — e.g. `cp docker-compose.yml
  docker-compose.yml.bak-notes-20260707` before hand-editing something. That file sits untracked and
  dirties `git status` indefinitely, with nothing to stop it.
- **No scripted update flow.** `scripts/deploy-selfhost-prebuilt.sh` (rebuild) and
  `scripts/selfhost-post-update-check.sh` (post-update health probe, #1823) already existed, but
  "pull upstream changes" itself was undocumented manual process, not a script: the docs showed a
  plain two-line `git pull` + `./scripts/deploy-selfhost-prebuilt.sh` sequence with no guard — a
  diverged local history would let `git pull` silently create a merge commit (or fail confusingly),
  and a dirty tree would get rebuilt with whatever local edits happened to be present.

This PR closes both gaps:

1. Two trailing `.gitignore` catch-alls, `*.bak-*` and `*.backup-*`, placed after the existing
   narrower patterns they generalize. Verified via `git ls-files | grep -E '\.bak-|\.backup-'`
   (empty) that nothing currently tracked matches either pattern before adding them, and pinned that
   check as a permanent regression test (see Validation).
2. `scripts/selfhost-update.sh` — a thin wrapper: `git fetch` → `git merge --ff-only` →
   `deploy-selfhost-prebuilt.sh` → `selfhost-post-update-check.sh`. It refuses to proceed, with a
   clear error and **no side effects and no wrapped script invoked**, on a dirty working tree, a
   checkout not on the expected branch (`main` by default, override with
   `SELFHOST_UPDATE_BRANCH`), or a non-fast-forward divergence — it never rebases, force-merges, or
   picks a side for the operator. `SELFHOST_UPDATE_REMOTE` and `SELFHOST_SKIP_POST_UPDATE_CHECK` are
   the two other overrides.
3. Documented in the existing "Updating and rolling back" section of
   `docs.self-hosting-operations.tsx` (`apps/gittensory-ui`) alongside the manual two-step flow it
   wraps, plus an explicit note that `.env`, `gittensory-config/`, `.deploy-backups/`, and any
   `*.local` override files all already survive an update untouched (all already gitignored, none
   touched by this script).

Closes #1660.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #1660`).

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint` (no workflow files touched; ran anyway as part of the full gate)
- [x] `npm run typecheck` — clean, twice (before and after the pre-push rebase)
- [x] `npm run test:coverage` locally — 584 test files passed / 2 skipped, 11915 tests passed / 7 skipped, unsharded. No `src/**`/`packages/**` lines changed (only `.gitignore`, one docs route, `scripts/**`, `test/**`), so there is no new Codecov `codecov/patch` obligation — ran it anyway to confirm nothing broke.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — two new test files:
  - `test/unit/selfhost-update-script.test.ts` — **real end-to-end execution** of
    `scripts/selfhost-update.sh` (via `spawnSync`) against a throwaway local git remote, with
    `deploy-selfhost-prebuilt.sh`/`selfhost-post-update-check.sh` swapped for logging stubs: happy
    path (fetch → ff → rebuild → verify, HEAD lands on the new upstream tip), already-up-to-date
    no-op, `SELFHOST_SKIP_POST_UPDATE_CHECK=1`, rebuild-step failure stops before the health check,
    dirty tree / wrong branch / non-fast-forward divergence all refuse with no script invoked and no
    HEAD movement, a non-default branch via `SELFHOST_UPDATE_BRANCH`, a renamed remote via
    `SELFHOST_UPDATE_REMOTE`, and running outside a git checkout entirely. 10/10 passing.
  - `test/unit/docs-selfhost-git-deploy-hygiene.test.ts` — drift guard (matches the existing
    `docs-selfhost-*.test.ts` convention) asserting the `.gitignore` patterns exist and are ordered
    after the narrower ones they generalize, a **real `git ls-files` check** that nothing tracked
    matches either pattern (not just a static approximation), the script's safety invariants
    (never `git push`/`reset --hard`/`--force`/`clean -f`/`merge --no-ff`), and that the docs
    reference the script and its guarantees. 8/8 passing.
  - Also ran `shellcheck scripts/selfhost-update.sh` (clean) and manually exercised the script in an
    ad hoc sandbox before writing the permanent tests.

If any required check was skipped, explain why:

- `npm run test:engine-parity` and `npm run db:migrations:check` / `npm run db:schema-drift:check` /
  `npm run selfhost:env-reference:check` / `npm run selfhost:validate-observability` /
  `npm run cf-typegen:check` aren't in this template's checklist but are part of `npm run test:ci`
  and all passed (`test:ci` ran green end-to-end twice: once before the pre-push rebase, once after,
  since the rebase picked up one same-file, different-section upstream commit — see Notes).
- Did not run the `gittensory-mcp` pre-submit predictors (`check_before_start`,
  `validate_linked_issue`, `check_slop_risk`, `lint_pr_text`, `predict_gate`): those need an
  interactive GitHub device-flow login this session can't complete, and as the repo owner this PR is
  held for manual merge rather than auto-closed on an adverse gate signal.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no such changes; this is a deploy-hygiene script and its docs.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no such changes; `ui:openapi:check` confirms no drift.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — static docs prose only, no data-fetching component touched.)
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository. (No visual/layout change — new paragraphs and code blocks inside the existing "Updating and rolling back" section of an already-shipped docs page; see UI Evidence below.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable: this PR only adds prose paragraphs and `<CodeBlock>` snippets inside the existing
"Updating and rolling back" section of `docs.self-hosting-operations.tsx` — no new component,
layout, route, or styling. The rendered page structure (headings, `Callout`/`FeatureRow`/`CodeBlock`
primitives already in use throughout the page) is identical to what is already live; only the words
and code samples describing the update flow changed.

## Notes

- Rebased onto the current `origin/main` tip before pushing (`git fetch origin && git rebase
  origin/main`); one upstream commit (#4142, merged during this session) touched the same docs file
  but a different section (the runner CPU/memory table around line ~330-420, versus my edits around
  line ~870-995) — rebase applied with zero conflicts, and both `npm run typecheck` and the two new
  test files were re-run clean afterward.
- Verified against source, not assumed: grepped `scripts/*.sh` and `docker-compose.yml` for any
  existing `.bak`/`.backup` usage before adding the ignore patterns (only `scripts/backup.sh`'s
  unrelated `sqlite3 ".backup"` SQL command, not a filename pattern); confirmed the "real rebuild
  step" by grepping every `scripts/*.sh` for `docker compose ... build` rather than guessing
  (`scripts/deploy-selfhost-prebuilt.sh` is the only source-based rebuild path, already documented
  as "Path 2: build from the current git checkout").
- `scripts/**` carries no Codecov `codecov/patch` obligation (only `src/**`/`packages/**` are
  measured), so the execution-based test suite above is extra rigor, not a coverage requirement.
