### PR TITLE
fix(engine): defer repo-map's createRequire past module scope to unbreak the api Worker deploy

### DIFF
--- a/packages/gittensory-engine/src/miner/repo-map.ts
+++ b/packages/gittensory-engine/src/miner/repo-map.ts
@@ -20,7 +20,15 @@ import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import Parser from "web-tree-sitter";
 
-const require = createRequire(import.meta.url);
+// Lazy, not module-scope: this file is reachable from the Cloudflare Workers bundle (barrel-exported via
+// `@jsonbored/gittensory-engine`) even though nothing there ever calls `buildRepoMap`. `import.meta.url` is
+// undefined in that bundle's startup-validation context, so an eager `createRequire(import.meta.url)` at
+// module scope would crash the Worker's deploy before any request is served. Deferring construction to
+// first real use keeps this module import-safe everywhere while still working for its actual CLI callers.
+let cachedRequire: NodeJS.Require | null = null;
+function requireFromHere(): NodeJS.Require {
+  return (cachedRequire ??= createRequire(import.meta.url));
+}
 
 export type RepoMapSymbolKind = "function" | "class" | "method" | "interface" | "type";
 
@@ -90,7 +98,7 @@ let parserInitialized: Promise<void> | null = null;
 async function defaultLoadRepoMapLanguage(languageName: string): Promise<Parser.Language> {
   parserInitialized ??= Parser.init();
   await parserInitialized;
-  const wasmPath = require.resolve(`tree-sitter-wasms/out/tree-sitter-${languageName}.wasm`);
+  const wasmPath = requireFromHere().resolve(`tree-sitter-wasms/out/tree-sitter-${languageName}.wasm`);
   return Parser.Language.load(readFileSync(wasmPath));
 }
 

--- a/packages/gittensory-miner/lib/status.js
+++ b/packages/gittensory-miner/lib/status.js
@@ -9,8 +9,18 @@ import { resolveMinerVersion } from "./version.js";
 // this laptop set up correctly). Both are read-only and 100% local — no repo-scanning, no coding-agent invocation,
 // no GitHub writes, and no network calls of any kind. Later phases add the real discover/plan/manage loop.
 
-const require = createRequire(import.meta.url);
-const moduleDir = import.meta.dirname;
+// Lazy, not module-scope: mirrors the gittensory-engine repo-map.ts fix -- this file is CLI-only today, but
+// an eager createRequire(import.meta.url)/import.meta.dirname at module scope would crash on import in any
+// bundler context where import.meta is unavailable (e.g. if a future import chain pulls this into a Worker
+// bundle, the way repo-map.ts was). Deferring construction to first real use keeps this import-safe.
+let cachedRequire = null;
+function requireFromHere() {
+  return (cachedRequire ??= createRequire(import.meta.url));
+}
+let cachedModuleDir = null;
+function moduleDir() {
+  return (cachedModuleDir ??= import.meta.dirname);
+}
 
 const PACKAGE_NAME = "@jsonbored/gittensory-miner";
 const ENGINE_PACKAGE = "@jsonbored/gittensory-engine";
