### PR TITLE
feat(ui): slop + duplicate trend card on maintainer dashboard (#2202)

### DIFF
--- a/apps/gittensory-ui/src/components/site/app-panels/maintainer-panel.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/maintainer-panel.tsx
@@ -20,6 +20,8 @@ import {
 import { ActivationPreview } from "@/components/site/app-panels/activation-preview";
 import { AiReviewSettings } from "@/components/site/app-panels/ai-review-settings";
 import { MaintainerSettings } from "@/components/site/app-panels/maintainer-settings";
+import { SlopDuplicateTrendCard } from "@/components/site/app-panels/slop-duplicate-trend-card";
+import type { MaintainerSlopDuplicateTrend } from "@/components/site/app-panels/slop-duplicate-trend-card-model";
 import { StatCard } from "@/components/site/primitives";
 import { EmptyState, LoadingState, StateBoundary } from "@/components/site/state-views";
 import { apiFetch } from "@/lib/api/request";
@@ -76,6 +78,9 @@ type MaintainerDashboard = {
     slop?: { risk: number; band: string } | null;
   }>;
   settingsPreview: { removed: string[]; added: string[] };
+  qualityDashboard?: {
+    slopDuplicateTrend: MaintainerSlopDuplicateTrend;
+  } | null;
 };
 
 type TrustChecklistStatus = "ready" | "needs_attention" | "blocked";
@@ -219,6 +224,10 @@ function MaintainerDashboardView() {
               />
             ))}
           </section>
+
+          {data.qualityDashboard?.slopDuplicateTrend ? (
+            <SlopDuplicateTrendCard trend={data.qualityDashboard.slopDuplicateTrend} />
+          ) : null}
 
           <section className="grid gap-6 lg:grid-cols-2">
             <div className="rounded-token border-hairline bg-card p-5">

--- a/apps/gittensory-ui/src/components/site/app-panels/slop-duplicate-trend-card-model.ts
+++ b/apps/gittensory-ui/src/components/site/app-panels/slop-duplicate-trend-card-model.ts
@@ -1,0 +1,63 @@
+// Slop + duplicate trend card model (#2202). UI-side mirror of MaintainerSlopDuplicateTrend from
+// src/services/maintainer-slop-duplicate-trend.ts — plus pure helpers for chart series mapping.
+
+export type SlopBandLabel = "clean" | "low" | "elevated" | "high";
+
+export type SlopDuplicateTrendWeek = {
+  weekStart: string;
+  slopFlagRatePct: number | null;
+  slopBandLabel: SlopBandLabel | null;
+  duplicateFlagRatePct: number | null;
+};
+
+export type MaintainerSlopDuplicateTrend = {
+  generatedAt: string;
+  stale: boolean;
+  weeks: SlopDuplicateTrendWeek[];
+  summary: string;
+};
+
+export function formatTrendRatePct(value: number | null | undefined): string {
+  if (value == null) return "—";
+  return `${value}%`;
+}
+
+export function chartValuesForSeries(
+  weeks: SlopDuplicateTrendWeek[],
+  series: "slop" | "duplicate",
+): number[] {
+  return weeks.map((week) => {
+    const value = series === "slop" ? week.slopFlagRatePct : week.duplicateFlagRatePct;
+    return value ?? 0;
+  });
+}
+
+export function seriesHasSignal(
+  weeks: SlopDuplicateTrendWeek[],
+  series: "slop" | "duplicate",
+): boolean {
+  return weeks.some((week) =>
+    series === "slop" ? week.slopFlagRatePct !== null : week.duplicateFlagRatePct !== null,
+  );
+}
+
+export function trendHasAnySignal(weeks: SlopDuplicateTrendWeek[]): boolean {
+  return seriesHasSignal(weeks, "slop") || seriesHasSignal(weeks, "duplicate");
+}
+
+export function latestWeekWithSignal(
+  weeks: SlopDuplicateTrendWeek[],
+): SlopDuplicateTrendWeek | null {
+  for (let index = weeks.length - 1; index >= 0; index -= 1) {
+    const week = weeks[index];
+    if (!week) continue;
+    if (week.slopFlagRatePct !== null || week.duplicateFlagRatePct !== null) return week;
+  }
+  return null;
+}
+
+export function formatGeneratedAt(iso: string): string {
+  const parsed = Date.parse(iso);
+  if (!Number.isFinite(parsed)) return iso;
+  return new Date(parsed).toUTCString().slice(5, 22);
+}

