### PR TITLE
feat(mcp): add gittensory_get_eligibility_plan tool

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -82,6 +82,7 @@ import {
 import { loadContributorDecisionPackForServing, repoDecisionFromPack } from "../services/decision-pack";
 import { buildPublicPrBodyDraft } from "../services/pr-body-draft";
 import { buildRemediationPlan } from "../services/remediation-plan";
+import { deriveEligibilityPlan } from "../services/eligibility-plan";
 import { explainScoreBreakdown } from "../services/score-breakdown";
 import { loadOrComputeIssueQualityResponse } from "../services/issue-quality";
 import { loadOrComputeBurdenForecastResponse } from "../services/burden-forecast";
@@ -1043,6 +1044,16 @@ const scoreBreakdownOutputSchema = {
   highestLeverageLever: z.unknown().optional(),
 };
 
+const eligibilityPlanOutputSchema = {
+  eligible: z.boolean().optional(),
+  linkedIssueStatus: z.string().optional(),
+  branchEligibilityStatus: z.string().optional(),
+  blockers: z.array(z.string()).optional(),
+  cleanupPaths: z.array(z.string()).optional(),
+  linkedIssueProjection: z.string().nullable().optional(),
+  publicSummary: z.string().optional(),
+};
+
 const lintPrTextOutputSchema = {
   verdict: z.string().optional(),
   score: z.number().optional(),
@@ -1620,6 +1631,17 @@ export class GittensoryMcp {
         outputSchema: scorePreviewRecordOutputSchema,
       },
       async (input) => this.toolResult(await this.previewScore(input)),
+    );
+
+    server.registerTool(
+      "gittensory_get_eligibility_plan",
+      {
+        description:
+          "Derive a structured eligibility plan from local score-preview metadata: whether the branch/PR is eligible now, public-safe blockers, and cleanup paths. Advisory dry-run only — no GitHub writes.",
+        inputSchema: scorePreviewShape,
+        outputSchema: eligibilityPlanOutputSchema,
+      },
+      async (input) => this.toolResult(await this.getEligibilityPlan(input)),
     );
 
     server.registerTool(
@@ -2796,6 +2818,25 @@ export class GittensoryMcp {
     return {
       summary: `Private Gittensory scoring preview for ${input.repoFullName}.`,
       data: makeScorePreviewRecord(scoreInput, snapshot, result) as unknown as Record<string, unknown>,
+    };
+  }
+
+  private async getEligibilityPlan(input: z.infer<z.ZodObject<typeof scorePreviewShape>>): Promise<ToolPayload> {
+    if (input.contributorLogin) this.requireContributorAccess(input.contributorLogin);
+    await this.requireRepoAccess(input.repoFullName);
+    const [repo, snapshot, evidence, contributorIssues] = await Promise.all([
+      getRepository(this.env, input.repoFullName),
+      getOrCreateScoringModelSnapshot(this.env),
+      input.contributorLogin ? getContributorEvidence(this.env, input.contributorLogin) : Promise.resolve(null),
+      input.contributorLogin ? listContributorIssues(this.env, input.contributorLogin) : Promise.resolve([]),
+    ]);
+    const openIssueCount = contributorOpenIssueCount(contributorIssues, input.repoFullName);
+    const scoreInput = { ...input, openIssueCount, applyTimeDecay: isTimeDecayEnabled(this.env) };
+    const preview = buildScorePreview({ input: scoreInput, repo, snapshot, contributorEvidence: evidence });
+    const plan = deriveEligibilityPlan(preview);
+    return {
+      summary: plan.publicSummary,
+      data: plan as unknown as Record<string, unknown>,
     };
   }
 

--- a/test/unit/mcp-eligibility-plan.test.ts
+++ b/test/unit/mcp-eligibility-plan.test.ts
@@ -1,7 +1,7 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { describe, expect, it } from "vitest";
-import { upsertRepositoryFromGitHub } from "../../src/db/repositories";
+import { upsertIssueFromGitHub, upsertRepositoryFromGitHub } from "../../src/db/repositories";
 import { GittensoryMcp } from "../../src/mcp/server";
 import { createTestEnv } from "../helpers/d1";
 
@@ -110,5 +110,34 @@ describe("MCP gittensory_get_eligibility_plan (#2222)", () => {
     expect(plan.branchEligibilityStatus).toBe("unknown");
     expect(plan.publicSummary).toMatch(/not yet validated/i);
     expect(plan.cleanupPaths.join(" ")).toMatch(/solved-by-PR|mirror/i);
+  });
+
+  it("uses contributor-scoped issue counts when contributorLogin is supplied", async () => {
+    const env = createTestEnv();
+    await upsertRepositoryFromGitHub(env, { name: "demo", full_name: "octo/demo", private: false, owner: { login: "octo" }, default_branch: "main" });
+    for (const number of [1, 2, 3]) {
+      await upsertIssueFromGitHub(env, "octo/demo", {
+        number,
+        title: `Open contributor issue ${number}`,
+        state: "open",
+        user: { login: "alice" },
+        labels: [],
+        body: "Issue body",
+      });
+    }
+    const server = new GittensoryMcp(env).createServer();
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    const client = new Client({ name: "gittensory-eligibility-plan-contributor-test", version: "0.1.0" }, { capabilities: {} });
+    await client.connect(clientTransport);
+
+    const plan = await callPlan(client, {
+      ...BASE_ARGS,
+      contributorLogin: "alice",
+      linkedIssueMode: "none",
+    });
+
+    expect(plan.linkedIssueStatus).toBe("not_required");
+    expect(plan.branchEligibilityStatus).toBe("not_required");
   });
 });

