### PR TITLE
test(engine): expand engine-parity golden fixtures for untested gate modes

### DIFF
--- a/test/fixtures/engine-parity/predicted-gate/ai-review-gate-mode-inert.ts
+++ b/test/fixtures/engine-parity/predicted-gate/ai-review-gate-mode-inert.ts
@@ -1,0 +1,22 @@
+import { BASE_INPUT, BASE_REPO, definePredictedGateFixture, openIssue, parseManifest } from "./_shared";
+
+// aiReviewGateMode branch: the AI-review sub-gate acts on an AI-reviewer finding, which is produced only by the
+// live dual-model review, never by this metadata-only predictor. So aiReviewMode=block leaves the predicted
+// verdict byte-identical to a clean pass. This fixture locks in that inertness (cf. manifest-blocked-path).
+export default definePredictedGateFixture({
+  id: "ai-review-gate-mode-inert",
+  title: "aiReviewMode is inert in the metadata-only predictor",
+  branch: "aiReviewGateMode=block with no AI finding available pre-merge stays a clean pass",
+  input: BASE_INPUT,
+  manifest: parseManifest({ gate: { aiReviewMode: "block" } }),
+  repo: BASE_REPO,
+  issues: [openIssue(7, "Uploads should retry on 5xx")],
+  pullRequests: [],
+  expected: {
+    conclusion: "success",
+    pack: "gittensor",
+    blockerCodes: [],
+    warningCodes: [],
+    funnelPresent: false,
+  },
+});

--- a/test/fixtures/engine-parity/predicted-gate/cla-gate-mode-inert.ts
+++ b/test/fixtures/engine-parity/predicted-gate/cla-gate-mode-inert.ts
@@ -1,0 +1,23 @@
+import { BASE_INPUT, BASE_REPO, definePredictedGateFixture, openIssue, parseManifest } from "./_shared";
+
+// claGateMode branch: the CLA sub-gate only acts on a CLA finding, which is produced from live PR-thread
+// signals the metadata-only predictor never has. So opting into claMode=block leaves the predicted verdict
+// byte-identical to a clean pass. This fixture locks in that inertness (cf. manifest-blocked-path), so a future
+// change that lets claMode act pre-merge is caught by the parity suite.
+export default definePredictedGateFixture({
+  id: "cla-gate-mode-inert",
+  title: "claMode is inert in the metadata-only predictor",
+  branch: "claGateMode=block with no CLA finding available pre-merge stays a clean pass",
+  input: BASE_INPUT,
+  manifest: parseManifest({ gate: { claMode: "block" } }),
+  repo: BASE_REPO,
+  issues: [openIssue(7, "Uploads should retry on 5xx")],
+  pullRequests: [],
+  expected: {
+    conclusion: "success",
+    pack: "gittensor",
+    blockerCodes: [],
+    warningCodes: [],
+    funnelPresent: false,
+  },
+});

--- a/test/fixtures/engine-parity/predicted-gate/first-time-grace-inert.ts
+++ b/test/fixtures/engine-parity/predicted-gate/first-time-grace-inert.ts
@@ -1,0 +1,22 @@
+import { BASE_INPUT, BASE_REPO, definePredictedGateFixture, openIssue, parseManifest } from "./_shared";
+
+// firstTimeContributorGrace branch: grace is threaded as compatibility context but is deliberately no longer
+// read by the gate evaluator (blocker findings are not softened by it). So enabling it leaves the predicted
+// verdict byte-identical to a clean pass. This fixture locks in that no-op so a future re-activation is caught.
+export default definePredictedGateFixture({
+  id: "first-time-grace-inert",
+  title: "firstTimeContributorGrace does not change the predicted verdict",
+  branch: "gate.firstTimeContributorGrace=true is compatibility context only and softens nothing",
+  input: BASE_INPUT,
+  manifest: parseManifest({ gate: { firstTimeContributorGrace: true } }),
+  repo: BASE_REPO,
+  issues: [openIssue(7, "Uploads should retry on 5xx")],
+  pullRequests: [],
+  expected: {
+    conclusion: "success",
+    pack: "gittensor",
+    blockerCodes: [],
+    warningCodes: [],
+    funnelPresent: false,
+  },
+});

