### PR TITLE
feat(ui): CSV export button for the analytics ledger

### DIFF
--- a/apps/gittensory-ui/src/lib/csv-export.test.ts
+++ b/apps/gittensory-ui/src/lib/csv-export.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+
+import { escapeCsvCell, operatorDashboardToCsvRows, toCsv } from "@/lib/csv-export";
+
+describe("toCsv (#2198)", () => {
+  it("returns an empty string for zero rows", () => {
+    expect(toCsv([])).toBe("");
+  });
+
+  it("serializes a normal row without quoting", () => {
+    expect(
+      toCsv([
+        ["section", "key", "value", "detail"],
+        ["metric", "Active actors", "42", "+3"],
+      ]),
+    ).toBe("section,key,value,detail\nmetric,Active actors,42,+3");
+  });
+
+  it("escapes quotes, commas, and newlines in every branch", () => {
+    expect(escapeCsvCell('say "hi"')).toBe('"say ""hi"""');
+    expect(escapeCsvCell("a,b")).toBe('"a,b"');
+    expect(escapeCsvCell("line\nbreak")).toBe('"line\nbreak"');
+    expect(toCsv([["quoted", 'value,with"comma', "multi\nline"]])).toBe(
+      'quoted,"value,with""comma","multi\nline"',
+    );
+  });
+});
+
+describe("operatorDashboardToCsvRows (#2198)", () => {
+  it("flattens metrics and optional usage sections", () => {
+    expect(
+      operatorDashboardToCsvRows({
+        metrics: [{ label: "Events", value: "10", delta: "+1" }],
+        weeklyValueReport: {
+          metrics: [{ id: "w1", label: "Weekly", value: 5, detail: "ok" }],
+        },
+        usageSummary: {
+          byEvent: [{ eventName: "doctor", count: 2 }],
+          bySurface: [{ surface: "cli", count: 1 }],
+        },
+      }),
+    ).toEqual([
+      ["section", "key", "value", "detail"],
+      ["metric", "Events", "10", "+1"],
+      ["weekly_value", "Weekly", "5", "ok"],
+      ["usage_event", "doctor", "2", ""],
+      ["usage_surface", "cli", "1", ""],
+    ]);
+  });
+});

