### PR TITLE
feat(miner-ui): read-only run-history table over the local run-state store

### DIFF
--- a/apps/gittensory-miner-ui/src/lib/run-history.ts
+++ b/apps/gittensory-miner-ui/src/lib/run-history.ts
@@ -1,0 +1,42 @@
+// Read-only client for the local run-state API (#4305). The dashboard is a browser app and the miner's stores
+// are `node:sqlite` files on disk, so the view never touches SQL — it fetches the dev server's local read-only
+// endpoint (see `vite-run-state-api.ts`), which itself calls into `packages/gittensory-miner/lib/run-state.js`'s
+// existing exports.
+
+export const RUN_STATE_API_PATH = "/api/run-state";
+
+/** One `miner_run_state` row as served by the local API — mirrors `run-state.js`'s row shape. */
+export type RunStateRow = {
+  repoFullName: string;
+  state: "idle" | "discovering" | "planning" | "preparing";
+  updatedAt: string;
+};
+
+export type RunHistoryResult = { ok: true; rows: RunStateRow[] } | { ok: false; error: string };
+
+function isRunStateRow(value: unknown): value is RunStateRow {
+  if (typeof value !== "object" || value === null) return false;
+  const row = value as Record<string, unknown>;
+  return (
+    typeof row.repoFullName === "string" &&
+    typeof row.updatedAt === "string" &&
+    (row.state === "idle" || row.state === "discovering" || row.state === "planning" || row.state === "preparing")
+  );
+}
+
+/** Fetch the local run-state rows. Failures (server down, malformed payload) surface as a typed error result —
+ *  the view renders them as a message, never a crash. `fetchImpl` is injectable for tests. */
+export async function fetchRunStates(fetchImpl: typeof fetch = fetch): Promise<RunHistoryResult> {
+  try {
+    const response = await fetchImpl(RUN_STATE_API_PATH);
+    if (!response.ok) return { ok: false, error: `local run-state API responded ${response.status}` };
+    const payload: unknown = await response.json();
+    const rows = (payload as { rows?: unknown }).rows;
+    if (!Array.isArray(rows) || !rows.every(isRunStateRow)) {
+      return { ok: false, error: "local run-state API returned an unexpected payload shape" };
+    }
+    return { ok: true, rows };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : "failed to reach the local run-state API" };
+  }
+}

--- a/apps/gittensory-miner-ui/src/routeTree.gen.ts
+++ b/apps/gittensory-miner-ui/src/routeTree.gen.ts
@@ -8,50 +8,70 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-import { Route as rootRouteImport } from "./routes/__root";
-import { Route as IndexRouteImport } from "./routes/index";
+import { Route as rootRouteImport } from './routes/__root'
+import { Route as RunHistoryRouteImport } from './routes/run-history'
+import { Route as IndexRouteImport } from './routes/index'
 
