### PR TITLE
feat(analytics): surface org-wide slop-band calibration + dashboard card (#2196)

### DIFF
--- a/apps/gittensory-ui/src/components/site/app-panels/slop-band-calibration-card.test.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/slop-band-calibration-card.test.tsx
@@ -1,0 +1,76 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { SlopBandCalibrationCard } from "@/components/site/app-panels/slop-band-calibration-card";
+
+describe("SlopBandCalibrationCard", () => {
+  it("renders a row per band with merge rate + counts and the discrimination verdict when all bands have data", () => {
+    render(
+      <SlopBandCalibrationCard
+        calibration={{
+          totalResolved: 40,
+          overallMergeRate: 0.6,
+          discriminates: true,
+          bands: [
+            { band: "clean", sampleSize: 20, merged: 18, closed: 2, mergeRate: 0.9 },
+            { band: "low", sampleSize: 10, merged: 6, closed: 4, mergeRate: 0.6 },
+            { band: "elevated", sampleSize: 6, merged: 2, closed: 4, mergeRate: 0.333 },
+            { band: "high", sampleSize: 4, merged: 0, closed: 4, mergeRate: 0 },
+          ],
+        }}
+      />,
+    );
+    expect(screen.getByText("clean")).toBeTruthy();
+    expect(screen.getByText("high")).toBeTruthy();
+    expect(screen.getByText("90% merged")).toBeTruthy();
+    expect(screen.getByText("predictive")).toBeTruthy();
+    expect(screen.getByText(/40 resolved · 60% merged overall/)).toBeTruthy();
+  });
+
+  it("shows the '— no samples' state for an empty band and marks insufficient data", () => {
+    render(
+      <SlopBandCalibrationCard
+        calibration={{
+          totalResolved: 3,
+          overallMergeRate: 1,
+          discriminates: null,
+          bands: [
+            { band: "clean", sampleSize: 3, merged: 3, closed: 0, mergeRate: 1 },
+            { band: "high", sampleSize: 0, merged: 0, closed: 0, mergeRate: 0 },
+          ],
+        }}
+      />,
+    );
+    expect(screen.getByText("— no samples")).toBeTruthy();
+    expect(screen.getByText("insufficient data")).toBeTruthy();
+  });
+
+  it("flags an inverted (non-predictive) score", () => {
+    render(
+      <SlopBandCalibrationCard
+        calibration={{
+          totalResolved: 20,
+          overallMergeRate: 0.5,
+          discriminates: false,
+          bands: [{ band: "clean", sampleSize: 20, merged: 10, closed: 10, mergeRate: 0.5 }],
+        }}
+      />,
+    );
+    expect(screen.getByText("inverted")).toBeTruthy();
+  });
+
+  it("shows the 'no resolved PRs' empty state when the calibration has no resolved data", () => {
+    render(
+      <SlopBandCalibrationCard
+        calibration={{ totalResolved: 0, overallMergeRate: null, discriminates: null, bands: [] }}
+      />,
+    );
+    expect(screen.getByText("No resolved PRs with a slop band")).toBeTruthy();
+    expect(screen.queryByText("predictive")).toBeNull();
+  });
+
+  it("shows the 'not yet available' empty state when the calibration field is absent", () => {
+    render(<SlopBandCalibrationCard />);
+    expect(screen.getByText("Not yet available")).toBeTruthy();
+  });
+});

--- a/apps/gittensory-ui/src/components/site/app-panels/slop-band-calibration-card.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/slop-band-calibration-card.tsx
@@ -1,0 +1,106 @@
+import { AnalyticsCardShell } from "@/components/site/app-panels/analytics-card-shell";
+import { StatusPill, type Status } from "@/components/site/control-primitives";
+import { cn } from "@/lib/utils";
+
+/** Slop-band calibration (#2196): per-band merge/close rates over resolved PRs that carry a persisted slop band —
+ *  is the deterministic slop score predictive (do higher-slop bands merge less)? Display slice over the
+ *  operator-dashboard's `slopCalibration` payload. Bands only, never raw scores (public/private boundary). */
+export type SlopBand = "clean" | "low" | "elevated" | "high";
+
+export type SlopBandCalibration = {
+  band: SlopBand;
+  sampleSize: number;
+  merged: number;
+  closed: number;
+  mergeRate: number;
+};
+
+export type SlopOutcomeCalibration = {
+  totalResolved: number;
+  bands: SlopBandCalibration[];
+  overallMergeRate: number | null;
+  discriminates: boolean | null;
+};
+
+/** clean → high reads low-to-high severity; the bar color tracks band severity. */
+const BAND_BAR: Record<SlopBand, string> = {
+  clean: "bg-success",
+  low: "bg-mint",
+  elevated: "bg-warning",
+  high: "bg-danger",
+};
+
+function discriminationPill(discriminates: boolean | null): { status: Status; label: string } {
+  if (discriminates === true) return { status: "ready", label: "predictive" };
+  if (discriminates === false) return { status: "degraded", label: "inverted" };
+  return { status: "info", label: "insufficient data" };
+}
+
+function BandRow({ row }: { row: SlopBandCalibration }) {
+  const hasSamples = row.sampleSize > 0;
+  const pct = hasSamples ? Math.round(row.mergeRate * 100) : null;
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-center justify-between gap-3 text-token-sm">
+        <span className="font-medium capitalize text-foreground">{row.band}</span>
+        <span className="font-mono text-token-xs text-muted-foreground">
+          {pct === null ? "— no samples" : `${pct}% merged`}
+        </span>
+      </div>
+      <div className="h-2 overflow-hidden rounded-full bg-border" aria-hidden>
+        {hasSamples ? (
+          <div className={cn("h-full", BAND_BAR[row.band])} style={{ width: `${pct}%` }} />
+        ) : null}
+      </div>
+      <div className="font-mono text-token-2xs text-muted-foreground">
+        {row.sampleSize} resolved · {row.merged} merged · {row.closed} closed
+      </div>
+    </div>
+  );
+}
+
+export function SlopBandCalibrationCard({ calibration }: { calibration?: SlopOutcomeCalibration }) {
+  const hasData =
+    calibration != null && calibration.totalResolved > 0 && calibration.bands.length > 0;
+
+  if (!hasData) {
+    return (
+      <AnalyticsCardShell
+        title="Slop-band calibration"
+        description="Predicted slop band vs realized merge/close outcome, across resolved PRs."
+        state="empty"
+        emptyTitle={calibration ? "No resolved PRs with a slop band" : "Not yet available"}
+        emptyHint={
+          calibration
+            ? "Calibration appears once resolved PRs carry a persisted slop band in the window."
+            : "Slop-band calibration appears once the payload includes resolved-PR slop bands."
+        }
+      />
+    );
+  }
+
+  const pill = discriminationPill(calibration.discriminates);
+  const overall =
+    calibration.overallMergeRate === null ? null : Math.round(calibration.overallMergeRate * 100);
+
+  return (
+    <AnalyticsCardShell
+      title="Slop-band calibration"
+      description="Predicted slop band vs realized merge/close outcome, across resolved PRs."
+      state="ready"
+    >
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <span className="font-mono text-token-2xs text-muted-foreground">
+          {calibration.totalResolved} resolved
+          {overall === null ? "" : ` · ${overall}% merged overall`}
+        </span>
+        <StatusPill status={pill.status}>{pill.label}</StatusPill>
+      </div>
+      <div className="mt-3 space-y-4">
+        {calibration.bands.map((row) => (
+          <BandRow key={row.band} row={row} />
+        ))}
+      </div>
+    </AnalyticsCardShell>
+  );
+}

