### PR TITLE
feat(ui): config-generator REES analyzer selection field group

### DIFF
--- a/apps/gittensory-ui/src/components/site/app-panels/config-generator-panel.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/config-generator-panel.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 
 import { AiProviderModeFieldGroup } from "@/components/site/app-panels/ai-provider-mode-field-group";
+import { ReesAnalyzerFieldGroup } from "@/components/site/app-panels/rees-analyzer-field-group";
 import type { GeneratorFormState } from "@/lib/config-generator-form-state";
 
 const INITIAL_STATE: GeneratorFormState = {};
@@ -11,6 +12,7 @@ export function ConfigGeneratorPanel() {
   return (
     <div className="space-y-6">
       <AiProviderModeFieldGroup state={formState} onChange={setFormState} />
+      <ReesAnalyzerFieldGroup state={formState} onChange={setFormState} />
     </div>
   );
 }

--- a/apps/gittensory-ui/src/components/site/app-panels/rees-analyzer-field-group.test.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/rees-analyzer-field-group.test.tsx
@@ -1,0 +1,123 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useState } from "react";
+import { describe, expect, it } from "vitest";
+
+import { ReesAnalyzerFieldGroup } from "@/components/site/app-panels/rees-analyzer-field-group";
+import type { GeneratorFormState } from "@/lib/config-generator-form-state";
+import {
+  effectiveReesAnalyzerEnabled,
+  patchGeneratorReesAnalyzer,
+  reesAnalyzersManifestPatch,
+  resetGeneratorReesAnalyzers,
+} from "@/lib/config-generator-form-state";
+import { REES_ANALYZERS, REES_DEFAULT_PROFILE } from "@/lib/rees-analyzers";
+
+const defaultOn = REES_ANALYZERS.find((analyzer) =>
+  analyzer.profiles.includes(REES_DEFAULT_PROFILE),
+)!;
+const defaultOff = REES_ANALYZERS.find(
+  (analyzer) => !analyzer.profiles.includes(REES_DEFAULT_PROFILE),
+);
+
+function Harness({ onState }: { onState: (state: GeneratorFormState) => void }) {
+  const [state, setState] = useState<GeneratorFormState>({});
+  return (
+    <ReesAnalyzerFieldGroup
+      state={state}
+      onChange={(next) => {
+        setState(next);
+        onState(next);
+      }}
+    />
+  );
+}
+
+describe("rees form-state helpers (#2207)", () => {
+  it("resolves both arms of the default-vs-override branch", () => {
+    // default arm: no override → profile membership decides
+    expect(effectiveReesAnalyzerEnabled(undefined, defaultOn, REES_DEFAULT_PROFILE)).toBe(true);
+    if (defaultOff) {
+      expect(effectiveReesAnalyzerEnabled({}, defaultOff, REES_DEFAULT_PROFILE)).toBe(false);
+    }
+    // override arm: explicit value wins over the profile default
+    const disabled = patchGeneratorReesAnalyzer({}, defaultOn.name, false);
+    expect(effectiveReesAnalyzerEnabled(disabled.rees, defaultOn, REES_DEFAULT_PROFILE)).toBe(
+      false,
+    );
+  });
+
+  it("clears a single override via the null patch and all overrides via reset", () => {
+    let state = patchGeneratorReesAnalyzer({}, defaultOn.name, false);
+    state = patchGeneratorReesAnalyzer(state, defaultOn.name, null);
+    expect(state.rees?.analyzers).toEqual({});
+    state = patchGeneratorReesAnalyzer(state, defaultOn.name, false);
+    expect(resetGeneratorReesAnalyzers(state).rees?.analyzers).toEqual({});
+  });
+
+  it("emits no manifest key without overrides, and the exact effective list with one", () => {
+    expect(reesAnalyzersManifestPatch(undefined, REES_ANALYZERS, REES_DEFAULT_PROFILE)).toEqual({
+      reesAnalyzers: null,
+    });
+    const state = patchGeneratorReesAnalyzer({}, defaultOn.name, false);
+    const patch = reesAnalyzersManifestPatch(state.rees, REES_ANALYZERS, REES_DEFAULT_PROFILE);
+    expect(patch.reesAnalyzers).not.toBeNull();
+    expect(patch.reesAnalyzers).not.toContain(defaultOn.name);
+    // every other default-profile analyzer is still present — exact-list semantics, not a delta
+    for (const analyzer of REES_ANALYZERS) {
+      if (analyzer.name === defaultOn.name) continue;
+      expect(patch.reesAnalyzers!.includes(analyzer.name)).toBe(
+        analyzer.profiles.includes(REES_DEFAULT_PROFILE),
+      );
+    }
+  });
+
+  it("enable-all: overriding every analyzer on yields the full catalog list", () => {
+    let state: GeneratorFormState = {};
+    for (const analyzer of REES_ANALYZERS) {
+      state = patchGeneratorReesAnalyzer(state, analyzer.name, true);
+    }
+    expect(reesAnalyzersManifestPatch(state.rees, REES_ANALYZERS, REES_DEFAULT_PROFILE)).toEqual({
+      reesAnalyzers: REES_ANALYZERS.map((analyzer) => analyzer.name),
+    });
+  });
+});
+
+describe("ReesAnalyzerFieldGroup (#2207)", () => {
+  it("renders one labeled toggle per catalog analyzer with its name and summary", () => {
+    render(<Harness onState={() => {}} />);
+    for (const analyzer of REES_ANALYZERS) {
+      expect(screen.getByRole("switch", { name: `Toggle ${analyzer.title}` })).toBeTruthy();
+    }
+    expect(screen.getByText(defaultOn.docs.summary)).toBeTruthy();
+  });
+
+  it("toggling one analyzer writes an override into the shared form state", () => {
+    let latest: GeneratorFormState = {};
+    render(<Harness onState={(state) => (latest = state)} />);
+    const toggle = screen.getByRole("switch", { name: `Toggle ${defaultOn.title}` });
+    expect(toggle.getAttribute("aria-checked")).toBe("true");
+    fireEvent.click(toggle);
+    expect(latest.rees?.analyzers).toEqual({ [defaultOn.name]: false });
+    expect(toggle.getAttribute("aria-checked")).toBe("false");
+    expect(screen.getByText("override")).toBeTruthy();
+  });
+
+  it("reset-to-profile-default clears overrides and disables itself when there are none", () => {
+    let latest: GeneratorFormState = {};
+    render(<Harness onState={(state) => (latest = state)} />);
+    const reset = screen.getByRole("button", {
+      name: "Reset to profile default",
+    }) as HTMLButtonElement;
+    expect(reset.disabled).toBe(true);
+    fireEvent.click(screen.getByRole("switch", { name: `Toggle ${defaultOn.title}` }));
+    expect(reset.disabled).toBe(false);
+    fireEvent.click(reset);
+    expect(latest.rees?.analyzers).toEqual({});
+    expect(reset.disabled).toBe(true);
+    expect(
+      screen
+        .getByRole("switch", { name: `Toggle ${defaultOn.title}` })
+        .getAttribute("aria-checked"),
+    ).toBe("true");
+  });
+});

