### PR TITLE
fix(review): make listPullRequestFiles order deterministic to stabilize content fingerprints

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -4097,12 +4097,23 @@ export async function deletePullRequestFiles(env: Env, fullName: string, pullNum
   await db.delete(pullRequestFiles).where(and(eq(pullRequestFiles.repoFullName, fullName), eq(pullRequestFiles.pullNumber, pullNumber)));
 }
 
+// #linked-issue-satisfaction-cache-fingerprint-stability: an explicit deterministic order is load-bearing,
+// not cosmetic. Without it, row order is whatever the query planner happens to return -- unstable across
+// otherwise-identical repeat calls for the SAME unchanged PR -- and downstream diff building
+// (buildUnifiedReviewDiff) only fully orders files by (priority bucket, added-line count); two files tied on
+// both fall back to THIS function's own (undefined) order. That untied order then flows straight into a
+// SHA-256 content fingerprint (linkedIssueSatisfactionCacheInputFingerprint and friends), so a silent reorder
+// alone changes the hash and defeats the cache even though the diff's actual content never changed --
+// confirmed live: JSONbored/metagraphed#4532 re-ran its linked-issue-satisfaction LLM call 12 times across 7
+// hours on one unchanged head SHA. `path` is unique per (repoFullName, pullNumber) (see the table's own
+// unique index), so it alone is a total, stable order -- no secondary tie-break needed.
 export async function listPullRequestFiles(env: Env, fullName: string, pullNumber: number): Promise<PullRequestFileRecord[]> {
   const db = getDb(env.DB);
   const rows = await db
     .select()
     .from(pullRequestFiles)
-    .where(and(eq(pullRequestFiles.repoFullName, fullName), eq(pullRequestFiles.pullNumber, pullNumber)));
+    .where(and(eq(pullRequestFiles.repoFullName, fullName), eq(pullRequestFiles.pullNumber, pullNumber)))
+    .orderBy(pullRequestFiles.path);
   return rows.map(toPullRequestFileRecord);
 }
 

--- a/test/unit/backfill-file-hydration-scoping.test.ts
+++ b/test/unit/backfill-file-hydration-scoping.test.ts
@@ -519,4 +519,33 @@ describe("GitHub PR file hydration scoping (#audit-rate-headroom)", () => {
       expect(await getPullRequestDetailSyncState(env, "JSONbored/gittensory", 91)).toMatchObject({ headSha: null });
     });
   });
+
+  describe("listPullRequestFiles ordering (#linked-issue-satisfaction-cache-fingerprint-stability)", () => {
+    it("REGRESSION: returns files in a stable path order regardless of write order, so a downstream content fingerprint never flips for an unchanged PR", async () => {
+      const env = createTestEnv();
+      // Written deliberately out of path order -- without an explicit ORDER BY, a query planner is free to
+      // return rows in ITS OWN order, which is not guaranteed to match write order or stay stable call to
+      // call. buildUnifiedReviewDiff only fully orders by (priority bucket, added-line count); files tied on
+      // both (as these three are: all source, all 0 additions/0 deletions) fall through to this function's
+      // own order, so an unstable order here silently reorders the diff string and flips any hash built from
+      // it (e.g. linkedIssueSatisfactionCacheInputFingerprint) even though nothing about the diff changed.
+      const paths = ["src/z.ts", "src/a.ts", "src/m.ts"];
+      for (const path of paths) {
+        await upsertPullRequestFile(env, {
+          repoFullName: "JSONbored/gittensory",
+          pullNumber: 200,
+          path,
+          status: "modified",
+          additions: 0,
+          deletions: 0,
+          changes: 0,
+          payload: {},
+        });
+      }
+      const first = await listPullRequestFiles(env, "JSONbored/gittensory", 200);
+      const second = await listPullRequestFiles(env, "JSONbored/gittensory", 200);
+      expect(first.map((file) => file.path)).toEqual(["src/a.ts", "src/m.ts", "src/z.ts"]);
+      expect(second.map((file) => file.path)).toEqual(first.map((file) => file.path));
+    });
+  });
 });

