### PR TITLE
fix(review): stop auto-assigning linked issues

### DIFF
--- a/src/services/agent-action-executor.ts
+++ b/src/services/agent-action-executor.ts
@@ -932,17 +932,6 @@ async function performAction(env: Env, ctx: AgentActionExecutionContext, action:
       const login = action.assignee ?? "";
       if (!login) return undefined;
       const result = await ensurePullRequestAssignee(env, ctx.installationId, ctx.repoFullName, ctx.pullNumber, login);
-      // Best-effort mirror the same assignment onto every linked issue (#priority-linked-issue-gate-ownership):
-      // gittensor:priority propagation requires the PR author to be the linked issue's own author OR assignee,
-      // so without this a contributor who picks up a maintainer-authored issue can never actually satisfy that
-      // check (see maybePlanAssign's doc comment, agent-actions.ts). Independent per-issue call: one issue's
-      // write failing (permissions, deleted issue, rate limit) must not affect another issue's assignment or the
-      // PR-assign outcome already computed above.
-      await Promise.all(
-        (action.assignLinkedIssues ?? []).map((issueNumber) =>
-          ensurePullRequestAssignee(env, ctx.installationId, ctx.repoFullName, issueNumber, login).catch(() => undefined),
-        ),
-      );
       if (!result.applied) {
         // GitHub silently drops an assignee lacking push/triage access to the repo -- the common case for an
         // external contributor. Fall back to a per-login label instead of a comment: ensurePullRequestLabel's
@@ -970,7 +959,6 @@ export function actionParams(action: PlannedAgentAction): AgentPendingActionPara
     ...(action.reviewBody !== undefined ? { reviewBody: action.reviewBody } : {}),
     ...(action.mergeMethod !== undefined ? { mergeMethod: action.mergeMethod } : {}),
     ...(action.assignee !== undefined ? { assignee: action.assignee } : {}),
-    ...(action.assignLinkedIssues !== undefined ? { assignLinkedIssues: action.assignLinkedIssues } : {}),
     ...(action.closeComment !== undefined ? { closeComment: action.closeComment } : {}),
     ...(action.closeReasons !== undefined ? { closeReasons: [...boundStructuredCloseReasonsForPersistence(action.closeReasons)] } : {}),
     ...(action.expectedHeadSha !== undefined ? { expectedHeadSha: action.expectedHeadSha } : {}),

--- a/src/settings/agent-actions.ts
+++ b/src/settings/agent-actions.ts
@@ -150,11 +150,9 @@ export type PlannedAgentAction = {
   // contributor. GitHub silently drops an assignee lacking push/triage access rather than erroring, so the
   // executor falls back to a per-login label when the real assignment doesn't stick.
   assignee?: string;
-  // For an `assign` action (#priority-linked-issue-gate-ownership): the SAME login also best-effort-assigned to
-  // each of these linked issue numbers (already capped, see maybePlanAssign). Without this, a contributor is
-  // assigned to their own PR but never to the issue(s) it closes -- and gittensor:priority propagation
-  // (resolveIssueLabelsForPropagation, linked-issue-label-propagation-fetch.ts) requires the PR author to be the
-  // linked issue's own author OR assignee, which an issue-opened-for-open-pickup contributor otherwise never is.
+  // Legacy approval-queue rows may contain this field from the reverted linked-issue assignment fan-out. New
+  // plans do not set it, actionParams does not persist it, and the executor ignores it because linked issue
+  // assignment is an authorization signal granted by maintainers, not by PR-body closing references.
   assignLinkedIssues?: number[];
 };
 
@@ -558,12 +556,6 @@ function screenshotTableCloseMessage(reason: string): string {
   return `${reason} This is an automated maintenance action.`;
 }
 
-// Best-effort assign-to-linked-issue fan-out cap (#priority-linked-issue-gate-ownership): a PR overwhelmingly
-// closes 1 (rarely 2-3) issues. `pr.linkedIssues` is already capped much higher (50, MAX_LINKED_ISSUE_NUMBERS)
-// for extraction/storage purposes only -- this narrower cap bounds the number of extra GitHub assignee-WRITE
-// calls the executor makes for one `assign` action.
-const ASSIGN_LINKED_ISSUES_MAX = 10;
-
 /**
  * Plan best-effort assignment of the PR's opening contributor (#3182), independent of merge/close/CI outcome.
  * MUST run before the CI-pending settle-before-decide return below (#assign-before-ci-pending) — a PR that has
@@ -571,26 +563,18 @@ const ASSIGN_LINKED_ISSUES_MAX = 10;
  * unrelated check is still pending; assign has no bearing on mergeability so it never needs CI to settle first.
  * Gated purely on its own `assign` autonomy class, same as every other independent action here.
  *
- * Also best-effort assigns the SAME contributor to the PR's own linked issues (#priority-linked-issue-gate-
- * ownership), capped at ASSIGN_LINKED_ISSUES_MAX. Without this, gittensor:priority propagation could never fire
- * in practice for a contributor's PR: resolveIssueLabelsForPropagation only unlocks that label when the PR
- * author is the linked issue's own author OR a GitHub assignee of it, but our issues are almost always opened
- * for open pickup and rarely formally assigned (see the propagation config's own comment in
- * gittensory-repo-focus-manifest.ts) -- so before this, only the PR itself ever got an assignee, never the
- * issue it closes.
+ * Do NOT mirror this assignment to PR-body linked issues. Those issue numbers are contributor-controlled
+ * closing references, while downstream linked-issue ownership checks intentionally treat issue assignees as a
+ * maintainer-granted authorization signal.
  */
 function maybePlanAssign(actions: PlannedAgentAction[], input: AgentActionPlanInput): void {
   const level = resolveAutonomy(input.autonomy, "assign");
   if (!isActingAutonomyLevel(level) || !input.pr.authorLogin) return;
-  const linkedIssues = input.pr.linkedIssues;
   actions.push({
     actionClass: "assign",
     requiresApproval: autonomyRequiresApproval(level),
     reason: "auto-assign PR opener",
     assignee: input.pr.authorLogin,
-    ...(linkedIssues && linkedIssues.length > 0
-      ? { assignLinkedIssues: linkedIssues.slice(0, ASSIGN_LINKED_ISSUES_MAX) }
-      : {}),
   });
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1253,8 +1253,9 @@ export type AgentPendingActionParams = {
   mergeMethod?: AutoMergeMethod;
   // For an `assign` action (#3182): the GitHub login to assign when a staged action is accepted.
   assignee?: string;
-  // For an `assign` action (#priority-linked-issue-gate-ownership): the linked issue numbers to ALSO assign
-  // `assignee` to when a staged action is accepted (see PlannedAgentAction.assignLinkedIssues).
+  // Legacy approval-queue rows may contain this field from the reverted linked-issue assignment fan-out. New
+  // plans do not set it, actionParams does not persist it, and the executor ignores it because linked issue
+  // assignment is an authorization signal granted by maintainers, not by PR-body closing references.
   assignLinkedIssues?: number[];
   closeComment?: string;
   // Individual close reasons, persisted for approval-queue replay so the eventual audit row keeps the structured

--- a/test/unit/agent-action-executor.test.ts
+++ b/test/unit/agent-action-executor.test.ts
@@ -144,14 +144,15 @@ describe("executeAgentMaintenanceActions (#778 gate stack)", () => {
     expect(replayed).toMatchObject({ actionClass: "assign", requiresApproval: false, reason: "auto-assign PR opener", assignee: "alice" });
   });
 
-  it("REGRESSION (#priority-linked-issue-gate-ownership): actionParams round-trips assignLinkedIssues through approval replay", () => {
+  it("REGRESSION: actionParams drops legacy assignLinkedIssues so staged assignment cannot fan out to linked issues", () => {
     const assign: PlannedAgentAction = { actionClass: "assign", requiresApproval: true, reason: "auto-assign PR opener", assignee: "alice", assignLinkedIssues: [42, 43] };
 
     const persisted = actionParams(assign);
     const replayed = pendingActionToPlanned({ actionClass: "assign", params: persisted, reason: assign.reason });
 
-    expect(persisted).toEqual({ assignee: "alice", assignLinkedIssues: [42, 43] });
-    expect(replayed).toMatchObject({ actionClass: "assign", requiresApproval: false, reason: "auto-assign PR opener", assignee: "alice", assignLinkedIssues: [42, 43] });
+    expect(persisted).toEqual({ assignee: "alice" });
+    expect(replayed).toMatchObject({ actionClass: "assign", requiresApproval: false, reason: "auto-assign PR opener", assignee: "alice" });
+    expect(replayed).not.toHaveProperty("assignLinkedIssues");
   });
 
   it("actionParams round-trips structured closeReasons so approval replay preserves every close cause", () => {
@@ -864,28 +865,13 @@ describe("executeAgentMaintenanceActions (#778 gate stack)", () => {
     expect(audit?.detail).toBe("assignee refused by GitHub — fell back to a by:external-contributor label");
   });
 
-  it("LIVE assign (#priority-linked-issue-gate-ownership): also assigns the PR's linked issues, not just the PR itself", async () => {
+  it("LIVE assign: ignores legacy assignLinkedIssues and assigns only the PR itself", async () => {
     const env = createTestEnv({});
     const assign: PlannedAgentAction = { actionClass: "assign", requiresApproval: false, reason: "auto-assign PR opener", assignee: "alice", assignLinkedIssues: [42, 43] };
     const outcomes = await executeAgentMaintenanceActions(env, ctx({ autonomy: { assign: "auto" } }), [assign]);
-    expect(ensurePullRequestAssignee).toHaveBeenCalledWith(env, 123, "owner/repo", 7, "alice"); // the PR itself
-    expect(ensurePullRequestAssignee).toHaveBeenCalledWith(env, 123, "owner/repo", 42, "alice"); // linked issue #42
-    expect(ensurePullRequestAssignee).toHaveBeenCalledWith(env, 123, "owner/repo", 43, "alice"); // linked issue #43
-    expect(ensurePullRequestAssignee).toHaveBeenCalledTimes(3);
-    expect(outcomes[0]?.outcome).toBe("completed");
-  });
-
-  it("LIVE assign: a linked issue's assignment failing does not affect the PR-assign outcome or the other linked issue", async () => {
-    const env = createTestEnv({});
-    vi.mocked(ensurePullRequestAssignee).mockImplementation(async (_env, _installationId, _repoFullName, issueOrPrNumber) => {
-      if (issueOrPrNumber === 42) throw new Error("boom");
-      return { applied: true };
-    });
-    const assign: PlannedAgentAction = { actionClass: "assign", requiresApproval: false, reason: "auto-assign PR opener", assignee: "alice", assignLinkedIssues: [42, 43] };
-    const outcomes = await executeAgentMaintenanceActions(env, ctx({ autonomy: { assign: "auto" } }), [assign]);
-    expect(outcomes[0]?.outcome).toBe("completed");
     expect(ensurePullRequestAssignee).toHaveBeenCalledWith(env, 123, "owner/repo", 7, "alice");
-    expect(ensurePullRequestAssignee).toHaveBeenCalledWith(env, 123, "owner/repo", 43, "alice");
+    expect(ensurePullRequestAssignee).toHaveBeenCalledTimes(1);
+    expect(outcomes[0]?.outcome).toBe("completed");
   });
 
   it("LIVE assign: no linkedIssues means no extra assignee calls beyond the PR itself", async () => {

--- a/test/unit/agent-actions.test.ts
+++ b/test/unit/agent-actions.test.ts
@@ -1371,29 +1371,20 @@ describe("assign — auto-assign PR opener (#3182)", () => {
     expect(classes(plan)).toContain("close");
   });
 
-  describe("#priority-linked-issue-gate-ownership: also assigns the PR's linked issues", () => {
-    it("threads linkedIssues into assignLinkedIssues when present", () => {
+  describe("assign action linked issue safety", () => {
+    it("does not thread PR-body linkedIssues into assignLinkedIssues", () => {
       const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { assign: "auto" }, pr: { labels: [], authorLogin: "alice", linkedIssues: [42, 43] } }));
-      expect(plan).toContainEqual(expect.objectContaining({ actionClass: "assign", assignee: "alice", assignLinkedIssues: [42, 43] }));
-    });
-
-    it("omits assignLinkedIssues when linkedIssues is absent", () => {
-      const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { assign: "auto" }, pr: { labels: [], authorLogin: "alice" } }));
       const assign = plan.find((a) => a.actionClass === "assign");
+      expect(assign).toMatchObject({ actionClass: "assign", assignee: "alice" });
       expect(assign).not.toHaveProperty("assignLinkedIssues");
     });
 
-    it("omits assignLinkedIssues when linkedIssues is an empty array", () => {
-      const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { assign: "auto" }, pr: { labels: [], authorLogin: "alice", linkedIssues: [] } }));
-      const assign = plan.find((a) => a.actionClass === "assign");
-      expect(assign).not.toHaveProperty("assignLinkedIssues");
-    });
-
-    it("caps assignLinkedIssues at ASSIGN_LINKED_ISSUES_MAX (10) — a PR cannot fan out unbounded assignee writes", () => {
-      const linkedIssues = Array.from({ length: 15 }, (_, i) => i + 1);
-      const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { assign: "auto" }, pr: { labels: [], authorLogin: "alice", linkedIssues } }));
-      const assign = plan.find((a) => a.actionClass === "assign");
-      expect(assign?.assignLinkedIssues).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    it("keeps linkedIssues absence and emptiness equivalent for assign planning", () => {
+      for (const pr of [{ labels: [], authorLogin: "alice" }, { labels: [], authorLogin: "alice", linkedIssues: [] }]) {
+        const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { assign: "auto" }, pr }));
+        const assign = plan.find((a) => a.actionClass === "assign");
+        expect(assign).not.toHaveProperty("assignLinkedIssues");
+      }
     });
   });
 });


### PR DESCRIPTION
### Motivation
- PR-body closing references are author-controlled and were being mirrored into issue-assignee writes, which weakens downstream ownership/priority checks that treat assignee status as an authorization signal.  
- The change prevents a contributor from converting a `Closes #N`-style reference into a persistent assignee grant that could be used to bypass maintainer-only or priority gates.

### Description
- Stop threading `pr.linkedIssues` into the assign planner so the `assign` action no longer includes `assignLinkedIssues` (keeps the PR-opener assignment intact).  
- Remove the executor's fan-out that wrote the PR author's login to each `assignLinkedIssues` issue number so only the PR itself is assigned at execution time.  
- Stop persisting `assignLinkedIssues` into approval-queue params and mark the field as legacy with a clarifying comment so staged/replayed actions cannot carry the unsafe fan-out forward.  
- Update unit tests to assert the planner no longer emits `assignLinkedIssues`, that persisted params drop legacy `assignLinkedIssues`, and that the executor assigns only the PR (tests updated in `test/unit/agent-actions.test.ts` and `test/unit/agent-action-executor.test.ts`).

### Testing
- Ran targeted unit tests with `npx vitest run test/unit/agent-actions.test.ts test/unit/agent-action-executor.test.ts --reporter=verbose`, and all tests in those files passed (421 tests ran in the invoked suite).  
- Ran type checking with `npm run typecheck` (`tsc --noEmit`) which completed with no errors.  
- Ran `git diff --check` to ensure no whitespace/conflict markers and verified the modified tests and code compile and pass locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4f8ecc32b0832cb83e565d47e5d6df)