### PR TITLE
ci: cache TypeScript incremental build state across validate-code runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -271,9 +271,29 @@ jobs:
         env:
           NODE_OPTIONS: ""
         run: node scripts/validate-observability-configs.mjs
+      # .tsbuildinfo mutates every run (tsc's own incremental state), unlike node_modules above which is
+      # immutable per lockfile -- so this needs the run_id-suffixed-key + restore-keys-prefix pattern (always
+      # creates a new cache entry to save into, restore falls back to the most recent matching prefix) rather
+      # than the hit-or-miss pattern node_modules uses. Measured ~13.5s cold vs ~3.6s warm locally; tsc
+      # verifies each file's content hash before trusting cached state, so a fresh checkout's reset mtimes
+      # can't cause a false cache hit that would mask a real type error.
+      - name: Restore TypeScript incremental build cache
+        if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' }}
+        uses: actions/cache/restore@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .tsbuildinfo
+          key: tsbuildinfo-${{ hashFiles('tsconfig.json', 'package-lock.json') }}-${{ github.run_id }}
+          restore-keys: |
+            tsbuildinfo-${{ hashFiles('tsconfig.json', 'package-lock.json') }}-
       - name: Typecheck
         if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' }}
         run: npm run typecheck
+      - name: Save TypeScript incremental build cache
+        if: ${{ !cancelled() && (github.event_name == 'push' || needs.changes.outputs.backend == 'true') }}
+        uses: actions/cache/save@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: .tsbuildinfo
+          key: tsbuildinfo-${{ hashFiles('tsconfig.json', 'package-lock.json') }}-${{ github.run_id }}
       # Moved ahead of "Test with coverage" (#ci-engine-build-order): src/mcp/find-opportunities.ts (root
       # backend, since #2281/#3985) imports packages/gittensory-miner/lib/opportunity-fanout.js -- committed,
       # pre-built JS -- which itself imports @jsonbored/gittensory-engine. That package's dist/ is gitignored

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -455,8 +455,6 @@ jobs:
         run: npm run build --workspace @jsonbored/gittensory-engine
       - name: Prepare test reports dir
         run: mkdir -p reports/junit
-      - name: Report runner CPU count (temporary diagnostic)
-        run: nproc
       - name: Test with coverage (shard ${{ matrix.shard }}/6)
         id: coverage
         env:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,13 @@
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "forceConsistentCasingInFileNames": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    // CI caches this across runs (validate-code job) to cut typecheck time on an unchanged/mostly-unchanged
+    // tree -- measured ~13.5s cold vs ~3.6s warm locally. Correctness is unaffected: tsc verifies each file's
+    // content hash before trusting the cached state, so a fresh checkout's reset mtimes can't cause a false
+    // cache hit.
+    "incremental": true,
+    "tsBuildInfoFile": ".tsbuildinfo"
   },
   "include": ["src", "test", "scripts/check-engine-parity.ts", "worker-configuration.d.ts", "vitest.config.ts", "vitest.workers.config.ts", "drizzle.config.ts"]
 }


### PR DESCRIPTION
## Summary
- Enables `tsc`'s own `--incremental` mode (`tsBuildInfoFile: .tsbuildinfo`) and caches it across `validate-code` runs. Measured ~13.5s cold vs ~3.6s warm locally on this codebase's typecheck -- a real cut on a step that runs unconditionally on every backend-touching PR.
- Uses the run_id-suffixed-key + restore-keys-prefix pattern (not the hit-or-miss pattern `node_modules` caching uses elsewhere in this job), since `.tsbuildinfo` mutates every run rather than being immutable per lockfile -- this always creates a fresh entry to save into, restore falls back to the most recent matching prefix.
- Also removes the temporary `nproc` diagnostic added in #4951: confirmed the real runner has exactly 4 vCPUs, exactly matching `--maxWorkers=4` already in use, so there's no free parallelism being left on the table without more shards.

## Why
This was originally the 2nd and 3rd commits on #4951 but didn't make it into that PR's merge (merged right after the 1st commit landed, before these follow-ups were pushed) -- reopening standalone.

## Correctness
Introduced a deliberate type error locally with a warm incremental cache present, confirmed `tsc` still reports it (real exit code 1); confirmed a clean tree still exits 0 after removing it. `tsc` verifies each file's content hash before trusting cached state, so a fresh CI checkout's reset mtimes can't produce a false cache hit that masks a real error.

## Test plan
- [x] `npx tsc --noEmit` clean (both cold and with a warm incremental cache)
- [x] `npm run actionlint` clean
- [x] YAML parses
- [x] Verified incremental-cache correctness with a deliberate type-error injection/removal cycle