### PR TITLE
fix(db): drop the 2 orphaned scoring-intelligence tables from #4619

### DIFF
--- a/migrations/0141_drop_orphaned_scoring_intelligence_tables.sql
+++ b/migrations/0141_drop_orphaned_scoring_intelligence_tables.sql
@@ -1,0 +1,9 @@
+-- Drop 2 tables scaffolded in 0004_scoring_intelligence.sql that never gained a real reader or writer
+-- (#4619, review-stack architecture audit). Their sibling tables from the same migration
+-- (scoring_model_snapshots, score_previews, contributor_evidence, contributor_scoring_profiles,
+-- burden_forecasts, bounty_lifecycle_events) all got wired with real read+write paths; these two alone
+-- never did -- the "issue quality report" concept now lives entirely in the generic signal_snapshots
+-- cache via src/services/issue-quality.ts instead. Confirmed zero rows on the live production database
+-- before writing this migration (both tables empty).
+DROP TABLE IF EXISTS issue_quality_reports;
+DROP TABLE IF EXISTS registry_drift_events;

--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -26,7 +26,6 @@ import {
   githubAgentCommandFeedback,
   installationHealth,
   installations,
-  issueQualityReports,
   issues,
   githubRateLimitObservations,
   notificationDeliveries,
@@ -43,7 +42,6 @@ import {
   repositories,
   repoGithubTotalsSnapshots,
   repoQueueTrendSnapshots,
-  registryDriftEvents,
   repoLabels,
   repoSnapshots,
   repoSyncSegments,
@@ -113,7 +111,6 @@ import type {
   InstallationHealthRecord,
   InstallationRecord,
   IssueRecord,
-  IssueQualityReportRecord,
   JsonValue,
   McpCompatibilityAdoptionSummary,
   NotificationChannel,
@@ -144,7 +141,6 @@ import type {
   PullRequestReviewRecord,
   RecentMergedPullRequestRecord,
   RegistryRepoConfig,
-  RegistryDriftEventRecord,
   RepoLabelRecord,
   RepoGithubTotalsSnapshotRecord,
   RepoQueueTrendSnapshotRecord,
@@ -3573,23 +3569,6 @@ export async function getContributorScoringProfile(env: Env, login: string): Pro
     : null;
 }
 
-export async function upsertIssueQualityReport(env: Env, report: IssueQualityReportRecord): Promise<void> {
-  const db = getDb(env.DB);
-  await db
-    .insert(issueQualityReports)
-    .values({
-      id: report.id,
-      repoFullName: report.repoFullName,
-      issueNumber: report.issueNumber,
-      payloadJson: jsonString(report.payload),
-      generatedAt: report.generatedAt,
-    })
-    .onConflictDoUpdate({
-      target: [issueQualityReports.repoFullName, issueQualityReports.issueNumber],
-      set: { payloadJson: jsonString(report.payload), generatedAt: report.generatedAt },
-    });
-}
-
 export async function upsertBurdenForecast(env: Env, forecast: BurdenForecastRecord): Promise<void> {
   const db = getDb(env.DB);
   await db
@@ -3611,22 +3590,6 @@ export async function getBurdenForecast(env: Env, repoFullName: string): Promise
     payload: parseJson<Record<string, JsonValue>>(first.payloadJson, {}),
     generatedAt: first.generatedAt,
   };
-}
-
-export async function persistRegistryDriftEvents(env: Env, events: RegistryDriftEventRecord[]): Promise<void> {
-  const db = getDb(env.DB);
-  for (const event of events) {
-    await db.insert(registryDriftEvents).values({
-      id: event.id,
-      repoFullName: event.repoFullName,
-      driftType: event.driftType,
-      detail: event.detail,
-      previousSnapshotId: event.previousSnapshotId,
-      currentSnapshotId: event.currentSnapshotId,
-      payloadJson: jsonString(event.payload),
-      generatedAt: event.generatedAt,
-    });
-  }
 }
 
 export async function persistBountyLifecycleEvent(env: Env, event: BountyLifecycleEventRecord): Promise<void> {

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1014,20 +1014,6 @@ export const officialMinerDetections = sqliteTable("official_miner_detections", 
   updatedAt: text("updated_at").notNull().$defaultFn(() => nowIso()),
 });
 
-export const issueQualityReports = sqliteTable(
-  "issue_quality_reports",
-  {
-    id: text("id").primaryKey(),
-    repoFullName: text("repo_full_name").notNull(),
-    issueNumber: integer("issue_number").notNull(),
-    payloadJson: text("payload_json").notNull().default("{}"),
-    generatedAt: text("generated_at").notNull().$defaultFn(() => nowIso()),
-  },
-  (table) => ({
-    repoIssue: uniqueIndex("issue_quality_reports_repo_issue_unique").on(table.repoFullName, table.issueNumber),
-  }),
-);
-
 export const burdenForecasts = sqliteTable("burden_forecasts", {
   repoFullName: text("repo_full_name").primaryKey(),
   payloadJson: text("payload_json").notNull().default("{}"),
@@ -1036,17 +1022,6 @@ export const burdenForecasts = sqliteTable("burden_forecasts", {
 
 export const repoQueueTrendSnapshots = sqliteTable("repo_queue_trend_snapshots", {
   repoFullName: text("repo_full_name").primaryKey(),
-  payloadJson: text("payload_json").notNull().default("{}"),
-  generatedAt: text("generated_at").notNull().$defaultFn(() => nowIso()),
-});
-
-export const registryDriftEvents = sqliteTable("registry_drift_events", {
-  id: text("id").primaryKey(),
-  repoFullName: text("repo_full_name").notNull(),
-  driftType: text("drift_type").notNull(),
-  detail: text("detail").notNull(),
-  previousSnapshotId: text("previous_snapshot_id"),
-  currentSnapshotId: text("current_snapshot_id"),
   payloadJson: text("payload_json").notNull().default("{}"),
   generatedAt: text("generated_at").notNull().$defaultFn(() => nowIso()),
 });

--- a/src/types.ts
+++ b/src/types.ts
@@ -2044,27 +2044,8 @@ export type ContributorScoringProfileRecord = {
   generatedAt: string;
 };
 
-export type IssueQualityReportRecord = {
-  id: string;
-  repoFullName: string;
-  issueNumber: number;
-  payload: Record<string, JsonValue>;
-  generatedAt: string;
-};
-
 export type BurdenForecastRecord = {
   repoFullName: string;
-  payload: Record<string, JsonValue>;
-  generatedAt: string;
-};
-
-export type RegistryDriftEventRecord = {
-  id: string;
-  repoFullName: string;
-  driftType: string;
-  detail: string;
-  previousSnapshotId?: string | null | undefined;
-  currentSnapshotId?: string | null | undefined;
   payload: Record<string, JsonValue>;
   generatedAt: string;
 };

--- a/test/unit/db-persistence.test.ts
+++ b/test/unit/db-persistence.test.ts
@@ -10,7 +10,6 @@ import {
   listRepoPullRequestFilePaths,
   listSignalSnapshots,
   persistBountyLifecycleEvent,
-  persistRegistryDriftEvents,
   persistRepoGithubTotalsSnapshot,
   persistSignalSnapshot,
   startActiveReviewTracking,
@@ -18,7 +17,6 @@ import {
   updateUpstreamDriftReportIssue,
   upsertContributorRepoStat,
   upsertContributorScoringProfile,
-  upsertIssueQualityReport,
   upsertPullRequestFile,
   upsertUpstreamDriftReport,
 } from "../../src/db/repositories";
@@ -27,7 +25,7 @@ import type { PullRequestFileRecord, PullRequestRecord, RepositoryRecord } from 
 import { createTestEnv } from "../helpers/d1";
 
 describe("database persistence helpers", () => {
-  it("round-trips drift, quality, lifecycle, and scoring persistence helpers", async () => {
+  it("round-trips drift, lifecycle, and scoring persistence helpers", async () => {
     const env = createTestEnv();
     await upsertUpstreamDriftReport(env, {
       id: "drift-1",
@@ -66,25 +64,6 @@ describe("database persistence helpers", () => {
       payload: { scoreability: "ready" },
     });
 
-    await upsertIssueQualityReport(env, {
-      id: "quality-1",
-      repoFullName: "JSONbored/gittensory",
-      issueNumber: 7,
-      payload: { score: 92 },
-      generatedAt: "2026-05-30T00:03:00.000Z",
-    });
-    await persistRegistryDriftEvents(env, [
-      {
-        id: "registry-event-1",
-        repoFullName: "JSONbored/gittensory",
-        driftType: "changed",
-        detail: "Emission changed",
-        previousSnapshotId: "old",
-        currentSnapshotId: "new",
-        payload: { emissionShare: 0.01 },
-        generatedAt: "2026-05-30T00:04:00.000Z",
-      },
-    ]);
     await persistBountyLifecycleEvent(env, {
       id: "bounty-event-1",
       bountyId: "bounty-1",
@@ -95,12 +74,6 @@ describe("database persistence helpers", () => {
       generatedAt: "2026-05-30T00:05:00.000Z",
     });
 
-    await expect(
-      env.DB.prepare("select payload_json from issue_quality_reports where repo_full_name = ? and issue_number = ?")
-        .bind("JSONbored/gittensory", 7)
-        .first<{ payload_json: string }>(),
-    ).resolves.toMatchObject({ payload_json: JSON.stringify({ score: 92 }) });
-    await expect(env.DB.prepare("select count(*) as count from registry_drift_events").first<{ count: number }>()).resolves.toMatchObject({ count: 1 });
     await expect(env.DB.prepare("select count(*) as count from bounty_lifecycle_events").first<{ count: number }>()).resolves.toMatchObject({ count: 1 });
   });
 


### PR DESCRIPTION
## What

Completes #4619's deferred scope. PR #4666 already removed the other 12 confirmed-dead exports; the
`issue_quality_reports`/`registry_drift_events` DB-table drop was deliberately held back pending
confirmation there's no production data, since that can't be verified from the codebase alone.

**Confirmed directly against the live production database**: both tables have zero rows. Safe to drop.

Both were scaffolded in migration `0004_scoring_intelligence.sql` alongside 6 sibling tables
(`scoring_model_snapshots`, `score_previews`, `contributor_evidence`, `contributor_scoring_profiles`,
`burden_forecasts`, `bounty_lifecycle_events`) that all got wired with real read+write paths — these two
alone never did. The "issue quality report" concept now lives entirely in the generic `signal_snapshots`
cache via `src/services/issue-quality.ts` instead.

## Changes

- `migrations/0141_drop_orphaned_scoring_intelligence_tables.sql` — `DROP TABLE IF EXISTS` for both.
- `src/db/schema.ts` — removed the two Drizzle table definitions.
- `src/db/repositories.ts` — removed `upsertIssueQualityReport`/`persistRegistryDriftEvents` (zero callers
  anywhere) and their now-unused imports.
- `src/types.ts` — removed `IssueQualityReportRecord`/`RegistryDriftEventRecord` (only ever referenced by
  the two removed functions).
- `test/unit/db-persistence.test.ts` — removed the two functions' round-trip coverage from a shared test
  that also exercises other, still-live persistence helpers; kept everything else in that test intact.

Verified zero remaining references to any of these identifiers anywhere in `src/`, `test/`, or `packages/`.

## Testing

`npm run db:migrations:check` and `npm run db:schema-drift:check` both pass clean (144 contiguous
migrations, schema.ts matches migrations/). `test/unit/db-persistence.test.ts` (24 tests) passes.
Typecheck clean.

Fixes #4619