### PR TITLE
fix(mcp-cli): add the missing gittensory_get_label_audit CLI descriptor

### DIFF
--- a/packages/gittensory-mcp/bin/gittensory-mcp.js
+++ b/packages/gittensory-mcp/bin/gittensory-mcp.js
@@ -409,6 +409,11 @@ const STDIO_TOOL_DESCRIPTORS = [
     description: "Return the latest cached Gittensor upstream ruleset drift status (stale/drift warnings) for MCP planning.",
   },
   {
+    name: "gittensory_get_label_audit",
+    description:
+      "Return the repo's label-policy audit (configured-vs-live labels, missing configured labels, suspicious status/source-style labels, and trusted-label-pipeline readiness) from the private Gittensory API.",
+  },
+  {
     name: "gittensory_preview_local_pr_score",
     description: "Inspect local diff metadata and request a private Gittensory scoring preview. No source contents are uploaded.",
   },
@@ -670,8 +675,7 @@ server.registerTool(
 server.registerTool(
   "gittensory_get_label_audit",
   {
-    description:
-      "Return the repo's label-policy audit (configured-vs-live labels, missing configured labels, suspicious status/source-style labels, and trusted-label-pipeline readiness) from the private Gittensory API.",
+    description: stdioToolDescription("gittensory_get_label_audit"),
     inputSchema: ownerRepoShape,
   },
   async ({ owner, repo }) => {


### PR DESCRIPTION
## Summary

- `test/unit/mcp-cli-tools.test.ts`'s tool-count assertion (`expect(payload.count).toBe(registered.length)`) has been failing on `main` (confirmed on a clean checkout, unrelated to any other change): the stdio MCP server has 34 tools registered via `server.registerTool`, but the CLI's `tools`/`tools --json` subcommand only reported 33.
- Root cause: #4219 registered `gittensory_get_label_audit` with its description written **inline** in the `server.registerTool` call, instead of following the established pattern every other tool uses — add an entry to the shared `STDIO_TOOL_DESCRIPTORS` array and reference it via `stdioToolDescription(name)`. The CLI's `tools`/`tools --json` output is built entirely from `STDIO_TOOL_DESCRIPTORS`, so a tool registered only inline never showed up there.
- Fix: added the missing descriptor entry (copied verbatim from the tool's own existing inline description, so the CLI output text doesn't change at all — this is a pure plumbing fix, not a content change), and switched the `registerTool` call to reference it via `stdioToolDescription("gittensory_get_label_audit")`, matching the neighboring tool's own pattern and preventing this exact class of drift from recurring.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally (unsharded, fresh `npm ci`) — full suite green, including the previously-failing `test/unit/mcp-cli-tools.test.ts`.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests — this fix makes an **already-existing** test (`test/unit/mcp-cli-tools.test.ts`) pass; no new test needed since the existing assertion already covers this exact drift class (any future tool registered without a matching descriptor entry will fail the same way).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests — n/a, no auth/session code touched.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed — the MCP tool's actual behavior/schema/description is unchanged; only its CLI-listing visibility is fixed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks — n/a, no UI changed.
- [ ] UI Evidence — not applicable, no visible UI/frontend/docs/extension change in this PR.
- [x] Public docs/changelogs are updated where needed (none needed); changelog itself is untouched.