### PR TITLE
feat(miner-config): parse a feasibilityGate policy block from .gittensory-miner.yml

### DIFF
--- a/.gittensory-miner.yml.example
+++ b/.gittensory-miner.yml.example
@@ -52,3 +52,11 @@ maxConcurrentClaims: 1
 # How strongly this repo encourages a miner to open discovery issues.
 # Values: encouraged | neutral | discouraged. Default: neutral.
 issueDiscoveryPolicy: neutral
+
+# Per-repo tuning for the feasibility gate a miner consults before starting work.
+# `enabled` (boolean, default: true) turns the gate off entirely for this repo.
+# `suppressedReasons` (string list, default: []) ignores specific avoid/raise
+# reason codes (e.g. duplicate_cluster_high) from the gate's verdict.
+feasibilityGate:
+  enabled: true
+  suppressedReasons: []

--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -253,6 +253,7 @@ export {
   parseMinerGoalSpecContent,
   discoverMinerGoalSpecPath,
   MINER_GOAL_SPEC_FILENAMES,
+  type FeasibilityGatePolicy,
   type MinerGoalSpec,
   type MinerIssueDiscoveryPolicy,
   type ParsedMinerGoalSpec,

--- a/packages/gittensory-engine/src/miner-goal-spec.ts
+++ b/packages/gittensory-engine/src/miner-goal-spec.ts
@@ -10,6 +10,19 @@ import { parse as parseYaml } from "yaml";
 /** How strongly opening discovery issues is encouraged for this repo. Mirrors the review-side policy vocabulary. */
 export type MinerIssueDiscoveryPolicy = "encouraged" | "neutral" | "discouraged";
 
+/** Per-repo tuning for the feasibility gate (`buildFeasibilityVerdict`, see `feasibility.ts`) a miner consults
+ *  before starting work. This is config-parsing surface only — it does not itself change the composer's
+ *  behavior; a caller wiring the gate into a decision flow reads this policy and applies it. */
+export type FeasibilityGatePolicy = {
+  /** Whether this repo wants the feasibility gate consulted at all before a miner starts work. Setting this
+   *  `false` lets a repo opt out of the gate entirely rather than tuning it. Default: true. */
+  enabled: boolean;
+  /** Specific `buildFeasibilityVerdict` avoid/raise reason codes (e.g. `"duplicate_cluster_high"`) this repo
+   *  wants ignored — for a repo that doesn't want duplicate-cluster signals to affect feasibility, for example.
+   *  String list. Default: [] (nothing suppressed). */
+  suppressedReasons: readonly string[];
+};
+
 /** Per-repo miner configuration parsed from `.gittensory-miner.yml`. See {@link DEFAULT_MINER_GOAL_SPEC}. */
 export type MinerGoalSpec = {
   /**
@@ -49,6 +62,11 @@ export type MinerGoalSpec = {
    * Default: neutral.
    */
   issueDiscoveryPolicy: MinerIssueDiscoveryPolicy;
+  /**
+   * Per-repo tuning for the feasibility gate a miner consults before starting work. See {@link FeasibilityGatePolicy}.
+   * Default: { enabled: true, suppressedReasons: [] }.
+   */
+  feasibilityGate: FeasibilityGatePolicy;
 };
 
 /** The tolerant parser result for `.gittensory-miner.yml`: the normalized spec plus parse warnings and whether the
@@ -77,6 +95,7 @@ export const DEFAULT_MINER_GOAL_SPEC: Readonly<MinerGoalSpec> = Object.freeze({
   blockedLabels: Object.freeze([]),
   maxConcurrentClaims: 1,
   issueDiscoveryPolicy: "neutral",
+  feasibilityGate: Object.freeze({ enabled: true, suppressedReasons: Object.freeze([]) }),
 });
 
 const MAX_MINER_GOAL_SPEC_BYTES = 32_768;
@@ -90,6 +109,10 @@ function cloneDefaultMinerGoalSpec(): MinerGoalSpec {
     blockedPaths: [...DEFAULT_MINER_GOAL_SPEC.blockedPaths],
     preferredLabels: [...DEFAULT_MINER_GOAL_SPEC.preferredLabels],
     blockedLabels: [...DEFAULT_MINER_GOAL_SPEC.blockedLabels],
+    feasibilityGate: {
+      enabled: DEFAULT_MINER_GOAL_SPEC.feasibilityGate.enabled,
+      suppressedReasons: [...DEFAULT_MINER_GOAL_SPEC.feasibilityGate.suppressedReasons],
+    },
   };
 }
 
@@ -149,6 +172,24 @@ function normalizeIssueDiscoveryPolicy(
   return fallback;
 }
 
+function normalizeFeasibilityGatePolicy(
+  value: unknown,
+  field: string,
+  fallback: FeasibilityGatePolicy,
+  warnings: string[],
+): FeasibilityGatePolicy {
+  if (value === undefined || value === null) return fallback;
+  if (typeof value !== "object" || Array.isArray(value)) {
+    warnings.push(`MinerGoalSpec field "${field}" must be a mapping; falling back to defaults.`);
+    return fallback;
+  }
+  const record = value as Record<string, unknown>;
+  return {
+    enabled: normalizeBoolean(record.enabled, `${field}.enabled`, fallback.enabled, warnings),
+    suppressedReasons: normalizeStringList(record.suppressedReasons, `${field}.suppressedReasons`, warnings),
+  };
+}
+
 function normalizePositiveInteger(value: unknown, field: string, fallback: number, warnings: string[]): number {
   if (value === undefined || value === null) return fallback;
   if (typeof value !== "number" || !Number.isFinite(value)) {
@@ -181,7 +222,9 @@ function hasConfiguredGoalFields(spec: MinerGoalSpec): boolean {
     spec.preferredLabels.length > 0 ||
     spec.blockedLabels.length > 0 ||
     spec.maxConcurrentClaims !== DEFAULT_MINER_GOAL_SPEC.maxConcurrentClaims ||
-    spec.issueDiscoveryPolicy !== DEFAULT_MINER_GOAL_SPEC.issueDiscoveryPolicy
+    spec.issueDiscoveryPolicy !== DEFAULT_MINER_GOAL_SPEC.issueDiscoveryPolicy ||
+    spec.feasibilityGate.enabled !== DEFAULT_MINER_GOAL_SPEC.feasibilityGate.enabled ||
+    spec.feasibilityGate.suppressedReasons.length > 0
   );
 }
 
@@ -220,6 +263,12 @@ export function parseMinerGoalSpec(raw: unknown): ParsedMinerGoalSpec {
       record.issueDiscoveryPolicy,
       "issueDiscoveryPolicy",
       DEFAULT_MINER_GOAL_SPEC.issueDiscoveryPolicy,
+      warnings,
+    ),
+    feasibilityGate: normalizeFeasibilityGatePolicy(
+      record.feasibilityGate,
+      "feasibilityGate",
+      DEFAULT_MINER_GOAL_SPEC.feasibilityGate,
       warnings,
     ),
   };

--- a/packages/gittensory-engine/test/miner-goal-spec-parser.test.ts
+++ b/packages/gittensory-engine/test/miner-goal-spec-parser.test.ts
@@ -34,6 +34,7 @@ test("parseMinerGoalSpec: valid raw config normalizes every field and keeps non-
     blockedLabels: ["duplicate", " duplicate "],
     maxConcurrentClaims: 2.9,
     issueDiscoveryPolicy: "encouraged",
+    feasibilityGate: { enabled: false, suppressedReasons: ["duplicate_cluster_high"] },
   });
 
   assert.equal(parsed.present, true);
@@ -45,8 +46,30 @@ test("parseMinerGoalSpec: valid raw config normalizes every field and keeps non-
     blockedLabels: ["duplicate"],
     maxConcurrentClaims: 2,
     issueDiscoveryPolicy: "encouraged",
+    feasibilityGate: { enabled: false, suppressedReasons: ["duplicate_cluster_high"] },
   });
   assert.deepEqual(parsed.warnings, []);
+});
+
+test("parseMinerGoalSpec: feasibilityGate sub-fields normalize independently and reject a non-mapping value", () => {
+  const valid = parseMinerGoalSpec({
+    wantedPaths: ["src/**"],
+    feasibilityGate: { enabled: false, suppressedReasons: ["issue_missing"] },
+  });
+  assert.deepEqual(valid.spec.feasibilityGate, { enabled: false, suppressedReasons: ["issue_missing"] });
+  assert.deepEqual(valid.warnings, []);
+
+  const malformed = parseMinerGoalSpec({
+    wantedPaths: ["src/**"],
+    feasibilityGate: { enabled: "nope", suppressedReasons: "not a list" },
+  });
+  assert.deepEqual(malformed.spec.feasibilityGate, { enabled: true, suppressedReasons: [] });
+  assert.match(malformed.warnings.join(" "), /feasibilityGate\.enabled/i);
+  assert.match(malformed.warnings.join(" "), /feasibilityGate\.suppressedReasons/i);
+
+  const arrayValue = parseMinerGoalSpec({ wantedPaths: ["src/**"], feasibilityGate: ["not", "a", "mapping"] });
+  assert.deepEqual(arrayValue.spec.feasibilityGate, { enabled: true, suppressedReasons: [] });
+  assert.match(arrayValue.warnings.join(" "), /feasibilityGate.*must be a mapping/i);
 });
 
 test("parseMinerGoalSpec: exactly 100 unique entries are accepted without a cap warning", () => {
@@ -119,6 +142,7 @@ test("parseMinerGoalSpec: malformed fields fall back independently with targeted
     blockedLabels: [123, " wontfix "],
     maxConcurrentClaims: 0.9,
     issueDiscoveryPolicy: "always",
+    feasibilityGate: "not a mapping",
   });
 
   assert.equal(parsed.present, true);
@@ -130,6 +154,7 @@ test("parseMinerGoalSpec: malformed fields fall back independently with targeted
     blockedLabels: ["wontfix"],
     maxConcurrentClaims: 1,
     issueDiscoveryPolicy: "neutral",
+    feasibilityGate: { enabled: true, suppressedReasons: [] },
   });
   const warningText = parsed.warnings.join(" ");
   assert.match(warningText, /minerEnabled/i);
@@ -139,6 +164,7 @@ test("parseMinerGoalSpec: malformed fields fall back independently with targeted
   assert.match(warningText, /blockedLabels/i);
   assert.match(warningText, /maxConcurrentClaims/i);
   assert.match(warningText, /issueDiscoveryPolicy/i);
+  assert.match(warningText, /feasibilityGate/i);
   assert.match(warningText, /truncated an over-long entry/i);
 });
 
@@ -156,6 +182,7 @@ test("parseMinerGoalSpec: unknown-only or default-only content stays absent with
     blockedLabels: [],
     maxConcurrentClaims: 1,
     issueDiscoveryPolicy: "neutral",
+    feasibilityGate: { enabled: true, suppressedReasons: [] },
   });
   assert.equal(explicitDefaults.present, false);
   assert.deepEqual(explicitDefaults.spec, DEFAULT_MINER_GOAL_SPEC);

--- a/packages/gittensory-engine/test/miner-goal-spec.test.ts
+++ b/packages/gittensory-engine/test/miner-goal-spec.test.ts
@@ -19,6 +19,7 @@ test("DEFAULT_MINER_GOAL_SPEC carries the documented safe defaults", () => {
     blockedLabels: [],
     maxConcurrentClaims: 1,
     issueDiscoveryPolicy: "neutral",
+    feasibilityGate: { enabled: true, suppressedReasons: [] },
   });
 });
 
@@ -28,12 +29,15 @@ test("DEFAULT_MINER_GOAL_SPEC is deep-frozen so the shared singleton can't be mu
   assert.ok(Object.isFrozen(DEFAULT_MINER_GOAL_SPEC.blockedPaths));
   assert.ok(Object.isFrozen(DEFAULT_MINER_GOAL_SPEC.preferredLabels));
   assert.ok(Object.isFrozen(DEFAULT_MINER_GOAL_SPEC.blockedLabels));
+  assert.ok(Object.isFrozen(DEFAULT_MINER_GOAL_SPEC.feasibilityGate));
+  assert.ok(Object.isFrozen(DEFAULT_MINER_GOAL_SPEC.feasibilityGate.suppressedReasons));
 });
 
 test("DEFAULT_MINER_GOAL_SPEC exposes exactly the specified field surface", () => {
   assert.deepEqual(Object.keys(DEFAULT_MINER_GOAL_SPEC).sort(), [
     "blockedLabels",
     "blockedPaths",
+    "feasibilityGate",
     "issueDiscoveryPolicy",
     "maxConcurrentClaims",
     "minerEnabled",

--- a/packages/gittensory-miner/docs/miner-goal-spec.md
+++ b/packages/gittensory-miner/docs/miner-goal-spec.md
@@ -49,3 +49,10 @@ Maximum issues one miner may hold claimed on this repo at once.
 ### `issueDiscoveryPolicy` (`encouraged` | `neutral` | `discouraged`, default: `neutral`)
 
 How strongly this repo encourages a miner to open discovery issues.
+
+### `feasibilityGate` (object, default: `{ enabled: true, suppressedReasons: [] }`)
+
+Per-repo tuning for the feasibility gate (`buildFeasibilityVerdict`) a miner consults before starting work. This is config-parsing surface only — a caller wiring the gate into a decision flow is responsible for reading and applying this policy.
+
+- `enabled` (boolean, default: `true`) — whether the feasibility gate is consulted at all before a miner starts work.
+- `suppressedReasons` (string list, default: `[]`) — specific avoid/raise reason codes (e.g. `duplicate_cluster_high`) this repo wants ignored.

--- a/packages/gittensory-miner/schema/miner-goal-spec.schema.json
+++ b/packages/gittensory-miner/schema/miner-goal-spec.schema.json
@@ -46,6 +46,25 @@
       "enum": ["encouraged", "neutral", "discouraged"],
       "default": "neutral",
       "description": "How strongly opening discovery issues is encouraged. Default: neutral."
+    },
+    "feasibilityGate": {
+      "type": "object",
+      "additionalProperties": true,
+      "default": { "enabled": true, "suppressedReasons": [] },
+      "description": "Per-repo tuning for the feasibility gate a miner consults before starting work. Default: { enabled: true, suppressedReasons: [] }.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "default": true,
+          "description": "Whether the feasibility gate is consulted at all before a miner starts work. Default: true."
+        },
+        "suppressedReasons": {
+          "type": "array",
+          "items": { "type": "string", "minLength": 1 },
+          "default": [],
+          "description": "buildFeasibilityVerdict avoid/raise reason codes this repo wants ignored. Default: []."
+        }
+      }
     }
   }
 }

--- a/test/unit/miner-goal-spec-doc.test.ts
+++ b/test/unit/miner-goal-spec-doc.test.ts
@@ -17,6 +17,7 @@ const SPEC_FIELDS = [
   "blockedLabels",
   "maxConcurrentClaims",
   "issueDiscoveryPolicy",
+  "feasibilityGate",
 ] as const;
 
 describe("miner goal spec docs (#2300)", () => {
@@ -53,6 +54,7 @@ describe("miner goal spec docs (#2300)", () => {
       blockedLabels: ["wontfix", "duplicate"],
       maxConcurrentClaims: 1,
       issueDiscoveryPolicy: "neutral",
+      feasibilityGate: { enabled: true, suppressedReasons: [] },
     });
     expect(parsed.warnings).toEqual([]);
   });

--- a/test/unit/miner-goal-spec-parser.test.ts
+++ b/test/unit/miner-goal-spec-parser.test.ts
@@ -41,6 +41,7 @@ describe("MinerGoalSpec parser (#2301)", () => {
       blockedLabels: ["duplicate", " duplicate "],
       maxConcurrentClaims: 2.9,
       issueDiscoveryPolicy: "encouraged",
+      feasibilityGate: { enabled: false, suppressedReasons: ["duplicate_cluster_high", "duplicate_cluster_high"] },
     });
 
     expect(parsed).toEqual({
@@ -53,6 +54,7 @@ describe("MinerGoalSpec parser (#2301)", () => {
         blockedLabels: ["duplicate"],
         maxConcurrentClaims: 2,
         issueDiscoveryPolicy: "encouraged",
+        feasibilityGate: { enabled: false, suppressedReasons: ["duplicate_cluster_high"] },
       },
       warnings: ['MinerGoalSpec field "blockedPaths" truncated an over-long entry.'],
     });
@@ -131,6 +133,7 @@ describe("MinerGoalSpec parser (#2301)", () => {
       blockedLabels: [123, " wontfix "],
       maxConcurrentClaims: "3",
       issueDiscoveryPolicy: "always",
+      feasibilityGate: "not a mapping",
     });
 
     expect(parsed).toEqual({
@@ -143,6 +146,7 @@ describe("MinerGoalSpec parser (#2301)", () => {
         blockedLabels: ["wontfix"],
         maxConcurrentClaims: 1,
         issueDiscoveryPolicy: "neutral",
+        feasibilityGate: { enabled: true, suppressedReasons: [] },
       },
       warnings: expect.arrayContaining([
         expect.stringMatching(/minerEnabled/i),
@@ -152,8 +156,47 @@ describe("MinerGoalSpec parser (#2301)", () => {
         expect.stringMatching(/blockedLabels/i),
         expect.stringMatching(/maxConcurrentClaims/i),
         expect.stringMatching(/issueDiscoveryPolicy/i),
+        expect.stringMatching(/feasibilityGate/i),
       ]),
     });
+  });
+
+  it("normalizes nested feasibilityGate sub-fields independently and rejects a non-mapping value", () => {
+    const validSubFields = parseMinerGoalSpec({
+      wantedPaths: ["src/**"],
+      feasibilityGate: { enabled: false, suppressedReasons: ["duplicate_cluster_high"] },
+    });
+    expect(validSubFields.spec.feasibilityGate).toEqual({
+      enabled: false,
+      suppressedReasons: ["duplicate_cluster_high"],
+    });
+    expect(validSubFields.warnings).toEqual([]);
+
+    const malformedSubFields = parseMinerGoalSpec({
+      wantedPaths: ["src/**"],
+      feasibilityGate: { enabled: "nope", suppressedReasons: "not a list" },
+    });
+    expect(malformedSubFields.spec.feasibilityGate).toEqual({ enabled: true, suppressedReasons: [] });
+    expect(malformedSubFields.warnings).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/feasibilityGate\.enabled/i),
+        expect.stringMatching(/feasibilityGate\.suppressedReasons/i),
+      ]),
+    );
+
+    const arrayValue = parseMinerGoalSpec({ wantedPaths: ["src/**"], feasibilityGate: ["not", "a", "mapping"] });
+    expect(arrayValue.spec.feasibilityGate).toEqual({ enabled: true, suppressedReasons: [] });
+    expect(arrayValue.warnings.join(" ")).toMatch(/feasibilityGate.*must be a mapping/i);
+  });
+
+  it("a feasibilityGate policy alone (all other fields default) marks the spec present", () => {
+    const parsed = parseMinerGoalSpec({ feasibilityGate: { enabled: false, suppressedReasons: [] } });
+    expect(parsed.present).toBe(true);
+    expect(parsed.spec.feasibilityGate).toEqual({ enabled: false, suppressedReasons: [] });
+
+    const suppressedOnly = parseMinerGoalSpec({ feasibilityGate: { suppressedReasons: ["issue_missing"] } });
+    expect(suppressedOnly.present).toBe(true);
+    expect(suppressedOnly.spec.feasibilityGate).toEqual({ enabled: true, suppressedReasons: ["issue_missing"] });
   });
 
   it("rejects claim counts below one after flooring", () => {
@@ -183,6 +226,7 @@ describe("MinerGoalSpec parser (#2301)", () => {
         blockedLabels: [],
         maxConcurrentClaims: 1,
         issueDiscoveryPolicy: "neutral",
+        feasibilityGate: { enabled: true, suppressedReasons: [] },
       }),
     ).toEqual({
       present: false,
@@ -222,6 +266,19 @@ describe("MinerGoalSpec parser (#2301)", () => {
         minerEnabled: false,
         blockedPaths: ["dist/**"],
         issueDiscoveryPolicy: "discouraged",
+      },
+      warnings: [],
+    });
+
+    expect(
+      parseMinerGoalSpecContent(
+        "feasibilityGate:\n  enabled: false\n  suppressedReasons:\n    - duplicate_cluster_high\n",
+      ),
+    ).toEqual({
+      present: true,
+      spec: {
+        ...DEFAULT_MINER_GOAL_SPEC,
+        feasibilityGate: { enabled: false, suppressedReasons: ["duplicate_cluster_high"] },
       },
       warnings: [],
     });

--- a/test/unit/miner-opportunity-ranker.test.ts
+++ b/test/unit/miner-opportunity-ranker.test.ts
@@ -142,6 +142,7 @@ describe("rankCandidateIssues (#2302 follow-up)", () => {
           blockedLabels: [],
           maxConcurrentClaims: 2,
           issueDiscoveryPolicy: "neutral",
+          feasibilityGate: { enabled: true, suppressedReasons: [] },
         },
       },
     });
@@ -160,6 +161,7 @@ describe("rankCandidateIssues (#2302 follow-up)", () => {
           blockedLabels: [],
           maxConcurrentClaims: 2,
           issueDiscoveryPolicy: "neutral",
+          feasibilityGate: { enabled: true, suppressedReasons: [] },
         },
       },
     });
@@ -217,6 +219,7 @@ describe("rankCandidateIssues (#2302 follow-up)", () => {
             blockedLabels: [],
             maxConcurrentClaims: 2,
             issueDiscoveryPolicy: "neutral",
+            feasibilityGate: { enabled: true, suppressedReasons: [] },
           },
         },
       },

--- a/test/unit/opportunity-branch-internals.test.ts
+++ b/test/unit/opportunity-branch-internals.test.ts
@@ -73,6 +73,7 @@ describe("opportunity branch internals", () => {
             blockedLabels: [],
             maxConcurrentClaims: 1,
             issueDiscoveryPolicy: "encouraged",
+            feasibilityGate: { enabled: true, suppressedReasons: [] },
           },
         },
       }).preferredLabels,

--- a/test/unit/opportunity-metadata-signals.test.ts
+++ b/test/unit/opportunity-metadata-signals.test.ts
@@ -66,6 +66,7 @@ describe("opportunity metadata signals", () => {
             blockedLabels: [],
             maxConcurrentClaims: 1,
             issueDiscoveryPolicy: "encouraged",
+            feasibilityGate: { enabled: true, suppressedReasons: [] },
           },
         },
       },


### PR DESCRIPTION
## Summary

- Closes #4275 by adding a `feasibilityGate` policy block to `MinerGoalSpec` (`packages/gittensory-engine/src/miner-goal-spec.ts`), the canonical config surface for `.gittensory-miner.yml` that `packages/gittensory-miner/lib/opportunity-ranker.js` already consumes via `parseMinerGoalSpecContent(content).spec`.
- Per the issue's explicit scope: this is **config-parsing surface only** — it does not wire the field into `buildFeasibilityVerdict` or its callers (that consumption is left to #4270's follow-up work, "coordinating loosely" as the issue puts it). No changes to `feasibility.ts` or the (separately-shipped, unrelated) `feasibility` MCP tool/CLI command.
- Shape chosen (the issue explicitly left this open, offering "override/suppress specific avoid/raise reasons" or "just tune thresholds" as options): `{ enabled: boolean, suppressedReasons: string[] }`. `enabled` mirrors the existing `minerEnabled`-style opt-out pattern; `suppressedReasons` is a data-only list of `buildFeasibilityVerdict` reason codes (e.g. `duplicate_cluster_high`) a future consumer can filter on — deliberately the more conservative of the two options since it needs no new enum/threshold surface and stays a simple mirror of the existing `normalizeStringList`/`normalizeBoolean` primitives already used throughout this file.
- Extended `parseMinerGoalSpec`/`hasConfiguredGoalFields` with a new `normalizeFeasibilityGatePolicy` helper (nested-object variant of the existing per-field normalizers: absent → default, non-mapping → warn+default, each sub-field independently normalized via the existing `normalizeBoolean`/`normalizeStringList`). Explicitly did **not** touch `miner-goal-spec-parse.ts`, the second non-exported/uncalled implementation the issue flags as a trap.
- Updated the JSON Schema (`packages/gittensory-miner/schema/miner-goal-spec.schema.json`), the field docs (`packages/gittensory-miner/docs/miner-goal-spec.md`), and the root example config (`.gittensory-miner.yml.example`) to match.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused: one new field through the type/parser/schema/docs/example, plus the minimal test-literal fixes required elsewhere for the new required field to typecheck. No unrelated backend/UI/dependency changes, and no change to the feasibility composer or its existing consumers.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` — not run; no workflow files touched.
- [x] `npm run typecheck` (clean on this diff; the repo's one pre-existing failure — a missing `aws4fetch` type declaration in `src/selfhost/s3-blob-store.ts` — reproduces identically on a clean `main` checkout and is unrelated). Adding a new required `MinerGoalSpec` field surfaced 5 pre-existing hand-written `MinerGoalSpec` object literals across `test/unit/miner-opportunity-ranker.test.ts`, `test/unit/opportunity-branch-internals.test.ts`, and `test/unit/opportunity-metadata-signals.test.ts`; all five now include the new field so they still satisfy the type.
- [x] `npm run test:coverage` locally — ran `packages/gittensory-engine/src/miner-goal-spec.ts`'s coverage in isolation against every test file that exercises it: **100%** statements/branches/functions/lines on every line this diff touches (the file's only uncovered lines, 325-326, are the pre-existing, untouched `discoverMinerGoalSpecPath` — unrelated to this change). Also ran `npm run test --workspace @jsonbored/gittensory-engine` (the package's own `node:test` suite, which duplicates the parser/default-spec assertions): 322/322 pass. Did not run the full unsharded `npm run test:coverage` (this dev machine is shared with several other concurrent contributor sessions and a full run does not complete in reasonable time).
- [ ] `npm run test:workers` — not run; no Cloudflare Worker code touched.
- [ ] `npm run build:mcp` / `npm run test:mcp-pack` / miner-pack equivalents — not run directly, but `npm --workspace @jsonbored/gittensory-engine run build` was run locally (required to exercise the compiled package in tests) and succeeds. `test:mcp-pack`/`test:miner-pack` themselves fail on this Windows machine for an unrelated, pre-existing reason (`spawnSync("npm", ...)` needs `shell:true` on Windows; reproduces identically on a clean `main` checkout).
- [x] `npm run docs:drift-check` — clean, unaffected.
- [ ] `npm run ui:openapi:check` / `ui:lint` / `ui:build` — not run; no UI files touched.
- [ ] `npm audit --audit-level=moderate` — not run; no dependency changes.
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries, mirroring the existing per-field coverage pattern in both `test/unit/miner-goal-spec-parser.test.ts` (vitest) and `packages/gittensory-engine/test/miner-goal-spec-parser.test.ts` (node:test): present/valid, absent (defaults), non-mapping (warn + default), each nested sub-field malformed independently, and a policy-only config (no other fields set) still marking the spec `present`.

If any required check was skipped, explain why:

- Everything skipped above is either inapplicable to this diff (no UI/Worker/dependency/workflow surface touched) or blocked by a pre-existing, reproducible-on-clean-`main` Windows-local environment issue (`npm pack`'s `spawnSync` Windows incompatibility) that does not reflect real CI behavior (GitHub Actions runs on Linux, and a dedicated CI step already builds `@jsonbored/gittensory-engine` before `test:coverage` runs).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session behavior is not changed.
- [x] API/OpenAPI/MCP behavior is not changed.
- [x] No visible UI changes; UI evidence is not applicable.
- [x] Public docs/changelogs are not changed (the `.md` file touched is the field reference doc this issue explicitly asks to update, not a changelog).

## UI Evidence

Not applicable; config-parsing surface change only, no UI.

## Notes

- Two commits: the feature itself, plus a small follow-up fixing three `MinerGoalSpec` test literals that a concurrent merge (landed between my initial implementation and pushing) reintroduced during a rebase.
