### PR TITLE
feat(miner-governor): add global + per-repo kill-switch resolver (#2341)

### DIFF
--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -137,6 +137,7 @@ export {
 } from "./track-record-summary.js";
 export * from "./governor/rate-limit.js";
 export * from "./governor/budget-cap.js";
+export * from "./miner/kill-switch.js";
 export {
   GOVERNOR_LEDGER_EVENT_TYPES,
   normalizeGovernorLedgerEvent,

--- a/packages/gittensory-engine/src/miner/kill-switch.ts
+++ b/packages/gittensory-engine/src/miner/kill-switch.ts
@@ -1,0 +1,59 @@
+// Miner kill-switch (#2341): pure resolution of the global + per-repo halt state the Governor chokepoint
+// consults FIRST — before any other calculator — to decide whether the miner may perform an autonomous write
+// (open_pr / file_issue / comment) on a repo. Mirrors the review-stack's global kill-switch
+// (AGENT_ACTIONS_PAUSED, src/settings/agent-execution.ts) for the miner's own local runtime, plus a per-repo
+// variant so one misbehaving target can be paused without stopping the whole fleet.
+//
+// No IO: the global flag is read from GITTENSORY_MINER_KILL_SWITCH and the per-repo set from each repo's
+// .gittensory-miner.yml by the caller, which passes them in here; recording a trip to the governor ledger is
+// likewise the caller's (separate, maintainer-owned enforcement wiring). This module only DECIDES.
+
+export type KillSwitchState = {
+  /** Global halt — when true, ALL miner write activity is denied regardless of per-repo state. */
+  global: boolean;
+  /** Repos individually halted (each from its own `.gittensory-miner.yml`). */
+  haltedRepos: readonly string[];
+};
+
+export type KillSwitchScope = "global" | "repo";
+
+export type KillSwitchVerdict = {
+  /** True when a write to this repo is currently halted. */
+  halted: boolean;
+  /** Which switch halted it, or null when nothing is engaged. */
+  scope: KillSwitchScope | null;
+  reason: string;
+};
+
+/** Parse the global kill-switch env value. Truthy follows the codebase convention (`/^(1|true|yes|on)$/i`,
+ *  same as isOpsEnabled / isSafetyEnabled). Pure. */
+export function isGlobalKillSwitchEnabled(value: string | undefined): boolean {
+  return /^(1|true|yes|on)$/i.test((value ?? "").trim());
+}
+
+/** Normalize a GitHub `owner/repo` for comparison — trimmed + lower-cased (GitHub repo names are
+ *  case-insensitive), so a config casing mismatch never lets a halted repo slip through. Pure. */
+function normalizeRepoFullName(repoFullName: string): string {
+  return repoFullName.trim().toLowerCase();
+}
+
+/**
+ * Resolve whether a write to `repoFullName` is halted. The GLOBAL switch is checked first and denies
+ * regardless of per-repo state; otherwise a per-repo switch denies only its own repo (case-insensitive match).
+ * Pure and deterministic.
+ */
+export function resolveKillSwitch(state: KillSwitchState, repoFullName: string): KillSwitchVerdict {
+  if (state.global) {
+    return { halted: true, scope: "global", reason: "global kill-switch engaged — all miner write activity halted" };
+  }
+  const target = normalizeRepoFullName(repoFullName);
+  if (state.haltedRepos.some((repo) => normalizeRepoFullName(repo) === target)) {
+    return { halted: true, scope: "repo", reason: `per-repo kill-switch engaged for ${repoFullName}` };
+  }
+  return { halted: false, scope: null, reason: "no kill-switch engaged" };
+}
+
+/** Convenience predicate: may the miner write to this repo? Pure. */
+export function isMinerWriteAllowed(state: KillSwitchState, repoFullName: string): boolean {
+  return !resolveKillSwitch(state, repoFullName).halted;
+}

--- a/test/unit/miner-kill-switch.test.ts
+++ b/test/unit/miner-kill-switch.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+import {
+  resolveKillSwitch,
+  isMinerWriteAllowed,
+  isGlobalKillSwitchEnabled,
+} from "../../packages/gittensory-engine/src/index";
+
+const REPO = "acme/widgets";
+
+describe("miner kill-switch (#2341)", () => {
+  it("global switch halts every repo regardless of per-repo state", () => {
+    const v = resolveKillSwitch({ global: true, haltedRepos: [] }, REPO);
+    expect(v.halted).toBe(true);
+    expect(v.scope).toBe("global");
+    expect(isMinerWriteAllowed({ global: true, haltedRepos: [] }, "other/repo")).toBe(false);
+  });
+
+  it("per-repo switch halts only its own repo, leaving others running", () => {
+    const state = { global: false, haltedRepos: [REPO] };
+    const halted = resolveKillSwitch(state, REPO);
+    expect(halted.halted).toBe(true);
+    expect(halted.scope).toBe("repo");
+    expect(halted.reason).toContain(REPO);
+    expect(isMinerWriteAllowed(state, "other/repo")).toBe(true); // untouched
+  });
+
+  it("allows writes when nothing is engaged (switch off resumes normal operation)", () => {
+    const v = resolveKillSwitch({ global: false, haltedRepos: [] }, REPO);
+    expect(v.halted).toBe(false);
+    expect(v.scope).toBeNull();
+    expect(isMinerWriteAllowed({ global: false, haltedRepos: [] }, REPO)).toBe(true);
+  });
+
+  it("matches per-repo halts case-insensitively (a casing mismatch cannot slip through)", () => {
+    expect(isMinerWriteAllowed({ global: false, haltedRepos: ["Acme/Widgets"] }, "acme/widgets")).toBe(false);
+  });
+
+  it("parses the global kill-switch env value on the codebase truthy convention", () => {
+    for (const on of ["true", "1", "yes", "on", "TRUE", " on "]) {
+      expect(isGlobalKillSwitchEnabled(on)).toBe(true);
+    }
+    for (const off of ["false", "0", "no", "", undefined, "maybe"]) {
+      expect(isGlobalKillSwitchEnabled(off)).toBe(false);
+    }
+  });
+
+  it("global takes precedence over an also-halted repo (checked first)", () => {
+    const v = resolveKillSwitch({ global: true, haltedRepos: [REPO] }, REPO);
+    expect(v.scope).toBe("global");
+  });
+});


### PR DESCRIPTION
Adds the miner kill-switch resolver (Closes #2341) — the halt state the Governor consults FIRST, before any other calculator. Mirrors the review-stack's global `AGENT_ACTIONS_PAUSED` for the miner's own local runtime, plus a per-repo variant.

New `packages/gittensory-engine/src/miner/kill-switch.ts`:
- **`resolveKillSwitch(state, repoFullName)`** → `{halted, scope, reason}`. The **global** switch denies every repo regardless of per-repo state (checked first); otherwise a **per-repo** switch denies only its own repo (case-insensitive match, so a config casing mismatch can't slip through), leaving others running.
- **`isGlobalKillSwitchEnabled(value)`** — parses `GITTENSORY_MINER_KILL_SWITCH` on the codebase truthy convention (`/^(1|true|yes|on)$/i`).
- **`isMinerWriteAllowed`** convenience predicate.

Pure, no IO: the caller reads the env flag + each repo's `.gittensory-miner.yml` and records ledger trips — that's separate, maintainer-owned enforcement wiring. This module only decides.

## Test
`test/unit/miner-kill-switch.test.ts` — global-denies-all (incl. a repo not in the halted set), per-repo isolation (others untouched), off-state resumes, case-insensitive match, env-value parsing (truthy + falsy incl. undefined), and global-over-repo precedence. 6 tests pass (engine src via vitest).

- [x] Conventional Commit; focused; **Closes #2341**. No `site/`/`CNAME`/`**/lovable/**`; no `CHANGELOG.md`. New engine module + test + one entrypoint export; no secrets.