### PR TITLE
feat(ui): add finding acceptance-rate analytics card

### DIFF
--- a/apps/gittensory-ui/src/components/site/app-panels/acceptance-rate-card-model.ts
+++ b/apps/gittensory-ui/src/components/site/app-panels/acceptance-rate-card-model.ts
@@ -1,0 +1,39 @@
+// Finding acceptance-rate analytics card model (#2197). UI-only display slice: the card consumes an acceptance
+// shape assumed present on the operator-dashboard payload (backend computation is tracked separately in #1967).
+// Types + the pure rate/band helpers live here (not in the .tsx) so the component file exports only components
+// (react-refresh/only-export-components).
+
+/** The finding-acceptance slice delivered on the operator-dashboard payload: how many posted inline findings the
+ *  contributor acted on (the PR merged after the finding was posted), over a rolling window. Public-safe counts. */
+export interface AcceptanceRateReport {
+  /** Findings a contributor acted on (finding posted inline → PR merged). */
+  accepted: number;
+  /** Inline findings posted in the window (the denominator). */
+  total: number;
+  /** Rolling measurement window, in days. */
+  windowDays: number;
+}
+
+/** The card's derived view: the raw counts plus the acceptance rate (null when nothing was posted). */
+export interface AcceptanceRateSummary {
+  accepted: number;
+  total: number;
+  /** accepted / total; null when `total` is 0 (empty denominator — nothing to be a rate of). */
+  rate: number | null;
+}
+
+/** Pure fold: derive the acceptance rate from the raw counts. An empty denominator yields a null rate. */
+export function summarizeAcceptanceRate(report: AcceptanceRateReport): AcceptanceRateSummary {
+  return {
+    accepted: report.accepted,
+    total: report.total,
+    rate: report.total > 0 ? report.accepted / report.total : null,
+  };
+}
+
+/** StatusPill quality band for an acceptance rate: >= 50% reads healthy, below that warns, an empty rate is
+ *  informational (no signal yet). Mirrors the Status vocabulary in control-primitives.ts. */
+export function bandForAcceptanceRate(rate: number | null): "ready" | "warn" | "info" {
+  if (rate === null) return "info";
+  return rate >= 0.5 ? "ready" : "warn";
+}

--- a/apps/gittensory-ui/src/components/site/app-panels/acceptance-rate-card.test.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/acceptance-rate-card.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { AcceptanceRateCard } from "@/components/site/app-panels/acceptance-rate-card";
+import {
+  bandForAcceptanceRate,
+  summarizeAcceptanceRate,
+} from "@/components/site/app-panels/acceptance-rate-card-model";
+
+describe("summarizeAcceptanceRate", () => {
+  it("derives the rate from the counts", () => {
+    expect(summarizeAcceptanceRate({ accepted: 3, total: 4, windowDays: 30 })).toEqual({
+      accepted: 3,
+      total: 4,
+      rate: 0.75,
+    });
+  });
+
+  it("returns a null rate for an empty denominator", () => {
+    expect(summarizeAcceptanceRate({ accepted: 0, total: 0, windowDays: 30 })).toEqual({
+      accepted: 0,
+      total: 0,
+      rate: null,
+    });
+  });
+});
+
+describe("bandForAcceptanceRate", () => {
+  it("bands the rate: >=50% ready, below warn, null info", () => {
+    expect(bandForAcceptanceRate(0.75)).toBe("ready");
+    expect(bandForAcceptanceRate(0.5)).toBe("ready");
+    expect(bandForAcceptanceRate(0.2)).toBe("warn");
+    expect(bandForAcceptanceRate(null)).toBe("info");
+  });
+});
+
+describe("AcceptanceRateCard", () => {
+  it("renders the rate percentage and accepted/total counts for a populated report", () => {
+    render(<AcceptanceRateCard report={{ accepted: 3, total: 4, windowDays: 30 }} />);
+    expect(screen.getByText("Finding acceptance rate")).toBeTruthy();
+    expect(screen.getByText("75%")).toBeTruthy();
+    expect(screen.getByText("30-day window")).toBeTruthy();
+    expect(screen.getByText("accepted / findings posted")).toBeTruthy();
+  });
+
+  it("renders '—' for the rate when nothing was posted (null-rate arm)", () => {
+    render(<AcceptanceRateCard report={{ accepted: 0, total: 0, windowDays: 7 }} />);
+    expect(screen.getByText("—")).toBeTruthy();
+    expect(screen.getByText("7-day window")).toBeTruthy();
+  });
+
+  it("renders a graceful EmptyState when the acceptance field is absent", () => {
+    render(<AcceptanceRateCard report={undefined} />);
+    expect(screen.getByText("Acceptance rate not yet available")).toBeTruthy();
+  });
+});

