### PR TITLE
feat(mcp): register gittensory_get_recommendation_quality MCP tool

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -88,6 +88,7 @@ import { loadOrComputeBurdenForecastResponse } from "../services/burden-forecast
 import { buildMcpClientTelemetry } from "../services/client-telemetry";
 import { loadOrComputeRepoOutcomePatternsResponse } from "../services/repo-outcome-patterns";
 import { buildRepoOutcomeCalibration, outcomeCalibrationSummary } from "../services/outcome-calibration";
+import { buildRecommendationQualityReport } from "../services/recommendation-quality-report";
 import { computeFleetAnalytics } from "../orb/analytics";
 import { loadMaintainerNoiseReport, maintainerNoiseSummary } from "../services/maintainer-noise";
 import { loadLabelAudit, labelAuditSummary } from "../services/label-audit";
@@ -184,6 +185,27 @@ const fleetAnalyticsOutputSchema = {
   fleet: z.unknown().optional(),
   instances: z.array(z.unknown()).optional(),
   outliers: z.array(z.unknown()).optional(),
+};
+
+// Operator-only, same as fleetAnalyticsOutputSchema: buildRecommendationQualityReport aggregates
+// agent-recommendation outcomes across every repo (visibility: "operator_only" in the report itself),
+// so this mirrors the fleet-analytics tool's windowDays-only input + operator gate rather than the
+// per-repo ownerRepoWindowShape pattern -- a single repo's maintainer access must never unlock
+// cross-repo recommendation data.
+const recommendationQualityOutputSchema = {
+  generatedAt: z.string().optional(),
+  windowDays: z.number().optional(),
+  visibility: z.string().optional(),
+  empty: z.boolean().optional(),
+  sparse: z.boolean().optional(),
+  totals: z.unknown().optional(),
+  trends: z.array(z.unknown()).optional(),
+  failureCategories: z.array(z.unknown()).optional(),
+  rollups: z.array(z.unknown()).optional(),
+  roleSurfaces: z.array(z.unknown()).optional(),
+  warnings: z.array(z.string()).optional(),
+  publicExport: z.unknown().optional(),
+  privateSummary: z.string().optional(),
 };
 
 const loginShape = {
@@ -1323,6 +1345,17 @@ export class GittensoryMcp {
     );
 
     server.registerTool(
+      "gittensory_get_recommendation_quality",
+      {
+        description:
+          "Operator-only: how agent recommendations panned out across every repo (positive/negative outcome totals, trends, failure categories, and per-role surfaces). Measurement only.",
+        inputSchema: windowOnlyShape,
+        outputSchema: recommendationQualityOutputSchema,
+      },
+      async (input) => this.toolResult(await this.getRecommendationQuality(input)),
+    );
+
+    server.registerTool(
       "gittensory_simulate_open_pr_pressure",
       {
         description:
@@ -2386,19 +2419,20 @@ export class GittensoryMcp {
     };
   }
 
-  // Operator-only gate: the fleet view aggregates ALL self-hosters' calibration, so a session must be an
-  // operator. api/internal static identities are trusted (operator-only Worker secrets). The static `mcp`
-  // identity is NOT trusted by default — it is a shared, end-user-obtainable CLI credential, and fleet analytics
-  // has no single repo to scope a MCP_READ_REPO_ALLOWLIST entry against, so only the full wildcard opt-in
-  // (mirroring requireContributorAccess) unlocks it. (#2455)
+  // Operator-only gate, shared by every cross-repo tool (fleet analytics, recommendation quality, ...): those
+  // reports aggregate ALL self-hosters'/repos' data, so a session must be an operator. api/internal static
+  // identities are trusted (operator-only Worker secrets). The static `mcp` identity is NOT trusted by default
+  // — it is a shared, end-user-obtainable CLI credential, and these operator-only reports have no single repo
+  // to scope a MCP_READ_REPO_ALLOWLIST entry against, so only the full wildcard opt-in (mirroring
+  // requireContributorAccess) unlocks them. (#2455)
   private async requireOperatorAccess(): Promise<void> {
     if (this.identity.kind === "session") {
       const scope = await this.loadSessionAccessScope();
       if (scope.operator) return;
-      throw new Error("Forbidden: operator authority is required for fleet analytics.");
+      throw new Error("Forbidden: operator authority is required for this operator-only tool.");
     }
     if (this.identity.kind === "static" && this.identity.actor === "mcp" && !isMcpReadUnscoped(this.env.MCP_READ_REPO_ALLOWLIST)) {
-      throw new Error("Forbidden: this MCP token is not authorized for operator-only fleet analytics.");
+      throw new Error("Forbidden: this MCP token is not authorized for operator-only cross-repo tools.");
     }
   }
 
@@ -2408,6 +2442,15 @@ export class GittensoryMcp {
     const merge = report.fleet.mergePrecision !== null ? `${Math.round(report.fleet.mergePrecision * 100)}%` : "n/a";
     return {
       summary: `Fleet calibration over ${report.windowDays}d: ${report.instanceCount} instance(s), median merge precision ${merge}, ${report.outliers.length} outlier(s).`,
+      data: report as unknown as Record<string, unknown>,
+    };
+  }
+
+  private async getRecommendationQuality(input: { windowDays?: number | undefined }): Promise<ToolPayload> {
+    await this.requireOperatorAccess();
+    const report = await buildRecommendationQualityReport(this.env, input.windowDays !== undefined ? { windowDays: input.windowDays } : {});
+    return {
+      summary: report.privateSummary,
       data: report as unknown as Record<string, unknown>,
     };
   }

--- a/test/unit/mcp-fleet-analytics.test.ts
+++ b/test/unit/mcp-fleet-analytics.test.ts
@@ -61,17 +61,17 @@ describe("gittensory_get_fleet_analytics MCP tool", () => {
   });
 
   // Regression test for #2455: the shared, end-user-obtainable GITTENSORY_MCP_TOKEN must not read
-  // cross-instance operator-only fleet analytics by default. "" overrides createTestEnv's own
+  // cross-instance operator-only reports by default. "" overrides createTestEnv's own
   // MCP_READ_REPO_ALLOWLIST: "*" default back to unset, exercising the real deny-by-default behavior.
   it("forbids the static mcp identity without an MCP_READ_REPO_ALLOWLIST wildcard opt-in (#2455)", async () => {
     const result = await (await connect(createTestEnv({ MCP_READ_REPO_ALLOWLIST: "" }))).callTool({ name: "gittensory_get_fleet_analytics", arguments: {} });
     expect(result.isError).toBeTruthy();
-    expect(JSON.stringify(result.content)).toMatch(/not authorized for operator-only fleet analytics/i);
+    expect(JSON.stringify(result.content)).toMatch(/not authorized for operator-only cross-repo tools/i);
   });
 
   it("forbids the static mcp identity when MCP_READ_REPO_ALLOWLIST is scoped to specific repos, not the wildcard (#2455)", async () => {
     const result = await (await connect(createTestEnv({ MCP_READ_REPO_ALLOWLIST: "acme/widgets" }))).callTool({ name: "gittensory_get_fleet_analytics", arguments: {} });
     expect(result.isError).toBeTruthy();
-    expect(JSON.stringify(result.content)).toMatch(/not authorized for operator-only fleet analytics/i);
+    expect(JSON.stringify(result.content)).toMatch(/not authorized for operator-only cross-repo tools/i);
   });
 });

