### PR TITLE
fix(miner): exclude local credentials from docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -37,4 +37,10 @@ review-enrichment
 .env
 .env.*
 .dev.vars
+.npmrc
+**/.npmrc
+*.pem
+**/*.pem
+*private*key*
+**/*private*key*
 !.env.example

--- a/test/unit/miner-deployment-doc.test.ts
+++ b/test/unit/miner-deployment-doc.test.ts
@@ -24,6 +24,7 @@ describe("miner deployment guide (#2330)", () => {
 
   it("ships a fleet Dockerfile with non-root runtime and no baked secrets (#4295)", () => {
     const dockerfile = readFileSync(join(process.cwd(), "packages/gittensory-miner/Dockerfile"), "utf8");
+    const dockerignore = readFileSync(join(process.cwd(), ".dockerignore"), "utf8");
     expect(dockerfile).toContain("COPY . .");
     expect(dockerfile).toContain("npm prune --omit=dev --ignore-scripts");
     expect(dockerfile).toContain("@jsonbored/gittensory-engine");
@@ -32,6 +33,12 @@ describe("miner deployment guide (#2330)", () => {
     expect(dockerfile).toContain("VOLUME");
     expect(dockerfile).toMatch(/No HEALTHCHECK/i);
     expect(dockerfile).not.toMatch(/GITHUB_TOKEN|ghp_|github_pat_/i);
+    expect(dockerignore).toContain(".npmrc");
+    expect(dockerignore).toContain("**/.npmrc");
+    expect(dockerignore).toContain("*.pem");
+    expect(dockerignore).toContain("**/*.pem");
+    expect(dockerignore).toContain("*private*key*");
+    expect(dockerignore).toContain("**/*private*key*");
   });
 
   it("is linked from the miner package README", () => {


### PR DESCRIPTION
### Motivation

- Prevent accidental inclusion of common local credential files (package-scoped `.npmrc`, PEM keys, and private-key-like filenames) in the fleet-mode miner Docker image build context, which could be baked into runtime image layers when the Dockerfile copies workspace package directories.
- Ensure the miner deployment guidance and regression test cover the `.dockerignore` patterns so this class of information-leak is detected by tests.
- Keep local developer checks happy by regenerating Cloudflare worker types required by the repo's drift checks.

### Description

- Added secure exclusions to `.dockerignore` for `.npmrc`, `**/.npmrc`, `*.pem`, `**/*.pem`, `*private*key*`, and `**/*private*key*` to stop common credential/key files from entering the Docker build context.
- Extended `test/unit/miner-deployment-doc.test.ts` to read `.dockerignore` and assert the new ignore patterns are present so the fleet Dockerfile test verifies the no-baked-secrets policy.
- Regenerated `worker-configuration.d.ts` via the repo `cf-typegen` flow so the local drift check stays green.

### Testing

- Ran `npx vitest run test/unit/miner-deployment-doc.test.ts` and the miner deployment unit tests passed.
- Ran `npm run test:miner-pack` and `npm run cf-typegen:check` and both checks completed successfully.
- Attempted the full local gate with `npm run test:ci` but the run timed out during unrelated, long `test/unit/queue.test.ts` sweep fan-out tests and did not complete; the `npm audit --audit-level=moderate` step also failed in this environment due to the registry returning `403 Forbidden`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a501e77ca5c832cb3a85d46d027257c)