### PR TITLE
feat(review): add REES complexity and Go/Python error-defect analyzers

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -68,32 +68,32 @@ GITTENSORY_REVIEW_ENRICHMENT=false
 # commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot
 # blameLink,approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene
 # pendingReviewRequests,testRatio,migrationSafety,looseRange,terminology,todoMarker,magicNumber
-# conflictMarker,debugLeftover,sizeSmell,floatingPromise,deepNesting,errorSwallow,unsafeAny,a11y
-# i18n,unusedExport,exhaustiveness,flakyTest,commitLint,apiBreak,deprecatedDep,revertRecurrence
-# coverageDelta,callerImpact
+# conflictMarker,debugLeftover,sizeSmell,floatingPromise,deepNesting,errorSwallow,complexity
+# unsafeAny,a11y,i18n,unusedExport,exhaustiveness,flakyTest,commitLint,apiBreak,deprecatedDep
+# revertRecurrence,coverageDelta,callerImpact
 #
 # Profile defaults:
 # fast: dependency,dependencyDiff,lockfileDrift,secret,license,installScript,heavyDependency
 # hardcodedUrl,actionPin,eol,redos,provenance,secretLog,typosquat,iacMisconfig,nativeBuild
 # testRatio,migrationSafety,looseRange,terminology,todoMarker,magicNumber,conflictMarker
-# debugLeftover,sizeSmell,floatingPromise,deepNesting,errorSwallow,unsafeAny,a11y,i18n,apiBreak
-# deprecatedDep
+# debugLeftover,sizeSmell,floatingPromise,deepNesting,errorSwallow,complexity,unsafeAny,a11y
+# i18n,apiBreak,deprecatedDep
 # balanced (default): dependency,dependencyDiff,lockfileDrift,secret,license,installScript
 # heavyDependency,hardcodedUrl,actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight
 # typosquat,commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift,duplication
 # churnHotspot,blameLink,approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch
 # commitHygiene,pendingReviewRequests,testRatio,migrationSafety,looseRange,terminology
 # todoMarker,magicNumber,conflictMarker,debugLeftover,sizeSmell,floatingPromise,deepNesting
-# errorSwallow,unsafeAny,a11y,i18n,unusedExport,exhaustiveness,flakyTest,commitLint,apiBreak
-# deprecatedDep,revertRecurrence,coverageDelta,callerImpact
+# errorSwallow,complexity,unsafeAny,a11y,i18n,unusedExport,exhaustiveness,flakyTest,commitLint
+# apiBreak,deprecatedDep,revertRecurrence,coverageDelta,callerImpact
 # deep: dependency,dependencyDiff,lockfileDrift,secret,license,installScript,heavyDependency
 # hardcodedUrl,actionPin,eol,redos,provenance,codeowners,secretLog,assetWeight,typosquat
 # commitSignature,iacMisconfig,nativeBuild,history,docCommentDrift,duplication,churnHotspot
 # blameLink,approvalIntegrity,ciCheckSignals,undocumentedExport,staleBranch,commitHygiene
 # pendingReviewRequests,testRatio,migrationSafety,looseRange,terminology,todoMarker,magicNumber
-# conflictMarker,debugLeftover,sizeSmell,floatingPromise,deepNesting,errorSwallow,unsafeAny,a11y
-# i18n,unusedExport,exhaustiveness,flakyTest,commitLint,apiBreak,deprecatedDep,revertRecurrence
-# coverageDelta,callerImpact
+# conflictMarker,debugLeftover,sizeSmell,floatingPromise,deepNesting,errorSwallow,complexity
+# unsafeAny,a11y,i18n,unusedExport,exhaustiveness,flakyTest,commitLint,apiBreak,deprecatedDep
+# revertRecurrence,coverageDelta,callerImpact
 # END GENERATED REES ANALYZERS
 
 # Submitter-reputation spend control (internal-only): downgrades new/burst/low-rep

