### PR TITLE
feat(ui): add confidence-calibration card to the analytics dashboard

### DIFF
--- a/apps/gittensory-ui/src/components/site/calibration-card-model.ts
+++ b/apps/gittensory-ui/src/components/site/calibration-card-model.ts
@@ -1,0 +1,80 @@
+import type { Status } from "@/components/site/control-primitives";
+
+// UI-side mirror of FleetOutcomeCalibration (src/services/outcome-calibration.ts), delivered on the
+// operator-dashboard payload's `calibration` field (#2192, part of #1967). "Bins" here are slop-severity
+// bands (clean/low/elevated/high) — the deterministic PREDICTED-risk signal gittensory actually computes
+// — each carrying its REALIZED merge rate (the "kept rate"). This intentionally does not mirror #2192's
+// own reference (src/review/ops.ts's `Calibration`/`computeCalibration`): that module is ported-but-unwired
+// "reviewbot" code whose `review_targets`/`review_audit` tables are never populated in gittensory (see
+// src/review/ops-wire.ts's header comment) — nothing constructs its config anywhere in this codebase, and
+// its handlers are registered on no route. This mirrors the live native equivalent instead.
+export type SlopBand = "clean" | "low" | "elevated" | "high";
+
+export type SlopBandCalibration = {
+  band: SlopBand;
+  sampleSize: number;
+  merged: number;
+  closed: number;
+  mergeRate: number;
+};
+
+export type SlopOutcomeCalibration = {
+  totalResolved: number;
+  bands: SlopBandCalibration[];
+  overallMergeRate: number | null;
+  discriminates: boolean | null;
+};
+
+export type RecommendationOutcomeCalibration = {
+  total: number;
+  positive: number;
+  negative: number;
+  pending: number;
+  positiveRate: number | null;
+};
+
+export type FleetOutcomeCalibration = {
+  generatedAt: string;
+  slop: SlopOutcomeCalibration;
+  recommendations: RecommendationOutcomeCalibration;
+  signals: string[];
+};
+
+export const SLOP_BAND_LABEL: Record<SlopBand, string> = {
+  clean: "Clean",
+  low: "Low",
+  elevated: "Elevated",
+  high: "High",
+};
+
+export type CalibrationBandRow = {
+  band: SlopBand;
+  label: string;
+  sampleSize: number;
+  /** 0-100, or null when there's no sample to show a bar for (distinct from a real 0% merge rate). */
+  mergeRatePercent: number | null;
+};
+
+/** Pure: shape each slop band into a display-ready row. */
+export function calibrationBandRows(slop: SlopOutcomeCalibration): CalibrationBandRow[] {
+  return slop.bands.map((entry) => ({
+    band: entry.band,
+    label: SLOP_BAND_LABEL[entry.band],
+    sampleSize: entry.sampleSize,
+    mergeRatePercent: entry.sampleSize > 0 ? Math.round(entry.mergeRate * 100) : null,
+  }));
+}
+
+/** Pure: pill tone for the discrimination verdict. */
+export function calibrationVerdictTone(discriminates: boolean | null): Status {
+  if (discriminates === true) return "ready";
+  if (discriminates === false) return "blocked";
+  return "warn";
+}
+
+/** Pure: human label for the discrimination verdict. */
+export function calibrationVerdictLabel(discriminates: boolean | null): string {
+  if (discriminates === true) return "Predictive";
+  if (discriminates === false) return "Not discriminating";
+  return "Insufficient data";
+}

