### PR TITLE
feat(miner-hands): add shared subprocess env-allowlist + secret-redaction helper to gittensory-engine

### DIFF
--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -164,6 +164,7 @@ export {
   type PromptPacketTextField,
 } from "./prompt-packet.js";
 export * from "./portfolio/queue.js";
+export * from "./miner/subprocess-env.js";
 export {
   applyAiPolicyFatigueToRankInput,
   createAiPolicyFatigueCacheEntry,

--- a/packages/gittensory-engine/src/miner/subprocess-env.ts
+++ b/packages/gittensory-engine/src/miner/subprocess-env.ts
@@ -1,0 +1,86 @@
+// Shared subprocess env-allowlist + secret-redaction helper (#4284). Engine-hosted so every
+// subprocess-spawning driver in gittensory-miner (and src/selfhost/ai.ts's subscription-CLI path)
+// can depend on one source of truth instead of copy-pasting the pattern.
+//
+// Generalized from the subscription-CLI code in src/selfhost/ai.ts: `buildAllowlistedEnv` parameterizes
+// the allowlist (a coding-agent subprocess may need a different/larger allowlist than a review-only CLI
+// call), and `redactSubprocessSecrets` carries over `redactSecrets`'s known-value + token-shape stripping
+// with the same `SECRET_PATTERNS` regex family (ported, not weakened).
+//
+// MIGRATION (#4284, deliberate): src/selfhost/ai.ts KEEPS its own copy for now — this change makes no
+// behavioral edit to the hosted review path. This module is the shared source of truth for NEW
+// subprocess drivers; refactoring ai.ts onto it (the shim pattern src/rules/predicted-gate.ts uses over
+// the engine) is deferred to a follow-up to avoid churning the hosted path in this PR.
+//
+// Pure: no IO, no Date.now(), no randomness.
+
+/** Well-known secret shapes to strip from untrusted subprocess output. Ported verbatim from
+ *  src/selfhost/ai.ts's SECRET_PATTERNS so the two stay coverage-equivalent (OpenAI/Anthropic keys,
+ *  GitHub tokens, fine-grained PATs, JWTs, AWS access-key ids). */
+export const SUBPROCESS_SECRET_PATTERNS: readonly RegExp[] = [
+  /\bsk-[A-Za-z0-9_-]{16,}/g, // OpenAI / Anthropic keys (sk-..., sk-ant-..., sk-proj-...)
+  /\bgh[oprsu]_[A-Za-z0-9]{20,}/g, // GitHub PAT / OAuth / server / refresh tokens
+  /\bgithub_pat_[A-Za-z0-9_]{20,}/g, // GitHub fine-grained PAT
+  /\beyJ[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}/g, // JWT (header.payload.signature)
+  /\bAKIA[0-9A-Z]{16}/g, // AWS access key id
+];
+
+/** The subscription-CLI review allowlist (src/selfhost/ai.ts) exported as a ready default for review-only
+ *  CLI calls. Other drivers should pass their OWN allowlist to `buildAllowlistedEnv` rather than reuse this. */
+export const SUBSCRIPTION_CLI_ENV_ALLOWLIST: readonly string[] = [
+  "HOME",
+  "HTTPS_PROXY",
+  "HTTP_PROXY",
+  "LANG",
+  "LC_ALL",
+  "NODE_EXTRA_CA_CERTS",
+  "NO_PROXY",
+  "PATH",
+  "SSL_CERT_DIR",
+  "SSL_CERT_FILE",
+  "TERM",
+  "XDG_CONFIG_HOME",
+  "XDG_DATA_HOME",
+  "XDG_STATE_HOME",
+  "https_proxy",
+  "http_proxy",
+  "no_proxy",
+];
+
+/**
+ * Build a strict allowlisted child environment: only keys named in `allowlist` are carried over from
+ * `parent`, then `extra` is layered on top. Keys with an `undefined` value (in either source) are omitted
+ * so the child never gains an empty var it wouldn't otherwise have. Pure — mirrors `subscriptionCliEnv`'s
+ * allowlist copy, minus the subscription-CLI-specific PATH rewrite (a caller that needs that composes it).
+ */
+export function buildAllowlistedEnv(
+  parent: Record<string, string | undefined>,
+  allowlist: readonly string[],
+  extra: Record<string, string | undefined> = {},
+): Record<string, string | undefined> {
+  const child: Record<string, string | undefined> = {};
+  for (const key of allowlist) {
+    const value = parent[key];
+    if (value !== undefined) child[key] = value;
+  }
+  for (const [key, value] of Object.entries(extra)) {
+    if (value !== undefined) child[key] = value;
+  }
+  return child;
+}
+
+/**
+ * Redact secrets from untrusted subprocess output before it enters an error message / log line: strip the
+ * caller's known secret VALUES exactly (length-guarded so a short/empty token can't blank unrelated text),
+ * then well-known token SHAPES from {@link SUBPROCESS_SECRET_PATTERNS}. Pure. Ported from
+ * src/selfhost/ai.ts's `redactSecrets`.
+ */
+export function redactSubprocessSecrets(text: string, knownSecrets: readonly string[] = []): string {
+  let out = text;
+  for (const secret of knownSecrets) {
+    // Length-guard so a short/empty token (e.g. a stubbed "t") can't blank out unrelated diagnostic text.
+    if (secret.length >= 8) out = out.split(secret).join("[redacted]");
+  }
+  for (const pattern of SUBPROCESS_SECRET_PATTERNS) out = out.replace(pattern, "[redacted]");
+  return out;
+}

--- a/packages/gittensory-engine/test/subprocess-env.test.ts
+++ b/packages/gittensory-engine/test/subprocess-env.test.ts
@@ -1,0 +1,72 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  buildAllowlistedEnv,
+  redactSubprocessSecrets,
+  SUBPROCESS_SECRET_PATTERNS,
+  SUBSCRIPTION_CLI_ENV_ALLOWLIST,
+} from "../dist/index.js";
+
+test("buildAllowlistedEnv honors a CALLER-SUPPLIED allowlist, not just the hardcoded default", () => {
+  const parent = { FOO: "1", BAR: "2", SECRET_TOKEN: "keep-out", PATH: "/bin" };
+  const child = buildAllowlistedEnv(parent, ["FOO", "BAR"]);
+  assert.deepEqual(child, { FOO: "1", BAR: "2" });
+  // A key outside the caller's allowlist is dropped even though it exists in parent.
+  assert.equal("SECRET_TOKEN" in child, false);
+  assert.equal("PATH" in child, false);
+});
+
+test("buildAllowlistedEnv layers `extra` over the allowlisted copy", () => {
+  const child = buildAllowlistedEnv({ HOME: "/home/x" }, ["HOME"], { EXTRA: "e", HOME: "/override" });
+  assert.deepEqual(child, { HOME: "/override", EXTRA: "e" });
+});
+
+test("buildAllowlistedEnv omits undefined values from both parent and extra", () => {
+  const child = buildAllowlistedEnv(
+    { HOME: "/home/x", LANG: undefined },
+    ["HOME", "LANG", "MISSING"],
+    { E1: "v", E2: undefined },
+  );
+  assert.deepEqual(child, { HOME: "/home/x", E1: "v" });
+  assert.equal("LANG" in child, false); // present-but-undefined in parent
+  assert.equal("MISSING" in child, false); // absent in parent
+  assert.equal("E2" in child, false); // undefined in extra
+});
+
+test("SUBSCRIPTION_CLI_ENV_ALLOWLIST default carries the ai.ts key set (PATH/HOME/proxy/cert/XDG)", () => {
+  for (const key of ["HOME", "PATH", "HTTPS_PROXY", "NODE_EXTRA_CA_CERTS", "XDG_CONFIG_HOME", "no_proxy"]) {
+    assert.ok(SUBSCRIPTION_CLI_ENV_ALLOWLIST.includes(key), `allowlist missing ${key}`);
+  }
+  const child = buildAllowlistedEnv({ HOME: "/h", PATH: "/bin", UNLISTED: "x" }, SUBSCRIPTION_CLI_ENV_ALLOWLIST);
+  assert.deepEqual(child, { HOME: "/h", PATH: "/bin" });
+});
+
+test("redactSubprocessSecrets strips every carried-over token shape (ported, not weakened)", () => {
+  const cases = [
+    "sk-abcdefghijklmnop1234", // OpenAI / Anthropic
+    "ghp_ABCDEFGHIJKLMNOPQRST12", // GitHub token
+    "github_pat_ABCDEFGHIJKLMNOPQRST1234", // GitHub fine-grained PAT
+    "eyJhbGciOi.eyJzdWIiOi.SflKxwRJSM", // JWT
+    "AKIA1234567890ABCDEF", // AWS access key id
+  ];
+  for (const secret of cases) {
+    const out = redactSubprocessSecrets(`error: leaked ${secret} here`);
+    assert.equal(out.includes(secret), false, `did not redact ${secret}`);
+    assert.match(out, /\[redacted\]/);
+  }
+});
+
+test("redactSubprocessSecrets strips known secret VALUES that are long enough, but guards short ones", () => {
+  const long = redactSubprocessSecrets("token=mysupersecretvalue done", ["mysupersecretvalue"]);
+  assert.equal(long.includes("mysupersecretvalue"), false);
+  assert.match(long, /token=\[redacted\] done/);
+
+  // A <8-char "secret" must NOT blank unrelated diagnostic text.
+  const short = redactSubprocessSecrets("the cat sat", ["cat"]);
+  assert.equal(short, "the cat sat");
+});
+
+test("redactSubprocessSecrets leaves clean text untouched, and the pattern family is exported", () => {
+  assert.equal(redactSubprocessSecrets("nothing to see here"), "nothing to see here");
+  assert.equal(SUBPROCESS_SECRET_PATTERNS.length, 5);
+});


