### PR TITLE
feat(miner-hands): add shared subprocess env-allowlist + secret-redaction helper to gittensory-engine

### DIFF
--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -176,6 +176,7 @@ export {
   type CreateCodingAgentDriverOptions,
   type RunCodingAgentAttemptOptions,
 } from "./miner/driver-factory.js";
+export * from "./miner/subprocess-env.js";
 export * from "./plan-export.js";
 export { countPlanStepsByStatus } from "./plan-step-stats.js";
 export { countPlanSteps } from "./plan-step-count.js";

--- a/packages/gittensory-engine/src/miner/subprocess-env.ts
+++ b/packages/gittensory-engine/src/miner/subprocess-env.ts
@@ -1,0 +1,92 @@
+// Shared subprocess env-allowlist + secret redaction (#4284): pure, engine-hosted helpers so every
+// subprocess-spawning driver (the CLI-subprocess CodingAgentDriver #4266, and anything else in
+// gittensory-miner) depends on ONE source of truth instead of copy-pasting the pattern from
+// `src/selfhost/ai.ts`. Strings/objects only — no IO, no `process.env` read, no spawning.
+//
+// Generalized from `src/selfhost/ai.ts`'s `SUBSCRIPTION_CLI_ENV_ALLOWLIST`/`subscriptionCliEnv` (:349-411),
+// `SECRET_PATTERNS` (:719-725) and `redactSecrets` (:724-731): the allowlist is a PARAMETER here (a
+// coding-agent subprocess may need a different/larger allowlist than a review-only CLI call), and the
+// redactor carries over the same secret-shape family verbatim. The CLI-specific PATH synthesis
+// (`resolveSubscriptionCliPath`) stays in `ai.ts` — it is not part of this generalized allowlist builder;
+// PATH here is treated like any other allowlisted/overridable key.
+//
+// MIGRATION (deliberate, documented choice per #4284): `src/selfhost/ai.ts` KEEPS its existing parallel copy
+// for now — this module is the shared source of truth for NEW engine/miner subprocess code. A follow-up may
+// shim `ai.ts` onto it (mirroring the `src/rules/predicted-gate.ts` → engine `predicted-gate.ts` shim). Left a
+// parallel copy rather than refactoring `ai.ts` in this PR to keep the change self-contained to the engine.
+
+/** Well-known secret shapes to redact from untrusted subprocess output before it reaches logs/errors.
+ *  Carried over verbatim from `src/selfhost/ai.ts`'s `SECRET_PATTERNS`. */
+export const SUBPROCESS_SECRET_PATTERNS: readonly RegExp[] = [
+  /\bsk-[A-Za-z0-9_-]{16,}/g, // OpenAI / Anthropic keys (sk-..., sk-ant-..., sk-proj-...)
+  /\bgh[oprsu]_[A-Za-z0-9]{20,}/g, // GitHub PAT / OAuth / server / refresh tokens
+  /\bgithub_pat_[A-Za-z0-9_]{20,}/g, // GitHub fine-grained PAT
+  /\beyJ[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]{6,}/g, // JWT (header.payload.signature)
+  /\bAKIA[0-9A-Z]{16}/g, // AWS access key id
+];
+
+/** A conservative default env allowlist for a locally-authenticated CLI subprocess — the CLI-auth / home /
+ *  proxy / cert vocabulary from `src/selfhost/ai.ts`'s `SUBSCRIPTION_CLI_ENV_ALLOWLIST`. Callers pass their
+ *  own when they need a different set (e.g. a coding-agent subprocess needing a larger allowlist). */
+export const DEFAULT_SUBPROCESS_ENV_ALLOWLIST: readonly string[] = [
+  "HOME",
+  "HTTPS_PROXY",
+  "HTTP_PROXY",
+  "LANG",
+  "LC_ALL",
+  "NODE_EXTRA_CA_CERTS",
+  "NO_PROXY",
+  "PATH",
+  "SSL_CERT_DIR",
+  "SSL_CERT_FILE",
+  "TERM",
+  "XDG_CONFIG_HOME",
+  "XDG_DATA_HOME",
+  "XDG_STATE_HOME",
+  "https_proxy",
+  "http_proxy",
+  "no_proxy",
+];
+
+export type BuildAllowlistedEnvOptions = {
+  /** Keys to carry from the parent env. Defaults to {@link DEFAULT_SUBPROCESS_ENV_ALLOWLIST}. */
+  allowlist?: readonly string[];
+  /** Extra vars overlaid after the allowlist (defined values win; `undefined` values are skipped). */
+  extra?: Record<string, string | undefined>;
+};
+
+/**
+ * Build a child-process env from `parent`, keeping ONLY the allowlisted keys that have a defined value, then
+ * overlaying `extra` (defined values win). This is the "strict allowlisted env, not the whole parent env"
+ * discipline from `subscriptionCliEnv` — credentials outside the allowlist never reach the subprocess. Pure:
+ * reads nothing external, mutates nothing, returns a new object.
+ */
+export function buildAllowlistedEnv(
+  parent: Record<string, string | undefined>,
+  options: BuildAllowlistedEnvOptions = {},
+): Record<string, string> {
+  const allowlist = options.allowlist ?? DEFAULT_SUBPROCESS_ENV_ALLOWLIST;
+  const child: Record<string, string> = {};
+  for (const key of allowlist) {
+    const value = parent[key];
+    if (value !== undefined) child[key] = value;
+  }
+  for (const [key, value] of Object.entries(options.extra ?? {})) {
+    if (value !== undefined) child[key] = value;
+  }
+  return child;
+}
+
+/**
+ * Redact secrets from untrusted text before it enters a log/error string. Strips the caller's known secret
+ * values exactly (length-guarded at ≥8 so a short/empty token can't blank unrelated text), then well-known
+ * token shapes from {@link SUBPROCESS_SECRET_PATTERNS}. Pure. Ported from `redactSecrets`.
+ */
+export function redactSubprocessSecrets(text: string, knownSecrets: readonly string[] = []): string {
+  let out = text;
+  for (const secret of knownSecrets) {
+    if (secret.length >= 8) out = out.split(secret).join("[redacted]");
+  }
+  for (const pattern of SUBPROCESS_SECRET_PATTERNS) out = out.replace(pattern, "[redacted]");
+  return out;
+}

