### PR TITLE
feat(miner-governor): add self-reputation throttle from own outcome history (#2346)

### DIFF
--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -211,6 +211,7 @@ export {
   type WorktreeRemoveResult,
 } from "./miner/worktree-allocator.js";
 export * from "./miner/worktree-pool.js";
+export * from "./miner/self-reputation-throttle.js";
 export {
   invokeCodingAgentDriver,
   type AttemptLogSink,

--- a/packages/gittensory-engine/src/miner/self-reputation-throttle.ts
+++ b/packages/gittensory-engine/src/miner/self-reputation-throttle.ts
@@ -1,0 +1,107 @@
+// Self-reputation throttle (#2346): pure. Given the miner's OWN recent PR outcomes on ONE repo, compute a
+// cadence multiplier (1.0 = normal, → floor when the miner's own close/reject ratio is bad) — a self-correcting
+// slowdown distinct from the fixed global/per-repo rate limit and driven by the miner's own local merge/close
+// history (never shared/cross-fleet data). NOT a permanent ban: an improving ratio recovers cadence next call.
+// FAILS OPEN on insufficient sample — a new miner or a new repo is never falsely throttled.
+//
+// No IO. The Governor chokepoint consults this before an open_pr/file_issue action and records the returned
+// verdict (with the triggering ratio) to the append-only governor ledger — that consultation + ledger write is
+// separate, maintainer-owned enforcement wiring. Shape stays consistent with the outcome-history-driven risk
+// vocabulary in src/signals/reward-risk.ts, adapted to the miner's own local-only counts.
+
+/** The miner's own terminal PR outcomes on one repo over the recent window. */
+export type OwnRepoOutcomes = {
+  /** PRs merged. */
+  merged: number;
+  /** PRs closed WITHOUT a merge (rejected). */
+  closed: number;
+};
+
+export type SelfReputationThresholds = {
+  /** Minimum terminal outcomes before the throttle engages at all; below this it fails open (full cadence). */
+  minSample: number;
+  /** Close ratio at or below which cadence stays full (1.0). */
+  healthyCloseRatio: number;
+  /** Close ratio at or above which cadence hits its floor. */
+  criticalCloseRatio: number;
+  /** The lowest cadence multiplier the throttle drops to — never 0 (a permanent ban is out of scope). */
+  minCadenceMultiplier: number;
+};
+
+/** Conservative built-in defaults (a `.gittensory-miner.yml` may override). */
+export const DEFAULT_SELF_REPUTATION_THRESHOLDS: SelfReputationThresholds = {
+  minSample: 4,
+  healthyCloseRatio: 0.2,
+  criticalCloseRatio: 0.6,
+  minCadenceMultiplier: 0.1,
+};
+
+export type SelfReputationThrottleReason =
+  | "insufficient_sample"
+  | "healthy"
+  | "degrading"
+  | "critical";
+
+export type SelfReputationThrottleVerdict = {
+  /** 1.0 = normal cadence; < 1 = throttled; never below the configured floor, never 0. */
+  cadenceMultiplier: number;
+  /** closed / (merged + closed) over the window; null when the sample is insufficient. */
+  closeRatio: number | null;
+  /** merged + closed. */
+  sample: number;
+  reason: SelfReputationThrottleReason;
+};
+
+function nonNegativeInt(value: number, label: string): number {
+  if (!Number.isFinite(value) || value < 0) throw new Error(`invalid ${label}: expected a finite count >= 0`);
+  return value;
+}
+
+function ratio01(value: number, label: string): number {
+  if (!Number.isFinite(value) || value < 0 || value > 1) throw new Error(`invalid ${label}: expected 0..1`);
+  return value;
+}
+
+function round(value: number): number {
+  return Math.round(value * 1000) / 1000;
+}
+
+/**
+ * Compute the self-reputation cadence multiplier from the miner's own recent outcomes on a repo. Pure and
+ * deterministic. Validates inputs (rejects negative / non-finite counts and out-of-range thresholds) rather
+ * than silently coercing them.
+ *
+ * - `sample < minSample` ⇒ `1.0` (fail open — insufficient evidence to throttle).
+ * - `closeRatio <= healthyCloseRatio` ⇒ `1.0`.
+ * - `closeRatio >= criticalCloseRatio` ⇒ `minCadenceMultiplier` (the floor).
+ * - Between the two ⇒ linear interpolation from `1.0` down to the floor.
+ */
+export function selfReputationThrottle(
+  outcomes: OwnRepoOutcomes,
+  thresholds: SelfReputationThresholds = DEFAULT_SELF_REPUTATION_THRESHOLDS,
+): SelfReputationThrottleVerdict {
+  const merged = nonNegativeInt(outcomes.merged, "outcomes.merged");
+  const closed = nonNegativeInt(outcomes.closed, "outcomes.closed");
+  const minSample = nonNegativeInt(thresholds.minSample, "thresholds.minSample");
+  const healthy = ratio01(thresholds.healthyCloseRatio, "thresholds.healthyCloseRatio");
+  const critical = ratio01(thresholds.criticalCloseRatio, "thresholds.criticalCloseRatio");
+  const floor = ratio01(thresholds.minCadenceMultiplier, "thresholds.minCadenceMultiplier");
+  if (critical <= healthy) throw new Error("invalid thresholds: criticalCloseRatio must exceed healthyCloseRatio");
+
+  const sample = merged + closed;
+  if (sample < minSample) {
+    return { cadenceMultiplier: 1, closeRatio: null, sample, reason: "insufficient_sample" };
+  }
+
+  const closeRatio = round(closed / sample);
+  if (closeRatio <= healthy) {
+    return { cadenceMultiplier: 1, closeRatio, sample, reason: "healthy" };
+  }
+  if (closeRatio >= critical) {
+    return { cadenceMultiplier: floor, closeRatio, sample, reason: "critical" };
+  }
+  // Linear interpolation: healthy ⇒ 1.0, critical ⇒ floor.
+  const fraction = (closeRatio - healthy) / (critical - healthy);
+  const cadenceMultiplier = round(1 - fraction * (1 - floor));
+  return { cadenceMultiplier, closeRatio, sample, reason: "degrading" };
+}

--- a/test/unit/miner-self-reputation-throttle.test.ts
+++ b/test/unit/miner-self-reputation-throttle.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import {
+  selfReputationThrottle,
+  DEFAULT_SELF_REPUTATION_THRESHOLDS,
+} from "../../packages/gittensory-engine/src/index";
+
+const FLOOR = DEFAULT_SELF_REPUTATION_THRESHOLDS.minCadenceMultiplier;
+
+describe("self-reputation throttle (#2346)", () => {
+  it("fails open on insufficient sample — a new miner / new repo is never throttled", () => {
+    const v = selfReputationThrottle({ merged: 1, closed: 2 }); // sample 3 < minSample 4
+    expect(v.cadenceMultiplier).toBe(1);
+    expect(v.closeRatio).toBeNull();
+    expect(v.reason).toBe("insufficient_sample");
+  });
+
+  it("allows full cadence on a clean / healthy track record", () => {
+    const v = selfReputationThrottle({ merged: 9, closed: 1 }); // ratio 0.1 <= healthy 0.2
+    expect(v.cadenceMultiplier).toBe(1);
+    expect(v.reason).toBe("healthy");
+    expect(v.closeRatio).toBe(0.1);
+  });
+
+  it("throttles to the floor at or above the critical close ratio", () => {
+    const v = selfReputationThrottle({ merged: 2, closed: 8 }); // ratio 0.8 >= critical 0.6
+    expect(v.cadenceMultiplier).toBe(FLOOR);
+    expect(v.reason).toBe("critical");
+  });
+
+  it("degrades cadence linearly between the healthy and critical ratios", () => {
+    const v = selfReputationThrottle({ merged: 6, closed: 4 }); // ratio 0.4, midway 0.2..0.6
+    expect(v.reason).toBe("degrading");
+    expect(v.closeRatio).toBe(0.4);
+    expect(v.cadenceMultiplier).toBe(0.55); // 1 - 0.5*(1-0.1)
+  });
+
+  it("recovers cadence as the close ratio improves (monotonic)", () => {
+    const worst = selfReputationThrottle({ merged: 4, closed: 6 }); // 0.6 ⇒ floor
+    const better = selfReputationThrottle({ merged: 7, closed: 3 }); // 0.3 ⇒ degrading
+    const best = selfReputationThrottle({ merged: 9, closed: 1 }); // 0.1 ⇒ full
+    expect(better.cadenceMultiplier).toBeGreaterThan(worst.cadenceMultiplier);
+    expect(best.cadenceMultiplier).toBeGreaterThan(better.cadenceMultiplier);
+  });
+
+  it("honors custom thresholds", () => {
+    const v = selfReputationThrottle(
+      { merged: 8, closed: 2 }, // ratio 0.2, between custom 0.1..0.3
+      { minSample: 2, healthyCloseRatio: 0.1, criticalCloseRatio: 0.3, minCadenceMultiplier: 0.2 },
+    );
+    expect(v.reason).toBe("degrading");
+  });
+
+  it("rejects malformed inputs instead of silently coercing them", () => {
+    expect(() => selfReputationThrottle({ merged: -1, closed: 2 })).toThrow(/outcomes\.merged/);
+    expect(() => selfReputationThrottle({ merged: Number.NaN, closed: 2 })).toThrow(/outcomes\.merged/);
+    expect(() =>
+      selfReputationThrottle({ merged: 5, closed: 5 }, { ...DEFAULT_SELF_REPUTATION_THRESHOLDS, healthyCloseRatio: 0.6, criticalCloseRatio: 0.2 }),
+    ).toThrow(/must exceed/);
+    expect(() =>
+      selfReputationThrottle({ merged: 5, closed: 5 }, { ...DEFAULT_SELF_REPUTATION_THRESHOLDS, minCadenceMultiplier: 1.5 }),
+    ).toThrow(/minCadenceMultiplier/);
+  });
+});


### PR DESCRIPTION
Adds the self-reputation throttle (Closes #2346) — a self-correcting slowdown driven by the miner's OWN local merge/close history, distinct from the fixed rate limit.

New `packages/gittensory-engine/src/miner/self-reputation-throttle.ts`:
- **`selfReputationThrottle(outcomes, thresholds?)`** → a cadence multiplier from the miner's own `{merged, closed}` on one repo:
  - `sample < minSample` ⇒ **1.0 (fails open)** — a new miner / new repo is never falsely throttled (documented).
  - `closeRatio <= healthyCloseRatio` ⇒ 1.0; `>= criticalCloseRatio` ⇒ the floor; **linear interpolation** between.
  - **Not a permanent ban** — an improving ratio recovers cadence on the next call.
- Conservative built-in `DEFAULT_SELF_REPUTATION_THRESHOLDS`, fully configurable (a `.gittensory-miner.yml` overrides).
- **Validates inputs** (rejects negative / non-finite counts and inverted/out-of-range thresholds) rather than silently coercing — matching the discipline just added to the attempt-metering module.

Pure, no IO, local-only. The Governor chokepoint consults this before an `open_pr`/`file_issue` action and records the verdict + triggering ratio to the ledger — that consultation + ledger write is separate, maintainer-owned enforcement wiring.

## Test
`test/unit/miner-self-reputation-throttle.test.ts` — insufficient-sample fail-open, healthy full cadence, critical floor, linear degradation (exact midpoint), monotonic recovery as the ratio improves, custom thresholds, and input-validation rejections. 7 tests pass (engine src imported via vitest, mirroring the worktree-allocator test).

- [x] Conventional Commit; focused; **Closes #2346**. No `site/`/`CNAME`/`**/lovable/**`; no `CHANGELOG.md`. New engine module + test + one entrypoint export; no secrets.