### PR TITLE
fix(review): compose additive linked-issue label matches with the exclusive winner

### DIFF
--- a/.gittensory.yml
+++ b/.gittensory.yml
@@ -71,7 +71,11 @@ review:
 # fallback already has zero equivalent verification) so they propagate even when the PR author isn't a
 # formal GitHub assignee of the issue — our issues are almost always maintainer-authored for open pickup and
 # rarely formally assigned. priority intentionally omits the flag: it is the scarce, maintainer-hand-picked
-# reward label, and must still require the PR author to be the issue's actual author/assignee.
+# reward label, and must still require the PR author to be the issue's actual author/assignee. priority is
+# also `removeOtherTypeLabels: false` (additive) -- unlike bug/feature, which are mutually-exclusive TYPE
+# categories, priority is a separate reward dimension that coexists WITH whichever type already applies (an
+# issue is routinely both gittensor:feature AND gittensor:priority at once); resolvePrTypeLabel composes every
+# additive match alongside the one exclusive winner, rather than the two categories competing for a single slot.
 #
 # Review-evasion protection: closing or converting-to-draft your OWN PR while gittensory has an active
 # review pass running, a prior recorded gate failure, or a repeated ready<->draft cycle on this PR, is
@@ -92,7 +96,7 @@ settings:
         trustMaintainerAuthoredIssue: true
       - issueLabel: "gittensor:priority"
         prLabel: "gittensor:priority"
-        removeOtherTypeLabels: true
+        removeOtherTypeLabels: false
   reviewEvasionProtection: close
 
 # Repo-doc generation roadmap (#2993/#3002) — opt-in only, off by default. Uncomment to let Gittensory open a

--- a/.gittensory.yml.example
+++ b/.gittensory.yml.example
@@ -603,22 +603,24 @@ settings:
   # label like `gittensor:priority` -- it is NEVER inferred from a PR's title, changed files, AI
   # output, or existing PR labels, only ever copied from a linked/closing issue ("Fixes #123") that
   # ALREADY carries the configured issue label. Generic beyond the priority use case: any issue label
-  # can map to any PR label. `removeOtherTypeLabels: true` REPLACES the type label entirely (bug/
-  # feature are removed), matching how `gittensor:priority` behaves today; `false` applies the mapped
-  # label ADDITIVELY alongside the normal title-based bug/feature label, leaving it untouched -- useful
-  # for a mapping unrelated to the bug/feature/priority triad (e.g. a `customer:vip` issue label
-  # copied to a `triage:vip` PR label). Disabled by default (no mappings) -- a self-hoster opts in per
-  # repo. If your labels carry reward or moderation weight, configure this in PRIVATE per-repo/global
-  # config (see `config/examples/README.md`) rather than the public `.gittensory.yml`, so contributors
-  # cannot see the exact mapping rules. A per-repo `mappings` override in the private-config layer
-  # REPLACES the global default list wholesale -- it does not merge with it.
+  # can map to any PR label. `removeOtherTypeLabels: true` marks the mapping EXCLUSIVE -- it REPLACES
+  # the type label entirely (bug/feature are removed), for genuinely mutually-exclusive categories; only
+  # the FIRST-configured exclusive match wins when more than one applies. `false` (e.g. `gittensor:priority`,
+  # which is a reward tag that coexists WITH whichever type already applies, not a type of its own) applies
+  # the mapped label ADDITIVELY alongside whichever exclusive match (or the normal title-based bug/feature
+  # label) already won -- every additive match composes together rather than competing for a single slot.
+  # Disabled by default (no mappings) -- a self-hoster opts in per repo. If your labels carry reward or
+  # moderation weight, configure this in PRIVATE per-repo/global config (see `config/examples/README.md`)
+  # rather than the public `.gittensory.yml`, so contributors cannot see the exact mapping rules. A per-repo
+  # `mappings` override in the private-config layer REPLACES the global default list wholesale -- it does
+  # not merge with it.
   # linkedIssueLabelPropagation:
   #   enabled: true
   #   mode: exclusive_type_label
   #   mappings:
   #     - issueLabel: gittensor:priority
   #       prLabel: gittensor:priority