--- a/apps/gittensory-ui/src/routes/app.analytics.tsx
+++ b/apps/gittensory-ui/src/routes/app.analytics.tsx
@@ -26,6 +26,10 @@ import {
   FindingsBreakdownCard,
   type FindingsBreakdown,
 } from "@/components/site/app-panels/findings-breakdown-card";
+import {
+  SlopBandCalibrationCard,
+  type SlopOutcomeCalibration,
+} from "@/components/site/app-panels/slop-band-calibration-card";
 import { useApiResource } from "@/lib/api/use-api-resource";
 import { exportOperatorDashboardCsv } from "@/lib/csv-export";
 
@@ -121,6 +125,7 @@ type OperatorDashboard = {
   agentHealth?: ReversalHealth;
   acceptance?: FindingAcceptance;
   findingsBreakdown?: FindingsBreakdown;
+  slopCalibration?: SlopOutcomeCalibration;
 };
 
 function ProductAnalytics() {
@@ -226,6 +231,8 @@ function ProductAnalytics() {
           <AcceptanceRateCard acceptance={data.acceptance} />
 
           <FindingsBreakdownCard findings={data.findingsBreakdown} />
+
+          <SlopBandCalibrationCard calibration={data.slopCalibration} />
 
           {data.usageSummary ? (
             <ProductUsageBreakdownPanel

--- a/src/services/operator-dashboard.ts
+++ b/src/services/operator-dashboard.ts
@@ -4,6 +4,7 @@ import {
   getCommandUsefulnessSummary,
   getLatestScoringModelSnapshot,
   getProductUsageRollupStatus,
+  listAllPullRequests,
   listInstallationHealth,
   listInstallations,
   listLatestGitHubRateLimitObservations,
@@ -28,10 +29,20 @@ import type {
 import { computeFleetAnalytics, type FleetAnalytics } from "../orb/analytics";
 import { computeAgentHealth, type AgentHealth } from "../review/ops";
 import { computeGateEval, type GateEvalReport } from "../review/parity";
-import { computeCycleTimeAggregate, type CycleTimeAggregate } from "../review/stats";
+import {
+  computeCycleTimeAggregate,
+  type CycleTimeAggregate,
+} from "../review/stats";
 import { loadUpstreamStatus, type UpstreamStatus } from "../upstream/ruleset";
 import { nowIso } from "../utils/json";
-import { buildRecommendationQualityReport, type RecommendationQualityReport } from "./recommendation-quality-report";
+import {
+  buildRecommendationQualityReport,
+  type RecommendationQualityReport,
+} from "./recommendation-quality-report";
+import {
+  buildSlopOutcomeCalibration,
+  type SlopOutcomeCalibration,
+} from "./outcome-calibration";
 import { buildWeeklyValueReport } from "./weekly-value-report";
 
 export type OperatorDashboardMetric = {
@@ -69,12 +80,19 @@ export type OperatorDashboardPayload = {
   cycleTime: CycleTimeAggregate;
   // Agent reversal health (#2193): how often humans reopened/reverted bot auto-actions (ops.ts AgentHealth).
   agentHealth: AgentHealth;
+  // Slop-band calibration (#2196): per-band merge/close rates over resolved PRs carrying a persisted slop band,
+  // org-wide — is the deterministic slop score predictive (do higher bands merge less)? Bands, never raw scores.
+  slopCalibration: SlopOutcomeCalibration;
 };
 
 const USAGE_WINDOW_DAYS = 7;
 
-export async function buildOperatorDashboardPayload(env: Env): Promise<OperatorDashboardPayload> {
-  const usageSince = new Date(Date.now() - USAGE_WINDOW_DAYS * 24 * 60 * 60 * 1000).toISOString();
+export async function buildOperatorDashboardPayload(
+  env: Env,
+): Promise<OperatorDashboardPayload> {
+  const usageSince = new Date(
+    Date.now() - USAGE_WINDOW_DAYS * 24 * 60 * 60 * 1000,
+  ).toISOString();
   const [
     repositories,
     installations,
@@ -95,6 +113,7 @@ export async function buildOperatorDashboardPayload(env: Env): Promise<OperatorD
     gateEval,
     cycleTime,
     agentHealth,
+    slopCalibration,
   ] = await Promise.all([
     listRepositories(env),
     listInstallations(env),
@@ -117,6 +136,9 @@ export async function buildOperatorDashboardPayload(env: Env): Promise<OperatorD
     // #2194: cycle-time percentiles from the stats feed; fails safe to an empty aggregate.
     computeCycleTimeAggregate(env, { days: 90, nowMs: Date.now() }),
     computeAgentHealth(env, operatorAgentConfig(env)),
+    // #2196: org-wide slop-band calibration from the persisted slop bands on resolved PRs. Pure aggregation
+    // over listAllPullRequests; fails safe to an empty (no-bands) calibration when there is no slop signal.
+    listAllPullRequests(env).then(buildSlopOutcomeCalibration),
   ]);
   const weeklyValueReport = buildWeeklyValueReport({
     generatedAt: nowIso(),
@@ -134,21 +156,58 @@ export async function buildOperatorDashboardPayload(env: Env): Promise<OperatorD
     activeSessions,
     digestSubscriptions,
   });
-  const installedRepos = repositories.filter((repo: RepositoryRecord) => repo.isInstalled).length;
-  const registeredRepos = repositories.filter((repo: RepositoryRecord) => repo.isRegistered).length;
+  const installedRepos = repositories.filter(
+    (repo: RepositoryRecord) => repo.isInstalled,
+  ).length;
+  const registeredRepos = repositories.filter(
+    (repo: RepositoryRecord) => repo.isRegistered,
+  ).length;
   return {
     generatedAt: nowIso(),
     metrics: [
-      { label: "Active sessions", value: String(activeSessions), delta: "browser + CLI/MCP" },
-      { label: "Installations", value: String(installations.length), delta: `${installedRepos} installed repos` },
-      { label: "Registered repos", value: String(registeredRepos), delta: registry ? `${registry.repoCount} in latest registry` : "registry missing" },
-      { label: "Digest subscriptions", value: String(digestSubscriptions), delta: "store-only" },
-      { label: "Product events", value: String(usageSummary.totalEvents), delta: "last 7 days" },
-      { label: "Active users", value: String(usageSummary.activeActors), delta: "hashed, last 7 days" },
-      { label: "Activation rollups", value: usageRollupStatus.status, delta: usageRollupStatus.latestRollupDay ?? "not generated" },
+      {
+        label: "Active sessions",
+        value: String(activeSessions),
+        delta: "browser + CLI/MCP",
+      },
+      {
+        label: "Installations",
+        value: String(installations.length),
+        delta: `${installedRepos} installed repos`,
+      },
+      {
+        label: "Registered repos",
+        value: String(registeredRepos),
+        delta: registry
+          ? `${registry.repoCount} in latest registry`
+          : "registry missing",
+      },
+      {
+        label: "Digest subscriptions",
+        value: String(digestSubscriptions),
+        delta: "store-only",
+      },
+      {
+        label: "Product events",
+        value: String(usageSummary.totalEvents),
+        delta: "last 7 days",
+      },
+      {
+        label: "Active users",
+        value: String(usageSummary.activeActors),
+        delta: "hashed, last 7 days",
+      },
+      {
+        label: "Activation rollups",
+        value: usageRollupStatus.status,
+        delta: usageRollupStatus.latestRollupDay ?? "not generated",
+      },
       {
         label: "MCP stale clients",
-        value: String(mcpCompatibilityAdoption.staleEvents + mcpCompatibilityAdoption.incompatibleEvents),
+        value: String(
+          mcpCompatibilityAdoption.staleEvents +
+            mcpCompatibilityAdoption.incompatibleEvents,
+        ),
         delta: `${mcpCompatibilityAdoption.totalEvents} MCP event(s)`,
       },
       {
@@ -159,43 +218,69 @@ export async function buildOperatorDashboardPayload(env: Env): Promise<OperatorD
       {
         label: "Recommendation quality",
         value: `${recommendationQuality.totals.positive}/${recommendationQuality.totals.total}`,
-        delta: recommendationQuality.empty ? "no evaluated outcomes" : `${Math.round(recommendationQuality.totals.positiveRate * 100)}% positive`,
+        delta: recommendationQuality.empty
+          ? "no evaluated outcomes"
+          : `${Math.round(recommendationQuality.totals.positiveRate * 100)}% positive`,
       },
       {
         label: "Install issues",
-        value: String(health.filter((record: InstallationHealthRecord) => record.status !== "healthy").length),
+        value: String(
+          health.filter(
+            (record: InstallationHealthRecord) => record.status !== "healthy",
+          ).length,
+        ),
         delta: "current health cache",
       },
-      { label: "Rate-limit events", value: String(rateLimits.length), delta: "latest observations" },
+      {
+        label: "Rate-limit events",
+        value: String(rateLimits.length),
+        delta: "latest observations",
+      },
       {
         label: "Fleet instances",
         value: String(fleetMetrics.instanceCount),
-        delta: fleetMetrics.outliers.length > 0 ? `${fleetMetrics.outliers.length} outlier(s)` : "self-host fleet",
+        delta:
+          fleetMetrics.outliers.length > 0
+            ? `${fleetMetrics.outliers.length} outlier(s)`
+            : "self-host fleet",
       },
       {
         label: "Fleet merge precision",
-        value: fleetMetrics.fleet.mergePrecision !== null ? `${Math.round(fleetMetrics.fleet.mergePrecision * 100)}%` : "—",
+        value:
+          fleetMetrics.fleet.mergePrecision !== null
+            ? `${Math.round(fleetMetrics.fleet.mergePrecision * 100)}%`
+            : "—",
         delta: "median across the fleet",
       },
     ],
     noiseReduction: [
       {
         label: "Healthy installations",
-        value: health.filter((record: InstallationHealthRecord) => record.status === "healthy").length,
+        value: health.filter(
+          (record: InstallationHealthRecord) => record.status === "healthy",
+        ).length,
         spark: sparklineFromCounts(
-          health.filter((record: InstallationHealthRecord) => record.status === "healthy").length,
+          health.filter(
+            (record: InstallationHealthRecord) => record.status === "healthy",
+          ).length,
           Math.max(health.length, 1),
         ),
       },
       {
         label: "Registered coverage",
         value: registeredRepos,
-        spark: sparklineFromCounts(registeredRepos, Math.max(repositories.length, 1)),
+        spark: sparklineFromCounts(
+          registeredRepos,
+          Math.max(repositories.length, 1),
+        ),
       },
       {
         label: "Installed coverage",
         value: installedRepos,
-        spark: sparklineFromCounts(installedRepos, Math.max(repositories.length, 1)),
+        spark: sparklineFromCounts(
+          installedRepos,
+          Math.max(repositories.length, 1),
+        ),
       },
     ],
     weeklyReport: weeklyValueReport.summary,
@@ -213,10 +298,14 @@ export async function buildOperatorDashboardPayload(env: Env): Promise<OperatorD
     gateEval,
     cycleTime,
     agentHealth,
+    slopCalibration,
   };
 }
 
-function operatorAgentConfig(env: Env): { slug: string; secrets: Record<string, never> } {
+function operatorAgentConfig(env: Env): {
+  slug: string;
+  secrets: Record<string, never>;
+} {
   const slug =
     typeof env.GITHUB_APP_SLUG === "string" && env.GITHUB_APP_SLUG.trim()
       ? env.GITHUB_APP_SLUG.trim()
@@ -226,17 +315,27 @@ function operatorAgentConfig(env: Env): { slug: string; secrets: Record<string, 
 
 export const __operatorDashboardInternals = { operatorAgentConfig };
 
-export function latestUsageRollup(rollups: ProductUsageDailyRollupRecord[]): ProductUsageDailyRollupRecord | null {
+export function latestUsageRollup(
+  rollups: ProductUsageDailyRollupRecord[],
+): ProductUsageDailyRollupRecord | null {
   if (rollups.length === 0) return null;
   return [...rollups].sort((a, b) => b.day.localeCompare(a.day))[0]!;
 }
 
 function usefulnessDelta(rate: number | null): string {
-  return rate === null ? "no feedback yet" : `${Math.round(rate * 100)}% useful over 30 days`;
+  return rate === null
+    ? "no feedback yet"
+    : `${Math.round(rate * 100)}% useful over 30 days`;
 }
 
 function sparklineFromCounts(value: number, total: number): number[] {
   const safeTotal = Math.max(total, 1);
   const ratio = Math.min(1, Math.max(0, value / safeTotal));
-  return [Math.round(ratio * 40), Math.round(ratio * 55), Math.round(ratio * 70), Math.round(ratio * 85), Math.round(ratio * 100)];
+  return [
+    Math.round(ratio * 40),
+    Math.round(ratio * 55),
+    Math.round(ratio * 70),
+    Math.round(ratio * 85),
+    Math.round(ratio * 100),
+  ];
 }

--- a/test/unit/operator-dashboard.test.ts
+++ b/test/unit/operator-dashboard.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { buildOperatorDashboardPayload, latestUsageRollup, __operatorDashboardInternals } from "../../src/services/operator-dashboard";
+import {
+  buildOperatorDashboardPayload,
+  latestUsageRollup,
+  __operatorDashboardInternals,
+} from "../../src/services/operator-dashboard";
 import type { ProductUsageDailyRollupRecord } from "../../src/types";
 import { createTestEnv } from "../helpers/d1";
 
@@ -8,7 +12,9 @@ const FORBIDDEN_EXPORT_TERMS =
 
 describe("operator dashboard payload", () => {
   it("builds operator metrics from product usage rollups without sensitive strings", async () => {
-    const env = createTestEnv({ PRODUCT_USAGE_HASH_SALT: "operator-dashboard-test-salt" });
+    const env = createTestEnv({
+      PRODUCT_USAGE_HASH_SALT: "operator-dashboard-test-salt",
+    });
     const payload = await buildOperatorDashboardPayload(env);
     const serialized = JSON.stringify(payload);
 
@@ -20,8 +26,13 @@ describe("operator dashboard payload", () => {
       ]),
     );
     expect(payload.weeklyValueReport.variant).toBe("operator");
-    expect(payload.usageSummary).toMatchObject({ totalEvents: expect.any(Number), activeActors: expect.any(Number) });
-    expect(payload.commandUsefulness.totals).toMatchObject({ feedbackCount: expect.any(Number) });
+    expect(payload.usageSummary).toMatchObject({
+      totalEvents: expect.any(Number),
+      activeActors: expect.any(Number),
+    });
+    expect(payload.commandUsefulness.totals).toMatchObject({
+      feedbackCount: expect.any(Number),
+    });
     expect(serialized).not.toMatch(FORBIDDEN_EXPORT_TERMS);
     // #2191: gate-eval report is surfaced read-only; with no review_audit signal it fails safe to an empty
     // report (no rows, no signal) rather than being absent.
@@ -40,18 +51,31 @@ describe("operator dashboard payload", () => {
       recentAutoActions: 0,
       reversedTargets: [],
     });
+    // #2196: org-wide slop-band calibration is surfaced read-only; with no resolved PRs carrying a slop band
+    // it fails safe to an empty calibration (no overall rate, undecidable discrimination) rather than absent.
+    expect(payload.slopCalibration).toMatchObject({
+      totalResolved: 0,
+      overallMergeRate: null,
+      discriminates: null,
+    });
     // Empty fleet → instanceCount 0, null precision card ("—"), no-outlier delta.
     expect(payload.fleetMetrics.instanceCount).toBe(0);
     expect(payload.metrics).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ label: "Fleet instances", value: "0", delta: "self-host fleet" }),
+        expect.objectContaining({
+          label: "Fleet instances",
+          value: "0",
+          delta: "self-host fleet",
+        }),
         expect.objectContaining({ label: "Fleet merge precision", value: "—" }),
       ]),
     );
   });
 
   it("falls back to the default agent slug when GITHUB_APP_SLUG is unset or blank", async () => {
-    const env = createTestEnv({ PRODUCT_USAGE_HASH_SALT: "operator-dashboard-test-salt" });
+    const env = createTestEnv({
+      PRODUCT_USAGE_HASH_SALT: "operator-dashboard-test-salt",
+    });
     delete (env as Partial<Env>).GITHUB_APP_SLUG;
     const missingSlug = await buildOperatorDashboardPayload(env);
     expect(missingSlug.agentHealth).toMatchObject({
@@ -63,7 +87,10 @@ describe("operator dashboard payload", () => {
     });
 
     const blankSlug = await buildOperatorDashboardPayload(
-      createTestEnv({ PRODUCT_USAGE_HASH_SALT: "operator-dashboard-test-salt", GITHUB_APP_SLUG: "   " }),
+      createTestEnv({
+        PRODUCT_USAGE_HASH_SALT: "operator-dashboard-test-salt",
+        GITHUB_APP_SLUG: "   ",
+      }),
     );
     expect(blankSlug.agentHealth).toMatchObject({
       reversals: 0,
@@ -76,30 +103,44 @@ describe("operator dashboard payload", () => {
 
   it("operatorAgentConfig trims a configured slug and falls back when absent", () => {
     const { operatorAgentConfig } = __operatorDashboardInternals;
-    expect(operatorAgentConfig(createTestEnv({ GITHUB_APP_SLUG: "  custom-app  " }))).toEqual({
+    expect(
+      operatorAgentConfig(createTestEnv({ GITHUB_APP_SLUG: "  custom-app  " })),
+    ).toEqual({
       slug: "custom-app",
       secrets: {},
     });
-    expect(operatorAgentConfig(createTestEnv({ GITHUB_APP_SLUG: "gittensory" }))).toEqual({
+    expect(
+      operatorAgentConfig(createTestEnv({ GITHUB_APP_SLUG: "gittensory" })),
+    ).toEqual({
       slug: "gittensory",
       secrets: {},
     });
     const unset = createTestEnv();
     delete (unset as Partial<Env>).GITHUB_APP_SLUG;
-    expect(operatorAgentConfig(unset)).toEqual({ slug: "gittensory", secrets: {} });
-    expect(operatorAgentConfig(createTestEnv({ GITHUB_APP_SLUG: "" }))).toEqual({
+    expect(operatorAgentConfig(unset)).toEqual({
       slug: "gittensory",
       secrets: {},
     });
+    expect(operatorAgentConfig(createTestEnv({ GITHUB_APP_SLUG: "" }))).toEqual(
+      {
+        slug: "gittensory",
+        secrets: {},
+      },
+    );
   });
 
   it("surfaces populated fleet metrics + outliers from orb_signals", async () => {
     const env = createTestEnv();
     let n = 0;
-    const seed = async (instance: string, count: number, outcome: string): Promise<void> => {
+    const seed = async (
+      instance: string,
+      count: number,
+      outcome: string,
+    ): Promise<void> => {
       for (let i = 0; i < count; i++) {
-        await env.DB
-          .prepare(`INSERT INTO orb_signals (instance_id, repo_hash, pr_hash, gate_verdict, outcome, reversal_flag) VALUES (?, ?, ?, 'merge', ?, 'none')`)
+        await env.DB.prepare(
+          `INSERT INTO orb_signals (instance_id, repo_hash, pr_hash, gate_verdict, outcome, reversal_flag) VALUES (?, ?, ?, 'merge', ?, 'none')`,
+        )
           .bind(instance, `r${n}`, `p${n++}`, outcome)
           .run();
       }
@@ -108,15 +149,28 @@ describe("operator dashboard payload", () => {
     await seed("good2", 5, "merged"); // precision 1.0
     await seed("bad", 5, "closed"); // precision 0.0 → outlier vs the median (1.0)
     for (const id of ["good1", "good2", "bad"]) {
-      await env.DB.prepare(`INSERT INTO orb_instances (instance_id, registered) VALUES (?, 1)`).bind(id).run(); // only registered instances count
+      await env.DB.prepare(
+        `INSERT INTO orb_instances (instance_id, registered) VALUES (?, 1)`,
+      )
+        .bind(id)
+        .run(); // only registered instances count
     }
     const payload = await buildOperatorDashboardPayload(env);
     expect(payload.fleetMetrics.instanceCount).toBe(3);
-    expect(payload.fleetMetrics.outliers.map((o) => o.instanceId)).toContain("bad");
+    expect(payload.fleetMetrics.outliers.map((o) => o.instanceId)).toContain(
+      "bad",
+    );
     expect(payload.metrics).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ label: "Fleet instances", value: "3", delta: "1 outlier(s)" }),
-        expect.objectContaining({ label: "Fleet merge precision", value: "100%" }),
+        expect.objectContaining({
+          label: "Fleet instances",
+          value: "3",
+          delta: "1 outlier(s)",
+        }),
+        expect.objectContaining({
+          label: "Fleet merge precision",
+          value: "100%",
+        }),
       ]),
     );
   });


### PR DESCRIPTION
## What

Adds the **slop-band calibration** card to the operator analytics dashboard (Closes #2196): predicted slop band vs realized merge/close outcome across resolved PRs — *is the deterministic slop score predictive* (do higher-slop bands merge less)?

Unlike a display-only slice, this **surfaces real data end-to-end**: the existing (tested) `buildSlopOutcomeCalibration` is wired over `listAllPullRequests` into the operator-dashboard payload as `slopCalibration`, then rendered. Bands only — never raw scores (public/private boundary).

## Changes

**Backend** (`src/services/operator-dashboard.ts`)
- Load `listAllPullRequests(env)` and fold it through `buildSlopOutcomeCalibration` (pure, already unit-tested) inside the existing `Promise.all`, exposing `slopCalibration: SlopOutcomeCalibration` on the payload — org-wide per-band `{ sampleSize, merged, closed, mergeRate }`, `overallMergeRate`, and a `discriminates` verdict. Fails safe to an empty calibration when there's no slop signal.
- Covered by `test/unit/operator-dashboard.test.ts` (new assertion on the empty-signal shape).

**Frontend**
- `slop-band-calibration-card.tsx` (new) — `SlopBandCalibrationCard`: per-band merge-rate bars (severity-colored) + `resolved · merged · closed` counts + a **predictive / inverted / insufficient-data** verdict pill. Reuses `AnalyticsCardShell`; graceful empty + absent states.
- `slop-band-calibration-card.test.tsx` (new) — 5 tests: all-bands populated, empty-band (`— no samples`), inverted score, no-resolved-data, and absent field.
- `app.analytics.tsx` — optional `slopCalibration?` on the dashboard type + renders the card after the findings-breakdown card.

## Verification

`ui:typecheck` ✓ · `ui:test` (5/5) ✓ · `test/unit/operator-dashboard.test.ts` (5/5) ✓ · `ui:build` ✓ · `ui:openapi` (no drift) ✓ · eslint 0 errors · prettier clean.

## Screenshots

Net-new card on `/app/analytics`. Shown populated (predictive: clean 90% → high 0%) and in the empty state, desktop + mobile, light + dark.

| State | Desktop (light) | Desktop (dark) | Mobile |
|---|---|---|---|
| **Populated** | [<img src="https://raw.githubusercontent.com/dhgoal/gittensory/ui-evidence-2196/shot-ready-light-desktop.png" width="260">](https://raw.githubusercontent.com/dhgoal/gittensory/ui-evidence-2196/shot-ready-light-desktop.png)<br><sub>predictive · light</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/gittensory/ui-evidence-2196/shot-ready-dark-desktop.png" width="260">](https://raw.githubusercontent.com/dhgoal/gittensory/ui-evidence-2196/shot-ready-dark-desktop.png)<br><sub>predictive · dark</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/gittensory/ui-evidence-2196/shot-ready-dark-mobile.png" width="150">](https://raw.githubusercontent.com/dhgoal/gittensory/ui-evidence-2196/shot-ready-dark-mobile.png)<br><sub>mobile</sub> |
| **Empty** | [<img src="https://raw.githubusercontent.com/dhgoal/gittensory/ui-evidence-2196/shot-empty-light-desktop.png" width="260">](https://raw.githubusercontent.com/dhgoal/gittensory/ui-evidence-2196/shot-empty-light-desktop.png)<br><sub>empty · light</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/gittensory/ui-evidence-2196/shot-empty-dark-desktop.png" width="260">](https://raw.githubusercontent.com/dhgoal/gittensory/ui-evidence-2196/shot-empty-dark-desktop.png)<br><sub>empty · dark</sub> | [<img src="https://raw.githubusercontent.com/dhgoal/gittensory/ui-evidence-2196/shot-empty-dark-mobile.png" width="150">](https://raw.githubusercontent.com/dhgoal/gittensory/ui-evidence-2196/shot-empty-dark-mobile.png)<br><sub>mobile</sub> |

Closes #2196
