### PR TITLE
feat(miner-hands): Agent-SDK CodingAgentDriver (query() loop)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -364,6 +364,156 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.3.205",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.205.tgz",
+      "integrity": "sha512-ft6iBw9kXudsusiXNpeybIPBJ07Z3tqp1ROSg5cEJqgA+9i+JJj2sRfQth+QD+lyenbbAU8yPieLxIimvfBhtw==",
+      "license": "SEE LICENSE IN README.md",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.205",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.205",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.205",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.205",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.205",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.205",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.205",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.205"
+      },
+      "peerDependencies": {
+        "@anthropic-ai/sdk": ">=0.93.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+      "version": "0.3.205",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.205.tgz",
+      "integrity": "sha512-lrfJ4eVtzfPkCpbSkBOGSMQCBbvmW6nbPzgHE4IwMN3scZlpuFMUFqh2aaJa/X2SAcWD9H2S0t2WWvSRgM7BjA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+      "version": "0.3.205",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.205.tgz",
+      "integrity": "sha512-G6ETPmL5mNzJ2DFsWxG3jmsmrXgZX1N2ZCJvxaGUUpjTsKZJ4Tup1cWYvcd/m7o5fYZmx9REmgzTwsAIc1fdPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+      "version": "0.3.205",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.205.tgz",
+      "integrity": "sha512-CXzySK3PV3EizCRPXnxPqeaAtgrBFDnMFOVpMe36oC3U16yDb1b1tAJGqZi/7uFrVvAiaXvnSFxhUWnDDSaO+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+      "version": "0.3.205",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.205.tgz",
+      "integrity": "sha512-91fgdG4aTnQ29sKOcUqgH4+tKCW2ut6PWGRSYmXNDbROasJm1rAlPdzC5brdu/e4c0CDSNV6TWyE5JCjaS/jlQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+      "version": "0.3.205",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.205.tgz",
+      "integrity": "sha512-siS+1iNqBSlGFZZvJY6+mhzZ/6/ec/TbX9GMuwmTF0E6fxGhIIp797jJxR1q8r6FAq7d39mEoRNhC0Ffo60uNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+      "version": "0.3.205",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.205.tgz",
+      "integrity": "sha512-vvsb7GlnA8CTSVvvTkrXjcSeRKqxSM7p/tU3Od9ICAZeWHglptekEyzLEApzLuLbI5ewfFF/F0q3NwOBbo18dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+      "version": "0.3.205",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.205.tgz",
+      "integrity": "sha512-SpP5zF68weFez/6pKrGzq/UVAJDMDNphWqmkLfOpWTDBL5xy6XlIZw5Bl4EXoVnfi2VLFkwuffNeFe+9SdX7kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+      "version": "0.3.205",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.205.tgz",
+      "integrity": "sha512-kg2kkXyeSoFLruO3Ic2IruLxzBR0xCUtmlJHdWi3SYW7JhAKNJg4fcrdJsWcardmEw23Y2UDGDJbRyxqSVx6wg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.110.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.110.0.tgz",
+      "integrity": "sha512-hOP4bNYXDFHDxxiEgzlILXrxZIYCDnhe8sry0RDRKD/QnsEpvZcQpablCdm9X/WuD/YgOiSIkkqsL1mLLlTqJw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@apm-js-collab/code-transformer": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.15.0.tgz",
@@ -4971,11 +5121,18 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@standard-schema/utils": {
@@ -9444,6 +9601,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense",
+      "peer": true
+    },
     "node_modules/fast-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
@@ -10701,6 +10865,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
@@ -11609,7 +11787,7 @@
       "version": "8.9.0",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.0.tgz",
       "integrity": "sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18 || ^20 || >= 21"
@@ -13524,6 +13702,17 @@
       "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -13891,6 +14080,13 @@
         "node": ">=18"
       }
     },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -14215,7 +14411,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/vary": {