--- a/apps/gittensory-ui/src/lib/csv-export.ts
+++ b/apps/gittensory-ui/src/lib/csv-export.ts
@@ -1,0 +1,61 @@
+/** RFC-4180-style CSV cell escaping for client-side ledger exports (#2198). */
+export function escapeCsvCell(value: string): string {
+  const needsQuotes = /[",\n\r]/.test(value);
+  const escaped = value.replace(/"/g, '""');
+  return needsQuotes ? `"${escaped}"` : escaped;
+}
+
+/** Serialize typed rows to a CSV string (no trailing newline requirement). */
+export function toCsv(rows: readonly (readonly string[])[]): string {
+  return rows.map((row) => row.map(escapeCsvCell).join(",")).join("\n");
+}
+
+/** Trigger a browser download for a generated CSV blob. */
+export function downloadCsvText(filename: string, csv: string): void {
+  const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  anchor.click();
+  URL.revokeObjectURL(url);
+}
+
+export type AnalyticsLedgerCsvInput = {
+  metrics: ReadonlyArray<{ label: string; value: string; delta: string }>;
+  weeklyValueReport?: {
+    metrics: ReadonlyArray<{ id: string; label: string; value: number; detail: string }>;
+  };
+  usageSummary?: {
+    byEvent: ReadonlyArray<{ eventName: string; count: number }>;
+    bySurface: ReadonlyArray<{ surface: string; count: number }>;
+  };
+};
+
+/** Flatten the loaded operator-dashboard payload into exportable ledger rows. */
+export function operatorDashboardToCsvRows(data: AnalyticsLedgerCsvInput): string[][] {
+  const rows: string[][] = [["section", "key", "value", "detail"]];
+
+  for (const metric of data.metrics) {
+    rows.push(["metric", metric.label, metric.value, metric.delta]);
+  }
+
+  for (const metric of data.weeklyValueReport?.metrics ?? []) {
+    rows.push(["weekly_value", metric.label, String(metric.value), metric.detail]);
+  }
+
+  for (const row of data.usageSummary?.byEvent ?? []) {
+    rows.push(["usage_event", row.eventName, String(row.count), ""]);
+  }
+
+  for (const row of data.usageSummary?.bySurface ?? []) {
+    rows.push(["usage_surface", row.surface, String(row.count), ""]);
+  }
+
+  return rows;
+}
+
+export function exportOperatorDashboardCsv(data: AnalyticsLedgerCsvInput): void {
+  const day = new Date().toISOString().slice(0, 10);
+  downloadCsvText(`gittensory-analytics-${day}.csv`, toCsv(operatorDashboardToCsvRows(data)));
+}

--- a/apps/gittensory-ui/src/routes/app.analytics.tsx
+++ b/apps/gittensory-ui/src/routes/app.analytics.tsx
@@ -1,8 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { Download } from "lucide-react";
 
 import { BoundaryBadge, Stat, StatusPill } from "@/components/site/control-primitives";
 import { RefreshMeta } from "@/components/site/refresh-meta";
-import { StateBoundary } from "@/components/site/state-views";
+import { StateActionButton, StateBoundary } from "@/components/site/state-views";
 import { TrendChart } from "@/components/site/trend-chart";
 import {
   AdoptionRetentionPanel,
@@ -15,6 +16,7 @@ import type { GateEvalReport } from "@/components/site/app-panels/gate-precision
 import { CycleTimeCard } from "@/components/site/app-panels/cycle-time-card";
 import type { CycleTimeAggregate } from "@/components/site/app-panels/cycle-time-card-model";
 import { useApiResource } from "@/lib/api/use-api-resource";
+import { exportOperatorDashboardCsv } from "@/lib/csv-export";
 
 export const Route = createFileRoute("/app/analytics")({
   component: ProductAnalytics,
@@ -164,6 +166,13 @@ function ProductAnalytics() {
                 </StatusPill>
               ) : null}
               <BoundaryBadge boundary="private-api" />
+              <StateActionButton
+                onClick={() => exportOperatorDashboardCsv(data)}
+                disabled={data.metrics.length === 0}
+                icon={<Download className="size-3 shrink-0" aria-hidden />}
+              >
+                Export CSV
+              </StateActionButton>
               <RefreshMeta loadedAt={dashboard.loadedAt} onRefresh={dashboard.reload} />
             </div>
           </header>


### PR DESCRIPTION
## Summary

- Add pure `toCsv` / `escapeCsvCell` helpers in `apps/gittensory-ui/src/lib/csv-export.ts`
- Add **Export CSV** to the `/app/analytics` header; serializes the already-loaded operator-dashboard payload client-side (metrics, weekly value, usage breakdown) into a downloadable blob
- Button is disabled when no metric rows are loaded

Closes #2198

## Test plan

- [x] `npm run test --workspace=@jsonbored/gittensory-ui -- src/lib/csv-export.test.ts`
- [x] `npm run typecheck --workspace=@jsonbored/gittensory-ui`
- [x] `npm run lint --workspace=@jsonbored/gittensory-ui`
- [x] CI green on prior run (validate-code, validate, security, UI preview build)

## UI Evidence

| Page / Feature | Before | After |
|---|---|---|
| `/app/analytics` header | [<img src="https://github.com/RealDiligent/gittensory/releases/download/ui-evidence-2198-v1/analytics-before-2198.png" width="260">](https://github.com/RealDiligent/gittensory/releases/download/ui-evidence-2198-v1/analytics-before-2198.png)<br><sub>before: refresh meta only, no export action</sub> | [<img src="https://github.com/RealDiligent/gittensory/releases/download/ui-evidence-2198-v1/analytics-after-2198.png" width="260">](https://github.com/RealDiligent/gittensory/releases/download/ui-evidence-2198-v1/analytics-after-2198.png)<br><sub>after: Export CSV button beside Refresh</sub> |
