### PR TITLE
fix(ci): dispatch orb-beta-release against the tag, not the floating main ref

### DIFF
--- a/.github/workflows/orb-beta-release.yml
+++ b/.github/workflows/orb-beta-release.yml
@@ -88,12 +88,22 @@ jobs:
       # `--verify-tag` GitHub Release step can run safely (see that workflow's own comments). Gated on
       # steps.tag.outputs.created (not just due) so a no-op tag step -- for any reason -- never triggers a
       # rebuild/republish of an existing GHCR image tag with different content.
+      #
+      # Dispatch against the TAG, not `main`: `main` is a floating ref, and this repo merges fast enough
+      # that a commit can land in the gap between the "Tag the new beta" step above pushing $TAG and this
+      # step's dispatch actually being processed by GitHub. `--ref main` would then resolve `github.sha`
+      # inside release-selfhost.yml to that NEWER commit, while $TAG (pushed moments ago, immutable) still
+      # points at the older one it was actually cut for -- tripping that workflow's own
+      # TAG_SHA-must-equal-RELEASE_SHA fail-safe and aborting the release. Dispatching against $TAG instead
+      # makes `github.sha` resolve to exactly the commit the tag points to, by construction, so the two can
+      # never disagree regardless of how many commits land on main afterward.
       - name: Dispatch the ORB release build
         if: steps.report.outputs.due == 'true' && steps.tag.outputs.created == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.report.outputs.tag }}
           VERSION: ${{ steps.report.outputs.version }}
-        run: gh workflow run release-selfhost.yml --ref main -f "version=${VERSION}" -f create_github_release=true
+        run: gh workflow run release-selfhost.yml --ref "$TAG" -f "version=${VERSION}" -f create_github_release=true
 
       - name: Summarize
         if: always()


### PR DESCRIPTION
## What broke

`orb-beta-release.yml`'s "Dispatch the ORB release build" step fires `release-selfhost.yml` via
`--ref main` — the floating branch — instead of the beta tag it had just created and pushed one step
earlier in the same job.

**Observed live**: `orb-v0.4.0-beta.21` was tagged at `347ada8ec`. By the time the dispatch fired, a
concurrent merge had moved `main` to `e984eef7c`. The dispatched run resolved `github.sha` to
`e984eef7c` (from `--ref main`), while the tag it was supposed to release still pointed at `347ada8ec` —
tripping `release-selfhost.yml`'s own `TAG_SHA`-must-equal-`RELEASE_SHA` fail-safe and aborting. The
fail-safe worked correctly (no bad image built/published), but that day's scheduled beta release was
skipped.

## Fix

Dispatch against `$TAG` instead of `main`. The tag is immutable once pushed, so `github.sha` inside the
dispatched run resolves to exactly the commit the tag points to, by construction — closes the race
regardless of how many commits land on `main` afterward.

## Verification

No `src/**` code touched — this is a `.github/workflows/*.yml` trigger-logic fix, not unit-testable
without actually triggering a real release (out of scope here). Verified via `npm run actionlint` (clean)
and manual reasoning about `gh workflow run --ref`'s dispatch semantics.

Fixes #4679