### PR TITLE
feat(mcp-cli): add `maintain precision` subcommand for gate false-positive telemetry

### DIFF
--- a/packages/gittensory-mcp/bin/gittensory-mcp.js
+++ b/packages/gittensory-mcp/bin/gittensory-mcp.js
@@ -53,7 +53,7 @@ const CLI_COMMAND_SPEC = {
   profile: ["list", "create", "switch", "remove"],
   cache: ["status", "clear"],
   agent: ["plan", "status", "explain", "packet"],
-  maintain: ["status", "approve", "reject", "pause", "resume", "set-level"],
+  maintain: ["status", "approve", "reject", "pause", "resume", "set-level", "precision"],
 };
 const COMPLETION_SHELLS = ["bash", "zsh", "fish", "powershell"];
 const AGENT_PROFILE_IDS = ["miner-planner", "miner-auto-dev", "maintainer-triage", "repo-owner-intake"];
@@ -1410,6 +1410,7 @@ function printMaintainHelp() {
       "  set-level <action> <level>   Set the autonomy level for one action class.",
       `                               actions: ${MAINTAIN_ACTION_CLASSES.join(", ")}`,
       `                               levels:  ${MAINTAIN_AUTONOMY_LEVELS.join(", ")}`,
+      "  precision [--window-days N]  Show gate false-positive telemetry (blocked-then-merged per gate type).",
       "",
       "Pass --json for machine-readable output.",
     ].join("\n") + "\n",
@@ -1464,7 +1465,28 @@ async function maintainCli(args) {
     emit(payload, `Set ${action} autonomy to ${level} for ${repoFullName}.`);
     return;
   }
