### PR TITLE
feat(ui): add findings-by-category/severity breakdown card

### DIFF
--- a/apps/gittensory-ui/src/components/site/app-panels/findings-breakdown-card-model.ts
+++ b/apps/gittensory-ui/src/components/site/app-panels/findings-breakdown-card-model.ts
@@ -1,0 +1,47 @@
+// Findings-by-category/severity analytics card model (#2195). UI-side mirror of the findings breakdown surfaced
+// on the operator-dashboard payload (from src/review/stats.ts StatsPayload) plus the pure folds the card renders.
+// Types + helpers live here (not in the .tsx) so the component file exports only components
+// (react-refresh/only-export-components).
+
+/** AI-review finding severity tiers, high → low. */
+export type FindingSeverity = "high" | "medium" | "low";
+
+/** One category's finding counts broken out by severity, over the report window. */
+export interface FindingsCategoryRow {
+  category: string;
+  high: number;
+  medium: number;
+  low: number;
+}
+
+/** The findings-breakdown slice delivered on the operator-dashboard payload. Public-safe counts only. */
+export interface FindingsBreakdownReport {
+  windowDays: number;
+  categories: FindingsCategoryRow[];
+}
+
+/** Aggregate severity totals across every category, plus the grand total. */
+export interface FindingsBreakdownTotals {
+  high: number;
+  medium: number;
+  low: number;
+  total: number;
+}
+
+/** Sum one category row across its severities. */
+export function categoryTotal(row: FindingsCategoryRow): number {
+  return row.high + row.medium + row.low;
+}
+
+/** Fold every category row into aggregate severity totals + a grand total. Pure; an empty report is all zeros. */
+export function totalFindingsBreakdown(report: FindingsBreakdownReport): FindingsBreakdownTotals {
+  const totals = report.categories.reduce(
+    (acc, row) => ({
+      high: acc.high + row.high,
+      medium: acc.medium + row.medium,
+      low: acc.low + row.low,
+    }),
+    { high: 0, medium: 0, low: 0 },
+  );
+  return { ...totals, total: totals.high + totals.medium + totals.low };
+}

--- a/apps/gittensory-ui/src/components/site/app-panels/findings-breakdown-card.test.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/findings-breakdown-card.test.tsx
@@ -1,0 +1,71 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { FindingsBreakdownCard } from "@/components/site/app-panels/findings-breakdown-card";
+import {
+  categoryTotal,
+  totalFindingsBreakdown,
+} from "@/components/site/app-panels/findings-breakdown-card-model";
+
+describe("findings-breakdown model", () => {
+  it("sums a category row and folds aggregate totals", () => {
+    expect(categoryTotal({ category: "security", high: 2, medium: 1, low: 0 })).toBe(3);
+    expect(
+      totalFindingsBreakdown({
+        windowDays: 30,
+        categories: [
+          { category: "security", high: 2, medium: 1, low: 0 },
+          { category: "style", high: 0, medium: 1, low: 4 },
+        ],
+      }),
+    ).toEqual({ high: 2, medium: 2, low: 4, total: 8 });
+  });
+
+  it("folds an empty report to all zeros", () => {
+    expect(totalFindingsBreakdown({ windowDays: 30, categories: [] })).toEqual({
+      high: 0,
+      medium: 0,
+      low: 0,
+      total: 0,
+    });
+  });
+});
+
+describe("FindingsBreakdownCard", () => {
+  it("renders aggregate tiles and a row per category for a multi-category report", () => {
+    render(
+      <FindingsBreakdownCard
+        report={{
+          windowDays: 30,
+          categories: [
+            { category: "security", high: 2, medium: 1, low: 0 },
+            { category: "style", high: 0, medium: 1, low: 4 },
+          ],
+        }}
+      />,
+    );
+    expect(screen.getByText("Findings by category")).toBeTruthy();
+    expect(screen.getByText("30-day window")).toBeTruthy();
+    expect(screen.getByText("security")).toBeTruthy();
+    expect(screen.getByText("style")).toBeTruthy();
+    expect(screen.getByText("2 high")).toBeTruthy();
+  });
+
+  it("renders a single-category report", () => {
+    render(
+      <FindingsBreakdownCard
+        report={{
+          windowDays: 7,
+          categories: [{ category: "security", high: 1, medium: 0, low: 0 }],
+        }}
+      />,
+    );
+    expect(screen.getByText("security")).toBeTruthy();
+    expect(screen.getByText("7-day window")).toBeTruthy();
+  });
+
+  it("renders an EmptyState when there are no findings in the window", () => {
+    render(<FindingsBreakdownCard report={{ windowDays: 30, categories: [] }} />);
+    expect(screen.getByText("No findings in window")).toBeTruthy();
+  });
+});

