### PR TITLE
fix(release): dispatch publish workflows against the release tag, not main

### DIFF
--- a/.github/workflows/mcp-release-please.yml
+++ b/.github/workflows/mcp-release-please.yml
@@ -98,14 +98,21 @@ jobs:
       # release-please already created the tag/release (released_by_release_please=true skips both
       # workflows' own tag-creation and GitHub-release steps). Without this, merging a Release PR
       # would silently never publish.
+      #
+      # Dispatched against the release tag itself, NOT main: main can move between this step and
+      # the dispatched run actually starting (anything else merging in that window), and the
+      # publish workflow's own safety check hard-fails if the commit it's building doesn't match
+      # the tag release-please just created (confirmed live: engine-v0.2.0's first dry run hit
+      # exactly this race when an unrelated PR merged seconds apart). A tag doesn't move, so
+      # dispatching against it makes the publish deterministic regardless of main's activity.
       - name: Dispatch MCP publish
         if: ${{ steps.release.outputs['packages/gittensory-mcp--release_created'] == 'true' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run npm-publish.yml --ref main -f released_by_release_please=true
+        run: gh workflow run npm-publish.yml --ref "${{ steps.release.outputs['packages/gittensory-mcp--tag_name'] }}" -f released_by_release_please=true
 
       - name: Dispatch Engine publish
         if: ${{ steps.release.outputs['packages/gittensory-engine--release_created'] == 'true' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh workflow run publish-engine.yml --ref main -f released_by_release_please=true
+        run: gh workflow run publish-engine.yml --ref "${{ steps.release.outputs['packages/gittensory-engine--tag_name'] }}" -f released_by_release_please=true


### PR DESCRIPTION
### Motivation

Confirmed live during the engine-v0.2.0 dry run: `mcp-release-please.yml` dispatches `npm-publish.yml`/`publish-engine.yml` with `--ref main`. That races against anything else merging to `main` between release-please tagging the release commit and the dispatched run actually starting -- and it's not hypothetical, it happened on the very first real run (#4202's merge landed seconds after `engine-v0.2.0` was tagged, so the dispatched `publish-engine.yml` run checked out a `HEAD` past the tag). The publish workflow's own safety check correctly refused to proceed with a mismatched commit rather than silently publishing from the wrong SHA.

### Change

- Dispatch against `steps.release.outputs['<path>--tag_name']` instead of `main`. Tags don't move, so the publish is deterministic regardless of what else merges to `main` in that window.
- Add `mcp-v*` / `engine-v*` tag-type deployment branch policies to the `release` GitHub Environment, which previously only allowed the `main` branch and would otherwise reject a tag-ref dispatch before it even reached the approval gate.

### Testing

- `npm run actionlint` -- clean.
- `tag_name` confirmed as a real per-path output key by reading `release-please-action`'s source directly (`setPathOutput` prefixes every release field, including the `tagName`→`tag_name` remap, with `${path}--`).