### PR TITLE
feat(mcp): add gittensory://enrichment-analyzers resource

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -150,6 +150,7 @@ import { SCENARIO_MAX_BRANCH_REF_CHARS, SCENARIO_MAX_LINKED_ISSUE_NUMBERS, SCENA
 import { loadUpstreamStatus } from "../upstream/ruleset";
 import { simulateOpenPrPressure, type OpenPrPressureInput } from "../services/open-pr-pressure-scenarios";
 import { buildFindingTaxonomyDocument, FINDING_TAXONOMY_URI } from "../review/finding-taxonomy";
+import { buildEnrichmentAnalyzersTaxonomyDocument, ENRICHMENT_ANALYZERS_URI } from "../review/enrichment-analyzers-taxonomy";
 
 type AppContext = Context<{ Bindings: Env }>;
 type ToolPayload = {
@@ -2023,6 +2024,26 @@ export class GittensoryMcp {
             uri: FINDING_TAXONOMY_URI,
             mimeType: "application/json",
             text: JSON.stringify(buildFindingTaxonomyDocument(), null, 2),
+          },
+        ],
+      }),
+    );
+
+    // #2226 — read-only REES enrichment analyzer taxonomy for MCP discovery.
+    server.registerResource(
+      "gittensory_enrichment_analyzers",
+      ENRICHMENT_ANALYZERS_URI,
+      {
+        title: "Gittensory Enrichment Analyzers",
+        description: "REES enrichment analyzer taxonomy: names, categories, cost classes, and default profiles.",
+        mimeType: "application/json",
+      },
+      async () => ({
+        contents: [
+          {
+            uri: ENRICHMENT_ANALYZERS_URI,
+            mimeType: "application/json",
+            text: JSON.stringify(buildEnrichmentAnalyzersTaxonomyDocument(), null, 2),
           },
         ],
       }),

--- a/src/review/enrichment-analyzers-taxonomy.ts
+++ b/src/review/enrichment-analyzers-taxonomy.ts
@@ -1,0 +1,40 @@
+import analyzerMetadata from "../../review-enrichment/analyzer-metadata.json";
+
+/** MCP resource URI for the REES enrichment analyzer taxonomy (#2226). */
+export const ENRICHMENT_ANALYZERS_URI = "gittensory://enrichment-analyzers" as const;
+
+type AnalyzerMetadataFile = {
+  defaultProfile: string;
+  analyzers: Array<{
+    name: string;
+    category: string;
+    cost: string;
+    profiles: string[];
+  }>;
+};
+
+export interface EnrichmentAnalyzerTaxonomyEntry {
+  name: string;
+  category: string;
+  costClass: string;
+  profiles: readonly string[];
+}
+
+export interface EnrichmentAnalyzersTaxonomyDocument {
+  defaultProfile: string;
+  analyzers: readonly EnrichmentAnalyzerTaxonomyEntry[];
+}
+
+/** Static taxonomy for REES enrichment analyzers — sourced from committed analyzer-metadata.json. */
+export function buildEnrichmentAnalyzersTaxonomyDocument(): EnrichmentAnalyzersTaxonomyDocument {
+  const metadata = analyzerMetadata as AnalyzerMetadataFile;
+  return {
+    defaultProfile: metadata.defaultProfile,
+    analyzers: metadata.analyzers.map((analyzer) => ({
+      name: analyzer.name,
+      category: analyzer.category,
+      costClass: analyzer.cost,
+      profiles: [...analyzer.profiles],
+    })),
+  };
+}

--- a/test/unit/enrichment-analyzers-taxonomy.test.ts
+++ b/test/unit/enrichment-analyzers-taxonomy.test.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+  buildEnrichmentAnalyzersTaxonomyDocument,
+  ENRICHMENT_ANALYZERS_URI,
+} from "../../src/review/enrichment-analyzers-taxonomy";
+
+const metadataPath = join(process.cwd(), "review-enrichment/analyzer-metadata.json");
+
+describe("enrichment analyzers taxonomy document", () => {
+  it("projects analyzer-metadata.json into the MCP taxonomy shape", () => {
+    const raw = JSON.parse(readFileSync(metadataPath, "utf8")) as {
+      defaultProfile: string;
+      analyzers: Array<{ name: string; category: string; cost: string; profiles: string[] }>;
+    };
+    const doc = buildEnrichmentAnalyzersTaxonomyDocument();
+    expect(doc.defaultProfile).toBe(raw.defaultProfile);
+    expect(doc.analyzers).toHaveLength(raw.analyzers.length);
+    expect(doc.analyzers.map((a) => a.name)).toEqual(raw.analyzers.map((a) => a.name));
+    for (const [index, analyzer] of raw.analyzers.entries()) {
+      expect(doc.analyzers[index]).toEqual({
+        name: analyzer.name,
+        category: analyzer.category,
+        costClass: analyzer.cost,
+        profiles: [...analyzer.profiles],
+      });
+    }
+  });
+
+  it("includes the canonical REES analyzer categories", () => {
+    const doc = buildEnrichmentAnalyzersTaxonomyDocument();
+    const categories = new Set(doc.analyzers.map((analyzer) => analyzer.category));
+    for (const category of ["supply-chain", "security", "performance", "ownership"]) {
+      expect(categories).toContain(category);
+    }
+    for (const analyzer of doc.analyzers) {
+      expect(analyzer.category.length).toBeGreaterThan(0);
+      expect(analyzer.costClass.length).toBeGreaterThan(0);
+      expect(analyzer.profiles.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("uses the stable MCP resource URI", () => {
+    expect(ENRICHMENT_ANALYZERS_URI).toBe("gittensory://enrichment-analyzers");
+  });
+});

--- a/test/unit/mcp-enrichment-analyzers.test.ts
+++ b/test/unit/mcp-enrichment-analyzers.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { describe, expect, it } from "vitest";
+import { GittensoryMcp } from "../../src/mcp/server";
+import { ENRICHMENT_ANALYZERS_URI } from "../../src/review/enrichment-analyzers-taxonomy";
+import { createTestEnv } from "../helpers/d1";
+
+const metadataPath = join(process.cwd(), "review-enrichment/analyzer-metadata.json");
+
+async function connectTestClient() {
+  const mcpServer = new GittensoryMcp(createTestEnv()).createServer();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await mcpServer.connect(serverTransport);
+  const client = new Client({ name: "gittensory-enrichment-analyzers-test", version: "0.1.0" }, { capabilities: {} });
+  await client.connect(clientTransport);
+  return { client, mcpServer };
+}
+
+describe("MCP enrichment-analyzers resource (#2226)", () => {
+  it("discovers the enrichment-analyzers resource", async () => {
+    const { client } = await connectTestClient();
+    const { resources } = await client.listResources();
+    expect(resources.map((r) => r.uri)).toContain(ENRICHMENT_ANALYZERS_URI);
+  });
+
+  it("returns analyzers with categories, cost classes, and profiles as JSON", async () => {
+    const raw = JSON.parse(readFileSync(metadataPath, "utf8")) as {
+      defaultProfile: string;
+      analyzers: Array<{ name: string; category: string; cost: string; profiles: string[] }>;
+    };
+    const { client } = await connectTestClient();
+    const result = await client.readResource({ uri: ENRICHMENT_ANALYZERS_URI });
+    expect(result.contents).toHaveLength(1);
+    const content = result.contents[0];
+    expect(content?.mimeType).toBe("application/json");
+    if (!content || !("text" in content)) throw new Error("expected text content");
+    const body = JSON.parse(content.text ?? "") as {
+      defaultProfile: string;
+      analyzers: Array<{ name: string; category: string; costClass: string; profiles: string[] }>;
+    };
+    expect(body.defaultProfile).toBe(raw.defaultProfile);
+    expect(body.analyzers).toHaveLength(raw.analyzers.length);
+    for (const expected of raw.analyzers) {
+      const actual = body.analyzers.find((analyzer) => analyzer.name === expected.name);
+      expect(actual).toMatchObject({
+        category: expected.category,
+        costClass: expected.cost,
+        profiles: expected.profiles,
+      });
+    }
+    for (const category of ["supply-chain", "security", "performance", "ownership"]) {
+      expect(body.analyzers.some((analyzer) => analyzer.category === category)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Add `src/review/enrichment-analyzers-taxonomy.ts` that projects the committed `review-enrichment/analyzer-metadata.json` into a slim MCP taxonomy (name, category, cost class, profiles + default profile).
- Register read-only hosted MCP resource `gittensory://enrichment-analyzers` (`application/json`) so agents can discover REES enrichment analyzers without importing the REES runtime.
- Add unit tests for the taxonomy builder and MCP resource discovery/read.

Closes #2226.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [x] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran focused tests: `enrichment-analyzers-taxonomy`, `mcp-enrichment-analyzers`, `npm run typecheck`, `npm run build:mcp`, `npm audit --audit-level=moderate`. Full `npm run test:ci` blocked locally by missing `wrangler` (`cf-typegen:check`); remaining gate jobs left to CI.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — MCP resource only; no visible UI.

## Notes

- Taxonomy is read from committed `analyzer-metadata.json` only; no REES runtime import.
