### PR TITLE
test(config): lock in review.max_findings parser for config-generator validation (#2211)

### DIFF
--- a/test/unit/config-templates.test.ts
+++ b/test/unit/config-templates.test.ts
@@ -140,6 +140,18 @@ describe("config/examples review templates (#1682)", () => {
     expect(resolveReviewPromptOverrides(off).cultureProfile).toBe(false);
   });
 
+  it("resolves review.max_findings via manifest parse + helper (#2211)", () => {
+    const full = readConfigExample("gittensory.full.yml");
+    expect(full).toMatch(/# max_findings:/);
+    const empty = { blockers: null, nits: null };
+    expect(parseFocusManifest({}).review.maxFindings).toEqual(empty);
+    expect(resolveReviewPromptOverrides(parseFocusManifest({})).maxFindings).toEqual(empty);
+    const on = parseFocusManifest({ review: { max_findings: { blockers: 5, nits: 8 } } });
+    expect(on.review.maxFindings).toEqual({ blockers: 5, nits: 8 });
+    expect(resolveReviewPromptOverrides(on).maxFindings).toEqual({ blockers: 5, nits: 8 });
+    expect(reviewConfigToJson(on.review)).toEqual({ max_findings: { blockers: 5, nits: 8 } });
+  });
+
   it("parses gittensory.minimal.yml with zero warnings and enables no agent actions", () => {
     const manifest = parseFocusManifestContent(readConfigExample("gittensory.minimal.yml"), "repo_file");
     expect(manifest.warnings).toEqual([]);


### PR DESCRIPTION
Closes #2211

## Summary
- Add a config-templates inventory test that locks in the shipped `review.max_findings` parser plumbing the config generator must mirror: docs entry in `gittensory.full.yml`, manifest parse round-trip, and `resolveReviewPromptOverrides` helper (unset → null caps).

## Validation
- `npx vitest run test/unit/config-templates.test.ts`

## UI Evidence
N/A — test-only (parser lock-in supporting #2211 validation rules; no UI files changed).