--- a/apps/gittensory-ui/src/components/site/app-panels/rees-analyzer-field-group.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/rees-analyzer-field-group.tsx
@@ -1,0 +1,112 @@
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Switch } from "@/components/ui/switch";
+import { StateActionButton } from "@/components/site/state-views";
+import type { GeneratorFormState } from "@/lib/config-generator-form-state";
+import {
+  effectiveReesAnalyzerEnabled,
+  patchGeneratorReesAnalyzer,
+  resetGeneratorReesAnalyzers,
+} from "@/lib/config-generator-form-state";
+import { REES_ANALYZERS, REES_DEFAULT_PROFILE } from "@/lib/rees-analyzers";
+
+// Stable category order for the grouped list: catalog order of first appearance, so the section
+// reads the same way the analyzer reference docs page does.
+const CATEGORIES = REES_ANALYZERS.reduce<string[]>((order, analyzer) => {
+  if (!order.includes(analyzer.category)) order.push(analyzer.category);
+  return order;
+}, []);
+
+export function ReesAnalyzerFieldGroup({
+  state,
+  onChange,
+}: {
+  state: GeneratorFormState;
+  onChange: (next: GeneratorFormState) => void;
+}) {
+  const overrides = state.rees?.analyzers ?? {};
+  const overrideCount = Object.keys(overrides).length;
+
+  return (
+    <section
+      className="rounded-token border-hairline bg-card p-5"
+      aria-labelledby="rees-analyzers-title"
+    >
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="space-y-1">
+          <h2 id="rees-analyzers-title" className="font-display text-token-lg font-semibold">
+            REES analyzers
+          </h2>
+          <p className="max-w-2xl text-token-xs text-muted-foreground">
+            Choose which enrichment analyzers run. Untouched analyzers follow the{" "}
+            <code className="font-mono">{REES_DEFAULT_PROFILE}</code> profile default; changing any
+            switch writes an exact analyzer list into the generated config (
+            <code className="font-mono">REES_ANALYZERS</code> is an exact list, not a delta).
+          </p>
+        </div>
+        <StateActionButton
+          onClick={() => onChange(resetGeneratorReesAnalyzers(state))}
+          disabled={overrideCount === 0}
+        >
+          Reset to profile default
+        </StateActionButton>
+      </div>
+
+      <ScrollArea className="mt-5 h-96 rounded-token border-hairline bg-background/40">
+        <div className="space-y-5 p-4">
+          {CATEGORIES.map((category) => (
+            <fieldset key={category}>
+              <legend className="font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
+                {category}
+              </legend>
+              <ul className="mt-2 space-y-2">
+                {REES_ANALYZERS.filter((analyzer) => analyzer.category === category).map(
+                  (analyzer) => {
+                    const enabled = effectiveReesAnalyzerEnabled(
+                      state.rees,
+                      analyzer,
+                      REES_DEFAULT_PROFILE,
+                    );
+                    const overridden = analyzer.name in overrides;
+                    return (
+                      <li
+                        key={analyzer.name}
+                        className="flex items-start justify-between gap-3 rounded-token border border-border bg-background/40 p-3"
+                      >
+                        <div className="min-w-0">
+                          <div className="flex flex-wrap items-center gap-2">
+                            <span className="text-token-sm font-medium text-foreground">
+                              {analyzer.title}
+                            </span>
+                            <code className="font-mono text-token-2xs text-muted-foreground">
+                              {analyzer.name}
+                            </code>
+                            {overridden && (
+                              <span className="font-mono text-token-2xs uppercase tracking-wider text-mint">
+                                override
+                              </span>
+                            )}
+                          </div>
+                          <p className="mt-1 text-token-xs text-muted-foreground">
+                            {analyzer.docs.summary}
+                          </p>
+                        </div>
+                        <Switch
+                          checked={enabled}
+                          onCheckedChange={(next) =>
+                            onChange(patchGeneratorReesAnalyzer(state, analyzer.name, next))
+                          }
+                          aria-label={`Toggle ${analyzer.title}`}
+                          className="mt-0.5 shrink-0"
+                        />
+                      </li>
+                    );
+                  },
+                )}
+              </ul>
+            </fieldset>
+          ))}
+        </div>
+      </ScrollArea>
+    </section>
+  );
+}