-const IndexRoute = IndexRouteImport.update({
-  id: "/",
-  path: "/",
+const RunHistoryRoute = RunHistoryRouteImport.update({
+  id: '/run-history',
+  path: '/run-history',
   getParentRoute: () => rootRouteImport,
-} as any);
+} as any)
+const IndexRoute = IndexRouteImport.update({
+  id: '/',
+  path: '/',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
-  "/": typeof IndexRoute;
+  '/': typeof IndexRoute
+  '/run-history': typeof RunHistoryRoute
 }
 export interface FileRoutesByTo {
-  "/": typeof IndexRoute;
+  '/': typeof IndexRoute
+  '/run-history': typeof RunHistoryRoute
 }
 export interface FileRoutesById {
-  __root__: typeof rootRouteImport;
-  "/": typeof IndexRoute;
+  __root__: typeof rootRouteImport
+  '/': typeof IndexRoute
+  '/run-history': typeof RunHistoryRoute
 }
 export interface FileRouteTypes {
-  fileRoutesByFullPath: FileRoutesByFullPath;
-  fullPaths: "/";
-  fileRoutesByTo: FileRoutesByTo;
-  to: "/";
-  id: "__root__" | "/";
-  fileRoutesById: FileRoutesById;
+  fileRoutesByFullPath: FileRoutesByFullPath
+  fullPaths: '/' | '/run-history'
+  fileRoutesByTo: FileRoutesByTo
+  to: '/' | '/run-history'
+  id: '__root__' | '/' | '/run-history'
+  fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
-  IndexRoute: typeof IndexRoute;
+  IndexRoute: typeof IndexRoute
+  RunHistoryRoute: typeof RunHistoryRoute
 }
 
-declare module "@tanstack/react-router" {
+declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
-    "/": {
-      id: "/";
-      path: "/";
-      fullPath: "/";
-      preLoaderRoute: typeof IndexRouteImport;
-      parentRoute: typeof rootRouteImport;
-    };
+    '/run-history': {
+      id: '/run-history'
+      path: '/run-history'
+      fullPath: '/run-history'
+      preLoaderRoute: typeof RunHistoryRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
-};
-export const routeTree = rootRouteImport._addFileChildren(rootRouteChildren)._addFileTypes<FileRouteTypes>();
+  RunHistoryRoute: RunHistoryRoute,
+}
+export const routeTree = rootRouteImport
+  ._addFileChildren(rootRouteChildren)
+  ._addFileTypes<FileRouteTypes>()

--- a/apps/gittensory-miner-ui/src/routes/__root.tsx
+++ b/apps/gittensory-miner-ui/src/routes/__root.tsx
@@ -13,9 +13,12 @@ function RootLayout() {
             <p className="text-sm uppercase tracking-[0.2em] text-emerald-300/80">Gittensory Miner</p>
             <h1 className="text-lg font-semibold">Local dashboard shell</h1>
           </div>
-          <nav className="text-sm text-white/70">
+          <nav className="flex gap-4 text-sm text-white/70">
             <Link to="/" className="hover:text-white">
               Overview
+            </Link>
+            <Link to="/run-history" className="hover:text-white">
+              Run history
             </Link>
           </nav>
         </div>

--- a/apps/gittensory-miner-ui/src/routes/run-history.tsx
+++ b/apps/gittensory-miner-ui/src/routes/run-history.tsx
@@ -1,0 +1,97 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useEffect, useState } from "react";
+
+import { fetchRunStates, type RunHistoryResult, type RunStateRow } from "../lib/run-history";
+
+export const Route = createFileRoute("/run-history")({
+  component: RunHistoryPage,
+});
+
+// Read-only run-history table (#4305): one row per repo from the local `miner_run_state` store (repo, state,
+// last-updated), served by the dev server's local API. No writes, no new state — a fresh install renders the
+// empty state, an unreachable API renders an error message.
+
+const STATE_BADGE_CLASSES: Record<RunStateRow["state"], string> = {
+  idle: "bg-white/10 text-white/70",
+  discovering: "bg-sky-500/20 text-sky-200",
+  planning: "bg-amber-500/20 text-amber-200",
+  preparing: "bg-emerald-500/20 text-emerald-200",
+};
+
+export function RunHistoryView({ result }: { result: RunHistoryResult | null }) {
+  if (result === null) {
+    return <p className="text-sm text-white/60">Loading local run state…</p>;
+  }
+  if (!result.ok) {
+    return (
+      <p role="alert" className="text-sm text-rose-300">
+        Could not read local run state: {result.error}
+      </p>
+    );
+  }
+  if (result.rows.length === 0) {
+    return (
+      <p className="text-sm text-white/60">
+        No local run state yet — the table fills in once the miner records its first repo run.
+      </p>
+    );
+  }
+  return (
+    <table className="w-full text-left text-sm">
+      <thead>
+        <tr className="border-b border-white/10 text-xs uppercase tracking-wider text-white/50">
+          <th scope="col" className="py-2 pr-4">
+            Repository
+          </th>
+          <th scope="col" className="py-2 pr-4">
+            State
+          </th>
+          <th scope="col" className="py-2">
+            Last updated
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {result.rows.map((row) => (
+          <tr key={row.repoFullName} className="border-b border-white/5">
+            <td className="py-2 pr-4 font-mono text-white/90">{row.repoFullName}</td>
+            <td className="py-2 pr-4">
+              <span className={`rounded-full px-2 py-0.5 text-xs ${STATE_BADGE_CLASSES[row.state]}`}>{row.state}</span>
+            </td>
+            <td className="py-2 text-white/70">{row.updatedAt}</td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+export function RunHistoryPage({
+  loadRunStates = fetchRunStates,
+}: {
+  loadRunStates?: () => Promise<RunHistoryResult>;
+}) {
+  const [result, setResult] = useState<RunHistoryResult | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    void loadRunStates().then((loaded) => {
+      if (!cancelled) setResult(loaded);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [loadRunStates]);
+
+  return (
+    <section className="rounded-xl border border-white/10 bg-white/5 p-6">
+      <h2 className="text-xl font-semibold">Run history</h2>
+      <p className="mt-1 text-sm text-white/60">
+        Local, read-only view over the miner&apos;s per-repo run state (`miner_run_state`).
+      </p>
+      <div className="mt-4">
+        <RunHistoryView result={result} />
+      </div>
+    </section>
+  );
+}

--- a/apps/gittensory-miner-ui/src/run-history.test.tsx
+++ b/apps/gittensory-miner-ui/src/run-history.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { fetchRunStates, RUN_STATE_API_PATH, type RunHistoryResult, type RunStateRow } from "./lib/run-history";
+import { RunHistoryPage, RunHistoryView } from "./routes/run-history";
+
+const fixtureRows: RunStateRow[] = [
+  { repoFullName: "acme/widgets", state: "preparing", updatedAt: "2026-07-10T06:00:00.000Z" },
+  { repoFullName: "acme/gadgets", state: "idle", updatedAt: "2026-07-10T05:00:00.000Z" },
+];
+
+describe("RunHistoryView (#4305)", () => {
+  it("renders one table row per run-state fixture row with repo, state badge, and last-updated", () => {
+    render(<RunHistoryView result={{ ok: true, rows: fixtureRows }} />);
+    expect(screen.getByRole("columnheader", { name: "Repository" })).toBeTruthy();
+    expect(screen.getByText("acme/widgets")).toBeTruthy();
+    expect(screen.getByText("preparing")).toBeTruthy();
+    expect(screen.getByText("acme/gadgets")).toBeTruthy();
+    expect(screen.getByText("2026-07-10T05:00:00.000Z")).toBeTruthy();
+    expect(screen.getAllByRole("row")).toHaveLength(3); // header + 2 fixture rows
+  });
+
+  it("renders the fresh-install empty state without erroring", () => {
+    render(<RunHistoryView result={{ ok: true, rows: [] }} />);
+    expect(screen.getByText(/No local run state yet/i)).toBeTruthy();
+    expect(screen.queryByRole("table")).toBeNull();
+  });
+
+  it("renders an error message when the local API is unreachable", () => {
+    render(<RunHistoryView result={{ ok: false, error: "connection refused" }} />);
+    expect(screen.getByRole("alert").textContent).toContain("connection refused");
+  });
+
+  it("renders the loading state before the first result arrives", () => {
+    render(<RunHistoryView result={null} />);
+    expect(screen.getByText(/Loading local run state/i)).toBeTruthy();
+  });
+});
+
+describe("RunHistoryPage (#4305)", () => {
+  it("loads rows through the injected loader and renders them", async () => {
+    const loadRunStates = async (): Promise<RunHistoryResult> => ({ ok: true, rows: fixtureRows });
+    render(<RunHistoryPage loadRunStates={loadRunStates} />);
+    expect(screen.getByRole("heading", { name: "Run history" })).toBeTruthy();
+    await waitFor(() => expect(screen.getByText("acme/widgets")).toBeTruthy());
+  });
+});
+
+describe("fetchRunStates (#4305)", () => {
+  const jsonResponse = (status: number, payload: unknown) =>
+    ({ ok: status >= 200 && status < 300, status, json: async () => payload }) as unknown as Response;
+
+  it("returns typed rows from a well-formed payload, requesting the local API path", async () => {
+    let requested: string | undefined;
+    const result = await fetchRunStates(async (input) => {
+      requested = String(input);
+      return jsonResponse(200, { rows: fixtureRows });
+    });
+    expect(requested).toBe(RUN_STATE_API_PATH);
+    expect(result).toEqual({ ok: true, rows: fixtureRows });
+  });
+
+  it("surfaces a non-2xx response as a typed error", async () => {
+    const result = await fetchRunStates(async () => jsonResponse(500, { error: "boom" }));
+    expect(result).toEqual({ ok: false, error: "local run-state API responded 500" });
+  });
+
+  it("rejects a malformed payload shape (missing rows / bad row fields)", async () => {
+    expect(await fetchRunStates(async () => jsonResponse(200, { rows: "nope" }))).toMatchObject({ ok: false });
+    expect(
+      await fetchRunStates(async () =>
+        jsonResponse(200, { rows: [{ repoFullName: 1, state: "idle", updatedAt: "t" }] }),
+      ),
+    ).toMatchObject({ ok: false });
+    expect(
+      await fetchRunStates(async () =>
+        jsonResponse(200, { rows: [{ repoFullName: "a/b", state: "warp", updatedAt: "t" }] }),
+      ),
+    ).toMatchObject({ ok: false });
+  });
+
+  it("surfaces a thrown fetch (server not running) as a typed error, never a crash", async () => {
+    const result = await fetchRunStates(async () => {
+      throw new Error("connection refused");
+    });
+    expect(result).toEqual({ ok: false, error: "connection refused" });
+  });
+});

--- a/apps/gittensory-miner-ui/src/run-state-api.test.ts
+++ b/apps/gittensory-miner-ui/src/run-state-api.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+
+import { handleRunStateRequest, type RunStateApiDeps } from "../vite-run-state-api";
+
+const rows = [{ repoFullName: "acme/widgets", state: "idle", updatedAt: "2026-07-10T06:00:00.000Z" }];
+
+function deps(overrides: Partial<RunStateApiDeps> = {}): RunStateApiDeps {
+  return {
+    loadRunStateModule: async () => ({
+      resolveRunStateDbPath: () => "/home/miner/.config/gittensory-miner/run-state.sqlite3",
+      listRunStates: () => rows,
+    }),
+    fileExists: () => true,
+    ...overrides,
+  };
+}
+
+describe("handleRunStateRequest (#4305)", () => {
+  it("serves the run-state rows via the existing run-state.js exports", async () => {
+    const handled = await handleRunStateRequest("GET", "/api/run-state", deps());
+    expect(handled).toEqual({ status: 200, body: JSON.stringify({ rows }) });
+  });
+
+  it("serves [] on a fresh install WITHOUT initializing the store (no DB file => no listRunStates call)", async () => {
+    let listed = false;
+    const handled = await handleRunStateRequest(
+      "GET",
+      "/api/run-state",
+      deps({
+        loadRunStateModule: async () => ({
+          resolveRunStateDbPath: () => "/nowhere/run-state.sqlite3",
+          listRunStates: () => {
+            listed = true;
+            return rows;
+          },
+        }),
+        fileExists: () => false,
+      }),
+    );
+    expect(handled).toEqual({ status: 200, body: JSON.stringify({ rows: [] }) });
+    expect(listed).toBe(false);
+  });
+
+  it("falls through (null) for other paths and non-GET methods", async () => {
+    expect(await handleRunStateRequest("GET", "/api/other", deps())).toBeNull();
+    expect(await handleRunStateRequest("POST", "/api/run-state", deps())).toBeNull();
+  });
+
+  it("surfaces a store read failure as a 500 with a safe message", async () => {
+    const handled = await handleRunStateRequest(
+      "GET",
+      "/api/run-state",
+      deps({
+        loadRunStateModule: async () => {
+          throw new Error("sqlite locked");
+        },
+      }),
+    );
+    expect(handled).toEqual({ status: 500, body: JSON.stringify({ error: "sqlite locked" }) });
+  });
+});

--- a/apps/gittensory-miner-ui/vite-run-state-api.ts
+++ b/apps/gittensory-miner-ui/vite-run-state-api.ts
@@ -1,0 +1,81 @@
+import { existsSync } from "node:fs";
+import type { Plugin } from "vite";
+
+// Local read-only run-state API (#4305). The dashboard is a browser app while the miner's stores are
+// `node:sqlite` files on disk, so the dev server bridges the two: GET /api/run-state returns the
+// `miner_run_state` rows by calling into `packages/gittensory-miner/lib/run-state.js`'s EXISTING exports
+// (`resolveRunStateDbPath`/`listRunStates`) — no SQL duplicated in the UI layer, and strictly read-only.
+//
+// Empty-state subtlety: `listRunStates()` lazily INITIALIZES the default store, which would CREATE the SQLite
+// file on a fresh install — a write, which a read-only dashboard must not perform. So the handler checks the
+// resolved DB path for existence FIRST and serves `[]` without ever touching the store when no DB exists yet.
+
+type RunStateModule = {
+  resolveRunStateDbPath: () => string;
+  listRunStates: () => Array<{ repoFullName: string; state: string; updatedAt: string }>;
+};
+
+export type RunStateApiDeps = {
+  /** Import of `packages/gittensory-miner/lib/run-state.js` — injectable so tests never touch a real store. */
+  loadRunStateModule: () => Promise<RunStateModule>;
+  /** File-existence probe for the fresh-install fast path. */
+  fileExists: (path: string) => boolean;
+};
+
+const defaultDeps: RunStateApiDeps = {
+  loadRunStateModule: () => import("../../packages/gittensory-miner/lib/run-state.js") as Promise<RunStateModule>,
+  fileExists: existsSync,
+};
+
+/** The request handler, factored out of the Vite plugin shape so tests drive it directly. Returns the JSON
+ *  body + status for a GET, or null when the request is not for this endpoint (caller falls through). */
+export async function handleRunStateRequest(
+  method: string | undefined,
+  url: string | undefined,
+  deps: RunStateApiDeps = defaultDeps,
+): Promise<{ status: number; body: string } | null> {
+  if (url !== "/api/run-state" || (method !== undefined && method !== "GET")) return null;
+  try {
+    const runState = await deps.loadRunStateModule();
+    // Fresh install: no DB file yet. Serve the empty list WITHOUT initializing the store (that would create
+    // the file — a write this read-only endpoint must never perform).
+    if (!deps.fileExists(runState.resolveRunStateDbPath())) {
+      return { status: 200, body: JSON.stringify({ rows: [] }) };
+    }
+    return { status: 200, body: JSON.stringify({ rows: runState.listRunStates() }) };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "failed to read local run state";
+    return { status: 500, body: JSON.stringify({ error: message }) };
+  }
+}
+
+/** Vite dev/preview middleware serving the local read-only run-state endpoint. */
+export function runStateApiPlugin(deps: RunStateApiDeps = defaultDeps): Plugin {
+  const attach = (middlewares: {
+    use: (
+      fn: (
+        req: { method?: string; url?: string },
+        res: { statusCode: number; setHeader: (k: string, v: string) => void; end: (body: string) => void },
+        next: () => void,
+      ) => void,
+    ) => void;
+  }) => {
+    middlewares.use((req, res, next) => {
+      void handleRunStateRequest(req.method, req.url, deps).then((handled) => {
+        if (!handled) return next();
+        res.statusCode = handled.status;
+        res.setHeader("Content-Type", "application/json");
+        res.end(handled.body);
+      });
+    });
+  };
+  return {
+    name: "gittensory-miner-ui:run-state-api",
+    configureServer(server) {
+      attach(server.middlewares);
+    },
+    configurePreviewServer(server) {
+      attach(server.middlewares);
+    },
+  };
+}

--- a/apps/gittensory-miner-ui/vite.config.ts
+++ b/apps/gittensory-miner-ui/vite.config.ts
@@ -4,8 +4,16 @@ import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 
+import { runStateApiPlugin } from "./vite-run-state-api";
+
 export default defineConfig({
-  plugins: [TanStackRouterVite({ target: "react", autoCodeSplitting: true }), react(), tailwindcss(), tsconfigPaths()],
+  plugins: [
+    TanStackRouterVite({ target: "react", autoCodeSplitting: true }),
+    react(),
+    tailwindcss(),
+    tsconfigPaths(),
+    runStateApiPlugin(),
+  ],
   server: {
     // Offset from gittensory-ui (5173) so both apps can run side-by-side locally.
     port: 5174,


### PR DESCRIPTION
Closes #4305

## What

A read-only run-history table view in `apps/gittensory-miner-ui/` — one row per repo from the local `miner_run_state` store (repository, state badge, last-updated) — plus the minimal local data-access layer the issue calls for so the browser app can read a `node:sqlite` file on disk.

## Design, per the issue's guidance

- **Data-access layer = a Vite dev/preview middleware** (the issue's suggested shape): `vite-run-state-api.ts` serves `GET /api/run-state` by calling into `packages/gittensory-miner/lib/run-state.js`'s EXISTING exports (`resolveRunStateDbPath`/`listRunStates`) — no SQL duplicated in the UI layer, wired into both `configureServer` and `configurePreviewServer`.
- **Strictly read-only, including the fresh-install path:** `listRunStates()` lazily initializes the default store, which would CREATE the SQLite file on a fresh install — a write a read-only dashboard must not perform. The handler therefore checks the resolved DB path for existence first and serves `{ rows: [] }` without ever touching the store when no DB exists yet (asserted in tests: no `listRunStates` call happens on that path).
- **The view** (`src/routes/run-history.tsx`, mounted in the shell's nav) renders four states: loading, error (API unreachable/500 — an inline alert, never a crash), the fresh-install empty state, and the populated table. The fetch client (`src/lib/run-history.ts`) validates the payload shape field-by-field before it reaches the view.
- `routeTree.gen.ts` regenerated and committed via the router plugin (same as the scaffold).

## Testing

14 cases across two suites: component tests for all four view states against fixture run-state rows plus the page-level injected-loader flow, fetch-client tests (happy path, non-2xx, three malformed-payload shapes, thrown fetch), and middleware-handler tests (rows served through the existing exports, the no-write fresh-install path, non-GET/other-path fall-through, store-failure → 500). Workspace `test`/`typecheck`/`lint`/`build` all green locally; the diff is confined to `apps/gittensory-miner-ui/**`.