### PR TITLE
fix(signals): reuse shared linked-issue-required predicate in AI signal bundle

### DIFF
--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -5175,12 +5175,9 @@ export function buildPublicCommentSignalBundle(args: {
     issues: [],
     profile: args.profile,
   });
-  const publicFindingTitles = args.preflight.findings
-    .filter((finding) => finding.severity !== "critical")
-    .filter((finding) => args.settings.requireLinkedIssue || finding.code !== "missing_linked_issue")
-    .filter((finding) => !containsPrivatePublicTerm([finding.code, finding.title].filter(Boolean).join(" ")))
-    .slice(0, args.settings.publicSignalLevel === "minimal" ? 2 : 5)
-    .map((finding) => finding.title);
+  // Reuse the single-source filter (severity, linked-issue-gate, bounty-lifecycle, private-term, slice)
+  // instead of re-deriving it here -- a third independent copy is exactly how this drifted before (#4606).
+  const publicFindingTitles = publicSafePreflightFindings(args.preflight, args.settings).map((finding) => finding.title);
   return {
     confirmedMiner,
     minerSignalDetected: confirmedMiner,

--- a/test/unit/signals.test.ts
+++ b/test/unit/signals.test.ts
@@ -697,6 +697,78 @@ describe("world-class backend signals", () => {
     expect(typeof minimalBundle.role).toBe("string");
   });
 
+  it("regression (#4606): buildPublicCommentSignalBundle agrees with the public panel on linkedIssueGateMode alone", () => {
+    // A repo that opts into the linked-issue gate purely via `.gittensory.yml` (linkedIssueGateMode !== "off")
+    // and never touches the legacy `requireLinkedIssue` boolean must still surface `missing_linked_issue` in
+    // the AI-rewrite signal bundle -- previously the bundle checked `requireLinkedIssue` alone and silently
+    // dropped the finding in exactly this configuration.
+    const currentPr: PullRequestRecord = {
+      ...pullRequests[0]!,
+      linkedIssues: [],
+      title: "Improve dashboard cache refresh handling",
+      body: "Rewrites the refresh path to avoid a stale cache after reconnect.",
+    };
+    const detection = detectGittensorContributor("oktofeesh1", currentPr, [currentPr], []);
+    const settings: RepositorySettings = {
+      repoFullName: repo.fullName,
+      commentMode: "detected_contributors_only",
+      publicAudienceMode: "gittensor_only",
+      publicSignalLevel: "standard",
+      checkRunMode: "off",
+      checkRunDetailLevel: "minimal",
+      gateCheckMode: "off",
+      regateSweepOrderMode: "staleness",
+      reviewCheckMode: "disabled",
+      gatePack: "gittensor",
+      linkedIssueGateMode: "block",
+      duplicatePrGateMode: "advisory",
+      qualityGateMode: "advisory",
+      slopGateMode: "off",
+      mergeReadinessGateMode: "off",
+      manifestPolicyGateMode: "off",
+      selfAuthoredLinkedIssueGateMode: "advisory",
+      linkedIssueSatisfactionGateMode: "off",
+      firstTimeContributorGrace: false,
+      slopAiAdvisory: false,
+      qualityGateMinScore: null,
+      autoLabelEnabled: true,
+      gittensorLabel: "gittensor",
+      createMissingLabel: true,
+      publicSurface: "comment_and_label",
+      includeMaintainerAuthors: false,
+      requireLinkedIssue: false,
+      backfillEnabled: true,
+      aiReviewMode: "off" as const,
+      aiReviewByok: false,
+      aiReviewAllAuthors: false,
+      closeOwnerAuthors: false,
+    };
+    const collisions = buildCollisionReport(repo.fullName, issues, [currentPr]);
+    const queueHealth = buildQueueHealth(repo, issues, [currentPr], collisions);
+    const preflight = buildPreflightResult({ repoFullName: repo.fullName, title: currentPr.title, body: currentPr.body ?? undefined, linkedIssues: [] }, repo, issues, [currentPr]);
+    const profile = buildContributorProfile("oktofeesh1", { login: "oktofeesh1", topLanguages: ["TypeScript"], source: "github" }, [currentPr], []);
+    // Sanity: the scenario actually produces the finding this test is about (no accidental no-issue rationale match).
+    expect(preflight.findings.some((finding) => finding.code === "missing_linked_issue")).toBe(true);
+
+    const blockedBundle = buildPublicCommentSignalBundle({ repo, pr: currentPr, profile, detection, queueHealth, collisions, preflight, settings });
+    expect(blockedBundle.requireLinkedIssue).toBe(false);
+    expect(blockedBundle.publicFindingTitles as string[]).toContain("No linked issue detected");
+
+    // The other side of the same `||`: when the gate is fully off AND requireLinkedIssue is false, the
+    // finding is correctly dropped from the bundle -- this was already correct before the fix.
+    const gateOffBundle = buildPublicCommentSignalBundle({
+      repo,
+      pr: currentPr,
+      profile,
+      detection,
+      queueHealth,
+      collisions,
+      preflight,
+      settings: { ...settings, linkedIssueGateMode: "off" },
+    });
+    expect(gateOffBundle.publicFindingTitles as string[]).not.toContain("No linked issue detected");
+  });
+
   it("classifies every participation lane boundary", () => {
     const inactive = buildLaneAdvice({ ...repo, registryConfig: { ...repo.registryConfig!, emissionShare: 0 } }, repo.fullName);
     const issueDiscovery = buildLaneAdvice({ ...repo, registryConfig: { ...repo.registryConfig!, issueDiscoveryShare: 1 } }, repo.fullName);


### PR DESCRIPTION
## Summary

- `buildPublicCommentSignalBundle` re-derived the "is a linked issue effectively required" condition
  independently of `publicSafePreflightFindings`, checking only `settings.requireLinkedIssue` and
  omitting the `settings.linkedIssueGateMode !== "off"` half that the doc comment on the shared
  filter says both call sites must agree on.
- A repo that opts into the gate purely via `.gittensory.yml`'s `linkedIssueGateMode: "block"` (the
  modern config-as-code path, never touching the legacy DB-backed `requireLinkedIssue` boolean) got
  correct behavior in the main preflight/comment surface, but the AI-rewrite signal bundle silently
  dropped the `missing_linked_issue` finding from the context handed to the optional AI-rewrite layer.
- Fix: `buildPublicCommentSignalBundle` now calls `publicSafePreflightFindings` directly and maps the
  result to titles, instead of re-deriving the filter chain a third time. This also picks up the
  bounty-lifecycle filter and the broader private-term check (detail/publicText/action, not just
  code/title) that the shared function already applies — strictly more conservative than before, never
  less.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` (no workflow files touched)
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally (scoped to `test/unit/signals.test.ts` + `test/unit/signals-coverage.test.ts` with coverage restricted to `src/signals/engine.ts`); the new line (`publicFindingTitles = publicSafePreflightFindings(...)`) is exercised by both the pre-existing bundle tests and the new regression test — no new branches are introduced at the call site itself, the branches live inside the already-covered shared predicate.
- [ ] `npm run test:workers` (no worker-pool code touched)
- [x] `npm run build:mcp` (ran as part of confirming a fresh worktree needed the workspace packages built before other test files would resolve; unaffected by this change)
- [ ] `npm run test:mcp-pack` (no MCP package changes)
- [x] `npm run ui:openapi:check`
- [ ] `npm run ui:lint` (no UI files touched)
- [ ] `npm run ui:typecheck` (no UI files touched)
- [ ] `npm run ui:build` (no UI files touched)
- [ ] `npm audit --audit-level=moderate` (no dependency changes)
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — added a regression test (`test/unit/signals.test.ts`) covering both sides of the fixed condition: `linkedIssueGateMode: "block"` with `requireLinkedIssue: false` (previously dropped, now correctly surfaced) and `linkedIssueGateMode: "off"` with `requireLinkedIssue: false` (correctly still dropped).

If any required check was skipped, explain why:

- This is a two-line backend logic change confined to `src/signals/engine.ts`; the skipped checks (actionlint, workers, MCP pack, UI lint/typecheck/build, dependency audit) have no surface this diff touches. `npm run db:migrations:check` and `npm run db:schema-drift:check` were also run locally and pass (no DB/schema change). Full CI (`test:ci`) will run the complete gate on push.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session surface touched.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP surface touched; `ui:openapi:check` and `ui:openapi:settings-parity` both pass unchanged.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes.)
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots... (N/A — no visible UI change; backend-only fix.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (N/A — no doc-facing behavior change; `docs:drift-check` unaffected.)

## UI Evidence

N/A — backend-only fix, no visible UI surface.

## Notes

- Part of the review-stack architecture audit (config-sprawl dimension, parent epic).
- Scope intentionally limited to the one divergent condition called out in #4606; did not also
  refactor `publicSafeNextSteps`'s separate `containsPrivatePublicTerm` usage, which is unrelated to
  the linked-issue-gate condition this issue is about.
