### PR TITLE
refactor(review): consolidate 3 duplicate helper implementations

### DIFF
--- a/packages/gittensory-engine/src/scoring/preview.ts
+++ b/packages/gittensory-engine/src/scoring/preview.ts
@@ -1,10 +1,14 @@
 import type { ContributorEvidenceRecord, JsonValue, RepositoryRecord, RepoTimeDecayOverrides, ScoringModelSnapshotRecord, ScorePreviewRecord } from "./types.js";
 import { DEFAULT_SCORING_CONSTANTS } from "./model.js";
+import { hasUnsafeWildcardCount } from "../signals/change-guardrail.js";
 
 // Deterministic score-preview builder extracted verbatim from the backend's `src/scoring/preview.ts`
 // (#2282) — this file has no D1/network/env dependency in the original, so it ports unchanged aside from
-// its imports and the two tiny pure helpers (`nowIso`, `hasUnsafeWildcardCount`) inlined below, which the
-// backend sources from `src/utils/json.ts` and `src/signals/change-guardrail.ts` respectively.
+// its imports and one tiny pure helper (`nowIso`) inlined below, which the backend sources from
+// `src/utils/json.ts`. `hasUnsafeWildcardCount` is imported from this package's own
+// `signals/change-guardrail.ts` (#4611) rather than re-derived here — that file is a verbatim port of the
+// backend's `src/signals/change-guardrail.ts`, kept in sync by the engine-parity contract test, so importing
+// it carries the same ReDoS-safety guarantee without a third hand-maintained copy.
 
 // The package's tsconfig sets `types: []` (no ambient DOM/Node globals, keeping the engine's type surface
 // independent of any consumer's lib config), so the Web Crypto global needs a minimal local declaration.
