### PR TITLE
fix(miner): bound repo-map parsing to prevent resource exhaustion

### DIFF
--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -255,6 +255,7 @@ export {
   renderRepoMap,
   resolveRepoMapLanguage,
   type BuildRepoMapOptions,
+  type ExtractRepoMapSymbolsOptions,
   type LoadRepoMapLanguageFn,
   type RepoMapFileEntry,
   type RepoMapSkipReason,

--- a/packages/gittensory-engine/src/miner/repo-map.ts
+++ b/packages/gittensory-engine/src/miner/repo-map.ts
@@ -16,6 +16,7 @@
 // at all yet) or reported as "<anonymous>" (a bare class/function expression). Good enough for a compact outline
 // today; resolving binding names is a reasonable follow-up, not attempted here.
 
+import { Buffer } from "node:buffer";
 import { readFileSync } from "node:fs";
 import { createRequire } from "node:module";
 import Parser from "web-tree-sitter";
@@ -30,7 +31,8 @@ function requireFromHere(): NodeJS.Require {
   return (cachedRequire ??= createRequire(import.meta.url));
 }
 
-export type RepoMapSymbolKind = "function" | "class" | "method" | "interface" | "type";
+export type RepoMapSymbolKind =
+  "function" | "class" | "method" | "interface" | "type";
 
 export type RepoMapSymbol = {
   kind: RepoMapSymbolKind;
@@ -39,7 +41,8 @@ export type RepoMapSymbol = {
   line: number;
 };
 
-export type RepoMapSkipReason = "unsupported_language" | "grammar_unavailable";
+export type RepoMapSkipReason =
+  "unsupported_language" | "grammar_unavailable" | "resource_limit";
 
 export type RepoMapFileEntry = {
   path: string;
@@ -65,18 +68,19 @@ const LANGUAGE_BY_EXTENSION: Readonly<Record<string, string>> = Object.freeze({
   ".tsx": "tsx",
 });
 
-const SYMBOL_NODE_KIND: Readonly<Record<string, RepoMapSymbolKind>> = Object.freeze({
-  function_declaration: "function",
-  // `function_expression`/`class` (bare, unnamed) cover `export default function() {}` / `export default class {}`
-  // and other expression positions -- these have no `name` field, so `nameOf` reports them as "<anonymous>"
-  // rather than skipping them outright.
-  function_expression: "function",
-  class_declaration: "class",
-  class: "class",
-  method_definition: "method",
-  interface_declaration: "interface",
-  type_alias_declaration: "type",
-});
+const SYMBOL_NODE_KIND: Readonly<Record<string, RepoMapSymbolKind>> =
+  Object.freeze({
+    function_declaration: "function",
+    // `function_expression`/`class` (bare, unnamed) cover `export default function() {}` / `export default class {}`
+    // and other expression positions -- these have no `name` field, so `nameOf` reports them as "<anonymous>"
+    // rather than skipping them outright.
+    function_expression: "function",
+    class_declaration: "class",
+    class: "class",
+    method_definition: "method",
+    interface_declaration: "interface",
+    type_alias_declaration: "type",
+  });
 
 function extensionOf(path: string): string {
   const dot = path.lastIndexOf(".");
@@ -91,51 +95,131 @@ export function resolveRepoMapLanguage(path: string): string | null {
 /** Test/injection seam for loading a compiled grammar -- real WASM-file IO lives only in the default
  *  implementation, so a test can inject a failing loader to exercise `grammar_unavailable` without needing an
  *  actually-broken WASM file. */
-export type LoadRepoMapLanguageFn = (languageName: string) => Promise<Parser.Language>;
+export type LoadRepoMapLanguageFn = (
+  languageName: string,
+) => Promise<Parser.Language>;
 
 let parserInitialized: Promise<void> | null = null;
 
-async function defaultLoadRepoMapLanguage(languageName: string): Promise<Parser.Language> {
+async function defaultLoadRepoMapLanguage(
+  languageName: string,
+): Promise<Parser.Language> {
   parserInitialized ??= Parser.init();
   await parserInitialized;
-  const wasmPath = requireFromHere().resolve(`tree-sitter-wasms/out/tree-sitter-${languageName}.wasm`);
+  const wasmPath = requireFromHere().resolve(
+    `tree-sitter-wasms/out/tree-sitter-${languageName}.wasm`,
+  );
   return Parser.Language.load(readFileSync(wasmPath));
+}
+
+const DEFAULT_MAX_FILES = 200;
+const DEFAULT_MAX_SOURCE_BYTES = 1_000_000;
+const DEFAULT_MAX_TOTAL_SOURCE_BYTES = 5_000_000;
+const DEFAULT_MAX_AST_NODES = 50_000;
+const DEFAULT_MAX_SYMBOLS = 5_000;
+const MAX_NAME_CHARS = 200;
+
+function boundedNodeText(
+  sourceText: string,
+  node: Parser.SyntaxNode,
+  maxChars: number,
+): string {
+  return sourceText.slice(
+    node.startIndex,
+    Math.min(node.endIndex, node.startIndex + maxChars),
+  );
 }
 
 /** First line of a symbol node's own text, trimmed and bounded to `maxChars` (with an ellipsis marker when cut),
  *  so one huge one-line minified function can't blow out the rendered output on its own. */
-function signatureOf(node: Parser.SyntaxNode, maxChars: number): string {
-  const firstLine = node.text.split("\n", 1)[0]!.trim();
-  return firstLine.length > maxChars ? `${firstLine.slice(0, maxChars)}…` : firstLine;
+function signatureOf(
+  sourceText: string,
+  node: Parser.SyntaxNode,
+  maxChars: number,
+): string {
+  const end = Math.min(node.endIndex, node.startIndex + maxChars + 1);
+  const newline = sourceText.indexOf("\n", node.startIndex);
+  const sliceEnd = newline === -1 || newline > end ? end : newline;
+  const firstLine = sourceText.slice(node.startIndex, sliceEnd).trim();
+  return node.endIndex - node.startIndex > maxChars &&
+    firstLine.length >= maxChars
+    ? `${firstLine.slice(0, maxChars)}…`
+    : firstLine;
 }
 
-function nameOf(node: Parser.SyntaxNode): string {
-  return node.childForFieldName("name")?.text ?? "<anonymous>";
+function nameOf(sourceText: string, node: Parser.SyntaxNode): string {
+  const nameNode = node.childForFieldName("name");
+  if (!nameNode) return "<anonymous>";
+  const name = boundedNodeText(sourceText, nameNode, MAX_NAME_CHARS + 1);
+  return name.length > MAX_NAME_CHARS
+    ? `${name.slice(0, MAX_NAME_CHARS)}…`
+    : name;
 }
+
+export type ExtractRepoMapSymbolsOptions = {
+  maxSignatureChars?: number | undefined;
+  maxAstNodes?: number | undefined;
+  maxSymbols?: number | undefined;
+};
 
 /** Walk a parsed tree collecting one `RepoMapSymbol` per matched node kind (function/class/method/interface/
- *  type declarations). Pure given an already-parsed tree. */
-export function extractRepoMapSymbols(tree: Parser.Tree, maxSignatureChars = 120): RepoMapSymbol[] {
+ *  type declarations). Pure given an already-parsed tree. Returns `null` when extraction exceeds its work budget. */
+export function extractRepoMapSymbols(
+  tree: Parser.Tree,
+  maxSignatureChars?: number,
+): RepoMapSymbol[] | null;
+export function extractRepoMapSymbols(
+  tree: Parser.Tree,
+  sourceText: string,
+  options?: ExtractRepoMapSymbolsOptions,
+): RepoMapSymbol[] | null;
+export function extractRepoMapSymbols(
+  tree: Parser.Tree,
+  sourceTextOrMaxSignatureChars: string | number = tree.rootNode.text,
+  options: ExtractRepoMapSymbolsOptions = {},
+): RepoMapSymbol[] | null {
+  const sourceText =
+    typeof sourceTextOrMaxSignatureChars === "string"
+      ? sourceTextOrMaxSignatureChars
+      : tree.rootNode.text;
+  const maxSignatureChars =
+    typeof sourceTextOrMaxSignatureChars === "number"
+      ? sourceTextOrMaxSignatureChars
+      : (options.maxSignatureChars ?? 120);
+  const maxAstNodes = options.maxAstNodes ?? DEFAULT_MAX_AST_NODES;
+  const maxSymbols = options.maxSymbols ?? DEFAULT_MAX_SYMBOLS;
   const symbols: RepoMapSymbol[] = [];
-  function walk(node: Parser.SyntaxNode): void {
+  const stack: Parser.SyntaxNode[] = [tree.rootNode];
+  let visited = 0;
+  while (stack.length > 0) {
+    const node = stack.pop()!;
+    visited += 1;
+    if (visited > maxAstNodes) return null;
     const kind = SYMBOL_NODE_KIND[node.type];
     if (kind) {
+      if (symbols.length >= maxSymbols) return null;
       symbols.push({
         kind,
-        name: nameOf(node),
-        signature: signatureOf(node, maxSignatureChars),
+        name: nameOf(sourceText, node),
+        signature: signatureOf(sourceText, node, maxSignatureChars),
         line: node.startPosition.row + 1,
       });
     }
-    for (const child of node.namedChildren) walk(child);
+    for (let index = node.namedChildCount - 1; index >= 0; index -= 1) {
+      stack.push(node.namedChild(index) as Parser.SyntaxNode);
+    }
   }
-  walk(tree.rootNode);
   return symbols;
 }
 
 export type BuildRepoMapOptions = {
   loadLanguage?: LoadRepoMapLanguageFn | undefined;
   maxSignatureChars?: number | undefined;
+  maxFiles?: number | undefined;
+  maxSourceBytes?: number | undefined;
+  maxTotalSourceBytes?: number | undefined;
+  maxAstNodes?: number | undefined;
+  maxSymbols?: number | undefined;
 };
 
 /** Build one `RepoMapFileEntry` per source file: unsupported extensions and grammar/parse failures are caught
@@ -147,9 +231,17 @@ export async function buildRepoMap(
 ): Promise<RepoMapFileEntry[]> {
   const loadLanguage = options.loadLanguage ?? defaultLoadRepoMapLanguage;
   const maxSignatureChars = options.maxSignatureChars ?? 120;
+  const maxFiles = options.maxFiles ?? DEFAULT_MAX_FILES;
+  const maxSourceBytes = options.maxSourceBytes ?? DEFAULT_MAX_SOURCE_BYTES;
+  const maxTotalSourceBytes =
+    options.maxTotalSourceBytes ?? DEFAULT_MAX_TOTAL_SOURCE_BYTES;
+  const maxAstNodes = options.maxAstNodes ?? DEFAULT_MAX_AST_NODES;
+  const maxSymbols = options.maxSymbols ?? DEFAULT_MAX_SYMBOLS;
   const languageCache = new Map<string, Parser.Language | null>();
 
-  async function resolveLanguage(name: string): Promise<Parser.Language | null> {
+  async function resolveLanguage(
+    name: string,
+  ): Promise<Parser.Language | null> {
     const cached = languageCache.get(name);
     if (cached !== undefined) return cached;
     try {
@@ -163,28 +255,73 @@ export async function buildRepoMap(
   }
 
   const entries: RepoMapFileEntry[] = [];
-  for (const file of files) {
+  let totalSourceBytes = 0;
+  for (const [index, file] of files.entries()) {
+    if (index >= maxFiles) {
+      entries.push({
+        path: file.path,
+        language: resolveRepoMapLanguage(file.path),
+        symbols: [],
+        skipped: "resource_limit",
+      });
+      continue;
+    }
     const languageName = resolveRepoMapLanguage(file.path);
+    const sourceBytes = Buffer.byteLength(file.sourceText, "utf8");
+    totalSourceBytes += sourceBytes;
+    if (
+      sourceBytes > maxSourceBytes ||
+      totalSourceBytes > maxTotalSourceBytes
+    ) {
+      entries.push({
+        path: file.path,
+        language: languageName,
+        symbols: [],
+        skipped: "resource_limit",
+      });
+      continue;
+    }
     if (!languageName) {
-      entries.push({ path: file.path, language: null, symbols: [], skipped: "unsupported_language" });
+      entries.push({
+        path: file.path,
+        language: null,
+        symbols: [],
+        skipped: "unsupported_language",
+      });
       continue;
     }
     const language = await resolveLanguage(languageName);
     if (!language) {
-      entries.push({ path: file.path, language: languageName, symbols: [], skipped: "grammar_unavailable" });
+      entries.push({
+        path: file.path,
+        language: languageName,
+        symbols: [],
+        skipped: "grammar_unavailable",
+      });
       continue;
     }
     try {
       const parser = new Parser();
       parser.setLanguage(language);
       const tree = parser.parse(file.sourceText);
+      const symbols = extractRepoMapSymbols(tree, file.sourceText, {
+        maxSignatureChars,
+        maxAstNodes,
+        maxSymbols,
+      });
       entries.push({
         path: file.path,
         language: languageName,
-        symbols: extractRepoMapSymbols(tree, maxSignatureChars),
+        symbols: symbols ?? [],
+        ...(symbols === null ? { skipped: "resource_limit" as const } : {}),
       });
     } catch {
-      entries.push({ path: file.path, language: languageName, symbols: [], skipped: "grammar_unavailable" });
+      entries.push({
+        path: file.path,
+        language: languageName,
+        symbols: [],
+        skipped: "grammar_unavailable",
+      });
     }
   }
   return entries;
@@ -193,7 +330,10 @@ export async function buildRepoMap(
 /** Render entries into a bounded plain-text outline: one line per symbol (`kind name (line N): signature`),
  *  skipped/empty files noted with a one-line placeholder. Stops once `maxOutputChars` would be exceeded and
  *  appends a truncation marker, so a caller/prompt-builder can tell the map is partial rather than complete. */
-export function renderRepoMap(entries: readonly RepoMapFileEntry[], maxOutputChars = 20_000): string {
+export function renderRepoMap(
+  entries: readonly RepoMapFileEntry[],
+  maxOutputChars = 20_000,
+): string {
   const lines: string[] = [];
   let length = 0;
   let truncated = false;
@@ -217,7 +357,12 @@ export function renderRepoMap(entries: readonly RepoMapFileEntry[], maxOutputCha
     } else {
       if (!pushLine(`${entry.path}:`)) break outer;
       for (const symbol of entry.symbols) {
-        if (!pushLine(`  ${symbol.kind} ${symbol.name} (line ${symbol.line}): ${symbol.signature}`)) break outer;
+        if (
+          !pushLine(
+            `  ${symbol.kind} ${symbol.name} (line ${symbol.line}): ${symbol.signature}`,
+          )
+        )
+          break outer;
       }
     }
   }

--- a/test/unit/repo-map.test.ts
+++ b/test/unit/repo-map.test.ts
@@ -1,7 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
   buildRepoMap,
-  extractRepoMapSymbols,
   renderRepoMap,
   resolveRepoMapLanguage,
   type LoadRepoMapLanguageFn,
@@ -48,9 +47,19 @@ describe("buildRepoMap + extractRepoMapSymbols (#4280)", () => {
     expect(entry!.symbols).toEqual([
       // The `export` keyword lives on the enclosing export_statement node, not the declaration node itself, so
       // it is not part of the extracted signature.
-      { kind: "function", name: "add", signature: "function add(a: number, b: number): number {", line: 1 },
+      {
+        kind: "function",
+        name: "add",
+        signature: "function add(a: number, b: number): number {",
+        line: 1,
+      },
       { kind: "class", name: "Widget", signature: "class Widget {", line: 5 },
-      { kind: "method", name: "render", signature: "render(): string {", line: 6 },
+      {
+        kind: "method",
+        name: "render",
+        signature: "render(): string {",
+        line: 6,
+      },
     ]);
   });
 
@@ -64,7 +73,9 @@ describe("buildRepoMap + extractRepoMapSymbols (#4280)", () => {
       "export type Pair = [Point, Point];",
     ].join("\n");
 
-    const [entry] = await buildRepoMap([{ path: "src/geometry.ts", sourceText }]);
+    const [entry] = await buildRepoMap([
+      { path: "src/geometry.ts", sourceText },
+    ]);
     expect(entry!.symbols.map((s) => s.kind)).toEqual(["interface", "type"]);
     expect(entry!.symbols.map((s) => s.name)).toEqual(["Point", "Pair"]);
   });
@@ -75,36 +86,57 @@ describe("buildRepoMap + extractRepoMapSymbols (#4280)", () => {
       "  return null;",
       "}",
     ].join("\n");
-    const [entry] = await buildRepoMap([{ path: "src/Button.tsx", sourceText }]);
+    const [entry] = await buildRepoMap([
+      { path: "src/Button.tsx", sourceText },
+    ]);
     expect(entry!.language).toBe("tsx");
     expect(entry!.symbols.map((s) => s.name)).toEqual(["Button"]);
   });
 
   it("parses plain .js with the javascript grammar", async () => {
-    const [entry] = await buildRepoMap([{ path: "src/legacy.js", sourceText: "function helper() {}\n" }]);
+    const [entry] = await buildRepoMap([
+      { path: "src/legacy.js", sourceText: "function helper() {}\n" },
+    ]);
     expect(entry!.language).toBe("javascript");
-    expect(entry!.symbols).toEqual([{ kind: "function", name: "helper", signature: "function helper() {}", line: 1 }]);
+    expect(entry!.symbols).toEqual([
+      {
+        kind: "function",
+        name: "helper",
+        signature: "function helper() {}",
+        line: 1,
+      },
+    ]);
   });
 
   it("truncates an overlong one-line signature and marks it with an ellipsis", async () => {
     const longBody = "x".repeat(200);
     const sourceText = `function longOne() { const ${longBody} = 1; }`;
-    const [entry] = await buildRepoMap([{ path: "src/long.ts", sourceText }], { maxSignatureChars: 30 });
+    const [entry] = await buildRepoMap([{ path: "src/long.ts", sourceText }], {
+      maxSignatureChars: 30,
+    });
     expect(entry!.symbols[0]!.signature.endsWith("…")).toBe(true);
     expect(entry!.symbols[0]!.signature.length).toBe(31); // 30 chars + the ellipsis marker
   });
 
   it("reports an anonymous name for an unnamed class/function expression (e.g. export default class/function)", async () => {
     const [classEntry] = await buildRepoMap([
-      { path: "src/anon-class.ts", sourceText: "export default class { method() {} }" },
+      {
+        path: "src/anon-class.ts",
+        sourceText: "export default class { method() {} }",
+      },
     ]);
     const classSymbol = classEntry!.symbols.find((s) => s.kind === "class");
     expect(classSymbol?.name).toBe("<anonymous>");
 
     const [functionEntry] = await buildRepoMap([
-      { path: "src/anon-function.ts", sourceText: "export default function() { return 1; }" },
+      {
+        path: "src/anon-function.ts",
+        sourceText: "export default function() { return 1; }",
+      },
     ]);
-    const functionSymbol = functionEntry!.symbols.find((s) => s.kind === "function");
+    const functionSymbol = functionEntry!.symbols.find(
+      (s) => s.kind === "function",
+    );
     expect(functionSymbol?.name).toBe("<anonymous>");
   });
 
@@ -114,30 +146,152 @@ describe("buildRepoMap + extractRepoMapSymbols (#4280)", () => {
       loadCalls += 1;
       throw new Error("should not be called");
     };
-    const [entry] = await buildRepoMap([{ path: "README.md", sourceText: "# hello" }], {
-      loadLanguage: countingLoader,
+    const [entry] = await buildRepoMap(
+      [{ path: "README.md", sourceText: "# hello" }],
+      {
+        loadLanguage: countingLoader,
+      },
+    );
+    expect(entry).toEqual({
+      path: "README.md",
+      language: null,
+      symbols: [],
+      skipped: "unsupported_language",
     });
-    expect(entry).toEqual({ path: "README.md", language: null, symbols: [], skipped: "unsupported_language" });
     expect(loadCalls).toBe(0);
+  });
+
+  it("skips supported files that exceed the per-file source byte budget before loading a grammar", async () => {
+    let loadCalls = 0;
+    const countingLoader: LoadRepoMapLanguageFn = async () => {
+      loadCalls += 1;
+      throw new Error("should not load grammar for oversized input");
+    };
+    const [entry] = await buildRepoMap(
+      [{ path: "src/huge.ts", sourceText: "function huge() {}" }],
+      { loadLanguage: countingLoader, maxSourceBytes: 5 },
+    );
+    expect(entry).toEqual({
+      path: "src/huge.ts",
+      language: "typescript",
+      symbols: [],
+      skipped: "resource_limit",
+    });
+    expect(loadCalls).toBe(0);
+  });
+
+  it("skips files after the aggregate source byte budget is consumed", async () => {
+    const entries = await buildRepoMap(
+      [
+        { path: "src/first.ts", sourceText: "function first() {}" },
+        { path: "src/second.ts", sourceText: "function second() {}" },
+      ],
+      { maxTotalSourceBytes: 20 },
+    );
+    expect(entries[0]!.skipped).toBeUndefined();
+    expect(entries[1]).toEqual({
+      path: "src/second.ts",
+      language: "typescript",
+      symbols: [],
+      skipped: "resource_limit",
+    });
+  });
+
+  it("keeps one entry per input file but resource-limits files beyond the file-count budget", async () => {
+    const entries = await buildRepoMap(
+      [
+        { path: "src/first.ts", sourceText: "function first() {}" },
+        { path: "src/second.ts", sourceText: "function second() {}" },
+      ],
+      { maxFiles: 1 },
+    );
+    expect(entries[0]!.symbols.map((symbol) => symbol.name)).toEqual(["first"]);
+    expect(entries[1]).toEqual({
+      path: "src/second.ts",
+      language: "typescript",
+      symbols: [],
+      skipped: "resource_limit",
+    });
+  });
+
+  it("reports resource_limit when symbol extraction exceeds the AST-node budget", async () => {
+    const [entry] = await buildRepoMap(
+      [{ path: "src/simple.ts", sourceText: "function simple() {}" }],
+      {
+        maxAstNodes: 1,
+      },
+    );
+    expect(entry).toEqual({
+      path: "src/simple.ts",
+      language: "typescript",
+      symbols: [],
+      skipped: "resource_limit",
+    });
+  });
+
+  it("reports resource_limit when symbol extraction exceeds the symbol budget", async () => {
+    const [entry] = await buildRepoMap(
+      [
+        {
+          path: "src/two.ts",
+          sourceText: "function one() {}\nfunction two() {}",
+        },
+      ],
+      {
+        maxSymbols: 1,
+      },
+    );
+    expect(entry).toEqual({
+      path: "src/two.ts",
+      language: "typescript",
+      symbols: [],
+      skipped: "resource_limit",
+    });
+  });
+
+  it("bounds a very long declaration name while preserving the rest of the symbol", async () => {
+    const longName = `fn${"x".repeat(250)}`;
+    const [entry] = await buildRepoMap([
+      { path: "src/long-name.ts", sourceText: `function ${longName}() {}` },
+    ]);
+    expect(entry!.symbols[0]!.name.endsWith("…")).toBe(true);
+    expect(entry!.symbols[0]!.name.length).toBe(201);
   });
 
   it("reports grammar_unavailable (not a thrown error) when the injected loader rejects", async () => {
     const failingLoader: LoadRepoMapLanguageFn = async () => {
       throw new Error("wasm load failed");
     };
-    const [entry] = await buildRepoMap([{ path: "src/foo.ts", sourceText: "function f() {}" }], {
-      loadLanguage: failingLoader,
+    const [entry] = await buildRepoMap(
+      [{ path: "src/foo.ts", sourceText: "function f() {}" }],
+      {
+        loadLanguage: failingLoader,
+      },
+    );
+    expect(entry).toEqual({
+      path: "src/foo.ts",
+      language: "typescript",
+      symbols: [],
+      skipped: "grammar_unavailable",
     });
-    expect(entry).toEqual({ path: "src/foo.ts", language: "typescript", symbols: [], skipped: "grammar_unavailable" });
   });
 
   it("reports grammar_unavailable when parsing itself throws, even though the grammar loaded fine", async () => {
     const throwingParseLanguage = {} as never; // setLanguage(this) will throw inside Parser -- not a real Language
-    const brokenLoader: LoadRepoMapLanguageFn = async () => throwingParseLanguage;
-    const [entry] = await buildRepoMap([{ path: "src/foo.ts", sourceText: "function f() {}" }], {
-      loadLanguage: brokenLoader,
+    const brokenLoader: LoadRepoMapLanguageFn = async () =>
+      throwingParseLanguage;
+    const [entry] = await buildRepoMap(
+      [{ path: "src/foo.ts", sourceText: "function f() {}" }],
+      {
+        loadLanguage: brokenLoader,
+      },
+    );
+    expect(entry).toEqual({
+      path: "src/foo.ts",
+      language: "typescript",
+      symbols: [],
+      skipped: "grammar_unavailable",
     });
-    expect(entry).toEqual({ path: "src/foo.ts", language: "typescript", symbols: [], skipped: "grammar_unavailable" });
   });
 
   it("parses multiple files of the same language correctly using the real (non-injected) default loader", async () => {
@@ -146,8 +300,17 @@ describe("buildRepoMap + extractRepoMapSymbols (#4280)", () => {
       { path: "b.ts", sourceText: "function b() {}" },
       { path: "c.ts", sourceText: "function c() {}" },
     ]);
-    expect(entries.every((entry) => entry.language === "typescript" && entry.skipped === undefined)).toBe(true);
-    expect(entries.map((entry) => entry.symbols[0]!.name)).toEqual(["a", "b", "c"]);
+    expect(
+      entries.every(
+        (entry) =>
+          entry.language === "typescript" && entry.skipped === undefined,
+      ),
+    ).toBe(true);
+    expect(entries.map((entry) => entry.symbols[0]!.name)).toEqual([
+      "a",
+      "b",
+      "c",
+    ]);
   });
 
   it("an injected loader is invoked once per distinct language across multiple files, not once per file", async () => {
@@ -175,14 +338,32 @@ describe("renderRepoMap (#4280)", () => {
   const normalEntry: RepoMapFileEntry = {
     path: "src/widget.ts",
     language: "typescript",
-    symbols: [{ kind: "function", name: "add", signature: "export function add() {", line: 1 }],
+    symbols: [
+      {
+        kind: "function",
+        name: "add",
+        signature: "export function add() {",
+        line: 1,
+      },
+    ],
   };
-  const skippedEntry: RepoMapFileEntry = { path: "README.md", language: null, symbols: [], skipped: "unsupported_language" };
-  const emptyEntry: RepoMapFileEntry = { path: "src/empty.ts", language: "typescript", symbols: [] };
+  const skippedEntry: RepoMapFileEntry = {
+    path: "README.md",
+    language: null,
+    symbols: [],
+    skipped: "unsupported_language",
+  };
+  const emptyEntry: RepoMapFileEntry = {
+    path: "src/empty.ts",
+    language: "typescript",
+    symbols: [],
+  };
 
   it("renders one line per symbol plus a header line per file", () => {
     const output = renderRepoMap([normalEntry]);
-    expect(output).toBe("src/widget.ts:\n  function add (line 1): export function add() {");
+    expect(output).toBe(
+      "src/widget.ts:\n  function add (line 1): export function add() {",
+    );
   });
 
   it("renders every symbol of a multi-symbol file, not just the first", () => {
@@ -195,11 +376,15 @@ describe("renderRepoMap (#4280)", () => {
       ],
     };
     const output = renderRepoMap([multiSymbolEntry]);
-    expect(output).toBe("src/multi.ts:\n  function a (line 1): function a() {\n  function b (line 3): function b() {");
+    expect(output).toBe(
+      "src/multi.ts:\n  function a (line 1): function a() {\n  function b (line 3): function b() {",
+    );
   });
 
   it("notes a skipped file with its skip reason", () => {
-    expect(renderRepoMap([skippedEntry])).toBe("README.md: (skipped: unsupported_language)");
+    expect(renderRepoMap([skippedEntry])).toBe(
+      "README.md: (skipped: unsupported_language)",
+    );
   });
 
   it("notes a file with no symbols", () => {
@@ -211,14 +396,28 @@ describe("renderRepoMap (#4280)", () => {
   });
 
   it("truncates once the char budget is exceeded and appends a truncation marker", () => {
-    const manyEntries: RepoMapFileEntry[] = Array.from({ length: 50 }, (_, i) => ({
-      path: `src/file${i}.ts`,
-      language: "typescript",
-      symbols: [{ kind: "function", name: `fn${i}`, signature: `export function fn${i}() {`, line: 1 }],
-    }));
+    const manyEntries: RepoMapFileEntry[] = Array.from(
+      { length: 50 },
+      (_, i) => ({
+        path: `src/file${i}.ts`,
+        language: "typescript",
+        symbols: [
+          {
+            kind: "function",
+            name: `fn${i}`,
+            signature: `export function fn${i}() {`,
+            line: 1,
+          },
+        ],
+      }),
+    );
     const output = renderRepoMap(manyEntries, 200);
-    expect(output.length).toBeLessThanOrEqual(200 + "\n… (repo map truncated to fit the output budget)".length);
-    expect(output.endsWith("… (repo map truncated to fit the output budget)")).toBe(true);
+    expect(output.length).toBeLessThanOrEqual(
+      200 + "\n… (repo map truncated to fit the output budget)".length,
+    );
+    expect(
+      output.endsWith("… (repo map truncated to fit the output budget)"),
+    ).toBe(true);
   });
 
   it("does not truncate when everything fits comfortably under the budget", () => {
@@ -250,16 +449,24 @@ describe("renderRepoMap (#4280)", () => {
         { kind: "function", name: "b", signature: "function b() {", line: 3 },
       ],
     };
-    const headerAndFirstSymbol = "src/multi.ts:\n  function a (line 1): function a() {";
-    const output = renderRepoMap([multiSymbolEntry], headerAndFirstSymbol.length);
-    expect(output).toBe(`${headerAndFirstSymbol}\n… (repo map truncated to fit the output budget)`);
+    const headerAndFirstSymbol =
+      "src/multi.ts:\n  function a (line 1): function a() {";
+    const output = renderRepoMap(
+      [multiSymbolEntry],
+      headerAndFirstSymbol.length,
+    );
+    expect(output).toBe(
+      `${headerAndFirstSymbol}\n… (repo map truncated to fit the output budget)`,
+    );
   });
 });
 
 describe("extractRepoMapSymbols default maxSignatureChars (#4280)", () => {
   it("uses a 120-char default when not passed explicitly by buildRepoMap's caller", async () => {
     const shortSource = "function shortFn(a) {}";
-    const [entry] = await buildRepoMap([{ path: "src/short.js", sourceText: shortSource }]);
+    const [entry] = await buildRepoMap([
+      { path: "src/short.js", sourceText: shortSource },
+    ]);
     expect(entry!.symbols[0]!.signature).toBe(shortSource);
   });
 });

--- a/test/unit/repo-map.test.ts
+++ b/test/unit/repo-map.test.ts
@@ -1,11 +1,31 @@
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import Parser from "web-tree-sitter";
 import { describe, expect, it } from "vitest";
 import {
   buildRepoMap,
+  extractRepoMapSymbols,
   renderRepoMap,
   resolveRepoMapLanguage,
   type LoadRepoMapLanguageFn,
   type RepoMapFileEntry,
 } from "../../packages/gittensory-engine/src/index";
+
+// Test-only parser, independent of `buildRepoMap`'s internal (unexported) loader -- gives direct tests of
+// `extractRepoMapSymbols` a real `Parser.Tree` to call it with.
+const require = createRequire(import.meta.url);
+let tsParserReady: Promise<Parser.Language> | null = null;
+async function parseTypescript(sourceText: string): Promise<Parser.Tree> {
+  await Parser.init();
+  tsParserReady ??= Parser.Language.load(
+    readFileSync(
+      require.resolve("tree-sitter-wasms/out/tree-sitter-typescript.wasm"),
+    ),
+  );
+  const parser = new Parser();
+  parser.setLanguage(await tsParserReady);
+  return parser.parse(sourceText)!;
+}
 
 describe("resolveRepoMapLanguage (#4280)", () => {
   it("maps known extensions to their grammar name", () => {
@@ -116,6 +136,18 @@ describe("buildRepoMap + extractRepoMapSymbols (#4280)", () => {
     });
     expect(entry!.symbols[0]!.signature.endsWith("…")).toBe(true);
     expect(entry!.symbols[0]!.signature.length).toBe(31); // 30 chars + the ellipsis marker
+  });
+
+  it("does not truncate a short first line even when the full multi-line node span exceeds maxSignatureChars", async () => {
+    // The node's total span (signature line + a long body line + closing brace) is well over the default
+    // 120-char maxSignatureChars, but the *first line* -- the part signatureOf actually renders -- is short.
+    // Truncation should key off the rendered first line, not the node's total byte span.
+    const sourceText = ["function short() {", `  ${"x".repeat(200)}`, "}"].join(
+      "\n",
+    );
+    const [entry] = await buildRepoMap([{ path: "src/short-sig.ts", sourceText }]);
+    expect(entry!.symbols[0]!.signature).toBe("function short() {");
+    expect(entry!.symbols[0]!.signature.endsWith("…")).toBe(false);
   });
 
   it("reports an anonymous name for an unnamed class/function expression (e.g. export default class/function)", async () => {
@@ -468,5 +500,26 @@ describe("extractRepoMapSymbols default maxSignatureChars (#4280)", () => {
       { path: "src/short.js", sourceText: shortSource },
     ]);
     expect(entry!.symbols[0]!.signature).toBe(shortSource);
+  });
+});
+
+describe("extractRepoMapSymbols legacy (tree, maxSignatureChars?) overload (#4280)", () => {
+  // `buildRepoMap` only ever calls the newer (tree, sourceText, options) form, but this overload is
+  // exported public API (packages/gittensory-engine/src/index.ts) for direct callers that pre-date the
+  // sourceText-slicing rewrite -- exercise it directly so its fallback-to-`tree.rootNode.text` path stays covered.
+  it("falls back to tree.rootNode.text and the 120-char default when called with just a tree", async () => {
+    const tree = await parseTypescript("function plain(a) {}");
+    const symbols = extractRepoMapSymbols(tree);
+    expect(symbols).toEqual([
+      { kind: "function", name: "plain", signature: "function plain(a) {}", line: 1 },
+    ]);
+  });
+
+  it("honors an explicit numeric maxSignatureChars, still sourced from tree.rootNode.text", async () => {
+    const tree = await parseTypescript("function overlyLongDeclarationName(a) {}");
+    const symbols = extractRepoMapSymbols(tree, 10);
+    expect(symbols).not.toBeNull();
+    expect(symbols![0]!.signature.endsWith("…")).toBe(true);
+    expect(symbols![0]!.signature.length).toBe(11); // 10 chars + the ellipsis marker
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent unbounded CPU/memory work when parsing contributor-controlled repo files by miners/coding-agents. 
- Ensure parsing and symbol extraction cannot be forced to materialize very large `node.text` or traverse arbitrarily large ASTs. 
- Apply lightweight, configurable limits so callers can safely analyze untrusted repositories without crashing the process. 

### Description
- Add a new `resource_limit` skip reason and exported `ExtractRepoMapSymbolsOptions` and updated `BuildRepoMapOptions` to accept budgets including `maxFiles`, `maxSourceBytes`, `maxTotalSourceBytes`, `maxAstNodes`, and `maxSymbols`. 
- Bound name/signature extraction to source slices instead of using `node.text`, by changing `signatureOf`/`nameOf` to slice `sourceText` and limit materialized bytes. 
- Change symbol extraction to an iterative stack traversal that tracks visited AST nodes and symbol counts and returns `null` (reported as `skipped: "resource_limit"`) when budgets are exceeded. 
- Enforce inexpensive pre-parse checks in `buildRepoMap` (file-count and per-file/aggregate byte budgets) and pass extraction budgets into `extractRepoMapSymbols`, and export the new types from the engine barrel (`src/index.ts`). 
- Add unit tests covering file-count limits, per-file/aggregate byte limits, AST-node/symbol extraction budgets, and long-name bounding, and adjust `renderRepoMap` formatting minorly. 

### Testing
- Ran `git diff --check` which passed locally. 
- Added and updated unit tests in `test/unit/repo-map.test.ts`, but `npx vitest run test/unit/repo-map.test.ts` could not complete due to the local environment missing the `web-tree-sitter` package, so the full suite was blocked. 
- Attempted `npm --workspace @jsonbored/gittensory-engine run build` which failed due to missing workspace dependencies (`web-tree-sitter` and `@anthropic-ai/claude-agent-sdk`) in the environment. 
- `npm audit --audit-level=moderate` and `npm ci` were blocked by registry responses (403) in this environment; the tests and build changes are committed and should run successfully in CI or a fully provisioned developer environment with the required packages.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a508c0c01f8832cb45165e1e0b67845)