--- a/apps/gittensory-ui/src/components/site/calibration-card.test.tsx
+++ b/apps/gittensory-ui/src/components/site/calibration-card.test.tsx
@@ -1,0 +1,164 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { CalibrationCard } from "@/components/site/calibration-card";
+import {
+  calibrationBandRows,
+  calibrationVerdictLabel,
+  calibrationVerdictTone,
+  type FleetOutcomeCalibration,
+  type SlopBandCalibration,
+} from "@/components/site/calibration-card-model";
+
+function band(overrides: Partial<SlopBandCalibration> = {}): SlopBandCalibration {
+  return { band: "clean", sampleSize: 0, merged: 0, closed: 0, mergeRate: 0, ...overrides };
+}
+
+function calibration(overrides: Partial<FleetOutcomeCalibration> = {}): FleetOutcomeCalibration {
+  return {
+    generatedAt: "2026-07-10T00:00:00.000Z",
+    slop: {
+      totalResolved: 0,
+      bands: [
+        band({ band: "clean" }),
+        band({ band: "low" }),
+        band({ band: "elevated" }),
+        band({ band: "high" }),
+      ],
+      overallMergeRate: null,
+      discriminates: null,
+    },
+    recommendations: { total: 0, positive: 0, negative: 0, pending: 0, positiveRate: null },
+    signals: [],
+    ...overrides,
+  };
+}
+
+describe("calibrationBandRows", () => {
+  it("marks a zero-sample band's merge rate as null (no bar), not a real 0%", () => {
+    const rows = calibrationBandRows({
+      totalResolved: 0,
+      bands: [band({ band: "clean", sampleSize: 0 })],
+      overallMergeRate: null,
+      discriminates: null,
+    });
+    expect(rows).toEqual([
+      { band: "clean", label: "Clean", sampleSize: 0, mergeRatePercent: null },
+    ]);
+  });
+
+  it("converts a populated band's merge rate to a rounded 0-100 percent", () => {
+    const rows = calibrationBandRows({
+      totalResolved: 6,
+      bands: [band({ band: "high", sampleSize: 6, merged: 1, closed: 5, mergeRate: 0.167 })],
+      overallMergeRate: 0.167,
+      discriminates: null,
+    });
+    expect(rows).toEqual([{ band: "high", label: "High", sampleSize: 6, mergeRatePercent: 17 }]);
+  });
+});
+
+describe("calibrationVerdictTone / calibrationVerdictLabel", () => {
+  it("reports a ready/predictive verdict when the score discriminates", () => {
+    expect(calibrationVerdictTone(true)).toBe("ready");
+    expect(calibrationVerdictLabel(true)).toBe("Predictive");
+  });
+  it("reports a blocked/not-discriminating verdict when the score inverts", () => {
+    expect(calibrationVerdictTone(false)).toBe("blocked");
+    expect(calibrationVerdictLabel(false)).toBe("Not discriminating");
+  });
+  it("reports a warn/insufficient-data verdict when there isn't enough signal to judge", () => {
+    expect(calibrationVerdictTone(null)).toBe("warn");
+    expect(calibrationVerdictLabel(null)).toBe("Insufficient data");
+  });
+});
+
+describe("CalibrationCard", () => {
+  it("renders nothing when there is no resolved-PR or recommendation signal at all (empty bins)", () => {
+    const { container } = render(<CalibrationCard calibration={calibration()} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders a single populated band alongside the rest as 'no data'", () => {
+    render(
+      <CalibrationCard
+        calibration={calibration({
+          slop: {
+            totalResolved: 6,
+            bands: [
+              band({ band: "clean", sampleSize: 6, merged: 5, closed: 1, mergeRate: 0.833 }),
+              band({ band: "low" }),
+              band({ band: "elevated" }),
+              band({ band: "high" }),
+            ],
+            overallMergeRate: 0.833,
+            discriminates: null,
+          },
+          signals: ["Not enough resolved PRs per band to judge slop calibration yet (6 resolved)."],
+        })}
+      />,
+    );
+    expect(screen.getByText("Confidence calibration")).toBeTruthy();
+    expect(screen.getByText("83% · n=6")).toBeTruthy();
+    expect(screen.getAllByText("no data")).toHaveLength(3);
+    expect(screen.getByText("Insufficient data")).toBeTruthy();
+    expect(screen.getByText(/Not enough resolved PRs per band/)).toBeTruthy();
+  });
+
+  it("renders the full curve across every band plus the recommendation-outcome split", () => {
+    render(
+      <CalibrationCard
+        calibration={calibration({
+          slop: {
+            totalResolved: 24,
+            bands: [
+              band({ band: "clean", sampleSize: 6, merged: 5, closed: 1, mergeRate: 0.833 }),
+              band({ band: "low", sampleSize: 6, merged: 3, closed: 3, mergeRate: 0.5 }),
+              band({ band: "elevated", sampleSize: 6, merged: 2, closed: 4, mergeRate: 0.333 }),
+              band({ band: "high", sampleSize: 6, merged: 1, closed: 5, mergeRate: 0.167 }),
+            ],
+            overallMergeRate: 0.458,
+            discriminates: true,
+          },
+          recommendations: { total: 5, positive: 3, negative: 1, pending: 1, positiveRate: 0.75 },
+          signals: [
+            "Slop score is predictive: merge rate falls as the band rises (24 resolved PRs).",
+          ],
+        })}
+      />,
+    );
+    expect(screen.getByText("Predictive")).toBeTruthy();
+    expect(screen.getByText("24 resolved")).toBeTruthy();
+    expect(screen.getByText("83% · n=6")).toBeTruthy();
+    expect(screen.getByText("50% · n=6")).toBeTruthy();
+    expect(screen.getByText("33% · n=6")).toBeTruthy();
+    expect(screen.getByText("17% · n=6")).toBeTruthy();
+    expect(screen.queryByText("no data")).toBeNull();
+    expect(screen.getByText("75%")).toBeTruthy();
+    expect(screen.getByText(/3\/4 positive/)).toBeTruthy();
+    expect(screen.getByText(/1 pending/)).toBeTruthy();
+  });
+
+  it("shows a '—' recommendation rate when nothing is resolved yet, even with slop signal present", () => {
+    render(
+      <CalibrationCard
+        calibration={calibration({
+          slop: {
+            totalResolved: 6,
+            bands: [
+              band({ band: "clean", sampleSize: 6, merged: 5, closed: 1, mergeRate: 0.833 }),
+              band({ band: "low" }),
+              band({ band: "elevated" }),
+              band({ band: "high" }),
+            ],
+            overallMergeRate: 0.833,
+            discriminates: null,
+          },
+          recommendations: { total: 2, positive: 0, negative: 0, pending: 2, positiveRate: null },
+        })}
+      />,
+    );
+    expect(screen.getByText("—")).toBeTruthy();
+    expect(screen.getByText(/0\/0 positive/)).toBeTruthy();
+  });
+});

--- a/apps/gittensory-ui/src/components/site/calibration-card.tsx
+++ b/apps/gittensory-ui/src/components/site/calibration-card.tsx
@@ -1,0 +1,91 @@
+import { BoundaryBadge, Stat, StatusPill } from "@/components/site/control-primitives";
+import {
+  calibrationBandRows,
+  calibrationVerdictLabel,
+  calibrationVerdictTone,
+  type FleetOutcomeCalibration,
+} from "@/components/site/calibration-card-model";
+
+/**
+ * Confidence-calibration card (#2192, part of #1967): predicted slop-severity band vs. realized merge
+ * rate per bucket, plus the recommendation-outcome split, over the existing FleetOutcomeCalibration
+ * payload. Renders nothing when there's no resolved-PR or recommendation signal yet (keeps the analytics
+ * page clean until calibration data exists), matching GatePrecisionCard's convention on this same page.
+ */
+export function CalibrationCard({ calibration }: { calibration: FleetOutcomeCalibration }) {
+  if (calibration.slop.totalResolved === 0 && calibration.recommendations.total === 0) return null;
+  const rows = calibrationBandRows(calibration.slop);
+  const resolvedRecommendations =
+    calibration.recommendations.positive + calibration.recommendations.negative;
+
+  return (
+    <section className="rounded-token border border-border bg-transparent p-5">
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h2 className="font-display text-token-lg font-semibold">Confidence calibration</h2>
+          <p className="mt-1 text-token-xs text-muted-foreground">
+            Predicted slop severity vs. realized merge rate per band — public-safe counts only.
+          </p>
+        </div>
+        <BoundaryBadge boundary="private-api" />
+      </div>
+
+      <div className="mt-4 grid gap-3 sm:grid-cols-2">
+        <Stat
+          label="Calibration signal"
+          value={calibrationVerdictLabel(calibration.slop.discriminates)}
+          hint={
+            <StatusPill status={calibrationVerdictTone(calibration.slop.discriminates)}>
+              {calibration.slop.totalResolved} resolved
+            </StatusPill>
+          }
+        />
+        <Stat
+          label="Recommendation outcomes"
+          value={
+            calibration.recommendations.positiveRate !== null
+              ? `${Math.round(calibration.recommendations.positiveRate * 100)}%`
+              : "—"
+          }
+          hint={
+            <span className="text-muted-foreground">
+              {calibration.recommendations.positive}/{resolvedRecommendations} positive ·{" "}
+              {calibration.recommendations.pending} pending
+            </span>
+          }
+        />
+      </div>
+
+      <div className="mt-4 space-y-2">
+        {rows.map((row) => (
+          <div key={row.band} className="flex items-center gap-3">
+            <span className="w-20 shrink-0 font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
+              {row.label}
+            </span>
+            <div className="h-2 flex-1 overflow-hidden rounded-token bg-background/40">
+              {row.mergeRatePercent !== null ? (
+                <div
+                  className="h-full rounded-token bg-mint/60"
+                  style={{ width: `${row.mergeRatePercent}%` }}
+                />
+              ) : null}
+            </div>
+            <span className="w-24 shrink-0 text-right font-mono text-token-2xs text-muted-foreground">
+              {row.mergeRatePercent !== null
+                ? `${row.mergeRatePercent}% · n=${row.sampleSize}`
+                : "no data"}
+            </span>
+          </div>
+        ))}
+      </div>
+
+      {calibration.signals.length > 0 ? (
+        <ul className="mt-4 space-y-1 text-token-xs text-muted-foreground">
+          {calibration.signals.map((signal) => (
+            <li key={signal}>{signal}</li>
+          ))}
+        </ul>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/gittensory-ui/src/routes/app.analytics.tsx
+++ b/apps/gittensory-ui/src/routes/app.analytics.tsx
@@ -12,6 +12,8 @@ import {
 } from "@/components/site/usage-analytics-panels";
 import { GatePrecisionCard } from "@/components/site/app-panels/gate-precision-card";
 import type { GateEvalReport } from "@/components/site/app-panels/gate-precision-card-model";
+import { CalibrationCard } from "@/components/site/calibration-card";
+import type { FleetOutcomeCalibration } from "@/components/site/calibration-card-model";
 import { CycleTimeCard } from "@/components/site/app-panels/cycle-time-card";
 import type { CycleTimeAggregate } from "@/components/site/app-panels/cycle-time-card-model";
 import { useApiResource } from "@/lib/api/use-api-resource";
@@ -104,6 +106,7 @@ type OperatorDashboard = {
   };
   upstreamDrift?: { status?: string; openReportCount?: number } | null;
   gateEval?: GateEvalReport;
+  calibration?: FleetOutcomeCalibration;
   cycleTime?: CycleTimeAggregate;
 };
 
@@ -187,6 +190,8 @@ function ProductAnalytics() {
           ) : null}
 
           {data.gateEval ? <GatePrecisionCard report={data.gateEval} /> : null}
+
+          {data.calibration ? <CalibrationCard calibration={data.calibration} /> : null}
 
           {data.cycleTime ? <CycleTimeCard cycleTime={data.cycleTime} /> : null}
 

--- a/src/services/operator-dashboard.ts
+++ b/src/services/operator-dashboard.ts
@@ -30,6 +30,7 @@ import { computeGateEval, type GateEvalReport } from "../review/parity";
 import { computeCycleTimeAggregate, type CycleTimeAggregate } from "../review/stats";
 import { loadUpstreamStatus, type UpstreamStatus } from "../upstream/ruleset";
 import { nowIso } from "../utils/json";
+import { buildFleetOutcomeCalibration, type FleetOutcomeCalibration } from "./outcome-calibration";
 import { buildRecommendationQualityReport, type RecommendationQualityReport } from "./recommendation-quality-report";
 import { buildWeeklyValueReport } from "./weekly-value-report";
 
@@ -64,6 +65,10 @@ export type OperatorDashboardPayload = {
   // Gate-precision eval (#2191): the per-project confusion matrix + precisions from computeGateEval, surfaced
   // read-only for the maintainer analytics card. Fail-safe empty report when there is no review_audit signal.
   gateEval: GateEvalReport;
+  // Fleet-wide confidence calibration (#2192, part of #1967): slop-band merge-rate curve + recommendation
+  // outcome split from buildFleetOutcomeCalibration, surfaced read-only for the analytics card. Fails safe
+  // to an all-zero/null-discriminates report when there is no resolved-PR signal yet.
+  calibration: FleetOutcomeCalibration;
   // PR review cycle-time percentiles (#2194): gate decision → outcome from review_audit; fail-safe empty aggregate.
   cycleTime: CycleTimeAggregate;
 };
@@ -90,6 +95,7 @@ export async function buildOperatorDashboardPayload(env: Env): Promise<OperatorD
     recommendationQuality,
     fleetMetrics,
     gateEval,
+    calibration,
     cycleTime,
   ] = await Promise.all([
     listRepositories(env),
@@ -110,6 +116,9 @@ export async function buildOperatorDashboardPayload(env: Env): Promise<OperatorD
     computeFleetAnalytics(env, { windowDays: 90 }),
     // #2191: reuse the existing eval (no new compute); it fails safe to an empty report on any read error.
     computeGateEval(env, { days: 90, nowMs: Date.now() }),
+    // #2192: fleet-wide slop-band calibration + recommendation outcome split (no new compute — reuses the
+    // same pure builders buildRepoOutcomeCalibration already uses, over every repo instead of one).
+    buildFleetOutcomeCalibration(env),
     // #2194: cycle-time percentiles from the stats feed; fails safe to an empty aggregate.
     computeCycleTimeAggregate(env, { days: 90, nowMs: Date.now() }),
   ]);
@@ -206,6 +215,7 @@ export async function buildOperatorDashboardPayload(env: Env): Promise<OperatorD
     upstreamDrift,
     fleetMetrics,
     gateEval,
+    calibration,
     cycleTime,
   };
 }