-  throw new Error(`Unknown maintain subcommand: ${subcommand}. Use status | approve <id> | reject <id> | pause | resume | set-level <action> <level>.`);
+  if (subcommand === "precision") {
+    // #554 gate false-positive telemetry: read-only measurement of blocked-then-merged PRs per gate type.
+    // The API enforces maintainer authorization; the CLI never decides locally. Optional --window-days bounds
+    // the block ledger the same way the route's ?windowDays query does (a non-positive value falls through to
+    // full history server-side).
+    const windowDays = Number(options.windowDays);
+    const query = windowDays > 0 ? `?windowDays=${encodeURIComponent(windowDays)}` : "";
+    const payload = await apiGet(`${repoBase}/gate-precision${query}`);
+    const overall = payload.overall ?? {};
+    const window = payload.windowDays ? `last ${payload.windowDays}d` : "all history";
+    const rate = (value) => (value === null || value === undefined ? "n/a (below sample)" : `${Math.round(value * 100)}%`);
+    const lines = [
+      `Gate precision for ${repoFullName} (${window}): ${overall.blocked ?? 0} blocked, ${overall.blockedThenMerged ?? 0} blocked-then-merged, false-positive rate ${rate(overall.falsePositiveRate)}.`,
+      ...(payload.perGateType ?? []).map(
+        (type) => `- ${type.gateType}: ${type.blocked} blocked, ${type.blockedThenMerged} merged anyway${type.falsePositiveRate === null ? "" : ` (${Math.round(type.falsePositiveRate * 100)}% FP)`}`,
+      ),
+      ...(payload.signals ?? []),
+    ];
+    emit(payload, lines.join("\n"));
+    return;
+  }
+  throw new Error(`Unknown maintain subcommand: ${subcommand}. Use status | approve <id> | reject <id> | pause | resume | set-level <action> <level> | precision.`);
 }
 
 async function runCli(args) {

--- a/test/unit/mcp-cli-basics.test.ts
+++ b/test/unit/mcp-cli-basics.test.ts
@@ -198,7 +198,7 @@ describe("gittensory-mcp CLI — basics", () => {
     expect(ps).toContain("Register-ArgumentCompleter -Native -CommandName gittensory-mcp");
     expect(ps).toContain("[System.Management.Automation.CompletionResult]::new");
     expect(ps).toContain("$commands = @('login', 'logout'");
-    expect(ps).toContain("'maintain' = @('status', 'approve', 'reject', 'pause', 'resume', 'set-level')");
+    expect(ps).toContain("'maintain' = @('status', 'approve', 'reject', 'pause', 'resume', 'set-level', 'precision')");
   });
 
   it("emits completion as machine-readable json", () => {

--- a/test/unit/mcp-cli-maintain.test.ts
+++ b/test/unit/mcp-cli-maintain.test.ts
@@ -49,6 +49,23 @@ describe("gittensory-mcp CLI — maintain (#784)", () => {
     expect(plain).toMatch(/Set merge autonomy to auto for owner\/repo/);
   });
 
+  it("precision reports gate false-positive telemetry (plain + json), passing the window through", async () => {
+    const e = await env();
+    const out = await runAsync(["maintain", "precision", "--repo", "owner/repo"], e);
+    expect(out).toMatch(/Gate precision for owner\/repo \(all history\): 11 blocked, 2 blocked-then-merged, false-positive rate 18%/);
+    expect(out).toMatch(/duplicate-pr: 8 blocked, 2 merged anyway \(25% FP\)/);
+    // A per-type rate of null (below sample) is rendered without an FP suffix.
+    expect(out).toMatch(/missing-linked-issue: 3 blocked, 0 merged anyway$/m);
+    expect(out).toMatch(/Highest false-positive gate: `duplicate-pr`/);
+    const json = JSON.parse(await runAsync(["maintain", "precision", "--repo", "owner/repo", "--json"], e)) as {
+      overall: { blocked: number; falsePositiveRate: number };
+    };
+    expect(json.overall).toMatchObject({ blocked: 11, falsePositiveRate: 0.182 });
+    // --window-days bounds the ledger; the CLI forwards it as ?windowDays and reflects it in the summary.
+    const scoped = await runAsync(["maintain", "precision", "--repo", "owner/repo", "--window-days", "30"], e);
+    expect(scoped).toMatch(/Gate precision for owner\/repo \(last 30d\)/);
+  });
+
   it("validates inputs: --repo required, id required for approve, known subcommand + action/level", async () => {
     const e = await env();
     await expect(runAsync(["maintain", "status"], e)).rejects.toThrow(/Pass --repo/);

--- a/test/unit/support/mcp-cli-harness.ts
+++ b/test/unit/support/mcp-cli-harness.ts
@@ -317,6 +317,24 @@ export async function startFixtureServer(
       response.end(JSON.stringify({ repoFullName: "owner/repo", agentPaused: body.agentPaused === true, ...(body.autonomy ? { autonomy: body.autonomy } : {}) }));
       return;
     }
+    // #554 gate precision telemetry (read-only). Echoes ?windowDays so the CLI window pass-through is testable.
+    if (request.url?.startsWith("/v1/repos/owner/repo/gate-precision") && request.method === "GET") {
+      const windowDays = new URL(request.url, "http://localhost").searchParams.get("windowDays");
+      response.end(
+        JSON.stringify({
+          repoFullName: "owner/repo",
+          generatedAt: "2026-05-30T00:00:00.000Z",
+          windowDays: windowDays ? Number(windowDays) : null,
+          perGateType: [
+            { gateType: "duplicate-pr", blocked: 8, blockedThenMerged: 2, overridden: 1, falsePositiveRate: 0.25 },
+            { gateType: "missing-linked-issue", blocked: 3, blockedThenMerged: 0, overridden: 0, falsePositiveRate: null },
+          ],
+          overall: { blocked: 11, blockedThenMerged: 2, falsePositiveRate: 0.182 },
+          signals: ["Highest false-positive gate: `duplicate-pr` — 25% of its 8 blocks merged anyway (1 overridden). Keep it advisory until this drops."],
+        }),
+      );
+      return;
+    }
     if (request.url === "/v1/upstream/drift" && request.method === "GET") {
       response.end(
         JSON.stringify({


### PR DESCRIPTION
## What

The published stdio CLI exposes maintainer subcommands (`maintainCli`: status / approve / reject / pause / resume / set-level) but no way to read **gate precision** — the blocked-then-merged false-positive telemetry a maintainer needs before promoting a gate to blocking.

This adds a `maintain precision` subcommand that proxies the existing `GET /v1/repos/:owner/:repo/gate-precision` route (`src/api/routes.ts`) via `apiGet`, mirroring the existing maintain-subcommand `emit()` / `--json` pattern. The API enforces maintainer authorization; the CLI never decides locally. Optional `--window-days N` is forwarded as `?windowDays` to bound the block ledger, exactly as the route already supports.

## Deliverables

- [x] Added a `precision` case to `maintainCli` calling `apiGet` against `${repoBase}/gate-precision` (with optional `--window-days` → `?windowDays`).
- [x] `emit()`s a human-readable summary (overall + per-gate-type false-positive rate + signals) and supports `--json` (follows the existing maintain-subcommand emit pattern).
- [x] Added `precision` to the `maintain` entry in `CLI_COMMAND_SPEC` so shell-completion picks it up.
- [x] Updated `printMaintainHelp()` usage text.
- [x] Added a subprocess-style CLI test (fixture route added to the MCP CLI harness) covering plain output, `--json`, per-type null-rate (below-sample) rendering, and `--window-days` pass-through.

Closes #2227
