### PR TITLE
feat(miner-config): parse a feasibility-gate policy block from .gittensory-miner.yml

### DIFF
--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -234,6 +234,7 @@ export {
   parseMinerGoalSpecContent,
   discoverMinerGoalSpecPath,
   MINER_GOAL_SPEC_FILENAMES,
+  type MinerFeasibilityGate,
   type MinerGoalSpec,
   type MinerIssueDiscoveryPolicy,
   type ParsedMinerGoalSpec,

--- a/packages/gittensory-engine/src/miner-goal-spec.ts
+++ b/packages/gittensory-engine/src/miner-goal-spec.ts
@@ -10,6 +10,27 @@ import { parse as parseYaml } from "yaml";
 /** How strongly opening discovery issues is encouraged for this repo. Mirrors the review-side policy vocabulary. */
 export type MinerIssueDiscoveryPolicy = "encouraged" | "neutral" | "discouraged";
 
+/**
+ * Per-repo tuning for the miner's feasibility gate — how selective a miner is about which candidate issues it
+ * deems workable before spending effort. Additive and OFF by default: with {@link DEFAULT_MINER_GOAL_SPEC}'s
+ * values the gate never blocks, so a repo with no `feasibilityGate` block behaves exactly as before. The gate's
+ * composer (a separate issue) is the consumer; this is only the config surface a maintainer tunes.
+ */
+export type MinerFeasibilityGate = {
+  /**
+   * Minimum feasibility score, in `[0, 1]`, a candidate must reach for a miner to pursue it. Default: `0` — no
+   * floor, so the gate stays inert until a maintainer opts in. The parser clamps out-of-range or non-finite input
+   * into `[0, 1]` (with a warning) rather than rejecting it.
+   */
+  minFeasibilityScore: number;
+  /**
+   * Feasibility "avoid" reason keys this repo opts to DOWNGRADE from blocking to advisory — a maintainer's way to
+   * say "that reason does not apply here." Free-form string list; the composer owns the reason vocabulary, so the
+   * config stays tolerant of unknown keys. Default: `[]` (suppress nothing).
+   */
+  suppressedAvoidReasons: readonly string[];
+};
+
 /** Per-repo miner configuration parsed from `.gittensory-miner.yml`. See {@link DEFAULT_MINER_GOAL_SPEC}. */
 export type MinerGoalSpec = {
   /**
@@ -49,6 +70,11 @@ export type MinerGoalSpec = {
    * Default: neutral.
    */
   issueDiscoveryPolicy: MinerIssueDiscoveryPolicy;
+  /**
+   * Per-repo feasibility-gate tuning. Default: an inert gate (score floor `0`, nothing suppressed), so the field
+   * is fully additive — a repo that omits it behaves exactly as before. See {@link MinerFeasibilityGate}.
+   */
+  feasibilityGate: MinerFeasibilityGate;
 };
 
 /** The tolerant parser result for `.gittensory-miner.yml`: the normalized spec plus parse warnings and whether the
@@ -77,6 +103,7 @@ export const DEFAULT_MINER_GOAL_SPEC: Readonly<MinerGoalSpec> = Object.freeze({
   blockedLabels: Object.freeze([]),
   maxConcurrentClaims: 1,
   issueDiscoveryPolicy: "neutral",
+  feasibilityGate: Object.freeze({ minFeasibilityScore: 0, suppressedAvoidReasons: Object.freeze([]) }),
 });
 
 const MAX_MINER_GOAL_SPEC_BYTES = 32_768;
@@ -90,6 +117,14 @@ function cloneDefaultMinerGoalSpec(): MinerGoalSpec {
     blockedPaths: [...DEFAULT_MINER_GOAL_SPEC.blockedPaths],
     preferredLabels: [...DEFAULT_MINER_GOAL_SPEC.preferredLabels],
     blockedLabels: [...DEFAULT_MINER_GOAL_SPEC.blockedLabels],
+    feasibilityGate: cloneDefaultFeasibilityGate(),
+  };
+}
+
+function cloneDefaultFeasibilityGate(): MinerFeasibilityGate {
+  return {
+    minFeasibilityScore: DEFAULT_MINER_GOAL_SPEC.feasibilityGate.minFeasibilityScore,
+    suppressedAvoidReasons: [...DEFAULT_MINER_GOAL_SPEC.feasibilityGate.suppressedAvoidReasons],
   };
 }
 
@@ -173,6 +208,46 @@ function utf8ByteLength(value: string): number {
   return bytes;
 }
 
+function normalizeFeasibilityGate(value: unknown, warnings: string[]): MinerFeasibilityGate {
+  if (value === undefined || value === null) return cloneDefaultFeasibilityGate();
+  if (typeof value !== "object" || Array.isArray(value)) {
+    warnings.push(
+      `MinerGoalSpec field "feasibilityGate" must be a mapping; ignoring a ${Array.isArray(value) ? "array" : typeof value} value.`,
+    );
+    return cloneDefaultFeasibilityGate();
+  }
+  const record = value as Record<string, unknown>;
+  return {
+    minFeasibilityScore: normalizeUnitScore(
+      record.minFeasibilityScore,
+      "feasibilityGate.minFeasibilityScore",
+      DEFAULT_MINER_GOAL_SPEC.feasibilityGate.minFeasibilityScore,
+      warnings,
+    ),
+    suppressedAvoidReasons: normalizeStringList(
+      record.suppressedAvoidReasons,
+      "feasibilityGate.suppressedAvoidReasons",
+      warnings,
+    ),
+  };
+}
+
+/** Normalize a `[0, 1]` score: a non-finite/non-number value falls back to `fallback`; an out-of-range finite value
+ *  clamps into `[0, 1]`. Both cases warn, matching the tolerant "degrade, don't throw" convention of this parser. */
+function normalizeUnitScore(value: unknown, field: string, fallback: number, warnings: string[]): number {
+  if (value === undefined || value === null) return fallback;
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    warnings.push(`MinerGoalSpec field "${field}" must be a number in [0, 1]; falling back to ${fallback}.`);
+    return fallback;
+  }
+  if (value < 0 || value > 1) {
+    const clamped = Math.min(1, Math.max(0, value));
+    warnings.push(`MinerGoalSpec field "${field}" was outside [0, 1]; clamped to ${clamped}.`);
+    return clamped;
+  }
+  return value;
+}
+
 function hasConfiguredGoalFields(spec: MinerGoalSpec): boolean {
   return (
     spec.minerEnabled !== DEFAULT_MINER_GOAL_SPEC.minerEnabled ||
@@ -181,7 +256,9 @@ function hasConfiguredGoalFields(spec: MinerGoalSpec): boolean {
     spec.preferredLabels.length > 0 ||
     spec.blockedLabels.length > 0 ||
     spec.maxConcurrentClaims !== DEFAULT_MINER_GOAL_SPEC.maxConcurrentClaims ||
-    spec.issueDiscoveryPolicy !== DEFAULT_MINER_GOAL_SPEC.issueDiscoveryPolicy
+    spec.issueDiscoveryPolicy !== DEFAULT_MINER_GOAL_SPEC.issueDiscoveryPolicy ||
+    spec.feasibilityGate.minFeasibilityScore !== DEFAULT_MINER_GOAL_SPEC.feasibilityGate.minFeasibilityScore ||
+    spec.feasibilityGate.suppressedAvoidReasons.length > 0
   );
 }
 
@@ -222,6 +299,7 @@ export function parseMinerGoalSpec(raw: unknown): ParsedMinerGoalSpec {
       DEFAULT_MINER_GOAL_SPEC.issueDiscoveryPolicy,
       warnings,
     ),
+    feasibilityGate: normalizeFeasibilityGate(record.feasibilityGate, warnings),
   };
   if (!hasConfiguredGoalFields(spec)) {
     warnings.push("MinerGoalSpec contained no recognized non-default goal fields; falling back to safe defaults.");

--- a/packages/gittensory-engine/test/miner-goal-spec-parser.test.ts
+++ b/packages/gittensory-engine/test/miner-goal-spec-parser.test.ts
@@ -45,8 +45,44 @@ test("parseMinerGoalSpec: valid raw config normalizes every field and keeps non-
     blockedLabels: ["duplicate"],
     maxConcurrentClaims: 2,
     issueDiscoveryPolicy: "encouraged",
+    feasibilityGate: { minFeasibilityScore: 0, suppressedAvoidReasons: [] }, // omitted → inert default
   });
   assert.deepEqual(parsed.warnings, []);
