### PR TITLE
refactor(queue): extract manifest-policy gate from maybePublishPrPublicSurface

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -9201,6 +9201,128 @@ export function reviewDurationMsSince(startedAt: string | null, nowMs: number): 
   return Number.isFinite(ms) && ms >= 0 ? ms : undefined;
 }
 
+/**
+ * Focus-manifest policy gate (#555, opt-in via `manifestPolicyGateMode`). Reloads the CACHED manifest (the
+ * settings resolver discards the raw manifest, but loadRepoFocusManifest is cached so this is cheap),
+ * recomputes the guidance over the PR's changed files, and pushes ONLY the three enforceable policy findings
+ * onto the advisory so isConfiguredGateBlocker can block under `manifestPolicy: block`. Also runs the E2E
+ * test-generation auto-trigger (#4196, part of the #4189 epic) — see the inline comments below for the full
+ * rationale of each step. `manifestPolicyGateMode: "off"` (the default) is a no-op, so the advisory/gate
+ * stays byte-identical to today. Extracted from maybePublishPrPublicSurface (#4607) — pure code motion;
+ * every branch, condition, and comment is preserved verbatim and in the same order.
+ */
+async function maybeApplyManifestPolicyGate(
+  env: Env,
+  args: {
+    repoFullName: string;
+    installationId: number;
+    pr: Awaited<ReturnType<typeof upsertPullRequestFromGitHub>>;
+    repo: Awaited<ReturnType<typeof getRepository>>;
+    settings: RepositorySettings;
+    advisory: Awaited<ReturnType<typeof buildPullRequestAdvisory>>;
+    webhook: { liveFacts: LiveGithubFacts; deliveryId: string };
+    gateFiles: Awaited<ReturnType<typeof listPullRequestFiles>> | null;
+    author: string | null;
+  },
+): Promise<void> {
+  // Focus-manifest policy (#555, opt-in via manifestPolicyGateMode). Reload the CACHED manifest (the
+  // settings resolver discards the raw manifest, but loadRepoFocusManifest is cached so this is cheap),
+  // recompute the guidance over the PR's changed files, and push ONLY the three enforceable policy
+  // findings into the advisory so isConfiguredGateBlocker can block under manifestPolicy: block.
+  if (args.settings.manifestPolicyGateMode !== "off") {
+    // `gateFiles` is threaded in by the ONLY caller (maybePublishPrPublicSurface) already resolved via
+    // getReviewFiles() whenever manifestPolicyGateMode is not "off" -- the same condition gating this whole
+    // block -- so it is never actually null here; the `| null` on the parameter type exists only because the
+    // caller's own local starts as `let gateFiles: ... | null = null` for TypeScript soundness before that
+    // conditional assignment runs. The `?? []` fallback is unreachable on this webhook-integration path
+    // (pre-existing on origin/main before this function was extracted from maybePublishPrPublicSurface, #4607).
+    /* v8 ignore next -- see the comment above */
+    const manifestFiles = args.gateFiles ?? [];
+    const manifest = await loadRepoFocusManifest(env, args.repoFullName);
+    const testFileCount = manifestFiles.filter((file) => isTestPath(file.path)).length;
+    const passedValidationCount = await resolveManifestPassedValidationCount(env, {
+      repoFullName: args.repoFullName,
+      installationId: args.installationId,
+      prNumber: args.pr.number,
+      headSha: args.pr.headSha,
+      baseRef: args.pr.baseRef ?? args.repo?.defaultBranch,
+      body: args.pr.body,
+      expectedCiContexts: args.settings.expectedCiContexts,
+      liveFacts: args.webhook.liveFacts,
+      testExpectationsConfigured: manifest.testExpectations.length > 0,
+      testFileCount,
+    });
+    const guidance = buildFocusManifestGuidance({
+      manifest,
+      changedPaths: manifestFiles.map((file) => file.path),
+      labels: args.pr.labels,
+      linkedIssueCount: args.pr.linkedIssues.length,
+      testFileCount,
+      passedValidationCount,
+      hasNoIssueRationale: hasClearNoIssueRationale(args.pr),
+    });
+    const policyCodes = new Set([
+      "manifest_blocked_path",
+      "manifest_linked_issue_required",
+      "manifest_missing_tests",
+    ]);
+    // Keep deterministic manifest policy findings independent from AI-review eligibility: ignored authors
+    // suppress review/public output only, never maintainer-configured gate blockers or their downstream triggers.
+    const policyFindings = guidance.findings;
+    // Computed once and reused below for the #4196 auto-trigger check -- same feature gate, one call. Also
+    // feeds #4583's inline CTA so the missing-tests finding surfaces `@gittensory generate-tests` right in
+    // ORB's own comment (mirrors CodeRabbit's inline walkthrough checkbox) only when the command would
+    // actually work for this repo, never as noise on a repo that hasn't opted in.
+    const e2eTestGenAvailable = resolveConvergedFeature(env, manifest, "e2eTests", args.repoFullName);
+    for (const finding of policyFindings) {
+      if (!policyCodes.has(finding.code)) continue;
+      args.advisory.findings.push(publicSafeManifestPolicyFinding(finding, { e2eTestGenAvailable }));
+    }
+    // E2E test-generation auto-trigger (#4196, part of the #4189 epic): promotes the deterministic
+    // manifest_missing_tests finding above from advisory-only text into an actual trigger for #4192/#4194's
+    // generation-and-render path -- additive to, never a replacement for, the explicit `@gittensory
+    // generate-tests` command (#4195), which stays available regardless of whether this signal fired.
+    // Filters the SAME policyFindings just computed above rather than re-deriving "PR probably needs
+    // tests" from scratch, per the issue's own requirement -- this is why the auto-trigger lives inside this
+    // exact manifestPolicyGateMode-gated block instead of a parallel code path: that is the only place this
+    // finding is computed at all today.
+    if (args.pr.headSha && policyFindings.some((finding) => finding.code === "manifest_missing_tests") && e2eTestGenAvailable) {
+      const e2eTargetKey = `${args.repoFullName}#${args.pr.number}`;
+      // Double-generation guard: an unchanged head SHA re-entering this pass (a re-review/sweep tick, not a
+      // new push) must never re-spend an LLM call or repost a duplicate suggestion. A genuinely NEW push
+      // (a new head SHA) is always a fresh miss here regardless of how many prior SHAs already fired. The
+      // explicit command deliberately does NOT consult this guard -- a maintainer typing the command always
+      // gets a fresh generation, even on a SHA the auto-trigger already covered (simplicity over a cache that
+      // would need its own invalidation rules; the daily neuron budget shared by both paths already bounds
+      // the cost of a maintainer choosing to ask twice).
+      const alreadyTriggered = await hasAuditEventForHeadSha(env, "github_app.e2e_tests_generation", e2eTargetKey, args.pr.headSha);
+      if (!alreadyTriggered) {
+        const e2eMode = resolveAgentActionMode({ globalPaused: isGlobalAgentPause(env) || (await isDbFrozenForRepo(env, args.settings.agentGlobalFreezeOverride)), agentPaused: args.settings.agentPaused, agentDryRun: args.settings.agentDryRun });
+        if (e2eMode === "live") {
+          await runE2eTestGenerationAndDeliver(env, {
+            repoFullName: args.repoFullName,
+            installationId: args.installationId,
+            pr: args.pr,
+            settings: args.settings,
+            manifest,
+            files: manifestFiles,
+            // No comment-invoker exists for an automated trigger -- the PR's own author is the closest
+            // analogue to "who this generated test is for" (unlike the explicit command, where `actor` is
+            // whoever typed the command).
+            actor: args.author ?? "the PR author",
+            mode: e2eMode,
+            deliveryId: args.webhook.deliveryId,
+            targetKey: e2eTargetKey,
+            trigger: "auto",
+          });
+        } else {
+          await recordGenerateTestsSkip(env, args.webhook.deliveryId, args.repoFullName, e2eTargetKey, args.author, e2eMode === "dry_run" ? "dry_run" : "agent_paused");
+        }
+      }
+    }
+  }
+}
+
 async function maybePublishPrPublicSurface(
   env: Env,
   installationId: number,
@@ -10080,95 +10202,18 @@ async function maybePublishPrPublicSurface(
         });
       }
     }
