### PR TITLE
test(miner-manage): cover ci-poller transient-failure edge cases

### DIFF
--- a/test/unit/miner-ci-poller-failure-modes.test.ts
+++ b/test/unit/miner-ci-poller-failure-modes.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it, vi } from "vitest";
+import { pollCheckRuns } from "../../packages/gittensory-miner/lib/ci-poller.js";
+
+const API = "https://api.github.com";
+
+function jsonResponse(body: unknown, init: ResponseInit = {}) {
+  return Response.json(body, init);
+}
+function prResponse(sha = "abc123") {
+  return jsonResponse({ head: { sha } });
+}
+function checkRun(name: string, status: string, conclusion: string | null = null) {
+  return {
+    name,
+    status,
+    conclusion,
+    details_url: `https://github.test/checks/${name}`,
+    started_at: "2026-07-01T00:00:00Z",
+    completed_at: status === "completed" ? "2026-07-01T00:01:00Z" : null,
+  };
+}
+
+// Three transient-failure modes the existing miner-ci-poller.test.ts (#2323) does not exercise (#4281). Because
+// pollCheckRuns' attempt loop (ci-poller.js:200-225) wraps NO try/catch around fetchHeadSha/fetchCheckRuns, a single
+// thrown error on attempt 1 aborts the whole poll immediately — it does not consume a backoff attempt and retry.
+// These pin that current behavior (no silent retry, no swallow, no hang) rather than changing it; if the poll should
+// instead retry on a 429, that is a separate feat/fix, deliberately not done here under a test-prefixed change.
+describe("miner CI poller transient-failure modes (#4281)", () => {
+  it.each([403, 429])(
+    "propagates a %d response as github_<status> and does NOT retry through the remaining attempts",
+    async (status) => {
+      const sleepFn = vi.fn(async () => {});
+      const fetchFn = vi.fn(async () => jsonResponse({ message: "API rate limit exceeded" }, { status }));
+
+      await expect(
+        pollCheckRuns("acme/widgets", 42, { apiBaseUrl: API, githubToken: "t", fetchFn, sleepFn, maxAttempts: 5 }),
+      ).rejects.toMatchObject({ code: `github_${status}` });
+
+      // The error surfaces on attempt 1's first request (the PR head-SHA fetch) and aborts the poll: no backoff
+      // sleep is consumed and none of the remaining four attempts run.
+      expect(fetchFn).toHaveBeenCalledTimes(1);
+      expect(sleepFn).not.toHaveBeenCalled();
+    },
+  );
+
+  it("propagates a fetchFn promise rejection (network timeout) during the PR head-SHA fetch", async () => {
+    const sleepFn = vi.fn(async () => {});
+    const fetchFn = vi.fn(async () => {
+      throw new Error("network timeout");
+    });
+
+    await expect(
+      pollCheckRuns("acme/widgets", 42, { apiBaseUrl: API, githubToken: "t", fetchFn, sleepFn, maxAttempts: 5 }),
+    ).rejects.toThrow("network timeout");
+    expect(fetchFn).toHaveBeenCalledTimes(1);
+    expect(sleepFn).not.toHaveBeenCalled();
+  });
+
+  it("propagates a fetchFn promise rejection during the check-runs fetch (after the PR fetch succeeds)", async () => {
+    const sleepFn = vi.fn(async () => {});
+    const fetchFn = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/pulls/42")) return prResponse("head-sha");
+      throw new Error("network timeout");
+    });
+
+    await expect(
+      pollCheckRuns("acme/widgets", 42, { apiBaseUrl: API, githubToken: "t", fetchFn, sleepFn, maxAttempts: 5 }),
+    ).rejects.toThrow("network timeout");
+    // PR head-SHA fetch (resolves) + the throwing check-runs fetch = 2 calls, then abort.
+    expect(fetchFn).toHaveBeenCalledTimes(2);
+    expect(sleepFn).not.toHaveBeenCalled();
+  });
+
+  it("aborts deterministically when page 1 of check-runs succeeds but page 2 fails mid-pagination", async () => {
+    const sleepFn = vi.fn(async () => {});
+    const fetchFn = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/pulls/42")) return prResponse("head-sha");
+      if (url.endsWith("page=1")) {
+        // A non-empty page 1 carrying a rel="next" Link header forces continuation to page 2.
+        return jsonResponse(
+          { total_count: 2, check_runs: [checkRun("validate", "in_progress")] },
+          {
+            headers: {
+              link: `<${API}/repos/acme/widgets/commits/head-sha/check-runs?per_page=100&page=2>; rel="next"`,
+            },
+          },
+        );
+      }
+      // Page 2 fails outright — fetchCheckRuns has no per-page retry, so this propagates out of the whole poll.
+      throw new Error("network timeout");
+    });
+
+    await expect(
+      pollCheckRuns("acme/widgets", 42, { apiBaseUrl: API, githubToken: "t", fetchFn, sleepFn, maxAttempts: 5 }),
+    ).rejects.toThrow("network timeout");
+    // PR head-SHA fetch + page 1 (resolves) + page 2 (throws) = 3 calls.
+    expect(fetchFn).toHaveBeenCalledTimes(3);
+    expect(sleepFn).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #4281.

`test/unit/miner-ci-poller.test.ts` (#2323) already covers `pollCheckRuns` thoroughly (13 cases). This adds the **three transient-failure modes it does not exercise**, using the existing injected `fetchFn`/`sleepFn` style (no real network):

1. **Rate-limit / non-OK response.** A `403`/`429` propagates as a `github_403`/`github_429` error and aborts the poll on attempt 1 — `pollCheckRuns`' attempt loop has no `try`/`catch` around the fetches, so it does **not** consume a backoff attempt or retry through the remaining `maxAttempts` (asserted: `sleepFn` never called, only the head-SHA fetch issued).
2. **`fetchFn` promise rejection (network timeout/abort)** during the PR head-SHA fetch *and* during the check-runs fetch — propagates a clear error rather than hanging or silently swallowing.
3. **Mid-pagination partial failure** — page 1 of check-runs succeeds (with a `rel="next"` Link header) but page 2 fails; `fetchCheckRuns` has no per-page retry, so the error propagates deterministically out of the whole poll.

These **pin the current behavior** (a single transient failure kills the poll with no retry). Per the issue's guidance, I did **not** change that behavior under a `test`-prefixed PR: if the poller should instead retry specifically on a `429`, that is worth a separate `feat`/`fix` — flagging it here rather than silently altering it.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] Focused; does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] Follows `CONTRIBUTING.md`; does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue (Closes #4281 — an open, unassigned `help wanted` / `gittensor:feature` issue).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (green)
- [x] `test/unit/miner-ci-poller-failure-modes.test.ts` — 5 assertions (403 + 429 via `it.each`, head-SHA-fetch rejection, check-runs-fetch rejection, mid-pagination page-2 failure) all pass.

If any required check was skipped, explain why:

- The full `npm run test:ci` was not run locally (several self-host suites require Linux/bash/Docker/Postgres and fail only on Windows). This PR is **test-only** — it adds one `test/unit/*.test.ts` file and changes no `src/`/package source, so there is no runtime, generated-artifact, or Codecov-patch surface; typecheck and the new tests are green, and the remaining CI runs on this PR.

## Safety

- [x] No secrets, wallets, hotkeys, coldkeys, PATs, private keys, trust scores, private rankings, or maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized and low-noise.
- [x] No auth/cookie/CORS/GitHub App/Cloudflare/session changes.
- [x] No API/OpenAPI/MCP behavior changes.

## UI Evidence

N/A - test-only change; no UI, frontend, docs, or extension change.
