### PR TITLE
fix(selfhost): distinguish missing-ref and detached-HEAD errors in update script

### DIFF
--- a/scripts/selfhost-update.sh
+++ b/scripts/selfhost-update.sh
@@ -46,6 +46,11 @@ fi
 cd "$SCRIPT_DIR/.."
 
 current_branch="$(git rev-parse --abbrev-ref HEAD)"
+if [ "$current_branch" = "HEAD" ]; then
+  echo "error: checkout is in a detached HEAD state, expected to be on '$BRANCH' -- checkout" \
+    "$BRANCH first (this script only updates a branch-tracking checkout)" >&2
+  exit 1
+fi
 if [ "$current_branch" != "$BRANCH" ]; then
   echo "error: currently on '$current_branch', expected '$BRANCH' -- checkout $BRANCH first, or" \
     "set SELFHOST_UPDATE_BRANCH=$current_branch if that is deliberate" >&2
@@ -60,6 +65,13 @@ fi
 
 echo "selfhost update: fetching $REMOTE"
 git fetch "$REMOTE"
+
+if ! git rev-parse --verify --quiet "$REMOTE/$BRANCH" >/dev/null; then
+  echo "error: $REMOTE/$BRANCH does not exist after fetching $REMOTE -- check" \
+    "SELFHOST_UPDATE_REMOTE/SELFHOST_UPDATE_BRANCH for a typo, or confirm $REMOTE actually has a" \
+    "'$BRANCH' branch" >&2
+  exit 1
+fi
 
 echo "selfhost update: fast-forwarding $BRANCH to $REMOTE/$BRANCH"
 if ! git merge --ff-only "$REMOTE/$BRANCH"; then

