### PR TITLE
fix(miner-ui): aggregate portfolio queue API to avoid exposing raw queue rows

### DIFF
--- a/apps/gittensory-miner-ui/src/lib/portfolio-queue.ts
+++ b/apps/gittensory-miner-ui/src/lib/portfolio-queue.ts
@@ -1,6 +1,5 @@
-// Read-only client + pure aggregation for the local portfolio-queue API (#4306). The view is summary CARDS,
-// so the aggregation lives here (client-side over `listQueue()`'s rows, per the issue's guidance) as pure,
-// unit-testable functions — the middleware serves raw rows and duplicates no aggregation.
+// Read-only client for the local portfolio-queue API (#4306). The view only needs summary cards, so the
+// middleware returns pre-aggregated counts and never republishes raw queue identifiers or priority metadata.
 
 export const PORTFOLIO_QUEUE_API_PATH = "/api/portfolio-queue";
 
@@ -8,77 +7,52 @@ export const QUEUE_STATUSES = ["queued", "in_progress", "done"] as const;
 
 export type QueueStatus = (typeof QUEUE_STATUSES)[number];
 
-/** One `miner_portfolio_queue` row as served by the local API — mirrors `portfolio-queue.js`'s `rowToEntry`. */
-export type PortfolioQueueRow = {
-  repoFullName: string;
-  identifier: string;
-  priority: number;
-  status: QueueStatus;
-  enqueuedAt: string;
-};
-
 export type QueueStatusCounts = Record<QueueStatus, number>;
-
-export type RepoQueueSummary = { repoFullName: string; counts: QueueStatusCounts; total: number };
 
 export type PortfolioQueueSummary = {
   total: number;
   counts: QueueStatusCounts;
-  byRepo: RepoQueueSummary[];
 };
 
-export type PortfolioQueueResult = { ok: true; rows: PortfolioQueueRow[] } | { ok: false; error: string };
+export type PortfolioQueueResult = { ok: true; summary: PortfolioQueueSummary } | { ok: false; error: string };
 
