### PR TITLE
feat(miner-selfimprove): calibration dashboard — predicted-gate accuracy vs real pr_outcome, read-only (#4261)

### DIFF
--- a/packages/gittensory-engine/src/calibration-dashboard.ts
+++ b/packages/gittensory-engine/src/calibration-dashboard.ts
@@ -1,0 +1,44 @@
+// Read-only Phase 7 calibration dashboard render (#4261). Pure: turns a computed Phase7CalibrationLoopResult
+// (from computePhase7CalibrationLoop, phase7-calibration-loop.ts) into a compact, deterministic, human-readable
+// view — CLI-suitable text today; a apps/gittensory-miner-ui/ panel can render the same result later.
+//
+// This is the read-only CONSUMER of the calibration module, never a producer: it renders, gates nothing, and
+// mutates nothing. It explicitly handles the "no real data yet" state (combinedAccuracy === null) with a clear
+// message rather than presenting an absent signal as a real 0% accuracy — that is the common case until the
+// historical-replay scorers are wired to feed live numbers (#4248, maintainer-only), so this view is groundwork
+// the wiring does not need to wait on.
+
+import type { Phase7CalibrationLoopResult } from "./phase7-calibration-loop.js";
+
+function pct(value: number | null): string {
+  return value === null ? "—" : `${Math.round(value * 100)}%`;
+}
+
+/**
+ * Render a {@link Phase7CalibrationLoopResult} as a compact read-only dashboard. Surfaces the combined accuracy vs
+ * the documented baseline (with the delta in percentage points), the per-source (`historical_replay` / `pr_outcome`)
+ * accuracy + sample size + freshness, the replay-harness status and whether a replay run is due, and any hold
+ * reasons. Deterministic — the same result always renders the same text.
+ */
+export function renderCalibrationDashboard(result: Phase7CalibrationLoopResult): string {
+  const lines: string[] = ["Phase 7 self-review calibration"];
+
+  if (result.combinedAccuracy === null) {
+    lines.push("  combined accuracy: no data yet — the replay scorers are not wired to feed live numbers (#4248).");
+  } else {
+    // deltaFromBaseline is computed alongside combinedAccuracy, so it is non-null whenever the combined value is.
+    const delta = result.deltaFromBaseline as number;
+    const deltaPp = `${delta >= 0 ? "+" : ""}${Math.round(delta * 100)}pp`;
+    lines.push(`  combined accuracy: ${pct(result.combinedAccuracy)} vs ${pct(result.baselineAccuracy)} baseline (${deltaPp})`);
+  }
+
+  for (const source of ["historical_replay", "pr_outcome"] as const) {
+    const metric = result.bySource[source];
+    lines.push(`  ${source}: ${pct(metric.accuracy)} (n=${metric.sampleSize}, ${metric.fresh ? "fresh" : "stale"})`);
+  }
+
+  lines.push(`  replay harness: ${result.replayHarnessStatus}${result.replayRunDue ? " — replay run due" : ""}`);
+  if (result.holdReasons.length > 0) lines.push(`  holds: ${result.holdReasons.join("; ")}`);
+
+  return lines.join("\n");
+}

--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -77,6 +77,7 @@ export {
   type PrOutcomeCalibrationInput,
   type ReplayHarnessStatus,
 } from "./phase7-calibration-loop.js";
+export { renderCalibrationDashboard } from "./calibration-dashboard.js";
 export {
   computeFindingSeverityCompositeCalibrationScore,
   ingestFindingSeverityCalibrationSignals,

--- a/test/unit/calibration-dashboard.test.ts
+++ b/test/unit/calibration-dashboard.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { renderCalibrationDashboard } from "../../packages/gittensory-engine/src/calibration-dashboard";
+import { computePhase7CalibrationLoop, resolvePhase7CalibrationConfig } from "../../packages/gittensory-engine/src/phase7-calibration-loop";
+import type { CalibrationSourceMetric, Phase7CalibrationLoopResult } from "../../packages/gittensory-engine/src/phase7-calibration-loop";
+
+const source = (over: Partial<CalibrationSourceMetric>): CalibrationSourceMetric => ({
+  source: "pr_outcome",
+  accuracy: 0.74,
+  sampleSize: 100,
+  observedAt: "2026-07-04T12:00:00.000Z",
+  fresh: true,
+  ...over,
+});
+
+const makeResult = (over: Partial<Phase7CalibrationLoopResult> = {}): Phase7CalibrationLoopResult => ({
+  enabled: true,
+  baselineAccuracy: 0.62,
+  combinedAccuracy: 0.78,
+  deltaFromBaseline: 0.16,
+  weights: { historicalReplay: 0.5, prOutcome: 0.5 },
+  bySource: {
+    historical_replay: source({ source: "historical_replay", accuracy: 0.82, replayRunId: "r1", harnessStatus: "healthy" }),
+    pr_outcome: source({ source: "pr_outcome", accuracy: 0.74 }),
+  },
+  replayHarnessHold: false,
+  replayHarnessStatus: "healthy",
+  autonomyIncreasePermitted: true,
+  holdReasons: [],
+  replayRunDue: false,
+  audit: { contributingSources: ["historical_replay", "pr_outcome"], rejectedSources: [] },
+  ...over,
+});
+
+describe("renderCalibrationDashboard (#4261)", () => {
+  it("renders a healthy result above baseline with a positive delta and per-source freshness", () => {
+    const out = renderCalibrationDashboard(makeResult());
+    expect(out).toContain("combined accuracy: 78% vs 62% baseline (+16pp)");
+    expect(out).toContain("historical_replay: 82% (n=100, fresh)");
+    expect(out).toContain("pr_outcome: 74% (n=100, fresh)");
+    expect(out).toContain("replay harness: healthy");
+    expect(out).not.toContain("replay run due");
+    expect(out).not.toContain("holds:");
+  });
+
+  it("renders a degraded result below baseline with a negative delta (no + sign)", () => {
+    const out = renderCalibrationDashboard(makeResult({ combinedAccuracy: 0.5, deltaFromBaseline: -0.12 }));
+    expect(out).toContain("combined accuracy: 50% vs 62% baseline (-12pp)");
+  });
+
+  it("renders the no-data state clearly instead of a fake 0%, showing '—' for absent sources, a due run, and holds", () => {
+    const out = renderCalibrationDashboard(
+      makeResult({
+        combinedAccuracy: null,
+        deltaFromBaseline: null,
+        bySource: {
+          historical_replay: source({ source: "historical_replay", accuracy: null, sampleSize: 0, observedAt: null, fresh: false }),
+          pr_outcome: source({ source: "pr_outcome", accuracy: null, sampleSize: 0, observedAt: null, fresh: false }),
+        },
+        replayHarnessStatus: "missing",
+        replayRunDue: true,
+        holdReasons: ["insufficient_data", "replay_harness_unavailable"],
+      }),
+    );
+    expect(out).toContain("no data yet");
+    expect(out).not.toMatch(/combined accuracy: \d/); // never a numeric 0%
+    expect(out).toContain("historical_replay: — (n=0, stale)");
+    expect(out).toContain("replay harness: missing — replay run due");
+    expect(out).toContain("holds: insufficient_data; replay_harness_unavailable");
+  });
+
+  it("integrates with a real computePhase7CalibrationLoop result (fixture inputs)", () => {
+    const result = computePhase7CalibrationLoop({
+      config: resolvePhase7CalibrationConfig({
+        miner: { calibration: { phase7LoopEnabled: true, autonomyIncreaseMinAccuracy: 0.7, replayFreshnessMaxAgeHours: 168, historicalReplayWeight: 0.5, prOutcomeWeight: 0.5, prOutcomeMinDecided: 10 } },
+      }),
+      prOutcome: { mergeConfirmed: 74, mergeFalse: 26, closeConfirmed: 0, closeFalse: 0, observedAt: "2026-07-04T18:00:00Z" },
+      historicalReplay: { compositeScore: 0.82, replayRunId: "replay-2026-07-04", observedAt: "2026-07-04T12:00:00Z", harnessStatus: "healthy" },
+      now: "2026-07-04T18:00:00Z",
+    });
+    const out = renderCalibrationDashboard(result);
+    expect(out).toContain("Phase 7 self-review calibration");
+    expect(out).toContain("combined accuracy:");
+    expect(out).toContain("pr_outcome: 74%");
+  });
+});


### PR DESCRIPTION
Adds `packages/gittensory-engine/src/calibration-dashboard.ts` — `renderCalibrationDashboard(result)`, a **pure, read-only** view that turns a computed `Phase7CalibrationLoopResult` (from the landed `computePhase7CalibrationLoop`) into a compact, deterministic, CLI-suitable dashboard for a human.

## What it surfaces
- Combined accuracy vs the documented baseline, with the delta in percentage points (`+16pp` / `-12pp`).
- Per-source (`historical_replay` / `pr_outcome`) accuracy + sample size + freshness.
- Replay-harness status and whether a replay run is due.
- Any hold reasons.

It is the read-only **consumer** of the calibration module — it renders, gates nothing, and mutates nothing.

## The 'no data yet' state
Explicitly handled: when `combinedAccuracy === null` (both sources absent/rejected), it prints a clear message rather than presenting an absent signal as a real **0%** accuracy — and shows `—` for absent per-source metrics. Per the issue, this is the common case until the historical-replay scorers are wired to feed live numbers (**#4248**, maintainer-only — cited, not duplicated); the render/view layer is groundwork the wiring doesn't need to wait on.

## Tests
`test/unit/calibration-dashboard.test.ts`: a healthy result above baseline (positive delta, fresh sources), a degraded result below baseline (negative delta, no `+`), the no-data state (`—`, due run, holds, never a numeric 0%), and a **real `computePhase7CalibrationLoop` integration** test with fixture inputs (mirroring the module's own test pattern). **100% branch coverage**; typecheck clean; engine node:test suite (325 tests) and engine-parity drift-check green. Re-exported from the barrel.

Closes #4261