--- a/test/unit/docs-selfhost-git-deploy-hygiene.test.ts
+++ b/test/unit/docs-selfhost-git-deploy-hygiene.test.ts
@@ -31,10 +31,15 @@ describe("self-host git-deploy hygiene (#1660)", () => {
   });
 
   it("does not shadow any file actually tracked in the repo", () => {
-    // The real regression concern: a future PR could add a legitimately-tracked file whose name
-    // happens to match `*.bak-*` or `*.backup-*`, which would silently untrack it the moment
-    // someone re-clones. Ask git itself, rather than approximating the glob in JS, since git's
-    // own matcher is the one that actually enforces these patterns.
+    // The real regression concern: .gitignore has no effect on a file git already tracks -- it
+    // keeps being tracked, staged, and diffed normally forever, ignore pattern or not (verified:
+    // `git add -A` still stages a modification to an already-tracked-but-now-ignored file). The
+    // actual risk is the opposite direction -- a future PR that genuinely intends to add a NEW
+    // tracked file whose name happens to match `*.bak-*` or `*.backup-*` would have that file
+    // silently excluded from `git status`'s untracked list and from `git add -A`/`git add .`, so
+    // it could go uncommitted without anyone noticing (an explicit `git add <path>` at least warns
+    // and needs `-f`; a broad add just skips it quietly). Ask git itself, rather than approximating
+    // the glob in JS, since git's own matcher is the one that actually enforces these patterns.
     const result = spawnSync("git", ["ls-files"], { encoding: "utf8" });
     expect(result.status).toBe(0);
     const trackedFiles = result.stdout.split("\n").filter(Boolean);

--- a/test/unit/selfhost-update-script.test.ts
+++ b/test/unit/selfhost-update-script.test.ts
@@ -182,6 +182,34 @@ describe("selfhost-update.sh", () => {
     expect(readCallLog(callLog)).toBe("");
   });
 
+  it("refuses a detached HEAD with a distinct message instead of the generic branch mismatch", () => {
+    const { seedDir, checkoutDir, callLog } = createSandbox();
+    advanceOrigin(seedDir, "advance for detached-head");
+    git(["checkout", "-q", "--detach", "HEAD"], checkoutDir);
+
+    const result = run(checkoutDir, callLog);
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("detached HEAD state");
+    expect(result.stderr).not.toContain("currently on 'HEAD'");
+    expect(readCallLog(callLog)).toBe("");
+  });
+
+  it("gives a distinct error when SELFHOST_UPDATE_BRANCH names a branch the remote doesn't have", () => {
+    const { checkoutDir, callLog } = createSandbox();
+    // The local checkout must actually be on the named branch for the branch-mismatch check to
+    // pass, so this exercises the *next* guard: the branch exists locally but has no upstream
+    // counterpart to fast-forward from.
+    git(["checkout", "-q", "-b", "no-such-branch-upstream"], checkoutDir);
+
+    const result = run(checkoutDir, callLog, { SELFHOST_UPDATE_BRANCH: "no-such-branch-upstream" });
+
+    expect(result.status).not.toBe(0);
+    expect(result.stderr).toContain("origin/no-such-branch-upstream does not exist");
+    expect(result.stderr).not.toContain("could not be fast-forwarded");
+    expect(readCallLog(callLog)).toBe("");
+  });
+
   it("accepts a non-default branch when SELFHOST_UPDATE_BRANCH names it explicitly", () => {
     const { seedDir, checkoutDir, callLog } = createSandbox();
     git(["checkout", "-q", "-b", "release"], seedDir);


### PR DESCRIPTION
## Summary

Precision follow-up to #4151 (merged; #1660 itself is done). While that PR was open, the Gittensory Orb
review flagged 7 non-blocking nits (readiness 100/100, no blockers, held only because it touched
guarded paths). #4151 got merged by a separate verification pass before I finished triaging those
nits, so this PR carries the two genuinely worth fixing, now tracked under #4156 since issue #1660 already shows CLOSED
already closed:

1. **Imprecise ff-only error.** `scripts/selfhost-update.sh`'s `git merge --ff-only` failure path
   printed the same "local history has diverged" message for two different causes: a real
   non-fast-forward divergence, and a bad `SELFHOST_UPDATE_BRANCH`/`SELFHOST_UPDATE_REMOTE` override
   pointing at a ref that doesn't exist at all (`git merge --ff-only <bad-ref>` fails the same way
   either way). Added `git rev-parse --verify --quiet "$REMOTE/$BRANCH"` right after the fetch so a
   missing ref gets its own distinct, actionable error instead of being misreported as a divergence.
2. **Confusing detached-HEAD message.** `current_branch="$(git rev-parse --abbrev-ref HEAD)"`
   literally returns the string `HEAD` in a detached checkout, so the existing branch-mismatch
   error read "currently on 'HEAD', expected 'main'" and suggested a nonsensical
   `SELFHOST_UPDATE_BRANCH=HEAD` override. Detached HEAD now gets its own message.

Also fixed, alongside those two: an inaccurate comment on the `.gitignore` tracked-file-shadowing
test (`test/unit/docs-selfhost-git-deploy-hygiene.test.ts`) claiming a tracked file matching the new
`*.bak-*`/`*.backup-*` patterns would get "silently untracked... the moment someone re-clones" —
verified empirically (scratch repo: track a file, add a matching ignore pattern, modify it, `git add
-A`) that `.gitignore` has **no effect on already-tracked files at all**; the modification still
staged normally. The real risk runs the other way: a *new* file matching the pattern would be
silently excluded from `git status`'s untracked list and from `git add -A`/`git add .`, so it could
go uncommitted without anyone noticing. Corrected the comment to describe that mechanism instead.

Closes #4156.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #4156`).

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint` (no workflow files touched; ran anyway as part of the full gate)
- [x] `npm run typecheck` — clean
- [x] `npm run test:coverage` locally — 587 test files passed / 2 skipped, 11982 tests passed / 7 skipped, unsharded. No `src/**`/`packages/**` lines changed (only `scripts/**`, `test/**`), so no new Codecov `codecov/patch` obligation — ran it anyway to confirm nothing broke.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — two new real-execution cases added to `test/unit/selfhost-update-script.test.ts`:
  - a checkout in a detached HEAD state gets the new distinct message, not the generic branch-mismatch one;
  - `SELFHOST_UPDATE_BRANCH` naming a branch the remote doesn't have gets the new "does not exist after fetching" message, distinct from the fast-forward-divergence message.
  20/20 passing (the 8 pre-existing cases plus the 2 new ones).

If any required check was skipped, explain why:

- Ran the full `npm run test:ci` gate end-to-end (all steps green, including `test:engine-parity`,
  `db:migrations:check`, `db:schema-drift:check`, `selfhost:env-reference:check`,
  `selfhost:validate-observability`, `cf-typegen:check`, `rees:test`, `ui:openapi:settings-parity`,
  `ui:version-audit`, `docs:drift-check`, `manifest:drift-check`, `command-reference:check`,
  `ui:test`) beyond just the boxes above.
- Did not run the `gittensory-mcp` pre-submit predictors: same as #4151, they need an interactive
  GitHub device-flow login this session can't complete, and as the repo owner this PR is held for
  manual merge rather than auto-closed on an adverse gate signal.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no such changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no such changes; `ui:openapi:check` confirms no drift.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes in this PR at all, only `scripts/**` and `test/**`.)
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository. (N/A — no UI/docs route touched by this PR.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable: this PR only touches `scripts/selfhost-update.sh` and its test files — no UI, docs
route, or other visible surface.

## Notes

- Root cause of why this is a separate PR rather than a #4151 follow-up commit: I was mid-triage on
  the Orb's 7 nits (verifying which were real before pushing anything) when a separate verification
  pass merged #4151 out from under the branch. Rather than push dangling commits to a closed PR's
  branch, cut a fresh branch off the post-merge `origin/main` tip, cherry-picked the one commit that
  carried genuine fixes, opened #4156 to track it (since issue #1660 already shows CLOSED and a linked open
  issue is required), and rebased/re-verified the full gate against the new base before pushing.
- Verified empirically, not asserted: the `.gitignore`-doesn't-untrack claim above was checked in a
  disposable scratch git repo (track a file → add a matching ignore pattern → modify the file →
  `git add -A` → confirm it still stages) before rewriting the comment, rather than trusting either
  the original (wrong) comment or the review's suggested rewording at face value — the suggested
  rewording ("`git add -A` would silently skip the file going forward") turned out to also be
  imprecise for an *already-tracked* file, so the final comment states the mechanism for a *new*
  file instead, which is what the test's `git ls-files` check actually guards against.