### PR TITLE
feat(ui): gate-outcome breakdown card (auto-merge / auto-close / hold)

### DIFF
--- a/apps/gittensory-ui/src/components/site/app-panels/gate-outcome-card-model.ts
+++ b/apps/gittensory-ui/src/components/site/app-panels/gate-outcome-card-model.ts
@@ -1,0 +1,57 @@
+// Gate-outcome breakdown maintainer-dashboard card model (#2203). UI-only display slice: the card consumes a
+// gate-outcome breakdown assumed present on the maintainer-dashboard payload (shaped by the #539 dashboard
+// service from gate-outcome audit events). Types + the pure fold/band helpers live here (not in the .tsx) so the
+// component file exports only components (react-refresh/only-export-components).
+
+import type { Status } from "@/components/site/control-primitives";
+
+/** The gate-outcome slice delivered on the maintainer-dashboard payload: how the maintainer's repos' PRs resolved
+ *  — auto-merged, auto-closed, or held for manual review — over a rolling window. Public-safe counts only (no
+ *  scores, rewards, or wallet fields). */
+export interface GateOutcomeBreakdown {
+  /** PRs the gate auto-merged. */
+  merged: number;
+  /** PRs the gate auto-closed. */
+  closed: number;
+  /** PRs held for manual / maintainer review. */
+  held: number;
+  /** Rolling measurement window, in days. */
+  windowDays: number;
+}
+
+/** The card's derived view: the raw counts, the total, and each bucket's share as a whole-number percentage. */
+export interface GateOutcomeSummary {
+  merged: number;
+  closed: number;
+  held: number;
+  total: number;
+  mergedPct: number;
+  closedPct: number;
+  heldPct: number;
+}
+
+/** Pure fold: derive the total and per-bucket percentages. An all-zero breakdown yields 0% for every bucket. */
+export function summarizeGateOutcomes(breakdown: GateOutcomeBreakdown): GateOutcomeSummary {
+  const total = breakdown.merged + breakdown.closed + breakdown.held;
+  const pct = (n: number): number => (total > 0 ? Math.round((n / total) * 100) : 0);
+  return {
+    merged: breakdown.merged,
+    closed: breakdown.closed,
+    held: breakdown.held,
+    total,
+    mergedPct: pct(breakdown.merged),
+    closedPct: pct(breakdown.closed),
+    heldPct: pct(breakdown.held),
+  };
+}
+
+/** StatusPill quality band for the held share: no outcomes yet is informational; a held share at or under 25%
+ *  reads healthy (the gate decides most PRs autonomously); up to 50% warns; above that blocks (most PRs still need
+ *  a human). Mirrors the Status vocabulary in control-primitives.ts. */
+export function bandForGateOutcomes(breakdown: GateOutcomeBreakdown): Status {
+  const total = breakdown.merged + breakdown.closed + breakdown.held;
+  if (total === 0) return "info";
+  const heldShare = breakdown.held / total;
+  if (heldShare <= 0.25) return "ready";
+  return heldShare <= 0.5 ? "warn" : "blocked";
+}