--- a/test/unit/rag-index.test.ts
+++ b/test/unit/rag-index.test.ts
@@ -992,8 +992,10 @@ describe("merged-PR incremental re-index trigger (webhook)", () => {
     // REGRESSION (#rate-limit-admission-attribution): installationId must be threaded through so the queue's
     // admission check attributes this job to the repo's OWN installation bucket, not the shared public-token
     // bucket -- omitting it starves an installed repo's re-index behind unrelated public-token traffic.
+    // paths reflects listPullRequestFiles's deterministic path-ascending order (#linked-issue-satisfaction-cache-fingerprint-stability),
+    // not the seed/insertion order above -- "README.md" sorts before "src/a.ts".
     expect(ragJobs).toEqual([
-      { type: "rag-index-repo", requestedBy: "webhook", repoFullName: "JSONbored/gittensory", paths: ["src/a.ts", "README.md"], installationId: 123 },
+      { type: "rag-index-repo", requestedBy: "webhook", repoFullName: "JSONbored/gittensory", paths: ["README.md", "src/a.ts"], installationId: 123 },
     ]);
   });
 


### PR DESCRIPTION
## Summary

- `listPullRequestFiles` (`src/db/repositories.ts`) had no `ORDER BY`, so row order was whatever the query planner returned — not guaranteed stable across repeat calls for the same unchanged PR.
- `buildUnifiedReviewDiff` only fully orders files by `(priority bucket, added-line count)`; files tied on both (common — e.g. multiple source files with 0 net additions) fall through to this function's own (previously undefined) order.
- That untied order flows straight into content-hash fingerprints downstream (`linkedIssueSatisfactionCacheInputFingerprint` and similar), so a silent reorder alone changes the hash and defeats caches even though the diff's actual content never changed.
- **Confirmed live**: `JSONbored/metagraphed#4532` re-ran its linked-issue-satisfaction LLM call 12 times across 7 hours on one unchanged head SHA, despite a matching cache row already existing (496 rows total in that cache table, 0 recorded hits ever) — the PR's own title/body and its linked issue's title/body were both unedited during that window (verified via the GitHub timeline API), ruling out a legitimate content change as the cause.
- Fix: add an explicit `.orderBy(pullRequestFiles.path)`. `path` is unique per `(repoFullName, pullNumber)` per the table's own unique index, so it alone is a total, stable order — no secondary tie-break needed.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] Owner PR, no linked issue required — a live-production caching bug found and root-caused during tonight's post-incident audit.

## Validation

- [x] `npm run typecheck`
- [x] New regression test added and verified to FAIL without the fix (temporarily reverted it locally, confirmed the test catches the exact insertion-order-vs-alphabetical mismatch) and PASS with it.
- [x] `npx vitest run test/unit/backfill.test.ts test/unit/backfill-file-hydration-scoping.test.ts test/unit/data-spine.test.ts test/unit/queue.test.ts test/unit/repository-settings-linked-issue-satisfaction.test.ts` (1002 passed)
- [ ] Full `npm run test:coverage` not re-run unsharded locally for this diff; relying on CI's full gate given the change is a single-line, well-covered, low-surface-area fix (one new `.orderBy()` call).

If any required check was skipped, explain why:

- See above — targeted suite run instead of the full unsharded suite, given the change's narrow blast radius and the lateness of an already-long incident-response session; CI runs the full gate.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] N/A — no auth/cookie/CORS/GitHub App/Cloudflare/session changes.
- [x] N/A — no API/OpenAPI/MCP behavior changed.
- [x] N/A — no UI changes.

## Notes

- This same instability plausibly also slightly undermines `ai_review`/`ai_slop`'s own cache hit rates (both build diffs through the same `buildAiReviewDiff`/`buildUnifiedReviewDiff` path), though those two also have upstream freeze/pause gates as a primary defense, so the practical impact there is smaller. `linked_issue_satisfaction` has no such upstream gate today and relies entirely on this fingerprint cache, which is why it was fully exposed to this bug.