### PR TITLE
chore(review): remove dead checkRunDetailLevel.deep (#4620)

### DIFF
--- a/apps/gittensory-ui/public/openapi.json
+++ b/apps/gittensory-ui/public/openapi.json
@@ -8732,8 +8732,7 @@
             "type": "string",
             "enum": [
               "minimal",
-              "standard",
-              "deep"
+              "standard"
             ]
           },
           "gateCheckMode": {
@@ -10138,8 +10137,7 @@
                 "type": "string",
                 "enum": [
                   "minimal",
-                  "standard",
-                  "deep"
+                  "standard"
                 ]
               },
               "gateCheckMode": {
@@ -10655,8 +10653,7 @@
                 "type": "string",
                 "enum": [
                   "minimal",
-                  "standard",
-                  "deep"
+                  "standard"
                 ]
               }
             },

--- a/apps/gittensory-ui/src/components/site/app-panels/maintainer-panel.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/maintainer-panel.tsx
@@ -716,7 +716,7 @@ export function PreviewResult({
 
       {preview.checkRun?.willCreate ? (
         <CheckRunReadinessTable
-          detailLevel={preview.checkRun.detailLevel as "minimal" | "standard" | "deep"}
+          detailLevel={preview.checkRun.detailLevel as "minimal" | "standard"}
           readiness={preview.checkRunReadiness}
         />
       ) : null}

--- a/apps/gittensory-ui/src/components/site/app-panels/maintainer-settings.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/maintainer-settings.tsx
@@ -20,7 +20,7 @@ type MaintainerSettings = {
   publicSignalLevel: "minimal" | "standard";
   publicSurface: "off" | "comment_and_label" | "comment_only" | "label_only";
   checkRunMode: "off" | "enabled";
-  checkRunDetailLevel: "minimal" | "standard" | "deep";
+  checkRunDetailLevel: "minimal" | "standard";
   // #4618: gateCheckMode is deprecated (a computed read-back value only) -- reviewCheckMode is the real,
   // writable authority for whether the review-agent check-run publishes.
   reviewCheckMode: "required" | "visible" | "disabled";
@@ -266,7 +266,6 @@ const SURFACE_FIELDS: FieldDef[] = [
     options: [
       ["minimal", "minimal"],
       ["standard", "standard"],
-      ["deep", "deep"],
     ],
   },
   { key: "includeMaintainerAuthors", label: "Include maintainer-authored PRs", kind: "toggle" },

--- a/apps/gittensory-ui/src/components/site/check-run-readiness-model.ts
+++ b/apps/gittensory-ui/src/components/site/check-run-readiness-model.ts
@@ -2,7 +2,7 @@
 // details slice — mirrors the public-safe band shape from buildExtensionPrStatus (src/signals/
 // extension-contributor-context.ts) so the UI never renders raw readiness scores.
 
-export type CheckRunDetailLevel = "minimal" | "standard" | "deep";
+export type CheckRunDetailLevel = "minimal" | "standard";
 
 export type ReadinessComponentBand = "met" | "partial" | "unmet";
 

--- a/apps/gittensory-ui/src/components/site/check-run-readiness-table.test.tsx
+++ b/apps/gittensory-ui/src/components/site/check-run-readiness-table.test.tsx
@@ -22,10 +22,9 @@ const SAMPLE: CheckRunReadinessTableData = {
 };
 
 describe("shouldShowCheckRunReadinessTable", () => {
-  it("shows at standard and deep, hides at minimal", () => {
+  it("shows at standard, hides at minimal", () => {
     expect(shouldShowCheckRunReadinessTable("minimal")).toBe(false);
     expect(shouldShowCheckRunReadinessTable("standard")).toBe(true);
-    expect(shouldShowCheckRunReadinessTable("deep")).toBe(true);
   });
 });
 
@@ -34,10 +33,9 @@ describe("resolveCheckRunReadinessView", () => {
     expect(resolveCheckRunReadinessView({ detailLevel: "minimal", readiness: SAMPLE })).toBeNull();
   });
 
-  it("returns null for an empty readiness component set at standard (both gate-off and gate-on shapes)", () => {
+  it("returns null for an empty readiness component set at standard", () => {
     const empty: CheckRunReadinessTableData = { readinessBand: "early", components: [] };
     expect(resolveCheckRunReadinessView({ detailLevel: "standard", readiness: empty })).toBeNull();
-    expect(resolveCheckRunReadinessView({ detailLevel: "deep", readiness: empty })).toBeNull();
   });
 
   it("returns the readiness payload at standard when components are present", () => {

--- a/packages/gittensory-engine/src/focus-manifest.ts
+++ b/packages/gittensory-engine/src/focus-manifest.ts
@@ -1712,7 +1712,7 @@ function parseSettingsOverride(value: JsonValue | undefined, warnings: string[],
   if (publicSignalLevel !== null) out.publicSignalLevel = publicSignalLevel;
   const checkRunMode = normalizeOptionalEnum(r.checkRunMode, "settings.checkRunMode", ["off", "enabled"] as const, warnings);
   if (checkRunMode !== null) out.checkRunMode = checkRunMode;
-  const checkRunDetailLevel = normalizeOptionalEnum(r.checkRunDetailLevel, "settings.checkRunDetailLevel", ["minimal", "standard", "deep"] as const, warnings);
+  const checkRunDetailLevel = normalizeOptionalEnum(r.checkRunDetailLevel, "settings.checkRunDetailLevel", ["minimal", "standard"] as const, warnings);
   if (checkRunDetailLevel !== null) out.checkRunDetailLevel = checkRunDetailLevel;
   // #4618: gateCheckMode is deprecated (a computed read-back value everywhere else) but this yml key still
   // parses for back-compat with existing `.gittensory.yml` files. A manifest setting ONLY gateCheckMode

--- a/packages/gittensory-engine/src/types/manifest-deps-types.ts
+++ b/packages/gittensory-engine/src/types/manifest-deps-types.ts
@@ -143,7 +143,7 @@ export type RepositorySettings = {
   publicAudienceMode: "oss_maintainer" | "gittensor_only";
   publicSignalLevel: "minimal" | "standard";
   checkRunMode: "off" | "enabled";
-  checkRunDetailLevel: "minimal" | "standard" | "deep";
+  checkRunDetailLevel: "minimal" | "standard";
   gateCheckMode: "off" | "enabled";
   /** Scheduled re-gate sweep candidate ordering (#3815). `staleness` (default) picks whichever open PR the
    *  sweep has gone longest WITHOUT re-gating (see selectRegateCandidates), which is what gives the sweep its

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -667,7 +667,7 @@ const repositorySettingsSchema = z.object({
   // Matches repository_settings.check_run_detail_level's own column default (#2907) -- the Context check's
   // public output is intentionally minimal by design (see formatCheckRunOutput's doc comment), so a caller of
   // this full-replace route that omits this field must land on the same safe default as a never-configured row.
-  checkRunDetailLevel: z.enum(["minimal", "standard", "deep"]).default("minimal"),
+  checkRunDetailLevel: z.enum(["minimal", "standard"]).default("minimal"),
   regateSweepOrderMode: z.enum(["staleness", "oldest-first"]).default("staleness"),
   // #4618: gateCheckMode dropped from this write schema -- it is a computed read-back value only (see its
   // doc comment on RepositorySettings). Set reviewCheckMode directly.
@@ -720,7 +720,7 @@ const maintainerSettingsSchema = z
     publicSignalLevel: z.enum(["minimal", "standard"]),
     publicSurface: z.enum(["off", "comment_and_label", "comment_only", "label_only"]),
     checkRunMode: z.enum(["off", "enabled"]),
-    checkRunDetailLevel: z.enum(["minimal", "standard", "deep"]),
+    checkRunDetailLevel: z.enum(["minimal", "standard"]),
     regateSweepOrderMode: z.enum(["staleness", "oldest-first"]),
     reviewCheckMode: z.enum(["required", "visible", "disabled"]),
     gatePack: z.enum(["gittensor", "oss-anti-slop"]),

--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -7344,8 +7344,9 @@ function parseCheckRunMode(value: string): RepositorySettings["checkRunMode"] {
 }
 
 function parseCheckRunDetailLevel(value: string): RepositorySettings["checkRunDetailLevel"] {
-  if (value === "minimal" || value === "deep") return value;
-  return "standard";
+  // #4620: a pre-#4620 row persisted as "deep" degrades to "standard" here -- the two were always
+  // behaviorally identical (see the type's own doc comment), so this is a display-only fallback.
+  return value === "minimal" ? "minimal" : "standard";
 }
 
 function parseRegateSweepOrderMode(value: string): RepositorySettings["regateSweepOrderMode"] {

--- a/src/github/app.ts
+++ b/src/github/app.ts
@@ -697,7 +697,7 @@ export async function createOrUpdateCheckRun(
   installationId: number,
   repoFullName: string,
   advisory: Advisory,
-  detailLevel: "minimal" | "standard" | "deep" = "minimal",
+  detailLevel: "minimal" | "standard" = "minimal",
   annotationContext?: CheckRunAnnotationContext,
   mode: AgentActionMode = "live",
 ): Promise<CheckRunOutcome | null> {

--- a/src/openapi/schemas.ts
+++ b/src/openapi/schemas.ts
@@ -669,7 +669,7 @@ export const RepositorySettingsSchema = z
     publicAudienceMode: z.enum(["oss_maintainer", "gittensor_only"]),
     publicSignalLevel: z.enum(["minimal", "standard"]),
     checkRunMode: z.enum(["off", "enabled"]),
-    checkRunDetailLevel: z.enum(["minimal", "standard", "deep"]),
+    checkRunDetailLevel: z.enum(["minimal", "standard"]),
     gateCheckMode: z.enum(["off", "enabled"]),
     regateSweepOrderMode: z.enum(["staleness", "oldest-first"]),
     reviewCheckMode: z.enum(["required", "visible", "disabled"]),
@@ -848,7 +848,7 @@ export const RepoSettingsPreviewSchema = z
       publicAudienceMode: z.enum(["oss_maintainer", "gittensor_only"]),
       publicSignalLevel: z.enum(["minimal", "standard"]),
       checkRunMode: z.enum(["off", "enabled"]),
-      checkRunDetailLevel: z.enum(["minimal", "standard", "deep"]),
+      checkRunDetailLevel: z.enum(["minimal", "standard"]),
       gateCheckMode: z.enum(["off", "enabled"]),
       regateSweepOrderMode: z.enum(["staleness", "oldest-first"]),
       reviewCheckMode: z.enum(["required", "visible", "disabled"]),
@@ -943,7 +943,7 @@ export const RepoSettingsPreviewSchema = z
       .object({
         willCreate: z.boolean(),
         title: z.string(),
-        detailLevel: z.enum(["minimal", "standard", "deep"]),
+        detailLevel: z.enum(["minimal", "standard"]),
       })
       .nullable(),
     checkRunReadiness: z

--- a/src/rules/advisory.ts
+++ b/src/rules/advisory.ts
@@ -382,7 +382,7 @@ function annotatablePullRequestFiles(files: PullRequestFileRecord[]): PullReques
 export function buildCheckRunAnnotations(
   advisoryResult: Advisory,
   annotationContext: CheckRunAnnotationContext | undefined,
-  detailLevel: "minimal" | "standard" | "deep" = "minimal",
+  detailLevel: "minimal" | "standard" = "minimal",
 ): CheckRunAnnotationBuildResult {
   if (detailLevel === "minimal" || !annotationContext) {
     return { annotations: [], omittedCount: 0 };
@@ -462,7 +462,7 @@ export function buildCheckRunAnnotations(
 
 export function formatCheckRunOutput(
   advisoryResult: Advisory,
-  detailLevel: "minimal" | "standard" | "deep" = "minimal",
+  detailLevel: "minimal" | "standard" = "minimal",
   annotationContext?: CheckRunAnnotationContext,
 ): CheckRunOutput {
   const title = advisoryResult.conclusion === "success" ? "Gittensory context checked" : "Gittensory context posted";

--- a/src/types.ts
+++ b/src/types.ts
@@ -704,7 +704,9 @@ export type RepositorySettings = {
   publicAudienceMode: "oss_maintainer" | "gittensor_only";
   publicSignalLevel: "minimal" | "standard";
   checkRunMode: "off" | "enabled";
-  checkRunDetailLevel: "minimal" | "standard" | "deep";
+  // #4620: "deep" removed -- it was never wired to any different behavior than "standard" (formatCheckRunOutput
+  // and buildCheckRunAnnotations in rules/advisory.ts both branch only on `=== "minimal"` vs not).
+  checkRunDetailLevel: "minimal" | "standard";
   /** Legacy shadow of {@link reviewCheckMode} (#2852), deprecated (#4618): a computed read-back value only,
    *  for API/dashboard back-compat display. `"enabled"` when `reviewCheckMode !== "disabled"`, else `"off"`
    *  -- see getRepositorySettings/upsertRepositorySettings in db/repositories.ts. No write path accepts this

--- a/test/integration/routes-errors.test.ts
+++ b/test/integration/routes-errors.test.ts
@@ -1170,14 +1170,14 @@ describe("api route guards and error branches", () => {
         body: JSON.stringify({
           commentMode: "all_prs",
           publicSignalLevel: "minimal",
-          checkRunDetailLevel: "deep",
+          checkRunDetailLevel: "standard",
           backfillEnabled: false,
         }),
       },
       env,
     );
     expect(updated.status).toBe(200);
-    await expect(updated.json()).resolves.toMatchObject({ commentMode: "all_prs", checkRunDetailLevel: "deep", backfillEnabled: false });
+    await expect(updated.json()).resolves.toMatchObject({ commentMode: "all_prs", checkRunDetailLevel: "standard", backfillEnabled: false });
   });
 });
 

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -1933,7 +1933,7 @@ describe("parseFocusManifest settings override + resolveEffectiveSettings", () =
         publicAudienceMode: "gittensor_only",
         publicSignalLevel: "minimal",
         checkRunMode: "enabled",
-        checkRunDetailLevel: "deep",
+        checkRunDetailLevel: "standard",
         gateCheckMode: "enabled",
         linkedIssueGateMode: "block",
         duplicatePrGateMode: "off",
@@ -1955,7 +1955,7 @@ describe("parseFocusManifest settings override + resolveEffectiveSettings", () =
       publicAudienceMode: "gittensor_only",
       publicSignalLevel: "minimal",
       checkRunMode: "enabled",
-      checkRunDetailLevel: "deep",
+      checkRunDetailLevel: "standard",
       gateCheckMode: "enabled",
       // #4618: gateCheckMode is deprecated -- setting it alone (no explicit reviewCheckMode) still derives
       // reviewCheckMode, so its historical effect on the actual publish authority is preserved.

--- a/test/unit/policy-sanitizer.test.ts
+++ b/test/unit/policy-sanitizer.test.ts
@@ -563,7 +563,7 @@ describe("validation guidance sanitizer", () => {
     const preview = buildRepoSettingsPreview({env: {},
       repoFullName: repo.fullName,
       repo,
-      settings: settingsFor(repo.fullName, { checkRunMode: "enabled", checkRunDetailLevel: "deep" }),
+      settings: settingsFor(repo.fullName, { checkRunMode: "enabled", checkRunDetailLevel: "standard" }),
       installation: previewHealthyInstall,
       issues: [],
       pullRequests: [],

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -777,10 +777,6 @@ describe("advisory rules", () => {
     const standard = formatCheckRunOutput(advisory, "standard");
     expect(standard.text).not.toContain("No detailed findings are published");
     expect(standard.text).toMatch(/⚠️|ℹ️/);
-
-    const deep = formatCheckRunOutput(advisory, "deep");
-    expect(deep.text).not.toContain("No detailed findings are published");
-    expect(deep.text).toMatch(/⚠️|ℹ️/);
   });
 
   it("formatCheckRunOutput sanitizes forbidden terms at every detail level", () => {
@@ -798,7 +794,7 @@ describe("advisory rules", () => {
         },
       ],
     };
-    for (const level of ["minimal", "standard", "deep"] as const) {
+    for (const level of ["minimal", "standard"] as const) {
       const out = formatCheckRunOutput(poisoned, level);
       expect(out.title).not.toMatch(/rewards?|wallets?|hotkeys?|trust score|score estimate|reviewability|scoreability|farming/i);
       expect(out.summary).not.toMatch(/rewards?|wallets?|hotkeys?|trust score|score estimate|reviewability|scoreability|farming/i);
@@ -829,7 +825,7 @@ describe("advisory rules", () => {
           },
         ],
       },
-      "deep",
+      "standard",
     );
 
     expect(output.text).toContain("Safe public repo context");
@@ -1147,7 +1143,7 @@ describe("advisory rules", () => {
       ],
     };
 
-    const { annotations } = buildCheckRunAnnotations(advisory, { files, collisions, pullNumber: 15 }, "deep");
+    const { annotations } = buildCheckRunAnnotations(advisory, { files, collisions, pullNumber: 15 }, "standard");
     expect(annotations.some((entry) => entry.annotation_level === "notice" && entry.title === "Configured lane")).toBe(true);
     expect(annotations.some((entry) => entry.annotation_level === "warning" && entry.title === "Queue pressure")).toBe(true);
     expect(annotations.some((entry) => entry.title === "   ")).toBe(false);
@@ -1171,11 +1167,11 @@ describe("advisory rules", () => {
       clusters: [],
     };
 
-    const { annotations, omittedCount } = buildCheckRunAnnotations(advisory, { files, collisions, pullNumber: 99 }, "deep");
+    const { annotations, omittedCount } = buildCheckRunAnnotations(advisory, { files, collisions, pullNumber: 99 }, "standard");
     expect(annotations).toHaveLength(CHECK_RUN_ANNOTATION_LIMIT);
     expect(omittedCount).toBe(5);
 
-    const output = formatCheckRunOutput(advisory, "deep", { files, collisions, pullNumber: 99 });
+    const output = formatCheckRunOutput(advisory, "standard", { files, collisions, pullNumber: 99 });
     expect(output.annotations).toHaveLength(CHECK_RUN_ANNOTATION_LIMIT);
     expect(output.text).toContain("…5 more hotspot annotation(s) omitted from inline check output.");
   });


### PR DESCRIPTION
## Summary

Follow-up to #4620's dead-config audit. `checkRunDetailLevel: "deep"` was never wired to any different behavior than `"standard"` — verified both consumers (`formatCheckRunOutput` and `buildCheckRunAnnotations` in `src/rules/advisory.ts`) branch only on `detailLevel === "minimal"` vs not, with zero code path distinguishing `"standard"` from `"deep"`. A repo configured to `"deep"` has always rendered byte-identical check-run output to `"standard"`.

- Removed the value from `RepositorySettings["checkRunDetailLevel"]`, both settings-write API schemas, the yml `settings.checkRunDetailLevel` parser (engine package), and the maintainer dashboard's detail-level select.
- `parseCheckRunDetailLevel` now degrades any non-`"minimal"` persisted value (including a pre-existing `"deep"` row) to `"standard"` on read — no DB migration needed since the two were already behaviorally identical.
- Mirrored the type change in the UI's `CheckRunDetailLevel` type and its readiness-table helpers.

## Test plan
- [x] `npx tsc --noEmit` (root + `apps/gittensory-ui`) — clean
- [x] Full unit + integration suite: 686 files / 13,644 tests passing
- [x] `npm run engine-parity:drift-check`, `npm run ui:openapi:check` (regenerated `openapi.json`), `npm run ui:openapi:settings-parity`, `npm run docs:drift-check`, `npm run manifest:drift-check` — all pass
- [x] `npm run ui:lint` (0 errors) + UI test suite + `npm audit --audit-level=moderate` (0 vulnerabilities)