### PR TITLE
refactor(github): consolidate githubHeaders cluster and CI-cache params (#4610)

### DIFF
--- a/src/github/app.ts
+++ b/src/github/app.ts
@@ -7,6 +7,7 @@ import { recordGitHubRateLimitObservation, updateInstallationPermissions } from 
 import { recordClockSkewFromResponse } from "../selfhost/clock-skew";
 import {
   clearGitHubResponseCacheForTest,
+  githubHeaders,
   githubRateLimitAdmissionKeyForInstallation,
   makeInstallationOctokit,
   timeoutFetch,
@@ -215,7 +216,7 @@ async function requestInstallationTokenWithJwt(
     `https://api.github.com/app/installations/${installationId}/access_tokens`,
     {
       method: "POST",
-      headers: githubHeaders(`Bearer ${jwt}`),
+      headers: githubHeaders({ token: jwt, json: true }),
     },
   );
   recordClockSkewFromResponse(response);
@@ -381,7 +382,7 @@ export async function getAppInstallation(
   // cache must stay keyed off the Authorization header (the no-admission-key fallback) to preserve per-App-identity
   // isolation (#1940). recordGitHubRateLimitObservation below records the SAME admissionKey directly instead.
   const response = await timeoutFetch(`https://api.github.com${path}`, {
-    headers: githubHeaders(`Bearer ${jwt}`),
+    headers: githubHeaders({ token: jwt, json: true }),
   });
   // #4506: refreshInstallationHealthRecords's per-installation loop (backfill.ts) makes one of these calls per
   // installation, but this call lives outside backfill.ts's module boundary -- and backfill.ts already imports
@@ -441,7 +442,7 @@ export async function getRepositoryCollaboratorPermission(
   const response = await timeoutFetch(
     `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/collaborators/${encodeURIComponent(login)}/permission`,
     {
-      headers: githubHeaders(`Bearer ${token}`),
+      headers: githubHeaders({ token, json: true }),
       githubRateLimitAdmission: true,
       githubRateLimitAdmissionKey: githubRateLimitAdmissionKeyForInstallation(installationId),
     },
@@ -475,7 +476,7 @@ export async function getGithubUserCreatedAt(
     const response = await timeoutFetch(
       `https://api.github.com/users/${encodeURIComponent(login)}`,
       {
-        headers: githubHeaders(`Bearer ${token}`),
+        headers: githubHeaders({ token, json: true }),
         githubRateLimitAdmission: true,
         githubRateLimitAdmissionKey: githubRateLimitAdmissionKeyForInstallation(installationId),
       },
@@ -615,7 +616,7 @@ export async function cancelInFlightWorkflowRunsForHeadSha(
   try {
     const token = await createInstallationToken(env, installationId);
     const fetchOptions: ActionsRunFetchOptions = {
-      headers: githubHeaders(`Bearer ${token}`),
+      headers: githubHeaders({ token, json: true }),
       githubRateLimitAdmission: true,
       githubRateLimitAdmissionKey: githubRateLimitAdmissionKeyForInstallation(installationId),
     };
@@ -1169,14 +1170,4 @@ export function getInstallationId(
   payload: GitHubWebhookPayload,
 ): number | null {
   return payload.installation?.id ?? null;
-}
-
-function githubHeaders(authorization: string): HeadersInit {
-  return {
-    accept: "application/vnd.github+json",
-    authorization,
-    "content-type": "application/json",
-    "user-agent": "gittensory/0.1",
-    "x-github-api-version": "2022-11-28",
-  };
 }

--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -29,6 +29,32 @@ const DEFAULT_METADATA_TTL_SECONDS = 10 * 60;
 const DEFAULT_COMMIT_TTL_SECONDS = 15 * 60;
 export const GITHUB_RESPONSE_CACHE_REPLAY_HEADER = "x-gittensory-cache";
 
+/** The single shared GitHub REST header-builder for every raw-`fetch`/`timeoutFetch` call in `src/` (Octokit
+ *  calls set their own headers internally and don't need this). Consolidates four independent, drifted
+ *  `githubHeaders` copies that had each grown a different signature (#4610). `token` is optional — a public,
+ *  unauthenticated read omits it rather than sending an empty `authorization`. */
+export interface GitHubHeadersOptions {
+  /** Bearer token. Omitted (or empty) → no `authorization` header. */
+  token?: string | undefined;
+  /** `accept` header value. Defaults to the standard REST JSON media type. */
+  accept?: string | undefined;
+  /** Include `content-type: application/json`, for a request with a JSON body. Defaults to false. */
+  json?: boolean | undefined;
+  /** Include the pinned `x-github-api-version` header. Defaults to true. */
+  apiVersion?: boolean | undefined;
+}
+
+export function githubHeaders(options: GitHubHeadersOptions = {}): Record<string, string> {
+  const { token, accept = "application/vnd.github+json", json = false, apiVersion = true } = options;
+  return {
+    accept,
+    "user-agent": "gittensory/0.1",
+    ...(apiVersion ? { "x-github-api-version": "2022-11-28" } : {}),
+    ...(json ? { "content-type": "application/json" } : {}),
+    ...(token ? { authorization: `Bearer ${token}` } : {}),
+  };
+}
+
 /** A shared cache for safe GitHub GET responses (e.g. Redis on the self-host). Stores only status/body/
  *  content-type plus pagination/validator headers — never rate-limit or encoding headers. Set on the self-host;
  *  the Worker leaves it null. */

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -792,124 +792,140 @@ function evictLiveFactOnReject<T>(
  */
 async function cachedFetchLiveCiAggregate(
   env: Env,
-  repoFullName: string,
-  prNumber: number,
-  headSha: string | null | undefined,
-  token: string | undefined,
-  requiredContexts: ReadonlySet<string> | null | undefined,
-  requiredContextsKey: string,
-  forceRefresh: boolean,
-  // False when the caller's own required-context lookup FAILED (not merely resolved to "none configured") --
-  // that fail-open aggregate must never be persisted under the normal key, or a transient lookup error would
-  // mask the repo's real required-context state for every other reader until the entry's TTL expires (#selfhost-
-  // ci-verification gate review finding). The live-fetched aggregate is still returned to THIS caller either way.
-  requiredContextsResolved: boolean,
-  admissionKey?: GitHubRateLimitAdmissionKey,
+  args: {
+    repoFullName: string;
+    prNumber: number;
+    headSha: string | null | undefined;
+    token: string | undefined;
+    requiredContexts: ReadonlySet<string> | null | undefined;
+    requiredContextsKey: string;
+    forceRefresh: boolean;
+    // False when the caller's own required-context lookup FAILED (not merely resolved to "none configured") --
+    // that fail-open aggregate must never be persisted under the normal key, or a transient lookup error would
+    // mask the repo's real required-context state for every other reader until the entry's TTL expires (#selfhost-
+    // ci-verification gate review finding). The live-fetched aggregate is still returned to THIS caller either way.
+    requiredContextsResolved: boolean;
+    admissionKey?: GitHubRateLimitAdmissionKey | undefined;
+  },
 ): Promise<LiveCiAggregate> {
-  const cached = await getPullRequestDetailSyncState(env, repoFullName, prNumber).catch(() => null);
-  if (!forceRefresh && cached && isCiStateCacheFresh(cached, headSha, requiredContextsKey)) {
+  const cached = await getPullRequestDetailSyncState(env, args.repoFullName, args.prNumber).catch(() => null);
+  if (!args.forceRefresh && cached && isCiStateCacheFresh(cached, args.headSha, args.requiredContextsKey)) {
     const deserialized = deserializeCachedCiAggregate(cached);
     if (deserialized) {
       incr(CI_STATE_CACHE_METRIC, { field: "aggregate", result: "hit" });
       return deserialized;
     }
   }
-  incr(CI_STATE_CACHE_METRIC, { field: "aggregate", result: forceRefresh ? "forced" : "miss" });
-  const live = await fetchLiveCiAggregatePreferGraphQl(env, repoFullName, headSha, token, requiredContexts, admissionKey);
-  if (requiredContextsResolved) {
-    await writeThroughCiStateCache(env, repoFullName, prNumber, cached, headSha, requiredContextsKey, live);
+  incr(CI_STATE_CACHE_METRIC, { field: "aggregate", result: args.forceRefresh ? "forced" : "miss" });
+  const live = await fetchLiveCiAggregatePreferGraphQl(env, args.repoFullName, args.headSha, args.token, args.requiredContexts, args.admissionKey);
+  if (args.requiredContextsResolved) {
+    await writeThroughCiStateCache(env, args.repoFullName, args.prNumber, cached, args.headSha, args.requiredContextsKey, live);
   }
   return live;
 }
 
 function fetchLiveCiAggregateWithRequiredContexts(
   env: Env,
-  repoFullName: string,
-  facts: LiveGithubFacts,
-  prNumber: number,
-  headSha: string | null | undefined,
-  baseRef: string | null | undefined,
-  token: string | undefined,
-  expectedCiContexts: ReadonlyArray<string> | null | undefined,
-  forceRefresh: boolean,
-  admissionKey?: GitHubRateLimitAdmissionKey,
+  args: {
+    repoFullName: string;
+    facts: LiveGithubFacts;
+    prNumber: number;
+    headSha: string | null | undefined;
+    baseRef: string | null | undefined;
+    token: string | undefined;
+    expectedCiContexts: ReadonlyArray<string> | null | undefined;
+    forceRefresh: boolean;
+    admissionKey?: GitHubRateLimitAdmissionKey | undefined;
+  },
 ): Promise<LiveCiAggregate> {
   // CI refresh callers need fresh check/status state; branch protection contexts move slowly enough to stay
   // request-cached. When the #1941 flag is on, fetchLiveCiAggregatePreferGraphQl collapses the check/status reads
   // into one GraphQL rollup (reusing these requiredContexts), else it uses the proven REST aggregate.
   // cachedFetchLiveCiAggregate (#selfhost-ci-verification) is the durable, cross-job snapshot cache sibling to
   // this request-scoped LiveGithubFacts memo -- it is only ever consulted here, on a LiveGithubFacts miss.
-  return cachedRequiredStatusContexts(env, repoFullName, facts, baseRef, token, expectedCiContexts, admissionKey)
+  return cachedRequiredStatusContexts(env, args.repoFullName, args.facts, args.baseRef, args.token, args.expectedCiContexts, args.admissionKey)
     .catch(() => ({ requiredContexts: null, resolved: false }))
     .then(({ requiredContexts, resolved }) =>
-      cachedFetchLiveCiAggregate(env, repoFullName, prNumber, headSha, token, requiredContexts, resolvedRequiredContextsKeyPart(requiredContexts), forceRefresh, resolved, admissionKey),
+      cachedFetchLiveCiAggregate(env, {
+        repoFullName: args.repoFullName,
+        prNumber: args.prNumber,
+        headSha: args.headSha,
+        token: args.token,
+        requiredContexts,
+        requiredContextsKey: resolvedRequiredContextsKeyPart(requiredContexts),
+        forceRefresh: args.forceRefresh,
+        requiredContextsResolved: resolved,
+        admissionKey: args.admissionKey,
+      }),
     );
 }
 
 function cachedLiveCiAggregate(
   env: Env,
-  repoFullName: string,
-  facts: LiveGithubFacts,
-  prNumber: number,
-  headSha: string | null | undefined,
-  baseRef: string | null | undefined,
-  token: string | undefined,
-  expectedCiContexts: ReadonlyArray<string> | null | undefined,
-  admissionKey?: GitHubRateLimitAdmissionKey,
+  args: {
+    repoFullName: string;
+    facts: LiveGithubFacts;
+    prNumber: number;
+    headSha: string | null | undefined;
+    baseRef: string | null | undefined;
+    token: string | undefined;
+    expectedCiContexts: ReadonlyArray<string> | null | undefined;
+    admissionKey?: GitHubRateLimitAdmissionKey | undefined;
+  },
 ): Promise<LiveCiAggregate> {
-  const key = liveFactKey(repoFullName, headSha, baseRef, liveFactTokenPart(token), expectedCiContextsKeyPart(expectedCiContexts));
-  const cached = facts.ciAggregates.get(key);
+  const key = liveFactKey(args.repoFullName, args.headSha, args.baseRef, liveFactTokenPart(args.token), expectedCiContextsKeyPart(args.expectedCiContexts));
+  const cached = args.facts.ciAggregates.get(key);
   if (cached) return cached;
   const next = evictLiveFactOnReject(
-    facts.ciAggregates,
+    args.facts.ciAggregates,
     key,
-    fetchLiveCiAggregateWithRequiredContexts(
-      env,
-      repoFullName,
-      facts,
-      prNumber,
-      headSha,
-      baseRef,
-      token,
-      expectedCiContexts,
-      false,
-      admissionKey,
-    ),
+    fetchLiveCiAggregateWithRequiredContexts(env, {
+      repoFullName: args.repoFullName,
+      facts: args.facts,
+      prNumber: args.prNumber,
+      headSha: args.headSha,
+      baseRef: args.baseRef,
+      token: args.token,
+      expectedCiContexts: args.expectedCiContexts,
+      forceRefresh: false,
+      admissionKey: args.admissionKey,
+    }),
   );
-  facts.ciAggregates.set(key, next);
+  args.facts.ciAggregates.set(key, next);
   return next;
 }
 
 function refreshLiveCiAggregate(
   env: Env,
-  repoFullName: string,
-  facts: LiveGithubFacts,
-  prNumber: number,
-  headSha: string | null | undefined,
-  baseRef: string | null | undefined,
-  token: string | undefined,
-  expectedCiContexts: ReadonlyArray<string> | null | undefined,
-  admissionKey?: GitHubRateLimitAdmissionKey,
+  args: {
+    repoFullName: string;
+    facts: LiveGithubFacts;
+    prNumber: number;
+    headSha: string | null | undefined;
+    baseRef: string | null | undefined;
+    token: string | undefined;
+    expectedCiContexts: ReadonlyArray<string> | null | undefined;
+    admissionKey?: GitHubRateLimitAdmissionKey | undefined;
+  },
 ): Promise<LiveCiAggregate> {
-  const key = liveFactKey(repoFullName, headSha, baseRef, liveFactTokenPart(token), expectedCiContextsKeyPart(expectedCiContexts));
+  const key = liveFactKey(args.repoFullName, args.headSha, args.baseRef, liveFactTokenPart(args.token), expectedCiContextsKeyPart(args.expectedCiContexts));
   const next = evictLiveFactOnReject(
-    facts.ciAggregates,
+    args.facts.ciAggregates,
     key,
-    fetchLiveCiAggregateWithRequiredContexts(
-      env,
-      repoFullName,
-      facts,
-      prNumber,
-      headSha,
-      baseRef,
-      token,
-      expectedCiContexts,
-      true,
-      admissionKey,
-    ),
+    fetchLiveCiAggregateWithRequiredContexts(env, {
+      repoFullName: args.repoFullName,
+      facts: args.facts,
+      prNumber: args.prNumber,
+      headSha: args.headSha,
+      baseRef: args.baseRef,
+      token: args.token,
+      expectedCiContexts: args.expectedCiContexts,
+      forceRefresh: true,
+      admissionKey: args.admissionKey,
+    }),
   );
-  facts.ciAggregates.set(key, next);
-  facts.forcedCiAggregateKeys.add(key);
+  args.facts.ciAggregates.set(key, next);
+  args.facts.forcedCiAggregateKeys.add(key);
   return next;
 }
 
@@ -1001,7 +1017,7 @@ function reuseOrRefreshLiveCiAggregate(
   const key = liveFactKey(repoFullName, headSha, baseRef, liveFactTokenPart(token), expectedCiContextsKeyPart(expectedCiContexts));
   const cached = facts.forcedCiAggregateKeys.has(key) ? facts.ciAggregates.get(key) : undefined;
   if (cached) return cached;
-  return refreshLiveCiAggregate(env, repoFullName, facts, prNumber, headSha, baseRef, token, expectedCiContexts, admissionKey);
+  return refreshLiveCiAggregate(env, { repoFullName, facts, prNumber, headSha, baseRef, token, expectedCiContexts, admissionKey });
 }
 
 /**
@@ -3819,7 +3835,16 @@ async function prReadyForReview(
   }
   // 2) wait for CI to finish before running the Gittensory review. Required contexts still define which failures
   // block/close, but hasPending tracks any visible non-bot CI that is not settled yet.
-  const ci = await cachedLiveCiAggregate(env, repoFullName, liveFacts, pr.number, pr.headSha, pr.baseRef, token, settings.expectedCiContexts, admissionKey).catch(() => undefined);
+  const ci = await cachedLiveCiAggregate(env, {
+    repoFullName,
+    facts: liveFacts,
+    prNumber: pr.number,
+    headSha: pr.headSha,
+    baseRef: pr.baseRef,
+    token,
+    expectedCiContexts: settings.expectedCiContexts,
+    admissionKey,
+  }).catch(() => undefined);
   if (ci?.hasPending) {
     // Staleness cap: inferred or unreadable pending CI can otherwise defer FOREVER (orphaned required context,
     // transiently unreadable pages, fork check that never reports). Past the cap we stop deferring and let the
@@ -8761,17 +8786,16 @@ async function resolveManifestPassedValidationCount(
   // fetchLiveCiAggregatePreferGraphQl, and the durable-cache read/write) is already fail-open at every
   // internal step (see their own doc comments), so it never rejects -- an extra catch here would just be
   // dead, uncoverable code.
-  const liveCi = await cachedLiveCiAggregate(
-    env,
-    args.repoFullName,
-    args.liveFacts,
-    args.prNumber,
-    args.headSha,
-    args.baseRef,
+  const liveCi = await cachedLiveCiAggregate(env, {
+    repoFullName: args.repoFullName,
+    facts: args.liveFacts,
+    prNumber: args.prNumber,
+    headSha: args.headSha,
+    baseRef: args.baseRef,
     token,
-    args.expectedCiContexts,
+    expectedCiContexts: args.expectedCiContexts,
     admissionKey,
-  );
+  });
   return liveCi.ciState === "passed" ? 1 : 0;
 }
 
@@ -11100,7 +11124,16 @@ async function maybePublishPrPublicSurface(
       const baseRef = pr.baseRef ?? repo?.defaultBranch;
       // Required contexts still detect missing/pending required CI, but every visible completed red check/status is
       // adverse and blocks the PR.
-      const liveCi = await refreshLiveCiAggregate(env, repoFullName, webhook.liveFacts, pr.number, pr.headSha, baseRef, token, settings.expectedCiContexts, admissionKey);
+      const liveCi = await refreshLiveCiAggregate(env, {
+        repoFullName,
+        facts: webhook.liveFacts,
+        prNumber: pr.number,
+        headSha: pr.headSha,
+        baseRef,
+        token,
+        expectedCiContexts: settings.expectedCiContexts,
+        admissionKey,
+      });
       // Live merge-state too — the SAME source the disposition uses (planAgentMaintenanceActions reads liveMergeState).
       // The stored pr.mergeableState lags GitHub's async recompute, and the gate's own check/review publication can
       // also advance mergeability after readiness ran, so refresh at this post-publish boundary.

--- a/src/scoring/model.ts
+++ b/src/scoring/model.ts
@@ -2,7 +2,7 @@ import {
   getLatestScoringModelSnapshot,
   persistScoringModelSnapshot,
 } from "../db/repositories";
-import { timeoutFetch } from "../github/client";
+import { githubHeaders, timeoutFetch } from "../github/client";
 import { getLatestRegistrySnapshot } from "../registry/sync";
 import { resolveUpstreamCommitSha } from "../upstream/commit";
 import { syncUnmodeledScoringConstantDrift } from "../upstream/unmodeled-scoring-drift";
@@ -162,7 +162,7 @@ function activeModelWarnings(constants: Record<string, number>): string[] {
 
 async function fetchText(url: string, token?: string): Promise<{ ok: true; value: string } | { ok: false; error: string }> {
   try {
-    const response = await timeoutFetch(url, { headers: githubHeaders(token, "text/plain") });
+    const response = await timeoutFetch(url, { headers: githubHeaders({ token, accept: "text/plain", apiVersion: false }) });
     if (!response.ok) return { ok: false, error: `${response.status} ${response.statusText}` };
     return { ok: true, value: await response.text() };
   } catch (error) {
@@ -172,18 +172,10 @@ async function fetchText(url: string, token?: string): Promise<{ ok: true; value
 
 async function fetchJson(url: string, token?: string): Promise<{ ok: true; value: Record<string, JsonValue> } | { ok: false; error: string }> {
   try {
-    const response = await timeoutFetch(url, { headers: githubHeaders(token, "application/json") });
+    const response = await timeoutFetch(url, { headers: githubHeaders({ token, accept: "application/json", apiVersion: false }) });
     if (!response.ok) return { ok: false, error: `${response.status} ${response.statusText}` };
     return { ok: true, value: (await response.json()) as Record<string, JsonValue> };
   } catch (error) {
     return { ok: false, error: errorMessage(error) };
   }
-}
-
-function githubHeaders(token: string | undefined, accept: string): Record<string, string> {
-  return {
-    accept,
-    "user-agent": "gittensory/0.1",
-    ...(token ? { authorization: `Bearer ${token}` } : {}),
-  };
 }

--- a/src/services/contributor-issue-draft.ts
+++ b/src/services/contributor-issue-draft.ts
@@ -17,7 +17,7 @@ import {
 import type { IssueRecord, RepositoryRecord, RepositorySettings } from "../types";
 import { isGlobalAgentPause } from "../settings/agent-execution";
 import { isMaintainerAssociation } from "../github/commands";
-import { timeoutFetch } from "../github/client";
+import { githubHeaders, timeoutFetch } from "../github/client";
 import { sha256Hex } from "../utils/crypto";
 import { jsonString, nowIso, repoParts } from "../utils/json";
 import {
@@ -559,7 +559,7 @@ async function createGitHubContributorIssue(env: Env, repoFullName: string, draf
   if (!owner || !name) return null;
   const response = await timeoutFetch(`https://api.github.com/repos/${owner}/${name}/issues`, {
     method: "POST",
-    headers: githubHeaders(token),
+    headers: githubHeaders({ token }),
     body: jsonString({
       title: draft.title,
       body: draft.body,
@@ -569,13 +569,4 @@ async function createGitHubContributorIssue(env: Env, repoFullName: string, draf
   if (!response.ok) return null;
   const payload = (await response.json()) as { number?: number; html_url?: string };
   return payload.number && payload.html_url ? { number: payload.number, url: payload.html_url } : null;
-}
-
-function githubHeaders(token: string): Record<string, string> {
-  return {
-    accept: "application/vnd.github+json",
-    "user-agent": "gittensory/0.1",
-    "x-github-api-version": "2022-11-28",
-    authorization: `Bearer ${token}`,
-  };
 }

--- a/src/upstream/ruleset.ts
+++ b/src/upstream/ruleset.ts
@@ -11,7 +11,7 @@ import {
   upsertUpstreamDriftReport,
 } from "../db/repositories";
 import { resolveGittensorySelfRepoFullName } from "../config/gittensory-repo-focus-manifest";
-import { timeoutFetch } from "../github/client";
+import { githubHeaders, timeoutFetch } from "../github/client";
 import { resolveUpstreamCommitSha } from "./commit";
 import { isGlobalAgentPause } from "../settings/agent-execution";
 import { normalizeRegistryPayload } from "../registry/normalize";
@@ -439,7 +439,7 @@ async function fetchTrackedSource(
   try {
     const response = await timeoutFetch(apiUrl, {
       headers: {
-        ...githubHeaders(env.GITHUB_PUBLIC_TOKEN, "application/vnd.github+json"),
+        ...githubHeaders({ token: env.GITHUB_PUBLIC_TOKEN, accept: "application/vnd.github+json" }),
         ...(previous?.etag ? { "if-none-match": previous.etag } : {}),
       },
     });
@@ -467,7 +467,7 @@ async function fetchTrackedSource(
   }
 
   try {
-    const response = await fetch(rawUrl(config, source.path), { headers: githubHeaders(env.GITHUB_PUBLIC_TOKEN, "text/plain") });
+    const response = await fetch(rawUrl(config, source.path), { headers: githubHeaders({ token: env.GITHUB_PUBLIC_TOKEN, accept: "text/plain" }) });
     if (!response.ok) throw new Error(`${response.status} ${response.statusText}`);
     return sourceSnapshotFromContent({
       config,
@@ -1040,7 +1040,7 @@ async function findGitHubIssueForFingerprint(repo: string, token: string, finger
   try {
     for (let page = 1; ; page += 1) {
       const url = `https://api.github.com/repos/${owner}/${name}/issues?state=open&labels=signals&per_page=100&page=${page}`;
-      const response = await timeoutFetch(url, { headers: githubHeaders(token, "application/vnd.github+json") });
+      const response = await timeoutFetch(url, { headers: githubHeaders({ token, accept: "application/vnd.github+json" }) });
       if (!response.ok) return null;
       const issues = (await response.json()) as Array<{
         number?: number;
@@ -1072,7 +1072,7 @@ async function createGitHubDriftIssue(repo: string, token: string, report: Upstr
   if (!owner || !name) return null;
   const response = await timeoutFetch(`https://api.github.com/repos/${owner}/${name}/issues`, {
     method: "POST",
-    headers: githubHeaders(token, "application/vnd.github+json"),
+    headers: githubHeaders({ token, accept: "application/vnd.github+json" }),
     body: jsonString(githubDriftIssuePayload(report, assignees)),
   });
   if (!response.ok) return null;
@@ -1085,7 +1085,7 @@ async function updateGitHubDriftIssue(repo: string, token: string, issueNumber: 
   if (!owner || !name || !Number.isInteger(issueNumber) || issueNumber <= 0) return null;
   const response = await timeoutFetch(`https://api.github.com/repos/${owner}/${name}/issues/${issueNumber}`, {
     method: "PATCH",
-    headers: githubHeaders(token, "application/vnd.github+json"),
+    headers: githubHeaders({ token, accept: "application/vnd.github+json" }),
     body: jsonString(githubDriftIssuePayload(report, assignees)),
   });
   if (!response.ok) return null;
@@ -1100,7 +1100,7 @@ async function validateRecordedGitHubIssue(repo: string, token: string, report: 
   if (!owner || !name || !parsedUrl || parsedUrl.number !== report.issueNumber) return null;
   if (parsedUrl.owner.toLowerCase() !== owner.toLowerCase() || parsedUrl.name.toLowerCase() !== name.toLowerCase()) return null;
   try {
-    const response = await timeoutFetch(`https://api.github.com/repos/${owner}/${name}/issues/${report.issueNumber}`, { headers: githubHeaders(token, "application/vnd.github+json") });
+    const response = await timeoutFetch(`https://api.github.com/repos/${owner}/${name}/issues/${report.issueNumber}`, { headers: githubHeaders({ token, accept: "application/vnd.github+json" }) });
     if (!response.ok) return null;
     const issue = (await response.json()) as {
       number?: number;
@@ -1272,15 +1272,6 @@ function upstreamModulesForArea(area: UpstreamDriftArea): string[] {
     case "source":
       return ["src/upstream/ruleset.ts", "test/contract/upstream-contract.test.ts"];
   }
-}
-
-function githubHeaders(token: string | undefined, accept: string): Record<string, string> {
-  return {
-    accept,
-    "user-agent": "gittensory/0.1",
-    "x-github-api-version": "2022-11-28",
-    ...(token ? { authorization: `Bearer ${token}` } : {}),
-  };
 }
 
 function rawUrl(config: { repo: string; ref: string }, path: string): string {

--- a/test/unit/github-client.test.ts
+++ b/test/unit/github-client.test.ts
@@ -3,6 +3,7 @@ import {
   clearGitHubResponseCacheForTest,
   forcedSelfhostMode,
   githubAdmissionKeyScope,
+  githubHeaders,
   githubRateLimitAdmissionKeyForInstallation,
   githubRateLimitAdmissionKeyForPublicToken,
   githubRateLimitAdmissionKeyForToken,
@@ -182,6 +183,39 @@ describe("githubAdmissionKeyScope — classify an admission key the SAME way as 
     expect(githubAdmissionKeyScope(null)).toBe("unknown");
     expect(githubAdmissionKeyScope(undefined)).toBe("unknown");
     expect(githubAdmissionKeyScope("pat:shared")).toBe("other");
+  });
+});
+
+describe("githubHeaders — the single shared GitHub REST header-builder (#4610, consolidating 4 drifted copies)", () => {
+  it("with no options, defaults to the standard accept + pinned api-version and omits content-type/authorization", () => {
+    expect(githubHeaders()).toEqual({
+      accept: "application/vnd.github+json",
+      "user-agent": "gittensory/0.1",
+      "x-github-api-version": "2022-11-28",
+    });
+  });
+
+  it("adds a Bearer authorization header only when a non-empty token is given", () => {
+    expect(githubHeaders({ token: "abc123" }).authorization).toBe("Bearer abc123");
+    expect(githubHeaders({}).authorization).toBeUndefined(); // omitted token → no header
+    expect(githubHeaders({ token: "" }).authorization).toBeUndefined(); // empty token → treated as absent
+  });
+
+  it("uses a caller-given accept header instead of the default (app.ts/model.ts/ruleset.ts all vary this)", () => {
+    expect(githubHeaders({ accept: "text/plain" }).accept).toBe("text/plain");
+    expect(githubHeaders({ accept: "application/json" }).accept).toBe("application/json");
+  });
+
+  it("includes content-type: application/json only when json is explicitly requested (app.ts's JSON POSTs)", () => {
+    expect(githubHeaders({ json: true })["content-type"]).toBe("application/json");
+    expect(githubHeaders({ json: false })["content-type"]).toBeUndefined();
+    expect(githubHeaders({})["content-type"]).toBeUndefined(); // defaults to false
+  });
+
+  it("includes x-github-api-version unless apiVersion is explicitly disabled (model.ts's fetchText/fetchJson omit it)", () => {
+    expect(githubHeaders({})["x-github-api-version"]).toBe("2022-11-28"); // defaults to true
+    expect(githubHeaders({ apiVersion: true })["x-github-api-version"]).toBe("2022-11-28");
+    expect(githubHeaders({ apiVersion: false })["x-github-api-version"]).toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary

- **Finding 1** — extracts one shared `githubHeaders` REST-header builder into `src/github/client.ts` and replaces four independently-drifted local copies (each with a different signature) in `src/github/app.ts`, `src/scoring/model.ts`, `src/services/contributor-issue-draft.ts`, and `src/upstream/ruleset.ts` (14 call sites total). The new options-object signature (`{ token?, accept?, json?, apiVersion? }`) reconciles the four original shapes while producing byte-identical headers at every existing call site.
- **Finding 2** — converts `processors.ts`'s live CI-aggregate cache cluster (`cachedFetchLiveCiAggregate`, `fetchLiveCiAggregateWithRequiredContexts`, `cachedLiveCiAggregate`, `refreshLiveCiAggregate`) from 9-10 positional params — including three consecutive same-shaped optional strings (`headSha`, `baseRef`, `token`) with no compiler protection against transposition — to the single labeled options-object convention already used by neighboring large functions in this file. The 3-layer cache architecture (`cachedLiveCiAggregate` → `refreshLiveCiAggregate` → `reuseOrRefreshLiveCiAggregate`) is unchanged; only the parameter-passing convention changes.
- Both parts are mechanical, no-behavior-change refactors bundled together per the parent issue. Out of scope and untouched: the sibling `review-enrichment/` `githubHeaders` cluster (#4609, already merged separately as a self-contained change).

Fixes #4610.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` (ran scoped `vitest --coverage` instead — see note below)
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This is a backend-only refactor (`src/queue`, `src/github`, `src/scoring`, `src/services`, `src/upstream`) with zero UI/MCP/workers-pool/OpenAPI/dependency surface, so those checks don't apply to this diff; CI runs them regardless. Locally: `npm run typecheck` is clean, and every changed file was verified with a targeted `vitest --coverage` pass (`test/unit/github-client.test.ts` — including 5 new tests exercising every branch of the new shared `githubHeaders` helper — plus `test/unit/github-app.test.ts`, `test/unit/scoring.test.ts`, `test/unit/contributor-issue-draft.test.ts`, `test/unit/routes-contributor-issue-draft.test.ts`, `test/unit/upstream-ruleset.test.ts`, and the full `test/unit/queue.test.ts`, 1124 tests total, all passing unmodified). Coverage was cross-checked line-by-line against the exact diff hunks: zero uncovered statements or branches on any changed line in either finding. The queue.test.ts suite needed no changes at all, confirming the CI-cache signature change is behavior-preserving.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (No auth *behavior* changed — only header construction — and the existing negative-path tests in `github-app.test.ts`, e.g. JWT-rejection/eviction and installation-token-rejection cases, pass unmodified against the refactored call sites.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (None changed.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (No UI changes.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — backend-only refactor, no UI/frontend/visible changes.

## Notes

- Rebased onto latest `main` immediately before pushing (`git fetch origin && git rebase origin/main`); the only concurrent `processors.ts` change on `main` (#4671, a 1-line edit ~6,000 lines away from this diff) rebased with no conflict.