### PR TITLE
fix(review): keep fallback marker until workflow completion

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -4601,6 +4601,7 @@ async function maybeCaptureOnActionsFallbackWorkflowRun(
     }
   ).workflow_run;
   if (run?.name !== FALLBACK_WORKFLOW_NAME || run?.event !== "workflow_dispatch") return false;
+  if (payload.action !== "completed") return false;
 
   const correlation = parseFallbackRunCorrelation(run.display_title);
   if (correlation) {

--- a/test/unit/actions-fallback-webhook.test.ts
+++ b/test/unit/actions-fallback-webhook.test.ts
@@ -484,6 +484,37 @@ describe("workflow_run webhook -> actions_fallback storage (#4112)", () => {
     expect(artifactsListCalled).toBe(false);
   });
 
+  it("does not clear the dispatch marker for a non-terminal workflow_run activity", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), GITTENSORY_REVIEW_REPOS: "owner/fallback-repo", REVIEW_AUDIT: memoryReviewAudit() });
+    await seedRepoAndPr(env, "cafebabecafebabecafebabecafebabecafebabe");
+    await markFallbackDispatched(env, "cafebabecafebabecafebabecafebabecafebabe");
+    let artifactsListCalled = false;
+    vi.stubGlobal(
+      "fetch",
+      baseFetchStub({
+        "/actions/runs/": () => {
+          artifactsListCalled = true;
+          return Response.json({ artifacts: [] });
+        },
+      }),
+    );
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "requested-run-keeps-marker",
+      eventName: "workflow_run",
+      payload: {
+        action: "requested",
+        repository: { name: "fallback-repo", full_name: "owner/fallback-repo", owner: { login: "owner" } },
+        installation: { id: 9101 },
+        workflow_run: { id: 589, name: "Gittensory Visual Capture Fallback", event: "workflow_dispatch", conclusion: null, display_title: "gittensory-visual-fallback pr=55 sha=cafebabecafebabecafebabecafebabecafebabe" },
+      },
+    } as never);
+
+    expect(artifactsListCalled).toBe(false);
+    await expect(isFallbackDispatchInFlight(env, "cafebabecafebabecafebabecafebabecafebabe")).resolves.toBe(true);
+  });
+
   it("clears the dispatch marker on a FAILED run too (#4112 review fix -- a failed run shouldn't block a retry for the rest of the max-age window)", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(), GITTENSORY_REVIEW_REPOS: "owner/fallback-repo", REVIEW_AUDIT: memoryReviewAudit() });
     await seedRepoAndPr(env, "cafebabecafebabecafebabecafebabecafebabe");


### PR DESCRIPTION
### Motivation
- The fallback dispatch marker was being cleared for any matching `workflow_run` activity, including non-terminal `requested`/`in_progress` events, which can cause redispatch -> cancel-in-progress loops and availability loss for visual fallback captures. 
- The intent is to only clear the persisted in-flight marker once the fallback workflow has actually settled (terminal/completed), while preserving the existing behavior that clears the marker for final states (success/failure/cancel/timed_out).

### Description
- Add a guard in `maybeCaptureOnActionsFallbackWorkflowRun` to ignore non-terminal webhook deliveries by returning early unless `payload.action === "completed"` (in `src/queue/processors.ts`).
- Keep the existing behavior that clears the marker on settled runs and still stores successful-run artifacts and triggers a re-review when appropriate.
- Add a regression unit test that seeds an in-flight marker, sends a non-terminal `workflow_run` webhook (`action: "requested"`), asserts no artifact-list fetch happens, and verifies the marker remains present (in `test/unit/actions-fallback-webhook.test.ts`).

### Testing
- Ran the focused unit file with `npx vitest run test/unit/actions-fallback-webhook.test.ts --pool=forks --reporter=verbose` and the test suite for that file passed (all tests in that file passed).
- Ran `npm run typecheck` and `git diff --check`, both of which succeeded with no type errors or repository hygiene issues found.
- Attempted the full coverage run via `npm run test:coverage`; the broader suite did not complete in this environment (long-running queue suite) and was terminated, and `npm run test:coverage -- --runInBand` failed due to Vitest not recognizing `--runInBand`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4dfd90c540832cb1a0b4b86376356e)