### PR TITLE
feat(ui): queue-health trend card on maintainer quality dashboard (#2201)

### DIFF
--- a/apps/gittensory-ui/src/components/site/app-panels/maintainer-panel.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/maintainer-panel.tsx
@@ -20,6 +20,8 @@ import {
 import { ActivationPreview } from "@/components/site/app-panels/activation-preview";
 import { AiReviewSettings } from "@/components/site/app-panels/ai-review-settings";
 import { MaintainerSettings } from "@/components/site/app-panels/maintainer-settings";
+import { QueueHealthCard } from "@/components/site/app-panels/queue-health-card";
+import type { QueueHealthCardModel } from "@/components/site/app-panels/queue-health-card-model";
 import { StatCard } from "@/components/site/primitives";
 import { RefreshMeta } from "@/components/site/refresh-meta";
 import { EmptyState, LoadingState, StateBoundary } from "@/components/site/state-views";
@@ -77,6 +79,7 @@ type MaintainerDashboard = {
     slop?: { risk: number; band: string } | null;
   }>;
   settingsPreview: { removed: string[]; added: string[] };
+  queueHealthCard: QueueHealthCardModel;
 };
 
 type TrustChecklistStatus = "ready" | "needs_attention" | "blocked";
@@ -225,6 +228,8 @@ function MaintainerDashboardView() {
               />
             ))}
           </section>
+
+          {data.queueHealthCard ? <QueueHealthCard card={data.queueHealthCard} /> : null}
 
           <section className="grid gap-6 lg:grid-cols-2">
             <div className="rounded-token border-hairline bg-card p-5">

--- a/apps/gittensory-ui/src/components/site/app-panels/queue-health-card-model.ts
+++ b/apps/gittensory-ui/src/components/site/app-panels/queue-health-card-model.ts
@@ -9,7 +9,9 @@ export type QueueHealthCardModel = {
   summary: string;
 };
 
