### PR TITLE
chore: verify tsbuildinfo cache sharing (throwaway, will close)

### DIFF
--- a/scripts/actionlint.mjs
+++ b/scripts/actionlint.mjs
@@ -68,3 +68,4 @@ async function runActionlint() {
 
 const result = await runActionlint();
 process.exit(result.code);
+// cache-verification no-op 1783739035


### PR DESCRIPTION
Diagnostic-only PR to confirm the TypeScript incremental build cache from #4956 shares correctly from main into a fresh PR branch. Will close without merging once confirmed.