### PR TITLE
fix(review): stub the live-PR verification fetch in the checkbox commit-delivery test

### DIFF
--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -26960,6 +26960,9 @@ describe("queue processors", () => {
         if (url === "https://api.gittensor.io/miners") return Response.json([]);
         if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
         if (url.includes("/collaborators/maintainer/permission")) return Response.json({ permission: "admin" });
+        // #4359: commitE2eTestToPrBranch re-fetches the live PR to verify the head branch/commit hasn't
+        // moved since this pass cached it, before ever writing -- must match seedCheckboxPr's own head.
+        if (url.endsWith("/pulls/6011") && method === "GET") return Response.json({ head: { ref: "feature/checkout-retry", sha: "checkbox-4589-commit-sha", repo: { full_name: repoFullName } } });
         if (url.includes("/git/commits/checkbox-4589-commit-sha") && method === "GET") return Response.json({ tree: { sha: "base-tree" } });
         if (url.includes("/git/trees") && method === "POST") {
           gitWrites.push("tree");


### PR DESCRIPTION
## Summary
- Main is currently red: `test/unit/queue.test.ts`'s "PR-panel generate-tests checkbox (#4589) > respects the repo's configured commit delivery mode via the checkbox" fails on a clean `origin/main` checkout, and was already failing at #4600's own merge commit (`4d4635709` — `validate`/`validate-code` both show `conclusion: failure` on that commit).
- Root cause: #4359 (merged the same day) added a live-PR head/ref/sha re-verification fetch inside `commitE2eTestToPrBranch` (`src/github/e2e-test-commit.ts`) before it ever writes a commit, and updated every existing commit-delivery test's fetch stub to handle the new `GET /pulls/{n}` call. #4600 added this NEW checkbox-specific commit-delivery test without that stub (developed in parallel, unaware of #4359), so its fetch mock 404s on the live-PR check and `commitE2eTestToPrBranch` correctly (fail-safe) declines — zero git-write calls, `gitWrites` stays `[]`.
- Not a production bug — the actual commit-delivery code path is correct. This is a test-only gap. Adds the exact same `GET /pulls/6011` stub the sibling passing tests (`commit delivery mode (#4197, #4201)` describe block) already use.

## Test plan
- [x] `npm run typecheck`
- [x] `npx vitest run test/unit/queue.test.ts -t "respects the repo's configured commit delivery mode via the checkbox"` — now passes
- [x] `npx vitest run test/unit/queue.test.ts` — full file, 783/783 passing