### PR TITLE
fix(review): prevent generated test markdown breakout

### DIFF
--- a/src/review/e2e-test-gen-render.ts
+++ b/src/review/e2e-test-gen-render.ts
@@ -31,6 +31,12 @@ export type E2eTestGenCommentInput = {
   commit?: E2eTestGenCommitOutcome | undefined;
 };
 
+function markdownFenceFor(source: string): string {
+  const backtickRunLengths = Array.from(source.matchAll(/`+/g), (match) => match[0]!.length);
+  const longestBacktickRun = Math.max(0, ...backtickRunLengths);
+  return "`".repeat(Math.max(3, longestBacktickRun + 1));
+}
+
 /**
  * Build the PR-comment body for a `@gittensory generate-tests` result. A null `testSource` renders a
  * clear "nothing usable" note rather than silently posting no comment at all — the maintainer who invoked
@@ -74,6 +80,7 @@ export function buildE2eTestGenCommentBody(input: E2eTestGenCommentInput): strin
             "",
           ]
         : [];
+  const fence = markdownFenceFor(input.testSource);
   return [
     AGENT_COMMAND_COMMENT_MARKER,
     "",
@@ -82,9 +89,9 @@ export function buildE2eTestGenCommentBody(input: E2eTestGenCommentInput): strin
     "> This is a suggestion, not a guarantee — review it like any other test before merging.",
     ...declineNote,
     "",
-    "```typescript",
+    `${fence}typescript`,
     input.testSource,
-    "```",
+    fence,
     "",
     "---",
     gittensoryFooter(),

--- a/test/unit/e2e-test-gen-render.test.ts
+++ b/test/unit/e2e-test-gen-render.test.ts
@@ -10,6 +10,27 @@ describe("buildE2eTestGenCommentBody", () => {
     expect(body).toContain("```typescript\ntest('x', () => {});\n```");
   });
 
+  it("uses a longer markdown fence when generated source contains backtick fences", () => {
+    const source = [
+      "import { test, expect } from '@playwright/test';",
+      "",
+      "test('injected markdown stays inside the code block', async ({ page }) => {",
+      "  const attackerMarkdown = `",
+      "```",
+      "# rendered outside the fence before the fix",
+      "```",
+      "  `;",
+      "  expect(attackerMarkdown).toContain('# rendered outside');",
+      "});",
+    ].join("\n");
+
+    const body = buildE2eTestGenCommentBody({ actor: "maintainer", testSource: source });
+
+    expect(body).toContain("````typescript\n");
+    expect(body).toContain(source + "\n````");
+    expect(body.split("\n")).not.toContain("```typescript");
+  });
+
   it("uses a custom framework name when provided", () => {
     const body = buildE2eTestGenCommentBody({ actor: "maintainer", testSource: "it('x', () => {});", framework: "Cypress" });
     expect(body).toContain("AI-generated Cypress test for @maintainer");


### PR DESCRIPTION
### Motivation
- Close a stored-comment Markdown injection vector where AI-generated Playwright tests containing triple-backtick runs could close the bot's fixed ```typescript fence and inject attacker-controlled Markdown into PR comments.
- Keep public comment rendering safe while preserving the ability to post the generated test source for maintainer review.

### Description
- Add `markdownFenceFor(source: string)` and use a fence length that is one backtick longer than any run found in the generated source so the renderer no longer emits a fixed triple-backtick opener/closer (`src/review/e2e-test-gen-render.ts`).
- Replace the hard-coded code-fence strings with the computed `fence` when rendering the AI-generated test body so nested backtick runs cannot break out of the code block (`src/review/e2e-test-gen-render.ts`).
- Add a regression unit test that includes attacker-controlled backtick fences inside generated Playwright-like source and asserts the renderer uses a longer fence and keeps the content inside the code block (`test/unit/e2e-test-gen-render.test.ts`).

### Testing
- Ran `npx vitest run test/unit/e2e-test-gen-render.test.ts` and all tests in that file passed. 
- Ran `npm run typecheck` and `git diff --check`, both succeeded with no errors. 
- Attempted `npm run test:coverage`; the tests passed but coverage remapping failed in this container under Node `v24.15.0` while the repo expects Node `22`, so a full unsharded coverage run / `npm run test:ci` should be executed in the project CI or a Node 22 environment before pushing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f2947c418832cb881c2c2f3bacbfb)