+});
+
+test("parseMinerGoalSpec: a feasibilityGate block normalizes score + suppressed reasons and marks the spec present", () => {
+  const parsed = parseMinerGoalSpec({
+    feasibilityGate: {
+      minFeasibilityScore: 0.4,
+      suppressedAvoidReasons: ["missing_local_test_harness", " missing_local_test_harness ", "", "no_ci"],
+    },
+  });
+  assert.equal(parsed.present, true); // a feasibilityGate-only config is still a non-default (present) spec
+  assert.deepEqual(parsed.spec.feasibilityGate, {
+    minFeasibilityScore: 0.4,
+    suppressedAvoidReasons: ["missing_local_test_harness", "no_ci"], // trimmed, de-duped, blanks dropped
+  });
+  assert.deepEqual(parsed.warnings, []);
+});
+
+test("parseMinerGoalSpec: feasibilityGate.minFeasibilityScore clamps out-of-range and rejects non-numbers with a warning", () => {
+  const high = parseMinerGoalSpec({ feasibilityGate: { minFeasibilityScore: 1.5 } });
+  assert.equal(high.spec.feasibilityGate.minFeasibilityScore, 1);
+  assert.match(high.warnings.join(" "), /minFeasibilityScore.*clamped to 1/i);
+
+  const low = parseMinerGoalSpec({ feasibilityGate: { minFeasibilityScore: -2 } });
+  assert.equal(low.spec.feasibilityGate.minFeasibilityScore, 0);
+  assert.match(low.warnings.join(" "), /minFeasibilityScore.*clamped to 0/i);
+
+  const bad = parseMinerGoalSpec({ feasibilityGate: { minFeasibilityScore: "high" } });
+  assert.equal(bad.spec.feasibilityGate.minFeasibilityScore, 0);
+  assert.match(bad.warnings.join(" "), /minFeasibilityScore.*must be a number/i);
+});
+
+test("parseMinerGoalSpec: a non-mapping feasibilityGate degrades to the inert default with a warning", () => {
+  const parsed = parseMinerGoalSpec({ feasibilityGate: ["nope"] });
+  assert.deepEqual(parsed.spec.feasibilityGate, DEFAULT_MINER_GOAL_SPEC.feasibilityGate);
+  assert.match(parsed.warnings.join(" "), /feasibilityGate.*must be a mapping/i);
 });
 
 test("parseMinerGoalSpec: exactly 100 unique entries are accepted without a cap warning", () => {

--- a/packages/gittensory-engine/test/miner-goal-spec.test.ts
+++ b/packages/gittensory-engine/test/miner-goal-spec.test.ts
@@ -19,6 +19,7 @@ test("DEFAULT_MINER_GOAL_SPEC carries the documented safe defaults", () => {
     blockedLabels: [],
     maxConcurrentClaims: 1,
     issueDiscoveryPolicy: "neutral",
+    feasibilityGate: { minFeasibilityScore: 0, suppressedAvoidReasons: [] }, // inert gate — additive default
   });
 });
 
