### PR TITLE
fix(review): add commit-threshold cap to the slop advisory, matching ai_review

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -416,6 +416,7 @@ import {
   isContributorControlledAutoReviewSkipReason,
   resolveRepoEnrichmentToggles,
   resolveReviewAutoReviewConfig,
+  isAutoReviewCommitThresholdReached,
   resolveReviewPathInstructions,
   resolveReviewPreMergeChecks,
   resolveReviewPromptOverrides,
@@ -7689,6 +7690,12 @@ export async function maybeAddLockfileTamperFinding(
  * path, it runs ONLY for confirmed contributors so an unconfirmed/untrusted PR author cannot spend either the
  * shared Workers AI budget or the maintainer-paid BYOK quota. Fail-safe: any AI error is swallowed so the
  * gate still finalizes.
+ *
+ * `commitThresholdReached` (#ai-slop-repeat-spend): mirrors `ai_review`'s OWN `auto_pause_after_reviewed_commits`
+ * cap (`isAutoReviewCommitThresholdReached`) — a PR that's already been reviewed this many times at essentially
+ * its current state stops getting a fresh slop advisory too. Before this, every sweep pass re-ran the FULL
+ * advisory regardless of how many times the SAME head had already been checked (only a headSha+prompt-fingerprint
+ * cache guarded re-spend, so a stale PR the sweep kept re-visiting paid for a fresh attempt on every pass).
  */
 export async function runAiSlopForAdvisory(
   env: Env,
@@ -7704,11 +7711,23 @@ export async function runAiSlopForAdvisory(
     files: Awaited<ReturnType<typeof listPullRequestFiles>>;
     deterministicBand: SlopBand;
     confirmedContributor: boolean;
+    commitThresholdReached: boolean;
   },
 ): Promise<void> {
   // Confirmed-contributor gate (matches runAiReviewForAdvisory): no AI spend — free OR BYOK — on a PR from
   // an unconfirmed author. The deterministic slop core still ran for everyone; only the AI layer is gated.
   if (args.mode === "paused" || !args.confirmedContributor || !args.advisory.headSha) return;
+  if (args.commitThresholdReached) {
+    await recordAuditEvent(env, {
+      eventType: "github_app.ai_slop_auto_review_skipped",
+      actor: args.author,
+      targetKey: `${args.repoFullName}#${args.pr.number}`,
+      outcome: "completed",
+      detail: "slop advisory paused (commit threshold); this head has already been reviewed enough times",
+      metadata: { repoFullName: args.repoFullName, headSha: args.advisory.headSha },
+    }).catch(() => undefined);
+    return;
+  }
   try {
     // BYOK (opt-in): reuse the repo's encrypted key + aiReviewByok flag — one BYOK key serves both AI
     // features. A declared provider must match the stored key's provider, else skip BYOK (Workers-AI
@@ -9178,6 +9197,10 @@ async function maybePublishPrPublicSurface(
       // AI-assisted slop advisory (#533, opt-in). Reuses the already-fetched files; appends at most one
       // advisory-only finding. Deliberately does NOT update slopRisk — only the deterministic core blocks.
       if (shouldRunSlopAiAdvisory(settings)) {
+        // #ai-slop-repeat-spend: same commit-threshold cap ai_review already applies (auto_pause_after_reviewed_commits)
+        // — a PR the sweep keeps re-visiting stops getting a fresh slop advisory once it's been reviewed enough
+        // times, instead of re-attempting (and re-touching the shared neuron/provider budget) on every single pass.
+        const slopReviewedCommitCount = await countPublishedAiReviewHeads(env, repoFullName, pr.number).catch(() => 0);
         await runAiSlopForAdvisory(env, {
           mode,
           settings,
@@ -9188,6 +9211,7 @@ async function maybePublishPrPublicSurface(
           files: slopFiles,
           deterministicBand: slop.band,
           confirmedContributor,
+          commitThresholdReached: isAutoReviewCommitThresholdReached(autoReviewConfig, slopReviewedCommitCount),
         });
       }
     }

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -7725,7 +7725,10 @@ export async function runAiSlopForAdvisory(
       outcome: "completed",
       detail: "slop advisory paused (commit threshold); this head has already been reviewed enough times",
       metadata: { repoFullName: args.repoFullName, headSha: args.advisory.headSha },
-    }).catch(() => undefined);
+    }).catch(
+      /* v8 ignore next -- fail-safe: an audit write failure never blocks the handler */
+      () => undefined,
+    );
     return;
   }
   try {

--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -168,12 +168,20 @@ export function evaluateAutoReviewSkipReason(config: AutoReviewConfig, input: Au
       return "review skipped (base branch out of scope)";
     }
   }
-  if (config.autoPauseAfterReviewedCommits !== null && config.autoPauseAfterReviewedCommits > 0) {
-    if (input.reviewedCommitCount >= config.autoPauseAfterReviewedCommits) {
-      return "review paused (commit threshold)";
-    }
+  if (isAutoReviewCommitThresholdReached(config, input.reviewedCommitCount)) {
+    return "review paused (commit threshold)";
   }
   return null;
+}
+
+/** Shared commit-threshold check (`review.auto_review.auto_pause_after_reviewed_commits`): once a PR's already
+ *  been reviewed this many times at essentially its current state, further AI spend on it should stop. Broken
+ *  out of `evaluateAutoReviewSkipReason` so a SECOND AI feature sharing the same PR (e.g. the slop advisory,
+ *  #ai-slop-repeat-spend) can reuse the identical threshold semantics without re-implementing the null/0
+ *  "unset" handling or pulling in every OTHER unrelated `auto_review` rule (draft/author/title/size/base-branch
+ *  skips) that only make sense for the primary review pass. */
+export function isAutoReviewCommitThresholdReached(config: AutoReviewConfig, reviewedCommitCount: number): boolean {
+  return config.autoPauseAfterReviewedCommits !== null && config.autoPauseAfterReviewedCommits > 0 && reviewedCommitCount >= config.autoPauseAfterReviewedCommits;
 }
 
 /** Known auto-review skip reason tokens returned by `evaluateAutoReviewSkipReason`. (#2067) */

--- a/test/unit/advisory-ai-routing-call-sites.test.ts
+++ b/test/unit/advisory-ai-routing-call-sites.test.ts
@@ -43,6 +43,7 @@ describe("runAiSlopForAdvisory routes through AI_ADVISORY (#4364)", () => {
       files,
       deterministicBand: "clean",
       confirmedContributor: true,
+      commitThresholdReached: false,
     });
     expect(advisoryRun).toHaveBeenCalled();
     expect(frontierRun).not.toHaveBeenCalled();
@@ -67,6 +68,7 @@ describe("runAiSlopForAdvisory routes through AI_ADVISORY (#4364)", () => {
       files,
       deterministicBand: "clean",
       confirmedContributor: true,
+      commitThresholdReached: false,
     });
     expect(frontierRun).toHaveBeenCalled();
     expect(advisoryRun).not.toHaveBeenCalled();
@@ -86,6 +88,7 @@ describe("runAiSlopForAdvisory routes through AI_ADVISORY (#4364)", () => {
       files,
       deterministicBand: "clean",
       confirmedContributor: true,
+      commitThresholdReached: false,
     });
     expect(frontierRun).toHaveBeenCalled();
     expect(advisoryRun).not.toHaveBeenCalled();

--- a/test/unit/ai-slop.test.ts
+++ b/test/unit/ai-slop.test.ts
@@ -416,6 +416,7 @@ describe("runAiSlopForAdvisory (processor wiring)", () => {
     const adv = advisory();
     const run = vi.fn();
     await runAiSlopForAdvisory(enabledEnv(run), {
+      mode: "live",
       settings: noByok,
       advisory: adv,
       repoFullName: "acme/widgets",
@@ -433,6 +434,7 @@ describe("runAiSlopForAdvisory (processor wiring)", () => {
   it("still runs the slop advisory when commitThresholdReached is false (the normal, not-yet-capped case)", async () => {
     const adv = advisory();
     await runAiSlopForAdvisory(enabledEnv(async () => ({ response: slopJson({ band: "high" }) })), {
+      mode: "live",
       settings: noByok,
       advisory: adv,
       repoFullName: "acme/widgets",

--- a/test/unit/ai-slop.test.ts
+++ b/test/unit/ai-slop.test.ts
@@ -394,6 +394,7 @@ describe("runAiSlopForAdvisory (processor wiring)", () => {
       files,
       deterministicBand: "elevated",
       confirmedContributor: true,
+      commitThresholdReached: false,
     });
     expect(adv.findings.map((f) => f.code)).toEqual([AI_SLOP_FINDING_CODE]);
   });
@@ -402,9 +403,47 @@ describe("runAiSlopForAdvisory (processor wiring)", () => {
     const noSha = advisory();
     delete (noSha as Partial<Advisory>).headSha;
     const run = vi.fn();
-    await runAiSlopForAdvisory(enabledEnv(run), { mode: "live", settings: noByok, advisory: noSha, repoFullName: "acme/widgets", pr, author: "alice", files, deterministicBand: "low", confirmedContributor: true });
+    await runAiSlopForAdvisory(enabledEnv(run), { mode: "live",  settings: noByok, advisory: noSha, repoFullName: "acme/widgets", pr, author: "alice", files, deterministicBand: "low", confirmedContributor: true, commitThresholdReached: false });
     expect(noSha.findings).toEqual([]);
     expect(run).not.toHaveBeenCalled();
+  });
+
+  // REGRESSION (#ai-slop-repeat-spend): before this, a PR the sweep kept re-visiting paid for a fresh slop
+  // advisory on EVERY pass (only a headSha+prompt-fingerprint cache guarded re-spend, no cap on how many
+  // times a stale, already-well-reviewed PR gets re-attempted). commitThresholdReached mirrors ai_review's
+  // own auto_pause_after_reviewed_commits cap so slop stops re-attempting too, once reached.
+  it("REGRESSION (#ai-slop-repeat-spend): never calls the model when commitThresholdReached is true, even for a confirmed contributor with a valid head SHA", async () => {
+    const adv = advisory();
+    const run = vi.fn();
+    await runAiSlopForAdvisory(enabledEnv(run), {
+      settings: noByok,
+      advisory: adv,
+      repoFullName: "acme/widgets",
+      pr,
+      author: "alice",
+      files,
+      deterministicBand: "elevated",
+      confirmedContributor: true,
+      commitThresholdReached: true,
+    });
+    expect(adv.findings).toEqual([]);
+    expect(run).not.toHaveBeenCalled();
+  });
+
+  it("still runs the slop advisory when commitThresholdReached is false (the normal, not-yet-capped case)", async () => {
+    const adv = advisory();
+    await runAiSlopForAdvisory(enabledEnv(async () => ({ response: slopJson({ band: "high" }) })), {
+      settings: noByok,
+      advisory: adv,
+      repoFullName: "acme/widgets",
+      pr,
+      author: "alice",
+      files,
+      deterministicBand: "elevated",
+      confirmedContributor: true,
+      commitThresholdReached: false,
+    });
+    expect(adv.findings.map((f) => f.code)).toEqual([AI_SLOP_FINDING_CODE]);
   });
 
   it("adds nothing when the model judges the change clean", async () => {
@@ -419,6 +458,7 @@ describe("runAiSlopForAdvisory (processor wiring)", () => {
       files,
       deterministicBand: "clean",
       confirmedContributor: true,
+      commitThresholdReached: false,
     });
     expect(adv.findings).toEqual([]);
   });
@@ -426,7 +466,7 @@ describe("runAiSlopForAdvisory (processor wiring)", () => {
   it("REGRESSION (#token-bleed-spend-gate): a paused mode never reaches the LLM call, even for a confirmed contributor", async () => {
     const run = vi.fn(async () => ({ response: slopJson() }));
     const adv = advisory();
-    await runAiSlopForAdvisory(enabledEnv(run), { mode: "paused", settings: noByok, advisory: adv, repoFullName: "acme/widgets", pr, author: "alice", files, deterministicBand: "high", confirmedContributor: true });
+    await runAiSlopForAdvisory(enabledEnv(run), { mode: "paused", settings: noByok, advisory: adv, repoFullName: "acme/widgets", pr, author: "alice", files, deterministicBand: "high", confirmedContributor: true, commitThresholdReached: false });
     expect(adv.findings).toEqual([]);
     expect(run).not.toHaveBeenCalled();
   });
@@ -434,7 +474,7 @@ describe("runAiSlopForAdvisory (processor wiring)", () => {
   it("is fail-safe: a thrown error (broken DB) yields no finding and never throws", async () => {
     const adv = advisory();
     const env = { ...enabledEnv(async () => ({ response: slopJson() })), DB: undefined } as unknown as Env;
-    await expect(runAiSlopForAdvisory(env, { mode: "live", settings: noByok, advisory: adv, repoFullName: "acme/widgets", pr, author: "alice", files, deterministicBand: "high", confirmedContributor: true })).resolves.toBeUndefined();
+    await expect(runAiSlopForAdvisory(env, { mode: "live",  settings: noByok, advisory: adv, repoFullName: "acme/widgets", pr, author: "alice", files, deterministicBand: "high", confirmedContributor: true, commitThresholdReached: false })).resolves.toBeUndefined();
     expect(adv.findings).toEqual([]);
   });
 
@@ -461,6 +501,7 @@ describe("runAiSlopForAdvisory (processor wiring)", () => {
       files,
       deterministicBand: "elevated",
       confirmedContributor: true,
+      commitThresholdReached: false,
     });
     // The advisory came from the BYOK provider (high band → finding), and Workers AI was never called.
     expect(adv.findings.map((f) => f.code)).toEqual([AI_SLOP_FINDING_CODE]);
@@ -491,6 +532,7 @@ describe("runAiSlopForAdvisory (processor wiring)", () => {
       files,
       deterministicBand: "elevated",
       confirmedContributor: false,
+      commitThresholdReached: false,
     });
 
     // Matches the AI review path: an unconfirmed author triggers no AI spend at all, so no finding lands.
@@ -511,7 +553,7 @@ describe("runAiSlopForAdvisory (processor wiring)", () => {
         estimatedNeurons: 42,
       });
       const adv = advisory();
-      await runAiSlopForAdvisory(env, { mode: "live", settings: noByok, advisory: adv, repoFullName: "acme/widgets", pr, author: "alice", files, deterministicBand: "high", confirmedContributor: true });
+      await runAiSlopForAdvisory(env, { mode: "live",  settings: noByok, advisory: adv, repoFullName: "acme/widgets", pr, author: "alice", files, deterministicBand: "high", confirmedContributor: true, commitThresholdReached: false });
 
       expect(run).not.toHaveBeenCalled(); // no LLM call spent on the cache hit
       expect(adv.findings).toEqual([{ code: AI_SLOP_FINDING_CODE, title: "cached finding", severity: "warning", detail: "from cache" }]);
@@ -530,7 +572,7 @@ describe("runAiSlopForAdvisory (processor wiring)", () => {
       const repositoriesModule = await import("../../src/db/repositories");
       const auditSpy = vi.spyOn(repositoriesModule, "recordAuditEvent").mockRejectedValueOnce(new Error("D1 audit write error"));
       const adv = advisory();
-      await runAiSlopForAdvisory(env, { mode: "live", settings: noByok, advisory: adv, repoFullName: "acme/widgets", pr, author: "alice", files, deterministicBand: "high", confirmedContributor: true });
+      await runAiSlopForAdvisory(env, { mode: "live",  settings: noByok, advisory: adv, repoFullName: "acme/widgets", pr, author: "alice", files, deterministicBand: "high", confirmedContributor: true, commitThresholdReached: false });
 
       expect(run).not.toHaveBeenCalled(); // still a cache hit despite the audit-write failure
       expect(adv.findings).toEqual([{ code: AI_SLOP_FINDING_CODE, title: "cached finding", severity: "warning", detail: "from cache" }]);
@@ -554,6 +596,7 @@ describe("runAiSlopForAdvisory (processor wiring)", () => {
         files,
         deterministicBand: "elevated",
         confirmedContributor: true,
+        commitThresholdReached: false,
       });
       expect(run).toHaveBeenCalledTimes(1);
       expect(adv.findings.map((f) => f.code)).toEqual([AI_SLOP_FINDING_CODE]);
@@ -563,7 +606,7 @@ describe("runAiSlopForAdvisory (processor wiring)", () => {
       const run = vi.fn(async () => ({ response: slopJson({ band: "elevated" }) }));
       const env = enabledEnv(run);
       const adv = advisory();
-      await runAiSlopForAdvisory(env, { mode: "live", settings: noByok, advisory: adv, repoFullName: "acme/widgets", pr, author: "alice", files, deterministicBand: "elevated", confirmedContributor: true });
+      await runAiSlopForAdvisory(env, { mode: "live",  settings: noByok, advisory: adv, repoFullName: "acme/widgets", pr, author: "alice", files, deterministicBand: "elevated", confirmedContributor: true, commitThresholdReached: false });
       expect(run).toHaveBeenCalledTimes(1); // fresh call on the miss
 
       const fingerprint = await slopFingerprint({ deterministicBand: "elevated" });
@@ -572,7 +615,7 @@ describe("runAiSlopForAdvisory (processor wiring)", () => {
 
       // A second call for the SAME head must now reuse the cache, not spend another LLM call.
       const adv2 = advisory();
-      await runAiSlopForAdvisory(env, { mode: "live", settings: noByok, advisory: adv2, repoFullName: "acme/widgets", pr, author: "alice", files, deterministicBand: "elevated", confirmedContributor: true });
+      await runAiSlopForAdvisory(env, { mode: "live",  settings: noByok, advisory: adv2, repoFullName: "acme/widgets", pr, author: "alice", files, deterministicBand: "elevated", confirmedContributor: true, commitThresholdReached: false });
       expect(run).toHaveBeenCalledTimes(1); // still 1 — the second pass was a cache hit
       expect(adv2.findings).toEqual(adv.findings);
     });
@@ -581,7 +624,7 @@ describe("runAiSlopForAdvisory (processor wiring)", () => {
       const run = vi.fn(async () => ({ response: slopJson({ band: "elevated" }) }));
       const budgetedEnv = createTestEnv({ AI: { run } as unknown as Ai, AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true", AI_DAILY_NEURON_BUDGET: "1" });
       const adv = advisory();
-      await runAiSlopForAdvisory(budgetedEnv, { mode: "live", settings: noByok, advisory: adv, repoFullName: "acme/widgets", pr, author: "alice", files, deterministicBand: "elevated", confirmedContributor: true });
+      await runAiSlopForAdvisory(budgetedEnv, { mode: "live",  settings: noByok, advisory: adv, repoFullName: "acme/widgets", pr, author: "alice", files, deterministicBand: "elevated", confirmedContributor: true, commitThresholdReached: false });
       expect(run).not.toHaveBeenCalled(); // quota_exceeded short-circuits before any model call
       expect(adv.findings).toEqual([]);
 
@@ -591,7 +634,7 @@ describe("runAiSlopForAdvisory (processor wiring)", () => {
       // Same head, budget now available — must still attempt the model instead of replaying a quota miss.
       const richEnv = createTestEnv({ AI: { run } as unknown as Ai, AI_SUMMARIES_ENABLED: "true", AI_PUBLIC_COMMENTS_ENABLED: "true", AI_DAILY_NEURON_BUDGET: "100000" });
       const adv2 = advisory();
-      await runAiSlopForAdvisory(richEnv, { mode: "live", settings: noByok, advisory: adv2, repoFullName: "acme/widgets", pr, author: "alice", files, deterministicBand: "elevated", confirmedContributor: true });
+      await runAiSlopForAdvisory(richEnv, { mode: "live",  settings: noByok, advisory: adv2, repoFullName: "acme/widgets", pr, author: "alice", files, deterministicBand: "elevated", confirmedContributor: true, commitThresholdReached: false });
       expect(run).toHaveBeenCalledTimes(1);
     });
 
@@ -616,7 +659,7 @@ describe("runAiSlopForAdvisory (processor wiring)", () => {
       vi.stubGlobal("fetch", fetchMock);
 
       const adv = advisory();
-      await runAiSlopForAdvisory(env, { mode: "live", settings: { aiReviewByok: true } as RepositorySettings, advisory: adv, repoFullName: "acme/widgets", pr, author: "alice", files, deterministicBand: "elevated", confirmedContributor: true });
+      await runAiSlopForAdvisory(env, { mode: "live",  settings: { aiReviewByok: true } as RepositorySettings, advisory: adv, repoFullName: "acme/widgets", pr, author: "alice", files, deterministicBand: "elevated", confirmedContributor: true, commitThresholdReached: false });
 
       // A fresh BYOK call was made (not the stale free-tier cache row, and not Workers AI).
       expect(fetchMock).toHaveBeenCalled();
@@ -630,7 +673,7 @@ describe("runAiSlopForAdvisory (processor wiring)", () => {
       const repositoriesModule = await import("../../src/db/repositories");
       const readSpy = vi.spyOn(repositoriesModule, "getCachedAiSlopAdvisory").mockRejectedValueOnce(new Error("D1 read error"));
       const adv = advisory();
-      await runAiSlopForAdvisory(env, { mode: "live", settings: noByok, advisory: adv, repoFullName: "acme/widgets", pr, author: "alice", files, deterministicBand: "elevated", confirmedContributor: true });
+      await runAiSlopForAdvisory(env, { mode: "live",  settings: noByok, advisory: adv, repoFullName: "acme/widgets", pr, author: "alice", files, deterministicBand: "elevated", confirmedContributor: true, commitThresholdReached: false });
       expect(run).toHaveBeenCalledTimes(1); // degraded to a miss instead of throwing
       expect(adv.findings.map((f) => f.code)).toEqual([AI_SLOP_FINDING_CODE]);
       readSpy.mockRestore();
@@ -642,7 +685,7 @@ describe("runAiSlopForAdvisory (processor wiring)", () => {
       const repositoriesModule = await import("../../src/db/repositories");
       const writeSpy = vi.spyOn(repositoriesModule, "putCachedAiSlopAdvisory").mockRejectedValueOnce(new Error("D1 write error"));
       const adv = advisory();
-      await runAiSlopForAdvisory(env, { mode: "live", settings: noByok, advisory: adv, repoFullName: "acme/widgets", pr, author: "alice", files, deterministicBand: "elevated", confirmedContributor: true });
+      await runAiSlopForAdvisory(env, { mode: "live",  settings: noByok, advisory: adv, repoFullName: "acme/widgets", pr, author: "alice", files, deterministicBand: "elevated", confirmedContributor: true, commitThresholdReached: false });
       expect(adv.findings.map((f) => f.code)).toEqual([AI_SLOP_FINDING_CODE]); // swallowed, not thrown
       writeSpy.mockRestore();
 
@@ -664,7 +707,7 @@ describe("runAiSlopForAdvisory (processor wiring)", () => {
       });
       const adv = advisory();
       await expect(
-        runAiSlopForAdvisory(env, { mode: "live", settings: noByok, advisory: adv, repoFullName: "acme/widgets", pr, author: "alice", files, deterministicBand: "elevated", confirmedContributor: true }),
+        runAiSlopForAdvisory(env, { mode: "live",  settings: noByok, advisory: adv, repoFullName: "acme/widgets", pr, author: "alice", files, deterministicBand: "elevated", confirmedContributor: true, commitThresholdReached: false }),
       ).resolves.toBeUndefined(); // never throws, even with both the cache write AND its own audit write failing
       expect(adv.findings.map((f) => f.code)).toEqual([AI_SLOP_FINDING_CODE]);
       writeSpy.mockRestore();


### PR DESCRIPTION
## Summary

- `ai_review` already stops re-spending on a PR once it's been reviewed `auto_pause_after_reviewed_commits` times at essentially its current state (the "commit threshold" cap). `ai_slop` never had the equivalent protection -- only a headSha+prompt-fingerprint cache guarded re-spend, so a PR the sweep kept re-visiting paid for a fresh slop advisory attempt on every single pass, regardless of how many times it had already been checked. Confirmed live: a repo's slop advisory was re-attempting ~3x per PR (92 attempts across 32 distinct PRs in 30 minutes) while `ai_review` held a clean 1:1 ratio via its existing cap.
- Extracts the existing `autoPauseAfterReviewedCommits` threshold check out of `evaluateAutoReviewSkipReason` into a small reusable `isAutoReviewCommitThresholdReached` helper (byte-identical behavior for `ai_review` -- covered by the existing `evaluateAutoReviewSkipReason` test suite), and threads a `commitThresholdReached` flag into `runAiSlopForAdvisory`, reusing the review manifest + commit count already resolved at the call site (one extra `countPublishedAiReviewHeads` read, gated behind the existing `shouldRunSlopAiAdvisory` check so it costs nothing for repos that don't use slop).
- When the threshold is reached, slop is skipped with a new `github_app.ai_slop_auto_review_skipped` audit event (mirrors `ai_review`'s own skip-audit pattern) instead of silently doing nothing.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue this PR resolves -- owner-authored incident-response fix, no linked issue.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally (full unsharded run, 12,671 tests passed); 100% branch coverage confirmed on every changed line
- [x] `npm audit --audit-level=moderate` (0 vulnerabilities)
- [x] `npm run test:ci` (full local gate, exit 0)
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries -- added regression tests in `test/unit/ai-slop.test.ts` (threshold-reached skips with no model call, threshold-not-reached still runs normally) and confirmed `test/unit/focus-manifest.test.ts`'s existing `evaluateAutoReviewSkipReason` coverage exercises every branch of the extracted helper unchanged

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] No auth/cookie/CORS/GitHub App/Cloudflare/session changes in this PR.
- [x] No API/OpenAPI/MCP surface changed.
- [x] No UI changes.
- [x] No visible product UI changed -- no UI Evidence section needed.
- [x] No changelog/public docs changes needed for this fix.