-export function queueHealthStatus(card: QueueHealthCardModel): "ready" | "warn" | "stale" | "blocked" {
+export function queueHealthStatus(
+  card: QueueHealthCardModel,
+): "ready" | "warn" | "stale" | "blocked" {
   if (card.stale) return "stale";
   if (card.dlq > 0) return "blocked";
   if (card.stuck > 0) return "warn";

--- a/apps/gittensory-ui/src/components/site/app-panels/queue-health-card-model.ts
+++ b/apps/gittensory-ui/src/components/site/app-panels/queue-health-card-model.ts
@@ -1,0 +1,23 @@
+export type QueueHealthCardModel = {
+  generatedAt: string;
+  stale: boolean;
+  pending: number;
+  inFlight: number;
+  stuck: number;
+  dlq: number;
+  queueDepthTrend: number[];
+  summary: string;
+};
+
+export function queueHealthStatus(card: QueueHealthCardModel): "ready" | "warn" | "stale" | "blocked" {
+  if (card.stale) return "stale";
+  if (card.dlq > 0) return "blocked";
+  if (card.stuck > 0) return "warn";
+  return "ready";
+}
+
+export function formatQueueHealthGeneratedAt(value: string): string {
+  const parsed = Date.parse(value);
+  if (!Number.isFinite(parsed)) return value;
+  return new Date(parsed).toLocaleString();
+}

--- a/apps/gittensory-ui/src/components/site/app-panels/queue-health-card.test.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/queue-health-card.test.tsx
@@ -51,13 +51,17 @@ describe("QueueHealthCard", () => {
   });
 
   it("renders a warn state when stuck PRs are present", () => {
-    render(<QueueHealthCard card={card({ stuck: 3, summary: "3 stale PR(s) across shaped repos." })} />);
+    render(
+      <QueueHealthCard card={card({ stuck: 3, summary: "3 stale PR(s) across shaped repos." })} />,
+    );
     expect(screen.getByText("stale PRs present")).toBeTruthy();
     expect(screen.getByText("3")).toBeTruthy();
   });
 
   it("renders a blocked state when DLQ duplicate-risk clusters are present", () => {
-    render(<QueueHealthCard card={card({ dlq: 2, summary: "2 high-risk duplicate cluster(s)." })} />);
+    render(
+      <QueueHealthCard card={card({ dlq: 2, summary: "2 high-risk duplicate cluster(s)." })} />,
+    );
     expect(screen.getByText("duplicate risk")).toBeTruthy();
     expect(screen.getByText("2 high-risk duplicate cluster(s).")).toBeTruthy();
   });
@@ -65,7 +69,9 @@ describe("QueueHealthCard", () => {
   it("renders a stale snapshot pill and generatedAt timestamp", () => {
     render(<QueueHealthCard card={card({ stale: true })} />);
     expect(screen.getByText("stale snapshot")).toBeTruthy();
-    expect(screen.getByText(new RegExp(formatQueueHealthGeneratedAt("2026-07-10T12:00:00.000Z")))).toBeTruthy();
+    expect(
+      screen.getByText(new RegExp(formatQueueHealthGeneratedAt("2026-07-10T12:00:00.000Z"))),
+    ).toBeTruthy();
   });
 
   it("shows a placeholder when queue-depth history has not accumulated yet", () => {

--- a/apps/gittensory-ui/src/components/site/app-panels/queue-health-card.test.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/queue-health-card.test.tsx
@@ -1,0 +1,81 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { QueueHealthCard } from "@/components/site/app-panels/queue-health-card";
+import {
+  formatQueueHealthGeneratedAt,
+  queueHealthStatus,
+  type QueueHealthCardModel,
+} from "@/components/site/app-panels/queue-health-card-model";
+
+function card(overrides: Partial<QueueHealthCardModel> = {}): QueueHealthCardModel {
+  return {
+    generatedAt: "2026-07-10T12:00:00.000Z",
+    stale: false,
+    pending: 4,
+    inFlight: 2,
+    stuck: 0,
+    dlq: 0,
+    queueDepthTrend: [2, 3, 4, 5, 4],
+    summary: "Queue health looks clear across shaped repos.",
+    ...overrides,
+  };
+}
+
+describe("queueHealthStatus", () => {
+  it("flags stale snapshots first", () => {
+    expect(queueHealthStatus(card({ stale: true, stuck: 3, dlq: 2 }))).toBe("stale");
+  });
+
+  it("flags DLQ pressure when duplicate-risk clusters are present", () => {
+    expect(queueHealthStatus(card({ dlq: 1 }))).toBe("blocked");
+  });
+
+  it("warns when stale PRs are present but DLQ is clear", () => {
+    expect(queueHealthStatus(card({ stuck: 2 }))).toBe("warn");
+  });
+
+  it("reports healthy when counts are clear and the snapshot is fresh", () => {
+    expect(queueHealthStatus(card())).toBe("ready");
+  });
+});
+
+describe("QueueHealthCard", () => {
+  it("renders healthy queue stats and the queue-depth trend", () => {
+    render(<QueueHealthCard card={card()} />);
+    expect(screen.getByText("Queue health")).toBeTruthy();
+    expect(screen.getByText("healthy")).toBeTruthy();
+    expect(screen.getByText("4")).toBeTruthy();
+    expect(screen.getByText("Queue depth trend")).toBeTruthy();
+    expect(screen.getByLabelText("Trend chart")).toBeTruthy();
+  });
+
+  it("renders a warn state when stuck PRs are present", () => {
+    render(<QueueHealthCard card={card({ stuck: 3, summary: "3 stale PR(s) across shaped repos." })} />);
+    expect(screen.getByText("stale PRs present")).toBeTruthy();
+    expect(screen.getByText("3")).toBeTruthy();
+  });
+
+  it("renders a blocked state when DLQ duplicate-risk clusters are present", () => {
+    render(<QueueHealthCard card={card({ dlq: 2, summary: "2 high-risk duplicate cluster(s)." })} />);
+    expect(screen.getByText("duplicate risk")).toBeTruthy();
+    expect(screen.getByText("2 high-risk duplicate cluster(s).")).toBeTruthy();
+  });
+
+  it("renders a stale snapshot pill and generatedAt timestamp", () => {
+    render(<QueueHealthCard card={card({ stale: true })} />);
+    expect(screen.getByText("stale snapshot")).toBeTruthy();
+    expect(screen.getByText(new RegExp(formatQueueHealthGeneratedAt("2026-07-10T12:00:00.000Z")))).toBeTruthy();
+  });
+
+  it("shows a placeholder when queue-depth history has not accumulated yet", () => {
+    render(<QueueHealthCard card={card({ queueDepthTrend: [] })} />);
+    expect(screen.getByText(/Queue-depth history will appear/)).toBeTruthy();
+  });
+});
+
+describe("formatQueueHealthGeneratedAt", () => {
+  it("returns the raw value when the timestamp cannot be parsed", () => {
+    expect(formatQueueHealthGeneratedAt("not-a-date")).toBe("not-a-date");
+  });
+});

--- a/apps/gittensory-ui/src/components/site/app-panels/queue-health-card.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/queue-health-card.tsx
@@ -32,10 +32,26 @@ export function QueueHealthCard({ card }: { card: QueueHealthCardModel }) {
       </div>
 
       <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-        <Stat label="Pending" value={String(card.pending)} hint={<span className="text-muted-foreground">open PRs in queue</span>} />
-        <Stat label="In flight" value={String(card.inFlight)} hint={<span className="text-muted-foreground">likely reviewable now</span>} />
-        <Stat label="Stuck" value={String(card.stuck)} hint={<span className="text-muted-foreground">stale open PRs</span>} />
-        <Stat label="DLQ" value={String(card.dlq)} hint={<span className="text-muted-foreground">high-risk duplicate clusters</span>} />
+        <Stat
+          label="Pending"
+          value={String(card.pending)}
+          hint={<span className="text-muted-foreground">open PRs in queue</span>}
+        />
+        <Stat
+          label="In flight"
+          value={String(card.inFlight)}
+          hint={<span className="text-muted-foreground">likely reviewable now</span>}
+        />
+        <Stat
+          label="Stuck"
+          value={String(card.stuck)}
+          hint={<span className="text-muted-foreground">stale open PRs</span>}
+        />
+        <Stat
+          label="DLQ"
+          value={String(card.dlq)}
+          hint={<span className="text-muted-foreground">high-risk duplicate clusters</span>}
+        />
       </div>
 
       {card.queueDepthTrend.length > 0 ? (

--- a/apps/gittensory-ui/src/components/site/app-panels/queue-health-card.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/queue-health-card.tsx
@@ -1,0 +1,60 @@
+import { Stat, StatusPill } from "@/components/site/control-primitives";
+import { TrendChart } from "@/components/site/trend-chart";
+import {
+  formatQueueHealthGeneratedAt,
+  queueHealthStatus,
+  type QueueHealthCardModel,
+} from "@/components/site/app-panels/queue-health-card-model";
+
+/** Maintainer quality dashboard card (#2201): aggregate queue-health counts + queue-depth trend from cached
+ *  signal snapshots. Read-only over the shaped maintainer-dashboard payload. */
+export function QueueHealthCard({ card }: { card: QueueHealthCardModel }) {
+  const status = queueHealthStatus(card);
+  const statusLabel =
+    status === "stale"
+      ? "stale snapshot"
+      : status === "blocked"
+        ? "duplicate risk"
+        : status === "warn"
+          ? "stale PRs present"
+          : "healthy";
+
+  return (
+    <section className="rounded-token border border-border bg-transparent p-5">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="font-display text-token-lg font-semibold">Queue health</h2>
+          <p className="mt-1 text-token-xs text-muted-foreground">
+            Pending review load, stale PR pressure, and duplicate-risk clusters across shaped repos.
+          </p>
+        </div>
+        <StatusPill status={status}>{statusLabel}</StatusPill>
+      </div>
+
+      <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+        <Stat label="Pending" value={String(card.pending)} hint={<span className="text-muted-foreground">open PRs in queue</span>} />
+        <Stat label="In flight" value={String(card.inFlight)} hint={<span className="text-muted-foreground">likely reviewable now</span>} />
+        <Stat label="Stuck" value={String(card.stuck)} hint={<span className="text-muted-foreground">stale open PRs</span>} />
+        <Stat label="DLQ" value={String(card.dlq)} hint={<span className="text-muted-foreground">high-risk duplicate clusters</span>} />
+      </div>
+
+      {card.queueDepthTrend.length > 0 ? (
+        <div className="mt-4 rounded-token border border-border bg-background/40 p-3">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <div className="text-token-xs text-muted-foreground">Queue depth trend</div>
+            <div className="font-mono text-token-2xs text-muted-foreground">
+              generated {formatQueueHealthGeneratedAt(card.generatedAt)}
+            </div>
+          </div>
+          <TrendChart values={card.queueDepthTrend} height={80} className="mt-2" />
+        </div>
+      ) : (
+        <p className="mt-4 text-token-sm text-muted-foreground">
+          Queue-depth history will appear after queue-health snapshots accumulate for shaped repos.
+        </p>
+      )}
+
+      <p className="mt-3 text-token-xs text-muted-foreground">{card.summary}</p>
+    </section>
+  );
+}

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -263,6 +263,7 @@ import { getPublicStats, isPublicStatsEnabled } from "../review/public-stats";
 import { loadPublicAccuracyTrend } from "../services/public-accuracy-trend";
 import { loadPublicReuseRateTrend } from "../services/public-reuse-rate-trend";
 import { buildMaintainerQualityDashboard, isMaintainerQualityDataStale } from "../services/maintainer-quality-dashboard";
+import { buildMaintainerQueueHealthCard } from "../services/maintainer-queue-health-card";
 import { MAX_LOCAL_SCORER_WARNING_CHARS, MAX_LOCAL_SCORER_WARNING_COUNT } from "../signals/local-scorer-diagnostics";
 import { compileFocusManifestPolicy, MAX_FOCUS_MANIFEST_BYTES, normalizeReadinessGateMode } from "../signals/focus-manifest";
 import { resolveRepositorySettings } from "../settings/repository-settings";
@@ -1390,9 +1391,17 @@ export function createApp() {
     const qualityRepoNames = new Set(qualityRepos.map((repo) => repo.fullName.toLowerCase()));
     const scopedSyncCompletions = allSyncStates.filter((state) => qualityRepoNames.has(state.repoFullName.toLowerCase())).map((state) => state.lastCompletedAt);
     const qualityStale = isMaintainerQualityDataStale({ lastCompletedAts: scopedSyncCompletions, repoCount: qualityRepos.length, nowMs: Date.parse(nowIso()) });
-    const qualityDashboard = buildMaintainerQualityDashboard({ repos: qualityRepoInputs, generatedAt: nowIso(), stale: qualityStale, repoTotal: repositories.length });
+    const generatedAt = nowIso();
+    const qualityDashboard = buildMaintainerQualityDashboard({ repos: qualityRepoInputs, generatedAt, stale: qualityStale, repoTotal: repositories.length });
+    const queueHealthHistories = await Promise.all(qualityRepos.map((repo) => listSignalSnapshots(c.env, "queue-health", repo.fullName)));
+    const queueHealthCard = buildMaintainerQueueHealthCard({
+      generatedAt,
+      stale: qualityStale,
+      histories: queueHealthHistories,
+      highRiskDuplicates: qualityDashboard.repoQuality.reduce((sum, repo) => sum + repo.highRiskDuplicates, 0),
+    });
     return c.json({
-      generatedAt: nowIso(),
+      generatedAt,
       installations,
       health: health.map(enrichInstallationHealth),
       metrics: [
@@ -1413,6 +1422,7 @@ export function createApp() {
       })),
       settingsPreview: buildMaintainerSettingsPreview(),
       qualityDashboard,
+      queueHealthCard,
     });
   });
 

--- a/src/services/maintainer-queue-health-card.ts
+++ b/src/services/maintainer-queue-health-card.ts
@@ -1,0 +1,89 @@
+// Maintainer queue-health trend card (#2201): shapes cached queue-health signal snapshots into the
+// read-only card payload the maintainer dashboard renders. Counts are aggregate-only — no actor logins,
+// burden scores, or reward fields.
+import type { JsonValue, SignalSnapshotRecord } from "../types";
+
+export type MaintainerQueueHealthCard = {
+  generatedAt: string;
+  stale: boolean;
+  pending: number;
+  inFlight: number;
+  stuck: number;
+  dlq: number;
+  queueDepthTrend: number[];
+  summary: string;
+};
+
+const TREND_POINT_LIMIT = 14;
+
+type QueueHealthSignals = {
+  openPullRequests: number;
+  stalePullRequests: number;
+  likelyReviewablePullRequests: number;
+  collisionClusters: number;
+};
+
+export function readQueueHealthSignals(payload: Record<string, JsonValue>): QueueHealthSignals | null {
+  const signals = payload.signals;
+  if (!signals || typeof signals !== "object" || Array.isArray(signals)) return null;
+  const record = signals as Record<string, JsonValue>;
+  return {
+    openPullRequests: numberValue(record.openPullRequests),
+    stalePullRequests: numberValue(record.stalePullRequests),
+    likelyReviewablePullRequests: numberValue(record.likelyReviewablePullRequests),
+    collisionClusters: numberValue(record.collisionClusters),
+  };
+}
+
+/** Fold cached queue-health snapshots + duplicate-risk totals into the maintainer card payload. */
+export function buildMaintainerQueueHealthCard(args: {
+  generatedAt: string;
+  stale: boolean;
+  histories: readonly (readonly SignalSnapshotRecord[])[];
+  highRiskDuplicates: number;
+}): MaintainerQueueHealthCard {
+  const latestByRepo = args.histories.map((history) => history[0] ?? null).filter((row): row is SignalSnapshotRecord => row !== null);
+  const latestSignals = latestByRepo
+    .map((row) => readQueueHealthSignals(row.payload))
+    .filter((signals): signals is QueueHealthSignals => signals !== null);
+
+  const pending = latestSignals.reduce((sum, signals) => sum + signals.openPullRequests, 0);
+  const inFlight = latestSignals.reduce((sum, signals) => sum + signals.likelyReviewablePullRequests, 0);
+  const stuck = latestSignals.reduce((sum, signals) => sum + signals.stalePullRequests, 0);
+  const dlq = args.highRiskDuplicates;
+
+  const trendBuckets = new Map<string, number>();
+  for (const history of args.histories) {
+    for (const row of history) {
+      const signals = readQueueHealthSignals(row.payload);
+      if (!signals) continue;
+      const bucket = row.generatedAt?.slice(0, 13);
+      if (!bucket) continue;
+      trendBuckets.set(bucket, (trendBuckets.get(bucket) ?? 0) + signals.openPullRequests);
+    }
+  }
+  const queueDepthTrend = [...trendBuckets.entries()]
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([, value]) => value)
+    .slice(-TREND_POINT_LIMIT);
+
+  const summary =
+    pending === 0 && stuck === 0 && dlq === 0
+      ? "Queue health looks clear across shaped repos."
+      : `${pending} open PR(s), ${stuck} stale, ${dlq} high-risk duplicate cluster(s) across shaped repos.`;
+
+  return {
+    generatedAt: args.generatedAt,
+    stale: args.stale,
+    pending,
+    inFlight,
+    stuck,
+    dlq,
+    queueDepthTrend,
+    summary,
+  };
+}
+
+function numberValue(value: JsonValue | undefined): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -2210,6 +2210,7 @@ describe("api routes", () => {
     const body = (await res.json()) as {
       metrics: Array<{ label: string; value: number }>;
       qualityDashboard: { generatedAt: string; stale: boolean; repoQuality: Array<{ repoFullName: string; queueBand: string }>; topContributors: Array<{ login: string; band: string }>; qualitySignals: { openPrs: number }; summary: string };
+      queueHealthCard: { generatedAt: string; stale: boolean; pending: number; inFlight: number; stuck: number; dlq: number; queueDepthTrend: number[]; summary: string };
     };
     expect(body.metrics.find((metric) => metric.label === "Open PRs cached")?.value).toBe(8);
     // Quality dashboard (#557): shaped, scoped, public-safe trend/outcome data with bands not raw scores.
@@ -2222,6 +2223,16 @@ describe("api routes", () => {
     expect(body.qualityDashboard.summary).toContain("open PR(s)");
     expect(JSON.stringify(body.qualityDashboard)).not.toMatch(FORBIDDEN_PUBLIC_REPORT_TERMS);
     expect(JSON.stringify(body.qualityDashboard)).not.toMatch(/"burdenScore"|"credibility"/);
+    // Queue-health trend card (#2201): shaped snapshot counts + queue-depth series for the maintainer dashboard.
+    expect(body.queueHealthCard.generatedAt).toEqual(expect.any(String));
+    expect(typeof body.queueHealthCard.stale).toBe("boolean");
+    expect(body.queueHealthCard.pending).toBeGreaterThanOrEqual(0);
+    expect(body.queueHealthCard.inFlight).toBeGreaterThanOrEqual(0);
+    expect(body.queueHealthCard.stuck).toBeGreaterThanOrEqual(0);
+    expect(body.queueHealthCard.dlq).toBeGreaterThanOrEqual(0);
+    expect(Array.isArray(body.queueHealthCard.queueDepthTrend)).toBe(true);
+    expect(body.queueHealthCard.summary.length).toBeGreaterThan(0);
+    expect(JSON.stringify(body.queueHealthCard)).not.toMatch(FORBIDDEN_PUBLIC_REPORT_TERMS);
   });
 
   it("counts cached open PRs from sync states beyond the latest 500 rows", async () => {

--- a/test/unit/maintainer-queue-health-card.test.ts
+++ b/test/unit/maintainer-queue-health-card.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from "vitest";
+import { buildMaintainerQueueHealthCard, readQueueHealthSignals } from "../../src/services/maintainer-queue-health-card";
+import type { SignalSnapshotRecord } from "../../src/types";
+
+function snapshot(generatedAt: string, openPullRequests: number, stalePullRequests = 0, likelyReviewable = 0): SignalSnapshotRecord {
+  return {
+    id: `${generatedAt}-${openPullRequests}`,
+    signalType: "queue-health",
+    targetKey: "octo/demo",
+    repoFullName: "octo/demo",
+    generatedAt,
+    payload: {
+      signals: {
+        openPullRequests,
+        stalePullRequests,
+        likelyReviewablePullRequests: likelyReviewable,
+        collisionClusters: 0,
+      },
+    },
+  };
+}
+
+describe("buildMaintainerQueueHealthCard (#2201)", () => {
+  it("aggregates pending/in-flight/stuck counts and queue-depth trend from cached snapshots", () => {
+    const card = buildMaintainerQueueHealthCard({
+      generatedAt: "2026-07-10T12:00:00.000Z",
+      stale: false,
+      histories: [[snapshot("2026-07-10T12:00:00.000Z", 5, 1, 2), snapshot("2026-07-08T12:00:00.000Z", 2)]],
+      highRiskDuplicates: 0,
+    });
+    expect(card).toMatchObject({ pending: 5, inFlight: 2, stuck: 1, dlq: 0, stale: false });
+    expect(card.queueDepthTrend).toEqual([2, 5]);
+  });
+
+  it("reports DLQ pressure from high-risk duplicate clusters", () => {
+    const card = buildMaintainerQueueHealthCard({
+      generatedAt: "2026-07-10T12:00:00.000Z",
+      stale: false,
+      histories: [[snapshot("2026-07-10T12:00:00.000Z", 3)]],
+      highRiskDuplicates: 2,
+    });
+    expect(card.dlq).toBe(2);
+    expect(card.summary).toContain("high-risk duplicate");
+  });
+
+  it("carries the stale flag through to the card payload", () => {
+    const card = buildMaintainerQueueHealthCard({
+      generatedAt: "2026-07-10T12:00:00.000Z",
+      stale: true,
+      histories: [],
+      highRiskDuplicates: 0,
+    });
+    expect(card.stale).toBe(true);
+    expect(card.pending).toBe(0);
+  });
+});
+
+describe("readQueueHealthSignals", () => {
+  it("returns null when the payload has no queue-health signals block", () => {
+    expect(readQueueHealthSignals({})).toBeNull();
+    expect(readQueueHealthSignals({ signals: [] })).toBeNull();
+  });
+
+  it("coerces missing or non-numeric signal fields to zero", () => {
+    expect(readQueueHealthSignals({ signals: { openPullRequests: "4" } })).toMatchObject({
+      openPullRequests: 0,
+      stalePullRequests: 0,
+      likelyReviewablePullRequests: 0,
+      collisionClusters: 0,
+    });
+  });
+});
+
+describe("buildMaintainerQueueHealthCard edge cases", () => {
+  it("skips histories with invalid payloads and caps the trend series", () => {
+    const histories = [
+      Array.from({ length: 16 }, (_, index) =>
+        snapshot(`2026-07-02T${String(index).padStart(2, "0")}:00:00.000Z`, index + 1),
+      ).reverse(),
+      [{ ...snapshot("2026-07-01T01:00:00.000Z", 99), payload: {} }],
+    ];
+    const card = buildMaintainerQueueHealthCard({
+      generatedAt: "2026-07-10T12:00:00.000Z",
+      stale: false,
+      histories,
+      highRiskDuplicates: 0,
+    });
+    expect(card.pending).toBe(16);
+    expect(card.queueDepthTrend.length).toBeLessThanOrEqual(14);
+  });
+
+  it("uses the non-clear summary when any queue pressure remains", () => {
+    const card = buildMaintainerQueueHealthCard({
+      generatedAt: "2026-07-10T12:00:00.000Z",
+      stale: false,
+      histories: [[snapshot("2026-07-10T12:00:00.000Z", 2, 1, 0)]],
+      highRiskDuplicates: 0,
+    });
+    expect(card.summary).toContain("open PR(s)");
+  });
+
+  it("skips trend rows when generatedAt is missing", () => {
+    const card = buildMaintainerQueueHealthCard({
+      generatedAt: "2026-07-10T12:00:00.000Z",
+      stale: false,
+      histories: [[{ ...snapshot("2026-07-10T12:00:00.000Z", 4), generatedAt: undefined }]],
+      highRiskDuplicates: 0,
+    });
+    expect(card.queueDepthTrend).toEqual([]);
+    expect(card.pending).toBe(4);
+  });
+});


### PR DESCRIPTION
Closes #2201

Supersedes #4714 (closed due to `validate-code` UI lint / prettier failures — fixed in this branch).

## Summary

- Add `buildMaintainerQueueHealthCard` to shape cached `queue-health` signal snapshots into pending/in-flight/stuck/DLQ counts plus a queue-depth trend series for the maintainer dashboard API.
- Add `QueueHealthCard` UI with `TrendChart`, `generatedAt` timestamp, and stale/healthy/warn/blocked `StatusPill` states; wire it into `MaintainerPanel`.
- Cover healthy, stuck>0, DLQ>0, stale-snapshot, empty-trend, and API integration branches with Vitest.

## Screenshots

| Page / Feature | Before | After |
|---|---|---|
| `/app/maintainer` | [<img src="https://github.com/kiannidev/gittensory/releases/download/pr-2201-screenshots-temp/before.png" width="260">](https://github.com/kiannidev/gittensory/releases/download/pr-2201-screenshots-temp/before.png)<br><sub>before: maintainer console without queue-health card</sub> | [<img src="https://github.com/kiannidev/gittensory/releases/download/pr-2201-screenshots-temp/after.png" width="260">](https://github.com/kiannidev/gittensory/releases/download/pr-2201-screenshots-temp/after.png)<br><sub>after: queue-health card with counts, trend, and status pill</sub> |

## Test plan

- [x] `npm --workspace @jsonbored/gittensory-ui run lint` (0 errors)
- [x] `npx vitest run test/unit/maintainer-queue-health-card.test.ts`
- [x] `npm --workspace @jsonbored/gittensory-ui run test -- src/components/site/app-panels/queue-health-card.test.tsx`
- [x] `npx vitest run test/integration/api.test.ts -t "counts cached open PRs across all in-scope repos"`
- [x] `npm --workspace @jsonbored/gittensory-ui run typecheck`


Made with [Cursor](https://cursor.com)