### PR TITLE
docs(selfhost): document OLLAMA_KV_CACHE_TYPE and recommend bge-m3

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -298,9 +298,13 @@ REDIS_URL=redis://redis:6379                # REQUIRED for the self-host review 
 #                                            #   Collection and schema are auto-created at startup. Off when unset.
 # QDRANT_API_KEY=                            # Bearer token for an authenticated Qdrant (cloud / on-prem). Omit for
 #                                            #   the local --profile qdrant container (unauthenticated).
-# QDRANT_DIM=768                             # vector dimension of the collection (768 = nomic-embed-text:latest;
-#                                            #   1024 = bge-m3/mxbai-embed-large). Must match AI_EMBED_MODEL;
-#                                            #   recreate the Qdrant collection when changing this after startup.
+# QDRANT_DIM=1024                            # vector dimension of the collection (1024 = bge-m3/mxbai-embed-large,
+#                                            #   the recommended default -- bge-m3's longer native context window
+#                                            #   is a better match for RAG's ~16k-char chunk budget than smaller
+#                                            #   embedders; 768 = nomic-embed-text:latest, a lighter alternative).
+#                                            #   Must match AI_EMBED_MODEL; recreate the Qdrant collection when
+#                                            #   changing this after startup (existing vectors are a fixed width
+#                                            #   and cannot be resized in place).
 # AI_EMBED_BATCH=96                          # items per RAG embed-provider call (#4327). Defaults to 96
 #                                            #   (a conservative bound sized for Workers AI's 100-item cap).
 #                                            #   Tune upward for GPU-accelerated self-host Ollama throughput --
@@ -566,6 +570,20 @@ REDIS_URL=redis://redis:6379                # REQUIRED for the self-host review 
 # OLLAMA_NUM_PARALLEL=2                      # concurrent requests per loaded model
 # OLLAMA_MAX_LOADED_MODELS=2                 # distinct models kept resident at once
 # OLLAMA_KEEP_ALIVE=30m                      # how long an idle model stays loaded before eviction
+# OLLAMA_FLASH_ATTENTION=1                   # usually auto-enabled already on supported GPUs (check the ollama
+#                                            #   container's boot log for "Flash Attention was auto, set to
+#                                            #   enabled" to confirm) -- set explicitly anyway, because it is
+#                                            #   REQUIRED alongside OLLAMA_KV_CACHE_TYPE below for KV-cache
+#                                            #   quantization to actually take effect; setting KV_CACHE_TYPE
+#                                            #   alone without this does nothing.
+# OLLAMA_KV_CACHE_TYPE=q8_0                  # f16 (default) | q8_0 | q4_0. q8_0 roughly HALVES per-context KV-
+#                                            #   cache VRAM (confirmed on an RTX A5000: 4608 MiB at f16 -> 2448
+#                                            #   MiB at q8_0 for one loaded context) with published perplexity
+#                                            #   impact of 0.002-0.05 -- undetectable in practice. Frees real
+#                                            #   headroom for more concurrent models or larger contexts on a
+#                                            #   VRAM-constrained GPU. q4_0 quarters it further at more
+#                                            #   noticeable quality cost; q8_0 is the recommended default for
+#                                            #   self-host GPU deployments.
 #
 # Generic OpenAI-compatible reviewer (AI_PROVIDER=openai-compatible). Defaults:
 # OPENAI_COMPATIBLE_AI_BASE_URL=http://localhost:11434/v1, OPENAI_COMPATIBLE_AI_MODEL=llama3.1.
@@ -600,9 +618,9 @@ REDIS_URL=redis://redis:6379                # REQUIRED for the self-host review 
 # CODEX_AI_EFFORT=medium                     # low | medium | high | xhigh. `max` is accepted and maps to xhigh.
 # CODEX_AI_TIMEOUT_MS=                       # override CLI timeout in ms; unset scales by effort (low/medium 120s, high 240s, xhigh 360s)
 #                                            # Codex service speed is standard by default. No fast/priority tier is requested by this stack.
-# AI_EMBED_MODEL=nomic-embed-text:latest     # embedding model for RAG (openai-compatible /embeddings). Its output
-#                                            #   dimension must match QDRANT_DIM. Used only when RAG is enabled
-#                                            #   (GITTENSORY_REVIEW_RAG + allowlist).
+# AI_EMBED_MODEL=bge-m3:latest               # embedding model for RAG (openai-compatible /embeddings). Its output
+#                                            #   dimension must match QDRANT_DIM (1024 for bge-m3). Used only when
+#                                            #   RAG is enabled (GITTENSORY_REVIEW_RAG + allowlist).
 # AI_EMBED_BASE_URL=                         # route embeddings to a SEPARATE openai-compatible endpoint instead
 #                                            #   of the review chain's own AI provider — e.g. a dedicated local
 #                                            #   Ollama for embeddings while Claude/Codex handle review. Unset =


### PR DESCRIPTION
## Summary
- Documents `OLLAMA_FLASH_ATTENTION` + `OLLAMA_KV_CACHE_TYPE` in `.env.example` — an existing Ollama runtime capability that was never surfaced to self-host operators. `q8_0` roughly halves per-context KV-cache VRAM with negligible quality impact; validated live (4608 MiB at f16 -> 2448 MiB at q8_0 for one loaded context, same generation speed, correct structured-output quality on a real request).
- Updates the `AI_EMBED_MODEL`/`QDRANT_DIM` example to recommend bge-m3 (1024-d) over nomic-embed-text (768-d) — bge-m3 already matches the code's own `DEFAULT_DIM` assumption (see `src/selfhost/qdrant-vectorize.ts`), its longer native context window is a better fit for RAG's ~16k-char chunk budget, and it's now the validated production choice.

Documentation-only change; no code paths affected.

## Scope
- [x] Stayed within `wantedPaths` (repo-root `.env.example`)
- [x] No secrets/wallets/trust-score/reward values anywhere
- [x] No changes to `site/`, `CNAME`, `**/lovable/**`, or `CHANGELOG.md`

## Validation
- [x] `npm run selfhost:env-reference:check` — clean (no `env.*` source reads changed, comment-only edit)
- [x] `git diff --check` — clean

## Safety
- [x] No secrets/tokens anywhere