### PR TITLE
chore(ui): bump MCP known-latest version pin to 0.7.0

### DIFF
--- a/apps/gittensory-ui/src/lib/mcp-package.ts
+++ b/apps/gittensory-ui/src/lib/mcp-package.ts
@@ -8,7 +8,7 @@ export const MCP_PACKAGE_REGISTRY_URL = `https://registry.npmjs.org/${MCP_PACKAG
 export const MCP_PACKAGE_NPM_URL = `https://www.npmjs.com/package/${MCP_PACKAGE_NAME}`;
 // Tracks the latest PUBLISHED release: ui:version-audit requires this to equal npm dist-tags.latest, so it is
 // bumped to a new version only AFTER that version publishes (never ahead of npm).
-export const MCP_PACKAGE_KNOWN_LATEST_VERSION = "0.6.0";
+export const MCP_PACKAGE_KNOWN_LATEST_VERSION = "0.7.0";
 export const MCP_MINIMUM_SUPPORTED_VERSION = "0.5.0";
 
 export type NpmPackageMetadata = {


### PR DESCRIPTION
## Summary
\`@jsonbored/gittensory-mcp\` v0.7.0 is now published (npm \`dist-tags.latest\` confirmed). This pin lags one release by design — \`ui:version-audit\` hard-requires it to equal npm's actual latest, and it must never point ahead of what's really published — so it only moves now that the publish is done.

## Test plan
- [x] \`npm run ui:version-audit\` — "MCP UI version copy ok: npm latest 0.7.0, scanned 3 target(s)"
- [x] \`npm run ui:typecheck\` — clean