### PR TITLE
feat(ui): add top-contributors-by-quality-band table to maintainer dashboard

### DIFF
--- a/apps/gittensory-ui/src/components/site/app-panels/contributor-quality-table-model.ts
+++ b/apps/gittensory-ui/src/components/site/app-panels/contributor-quality-table-model.ts
@@ -1,0 +1,21 @@
+import type { Status } from "@/components/site/control-primitives";
+
+// UI-side mirror of MaintainerTopContributor (src/services/maintainer-quality-dashboard.ts), delivered on
+// the /v1/app/maintainer-dashboard payload's qualityDashboard.topContributors (#2204, part of #539). `band`
+// is a plain string, not the narrower server-side union, because it crosses the API boundary the same way
+// reviewability's `bucket` / `slop.band` fields do elsewhere in this panel: an unrecognized value degrades
+// to a neutral pill instead of a type error. Only a BAND and an observable open-PR count are modeled here —
+// never a raw clean-ratio/credibility number (see the boundary rule in maintainer-quality-dashboard.ts).
+export type MaintainerTopContributor = {
+  login: string;
+  band: string;
+  openPrCount: number;
+};
+
+// Deterministic quality band -> pill tone. Unrecognized bands fall back to the neutral "info" tone rather
+// than throwing, mirroring maintainer-panel.tsx's BUCKET_TONE/SLOP_BAND_TONE maps.
+export const QUALITY_BAND_TONE: Record<string, Status> = {
+  strong: "ready",
+  developing: "info",
+  early: "warn",
+};

--- a/apps/gittensory-ui/src/components/site/app-panels/contributor-quality-table.test.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/contributor-quality-table.test.tsx
@@ -1,0 +1,86 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ContributorQualityTable } from "@/components/site/app-panels/contributor-quality-table";
+import type { MaintainerTopContributor } from "@/components/site/app-panels/contributor-quality-table-model";
+
+// Mirrors the forbidden-terms guard in test/unit/maintainer-quality-dashboard.test.ts — the UI must never
+// surface a raw credibility/reward signal even if a caller accidentally widened the prop type.
+const FORBIDDEN_PUBLIC_TERMS =
+  /wallet|hotkey|coldkey|mnemonic|reward|payout|farming|raw trust|trust score|scoreability|credibility|clean ratio|private ranking/i;
+
+function contributor(overrides: Partial<MaintainerTopContributor> = {}): MaintainerTopContributor {
+  return { login: "alice", band: "strong", openPrCount: 4, ...overrides };
+}
+
+describe("ContributorQualityTable", () => {
+  it("renders a row per contributor with login, band pill, and open PR count", () => {
+    render(
+      <ContributorQualityTable
+        topContributors={[
+          contributor({ login: "alice", band: "strong", openPrCount: 5 }),
+          contributor({ login: "bob", band: "developing", openPrCount: 2 }),
+        ]}
+      />,
+    );
+    expect(screen.getByText("Top contributors by quality band")).toBeTruthy();
+    expect(screen.getByText("alice")).toBeTruthy();
+    expect(screen.getByText("bob")).toBeTruthy();
+    expect(screen.getByText("strong")).toBeTruthy();
+    expect(screen.getByText("developing")).toBeTruthy();
+    expect(screen.getByText("5")).toBeTruthy();
+    expect(screen.getByText("2")).toBeTruthy();
+  });
+
+  it("renders a single row without error when there is exactly one contributor in window", () => {
+    render(
+      <ContributorQualityTable
+        topContributors={[contributor({ login: "carol", band: "early", openPrCount: 1 })]}
+      />,
+    );
+    expect(screen.getByText("carol")).toBeTruthy();
+    expect(screen.getByText("early")).toBeTruthy();
+    expect(screen.getByText("1")).toBeTruthy();
+    expect(screen.queryByText("No contributor quality data yet")).toBeNull();
+  });
+
+  it("renders an EmptyState instead of a table when there are no contributors in window", () => {
+    render(<ContributorQualityTable topContributors={[]} />);
+    expect(screen.getByText("No contributor quality data yet")).toBeTruthy();
+    expect(screen.queryByRole("table")).toBeNull();
+  });
+
+  it("falls back to the neutral 'info' pill tone for an unrecognized band value (defensive ?? fallback)", () => {
+    render(
+      <ContributorQualityTable
+        topContributors={[contributor({ login: "dave", band: "mystery" })]}
+      />,
+    );
+    const pill = screen.getByText("mystery");
+    // "info" tone (see STATUS_STYLES in control-primitives.tsx), not the "strong"/"developing"/"early" tones.
+    expect(pill.className).toContain("border-mint/30");
+  });
+
+  it("applies the 'ready' tone for the 'strong' band, distinct from the fallback tone", () => {
+    render(
+      <ContributorQualityTable
+        topContributors={[contributor({ login: "erin", band: "strong" })]}
+      />,
+    );
+    const pill = screen.getByText("strong");
+    expect(pill.className).toContain("border-success/40");
+    expect(pill.className).not.toContain("border-mint/30");
+  });
+
+  it("never renders a raw credibility/clean-ratio number — band label and open PR count only (redaction)", () => {
+    const { container } = render(
+      <ContributorQualityTable
+        topContributors={[contributor({ login: "frank", band: "developing", openPrCount: 3 })]}
+      />,
+    );
+    const text = container.textContent ?? "";
+    expect(text).not.toMatch(FORBIDDEN_PUBLIC_TERMS);
+    // Only the observable open-PR count is numeric — no decimal/percentage-shaped score is ever rendered.
+    expect(text).not.toMatch(/\d+\.\d+|\d+%/);
+  });
+});

