### PR TITLE
test(config): lock in review.comment_verbosity parser for config-generator import (#2212)

### DIFF
--- a/test/unit/config-templates.test.ts
+++ b/test/unit/config-templates.test.ts
@@ -166,6 +166,17 @@ describe("config/examples review templates (#1682)", () => {
     expect(resolveReviewPromptOverrides(off).inlineComments).toBe(false);
   });
 
+  it("resolves review.comment_verbosity via manifest parse + helper (#2212)", () => {
+    const full = readConfigExample("gittensory.full.yml");
+    expect(full).toMatch(/# comment_verbosity:/);
+    expect(parseFocusManifest({}).review.commentVerbosity).toBeNull();
+    expect(resolveReviewPromptOverrides(parseFocusManifest({})).commentVerbosity).toBeNull();
+    const detailed = parseFocusManifest({ review: { comment_verbosity: "detailed" } });
+    expect(detailed.review.commentVerbosity).toBe("detailed");
+    expect(resolveReviewPromptOverrides(detailed).commentVerbosity).toBe("detailed");
+    expect(reviewConfigToJson(detailed.review)).toEqual({ comment_verbosity: "detailed" });
+  });
+
   it("parses gittensory.minimal.yml with zero warnings and enables no agent actions", () => {
     const manifest = parseFocusManifestContent(readConfigExample("gittensory.minimal.yml"), "repo_file");
     expect(manifest.warnings).toEqual([]);


### PR DESCRIPTION
Closes #2212

## Summary
- Add a config-templates inventory test that locks in the shipped `review.comment_verbosity` parser plumbing the config-generator import path must share: docs entry in `gittensory.full.yml`, manifest parse round-trip, and `resolveReviewPromptOverrides` helper (unset → null).

## Validation
- `npx vitest run test/unit/config-templates.test.ts`

## UI Evidence
N/A — test-only (parser lock-in supporting #2212 yamlToFormState import; no UI files changed).
