### PR TITLE
test(config): lock in gate-policy field group parser for config-generator (#2205)

### DIFF
--- a/test/unit/config-templates.test.ts
+++ b/test/unit/config-templates.test.ts
@@ -177,4 +177,19 @@ describe("config/examples review templates (#1682)", () => {
     expect(round.gate.enabled).toBe(false);
     expect(isAgentConfigured(round.settings.autonomy)).toBe(false);
   });
+
+  it("resolves the gate-policy field group (enabled + advisory/block modes) via parse + gateConfigToJson round-trip (#2205)", () => {
+    const full = readConfigExample("gittensory.full.yml");
+    expect(full).toMatch(/^gate:/m);
+    expect(full).toMatch(/linkedIssue:/);
+    // No gate block ⇒ no per-repo gate override (null), so an operator's absent gate policy stays inherited.
+    expect(gateConfigToJson(parseFocusManifest({}).gate)).toBeNull();
+    // Explicit gate policy: the on/off switch + the advisory-vs-block mode controls parse and round-trip
+    // byte-for-byte — the parity the config-generator's gate-policy field group depends on.
+    const on = parseFocusManifest({ gate: { enabled: true, linkedIssue: "block", duplicates: "advisory" } });
+    expect(on.gate.enabled).toBe(true);
+    expect(on.gate.linkedIssue).toBe("block");
+    expect(on.gate.duplicates).toBe("advisory");
+    expect(gateConfigToJson(on.gate)).toEqual({ enabled: true, linkedIssue: "block", duplicates: "advisory" });
+  });
 });


### PR DESCRIPTION
Locks in the parser parity the config-generator's **repo + gate-policy field group** depends on (Closes #2205) — the same test-only approach as #4454/#4465 for their field groups.

Asserts, against `gittensory.full.yml` + `parseFocusManifest`/`gateConfigToJson`:
- No `gate:` block ⇒ `gateConfigToJson` is `null` (an absent per-repo gate policy stays inherited).
- An explicit gate policy — the on/off switch (`enabled`) plus the **advisory-vs-block mode** controls (`linkedIssue`, `duplicates`) — parses and **round-trips byte-for-byte** through `gateConfigToJson`.

That round-trip is exactly the parity the generator's gate-policy field group emits into, so this pins it before the UI slice builds on it.

## Test
One `it(...)` appended to `test/unit/config-templates.test.ts` (15 pass). **Test-only, single file** — no `src` diff, no serialization change.

- [x] Conventional Commit; focused; **Closes #2205**. No `site/`/`CNAME`/`**/lovable/**`; no `CHANGELOG.md`. Test-only.