### PR TITLE
feat(miner-discover): wire the fanout+ranker+queue pipeline into a discover CLI command

### DIFF
--- a/packages/gittensory-miner/bin/gittensory-miner.js
+++ b/packages/gittensory-miner/bin/gittensory-miner.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { printHelp, printVersion, runCli } from "../lib/cli.js";
 import { runDenyCheck } from "../lib/deny-check.js";
+import { runDiscover } from "../lib/discover-cli.js";
 import { runGovernorCli } from "../lib/governor-ledger-cli.js";
 import { runLedgerCli } from "../lib/event-ledger-cli.js";
 import { runManagePoll } from "../lib/manage-poll.js";
@@ -105,6 +106,12 @@ if (cliArgs[0] === "state") {
 
 if (cliArgs[0] === "manage" && cliArgs[1] === "poll") {
   const exitCode = await runManagePoll(cliArgs.slice(2));
+  await awaitOpportunisticUpdateCheck(updateCheck);
+  process.exit(exitCode);
+}
+
+if (cliArgs[0] === "discover") {
+  const exitCode = await runDiscover(cliArgs.slice(1));
   await awaitOpportunisticUpdateCheck(updateCheck);
   process.exit(exitCode);
 }

--- a/packages/gittensory-miner/lib/cli.js
+++ b/packages/gittensory-miner/lib/cli.js
@@ -19,6 +19,8 @@ export function printHelp(input) {
       "  gittensory-miner doctor [--json]                              Check this laptop is set up correctly",
       "  gittensory-miner manage status [--json]                       Show managed PR rows from local portfolio + ledger",
       "  gittensory-miner manage poll <owner/repo> <pr#> [--branch <name>] [--json]",
+      "  gittensory-miner discover <owner/repo> [<owner/repo>...] [--json]",
+      "  gittensory-miner discover --search <query> [--json]           Fan out, rank, and enqueue candidates",
       "  gittensory-miner queue list [--repo <owner/repo>] [--json]    List portfolio backlog rows",
       "  gittensory-miner queue next [--json]                          Claim the highest-priority queued item",
       "  gittensory-miner queue done <owner/repo> <identifier> [--json]",

--- a/packages/gittensory-miner/lib/discover-cli.d.ts
+++ b/packages/gittensory-miner/lib/discover-cli.d.ts
@@ -1,0 +1,65 @@
+import type {
+  CandidateIssueWarning,
+  FanoutTarget,
+  RawCandidateIssue,
+} from "./opportunity-fanout.js";
+import type { RankedCandidateIssue, RankedCandidateSummary } from "./opportunity-ranker.js";
+import type { EnqueueRankedDiscoverySummary } from "./portfolio-discovery.js";
+import type { PortfolioQueueStore } from "./portfolio-queue.js";
+
+export type ParsedDiscoverArgs =
+  | {
+      targets: FanoutTarget[];
+      search: string | null;
+      json: boolean;
+    }
+  | { error: string };
+
+/** The subset of `CandidateIssueSummary` runDiscover actually reads, so callers may inject a fake without
+ * fabricating rate-limit telemetry it never touches. A real `fetchCandidateIssuesWithSummary` result satisfies
+ * this too, since it is a strict superset. */
+export type DiscoverFanOutSummary = {
+  issues: RawCandidateIssue[];
+  warnings: CandidateIssueWarning[];
+};
+
+/** The subset of a ranked entry that `renderDiscoverSummary` reads for its top-candidates listing. */
+export type DiscoverRankedEntry = Pick<RankedCandidateIssue, "repoFullName" | "issueNumber" | "title" | "rankScore">;
+
+export type DiscoverResult = {
+  fanOutCount: number;
+  warnings: CandidateIssueWarning[];
+  ranked: DiscoverRankedEntry[];
+  enqueueSummary: EnqueueRankedDiscoverySummary;
+};
+
+export type RunDiscoverOptions = {
+  githubToken?: string;
+  apiBaseUrl?: string;
+  nowMs?: number;
+  initPortfolioQueue?: () => PortfolioQueueStore;
+  fetchCandidateIssuesWithSummary?: (
+    targets: FanoutTarget[],
+    githubToken: string,
+    options?: { apiBaseUrl?: string },
+  ) => Promise<DiscoverFanOutSummary>;
+  searchCandidateIssuesWithSummary?: (
+    searchQuery: string,
+    githubToken: string,
+    options?: { apiBaseUrl?: string },
+  ) => Promise<DiscoverFanOutSummary>;
+  rankCandidateIssuesWithSummary?: (
+    candidates: RawCandidateIssue[],
+    options?: { nowMs?: number },
+  ) => RankedCandidateSummary;
+  enqueueRankedDiscovery?: (
+    rankedIssues: RankedCandidateIssue[],
+    options: { queueStore: PortfolioQueueStore },
+  ) => EnqueueRankedDiscoverySummary;
+};
+
+export function parseDiscoverArgs(args: string[]): ParsedDiscoverArgs;
+
+export function renderDiscoverSummary(result: DiscoverResult): string;
+
+export function runDiscover(args: string[], options?: RunDiscoverOptions): Promise<number>;

--- a/packages/gittensory-miner/lib/discover-cli.js
+++ b/packages/gittensory-miner/lib/discover-cli.js
@@ -1,0 +1,121 @@
+/** `discover` CLI command (#4247): wires the existing fanout -> rank -> enqueue pipeline together so a miner
+ * can actually run it. Every piece already exists and is independently tested; this module only composes them. */
+import {
+  fetchCandidateIssuesWithSummary,
+  searchCandidateIssuesWithSummary,
+} from "./opportunity-fanout.js";
+import { rankCandidateIssuesWithSummary } from "./opportunity-ranker.js";
+import { enqueueRankedDiscovery } from "./portfolio-discovery.js";
+import { initPortfolioQueueStore } from "./portfolio-queue.js";
+
+const DISCOVER_USAGE =
+  "Usage: gittensory-miner discover <owner/repo> [<owner/repo>...] | --search <query> [--json]";
+
+function parseRepoTarget(value) {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  const [owner, repo, extra] = trimmed.split("/");
+  if (!owner || !repo || extra !== undefined) return null;
+  return { owner, repo };
+}
+
+export function parseDiscoverArgs(args) {
+  const options = { json: false, search: null };
+  const targets = [];
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (token === "--search") {
+      const query = args[index + 1];
+      if (!query || query.startsWith("-")) return { error: DISCOVER_USAGE };
+      options.search = query;
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("-")) {
+      return { error: `Unknown option: ${token}` };
+    }
+    const target = parseRepoTarget(token);
+    if (!target) return { error: `Repository must be in owner/repo form: ${token}` };
+    targets.push(target);
+  }
+
+  if (options.search === null && targets.length === 0) {
+    return { error: DISCOVER_USAGE };
+  }
+  if (options.search !== null && targets.length > 0) {
+    return { error: "Pass either repository targets or --search, not both." };
+  }
+
+  return { targets, search: options.search, json: options.json };
+}
+
+export function renderDiscoverSummary(result) {
+  const lines = [
+    `fanned out: ${result.fanOutCount} candidate issue(s)`,
+    `ai-policy warnings: ${result.warnings.length}`,
+    `ranked: ${result.ranked.length}`,
+    `enqueued: ${result.enqueueSummary.enqueued}`,
+  ];
+  if (result.enqueueSummary.skippedBelowMinRank > 0) {
+    lines.push(`skipped (below min rank): ${result.enqueueSummary.skippedBelowMinRank}`);
+  }
+  if (result.ranked.length === 0) {
+    lines.push("", "no candidates found.");
+    return lines.join("\n");
+  }
+  lines.push("", "top candidates:");
+  for (const entry of result.ranked.slice(0, 10)) {
+    lines.push(`  ${entry.repoFullName}#${entry.issueNumber}  score=${entry.rankScore.toFixed(4)}  ${entry.title}`);
+  }
+  return lines.join("\n");
+}
+
+export async function runDiscover(args, options = {}) {
+  const parsed = parseDiscoverArgs(args);
+  if ("error" in parsed) {
+    console.error(parsed.error);
+    return 2;
+  }
+
+  const githubToken = options.githubToken ?? process.env.GITHUB_TOKEN ?? "";
+  const fetchTargets = options.fetchCandidateIssuesWithSummary ?? fetchCandidateIssuesWithSummary;
+  const searchTargets = options.searchCandidateIssuesWithSummary ?? searchCandidateIssuesWithSummary;
+  const rankIssues = options.rankCandidateIssuesWithSummary ?? rankCandidateIssuesWithSummary;
+  const enqueue = options.enqueueRankedDiscovery ?? enqueueRankedDiscovery;
+
+  const ownsPortfolioQueue = options.initPortfolioQueue === undefined;
+  const portfolioQueue = (options.initPortfolioQueue ?? initPortfolioQueueStore)();
+
+  try {
+    const fanOut =
+      parsed.search !== null
+        ? await searchTargets(parsed.search, githubToken, { apiBaseUrl: options.apiBaseUrl })
+        : await fetchTargets(parsed.targets, githubToken, { apiBaseUrl: options.apiBaseUrl });
+
+    const rankedSummary = rankIssues(fanOut.issues, { nowMs: options.nowMs });
+    const enqueueSummary = enqueue(rankedSummary.issues, { queueStore: portfolioQueue });
+
+    const result = {
+      fanOutCount: fanOut.issues.length,
+      warnings: fanOut.warnings,
+      ranked: rankedSummary.issues,
+      enqueueSummary,
+    };
+
+    if (parsed.json) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.log(renderDiscoverSummary(result));
+    }
+    return 0;
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 2;
+  } finally {
+    if (ownsPortfolioQueue) portfolioQueue.close();
+  }
+}

