### PR TITLE
feat(ui): cycle-time percentiles card (p50/p90/p99)

### DIFF
--- a/apps/gittensory-ui/src/components/site/app-panels/cycle-time-card-model.ts
+++ b/apps/gittensory-ui/src/components/site/app-panels/cycle-time-card-model.ts
@@ -1,0 +1,21 @@
+// Cycle-time analytics card model (#2194). UI-side mirror of the CycleTimeAggregate shape produced by
+// computeCycleTimeAggregate (src/review/stats.ts) and surfaced on the operator-dashboard payload. Types +
+// pure formatters live here (not in the .tsx) so the component file exports only components
+// (react-refresh/only-export-components).
+
+/** PR review cycle-time percentiles (mirror of src/review/stats.ts CycleTimeAggregate). */
+export interface CycleTimeAggregate {
+  p50Ms: number | null;
+  p90Ms: number | null;
+  p99Ms: number | null;
+  distribution: number[];
+  sampleSize: number;
+}
+
+/** Human-readable duration for percentile tiles; null/undefined → em dash. */
+export function formatCycleTimeMs(v: number | null | undefined): string {
+  if (v == null) return "—";
+  if (v < 60_000) return `${Math.round(v / 1000)}s`;
+  if (v < 3_600_000) return `${Math.round(v / 60_000)}m`;
+  return `${(v / 3_600_000).toFixed(1)}h`;
+}

--- a/apps/gittensory-ui/src/components/site/app-panels/cycle-time-card.test.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/cycle-time-card.test.tsx
@@ -1,0 +1,79 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { CycleTimeCard } from "@/components/site/app-panels/cycle-time-card";
+import {
+  formatCycleTimeMs,
+  type CycleTimeAggregate,
+} from "@/components/site/app-panels/cycle-time-card-model";
+
+describe("formatCycleTimeMs", () => {
+  it("formats seconds, minutes, and hours for present values", () => {
+    expect(formatCycleTimeMs(45_000)).toBe("45s");
+    expect(formatCycleTimeMs(120_000)).toBe("2m");
+    expect(formatCycleTimeMs(7_200_000)).toBe("2.0h");
+  });
+
+  it("renders em dash for nullish percentiles (nullish arm)", () => {
+    expect(formatCycleTimeMs(null)).toBe("—");
+    expect(formatCycleTimeMs(undefined)).toBe("—");
+  });
+});
+
+describe("CycleTimeCard", () => {
+  it("renders p50/p90/p99 tiles and the distribution sparkbar for populated percentiles", () => {
+    const cycleTime: CycleTimeAggregate = {
+      p50Ms: 60_000,
+      p90Ms: 120_000,
+      p99Ms: 300_000,
+      distribution: [1, 3, 5, 2],
+      sampleSize: 11,
+    };
+    render(<CycleTimeCard cycleTime={cycleTime} />);
+    expect(screen.getByText("Review cycle time")).toBeTruthy();
+    expect(screen.getByText("1m")).toBeTruthy();
+    expect(screen.getByText("2m")).toBeTruthy();
+    expect(screen.getByText("5m")).toBeTruthy();
+    expect(screen.getByText("11 paired PR(s)")).toBeTruthy();
+    expect(screen.getByText("Cycle-time distribution")).toBeTruthy();
+  });
+
+  it("shows em dashes when percentiles are null (nullish arm)", () => {
+    const cycleTime: CycleTimeAggregate = {
+      p50Ms: null,
+      p90Ms: null,
+      p99Ms: null,
+      distribution: [2],
+      sampleSize: 2,
+    };
+    render(<CycleTimeCard cycleTime={cycleTime} />);
+    expect(screen.getAllByText("—")).toHaveLength(3);
+    expect(screen.getByText("2 paired PR(s)")).toBeTruthy();
+  });
+
+  it("shows inline empty copy when there are no samples", () => {
+    const cycleTime: CycleTimeAggregate = {
+      p50Ms: null,
+      p90Ms: null,
+      p99Ms: null,
+      distribution: [],
+      sampleSize: 0,
+    };
+    render(<CycleTimeCard cycleTime={cycleTime} />);
+    expect(screen.getByText("no samples yet")).toBeTruthy();
+    expect(screen.queryByText("Cycle-time distribution")).toBeNull();
+  });
+
+  it("omits the sparkbar when the distribution is empty", () => {
+    const cycleTime: CycleTimeAggregate = {
+      p50Ms: 60_000,
+      p90Ms: 90_000,
+      p99Ms: 120_000,
+      distribution: [],
+      sampleSize: 3,
+    };
+    render(<CycleTimeCard cycleTime={cycleTime} />);
+    expect(screen.getByText("3 paired PR(s)")).toBeTruthy();
+    expect(screen.queryByText("Cycle-time distribution")).toBeNull();
+  });
+});