--- a/test/unit/mcp-eligibility-plan.test.ts
+++ b/test/unit/mcp-eligibility-plan.test.ts
@@ -1,0 +1,114 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { describe, expect, it } from "vitest";
+import { upsertRepositoryFromGitHub } from "../../src/db/repositories";
+import { GittensoryMcp } from "../../src/mcp/server";
+import { createTestEnv } from "../helpers/d1";
+
+const FORBIDDEN_PUBLIC_LANGUAGE = /wallet|hotkey|coldkey|mnemonic|seed phrase|payout|raw trust|trust score|reward estimate|farming|private reviewability|scoreability|private ranking/i;
+
+const BASE_ARGS = {
+  repoFullName: "octo/demo",
+  sourceTokenScore: 60,
+  totalTokenScore: 80,
+  sourceLines: 50,
+  credibility: 1,
+  metadataOnly: true,
+};
+
+async function connect(env: Env = createTestEnv()) {
+  await upsertRepositoryFromGitHub(env, { name: "demo", full_name: "octo/demo", private: false, owner: { login: "octo" }, default_branch: "main" });
+  const server = new GittensoryMcp(env).createServer();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  const client = new Client({ name: "gittensory-eligibility-plan-test", version: "0.1.0" }, { capabilities: {} });
+  await client.connect(clientTransport);
+  return client;
+}
+
+type EligibilityPlanPayload = {
+  eligible: boolean;
+  linkedIssueStatus: string;
+  branchEligibilityStatus: string;
+  blockers: string[];
+  cleanupPaths: string[];
+  linkedIssueProjection: string | null;
+  publicSummary: string;
+};
+
+async function callPlan(client: Client, arguments_: Record<string, unknown>): Promise<EligibilityPlanPayload> {
+  const result = await client.callTool({ name: "gittensory_get_eligibility_plan", arguments: arguments_ });
+  expect(result.isError).toBeFalsy();
+  const data = result.structuredContent as EligibilityPlanPayload;
+  expect(JSON.stringify(data)).not.toMatch(FORBIDDEN_PUBLIC_LANGUAGE);
+  return data;
+}
+
+describe("MCP gittensory_get_eligibility_plan (#2222)", () => {
+  it("returns an eligible maintainer-lane plan", async () => {
+    const client = await connect();
+    const plan = await callPlan(client, {
+      ...BASE_ARGS,
+      linkedIssueMode: "maintainer",
+    });
+    expect(plan.eligible).toBe(true);
+    expect(plan.linkedIssueStatus).toBe("not_required");
+    expect(plan.branchEligibilityStatus).toBe("not_required");
+    expect(plan.blockers).toEqual([]);
+    expect(typeof plan.publicSummary).toBe("string");
+  });
+
+  it("returns not_required statuses when linked-issue mode is none", async () => {
+    const client = await connect();
+    const plan = await callPlan(client, {
+      ...BASE_ARGS,
+      linkedIssueMode: "none",
+    });
+    expect(plan.eligible).toBe(false);
+    expect(plan.linkedIssueStatus).toBe("not_required");
+    expect(plan.branchEligibilityStatus).toBe("not_required");
+    expect(plan.publicSummary).toMatch(/not required/i);
+    expect(plan.linkedIssueProjection).toBeNull();
+  });
+
+  it("returns an ineligible-branch plan for confirmed ineligible branch metadata", async () => {
+    const client = await connect();
+    const plan = await callPlan(client, {
+      ...BASE_ARGS,
+      linkedIssueMode: "standard",
+      linkedIssueContext: {
+        status: "validated",
+        source: "official_mirror",
+        issueNumbers: [55],
+        solvedByPullRequests: [56],
+      },
+      branchEligibility: {
+        status: "ineligible",
+        reason: "Base branch is not a registered registry branch.",
+      },
+    });
+    expect(plan.eligible).toBe(false);
+    expect(plan.branchEligibilityStatus).toBe("ineligible");
+    expect(plan.blockers.join(" ")).toMatch(/eligible branch/i);
+    expect(plan.cleanupPaths.join(" ")).toMatch(/eligible branch/i);
+    expect(plan.publicSummary).toMatch(/branch blocker/i);
+  });
+
+  it("returns an unvalidated-linked-issue plan for raw issue context", async () => {
+    const client = await connect();
+    const plan = await callPlan(client, {
+      ...BASE_ARGS,
+      linkedIssueMode: "standard",
+      linkedIssueContext: {
+        status: "raw",
+        source: "user_supplied",
+        issueNumbers: [12],
+      },
+    });
+    expect(plan.eligible).toBe(false);
+    expect(plan.linkedIssueStatus).toBe("raw");
+    expect(plan.branchEligibilityStatus).toBe("unknown");
+    expect(plan.publicSummary).toMatch(/not yet validated/i);
+    expect(plan.cleanupPaths.join(" ")).toMatch(/solved-by-PR|mirror/i);
+  });
+});