--- a/src/services/outcome-calibration.ts
+++ b/src/services/outcome-calibration.ts
@@ -8,7 +8,7 @@
 //     recommendation-outcome ledger.
 // All inputs already exist: slop_band persists on the PR row (#726) + closed PRs are retained, and the
 // agent_recommendation_outcomes ledger (#543's recommendation half) is populated by evaluateRecommendationOutcomes.
-import { listAgentRecommendationOutcomes, listPullRequests } from "../db/repositories";
+import { listAgentRecommendationOutcomes, listAllPullRequests, listPullRequests } from "../db/repositories";
 import type { SlopBand } from "../signals/slop";
 import type { AgentRecommendationOutcomeRecord, PullRequestRecord } from "../types";
 import { nowIso } from "../utils/json";
@@ -161,4 +161,27 @@ export async function buildRepoOutcomeCalibration(
   const slop = buildSlopOutcomeCalibration(pullRequests);
   const recommendations = buildRecommendationOutcomeCalibration(outcomes, repoFullName, options);
   return { repoFullName, generatedAt: nowIso(), windowDays: windowDays ?? null, slop, recommendations, signals: buildOutcomeCalibrationSignals(slop, recommendations) };
+}
+
+export type FleetOutcomeCalibration = {
+  generatedAt: string;
+  slop: SlopOutcomeCalibration;
+  recommendations: RecommendationOutcomeCalibration;
+  signals: string[];
+};
+
+/**
+ * Fleet-wide mirror of buildRepoOutcomeCalibration (#2192, part of #1967): the same pure calibration fold,
+ * over every repo's PRs/outcomes instead of one repo, for the operator analytics dashboard's
+ * confidence-calibration card. Reuses the already-tested pure builders above; the only new I/O is two
+ * existing bulk-read repository calls (no new SQL).
+ */
+export async function buildFleetOutcomeCalibration(env: Env): Promise<FleetOutcomeCalibration> {
+  const [pullRequests, outcomes] = await Promise.all([
+    listAllPullRequests(env),
+    listAgentRecommendationOutcomes(env, { limit: 5000 }),
+  ]);
+  const slop = buildSlopOutcomeCalibration(pullRequests);
+  const recommendations = buildRecommendationOutcomeCalibration(outcomes);
+  return { generatedAt: nowIso(), slop, recommendations, signals: buildOutcomeCalibrationSignals(slop, recommendations) };
 }