--- a/test/fixtures/engine-parity/predicted-gate/golden/ai-review-gate-mode-inert.json
+++ b/test/fixtures/engine-parity/predicted-gate/golden/ai-review-gate-mode-inert.json
@@ -1,0 +1,13 @@
+{
+  "predicted": true,
+  "basis": "public_config",
+  "pack": "gittensor",
+  "conclusion": "success",
+  "title": "Gittensory Orb Review Agent passed",
+  "summary": "No configured hard blocker was found. Advisory findings, if any, stay advisory.",
+  "readinessScore": 95,
+  "blockers": [],
+  "warnings": [],
+  "funnel": null,
+  "note": "Predicted from the repo's public .gittensory.yml gate config + safe defaults. The maintainer may have private dashboard overrides not reflected here, and the dual-model AI-consensus blocker is only evaluated on a real PR. The slop score is NOT evaluated pre-submission (it needs the diff content) and may still fail the real gate. Provide the PR's changed paths to also predict the focus-manifest path policy, the size/guardrail hold, and any pre-merge check scoped to changed paths; without them only path-independent title/description/label pre-merge checks are predicted. Every author is gated the same: a configured hard blocker fails the gate regardless of confirmed-contributor status (which affects only on-chain scoring)."
+}

--- a/test/fixtures/engine-parity/predicted-gate/golden/cla-gate-mode-inert.json
+++ b/test/fixtures/engine-parity/predicted-gate/golden/cla-gate-mode-inert.json
@@ -1,0 +1,13 @@
+{
+  "predicted": true,
+  "basis": "public_config",
+  "pack": "gittensor",
+  "conclusion": "success",
+  "title": "Gittensory Orb Review Agent passed",
+  "summary": "No configured hard blocker was found. Advisory findings, if any, stay advisory.",
+  "readinessScore": 95,
+  "blockers": [],
+  "warnings": [],
+  "funnel": null,
+  "note": "Predicted from the repo's public .gittensory.yml gate config + safe defaults. The maintainer may have private dashboard overrides not reflected here, and the dual-model AI-consensus blocker is only evaluated on a real PR. The slop score is NOT evaluated pre-submission (it needs the diff content) and may still fail the real gate. Provide the PR's changed paths to also predict the focus-manifest path policy, the size/guardrail hold, and any pre-merge check scoped to changed paths; without them only path-independent title/description/label pre-merge checks are predicted. Every author is gated the same: a configured hard blocker fails the gate regardless of confirmed-contributor status (which affects only on-chain scoring)."
+}

--- a/test/fixtures/engine-parity/predicted-gate/golden/first-time-grace-inert.json
+++ b/test/fixtures/engine-parity/predicted-gate/golden/first-time-grace-inert.json
@@ -1,0 +1,13 @@
+{
+  "predicted": true,
+  "basis": "public_config",
+  "pack": "gittensor",
+  "conclusion": "success",
+  "title": "Gittensory Orb Review Agent passed",
+  "summary": "No configured hard blocker was found. Advisory findings, if any, stay advisory.",
+  "readinessScore": 95,
+  "blockers": [],
+  "warnings": [],
+  "funnel": null,
+  "note": "Predicted from the repo's public .gittensory.yml gate config + safe defaults. The maintainer may have private dashboard overrides not reflected here, and the dual-model AI-consensus blocker is only evaluated on a real PR. The slop score is NOT evaluated pre-submission (it needs the diff content) and may still fail the real gate. Provide the PR's changed paths to also predict the focus-manifest path policy, the size/guardrail hold, and any pre-merge check scoped to changed paths; without them only path-independent title/description/label pre-merge checks are predicted. Every author is gated the same: a configured hard blocker fails the gate regardless of confirmed-contributor status (which affects only on-chain scoring)."
+}

