### PR TITLE
fix(rag): reject invalid embed batch sizes

### DIFF
--- a/src/review/rag.ts
+++ b/src/review/rag.ts
@@ -122,8 +122,8 @@ export function ragDimensionsFromEnv(value: string | undefined): number {
 }
 
 export function ragEmbedBatchFromEnv(value: string | undefined): number {
-  const batch = Number(value);
-  return Number.isFinite(batch) && batch > 0 ? Math.floor(batch) : EMBED_BATCH;
+  const batch = Math.floor(Number(value));
+  return Number.isFinite(batch) && batch > 0 ? batch : EMBED_BATCH;
 }
 
 // ── Filtering: index CODE, not content/data corpora (the primary free-tier cost guard) ───────────
@@ -298,10 +298,12 @@ export async function embedTexts(
   batchSize = EMBED_BATCH,
 ): Promise<number[][] | null> {
   if (!inference || texts.length === 0) return null;
+  const effectiveBatchSize = Math.floor(batchSize);
+  if (!Number.isFinite(effectiveBatchSize) || effectiveBatchSize < 1) return null;
   try {
     const out: number[][] = [];
-    for (let i = 0; i < texts.length; i += batchSize) {
-      const batch = texts.slice(i, i + batchSize);
+    for (let i = 0; i < texts.length; i += effectiveBatchSize) {
+      const batch = texts.slice(i, i + effectiveBatchSize);
       const res = (await inference.run(EMBED_MODEL, { text: batch })) as { data?: number[][] } | null;
       const data = res?.data;
       // Validate COUNT and DIMENSION: a self-host embedding endpoint can return a structurally-valid response

--- a/test/unit/rag.test.ts
+++ b/test/unit/rag.test.ts
@@ -169,6 +169,7 @@ describe("ragEmbedBatchFromEnv", () => {
     expect(ragEmbedBatchFromEnv("")).toBe(96);
     expect(ragEmbedBatchFromEnv("not-a-number")).toBe(96);
     expect(ragEmbedBatchFromEnv("0")).toBe(96);
+    expect(ragEmbedBatchFromEnv("0.5")).toBe(96);
     expect(ragEmbedBatchFromEnv("-5")).toBe(96);
   });
 });
@@ -731,6 +732,16 @@ describe("rag: embedTexts validation branches", () => {
     expect(out).not.toBeNull();
     expect(out?.length).toBe(150);
     expect(calls).toEqual([96, 54]); // proves the batching loop ran twice
+  });
+
+  it("rejects an invalid batchSize before embedding so a zero step cannot hang", async () => {
+    const inference: InferenceAdapter = {
+      run: async () => {
+        throw new Error("must not call embedding provider for an invalid batch size");
+      },
+    };
+    expect(await embedTexts(inference, ["hi"], RAG_DIMENSIONS, 0)).toBeNull();
+    expect(await embedTexts(inference, ["hi"], RAG_DIMENSIONS, Number.NaN)).toBeNull();
   });
 
   it("honors a configured batchSize override instead of the EMBED_BATCH=96 default (self-host GPU tuning)", async () => {


### PR DESCRIPTION
### Motivation

- The environment parser accepted positive fractional `AI_EMBED_BATCH` values that floored to `0`, which could be threaded into RAG operations and produce a non-advancing batching loop. 
- A zero `batchSize` leads to empty batches and a self-host embedding adapter returning `{ data: [] }`, allowing the embedding loop to spin indefinitely and hang review/index/retrieval work. 
- The change prevents accidental denial-of-service on self-hosted deployments by validating the effective integer batch size before use. 

### Description

- Change `ragEmbedBatchFromEnv` to floor the numeric value first and validate the floored integer, i.e. `const batch = Math.floor(Number(value)); return Number.isFinite(batch) && batch > 0 ? batch : EMBED_BATCH;`. 
- Add a defensive guard in `embedTexts` that computes `effectiveBatchSize = Math.floor(batchSize)` and returns `null` if `effectiveBatchSize` is not finite or is `< 1`, and use `effectiveBatchSize` for slicing and loop increments. 
- Add regression unit tests to assert fractional env parsing falls back to the default and that invalid/zero/NaN `batchSize` inputs cause `embedTexts` to return `null` without calling the embedding provider. 

### Testing

- Ran the targeted unit suite `npx vitest run test/unit/rag.test.ts` which passed (all relevant `rag` tests succeeded). 
- Ran type checking via `npm run typecheck` which completed without errors. 
- Attempted full coverage with `npm run test:coverage` in this environment but it did not complete here (the focused unit coverage for the changed files was exercised and passed); the full CI gate should be run before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f40754590832ca9c7c977c160ed14)