### PR TITLE
fix(selfhost): stop .dockerignore from breaking the engine's own build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -24,8 +24,13 @@ gittensory-config
 **/.codex
 auth.json
 **/auth.json
-# The review-enrichment service (REES) is a separate Railway service with its own Dockerfile — keep it out of the engine image.
+# The review-enrichment service (REES) is a separate Railway service with its own Dockerfile — keep it out of
+# the engine image. EXCEPT analyzer-metadata.json: the main engine's own code (src/review/enrichment-analyzers-
+# taxonomy.ts) imports it directly, so excluding it wholesale breaks `scripts/build-selfhost.mjs`'s esbuild
+# bundle (module resolution failure at build time, not a runtime gap -- caught by the "build + boot smoke test"
+# workflow, which is path-gated and doesn't run on every PR).
 review-enrichment
+!review-enrichment/analyzer-metadata.json
 .DS_Store
 *.tsbuildinfo
 # Never ship secrets into the build context


### PR DESCRIPTION
## Summary

- `review-enrichment/` is correctly excluded from the Docker build context wholesale — it's REES, a separate Railway service with its own Dockerfile. But the main engine's own `src/review/enrichment-analyzers-taxonomy.ts` imports `review-enrichment/analyzer-metadata.json` directly, so excluding the whole directory strips a file `scripts/build-selfhost.mjs`'s esbuild bundle actually needs.
- Result: `docker build` fails with `Could not resolve "../../review-enrichment/analyzer-metadata.json"` — a pre-existing bug on `main`, not caused by any in-flight change. It surfaced now because the "build + boot smoke test" workflow is path-gated (only runs when relevant paths change) and hadn't been triggered by a recent PR until one touching `docker-compose.yml` did.
- Fix: re-include just that one file via a `.dockerignore` negation pattern (`!review-enrichment/analyzer-metadata.json`), mirroring the exact same technique already used two lines above it for `dist/server.mjs`. The rest of `review-enrichment/` (the actual REES service code) stays excluded.

Verified with a real local `docker build --target build -t gittensory-build-test:local .` — reproduced the failure on the unpatched file, confirmed green after the fix (`build-selfhost.mjs` + `validate-selfhost-sourcemap.mjs` both pass).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused — a single-line root-cause fix, no unrelated changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] Discovered as a blocking CI failure while validating #4352; filing as its own PR since it's a pre-existing, unrelated bug.

## Validation

- [x] `git diff --check`
- [x] Real local `docker build --target build` — reproduced the failure pre-fix, confirmed the fix resolves it (esbuild bundle + sourcemap validation both pass)
- [x] No `src/**`/`test/**` change — nothing for `npm run test:coverage`/Codecov to measure; `.dockerignore` isn't TypeScript and isn't part of the patch-coverage surface
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities (unaffected by this change, ran as part of validating the sibling PRs)

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [ ] N/A — no auth/UI/API/OpenAPI/MCP surface touched; single-file `.dockerignore` change.

## Notes

- No migration, OpenAPI, or `cf-typegen` regeneration needed.