@@ -14871,6 +15067,7 @@
       "version": "0.2.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.3.205",
         "yaml": "^2.9.0"
       },
       "devDependencies": {

--- a/packages/gittensory-engine/package.json
+++ b/packages/gittensory-engine/package.json
@@ -65,6 +65,7 @@
     "test": "npm run build && rm -rf dist-test && tsc -p tsconfig.test.json && node --test \"dist-test/**/*.test.js\""
   },
   "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.3.205",
     "yaml": "^2.9.0"
   },
   "devDependencies": {

--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -220,6 +220,13 @@ export {
   type RunCodingAgentAttemptOptions,
 } from "./miner/driver-factory.js";
 export * from "./miner/attempt-metering.js";
+export {
+  createAgentSdkCodingAgentDriver,
+  parseGitStatusPorcelain,
+  type AgentSdkQueryFn,
+  type CreateAgentSdkCodingAgentDriverOptions,
+  type ListChangedFilesFn,
+} from "./miner/agent-sdk-driver.js";
 export * from "./plan-export.js";
 export { countPlanStepsByStatus } from "./plan-step-stats.js";
 export { countPlanSteps } from "./plan-step-count.js";

--- a/packages/gittensory-engine/src/miner/agent-sdk-driver.ts
+++ b/packages/gittensory-engine/src/miner/agent-sdk-driver.ts
@@ -1,0 +1,187 @@
+// Agent-SDK `CodingAgentDriver` implementation (#4267): a second implementation of the driver interface
+// (#4262), this one driving the coding agent in-process via the Claude Agent SDK's `query()` async-iterable
+// loop rather than shelling out to a CLI binary (the CLI-subprocess sibling, #4266). Same
+// `CodingAgentDriverTask`/`CodingAgentDriverResult` contract as that sibling, so a caller (the iterate-loop
+// orchestrator, maintainer-only #2333) can swap between the two with no caller-side changes.
+//
+// `changedFiles` is derived from a `git status --porcelain` snapshot taken before and after the run (diffed),
+// NOT from parsing the SDK's streamed `tool_use` blocks. This is deliberate: `guardCodingAgentDriverResult`
+// (#4276) skips its lint-guard entirely when `changedFiles` is empty ("nothing to check"), so an incomplete
+// extraction here would silently skip real checks on files the agent actually touched. A git-status diff
+// catches every edit regardless of which tool made it (Edit, Write, or a Bash-run `sed`), where enumerating
+// every builtin tool's input schema would not.
+//
+// `options.hooks` forwards verbatim into the SDK's own `query()` hooks option (e.g. `PreToolUse`) rather than
+// being consumed or hidden here: maintainer-only #2343 ("PreToolUse-hook-enforced house rules") names this
+// driver's SDK session as its intended hook attachment point, so that surface must stay reachable from outside
+// this module, not fully encapsulated.
+
+import { execFile } from "node:child_process";
+import { query as claudeAgentSdkQuery } from "@anthropic-ai/claude-agent-sdk";
+import type { Options as ClaudeAgentSdkOptions, SDKMessage } from "@anthropic-ai/claude-agent-sdk";
+import { buildAllowlistedEnv, redactSecrets, SUBPROCESS_CLI_ENV_ALLOWLIST } from "../subprocess-env.js";
+import type { CodingAgentDriver, CodingAgentDriverResult, CodingAgentDriverTask } from "./coding-agent-driver.js";
+
+/** `SUBPROCESS_CLI_ENV_ALLOWLIST` plus the one credential the Agent SDK's underlying session needs. */
+const AGENT_SDK_ENV_ALLOWLIST = [...SUBPROCESS_CLI_ENV_ALLOWLIST, "ANTHROPIC_API_KEY"] as const;
+
+/** Test/injection seam for `query()` — only the async-iterable half of the SDK's real `Query` return type
+ *  (which also carries ~15 control-plane methods like `interrupt`/`setPermissionMode` this driver never
+ *  calls), so a test fake only has to be an async generator, not a full `Query` implementation. */
+export type AgentSdkQueryFn = (params: {
+  prompt: string;
+  options?: ClaudeAgentSdkOptions;
+}) => AsyncIterable<SDKMessage>;
+
+/** Test/injection seam for the changed-files snapshot — real IO (spawns `git`) lives only in the default
+ *  implementation, mirroring `LintGuardSpawnFn`'s injected-IO convention (#4276) so this module stays
+ *  synchronous-IO-free in tests. */
+export type ListChangedFilesFn = (cwd: string) => Promise<readonly string[]>;
+
+export type CreateAgentSdkCodingAgentDriverOptions = {
+  /** Parent env to allowlist-filter for the SDK subprocess; defaults to `process.env`. */
+  env?: Record<string, string | undefined> | undefined;
+  /** Forwarded verbatim into the SDK's `query()` `hooks` option — see module header. */
+  hooks?: ClaudeAgentSdkOptions["hooks"] | undefined;
+  query?: AgentSdkQueryFn | undefined;
+  listChangedFiles?: ListChangedFilesFn | undefined;
+};
+
+/**
+ * Pure parser for `git status --porcelain` (v1 format) output into a list of relative file paths. Each line is
+ * a fixed 2-character status code, a space, then the path; a rename/copy line additionally has ` -> ` before
+ * the new path, and only the new path is kept. Best-effort: this feeds a diff-against-a-before-snapshot, not a
+ * security boundary, so unusual porcelain shapes (e.g. paths containing " -> ") are not specially escaped.
+ */
+export function parseGitStatusPorcelain(output: string): string[] {
+  return output
+    .split("\n")
+    .map((line) => line.replace(/\r$/, ""))
+    .filter((line) => line.length > 3)
+    .map((line) => {
+      const rest = line.slice(3);
+      const arrowIndex = rest.indexOf(" -> ");
+      return arrowIndex === -1 ? rest : rest.slice(arrowIndex + 4);
+    })
+    .map((path) => path.trim())
+    .filter(Boolean);
+}
+
+function defaultListChangedFiles(cwd: string): Promise<string[]> {
+  return new Promise((resolve, reject) => {
+    execFile("git", ["status", "--porcelain"], { cwd }, (error, stdout) => {
+      if (error) {
+        reject(error);
+        return;
+      }
+      resolve(parseGitStatusPorcelain(stdout));
+    });
+  });
+}
+
+function isResultMessage(message: SDKMessage): message is Extract<SDKMessage, { type: "result" }> {
+  return message.type === "result";
+}
+
+function isAssistantMessage(message: SDKMessage): message is Extract<SDKMessage, { type: "assistant" }> {
+  return message.type === "assistant";
+}
+
+function isSuccessResult(
+  message: Extract<SDKMessage, { type: "result" }>,
+): message is Extract<SDKMessage, { type: "result"; subtype: "success" }> {
+  return message.subtype === "success";
+}
+
+function extractAssistantText(message: Extract<SDKMessage, { type: "assistant" }>): string[] {
+  const parts: string[] = [];
+  for (const block of message.message.content) {
+    if (block.type === "text") parts.push(block.text);
+  }
+  return parts;
+}
+
+function buildPrompt(task: CodingAgentDriverTask): string {
+  return [
+    task.instructions,
+    "",
+    `Read the acceptance criteria at ${task.acceptanceCriteriaPath} before making any changes, and stay scoped to ${task.workingDirectory}.`,
+  ].join("\n");
+}
+
+/** Construct an Agent-SDK-backed `CodingAgentDriver`. See module header for the design rationale. */
+export function createAgentSdkCodingAgentDriver(
+  options: CreateAgentSdkCodingAgentDriverOptions = {},
+): CodingAgentDriver {
+  const runQuery = options.query ?? claudeAgentSdkQuery;
+  const listChangedFiles = options.listChangedFiles ?? defaultListChangedFiles;
+
+  return {
+    async run(task: CodingAgentDriverTask): Promise<CodingAgentDriverResult> {
+      const env = buildAllowlistedEnv(options.env ?? process.env, AGENT_SDK_ENV_ALLOWLIST);
+      const before = new Set(await listChangedFiles(task.workingDirectory));
+      const transcriptParts: string[] = [];
+      let terminal: Extract<SDKMessage, { type: "result" }> | null = null;
+
+      try {
+        for await (const message of runQuery({
+          prompt: buildPrompt(task),
+          options: {
+            cwd: task.workingDirectory,
+            maxTurns: task.maxTurns,
+            env,
+            ...(options.hooks !== undefined ? { hooks: options.hooks } : {}),
+          },
+        })) {
+          if (isAssistantMessage(message)) transcriptParts.push(...extractAssistantText(message));
+          if (isResultMessage(message)) terminal = message;
+        }
+      } catch (error) {
+        const messageText = error instanceof Error ? error.message : "unknown error";
+        return {
+          ok: false,
+          changedFiles: [],
+          summary: "agent-sdk driver invocation failed",
+          // Whatever transcript accumulated before the throw is real diagnostic material for a failed attempt
+          // (mirrors src/selfhost/ai.ts's spawn wrapper resolving with partial stdout/stderr on a kill/timeout
+          // rather than discarding it), so it is kept here rather than dropped.
+          transcript: redactSecrets(transcriptParts.join("\n\n")),
+          error: redactSecrets(messageText),
+        };
+      }
+
+      const after = await listChangedFiles(task.workingDirectory);
+      const changedFiles = after.filter((file) => !before.has(file));
+      const transcript = redactSecrets(transcriptParts.join("\n\n"));
+
+      if (!terminal) {
+        return {
+          ok: false,
+          changedFiles,
+          summary: "agent-sdk driver ended without a result message",
+          transcript,
+          error: "missing_result_message",
+        };
+      }
+
+      if (isSuccessResult(terminal)) {
+        return {
+          ok: !terminal.is_error,
+          changedFiles,
+          summary: terminal.result,
+          transcript,
+          turnsUsed: terminal.num_turns,
+        };
+      }
+
+      return {
+        ok: false,
+        changedFiles,
+        summary: `agent-sdk driver ${terminal.subtype}`,
+        transcript,
+        turnsUsed: terminal.num_turns,
+        error: redactSecrets(terminal.errors.join("; ") || terminal.subtype),
+      };
+    },
+  };
+}

--- a/test/unit/agent-sdk-driver.test.ts
+++ b/test/unit/agent-sdk-driver.test.ts
@@ -1,0 +1,288 @@
+import { execFile } from "node:child_process";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  createAgentSdkCodingAgentDriver,
+  parseGitStatusPorcelain,
+  type AgentSdkQueryFn,
+  type CodingAgentDriverTask,
+} from "../../packages/gittensory-engine/src/index";
+
+const execFileAsync = promisify(execFile);
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+const task: CodingAgentDriverTask = {
+  attemptId: "attempt-1",
+  workingDirectory: "/tmp/attempt-1",
+  acceptanceCriteriaPath: "/tmp/attempt-1/acceptance-criteria.json",
+  instructions: "fix the flaky test",
+  maxTurns: 8,
+};
+
+function successResult(overrides: Partial<Record<string, unknown>> = {}) {
+  return {
+    type: "result" as const,
+    subtype: "success" as const,
+    is_error: false,
+    num_turns: 3,
+    result: "fixed the flaky test",
+    ...overrides,
+  };
+}
+
+function assistantMessage(text: string) {
+  return {
+    type: "assistant" as const,
+    message: { content: [{ type: "text", text }] },
+  };
+}
+
+function fakeQuery(messages: unknown[]): AgentSdkQueryFn {
+  return (() =>
+    (async function* () {
+      for (const message of messages) yield message;
+    })()) as unknown as AgentSdkQueryFn;
+}
+
+describe("parseGitStatusPorcelain (#4267)", () => {
+  it("parses modified/added/untracked lines", () => {
+    expect(parseGitStatusPorcelain(" M src/foo.ts\nA  src/bar.ts\n?? src/baz.ts\n")).toEqual([
+      "src/foo.ts",
+      "src/bar.ts",
+      "src/baz.ts",
+    ]);
+  });
+
+  it("keeps only the new path for a rename/copy line", () => {
+    expect(parseGitStatusPorcelain("R  src/old.ts -> src/new.ts\n")).toEqual(["src/new.ts"]);
+  });
+
+  it("returns an empty array for empty or whitespace-only output", () => {
+    expect(parseGitStatusPorcelain("")).toEqual([]);
+    expect(parseGitStatusPorcelain("\n\n")).toEqual([]);
+  });
+
+  it("strips trailing carriage returns", () => {
+    expect(parseGitStatusPorcelain(" M src/foo.ts\r\n")).toEqual(["src/foo.ts"]);
+  });
+});
+
+describe("createAgentSdkCodingAgentDriver (#4267)", () => {
+  it("maps a successful result message into an ok CodingAgentDriverResult, joining assistant text into the transcript", async () => {
+    const driver = createAgentSdkCodingAgentDriver({
+      query: fakeQuery([assistantMessage("reading the code"), assistantMessage("applied the fix"), successResult()]),
+      listChangedFiles: async (cwd) => (cwd === task.workingDirectory ? [] : []),
+    });
+    const result = await driver.run(task);
+    expect(result).toMatchObject({
+      ok: true,
+      summary: "fixed the flaky test",
+      turnsUsed: 3,
+      changedFiles: [],
+    });
+    expect(result.transcript).toBe("reading the code\n\napplied the fix");
+  });
+
+  it("diffs changedFiles as (after - before), so a pre-existing dirty file is excluded but a new edit is kept", async () => {
+    let call = 0;
+    const driver = createAgentSdkCodingAgentDriver({
+      query: fakeQuery([successResult()]),
+      listChangedFiles: async () => {
+        call += 1;
+        return call === 1 ? ["acceptance-criteria.json"] : ["acceptance-criteria.json", "src/foo.ts"];
+      },
+    });
+    const result = await driver.run(task);
+    expect(result.changedFiles).toEqual(["src/foo.ts"]);
+  });
+
+  it("reports ok:false when the result message itself carries is_error:true despite subtype 'success'", async () => {
+    const driver = createAgentSdkCodingAgentDriver({
+      query: fakeQuery([successResult({ is_error: true })]),
+      listChangedFiles: async () => [],
+    });
+    const result = await driver.run(task);
+    expect(result.ok).toBe(false);
+  });
+
+  it("maps a non-success result subtype into ok:false with a joined error message", async () => {
+    const driver = createAgentSdkCodingAgentDriver({
+      query: fakeQuery([
+        {
+          type: "result",
+          subtype: "error_max_turns",
+          is_error: true,
+          num_turns: 8,
+          errors: ["exceeded max turns"],
+        },
+      ]),
+      listChangedFiles: async () => [],
+    });
+    const result = await driver.run(task);
+    expect(result).toMatchObject({
+      ok: false,
+      summary: "agent-sdk driver error_max_turns",
+      turnsUsed: 8,
+      error: "exceeded max turns",
+    });
+  });
+
+  it("falls back to the subtype string when the error result has no errors entries", async () => {
+    const driver = createAgentSdkCodingAgentDriver({
+      query: fakeQuery([
+        { type: "result", subtype: "error_max_budget_usd", is_error: true, num_turns: 2, errors: [] },
+      ]),
+      listChangedFiles: async () => [],
+    });
+    const result = await driver.run(task);
+    expect(result.error).toBe("error_max_budget_usd");
+  });
+
+  it("reports ok:false with missing_result_message when the stream ends without a result message", async () => {
+    const driver = createAgentSdkCodingAgentDriver({
+      query: fakeQuery([assistantMessage("still working")]),
+      listChangedFiles: async () => [],
+    });
+    const result = await driver.run(task);
+    expect(result).toMatchObject({ ok: false, error: "missing_result_message" });
+    expect(result.transcript).toBe("still working");
+  });
+
+  it("returns ok:false with the caught error message when the query stream throws", async () => {
+    const throwingQuery: AgentSdkQueryFn = (() =>
+      (async function* () {
+        yield assistantMessage("about to fail");
+        throw new Error("session crashed");
+      })()) as unknown as AgentSdkQueryFn;
+    const driver = createAgentSdkCodingAgentDriver({ query: throwingQuery, listChangedFiles: async () => [] });
+    const result = await driver.run(task);
+    expect(result).toMatchObject({ ok: false, changedFiles: [], error: "session crashed" });
+  });
+
+  it("redacts a known secret shape out of both the transcript accumulated so far and a thrown error message", async () => {
+    const secretToken = "sk-ant-abcdefghijklmnopqrstuvwxyz";
+    const throwingQuery: AgentSdkQueryFn = (() =>
+      (async function* () {
+        yield assistantMessage(`leaked token ${secretToken}`);
+        throw new Error(`auth failed with ${secretToken}`);
+      })()) as unknown as AgentSdkQueryFn;
+    const driver = createAgentSdkCodingAgentDriver({ query: throwingQuery, listChangedFiles: async () => [] });
+    const result = await driver.run(task);
+    expect(result.error).not.toContain(secretToken);
+    expect(result.error).toContain("[redacted]");
+    expect(result.transcript).not.toContain(secretToken);
+    expect(result.transcript).toContain("[redacted]");
+  });
+
+  it("forwards options.hooks verbatim into the query() call's options.hooks", async () => {
+    const hooks = { PreToolUse: [{ hooks: [async () => ({ continue: true })] }] } as never;
+    let capturedOptions: Record<string, unknown> | undefined;
+    const capturingQuery: AgentSdkQueryFn = ((params: { options?: Record<string, unknown> }) => {
+      capturedOptions = params.options;
+      return (async function* () {
+        yield successResult();
+      })();
+    }) as unknown as AgentSdkQueryFn;
+    const driver = createAgentSdkCodingAgentDriver({ query: capturingQuery, hooks, listChangedFiles: async () => [] });
+    await driver.run(task);
+    expect(capturedOptions?.hooks).toBe(hooks);
+  });
+
+  it("omits the hooks key entirely from query() options when no hooks were configured", async () => {
+    let capturedOptions: Record<string, unknown> | undefined;
+    const capturingQuery: AgentSdkQueryFn = ((params: { options?: Record<string, unknown> }) => {
+      capturedOptions = params.options;
+      return (async function* () {
+        yield successResult();
+      })();
+    }) as unknown as AgentSdkQueryFn;
+    const driver = createAgentSdkCodingAgentDriver({ query: capturingQuery, listChangedFiles: async () => [] });
+    await driver.run(task);
+    expect(capturedOptions).not.toHaveProperty("hooks");
+  });
+
+  it("passes cwd/maxTurns from the task through to query() options, and allowlists the env (dropping non-allowlisted vars, keeping ANTHROPIC_API_KEY)", async () => {
+    let capturedOptions: Record<string, unknown> | undefined;
+    const capturingQuery: AgentSdkQueryFn = ((params: { options?: Record<string, unknown> }) => {
+      capturedOptions = params.options;
+      return (async function* () {
+        yield successResult();
+      })();
+    }) as unknown as AgentSdkQueryFn;
+    const driver = createAgentSdkCodingAgentDriver({
+      query: capturingQuery,
+      listChangedFiles: async () => [],
+      env: { HOME: "/home/miner", ANTHROPIC_API_KEY: "sk-ant-test-key-000000000000", SECRET_OTHER: "nope" },
+    });
+    await driver.run(task);
+    expect(capturedOptions).toMatchObject({ cwd: task.workingDirectory, maxTurns: task.maxTurns });
+    expect((capturedOptions?.env as Record<string, string>).HOME).toBe("/home/miner");
+    expect((capturedOptions?.env as Record<string, string>).ANTHROPIC_API_KEY).toBe("sk-ant-test-key-000000000000");
+    expect(capturedOptions?.env).not.toHaveProperty("SECRET_OTHER");
+  });
+
+  it("with no listChangedFiles injected, the default implementation diffs a real git-status snapshot in the working directory", async () => {
+    const root = mkdtempSync(join(tmpdir(), "agent-sdk-driver-"));
+    roots.push(root);
+    await execFileAsync("git", ["init", "-q"], { cwd: root });
+    writeFileSync(join(root, "pre-existing.txt"), "already dirty before the attempt\n");
+
+    const editDuringAttempt: AgentSdkQueryFn = (() =>
+      (async function* () {
+        // Simulate the coding agent editing a file mid-attempt, the same way a real Edit/Write tool call would --
+        // this must happen DURING iteration (after the "before" snapshot, before the "after" one), not eagerly.
+        writeFileSync(join(root, "fixed.ts"), "// fix applied\n");
+        yield successResult();
+      })()) as unknown as AgentSdkQueryFn;
+    const driver = createAgentSdkCodingAgentDriver({ query: editDuringAttempt });
+    const result = await driver.run({ ...task, workingDirectory: root });
+
+    expect(result.ok).toBe(true);
+    expect(result.changedFiles).toEqual(["fixed.ts"]); // pre-existing.txt was already dirty -> excluded by the diff
+  });
+
+  it("the default listChangedFiles implementation rejects when the working directory is not a git repository", async () => {
+    const root = mkdtempSync(join(tmpdir(), "agent-sdk-driver-not-git-"));
+    roots.push(root);
+
+    const driver = createAgentSdkCodingAgentDriver({ query: fakeQuery([successResult()]) });
+    await expect(driver.run({ ...task, workingDirectory: root })).rejects.toThrow();
+  });
+
+  it("ignores non-text assistant content blocks (e.g. tool_use) when building the transcript", async () => {
+    const driver = createAgentSdkCodingAgentDriver({
+      query: fakeQuery([
+        {
+          type: "assistant",
+          message: { content: [{ type: "tool_use", name: "Edit", input: {} }, { type: "text", text: "done" }] },
+        },
+        successResult(),
+      ]),
+      listChangedFiles: async () => [],
+    });
+    const result = await driver.run(task);
+    expect(result.transcript).toBe("done");
+  });
+
+  it("falls back to 'unknown error' when the query stream throws a non-Error value", async () => {
+    const throwingQuery: AgentSdkQueryFn = (() =>
+      (async function* () {
+        throw "not an Error instance";
+      })()) as unknown as AgentSdkQueryFn;
+    const driver = createAgentSdkCodingAgentDriver({ query: throwingQuery, listChangedFiles: async () => [] });
+    const result = await driver.run(task);
+    expect(result.error).toBe("unknown error");
+  });
+
+  it("constructing the driver with no injected query falls back to the real Agent SDK query() reference without invoking it", () => {
+    const driver = createAgentSdkCodingAgentDriver({});
+    expect(typeof driver.run).toBe("function");
+  });
+});


