### PR TITLE
fix: resolve draft OAuth redirect origin trust

### DIFF
--- a/src/services/draft.ts
+++ b/src/services/draft.ts
@@ -573,6 +573,13 @@ export async function handleDraftCreate(request: Request, env: Env): Promise<Res
     return json({ ok: false, error: error instanceof Error ? error.message : "invalid_submission" }, 400);
   }
 
+  let origin: string;
+  try {
+    origin = trustedDraftOAuthOrigin(env, request.url);
+  } catch {
+    return json({ ok: false, error: "draft_flow_not_configured" }, 503);
+  }
+
   const id = newDraftId("draft");
   const state = randomDraftToken();
   await env.DB.prepare(
@@ -582,12 +589,6 @@ export async function handleDraftCreate(request: Request, env: Env): Promise<Res
     .bind(id, target.category, target.slug, target.targetPath, target.branchName, config.baseRef, JSON.stringify(fields), await sha256Hex(state))
     .run();
 
-  let origin: string;
-  try {
-    origin = trustedDraftOAuthOrigin(env, request.url);
-  } catch {
-    return json({ ok: false, error: "draft_flow_not_configured" }, 503);
-  }
   const authUrl = new URL("https://github.com/login/oauth/authorize");
   authUrl.searchParams.set("client_id", clientId);
   authUrl.searchParams.set("redirect_uri", `${origin}/v1/drafts/auth/callback`);

--- a/src/services/draft.ts
+++ b/src/services/draft.ts
@@ -58,6 +58,14 @@ function draftSecrets(env: Env): { clientId: string; clientSecret: string; encKe
   };
 }
 
+function trustedDraftOAuthOrigin(env: Env, requestUrl: string): string {
+  const configured = String(env.PUBLIC_API_ORIGIN ?? "").trim();
+  if (configured) return new URL(configured).origin;
+  const requestOrigin = new URL(requestUrl).origin;
+  if (/^https?:\/\/(?:localhost|127\.0\.0\.1)(?::\d+)?$/i.test(requestOrigin)) return requestOrigin;
+  throw new Error("draft_flow_not_configured");
+}
+
 interface DraftRow {
   id: string;
   status: string;
@@ -574,7 +582,12 @@ export async function handleDraftCreate(request: Request, env: Env): Promise<Res
     .bind(id, target.category, target.slug, target.targetPath, target.branchName, config.baseRef, JSON.stringify(fields), await sha256Hex(state))
     .run();
 
-  const origin = new URL(request.url).origin;
+  let origin: string;
+  try {
+    origin = trustedDraftOAuthOrigin(env, request.url);
+  } catch {
+    return json({ ok: false, error: "draft_flow_not_configured" }, 503);
+  }
   const authUrl = new URL("https://github.com/login/oauth/authorize");
   authUrl.searchParams.set("client_id", clientId);
   authUrl.searchParams.set("redirect_uri", `${origin}/v1/drafts/auth/callback`);
@@ -635,10 +648,16 @@ export async function handleDraftOAuthCallback(request: Request, env: Env): Prom
 
   const { clientId, clientSecret, encKey } = draftSecrets(env);
   if (!clientId || !clientSecret || !encKey) return new Response("Draft flow not configured.", { status: 503 });
+  let callbackOrigin: string;
+  try {
+    callbackOrigin = trustedDraftOAuthOrigin(env, request.url);
+  } catch {
+    return new Response("Draft flow not configured.", { status: 503 });
+  }
 
   let userToken: string;
   try {
-    userToken = await exchangeGitHubUserCode({ clientId, clientSecret, code, callbackUrl: `${url.origin}/v1/drafts/auth/callback` });
+    userToken = await exchangeGitHubUserCode({ clientId, clientSecret, code, callbackUrl: `${callbackOrigin}/v1/drafts/auth/callback` });
   } catch {
     return new Response("GitHub authorization failed.", { status: 400 });
   }
@@ -657,7 +676,7 @@ export async function handleDraftOAuthCallback(request: Request, env: Env): Prom
   await env.JOBS.send({ type: "submit-draft", requestedBy: "api", draftId });
 
   return new Response(`<meta http-equiv="refresh" content="0; url=/v1/drafts/${draftId}">Submission queued.`, {
-    headers: { "content-type": "text/html", "set-cookie": draftOAuthCookie("", url.origin, 0) },
+    headers: { "content-type": "text/html", "set-cookie": draftOAuthCookie("", callbackOrigin, 0) },
   });
 }
 

--- a/test/unit/draft.test.ts
+++ b/test/unit/draft.test.ts
@@ -896,6 +896,8 @@ describe("handleDraftCreate — nested body.fields branch + title fallbacks", ()
     );
     expect(res.status).toBe(503);
     expect((await res.json()) as { error: string }).toMatchObject({ error: "draft_flow_not_configured" });