@@ -28,12 +29,15 @@ test("DEFAULT_MINER_GOAL_SPEC is deep-frozen so the shared singleton can't be mu
   assert.ok(Object.isFrozen(DEFAULT_MINER_GOAL_SPEC.blockedPaths));
   assert.ok(Object.isFrozen(DEFAULT_MINER_GOAL_SPEC.preferredLabels));
   assert.ok(Object.isFrozen(DEFAULT_MINER_GOAL_SPEC.blockedLabels));
+  assert.ok(Object.isFrozen(DEFAULT_MINER_GOAL_SPEC.feasibilityGate));
+  assert.ok(Object.isFrozen(DEFAULT_MINER_GOAL_SPEC.feasibilityGate.suppressedAvoidReasons));
 });
 
 test("DEFAULT_MINER_GOAL_SPEC exposes exactly the specified field surface", () => {
   assert.deepEqual(Object.keys(DEFAULT_MINER_GOAL_SPEC).sort(), [
     "blockedLabels",
     "blockedPaths",
+    "feasibilityGate",
     "issueDiscoveryPolicy",
     "maxConcurrentClaims",
     "minerEnabled",

--- a/packages/gittensory-miner/docs/miner-goal-spec.md
+++ b/packages/gittensory-miner/docs/miner-goal-spec.md
@@ -49,3 +49,21 @@ Maximum issues one miner may hold claimed on this repo at once.
 ### `issueDiscoveryPolicy` (`encouraged` | `neutral` | `discouraged`, default: `neutral`)
 
 How strongly this repo encourages a miner to open discovery issues.
+
+### `feasibilityGate` (mapping, default: inert)
+
+Per-repo tuning for the miner's feasibility gate — how selective a miner is about which candidate issues it deems workable before spending effort. Additive and OFF by default: with the defaults below the gate never blocks, so a repo that omits this block behaves exactly as before.
+
+| Sub-field | Type | Default | Meaning |
+|-----------|------|---------|---------|
+| `minFeasibilityScore` | number in `[0, 1]` | `0` | Minimum feasibility score a candidate must reach for a miner to pursue it. `0` means no floor. Out-of-range or non-finite values clamp into `[0, 1]` with a warning. |
+| `suppressedAvoidReasons` | string list | `[]` | Feasibility "avoid" reason keys this repo downgrades from blocking to advisory ("that reason does not apply here"). Free-form; unknown keys are tolerated. |
+
+```yaml
+feasibilityGate:
+  minFeasibilityScore: 0.4
+  suppressedAvoidReasons:
+    - missing_local_test_harness
+```
+
+The feasibility-gate composer (a separate change) is the consumer of this block; this is only the config surface a maintainer tunes.

--- a/packages/gittensory-miner/schema/miner-goal-spec.schema.json
+++ b/packages/gittensory-miner/schema/miner-goal-spec.schema.json
@@ -46,6 +46,26 @@
       "enum": ["encouraged", "neutral", "discouraged"],
       "default": "neutral",
       "description": "How strongly opening discovery issues is encouraged. Default: neutral."
+    },
+    "feasibilityGate": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Per-repo feasibility-gate tuning. Additive and inert by default. See packages/gittensory-miner/docs/miner-goal-spec.md.",
+      "properties": {
+        "minFeasibilityScore": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1,
+          "default": 0,
+          "description": "Minimum feasibility score a candidate must reach for a miner to pursue it. Default: 0 (no floor)."
+        },
+        "suppressedAvoidReasons": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "default": [],
+          "description": "Feasibility avoid-reason keys this repo downgrades from blocking to advisory. Default: []."
+        }
+      }
     }
   }
 }

