### PR TITLE
feat(observability): add issue-activity stat panels to the maintainer PR dashboard

### DIFF
--- a/grafana/dashboards/maintainer-reviews.json
+++ b/grafana/dashboards/maintainer-reviews.json
@@ -4,7 +4,7 @@
   "tags": ["gittensory", "maintainer"],
   "timezone": "browser",
   "schemaVersion": 39,
-  "version": 5,
+  "version": 6,
   "editable": false,
   "graphTooltip": 1,
   "refresh": "1m",
@@ -84,11 +84,51 @@
       "targets": [{ "datasource": { "type": "frser-sqlite-datasource", "uid": "gittensory-db" }, "refId": "A", "queryType": "table", "queryText": "SELECT count(*) AS ignored FROM review_targets WHERE (status='ignored' OR verdict='ignore') AND unixepoch(updated_at) >= ${__from:date:seconds} AND unixepoch(updated_at) < ${__to:date:seconds}", "rawQueryText": "SELECT count(*) AS ignored FROM review_targets WHERE (status='ignored' OR verdict='ignore') AND unixepoch(updated_at) >= ${__from:date:seconds} AND unixepoch(updated_at) < ${__to:date:seconds}" }]
     },
     {
+      "type": "row",
+      "id": 11,
+      "title": "Issue activity",
+      "collapsed": false,
+      "gridPos": { "h": 1, "w": 24, "x": 0, "y": 5 }
+    },
+    {
+      "type": "stat",
+      "id": 12,
+      "title": "Issues opened",
+      "description": "Live GitHub-API count via the grafana-github-datasource (org:JSONbored is:issue), not the local webhook-observed issues table -- upstream-accurate regardless of local sync gaps, at the cost of a different consistency model from the review_targets-backed PR panels above. See #3716 for the tradeoff.",
+      "datasource": { "type": "grafana-github-datasource", "uid": "github" },
+      "gridPos": { "h": 4, "w": 8, "x": 0, "y": 6 },
+      "fieldConfig": { "defaults": { "color": { "mode": "fixed", "fixedColor": "blue" } } },
+      "options": { "colorMode": "value", "graphMode": "none", "justifyMode": "center", "reduceOptions": { "calcs": ["count"], "fields": "/^number$/" } },
+      "targets": [{ "refId": "A", "queryType": "Issues", "owner": "", "repository": "", "options": { "query": "org:JSONbored is:issue", "timeField": 1 } }]
+    },
+    {
+      "type": "stat",
+      "id": 13,
+      "title": "Issues closed",
+      "description": "Live GitHub-API count via the grafana-github-datasource (org:JSONbored is:issue is:closed), not the local webhook-observed issues table. See #3716 for the tradeoff.",
+      "datasource": { "type": "grafana-github-datasource", "uid": "github" },
+      "gridPos": { "h": 4, "w": 8, "x": 8, "y": 6 },
+      "fieldConfig": { "defaults": { "color": { "mode": "fixed", "fixedColor": "red" } } },
+      "options": { "colorMode": "value", "graphMode": "none", "justifyMode": "center", "reduceOptions": { "calcs": ["count"], "fields": "/^number$/" } },
+      "targets": [{ "refId": "A", "queryType": "Issues", "owner": "", "repository": "", "options": { "query": "org:JSONbored is:issue is:closed", "timeField": 0 } }]
+    },
+    {
+      "type": "stat",
+      "id": 14,
+      "title": "Issues open",
+      "description": "Current open-issue backlog (org:JSONbored is:issue is:open) -- a state snapshot, not filtered by the dashboard time window, mirroring github-prs.json's own 'Open issues' panel.",
+      "datasource": { "type": "grafana-github-datasource", "uid": "github" },
+      "gridPos": { "h": 4, "w": 8, "x": 16, "y": 6 },
+      "fieldConfig": { "defaults": { "color": { "mode": "fixed", "fixedColor": "orange" } } },
+      "options": { "colorMode": "value", "graphMode": "none", "justifyMode": "center", "reduceOptions": { "calcs": ["count"], "fields": "/^number$/" } },
+      "targets": [{ "refId": "A", "queryType": "Issues", "owner": "", "repository": "", "options": { "query": "org:JSONbored is:issue is:open" } }]
+    },
+    {
       "type": "table",
       "id": 8,
       "title": "Pull requests (latest 1000)",
       "datasource": { "type": "frser-sqlite-datasource", "uid": "gittensory-db" },
-      "gridPos": { "h": 16, "w": 24, "x": 0, "y": 5 },
+      "gridPos": { "h": 16, "w": 24, "x": 0, "y": 10 },
       "fieldConfig": {
         "defaults": { "custom": { "align": "auto", "cellOptions": { "type": "auto" }, "filterable": true, "inspect": false } },
         "overrides": [
@@ -122,7 +162,7 @@
       "id": 9,
       "title": "Reviews per day",
       "datasource": { "type": "frser-sqlite-datasource", "uid": "gittensory-db" },
-      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 21 },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 26 },
       "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "custom": { "drawStyle": "bars", "fillOpacity": 60, "lineWidth": 1, "showPoints": "never", "stacking": { "mode": "none" } }, "unit": "short" }, "overrides": [] },
       "options": { "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": false }, "tooltip": { "mode": "single", "sort": "none" } },
       "targets": [{ "datasource": { "type": "frser-sqlite-datasource", "uid": "gittensory-db" }, "refId": "A", "queryType": "time series", "timeColumns": ["time"], "queryText": "SELECT date(updated_at) AS time, count(*) AS reviews FROM review_targets WHERE unixepoch(updated_at) >= ${__from:date:seconds} AND unixepoch(updated_at) < ${__to:date:seconds} GROUP BY date(updated_at) ORDER BY time", "rawQueryText": "SELECT date(updated_at) AS time, count(*) AS reviews FROM review_targets WHERE unixepoch(updated_at) >= ${__from:date:seconds} AND unixepoch(updated_at) < ${__to:date:seconds} GROUP BY date(updated_at) ORDER BY time" }]
