### PR TITLE
feat(ui): add a time-window selector to the analytics dashboard

### DIFF
--- a/apps/gittensory-ui/src/components/site/analytics-window-toggle.test.tsx
+++ b/apps/gittensory-ui/src/components/site/analytics-window-toggle.test.tsx
@@ -1,0 +1,33 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { AnalyticsWindowToggle } from "@/components/site/analytics-window-toggle";
+
+describe("AnalyticsWindowToggle", () => {
+  it("renders every window option and marks the current value as pressed (default)", () => {
+    render(<AnalyticsWindowToggle value="30d" onChange={() => {}} />);
+    const active = screen.getByRole("radio", { name: "Last 30 days" });
+    expect(active.getAttribute("data-state")).toBe("on");
+    expect(screen.getByRole("radio", { name: "Last 7 days" }).getAttribute("data-state")).toBe(
+      "off",
+    );
+    expect(screen.getByRole("radio", { name: "Last 90 days" }).getAttribute("data-state")).toBe(
+      "off",
+    );
+  });
+
+  it("calls onChange with the selected window when switching", () => {
+    const onChange = vi.fn();
+    render(<AnalyticsWindowToggle value="30d" onChange={onChange} />);
+    fireEvent.click(screen.getByRole("radio", { name: "Last 7 days" }));
+    expect(onChange).toHaveBeenCalledWith("7d");
+  });
+
+  it("does not fire onChange when the already-active window is re-pressed", () => {
+    const onChange = vi.fn();
+    render(<AnalyticsWindowToggle value="30d" onChange={onChange} />);
+    // Radix emits "" on deselect; the toggle must swallow it to keep a window selected.
+    fireEvent.click(screen.getByRole("radio", { name: "Last 30 days" }));
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/apps/gittensory-ui/src/components/site/analytics-window-toggle.tsx
+++ b/apps/gittensory-ui/src/components/site/analytics-window-toggle.tsx
@@ -1,0 +1,37 @@
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { ANALYTICS_WINDOWS, type AnalyticsWindow } from "@/lib/analytics-window";
+
+/**
+ * Header control that lets an operator pick the analytics time window. Purely
+ * presentational — the selected value is owned (and persisted) by the route.
+ */
+export function AnalyticsWindowToggle({
+  value,
+  onChange,
+  className,
+}: {
+  value: AnalyticsWindow;
+  onChange: (value: AnalyticsWindow) => void;
+  className?: string;
+}) {
+  return (
+    <ToggleGroup
+      type="single"
+      value={value}
+      onValueChange={(next) => {
+        // Radix emits "" when the active item is re-pressed; keep a window always selected.
+        if (next) onChange(next as AnalyticsWindow);
+      }}
+      variant="outline"
+      size="sm"
+      aria-label="Analytics time window"
+      className={className}
+    >
+      {ANALYTICS_WINDOWS.map((option) => (
+        <ToggleGroupItem key={option.value} value={option.value} aria-label={option.label}>
+          {option.value}
+        </ToggleGroupItem>
+      ))}
+    </ToggleGroup>
+  );
+}

--- a/apps/gittensory-ui/src/lib/analytics-window.test.ts
+++ b/apps/gittensory-ui/src/lib/analytics-window.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_ANALYTICS_WINDOW,
+  isAnalyticsWindow,
+  withWindowParam,
+} from "@/lib/analytics-window";
+
+describe("analytics-window helpers", () => {
+  it("exposes a valid default window", () => {
+    expect(isAnalyticsWindow(DEFAULT_ANALYTICS_WINDOW)).toBe(true);
+  });
+
+  it("narrows only known window values", () => {
+    expect(isAnalyticsWindow("7d")).toBe(true);
+    expect(isAnalyticsWindow("30d")).toBe(true);
+    expect(isAnalyticsWindow("90d")).toBe(true);
+    expect(isAnalyticsWindow("1d")).toBe(false);
+    expect(isAnalyticsWindow("")).toBe(false);
+    expect(isAnalyticsWindow(undefined)).toBe(false);
+    expect(isAnalyticsWindow(7)).toBe(false);
+  });
+
+  it("appends the window as a query param on a bare path", () => {
+    expect(withWindowParam("/v1/app/operator-dashboard", "7d")).toBe(
+      "/v1/app/operator-dashboard?window=7d",
+    );
+  });
+
+  it("preserves an existing query string", () => {
+    expect(withWindowParam("/v1/app/operator-dashboard?flag=1", "90d")).toBe(
+      "/v1/app/operator-dashboard?flag=1&window=90d",
+    );
+  });
+
+  it("overrides a stale window already present in the query", () => {
+    expect(withWindowParam("/v1/app/operator-dashboard?window=7d", "30d")).toBe(
+      "/v1/app/operator-dashboard?window=30d",
+    );
+  });
+});

--- a/apps/gittensory-ui/src/lib/analytics-window.ts
+++ b/apps/gittensory-ui/src/lib/analytics-window.ts
@@ -1,0 +1,32 @@
+/**
+ * Time-window options for the product analytics dashboard. The selected window
+ * is threaded into the dashboard fetch as a `window` query param (which doubles
+ * as the useApiResource cache/refetch key) and persisted per-browser.
+ */
+export const ANALYTICS_WINDOWS = [
+  { value: "7d", label: "Last 7 days", days: 7 },
+  { value: "30d", label: "Last 30 days", days: 30 },
+  { value: "90d", label: "Last 90 days", days: 90 },
+] as const;
+
+export type AnalyticsWindow = (typeof ANALYTICS_WINDOWS)[number]["value"];
+
+export const DEFAULT_ANALYTICS_WINDOW: AnalyticsWindow = "30d";
+
+const WINDOW_VALUES = new Set<string>(ANALYTICS_WINDOWS.map((option) => option.value));
+
+/** Narrow an unknown (e.g. a persisted localStorage value) to a valid window. */
+export function isAnalyticsWindow(value: unknown): value is AnalyticsWindow {
+  return typeof value === "string" && WINDOW_VALUES.has(value);
+}
+
+/**
+ * Append the selected window as a `window` query param, preserving any existing
+ * query string and overriding a stale `window` if one is already present.
+ */
+export function withWindowParam(path: string, window: AnalyticsWindow): string {
+  const [base, existingQuery = ""] = path.split("?");
+  const params = new URLSearchParams(existingQuery);
+  params.set("window", window);
+  return `${base}?${params.toString()}`;
+}

--- a/apps/gittensory-ui/src/routes/app.analytics.tsx
+++ b/apps/gittensory-ui/src/routes/app.analytics.tsx
@@ -14,7 +14,15 @@ import { GatePrecisionCard } from "@/components/site/app-panels/gate-precision-c
 import type { GateEvalReport } from "@/components/site/app-panels/gate-precision-card-model";
 import { CycleTimeCard } from "@/components/site/app-panels/cycle-time-card";
 import type { CycleTimeAggregate } from "@/components/site/app-panels/cycle-time-card-model";
+import { AnalyticsWindowToggle } from "@/components/site/analytics-window-toggle";
+import {
+  DEFAULT_ANALYTICS_WINDOW,
+  isAnalyticsWindow,
+  withWindowParam,
+  type AnalyticsWindow,
+} from "@/lib/analytics-window";
 import { useApiResource } from "@/lib/api/use-api-resource";
+import { useLocalStorage } from "@/lib/use-local-storage";
 
 export const Route = createFileRoute("/app/analytics")({
   component: ProductAnalytics,
@@ -108,8 +116,14 @@ type OperatorDashboard = {
 };
 
 function ProductAnalytics() {
+  const [storedWindow, setWindow] = useLocalStorage<AnalyticsWindow>(
+    "analytics:window",
+    DEFAULT_ANALYTICS_WINDOW,
+  );
+  // Guard against a corrupt/legacy persisted value before it reaches the query key.
+  const analyticsWindow = isAnalyticsWindow(storedWindow) ? storedWindow : DEFAULT_ANALYTICS_WINDOW;
   const dashboard = useApiResource<OperatorDashboard>(
-    "/v1/app/operator-dashboard",
+    withWindowParam("/v1/app/operator-dashboard", analyticsWindow),
     "Product analytics",
   );
   const data = dashboard.status === "ready" ? dashboard.data : null;
@@ -146,6 +160,7 @@ function ProductAnalytics() {
               </p>
             </div>
             <div className="flex items-center gap-2">
+              <AnalyticsWindowToggle value={analyticsWindow} onChange={setWindow} />
               <StatusPill
                 status={
                   data.usageRollupStatus?.status === "ready" ||


### PR DESCRIPTION
## Summary

Adds a **7d / 30d / 90d** time-window selector to the product analytics dashboard header (#2199). The chosen window is persisted per-browser and threaded into the dashboard fetch as a `?window=` query param, so switching windows re-fetches the operator dashboard for that range.

- `AnalyticsWindowToggle` (`apps/gittensory-ui/src/components/site/analytics-window-toggle.tsx`) — a `ToggleGroup` (from `components/ui/toggle-group.tsx`) wired into the analytics header next to the existing status pills.
- Pure helpers in `apps/gittensory-ui/src/lib/analytics-window.ts`: `ANALYTICS_WINDOWS`, an `isAnalyticsWindow` guard, and `withWindowParam(path, window)` which appends `window=<value>` while preserving any existing query and overriding a stale `window`.
- The window is threaded into the fetch via `withWindowParam(...)` — this URL doubles as the `useApiResource` refetch key (the path is already in its `load` dependency list), so a switch re-fetches with **no change to the shared hook**.
- Persisted with the existing `useLocalStorage` hook (`analytics:window`); a corrupt/legacy stored value falls back to the default (`30d`) via the guard.

Anchored on existing analogues: the analytics header/pills in `routes/app.analytics.tsx`, the `ToggleGroup` primitive, and `useLocalStorage`.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #2199`).

## Validation

- [x] `git diff --check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build` (re-runs `ui:openapi`; no OpenAPI drift — spec unchanged)
- [x] `npm run ui:test` — 103 UI tests pass, incl. the new `analytics-window` and `analytics-window-toggle` suites
- [x] New behavior has unit tests (helpers + toggle default/switch/deselect branches)

If any required check was skipped, explain why:

- This is a **UI-only** change confined to `apps/gittensory-ui/**` — no `src/**`, workflow, MCP, migration, or dependency changes. So the backend/MCP/actionlint/coverage/audit jobs are path-skipped and not applicable, and Codecov ignores `apps/**` (no patch-coverage obligation). Tests are included regardless.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, private keys, raw trust scores, private rankings, or maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and implies no compensation guarantees or optimization tactics.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed (nothing needed; `ui:openapi:check` clean).
- [x] UI changes use live API data / real states — the selector drives the real `/v1/app/operator-dashboard` request, no mock/demo fallback.
- [x] Visible UI changes include a `UI Evidence` section below with PNG thumbnails (not committed to the repo).
- [x] No changelog edited.

_No auth, cookie, CORS, GitHub App, Cloudflare, or session code is touched, so the negative-path-tests box is not applicable._

## UI Evidence

Captured against the real component in a dark-mode dev build (backend offline, so the dev API-status banner is stripped from the frame).

| State / title | PNG evidence |
| --- | --- |
| Window selector control (7d · 30d · 90d) | [<img src="https://raw.githubusercontent.com/nickmopen/gittensory/screenshots/window-selector-control.png" alt="Window selector control" width="240">](https://raw.githubusercontent.com/nickmopen/gittensory/screenshots/window-selector-control.png) |
| Default — `30d` selected → fetch key `?window=30d` | [<img src="https://raw.githubusercontent.com/nickmopen/gittensory/screenshots/window-selector-30d.png" alt="Default 30d" width="240">](https://raw.githubusercontent.com/nickmopen/gittensory/screenshots/window-selector-30d.png) |
| Switched — `90d` selected → fetch key `?window=90d` | [<img src="https://raw.githubusercontent.com/nickmopen/gittensory/screenshots/window-selector-90d.png" alt="Switched 90d" width="240">](https://raw.githubusercontent.com/nickmopen/gittensory/screenshots/window-selector-90d.png) |

## Notes

- The selector persists across reloads (`analytics:window` in localStorage) and defaults to `30d`.

Closes #2199
