### PR TITLE
feat(notifications): gate-outcomes section for the maintainer recap

### DIFF
--- a/src/services/maintainer-recap.ts
+++ b/src/services/maintainer-recap.ts
@@ -1,0 +1,30 @@
+// Maintainer recap digest — content sections (#1963). Pure section builders that fold an already-aggregated
+// report into titled digest lines; the formatter (#2240) composes them into the recap body. No new queries,
+// no delivery, no scoring/trust/reward internals — every input here is a public-safe aggregate count.
+import type { GatePrecisionReport } from "./gate-precision";
+
+/** Gate-outcomes section (#2242, part of #1963): summarize the gate's window from the already-computed
+ *  {@link GatePrecisionReport} (services/gate-precision.ts — the same source src/review/ops-wire.ts reads).
+ *  Reports how many PRs the gate blocked, how many a maintainer overrode, and the blocked-then-merged
+ *  false-positive count, plus the overall false-positive rate.
+ *
+ *  `overall.falsePositiveRate` is null below the report's MIN_SAMPLE (too few decided blocks to judge — the
+ *  exact treatment ops-wire.ts gives it), in which case the percentage is replaced by a "not enough … yet"
+ *  line rather than dividing by a tiny denominator. `overridden` isn't carried on `overall`, so it's summed
+ *  across the per-gate-type rows (same field ops-wire surfaces per type). Pure: no I/O, no mutation. */
+export function buildGateOutcomesRecapSection(report: GatePrecisionReport): string[] {
+  const { blocked, blockedThenMerged, falsePositiveRate } = report.overall;
+  let overridden = 0;
+  for (const type of report.perGateType) overridden += type.overridden;
+  const rateLine =
+    falsePositiveRate !== null
+      ? `False-positive rate: ${Math.round(falsePositiveRate * 100)}% of blocks merged anyway.`
+      : "False-positive rate: not enough decided blocks yet to report.";
+  return [
+    "## Gate outcomes",
+    `- Blocked: ${blocked} PR(s)`,
+    `- Overridden by a maintainer: ${overridden}`,
+    `- Blocked then merged (false positive): ${blockedThenMerged}`,
+    `- ${rateLine}`,
+  ];
+}

--- a/test/unit/maintainer-recap.test.ts
+++ b/test/unit/maintainer-recap.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from "vitest";
+import { buildGateOutcomesRecapSection } from "../../src/services/maintainer-recap";
+import type { GatePrecisionReport } from "../../src/services/gate-precision";
+
+function report(overrides: Partial<GatePrecisionReport> = {}): GatePrecisionReport {
+  return {
+    repoFullName: "JSONbored/gittensory",
+    generatedAt: "2026-07-08T00:00:00Z",
+    windowDays: 7,
+    perGateType: [],
+    overall: { blocked: 0, blockedThenMerged: 0, falsePositiveRate: null },
+    signals: [],
+    ...overrides,
+  };
+}
+
+describe("buildGateOutcomesRecapSection (#2242, part of #1963)", () => {
+  it("renders counts + a false-positive rate when the sample is large enough (rate not null)", () => {
+    const lines = buildGateOutcomesRecapSection(
+      report({
+        overall: { blocked: 11, blockedThenMerged: 2, falsePositiveRate: 0.182 },
+        perGateType: [
+          { gateType: "duplicate-pr", blocked: 8, blockedThenMerged: 2, overridden: 1, falsePositiveRate: 0.25 },
+          { gateType: "missing-linked-issue", blocked: 3, blockedThenMerged: 0, overridden: 2, falsePositiveRate: null },
+        ],
+      }),
+    );
+    expect(lines[0]).toBe("## Gate outcomes");
+    expect(lines).toContain("- Blocked: 11 PR(s)");
+    // overridden is summed across the per-gate-type rows (1 + 2), since overall doesn't carry it.
+    expect(lines).toContain("- Overridden by a maintainer: 3");
+    expect(lines).toContain("- Blocked then merged (false positive): 2");
+    expect(lines).toContain("- False-positive rate: 18% of blocks merged anyway.");
+  });
+
+  it("replaces the rate with a fallback line when the rate is null (below MIN_SAMPLE)", () => {
+    const lines = buildGateOutcomesRecapSection(
+      report({
+        overall: { blocked: 3, blockedThenMerged: 1, falsePositiveRate: null },
+        perGateType: [{ gateType: "duplicate-pr", blocked: 3, blockedThenMerged: 1, overridden: 0, falsePositiveRate: null }],
+      }),
+    );
+    expect(lines).toContain("- Blocked: 3 PR(s)");
+    expect(lines).toContain("- Overridden by a maintainer: 0");
+    expect(lines).toContain("- Blocked then merged (false positive): 1");
+    expect(lines).toContain("- False-positive rate: not enough decided blocks yet to report.");
+    expect(lines).not.toContain("- False-positive rate: 33% of blocks merged anyway.");
+  });
+
+  it("handles an empty report (no gate activity): all-zero counts + fallback rate, reduce over no rows", () => {
+    expect(buildGateOutcomesRecapSection(report())).toEqual([
+      "## Gate outcomes",
+      "- Blocked: 0 PR(s)",
+      "- Overridden by a maintainer: 0",
+      "- Blocked then merged (false positive): 0",
+      "- False-positive rate: not enough decided blocks yet to report.",
+    ]);
+  });
+});


### PR DESCRIPTION
## What

Adds the **gate-outcomes section** for the maintainer recap digest (#1963): a pure builder that summarizes the gate's window from the already-computed `GatePrecisionReport` (`src/services/gate-precision.ts`) — the same aggregate `src/review/ops-wire.ts` reads. It reports how many PRs the gate **blocked**, how many a maintainer **overrode**, the **blocked-then-merged** false-positive count, and the overall false-positive **rate**.

No new queries, no delivery, no scoring/trust/reward internals — just public-safe aggregate counts. It's a standalone section builder (`buildGateOutcomesRecapSection`) that the recap formatter (#2240) will compose into the digest body, matching how #1963 splits the digest into per-section builders.

## Deliverables

- [x] `buildGateOutcomesRecapSection(report)` producing blocked / overridden / false-positive counts + a rate line, in `src/services/maintainer-recap.ts`.
- [x] Guards the null-rate arm exactly as ops-wire nulls the rate below `MIN_SAMPLE` (`src/review/ops-wire.ts`): when `overall.falsePositiveRate` is null, a "not enough decided blocks yet" line replaces the percentage. `overridden` (not carried on `overall`) is summed across the per-gate-type rows.
- [x] Unit tests cover the populated report (rate rendered), the empty report (all-zero counts + fallback), and the below-sample null-rate branch — exercising both arms of the rate branch and the sum over zero and many rows.

Closes #2242
