### PR TITLE
fix(selfhost): protect manual beta Orb releases

### DIFF
--- a/.github/workflows/release-selfhost.yml
+++ b/.github/workflows/release-selfhost.yml
@@ -38,12 +38,13 @@ jobs:
   release:
     runs-on: ubuntu-latest
     timeout-minutes: 40
-    # Environment gate. Only an actual `-beta.N` version routes to `release-beta` (no required
-    # reviewers -- see orb-beta-release.yml, which dispatches daily with no human in the loop); every
-    # other version (stable X.Y.Z or an -rc.N) stays on `release`, which requires reviewer approval
-    # under repo Settings > Environments. The check reads the raw version string directly (not a step
-    # output), since a job's `environment:` is resolved before any step runs.
-    environment: ${{ ((github.event_name == 'push' && contains(github.ref_name, '-beta.')) || (github.event_name == 'workflow_dispatch' && contains(inputs.version, '-beta.'))) && 'release-beta' || 'release' }}
+    # Environment gate. Only the trusted orb-beta-release automation may use `release-beta` (no
+    # required reviewers): it dispatches this workflow as github-actions[bot], asks to create the
+    # GitHub Release, and the validation below requires that exact beta tag to already point at this
+    # commit. Human workflow_dispatch runs and direct beta tag pushes stay on `release`, which requires
+    # reviewer approval under repo Settings > Environments. This expression reads only event fields
+    # because a job's `environment:` is resolved before any step runs.
+    environment: ${{ github.event_name == 'workflow_dispatch' && github.actor == 'github-actions[bot]' && inputs.create_github_release && contains(inputs.version, '-beta.') && 'release-beta' || 'release' }}
     env:
       SENTRY_ORG: jsonbored
       SENTRY_PROJECT: gittensory
@@ -67,9 +68,12 @@ jobs:
       - name: Resolve version
         id: version
         env:
+          CREATE_GITHUB_RELEASE: ${{ github.event.inputs.create_github_release || 'false' }}
           EVENT_NAME: ${{ github.event_name }}
           INPUT_VERSION: ${{ github.event.inputs.version }}
           REF_NAME: ${{ github.ref_name }}
+          RELEASE_SHA: ${{ github.sha }}
+          RUN_ACTOR: ${{ github.actor }}
         run: |
           set -euo pipefail
           if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
@@ -91,6 +95,17 @@ jobs:
           PRERELEASE=false
           if printf '%s' "$VERSION" | grep -Eq -- '-(rc|beta)\.[0-9]+$'; then
             PRERELEASE=true
+          fi
+          if printf '%s' "$VERSION" | grep -Eq -- '-beta\.[0-9]+$' \
+            && [ "$EVENT_NAME" = "workflow_dispatch" ] \
+            && [ "$RUN_ACTOR" = "github-actions[bot]" ] \
+            && [ "$CREATE_GITHUB_RELEASE" = "true" ]; then
+            git fetch --force --tags origin "refs/tags/orb-v${VERSION}:refs/tags/orb-v${VERSION}"
+            TAG_SHA="$(git rev-list -n 1 "refs/tags/orb-v${VERSION}")"
+            if [ "$TAG_SHA" != "$RELEASE_SHA" ]; then
+              echo "automated beta releases must dispatch the tag that was just created for this commit" >&2
+              exit 1
+            fi
           fi
           {
             echo "v=${VERSION}"


### PR DESCRIPTION
### Motivation
- Prevent unreviewed publication of GHCR beta image tags by ensuring only the automated orb-beta-release bot can route a run into the unreviewed `release-beta` environment. 
- Add a server-side validation so an automated beta dispatch cannot be abused to rebuild or republish an arbitrary existing beta tag.

### Description
- Tighten the `environment:` expression in `.github/workflows/release-selfhost.yml` so `release-beta` is selected only when the event is `workflow_dispatch`, the actor is `github-actions[bot]`, `inputs.create_github_release` is truthy, and `inputs.version` contains `-beta.`; all other beta dispatches and tag pushes remain on the protected `release` environment.
- Expose `CREATE_GITHUB_RELEASE`, `RELEASE_SHA`, and `RUN_ACTOR` to the `Resolve version` step and add a pre-publish check that, for automated beta dispatches, fetches the expected tag and verifies the tag object resolves to the current workflow commit before allowing the job to continue.
- Update comments to document the tighter guard and the intent to keep manual dispatches on the reviewer-gated environment.

### Testing
- Ran `git diff --check` to ensure no whitespace/conflict markers, which succeeded.
- Ran the workflow linter via `npm run actionlint`, which completed successfully (used the WASM fallback after GitHub download retries) and reported no blocking issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e214a22c0832c8eaed25375124112)