### PR TITLE
feat(mcp): add gittensory_check_test_evidence MCP tool

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -149,6 +149,7 @@ import { PREFLIGHT_LIMITS } from "../signals/preflight-limits";
 import { SCENARIO_MAX_BRANCH_REF_CHARS, SCENARIO_MAX_LINKED_ISSUE_NUMBERS, SCENARIO_MAX_REPO_FULL_NAME_CHARS } from "../scenarios/input-model";
 import { loadUpstreamStatus } from "../upstream/ruleset";
 import { simulateOpenPrPressure, type OpenPrPressureInput } from "../services/open-pr-pressure-scenarios";
+import { buildTestEvidenceReport } from "../services/test-evidence-report";
 
 type AppContext = Context<{ Bindings: Env }>;
 type ToolPayload = {
@@ -1103,6 +1104,23 @@ const simulateOpenPrPressureOutputSchema = {
   scenarios: z.array(z.unknown()).optional(),
   summary: z.string().optional(),
 };
+
+// #2235 - deterministic, source-free test-evidence self-check. Plain path arrays (not opaque engine objects),
+// capped like the other path-list MCP inputs (suggestBoundaryTestsShape); the tool reveals nothing beyond a
+// computation on the caller's own changed-path metadata (no source content, no repo access).
+const checkTestEvidenceShape = {
+  changedPaths: z.array(z.string().max(400)).max(2000),
+  testFiles: z.array(z.string().max(400)).max(2000).optional(),
+};
+const checkTestEvidenceOutputSchema = {
+  coverageBand: z.string().optional(),
+  changedPathCount: z.number().optional(),
+  testPathCount: z.number().optional(),
+  hasCodeChanges: z.boolean().optional(),
+  hasTestEvidence: z.boolean().optional(),
+  guidance: z.string().optional(),
+  summary: z.string().optional(),
+};
 const preflightCurrentBranchOutputSchema = {
   login: z.string().optional(),
   repoFullName: z.string().optional(),
@@ -1331,6 +1349,17 @@ export class GittensoryMcp {
         outputSchema: simulateOpenPrPressureOutputSchema,
       },
       async (input) => this.toolResult(this.simulateOpenPrPressureTool(input)),
+    );
+
+    server.registerTool(
+      "gittensory_check_test_evidence",
+      {
+        description:
+          "Check whether a planned change carries enough test evidence, from changed-path metadata alone (paths + optional test paths; no source content) - an agent-native, source-free pre-submission self-check. Returns the coverage band (strong/adequate/weak/absent) plus actionable guidance. Deterministic and read-only - no repo access required and no GitHub writes.",
+        inputSchema: checkTestEvidenceShape,
+        outputSchema: checkTestEvidenceOutputSchema,
+      },
+      async (input) => this.toolResult(this.checkTestEvidence(input)),
     );
 
     server.registerTool(
@@ -2383,6 +2412,17 @@ export class GittensoryMcp {
     return {
       summary: simulation.summary,
       data: simulation as unknown as Record<string, unknown>,
+    };
+  }
+
+  // #2235 - surface the deterministic test-evidence classifier over MCP. Pure and read-only: the caller supplies
+  // the changed-path metadata, so nothing beyond a computation on that input is revealed and no repo access is
+  // required (mirrors gittensory_run_local_scorer / gittensory_check_slop_risk). Report is branchless, path-only.
+  private checkTestEvidence(input: z.infer<z.ZodObject<typeof checkTestEvidenceShape>>): ToolPayload {
+    const report = buildTestEvidenceReport(input.changedPaths, input.testFiles);
+    return {
+      summary: report.summary,
+      data: report as unknown as Record<string, unknown>,
     };
   }
 

--- a/src/services/test-evidence-report.ts
+++ b/src/services/test-evidence-report.ts
@@ -1,0 +1,68 @@
+import {
+  classifyTestCoverage,
+  hasLocalTestEvidence,
+  isCodeFile,
+  isTestPath,
+  type TestCoverageClassification,
+} from "../signals/test-evidence";
+
+/**
+ * Deterministic, source-free test-evidence self-check (#2235). Surfaces the engine's
+ * changed-path -> coverage classifier (src/signals/test-evidence.ts) as a structured report an
+ * agent can consult BEFORE opening a PR: "do my changed files carry enough test evidence?".
+ *
+ * Pure and read-only: it computes solely over the caller-supplied path metadata (no source
+ * content, no repo access, no env). Branchless by construction so the MCP handler that wraps it
+ * stays trivially patch-coverable.
+ */
+export type TestEvidenceReport = {
+  /** Coarse coverage band from the shared classifier: strong | adequate | weak | absent. */
+  coverageBand: TestCoverageClassification;
+  /** Number of changed paths supplied. */
+  changedPathCount: number;
+  /** How many of the changed paths are themselves test files. */
+  testPathCount: number;
+  /** Whether any changed path is hand-authored program source (i.e. tests may be expected). */
+  hasCodeChanges: boolean;
+  /** Whether any local test evidence was supplied (changed test files or explicit test paths). */
+  hasTestEvidence: boolean;
+  /** One actionable, public-safe guidance line keyed off the coverage band. */
+  guidance: string;
+  /** One-sentence public-safe summary. */
+  summary: string;
+};
+
+// Total map over every TestCoverageClassification value, so the report builder needs no branch to
+// select guidance (a missing key would be a compile error via the Record type).
+const TEST_EVIDENCE_GUIDANCE: Record<TestCoverageClassification, string> = {
+  strong:
+    "Strong test coverage accompanies this change - no additional tests are required for the coverage gate.",
+  adequate:
+    "Test coverage is adequate - consider one more case for the primary changed path to strengthen the diff.",
+  weak: "Test coverage is weak relative to the changed surface - add tests for the untested code paths to clear the coverage gate.",
+  absent:
+    "No test files are present in the changed set - add at least one test exercising the changed code before opening the PR.",
+};
+
+/**
+ * Build the structured test-evidence report for a set of changed paths and optional explicit test
+ * paths. Deterministic and branchless: delegates every classification decision to the shared
+ * (already-tested) engine classifiers so this layer only assembles their results.
+ */
+export function buildTestEvidenceReport(changedPaths: string[], testFiles?: string[]): TestEvidenceReport {
+  const coverageBand = classifyTestCoverage(changedPaths);
+  const testPathCount = changedPaths.filter(isTestPath).length;
+  const hasCodeChanges = changedPaths.some(isCodeFile);
+  // Evidence if the caller flagged explicit test paths (`tests`) OR any changed path is itself a test file
+  // (`testFiles` is filtered through isTestPath inside the classifier). Mirrors buildBoundaryTestGenerationFinding.
+  const hasTestEvidence = hasLocalTestEvidence({ tests: testFiles, testFiles: changedPaths });
+  return {
+    coverageBand,
+    changedPathCount: changedPaths.length,
+    testPathCount,
+    hasCodeChanges,
+    hasTestEvidence,
+    guidance: TEST_EVIDENCE_GUIDANCE[coverageBand],
+    summary: `Test-evidence check: ${coverageBand} coverage across ${changedPaths.length} changed path(s), ${testPathCount} test file(s).`,
+  };
+}

--- a/test/unit/mcp-check-test-evidence.test.ts
+++ b/test/unit/mcp-check-test-evidence.test.ts
@@ -1,0 +1,97 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { describe, expect, it } from "vitest";
+import { GittensoryMcp } from "../../src/mcp/server";
+import { createTestEnv } from "../helpers/d1";
+
+async function connect() {
+  const server = new GittensoryMcp(createTestEnv()).createServer();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  const client = new Client({ name: "gittensory-check-test-evidence-test", version: "0.1.0" }, { capabilities: {} });
+  await client.connect(clientTransport);
+  return client;
+}
+
+type TestEvidenceReport = {
+  coverageBand: "strong" | "adequate" | "weak" | "absent";
+  changedPathCount: number;
+  testPathCount: number;
+  hasCodeChanges: boolean;
+  hasTestEvidence: boolean;
+  guidance: string;
+  summary: string;
+};
+
+async function check(args: { changedPaths: string[]; testFiles?: string[] }) {
+  const client = await connect();
+  const result = await client.callTool({ name: "gittensory_check_test_evidence", arguments: args });
+  expect(result.isError).toBeFalsy();
+  return result.structuredContent as TestEvidenceReport;
+}
+
+describe("MCP gittensory_check_test_evidence (#2235)", () => {
+  it("registers with an outputSchema and needs no repo access", async () => {
+    const client = await connect();
+    const { tools } = await client.listTools();
+    const tool = tools.find((t) => t.name === "gittensory_check_test_evidence");
+    expect(tool).toBeDefined();
+    expect(tool?.outputSchema?.type).toBe("object");
+  });
+
+  it("reports absent coverage for a code-only diff with no tests", async () => {
+    const data = await check({ changedPaths: ["src/foo.ts", "src/bar.ts"] });
+    expect(data.coverageBand).toBe("absent");
+    expect(data.changedPathCount).toBe(2);
+    expect(data.testPathCount).toBe(0);
+    expect(data.hasCodeChanges).toBe(true);
+    expect(data.hasTestEvidence).toBe(false);
+    expect(data.guidance).toMatch(/add at least one test/i);
+    expect(data.summary).toContain("absent");
+    expect(JSON.stringify(data)).not.toMatch(/wallet|hotkey|coldkey|reward|payout|trust score/i);
+  });
+
+  it("reports absent coverage but no code changes for a docs-only diff", async () => {
+    const data = await check({ changedPaths: ["README.md", "docs/guide.md"] });
+    expect(data.coverageBand).toBe("absent");
+    expect(data.hasCodeChanges).toBe(false);
+    expect(data.hasTestEvidence).toBe(false);
+  });
+
+  it("reports strong coverage for a balanced code+tests diff", async () => {
+    const data = await check({ changedPaths: ["src/foo.ts", "src/foo.test.ts"] });
+    expect(data.coverageBand).toBe("strong");
+    expect(data.testPathCount).toBe(1);
+    expect(data.hasCodeChanges).toBe(true);
+    expect(data.hasTestEvidence).toBe(true);
+    expect(data.guidance).toMatch(/no additional tests/i);
+  });
+
+  it("classifies the adequate and weak threshold bands from the changed-path ratio", async () => {
+    const adequate = await check({ changedPaths: ["src/a.ts", "src/b.ts", "src/c.ts", "src/a.test.ts"] });
+    expect(adequate.coverageBand).toBe("adequate");
+
+    const weak = await check({
+      changedPaths: [
+        "src/a.ts",
+        "src/b.ts",
+        "src/c.ts",
+        "src/d.ts",
+        "src/e.ts",
+        "src/f.ts",
+        "src/g.ts",
+        "src/h.ts",
+        "src/i.ts",
+        "src/a.test.ts",
+      ],
+    });
+    expect(weak.coverageBand).toBe("weak");
+    expect(weak.guidance).toMatch(/weak/i);
+  });
+
+  it("recognizes explicit test paths as local test evidence even when the changed set has none", async () => {
+    const data = await check({ changedPaths: ["src/foo.ts"], testFiles: ["test/foo.test.ts"] });
+    expect(data.hasCodeChanges).toBe(true);
+    expect(data.hasTestEvidence).toBe(true);
+  });
+});

--- a/test/unit/mcp-output-schemas.test.ts
+++ b/test/unit/mcp-output-schemas.test.ts
@@ -34,6 +34,7 @@ const TOOLS_WITH_OUTPUT_SCHEMA = [
   "gittensory_remediation_plan",
   "gittensory_explain_score_breakdown",
   "gittensory_simulate_open_pr_pressure",
+  "gittensory_check_test_evidence",
 ];
 
 async function connectTestClient(env: Env = createTestEnv(), identity?: AuthIdentity) {


### PR DESCRIPTION
Surfaces the deterministic changed-path -> test-coverage classifier (`src/signals/test-evidence.ts`) as a standalone, source-free MCP tool so an agent can ask "do my changed files carry enough test evidence?" before opening a PR.

Pure and read-only: the handler computes only over caller-supplied path metadata (no source content, no repo access, no env). It returns the coverage band (strong/adequate/weak/absent), path/test counts, code-change + test-evidence flags, and one actionable guidance line.

- Adds `gittensory_check_test_evidence` in `src/mcp/server.ts` (branchless pass-through) with input/output zod schemas, registered in `TOOLS_WITH_OUTPUT_SCHEMA`.
- New pure builder `src/services/test-evidence-report.ts` delegating to the shared engine classifiers (`classifyTestCoverage`, `isTestPath`, `isCodeFile`, `hasLocalTestEvidence`).
- Tests cover code-only-no-tests, docs-only, balanced code+tests, adequate/weak threshold bands, and explicit test-path evidence.

Closes #2235