### PR TITLE
fix(miner): avoid unscoped run-state lookup

### DIFF
--- a/packages/gittensory-miner/lib/loop-closure.d.ts
+++ b/packages/gittensory-miner/lib/loop-closure.d.ts
@@ -1,5 +1,5 @@
 export interface LoopClosureEventLedger {
-  readEvents(filter?: { since?: number; repoFullName?: string }): Array<{ seq?: number; type?: unknown; repoFullName?: string }>;
+  readEvents(filter?: { since?: number; repoFullName?: string }): Array<{ seq?: number; type?: unknown; repoFullName?: string | null }>;
 }
 
 export interface LoopClosurePortfolioQueue {
@@ -7,7 +7,7 @@ export interface LoopClosurePortfolioQueue {
 }
 
 export interface LoopClosureRunState {
-  getRunState(repoFullName: string | null): string | null;
+  getRunState(repoFullName: string): string | null;
 }
 
 export interface LoopClosureSources {

--- a/packages/gittensory-miner/lib/loop-closure.js
+++ b/packages/gittensory-miner/lib/loop-closure.js
@@ -52,7 +52,9 @@ export function buildLoopClosureSummary(sources, options = {}) {
     byStatus[status] = (byStatus[status] ?? 0) + 1;
   }
 
-  const currentRunState = runState && typeof runState.getRunState === "function" ? runState.getRunState(repoFullName) : null;
+  const currentRunState = runState && typeof runState.getRunState === "function" && repoFullName !== null
+    ? runState.getRunState(repoFullName)
+    : null;
 
   return {
     sinceSeq,

--- a/test/unit/miner-loop-closure.test.ts
+++ b/test/unit/miner-loop-closure.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { initEventLedger } from "../../packages/gittensory-miner/lib/event-ledger.js";
 import { buildLoopClosureSummary } from "../../packages/gittensory-miner/lib/loop-closure.js";
+import { initPortfolioQueueStore } from "../../packages/gittensory-miner/lib/portfolio-queue.js";
+import { initRunStateStore } from "../../packages/gittensory-miner/lib/run-state.js";
 
 // A mock event ledger that honors the real `readEvents({ since, repoFullName })` cursor contract (strictly-greater
 // seq, optional repo filter), so the sinceSeq cycle boundary is exercised through the same shape as the SQLite one.
@@ -14,6 +20,19 @@ function mockEventLedger(events: Array<{ seq: number; type?: unknown; repoFullNa
   };
 }
 const mockQueue = (entries: Array<{ status?: unknown }>): { listQueue: () => typeof entries } => ({ listQueue: () => entries });
+const roots: string[] = [];
+
+function tempRoot(): string {
+  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-loop-closure-"));
+  roots.push(root);
+  return root;
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
 
 describe("buildLoopClosureSummary (#4282 loop-closure summary)", () => {
   it("rejects sources missing a usable event ledger or portfolio queue", () => {
@@ -75,11 +94,40 @@ describe("buildLoopClosureSummary (#4282 loop-closure summary)", () => {
     expect(summary.lastSeq).toBe(5); // the NaN-seq event never advances lastSeq
   });
 
+  it("does not ask the repo-scoped run-state store for an unscoped all-repo summary", () => {
+    const root = tempRoot();
+    const eventLedger = initEventLedger(join(root, "event-ledger.sqlite3"));
+    const portfolioQueue = initPortfolioQueueStore(join(root, "portfolio-queue.sqlite3"));
+    const runState = initRunStateStore(join(root, "run-state.sqlite3"));
+    try {
+      eventLedger.appendEvent({ type: "discovered_issue", repoFullName: "acme/widgets", payload: {} });
+      eventLedger.appendEvent({ type: "plan_built", repoFullName: "octo/tools", payload: {} });
+      portfolioQueue.enqueue({ repoFullName: "acme/widgets", identifier: "issue-1", priority: 1 });
+      portfolioQueue.enqueue({ repoFullName: "octo/tools", identifier: "issue-2", priority: 1 });
+      runState.setRunState("acme/widgets", "idle");
+
+      const summary = buildLoopClosureSummary({ eventLedger, portfolioQueue, runState });
+
+      expect(summary.events).toEqual({ total: 2, byType: { discovered_issue: 1, plan_built: 1 } });
+      expect(summary.queue).toEqual({ total: 2, byStatus: { queued: 2 } });
+      expect(summary.runState).toBeNull();
+    } finally {
+      eventLedger.close();
+      portfolioQueue.close();
+      runState.close();
+    }
+  });
+
   it("treats a run-state source that reports no state as null, and omits run-state entirely when not supplied", () => {
     const nullState = buildLoopClosureSummary({ eventLedger: mockEventLedger([]), portfolioQueue: mockQueue([]), runState: { getRunState: () => null } });
     expect(nullState.runState).toBeNull();
     const noSource = buildLoopClosureSummary({ eventLedger: mockEventLedger([]), portfolioQueue: mockQueue([]) });
     expect(noSource.runState).toBeNull();
+    const unusableSource = buildLoopClosureSummary(
+      { eventLedger: mockEventLedger([]), portfolioQueue: mockQueue([]), runState: {} as never },
+      { repoFullName: "acme/widgets" },
+    );
+    expect(unusableSource.runState).toBeNull();
   });
 
   it("is deterministic: same sources + options yield identical output", () => {


### PR DESCRIPTION
### Motivation
- Prevent a reliability crash when building an unscoped (all-repo) loop-closure summary that previously passed `null` into the repo-scoped run-state store and raised `invalid_repo_full_name`.

### Description
- Stop calling `runState.getRunState` when `options.repoFullName` is absent by guarding the call so unscoped summaries return `runState: null` instead of passing `null` into the store.
- Align TypeScript declarations: make event rows allow `repoFullName: string | null` and make `LoopClosureRunState.getRunState` accept a `string` (repo-scoped) parameter to match the real run-state API.
- Add a regression test that uses the real SQLite-backed `initEventLedger`, `initPortfolioQueueStore`, and `initRunStateStore` to verify an unscoped summary with a run-state source does not throw.
- Add temp-dir lifecycle/cleanup helpers in the test to avoid filesystem leakage when exercising the real stores.

### Testing
- Ran `npx vitest run test/unit/miner-loop-closure.test.ts` and the test file passed (8 tests).
- Ran `npm run build:miner` and `npm run typecheck`; both completed successfully.
- Attempted the full gate with `npm run test:ci`, which could not complete locally due to pre-existing generated-file drift reported by `cf-typegen:check` and an external `npm audit` endpoint failure; these blocked completing the full `test:ci` run locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a501e77c2f8832cbac4a2a6a187b5e7)