### PR TITLE
test(config): lock in .gittensory.yml import fidelity for config-generator (#2212)

### DIFF
--- a/test/unit/config-templates.test.ts
+++ b/test/unit/config-templates.test.ts
@@ -234,4 +234,29 @@ describe("config/examples review templates (#1682)", () => {
     expect(resolveAutonomy(on.settings.autonomy, "merge")).toBe("auto");
     expect(resolveAutonomy(on.settings.autonomy, "close")).toBe("observe"); // unset action ⇒ default
   });
+  it("imports an existing .gittensory.yml's field values across sections into the parsed manifest (#2212)", () => {
+    // The config-generator's "import existing .gittensory.yml into the form" reads an operator's file back
+    // through the same parser; lock in that a multi-section config's values round-trip faithfully (not just
+    // that it parses without warnings).
+    const yml = [
+      "gate:",
+      "  enabled: true",
+      "  linkedIssue: block",
+      "review:",
+      "  inline_comments: true",
+      "  exclude_paths:",
+      "    - dist/**",
+      "settings:",
+      "  autonomy:",
+      "    review: suggest",
+    ].join("\n");
+    const imported = parseFocusManifestContent(yml, "repo_file");
+    expect(imported.warnings).toEqual([]);
+    expect(imported.present).toBe(true);
+    expect(imported.gate.enabled).toBe(true);
+    expect(imported.gate.linkedIssue).toBe("block");
+    expect(imported.review.inlineComments).toBe(true);
+    expect(imported.review.excludePaths).toEqual(["dist/**"]);
+    expect(resolveAutonomy(imported.settings.autonomy, "review")).toBe("suggest");
+  });
 });


### PR DESCRIPTION
Locks in the parser fidelity the config-generator's **import existing .gittensory.yml into the form** depends on (Closes #2212) — same test-only approach as #4480/#4495/#4591 (all merged).

Asserts that a multi-section config imported through `parseFocusManifestContent` round-trips its values faithfully (not merely that it parses without warnings): `gate.enabled`/`linkedIssue`, `review.inline_comments`/`exclude_paths`, and `settings.autonomy` all land at the expected values. That's exactly what the generator's import path reads back into the form.

## Test
One `it(...)` appended to `test/unit/config-templates.test.ts` (18 pass). **Test-only, single file** — no `src` diff.

- [x] Conventional Commit; focused; **Closes #2212**. No `site/`/`CNAME`/`**/lovable/**`; no `CHANGELOG.md`. Test-only.