--- a/packages/gittensory-engine/test/subprocess-env.test.ts
+++ b/packages/gittensory-engine/test/subprocess-env.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import {
+  buildAllowlistedEnv,
+  redactSubprocessSecrets,
+  DEFAULT_SUBPROCESS_ENV_ALLOWLIST,
+} from "../dist/index.js";
+
+// Structurally-valid but obviously-fake placeholder tokens (the same low-entropy / EXAMPLE convention the
+// repo's own secrets-scan tests use) — no real credential is present in this file.
+const FAKE = {
+  openai: "sk-ABCDEFGHIJKLMNOP0123",
+  github: "ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789",
+  githubPat: "github_pat_ABCDEFGHIJKLMNOPQRSTUV",
+  jwt: "eyJhbGciOi.eyJzdWIiOi.SIGNATUREXX",
+  aws: "AKIAIOSFODNN7EXAMPLE",
+};
+
+test("buildAllowlistedEnv keeps only allowlisted keys from the parent (default allowlist)", () => {
+  const child = buildAllowlistedEnv({
+    HOME: "/home/node",
+    PATH: "/usr/bin",
+    OPENAI_API_KEY: "should-not-pass", // not on the allowlist
+    ANTHROPIC_API_KEY: "should-not-pass",
+  });
+  assert.deepEqual(child, { HOME: "/home/node", PATH: "/usr/bin" }); // secrets excluded
+});
+
+test("buildAllowlistedEnv honors a caller-supplied allowlist, not just the default", () => {
+  const child = buildAllowlistedEnv(
+    { FOO: "1", BAR: "2", HOME: "/home/node" },
+    { allowlist: ["FOO", "BAR"] },
+  );
+  assert.deepEqual(child, { FOO: "1", BAR: "2" }); // HOME on the default list but not this caller's list, so excluded
+});
+
+test("buildAllowlistedEnv skips allowlisted keys absent from the parent", () => {
+  const child = buildAllowlistedEnv({ HOME: "/home/node" }); // PATH etc. absent
+  assert.deepEqual(child, { HOME: "/home/node" });
+});
+
+test("buildAllowlistedEnv overlays extra (defined wins, undefined is skipped)", () => {
+  const child = buildAllowlistedEnv(
+    { HOME: "/home/node", PATH: "/usr/bin" },
+    { extra: { PATH: "/opt/bin", CLAUDE_MODEL: "claude-sonnet-5", EMPTY: undefined } },
+  );
+  assert.equal(child.PATH, "/opt/bin"); // extra overrides the allowlisted value
+  assert.equal(child.CLAUDE_MODEL, "claude-sonnet-5"); // extra can add a non-allowlisted key
+  assert.equal("EMPTY" in child, false); // undefined extra is skipped
+  assert.equal(child.HOME, "/home/node");
+});
+
+test("DEFAULT_SUBPROCESS_ENV_ALLOWLIST includes the core CLI-auth/proxy/cert keys", () => {
+  for (const key of ["HOME", "PATH", "NODE_EXTRA_CA_CERTS", "HTTPS_PROXY"]) {
+    assert.ok(DEFAULT_SUBPROCESS_ENV_ALLOWLIST.includes(key), `missing ${key}`);
+  }
+});
+
+test("redactSubprocessSecrets redacts every well-known token shape", () => {
+  for (const [kind, tok] of Object.entries(FAKE)) {
+    const out = redactSubprocessSecrets(`stderr: leaked ${tok} here`);
+    assert.equal(out.includes(tok), false, `${kind} not redacted`);
+    assert.match(out, /\[redacted\]/);
+  }
+});
+
+test("redactSubprocessSecrets strips a caller-supplied known secret exactly (length-guarded ≥ 8)", () => {
+  const secret = "supersecrettokenvalue";
+  assert.match(redactSubprocessSecrets(`used ${secret}`, [secret]), /used \[redacted\]/);
+});
+
+test("redactSubprocessSecrets does NOT blank a short (<8) known secret, to protect unrelated text", () => {
+  const out = redactSubprocessSecrets("the value t appears in tent and butter", ["t"]);
+  assert.equal(out, "the value t appears in tent and butter"); // unchanged
+});
+
+test("redactSubprocessSecrets leaves ordinary text untouched", () => {
+  const clean = "run finished: 3 files changed, 0 errors";
+  assert.equal(redactSubprocessSecrets(clean), clean);
+});


