### PR TITLE
fix(github): drive public repo-stats allowlist from env instead of a hardcoded repo

### DIFF
--- a/apps/gittensory-ui/public/openapi.json
+++ b/apps/gittensory-ui/public/openapi.json
@@ -13855,7 +13855,7 @@
         ],
         "responses": {
           "200": {
-            "description": "Public GitHub repository stars/forks for the website chrome; only JSONbored/gittensory is accepted.",
+            "description": "Public GitHub repository stars/forks for the website chrome; any syntactically-valid owner/repo is accepted unless the deployment configures PUBLIC_REPO_STATS_ALLOWLIST.",
             "content": {
               "application/json": {
                 "schema": {

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -173,6 +173,13 @@ declare global {
     GITTENSOR_UPSTREAM_REF?: string;
     GITTENSOR_REGISTRY_URL: string;
     GITHUB_PUBLIC_TOKEN?: string;
+    /** Public repo-stats endpoint (#4612): comma-separated allowlist of "owner/repo" pairs (case-insensitive)
+     *  permitted to query GET /v1/public/github/repos/:owner/:repo/stats. Default "" (unset) => allow any
+     *  syntactically-valid owner/repo -- this route proxies the live GitHub API rather than gittensory's own
+     *  installation DB, so (unlike the sibling badge.svg route) there is no "installed" gate to fall back on
+     *  instead. Set this to restrict a deployment to specific repos. Mirrors GITTENSORY_PUBLIC_STATS_REPOS's
+     *  comma-separated shape (src/review/public-stats.ts). See src/github/public.ts. */
+    PUBLIC_REPO_STATS_ALLOWLIST?: string;
     /** #703: owner-gated global to apply upstream sigmoid time-decay in score previews. Default off. */
     SCORING_TIME_DECAY_ENABLED?: string;
     /** #776 agent-layer GLOBAL kill-switch — when truthy, halts ALL agent actions across every repo. */

--- a/src/github/public.ts
+++ b/src/github/public.ts
@@ -51,8 +51,6 @@ type RepoStatsCacheEntry = {
   staleUntilMs: number;
 };
 
-const PUBLIC_REPO_STATS_OWNER = "jsonbored";
-const PUBLIC_REPO_STATS_REPO = "gittensory";
 const REPO_STATS_CACHE_TTL_MS = 1000 * 60 * 10;
 const REPO_STATS_STALE_TTL_MS = 1000 * 60 * 60 * 24;
 const repoStatsCache = new Map<string, RepoStatsCacheEntry>();
@@ -122,8 +120,12 @@ export async function fetchPublicContributorProfile(login: string, env?: Pick<En
   }
 }
 
-export async function fetchPublicRepoStats(env: Pick<Env, "GITHUB_PUBLIC_TOKEN">, owner: string, repo: string): Promise<PublicRepoStats> {
-  const repoFullName = publicRepoFullName(owner, repo);
+export async function fetchPublicRepoStats(
+  env: Pick<Env, "GITHUB_PUBLIC_TOKEN" | "PUBLIC_REPO_STATS_ALLOWLIST">,
+  owner: string,
+  repo: string,
+): Promise<PublicRepoStats> {
+  const repoFullName = publicRepoFullName(env, owner, repo);
   const cacheKey = repoFullName.toLowerCase();
   const nowMs = Date.now();
   const cached = repoStatsCache.get(cacheKey);
@@ -143,15 +145,30 @@ export function clearPublicRepoStatsCacheForTests(): void {
   repoStatsCache.clear();
 }
 
-function publicRepoFullName(owner: string, repo: string): string {
+// Parses PUBLIC_REPO_STATS_ALLOWLIST into a lowercased "owner/repo" set, mirroring publicStatsProjects's
+// comma-separated parsing in src/review/public-stats.ts. Empty/unset -> empty set -> no allowlist restriction
+// (#4612): a self-hosted fork's own repo works out of the box, with no code change, exactly like the sibling
+// badge.svg route already does for any installed repo.
+function publicRepoStatsAllowlist(env: Pick<Env, "PUBLIC_REPO_STATS_ALLOWLIST">): Set<string> {
+  const allowlist = new Set<string>();
+  for (const entry of (env.PUBLIC_REPO_STATS_ALLOWLIST ?? "").split(",")) {
+    const project = entry.trim().toLowerCase();
+    if (project) allowlist.add(project);
+  }
+  return allowlist;
+}
+
+function publicRepoFullName(env: Pick<Env, "PUBLIC_REPO_STATS_ALLOWLIST">, owner: string, repo: string): string {
   const ownerName = owner.trim();
   const repoName = repo.trim();
   if (!/^[A-Za-z0-9][A-Za-z0-9-]{0,38}$/.test(ownerName)) throw new Error("invalid_github_repo");
   if (!/^[A-Za-z0-9._-]{1,100}$/.test(repoName) || repoName === "." || repoName === "..") throw new Error("invalid_github_repo");
   const normalizedOwnerName = ownerName.toLowerCase();
   const normalizedRepoName = repoName.toLowerCase();
-  if (normalizedOwnerName !== PUBLIC_REPO_STATS_OWNER || normalizedRepoName !== PUBLIC_REPO_STATS_REPO) throw new Error("invalid_github_repo");
-  return `${normalizedOwnerName}/${normalizedRepoName}`;
+  const normalizedFullName = `${normalizedOwnerName}/${normalizedRepoName}`;
+  const allowlist = publicRepoStatsAllowlist(env);
+  if (allowlist.size > 0 && !allowlist.has(normalizedFullName)) throw new Error("invalid_github_repo");
+  return normalizedFullName;
 }
 
 async function fetchRepoStatsFromGitHub(env: Pick<Env, "GITHUB_PUBLIC_TOKEN">, repoFullName: string, nowMs: number): Promise<PublicRepoStats> {

--- a/src/openapi/spec.ts
+++ b/src/openapi/spec.ts
@@ -185,7 +185,7 @@ export function buildOpenApiSpec() {
     path: "/v1/public/github/repos/{owner}/{repo}/stats",
     request: { params: z.object({ owner: z.string(), repo: z.string() }) },
     responses: {
-      200: { description: "Public GitHub repository stars/forks for the website chrome; only JSONbored/gittensory is accepted.", content: { "application/json": { schema: PublicRepoStatsSchema } } },
+      200: { description: "Public GitHub repository stars/forks for the website chrome; any syntactically-valid owner/repo is accepted unless the deployment configures PUBLIC_REPO_STATS_ALLOWLIST.", content: { "application/json": { schema: PublicRepoStatsSchema } } },
       400: { description: "Invalid or non-allowlisted GitHub repository" },
       503: { description: "GitHub repository stats are unavailable" },
     },

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -155,6 +155,54 @@ describe("api routes", () => {
     expect(calls).toHaveLength(1);
   });
 
+  it("serves public GitHub repo stats for any repo when PUBLIC_REPO_STATS_ALLOWLIST is unset (#4612)", async () => {
+    const app = createApp();
+    // No PUBLIC_REPO_STATS_ALLOWLIST override: a self-hoster's own fork must work without code changes.
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
+    const calls: string[] = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      calls.push(input.toString());
+      return Response.json({ full_name: "acme/widgets", html_url: "https://github.com/acme/widgets", stargazers_count: 5, forks_count: 1 });
+    });
+
+    const response = await app.request("/v1/public/github/repos/acme/widgets/stats", {}, env);
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      repoFullName: "acme/widgets",
+      htmlUrl: "https://github.com/acme/widgets",
+      stargazers_count: 5,
+      forks_count: 1,
+      source: "github",
+      stale: false,
+    });
+    expect(calls).toEqual(["https://api.github.com/repos/acme/widgets"]);
+  });
+
+  it("rejects public GitHub repo stats for repos outside a configured PUBLIC_REPO_STATS_ALLOWLIST, tolerating whitespace/casing/empty entries (#4612)", async () => {
+    const app = createApp();
+    const env = createTestEnv({
+      GITHUB_PUBLIC_TOKEN: "public-token",
+      PUBLIC_REPO_STATS_ALLOWLIST: " JSONbored/gittensory , Acme/Widgets ,,",
+    });
+    const calls: string[] = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      calls.push(input.toString());
+      return Response.json({ stargazers_count: 9, forks_count: 2 });
+    });
+
+    // A listed repo (with mismatched casing, exercising the trim + lowercase parsing) is served.
+    const allowed = await app.request("/v1/public/github/repos/ACME/WIDGETS/stats", {}, env);
+    expect(allowed.status).toBe(200);
+    await expect(allowed.json()).resolves.toMatchObject({ stargazers_count: 9, forks_count: 2, source: "github" });
+    expect(calls).toEqual(["https://api.github.com/repos/acme/widgets"]);
+
+    // A repo absent from the allowlist is rejected before ever calling GitHub.
+    const rejected = await app.request("/v1/public/github/repos/Attacker/missing-one/stats", {}, env);
+    expect(rejected.status).toBe(400);
+    await expect(rejected.json()).resolves.toMatchObject({ error: "invalid_github_repo" });
+    expect(calls).toHaveLength(1);
+  });
+
   it("normalizes allowlisted public GitHub repo stats casing before fetching and caching", async () => {
     const app = createApp();
     const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
@@ -403,18 +451,6 @@ describe("api routes", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const response = await app.request("/v1/public/github/repos/-bad/gittensory/stats", {}, env);
-    expect(response.status).toBe(400);
-    await expect(response.json()).resolves.toMatchObject({ error: "invalid_github_repo" });
-    expect(fetchMock).not.toHaveBeenCalled();
-  });
-
-  it("rejects non-allowlisted public GitHub repo stats paths before calling GitHub", async () => {
-    const app = createApp();
-    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
-    const fetchMock = vi.fn();
-    vi.stubGlobal("fetch", fetchMock);
-
-    const response = await app.request("/v1/public/github/repos/Attacker/missing-one/stats", {}, env);
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toMatchObject({ error: "invalid_github_repo" });
     expect(fetchMock).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

- `GET /v1/public/github/repos/:owner/:repo/stats` looked like a generic, per-repo route but hard-rejected every repo except a literal `jsonbored/gittensory` via two hardcoded constants (`PUBLIC_REPO_STATS_OWNER`/`PUBLIC_REPO_STATS_REPO`). A self-hoster's own fork got a hard 400 `invalid_github_repo` on their own repo.
- Replaces the constants with `PUBLIC_REPO_STATS_ALLOWLIST`, a comma-separated `owner/repo` allowlist env var mirroring `GITTENSORY_PUBLIC_STATS_REPOS`'s parsing shape in `src/review/public-stats.ts`. Empty/unset allows any syntactically-valid `owner/repo` (matching the sibling `badge.svg` route's any-repo behavior); setting it restricts the endpoint to specific repos.
- Also updates the stale OpenAPI response description that claimed "only JSONbored/gittensory is accepted" and regenerates `apps/gittensory-ui/public/openapi.json` accordingly.

Closes #4612

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran `npx vitest run test/integration/api.test.ts test/unit/openapi.test.ts test/unit/auth.test.ts --coverage` scoped to the changed source files (`src/github/public.ts`, `src/openapi/spec.ts`) instead of the full unsharded `test:coverage`; every changed line/branch in the diff shows nonzero hit counts on both sides. `actionlint`/`test:workers`/`build:mcp`/`test:mcp-pack`/`ui:lint`/`ui:typecheck`/`ui:build` are untouched by this change (no workflow, worker-pool, MCP, or UI source files changed) and are left to CI.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — backend-only change, no visible UI surface touched.

## Notes

- Default behavior for JSONbored's own production call (`/v1/public/github/repos/JSONbored/gittensory/stats`) is unchanged: it is covered by the "allow any" default (no `PUBLIC_REPO_STATS_ALLOWLIST` set), and existing tests for that repo still pass unmodified.
- One pre-existing test (`rejects non-allowlisted public GitHub repo stats paths before calling GitHub`) asserted the old hardcoded-repo behavior with no allowlist configured; it is replaced by two tests that cover the new semantics explicitly: allow-any-when-unset, and reject-when-configured (including allowlist parsing of whitespace/casing/empty entries).
