### PR TITLE
fix(engine): keep soft-claim payload public-safe

### DIFF
--- a/packages/gittensory-engine/src/discovery-soft-claim.ts
+++ b/packages/gittensory-engine/src/discovery-soft-claim.ts
@@ -32,8 +32,7 @@ export type SoftClaimRecord = {
   note?: string | null;
 };
 
-/** Optional caller context. `instanceId` is an opaque, caller-anonymized fleet handle — NOT a wallet/hotkey or any
- *  identity secret; it is copied through verbatim and never interpreted here. */
+/** Optional caller context. Reserved for future public-safe, anonymized coordination metadata. */
 export type SoftClaimRequestContext = {
   instanceId?: string;
 };
@@ -73,7 +72,7 @@ function isSoftClaimStatus(value: unknown): value is SoftClaimStatus {
  * statuses map to a request). Only the fixed set of known fields is copied onto the request, so the payload stays
  * metadata-only by construction.
  */
-export function buildSoftClaimRequest(claim: unknown, context: SoftClaimRequestContext = {}): SoftClaimRequest | null {
+export function buildSoftClaimRequest(claim: unknown, _context: SoftClaimRequestContext = {}): SoftClaimRequest | null {
   if (!claim || typeof claim !== "object" || Array.isArray(claim)) return null;
   const record = claim as Record<string, unknown>;
   const repoFullName = normalizeRepoFullName(record.repoFullName);
@@ -82,15 +81,15 @@ export function buildSoftClaimRequest(claim: unknown, context: SoftClaimRequestC
   if (typeof issueNumber !== "number" || !Number.isInteger(issueNumber) || issueNumber <= 0) return null;
   if (typeof record.claimedAt !== "string" || record.claimedAt.trim() === "") return null;
   if (!isSoftClaimStatus(record.status)) return null;
-  const note = typeof record.note === "string" && record.note.trim() !== "" ? record.note : null;
-  const instanceId = typeof context.instanceId === "string" && context.instanceId.trim() !== "" ? context.instanceId : null;
   return {
     contractVersion: DISCOVERY_INDEX_CONTRACT_VERSION,
     action: softClaimActionForStatus(record.status),
     repoFullName,
     issueNumber,
     claimedAt: record.claimedAt,
-    note,
-    instanceId,
+    // Local claim-ledger notes and caller instance IDs may contain operator prose or private identifiers. The hosted
+    // discovery plane only receives fixed public metadata, so keep both fields empty.
+    note: null,
+    instanceId: null,
   };
 }

--- a/test/unit/discovery-soft-claim.test.ts
+++ b/test/unit/discovery-soft-claim.test.ts
@@ -20,7 +20,7 @@ describe("soft-claim coordination request builder (#4302)", () => {
     expect(typeof softClaimActionForStatus).toBe("function");
   });
 
-  it("builds a public-safe claim request from an active claim, copying only known fields", () => {
+  it("builds a public-safe claim request from an active claim, copying only fixed metadata", () => {
     const req = buildSoftClaimRequest(ACTIVE_CLAIM, { instanceId: "inst-abc" });
     expect(req).toEqual({
       contractVersion: DISCOVERY_INDEX_CONTRACT_VERSION,
@@ -28,10 +28,10 @@ describe("soft-claim coordination request builder (#4302)", () => {
       repoFullName: "owner/repo",
       issueNumber: 42,
       claimedAt: "2026-01-01T00:00:00Z",
-      note: "picked from the miner lane",
-      instanceId: "inst-abc",
+      note: null,
+      instanceId: null,
     });
-    // the local ledger `id` is not leaked into the outbound request
+    // Local-only ledger and caller context fields are not leaked into the outbound request.
     expect(Object.keys(req ?? {})).not.toContain("id");
   });
 
@@ -43,13 +43,16 @@ describe("soft-claim coordination request builder (#4302)", () => {
     expect(buildSoftClaimRequest({ ...ACTIVE_CLAIM, status: "expired" })?.action).toBe("release");
   });
 
-  it("normalizes note and instanceId to null when blank, non-string, or absent", () => {
-    expect(buildSoftClaimRequest({ ...ACTIVE_CLAIM, note: "   " })?.note).toBeNull();
-    expect(buildSoftClaimRequest({ ...ACTIVE_CLAIM, note: 5 })?.note).toBeNull();
-    expect(buildSoftClaimRequest({ ...ACTIVE_CLAIM, note: undefined })?.note).toBeNull();
-    expect(buildSoftClaimRequest(ACTIVE_CLAIM)?.instanceId).toBeNull();
-    expect(buildSoftClaimRequest(ACTIVE_CLAIM, { instanceId: "   " })?.instanceId).toBeNull();
-    expect(buildSoftClaimRequest(ACTIVE_CLAIM, { instanceId: 9 as unknown as string })?.instanceId).toBeNull();
+  it("omits local free-text notes and caller instance identifiers from the hosted-plane payload", () => {
+    const sensitiveClaim = {
+      ...ACTIVE_CLAIM,
+      note: "operator note: private coordination details for a local-only workflow",
+    };
+    const req = buildSoftClaimRequest(sensitiveClaim, {
+      instanceId: "host=builder-01 private local identifier",
+    });
+    expect(req?.note).toBeNull();
+    expect(req?.instanceId).toBeNull();
   });
 
   it("returns null for a non-object claim", () => {


### PR DESCRIPTION
### Motivation

- Prevent accidental leakage of local free-text notes and raw caller instance identifiers into the hosted discovery-plane payload by ensuring the soft-claim request stays public-safe and metadata-only.

### Description

- Stop copying `record.note` and `context.instanceId` verbatim into the outbound `SoftClaimRequest` and instead emit `note: null` and `instanceId: null` so local free text and caller identifiers never leave the instance (`packages/gittensory-engine/src/discovery-soft-claim.ts`).
- Mark the caller context as reserved for future anonymized metadata and ignore the incoming `instanceId` in the builder (`SoftClaimRequestContext` doc + `_context` param). 
- Update unit tests to assert the hosted-plane request omits local notes and instance identifiers and to reflect the new public-safe behavior (`test/unit/discovery-soft-claim.test.ts`).

### Testing

- Ran the targeted unit file: `npx vitest run test/unit/discovery-soft-claim.test.ts`, and the test suite passed (9/9 tests).
- Ran TypeScript typecheck: `npm run typecheck`, which succeeded with no errors.
- Ran the local CI orchestration `npm run test:ci`; it progressed but stopped at `cf-typegen:check` because the runner detected a generated runtime types drift (`worker-configuration.d.ts`) in this environment (warning noted), so the full gate was not completed here.
- Ran coverage: `npm run test:coverage` was started but interrupted by unrelated long-running/integration suites in this checkout; the regression/unit targets for the changed file were covered by the unit test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a501e798e98832c81d4ffb1cf5ab339)