### PR TITLE
fix(notifications): mark recaps after successful generation

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -2536,23 +2536,29 @@ export async function claimRegateFanoutSlot(env: Env, now: string, windowMs: num
   }
 }
 
-/** Atomic per-period dedup for the cross-repo maintainer recap digest (#2249): claim `periodKey` (the current
- *  UTC date, "YYYY-MM-DD") as the singleton's last-sent period. Mirrors {@link claimRegateFanoutSlot}: the
- *  conditional UPDATE matches only when the stored period is unset or DIFFERENT from `periodKey`, so a retried
- *  cron tick or a redelivered (at-least-once) queue message for the SAME period gets 0 changes and skips
- *  before any repo scan or Discord send. Fail-open on a driver error (return true → the digest still runs,
- *  degrading to the pre-dedup behaviour rather than silently going dark). */
-export async function claimMaintainerRecapPeriod(env: Env, periodKey: string): Promise<boolean> {
+/** Read the last successfully generated maintainer recap period (#2249). Fail-open on a driver error
+ *  (`null` → the digest still runs), matching the notification job's availability-first posture. */
+export async function getLastMaintainerRecapPeriodKey(env: Env): Promise<string | null> {
   try {
-    const result = await env.DB.prepare(
-      "UPDATE global_agent_controls SET last_recap_period_key = ?1 WHERE id = 'singleton' AND (last_recap_period_key IS NULL OR last_recap_period_key != ?1)",
-    )
+    const row = await env.DB.prepare("SELECT last_recap_period_key FROM global_agent_controls WHERE id = 'singleton'").first<{
+      last_recap_period_key: string | null;
+    }>();
+    return row?.last_recap_period_key ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** Mark a maintainer recap period as successfully generated only after the scan, delivery attempt, and
+ *  generated-audit ledger write have all completed. A failed marker write is fail-open: the next retry may
+ *  re-send, which is safer than suppressing a digest that may never have been delivered. */
+export async function markMaintainerRecapPeriodSent(env: Env, periodKey: string): Promise<void> {
+  try {
+    await env.DB.prepare("UPDATE global_agent_controls SET last_recap_period_key = ?1 WHERE id = 'singleton'")
       .bind(periodKey)
       .run();
-    /* v8 ignore next -- D1 update metadata normally includes changes; the ?? 0 fallback protects driver anomalies. */
-    return Number(result.meta.changes ?? 0) === 1;
   } catch {
-    return true;
+    // Fail open: do not fail a successfully generated digest solely because the dedup marker could not persist.
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -226,7 +226,7 @@ async function enqueueScheduledJobs(env: Env, controller: ScheduledController): 
   if (selfHostedReviews && isHourly) {
     const maintainerRecapOverride = await resolveMaintainerRecapManifestOverride(env);
     if (isRecapEnabled(env, maintainerRecapOverride) && shouldFireMaintainerRecap(env, hour, scheduledAt.getUTCDay(), maintainerRecapOverride)) {
-      jobs.push({ type: "generate-maintainer-recap", requestedBy: "schedule" });
+      jobs.push({ type: "generate-maintainer-recap", requestedBy: "schedule", scheduledPeriodKey: scheduledAt.toISOString().slice(0, 10) });
     }
   }
   if (isFullSyncWindow) {

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -1116,7 +1116,7 @@ export async function processJob(env: Env, message: JobMessage): Promise<void> {
       // override #2250). Defense-in-depth: the cron only ENQUEUES this when enabled, but a stale in-flight job
       // that lands after a flag-flip (env OR manifest) must still no-op, so disabled does zero work here too.
       const maintainerRecapOverride = await resolveMaintainerRecapManifestOverride(env);
-      if (isRecapEnabled(env, maintainerRecapOverride)) await runMaintainerRecapJob(env, message.windowDays, maintainerRecapOverride);
+      if (isRecapEnabled(env, maintainerRecapOverride)) await runMaintainerRecapJob(env, message.windowDays, maintainerRecapOverride, message.scheduledPeriodKey);
       return;
     }
     case "agent-regate-sweep":

--- a/src/review/maintainer-recap-wire.ts
+++ b/src/review/maintainer-recap-wire.ts
@@ -3,7 +3,7 @@
 // single-repo ReviewRecap job, which is manually-triggerable only (review-recap.ts). Flag-gated and OFF by
 // default, mirroring isOpsEnabled: flag-OFF, the cron enqueues no job and this module's exports are never
 // invoked, so the deploy is byte-identical to today.
-import { claimMaintainerRecapPeriod, listRepositories, recordAuditEvent } from "../db/repositories";
+import { getLastMaintainerRecapPeriodKey, listRepositories, markMaintainerRecapPeriodSent, recordAuditEvent } from "../db/repositories";
 import { isAgentConfigured } from "../settings/autonomy";
 import { resolveRepositorySettings } from "../settings/repository-settings";
 import { buildRepoOutcomeCalibration } from "../services/outcome-calibration";
@@ -151,10 +151,9 @@ export type MaintainerRecapJobSkipped = { skipped: true; reason: "already_sent_t
  * dual-channel (Discord + Slack) delivery. A per-repo aggregator failure is logged and that repo is skipped --
  * one repo's D1 hiccup must not blank the whole digest (mirrors ops-wire.ts's runOpsAlerts).
  *
- * Idempotent per UTC calendar date (#2249): claims the day via claimMaintainerRecapPeriod BEFORE doing any
- * repo scan or send, so a retried cron tick / redelivered (at-least-once) queue message for a period already
- * claimed short-circuits to `{ skipped: true, reason: "already_sent_this_period" }` without re-scanning repos
- * or re-delivering.
+ * Idempotent per scheduled UTC calendar date (#2249): the queue message carries the intended fire date, and
+ * only a successfully generated + audited digest advances the last-sent marker. A retried cron tick for an
+ * already completed period still short-circuits without re-scanning repos or re-delivering.
  *
  * Records a `maintainer_recap_generated` audit event once the report is built (#2251), mirroring
  * generateWeeklyValueReport's own audit call -- gives operators a ledger trail ("did the digest run today?")
@@ -165,10 +164,11 @@ export async function runMaintainerRecapJob(
   env: Env,
   windowDays?: number,
   manifestOverride?: MaintainerRecapManifestOverride | undefined,
+  scheduledPeriodKey?: string | undefined,
 ): Promise<MaintainerRecapJobSkipped | RunMaintainerRecapResult> {
-  const periodKey = computeRecapPeriodKey(new Date());
-  const claimed = await claimMaintainerRecapPeriod(env, periodKey);
-  if (!claimed) return { skipped: true, reason: "already_sent_this_period" };
+  const periodKey = scheduledPeriodKey ?? computeRecapPeriodKey(new Date());
+  const lastSentPeriodKey = await getLastMaintainerRecapPeriodKey(env);
+  if (lastSentPeriodKey === periodKey) return { skipped: true, reason: "already_sent_this_period" };
 
   const resolvedWindowDays = windowDays ?? DEFAULT_RECAP_WINDOW_DAYS;
   const repoNames = await recapScanRepos(env);
@@ -207,6 +207,7 @@ export async function runMaintainerRecapJob(
         channelsAttempted: [...RECAP_CHANNELS_ATTEMPTED],
       },
     });
+    await markMaintainerRecapPeriodSent(env, periodKey);
   }
   return result;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -165,6 +165,7 @@ export type JobMessage =
       type: "generate-maintainer-recap";
       requestedBy: "schedule" | "api" | "test";
       windowDays?: number;
+      scheduledPeriodKey?: string;
     }
   | {
       // Scheduled re-gate sweep (#777). No `repoFullName` = fan-out: enqueue one per agent-configured repo.

--- a/test/unit/db-parsers.test.ts
+++ b/test/unit/db-parsers.test.ts
@@ -1,7 +1,8 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
-  claimMaintainerRecapPeriod,
   claimRegateFanoutSlot,
+  getLastMaintainerRecapPeriodKey,
+  markMaintainerRecapPeriodSent,
   countRecentDeadLetters,
   countRecentDeadLettersByType,
   countRecentAuditEventsForActorAndTarget,
@@ -394,18 +395,20 @@ describe("database row parser hardening", () => {
     expect(await claimRegateFanoutSlot(broken, "2026-06-25T01:00:00.000Z", 90 * 1000)).toBe(true);
   });
 
-  it("claimMaintainerRecapPeriod: first claim for a period wins, a retry for the SAME period loses, a DIFFERENT period wins again (#2249)", async () => {
+  it("maintainer recap period marker records only completed periods and reads them back (#2249)", async () => {
     const env = createTestEnv();
-    expect(await claimMaintainerRecapPeriod(env, "2026-07-09")).toBe(true); // first claim (marker NULL)
-    expect(await claimMaintainerRecapPeriod(env, "2026-07-09")).toBe(false); // retried tick, same period → loses
-    expect(await claimMaintainerRecapPeriod(env, "2026-07-10")).toBe(true); // a new day → wins again
-    expect(await claimMaintainerRecapPeriod(env, "2026-07-10")).toBe(false); // retried again → loses
+    expect(await getLastMaintainerRecapPeriodKey(env)).toBeNull();
+    await markMaintainerRecapPeriodSent(env, "2026-07-09");
+    expect(await getLastMaintainerRecapPeriodKey(env)).toBe("2026-07-09");
+    await markMaintainerRecapPeriodSent(env, "2026-07-10");
+    expect(await getLastMaintainerRecapPeriodKey(env)).toBe("2026-07-10");
   });
 
-  it("claimMaintainerRecapPeriod fails open (returns true) on a DB error so the digest never silently stalls", async () => {
+  it("maintainer recap period marker fails open on DB errors so the digest never silently stalls", async () => {
     const env = createTestEnv();
     const broken = { ...env, DB: null } as unknown as typeof env;
-    expect(await claimMaintainerRecapPeriod(broken, "2026-07-09")).toBe(true);
+    expect(await getLastMaintainerRecapPeriodKey(broken)).toBeNull();
+    await expect(markMaintainerRecapPeriodSent(broken, "2026-07-09")).resolves.toBeUndefined();
   });
 
   it("REGRESSION: a later GitHub sync does NOT clobber last_regated_at (omitted from the upsert SET clause)", async () => {

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -839,7 +839,7 @@ describe("worker entrypoint", () => {
     expect((await sentFor("false")).some((m) => m.type === "generate-maintainer-recap")).toBe(false);
     // Flag ON, on the default weekly cadence tick → exactly one recap job.
     const on = await sentFor("true");
-    expect(on.filter((m) => m.type === "generate-maintainer-recap")).toEqual([{ type: "generate-maintainer-recap", requestedBy: "schedule" }]);
+    expect(on.filter((m) => m.type === "generate-maintainer-recap")).toEqual([{ type: "generate-maintainer-recap", requestedBy: "schedule", scheduledPeriodKey: "2026-06-01" }]);
   });
 
   it("does NOT enqueue the maintainer recap digest outside its configured cadence even when GITTENSORY_MAINTAINER_RECAP is ON", async () => {
@@ -872,7 +872,7 @@ describe("worker entrypoint", () => {
     const waitUntil: Promise<unknown>[] = [];
     await worker.scheduled(controllerFor("2026-06-02T14:00:00.000Z"), env, executionContext(waitUntil)); // Tuesday — not the weekly default day
     await Promise.all(waitUntil);
-    expect(sent.filter((m) => m.type === "generate-maintainer-recap")).toEqual([{ type: "generate-maintainer-recap", requestedBy: "schedule" }]);
+    expect(sent.filter((m) => m.type === "generate-maintainer-recap")).toEqual([{ type: "generate-maintainer-recap", requestedBy: "schedule", scheduledPeriodKey: "2026-06-02" }]);
   });
 });
 

--- a/test/unit/maintainer-recap-wire.test.ts
+++ b/test/unit/maintainer-recap-wire.test.ts
@@ -281,6 +281,25 @@ describe("runMaintainerRecapJob — cross-repo digest (#1963, #2248)", () => {
     vi.useRealTimers();
   });
 
+  it("REGRESSION: a failed repo scan does not mark an unsent period complete (#2249)", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-09T14:00:00.000Z"));
+    const env = createTestEnv({ DISCORD_WEBHOOK_URL: HOOK });
+    await seedRegisteredRepo(env, "owner/alpha");
+    await seedMergedPr(env, "owner/alpha", 1);
+    const posted = stubDiscordFetch();
+    const realDb = env.DB;
+    env.DB = null as unknown as typeof env.DB;
+
+    await expect(runMaintainerRecapJob(env)).rejects.toThrow();
+    env.DB = realDb;
+    const retry = ranRecap(await runMaintainerRecapJob(env));
+
+    expect(retry.delivery.discord).toEqual({ sent: true });
+    expect(posted).toHaveLength(1);
+    vi.useRealTimers();
+  });
+
   it("a tick on a DIFFERENT UTC date gets its own fresh claim and sends again (#2249)", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-07-09T14:00:00.000Z"));
@@ -296,6 +315,21 @@ describe("runMaintainerRecapJob — cross-repo digest (#1963, #2248)", () => {
     expect(first.delivery.discord).toEqual({ sent: true });
     expect(second.delivery.discord).toEqual({ sent: true });
     expect(posted).toHaveLength(2);
+    vi.useRealTimers();
+  });
+
+  it("uses the scheduled period key instead of processing time for delayed queue jobs (#2249)", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-07-10T00:05:00.000Z"));
+    const env = createTestEnv({ DISCORD_WEBHOOK_URL: HOOK });
+    stubDiscordFetch();
+
+    await runMaintainerRecapJob(env, undefined, undefined, "2026-07-09");
+
+    const row = await env.DB.prepare("select target_key from audit_events where event_type = ? order by created_at desc limit 1")
+      .bind("maintainer_recap_generated")
+      .first<{ target_key: string }>();
+    expect(row!.target_key).toBe("maintainer-recap:2026-07-09");
     vi.useRealTimers();
   });
 


### PR DESCRIPTION
### Motivation
- Prevent a transient failure during scan/generation/delivery from consuming the per-period dedup marker and suppressing legitimate retries.  
- Ensure delayed queue messages processed after midnight deduplicate against the intended scheduled UTC date rather than processing-time.  

### Description
- Replace the pre-scan conditional `claimMaintainerRecapPeriod` flow with a read-before/mark-after-success approach by adding `getLastMaintainerRecapPeriodKey` and `markMaintainerRecapPeriodSent` in `src/db/repositories.ts`.  
- Change `runMaintainerRecapJob` to consult `getLastMaintainerRecapPeriodKey` (skip if already completed) and to call `markMaintainerRecapPeriodSent` only after the report is generated and the `maintainer_recap_generated` audit event is recorded in `src/review/maintainer-recap-wire.ts`.  
- Thread a `scheduledPeriodKey` through the cron enqueue, job `JobMessage` type, and the queue processor so scheduled jobs carry the intended UTC date (`src/index.ts`, `src/types.ts`, `src/queue/processors.ts`).  
- Add and update unit tests to cover the completed-period marker, the regression where a failed scan must not mark the period complete, and the scheduled-period-key behavior (`test/unit/db-parsers.test.ts`, `test/unit/maintainer-recap-wire.test.ts`, `test/unit/index.test.ts`).  

### Testing
- Ran the focused unit suites with `npx vitest run test/unit/maintainer-recap-wire.test.ts test/unit/db-parsers.test.ts` and both suites passed.  
- Ran TypeScript checks with `npm run typecheck` which completed successfully.  
- Ran repository hygiene checks with `git diff --check` which passed locally.  
- Attempted a targeted `index` test invocation (`npx vitest run test/unit/index.test.ts -t "maintainer recap"`) which timed out in this environment's scheduled-worker harness.  
- `npm audit --audit-level=moderate` could not complete in this environment due to the registry audit endpoint returning `403 Forbidden`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a501e7950d8832c865081df7e8da872)