### PR TITLE
feat(ui): one-click advisory-to-blocking gate ramp control

### DIFF
--- a/apps/gittensory-ui/src/components/site/app-panels/gate-ramp-confirm-dialog.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/gate-ramp-confirm-dialog.tsx
@@ -43,14 +43,15 @@ export function GateRampConfirmDialog({
         <AlertDialogHeader>
           <AlertDialogTitle>Enable blocking gate rules?</AlertDialogTitle>
           <AlertDialogDescription asChild>
-            <div className="space-y-3 text-left text-sm text-muted-foreground">
+            <div className="space-y-3 text-left text-token-sm text-muted-foreground">
               <p>
-                This updates <span className="font-mono text-foreground/90">{repoFullName}</span> via the
-                same settings mutation as the repository settings editor. Pull requests that trip these
-                gates may be blocked from merging once branch protection requires the Gittensory check.
+                This updates <span className="font-mono text-foreground/90">{repoFullName}</span>{" "}
+                via the same settings mutation as the repository settings editor. Pull requests that
+                trip these gates may be blocked from merging once branch protection requires the
+                Gittensory check.
               </p>
               {transitions.length > 0 ? (
-                <ul className="space-y-1 rounded-token border border-border/60 bg-muted/20 px-3 py-2 font-mono text-token-2xs">
+                <ul className="space-y-1 rounded-token border-hairline bg-muted/20 px-3 py-2 font-mono text-token-2xs">
                   {transitions.map((entry) => (
                     <li key={entry.key}>
                       {RAMP_GATE_DISPLAY_LABELS[entry.key]}: {entry.from} → {entry.to}

--- a/apps/gittensory-ui/src/components/site/app-panels/gate-ramp-confirm-dialog.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/gate-ramp-confirm-dialog.tsx
@@ -1,0 +1,81 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  listRampGateTransitions,
+  RAMP_GATE_DISPLAY_LABELS,
+  type GateRampSettingsSlice,
+} from "@/lib/gate-ramp";
+
+type GateRampConfirmDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  repoFullName: string;
+  settings: GateRampSettingsSlice;
+  busy: boolean;
+  onConfirm: () => void;
+};
+
+/**
+ * Confirmation gate before moving deterministic rules from advisory to blocking (#2218). Lists the exact
+ * sub-gates that will change so maintainers know what becomes merge-blocking.
+ */
+export function GateRampConfirmDialog({
+  open,
+  onOpenChange,
+  repoFullName,
+  settings,
+  busy,
+  onConfirm,
+}: GateRampConfirmDialogProps) {
+  const transitions = listRampGateTransitions(settings);
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Enable blocking gate rules?</AlertDialogTitle>
+          <AlertDialogDescription asChild>
+            <div className="space-y-3 text-left text-sm text-muted-foreground">
+              <p>
+                This updates <span className="font-mono text-foreground/90">{repoFullName}</span> via the
+                same settings mutation as the repository settings editor. Pull requests that trip these
+                gates may be blocked from merging once branch protection requires the Gittensory check.
+              </p>
+              {transitions.length > 0 ? (
+                <ul className="space-y-1 rounded-token border border-border/60 bg-muted/20 px-3 py-2 font-mono text-token-2xs">
+                  {transitions.map((entry) => (
+                    <li key={entry.key}>
+                      {RAMP_GATE_DISPLAY_LABELS[entry.key]}: {entry.from} → {entry.to}
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p>All ramp gates are already blocking.</p>
+              )}
+            </div>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={busy}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            disabled={busy || transitions.length === 0}
+            onClick={(event) => {
+              event.preventDefault();
+              onConfirm();
+            }}
+          >
+            {busy ? "Saving…" : "Enable blocking"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/gittensory-ui/src/components/site/app-panels/gate-ramp-control.test.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/gate-ramp-control.test.tsx
@@ -101,7 +101,9 @@ describe("GateRampControl (#2218)", () => {
       ),
     );
 
-    const putCall = apiFetch.mock.calls.find(([, opts]) => (opts as { method?: string })?.method === "PUT");
+    const putCall = apiFetch.mock.calls.find(
+      ([, opts]) => (opts as { method?: string })?.method === "PUT",
+    );
     expect(putCall?.[0]).toContain("/v1/repos/acme/widgets/settings");
     const body = JSON.parse(String((putCall?.[1] as { body?: string })?.body ?? "{}"));
     expect(body.linkedIssueGateMode).toBe("block");
@@ -119,7 +121,9 @@ describe("GateRampControl (#2218)", () => {
     fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
 
     await waitFor(() => expect(screen.queryByText(/Enable blocking gate rules/i)).toBeNull());
-    expect(apiFetch.mock.calls.filter(([, opts]) => (opts as { method?: string })?.method === "PUT")).toHaveLength(0);
+    expect(
+      apiFetch.mock.calls.filter(([, opts]) => (opts as { method?: string })?.method === "PUT"),
+    ).toHaveLength(0);
   });
 
   it("toasts an error when the blocking ramp save fails", async () => {

--- a/apps/gittensory-ui/src/components/site/app-panels/gate-ramp-control.test.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/gate-ramp-control.test.tsx
@@ -1,0 +1,163 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { apiFetch } = vi.hoisted(() => ({ apiFetch: vi.fn() }));
+vi.mock("@/lib/api/request", () => ({ apiFetch: (...args: unknown[]) => apiFetch(...args) }));
+vi.mock("@/lib/api/origin", () => ({ getApiOrigin: () => "https://api.test" }));
+
+const { toastSuccess, toastError } = vi.hoisted(() => ({
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+}));
+vi.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccess(...args),
+    error: (...args: unknown[]) => toastError(...args),
+  },
+}));
+
+import { GateRampControl } from "@/components/site/app-panels/gate-ramp-control";
+
+const REVIEWABILITY = [{ pr: "acme/widgets#1" }];
+
+const ADVISORY_SETTINGS = {
+  commentMode: "detected_contributors_only" as const,
+  publicAudienceMode: "oss_maintainer" as const,
+  publicSignalLevel: "standard" as const,
+  publicSurface: "comment_and_label" as const,
+  checkRunMode: "enabled" as const,
+  checkRunDetailLevel: "standard" as const,
+  gateCheckMode: "enabled" as const,
+  reviewCheckMode: "required" as const,
+  gatePack: "gittensor" as const,
+  linkedIssueGateMode: "advisory" as const,
+  duplicatePrGateMode: "advisory" as const,
+  qualityGateMode: "advisory" as const,
+  qualityGateMinScore: null,
+  mergeReadinessGateMode: "off" as const,
+  manifestPolicyGateMode: "off" as const,
+  firstTimeContributorGrace: false,
+  slopGateMode: "off" as const,
+  slopGateMinScore: null,
+  slopAiAdvisory: false,
+  autoLabelEnabled: true,
+  gittensorLabel: "gittensor",
+  createMissingLabel: true,
+  includeMaintainerAuthors: false,
+  requireLinkedIssue: false,
+  badgeEnabled: false,
+  publicQualityMetrics: false,
+  commandAuthorization: {},
+  autonomy: {},
+  autoMaintain: { requireApprovals: 1, mergeMethod: "squash" as const },
+  agentPaused: false,
+  agentDryRun: false,
+};
+
+const BLOCKING_SETTINGS = {
+  ...ADVISORY_SETTINGS,
+  linkedIssueGateMode: "block" as const,
+  duplicatePrGateMode: "block" as const,
+  qualityGateMode: "block" as const,
+};
+
+describe("GateRampControl (#2218)", () => {
+  beforeEach(() => {
+    apiFetch.mockReset();
+    toastSuccess.mockReset();
+    toastError.mockReset();
+  });
+
+  it("loads settings and shows advisory phase with ramp switch off", async () => {
+    apiFetch.mockResolvedValue({ ok: true, data: ADVISORY_SETTINGS });
+    render(<GateRampControl reviewability={REVIEWABILITY} />);
+
+    await waitFor(() => expect(screen.getByText(/Advisory/i)).toBeTruthy());
+    const rampSwitch = screen.getByRole("switch", { name: /blocking enforcement/i });
+    expect(rampSwitch.getAttribute("aria-checked")).toBe("false");
+    expect(apiFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/v1/repos/acme/widgets/settings"),
+      expect.objectContaining({ label: "Repository settings" }),
+    );
+  });
+
+  it("opens confirm on switch, saves blocking ramp on confirm, and toasts success", async () => {
+    apiFetch.mockResolvedValueOnce({ ok: true, data: ADVISORY_SETTINGS });
+    render(<GateRampControl reviewability={REVIEWABILITY} />);
+    await waitFor(() => expect(screen.getByRole("switch")).toBeTruthy());
+
+    apiFetch.mockResolvedValueOnce({ ok: true, data: BLOCKING_SETTINGS });
+    fireEvent.click(screen.getByRole("switch"));
+    expect(screen.getByText(/Enable blocking gate rules/i)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /^Enable blocking$/i }));
+
+    await waitFor(() =>
+      expect(toastSuccess).toHaveBeenCalledWith(
+        "Blocking mode enabled",
+        expect.objectContaining({
+          description: expect.stringContaining("can now block merges"),
+        }),
+      ),
+    );
+
+    const putCall = apiFetch.mock.calls.find(([, opts]) => (opts as { method?: string })?.method === "PUT");
+    expect(putCall?.[0]).toContain("/v1/repos/acme/widgets/settings");
+    const body = JSON.parse(String((putCall?.[1] as { body?: string })?.body ?? "{}"));
+    expect(body.linkedIssueGateMode).toBe("block");
+    expect(body.duplicatePrGateMode).toBe("block");
+    expect(body.qualityGateMode).toBe("block");
+    expect(body.commentMode).toBe("detected_contributors_only");
+  });
+
+  it("closes confirm without saving when cancel is clicked", async () => {
+    apiFetch.mockResolvedValueOnce({ ok: true, data: ADVISORY_SETTINGS });
+    render(<GateRampControl reviewability={REVIEWABILITY} />);
+    await waitFor(() => expect(screen.getByRole("switch")).toBeTruthy());
+
+    fireEvent.click(screen.getByRole("switch"));
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+    await waitFor(() => expect(screen.queryByText(/Enable blocking gate rules/i)).toBeNull());
+    expect(apiFetch.mock.calls.filter(([, opts]) => (opts as { method?: string })?.method === "PUT")).toHaveLength(0);
+  });
+
+  it("toasts an error when the blocking ramp save fails", async () => {
+    apiFetch.mockResolvedValueOnce({ ok: true, data: ADVISORY_SETTINGS });
+    render(<GateRampControl reviewability={REVIEWABILITY} />);
+    await waitFor(() => expect(screen.getByRole("switch")).toBeTruthy());
+
+    fireEvent.click(screen.getByRole("switch"));
+    apiFetch.mockResolvedValueOnce({ ok: false, message: "403 Forbidden" });
+    fireEvent.click(screen.getByRole("button", { name: /^Enable blocking$/i }));
+
+    await waitFor(() =>
+      expect(toastError).toHaveBeenCalledWith(
+        "Could not enable blocking",
+        expect.objectContaining({ description: "403 Forbidden" }),
+      ),
+    );
+    expect(toastSuccess).not.toHaveBeenCalled();
+  });
+
+  it("disables the switch when the gate is inactive", async () => {
+    apiFetch.mockResolvedValue({
+      ok: true,
+      data: { ...ADVISORY_SETTINGS, reviewCheckMode: "disabled", gateCheckMode: "off" },
+    });
+    render(<GateRampControl reviewability={REVIEWABILITY} />);
+
+    await waitFor(() => expect(screen.getByText(/Gate off/i)).toBeTruthy());
+    expect(screen.getByRole("switch")).toHaveProperty("disabled", true);
+  });
+
+  it("shows blocking phase with switch on and disabled when already ramped", async () => {
+    apiFetch.mockResolvedValue({ ok: true, data: BLOCKING_SETTINGS });
+    render(<GateRampControl reviewability={REVIEWABILITY} />);
+
+    await waitFor(() => expect(screen.getByText(/Blocking/i)).toBeTruthy());
+    const rampSwitch = screen.getByRole("switch");
+    expect(rampSwitch.getAttribute("aria-checked")).toBe("true");
+    expect(rampSwitch).toHaveProperty("disabled", true);
+  });
+});

--- a/apps/gittensory-ui/src/components/site/app-panels/gate-ramp-control.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/gate-ramp-control.tsx
@@ -8,7 +8,11 @@ import { StateBoundary } from "@/components/site/state-views";
 import { Switch } from "@/components/ui/switch";
 import { apiFetch } from "@/lib/api/request";
 import { getApiOrigin } from "@/lib/api/origin";
-import { buildBlockingRampPatch, summarizeGateRamp, type GateRampSettingsSlice } from "@/lib/gate-ramp";
+import {
+  buildBlockingRampPatch,
+  summarizeGateRamp,
+  type GateRampSettingsSlice,
+} from "@/lib/gate-ramp";
 import {
   buildMaintainerSettingsSavePayload,
   type MaintainerSettingsEditable,
@@ -132,12 +136,14 @@ export function GateRampControl({ reviewability }: { reviewability: Array<{ pr: 
             Gate ramp control
           </h2>
           <p className="mt-1 text-token-xs text-muted-foreground">
-            After advisory mode is on, ramp deterministic gate rules to blocking in one action — with
-            confirmation before merges can be held.
+            After advisory mode is on, ramp deterministic gate rules to blocking in one action —
+            with confirmation before merges can be held.
           </p>
         </div>
         {summary ? (
-          <StatusPill status={summary.isBlocking ? "blocked" : summary.phase === "advisory" ? "info" : "warn"}>
+          <StatusPill
+            status={summary.isBlocking ? "blocked" : summary.phase === "advisory" ? "info" : "warn"}
+          >
             {summary.label}
           </StatusPill>
         ) : null}
@@ -186,7 +192,7 @@ export function GateRampControl({ reviewability }: { reviewability: Array<{ pr: 
             <div className="space-y-4">
               <p className="text-token-sm text-foreground/90">{summary.description}</p>
 
-              <div className="flex flex-wrap items-center justify-between gap-4 rounded-token border border-border/60 bg-background/40 px-4 py-3">
+              <div className="flex flex-wrap items-center justify-between gap-4 rounded-token border-hairline bg-background/40 px-4 py-3">
                 <div className="flex min-w-0 items-start gap-3">
                   <ShieldAlert className="mt-0.5 size-4 shrink-0 text-warning" aria-hidden />
                   <div>
@@ -203,7 +209,9 @@ export function GateRampControl({ reviewability }: { reviewability: Array<{ pr: 
                   </div>
                 </div>
                 <div className="flex items-center gap-2">
-                  {busy ? <Loader2 className="size-4 animate-spin text-muted-foreground" aria-hidden /> : null}
+                  {busy ? (
+                    <Loader2 className="size-4 animate-spin text-muted-foreground" aria-hidden />
+                  ) : null}
                   <Switch
                     id={switchId}
                     checked={switchChecked}

--- a/apps/gittensory-ui/src/components/site/app-panels/gate-ramp-control.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/gate-ramp-control.tsx
@@ -1,0 +1,233 @@
+import { Loader2, ShieldAlert } from "lucide-react";
+import { useCallback, useEffect, useId, useMemo, useState } from "react";
+import { toast } from "sonner";
+
+import { StatusPill } from "@/components/site/control-primitives";
+import { GateRampConfirmDialog } from "@/components/site/app-panels/gate-ramp-confirm-dialog";
+import { StateBoundary } from "@/components/site/state-views";
+import { Switch } from "@/components/ui/switch";
+import { apiFetch } from "@/lib/api/request";
+import { getApiOrigin } from "@/lib/api/origin";
+import { buildBlockingRampPatch, summarizeGateRamp, type GateRampSettingsSlice } from "@/lib/gate-ramp";
+import {
+  buildMaintainerSettingsSavePayload,
+  type MaintainerSettingsEditable,
+} from "@/lib/maintainer-settings-editable";
+import { extractPreviewRepoOptions, splitRepoFullName } from "@/lib/maintainer-settings-preview";
+
+function repoApiBase(repoFullName: string): string | null {
+  const target = splitRepoFullName(repoFullName);
+  if (!target) return null;
+  return `${getApiOrigin().replace(/\/$/, "")}/v1/repos/${encodeURIComponent(target.owner)}/${encodeURIComponent(target.repo)}`;
+}
+
+const JSON_HEADERS = { Accept: "application/json", "Content-Type": "application/json" };
+const FIELD_CLASS =
+  "mt-1 min-h-10 w-full rounded-token border border-border bg-background/70 px-3 py-2 font-mono text-token-sm text-foreground outline-none transition-colors focus:border-mint";
+const LABEL_CLASS = "font-mono text-token-2xs uppercase tracking-wider text-muted-foreground";
+
+function normalizeLoadedSettings(data: MaintainerSettingsEditable): MaintainerSettingsEditable {
+  return {
+    ...data,
+    autonomy: data.autonomy ?? {},
+    agentPaused: data.agentPaused ?? false,
+    agentDryRun: data.agentDryRun ?? false,
+    autoMaintain: data.autoMaintain ?? { requireApprovals: 1, mergeMethod: "squash" },
+  };
+}
+
+/**
+ * One-click advisory → blocking ramp for the maintainer onboarding surface (#2218). Loads GET /settings,
+ * reflects the current ramp phase, and on confirm merges the blocking patch through PUT /settings (same path
+ * as maintainer-settings.tsx). AlertDialog gates the destructive flip; sonner toasts report save outcomes.
+ */
+export function GateRampControl({ reviewability }: { reviewability: Array<{ pr: string }> }) {
+  const repoOptions = useMemo(() => extractPreviewRepoOptions(reviewability), [reviewability]);
+  const [repoFullName, setRepoFullName] = useState(repoOptions[0] ?? "");
+  const [settings, setSettings] = useState<MaintainerSettingsEditable | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const switchId = useId();
+  const base = repoApiBase(repoFullName);
+  const hasRepos = repoOptions.length > 0;
+
+  const rampSlice: GateRampSettingsSlice | null = settings
+    ? {
+        gateCheckMode: settings.gateCheckMode,
+        reviewCheckMode: settings.reviewCheckMode,
+        linkedIssueGateMode: settings.linkedIssueGateMode,
+        duplicatePrGateMode: settings.duplicatePrGateMode,
+        qualityGateMode: settings.qualityGateMode,
+      }
+    : null;
+
+  const summary = rampSlice ? summarizeGateRamp(rampSlice) : null;
+
+  const load = useCallback(async () => {
+    const apiBase = repoApiBase(repoFullName);
+    if (!apiBase) {
+      setSettings(null);
+      setLoadError(null);
+      return;
+    }
+    setLoadError(null);
+    setLoading(true);
+    const result = await apiFetch<MaintainerSettingsEditable>(`${apiBase}/settings`, {
+      label: "Repository settings",
+      credentials: "include",
+      silentStatus: true,
+    });
+    setSettings(result.ok ? normalizeLoadedSettings(result.data) : null);
+    if (!result.ok) setLoadError(result.message);
+    setLoading(false);
+  }, [repoFullName]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function saveBlockingRamp() {
+    if (!base || !settings) return;
+    setBusy(true);
+    const payload = buildMaintainerSettingsSavePayload(settings, buildBlockingRampPatch());
+    const result = await apiFetch<MaintainerSettingsEditable>(`${base}/settings`, {
+      method: "PUT",
+      label: "Ramp to blocking",
+      credentials: "include",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(payload),
+    });
+    setBusy(false);
+    setConfirmOpen(false);
+    if (result.ok) {
+      setSettings(normalizeLoadedSettings(result.data));
+      toast.success("Blocking mode enabled", {
+        description: "Linked-issue, duplicate-PR, and quality gates can now block merges.",
+      });
+    } else {
+      toast.error("Could not enable blocking", { description: result.message });
+    }
+  }
+
+  function handleSwitchChange(checked: boolean) {
+    if (!summary?.canRampToBlocking || !checked) return;
+    setConfirmOpen(true);
+  }
+
+  const switchChecked = summary?.isBlocking ?? false;
+  const switchDisabled =
+    busy || loading || !summary || !summary.canRampToBlocking || summary.isBlocking;
+
+  return (
+    <section
+      className="rounded-token border-hairline bg-card p-5"
+      aria-labelledby="gate-ramp-control-title"
+    >
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h2 id="gate-ramp-control-title" className="font-display text-token-lg font-semibold">
+            Gate ramp control
+          </h2>
+          <p className="mt-1 text-token-xs text-muted-foreground">
+            After advisory mode is on, ramp deterministic gate rules to blocking in one action — with
+            confirmation before merges can be held.
+          </p>
+        </div>
+        {summary ? (
+          <StatusPill status={summary.isBlocking ? "blocked" : summary.phase === "advisory" ? "info" : "warn"}>
+            {summary.label}
+          </StatusPill>
+        ) : null}
+      </div>
+
+      <label className="mt-4 block max-w-sm">
+        <span className={LABEL_CLASS}>Repository</span>
+        <input
+          value={repoFullName}
+          onChange={(event) => setRepoFullName(event.target.value)}
+          list="gate-ramp-repos"
+          placeholder="owner/repo"
+          className={FIELD_CLASS}
+        />
+        <datalist id="gate-ramp-repos">
+          {repoOptions.map((repo) => (
+            <option key={repo} value={repo} />
+          ))}
+        </datalist>
+        {!hasRepos ? (
+          <span className="mt-1 block text-token-2xs text-muted-foreground">
+            No registered repositories detected yet — type an installed{" "}
+            <code className="font-mono">owner/repo</code>.
+          </span>
+        ) : null}
+      </label>
+
+      <div className="mt-6">
+        <StateBoundary
+          isLoading={Boolean(base) && loading}
+          isError={Boolean(base) && !loading && loadError !== null}
+          isEmpty={false}
+          onRetry={load}
+          onRefresh={load}
+          loadingTitle="Loading gate ramp state…"
+          errorTitle="Couldn't load repository settings"
+          errorDescription={loadError ?? undefined}
+        >
+          {!base ? (
+            <p className="text-token-sm text-muted-foreground">
+              {hasRepos
+                ? "Settings are unavailable for this repository."
+                : "Enter an installed repository to manage the gate ramp."}
+            </p>
+          ) : summary && settings ? (
+            <div className="space-y-4">
+              <p className="text-token-sm text-foreground/90">{summary.description}</p>
+
+              <div className="flex flex-wrap items-center justify-between gap-4 rounded-token border border-border/60 bg-background/40 px-4 py-3">
+                <div className="flex min-w-0 items-start gap-3">
+                  <ShieldAlert className="mt-0.5 size-4 shrink-0 text-warning" aria-hidden />
+                  <div>
+                    <label htmlFor={switchId} className="text-token-sm font-medium text-foreground">
+                      Blocking enforcement
+                    </label>
+                    <p className="mt-0.5 text-token-2xs text-muted-foreground">
+                      {summary.canRampToBlocking
+                        ? "Off — advisory only. Turn on to block merges when gate findings fire."
+                        : summary.isBlocking
+                          ? "On — deterministic gates are blocking."
+                          : "Unavailable until advisory mode is enabled above."}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  {busy ? <Loader2 className="size-4 animate-spin text-muted-foreground" aria-hidden /> : null}
+                  <Switch
+                    id={switchId}
+                    checked={switchChecked}
+                    disabled={switchDisabled}
+                    aria-busy={busy}
+                    onCheckedChange={handleSwitchChange}
+                  />
+                </div>
+              </div>
+            </div>
+          ) : null}
+        </StateBoundary>
+      </div>
+
+      {settings && rampSlice ? (
+        <GateRampConfirmDialog
+          open={confirmOpen}
+          onOpenChange={setConfirmOpen}
+          repoFullName={repoFullName}
+          settings={rampSlice}
+          busy={busy}
+          onConfirm={() => void saveBlockingRamp()}
+        />
+      ) : null}
+    </section>
+  );
+}

--- a/apps/gittensory-ui/src/components/site/app-panels/maintainer-panel.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/maintainer-panel.tsx
@@ -18,6 +18,7 @@ import {
   type Status,
 } from "@/components/site/control-primitives";
 import { ActivationPreview } from "@/components/site/app-panels/activation-preview";
+import { GateRampControl } from "@/components/site/app-panels/gate-ramp-control";
 import { AiReviewSettings } from "@/components/site/app-panels/ai-review-settings";
 import { MaintainerSettings } from "@/components/site/app-panels/maintainer-settings";
 import { StatCard } from "@/components/site/primitives";
@@ -353,6 +354,8 @@ function MaintainerDashboardView() {
           </section>
 
           <ActivationPreview reviewability={data.reviewability} />
+
+          <GateRampControl reviewability={data.reviewability} />
 
           <SurfacePreview reviewability={data.reviewability} />
 

--- a/apps/gittensory-ui/src/components/site/app-panels/maintainer-settings.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/maintainer-settings.tsx
@@ -5,8 +5,11 @@ import { StatusPill } from "@/components/site/control-primitives";
 import { apiFetch } from "@/lib/api/request";
 import { getApiOrigin } from "@/lib/api/origin";
 import { extractPreviewRepoOptions, splitRepoFullName } from "@/lib/maintainer-settings-preview";
-
-type GateMode = "off" | "advisory" | "block";
+import {
+  buildMaintainerSettingsSavePayload,
+  type MaintainerSettingsEditable,
+} from "@/lib/maintainer-settings-editable";
+import type { GateMode } from "@/lib/gate-ramp";
 type CommandRole = "maintainer" | "collaborator" | "pr_author" | "confirmed_miner";
 
 type CommandAuthorization = {
@@ -14,38 +17,7 @@ type CommandAuthorization = {
   commands?: Record<string, CommandRole[]>;
 };
 
-type MaintainerSettings = {
-  commentMode: "off" | "detected_contributors_only" | "all_prs";
-  publicAudienceMode: "oss_maintainer" | "gittensor_only";
-  publicSignalLevel: "minimal" | "standard";
-  publicSurface: "off" | "comment_and_label" | "comment_only" | "label_only";
-  checkRunMode: "off" | "enabled";
-  checkRunDetailLevel: "minimal" | "standard" | "deep";
-  gateCheckMode: "off" | "enabled";
-  gatePack: "gittensor" | "oss-anti-slop";
-  linkedIssueGateMode: GateMode;
-  duplicatePrGateMode: GateMode;
-  qualityGateMode: GateMode;
-  qualityGateMinScore: number | null;
-  mergeReadinessGateMode: GateMode;
-  manifestPolicyGateMode: GateMode;
-  firstTimeContributorGrace: boolean;
-  slopGateMode: GateMode;
-  slopGateMinScore: number | null;
-  slopAiAdvisory: boolean;
-  autoLabelEnabled: boolean;
-  gittensorLabel: string;
-  createMissingLabel: boolean;
-  includeMaintainerAuthors: boolean;
-  requireLinkedIssue: boolean;
-  badgeEnabled: boolean;
-  publicQualityMetrics: boolean;
-  commandAuthorization: CommandAuthorization;
-  autonomy: Partial<Record<AgentActionClass, AutonomyLevel>>;
-  autoMaintain: { requireApprovals: number; mergeMethod: AutoMergeMethod };
-  agentPaused: boolean;
-  agentDryRun: boolean;
-};
+type MaintainerSettings = MaintainerSettingsEditable;
 
 type AutonomyLevel = "observe" | "suggest" | "propose" | "auto_with_approval" | "auto";
 type AgentActionClass = "review" | "request_changes" | "approve" | "merge" | "close" | "label";
@@ -82,39 +54,7 @@ const COMMAND_ROLES: Array<[CommandRole, string]> = [
   ["confirmed_miner", "confirmed miner"],
 ];
 
-// The maintainer-editable subset, sent verbatim to PUT /settings (which merges onto current settings).
-const EDITABLE_KEYS: Array<keyof MaintainerSettings> = [
-  "commentMode",
-  "publicAudienceMode",
-  "publicSignalLevel",
-  "publicSurface",
-  "checkRunMode",
-  "checkRunDetailLevel",
-  "gateCheckMode",
-  "gatePack",
-  "linkedIssueGateMode",
-  "duplicatePrGateMode",
-  "qualityGateMode",
-  "qualityGateMinScore",
-  "mergeReadinessGateMode",
-  "manifestPolicyGateMode",
-  "firstTimeContributorGrace",
-  "slopGateMode",
-  "slopGateMinScore",
-  "slopAiAdvisory",
-  "autoLabelEnabled",
-  "gittensorLabel",
-  "createMissingLabel",
-  "includeMaintainerAuthors",
-  "requireLinkedIssue",
-  "badgeEnabled",
-  "publicQualityMetrics",
-  "commandAuthorization",
-  "autonomy",
-  "autoMaintain",
-  "agentPaused",
-  "agentDryRun",
-];
+// The maintainer-editable subset is centralized in maintainer-settings-editable.ts (#2218).
 
 type SelectFieldDef = {
   key: keyof MaintainerSettings;
@@ -337,7 +277,7 @@ export function MaintainerSettings({ reviewability }: { reviewability: Array<{ p
   async function save() {
     if (!base || !settings) return;
     setBusy(true);
-    const payload = Object.fromEntries(EDITABLE_KEYS.map((key) => [key, settings[key]]));
+    const payload = buildMaintainerSettingsSavePayload(settings);
     const result = await apiFetch<MaintainerSettings>(`${base}/settings`, {
       method: "PUT",
       label: "Save repository settings",

--- a/apps/gittensory-ui/src/lib/gate-ramp.test.ts
+++ b/apps/gittensory-ui/src/lib/gate-ramp.test.ts
@@ -35,13 +35,15 @@ describe("gate-ramp helpers (#2218)", () => {
         qualityGateMode: "advisory",
       }),
     ).toBe(false);
-    expect(deriveGateRampPhase({
-      gateCheckMode: "enabled",
-      reviewCheckMode: "disabled",
-      linkedIssueGateMode: "advisory",
-      duplicatePrGateMode: "advisory",
-      qualityGateMode: "advisory",
-    })).toBe("inactive");
+    expect(
+      deriveGateRampPhase({
+        gateCheckMode: "enabled",
+        reviewCheckMode: "disabled",
+        linkedIssueGateMode: "advisory",
+        duplicatePrGateMode: "advisory",
+        qualityGateMode: "advisory",
+      }),
+    ).toBe("inactive");
   });
 
   it("detects advisory and blocking phases from the ramp trio", () => {

--- a/apps/gittensory-ui/src/lib/gate-ramp.test.ts
+++ b/apps/gittensory-ui/src/lib/gate-ramp.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildBlockingRampPatch,
+  deriveGateRampPhase,
+  isBlockingRampComplete,
+  isGateRampActive,
+  listRampGateTransitions,
+  summarizeGateRamp,
+} from "@/lib/gate-ramp";
+
+const ADVISORY_SLICE = {
+  gateCheckMode: "enabled" as const,
+  reviewCheckMode: "required" as const,
+  linkedIssueGateMode: "advisory" as const,
+  duplicatePrGateMode: "advisory" as const,
+  qualityGateMode: "advisory" as const,
+};
+
+const BLOCKING_SLICE = {
+  ...ADVISORY_SLICE,
+  linkedIssueGateMode: "block" as const,
+  duplicatePrGateMode: "block" as const,
+  qualityGateMode: "block" as const,
+};
+
+describe("gate-ramp helpers (#2218)", () => {
+  it("treats reviewCheckMode disabled as inactive even when gateCheckMode is enabled", () => {
+    expect(
+      isGateRampActive({
+        gateCheckMode: "enabled",
+        reviewCheckMode: "disabled",
+        linkedIssueGateMode: "advisory",
+        duplicatePrGateMode: "advisory",
+        qualityGateMode: "advisory",
+      }),
+    ).toBe(false);
+    expect(deriveGateRampPhase({
+      gateCheckMode: "enabled",
+      reviewCheckMode: "disabled",
+      linkedIssueGateMode: "advisory",
+      duplicatePrGateMode: "advisory",
+      qualityGateMode: "advisory",
+    })).toBe("inactive");
+  });
+
+  it("detects advisory and blocking phases from the ramp trio", () => {
+    expect(deriveGateRampPhase(ADVISORY_SLICE)).toBe("advisory");
+    expect(isBlockingRampComplete(ADVISORY_SLICE)).toBe(false);
+    expect(deriveGateRampPhase(BLOCKING_SLICE)).toBe("blocking");
+    expect(isBlockingRampComplete(BLOCKING_SLICE)).toBe(true);
+  });
+
+  it("summarizeGateRamp exposes ramp affordances only in advisory phase", () => {
+    const advisory = summarizeGateRamp(ADVISORY_SLICE);
+    expect(advisory.label).toBe("Advisory");
+    expect(advisory.canRampToBlocking).toBe(true);
+    expect(advisory.isBlocking).toBe(false);
+
+    const blocking = summarizeGateRamp(BLOCKING_SLICE);
+    expect(blocking.canRampToBlocking).toBe(false);
+    expect(blocking.isBlocking).toBe(true);
+  });
+
+  it("buildBlockingRampPatch flips the deterministic trio to block", () => {
+    expect(buildBlockingRampPatch()).toEqual({
+      linkedIssueGateMode: "block",
+      duplicatePrGateMode: "block",
+      qualityGateMode: "block",
+    });
+  });
+
+  it("listRampGateTransitions omits gates already at the target mode", () => {
+    const mixed = {
+      ...ADVISORY_SLICE,
+      duplicatePrGateMode: "block" as const,
+    };
+    const transitions = listRampGateTransitions(mixed);
+    expect(transitions).toHaveLength(2);
+    expect(transitions.map((t) => t.key)).toEqual(["linkedIssueGateMode", "qualityGateMode"]);
+  });
+});

--- a/apps/gittensory-ui/src/lib/gate-ramp.ts
+++ b/apps/gittensory-ui/src/lib/gate-ramp.ts
@@ -1,0 +1,107 @@
+/**
+ * Advisory → blocking ramp helpers for the maintainer onboarding surface (#2218). Mirrors the deterministic
+ * gate trio that `recommendedAdvisoryActivationSettings` enables in advisory mode; blocking ramps those same
+ * fields to `block` via the existing PUT /settings merge path (maintainer-settings.tsx).
+ */
+
+export type GateMode = "off" | "advisory" | "block";
+
+/** The three deterministic sub-gates flipped together during the CodeRabbit-style onboarding ramp. */
+export const RAMP_DETERMINISTIC_GATE_KEYS = [
+  "linkedIssueGateMode",
+  "duplicatePrGateMode",
+  "qualityGateMode",
+] as const;
+
+export type RampDeterministicGateKey = (typeof RAMP_DETERMINISTIC_GATE_KEYS)[number];
+
+export type GateRampSettingsSlice = {
+  gateCheckMode: "off" | "enabled";
+  reviewCheckMode?: "required" | "visible" | "disabled";
+} & Record<RampDeterministicGateKey, GateMode>;
+
+export type GateRampPhase = "inactive" | "advisory" | "blocking";
+
+export type GateRampSummary = {
+  phase: GateRampPhase;
+  /** Human label for the ramp pill (inactive / advisory / blocking). */
+  label: string;
+  /** Short helper copy under the switch. */
+  description: string;
+  /** Whether the maintainer can attempt the advisory → blocking transition. */
+  canRampToBlocking: boolean;
+  /** Whether blocking is already fully engaged for the ramp trio. */
+  isBlocking: boolean;
+};
+
+const PHASE_LABEL: Record<GateRampPhase, string> = {
+  inactive: "Gate off",
+  advisory: "Advisory",
+  blocking: "Blocking",
+};
+
+const PHASE_DESCRIPTION: Record<GateRampPhase, string> = {
+  inactive:
+    "Enable advisory mode in the activation preview above before ramping deterministic rules to blocking.",
+  advisory:
+    "Deterministic linked-issue, duplicate-PR, and quality gates surface guidance without blocking merges. Flip to blocking when you are ready to enforce.",
+  blocking:
+    "Linked-issue, duplicate-PR, and quality gates can block merges when findings fire. Re-tune individual gates in repository settings below.",
+};
+
+/** Whether the Gittensory gate is actively publishing (parity with buildMaintainerActivationPreview). */
+export function isGateRampActive(settings: GateRampSettingsSlice): boolean {
+  return settings.reviewCheckMode !== undefined && settings.reviewCheckMode !== "disabled";
+}
+
+/** True when every ramp deterministic sub-gate is set to block. */
+export function isBlockingRampComplete(settings: GateRampSettingsSlice): boolean {
+  return RAMP_DETERMINISTIC_GATE_KEYS.every((key) => settings[key] === "block");
+}
+
+/** Derive the maintainer-facing ramp phase from loaded repository settings. */
+export function deriveGateRampPhase(settings: GateRampSettingsSlice): GateRampPhase {
+  if (!isGateRampActive(settings)) return "inactive";
+  if (isBlockingRampComplete(settings)) return "blocking";
+  return "advisory";
+}
+
+export function summarizeGateRamp(settings: GateRampSettingsSlice): GateRampSummary {
+  const phase = deriveGateRampPhase(settings);
+  const isBlocking = phase === "blocking";
+  return {
+    phase,
+    label: PHASE_LABEL[phase],
+    description: PHASE_DESCRIPTION[phase],
+    canRampToBlocking: phase === "advisory",
+    isBlocking,
+  };
+}
+
+/** Patch applied on confirm: only the ramp trio moves to block; everything else is preserved by PUT merge. */
+export function buildBlockingRampPatch(): Pick<GateRampSettingsSlice, RampDeterministicGateKey> {
+  return {
+    linkedIssueGateMode: "block",
+    duplicatePrGateMode: "block",
+    qualityGateMode: "block",
+  };
+}
+
+/** List gate keys that would change when ramping (for confirm-dialog copy). */
+export function listRampGateTransitions(
+  settings: GateRampSettingsSlice,
+): Array<{ key: RampDeterministicGateKey; from: GateMode; to: GateMode }> {
+  const patch = buildBlockingRampPatch();
+  return RAMP_DETERMINISTIC_GATE_KEYS.map((key) => ({
+    key,
+    from: settings[key],
+    to: patch[key],
+  })).filter((entry) => entry.from !== entry.to);
+}
+
+/** Friendly labels for confirm-dialog rows. */
+export const RAMP_GATE_DISPLAY_LABELS: Record<RampDeterministicGateKey, string> = {
+  linkedIssueGateMode: "Linked issue gate",
+  duplicatePrGateMode: "Duplicate PR gate",
+  qualityGateMode: "Quality / readiness gate",
+};

--- a/apps/gittensory-ui/src/lib/maintainer-settings-editable.test.ts
+++ b/apps/gittensory-ui/src/lib/maintainer-settings-editable.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildMaintainerSettingsSavePayload,
+  MAINTAINER_SETTINGS_EDITABLE_KEYS,
+} from "@/lib/maintainer-settings-editable";
+
+describe("maintainer-settings-editable (#2218)", () => {
+  it("buildMaintainerSettingsSavePayload includes every editable key", () => {
+    const settings = {
+      commentMode: "detected_contributors_only" as const,
+      publicAudienceMode: "oss_maintainer" as const,
+      publicSignalLevel: "standard" as const,
+      publicSurface: "comment_and_label" as const,
+      checkRunMode: "enabled" as const,
+      checkRunDetailLevel: "standard" as const,
+      gateCheckMode: "enabled" as const,
+      gatePack: "gittensor" as const,
+      linkedIssueGateMode: "advisory" as const,
+      duplicatePrGateMode: "advisory" as const,
+      qualityGateMode: "advisory" as const,
+      qualityGateMinScore: null,
+      mergeReadinessGateMode: "off" as const,
+      manifestPolicyGateMode: "off" as const,
+      firstTimeContributorGrace: false,
+      slopGateMode: "off" as const,
+      slopGateMinScore: null,
+      slopAiAdvisory: false,
+      autoLabelEnabled: true,
+      gittensorLabel: "gittensor",
+      createMissingLabel: true,
+      includeMaintainerAuthors: false,
+      requireLinkedIssue: false,
+      badgeEnabled: false,
+      publicQualityMetrics: false,
+      commandAuthorization: {},
+      autonomy: {},
+      autoMaintain: { requireApprovals: 1, mergeMethod: "squash" as const },
+      agentPaused: false,
+      agentDryRun: false,
+    };
+
+    const payload = buildMaintainerSettingsSavePayload(settings, {
+      linkedIssueGateMode: "block",
+    });
+    expect(Object.keys(payload).sort()).toEqual([...MAINTAINER_SETTINGS_EDITABLE_KEYS].sort());
+    expect(payload.linkedIssueGateMode).toBe("block");
+    expect(payload.commentMode).toBe("detected_contributors_only");
+  });
+});

--- a/apps/gittensory-ui/src/lib/maintainer-settings-editable.ts
+++ b/apps/gittensory-ui/src/lib/maintainer-settings-editable.ts
@@ -34,7 +34,10 @@ export type MaintainerSettingsEditable = {
   publicQualityMetrics: boolean;
   commandAuthorization: {
     default?: Array<"maintainer" | "collaborator" | "pr_author" | "confirmed_miner">;
-    commands?: Record<string, Array<"maintainer" | "collaborator" | "pr_author" | "confirmed_miner">>;
+    commands?: Record<
+      string,
+      Array<"maintainer" | "collaborator" | "pr_author" | "confirmed_miner">
+    >;
   };
   autonomy: Partial<
     Record<
@@ -90,7 +93,5 @@ export function buildMaintainerSettingsSavePayload(
   patch: Partial<MaintainerSettingsEditable> = {},
 ): Record<string, unknown> {
   const merged = { ...settings, ...patch };
-  return Object.fromEntries(
-    MAINTAINER_SETTINGS_EDITABLE_KEYS.map((key) => [key, merged[key]]),
-  );
+  return Object.fromEntries(MAINTAINER_SETTINGS_EDITABLE_KEYS.map((key) => [key, merged[key]]));
 }

--- a/apps/gittensory-ui/src/lib/maintainer-settings-editable.ts
+++ b/apps/gittensory-ui/src/lib/maintainer-settings-editable.ts
@@ -1,0 +1,96 @@
+/**
+ * Maintainer-editable repository settings keys and save-payload builder (#130, #2218). Shared between the
+ * full settings editor (maintainer-settings.tsx) and the one-click gate ramp control so both hit PUT /settings
+ * with the same merge shape.
+ */
+
+import type { GateMode } from "@/lib/gate-ramp";
+
+export type MaintainerSettingsEditable = {
+  commentMode: "off" | "detected_contributors_only" | "all_prs";
+  publicAudienceMode: "oss_maintainer" | "gittensor_only";
+  publicSignalLevel: "minimal" | "standard";
+  publicSurface: "off" | "comment_and_label" | "comment_only" | "label_only";
+  checkRunMode: "off" | "enabled";
+  checkRunDetailLevel: "minimal" | "standard" | "deep";
+  gateCheckMode: "off" | "enabled";
+  gatePack: "gittensor" | "oss-anti-slop";
+  linkedIssueGateMode: GateMode;
+  duplicatePrGateMode: GateMode;
+  qualityGateMode: GateMode;
+  qualityGateMinScore: number | null;
+  mergeReadinessGateMode: GateMode;
+  manifestPolicyGateMode: GateMode;
+  firstTimeContributorGrace: boolean;
+  slopGateMode: GateMode;
+  slopGateMinScore: number | null;
+  slopAiAdvisory: boolean;
+  autoLabelEnabled: boolean;
+  gittensorLabel: string;
+  createMissingLabel: boolean;
+  includeMaintainerAuthors: boolean;
+  requireLinkedIssue: boolean;
+  badgeEnabled: boolean;
+  publicQualityMetrics: boolean;
+  commandAuthorization: {
+    default?: Array<"maintainer" | "collaborator" | "pr_author" | "confirmed_miner">;
+    commands?: Record<string, Array<"maintainer" | "collaborator" | "pr_author" | "confirmed_miner">>;
+  };
+  autonomy: Partial<
+    Record<
+      "review" | "request_changes" | "approve" | "merge" | "close" | "label",
+      "observe" | "suggest" | "propose" | "auto_with_approval" | "auto"
+    >
+  >;
+  autoMaintain: { requireApprovals: number; mergeMethod: "merge" | "squash" | "rebase" };
+  agentPaused: boolean;
+  agentDryRun: boolean;
+  reviewCheckMode?: "required" | "visible" | "disabled";
+};
+
+/** Keys sent verbatim to PUT /settings (PATCH-style merge on the server). */
+export const MAINTAINER_SETTINGS_EDITABLE_KEYS = [
+  "commentMode",
+  "publicAudienceMode",
+  "publicSignalLevel",
+  "publicSurface",
+  "checkRunMode",
+  "checkRunDetailLevel",
+  "gateCheckMode",
+  "gatePack",
+  "linkedIssueGateMode",
+  "duplicatePrGateMode",
+  "qualityGateMode",
+  "qualityGateMinScore",
+  "mergeReadinessGateMode",
+  "manifestPolicyGateMode",
+  "firstTimeContributorGrace",
+  "slopGateMode",
+  "slopGateMinScore",
+  "slopAiAdvisory",
+  "autoLabelEnabled",
+  "gittensorLabel",
+  "createMissingLabel",
+  "includeMaintainerAuthors",
+  "requireLinkedIssue",
+  "badgeEnabled",
+  "publicQualityMetrics",
+  "commandAuthorization",
+  "autonomy",
+  "autoMaintain",
+  "agentPaused",
+  "agentDryRun",
+] as const satisfies ReadonlyArray<keyof MaintainerSettingsEditable>;
+
+export type MaintainerSettingsEditableKey = (typeof MAINTAINER_SETTINGS_EDITABLE_KEYS)[number];
+
+/** Build the PUT /settings body from a loaded settings object (optionally merged with a patch first). */
+export function buildMaintainerSettingsSavePayload(
+  settings: MaintainerSettingsEditable,
+  patch: Partial<MaintainerSettingsEditable> = {},
+): Record<string, unknown> {
+  const merged = { ...settings, ...patch };
+  return Object.fromEntries(
+    MAINTAINER_SETTINGS_EDITABLE_KEYS.map((key) => [key, merged[key]]),
+  );
+}


### PR DESCRIPTION
## Summary

- Add **Gate ramp control** on the maintainer onboarding panel (`/app/maintainer`): reflects advisory vs blocking phase from loaded settings, and ramps linked-issue / duplicate-PR / quality gates to `block` via PUT `/settings`.
- **AlertDialog** confirmation before blocking; **sonner** toasts; switch disabled while saving or when inactive/already blocking.
- Shared **maintainer-settings-editable** helpers keep ramp control and the settings editor on identical PUT payloads.

Closes #2218

## Scope

- [x] Conventional Commit PR title
- [x] Focused UI change for #2218
- [x] Linked open issue `Closes #2218`

## Validation

- [x] `git diff --check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:test`
- [x] `npm run ui:build`
- [x] `npm run ui:openapi:settings-parity`
- [x] Vitest: advisory→blocking confirm, cancel, save-failure (`gate-ramp-control.test.tsx`)

## Safety

- [x] No secrets or scoring internals exposed
- [x] Auth negative paths covered in tests

## UI Evidence

| Page / Feature | Before | After |
|---|---|---|
| `/app/maintainer` — Gate ramp control | [<img src="https://github.com/jsdevninja/gittensory/releases/download/ui-evidence-2218-v1/gate-ramp-before.png" width="260">](https://github.com/jsdevninja/gittensory/releases/download/ui-evidence-2218-v1/gate-ramp-before.png)<br><sub>before: maintainer onboarding without gate ramp section</sub> | [<img src="https://github.com/jsdevninja/gittensory/releases/download/ui-evidence-2218-v1/gate-ramp-after.png" width="260">](https://github.com/jsdevninja/gittensory/releases/download/ui-evidence-2218-v1/gate-ramp-after.png)<br><sub>after: gate ramp control with advisory pill and blocking switch</sub> |
| `/app/maintainer` — Blocking confirm dialog | [<img src="https://github.com/jsdevninja/gittensory/releases/download/ui-evidence-2218-v1/gate-ramp-before.png" width="260">](https://github.com/jsdevninja/gittensory/releases/download/ui-evidence-2218-v1/gate-ramp-before.png)<br><sub>before: no confirm step</sub> | [<img src="https://github.com/jsdevninja/gittensory/releases/download/ui-evidence-2218-v1/gate-ramp-after.png" width="260">](https://github.com/jsdevninja/gittensory/releases/download/ui-evidence-2218-v1/gate-ramp-after.png)<br><sub>after: AlertDialog listing gate advisory→block transitions</sub> |

## Notes

- Supersedes closed #4696 (screenshot-table gate). No `src/**` changes — codecov patch N/A.
