### PR TITLE
chore(changelog): regenerate mcp-v0.7.0 CHANGELOG for #4135

### DIFF
--- a/packages/gittensory-mcp/CHANGELOG.md
+++ b/packages/gittensory-mcp/CHANGELOG.md
@@ -247,6 +247,7 @@
 - Apply the no-issue-rationale exemption to all linked-issue findings (#4064)
 - Sanitize validate-config terminal output (#4090)
 - Bound opportunity target fanout (#4072)
+- Build gittensory-engine before the publish gate + switch to workflow_dispatch (#4135)
 
 ### Security
 - Bound focus manifest ingestion (#890)


### PR DESCRIPTION
## Summary
The v0.7.0 publish workflow failed at \`changelog:check:mcp\` because #4135 (\`fix(mcp): build gittensory-engine before the publish gate + switch to workflow_dispatch\`) merged after PR #4132 originally generated \`packages/gittensory-mcp/CHANGELOG.md\`. #4135 is a real MCP-relevant commit (touches \`.github/workflows/npm-publish.yml\`, a \`DIRECT_MCP_PATH\`), so the regenerated changelog now correctly includes it. Regenerated locally — 251 commits, one new line.

## Test plan
- [x] \`npm run changelog:mcp\` then \`npm run changelog:check:mcp\` — reports current