### PR TITLE
feat(review): reuse review.instructions/pathInstructions for E2E test generation

### DIFF
--- a/.gittensory.yml.example
+++ b/.gittensory.yml.example
@@ -883,10 +883,13 @@ settings:
 #   security_focus: false
 #   # A repo-level natural-language brief handed to the AI reviewer on EVERY review (vs the per-path
 #   # path_instructions below) -- the maintainer's conventions/voice. Bounded + public-safe at parse time.
-#   # String or null. Default: null (byte-identical prompt).
+#   # String or null. Default: null (byte-identical prompt). Also feeds AI-generated E2E test coverage
+#   # (features.e2eTests, #4190/#4189) when that feature is enabled -- the same conventions brief steers
+#   # both the AI reviewer and the AI test generator, so you only write it once.
 #   instructions: "Prefer small, focused PRs. Flag any missing test for a bug fix."
 #   # Per-path natural-language guidance handed to the AI reviewer when a changed file matches the glob.
-#   # Empty/default ⇒ byte-identical prompt.
+#   # Empty/default ⇒ byte-identical prompt. Also feeds AI-generated E2E test coverage the same way as
+#   # `instructions` above, for path-scoped rules ("always test the payment-failure retry path").
 #   path_instructions:
 #     - path: "src/db/**"
 #       instructions: "Flag any migration missing a matching down-path note."

--- a/config/examples/gittensory.full.yml
+++ b/config/examples/gittensory.full.yml
@@ -896,10 +896,13 @@ settings:
 #   security_focus: false
 #   # A repo-level natural-language brief handed to the AI reviewer on EVERY review (vs the per-path
 #   # path_instructions below) -- the maintainer's conventions/voice. Bounded + public-safe at parse time.
-#   # String or null. Default: null (byte-identical prompt).
+#   # String or null. Default: null (byte-identical prompt). Also feeds AI-generated E2E test coverage
+#   # (features.e2eTests, #4190/#4189) when that feature is enabled -- the same conventions brief steers
+#   # both the AI reviewer and the AI test generator, so you only write it once.
 #   instructions: "Prefer small, focused PRs. Flag any missing test for a bug fix."
 #   # Per-path natural-language guidance handed to the AI reviewer when a changed file matches the glob.
-#   # Empty/default ⇒ byte-identical prompt.
+#   # Empty/default ⇒ byte-identical prompt. Also feeds AI-generated E2E test coverage the same way as
+#   # `instructions` above, for path-scoped rules ("always test the payment-failure retry path").
 #   path_instructions:
 #     - path: "src/db/**"
 #       instructions: "Flag any migration missing a matching down-path note."

