### PR TITLE
fix(review): mark firstLineMatching's noUncheckedIndexedAccess fallback unreachable

### DIFF
--- a/src/review/content-lane/security-scan.ts
+++ b/src/review/content-lane/security-scan.ts
@@ -154,7 +154,11 @@ const PIPED_INSTALL_RE = /\b(?:curl|wget)\b[^\n|]*\|\s*(?:sudo\s+)?(?:sh|bash|zs
 function firstLineMatching(text: string, re: RegExp): { n: number; text: string } | null {
   const lines = text.split(/\r?\n/);
   for (let i = 0; i < lines.length; i += 1) {
-    if (re.test(lines[i] ?? "")) return { n: i + 1, text: (lines[i] ?? "").trim().slice(0, 160) };
+    // `?? ""` only exists to satisfy noUncheckedIndexedAccess -- the loop bound above guarantees lines[i] is
+    // always defined here (`.split()` never produces holes), so the fallback branch is unreachable in practice.
+    /* v8 ignore next */
+    const line = lines[i] ?? "";
+    if (re.test(line)) return { n: i + 1, text: line.trim().slice(0, 160) };
   }
   return null;
 }


### PR DESCRIPTION
## Summary
Pre-existing coverage gap found while touching this file for #4587 (the `generic_secret_assignment` false-positive fix): the loop bound already guarantees `lines[i]` is defined, so the `?? ""` fallback (duplicated twice on one line) was dead code requiring two separate, unreachable branches. Hoists it into one local binding with a single documented `/* v8 ignore next */`, matching the convention already used elsewhere in this codebase for this exact `noUncheckedIndexedAccess` shape.

## Test plan
- [x] `npm run typecheck`, existing `content-lane-security-scan.test.ts` suite (43 tests, unchanged behavior)
- [x] Verified via lcov that the two previously-uncovered branches at this line are now clean