### PR TITLE
fix(miner): resolve doctor paths in ESM (use import.meta.dirname)

### DIFF
--- a/packages/gittensory-miner/lib/status.js
+++ b/packages/gittensory-miner/lib/status.js
@@ -10,6 +10,7 @@ import { resolveMinerVersion } from "./version.js";
 // no GitHub writes, and no network calls of any kind. Later phases add the real discover/plan/manage loop.
 
 const require = createRequire(import.meta.url);
+const moduleDir = import.meta.dirname;
 
 const PACKAGE_NAME = "@jsonbored/gittensory-miner";
 const ENGINE_PACKAGE = "@jsonbored/gittensory-engine";
@@ -75,10 +76,10 @@ export function readInstalledEnginePackageVersion() {
   try {
     return readInstalledEnginePackageVersionFromPaths(
       require.resolve(ENGINE_PACKAGE),
-      join(__dirname, "../../gittensory-engine/package.json"),
+      join(moduleDir, "../../gittensory-engine/package.json"),
     );
   } catch {
-    const workspacePkg = join(__dirname, "../../gittensory-engine/package.json");
+    const workspacePkg = join(moduleDir, "../../gittensory-engine/package.json");
     if (existsSync(workspacePkg)) {
       try {
         return JSON.parse(readFileSync(workspacePkg, "utf8")).version ?? null;
@@ -113,8 +114,8 @@ export function readExpectedEnginePackageVersionFromPaths(
 
 export function readExpectedEnginePackageVersion() {
   return readExpectedEnginePackageVersionFromPaths(
-    join(__dirname, "../../gittensory-engine/package.json"),
-    join(__dirname, "../expected-engine.version"),
+    join(moduleDir, "../../gittensory-engine/package.json"),
+    join(moduleDir, "../expected-engine.version"),
   );
 }
 


### PR DESCRIPTION
### Motivation
- The miner package is declared as an ES module and using CommonJS `__dirname` caused `gittensory-miner doctor` to throw at runtime when running the engine-version skew checks.

### Description
- Introduce an ES-module-safe `moduleDir` derived from `import.meta.dirname` and use it where the code previously relied on `__dirname`.
- Replace path joins in `readInstalledEnginePackageVersion` and `readExpectedEnginePackageVersion` to use `moduleDir` so the engine workspace `package.json` and `expected-engine.version` are resolved correctly in ESM.
- Preserve the existing skew-check logic and fallbacks; no behavioral changes beyond fixing the runtime crash.

### Testing
- Ran the unit suite for the miner status with `npx vitest run test/unit/miner-status.test.ts`, which passed (15 tests).
- Exercised the CLI manually: `GITTENSORY_MINER_CONFIG_DIR=/tmp/... node packages/gittensory-miner/bin/gittensory-miner.js doctor --json` returned the expected checks (it fails when state is uninitialized and returns `ok: true` after `init`), confirming the crash is resolved.
- Attempted the full gate (`npm run test:ci`) and `npm audit --audit-level=moderate`, but `test:ci` reported unrelated `cf-typegen` drift and `npm audit` hit a registry 403 in this environment, neither of which are caused by this miner-only fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4ff5961fdc832c98df44ffcd9c218e)