### PR TITLE
feat(mcp): add gittensory_get_gate_precision measurement tool

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -95,6 +95,7 @@ import { loadMaintainerNoiseReport, maintainerNoiseSummary } from "../services/m
 import { loadLabelAudit, labelAuditSummary } from "../services/label-audit";
 import { loadMaintainerLaneReport, maintainerLaneSummary } from "../services/maintainer-lane";
 import { buildRepoOnboardingPackPreviewForRepo } from "../services/repo-onboarding-pack";
+import { loadGatePrecisionReport } from "../services/gate-precision";
 import { buildUnavailableQueueTrendReport } from "../services/queue-trends";
 import {
   applyMcpPlanningChoices,
@@ -778,6 +779,18 @@ const maintainerMeasurementReportOutputSchema = {
   status: z.string().optional(),
 };
 
+// #2220 - gate-precision measurement surfaced over MCP. Mirrors the
+// maintainerMeasurementReportOutputSchema pattern: report fields optional, structured sub-reports as
+// z.unknown() (buildGatePrecisionReport is the single source of truth for their shape).
+const gatePrecisionOutputSchema = {
+  repoFullName: z.string().optional(),
+  generatedAt: z.string().optional(),
+  windowDays: z.number().nullable().optional(),
+  perGateType: z.array(z.unknown()).optional(),
+  overall: z.unknown().optional(),
+  signals: z.array(z.string()).optional(),
+};
+
 const contributorProfileOutputSchema = {
   login: z.string().optional(),
   github: z.unknown().optional(),
@@ -1402,6 +1415,17 @@ export class GittensoryMcp {
         outputSchema: maintainerMeasurementReportOutputSchema,
       },
       async (input) => this.toolResult(await this.getOutcomeCalibration(input)),
+    );
+
+    server.registerTool(
+      "gittensory_get_gate_precision",
+      {
+        description:
+          "Return per-gate-type false-positive precision for a repo's recorded gate blocks — blocked / blocked-then-merged / overridden counts and false-positive rates with low-sample guards. Maintainer-authenticated; measurement only.",
+        inputSchema: ownerRepoWindowShape,
+        outputSchema: gatePrecisionOutputSchema,
+      },
+      async (input) => this.toolResult(await this.getGatePrecision(input)),
     );
 
     server.registerTool(
@@ -2583,6 +2607,20 @@ export class GittensoryMcp {
     const report = await buildRepoOutcomeCalibration(this.env, fullName, input.windowDays);
     return {
       summary: outcomeCalibrationSummary(fullName, report.slop),
+      data: report as unknown as Record<string, unknown>,
+    };
+  }
+
+  // #2220 - surface the existing gate-precision measurement over MCP. Same per-repo read gate as
+  // getOutcomeCalibration (requireRepoAccess); loadGatePrecisionReport is measurement-only and already
+  // scoped to the single repo, so nothing cross-repo is revealed. The options object is spread-omitted
+  // when windowDays is absent to satisfy exactOptionalPropertyTypes.
+  private async getGatePrecision(input: { owner: string; repo: string; windowDays?: number | undefined }): Promise<ToolPayload> {
+    const fullName = `${input.owner}/${input.repo}`;
+    await this.requireRepoAccess(fullName);
+    const report = await loadGatePrecisionReport(this.env, fullName, input.windowDays === undefined ? {} : { windowDays: input.windowDays });
+    return {
+      summary: `Gittensory gate precision for ${fullName}: ${report.overall.blocked} gate blocks, overall false-positive rate ${report.overall.falsePositiveRate ?? "n/a (below sample threshold)"}.`,
       data: report as unknown as Record<string, unknown>,
     };
   }

--- a/test/unit/mcp-gate-precision.test.ts
+++ b/test/unit/mcp-gate-precision.test.ts
@@ -1,0 +1,79 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { describe, expect, it } from "vitest";
+import { GittensoryMcp } from "../../src/mcp/server";
+import { recordGateBlockOutcome, upsertPullRequestFromGitHub } from "../../src/db/repositories";
+import { createTestEnv } from "../helpers/d1";
+
+const REPO = "owner/widgets";
+
+async function connect(env: Env) {
+  const server = new GittensoryMcp(env).createServer();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  const client = new Client({ name: "gittensory-gate-precision-test", version: "0.1.0" }, { capabilities: {} });
+  await client.connect(clientTransport);
+  return client;
+}
+
+// 6 blocks citing one code, 2 on PRs that later merged (false positives) → rate 2/6 = 0.333,
+// comfortably above the service's MIN_SAMPLE guard so the per-type rate is a number, not null.
+async function seedGateLedger(env: Env) {
+  for (let n = 1; n <= 6; n += 1) {
+    await recordGateBlockOutcome(env, { repoFullName: REPO, pullNumber: n, headSha: `sha${n}`, blockerCodes: ["missing_linked_issue"] });
+    await upsertPullRequestFromGitHub(env, REPO, {
+      number: n,
+      title: `PR ${n}`,
+      state: "closed",
+      user: { login: "alice" },
+      ...(n <= 2 ? { merged_at: "2026-06-01T00:00:00.000Z" } : {}),
+    });
+  }
+}
+
+describe("MCP gittensory_get_gate_precision (#2220)", () => {
+  it("returns the per-gate-type precision report for an authorized caller and passes windowDays through", async () => {
+    const env = createTestEnv();
+    await seedGateLedger(env);
+    const client = await connect(env);
+    const result = await client.callTool({ name: "gittensory_get_gate_precision", arguments: { owner: "owner", repo: "widgets", windowDays: 30 } });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as {
+      repoFullName: string;
+      windowDays: number | null;
+      perGateType: Array<{ gateType: string; blocked: number; blockedThenMerged: number; falsePositiveRate: number | null }>;
+      overall: { blocked: number; blockedThenMerged: number; falsePositiveRate: number | null };
+      signals: string[];
+    };
+    expect(data.repoFullName).toBe(REPO);
+    expect(data.windowDays).toBe(30);
+    expect(data.overall).toMatchObject({ blocked: 6, blockedThenMerged: 2, falsePositiveRate: 0.333 });
+    expect(data.perGateType[0]).toMatchObject({ gateType: "missing_linked_issue", blocked: 6, blockedThenMerged: 2, falsePositiveRate: 0.333 });
+    expect(Array.isArray(data.signals)).toBe(true);
+    // Numeric branch of the summary's ?? fallback.
+    expect(JSON.stringify(result.content)).toContain("overall false-positive rate 0.333");
+  });
+
+  it("returns an empty report with a null rate when no gate blocks are recorded (no windowDays)", async () => {
+    const env = createTestEnv();
+    const client = await connect(env);
+    const result = await client.callTool({ name: "gittensory_get_gate_precision", arguments: { owner: "owner", repo: "widgets" } });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as { windowDays: number | null; perGateType: unknown[]; overall: { blocked: number; falsePositiveRate: number | null } };
+    expect(data.windowDays).toBeNull();
+    expect(data.perGateType).toEqual([]);
+    expect(data.overall.blocked).toBe(0);
+    expect(data.overall.falsePositiveRate).toBeNull();
+    // Null branch of the summary's ?? fallback.
+    expect(JSON.stringify(result.content)).toContain("n/a (below sample threshold)");
+  });
+
+  it("forbids the static mcp identity when the repo is outside MCP_READ_REPO_ALLOWLIST", async () => {
+    const env = createTestEnv({ MCP_READ_REPO_ALLOWLIST: "" });
+    await seedGateLedger(env);
+    const client = await connect(env);
+    const result = await client.callTool({ name: "gittensory_get_gate_precision", arguments: { owner: "owner", repo: "widgets" } });
+    expect(result.isError).toBeTruthy();
+    expect(JSON.stringify(result.content)).toMatch(/cannot access this repository/i);
+  });
+});

--- a/test/unit/mcp-output-schemas.test.ts
+++ b/test/unit/mcp-output-schemas.test.ts
@@ -36,6 +36,7 @@ const TOOLS_WITH_OUTPUT_SCHEMA = [
   "gittensory_explain_score_breakdown",
   "gittensory_get_eligibility_plan",
   "gittensory_simulate_open_pr_pressure",
+  "gittensory_get_gate_precision",
 ];
 
 async function connectTestClient(env: Env = createTestEnv(), identity?: AuthIdentity) {


### PR DESCRIPTION
## What

The gate-precision report builder and HTTP route already exist (`buildGatePrecisionReport` / `loadGatePrecisionReport` in `src/services/gate-precision.ts`; `GET /v1/repos/:owner/:repo/gate-precision`), but there was no MCP tool wrapper, so agents can't ask "how accurate is my gate?" over MCP the way they can for outcome calibration (`gittensory_get_outcome_calibration`).

This registers `gittensory_get_gate_precision` alongside the other maintainer-intel tools:

- `inputSchema = ownerRepoWindowShape` with the windowDays option spread-omitted when absent (exactOptionalPropertyTypes-safe), passed through to `loadGatePrecisionReport(env, repoFullName, { windowDays })`.
- Same `requireRepoAccess` read gate as `getOutcomeCalibration`.
- zod `outputSchema` mirroring the `maintainerMeasurementReportOutputSchema` convention for report-shaped outputs (structured sub-reports as `z.unknown()`; the service stays the single source of truth), wired into the output-schema inventory test list.
- "Measurement only" posture matching the sibling tools' descriptions.

## Deliverables

- [x] Register `gittensory_get_gate_precision` in `src/mcp/server.ts` alongside the other maintainer-intel tools, `inputSchema=ownerRepoWindowShape`, description "measurement only"
- [x] Private handler calling `loadGatePrecisionReport(env, repoFullName, {windowDays})` behind the same repo-access guard as `getOutcomeCalibration`
- [x] zod outputSchema for the `GatePrecisionReport` shape (mirrors the `maintainerMeasurementReportOutputSchema` pattern)
- [x] Tests: authorized path with a seeded gate-block ledger (per-type + overall rates, windowDays pass-through), empty-ledger path (null false-positive rate), forbidden path, and both branches of the summary's `??` fallback

## Validation

- `npx tsc --noEmit` (0 errors on top of d329591)
- `npx vitest run test/unit/mcp-gate-precision.test.ts test/unit/mcp-output-schemas.test.ts test/unit/gate-precision.test.ts`
- `git diff --check`

Closes #2220