--- a/apps/gittensory-ui/src/components/site/app-panels/contributor-quality-table.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/contributor-quality-table.tsx
@@ -1,0 +1,65 @@
+import { BoundaryBadge, StatusPill } from "@/components/site/control-primitives";
+import { EmptyState } from "@/components/site/state-views";
+import {
+  QUALITY_BAND_TONE,
+  type MaintainerTopContributor,
+} from "@/components/site/app-panels/contributor-quality-table-model";
+
+/**
+ * Top-contributors-by-quality-band table (#2204, part of #539): a single, read-only slice of the
+ * maintainer quality dashboard listing each contributor's login, quality band, and open PR count.
+ * Renders the band only — never the raw clean-ratio/credibility number it's derived from.
+ */
+export function ContributorQualityTable({
+  topContributors,
+}: {
+  topContributors: MaintainerTopContributor[];
+}) {
+  return (
+    <section className="rounded-token border-hairline bg-card p-5">
+      <div className="flex items-center justify-between gap-3">
+        <h2 className="font-display text-token-lg font-semibold">
+          Top contributors by quality band
+        </h2>
+        <BoundaryBadge boundary="public" />
+      </div>
+      {topContributors.length === 0 ? (
+        <EmptyState
+          className="mt-4"
+          title="No contributor quality data yet"
+          description="Quality bands appear once this maintainer's repos have cached open pull requests to shape."
+        />
+      ) : (
+        <div className="mt-4 overflow-x-auto">
+          <table className="w-full min-w-[420px] text-left text-token-sm">
+            <thead>
+              <tr className="border-b-hairline font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
+                <th className="py-2 pr-3 font-normal">Contributor</th>
+                <th className="py-2 pr-3 font-normal">Band</th>
+                <th className="py-2 font-normal">Open PRs</th>
+              </tr>
+            </thead>
+            <tbody>
+              {topContributors.map((contributor) => (
+                <tr
+                  key={contributor.login}
+                  className="border-b-hairline last:border-b-0 transition-colors hover:bg-muted/40"
+                >
+                  <td className="py-2 pr-3 font-medium text-foreground">{contributor.login}</td>
+                  <td className="py-2 pr-3">
+                    <StatusPill status={QUALITY_BAND_TONE[contributor.band] ?? "info"}>
+                      {contributor.band}
+                    </StatusPill>
+                  </td>
+                  <td className="py-2 font-mono text-token-xs text-muted-foreground">
+                    {contributor.openPrCount}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/gittensory-ui/src/components/site/app-panels/maintainer-panel-slop.test.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/maintainer-panel-slop.test.tsx
@@ -28,6 +28,7 @@ const dashboard = {
     },
   ],
   settingsPreview: { removed: [], added: [] },
+  qualityDashboard: { topContributors: [] },
 };
 
 vi.mock("@/lib/api/use-api-resource", () => ({

--- a/apps/gittensory-ui/src/components/site/app-panels/maintainer-panel.test.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/maintainer-panel.test.tsx
@@ -66,6 +66,7 @@ describe("MaintainerPanel install health — Orb broker mode (#selfhost-runtime-
     ],
     reviewability: [],
     settingsPreview: { removed: [], added: [] },
+    qualityDashboard: { topContributors: [] },
   };
 
   it("shows a neutral 'n/a (broker)' pill instead of a fabricated perms/webhook verdict for a brokered install", () => {

--- a/apps/gittensory-ui/src/components/site/app-panels/maintainer-panel.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/maintainer-panel.tsx
@@ -19,6 +19,8 @@ import {
 } from "@/components/site/control-primitives";
 import { ActivationPreview } from "@/components/site/app-panels/activation-preview";
 import { AiReviewSettings } from "@/components/site/app-panels/ai-review-settings";
+import { ContributorQualityTable } from "@/components/site/app-panels/contributor-quality-table";
+import type { MaintainerTopContributor } from "@/components/site/app-panels/contributor-quality-table-model";
 import { MaintainerSettings } from "@/components/site/app-panels/maintainer-settings";
 import { StatCard } from "@/components/site/primitives";
 import { EmptyState, LoadingState, StateBoundary } from "@/components/site/state-views";
@@ -76,6 +78,7 @@ type MaintainerDashboard = {
     slop?: { risk: number; band: string } | null;
   }>;
   settingsPreview: { removed: string[]; added: string[] };
+  qualityDashboard: { topContributors: MaintainerTopContributor[] };
 };
 
 type TrustChecklistStatus = "ready" | "needs_attention" | "blocked";
@@ -351,6 +354,8 @@ function MaintainerDashboardView() {
               </tbody>
             </table>
           </section>
+
+          <ContributorQualityTable topContributors={data.qualityDashboard.topContributors} />
 
           <ActivationPreview reviewability={data.reviewability} />
 


### PR DESCRIPTION
## Summary

- Adds a new `ContributorQualityTable` to the maintainer dashboard: a single, read-only table listing each contributor's login, quality band pill, and open PR count.
- Sourced entirely from the already-existing `qualityDashboard.topContributors` field on `GET /v1/app/maintainer-dashboard` (built by `buildMaintainerQualityDashboard`, #557) — no backend/API change needed, this PR is UI-only.
- Bands render only via `StatusPill` (`strong`/`developing`/`early`, with a defensive neutral fallback for an unrecognized value) — never a raw clean-ratio/credibility number, per the #539 public/private boundary rule already enforced server-side.
- Shows an `EmptyState` when there are no contributors in the current window, and wraps the table in a horizontal-scroll container for narrow viewports.
- Wired into `MaintainerDashboardView` right after the existing Reviewability queue section.
- New pure types/tone-map live in a sibling `contributor-quality-table-model.ts` (component file exports only the component), mirroring `gate-precision-card.tsx` / `gate-precision-card-model.ts`.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves — Closes #2204.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally (full unsharded run; `apps/**` is Codecov-ignored, so this is a UI-only change with no patch-coverage obligation — still added 6 new component tests: populated rows, single row, empty state, unrecognized-band fallback tone, known-band tone, and a redaction assertion that no raw score/ratio ever renders)
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:openapi:settings-parity`
- [x] `npm run ui:version-audit`
- [x] `npm run docs:drift-check`
- [x] `npm run manifest:drift-check`
- [x] `npm run command-reference:check`
- [x] `npm run db:migrations:check`
- [x] `npm run db:schema-drift:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:test` (118/118 passed across both UI workspaces)
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate` (0 vulnerabilities)

If any required check was skipped, explain why:

- `npm run test:mcp-pack` and `npm run cf-typegen:check` fail locally with `spawnSync ENOENT` for `npm`/`wrangler` respectively — a pre-existing Windows dev-machine gap (bare-command `spawnSync` doesn't resolve npm's `.cmd` shims without `shell: true`), reproduced in isolation and unrelated to this diff (no `packages/gittensory-mcp` or `wrangler.jsonc`/Cloudflare-binding changes in this PR).
- `npm run engine-parity:drift-check` fails locally because it falls back to comparing against my local `origin/main` git ref (my fork), which is far behind `upstream/main`; the script uses `GITHUB_BASE_SHA` when set in real CI. No `src/signals/**` or `packages/gittensory-engine/**` files are touched by this PR.
- `test/unit/workflow-runner-labels.test.ts` and ~140 other `test/unit/**` cases fail locally on this Windows machine for pre-existing, environment-only reasons unrelated to this diff (POSIX file-permission assertions, missing `claude`/`codex`/`docker`/`psql` CLIs, a workflow-file test that assumes LF against a file legitimately committed with CRLF). None touch `apps/gittensory-ui/**` or the maintainer-quality-dashboard service this PR reads from.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed — only `login`, a quality **band** (never the raw clean-ratio it's derived from), and an observable open-PR count are rendered; covered by a redaction test.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics. (N/A surface — this is authenticated maintainer-console UI, not a public GitHub comment.)
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no such changes in this PR.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP change; the field this PR consumes already exists and is already tested in `test/unit/maintainer-quality-dashboard.test.ts`.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks — reads the live `qualityDashboard.topContributors` field and renders an honest `EmptyState` when it's empty.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (No changelog edit in this PR.)

## UI Evidence

| State / title | Screenshot |
| --- | --- |
| Loaded state (populated table) | <a href="https://gist.githubusercontent.com/claytonlin1110/2da327f4b9560f01feb9ac3ddb0bf738/raw/contributor-quality-populated.png"><img src="https://gist.githubusercontent.com/claytonlin1110/2da327f4b9560f01feb9ac3ddb0bf738/raw/contributor-quality-populated.png" alt="Loaded state" width="420"></a><br><sub>3 contributors across strong/developing/early bands</sub> |
| Empty state | <a href="https://gist.githubusercontent.com/claytonlin1110/2da327f4b9560f01feb9ac3ddb0bf738/raw/contributor-quality-empty.png"><img src="https://gist.githubusercontent.com/claytonlin1110/2da327f4b9560f01feb9ac3ddb0bf738/raw/contributor-quality-empty.png" alt="Empty state" width="420"></a><br><sub>No contributors in the current window</sub> |

## Notes

- No backend/API changes: the `qualityDashboard.topContributors` field this PR renders was already being returned by `GET /v1/app/maintainer-dashboard` (added for #557); this PR is purely the UI consumer for it.
- `apps/**` is excluded from Codecov's patch-coverage gate, but this PR still ships 6 new unit tests for the new component (populated/single/empty states, tone-fallback branch, and a redaction assertion) to match the issue's explicit test requirement.
