### PR TITLE
feat(ui): add finding acceptance-rate card to the analytics dashboard (#2197)

### DIFF
--- a/apps/gittensory-ui/src/components/site/app-panels/acceptance-rate-card.test.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/acceptance-rate-card.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { AcceptanceRateCard } from "@/components/site/app-panels/acceptance-rate-card";
+
+describe("AcceptanceRateCard", () => {
+  it("renders the rounded rate, plural counts, healthy band, and window label when data is present", () => {
+    render(
+      <AcceptanceRateCard acceptance={{ windowDays: 30, accepted: 9, total: 12, rate: 0.75 }} />,
+    );
+    expect(screen.getByText("75%")).toBeTruthy();
+    expect(screen.getByText(/9 of 12 inline findings acted on/)).toBeTruthy();
+    expect(screen.getByText("healthy")).toBeTruthy();
+    expect(screen.getByText("30d window")).toBeTruthy();
+  });
+
+  it("uses the singular 'finding' wording when exactly one finding is in the window", () => {
+    render(<AcceptanceRateCard acceptance={{ windowDays: 14, accepted: 1, total: 1, rate: 1 }} />);
+    expect(screen.getByText("100%")).toBeTruthy();
+    expect(screen.getByText(/1 of 1 inline finding acted on/)).toBeTruthy();
+  });
+
+  it("bands a mid-range rate as 'mixed'", () => {
+    render(<AcceptanceRateCard acceptance={{ windowDays: 7, accepted: 2, total: 5, rate: 0.4 }} />);
+    expect(screen.getByText("40%")).toBeTruthy();
+    expect(screen.getByText("mixed")).toBeTruthy();
+  });
+
+  it("bands a low rate as 'low'", () => {
+    render(
+      <AcceptanceRateCard acceptance={{ windowDays: 7, accepted: 1, total: 10, rate: 0.1 }} />,
+    );
+    expect(screen.getByText("10%")).toBeTruthy();
+    expect(screen.getByText("low")).toBeTruthy();
+  });
+
+  it("shows an em-dash and 'no findings' band when the window is empty (rate null)", () => {
+    render(
+      <AcceptanceRateCard acceptance={{ windowDays: 7, accepted: 0, total: 0, rate: null }} />,
+    );
+    expect(screen.getByText("—")).toBeTruthy();
+    expect(screen.getByText(/0 of 0 inline findings acted on/)).toBeTruthy();
+    expect(screen.getByText("no findings")).toBeTruthy();
+  });
+
+  it("renders the 'not yet available' empty state when the acceptance field is absent", () => {
+    render(<AcceptanceRateCard />);
+    expect(screen.getByText("Not yet available")).toBeTruthy();
+    expect(screen.queryByText("Acceptance rate")).toBeNull();
+  });
+});

--- a/apps/gittensory-ui/src/components/site/app-panels/acceptance-rate-card.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/acceptance-rate-card.tsx
@@ -1,0 +1,70 @@
+import { AnalyticsCardShell } from "@/components/site/app-panels/analytics-card-shell";
+import { Stat, StatusPill, type Status } from "@/components/site/control-primitives";
+
+/** Finding acceptance-rate slice (#2197): the share of inline AI-review findings the contributor acted on
+ *  (a finding was posted inline → the PR then merged). Display-only — the backend acceptance computation is
+ *  tracked separately in #1967, so this card assumes the shape may be absent from the dashboard payload today
+ *  and degrades to a "not yet available" empty state until it lands, rather than assuming a value. */
+export type FindingAcceptance = {
+  windowDays: number;
+  accepted: number;
+  total: number;
+  /** accepted / total, already computed server-side; null when total === 0 so the card never divides by zero. */
+  rate: number | null;
+};
+
+/** Quality band for the rate — higher acceptance = healthier signal; null (no findings) reads as neutral. */
+function acceptanceStatus(rate: number | null): Status {
+  if (rate === null) return "info";
+  if (rate >= 0.6) return "ready";
+  if (rate >= 0.3) return "warn";
+  return "degraded";
+}
+
+function acceptanceBandLabel(rate: number | null): string {
+  if (rate === null) return "no findings";
+  if (rate >= 0.6) return "healthy";
+  if (rate >= 0.3) return "mixed";
+  return "low";
+}
+
+export function AcceptanceRateCard({ acceptance }: { acceptance?: FindingAcceptance }) {
+  if (!acceptance) {
+    return (
+      <AnalyticsCardShell
+        title="Finding acceptance rate"
+        description="Inline findings the contributor acted on (posted inline → PR merged)."
+        state="empty"
+        emptyTitle="Not yet available"
+        emptyHint="Acceptance tracking appears once inline findings are posted and their PRs resolve in the analytics window."
+      />
+    );
+  }
+
+  const { windowDays, accepted, total, rate } = acceptance;
+  const value = rate === null ? "—" : `${Math.round(rate * 100)}%`;
+
+  return (
+    <AnalyticsCardShell
+      title="Finding acceptance rate"
+      description="Inline findings the contributor acted on (posted inline → PR merged)."
+      state="ready"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <Stat
+          label="Acceptance rate"
+          value={value}
+          hint={
+            <span className="text-muted-foreground">
+              {accepted} of {total} inline finding{total === 1 ? "" : "s"} acted on
+            </span>
+          }
+        />
+        <div className="flex items-center gap-2">
+          <StatusPill status={acceptanceStatus(rate)}>{acceptanceBandLabel(rate)}</StatusPill>
+          <StatusPill status="info">{windowDays}d window</StatusPill>
+        </div>
+      </div>
+    </AnalyticsCardShell>
+  );
+}

--- a/apps/gittensory-ui/src/routes/app.analytics.tsx
+++ b/apps/gittensory-ui/src/routes/app.analytics.tsx
@@ -16,6 +16,10 @@ import type { GateEvalReport } from "@/components/site/app-panels/gate-precision
 import { CycleTimeCard } from "@/components/site/app-panels/cycle-time-card";
 import type { CycleTimeAggregate } from "@/components/site/app-panels/cycle-time-card-model";
 import { AnalyticsCardShell } from "@/components/site/app-panels/analytics-card-shell";
+import {
+  AcceptanceRateCard,
+  type FindingAcceptance,
+} from "@/components/site/app-panels/acceptance-rate-card";
 import { useApiResource } from "@/lib/api/use-api-resource";
 import { exportOperatorDashboardCsv } from "@/lib/csv-export";
 
@@ -108,6 +112,7 @@ type OperatorDashboard = {
   upstreamDrift?: { status?: string; openReportCount?: number } | null;
   gateEval?: GateEvalReport;
   cycleTime?: CycleTimeAggregate;
+  acceptance?: FindingAcceptance;
 };
 
 function ProductAnalytics() {
@@ -208,6 +213,8 @@ function ProductAnalytics() {
               emptyHint="Percentiles appear once the gate has resolved paired PRs in the analytics window."
             />
           )}
+
+          <AcceptanceRateCard acceptance={data.acceptance} />
 
           {data.usageSummary ? (
             <ProductUsageBreakdownPanel


### PR DESCRIPTION
## What

Adds the **finding acceptance-rate** card to the operator analytics dashboard (Closes #2197): the share of inline AI-review findings the contributor acted on (a finding was posted inline → the PR then merged), banded `healthy` / `mixed` / `low` with a window-days label.

Per the bounty, this is the **display slice only** — the backend acceptance computation is tracked separately in #1967. The card reads an optional `acceptance` shape off the operator-dashboard payload and **degrades to a "not yet available" empty state** while that field is absent, so it ships safely ahead of the backend and lights up automatically once the data lands. No `src/**` change.

## Changes

- **`acceptance-rate-card.tsx`** (new) — `AcceptanceRateCard` + `FindingAcceptance` type. Reuses the shared `AnalyticsCardShell` (#2200) for the card/empty treatment and `Stat` / `StatusPill` primitives. Rate is rounded, guards `total === 0` (`rate: null` → `—`, no divide-by-zero), and singular/plural counts are handled.
- **`acceptance-rate-card.test.tsx`** (new) — 6 tests: populated (healthy), singular wording, `mixed` band, `low` band, empty-window (`rate null`), and absent-field empty state — covering both arms of every guard.
- **`app.analytics.tsx`** — optional `acceptance?: FindingAcceptance` on the dashboard type + renders `<AcceptanceRateCard acceptance={data.acceptance} />` after the cycle-time card.

## Verification

`ui:typecheck` ✓ · `ui:test` (6/6) ✓ · `ui:build` ✓ · eslint 0 errors · prettier clean.

## Screenshots

Net-new card — no acceptance-rate card existed on `/app/analytics` before. After state shown in both the live **empty** (field absent today) and **populated** (once #1967 lands) forms, across desktop + mobile, light + dark.

| State | Desktop (light) | Desktop (dark) | Mobile |
|---|---|---|---|
| **After — empty (live today)** | [<img src="https://raw.githubusercontent.com/dhgoal/gittensory/ui-evidence-2197/shot-empty-light-desktop.png" width="260">](https://raw.githubusercontent.com/dhgoal/gittensory/ui-evidence-2197/shot-empty-light-desktop.png)<br><sub>empty · light</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/gittensory/ui-evidence-2197/shot-empty-dark-desktop.png" width="260">](https://raw.githubusercontent.com/dhgoal/gittensory/ui-evidence-2197/shot-empty-dark-desktop.png)<br><sub>empty · dark</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/gittensory/ui-evidence-2197/shot-empty-dark-mobile.png" width="150">](https://raw.githubusercontent.com/dhgoal/gittensory/ui-evidence-2197/shot-empty-dark-mobile.png)<br><sub>empty · mobile</sub> |
| **After — populated (#1967 data)** | [<img src="https://raw.githubusercontent.com/dhgoal/gittensory/ui-evidence-2197/shot-ready-light-desktop.png" width="260">](https://raw.githubusercontent.com/dhgoal/gittensory/ui-evidence-2197/shot-ready-light-desktop.png)<br><sub>ready · light</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/gittensory/ui-evidence-2197/shot-ready-dark-desktop.png" width="260">](https://raw.githubusercontent.com/dhgoal/gittensory/ui-evidence-2197/shot-ready-dark-desktop.png)<br><sub>ready · dark</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/gittensory/ui-evidence-2197/shot-ready-dark-mobile.png" width="150">](https://raw.githubusercontent.com/dhgoal/gittensory/ui-evidence-2197/shot-ready-dark-mobile.png)<br><sub>ready · mobile</sub> |

Closes #2197
