### PR TITLE
fix(selfhost): exclude Docker Compose's reserved _FILE vars from the secret-dereference scan

### DIFF
--- a/src/selfhost/load-file-secrets.ts
+++ b/src/selfhost/load-file-secrets.ts
@@ -1,0 +1,37 @@
+// Resolve `<NAME>_FILE` env vars (Docker secrets / multi-line keys) into `<NAME>` at self-host startup.
+// Extracted from server.ts (#4403) so this has a real test harness -- server.ts itself boots the whole
+// app on import and is Codecov-ignored, so it has no runtime test coverage of its own.
+import { readFileSync } from "node:fs";
+
+// Docker Compose's OWN reserved `_FILE`-suffixed environment variables -- never gittensory's secret-file
+// convention, so they must never be dereferenced below. `COMPOSE_FILE` is a colon-delimited list of
+// compose file paths (never a single readable file itself, so readFileSync always throws), and
+// `COMPOSE_ENV_FILE` (less commonly set, but equally reserved by Compose) points at an operator's custom
+// .env file, not a secret. Excluding both by name is the fix (#4403) -- a real operator secret is never
+// named exactly one of these.
+const COMPOSE_RESERVED_FILE_VARS = new Set(["COMPOSE_FILE", "COMPOSE_ENV_FILE"]);
+
+/** `env` and `readFile` are injectable purely for testability -- every real caller uses the defaults
+ *  (`process.env`, `node:fs`'s `readFileSync`), so this is byte-identical to a hardcoded version at
+ *  runtime while letting tests pass a plain object and a mock reader instead of mutating global state. */
+export function loadFileSecrets(
+  env: Record<string, string | undefined> = process.env,
+  readFile: (path: string) => string = (path) => readFileSync(path, "utf8"),
+): void {
+  for (const key of Object.keys(env)) {
+    if (!key.endsWith("_FILE") || !env[key] || COMPOSE_RESERVED_FILE_VARS.has(key)) continue;
+    const target = key.slice(0, -"_FILE".length);
+    if (env[target]) continue; // an explicit value wins
+    try {
+      env[target] = readFile(env[key] as string).trim();
+    } catch {
+      console.error(
+        JSON.stringify({
+          level: "error",
+          event: "selfhost_secret_file_unreadable",
+          var: key,
+        }),
+      );
+    }
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,7 +6,7 @@
 // Serves the Hono app via @hono/node-server, drives the queue with the same processJob, ticks the same
 // scheduled handler on a timer, exposes /health /ready /metrics, and shuts down gracefully. The Cloudflare
 // Worker (src/index.ts) is untouched — this is a parallel entry the self-host esbuild build bundles.
-import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { existsSync, writeFileSync } from "node:fs";
 import { delimiter, join } from "node:path";
 import { randomUUID } from "node:crypto";
 import { DatabaseSync } from "node:sqlite";
@@ -42,6 +42,7 @@ import {
 import { createOrbRelayRegistrationState, isOrbBrokerMode, registerOrbRelayTargetWithRetry } from "./orb/broker-client";
 import { exportOrbBatch } from "./selfhost/orb-collector";
 import { createD1Adapter, nodeSqliteDriver } from "./selfhost/d1-adapter";
+import { loadFileSecrets } from "./selfhost/load-file-secrets";
 import {
   backupAcknowledgedGaugeValue,
   buildHealthBody,
@@ -106,28 +107,6 @@ import { probeReesSecretAtStartup } from "./review/enrichment-wire";
 import { sampleRecentDeadLetters } from "./selfhost/dlq-recent";
 import type { JobMessage } from "./types";
 
-/** Resolve `<NAME>_FILE` env vars (Docker secrets / multi-line keys) into `<NAME>` at startup. */
-function loadFileSecrets(): void {
-  for (const key of Object.keys(process.env)) {
-    if (!key.endsWith("_FILE") || !process.env[key]) continue;
-    const target = key.slice(0, -"_FILE".length);
-    if (process.env[target]) continue; // an explicit value wins
-    try {
-      process.env[target] = readFileSync(
-        process.env[key] as string,
-        "utf8",
-      ).trim();
-    } catch {
-      console.error(
-        JSON.stringify({
-          level: "error",
-          event: "selfhost_secret_file_unreadable",
-          var: key,
-        }),
-      );
-    }
-  }
-}
 
 interface Backend {
   db: D1Database;

--- a/test/unit/selfhost-load-file-secrets.test.ts
+++ b/test/unit/selfhost-load-file-secrets.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+import { loadFileSecrets } from "../../src/selfhost/load-file-secrets";
+
+describe("loadFileSecrets (#4403)", () => {
+  it("REGRESSION: never dereferences COMPOSE_FILE, and logs no false error for it", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const readFile = vi.fn(() => "should never be called");
+    const env: Record<string, string | undefined> = {
+      COMPOSE_FILE: "docker-compose.yml:docker-compose.override.yml:docker-compose.local-gpu.yml",
+    };
+    loadFileSecrets(env, readFile);
+    expect(env.COMPOSE).toBeUndefined();
+    expect(readFile).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it("also excludes COMPOSE_ENV_FILE, Compose's other reserved _FILE var", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const readFile = vi.fn(() => "should never be called");
+    const env: Record<string, string | undefined> = { COMPOSE_ENV_FILE: ".env.prod" };
+    loadFileSecrets(env, readFile);
+    expect(env.COMPOSE_ENV).toBeUndefined();
+    expect(readFile).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it("dereferences a real gittensory secret _FILE var into its target name", () => {
+    const readFile = vi.fn(() => "s3cr3t-value\n");
+    const env: Record<string, string | undefined> = { SENTRY_DSN_FILE: "/run/secrets/sentry_dsn" };
+    loadFileSecrets(env, readFile);
+    expect(readFile).toHaveBeenCalledWith("/run/secrets/sentry_dsn");
+    expect(env.SENTRY_DSN).toBe("s3cr3t-value"); // trimmed
+  });
+
+  it("does not overwrite an already-set explicit value", () => {
+    const readFile = vi.fn(() => "from-file");
+    const env: Record<string, string | undefined> = { SENTRY_DSN_FILE: "/run/secrets/sentry_dsn", SENTRY_DSN: "already-set" };
+    loadFileSecrets(env, readFile);
+    expect(readFile).not.toHaveBeenCalled();
+    expect(env.SENTRY_DSN).toBe("already-set");
+  });
+
+  it("ignores a key that doesn't end in _FILE, and a _FILE key with no value", () => {
+    const readFile = vi.fn();
+    const env: Record<string, string | undefined> = { NOT_A_SECRET: "x", EMPTY_FILE: "" };
+    loadFileSecrets(env, readFile);
+    expect(readFile).not.toHaveBeenCalled();
+  });
+
+  it("logs a structured error and leaves the target unset when the file read fails, for a genuine secret var", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const readFile = vi.fn(() => {
+      throw new Error("ENOENT");
+    });
+    const env: Record<string, string | undefined> = { SENTRY_DSN_FILE: "/run/secrets/missing" };
+    loadFileSecrets(env, readFile);
+    expect(env.SENTRY_DSN).toBeUndefined();
+    expect(errorSpy).toHaveBeenCalledWith(
+      JSON.stringify({ level: "error", event: "selfhost_secret_file_unreadable", var: "SENTRY_DSN_FILE" }),
+    );
+    errorSpy.mockRestore();
+  });
+
+  it("defaults to process.env and the real node:fs reader when called with no arguments", () => {
+    const original = process.env.NOT_A_REAL_SECRET_FILE;
+    process.env.NOT_A_REAL_SECRET_FILE = "/definitely/does/not/exist";
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    loadFileSecrets();
+    expect(errorSpy).toHaveBeenCalledWith(
+      JSON.stringify({ level: "error", event: "selfhost_secret_file_unreadable", var: "NOT_A_REAL_SECRET_FILE" }),
+    );
+    errorSpy.mockRestore();
+    if (original === undefined) delete process.env.NOT_A_REAL_SECRET_FILE;
+    else process.env.NOT_A_REAL_SECRET_FILE = original;
+  });
+});


### PR DESCRIPTION
## Summary

- `loadFileSecrets()` scans every env var ending in `_FILE` and dereferences it as a gittensory Docker-secret pointer. It had no exclusion for Docker Compose's own reserved `COMPOSE_FILE` (a colon-delimited list of compose file paths, e.g. `docker-compose.yml:docker-compose.override.yml:docker-compose.local-gpu.yml`) or `COMPOSE_ENV_FILE` — neither is ever a single readable file, so `readFileSync` always throws, logging a guaranteed-false `level:"error"` structured line on every container boot. Confirmed live on edge-nl-01 tonight (`{"level":"error","event":"selfhost_secret_file_unreadable","var":"COMPOSE_FILE"}` on every deploy).
- This undermines the convention this codebase relies on: `level:"error"` logs are the actual signal for Sentry-visible operator alerts. A guaranteed false alarm on every restart trains operators to ignore them.
- Fix: exclude both Compose-reserved `_FILE` vars by name before the dereference attempt.
- Also extracted `loadFileSecrets` into its own module (`src/selfhost/load-file-secrets.ts`), injecting `env`/`readFile` as optional params (defaulting to `process.env`/real `readFileSync`, byte-identical at runtime) — `server.ts` itself boots the entire app on import and is Codecov-ignored, so there was no way to give this fix a real runtime regression test while it lived there.

Closes #4403

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — 7 tests, 100% stmt/branch coverage on the new module, including the exact regression repro (`COMPOSE_FILE` set → no dereference attempt, no error log).
- [x] `npm run engine-parity:drift-check` — clean (this file isn't a hand-duplicated twin).

If any required check was skipped, explain why:

- No UI/MCP/OpenAPI/wrangler-binding/build-pipeline surface touched — not applicable. `test:coverage` was run targeted on the new test file (7/7 passing, 100% line/branch/function coverage on `src/selfhost/load-file-secrets.ts`) rather than the full unsharded suite.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed. (Ran the diff through the repo's own `hasGenericSecretAssignment` detector directly — clean.)
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics. (N/A — no public-facing text changed)
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A)
- [x] Visible UI changes include a `UI Evidence` section below. (N/A — no visible UI change)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (N/A)

## UI Evidence

N/A — no UI/frontend/docs-visible change.

## Notes

- Verified against real production evidence: this exact false error has been firing on every edge-nl-01 boot tonight (multiple deploys observed during unrelated work).
