### PR TITLE
feat(mcp): add gittensory_simulate_open_pr_pressure MCP tool

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -148,6 +148,7 @@ import { buildRepoDataQuality } from "../signals/data-quality";
 import { PREFLIGHT_LIMITS } from "../signals/preflight-limits";
 import { SCENARIO_MAX_BRANCH_REF_CHARS, SCENARIO_MAX_LINKED_ISSUE_NUMBERS, SCENARIO_MAX_REPO_FULL_NAME_CHARS } from "../scenarios/input-model";
 import { loadUpstreamStatus } from "../upstream/ruleset";
+import { simulateOpenPrPressure, type OpenPrPressureInput } from "../services/open-pr-pressure-scenarios";
 
 type AppContext = Context<{ Bindings: Env }>;
 type ToolPayload = {
@@ -1082,6 +1083,26 @@ const explainReviewRiskOutputSchema = {
 const variantsOutputSchema = {
   variants: z.array(z.unknown()).optional(),
 };
+
+// #2224 - pure, read-only open-PR pressure simulator surfaced over MCP. queueHealth/roleContext use the same
+// permissive z.unknown() convention as the other engine-shaped MCP inputs (the simulator is the single source
+// of truth for their structure); the tool reveals nothing beyond a computation on the caller-supplied context.
+const simulateOpenPrPressureShape = {
+  repoFullName: z.string(),
+  generatedAt: z.string(),
+  queueHealth: z.unknown(),
+  roleContext: z.unknown(),
+  contributorOpenPrCount: z.number().optional(),
+};
+const simulateOpenPrPressureOutputSchema = {
+  repoFullName: z.string().optional(),
+  generatedAt: z.string().optional(),
+  lane: z.string().optional(),
+  queuePressure: z.string().optional(),
+  recommendedOption: z.string().optional(),
+  scenarios: z.array(z.unknown()).optional(),
+  summary: z.string().optional(),
+};
 const preflightCurrentBranchOutputSchema = {
   login: z.string().optional(),
   repoFullName: z.string().optional(),
@@ -1299,6 +1320,17 @@ export class GittensoryMcp {
         outputSchema: fleetAnalyticsOutputSchema,
       },
       async (input) => this.toolResult(await this.getFleetAnalytics(input)),
+    );
+
+    server.registerTool(
+      "gittensory_simulate_open_pr_pressure",
+      {
+        description:
+          "Simulate how opening another PR affects a repo's review-queue pressure: ranks the open-new-work / wait / clean-up-first strategy options for the supplied queue-health and role context. Deterministic, public-safe, and read-only - no repo access required and no GitHub writes.",
+        inputSchema: simulateOpenPrPressureShape,
+        outputSchema: simulateOpenPrPressureOutputSchema,
+      },
+      async (input) => this.toolResult(this.simulateOpenPrPressureTool(input)),
     );
 
     server.registerTool(
@@ -2339,6 +2371,18 @@ export class GittensoryMcp {
     return {
       summary: outcomeCalibrationSummary(fullName, report.slop),
       data: report as unknown as Record<string, unknown>,
+    };
+  }
+
+  // #2224 - surface the deterministic open-PR pressure simulator over MCP. Pure and read-only: the caller
+  // supplies all queue/role context, so nothing beyond a computation on that input is revealed and no repo
+  // access is required (mirrors gittensory_run_local_scorer). Output is already public-safe - every scenario
+  // line is scrubbed through sanitizePublicComment inside simulateOpenPrPressure.
+  private simulateOpenPrPressureTool(input: z.infer<z.ZodObject<typeof simulateOpenPrPressureShape>>): ToolPayload {
+    const simulation = simulateOpenPrPressure(input as unknown as OpenPrPressureInput);
+    return {
+      summary: simulation.summary,
+      data: simulation as unknown as Record<string, unknown>,
     };
   }
 

--- a/test/unit/mcp-output-schemas.test.ts
+++ b/test/unit/mcp-output-schemas.test.ts
@@ -33,6 +33,7 @@ const TOOLS_WITH_OUTPUT_SCHEMA = [
   "gittensory_local_status",
   "gittensory_remediation_plan",
   "gittensory_explain_score_breakdown",
+  "gittensory_simulate_open_pr_pressure",
 ];
 
 async function connectTestClient(env: Env = createTestEnv(), identity?: AuthIdentity) {

--- a/test/unit/mcp-simulate-open-pr-pressure.test.ts
+++ b/test/unit/mcp-simulate-open-pr-pressure.test.ts
@@ -1,0 +1,137 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { describe, expect, it } from "vitest";
+import { GittensoryMcp } from "../../src/mcp/server";
+import { createTestEnv } from "../helpers/d1";
+
+async function connect() {
+  const server = new GittensoryMcp(createTestEnv()).createServer();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  const client = new Client({ name: "gittensory-open-pr-pressure-test", version: "0.1.0" }, { capabilities: {} });
+  await client.connect(clientTransport);
+  return client;
+}
+
+function queueHealth(level: "low" | "medium" | "high" | "critical", overrides: { openIssues?: number; openPullRequests?: number; stalePullRequests?: number } = {}) {
+  return {
+    repoFullName: "acme/widgets",
+    generatedAt: "2026-07-08T00:00:00.000Z",
+    burdenScore: 0,
+    level,
+    summary: `Queue pressure is ${level}.`,
+    signals: {
+      openIssues: overrides.openIssues ?? 4,
+      openPullRequests: overrides.openPullRequests ?? 6,
+      unlinkedPullRequests: 0,
+      stalePullRequests: overrides.stalePullRequests ?? 0,
+      draftPullRequests: 0,
+      maintainerAuthoredPullRequests: 0,
+      collisionClusters: 0,
+      ageBuckets: { under7Days: 3, days7To30: 2, over30Days: 1 },
+      likelyReviewablePullRequests: 5,
+    },
+    findings: [],
+  };
+}
+
+type Scenario = { option: string; label: string; rank: number; recommended: boolean; facts: string[] };
+type Simulation = {
+  repoFullName: string;
+  generatedAt: string;
+  lane: string;
+  queuePressure: string;
+  recommendedOption: string;
+  scenarios: Scenario[];
+  summary: string;
+};
+
+describe("MCP gittensory_simulate_open_pr_pressure (#2224)", () => {
+  it("registers with an outputSchema and needs no repo access", async () => {
+    const client = await connect();
+    const { tools } = await client.listTools();
+    const tool = tools.find((t) => t.name === "gittensory_simulate_open_pr_pressure");
+    expect(tool).toBeDefined();
+    expect(tool?.outputSchema?.type).toBe("object");
+  });
+
+  it("recommends opening new work for a contributor with no open PRs under low pressure", async () => {
+    const client = await connect();
+    const result = await client.callTool({
+      name: "gittensory_simulate_open_pr_pressure",
+      arguments: {
+        repoFullName: "acme/widgets",
+        generatedAt: "2026-07-08T00:00:00.000Z",
+        queueHealth: queueHealth("low"),
+        roleContext: { maintainerLane: false },
+        contributorOpenPrCount: 0,
+      },
+    });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as Simulation;
+    expect(data.repoFullName).toBe("acme/widgets");
+    expect(data.lane).toBe("contributor");
+    expect(data.queuePressure).toBe("low");
+    expect(data.recommendedOption).toBe("open_new_work");
+    expect(data.scenarios).toHaveLength(3);
+    expect(data.scenarios[0]).toMatchObject({ option: "open_new_work", rank: 1, recommended: true });
+    expect(data.summary).toContain("contributor");
+    expect(JSON.stringify(data)).not.toMatch(/wallet|hotkey|coldkey|reward|payout|trust score/i);
+  });
+
+  it("recommends cleaning up first when a contributor already has open work under heavy pressure", async () => {
+    const client = await connect();
+    const result = await client.callTool({
+      name: "gittensory_simulate_open_pr_pressure",
+      arguments: {
+        repoFullName: "acme/widgets",
+        generatedAt: "2026-07-08T00:00:00.000Z",
+        queueHealth: queueHealth("high", { stalePullRequests: 2 }),
+        roleContext: { maintainerLane: false },
+        contributorOpenPrCount: 3,
+      },
+    });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as Simulation;
+    expect(data.queuePressure).toBe("high");
+    expect(data.recommendedOption).toBe("cleanup_first");
+    expect(data.scenarios.map((s) => s.option)).toEqual(["cleanup_first", "wait", "open_new_work"]);
+  });
+
+  it("ranks maintainer-lane authors separately", async () => {
+    const client = await connect();
+    const result = await client.callTool({
+      name: "gittensory_simulate_open_pr_pressure",
+      arguments: {
+        repoFullName: "acme/widgets",
+        generatedAt: "2026-07-08T00:00:00.000Z",
+        queueHealth: queueHealth("critical"),
+        roleContext: { maintainerLane: true },
+      },
+    });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as Simulation;
+    expect(data.lane).toBe("maintainer");
+    expect(data.recommendedOption).toBe("cleanup_first");
+    expect(data.summary).toContain("maintainer");
+  });
+
+  it("falls back to unknown pressure when queue health is unavailable", async () => {
+    const client = await connect();
+    const result = await client.callTool({
+      name: "gittensory_simulate_open_pr_pressure",
+      arguments: {
+        repoFullName: "acme/widgets",
+        generatedAt: "2026-07-08T00:00:00.000Z",
+        queueHealth: null,
+        roleContext: { maintainerLane: false },
+        contributorOpenPrCount: 0,
+      },
+    });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as Simulation;
+    expect(data.queuePressure).toBe("unknown");
+    expect(data.recommendedOption).toBe("wait");
+    expect(data.summary).toMatch(/conservative default|unavailable/i);
+  });
+});


### PR DESCRIPTION
Surface the deterministic `simulateOpenPrPressure` what-if simulator (`src/services/open-pr-pressure-scenarios.ts`) over MCP so a maintainer agent can ask how opening another PR would affect a repo review-queue pressure. It ranks the open-new-work / wait / clean-up-first strategy options for the supplied queue-health and role context.

The tool is pure and read-only: the caller supplies all queue/role context, so nothing beyond a computation on that input is revealed and no repo access is required (mirrors `gittensory_run_local_scorer`). Output is already public-safe -- every scenario line is scrubbed through `sanitizePublicComment` inside the simulator.

## Changes
- Register `gittensory_simulate_open_pr_pressure` in `src/mcp/server.ts` with input/output zod schemas. `queueHealth`/`roleContext` use the same permissive `z.unknown()` convention as the other engine-shaped MCP inputs (the simulator is the single source of truth for their structure).
- Add a small pass-through handler that calls `simulateOpenPrPressure` and returns the simulation.
- Tests exercising the contributor lane (open-new-work vs cleanup-first ranking), the maintainer lane, and the unknown-pressure fallback, plus the output-schema registry check.

Closes #2224
