### PR TITLE
fix(mcp): validate open pr pressure input

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -1179,15 +1179,49 @@ const variantsOutputSchema = {
   variants: z.array(z.unknown()).optional(),
 };
 
-// #2224 - pure, read-only open-PR pressure simulator surfaced over MCP. queueHealth/roleContext use the same
-// permissive z.unknown() convention as the other engine-shaped MCP inputs (the simulator is the single source
-// of truth for their structure); the tool reveals nothing beyond a computation on the caller-supplied context.
+const SIMULATE_OPEN_PR_PRESSURE_MAX_COUNT = 1_000_000;
+const simulateOpenPrPressureCountSchema = z.number().int().min(0).max(SIMULATE_OPEN_PR_PRESSURE_MAX_COUNT);
+const simulateOpenPrPressureQueueHealthSchema = z
+  .object({
+    repoFullName: z.string().min(3).max(SCENARIO_MAX_REPO_FULL_NAME_CHARS),
+    generatedAt: z.string().min(1).max(100),
+    burdenScore: z.number().finite(),
+    level: z.enum(["low", "medium", "high", "critical"]),
+    summary: z.string().max(1_000),
+    signals: z
+      .object({
+        openIssues: simulateOpenPrPressureCountSchema,
+        openPullRequests: simulateOpenPrPressureCountSchema,
+        unlinkedPullRequests: simulateOpenPrPressureCountSchema,
+        stalePullRequests: simulateOpenPrPressureCountSchema,
+        draftPullRequests: simulateOpenPrPressureCountSchema,
+        maintainerAuthoredPullRequests: simulateOpenPrPressureCountSchema,
+        collisionClusters: simulateOpenPrPressureCountSchema,
+        ageBuckets: z
+          .object({
+            under7Days: simulateOpenPrPressureCountSchema,
+            days7To30: simulateOpenPrPressureCountSchema,
+            over30Days: simulateOpenPrPressureCountSchema,
+          })
+          .passthrough(),
+        likelyReviewablePullRequests: simulateOpenPrPressureCountSchema,
+        cachedOpenPullRequests: simulateOpenPrPressureCountSchema.optional(),
+        likelyReviewablePullRequestsSource: z.enum(["cache", "sampled_cache", "authoritative"]).optional(),
+      })
+      .passthrough(),
+    findings: z.array(z.unknown()).max(100),
+  })
+  .passthrough()
+  .nullable();
+
+// #2224 - pure, read-only open-PR pressure simulator surfaced over MCP. The simulator only reads
+// bounded queue counts and maintainer-lane state, so validate those fields at the MCP boundary.
 const simulateOpenPrPressureShape = {
-  repoFullName: z.string(),
-  generatedAt: z.string(),
-  queueHealth: z.unknown(),
-  roleContext: z.unknown(),
-  contributorOpenPrCount: z.number().optional(),
+  repoFullName: z.string().min(3).max(SCENARIO_MAX_REPO_FULL_NAME_CHARS),
+  generatedAt: z.string().min(1).max(100),
+  queueHealth: simulateOpenPrPressureQueueHealthSchema,
+  roleContext: z.object({ maintainerLane: z.boolean() }).passthrough(),
+  contributorOpenPrCount: simulateOpenPrPressureCountSchema.optional(),
 };
 const simulateOpenPrPressureOutputSchema = {
   repoFullName: z.string().optional(),

--- a/test/unit/mcp-simulate-open-pr-pressure.test.ts
+++ b/test/unit/mcp-simulate-open-pr-pressure.test.ts
@@ -134,4 +134,53 @@ describe("MCP gittensory_simulate_open_pr_pressure (#2224)", () => {
     expect(data.recommendedOption).toBe("wait");
     expect(data.summary).toMatch(/conservative default|unavailable/i);
   });
+
+  it("rejects a null role context at the MCP boundary", async () => {
+    const client = await connect();
+    const result = await client.callTool({
+      name: "gittensory_simulate_open_pr_pressure",
+      arguments: {
+        repoFullName: "acme/widgets",
+        generatedAt: "2026-07-08T00:00:00.000Z",
+        queueHealth: queueHealth("low"),
+        roleContext: null,
+      },
+    });
+    expect(result.isError).toBe(true);
+  });
+
+  it("rejects queue health without bounded numeric signals at the MCP boundary", async () => {
+    const client = await connect();
+    const result = await client.callTool({
+      name: "gittensory_simulate_open_pr_pressure",
+      arguments: {
+        repoFullName: "acme/widgets",
+        generatedAt: "2026-07-08T00:00:00.000Z",
+        queueHealth: { level: "low" },
+        roleContext: { maintainerLane: false },
+      },
+    });
+    expect(result.isError).toBe(true);
+  });
+
+  it("rejects oversized string queue counts before they can be reflected in output", async () => {
+    const client = await connect();
+    const result = await client.callTool({
+      name: "gittensory_simulate_open_pr_pressure",
+      arguments: {
+        repoFullName: "acme/widgets",
+        generatedAt: "2026-07-08T00:00:00.000Z",
+        queueHealth: {
+          ...queueHealth("low"),
+          signals: {
+            ...queueHealth("low").signals,
+            openPullRequests: "x".repeat(1024),
+          },
+        },
+        roleContext: { maintainerLane: false },
+      },
+    });
+    expect(result.isError).toBe(true);
+    expect(JSON.stringify(result)).not.toContain("x".repeat(512));
+  });
 });


### PR DESCRIPTION
### Motivation
- The MCP tool `gittensory_simulate_open_pr_pressure` accepted unbounded/malformed `queueHealth` and `roleContext` (via `z.unknown()`), allowing authenticated callers to cause runtime TypeErrors or reflect large payloads into output. 
- Tighten validation at the MCP boundary to prevent availability/resource-exhaustion and runtime crashes while keeping the simulator pure and read-only.

### Description
- Replace permissive `z.unknown()` inputs with a bounded `queueHealth` schema (`simulateOpenPrPressureQueueHealthSchema`) that validates pressure `level`, numeric signal counts, limited `findings` and reasonable string lengths, and add `SIMULATE_OPEN_PR_PRESSURE_MAX_COUNT` to cap numeric fields. 
- Validate `roleContext` minimally as an object with `maintainerLane: boolean` while using `.passthrough()` so the fuller engine context is preserved. 
- Constrain `repoFullName`, `generatedAt`, and `contributorOpenPrCount` with length/number bounds to avoid oversized inputs. 
- Add regression tests that exercise the MCP boundary rejecting `roleContext: null`, missing/ill-formed `queueHealth.signals`, and oversized/string queue counts so malformed inputs fail at schema validation instead of crashing or being reflected in output.

### Testing
- Ran `npm run build:miner` and the build succeeded. 
- Ran `npx vitest run test/unit/mcp-simulate-open-pr-pressure.test.ts` and all tests in that file passed. 
- Ran `npm run typecheck` and TypeScript typecheck passed. 
- Attempted coverage: `npx vitest run --coverage test/unit/mcp-simulate-open-pr-pressure.test.ts` the tests passed but coverage remapping failed with `TypeError: jsTokens is not a function`; a full `npm run test:coverage` run did not complete in this environment. 
- `npm audit --audit-level=moderate` could not be completed due to the registry audit endpoint returning `403 Forbidden` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f2948f234832c878ac168a054048b)