### PR TITLE
refactor(review-enrichment): dedupe REES analyzer limit constants

### DIFF
--- a/review-enrichment/src/analyzers/a11y-regression.ts
+++ b/review-enrichment/src/analyzers/a11y-regression.ts
@@ -3,9 +3,10 @@
 // positive tabindex values. Pure compute over added lines in .jsx/.tsx/.html/.vue files, no network.
 import type { A11yFinding, EnrichRequest } from "../types.js";
 import { isTestPath } from "./test-ratio.js";
+import { DEFAULT_MAX_FINDINGS, DEFAULT_MAX_LINE_CHARS } from "./limits.js";
 
-const MAX_FINDINGS = 25;
-const MAX_LINE_CHARS = 2000;
+const MAX_FINDINGS = DEFAULT_MAX_FINDINGS;
+const MAX_LINE_CHARS = DEFAULT_MAX_LINE_CHARS;
 
 const MARKUP_PATH_RE = /\.(?:tsx|jsx|html|vue)$/i;
 

--- a/review-enrichment/src/analyzers/api-break.ts
+++ b/review-enrichment/src/analyzers/api-break.ts
@@ -8,9 +8,10 @@
 // exact whole-name loss is; a non-entrypoint file is out of scope (that is the caller-impact analyzer's job).
 // Deterministic, no network, no token. Reports file, old-file line, and symbol only — never surrounding code.
 import type { ApiBreakFinding, EnrichRequest } from "../types.js";
+import { DEFAULT_MAX_FINDINGS } from "./limits.js";
 
 const MAX_ENTRYPOINTS = 25; // cap changed entrypoint files scanned per PR
-const MAX_FINDINGS = 25; // keep the brief bounded
+const MAX_FINDINGS = DEFAULT_MAX_FINDINGS;
 
 // Files whose top-level exports form a package's PUBLIC surface: barrel/entry modules only. Restricting to these
 // entrypoint basenames keeps the signal conservative — a removed export in an internal module is not a downstream

--- a/review-enrichment/src/analyzers/caller-impact.ts
+++ b/review-enrichment/src/analyzers/caller-impact.ts
@@ -29,6 +29,7 @@ import type { AnalysisContext } from "../analysis-context.js";
 import { boundedFetchJson } from "../external-fetch.js";
 import { exportedNames, isPublicEntrypoint } from "./api-break.js";
 import { isTestPath } from "./test-ratio.js";
+import { DEFAULT_MAX_FINDINGS } from "./limits.js";
 
 const GITHUB_API = "https://api.github.com";
 const GITHUB_API_VERSION = "2022-11-28";
@@ -37,7 +38,7 @@ const MAX_SYMBOLS = 6; // removed symbols searched per PR (Code Search rate budg
 const MAX_SEARCHES = 6; // bounded Code Search queries per PR
 const MAX_FILE_FETCHES = 12; // bounded candidate-caller content fetches per PR
 const MAX_CALLERS_PER_FINDING = 5; // caller paths listed per finding (keeps the brief bounded)
-const MAX_FINDINGS = 25;
+const MAX_FINDINGS = DEFAULT_MAX_FINDINGS;
 const MIN_SYMBOL_LEN = 3; // skip 1-2 char names — too generic to search reliably
 const MAX_FETCH_BYTES = 1_000_000;
 const MAX_SEARCH_JSON_BYTES = 256 * 1024;

--- a/review-enrichment/src/analyzers/commit-hygiene.ts
+++ b/review-enrichment/src/analyzers/commit-hygiene.ts
@@ -16,11 +16,12 @@ import type {
 } from "../types.js";
 import type { AnalysisContext } from "../analysis-context.js";
 import { boundedFetchJson } from "../external-fetch.js";
+import { DEFAULT_MAX_FINDINGS } from "./limits.js";
 
 const GITHUB_API = "https://api.github.com";
 const SLUG_RE = /^[A-Za-z0-9._-]+$/;
 const MAX_COMMITS = 100;
-const MAX_FINDINGS = 25;
+const MAX_FINDINGS = DEFAULT_MAX_FINDINGS;
 const SHA_PREFIX_LEN = 12;
 
 // Git's own autosquash markers (`git commit --fixup`/`--squash`, `git rebase -i --autosquash`) — a documented,

--- a/review-enrichment/src/analyzers/commit-lint.ts
+++ b/review-enrichment/src/analyzers/commit-lint.ts
@@ -12,11 +12,12 @@ import type {
 } from "../types.js";
 import type { AnalysisContext } from "../analysis-context.js";
 import { boundedFetchJson } from "../external-fetch.js";
+import { DEFAULT_MAX_FINDINGS } from "./limits.js";
 
 const GITHUB_API = "https://api.github.com";
 const SLUG_RE = /^[A-Za-z0-9._-]+$/;
 const MAX_COMMITS = 100;
-const MAX_FINDINGS = 25;
+const MAX_FINDINGS = DEFAULT_MAX_FINDINGS;
 const SHA_PREFIX_LEN = 12;
 const MAX_SUBJECT_LEN = 72; // Conventional Commits / git convention soft cap for the subject line.
 

--- a/review-enrichment/src/analyzers/complexity.ts
+++ b/review-enrichment/src/analyzers/complexity.ts
@@ -27,10 +27,11 @@
 import type { ComplexityFinding, EnrichRequest } from "../types.js";
 import { codeOnly } from "./secret-log.js";
 import { isTestPath } from "./test-ratio.js";
+import { DEFAULT_MAX_FINDINGS, DEFAULT_MAX_LINE_CHARS } from "./limits.js";
 
 export const DEFAULT_MAX_COMPLEXITY = 10;
-const MAX_FINDINGS = 25;
-const MAX_LINE_CHARS = 2000;
+const MAX_FINDINGS = DEFAULT_MAX_FINDINGS;
+const MAX_LINE_CHARS = DEFAULT_MAX_LINE_CHARS;
 
 const JS_TS_PATH_RE = /\.(?:tsx?|jsx?|mts|cts|cjs|mjs)$/i;
 
@@ -88,6 +89,34 @@ function braceDepthDelta(code: string): number {
     else if (ch === "}") depth--;
   }
   return depth;