--- a/test/fixtures/engine-parity/predicted-gate/golden/guardrail-hold.json
+++ b/test/fixtures/engine-parity/predicted-gate/golden/guardrail-hold.json
@@ -1,0 +1,20 @@
+{
+  "predicted": true,
+  "basis": "public_config",
+  "pack": "gittensor",
+  "conclusion": "neutral",
+  "title": "Gittensory Orb Review Agent — held for manual review",
+  "summary": "Touches a guarded path — held for manual review",
+  "readinessScore": 95,
+  "blockers": [],
+  "warnings": [
+    {
+      "code": "guardrail_hold",
+      "title": "Touches a guarded path — held for manual review",
+      "detail": "This PR changes guardrail-protected path(s): `migrations/0001_add_retry_column.sql` (matched `migrations/**`).",
+      "action": "A maintainer must review and merge this change."
+    }
+  ],
+  "funnel": null,
+  "note": "Predicted from the repo's public .gittensory.yml gate config + safe defaults. The maintainer may have private dashboard overrides not reflected here, and the dual-model AI-consensus blocker is only evaluated on a real PR. The slop score is NOT evaluated pre-submission (it needs the diff content) and may still fail the real gate. The size-hold prediction uses changed FILE count only, not changed LINE count (line-diff stats are not available pre-submission), so it may under-predict a hold for a PR with many changed lines across few files. Every author is gated the same: a configured hard blocker fails the gate regardless of confirmed-contributor status (which affects only on-chain scoring)."
+}

--- a/test/fixtures/engine-parity/predicted-gate/golden/merge-readiness-composite-block.json
+++ b/test/fixtures/engine-parity/predicted-gate/golden/merge-readiness-composite-block.json
@@ -1,0 +1,20 @@
+{
+  "predicted": true,
+  "basis": "public_config",
+  "pack": "gittensor",
+  "conclusion": "failure",
+  "title": "Gittensory Orb Review Agent: No linked issue detected",
+  "summary": "No linked issue detected — If this PR is intended to solve an issue, link it explicitly in the PR body.",
+  "readinessScore": 80,
+  "blockers": [
+    {
+      "code": "missing_linked_issue",
+      "title": "No linked issue detected",
+      "detail": "No closing reference or linked issue number was found in the PR metadata/body.",
+      "action": "If this PR is intended to solve an issue, link it explicitly in the PR body."
+    }
+  ],
+  "warnings": [],
+  "funnel": null,
+  "note": "Predicted from the repo's public .gittensory.yml gate config + safe defaults. The maintainer may have private dashboard overrides not reflected here, and the dual-model AI-consensus blocker is only evaluated on a real PR. The slop score is NOT evaluated pre-submission (it needs the diff content) and may still fail the real gate. Provide the PR's changed paths to also predict the focus-manifest path policy, the size/guardrail hold, and any pre-merge check scoped to changed paths; without them only path-independent title/description/label pre-merge checks are predicted. Every author is gated the same: a configured hard blocker fails the gate regardless of confirmed-contributor status (which affects only on-chain scoring)."
+}

--- a/test/fixtures/engine-parity/predicted-gate/golden/self-authored-linked-issue-block.json
+++ b/test/fixtures/engine-parity/predicted-gate/golden/self-authored-linked-issue-block.json
@@ -1,0 +1,20 @@
+{
+  "predicted": true,
+  "basis": "public_config",
+  "pack": "gittensor",
+  "conclusion": "failure",
+  "title": "Gittensory Orb Review Agent: PR author also opened the linked issue",
+  "summary": "PR author also opened the linked issue — Link an issue that was opened by a different contributor, or provide a rationale for why this self-authored issue represents genuine discovery work.",
+  "readinessScore": 95,
+  "blockers": [
+    {
+      "code": "self_authored_linked_issue",
+      "title": "PR author also opened the linked issue",
+      "detail": "The contributor who opened this PR also filed the linked issue. This pattern can indicate artificial issue-discovery work rather than solving an independently discovered problem.",
+      "action": "Link an issue that was opened by a different contributor, or provide a rationale for why this self-authored issue represents genuine discovery work."
+    }
+  ],
+  "warnings": [],
+  "funnel": null,
+  "note": "Predicted from the repo's public .gittensory.yml gate config + safe defaults. The maintainer may have private dashboard overrides not reflected here, and the dual-model AI-consensus blocker is only evaluated on a real PR. The slop score is NOT evaluated pre-submission (it needs the diff content) and may still fail the real gate. Provide the PR's changed paths to also predict the focus-manifest path policy, the size/guardrail hold, and any pre-merge check scoped to changed paths; without them only path-independent title/description/label pre-merge checks are predicted. Every author is gated the same: a configured hard blocker fails the gate regardless of confirmed-contributor status (which affects only on-chain scoring)."
+}