--- a/test/unit/miner-goal-spec-doc.test.ts
+++ b/test/unit/miner-goal-spec-doc.test.ts
@@ -17,6 +17,7 @@ const SPEC_FIELDS = [
   "blockedLabels",
   "maxConcurrentClaims",
   "issueDiscoveryPolicy",
+  "feasibilityGate",
 ] as const;
 
 describe("miner goal spec docs (#2300)", () => {

--- a/test/unit/miner-goal-spec-feasibility-gate.test.ts
+++ b/test/unit/miner-goal-spec-feasibility-gate.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_MINER_GOAL_SPEC,
+  parseMinerGoalSpec,
+} from "../../packages/gittensory-engine/src/miner-goal-spec";
+
+describe("MinerGoalSpec feasibilityGate config block (#4275)", () => {
+  it("defaults to an inert gate (score floor 0, nothing suppressed) when the block is absent", () => {
+    const parsed = parseMinerGoalSpec({ minerEnabled: false });
+    expect(parsed.spec.feasibilityGate).toEqual({ minFeasibilityScore: 0, suppressedAvoidReasons: [] });
+    expect(DEFAULT_MINER_GOAL_SPEC.feasibilityGate).toEqual({ minFeasibilityScore: 0, suppressedAvoidReasons: [] });
+  });
+
+  it("normalizes a valid feasibilityGate and treats a gate-only config as present", () => {
+    const parsed = parseMinerGoalSpec({
+      feasibilityGate: {
+        minFeasibilityScore: 0.4,
+        suppressedAvoidReasons: ["missing_local_test_harness", " missing_local_test_harness ", "", "no_ci"],
+      },
+    });
+    expect(parsed.present).toBe(true); // a feasibilityGate-only spec is non-default → present
+    expect(parsed.spec.feasibilityGate).toEqual({
+      minFeasibilityScore: 0.4,
+      suppressedAvoidReasons: ["missing_local_test_harness", "no_ci"], // trimmed, de-duped, blanks dropped
+    });
+    expect(parsed.warnings).toEqual([]);
+  });
+
+  it("clamps an out-of-range minFeasibilityScore into [0, 1] with a warning", () => {
+    const high = parseMinerGoalSpec({ feasibilityGate: { minFeasibilityScore: 1.5 } });
+    expect(high.spec.feasibilityGate.minFeasibilityScore).toBe(1);
+    expect(high.warnings.join(" ")).toMatch(/minFeasibilityScore.*clamped to 1/i);
+
+    const low = parseMinerGoalSpec({ feasibilityGate: { minFeasibilityScore: -0.5 } });
+    expect(low.spec.feasibilityGate.minFeasibilityScore).toBe(0);
+    expect(low.warnings.join(" ")).toMatch(/minFeasibilityScore.*clamped to 0/i);
+  });
+
+  it("rejects a non-finite / non-number minFeasibilityScore, falling back to 0 with a warning", () => {
+    for (const bad of ["high", Number.NaN, Number.POSITIVE_INFINITY]) {
+      const parsed = parseMinerGoalSpec({ feasibilityGate: { minFeasibilityScore: bad as unknown as number } });
+      expect(parsed.spec.feasibilityGate.minFeasibilityScore).toBe(0);
+      expect(parsed.warnings.join(" ")).toMatch(/minFeasibilityScore.*must be a number/i);
+    }
+  });
+
+  it("degrades a non-mapping feasibilityGate to the inert default with a warning", () => {
+    for (const bad of [["nope"], "0.5", 42]) {
+      const parsed = parseMinerGoalSpec({ feasibilityGate: bad as unknown });
+      expect(parsed.spec.feasibilityGate).toEqual(DEFAULT_MINER_GOAL_SPEC.feasibilityGate);
+      expect(parsed.warnings.join(" ")).toMatch(/feasibilityGate.*must be a mapping/i);
+    }
+  });
+
+  it("tolerates a malformed suppressedAvoidReasons list (non-array → empty, with a warning)", () => {
+    const parsed = parseMinerGoalSpec({ feasibilityGate: { suppressedAvoidReasons: "no_ci" } });
+    expect(parsed.spec.feasibilityGate.suppressedAvoidReasons).toEqual([]);
+    expect(parsed.warnings.join(" ")).toMatch(/suppressedAvoidReasons.*must be a list/i);
+  });
+});

--- a/test/unit/miner-opportunity-ranker.test.ts
+++ b/test/unit/miner-opportunity-ranker.test.ts
@@ -142,6 +142,7 @@ describe("rankCandidateIssues (#2302 follow-up)", () => {
           blockedLabels: [],
           maxConcurrentClaims: 2,
           issueDiscoveryPolicy: "neutral",
+          feasibilityGate: { minFeasibilityScore: 0, suppressedAvoidReasons: [] },
         },
       },
     });
