### PR TITLE
feat(mcp-cli): add `--format ndjson` streaming output for list-shaped commands

### DIFF
--- a/packages/gittensory-mcp/bin/gittensory-mcp.js
+++ b/packages/gittensory-mcp/bin/gittensory-mcp.js
@@ -2002,8 +2002,8 @@ function runCacheCli(args) {
   }
   if (subcommand === "list" || subcommand === "ls") {
     const payload = listDecisionPackCache();
-    if (options.json) process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
-    else if (payload.count === 0) process.stdout.write("Decision-pack cache is empty.\n");
+    if (emitList(options, payload.entries, payload)) return;
+    if (payload.count === 0) process.stdout.write("Decision-pack cache is empty.\n");
     else for (const entry of payload.entries) process.stdout.write(`- ${entry.login ?? "unknown"} (cached ${entry.cachedAt ?? "unknown"}, ${entry.bytes} bytes)\n`);
     return;
   }
@@ -2380,7 +2380,7 @@ function printHelp() {
 function printCacheHelp() {
   process.stdout.write(`Usage:
   gittensory-mcp cache status [--json]
-  gittensory-mcp cache list [--json]
+  gittensory-mcp cache list [--json | --format ndjson]
   gittensory-mcp cache clear [--json]
 
 Decision-pack cache entries are local-only stale fallbacks for temporary API/network outages.
@@ -2402,7 +2402,7 @@ Source upload remains disabled.
 
 function printProfileHelp() {
   process.stdout.write(`Usage:
-  gittensory-mcp profile list [--json]
+  gittensory-mcp profile list [--json | --format ndjson]
   gittensory-mcp profile create <name> [--json]
   gittensory-mcp profile switch <name> [--json]
   gittensory-mcp profile remove <name> [--json]
@@ -2432,6 +2432,22 @@ function parseOptions(args) {
     else options[key] = value;
   }
   return options;
+}
+
+// Shared machine-readable output for list-shaped commands. `--format ndjson` streams one JSON object per
+// array element per line (for piping into jq/log processors); `--json` (or `--format json`) keeps the
+// existing pretty object. Returns true when it emitted a machine-readable format, so the caller skips the
+// human view. Each record ends in "\n" and Node flushes stdout on exit, so piped output is not truncated.
+function emitList(options, items, pretty) {
+  if (options.format === "ndjson") {
+    for (const item of items) process.stdout.write(`${JSON.stringify(item)}\n`);
+    return true;
+  }
+  if (options.json || options.format === "json") {
+    process.stdout.write(`${JSON.stringify(pretty, null, 2)}\n`);
+    return true;
+  }
+  return false;
 }
 
 async function login(options) {
@@ -2499,12 +2515,10 @@ function profileCommand(args) {
   if (subcommand === "list" || subcommand === "ls") {
     const profiles = profileList(config);
     const payload = { activeProfile: activeProfileName, profiles };
-    if (options.json) process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
-    else {
-      process.stdout.write(`Active profile: ${activeProfileName}\n`);
-      for (const profile of profiles) {
-        process.stdout.write(`- ${profile.name}${profile.active ? " (active)" : ""}: ${profile.login ?? "not authenticated"}\n`);
-      }
+    if (emitList(options, profiles, payload)) return;
+    process.stdout.write(`Active profile: ${activeProfileName}\n`);
+    for (const profile of profiles) {
+      process.stdout.write(`- ${profile.name}${profile.active ? " (active)" : ""}: ${profile.login ?? "not authenticated"}\n`);
     }
     return;
   }

--- a/test/unit/mcp-cli-packets.test.ts
+++ b/test/unit/mcp-cli-packets.test.ts
@@ -131,6 +131,30 @@ describe("gittensory-mcp CLI — packets", () => {
     expect(human).toContain("jsonbored");
   });
 
+  it("cache list --format ndjson streams one JSON object per cached entry", async () => {
+    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    const url = await startFixtureServer();
+    const env = {
+      GITTENSORY_API_URL: url,
+      GITTENSORY_TOKEN: "session-token",
+      GITTENSORY_CONFIG_DIR: tempDir,
+      GITTENSORY_API_TIMEOUT_MS: "1000",
+    };
+
+    // Empty cache → zero ndjson lines (not a wrapper object).
+    expect(run(["cache", "list", "--format", "ndjson"], env).trim()).toBe("");
+
+    await runAsync(["decision-pack", "--login", "JSONbored", "--json"], env);
+    const lines = run(["cache", "list", "--format", "ndjson"], env).trim().split("\n");
+    expect(lines).toHaveLength(1);
+    const [firstLine] = lines as [string];
+    const entry = JSON.parse(firstLine) as { login: string; bytes: number };
+    expect(entry).toMatchObject({ login: "jsonbored" });
+    expect(entry.bytes).toBeGreaterThan(0);
+    // Each line is a bare entry, not the {count, entries} wrapper.
+    expect(firstLine).not.toContain('"count"');
+  });
+
   it("does not use stale decision-pack cache created by a different local token", async () => {
     tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
     const fixtureOptions: { decisionPackStatus?: number } = {};

--- a/test/unit/mcp-cli-profiles.test.ts
+++ b/test/unit/mcp-cli-profiles.test.ts
@@ -57,6 +57,42 @@ describe("gittensory-mcp CLI — profiles", () => {
     expect(JSON.stringify(list)).not.toMatch(/session-jsonbored|session-okto|github-jsonbored|github-okto|gittensory-cli-/);
   }, 45_000);
 
+  it("profile list --format ndjson streams one JSON object per profile (and --json stays pretty)", () => {
+    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    const configPath = join(tempDir, "config.json");
+    // Two credential-free profiles (default + active "beta"); profile list needs only names to enumerate,
+    // so the fixture carries no session token — the streaming format is what this exercises.
+    writeFileSync(
+      configPath,
+      JSON.stringify(
+        {
+          apiUrl: "https://api.example.test",
+          activeProfile: "beta",
+          profiles: {
+            default: { session: { login: "default-user", scopes: [] } },
+            beta: { session: { login: "beta-user", scopes: [] } },
+          },
+        },
+        null,
+        2,
+      ),
+    );
+    const env = { GITTENSORY_CONFIG_DIR: tempDir, GITTENSORY_SKIP_NPM_VERSION_CHECK: "true" };
+
+    const lines = run(["profile", "list", "--format", "ndjson"], env).trim().split("\n");
+    expect(lines).toHaveLength(2);
+    const parsed = lines.map((line) => JSON.parse(line) as { name: string; active: boolean });
+    expect(parsed.map((p) => p.name).sort()).toEqual(["beta", "default"]);
+    // The active profile is flagged on its own record.
+    expect(parsed.find((p) => p.name === "beta")?.active).toBe(true);
+    // Each line is a bare profile object — not the {activeProfile, profiles} wrapper.
+    for (const line of lines) expect(line).not.toContain("activeProfile");
+    // --json still returns the pretty wrapper object (unchanged behavior).
+    const pretty = JSON.parse(run(["profile", "list", "--json"], env)) as { activeProfile: string; profiles: unknown[] };
+    expect(pretty).toMatchObject({ activeProfile: "beta" });
+    expect(pretty.profiles).toHaveLength(2);
+  });
+
   it("keeps environment tokens ahead of active profile sessions", async () => {
     tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
     const requests: Array<{ url: string | undefined; authorization: string | undefined }> = [];


### PR DESCRIPTION
## What

List-shaped CLI outputs (`cache list`, `profile list`) only offered pretty JSON via `--json` — awkward to pipe into `jq` or a log processor line-by-line. This adds a `--format ndjson` mode that streams **one JSON object per array element per line**, so downstream tooling can consume results as a stream.

A small shared `emitList(options, items, pretty)` helper is the single place that renders machine-readable output: `--format ndjson` streams the array; `--json` (and `--format json`) keep the existing pretty wrapper object unchanged. The human-readable output is untouched.

Applied to the two array-returning list commands that exist today:

- `cache list` — streams each cached decision-pack entry
- `profile list` — streams each profile

(The `agent` CLI exposes only single-run subcommands — `plan` / `status` / `explain` / `packet` — so it has no array-returning list command to cover.)

## Deliverables

- [x] `--format ndjson` accepted (parsed by the existing generic `--<key> <value>` handling); `--json` remains the pretty-JSON alias, and `--format json` maps to it too.
- [x] One JSON object per line for the array-returning commands (`cache list`, `profile list`).
- [x] Each record ends in `\n`; Node flushes stdout on exit, so piped output is not truncated.
- [x] CLI tests: each ndjson line parses as JSON and the count matches the number of entries (empty cache → zero lines); the `--json` pretty output is verified unchanged.

Closes #2232
