### PR TITLE
feat(ui): last-refresh meta + manual refresh on the analytics and maintainer headers

### DIFF
--- a/apps/gittensory-ui/src/components/site/app-panels/maintainer-panel.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/maintainer-panel.tsx
@@ -21,6 +21,7 @@ import { ActivationPreview } from "@/components/site/app-panels/activation-previ
 import { AiReviewSettings } from "@/components/site/app-panels/ai-review-settings";
 import { MaintainerSettings } from "@/components/site/app-panels/maintainer-settings";
 import { StatCard } from "@/components/site/primitives";
+import { RefreshMeta } from "@/components/site/refresh-meta";
 import { EmptyState, LoadingState, StateBoundary } from "@/components/site/state-views";
 import { apiFetch } from "@/lib/api/request";
 import { getApiOrigin } from "@/lib/api/origin";
@@ -209,6 +210,11 @@ function MaintainerDashboardView() {
         </div>
       ) : data ? (
         <div className="space-y-6">
+          {/* Dashboard-level refresh metadata (#2219) — lives here rather than the route's PageHeader
+              because the maintainer resource is gated behind the session/role check above. */}
+          <div className="flex items-center justify-end">
+            <RefreshMeta loadedAt={dashboard.loadedAt} onRefresh={dashboard.reload} />
+          </div>
           <section className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
             {data.metrics.map((metric) => (
               <StatCard

--- a/apps/gittensory-ui/src/components/site/refresh-meta.test.tsx
+++ b/apps/gittensory-ui/src/components/site/refresh-meta.test.tsx
@@ -1,0 +1,84 @@
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RefreshMeta } from "@/components/site/refresh-meta";
+import { relativeTimeFromNow } from "@/lib/utils";
+
+const MINUTE_MS = 60_000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+
+describe("relativeTimeFromNow (#2219)", () => {
+  const now = Date.UTC(2026, 6, 10, 12, 0, 0);
+
+  it("labels each bucket at and around its boundary", () => {
+    // seconds bucket, including the exact lower edge and the last second before a minute
+    expect(relativeTimeFromNow(now, now)).toBe("just now");
+    expect(relativeTimeFromNow(now - 59_000, now)).toBe("just now");
+    // minutes bucket: 60s flips to 1m; 59m59s still reads 59m
+    expect(relativeTimeFromNow(now - MINUTE_MS, now)).toBe("1m ago");
+    expect(relativeTimeFromNow(now - (HOUR_MS - 1000), now)).toBe("59m ago");
+    // hours bucket: 60m flips to 1h; 23h59m still reads 23h
+    expect(relativeTimeFromNow(now - HOUR_MS, now)).toBe("1h ago");
+    expect(relativeTimeFromNow(now - (DAY_MS - MINUTE_MS), now)).toBe("23h ago");
+    // days bucket: 24h flips to 1d and keeps counting
+    expect(relativeTimeFromNow(now - DAY_MS, now)).toBe("1d ago");
+    expect(relativeTimeFromNow(now - 3 * DAY_MS - 2 * HOUR_MS, now)).toBe("3d ago");
+  });
+
+  it("clamps a marginally-future timestamp to 'just now' instead of a negative age", () => {
+    expect(relativeTimeFromNow(now + 5_000, now)).toBe("just now");
+  });
+});
+
+describe("RefreshMeta (#2219)", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(Date.UTC(2026, 6, 10, 12, 0, 0));
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders nothing before the first successful load", () => {
+    const { container } = render(<RefreshMeta loadedAt={null} onRefresh={() => {}} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("shows the relative label for the loaded timestamp", () => {
+    render(<RefreshMeta loadedAt={Date.now() - 3 * MINUTE_MS} onRefresh={() => {}} />);
+    expect(screen.getByText("last refresh 3m ago")).toBeTruthy();
+  });
+
+  it("advances the label on the interval tick without a reload", () => {
+    render(<RefreshMeta loadedAt={Date.now()} onRefresh={() => {}} />);
+    expect(screen.getByText("last refresh just now")).toBeTruthy();
+    act(() => {
+      vi.advanceTimersByTime(2 * MINUTE_MS);
+    });
+    expect(screen.getByText("last refresh 2m ago")).toBeTruthy();
+  });
+
+  it("invokes onRefresh when the refresh button is clicked", () => {
+    const onRefresh = vi.fn();
+    render(<RefreshMeta loadedAt={Date.now()} onRefresh={onRefresh} />);
+    fireEvent.click(screen.getByRole("button", { name: /refresh/i }));
+    expect(onRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it("disables the button while a refresh is in flight", () => {
+    const onRefresh = vi.fn();
+    render(<RefreshMeta loadedAt={Date.now()} onRefresh={onRefresh} refreshing />);
+    const button = screen.getByRole("button", { name: /refresh/i }) as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    fireEvent.click(button);
+    expect(onRefresh).not.toHaveBeenCalled();
+  });
+
+  it("clears its interval on unmount", () => {
+    const clearSpy = vi.spyOn(window, "clearInterval");
+    const { unmount } = render(<RefreshMeta loadedAt={Date.now()} onRefresh={() => {}} />);
+    unmount();
+    expect(clearSpy).toHaveBeenCalled();
+  });
+});

--- a/apps/gittensory-ui/src/components/site/refresh-meta.tsx
+++ b/apps/gittensory-ui/src/components/site/refresh-meta.tsx
@@ -1,0 +1,46 @@
+import { RefreshCw } from "lucide-react";
+import { useEffect, useState } from "react";
+
+import { StateActionButton } from "@/components/site/state-views";
+import { cn, relativeTimeFromNow } from "@/lib/utils";
+
+/**
+ * Shared "last refresh Xm ago" label + manual refresh button for dashboard headers (#2219).
+ * Renders nothing until the resource has loaded once (`loadedAt` is null while loading/error —
+ * those states already have their own retry/refresh affordances in StateBoundary).
+ */
+export function RefreshMeta({
+  loadedAt,
+  onRefresh,
+  refreshing = false,
+  className,
+}: {
+  loadedAt: number | null;
+  onRefresh: () => void;
+  refreshing?: boolean;
+  className?: string;
+}) {
+  // Re-render on a coarse tick so the relative label stays honest without a per-second timer.
+  const [now, setNow] = useState(() => Date.now());
+  useEffect(() => {
+    const id = window.setInterval(() => setNow(Date.now()), 30_000);
+    return () => window.clearInterval(id);
+  }, []);
+
+  if (loadedAt === null) return null;
+
+  return (
+    <div className={cn("flex items-center gap-2", className)}>
+      <span className="font-mono text-token-2xs text-muted-foreground">
+        last refresh {relativeTimeFromNow(loadedAt, now)}
+      </span>
+      <StateActionButton
+        onClick={onRefresh}
+        disabled={refreshing}
+        icon={<RefreshCw className="size-3 shrink-0" aria-hidden />}
+      >
+        Refresh
+      </StateActionButton>
+    </div>
+  );
+}

--- a/apps/gittensory-ui/src/lib/api/use-api-resource.test.ts
+++ b/apps/gittensory-ui/src/lib/api/use-api-resource.test.ts
@@ -1,0 +1,38 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const { apiFetch } = vi.hoisted(() => ({ apiFetch: vi.fn() }));
+vi.mock("@/lib/api/request", () => ({
+  apiFetch: (...args: unknown[]) => apiFetch(...args),
+}));
+vi.mock("@/lib/api/origin", () => ({ getApiOrigin: () => "https://api.test" }));
+
+import { useApiResource } from "@/lib/api/use-api-resource";
+
+describe("useApiResource loadedAt (#2219)", () => {
+  it("stamps loadedAt when a load succeeds, so headers can show 'last refresh'", async () => {
+    apiFetch.mockResolvedValue({ ok: true, data: { rows: [] }, status: 200, durationMs: 5 });
+    const before = Date.now();
+    const { result } = renderHook(() => useApiResource<{ rows: [] }>("/v1/thing", "Thing"));
+    expect(result.current.loadedAt).toBeNull();
+    await waitFor(() => expect(result.current.status).toBe("ready"));
+    expect(result.current.loadedAt).toBeGreaterThanOrEqual(before);
+    expect(result.current.loadedAt).toBeLessThanOrEqual(Date.now());
+  });
+
+  it("keeps loadedAt null on a failed load", async () => {
+    apiFetch.mockResolvedValue({ ok: false, message: "boom", status: 500, durationMs: 5 });
+    const { result } = renderHook(() => useApiResource("/v1/thing", "Thing"));
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.loadedAt).toBeNull();
+  });
+
+  it("keeps loadedAt null when the resource is disabled", async () => {
+    const { result } = renderHook(() =>
+      useApiResource("/v1/thing", "Thing", undefined, { enabled: false }),
+    );
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current.error).toBe("disabled");
+    expect(result.current.loadedAt).toBeNull();
+  });
+});

--- a/apps/gittensory-ui/src/lib/api/use-api-resource.ts
+++ b/apps/gittensory-ui/src/lib/api/use-api-resource.ts
@@ -4,9 +4,9 @@ import { getApiOrigin } from "./origin";
 import { apiFetch } from "./request";
 
 type ResourceState<T> =
-  | { status: "loading"; data: null; error: null }
-  | { status: "ready"; data: T; error: null }
-  | { status: "error"; data: null; error: string };
+  | { status: "loading"; data: null; error: null; loadedAt: null }
+  | { status: "ready"; data: T; error: null; loadedAt: number }
+  | { status: "error"; data: null; error: string; loadedAt: null };
 
 type UseApiResourceOptions = {
   enabled?: boolean;
@@ -23,14 +23,15 @@ export function useApiResource<T>(
     status: "loading",
     data: null,
     error: null,
+    loadedAt: null,
   });
 
   const load = useCallback(async () => {
     if (!enabled) {
-      setState({ status: "error", data: null, error: "disabled" });
+      setState({ status: "error", data: null, error: "disabled", loadedAt: null });
       return;
     }
-    setState({ status: "loading", data: null, error: null });
+    setState({ status: "loading", data: null, error: null, loadedAt: null });
     const headers: Record<string, string> = { Accept: "application/json" };
     if (token) headers.Authorization = `Bearer ${token}`;
     const result = await apiFetch<T>(`${getApiOrigin().replace(/\/$/, "")}${path}`, {
@@ -39,15 +40,15 @@ export function useApiResource<T>(
       credentials: "include",
     });
     if (result.ok) {
-      setState({ status: "ready", data: result.data, error: null });
+      setState({ status: "ready", data: result.data, error: null, loadedAt: Date.now() });
     } else {
-      setState({ status: "error", data: null, error: result.message });
+      setState({ status: "error", data: null, error: result.message, loadedAt: null });
     }
   }, [enabled, label, path, token]);
 
   useEffect(() => {
     if (!enabled) {
-      setState({ status: "error", data: null, error: "disabled" });
+      setState({ status: "error", data: null, error: "disabled", loadedAt: null });
       return;
     }
     void load();

--- a/apps/gittensory-ui/src/lib/utils.ts
+++ b/apps/gittensory-ui/src/lib/utils.ts
@@ -4,3 +4,18 @@ import { twMerge } from "tailwind-merge";
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+/**
+ * Coarse relative-time label for "last refresh" style metadata (#2219). Clock skew or a
+ * just-written timestamp can land marginally in the future — clamp to "just now" instead
+ * of rendering a negative age.
+ */
+export function relativeTimeFromNow(timestampMs: number, nowMs: number): string {
+  const deltaSeconds = Math.max(0, Math.floor((nowMs - timestampMs) / 1000));
+  if (deltaSeconds < 60) return "just now";
+  const minutes = Math.floor(deltaSeconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}

--- a/apps/gittensory-ui/src/routes/app.analytics.tsx
+++ b/apps/gittensory-ui/src/routes/app.analytics.tsx
@@ -1,6 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 
 import { BoundaryBadge, Stat, StatusPill } from "@/components/site/control-primitives";
+import { RefreshMeta } from "@/components/site/refresh-meta";
 import { StateBoundary } from "@/components/site/state-views";
 import { TrendChart } from "@/components/site/trend-chart";
 import {
@@ -163,6 +164,7 @@ function ProductAnalytics() {
                 </StatusPill>
               ) : null}
               <BoundaryBadge boundary="private-api" />
+              <RefreshMeta loadedAt={dashboard.loadedAt} onRefresh={dashboard.reload} />
             </div>
           </header>
 


### PR DESCRIPTION
## Summary

- Adds a shared **`RefreshMeta`** primitive (`apps/gittensory-ui/src/components/site/refresh-meta.tsx`): a `last refresh Xm ago` label plus a manual refresh button, reusing `StateActionButton` + the `RefreshCw` icon already used by `StateBoundary`'s refresh affordances so the control reads consistently.
- Adds the pure **`relativeTimeFromNow(timestampMs, nowMs)`** helper to `apps/gittensory-ui/src/lib/utils.ts` with unit tests across every bucket boundary (seconds → minutes → hours → days) and a clamp for marginally-future timestamps.
- Extends **`useApiResource`** with a `loadedAt` stamp (set when a load succeeds, `null` while loading/on error/disabled) so headers can show refresh recency without any new fetch plumbing; `reload` is unchanged and is what the button calls.
- Adopts it on the **analytics** header pill row (`app.analytics.tsx`) and on the **maintainer dashboard** header row. The maintainer adoption lives at the top of `MaintainerDashboardView` (in `maintainer-panel.tsx`) rather than the route's `PageHeader` because the maintainer resource is created behind the session/role check inside the panel — the route header renders before any data exists to describe.
- The label re-renders on a coarse 30s interval (cleared on unmount) so it stays honest without a per-second timer; `RefreshMeta` renders nothing until the first successful load since the loading/error/empty states already carry their own retry/refresh affordances in `StateBoundary`.

Scoped to the dashboard headers only, per the issue — no `StateBoundary` refactor.

Closes #2219

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- None skipped — full `npm run test:ci` run locally. The diff is confined to `apps/gittensory-ui/**` (Codecov-exempt paths); the new helper, hook field, and component are still fully unit-tested (11 new cases: every relative-time bucket boundary + future-clamp, `loadedAt` on success/error/disabled, label tick, refetch-on-click, disabled-while-refreshing, null-before-first-load, interval cleanup).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

| State / title | Before | After |
| --- | --- | --- |
| `/app/analytics` header — refresh meta joins the status pill row | <a href="https://github.com/reyanthony062001-ops/gittensory/releases/download/ui-evidence-2219-v1/analytics-before.png"><img src="https://github.com/reyanthony062001-ops/gittensory/releases/download/ui-evidence-2219-v1/analytics-before.png" alt="Analytics header before" width="240"></a><br><sub>before: pills only, no refresh affordance</sub> | <a href="https://github.com/reyanthony062001-ops/gittensory/releases/download/ui-evidence-2219-v1/analytics-after.png"><img src="https://github.com/reyanthony062001-ops/gittensory/releases/download/ui-evidence-2219-v1/analytics-after.png" alt="Analytics header after" width="240"></a><br><sub>after: `last refresh just now` + Refresh button beside the boundary badge</sub> |
| `/app/maintainer` — dashboard header row above the metric cards | <a href="https://github.com/reyanthony062001-ops/gittensory/releases/download/ui-evidence-2219-v1/maintainer-before.png"><img src="https://github.com/reyanthony062001-ops/gittensory/releases/download/ui-evidence-2219-v1/maintainer-before.png" alt="Maintainer console before" width="240"></a><br><sub>before: metrics start with no refresh recency</sub> | <a href="https://github.com/reyanthony062001-ops/gittensory/releases/download/ui-evidence-2219-v1/maintainer-after.png"><img src="https://github.com/reyanthony062001-ops/gittensory/releases/download/ui-evidence-2219-v1/maintainer-after.png" alt="Maintainer console after" width="240"></a><br><sub>after: right-aligned `last refresh` meta + Refresh above the cards</sub> |

## Notes

- Loading/error/empty states intentionally show no `RefreshMeta` — `StateBoundary` already renders retry/refresh there; this control only describes a successfully loaded dashboard.
