### PR TITLE
fix(release): sync package-lock.json via script, not release-please extra-files

### DIFF
--- a/.github/workflows/mcp-release-please.yml
+++ b/.github/workflows/mcp-release-please.yml
@@ -52,6 +52,39 @@ jobs:
           manifest-file: .release-please-manifest.json
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      # release-please's extra-files JSON-path updater doesn't reliably reach package-lock.json's
+      # per-workspace version fields (keys containing "/", nested under a manifest-mode component
+      # block) -- confirmed empirically (both the mcp-v0.7.0 dry run's precursor and the first two
+      # engine-v0.2.0 dry runs left it stale, breaking npm ci with "Missing: <pkg>@<version> from
+      # lock file"). Patches it directly on whichever release branch(es) release-please just
+      # created/updated, using the same branch naming convention its own commits already rely on.
+      - name: Sync package-lock.json on any release branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
+          gh auth setup-git
+          for component in mcp engine; do
+            branch="release-please--branches--main--components--${component}"
+            if ! git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+              echo "No release branch for $component, skipping."
+              continue
+            fi
+            git fetch origin "$branch"
+            git checkout -B "sync-check-${component}" "origin/$branch"
+            node scripts/sync-release-lockfile-versions.mjs packages/gittensory-mcp packages/gittensory-engine
+            if git diff --quiet package-lock.json; then
+              echo "package-lock.json already in sync on $branch."
+            else
+              git add package-lock.json
+              git commit -m "chore(release): sync package-lock.json"
+              git push origin "HEAD:$branch"
+            fi
+          done
+
       # release-please creates the component tag + GitHub Release with GITHUB_TOKEN, which (by
       # GitHub's recursion-prevention rule) does NOT fire push/tag-based workflows. workflow_dispatch
       # IS exempt from that rule, so dispatch the OIDC publish workflow explicitly, telling it

--- a/package-lock.json
+++ b/package-lock.json
@@ -15899,7 +15899,7 @@
       "version": "0.7.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@jsonbored/gittensory-engine": ">=0.1.0",
+        "@jsonbored/gittensory-engine": ">=0.1.0 <1.0.0",
         "@modelcontextprotocol/sdk": "1.29.0",
         "zod": "^4.4.3"
       },
@@ -15915,7 +15915,7 @@
       "version": "0.1.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@jsonbored/gittensory-engine": ">=0.1.0"
+        "@jsonbored/gittensory-engine": ">=0.1.0 <1.0.0"
       },
       "bin": {
         "gittensory-miner": "bin/gittensory-miner.js"

--- a/package-lock.json
+++ b/package-lock.json
@@ -15899,7 +15899,7 @@
       "version": "0.7.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@jsonbored/gittensory-engine": "^0.1.0",
+        "@jsonbored/gittensory-engine": ">=0.1.0",
         "@modelcontextprotocol/sdk": "1.29.0",
         "zod": "^4.4.3"
       },
@@ -15915,7 +15915,7 @@
       "version": "0.1.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@jsonbored/gittensory-engine": "0.1.0"
