### PR TITLE
feat(mcp): add gittensory_get_gate_precision measurement tool

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -88,6 +88,7 @@ import { loadOrComputeBurdenForecastResponse } from "../services/burden-forecast
 import { buildMcpClientTelemetry } from "../services/client-telemetry";
 import { loadOrComputeRepoOutcomePatternsResponse } from "../services/repo-outcome-patterns";
 import { buildRepoOutcomeCalibration, outcomeCalibrationSummary } from "../services/outcome-calibration";
+import { loadGatePrecisionReport } from "../services/gate-precision";
 import { computeFleetAnalytics } from "../orb/analytics";
 import { loadMaintainerNoiseReport, maintainerNoiseSummary } from "../services/maintainer-noise";
 import { loadLabelAudit, labelAuditSummary } from "../services/label-audit";
@@ -742,6 +743,16 @@ const maintainerMeasurementReportOutputSchema = {
   status: z.string().optional(),
 };
 
+const gatePrecisionReportOutputSchema = {
+  repoFullName: z.string().optional(),
+  generatedAt: z.string().optional(),
+  windowDays: z.number().nullable().optional(),
+  perGateType: z.array(z.unknown()).optional(),
+  overall: z.unknown().optional(),
+  signals: z.array(z.string()).optional(),
+  status: z.string().optional(),
+};
+
 const contributorProfileOutputSchema = {
   login: z.string().optional(),
   github: z.unknown().optional(),
@@ -1288,6 +1299,17 @@ export class GittensoryMcp {
         outputSchema: maintainerMeasurementReportOutputSchema,
       },
       async (input) => this.toolResult(await this.getOutcomeCalibration(input)),
+    );
+
+    server.registerTool(
+      "gittensory_get_gate_precision",
+      {
+        description:
+          "Return gate-precision measurement for a repo: per-gate-type block counts, blocked-then-merged false positives, and the overall gate false-positive rate. Maintainer-authenticated; measurement only.",
+        inputSchema: ownerRepoWindowShape,
+        outputSchema: gatePrecisionReportOutputSchema,
+      },
+      async (input) => this.toolResult(await this.getGatePrecision(input)),
     );
 
     server.registerTool(
@@ -2338,6 +2360,16 @@ export class GittensoryMcp {
     const report = await buildRepoOutcomeCalibration(this.env, fullName, input.windowDays);
     return {
       summary: outcomeCalibrationSummary(fullName, report.slop),
+      data: report as unknown as Record<string, unknown>,
+    };
+  }
+
+  private async getGatePrecision(input: { owner: string; repo: string; windowDays?: number | undefined }): Promise<ToolPayload> {
+    const fullName = `${input.owner}/${input.repo}`;
+    await this.requireRepoAccess(fullName);
+    const report = await loadGatePrecisionReport(this.env, fullName, input.windowDays !== undefined ? { windowDays: input.windowDays } : {});
+    return {
+      summary: `Gate precision for ${fullName} over ${report.windowDays ?? "all"} day(s): ${report.overall.blocked} block(s), ${report.overall.blockedThenMerged} later merged.`,
       data: report as unknown as Record<string, unknown>,
     };
   }

--- a/test/unit/mcp-gate-precision.test.ts
+++ b/test/unit/mcp-gate-precision.test.ts
@@ -1,0 +1,63 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { describe, expect, it } from "vitest";
+import { createSessionForGitHubUser, type AuthIdentity } from "../../src/auth/security";
+import { GittensoryMcp } from "../../src/mcp/server";
+import { recordGateBlockOutcome, upsertPullRequestFromGitHub } from "../../src/db/repositories";
+import { createTestEnv } from "../helpers/d1";
+
+async function connect(env: Env, identity?: AuthIdentity): Promise<Client> {
+  const server = (identity ? new GittensoryMcp(env, identity) : new GittensoryMcp(env)).createServer();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  const client = new Client({ name: "gate-precision-test", version: "0.1.0" }, { capabilities: {} });
+  await client.connect(clientTransport);
+  return client;
+}
+
+describe("gittensory_get_gate_precision MCP tool", () => {
+  it("returns the gate-precision report for a trusted identity, honoring windowDays and surfacing a blocked-then-merged false positive", async () => {
+    const env = createTestEnv();
+    // One PR blocked, then merged anyway → a gate false positive within the window.
+    await recordGateBlockOutcome(env, { repoFullName: "owner/repo", pullNumber: 1, headSha: "sha1", blockerCodes: ["slop_risk"] });
+    await upsertPullRequestFromGitHub(env, "owner/repo", { number: 1, title: "merged", state: "closed", user: { login: "alice" }, merged_at: "2026-06-01T00:00:00.000Z" });
+
+    const result = await (await connect(env)).callTool({ name: "gittensory_get_gate_precision", arguments: { owner: "owner", repo: "repo", windowDays: 30 } });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as {
+      repoFullName: string;
+      windowDays: number | null;
+      overall: { blocked: number; blockedThenMerged: number };
+      perGateType: unknown[];
+    };
+    expect(data.repoFullName).toBe("owner/repo");
+    expect(data.windowDays).toBe(30);
+    expect(data.overall).toMatchObject({ blocked: 1, blockedThenMerged: 1 });
+    expect(Array.isArray(data.perGateType)).toBe(true);
+    // windowDays present ⇒ the "over 30 day(s)" summary arm.
+    expect(JSON.stringify(result.content)).toContain("over 30 day(s)");
+    // Public-safe by construction: no private scoring terms leak through the tool payload.
+    expect(JSON.stringify(result)).not.toMatch(/reward|payout|trust score|wallet|hotkey/i);
+  });
+
+  it("returns a zeroed all-time report when windowDays is omitted (empty window, null-window summary arm)", async () => {
+    const result = await (await connect(createTestEnv())).callTool({ name: "gittensory_get_gate_precision", arguments: { owner: "owner", repo: "repo" } });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as { windowDays: number | null; overall: { blocked: number; blockedThenMerged: number } };
+    // windowDays omitted ⇒ loadGatePrecisionReport's `?? null` ⇒ the "over all day(s)" summary arm.
+    expect(data.windowDays).toBeNull();
+    expect(data.overall).toMatchObject({ blocked: 0, blockedThenMerged: 0 });
+    expect(JSON.stringify(result.content)).toContain("over all day(s)");
+  });
+
+  it("forbids a session identity that cannot access the repository", async () => {
+    const env = createTestEnv();
+    const { session } = await createSessionForGitHubUser(env, { login: "rando", id: 2 });
+    const result = await (await connect(env, { kind: "session", actor: "rando", session })).callTool({
+      name: "gittensory_get_gate_precision",
+      arguments: { owner: "owner", repo: "repo" },
+    });
+    expect(result.isError).toBeTruthy();
+    expect(JSON.stringify(result.content)).toMatch(/cannot access this repository/i);
+  });
+});


### PR DESCRIPTION
## Summary

Surface the existing gate-precision report as a maintainer-authenticated MCP tool, `gittensory_get_gate_precision`. Agents can already ask "how is my outcome calibration?" over MCP via `gittensory_get_outcome_calibration`; this adds the sibling "how accurate is my gate?" question, reading the same gate-precision ledger the HTTP route already exposes.

The tool is a thin, additive wrapper — it mirrors `gittensory_get_outcome_calibration` exactly:
- `inputSchema: ownerRepoWindowShape` (owner / repo / optional `windowDays`)
- the same `requireRepoAccess` maintainer authorization guard
- calls the existing `loadGatePrecisionReport(env, repoFullName, { windowDays })` — **no new DB reads**
- a zod `outputSchema` for the `GatePrecisionReport` shape, mirroring the `maintainerMeasurementReportOutputSchema` pattern

Measurement only; the response flows through the existing `redactSensitiveForMcp` scrub, so no private scoring terms can leak.

## Scope

- [x] Narrow, one coherent change — a single new MCP tool + its handler and output schema
- [x] In scope (`src/`), no `blockedPaths`, no secrets/private terms
- [x] No API route, OpenAPI, migration, or wrangler-binding changes (nothing to regenerate)

## Validation

- [x] `npm run typecheck`
- [x] `npm run test:coverage` (full unsharded suite)
- [x] New unit test `test/unit/mcp-gate-precision.test.ts`: authorized path (honors `windowDays`, surfaces a blocked-then-merged false positive), empty-window path (null-window summary arm), and unauthorized-session path
- [x] Every changed line and branch covered (both arms of the `windowDays ?? "all"` summary fallback and the access guard)

## Safety

- [x] Maintainer-authenticated via the same `requireRepoAccess` guard as the sibling tool; negative-path (unauthorized session) test included
- [x] No secrets, tokens, wallets, trust scores, or reward values in code, tests, or this description; output is scrubbed by `redactSensitiveForMcp` and asserted free of financial keys

Closes #2220