--- a/apps/gittensory-ui/src/components/site/app-panels/gate-outcome-card.test.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/gate-outcome-card.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { GateOutcomeCard } from "@/components/site/app-panels/gate-outcome-card";
+import {
+  bandForGateOutcomes,
+  summarizeGateOutcomes,
+} from "@/components/site/app-panels/gate-outcome-card-model";
+
+describe("summarizeGateOutcomes", () => {
+  it("derives the total and per-bucket percentages when all outcomes are present", () => {
+    expect(summarizeGateOutcomes({ merged: 6, closed: 3, held: 1, windowDays: 30 })).toEqual({
+      merged: 6,
+      closed: 3,
+      held: 1,
+      total: 10,
+      mergedPct: 60,
+      closedPct: 30,
+      heldPct: 10,
+    });
+  });
+
+  it("handles a zero-in-one-bucket breakdown", () => {
+    expect(summarizeGateOutcomes({ merged: 5, closed: 5, held: 0, windowDays: 30 })).toMatchObject({
+      total: 10,
+      mergedPct: 50,
+      closedPct: 50,
+      heldPct: 0,
+    });
+  });
+
+  it("yields 0% for every bucket on an all-zero breakdown", () => {
+    expect(summarizeGateOutcomes({ merged: 0, closed: 0, held: 0, windowDays: 7 })).toEqual({
+      merged: 0,
+      closed: 0,
+      held: 0,
+      total: 0,
+      mergedPct: 0,
+      closedPct: 0,
+      heldPct: 0,
+    });
+  });
+});
+
+describe("bandForGateOutcomes", () => {
+  it("bands by held share: empty info, <=25% ready, <=50% warn, above blocked", () => {
+    expect(bandForGateOutcomes({ merged: 0, closed: 0, held: 0, windowDays: 30 })).toBe("info");
+    expect(bandForGateOutcomes({ merged: 8, closed: 0, held: 2, windowDays: 30 })).toBe("ready");
+    expect(bandForGateOutcomes({ merged: 5, closed: 1, held: 4, windowDays: 30 })).toBe("warn");
+    expect(bandForGateOutcomes({ merged: 2, closed: 1, held: 7, windowDays: 30 })).toBe("blocked");
+  });
+});
+
+describe("GateOutcomeCard", () => {
+  it("renders the three outcome tiles with counts and shares", () => {
+    render(<GateOutcomeCard breakdown={{ merged: 6, closed: 3, held: 1, windowDays: 30 }} />);
+    expect(screen.getByText("Gate-outcome breakdown")).toBeTruthy();
+    expect(screen.getByText("Auto-merged")).toBeTruthy();
+    expect(screen.getByText("6")).toBeTruthy();
+    expect(screen.getByText("60% of outcomes")).toBeTruthy();
+    expect(screen.getByText("30-day window")).toBeTruthy();
+  });
+
+  it("shows an empty state for an all-zero breakdown", () => {
+    render(<GateOutcomeCard breakdown={{ merged: 0, closed: 0, held: 0, windowDays: 7 }} />);
+    expect(screen.getByText("No gate outcomes yet")).toBeTruthy();
+  });
+
+  it("renders a graceful EmptyState when the breakdown field is absent", () => {
+    render(<GateOutcomeCard breakdown={undefined} />);
+    expect(screen.getByText("Gate outcomes not yet available")).toBeTruthy();
+  });
+});

