### PR TITLE
fix(selfhost): exclude gate calibration ledger from exports

### DIFF
--- a/scripts/export-d1-core.mjs
+++ b/scripts/export-d1-core.mjs
@@ -6,8 +6,19 @@ import { createHash } from "node:crypto";
 
 // Tables NEVER exported: SQLite/Drizzle internals, the cloud's own migration ledger (the self-host applies its
 // own forward migrations), plus private cloud-only calibration signals that must not cross instance boundaries.
+// predicted_gate_calls (0137) and predicted_gate_calibration_ledger (0138) are both login-keyed, LOCAL-ONLY by
+// their own migration docstrings ("never wired into exportOrbBatch or any other cross-instance/public export
+// path") — same sensitivity class, same exclusion.
 // Keep this conservative — excluding a real table loses data; the importer also skips it.
-export const EXCLUDED_TABLES = new Set(["sqlite_sequence", "sqlite_stat1", "d1_migrations", "_cf_KV", "__drizzle_migrations", "predicted_gate_calibration_ledger"]);
+export const EXCLUDED_TABLES = new Set([
+  "sqlite_sequence",
+  "sqlite_stat1",
+  "d1_migrations",
+  "_cf_KV",
+  "__drizzle_migrations",
+  "predicted_gate_calibration_ledger",
+  "predicted_gate_calls",
+]);
 
 // Columns dropped per table on export — cloud-specific secrets/hashes that are dead or unsafe on self-host. A
 // committed credential never crosses the boundary (#selfhost-migration DO-NOT-MIGRATE list):

--- a/scripts/export-d1-core.mjs
+++ b/scripts/export-d1-core.mjs
@@ -4,9 +4,10 @@
 // so this stays unit-testable. See [[gittensory-selfhost-migration-plan]].
 import { createHash } from "node:crypto";
 
-// Tables NEVER exported: SQLite/Drizzle internals + the cloud's own migration ledger (the self-host applies its
-// own forward migrations). Keep this conservative — excluding a real table loses data; the importer also skips it.
-export const EXCLUDED_TABLES = new Set(["sqlite_sequence", "sqlite_stat1", "d1_migrations", "_cf_KV", "__drizzle_migrations"]);
+// Tables NEVER exported: SQLite/Drizzle internals, the cloud's own migration ledger (the self-host applies its
+// own forward migrations), plus private cloud-only calibration signals that must not cross instance boundaries.
+// Keep this conservative — excluding a real table loses data; the importer also skips it.
+export const EXCLUDED_TABLES = new Set(["sqlite_sequence", "sqlite_stat1", "d1_migrations", "_cf_KV", "__drizzle_migrations", "predicted_gate_calibration_ledger"]);
 
 // Columns dropped per table on export — cloud-specific secrets/hashes that are dead or unsafe on self-host. A
 // committed credential never crosses the boundary (#selfhost-migration DO-NOT-MIGRATE list):

--- a/test/unit/export-d1-core.test.ts
+++ b/test/unit/export-d1-core.test.ts
@@ -121,6 +121,22 @@ describe("export-d1-core buildTableExport + manifest", () => {
     expect(out).toBeNull();
   });
 
+  it("excludes the login-keyed predicted-gate-calls ledger from self-host exports (regression)", () => {
+    const out = buildTableExport("predicted_gate_calls", [
+      {
+        id: "1",
+        login: "alice",
+        project: "owner/repo",
+        predicted_action: "merge",
+        conclusion: "success",
+        reason_code: null,
+      },
+    ]);
+
+    expect(EXCLUDED_TABLES.has("predicted_gate_calls")).toBe(true);
+    expect(out).toBeNull();
+  });
+
   it("redacts + checksums + counts rows for an exported table", () => {
     const out = buildTableExport("auth_sessions", [{ id: 1, token_hash: "h1" }, { id: 2, token_hash: "h2" }]);
     expect(out).not.toBeNull();

--- a/test/unit/export-d1-core.test.ts
+++ b/test/unit/export-d1-core.test.ts
@@ -105,6 +105,22 @@ describe("export-d1-core buildTableExport + manifest", () => {
     expect(buildTableExport("d1_migrations", [{ id: 1 }])).toBeNull();
   });
 
+  it("excludes the private gate calibration ledger from self-host exports (regression)", () => {
+    const out = buildTableExport("predicted_gate_calibration_ledger", [
+      {
+        login: "alice",
+        project: "owner/repo",
+        target_id: "owner/repo#1",
+        predicted_action: "merge",
+        real_decision: "hold",
+        agreed: 0,
+      },
+    ]);
+
+    expect(EXCLUDED_TABLES.has("predicted_gate_calibration_ledger")).toBe(true);
+    expect(out).toBeNull();
+  });
+
   it("redacts + checksums + counts rows for an exported table", () => {
     const out = buildTableExport("auth_sessions", [{ id: 1, token_hash: "h1" }, { id: 2, token_hash: "h2" }]);
     expect(out).not.toBeNull();


### PR DESCRIPTION
### Motivation

- The new `predicted_gate_calibration_ledger` table contains sensitive per-login calibration data but was not excluded from the D1 self-host export, allowing raw calibration rows to be emitted by the generic `SELECT *` exporter.

### Description

- Add `predicted_gate_calibration_ledger` to the `EXCLUDED_TABLES` set in `scripts/export-d1-core.mjs` so the ledger is never exported.
- Add a regression unit test in `test/unit/export-d1-core.test.ts` that asserts `buildTableExport("predicted_gate_calibration_ledger", ...)` returns `null` and that the table is present in `EXCLUDED_TABLES`.

### Testing

- Ran `npx vitest run test/unit/export-d1-core.test.ts`, and the unit test passed.
- Ran `git diff --check` which reported no issues for the modified files.
- Attempted full gate with `npm run test:ci`, but the run was blocked by an unrelated `cf-typegen:check` drift (`worker-configuration.d.ts is stale`) and the `npm audit --audit-level=moderate` step failed due to an npm registry `403` error; these failures are environmental/unrelated to the export-policy change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a508c0ee068832ca1442b6f20c634b7)