### PR TITLE
test(api): read the expected MCP version dynamically instead of hardcoding it

### DIFF
--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import mcpPackageJson from "../../packages/gittensory-mcp/package.json";
 import { createSessionForGitHubUser, hashToken } from "../../src/auth/security";
 import {
   upsertBounty,
@@ -97,7 +98,7 @@ describe("api routes", () => {
       status: "ok",
       service: "gittensory-api",
       minMcpVersion: "0.5.0",
-      latestRecommendedMcpVersion: "0.7.0",
+      latestRecommendedMcpVersion: mcpPackageJson.version,
     });
 
     const compatibility = await app.request("/v1/mcp/compatibility", {}, env);
@@ -110,8 +111,8 @@ describe("api routes", () => {
       mcp: {
         packageName: "@jsonbored/gittensory-mcp",
         minimumSupportedVersion: "0.5.0",
-        latestRecommendedVersion: "0.7.0",
-        latestPackageVersion: "0.7.0",
+        latestRecommendedVersion: mcpPackageJson.version,
+        latestPackageVersion: mcpPackageJson.version,
       },
       compatibilityWarnings: [],
       breakingChanges: [],
@@ -3964,7 +3965,7 @@ describe("api routes", () => {
     expect(mcpCompatibilityBody).toMatchObject({
       adoption: expect.objectContaining({
         minimumSupportedVersion: "0.5.0",
-        latestRecommendedVersion: "0.7.0",
+        latestRecommendedVersion: mcpPackageJson.version,
         staleEvents: 1,
         incompatibleEvents: 3,
         totalEvents: 4,
@@ -5855,7 +5856,7 @@ describe("api routes", () => {
             protocolVersion: "2025-03-26",
             compatibilityStatus: "incompatible",
             minimumSupportedVersion: "0.5.0",
-            latestRecommendedVersion: "0.7.0",
+            latestRecommendedVersion: mcpPackageJson.version,
           }),
         }),
       ]),


### PR DESCRIPTION
## Summary
- `test/integration/api.test.ts` hardcoded `"0.7.0"` in 5 places asserting `latestRecommendedMcpVersion`/`latestRecommendedVersion`/`latestPackageVersion`, but `src/services/mcp-compatibility.ts`'s `LATEST_RECOMMENDED_MCP_VERSION` derives live from `packages/gittensory-mcp/package.json`'s `version` field.
- Confirmed this breaks on every release: #4204 (release-please's own automated 0.7.0→0.7.1 bump PR) fails `validate-code` on exactly these assertions.
- Fix: import `mcpPackageJson` and reference `mcpPackageJson.version`, mirroring the pattern `test/unit/mcp-cli-doctor.test.ts:178` already uses for the same field.

## Test plan
- [x] `npm run typecheck`
- [x] `npx vitest run test/integration/api.test.ts` — 43/43 passing