### PR TITLE
test(config): lock in path-instructions + exclude-paths field group parser (#2209)

### DIFF
--- a/test/unit/config-templates.test.ts
+++ b/test/unit/config-templates.test.ts
@@ -5,6 +5,7 @@ import {
   gateConfigToJson,
   parseFocusManifest,
   parseFocusManifestContent,
+  resolveReviewPathInstructions,
   resolveReviewPromptOverrides,
   reviewConfigToJson,
 } from "../../src/signals/focus-manifest";
@@ -191,5 +192,29 @@ describe("config/examples review templates (#1682)", () => {
     expect(on.gate.linkedIssue).toBe("block");
     expect(on.gate.duplicates).toBe("advisory");
     expect(gateConfigToJson(on.gate)).toEqual({ enabled: true, linkedIssue: "block", duplicates: "advisory" });
+  });
+
+  it("resolves the path-instructions + exclude-paths field group via parse + round-trip + glob application (#2209)", () => {
+    const full = readConfigExample("gittensory.full.yml");
+    expect(full).toMatch(/exclude_paths:/);
+    expect(full).toMatch(/path_instructions:/);
+    // Defaults: both are empty lists — no per-path review instructions, nothing excluded.
+    const def = parseFocusManifest({});
+    expect(def.review.pathInstructions).toEqual([]);
+    expect(def.review.excludePaths).toEqual([]);
+    // Explicit values parse and round-trip byte-for-byte through reviewConfigToJson — the parity the
+    // config-generator's list editors for these two fields emit into.
+    const on = parseFocusManifest({
+      review: { path_instructions: [{ path: "src/**", instructions: "be strict" }], exclude_paths: ["dist/**"] },
+    });
+    expect(on.review.pathInstructions).toEqual([{ path: "src/**", instructions: "be strict" }]);
+    expect(on.review.excludePaths).toEqual(["dist/**"]);
+    expect(reviewConfigToJson(on.review)).toEqual({
+      path_instructions: [{ path: "src/**", instructions: "be strict" }],
+      exclude_paths: ["dist/**"],
+    });
+    // A path instruction applies only to changed files matching its glob (empty string otherwise).
+    expect(resolveReviewPathInstructions(on.review.pathInstructions, ["src/index.ts"])).toContain("be strict");
+    expect(resolveReviewPathInstructions(on.review.pathInstructions, ["docs/readme.md"])).toBe("");
   });
 });


### PR DESCRIPTION
Locks in the parser parity the config-generator's **path-instructions + exclude-paths field group** depends on (Closes #2209) — same test-only approach as #4454/#4465/#4480.

Asserts, against `gittensory.full.yml` + `parseFocusManifest`/`reviewConfigToJson`:
- Both fields **default to empty lists** (no per-path instructions, nothing excluded).
- Explicit values — a `{ path, instructions }` entry and a glob exclude list — **parse and round-trip byte-for-byte** through `reviewConfigToJson`.
- A path instruction **applies only to changed files matching its glob** (`resolveReviewPathInstructions` returns the instruction for `src/index.ts`, empty for `docs/readme.md`).

That's exactly the parity the generator's two list editors emit into, pinned before the UI slice builds on it.

## Test
One `it(...)` appended to `test/unit/config-templates.test.ts` (16 pass). **Test-only, single file** — no `src` diff.

- [x] Conventional Commit; focused; **Closes #2209**. No `site/`/`CNAME`/`**/lovable/**`; no `CHANGELOG.md`. Test-only.