### PR TITLE
ci(release): run lockfile sync from trusted checkout

### DIFF
--- a/.github/workflows/mcp-release-please.yml
+++ b/.github/workflows/mcp-release-please.yml
@@ -72,6 +72,8 @@ jobs:
           set -euo pipefail
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          trusted_sync_script="${RUNNER_TEMP}/sync-release-lockfile-versions.mjs"
+          cp scripts/sync-release-lockfile-versions.mjs "$trusted_sync_script"
           git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
           gh auth setup-git
           for component in mcp engine; do
@@ -82,7 +84,7 @@ jobs:
             fi
             git fetch origin "$branch"
             git checkout -B "sync-check-${component}" "origin/$branch"
-            node scripts/sync-release-lockfile-versions.mjs packages/gittensory-mcp packages/gittensory-engine
+            node "$trusted_sync_script" packages/gittensory-mcp packages/gittensory-engine
             if git diff --quiet package-lock.json; then
               echo "package-lock.json already in sync on $branch."
             else


### PR DESCRIPTION
### Motivation
- Close a critical workflow trust-boundary where the release job checked out `release-please` branches and then executed `scripts/sync-release-lockfile-versions.mjs` while a write-scoped `GITHUB_TOKEN` was available, allowing branch-controlled code to run with privileged credentials.
- Preserve the existing lockfile-sync behavior while ensuring the code executed is the trusted default-branch copy, not branch-owned content.

### Description
- Copy `scripts/sync-release-lockfile-versions.mjs` to a runner-local trusted path (`${RUNNER_TEMP}/sync-release-lockfile-versions.mjs`) before fetching or checking out any release branches. 
- Execute the trusted copy via `node "$trusted_sync_script" ...` inside the loop instead of running the script directly from the checked-out branch, and only change the workflow file `.
.github/workflows/mcp-release-please.yml` to implement this.

### Testing
- Ran `git diff --check` to validate there are no whitespace/conflict issues and it passed. 
- Ran `npm run actionlint -- .github/workflows/mcp-release-please.yml` and it passed (the local runner used the WASM fallback after external action fetch failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e33d99794832c9f2cc6e4d0817b43)