### PR DESCRIPTION
## Summary

A second implementation of the `CodingAgentDriver` interface (#4262), driving the coding agent in-process via the Claude Agent SDK's `query()` async-iterable loop rather than shelling out to a CLI binary (the CLI-subprocess sibling, #4266). Same `CodingAgentDriverTask`/`CodingAgentDriverResult` contract as that sibling, so a caller (the iterate-loop orchestrator, maintainer-only #2333) can swap between the two with no caller-side changes.

- `createAgentSdkCodingAgentDriver(options)`: builds a prompt from the task's instructions + acceptance-criteria path, calls `query({ prompt, options: { cwd, maxTurns, env, hooks } })`, collects assistant text into an (redacted) transcript, and maps the terminal `result` message into `CodingAgentDriverResult`.
- `changedFiles` is derived from a `git status --porcelain` snapshot taken **before and after** the run (diffed), not from parsing streamed `tool_use` messages. This is deliberate: `guardCodingAgentDriverResult` (#4276) skips its lint-guard entirely when `changedFiles` is empty ("nothing to check"), so an incomplete extraction here would silently skip real checks on files the agent actually touched — a git-status diff catches every edit regardless of which tool made it, where enumerating every builtin tool's input schema would not.
- `options.hooks` forwards verbatim into the SDK's own `query()` hooks option rather than being consumed/hidden here: maintainer-only #2343 ("PreToolUse-hook-enforced house rules") names this driver's SDK session as its intended hook attachment point, so that surface stays reachable from outside this module.
- Env is filtered through the existing `subprocess-env.ts` allowlist (#4284) plus `ANTHROPIC_API_KEY`, and both the transcript and any error message are run through the existing `redactSecrets`.
- Adds `@anthropic-ai/claude-agent-sdk` as a new `gittensory-engine` dependency — `npm audit` reports 0 findings. Verified `npm run ui:build` still tree-shakes it out of the Cloudflare Workers bundle (`src/` never imports the `miner/` subpath of the engine), so the hosted app's deployment is unaffected.
- Deliberately does **not** touch `driver-factory.ts`'s provider registration (`CODING_AGENT_DRIVER_NAMES`/the `createCodingAgentDriver` switch) — that file is also being touched by the in-flight sibling PR for #4266, so registering both providers is left to whichever of the two lands second (or a follow-up), avoiding an unnecessary merge collision.

Closes #4267

## Test plan

- [x] `test/unit/agent-sdk-driver.test.ts` (20 tests, 100% statement/branch/function/line coverage on the new file): `parseGitStatusPorcelain` parsing (modified/added/untracked/renamed/empty), successful result mapping, the before/after changedFiles diff (including excluding a pre-existing dirty file), `is_error:true` under a `success` subtype, non-success result subtypes (with and without `errors` entries), a stream ending without a result message, a thrown error mid-stream (including secret redaction of both the transcript-so-far and the error message), `hooks` passthrough (present and absent), env allowlisting, and a real git-repo integration test exercising the default (non-injected) `listChangedFiles` implementation, including its rejection path when the working directory isn't a git repo
- [x] `npm run typecheck`
- [x] `npm audit --audit-level=moderate` (0 vulnerabilities)
- [x] `npm run ui:build` (Workers bundle unaffected by the new dependency)
- [x] `npm run test:ci` (full local gate, green)