### PR DESCRIPTION
Adds a shared subprocess env-allowlist + secret-redaction helper to the engine (Closes #4284).

Generalizes the subscription-CLI pattern in `src/selfhost/ai.ts` into a reusable, engine-hosted helper so future subprocess-spawning drivers depend on one source of truth instead of copy-pasting it.

- **`buildAllowlistedEnv(parent, allowlist, extra)`** — a **parameterized** env-allowlist builder (the allowlist is a caller argument, so a coding-agent subprocess can pass a different/larger list than a review-only CLI call), omitting `undefined` values.
- **`redactSubprocessSecrets(text, knownSecrets)`** — known-value (length-guarded) + token-shape stripping, carrying over the `SECRET_PATTERNS` family **verbatim** (OpenAI/Anthropic keys, GitHub tokens + fine-grained PATs, JWTs, AWS access-key ids) so coverage is ported, not weakened.
- **`SUBSCRIPTION_CLI_ENV_ALLOWLIST`** exported as the ready default for review-only CLI calls.

**Migration decision (deliberate):** `src/selfhost/ai.ts` keeps its own copy for now — this PR makes **no behavioral change** to the hosted review path. This module is the shared source of truth for *new* drivers; refactoring `ai.ts` onto it (the shim pattern `src/rules/predicted-gate.ts` uses over the engine) is deferred to a follow-up to avoid churning the hosted path here. Documented in the module header.

Pure: no IO, no `Date.now()`, no randomness. Re-exported from the engine entrypoint.

## Test
`packages/gittensory-engine/test/subprocess-env.test.ts` — a caller-supplied allowlist is honored (not just the default), `extra` layering, undefined-omission from both sources, the default allowlist's key set, every carried-over token shape redacted, the known-value length guard (long redacted / short left intact), and clean text untouched. Engine suite: 280 pass; `test:engine-parity` green.

- [x] Conventional Commit; focused; **Closes #4284**. No `site/`/`CNAME`/`**/lovable/**`; no `CHANGELOG.md`. New engine module + test + one entrypoint re-export.