### PR TITLE
perf(review): cap vision request context to bound KV cache under load

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -8203,6 +8203,11 @@ async function runSelfHostVisualVision(env: Env, system: string, user: string, i
         { role: "user", content: [{ type: "text", text: user }, ...images] },
       ],
       max_tokens: 600,
+      // Bounds per-request KV cache on a concurrency-constrained GPU (#4327/#4335 concurrency tuning docs
+      // this exact figure) -- without a cap, vision's larger-than-text context can exhaust VRAM under
+      // concurrent load faster than the embed model does, degrading to latency collapse rather than a clean
+      // OOM. Ignored by every non-Ollama provider (embeddings, subscription CLIs, Anthropic).
+      providerOptions: { num_ctx: 4096 },
     })) as { response?: string } | null;
     return result?.response?.trim() || null;
   } catch {

--- a/src/selfhost/ai.ts
+++ b/src/selfhost/ai.ts
@@ -25,6 +25,12 @@ interface AiRunOptions {
   text?: string[]; // embedding input — the core's embedTexts passes { text: string[] }
   max_tokens?: number;
   temperature?: number;
+  // Ollama-specific runtime options (e.g. `{ num_ctx: 4096 }` to bound per-request KV cache on a
+  // concurrency-constrained GPU, #4327/#4335) — forwarded verbatim as the OpenAI-compatible endpoint's
+  // `options` extension field. Only createOpenAiCompatibleAi's chat path reads this; every other provider
+  // (embeddings, the subscription CLIs, Anthropic) ignores it, so it is safe to set unconditionally on a
+  // call that ONLY ever targets an Ollama-backed binding (e.g. AI_VISION).
+  providerOptions?: Record<string, unknown>;
   // Correlation context for a provider-failure log (#codex-timeout-fields): purely observational, never read by a
   // provider's own request logic. The caller (runWorkersOpinion) passes whatever of these it already has in scope
   // for THIS review — job id and attempt are per-attempt, repoFullName/pullNumber identify the PR being reviewed —
@@ -281,6 +287,7 @@ export function createOpenAiCompatibleAi(opts: {
           messages: toMessages(options).map((message) => ({ role: message.role, content: toOpenAiMessageContent(message.content) })),
           max_tokens: options.max_tokens,
           temperature: options.temperature,
+          ...(options.providerOptions ? { options: options.providerOptions } : {}),
         }),
         signal: AbortSignal.timeout(120_000),
       });

--- a/test/unit/selfhost-ai.test.ts
+++ b/test/unit/selfhost-ai.test.ts
@@ -117,6 +117,28 @@ describe("createOpenAiCompatibleAi (#979)", () => {
     expect(first?.body.model).toBe("llama3.1");
   });
 
+  it("forwards providerOptions verbatim as the request's `options` field (#4327/#4335 num_ctx capping)", async () => {
+    let body: Record<string, unknown> | undefined;
+    vi.stubGlobal("fetch", vi.fn(async (_u: string, init: { body: string }) => {
+      body = JSON.parse(init.body);
+      return new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), { status: 200 });
+    }));
+    const ai = createOpenAiCompatibleAi({ baseUrl: "http://ollama:11434/v1" });
+    await ai.run("qwen3-vl:8b-instruct", { messages: [{ role: "user", content: "x" }], providerOptions: { num_ctx: 4096 } });
+    expect(body?.options).toEqual({ num_ctx: 4096 });
+  });
+
+  it("omits `options` entirely from the request body when providerOptions is unset (byte-identical to before)", async () => {
+    let body: Record<string, unknown> | undefined;
+    vi.stubGlobal("fetch", vi.fn(async (_u: string, init: { body: string }) => {
+      body = JSON.parse(init.body);
+      return new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), { status: 200 });
+    }));
+    const ai = createOpenAiCompatibleAi({ baseUrl: "http://ollama:11434/v1" });
+    await ai.run("llama3.1", { messages: [{ role: "user", content: "x" }] });
+    expect("options" in (body ?? {})).toBe(false);
+  });
+
   it("throws on a non-OK response so the caller degrades", async () => {
     vi.stubGlobal("fetch", vi.fn(async () => new Response("err", { status: 500 })));
     await expect(createOpenAiCompatibleAi({ baseUrl: "http://x/v1" }).run("m", { prompt: "p" })).rejects.toThrow(/ai_http_500/);

--- a/test/unit/visual-vision-wiring.test.ts
+++ b/test/unit/visual-vision-wiring.test.ts
@@ -426,6 +426,7 @@ describe("runVisualVisionForAdvisory: self-host local vision provider (#4335)", 
     const [, options] = runMock.mock.calls[0]!;
     expect(options.messages[0]).toMatchObject({ role: "system" });
     expect(options.messages[1]).toMatchObject({ role: "user" });
+    expect((options as unknown as { providerOptions?: { num_ctx?: number } }).providerOptions).toEqual({ num_ctx: 4096 });
     expect(adv.findings).toEqual([
       {
         code: "visual_regression_finding",


### PR DESCRIPTION
## Summary

- The self-host Ollama concurrency tuning (#4352/#4327) sized VRAM headroom assuming a bounded per-request context for concurrent slots. Vision calls had no `num_ctx` cap, so under concurrent load a large context is the actual OOM/thrashing risk on a shared embed+vision GPU (per the concurrency research: "the real danger is pushing the VLM to higher parallelism with uncapped context").
- Adds a generic `providerOptions` passthrough on `createOpenAiCompatibleAi`'s chat path (an Ollama-specific request extension field, silently ignored by every other provider — embeddings, subscription CLIs, Anthropic) and sets `num_ctx: 4096` on the self-host visual-vision call.
- Companion image-downscaling optimization (screenshots are captured `fullPage: true`, so image height can far exceed the 1440px viewport width) is scoped separately — it needs a real image-processing dependency + Dockerfile/esbuild change since this self-host build bundles everything with zero `node_modules` at runtime today, filed as its own follow-up rather than bundled into this smaller, zero-dependency fix.

Part of #4325.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused — a single, small, zero-dependency change.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] Part of #4325 (maintainer-owned GPU-migration epic).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — new `providerOptions` passthrough branches (present/absent) covered in `test/unit/selfhost-ai.test.ts`; the vision call site's `num_ctx` value asserted in `test/unit/visual-vision-wiring.test.ts`
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] Ran `npm run test:ci` (full unsharded suite) end-to-end — green

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] N/A — no auth/UI/API/OpenAPI/MCP surface touched.

## Notes

- No migration, OpenAPI, or `cf-typegen` regeneration needed.