+    const row = await env.DB.prepare("SELECT COUNT(*) AS n FROM submission_drafts").first<{ n: number }>();
+    expect(row?.n).toBe(0);
   });
 
   it("returns 404 when the flag is off (handleDraftCreate guard)", async () => {
@@ -1274,6 +1276,28 @@ describe("handleDraftOAuthCallback — extra guards", () => {
     fetchSpy.mockRestore();
     expect(res.status).toBe(400);
     expect(await res.text()).toBe("GitHub authorization failed.");
+  });
+
+  it("returns 503 in callback when PUBLIC_API_ORIGIN is unset for non-localhost origins", async () => {
+    const app = createApp();
+    const env = draftEnv({ PUBLIC_API_ORIGIN: "" });
+    const localCreated = await app.request(
+      "/v1/drafts",
+      { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(SAMPLE_FIELDS) },
+      env,
+    );
+    const created = (await localCreated.json()) as { authUrl: string };
+    const state = new URL(created.authUrl).searchParams.get("state") ?? "";
+    const cookie = localCreated.headers.get("set-cookie") ?? "";
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const res = await handleDraftOAuthCallback(
+      new Request(`${ORIGIN}/v1/drafts/auth/callback?code=valid&state=${encodeURIComponent(state)}`, { headers: callbackHeaders(cookie) }),
+      env,
+    );
+    expect(res.status).toBe(503);
+    expect(await res.text()).toBe("Draft flow not configured.");
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
   });
 });
 

--- a/test/unit/draft.test.ts
+++ b/test/unit/draft.test.ts
@@ -900,6 +900,18 @@ describe("handleDraftCreate — nested body.fields branch + title fallbacks", ()
     expect(row?.n).toBe(0);
   });
 
+  it("returns 503 when PUBLIC_API_ORIGIN is malformed", async () => {
+    const env = draftEnv({ PUBLIC_API_ORIGIN: "not-a-valid-url" });
+    const res = await handleDraftCreate(
+      new Request(`${ORIGIN}/v1/drafts`, { method: "POST", headers: jsonHeaders(), body: JSON.stringify(SAMPLE_FIELDS) }),
+      env,
+    );
+    expect(res.status).toBe(503);
+    expect((await res.json()) as { error: string }).toMatchObject({ error: "draft_flow_not_configured" });
+    const row = await env.DB.prepare("SELECT COUNT(*) AS n FROM submission_drafts").first<{ n: number }>();
+    expect(row?.n).toBe(0);
+  });
+
   it("returns 404 when the flag is off (handleDraftCreate guard)", async () => {
     const env = createTestEnv(); // flag unset
     const res = await handleDraftCreate(new Request(`${ORIGIN}/v1/drafts`, { method: "POST", headers: jsonHeaders(), body: JSON.stringify(SAMPLE_FIELDS) }), env);
@@ -1293,6 +1305,25 @@ describe("handleDraftOAuthCallback — extra guards", () => {
     const res = await handleDraftOAuthCallback(
       new Request(`${ORIGIN}/v1/drafts/auth/callback?code=valid&state=${encodeURIComponent(state)}`, { headers: callbackHeaders(cookie) }),
       env,
+    );
+    expect(res.status).toBe(503);
+    expect(await res.text()).toBe("Draft flow not configured.");
+    expect(fetchSpy).not.toHaveBeenCalled();
+    fetchSpy.mockRestore();
+  });
+
+  it("returns 503 in callback when PUBLIC_API_ORIGIN is malformed", async () => {
+    const app = createApp();
+    const createEnv = draftEnv({ PUBLIC_API_ORIGIN: ORIGIN });
+    const created = await app.request("/v1/drafts", { method: "POST", headers: jsonHeaders(), body: JSON.stringify(SAMPLE_FIELDS) }, createEnv);
+    const payload = (await created.json()) as { authUrl: string };
+    const state = new URL(payload.authUrl).searchParams.get("state") ?? "";
+    const cookie = created.headers.get("set-cookie") ?? "";
+    const callbackEnv = draftEnv({ PUBLIC_API_ORIGIN: "not-a-valid-url", DB: createEnv.DB });
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const res = await handleDraftOAuthCallback(
+      new Request(`${ORIGIN}/v1/drafts/auth/callback?code=valid&state=${encodeURIComponent(state)}`, { headers: callbackHeaders(cookie) }),
+      callbackEnv,
     );
     expect(res.status).toBe(503);
     expect(await res.text()).toBe("Draft flow not configured.");

--- a/test/unit/draft.test.ts
+++ b/test/unit/draft.test.ts
@@ -12,6 +12,7 @@ function draftEnv(overrides: Partial<Env> = {}): Env {
     GITHUB_OAUTH_CLIENT_ID: "Iv-test-client-id",
     GITHUB_OAUTH_CLIENT_SECRET: "test-oauth-client-secret",
     DRAFT_TOKEN_ENCRYPTION_SECRET: DRAFT_SECRET,
+    PUBLIC_API_ORIGIN: ORIGIN,
     ...overrides,
   });
 }
@@ -92,9 +93,8 @@ describe("draft endpoints — flag ON, public + unauthenticated", () => {
     const authUrl = new URL(body.authUrl);
     expect(authUrl.origin + authUrl.pathname).toBe("https://github.com/login/oauth/authorize");
     expect(authUrl.searchParams.get("client_id")).toBe("Iv-test-client-id");
-    // The callback URL is derived from the request origin (matches reviewbot). `app.request` with a
-    // path-only URL resolves the origin to http://localhost, so the redirect_uri lives under it.
-    expect(authUrl.searchParams.get("redirect_uri")).toBe("http://localhost/v1/drafts/auth/callback");
+    // The callback URL is anchored to PUBLIC_API_ORIGIN.
+    expect(authUrl.searchParams.get("redirect_uri")).toBe(`${ORIGIN}/v1/drafts/auth/callback`);
     expect(authUrl.searchParams.get("state")?.startsWith(`${body.draftId}.`)).toBe(true);
     expect(res.headers.get("set-cookie")).toContain("gittensory_draft_oauth=");
     expect(res.headers.get("set-cookie")).toContain("HttpOnly");
@@ -872,6 +872,28 @@ describe("handleDraftCreate — nested body.fields branch + title fallbacks", ()
   it("returns 503 when the OAuth client id is missing (draftSecrets clientId empty branch)", async () => {
     const env = draftEnv({ GITHUB_OAUTH_CLIENT_ID: "" });
     const res = await handleDraftCreate(new Request(`${ORIGIN}/v1/drafts`, { method: "POST", headers: jsonHeaders(), body: JSON.stringify(SAMPLE_FIELDS) }), env);
+    expect(res.status).toBe(503);
+    expect((await res.json()) as { error: string }).toMatchObject({ error: "draft_flow_not_configured" });
+  });
+
+  it("falls back to localhost request origin when PUBLIC_API_ORIGIN is unset (dev-only path)", async () => {
+    const env = draftEnv({ PUBLIC_API_ORIGIN: "" });
+    const res = await handleDraftCreate(
+      new Request("http://localhost/v1/drafts", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(SAMPLE_FIELDS) }),
+      env,
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { authUrl: string };
+    const authUrl = new URL(body.authUrl);
+    expect(authUrl.searchParams.get("redirect_uri")).toBe("http://localhost/v1/drafts/auth/callback");
+  });
+
+  it("returns 503 when PUBLIC_API_ORIGIN is unset for non-localhost origins", async () => {
+    const env = draftEnv({ PUBLIC_API_ORIGIN: "" });
+    const res = await handleDraftCreate(
+      new Request(`${ORIGIN}/v1/drafts`, { method: "POST", headers: jsonHeaders(), body: JSON.stringify(SAMPLE_FIELDS) }),
+      env,
+    );
     expect(res.status).toBe(503);
     expect((await res.json()) as { error: string }).toMatchObject({ error: "draft_flow_not_configured" });
   });


### PR DESCRIPTION
## No-issue rationale
This is a security/correctness hotfix from external contribution. I do not have permission to create issues in this repository (`CreateIssue` permission denied), so this PR includes full root-cause details inline.

Supersedes closed PR #4237 (same fix intent, expanded with pre-insert fail-closed behavior and added callback misconfiguration test coverage).

## Root cause
Draft OAuth used request-derived origin when constructing `redirect_uri`, allowing proxy/misconfigured host values to influence callback binding.

## Fix approach
- Add `trustedDraftOAuthOrigin()` and prefer canonical `PUBLIC_API_ORIGIN`.
- Allow request-origin fallback only for `localhost` / `127.0.0.1` (dev-only).
- Fail closed with 503 when trusted origin is unavailable.
- Validate trusted origin before inserting draft rows to avoid orphan rows in misconfigured production.
- Add unit coverage for callback misconfiguration and no-row-on-503 behavior.

## Impact
- Production draft OAuth callback binding is deterministic and trusted.
- Misconfigured non-localhost deployments fail safely.
- No behavior change for localhost development.

## Validation
- `npx vitest run test/unit/draft.test.ts`
- `npm run typecheck`

## Risk / tradeoffs
Instances that rely on non-localhost draft OAuth without setting `PUBLIC_API_ORIGIN` now receive a clear 503 until configured.