### PR TITLE
ci: bump the coverage-run matrix from 4 to 6 shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -381,7 +381,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4]
+        shard: [1, 2, 3, 4, 5, 6]
     env:
       VITE_GITTENSORY_API_ORIGIN: https://gittensory-api.aethereal.dev
     steps:
@@ -435,13 +435,13 @@ jobs:
         run: npm run build --workspace @jsonbored/gittensory-engine
       - name: Prepare test reports dir
         run: mkdir -p reports/junit
-      - name: Test with coverage (shard ${{ matrix.shard }}/4)
+      - name: Test with coverage (shard ${{ matrix.shard }}/6)
         id: coverage
         env:
           # Disables vitest.config.ts's own global 90% threshold check for THIS per-shard invocation -- a
           # single shard only exercises part of the tree, so it would always false-fail. The global-threshold
           # "catastrophe net" this disables is NOT dropped from CI, though: validate-tests-merge (below) merges
-          # all 4 shards' coverage via vitest's own --mergeReports and re-checks the threshold against that
+          # all shards' coverage via vitest's own --mergeReports and re-checks the threshold against that
           # merged (whole-suite) total, without COVERAGE_NO_THRESHOLDS set.
           COVERAGE_NO_THRESHOLDS: "true"
           # Same self-contained-test-file narrowing as the pre-sharding job had -- see the `mcpCliHarness`/
@@ -464,11 +464,11 @@ jobs:
               --exclude "test/unit/miner-calibration-types.test.ts"
             )
           fi
-          npm run test:coverage -- --maxWorkers=4 --shard=${{ matrix.shard }}/4 --reporter=default --reporter=blob --reporter=junit --outputFile.blob=blob-report/report-${{ matrix.shard }}.blob --outputFile.junit=reports/junit/vitest.xml "${EXCLUDE_ARGS[@]}"
+          npm run test:coverage -- --maxWorkers=4 --shard=${{ matrix.shard }}/6 --reporter=default --reporter=blob --reporter=junit --outputFile.blob=blob-report/report-${{ matrix.shard }}.blob --outputFile.junit=reports/junit/vitest.xml "${EXCLUDE_ARGS[@]}"
       - name: Test failure guidance
         if: ${{ failure() && steps.coverage.conclusion == 'failure' }}
         run: |
-          echo "::error title=Tests::The backend test coverage suite failed (shard ${{ matrix.shard }}/4)."
+          echo "::error title=Tests::The backend test coverage suite failed (shard ${{ matrix.shard }}/6)."
           echo "Coverage itself is gated by Codecov on changed lines (codecov/patch), computed from all shards' merged lcov."
           echo "Reproduce locally with: 'npm run test:coverage' (unsharded, runs the whole suite)."
       - name: Verify coverage report exists
@@ -478,7 +478,7 @@ jobs:
             echo "::error title=Coverage::coverage/lcov.info is missing or empty"
             exit 1
           fi
-      # Consumed by validate-tests-merge to re-check the global coverage threshold against all 4 shards
+      # Consumed by validate-tests-merge to re-check the global coverage threshold against all shards
       # combined -- see this job's own header comment.
       - name: Upload coverage blob report
         if: ${{ success() }}
@@ -547,7 +547,7 @@ jobs:
           override_pr: ${{ github.event.pull_request.number }}
           fail_ci_if_error: false
 
-  # Re-checks vitest.config.ts's global 90% coverage threshold against all 4 shards MERGED -- each shard
+  # Re-checks vitest.config.ts's global 90% coverage threshold against all shards MERGED -- each shard
   # above deliberately disables that check for itself (COVERAGE_NO_THRESHOLDS=true), since a single shard's
   # partial view would always false-fail it. This is the "loose catastrophe net" (e.g. a deleted test file)
   # vitest.config.ts's own comment describes; Codecov's patch gate (changed-lines only) doesn't cover a

--- a/test/unit/workflow-runner-labels.test.ts
+++ b/test/unit/workflow-runner-labels.test.ts
@@ -33,7 +33,7 @@ describe("workflow runner labels", () => {
     // validate-code so the dominant ~9-10min step no longer serializes with the much-faster checks.
     const validateTestsJob = workflow.slice(workflow.indexOf("\n  validate-tests:\n"), workflow.indexOf("\n  validate-tests-merge:\n"));
     expect(validateTestsJob).toContain("runs-on: ubuntu-latest");
-    // validate-tests-merge re-checks the global coverage threshold against all 4 shards merged -- see its
+    // validate-tests-merge re-checks the global coverage threshold against all shards merged -- see its
     // own header comment in ci.yml.
     const validateTestsMergeJob = workflow.slice(workflow.indexOf("\n  validate-tests-merge:\n"), workflow.indexOf("\n  security:\n"));
     expect(validateTestsMergeJob).toContain("runs-on: ubuntu-latest");


### PR DESCRIPTION
## Summary
- Bumps `validate-tests`'s matrix from 4 to 6 shards (`--shard=<i>/6`), following up #4815 now that real per-shard timing data exists.

## Why
Measured from the 4-way rollout: ~2,026s of aggregate test+import work spread across 4 shards, landing at ~150s wall time each (~85% parallel efficiency), with ~35s of fixed per-shard overhead (checkout/cache/build-engine + upload steps). At 6 shards, that projects to ~135s (~2.2min) wall time per shard, cutting the overall CI critical path from ~3.5-4min down to roughly ~2.7-2.9min.

Deliberately **not** going straight to 8: checked this repo's actual concurrent-run history and found genuine bursts of 15-20+ simultaneous `ci.yml` runs (confirmed only 2 of 17 concurrent runs in one sampled burst were from my own session's retriggers -- the rest were other contributors'/automation's real traffic, mostly automatic `push`-to-main runs). Since each PR's shard phase multiplies the job-slots that run demands from the shared concurrent-runner pool, doubling shard count (4→8) doubles that per-run demand during exactly the bursts this repo already produces regularly -- risking queuing that could offset or reverse the wall-clock win. 6 shards is a smaller (1.5x, not 2x) step to validate before considering 8.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run actionlint` clean
- [x] YAML parses
- [x] `codecov-policy.test.ts` / `workflow-runner-labels.test.ts` pass (no shard-count-specific assertions broke, only comment text updated)
- [ ] Watch real CI timing after merge, and watch for any shard jobs sitting `queued` rather than `in_progress` during a busy window -- that would be the signal to back off rather than push to 8