### PR TITLE
test(config): lock in review.culture_profile parser for dashboard config (#1683)

### DIFF
--- a/test/unit/config-templates.test.ts
+++ b/test/unit/config-templates.test.ts
@@ -126,6 +126,20 @@ describe("config/examples review templates (#1682)", () => {
     expect(resolveReviewPromptOverrides(off).impactMap).toBe(false);
   });
 
+  it("resolves review.culture_profile via manifest parse + boolean helper (#1683)", () => {
+    const full = readConfigExample("gittensory.full.yml");
+    expect(full).toMatch(/# culture_profile:/);
+    expect(parseFocusManifest({}).review.cultureProfile).toBeNull();
+    expect(resolveReviewPromptOverrides(parseFocusManifest({})).cultureProfile).toBe(false);
+    const on = parseFocusManifest({ review: { culture_profile: true } });
+    expect(on.review.cultureProfile).toBe(true);
+    expect(resolveReviewPromptOverrides(on).cultureProfile).toBe(true);
+    expect(reviewConfigToJson(on.review)).toEqual({ culture_profile: true });
+    const off = parseFocusManifest({ review: { culture_profile: false } });
+    expect(off.review.cultureProfile).toBe(false);
+    expect(resolveReviewPromptOverrides(off).cultureProfile).toBe(false);
+  });
+
   it("parses gittensory.minimal.yml with zero warnings and enables no agent actions", () => {
     const manifest = parseFocusManifestContent(readConfigExample("gittensory.minimal.yml"), "repo_file");
     expect(manifest.warnings).toEqual([]);


### PR DESCRIPTION
Closes #1683

## Summary
- Add a config-templates inventory test that locks in the shipped `review.culture_profile` parser plumbing the dashboard generator must share: docs entry in `gittensory.full.yml`, manifest parse round-trip, and `resolveReviewPromptOverrides` boolean helper (unset → false).

## Validation
- `npx vitest run test/unit/config-templates.test.ts`

## UI Evidence
N/A — test-only.
