### PR TITLE
fix(release): remove the double space in release-please's PR title

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -28,7 +28,7 @@
   },
   "include-component-in-tag": true,
   "separate-pull-requests": true,
-  "pull-request-title-pattern": "chore(release): cut ${component} v${version}",
+  "pull-request-title-pattern": "chore(release): cut${component} v${version}",
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Fixes" },


### PR DESCRIPTION
## Summary
\`pull-request-title-pattern\` had a literal space before \`\${component}\`, but release-please's own docs confirm \`\${component}\` always renders with its own leading space baked in (the tool's default pattern is literally \`"chore\${scope}: release\${component} \${version}"\` — no manual space before it). The extra space produced "chore(release): cut  engine v0.2.0" (double space) on the first two real dry-run attempts of \`mcp-release-please.yml\`.

## Test plan
- [x] Valid JSON
- [ ] Will re-verify with a manual \`workflow_dispatch\` of \`mcp-release-please.yml\` after merge — confirming the earlier engine-v0.1.0 anchor tag fix already produces a correctly-scoped changelog (verified in the two prior dry-run attempts), this just fixes the title's cosmetic spacing