### PR TITLE
fix(selfhost): build gittensory-engine before bundling in deploy-selfhost-prebuilt.sh

### DIFF
--- a/scripts/deploy-selfhost-prebuilt.sh
+++ b/scripts/deploy-selfhost-prebuilt.sh
@@ -35,7 +35,7 @@ run_node_build() {
     -v "$PWD:/work" \
     -w /work \
     "$NODE_IMAGE" \
-    sh -lc 'npm ci --ignore-scripts && node scripts/build-selfhost.mjs --all && node scripts/validate-selfhost-sourcemap.mjs'
+    sh -lc 'npm ci --ignore-scripts && npm --workspace @jsonbored/gittensory-engine run build && node scripts/build-selfhost.mjs --all && node scripts/validate-selfhost-sourcemap.mjs'
 }
 
 run_sentry_upload() {

--- a/test/unit/docs-selfhost-update-rollback.test.ts
+++ b/test/unit/docs-selfhost-update-rollback.test.ts
@@ -32,6 +32,17 @@ describe("self-host update + rollback docs (#1823)", () => {
     expect(prebuiltScript).toContain('up -d --no-deps "$SERVICE"');
   });
 
+  it("prebuilt deploy builds the gittensory-engine workspace before bundling (#4530)", () => {
+    // packages/gittensory-engine/dist/ is gitignored and built via `tsc`; `npm ci --ignore-scripts`
+    // never triggers that build on its own, so anything that imports the engine (e.g.
+    // packages/gittensory-miner) fails to resolve during the --all bundle unless this runs first.
+    const engineBuildIndex = prebuiltScript.indexOf("@jsonbored/gittensory-engine run build");
+    const bundleIndex = prebuiltScript.indexOf("build-selfhost.mjs --all");
+    expect(engineBuildIndex).toBeGreaterThan(-1);
+    expect(bundleIndex).toBeGreaterThan(-1);
+    expect(engineBuildIndex).toBeLessThan(bundleIndex);
+  });
+
   it("post-update script probes /ready without mutating operator-owned state", () => {
     expect(postUpdateScript).toContain("/ready");
     expect(postUpdateScript).toContain("GITTENSORY_IMAGE");


### PR DESCRIPTION
## Summary
- `run_node_build()` ran `npm ci --ignore-scripts` straight into `build-selfhost.mjs --all` with no step to build `packages/gittensory-engine` first
- `packages/gittensory-engine/dist/` is gitignored (built via `tsc`), and the self-host bundle's dependency graph reaches it transitively (`src/mcp/find-opportunities.ts` → `packages/gittensory-miner/lib/opportunity-fanout.js`/`opportunity-ranker.js` → `@jsonbored/gittensory-engine` by package name) — this was latent until that miner-side import landed, and will reproduce on any self-host instance's next update until fixed
- Mirrors the existing `build:miner` root script's ordering (engine build before miner build)

## Verification
- Reproduced and fixed live on `edge-nl-01` while bringing it current with `main` (worked around out-of-band there first, no repo changes, then verified this exact fix resolves it cleanly on a second run)
- Added a regression test asserting the engine build step precedes the bundle step in the script content
- `bash -n` syntax check passes; new test passes; unrelated pre-existing typecheck errors in `test/unit/miner-opportunity-ranker.test.ts` are untouched by this change

## Test plan
- [x] `npx vitest run test/unit/docs-selfhost-update-rollback.test.ts`
- [x] `bash -n scripts/deploy-selfhost-prebuilt.sh`
- [x] Verified live against a real self-host instance

Fixes #4530