--- a/test/fixtures/engine-parity/predicted-gate/guardrail-hold.ts
+++ b/test/fixtures/engine-parity/predicted-gate/guardrail-hold.ts
@@ -1,0 +1,22 @@
+import { BASE_INPUT, BASE_REPO, definePredictedGateFixture, openIssue, parseManifest } from "./_shared";
+
+// guardrailHit branch: a changed path matches a settings.hardGuardrailGlobs pattern, so the predictor previews
+// the manual-review guardrail HOLD (neutral verdict), the way the live gate holds guarded-path changes.
+export default definePredictedGateFixture({
+  id: "guardrail-hold",
+  title: "Guarded-path change previews a manual-review hold",
+  branch: "guardrail_hold when settings.hardGuardrailGlobs matches a changed path",
+  input: BASE_INPUT,
+  manifest: parseManifest({ settings: { hardGuardrailGlobs: ["migrations/**"] } }),
+  repo: BASE_REPO,
+  issues: [openIssue(7, "Uploads should retry on 5xx")],
+  pullRequests: [],
+  changedPaths: ["migrations/0001_add_retry_column.sql"],
+  expected: {
+    conclusion: "neutral",
+    pack: "gittensor",
+    blockerCodes: [],
+    warningCodes: ["guardrail_hold"],
+    funnelPresent: false,
+  },
+});

--- a/test/fixtures/engine-parity/predicted-gate/index.ts
+++ b/test/fixtures/engine-parity/predicted-gate/index.ts
@@ -1,5 +1,11 @@
+import aiReviewGateModeInert from "./ai-review-gate-mode-inert";
+import claGateModeInert from "./cla-gate-mode-inert";
 import cleanPassGittensor from "./clean-pass-gittensor";
 import cleanPassOssAntiSlop from "./clean-pass-oss-anti-slop";
+import firstTimeGraceInert from "./first-time-grace-inert";
+import guardrailHold from "./guardrail-hold";
+import mergeReadinessCompositeBlock from "./merge-readiness-composite-block";
+import selfAuthoredLinkedIssueBlock from "./self-authored-linked-issue-block";
 import duplicatePrBlock from "./duplicate-pr-block";
 import manifestBlockedPath from "./manifest-blocked-path";
 import missingLinkedIssueBlock from "./missing-linked-issue-block";
@@ -18,4 +24,10 @@ export const predictedGateFixtures = [
   readinessWarning,
   pathGatedCheckWithPaths,
   pathGatedCheckWithoutPaths,
+  selfAuthoredLinkedIssueBlock,
+  guardrailHold,
+  mergeReadinessCompositeBlock,
+  claGateModeInert,
+  aiReviewGateModeInert,
+  firstTimeGraceInert,
 ];

--- a/test/fixtures/engine-parity/predicted-gate/merge-readiness-composite-block.ts
+++ b/test/fixtures/engine-parity/predicted-gate/merge-readiness-composite-block.ts
@@ -1,0 +1,21 @@
+import { BASE_INPUT, BASE_REPO, definePredictedGateFixture, parseManifest } from "./_shared";
+
+// mergeReadinessGateMode branch: the composite merge-readiness mode drives the linked-issue / duplicate / slop
+// sub-gates at once. With it set to block and no linked issue, the missing-linked-issue sub-gate becomes blocking.
+export default definePredictedGateFixture({
+  id: "merge-readiness-composite-block",
+  title: "Composite merge-readiness mode blocks a missing linked issue",
+  branch: "missing_linked_issue promoted to blocking when gate.mergeReadiness=block and no issue is linked",
+  input: { ...BASE_INPUT, body: "No linked issue yet", linkedIssues: [] },
+  manifest: parseManifest({ gate: { mergeReadiness: "block" } }),
+  repo: BASE_REPO,
+  issues: [],
+  pullRequests: [],
+  expected: {
+    conclusion: "failure",
+    pack: "gittensor",
+    blockerCodes: ["missing_linked_issue"],
+    warningCodes: [],
+    funnelPresent: false,
+  },
+});

