### PR TITLE
fix(release): keep the release-please job unattended, gate publish only

### DIFF
--- a/.github/workflows/mcp-release-please.yml
+++ b/.github/workflows/mcp-release-please.yml
@@ -30,10 +30,16 @@ concurrency:
   group: mcp-release-please
   cancel-in-progress: false
 
+# Deliberately no `environment: release` on the job below. The approval boundary lives at the
+# actual npm publish step (npm-publish.yml / publish-engine.yml's `publish` job), not here --
+# gating this job too would pause EVERY cron tick for manual approval, including the near-all
+# no-op runs that just check for new commits, defeating unattended automation entirely. This was
+# tried (#4182) and reverted for exactly that reason. release-please creating a tag/
+# GitHub Release unattended is accepted as within the automation's scope ("fully unattended
+# through npm publish"); only the registry-affecting, irreversible step is gated.
 jobs:
   release-please:
     runs-on: ubuntu-latest
-    environment: release
     timeout-minutes: 15
     permissions:
       contents: write


### PR DESCRIPTION
### Motivation

PR #4182 added `environment: release` to the whole `release-please` job in `mcp-release-please.yml`, closing a real gap: release-please's own tag/GitHub-Release creation (part of the same action call that opens/updates the Release PR) had no approval gate, unlike the actual `npm publish` step.

The fix is broader than the gap, though. `environment:` at the job level pauses **every** run for manual approval before any step executes -- including the near-all no-op cron ticks that just check for new commits against `release-please-config.json` and find nothing to do. That turns "fully unattended through npm publish" (this automation's explicitly approved design goal) into "someone has to click approve every ~2 days regardless of whether anything happened."

### Change

Remove the job-level `environment: release`. The approval boundary stays where it was designed to be: the actual `npm publish` step, inside `npm-publish.yml`/`publish-engine.yml`'s own `environment: release`-gated `publish` job. release-please creating a tag + GitHub Release unattended is accepted as within scope -- it's reversible (delete the tag/release) and has no external registry/supply-chain effect, unlike a real `npm publish`.

Added a comment at the job so a future pass doesn't reintroduce the same gate without this context.

### Testing

- `npm run actionlint` -- clean.