### PR TITLE
feat(miner-extension): add read-only issue-page opportunity badge

### DIFF
--- a/apps/gittensory-miner-extension/README.md
+++ b/apps/gittensory-miner-extension/README.md
@@ -1,13 +1,23 @@
 # Gittensory Miner Extension
 
-Contributor-facing browser extension scaffold for GitHub **issue** pages. It is intentionally separate from
+Contributor-facing browser extension for GitHub **issue** pages. It is intentionally separate from
 [`apps/gittensory-extension/`](../gittensory-extension/) (the **Maintainer Overlay**), which injects private PR/issue
 context for maintainers.
 
-This package is Phase 6 scaffolding only:
+## What it does
 
 - Manifest V3 with issue-page `content_scripts`
-- `background.js` service worker + `content.js` message-passing shell
-- Options page for local watched-repo configuration
+- `background.js` service worker + `content.js` message-passing
+- Read-only opportunity badge (score/tier + short why) for watched repositories
+- Options page for watched repos and a local ranked-candidate cache
 
-The read-only issue-page opportunity badge is implemented in a follow-up issue after this scaffold lands.
+The badge surfaces the same ranked signal as `packages/gittensory-miner/lib/opportunity-ranker.js` by reading
+pre-ranked candidates from browser local storage. It never writes to GitHub and omits itself when no ranked signal is
+available for the current issue.
+
+## Local ranked cache
+
+Laptop-mode installs can paste JSON from a miner `discover` run into the options page. The extension stores that list in
+`chrome.storage.local.rankedCandidates` and looks up the current issue there. A hosted discovery-index URL can be saved
+for future client support; when only unranked hosted metadata is available, the badge degrades gracefully by staying
+hidden.

--- a/apps/gittensory-miner-extension/README.md
+++ b/apps/gittensory-miner-extension/README.md
@@ -18,6 +18,6 @@ available for the current issue.
 ## Local ranked cache
 
 Laptop-mode installs can paste JSON from a miner `discover` run into the options page. The extension stores that list in
-`chrome.storage.local.rankedCandidates` and looks up the current issue there. A hosted discovery-index URL can be saved
-for future client support; when only unranked hosted metadata is available, the badge degrades gracefully by staying
-hidden.
+`chrome.storage.local.rankedCandidates` and looks up the current issue there. A discovery-index URL can be saved for a
+future hosted client path; it is not read yet, so when only unranked hosted metadata would be available the badge
+degrades gracefully by staying hidden.

--- a/apps/gittensory-miner-extension/background.js
+++ b/apps/gittensory-miner-extension/background.js
@@ -1,3 +1,8 @@
+import {
+  formatOpportunityBadge,
+  lookupRankedOpportunity,
+} from "./opportunity-badge.js";
+
 const PING_MESSAGE = "gittensory-miner:ping";
 const ISSUE_CONTEXT_MESSAGE = "gittensory-miner:issue-context";
 
@@ -8,7 +13,7 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     return false;
   }
   if (message.type === ISSUE_CONTEXT_MESSAGE) {
-    const task = loadIssueContextShell(message);
+    const task = loadIssueOpportunityContext(message);
     void task.then((payload) => sendResponse({ ok: true, payload })).catch((error) =>
       sendResponse({ ok: false, error: error instanceof Error ? error.message : String(error) }),
     );
@@ -17,32 +22,64 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
   return false;
 });
 