@@ -132,7 +172,7 @@
       "id": 10,
       "title": "By verdict",
       "datasource": { "type": "frser-sqlite-datasource", "uid": "gittensory-db" },
-      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 21 },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 26 },
       "fieldConfig": { "defaults": { "color": { "mode": "palette-classic" }, "unit": "short" }, "overrides": [] },
       "options": { "legend": { "displayMode": "list", "placement": "right", "showLegend": true, "values": ["value", "percent"] }, "pieType": "donut", "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": true }, "tooltip": { "mode": "single", "sort": "none" } },
       "targets": [{ "datasource": { "type": "frser-sqlite-datasource", "uid": "gittensory-db" }, "refId": "A", "queryType": "table", "queryText": "SELECT verdict, count(*) AS c FROM review_targets WHERE verdict IS NOT NULL AND unixepoch(updated_at) >= ${__from:date:seconds} AND unixepoch(updated_at) < ${__to:date:seconds} GROUP BY verdict ORDER BY c DESC", "rawQueryText": "SELECT verdict, count(*) AS c FROM review_targets WHERE verdict IS NOT NULL AND unixepoch(updated_at) >= ${__from:date:seconds} AND unixepoch(updated_at) < ${__to:date:seconds} GROUP BY verdict ORDER BY c DESC" }]