--- a/apps/gittensory-ui/src/components/site/app-panels/cycle-time-card.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/cycle-time-card.tsx
@@ -1,0 +1,63 @@
+import { MiniSparkbar, Stat, StatusPill } from "@/components/site/control-primitives";
+import {
+  formatCycleTimeMs,
+  type CycleTimeAggregate,
+} from "@/components/site/app-panels/cycle-time-card-model";
+
+/** Self-host maintainer analytics card (#2194): PR review cycle-time percentiles (p50/p90/p99) from the stats
+ *  feed, read-only over the operator-dashboard payload. Shows an inline empty state when there are no paired
+ *  gate_decision → pr_outcome samples in the window. */
+export function CycleTimeCard({ cycleTime }: { cycleTime: CycleTimeAggregate }) {
+  const hasSamples = cycleTime.sampleSize > 0;
+  const hasDistribution = cycleTime.distribution.length > 0;
+
+  return (
+    <section className="rounded-token border border-border bg-transparent p-5">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="font-display text-token-lg font-semibold">Review cycle time</h2>
+          <p className="mt-1 text-token-xs text-muted-foreground">
+            Gate decision → PR outcome duration percentiles from review_audit. Public-safe aggregates
+            only.
+          </p>
+        </div>
+        <StatusPill status={hasSamples ? "ready" : "info"}>
+          {hasSamples ? `${cycleTime.sampleSize} paired PR(s)` : "no samples yet"}
+        </StatusPill>
+      </div>
+
+      {hasSamples ? (
+        <>
+          <div className="mt-4 grid gap-3 sm:grid-cols-3">
+            <Stat
+              label="p50"
+              value={formatCycleTimeMs(cycleTime.p50Ms)}
+              hint={<span className="text-muted-foreground">median cycle time</span>}
+            />
+            <Stat
+              label="p90"
+              value={formatCycleTimeMs(cycleTime.p90Ms)}
+              hint={<span className="text-muted-foreground">90th percentile</span>}
+            />
+            <Stat
+              label="p99"
+              value={formatCycleTimeMs(cycleTime.p99Ms)}
+              hint={<span className="text-muted-foreground">99th percentile</span>}
+            />
+          </div>
+          {hasDistribution ? (
+            <div className="mt-4 rounded-token border border-border bg-background/40 p-3">
+              <div className="text-token-xs text-muted-foreground">Cycle-time distribution</div>
+              <MiniSparkbar values={cycleTime.distribution} className="mt-2" />
+            </div>
+          ) : null}
+        </>
+      ) : (
+        <p className="mt-4 text-token-sm text-muted-foreground">
+          Paired gate decisions and PR outcomes will appear here once the gate has resolved pull requests
+          in the analytics window.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/apps/gittensory-ui/src/components/site/app-panels/cycle-time-card.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/cycle-time-card.tsx
@@ -17,8 +17,8 @@ export function CycleTimeCard({ cycleTime }: { cycleTime: CycleTimeAggregate }) 
         <div>
           <h2 className="font-display text-token-lg font-semibold">Review cycle time</h2>
           <p className="mt-1 text-token-xs text-muted-foreground">
-            Gate decision → PR outcome duration percentiles from review_audit. Public-safe aggregates
-            only.
+            Gate decision → PR outcome duration percentiles from review_audit. Public-safe
+            aggregates only.
           </p>
         </div>
         <StatusPill status={hasSamples ? "ready" : "info"}>
@@ -54,8 +54,8 @@ export function CycleTimeCard({ cycleTime }: { cycleTime: CycleTimeAggregate }) 
         </>
       ) : (
         <p className="mt-4 text-token-sm text-muted-foreground">
-          Paired gate decisions and PR outcomes will appear here once the gate has resolved pull requests
-          in the analytics window.
+          Paired gate decisions and PR outcomes will appear here once the gate has resolved pull
+          requests in the analytics window.
         </p>
       )}
     </section>

--- a/apps/gittensory-ui/src/routes/app.analytics.tsx
+++ b/apps/gittensory-ui/src/routes/app.analytics.tsx
@@ -11,6 +11,8 @@ import {
 } from "@/components/site/usage-analytics-panels";
 import { GatePrecisionCard } from "@/components/site/app-panels/gate-precision-card";
 import type { GateEvalReport } from "@/components/site/app-panels/gate-precision-card-model";
+import { CycleTimeCard } from "@/components/site/app-panels/cycle-time-card";
+import type { CycleTimeAggregate } from "@/components/site/app-panels/cycle-time-card-model";
 import { useApiResource } from "@/lib/api/use-api-resource";
 
 export const Route = createFileRoute("/app/analytics")({
@@ -101,6 +103,7 @@ type OperatorDashboard = {
   };
   upstreamDrift?: { status?: string; openReportCount?: number } | null;
   gateEval?: GateEvalReport;
+  cycleTime?: CycleTimeAggregate;
 };
 
 function ProductAnalytics() {
@@ -182,6 +185,8 @@ function ProductAnalytics() {
           ) : null}
 
           {data.gateEval ? <GatePrecisionCard report={data.gateEval} /> : null}
+
+          {data.cycleTime ? <CycleTimeCard cycleTime={data.cycleTime} /> : null}
 
           {data.usageSummary ? (
             <ProductUsageBreakdownPanel

--- a/src/review/stats.ts
+++ b/src/review/stats.ts
@@ -238,7 +238,7 @@ export function buildCycleTimeDistribution(samplesMs: number[], bucketCount = 12
   const min = Math.min(...samplesMs);
   if (max === min) return [samplesMs.length];
   const buckets = Array.from({ length: bucketCount }, () => 0);
-  const span = max - min || 1;
+  const span = max - min;
   for (const ms of samplesMs) {
     const idx = Math.min(bucketCount - 1, Math.floor(((ms - min) / span) * bucketCount));
     buckets[idx]! += 1;

--- a/src/review/stats.ts
+++ b/src/review/stats.ts
@@ -175,6 +175,26 @@ export interface ReviewEffortAggregate {
   totalEstimatedMinutes: number;
 }
 
+/** PR review cycle-time percentiles (gate decision → PR outcome) for the maintainer stats feed (#2194). */
+export interface CycleTimeAggregate {
+  /** Milliseconds from gate decision to PR outcome; null when no samples in the window. */
+  p50Ms: number | null;
+  p90Ms: number | null;
+  p99Ms: number | null;
+  /** Histogram bucket counts for sparkbar visualization; empty when there are no samples. */
+  distribution: number[];
+  /** Count of PRs with a paired gate_decision + pr_outcome in the window. */
+  sampleSize: number;
+}
+
+export const EMPTY_CYCLE_TIME: CycleTimeAggregate = {
+  p50Ms: null,
+  p90Ms: null,
+  p99Ms: null,
+  distribution: [],
+  sampleSize: 0,
+};
+
 export interface StatsPayload {
   generatedAt: string;
   window: { fromIso: string; days: number; bucket: string };
@@ -194,6 +214,86 @@ export interface StatsPayload {
   recommendations: TuningRec[];
   /** Cross-system gate-decision parity: a SHADOW writer's gate decisions vs the authoritative ones. */
   gateParity: GateParityReport & { cutoverReady: Array<{ project: string; ready: boolean }> };
+  /** PR review cycle-time percentiles (gate decision → outcome) from review_audit (#2194). */
+  cycleTime: CycleTimeAggregate;
+}
+
+/** ms between the gate decision and the resolution; null if implausible (NaN or negative). */
+export function cycleTimeMs(decidedAt: string, outcomeAt: string): number | null {
+  const ms = new Date(outcomeAt).getTime() - new Date(decidedAt).getTime();
+  return Number.isFinite(ms) && ms >= 0 ? ms : null;
+}
+
+/** Nearest-rank percentile on a pre-sorted sample; null when empty (mirrors orb/analytics.ts). */
+export function percentileNearestRank(sorted: number[], p: number): number | null {
+  if (sorted.length === 0) return null;
+  const idx = Math.min(sorted.length - 1, Math.max(0, Math.ceil((p / 100) * sorted.length) - 1));
+  return sorted[idx]!;
+}
+
+/** Fold cycle-time samples into histogram buckets for the sparkbar; empty input → []. */
+export function buildCycleTimeDistribution(samplesMs: number[], bucketCount = 12): number[] {
+  if (samplesMs.length === 0) return [];
+  const max = Math.max(...samplesMs);
+  const min = Math.min(...samplesMs);
+  if (max === min) return [samplesMs.length];
+  const buckets = Array.from({ length: bucketCount }, () => 0);
+  const span = max - min || 1;
+  for (const ms of samplesMs) {
+    const idx = Math.min(bucketCount - 1, Math.floor(((ms - min) / span) * bucketCount));
+    buckets[idx]! += 1;
+  }
+  return buckets;
+}
+
+/** Pure fold: cycle-time samples → p50/p90/p99 + distribution (#2194). */
+export function aggregateCycleTimePercentiles(samplesMs: number[]): CycleTimeAggregate {
+  const sorted = samplesMs.filter((ms) => Number.isFinite(ms) && ms >= 0).sort((a, b) => a - b);
+  if (sorted.length === 0) return EMPTY_CYCLE_TIME;
+  return {
+    p50Ms: percentileNearestRank(sorted, 50),
+    p90Ms: percentileNearestRank(sorted, 90),
+    p99Ms: percentileNearestRank(sorted, 99),
+    distribution: buildCycleTimeDistribution(sorted),
+    sampleSize: sorted.length,
+  };
+}
+
+const CYCLE_TIME_SQL = `WITH gd AS (
+  SELECT target_id, created_at AS decided_at,
+  ROW_NUMBER() OVER (PARTITION BY target_id ORDER BY created_at DESC) AS rn
+  FROM review_audit
+  WHERE event_type = 'gate_decision' AND decision IS NOT NULL AND created_at >= ?
+),
+po AS (
+  SELECT target_id, created_at AS outcome_at, ROW_NUMBER() OVER (PARTITION BY target_id ORDER BY created_at DESC) AS rn
+  FROM review_audit
+  WHERE event_type = 'pr_outcome' AND decision IS NOT NULL AND created_at >= ?
+)
+SELECT gd.decided_at AS decided_at, po.outcome_at AS outcome_at
+FROM gd
+JOIN po ON gd.target_id = po.target_id
+WHERE gd.rn = 1 AND po.rn = 1`;
+
+/** Load paired gate_decision → pr_outcome cycle times for the stats window. Fail-safe → empty aggregate. */
+export async function computeCycleTimeAggregate(
+  env: Env,
+  opts: { days: number; nowMs: number },
+): Promise<CycleTimeAggregate> {
+  const days = Number.isFinite(opts.days) && opts.days > 0 ? Math.min(opts.days, 730) : 90;
+  const fromIso = new Date(opts.nowMs - days * 86_400_000).toISOString().slice(0, 10);
+  try {
+    const rows = await storage(env)
+      .prepare(CYCLE_TIME_SQL)
+      .bind(fromIso, fromIso)
+      .all<{ decided_at: string; outcome_at: string }>();
+    const samples = (rows.results ?? [])
+      .map((row) => cycleTimeMs(row.decided_at, row.outcome_at))
+      .filter((ms): ms is number => ms !== null);
+    return aggregateCycleTimePercentiles(samples);
+  } catch {
+    return EMPTY_CYCLE_TIME;
+  }
 }
 
 /** Fold per-PR persisted minutes into the maintainer aggregate (avg band + total minutes). */
@@ -224,7 +324,7 @@ export async function computeStats(
   const bucketExpr = BUCKET_SQL[bucket] ?? BUCKET_SQL.day;
   const fromIso = new Date(opts.nowMs - days * 86_400_000).toISOString().slice(0, 10); // YYYY-MM-DD
 
-  const [decisionRows, reversalRows, effortRows] = await Promise.all([
+  const [decisionRows, reversalRows, effortRows, cycleTime] = await Promise.all([
     storage(env).prepare(
       `SELECT ${bucketExpr} AS bucket, project, COALESCE(verdict, status) AS verdict, COUNT(*) AS n
        FROM review_targets
@@ -258,6 +358,7 @@ export async function computeStats(
        )`,
     ).bind(fromIso).all<{ minutes: number }>()
       .catch(() => ({ results: [] as Array<{ minutes: number }> })),
+    computeCycleTimeAggregate(env, { days, nowMs: opts.nowMs }),
   ]);
 
   // Non-content gate decisions (incl. SHADOW would-actions) — recorded as `gate_decision` audit rows with
@@ -294,6 +395,7 @@ export async function computeStats(
     gateEval,
     recommendations,
     gateParity: { ...parity, cutoverReady: parity.rows.map((r) => ({ project: r.project, ready: isParityCutoverReady(r) })) },
+    cycleTime,
   };
 }
 

--- a/src/services/operator-dashboard.ts
+++ b/src/services/operator-dashboard.ts
@@ -27,6 +27,7 @@ import type {
 } from "../types";
 import { computeFleetAnalytics, type FleetAnalytics } from "../orb/analytics";
 import { computeGateEval, type GateEvalReport } from "../review/parity";
+import { computeCycleTimeAggregate, type CycleTimeAggregate } from "../review/stats";
 import { loadUpstreamStatus, type UpstreamStatus } from "../upstream/ruleset";
 import { nowIso } from "../utils/json";
 import { buildRecommendationQualityReport, type RecommendationQualityReport } from "./recommendation-quality-report";
@@ -63,6 +64,8 @@ export type OperatorDashboardPayload = {
   // Gate-precision eval (#2191): the per-project confusion matrix + precisions from computeGateEval, surfaced
   // read-only for the maintainer analytics card. Fail-safe empty report when there is no review_audit signal.
   gateEval: GateEvalReport;
+  // PR review cycle-time percentiles (#2194): gate decision → outcome from review_audit; fail-safe empty aggregate.
+  cycleTime: CycleTimeAggregate;
 };
 
 const USAGE_WINDOW_DAYS = 7;
@@ -87,6 +90,7 @@ export async function buildOperatorDashboardPayload(env: Env): Promise<OperatorD
     recommendationQuality,
     fleetMetrics,
     gateEval,
+    cycleTime,
   ] = await Promise.all([
     listRepositories(env),
     listInstallations(env),
@@ -106,6 +110,8 @@ export async function buildOperatorDashboardPayload(env: Env): Promise<OperatorD
     computeFleetAnalytics(env, { windowDays: 90 }),
     // #2191: reuse the existing eval (no new compute); it fails safe to an empty report on any read error.
     computeGateEval(env, { days: 90, nowMs: Date.now() }),
+    // #2194: cycle-time percentiles from the stats feed; fails safe to an empty aggregate.
+    computeCycleTimeAggregate(env, { days: 90, nowMs: Date.now() }),
   ]);
   const weeklyValueReport = buildWeeklyValueReport({
     generatedAt: nowIso(),
@@ -200,6 +206,7 @@ export async function buildOperatorDashboardPayload(env: Env): Promise<OperatorD
     upstreamDrift,
     fleetMetrics,
     gateEval,
+    cycleTime,
   };
 }
 

--- a/test/unit/operator-dashboard.test.ts
+++ b/test/unit/operator-dashboard.test.ts
@@ -26,6 +26,13 @@ describe("operator dashboard payload", () => {
     // #2191: gate-eval report is surfaced read-only; with no review_audit signal it fails safe to an empty
     // report (no rows, no signal) rather than being absent.
     expect(payload.gateEval).toEqual({ rows: [], hasSignal: false });
+    expect(payload.cycleTime).toEqual({
+      p50Ms: null,
+      p90Ms: null,
+      p99Ms: null,
+      distribution: [],
+      sampleSize: 0,
+    });
     // Empty fleet → instanceCount 0, null precision card ("—"), no-outlier delta.
     expect(payload.fleetMetrics.instanceCount).toBe(0);
     expect(payload.metrics).toEqual(

--- a/test/unit/stats.test.ts
+++ b/test/unit/stats.test.ts
@@ -445,6 +445,10 @@ describe("cycle-time aggregation (#2194)", () => {
     expect(buildCycleTimeDistribution([5, 5, 5])).toEqual([3]);
   });
 
+  it("buildCycleTimeDistribution places the max sample in the last bucket (boundary clamp)", () => {
+    expect(buildCycleTimeDistribution([0, 100], 2)).toEqual([1, 1]);
+  });
+
   it("aggregateCycleTimePercentiles folds samples into p50/p90/p99 + distribution", () => {
     const agg = aggregateCycleTimePercentiles([60_000, 120_000, 180_000, 240_000, 300_000]);
     expect(agg.sampleSize).toBe(5);
@@ -489,6 +493,71 @@ describe("cycle-time aggregation (#2194)", () => {
     } as unknown as Env;
     const { computeCycleTimeAggregate } = await import("../../src/review/stats");
     expect(await computeCycleTimeAggregate(env, { days: 30, nowMs: NOW })).toEqual(EMPTY_CYCLE_TIME);
+  });
+
+  it("computeCycleTimeAggregate defaults non-finite/non-positive days to 90", async () => {
+    let boundFrom: string | undefined;
+    const env = {
+      DB: {
+        prepare: () => ({
+          bind: (fromIso: string) => {
+            boundFrom = fromIso;
+            return { all: async () => ({ results: [] as Array<{ decided_at: string; outcome_at: string }> }) };
+          },
+        }),
+      },
+    } as unknown as Env;
+    const { computeCycleTimeAggregate } = await import("../../src/review/stats");
+    await computeCycleTimeAggregate(env, { days: Number.NaN, nowMs: NOW });
+    expect(boundFrom).toBe(new Date(NOW - 90 * 86_400_000).toISOString().slice(0, 10));
+  });
+
+  it("computeCycleTimeAggregate clamps days to 730", async () => {
+    let boundFrom: string | undefined;
+    const env = {
+      DB: {
+        prepare: () => ({
+          bind: (fromIso: string) => {
+            boundFrom = fromIso;
+            return { all: async () => ({ results: [] as Array<{ decided_at: string; outcome_at: string }> }) };
+          },
+        }),
+      },
+    } as unknown as Env;
+    const { computeCycleTimeAggregate } = await import("../../src/review/stats");
+    await computeCycleTimeAggregate(env, { days: 99_999, nowMs: NOW });
+    expect(boundFrom).toBe(new Date(NOW - 730 * 86_400_000).toISOString().slice(0, 10));
+  });
+
+  it("computeCycleTimeAggregate tolerates missing D1 results and skips null cycle deltas", async () => {
+    const env = {
+      DB: {
+        prepare: () => ({
+          bind: () => ({
+            all: async () => ({
+              results: undefined,
+            }),
+          }),
+        }),
+      },
+    } as unknown as Env;
+    const envWithBadRows = {
+      DB: {
+        prepare: () => ({
+          bind: () => ({
+            all: async () => ({
+              results: [
+                { decided_at: "2026-06-01T10:00:00Z", outcome_at: "2026-06-01T09:00:00Z" },
+                { decided_at: "bad", outcome_at: "2026-06-01T09:00:00Z" },
+              ],
+            }),
+          }),
+        }),
+      },
+    } as unknown as Env;
+    const { computeCycleTimeAggregate } = await import("../../src/review/stats");
+    expect(await computeCycleTimeAggregate(env, { days: 30, nowMs: NOW })).toEqual(EMPTY_CYCLE_TIME);
+    expect(await computeCycleTimeAggregate(envWithBadRows, { days: 30, nowMs: NOW })).toEqual(EMPTY_CYCLE_TIME);
   });
 });
 

--- a/test/unit/stats.test.ts
+++ b/test/unit/stats.test.ts
@@ -1,13 +1,18 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createTestEnv } from "../helpers/d1";
 import {
+  aggregateCycleTimePercentiles,
   aggregateReviewEffort,
+  buildCycleTimeDistribution,
   computeStats,
+  cycleTimeMs,
+  EMPTY_CYCLE_TIME,
   handleParity,
   handleStats,
   isParityCutoverReady,
   MIN_PARITY_SAMPLE,
   PARITY_AGREEMENT_FLOOR,
+  percentileNearestRank,
   type GateParityRow,
   type StatsEvalDeps,
 } from "../../src/review/stats";
@@ -28,6 +33,10 @@ function stubEnv(extra: Record<string, unknown> = {}): Env {
     { minutes: 4 },
     { minutes: 96 },
   ];
+  const cyclePairs = [
+    { decided_at: "2026-06-01T10:00:00Z", outcome_at: "2026-06-01T10:05:00Z" },
+    { decided_at: "2026-06-01T11:00:00Z", outcome_at: "2026-06-01T11:30:00Z" },
+  ];
   let lastSql = "";
   return {
     ...extra,
@@ -37,15 +46,17 @@ function stubEnv(extra: Record<string, unknown> = {}): Env {
         return {
           bind: () => ({
             all: async () => ({
-              // review-effort read → effortMinutes; gate_decision → gateActions; other review_audit → reversals;
-              // everything else → decision rows. (The eval/parity engine is the default no-op deps.)
+              // review-effort read → effortMinutes; cycle-time pairs → cyclePairs; gate action counts → gateActions;
+              // other review_audit → reversals; everything else → decision rows.
               results: lastSql.includes("reviewEffortMinutes")
                 ? effortMinutes
-                : lastSql.includes("gate_decision")
-                  ? gateActions
-                  : lastSql.includes("review_audit")
-                    ? reversals
-                    : decisions,
+                : lastSql.includes("decided_at") && lastSql.includes("outcome_at")
+                  ? cyclePairs
+                  : lastSql.includes("decision AS action")
+                    ? gateActions
+                    : lastSql.includes("review_audit")
+                      ? reversals
+                      : decisions,
             }),
           }),
         };
@@ -72,6 +83,9 @@ describe("computeStats — D1 aggregate for the dashboard", () => {
     expect(out.recommendations).toEqual([]);
     expect(out.gateParity.cutoverReady).toEqual([]);
     expect(out.reviewEffort).toEqual({ avgBand: 3, totalEstimatedMinutes: 100 });
+    expect(out.cycleTime.sampleSize).toBe(2);
+    expect(out.cycleTime.p50Ms).toBe(300_000);
+    expect(out.cycleTime.distribution.length).toBeGreaterThan(0);
   });
 
   it("clamps an absurd window and falls back to a safe bucket", async () => {
@@ -249,7 +263,7 @@ describe("computeStats — gate-decision read is fail-safe", () => {
           return {
             bind: () => ({
               all: async () => {
-                if (lastSql.includes("gate_decision")) throw new Error("gate read down");
+                if (lastSql.includes("decision AS action")) throw new Error("gate read down");
                 return { results: lastSql.includes("review_audit") ? [] : decisions };
               },
             }),
@@ -408,6 +422,73 @@ describe("computeStats — NaN window + null D1 results (the ?? [] fallbacks)", 
     expect(out.projects).toEqual([]);
     expect(out.verdicts).toEqual([]);
     expect(out.reviewEffort).toEqual({ avgBand: null, totalEstimatedMinutes: 0 });
+    expect(out.cycleTime).toEqual(EMPTY_CYCLE_TIME);
+  });
+});
+
+describe("cycle-time aggregation (#2194)", () => {
+  it("cycleTimeMs rejects negative and non-finite deltas", () => {
+    expect(cycleTimeMs("2026-06-01T10:00:00Z", "2026-06-01T09:00:00Z")).toBeNull();
+    expect(cycleTimeMs("bad", "2026-06-01T09:00:00Z")).toBeNull();
+    expect(cycleTimeMs("2026-06-01T10:00:00Z", "2026-06-01T10:05:00Z")).toBe(300_000);
+  });
+
+  it("percentileNearestRank uses nearest-rank on sorted samples", () => {
+    const sorted = [100, 200, 300, 400];
+    expect(percentileNearestRank(sorted, 50)).toBe(200);
+    expect(percentileNearestRank(sorted, 90)).toBe(400);
+    expect(percentileNearestRank([], 50)).toBeNull();
+  });
+
+  it("buildCycleTimeDistribution returns [] for empty input and a single bucket when all samples match", () => {
+    expect(buildCycleTimeDistribution([])).toEqual([]);
+    expect(buildCycleTimeDistribution([5, 5, 5])).toEqual([3]);
+  });
+
+  it("aggregateCycleTimePercentiles folds samples into p50/p90/p99 + distribution", () => {
+    const agg = aggregateCycleTimePercentiles([60_000, 120_000, 180_000, 240_000, 300_000]);
+    expect(agg.sampleSize).toBe(5);
+    expect(agg.p50Ms).toBe(180_000);
+    expect(agg.p90Ms).toBe(300_000);
+    expect(agg.p99Ms).toBe(300_000);
+    expect(agg.distribution.length).toBeGreaterThan(0);
+  });
+
+  it("aggregateCycleTimePercentiles returns EMPTY_CYCLE_TIME for no valid samples", () => {
+    expect(aggregateCycleTimePercentiles([])).toEqual(EMPTY_CYCLE_TIME);
+    expect(aggregateCycleTimePercentiles([-1, Number.NaN])).toEqual(EMPTY_CYCLE_TIME);
+  });
+
+  it("computeCycleTimeAggregate reads paired review_audit rows from D1", async () => {
+    const env = createTestEnv();
+    await env.DB.prepare(
+      `INSERT INTO review_audit (id, project, target_id, event_type, decision, source, created_at) VALUES
+        ('gd1', 'owner/repo', 'owner/repo#1', 'gate_decision', 'merge', 'test', '2026-06-10T10:00:00Z'),
+        ('po1', 'owner/repo', 'owner/repo#1', 'pr_outcome', 'merged', 'test', '2026-06-10T10:10:00Z'),
+        ('gd2', 'owner/repo', 'owner/repo#2', 'gate_decision', 'close', 'test', '2026-06-11T10:00:00Z'),
+        ('po2', 'owner/repo', 'owner/repo#2', 'pr_outcome', 'closed', 'test', '2026-06-11T10:30:00Z')`,
+    ).run();
+    const { computeCycleTimeAggregate } = await import("../../src/review/stats");
+    const agg = await computeCycleTimeAggregate(env, { days: 90, nowMs: NOW });
+    expect(agg.sampleSize).toBe(2);
+    expect(agg.p50Ms).toBe(600_000);
+    expect(agg.distribution.length).toBeGreaterThan(0);
+  });
+
+  it("computeCycleTimeAggregate fails safe to EMPTY_CYCLE_TIME when the query rejects", async () => {
+    const env = {
+      DB: {
+        prepare: () => ({
+          bind: () => ({
+            all: async () => {
+              throw new Error("d1 down");
+            },
+          }),
+        }),
+      },
+    } as unknown as Env;
+    const { computeCycleTimeAggregate } = await import("../../src/review/stats");
+    expect(await computeCycleTimeAggregate(env, { days: 30, nowMs: NOW })).toEqual(EMPTY_CYCLE_TIME);
   });
 });
 


### PR DESCRIPTION
## Summary

- Add `cycleTime` (p50/p90/p99 + histogram distribution) to `StatsPayload` via `computeCycleTimeAggregate`, reading paired `gate_decision` → `pr_outcome` rows from `review_audit`.
- Surface `cycleTime` on the operator dashboard payload and render a new read-only `CycleTimeCard` on `/app/analytics` with three percentile Stat tiles and a `MiniSparkbar` when distribution data is present.
- Vitest coverage for present percentiles, nullish percentile formatting, empty distribution, and fail-safe empty aggregates.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

Closes #2194

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Full `npm run test:ci` gate pending CI; targeted unit/UI tests and coverage run locally on changed paths.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

| Page / Feature | Before | After |
|---|---|---|
| `/app/analytics` | [<img src="FULL_IMAGE_URL" width="260">](FULL_IMAGE_URL)<br><sub>before: analytics page without cycle-time card</sub> | [<img src="FULL_IMAGE_URL" width="260">](FULL_IMAGE_URL)<br><sub>after: Review cycle time card with p50/p90/p99 + distribution</sub> |

_Screenshots to be uploaded to the PR (drag-and-drop) and URLs substituted above before merge._

## Test plan

- [x] `npm run test -- test/unit/stats.test.ts test/unit/operator-dashboard.test.ts`
- [x] `npm run test -- src/components/site/app-panels/cycle-time-card.test.tsx` (UI)
- [ ] Confirm `/app/analytics` shows empty state when no paired audit rows exist
- [ ] Confirm percentile tiles populate when review_audit has gate_decision + pr_outcome pairs

## Notes

- Mirrors the #2191 gate-precision card pattern: backend aggregate on the operator dashboard, UI model + card + Vitest.