-  #       removeOtherTypeLabels: true
+  #       removeOtherTypeLabels: false
 
   # Create the label if it does not yet exist. Bool. Default: true.
   createMissingLabel: true

--- a/config/examples/gittensory.full.yml
+++ b/config/examples/gittensory.full.yml
@@ -616,22 +616,24 @@ settings:
   # label like `gittensor:priority` -- it is NEVER inferred from a PR's title, changed files, AI
   # output, or existing PR labels, only ever copied from a linked/closing issue ("Fixes #123") that
   # ALREADY carries the configured issue label. Generic beyond the priority use case: any issue label
-  # can map to any PR label. `removeOtherTypeLabels: true` REPLACES the type label entirely (bug/
-  # feature are removed), matching how `gittensor:priority` behaves today; `false` applies the mapped
-  # label ADDITIVELY alongside the normal title-based bug/feature label, leaving it untouched -- useful
-  # for a mapping unrelated to the bug/feature/priority triad (e.g. a `customer:vip` issue label
-  # copied to a `triage:vip` PR label). Disabled by default (no mappings) -- a self-hoster opts in per
-  # repo. If your labels carry reward or moderation weight, configure this in PRIVATE per-repo/global
-  # config (see `config/examples/README.md`) rather than the public `.gittensory.yml`, so contributors
-  # cannot see the exact mapping rules. A per-repo `mappings` override in the private-config layer
-  # REPLACES the global default list wholesale -- it does not merge with it.
+  # can map to any PR label. `removeOtherTypeLabels: true` marks the mapping EXCLUSIVE -- it REPLACES
+  # the type label entirely (bug/feature are removed), for genuinely mutually-exclusive categories; only
+  # the FIRST-configured exclusive match wins when more than one applies. `false` (e.g. `gittensor:priority`,
+  # which is a reward tag that coexists WITH whichever type already applies, not a type of its own) applies
+  # the mapped label ADDITIVELY alongside whichever exclusive match (or the normal title-based bug/feature
+  # label) already won -- every additive match composes together rather than competing for a single slot.
+  # Disabled by default (no mappings) -- a self-hoster opts in per repo. If your labels carry reward or
+  # moderation weight, configure this in PRIVATE per-repo/global config (see `config/examples/README.md`)
+  # rather than the public `.gittensory.yml`, so contributors cannot see the exact mapping rules. A per-repo
+  # `mappings` override in the private-config layer REPLACES the global default list wholesale -- it does
+  # not merge with it.
   # linkedIssueLabelPropagation:
   #   enabled: true
   #   mode: exclusive_type_label
   #   mappings:
   #     - issueLabel: gittensor:priority
   #       prLabel: gittensor:priority
-  #       removeOtherTypeLabels: true
+  #       removeOtherTypeLabels: false
 
   # Create the label if it does not yet exist. Bool. Default: true.
   createMissingLabel: true

--- a/src/config/gittensory-repo-focus-manifest.ts
+++ b/src/config/gittensory-repo-focus-manifest.ts
@@ -75,7 +75,11 @@ review:
 # fallback already has zero equivalent verification) so they propagate even when the PR author isn't a
 # formal GitHub assignee of the issue — our issues are almost always maintainer-authored for open pickup and
 # rarely formally assigned. priority intentionally omits the flag: it is the scarce, maintainer-hand-picked
-# reward label, and must still require the PR author to be the issue's actual author/assignee.
+# reward label, and must still require the PR author to be the issue's actual author/assignee. priority is
+# also \`removeOtherTypeLabels: false\` (additive) -- unlike bug/feature, which are mutually-exclusive TYPE
+# categories, priority is a separate reward dimension that coexists WITH whichever type already applies (an
+# issue is routinely both gittensor:feature AND gittensor:priority at once); resolvePrTypeLabel composes every
+# additive match alongside the one exclusive winner, rather than the two categories competing for a single slot.
 #
 # Review-evasion protection: closing or converting-to-draft your OWN PR while gittensory has an active
 # review pass running, a prior recorded gate failure, or a repeated ready<->draft cycle on this PR, is
@@ -96,7 +100,7 @@ settings:
         trustMaintainerAuthoredIssue: true
       - issueLabel: "gittensor:priority"
         prLabel: "gittensor:priority"