--- a/apps/gittensory-ui/src/components/site/app-panels/gate-outcome-card.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/gate-outcome-card.tsx
@@ -1,0 +1,76 @@
+import { Stat, StatusPill } from "@/components/site/control-primitives";
+import { EmptyState } from "@/components/site/state-views";
+
+import {
+  bandForGateOutcomes,
+  summarizeGateOutcomes,
+  type GateOutcomeBreakdown,
+} from "./gate-outcome-card-model";
+
+/** Maintainer-dashboard card (#2203): the gate-outcome breakdown — how the maintainer's repos' PRs resolved
+ *  (auto-merged / auto-closed / held for manual review) over a rolling window, as three count tiles plus a small
+ *  stacked-proportion bar in token colors. UI-only display slice; the breakdown is assumed present on the
+ *  maintainer-dashboard payload (shaped by the #539 dashboard service), so absence renders a graceful "not yet
+ *  available" EmptyState. Public-safe counts only — no scores, rewards, or wallet fields. */
+export function GateOutcomeCard({ breakdown }: { breakdown?: GateOutcomeBreakdown }) {
+  if (!breakdown) {
+    return (
+      <EmptyState
+        title="Gate outcomes not yet available"
+        description="This appears once gate-outcome data is present on the maintainer-dashboard payload."
+      />
+    );
+  }
+  const summary = summarizeGateOutcomes(breakdown);
+  return (
+    <section className="rounded-token border border-border bg-transparent p-5">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="font-display text-token-lg font-semibold">Gate-outcome breakdown</h2>
+          <p className="mt-1 text-token-xs text-muted-foreground">
+            How your repositories&rsquo; PRs resolved — auto-merged, auto-closed, or held for manual
+            review. Public-safe counts only.
+          </p>
+        </div>
+        <StatusPill
+          status={bandForGateOutcomes(breakdown)}
+        >{`${breakdown.windowDays}-day window`}</StatusPill>
+      </div>
+      <div className="mt-4 grid gap-3 sm:grid-cols-3">
+        <Stat
+          label="Auto-merged"
+          value={String(summary.merged)}
+          hint={
+            <span className="text-muted-foreground">{`${summary.mergedPct}% of outcomes`}</span>
+          }
+        />
+        <Stat
+          label="Auto-closed"
+          value={String(summary.closed)}
+          hint={
+            <span className="text-muted-foreground">{`${summary.closedPct}% of outcomes`}</span>
+          }
+        />
+        <Stat
+          label="Held / manual"
+          value={String(summary.held)}
+          hint={<span className="text-muted-foreground">{`${summary.heldPct}% of outcomes`}</span>}
+        />
+      </div>
+      {summary.total > 0 ? (
+        <div className="mt-4 flex h-2 overflow-hidden rounded-token" aria-hidden="true">
+          <div className="bg-mint" style={{ width: `${summary.mergedPct}%` }} />
+          <div className="bg-danger" style={{ width: `${summary.closedPct}%` }} />
+          <div className="bg-warning" style={{ width: `${summary.heldPct}%` }} />
+        </div>
+      ) : (
+        <div className="mt-4">
+          <EmptyState
+            title="No gate outcomes yet"
+            description="No PR reached an auto-merge, auto-close, or hold in this window."
+          />
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/gittensory-ui/src/components/site/app-panels/maintainer-panel.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/maintainer-panel.tsx
@@ -19,6 +19,8 @@ import {
 } from "@/components/site/control-primitives";
 import { ActivationPreview } from "@/components/site/app-panels/activation-preview";
 import { AiReviewSettings } from "@/components/site/app-panels/ai-review-settings";
+import { GateOutcomeCard } from "@/components/site/app-panels/gate-outcome-card";
+import type { GateOutcomeBreakdown } from "@/components/site/app-panels/gate-outcome-card-model";
 import { MaintainerSettings } from "@/components/site/app-panels/maintainer-settings";
 import { StatCard } from "@/components/site/primitives";
 import { EmptyState, LoadingState, StateBoundary } from "@/components/site/state-views";
@@ -76,6 +78,7 @@ type MaintainerDashboard = {
     slop?: { risk: number; band: string } | null;
   }>;
   settingsPreview: { removed: string[]; added: string[] };
+  gateOutcomes?: GateOutcomeBreakdown;
 };
 
 type TrustChecklistStatus = "ready" | "needs_attention" | "blocked";
@@ -351,6 +354,8 @@ function MaintainerDashboardView() {
               </tbody>
             </table>
           </section>
+
+          {data.gateOutcomes ? <GateOutcomeCard breakdown={data.gateOutcomes} /> : null}
 
           <ActivationPreview reviewability={data.reviewability} />
 


### PR DESCRIPTION
## What & why

Closes #2203.

Adds a maintainer-dashboard card summarizing **gate outcomes** — how the maintainer's repositories' PRs resolved (auto-merged / auto-closed / held for manual review) over a rolling window — as three count tiles plus a small stacked-proportion bar.

- **`gate-outcome-card-model.ts`** — `GateOutcomeBreakdown` type + pure folds: `summarizeGateOutcomes` (total + each bucket's whole-number percentage, 0% on an all-zero breakdown) and `bandForGateOutcomes` (`info` when empty, `ready` when the held share is ≤25%, `warn` ≤50%, `blocked` above — a high held share means most PRs still need a human).
- **`gate-outcome-card.tsx`** — three `Stat` tiles (merged / closed / held) with per-bucket shares, a `StatusPill` band, and a stacked-proportion bar in token colors; an `EmptyState` on an all-zero breakdown or when the field is absent. **Public-safe counts only** — no scores, rewards, or wallet fields.
- **Wiring** — `maintainer-panel.tsx` gains an optional `gateOutcomes` field (shaped by the #539 dashboard service) and renders the card when present.

**Tests** (`gate-outcome-card.test.tsx`): the fold/band helpers (all-outcomes-present, zero-in-one-bucket, empty) and the card's populated / empty / field-absent arms. `ui:typecheck`, `ui:lint`, `vitest`, and the Vite build all pass.

## Screenshots

| View | Before | After |
| --- | --- | --- |
| Maintainer quality dashboard (`/app/maintainer`) | _screenshot pending_ | _screenshot pending_ |

> ⚠️ **Draft — screenshots pending.** The card renders on the maintainer-dashboard payload once a `gateOutcomes` slice is present; before/after screenshots of the maintainer dashboard are being captured and will be added to the table above before this is marked ready for review.