--- a/test/fixtures/engine-parity/predicted-gate/self-authored-linked-issue-block.ts
+++ b/test/fixtures/engine-parity/predicted-gate/self-authored-linked-issue-block.ts
@@ -1,0 +1,21 @@
+import { BASE_INPUT, BASE_REPO, definePredictedGateFixture, openIssue, parseManifest } from "./_shared";
+
+// selfAuthoredLinkedIssue branch: the linked issue #7 is authored by the same login opening the PR, and the
+// repo opts into blocking self-authored linked issues. Advisory by default, so this only blocks on opt-in.
+export default definePredictedGateFixture({
+  id: "self-authored-linked-issue-block",
+  title: "Self-authored linked issue blocks on opt-in",
+  branch: "self_authored_linked_issue when gate.selfAuthoredLinkedIssue=block and issue #7 authorLogin equals the contributor",
+  input: BASE_INPUT,
+  manifest: parseManifest({ gate: { selfAuthoredLinkedIssue: "block" } }),
+  repo: BASE_REPO,
+  issues: [openIssue(7, "Uploads should retry on 5xx", "miner1")],
+  pullRequests: [],
+  expected: {
+    conclusion: "failure",
+    pack: "gittensor",
+    blockerCodes: ["self_authored_linked_issue"],
+    warningCodes: [],
+    funnelPresent: false,
+  },
+});


### PR DESCRIPTION
## What

The predicted-gate engine-parity suite (#2286) had 8 golden fixtures covering roughly half of `evaluateGateCheck`'s gate-mode surface. Per #4255, this adds one fixture per previously-untested gate mode, all generated through the existing `record-engine-parity-goldens.ts` tooling and wired into the existing fixture-iteration loop (no test-file logic changes — only new fixture files + the index).

**Three modes exercised with a distinct verdict:**
- `selfAuthoredLinkedIssueGateMode` -> `self_authored_linked_issue` blocker when the linked issue is authored by the contributor and the repo opts into blocking.
- `guardrailHit` (the `sizeGateMode`/`guardrailHit` pair) -> `guardrail_hold` neutral when a changed path matches `settings.hardGuardrailGlobs`.
- `mergeReadinessGateMode` -> the composite mode promotes the missing linked-issue sub-gate to blocking.

**Three modes are inert in the metadata-only predictor**, and the fixtures lock that in — mirroring the existing `manifest-blocked-path` fixture that documents an inert mode — so a future change that lets them act pre-merge is caught by the parity suite:
- `claGateMode`: the CLA sub-gate needs a CLA finding this predictor never has pre-merge.
- `aiReviewGateMode`: the AI sub-gate needs a live dual-model finding.
- `firstTimeContributorGrace`: threaded as compatibility context but no longer read by the evaluator.

## Deliverables

- [x] One golden fixture per currently-untested gate mode (6 new fixtures)
- [x] Generated via the existing `record-engine-parity-goldens.ts` tooling, same fixture format as the current 8
- [x] Wired into `test/contract/engine-parity.test.ts`'s existing fixture-iteration loop (no test-file logic changes, only new fixture files + index)
- [x] `npm run test:engine-parity` passes with the expanded set

## Validation

- `npm run test:engine-parity` (15 tests, 14 fixtures)
- `npx vitest run test/unit/engine-parity-fixtures.test.ts test/contract/engine-parity.test.ts` (30 tests)
- `npm run test --workspace @jsonbored/gittensory-engine` (277 tests)
- `npm run typecheck` (0 errors)
- Test-only change; no source files touched.

Closes #4255