### PR TITLE
fix(review): never cache a truncated grounding file fetch

### DIFF
--- a/src/review/grounding-wire.ts
+++ b/src/review/grounding-wire.ts
@@ -140,8 +140,13 @@ export async function makeGithubFileFetcher(env: Env, repoFullName: string, inst
     async getFileContent(path: string, ref: string, maxChars = 24_001): Promise<string | null> {
       // #4499: content for a given (repo, path, ref) is a git blob at an immutable commit -- it never changes,
       // so a cache hit is always safe to reuse verbatim, skipping the GitHub call entirely. Checked BEFORE the
-      // network fetch below; only a genuinely successful fetch is ever written back (see the .catch-free write
-      // after the try block), so a transient failure is never mistaken for a confirmed-permanent one.
+      // network fetch below; only a genuinely COMPLETE fetch is ever written back (see the maxChars guard after
+      // the try block) -- a transient failure is never mistaken for a confirmed-permanent one, AND a fetch that
+      // hit ITS OWN caller's maxChars cap is never cached either. The cache key is (repo, path, ref) only, with
+      // no maxChars dimension, so caching a truncated placeholder would silently poison every OTHER caller that
+      // asks for this same file with a larger cap -- including patchless-secret-scan's 512KB probe, whose own
+      // truncation check compares against ITS cap, not the original (smaller) one, so a small cached placeholder
+      // reads as "complete" to it and a real secret past the original cutoff would never be scanned (#4584).
       const cached = await getCachedGroundingFileContent(env, repoFullName, path, ref).catch(() => null);
       if (cached !== null) {
         // #4448: mirrors repo-culture-profile's #4509 cache hit/miss instrumentation exactly -- one of the six
@@ -171,7 +176,7 @@ export async function makeGithubFileFetcher(env: Env, repoFullName: string, inst
           .join("/")}?ref=${encodeURIComponent(ref)}`;
         const controller = new AbortController();
         const timeout = setTimeout(() => controller.abort(), 10_000);
-        let content: string | null;
+        let content: string;
         try {
           const response = await timeoutFetch(url, {
             signal: controller.signal,
@@ -191,11 +196,11 @@ export async function makeGithubFileFetcher(env: Env, repoFullName: string, inst
         } finally {
           clearTimeout(timeout);
         }
-        /* v8 ignore next -- readTextWithLimit's `string | null` return type is defensive; both of its actual
-         * return paths (text.slice(...) / text) always produce a string, never null, so this guard's false
-         * side is unreachable via the current implementation. Kept so a future readTextWithLimit change that
-         * legitimately returns null can never get cached as if it were real fetched content. */
-        if (content !== null) {
+        // Cache ONLY a complete body (length within THIS caller's own maxChars). A maxChars+1-length result is
+        // either the synthetic truncation placeholder above or a real prefix sliced by readTextWithLimit -- both
+        // are partial-by-construction and must stay a cache miss for every caller, including one with a larger
+        // cap that would otherwise wrongly treat the cached partial as complete (#4584).
+        if (content.length <= maxChars) {
           await putCachedGroundingFileContent(env, repoFullName, path, ref, content).catch(() => undefined);
         }
         return content;
@@ -206,7 +211,7 @@ export async function makeGithubFileFetcher(env: Env, repoFullName: string, inst
   };
 }
 
-async function readTextWithLimit(response: Response, maxChars: number): Promise<string | null> {
+async function readTextWithLimit(response: Response, maxChars: number): Promise<string> {
   if (!response.body) {
     const text = await response.text();
     return text.length > maxChars ? text.slice(0, maxChars + 1) : text;

--- a/test/unit/grounding-wiring.test.ts
+++ b/test/unit/grounding-wiring.test.ts
@@ -541,7 +541,7 @@ describe("makeGithubFileFetcher (GitHub Contents-API-backed FileFetcher)", () =>
 
   it("REGRESSION (#4584): a truncated fetch is never cached, so a later call with a LARGER cap for the same (repo, path, ref) still fetches fresh instead of reusing the smaller cap's placeholder", async () => {
     const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "ghp_test" });
-    const full = "export const secret = 'token_after_the_small_cap';";
+    const full = "export const marker = 'content_beyond_the_small_caps_boundary';";
     let fetchCount = 0;
     const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
       const u = String(url);
@@ -558,9 +558,10 @@ describe("makeGithubFileFetcher (GitHub Contents-API-backed FileFetcher)", () =>
     // placeholder (a string of spaces, maxChars+1 long), which must NOT be cached.
     const small = await fetcher.getFileContent("truncated.ts", "sha7", 5);
     expect(small).toBe(" ".repeat(6));
-    // Second caller (e.g. the secret scanner) asks for the SAME file with a cap large enough to fit the
-    // whole body. Before the fix, this would have hit the cache and returned the 6-char space placeholder
-    // (which reads as "complete" against THIS caller's own 100-char cap), silently hiding the real content.
+    // Second caller (e.g. a content scanner that reads past where the first, smaller-cap caller stopped)
+    // asks for the SAME file with a cap large enough to fit the whole body. Before the fix, this would have
+    // hit the cache and returned the 6-char space placeholder (which reads as "complete" against THIS
+    // caller's own 100-char cap), silently hiding the real content past the original small cap.
     const large = await fetcher.getFileContent("truncated.ts", "sha7", 100);
     expect(large).toBe(full);
     expect(fetchCount).toBe(2);

--- a/test/unit/grounding-wiring.test.ts
+++ b/test/unit/grounding-wiring.test.ts
@@ -539,6 +539,46 @@ describe("makeGithubFileFetcher (GitHub Contents-API-backed FileFetcher)", () =>
     fetchSpy.mockRestore();
   });
 
+  it("REGRESSION (#4584): a truncated fetch is never cached, so a later call with a LARGER cap for the same (repo, path, ref) still fetches fresh instead of reusing the smaller cap's placeholder", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "ghp_test" });
+    const full = "export const secret = 'token_after_the_small_cap';";
+    let fetchCount = 0;
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockImplementation(async (url) => {
+      const u = String(url);
+      if (u.includes("/contents/truncated.ts")) {
+        fetchCount += 1;
+        // An explicit Content-Length over the caller's cap (as GitHub's Contents API always sends) takes the
+        // early-bail placeholder path -- matches the real exploit shape (`+1` bytes of spaces, not a real prefix).
+        return new Response(full, { status: 200, headers: { "content-length": String(full.length) } });
+      }
+      return new Response("missing", { status: 404 });
+    });
+    const fetcher = await makeGithubFileFetcher(env, "acme/widgets", null);
+    // First caller has a small cap -- the file exceeds it, so getFileContent returns the truncation
+    // placeholder (a string of spaces, maxChars+1 long), which must NOT be cached.
+    const small = await fetcher.getFileContent("truncated.ts", "sha7", 5);
+    expect(small).toBe(" ".repeat(6));
+    // Second caller (e.g. the secret scanner) asks for the SAME file with a cap large enough to fit the
+    // whole body. Before the fix, this would have hit the cache and returned the 6-char space placeholder
+    // (which reads as "complete" against THIS caller's own 100-char cap), silently hiding the real content.
+    const large = await fetcher.getFileContent("truncated.ts", "sha7", 100);
+    expect(large).toBe(full);
+    expect(fetchCount).toBe(2);
+    fetchSpy.mockRestore();
+  });
+
+  it("REGRESSION (#4584): a truncated fetch writes no row to grounding_file_content_cache at all", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "ghp_test" });
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("x".repeat(50), { status: 200 }));
+    try {
+      const fetcher = await makeGithubFileFetcher(env, "acme/widgets", null);
+      await fetcher.getFileContent("nocache.ts", "sha7", 10);
+      expect(await getCachedGroundingFileContent(env, "acme/widgets", "nocache.ts", "sha7")).toBeNull();
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
   it("a throwing cache READ degrades to a fresh live fetch (fail-safe, never blocks the file fetch)", async () => {
     const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "ghp_test" });
     const prepareSpy = vi.spyOn(env.DB, "prepare").mockImplementation(() => {


### PR DESCRIPTION
## Summary

- `getFileContent`'s cache key is `(repo, path, ref)` with no `maxChars` dimension, but a fetch that hit the *caller's own* `maxChars` cap was cached anyway (either the synthetic space placeholder or a real partial prefix from `readTextWithLimit`).
- A later caller asking for the same file with a *larger* cap — notably `patchless-secret-scan.ts`'s 512KB probe — would then get a cache hit returning the earlier, smaller caller's partial content. Since that partial content is shorter than the later caller's own truncation threshold, its own "is this truncated" check reads it as complete. A secret sitting past the original small cap's cutoff would never actually be scanned.
- Fix: only cache a fetch whose length fits within its own `maxChars`. Every other case stays a cache miss, so a later, larger-cap caller always re-fetches instead of trusting a partial result.
- Also narrowed `readTextWithLimit`'s return type from `string | null` to `string` (its actual implementation never returns null on the taken paths) and removed the now-inaccurate `v8 ignore` comment that depended on the old, looser type.

Follow-up to closed PR #4584, which identified this exact gap but closed on a CI/timing technicality before ever reaching a review verdict (`gittensory-orb`'s comment was still frozen at "reviewing…" when the PR closed). Re-verified the gap is still live against current `main` before reimplementing — the cache-key shape and the unconditional `content !== null` cache-write guard are unchanged since.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] Focused — one file's caching invariant, plus its test file. No unrelated changes.
- [x] Follows `CONTRIBUTING.md`; no `site/`/`CNAME`/`lovable` changes.
- [x] Owner PR — no separate linked-issue requirement (maintainer-side finding, not contributor work).

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` (full `npm run test:ci`, unsharded) — 100% statement / 100% branch on every changed line; the fix is bug-injection verified (temporarily reverted the `content.length <= maxChars` guard, confirmed both new regression tests fail with the exact poisoned-cache symptom, restored and confirmed green).
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] Two new regression tests: one behavioral (a small-cap truncated fetch followed by a larger-cap fetch for the same file still re-fetches and returns the complete body, not the placeholder), one direct-DB (a truncated fetch writes no row to `grounding_file_content_cache` at all).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, private keys, trust scores, or reward values exposed.
- [x] This IS the security fix — a cache-poisoning path that could cause the secret scanner to silently skip real secrets past a small cap's cutoff.
- [x] No auth/CORS/session changes.
- [x] No API/OpenAPI/MCP surface changed — internal caching behavior only.
- [x] No UI changes.