### PR TITLE
fix(review): gate self-host visual-vision behind author opt-in

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -8255,10 +8255,11 @@ export async function runVisualVisionForAdvisory(
             model: args.settings.aiReviewModel ?? storedVisionKey.model,
           }
         : null;
-    // Self-host local vision (#4335): a dedicated ollama+VLM binding lets vision run WITHOUT a maintainer
-    // BYOK key -- see evaluateVisualVisionGate's header for why only an HTTP-capable provider (BYOK or this)
-    // can see the screenshots at all.
-    const selfHostVisionAvailable = Boolean(env.AI_VISION);
+    // Self-host local vision (#4335) still consumes operator resources, so mirror the AI-spend gate used by
+    // the other self-host review paths: confirmed contributors only unless the repo explicitly opts in to all
+    // authors. BYOK remains checked above because it also requires a confirmed contributor-owned repo key.
+    const selfHostVisionAllowed = args.confirmedContributor || args.settings.aiReviewAllAuthors;
+    const selfHostVisionAvailable = selfHostVisionAllowed && Boolean(env.AI_VISION);
     const visionGate = evaluateVisualVisionGate({
       routes: args.routes,
       reputationSignal: visionReputation.signal,

--- a/test/unit/visual-vision-wiring.test.ts
+++ b/test/unit/visual-vision-wiring.test.ts
@@ -438,6 +438,48 @@ describe("runVisualVisionForAdvisory: self-host local vision provider (#4335)", 
     ]);
   });
 
+  it("does not let an unconfirmed contributor spend self-host vision resources unless all-authors is enabled", async () => {
+    const runMock = vi.fn(async () => ({ response: findingsResponse([{ path: "/app", body: "should not run" }]) }));
+    const env = byokEnv();
+    (env as unknown as { AI_VISION: unknown }).AI_VISION = { run: runMock };
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const adv = findingsHolder();
+    await runVisualVisionForAdvisory(env, {
+      repoFullName,
+      pr,
+      author: "alice",
+      confirmedContributor: false,
+      settings: byokSettings({ aiReviewByok: false, aiReviewAllAuthors: false }),
+      advisory: adv,
+      routes: selfHostVisionRoutes(),
+    });
+    expect(runMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(adv.findings).toEqual([]);
+  });
+
+  it("allows self-host vision for an unconfirmed contributor when all-authors is explicitly enabled", async () => {
+    const runMock = vi.fn(async () => ({
+      response: findingsResponse([{ path: "/app", body: "All-authors opt-in covers this self-host call." }]),
+    }));
+    const env = byokEnv();
+    (env as unknown as { AI_VISION: unknown }).AI_VISION = { run: runMock };
+    stubShots();
+    const adv = findingsHolder();
+    await runVisualVisionForAdvisory(env, {
+      repoFullName,
+      pr,
+      author: "alice",
+      confirmedContributor: false,
+      settings: byokSettings({ aiReviewByok: false, aiReviewAllAuthors: true }),
+      advisory: adv,
+      routes: selfHostVisionRoutes(),
+    });
+    expect(runMock).toHaveBeenCalledTimes(1);
+    expect(adv.findings[0]).toMatchObject({ detail: "All-authors opt-in covers this self-host call." });
+  });
+
   it("prefers a configured BYOK key over env.AI_VISION when both are available", async () => {
     const env = byokEnv();
     await upsertRepositoryAiKey(env, { repoFullName, provider: "anthropic", key: "sk-ant-vision-key", model: null });


### PR DESCRIPTION
### Motivation

- A recent change allowed the self-host `AI_VISION` path to run without the existing author/spend gate, enabling unconfirmed external contributors to trigger local vision model work and consume operator resources. 
- The intent is to preserve the operator-protected AI-spend semantics used elsewhere: run for confirmed contributors by default, or for all authors only when a repository explicitly opts in (`aiReviewAllAuthors`).

### Description

- Require the same author opt-in for self-host vision by introducing `selfHostVisionAllowed = args.confirmedContributor || args.settings.aiReviewAllAuthors` and computing `selfHostVisionAvailable = selfHostVisionAllowed && Boolean(env.AI_VISION)` in `src/queue/processors.ts` so the gate cannot be satisfied solely by `env.AI_VISION`.
- Pass the guarded `selfHostVisionAvailable` into the existing `evaluateVisualVisionGate` call so the visual-vision gate only permits execution when the author/repo opt-in is satisfied.
- Add regression tests in `test/unit/visual-vision-wiring.test.ts` that assert an unconfirmed contributor cannot trigger screenshot fetches or `env.AI_VISION.run` unless `aiReviewAllAuthors` is enabled, and that `aiReviewAllAuthors` still allows the explicit opt-in path.

### Testing

- Ran the focused unit suites with `npx vitest run test/unit/visual-vision-wiring.test.ts test/unit/visual-findings.test.ts --reporter=verbose`, and all tests in those files passed (48 tests across the two files).
- Type-check succeeded (`npm run typecheck`).
- `npm audit --audit-level=moderate` could not complete due to a registry `403 Forbidden` response (not related to the change).
- Attempting the full local gate via `npm run test:ci` did not complete because `cf-typegen:check` reported a stale `worker-configuration.d.ts` requiring regeneration; this drift is unrelated to the visual-vision logic and blocks completing the entire gate in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f407606e0832c94fc7e0036250157)