-    // Focus-manifest policy (#555, opt-in via manifestPolicyGateMode). Reload the CACHED manifest (the
-    // settings resolver discards the raw manifest, but loadRepoFocusManifest is cached so this is cheap),
-    // recompute the guidance over the PR's changed files, and push ONLY the three enforceable policy
-    // findings into the advisory so isConfiguredGateBlocker can block under manifestPolicy: block.
-    if (settings.manifestPolicyGateMode !== "off") {
-      const manifestFiles = gateFiles ?? [];
-      const manifest = await loadRepoFocusManifest(env, repoFullName);
-      const testFileCount = manifestFiles.filter((file) => isTestPath(file.path)).length;
-      const passedValidationCount = await resolveManifestPassedValidationCount(env, {
-        repoFullName,
-        installationId,
-        prNumber: pr.number,
-        headSha: pr.headSha,
-        baseRef: pr.baseRef ?? repo?.defaultBranch,
-        body: pr.body,
-        expectedCiContexts: settings.expectedCiContexts,
-        liveFacts: webhook.liveFacts,
-        testExpectationsConfigured: manifest.testExpectations.length > 0,
-        testFileCount,
-      });
-      const guidance = buildFocusManifestGuidance({
-        manifest,
-        changedPaths: manifestFiles.map((file) => file.path),
-        labels: pr.labels,
-        linkedIssueCount: pr.linkedIssues.length,
-        testFileCount,
-        passedValidationCount,
-        hasNoIssueRationale: hasClearNoIssueRationale(pr),
-      });
-      const policyCodes = new Set([
-        "manifest_blocked_path",
-        "manifest_linked_issue_required",
-        "manifest_missing_tests",
-      ]);
-      // Keep deterministic manifest policy findings independent from AI-review eligibility: ignored authors
-      // suppress review/public output only, never maintainer-configured gate blockers or their downstream triggers.
-      const policyFindings = guidance.findings;
-      // Computed once and reused below for the #4196 auto-trigger check -- same feature gate, one call. Also
-      // feeds #4583's inline CTA so the missing-tests finding surfaces `@gittensory generate-tests` right in
-      // ORB's own comment (mirrors CodeRabbit's inline walkthrough checkbox) only when the command would
-      // actually work for this repo, never as noise on a repo that hasn't opted in.
-      const e2eTestGenAvailable = resolveConvergedFeature(env, manifest, "e2eTests", repoFullName);
-      for (const finding of policyFindings) {
-        if (!policyCodes.has(finding.code)) continue;
-        advisory.findings.push(publicSafeManifestPolicyFinding(finding, { e2eTestGenAvailable }));
-      }
-      // E2E test-generation auto-trigger (#4196, part of the #4189 epic): promotes the deterministic
-      // manifest_missing_tests finding above from advisory-only text into an actual trigger for #4192/#4194's
-      // generation-and-render path -- additive to, never a replacement for, the explicit `@gittensory
-      // generate-tests` command (#4195), which stays available regardless of whether this signal fired.
-      // Filters the SAME policyFindings just computed above rather than re-deriving "PR probably needs
-      // tests" from scratch, per the issue's own requirement -- this is why the auto-trigger lives inside this
-      // exact manifestPolicyGateMode-gated block instead of a parallel code path: that is the only place this
-      // finding is computed at all today.
-      if (pr.headSha && policyFindings.some((finding) => finding.code === "manifest_missing_tests") && e2eTestGenAvailable) {
-        const e2eTargetKey = `${repoFullName}#${pr.number}`;
-        // Double-generation guard: an unchanged head SHA re-entering this pass (a re-review/sweep tick, not a
-        // new push) must never re-spend an LLM call or repost a duplicate suggestion. A genuinely NEW push
-        // (a new head SHA) is always a fresh miss here regardless of how many prior SHAs already fired. The
-        // explicit command deliberately does NOT consult this guard -- a maintainer typing the command always
-        // gets a fresh generation, even on a SHA the auto-trigger already covered (simplicity over a cache that
-        // would need its own invalidation rules; the daily neuron budget shared by both paths already bounds
-        // the cost of a maintainer choosing to ask twice).
-        const alreadyTriggered = await hasAuditEventForHeadSha(env, "github_app.e2e_tests_generation", e2eTargetKey, pr.headSha);
-        if (!alreadyTriggered) {
-          const e2eMode = resolveAgentActionMode({ globalPaused: isGlobalAgentPause(env) || (await isDbFrozenForRepo(env, settings.agentGlobalFreezeOverride)), agentPaused: settings.agentPaused, agentDryRun: settings.agentDryRun });
-          if (e2eMode === "live") {
-            await runE2eTestGenerationAndDeliver(env, {
-              repoFullName,
-              installationId,
-              pr,
-              settings,
-              manifest,
-              files: manifestFiles,
-              // No comment-invoker exists for an automated trigger -- the PR's own author is the closest
-              // analogue to "who this generated test is for" (unlike the explicit command, where `actor` is
-              // whoever typed the command).
-              actor: author ?? "the PR author",
-              mode: e2eMode,
-              deliveryId: webhook.deliveryId,
-              targetKey: e2eTargetKey,
-              trigger: "auto",
-            });
-          } else {
-            await recordGenerateTestsSkip(env, webhook.deliveryId, repoFullName, e2eTargetKey, author, e2eMode === "dry_run" ? "dry_run" : "agent_paused");
-          }
-        }
-      }
-    }
+    // Focus-manifest policy gate (#555) -- see maybeApplyManifestPolicyGate's own doc comment.
+    await maybeApplyManifestPolicyGate(env, {
+      repoFullName,
+      installationId,
+      pr,
+      repo,
+      settings,
+      advisory,
+      webhook,
+      gateFiles,
+      author,
+    });
     // Pre-merge checks (#review-pre-merge-checks, opt-in via .gittensory.yml review.pre_merge_checks). DETERMINISTIC
     // content assertions (title/description must contain a phrase, a label must be present), optionally path-gated.
     // Each FAILED check appends an advisory `pre_merge_check_failed` finding — or a blocking `pre_merge_check_required`

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -10015,6 +10015,105 @@ describe("queue processors", () => {
     expect(JSON.stringify(gatePatches[0])).toContain("Configured validation evidence missing");
   });
 