@@ -160,6 +161,7 @@ describe("rankCandidateIssues (#2302 follow-up)", () => {
           blockedLabels: [],
           maxConcurrentClaims: 2,
           issueDiscoveryPolicy: "neutral",
+          feasibilityGate: { minFeasibilityScore: 0, suppressedAvoidReasons: [] },
         },
       },
     });
@@ -217,6 +219,7 @@ describe("rankCandidateIssues (#2302 follow-up)", () => {
             blockedLabels: [],
             maxConcurrentClaims: 2,
             issueDiscoveryPolicy: "neutral",
+            feasibilityGate: { minFeasibilityScore: 0, suppressedAvoidReasons: [] },
           },
         },
       },

--- a/test/unit/opportunity-branch-internals.test.ts
+++ b/test/unit/opportunity-branch-internals.test.ts
@@ -73,6 +73,7 @@ describe("opportunity branch internals", () => {
             blockedLabels: [],
             maxConcurrentClaims: 1,
             issueDiscoveryPolicy: "encouraged",
+            feasibilityGate: { minFeasibilityScore: 0, suppressedAvoidReasons: [] },
           },
         },
       }).preferredLabels,

--- a/test/unit/opportunity-metadata-signals.test.ts
+++ b/test/unit/opportunity-metadata-signals.test.ts
@@ -66,6 +66,7 @@ describe("opportunity metadata signals", () => {
             blockedLabels: [],
             maxConcurrentClaims: 1,
             issueDiscoveryPolicy: "encouraged",
+            feasibilityGate: { minFeasibilityScore: 0, suppressedAvoidReasons: [] },
           },
         },
       },


