### PR TITLE
fix(selfhost): keep advisory AI key explicit

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -518,7 +518,7 @@ async function main(): Promise<void> {
   const advisoryAi = process.env.AI_ADVISORY_BASE_URL
     ? createOpenAiCompatibleAi({
         baseUrl: process.env.AI_ADVISORY_BASE_URL,
-        apiKey: process.env.AI_ADVISORY_API_KEY ?? process.env.OPENAI_API_KEY,
+        apiKey: process.env.AI_ADVISORY_API_KEY,
         model: process.env.AI_ADVISORY_MODEL,
       })
     : undefined;

--- a/test/unit/selfhost-ai.test.ts
+++ b/test/unit/selfhost-ai.test.ts
@@ -117,6 +117,19 @@ describe("createOpenAiCompatibleAi (#979)", () => {
     expect(first?.body.model).toBe("llama3.1");
   });
 
+  it("only sends an Authorization header when this OpenAI-compatible provider has its own apiKey", async () => {
+    const authHeaders: Array<string | null> = [];
+    vi.stubGlobal("fetch", vi.fn(async (_u: string, init?: RequestInit) => {
+      authHeaders.push(new Headers(init?.headers).get("authorization"));
+      return new Response(JSON.stringify({ choices: [{ message: { content: "ok" } }] }), { status: 200 });
+    }));
+
+    await createOpenAiCompatibleAi({ baseUrl: "http://advisory.local/v1" }).run("m", { prompt: "x" });
+    await createOpenAiCompatibleAi({ baseUrl: "http://advisory.local/v1", apiKey: "sk-advisory" }).run("m", { prompt: "x" });
+
+    expect(authHeaders).toEqual([null, "Bearer sk-advisory"]);
+  });
+
   it("forwards providerOptions verbatim as the request's `options` field (#4327/#4335 num_ctx capping)", async () => {
     let body: Record<string, unknown> | undefined;
     vi.stubGlobal("fetch", vi.fn(async (_u: string, init: { body: string }) => {


### PR DESCRIPTION
### Motivation

- Prevent accidental disclosure of the main OpenAI API key by stopping the AI_ADVISORY provider from falling back to `OPENAI_API_KEY` when `AI_ADVISORY_API_KEY` is unset.

### Description

- Stop sending the main OpenAI credential to advisory endpoints by changing the advisory provider construction in `src/server.ts` to use `apiKey: process.env.AI_ADVISORY_API_KEY` instead of `AI_ADVISORY_API_KEY ?? OPENAI_API_KEY`.
- Add a regression unit test in `test/unit/selfhost-ai.test.ts` that asserts an OpenAI-compatible provider omits `Authorization` when no `apiKey` is given and sends its own bearer token when configured.
- Preserve the existing fail-safe behavior that an unset advisory binding leaves advisory call sites routing to the shared `env.AI` (no other runtime behavior was changed).

### Testing

- Ran the new focused unit test via `npx vitest run test/unit/selfhost-ai.test.ts -t "OpenAI-compatible provider has its own apiKey"` and it passed.
- Ran `npm run selfhost:env-reference:check` and `npm run typecheck` and both checks succeeded.
- Ran the broader `test/unit/selfhost-ai.test.ts` suite and the file completed successfully (all targeted tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f5a4fd4e0832cab5bc73a4b797756)