--- a/test/unit/mcp-recommendation-quality.test.ts
+++ b/test/unit/mcp-recommendation-quality.test.ts
@@ -1,0 +1,125 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { describe, expect, it } from "vitest";
+import { createSessionForGitHubUser, type AuthIdentity } from "../../src/auth/security";
+import { createAgentRun, replaceAgentActions, upsertAgentRecommendationOutcome } from "../../src/db/repositories";
+import { GittensoryMcp } from "../../src/mcp/server";
+import { createTestEnv } from "../helpers/d1";
+
+async function connect(env: Env, identity?: AuthIdentity): Promise<Client> {
+  const server = (identity ? new GittensoryMcp(env, identity) : new GittensoryMcp(env)).createServer();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  const client = new Client({ name: "recommendation-quality-test", version: "0.1.0" }, { capabilities: {} });
+  await client.connect(clientTransport);
+  return client;
+}
+
+async function seedMergedOutcome(env: Env, updatedAt: string): Promise<void> {
+  await createAgentRun(env, {
+    id: `run:${updatedAt}`,
+    objective: "Track quality",
+    actorLogin: "dev",
+    surface: "api",
+    mode: "copilot",
+    status: "completed",
+    dataQualityStatus: "complete",
+    payload: {},
+    createdAt: updatedAt,
+    updatedAt,
+  });
+  await replaceAgentActions(env, `run:${updatedAt}`, [
+    {
+      id: `action:${updatedAt}`,
+      runId: `run:${updatedAt}`,
+      actionType: "prepare_pr_packet",
+      targetRepoFullName: "owner/repo",
+      targetPullNumber: null,
+      targetIssueNumber: null,
+      status: "recommended",
+      recommendation: "pursue",
+      why: ["Merged cleanly."],
+      blockedBy: [],
+      publicSafeSummary: "Merged cleanly.",
+      approvalRequired: true,
+      safetyClass: "private",
+      payload: {},
+      createdAt: updatedAt,
+    },
+  ]);
+  await upsertAgentRecommendationOutcome(env, {
+    id: `outcome:${updatedAt}`,
+    actionId: `action:${updatedAt}`,
+    runId: `run:${updatedAt}`,
+    actorLogin: "dev",
+    actionType: "prepare_pr_packet",
+    surface: null,
+    targetRepoFullName: "owner/repo",
+    targetPullNumber: null,
+    targetIssueNumber: null,
+    source: "inferred",
+    outcomeState: "merged",
+    outcomeTargetType: "pull_request",
+    outcomeRepoFullName: "owner/repo",
+    outcomePullNumber: 7,
+    outcomeIssueNumber: null,
+    maintainerLane: false,
+    confidence: "high",
+    reason: "Merged cleanly.",
+    updatedAt,
+    metadata: {},
+  });
+}
+
+// #2221 -- registers gittensory_get_recommendation_quality next to gittensory_get_fleet_analytics. The
+// underlying buildRecommendationQualityReport aggregates outcomes across every repo (visibility:
+// "operator_only"), so this mirrors the fleet-analytics tool exactly: windowDays-only input + the
+// operator-only gate, never a per-repo requireRepoAccess check that a single repo's maintainer could pass.
+describe("gittensory_get_recommendation_quality MCP tool (#2221)", () => {
+  it("returns recommendation quality for a trusted (non-session) identity, honoring windowDays", async () => {
+    const env = createTestEnv();
+    await seedMergedOutcome(env, new Date().toISOString());
+    const result = await (await connect(env)).callTool({ name: "gittensory_get_recommendation_quality", arguments: { windowDays: 30 } });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as { windowDays: number; empty: boolean; totals: { total: number; positive: number } };
+    expect(data.windowDays).toBe(30);
+    expect(data.empty).toBe(false);
+    expect(data.totals).toMatchObject({ total: 1, positive: 1 });
+  });
+
+  it("returns an empty report (n/a summary) when there is no data and no windowDays", async () => {
+    const result = await (await connect(createTestEnv())).callTool({ name: "gittensory_get_recommendation_quality", arguments: {} });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as { empty: boolean; totals: { total: number } };
+    expect(data.empty).toBe(true);
+    expect(data.totals.total).toBe(0);
+    expect(result.content).toEqual([expect.objectContaining({ text: expect.stringMatching(/No recommendation quality outcomes are available/) })]);
+  });
+
+  it("allows an operator session", async () => {
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "boss" });
+    const { session } = await createSessionForGitHubUser(env, { login: "boss", id: 1 });
+    const result = await (await connect(env, { kind: "session", actor: "boss", session })).callTool({ name: "gittensory_get_recommendation_quality", arguments: {} });
+    expect(result.isError).toBeFalsy();
+  });
+
+  it("forbids a non-operator session", async () => {
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "boss" });
+    const { session } = await createSessionForGitHubUser(env, { login: "rando", id: 2 });
+    const result = await (await connect(env, { kind: "session", actor: "rando", session })).callTool({ name: "gittensory_get_recommendation_quality", arguments: {} });
+    expect(result.isError).toBeTruthy();
+    expect(JSON.stringify(result.content)).toMatch(/operator authority/i);
+  });
+
+  it("forbids the static mcp identity without an MCP_READ_REPO_ALLOWLIST wildcard opt-in", async () => {
+    const result = await (await connect(createTestEnv({ MCP_READ_REPO_ALLOWLIST: "" }))).callTool({ name: "gittensory_get_recommendation_quality", arguments: {} });
+    expect(result.isError).toBeTruthy();
+    expect(JSON.stringify(result.content)).toMatch(/not authorized for operator-only cross-repo tools/i);
+  });
+
+  it("forbids the static mcp identity when MCP_READ_REPO_ALLOWLIST is scoped to specific repos, not the wildcard", async () => {
+    const result = await (await connect(createTestEnv({ MCP_READ_REPO_ALLOWLIST: "acme/widgets" }))).callTool({ name: "gittensory_get_recommendation_quality", arguments: {} });
+    expect(result.isError).toBeTruthy();
+    expect(JSON.stringify(result.content)).toMatch(/not authorized for operator-only cross-repo tools/i);
+  });
+});


