### PR TITLE
feat(engine): add pure governor budget/turn/termination cap calculator (#4288)

### DIFF
--- a/packages/gittensory-engine/src/governor/budget-cap.ts
+++ b/packages/gittensory-engine/src/governor/budget-cap.ts
@@ -1,0 +1,116 @@
+// Governor budget/turn/termination cap calculator (pure).
+// Deterministic, side-effect-free cumulative cap math for the local Governor. Given a caller-supplied usage
+// snapshot and configured ceilings it decides whether another action is permitted and how much budget, turn
+// headroom, and elapsed session time remain. This module computes a verdict only — it does NOT store state,
+// schedule anything, or gate any write action; that enforcement wiring is separate maintainer-owned work (#2340).
+
+import type { GovernorLedgerEventType } from "../governor-ledger.js";
+
+export type GovernorCapLimits = {
+  /** Maximum cumulative cost/budget units permitted for the run (omit to disable this cap). */
+  maxBudget?: number;
+  /** Maximum iteration/turn count permitted for the run (omit to disable this cap). */
+  maxTurns?: number;
+  /** Maximum elapsed session time in milliseconds (omit to disable this cap). */
+  maxElapsedMs?: number;
+};
+
+export type GovernorCapUsage = {
+  /** Cumulative cost/budget units already consumed. */
+  budgetSpent: number;
+  /** Iteration/turn count already taken. */
+  turnsTaken: number;
+  /** Elapsed session time in milliseconds (caller-supplied; never read from a clock here). */
+  elapsedMs: number;
+};
+
+export type GovernorCapDimension = "budget" | "turns" | "termination";
+
+export type GovernorCapVerdict = {
+  /** Verdict vocabulary aligned with GOVERNOR_LEDGER_EVENT_TYPES for downstream ledger wiring. */
+  eventType: GovernorLedgerEventType;
+  /** Whether another action is permitted under the configured caps. */
+  allowed: boolean;
+  /** Human-readable reason for the verdict. */
+  reason: string;
+  /** Remaining budget headroom (`null` when the budget cap is disabled). */
+  remainingBudget: number | null;
+  /** Remaining turn headroom (`null` when the turn cap is disabled). */
+  remainingTurns: number | null;
+  /** Remaining elapsed-time headroom in ms (`null` when the termination cap is disabled). */
+  remainingElapsedMs: number | null;
+  /** Cap dimensions that are at or over their configured ceiling. */
+  triggeredCaps: GovernorCapDimension[];
+};
+
+function finiteNonNegativeInt(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
+function remainingHeadroom(limit: number | undefined, usage: number): number | null {
+  if (limit === undefined) return null;
+  return Math.max(0, finiteNonNegativeInt(limit) - finiteNonNegativeInt(usage));
+}
+
+function isCapTriggered(limit: number | undefined, usage: number): boolean {
+  if (limit === undefined) return false;
+  return finiteNonNegativeInt(usage) >= finiteNonNegativeInt(limit);
+}
+
+/**
+ * Evaluate cumulative budget, turn, and termination caps from a caller-supplied usage snapshot. Pure: it
+ * reads the inputs and returns a verdict without mutating anything. Every numeric input is normalized first,
+ * so a non-finite or negative value can never produce NaN or negative remaining headroom.
+ */
+export function evaluateGovernorCaps(usage: GovernorCapUsage, limits: GovernorCapLimits): GovernorCapVerdict {
+  const budgetSpent = finiteNonNegativeInt(usage.budgetSpent);
+  const turnsTaken = finiteNonNegativeInt(usage.turnsTaken);
+  const elapsedMs = finiteNonNegativeInt(usage.elapsedMs);
+
+  const triggeredCaps: GovernorCapDimension[] = [];
+  if (isCapTriggered(limits.maxBudget, budgetSpent)) triggeredCaps.push("budget");
+  if (isCapTriggered(limits.maxTurns, turnsTaken)) triggeredCaps.push("turns");
+  if (isCapTriggered(limits.maxElapsedMs, elapsedMs)) triggeredCaps.push("termination");
+
+  const remainingBudget = remainingHeadroom(limits.maxBudget, budgetSpent);
+  const remainingTurns = remainingHeadroom(limits.maxTurns, turnsTaken);
+  const remainingElapsedMs = remainingHeadroom(limits.maxElapsedMs, elapsedMs);
+
+  if (triggeredCaps.length === 0) {
+    return {
+      eventType: "allowed",
+      allowed: true,
+      reason: "within_governor_caps",
+      remainingBudget,
+      remainingTurns,
+      remainingElapsedMs,
+      triggeredCaps,
+    };
+  }
+
+  if (triggeredCaps.includes("termination")) {
+    return {
+      eventType: "kill_switch",
+      allowed: false,
+      reason: "termination_cap_exceeded",
+      remainingBudget,
+      remainingTurns,
+      remainingElapsedMs,
+      triggeredCaps,
+    };
+  }
+
+  return {
+    eventType: "denied",
+    allowed: false,
+    reason: triggeredCaps.includes("budget") && triggeredCaps.includes("turns")
+      ? "budget_and_turn_caps_exceeded"
+      : triggeredCaps.includes("budget")
+        ? "budget_cap_exceeded"
+        : "turn_cap_exceeded",
+    remainingBudget,
+    remainingTurns,
+    remainingElapsedMs,
+    triggeredCaps,
+  };
+}

--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -129,6 +129,7 @@ export {
   type TrackRecordTenure,
 } from "./track-record-summary.js";
 export * from "./governor/rate-limit.js";
+export * from "./governor/budget-cap.js";
 export {
   GOVERNOR_LEDGER_EVENT_TYPES,
   normalizeGovernorLedgerEvent,

--- a/test/unit/governor-budget-cap.test.ts
+++ b/test/unit/governor-budget-cap.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import {
+  evaluateGovernorCaps,
+  type GovernorCapLimits,
+  type GovernorCapUsage,
+} from "../../packages/gittensory-engine/src/governor/budget-cap";
+
+const limits: GovernorCapLimits = { maxBudget: 100, maxTurns: 10, maxElapsedMs: 60_000 };
+
+describe("evaluateGovernorCaps (#4288)", () => {
+  it("permits when every configured cap is under its ceiling", () => {
+    const usage: GovernorCapUsage = { budgetSpent: 40, turnsTaken: 3, elapsedMs: 30_000 };
+    const verdict = evaluateGovernorCaps(usage, limits);
+    expect(verdict).toEqual({
+      eventType: "allowed",
+      allowed: true,
+      reason: "within_governor_caps",
+      remainingBudget: 60,
+      remainingTurns: 7,
+      remainingElapsedMs: 30_000,
+      triggeredCaps: [],
+    });
+  });
+
+  it("blocks at the budget ceiling with remaining headroom zero", () => {
+    const verdict = evaluateGovernorCaps({ budgetSpent: 100, turnsTaken: 0, elapsedMs: 0 }, limits);
+    expect(verdict.allowed).toBe(false);
+    expect(verdict.eventType).toBe("denied");
+    expect(verdict.reason).toBe("budget_cap_exceeded");
+    expect(verdict.remainingBudget).toBe(0);
+    expect(verdict.triggeredCaps).toEqual(["budget"]);
+  });
+
+  it("blocks at the turn ceiling", () => {
+    const verdict = evaluateGovernorCaps({ budgetSpent: 0, turnsTaken: 10, elapsedMs: 0 }, limits);
+    expect(verdict.eventType).toBe("denied");
+    expect(verdict.reason).toBe("turn_cap_exceeded");
+    expect(verdict.remainingTurns).toBe(0);
+    expect(verdict.triggeredCaps).toEqual(["turns"]);
+  });
+
+  it("blocks at the termination ceiling with kill_switch", () => {
+    const verdict = evaluateGovernorCaps({ budgetSpent: 0, turnsTaken: 0, elapsedMs: 60_000 }, limits);
+    expect(verdict.eventType).toBe("kill_switch");
+    expect(verdict.reason).toBe("termination_cap_exceeded");
+    expect(verdict.remainingElapsedMs).toBe(0);
+    expect(verdict.triggeredCaps).toEqual(["termination"]);
+  });
+
+  it("prefers kill_switch when termination and budget caps are both exceeded", () => {
+    const verdict = evaluateGovernorCaps({ budgetSpent: 200, turnsTaken: 0, elapsedMs: 90_000 }, limits);
+    expect(verdict.eventType).toBe("kill_switch");
+    expect(verdict.triggeredCaps).toEqual(expect.arrayContaining(["budget", "termination"]));
+  });
+
+  it("reports combined budget and turn denial when both are exceeded", () => {
+    const verdict = evaluateGovernorCaps({ budgetSpent: 150, turnsTaken: 12, elapsedMs: 0 }, limits);
+    expect(verdict.eventType).toBe("denied");
+    expect(verdict.reason).toBe("budget_and_turn_caps_exceeded");
+    expect(verdict.triggeredCaps).toEqual(expect.arrayContaining(["budget", "turns"]));
+  });
+
+  it("treats omitted limits as disabled dimensions with null remaining headroom", () => {
+    const verdict = evaluateGovernorCaps(
+      { budgetSpent: 999, turnsTaken: 999, elapsedMs: 999_999 },
+      {},
+    );
+    expect(verdict.allowed).toBe(true);
+    expect(verdict.remainingBudget).toBeNull();
+    expect(verdict.remainingTurns).toBeNull();
+    expect(verdict.remainingElapsedMs).toBeNull();
+  });
+
+  it("normalizes non-finite and negative inputs so remaining values are never NaN or negative", () => {
+    const verdict = evaluateGovernorCaps(
+      { budgetSpent: NaN, turnsTaken: -3.9, elapsedMs: Number.POSITIVE_INFINITY },
+      { maxBudget: NaN, maxTurns: -5, maxElapsedMs: 1_000 },
+    );
+    for (const value of [verdict.remainingBudget, verdict.remainingTurns, verdict.remainingElapsedMs]) {
+      if (value !== null) {
+        expect(Number.isFinite(value)).toBe(true);
+        expect(value).toBeGreaterThanOrEqual(0);
+      }
+    }
+    expect(verdict.allowed).toBe(false);
+    expect(verdict.eventType).toBe("denied");
+    expect(verdict.reason).toBe("budget_and_turn_caps_exceeded");
+  });
+
+  it("floors fractional usage before comparing against integer caps", () => {
+    const verdict = evaluateGovernorCaps(
+      { budgetSpent: 9.9, turnsTaken: 2.1, elapsedMs: 499.9 },
+      { maxBudget: 10, maxTurns: 3, maxElapsedMs: 500 },
+    );
+    expect(verdict.allowed).toBe(true);
+    expect(verdict.remainingBudget).toBe(1);
+    expect(verdict.remainingTurns).toBe(1);
+    expect(verdict.remainingElapsedMs).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #4288

Adds a pure cumulative cap calculator alongside the existing rolling-window rate limiter:

- New `packages/gittensory-engine/src/governor/budget-cap.ts` with `evaluateGovernorCaps(usage, limits)`
- Three independent dimensions: budget, turns, termination (elapsed ms) — caller-supplied usage, no internal clock
- Verdict vocabulary aligned with `GOVERNOR_LEDGER_EVENT_TYPES` (`allowed` / `denied` / `kill_switch`)
- Input normalization mirrors `rate-limit.ts` `finiteNonNegativeInt` discipline
- Exported from `packages/gittensory-engine/src/index.ts`

## Validation

- `npx vitest run test/unit/governor-budget-cap.test.ts` (9 tests)
- `npm run build --workspace @jsonbored/gittensory-engine`
- `npm run test --workspace @jsonbored/gittensory-engine`

Made with [Cursor](https://cursor.com)