### PR TITLE
feat(mcp-cli): add maintain queue to list pending actions

### DIFF
--- a/packages/gittensory-mcp/bin/gittensory-mcp.js
+++ b/packages/gittensory-mcp/bin/gittensory-mcp.js
@@ -54,7 +54,7 @@ const CLI_COMMAND_SPEC = {
   profile: ["list", "create", "switch", "remove"],
   cache: ["status", "clear"],
   agent: ["plan", "status", "explain", "packet"],
-  maintain: ["status", "approve", "reject", "pause", "resume", "set-level", "precision"],
+  maintain: ["status", "queue", "approve", "reject", "pause", "resume", "set-level", "precision"],
 };
 const COMPLETION_SHELLS = ["bash", "zsh", "fish", "powershell"];
 const AGENT_PROFILE_IDS = ["miner-planner", "miner-auto-dev", "maintainer-triage", "repo-owner-intake"];
@@ -1535,6 +1535,7 @@ function printMaintainHelp() {
       "",
       "Subcommands:",
       "  status                       List the agent approval queue (auto_with_approval actions awaiting a decision).",
+      "  queue                        List pending actions (id, kind, target) for approve/reject. Alias: pending.",
       "  approve <id>                 Approve a staged action -> execute it.",
       "  reject <id>                  Reject a staged action -> cancel it.",
       "  pause                        Pause ALL agent actions on the repo (kill-switch).",
@@ -1569,6 +1570,24 @@ async function maintainCli(args) {
     const payload = await apiGet(queueBase);
     const actions = payload.pendingActions ?? [];
     emit(payload, [`Agent approval queue for ${repoFullName}: ${actions.length} pending.`, ...actions.map((action) => `- ${action.id}  ${action.actionClass} on #${action.pullNumber}  ${action.reason ?? ""}`)].join("\n"));
+    return;
+  }
+  // #2236 — explicit queue listing so maintainers can discover ids for approve/reject (alias: pending).
+  if (subcommand === "queue" || subcommand === "pending") {
+    const payload = await apiGet(queueBase);
+    const actions = payload.pendingActions ?? [];
+    emit(
+      payload,
+      [
+        `Pending agent actions for ${repoFullName}: ${actions.length}.`,
+        ...actions.map((action) => {
+          const kind = action.actionClass ?? action.kind ?? "unknown";
+          const target = action.pullNumber != null ? `#${action.pullNumber}` : (action.target ?? "—");
+          const summary = action.reason ?? action.summary ?? "";
+          return `- ${action.id}  ${kind}  ${target}${summary ? `  ${summary}` : ""}`;
+        }),
+      ].join("\n"),
+    );
     return;
   }
   if (subcommand === "approve" || subcommand === "reject") {
@@ -1618,7 +1637,7 @@ async function maintainCli(args) {
     emit(payload, lines.join("\n"));
     return;
   }
-  throw new Error(`Unknown maintain subcommand: ${subcommand}. Use status | approve <id> | reject <id> | pause | resume | set-level <action> <level> | precision.`);
+  throw new Error(`Unknown maintain subcommand: ${subcommand}. Use status | queue | approve <id> | reject <id> | pause | resume | set-level <action> <level> | precision.`);
 }
 
 async function runCli(args) {

--- a/test/unit/mcp-cli-basics.test.ts
+++ b/test/unit/mcp-cli-basics.test.ts
@@ -200,7 +200,7 @@ describe("gittensory-mcp CLI — basics", () => {
     expect(ps).toContain("Register-ArgumentCompleter -Native -CommandName gittensory-mcp");
     expect(ps).toContain("[System.Management.Automation.CompletionResult]::new");
     expect(ps).toContain("$commands = @('login', 'logout'");
-    expect(ps).toContain("'maintain' = @('status', 'approve', 'reject', 'pause', 'resume', 'set-level', 'precision')");
+    expect(ps).toContain("'maintain' = @('status', 'queue', 'approve', 'reject', 'pause', 'resume', 'set-level', 'precision')");
   });
 
   it("emits completion as machine-readable json", () => {

--- a/test/unit/mcp-cli-maintain.test.ts
+++ b/test/unit/mcp-cli-maintain.test.ts
@@ -28,6 +28,22 @@ describe("gittensory-mcp CLI — maintain (#784)", () => {
     expect(json.pendingActions[0]).toMatchObject({ id: "pa-1", actionClass: "merge" });
   });
 
+  it("queue lists pending action ids that maintain approve can consume (#2236)", async () => {
+    const e = await env();
+    const plain = await runAsync(["maintain", "queue", "--repo", "owner/repo"], e);
+    expect(plain).toMatch(/Pending agent actions for owner\/repo: 1\./);
+    expect(plain).toMatch(/pa-1\s+merge\s+#7\s+clean/);
+    const payload = JSON.parse(await runAsync(["maintain", "pending", "--repo", "owner/repo", "--json"], e)) as {
+      pendingActions: Array<{ id: string; actionClass: string; pullNumber: number }>;
+    };
+    expect(payload.pendingActions).toHaveLength(1);
+    expect(payload.pendingActions[0]).toMatchObject({ id: "pa-1", actionClass: "merge", pullNumber: 7 });
+    expect(plain).toContain(payload.pendingActions[0]!.id);
+    expect(await runAsync(["maintain", "approve", payload.pendingActions[0]!.id, "--repo", "owner/repo"], e)).toMatch(
+      /Accepted pa-1: accepted \(completed\)/,
+    );
+  });
+
   it("approve executes a staged action; reject cancels one", async () => {
     const e = await env();
     expect(await runAsync(["maintain", "approve", "pa-1", "--repo", "owner/repo"], e)).toMatch(/Accepted pa-1: accepted \(completed\)/);
@@ -81,6 +97,7 @@ describe("gittensory-mcp CLI — maintain (#784)", () => {
     const out = await runAsync(["maintain"], e);
     expect(out).toMatch(/Usage: gittensory-mcp maintain/);
     expect(out).toMatch(/approve <id>/);
+    expect(out).toMatch(/queue/);
     expect(out).toMatch(/pause/);
   });
 });


### PR DESCRIPTION
## Summary

- Add `gittensory-mcp maintain queue` (alias `pending`) to list pending agent actions (`id`, kind, target/summary) via the existing `/agent/pending-actions` endpoint, so maintainers can discover ids for `approve`/`reject`.
- Wire `queue` into `CLI_COMMAND_SPEC`, `printMaintainHelp()`, and the unknown-subcommand hint; support `--json` through the shared `emit()` path.
- CLI test asserts `queue`/`pending` listing returns ids that `maintain approve <id>` can consume.

Closes #2236.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [x] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- MCP-CLI-only change under `packages/gittensory-mcp/**` + `test/unit/mcp-cli-*.test.ts` (Codecov ignores `packages/**` and `test/**`). Ran `mcp-cli-maintain` + `mcp-cli-basics` and `npm run build:mcp`. Remaining full-gate jobs left to CI path filters / `validate`.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — CLI/MCP packaging change only; no visible UI.

## Notes

-