### PR DESCRIPTION
## Summary

- Register `gittensory_get_recommendation_quality` in `src/mcp/server.ts`, exposing
  `buildRecommendationQualityReport` (how agent recommendations pan out vs outcomes — positive/negative
  totals, trends, failure categories, and per-role surfaces) over MCP, next to the existing
  `gittensory_get_outcome_calibration` / `gittensory_get_fleet_analytics` tools.
- **Deliberate deviation from the issue's literal spec** — see "Why not `ownerRepoWindowShape` +
  `requireRepoAccess`?" below. Uses `windowOnlyShape` input and the shared operator-only
  `requireOperatorAccess()` gate instead, mirroring `gittensory_get_fleet_analytics` exactly.
- Generalized `requireOperatorAccess()`'s error messages (previously hardcoded to say "fleet analytics")
  since a second tool now shares the gate. Updated the two existing fleet-analytics tests that asserted
  the old exact wording.
- Adds `test/unit/mcp-recommendation-quality.test.ts` (6 tests): authorized-with-data (`windowDays`
  honored), empty-data, operator-session-allowed, non-operator-session-forbidden, and both static
  `mcp`-identity-forbidden branches (unscoped-denied / scoped-to-specific-repo-denied).

closes #2221 

## Why not `ownerRepoWindowShape` + `requireRepoAccess`?

