### PR TITLE
refactor(rees): promote reconstructOldContent into a shared analyzer helper

### DIFF
--- a/review-enrichment/src/analyzers/doc-comment-drift.ts
+++ b/review-enrichment/src/analyzers/doc-comment-drift.ts
@@ -6,6 +6,7 @@
 // non-finding. Deliberately conservative: only NAMED `function` declarations whose parameters are confidently
 // enumerable (any destructuring / non-identifier param → skip the function). Reports symbol + stale params + line.
 import type { EnrichRequest, DocCommentDriftFinding } from "../types.js";
+import { reconstructOldContent } from "./reconstruct-old-content.js";
 
 const MAX_FILES = 20;
 const MAX_FINDINGS = 50;
@@ -49,47 +50,6 @@ async function readBoundedText(resp: Response, signal?: AbortSignal): Promise<st
   } finally {
     reader.releaseLock();
   }
-}
-
-/** Reconstruct the pre-PR content of a file by reverse-applying its unified `patch` to the post-PR `newContent`:
- *  context and removed (`-`) lines rebuild the old text; added (`+`) lines are dropped. Returns null if a hunk's
- *  position runs past the content (so the caller falls back to "no old parameters" and reports nothing). Pure. */
-export function reconstructOldContent(newContent: string, patch: string): string | null {
-  const newLines = newContent.split("\n");
-  const patchLines = patch.split("\n");
-  const out: string[] = [];
-  let cursor = 0; // next unconsumed index into newLines
-  let i = 0;
-  while (i < patchLines.length) {
-    const header = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(patchLines[i]!);
-    if (!header) {
-      i += 1;
-      continue;
-    }
-    const hunkStart = Number(header[1]) - 1; // 0-based new-file line the hunk begins at
-    if (hunkStart < cursor || hunkStart > newLines.length) return null;
-    while (cursor < hunkStart) out.push(newLines[cursor++]!); // unchanged lines before the hunk
-    i += 1;
-    while (i < patchLines.length && !patchLines[i]!.startsWith("@@")) {
-      const l = patchLines[i]!;
-      if (!l.startsWith("\\")) {
-        const sign = l[0];
-        const body = l.slice(1);
-        if (sign === "-") {
-          out.push(body); // removed: present in old only
-        } else {
-          // added or context lines must match the fetched head content at the cursor; a mismatch means the patch
-          // doesn't align with `newContent` (malformed/truncated input) → bail so we never trust a bad old signature.
-          if (newLines[cursor] !== body) return null;
-          if (sign !== "+") out.push(body); // context is present in old too; an added line is not
-          cursor += 1;
-        }
-      }
-      i += 1;
-    }
-  }
-  while (cursor < newLines.length) out.push(newLines[cursor++]!);
-  return out.join("\n");
 }
 
 /** Map every named `function NAME` declaration in `content` to its enumerable parameter-name set. A function whose

--- a/review-enrichment/src/analyzers/exhaustiveness-drift.ts
+++ b/review-enrichment/src/analyzers/exhaustiveness-drift.ts
@@ -5,7 +5,7 @@
 // file-fetch caps; fail-safe on missing token/headSha, bad slug, or fetch errors.
 import type { EnrichRequest, ExhaustivenessFinding } from "../types.js";
 import { githubHeaders } from "../github-headers.js";
-import { reconstructOldContent } from "./doc-comment-drift.js";
+import { reconstructOldContent } from "./reconstruct-old-content.js";
 import { isDiffFileHeaderLine } from "./diff-lines.js";
 import { isTestPath } from "./test-ratio.js";
 import { DEFAULT_MAX_FINDINGS } from "./limits.js";

--- a/review-enrichment/src/analyzers/reconstruct-old-content.ts
+++ b/review-enrichment/src/analyzers/reconstruct-old-content.ts
@@ -1,0 +1,71 @@
+// Shared unified-diff reverse-patch reconstruction (#4739, part of epic #4737). Originally private to
+// doc-comment-drift.ts (#1519) and imported cross-file from there by exhaustiveness-drift.ts (#2028) — a
+// one-off trick living in the wrong place rather than shared infrastructure. Promoted here, unchanged in
+// behavior, so any analyzer can recover a changed file's pre-PR text without re-deriving this.
+//
+// Cost note: this function does no I/O. The caller must already have fetched the file's post-change
+// (`headSha`) content — the same authed GitHub contents-API fetch every current caller already performs
+// for its own purposes — and pass it in as `newContent`. Promoting the reverse-patch algorithm out of
+// doc-comment-drift.ts does not add a new network call.
+//
+// Binary files: this function only ever sees two text blobs (`newContent`, `patch`) and has no file path
+// or extension to inspect, so it cannot itself detect a binary file. That filtering happens one layer up:
+// every current caller only invokes this after confirming the file's patch is present and its path
+// matches a known source extension (GitHub omits `.patch` entirely for binary/oversized files, so a
+// binary path never reaches here in practice). A future caller must keep doing that same source/extension
+// filtering before calling this — it is not this function's job to guess from content alone.
+
+/** Reconstruct the pre-PR content of a file by reverse-applying its unified `patch` to the post-PR
+ *  `newContent`: context and removed (`-`) lines rebuild the old text; added (`+`) lines are dropped.
+ *
+ *  Returns `null` when the patch cannot be reverse-applied against the given `newContent` — a hunk starts
+ *  before the cursor or past the end of the content, or an added/context line doesn't match `newContent`
+ *  at the expected position (a malformed/truncated patch, or a `newContent` that doesn't correspond to
+ *  the same ref the patch was computed against).
+ *
+ *  Returns an empty string when the patch reverse-applies cleanly but yields zero pre-PR lines — the case
+ *  for a file that did not exist before this PR (a "wholly added" patch has no old-side content to
+ *  rebuild). An empty string and `null` are both falsy; every caller should treat either as "no usable
+ *  before-content for this file" via a plain truthiness check (`if (!beforeContent) …`), not a strict
+ *  `=== null` comparison — the two are operationally the same "nothing to compare against" outcome, and
+ *  patch data alone cannot (and need not) distinguish a brand-new file from a pre-existing 0-byte one.
+ *
+ *  Pure — no I/O, no dependency on `path` or any other file metadata. */
+export function reconstructOldContent(newContent: string, patch: string): string | null {
+  const newLines = newContent.split("\n");
+  const patchLines = patch.split("\n");
+  const out: string[] = [];
+  let cursor = 0; // next unconsumed index into newLines
+  let i = 0;
+  while (i < patchLines.length) {
+    const header = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(patchLines[i]!);
+    if (!header) {
+      i += 1;
+      continue;
+    }
+    const hunkStart = Number(header[1]) - 1; // 0-based new-file line the hunk begins at
+    if (hunkStart < cursor || hunkStart > newLines.length) return null;
+    while (cursor < hunkStart) out.push(newLines[cursor++]!); // unchanged lines before the hunk
+    i += 1;
+    while (i < patchLines.length && !patchLines[i]!.startsWith("@@")) {
+      const l = patchLines[i]!;
+      if (!l.startsWith("\\")) {
+        const sign = l[0];
+        const body = l.slice(1);
+        if (sign === "-") {
+          out.push(body); // removed: present in old only
+        } else {
+          // added or context lines must match the fetched head content at the cursor; a mismatch means the patch
+          // doesn't align with `newContent` (malformed/truncated input, or a different ref) → bail so we never
+          // trust a reconstructed result that isn't provably faithful to the real pre-PR file.
+          if (newLines[cursor] !== body) return null;
+          if (sign !== "+") out.push(body); // context is present in old too; an added line is not
+          cursor += 1;
+        }
+      }
+      i += 1;
+    }
+  }
+  while (cursor < newLines.length) out.push(newLines[cursor++]!);
+  return out.join("\n");
+}

