### PR TITLE
refactor(review-enrichment): dedupe githubHeaders() across 17 analyzers

### DIFF
--- a/review-enrichment/src/analyzers/approval-integrity.ts
+++ b/review-enrichment/src/analyzers/approval-integrity.ts
@@ -14,6 +14,7 @@ import type {
 } from "../types.js";
 import type { AnalysisContext } from "../analysis-context.js";
 import { boundedFetchJson } from "../external-fetch.js";
+import { githubHeaders } from "../github-headers.js";
 
 const GITHUB_API = "https://api.github.com";
 const SLUG_RE = /^[A-Za-z0-9._-]+$/;
@@ -44,14 +45,6 @@ interface LatestReview {
   state: string;
   commitId: string | undefined;
   submittedAt: string;
-}
-
-function githubHeaders(token: string): Record<string, string> {
-  return {
-    Authorization: `Bearer ${token}`,
-    Accept: "application/vnd.github+json",
-    "X-GitHub-Api-Version": "2022-11-28",
-  };
 }
 
 async function fetchReviewsPage(

--- a/review-enrichment/src/analyzers/asset-weight.ts
+++ b/review-enrichment/src/analyzers/asset-weight.ts
@@ -12,13 +12,13 @@ import type {
 } from "../types.js";
 import type { AnalysisContext } from "../analysis-context.js";
 import { boundedFetchJson } from "../external-fetch.js";
+import { githubHeaders } from "../github-headers.js";
 import { isBinaryFileExtension } from "./binary-extensions.js";
 
 const MAX_FINDINGS = 50; // keep the brief bounded after evaluating every changed binary candidate
 const MAX_PATH_SIZE_LOOKUPS = 50; // fallback Contents API calls when a recursive tree is truncated
 const THRESHOLD_BYTES = 100 * 1024; // flag a newly-added blob >= 100 KB, or growth >= 100 KB
 const GITHUB_API = "https://api.github.com";
-const GITHUB_API_VERSION = "2022-11-28";
 
 interface ScanOptions {
   signal?: AbortSignal;
@@ -46,15 +46,6 @@ export function basePathForGrowth(file: EnrichFile): string | null {
   if (file.status === "modified" || file.status === "changed") return file.path;
   if (file.status === "renamed") return file.previousPath || null;
   return null;
-}
-
-function githubHeaders(token: string): Record<string, string> {
-  return {
-    Authorization: `Bearer ${token}`,
-    Accept: "application/vnd.github+json",
-    "X-GitHub-Api-Version": GITHUB_API_VERSION,
-    "User-Agent": "gittensory-review-enrichment",
-  };
 }
 
 /** Percent-encode each segment of a repo path for a Contents API URL, rejecting (null) an empty path or any

--- a/review-enrichment/src/analyzers/blame-link.ts
+++ b/review-enrichment/src/analyzers/blame-link.ts
@@ -12,6 +12,7 @@ import type {
 } from "../types.js";
 import type { AnalysisContext } from "../analysis-context.js";
 import { boundedFetchJson } from "../external-fetch.js";
+import { githubHeaders } from "../github-headers.js";
 import { isHistoryUninformativePath } from "./history-path.js";
 
 const GITHUB_API = "https://api.github.com";
@@ -60,14 +61,6 @@ export function firstTouchedOldLine(patch: string): number | null {
     // Everything else (additions, `\`/`+` markers, malformed text) is not an old-file line: do not advance.
   }
   return null;
-}
-
-function githubHeaders(token: string): Record<string, string> {
-  return {
-    Authorization: `Bearer ${token}`,
-    Accept: "application/vnd.github+json",
-    "X-GitHub-Api-Version": "2022-11-28",
-  };
 }
 
 async function fetchGithubJson<T>(

--- a/review-enrichment/src/analyzers/caller-impact.ts
+++ b/review-enrichment/src/analyzers/caller-impact.ts
@@ -27,12 +27,12 @@ import type {
 } from "../types.js";
 import type { AnalysisContext } from "../analysis-context.js";
 import { boundedFetchJson } from "../external-fetch.js";
+import { githubHeaders } from "../github-headers.js";
 import { exportedNames, isPublicEntrypoint } from "./api-break.js";
 import { isTestPath } from "./test-ratio.js";
 import { DEFAULT_MAX_FINDINGS } from "./limits.js";
 
 const GITHUB_API = "https://api.github.com";
-const GITHUB_API_VERSION = "2022-11-28";
 const SLUG_RE = /^[A-Za-z0-9._-]+$/;
 const MAX_SYMBOLS = 6; // removed symbols searched per PR (Code Search rate budget)
 const MAX_SEARCHES = 6; // bounded Code Search queries per PR
@@ -67,15 +67,6 @@ interface RemovedExport {
   file: string;
   symbol: string;
   line: number;
-}
-
-function githubHeaders(token: string, raw = false): Record<string, string> {
-  return {
-    Authorization: `Bearer ${token}`,
-    Accept: raw ? "application/vnd.github.raw" : "application/vnd.github+json",
-    "X-GitHub-Api-Version": GITHUB_API_VERSION,
-    "User-Agent": "gittensory-review-enrichment",
-  };
 }
 
 function escapeRegExp(value: string): string {
@@ -287,7 +278,7 @@ async function fetchFileAtHead(
     const encoded = path.split("/").map(encodeURIComponent).join("/");
     const resp = await fetchImpl(
       `${GITHUB_API}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/contents/${encoded}?ref=${encodeURIComponent(headSha)}`,
-      { headers: githubHeaders(token, true), signal },
+      { headers: githubHeaders(token, { raw: true }), signal },
     );
     if (!resp.ok) return null;
     return await readBoundedText(resp, signal);

--- a/review-enrichment/src/analyzers/churn-hotspot.ts
+++ b/review-enrichment/src/analyzers/churn-hotspot.ts
@@ -11,6 +11,7 @@ import type {
 } from "../types.js";
 import type { AnalysisContext } from "../analysis-context.js";
 import { boundedFetchJson } from "../external-fetch.js";
+import { githubHeaders } from "../github-headers.js";
 import { isHistoryUninformativePath } from "./history-path.js";
 
 const GITHUB_API = "https://api.github.com";
@@ -55,14 +56,6 @@ export function summarizeChurn(commits: CommitItem[]): {
 /** True when a file's churn summary meets the hotspot thresholds (enough commits AND enough of them fixes). Pure. */
 export function isHotspot(summary: { commitCount: number; fixFraction: number }): boolean {
   return summary.commitCount >= MIN_COMMITS && summary.fixFraction >= MIN_FIX_FRACTION;
-}
-
-function githubHeaders(token: string): Record<string, string> {
-  return {
-    Authorization: `Bearer ${token}`,
-    Accept: "application/vnd.github+json",
-    "X-GitHub-Api-Version": "2022-11-28",
-  };
 }
 
 /** Fetch one page of commits touching `path` since `since`. Returns the list, or null on any error / non-200. */

--- a/review-enrichment/src/analyzers/commit-hygiene.ts
+++ b/review-enrichment/src/analyzers/commit-hygiene.ts
@@ -16,6 +16,7 @@ import type {
 } from "../types.js";
 import type { AnalysisContext } from "../analysis-context.js";
 import { boundedFetchJson } from "../external-fetch.js";
+import { githubHeaders } from "../github-headers.js";
 import { DEFAULT_MAX_FINDINGS } from "./limits.js";
 
 const GITHUB_API = "https://api.github.com";
@@ -41,14 +42,6 @@ interface CommitListItem {
   sha?: string;
   commit?: { message?: string };
   parents?: Array<{ sha?: string }>;
-}
-
-function githubHeaders(token: string): Record<string, string> {
-  return {
-    Authorization: `Bearer ${token}`,
-    Accept: "application/vnd.github+json",
-    "X-GitHub-Api-Version": "2022-11-28",
-  };
 }
 
 async function fetchPrCommits(

--- a/review-enrichment/src/analyzers/commit-lint.ts
+++ b/review-enrichment/src/analyzers/commit-lint.ts
@@ -12,6 +12,7 @@ import type {
 } from "../types.js";
 import type { AnalysisContext } from "../analysis-context.js";
 import { boundedFetchJson } from "../external-fetch.js";
+import { githubHeaders } from "../github-headers.js";
 import { DEFAULT_MAX_FINDINGS } from "./limits.js";
 
 const GITHUB_API = "https://api.github.com";
@@ -51,14 +52,6 @@ interface ScanOptions {
 interface CommitListItem {
   sha?: string;
   commit?: { message?: string };
-}
-
-function githubHeaders(token: string): Record<string, string> {
-  return {
-    Authorization: `Bearer ${token}`,
-    Accept: "application/vnd.github+json",
-    "X-GitHub-Api-Version": "2022-11-28",
-  };
 }
 
 async function fetchPrCommits(

--- a/review-enrichment/src/analyzers/commit-signature.ts
+++ b/review-enrichment/src/analyzers/commit-signature.ts
@@ -11,6 +11,7 @@ import type {
 } from "../types.js";
 import type { AnalysisContext } from "../analysis-context.js";
 import { boundedFetchJson } from "../external-fetch.js";
+import { githubHeaders } from "../github-headers.js";
 
 const GITHUB_API = "https://api.github.com";
 // Pull a bounded slice of recent commits — enough to decide "has any verified history" without paging the whole
@@ -39,14 +40,6 @@ interface CommitResponse {
 
 interface HistoryCommit {
   commit?: { verification?: { verified?: boolean } };
-}
-
-function githubHeaders(token: string): Record<string, string> {
-  return {
-    Authorization: `Bearer ${token}`,
-    Accept: "application/vnd.github+json",
-    "X-GitHub-Api-Version": "2022-11-28",
-  };
 }
 
 async function fetchGithubJson<T>(

--- a/review-enrichment/src/analyzers/coverage-delta.ts
+++ b/review-enrichment/src/analyzers/coverage-delta.ts
@@ -15,6 +15,7 @@ import type {
 } from "../types.js";
 import type { AnalysisContext } from "../analysis-context.js";
 import { boundedFetchJson } from "../external-fetch.js";
+import { githubHeaders } from "../github-headers.js";
 
 const GITHUB_API = "https://api.github.com";
 const SLUG_RE = /^[A-Za-z0-9._-]+$/;
@@ -244,14 +245,6 @@ export function pathMatches(coveragePath: string, prFile: string): boolean {
   const c = coveragePath.replace(/\\/g, "/");
   const p = prFile.replace(/\\/g, "/");
   return c === p || c.endsWith(`/${p}`);
-}
-
-function githubHeaders(token: string): Record<string, string> {
-  return {
-    Authorization: `Bearer ${token}`,
-    Accept: "application/vnd.github+json",
-    "X-GitHub-Api-Version": "2022-11-28",
-  };
 }
 
 /** Fetch + parse JSON with the shared bounded-fetch guard rails; returns the parsed body or null on any

--- a/review-enrichment/src/analyzers/duplication-scan.ts
+++ b/review-enrichment/src/analyzers/duplication-scan.ts
@@ -15,10 +15,10 @@ import type {
 } from "../types.js";
 import type { AnalysisContext } from "../analysis-context.js";
 import { boundedFetchJson } from "../external-fetch.js";
+import { githubHeaders } from "../github-headers.js";
 import { DEFAULT_MAX_FINDINGS } from "./limits.js";
 
 const GITHUB_API = "https://api.github.com";
-const GITHUB_API_VERSION = "2022-11-28";
 
 const MIN_RUN = 8; // a contiguous run of >= this many significant normalized lines is required to flag a duplicate
 const MAX_CANDIDATES = 40; // cap candidate files (closest-by-path first) we consider per scan
@@ -46,15 +46,6 @@ interface ScanOptions {
   signal?: AbortSignal;
   analysis?: Pick<AnalysisContext, "fetchJson">;
   diagnostics?: AnalyzerDiagnostics;
-}
-
-function githubHeaders(token: string): Record<string, string> {
-  return {
-    Authorization: `Bearer ${token}`,
-    Accept: "application/vnd.github+json",
-    "X-GitHub-Api-Version": GITHUB_API_VERSION,
-    "User-Agent": "gittensory-review-enrichment",
-  };
 }
 
 /** Parse `owner/repo`, rejecting anything that isn't exactly two safe segments (no traversal, no extra slashes) so a

--- a/review-enrichment/src/analyzers/exhaustiveness-drift.ts
+++ b/review-enrichment/src/analyzers/exhaustiveness-drift.ts
@@ -4,6 +4,7 @@
 // pre-PR member set, and only reports high-confidence misses (explicit enum/union cases, no default branch). Bounded
 // file-fetch caps; fail-safe on missing token/headSha, bad slug, or fetch errors.
 import type { EnrichRequest, ExhaustivenessFinding } from "../types.js";
+import { githubHeaders } from "../github-headers.js";
 import { reconstructOldContent } from "./doc-comment-drift.js";
 import { isDiffFileHeaderLine } from "./diff-lines.js";
 import { isTestPath } from "./test-ratio.js";
@@ -43,14 +44,6 @@ function escapeRegExp(value: string): string {
 
 function isScannablePath(path: string): boolean {
   return SOURCE_RE.test(path) && !SKIP_RE.test(path) && !isTestPath(path);
-}
-
-function githubHeaders(token: string): Record<string, string> {
-  return {
-    Authorization: `Bearer ${token}`,
-    Accept: "application/vnd.github.raw",
-    "X-GitHub-Api-Version": "2022-11-28",
-  };
 }
 
 async function readBoundedText(resp: Response, signal?: AbortSignal): Promise<string | null> {
@@ -93,7 +86,7 @@ async function fetchFileAtHead(
     const encoded = path.split("/").map(encodeURIComponent).join("/");
     const resp = await fetchFn(
       `${GITHUB_API}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/contents/${encoded}?ref=${encodeURIComponent(headSha)}`,
-      { headers: githubHeaders(token), signal },
+      { headers: githubHeaders(token, { raw: true }), signal },
     );
     if (!resp.ok) return null;
     return await readBoundedText(resp, signal);

--- a/review-enrichment/src/analyzers/flaky-test.ts
+++ b/review-enrichment/src/analyzers/flaky-test.ts
@@ -10,6 +10,7 @@ import type {
 } from "../types.js";
 import type { AnalysisContext } from "../analysis-context.js";
 import { boundedFetchJson } from "../external-fetch.js";
+import { githubHeaders } from "../github-headers.js";
 import { isTestPath } from "./test-ratio.js";
 import { DEFAULT_MAX_FINDINGS } from "./limits.js";
 
@@ -51,14 +52,6 @@ interface CheckRunsResponse {
 
 interface RepoInfo {
   default_branch?: string;
-}
-
-function githubHeaders(token: string): Record<string, string> {
-  return {
-    Authorization: `Bearer ${token}`,
-    Accept: "application/vnd.github+json",
-    "X-GitHub-Api-Version": "2022-11-28",
-  };
 }
 
 function markPartial(diagnostics: AnalyzerDiagnostics | undefined, reason: string): void {

--- a/review-enrichment/src/analyzers/history.ts
+++ b/review-enrichment/src/analyzers/history.ts
@@ -12,10 +12,10 @@
 import type { AnalyzerDiagnostics, EnrichRequest, HistoryFinding } from "../types.js";
 import type { AnalysisContext } from "../analysis-context.js";
 import { boundedFetchJson } from "../external-fetch.js";
+import { githubHeaders } from "../github-headers.js";
 import { isDiffFileHeaderLine } from "./diff-lines.js";
 
 const GITHUB_API = "https://api.github.com";
-const GITHUB_API_VERSION = "2022-11-28";
 const MAX_FILES_PROBED = 5; // bound the per-file commit-history fan-out
 const COMMITS_PER_FILE = 10; // recent commits to inspect per probed file
 const MAX_PR_LOOKUPS = 12; // global cap on commit→PR resolution calls
@@ -177,15 +177,6 @@ export function parseRepo(
     }
   }
   return { owner: owner!, repo: repo! };
-}
-
-function githubHeaders(token: string): Record<string, string> {
-  return {
-    Authorization: `Bearer ${token}`,
-    Accept: "application/vnd.github+json",
-    "X-GitHub-Api-Version": GITHUB_API_VERSION,
-    "User-Agent": "gittensory-review-enrichment",
-  };
 }
 
 // ── Linked-issue alignment (no fetch — the issue text is in the envelope) ───────

--- a/review-enrichment/src/analyzers/pending-review-requests.ts
+++ b/review-enrichment/src/analyzers/pending-review-requests.ts
@@ -15,6 +15,7 @@ import type {
 } from "../types.js";
 import type { AnalysisContext } from "../analysis-context.js";
 import { boundedFetchJson } from "../external-fetch.js";
+import { githubHeaders } from "../github-headers.js";
 
 const GITHUB_API = "https://api.github.com";
 const SLUG_RE = /^[A-Za-z0-9._-]+$/;
@@ -40,14 +41,6 @@ interface TimelineEvent {
   created_at?: string;
   requested_reviewer?: { login?: string };
   requested_team?: { slug?: string };
-}
-
-function githubHeaders(token: string): Record<string, string> {
-  return {
-    Authorization: `Bearer ${token}`,
-    Accept: "application/vnd.github+json",
-    "X-GitHub-Api-Version": "2022-11-28",
-  };
 }
 
 async function fetchRequestedReviewers(

--- a/review-enrichment/src/analyzers/revert-recurrence.ts
+++ b/review-enrichment/src/analyzers/revert-recurrence.ts
@@ -13,6 +13,7 @@ import type {
 } from "../types.js";
 import type { AnalysisContext } from "../analysis-context.js";
 import { boundedFetchJson } from "../external-fetch.js";
+import { githubHeaders } from "../github-headers.js";
 import { isHistoryUninformativePath } from "./history-path.js";
 import { DEFAULT_MAX_FINDINGS } from "./limits.js";
 
@@ -145,14 +146,6 @@ export function firstOverlap(left: Range[], right: Range[]): Range | null {
     }
   }
   return null;
-}
-
-function githubHeaders(token: string): Record<string, string> {
-  return {
-    Authorization: `Bearer ${token}`,
-    Accept: "application/vnd.github+json",
-    "X-GitHub-Api-Version": "2022-11-28",
-  };
 }
 
 /** Fetch + parse JSON with the shared bounded-fetch guard rails. Returns the parsed body, or null on any

--- a/review-enrichment/src/analyzers/stale-branch.ts
+++ b/review-enrichment/src/analyzers/stale-branch.ts
@@ -13,6 +13,7 @@ import type {
 } from "../types.js";
 import type { AnalysisContext } from "../analysis-context.js";
 import { boundedFetchJson } from "../external-fetch.js";
+import { githubHeaders } from "../github-headers.js";
 
 const GITHUB_API = "https://api.github.com";
 const SLUG_RE = /^[A-Za-z0-9._-]+$/;
@@ -32,14 +33,6 @@ interface RepoInfo {
 interface CompareResult {
   status?: string;
   behind_by?: number;
-}
-
-function githubHeaders(token: string): Record<string, string> {
-  return {
-    Authorization: `Bearer ${token}`,
-    Accept: "application/vnd.github+json",
-    "X-GitHub-Api-Version": "2022-11-28",
-  };
 }
 
 async function fetchDefaultBranch(

--- a/review-enrichment/src/analyzers/unused-export.ts
+++ b/review-enrichment/src/analyzers/unused-export.ts
@@ -12,12 +12,12 @@ import type {
 } from "../types.js";
 import type { AnalysisContext } from "../analysis-context.js";
 import { boundedFetchJson } from "../external-fetch.js";
+import { githubHeaders } from "../github-headers.js";
 import { exportedSymbols, parseAddedExports } from "./undocumented-export.js";
 import { isTestPath } from "./test-ratio.js";
 import { DEFAULT_MAX_FINDINGS } from "./limits.js";
 
 const GITHUB_API = "https://api.github.com";
-const GITHUB_API_VERSION = "2022-11-28";
 const SLUG_RE = /^[A-Za-z0-9._-]+$/;
 const MAX_SYMBOLS = 10;
 const MAX_SEARCHES = 10;
@@ -44,15 +44,6 @@ interface CodeSearchResponse {
   total_count?: number;
   incomplete_results?: boolean;
   items?: CodeSearchItem[];
-}
-
-function githubHeaders(token: string, raw = false): Record<string, string> {
-  return {
-    Authorization: `Bearer ${token}`,
-    Accept: raw ? "application/vnd.github.raw" : "application/vnd.github+json",
-    "X-GitHub-Api-Version": GITHUB_API_VERSION,
-    "User-Agent": "gittensory-review-enrichment",
-  };
 }
 
 function escapeRegExp(value: string): string {
@@ -133,7 +124,7 @@ async function fetchFileAtHead(
     const encoded = path.split("/").map(encodeURIComponent).join("/");
     const resp = await fetchImpl(
       `${GITHUB_API}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/contents/${encoded}?ref=${encodeURIComponent(headSha)}`,
-      { headers: githubHeaders(token, true), signal },
+      { headers: githubHeaders(token, { raw: true }), signal },
     );
     if (!resp.ok) return null;
     return await readBoundedText(resp, signal);

--- a/review-enrichment/src/github-headers.ts
+++ b/review-enrichment/src/github-headers.ts
@@ -1,0 +1,21 @@
+// Shared outbound GitHub REST API request headers (#4609). Before this, 17 of 63 analyzer files hand-copied a
+// private githubHeaders() helper that had drifted into 4 shapes: 11 sent no User-Agent, 3 added a User-Agent +
+// a GITHUB_API_VERSION constant, 1 hardcoded Accept to raw-only (unable to ever request JSON), and 2 reinvented a
+// raw-toggle param a 4th way. One export, one shape, used by every analyzer that talks to the GitHub API.
+const GITHUB_API_VERSION = "2022-11-28";
+const USER_AGENT = "gittensory-review-enrichment";
+
+/** Standard headers for an authenticated GitHub REST API request: `Authorization`, `X-GitHub-Api-Version`, and
+ *  `User-Agent` are always present. `Accept` defaults to the structured-JSON media type; pass `{ raw: true }`
+ *  when fetching raw file/blob content (e.g. the Contents API) instead of JSON metadata. Pure. */
+export function githubHeaders(
+  token: string,
+  opts?: { raw?: boolean },
+): Record<string, string> {
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: opts?.raw ? "application/vnd.github.raw" : "application/vnd.github+json",
+    "X-GitHub-Api-Version": GITHUB_API_VERSION,
+    "User-Agent": USER_AGENT,
+  };
+}

--- a/review-enrichment/test/github-headers.test.ts
+++ b/review-enrichment/test/github-headers.test.ts
@@ -1,0 +1,36 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import { githubHeaders } from "../dist/github-headers.js";
+
+test("githubHeaders defaults to the structured-JSON Accept media type", () => {
+  const headers = githubHeaders("tok_abc123");
+  assert.deepEqual(headers, {
+    Authorization: "Bearer tok_abc123",
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "User-Agent": "gittensory-review-enrichment",
+  });
+});
+
+test("githubHeaders with no opts argument matches an explicit raw:false", () => {
+  assert.deepEqual(githubHeaders("tok_abc123"), githubHeaders("tok_abc123", { raw: false }));
+});
+
+test("githubHeaders switches Accept to the raw media type when opts.raw is true", () => {
+  const headers = githubHeaders("tok_abc123", { raw: true });
+  assert.deepEqual(headers, {
+    Authorization: "Bearer tok_abc123",
+    Accept: "application/vnd.github.raw",
+    "X-GitHub-Api-Version": "2022-11-28",
+    "User-Agent": "gittensory-review-enrichment",
+  });
+});
+
+test("githubHeaders with an empty opts object behaves like the default (JSON)", () => {
+  assert.deepEqual(githubHeaders("tok_abc123", {}), githubHeaders("tok_abc123"));
+});
+
+test("githubHeaders always embeds the caller's token verbatim in the Bearer value", () => {
+  assert.equal(githubHeaders("ghs_anotherToken999").Authorization, "Bearer ghs_anotherToken999");
+});


### PR DESCRIPTION
## Summary

- 17 of 63 `review-enrichment/src/analyzers/*.ts` files hand-copied a private `githubHeaders()` helper that had drifted into 4 shapes: 11 files sent no `User-Agent`, 3 added a `User-Agent` plus a local `GITHUB_API_VERSION` constant, 1 (`exhaustiveness-drift.ts`) hardcoded `Accept` to raw-only (unable to ever request JSON), and 2 reinvented a raw-toggle param a 4th way.
- Added one exported `githubHeaders(token: string, opts?: { raw?: boolean }): Record<string, string>` in a new `review-enrichment/src/github-headers.ts`, using the most complete existing shape (Accept toggle + `GITHUB_API_VERSION` + `User-Agent`) as the target shape.
- Replaced all 17 call sites with an import of the shared helper and deleted each file's own private copy (plus the now-dead local `GITHUB_API_VERSION` const in the 5 files that had one).
- Call sites that previously passed a positional `true` for raw content (`caller-impact.ts`, `unused-export.ts`) now pass `{ raw: true }`. `exhaustiveness-drift.ts`'s one call site now explicitly passes `{ raw: true }` too, preserving its existing runtime behavior (it fetches raw file content) while closing the structural gap called out in the issue — it can now request JSON like every other analyzer, it just doesn't need to today.
- All 17 files updated: `approval-integrity.ts`, `blame-link.ts`, `churn-hotspot.ts`, `commit-hygiene.ts`, `commit-lint.ts`, `commit-signature.ts`, `coverage-delta.ts`, `flaky-test.ts`, `pending-review-requests.ts`, `revert-recurrence.ts`, `stale-branch.ts`, `asset-weight.ts`, `duplication-scan.ts`, `history.ts`, `exhaustiveness-drift.ts`, `caller-impact.ts`, `unused-export.ts`.
- Entirely self-contained within `review-enrichment/` (own `tsconfig.json`, own build, own Railway deploy) — no cross-service-boundary risk, no version-bump ceremony.

Fixes #4609.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage`
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This change touches only `review-enrichment/**`, which has its own `tsconfig.json` (not included by the root `tsconfig.json`) and its own `node --test` suite (not matched by the root vitest `test/**/*.test.ts` include), so the root `actionlint` / `typecheck` / `test:coverage` / `test:workers` / `build:mcp` / `test:mcp-pack` / `ui:*` checks are structurally unaffected by this diff and were not re-run. The actual CI check for this change is `rees:test`, which I ran directly: `npm run rees:test` (build + `validate:sourcemaps` + `generate-analyzer-metadata.mjs --check` + the full `node:test` suite) — 1223 passing, 0 failing, including a new `test/github-headers.test.ts` covering the shared helper's default/raw/empty-opts branches. Ran once before the final rebase and again immediately after rebasing onto latest `origin/main`, both green.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [ ] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

The four unchecked Safety boxes are not applicable: this PR touches no auth/cookie/CORS/GitHub App/Cloudflare/session code, no API/OpenAPI/MCP surface, no UI, and no docs/changelog — it is a pure internal header-builder consolidation inside `review-enrichment/src/analyzers/`.

## UI Evidence

Not applicable — no UI/frontend/docs changes.

## Notes

- Follows the same pattern as #4164 (`refactor(review-enrichment): dedupe REES analyzer limit constants`), which consolidated another cross-analyzer constant duplication the same way.