--- a/apps/gittensory-ui/src/components/site/app-panels/slop-duplicate-trend-card.test.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/slop-duplicate-trend-card.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { SlopDuplicateTrendCard } from "@/components/site/app-panels/slop-duplicate-trend-card";
+import type { MaintainerSlopDuplicateTrend } from "@/components/site/app-panels/slop-duplicate-trend-card-model";
+
+function trend(overrides: Partial<MaintainerSlopDuplicateTrend> = {}): MaintainerSlopDuplicateTrend {
+  return {
+    generatedAt: "2026-06-14T12:00:00.000Z",
+    stale: false,
+    summary: "8-week slop + duplicate flag rates across 1 shaped repo(s).",
+    weeks: Array.from({ length: 8 }, (_, index) => ({
+      weekStart: `2026-04-${String(21 + index).padStart(2, "0")}`,
+      slopFlagRatePct: 12.5,
+      slopBandLabel: "low" as const,
+      duplicateFlagRatePct: 25,
+    })),
+    ...overrides,
+  };
+}
+
+describe("SlopDuplicateTrendCard", () => {
+  it("renders both trend series, shared legend, and freshness metadata", () => {
+    render(<SlopDuplicateTrendCard trend={trend()} />);
+    expect(screen.getByText("Slop + duplicate trend")).toBeTruthy();
+    expect(screen.getAllByText("Slop flag rate").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Duplicate flag rate").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText(/latest band: low/i)).toBeTruthy();
+    expect(screen.getByText(/latest: 25%/i)).toBeTruthy();
+    expect(screen.getByText(/fresh snapshot/i)).toBeTruthy();
+    expect(screen.getByText(/generated/i)).toBeTruthy();
+    expect(screen.getAllByLabelText("Trend chart")).toHaveLength(2);
+  });
+
+  it("shows a one-series-empty branch when only duplicate samples exist", () => {
+    render(
+      <SlopDuplicateTrendCard
+        trend={trend({
+          weeks: [
+            {
+              weekStart: "2026-06-09",
+              slopFlagRatePct: null,
+              slopBandLabel: null,
+              duplicateFlagRatePct: 50,
+            },
+          ],
+        })}
+      />,
+    );
+    expect(screen.getByText("No slop-flag samples in the snapshot window yet.")).toBeTruthy();
+    expect(screen.getByLabelText("Trend chart")).toBeTruthy();
+    expect(screen.getByText(/latest: 50%/i)).toBeTruthy();
+  });
+
+  it("shows the no-data branch when every weekly bucket is empty", () => {
+    render(
+      <SlopDuplicateTrendCard
+        trend={trend({
+          summary: "No queue-health snapshot history yet for slop + duplicate trends across 1 shaped repo(s).",
+          weeks: [
+            {
+              weekStart: "2026-06-09",
+              slopFlagRatePct: null,
+              slopBandLabel: null,
+              duplicateFlagRatePct: null,
+            },
+          ],
+        })}
+      />,
+    );
+    expect(
+      screen.getByText(/Queue-health snapshot history will appear here after signal snapshot jobs run/i),
+    ).toBeTruthy();
+    expect(screen.queryByLabelText("Trend chart")).toBeNull();
+  });
+
+  it("surfaces the stale snapshot pill when data is old", () => {
+    render(<SlopDuplicateTrendCard trend={trend({ stale: true })} />);
+    expect(screen.getByText(/stale snapshot/i)).toBeTruthy();
+  });
+});

--- a/apps/gittensory-ui/src/components/site/app-panels/slop-duplicate-trend-card.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/slop-duplicate-trend-card.tsx
@@ -1,0 +1,155 @@
+import { StatusPill } from "@/components/site/control-primitives";
+import { TrendChart } from "@/components/site/trend-chart";
+import {
+  chartValuesForSeries,
+  formatGeneratedAt,
+  formatTrendRatePct,
+  latestWeekWithSignal,
+  seriesHasSignal,
+  trendHasAnySignal,
+  type MaintainerSlopDuplicateTrend,
+  type SlopBandLabel,
+} from "@/components/site/app-panels/slop-duplicate-trend-card-model";
+import { cn } from "@/lib/utils";
+
+const SLOP_BAND_TONE: Record<SlopBandLabel, string> = {
+  clean: "text-success",
+  low: "text-mint",
+  elevated: "text-warning",
+  high: "text-danger",
+};
+
+/** Maintainer quality dashboard card (#2202): weekly slop-flag and duplicate-flag rates from queue-health
+ *  snapshots. Band labels only — never raw slop-risk or credibility numbers. */
+export function SlopDuplicateTrendCard({ trend }: { trend: MaintainerSlopDuplicateTrend }) {
+  const hasSignal = trendHasAnySignal(trend.weeks);
+  const hasSlop = seriesHasSignal(trend.weeks, "slop");
+  const hasDuplicate = seriesHasSignal(trend.weeks, "duplicate");
+  const latest = latestWeekWithSignal(trend.weeks);
+
+  return (
+    <section className="rounded-token border border-border bg-transparent p-5">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="font-display text-token-lg font-semibold">Slop + duplicate trend</h2>
+          <p className="mt-1 text-token-xs text-muted-foreground">
+            Weekly slop-flag and duplicate-flag rates from queue-health snapshots. Band labels only.
+          </p>
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          <StatusPill status={trend.stale ? "warn" : "ready"}>
+            {trend.stale ? "stale snapshot" : "fresh snapshot"}
+          </StatusPill>
+          <span className="font-mono text-token-2xs text-muted-foreground">
+            generated {formatGeneratedAt(trend.generatedAt)}
+          </span>
+        </div>
+      </div>
+
+      {hasSignal ? (
+        <>
+          <div className="mt-4 flex flex-wrap items-center gap-4 text-token-xs">
+            <LegendItem
+              color="var(--mint)"
+              label="Slop flag rate"
+              detail={
+                latest?.slopBandLabel
+                  ? `latest band: ${latest.slopBandLabel}`
+                  : hasSlop
+                    ? `latest: ${formatTrendRatePct(latest?.slopFlagRatePct)}`
+                    : "no slop samples"
+              }
+              bandLabel={latest?.slopBandLabel}
+            />
+            <LegendItem
+              color="var(--warning)"
+              label="Duplicate flag rate"
+              detail={
+                hasDuplicate
+                  ? `latest: ${formatTrendRatePct(latest?.duplicateFlagRatePct)}`
+                  : "no duplicate samples"
+              }
+            />
+          </div>
+
+          <div className="mt-4 grid gap-4 lg:grid-cols-2">
+            <TrendPanel
+              title="Slop flag rate"
+              emptyMessage="No slop-flag samples in the snapshot window yet."
+              hasSignal={hasSlop}
+              values={chartValuesForSeries(trend.weeks, "slop")}
+              stroke="var(--mint)"
+              fill="color-mix(in oklab, var(--mint) 18%, transparent)"
+            />
+            <TrendPanel
+              title="Duplicate flag rate"
+              emptyMessage="No duplicate-flag samples in the snapshot window yet."
+              hasSignal={hasDuplicate}
+              values={chartValuesForSeries(trend.weeks, "duplicate")}
+              stroke="var(--warning)"
+              fill="color-mix(in oklab, var(--warning) 18%, transparent)"
+            />
+          </div>
+
+          <p className="mt-3 text-token-xs text-muted-foreground">{trend.summary}</p>
+        </>
+      ) : (
+        <p className="mt-4 text-token-sm text-muted-foreground">
+          Queue-health snapshot history will appear here after signal snapshot jobs run for your
+          scoped repositories.
+        </p>
+      )}
+    </section>
+  );
+}
+
+function TrendPanel({
+  title,
+  emptyMessage,
+  hasSignal,
+  values,
+  stroke,
+  fill,
+}: {
+  title: string;
+  emptyMessage: string;
+  hasSignal: boolean;
+  values: number[];
+  stroke: string;
+  fill: string;
+}) {
+  return (
+    <div className="rounded-token border border-border bg-background/40 p-3">
+      <div className="text-token-xs font-medium text-foreground">{title}</div>
+      {hasSignal ? (
+        <div className="mt-2 h-20">
+          <TrendChart values={values} stroke={stroke} fill={fill} height={80} showAxis />
+        </div>
+      ) : (
+        <p className="mt-2 text-token-xs text-muted-foreground">{emptyMessage}</p>
+      )}
+    </div>
+  );
+}
+
+function LegendItem({
+  color,
+  label,
+  detail,
+  bandLabel,
+}: {
+  color: string;
+  label: string;
+  detail: string;
+  bandLabel?: SlopBandLabel | null;
+}) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="inline-block h-2 w-6 rounded-full" style={{ backgroundColor: color }} />
+      <span className="text-foreground">{label}</span>
+      <span className={cn("text-muted-foreground", bandLabel ? SLOP_BAND_TONE[bandLabel] : undefined)}>
+        {detail}
+      </span>
+    </div>
+  );
+}

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -263,6 +263,7 @@ import { getPublicStats, isPublicStatsEnabled } from "../review/public-stats";
 import { loadPublicAccuracyTrend } from "../services/public-accuracy-trend";
 import { loadPublicReuseRateTrend } from "../services/public-reuse-rate-trend";
 import { buildMaintainerQualityDashboard, isMaintainerQualityDataStale } from "../services/maintainer-quality-dashboard";
