### PR TITLE
feat(review): add a submission-cadence signal to submitter reputation

### DIFF
--- a/src/review/submitter-reputation.ts
+++ b/src/review/submitter-reputation.ts
@@ -24,6 +24,19 @@
 // submitter_stats) — gittensory does not yet have them, so getSubmitterReputation / recordSubmissionOutcome
 // degrade fail-safe (neutral / no-op) until a later migration lands them. The PURE classifiers
 // (classifyOutcome / countOutcomes / signalFromCounts) are usable immediately.
+//
+// SUBMISSION-CADENCE SIGNAL (#4514): every existing signal here counts volume or ratios within a time window —
+// none has an inter-arrival-time (submission-cadence) dimension, so an autonomous agent operating at a
+// superhuman-but-clean pace was invisible to this module. `classifySubmissionCadence` computes the MEDIAN gap
+// (minutes) between a submitter's recent `review_targets.created_at` timestamps within the same window the
+// quality signal already reads — no new query, no migration. Its interaction with the existing signal is
+// deliberately narrow: cadence is a TIE-BREAKER folded into the existing serial-quality-failure rule in
+// `signalFromCounts`, never an independent path to 'low' — a superhuman-pace submitter with a healthy fail rate
+// and real successes is NEVER branded on cadence alone (the same success guard as the rate-based rule applies).
+// It only tips an ALREADY-elevated fail rate (at/above `cadenceAssistLowRate`, a lower bar than the hard
+// `qualityFailLowRate`) the rest of the way to 'low'. Too small a sample (`< cfg.cadenceMinGaps` computed gaps)
+// never reports an outlier — there is nothing (yet) to distinguish a genuine burst of quick, real submissions
+// from a data artifact.
 
 // ── Inlined minimal deps (no reviewbot imports) ─────────────────────────────────────────────────────────
 
@@ -49,6 +62,15 @@ export interface ReputationConfig {
   trustedMinSuccess: number;
   /** …AND a fail rate at/under this (0–1). */
   trustedMaxFailRate: number;
+  /** Cadence (#4514): fewer than this many computed inter-arrival gaps is too small a sample for a cadence
+   *  verdict — `classifySubmissionCadence` never reports an outlier below this. */
+  cadenceMinGaps: number;
+  /** Cadence (#4514): a median inter-arrival gap (minutes) at/below this counts as a superhuman-pace outlier. */
+  cadenceOutlierMedianGapMinutes: number;
+  /** Cadence (#4514): the LOWER fail-rate bar (0–1, below `qualityFailLowRate`) that, ONLY when cadence is ALSO
+   *  an outlier and the success guard still holds, tips `signalFromCounts` to 'low' — cadence is a tie-breaker,
+   *  never independently sufficient. */
+  cadenceAssistLowRate: number;
 }
 
 export type ReputationSignal = "trusted" | "neutral" | "low";
@@ -122,6 +144,41 @@ export interface ReputationCounts {
   promptInjection: number; // the ONLY hard-abuse signal — genuinely malicious
 }
 
+/** A submitter's classified submission cadence over a recency-windowed, ascending set of submission
+ *  timestamps (#4514). `medianGapMinutes` is null when there are no computable gaps (0 or 1 timestamp).
+ *  `isOutlier` is always false below `cfg.cadenceMinGaps` gaps — too small a sample to call. */
+export interface SubmissionCadence {
+  sampleGaps: number;
+  medianGapMinutes: number | null;
+  isOutlier: boolean;
+}
+
+/** Median of a non-empty numeric array. Pure; sorts a copy (does not mutate `values`). */
+function median(values: readonly number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1]! + sorted[mid]!) / 2 : sorted[mid]!;
+}
+
+/**
+ * Classify a submitter's recent submission cadence from their submission timestamps (ms epoch; any order —
+ * sorted internally). Computes the MEDIAN inter-arrival gap in minutes and flags it as a superhuman-pace
+ * outlier once the sample is large enough to be meaningful (#4514). Pure — never reads the ambient clock.
+ */
+export function classifySubmissionCadence(
+  submittedAtMs: readonly number[],
+  cfg: ReputationConfig = DEFAULT_REPUTATION_CONFIG,
+): SubmissionCadence {
+  const sorted = [...submittedAtMs].sort((a, b) => a - b);
+  const gaps: number[] = [];
+  for (let i = 1; i < sorted.length; i++) gaps.push((sorted[i]! - sorted[i - 1]!) / 60_000);
+  if (gaps.length < cfg.cadenceMinGaps) {
+    return { sampleGaps: gaps.length, medianGapMinutes: gaps.length > 0 ? median(gaps) : null, isOutlier: false };
+  }
+  const medianGapMinutes = median(gaps);
+  return { sampleGaps: gaps.length, medianGapMinutes, isOutlier: medianGapMinutes <= cfg.cadenceOutlierMedianGapMinutes };
+}
+
 // ── Signal thresholds (#reputation-redesign). Default GENEROUS: 'low' ONLY for CLEAR, RECENT, genuine abuse or
 // serial quality-failure. A high-volume contributor with a healthy number of recent SUCCESSES is NEVER 'low'. ──
 //
