### PR TITLE
fix(release): require approval for release-please

### DIFF
--- a/.github/workflows/mcp-release-please.yml
+++ b/.github/workflows/mcp-release-please.yml
@@ -33,6 +33,7 @@ concurrency:
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    environment: release
     timeout-minutes: 15
     permissions:
       contents: write


### PR DESCRIPTION
### Motivation
- Prevent release-please from creating GitHub tags/Releases outside the repo's protected `release` approval boundary by ensuring the job runs under the `release` environment.

### Description
- Add `environment: release` to the `release-please` job in `.github/workflows/mcp-release-please.yml` so tag/GitHub Release creation requires the same protected release approval used for package publishing.

### Testing
- `git diff --check` ran and returned clean results.
- `npm run actionlint` ran and passed for the repository workflows.
- `npm run test:ci` was executed and advanced through multiple checks (lint, migrations, schema drift, selfhost checks, observability) before stopping at a pre-existing `cf-typegen` drift unrelated to this workflow-only change.
- `npm audit --audit-level=moderate` could not complete due to the npm registry returning `403 Forbidden` for the audit endpoint.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e206c6454832cbd8a488349dc4511)