+        "@jsonbored/gittensory-engine": ">=0.1.0"
       },
       "bin": {
         "gittensory-miner": "bin/gittensory-miner.js"

--- a/packages/gittensory-engine/src/version.ts
+++ b/packages/gittensory-engine/src/version.ts
@@ -1,5 +1,14 @@
-/**
- * Published semver of `@jsonbored/gittensory-engine`. Keep in lockstep with `package.json` `version`
- * (enforced by `test/unit/engine-version.test.ts`).
- */
-export const ENGINE_VERSION = "0.1.0";
+import { readFileSync } from "node:fs";
+import { fileURLToPath, URL } from "node:url";
+
+// Read at runtime instead of a hand-synced literal -- works identically from src/version.ts
+// (source, under vitest) and dist/version.js (compiled output): package.json is always the
+// direct parent of both directories, and this is a plain file read, not a compile-time import,
+// so it isn't subject to tsconfig's rootDir: "src" restriction. URL imported explicitly from
+// node:url (not the ambient global) -- they've subtly diverged in this @types/node version
+// (Symbol.dispose on URLSearchParamsIterator), which fileURLToPath's overloads reject otherwise.
+const ownPackageJsonPath = fileURLToPath(new URL("../package.json", import.meta.url));
+const ownPackageJson = JSON.parse(readFileSync(ownPackageJsonPath, "utf8")) as { version: string };
+
+/** Published semver of `@jsonbored/gittensory-engine`, derived from this package's own package.json. */
+export const ENGINE_VERSION: string = ownPackageJson.version;

--- a/packages/gittensory-engine/src/version.ts
+++ b/packages/gittensory-engine/src/version.ts
@@ -1,14 +1,4 @@
-import { readFileSync } from "node:fs";
-import { fileURLToPath, URL } from "node:url";
-
-// Read at runtime instead of a hand-synced literal -- works identically from src/version.ts
-// (source, under vitest) and dist/version.js (compiled output): package.json is always the
-// direct parent of both directories, and this is a plain file read, not a compile-time import,
-// so it isn't subject to tsconfig's rootDir: "src" restriction. URL imported explicitly from
-// node:url (not the ambient global) -- they've subtly diverged in this @types/node version
-// (Symbol.dispose on URLSearchParamsIterator), which fileURLToPath's overloads reject otherwise.
-const ownPackageJsonPath = fileURLToPath(new URL("../package.json", import.meta.url));
-const ownPackageJson = JSON.parse(readFileSync(ownPackageJsonPath, "utf8")) as { version: string };
+import ownPackageJson from "../package.json" with { type: "json" };
 
 /** Published semver of `@jsonbored/gittensory-engine`, derived from this package's own package.json. */
 export const ENGINE_VERSION: string = ownPackageJson.version;

--- a/packages/gittensory-mcp/package.json
+++ b/packages/gittensory-mcp/package.json
@@ -38,7 +38,7 @@
     "build": "node --check bin/gittensory-mcp.js && node --check lib/local-branch.js && node --check scripts/gittensor-score-preview.mjs"
   },
   "dependencies": {
-    "@jsonbored/gittensory-engine": "^0.1.0",
+    "@jsonbored/gittensory-engine": ">=0.1.0",
     "@modelcontextprotocol/sdk": "1.29.0",
     "zod": "^4.4.3"
   },

--- a/packages/gittensory-mcp/package.json
+++ b/packages/gittensory-mcp/package.json
@@ -38,7 +38,7 @@
     "build": "node --check bin/gittensory-mcp.js && node --check lib/local-branch.js && node --check scripts/gittensor-score-preview.mjs"
   },
   "dependencies": {
-    "@jsonbored/gittensory-engine": ">=0.1.0",
+    "@jsonbored/gittensory-engine": ">=0.1.0 <1.0.0",
     "@modelcontextprotocol/sdk": "1.29.0",
     "zod": "^4.4.3"
   },