-        removeOtherTypeLabels: true
+        removeOtherTypeLabels: false
   reviewEvasionProtection: close
 
 # Repo-doc generation roadmap (#2993/#3002) — opt-in only, off by default. Uncomment to let Gittensory open a

--- a/src/settings/pr-type-label.ts
+++ b/src/settings/pr-type-label.ts
@@ -14,7 +14,7 @@
 // moves away from it. Public + neutral categorization (NOT the reputation signal). Review-time +
 // independent of the gate / autonomy / dry-run (matches reviewbot, where auto-label runs at review
 // start). Fail-safe.
-import type { LinkedIssueLabelPropagationConfig, PrTypeLabelSet } from "../types";
+import type { LinkedIssueLabelPropagationConfig, LinkedIssueLabelPropagationMapping, PrTypeLabelSet } from "../types";
 
 export type { PrTypeLabelSet } from "../types";
 
@@ -156,9 +156,25 @@ export function resolvePrTypeLabel(input: {
 
   if (input.propagation?.enabled) {
     const wanted = new Set((input.linkedIssueLabels ?? []).map((label) => label.toLowerCase()));
+    // Collect EVERY mapping the linked issue's labels satisfy, not just the first. An exclusive mapping
+    // (removeOtherTypeLabels: true -- e.g. bug/feature, genuinely mutually-exclusive categories) still only
+    // ever lets the FIRST-configured match win, same precedence as before. But an additive mapping (e.g.
+    // priority -- a maintainer-hand-picked reward tag that coexists WITH whichever type already applies, not a
+    // type of its own) must compose with that winner instead of being skipped just because an earlier mapping
+    // in the array already matched and returned. Before this, an additive match was unreachable whenever the
+    // SAME linked issue also carried a label an earlier (exclusive) mapping matched -- the overwhelmingly common
+    // case for gittensor:priority, which is applied ALONGSIDE gittensor:bug/gittensor:feature on the issue, never
+    // instead of it (#priority-linked-issue-gate).
+    let exclusiveMatch: LinkedIssueLabelPropagationMapping | undefined;
+    const additiveMatches: LinkedIssueLabelPropagationMapping[] = [];
     for (const mapping of input.propagation.mappings) {
       if (!wanted.has(mapping.issueLabel.toLowerCase())) continue;
-      return mapping.removeOtherTypeLabels ? decide([mapping.prLabel], "propagation_exclusive") : decide([titleLabel, mapping.prLabel], "propagation_additive");
+      if (mapping.removeOtherTypeLabels) exclusiveMatch ??= mapping;
+      else additiveMatches.push(mapping);
+    }
+    if (exclusiveMatch || additiveMatches.length > 0) {
+      const applyLabels = [exclusiveMatch ? exclusiveMatch.prLabel : titleLabel, ...additiveMatches.map((mapping) => mapping.prLabel)];
+      return decide(applyLabels, exclusiveMatch ? "propagation_exclusive" : "propagation_additive");
     }
   }
   return decide([titleLabel], "title");

--- a/test/unit/pr-type-label.test.ts
+++ b/test/unit/pr-type-label.test.ts
@@ -123,6 +123,66 @@ describe("resolvePrTypeLabel (#priority-linked-issue-gate)", () => {
     expect(result.source).toBe("propagation_exclusive");
   });
 
+  describe("additive matches compose with the exclusive winner (#priority-linked-issue-gate composition fix)", () => {
+    const bugFeaturePriorityMappings = [
+      { issueLabel: "gittensor:bug", prLabel: "gittensor:bug", removeOtherTypeLabels: true },
+      { issueLabel: "gittensor:feature", prLabel: "gittensor:feature", removeOtherTypeLabels: true },
+      { issueLabel: "gittensor:priority", prLabel: "gittensor:priority", removeOtherTypeLabels: false },
+    ];
+
+    it("REGRESSION: a linked issue carrying BOTH gittensor:feature (exclusive) and gittensor:priority (additive) gets both labels, not just the first match", () => {
+      // Before this fix, the loop returned on the FIRST wanted mapping (feature, since it's checked before
+      // priority) and never even looked at priority's own mapping -- silently dropping priority whenever the
+      // SAME issue also carried a type label, which is the overwhelmingly common case in practice.
+      const result = resolvePrTypeLabel({
+        title: "fix: y",
+        linkedIssueLabels: ["gittensor:feature", "gittensor:priority"],
+        propagation: propagation({ mappings: bugFeaturePriorityMappings }),
+      });
+      expect(result).toEqual({ applyLabels: ["gittensor:feature", "gittensor:priority"], removeLabels: ["gittensor:bug"], source: "propagation_exclusive" });
+    });
+
+    it("REGRESSION: a linked issue carrying BOTH gittensor:bug (exclusive) and gittensor:priority (additive) gets both labels", () => {
+      const result = resolvePrTypeLabel({
+        title: "feat: add provider fallback", // title alone would say "feature" -- propagation must still win
+        linkedIssueLabels: ["gittensor:bug", "gittensor:priority"],
+        propagation: propagation({ mappings: bugFeaturePriorityMappings }),
+      });
+      expect(result).toEqual({ applyLabels: ["gittensor:bug", "gittensor:priority"], removeLabels: ["gittensor:feature"], source: "propagation_exclusive" });
+    });
+
+    it("priority alone (no bug/feature match): applies additively alongside the title-based label, source is propagation_additive", () => {
+      const result = resolvePrTypeLabel({
+        title: "fix: y",
+        linkedIssueLabels: ["gittensor:priority"],
+        propagation: propagation({ mappings: bugFeaturePriorityMappings }),
+      });
+      expect(result).toEqual({ applyLabels: ["gittensor:bug", "gittensor:priority"], removeLabels: ["gittensor:feature"], source: "propagation_additive" });
+    });
+
+    it("multiple additive matches all compose together alongside a single exclusive winner", () => {
+      const result = resolvePrTypeLabel({
+        title: "fix: y",
+        linkedIssueLabels: ["gittensor:bug", "gittensor:priority", "customer:vip"],
+        propagation: propagation({
+          mappings: [...bugFeaturePriorityMappings, { issueLabel: "customer:vip", prLabel: "triage:vip", removeOtherTypeLabels: false }],
+        }),
+      });
+      expect(result.applyLabels).toEqual(["gittensor:bug", "gittensor:priority", "triage:vip"]);
+      expect(result.source).toBe("propagation_exclusive");
+    });
+
+    it("two exclusive candidates + an additive one: only the FIRST-configured exclusive mapping wins, additive still composes", () => {
+      const result = resolvePrTypeLabel({
+        title: "fix: y",
+        linkedIssueLabels: ["gittensor:bug", "gittensor:feature", "gittensor:priority"],
+        propagation: propagation({ mappings: bugFeaturePriorityMappings }),
+      });
+      // bug is configured before feature, so bug wins the exclusive slot even though both matched.
+      expect(result).toEqual({ applyLabels: ["gittensor:bug", "gittensor:priority"], removeLabels: ["gittensor:feature"], source: "propagation_exclusive" });
+    });
+  });
+
   it("respects a custom typeLabels set for both the title fallback and the removal set", () => {
     const custom = { bug: "kind:bug", feature: "kind:feature", priority: "kind:priority" };
     const result = resolvePrTypeLabel({ title: "feat: add provider fallback", labels: custom });

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -26673,9 +26673,15 @@ describe("queue processors", () => {
         },
       });
 
+      // JSONbored/gittensory falls back to its own bundled manifest (GITTENSORY_REPO_FOCUS_MANIFEST_YAML) when
+      // no other manifest source responds, which REPLACES this test's DB-configured single-mapping override
+      // with its own bug/feature (exclusive) + priority (additive) mapping list -- so the linked issue's
+      // gittensor:priority label composes with the title-derived "fix" -> gittensor:bug, rather than replacing
+      // it. Priority is additive (not a type of its own; see resolvePrTypeLabel's composition fix), so bug
+      // still applies from the title and only feature (never matched) needs removing.
       expect(seen.issueFetches).toBe(1);
-      expect(seen.posted).toEqual(["gittensor:priority"]);
-      expect(seen.removed.sort()).toEqual(["gittensor:bug", "gittensor:feature"]);
+      expect(seen.posted).toEqual(["gittensor:bug", "gittensor:priority"]);
+      expect(seen.removed).toEqual(["gittensor:feature"]);
     });
 
     it("fails open to the normal title-based label when the linked issue's fetch fails (#priority-linked-issue-gate)", async () => {


### PR DESCRIPTION
## Summary

- `resolvePrTypeLabel`'s propagation loop returned on the FIRST mapping the linked issue's labels satisfied, so an ADDITIVE mapping (e.g. `gittensor:priority` -- a reward tag meant to coexist with whichever type already applies) was silently unreachable whenever the SAME issue also carried a label an earlier, EXCLUSIVE mapping (bug/feature) matched. Since `bug`/`feature` are checked before `priority` in the mappings array, and our issues routinely carry a type label AND priority together (confirmed live: issue #3348 in metagraphed carried both `gittensor:feature` and `gittensor:priority`), priority appeared to work when tested in isolation but was actually being dropped -- and REMOVED, since it's in the same exclusive-cleanup set -- on nearly every real PR. This is the actual root cause behind "priority labels aren't detected/propagating," a live, reproducible bug (screenshot: `gittensory-orb` repeatedly stripped a maintainer's manually-applied `gittensor:priority`/`gittensor:feature` and replaced them with `gittensor:bug` from title classification alone).
- Fixed the matching loop to collect every satisfied mapping instead of stopping at the first: the first EXCLUSIVE match still wins the single type-label slot (same bug-vs-feature precedence as before), and every ADDITIVE match now composes alongside it instead of losing to whichever exclusive mapping happened to be checked first in the array.
- Also flipped `gittensor:priority`'s own `removeOtherTypeLabels` to `false` (additive) in every config that models it: the repo's own `.gittensory.yml`, the bundled fallback (`src/config/gittensory-repo-focus-manifest.ts`), and both public example templates (`.gittensory.yml.example`, `config/examples/gittensory.full.yml`). Priority is a reward dimension, not a type of its own -- it should never have competed with bug/feature for the same exclusive slot in the first place.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue this PR resolves — owner-authored PR fixing a live-reported, reproduced bug; no separate issue was filed for this follow-up fix.

## Validation

- [x] `npm run typecheck`
- [x] `npm run manifest:drift-check` / `npm run docs:drift-check` — both clean (the repo-root `.gittensory.yml` and the bundled `GITTENSORY_REPO_FOCUS_MANIFEST_YAML` fallback are kept in sync, as required)
- [x] `npx vitest run test/unit/pr-type-label.test.ts test/unit/pr-type-label-engine.test.ts` — 74/74 pass. All 18 pre-existing `resolvePrTypeLabel` cases traced by hand against the new logic and confirmed unaffected; 5 new regression tests added for the actual composition bug (issue carrying bug+priority, feature+priority, priority-alone, multiple additive matches, and two-exclusive-candidates-plus-additive to confirm first-exclusive-still-wins).
- [x] `npx vitest run test/unit/queue.test.ts` — full suite, 754/754 pass. One pre-existing integration test's expectations were updated: `JSONbored/gittensory`'s own bundled-manifest fallback now correctly composes `gittensor:bug` (title) + `gittensor:priority` (additive) instead of the old exclusive-only `gittensor:priority` alone.
- [ ] `npm run actionlint` / `npm run test:workers` / `npm run build:mcp` / `npm run test:mcp-pack` / `npm run ui:openapi:check` / `npm run ui:lint` / `npm run ui:typecheck` / `npm run ui:build` / `npm audit` — not run locally for this focused change; relying on CI (`validate`) for the full gate.

If any required check was skipped, explain why:

- This is a narrow, single-concern fix; the full `npm run test:ci` gate is left to CI per the repo's own established practice for this size of change.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no auth/session surface touched.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, pure label-classification logic, no external surface.
- [ ] UI changes use live API data or real empty/error/loading states. — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section. — N/A, no UI changes.
- [x] Public docs/changelogs are updated where needed — both public `.gittensory.yml` example templates corrected alongside the code fix, so new self-hosters don't copy the same bug.

## Notes

- Root-caused live from a screenshot showing `gittensory-orb` repeatedly removing a maintainer's manually-applied `gittensor:feature`/`gittensor:priority` labels and replacing them with `gittensor:bug` on PR #4531 (metagraphed), whose linked issue #3348 carried both `gittensor:feature` and `gittensor:priority`.