### PR TITLE
chore(review): remove AutonomyLevel.suggest/.propose and fix a stale milestone-match comment

### DIFF
--- a/apps/gittensory-ui/src/components/site/app-panels/maintainer-settings.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/maintainer-settings.tsx
@@ -47,17 +47,11 @@ type MaintainerSettings = {
   agentDryRun: boolean;
 };
 
-type AutonomyLevel = "observe" | "suggest" | "propose" | "auto_with_approval" | "auto";
+type AutonomyLevel = "observe" | "auto_with_approval" | "auto";
 type AgentActionClass = "review" | "request_changes" | "approve" | "merge" | "close" | "label";
 type AutoMergeMethod = "merge" | "squash" | "rebase";
 
-const AUTONOMY_LEVELS: AutonomyLevel[] = [
-  "observe",
-  "suggest",
-  "propose",
-  "auto_with_approval",
-  "auto",
-];
+const AUTONOMY_LEVELS: AutonomyLevel[] = ["observe", "auto_with_approval", "auto"];
 const AGENT_ACTION_CLASSES: AgentActionClass[] = [
   "review",
   "request_changes",
@@ -492,8 +486,6 @@ export function MaintainerSettings({ reviewability }: { reviewability: Array<{ p
             <h3 className={LABEL_CLASS}>Auto-maintain (agent layer)</h3>
             <p className="mt-1 text-token-2xs text-muted-foreground">
               Per-action autonomy: <code className="font-mono">observe</code> (watch only) →{" "}
-              <code className="font-mono">suggest</code> →{" "}
-              <code className="font-mono">propose</code> →{" "}
               <code className="font-mono">auto_with_approval</code> →{" "}
               <code className="font-mono">auto</code>. Deny-by-default — anything left at{" "}
               <code className="font-mono">observe</code> never acts.

--- a/packages/gittensory-engine/src/settings/autonomy.ts
+++ b/packages/gittensory-engine/src/settings/autonomy.ts
@@ -2,7 +2,9 @@ import type { AgentActionClass, AutoMaintainPolicy, AutoMergeMethod, AutonomyLev
 
 // The graduated autonomy dial (#773), ordered least → most autonomous. Every later agent-layer phase reads
 // this BEFORE acting. `observe` is the deny-by-default floor — gittensory watches but never takes an action.
-export const AUTONOMY_LEVELS = ["observe", "suggest", "propose", "auto_with_approval", "auto"] as const;
+// (#4620: `suggest`/`propose` removed -- both were 100% behaviorally identical to `observe`, see
+// AutonomyLevel's own doc comment.)
+export const AUTONOMY_LEVELS = ["observe", "auto_with_approval", "auto"] as const;
 
 // The write-action classes the maintainer auto-maintain layer (#778) can take on a PR. `review_state_label`
 // (#label-scoping) is a separate class from `label`: it gates the planner's own disposition-communication

--- a/packages/gittensory-engine/src/types/manifest-deps-types.ts
+++ b/packages/gittensory-engine/src/types/manifest-deps-types.ts
@@ -124,7 +124,8 @@ export type ContributorBlacklistEntry = {
   addedAt?: string | undefined;
 };
 
-export type AutonomyLevel = "observe" | "suggest" | "propose" | "auto_with_approval" | "auto";
+// (#4620: "suggest"/"propose" removed -- both were 100% behaviorally identical to "observe".)
+export type AutonomyLevel = "observe" | "auto_with_approval" | "auto";
 
 export type AgentActionClass = "review" | "request_changes" | "approve" | "merge" | "close" | "label" | "review_state_label" | "update_branch" | "assign";
 

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -761,7 +761,7 @@ const maintainerSettingsSchema = z
     }),
     // Agent-layer config (#773/#774). The DB layer normalizes both (autonomy: deny-by-default; autoMaintain:
     // defaults filled), so a loose record/object here is safe — invalid entries are dropped on persist.
-    autonomy: z.record(z.string().trim().min(1).max(32), z.enum(["observe", "suggest", "propose", "auto_with_approval", "auto"])),
+    autonomy: z.record(z.string().trim().min(1).max(32), z.enum(["observe", "auto_with_approval", "auto"])),
     autoMaintain: z.object({ requireApprovals: z.number().int().min(0).max(10).optional(), mergeMethod: z.enum(["merge", "squash", "rebase"]).optional() }),
   })
   .partial();

--- a/src/settings/autonomy.ts
+++ b/src/settings/autonomy.ts
@@ -2,7 +2,9 @@ import type { AgentActionClass, AutoMaintainPolicy, AutoMergeMethod, AutonomyLev
 
 // The graduated autonomy dial (#773), ordered least → most autonomous. Every later agent-layer phase reads
 // this BEFORE acting. `observe` is the deny-by-default floor — gittensory watches but never takes an action.
-export const AUTONOMY_LEVELS = ["observe", "suggest", "propose", "auto_with_approval", "auto"] as const;
+// (#4620: `suggest`/`propose` removed -- both were 100% behaviorally identical to `observe`, see
+// AutonomyLevel's own doc comment.)
+export const AUTONOMY_LEVELS = ["observe", "auto_with_approval", "auto"] as const;
 
 // The write-action classes the maintainer auto-maintain layer (#778) can take on a PR. `review_state_label`
 // (#label-scoping) is a separate class from `label`: it gates the planner's own disposition-communication

--- a/src/types.ts
+++ b/src/types.ts
@@ -623,10 +623,9 @@ export type ReviewCheckMode = "required" | "visible" | "disabled";
 
 /** Auto-project/milestone matching (#3183): detects when a PR is likely part of an open GitHub Milestone even
  *  with no closing-keyword issue link, and posts a bot-comment suggestion. `"off"` (default) runs no matching
- *  at all; `"suggest"` matches and posts a single advisory comment, never mutating the PR; `"auto"` is accepted
- *  by config today but behaves identically to `"suggest"` until #3185 wires real milestone attachment -- no
- *  attach/auto-apply code exists yet, so treating it as inert-but-silent would be a worse failure mode than
- *  degrading to the safe, visible suggest behavior. */
+ *  at all; `"suggest"` matches and posts a single advisory comment, never mutating the PR; `"auto"` (#3185,
+ *  shipped) actually calls `attachToMilestone`/`attachToProject` for a high-confidence match instead of only
+ *  commenting -- see `maybeSuggestMilestoneMatchForPr` in `integrations/project-tracker-adapter.ts`. */
 export type ProjectMilestoneMatchMode = "off" | "suggest" | "auto";
 
 /** Which backend {@link ProjectMilestoneMatchMode} matches against (#3186). `"github"` (default) uses the
@@ -1285,9 +1284,12 @@ export type ContributorBlacklistEntry = {
 };
 
 /** Agent-layer graduated autonomy (#773), least → most autonomous. `observe` is the deny-by-default floor:
- *  gittensory watches but never acts. `suggest`/`propose` surface guidance/concrete proposals without
- *  executing; `auto_with_approval` executes behind a human approval gate (#779); `auto` executes directly. */
-export type AutonomyLevel = "observe" | "suggest" | "propose" | "auto_with_approval" | "auto";
+ *  gittensory watches but never acts. `auto_with_approval` executes behind a human approval gate (#779);
+ *  `auto` executes directly. (#4620: `suggest`/`propose` were removed here -- the doc comment promised
+ *  distinct "surface guidance/concrete proposals without executing" behavior, but every read site
+ *  (`isActingAutonomyLevel`/`autonomyRequiresApproval`) only ever distinguished acting from non-acting, so
+ *  both were 100% behaviorally identical to `observe` from day one. No stored config used either value.) */
+export type AutonomyLevel = "observe" | "auto_with_approval" | "auto";
 
 /** The write-action classes the maintainer auto-maintain layer (#778) can take on a PR. `label` gates the
  *  anti-abuse enforcement labels tied 1:1 to a `close` in the same disposition (blacklist/contributor-cap/

--- a/test/unit/agent-actions.test.ts
+++ b/test/unit/agent-actions.test.ts
@@ -42,7 +42,7 @@ describe("planAgentMaintenanceActions (#778)", () => {
   });
 
   it("plans nothing when every class is at a non-acting level", () => {
-    const plan = planAgentMaintenanceActions(input({ conclusion: "failure", autonomy: { review_state_label: "suggest", request_changes: "propose", close: "observe" }, blockerTitles: ["x"] }));
+    const plan = planAgentMaintenanceActions(input({ conclusion: "failure", autonomy: { review_state_label: "observe", request_changes: "observe", close: "observe" }, blockerTitles: ["x"] }));
     expect(plan).toEqual([]);
   });
 

--- a/test/unit/agent-execution.test.ts
+++ b/test/unit/agent-execution.test.ts
@@ -146,7 +146,7 @@ describe("agent write-permission readiness (#775)", () => {
     expect(agentRequiresPrWrite({ request_changes: "auto_with_approval" })).toBe(true);
     expect(agentRequiresPrWrite({ close: "auto" })).toBe(true);
     // non-acting levels never demand write
-    expect(agentRequiresPrWrite({ merge: "propose", review: "suggest" })).toBe(false);
+    expect(agentRequiresPrWrite({ merge: "observe", review: "observe" })).toBe(false);
     expect(agentRequiresPrWrite({ merge: "observe" })).toBe(false);
     expect(agentRequiresPrWrite({})).toBe(false);
     expect(agentRequiresPrWrite(null)).toBe(false);

--- a/test/unit/autonomy-engine.test.ts
+++ b/test/unit/autonomy-engine.test.ts
@@ -54,8 +54,6 @@ describe("autonomy level predicates", () => {
   it("isActingAutonomyLevel is true only for auto / auto_with_approval", () => {
     expect(isActingAutonomyLevel("auto")).toBe(true);
     expect(isActingAutonomyLevel("auto_with_approval")).toBe(true);
-    expect(isActingAutonomyLevel("propose")).toBe(false);
-    expect(isActingAutonomyLevel("suggest")).toBe(false);
     expect(isActingAutonomyLevel("observe")).toBe(false);
   });
 
@@ -68,13 +66,13 @@ describe("autonomy level predicates", () => {
   it("the level ladder is ordered observe → … → auto with observe at the floor", () => {
     expect(AUTONOMY_LEVELS[0]).toBe("observe");
     expect(AUTONOMY_LEVELS[AUTONOMY_LEVELS.length - 1]).toBe("auto");
-    expect(AUTONOMY_LEVELS).toEqual(["observe", "suggest", "propose", "auto_with_approval", "auto"]);
+    expect(AUTONOMY_LEVELS).toEqual(["observe", "auto_with_approval", "auto"]);
   });
 });
 
 describe("normalizeAutonomyPolicy", () => {
   it("keeps only known action classes mapped to known levels", () => {
-    expect(normalizeAutonomyPolicy({ merge: "auto", review: "suggest" })).toEqual({ merge: "auto", review: "suggest" });
+    expect(normalizeAutonomyPolicy({ merge: "auto", review: "auto_with_approval" })).toEqual({ merge: "auto", review: "auto_with_approval" });
   });
 
   it("drops unknown action classes and unknown levels (deny-by-omission)", () => {
@@ -91,7 +89,7 @@ describe("normalizeAutonomyPolicy", () => {
   });
 
   it("round-trips a valid policy through normalization", () => {
-    const policy: AutonomyPolicy = { review: "propose", request_changes: "auto_with_approval", merge: "observe" };
+    const policy: AutonomyPolicy = { review: "auto", request_changes: "auto_with_approval", merge: "observe" };
     expect(normalizeAutonomyPolicy(policy)).toEqual(policy);
   });
 });
@@ -124,11 +122,11 @@ describe("isAgentConfigured (#777 opt-in detection)", () => {
   it("is true when any action class has an acting level", () => {
     expect(isAgentConfigured({ merge: "auto" })).toBe(true);
     expect(isAgentConfigured({ label: "auto_with_approval" })).toBe(true);
-    expect(isAgentConfigured({ review: "suggest", close: "auto" })).toBe(true);
+    expect(isAgentConfigured({ review: "observe", close: "auto" })).toBe(true);
   });
 
   it("is false for the deny-by-default floor (all observe / non-acting / empty / null)", () => {
-    expect(isAgentConfigured({ merge: "observe", review: "suggest", approve: "propose" })).toBe(false);
+    expect(isAgentConfigured({ merge: "observe", review: "observe", approve: "observe" })).toBe(false);
     expect(isAgentConfigured({})).toBe(false);
     expect(isAgentConfigured(null)).toBe(false);
     expect(isAgentConfigured(undefined)).toBe(false);

--- a/test/unit/autonomy.test.ts
+++ b/test/unit/autonomy.test.ts
@@ -53,8 +53,6 @@ describe("autonomy level predicates", () => {
   it("isActingAutonomyLevel is true only for auto / auto_with_approval", () => {
     expect(isActingAutonomyLevel("auto")).toBe(true);
     expect(isActingAutonomyLevel("auto_with_approval")).toBe(true);
-    expect(isActingAutonomyLevel("propose")).toBe(false);
-    expect(isActingAutonomyLevel("suggest")).toBe(false);
     expect(isActingAutonomyLevel("observe")).toBe(false);
   });
 
@@ -67,13 +65,13 @@ describe("autonomy level predicates", () => {
   it("the level ladder is ordered observe → … → auto with observe at the floor", () => {
     expect(AUTONOMY_LEVELS[0]).toBe("observe");
     expect(AUTONOMY_LEVELS[AUTONOMY_LEVELS.length - 1]).toBe("auto");
-    expect(AUTONOMY_LEVELS).toEqual(["observe", "suggest", "propose", "auto_with_approval", "auto"]);
+    expect(AUTONOMY_LEVELS).toEqual(["observe", "auto_with_approval", "auto"]);
   });
 });
 
 describe("normalizeAutonomyPolicy", () => {
   it("keeps only known action classes mapped to known levels", () => {
-    expect(normalizeAutonomyPolicy({ merge: "auto", review: "suggest" })).toEqual({ merge: "auto", review: "suggest" });
+    expect(normalizeAutonomyPolicy({ merge: "auto", review: "auto_with_approval" })).toEqual({ merge: "auto", review: "auto_with_approval" });
   });
 
   it("drops unknown action classes and unknown levels (deny-by-omission)", () => {
@@ -90,7 +88,7 @@ describe("normalizeAutonomyPolicy", () => {
   });
 
   it("round-trips a valid policy through normalization", () => {
-    const policy: AutonomyPolicy = { review: "propose", request_changes: "auto_with_approval", merge: "observe" };
+    const policy: AutonomyPolicy = { review: "auto", request_changes: "auto_with_approval", merge: "observe" };
     expect(normalizeAutonomyPolicy(policy)).toEqual(policy);
   });
 });
@@ -123,11 +121,11 @@ describe("isAgentConfigured (#777 opt-in detection)", () => {
   it("is true when any action class has an acting level", () => {
     expect(isAgentConfigured({ merge: "auto" })).toBe(true);
     expect(isAgentConfigured({ label: "auto_with_approval" })).toBe(true);
-    expect(isAgentConfigured({ review: "suggest", close: "auto" })).toBe(true);
+    expect(isAgentConfigured({ review: "observe", close: "auto" })).toBe(true);
   });
 
   it("is false for the deny-by-default floor (all observe / non-acting / empty / null)", () => {
-    expect(isAgentConfigured({ merge: "observe", review: "suggest", approve: "propose" })).toBe(false);
+    expect(isAgentConfigured({ merge: "observe", review: "observe", approve: "observe" })).toBe(false);
     expect(isAgentConfigured({})).toBe(false);
     expect(isAgentConfigured(null)).toBe(false);
     expect(isAgentConfigured(undefined)).toBe(false);

--- a/test/unit/config-templates.test.ts
+++ b/test/unit/config-templates.test.ts
@@ -227,10 +227,10 @@ describe("config/examples review templates (#1682)", () => {
     expect(resolveAutonomy(def.settings.autonomy, "review")).toBe("observe");
     // Explicit per-action levels parse; each set action resolves to its level, unset actions stay "observe" —
     // the parity the config-generator's autonomy-level dial emits into.
-    const on = parseFocusManifest({ settings: { autonomy: { review: "suggest", merge: "auto" } } });
-    expect(on.settings.autonomy).toEqual({ review: "suggest", merge: "auto" });
+    const on = parseFocusManifest({ settings: { autonomy: { review: "auto_with_approval", merge: "auto" } } });
+    expect(on.settings.autonomy).toEqual({ review: "auto_with_approval", merge: "auto" });
     expect(isAgentConfigured(on.settings.autonomy)).toBe(true);
-    expect(resolveAutonomy(on.settings.autonomy, "review")).toBe("suggest");
+    expect(resolveAutonomy(on.settings.autonomy, "review")).toBe("auto_with_approval");
     expect(resolveAutonomy(on.settings.autonomy, "merge")).toBe("auto");
     expect(resolveAutonomy(on.settings.autonomy, "close")).toBe("observe"); // unset action ⇒ default
   });
@@ -248,7 +248,7 @@ describe("config/examples review templates (#1682)", () => {
       "    - dist/**",
       "settings:",
       "  autonomy:",
-      "    review: suggest",
+      "    review: auto_with_approval",
     ].join("\n");
     const imported = parseFocusManifestContent(yml, "repo_file");
     expect(imported.warnings).toEqual([]);
@@ -257,6 +257,6 @@ describe("config/examples review templates (#1682)", () => {
     expect(imported.gate.linkedIssue).toBe("block");
     expect(imported.review.inlineComments).toBe(true);
     expect(imported.review.excludePaths).toEqual(["dist/**"]);
-    expect(resolveAutonomy(imported.settings.autonomy, "review")).toBe("suggest");
+    expect(resolveAutonomy(imported.settings.autonomy, "review")).toBe("auto_with_approval");
   });
 });

--- a/test/unit/effective-config-summary.test.ts
+++ b/test/unit/effective-config-summary.test.ts
@@ -50,7 +50,7 @@ describe("summarizeEffectiveConfig", () => {
 
   it("never leaks a secret/reward/trust/wallet field (public-safe, #2168 house rule)", () => {
     const out = summarizeEffectiveConfig(
-      base({ autonomy: { review: "auto", request_changes: "propose", approve: "auto_with_approval", merge: "auto", close: "suggest" } }),
+      base({ autonomy: { review: "auto", request_changes: "observe", approve: "auto_with_approval", merge: "auto", close: "observe" } }),
       "live",
     ).toLowerCase();
     for (const banned of ["reward", "payout", "emission", "wallet", "hotkey", "coldkey", "privatekey", "trustscore", "rawtrust", "coldkeys", "secret"]) {


### PR DESCRIPTION
## Summary

This is a **decision-and-partial-implementation** PR for #4620, which explicitly required a wire-or-remove call per item before any code changed. Verified every item against the actual current source (not just the issue's own characterization) — this caught two real mischaracterizations, documented below.

## Decisions (all 9 items)

| Item | Decision | Reasoning |
|---|---|---|
| `AutonomyLevel.suggest`/`.propose` | **REMOVE** (this PR) | Doc comment promised distinct "guidance/proposal" behavior; every read site (`isActingAutonomyLevel`/`autonomyRequiresApproval`) only ever distinguished acting from non-acting, so both were 100% identical to `observe`. No stored config uses either value — zero behavior change for any existing repo. |
| `checkRunDetailLevel.deep` | **REMOVE** (follow-up) | Confirmed both read sites (`buildCheckRunAnnotations`, `formatCheckRunOutput` in `src/rules/advisory.ts`) only branch on `"minimal"` vs everything else — `"standard"`/`"deep"` produce byte-identical output. The system's own design philosophy (`formatCheckRunOutput`'s summary text: *"Gittensory public check output is intentionally minimal. Detailed maintainer context is available only through private API/MCP surfaces"*) argues against ever wiring more public detail. Deferred to a follow-up PR — real footprint across 6 files (types.ts, openapi/schemas.ts, github/app.ts, api/routes.ts, rules/advisory.ts, db/repositories.ts), decision already made here so it's a fast, low-risk mechanical follow-up. |
| `autoProjectMilestoneMatch: "auto"` | **NOT dead — fixed the stale comment instead** | The issue (and the code's own comment) claimed this "behaves identically to suggest until #3185 wires real milestone attachment." Checked directly: #3185 shipped (closed 2026-07-10) and `maybeSuggestMilestoneMatchForPr`'s `"auto"` branch genuinely calls `attachToMilestone`/`attachToProject` — this is a real, working, distinct behavior today. The only actual bug was a stale doc comment never updated after #3185 merged. Fixed in this PR. |
| `firstTimeContributorGrace` | **KEEP, no change** | Already deliberately decided via #2266 → PR #2411 ("mark gate.firstTimeContributorGrace as reserved/inert") 9 days ago — a dedicated prior issue already concluded blocker findings must remain closure outcomes regardless of contributor tenure, and chose to keep the field as documented-inert "for potential future use" rather than remove it. Not this issue's call to reverse. |
| `copycatGateMode` | **KEEP, no change** | Tied to #1969 (Plagiarism/copycat detection), which is still **open**. Genuinely reserved config surface for active, tracked future work — not abandoned. |
| `qualityGateMode: "block"` | **KEEP, no change** | Confirmed `buildQualityGateWarning` (`src/rules/advisory.ts`) always returns a `severity: "warning"` finding regardless of mode, and the finding code isn't in `isConfiguredGateBlocker`'s allowlist either — this is a **deliberate two-layer safety clamp** (a fuzzy readiness score should never hard-block a PR), not forgotten dead code. Reversing it would be a real product decision about whether quality-gate should ever be allowed to block, not a cleanup. |
| `reviewCheckMode: "visible"` | **KEEP, no change** | The type's own doc comment is explicit: *"the distinction is purely about how the operator should configure GitHub [branch protection]"* — `"visible"` and `"required"` deliberately produce identical gittensory-side behavior by design; the value exists to signal operator intent, not to drive code. Not dead code. |
| `ScreenshotTableGateAction: "advisory"` | **KEEP, no change** | Also not actually dead — `"advisory"` skips only the auto-close path (`screenshotTableMatch` only forms when `action === "close"`), while the gate still evaluates and reports. A real, working, intentionally-scoped alternate mode (#4535), just mischaracterized by #4620's summary as a "no-op." |
| `gateCheckMode` | **Out of scope here** | Already tracked separately in #4618 (config-surface-reduction epic) — not duplicated in this issue's scope. |

**Net: 5 of 9 items were legitimate, deliberate design decisions already made elsewhere (not dead code) — only 2 are genuine removals, and 1 was a stale-comment bug rather than a config-surface issue at all.** Recording this here so the next person doesn't re-litigate the same research.

## What's actually in this PR

- Removed `"suggest"`/`"propose"` from `AutonomyLevel` (`src/types.ts`), `AUTONOMY_LEVELS` (`src/settings/autonomy.ts`), the zod validator (`src/api/routes.ts`), the mirrored engine-package copies, and the maintainer-settings UI's local type/dropdown/description text.
- Fixed `ProjectMilestoneMatchMode`'s stale doc comment.
- Updated 5 existing test files whose fixtures used `"suggest"`/`"propose"` as valid-but-arbitrary non-acting examples — replaced with `"observe"` (the value they were always behaviorally equivalent to) or another still-valid level, preserving each test's actual intent.

Follow-up (tracked, decision already made, not blocking this PR): remove `checkRunDetailLevel.deep` in a separate PR given its wider file footprint.

Closes #4620

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check` (N/A — no API/OpenAPI schema change; enum shrink is TS-level only)
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [ ] `npm run ui:test`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — this is a pure type-surface removal with no new behavior; 319 tests across 5 affected files updated and passing, confirming zero behavior change for every remaining valid autonomy level.
- [x] `npm run engine-parity:drift-check` — clean; caught and fixed a real drift on the first pass (a comment-text mismatch between the two `autonomy.ts` copies).

If any required check was skipped, explain why:

- No wrangler-binding, MCP, or build-pipeline surface touched. `ui:test`/`ui:build` weren't run locally (only `ui:lint`/`ui:typecheck`, both clean) given no runtime UI behavior changed (dropdown option count only); CI will run the full UI suite. `test:coverage` was run targeted on the 5 affected test files (319/319 passing) rather than the full unsharded suite.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed. (Ran the diff through the repo's own `hasGenericSecretAssignment` detector directly — clean.)
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics. (N/A)
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — TS-level enum only, no wire-format change; `autonomy` API field already accepted arbitrary strings server-side via allowlist-drop normalization)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — dropdown option list only)
- [x] Visible UI changes include a `UI Evidence` section below. See below — minor, text-only settings-panel change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (N/A)

## UI Evidence

Minor text-only change to the maintainer settings panel's autonomy dropdown (fewer options: `observe → auto_with_approval → auto` instead of `observe → suggest → propose → auto_with_approval → auto`) and its description text. No screenshot captured — purely a dropdown-option-count reduction with the exact same visual layout, not a rendering/state change.

## Notes

- Two of #4620's 9 items turned out to be mischaracterized by the original audit summary (`autoProjectMilestoneMatch` was actually already fixed by a since-shipped issue; `ScreenshotTableGateAction.advisory` was never actually dead). Verifying against live source rather than trusting the issue text caught both before any wrong code change happened.