--- a/apps/gittensory-ui/src/components/site/app-panels/acceptance-rate-card.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/acceptance-rate-card.tsx
@@ -1,0 +1,57 @@
+import { Stat, StatusPill } from "@/components/site/control-primitives";
+import { EmptyState } from "@/components/site/state-views";
+
+import {
+  bandForAcceptanceRate,
+  summarizeAcceptanceRate,
+  type AcceptanceRateReport,
+} from "./acceptance-rate-card-model";
+
+/** Self-host analytics card (#2197): the finding acceptance rate — how often a contributor acted on an inline
+ *  finding (the PR merged after it was posted) — as a single percentage Stat plus accepted/total counts, over a
+ *  rolling window. UI-only display slice; the acceptance shape is assumed present on the operator-dashboard payload
+ *  (backend computation is #1967), so absence renders a graceful "not yet available" EmptyState. */
+export function AcceptanceRateCard({ report }: { report?: AcceptanceRateReport }) {
+  if (!report) {
+    return (
+      <EmptyState
+        title="Acceptance rate not yet available"
+        description="This appears once finding-acceptance data is present on the dashboard payload."
+      />
+    );
+  }
+  const summary = summarizeAcceptanceRate(report);
+  return (
+    <section className="rounded-token border border-border bg-transparent p-5">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="font-display text-token-lg font-semibold">Finding acceptance rate</h2>
+          <p className="mt-1 text-token-xs text-muted-foreground">
+            How often a contributor acted on an inline finding — the PR merged after it was posted.
+            Public-safe counts only.
+          </p>
+        </div>
+        <StatusPill status={bandForAcceptanceRate(summary.rate)}>
+          {`${report.windowDays}-day window`}
+        </StatusPill>
+      </div>
+      <div className="mt-4 grid gap-3 sm:grid-cols-3">
+        <Stat
+          label="Acceptance rate"
+          value={summary.rate !== null ? `${Math.round(summary.rate * 100)}%` : "—"}
+          hint={<span className="text-muted-foreground">accepted / findings posted</span>}
+        />
+        <Stat
+          label="Accepted"
+          value={String(summary.accepted)}
+          hint={<span className="text-muted-foreground">findings acted on</span>}
+        />
+        <Stat
+          label="Findings posted"
+          value={String(summary.total)}
+          hint={<span className="text-muted-foreground">inline findings in window</span>}
+        />
+      </div>
+    </section>
+  );
+}

--- a/apps/gittensory-ui/src/routes/app.analytics.tsx
+++ b/apps/gittensory-ui/src/routes/app.analytics.tsx
@@ -9,6 +9,8 @@ import {
   ProductUsageBreakdownPanel,
   WeeklyValueMetricsPanel,
 } from "@/components/site/usage-analytics-panels";
+import { AcceptanceRateCard } from "@/components/site/app-panels/acceptance-rate-card";
+import type { AcceptanceRateReport } from "@/components/site/app-panels/acceptance-rate-card-model";
 import { GatePrecisionCard } from "@/components/site/app-panels/gate-precision-card";
 import type { GateEvalReport } from "@/components/site/app-panels/gate-precision-card-model";
 import { useApiResource } from "@/lib/api/use-api-resource";
@@ -101,6 +103,7 @@ type OperatorDashboard = {
   };
   upstreamDrift?: { status?: string; openReportCount?: number } | null;
   gateEval?: GateEvalReport;
+  acceptance?: AcceptanceRateReport;
 };
 
 function ProductAnalytics() {
@@ -182,6 +185,8 @@ function ProductAnalytics() {
           ) : null}
 
           {data.gateEval ? <GatePrecisionCard report={data.gateEval} /> : null}
+
+          <AcceptanceRateCard report={data.acceptance} />
 
           {data.usageSummary ? (
             <ProductUsageBreakdownPanel


### PR DESCRIPTION
Closes #2197

## What

Adds a **finding acceptance-rate** analytics card to the self-host analytics dashboard (`/app/analytics`): how often a contributor acted on an inline finding — the PR merged after the finding was posted — as a single percentage Stat plus accepted/total counts over a rolling window.

This is the **display slice only** — the backend acceptance computation is tracked separately in #1967 — so the card assumes the acceptance shape is present on the operator-dashboard payload and guards its absence with a graceful "not yet available" `EmptyState`.

## Follows the existing card convention

Mirrors the `gate-precision-card` triplet exactly:

- **`acceptance-rate-card-model.ts`** — the `AcceptanceRateReport` payload type + pure `summarizeAcceptanceRate` / `bandForAcceptanceRate` helpers (kept out of the `.tsx` per the `react-refresh/only-export-components` rule).
- **`acceptance-rate-card.tsx`** — the card: a `%` `Stat` + accepted/total count tiles + a window-days `StatusPill` banded by the rate (≥50% ready, below warn, empty info); `EmptyState` when the slice is absent. Uses only the shared control-primitives and design tokens (`text-token-*`, `rounded-token`, `border-border`).
- **`acceptance-rate-card.test.tsx`** — present-with-data, present-zero (null-rate `—` arm), and absent (`EmptyState`) branches, plus the pure helpers.
- **`app.analytics.tsx`** — wires the card into the `space-y-8` dashboard stack and adds the optional `acceptance?: AcceptanceRateReport` slice to the `OperatorDashboard` payload type.

Rendered output: a titled card showing **"Acceptance rate 75%"**, **"Accepted"** and **"Findings posted"** count tiles, and a **"30-day window"** status pill; or a "not yet available" empty state before the payload carries the slice. Public-safe counts only — no reward/wallet fields, no raw scores.

## Testing

```
npm run ui:typecheck
npm run ui:lint
npm --workspace @jsonbored/gittensory-ui run test -- acceptance-rate-card
npm --workspace @jsonbored/gittensory-ui run build
```

All green: typecheck 0, lint 0 errors, 6/6 tests pass, vite build clean.