--- a/apps/gittensory-ui/src/lib/config-generator-form-state.ts
+++ b/apps/gittensory-ui/src/lib/config-generator-form-state.ts
@@ -9,10 +9,17 @@ export type GeneratorGateAiReviewState = {
   model?: string | null;
 };
 
+/** Per-analyzer enable/disable OVERRIDES only — an analyzer absent from the map follows the
+ *  REES_DEFAULT_PROFILE default (see effectiveReesAnalyzerEnabled). */
+export type GeneratorReesState = {
+  analyzers?: Record<string, boolean>;
+};
+
 export type GeneratorFormState = {
   gate?: {
     aiReview?: GeneratorGateAiReviewState;
   };
+  rees?: GeneratorReesState;
 };
 
 export function patchGeneratorGateAiReview(
@@ -28,6 +35,55 @@ export function patchGeneratorGateAiReview(
         ...patch,
       },
     },
+  };
+}
+
+/** Set or clear one analyzer's enable/disable override (#2207). Passing `enabled === null` removes
+ *  the override so the analyzer falls back to its REES_DEFAULT_PROFILE membership. */
+export function patchGeneratorReesAnalyzer(
+  state: GeneratorFormState,
+  name: string,
+  enabled: boolean | null,
+): GeneratorFormState {
+  const overrides = { ...state.rees?.analyzers };
+  if (enabled === null) {
+    delete overrides[name];
+  } else {
+    overrides[name] = enabled;
+  }
+  return { ...state, rees: { ...state.rees, analyzers: overrides } };
+}
+
+/** Drop every analyzer override — the "reset to profile default" affordance (#2207). */
+export function resetGeneratorReesAnalyzers(state: GeneratorFormState): GeneratorFormState {
+  return { ...state, rees: { ...state.rees, analyzers: {} } };
+}
+
+/** An analyzer's effective enabled state: explicit override first, else whether the analyzer belongs
+ *  to the default profile (REES_ANALYZERS unset runs the registry's profile defaults). */
+export function effectiveReesAnalyzerEnabled(
+  rees: GeneratorReesState | undefined,
+  analyzer: { name: string; profiles: readonly string[] },
+  defaultProfile: string,
+): boolean {
+  const override = rees?.analyzers?.[analyzer.name];
+  return override ?? analyzer.profiles.includes(defaultProfile);
+}
+
+/** Map the REES slice to the manifest's exact-list semantics: with no overrides the key stays unset
+ *  (REES runs its profile defaults); with any override, emit the full effective enabled list, since
+ *  REES_ANALYZERS is an exact comma-list, not a delta. */
+export function reesAnalyzersManifestPatch(
+  rees: GeneratorReesState | undefined,
+  catalog: ReadonlyArray<{ name: string; profiles: readonly string[] }>,
+  defaultProfile: string,
+): { reesAnalyzers: string[] | null } {
+  const overrides = rees?.analyzers ?? {};
+  if (Object.keys(overrides).length === 0) return { reesAnalyzers: null };
+  return {
+    reesAnalyzers: catalog
+      .filter((analyzer) => effectiveReesAnalyzerEnabled(rees, analyzer, defaultProfile))
+      .map((analyzer) => analyzer.name),
   };
 }
 


