### PR TITLE
feat(review): miner-vs-human cohort split in maintainer recap

### DIFF
--- a/packages/gittensory-engine/src/focus-manifest.ts
+++ b/packages/gittensory-engine/src/focus-manifest.ts
@@ -1617,7 +1617,8 @@ export function reviewRecapConfigToJson(config: FocusManifestReviewRecapConfig):
  * Parse the optional `maintainerRecap:` mapping (#1963, #2250). Mirrors {@link parseReviewRecapConfig}: every
  * field has a concrete default (no DB layer to overlay onto), so the parsed value IS the effective value. An
  * invalid `cadence`/`channel` falls back to its default via {@link normalizeEnum} (with a warning) rather than
- * silently firing more often or targeting an unsupported channel.
+ * silently firing more often or targeting an unsupported channel. When upstream gate-precision/outcome-calibration
+ * reports carry an aggregate-only miner-vs-human split, the recap digest adds a Cohort section (#4521).
  */
 function parseMaintainerRecapConfig(value: JsonValue | undefined, warnings: string[]): FocusManifestMaintainerRecapConfig {
   if (value === undefined || value === null) return { ...EMPTY_MAINTAINER_RECAP_CONFIG };

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -351,7 +351,9 @@ declare global {
      *  default "weekly"; an invalid value falls back to "weekly") picks how often; GITTENSORY_RECAP_HOUR
      *  (0-23, default 14) and GITTENSORY_RECAP_DAY (0-6, Sunday=0, default 1/Monday, only consulted when
      *  weekly) pick when, so the tick fires at most once per period. Default OFF -- unset/false means the
-     *  cron enqueues NO recap job, byte-identical to today. See src/review/maintainer-recap-wire.ts. */
+     *  cron enqueues NO recap job, byte-identical to today. When upstream gate-precision/outcome-calibration
+     *  reports carry an aggregate-only miner-vs-human split, the recap adds a Cohort section (#4521). See
+     *  src/review/maintainer-recap-wire.ts. */
     GITTENSORY_MAINTAINER_RECAP?: string;
     GITTENSORY_RECAP_CADENCE?: string;
     GITTENSORY_RECAP_HOUR?: string;

--- a/src/services/contributor-cohort.ts
+++ b/src/services/contributor-cohort.ts
@@ -1,0 +1,34 @@
+// Privacy-safe miner-vs-human cohort classification for aggregate-only analytics (#4520/#4521).
+// Uses cached official-miner detection at aggregation time; never emits actor logins downstream.
+import { getFreshOfficialMinerDetection } from "../db/repositories";
+import type { PullRequestRecord } from "../types";
+
+export type ContributorCohort = "miner" | "human";
+
+export function normalizeContributorLogin(login: string): string {
+  return login.trim().toLowerCase();
+}
+
+/** Classify a PR's contributor origin when author login is known. Returns null when unknown. */
+export function classifyPullRequestCohort(
+  pr: Pick<PullRequestRecord, "authorLogin">,
+  confirmedMinerLogins: ReadonlySet<string>,
+): ContributorCohort | null {
+  const login = pr.authorLogin?.trim();
+  if (!login) return null;
+  return confirmedMinerLogins.has(normalizeContributorLogin(login)) ? "miner" : "human";
+}
+
+/** Resolve confirmed official-miner logins for the PR authors in a window (cached detection). */
+export async function loadConfirmedMinerLoginsForPullRequests(
+  env: Env,
+  pullRequests: readonly PullRequestRecord[],
+): Promise<Set<string>> {
+  const logins = [
+    ...new Set(pullRequests.flatMap((pr) => (pr.authorLogin ? [normalizeContributorLogin(pr.authorLogin)] : []))),
+  ].slice(0, 100);
+  const detections = await Promise.all(
+    logins.map(async (login) => [login, await getFreshOfficialMinerDetection(env, login)] as const),
+  );
+  return new Set(detections.flatMap(([login, detection]) => (detection?.status === "confirmed" ? [login] : [])));
+}

--- a/src/services/gate-precision.ts
+++ b/src/services/gate-precision.ts
@@ -17,6 +17,11 @@
 import { listGateOutcomes, listPullRequests } from "../db/repositories";
 import type { GateOutcomeRecord, PullRequestRecord } from "../types";
 import { nowIso } from "../utils/json";
+import {
+  classifyPullRequestCohort,
+  loadConfirmedMinerLoginsForPullRequests,
+  type ContributorCohort,
+} from "./contributor-cohort";
 
 // Below this per-gate-type blocked sample the false-positive rate is too noisy to judge.
 const MIN_SAMPLE = 5;
@@ -29,12 +34,26 @@ export type GatePrecisionPerType = {
   falsePositiveRate: number | null;
 };
 
+export type GatePrecisionCohortOverall = {
+  blocked: number;
+  blockedThenMerged: number;
+  falsePositiveRate: number | null;
+};
+
+export type GatePrecisionOverall = {
+  blocked: number;
+  blockedThenMerged: number;
+  falsePositiveRate: number | null;
+  /** Aggregate-only miner-vs-human split when official-miner detection is available (#4520/#4521). */
+  byCohort?: Partial<Record<ContributorCohort, GatePrecisionCohortOverall>>;
+};
+
 export type GatePrecisionReport = {
   repoFullName: string;
   generatedAt: string;
   windowDays: number | null;
   perGateType: GatePrecisionPerType[];
-  overall: { blocked: number; blockedThenMerged: number; falsePositiveRate: number | null };
+  overall: GatePrecisionOverall;
   signals: string[];
 };
 
@@ -64,9 +83,12 @@ function sameRepo(a: string | null | undefined, b: string): boolean {
 export function buildGatePrecisionReport(
   outcomes: GateOutcomeRecord[],
   pullRequests: PullRequestRecord[],
-  options: { repoFullName?: string } = {},
+  options: { repoFullName?: string; confirmedMinerLogins?: ReadonlySet<string> } = {},
 ): Omit<GatePrecisionReport, "repoFullName" | "generatedAt" | "windowDays"> {
   const repoFullName = options.repoFullName;
+  const trackCohorts = Boolean(options.confirmedMinerLogins);
+  const cohortBlocked: Record<ContributorCohort, number> = { miner: 0, human: 0 };
+  const cohortMerged: Record<ContributorCohort, number> = { miner: 0, human: 0 };
   // Index PRs by number for an O(1) terminal-outcome lookup, scoped to the repo when one is given.
   const prByNumber = new Map<number, PullRequestRecord>();
   for (const pr of pullRequests) {
@@ -84,6 +106,13 @@ export function buildGatePrecisionReport(
     const merged = pr ? terminalOutcome(pr) === "merged" : false;
     overallBlocked += 1;
     if (merged) overallMerged += 1;
+    if (trackCohorts && options.confirmedMinerLogins && pr) {
+      const cohort = classifyPullRequestCohort(pr, options.confirmedMinerLogins);
+      if (cohort) {
+        cohortBlocked[cohort] += 1;
+        if (merged) cohortMerged[cohort] += 1;
+      }
+    }
     for (const code of outcome.blockerCodes) {
       const entry = perType.get(code) ?? { blocked: 0, blockedThenMerged: 0, overridden: 0 };
       entry.blocked += 1;
@@ -104,12 +133,27 @@ export function buildGatePrecisionReport(
     }))
     .sort((a, b) => b.blocked - a.blocked || a.gateType.localeCompare(b.gateType));
 
+  const byCohort = trackCohorts
+    ? (["miner", "human"] as const).reduce<Partial<Record<ContributorCohort, GatePrecisionCohortOverall>>>((acc, cohort) => {
+        const blocked = cohortBlocked[cohort];
+        const blockedThenMerged = cohortMerged[cohort];
+        if (blocked === 0 && blockedThenMerged === 0) return acc;
+        acc[cohort] = {
+          blocked,
+          blockedThenMerged,
+          falsePositiveRate: blocked >= MIN_SAMPLE ? round(blockedThenMerged / blocked) : null,
+        };
+        return acc;
+      }, {})
+    : undefined;
+
   return {
     perGateType,
     overall: {
       blocked: overallBlocked,
       blockedThenMerged: overallMerged,
       falsePositiveRate: overallBlocked >= MIN_SAMPLE ? round(overallMerged / overallBlocked) : null,
+      ...(byCohort && Object.keys(byCohort).length > 0 ? { byCohort } : {}),
     },
     signals: buildGatePrecisionSignals(perGateType, overallBlocked, overallMerged),
   };
@@ -139,6 +183,7 @@ export async function loadGatePrecisionReport(env: Env, repoFullName: string, op
     listPullRequests(env, repoFullName),
     listGateOutcomes(env, { repoFullName, ...(options.windowDays !== undefined ? { windowDays: options.windowDays } : {}) }),
   ]);
-  const report = buildGatePrecisionReport(outcomes, pullRequests, { repoFullName });
+  const confirmedMinerLogins = await loadConfirmedMinerLoginsForPullRequests(env, pullRequests);
+  const report = buildGatePrecisionReport(outcomes, pullRequests, { repoFullName, confirmedMinerLogins });
   return { repoFullName, generatedAt: nowIso(), windowDays: options.windowDays ?? null, ...report };
 }

--- a/src/services/maintainer-recap-cohort.ts
+++ b/src/services/maintainer-recap-cohort.ts
@@ -1,0 +1,38 @@
+// Maintainer-recap COHORT section (#4521): miner-vs-human aggregate split when upstream reports carry it.
+import { PUBLIC_LOCAL_PATH_SCRUB_PATTERN } from "../signals/redaction";
+import type { MaintainerRecapCohortSlice } from "../types";
+
+export type CohortRecapSource = {
+  windowDays: number;
+  cohorts?: Partial<Record<"miner" | "human", MaintainerRecapCohortSlice>>;
+};
+
+export type CohortRecapSection = {
+  title: string;
+  lines: string[];
+};
+
+function sanitizeRecapText(value: string): string {
+  return value.replace(PUBLIC_LOCAL_PATH_SCRUB_PATTERN, "<redacted-path>").slice(0, 240);
+}
+
+function formatRate(rate: number | null): string {
+  return rate === null ? "n/a" : `${Math.round(rate * 100)}%`;
+}
+
+function cohortLine(label: string, slice: MaintainerRecapCohortSlice, windowDays: number): string {
+  return sanitizeRecapText(
+    `${label}: ${slice.merged} merged of ${slice.reviewed} reviewed over ${windowDays} day(s); gate false-positive rate ${formatRate(slice.gateFalsePositiveRate)} (${slice.gateFalsePositives}/${slice.blocked} blocked-then-merged).`,
+  );
+}
+
+/** Pure cohort section over a RecapReport projection. Omits entirely when no cohort data is present. */
+export function buildCohortRecapSection(report: CohortRecapSource): CohortRecapSection | null {
+  const cohorts = report.cohorts;
+  if (!cohorts || Object.keys(cohorts).length === 0) return null;
+  const lines: string[] = [];
+  if (cohorts.miner) lines.push(cohortLine("Miner-originated", cohorts.miner, report.windowDays));
+  if (cohorts.human) lines.push(cohortLine("Human-originated", cohorts.human, report.windowDays));
+  if (lines.length === 0) return null;
+  return { title: "Cohort", lines };
+}

--- a/src/services/maintainer-recap.ts
+++ b/src/services/maintainer-recap.ts
@@ -14,7 +14,9 @@ import { PUBLIC_LOCAL_PATH_SCRUB_PATTERN, PUBLIC_UNSAFE_PATTERN } from "../signa
 import { deliverRecapToDiscord, deliverRecapToSlack } from "./notify-discord";
 import type { GatePrecisionReport } from "./gate-precision";
 import type { OutcomeCalibration } from "./outcome-calibration";
-import type { MaintainerRecapRepo, RecapReport } from "../types";
+import { buildCohortRecapSection } from "./maintainer-recap-cohort";
+import type { ContributorCohort } from "./contributor-cohort";
+import type { MaintainerRecapCohortSlice, MaintainerRecapRepo, RecapReport } from "../types";
 import { nowIso } from "../utils/json";
 
 const DEFAULT_WINDOW_DAYS = 7;
@@ -36,8 +38,82 @@ function sanitizeRecapText(value: string): string {
 }
 
 /** One repo's two already-computed aggregators. Both carry the SAME repoFullName; the gate report drives repo
- *  identity. Injected by the caller (no new D1 read here), exactly like buildWeeklyValueReport's inputs. */
+ *  identity. Injected by the caller (no new D1 read here), exactly like buildWeeklyValueReport's inputs.
+ *  Upstream reports may optionally include aggregate-only miner-vs-human cohort splits (#4521). */
 export type MaintainerRecapRepoInput = { gatePrecision: GatePrecisionReport; calibration: OutcomeCalibration };
+
+function emptyCohortSlice(): MaintainerRecapCohortSlice {
+  return { reviewed: 0, merged: 0, closed: 0, blocked: 0, gateFalsePositives: 0, gateFalsePositiveRate: null };
+}
+
+function foldCohortSlice(
+  target: MaintainerRecapCohortSlice,
+  cohort: ContributorCohort,
+  gatePrecision: GatePrecisionReport,
+  calibration: OutcomeCalibration,
+): void {
+  const slop = calibration.slop.byCohort?.[cohort];
+  const gate = gatePrecision.overall.byCohort?.[cohort];
+  if (!slop && !gate) return;
+  if (slop) {
+    target.reviewed += slop.totalResolved;
+    target.merged += slop.merged;
+    target.closed += slop.closed;
+  }
+  if (gate) {
+    target.blocked += gate.blocked;
+    target.gateFalsePositives += gate.blockedThenMerged;
+  }
+}
+
+function finalizeCohortRate(slice: MaintainerRecapCohortSlice): MaintainerRecapCohortSlice {
+  slice.gateFalsePositiveRate =
+    slice.blocked > 0 ? Math.round((slice.gateFalsePositives / slice.blocked) * 100) / 100 : null;
+  return slice;
+}
+
+function buildRepoCohorts(
+  gatePrecision: GatePrecisionReport,
+  calibration: OutcomeCalibration,
+): Partial<Record<ContributorCohort, MaintainerRecapCohortSlice>> | undefined {
+  const miner = emptyCohortSlice();
+  const human = emptyCohortSlice();
+  foldCohortSlice(miner, "miner", gatePrecision, calibration);
+  foldCohortSlice(human, "human", gatePrecision, calibration);
+  const cohorts: Partial<Record<ContributorCohort, MaintainerRecapCohortSlice>> = {};
+  if (miner.reviewed > 0 || miner.blocked > 0) cohorts.miner = finalizeCohortRate(miner);
+  if (human.reviewed > 0 || human.blocked > 0) cohorts.human = finalizeCohortRate(human);
+  return Object.keys(cohorts).length > 0 ? cohorts : undefined;
+}
+
+function foldFleetCohorts(
+  repos: MaintainerRecapRepo[],
+): Partial<Record<ContributorCohort, MaintainerRecapCohortSlice>> | undefined {
+  const miner = emptyCohortSlice();
+  const human = emptyCohortSlice();
+  for (const repo of repos) {
+    if (repo.cohorts?.miner) {
+      const slice = repo.cohorts.miner;
+      miner.reviewed += slice.reviewed;
+      miner.merged += slice.merged;
+      miner.closed += slice.closed;
+      miner.blocked += slice.blocked;
+      miner.gateFalsePositives += slice.gateFalsePositives;
+    }
+    if (repo.cohorts?.human) {
+      const slice = repo.cohorts.human;
+      human.reviewed += slice.reviewed;
+      human.merged += slice.merged;
+      human.closed += slice.closed;
+      human.blocked += slice.blocked;
+      human.gateFalsePositives += slice.gateFalsePositives;
+    }
+  }
+  const cohorts: Partial<Record<ContributorCohort, MaintainerRecapCohortSlice>> = {};
+  if (miner.reviewed > 0 || miner.blocked > 0) cohorts.miner = finalizeCohortRate(miner);
+  if (human.reviewed > 0 || human.blocked > 0) cohorts.human = finalizeCohortRate(human);
+  return Object.keys(cohorts).length > 0 ? cohorts : undefined;
+}
 
 export type MaintainerRecapInputs = {
   generatedAt: string;
@@ -70,6 +146,7 @@ export function buildMaintainerRecap(args: MaintainerRecapInputs): RecapReport {
     }
     let gateOverrides = 0;
     for (const perType of gatePrecision.perGateType) gateOverrides += perType.overridden;
+    const repoCohorts = buildRepoCohorts(gatePrecision, calibration);
     const repo: MaintainerRecapRepo = {
       repoFullName: sanitizeRecapText(gatePrecision.repoFullName),
       reviewed: calibration.slop.totalResolved,
@@ -78,6 +155,7 @@ export function buildMaintainerRecap(args: MaintainerRecapInputs): RecapReport {
       gateFalsePositives: gatePrecision.overall.blockedThenMerged,
       gateOverrides,
       reversals: calibration.recommendations.negative,
+      ...(repoCohorts ? { cohorts: repoCohorts } : {}),
     };
     repos.push(repo);
     totals.reviewed += repo.reviewed;
@@ -99,7 +177,8 @@ export function buildMaintainerRecap(args: MaintainerRecapInputs): RecapReport {
     rateLine,
     `${totals.gateOverrides} maintainer override(s), ${totals.reversals} recommendation reversal(s).`,
   ].map(sanitizeRecapText);
-  return { generatedAt: args.generatedAt, windowDays, repos, totals, summary };
+  const cohorts = foldFleetCohorts(repos);
+  return { generatedAt: args.generatedAt, windowDays, repos, totals, summary, ...(cohorts ? { cohorts } : {}) };
 }
 
 /** Redact one free-text line bound for the public digest body. Two arms mirroring weekly-value-report.ts's
@@ -129,6 +208,7 @@ export function formatMaintainerRecap(report: RecapReport): string {
     (repo) =>
       `${redactRecapLine(repo.repoFullName)} — ${repo.reviewed} reviewed, ${repo.merged} merged, ${repo.closed} closed, ${repo.gateFalsePositives} gate false-positive(s), ${repo.gateOverrides} override(s), ${repo.reversals} reversal(s)`,
   );
+  const cohortSection = buildCohortRecapSection(report);
   const lines = [
     "# Maintainer recap",
     "",
@@ -146,6 +226,9 @@ export function formatMaintainerRecap(report: RecapReport): string {
     `- Gate false positives: ${totals.gateFalsePositives}/${totals.blocked} (${rate})`,
     `- Overrides: ${totals.gateOverrides}`,
     `- Reversals: ${totals.reversals}`,
+    ...(cohortSection
+      ? ["", `## ${cohortSection.title}`, ...recapSectionLines(cohortSection.lines, "_No cohort data for this window._")]
+      : []),
     "",
     "## Per-repo",
     ...recapSectionLines(perRepoLines, "_No repositories in this window._"),

--- a/src/services/outcome-calibration.ts
+++ b/src/services/outcome-calibration.ts
@@ -12,6 +12,11 @@ import { listAgentRecommendationOutcomes, listPullRequests } from "../db/reposit
 import type { SlopBand } from "../signals/slop";
 import type { AgentRecommendationOutcomeRecord, PullRequestRecord } from "../types";
 import { nowIso } from "../utils/json";
+import {
+  classifyPullRequestCohort,
+  loadConfirmedMinerLoginsForPullRequests,
+  type ContributorCohort,
+} from "./contributor-cohort";
 
 // Severity order — calibration checks that merge rate is non-increasing along it.
 const SLOP_BAND_ORDER: readonly SlopBand[] = ["clean", "low", "elevated", "high"];
@@ -20,10 +25,14 @@ const MIN_BAND_SAMPLE = 5;
 
 export type SlopBandCalibration = { band: SlopBand; sampleSize: number; merged: number; closed: number; mergeRate: number };
 
+export type SlopCohortOutcomeCounts = { totalResolved: number; merged: number; closed: number };
+
 export type SlopOutcomeCalibration = {
   totalResolved: number;
   bands: SlopBandCalibration[];
   overallMergeRate: number | null;
+  /** Aggregate-only miner-vs-human split when official-miner detection is available (#4520/#4521). */
+  byCohort?: Partial<Record<ContributorCohort, SlopCohortOutcomeCounts>>;
   /** True iff the score discriminates (merge rate non-increasing as band severity rises) given enough
    *  per-band sample; false iff it inverts; null iff there isn't enough resolved data to judge. */
   discriminates: boolean | null;
@@ -58,7 +67,15 @@ function terminalOutcome(pr: PullRequestRecord): "merged" | "closed" | null {
 }
 
 /** Per-slop-band merge/close calibration over the resolved PRs that carry a slop assessment. Pure. */
-export function buildSlopOutcomeCalibration(pullRequests: PullRequestRecord[]): SlopOutcomeCalibration {
+export function buildSlopOutcomeCalibration(
+  pullRequests: PullRequestRecord[],
+  options: { confirmedMinerLogins?: ReadonlySet<string> } = {},
+): SlopOutcomeCalibration {
+  const trackCohorts = Boolean(options.confirmedMinerLogins);
+  const cohortCounts: Record<ContributorCohort, SlopCohortOutcomeCounts> = {
+    miner: { totalResolved: 0, merged: 0, closed: 0 },
+    human: { totalResolved: 0, merged: 0, closed: 0 },
+  };
   const counts = new Map<SlopBand, { merged: number; closed: number }>();
   let totalMerged = 0;
   let totalResolved = 0;
@@ -77,16 +94,34 @@ export function buildSlopOutcomeCalibration(pullRequests: PullRequestRecord[]): 
     }
     counts.set(band, entry);
     totalResolved += 1;
+    if (trackCohorts && options.confirmedMinerLogins) {
+      const cohort = classifyPullRequestCohort(pr, options.confirmedMinerLogins);
+      if (cohort) {
+        const bucket = cohortCounts[cohort];
+        bucket.totalResolved += 1;
+        if (outcome === "merged") bucket.merged += 1;
+        else bucket.closed += 1;
+      }
+    }
   }
   const bands: SlopBandCalibration[] = SLOP_BAND_ORDER.map((band) => {
     const { merged, closed } = counts.get(band) ?? { merged: 0, closed: 0 };
     const sampleSize = merged + closed;
     return { band, sampleSize, merged, closed, mergeRate: sampleSize > 0 ? round(merged / sampleSize) : 0 };
   });
+  const byCohort = trackCohorts
+    ? (["miner", "human"] as const).reduce<Partial<Record<ContributorCohort, SlopCohortOutcomeCounts>>>((acc, cohort) => {
+        const bucket = cohortCounts[cohort];
+        if (bucket.totalResolved === 0) return acc;
+        acc[cohort] = { ...bucket };
+        return acc;
+      }, {})
+    : undefined;
   return {
     totalResolved,
     bands,
     overallMergeRate: totalResolved > 0 ? round(totalMerged / totalResolved) : null,
+    ...(byCohort && Object.keys(byCohort).length > 0 ? { byCohort } : {}),
     discriminates: computeDiscriminates(bands),
   };
 }
@@ -158,7 +193,8 @@ export async function buildRepoOutcomeCalibration(
     listPullRequests(env, repoFullName),
     listAgentRecommendationOutcomes(env, windowDays !== undefined ? { repoFullName, windowDays } : { repoFullName }),
   ]);
-  const slop = buildSlopOutcomeCalibration(pullRequests);
+  const confirmedMinerLogins = await loadConfirmedMinerLoginsForPullRequests(env, pullRequests);
+  const slop = buildSlopOutcomeCalibration(pullRequests, { confirmedMinerLogins });
   const recommendations = buildRecommendationOutcomeCalibration(outcomes, repoFullName, options);
   return { repoFullName, generatedAt: nowIso(), windowDays: windowDays ?? null, slop, recommendations, signals: buildOutcomeCalibrationSignals(slop, recommendations) };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2444,6 +2444,16 @@ export type ReviewRecap = {
   summary: string[];
 };
 
+/** Aggregate-only miner-vs-human slice inside a maintainer recap (#4521). Counts only — no actor logins. */
+export type MaintainerRecapCohortSlice = {
+  reviewed: number;
+  merged: number;
+  closed: number;
+  blocked: number;
+  gateFalsePositives: number;
+  gateFalsePositiveRate: number | null;
+};
+
 /** One repo's realized review-outcome roll-up inside a maintainer recap window (#2239, foundation for #1963).
  *  Counts are ground-truth PR outcomes + gate/recommendation calibration totals — never predictions. */
 export type MaintainerRecapRepo = {
@@ -2458,6 +2468,8 @@ export type MaintainerRecapRepo = {
   gateOverrides: number;
   /** Recommendations that resolved NEGATIVELY (a reversal) over the window, from the outcome calibration. */
   reversals: number;
+  /** Present when upstream gate-precision/outcome-calibration carried a cohort split for this repo. */
+  cohorts?: Partial<Record<"miner" | "human", MaintainerRecapCohortSlice>>;
 };
 
 /** A serializable maintainer recap: a window of gittensory's OWN review-outcome data folded across repos.
@@ -2480,5 +2492,7 @@ export type RecapReport = {
     /** Aggregate false-positive rate (gateFalsePositives / blocked), null when nothing was blocked. */
     gateFalsePositiveRate: number | null;
   };
+  /** Fleet-wide miner-vs-human cohort roll-up when upstream aggregates carried a split (#4521). */
+  cohorts?: Partial<Record<"miner" | "human", MaintainerRecapCohortSlice>>;
   summary: string[];
 };

--- a/test/unit/contributor-cohort.test.ts
+++ b/test/unit/contributor-cohort.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  classifyPullRequestCohort,
+  loadConfirmedMinerLoginsForPullRequests,
+  normalizeContributorLogin,
+} from "../../src/services/contributor-cohort";
+import * as repositories from "../../src/db/repositories";
+import type { PullRequestRecord } from "../../src/types";
+import { createTestEnv } from "../helpers/d1";
+
+describe("contributor-cohort (#4521)", () => {
+  it("normalizes logins and classifies miner vs human origins", () => {
+    const miners = new Set(["alice"]);
+    expect(normalizeContributorLogin(" Alice ")).toBe("alice");
+    expect(classifyPullRequestCohort({ authorLogin: "alice" }, miners)).toBe("miner");
+    expect(classifyPullRequestCohort({ authorLogin: "bob" }, miners)).toBe("human");
+    expect(classifyPullRequestCohort({ authorLogin: null }, miners)).toBeNull();
+  });
+
+  it("loads confirmed miner logins from cached official-miner detection", async () => {
+    const env = createTestEnv();
+    const pullRequests: PullRequestRecord[] = [
+      { repoFullName: "owner/repo", number: 1, title: "a", state: "closed", authorLogin: "miner-one", labels: [], linkedIssues: [] },
+      { repoFullName: "owner/repo", number: 2, title: "b", state: "closed", authorLogin: "human-one", labels: [], linkedIssues: [] },
+    ];
+    const spy = vi.spyOn(repositories, "getFreshOfficialMinerDetection").mockImplementation(async (_env, login) =>
+      login === "miner-one"
+        ? { status: "confirmed", snapshot: { login: "miner-one", githubId: "1", priorPullRequests: 1, priorIssues: 0 } as never }
+        : { status: "not_found" },
+    );
+    const logins = await loadConfirmedMinerLoginsForPullRequests(env, pullRequests);
+    expect([...logins]).toEqual(["miner-one"]);
+    spy.mockRestore();
+  });
+});

--- a/test/unit/contributor-cohort.test.ts
+++ b/test/unit/contributor-cohort.test.ts
@@ -32,4 +32,20 @@ describe("contributor-cohort (#4521)", () => {
     expect([...logins]).toEqual(["miner-one"]);
     spy.mockRestore();
   });
+
+  it("skips PRs with no author login when resolving confirmed miners", async () => {
+    const env = createTestEnv();
+    const pullRequests: PullRequestRecord[] = [
+      { repoFullName: "owner/repo", number: 1, title: "no author", state: "closed", labels: [], linkedIssues: [] },
+      { repoFullName: "owner/repo", number: 2, title: "has author", state: "closed", authorLogin: "miner-one", labels: [], linkedIssues: [] },
+    ];
+    const spy = vi.spyOn(repositories, "getFreshOfficialMinerDetection").mockResolvedValue({
+      status: "confirmed",
+      snapshot: { login: "miner-one", githubId: "1", priorPullRequests: 1, priorIssues: 0 } as never,
+    });
+    const logins = await loadConfirmedMinerLoginsForPullRequests(env, pullRequests);
+    expect([...logins]).toEqual(["miner-one"]);
+    expect(spy).toHaveBeenCalledTimes(1);
+    spy.mockRestore();
+  });
 });

--- a/test/unit/gate-precision.test.ts
+++ b/test/unit/gate-precision.test.ts
@@ -87,6 +87,12 @@ describe("buildGatePrecisionReport", () => {
     expect(JSON.stringify(report)).not.toMatch(/login|actor|reward|payout|trust|wallet|hotkey|credibility/i);
   });
 
+  it("skips cohort tracking when a blocked PR has no author login", () => {
+    const miners = new Set(["miner-author"]);
+    const report = buildGatePrecisionReport([block(1, ["x"])], [pr(1, "merged")], { confirmedMinerLogins: miners });
+    expect(report.overall.byCohort).toBeUndefined();
+  });
+
   it("partitions overall precision by miner-vs-human cohort when confirmed miner logins are provided", () => {
     const miners = new Set(["miner-author"]);
     const blocks = [block(1, ["x"]), block(2, ["x"]), block(3, ["x"]), block(4, ["x"]), block(5, ["x"]), block(6, ["x"])];
@@ -165,12 +171,22 @@ describe("loadGatePrecisionReport (env loader)", () => {
 
     const report = await loadGatePrecisionReport(env, "owner/repo");
     expect(report.repoFullName).toBe("owner/repo");
+    expect(report.windowDays).toBeNull();
     const byType = Object.fromEntries(report.perGateType.map((t) => [t.gateType, t]));
     expect(byType.slop_risk).toMatchObject({ blocked: 2, blockedThenMerged: 1, overridden: 1 }); // PR1 (merged+overridden) + PR2 (closed)
     expect(byType.missing_linked_issue).toMatchObject({ blocked: 1, blockedThenMerged: 1, overridden: 1 });
     expect(report.overall).toMatchObject({ blocked: 2, blockedThenMerged: 1 });
     expect(report.signals.length).toBeGreaterThan(0);
     expect(JSON.stringify(report)).not.toMatch(/reward|payout|trust score|wallet|hotkey|login|actor/i);
+  });
+
+  it("honors windowDays when loading gate outcomes for precision", async () => {
+    const env = createTestEnv();
+    await recordGateBlockOutcome(env, { repoFullName: "owner/repo", pullNumber: 1, headSha: "sha1", blockerCodes: ["slop_risk"] });
+    await upsertPullRequestFromGitHub(env, "owner/repo", { number: 1, title: "closed", state: "closed", user: { login: "alice" } });
+    const report = await loadGatePrecisionReport(env, "owner/repo", { windowDays: 7 });
+    expect(report.windowDays).toBe(7);
+    expect(report.overall.blocked).toBe(1);
   });
 
   it("preserves overridden across a SAME-head re-block (a re-block on the same commit keeps the override)", async () => {

--- a/test/unit/gate-precision.test.ts
+++ b/test/unit/gate-precision.test.ts
@@ -17,7 +17,7 @@ function block(pullNumber: number, blockerCodes: string[], overridden = false): 
 
 // A resolved PR: `merged` → has a merge timestamp (a false positive when it was also blocked); otherwise
 // closed-unmerged (the block held). `open` PRs have no terminal outcome yet.
-function pr(number: number, outcome: "merged" | "closed" | "open"): PullRequestRecord {
+function pr(number: number, outcome: "merged" | "closed" | "open", authorLogin?: string): PullRequestRecord {
   return {
     repoFullName: "owner/repo",
     number,
@@ -26,6 +26,7 @@ function pr(number: number, outcome: "merged" | "closed" | "open"): PullRequestR
     mergedAt: outcome === "merged" ? "2026-06-01T00:00:00.000Z" : null,
     labels: [],
     linkedIssues: [],
+    ...(authorLogin === undefined ? {} : { authorLogin }),
   };
 }
 
@@ -84,6 +85,23 @@ describe("buildGatePrecisionReport", () => {
   it("carries no actor login or trust/reward fields (privacy)", () => {
     const report = buildGatePrecisionReport([block(1, ["x"])], [pr(1, "merged")]);
     expect(JSON.stringify(report)).not.toMatch(/login|actor|reward|payout|trust|wallet|hotkey|credibility/i);
+  });
+
+  it("partitions overall precision by miner-vs-human cohort when confirmed miner logins are provided", () => {
+    const miners = new Set(["miner-author"]);
+    const blocks = [block(1, ["x"]), block(2, ["x"]), block(3, ["x"]), block(4, ["x"]), block(5, ["x"]), block(6, ["x"])];
+    const prs = [
+      pr(1, "merged", "miner-author"),
+      pr(2, "merged", "miner-author"),
+      pr(3, "closed", "miner-author"),
+      pr(4, "closed", "miner-author"),
+      pr(5, "closed", "miner-author"),
+      pr(6, "merged", "human-author"),
+    ];
+    const report = buildGatePrecisionReport(blocks, prs, { confirmedMinerLogins: miners });
+    expect(report.overall.byCohort?.miner).toMatchObject({ blocked: 5, blockedThenMerged: 2, falsePositiveRate: 0.4 });
+    expect(report.overall.byCohort?.human).toMatchObject({ blocked: 1, blockedThenMerged: 1, falsePositiveRate: null });
+    expect(JSON.stringify(report.overall.byCohort)).not.toMatch(/miner-author|human-author/);
   });
 
   it("scopes to options.repoFullName — ignores blocks and PRs from other repos", () => {

--- a/test/unit/maintainer-recap-cohort.test.ts
+++ b/test/unit/maintainer-recap-cohort.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildCohortRecapSection } from "../../src/services/maintainer-recap-cohort";
+import { buildCohortRecapSection, type CohortRecapSource } from "../../src/services/maintainer-recap-cohort";
 
 describe("buildCohortRecapSection (#4521)", () => {
   it("returns null when no cohort data is present", () => {
@@ -47,11 +47,8 @@ describe("buildCohortRecapSection (#4521)", () => {
   });
 
   it("returns null when cohort keys exist but every slice is empty", () => {
-    expect(
-      buildCohortRecapSection({
-        windowDays: 7,
-        cohorts: { miner: undefined, human: undefined },
-      }),
-    ).toBeNull();
+    // Upstream may carry cohort keys without populated slices; cast exercises the runtime guard.
+    const cohorts = { miner: undefined, human: undefined } as unknown as NonNullable<CohortRecapSource["cohorts"]>;
+    expect(buildCohortRecapSection({ windowDays: 7, cohorts })).toBeNull();
   });
 });

--- a/test/unit/maintainer-recap-cohort.test.ts
+++ b/test/unit/maintainer-recap-cohort.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+import { buildCohortRecapSection } from "../../src/services/maintainer-recap-cohort";
+
+describe("buildCohortRecapSection (#4521)", () => {
+  it("returns null when no cohort data is present", () => {
+    expect(buildCohortRecapSection({ windowDays: 7 })).toBeNull();
+    expect(buildCohortRecapSection({ windowDays: 7, cohorts: {} })).toBeNull();
+  });
+
+  it("renders aggregate miner and human lines without actor logins", () => {
+    const section = buildCohortRecapSection({
+      windowDays: 7,
+      cohorts: {
+        miner: { reviewed: 4, merged: 3, closed: 1, blocked: 5, gateFalsePositives: 1, gateFalsePositiveRate: 0.2 },
+        human: { reviewed: 6, merged: 4, closed: 2, blocked: 8, gateFalsePositives: 2, gateFalsePositiveRate: 0.25 },
+      },
+    });
+    expect(section?.title).toBe("Cohort");
+    expect(section?.lines).toHaveLength(2);
+    expect(section?.lines.join("\n")).toContain("Miner-originated: 3 merged of 4 reviewed");
+    expect(section?.lines.join("\n")).toContain("Human-originated: 4 merged of 6 reviewed");
+    expect(section?.lines.join("\n")).not.toMatch(/miner-one|human-one|@/);
+  });
+
+  it("renders miner-only cohort lines and n/a gate rates", () => {
+    const section = buildCohortRecapSection({
+      windowDays: 14,
+      cohorts: {
+        miner: { reviewed: 2, merged: 1, closed: 1, blocked: 2, gateFalsePositives: 1, gateFalsePositiveRate: null },
+      },
+    });
+    expect(section?.lines).toHaveLength(1);
+    expect(section?.lines[0]).toContain("Miner-originated");
+    expect(section?.lines[0]).toContain("gate false-positive rate n/a");
+  });
+});

--- a/test/unit/maintainer-recap-cohort.test.ts
+++ b/test/unit/maintainer-recap-cohort.test.ts
@@ -33,4 +33,25 @@ describe("buildCohortRecapSection (#4521)", () => {
     expect(section?.lines[0]).toContain("Miner-originated");
     expect(section?.lines[0]).toContain("gate false-positive rate n/a");
   });
+
+  it("renders human-only cohort lines when miner data is absent", () => {
+    const section = buildCohortRecapSection({
+      windowDays: 7,
+      cohorts: {
+        human: { reviewed: 5, merged: 3, closed: 2, blocked: 4, gateFalsePositives: 1, gateFalsePositiveRate: 0.25 },
+      },
+    });
+    expect(section?.lines).toHaveLength(1);
+    expect(section?.lines[0]).toContain("Human-originated");
+    expect(section?.lines[0]).not.toContain("Miner-originated");
+  });
+
+  it("returns null when cohort keys exist but every slice is empty", () => {
+    expect(
+      buildCohortRecapSection({
+        windowDays: 7,
+        cohorts: { miner: undefined, human: undefined },
+      }),
+    ).toBeNull();
+  });
 });

--- a/test/unit/maintainer-recap-format.test.ts
+++ b/test/unit/maintainer-recap-format.test.ts
@@ -90,4 +90,31 @@ describe("formatMaintainerRecap (#2240)", () => {
     expect(body).toContain("- <redacted>");
     expect(body).not.toContain("payout");
   });
+
+  it("renders a cohort section when miner-vs-human aggregates are present", () => {
+    const body = formatMaintainerRecap({
+      generatedAt: GEN,
+      windowDays: 7,
+      repos: [],
+      totals: {
+        reviewed: 7,
+        merged: 5,
+        closed: 2,
+        blocked: 11,
+        gateFalsePositives: 3,
+        gateOverrides: 0,
+        reversals: 0,
+        gateFalsePositiveRate: 0.273,
+      },
+      cohorts: {
+        miner: { reviewed: 3, merged: 2, closed: 1, blocked: 5, gateFalsePositives: 1, gateFalsePositiveRate: 0.2 },
+        human: { reviewed: 4, merged: 3, closed: 1, blocked: 6, gateFalsePositives: 2, gateFalsePositiveRate: 0.333 },
+      },
+      summary: ["Blended recap line."],
+    });
+    expect(body).toContain("## Cohort");
+    expect(body).toContain("Miner-originated: 2 merged of 3 reviewed");
+    expect(body).toContain("Human-originated: 3 merged of 4 reviewed");
+    expect(body).not.toMatch(/login|@/);
+  });
 });

--- a/test/unit/maintainer-recap.test.ts
+++ b/test/unit/maintainer-recap.test.ts
@@ -145,6 +145,91 @@ describe("buildMaintainerRecap (#2239)", () => {
     expect(report.repos[0]?.repoFullName).not.toContain("/Users/secret");
   });
 
+  it("omits cohorts when upstream reports carry no miner or human slices", () => {
+    const report = buildMaintainerRecap({ generatedAt: GEN, repos: [repoInput("owner/repo-a")] });
+    expect(report.cohorts).toBeUndefined();
+    expect(report.repos[0]?.cohorts).toBeUndefined();
+  });
+
+  it("folds gate-only cohort slices when slop cohort data is absent", () => {
+    const report = buildMaintainerRecap({
+      generatedAt: GEN,
+      repos: [
+        {
+          gatePrecision: {
+            repoFullName: "owner/repo-a",
+            generatedAt: GEN,
+            windowDays: 7,
+            perGateType: [],
+            overall: {
+              blocked: 5,
+              blockedThenMerged: 1,
+              falsePositiveRate: null,
+              byCohort: { miner: { blocked: 5, blockedThenMerged: 1, falsePositiveRate: 0.2 } },
+            },
+            signals: [],
+          },
+          calibration: {
+            repoFullName: "owner/repo-a",
+            generatedAt: GEN,
+            windowDays: 7,
+            slop: { totalResolved: 0, bands: [], overallMergeRate: null, discriminates: null },
+            recommendations: { total: 0, positive: 0, negative: 0, pending: 0, positiveRate: null },
+            signals: [],
+          },
+        },
+      ],
+    });
+    expect(report.repos[0]?.cohorts?.miner).toMatchObject({
+      reviewed: 0,
+      merged: 0,
+      closed: 0,
+      blocked: 5,
+      gateFalsePositives: 1,
+      gateFalsePositiveRate: 0.2,
+    });
+  });
+
+  it("folds slop-only cohort slices and nulls the gate rate when nothing was blocked", () => {
+    const report = buildMaintainerRecap({
+      generatedAt: GEN,
+      repos: [
+        {
+          gatePrecision: {
+            repoFullName: "owner/repo-a",
+            generatedAt: GEN,
+            windowDays: 7,
+            perGateType: [],
+            overall: { blocked: 0, blockedThenMerged: 0, falsePositiveRate: null },
+            signals: [],
+          },
+          calibration: {
+            repoFullName: "owner/repo-a",
+            generatedAt: GEN,
+            windowDays: 7,
+            slop: {
+              totalResolved: 3,
+              bands: [],
+              overallMergeRate: null,
+              discriminates: null,
+              byCohort: { human: { totalResolved: 3, merged: 2, closed: 1 } },
+            },
+            recommendations: { total: 0, positive: 0, negative: 0, pending: 0, positiveRate: null },
+            signals: [],
+          },
+        },
+      ],
+    });
+    expect(report.repos[0]?.cohorts?.human).toMatchObject({
+      reviewed: 3,
+      merged: 2,
+      closed: 1,
+      blocked: 0,
+      gateFalsePositives: 0,
+      gateFalsePositiveRate: null,
+    });
+  });
+
   it("folds miner-vs-human cohort slices when upstream reports carry them", () => {
     const report = buildMaintainerRecap({
       generatedAt: GEN,

--- a/test/unit/maintainer-recap.test.ts
+++ b/test/unit/maintainer-recap.test.ts
@@ -20,6 +20,10 @@ function repoInput(
     closed?: number;
     reversals?: number;
     emptyBands?: boolean;
+    cohort?: {
+      miner?: { reviewed: number; merged: number; closed: number; blocked: number; blockedThenMerged: number };
+      human?: { reviewed: number; merged: number; closed: number; blocked: number; blockedThenMerged: number };
+    };
   } = {},
 ): MaintainerRecapRepoInput {
   const blocked = c.blocked ?? 0;
@@ -33,14 +37,55 @@ function repoInput(
       generatedAt: GEN,
       windowDays: 7,
       perGateType: [{ gateType: "missing_linked_issue", blocked, blockedThenMerged, overridden: c.overridden ?? 0, falsePositiveRate: null }],
-      overall: { blocked, blockedThenMerged, falsePositiveRate: null },
+      overall: {
+        blocked,
+        blockedThenMerged,
+        falsePositiveRate: null,
+        ...(c.cohort
+          ? {
+              byCohort: {
+                ...(c.cohort.miner
+                  ? {
+                      miner: {
+                        blocked: c.cohort.miner.blocked,
+                        blockedThenMerged: c.cohort.miner.blockedThenMerged,
+                        falsePositiveRate: c.cohort.miner.blocked >= 5 ? c.cohort.miner.blockedThenMerged / c.cohort.miner.blocked : null,
+                      },
+                    }
+                  : {}),
+                ...(c.cohort.human
+                  ? {
+                      human: {
+                        blocked: c.cohort.human.blocked,
+                        blockedThenMerged: c.cohort.human.blockedThenMerged,
+                        falsePositiveRate: c.cohort.human.blocked >= 5 ? c.cohort.human.blockedThenMerged / c.cohort.human.blocked : null,
+                      },
+                    }
+                  : {}),
+              },
+            }
+          : {}),
+      },
       signals: [],
     },
     calibration: {
       repoFullName,
       generatedAt: GEN,
       windowDays: 7,
-      slop: { totalResolved: c.totalResolved ?? 0, bands, overallMergeRate: null, discriminates: null },
+      slop: {
+        totalResolved: c.totalResolved ?? 0,
+        bands,
+        overallMergeRate: null,
+        discriminates: null,
+        ...(c.cohort
+          ? {
+              byCohort: {
+                ...(c.cohort.miner ? { miner: { totalResolved: c.cohort.miner.reviewed, merged: c.cohort.miner.merged, closed: c.cohort.miner.closed } } : {}),
+                ...(c.cohort.human ? { human: { totalResolved: c.cohort.human.reviewed, merged: c.cohort.human.merged, closed: c.cohort.human.closed } } : {}),
+              },
+            }
+          : {}),
+      },
       recommendations: { total: 0, positive: 0, negative: c.reversals ?? 0, pending: 0, positiveRate: null },
       signals: [],
     },
@@ -98,6 +143,24 @@ describe("buildMaintainerRecap (#2239)", () => {
     const report = buildMaintainerRecap({ generatedAt: GEN, repos: [repoInput("/Users/secret/repo", { blocked: 1, blockedThenMerged: 0 })] });
     expect(report.repos[0]?.repoFullName).toContain("<redacted-path>");
     expect(report.repos[0]?.repoFullName).not.toContain("/Users/secret");
+  });
+
+  it("folds miner-vs-human cohort slices when upstream reports carry them", () => {
+    const report = buildMaintainerRecap({
+      generatedAt: GEN,
+      repos: [
+        repoInput("owner/repo-a", {
+          cohort: {
+            miner: { reviewed: 3, merged: 2, closed: 1, blocked: 5, blockedThenMerged: 1 },
+            human: { reviewed: 4, merged: 3, closed: 1, blocked: 6, blockedThenMerged: 2 },
+          },
+        }),
+      ],
+    });
+    expect(report.cohorts?.miner).toMatchObject({ reviewed: 3, merged: 2, closed: 1, blocked: 5, gateFalsePositives: 1, gateFalsePositiveRate: 0.2 });
+    expect(report.cohorts?.human).toMatchObject({ reviewed: 4, merged: 3, closed: 1, blocked: 6, gateFalsePositives: 2, gateFalsePositiveRate: 0.33 });
+    expect(report.repos[0]?.cohorts?.miner?.merged).toBe(2);
+    expect(JSON.stringify(report)).not.toMatch(/login|author/i);
   });
 });
 

--- a/test/unit/outcome-calibration.test.ts
+++ b/test/unit/outcome-calibration.test.ts
@@ -55,6 +55,25 @@ describe("buildSlopOutcomeCalibration", () => {
     expect(result.totalResolved).toBe(4);
   });
 
+  it("skips PRs whose slop band is outside the calibration order", () => {
+    const bogusBand = "bogus" as SlopBand;
+    const result = buildSlopOutcomeCalibration([
+      { repoFullName: "owner/repo", number: 1, title: "bogus band", state: "closed", mergedAt: "2026-06-01T00:00:00.000Z", labels: [], linkedIssues: [], slopRisk: 50, slopBand: bogusBand },
+      ...band("clean", 1, 1, 0),
+    ]);
+    expect(result.totalResolved).toBe(1);
+  });
+
+  it("skips cohort tracking when a resolved PR has no author login", () => {
+    const miners = new Set(["miner-author"]);
+    const result = buildSlopOutcomeCalibration(
+      [pr("clean", true, 1), pr("clean", false, 2, "human-author")],
+      { confirmedMinerLogins: miners },
+    );
+    expect(result.byCohort?.human).toMatchObject({ totalResolved: 1, merged: 0, closed: 1 });
+    expect(result.byCohort?.miner).toBeUndefined();
+  });
+
   it("partitions resolved outcomes by miner-vs-human cohort when confirmed miner logins are provided", () => {
     const miners = new Set(["miner-author"]);
     const result = buildSlopOutcomeCalibration(

--- a/test/unit/outcome-calibration.test.ts
+++ b/test/unit/outcome-calibration.test.ts
@@ -13,7 +13,7 @@ import type { AgentActionRecord, AgentRecommendationOutcomeRecord, AgentRecommen
 import { createTestEnv } from "../helpers/d1";
 
 // A resolved PR carrying a slop assessment. `merged` → has a merge timestamp; otherwise closed-unmerged.
-function pr(band: SlopBand, merged: boolean, number: number): PullRequestRecord {
+function pr(band: SlopBand, merged: boolean, number: number, authorLogin?: string): PullRequestRecord {
   return {
     repoFullName: "owner/repo",
     number,
@@ -24,6 +24,7 @@ function pr(band: SlopBand, merged: boolean, number: number): PullRequestRecord 
     linkedIssues: [],
     slopRisk: band === "clean" ? 0 : band === "low" ? 10 : band === "elevated" ? 40 : 70,
     slopBand: band,
+    ...(authorLogin === undefined ? {} : { authorLogin }),
   };
 }
 
@@ -52,6 +53,17 @@ describe("buildSlopOutcomeCalibration", () => {
     const result = buildSlopOutcomeCalibration([...band("clean", 2, 2, 0), ...band("high", 2, 0, 100)]);
     expect(result.discriminates).toBeNull(); // each band below the min sample
     expect(result.totalResolved).toBe(4);
+  });
+
+  it("partitions resolved outcomes by miner-vs-human cohort when confirmed miner logins are provided", () => {
+    const miners = new Set(["miner-author"]);
+    const result = buildSlopOutcomeCalibration(
+      [pr("clean", true, 1, "miner-author"), pr("clean", true, 2, "miner-author"), pr("clean", true, 3, "human-author"), pr("clean", false, 4, "human-author")],
+      { confirmedMinerLogins: miners },
+    );
+    expect(result.byCohort?.miner).toMatchObject({ totalResolved: 2, merged: 2, closed: 0 });
+    expect(result.byCohort?.human).toMatchObject({ totalResolved: 2, merged: 1, closed: 1 });
+    expect(JSON.stringify(result.byCohort)).not.toMatch(/miner-author|human-author/);
   });
 
   it("excludes open PRs and PRs with no slop assessment", () => {


### PR DESCRIPTION
## Summary

Implements [#4521](https://github.com/JSONbored/gittensory/issues/4521): extend the maintainer recap digest with an aggregate-only miner-vs-human cohort dimension when upstream reports carry it.

- Add `contributor-cohort.ts` — privacy-safe PR origin classification via cached official-miner detection (no logins in recap output)
- Extend `gate-precision.ts` / `outcome-calibration.ts` with optional `byCohort` slices on `overall` / `slop`
- Fold cohort slices in `buildMaintainerRecap` into `RecapReport.cohorts` and per-repo `cohorts`
- Add `maintainer-recap-cohort.ts` + render `## Cohort` in `formatMaintainerRecap` when data exists; blended output unchanged when absent
- Docs: `env.d.ts` maintainer recap comment + `focus-manifest` maintainerRecap parser note

Closes #4521

## Test plan

- [x] `npm run typecheck` (src changes)
- [x] `npx vitest run test/unit/contributor-cohort.test.ts test/unit/maintainer-recap-cohort.test.ts test/unit/maintainer-recap.test.ts test/unit/maintainer-recap-format.test.ts test/unit/gate-precision.test.ts test/unit/outcome-calibration.test.ts`
- [ ] CI: `validate-code`, `validate`, `codecov/patch`, security

## UI Evidence

N/A — backend recap aggregation/formatting only (no visible UI).

Made with [Cursor](https://cursor.com)