### PR TITLE
fix: resolve draft OAuth redirect origin trust

### DIFF
--- a/src/services/draft.ts
+++ b/src/services/draft.ts
@@ -58,6 +58,14 @@ function draftSecrets(env: Env): { clientId: string; clientSecret: string; encKe
   };
 }
 
+function trustedDraftOAuthOrigin(env: Env, requestUrl: string): string {
+  const configured = String(env.PUBLIC_API_ORIGIN ?? "").trim();
+  if (configured) return new URL(configured).origin;
+  const requestOrigin = new URL(requestUrl).origin;
+  if (/^https?:\/\/(?:localhost|127\.0\.0\.1)(?::\d+)?$/i.test(requestOrigin)) return requestOrigin;
+  throw new Error("draft_flow_not_configured");
+}
+
 interface DraftRow {
   id: string;
   status: string;
@@ -574,7 +582,12 @@ export async function handleDraftCreate(request: Request, env: Env): Promise<Res
     .bind(id, target.category, target.slug, target.targetPath, target.branchName, config.baseRef, JSON.stringify(fields), await sha256Hex(state))
     .run();
 
-  const origin = new URL(request.url).origin;
+  let origin: string;
+  try {
+    origin = trustedDraftOAuthOrigin(env, request.url);
+  } catch {
+    return json({ ok: false, error: "draft_flow_not_configured" }, 503);
+  }
   const authUrl = new URL("https://github.com/login/oauth/authorize");
   authUrl.searchParams.set("client_id", clientId);
   authUrl.searchParams.set("redirect_uri", `${origin}/v1/drafts/auth/callback`);
@@ -635,10 +648,16 @@ export async function handleDraftOAuthCallback(request: Request, env: Env): Prom
 
   const { clientId, clientSecret, encKey } = draftSecrets(env);
   if (!clientId || !clientSecret || !encKey) return new Response("Draft flow not configured.", { status: 503 });
+  let callbackOrigin: string;
+  try {
+    callbackOrigin = trustedDraftOAuthOrigin(env, request.url);
+  } catch {
+    return new Response("Draft flow not configured.", { status: 503 });
+  }
 
   let userToken: string;
   try {
-    userToken = await exchangeGitHubUserCode({ clientId, clientSecret, code, callbackUrl: `${url.origin}/v1/drafts/auth/callback` });
+    userToken = await exchangeGitHubUserCode({ clientId, clientSecret, code, callbackUrl: `${callbackOrigin}/v1/drafts/auth/callback` });
   } catch {
     return new Response("GitHub authorization failed.", { status: 400 });
   }
@@ -657,7 +676,7 @@ export async function handleDraftOAuthCallback(request: Request, env: Env): Prom
   await env.JOBS.send({ type: "submit-draft", requestedBy: "api", draftId });
 
   return new Response(`<meta http-equiv="refresh" content="0; url=/v1/drafts/${draftId}">Submission queued.`, {
-    headers: { "content-type": "text/html", "set-cookie": draftOAuthCookie("", url.origin, 0) },
+    headers: { "content-type": "text/html", "set-cookie": draftOAuthCookie("", callbackOrigin, 0) },
   });
 }
 

--- a/test/unit/draft.test.ts
+++ b/test/unit/draft.test.ts
@@ -12,6 +12,7 @@ function draftEnv(overrides: Partial<Env> = {}): Env {
     GITHUB_OAUTH_CLIENT_ID: "Iv-test-client-id",
     GITHUB_OAUTH_CLIENT_SECRET: "test-oauth-client-secret",
     DRAFT_TOKEN_ENCRYPTION_SECRET: DRAFT_SECRET,
+    PUBLIC_API_ORIGIN: ORIGIN,
     ...overrides,
   });
 }
@@ -92,9 +93,8 @@ describe("draft endpoints — flag ON, public + unauthenticated", () => {
     const authUrl = new URL(body.authUrl);
     expect(authUrl.origin + authUrl.pathname).toBe("https://github.com/login/oauth/authorize");
     expect(authUrl.searchParams.get("client_id")).toBe("Iv-test-client-id");
-    // The callback URL is derived from the request origin (matches reviewbot). `app.request` with a
-    // path-only URL resolves the origin to http://localhost, so the redirect_uri lives under it.
-    expect(authUrl.searchParams.get("redirect_uri")).toBe("http://localhost/v1/drafts/auth/callback");
+    // The callback URL is anchored to PUBLIC_API_ORIGIN.
+    expect(authUrl.searchParams.get("redirect_uri")).toBe(`${ORIGIN}/v1/drafts/auth/callback`);
     expect(authUrl.searchParams.get("state")?.startsWith(`${body.draftId}.`)).toBe(true);
     expect(res.headers.get("set-cookie")).toContain("gittensory_draft_oauth=");
     expect(res.headers.get("set-cookie")).toContain("HttpOnly");
@@ -872,6 +872,28 @@ describe("handleDraftCreate — nested body.fields branch + title fallbacks", ()
   it("returns 503 when the OAuth client id is missing (draftSecrets clientId empty branch)", async () => {
     const env = draftEnv({ GITHUB_OAUTH_CLIENT_ID: "" });
     const res = await handleDraftCreate(new Request(`${ORIGIN}/v1/drafts`, { method: "POST", headers: jsonHeaders(), body: JSON.stringify(SAMPLE_FIELDS) }), env);
+    expect(res.status).toBe(503);
+    expect((await res.json()) as { error: string }).toMatchObject({ error: "draft_flow_not_configured" });
+  });
+
+  it("falls back to localhost request origin when PUBLIC_API_ORIGIN is unset (dev-only path)", async () => {
+    const env = draftEnv({ PUBLIC_API_ORIGIN: "" });
+    const res = await handleDraftCreate(
+      new Request("http://localhost/v1/drafts", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(SAMPLE_FIELDS) }),
+      env,
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { authUrl: string };
+    const authUrl = new URL(body.authUrl);
+    expect(authUrl.searchParams.get("redirect_uri")).toBe("http://localhost/v1/drafts/auth/callback");
+  });
+
+  it("returns 503 when PUBLIC_API_ORIGIN is unset for non-localhost origins", async () => {
+    const env = draftEnv({ PUBLIC_API_ORIGIN: "" });
+    const res = await handleDraftCreate(
+      new Request(`${ORIGIN}/v1/drafts`, { method: "POST", headers: jsonHeaders(), body: JSON.stringify(SAMPLE_FIELDS) }),
+      env,
+    );
     expect(res.status).toBe(503);
     expect((await res.json()) as { error: string }).toMatchObject({ error: "draft_flow_not_configured" });
   });


### PR DESCRIPTION
## Root cause
The draft submission OAuth flow built `redirect_uri` from the request origin, which can be proxy-influenced or misconfigured in production and leads to callback misbinding.

## Fix approach
- Added `trustedDraftOAuthOrigin()` in `src/services/draft.ts`.
- Prefer `PUBLIC_API_ORIGIN` as the canonical callback origin.
- Allow request-origin fallback only for localhost/127.0.0.1 development.
- Return `draft_flow_not_configured` / `Draft flow not configured.` when a trusted origin cannot be established.
- Updated draft unit tests to assert canonical-origin behavior and localhost-only fallback.

## Impact
Draft OAuth callback URLs are now stable and trusted in production deployments, preventing host-derived redirect mismatches while preserving local-dev behavior.

## Risks / tradeoffs
Deployments using non-localhost draft OAuth without setting `PUBLIC_API_ORIGIN` will now receive a configuration error (503) until that env var is set.

## Validation
- `npx vitest run test/unit/draft.test.ts`
- `npm run typecheck`