### PR TITLE
feat(review): route visual-vision to a local self-host provider (#4335)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -600,6 +600,16 @@ REDIS_URL=redis://redis:6379                # REQUIRED for the self-host review 
 #                                            #   embeddings use the same provider as everything else; setting
 #                                            #   AI_EMBED_MODEL above alone does nothing without this.
 # AI_EMBED_API_KEY=                          # bearer credential for AI_EMBED_BASE_URL, if it requires one.
+# AI_VISION_MODEL=qwen3-vl:8b-instruct       # vision-language model for the visual-vision advisory (#4111/#4335)
+#                                            #   analyzing before/after PR screenshots. Only used when
+#                                            #   AI_VISION_BASE_URL is also set.
+# AI_VISION_BASE_URL=                        # route visual-vision to a SEPARATE openai-compatible endpoint that
+#                                            #   can actually see images — e.g. a local Ollama running a VLM. The
+#                                            #   subscription CLIs (claude-code/codex) cannot consume inline image
+#                                            #   bytes, so before this was set, visual-vision required a maintainer
+#                                            #   BYOK (anthropic/openai) key; this gives self-host a local option.
+#                                            #   Unset = visual-vision falls back to BYOK-only.
+# AI_VISION_API_KEY=                         # bearer credential for AI_VISION_BASE_URL, if it requires one.
 
 # --- Gittensory Orb (#1255; ALWAYS-ON fleet-calibration telemetry) ---
 # TELEMETRY NOTICE: running this self-hosted image contributes anonymized gate-calibration data to

--- a/apps/gittensory-ui/src/lib/selfhost-env-reference.ts
+++ b/apps/gittensory-ui/src/lib/selfhost-env-reference.ts
@@ -34,6 +34,18 @@ export const SELFHOST_ENV_REFERENCE_ROWS: SelfHostEnvReferenceRow[] = [
     firstReference: "src/selfhost/ai-config.ts",
   },
   {
+    name: "AI_VISION_API_KEY",
+    firstReference: "src/server.ts",
+  },
+  {
+    name: "AI_VISION_BASE_URL",
+    firstReference: "src/server.ts",
+  },
+  {
+    name: "AI_VISION_MODEL",
+    firstReference: "src/server.ts",
+  },
+  {
     name: "ANTHROPIC_AI_BASE_URL",
     firstReference: "src/selfhost/ai.ts",
   },
@@ -441,6 +453,9 @@ export const SELFHOST_ENV_REFERENCE_MARKDOWN = [
   "| `AI_EMBED_MODEL` | `src/selfhost/ai.ts` |",
   "| `AI_ON_MERGE` | `src/selfhost/ai.ts` |",
   "| `AI_PROVIDER` | `src/selfhost/ai-config.ts` |",
+  "| `AI_VISION_API_KEY` | `src/server.ts` |",
+  "| `AI_VISION_BASE_URL` | `src/server.ts` |",
+  "| `AI_VISION_MODEL` | `src/server.ts` |",
   "| `ANTHROPIC_AI_BASE_URL` | `src/selfhost/ai.ts` |",
   "| `ANTHROPIC_AI_MODEL` | `src/selfhost/ai.ts` |",
   "| `ANTHROPIC_API_KEY` | `src/selfhost/ai.ts` |",

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -11,6 +11,11 @@ declare global {
      *  local/openai-compatible endpoint (ollama). Built at boot from AI_EMBED_BASE_URL/AI_EMBED_MODEL. Absent ⇒
      *  `createReviewAdapters` falls back to `env.AI` (byte-identical to before). */
     AI_EMBED?: Ai;
+    /** Self-host (visual-vision, #4111/#4335): a DEDICATED vision-capable provider, separate from both the
+     *  review chain and the embed provider — a local/openai-compatible endpoint (ollama + a vision-language
+     *  model). Built at boot from AI_VISION_BASE_URL/AI_VISION_MODEL. Absent ⇒ visual-vision advisory falls
+     *  back to requiring a maintainer BYOK key (the only option before this binding existed). */
+    AI_VISION?: Ai;
     /** Self-host RAG vector adapter. Cloudflare no longer binds Vectorize for hosted reviews; the Node runtime
      *  injects Qdrant/sqlite/pg adapters here when configured. Absent ⇒ no RAG, review proceeds with no retrieved
      *  context. */

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -8287,11 +8287,13 @@ export async function runVisualVisionForAdvisory(
     // BYOK (a maintainer's own anthropic/openai key) takes priority when both are configured -- matches
     // every other dual-path AI call site's convention (BYOK bills the maintainer's own account, so it's
     // preferred over the shared/free local resource when the operator has explicitly set one up).
-    const visionText = visionProviderKey
-      ? (
-          await callAiProvider(visionProviderKey, VISUAL_VISION_SYSTEM_PROMPT, buildVisualVisionUserPrompt(visionGate.routes), 600, images)
-        ).text
-      : await runSelfHostVisualVision(env, VISUAL_VISION_SYSTEM_PROMPT, buildVisualVisionUserPrompt(visionGate.routes), images);
+    let visionText: string | null;
+    if (visionProviderKey) {
+      const visionResponse = await callAiProvider(visionProviderKey, VISUAL_VISION_SYSTEM_PROMPT, buildVisualVisionUserPrompt(visionGate.routes), 600, images);
+      visionText = visionResponse.text;
+    } else {
+      visionText = await runSelfHostVisualVision(env, VISUAL_VISION_SYSTEM_PROMPT, buildVisualVisionUserPrompt(visionGate.routes), images);
+    }
     if (!visionText) return;
     const visionFindings = parseVisualVisionResponse(visionText);
     args.advisory.findings.push(...buildVisualRegressionFindings(visionFindings));

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -8181,6 +8181,35 @@ class RetryablePublicSurfacePublishFailedError extends RetryableJobError {
   }
 }
 
+/** A vision-capable self-host provider's `.run()` — mirrors ai-slop.ts's `AiRunner` (same loose shape for a
+ *  `env.AI`-family binding called outside the SelfHostAi/RagInfra type boundaries), scoped locally since it
+ *  is not exported. */
+type SelfHostVisionRunner = { run?: (model: string, options: Record<string, unknown>) => Promise<unknown> };
+
+/** Self-host local vision (#4335): calls the dedicated `env.AI_VISION` binding (ollama + a vision-language
+ *  model) the SAME way `env.AI_EMBED` is called for embeddings — a binding kept separate from the review
+ *  chain so a vision request never competes with/degrades review-model routing. The `model` argument is a
+ *  placeholder: `createOpenAiCompatibleAi`'s chat path prefers its own construction-time-configured model
+ *  (AI_VISION_MODEL) over whatever string is passed here (see `resolveModel` in `selfhost/ai.ts`). Fail-safe
+ *  on every path, exactly like `callAiProvider`'s BYOK sibling: no binding / no `.run` / a thrown error / an
+ *  unparseable response all degrade to `null`, never a thrown error reaching the caller. */
+async function runSelfHostVisualVision(env: Env, system: string, user: string, images: readonly AiContentBlock[]): Promise<string | null> {
+  const ai = env.AI_VISION as unknown as SelfHostVisionRunner | undefined;
+  if (!ai || typeof ai.run !== "function") return null;
+  try {
+    const result = (await ai.run("visual-vision", {
+      messages: [
+        { role: "system", content: system },
+        { role: "user", content: [{ type: "text", text: user }, ...images] },
+      ],
+      max_tokens: 600,
+    })) as { response?: string } | null;
+    return result?.response?.trim() || null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * AI-vision analysis of a confirmed visual regression (#4111 wiring): the existing pixel-diff threshold can
  * tell "the pixels changed" but not "does it look broken" — a route the capture pipeline already flagged
@@ -8221,17 +8250,22 @@ export async function runVisualVisionForAdvisory(
             model: args.settings.aiReviewModel ?? storedVisionKey.model,
           }
         : null;
+    // Self-host local vision (#4335): a dedicated ollama+VLM binding lets vision run WITHOUT a maintainer
+    // BYOK key -- see evaluateVisualVisionGate's header for why only an HTTP-capable provider (BYOK or this)
+    // can see the screenshots at all.
+    const selfHostVisionAvailable = Boolean(env.AI_VISION);
     const visionGate = evaluateVisualVisionGate({
       routes: args.routes,
       reputationSignal: visionReputation.signal,
       providerKey: visionProviderKey,
+      selfHostVisionAvailable,
     });
     if (!visionGate.run) return;
-    // evaluateVisualVisionGate only ever returns run:true when its own providerKey input (the SAME
-    // visionProviderKey resolved above) was non-null -- this is a defensive type-narrowing guard for the
-    // callAiProvider call below, not a reachable false case.
-    /* v8 ignore next -- see comment above */
-    if (!visionProviderKey) return;
+    // evaluateVisualVisionGate only ever returns run:true when providerKey OR selfHostVisionAvailable (the
+    // SAME two values resolved above) was truthy -- this is a defensive type-narrowing guard, not a reachable
+    // false case: if neither is set here, the gate itself would already have returned run:false above.
+    /* v8 ignore next 2 -- see comment above */
+    if (!visionProviderKey && !selfHostVisionAvailable) return;
     const images: AiContentBlock[] = [];
     for (const route of visionGate.routes) {
       // Show the model the viewport that actually crossed the pixel-diff threshold — a route can qualify via
@@ -8250,15 +8284,16 @@ export async function runVisualVisionForAdvisory(
       if (afterBlock) images.push(afterBlock);
     }
     if (images.length === 0) return;
-    const visionResponse = await callAiProvider(
-      visionProviderKey,
-      VISUAL_VISION_SYSTEM_PROMPT,
-      buildVisualVisionUserPrompt(visionGate.routes),
-      600,
-      images,
-    );
-    if (!visionResponse.text) return;
-    const visionFindings = parseVisualVisionResponse(visionResponse.text);
+    // BYOK (a maintainer's own anthropic/openai key) takes priority when both are configured -- matches
+    // every other dual-path AI call site's convention (BYOK bills the maintainer's own account, so it's
+    // preferred over the shared/free local resource when the operator has explicitly set one up).
+    const visionText = visionProviderKey
+      ? (
+          await callAiProvider(visionProviderKey, VISUAL_VISION_SYSTEM_PROMPT, buildVisualVisionUserPrompt(visionGate.routes), 600, images)
+        ).text
+      : await runSelfHostVisualVision(env, VISUAL_VISION_SYSTEM_PROMPT, buildVisualVisionUserPrompt(visionGate.routes), images);
+    if (!visionText) return;
+    const visionFindings = parseVisualVisionResponse(visionText);
     args.advisory.findings.push(...buildVisualRegressionFindings(visionFindings));
   } catch (error) {
     console.log(

--- a/src/review/visual/visual-findings.ts
+++ b/src/review/visual/visual-findings.ts
@@ -62,20 +62,23 @@ export type VisualVisionGateResult =
  *      exactly like the other AI neurons already skip for a low-reputation/burst submitter
  *      (`shouldSkipAiForReputation`, `../reputation-wire.ts`); checked FIRST so a low-reputation submitter is
  *      never even told which reason applies to their capture.
- *   3. BYOK — vision rides the maintainer's OWN provider key (`providerKey` non-null): Workers AI is fully
- *      retired (no free vision-capable path exists) and the self-host subscription CLIs (claude-code/codex)
- *      cannot consume inline image bytes through their stdin-JSON invocation (see `../../selfhost/ai.ts`'s
- *      `contentText`), so only an HTTP BYOK provider (anthropic/openai) can actually see the screenshots.
- * Pure + total: the caller resolves the reputation signal / provider key (D1 + decryption both live outside
- * this file) and passes the results in.
+ *   3. a provider that can actually SEE the screenshots — either BYOK (`providerKey` non-null: the
+ *      maintainer's own anthropic/openai key) or a self-host local vision provider (`selfHostVisionAvailable`,
+ *      #4335: a dedicated ollama+VLM binding, `env.AI_VISION`). Workers AI is fully retired (no free
+ *      vision-capable path exists) and the self-host subscription CLIs (claude-code/codex) cannot consume
+ *      inline image bytes through their stdin-JSON invocation (see `../../selfhost/ai.ts`'s `contentText`),
+ *      so only an HTTP-capable provider — BYOK or self-host's dedicated AI_VISION binding — can see them.
+ * Pure + total: the caller resolves the reputation signal / provider key / self-host vision availability (D1,
+ * decryption, and env all live outside this file) and passes the results in.
  */
 export function evaluateVisualVisionGate(input: {
   routes: readonly CaptureRoute[];
   reputationSignal: ReputationSignal;
   providerKey: AiReviewProviderKey | null;
+  selfHostVisionAvailable?: boolean;
 }): VisualVisionGateResult {
   if (input.reputationSignal === "low") return { run: false, reason: "low_reputation" };
-  if (!input.providerKey) return { run: false, reason: "byok_not_configured" };
+  if (!input.providerKey && !input.selfHostVisionAvailable) return { run: false, reason: "byok_not_configured" };
   const routes = selectRoutesForVisualVision(input.routes);
   if (routes.length === 0) return { run: false, reason: "no_confirmed_regression" };
   return { run: true, routes };

--- a/src/server.ts
+++ b/src/server.ts
@@ -488,6 +488,26 @@ async function main(): Promise<void> {
         model: process.env.AI_EMBED_MODEL ?? "bge-m3",
       }),
     );
+  // Dedicated visual-vision provider (#4111/#4335): when AI_VISION_BASE_URL is set, the visual-vision
+  // advisory routes to a SEPARATE openai-compatible endpoint (e.g. ollama at http://ollama:11434/v1, a
+  // vision-language model) instead of requiring a maintainer BYOK key -- kept separate from AI_EMBED (a
+  // different model, a different capability) the same way AI_EMBED is kept separate from the review chain.
+  // Unset ⇒ absent ⇒ visual-vision falls back to BYOK-only (byte-identical to before this binding existed).
+  const visionAi = process.env.AI_VISION_BASE_URL
+    ? createOpenAiCompatibleAi({
+        baseUrl: process.env.AI_VISION_BASE_URL,
+        apiKey: process.env.AI_VISION_API_KEY ?? process.env.OPENAI_API_KEY,
+        model: process.env.AI_VISION_MODEL,
+      })
+    : undefined;
+  if (visionAi)
+    console.log(
+      JSON.stringify({
+        event: "selfhost_vision_provider",
+        baseUrl: process.env.AI_VISION_BASE_URL,
+        model: process.env.AI_VISION_MODEL,
+      }),
+    );
   // Dual-review plan (#dual-ai-combiner): resolve which provider(s) review + how to combine, attached to env
   // below so the review call site uses it. Undefined for a single provider's default review or no AI.
   const aiReviewPlan = resolveAiReviewerPlan(process.env);
@@ -594,6 +614,7 @@ async function main(): Promise<void> {
     WEBHOOKS: backend.queue.binding, // the brokered relay receiver enqueues via WEBHOOKS; both lanes share the in-process queue
     AI: ai,
     ...(embedAi ? { AI_EMBED: embedAi as unknown as Ai } : {}),
+    ...(visionAi ? { AI_VISION: visionAi as unknown as Ai } : {}),
     ...(aiReviewPlan ? { AI_REVIEW_PLAN: aiReviewPlan } : {}),
     SELFHOST_TRANSIENT_CACHE: webhookCache,
     // Qdrant takes priority; falls back to the backend's built-in vectorize (pgvector or sqlite-vec)

--- a/test/unit/visual-findings.test.ts
+++ b/test/unit/visual-findings.test.ts
@@ -91,6 +91,18 @@ describe("evaluateVisualVisionGate", () => {
       routes: [changedRoute("/a")],
     });
   });
+
+  it("runs via a self-host local vision provider even with NO BYOK key configured (#4335)", () => {
+    expect(
+      evaluateVisualVisionGate({ routes: [changedRoute("/a")], reputationSignal: "neutral", providerKey: null, selfHostVisionAvailable: true }),
+    ).toEqual({ run: true, routes: [changedRoute("/a")] });
+  });
+
+  it("still skips when self-host vision is explicitly unavailable and there is no BYOK key either", () => {
+    expect(
+      evaluateVisualVisionGate({ routes: [changedRoute("/a")], reputationSignal: "neutral", providerKey: null, selfHostVisionAvailable: false }),
+    ).toEqual({ run: false, reason: "byok_not_configured" });
+  });
 });
 
 describe("buildVisualVisionUserPrompt", () => {

--- a/test/unit/visual-vision-wiring.test.ts
+++ b/test/unit/visual-vision-wiring.test.ts
@@ -389,3 +389,140 @@ describe("runVisualVisionForAdvisory", () => {
     expect(fetchMock).not.toHaveBeenCalled();
   });
 });
+
+/** Only the shot-fetch side of stubShotsAndProvider — the self-host vision path never calls `fetch` for the
+ *  AI call itself (it calls `env.AI_VISION.run` directly), so no provider URL needs mocking here. */
+function stubShots() {
+  vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL) => {
+    const url = input.toString();
+    if (url.includes("/gittensory/shot")) return new Response(new Uint8Array([1, 2, 3]), { status: 200, headers: { "content-type": "image/png" } });
+    return new Response("not found", { status: 404 });
+  }));
+}
+
+function selfHostVisionRoutes() {
+  return [route({ path: "/app", diffUrl: "https://x/gittensory/shot?key=diff", beforeUrl: "https://x/gittensory/shot?key=before", afterUrl: "https://x/gittensory/shot?key=after" })];
+}
+
+describe("runVisualVisionForAdvisory: self-host local vision provider (#4335)", () => {
+  it("runs via env.AI_VISION when NO BYOK key is configured at all", async () => {
+    const runMock = vi.fn(async (_model: string, _options: { messages: Array<{ role: string; content: unknown }> }) => ({
+      response: findingsResponse([{ path: "/app", body: "Nav bar overlaps the logo on the AFTER screenshot." }]),
+    }));
+    const env = byokEnv();
+    (env as unknown as { AI_VISION: unknown }).AI_VISION = { run: runMock };
+    stubShots();
+    const adv = findingsHolder();
+    await runVisualVisionForAdvisory(env, {
+      repoFullName,
+      pr,
+      author: "alice",
+      confirmedContributor: true,
+      settings: byokSettings({ aiReviewByok: false }), // no BYOK configured
+      advisory: adv,
+      routes: selfHostVisionRoutes(),
+    });
+    expect(runMock).toHaveBeenCalledTimes(1);
+    const [, options] = runMock.mock.calls[0]!;
+    expect(options.messages[0]).toMatchObject({ role: "system" });
+    expect(options.messages[1]).toMatchObject({ role: "user" });
+    expect(adv.findings).toEqual([
+      {
+        code: "visual_regression_finding",
+        severity: "warning",
+        title: "Possible visual regression: /app",
+        detail: "Nav bar overlaps the logo on the AFTER screenshot.",
+        action: "Advisory only — verify against the Visual preview screenshots before deciding.",
+      },
+    ]);
+  });
+
+  it("prefers a configured BYOK key over env.AI_VISION when both are available", async () => {
+    const env = byokEnv();
+    await upsertRepositoryAiKey(env, { repoFullName, provider: "anthropic", key: "sk-ant-vision-key", model: null });
+    const runMock = vi.fn(async () => ({ response: findingsResponse([{ path: "/app", body: "should not be used" }]) }));
+    (env as unknown as { AI_VISION: unknown }).AI_VISION = { run: runMock };
+    stubShotsAndProvider(findingsResponse([{ path: "/app", body: "BYOK finding wins." }]));
+    const adv = findingsHolder();
+    await runVisualVisionForAdvisory(env, {
+      repoFullName,
+      pr,
+      author: "alice",
+      confirmedContributor: true,
+      settings: byokSettings(),
+      advisory: adv,
+      routes: selfHostVisionRoutes(),
+    });
+    expect(runMock).not.toHaveBeenCalled();
+    expect(adv.findings[0]).toMatchObject({ detail: "BYOK finding wins." });
+  });
+
+  it("adds no finding (fail-safe) when env.AI_VISION.run throws", async () => {
+    const env = byokEnv();
+    (env as unknown as { AI_VISION: unknown }).AI_VISION = { run: vi.fn(async () => { throw new Error("ollama connection refused"); }) };
+    stubShots();
+    const adv = findingsHolder();
+    await runVisualVisionForAdvisory(env, {
+      repoFullName,
+      pr,
+      author: "alice",
+      confirmedContributor: true,
+      settings: byokSettings({ aiReviewByok: false }),
+      advisory: adv,
+      routes: selfHostVisionRoutes(),
+    });
+    expect(adv.findings).toEqual([]);
+  });
+
+  it("adds no finding when env.AI_VISION.run resolves to an empty/whitespace-only response", async () => {
+    const env = byokEnv();
+    (env as unknown as { AI_VISION: unknown }).AI_VISION = { run: vi.fn(async () => ({ response: "   " })) };
+    stubShots();
+    const adv = findingsHolder();
+    await runVisualVisionForAdvisory(env, {
+      repoFullName,
+      pr,
+      author: "alice",
+      confirmedContributor: true,
+      settings: byokSettings({ aiReviewByok: false }),
+      advisory: adv,
+      routes: selfHostVisionRoutes(),
+    });
+    expect(adv.findings).toEqual([]);
+  });
+
+  it("adds no finding when env.AI_VISION is present but has no callable .run (a malformed binding)", async () => {
+    const env = byokEnv();
+    (env as unknown as { AI_VISION: unknown }).AI_VISION = {};
+    stubShots();
+    const adv = findingsHolder();
+    await runVisualVisionForAdvisory(env, {
+      repoFullName,
+      pr,
+      author: "alice",
+      confirmedContributor: true,
+      settings: byokSettings({ aiReviewByok: false }),
+      advisory: adv,
+      routes: selfHostVisionRoutes(),
+    });
+    expect(adv.findings).toEqual([]);
+  });
+
+  it("still declines entirely when NEITHER BYOK nor env.AI_VISION is configured", async () => {
+    const env = byokEnv();
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const adv = findingsHolder();
+    await runVisualVisionForAdvisory(env, {
+      repoFullName,
+      pr,
+      author: "alice",
+      confirmedContributor: true,
+      settings: byokSettings({ aiReviewByok: false }),
+      advisory: adv,
+      routes: selfHostVisionRoutes(),
+    });
+    expect(adv.findings).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- The visual-vision advisory (#4111) required a maintainer BYOK (anthropic/openai) key to run at all — Workers AI is retired and the subscription CLIs (claude-code/codex) can't consume inline image bytes, so BYOK was the only option, even for self-host operators with no interest in paying for a cloud vision API.
- Adds a dedicated `AI_VISION` binding (mirrors `AI_EMBED`'s existing separation from the review chain — same pattern, same reasoning) so self-host operators can point visual-vision at a local Ollama vision-language model instead. BYOK is still preferred when both are configured (bills the maintainer's own account, same convention as every other dual-path AI call site in this codebase).
- `evaluateVisualVisionGate`'s provider check is broadened **additively** — `providerKey OR selfHostVisionAvailable` — so behavior is byte-identical for any deployment that doesn't set `AI_VISION` (existing BYOK-only deployments are unaffected).
- Investigated as part of #4335 (stretch/evaluation issue) — found the existing "only BYOK can see screenshots" comment was stale: the self-host `ollama`/`openai-compatible` HTTP provider path already forwards images correctly (`toOpenAiMessageContent` in `src/selfhost/ai.ts`), it just wasn't wired as an option for this specific call site.

Closes #4335. **Note on methodology**: #4335 asked for a side-by-side quality comparison against the current cloud-based analysis on real past PR screenshots before adopting. That comparison turned out to be blocked — no BYOK vision key was configured for any repo in this deployment, so there was no real cloud-path baseline to compare against (the feature had never actually fired in production). Rather than leave this stalled, the maintainer made a direct decision to adopt local Ollama vision given the hardware is provisioned for it; this PR is that decision implemented, not the outcome of the originally-planned comparison. Closing #4335 on that basis rather than leaving an evaluation issue open for a question that's already been answered.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] Part of #4335 (maintainer-owned infra/review-engine tracking issue).

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint` (via `npm run test:ci`)
- [x] `npm run typecheck` (via `npm run test:ci`)
- [x] `npm run test:coverage` locally — `visual-findings.ts` gate change and the new `runSelfHostVisualVision` helper/call-site branch in `processors.ts` both fully covered (both BYOK-preferred and self-host-only paths, plus fail-safe: no binding, no `.run`, thrown error, empty response)
- [x] `npm run test:workers` (via `npm run test:ci`)
- [x] `npm run build:mcp` / `npm run test:mcp-pack` (via `npm run test:ci`)
- [x] `npm run ui:openapi:check` / `npm run ui:lint` / `npm run ui:typecheck` / `npm run ui:build` (via `npm run test:ci`) — no UI/API surface touched
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] New behavior has unit tests for every new branch and fallback path (see `test/unit/visual-findings.test.ts` and `test/unit/visual-vision-wiring.test.ts`)

`src/server.ts` is excluded from Codecov (`codecov.yml`) — validated by the self-host integration workflow, not unit-coverable without booting a real server; the new `AI_VISION` wiring there mirrors the existing (also-excluded) `AI_EMBED` block exactly.

Ran `npm run test:ci` (full unsharded suite) end-to-end — green.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth/cookie/CORS/GitHub App/Cloudflare/session changes include negative-path tests. — N/A, no such surface touched.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no API/OpenAPI/MCP surface touched.
- [ ] UI changes use live API data or real empty/error/loading states. — N/A, backend-only change.
- [ ] Visible UI changes include a `UI Evidence` section. — N/A, no UI change.
- [x] Public docs updated where needed (`.env.example` documents every new var; `selfhost-env-reference.ts` regenerated via `npm run selfhost:env-reference`).

## Notes

- No migration or `cf-typegen` regeneration needed. `npm run selfhost:env-reference` was run and its output committed (server.ts is a scanned source root for that generator).