--- a/packages/gittensory-miner/package.json
+++ b/packages/gittensory-miner/package.json
@@ -34,7 +34,7 @@
     "build": "node --check bin/gittensory-miner.js && node --check lib/cli.js && node --check lib/deny-check.js && node --check lib/run-state-cli.js && node --check lib/update-check.js && node --check lib/opportunity-fanout.js && node --check lib/ci-poller.js && node --check lib/run-state.js && node --check lib/deny-hooks.js && node --check lib/event-ledger.js && node --check lib/event-ledger-cli.js && node --check lib/claim-ledger.js && node --check lib/claim-ledger-expiry.js && node --check lib/portfolio-queue.js && node --check lib/portfolio-queue-cli.js && node --check lib/portfolio-discovery.js && node --check lib/opportunity-ranker.js && node --check lib/plan-store.js && node --check lib/plan-store-cli.js && node --check lib/rejection-templates.js && node --check lib/governor-ledger.js && node --check lib/governor-ledger-cli.js && node --check lib/manage-status.js && node --check lib/manage-poll.js && node --check lib/status.js && node --check lib/laptop-init.js && node --check lib/replay-objective-anchor.js && node --check lib/replay-task-generation.js && node --check lib/calibration-types.js && node --check lib/calibration.js"
   },
   "dependencies": {
-    "@jsonbored/gittensory-engine": "0.1.0"
+    "@jsonbored/gittensory-engine": ">=0.1.0"
   },
   "engines": {
     "node": ">=22.13.0"

--- a/packages/gittensory-miner/package.json
+++ b/packages/gittensory-miner/package.json
@@ -34,7 +34,7 @@
     "build": "node --check bin/gittensory-miner.js && node --check lib/cli.js && node --check lib/deny-check.js && node --check lib/run-state-cli.js && node --check lib/update-check.js && node --check lib/opportunity-fanout.js && node --check lib/ci-poller.js && node --check lib/run-state.js && node --check lib/deny-hooks.js && node --check lib/event-ledger.js && node --check lib/event-ledger-cli.js && node --check lib/claim-ledger.js && node --check lib/claim-ledger-expiry.js && node --check lib/portfolio-queue.js && node --check lib/portfolio-queue-cli.js && node --check lib/portfolio-discovery.js && node --check lib/opportunity-ranker.js && node --check lib/plan-store.js && node --check lib/plan-store-cli.js && node --check lib/rejection-templates.js && node --check lib/governor-ledger.js && node --check lib/governor-ledger-cli.js && node --check lib/manage-status.js && node --check lib/manage-poll.js && node --check lib/status.js && node --check lib/laptop-init.js && node --check lib/replay-objective-anchor.js && node --check lib/replay-task-generation.js && node --check lib/calibration-types.js && node --check lib/calibration.js"
   },
   "dependencies": {
-    "@jsonbored/gittensory-engine": ">=0.1.0"
+    "@jsonbored/gittensory-engine": ">=0.1.0 <1.0.0"
   },
   "engines": {
     "node": ">=22.13.0"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,26 +4,12 @@
     "packages/gittensory-mcp": {
       "release-type": "node",
       "component": "mcp",
-      "package-name": "@jsonbored/gittensory-mcp",
-      "extra-files": [
-        {
-          "type": "json",
-          "path": "package-lock.json",
-          "jsonpath": "$.packages['packages/gittensory-mcp'].version"
-        }
-      ]
+      "package-name": "@jsonbored/gittensory-mcp"
     },
     "packages/gittensory-engine": {
       "release-type": "node",
       "component": "engine",
-      "package-name": "@jsonbored/gittensory-engine",
-      "extra-files": [
-        {
-          "type": "json",
-          "path": "package-lock.json",
-          "jsonpath": "$.packages['packages/gittensory-engine'].version"
-        }
-      ]
+      "package-name": "@jsonbored/gittensory-engine"
     }
   },
   "include-component-in-tag": true,

--- a/scripts/sync-release-lockfile-versions.mjs
+++ b/scripts/sync-release-lockfile-versions.mjs
@@ -1,0 +1,43 @@
+#!/usr/bin/env node
+// release-please's `extra-files` JSON-path updater doesn't reliably reach package-lock.json's
+// per-workspace version fields, whose keys contain slashes (e.g. "packages/gittensory-engine")
+// nested under a manifest-mode component's own release-please-config.json block -- confirmed
+// empirically (mcp-v0.7.0/engine-v0.2.0 dry runs both left package-lock.json un-synced, breaking
+// `npm ci` with "Missing: @jsonbored/gittensory-engine@0.1.0 from lock file"). This does the same
+// single-line replacement a human would make by hand: find the workspace's own manifest-mirror
+// entry, replace just its "version" value. No JSON.parse/stringify round-trip on the whole
+// multi-thousand-line lockfile, which would risk reordering/reformatting far beyond the one line
+// that actually changed.
+import { readFileSync, writeFileSync } from "node:fs";
+
+const targets = process.argv.slice(2);
+if (targets.length === 0) {
+  console.error("Usage: node sync-release-lockfile-versions.mjs <workspace-path> [<workspace-path> ...]");
+  process.exit(1);
+}
+
+const lockPath = "package-lock.json";
+let content = readFileSync(lockPath, "utf8");
+let changed = false;
+
+for (const workspacePath of targets) {
+  const version = JSON.parse(readFileSync(`${workspacePath}/package.json`, "utf8")).version;
+  const escapedKey = workspacePath.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  // Anchors on the workspace's own block header + its "name" line (both stable, unique) so this
+  // can't accidentally match a different package's "version" line elsewhere in the file.
+  const pattern = new RegExp(`("${escapedKey}":\\s*\\{\\s*\\n\\s*"name":[^\\n]*\\n\\s*"version":\\s*")[^"]*(")`);
+  if (!pattern.test(content)) {
+    console.error(`${workspacePath}: pattern not found in ${lockPath} -- nothing changed.`);
+    continue;
+  }
+  const updated = content.replace(pattern, `$1${version}$2`);
+  if (updated === content) {
+    console.log(`${workspacePath}: already at ${version}.`);
+  } else {
+    content = updated;
+    changed = true;
+    console.log(`${workspacePath}: synced to ${version}.`);
+  }
+}
+
+if (changed) writeFileSync(lockPath, content);

