### PR TITLE
fix(engine): correct Cartfile.resolved regex and cover it with parity checks

### DIFF
--- a/packages/gittensory-engine/src/review/diff-file-priority.ts
+++ b/packages/gittensory-engine/src/review/diff-file-priority.ts
@@ -1,7 +1,7 @@
 import { isTestPath } from "../signals/test-evidence.js";
 
 export function diffFilePriority(path: string): number {
-  if (/(^|\/)(package-lock\.json|npm-shrinkwrap\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lock|bun\.lockb|cargo\.lock|poetry\.lock|pipfile\.lock|composer\.lock|gemfile\.lock|go\.sum|go\.work\.sum|uv\.lock|packages\.lock\.json|flake\.lock|deno\.lock|pubspec\.lock|podfile\.lock|mix\.lock|package\.resolved|gradle\.lockfile|pdm\.lock|conan\.lock|pixi\.lock|cartfile\.lock|gopkg\.lock|shard\.lock|rebar\.lock|renv\.lock|chart\.lock)$|\.(min\.(js|css)|map|snap)$/i.test(path)) return 4;
+  if (/(^|\/)(package-lock\.json|npm-shrinkwrap\.json|pnpm-lock\.yaml|yarn\.lock|bun\.lock|bun\.lockb|cargo\.lock|poetry\.lock|pipfile\.lock|composer\.lock|gemfile\.lock|go\.sum|go\.work\.sum|uv\.lock|packages\.lock\.json|flake\.lock|deno\.lock|pubspec\.lock|podfile\.lock|mix\.lock|package\.resolved|gradle\.lockfile|pdm\.lock|conan\.lock|pixi\.lock|cartfile\.resolved|gopkg\.lock|shard\.lock|rebar\.lock|renv\.lock|chart\.lock)$|\.(min\.(js|css)|map|snap)$/i.test(path)) return 4;
   if (/(^|\/)(dist|build|out|coverage|vendor|node_modules)\//i.test(path)) return 4;
   if (/\.(md|mdx|markdown|rst|adoc|asciidoc|txt)$/i.test(path)) return 2;
   if (isTestPath(path)) return 1;

--- a/packages/gittensory-engine/test/diff-file-priority.test.ts
+++ b/packages/gittensory-engine/test/diff-file-priority.test.ts
@@ -1,0 +1,32 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { diffFilePriority } from "../dist/review/diff-file-priority.js";
+import { predictedGateEngineInternals } from "../dist/signals/predicted-gate-engine.js";
+
+test("diffFilePriority: ranks lockfiles/generated output above test files above source", () => {
+  assert.equal(diffFilePriority("package-lock.json"), 4);
+  assert.equal(diffFilePriority("dist/bundle.js"), 4);
+  assert.equal(diffFilePriority("src/app.test.ts"), 1);
+  assert.equal(diffFilePriority("src/app.ts"), 0);
+});
+
+test("diffFilePriority: matches Cartfile.resolved, Carthage's real lockfile name (#4605 regression)", () => {
+  // Carthage's actual lockfile is `Cartfile.resolved` — there is no `Cartfile.lock`. This engine-package
+  // copy of diffFilePriority previously matched `cartfile\.lock` (a one-character-class typo), so a
+  // touched Cartfile.resolved was ranked as SOURCE(0) here while the host copies
+  // (src/review/review-diff.ts, src/review/review-grounding.ts) correctly ranked it lockfile(4) — silent
+  // host/engine behavioral drift for Carthage/iOS repos that no drift check covered.
+  assert.equal(diffFilePriority("Cartfile.resolved"), 4);
+  assert.equal(diffFilePriority("ios/Cartfile.resolved"), 4);
+  // `Cartfile.lock` is not a real Carthage filename — must NOT match.
+  assert.equal(diffFilePriority("Cartfile.lock"), 0);
+});
+
+test("predictedGateEngineInternals.sharesMeaningfulFile: a shared Cartfile.resolved is not meaningful collision evidence (#4605)", () => {
+  assert.equal(
+    predictedGateEngineInternals.sharesMeaningfulFile(["Cartfile.resolved"], ["Cartfile.resolved"]),
+    false,
+  );
+  assert.equal(predictedGateEngineInternals.sharesMeaningfulFile(["src/app.ts"], ["src/app.ts"]), true);
+});

--- a/scripts/check-engine-parity.ts
+++ b/scripts/check-engine-parity.ts
@@ -11,14 +11,26 @@ import { fileURLToPath } from "node:url";
 
 export const ENGINE_PARITY_AREAS = Object.freeze(["review", "settings", "signals"] as const);
 
+/** Shared shape for an explicitly named (non-directory-discovered) host/engine twin pair. The directory
+ *  scan below only pairs identical top-level filenames within src/{review,settings,signals}, so anything
+ *  nested one directory deeper, differently named, or duplicated by FUNCTION rather than by whole file is
+ *  invisible to it by construction — this is the escape hatch (#4518, generalized #4605). */
+export type NamedTwinPair = Readonly<{
+  area: string;
+  hostRelative: string;
+  engineRelative: string;
+  hostFileName: string;
+  engineFileName: string;
+}>;
+
 /** Hand-duplicated gate-decision twins live outside src/{review,settings,signals} (#4518). */
-export const GATE_DECISION_TWIN_PAIR = Object.freeze({
+export const GATE_DECISION_TWIN_PAIR: NamedTwinPair = Object.freeze({
   area: "gate-decision",
   hostRelative: "src/rules/advisory.ts",
   engineRelative: "packages/gittensory-engine/src/advisory/gate-advisory.ts",
   hostFileName: "advisory.ts",
   engineFileName: "gate-advisory.ts",
-} as const);
+});
 
 export const GATE_DECISION_CORE_MARKERS = Object.freeze([
   "function evaluateGateCheckCore",
@@ -26,6 +38,70 @@ export const GATE_DECISION_CORE_MARKERS = Object.freeze([
   "export function buildPullRequestAdvisory",
   "export function evaluateGateCheck",
 ] as const);
+
+/** `safe-url.ts` lives nested under src/review/content-lane/ on the host but flat under the engine's
+ *  review/ dir, so the directory scan's identical-top-level-filename match never sees it — currently
+ *  byte-identical, but that is luck, not enforcement (#4605 Finding 2). */
+export const SAFE_URL_TWIN_PAIR: NamedTwinPair = Object.freeze({
+  area: "content-lane",
+  hostRelative: "src/review/content-lane/safe-url.ts",
+  engineRelative: "packages/gittensory-engine/src/review/safe-url.ts",
+  hostFileName: "safe-url.ts",
+  engineFileName: "safe-url.ts",
+});
+
+export const SAFE_URL_MARKERS = Object.freeze([
+  "export function isSafeHttpUrl",
+  "export function isSafeEndpointUrl",
+] as const);
+
+/** `diffFilePriority` is duplicated by FUNCTION, not by file: two byte-identical host copies
+ *  (review-diff.ts, review-grounding.ts) and a differently-named engine copy (diff-file-priority.ts) —
+ *  none share a filename, so the directory scan never pairs them. The `cartfile\.resolved` marker directly
+ *  regression-guards #4605 Finding 1: the engine copy's Carthage-lockfile regex had silently drifted to
+ *  `cartfile\.lock`, which is not a real filename (Carthage's lockfile is `Cartfile.resolved`). */
+export const DIFF_FILE_PRIORITY_TWIN_PAIR: NamedTwinPair = Object.freeze({
+  area: "diff-file-priority",
+  hostRelative: "src/review/review-diff.ts",
+  engineRelative: "packages/gittensory-engine/src/review/diff-file-priority.ts",
+  hostFileName: "review-diff.ts",
+  engineFileName: "diff-file-priority.ts",
+});
+
+export const DIFF_FILE_PRIORITY_MARKERS = Object.freeze([
+  "export function diffFilePriority(path: string): number {",
+  "cartfile\\.resolved",
+] as const);
+
+/** `sharesMeaningfulFile` is a near-duplicate helper (the host folds its guard clause into one `if`; the
+ *  engine splits it into two) that both gate collision-detection on the same `diffFilePriority` threshold.
+ *  It lives inside much larger files on both sides, so it's invisible to the file-level scan too. */
+export const SHARES_MEANINGFUL_FILE_TWIN_PAIR: NamedTwinPair = Object.freeze({
+  area: "shares-meaningful-file",
+  hostRelative: "src/signals/engine.ts",
+  engineRelative: "packages/gittensory-engine/src/signals/predicted-gate-engine.ts",
+  hostFileName: "engine.ts",
+  engineFileName: "predicted-gate-engine.ts",
+});
+
+export const SHARES_MEANINGFUL_FILE_MARKERS = Object.freeze([
+  "function sharesMeaningfulFile(left: string[] | undefined, right: string[] | undefined): boolean {",
+  "diffFilePriority(path) < 4",
+] as const);
+
+/** Every explicitly named twin pair, checked for core-marker presence in `runEngineParityChecks` — the
+ *  same escape hatch #4518 built for `GATE_DECISION_TWIN_PAIR`, generalized (#4605) so a function-level or
+ *  nested-directory duplicate can be added here without inventing a new mechanism. `GATE_DECISION_TWIN_PAIR`
+ *  additionally gets the co-edit-or-version-bump enforcement (`checkGateDecisionVersionBump`) since its two
+ *  sides are deliberately maintained as structurally divergent implementations; the other pairs here are
+ *  meant to stay much closer to byte-identical, so presence-check plus a content marker on the specific
+ *  historically-drifted value (see `DIFF_FILE_PRIORITY_MARKERS`) is the proportionate guard for now. */
+export const NAMED_TWIN_PAIRS: ReadonlyArray<{ pair: NamedTwinPair; markers: readonly string[] }> = Object.freeze([
+  { pair: GATE_DECISION_TWIN_PAIR, markers: GATE_DECISION_CORE_MARKERS },
+  { pair: SAFE_URL_TWIN_PAIR, markers: SAFE_URL_MARKERS },
+  { pair: DIFF_FILE_PRIORITY_TWIN_PAIR, markers: DIFF_FILE_PRIORITY_MARKERS },
+  { pair: SHARES_MEANINGFUL_FILE_TWIN_PAIR, markers: SHARES_MEANINGFUL_FILE_MARKERS },
+]);
 const ENGINE_SRC_ROOT = "packages/gittensory-engine/src";
 const HOST_SRC_ROOT = "src";
 const ENGINE_PACKAGE_JSON = "packages/gittensory-engine/package.json";
@@ -138,7 +214,8 @@ export function normalizeChangedPath(path: string): string {
     .replace(/^\.\//, "");
 }
 
-/** Load the explicit gate-decision twin pair for monitoring and PR version-bump enforcement. */
+/** Load an explicitly named twin pair (default: the gate-decision pair) for monitoring and, for
+ *  gate-decision specifically, PR version-bump enforcement. */
 export function discoverGateDecisionTwinPair({
   root,
   readFile = defaultReadFile,
@@ -146,7 +223,7 @@ export function discoverGateDecisionTwinPair({
 }: {
   root: string;
   readFile?: EngineParityReadFile;
-  pair?: typeof GATE_DECISION_TWIN_PAIR;
+  pair?: NamedTwinPair;
 }): EngineParityPair {
   return {
     area: pair.area,
@@ -158,7 +235,9 @@ export function discoverGateDecisionTwinPair({
   };
 }
 
-/** Structural guard: both gate-decision twins still expose the core gate entrypoints (#4518). */
+/** Structural guard: both sides of a named twin pair still expose its core markers — e.g. the
+ *  gate-decision twins' core entrypoints (#4518), or a hand-duplicated function's signature and any
+ *  historically-drifted literal it must keep matching (#4605). */
 export function checkGateDecisionTwinPresence({
   root,
   readFile = defaultReadFile,
@@ -167,7 +246,7 @@ export function checkGateDecisionTwinPresence({
 }: {
   root: string;
   readFile?: EngineParityReadFile;
-  pair?: typeof GATE_DECISION_TWIN_PAIR;
+  pair?: NamedTwinPair;
   markers?: readonly string[];
 }): { failures: string[]; pairChecked: EngineParityPair } {
   let twin: EngineParityPair;
@@ -176,7 +255,7 @@ export function checkGateDecisionTwinPresence({
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     return {
-      failures: [`Could not load gate-decision twin files: ${message}`],
+      failures: [`Could not load ${pair.area} twin pair files: ${message}`],
       pairChecked: {
         area: pair.area,
         fileName: `${pair.hostFileName}<->${pair.engineFileName}`,
@@ -190,10 +269,10 @@ export function checkGateDecisionTwinPresence({
   const failures: string[] = [];
   for (const marker of markers) {
     if (!twin.hostText.includes(marker)) {
-      failures.push(`${pair.hostRelative} is missing gate-decision marker ${JSON.stringify(marker)}.`);
+      failures.push(`${pair.hostRelative} is missing expected twin-pair marker ${JSON.stringify(marker)}.`);
     }
     if (!twin.engineText.includes(marker)) {
-      failures.push(`${pair.engineRelative} is missing gate-decision marker ${JSON.stringify(marker)}.`);
+      failures.push(`${pair.engineRelative} is missing expected twin-pair marker ${JSON.stringify(marker)}.`);
     }
   }
   return { failures, pairChecked: twin };
@@ -226,7 +305,7 @@ export function checkGateDecisionVersionBump({
   headEngineVersion,
 }: {
   changedFiles: readonly string[];
-  pair?: typeof GATE_DECISION_TWIN_PAIR;
+  pair?: NamedTwinPair;
   enginePackageJson?: string;
   baseEngineVersion: string | null;
   headEngineVersion: string | null;
@@ -456,7 +535,7 @@ export function checkMinerEngineVersionPinSync({
   return { failures, expected, pin };
 }
 
-/** Run drift, gate-decision, version-skew, and optional PR version-bump checks. */
+/** Run drift, named-twin-pair marker-presence, version-skew, and optional PR version-bump checks. */
 export function runEngineParityChecks(options: {
   root: string;
   readFile?: EngineParityReadFile;
@@ -472,10 +551,17 @@ export function runEngineParityChecks(options: {
   versionSkew: EngineVersionSkewResult;
 } {
   const drift = checkEngineParityDrift(options);
-  const gateDecision = checkGateDecisionTwinPresence(options);
+  const readFile = options.readFile ?? defaultReadFile;
+  // Every named pair (gate-decision + #4605's safe-url/diff-file-priority/shares-meaningful-file) gets a
+  // marker-presence check. Only gate-decision additionally gets the co-edit-or-version-bump enforcement
+  // below — its two sides are deliberately maintained as structurally divergent implementations, while the
+  // other pairs are meant to stay close to byte-identical and already carry a content-level marker on the
+  // specific value that drifted (see e.g. `DIFF_FILE_PRIORITY_MARKERS`).
+  const namedTwinPresence = NAMED_TWIN_PAIRS.map(({ pair, markers }) =>
+    checkGateDecisionTwinPresence({ root: options.root, readFile, pair, markers }),
+  );
   const skew = checkEngineVersionSkew(options);
   const pinSync = checkMinerEngineVersionPinSync(options);
-  const readFile = options.readFile ?? defaultReadFile;
   let headEngineVersion = options.headEngineVersion;
   if (headEngineVersion === undefined) {
     try {
@@ -497,12 +583,12 @@ export function runEngineParityChecks(options: {
   return {
     failures: [
       ...drift.failures,
-      ...gateDecision.failures,
+      ...namedTwinPresence.flatMap((result) => result.failures),
       ...versionBump.failures,
       ...skew.failures,
       ...pinSync.failures,
     ],
-    pairsChecked: [...drift.pairsChecked, gateDecision.pairChecked],
+    pairsChecked: [...drift.pairsChecked, ...namedTwinPresence.map((result) => result.pairChecked)],
     versionSkew: skew,
   };
 }

--- a/test/unit/check-engine-parity-script.test.ts
+++ b/test/unit/check-engine-parity-script.test.ts
@@ -13,6 +13,8 @@ import {
   defaultReadExpectedEngineVersion,
   defaultResolveInstalledEngineVersion,
   describeEngineVersionSkew,
+  DIFF_FILE_PRIORITY_MARKERS,
+  DIFF_FILE_PRIORITY_TWIN_PAIR,
   discoverEngineParityPairs,
   discoverGateDecisionTwinPair,
   enginePackageVersionIncreased,
@@ -20,12 +22,17 @@ import {
   type EngineParityPair,
   isEngineStubPair,
   isThinEngineReExportShim,
+  NAMED_TWIN_PAIRS,
   normalizeChangedPath,
   normalizeEngineParityText,
   normalizeImportSpec,
   parseEnginePackageVersion,
   runEngineParityChecks,
   runEngineParityMain,
+  SAFE_URL_MARKERS,
+  SAFE_URL_TWIN_PAIR,
+  SHARES_MEANINGFUL_FILE_MARKERS,
+  SHARES_MEANINGFUL_FILE_TWIN_PAIR,
 } from "../../scripts/check-engine-parity";
 
 const TSX_BIN = join(process.cwd(), "node_modules", ".bin", "tsx");
@@ -175,6 +182,81 @@ describe("check-engine-parity script", () => {
           throw new Error(`unexpected read: ${relativePath}`);
         },
       }).failures).toEqual([]);
+    });
+  });
+
+  describe("named twin-pair coverage (#4605)", () => {
+    it("registers the gate-decision, safe-url, diff-file-priority, and shares-meaningful-file pairs", () => {
+      const areas = NAMED_TWIN_PAIRS.map(({ pair }) => pair.area);
+      expect(areas).toEqual([
+        "gate-decision",
+        "content-lane",
+        "diff-file-priority",
+        "shares-meaningful-file",
+      ]);
+    });
+
+    it("discovers the content-lane/safe-url.ts pair invisible to the top-level directory scan", () => {
+      const pair = discoverGateDecisionTwinPair({ root: process.cwd(), pair: SAFE_URL_TWIN_PAIR });
+      expect(pair.hostRelative).toBe("src/review/content-lane/safe-url.ts");
+      expect(pair.engineRelative).toBe("packages/gittensory-engine/src/review/safe-url.ts");
+      // Confirms the directory scan really would miss it: "safe-url.ts" is nested under content-lane/ on
+      // the host, so a top-level readdirSync("src/review") pairing by filename never lists it.
+      const scanned = discoverEngineParityPairs({ root: process.cwd() });
+      expect(scanned.some((discovered) => discovered.fileName === "safe-url.ts")).toBe(false);
+    });
+
+    it("passes marker presence for all four named pairs against the real repo (regression guard)", () => {
+      for (const { pair, markers } of NAMED_TWIN_PAIRS) {
+        const result = checkGateDecisionTwinPresence({ root: process.cwd(), pair, markers });
+        expect(result.failures).toEqual([]);
+      }
+    });
+
+    it("diffFilePriority markers cover the exact Cartfile.resolved regression (#4605 Finding 1)", () => {
+      // Reproduces the actual bug: the engine copy's regex previously matched `cartfile\.lock` (not a
+      // real Carthage filename) instead of `cartfile\.resolved`. A body missing the resolved-lockfile
+      // marker fails presence — exactly what the old, un-checked engine copy would have done.
+      const buggyEngineBody =
+        "export function diffFilePriority(path: string): number {\n" +
+        "  if (/cartfile\\.lock$/i.test(path)) return 4;\n" +
+        "  return 0;\n" +
+        "}\n";
+      const fixedHostBody =
+        "export function diffFilePriority(path: string): number {\n" +
+        "  if (/cartfile\\.resolved$/i.test(path)) return 4;\n" +
+        "  return 0;\n" +
+        "}\n";
+      const result = checkGateDecisionTwinPresence({
+        root: "/fake",
+        readFile: (_root, relativePath) => {
+          if (relativePath === DIFF_FILE_PRIORITY_TWIN_PAIR.hostRelative) return fixedHostBody;
+          if (relativePath === DIFF_FILE_PRIORITY_TWIN_PAIR.engineRelative) return buggyEngineBody;
+          throw new Error(`unexpected read: ${relativePath}`);
+        },
+        pair: DIFF_FILE_PRIORITY_TWIN_PAIR,
+        markers: DIFF_FILE_PRIORITY_MARKERS,
+      });
+      expect(result.failures).toHaveLength(1);
+      expect(result.failures[0]).toContain(DIFF_FILE_PRIORITY_TWIN_PAIR.engineRelative);
+      expect(result.failures[0]).toContain(JSON.stringify(DIFF_FILE_PRIORITY_MARKERS[1]));
+    });
+
+    it("safe-url and shares-meaningful-file marker sets are non-empty and pair-specific", () => {
+      expect(SAFE_URL_MARKERS.length).toBeGreaterThan(0);
+      expect(SHARES_MEANINGFUL_FILE_MARKERS.length).toBeGreaterThan(0);
+      expect(SHARES_MEANINGFUL_FILE_TWIN_PAIR.hostRelative).toBe("src/signals/engine.ts");
+      expect(SHARES_MEANINGFUL_FILE_TWIN_PAIR.engineRelative).toBe(
+        "packages/gittensory-engine/src/signals/predicted-gate-engine.ts",
+      );
+    });
+
+    it("includes all four named pairs in runEngineParityChecks pairsChecked", () => {
+      const result = runEngineParityChecks({ root: process.cwd() });
+      const checkedAreas = result.pairsChecked.map((pair) => pair.area);
+      for (const { pair } of NAMED_TWIN_PAIRS) {
+        expect(checkedAreas).toContain(pair.area);
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

- Fixes #4605 (part 1, must-have): `packages/gittensory-engine/src/review/diff-file-priority.ts`'s `diffFilePriority` matched `cartfile\.lock` — not a real Carthage filename — instead of `cartfile\.resolved`. The two host copies (`src/review/review-diff.ts`, `src/review/review-grounding.ts`) already matched the correct filename, so the engine package's predicted-gate collision check silently disagreed with the host for Carthage/iOS repos.
- Fixes #4605 (part 2): `scripts/check-engine-parity.ts`'s directory scan only pairs identical top-level filenames within `src/{review,settings,signals}`, so it can't see a duplicate that's nested one directory deeper or duplicated by function rather than by file. Generalized the existing `GATE_DECISION_TWIN_PAIR` escape hatch (#4518) into a reusable `NAMED_TWIN_PAIRS` list and added named pairs for:
  - `safe-url.ts` (host copy lives under `src/review/content-lane/`, engine copy is flat under `packages/gittensory-engine/src/review/` — different depths, so the scan never lists both under the same relative path).
  - `diffFilePriority` (host: `review-diff.ts`; engine: `diff-file-priority.ts` — different filenames, so no scan match exists at all). Its marker set includes the literal `cartfile\.resolved` regex fragment so this exact regression is caught if it ever recurs.
  - `sharesMeaningfulFile` (host: `src/signals/engine.ts`; engine: `packages/gittensory-engine/src/signals/predicted-gate-engine.ts`), which both gate collision-detection on `diffFilePriority`'s threshold.
- `engine-parity:drift-check` now reports 21 checked pairs (17 directory-discovered + 4 named), up from 18 (17 + 1) before this PR.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

Closes #4605

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

Ran the full `npm run test:ci` gate locally (this touches shared parity-checking infrastructure used by CI itself, so it warranted the fuller local pass rather than just the touched-file scope) — all green, including `test:engine-parity`, `engine-parity:drift-check`, and the engine package's own `npm run test --workspace @jsonbored/gittensory-engine`. Added a direct regression test in `packages/gittensory-engine/test/diff-file-priority.test.ts` that reproduces the original bug (asserts `diffFilePriority("Cartfile.resolved")` and `sharesMeaningfulFile`'s Cartfile.resolved collision case) — verified this test fails without the regex fix and passes with it. Also added a `named twin-pair coverage (#4605)` test block to `test/unit/check-engine-parity-script.test.ts` covering the new pairs, including a synthetic case proving the missing-marker detection actually fires. Neither `scripts/**` nor `packages/gittensory-engine/src/**` is in Codecov's `patch` coverage scope, so this PR owes no `codecov/patch` obligation, but both new test suites are exercised by `npm run test:ci` regardless.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session surface touched.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP surface touched.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes.)
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. (N/A — no visible UI changes.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (N/A.)

## UI Evidence

N/A — no UI/frontend/docs changes in this PR.

## Notes

- Deferred per #4605's explicit allowance: making `discoverEngineParityPairs`'s `listDir` recursive. Named-pair coverage for the two known-missing pairs is must-have and included; full recursion is left as a follow-up so it can be verified against the whole directory tree without risking an unintended behavior change in this focused fix. Note also that recursion alone would not have discovered `safe-url.ts`'s pairing anyway, since the host and engine copies sit at different relative depths (`content-lane/safe-url.ts` vs `safe-url.ts`) — a name-only recursive match wouldn't line them up without also relaxing the match key, which is a larger design decision better suited to its own PR.
- Out of scope, noted for visibility: `src/review/review-diff.ts` and `src/review/review-grounding.ts` both define byte-identical copies of `diffFilePriority` on the host side. That's an intra-host duplication, not a host/engine drift, so it's outside `check-engine-parity.ts`'s purpose (which only tripwires host vs. published-engine-package drift) — flagging it here rather than folding an unrelated dedup into this fix.