--- a/apps/gittensory-ui/src/components/site/app-panels/findings-breakdown-card.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/findings-breakdown-card.tsx
@@ -1,0 +1,62 @@
+import { Stat, StatusPill } from "@/components/site/control-primitives";
+import { EmptyState } from "@/components/site/state-views";
+
+import {
+  categoryTotal,
+  totalFindingsBreakdown,
+  type FindingsBreakdownReport,
+} from "./findings-breakdown-card-model";
+
+/** Self-host analytics card (#2195): AI-review findings broken down by category and severity over a rolling
+ *  window. Aggregate high/medium/low Stat tiles on top, then one row per category with its per-severity counts
+ *  (colored by design tokens, never raw hex). Renders a graceful EmptyState when there are no findings in the
+ *  window. Read-only, public-safe counts only. */
+export function FindingsBreakdownCard({ report }: { report: FindingsBreakdownReport }) {
+  const totals = totalFindingsBreakdown(report);
+  return (
+    <section className="rounded-token border border-border bg-transparent p-5">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="font-display text-token-lg font-semibold">Findings by category</h2>
+          <p className="mt-1 text-token-xs text-muted-foreground">
+            AI-review findings grouped by category and severity. Public-safe counts only.
+          </p>
+        </div>
+        <StatusPill status={totals.total > 0 ? "ready" : "info"}>
+          {`${report.windowDays}-day window`}
+        </StatusPill>
+      </div>
+      {totals.total === 0 ? (
+        <EmptyState
+          className="mt-4"
+          title="No findings in window"
+          description="Nothing has been flagged in the selected window yet."
+        />
+      ) : (
+        <>
+          <div className="mt-4 grid grid-cols-3 gap-3">
+            <Stat label="High" value={String(totals.high)} />
+            <Stat label="Medium" value={String(totals.medium)} />
+            <Stat label="Low" value={String(totals.low)} />
+          </div>
+          <ul className="mt-3 space-y-2">
+            {report.categories.map((row) => (
+              <li
+                key={row.category}
+                className="flex items-center justify-between gap-3 rounded-token border border-border p-3"
+              >
+                <div className="text-token-sm text-foreground">{row.category}</div>
+                <div className="flex items-center gap-3 font-mono text-token-xs">
+                  <span className="text-danger">{row.high} high</span>
+                  <span className="text-warning">{row.medium} med</span>
+                  <span className="text-muted-foreground">{row.low} low</span>
+                  <span className="text-foreground">{categoryTotal(row)} total</span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+    </section>
+  );
+}

--- a/apps/gittensory-ui/src/routes/app.analytics.tsx
+++ b/apps/gittensory-ui/src/routes/app.analytics.tsx
@@ -9,6 +9,8 @@ import {
   ProductUsageBreakdownPanel,
   WeeklyValueMetricsPanel,
 } from "@/components/site/usage-analytics-panels";
+import { FindingsBreakdownCard } from "@/components/site/app-panels/findings-breakdown-card";
+import type { FindingsBreakdownReport } from "@/components/site/app-panels/findings-breakdown-card-model";
 import { GatePrecisionCard } from "@/components/site/app-panels/gate-precision-card";
 import type { GateEvalReport } from "@/components/site/app-panels/gate-precision-card-model";
 import { useApiResource } from "@/lib/api/use-api-resource";
@@ -101,6 +103,7 @@ type OperatorDashboard = {
   };
   upstreamDrift?: { status?: string; openReportCount?: number } | null;
   gateEval?: GateEvalReport;
+  findingsBreakdown?: FindingsBreakdownReport;
 };
 
 function ProductAnalytics() {
@@ -182,6 +185,10 @@ function ProductAnalytics() {
           ) : null}
 
           {data.gateEval ? <GatePrecisionCard report={data.gateEval} /> : null}
+
+          {data.findingsBreakdown ? (
+            <FindingsBreakdownCard report={data.findingsBreakdown} />
+          ) : null}
 
           {data.usageSummary ? (
             <ProductUsageBreakdownPanel


### PR DESCRIPTION
Closes #2195

## What

Adds a **findings-by-category/severity** breakdown card to the self-host analytics dashboard (`/app/analytics`): AI-review findings grouped by category, each broken out by severity (high/medium/low), over a rolling window. Read-only over an existing operator-dashboard payload slice; public-safe counts only.

## Follows the existing card convention

Mirrors the `gate-precision-card` triplet:

- **`findings-breakdown-card-model.ts`** — the `FindingsBreakdownReport` payload type + pure `categoryTotal` / `totalFindingsBreakdown` folds (kept out of the `.tsx` per `react-refresh/only-export-components`).
- **`findings-breakdown-card.tsx`** — aggregate high/medium/low `Stat` tiles, then one row per category with its per-severity counts colored via **design tokens only** (`text-danger` / `text-warning` / `text-muted-foreground` — no hardcoded hex); a graceful `EmptyState` when there are no findings in the window; a window-days `StatusPill`.
- **`findings-breakdown-card.test.tsx`** — multi-category, single-category, and empty (`EmptyState`) branches, plus the pure folds.
- **`app.analytics.tsx`** — wires the card into the dashboard stack and adds the optional `findingsBreakdown?: FindingsBreakdownReport` slice to the `OperatorDashboard` payload type.

Rendered output: a titled card with **High/Medium/Low** total tiles and a per-category list (each row showing `N high · N med · N low · N total` in token colors), or a "No findings in window" empty state.

## Testing

```
npm run ui:typecheck
npm run ui:lint
npm --workspace @jsonbored/gittensory-ui run test -- findings-breakdown
npm --workspace @jsonbored/gittensory-ui run build
```

All green: typecheck 0, lint 0 errors, 5/5 tests pass, vite build clean.