--- a/packages/gittensory-engine/src/focus-manifest.ts
+++ b/packages/gittensory-engine/src/focus-manifest.ts
@@ -527,11 +527,15 @@ export type FocusManifestReviewConfig = {
    *  (#1955) knobs. (#2047) */
   commentVerbosity: CommentVerbosity | null;
   /** `review.path_instructions`: per-path natural-language guidance handed to the AI reviewer when the PR's
-   *  changed files match the glob. Empty (default) ⇒ byte-identical reviewer prompt. (#review-path-instructions) */
+   *  changed files match the glob. Empty (default) ⇒ byte-identical reviewer prompt. Also consumed by
+   *  AI-generated E2E test coverage (`resolveE2eTestGenInstructions` in `ai-e2e-test-gen.ts`, #4200) when
+   *  that feature is enabled — the same maintainer-authored guidance steers both consumers, no separate
+   *  test-generation-specific instructions schema. (#review-path-instructions) */
   pathInstructions: ReviewPathInstruction[];
   /** `review.instructions`: a repo-level natural-language brief handed to the AI reviewer on EVERY review (vs the
    *  per-path path_instructions) — the maintainer's conventions/voice for this repo. Bounded + public-safe at parse
-   *  time (so it stays cost-cheap, unlike ingesting a whole CLAUDE.md). null (default, absent) ⇒ byte-identical
+   *  time (so it stays cost-cheap, unlike ingesting a whole CLAUDE.md). Also consumed by AI-generated E2E test
+   *  coverage (#4200) for the same reason as pathInstructions above. null (default, absent) ⇒ byte-identical
    *  reviewer prompt. (#review-instructions) */
   instructions: string | null;
   /** `review.exclude_paths`: globs whose matching files are EXCLUDED from the AI review (diff + grounding + RAG)

--- a/src/services/ai-e2e-test-gen.ts
+++ b/src/services/ai-e2e-test-gen.ts
@@ -1,4 +1,4 @@
-// Gittensory AI-generated E2E test coverage (the `e2eTests` capability, #4191, part of the #4189 epic).
+// Gittensory AI-generated E2E test coverage (the `e2eTests` capability, #4191/#4200, part of the #4189 epic).
 //
 // Turns a PR's changed-file diffs into a complete Playwright test file, following the SAME shape as
 // `ai-slop.ts`'s AI-assisted advisory: an opt-in, fail-safe second capability layered on top of the
@@ -25,6 +25,7 @@ import { countByokAiEventsForRepoSince, recordAiUsageEvent, sumAiEstimatedNeuron
 import { convergedFeatureActive } from "../review/feature-activation";
 import { defangReviewInput } from "../review/safety";
 import { isE2eTestGenerationEnabled } from "../review/e2e-test-gen-wire";
+import { resolveReviewPathInstructions, type FocusManifestReviewConfig } from "../signals/focus-manifest";
 import {
   type AiReviewActualUsage,
   type AiReviewProviderKey,
@@ -110,6 +111,27 @@ export function buildE2eTestGenDiffText(files: E2eTestGenChangedFile[]): string 
     .map((file) => `--- ${file.path} ---\n${file.patch}`)
     .join("\n\n")
     .slice(0, MAX_DIFF_CHARS);
+}
+
+/**
+ * Pure: combine a repo's general `review.instructions` (#4200) with any `review.pathInstructions` entries
+ * matching the PR's changed files into one instructions block for E2E test generation — reusing the
+ * EXISTING config-as-code mechanism the AI reviewer itself already consumes (`resolveReviewPathInstructions`),
+ * rather than inventing a second, e2e-test-gen-specific instructions schema. A maintainer's repo-wide
+ * conventions ("use Playwright with our page-object pattern under test/e2e/pages/") and path-scoped rules
+ * ("always test the payment-failure retry path for src/checkout/**") apply equally well to steering an AI
+ * reviewer or an AI test generator, so both draw from the same maintainer-authored brief. Returns null when
+ * nothing is configured (no repo-wide instructions, no matching path instructions) — never an empty string,
+ * so a caller can treat "no instructions" and "instructions" as a clean two-way branch.
+ */
+export function resolveE2eTestGenInstructions(
+  review: Pick<FocusManifestReviewConfig, "instructions" | "pathInstructions"> | null | undefined,
+  changedPaths: string[],
+): string | null {
+  const repoWide = review?.instructions?.trim() || "";
+  const pathGuidance = resolveReviewPathInstructions(review?.pathInstructions ?? [], changedPaths).trim();
+  const combined = [repoWide, pathGuidance].filter(Boolean).join("\n\n");
+  return combined || null;
 }
 
 /**

--- a/test/unit/ai-e2e-test-gen.test.ts
+++ b/test/unit/ai-e2e-test-gen.test.ts
@@ -4,10 +4,12 @@ import {
   buildE2eTestGenDiffText,
   buildE2eTestGenPrompt,
   parseE2eTestGenResponse,
+  resolveE2eTestGenInstructions,
   runGittensoryE2eTestGeneration,
   type E2eTestGenInput,
 } from "../../src/services/ai-e2e-test-gen";
 import { recordAiUsageEvent } from "../../src/db/repositories";
+import type { FocusManifestReviewConfig } from "../../src/signals/focus-manifest";
 import { createTestEnv } from "../helpers/d1";
 
 const { runWorkersE2eTestGen } = __aiE2eTestGenInternals;
@@ -102,6 +104,61 @@ describe("buildE2eTestGenPrompt", () => {
     expect(prompt).toContain("Target test framework: Cypress");
     expect(prompt).toContain("Always cover the empty-cart case.");
     expect(prompt).toContain("--- x.ts ---\n+const x = 1;");
+  });
+});
+
+function reviewWith(over: Partial<Pick<FocusManifestReviewConfig, "instructions" | "pathInstructions">>) {
+  return { instructions: null, pathInstructions: [], ...over };
+}
+
+describe("resolveE2eTestGenInstructions", () => {
+  it("returns null when nothing is configured", () => {
+    expect(resolveE2eTestGenInstructions(reviewWith({}), ["src/a.ts"])).toBeNull();
+  });
+
+  it("returns null for a null/undefined review config (tolerates an absent manifest)", () => {
+    expect(resolveE2eTestGenInstructions(null, ["src/a.ts"])).toBeNull();
+    expect(resolveE2eTestGenInstructions(undefined, ["src/a.ts"])).toBeNull();
+  });
+
+  it("returns the repo-wide instructions alone when no path instructions match", () => {
+    const result = resolveE2eTestGenInstructions(
+      reviewWith({ instructions: "Use Playwright with our page-object pattern." }),
+      ["src/other.ts"],
+    );
+    expect(result).toBe("Use Playwright with our page-object pattern.");
+  });
+
+  it("returns matching path instructions alone when no repo-wide instructions are set", () => {
+    const result = resolveE2eTestGenInstructions(
+      reviewWith({ pathInstructions: [{ path: "src/checkout/**", instructions: "Always test the payment-failure retry path." }] }),
+      ["src/checkout/pay.ts"],
+    );
+    expect(result).toContain("Always test the payment-failure retry path.");
+  });
+
+  it("combines repo-wide and matching path instructions together", () => {
+    const result = resolveE2eTestGenInstructions(
+      reviewWith({
+        instructions: "Use Playwright with our page-object pattern.",
+        pathInstructions: [{ path: "src/checkout/**", instructions: "Always test the payment-failure retry path." }],
+      }),
+      ["src/checkout/pay.ts"],
+    );
+    expect(result).toContain("Use Playwright with our page-object pattern.");
+    expect(result).toContain("Always test the payment-failure retry path.");
+  });
+
+  it("omits a path instruction whose glob does not match any changed file", () => {
+    const result = resolveE2eTestGenInstructions(
+      reviewWith({
+        instructions: "Use Playwright.",
+        pathInstructions: [{ path: "src/checkout/**", instructions: "Payment-specific guidance." }],
+      }),
+      ["src/unrelated.ts"],
+    );
+    expect(result).toBe("Use Playwright.");
+    expect(result).not.toContain("Payment-specific guidance");
   });
 });
 


### PR DESCRIPTION
## Summary

- Investigated `#4200`'s original ask (a dedicated `review.e2eTestGeneration.instructions`/`pathInstructions` config block, CodeRabbit-`path_instructions`-style) against the current codebase, and found the codebase **already has** a fully general-purpose, working mechanism for exactly this: `review.instructions` (repo-wide brief) and `review.pathInstructions` (`{path, instructions}[]`), already parsed, validated, and fed into the AI reviewer's prompt today (`resolveReviewPathInstructions` in `src/signals/focus-manifest.ts`).
- Rather than inventing a second, e2e-test-gen-specific instructions schema that would duplicate this exact concept, this PR adds `resolveE2eTestGenInstructions` — a small pure function that combines the SAME existing `review.instructions` + matching `review.pathInstructions` entries into one instructions block for `E2eTestGenInput.instructions` (the field #4191/PR #4207 already built and wired to accept).
- **No new config schema, no new migration, no new OpenAPI field, no new glob-matching logic** — this is 100% reuse of already-shipped, already-documented config. A maintainer's repo conventions and path-scoped rules ("use Playwright with our page-object pattern," "always test the payment-failure retry path for `src/checkout/**`") apply equally well to steering an AI reviewer or an AI test generator, so both now draw from the same maintainer-authored brief, written once.
- Updated the doc comments on `pathInstructions`/`instructions` (engine package + both public/self-host `.gittensory.yml` examples) to note this second consumer, so a maintainer reading the existing docs knows their instructions now also steer test generation once that feature is enabled.

Closes #4200.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused — one new pure function, its tests, and doc-comment updates to the exact fields it reuses; no unrelated changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] Linked issue: Closes #4200 (part of epic #4189).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` (targeted at the changed files + the config-example drift tests) — **100% statements/branches/functions/lines** on the changed portion of `src/services/ai-e2e-test-gen.ts` (82/82 stmts, 76/76 branches, 9/9 funcs, 71/71 lines, confirmed via `--coverage.include`); `test/unit/config-templates.test.ts` (verifies `.gittensory.yml.example` ↔ `config/examples/gittensory.full.yml` byte-for-byte parity) and `test/unit/focus-manifest.test.ts` both still pass, confirming the doc updates didn't break the existing mirror check.
- [x] `npm run docs:drift-check` — clean, no new env vars introduced.
- [x] `npm audit --audit-level=moderate` — N/A, no dependency changes (not re-run this PR; nothing in `package.json`/lockfiles touched).
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — 6 new tests: nothing configured (null), null/undefined review config tolerated, repo-wide alone, path-instructions alone, both combined, and a non-matching glob correctly omitted.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise — N/A directly (this reuses the EXISTING `parsePublicSafeText`-validated fields verbatim; no new text-handling path).
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no auth/session/CORS surface touched.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed — N/A, no new API/OpenAPI/MCP surface (reuses existing fields as-is).
- [x] UI changes use live API data or real empty/error/loading states — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section — N/A, no UI changes.
- [x] Public docs/changelogs are updated where needed (doc comments + both `.gittensory.yml` examples updated to note the new consumer); `CHANGELOG.md` itself is untouched.

## Notes

- This is a legitimate scope simplification from #4200's originally-filed text (which assumed a new config block was needed) — implementation revealed the codebase already had a general-purpose mechanism covering the same need, so building a parallel one would have been a needless duplicate abstraction.
- Still dead code from the deployment's perspective until a future PR in the epic (#4194/#4195, dispatch + the `@gittensory generate-tests` command) actually calls `runGittensoryE2eTestGeneration` with a resolved `instructions` value.