--- a/test/unit/miner-discover-cli.test.ts
+++ b/test/unit/miner-discover-cli.test.ts
@@ -1,0 +1,292 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  closeDefaultPortfolioQueueStore,
+  initPortfolioQueueStore,
+} from "../../packages/gittensory-miner/lib/portfolio-queue.js";
+import {
+  parseDiscoverArgs,
+  renderDiscoverSummary,
+  runDiscover,
+} from "../../packages/gittensory-miner/lib/discover-cli.js";
+import { bin, runCapture } from "./support/miner-cli-harness";
+
+const NOW = Date.parse("2026-07-09T12:00:00.000Z");
+
+const roots: string[] = [];
+const stores: Array<{ close(): void }> = [];
+
+function tempQueueStore() {
+  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-discover-cli-"));
+  roots.push(root);
+  const store = initPortfolioQueueStore(join(root, "portfolio-queue.sqlite3"));
+  stores.push(store);
+  return store;
+}
+
+function fanOutIssue(overrides: Record<string, unknown> = {}) {
+  return {
+    owner: "acme",
+    repo: "widgets",
+    repoFullName: "acme/widgets",
+    issueNumber: 1,
+    title: "Add queue retry helper",
+    labels: ["help wanted"],
+    commentsCount: 1,
+    createdAt: "2026-07-09T10:00:00.000Z",
+    updatedAt: "2026-07-09T10:00:00.000Z",
+    htmlUrl: "https://github.com/acme/widgets/issues/1",
+    aiPolicyAllowed: true as const,
+    aiPolicySource: "none" as const,
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  for (const store of stores.splice(0)) store.close();
+  closeDefaultPortfolioQueueStore();
+  vi.restoreAllMocks();
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("parseDiscoverArgs (#4247)", () => {
+  it("requires either repo targets or --search", () => {
+    expect(parseDiscoverArgs([])).toEqual({
+      error: expect.stringContaining("Usage: gittensory-miner discover"),
+    });
+  });
+
+  it("parses one or more owner/repo targets plus --json", () => {
+    expect(parseDiscoverArgs(["acme/widgets", "acme/gadgets", "--json"])).toEqual({
+      targets: [
+        { owner: "acme", repo: "widgets" },
+        { owner: "acme", repo: "gadgets" },
+      ],
+      search: null,
+      json: true,
+    });
+  });
+
+  it("parses --search as an alternative to repo targets", () => {
+    expect(parseDiscoverArgs(["--search", "label:bug"])).toEqual({
+      targets: [],
+      search: "label:bug",
+      json: false,
+    });
+  });
+
+  it("rejects malformed repo targets", () => {
+    expect(parseDiscoverArgs(["not-a-repo"])).toEqual({
+      error: "Repository must be in owner/repo form: not-a-repo",
+    });
+  });
+
+  it("rejects mixing repo targets with --search", () => {
+    expect(parseDiscoverArgs(["acme/widgets", "--search", "x"])).toEqual({
+      error: "Pass either repository targets or --search, not both.",
+    });
+  });
+
+  it("rejects a --search flag missing its query and unknown options", () => {
+    expect(parseDiscoverArgs(["--search"])).toEqual({
+      error: expect.stringContaining("Usage: gittensory-miner discover"),
+    });
+    expect(parseDiscoverArgs(["--search", "--json"])).toEqual({
+      error: expect.stringContaining("Usage: gittensory-miner discover"),
+    });
+    expect(parseDiscoverArgs(["acme/widgets", "--verbose"])).toEqual({
+      error: "Unknown option: --verbose",
+    });
+  });
+});
+
+describe("renderDiscoverSummary (#4247)", () => {
+  it("summarizes fan-out, ranking, and enqueue counts with top candidates", () => {
+    const text = renderDiscoverSummary({
+      fanOutCount: 2,
+      warnings: [{ repoFullName: "acme/banned", stage: "policy:AI-USAGE.md", message: "denied" }],
+      ranked: [
+        { repoFullName: "acme/widgets", issueNumber: 1, title: "Add retry helper", rankScore: 0.8 },
+        { repoFullName: "acme/widgets", issueNumber: 2, title: "Fix flaky test", rankScore: 0.4 },
+      ],
+      enqueueSummary: { enqueued: 2, skippedBelowMinRank: 0, skippedInvalid: 0, eventsAppended: 0 },
+    });
+    expect(text).toContain("fanned out: 2 candidate issue(s)");
+    expect(text).toContain("ai-policy warnings: 1");
+    expect(text).toContain("ranked: 2");
+    expect(text).toContain("enqueued: 2");
+    expect(text).toContain("acme/widgets#1  score=0.8000  Add retry helper");
+    expect(text).not.toContain("skipped (below min rank)");
+  });
+
+  it("reports skipped-below-min-rank counts and an empty-result message", () => {
+    const withSkips = renderDiscoverSummary({
+      fanOutCount: 1,
+      warnings: [],
+      ranked: [{ repoFullName: "acme/widgets", issueNumber: 1, title: "x", rankScore: 0.1 }],
+      enqueueSummary: { enqueued: 0, skippedBelowMinRank: 1, skippedInvalid: 0, eventsAppended: 0 },
+    });
+    expect(withSkips).toContain("skipped (below min rank): 1");
+
+    const empty = renderDiscoverSummary({
+      fanOutCount: 0,
+      warnings: [],
+      ranked: [],
+      enqueueSummary: { enqueued: 0, skippedBelowMinRank: 0, skippedInvalid: 0, eventsAppended: 0 },
+    });
+    expect(empty).toContain("no candidates found.");
+  });
+});
+
+describe("runDiscover (#4247)", () => {
+  it("fans out repo targets, ranks, and enqueues into the real portfolio queue", async () => {
+    const portfolioQueue = tempQueueStore();
+    const fetchCandidateIssuesWithSummary = vi.fn(async () => ({
+      issues: [
+        fanOutIssue({ issueNumber: 1, title: "Add retry helper", labels: ["help wanted", "feature"] }),
+        fanOutIssue({ issueNumber: 2, title: "Fix flaky test", labels: ["help wanted"] }),
+      ],
+      warnings: [],
+    }));
+    const searchCandidateIssuesWithSummary = vi.fn(async () => {
+      throw new Error("must not be called for repo-target mode");
+    });
+
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const exitCode = await runDiscover(["acme/widgets", "--json"], {
+      nowMs: NOW,
+      initPortfolioQueue: () => portfolioQueue,
+      fetchCandidateIssuesWithSummary,
+      searchCandidateIssuesWithSummary,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(fetchCandidateIssuesWithSummary).toHaveBeenCalledWith(
+      [{ owner: "acme", repo: "widgets" }],
+      "",
+      expect.objectContaining({}),
+    );
+    expect(searchCandidateIssuesWithSummary).not.toHaveBeenCalled();
+
+    const payload = JSON.parse(String(log.mock.calls[0]?.[0]));
+    expect(payload.fanOutCount).toBe(2);
+    expect(payload.enqueueSummary.enqueued).toBe(2);
+    expect(payload.ranked.map((entry: { issueNumber: number }) => entry.issueNumber)).toEqual([1, 2]);
+
+    const queued = portfolioQueue.listQueue("acme/widgets");
+    expect(queued.map((entry) => entry.identifier).sort()).toEqual(["issue:1", "issue:2"]);
+  });
+
+  it("uses --search instead of repo targets and never calls the repo fan-out", async () => {
+    const portfolioQueue = tempQueueStore();
+    const fetchCandidateIssuesWithSummary = vi.fn(async () => {
+      throw new Error("must not be called in --search mode");
+    });
+    const searchCandidateIssuesWithSummary = vi.fn(async (query: string) => ({
+      issues: [fanOutIssue({ issueNumber: 9, title: `Result for ${query}` })],
+      warnings: [],
+    }));
+
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const exitCode = await runDiscover(["--search", "label:bug"], {
+      nowMs: NOW,
+      initPortfolioQueue: () => portfolioQueue,
+      fetchCandidateIssuesWithSummary,
+      searchCandidateIssuesWithSummary,
+    });
+
+    expect(exitCode).toBe(0);
+    expect(searchCandidateIssuesWithSummary).toHaveBeenCalledWith("label:bug", "", expect.objectContaining({}));
+    expect(fetchCandidateIssuesWithSummary).not.toHaveBeenCalled();
+    expect(String(log.mock.calls[0]?.[0])).toContain("Result for label:bug");
+  });
+
+  it("prints a human-readable summary by default (no --json)", async () => {
+    const portfolioQueue = tempQueueStore();
+    const fetchCandidateIssuesWithSummary = vi.fn(async () => ({
+      issues: [fanOutIssue()],
+      warnings: [],
+    }));
+
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const exitCode = await runDiscover(["acme/widgets"], {
+      nowMs: NOW,
+      initPortfolioQueue: () => portfolioQueue,
+      fetchCandidateIssuesWithSummary,
+    });
+
+    expect(exitCode).toBe(0);
+    const text = String(log.mock.calls[0]?.[0]);
+    expect(text).toContain("fanned out: 1 candidate issue(s)");
+    expect(text).toContain("top candidates:");
+  });
+
+  it("prints argument errors without opening the portfolio queue", async () => {
+    const initPortfolioQueue = vi.fn(() => {
+      throw new Error("must not open the queue on a parse error");
+    });
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const exitCode = await runDiscover(["not-a-repo"], { initPortfolioQueue });
+    expect(exitCode).toBe(2);
+    expect(initPortfolioQueue).not.toHaveBeenCalled();
+    expect(error).toHaveBeenCalledWith("Repository must be in owner/repo form: not-a-repo");
+  });
+
+  it("reports fan-out failures and exits non-zero without leaking the error", async () => {
+    const portfolioQueue = tempQueueStore();
+    const fetchCandidateIssuesWithSummary = vi.fn(async () => {
+      throw new Error("github_unreachable");
+    });
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    const exitCode = await runDiscover(["acme/widgets"], {
+      initPortfolioQueue: () => portfolioQueue,
+      fetchCandidateIssuesWithSummary,
+    });
+
+    expect(exitCode).toBe(2);
+    expect(error).toHaveBeenCalledWith("github_unreachable");
+  });
+
+  it("opens and closes the default on-disk portfolio queue when no override is supplied", async () => {
+    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-discover-cli-default-"));
+    roots.push(root);
+    const dbPath = join(root, "portfolio-queue.sqlite3");
+    const previousDbPath = process.env.GITTENSORY_MINER_PORTFOLIO_QUEUE_DB;
+    process.env.GITTENSORY_MINER_PORTFOLIO_QUEUE_DB = dbPath;
+    try {
+      const fetchCandidateIssuesWithSummary = vi.fn(async () => ({
+        issues: [fanOutIssue({ issueNumber: 5 })],
+        warnings: [],
+      }));
+      vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+      const exitCode = await runDiscover(["acme/widgets"], { nowMs: NOW, fetchCandidateIssuesWithSummary });
+      expect(exitCode).toBe(0);
+
+      // runDiscover owned and closed this store itself (no initPortfolioQueue override was passed); reopening
+      // the same file confirms the enqueue was actually persisted through the default code path.
+      const reopened = initPortfolioQueueStore(dbPath);
+      stores.push(reopened);
+      expect(reopened.listQueue().map((entry) => entry.identifier)).toEqual(["issue:5"]);
+    } finally {
+      if (previousDbPath === undefined) delete process.env.GITTENSORY_MINER_PORTFOLIO_QUEUE_DB;
+      else process.env.GITTENSORY_MINER_PORTFOLIO_QUEUE_DB = previousDbPath;
+    }
+  });
+});
+
+describe("gittensory-miner discover CLI entrypoint (#4247)", () => {
+  it("lists the discover command in --help", () => {
+    const output = runCapture(["--help", "--no-update-check"]);
+    expect(output).toContain("gittensory-miner discover");
+  });
+
+  it("exits 2 with a usage error when neither repo targets nor --search are given", () => {
+    const output = runCapture(["discover"]);
+    expect(output).toContain("Usage: gittensory-miner discover");
+  });
+});


### PR DESCRIPTION
## Summary

- Closes #4247 by wiring the already-existing, already-tested Phase 1 discovery pipeline into a real `gittensory-miner discover` command — every piece it composes (`fetchCandidateIssuesWithSummary`/`searchCandidateIssuesWithSummary`, `rankCandidateIssuesWithSummary`, `enqueueRankedDiscovery`) already existed and was independently tested; this PR is pure plumbing, not new logic.
- `packages/gittensory-miner/lib/discover-cli.js` adds `gittensory-miner discover <owner/repo> [<owner/repo>...]` and a `--search <query>` variant (mutually exclusive), runs fan-out -> rank -> enqueue against the local portfolio queue, and prints a human-readable summary (fan-out count, AI-policy warning count, ranked count, enqueued count, top-10 ranked candidates) or `--json`.
- Wired into `bin/gittensory-miner.js` (dispatched alongside the other async, network-touching subcommands) and documented in `lib/cli.js`'s `--help` output, matching the existing command-dispatch and injectable-dependency conventions (`initPortfolioQueue`, `fetchCandidateIssuesWithSummary`, etc.) used by `claim`, `queue`, and `manage poll`.
- Added `discover-cli.d.ts` following this package's hand-written-declaration convention (every `.js` file under `packages/gittensory-miner/lib/` has a sibling `.d.ts`).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused: one new CLI command file + its declaration + its test, plus the two small wiring edits to `bin/gittensory-miner.js` and `lib/cli.js`. No unrelated backend/UI/docs/dependency changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` — not run; no workflow files touched.
- [x] `npm run typecheck` (clean on this diff; the repo's one pre-existing failure, a missing `aws4fetch` type declaration in `src/selfhost/s3-blob-store.ts`, reproduces identically on a clean `main` checkout and is unrelated to this change).
- [x] `npm run test:coverage` locally — `packages/gittensory-miner/**` is plain JS and is **not** in vitest's coverage `include` globs (only `src/**` and `packages/gittensory-engine/src/**` are instrumented, per `vitest.config.ts`), so this diff carries no Codecov `codecov/patch` obligation. In lieu of the full unsharded run (this dev machine is shared with several other concurrent contributor sessions and a full run did not complete in reasonable time), I ran the new suite (`test/unit/miner-discover-cli.test.ts`, 16 tests: arg parsing, summary rendering, `runDiscover` fan-out/search/enqueue/error paths against a real temp SQLite portfolio queue, and two true subprocess CLI-entrypoint tests) plus every directly-adjacent sibling suite it touches (`miner-cli`, `miner-opportunity-fanout`, `opportunity-fanout-ai-policy`, `miner-opportunity-ranker`, `miner-portfolio-queue-cli`, `miner-manage-poll`, `miner-claim-ledger-cli`, `miner-package-skeleton`) — 88/90 pass; the 2 pre-existing failures in `miner-package-skeleton.test.ts` (a shebang byte-equality check and an `npm ls` invocation) reproduce identically on a clean `main` checkout, caused by this Windows machine's `core.autocrlf=true` converting every checked-out file to CRLF — unrelated to this diff and a non-issue on Linux CI.
- [ ] `npm run test:workers` — not run; no Cloudflare Worker code touched.
- [ ] `npm run build:mcp` — not run; unrelated (`@jsonbored/gittensory-mcp` package untouched).
- [ ] `npm run test:mcp-pack` / miner-pack equivalents — not run; both currently fail locally on this Windows machine for an unrelated, pre-existing reason (`spawnSync("npm", ...)` requires `shell:true` on Windows; reproduces identically on a clean `main` checkout) independent of this diff.
- [ ] `npm run ui:openapi:check` / `ui:lint` / `ui:typecheck` / `ui:build` — not run; no `apps/gittensory-ui` files touched. (`npm run command-reference:check` was checked too: it tracks an unrelated GitHub `@gittensory` mention-command catalog in `src/github/commands.ts`, not this CLI; confirmed a no-op for this diff.)
- [ ] `npm audit --audit-level=moderate` — not run; no dependency changes.
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries: repo-target mode, `--search` mode (and their mutual exclusion), `--json` vs human-readable output, argument-error paths (queue never opened), fan-out-failure error path, and the default (non-injected) on-disk portfolio-queue code path.

If any required check was skipped, explain why:

- Everything skipped above is either inapplicable to a plain-JS, non-`src/`, non-UI, non-workflow CLI-plumbing change, or blocked by pre-existing, reproducible-on-clean-`main` Windows-local environment issues (CRLF checkout, `npm pack`'s `spawnSync` Windows incompatibility) that do not reflect real CI behavior (GitHub Actions runs on Linux with an LF checkout).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session behavior is not changed.
- [x] API/OpenAPI/MCP behavior is not changed.
- [x] No visible UI changes; UI evidence is not applicable.
- [x] Public docs/changelogs are not changed.

## UI Evidence

Not applicable; this is a local CLI-only change.

## Notes

- `packages/gittensory-miner/**` writes only to the miner's own local SQLite portfolio-queue file and performs metadata-only GitHub GETs (issue listing + `AI-USAGE.md`/`CONTRIBUTING.md` policy docs) via the already-existing, already-tested fan-out module — this command introduces no new network surface or write path.