--- a/test/unit/gittensory-engine-scaffold.test.ts
+++ b/test/unit/gittensory-engine-scaffold.test.ts
@@ -7,7 +7,7 @@ import enginePkg from "../../packages/gittensory-engine/package.json";
 describe("gittensory-engine package scaffold", () => {
   it("declares the published package identity", () => {
     expect(enginePkg.name).toBe("@jsonbored/gittensory-engine");
-    expect(enginePkg.version).toBe("0.1.0");
+    expect(enginePkg.version).toMatch(/^\d+\.\d+\.\d+$/);
     expect(enginePkg.type).toBe("module");
     expect(enginePkg.license).toBe("AGPL-3.0-only");
     expect(enginePkg.publishConfig?.access).toBe("public");


### PR DESCRIPTION
## Summary

**1. package-lock.json sync (original fix):** release-please's `extra-files` JSON-path updater didn't reach `package-lock.json`'s per-workspace version fields (keys containing "/", nested under a manifest-mode component block) — confirmed empirically twice: the `engine-v0.2.0` dry run's `package-lock.json` stayed at `0.1.0` after `package.json` bumped to `0.2.0`, breaking `npm ci` with `"Missing: @jsonbored/gittensory-engine@0.1.0 from lock file"`.

Replaces it with `scripts/sync-release-lockfile-versions.mjs` — the same single-line string replacement already proven correct by hand for both packages earlier in this release cycle, not a full `JSON.parse`/`stringify` round-trip on a multi-thousand-line file. A new workflow step runs it directly against whichever release-please branch(es) exist (`release-please--branches--main--components--<mcp|engine>`, the same naming convention release-please's own commits already rely on), commits if anything changed, before the tag/publish-dispatch steps that follow.

Removed the two now-dead `extra-files` blocks from `release-please-config.json`.

**2. Dependency range widening (found while validating fix #1 on the real dry-run branch):** even after the lockfile sync fix, `npm ci` still failed the same way. Root cause: semver caret ranges for 0.x versions only allow patch bumps (`^0.1.0` means `>=0.1.0 <0.2.0`), so `gittensory-mcp`'s `"^0.1.0"` and `gittensory-miner`'s exact `"0.1.0"` pin both break on `gittensory-engine`'s very first real release (0.1.0 → 0.2.0). Widened both to `">=0.1.0"` — these are internal, same-monorepo dependencies whose real compatibility guarantee comes from this repo's own test suite, not strict semver-range enforcement against a pre-1.0 package expected to move through minor versions often.

Both fixes were also applied directly to PR #4176's branch (the real, currently-open dry-run PR) to unblock it immediately, in addition to landing here for all future releases.

## Test plan
- [x] Script tested against a simulated broken state (engine bumped to 0.2.0, lockfile left at 0.1.0) — correctly produces a single-line diff
- [x] Script tested against the current, already-in-sync state — correctly no-ops for both packages
- [x] `npm ci` verified clean after both fixes, on both this branch and PR #4176's branch
- [x] `npm run typecheck`, `npm run build:mcp`, `npm run build:miner` — all clean
- [x] `npm run actionlint` — clean
- [x] Valid JSON