-async function loadIssueContextShell(message) {
+async function loadIssueOpportunityContext(message) {
   const settings = await loadMinerExtensionSettings();
   const repoFullName = `${message.owner}/${message.repo}`;
-  const watched = settings.watchedRepos.includes(repoFullName);
+  const watched = settings.watchedRepos.some(
+    (repo) => repo.trim().toLowerCase() === repoFullName.toLowerCase(),
+  );
+  if (!watched) {
+    return {
+      watched: false,
+      issueNumber: message.issueNumber,
+      repoFullName,
+      badge: null,
+      status: "repo-not-watched",
+    };
+  }
+
+  const rankedCandidates = await loadRankedCandidates();
+  const rankedEntry = lookupRankedOpportunity(rankedCandidates, repoFullName, message.issueNumber);
+  if (!rankedEntry) {
+    return {
+      watched: true,
+      issueNumber: message.issueNumber,
+      repoFullName,
+      badge: null,
+      status: "no-signal",
+    };
+  }
+
   return {
-    watched,
+    watched: true,
     issueNumber: message.issueNumber,
     repoFullName,
-    badge: null,
-    status: watched ? "shell-ready" : "repo-not-watched",
+    badge: formatOpportunityBadge(rankedEntry),
+    status: "ready",
   };
 }
 
 async function loadMinerExtensionSettings() {
-  const stored = await chrome.storage.sync.get({ watchedRepos: [] });
+  const stored = await chrome.storage.sync.get({ watchedRepos: [], discoveryIndexUrl: "" });
   const watchedRepos = Array.isArray(stored.watchedRepos)
     ? stored.watchedRepos.map((value) => String(value).trim()).filter(Boolean)
     : [];
-  return { watchedRepos };
+  const discoveryIndexUrl =
+    typeof stored.discoveryIndexUrl === "string" ? stored.discoveryIndexUrl.trim() : "";
+  return { watchedRepos, discoveryIndexUrl };
+}
+
+async function loadRankedCandidates() {
+  const stored = await chrome.storage.local.get({ rankedCandidates: [] });
+  return Array.isArray(stored.rankedCandidates) ? stored.rankedCandidates : [];
 }
 
 if (globalThis.__GITTENSORY_MINER_EXTENSION_TEST__) {
   globalThis.__gittensoryMinerBackgroundInternals = {
     PING_MESSAGE,
     ISSUE_CONTEXT_MESSAGE,
-    loadIssueContextShell,
+    loadIssueOpportunityContext,
     loadMinerExtensionSettings,
+    loadRankedCandidates,
   };
 }

--- a/apps/gittensory-miner-extension/background.js
+++ b/apps/gittensory-miner-extension/background.js
@@ -1,7 +1,6 @@
-import {
-  formatOpportunityBadge,
-  lookupRankedOpportunity,
-} from "./opportunity-badge.js";
+import "./opportunity-badge.js";
+
+const badgeApi = globalThis.__gittensoryMinerOpportunityBadge;
 
 const PING_MESSAGE = "gittensory-miner:ping";
 const ISSUE_CONTEXT_MESSAGE = "gittensory-miner:issue-context";
@@ -39,7 +38,7 @@ async function loadIssueOpportunityContext(message) {
   }
 
   const rankedCandidates = await loadRankedCandidates();
-  const rankedEntry = lookupRankedOpportunity(rankedCandidates, repoFullName, message.issueNumber);
+  const rankedEntry = badgeApi.lookupRankedOpportunity(rankedCandidates, repoFullName, message.issueNumber);
   if (!rankedEntry) {
     return {
       watched: true,
@@ -54,7 +53,7 @@ async function loadIssueOpportunityContext(message) {
     watched: true,
     issueNumber: message.issueNumber,
     repoFullName,
-    badge: formatOpportunityBadge(rankedEntry),
+    badge: badgeApi.formatOpportunityBadge(rankedEntry),
     status: "ready",
   };
 }

--- a/apps/gittensory-miner-extension/content.js
+++ b/apps/gittensory-miner-extension/content.js
@@ -1,7 +1,9 @@
+const badgeApi = globalThis.__gittensoryMinerOpportunityBadge;
+
 const target = matchGitHubIssueTarget(location.pathname);
 
 if (target?.kind === "issue") {
-  mountIssueShell(target);
+  mountOpportunityBadge(target);
 }
 
 function matchGitHubIssueTarget(pathname) {
@@ -11,17 +13,33 @@ function matchGitHubIssueTarget(pathname) {
   return { kind: "issue", owner, repo, issueNumber: Number(number) };
 }
 
-function mountIssueShell(target) {
-  if (document.querySelector("[data-gittensory-miner-issue-shell]")) return;
+function mountOpportunityBadge(target) {
+  if (document.querySelector("[data-gittensory-miner-opportunity-badge]")) return;
+  const host = findIssueSidebar();
   const container = document.createElement("aside");
-  container.className = "gittensory-miner-issue-shell";
-  container.dataset.gittensoryMinerIssueShell = "true";
+  container.className = host
+    ? "gittensory-miner-opportunity-badge"
+    : "gittensory-miner-opportunity-badge gittensory-miner-opportunity-badge--floating";
+  container.dataset.gittensoryMinerOpportunityBadge = "true";
   container.hidden = true;
-  document.body.appendChild(container);
-  void loadIssueShell(container, target);
+  if (host) {
+    host.prepend(container);
+  } else {
+    document.body.appendChild(container);
+  }
+  void loadOpportunityBadge(container, target);
 }
 
-async function loadIssueShell(container, target) {
+function findIssueSidebar() {
+  return (
+    document.querySelector("#partial-discussion-sidebar") ||
+    document.querySelector("[data-testid='issue-sidebar']") ||
+    document.querySelector(".Layout-sidebar") ||
+    document.querySelector(".discussion-sidebar")
+  );
+}
+
+async function loadOpportunityBadge(container, target) {
   const response = await chrome.runtime.sendMessage({
     type: "gittensory-miner:issue-context",
     owner: target.owner,
@@ -29,28 +47,30 @@ async function loadIssueShell(container, target) {
     issueNumber: target.issueNumber,
   });
   if (!response?.ok) {
-    container.hidden = true;
+    container.remove();
     return;
   }
-  renderIssueShell(container, response.payload);
+  renderOpportunityBadge(container, response.payload);
 }
 
-function renderIssueShell(container, payload) {
-  if (!payload?.watched) {
-    container.hidden = true;
+function renderOpportunityBadge(container, payload) {
+  if (!payload?.watched || !payload?.badge) {
+    container.remove();
+    return;
+  }
+  const markup = badgeApi?.renderOpportunityBadgeMarkup?.(payload.badge);
+  if (!markup) {
+    container.remove();
     return;
   }
   container.hidden = false;
-  container.textContent = "";
-  const label = document.createElement("span");
-  label.className = "gittensory-miner-issue-shell__label";
-  label.textContent = "Gittensory miner opportunity shell";
-  container.appendChild(label);
+  container.innerHTML = markup;
 }
 
 if (globalThis.__GITTENSORY_MINER_EXTENSION_TEST__) {
   globalThis.__gittensoryMinerContentInternals = {
     matchGitHubIssueTarget,
-    renderIssueShell,
+    findIssueSidebar,
+    renderOpportunityBadge,
   };
 }

--- a/apps/gittensory-miner-extension/manifest.json
+++ b/apps/gittensory-miner-extension/manifest.json
@@ -12,7 +12,8 @@
   "content_scripts": [
     {
       "matches": ["https://github.com/*/*/issues/*"],
-      "js": ["content.js"],
+      "js": ["opportunity-badge.js", "content.js"],
+      "css": ["styles.css"],
       "run_at": "document_idle"
     }
   ],

--- a/apps/gittensory-miner-extension/opportunity-badge.js
+++ b/apps/gittensory-miner-extension/opportunity-badge.js
@@ -1,0 +1,91 @@
+export function issueLookupKey(repoFullName, issueNumber) {
+  const repo = String(repoFullName ?? "").trim().toLowerCase();
+  const number = Number(issueNumber);
+  if (!repo || !Number.isInteger(number) || number <= 0) return null;
+  return `${repo}#${number}`;
+}
+
+export function lookupRankedOpportunity(rankedIssues, repoFullName, issueNumber) {
+  const targetKey = issueLookupKey(repoFullName, issueNumber);
+  if (!targetKey || !Array.isArray(rankedIssues)) return null;
+  for (const entry of rankedIssues) {
+    if (!entry || typeof entry !== "object") continue;
+    const key = issueLookupKey(entry.repoFullName, entry.issueNumber);
+    if (key === targetKey) return entry;
+  }
+  return null;
+}
+
+export function scoreToTier(rankScore) {
+  const score = Number(rankScore);
+  if (!Number.isFinite(score)) return "Unknown";
+  if (score >= 0.75) return "High";
+  if (score >= 0.5) return "Medium";
+  return "Low";
+}
+
+export function buildOpportunityWhy(entry) {
+  const reasons = [];
+  if (Number(entry.laneFit) >= 0.7) reasons.push("Strong lane fit");
+  if (Number(entry.freshness) >= 0.7) reasons.push("Fresh issue");
+  if (Number(entry.potential) >= 0.7) reasons.push("High reward potential");
+  if (Number(entry.feasibility) >= 0.7) reasons.push("Feasible scope");
+  if (Number(entry.dupRisk) <= 0.3) reasons.push("Low duplicate risk");
+  if (reasons.length === 0) reasons.push("Balanced opportunity signals");
+  return reasons.slice(0, 2).join("; ");
+}
+
+export function formatOpportunityBadge(entry) {
+  const rankScore = Number(entry.rankScore);
+  return {
+    tier: scoreToTier(rankScore),
+    score: Number.isFinite(rankScore) ? rankScore.toFixed(2) : "—",
+    why: buildOpportunityWhy(entry),
+    rankScore: Number.isFinite(rankScore) ? rankScore : null,
+  };
+}
+
+export function escapeOpportunityHtml(value) {
+  return String(value).replace(/[&<>"']/g, (char) => {
+    switch (char) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case '"':
+        return "&quot;";
+      default:
+        return "&#39;";
+    }
+  });
+}
+
+export function renderOpportunityBadgeMarkup(badge) {
+  if (!badge || typeof badge !== "object") return "";
+  return `
+    <div class="gittensory-miner-opportunity-badge__header">
+      <span class="gittensory-miner-opportunity-badge__mark">G</span>
+      <span>Gittensory opportunity</span>
+      <span class="gittensory-miner-opportunity-badge__read-only">Read-only</span>
+    </div>
+    <div class="gittensory-miner-opportunity-badge__score">
+      <strong>${escapeOpportunityHtml(badge.tier)}</strong>
+      <span>${escapeOpportunityHtml(badge.score)}</span>
+    </div>
+    <p class="gittensory-miner-opportunity-badge__why">${escapeOpportunityHtml(badge.why)}</p>
+  `;
+}
+
+if (typeof globalThis !== "undefined") {
+  globalThis.__gittensoryMinerOpportunityBadge = {
+    issueLookupKey,
+    lookupRankedOpportunity,
+    scoreToTier,
+    buildOpportunityWhy,
+    formatOpportunityBadge,
+    escapeOpportunityHtml,
+    renderOpportunityBadgeMarkup,
+  };
+}

--- a/apps/gittensory-miner-extension/opportunity-badge.js
+++ b/apps/gittensory-miner-extension/opportunity-badge.js
@@ -1,11 +1,11 @@
-export function issueLookupKey(repoFullName, issueNumber) {
+function issueLookupKey(repoFullName, issueNumber) {
   const repo = String(repoFullName ?? "").trim().toLowerCase();
   const number = Number(issueNumber);
   if (!repo || !Number.isInteger(number) || number <= 0) return null;
   return `${repo}#${number}`;
 }
 
-export function lookupRankedOpportunity(rankedIssues, repoFullName, issueNumber) {
+function lookupRankedOpportunity(rankedIssues, repoFullName, issueNumber) {
   const targetKey = issueLookupKey(repoFullName, issueNumber);
   if (!targetKey || !Array.isArray(rankedIssues)) return null;
   for (const entry of rankedIssues) {
@@ -16,7 +16,7 @@ export function lookupRankedOpportunity(rankedIssues, repoFullName, issueNumber)
   return null;
 }
 
-export function scoreToTier(rankScore) {
+function scoreToTier(rankScore) {
   const score = Number(rankScore);
   if (!Number.isFinite(score)) return "Unknown";
   if (score >= 0.75) return "High";
@@ -24,7 +24,7 @@ export function scoreToTier(rankScore) {
   return "Low";
 }
 
-export function buildOpportunityWhy(entry) {
+function buildOpportunityWhy(entry) {
   const reasons = [];
   if (Number(entry.laneFit) >= 0.7) reasons.push("Strong lane fit");
   if (Number(entry.freshness) >= 0.7) reasons.push("Fresh issue");
@@ -35,7 +35,7 @@ export function buildOpportunityWhy(entry) {
   return reasons.slice(0, 2).join("; ");
 }
 
-export function formatOpportunityBadge(entry) {
+function formatOpportunityBadge(entry) {
   const rankScore = Number(entry.rankScore);
   return {
     tier: scoreToTier(rankScore),
@@ -45,7 +45,7 @@ export function formatOpportunityBadge(entry) {
   };
 }
 
-export function escapeOpportunityHtml(value) {
+function escapeOpportunityHtml(value) {
   return String(value).replace(/[&<>"']/g, (char) => {
     switch (char) {
       case "&":
@@ -62,7 +62,7 @@ export function escapeOpportunityHtml(value) {
   });
 }
 
-export function renderOpportunityBadgeMarkup(badge) {
+function renderOpportunityBadgeMarkup(badge) {
   if (!badge || typeof badge !== "object") return "";
   return `
     <div class="gittensory-miner-opportunity-badge__header">
@@ -78,14 +78,18 @@ export function renderOpportunityBadgeMarkup(badge) {
   `;
 }
 
-if (typeof globalThis !== "undefined") {
-  globalThis.__gittensoryMinerOpportunityBadge = {
-    issueLookupKey,
-    lookupRankedOpportunity,
-    scoreToTier,
-    buildOpportunityWhy,
-    formatOpportunityBadge,
-    escapeOpportunityHtml,
-    renderOpportunityBadgeMarkup,
-  };
+const opportunityBadgeApi = {
+  issueLookupKey,
+  lookupRankedOpportunity,
+  scoreToTier,
+  buildOpportunityWhy,
+  formatOpportunityBadge,
+  escapeOpportunityHtml,
+  renderOpportunityBadgeMarkup,
+};
+
+globalThis.__gittensoryMinerOpportunityBadge = opportunityBadgeApi;
+
+if (globalThis.__GITTENSORY_MINER_EXTENSION_TEST__) {
+  globalThis.__gittensoryMinerOpportunityBadgeTestExports = opportunityBadgeApi;
 }

--- a/apps/gittensory-miner-extension/options.html
+++ b/apps/gittensory-miner-extension/options.html
@@ -21,14 +21,17 @@
         gap: 6px;
         margin-top: 16px;
       }
+      input,
       textarea {
         border: 1px solid rgba(255, 255, 255, 0.16);
         border-radius: 7px;
         background: rgba(255, 255, 255, 0.06);
         color: inherit;
         font: inherit;
-        min-height: 120px;
         padding: 9px 10px;
+      }
+      textarea {
+        min-height: 120px;
         resize: vertical;
       }
       button {
@@ -60,6 +63,18 @@
         <label>
           Watched repositories
           <textarea id="watchedRepos" name="watchedRepos" placeholder="owner/repo, one per line"></textarea>
+        </label>
+        <label>
+          Discovery index URL (optional)
+          <input id="discoveryIndexUrl" name="discoveryIndexUrl" placeholder="https://example.com/discovery-index" />
+        </label>
+        <label>
+          Ranked candidates JSON (local cache)
+          <textarea
+            id="rankedCandidatesJson"
+            name="rankedCandidatesJson"
+            placeholder='[{"repoFullName":"owner/repo","issueNumber":1,"rankScore":0.82,...}]'
+          ></textarea>
         </label>
         <button type="submit">Save</button>
       </form>

--- a/apps/gittensory-miner-extension/options.js
+++ b/apps/gittensory-miner-extension/options.js
@@ -5,17 +5,30 @@ function parseWatchedRepos(text) {
     .filter(Boolean);
 }
 
+function parseRankedCandidatesJson(text) {
+  const trimmed = String(text ?? "").trim();
+  if (!trimmed) return [];
+  const parsed = JSON.parse(trimmed);
+  if (!Array.isArray(parsed)) {
+    throw new Error("Ranked candidates JSON must be an array.");
+  }
+  return parsed;
+}
+
 if (globalThis.__GITTENSORY_MINER_EXTENSION_TEST__) {
   globalThis.__gittensoryMinerOptionsInternals = {
     parseWatchedRepos,
+    parseRankedCandidatesJson,
   };
 }
 
 const form = document.querySelector("#settings");
 const status = document.querySelector("#status");
 const watchedRepos = document.querySelector("#watchedRepos");
+const discoveryIndexUrl = document.querySelector("#discoveryIndexUrl");
+const rankedCandidatesJson = document.querySelector("#rankedCandidatesJson");
 
-if (!form || !status || !watchedRepos) {
+if (!form || !status || !watchedRepos || !discoveryIndexUrl || !rankedCandidatesJson) {
   // options.html is not mounted (unit-test harness or partial load).
 } else {
 void refreshSettings();
@@ -24,9 +37,18 @@ form.addEventListener("submit", async (event) => {
   event.preventDefault();
   try {
     const repos = parseWatchedRepos(watchedRepos.value);
-    await chrome.storage.sync.set({ watchedRepos: repos });
+    const rankedCandidates = parseRankedCandidatesJson(rankedCandidatesJson.value);
+    await chrome.storage.sync.set({
+      watchedRepos: repos,
+      discoveryIndexUrl: discoveryIndexUrl.value.trim(),
+    });
+    await chrome.storage.local.set({ rankedCandidates });
     await refreshSettings();
-    showStatus(repos.length > 0 ? `Watching ${repos.length} repository(ies).` : "Cleared watched repositories.");
+    showStatus(
+      rankedCandidates.length > 0
+        ? `Saved ${repos.length} watched repo(s) and ${rankedCandidates.length} ranked candidate(s).`
+        : `Watching ${repos.length} repository(ies).`,
+    );
   } catch (error) {
     showStatus(error instanceof Error ? error.message : String(error));
   }
@@ -34,9 +56,14 @@ form.addEventListener("submit", async (event) => {
 }
 
 async function refreshSettings() {
-  const stored = await chrome.storage.sync.get({ watchedRepos: [] });
+  const stored = await chrome.storage.sync.get({ watchedRepos: [], discoveryIndexUrl: "" });
+  const local = await chrome.storage.local.get({ rankedCandidates: [] });
   const repos = Array.isArray(stored.watchedRepos) ? stored.watchedRepos : [];
   watchedRepos.value = repos.join("\n");
+  discoveryIndexUrl.value = typeof stored.discoveryIndexUrl === "string" ? stored.discoveryIndexUrl : "";
+  const rankedCandidates = Array.isArray(local.rankedCandidates) ? local.rankedCandidates : [];
+  rankedCandidatesJson.value =
+    rankedCandidates.length > 0 ? JSON.stringify(rankedCandidates, null, 2) : "";
 }
 
 function showStatus(message) {

--- a/apps/gittensory-miner-extension/styles.css
+++ b/apps/gittensory-miner-extension/styles.css
@@ -1,0 +1,64 @@
+.gittensory-miner-opportunity-badge {
+  border: 1px solid rgba(126, 231, 188, 0.35);
+  border-radius: 8px;
+  background: rgba(15, 17, 23, 0.96);
+  color: #f4f7f5;
+  font: 13px/1.45 -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  margin: 12px 0;
+  padding: 12px;
+}
+
+.gittensory-miner-opportunity-badge--floating {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  max-width: 280px;
+  z-index: 9999;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+}
+
+.gittensory-miner-opportunity-badge__header {
+  align-items: center;
+  display: flex;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.gittensory-miner-opportunity-badge__mark {
+  align-items: center;
+  background: #7ee7bc;
+  border-radius: 999px;
+  color: #111317;
+  display: inline-flex;
+  font-size: 11px;
+  font-weight: 700;
+  height: 20px;
+  justify-content: center;
+  width: 20px;
+}
+
+.gittensory-miner-opportunity-badge__read-only {
+  color: rgba(244, 247, 245, 0.55);
+  font-size: 11px;
+  margin-left: auto;
+}
+
+.gittensory-miner-opportunity-badge__score {
+  align-items: baseline;
+  display: flex;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+
+.gittensory-miner-opportunity-badge__score strong {
+  font-size: 15px;
+}
+
+.gittensory-miner-opportunity-badge__score span {
+  color: rgba(244, 247, 245, 0.72);
+}
+
+.gittensory-miner-opportunity-badge__why {
+  color: rgba(244, 247, 245, 0.78);
+  margin: 0;
+}

--- a/test/unit/miner-extension-content.test.ts
+++ b/test/unit/miner-extension-content.test.ts
@@ -23,8 +23,8 @@ function rawIssue(overrides: Record<string, unknown> = {}) {
     createdAt: "2026-07-01T00:00:00.000Z",
     updatedAt: "2026-07-02T00:00:00.000Z",
     htmlUrl: "https://github.com/JSONbored/gittensory/issues/145",
-    aiPolicyAllowed: true,
-    aiPolicySource: "CONTRIBUTING.md",
+    aiPolicyAllowed: true as const,
+    aiPolicySource: "CONTRIBUTING.md" as const,
     ...overrides,
   };
 }

--- a/test/unit/miner-extension-content.test.ts
+++ b/test/unit/miner-extension-content.test.ts
@@ -1,25 +1,48 @@
 import { readFileSync } from "node:fs";
 import { Script, createContext } from "node:vm";
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { rankCandidateIssues } from "../../packages/gittensory-miner/lib/opportunity-ranker.js";
 
 const contentScript = readFileSync("apps/gittensory-miner-extension/content.js", "utf8");
 const backgroundScript = readFileSync("apps/gittensory-miner-extension/background.js", "utf8");
+const badgeScript = readFileSync("apps/gittensory-miner-extension/opportunity-badge.js", "utf8");
 const optionsScript = readFileSync("apps/gittensory-miner-extension/options.js", "utf8");
 const manifest = JSON.parse(readFileSync("apps/gittensory-miner-extension/manifest.json", "utf8"));
 
-describe("miner extension scaffold", () => {
-  it("ships a Manifest V3 issue-page-only content script surface", () => {
+const NOW = Date.parse("2026-07-03T12:00:00.000Z");
+
+function rawIssue(overrides: Record<string, unknown> = {}) {
+  return {
+    owner: "JSONbored",
+    repo: "gittensory",
+    repoFullName: "JSONbored/gittensory",
+    issueNumber: 145,
+    title: "Add miner extension badge",
+    labels: ["help wanted", "gittensor:feature"],
+    commentsCount: 1,
+    createdAt: "2026-07-01T00:00:00.000Z",
+    updatedAt: "2026-07-02T00:00:00.000Z",
+    htmlUrl: "https://github.com/JSONbored/gittensory/issues/145",
+    aiPolicyAllowed: true,
+    aiPolicySource: "CONTRIBUTING.md",
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("miner extension opportunity badge", () => {
+  it("ships a Manifest V3 issue-page content script with badge assets", () => {
     expect(manifest.manifest_version).toBe(3);
-    expect(manifest.name).toContain("Miner");
-    expect(manifest.content_scripts).toHaveLength(1);
     expect(manifest.content_scripts[0].matches).toEqual(["https://github.com/*/*/issues/*"]);
-    expect(manifest.background.service_worker).toBe("background.js");
-    expect(manifest.options_page).toBe("options.html");
+    expect(manifest.content_scripts[0].js).toEqual(["opportunity-badge.js", "content.js"]);
+    expect(manifest.content_scripts[0].css).toEqual(["styles.css"]);
   });
 
   it("detects GitHub issue routes without matching pull requests", () => {
     const internals = loadContentInternals();
-
     expect(internals.matchGitHubIssueTarget("/JSONbored/gittensory/issues/145")).toEqual({
       kind: "issue",
       owner: "JSONbored",
@@ -27,95 +50,130 @@ describe("miner extension scaffold", () => {
       issueNumber: 145,
     });
     expect(internals.matchGitHubIssueTarget("/JSONbored/gittensory/pull/146")).toBeNull();
-    expect(internals.matchGitHubIssueTarget("/JSONbored/gittensory/issues")).toBeNull();
   });
 
-  it("renders the watched-repo shell placeholder without a badge payload", () => {
+  it("looks up ranked opportunities using the same repo#issue key as the miner ranker", () => {
+    const ranked = rankCandidateIssues([rawIssue(), rawIssue({ issueNumber: 99, labels: ["question"] })], {
+      nowMs: NOW,
+    });
+    const badge = loadBadgeInternals();
+
+    const match = badge.lookupRankedOpportunity(ranked, "JSONbored/gittensory", 145);
+    expect(match?.issueNumber).toBe(145);
+    expect(match?.rankScore).toBeGreaterThan(0);
+    expect(badge.lookupRankedOpportunity(ranked, "JSONbored/gittensory", 404)).toBeNull();
+  });
+
+  it("formats tier, score, and a short why without duplicating ranking math", () => {
+    const ranked = rankCandidateIssues([rawIssue()], { nowMs: NOW })[0]!;
+    const badge = loadBadgeInternals();
+    const formatted = badge.formatOpportunityBadge(ranked);
+
+    expect(formatted.tier).toMatch(/High|Medium|Low/);
+    expect(formatted.score).toMatch(/^\d+\.\d{2}$/);
+    expect(formatted.why.length).toBeGreaterThan(0);
+    expect(badge.renderOpportunityBadgeMarkup(formatted)).toContain("Read-only");
+    expect(badge.renderOpportunityBadgeMarkup(formatted)).not.toContain("<script>");
+  });
+
+  it("renders the badge when a ranked signal is available and removes it otherwise", () => {
     const internals = loadContentInternals();
     const container = createMockContainer();
+    const ranked = rankCandidateIssues([rawIssue()], { nowMs: NOW })[0]!;
+    const badge = loadBadgeInternals();
+    const formatted = badge.formatOpportunityBadge(ranked);
 
-    internals.renderIssueShell(container, {
+    internals.renderOpportunityBadge(container, {
       watched: true,
-      issueNumber: 145,
-      repoFullName: "JSONbored/gittensory",
-      badge: null,
-      status: "shell-ready",
+      badge: formatted,
+      status: "ready",
     });
-
     expect(container.hidden).toBe(false);
-    expect(container.textContent).toContain("opportunity shell");
+    expect(container.innerHTML).toContain("Gittensory opportunity");
+    expect(container.innerHTML).toContain(formatted.tier);
+
+    const missing = createMockContainer();
+    internals.renderOpportunityBadge(missing, { watched: true, badge: null, status: "no-signal" });
+    expect(missing.removed).toBe(true);
   });
 
-  it("keeps the shell hidden for unwatched repositories", () => {
-    const internals = loadContentInternals();
-    const container = createMockContainer();
-
-    internals.renderIssueShell(container, {
-      watched: false,
-      issueNumber: 145,
-      repoFullName: "JSONbored/gittensory",
-      badge: null,
-      status: "repo-not-watched",
-    });
-
-    expect(container.hidden).toBe(true);
-  });
-
-  it("returns shell-ready issue context for watched repositories", async () => {
+  it("returns ready context when watched repo has a cached ranked candidate", async () => {
+    const ranked = rankCandidateIssues([rawIssue()], { nowMs: NOW });
     const internals = loadBackgroundInternals({
       watchedRepos: ["JSONbored/gittensory"],
+      rankedCandidates: ranked,
     });
 
-    const payload = await internals.loadIssueContextShell({
+    const payload = await internals.loadIssueOpportunityContext({
       owner: "JSONbored",
       repo: "gittensory",
       issueNumber: 145,
     });
 
-    expect(payload).toEqual({
-      watched: true,
-      issueNumber: 145,
-      repoFullName: "JSONbored/gittensory",
-      badge: null,
-      status: "shell-ready",
-    });
+    expect(payload.status).toBe("ready");
+    expect(payload.badge?.tier).toMatch(/High|Medium|Low/);
+    expect(payload.badge?.why).toBeTruthy();
   });
 
-  it("parses watched repositories from newline or comma separated options input", () => {
+  it("omits badge context when repo is watched but no ranked signal exists", async () => {
+    const internals = loadBackgroundInternals({
+      watchedRepos: ["JSONbored/gittensory"],
+      rankedCandidates: [],
+    });
+
+    const payload = await internals.loadIssueOpportunityContext({
+      owner: "JSONbored",
+      repo: "gittensory",
+      issueNumber: 145,
+    });
+
+    expect(payload.status).toBe("no-signal");
+    expect(payload.badge).toBeNull();
+  });
+
+  it("parses watched repos and ranked candidate JSON for options storage", () => {
     const internals = loadOptionsInternals();
     expect(internals.parseWatchedRepos("JSONbored/gittensory\nowner/repo")).toEqual([
       "JSONbored/gittensory",
       "owner/repo",
     ]);
-    expect(internals.parseWatchedRepos("JSONbored/gittensory, owner/repo")).toEqual([
-      "JSONbored/gittensory",
-      "owner/repo",
-    ]);
+    expect(internals.parseRankedCandidatesJson("[]")).toEqual([]);
+    expect(internals.parseRankedCandidatesJson('[{"repoFullName":"a/b","issueNumber":1}]')).toHaveLength(1);
+    expect(() => internals.parseRankedCandidatesJson("{")).toThrow();
+    expect(() => internals.parseRankedCandidatesJson('{"not":"array"}')).toThrow();
   });
 });
 
 function createMockContainer() {
   const container = {
     hidden: false,
-    textContent: "",
-    dataset: {} as Record<string, string>,
-    appendChild(node: { textContent?: string }) {
-      if (node.textContent) {
-        container.textContent += node.textContent;
-      }
+    innerHTML: "",
+    removed: false,
+    remove() {
+      container.removed = true;
     },
   };
-  return container as {
-    hidden: boolean;
-    textContent: string;
-    dataset: Record<string, string>;
-    appendChild: (node: { textContent?: string }) => void;
+  return container;
+}
+
+function loadBadgeInternals() {
+  const context: Record<string, unknown> = { globalThis: {} as Record<string, unknown> };
+  context.globalThis = context;
+  const vmContext = createContext(context);
+  const badgeForVm = badgeScript.replace(/\bexport\s+/g, "");
+  new Script(badgeForVm).runInContext(vmContext);
+  return vmContext.__gittensoryMinerOpportunityBadge as {
+    lookupRankedOpportunity: (ranked: unknown[], repoFullName: string, issueNumber: number) => Record<string, unknown> | null;
+    formatOpportunityBadge: (entry: Record<string, unknown>) => { tier: string; score: string; why: string };
+    renderOpportunityBadgeMarkup: (badge: { tier: string; score: string; why: string }) => string;
   };
 }
 
 function loadContentInternals() {
+  const badge = loadBadgeInternals();
   const context: Record<string, unknown> = {
     __GITTENSORY_MINER_EXTENSION_TEST__: true,
+    __gittensoryMinerOpportunityBadge: badge,
     location: { pathname: "/JSONbored/gittensory/pull/146" },
     document: {
       querySelector: () => null,
@@ -131,38 +189,55 @@ function loadContentInternals() {
     matchGitHubIssueTarget: (
       pathname: string,
     ) => { kind: "issue"; owner: string; repo: string; issueNumber: number } | null;
-    renderIssueShell: (container: { hidden: boolean; textContent: string }, payload: unknown) => void;
+    renderOpportunityBadge: (container: ReturnType<typeof createMockContainer>, payload: unknown) => void;
   };
 }
 
-function loadBackgroundInternals({ watchedRepos = [] as string[] } = {}) {
+function loadBackgroundInternals({
+  watchedRepos = [] as string[],
+  rankedCandidates = [] as unknown[],
+} = {}) {
   const context: Record<string, unknown> = {
     __GITTENSORY_MINER_EXTENSION_TEST__: true,
     chrome: {
-      storage: { sync: { get: async () => ({ watchedRepos }) } },
+      storage: {
+        sync: {
+          get: async () => ({ watchedRepos, discoveryIndexUrl: "" }),
+        },
+        local: {
+          get: async () => ({ rankedCandidates }),
+        },
+      },
       runtime: { onMessage: { addListener: () => {} } },
     },
   };
   context.globalThis = context;
   const vmContext = createContext(context);
-  new Script(backgroundScript).runInContext(vmContext);
+  const badgeForVm = badgeScript.replace(/\bexport\s+/g, "");
+  new Script(badgeForVm).runInContext(vmContext);
+  const backgroundForTest = backgroundScript.replace(/^import\s+[\s\S]*?from\s+["'][^"']+["'];\s*/m, "");
+  new Script(backgroundForTest).runInContext(vmContext);
   return vmContext.__gittensoryMinerBackgroundInternals as {
-    loadIssueContextShell: (message: {
+    loadIssueOpportunityContext: (message: {
       owner: string;
       repo: string;
       issueNumber: number;
-    }) => Promise<Record<string, unknown>>;
+    }) => Promise<{
+      status: string;
+      badge: { tier: string; why: string } | null;
+    }>;
   };
 }
 
 function loadOptionsInternals() {
   const context: Record<string, unknown> = {
     __GITTENSORY_MINER_EXTENSION_TEST__: true,
-    document: {
-      querySelector: () => null,
-    },
+    document: { querySelector: () => null },
     chrome: {
-      storage: { sync: { get: async () => ({ watchedRepos: [] }), set: async () => {} } },
+      storage: {
+        sync: { get: async () => ({ watchedRepos: [], discoveryIndexUrl: "" }), set: async () => {} },
+        local: { get: async () => ({ rankedCandidates: [] }), set: async () => {} },
+      },
     },
     setTimeout: () => 0,
   };
@@ -171,5 +246,6 @@ function loadOptionsInternals() {
   new Script(optionsScript).runInContext(vmContext);
   return vmContext.__gittensoryMinerOptionsInternals as {
     parseWatchedRepos: (text: string) => string[];
+    parseRankedCandidatesJson: (text: string) => unknown[];
   };
 }

--- a/test/unit/miner-extension-content.test.ts
+++ b/test/unit/miner-extension-content.test.ts
@@ -34,6 +34,10 @@ afterEach(() => {
 });
 
 describe("miner extension opportunity badge", () => {
+  it("ships browser-loadable content scripts without ESM export syntax", () => {
+    expect(badgeScript).not.toMatch(/\bexport\s+/);
+  });
+
   it("ships a Manifest V3 issue-page content script with badge assets", () => {
     expect(manifest.manifest_version).toBe(3);
     expect(manifest.content_scripts[0].matches).toEqual(["https://github.com/*/*/issues/*"]);
@@ -157,12 +161,13 @@ function createMockContainer() {
 }
 
 function loadBadgeInternals() {
-  const context: Record<string, unknown> = { globalThis: {} as Record<string, unknown> };
+  const context: Record<string, unknown> = {
+    __GITTENSORY_MINER_EXTENSION_TEST__: true,
+  };
   context.globalThis = context;
   const vmContext = createContext(context);
-  const badgeForVm = badgeScript.replace(/\bexport\s+/g, "");
-  new Script(badgeForVm).runInContext(vmContext);
-  return vmContext.__gittensoryMinerOpportunityBadge as {
+  new Script(badgeScript).runInContext(vmContext);
+  return vmContext.__gittensoryMinerOpportunityBadgeTestExports as {
     lookupRankedOpportunity: (ranked: unknown[], repoFullName: string, issueNumber: number) => Record<string, unknown> | null;
     formatOpportunityBadge: (entry: Record<string, unknown>) => { tier: string; score: string; why: string };
     renderOpportunityBadgeMarkup: (badge: { tier: string; score: string; why: string }) => string;
@@ -213,9 +218,8 @@ function loadBackgroundInternals({
   };
   context.globalThis = context;
   const vmContext = createContext(context);
-  const badgeForVm = badgeScript.replace(/\bexport\s+/g, "");
-  new Script(badgeForVm).runInContext(vmContext);
-  const backgroundForTest = backgroundScript.replace(/^import\s+[\s\S]*?from\s+["'][^"']+["'];\s*/m, "");
+  new Script(badgeScript).runInContext(vmContext);
+  const backgroundForTest = backgroundScript.replace(/^import\s+["'][^"']+["'];\s*/m, "");
   new Script(backgroundForTest).runInContext(vmContext);
   return vmContext.__gittensoryMinerBackgroundInternals as {
     loadIssueOpportunityContext: (message: {


### PR DESCRIPTION
## Summary
- Adds a read-only GitHub issue-page opportunity badge to `apps/gittensory-miner-extension/`, surfacing tier/score plus a short why from pre-ranked miner candidates.
- Background looks up `chrome.storage.local.rankedCandidates` via the same repo#issue key as `opportunity-ranker.js`; badge helper is a classic content script (no top-level `export`) shared with the module background worker through `globalThis`.
- Omits the badge when the repo is unwatched or no ranked signal exists; includes regression tests wired to real `rankCandidateIssues` output and a guard that the shippable badge script has no ESM export syntax.

Supersedes #4559 (auto-closed after fixing the content-script export blocker).

Closes #4308

## Test plan
- [x] `npx vitest run test/unit/miner-extension-content.test.ts`
- [ ] CI green on upstream PR