### PR TITLE
fix(manifest): keep freeze override operator-only

### DIFF
--- a/.gittensory.yml.example
+++ b/.gittensory.yml.example
@@ -668,13 +668,6 @@ settings:
   # Bool. Default: false.
   agentDryRun: false
 
-  # Per-repo override of the GLOBAL DB-backed agent freeze (the operator kill-switch an operator flips with
-  # one row, no redeploy): when true, THIS repo's actions execute even while the global freeze is on, so an
-  # operator can re-activate one repo at a time without lifting the fleet-wide brake. Never overrides the
-  # AGENT_ACTIONS_PAUSED env var (that hard stop always wins), and agentPaused above on this same repo still
-  # wins over this too. Bool. Default: false.
-  agentGlobalFreezeOverride: false
-
   # Four independent label families, none of which gates or silently disables another (#label-decoupling,
   # #label-scoping):
   #   1. Context label (`gittensorLabel`, gated by `autoLabelEnabled` above) — the base per-PR marker shown

--- a/config/examples/gittensory.full.yml
+++ b/config/examples/gittensory.full.yml
@@ -681,13 +681,6 @@ settings:
   # Bool. Default: false.
   agentDryRun: false
 
-  # Per-repo override of the GLOBAL DB-backed agent freeze (the operator kill-switch an operator flips with
-  # one row, no redeploy): when true, THIS repo's actions execute even while the global freeze is on, so an
-  # operator can re-activate one repo at a time without lifting the fleet-wide brake. Never overrides the
-  # AGENT_ACTIONS_PAUSED env var (that hard stop always wins), and agentPaused above on this same repo still
-  # wins over this too. Bool. Default: false.
-  agentGlobalFreezeOverride: false
-
   # Four independent label families, none of which gates or silently disables another (#label-decoupling,
   # #label-scoping):
   #   1. Context label (`gittensorLabel`, gated by `autoLabelEnabled` above) — the base per-PR marker shown

--- a/packages/gittensory-engine/src/focus-manifest.ts
+++ b/packages/gittensory-engine/src/focus-manifest.ts
@@ -331,7 +331,6 @@ export type FocusManifestSettings = Partial<
     | "autoMaintain"
     | "agentPaused"
     | "agentDryRun"
-    | "agentGlobalFreezeOverride"
     | "commandAuthorization"
     | "contributorBlacklist"
     | "blacklistLabel"
@@ -1660,7 +1659,7 @@ function parseSettingsOverride(value: JsonValue | undefined, warnings: string[])
   }
   const publicSurface = normalizeOptionalEnum(r.publicSurface, "settings.publicSurface", ["off", "comment_and_label", "comment_only", "label_only"] as const, warnings);
   if (publicSurface !== null) out.publicSurface = publicSurface;
-  for (const key of ["aiReviewByok", "aiReviewAllAuthors", "closeOwnerAuthors", "autoLabelEnabled", "typeLabelsEnabled", "badgeEnabled", "publicQualityMetrics", "createMissingLabel", "includeMaintainerAuthors", "requireLinkedIssue", "backfillEnabled", "agentPaused", "agentDryRun", "agentGlobalFreezeOverride"] as const) {
+  for (const key of ["aiReviewByok", "aiReviewAllAuthors", "closeOwnerAuthors", "autoLabelEnabled", "typeLabelsEnabled", "badgeEnabled", "publicQualityMetrics", "createMissingLabel", "includeMaintainerAuthors", "requireLinkedIssue", "backfillEnabled", "agentPaused", "agentDryRun"] as const) {
     const flag = normalizeOptionalBoolean(r[key], `settings.${key}`, warnings);
     if (flag !== null) out[key] = flag;
   }

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -312,7 +312,6 @@ describe(".gittensory.yml.example field-exhaustiveness (#1670)", () => {
     autoMaintain: "autoMaintain:",
     agentPaused: "agentPaused:",
     agentDryRun: "agentDryRun:",
-    agentGlobalFreezeOverride: "agentGlobalFreezeOverride:",
     commandAuthorization: "commandAuthorization:",
     contributorBlacklist: "contributorBlacklist:",
     blacklistLabel: "blacklistLabel:",
@@ -1856,11 +1855,10 @@ describe("parseFocusManifest settings override + resolveEffectiveSettings", () =
       includeMaintainerAuthors: true,
       requireLinkedIssue: true,
       backfillEnabled: false,
-      agentGlobalFreezeOverride: true,
     });
-    // #4372: the yml override wins over the DB value via resolveEffectiveSettings's spread, same as every
-    // other generic settings: field.
-    expect(resolveEffectiveSettings({ agentGlobalFreezeOverride: false } as unknown as RepositorySettings, m).agentGlobalFreezeOverride).toBe(true);
+    // Operator-only freeze overrides are deliberately not config-as-code fields; a maintainer-owned
+    // manifest must not be able to bypass the DB-backed global freeze.
+    expect(resolveEffectiveSettings({ agentGlobalFreezeOverride: false } as unknown as RepositorySettings, m).agentGlobalFreezeOverride).toBe(false);
   });
 
   it("drops invalid settings values with warnings and keeps the valid ones", () => {


### PR DESCRIPTION
### Motivation

- A maintainer-accessible focus-manifest path was recognizing `agentGlobalFreezeOverride`, which let repo maintainers bypass the operator DB-backed global agent freeze and restore live bot mutations for that repo.
- The field must remain an operator-only control (YAML/operator config), not a maintainer-editable config-as-code setting, to preserve the global kill-switch semantics.

### Description

- Remove `agentGlobalFreezeOverride` from the focus-manifest `FocusManifestSettings` type so it is no longer a recognized repo-config field in `packages/gittensory-engine/src/focus-manifest.ts`.
- Stop parsing `settings.agentGlobalFreezeOverride` from manifests by removing it from the boolean-flag parsing loop in `parseSettingsOverride` so manifest content can no longer inject the override.
- Remove the field and its explanatory example from the checked-in manifest examples (`.gittensory.yml.example` and `config/examples/gittensory.full.yml`).
- Update the manifest unit test (`test/unit/focus-manifest.test.ts`) to assert a manifest-supplied `agentGlobalFreezeOverride` is ignored and that the DB value remains authoritative.

### Testing

- Ran the focused unit suite: `npx vitest run test/unit/focus-manifest.test.ts --no-color` and it passed (all tests in that file succeeded).
- Type-checked the code with `npm run typecheck` and it succeeded with no errors.
- Ran repository checks `git diff --check`, `npm run docs:drift-check`, and `npm run manifest:drift-check` which all succeeded.
- Attempted the full local gate (`npm run test:ci`) and `npm audit --audit-level=moderate` but these were blocked by unrelated local environment issues (`cf-typegen`/wrangler drift and npm registry audit returning 403) so the complete CI gate was not completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f4c4570e0832c83cf84fc5fbac982)