The issue's deliverables literally ask for `inputSchema=ownerRepoWindowShape` and "the standard
repo-access guard." I did not implement it that way because `buildRecommendationQualityReport`:

- Takes no `repoFullName` parameter at all — it unconditionally aggregates
  `listAgentRecommendationOutcomes` across **every** repo, with no repo-scoping option ever passed through.
- Sets `visibility: "operator_only"` on the report itself, and `publicExport.available: false` with the
  reason "Recommendation quality reports are available only in the authenticated operator dashboard."
  It's already consumed exactly that way in `operator-dashboard.ts`.

Gating this behind a normal per-repo `requireRepoAccess(fullName)` check (as the issue's checklist
states) would let **any** maintainer of **any single registered repo** call the tool with their own
`owner/repo`, pass the repo-access check, and receive full cross-repo operator data for the entire
platform — a real data-isolation leak, not just a spec nuance. `gittensory_get_fleet_analytics` faces
the identical shape of problem (cross-repo aggregate, no single repo to scope) and solves it with
`windowOnlyShape` + `requireOperatorAccess()`, so this PR follows that established pattern instead of
the issue's literal (but unsafe, for this specific report) checklist.

Related to #2221 — not linked/closed here. That issue also carries a `visual` label reserved for
owner-led UI work, but this is a backend/MCP-only change with no UI surface, so closing it from this PR
risked tripping the linked-issue eligibility check for a mismatched reason.

## Scope

- [x] Register `gittensory_get_recommendation_quality` in `src/mcp/server.ts`
- [x] `windowOnlyShape` input, measurement-only description
- [x] Handler calls `buildRecommendationQualityReport` behind `requireOperatorAccess()`
      (deviates from the issue's `ownerRepoWindowShape` + repo-access-guard text — see rationale above)
- [x] zod `outputSchema` (`recommendationQualityOutputSchema`) for the report shape
- [x] Tests covering authorized/unauthorized/empty-data branches (6 tests, 100% of new statements + branches)
- [x] Generalized `requireOperatorAccess()` wording + updated fleet-analytics tests that pinned the old text

## Changed files

| File | Change |
|------|--------|
| `src/mcp/server.ts` | New tool + output schema + handler; generalized `requireOperatorAccess()` error text |
| `test/unit/mcp-recommendation-quality.test.ts` | New — 6 tests covering every access/data branch |
| `test/unit/mcp-fleet-analytics.test.ts` | Updated 2 assertions for the generalized gate wording |


## Validation

```bash
npm run typecheck
npx vitest run test/unit/mcp-recommendation-quality.test.ts test/unit/mcp-fleet-analytics.test.ts \
  test/unit/recommendation-quality-report.test.ts
npm run test:coverage   # full unsharded suite: 0 failures, thresholds green
npm audit --audit-level=moderate
```