### PR TITLE
feat(mcp-cli): register gittensory_get_upstream_drift stdio proxy tool

### DIFF
--- a/packages/gittensory-mcp/bin/gittensory-mcp.js
+++ b/packages/gittensory-mcp/bin/gittensory-mcp.js
@@ -509,6 +509,15 @@ server.registerTool(
 );
 
 server.registerTool(
+  "gittensory_get_upstream_drift",
+  {
+    description: "Return the latest cached Gittensor upstream ruleset drift status (stale/drift warnings) for MCP planning.",
+    inputSchema: {},
+  },
+  async () => toolResult("Gittensory upstream drift status.", await apiGet("/v1/upstream/drift")),
+);
+
+server.registerTool(
   "gittensory_preview_local_pr_score",
   {
     description: "Inspect local diff metadata and request a private Gittensory scoring preview. No source contents are uploaded.",

--- a/test/unit/mcp-cli-upstream-drift.test.ts
+++ b/test/unit/mcp-cli-upstream-drift.test.ts
@@ -1,0 +1,71 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { closeFixtureServer, startFixtureServer } from "./support/mcp-cli-harness";
+
+const bin = join(process.cwd(), "packages/gittensory-mcp/bin/gittensory-mcp.js");
+const FORBIDDEN_PUBLIC_TERMS = /wallet\s*[:=]\s*\S+|hotkey\s*[:=]\s*\S+|coldkey\s*[:=]\s*\S+|raw trust score is|your trust score|reward estimate is|estimated reward/i;
+
+let client: Client;
+let transport: StdioClientTransport;
+let configDir: string;
+let apiUrl: string;
+let capturedRequests: Array<{ url: string; method: string }>;
+
+async function connect() {
+  configDir = mkdtempSync(join(tmpdir(), "gittensory-upstream-drift-"));
+  capturedRequests = [];
+  apiUrl = await startFixtureServer({
+    onApiRequest: (request) => {
+      if (request.url && request.url.includes("/v1/upstream/drift")) {
+        capturedRequests.push({ url: request.url ?? "", method: request.method ?? "GET" });
+      }
+    },
+  });
+  transport = new StdioClientTransport({
+    command: "node",
+    args: [bin, "--stdio"],
+    env: {
+      ...process.env,
+      GITTENSORY_CONFIG_DIR: configDir,
+      GITTENSORY_API_URL: apiUrl,
+      GITTENSORY_TOKEN: "session-token",
+      GITTENSORY_API_TIMEOUT_MS: "5000",
+    },
+  });
+  client = new Client({ name: "upstream-drift-test", version: "0.0.1" });
+  await client.connect(transport);
+}
+
+async function disconnect() {
+  await client.close().catch(() => undefined);
+  await closeFixtureServer();
+  if (configDir) rmSync(configDir, { recursive: true, force: true });
+}
+
+describe("gittensory_get_upstream_drift stdio proxy", () => {
+  beforeEach(connect);
+  afterEach(disconnect);
+
+  it("registers the tool in the stdio server tool list", async () => {
+    const { tools } = await client.listTools();
+    expect(tools.map((t) => t.name)).toContain("gittensory_get_upstream_drift");
+  });
+
+  it("proxies the call to /v1/upstream/drift via apiGet and returns the payload", async () => {
+    const result = await client.callTool({ name: "gittensory_get_upstream_drift", arguments: {} });
+    expect(capturedRequests.length).toBe(1);
+    const captured = capturedRequests[0]!;
+    expect(captured.url).toContain("/v1/upstream/drift");
+    expect(captured.method).toBe("GET");
+    expect(result.isError).toBeFalsy();
+    const text = JSON.stringify(result);
+    expect(text).not.toMatch(FORBIDDEN_PUBLIC_TERMS);
+    expect(text).toContain("upstreamDrift");
+    expect(text).toContain("reports");
+    expect(text).toContain("gittensor-core");
+  });
+});

--- a/test/unit/support/mcp-cli-harness.ts
+++ b/test/unit/support/mcp-cli-harness.ts
@@ -317,6 +317,16 @@ export async function startFixtureServer(
       response.end(JSON.stringify({ repoFullName: "owner/repo", agentPaused: body.agentPaused === true, ...(body.autonomy ? { autonomy: body.autonomy } : {}) }));
       return;
     }
+    if (request.url === "/v1/upstream/drift" && request.method === "GET") {
+      response.end(
+        JSON.stringify({
+          generatedAt: "2026-05-30T00:00:00.000Z",
+          upstreamDrift: { status: "ok", ruleset: "gittensor-core", lastCheckedAt: "2026-05-30T00:00:00.000Z", warnings: [] },
+          reports: [{ id: "drift-1", severity: "info", summary: "no drift detected", detectedAt: "2026-05-30T00:00:00.000Z" }],
+        }),
+      );
+      return;
+    }
     response.statusCode = 404;
     response.end(JSON.stringify({ error: "not_found" }));
   });


### PR DESCRIPTION
## What

The hosted MCP server registers `gittensory_get_upstream_drift` (`src/mcp/server.ts`), but the stdio package (`packages/gittensory-mcp/bin/gittensory-mcp.js`) never registered it, so a locally-run stdio server could not serve the upstream ruleset drift status.

This adds the missing stdio tool proxying the public `GET /v1/upstream/drift` endpoint (`src/api/routes.ts`) via `apiGet`, mirroring the existing param-less `gittensory_get_registry_changes` proxy.

## Deliverables

- [x] Register `gittensory_get_upstream_drift` in the stdio bin proxying the upstream-drift endpoint via `apiGet`.
- [x] Local-status inventory: current `main` has no dangling reference to the tool, so no reconciliation is needed.
- [x] Subprocess stdio test asserting the tool is listed and returns the proxied payload (fixture route added to the MCP CLI harness).

Closes #2238