### PR TITLE
fix(review): avoid caching truncated grounding file content

### DIFF
--- a/src/review/grounding-wire.ts
+++ b/src/review/grounding-wire.ts
@@ -136,10 +136,9 @@ export async function makeGithubFileFetcher(env: Env, repoFullName: string, inst
   const { owner, name } = repoParts(repoFullName);
   return {
     async getFileContent(path: string, ref: string, maxChars = 24_001): Promise<string | null> {
-      // #4499: content for a given (repo, path, ref) is a git blob at an immutable commit -- it never changes,
-      // so a cache hit is always safe to reuse verbatim, skipping the GitHub call entirely. Checked BEFORE the
-      // network fetch below; only a genuinely successful fetch is ever written back (see the .catch-free write
-      // after the try block), so a transient failure is never mistaken for a confirmed-permanent one.
+      // #4499: complete content for a given (repo, path, ref) is a git blob at an immutable commit -- it
+      // never changes, so a complete cache hit is safe to reuse verbatim. Truncated maxChars probes are
+      // deliberately not cached below: security-sensitive callers may later request a larger cap.
       const cached = await getCachedGroundingFileContent(env, repoFullName, path, ref).catch(() => null);
       if (cached !== null) return cached;
       try {
@@ -149,7 +148,7 @@ export async function makeGithubFileFetcher(env: Env, repoFullName: string, inst
           .join("/")}?ref=${encodeURIComponent(ref)}`;
         const controller = new AbortController();
         const timeout = setTimeout(() => controller.abort(), 10_000);
-        let content: string | null;
+        let content: string;
         try {
           const response = await timeoutFetch(url, {
             signal: controller.signal,
@@ -165,15 +164,17 @@ export async function makeGithubFileFetcher(env: Env, repoFullName: string, inst
           });
           if (!response.ok) return null;
           const contentLength = response.headers.get("content-length");
-          content = contentLength && Number(contentLength) > maxChars ? " ".repeat(maxChars + 1) : await readTextWithLimit(response, maxChars);
+          if (contentLength && Number(contentLength) > maxChars) {
+            content = " ".repeat(maxChars + 1);
+          } else {
+            content = await readTextWithLimit(response, maxChars);
+          }
         } finally {
           clearTimeout(timeout);
         }
-        /* v8 ignore next -- readTextWithLimit's `string | null` return type is defensive; both of its actual
-         * return paths (text.slice(...) / text) always produce a string, never null, so this guard's false
-         * side is unreachable via the current implementation. Kept so a future readTextWithLimit change that
-         * legitimately returns null can never get cached as if it were real fetched content. */
-        if (content !== null) {
+        // Cache only complete bodies. A maxChars+1 probe result is a truncation marker/prefix and must
+        // not satisfy a later caller that asks for a larger security-sensitive scan window.
+        if (content.length <= maxChars) {
           await putCachedGroundingFileContent(env, repoFullName, path, ref, content).catch(() => undefined);
         }
         return content;
@@ -184,7 +185,7 @@ export async function makeGithubFileFetcher(env: Env, repoFullName: string, inst
   };
 }
 
-async function readTextWithLimit(response: Response, maxChars: number): Promise<string | null> {
+async function readTextWithLimit(response: Response, maxChars: number): Promise<string> {
   if (!response.body) {
     const text = await response.text();
     return text.length > maxChars ? text.slice(0, maxChars + 1) : text;

--- a/test/unit/grounding-wiring.test.ts
+++ b/test/unit/grounding-wiring.test.ts
@@ -525,6 +525,24 @@ describe("makeGithubFileFetcher (GitHub Contents-API-backed FileFetcher)", () =>
     fetchSpy.mockRestore();
   });
 
+  it("REGRESSION: truncated small-cap probes are not cached for later larger security scans", async () => {
+    const env = createTestEnv();
+    let fetchCount = 0;
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async () => {
+      fetchCount += 1;
+      if (fetchCount === 1) {
+        return new Response("short cap skipped", { status: 200, headers: { "content-length": "100" } });
+      }
+      return new Response("prefix" + "x".repeat(20) + "credential_marker_after_grounding_cap", { status: 200 });
+    });
+    const fetcher = await makeGithubFileFetcher(env, "acme/widgets", null);
+
+    expect(await fetcher.getFileContent("large.ts", "sha7", 10)).toBe(" ".repeat(11));
+    expect(await fetcher.getFileContent("large.ts", "sha7", 100)).toContain("credential_marker_after_grounding_cap");
+    expect(fetchCount).toBe(2);
+    fetchSpy.mockRestore();
+  });
+
   it("streams the body and truncates once the running text exceeds the per-file cap", async () => {
     const env = createTestEnv();
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(


### PR DESCRIPTION
### Motivation
- Prevent a cache poisoning window where small capped grounding fetches (e.g. 24 KB probes) could be stored as durable entries and later be reused by security-sensitive larger fetchers (e.g. 512 KB patchless secret-scan), allowing secrets placed beyond the grounding cap to be missed. 
- Ensure the durable `grounding_file_content_cache` only stores complete immutable blob bodies and never a caller-specific truncated probe marker or prefix. 
- Simplify defensive nullable handling for the streaming read helper to match its actual behavior.

### Description
- Change `makeGithubFileFetcher` so fetched content is only written to `putCachedGroundingFileContent` when the returned `content.length <= maxChars`, ensuring maxChars+1 truncation markers/prefixes are not cached. 
- Rework the per-response read path to distinguish the Content-Length early branch and to assign `content` only after a successful `readTextWithLimit` when appropriate. 
- Change `readTextWithLimit` to return `Promise<string>` (not nullable) to reflect its real return behavior and remove an unnecessary defensive cache-guard. 
- Add a regression unit test (`test/unit/grounding-wiring.test.ts`) that proves a small capped probe does not poison the durable cache and that a later larger probe performs a fresh live fetch.

### Testing
- Ran the grounding wiring unit file with Vitest and the new regression: `npx vitest run test/unit/grounding-wiring.test.ts -t "truncated small-cap"`, and `npx vitest run test/unit/grounding-wiring.test.ts`, both succeeded (all tests in that file passed). 
- Executed targeted `makeGithubFileFetcher` invariants and the new regression which verified a first small probe produced a truncation marker and a later larger probe triggered a second live fetch and saw the larger content. 
- Attempted `npm run typecheck` and full `npm run test:coverage` but these encountered unrelated environment/setup issues in this run: `tsc` failed due to a missing `web-tree-sitter` module/type in the workspace and a coverage provider error (`jsTokens is not a function`) surfaced when running the full coverage suite, so full unsharded coverage could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5046c43060832c91c70ef4268f4d20)