-function isQueueStatus(value: unknown): value is QueueStatus {
-  return value === "queued" || value === "in_progress" || value === "done";
-}
-
-function isPortfolioQueueRow(value: unknown): value is PortfolioQueueRow {
+function isQueueStatusCounts(value: unknown): value is QueueStatusCounts {
   if (typeof value !== "object" || value === null) return false;
-  const row = value as Record<string, unknown>;
-  return (
-    typeof row.repoFullName === "string" &&
-    typeof row.identifier === "string" &&
-    typeof row.priority === "number" &&
-    typeof row.enqueuedAt === "string" &&
-    isQueueStatus(row.status)
-  );
+  const counts = value as Record<string, unknown>;
+  return QUEUE_STATUSES.every((status) => typeof counts[status] === "number");
 }
 
-const emptyCounts = (): QueueStatusCounts => ({ queued: 0, in_progress: 0, done: 0 });
+function isPortfolioQueueSummary(value: unknown): value is PortfolioQueueSummary {
+  if (typeof value !== "object" || value === null) return false;
+  const summary = value as Record<string, unknown>;
+  return typeof summary.total === "number" && isQueueStatusCounts(summary.counts);
+}
 
-/** Pure aggregation: overall counts by status plus a per-repo breakdown (sorted by repo name for stable cards).
- *  The cross-repo section is the schema's own multi-repo shape surfaced as data — the view decides rendering. */
-export function summarizePortfolioQueue(rows: PortfolioQueueRow[]): PortfolioQueueSummary {
-  const counts = emptyCounts();
-  const perRepo = new Map<string, QueueStatusCounts>();
-  for (const row of rows) {
-    counts[row.status] += 1;
-    const repoCounts = perRepo.get(row.repoFullName) ?? emptyCounts();
-    repoCounts[row.status] += 1;
-    perRepo.set(row.repoFullName, repoCounts);
+export const emptyPortfolioQueueSummary = (): PortfolioQueueSummary => ({
+  total: 0,
+  counts: { queued: 0, in_progress: 0, done: 0 },
+});
+
+export function summarizePortfolioQueueStatuses(statuses: QueueStatus[]): PortfolioQueueSummary {
+  const summary = emptyPortfolioQueueSummary();
+  for (const status of statuses) {
+    summary.total += 1;
+    summary.counts[status] += 1;
   }
-  const byRepo = [...perRepo.entries()]
-    .map(([repoFullName, repoCounts]) => ({
-      repoFullName,
-      counts: repoCounts,
-      total: repoCounts.queued + repoCounts.in_progress + repoCounts.done,
-    }))
-    .sort((a, b) => a.repoFullName.localeCompare(b.repoFullName));
-  return { total: rows.length, counts, byRepo };
+  return summary;
 }
 
-/** Fetch the local queue rows; failures surface as a typed error result the view renders, never a crash. */
+/** Fetch the local queue summary; failures surface as a typed error result the view renders, never a crash. */
 export async function fetchPortfolioQueue(fetchImpl: typeof fetch = fetch): Promise<PortfolioQueueResult> {
   try {
     const response = await fetchImpl(PORTFOLIO_QUEUE_API_PATH);
     if (!response.ok) return { ok: false, error: `local portfolio-queue API responded ${response.status}` };
     const payload: unknown = await response.json();
-    const rows = (payload as { rows?: unknown }).rows;
-    if (!Array.isArray(rows) || !rows.every(isPortfolioQueueRow)) {
+    const summary = (payload as { summary?: unknown }).summary;
+    if (!isPortfolioQueueSummary(summary)) {
       return { ok: false, error: "local portfolio-queue API returned an unexpected payload shape" };
     }
-    return { ok: true, rows };
+    return { ok: true, summary };
   } catch (error) {
     return {
       ok: false,

--- a/apps/gittensory-miner-ui/src/portfolio-queue.test.tsx
+++ b/apps/gittensory-miner-ui/src/portfolio-queue.test.tsx
@@ -2,39 +2,44 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import {
+  emptyPortfolioQueueSummary,
   fetchPortfolioQueue,
   PORTFOLIO_QUEUE_API_PATH,
-  summarizePortfolioQueue,
+  summarizePortfolioQueueStatuses,
   type PortfolioQueueResult,
-  type PortfolioQueueRow,
 } from "./lib/portfolio-queue";
 import { PortfolioPage, PortfolioQueueView } from "./routes/portfolio";
 import { handlePortfolioQueueRequest, type PortfolioQueueApiDeps } from "../vite-portfolio-queue-api";
 
-const fixtureRows: PortfolioQueueRow[] = [
+const fixtureSummary = {
+  total: 4,
+  counts: { queued: 2, in_progress: 1, done: 1 },
+};
+
+const rawQueueRows = [
   {
-    repoFullName: "acme/widgets",
+    repoFullName: "private-org/secret-repo",
     identifier: "issue:12",
     priority: 5,
     status: "queued",
     enqueuedAt: "2026-07-10T06:00:00.000Z",
   },
   {
-    repoFullName: "acme/widgets",
+    repoFullName: "private-org/secret-repo",
     identifier: "issue:13",
     priority: 3,
     status: "in_progress",
     enqueuedAt: "2026-07-10T06:05:00.000Z",
   },
   {
-    repoFullName: "acme/gadgets",
+    repoFullName: "private-org/another-repo",
     identifier: "issue:7",
     priority: 8,
     status: "done",
     enqueuedAt: "2026-07-10T05:00:00.000Z",
   },
   {
-    repoFullName: "acme/gadgets",
+    repoFullName: "private-org/another-repo",
     identifier: "issue:8",
     priority: 1,
     status: "queued",
@@ -42,50 +47,29 @@ const fixtureRows: PortfolioQueueRow[] = [
   },
 ];
 
-describe("summarizePortfolioQueue (#4306)", () => {
-  it("counts rows by status and per repo, sorted by repo name", () => {
-    const summary = summarizePortfolioQueue(fixtureRows);
-    expect(summary.total).toBe(4);
-    expect(summary.counts).toEqual({ queued: 2, in_progress: 1, done: 1 });
-    expect(summary.byRepo).toEqual([
-      { repoFullName: "acme/gadgets", counts: { queued: 1, in_progress: 0, done: 1 }, total: 2 },
-      { repoFullName: "acme/widgets", counts: { queued: 1, in_progress: 1, done: 0 }, total: 2 },
-    ]);
+describe("summarizePortfolioQueueStatuses (#4306)", () => {
+  it("counts queue statuses without retaining row identifiers", () => {
+    expect(summarizePortfolioQueueStatuses(["queued", "in_progress", "done", "queued"])).toEqual(fixtureSummary);
   });
 
-  it("summarizes an empty queue to zeros with no repo rows", () => {
-    expect(summarizePortfolioQueue([])).toEqual({
+  it("summarizes an empty queue to zeros", () => {
+    expect(emptyPortfolioQueueSummary()).toEqual({
       total: 0,
       counts: { queued: 0, in_progress: 0, done: 0 },
-      byRepo: [],
     });
   });
 });
 
 describe("PortfolioQueueView (#4306)", () => {
   it("renders one card per status with the aggregated counts", () => {
-    render(<PortfolioQueueView result={{ ok: true, rows: fixtureRows }} />);
-    // The status words also appear as per-repo column headers, so target the card <dt> elements (first match).
-    expect(screen.getAllByText("Queued")[0]!.nextSibling?.textContent).toBe("2");
-    expect(screen.getAllByText("In progress")[0]!.nextSibling?.textContent).toBe("1");
-    expect(screen.getAllByText("Done")[0]!.nextSibling?.textContent).toBe("1");
-  });
-
-  it("renders the per-repo breakdown when the queue spans multiple repos", () => {
-    render(<PortfolioQueueView result={{ ok: true, rows: fixtureRows }} />);
-    expect(screen.getByRole("columnheader", { name: "Repository" })).toBeTruthy();
-    expect(screen.getByText("acme/widgets")).toBeTruthy();
-    expect(screen.getByText("acme/gadgets")).toBeTruthy();
-  });
-
-  it("omits the per-repo table for a single-repo queue (cards only)", () => {
-    render(<PortfolioQueueView result={{ ok: true, rows: fixtureRows.slice(0, 2) }} />);
-    expect(screen.queryByRole("table")).toBeNull();
-    expect(screen.getByText("Queued").nextSibling?.textContent).toBe("1");
+    render(<PortfolioQueueView result={{ ok: true, summary: fixtureSummary }} />);
+    expect(screen.getByText("Queued").nextSibling?.textContent).toBe("2");
+    expect(screen.getByText("In progress").nextSibling?.textContent).toBe("1");
+    expect(screen.getByText("Done").nextSibling?.textContent).toBe("1");
   });
 
   it("renders the fresh-install empty state without erroring", () => {
-    render(<PortfolioQueueView result={{ ok: true, rows: [] }} />);
+    render(<PortfolioQueueView result={{ ok: true, summary: emptyPortfolioQueueSummary() }} />);
     expect(screen.getByText(/No queued work yet/i)).toBeTruthy();
   });
 
@@ -101,11 +85,11 @@ describe("PortfolioQueueView (#4306)", () => {
 });
 
 describe("PortfolioPage (#4306)", () => {
-  it("loads rows through the injected loader and renders the cards", async () => {
-    const loadPortfolioQueue = async (): Promise<PortfolioQueueResult> => ({ ok: true, rows: fixtureRows });
+  it("loads the summary through the injected loader and renders the cards", async () => {
+    const loadPortfolioQueue = async (): Promise<PortfolioQueueResult> => ({ ok: true, summary: fixtureSummary });
     render(<PortfolioPage loadPortfolioQueue={loadPortfolioQueue} />);
     expect(screen.getByRole("heading", { name: "Portfolio queue" })).toBeTruthy();
-    await waitFor(() => expect(screen.getByText("acme/widgets")).toBeTruthy());
+    await waitFor(() => expect(screen.getByText("Queued").nextSibling?.textContent).toBe("2"));
   });
 });
 
@@ -113,14 +97,14 @@ describe("fetchPortfolioQueue (#4306)", () => {
   const jsonResponse = (status: number, payload: unknown) =>
     ({ ok: status >= 200 && status < 300, status, json: async () => payload }) as unknown as Response;
 
-  it("returns typed rows from a well-formed payload, requesting the local API path", async () => {
+  it("returns a typed summary from a well-formed payload, requesting the local API path", async () => {
     let requested: string | undefined;
     const result = await fetchPortfolioQueue(async (input) => {
       requested = String(input);
-      return jsonResponse(200, { rows: fixtureRows });
+      return jsonResponse(200, { summary: fixtureSummary });
     });
     expect(requested).toBe(PORTFOLIO_QUEUE_API_PATH);
-    expect(result).toEqual({ ok: true, rows: fixtureRows });
+    expect(result).toEqual({ ok: true, summary: fixtureSummary });
   });
 
   it("surfaces non-2xx, malformed payloads, and thrown fetches as typed errors", async () => {
@@ -128,9 +112,11 @@ describe("fetchPortfolioQueue (#4306)", () => {
       ok: false,
       error: "local portfolio-queue API responded 500",
     });
-    expect(await fetchPortfolioQueue(async () => jsonResponse(200, { rows: "nope" }))).toMatchObject({ ok: false });
+    expect(await fetchPortfolioQueue(async () => jsonResponse(200, { rows: rawQueueRows }))).toMatchObject({
+      ok: false,
+    });
     expect(
-      await fetchPortfolioQueue(async () => jsonResponse(200, { rows: [{ ...fixtureRows[0], status: "warp" }] })),
+      await fetchPortfolioQueue(async () => jsonResponse(200, { summary: { total: 1, counts: { queued: "1" } } })),
     ).toMatchObject({ ok: false });
     expect(
       await fetchPortfolioQueue(async () => {
@@ -141,7 +127,7 @@ describe("fetchPortfolioQueue (#4306)", () => {
 });
 
 describe("handlePortfolioQueueRequest (#4306)", () => {
-  const rows = fixtureRows;
+  const rows = rawQueueRows;
   function deps(overrides: Partial<PortfolioQueueApiDeps> = {}): PortfolioQueueApiDeps {
     return {
       loadPortfolioQueueModule: async () => ({
@@ -153,12 +139,15 @@ describe("handlePortfolioQueueRequest (#4306)", () => {
     };
   }
 
-  it("serves the queue rows via the existing portfolio-queue.js exports", async () => {
+  it("serves only aggregate counts and omits raw queue metadata", async () => {
     const handled = await handlePortfolioQueueRequest("GET", "/api/portfolio-queue", deps());
-    expect(handled).toEqual({ status: 200, body: JSON.stringify({ rows }) });
+    expect(handled).toEqual({ status: 200, body: JSON.stringify({ summary: fixtureSummary }) });
+    expect(handled?.body).not.toContain("private-org/secret-repo");
+    expect(handled?.body).not.toContain("issue:12");
+    expect(handled?.body).not.toContain("priority");
   });
 
-  it("serves [] on a fresh install WITHOUT initializing the store", async () => {
+  it("serves an empty summary on a fresh install WITHOUT initializing the store", async () => {
     let listed = false;
     const handled = await handlePortfolioQueueRequest(
       "GET",
@@ -174,7 +163,7 @@ describe("handlePortfolioQueueRequest (#4306)", () => {
         fileExists: () => false,
       }),
     );
-    expect(handled).toEqual({ status: 200, body: JSON.stringify({ rows: [] }) });
+    expect(handled).toEqual({ status: 200, body: JSON.stringify({ summary: emptyPortfolioQueueSummary() }) });
     expect(listed).toBe(false);
   });
 

--- a/apps/gittensory-miner-ui/src/routes/portfolio.tsx
+++ b/apps/gittensory-miner-ui/src/routes/portfolio.tsx
@@ -1,20 +1,14 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
 
-import {
-  fetchPortfolioQueue,
-  summarizePortfolioQueue,
-  type PortfolioQueueResult,
-  type QueueStatus,
-} from "../lib/portfolio-queue";
+import { fetchPortfolioQueue, type PortfolioQueueResult, type QueueStatus } from "../lib/portfolio-queue";
 
 export const Route = createFileRoute("/portfolio")({
   component: PortfolioPage,
 });
 
 // Portfolio/queue summary cards (#4306): read-only counts by status over the local `miner_portfolio_queue`
-// store, with a per-repo breakdown when the local queue spans repos. Same 4-state pattern as the run-history
-// view (loading / error / fresh-install empty / populated).
+// store. Same 4-state pattern as the run-history view (loading / error / fresh-install empty / populated).
 
 const STATUS_LABELS: Record<QueueStatus, string> = {
   queued: "Queued",
@@ -39,7 +33,7 @@ export function PortfolioQueueView({ result }: { result: PortfolioQueueResult | 
       </p>
     );
   }
-  const summary = summarizePortfolioQueue(result.rows);
+  const summary = result.summary;
   if (summary.total === 0) {
     return (
       <p className="text-sm text-white/60">
@@ -57,36 +51,6 @@ export function PortfolioQueueView({ result }: { result: PortfolioQueueResult | 
           </div>
         ))}
       </dl>
-      {summary.byRepo.length > 1 && (
-        <table className="mt-6 w-full text-left text-sm">
-          <thead>
-            <tr className="border-b border-white/10 text-xs uppercase tracking-wider text-white/50">
-              <th scope="col" className="py-2 pr-4">
-                Repository
-              </th>
-              <th scope="col" className="py-2 pr-4">
-                Queued
-              </th>
-              <th scope="col" className="py-2 pr-4">
-                In progress
-              </th>
-              <th scope="col" className="py-2">
-                Done
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {summary.byRepo.map((repo) => (
-              <tr key={repo.repoFullName} className="border-b border-white/5">
-                <td className="py-2 pr-4 font-mono text-white/90">{repo.repoFullName}</td>
-                <td className="py-2 pr-4 text-white/70">{repo.counts.queued}</td>
-                <td className="py-2 pr-4 text-white/70">{repo.counts.in_progress}</td>
-                <td className="py-2 text-white/70">{repo.counts.done}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      )}
     </div>
   );
 }

--- a/apps/gittensory-miner-ui/vite-portfolio-queue-api.ts
+++ b/apps/gittensory-miner-ui/vite-portfolio-queue-api.ts
@@ -4,21 +4,16 @@ import type { Plugin } from "vite";
 // Local read-only portfolio-queue API (#4306) — the sibling of `vite-run-state-api.ts` (#4305), same shape for
 // the same reason: the dashboard is a browser app while the queue store is a `node:sqlite` file on disk, so the
 // dev server bridges the two by calling into `packages/gittensory-miner/lib/portfolio-queue.js`'s EXISTING
-// exports (`resolvePortfolioQueueDbPath`/`listQueue`) — no SQL and no aggregation duplicated at this layer.
+// exports (`resolvePortfolioQueueDbPath`/`listQueue`). It aggregates server-side so the HTTP surface never
+// republishes raw queue identifiers or rank-derived priorities.
 //
 // Same read-only fresh-install rule as the run-state endpoint: `listQueue()` lazily initializes the default
-// store, which would CREATE the SQLite file — so the handler probes the resolved DB path first and serves
-// `{ rows: [] }` without ever touching the store when no DB exists yet.
+// store, which would CREATE the SQLite file — so the handler probes the resolved DB path first and serves an
+// empty summary without ever touching the store when no DB exists yet.
 
 type PortfolioQueueModule = {
   resolvePortfolioQueueDbPath: () => string;
-  listQueue: () => Array<{
-    repoFullName: string;
-    identifier: string;
-    priority: number;
-    status: string;
-    enqueuedAt: string;
-  }>;
+  listQueue: () => Array<{ status: string }>;
 };
 
 export type PortfolioQueueApiDeps = {
@@ -27,6 +22,30 @@ export type PortfolioQueueApiDeps = {
   /** File-existence probe for the fresh-install fast path. */
   fileExists: (path: string) => boolean;
 };
+
+type QueueStatus = "queued" | "in_progress" | "done";
+type QueueStatusCounts = Record<QueueStatus, number>;
+type PortfolioQueueSummary = { total: number; counts: QueueStatusCounts };
+
+const QUEUE_STATUSES = ["queued", "in_progress", "done"] as const;
+
+function emptyPortfolioQueueSummary(): PortfolioQueueSummary {
+  return { total: 0, counts: { queued: 0, in_progress: 0, done: 0 } };
+}
+
+function isQueueStatus(value: string): value is QueueStatus {
+  return (QUEUE_STATUSES as readonly string[]).includes(value);
+}
+
+function summarizePortfolioQueueRows(rows: Array<{ status: string }>): PortfolioQueueSummary {
+  const summary = emptyPortfolioQueueSummary();
+  for (const row of rows) {
+    if (!isQueueStatus(row.status)) continue;
+    summary.total += 1;
+    summary.counts[row.status] += 1;
+  }
+  return summary;
+}
 
 const defaultDeps: PortfolioQueueApiDeps = {
   loadPortfolioQueueModule: () =>
@@ -44,9 +63,9 @@ export async function handlePortfolioQueueRequest(
   try {
     const queue = await deps.loadPortfolioQueueModule();
     if (!deps.fileExists(queue.resolvePortfolioQueueDbPath())) {
-      return { status: 200, body: JSON.stringify({ rows: [] }) };
+      return { status: 200, body: JSON.stringify({ summary: emptyPortfolioQueueSummary() }) };
     }
-    return { status: 200, body: JSON.stringify({ rows: queue.listQueue() }) };
+    return { status: 200, body: JSON.stringify({ summary: summarizePortfolioQueueRows(queue.listQueue()) }) };
   } catch (error) {
     const message = error instanceof Error ? error.message : "failed to read local portfolio queue";
     return { status: 500, body: JSON.stringify({ error: message }) };


### PR DESCRIPTION
### Motivation
- The Vite dev/preview middleware previously serialized `queue.listQueue()` and returned raw rows including `repoFullName`, `identifier`, and `priority`, which exposed private ranking metadata and identifiers over an unauthenticated HTTP surface. 
- The portfolio UI only requires aggregate counts for cards, so the endpoint should return only the minimal aggregated data to avoid unnecessary information disclosure. 

### Description
- Change the Vite middleware to return a minimized summary payload `{ summary: { total, counts } }` instead of raw rows by adding server-side aggregation (`summarizePortfolioQueueRows`) in `apps/gittensory-miner-ui/vite-portfolio-queue-api.ts`. 
- Replace the client contract to consume and validate the `summary` payload and remove client-side reliance on raw `PortfolioQueueRow` fields in `apps/gittensory-miner-ui/src/lib/portfolio-queue.ts`. 
- Update the UI to render directly from the minimized `summary` and remove the per-repo table that required raw repo-level rows in `apps/gittensory-miner-ui/src/routes/portfolio.tsx`. 
- Add/adjust tests in `apps/gittensory-miner-ui/src/portfolio-queue.test.tsx` to assert the endpoint returns aggregated counts, omits raw identifiers/priority, preserves the fresh-install empty behavior, and surfaces store-read errors as a 500-safe message. 

### Testing
- Ran the component/unit tests for the miner UI with `npm --workspace @jsonbored/gittensory-miner-ui run test -- src/portfolio-queue.test.tsx` and all tests passed. 
- Ran `npm --workspace @jsonbored/gittensory-miner-ui run typecheck` and `npm --workspace @jsonbored/gittensory-miner-ui run lint`, and both succeeded (lint produced non-blocking fast-refresh warnings elsewhere). 
- Ran the workspace test command `npm --workspace @jsonbored/gittensory-miner-ui run test` and the miner-ui test suite passed. 
- Attempted the full local gate with `npm run test:ci`, which progressed normally but stopped at the `cf-typegen:check` step because the checked-out workspace had a stale `worker-configuration.d.ts` unrelated to these changes; this change does not modify Wrangler bindings or worker typegen inputs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50bb202d68832cb3e74d0ad8ff1f6f)