@@ -14,28 +18,6 @@ declare const crypto: { randomUUID(): string };
 
 function nowIso(): string {
   return new Date().toISOString();
-}
-
-// Mirrors `src/signals/change-guardrail.ts`'s `hasUnsafeWildcardCount`/wildcard-group counting exactly —
-// see that file for the full ReDoS-safety rationale. Duplicated here (rather than imported) because this
-// package cannot reach into `src/`; keep the two in sync by hand.
-const MAX_GLOB_WILDCARD_GROUPS = 2;
-
-function countWildcardGroups(glob: string): number {
-  let count = 0;
-  for (let i = 0; i < glob.length; i += 1) {
-    if (glob.charAt(i) !== "*") continue;
-    count += 1;
-    if (glob.charAt(i + 1) === "*") {
-      i += 1; // consume the second star of the "**" pair — one group, not two
-      if (glob.charAt(i + 1) === "/") i += 1; // `**/` also matches zero segments, mirroring globToRegExp
-    }
-  }
-  return count;
-}
-
-function hasUnsafeWildcardCount(glob: string): boolean {
-  return countWildcardGroups(glob) > MAX_GLOB_WILDCARD_GROUPS;
 }
 
 export type ScorePreviewInput = {

--- a/review-enrichment/src/analyzers/a11y-regression.ts
+++ b/review-enrichment/src/analyzers/a11y-regression.ts
@@ -4,6 +4,7 @@
 import type { A11yFinding, EnrichRequest } from "../types.js";
 import { isTestPath } from "./test-ratio.js";
 import { DEFAULT_MAX_FINDINGS, DEFAULT_MAX_LINE_CHARS } from "./limits.js";
+import { isBasicCommentLine } from "./diff-lines.js";
 
 const MAX_FINDINGS = DEFAULT_MAX_FINDINGS;
 const MAX_LINE_CHARS = DEFAULT_MAX_LINE_CHARS;
@@ -24,9 +25,12 @@ const NON_INTERACTIVE_CLICK_TARGET_RE =
 const FORM_CONTROL_RE = /<(?:input|select|textarea)\b/i;
 const LABEL_ASSOC_RE = /\b(?:aria-label|aria-labelledby|id)\s*=|<label\b/i;
 
+// Layers the HTML `<!--` comment form and JSX-adjacent `import`/`from` statements on top of the shared
+// `isBasicCommentLine` base (#4611) — this analyzer scans markup (.jsx/.tsx/.html/.vue) where an import
+// line is boilerplate, not a markup regression candidate, and HTML comments are common.
 function isCommentLine(line: string): boolean {
   const trimmed = line.trimStart();
-  return /^(?:\/\/|\/\*|\*|<!--|import\b|from\b)/.test(trimmed);
+  return isBasicCommentLine(line) || /^(?:<!--|import\b|from\b)/.test(trimmed);
 }
 
 function isMarkupPath(path: string): boolean {

--- a/review-enrichment/src/analyzers/complexity.ts
+++ b/review-enrichment/src/analyzers/complexity.ts
@@ -28,6 +28,7 @@ import type { ComplexityFinding, EnrichRequest } from "../types.js";
 import { codeOnly } from "./secret-log.js";
 import { isTestPath } from "./test-ratio.js";
 import { DEFAULT_MAX_FINDINGS, DEFAULT_MAX_LINE_CHARS } from "./limits.js";
+import { isBasicCommentLine } from "./diff-lines.js";
 
 export const DEFAULT_MAX_COMPLEXITY = 10;
 const MAX_FINDINGS = DEFAULT_MAX_FINDINGS;
@@ -59,11 +60,6 @@ function isJsTsPath(path: string): boolean {
   return JS_TS_PATH_RE.test(path) && !isTestPath(path);
 }
 
-function isCommentLine(line: string): boolean {
-  const trimmed = line.trimStart();
-  return /^(?:\/\/|\/\*|\*)/.test(trimmed);
-}
-
 /** Count decision-point tokens (if/for/while/case/catch/&&/||/??) in one code fragment. Pure. */
 export function countDecisionPoints(code: string): number {
   let total = 0;
@@ -77,7 +73,7 @@ export function countDecisionPoints(code: string): number {
 /** The declared/assigned name when a line opens a named function declaration or an arrow function assigned to a
  *  const/let/var -- the same structural scope size-smell.ts's function detection uses. Pure. */
 export function functionNameFromLine(line: string): string | undefined {
-  if (isCommentLine(line)) return undefined;
+  if (isBasicCommentLine(line)) return undefined;
   const match = FUNCTION_OPEN_RE.exec(codeOnly(line));
   return match?.[1] ?? match?.[2];
 }
@@ -177,7 +173,7 @@ export function scanPatchForComplexity(
     if (line.startsWith("+")) {
       const body = line.slice(1);
       if (body.length <= MAX_LINE_CHARS) {
-        const commented = isCommentLine(body);
+        const commented = isBasicCommentLine(body);
         const code = codeOnly(body);
         pending = advancePendingFunction(pending, body, commented, code, newLine);
         if (pending && pending.depth <= 0) flushFunction();

--- a/review-enrichment/src/analyzers/diff-lines.ts
+++ b/review-enrichment/src/analyzers/diff-lines.ts
@@ -15,3 +15,19 @@
 export function isDiffFileHeaderLine(line: string): boolean {
   return /^(?:\+\+\+|---) (?:[ab]\/|\/dev\/null)/.test(line);
 }
+
+/**
+ * True for a line whose visible content opens with a `//` line comment, a `/* ` block-comment opener, or a
+ * `*` block-comment continuation — the baseline "this added line is not real code" check shared by analyzers
+ * that skip comment lines before pattern-matching (#4611).
+ *
+ * This is the common BASE only. `hardcoded-url.ts` and `a11y-regression.ts` each layer additional
+ * language-specific comment forms on top of it (shell/Python `#`, HTML `<!--`, JSX-adjacent `import`/`from`)
+ * via their own local `isCommentLine` override — those two are deliberately not folded in here, since e.g. a
+ * `#` line-start is a real comment in Python but a real (and common) Markdown heading / hex-color / URL
+ * fragment elsewhere, so it isn't a safe universal default.
+ */
+export function isBasicCommentLine(line: string): boolean {
+  const trimmed = line.trimStart();
+  return /^(?:\/\/|\/\*|\*)/.test(trimmed);
+}

--- a/review-enrichment/src/analyzers/floating-promise.ts
+++ b/review-enrichment/src/analyzers/floating-promise.ts
@@ -6,6 +6,7 @@ import type { EnrichRequest, FloatingPromiseFinding } from "../types.js";
 import { codeOnly } from "./secret-log.js";
 import { isTestPath } from "./test-ratio.js";
 import { DEFAULT_MAX_FINDINGS, DEFAULT_MAX_LINE_CHARS } from "./limits.js";
+import { isBasicCommentLine } from "./diff-lines.js";
 
 const MAX_FINDINGS = DEFAULT_MAX_FINDINGS;
 const MAX_LINE_CHARS = DEFAULT_MAX_LINE_CHARS;
@@ -20,11 +21,6 @@ const PROMISE_CHAIN_RE = /\.(?:then|catch)\s*\(/;
 
 function isJsTsPath(path: string): boolean {
   return JS_TS_PATH_RE.test(path) && !isTestPath(path);
-}
-
-function isCommentLine(line: string): boolean {
-  const trimmed = line.trimStart();
-  return /^(?:\/\/|\/\*|\*)/.test(trimmed);
 }
 
 function truncateCall(call: string): string {
@@ -58,7 +54,7 @@ function extractLeadingCallCallee(line: string): string | null {
 
 /** Classify one added line for a floating promise call, or null. Pure. */
 export function detectFloatingPromise(line: string): string | null {
-  if (isCommentLine(line) || HANDLED_PREFIX.test(line)) {
+  if (isBasicCommentLine(line) || HANDLED_PREFIX.test(line)) {
     return null;
   }
 

--- a/review-enrichment/src/analyzers/hardcoded-url.ts
+++ b/review-enrichment/src/analyzers/hardcoded-url.ts
@@ -5,6 +5,7 @@
 import type { EnrichRequest, HardcodedUrlFinding } from "../types.js";
 import { isMagicNumberSourcePath } from "./magic-number.js";
 import { DEFAULT_MAX_FINDINGS, DEFAULT_MAX_LINE_CHARS } from "./limits.js";
+import { isBasicCommentLine } from "./diff-lines.js";
 
 const MAX_FINDINGS = DEFAULT_MAX_FINDINGS;
 const MAX_LINE_CHARS = DEFAULT_MAX_LINE_CHARS;
@@ -44,9 +45,12 @@ function hostFromHttpUrl(url: string): string {
   return match?.[1] ?? url;
 }
 
+// Layers the shell/Python `#` and HTML `<!--` comment forms on top of the shared `isBasicCommentLine` base
+// (#4611) — this analyzer scans non-TS source (Dockerfiles, shell scripts, YAML) where `#` is a real comment
+// marker, unlike the shared base's TS/JS-only `//`/`/* `/`*` forms.
 function isCommentLine(line: string): boolean {
   const trimmed = line.trimStart();
-  return /^(?:\/\/|#|\/\*|\*|<!--)/.test(trimmed);
+  return isBasicCommentLine(line) || /^(?:#|<!--)/.test(trimmed);
 }
 
 function isImportLine(line: string): boolean {

--- a/review-enrichment/src/analyzers/unsafe-any.ts
+++ b/review-enrichment/src/analyzers/unsafe-any.ts
@@ -5,6 +5,7 @@ import type { EnrichRequest, UnsafeAnyFinding } from "../types.js";
 import { codeOnly } from "./secret-log.js";
 import { isTestPath } from "./test-ratio.js";
 import { DEFAULT_MAX_FINDINGS, DEFAULT_MAX_LINE_CHARS } from "./limits.js";
+import { isBasicCommentLine } from "./diff-lines.js";
 
 const MAX_FINDINGS = DEFAULT_MAX_FINDINGS;
 const MAX_LINE_CHARS = DEFAULT_MAX_LINE_CHARS;
@@ -15,14 +16,9 @@ function isTsPath(path: string): boolean {
   return TS_PATH_RE.test(path) && !isTestPath(path);
 }
 
-function isCommentLine(line: string): boolean {
-  const trimmed = line.trimStart();
-  return /^(?:\/\/|\/\*|\*)/.test(trimmed);
-}
-
 /** Classify one added line for an unsafe `any` pattern, or null. Pure. */
 export function detectUnsafeAny(line: string): UnsafeAnyFinding["kind"] | null {
-  if (isCommentLine(line) || line.length > MAX_LINE_CHARS) return null;
+  if (isBasicCommentLine(line) || line.length > MAX_LINE_CHARS) return null;
   const code = codeOnly(line);
   if (/\bas any\b/.test(code)) return "cast";
   if (/<any>/.test(code)) return "assertion";

--- a/review-enrichment/test/diff-lines.test.ts
+++ b/review-enrichment/test/diff-lines.test.ts
@@ -2,7 +2,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { isDiffFileHeaderLine } from "../dist/analyzers/diff-lines.js";
+import { isBasicCommentLine, isDiffFileHeaderLine } from "../dist/analyzers/diff-lines.js";
 
 test("isDiffFileHeaderLine matches real file headers only, not ++/--- content", () => {
   // Real unified-diff file headers → skipped.
@@ -13,5 +13,20 @@ test("isDiffFileHeaderLine matches real file headers only, not ++/--- content", 
   // must be scanned; likewise plain content and headerless single-line diffs.
   for (const content of ["+++x", "+++ const key = 1;", '+++ "lodash": "^1.0.0"', "+history analyzer", "---x", "+const y = 2;", "@@ -1,0 +1,1 @@"]) {
     assert.equal(isDiffFileHeaderLine(content), false, content);
+  }
+});
+
+test("isBasicCommentLine matches //, /*, and * comment openers, leading whitespace included", () => {
+  for (const line of ["// a note", "  // indented", "/* block open", "* jsdoc continuation", "   * indented continuation"]) {
+    assert.equal(isBasicCommentLine(line), true, line);
+  }
+  // Not real code either, but outside this shared base's scope — analyzers that need these layer their own
+  // override on top (hardcoded-url.ts's `#`/`<!--`, a11y-regression.ts's `<!--`/`import`/`from`).
+  for (const line of ["# shell/python comment", "<!-- html comment -->", "import x from 'y'", "from y import x"]) {
+    assert.equal(isBasicCommentLine(line), false, line);
+  }
+  // Real code → never flagged.
+  for (const line of ["const x = 1;", "  return a && b;", "export function run() {"]) {
+    assert.equal(isBasicCommentLine(line), false, line);
   }
 });

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -166,6 +166,7 @@ import { decidePendingAgentAction } from "../services/agent-approval-queue";
 import { explainScoreBreakdown } from "../services/score-breakdown";
 import { buildMcpClientTelemetry } from "../services/client-telemetry";
 import {
+  authoritativeContributorRepoStats,
   buildAndPersistContributorDecisionPack,
   CONTRIBUTOR_DECISION_PACK_SIGNAL,
   loadContributorDecisionPackForServing,
@@ -5202,14 +5203,6 @@ function enrichSyncSegment(segment: RepoSyncSegmentRecord) {
 
 function parseBackfillSegment(value: unknown): Extract<JobMessage, { type: "backfill-repo-segment" }>["segment"] | null {
   return value === "labels" || value === "open_issues" || value === "open_pull_requests" || value === "recent_merged_pull_requests" ? value : null;
-}
-
-function authoritativeContributorRepoStats(
-  gittensorSnapshot: Awaited<ReturnType<typeof fetchGittensorContributorSnapshot>>,
-  cachedRepoStats: Awaited<ReturnType<typeof listContributorRepoStats>>,
-) {
-  const officialRepoStats = contributorRepoStatsFromGittensor(gittensorSnapshot);
-  return officialRepoStats.length > 0 ? officialRepoStats : cachedRepoStats;
 }
 
 async function persistSignal(

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -86,7 +86,7 @@ import {
   preparePrPacketWithAgent,
   startAgentRun,
 } from "../services/agent-orchestrator";
-import { loadContributorDecisionPackForServing, repoDecisionFromPack } from "../services/decision-pack";
+import { authoritativeContributorRepoStats, loadContributorDecisionPackForServing, repoDecisionFromPack } from "../services/decision-pack";
 import { buildPublicPrBodyDraft } from "../services/pr-body-draft";
 import { buildRemediationPlan } from "../services/remediation-plan";
 import { deriveEligibilityPlan } from "../services/eligibility-plan";
@@ -3780,14 +3780,6 @@ function redactSensitiveForMcp(value: unknown): unknown {
       .filter(([key]) => !/hotkey|coldkey|wallet|private_key|privateKey|mnemonic|alphaPerDay|taoPerDay|usdPerDay/i.test(key))
       .map(([key, entry]) => [key, redactSensitiveForMcp(entry)]),
   );
-}
-
-function authoritativeContributorRepoStats(
-  gittensorSnapshot: Awaited<ReturnType<typeof fetchGittensorContributorSnapshot>>,
-  cachedRepoStats: Awaited<ReturnType<typeof listContributorRepoStats>>,
-) {
-  const officialRepoStats = contributorRepoStatsFromGittensor(gittensorSnapshot);
-  return officialRepoStats.length > 0 ? officialRepoStats : cachedRepoStats;
 }
 
 async function authenticateMcpRequest(c: AppContext): Promise<AuthIdentity | null> {

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -228,6 +228,7 @@ import {
   refreshScoringModelSnapshot,
 } from "../scoring/model";
 import {
+  authoritativeContributorRepoStats,
   buildAndPersistContributorDecisionPack,
   loadDecisionPackSharedInputs,
 } from "../services/decision-pack";
@@ -15556,17 +15557,6 @@ function officialGittensorContributorDetection(
       snapshot.totals.openIssues + snapshot.totals.closedIssues,
     ),
   };
-}
-
-function authoritativeContributorRepoStats(
-  gittensorSnapshot: Awaited<
-    ReturnType<typeof fetchGittensorContributorSnapshot>
-  >,
-  cachedRepoStats: Awaited<ReturnType<typeof listContributorRepoStats>>,
-) {
-  const officialRepoStats =
-    contributorRepoStatsFromGittensor(gittensorSnapshot);
-  return officialRepoStats.length > 0 ? officialRepoStats : cachedRepoStats;
 }
 
 /** Split `owner/name` into the project/repo key shape shared by RAG indexing and retrieval. */

--- a/src/services/decision-pack.ts
+++ b/src/services/decision-pack.ts
@@ -1794,7 +1794,11 @@ function snapshotAgeMs(generatedAt: string): number {
   return Number.isFinite(parsed) ? Date.now() - parsed : Number.POSITIVE_INFINITY;
 }
 
-function authoritativeContributorRepoStats(
+/** The gittensor-official snapshot's repo stats when present, falling back to the last cached copy —
+ *  gittensor is the authoritative source when reachable, the cache is only a degrade-gracefully fallback for
+ *  when it isn't. Shared by every site that resolves a contributor's repo stats (#4611) — mcp/server.ts,
+ *  api/routes.ts, and queue/processors.ts all import this rather than redefining it. */
+export function authoritativeContributorRepoStats(
   gittensorSnapshot: Awaited<ReturnType<typeof fetchGittensorContributorSnapshot>>,
   cachedRepoStats: ContributorRepoStatRecord[],
 ) {


### PR DESCRIPTION
## Summary

- Consolidates the 3 lower-priority duplicate clusters from the review-stack architecture audit's duplication dimension, each independently confirmed against current `main` before fixing:
  1. **`isCommentLine`** (5 bodies in `review-enrichment/src/analyzers/`): `unsafe-any.ts`, `complexity.ts`, and `floating-promise.ts` carried a byte-identical `isCommentLine`. Extracted it as a new `isBasicCommentLine` export in `diff-lines.ts` (the existing home for shared diff-line predicates, alongside `isDiffFileHeaderLine`), and pointed those 3 files at the import. `hardcoded-url.ts` and `a11y-regression.ts` keep their own `isCommentLine` — each now composes the shared base plus its deliberate per-language extra (`#`/`<!--` for shell/Python/HTML, `<!--`/`import`/`from` for JSX) instead of re-deriving the whole regex, documented as an override.
  2. **`authoritativeContributorRepoStats`** (4 copies): confirmed all 4 still functionally identical (only type-spelling/formatting differed). Exported the one in `services/decision-pack.ts` and replaced the local copies in `api/routes.ts`, `mcp/server.ts`, and `queue/processors.ts` with an import.
  3. **`hasUnsafeWildcardCount`** (3rd private copy): the guarded host/engine pair (`src/signals/change-guardrail.ts` ↔ `packages/gittensory-engine/src/signals/change-guardrail.ts`) is untouched. `packages/gittensory-engine/src/scoring/preview.ts` had a 3rd, non-exported copy invisible to the engine-parity drift check by construction — it now imports `hasUnsafeWildcardCount` from its own package's `signals/change-guardrail.ts` instead of redefining it.
- No behavior change in any of the three. Each site's runtime output is identical before/after.

Fixes #4611

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This is a pure relocate-and-import refactor with no new branches or behavior changes, so validation was scoped to what the diff can actually affect rather than the full battery: `npm run typecheck` (full, clean), `npm --workspace @jsonbored/gittensory-engine run build` (clean), `npm run rees:test` (review-enrichment's own build + node:test suite, 1224/1224 passing), `npm run test:engine-parity` (15/15, confirms the guarded host/engine `change-guardrail.ts` pair is untouched), `npm run test --workspace @jsonbored/gittensory-engine` (the engine package's own standalone suite, 349/349), and targeted `vitest run` against every test file that exercises a changed line (`decision-pack.test.ts`, `api.test.ts`, the `queue.test.ts` contributor-evidence tests, `scoring.test.ts`) with `--coverage` scoped to the changed files — `decision-pack.ts` at 98.96%/96.76% (line/branch) with `authoritativeContributorRepoStats` fully exercised, `preview.ts` at 98.73%/99.56% with `hasUnsafeWildcardCount` fully exercised on both branches, and the `processors.ts` call site directly confirmed executed via the lcov report. `actionlint`/`test:workers`/`build:mcp`/`test:mcp-pack`/`ui:*`/`npm audit` are not exercised by this diff (no workflow, workers-pool, MCP-package-build, UI, or dependency changes) and are left to CI. Rebased onto fresh `main` immediately before pushing (main had moved, including an unrelated review-enrichment dedupe PR and a large `queue/processors.ts` change) and re-ran the full validation pass above against the rebased tree with identical results.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [ ] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

Not applicable: no auth/cookie/CORS/GitHub App/Cloudflare/session changes, no API/OpenAPI/MCP request/response shape changes, and no UI/docs changes in this PR.

## UI Evidence

Not applicable — no visible UI, frontend, docs, or extension changes.

## Notes

- Each of the 3 clusters was independently re-verified against current `main` (not just the issue text) before fixing, since line numbers had drifted (e.g. `authoritativeContributorRepoStats` in `queue/processors.ts` had moved by ~340 lines).