+  // #4607 (maybeApplyManifestPolicyGate extraction): buildFocusManifestGuidance can produce findings whose
+  // code is NOT one of the three enforceable manifest-policy codes (manifest_blocked_path /
+  // manifest_linked_issue_required / manifest_missing_tests) -- e.g. manifest_off_focus, when wantedPaths is
+  // configured and no changed path matches it. Those non-enforceable findings must be filtered out before
+  // ever reaching the advisory/gate, never published alongside an enforceable one from the same pass.
+  it("filters out a non-enforceable manifest finding (manifest_off_focus) while still surfacing an enforceable one", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await persistRegistrySnapshot(
+      env,
+      normalizeRegistryPayload(
+        { "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } },
+        { kind: "raw-github", url: "https://example.test" },
+        "2026-05-23T00:00:00.000Z",
+      ),
+    );
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    await upsertInstallation(env, {
+      installation: {
+        id: 123,
+        account: { login: "JSONbored", id: 1, type: "User" },
+        repository_selection: "selected",
+        permissions: { metadata: "read", pull_requests: "write", issues: "write" },
+        events: ["pull_request"],
+      },
+      repositories: [{ name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }],
+    });
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      commentMode: "off",
+      publicSurface: "off",
+      autoLabelEnabled: false,
+      checkRunMode: "off",
+      gateCheckMode: "enabled",
+      linkedIssueGateMode: "off",
+      manifestPolicyGateMode: "block",
+      requireLinkedIssue: false,
+      typeLabelsEnabled: false,
+    });
+    // wantedPaths configured + a changed file outside it produces manifest_off_focus (NOT one of the three
+    // enforceable codes); testExpectations configured + no evidence produces manifest_missing_tests (IS
+    // enforceable) -- so this single pass yields one filtered finding and one published finding.
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", {
+      wantedPaths: ["docs/"],
+      testExpectations: ["Run npm run test:ci."],
+    });
+    await upsertPullRequestFile(env, {
+      repoFullName: "JSONbored/gittensory",
+      pullNumber: 45,
+      path: "src/feature.ts",
+      status: "modified",
+      additions: 1,
+      deletions: 0,
+      changes: 1,
+      payload: {},
+    });
+
+    const gatePatches: Array<Record<string, unknown>> = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url === "https://api.gittensor.io/miners") return Response.json([]);
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/commits/gate-off-focus/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/check-runs") && method === "POST") return Response.json({ id: 903 }, { status: 201 });
+      if (url.includes("/check-runs/903") && method === "PATCH") {
+        gatePatches.push(JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>);
+        return Response.json({ id: 903, html_url: "https://github.com/checks/903" });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "gate-off-focus-filtered",
+      eventName: "pull_request",
+      payload: {
+        action: "opened",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        pull_request: {
+          number: 45,
+          title: "Out of focus change",
+          state: "open",
+          user: { login: "contributor" },
+          head: { sha: "gate-off-focus" },
+          labels: [],
+          body: "No tests run.",
+        },
+      },
+    });
+
+    expect(gatePatches).toHaveLength(1);
+    // The enforceable finding (manifest_missing_tests) is published...
+    expect(JSON.stringify(gatePatches[0])).toContain("Configured validation evidence missing");
+    // ...but the non-enforceable finding (manifest_off_focus) is filtered out before it ever reaches the advisory.
+    expect(JSON.stringify(gatePatches[0])).not.toContain("Change is outside maintainer-wanted areas");
+    expect(JSON.stringify(gatePatches[0])).not.toContain("manifest_off_focus");
+  });
+
   // REGRESSION (#3304): a PR with no body at all (GitHub sends `body: null` for an empty description) must
   // fall back to treating validation evidence as absent, not throw or silently pass the manifest gate.
   it("still flags manifest_missing_tests for a PR with a null body", async () => {


### PR DESCRIPTION
## Summary

- Part of #4607 (the `processors.ts` mega-function breakup). This PR does one slice of the
  `maybePublishPrPublicSurface` portion of that issue — the largest and riskiest of the three functions,
  explicitly called out as needing "its own careful multi-part approach given the size" (2,600+ lines, 17%
  of the file, up to 10 levels of nesting). `runAgentMaintenancePlanAndExecute` (#4688) and
  `processGitHubWebhook` (#4695) already shipped as the first two parts of this issue.
- After reading the entire function start to finish, I picked the **focus-manifest policy gate** block —
  one of the issue's own named extraction targets ("manifest-policy evaluation") — as the safest first
  slice, over the other candidates (dry-run-chokepoint / unified-comment feature resolution / AI-vision BYOK
  gate are already single-call sites into existing helpers with nothing left to extract; the unified-comment
  render block and the review-memory suppression block are both more deeply nested, inside two stacked
  conditionals after the function's own `try/catch`). The manifest-policy block instead sits at the same
  shallow, top-level sequential position in the gate-evaluation `try` block as its already-extracted
  siblings `maybeAddSecretLeakFinding` / `maybeAddLockfileTamperFinding` (same file), has **zero** early
  returns, and every one of its own locals is provably block-scoped — the surrounding code even has its own
  comment confirming `e2eTestGenAvailable` is "block-scoped to the manifestPolicyGateMode branch above...
  and out of scope here," independently re-resolving it a few hundred lines later.
- Extracted the whole `if (settings.manifestPolicyGateMode !== "off") { ... }` block (findings computation
  **and** the E2E test-generation auto-trigger it gates, both tightly coupled to the same
  `policyFindings`/`e2eTestGenAvailable` values) into a new, named `maybeApplyManifestPolicyGate` helper,
  colocated directly above `maybePublishPrPublicSurface`, called from the exact spot the inline block used
  to sit.
- **Pure code motion — zero behavior change.** Kept the original `if (cond) { ... }` shape rather than
  inverting it into an early-return guard clause, specifically so a mechanical byte-diff could verify
  fidelity without also having to reason about a control-flow rewrite. Wrote a small Node script
  (not committed — a one-off local check, like the sibling PRs used) that: cuts the original inline block
  from `origin/main` by exact line range, cuts the new function's body by exact line range, dedents both,
  and reverse-transforms the new text (`args.X` → `X`, then collapses the `X: X` object-shorthand the
  rename necessarily expanded back to bare `X`, e.g. `repoFullName: args.repoFullName` → `repoFullName`) —
  confirmed **byte-identical** to the original. Every comment is preserved verbatim and in the same order.
- Net effect: `maybePublishPrPublicSurface` shrinks by ~77 lines (89 inline → a 12-line call), with the
  logic itself now independently named and one step closer to independently testable.

## Coverage follow-up in the same commit (the documented #4607 hard lesson)

Per PR #4695's own retro (a relocated-but-previously-untested line still counts as "new" against Codecov's
diff-based patch gate — line coverage alone also isn't enough, since Codecov measures branches too), I
cross-referenced `coverage/coverage-final.json`'s `statementMap`/`s` **and** `branchMap`/`b` (not just the
terminal summary table) against this diff's exact added-line ranges after the raw extraction, before
declaring it done. Found 3 gaps (1 statement + 2 branches, resolving to the same 2 underlying lines). For
each, I confirmed NEW-vs-PRE-EXISTING empirically — not by assumption — by running the identical
`vitest --coverage` command against an unmodified `origin/main` checkout (a throwaway `git worktree`) and
diffing hit-count arrays at the original line numbers:

- `gateFiles ?? []` (branch): `hits=[20,0]` on `origin/main` at line 10088, `hits=[20,0]` post-extraction —
  identical, confirmed pre-existing. It's also **provably unreachable** on the only real call path: the
  sole caller only invokes this function when `manifestPolicyGateMode !== "off"`, and that exact same
  condition is what makes the caller's own `gateFiles` local resolve via `getReviewFiles()` (never null)
  immediately beforehand — the `| null` on the type exists only for TypeScript soundness on the caller's
  `let`-then-conditionally-assigned local, not because of a reachable runtime null. Marked
  `/* v8 ignore next -- see the comment above */`, matching this exact file's own established convention
  (e.g. the neighboring `typeLabelsEnabled ?? true`).
- `if (!policyCodes.has(finding.code)) continue;` (statement + branch): `hits=[0,15]` on `origin/main` at
  line 10126, identical post-extraction — also pre-existing, but **genuinely reachable and testable**:
  `buildFocusManifestGuidance` can produce finding codes outside the three enforceable ones (e.g.
  `manifest_off_focus`, `manifest_preferred_path`, `manifest_missing_preferred_label`), which this filter is
  specifically there to drop before they reach the advisory. Added one real test
  (`test/unit/queue.test.ts`) that configures `wantedPaths` so an out-of-focus changed file produces a
  `manifest_off_focus` finding alongside a `manifest_missing_tests` finding from the same pass, and asserts
  the published gate output contains the enforceable one's text but not the filtered one's — exercising
  both sides of the branch with a real functional assertion, not just a coverage-padding call.

Re-ran the full cross-reference after both fixes: **zero gaps remaining, at both line and branch level**,
within this diff's added-line ranges.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

Note on the issue link: this is `Part of #4607`, not `Closes`/`Fixes` — the issue explicitly covers the rest
of `maybePublishPrPublicSurface` (this is one slice of one of three parts) as further sequential PRs. See
the issue body: "this is expected to land as multiple sequential PRs."

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` — not run; no `.github/workflows/**` files touched.
- [x] `npm run typecheck` — clean: before the coverage follow-up, after it, and again immediately after
      rebasing onto fresh `origin/main`.
- [ ] `npm run test:coverage` — not run as the literal full-suite command; a scoped coverage run (below)
      proved the diff itself is fully exercised at both line and branch level, matching the precedent set
      by the two sibling #4607 extraction PRs.
- [ ] `npm run test:workers` — not run; no `test/workers/**`-relevant code touched.
- [ ] `npm run build:mcp` / `npm run test:mcp-pack` — not run; no MCP package changes.
- [ ] `npm run ui:openapi:check` / `npm run ui:lint` / `npm run ui:typecheck` / `npm run ui:build` — not
      run; no `apps/gittensory-ui/**` or API/schema changes.
- [ ] `npm audit --audit-level=moderate` — not run; no dependency changes.
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — the extraction itself has no new behavior; one real regression-style test was added for the pre-existing (relocated) `manifest_off_focus` filter branch (see Coverage follow-up above).

If any required check was skipped, explain why:

- This is a single-file-plus-its-test-file, behavior-preserving refactor of `src/queue/processors.ts` with
  no UI, MCP, workers, schema, OpenAPI, workflow, or dependency surface touched, so those gates are left to
  CI rather than duplicated locally (most path-filter out for this diff anyway). The checks that matter for
  this change were run directly, in full, in the foreground, **both before and after rebasing**:
  - `npm run typecheck`: clean every time.
  - `npx vitest run test/unit/queue.test.ts`: **810/810 tests passed** (809 pre-existing, unmodified, plus
    1 new) — the primary suite exercising `maybePublishPrPublicSurface` end-to-end via webhook processing,
    auto-action convergence, and the manifest-policy-gate-specific scenarios this PR's function now serves.
  - Coverage: `npx vitest run test/unit/queue.test.ts --coverage --coverage.include='src/queue/processors.ts' --coverage.reporter=json`,
    parsed `coverage/coverage-final.json` directly (`statementMap`/`s` and `branchMap`/`b`, not the mixed
    terminal summary) and cross-referenced against the diff's exact added-line ranges from
    `git diff origin/main --unified=0`. Zero uncovered statements, zero partially-covered branches, within
    those ranges — full detail above.
  - Rebase: `git fetch origin && git rebase origin/main` immediately before pushing completed with **no
    conflicts** (none of the 6 commits that had landed on `main` since this branch was created touched
    `src/queue/processors.ts`). Re-ran typecheck, the full `queue.test.ts` suite, and the coverage
    cross-reference again after rebasing — identical clean results.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no auth/cookie/CORS/session code touched (pure structural refactor).
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no API/OpenAPI/MCP surface touched.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section below... — N/A, no visible/UI changes (backend-only refactor).
- [ ] Public docs/changelogs are updated where needed... — N/A, no doc-affecting behavior change; `CHANGELOG.md` intentionally not touched.

## UI Evidence

Not applicable — this PR has no visible/UI/frontend/docs surface; it is a backend-only, behavior-preserving
extraction inside `src/queue/processors.ts`.

## Notes

- This is a maintainer/owner PR (issue #4607 is labeled `maintainer-only`).
- Deliberately scoped to ONE block, per the issue's own instruction that `maybePublishPrPublicSurface`
  "needs its own careful multi-part approach given the size" — did not attempt the unified-comment render
  block, the review-memory suppression block, the AI-review cache/dispatch closure, or any of the other
  large sections in the same pass, to keep this PR's own risk surface reviewable and its byte-diff
  verification tractable.
- Follow-ups (separate PRs, per the issue): the remaining named blocks in `maybePublishPrPublicSurface`
  (unified-comment rendering, review-memory/publish-suppression, the AI-review dispatch closure, and
  whatever else the next read of the function surfaces) — each is a substantially larger and more
  deeply-nested/mutable-state-coupled unit than this one, and will need their own individually-scoped PRs
  and their own byte-diff + coverage verification passes.
