### PR TITLE
fix(review): refresh capped RAG files on full reindex

### DIFF
--- a/src/review/rag-index.ts
+++ b/src/review/rag-index.ts
@@ -315,14 +315,14 @@ export async function indexRepo(
     let skipped = 0;
     let capped = false;
     for (const entry of tree) {
-      if (stored >= MAX_CHUNKS_PER_REPO) {
-        capped = true;
-        break;
-      }
       const known = knownChunks.get(entry.path);
       if (entry.sha && known?.blobSha && known.blobSha === entry.sha) {
         skipped += 1;
         continue; // unchanged since the last full index — skip the fetch/chunk/embed entirely
+      }
+      if (stored >= MAX_CHUNKS_PER_REPO && (!known || known.count <= 0)) {
+        capped = true;
+        break;
       }
       const text = await fetchFileText(env, repoFullName, entry.path, ref, token, admissionKey);
       if (text === null) continue;

--- a/test/unit/rag-index.test.ts
+++ b/test/unit/rag-index.test.ts
@@ -426,6 +426,44 @@ describe("indexRepo: embedding cache (#4365) — skip unchanged files by git blo
     expect(result.files).toBe(1); // only one of the two new files fit under the cap
     expect(await countChunks(env, PROJECT, "gittensory")).toBe(MAX_CHUNKS_PER_REPO); // never exceeds the cap
   });
+
+  it("refreshes changed files in a full reindex even when the repository is already capped", async () => {
+    const { env, ai } = indexEnv();
+    const ns = ragNamespace(PROJECT, "gittensory");
+    await env.DB.batch(
+      Array.from({ length: MAX_CHUNKS_PER_REPO }, (_, i) => {
+        const path = i === 0 ? "src/changed.ts" : `src/existing${i}.ts`;
+        return env.DB.prepare("INSERT INTO repo_chunks (id, project, repo, path, chunk_index, kind, text, blob_sha) VALUES (?,?,?,?,?,?,?,?)").bind(
+          `${ns}|${path}::0`,
+          PROJECT,
+          "gittensory",
+          path,
+          0,
+          "code",
+          i === 0 ? "old changed file" : "old",
+          i === 0 ? "sha-old" : `sha-existing-${i}`,
+        );
+      }),
+    );
+    stubGithub({
+      tree: [
+        { path: "src/changed.ts", size: 30, sha: "sha-new" },
+        ...Array.from({ length: MAX_CHUNKS_PER_REPO - 1 }, (_, i) => ({ path: `src/existing${i + 1}.ts`, size: 10, sha: `sha-existing-${i + 1}` })),
+        { path: "src/new.ts", size: 10, sha: "sha-new-file" },
+      ],
+      files: { "src/changed.ts": "export const changed = true;\n", "src/new.ts": "export const n = 1;\n" },
+    });
+
+    const result = await indexRepo(env, PROJECT, REPO);
+
+    expect(result).toMatchObject({ indexed: 1, files: 1, capped: true });
+    expect(ai.run).toHaveBeenCalledTimes(1);
+    expect(await countChunks(env, PROJECT, "gittensory")).toBe(MAX_CHUNKS_PER_REPO);
+    const row = await env.DB.prepare("SELECT text, blob_sha FROM repo_chunks WHERE project=? AND repo=? AND path=?")
+      .bind(PROJECT, "gittensory", "src/changed.ts")
+      .first<{ text: string; blob_sha: string }>();
+    expect(row).toEqual({ text: "export const changed = true;\n", blob_sha: "sha-new" });
+  });
 });
 
 describe("indexRepo: MAX_CHUNKS_PER_REPO cap holds", () => {


### PR DESCRIPTION
### Motivation
- A full-RAG reindex could treat a repository already at `MAX_CHUNKS_PER_REPO` as fully done before inspecting per-path metadata, which prevented changed files from being deleted/replaced and left stale chunks in capped repos.

### Description
- Change `src/review/rag-index.ts` so the per-repo cap is checked only after consulting the stored per-path metadata and the unchanged-blob (`blobSha`) shortcut; the loop now allows processing a path if it has known stored chunks to delete and replace while still stopping for unknown/new paths once the cap is reached.
- The new logic checks `if (stored >= MAX_CHUNKS_PER_REPO && (!known || known.count <= 0))` to preserve the cap for genuinely new content but permit refreshes of existing paths.
- Add a regression unit test in `test/unit/rag-index.test.ts` that seeds a repo already at the cap, marks one path as changed (new `blob_sha`) and asserts that the changed file is re-embedded and the repo remains capped overall.

### Testing
- Ran the targeted test: `npx vitest run test/unit/rag-index.test.ts -t "refreshes changed files"`, and it passed (regression reproduced and fixed).
- Ran the full `test/unit/rag-index.test.ts`; the targeted regression and related index tests passed, but three existing cron fan-out tests in that file timed out (15s timeout) and are unrelated to the cap change.
- Verified repository-style checks locally (format/linters for the edited files) and no changed-line/style errors were produced.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f626fd8b8832c926c812ad8ff3dd7)