### PR TITLE
refactor(queue): extract plan-input builder from runAgentMaintenancePlanAndExecute

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -302,6 +302,7 @@ import {
   MAX_REVIEW_NAG_COOLDOWN_DAYS,
   isProtectedAutomationAuthor,
   planAgentMaintenanceActions,
+  type AgentActionPlanInput,
   type AgentDispositionLabelSettings,
   type PlannedAgentAction,
 } from "../settings/agent-actions";
@@ -2832,6 +2833,144 @@ async function maybeRunAgentMaintenance(
   }
 }
 
+/**
+ * Assemble the {@link AgentActionPlanInput} for {@link runAgentMaintenancePlanAndExecute}'s
+ * planAgentMaintenanceActions call from its ~30 already-resolved local signals (gate verdict, settings, live
+ * CI/merge/review state, guardrail + hold/match results, author flags, duplicate-cluster state). PURE — every
+ * input is already resolved by the caller; this only shapes them into the planner's input contract, so the
+ * shaping itself is unit-tested directly instead of only through the orchestrator (#4607).
+ */
+function buildAgentMaintenancePlanInput(args: {
+  gate: ReturnType<typeof evaluateGateCheck>;
+  settings: RepositorySettings;
+  changedPaths: string[];
+  hardGuardrailGlobs: string[];
+  authorIsOwner: boolean;
+  authorIsAdmin: boolean;
+  authorIsAutomationBot: boolean;
+  ciAggregate: LiveCiAggregate;
+  requiredContexts: Set<string> | null;
+  blacklistEntry: ReturnType<typeof findBlacklistEntry>;
+  screenshotTableMatch: AgentActionPlanInput["screenshotTableMatch"];
+  contributorCapMatch: AgentActionPlanInput["contributorCapMatch"];
+  linkedIssueHardRule: AgentActionPlanInput["linkedIssueHardRule"];
+  linkedIssueRulesConfig: Awaited<ReturnType<typeof loadLinkedIssueHardRules>>;
+  migrationCollisionHold: AgentActionPlanInput["migrationCollisionHold"];
+  unlinkedIssueMatchHold: AgentActionPlanInput["unlinkedIssueMatchHold"];
+  aiReviewLowConfidenceHold: AgentActionPlanInput["aiReviewLowConfidenceHold"];
+  unlinkedIssueMatchClose: AgentActionPlanInput["unlinkedIssueMatchClose"];
+  liveMergeState: string | undefined;
+  liveReviewDecision: string | undefined;
+  pr: PullRequestRecord;
+  openDuplicateSiblings: ReturnType<typeof linkedIssueDuplicatePullRequestRecordsForGate>;
+  duplicateWinnerEnabled: boolean;
+}): AgentActionPlanInput {
+  const {
+    gate,
+    settings,
+    changedPaths,
+    hardGuardrailGlobs,
+    authorIsOwner,
+    authorIsAdmin,
+    authorIsAutomationBot,
+    ciAggregate,
+    requiredContexts,
+    blacklistEntry,
+    screenshotTableMatch,
+    contributorCapMatch,
+    linkedIssueHardRule,
+    linkedIssueRulesConfig,
+    migrationCollisionHold,
+    unlinkedIssueMatchHold,
+    aiReviewLowConfidenceHold,
+    unlinkedIssueMatchClose,
+    liveMergeState,
+    liveReviewDecision,
+    pr,
+    openDuplicateSiblings,
+    duplicateWinnerEnabled,
+  } = args;
+  return {
+    conclusion: gate.conclusion,
+    blockerTitles: gate.blockers.map((blocker) => blocker.title),
+    // Public-safe finding identifiers retained for telemetry/action reasons. They no longer refute a blocker on
+    // green CI; once the gate says failure, the close/hold decision follows that verdict.
+    gateBlockerCodes: gate.blockers.map((blocker) => blocker.code),
+    autonomy: settings.autonomy,
+    autoMaintain: settings.autoMaintain,
+    slopGateMinScore: settings.slopGateMinScore,
+    changedPaths,
+    hardGuardrailGlobs,
+    manualReviewLabel: settings.manualReviewLabel,
+    readyToMergeLabel: settings.readyToMergeLabel,
+    changesRequestedLabel: settings.changesRequestedLabel,
+    migrationCollisionLabel: settings.migrationCollisionLabel,
+    pendingClosureLabel: settings.pendingClosureLabel,
+    authorIsOwner,
+    authorIsAdmin,
+    authorIsAutomationBot,
+    closeOwnerAuthors: settings.closeOwnerAuthors,
+    ciState: ciAggregate.ciState,
+    ciHasPending: ciAggregate.hasPending,
+    failingCheckNames: ciAggregate.failingDetails.map((detail) => detail.name),
+    ciRequiredContextsVerified: hasVerifiedRequiredContexts(requiredContexts),
+    ...(blacklistEntry !== null
+      ? { blacklistMatch: { matched: true, reason: blacklistEntry.reason } }
+      : {}),
+    // Always threaded (the DB layer populates it, default "slop"); the planner applies its own fallback.
+    blacklistLabel: settings.blacklistLabel,
+    ...(screenshotTableMatch !== undefined ? { screenshotTableMatch } : {}),
+    ...(contributorCapMatch !== undefined ? { contributorCapMatch } : {}),
+    // Always threaded (the DB layer populates it, default "over-contributor-limit"); the planner applies its
+    // own fallback.
+    contributorCapLabel: settings.contributorCapLabel,
+    ...(linkedIssueHardRule !== undefined ? { linkedIssueHardRule } : {}),
+    // Flag-then-close double-check: thread the loaded verify config so the planner FLAGS first then closes on
+    // re-verification (default ON). Only passed when a rule is on (the planner reads it only for a violation).
+    linkedIssueVerify: {
+      verifyBeforeClose: linkedIssueRulesConfig.verifyBeforeClose,
+      closeDelaySeconds: linkedIssueRulesConfig.closeDelaySeconds,
+    },
+    ...(migrationCollisionHold !== undefined ? { migrationCollisionHold } : {}),
+    ...(unlinkedIssueMatchHold !== undefined ? { unlinkedIssueMatchHold } : {}),
+    ...(aiReviewLowConfidenceHold !== undefined ? { aiReviewLowConfidenceHold } : {}),
+    ...(unlinkedIssueMatchClose !== undefined ? { unlinkedIssueMatchClose } : {}),
+    pr: {
+      mergeableState: liveMergeState ?? pr.mergeableState,
+      reviewDecision: liveReviewDecision ?? pr.reviewDecision,
+      slopRisk: pr.slopRisk,
+      labels: pr.labels,
+      // Duplicate-winner adjudication (#dup-winner): the gate's open-only duplicate siblings drive the close
+      // reason ("duplicate of another open PR" via agent-actions when count > 0). When the flag is ON and this
+      // PR is the cluster winner, force the count to 0 so the winner's close reason OMITS the duplicate cause
+      // (it can still close on its own merits — CI/conflict/blockers). Flag-OFF short-circuits ⇒ the real
+      // count is used (byte-identical). Sparse legacy rows fail closed so duplicate evidence remains visible.
+      linkedDuplicateCount: dupWinnerLinkedDuplicateCount(
+        openDuplicateSiblings,
+        pr.number,
+        pr.linkedIssueClaimedAt,
+        duplicateWinnerEnabled,
+        pr.createdAt,
+      ),
+      // #dup-winner-credit: name the cluster's actual winner in a loser's close comment instead of a generic
+      // "duplicate of another open PR". `null` (flag off, this PR IS the winner, or an ambiguous election)
+      // falls back to the pre-existing generic wording in agent-actions.ts, byte-identical to before this existed.
+      linkedDuplicateWinnerNumber: dupWinnerLinkedDuplicateWinnerNumber(
+        openDuplicateSiblings,
+        pr.number,
+        pr.linkedIssueClaimedAt,
+        duplicateWinnerEnabled,
+        pr.createdAt,
+      ),
+      headSha: pr.headSha,
+      mergeBlockedSha: pr.mergeBlockedSha,
+      approvedHeadSha: pr.approvedHeadSha,
+      authorLogin: pr.authorLogin,
+      linkedIssues: pr.linkedIssues,
+    },
+  };
+}
+
 /** The plan-and-execute critical section of {@link maybeRunAgentMaintenance}, extracted so the caller's
  *  per-PR lock (#2129) wraps it in a try/finally without reindenting this whole block. */
 async function runAgentMaintenancePlanAndExecute(
@@ -3230,85 +3369,33 @@ async function runAgentMaintenancePlanAndExecute(
   // gate failed SOLELY on a sub-aiReviewCloseConfidence-floor ai_consensus_defect/ai_review_split finding under
   // the (default) hold_for_review disposition. See resolveAiReviewLowConfidenceHold's own doc comment.
   const aiReviewLowConfidenceHold = resolveAiReviewLowConfidenceHold(gate, settings);
-  const planned = planAgentMaintenanceActions({
-    conclusion: gate.conclusion,
-    blockerTitles: gate.blockers.map((blocker) => blocker.title),
-    // Public-safe finding identifiers retained for telemetry/action reasons. They no longer refute a blocker on
-    // green CI; once the gate says failure, the close/hold decision follows that verdict.
-    gateBlockerCodes: gate.blockers.map((blocker) => blocker.code),
-    autonomy: settings.autonomy,
-    autoMaintain: settings.autoMaintain,
-    slopGateMinScore: settings.slopGateMinScore,
-    changedPaths,
-    hardGuardrailGlobs,
-    manualReviewLabel: settings.manualReviewLabel,
-    readyToMergeLabel: settings.readyToMergeLabel,
-    changesRequestedLabel: settings.changesRequestedLabel,
-    migrationCollisionLabel: settings.migrationCollisionLabel,
-    pendingClosureLabel: settings.pendingClosureLabel,
-    authorIsOwner,
-    authorIsAdmin,
-    authorIsAutomationBot,
-    closeOwnerAuthors: settings.closeOwnerAuthors,
-    ciState: ciAggregate.ciState,
-    ciHasPending: ciAggregate.hasPending,
-    failingCheckNames: ciAggregate.failingDetails.map((detail) => detail.name),
-    ciRequiredContextsVerified: hasVerifiedRequiredContexts(requiredContexts),
-    ...(blacklistEntry !== null
-      ? { blacklistMatch: { matched: true, reason: blacklistEntry.reason } }
-      : {}),
-    // Always threaded (the DB layer populates it, default "slop"); the planner applies its own fallback.
-    blacklistLabel: settings.blacklistLabel,
-    ...(screenshotTableMatch !== undefined ? { screenshotTableMatch } : {}),
-    ...(contributorCapMatch !== undefined ? { contributorCapMatch } : {}),
-    // Always threaded (the DB layer populates it, default "over-contributor-limit"); the planner applies its
-    // own fallback.
-    contributorCapLabel: settings.contributorCapLabel,
-    ...(linkedIssueHardRule !== undefined ? { linkedIssueHardRule } : {}),
-    // Flag-then-close double-check: thread the loaded verify config so the planner FLAGS first then closes on
-    // re-verification (default ON). Only passed when a rule is on (the planner reads it only for a violation).
-    linkedIssueVerify: {
-      verifyBeforeClose: linkedIssueRulesConfig.verifyBeforeClose,
-      closeDelaySeconds: linkedIssueRulesConfig.closeDelaySeconds,
-    },
-    ...(migrationCollisionHold !== undefined ? { migrationCollisionHold } : {}),
-    ...(unlinkedIssueMatchHold !== undefined ? { unlinkedIssueMatchHold } : {}),
-    ...(aiReviewLowConfidenceHold !== undefined ? { aiReviewLowConfidenceHold } : {}),
-    ...(unlinkedIssueMatchClose !== undefined ? { unlinkedIssueMatchClose } : {}),
-    pr: {
-      mergeableState: liveMergeState ?? pr.mergeableState,
-      reviewDecision: liveReviewDecision ?? pr.reviewDecision,
-      slopRisk: pr.slopRisk,
-      labels: pr.labels,
-      // Duplicate-winner adjudication (#dup-winner): the gate's open-only duplicate siblings drive the close
-      // reason ("duplicate of another open PR" via agent-actions when count > 0). When the flag is ON and this
-      // PR is the cluster winner, force the count to 0 so the winner's close reason OMITS the duplicate cause
-      // (it can still close on its own merits — CI/conflict/blockers). Flag-OFF short-circuits ⇒ the real
-      // count is used (byte-identical). Sparse legacy rows fail closed so duplicate evidence remains visible.
-      linkedDuplicateCount: dupWinnerLinkedDuplicateCount(
-        openDuplicateSiblings,
-        pr.number,
-        pr.linkedIssueClaimedAt,
-        duplicateWinnerEnabled,
-        pr.createdAt,
-      ),
-      // #dup-winner-credit: name the cluster's actual winner in a loser's close comment instead of a generic
-      // "duplicate of another open PR". `null` (flag off, this PR IS the winner, or an ambiguous election)
-      // falls back to the pre-existing generic wording in agent-actions.ts, byte-identical to before this existed.
-      linkedDuplicateWinnerNumber: dupWinnerLinkedDuplicateWinnerNumber(
-        openDuplicateSiblings,
-        pr.number,
-        pr.linkedIssueClaimedAt,
-        duplicateWinnerEnabled,
-        pr.createdAt,
-      ),
-      headSha: pr.headSha,
-      mergeBlockedSha: pr.mergeBlockedSha,
-      approvedHeadSha: pr.approvedHeadSha,
-      authorLogin: pr.authorLogin,
-      linkedIssues: pr.linkedIssues,
-    },
-  });
+  const planned = planAgentMaintenanceActions(
+    buildAgentMaintenancePlanInput({
+      gate,
+      settings,
+      changedPaths,
+      hardGuardrailGlobs,
+      authorIsOwner,
+      authorIsAdmin,
+      authorIsAutomationBot,
+      ciAggregate,
+      requiredContexts,
+      blacklistEntry,
+      screenshotTableMatch,
+      contributorCapMatch,
+      linkedIssueHardRule,
+      linkedIssueRulesConfig,
+      migrationCollisionHold,
+      unlinkedIssueMatchHold,
+      aiReviewLowConfidenceHold,
+      unlinkedIssueMatchClose,
+      liveMergeState,
+      liveReviewDecision,
+      pr,
+      openDuplicateSiblings,
+      duplicateWinnerEnabled,
+    }),
+  );
   // Accuracy circuit-breakers (#self-improve / GAP-4): two INDEPENDENT, fail-open precision breakers, chained.
   //   • MERGE breaker (holdonly:<scope>): when set, convert a would-MERGE into a human HOLD before executing.
   //   • CLOSE breaker (closehold:<scope>): when set, convert a HEURISTIC would-CLOSE into a human HOLD (the


### PR DESCRIPTION
## Summary

- Part of #4607 (the `processors.ts` mega-function breakup). This PR does **only** the
  `runAgentMaintenancePlanAndExecute` slice of that issue — `maybePublishPrPublicSurface` and
  `processGitHubWebhook` are separate, much larger follow-ups, not touched here.
- The issue's own finding for this function: it "threads ~30 locally-computed values into one giant
  `planAgentMaintenanceActions(...)` call." This PR extracts that ~79-line inline object literal into a
  new, named, independently-typed `buildAgentMaintenancePlanInput` helper (colocated in
  `src/queue/processors.ts`, right above the orchestrator, matching the existing pattern already used
  there for `applyPrecisionBreakers` / `agentHoldAuditDetail` / `agentDispositionLabels` /
  `resolveLiveMigrationCollisionHold`).
- **Pure code motion — zero behavior change.** Every field, every conditional spread
  (`...(x !== undefined ? { x } : {})`), every comment explaining a non-obvious decision, and the exact
  set of already-resolved local values feeding the call are preserved verbatim; only the *shape* of how
  they reach `planAgentMaintenanceActions` changed. Control flow, short-circuit ordering, error handling,
  and every computed value are unchanged.
- Net effect: `runAgentMaintenancePlanAndExecute` shrinks from 717 to 665 lines (-52), with the extracted
  79-line inline object replaced by a 27-line call passing the same already-in-scope local variables by
  name to the new helper.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

Note on the issue link: this is `Part of #4607`, not `Closes`/`Fixes`, since the issue explicitly covers
two more functions (`maybePublishPrPublicSurface`, `processGitHubWebhook`) as separate follow-up PRs — see
the issue body: "this is expected to land as multiple sequential PRs (one per function)."

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` — not run; no `.github/workflows/**` files touched.
- [x] `npm run typecheck` — clean, both before and after rebasing onto latest `main`.
- [ ] `npm run test:coverage` — not run as the literal full-suite command (see explanation below); a
      scoped coverage run proved the diff itself is fully covered.
- [ ] `npm run test:workers` — not run; no `test/workers/**`-relevant code touched.
- [ ] `npm run build:mcp` / `npm run test:mcp-pack` — not run; no MCP package changes.
- [ ] `npm run ui:openapi:check` / `npm run ui:lint` / `npm run ui:typecheck` / `npm run ui:build` — not
      run; no `apps/gittensory-ui/**` or API/schema changes.
- [ ] `npm audit --audit-level=moderate` — not run; no dependency changes.
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — there is no new behavior (pure extraction); see below for how the moved code's existing coverage was confirmed.

If any required check was skipped, explain why:

- This is a single-file, behavior-preserving refactor of `src/queue/processors.ts` with no UI, MCP,
  workers, schema, OpenAPI, or dependency surface touched, so those gates are left to CI rather than
  duplicated locally (they path-filter out for this diff anyway). The two checks that matter for a pure
  refactor — typecheck and the exercising test suite — were run directly, in full, in the foreground,
  **twice** (once pre-rebase, once immediately after rebasing onto the latest `main`):
  - `npm run typecheck`: clean both times.
  - `npx vitest run test/unit/queue.test.ts`: **807/807 tests passed, unmodified**, both times. This is
    the primary test file exercising `runAgentMaintenancePlanAndExecute` (via the higher-level webhook
    processing / auto-action-convergence suites) and `planAgentMaintenanceActions`. No existing assertion
    was touched — an unmodified green run of the exact pre-existing suite is the correctness signal for a
    zero-behavior-change extraction.
  - Coverage: `npx vitest run test/unit/queue.test.ts --coverage`, then cross-referenced the resulting
    `coverage/lcov.info` against the exact added-line ranges from `git diff --unified=0` (the new
    `buildAgentMaintenancePlanInput` function and the rewritten call site). Zero uncovered lines and zero
    uncovered branches within those ranges — the extraction is fully exercised by the existing suite
    transitively, so no new dedicated test file was added for it (a hand-built `RepositorySettings` /
    `PullRequestRecord` / gate fixture for a new test file would be disproportionate — `RepositorySettings`
    alone is a 432-line type with no existing minimal-fixture helper in the codebase).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no auth/cookie/CORS/session code touched.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no API/OpenAPI/MCP surface touched.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section below... — N/A, no visible/UI changes (backend-only refactor).
- [ ] Public docs/changelogs are updated where needed... — N/A, no doc-affecting behavior change; `CHANGELOG.md` intentionally not touched.

## UI Evidence

Not applicable — this PR has no visible/UI/frontend/docs surface; it is a backend-only, behavior-preserving
extraction inside `src/queue/processors.ts`.

## Notes

- This is a maintainer/owner PR (issue #4607 is labeled `maintainer-only`).
- Follow-ups (separate PRs, per the issue): extracting `maybePublishPrPublicSurface` into named steps, and
  splitting `processGitHubWebhook` into per-event-type handlers.