--- a/review-enrichment/test/doc-comment-drift.test.ts
+++ b/review-enrichment/test/doc-comment-drift.test.ts
@@ -3,7 +3,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
-  reconstructOldContent,
   extractFunctionParams,
   parseDocParams,
   parseFunctionParams,
@@ -25,12 +24,6 @@ const oldParams = (entries) => new Map(entries.map(([name, ids]) => [name, new S
 
 const DRIFTED = `/**\n * @param oldName the old one\n */\nexport function doThing(newName) {\n  return newName;\n}\n`;
 const DRIFT_PATCH = `@@ -1,6 +1,6 @@\n /**\n  * @param oldName the old one\n  */\n-export function doThing(oldName) {\n+export function doThing(newName) {\n   return newName;\n }`;
-
-test("reconstructOldContent: reverse-applies a patch to rebuild the pre-PR file", () => {
-  const old = reconstructOldContent(DRIFTED, DRIFT_PATCH);
-  assert.match(old, /function doThing\(oldName\)/); // the old parameter name is restored
-  assert.doesNotMatch(old, /newName\) \{/); // the added signature line is dropped
-});
 
 test("extractFunctionParams: maps each enumerable named function to its parameter set", () => {
   const map = extractFunctionParams(`export function f(a, b) {}\nfunction g({ x }) {}\nfunction h(c) {}\n`);
@@ -63,25 +56,6 @@ test("extractFunctionParams: strips a TS type annotation and a default value fro
 test("extractFunctionParams: skips a TS `this` pseudo-parameter, keeping the real args", () => {
   const map = extractFunctionParams("function qux(this: T, a) {}\n");
   assert.deepEqual([...map.get("qux")], ["a"]);
-});
-
-test("reconstructOldContent: bails (null) when the patch context does not match the head content", () => {
-  // The context line ` other` doesn't exist in newContent → misaligned patch → fail closed.
-  assert.equal(reconstructOldContent(`a\nb\n`, `@@ -1,2 +1,2 @@\n-x\n+a\n other`), null);
-});
-
-test("reconstructOldContent: rebuilds across MULTIPLE hunks, filling the unchanged gap between them", () => {
-  // new file: a / X / c / d. Hunk 1 changed Y→X (line 2); hunk 2 changed D→d (line 4); `c` is the untouched gap.
-  const old = reconstructOldContent(
-    `a\nX\nc\nd\n`,
-    `@@ -1,2 +1,2 @@\n a\n-Y\n+X\n@@ -4,1 +4,1 @@\n-D\n+d`,
-  );
-  assert.equal(old, `a\nY\nc\nD\n`);
-});
-
-test("reconstructOldContent: bails (null) when a hunk starts beyond the head content's length", () => {
-  // A hunk anchored at line 99 of a 2-line file can't align → fail closed rather than fabricate old content.
-  assert.equal(reconstructOldContent(`a\nb\n`, `@@ -99,1 +99,1 @@\n a`), null);
 });
 
 test("findDocCommentDrift: a duplicate-named function is skipped (no cross-declaration false positive)", () => {

--- a/review-enrichment/test/reconstruct-old-content.test.ts
+++ b/review-enrichment/test/reconstruct-old-content.test.ts
@@ -1,0 +1,83 @@
+// Units for the shared reverse-patch reconstruction helper (#4739, part of epic #4737). Own file (not
+// doc-comment-drift.test.ts / exhaustiveness-drift.test.ts) now that the function lives in its own
+// module and is consumed by both of those analyzers. Runs against the compiled dist/.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { reconstructOldContent } from "../dist/analyzers/reconstruct-old-content.js";
+
+// The four tests below are relocated verbatim from doc-comment-drift.test.ts (this function's prior home)
+// as part of #4739's extraction — same fixtures, same assertions, zero behavior change.
+
+test("reconstructOldContent: reverse-applies a patch to rebuild the pre-PR file", () => {
+  const DRIFTED = `/**\n * @param oldName the old one\n */\nexport function doThing(newName) {\n  return newName;\n}\n`;
+  const DRIFT_PATCH = `@@ -1,6 +1,6 @@\n /**\n  * @param oldName the old one\n  */\n-export function doThing(oldName) {\n+export function doThing(newName) {\n   return newName;\n }`;
+  const old = reconstructOldContent(DRIFTED, DRIFT_PATCH);
+  assert.match(old, /function doThing\(oldName\)/); // the old parameter name is restored
+  assert.doesNotMatch(old, /newName\) \{/); // the added signature line is dropped
+});
+
+test("reconstructOldContent: bails (null) when the patch context does not match the head content", () => {
+  // The context line ` other` doesn't exist in newContent → misaligned patch → fail closed.
+  assert.equal(reconstructOldContent(`a\nb\n`, `@@ -1,2 +1,2 @@\n-x\n+a\n other`), null);
+});
+
+test("reconstructOldContent: rebuilds across MULTIPLE hunks, filling the unchanged gap between them", () => {
+  // new file: a / X / c / d. Hunk 1 changed Y→X (line 2); hunk 2 changed D→d (line 4); `c` is the untouched gap.
+  const old = reconstructOldContent(
+    `a\nX\nc\nd\n`,
+    `@@ -1,2 +1,2 @@\n a\n-Y\n+X\n@@ -4,1 +4,1 @@\n-D\n+d`,
+  );
+  assert.equal(old, `a\nY\nc\nD\n`);
+});
+
+test("reconstructOldContent: bails (null) when a hunk starts beyond the head content's length", () => {
+  // A hunk anchored at line 99 of a 2-line file can't align → fail closed rather than fabricate old content.
+  assert.equal(reconstructOldContent(`a\nb\n`, `@@ -99,1 +99,1 @@\n a`), null);
+});
+
+// The tests below are new, added for #4739's full-branch-coverage requirement on the promoted shared
+// helper — each pins a branch the four relocated tests above don't already exercise.
+
+test("reconstructOldContent: a non-hunk preamble line before the first @@ header is skipped, not fatal", () => {
+  // A raw `diff --git a/x b/x` style line (never present in GitHub's per-file `.patch`, but the loop
+  // defensively tolerates it) must be skipped over, not mistaken for hunk content or a parse failure.
+  const old = reconstructOldContent("b", "diff --git a/x b/x\n@@ -1,1 +1,1 @@\n-a\n+b");
+  assert.equal(old, "a");
+});
+
+test("reconstructOldContent: bails (null) when a later hunk starts before the previous hunk's cursor (out of order/overlap)", () => {
+  // Hunk 1 consumes new-file lines 1-2 (cursor ends at 2); hunk 2 claims to start at new-file line 2
+  // (0-based index 1), which is BEHIND the cursor — an out-of-order or overlapping hunk pair that must
+  // fail closed rather than reconstruct a nonsensical result.
+  assert.equal(
+    reconstructOldContent("a\nb\nc\nd", "@@ -1,2 +1,2 @@\n a\n b\n@@ -2,1 +2,1 @@\n c"),
+    null,
+  );
+});
+
+test("reconstructOldContent: a `\\ No newline at end of file` marker line is skipped, not treated as content", () => {
+  // The marker starts with `\` (never `+`/`-`/` `); it must be ignored entirely rather than parsed as a
+  // sign+body pair (which would read a bogus sign and desync the cursor, or falsely fail closed).
+  const old = reconstructOldContent(
+    "a\nb",
+    "@@ -1,2 +1,2 @@\n a\n-x\n+b\n\\ No newline at end of file",
+  );
+  assert.equal(old, "a\nx");
+});
+
+test("reconstructOldContent: the trailing unchanged-lines flush is a no-op when the last hunk already reaches EOF", () => {
+  // The final `while (cursor < newLines.length)` flush must correctly do NOTHING when the last hunk's
+  // context/added lines already consumed every remaining new-file line.
+  const old = reconstructOldContent("a\nb", "@@ -1,2 +1,2 @@\n-x\n+a\n b");
+  assert.equal(old, "x\nb");
+});
+
+test("reconstructOldContent: a wholly new file reconstructs to an empty string, not null — both are falsy", () => {
+  // A patch that is 100% additions (old range `-0,0`) has no old-side content to rebuild: the correct
+  // reconstruction of "the file did not exist before this PR" is an empty string, not null. Every caller
+  // must treat this the same as null via a plain truthiness check (see the module's own doc comment) —
+  // patch data alone cannot (and need not) distinguish a brand-new file from a pre-existing 0-byte one.
+  const old = reconstructOldContent("a\nb\nc", "@@ -0,0 +1,3 @@\n+a\n+b\n+c");
+  assert.equal(old, "");
+  assert.ok(!old); // falsy, exactly like null — this is the contract every caller relies on
+});


### PR DESCRIPTION
## Summary

- Implements #4739 (sub-issue of epic #4737). `reconstructOldContent(newContent, patch)` — the
  unified-diff reverse-patch reconstruction primitive that recovers a changed file's pre-PR text — was
  private to `doc-comment-drift.ts` (#1519) and imported cross-file from there by
  `exhaustiveness-drift.ts` (#2028): a one-off trick living in the wrong place, not shared
  infrastructure. This PR promotes it into its own co-located module,
  `review-enrichment/src/analyzers/reconstruct-old-content.ts`, and migrates both existing callers to it.
- **Pure code motion — zero behavior change for both callers.** Confirmed mechanically (detail below),
  not by eyeballing, matching the verification discipline #4607's sibling extraction PRs
  (#4688/#4695/#4728) established for this kind of change.

### Architecture decision: co-located module, not an `AnalysisContext` method

The issue offered either shape. I looked at both before choosing:

- `AnalysisContext` (`review-enrichment/src/analysis-context.ts`) does **not** expose the GitHub token —
  it's pure authenticated transport (`fetchJson`/`fetchText`/`fetchStatus`); every current caller builds
  its own `Authorization` header from `req.githubToken`. A `context`-based version would still need the
  token threaded in from `req`, so it buys no real encapsulation over a plain function.
- `reconstructOldContent` is already pure and I/O-free — the fetch happens separately in each caller. The
  only thing to "promote" is the reverse-patch algorithm itself, which needs no context at all.
- Both current callers use the older `(req, fetchFn, options)` analyzer-function shape, not the
  `AnalysisContext`-consuming shape some other analyzers use (`codeowners.ts`, `caller-impact.ts`,
  `coverage-delta.ts`, `duplication-scan.ts`, etc.). Making this an `AnalysisContext` method would force
  both callers' exported signatures (and both existing test files' mocking convention — bare `fetchFn`
  injection, no `AnalysisContext` construction today) to change just to reach one small helper, and would
  touch `registry.ts`'s wiring for both analyzers — a materially larger blast radius than the issue's own
  "pure extraction, not a behavior change" framing calls for.
- A plain co-located module is callable from **either** convention — the raw-`req` analyzers this issue
  touches today, and the `AnalysisContext`-based analyzers #4740/#4741 will likely extend
  (`coverage-delta.ts`/`duplication-scan.ts` already receive `AnalysisContext`) — without forcing either
  style on the other. This matches the existing precedent in the same directory for shared analyzer
  helpers: `diff-lines.ts`, `binary-extensions.ts`, `github-headers.ts` are all plain sibling modules, not
  context methods.

### Byte-faithful verification (mechanical, not eyeballed)

- Extracted the original function body (both locations, signature line through closing brace) into two
  files and diffed them directly: the **only** difference anywhere in the 37-line function is one inline
  comment (2 lines), reworded from doc-comment-drift-specific language ("bail so we never trust a bad old
  signature") to caller-agnostic language ("bail so we never trust a reconstructed result that isn't
  provably faithful to the real pre-PR file") — a comment has zero runtime effect.
- Stripped whole-line comments from both extracted bodies and compared: **identical MD5 hash**
  (`7b195bf14c422e114a54d91da3d3e4a6`) — the executable code is provably byte-identical, not just
  eyeballed-similar.
- `exhaustiveness-drift.ts`'s diff is a single line: the import path
  (`./doc-comment-drift.js` → `./reconstruct-old-content.js`). Nothing else in the file changed.
- `doc-comment-drift.ts`'s diff is exactly: one import line added, and the function's 40 lines (doc
  comment + body) removed. The call site (`reconstructOldContent(content, file.patch!)` inside
  `scanDocCommentDrift`) is untouched — same name, now resolved via import instead of a local definition.
- The full pre-existing test suites for both analyzers (14 `scanDocCommentDrift` tests, 4
  `scanExhaustivenessDrift` tests) pass **unmodified**, proving both callers' end-to-end observable
  behavior is unchanged.

### Edge cases (patch doesn't cleanly reverse-apply / binary file / newly-added file)

- **Patch doesn't cleanly reverse-apply**: unchanged — still returns `null` (a hunk starting before the
  cursor or past the content's end, or a context/added line that doesn't match `newContent` at the
  expected position).
- **Binary file**: this function only ever sees two text blobs and has no path/extension to inspect, so
  it cannot detect this itself — both callers already filter to known source extensions and require
  `file.patch` to be present before calling it (GitHub omits `.patch` entirely for binary/oversized
  files), and that filtering is untouched by this PR (see the byte-faithful diffs above).
- **File didn't exist before the PR (newly added)**: unchanged — a "wholly added" patch (`-0,0` old
  range) reconstructs to an empty string, not `null`. I deliberately did **not** normalize this to `null`
  in this PR: doing so is 100% safe for both current callers (they already branch on `if (!oldContent)`,
  which treats `""` and `null` identically) but it's a real, separate behavior decision on the shared
  function's own contract, and this issue is explicitly scoped as pure extraction. I instead pinned the
  current contract with an explicit regression test and documented it plainly in the module's doc comment
  so every future caller (including #4740/#4741) knows to check falsiness, not `=== null`. Happy to open a
  small separate follow-up if a strict-null contract is preferred later.

### Coverage

Added `review-enrichment/test/reconstruct-old-content.test.ts`: the four existing
`reconstructOldContent` unit tests move over verbatim (removed from `doc-comment-drift.test.ts`, which no
longer imports the function directly), plus five new tests closing every branch the original four didn't
already exercise — a non-hunk preamble line before the first `@@` header, out-of-order/overlapping hunks,
a `\ No newline at end of file` marker line, the trailing-flush no-op case (last hunk already reaches
EOF), and the wholly-new-file case. Verified with node's own coverage instrumentation
(`node --test --experimental-test-coverage --test-coverage-include='dist/analyzers/reconstruct-old-content.js'`):
**100.00% line / 100.00% branch / 100.00% function** coverage on the new module.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

Note on the issue link: this **implements #4739**, a sub-issue of epic #4737 — not `Fixes`/`Closes`
wording, per the epic's multi-part sub-issue convention.

## Validation

- [x] `git diff --check` — clean.
- [ ] `npm run actionlint` — not run; no `.github/workflows/**` files touched.
- [x] `npm run typecheck` — clean (root-level; `review-enrichment` has its own separate `tsconfig.json`
      and is not part of this project reference, but its own build/typecheck is covered by `rees:test`
      below).
- [ ] `npm run test:coverage` — not run; `review-enrichment/` is a standalone project (its own
      `package.json`/`package-lock.json`, not an npm workspace member) tested via node's built-in test
      runner, not vitest — it is **not** part of the root Codecov `codecov/patch` gate (that gate's
      coverage comes only from the root `vitest run --coverage` → `coverage/lcov.info`, which never
      touches `review-enrichment/src/**`). `review-enrichment/` changes are gated entirely by
      `npm run rees:test` (CI's own "REES build, source-map validation, and tests" step, path-filtered on
      `review-enrichment/**`), run below.
- [ ] `npm run test:workers` — not run; no `test/workers/**`-relevant code touched.
- [ ] `npm run build:mcp` / `npm run test:mcp-pack` — not run; no MCP package changes.
- [ ] `npm run ui:openapi:check` / `npm run ui:lint` / `npm run ui:typecheck` / `npm run ui:build` — not
      run; no `apps/gittensory-ui/**` or API/schema changes.
- [ ] `npm audit --audit-level=moderate` — not run; no dependency changes (no `package.json`/lockfile
      touched in either the root or `review-enrichment`).
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — no new behavior (pure extraction); the promoted helper has a dedicated test file with 100% line/branch/function coverage (verified with node's built-in coverage instrumentation, detail above), and both existing callers' full pre-existing test suites pass unmodified.

If any required check was skipped, explain why:

- This is a `review-enrichment/`-only, behavior-preserving extraction with no root `src/**`, UI, MCP,
  workers, schema, OpenAPI, or dependency surface touched, so those gates are left to CI rather than
  duplicated locally (they path-filter out for this diff anyway). The checks that matter for this change
  were run directly, in full, in the foreground:
  - `npm ci` (root) and `npm run rees:install` (fresh worktree, no prior `node_modules`): both clean.
  - `npm run rees:test` (`npm --prefix review-enrichment test` — build, source-map validation, analyzer
    metadata drift check, then the full node-test suite): **1229/1229 tests passed**, including all 14
    `scanDocCommentDrift` tests, all 4 `scanExhaustivenessDrift` tests, the 4 relocated
    `reconstructOldContent` tests, and the 5 new tests — zero failures.
  - `npm run typecheck` (root): clean.
  - `git diff --check`: clean.
  - Coverage: node's built-in `--experimental-test-coverage`, scoped to the new module via
    `--test-coverage-include`, reported 100.00% line / 100.00% branch / 100.00% function — see Coverage
    above.
  - Byte-faithful diff + MD5 comparison of the moved function's body against its original location — see
    the Summary section above for the full method and result.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no auth/cookie/CORS/session code touched.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no API/OpenAPI/MCP surface touched.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section below... — N/A, no visible/UI changes (backend-only refactor, internal to `review-enrichment/`).
- [ ] Public docs/changelogs are updated where needed... — N/A, no doc-affecting behavior change; `CHANGELOG.md` intentionally not touched.

## UI Evidence

Not applicable — this PR has no visible/UI/frontend surface; it is an internal `review-enrichment/`
(REES) refactor with no API, schema, or behavior change.

## Notes

- Prerequisite for the complexity-delta and duplication-delta sub-issues under epic #4737 (per the
  epic's own text, likely extending `coverage-delta.ts`/`duplication-scan.ts`, which already receive
  `AnalysisContext` — either of those can import this shared helper directly regardless of which analyzer
  calling convention they end up using).
- Deliberately scoped to only this extraction — did not also add an `AnalysisContext.beforeContentFor`-style
  convenience method with no real caller today; see the architecture-decision writeup above for why, and
  happy to add one in a follow-up once a concrete `AnalysisContext`-based consumer exists.
