### PR TITLE
fix(ci): require main ancestry for engine publish

### DIFF
--- a/.github/workflows/publish-engine.yml
+++ b/.github/workflows/publish-engine.yml
@@ -46,6 +46,17 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Verify release commit is on main
+        env:
+          RELEASE_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+          if ! git merge-base --is-ancestor "$RELEASE_SHA" origin/main; then
+            echo "::error::Engine package releases must be cut from a commit reachable from main."
+            exit 1
+          fi
+
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
@@ -135,6 +146,17 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Verify release commit is on main
+        env:
+          RELEASE_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+          if ! git merge-base --is-ancestor "$RELEASE_SHA" origin/main; then
+            echo "::error::Engine package releases must be cut from a commit reachable from main."
+            exit 1
+          fi
 
       - name: Setup Node
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6


### PR DESCRIPTION
### Motivation
- Prevent the publish workflow from creating official `@jsonbored/gittensory-engine` releases from an unchecked, unmerged ref by enforcing that the dispatched commit is reachable from `origin/main`.

### Description
- Add a `git fetch --no-tags origin main` + `git merge-base --is-ancestor "$RELEASE_SHA" origin/main` check to the `validate` job in `.github/workflows/publish-engine.yml` so the artifact is only built from a commit on the protected branch.
- Repeat the same `merge-base` ancestry check in the privileged `publish` job before creating the release tag and performing OIDC/npm publishing as defense in depth.

### Testing
- `git diff --check` and `npm run actionlint` completed (actionlint used the WASM fallback after transient setup failures).  
- `npm run test:ci` was executed but failed on a pre-existing drift (`cf-typegen`) unrelated to this change and reported `worker-configuration.d.ts is stale`; the new checks themselves do not introduce test failures.  
- `npm audit --audit-level=moderate` could not complete due to the npm audit endpoint returning `403 Forbidden`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e27220130832c93f27511a7365f3d)