### PR DESCRIPTION
Adds a shared, engine-hosted subprocess env-allowlist + secret-redaction helper (Closes #4284).

Today the pattern lives only in `src/selfhost/ai.ts` and isn't exported from the engine, so every future subprocess-spawning driver would copy-paste it. This promotes the reusable bits to `packages/gittensory-engine/src/miner/subprocess-env.ts`:

- **`buildAllowlistedEnv(parent, { allowlist?, extra? })`** — build a child env keeping only allowlisted keys (defined values), then overlaying `extra`. The allowlist is a **parameter** (generalized from `SUBSCRIPTION_CLI_ENV_ALLOWLIST`, which is exported as `DEFAULT_SUBPROCESS_ENV_ALLOWLIST`) since a coding-agent subprocess may need a different set than a review-only CLI call.
- **`redactSubprocessSecrets(text, knownSecrets?)`** + **`SUBPROCESS_SECRET_PATTERNS`** — strip known secret values (length-guarded ≥8) then well-known token shapes (OpenAI/Anthropic `sk-`, GitHub `gh*_`/`github_pat_`, JWT, AWS), carried over verbatim from `redactSecrets`/`SECRET_PATTERNS`.

Pure — strings/objects only, no IO, no `process.env` read, no spawning. The CLI-specific PATH synthesis (`resolveSubscriptionCliPath`) stays in `ai.ts`.

**Migration (deliberate, documented choice per the issue):** `src/selfhost/ai.ts` keeps its existing parallel copy for now; this module is the shared source of truth for **new** engine/miner subprocess code, with a follow-up shim possible (mirroring `src/rules/predicted-gate.ts` over the engine). Kept self-contained to the engine in this PR.

## Test
`test/subprocess-env.test.ts` — allowlist filtering (default + caller-supplied), absent-key skip, `extra` overlay (override / add / skip-undefined), each secret shape redacted, exact known-secret stripping, the <8 length-guard, and clean-text passthrough. Fixtures use obviously-fake placeholder tokens (the repo's own EXAMPLE convention). Full engine suite: 320 pass; `test:engine-parity` green.

- [x] Conventional Commit; focused; **Closes #4284**. No `site/`/`CNAME`/`**/lovable/**`; no `CHANGELOG.md`. New engine module + test + one entrypoint re-export.