--- a/apps/gittensory-ui/src/lib/rees-analyzers.ts
+++ b/apps/gittensory-ui/src/lib/rees-analyzers.ts
@@ -1041,12 +1041,37 @@ export const REES_ANALYZERS = [
     },
     docs: {
       summary:
-        "Flags newly-added catch/except blocks that swallow the error — empty body, unused binding, or a bare `return null`.",
-      looksAt: "Added lines in changed non-test JS/TS/Python source files.",
-      reports: "File, line, and kind: empty-catch, unused-binding, or return-null.",
+        "Flags newly-added catch/except blocks (and Go if-err checks) that swallow or mishandle the error — empty body, unused binding, a bare `return null`/`nil`, or a Python bare `except:` naming no exception type.",
+      looksAt: "Added lines in changed non-test JS/TS/Python/Go source files.",
+      reports: "File, line, and kind: empty-catch, unused-binding, return-null, or bare-except.",
       network: "Pure local analyzer. No external network call.",
       notes:
-        "Multiline catch bodies are collected with brace balance. Catches that log, rethrow, or reference the binding are not flagged. Brace counting is character-level (string literals are not stripped).",
+        "Multiline catch/if-err bodies are collected with brace balance (Go's `if err != nil { … }`, including the if-with-initializer form, is treated the same as a JS/TS catch). Handlers that log, rethrow/panic, or reference the checked binding are not flagged. Python's bare `except:` is flagged regardless of body — it catches SystemExit/KeyboardInterrupt too. Brace counting is character-level (string literals are not stripped).",
+    },
+  },
+  {
+    name: "complexity",
+    title: "Approximate cyclomatic complexity",
+    category: "quality",
+    cost: "local",
+    defaultEnabled: true,
+    profiles: ["fast", "balanced", "deep"],
+    requires: ["files"],
+    limits: {
+      maxFindings: 25,
+      maxComplexity: 10,
+      maxLineChars: 2000,
+    },
+    docs: {
+      summary:
+        "Flags a newly-added function whose approximate cyclomatic complexity (branch/loop/logical-operator density, computed on the diff-visible lines) exceeds a threshold.",
+      looksAt:
+        "Added lines in changed non-test TS/JS source files, starting from a named function declaration or a const/let/var-assigned arrow function whose opening line is part of the diff.",
+      reports:
+        "File, line, the detected function name, the measured complexity, and the configured threshold.",
+      network: "Pure local analyzer. No external network call.",
+      notes:
+        "Diff-hunk approximation, not a whole-function true McCabe count: REES has no full-file content, so this counts if/for/while/case/catch/&&/||/?? token occurrences across the function's ADDED body lines only (1 + count), the same function-boundary detection size-smell.ts (#2019) uses for 'big-function'. A function whose signature line is not part of the diff is not scored. Distinct from deep-nesting (#2030), which measures brace NESTING depth, a readability smell, not decision-point density. Ternary (`? :`) is intentionally excluded — see the analyzer source header for why.",
     },
   },
   {

--- a/packages/gittensory-engine/src/review/enrichment-analyzer-names.ts
+++ b/packages/gittensory-engine/src/review/enrichment-analyzer-names.ts
@@ -46,6 +46,7 @@ export const REES_ANALYZER_NAMES = [
   "floatingPromise",
   "deepNesting",
   "errorSwallow",
+  "complexity",
   "unsafeAny",
   "a11y",
   "i18n",

--- a/review-enrichment/Dockerfile
+++ b/review-enrichment/Dockerfile
@@ -1,4 +1,6 @@
-# Gittensory review-enrichment service (REES). Lean two-stage Node build; analyzers add CLI tools later (#1477).
+# Gittensory review-enrichment service (REES). Lean two-stage Node build; analyzers are pure-JS diff-hunk
+# heuristics with no external CLI tools (#1477 scoped this to the cheap, no-checkout path -- see
+# review-enrichment/src/analyzers/complexity.ts's header for why a real linter/AST toolchain is out of scope).
 # Build context = the review-enrichment/ directory (Railway "Root Directory" = review-enrichment).
 FROM node:22-slim AS build
 WORKDIR /app

--- a/review-enrichment/analyzer-metadata.json
+++ b/review-enrichment/analyzer-metadata.json
@@ -1180,11 +1180,38 @@
         "maxLineChars": 2000
       },
       "docs": {
-        "summary": "Flags newly-added catch/except blocks that swallow the error — empty body, unused binding, or a bare `return null`.",
-        "looksAt": "Added lines in changed non-test JS/TS/Python source files.",
-        "reports": "File, line, and kind: empty-catch, unused-binding, or return-null.",
+        "summary": "Flags newly-added catch/except blocks (and Go if-err checks) that swallow or mishandle the error — empty body, unused binding, a bare `return null`/`nil`, or a Python bare `except:` naming no exception type.",
+        "looksAt": "Added lines in changed non-test JS/TS/Python/Go source files.",
+        "reports": "File, line, and kind: empty-catch, unused-binding, return-null, or bare-except.",
         "network": "Pure local analyzer. No external network call.",
-        "notes": "Multiline catch bodies are collected with brace balance. Catches that log, rethrow, or reference the binding are not flagged. Brace counting is character-level (string literals are not stripped)."
+        "notes": "Multiline catch/if-err bodies are collected with brace balance (Go's `if err != nil { … }`, including the if-with-initializer form, is treated the same as a JS/TS catch). Handlers that log, rethrow/panic, or reference the checked binding are not flagged. Python's bare `except:` is flagged regardless of body — it catches SystemExit/KeyboardInterrupt too. Brace counting is character-level (string literals are not stripped)."
+      }
+    },
+    {
+      "name": "complexity",
+      "title": "Approximate cyclomatic complexity",
+      "category": "quality",
+      "cost": "local",
+      "defaultEnabled": true,
+      "profiles": [
+        "fast",
+        "balanced",
+        "deep"
+      ],
+      "requires": [
+        "files"
+      ],
+      "limits": {
+        "maxFindings": 25,
+        "maxComplexity": 10,
+        "maxLineChars": 2000
+      },
+      "docs": {
+        "summary": "Flags a newly-added function whose approximate cyclomatic complexity (branch/loop/logical-operator density, computed on the diff-visible lines) exceeds a threshold.",
+        "looksAt": "Added lines in changed non-test TS/JS source files, starting from a named function declaration or a const/let/var-assigned arrow function whose opening line is part of the diff.",
+        "reports": "File, line, the detected function name, the measured complexity, and the configured threshold.",
+        "network": "Pure local analyzer. No external network call.",
+        "notes": "Diff-hunk approximation, not a whole-function true McCabe count: REES has no full-file content, so this counts if/for/while/case/catch/&&/||/?? token occurrences across the function's ADDED body lines only (1 + count), the same function-boundary detection size-smell.ts (#2019) uses for 'big-function'. A function whose signature line is not part of the diff is not scored. Distinct from deep-nesting (#2030), which measures brace NESTING depth, a readability smell, not decision-point density. Ternary (`? :`) is intentionally excluded — see the analyzer source header for why."
       }
     },
     {

--- a/review-enrichment/src/analyzers/complexity.ts
+++ b/review-enrichment/src/analyzers/complexity.ts
@@ -1,0 +1,203 @@
+// Approximate cyclomatic-complexity analyzer (#1477). REES has no full-file content -- only diff hunks -- so
+// this is deliberately NOT a whole-function true McCabe count (that needs a real parser reading the ENTIRE
+// function, including any part outside the diff, and a new AST-parser dependency this service does not carry).
+// Instead it approximates: for each newly-added function whose OPENING line is visible in the diff (named
+// `function` declarations and arrow functions assigned to const/let/var -- the same structural detection
+// size-smell.ts (#2019) already uses for "big-function"), it counts branch/loop/logical-operator tokens across
+// the function's ADDED body lines only and reports `1 + that count`, the standard McCabe formula computed on
+// the visible slice. A function whose signature line is NOT part of the diff (only its body was edited) is not
+// attributed a complexity score, the same accepted scope limit size-smell.ts already carries for "big-function".
+//
+// Distinct from deep-nesting.ts (#2030), which measures brace NESTING depth -- a readability smell that
+// analyzer's own header explicitly disclaims as a complexity metric. This analyzer counts DECISION POINTS
+// instead: a flat function (nesting depth 1) can still have high complexity from many sibling `if`/`&&` checks,
+// and a deeply-nested function can have low complexity if each level has only one predicate. The two analyzers
+// intentionally measure different axes of the same diff.
+//
+// Ternary (`? :`) is deliberately EXCLUDED from the decision-point count: distinguishing a conditional
+// expression's `?` from TypeScript's optional-property/parameter marker (`foo?: T`) or optional chaining
+// (`?.`) is not reliably decidable per-line by regex without a false-positive rate this precision-first
+// heuristic rejects. if/for/while/case/catch/&&/||/?? are unambiguous token shapes that cover the bulk of
+// realistic branching.
+//
+// Pure compute over added diff lines, no network, no new dependency. churn-hotspot (#1513) is not precedent for
+// a broader one-time fetch here: it fetches commit METADATA that cannot exist in a diff in any form at all, so a
+// fetch is its only option; complexity is partially approximable from the diff text itself, so the cheap
+// in-hunk approximation -- not a full-file fetch -- is the right scope for this analyzer.
+import type { ComplexityFinding, EnrichRequest } from "../types.js";
+import { codeOnly } from "./secret-log.js";
+import { isTestPath } from "./test-ratio.js";
+
+export const DEFAULT_MAX_COMPLEXITY = 10;
+const MAX_FINDINGS = 25;
+const MAX_LINE_CHARS = 2000;
+
+const JS_TS_PATH_RE = /\.(?:tsx?|jsx?|mts|cts|cjs|mjs)$/i;
+
+const FUNCTION_OPEN_RE =
+  /\bfunction\s+(\w+)\s*\([^)]*\)\s*\{|\b(?:const|let|var)\s+(\w+)\s*=\s*(?:async\s*)?(?:function\s*)?\([^)]*\)\s*=>\s*\{/;
+
+// Decision-point token classes, each counted as +1 branch. `if` also matches the "if" inside "else if" (correct:
+// only the branch "else if" itself introduces should add 1; a bare "else" with no "if" adds 0, matching McCabe
+// semantics). for/for-of/for-in/for-await, while (do-while is counted once via its trailing `while(...)`), a
+// switch `case` label (never `default`, which is not an additional predicate), `catch`, and the `&&`/`||`/`??`
+// short-circuit operators (each occurrence is its own branch). All patterns are flat (no group is itself
+// quantified), so none can backtrack catastrophically.
+const DECISION_RES: RegExp[] = [
+  /\bif\s*\(/g,
+  /\bfor\s*(?:await\s*)?\(/g,
+  /\bwhile\s*\(/g,
+  /\bcatch\s*[({]/g,
+  /\bcase\s+/g,
+  /&&/g,
+  /\|\|/g,
+  /\?\?/g,
+];
+
+function isJsTsPath(path: string): boolean {
+  return JS_TS_PATH_RE.test(path) && !isTestPath(path);
+}
+
+function isCommentLine(line: string): boolean {
+  const trimmed = line.trimStart();
+  return /^(?:\/\/|\/\*|\*)/.test(trimmed);
+}
+
+/** Count decision-point tokens (if/for/while/case/catch/&&/||/??) in one code fragment. Pure. */
+export function countDecisionPoints(code: string): number {
+  let total = 0;
+  for (const re of DECISION_RES) {
+    const matches = code.match(re);
+    if (matches) total += matches.length;
+  }
+  return total;
+}
+
+/** The declared/assigned name when a line opens a named function declaration or an arrow function assigned to a
+ *  const/let/var -- the same structural scope size-smell.ts's function detection uses. Pure. */
+export function functionNameFromLine(line: string): string | undefined {
+  if (isCommentLine(line)) return undefined;
+  const match = FUNCTION_OPEN_RE.exec(codeOnly(line));
+  return match?.[1] ?? match?.[2];
+}
+
+function braceDepthDelta(code: string): number {
+  let depth = 0;
+  for (const ch of code) {
+    if (ch === "{") depth++;
+    else if (ch === "}") depth--;
+  }
+  return depth;
+}
+
+type ScanLimits = {
+  maxComplexity?: number;
+  maxFindings?: number;
+  signal?: AbortSignal;
+};
+
+type PendingFunction = {
+  name: string;
+  startLine: number;
+  complexity: number;
+  depth: number;
+};
+
+/** Scan one file patch's added lines for a newly-added function whose approximate complexity exceeds a
+ *  threshold, line-cited via hunk headers. Pure. */
+export function scanPatchForComplexity(
+  path: string,
+  patch: string,
+  limits: ScanLimits = {},
+): ComplexityFinding[] {
+  const configured = limits.maxComplexity ?? DEFAULT_MAX_COMPLEXITY;
+  const maxComplexity = configured > 0 ? configured : DEFAULT_MAX_COMPLEXITY;
+  const maxFindings = limits.maxFindings ?? MAX_FINDINGS;
+  if (maxFindings <= 0 || !isJsTsPath(path)) return [];
+
+  const findings: ComplexityFinding[] = [];
+  let newLine = 0;
+  let inHunk = false;
+  let pending: PendingFunction | null = null;
+
+  const flushFunction = () => {
+    if (!pending) return;
+    if (pending.complexity > maxComplexity) {
+      findings.push({
+        file: path,
+        line: pending.startLine,
+        name: pending.name,
+        complexity: pending.complexity,
+        threshold: maxComplexity,
+      });
+    }
+    pending = null;
+  };
+
+  for (const line of patch.split("\n")) {
+    if (limits.signal?.aborted) throw new Error("analyzer_aborted");
+    const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(line);
+    if (hunk) {
+      flushFunction();
+      newLine = Number(hunk[1]);
+      inHunk = true;
+      continue;
+    }
+    if (!inHunk) continue;
+
+    if (line.startsWith("+")) {
+      const body = line.slice(1);
+      if (body.length <= MAX_LINE_CHARS) {
+        const commented = isCommentLine(body);
+        const code = codeOnly(body);
+        if (pending) {
+          if (!commented) pending.complexity += countDecisionPoints(code);
+          pending.depth += braceDepthDelta(code);
+          if (pending.depth <= 0) flushFunction();
+        } else {
+          const name = functionNameFromLine(body);
+          if (name) {
+            pending = {
+              name,
+              startLine: newLine,
+              complexity: 1 + (commented ? 0 : countDecisionPoints(code)),
+              depth: braceDepthDelta(code),
+            };
+            if (pending.depth <= 0) flushFunction();
+          }
+        }
+      }
+      newLine++;
+    } else {
+      flushFunction();
+      if (!line.startsWith("-") && !line.startsWith("\\")) {
+        newLine++;
+      }
+    }
+
+    if (findings.length >= maxFindings) return findings;
+  }
+
+  flushFunction();
+  return findings;
+}
+
+/** Analyzer entrypoint: scan every changed TS/JS file's added lines for high approximate complexity. */
+export async function scanComplexity(
+  req: EnrichRequest,
+  signal?: AbortSignal,
+): Promise<ComplexityFinding[]> {
+  const findings: ComplexityFinding[] = [];
+  for (const file of req.files ?? []) {
+    if (signal?.aborted) throw new Error("analyzer_aborted");
+    if (!file.patch) continue;
+    for (const finding of scanPatchForComplexity(file.path, file.patch, {
+      maxFindings: MAX_FINDINGS - findings.length,
+      signal,
+    })) {
+      findings.push(finding);
+      if (findings.length >= MAX_FINDINGS) return findings;
+    }
+  }
+  return findings;
+}

--- a/review-enrichment/src/analyzers/error-swallow.ts
+++ b/review-enrichment/src/analyzers/error-swallow.ts
@@ -1,16 +1,41 @@
-// Empty-catch / error-swallow analyzer (#2014). Flags newly-added catch/except blocks that swallow the error
-// (empty body, unused binding, or a bare `return null`) — a top source of silent failures. Pure compute over
-// added diff lines, no network. Scoped to JS/TS/Python source files; Python `except: pass` is included.
+// Empty-catch / error-swallow analyzer (#2014, extended for Go + Python bare-except by #1477). Flags
+// newly-added catch/except blocks (and Go `if err != nil` checks) that swallow or mishandle the error — empty
+// body, unused binding, a bare `return null`/`nil`, or (Python-only) a bare `except:` naming no exception type,
+// which catches everything (including SystemExit/KeyboardInterrupt) regardless of its body — all top sources
+// of silent failures. Pure compute over added diff lines, no network. Scoped to JS/TS/Python/Go source files.
 import type { EnrichRequest, ErrorSwallowFinding } from "../types.js";
 import { isTestPath } from "./test-ratio.js";
 
 const MAX_FINDINGS = 25;
 const MAX_LINE_CHARS = 2000;
 
-const SOURCE_EXTS = new Set(["ts", "tsx", "js", "jsx", "mjs", "cjs", "mts", "cts", "py"]);
+const SOURCE_EXTS = new Set(["ts", "tsx", "js", "jsx", "mjs", "cjs", "mts", "cts", "py", "go"]);
 
 const CATCH_OPEN_RE = /catch\s*(?:\(\s*([\w$]+)?\s*\))?\s*\{/;
+// Go's `if err != nil { ... }` check, in both its bare form (`if err != nil {`) and its very common
+// if-with-initializer form (`if err := f(); err != nil {`, where only the text after the `;` is the actual
+// check). The captured identifier must itself look like an error variable (contains "err"/"error",
+// case-insensitively on the leading letter) so an unrelated nil-pointer check like `if node != nil {` is never
+// mistaken for error handling. Parens are deliberately NOT part of the match: JS/TS require parens around an
+// `if` condition and Go idiomatic (gofmt) style never adds them, so this shape cannot occur in valid JS/TS.
+const GO_ERR_CHECK_OPEN_RE = /(?:\bif\s+|;\s*)(\w*[Ee]rr(?:or)?\d*)\s*!=\s*nil\s*\{/;
+const OPEN_RES: RegExp[] = [CATCH_OPEN_RE, GO_ERR_CHECK_OPEN_RE];
 const PY_EXCEPT_PASS_RE = /^\s*except(?:\s+[\w.]+\s*(?:as\s+(\w+))?)?\s*:\s*pass\s*(?:#.*)?$/;
+// A bare Python `except:` naming no exception type at all — flake8's E722. This is a defect independent of the
+// handler body (which may log or re-raise perfectly well): a bare except also catches SystemExit,
+// KeyboardInterrupt, and GeneratorExit, which should almost never be swallowed alongside ordinary exceptions.
+// Anchored so `except Exception:` / `except (A, B):` (a real type named) never match.
+const PY_BARE_EXCEPT_RE = /^\s*except\s*:\s*(?:#.*)?$/;
+
+/** Try each recognized error-handling opener (JS/TS `catch`, Go `if err != nil`) against `line`, in order.
+ *  Returns the first match, with the checked/bound identifier always in capture group 1. Pure. */
+function matchErrorOpen(line: string): RegExpExecArray | null {
+  for (const re of OPEN_RES) {
+    const match = re.exec(line);
+    if (match) return match;
+  }
+  return null;
+}
 
 function isScannablePath(path: string): boolean {
   const ext = /\.([^.]+)$/.exec(path)?.[1]?.toLowerCase();
@@ -30,9 +55,12 @@ function referencesBinding(body: string, binding: string): boolean {
 function bodySwallowsError(body: string, binding: string | null): ErrorSwallowFinding["kind"] | null {
   const trimmed = body.trim();
   if (!trimmed) return "empty-catch";
-  if (/^return\s+null\s*;?$/.test(trimmed)) return "return-null";
+  // `null` covers JS/TS; `nil` covers the Go equivalent (Go has no `null` literal).
+  if (/^return\s+(?:null|nil)\s*;?$/.test(trimmed)) return "return-null";
   if (!binding) return null;
   if (/\bthrow\b/.test(trimmed)) return null;
+  // Go's `panic(err)` re-escalates rather than swallowing, the same role `throw` plays in JS/TS.
+  if (/\bpanic\s*\(/.test(trimmed)) return null;
   if (/\b(?:console|logger|log|winston|pino|bunyan)\s*[.(]/.test(trimmed)) return null;
   if (/\bprint\s*\(/.test(trimmed)) return null;
   if (!referencesBinding(trimmed, binding)) return "unused-binding";
@@ -49,11 +77,12 @@ function braceBalanceFrom(line: string, openBrace: number): number {
   return depth;
 }
 
-/** Extract a complete JS/TS catch block from one line using brace balance, or null if incomplete. Pure. */
+/** Extract a complete error-handling block (JS/TS `catch`, or Go `if err != nil`) from one line using brace
+ *  balance, or null if incomplete. Pure. */
 export function parseCompleteCatchLine(
   line: string,
 ): { binding: string | null; body: string } | null {
-  const open = CATCH_OPEN_RE.exec(line);
+  const open = matchErrorOpen(line);
   if (!open) return null;
   const braceStart = line.indexOf("{", open.index ?? 0);
   if (braceStart < 0) return null;
@@ -73,12 +102,13 @@ export function parseCompleteCatchLine(
   return null;
 }
 
-/** Classify one source line for an error-swallow pattern, or null. Pure. */
+/** Classify one source line for an error-swallow / error-mishandling pattern, or null. Pure. */
 export function detectErrorSwallow(line: string): ErrorSwallowFinding["kind"] | null {
   const pyMatch = PY_EXCEPT_PASS_RE.exec(line);
   if (pyMatch) {
     return pyMatch[1] ? "unused-binding" : "empty-catch";
   }
+  if (PY_BARE_EXCEPT_RE.test(line)) return "bare-except";
 
   const complete = parseCompleteCatchLine(line);
   if (complete) {
@@ -161,7 +191,7 @@ export function scanPatchForErrorSwallow(
             pushFinding(newLine, kind);
             if (findings.length >= maxFindings) return findings;
           } else {
-            const open = CATCH_OPEN_RE.exec(body);
+            const open = matchErrorOpen(body);
             if (open) {
               const braceIndex = body.indexOf("{", open.index ?? 0);
               if (braceIndex >= 0) {

--- a/review-enrichment/src/analyzers/registry.ts
+++ b/review-enrichment/src/analyzers/registry.ts
@@ -35,6 +35,7 @@ import { scanDebugLeftover } from "./debug-leftover.js";
 import { scanDeepNesting } from "./deep-nesting.js";
 import { scanI18nRegression } from "./i18n-regression.js";
 import { scanErrorSwallow } from "./error-swallow.js";
+import { scanComplexity } from "./complexity.js";
 import { scanFloatingPromise } from "./floating-promise.js";
 import { scanSizeSmell } from "./size-smell.js";
 import { scanA11yRegression } from "./a11y-regression.js";
@@ -1128,24 +1129,64 @@ export const ANALYZER_DESCRIPTORS = [
     limits: { maxFindings: 25, maxLineChars: 2000 },
     docs: {
       summary:
-        "Flags newly-added catch/except blocks that swallow the error — empty body, unused binding, or a bare `return null`.",
-      looksAt: "Added lines in changed non-test JS/TS/Python source files.",
-      reports: "File, line, and kind: empty-catch, unused-binding, or return-null.",
+        "Flags newly-added catch/except blocks (and Go if-err checks) that swallow or mishandle the error — empty body, unused binding, a bare `return null`/`nil`, or a Python bare `except:` naming no exception type.",
+      looksAt: "Added lines in changed non-test JS/TS/Python/Go source files.",
+      reports: "File, line, and kind: empty-catch, unused-binding, return-null, or bare-except.",
       network: "Pure local analyzer. No external network call.",
       notes:
-        "Multiline catch bodies are collected with brace balance. Catches that log, rethrow, or reference the binding are not flagged. Brace counting is character-level (string literals are not stripped).",
+        "Multiline catch/if-err bodies are collected with brace balance (Go's `if err != nil { … }`, including the if-with-initializer form, is treated the same as a JS/TS catch). Handlers that log, rethrow/panic, or reference the checked binding are not flagged. Python's bare `except:` is flagged regardless of body — it catches SystemExit/KeyboardInterrupt too. Brace counting is character-level (string literals are not stripped).",
     },
     render: (findings, helpers) => {
       if (!findings.length) return [];
-      const lines = ["### Swallowed errors (empty catch / unused binding / return null)"];
+      const explain = (kind: (typeof findings)[number]["kind"]): string => {
+        switch (kind) {
+          case "empty-catch":
+            return "empty-catch — the error is checked/caught but the handling block is empty";
+          case "unused-binding":
+            return "unused-binding — the error is checked/caught but never referenced, logged, or returned";
+          case "return-null":
+            return "return-null — returns null/nil instead of propagating the error";
+          case "bare-except":
+            return "bare-except — catches every exception (including SystemExit/KeyboardInterrupt), no type named";
+        }
+      };
+      const lines = ["### Swallowed errors (empty catch / unused binding / return null / bare except)"];
       for (const item of findings) {
-        lines.push(
-          `- ${helpers.safeCodeSpan(`${item.file}:${item.line}`)} — ${helpers.safeCodeSpan(item.kind)}`,
-        );
+        lines.push(`- ${helpers.safeCodeSpan(`${item.file}:${item.line}`)} — ${explain(item.kind)}`);
       }
       return lines;
     },
     run: (req, { signal }) => scanErrorSwallow(req, signal),
+  }),
+  descriptor({
+    name: "complexity",
+    title: "Approximate cyclomatic complexity",
+    category: "quality",
+    cost: "local",
+    defaultEnabled: true,
+    requires: ["files"],
+    limits: { maxFindings: 25, maxComplexity: 10, maxLineChars: 2000 },
+    docs: {
+      summary:
+        "Flags a newly-added function whose approximate cyclomatic complexity (branch/loop/logical-operator density, computed on the diff-visible lines) exceeds a threshold.",
+      looksAt:
+        "Added lines in changed non-test TS/JS source files, starting from a named function declaration or a const/let/var-assigned arrow function whose opening line is part of the diff.",
+      reports: "File, line, the detected function name, the measured complexity, and the configured threshold.",
+      network: "Pure local analyzer. No external network call.",
+      notes:
+        "Diff-hunk approximation, not a whole-function true McCabe count: REES has no full-file content, so this counts if/for/while/case/catch/&&/||/?? token occurrences across the function's ADDED body lines only (1 + count), the same function-boundary detection size-smell.ts (#2019) uses for 'big-function'. A function whose signature line is not part of the diff is not scored. Distinct from deep-nesting (#2030), which measures brace NESTING depth, a readability smell, not decision-point density. Ternary (`? :`) is intentionally excluded — see the analyzer source header for why.",
+    },
+    render: (findings, helpers) => {
+      if (!findings.length) return [];
+      const lines = ["### Approximate cyclomatic complexity (diff-visible branch/loop/logical-operator density)"];
+      for (const item of findings) {
+        const location = helpers.safeCodeSpan(`${item.file}:${item.line}`);
+        const name = helpers.safeCodeSpan(item.name);
+        lines.push(`- ${location} — ${name}: approx. complexity ${item.complexity} (threshold ${item.threshold})`);
+      }
+      return lines;
+    },
+    run: (req, { signal }) => scanComplexity(req, signal),
   }),
   descriptor({
     name: "unsafeAny",

--- a/review-enrichment/src/render.ts
+++ b/review-enrichment/src/render.ts
@@ -496,6 +496,7 @@ export function renderBrief(
   lines.push(...renderDescriptorSection("floatingPromise", findings.floatingPromise));
   lines.push(...renderDescriptorSection("deepNesting", findings.deepNesting));
   lines.push(...renderDescriptorSection("errorSwallow", findings.errorSwallow));
+  lines.push(...renderDescriptorSection("complexity", findings.complexity));
   lines.push(...renderDescriptorSection("unsafeAny", findings.unsafeAny));
   lines.push(...renderDescriptorSection("a11y", findings.a11y));
   lines.push(...renderDescriptorSection("i18n", findings.i18n));

--- a/review-enrichment/src/types.ts
+++ b/review-enrichment/src/types.ts
@@ -530,12 +530,30 @@ export interface I18nFinding {
   line: number;
 }
 
-/** A swallowed-error catch/except block newly added in the diff (#2014, part of #1499).
- *  Reports file, line, and kind only — never catch body content. */
+/** A swallowed or mishandled error/exception newly added in the diff (#2014, extended for Go + Python
+ *  bare-except by #1477). Reports file, line, and kind only — never catch/handler body content. `empty-catch`:
+ *  an empty JS/TS `catch`, Go `if err != nil {}`, or Python `except: pass` body. `unused-binding`: the bound
+ *  exception/checked error variable is never referenced, logged, or re-thrown. `return-null`: the handler
+ *  returns a bare `null`/`nil` instead of propagating the error. `bare-except`: a Python `except:` naming no
+ *  exception type, which catches everything (including `SystemExit`/`KeyboardInterrupt`) regardless of body. */
 export interface ErrorSwallowFinding {
   file: string;
   line: number;
-  kind: "empty-catch" | "unused-binding" | "return-null";
+  kind: "empty-catch" | "unused-binding" | "return-null" | "bare-except";
+}
+
+/** An approximate cyclomatic complexity for a newly-added function, computed from diff-visible added lines only
+ *  (#1477) — `1 + a count of if/for/while/case/catch/&&/||/?? tokens` within the function's added body lines,
+ *  not a whole-function true McCabe count (REES has no full-file content to walk). Distinct from deep-nesting
+ *  (#2030), which measures brace NESTING depth, a readability smell, not decision-point density. Reports file,
+ *  line, the detected function name, the measured complexity, and the configured threshold — never source
+ *  content. */
+export interface ComplexityFinding {
+  file: string;
+  line: number;
+  name: string;
+  complexity: number;
+  threshold: number;
 }
 
 /** Deep control-flow nesting newly added in the diff (#2030, part of #1499).
@@ -698,6 +716,7 @@ export interface BriefFindings {
   floatingPromise?: FloatingPromiseFinding[];
   deepNesting?: DeepNestingFinding[];
   errorSwallow?: ErrorSwallowFinding[];
+  complexity?: ComplexityFinding[];
   unsafeAny?: UnsafeAnyFinding[];
   a11y?: A11yFinding[];
   i18n?: I18nFinding[];

--- a/review-enrichment/test/analyzer-registry.test.ts
+++ b/review-enrichment/test/analyzer-registry.test.ts
@@ -52,6 +52,7 @@ const EXPECTED_ANALYZERS = [
   "floatingPromise",
   "deepNesting",
   "errorSwallow",
+  "complexity",
   "unsafeAny",
   "a11y",
   "i18n",

--- a/review-enrichment/test/complexity.test.ts
+++ b/review-enrichment/test/complexity.test.ts
@@ -1,0 +1,199 @@
+// Units for the approximate cyclomatic-complexity analyzer (#1477). Own file so concurrent analyzer PRs don't collide.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  countDecisionPoints,
+  DEFAULT_MAX_COMPLEXITY,
+  functionNameFromLine,
+  scanComplexity,
+  scanPatchForComplexity,
+} from "../dist/analyzers/complexity.js";
+import { renderBrief } from "../dist/render.js";
+
+const patchOf = (lines: string[]) =>
+  `@@ -1,0 +1,${lines.length} @@\n${lines.map((l) => `+${l}`).join("\n")}`;
+
+test("countDecisionPoints: counts if/for/while/catch/case and logical operators", () => {
+  assert.equal(countDecisionPoints(""), 0);
+  assert.equal(countDecisionPoints("if (a) {"), 1);
+  assert.equal(countDecisionPoints("for (const x of y) {"), 1);
+  assert.equal(countDecisionPoints("for await (const x of y) {"), 1);
+  assert.equal(countDecisionPoints("while (true) {"), 1);
+  assert.equal(countDecisionPoints("catch (e) {"), 1);
+  assert.equal(countDecisionPoints("catch {"), 1);
+  assert.equal(countDecisionPoints("case 1:"), 1);
+  assert.equal(countDecisionPoints("a && b || c ?? d"), 3);
+  assert.equal(countDecisionPoints("if (a) { if (b) {} }"), 2);
+});
+
+test("countDecisionPoints: does not count default, ternary, or optional chaining", () => {
+  assert.equal(countDecisionPoints("default:"), 0);
+  assert.equal(countDecisionPoints("const x = a ? b : c;"), 0);
+  assert.equal(countDecisionPoints("a?.b ?? c"), 1);
+  assert.equal(countDecisionPoints("function f(x?: number) {"), 0);
+});
+
+test("countDecisionPoints: does not falsely match identifiers containing the token as a substring", () => {
+  assert.equal(countDecisionPoints("const testCase1 = getCase();"), 0);
+  assert.equal(countDecisionPoints("const forecast = 1;"), 0);
+});
+
+test("functionNameFromLine: detects named functions and arrow-assigned functions", () => {
+  assert.equal(functionNameFromLine("function run() {"), "run");
+  assert.equal(functionNameFromLine("export function run() {"), "run");
+  assert.equal(functionNameFromLine("const run = () => {"), "run");
+  assert.equal(functionNameFromLine("export const run = async () => {"), "run");
+  assert.equal(functionNameFromLine("const run = (x: number) => {"), "run");
+});
+
+test("functionNameFromLine: a plain (non-arrow) function expression assigned to a const is out of scope", () => {
+  // Same structural scope as size-smell.ts's function detection: only named `function` declarations and
+  // arrow functions are recognized, not a bare `function` expression assigned via const/let/var.
+  assert.equal(functionNameFromLine("const run = function () {"), undefined);
+});
+
+test("functionNameFromLine: returns undefined for non-function lines and comments", () => {
+  assert.equal(functionNameFromLine("if (a) {"), undefined);
+  assert.equal(functionNameFromLine("  return x;"), undefined);
+  assert.equal(functionNameFromLine("// function run() {"), undefined);
+  assert.equal(functionNameFromLine(" * function run() {"), undefined);
+});
+
+test("scanPatchForComplexity: flags a function whose approximate complexity exceeds the threshold", () => {
+  const ifCount = DEFAULT_MAX_COMPLEXITY + 1;
+  const lines = [
+    "function big() {",
+    ...Array.from({ length: ifCount }, (_, i) => `  if (cond${i}) {}`),
+    "}",
+  ];
+  const findings = scanPatchForComplexity("src/widget.ts", patchOf(lines));
+  assert.equal(findings.length, 1);
+  assert.deepEqual(findings[0], {
+    file: "src/widget.ts",
+    line: 1,
+    name: "big",
+    complexity: 1 + ifCount,
+    threshold: DEFAULT_MAX_COMPLEXITY,
+  });
+});
+
+test("scanPatchForComplexity: does not flag a function at or under the threshold", () => {
+  const ifCount = DEFAULT_MAX_COMPLEXITY - 1;
+  const lines = [
+    "function ok() {",
+    ...Array.from({ length: ifCount }, (_, i) => `  if (cond${i}) {}`),
+    "}",
+  ];
+  assert.deepEqual(scanPatchForComplexity("src/widget.ts", patchOf(lines)), []);
+});
+
+test("scanPatchForComplexity: scores sibling functions independently in the same hunk", () => {
+  const ifCount = DEFAULT_MAX_COMPLEXITY + 1;
+  const lines = [
+    "function complicated() {",
+    ...Array.from({ length: ifCount }, (_, i) => `  if (cond${i}) {}`),
+    "}",
+    "function simple() {",
+    "  if (a) {}",
+    "}",
+  ];
+  const findings = scanPatchForComplexity("src/widget.ts", patchOf(lines));
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0]?.name, "complicated");
+});
+
+test("scanPatchForComplexity: arrow functions are scored the same as named functions", () => {
+  const ifCount = DEFAULT_MAX_COMPLEXITY + 1;
+  const lines = [
+    "export const big = () => {",
+    ...Array.from({ length: ifCount }, (_, i) => `  if (cond${i}) {}`),
+    "};",
+  ];
+  const findings = scanPatchForComplexity("src/widget.ts", patchOf(lines));
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0]?.name, "big");
+});
+
+test("scanPatchForComplexity: comment-only added lines do not inflate complexity", () => {
+  const ifCount = DEFAULT_MAX_COMPLEXITY - 1;
+  const lines = [
+    "function ok() {",
+    ...Array.from({ length: ifCount }, (_, i) => `  if (cond${i}) {}`),
+    "  // if (extra) { would push this over the threshold if counted }",
+    "}",
+  ];
+  assert.deepEqual(scanPatchForComplexity("src/widget.ts", patchOf(lines)), []);
+});
+
+test("scanPatchForComplexity: an edit to an existing function's body (signature not in the diff) is not scored", () => {
+  const patch = [
+    "@@ -5,4 +5,6 @@",
+    " function existing() {",
+    "+  if (a) {}",
+    "+  if (b) {}",
+    "   return x;",
+    " }",
+  ].join("\n");
+  assert.deepEqual(scanPatchForComplexity("src/widget.ts", patch), []);
+});
+
+test("scanPatchForComplexity: a context line flushes an in-progress function using its partial count", () => {
+  const ifCount = DEFAULT_MAX_COMPLEXITY + 1;
+  const patch = [
+    "@@ -1,0 +1,3 @@",
+    "+function big() {",
+    ...Array.from({ length: ifCount }, (_, i) => `+  if (cond${i}) {}`),
+    " // unchanged context line interrupts the run before the closing brace",
+  ].join("\n");
+  const findings = scanPatchForComplexity("src/widget.ts", patch);
+  assert.equal(findings.length, 1);
+  assert.equal(findings[0]?.name, "big");
+  assert.equal(findings[0]?.complexity, 1 + ifCount);
+});
+
+test("scanPatchForComplexity: skips non-TS/JS files and test files", () => {
+  const ifCount = DEFAULT_MAX_COMPLEXITY + 1;
+  const lines = [
+    "function big() {",
+    ...Array.from({ length: ifCount }, (_, i) => `  if (cond${i}) {}`),
+    "}",
+  ];
+  assert.deepEqual(scanPatchForComplexity("src/widget.py", patchOf(lines)), []);
+  assert.deepEqual(scanPatchForComplexity("src/widget.test.ts", patchOf(lines)), []);
+});
+
+test("scanPatchForComplexity: respects a custom maxComplexity limit", () => {
+  const lines = ["function f() {", "  if (a) {}", "  if (b) {}", "}"];
+  assert.deepEqual(scanPatchForComplexity("src/widget.ts", patchOf(lines), { maxComplexity: 2 }), [
+    { file: "src/widget.ts", line: 1, name: "f", complexity: 3, threshold: 2 },
+  ]);
+  assert.deepEqual(scanPatchForComplexity("src/widget.ts", patchOf(lines), { maxComplexity: 3 }), []);
+});
+
+test("scanPatchForComplexity: respects the findings cap across many functions", () => {
+  const ifCount = DEFAULT_MAX_COMPLEXITY + 1;
+  const functionBlock = (i: number) => [
+    `function big${i}() {`,
+    ...Array.from({ length: ifCount }, (_, j) => `  if (cond${j}) {}`),
+    "}",
+  ];
+  const lines = Array.from({ length: 30 }, (_, i) => functionBlock(i)).flat();
+  assert.equal(scanPatchForComplexity("src/widget.ts", patchOf(lines), { maxFindings: 3 }).length, 3);
+});
+
+test("scanComplexity: aggregates across files and renders a public-safe brief", async () => {
+  const ifCount = DEFAULT_MAX_COMPLEXITY + 1;
+  const findings = await scanComplexity({
+    files: [
+      {
+        path: "src/a.ts",
+        patch: patchOf(["function big() {", ...Array.from({ length: ifCount }, (_, i) => `  if (cond${i}) {}`), "}"]),
+      },
+    ],
+  });
+  assert.equal(findings.length, 1);
+  const { promptSection } = renderBrief({ complexity: findings });
+  assert.match(promptSection, /Approximate cyclomatic complexity/);
+  assert.match(promptSection, /src\/a\.ts:1/);
+  assert.match(promptSection, /big/);
+});

--- a/review-enrichment/test/error-swallow.test.ts
+++ b/review-enrichment/test/error-swallow.test.ts
@@ -91,3 +91,62 @@ test("scanErrorSwallow: aggregates across files and renders a public-safe brief"
   assert.match(promptSection, /src\/a\.ts:1/);
   assert.doesNotMatch(promptSection, /catch \(e\)/);
 });
+
+test("detectErrorSwallow: flags Go if-err checks that swallow the error", () => {
+  assert.equal(detectErrorSwallow("if err != nil {}"), "empty-catch");
+  assert.equal(detectErrorSwallow("if err != nil { return }"), "unused-binding");
+  assert.equal(detectErrorSwallow("if err != nil { return nil }"), "return-null");
+  assert.equal(detectErrorSwallow("if writeErr != nil { return nil }"), "return-null");
+});
+
+test("detectErrorSwallow: does not flag Go if-err checks that propagate, log, or panic", () => {
+  assert.equal(detectErrorSwallow("if err != nil { return err }"), null);
+  assert.equal(detectErrorSwallow("if err != nil { return fmt.Errorf(\"x: %w\", err) }"), null);
+  assert.equal(detectErrorSwallow("if err != nil { log.Println(err) }"), null);
+  assert.equal(detectErrorSwallow("if err != nil { panic(err) }"), null);
+});
+
+test("detectErrorSwallow: does not mistake an unrelated nil-pointer check for error handling", () => {
+  assert.equal(detectErrorSwallow("if node != nil { return defaultNode }"), null);
+});
+
+test("detectErrorSwallow: recognizes the Go if-with-initializer form", () => {
+  assert.equal(detectErrorSwallow("if err := doStuff(); err != nil { return }"), "unused-binding");
+  assert.equal(detectErrorSwallow("if err := doStuff(); err != nil { return err }"), null);
+});
+
+test("detectErrorSwallow: flags a bare Python except naming no exception type, regardless of body", () => {
+  assert.equal(detectErrorSwallow("except:"), "bare-except");
+  assert.equal(detectErrorSwallow("  except:  "), "bare-except");
+  assert.equal(detectErrorSwallow("except:  # noqa"), "bare-except");
+});
+
+test("detectErrorSwallow: does not flag a Python except naming a real exception type", () => {
+  assert.equal(detectErrorSwallow("except Exception:"), null);
+  assert.equal(detectErrorSwallow("except (TypeError, ValueError):"), null);
+});
+
+test("scanPatchForErrorSwallow: supports multi-line Go if-err blocks on added lines", () => {
+  const patch = [
+    "@@ -1,0 +1,4 @@",
+    "+resp, err := doStuff()",
+    "+if err != nil {",
+    "+  return",
+    "+}",
+  ].join("\n");
+  assert.deepEqual(scanPatchForErrorSwallow("main.go", patch), [
+    { file: "main.go", line: 2, kind: "unused-binding" },
+  ]);
+});
+
+test("scanPatchForErrorSwallow: flags a bare except on an added Python line", () => {
+  const findings = scanPatchForErrorSwallow("lib/b.py", patchOf(["except:", "    handle()"]));
+  assert.deepEqual(findings, [{ file: "lib/b.py", line: 1, kind: "bare-except" }]);
+});
+
+test("scanPatchForErrorSwallow: skips Go test files", () => {
+  assert.deepEqual(
+    scanPatchForErrorSwallow("main_test.go", patchOf(["if err != nil {}"])),
+    [],
+  );
+});

--- a/src/review/enrichment-analyzer-names.ts
+++ b/src/review/enrichment-analyzer-names.ts
@@ -46,6 +46,7 @@ export const REES_ANALYZER_NAMES = [
   "floatingPromise",
   "deepNesting",
   "errorSwallow",
+  "complexity",
   "unsafeAny",
   "a11y",
   "i18n",


### PR DESCRIPTION
## Summary

- Adds a new `complexity` REES analyzer (`review-enrichment/src/analyzers/complexity.ts`): an approximate cyclomatic-complexity walker. For a newly-added function whose opening line is visible in the diff (named `function` declarations or a const/let/var-assigned arrow function — the same structural detection `size-smell.ts` uses for "big-function"), it counts `if`/`for`/`while`/`case`/`catch`/`&&`/`||`/`??` token occurrences across the function's ADDED body lines and reports `1 + that count` (the McCabe formula on the visible slice). This is explicitly **not** a whole-function true McCabe count — REES has no full-file content, only diff hunks — and is genuinely distinct from `deep-nesting.ts` (#2030), which measures brace *nesting depth* (a readability smell its own header disclaims as a complexity metric), not decision-point density.
- Extends the existing `error-swallow` analyzer (rather than adding a third analyzer file) with:
  - Go's `if err != nil { ... }` check (including the very common if-with-initializer form `if err := f(); err != nil { ... }`), reusing the exact same empty/unused-binding/return-null classification the JS/TS `catch` path already has, plus a `panic()` exclusion mirroring the existing `throw` exclusion.
  - A Python bare `except:` detector (flake8 E722-equivalent) — a new `bare-except` finding kind, since catching every exception (including `SystemExit`/`KeyboardInterrupt`) is a defect independent of the handler body.
- Registers both in `registry.ts`/`types.ts` (`BriefFindings.complexity`, widened `ErrorSwallowFinding.kind`) and `render.ts`, exactly like every sibling analyzer (`floating-promise.ts`/`deep-nesting.ts` were the primary analogues traced). Adds `complexity` to both `REES_ANALYZER_NAMES` copies (`src/review/enrichment-analyzer-names.ts` and `packages/gittensory-engine/src/review/enrichment-analyzer-names.ts` — the latter is what the engine's `.gittensory.yml` `review.enrichment.*` parser validates against, so a repo owner can toggle `complexity` the same way as any other analyzer). `errorSwallow` already had a key, so no new entry was needed for the Go/Python extension.
- Regenerates the generated analyzer metadata (`review-enrichment/analyzer-metadata.json`, `apps/gittensory-ui/src/lib/rees-analyzers.ts`, the `.env.example` generated block) via `npm run rees:metadata`.
- Updates `review-enrichment/Dockerfile`'s line-1 comment, which said "analyzers add CLI tools later (#1477)" — this PR deliberately does not add any external linter/AST-parser/CLI tool, so the comment was stale relative to what actually shipped.
- Unrelated drive-by fix: `error-swallow.ts` and its test file were already committed with CRLF line endings (confirmed via `git cat-file` on the pre-existing HEAD blob — not introduced by this PR). Since I materially edit both files here, `git diff --check` fails on every added line unless the file is normalized, so I converted both to LF to match the rest of the codebase. No other CRLF files in the repo were touched.

### Why the cheap path, and why not duplicate churn-hotspot

Per the scoped-down plan for #1477: the original issue asked for real external linters (eslint/ruff/golangci-lint/semgrep) baked into the runtime image. This PR intentionally does **not** do that — REES stays no-checkout/no-external-process. `churn-hotspot.ts` (#1513, already shipped) is not precedent for a broader one-time full-file fetch here: it fetches commit *history metadata*, which cannot exist in a diff in any form at all, so a fetch is its only option. Complexity is *partially* derivable from the diff text itself (the added lines are real source), so the cheap in-hunk approximation — not a full-file fetch — is the right scope, and is documented as such in the analyzer's own header comment.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

Closes #1477

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint` (part of the full `npm run test:ci` run below; no workflow files changed)
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — full unsharded run, 1 file failed then passed in isolation (`test/unit/selfhost-ai.test.ts`'s real-subprocess timing test — confirmed pre-existing/unrelated flake under load, not touched by this diff)
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — 17 new tests for `complexity.ts` (decision-point counting, function detection, per-function partitioning of sibling functions, comment-line exclusion, the "signature not in diff" scope limit, custom threshold, findings cap) and 9 new Go/bare-except cases for `error-swallow.ts` (empty/unused-binding/return-nil/propagated/logged/panicked, the nil-pointer-vs-err disambiguation, the if-with-initializer form, bare-except vs named-exception). Ran the full local gate via `npm run test:ci` (green) plus `review-enrichment`'s own suite directly (`npm run test:node`, 1216/1216 passing). `review-enrichment/**` is not Codecov-measured (only `src/**`/`packages/gittensory-engine/src/**` are, per `vitest.config.ts`'s coverage `include`), so I additionally confirmed via `coverage/lcov.info` that the one line I added to each of the two `enrichment-analyzer-names.ts` copies is 100%-line-covered by the existing tests that already import those modules.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no such changes.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no public API/OpenAPI surface changed; this is REES-internal.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no manual UI change (the generated `rees-analyzers.ts` docs data file is regenerated output only).
- [x] Visible UI changes include a `UI Evidence` section — N/A, no visible UI change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — no `CHANGELOG.md` edit.

## Notes

- Traced analogues before writing anything: `floating-promise.ts`, `deep-nesting.ts`, `error-swallow.ts`, `size-smell.ts`, and `churn-hotspot.ts` (per the issue's own guidance).