### PR TITLE
feat(review): surface generate-tests command inline in the review comment

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -1029,10 +1029,16 @@ const PUBLIC_MANIFEST_POLICY_FINDING_OVERRIDES: Partial<
   },
 };
 
+// #4583: surfaces the AI test-generation command right where a maintainer already sees the missing-coverage
+// finding, mirroring CodeRabbit's inline "Generate unit tests" walkthrough checkbox instead of requiring the
+// maintainer to already know the `@gittensory generate-tests` command exists from documentation alone.
+const E2E_TEST_GEN_CTA = "Maintainers can also comment `@gittensory generate-tests` for an AI-generated Playwright test.";
+
 export function publicSafeManifestPolicyFinding(
   finding: FocusManifestFinding,
+  options: { e2eTestGenAvailable?: boolean } = {},
 ): AdvisoryFinding {
-  return {
+  const base: AdvisoryFinding = {
     code: finding.code,
     severity: finding.severity,
     title: finding.title,
@@ -1043,6 +1049,16 @@ export function publicSafeManifestPolicyFinding(
     // private blocked-path globs / test expectations; codes absent from the table keep their already-generic text.
     ...PUBLIC_MANIFEST_POLICY_FINDING_OVERRIDES[finding.code],
   };
+  // Only appended when e2eTests is actually enabled for this repo (the SAME resolveConvergedFeature check the
+  // #4196 auto-trigger already gates on), so an unconfigured repo is never told about a command that would just
+  // bounce with "not enabled" -- and only for the missing-tests finding, the one case where the command is a
+  // directly relevant next step rather than noise on an unrelated finding. base.action is always defined here
+  // (PUBLIC_MANIFEST_POLICY_FINDING_OVERRIDES.manifest_missing_tests always sets one), the same always-populated
+  // guarantee the v8-ignore above already documents for this code path.
+  if (finding.code === "manifest_missing_tests" && options.e2eTestGenAvailable) {
+    return { ...base, action: `${base.action} ${E2E_TEST_GEN_CTA}` };
+  }
+  return base;
 }
 
 export async function processJob(env: Env, message: JobMessage): Promise<void> {
@@ -9442,9 +9458,14 @@ async function maybePublishPrPublicSurface(
       // Keep deterministic manifest policy findings independent from AI-review eligibility: ignored authors
       // suppress review/public output only, never maintainer-configured gate blockers or their downstream triggers.
       const policyFindings = guidance.findings;
+      // Computed once and reused below for the #4196 auto-trigger check -- same feature gate, one call. Also
+      // feeds #4583's inline CTA so the missing-tests finding surfaces `@gittensory generate-tests` right in
+      // ORB's own comment (mirrors CodeRabbit's inline walkthrough checkbox) only when the command would
+      // actually work for this repo, never as noise on a repo that hasn't opted in.
+      const e2eTestGenAvailable = resolveConvergedFeature(env, manifest, "e2eTests", repoFullName);
       for (const finding of policyFindings) {
         if (!policyCodes.has(finding.code)) continue;
-        advisory.findings.push(publicSafeManifestPolicyFinding(finding));
+        advisory.findings.push(publicSafeManifestPolicyFinding(finding, { e2eTestGenAvailable }));
       }
       // E2E test-generation auto-trigger (#4196, part of the #4189 epic): promotes the deterministic
       // manifest_missing_tests finding above from advisory-only text into an actual trigger for #4192/#4194's
@@ -9454,7 +9475,7 @@ async function maybePublishPrPublicSurface(
       // tests" from scratch, per the issue's own requirement -- this is why the auto-trigger lives inside this
       // exact manifestPolicyGateMode-gated block instead of a parallel code path: that is the only place this
       // finding is computed at all today.
-      if (pr.headSha && policyFindings.some((finding) => finding.code === "manifest_missing_tests") && resolveConvergedFeature(env, manifest, "e2eTests", repoFullName)) {
+      if (pr.headSha && policyFindings.some((finding) => finding.code === "manifest_missing_tests") && e2eTestGenAvailable) {
         const e2eTargetKey = `${repoFullName}#${pr.number}`;
         // Double-generation guard: an unchanged head SHA re-entering this pass (a re-review/sweep tick, not a
         // new push) must never re-spend an LLM call or repost a duplicate suggestion. A genuinely NEW push

--- a/test/unit/public-safe-manifest-finding.test.ts
+++ b/test/unit/public-safe-manifest-finding.test.ts
@@ -33,4 +33,33 @@ describe("publicSafeManifestPolicyFinding", () => {
     expect(safe.detail).toBe(finding.detail);
     expect(safe.action).toBe(finding.action);
   });
+
+  // #4583: surfaces `@gittensory generate-tests` inline in the SAME comment as the missing-coverage finding
+  // (mirrors CodeRabbit's inline walkthrough checkbox), gated on the caller-resolved e2eTests feature state.
+  it("appends the generate-tests CTA to the missing-tests finding when e2e test generation is available", () => {
+    const finding: FocusManifestFinding = {
+      code: "manifest_missing_tests",
+      severity: "warning",
+      title: "Maintainer test expectations unmet",
+      detail: "Maintainer expects test evidence: run the private fuzz suite.",
+      action: "Add or update tests for the private fuzz suite.",
+    };
+    const safe = publicSafeManifestPolicyFinding(finding, { e2eTestGenAvailable: true });
+    expect(safe.action).toBe(
+      "Add regression/invariant coverage, update relevant tests, or attach passing validation output that satisfies the repo's configured expectations. Maintainers can also comment `@gittensory generate-tests` for an AI-generated Playwright test.",
+    );
+  });
+
+  it("never appends the generate-tests CTA to a finding other than manifest_missing_tests, even when e2e test generation is available", () => {
+    const finding: FocusManifestFinding = {
+      code: "manifest_linked_issue_required",
+      severity: "warning",
+      title: "Maintainer requires a linked issue",
+      detail: "This repo's maintainer focus manifest requires every PR to reference a tracked issue.",
+      action: "Link the relevant issue (for example `Closes #123`) before opening the PR.",
+    };
+    const safe = publicSafeManifestPolicyFinding(finding, { e2eTestGenAvailable: true });
+    expect(safe.action).toBe(finding.action);
+    expect(safe.action).not.toContain("generate-tests");
+  });
 });


### PR DESCRIPTION
## Summary

- Epic #4189 (AI-generated E2E test coverage) is code-complete — `@gittensory generate-tests` and the
  `manifest_missing_tests` auto-trigger both work — but nothing in ORB's own review comment ever told a
  maintainer the command exists. A maintainer would have to already know it from documentation.
- CodeRabbit's own equivalent avoids this exact gap: their "Generate unit tests" affordance is a
  checkbox inside their own PR walkthrough comment, not a separate dashboard toggle — discoverable at
  the point a maintainer is already looking.
- `publicSafeManifestPolicyFinding` (src/queue/processors.ts) now accepts an optional
  `{ e2eTestGenAvailable }` and, only for the `manifest_missing_tests` finding and only when the
  `e2eTests` converged feature is actually enabled for the repo, appends a short CTA to that finding's
  rendered action text: "Maintainers can also comment `@gittensory generate-tests` for an AI-generated
  Playwright test."
- The gating check (`resolveConvergedFeature(env, manifest, "e2eTests", repoFullName)`) is hoisted once
  and reused by the existing #4196 auto-trigger `if` immediately below it, rather than computed twice.
- No new UI surface, no dashboard — text-only, inline in the comment ORB already posts. Byte-identical
  output for every repo that doesn't have `e2eTests` enabled.

Fixes #4583

## Test plan

- [x] `test/unit/public-safe-manifest-finding.test.ts`: 2 new cases — CTA appended when
      `e2eTestGenAvailable: true` on `manifest_missing_tests`; CTA never leaks onto an unrelated finding
      code even when `e2eTestGenAvailable: true` — plus the 2 pre-existing cases (redaction, pass-through)
      continue to cover the default/omitted-options path unchanged
- [x] Full `test/unit/queue.test.ts` (768 tests, including the existing `manifest_missing_tests
      auto-trigger (#4196)` describe block) — all pass, confirming the hoisted `e2eTestGenAvailable`
      const is behavior-preserving for the auto-trigger
- [x] Verified via lcov branch data (BRDA) that both branches of the new `if` are exercised and no
      branch introduced by this diff is left uncovered
- [x] `npx tsc --noEmit` clean on this diff (a pre-existing, unrelated typecheck failure in
      `test/unit/miner-attempt-log.test.ts` predates this branch — confirmed via `git diff origin/main`
      showing zero changes to that file)
- [x] `git diff --check` clean; no drift against `origin/main` at push time
- [x] No generated artifacts invalidated (no API/OpenAPI, wrangler binding, Drizzle schema, selfhost
      env-read, or CLI command-surface changes)