--- a/test/unit/selfhost-grafana-dashboard.test.ts
+++ b/test/unit/selfhost-grafana-dashboard.test.ts
@@ -11,6 +11,8 @@ type DashboardTarget = {
   rawQueryText?: string;
   format?: string;
   instant?: boolean;
+  queryType?: string;
+  options?: { query?: string; timeField?: number };
 };
 
 type DashboardPanel = {
@@ -18,6 +20,7 @@ type DashboardPanel = {
   title?: string;
   description?: string;
   targets?: DashboardTarget[];
+  datasource?: { type?: string; uid?: string };
 };
 
 type Dashboard = {
@@ -269,6 +272,33 @@ describe("maintainer Reviews & PRs Grafana dashboard", () => {
       expect(panel?.description?.length ?? 0).toBeGreaterThan(0);
       expect(panel?.description).toContain("window");
     }
+  });
+
+  it("adds GitHub-API-backed issue-activity stat panels alongside the review_targets PR panels (#3716)", () => {
+    const dashboard = readDashboard();
+    const panelsById = new Map(dashboard.panels.map((panel) => [panel.id, panel]));
+
+    for (const [id, title, expectedQuery] of [
+      [12, "Issues opened", "org:JSONbored is:issue"],
+      [13, "Issues closed", "org:JSONbored is:issue is:closed"],
+      [14, "Issues open", "org:JSONbored is:issue is:open"],
+    ] as const) {
+      const panel = panelsById.get(id);
+      expect(panel?.title).toBe(title);
+      expect(panel?.datasource?.type).toBe("grafana-github-datasource");
+      const target = panel?.targets?.[0];
+      expect(target?.queryType).toBe("Issues");
+      expect(target?.options?.query).toBe(expectedQuery);
+      // A live GitHub-API source (not review_targets) — never asserted to be time-window bound the way
+      // the SQL panels above are; "Issues open" is deliberately a state snapshot with no timeField at all.
+      expect(panel?.description?.length ?? 0).toBeGreaterThan(0);
+    }
+
+    // "Issues open" is a current-state snapshot (mirrors github-prs.json's own "Open issues" panel) —
+    // no timeField, unlike the opened/closed flow panels.
+    expect(panelsById.get(14)?.targets?.[0]?.options?.timeField).toBeUndefined();
+    expect(panelsById.get(12)?.targets?.[0]?.options?.timeField).toBe(1);
+    expect(panelsById.get(13)?.targets?.[0]?.options?.timeField).toBe(0);
   });
 
   (sqliteCliAvailable ? it : it.skip)("filters the pull request table to the selected time window", () => {


### PR DESCRIPTION
## Summary

- Adds three new stat panels to `grafana/dashboards/maintainer-reviews.json`'s "Reviews & PRs" dashboard: **Issues opened**, **Issues closed**, **Issues open** — the dashboard currently tracks pull requests only.
- **Data source chosen: `grafana-github-datasource` (live GitHub API)**, mirroring the exact pattern already proven in `grafana/dashboards/github-prs.json`'s "Open issues" panel (id 4) and "PRs opened" flow panels (id 7-9), rather than the local webhook-observed `issues` table via `frser-sqlite-datasource`. Documented in each new panel's own `description` field (per the issue's request), and here:
  - **Chosen (live API):** upstream-accurate regardless of local webhook sync gaps or backfill-timing holes — matters because this is a maintainer-facing accuracy dashboard, and `github-prs.json`'s own existence is explicitly the "accuracy fix" over an earlier local-only approach for PRs. Tradeoff: a different consistency model from the `review_targets`-backed PR panels on the same dashboard (live-API vs. local-snapshot), and the datasource caps results at 1000 rows (irrelevant for a `count` stat query).
  - **Not chosen (local `issues` table):** would match this dashboard's existing "local, webhook-observed" philosophy for the PR panels, but I could not confirm the local table is actually populated for every repo this dashboard implicitly covers (webhook-observed data has real gaps for repos onboarded before webhook coverage existed, or during backfill outages) — the issue explicitly calls out confirming this as a pre-req for that option, and I don't have production DB access to spot-check per-repo row counts from this environment. The live-API option sidesteps that risk entirely.
- **Opened/closed use `timeField`** (the dashboard's selected time range) mirroring `github-prs.json`'s flow panels exactly: `timeField: 1` for opened (created, matching PRs' own "opened" panel), `timeField: 0` for closed (matching PRs' own "closed" panel's index). **Open** is a current-state snapshot with no `timeField` at all, mirroring `github-prs.json`'s own "Open issues" panel precisely.
- Query scope hardcodes `org:JSONbored`, matching the existing precedent already baked into `github-prs.json`'s own `$scope` template variable (`"All repos" → org:JSONbored`) — `maintainer-reviews.json` has no `$scope` variable of its own (per the issue's own note), so this mirrors the sibling dashboard's existing convention rather than inventing a new one.
- Laid out as a **second stat row** ("Issue activity", new row id 11) below the existing 6 PR panels rather than cramming 9 panels into one 24-unit-wide row — 3 panels at `w:8` fills the row cleanly and stays visually distinct from the PR row it sits under. The table/timeseries/piechart panels below are shifted down accordingly (`y` values only, no other changes).

## Scope

- [x] Conventional Commit title.
- [x] Focused — pure Grafana JSON + test addition, no `src/**` changes.
- [x] Follows `CONTRIBUTING.md`.
- [x] Owner PR — linked issue eligibility gate does not apply. Advances #3716 (part of #1819).

## Validation

- [x] `git diff --check`
- [x] `npx vitest run test/unit/selfhost-grafana-dashboard.test.ts` — 13/13 passing, including a new test asserting all 3 panels' `datasource.type`, `queryType`, `options.query`, and `timeField` presence/absence.
- [x] `npm run selfhost:validate-observability` — dashboards and alert rules valid.
- [x] `npm run docs:drift-check` — unaffected (no gate-mode/flag/command surface touched).
- [x] Dashboard JSON validated with `python3 -m json.tool` (well-formed).
- [ ] `npm run typecheck`, `test:workers`, `build:mcp`, `test:mcp-pack`, `ui:openapi:check`, `ui:lint`, `ui:typecheck`, `ui:build`, `npm audit` — typecheck run clean locally; the rest not re-run (no `src/**`/worker/MCP/OpenAPI/UI-component code touched — pure `grafana/**` + `test/**`); CI runs them authoritatively.

## Safety

- [x] No secrets, wallet/hotkey/trust-score/reward data anywhere.
- [x] No runtime app behavior change — Grafana dashboard config only, self-host maintainer-facing observability, no gate/scoring impact.
- [x] No UI changes (this is a self-hosted Grafana dashboard, not `apps/gittensory-ui/**`) — no UI Evidence section needed.
- [x] No docs/changelog changes needed.

## Notes

- Grid layout: the existing 6 PR stat panels already fill the 24-unit-wide row (`w:4` each); the new row uses `w:8` × 3 panels rather than shrinking the existing PR panels, so this PR touches zero existing panel definitions besides the `y`-position shift on the 3 panels below the new row.
- Per the issue's non-goal: this does not duplicate `github-prs.json`'s deeper issue-triage view (oldest-first table, org-wide `$scope` selector) — it's a lightweight stats row on the PR-focused dashboard, matching what the issue asks for.