### PR TITLE
test(selfhost): disable commit signing in the update-script sandbox

### DIFF
--- a/test/unit/selfhost-update-script.test.ts
+++ b/test/unit/selfhost-update-script.test.ts
@@ -31,7 +31,16 @@ exit "\${STUB_POST_UPDATE_EXIT:-0}"
 `;
 
 function git(args: string[], cwd: string) {
-  const result = spawnSync("git", args, { cwd, encoding: "utf8", env: { ...process.env, ...GIT_ENV } });
+  // -c commit.gpgsign=false: these are disposable sandbox repos for exercising the script's git
+  // plumbing, not real commits -- they must never depend on (or block on) a contributor's personal
+  // signing setup. Without this, a machine with `commit.gpgsign=true` and a hardware-backed signing
+  // key (e.g. a TouchID-gated SSH key) makes every sandbox commit wait on an interactive prompt that
+  // never comes in a test run, which manifests as a flaky ~15s test timeout on an arbitrary test.
+  const result = spawnSync("git", ["-c", "commit.gpgsign=false", ...args], {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env, ...GIT_ENV },
+  });
   if (result.status !== 0) {
     throw new Error(`git ${args.join(" ")} failed in ${cwd}: ${result.stderr}`);
   }


### PR DESCRIPTION
## Summary

- `test/unit/selfhost-update-script.test.ts` intermittently failed with `Test timed out in 15000ms` on an arbitrary test (varied run to run). Root cause: the test's shared `git()` helper spawns real `git commit` calls against throwaway sandbox repos with no override for `commit.gpgsign`, so on a machine with commit signing enabled and a hardware-backed key, every sandbox commit attempts a real interactive signature — which hangs waiting on a prompt nobody is present to answer in a test run. Fixed by passing `-c commit.gpgsign=false` in the shared `git()` helper: these are disposable fixtures for exercising the script's git plumbing, not real commits, so they must never depend on a contributor's personal signing configuration.

Closes #4949

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — this change touches only `test/**`, which Codecov does not measure; ran the full unsharded suite anyway (13906 passed, 0 failed) and re-ran the affected file alone 6x consecutively (12/12 passing every time, ~6s total, down from ~244s with 2 timeouts pre-fix).
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — N/A, this is a test-infrastructure-only fix with no production code change.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no such surface touched.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no API/MCP surface touched.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI touched.
- [x] Visible UI changes include a `UI Evidence` section below with screenshots. — N/A, no UI touched.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Owner PR (JSONbored); ran the full `npm run test:ci` gate plus `npm audit --audit-level=moderate` locally, both fully green.