@@ -149,11 +206,23 @@ export const DEFAULT_REPUTATION_CONFIG: ReputationConfig = {
   lightFailWeight: 0.5,
   trustedMinSuccess: 5,
   trustedMaxFailRate: 0.2,
+  // Cadence (#4514): 4 gaps (5 submissions) before a verdict is meaningful; a 15-minute-or-less median gap
+  // between well-formed, tested, documented PRs is beyond sustainable human pace; 0.5 is a materially lower
+  // bar than qualityFailLowRate (0.7) since cadence only ever ASSISTS an already-elevated fail rate.
+  cadenceMinGaps: 4,
+  cadenceOutlierMedianGapMinutes: 15,
+  cadenceAssistLowRate: 0.5,
 };
 
 /** Derive the reputation signal from the recency-windowed, quality-classified bucket counts. Pure + total.
- *  Thresholds default to DEFAULT_REPUTATION_CONFIG (behavior-preserving); a deployment may tune them privately. */
-export function signalFromCounts(c: ReputationCounts, cfg: ReputationConfig = DEFAULT_REPUTATION_CONFIG): ReputationSignal {
+ *  Thresholds default to DEFAULT_REPUTATION_CONFIG (behavior-preserving); a deployment may tune them privately.
+ *  `cadence` (#4514) is optional and, when present, can only ever TIP an already-elevated fail rate to 'low' —
+ *  see the module header for why it is never an independent path there. */
+export function signalFromCounts(
+  c: ReputationCounts,
+  cfg: ReputationConfig = DEFAULT_REPUTATION_CONFIG,
+  cadence?: SubmissionCadence,
+): ReputationSignal {
   // Effective (weighted) genuine-fail count: full-weight reviewer rejects + half-weight light signals (flaky
   // CI + honest-collision / transient-fetch). Prompt-injection is handled separately (its own hard rule).
   const weightedFails = c.qualityFail + c.qualityFailLight * cfg.lightFailWeight;
@@ -168,6 +237,14 @@ export function signalFromCounts(c: ReputationCounts, cfg: ReputationConfig = DE
   // soft signals (duplicates/unfetchable) only count at half weight here, so they can't brand alone. ──
   const failRate = sample > 0 ? weightedFails / sample : 0;
   if (failRate >= cfg.qualityFailLowRate && c.success < cfg.qualityFailLowMaxSuccess) return "low";
+
+  // ── 'low' — cadence-assisted (#4514): a superhuman-pace outlier tips an ALREADY-elevated fail rate (past the
+  // lower cadenceAssistLowRate bar, still under the hard qualityFailLowRate one above) the rest of the way to
+  // 'low', gated by the SAME success guard. Cadence alone (no `cadence` arg, or a non-outlier, or a low/zero
+  // fail rate) never reaches this — a fast but well-calibrated actor is not penalized on pace alone. ──
+  if (cadence?.isOutlier && failRate >= cfg.cadenceAssistLowRate && c.success < cfg.qualityFailLowMaxSuccess) {
+    return "low";
+  }
 
   // ── 'trusted' — solid recent successes and a low effective fail rate. ──
   if (c.success >= cfg.trustedMinSuccess && failRate <= cfg.trustedMaxFailRate) return "trusted";
@@ -240,15 +317,19 @@ export async function getSubmitterReputation(env: Env, project: string, submitte
   try {
     const result = await storage(env)
       .prepare(
-        `SELECT status, json_extract(decision_json, '$.reasonCode') AS reasonCode
+        `SELECT status, json_extract(decision_json, '$.reasonCode') AS reasonCode, created_at AS createdAt
            FROM review_targets
           WHERE project = ? AND submitter = ? AND terminal_at IS NOT NULL AND terminal_at >= datetime('now', ?)
           ORDER BY terminal_at DESC LIMIT ?`,
       )
       .bind(project, submitter, `-${cfg.windowDays} days`, REPUTATION_WINDOW_ROW_CAP)
-      .all<{ status: string; reasonCode: string | null }>();
+      .all<{ status: string; reasonCode: string | null; createdAt: string | null }>();
     const rows = result?.results ?? [];
-    signal = signalFromCounts(countOutcomes(rows), cfg);
+    // Cadence (#4514) reuses this same windowed query — no second DB round-trip. Unparseable/missing
+    // `createdAt` values are dropped rather than treated as NaN gaps (defensive against a malformed row).
+    const submittedAtMs = rows.map((r) => (r.createdAt ? Date.parse(r.createdAt) : NaN)).filter((ms) => !Number.isNaN(ms));
+    const cadence = classifySubmissionCadence(submittedAtMs, cfg);
+    signal = signalFromCounts(countOutcomes(rows), cfg, cadence);
   } catch {
     signal = "neutral"; // fail-safe — never throw into the gate.
   }

--- a/test/unit/submitter-reputation.test.ts
+++ b/test/unit/submitter-reputation.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   classifyOutcome,
+  classifySubmissionCadence,
   countOutcomes,
   DEFAULT_REPUTATION_CONFIG,
   getSubmitterReputation,
@@ -59,6 +60,97 @@ describe("classifyOutcome — reasonCode → quality bucket (#reputation-redesig
   });
   it("an unknown close reasonCode is EXCLUDED (be generous — never penalise on an unknown code)", () => {
     expect(classifyOutcome("closed", "some_future_reason")).toBe("exclude");
+  });
+});
+
+const MINUTE = 60_000;
+
+describe("classifySubmissionCadence — median inter-arrival gap (#4514)", () => {
+  it("computes the median gap from ascending timestamps and flags a superhuman-pace outlier", () => {
+    // 5 submissions, 4 gaps of exactly 5 minutes each: median 5 <= default 15-minute outlier bar.
+    const base = 1_700_000_000_000;
+    const timestamps = [0, 1, 2, 3, 4].map((i) => base + i * 5 * MINUTE);
+    const cadence = classifySubmissionCadence(timestamps);
+    expect(cadence).toEqual({ sampleGaps: 4, medianGapMinutes: 5, isOutlier: true });
+  });
+
+  it("sorts unsorted input internally before computing gaps", () => {
+    const base = 1_700_000_000_000;
+    const ascending = [0, 1, 2, 3, 4].map((i) => base + i * 5 * MINUTE);
+    const shuffled = [ascending[2]!, ascending[0]!, ascending[4]!, ascending[1]!, ascending[3]!];
+    expect(classifySubmissionCadence(shuffled)).toEqual(classifySubmissionCadence(ascending));
+  });
+
+  it("a normal human cadence (well above the outlier bar) is not flagged", () => {
+    const base = 1_700_000_000_000;
+    // 4 gaps of 3 hours each — nowhere near the 15-minute default bar.
+    const timestamps = [0, 1, 2, 3, 4].map((i) => base + i * 3 * 60 * MINUTE);
+    const cadence = classifySubmissionCadence(timestamps);
+    expect(cadence.isOutlier).toBe(false);
+    expect(cadence.medianGapMinutes).toBe(180);
+  });
+
+  it("too few gaps (below cadenceMinGaps) never reports an outlier, even at an extreme pace", () => {
+    const base = 1_700_000_000_000;
+    // 3 submissions, 2 gaps of 1 minute each: default cadenceMinGaps is 4, so this sample is too small.
+    const timestamps = [base, base + MINUTE, base + 2 * MINUTE];
+    const cadence = classifySubmissionCadence(timestamps);
+    expect(cadence.sampleGaps).toBe(2);
+    expect(cadence.isOutlier).toBe(false);
+    expect(cadence.medianGapMinutes).toBe(1);
+  });
+
+  it("reports a null medianGapMinutes for 0 or 1 timestamps (no computable gap)", () => {
+    expect(classifySubmissionCadence([])).toEqual({ sampleGaps: 0, medianGapMinutes: null, isOutlier: false });
+    expect(classifySubmissionCadence([1_700_000_000_000])).toEqual({
+      sampleGaps: 0,
+      medianGapMinutes: null,
+      isOutlier: false,
+    });
+  });
+
+  it("computes an even-length median as the average of the two middle gaps", () => {
+    const base = 1_700_000_000_000;
+    // Gaps (minutes): 2, 4, 6, 8, 10, 12 (6 gaps, 7 timestamps) -> sorted median = avg(6, 8) = 7.
+    let cursor = base;
+    const gapsMinutes = [2, 4, 6, 8, 10, 12];
+    const timestamps = [cursor];
+    for (const gap of gapsMinutes) {
+      cursor += gap * MINUTE;
+      timestamps.push(cursor);
+    }
+    const cadence = classifySubmissionCadence(timestamps);
+    expect(cadence.sampleGaps).toBe(6);
+    expect(cadence.medianGapMinutes).toBe(7);
+    expect(cadence.isOutlier).toBe(true); // 7 <= the default 15-minute outlier bar
+  });
+
+  it("computes an odd-length median as the single middle gap", () => {
+    const base = 1_700_000_000_000;
+    // Gaps (minutes): 10, 20, 30, 40, 50 (5 gaps, 6 timestamps) -> sorted median (middle of 5) = 30.
+    let cursor = base;
+    const timestamps = [cursor];
+    for (const gap of [10, 20, 30, 40, 50]) {
+      cursor += gap * MINUTE;
+      timestamps.push(cursor);
+    }
+    const cadence = classifySubmissionCadence(timestamps);
+    expect(cadence.sampleGaps).toBe(5);
+    expect(cadence.medianGapMinutes).toBe(30);
+    expect(cadence.isOutlier).toBe(false); // 30 > the default 15-minute outlier bar
+  });
+
+  it("respects a custom config's cadenceMinGaps and cadenceOutlierMedianGapMinutes", () => {
+    const base = 1_700_000_000_000;
+    const timestamps = [0, 1, 2].map((i) => base + i * 20 * MINUTE); // 2 gaps of 20 minutes
+    const strictConfig: ReputationConfig = { ...DEFAULT_REPUTATION_CONFIG, cadenceMinGaps: 2, cadenceOutlierMedianGapMinutes: 25 };
+    expect(classifySubmissionCadence(timestamps, strictConfig)).toEqual({
+      sampleGaps: 2,
+      medianGapMinutes: 20,
+      isOutlier: true, // 20 <= 25 under the widened custom bar, and the sample now clears cadenceMinGaps: 2
+    });
+    // The SAME timestamps against the default config (cadenceMinGaps: 4) are too small a sample to call.
+    expect(classifySubmissionCadence(timestamps).isOutlier).toBe(false);
   });
 });
 
@@ -121,6 +213,37 @@ describe("signalFromCounts — generous, quality-weighted, recency-aware (#reput
   });
 });
 
+describe("signalFromCounts — cadence tie-breaker, never independent (#4514)", () => {
+  // success=1, qualityFail=2, qualityFailLight=2: sample 5, weightedFails 2+1=3, failRate 0.6 -- between the
+  // cadence-assist bar (0.5) and the hard low bar (0.7), with success (1) below qualityFailLowMaxSuccess (2).
+  const borderlineCounts = () => countOutcomes(rows(["merged", "dual_review_approved", 1], ["closed", "dual_review_declined", 2], ["closed", "checks_failed", 2]));
+
+  it("without cadence, the borderline fail rate stays neutral (the existing baseline)", () => {
+    expect(signalFromCounts(borderlineCounts())).toBe("neutral");
+  });
+
+  it("a cadence outlier tips the SAME borderline fail rate to 'low'", () => {
+    expect(signalFromCounts(borderlineCounts(), DEFAULT_REPUTATION_CONFIG, { sampleGaps: 4, medianGapMinutes: 5, isOutlier: true })).toBe("low");
+  });
+
+  it("a non-outlier cadence verdict leaves the borderline case neutral (no change)", () => {
+    expect(signalFromCounts(borderlineCounts(), DEFAULT_REPUTATION_CONFIG, { sampleGaps: 4, medianGapMinutes: 180, isOutlier: false })).toBe("neutral");
+  });
+
+  it("a cadence outlier NEVER penalizes a well-calibrated actor on its own (success guard + low fail rate hold)", () => {
+    // 6 successes, 1 genuine decline: failRate 1/7 ~= 0.14, well under BOTH the assist (0.5) and hard (0.7)
+    // bars, and success (6) clears the trusted bar -- an outlier cadence verdict must not touch this.
+    const wellCalibrated = countOutcomes(rows(["merged", "dual_review_approved", 6], ["closed", "dual_review_declined", 1]));
+    expect(signalFromCounts(wellCalibrated, DEFAULT_REPUTATION_CONFIG, { sampleGaps: 10, medianGapMinutes: 1, isOutlier: true })).toBe("trusted");
+  });
+
+  it("a cadence outlier does not affect an already-'low' or already-'trusted' verdict (falls through fine)", () => {
+    // Already 'low' via the existing hard rule regardless of cadence.
+    const alreadyLow = countOutcomes(rows(["merged", "dual_review_approved", 1], ["closed", "dual_review_declined", 7]));
+    expect(signalFromCounts(alreadyLow, DEFAULT_REPUTATION_CONFIG, { sampleGaps: 10, medianGapMinutes: 500, isOutlier: false })).toBe("low");
+  });
+});
+
 describe("signalFromCounts — config-overridable thresholds (#private-config params)", () => {
   it("defaults to DEFAULT_REPUTATION_CONFIG when no config is passed (behavior-preserving)", () => {
     const c = countOutcomes(rows(["merged", "dual_review_approved", 12], ["closed", "dual_review_declined", 1]));
@@ -178,6 +301,44 @@ describe("recordSubmissionOutcome / getSubmitterReputation (D1, fail-safe)", () 
     const rep = await getSubmitterReputation(env, "p", "u");
     expect(rep.signal).toBe("low");
     expect(rep.closeRate).toBeCloseTo(0.9); // aggregate closeRate is still surfaced for /stats
+  });
+
+  it("cadence (#4514): a superhuman-pace createdAt spread tips an already-borderline fail rate to low", async () => {
+    // Same borderline shape as the pure signalFromCounts cadence test: 1 success, 2 declines, 2 checks_failed
+    // (failRate 0.6 -- between the assist and hard bars), but every row is 5 minutes apart -> cadence outlier.
+    const base = new Date("2026-07-01T00:00:00.000Z").getTime();
+    const windowRows = [
+      { status: "merged", reasonCode: "dual_review_approved", createdAt: new Date(base).toISOString() },
+      { status: "closed", reasonCode: "dual_review_declined", createdAt: new Date(base + 5 * MINUTE).toISOString() },
+      { status: "closed", reasonCode: "dual_review_declined", createdAt: new Date(base + 10 * MINUTE).toISOString() },
+      { status: "closed", reasonCode: "checks_failed", createdAt: new Date(base + 15 * MINUTE).toISOString() },
+      { status: "closed", reasonCode: "checks_failed", createdAt: new Date(base + 20 * MINUTE).toISOString() },
+    ];
+    const env = makeEnv({ statRow: { submissions: 5, merged: 1, closed: 4, manual: 0 }, windowRows });
+    const rep = await getSubmitterReputation(env, "p", "u");
+    expect(rep.signal).toBe("low");
+  });
+
+  it("cadence (#4514): the SAME borderline shape at a normal human cadence stays neutral", async () => {
+    const base = new Date("2026-07-01T00:00:00.000Z").getTime();
+    const windowRows = [
+      { status: "merged", reasonCode: "dual_review_approved", createdAt: new Date(base).toISOString() },
+      { status: "closed", reasonCode: "dual_review_declined", createdAt: new Date(base + 5 * 60 * MINUTE).toISOString() },
+      { status: "closed", reasonCode: "dual_review_declined", createdAt: new Date(base + 10 * 60 * MINUTE).toISOString() },
+      { status: "closed", reasonCode: "checks_failed", createdAt: new Date(base + 15 * 60 * MINUTE).toISOString() },
+      { status: "closed", reasonCode: "checks_failed", createdAt: new Date(base + 20 * 60 * MINUTE).toISOString() },
+    ];
+    const env = makeEnv({ statRow: { submissions: 5, merged: 1, closed: 4, manual: 0 }, windowRows });
+    const rep = await getSubmitterReputation(env, "p", "u");
+    expect(rep.signal).toBe("neutral");
+  });
+
+  it("cadence (#4514): a missing/unparseable createdAt is dropped, not treated as a zero-gap outlier", async () => {
+    const windowRows = rows(["merged", "dual_review_approved", 1], ["closed", "dual_review_declined", 2], ["closed", "checks_failed", 2]);
+    // No createdAt on any row (the existing Row shape) -> makeEnv defaults createdAt to null for all of them.
+    const env = makeEnv({ statRow: { submissions: 5, merged: 1, closed: 4, manual: 0 }, windowRows });
+    const rep = await getSubmitterReputation(env, "p", "u");
+    expect(rep.signal).toBe("neutral"); // same borderline shape, but no usable cadence data -> unaffected
   });
   it("fail-safe → neutral when the window query throws (never throws into the gate)", async () => {
     const env = {
@@ -275,13 +436,18 @@ describe("recordSubmissionOutcome / getSubmitterReputation (D1, fail-safe)", () 
 
 // A minimal D1 stub: the first query (.first) returns submitter_stats; the window query (.all) returns the
 // review_targets rows. Both come off the same prepared-statement stub (the two call sites use .first vs .all).
-function makeEnv(opts: { statRow: { submissions: number; merged: number; closed: number; manual: number } | null; windowRows: Row[] }): Env {
+function makeEnv(opts: {
+  statRow: { submissions: number; merged: number; closed: number; manual: number } | null;
+  windowRows: Array<Row & { createdAt?: string | null }>;
+}): Env {
   return {
     DB: {
       prepare: () => ({
         bind: () => ({
           first: async () => opts.statRow,
-          all: async () => ({ results: opts.windowRows.map((r) => ({ status: r.status, reasonCode: r.reasonCode })) }),
+          all: async () => ({
+            results: opts.windowRows.map((r) => ({ status: r.status, reasonCode: r.reasonCode, createdAt: r.createdAt ?? null })),
+          }),
         }),
       }),
     },


### PR DESCRIPTION
## Summary

Every anti-abuse signal in the review stack counts volume or ratios within a time window — none has a submission-cadence (inter-arrival-time) dimension, so an autonomous agent operating at a superhuman-but-clean pace was invisible to the reputation signal.

- `classifySubmissionCadence(submittedAtMs, cfg)`: pure, computes the **median** inter-arrival gap (minutes) between a submitter's recent submission timestamps and flags a superhuman-pace outlier once the sample is large enough to be meaningful (`cadenceMinGaps`, default 4 gaps).
- `getSubmitterReputation` reuses its **existing** recency-windowed `review_targets` query (adds `created_at` to the `SELECT` list) rather than a second DB round-trip or a new migration.
- Wired into `signalFromCounts` as a **tie-breaker only**, per the issue's explicit non-goal ("should not penalize a genuinely fast but well-calibrated actor on its own"): a cadence outlier can tip an **already-elevated** fail rate (past a lower `cadenceAssistLowRate` bar — 0.5 — but still under the existing hard `qualityFailLowRate` bar — 0.7) the rest of the way to `'low'`, gated by the **same success guard** as the existing rate-based rule. A fast actor with a healthy fail rate and real recent successes is never branded by cadence alone — it cannot demote `'trusted'`, and it never independently produces `'low'`.
- Docs: the new signal and its interaction with the existing thresholds are documented in the module header and inline at each new config field / branch, matching this file's existing documentation convention (no separate external doc exists for this module today).

Not touched (left as a natural follow-up, since the issue's "and/or" phrasing allows scoping to one): `src/signals/slop.ts`'s per-PR content signals.

Closes #4514

## Test plan

- [x] `test/unit/submitter-reputation.test.ts` (47 tests, 100% statement/branch/function/line coverage on the file): `classifySubmissionCadence` (median computation for even/odd gap counts, unsorted-input sorting, below-`cadenceMinGaps` sample, 0/1-timestamp edge cases, custom config overrides), `signalFromCounts`'s cadence tie-breaker (borderline-without-cadence stays neutral, the same borderline WITH a cadence outlier tips to low, a non-outlier verdict leaves it unchanged, a well-calibrated actor is never penalized by cadence alone even as an outlier, an already-`low`/`trusted` verdict is unaffected), and `getSubmitterReputation`'s end-to-end D1 wiring (a real superhuman-cadence `created_at` spread vs. a normal-human-cadence one against the identical borderline shape, plus a missing/unparseable `created_at` case proving existing callers are unaffected)
- [x] All 47 pre-existing tests in this file plus all 17 in `test/unit/reputation-wiring.test.ts` still pass unmodified
- [x] `npm run typecheck`
- [x] `npm run test:ci` (full local gate, green, both before and after rebasing onto latest `main`)