### PR DESCRIPTION
## Summary

- Adds the **REES analyzer selection field group** to the config generator: one enable/disable switch per `REES_ANALYZERS` catalog entry, grouped by category inside a `ScrollArea` so the ~20 analyzers stay scannable, each row showing the analyzer's title, `name`, and docs summary.
- A **"Reset to profile default"** affordance keyed to `REES_DEFAULT_PROFILE` (`rees-analyzers.ts:33`) clears every override and disables itself when there are none; rows with an explicit override carry an `override` tag.
- Selection writes an **overrides-only `rees.analyzers` slice** into the shared `GeneratorFormState` (`patchGeneratorReesAnalyzer` / `resetGeneratorReesAnalyzers`, mirroring the merged AI-provider group's patch-helper shape). An analyzer absent from the map follows its default-profile membership (`effectiveReesAnalyzerEnabled`).
- `reesAnalyzersManifestPatch` mirrors `REES_ANALYZERS`'s documented **exact-list semantics**: with no overrides the key stays unset (REES runs its profile defaults); with any override it emits the full effective analyzer list, never a delta — ready for the YAML preview (#2210) to serialize.

Closes #2207

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- None skipped. The diff is confined to `apps/gittensory-ui/**` (Codecov-exempt); the new state helpers and component are still fully unit-tested — 7 new cases covering both arms of the default-vs-override branch, single-override clear via the null patch, reset-clears-all, exact-list manifest semantics (no-overrides → unset key; one override → full effective list; enable-all → full catalog), per-analyzer toggle rendering, override write-through, and the reset affordance's disabled state.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

| State / title | Before | After |
| --- | --- | --- |
| `/app/config-generator` — REES field group added below AI provider mode | <a href="https://github.com/reyanthony062001-ops/gittensory/releases/download/ui-evidence-2207-v1/config-generator-before.png"><img src="https://github.com/reyanthony062001-ops/gittensory/releases/download/ui-evidence-2207-v1/config-generator-before.png" alt="Config generator before" width="240"></a><br><sub>before: AI provider mode is the only field group</sub> | <a href="https://github.com/reyanthony062001-ops/gittensory/releases/download/ui-evidence-2207-v1/config-generator-after.png"><img src="https://github.com/reyanthony062001-ops/gittensory/releases/download/ui-evidence-2207-v1/config-generator-after.png" alt="Config generator after" width="240"></a><br><sub>after: REES analyzers section with reset affordance + scrollable grouped toggles</sub> |
| Override state — one analyzer switched off | | <a href="https://github.com/reyanthony062001-ops/gittensory/releases/download/ui-evidence-2207-v1/config-generator-after-override.png"><img src="https://github.com/reyanthony062001-ops/gittensory/releases/download/ui-evidence-2207-v1/config-generator-after-override.png" alt="Override state" width="240"></a><br><sub>after: `dependency` toggled off carries the `override` tag; reset button active</sub> |

## Notes

- The category grouping follows the catalog's order of first appearance so the section reads the same way as the analyzer reference docs page.
