### PR TITLE
test(selfhost): raise selfhost-update-script's timeout for full-suite contention

### DIFF
--- a/test/unit/selfhost-update-script.test.ts
+++ b/test/unit/selfhost-update-script.test.ts
@@ -2,7 +2,14 @@ import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync 
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { spawnSync } from "node:child_process";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Each test here does 10-15+ real `git`/`bash` subprocess spawns (init, commit, push, clone, fetch, plus
+// the script-under-test's own git calls) -- the heaviest subprocess user of any file in the suite. That's
+// near-instant in isolation but can occasionally exceed the global 15s testTimeout under full-suite
+// parallel load (many concurrent worker processes contending for CPU), producing a spurious timeout rather
+// than a real failure. Raise this file's own timeout well above what real contention should ever cost.
+vi.setConfig({ testTimeout: 60_000 });
 
 // Real end-to-end execution of scripts/selfhost-update.sh (#1660) against a throwaway git remote,
 // with deploy-selfhost-prebuilt.sh and selfhost-post-update-check.sh replaced by stubs that just


### PR DESCRIPTION
## Summary
- `test/unit/selfhost-update-script.test.ts` inherits the global 15s `testTimeout` from `vitest.config.ts`, but each of its 12 tests does 10-15+ real `git`/`bash` subprocess spawns (`createSandbox()` alone does init/symbolic-ref/mkdir/write/chmod×3/init/remote-add/add/commit/push/clone, plus more per-test, plus the actual `selfhost-update.sh` script under test running its own git calls) — the heaviest subprocess user of any file in the suite.
- That's near-instant in isolation (each test 300-1100ms, whole file ~6.5s), but during this session's full-suite runs it spuriously timed out 3 separate times under heavy parallel load (~700 files, many concurrent workers contending for CPU/process-creation), each time on a *different* sub-test, always passing cleanly when re-run in isolation — a contention artifact, not a logic bug in the script or the test.
- Raises this file's own `testTimeout` to 60s via `vi.setConfig` (test-only change, doesn't touch the global default or any other file).
- Verified the fix: 2 full-suite runs after applying it (unrelated PR work in this session) both passed cleanly with no timeout on this file.

## Test plan
- [x] `npx tsc --noEmit -p .` — zero errors
- [x] `npx vitest run test/unit/selfhost-update-script.test.ts` — 12/12 passed in isolation
- [x] `npx vitest run test/unit test/integration` — 696/697 files passed (1 skipped, pre-existing), no timeout flake
- [x] `npm run docs:drift-check`, `npm run manifest:drift-check`, `npm run engine-parity:drift-check` — all ok
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities