### PR TITLE
feat(mcp): add gittensory_get_repo_onboarding_pack tool

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -94,6 +94,7 @@ import { computeFleetAnalytics } from "../orb/analytics";
 import { loadMaintainerNoiseReport, maintainerNoiseSummary } from "../services/maintainer-noise";
 import { loadLabelAudit, labelAuditSummary } from "../services/label-audit";
 import { loadMaintainerLaneReport, maintainerLaneSummary } from "../services/maintainer-lane";
+import { buildRepoOnboardingPackPreviewForRepo } from "../services/repo-onboarding-pack";
 import { buildUnavailableQueueTrendReport } from "../services/queue-trends";
 import {
   applyMcpPlanningChoices,
@@ -750,6 +751,14 @@ const maintainerLaneOutputSchema = {
   summary: z.string().optional(),
 };
 
+const repoOnboardingPackOutputSchema = {
+  repoFullName: z.string().optional(),
+  accepted: z.boolean().optional(),
+  preview: z.unknown().optional(),
+  policySource: z.string().optional(),
+  error: z.string().optional(),
+};
+
 const freshnessResponseOutputSchema = {
   status: z.string().optional(),
   repoFullName: z.string().optional(),
@@ -1314,6 +1323,17 @@ export class GittensoryMcp {
         outputSchema: maintainerLaneOutputSchema,
       },
       async (input) => this.toolResult(await this.getMaintainerLane(input)),
+    );
+
+    server.registerTool(
+      "gittensory_get_repo_onboarding_pack",
+      {
+        description:
+          "Preview-only onboarding pack for a repository owner (contribution lanes, label policy, and public-safe guidance). Not published to GitHub.",
+        inputSchema: ownerRepoShape,
+        outputSchema: repoOnboardingPackOutputSchema,
+      },
+      async (input) => this.toolResult(await this.getRepoOnboardingPack(input)),
     );
 
     server.registerTool(
@@ -2280,6 +2300,22 @@ export class GittensoryMcp {
     return {
       summary: maintainerLaneSummary(report),
       data: report as unknown as Record<string, unknown>,
+    };
+  }
+
+  private async getRepoOnboardingPack(input: { owner: string; repo: string }): Promise<ToolPayload> {
+    const fullName = `${input.owner}/${input.repo}`;
+    await this.requireRepoAccess(fullName);
+    const response = await buildRepoOnboardingPackPreviewForRepo(this.env, fullName);
+    if ("error" in response) {
+      return {
+        summary: `Onboarding pack preview unavailable for ${fullName}: repository is not accepted.`,
+        data: response as unknown as Record<string, unknown>,
+      };
+    }
+    return {
+      summary: `Gittensory onboarding pack preview for ${fullName} (preview-only, not published).`,
+      data: response as unknown as Record<string, unknown>,
     };
   }
 

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -5146,6 +5146,7 @@ describe("api routes", () => {
     expect(toolNames).toContain("gittensory_get_maintainer_noise");
     expect(toolNames).toContain("gittensory_get_label_audit");
     expect(toolNames).toContain("gittensory_get_maintainer_lane");
+    expect(toolNames).toContain("gittensory_get_repo_onboarding_pack");
     expect(toolNames).toContain("gittensory_get_issue_quality");
     expect(toolNames).toContain("gittensory_get_burden_forecast");
     expect(toolNames).toContain("gittensory_get_contributor_profile");

--- a/test/unit/mcp-output-schemas.test.ts
+++ b/test/unit/mcp-output-schemas.test.ts
@@ -15,6 +15,7 @@ const TOOLS_WITH_OUTPUT_SCHEMA = [
   "gittensory_get_maintainer_noise",
   "gittensory_get_label_audit",
   "gittensory_get_maintainer_lane",
+  "gittensory_get_repo_onboarding_pack",
   "gittensory_get_burden_forecast",
   "gittensory_get_repo_outcome_patterns",
   "gittensory_get_outcome_calibration",
@@ -292,6 +293,22 @@ describe("MCP tool calls return schema-valid structured content", () => {
     expect(data.lane).toBeTruthy();
     expect(data.contributorIntakeHealth).toBeTruthy();
     expect(JSON.stringify(data)).not.toMatch(/hotkey|coldkey|wallet|payout|reward/i);
+  });
+
+  it("gittensory_get_repo_onboarding_pack returns a structured preview for a registered repo", async () => {
+    const env = createTestEnv();
+    await upsertRepositoryFromGitHub(env, { name: "demo", full_name: "octo/demo", private: false, owner: { login: "octo" } });
+    await env.DB.prepare("UPDATE repositories SET is_registered = 1 WHERE full_name = ?").bind("octo/demo").run();
+    const { client } = await connectTestClient(env);
+    const result = await client.callTool({ name: "gittensory_get_repo_onboarding_pack", arguments: { owner: "octo", repo: "demo" } });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as Record<string, unknown>;
+    expect(data).toMatchObject({
+      repoFullName: "octo/demo",
+      accepted: true,
+      policySource: "policy_compiler",
+      preview: { previewOnly: true, publicSafe: true },
+    });
   });
 
   it("gittensory_validate_linked_issue reports multiplier eligibility for an uncached issue", async () => {

--- a/test/unit/mcp-repo-onboarding-pack.test.ts
+++ b/test/unit/mcp-repo-onboarding-pack.test.ts
@@ -1,0 +1,103 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { describe, expect, it } from "vitest";
+import { createSessionForGitHubUser, type AuthIdentity } from "../../src/auth/security";
+import { persistSignalSnapshot, upsertInstallation, upsertRepositoryFromGitHub } from "../../src/db/repositories";
+import { GittensoryMcp } from "../../src/mcp/server";
+import { createTestEnv } from "../helpers/d1";
+
+async function connect(env: Env, identity?: AuthIdentity): Promise<Client> {
+  const server = (identity ? new GittensoryMcp(env, identity) : new GittensoryMcp(env)).createServer();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  const client = new Client({ name: "repo-onboarding-pack-test", version: "0.1.0" }, { capabilities: {} });
+  await client.connect(clientTransport);
+  return client;
+}
+
+async function seedRegisteredInstalledRepo(env: Env, installationId: number, owner: string, name: string): Promise<void> {
+  await upsertInstallation(env, {
+    installation: {
+      id: installationId,
+      account: { login: owner, id: installationId, type: "User" },
+      repository_selection: "selected",
+      permissions: { metadata: "read", contents: "read" },
+      events: ["repository"],
+    },
+  });
+  await upsertRepositoryFromGitHub(
+    env,
+    { name, full_name: `${owner}/${name}`, private: false, owner: { login: owner } },
+    installationId,
+  );
+  await env.DB.prepare("UPDATE repositories SET is_registered = 1 WHERE full_name = ?")
+    .bind(`${owner}/${name}`)
+    .run();
+}
+
+describe("gittensory_get_repo_onboarding_pack MCP tool (#2223)", () => {
+  it("returns a structured onboarding-pack preview for an authorized repo maintainer session", async () => {
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
+    await seedRegisteredInstalledRepo(env, 201, "repo-owner", "owned-repo");
+    await persistSignalSnapshot(env, {
+      id: "owned-repo-focus-manifest",
+      signalType: "repo-focus-manifest",
+      targetKey: "repo-owner/owned-repo",
+      repoFullName: "repo-owner/owned-repo",
+      payload: {
+        wantedPaths: ["src/"],
+        testExpectations: ["npm test"],
+        publicNotes: ["Keep onboarding guidance public-safe."],
+      },
+      generatedAt: new Date().toISOString(),
+    });
+    const { session } = await createSessionForGitHubUser(env, { login: "repo-owner", id: 201 });
+    const result = await (await connect(env, { kind: "session", actor: "repo-owner", session })).callTool({
+      name: "gittensory_get_repo_onboarding_pack",
+      arguments: { owner: "repo-owner", repo: "owned-repo" },
+    });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as Record<string, unknown>;
+    expect(data).toMatchObject({
+      repoFullName: "repo-owner/owned-repo",
+      accepted: true,
+      policySource: "policy_compiler",
+      preview: { previewOnly: true, publicSafe: true },
+    });
+    expect(JSON.stringify(data)).not.toMatch(/hotkey|coldkey|wallet|payout|reward/i);
+  });
+
+  it("forbids a session that cannot access the repository", async () => {
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
+    await seedRegisteredInstalledRepo(env, 201, "repo-owner", "owned-repo");
+    await seedRegisteredInstalledRepo(env, 202, "other-owner", "other-repo");
+    const { session } = await createSessionForGitHubUser(env, { login: "other-owner", id: 202 });
+    const result = await (await connect(env, { kind: "session", actor: "other-owner", session })).callTool({
+      name: "gittensory_get_repo_onboarding_pack",
+      arguments: { owner: "repo-owner", repo: "owned-repo" },
+    });
+    expect(result.isError).toBe(true);
+    expect(JSON.stringify(result.content)).toMatch(/cannot access this repository/i);
+  });
+
+  it("returns repo_not_accepted when the repository is not registered", async () => {
+    const env = createTestEnv();
+    await upsertRepositoryFromGitHub(env, {
+      name: "unregistered",
+      full_name: "octo/unregistered",
+      private: false,
+      owner: { login: "octo" },
+    });
+    const result = await (await connect(env)).callTool({
+      name: "gittensory_get_repo_onboarding_pack",
+      arguments: { owner: "octo", repo: "unregistered" },
+    });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as Record<string, unknown>;
+    expect(data).toMatchObject({
+      error: "repo_not_accepted",
+      repoFullName: "octo/unregistered",
+    });
+    expect(result.content).toEqual([expect.objectContaining({ text: expect.stringMatching(/not accepted/i) })]);
+  });
+});


### PR DESCRIPTION
## Summary

- Register `gittensory_get_repo_onboarding_pack` on the hosted MCP server with `ownerRepoShape` input and a zod output schema for the onboarding-pack preview shape.
- Handler calls `buildRepoOnboardingPackPreviewForRepo` behind `requireRepoAccess`, returning `repo_not_accepted` when the repository is not registered.
- Add unit tests for authorized maintainer session, unauthorized cross-repo session, and unregistered-repo branches; extend output-schema and tools/list coverage.

Closes #2223

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck` (passed before rebase onto latest `main`; upstream added `aws4fetch` for selfhost S3 — CI installs full deps)
- [x] `npm run test:coverage` locally on focused MCP onboarding-pack tests; branch arms in `getRepoOnboardingPack` covered (success, `repo_not_accepted`, forbidden session)
- [ ] `npm run test:workers`
- [x] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Full local `npm run validate` / `test:ci` not run end-to-end here (large suite + local env variance); focused MCP tests, `build:mcp`, and `npm audit` were run. CI `validate` is the authoritative gate.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — MCP server change only; no visible UI.

## Notes

- Mirrors existing repo-scoped read tools (`gittensory_get_maintainer_lane`, `gittensory_get_label_audit`) for access control and structured output.