### PR TITLE
fix(github): allow self-host TRUSTED_SCANNER_BOT_LOGINS override

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -191,6 +191,12 @@ declare global {
     /** Comma-separated GitHub logins assigned to filed upstream-drift issues (default: the gittensory
      *  maintainer). Lets a self-host operator route drift issues to their own team. */
     GITTENSORY_DRIFT_ISSUE_ASSIGNEES?: string;
+    /** Comma-separated GitHub bot logins ADDITIONALLY trusted to author review-thread blockers via scanner
+     *  comments (src/github/backfill.ts isTrustedScannerReviewThreadAuthor), merged with the built-in baseline
+     *  (superagent[bot], superagent-security[bot], superagent-security-dev[bot], brin[bot]). Lets a self-host
+     *  operator running a different third-party scanner (CodeQL, Snyk, Semgrep, SonarCloud, DeepSource, etc.)
+     *  get the same review-thread trust as the built-in scanners (#4614). */
+    TRUSTED_SCANNER_BOT_LOGINS?: string;
     /** Self-host default Discord webhook URL — per-action notifications (merged/closed/manual) for any repo
      *  not in the built-in per-repo map. Lets a self-host operator wire one channel without a source edit. */
     DISCORD_WEBHOOK_URL?: string;

--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -3800,7 +3800,7 @@ async function isAuthorizedReviewThreadAuthor(
   association: string | null | undefined,
 ): Promise<boolean> {
   if (isOwnReviewThreadAuthor(login)) return false;
-  if (isTrustedScannerReviewThreadAuthor(login)) return true;
+  if (isTrustedScannerReviewThreadAuthor(env, login)) return true;
   if (isMaintainerReviewThreadAuthor(association)) return true;
   return isVerifiedMemberReviewThreadAuthor(env, repoFullName, token, memberPermissionCache, admissionKey, login, association);
 }
@@ -3843,10 +3843,23 @@ function isVerifiedMemberReviewThreadAuthor(
   return verified;
 }
 
-// External scanner GitHub App bot logins allowed to create review-thread blockers.
+// External scanner GitHub App bot logins allowed to create review-thread blockers -- built-in baseline. A
+// self-hoster running a different scanner (CodeQL, Snyk, Semgrep, SonarCloud, DeepSource, etc.) can trust it
+// too via TRUSTED_SCANNER_BOT_LOGINS (comma-separated logins), ADDITIVE to this baseline -- same shape as
+// resolveDriftAssignees in src/upstream/ruleset.ts -- instead of that scanner's comments silently falling
+// through every trust check and never blocking (#4614).
 const TRUSTED_SCANNER_REVIEW_THREAD_AUTHORS = new Set(["superagent[bot]", "superagent-security[bot]", "superagent-security-dev[bot]", "brin[bot]"]);
-function isTrustedScannerReviewThreadAuthor(login: string | null | undefined): boolean {
-  return typeof login === "string" && TRUSTED_SCANNER_REVIEW_THREAD_AUTHORS.has(login.toLowerCase());
+function isTrustedScannerReviewThreadAuthor(env: Env, login: string | null | undefined): boolean {
+  if (typeof login !== "string") return false;
+  const normalized = login.toLowerCase();
+  if (TRUSTED_SCANNER_REVIEW_THREAD_AUTHORS.has(normalized)) return true;
+  const raw = env.TRUSTED_SCANNER_BOT_LOGINS;
+  if (typeof raw !== "string" || !raw.trim()) return false;
+  return raw
+    .split(",")
+    .map((extra) => extra.trim().toLowerCase())
+    .filter((extra) => extra.length > 0)
+    .includes(normalized);
 }
 
 // Match only OUR OWN app bot login (a `gittensory` / `gittensory-orb[bot]` PREFIX), never a third-party slug

--- a/test/unit/backfill.test.ts
+++ b/test/unit/backfill.test.ts
@@ -5590,6 +5590,97 @@ describe("GitHub backfill", () => {
       expect(blockers.map((blocker) => blocker.path)).toEqual(["src/superagent.ts", "src/superagent-security.ts", "src/superagent-security-dev.ts", "src/brin.ts"]);
     });
 
+    it("trusts self-host-configured TRUSTED_SCANNER_BOT_LOGINS additively alongside the built-in defaults (#4614)", async () => {
+      // Whitespace + case variation + an empty entry between commas -- exercises the trim/lowercase/filter
+      // handling, not just a bare exact match.
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token", TRUSTED_SCANNER_BOT_LOGINS: " CodeQL[bot] ,,Snyk-Security[bot]" });
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        if (input.toString() !== "https://api.github.com/graphql") return new Response("not found", { status: 404 });
+        return Response.json({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewThreads: {
+                  nodes: [
+                    {
+                      isResolved: false,
+                      isOutdated: false,
+                      path: "src/codeql-finding.ts",
+                      line: 5,
+                      comments: { nodes: [{ body: "**P1:** Configured CodeQL blocker", author: { login: "codeql[bot]" }, authorAssociation: "NONE" }] },
+                    },
+                    {
+                      isResolved: false,
+                      isOutdated: false,
+                      path: "src/snyk-finding.ts",
+                      line: 15,
+                      comments: { nodes: [{ body: "**P1:** Configured Snyk blocker", author: { login: "snyk-security[bot]" }, authorAssociation: "NONE" }] },
+                    },
+                    {
+                      isResolved: false,
+                      isOutdated: false,
+                      path: "src/superagent-still-trusted.ts",
+                      line: 25,
+                      comments: { nodes: [{ body: "**P1:** Built-in default still trusted", author: { login: "superagent-security[bot]" }, authorAssociation: "NONE" }] },
+                    },
+                    {
+                      isResolved: false,
+                      isOutdated: false,
+                      path: "src/unconfigured-scanner.ts",
+                      line: 35,
+                      comments: { nodes: [{ body: "**P1:** Unconfigured scanner stays untrusted", author: { login: "semgrep[bot]" }, authorAssociation: "NONE" }] },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        });
+      });
+
+      const blockers = await fetchLiveReviewThreadBlockers(env, "JSONbored/gittensory", 1900, "public-token");
+
+      expect(blockers.map((blocker) => blocker.title)).toEqual(["Configured CodeQL blocker", "Configured Snyk blocker", "Built-in default still trusted"]);
+      expect(blockers.map((blocker) => blocker.authorLogin)).toEqual(["codeql[bot]", "snyk-security[bot]", "superagent-security[bot]"]);
+    });
+
+    it("ignores a whitespace-only TRUSTED_SCANNER_BOT_LOGINS override and keeps only the built-in defaults trusted", async () => {
+      const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token", TRUSTED_SCANNER_BOT_LOGINS: "   " });
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+        if (input.toString() !== "https://api.github.com/graphql") return new Response("not found", { status: 404 });
+        return Response.json({
+          data: {
+            repository: {
+              pullRequest: {
+                reviewThreads: {
+                  nodes: [
+                    {
+                      isResolved: false,
+                      isOutdated: false,
+                      path: "src/codeql-finding.ts",
+                      line: 5,
+                      comments: { nodes: [{ body: "**P1:** Not configured, must not block", author: { login: "codeql[bot]" }, authorAssociation: "NONE" }] },
+                    },
+                    {
+                      isResolved: false,
+                      isOutdated: false,
+                      path: "src/superagent-still-trusted.ts",
+                      line: 25,
+                      comments: { nodes: [{ body: "**P1:** Built-in default still trusted", author: { login: "superagent-security[bot]" }, authorAssociation: "NONE" }] },
+                    },
+                  ],
+                },
+              },
+            },
+          },
+        });
+      });
+
+      const blockers = await fetchLiveReviewThreadBlockers(env, "JSONbored/gittensory", 1901, "public-token");
+
+      expect(blockers.map((blocker) => blocker.authorLogin)).toEqual(["superagent-security[bot]"]);
+    });
+
     it("paginates review threads so blockers beyond the first page cannot hide", async () => {
       const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
       const queries: string[] = [];


### PR DESCRIPTION
## Summary

- `isTrustedScannerReviewThreadAuthor` (`src/github/backfill.ts`) only recognized four hardcoded scanner bot logins (`superagent[bot]`, `superagent-security[bot]`, `superagent-security-dev[bot]`, `brin[bot]`), so a self-hoster running a different third-party scanner (CodeQL, Snyk, Semgrep, SonarCloud, DeepSource, etc.) had that scanner's unresolved review-thread comments silently fall through every trust check and never create a `review_thread_unresolved` gate blocker.
- Adds an additive `TRUSTED_SCANNER_BOT_LOGINS` env var (comma-separated logins, merged with the built-in defaults — same shape as `resolveDriftAssignees` in `src/upstream/ruleset.ts`), so a self-hoster can trust their own scanner bot without a source edit while the four built-in defaults stay recognized unless the operator lists more.
- Checked `npm run selfhost:env-reference`: `src/github/backfill.ts` is not in the generator's `DEFAULT_SOURCE_ROOTS`, so no change was produced for this new env var — the generated doc's scope did not need updating for this change.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This is a backend-only, single-file change (`src/github/backfill.ts`) with no UI/MCP/workflow/dependency surface, so `ui:*`, `build:mcp`/`test:mcp-pack`, `test:workers`, `actionlint`, and `npm audit` were not run locally — CI covers them and none of these surfaces were touched. `test:coverage` was run scoped to `test/unit/backfill.test.ts` with coverage restricted to `src/github/backfill.ts` (not the full unsharded suite); the lcov output confirms 100% line and branch coverage on every line this PR changes (`src/github/backfill.ts:3800`, `3846-3865`).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/cookie/CORS/session surface touched; new tests cover the trust-check's negative paths: unconfigured scanner, whitespace-only override.)
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (No changelog edit; no visible-doc change required — see Summary note on `selfhost:env-reference`.)

## UI Evidence

N/A — backend-only change, no UI surface.

## Notes

- Fixes #4614