--- a/test/unit/mcp-output-schemas.test.ts
+++ b/test/unit/mcp-output-schemas.test.ts
@@ -33,6 +33,7 @@ const TOOLS_WITH_OUTPUT_SCHEMA = [
   "gittensory_local_status",
   "gittensory_remediation_plan",
   "gittensory_explain_score_breakdown",
+  "gittensory_get_eligibility_plan",
   "gittensory_simulate_open_pr_pressure",
 ];
 
@@ -442,6 +443,31 @@ describe("MCP tool calls return schema-valid structured content", () => {
       arguments: { repoFullName: "octo/demo", sourceTokenScore: 40, totalTokenScore: 60, sourceLines: 80 },
     });
     expect(result.isError).toBe(true);
+  });
+
+  it("gittensory_get_eligibility_plan returns validated structured content", async () => {
+    const env = createTestEnv();
+    await upsertRepositoryFromGitHub(env, { name: "demo", full_name: "octo/demo", private: false, owner: { login: "octo" }, default_branch: "main" });
+    const { client } = await connectTestClient(env);
+    const result = await client.callTool({
+      name: "gittensory_get_eligibility_plan",
+      arguments: {
+        repoFullName: "octo/demo",
+        linkedIssueMode: "none",
+        sourceTokenScore: 40,
+        totalTokenScore: 60,
+        sourceLines: 80,
+        credibility: 1,
+      },
+    });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as Record<string, unknown>;
+    expect(data.eligible).toBe(false);
+    expect(data.linkedIssueStatus).toBe("not_required");
+    expect(data.branchEligibilityStatus).toBe("not_required");
+    expect(Array.isArray(data.blockers)).toBe(true);
+    expect(Array.isArray(data.cleanupPaths)).toBe(true);
+    expect(typeof data.publicSummary).toBe("string");
   });
 
   it("gittensory_lint_pr_text returns a deterministic verdict and fixes", async () => {


### PR DESCRIPTION
## Summary

- Register `gittensory_get_eligibility_plan` on the hosted MCP server using `scorePreviewShape` (same input as `gittensory_preview_local_pr_score`).
- Handler builds a `ScorePreviewResult` then calls `deriveEligibilityPlan`, returning the public-safe `EligibilityPlan` fields.
- Add `eligibilityPlanOutputSchema` and tests covering eligible, ineligible-branch, unvalidated-linked-issue, and not_required status branches.

Closes #2222.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [x] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran focused tests: `mcp-eligibility-plan`, `mcp-output-schemas`, `npm run typecheck`, `npm run build:mcp`, `npm audit --audit-level=moderate`. Full `npm run test:ci` blocked locally by missing `wrangler` (`cf-typegen:check`); remaining gate jobs left to CI.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — MCP tool only; no visible UI.

## Notes

- Maintainer-lane input exercises the eligible path because MCP score-preview input cannot assert caller-supplied eligible branch metadata (transformed to unknown).