@@ -40,7 +50,7 @@ export function resolveMinerStateDir(env = process.env) {
 // be absent depending on build order, so the declared-dependency version is the reliable, always-available source.)
 function readEngineVersion() {
   try {
-    return require("../package.json").dependencies?.[ENGINE_PACKAGE] ?? null;
+    return requireFromHere()("../package.json").dependencies?.[ENGINE_PACKAGE] ?? null;
   } catch {
     return null;
   }
@@ -75,11 +85,11 @@ export function readInstalledEnginePackageVersionFromPaths(
 export function readInstalledEnginePackageVersion() {
   try {
     return readInstalledEnginePackageVersionFromPaths(
-      require.resolve(ENGINE_PACKAGE),
-      join(moduleDir, "../../gittensory-engine/package.json"),
+      requireFromHere().resolve(ENGINE_PACKAGE),
+      join(moduleDir(), "../../gittensory-engine/package.json"),
     );
   } catch {
-    const workspacePkg = join(moduleDir, "../../gittensory-engine/package.json");
+    const workspacePkg = join(moduleDir(), "../../gittensory-engine/package.json");
     if (existsSync(workspacePkg)) {
       try {
         return JSON.parse(readFileSync(workspacePkg, "utf8")).version ?? null;
@@ -114,8 +124,8 @@ export function readExpectedEnginePackageVersionFromPaths(
 
 export function readExpectedEnginePackageVersion() {
   return readExpectedEnginePackageVersionFromPaths(
-    join(moduleDir, "../../gittensory-engine/package.json"),
-    join(moduleDir, "../expected-engine.version"),
+    join(moduleDir(), "../../gittensory-engine/package.json"),
+    join(moduleDir(), "../expected-engine.version"),
   );
 }
 
@@ -170,7 +180,7 @@ function checkEngineVersionSkew() {
 
 /** The minimum Node major version from the package's `engines.node` floor (e.g. ">=22.13.0" → 22). */
 function requiredNodeMajor() {
-  const engines = require("../package.json").engines;
+  const engines = requireFromHere()("../package.json").engines;
   const match = typeof engines?.node === "string" ? engines.node.match(/(\d+)/) : null;
   return match ? Number(match[1]) : 0;
 }


### PR DESCRIPTION
## Summary
- `gittensory-api`'s `wrangler deploy` was failing at Cloudflare's startup-validation step with `Uncaught TypeError: The argument 'path' ... Received 'undefined'` from `createRequire` in `packages/gittensory-engine/dist/miner/repo-map.js`.
- Root cause: `repo-map.ts` called `createRequire(import.meta.url)` eagerly at module scope. That file is barrel-exported from `@jsonbored/gittensory-engine`, which `gittensory-miner`'s `opportunity-fanout.js`/`opportunity-ranker.js` import via the bare package specifier — and those are pulled into the `gittensory-api` Worker bundle through `src/mcp/find-opportunities.ts`. `import.meta.url` is `undefined` in that bundle's startup context, so the eager call crashed the deploy before any request could be served, even though nothing in the Worker ever calls `buildRepoMap`.
- Fix: construct the `require` lazily, only when a grammar actually needs to be resolved. This lets esbuild tree-shake the whole unused module out of the Worker bundle (verified via `wrangler deploy --dry-run --outdir`) instead of retaining it for its top-level side effect.
- Follow-up commit: `packages/gittensory-miner/lib/status.js` had the identical pattern (`createRequire(import.meta.url)` + `import.meta.dirname` at module scope). Not currently reachable from the Worker bundle, but it's the exact same landmine, so closed it too before some future import chain connects it.

## Test plan
- [x] `npm --workspace @jsonbored/gittensory-engine run build`
- [x] `npm run typecheck`
- [x] `npx vitest run test/unit/repo-map.test.ts` (25/25, 100% stmt/branch coverage on the changed file)
- [x] `npx vitest run test/unit/find-opportunities.test.ts test/unit/mcp-find-opportunities.test.ts test/unit/opportunity-fanout-ai-policy.test.ts test/unit/gittensory-engine-scaffold.test.ts`
- [x] `npx wrangler deploy --dry-run --outdir=/tmp/wrangler-verify` — confirmed the bundle no longer contains `createRequire(`/`import.meta` at all (module fully tree-shaken since unused)
- [x] `node --check packages/gittensory-miner/lib/status.js` + `npm --workspace @jsonbored/gittensory-miner run build`
- [x] `npx vitest run test/unit/miner-status.test.ts test/unit/miner-manage-status.test.ts test/unit/miner-cli-doctor-checks.test.ts` (35/35; branch coverage on `status.js` unchanged from pre-existing baseline — no new gaps introduced)