### PR TITLE
fix(selfhost): .gitignore *.local pattern doesn't match docker-compose.local-*.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,11 @@ output/
 docker-compose.override.yml
 !docker-compose.override.yml.example
 *.local
+# A second local-override naming shape beyond bare `*.local` (e.g. alertmanager.local): a host-specific
+# compose override named docker-compose.local-<label>.yml (label distinguishes multiple such overrides
+# on one operator, e.g. local-gpu) -- *.local alone does not match this since `.local` sits mid-name,
+# not as the literal filename suffix. #4664
+docker-compose.local-*.yml
 # Alertmanager receiver webhook files used by self-host local configs.
 alertmanager/*_url
 alertmanager/*_url_file

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-operations.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-operations.tsx
@@ -963,11 +963,11 @@ GITTENSORY_IMAGE=ghcr.io/jsonbored/gittensory-selfhost@sha256:... ./scripts/depl
       <p>
         None of this touches operator-owned state: <code>.env</code>, the{" "}
         <code>gittensory-config/</code> mount, <code>.deploy-backups/</code>, any{" "}
-        <code>*.local</code> compose override or Alertmanager file, and every named data volume are
-        already gitignored or outside the source tree entirely, so a fetch-and-rebuild never touches
-        them. See the <Link to="/docs/self-hosting-quickstart">Quickstart</Link> for the initial
-        clone; this script assumes that checkout already exists and already tracks{" "}
-        <code>origin/main</code>.
+        <code>*.local</code> or <code>docker-compose.local-*.yml</code> compose override, or
+        Alertmanager file, and every named data volume are already gitignored or outside the source
+        tree entirely, so a fetch-and-rebuild never touches them. See the{" "}
+        <Link to="/docs/self-hosting-quickstart">Quickstart</Link> for the initial clone; this
+        script assumes that checkout already exists and already tracks <code>origin/main</code>.
       </p>
       <CodeBlock
         lang="bash"

--- a/scripts/selfhost-update.sh
+++ b/scripts/selfhost-update.sh
@@ -13,7 +13,7 @@
 #   - .env and any *_FILE secret mounts
 #   - gittensory-config/ (private per-repo .gittensory.yml policy)
 #   - .deploy-backups/ (operator deploy-backup snapshots)
-#   - any *.local compose override or alertmanager config files
+#   - any *.local or docker-compose.local-*.yml compose override, or alertmanager config files
 #   - named data volumes (gittensory-data, gittensory-pg, qdrant-data, gittensory-backups,
 #     grafana-data) -- untouched because this script only fetches source and rebuilds the
 #     gittensory app image; it never runs `docker volume` commands or touches compose profiles.

--- a/test/unit/docs-selfhost-git-deploy-hygiene.test.ts
+++ b/test/unit/docs-selfhost-git-deploy-hygiene.test.ts
@@ -48,6 +48,23 @@ describe("self-host git-deploy hygiene (#1660)", () => {
     expect(shadowed).toEqual([]);
   });
 
+  it("catches a docker-compose.local-*.yml host override even though bare *.local does not match it (#4664)", () => {
+    // Regression: *.local only matches a filename literally ENDING in .local (e.g. the documented
+    // alertmanager.local convention) -- it does NOT match docker-compose.local-gpu.yml, where
+    // .local- sits mid-name before a -gpu.yml suffix. Found live on a self-host box: a genuine
+    // local-only GPU compose override showed up as untracked, blocking selfhost-update.sh's
+    // clean-tree check. Assert the broader pattern exists, matches that exact real-world shape, and
+    // -- mirroring the shadow check above -- doesn't hide any file this repo actually tracks.
+    expect(gitignore).toContain("docker-compose.local-*.yml");
+    const result = spawnSync("git", ["check-ignore", "--quiet", "docker-compose.local-gpu.yml"]);
+    expect(result.status).toBe(0); // exit 0 = git confirms this path would be ignored
+    const tracked = spawnSync("git", ["ls-files"], { encoding: "utf8" });
+    expect(tracked.status).toBe(0);
+    const localComposeGlob = /(^|\/)docker-compose\.local-[^/]*\.yml$/;
+    const shadowed = tracked.stdout.split("\n").filter(Boolean).filter((path) => localComposeGlob.test(path));
+    expect(shadowed).toEqual([]);
+  });
+
   it("wraps fetch, fast-forward-only merge, rebuild, and the post-update check", () => {
     expect(updateScript).toContain("#!/usr/bin/env bash");
     expect(updateScript).toContain("set -euo pipefail");
@@ -89,5 +106,6 @@ describe("self-host git-deploy hygiene (#1660)", () => {
     expect(operations).toContain("gittensory-config/");
     expect(operations).toContain(".deploy-backups/");
     expect(operations).toContain("*.local");
+    expect(operations).toContain("docker-compose.local-*.yml");
   });
 });


### PR DESCRIPTION
## Summary

- \`.gitignore\`'s \`*.local\` only matches a filename literally *ending* in \`.local\` (the documented \`alertmanager/alertmanager.local\` convention). It does not match a host-specific compose override named like \`docker-compose.local-gpu.yml\`, where \`.local-\` sits mid-name before a \`-gpu.yml\` suffix — a different, but equally legitimate, naming shape for the same "local, gitignored, operator-specific override" concept.
- Found live on a self-host box: a genuine local-only GPU compose override (own header: "NOT committed to the repo") showed up as untracked in \`git status\`, which blocks \`scripts/selfhost-update.sh\`'s clean-tree check (it refuses to run on a dirty tree).
- Adds \`docker-compose.local-*.yml\` to \`.gitignore\` — covers this naming shape generally (any \`-<label>\` suffix, not just the one observed \`-gpu\` file) without broadening beyond docker-compose override files specifically.
- Extends the existing \`test/unit/docs-selfhost-git-deploy-hygiene.test.ts\` drift-guard suite (already keeps \`.gitignore\` ↔ \`selfhost-update.sh\` ↔ the operations docs in sync for the git-backed self-host update flow) with a new case: asserts the pattern exists, asserts \`git check-ignore\` actually confirms the real-world filename shape is ignored, and — mirroring the suite's own existing shadow-check for the backup-file patterns — asserts it doesn't hide any file this repo actually tracks.
- Updates the two docs/comments that described "\`*.local\` compose override" as the complete story (\`scripts/selfhost-update.sh\`'s header, \`docs.self-hosting-operations.tsx\`'s prose) so they don't go stale relative to the broadened pattern.

Fixes #4664

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] No `src/**` lines changed — `.gitignore`, a shell-script comment, one docs `.tsx` prose edit, and a test file are all Codecov-exempt (`test/**` and non-`src/**` paths aren't measured by `codecov/patch`); ran the new/existing test coverage directly instead (`test/unit/docs-selfhost-git-deploy-hygiene.test.ts`, 9/9 passing, including a `git check-ignore` + tracked-file-shadow check against the real pattern).
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New/changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

Full `npm run test:ci` green from a freshly rebased `origin/main`: 13,552 tests passed, 0 failed.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no such change.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API change.)
- [ ] Visible UI changes include a `UI Evidence` section — the only UI-adjacent change is a two-clause prose edit on an existing docs page (no new component/layout), verified via `ui:build`/`ui:typecheck`/`ui:lint` passing; not a visual/layout change warranting screenshots.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.