+import { buildMaintainerSlopDuplicateTrend } from "../services/maintainer-slop-duplicate-trend";
 import { MAX_LOCAL_SCORER_WARNING_CHARS, MAX_LOCAL_SCORER_WARNING_COUNT } from "../signals/local-scorer-diagnostics";
 import { compileFocusManifestPolicy, MAX_FOCUS_MANIFEST_BYTES, normalizeReadinessGateMode } from "../signals/focus-manifest";
 import { resolveRepositorySettings } from "../settings/repository-settings";
@@ -1390,9 +1391,35 @@ export function createApp() {
     const qualityRepoNames = new Set(qualityRepos.map((repo) => repo.fullName.toLowerCase()));
     const scopedSyncCompletions = allSyncStates.filter((state) => qualityRepoNames.has(state.repoFullName.toLowerCase())).map((state) => state.lastCompletedAt);
     const qualityStale = isMaintainerQualityDataStale({ lastCompletedAts: scopedSyncCompletions, repoCount: qualityRepos.length, nowMs: Date.parse(nowIso()) });
-    const qualityDashboard = buildMaintainerQualityDashboard({ repos: qualityRepoInputs, generatedAt: nowIso(), stale: qualityStale, repoTotal: repositories.length });
+    const generatedAt = nowIso();
+    const queueHealthHistories = await Promise.all(
+      qualityRepos.map((repo) => listSignalSnapshots(c.env, "queue-health", repo.fullName)),
+    );
+    const slopDuplicateTrend = buildMaintainerSlopDuplicateTrend({
+      repos: qualityRepoInputs.map((input, index) => {
+        const collisions = buildCollisionReport(input.repo.fullName, input.issues, input.pullRequests);
+        const currentQueueHealth = buildQueueHealth(input.repo, input.issues, input.pullRequests, collisions);
+        return {
+          repoFullName: input.repo.fullName,
+          queueHealthSnapshots: queueHealthHistories[index],
+          currentQueueHealth,
+        };
+      }),
+      generatedAt,
+      stale: qualityStale,
+      nowMs: Date.parse(generatedAt),
+    });
+    const qualityDashboard = {
+      ...buildMaintainerQualityDashboard({
+        repos: qualityRepoInputs,
+        generatedAt,
+        stale: qualityStale,
+        repoTotal: repositories.length,
+      }),
+      slopDuplicateTrend,
+    };
     return c.json({
-      generatedAt: nowIso(),
+      generatedAt,
       installations,
       health: health.map(enrichInstallationHealth),
       metrics: [

--- a/src/services/maintainer-quality-dashboard.ts
+++ b/src/services/maintainer-quality-dashboard.ts
@@ -1,4 +1,5 @@
 import { buildCollisionReport, buildQueueHealth, type QueueHealth } from "../signals/engine";
+import type { MaintainerSlopDuplicateTrend } from "./maintainer-slop-duplicate-trend";
 import type { IssueRecord, PullRequestRecord, RepositoryRecord } from "../types";
 
 // ─── Maintainer quality dashboard (#557) ─────────────────────────────────────────────────────────
@@ -46,6 +47,8 @@ export type MaintainerQualityDashboard = {
   topContributors: MaintainerTopContributor[];
   /** Aggregate counts across the SHAPED repos' open PRs — observable facts, not private scores. */
   qualitySignals: { openPrs: number; duplicatePrRisk: number; missingLinkedIssue: number };
+  /** Weekly slop-flag + duplicate-flag rates from queue-health snapshots (#2202). Attached at API compose time. */
+  slopDuplicateTrend?: MaintainerSlopDuplicateTrend;
   summary: string;
 };
 

--- a/src/services/maintainer-slop-duplicate-trend.ts
+++ b/src/services/maintainer-slop-duplicate-trend.ts
@@ -1,0 +1,190 @@
+import type { JsonValue, SignalSnapshotRecord } from "../types";
+import type { QueueHealth } from "../signals/engine";
+import { isoWeekStart } from "./public-quality-metrics";
+
+// Maintainer slop + duplicate flag-rate trend (#2202). Shapes queue-health signal snapshots (and optional
+// live queue-health points) into weekly slop-flag and duplicate-flag RATES for the maintainer dashboard card.
+// Public-safe: band labels and observable rates only — never raw slop-risk or credibility numbers.
+
+export const SLOP_DUPLICATE_TREND_WEEKS = 8;
+const MS_PER_WEEK = 7 * 86_400_000;
+const MIN_OPEN_PRS_FOR_RATE = 1;
+
+export type SlopBandLabel = "clean" | "low" | "elevated" | "high";
+
+export type SlopDuplicateTrendWeek = {
+  /** UTC Monday (YYYY-MM-DD) that starts the bucket. */
+  weekStart: string;
+  /** Share of open PRs flagged elevated/high slop; null when no open PR sample. */
+  slopFlagRatePct: number | null;
+  /** Dominant slop band label for the week (from the aggregate flag rate, not raw risk scores). */
+  slopBandLabel: SlopBandLabel | null;
+  /** Share of open PRs in a high-risk duplicate cluster; null when no open PR sample. */
+  duplicateFlagRatePct: number | null;
+};
+
+export type MaintainerSlopDuplicateTrend = {
+  generatedAt: string;
+  stale: boolean;
+  weeks: SlopDuplicateTrendWeek[];
+  summary: string;
+};
+
+export type MaintainerSlopDuplicateTrendRepoInput = {
+  repoFullName: string;
+  queueHealthSnapshots?: SignalSnapshotRecord[] | undefined;
+  currentQueueHealth?: QueueHealth | undefined;
+};
+
+type TrendPoint = {
+  generatedAt: string;
+  repoFullName: string;
+  openPullRequests: number;
+  slopFlaggedPullRequests: number;
+  duplicateFlaggedPullRequests: number;
+};
+
+export function buildMaintainerSlopDuplicateTrend(args: {
+  repos: MaintainerSlopDuplicateTrendRepoInput[];
+  generatedAt: string;
+  stale?: boolean;
+  nowMs?: number;
+  weeks?: number;
+}): MaintainerSlopDuplicateTrend {
+  const weeks = args.weeks ?? SLOP_DUPLICATE_TREND_WEEKS;
+  const nowMs = args.nowMs ?? Date.parse(args.generatedAt);
+  const currentStartMs = Date.parse(isoWeekStart(nowMs));
+  const oldestStartMs = currentStartMs - (weeks - 1) * MS_PER_WEEK;
+  const points = collectTrendPoints(args.repos);
+  const trendWeeks = Array.from({ length: weeks }, (_, offset) => {
+    const weekStart = isoWeekStart(oldestStartMs + offset * MS_PER_WEEK);
+    const weekEndMs = oldestStartMs + (offset + 1) * MS_PER_WEEK;
+    const weekStartMs = oldestStartMs + offset * MS_PER_WEEK;
+    const totals = aggregateWeek(points, weekStartMs, weekEndMs);
+    const slopFlagRatePct = ratePct(totals.slopFlaggedPullRequests, totals.openPullRequests);
+    const duplicateFlagRatePct = ratePct(totals.duplicateFlaggedPullRequests, totals.openPullRequests);
+    return {
+      weekStart,
+      slopFlagRatePct,
+      slopBandLabel: slopBandLabelFromRate(slopFlagRatePct),
+      duplicateFlagRatePct,
+    };
+  });
+  const shapedRepos = args.repos.length;
+  const hasSignal = trendWeeks.some(
+    (week) => week.slopFlagRatePct !== null || week.duplicateFlagRatePct !== null,
+  );
+  return {
+    generatedAt: args.generatedAt,
+    stale: args.stale ?? false,
+    weeks: trendWeeks,
+    summary: hasSignal
+      ? `${weeks}-week slop + duplicate flag rates across ${shapedRepos} shaped repo(s).`
+      : `No queue-health snapshot history yet for slop + duplicate trends across ${shapedRepos} shaped repo(s).`,
+  };
+}
+
+/** Map an aggregate slop flag rate to a public band label (never a raw credibility score). */
+export function slopBandLabelFromRate(ratePct: number | null): SlopBandLabel | null {
+  if (ratePct == null) return null;
+  if (ratePct <= 0) return "clean";
+  if (ratePct < 25) return "low";
+  if (ratePct < 60) return "elevated";
+  return "high";
+}
+
+export function trendPointFromQueueHealth(queueHealth: QueueHealth): Omit<TrendPoint, "repoFullName"> {
+  return {
+    generatedAt: queueHealth.generatedAt,
+    openPullRequests: queueHealth.signals.openPullRequests,
+    slopFlaggedPullRequests: queueHealth.signals.slopFlaggedPullRequests,
+    duplicateFlaggedPullRequests: queueHealth.signals.duplicateFlaggedPullRequests,
+  };
+}
+
+function collectTrendPoints(repos: MaintainerSlopDuplicateTrendRepoInput[]): TrendPoint[] {
+  const points: TrendPoint[] = [];
+  for (const repo of repos) {
+    for (const snapshot of repo.queueHealthSnapshots ?? []) {
+      const extracted = trendPointFromSignalSnapshot(snapshot);
+      if (extracted) points.push({ repoFullName: repo.repoFullName, ...extracted });
+    }
+    if (repo.currentQueueHealth) {
+      points.push({ repoFullName: repo.repoFullName, ...trendPointFromQueueHealth(repo.currentQueueHealth) });
+    }
+  }
+  return points.filter((point) => Number.isFinite(Date.parse(point.generatedAt)));
+}
+
+function aggregateWeek(
+  points: TrendPoint[],
+  weekStartMs: number,
+  weekEndMs: number,
+): { openPullRequests: number; slopFlaggedPullRequests: number; duplicateFlaggedPullRequests: number } {
+  const latestByRepo = new Map<string, TrendPoint>();
+  for (const point of points) {
+    const ms = Date.parse(point.generatedAt);
+    if (ms < weekStartMs || ms >= weekEndMs) continue;
+    const existing = latestByRepo.get(point.repoFullName);
+    if (!existing || Date.parse(existing.generatedAt) < ms) latestByRepo.set(point.repoFullName, point);
+  }
+  let openPullRequests = 0;
+  let slopFlaggedPullRequests = 0;
+  let duplicateFlaggedPullRequests = 0;
+  for (const point of latestByRepo.values()) {
+    openPullRequests += point.openPullRequests;
+    slopFlaggedPullRequests += point.slopFlaggedPullRequests;
+    duplicateFlaggedPullRequests += point.duplicateFlaggedPullRequests;
+  }
+  return { openPullRequests, slopFlaggedPullRequests, duplicateFlaggedPullRequests };
+}
+
+function trendPointFromSignalSnapshot(
+  snapshot: SignalSnapshotRecord,
+): Omit<TrendPoint, "repoFullName"> | null {
+  if (!snapshot.generatedAt) return null;
+  const signals = readQueueHealthSignals(snapshot.payload);
+  return signals ? { generatedAt: snapshot.generatedAt, ...signals } : null;
+}
+
+function readQueueHealthSignals(
+  payload: Record<string, JsonValue>,
+): Omit<TrendPoint, "generatedAt" | "repoFullName"> | null {
+  const signals = isRecord(payload.signals) ? payload.signals : null;
+  if (!signals) return null;
+  const openPullRequests = numberValue(signals.openPullRequests);
+  const collisionClusters = numberValue(signals.collisionClusters);
+  const slopFlaggedPullRequests = numberValue(signals.slopFlaggedPullRequests);
+  const duplicateFlaggedPullRequests =
+    signals.duplicateFlaggedPullRequests !== undefined
+      ? numberValue(signals.duplicateFlaggedPullRequests)
+      : legacyDuplicateFlagged(openPullRequests, collisionClusters);
+  return {
+    openPullRequests,
+    slopFlaggedPullRequests,
+    duplicateFlaggedPullRequests,
+  };
+}
+
+/** Pre-#2202 queue-health snapshots only stored collision cluster counts — approximate flagged PRs. */
+function legacyDuplicateFlagged(openPullRequests: number, collisionClusters: number): number {
+  if (openPullRequests <= 0 || collisionClusters <= 0) return 0;
+  return Math.min(openPullRequests, collisionClusters * 2);
+}
+
+function ratePct(flagged: number, openPullRequests: number): number | null {
+  if (openPullRequests < MIN_OPEN_PRS_FOR_RATE) return null;
+  return roundPct((flagged / openPullRequests) * 100);
+}
+
+function roundPct(value: number): number {
+  return Math.round(value * 10) / 10;
+}
+
+function numberValue(value: JsonValue | undefined): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}
+
+function isRecord(value: JsonValue | undefined): value is Record<string, JsonValue> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -96,6 +96,10 @@ export type QueueHealth = {
     draftPullRequests: number;
     maintainerAuthoredPullRequests: number;
     collisionClusters: number;
+    /** Open PRs with slop band elevated or high (public-safe flag count for trend snapshots). */
+    slopFlaggedPullRequests: number;
+    /** Open PRs in a high-risk duplicate cluster with 2+ pull requests (public-safe flag count). */
+    duplicateFlaggedPullRequests: number;
     ageBuckets: {
       under7Days: number;
       days7To30: number;
@@ -954,6 +958,23 @@ export function buildQueueHealth(
   const stalePullRequests = openPullRequests.filter((pr) => daysSince(pr.updatedAt ?? pr.createdAt) >= 14);
   const draftPullRequests = openPullRequests.filter((pr) => pr.isDraft);
   const maintainerAuthoredPullRequests = openPullRequests.filter((pr) => isMaintainerAssociation(pr.authorAssociation));
+  const slopFlaggedPullRequests = openPullRequests.filter(
+    (pr) => pr.slopBand === "elevated" || pr.slopBand === "high",
+  ).length;
+  const highRiskDuplicatePrNumbers = new Set(
+    collisions.clusters
+      .filter(
+        (cluster) =>
+          cluster.risk === "high" &&
+          cluster.items.filter((item) => item.type === "pull_request").length >= 2,
+      )
+      .flatMap((cluster) =>
+        cluster.items.filter((item) => item.type === "pull_request").map((item) => item.number),
+      ),
+  );
+  const duplicateFlaggedPullRequests = openPullRequests.filter((pr) =>
+    highRiskDuplicatePrNumbers.has(pr.number),
+  ).length;
   const cachedLikelyReviewablePullRequests = openPullRequests.filter((pr) => pr.linkedIssues.length > 0 && daysSince(pr.updatedAt ?? pr.createdAt) < 30).length;
   const likelyReviewablePullRequests = Math.min(openPullRequestCount, Math.max(cachedLikelyReviewablePullRequests, countOverrides.likelyReviewablePullRequests ?? 0));
   const ageBuckets = {
@@ -1027,6 +1048,8 @@ export function buildQueueHealth(
       draftPullRequests: draftPullRequests.length,
       maintainerAuthoredPullRequests: maintainerAuthoredPullRequests.length,
       collisionClusters: collisions.summary.clusterCount,
+      slopFlaggedPullRequests,
+      duplicateFlaggedPullRequests,
       ageBuckets,
       likelyReviewablePullRequests,
       cachedOpenPullRequests: openPullRequests.length,

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -2209,7 +2209,7 @@ describe("api routes", () => {
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
       metrics: Array<{ label: string; value: number }>;
-      qualityDashboard: { generatedAt: string; stale: boolean; repoQuality: Array<{ repoFullName: string; queueBand: string }>; topContributors: Array<{ login: string; band: string }>; qualitySignals: { openPrs: number }; summary: string };
+      qualityDashboard: { generatedAt: string; stale: boolean; repoQuality: Array<{ repoFullName: string; queueBand: string }>; topContributors: Array<{ login: string; band: string }>; qualitySignals: { openPrs: number }; slopDuplicateTrend: { generatedAt: string; stale: boolean; weeks: Array<{ weekStart: string }>; summary: string }; summary: string };
     };
     expect(body.metrics.find((metric) => metric.label === "Open PRs cached")?.value).toBe(8);
     // Quality dashboard (#557): shaped, scoped, public-safe trend/outcome data with bands not raw scores.
@@ -2219,6 +2219,8 @@ describe("api routes", () => {
     expect(body.qualityDashboard.repoQuality.every((entry) => ["low", "medium", "high", "critical"].includes(entry.queueBand))).toBe(true);
     expect(body.qualityDashboard.topContributors.every((entry) => ["strong", "developing", "early"].includes(entry.band))).toBe(true);
     expect(body.qualityDashboard.qualitySignals.openPrs).toBeGreaterThanOrEqual(0);
+    expect(body.qualityDashboard.slopDuplicateTrend.generatedAt).toEqual(expect.any(String));
+    expect(body.qualityDashboard.slopDuplicateTrend.weeks.length).toBeGreaterThan(0);
     expect(body.qualityDashboard.summary).toContain("open PR(s)");
     expect(JSON.stringify(body.qualityDashboard)).not.toMatch(FORBIDDEN_PUBLIC_REPORT_TERMS);
     expect(JSON.stringify(body.qualityDashboard)).not.toMatch(/"burdenScore"|"credibility"/);

--- a/test/unit/maintainer-slop-duplicate-trend.test.ts
+++ b/test/unit/maintainer-slop-duplicate-trend.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, it } from "vitest";
+
+import { buildQueueHealth, buildCollisionReport } from "../../src/signals/engine";
+import {
+  buildMaintainerSlopDuplicateTrend,
+  slopBandLabelFromRate,
+  SLOP_DUPLICATE_TREND_WEEKS,
+} from "../../src/services/maintainer-slop-duplicate-trend";
+import type { IssueRecord, PullRequestRecord, RepositoryRecord } from "../../src/types";
+
+const FORBIDDEN_PUBLIC_TERMS =
+  /wallet|hotkey|coldkey|mnemonic|reward|payout|farming|raw trust|trust score|scoreability|credibility|private ranking|slopRisk/i;
+
+function repo(fullName: string): RepositoryRecord {
+  return {
+    fullName,
+    owner: fullName.split("/")[0]!,
+    name: fullName.split("/")[1]!,
+    isInstalled: true,
+    isRegistered: true,
+    isPrivate: false,
+    registryConfig: {
+      repo: fullName,
+      emissionShare: 0.02,
+      issueDiscoveryShare: 0,
+      labelMultipliers: {},
+      maintainerCut: 0,
+      raw: {},
+    },
+  };
+}
+
+function pr(number: number, over: Partial<PullRequestRecord> = {}): PullRequestRecord {
+  return {
+    repoFullName: "octo/demo",
+    number,
+    title: `PR ${number}`,
+    state: "open",
+    authorLogin: "alice",
+    authorAssociation: "NONE",
+    headSha: `sha${number}`,
+    labels: [],
+    linkedIssues: [number + 100],
+    ...over,
+  };
+}
+
+function issue(number: number): IssueRecord {
+  return {
+    repoFullName: "octo/demo",
+    number,
+    title: `Issue ${number}`,
+    state: "open",
+    authorLogin: "maintainer",
+    authorAssociation: "OWNER",
+    labels: [],
+    linkedPrs: [],
+  };
+}
+
+function queueHealthSnapshot(generatedAt: string, signals: Record<string, number>) {
+  return {
+    id: crypto.randomUUID(),
+    signalType: "queue-health",
+    targetKey: "octo/demo",
+    repoFullName: "octo/demo",
+    payload: { signals },
+    generatedAt,
+  };
+}
+
+describe("buildMaintainerSlopDuplicateTrend", () => {
+  it("builds both weekly series with band labels and no forbidden public terms", () => {
+    const trend = buildMaintainerSlopDuplicateTrend({
+      generatedAt: "2026-06-14T12:00:00.000Z",
+      stale: false,
+      nowMs: Date.parse("2026-06-14T12:00:00.000Z"),
+      repos: [
+        {
+          repoFullName: "octo/demo",
+          queueHealthSnapshots: [
+            queueHealthSnapshot("2026-06-02T00:00:00.000Z", {
+              openPullRequests: 10,
+              collisionClusters: 1,
+              slopFlaggedPullRequests: 1,
+              duplicateFlaggedPullRequests: 2,
+            }),
+            queueHealthSnapshot("2026-06-09T00:00:00.000Z", {
+              openPullRequests: 8,
+              collisionClusters: 2,
+              slopFlaggedPullRequests: 4,
+              duplicateFlaggedPullRequests: 3,
+            }),
+          ],
+        },
+      ],
+    });
+    expect(trend.generatedAt).toBe("2026-06-14T12:00:00.000Z");
+    expect(trend.stale).toBe(false);
+    expect(trend.weeks).toHaveLength(SLOP_DUPLICATE_TREND_WEEKS);
+    const populated = trend.weeks.filter(
+      (week) => week.slopFlagRatePct !== null || week.duplicateFlagRatePct !== null,
+    );
+    expect(populated.length).toBeGreaterThan(0);
+    expect(populated.some((week) => week.slopFlagRatePct !== null)).toBe(true);
+    expect(populated.some((week) => week.duplicateFlagRatePct !== null)).toBe(true);
+    for (const week of populated) {
+      if (week.slopBandLabel) {
+        expect(["clean", "low", "elevated", "high"]).toContain(week.slopBandLabel);
+      }
+    }
+    expect(JSON.stringify(trend)).not.toMatch(FORBIDDEN_PUBLIC_TERMS);
+  });
+
+  it("returns null slop series when snapshots lack slop counts but still shapes duplicate series", () => {
+    const trend = buildMaintainerSlopDuplicateTrend({
+      generatedAt: "2026-06-14T12:00:00.000Z",
+      nowMs: Date.parse("2026-06-14T12:00:00.000Z"),
+      repos: [
+        {
+          repoFullName: "octo/demo",
+          queueHealthSnapshots: [
+            queueHealthSnapshot("2026-06-09T00:00:00.000Z", {
+              openPullRequests: 4,
+              collisionClusters: 1,
+            }),
+          ],
+        },
+      ],
+    });
+    const week = trend.weeks.find((entry) => entry.duplicateFlagRatePct !== null);
+    expect(week?.duplicateFlagRatePct).toBeGreaterThan(0);
+    expect(week?.slopFlagRatePct).toBe(0);
+    expect(week?.slopBandLabel).toBe("clean");
+  });
+
+  it("returns an all-null series when there is no snapshot history", () => {
+    const trend = buildMaintainerSlopDuplicateTrend({
+      generatedAt: "2026-06-14T12:00:00.000Z",
+      repos: [{ repoFullName: "octo/demo", queueHealthSnapshots: [] }],
+    });
+    expect(trend.weeks.every((week) => week.slopFlagRatePct === null && week.duplicateFlagRatePct === null)).toBe(
+      true,
+    );
+    expect(trend.summary).toContain("No queue-health snapshot history");
+  });
+
+  it("uses live queue-health for the current week when provided", () => {
+    const issues = [issue(101), issue(102)];
+    const pullRequests = [
+      pr(1, { linkedIssues: [101], slopBand: "high", slopRisk: 80 }),
+      pr(2, { linkedIssues: [102], slopBand: "clean", slopRisk: 0 }),
+      pr(3, { linkedIssues: [101], slopBand: "elevated", slopRisk: 40 }),
+    ];
+    const collisions = buildCollisionReport("octo/demo", issues, pullRequests);
+    const queueHealth = buildQueueHealth(repo("octo/demo"), issues, pullRequests, collisions);
+    const trend = buildMaintainerSlopDuplicateTrend({
+      generatedAt: queueHealth.generatedAt,
+      nowMs: Date.parse(queueHealth.generatedAt),
+      repos: [{ repoFullName: "octo/demo", currentQueueHealth: queueHealth }],
+    });
+    const latest = trend.weeks.at(-1);
+    expect(latest?.slopFlagRatePct).toBeGreaterThan(0);
+    expect(latest?.slopBandLabel).not.toBe("clean");
+    expect(JSON.stringify(trend)).not.toMatch(/"slopRisk"/);
+  });
+});
+
+describe("slopBandLabelFromRate", () => {
+  it("maps aggregate flag rates to public band labels", () => {
+    expect(slopBandLabelFromRate(null)).toBeNull();
+    expect(slopBandLabelFromRate(0)).toBe("clean");
+    expect(slopBandLabelFromRate(10)).toBe("low");
+    expect(slopBandLabelFromRate(40)).toBe("elevated");
+    expect(slopBandLabelFromRate(75)).toBe("high");
+  });
+});

--- a/test/unit/predicted-gate-engine-branch-coverage.test.ts
+++ b/test/unit/predicted-gate-engine-branch-coverage.test.ts
@@ -349,7 +349,7 @@ describe("predicted-gate engine branch coverage (#2283)", () => {
       burdenScore: 0,
       level: "low",
       summary: "s",
-      signals: { openIssues: 0, openPullRequests: 0, unlinkedPullRequests: 0, stalePullRequests: 0, draftPullRequests: 0, maintainerAuthoredPullRequests: 0, collisionClusters: 0, ageBuckets: { under7Days: 0, days7To30: 0, over30Days: 0 }, likelyReviewablePullRequests: 0, cachedOpenPullRequests: 0, likelyReviewablePullRequestsSource: "cache" },
+      signals: { openIssues: 0, openPullRequests: 0, unlinkedPullRequests: 0, stalePullRequests: 0, draftPullRequests: 0, maintainerAuthoredPullRequests: 0, collisionClusters: 0, slopFlaggedPullRequests: 0, duplicateFlaggedPullRequests: 0, ageBuckets: { under7Days: 0, days7To30: 0, over30Days: 0 }, likelyReviewablePullRequests: 0, cachedOpenPullRequests: 0, likelyReviewablePullRequestsSource: "cache" },
       findings: [],
     });
     expect(emptyQueue.evidence).toContain("0 likely reviewable");


### PR DESCRIPTION
Add weekly slop-flag and duplicate-flag rate trends from queue-health snapshots to the maintainer console, with band labels, freshness metadata, and Vitest coverage.

## Summary

- Extends `buildQueueHealth` / queue-health signal snapshots with `slopFlaggedPullRequests` and `duplicateFlaggedPullRequests` counts.
- Adds `buildMaintainerSlopDuplicateTrend` to roll up an 8-week trend from historical snapshots plus the live queue-health point for the current week.
- Exposes `qualityDashboard.slopDuplicateTrend` on `GET /v1/app/maintainer-dashboard`.
- Adds `SlopDuplicateTrendCard` to the maintainer console: dual `TrendChart` series (slop flag rate, duplicate flag rate), shared legend, `generatedAt`, and stale/fresh pill.
- Surfaces **band labels only** on the card — no raw slop-risk, trust, or credibility numbers.
- Vitest coverage for the service (populated series, one-series-empty, no-data) and the UI card (loaded, empty, stale branches).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

Closes #2202  
Part of #539

## Validation

- [ ] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- MCP / worker / actionlint checks are unchanged by this PR (UI + maintainer-dashboard API + queue-health signal only); CI will run the full matrix on push.
- Targeted local runs completed during development:
  - `npm test -- --run test/unit/maintainer-slop-duplicate-trend.test.ts`
  - `npm --workspace @jsonbored/gittensory-ui test -- --run src/components/site/app-panels/slop-duplicate-trend-card.test.tsx`
  - `npm test -- --run test/integration/api.test.ts -t "counts cached open PRs across all in-scope repos"`
  - `npm --workspace @jsonbored/gittensory-ui run typecheck`

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

Auth/session/CORS unchanged. The card reads maintainer-scoped dashboard data from the existing authenticated route; empty and stale states are driven by real snapshot availability, not hard-coded demo payloads in production code.

## UI Evidence

| State / title | JPG/PNG evidence |
| --- | --- |
| **Before** — `/app/maintainer` loaded state (no trend card between StatCards and Install health) | <a href="https://github.com/user-attachments/assets/2437719c-95cf-4117-8a47-17aa8f2bca77"><img width="240" alt="before" src="https://github.com/user-attachments/assets/2437719c-95cf-4117-8a47-17aa8f2bca77" /></a> |
| **After** — `/app/maintainer` loaded state (new **Slop + duplicate trend** card with dual charts, legend, `generatedAt`, fresh pill) | <a href="https://github.com/user-attachments/assets/27bef5c1-d6e9-46f0-bdb3-a737e05892a9"><img width="240" alt="after" src="https://github.com/user-attachments/assets/27bef5c1-d6e9-46f0-bdb3-a737e05892a9" /></a> |

**What changed (annotated framing):** capture the row of four **StatCards** (`Installations`, `Open PRs cached`, `Install issues`, `Rate-limit events`) and the section directly beneath them. **Before:** StatCards flow straight into **Install health**. **After:** the new **Slop + duplicate trend** card sits between StatCards and **Install health**.


## Notes

- Trend rates are derived from existing `queue-health` signal snapshots; no new public GitHub surface is added.
- Slop severity is shown as band labels (`clean` / `low` / `elevated` / `high`) only — raw slop-risk values are not rendered.
- If the chart is flat on a live install, queue-health snapshot history may still be warming up; the card shows the appropriate empty/stale state until snapshots accumulate.