+}
+
+/** Given the current pending function (or none) and one added code line, return the updated pending
+ *  state -- mutated in place and returned when tracking continues, freshly started when the line opens
+ *  a new function, or null when neither applies. Extracted out of scanPatchForComplexity's own loop
+ *  (rather than left as an inline if/else) to keep that loop's own control-flow nesting under this
+ *  analyzer's sibling deep-nesting.ts threshold. Pure; deciding whether to flush (pending.depth <= 0)
+ *  stays the caller's job so this has no dependency on flushFunction's closure. */
+function advancePendingFunction(
+  pending: PendingFunction | null,
+  body: string,
+  commented: boolean,
+  code: string,
+  newLine: number,
+): PendingFunction | null {
+  if (pending) {
+    if (!commented) pending.complexity += countDecisionPoints(code);
+    pending.depth += braceDepthDelta(code);
+    return pending;
+  }
+  const name = functionNameFromLine(body);
+  if (!name) return null;
+  return {
+    name,
+    startLine: newLine,
+    complexity: 1 + (commented ? 0 : countDecisionPoints(code)),
+    depth: braceDepthDelta(code),
+  };
 }
 
 type ScanLimits = {
@@ -150,22 +179,8 @@ export function scanPatchForComplexity(
       if (body.length <= MAX_LINE_CHARS) {
         const commented = isCommentLine(body);
         const code = codeOnly(body);
-        if (pending) {
-          if (!commented) pending.complexity += countDecisionPoints(code);
-          pending.depth += braceDepthDelta(code);
-          if (pending.depth <= 0) flushFunction();
-        } else {
-          const name = functionNameFromLine(body);
-          if (name) {
-            pending = {
-              name,
-              startLine: newLine,
-              complexity: 1 + (commented ? 0 : countDecisionPoints(code)),
-              depth: braceDepthDelta(code),
-            };
-            if (pending.depth <= 0) flushFunction();
-          }
-        }
+        pending = advancePendingFunction(pending, body, commented, code, newLine);
+        if (pending && pending.depth <= 0) flushFunction();
       }
       newLine++;
     } else {

--- a/review-enrichment/src/analyzers/conflict-marker.ts
+++ b/review-enrichment/src/analyzers/conflict-marker.ts
@@ -4,8 +4,9 @@
 // Detection is purely structural (a fixed run of seven identical characters at column 0), so there is no
 // comment/string state to track. Line-cited via hunk headers, mirroring the sibling local analyzers.
 import type { EnrichRequest, ConflictMarkerFinding } from "../types.js";
+import { DEFAULT_MAX_FINDINGS } from "./limits.js";
 
-const MAX_FINDINGS = 25;
+const MAX_FINDINGS = DEFAULT_MAX_FINDINGS;
 
 // Git writes each conflict marker as EXACTLY seven identical characters at the start of the line. The ours/base/
 // theirs markers may carry a trailing space + label (a branch or commit); the separator is a bare seven `=`.

--- a/review-enrichment/src/analyzers/debug-leftover.ts
+++ b/review-enrichment/src/analyzers/debug-leftover.ts
@@ -6,9 +6,10 @@
 import type { DebugLeftoverFinding, EnrichRequest } from "../types.js";
 import { codeOnly } from "./secret-log.js";
 import { isTestPath } from "./test-ratio.js";
+import { DEFAULT_MAX_FINDINGS, DEFAULT_MAX_LINE_CHARS } from "./limits.js";
 
-const MAX_FINDINGS = 25;
-const MAX_LINE_CHARS = 2000;
+const MAX_FINDINGS = DEFAULT_MAX_FINDINGS;
+const MAX_LINE_CHARS = DEFAULT_MAX_LINE_CHARS;
 
 const DEBUGGER_RE = /\bdebugger\s*;/;
 const CONSOLE_RE = /\bconsole\s*\.\s*(?:log|debug|info|warn|error|trace|dir|table)\s*\(/;

--- a/review-enrichment/src/analyzers/deep-nesting.ts
+++ b/review-enrichment/src/analyzers/deep-nesting.ts
@@ -5,10 +5,11 @@
 import type { DeepNestingFinding, EnrichRequest } from "../types.js";
 import { codeOnly } from "./secret-log.js";
 import { isTestPath } from "./test-ratio.js";
+import { DEFAULT_MAX_FINDINGS, DEFAULT_MAX_LINE_CHARS } from "./limits.js";
 
 export const DEFAULT_MAX_DEPTH = 4;
-const MAX_FINDINGS = 25;
-const MAX_LINE_CHARS = 2000;
+const MAX_FINDINGS = DEFAULT_MAX_FINDINGS;
+const MAX_LINE_CHARS = DEFAULT_MAX_LINE_CHARS;
 
 type BraceKind = "control" | "other";
 

--- a/review-enrichment/src/analyzers/dependency-diff.ts
+++ b/review-enrichment/src/analyzers/dependency-diff.ts
@@ -6,8 +6,9 @@ import {
   extractDependencyInventoryChanges,
   type ScanLimits,
 } from "./dependency-scan.js";
+import { DEFAULT_MAX_FINDINGS } from "./limits.js";
 
-const MAX_FINDINGS = 25;
+const MAX_FINDINGS = DEFAULT_MAX_FINDINGS;
 const LIMITS: ScanLimits = {
   maxManifestFiles: 20,
   maxPatchLinesPerFile: 500,

--- a/review-enrichment/src/analyzers/deprecated-dep.ts
+++ b/review-enrichment/src/analyzers/deprecated-dep.ts
@@ -9,10 +9,11 @@
 // version, the change direction, the documented reason, and the recommended replacement — never manifest contents.
 import type { DeprecatedDependencyFinding, EnrichRequest } from "../types.js";
 import { extractDependencyChanges } from "./dependency-scan.js";
+import { DEFAULT_MAX_FINDINGS } from "./limits.js";
 
 const MAX_MANIFEST_FILES = 20; // bound manifest files parsed per PR
 const MAX_PATCH_LINES_PER_FILE = 500; // bound patch lines parsed per manifest
-const MAX_FINDINGS = 25; // keep the brief bounded
+const MAX_FINDINGS = DEFAULT_MAX_FINDINGS;
 
 interface DeprecationNote {
   reason: string;

--- a/review-enrichment/src/analyzers/duplication-scan.ts
+++ b/review-enrichment/src/analyzers/duplication-scan.ts
@@ -15,6 +15,7 @@ import type {
 } from "../types.js";
 import type { AnalysisContext } from "../analysis-context.js";
 import { boundedFetchJson } from "../external-fetch.js";
+import { DEFAULT_MAX_FINDINGS } from "./limits.js";
 
 const GITHUB_API = "https://api.github.com";
 const GITHUB_API_VERSION = "2022-11-28";
@@ -22,7 +23,7 @@ const GITHUB_API_VERSION = "2022-11-28";
 const MIN_RUN = 8; // a contiguous run of >= this many significant normalized lines is required to flag a duplicate
 const MAX_CANDIDATES = 40; // cap candidate files (closest-by-path first) we consider per scan
 const MAX_FETCHES = 30; // global cap on candidate blob fetches per scan
-const MAX_FINDINGS = 25; // keep the brief bounded
+const MAX_FINDINGS = DEFAULT_MAX_FINDINGS;
 const MIN_SIGNIFICANT_LEN = 12; // lines shorter than this (after trim) are treated as trivial and dropped
 const MAX_FILE_BYTES = 500_000; // skip an oversized candidate blob so one huge (likely generated) file can't eat the budget
 const MAX_TREE_JSON_BYTES = 4 * 1024 * 1024; // recursive git tree can be large; bound it like asset-weight does

--- a/review-enrichment/src/analyzers/error-swallow.ts
+++ b/review-enrichment/src/analyzers/error-swallow.ts
@@ -5,9 +5,10 @@
 // of silent failures. Pure compute over added diff lines, no network. Scoped to JS/TS/Python/Go source files.
 import type { EnrichRequest, ErrorSwallowFinding } from "../types.js";
 import { isTestPath } from "./test-ratio.js";
+import { DEFAULT_MAX_FINDINGS, DEFAULT_MAX_LINE_CHARS } from "./limits.js";
 
-const MAX_FINDINGS = 25;
-const MAX_LINE_CHARS = 2000;
+const MAX_FINDINGS = DEFAULT_MAX_FINDINGS;
+const MAX_LINE_CHARS = DEFAULT_MAX_LINE_CHARS;
 
 const SOURCE_EXTS = new Set(["ts", "tsx", "js", "jsx", "mjs", "cjs", "mts", "cts", "py", "go"]);
 
@@ -139,6 +140,43 @@ function flushPending(pending: PendingCatch): ErrorSwallowFinding["kind"] | null
   return bodySwallowsError(body, pending.binding);
 }
 
+type PendingCatchResult = {
+  pending: PendingCatch | null;
+  finding: ErrorSwallowFinding["kind"] | null;
+  findingLine: number | null;
+};
+
+/** Continue tracking an already-open catch/error block for one more added line: buffer it and update its
+ *  brace depth, then flush (classify + clear) once the depth balances back to zero. Pure. Extracted out
+ *  of scanPatchForErrorSwallow's own loop to keep that loop's control-flow nesting under this analyzer's
+ *  sibling deep-nesting.ts threshold. */
+function advancePendingCatch(pending: PendingCatch, body: string): PendingCatchResult {
+  const updated = updatePending(pending, body);
+  if (updated.depth > 0) return { pending: updated, finding: null, findingLine: null };
+  return { pending: null, finding: flushPending(updated), findingLine: updated.startLine };
+}
+
+/** Look for a NEW error-handling block opening on one added line when nothing is currently pending:
+ *  either an immediate single-line finding, or the start of a multi-line block whose closing brace
+ *  hasn't appeared yet. Pure. Same extraction rationale as advancePendingCatch. */
+function tryStartPendingCatch(body: string, newLine: number): PendingCatchResult {
+  const kind = detectErrorSwallow(body);
+  if (kind) return { pending: null, finding: kind, findingLine: newLine };
+
+  const open = matchErrorOpen(body);
+  if (!open) return { pending: null, finding: null, findingLine: null };
+  const braceIndex = body.indexOf("{", open.index ?? 0);
+  if (braceIndex < 0) return { pending: null, finding: null, findingLine: null };
+  const depth = braceBalanceFrom(body, braceIndex);
+  if (depth <= 0) return { pending: null, finding: null, findingLine: null };
+
+  return {
+    pending: { startLine: newLine, binding: open[1] ?? null, body: body.slice(braceIndex), depth },
+    finding: null,
+    findingLine: null,
+  };
+}
+
 type ScanLimits = {
   maxFindings?: number;
   signal?: AbortSignal;
@@ -175,38 +213,11 @@ export function scanPatchForErrorSwallow(
     if (line.startsWith("+")) {
       const body = line.slice(1);
       if (body.length <= MAX_LINE_CHARS) {
-        if (pending) {
-          pending = updatePending(pending, body);
-          if (pending.depth <= 0) {
-            const kind = flushPending(pending);
-            if (kind) {
-              pushFinding(pending.startLine, kind);
-              if (findings.length >= maxFindings) return findings;
-            }
-            pending = null;
-          }
-        } else {
-          const kind = detectErrorSwallow(body);
-          if (kind) {
-            pushFinding(newLine, kind);
-            if (findings.length >= maxFindings) return findings;
-          } else {
-            const open = matchErrorOpen(body);
-            if (open) {
-              const braceIndex = body.indexOf("{", open.index ?? 0);
-              if (braceIndex >= 0) {
-                const depth = braceBalanceFrom(body, braceIndex);
-                if (depth > 0) {
-                  pending = {
-                    startLine: newLine,
-                    binding: open[1] ?? null,
-                    body: body.slice(braceIndex),
-                    depth,
-                  };
-                }
-              }
-            }
-          }
+        const result: PendingCatchResult = pending ? advancePendingCatch(pending, body) : tryStartPendingCatch(body, newLine);
+        pending = result.pending;
+        if (result.finding) {
+          pushFinding(result.findingLine ?? newLine, result.finding);
+          if (findings.length >= maxFindings) return findings;
         }
       }
       newLine++;

--- a/review-enrichment/src/analyzers/exhaustiveness-drift.ts
+++ b/review-enrichment/src/analyzers/exhaustiveness-drift.ts
@@ -7,12 +7,13 @@ import type { EnrichRequest, ExhaustivenessFinding } from "../types.js";
 import { reconstructOldContent } from "./doc-comment-drift.js";
 import { isDiffFileHeaderLine } from "./diff-lines.js";
 import { isTestPath } from "./test-ratio.js";
+import { DEFAULT_MAX_FINDINGS } from "./limits.js";
 
 const GITHUB_API = "https://api.github.com";
 const SLUG_RE = /^[A-Za-z0-9._-]+$/;
 const MAX_FILES = 10;
 const MAX_FETCHES = 10;
-const MAX_FINDINGS = 25;
+const MAX_FINDINGS = DEFAULT_MAX_FINDINGS;
 const MAX_FETCH_BYTES = 1_000_000;
 const MAX_SWITCH_HEADER_LINES = 25;
 const SOURCE_RE = /\.(?:ts|tsx|mts|cts|js|jsx|mjs|cjs)$/;

--- a/review-enrichment/src/analyzers/flaky-test.ts
+++ b/review-enrichment/src/analyzers/flaky-test.ts
@@ -11,6 +11,7 @@ import type {
 import type { AnalysisContext } from "../analysis-context.js";
 import { boundedFetchJson } from "../external-fetch.js";
 import { isTestPath } from "./test-ratio.js";
+import { DEFAULT_MAX_FINDINGS } from "./limits.js";
 
 const GITHUB_API = "https://api.github.com";
 const SLUG_RE = /^[A-Za-z0-9._-]+$/;
@@ -19,7 +20,7 @@ const WINDOW_LABEL = "30d";
 const MAX_FILES_PROBED = 6;
 const MAX_COMMITS_PER_FILE = 5;
 const MAX_CHECK_RUN_FETCHES = 12;
-const MAX_FINDINGS = 25;
+const MAX_FINDINGS = DEFAULT_MAX_FINDINGS;
 const MIN_FAILURE_EVENTS = 2;
 const COMMITS_PER_PAGE = 20;
 

--- a/review-enrichment/src/analyzers/floating-promise.ts
+++ b/review-enrichment/src/analyzers/floating-promise.ts
@@ -5,9 +5,10 @@
 import type { EnrichRequest, FloatingPromiseFinding } from "../types.js";
 import { codeOnly } from "./secret-log.js";
 import { isTestPath } from "./test-ratio.js";
+import { DEFAULT_MAX_FINDINGS, DEFAULT_MAX_LINE_CHARS } from "./limits.js";
 
-const MAX_FINDINGS = 25;
-const MAX_LINE_CHARS = 2000;
+const MAX_FINDINGS = DEFAULT_MAX_FINDINGS;
+const MAX_LINE_CHARS = DEFAULT_MAX_LINE_CHARS;
 const MAX_CALL_CHARS = 40;
 
 const JS_TS_PATH_RE = /\.(?:tsx?|jsx?|mts|cts|cjs|mjs)$/i;

--- a/review-enrichment/src/analyzers/hardcoded-url.ts
+++ b/review-enrichment/src/analyzers/hardcoded-url.ts
@@ -4,9 +4,10 @@
 // over added lines, no network. Hostnames are redacted/truncated in findings — never full paths or queries.
 import type { EnrichRequest, HardcodedUrlFinding } from "../types.js";
 import { isMagicNumberSourcePath } from "./magic-number.js";
+import { DEFAULT_MAX_FINDINGS, DEFAULT_MAX_LINE_CHARS } from "./limits.js";
 
-const MAX_FINDINGS = 25;
-const MAX_LINE_CHARS = 2000;
+const MAX_FINDINGS = DEFAULT_MAX_FINDINGS;
+const MAX_LINE_CHARS = DEFAULT_MAX_LINE_CHARS;
 const MAX_HOST_CHARS = 40;
 
 const CONFIG_PATH_RE =

--- a/review-enrichment/src/analyzers/i18n-regression.ts
+++ b/review-enrichment/src/analyzers/i18n-regression.ts
@@ -4,9 +4,10 @@
 // Pure compute over added lines, no network. Never returns string content in findings.
 import type { EnrichRequest, I18nFinding } from "../types.js";
 import { isTestPath } from "./test-ratio.js";
+import { DEFAULT_MAX_FINDINGS, DEFAULT_MAX_LINE_CHARS } from "./limits.js";
 
-const MAX_FINDINGS = 25;
-const MAX_LINE_CHARS = 2000;
+const MAX_FINDINGS = DEFAULT_MAX_FINDINGS;
+const MAX_LINE_CHARS = DEFAULT_MAX_LINE_CHARS;
 
 const UI_PATH_RE = /\.(?:tsx|jsx|vue)$/i;
 

--- a/review-enrichment/src/analyzers/iac-misconfig.ts
+++ b/review-enrichment/src/analyzers/iac-misconfig.ts
@@ -1,7 +1,8 @@
 import type { EnrichRequest, IacMisconfigFinding } from "../types.js";
+import { DEFAULT_MAX_FINDINGS, DEFAULT_MAX_LINE_CHARS } from "./limits.js";
 
-const MAX_FINDINGS = 25;
-const MAX_LINE_CHARS = 2000;
+const MAX_FINDINGS = DEFAULT_MAX_FINDINGS;
+const MAX_LINE_CHARS = DEFAULT_MAX_LINE_CHARS;
 
 const CONFIG_PATH_RE =
   /(?:^|\/)(?:docker-compose[^/]*\.ya?ml|compose[^/]*\.ya?ml|values(?:\.[^/]+)?\.ya?ml|\.env(?:\.[^/]+)?|.*\.(?:tf|tfvars|hcl|ya?ml|json|toml|ini|conf|env)|Dockerfile(?:\.[^/]+)?|nginx[^/]*\.conf)$/i;

--- a/review-enrichment/src/analyzers/limits.ts
+++ b/review-enrichment/src/analyzers/limits.ts
@@ -1,0 +1,12 @@
+// Shared default limits for REES analyzers (#1477 follow-up). Most analyzers cap their findings and
+// skip pathologically long lines at the same two numbers -- centralizing them here means changing the
+// platform-wide bound in ONE place instead of ~30 duplicated literals scattered across analyzer files
+// and their registry.ts descriptors. An analyzer with a genuinely different bound (e.g. asset-weight's
+// 50, heavy-dependency's 15) keeps its own local override -- only the REPEATED 25/2000 pair moves here.
+
+/** Default cap on findings a single analyzer emits per request, keeping the brief bounded. */
+export const DEFAULT_MAX_FINDINGS = 25;
+
+/** Default per-line length ceiling analyzers skip past without inspecting -- defensive against a
+ *  pathologically long generated/minified line, not a real code-quality signal. */
+export const DEFAULT_MAX_LINE_CHARS = 2000;

--- a/review-enrichment/src/analyzers/loose-range.ts
+++ b/review-enrichment/src/analyzers/loose-range.ts
@@ -8,9 +8,10 @@
 // without resolving the whole tree.
 import type { EnrichRequest, LooseRangeFinding } from "../types.js";
 import { isDiffFileHeaderLine } from "./diff-lines.js";
+import { DEFAULT_MAX_LINE_CHARS } from "./limits.js";
 
 const MAX_FINDINGS = 20;
-const MAX_LINE_CHARS = 2000;
+const MAX_LINE_CHARS = DEFAULT_MAX_LINE_CHARS;
 
 // `"name": "spec"` on an added line, same shape the sibling dependency-scan.ts keys on.
 const NPM_LINE_RE = /^"([^"]+)"\s*:\s*"([^"]+)"/;

--- a/review-enrichment/src/analyzers/magic-number.ts
+++ b/review-enrichment/src/analyzers/magic-number.ts
@@ -5,9 +5,10 @@
 import type { EnrichRequest, MagicNumberFinding } from "../types.js";
 import { codeOnly } from "./secret-log.js";
 import { isTestPath } from "./test-ratio.js";
+import { DEFAULT_MAX_FINDINGS, DEFAULT_MAX_LINE_CHARS } from "./limits.js";
 
-const MAX_FINDINGS = 25;
-const MAX_LINE_CHARS = 2000;
+const MAX_FINDINGS = DEFAULT_MAX_FINDINGS;
+const MAX_LINE_CHARS = DEFAULT_MAX_LINE_CHARS;
 const REPORT_CHARS = 40;
 
 const SOURCE_EXTS = new Set([

--- a/review-enrichment/src/analyzers/migration-safety.ts
+++ b/review-enrichment/src/analyzers/migration-safety.ts
@@ -6,9 +6,10 @@
 // line-anchored: a statement split across lines is missed (fail-quiet) rather than tracked with cross-line
 // state, and each shape is a finite, documented DDL form — never a general SQL grammar.
 import type { EnrichRequest, MigrationSafetyFinding } from "../types.js";
+import { DEFAULT_MAX_LINE_CHARS } from "./limits.js";
 
 const MAX_FINDINGS = 20;
-const MAX_LINE_CHARS = 2000;
+const MAX_LINE_CHARS = DEFAULT_MAX_LINE_CHARS;
 
 // Migration SQL locations: a migrations/ directory (Wrangler/D1, Prisma, Flyway, …), Rails-style db/migrate/,
 // or any .sql file — the three forms named by #2022.

--- a/review-enrichment/src/analyzers/redos.ts
+++ b/review-enrichment/src/analyzers/redos.ts
@@ -4,11 +4,12 @@
 // Pure compute, no network, no external detector (structural-only → high precision: linear shapes like `(abc)+`
 // are NOT flagged). Line-cited via hunk headers, mirroring the actions-pin analyzer.
 import type { EnrichRequest, RedosFinding } from "../types.js";
+import { DEFAULT_MAX_FINDINGS, DEFAULT_MAX_LINE_CHARS } from "./limits.js";
 
 // Every loop runs over an attacker-controlled patch, so each is bounded.
-const MAX_FINDINGS = 25; // keep the brief bounded
+const MAX_FINDINGS = DEFAULT_MAX_FINDINGS;
 const MAX_PATTERN_CHARS = 1000; // ignore absurdly long literals (a hand-written regex is never this long)
-const MAX_LINE_CHARS = 2000; // skip extraction on pathologically long lines (defensive)
+const MAX_LINE_CHARS = DEFAULT_MAX_LINE_CHARS;
 const REPORT_CHARS = 80; // truncate the reported pattern so the brief stays readable
 
 type RedosScanLimits = {

--- a/review-enrichment/src/analyzers/registry.ts
+++ b/review-enrichment/src/analyzers/registry.ts
@@ -32,10 +32,10 @@ import { scanLooseRanges } from "./loose-range.js";
 import { scanMagicNumbers } from "./magic-number.js";
 import { scanConflictMarkers } from "./conflict-marker.js";
 import { scanDebugLeftover } from "./debug-leftover.js";
-import { scanDeepNesting } from "./deep-nesting.js";
+import { scanDeepNesting, DEFAULT_MAX_DEPTH } from "./deep-nesting.js";
 import { scanI18nRegression } from "./i18n-regression.js";
 import { scanErrorSwallow } from "./error-swallow.js";
-import { scanComplexity } from "./complexity.js";
+import { scanComplexity, DEFAULT_MAX_COMPLEXITY } from "./complexity.js";
 import { scanFloatingPromise } from "./floating-promise.js";
 import { scanSizeSmell } from "./size-smell.js";
 import { scanA11yRegression } from "./a11y-regression.js";
@@ -60,6 +60,7 @@ import type {
   AnalyzerRegistry,
   AnyAnalyzerDescriptor,
 } from "./types.js";
+import { DEFAULT_MAX_FINDINGS, DEFAULT_MAX_LINE_CHARS } from "./limits.js";
 
 function descriptor<Name extends AnalyzerName>(
   definition: AnalyzerDescriptor<Name>,
@@ -76,7 +77,7 @@ export const ANALYZER_DESCRIPTORS = [
     cost: "local",
     defaultEnabled: true,
     requires: ["files"],
-    limits: { maxFindings: 25, maxManifestFiles: 20, maxPatchLinesPerFile: 500 },
+    limits: { maxFindings: DEFAULT_MAX_FINDINGS, maxManifestFiles: 20, maxPatchLinesPerFile: 500 },
     docs: {
       summary:
         "Summarizes direct dependency add/remove/version-change deltas in changed manifest patches — informational, not a CVE scan.",
@@ -196,7 +197,7 @@ export const ANALYZER_DESCRIPTORS = [
     cost: "local",
     defaultEnabled: true,
     requires: ["files"],
-    limits: { maxFindings: 25, maxLineChars: 2000, maxHostChars: 40 },
+    limits: { maxFindings: DEFAULT_MAX_FINDINGS, maxLineChars: DEFAULT_MAX_LINE_CHARS, maxHostChars: 40 },
     docs: {
       summary:
         "Flags absolute HTTP(S) URLs and raw IP:port endpoints newly added in non-test, non-config source.",
@@ -261,7 +262,7 @@ export const ANALYZER_DESCRIPTORS = [
     cost: "local",
     defaultEnabled: true,
     requires: ["files"],
-    limits: { maxFindings: 25, maxPatternChars: 1000, maxLineChars: 2000 },
+    limits: { maxFindings: DEFAULT_MAX_FINDINGS, maxPatternChars: 1000, maxLineChars: DEFAULT_MAX_LINE_CHARS },
     docs: {
       summary: "Finds newly introduced regex shapes that can catastrophically backtrack.",
       looksAt: "Regex literals and RegExp constructor string arguments in added lines.",
@@ -324,7 +325,7 @@ export const ANALYZER_DESCRIPTORS = [
     cost: "local",
     defaultEnabled: true,
     requires: ["files"],
-    limits: { maxFindings: 25, maxLineChars: 2000 },
+    limits: { maxFindings: DEFAULT_MAX_FINDINGS, maxLineChars: DEFAULT_MAX_LINE_CHARS },
     docs: {
       summary: "Flags added code that writes sensitive values to logs or stdout.",
       looksAt: "Added lines that call console, logger, process.stdout, or process.stderr sinks.",
@@ -406,7 +407,7 @@ export const ANALYZER_DESCRIPTORS = [
     cost: "local",
     defaultEnabled: true,
     requires: ["files"],
-    limits: { maxFindings: 25, maxLineChars: 2000 },
+    limits: { maxFindings: DEFAULT_MAX_FINDINGS, maxLineChars: DEFAULT_MAX_LINE_CHARS },
     docs: {
       summary: "Flags risky IaC/config changes such as public buckets or insecure CORS.",
       looksAt: "Added lines in Docker, Terraform, YAML, JSON, and similar config files.",
@@ -500,7 +501,7 @@ export const ANALYZER_DESCRIPTORS = [
       minRun: 8,
       maxCandidates: 40,
       maxFetches: 30,
-      maxFindings: 25,
+      maxFindings: DEFAULT_MAX_FINDINGS,
       maxFileBytes: 500_000,
     },
     docs: {
@@ -717,7 +718,7 @@ export const ANALYZER_DESCRIPTORS = [
     cost: "github-light",
     defaultEnabled: true,
     requires: ["github-token"],
-    limits: { maxCommits: 100, maxFindings: 25 },
+    limits: { maxCommits: 100, maxFindings: DEFAULT_MAX_FINDINGS },
     docs: {
       summary:
         "Flags commit-history hygiene issues: a merge commit pulled into the PR's own history, a commit left with git's fixup!/squash! autosquash marker, and a commit carrying a Co-authored-by trailer.",
@@ -807,7 +808,7 @@ export const ANALYZER_DESCRIPTORS = [
     cost: "local",
     defaultEnabled: true,
     requires: ["files"],
-    limits: { maxFindings: 20, maxLineChars: 2000 },
+    limits: { maxFindings: 20, maxLineChars: DEFAULT_MAX_LINE_CHARS },
     docs: {
       summary:
         "Flags risky schema operations in added migration SQL: drops, renames, non-nullable columns without a default, and blocking table rewrites.",
@@ -848,7 +849,7 @@ export const ANALYZER_DESCRIPTORS = [
     cost: "local",
     defaultEnabled: true,
     requires: ["files"],
-    limits: { maxFindings: 20, maxLineChars: 2000 },
+    limits: { maxFindings: 20, maxLineChars: DEFAULT_MAX_LINE_CHARS },
     docs: {
       summary:
         "Flags newly-added npm dependency specifiers that use dangerously loose ranges instead of a pinned/caret/tilde range.",
@@ -889,7 +890,7 @@ export const ANALYZER_DESCRIPTORS = [
     cost: "local",
     defaultEnabled: true,
     requires: ["files"],
-    limits: { maxFindings: 25, maxLineChars: 2000 },
+    limits: { maxFindings: DEFAULT_MAX_FINDINGS, maxLineChars: DEFAULT_MAX_LINE_CHARS },
     docs: {
       summary:
         "Flags non-inclusive terms newly added in identifiers or comments (whitelist/blacklist, master/slave) and suggests the neutral replacement.",
@@ -918,7 +919,7 @@ export const ANALYZER_DESCRIPTORS = [
     cost: "local",
     defaultEnabled: true,
     requires: ["files"],
-    limits: { maxFindings: 25, maxLineChars: 2000, maxNoteChars: 120 },
+    limits: { maxFindings: DEFAULT_MAX_FINDINGS, maxLineChars: DEFAULT_MAX_LINE_CHARS, maxNoteChars: 120 },
     docs: {
       summary:
         "Surfaces TODO/FIXME/HACK/XXX markers a PR adds in comments, so a reviewer sees the change is shipping known-incomplete work.",
@@ -948,7 +949,7 @@ export const ANALYZER_DESCRIPTORS = [
     cost: "local",
     defaultEnabled: true,
     requires: ["files"],
-    limits: { maxFindings: 25, maxLineChars: 2000 },
+    limits: { maxFindings: DEFAULT_MAX_FINDINGS, maxLineChars: DEFAULT_MAX_LINE_CHARS },
     docs: {
       summary:
         "Flags newly-added non-trivial numeric literals in non-test source where a named constant would clarify intent.",
@@ -978,7 +979,7 @@ export const ANALYZER_DESCRIPTORS = [
     cost: "local",
     defaultEnabled: true,
     requires: ["files"],
-    limits: { maxFindings: 25 },
+    limits: { maxFindings: DEFAULT_MAX_FINDINGS },
     docs: {
       summary:
         "Flags leftover VCS conflict markers (`<<<<<<<`, `|||||||`, `=======`, `>>>>>>>`) accidentally committed in added lines.",
@@ -1007,7 +1008,7 @@ export const ANALYZER_DESCRIPTORS = [
     cost: "local",
     defaultEnabled: true,
     requires: ["files"],
-    limits: { maxFindings: 25, maxLineChars: 2000 },
+    limits: { maxFindings: DEFAULT_MAX_FINDINGS, maxLineChars: DEFAULT_MAX_LINE_CHARS },
     docs: {
       summary:
         "Flags debugging leftovers a PR adds in non-test source — `debugger;`, bare console sinks, or `print()` calls.",
@@ -1036,7 +1037,7 @@ export const ANALYZER_DESCRIPTORS = [
     cost: "local",
     defaultEnabled: true,
     requires: ["files"],
-    limits: { maxFindings: 25, maxFileLines: 400, maxFunctionLines: 60, maxLineChars: 2000 },
+    limits: { maxFindings: DEFAULT_MAX_FINDINGS, maxFileLines: 400, maxFunctionLines: 60, maxLineChars: DEFAULT_MAX_LINE_CHARS },
     docs: {
       summary:
         "Flags maintainability size smells from patch structure: an estimated resulting file length or an added function body span that exceeds configured thresholds.",
@@ -1068,7 +1069,7 @@ export const ANALYZER_DESCRIPTORS = [
     cost: "local",
     defaultEnabled: true,
     requires: ["files"],
-    limits: { maxFindings: 25, maxLineChars: 2000, maxCallChars: 40 },
+    limits: { maxFindings: DEFAULT_MAX_FINDINGS, maxLineChars: DEFAULT_MAX_LINE_CHARS, maxCallChars: 40 },
     docs: {
       summary:
         "Flags newly-added promise-shaped calls whose returned promise is neither awaited, returned, voided, nor same-line .then/.catch-chained.",
@@ -1097,7 +1098,7 @@ export const ANALYZER_DESCRIPTORS = [
     cost: "local",
     defaultEnabled: true,
     requires: ["files"],
-    limits: { maxFindings: 25, maxDepth: 4, maxLineChars: 2000 },
+    limits: { maxFindings: DEFAULT_MAX_FINDINGS, maxDepth: DEFAULT_MAX_DEPTH, maxLineChars: DEFAULT_MAX_LINE_CHARS },
     docs: {
       summary:
         "Flags newly-added control-flow blocks whose nesting depth exceeds a threshold inside a contiguous run of added lines.",
@@ -1126,7 +1127,7 @@ export const ANALYZER_DESCRIPTORS = [
     cost: "local",
     defaultEnabled: true,
     requires: ["files"],
-    limits: { maxFindings: 25, maxLineChars: 2000 },
+    limits: { maxFindings: DEFAULT_MAX_FINDINGS, maxLineChars: DEFAULT_MAX_LINE_CHARS },
     docs: {
       summary:
         "Flags newly-added catch/except blocks (and Go if-err checks) that swallow or mishandle the error — empty body, unused binding, a bare `return null`/`nil`, or a Python bare `except:` naming no exception type.",
@@ -1165,7 +1166,7 @@ export const ANALYZER_DESCRIPTORS = [
     cost: "local",
     defaultEnabled: true,
     requires: ["files"],
-    limits: { maxFindings: 25, maxComplexity: 10, maxLineChars: 2000 },
+    limits: { maxFindings: DEFAULT_MAX_FINDINGS, maxComplexity: DEFAULT_MAX_COMPLEXITY, maxLineChars: DEFAULT_MAX_LINE_CHARS },
     docs: {
       summary:
         "Flags a newly-added function whose approximate cyclomatic complexity (branch/loop/logical-operator density, computed on the diff-visible lines) exceeds a threshold.",
@@ -1195,7 +1196,7 @@ export const ANALYZER_DESCRIPTORS = [
     cost: "local",
     defaultEnabled: true,
     requires: ["files"],
-    limits: { maxFindings: 25, maxLineChars: 2000 },
+    limits: { maxFindings: DEFAULT_MAX_FINDINGS, maxLineChars: DEFAULT_MAX_LINE_CHARS },
     docs: {
       summary:
         "Counts and locates explicit `any` annotations, `<any>` assertions, and `as any` casts newly introduced in TypeScript diffs.",
@@ -1224,7 +1225,7 @@ export const ANALYZER_DESCRIPTORS = [
     cost: "local",
     defaultEnabled: true,
     requires: ["files"],
-    limits: { maxFindings: 25, maxLineChars: 2000 },
+    limits: { maxFindings: DEFAULT_MAX_FINDINGS, maxLineChars: DEFAULT_MAX_LINE_CHARS },
     docs: {
       summary:
         "Flags common accessibility regressions in newly added JSX/HTML markup lines.",
@@ -1255,7 +1256,7 @@ export const ANALYZER_DESCRIPTORS = [
     cost: "local",
     defaultEnabled: true,
     requires: ["files"],
-    limits: { maxFindings: 25, maxLineChars: 2000 },
+    limits: { maxFindings: DEFAULT_MAX_FINDINGS, maxLineChars: DEFAULT_MAX_LINE_CHARS },
     docs: {
       summary:
         "When the diff shows a translation convention, flags newly-added user-facing JSX text or label/title props that bypass it.",
@@ -1282,7 +1283,7 @@ export const ANALYZER_DESCRIPTORS = [
     cost: "github-light",
     defaultEnabled: true,
     requires: ["files", "github-token", "head-sha"],
-    limits: { maxSymbols: 10, maxSearches: 10, maxFindings: 25 },
+    limits: { maxSymbols: 10, maxSearches: 10, maxFindings: DEFAULT_MAX_FINDINGS },
     docs: {
       summary:
         "Flags exports newly added by the PR that have zero non-declaration references anywhere in the repo.",
@@ -1314,7 +1315,7 @@ export const ANALYZER_DESCRIPTORS = [
     cost: "github-light",
     defaultEnabled: true,
     requires: ["files", "github-token", "head-sha"],
-    limits: { maxFiles: 10, maxFetches: 10, maxFindings: 25 },
+    limits: { maxFiles: 10, maxFetches: 10, maxFindings: DEFAULT_MAX_FINDINGS },
     docs: {
       summary:
         "Flags when a PR adds a new enum member or string-literal union variant but an exhaustive switch still omits it.",
@@ -1353,7 +1354,7 @@ export const ANALYZER_DESCRIPTORS = [
       maxCommitsPerFile: 5,
       maxCheckRunFetches: 12,
       windowDays: 30,
-      maxFindings: 25,
+      maxFindings: DEFAULT_MAX_FINDINGS,
     },
     docs: {
       summary:
@@ -1386,7 +1387,7 @@ export const ANALYZER_DESCRIPTORS = [
     cost: "github-light",
     defaultEnabled: true,
     requires: ["github-token"],
-    limits: { maxCommits: 100, maxFindings: 25 },
+    limits: { maxCommits: 100, maxFindings: DEFAULT_MAX_FINDINGS },
     docs: {
       summary:
         "Lints the PR's commit subjects against the Conventional Commits spec and flags non-conforming subjects (bad/absent type, over-long, or empty).",
@@ -1428,7 +1429,7 @@ export const ANALYZER_DESCRIPTORS = [
     cost: "local",
     defaultEnabled: true,
     requires: ["files"],
-    limits: { maxEntrypoints: 25, maxFindings: 25 },
+    limits: { maxEntrypoints: 25, maxFindings: DEFAULT_MAX_FINDINGS },
     docs: {
       summary:
         "Flags an exported symbol a PR removes or renames in a package public entrypoint — a semver-major break for downstream consumers shipped without a major version bump.",
@@ -1461,7 +1462,7 @@ export const ANALYZER_DESCRIPTORS = [
     cost: "local",
     defaultEnabled: true,
     requires: ["files"],
-    limits: { maxManifestFiles: 20, maxPatchLinesPerFile: 500, maxFindings: 25 },
+    limits: { maxManifestFiles: 20, maxPatchLinesPerFile: 500, maxFindings: DEFAULT_MAX_FINDINGS },
     docs: {
       summary:
         "Flags a direct dependency a PR newly adds or upgrades that is an officially deprecated or unmaintained package with a maintained successor — an adoption risk the review brief should surface.",
@@ -1501,7 +1502,7 @@ export const ANALYZER_DESCRIPTORS = [
       maxFilesProbed: 5,
       commitsPerFile: 15,
       maxRevertLookups: 10,
-      maxFindings: 25,
+      maxFindings: DEFAULT_MAX_FINDINGS,
     },
     docs: {
       summary:
@@ -1589,7 +1590,7 @@ export const ANALYZER_DESCRIPTORS = [
       maxSearches: 6,
       maxFileFetches: 12,
       maxCallersPerFinding: 5,
-      maxFindings: 25,
+      maxFindings: DEFAULT_MAX_FINDINGS,
     },
     docs: {
       summary:

--- a/review-enrichment/src/analyzers/revert-recurrence.ts
+++ b/review-enrichment/src/analyzers/revert-recurrence.ts
@@ -14,13 +14,14 @@ import type {
 import type { AnalysisContext } from "../analysis-context.js";
 import { boundedFetchJson } from "../external-fetch.js";
 import { isHistoryUninformativePath } from "./history-path.js";
+import { DEFAULT_MAX_FINDINGS } from "./limits.js";
 
 const GITHUB_API = "https://api.github.com";
 const SLUG_RE = /^[A-Za-z0-9._-]+$/;
 const MAX_FILES_PROBED = 5; // bound the per-file commit-history fan-out, matching the other history-class analyzers
 const COMMITS_PER_FILE = 15; // recent commits to inspect per probed file when looking for a revert
 const MAX_REVERT_LOOKUPS = 10; // global cap on revert-commit detail fetches across all probed files
-const MAX_FINDINGS = 25;
+const MAX_FINDINGS = DEFAULT_MAX_FINDINGS;
 // GitHub's auto-generated revert commit has a `Revert "<original> (#N)"` subject; a hand-written revert body
 // carries the `This reverts commit <sha>` trailer. Either shape confirms a revert without diff-classifying a patch.
 const REVERT_SUBJECT_RE = /^revert\b/i;

--- a/review-enrichment/src/analyzers/secret-log.ts
+++ b/review-enrichment/src/analyzers/secret-log.ts
@@ -5,9 +5,10 @@
 // `console.log("password reset")` is NOT flagged — a hit requires a sensitive name used as CODE (property access,
 // a `${…}` interpolation, or a dumped request object). Line-cited via hunk headers, mirroring the other analyzers.
 import type { EnrichRequest, SecretLogFinding } from "../types.js";
+import { DEFAULT_MAX_FINDINGS, DEFAULT_MAX_LINE_CHARS } from "./limits.js";
 
-const MAX_FINDINGS = 25; // keep the brief bounded
-const MAX_LINE_CHARS = 2000; // skip pathologically long lines (defensive)
+const MAX_FINDINGS = DEFAULT_MAX_FINDINGS;
+const MAX_LINE_CHARS = DEFAULT_MAX_LINE_CHARS;
 
 // All matchers below are FLAT alternations (no group is itself quantified), so each is linear-time — the analyzer
 // can never be the DoS class it sits beside (#1503). Logging / stdout sinks. The console branch is kept separate

--- a/review-enrichment/src/analyzers/size-smell.ts
+++ b/review-enrichment/src/analyzers/size-smell.ts
@@ -4,11 +4,12 @@
 import type { EnrichRequest, SizeSmellFinding } from "../types.js";
 import { codeOnly } from "./secret-log.js";
 import { isTestPath } from "./test-ratio.js";
+import { DEFAULT_MAX_FINDINGS, DEFAULT_MAX_LINE_CHARS } from "./limits.js";
 
 export const DEFAULT_MAX_FILE_LINES = 400;
 export const DEFAULT_MAX_FUNCTION_LINES = 60;
-const MAX_FINDINGS = 25;
-const MAX_LINE_CHARS = 2000;
+const MAX_FINDINGS = DEFAULT_MAX_FINDINGS;
+const MAX_LINE_CHARS = DEFAULT_MAX_LINE_CHARS;
 
 const HUNK_RE = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/;
 

--- a/review-enrichment/src/analyzers/terminology.ts
+++ b/review-enrichment/src/analyzers/terminology.ts
@@ -6,9 +6,10 @@
 // `master` token (in `master`, `master_node`, `masterNode`, or a comment word) does. URLs are blanked first so a
 // link path segment cannot trip a finding. Line-cited via hunk headers, mirroring the sibling local analyzers.
 import type { EnrichRequest, TerminologyFinding } from "../types.js";
+import { DEFAULT_MAX_FINDINGS, DEFAULT_MAX_LINE_CHARS } from "./limits.js";
 
-const MAX_FINDINGS = 25;
-const MAX_LINE_CHARS = 2000;
+const MAX_FINDINGS = DEFAULT_MAX_FINDINGS;
+const MAX_LINE_CHARS = DEFAULT_MAX_LINE_CHARS;
 
 // A bounded, in-file term → neutral-suggestion table (self-host operators can read the whole policy here). Keys
 // are the lowercased TOKENS the tokenizer produces. A key matches whenever it appears as a WHOLE token after

--- a/review-enrichment/src/analyzers/todo-marker.ts
+++ b/review-enrichment/src/analyzers/todo-marker.ts
@@ -10,9 +10,10 @@
 // anchors on the leading `*`. Line-cited via hunk headers, mirroring the sibling local analyzers.
 import type { EnrichRequest, TodoMarkerFinding } from "../types.js";
 import { codeOnly } from "./secret-log.js";
+import { DEFAULT_MAX_FINDINGS, DEFAULT_MAX_LINE_CHARS } from "./limits.js";
 
-const MAX_FINDINGS = 25;
-const MAX_LINE_CHARS = 2000;
+const MAX_FINDINGS = DEFAULT_MAX_FINDINGS;
+const MAX_LINE_CHARS = DEFAULT_MAX_LINE_CHARS;
 const MAX_NOTE_CHARS = 120;
 
 // A comment lead-in followed by an UPPERCASE tag as a whole word, then an optional separator and the note.

--- a/review-enrichment/src/analyzers/unsafe-any.ts
+++ b/review-enrichment/src/analyzers/unsafe-any.ts
@@ -4,9 +4,10 @@
 import type { EnrichRequest, UnsafeAnyFinding } from "../types.js";
 import { codeOnly } from "./secret-log.js";
 import { isTestPath } from "./test-ratio.js";
+import { DEFAULT_MAX_FINDINGS, DEFAULT_MAX_LINE_CHARS } from "./limits.js";
 
-const MAX_FINDINGS = 25;
-const MAX_LINE_CHARS = 2000;
+const MAX_FINDINGS = DEFAULT_MAX_FINDINGS;
+const MAX_LINE_CHARS = DEFAULT_MAX_LINE_CHARS;
 
 const TS_PATH_RE = /\.(?:tsx?|mts|cts)$/i;
 

--- a/review-enrichment/src/analyzers/unused-export.ts
+++ b/review-enrichment/src/analyzers/unused-export.ts
@@ -14,6 +14,7 @@ import type { AnalysisContext } from "../analysis-context.js";
 import { boundedFetchJson } from "../external-fetch.js";
 import { exportedSymbols, parseAddedExports } from "./undocumented-export.js";
 import { isTestPath } from "./test-ratio.js";
+import { DEFAULT_MAX_FINDINGS } from "./limits.js";
 
 const GITHUB_API = "https://api.github.com";
 const GITHUB_API_VERSION = "2022-11-28";
@@ -21,7 +22,7 @@ const SLUG_RE = /^[A-Za-z0-9._-]+$/;
 const MAX_SYMBOLS = 10;
 const MAX_SEARCHES = 10;
 const MAX_FILE_FETCHES = 10;
-const MAX_FINDINGS = 25;
+const MAX_FINDINGS = DEFAULT_MAX_FINDINGS;
 const MIN_SYMBOL_LEN = 3;
 const MAX_FETCH_BYTES = 1_000_000;
 const MAX_SEARCH_JSON_BYTES = 256 * 1024;


### PR DESCRIPTION
## Summary

- The gittensory-orb review on #4155 (#1477, merged) flagged as non-blocking nits: "The magic numbers 25/2000/10 are duplicated as literals across registry.ts, rees-analyzers.ts, and analyzer-metadata.json ... worth a shared constant given how many copies now exist" and "this PR is the third analyzer to duplicate the same numbers verbatim." Tracing the codebase found it's much broader than "third" — **28** analyzer files repeat `const MAX_FINDINGS = 25;` verbatim and **18** repeat `const MAX_LINE_CHARS = 2000;`, plus `registry.ts`'s descriptors repeat the same two literals 28 and 18 times respectively.
- Added `review-enrichment/src/analyzers/limits.ts` exporting `DEFAULT_MAX_FINDINGS = 25` / `DEFAULT_MAX_LINE_CHARS = 2000`. Every file with the plain default now does `const MAX_FINDINGS = DEFAULT_MAX_FINDINGS;` (imported) instead of redeclaring the literal — zero usage-site churn, since the local identifier name is unchanged. Analyzer-specific overrides (asset-weight's 50, heavy-dependency's 15, migration-safety/loose-range's 20, undocumented-export/provenance's 30) are deliberately **untouched** — those are real per-analyzer tuning, not a duplicate worth centralizing.
- `registry.ts`'s 50 descriptor `limits: {...}` objects: replaced the exact `maxFindings: 25` (28×) and `maxLineChars: 2000` (18×) occurrences with the imported constants, via precise word-boundary matching that never touched a genuinely different value (`15`/`20`/`30`/`50`).
- `maxDepth: 4` and `maxComplexity: 10` in `registry.ts` were *also* duplicating a literal that each analyzer already exports as its own named constant (`DEFAULT_MAX_DEPTH` in `deep-nesting.ts`, `DEFAULT_MAX_COMPLEXITY` in `complexity.ts`) — imported those instead of repeating the numbers a second time.
- Regenerated `review-enrichment/analyzer-metadata.json` + `apps/gittensory-ui/src/lib/rees-analyzers.ts` + the `.env.example` generated block via `npm run rees:metadata` — confirmed byte-identical (only the *source's* use of named constants changed, not the underlying values, so nothing downstream drifted).

Separately, the same review noted `complexity.ts` and `error-swallow.ts` "themselves trip the repo's own deep-nesting threshold (depth 5 vs. 4)." Fixed both:

- `complexity.ts`: extracted the innermost `if (pending) {...} else {...}` block (continue-tracking vs. start-tracking a function) into a new top-level `advancePendingFunction` helper, called from a single flat `if` in the scan loop instead of a nested if/else.
- `error-swallow.ts`: same shape, split into two helpers (`advancePendingCatch` for the continue-tracking branch, `tryStartPendingCatch` for the immediate-finding-or-start-tracking branch), both returning a uniform `{ pending, finding, findingLine }` result so the scan loop's own body collapses to a ternary + one flat `if`.
- Verified empirically, not just by inspection: fed each file's actual diff (pre- and post-refactor) through the sibling `deep-nesting.ts` analyzer's own exported `scanPatchForDeepNesting` function. The **original** diff (from merged PR #4155) reports `{"depth":5,"threshold":4}` for both files — reproducing the exact finding the review described. The **refactored** diff reports zero findings for both.
- Both extractions are pure refactors with no behavior change — verified by running the full pre-existing test suite (unchanged assertions) before and after: 45/45 tests across `complexity.test.ts`/`error-swallow.test.ts`/`deep-nesting.test.ts` pass identically.

Closes #4163.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #4163`).

## Validation

- [x] `git diff --check`
- [x] `npm run rees:test` (the exact root-level command CI runs: `npm ci --prefix review-enrichment` + `npm --prefix review-enrichment test`, which itself chains build + sourcemap validation + `generate-analyzer-metadata.mjs --check` + the full node test suite) — 1216/1216 tests passing, metadata check clean (no drift after regeneration).
- [x] `npm --prefix review-enrichment run build` (`tsc -p tsconfig.json`) — clean, both before and after the rebase onto latest `main`.
- [x] Empirical nesting-depth verification (see Summary above) — both files' diffs confirmed to trip depth 5 before this change and produce zero findings after, using the repo's own `scanPatchForDeepNesting`.
- [x] Not Codecov-measured: `review-enrichment/**` is outside `src/**`/`packages/**`, so no `codecov/patch` obligation — confirmed via `.claude/skills/contributing-to-gittensory/reference.md`.
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities (review-enrichment's own `npm ci` reported none; no new dependency was added anywhere in this PR).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no such changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — `review-enrichment` is a standalone service with its own test suite; no `src/api` or MCP surface touched.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — `apps/gittensory-ui/src/lib/rees-analyzers.ts` is a generated data file, regenerated byte-identical, not hand-edited.)
- [x] Visible UI changes include a `UI Evidence` section below with screenshots. (N/A — no visible UI surface changed.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — this PR only touches `review-enrichment/src/analyzers/**` plus the three files its own metadata generator regenerates (confirmed byte-identical).