### PR TITLE
fix(ci): disambiguate engine publish ancestry ref

### DIFF
--- a/.github/workflows/publish-engine.yml
+++ b/.github/workflows/publish-engine.yml
@@ -51,8 +51,8 @@ jobs:
           RELEASE_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          git fetch --no-tags origin main
-          if ! git merge-base --is-ancestor "$RELEASE_SHA" origin/main; then
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          if ! git merge-base --is-ancestor "$RELEASE_SHA" refs/remotes/origin/main; then
             echo "::error::Engine package releases must be cut from a commit reachable from main."
             exit 1
           fi
@@ -152,8 +152,8 @@ jobs:
           RELEASE_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          git fetch --no-tags origin main
-          if ! git merge-base --is-ancestor "$RELEASE_SHA" origin/main; then
+          git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main
+          if ! git merge-base --is-ancestor "$RELEASE_SHA" refs/remotes/origin/main; then
             echo "::error::Engine package releases must be cut from a commit reachable from main."
             exit 1
           fi


### PR DESCRIPTION
### Motivation
- The release ancestry check used the ambiguous short ref `origin/main`, which Git can resolve to a tag named `origin/main` and allow an off-main commit to pass the gate.
- The publish workflow is security-sensitive (`contents: write`, `id-token: write` and npm publish), so the ancestry check must be robust against tag/name ambiguity.

### Description
- Replace the ambiguous fetch with an explicit fetch of main into the remote-tracking ref by running `git fetch --no-tags origin +refs/heads/main:refs/remotes/origin/main`.
- Update the ancestry test to check `refs/remotes/origin/main` explicitly via `git merge-base --is-ancestor "$RELEASE_SHA" refs/remotes/origin/main`.
- Apply the same fix in both the unprivileged `validate` job and the privileged `publish` job in `.github/workflows/publish-engine.yml`.

### Testing
- Ran `git diff --check` to validate workspace hygiene and it succeeded.
- Ran `npm run actionlint` to lint workflow YAML files, which completed successfully (used the WASM fallback for `actionlint` setup).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f3ea9b944832c98cbe447d3e2e3b6)