### PR TITLE
feat(portfolio): add non-convergence detector for queue items

### DIFF
--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -163,6 +163,7 @@ export {
   type PromptPacketTextField,
 } from "./prompt-packet.js";
 export * from "./portfolio/queue.js";
+export * from "./portfolio/non-convergence.js";
 export {
   applyAiPolicyFatigueToRankInput,
   createAiPolicyFatigueCacheEntry,

--- a/packages/gittensory-engine/src/portfolio/non-convergence.ts
+++ b/packages/gittensory-engine/src/portfolio/non-convergence.ts
@@ -1,0 +1,94 @@
+// Portfolio non-convergence DETECTOR (pure signal, no enforcement).
+// Deterministic classifier over one local portfolio-queue item's attempt/outcome history. A miner's queue item
+// (portfolio-queue.js, status queued → in_progress → done) can be re-enqueued in place — an item that keeps
+// cycling queued → in_progress → queued without ever reaching done, or that fails repeatedly without improving,
+// is "not converging" and worth flagging so a later stage can stop spending budget on it. This module computes
+// a verdict from typed counts ONLY: no IO, no clock read, no randomness, and it does not enforce, gate, or block
+// any action by itself. It mirrors classifyContributorFit's pure-classifier-over-typed-input shape (including
+// its "absence of history is not evidence of a problem" rule) and rate-limit.ts's numbers-only discipline. Its
+// output is one input signal for the fail-closed Governor chokepoint that composes it later — that composition
+// (rate-limit + budget caps + this detector) is separate, maintainer-owned work (#2340), not this module.
+
+// Normalize any numeric input to a finite, non-negative integer (a non-finite or negative value becomes 0), so
+// no count or threshold can make the verdict NaN or negative. Matches rate-limit.ts's finiteNonNegativeInt.
+function finiteNonNegativeInt(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
+/** One queue item's attempt/outcome history so far. Caller-supplied — the table has no attempt-history columns
+ *  today, so this detector never fetches or persists; it classifies counts the caller already tracks. */
+export type PortfolioConvergenceInput = {
+  /** Total attempts made on this item. Zero means not yet tried. */
+  attempts: number;
+  /** Consecutive failures since the last improvement (reset to 0 whenever progress is made). */
+  consecutiveFailures: number;
+  /** Times the item has been re-enqueued (queued → in_progress → queued) in place. */
+  reEnqueues: number;
+  /** Whether the item has ever reached the terminal `done` status. */
+  reachedDone: boolean;
+};
+
+/** The streak thresholds past which an item reads non-convergent. Each is floored to a minimum of 1 so a
+ *  degenerate 0 threshold can never flag a clean item. */
+export type PortfolioConvergenceThresholds = {
+  /** A consecutive-failure streak at or past this count reads non-convergent. */
+  maxConsecutiveFailures: number;
+  /** Re-enqueues at or past this count WITHOUT ever reaching done read non-convergent. */
+  maxReEnqueues: number;
+};
+
+export type PortfolioConvergenceStatus = "converging" | "stalled" | "non_convergent";
+
+/** A structured verdict: the status plus human-readable reasons, matching classifyContributorFit's shape. */
+export type PortfolioConvergenceVerdict = {
+  status: PortfolioConvergenceStatus;
+  reasons: string[];
+};
+
+/**
+ * Classify whether a queue item's attempt history shows convergence. Pure and deterministic: same input →
+ * same verdict, with no IO, clock, or randomness. An item with zero attempts reads `converging` (a first
+ * attempt is not evidence of a stuck loop). Otherwise a sustained streak — consecutive failures at/past the
+ * threshold, OR re-enqueues at/past the threshold without ever reaching done — reads `non_convergent`; any
+ * lesser sign of non-progress (a failure or a re-enqueue below threshold) reads `stalled`; a clean item making
+ * progress reads `converging`. Every count and threshold is normalized first, so no input can yield a NaN or
+ * negative verdict.
+ */
+export function classifyPortfolioConvergence(
+  input: PortfolioConvergenceInput,
+  thresholds: PortfolioConvergenceThresholds,
+): PortfolioConvergenceVerdict {
+  const attempts = finiteNonNegativeInt(input.attempts);
+  const consecutiveFailures = finiteNonNegativeInt(input.consecutiveFailures);
+  const reEnqueues = finiteNonNegativeInt(input.reEnqueues);
+  const maxConsecutiveFailures = Math.max(1, finiteNonNegativeInt(thresholds.maxConsecutiveFailures));
+  const maxReEnqueues = Math.max(1, finiteNonNegativeInt(thresholds.maxReEnqueues));
+
+  if (attempts === 0) {
+    return { status: "converging", reasons: ["No attempts yet; a first attempt is not evidence of a stuck loop."] };
+  }
+
+  const failureStreakExceeded = consecutiveFailures >= maxConsecutiveFailures;
+  const reEnqueueExceeded = !input.reachedDone && reEnqueues >= maxReEnqueues;
+  if (failureStreakExceeded || reEnqueueExceeded) {
+    const reasons: string[] = [];
+    if (failureStreakExceeded) {
+      reasons.push(`${consecutiveFailures} consecutive failure(s), at or past the threshold of ${maxConsecutiveFailures}`);
+    }
+    if (reEnqueueExceeded) {
+      reasons.push(`re-enqueued ${reEnqueues} time(s) without ever reaching done`);
+    }
+    return { status: "non_convergent", reasons };
+  }
+
+  if (consecutiveFailures > 0 || reEnqueues > 0) {
+    const reasons: string[] = [];
+    if (consecutiveFailures > 0) {
+      reasons.push(`${consecutiveFailures} consecutive failure(s), below the threshold of ${maxConsecutiveFailures}`);
+    }
+    if (reEnqueues > 0) reasons.push(`re-enqueued ${reEnqueues} time(s) so far`);
+    return { status: "stalled", reasons };
+  }
+
+  return { status: "converging", reasons: [`${attempts} attempt(s) with no failure streak`] };
+}

--- a/test/unit/portfolio-non-convergence.test.ts
+++ b/test/unit/portfolio-non-convergence.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyPortfolioConvergence,
+  type PortfolioConvergenceInput,
+  type PortfolioConvergenceThresholds,
+} from "../../packages/gittensory-engine/src/portfolio/non-convergence";
+
+const THRESHOLDS: PortfolioConvergenceThresholds = { maxConsecutiveFailures: 3, maxReEnqueues: 3 };
+
+function input(overrides: Partial<PortfolioConvergenceInput> = {}): PortfolioConvergenceInput {
+  return { attempts: 1, consecutiveFailures: 0, reEnqueues: 0, reachedDone: false, ...overrides };
+}
+
+describe("classifyPortfolioConvergence", () => {
+  it("reads converging for a not-yet-tried item (zero attempts is not evidence of a stuck loop)", () => {
+    const v = classifyPortfolioConvergence(input({ attempts: 0, consecutiveFailures: 9, reEnqueues: 9 }), THRESHOLDS);
+    expect(v.status).toBe("converging");
+    expect(v.reasons[0]).toContain("first attempt is not evidence");
+  });
+
+  it("reads converging for an item making progress with no failure streak", () => {
+    const v = classifyPortfolioConvergence(input({ attempts: 4, consecutiveFailures: 0, reEnqueues: 0 }), THRESHOLDS);
+    expect(v.status).toBe("converging");
+    expect(v.reasons[0]).toContain("4 attempt(s)");
+  });
+
+  it("reads stalled — not non_convergent — for a single failure below the threshold", () => {
+    const v = classifyPortfolioConvergence(input({ attempts: 2, consecutiveFailures: 1 }), THRESHOLDS);
+    expect(v.status).toBe("stalled");
+    expect(v.reasons.join(" ")).toContain("below the threshold");
+  });
+
+  it("reads non_convergent for a consecutive-failure streak at the threshold (failure arm only)", () => {
+    const v = classifyPortfolioConvergence(input({ attempts: 3, consecutiveFailures: 3, reEnqueues: 0 }), THRESHOLDS);
+    expect(v.status).toBe("non_convergent");
+    expect(v.reasons.join(" ")).toContain("at or past the threshold");
+    expect(v.reasons.join(" ")).not.toContain("re-enqueued");
+  });
+
+  it("reads non_convergent for repeated re-enqueues without ever reaching done (re-enqueue arm only)", () => {
+    const v = classifyPortfolioConvergence(input({ attempts: 5, consecutiveFailures: 0, reEnqueues: 4, reachedDone: false }), THRESHOLDS);
+    expect(v.status).toBe("non_convergent");
+    expect(v.reasons.join(" ")).toContain("without ever reaching done");
+    expect(v.reasons.join(" ")).not.toContain("consecutive failure");
+  });
+
+  it("does NOT flag re-enqueues once the item has reached done (reachedDone suppresses the re-enqueue arm)", () => {
+    const v = classifyPortfolioConvergence(input({ attempts: 5, consecutiveFailures: 0, reEnqueues: 9, reachedDone: true }), THRESHOLDS);
+    expect(v.status).toBe("stalled");
+    expect(v.reasons.join(" ")).toContain("re-enqueued 9 time(s) so far");
+  });
+
+  it("normalizes non-finite/negative counts and a degenerate zero threshold so no verdict is NaN", () => {
+    const v = classifyPortfolioConvergence(
+      { attempts: 6, consecutiveFailures: Number.NaN, reEnqueues: -4, reachedDone: false },
+      { maxConsecutiveFailures: Number.NaN, maxReEnqueues: 0 },
+    );
+    // consecutiveFailures NaN→0, reEnqueues -4→0, thresholds floored to 1 ⇒ nothing exceeded, no non-progress signal.
+    expect(v.status).toBe("converging");
+    expect(v.reasons[0]).toContain("6 attempt(s)");
+  });
+});


### PR DESCRIPTION
## Summary

Add a pure non-convergence detector to the engine's portfolio module — `classifyPortfolioConvergence(input, thresholds)` in `packages/gittensory-engine/src/portfolio/non-convergence.ts`, a **sibling** to `queue.ts`.

A local portfolio-queue item (`portfolio-queue.js`, status `queued → in_progress → done`) can be re-enqueued in place. An item that keeps cycling `queued → in_progress → queued` without ever reaching `done`, or that fails repeatedly without improving, is "not converging" — worth a pure signal so a later stage can decide to stop spending budget on it. This detector defines a typed input (attempt count, consecutive-failure count since the last improvement, re-enqueue count, whether it ever reached `done`) and returns a structured `{ status, reasons }` verdict — `converging | stalled | non_convergent`.

It mirrors `classifyContributorFit`'s pure-classifier-over-typed-input shape (`packages/gittensory-engine/src/contributor-fit.ts`), including its **"absence of history isn't evidence of a problem"** rule:
- zero attempts reads `converging` (a first attempt is not a stuck loop)
- a single failure reads `stalled`, never `non_convergent`
- only a sustained streak — consecutive failures at/past the threshold, or re-enqueues at/past the threshold without ever reaching `done` — reads `non_convergent`

Pure and deterministic, matching `rate-limit.ts`'s discipline: no IO, no `Date.now()`, no randomness; every count/threshold normalized (non-finite/negative → 0, thresholds floored to 1) so no input can produce a NaN or negative verdict. Re-exported from the package entrypoint alongside `portfolio/queue`.

This is a **detector only** — no enforcement, no write-blocking. The fail-closed Governor chokepoint that composes it with rate-limit and the budget caps is separate, maintainer-owned work (#2340).

## Scope

- [x] Narrow, one coherent change — one new pure module + its barrel export + tests
- [x] In scope (`packages/`), no `blockedPaths`, no secrets/private terms
- [x] No API/OpenAPI/migration/wrangler changes (nothing to regenerate)

## Validation

- [x] `npm run typecheck`
- [x] `npm run test:coverage` (full unsharded suite)
- [x] New unit test `test/unit/portfolio-non-convergence.test.ts`: zero history, progress-with-no-streak, single failure (stalled), failure-streak (non_convergent), re-enqueue-streak (non_convergent), reached-done suppression, and non-finite/negative normalization
- [x] Every changed line and branch covered — 100% statements/branches/functions on the new file

## Safety

- [x] Pure detector: no state, scheduling, IO, or write-action gating; explicitly documented, with #2340 named as the future (separate, maintainer-only) consumer
- [x] No secrets, tokens, wallets, trust scores, or reward values in code, tests, or this description

Closes #4286