### PR DESCRIPTION
## Summary

Adds a `feasibilityGate` block to `MinerGoalSpec` (`packages/gittensory-engine/src/miner-goal-spec.ts`) so a maintainer can tune the miner's feasibility gate per-repo via `.gittensory-miner.yml`. It is **additive and inert by default** (score floor `0`, nothing suppressed), so a repo that omits the block behaves exactly as before.

Two tolerant sub-fields (the tolerant "degrade, don't throw" convention of the existing parser):
- `minFeasibilityScore` — a `[0, 1]` floor a candidate must reach; out-of-range or non-finite input clamps into `[0, 1]` with a warning. Default `0`.
- `suppressedAvoidReasons` — a free-form string list of feasibility avoid-reason keys to downgrade from blocking to advisory. Default `[]`.

Wired through the **canonical** `parseMinerGoalSpec` + `hasConfiguredGoalFields` (a gate-only config is correctly `present: true`), exported from the engine barrel, mirrored in the JSON Schema and the docs, and covered by present / absent / malformed / clamp tests. Per the issue's caution, only `miner-goal-spec.ts` is extended — the non-exported, uncalled `miner-goal-spec-parse.ts` sibling is left untouched. `buildFeasibilityVerdict` (the gate's composer) does not exist yet, so this is purely the config surface, following the repo's config-before-consumer pattern; the block's shape is documented as the issue requested.

Closes #4275

## Scope

- [x] Conventional Commit title.
- [x] Focused; no unrelated backend/UI/MCP/docs/dependency/deploy changes.
- [x] Follows `CONTRIBUTING.md`; no `site/`, `CNAME`, VitePress.
- [x] Linked issue: Closes #4275.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (green)
- [x] `npm run build:miner` (engine + miner build/typecheck, green)
- [x] New root vitest suite `test/unit/miner-goal-spec-feasibility-gate.test.ts` (6 tests) + extended engine node:test parser/contract tests + the doc/schema parity test now assert the new field. The existing `MinerGoalSpec` literal sites in three `test/unit` opportunity tests were updated for the new required field.
- [x] Adding a required field: verified the full field-surface (`maxConcurrentClaims` grep) so every `MinerGoalSpec` literal in the repo now includes `feasibilityGate`.

If any required check was skipped, explain why:

- Full `npm run test:ci` was not run in the local Windows dev environment (several self-host suites require Linux/bash/Docker/Postgres). This change is confined to `packages/gittensory-engine` + `packages/gittensory-miner` config/docs/schema (pure parsing, no `src/` app, API/OpenAPI, MCP, binding, DB, or migration surface); typecheck, the engine+miner build, and all affected unit tests are green locally, and the remaining CI runs on this PR.

## Safety

- [x] No secrets, wallets, hotkeys, trust scores, private rankings, or maintainer evidence.
- [x] Public GitHub text stays sanitized and low-noise.
- [x] No auth/CORS/session changes.
- [x] No API/OpenAPI/MCP behavior changes (pure config-parsing surface).

## UI Evidence

N/A - backend config parsing; no UI, frontend, or extension change.
