### PR TITLE
test(review): add a cross-order-mode invariant test for the sweep one-shot fix

### DIFF
--- a/test/unit/agent-sweep.test.ts
+++ b/test/unit/agent-sweep.test.ts
@@ -272,6 +272,60 @@ describe("selectRegateCandidates (#777 re-gate sweep selection)", () => {
     );
   });
 
+  it("INVARIANT (#never-endless-reregate, incident 2026-07-09): once regated (and not repair-priority), a PR never reappears on any later sweep, across every order mode -- the exact property the endless-reregate-sweep incident broke", () => {
+    // A deliberately mixed, randomized-shape backlog: some PRs already regated (at varying ages), some never
+    // regated, a handful flagged repair-priority (the ONLY sanctioned bypass). Every PR's GitHub updatedAt is
+    // pinned far outside the freshness window so the freshness guard never masks this property. Simulates a
+    // real multi-sweep drain (mirroring the "REGRESSION (convergence)" test above): each sweep's picks get
+    // stamped with lastRegatedAt = now and feed into the next sweep, so the invariant is checked against
+    // genuinely evolving state, not a single static snapshot.
+    const TOTAL = 30;
+    const repairPullNumbers = new Set([5, 17, 23]);
+    const basePulls = Array.from({ length: TOTAL }, (_, i) => {
+      const number = i + 1;
+      const alreadyRegated = number % 3 !== 0 && !repairPullNumbers.has(number);
+      return pr({
+        number,
+        createdAt: minutesAgo(2000 - number),
+        updatedAt: minutesAgo(1000), // always stale relative to the freshness window
+        ...(alreadyRegated ? { lastRegatedAt: minutesAgo(500 + (number % 400)) } : {}),
+      });
+    });
+    const alreadyRegatedNonRepair = new Set(
+      basePulls.filter((p) => Boolean(p.lastRegatedAt)).map((p) => p.number),
+    );
+    for (const orderMode of ["staleness", "oldest-first"] as const) {
+      const stampedAt = new Map<number, string>();
+      let sweepNow = nowMs;
+      for (let sweep = 0; sweep < 8; sweep++) {
+        sweepNow += 10 * 60 * 1000;
+        const now = new Date(sweepNow).toISOString();
+        const view = basePulls.map((p) => ({
+          ...p,
+          lastRegatedAt: stampedAt.get(p.number) ?? p.lastRegatedAt,
+        }));
+        const picked = selectRegateCandidates({
+          pulls: view,
+          now,
+          orderMode,
+          priorityPullNumbers: repairPullNumbers,
+        });
+        for (const p of picked) {
+          expect(
+            alreadyRegatedNonRepair.has(p.number),
+            `orderMode=${orderMode} sweep=${sweep}: PR #${p.number} was already regated pre-test and is not repair-priority, yet was re-selected`,
+          ).toBe(false);
+          // A repair-priority PR CAN legitimately be picked more than once (its bypass is deliberate); any
+          // other PR picked on THIS sweep must not already carry a stamp from an earlier sweep in this run.
+          if (!repairPullNumbers.has(p.number)) {
+            expect(stampedAt.has(p.number)).toBe(false);
+          }
+          stampedAt.set(p.number, now);
+        }
+      }
+    }
+  });
+
   describe("orderMode: oldest-first (#3815)", () => {
     it("orders by createdAt ascending when neither PR has ever been regated", () => {
       const pulls = [


### PR DESCRIPTION
## Summary

- Follow-up to #4474 (the sweep endless-reregate fix): adds an INVARIANT test for `selectRegateCandidates` covering both order modes (`staleness`, `oldest-first`) across a simulated multi-sweep drain with a mixed backlog (never-regated, already-regated, repair-priority PRs), asserting an already-regated non-repair PR never resurfaces on any later sweep.
- Test-only change; no production code touched.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] Owner PR, no linked issue required (test-hardening follow-up to an already-merged incident fix, #4474).

## Validation

- [x] `npm run typecheck`
- [x] `npx vitest run test/unit/agent-sweep.test.ts test/unit/queue.test.ts` (791 passed)
- [ ] Full `npm run test:coverage` not re-run locally for this test-only diff; `test/**` is Codecov-ignored and CI runs the full gate.

If any required check was skipped, explain why:

- This is a test-only addition (no `src/**` lines changed), so `codecov/patch` has nothing to measure; relying on CI for the full gate per house convention for test-only diffs.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] N/A — no auth/cookie/CORS/GitHub App/Cloudflare/session changes.
- [x] N/A — no API/OpenAPI/MCP behavior changed.
- [x] N/A — no UI changes.

## Notes

- Also verified live in production that the separate guardrail-hold-freeze concern raised alongside this incident is already covered by an existing mechanism (PR #3461, merged 2026-07-05): once a PR carries the manual-review label, subsequent contributor pushes reuse the last published AI review (`github_app.ai_review_frozen_reuse`) instead of spending a fresh call, until a maintainer explicitly retriggers it. No new code needed there.