### PR TITLE
feat(review): raise the RAG per-repo chunk cap from 1500 to 4000

### DIFF
--- a/src/review/rag.ts
+++ b/src/review/rag.ts
@@ -100,8 +100,16 @@ export const RAG_DIMENSIONS = 1024;
 
 const CHUNK_CHARS = 16000; // per-file chunk budget; only files larger than this are split
 const CHUNK_OVERLAP = 1500;
-/** Hard per-repo stored-vector cap — the free-tier guard. Source is prioritized so it survives the cap. */
-export const MAX_CHUNKS_PER_REPO = 1500;
+/** Hard per-repo stored-vector cap — bounds a repo-controlled, unboundedly-growable store. Source is
+ *  prioritized so it survives the cap. Raised from 1500 (2026-07-09): all 3 currently-gated repos were
+ *  sitting AT the old cap (confirmed live), and gittensory's own indexable tree alone is within range of
+ *  it before accounting for large files splitting into multiple chunks -- meaning real code was silently
+ *  never indexed. Storage/search cost at this scale is trivial for Qdrant regardless of cap size (the
+ *  bound exists to protect against a pathological future repo, not because 4000 vectors is expensive);
+ *  the real cost of a higher cap is embedding COMPUTE, which is now a one-time cost per file instead of a
+ *  recurring one per cron cycle (#4365's blob-SHA skip-cache). Self-host only: this is not a Cloudflare
+ *  free-tier constraint on this deployment, but the name/comment history predates self-host. */
+export const MAX_CHUNKS_PER_REPO = 4000;
 const EMBED_BATCH = 96; // Workers AI caps embedding input at 100 items/call; kept as a conservative general
 // bound — other embed providers (Ollama/vLLM/etc via the self-host adapter) may not share this exact cap.
 const MAX_CONTEXT_CHARS = 14000; // bound the injected block (mirrors diff/knowledge budgets)


### PR DESCRIPTION
## Summary
- `MAX_CHUNKS_PER_REPO` (the hard per-repo bound on stored RAG vectors) raised from 1500 to 4000.
- All 3 currently-gated repos (gittensory, metagraphed, awesome-claude) were sitting exactly at the old cap, confirmed live — meaning real, indexable code was silently never making it into the RAG index for at least one of them.
- Storage/search cost at this scale is trivial for Qdrant regardless of cap size — the bound exists to protect against a future pathological repo, not because a few thousand vectors is expensive. The real cost of a higher cap is embedding compute, which #4365 (the blob-SHA skip-cache) turns from a recurring per-cron-cycle cost into a one-time cost per file.

## Scope
- [x] Stayed within `wantedPaths` (`src/`)
- [x] No secrets/wallets/trust-score/reward values anywhere
- [x] No changes to `site/`, `CNAME`, `**/lovable/**`, or `CHANGELOG.md`

## Validation
- [x] `npm run typecheck`
- [x] `npx vitest run test/unit/rag.test.ts test/unit/rag-index.test.ts` — 127/127 passing (every cap-related test references the exported constant, none hardcode the old value)
- [x] `npm run db:schema-drift:check` / `npm run selfhost:env-reference:check` — clean (no schema/env surface touched)
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities

## Safety
- [x] No secrets/tokens anywhere
- [x] Single-constant change, no logic touched