### PR TITLE
test(ui): add AGPL-3.0 badge to footer to validate visual-capture pipeline

### DIFF
--- a/apps/gittensory-ui/src/components/site/site-footer.tsx
+++ b/apps/gittensory-ui/src/components/site/site-footer.tsx
@@ -1,6 +1,8 @@
 import { Link } from "@tanstack/react-router";
 import { Github } from "lucide-react";
 
+import { Badge } from "@/components/ui/badge";
+
 import { GittensoryMark } from "./mark";
 import { HealthDot } from "./health-dot";
 
@@ -122,6 +124,9 @@ export function SiteFooter() {
               </a>{" "}
               OSS project.
             </span>
+            <Badge variant="outline" className="border-hairline text-muted-foreground">
+              AGPL-3.0
+            </Badge>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- **This is a deliberate test PR, not a feature.** It adds a small, real, visible "AGPL-3.0" badge to the site footer (reusing the existing `Badge` UI component, `variant="outline"`) purely to validate the newly-activated before/after visual-capture pipeline end-to-end on a real gittensory-ui PR.
- Verified locally in a dev server first (`preview_eval`/DOM inspection confirmed the badge renders with the correct classes and a real, visible bounding box).
- Expecting: the bot's review comment to show a before/after table (production vs. this PR's preview deploy) with the badge visible in the "after" shot at both desktop and mobile viewports.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused (one file, one small visible change) and does not mix unrelated backend/UI/MCP/docs/dependency/deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue this PR resolves -- N/A, deliberate test PR, no feature being solved.

## Validation

- [x] `git diff --check`
- [x] `npm --workspace @jsonbored/gittensory-ui run typecheck`
- [x] `npm --workspace @jsonbored/gittensory-ui run lint` (0 errors; pre-existing warnings elsewhere untouched)
- [x] `npm --workspace @jsonbored/gittensory-ui run format` (no changes needed)
- [x] `npm run ui:build`
- [x] Manually verified in a local dev server via DOM inspection (real bounding box, correct Badge classes)
- [ ] `npm run test:coverage` -- N/A, `apps/**` is not measured by Codecov and no `src/**` logic changed.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, private keys, trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized and low-noise.
- [x] Auth/cookie/CORS/GitHub App/Cloudflare/session changes include negative-path tests. -- N/A, no such changes.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. -- N/A, no such surface touched.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. -- N/A.

## UI Evidence

Intentionally left blank -- this PR's entire purpose is to let the bot's own visual-capture pipeline produce that evidence automatically. See the gittensory-orb review comment for the actual before/after table once it renders.

## Notes

- This PR is expected to be **held for manual review** regardless of CI outcome (`apps/gittensory-ui/src/components/**` is in this repo's `hardGuardrailGlobs`) -- that's expected and fine, this isn't meant to auto-merge.