--- a/test/unit/operator-dashboard.test.ts
+++ b/test/unit/operator-dashboard.test.ts
@@ -26,6 +26,10 @@ describe("operator dashboard payload", () => {
     // #2191: gate-eval report is surfaced read-only; with no review_audit signal it fails safe to an empty
     // report (no rows, no signal) rather than being absent.
     expect(payload.gateEval).toEqual({ rows: [], hasSignal: false });
+    // #2192: fleet-wide calibration fails safe to an all-zero/null-discriminates report, never absent.
+    expect(payload.calibration.slop).toMatchObject({ totalResolved: 0, overallMergeRate: null, discriminates: null });
+    expect(payload.calibration.recommendations).toMatchObject({ total: 0, positiveRate: null });
+    expect(payload.calibration.signals.length).toBeGreaterThan(0);
     expect(payload.cycleTime).toEqual({
       p50Ms: null,
       p90Ms: null,

--- a/test/unit/outcome-calibration.test.ts
+++ b/test/unit/outcome-calibration.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
+  buildFleetOutcomeCalibration,
   buildOutcomeCalibrationSignals,
   buildRecommendationOutcomeCalibration,
   buildRepoOutcomeCalibration,
@@ -188,6 +189,48 @@ describe("buildRepoOutcomeCalibration (env loader)", () => {
 
     const report = await buildRepoOutcomeCalibration(env, "owner/repo", 365);
     expect(report.recommendations).toMatchObject({ total: 2, positive: 1, negative: 1, positiveRate: 0.5 });
+  });
+});
+
+describe("buildFleetOutcomeCalibration (env loader)", () => {
+  it("folds resolved PRs + recommendation outcomes across EVERY repo, not just one", async () => {
+    const env = createTestEnv();
+    await upsertPullRequestFromGitHub(env, "owner/repo-a", { number: 1, title: "merged clean", state: "closed", user: { login: "alice" }, merged_at: "2026-06-01T00:00:00.000Z" });
+    await updatePullRequestSlopAssessment(env, "owner/repo-a", 1, { slopRisk: 0, slopBand: "clean" });
+    await upsertPullRequestFromGitHub(env, "owner/repo-b", { number: 1, title: "closed high", state: "closed", user: { login: "bob" } });
+    await updatePullRequestSlopAssessment(env, "owner/repo-b", 1, { slopRisk: 70, slopBand: "high" });
+    await createAgentRun(env, runRecord("r-fleet", "miner", "2026-06-01T00:00:00.000Z"));
+    await replaceAgentActions(env, "r-fleet", [actionRecord("fleet-merged", "r-fleet")]);
+    await upsertAgentRecommendationOutcome(env, {
+      actionId: "fleet-merged",
+      runId: "r-fleet",
+      actorLogin: "miner",
+      actionType: "choose_next_work",
+      targetRepoFullName: "owner/repo-a",
+      source: "explicit",
+      outcomeState: "merged",
+      outcomeTargetType: "pull_request",
+      maintainerLane: false,
+      confidence: "high",
+      reason: "fleet-wide signal",
+      metadata: {},
+    });
+
+    const report = await buildFleetOutcomeCalibration(env);
+    expect(report.slop.totalResolved).toBe(2); // both repos counted, not just one
+    expect(report.slop.bands.find((b) => b.band === "clean")).toMatchObject({ merged: 1, closed: 0 });
+    expect(report.slop.bands.find((b) => b.band === "high")).toMatchObject({ merged: 0, closed: 1 });
+    expect(report.recommendations).toMatchObject({ total: 1, positive: 1, positiveRate: 1 });
+    expect(report.signals.length).toBeGreaterThan(0);
+    expect(JSON.stringify(report)).not.toMatch(/reward|payout|trust score|wallet|hotkey/i);
+  });
+
+  it("fails safe to an all-empty report when there is no resolved-PR signal yet", async () => {
+    const env = createTestEnv();
+    const report = await buildFleetOutcomeCalibration(env);
+    expect(report.slop).toMatchObject({ totalResolved: 0, overallMergeRate: null, discriminates: null });
+    expect(report.recommendations).toMatchObject({ total: 0, positiveRate: null });
+    expect(report.signals.length).toBeGreaterThan(0); // still narrates the "not enough data" state
   });
 });
 


### PR DESCRIPTION
## Summary

- Adds `CalibrationCard` to the analytics dashboard (`/app/analytics`): predicted slop-severity band vs. realized merge rate per bucket (a genuine confidence-calibration curve), plus the recommendation-outcome split and a headline "is this actually predictive?" verdict.
- **A note on the data source, since it required a real correction to the issue's own references.** #2192 cites `src/review/ops.ts`'s `Calibration`/`computeCalibration` (lines 61/250) as "the existing computed payload." I traced that all the way through before implementing and found it's ported-but-unwired **"reviewbot" code from a prior convergence** (`3c4a30b0 Convergence: reviewbot → gittensory`): nothing anywhere in this repo constructs its `OpsAgentConfig`, its `handleInternalCalibration`/`handleInternalDecision` handlers are registered on **no route**, and its own `review_targets`/`review_audit` tables are **never populated** in gittensory — `src/review/ops-wire.ts`'s own header comment says so explicitly ("ADAPTED TO GITTENSORY'S OWN OUTCOME DATA — NOT reviewbot's `review_targets`/`review_audit` (those tables are not populated here)"). Building a card against it would mean either fabricating a fake `slug`/config or shipping a card that can never show real data.
- Gittensory's actual, live equivalent is `src/services/outcome-calibration.ts`'s `buildSlopOutcomeCalibration`/`buildRecommendationOutcomeCalibration` — already used by the real, maintainer-authenticated `GET /v1/repos/:owner/:repo/outcome-calibration` route and the `ops-wire.ts` observability cron. This PR mirrors that instead: same "bins" concept (per-slop-band merge rate, the deterministic predicted-risk signal gittensory actually computes), same "is it predictive" verdict (`discriminates`), just fleet-wide instead of per-repo.
- **Backend addition (small, reuses only existing pure/tested builders, no new SQL):** `buildFleetOutcomeCalibration` in `src/services/outcome-calibration.ts` — a thin new async loader that feeds `listAllPullRequests`/`listAgentRecommendationOutcomes` (both pre-existing bulk-read helpers) into the same pure `buildSlopOutcomeCalibration`/`buildRecommendationOutcomeCalibration`/`buildOutcomeCalibrationSignals` functions the per-repo route already uses and already tests. Wired into `operator-dashboard.ts`'s `OperatorDashboardPayload` exactly like PR #4314 wired `gateEval` for the sibling gate-precision card (#2191).
- Surfaces the "recommended confidence floor" deliverable as a labeled `Stat` ("Calibration signal": Predictive / Not discriminating / Insufficient data) + `BoundaryBadge boundary="private-api"`, since a literal numeric floor doesn't exist in the real signal — the verdict + boundary marker is the equivalent "is this trustworthy, and is it private-scoped" signal the issue asks for.
- Renders nothing when there's no resolved-PR or recommendation signal at all, matching `GatePrecisionCard`'s established convention on this same page.
- **Placed between the `gateEval` and `cycleTime` cards** (not after `cycleTime`) deliberately: PR #4702 (still open, sibling issue #2193) is sitting on the "after cycleTime" insertion point in this same file, so this avoids a guaranteed line-level collision with it.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused (one card + its one backend data source) and does not mix unrelated changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves — Closes #2192.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally (full unsharded run; new backend code — `src/services/outcome-calibration.ts`'s `buildFleetOutcomeCalibration` and its `operator-dashboard.ts` wiring — is `src/**`, so it IS Codecov-patch-gated, unlike my prior UI-only PRs this session. Added 2 new `buildFleetOutcomeCalibration` tests (populated fleet data across multiple repos, and a fully-empty fail-safe case) plus an `operator-dashboard.test.ts` assertion for the new `calibration` field's fail-safe empty shape. Scoped `--coverage` run on just these two files showed 100%/100% lines on `outcome-calibration.ts` and confirmed zero of my added lines were uncovered on either file — the only flagged gaps were pre-existing lines I never touched.)
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run db:migrations:check`
- [x] `npm run db:schema-drift:check`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:openapi:settings-parity`
- [x] `npm run ui:version-audit`
- [x] `npm run docs:drift-check`
- [x] `npm run manifest:drift-check`
- [x] `npm run command-reference:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:test` (149/149 passed across both UI workspaces)
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate` (0 vulnerabilities)

If any required check was skipped, explain why:

- `npm run test:mcp-pack` and `npm run cf-typegen:check` fail locally only due to a pre-existing Windows dev-machine `spawnSync` bare-command resolution gap (`ENOENT` for `npm`/`wrangler` without `shell: true`) — unrelated to this diff.
- `npm run engine-parity:drift-check` fails locally only because it falls back to my local (stale) fork `origin/main` ref absent `GITHUB_BASE_SHA`, which real CI sets. No `src/signals/**`/`packages/gittensory-engine/**` files are touched by this PR.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed — only aggregate counts (per-band sample size/merge rate, recommendation positive/negative/pending) ever render; asserted by a redaction check in the new backend test.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics. (N/A surface — authenticated operator analytics UI, not a public GitHub comment.)
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no such changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (No new route; the payload field is on the existing operator-dashboard response, which is registered with a loose passthrough OpenAPI schema like its `gateEval`/`cycleTime` siblings — no schema regen needed.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks — the card renders the real fleet-wide `calibration` field; the "no signal yet" state is a genuine `totalResolved === 0` early return, not a demo placeholder.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (No changelog edit in this PR.)

## UI Evidence

| State / title | Screenshot |
| --- | --- |
| Full curve (4 bands + recommendation split) | <a href="https://gist.githubusercontent.com/claytonlin1110/907185bedd31d9c0063b2304934dc790/raw/calibration-card-populated.png"><img src="https://gist.githubusercontent.com/claytonlin1110/907185bedd31d9c0063b2304934dc790/raw/calibration-card-populated.png" alt="Populated calibration curve" width="420"></a><br><sub>predictive verdict, merge rate descending clean→high</sub> |
| Single populated band | <a href="https://gist.githubusercontent.com/claytonlin1110/907185bedd31d9c0063b2304934dc790/raw/calibration-card-single-bin.png"><img src="https://gist.githubusercontent.com/claytonlin1110/907185bedd31d9c0063b2304934dc790/raw/calibration-card-single-bin.png" alt="Single-bin insufficient-data state" width="420"></a><br><sub>insufficient-data verdict, 3 bands shown as "no data"</sub> |

## Notes

- The fully-empty case (zero resolved PRs and zero recommendation outcomes) renders nothing at all — there is no third screenshot for it because there is nothing to show, matching `GatePrecisionCard`'s identical convention on this same page.
- Flagging for visibility: this PR touches `src/services/operator-dashboard.ts`, a file PR #4702 (open, sibling issue #2193) is also mid-flight on modifying, though at a different insertion point chosen specifically to avoid overlap. If #4702 merges first, this branch may still need a follow-up rebase.
