### PR TITLE
fix(rees): harden SLUG_RE against dot-segment path traversal in 17 analyzers

### DIFF
--- a/review-enrichment/src/analyzers/approval-integrity.ts
+++ b/review-enrichment/src/analyzers/approval-integrity.ts
@@ -17,7 +17,7 @@ import { boundedFetchJson } from "../external-fetch.js";
 import { githubHeaders } from "../github-headers.js";
 
 const GITHUB_API = "https://api.github.com";
-const SLUG_RE = /^[A-Za-z0-9._-]+$/;
+const SLUG_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/; // rejects `..` and other path-traversal segments
 const REVIEWS_PER_PAGE = 100;
 // GitHub returns PR reviews oldest-first with no reorder option, so a single `per_page=100` fetch would silently
 // read only the OLDEST reviews on any PR with more — exactly backwards for "each reviewer's latest vote". Walk

--- a/review-enrichment/src/analyzers/blame-link.ts
+++ b/review-enrichment/src/analyzers/blame-link.ts
@@ -16,7 +16,7 @@ import { githubHeaders } from "../github-headers.js";
 import { isHistoryUninformativePath } from "./history-path.js";
 
 const GITHUB_API = "https://api.github.com";
-const SLUG_RE = /^[A-Za-z0-9._-]+$/;
+const SLUG_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/; // rejects `..` and other path-traversal segments
 const MAX_FILES_PROBED = 6; // bound the files we probe, matching the other history-class analyzers
 const MAX_LOOKUPS = 12; // hard cap on total GitHub round-trips (each file costs up to 2: commits + pulls)
 const SHA_PREFIX_LEN = 12;

--- a/review-enrichment/src/analyzers/caller-impact.ts
+++ b/review-enrichment/src/analyzers/caller-impact.ts
@@ -33,7 +33,7 @@ import { isTestPath } from "./test-ratio.js";
 import { DEFAULT_MAX_FINDINGS } from "./limits.js";
 
 const GITHUB_API = "https://api.github.com";
-const SLUG_RE = /^[A-Za-z0-9._-]+$/;
+const SLUG_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/; // rejects `..` and other path-traversal segments
 const MAX_SYMBOLS = 6; // removed symbols searched per PR (Code Search rate budget)
 const MAX_SEARCHES = 6; // bounded Code Search queries per PR
 const MAX_FILE_FETCHES = 12; // bounded candidate-caller content fetches per PR

--- a/review-enrichment/src/analyzers/churn-hotspot.ts
+++ b/review-enrichment/src/analyzers/churn-hotspot.ts
@@ -15,7 +15,7 @@ import { githubHeaders } from "../github-headers.js";
 import { isHistoryUninformativePath } from "./history-path.js";
 
 const GITHUB_API = "https://api.github.com";
-const SLUG_RE = /^[A-Za-z0-9._-]+$/;
+const SLUG_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/; // rejects `..` and other path-traversal segments
 const WINDOW_DAYS = 90;
 const PER_PAGE = 100; // one page; a file with a full page of commits in the window is already a clear hotspot
 const MAX_FILES_PROBED = 8; // bound the GitHub round-trips, matching the other history-class analyzers

--- a/review-enrichment/src/analyzers/commit-hygiene.ts
+++ b/review-enrichment/src/analyzers/commit-hygiene.ts
@@ -20,7 +20,7 @@ import { githubHeaders } from "../github-headers.js";
 import { DEFAULT_MAX_FINDINGS } from "./limits.js";
 
 const GITHUB_API = "https://api.github.com";
-const SLUG_RE = /^[A-Za-z0-9._-]+$/;
+const SLUG_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/; // rejects `..` and other path-traversal segments
 const MAX_COMMITS = 100;
 const MAX_FINDINGS = DEFAULT_MAX_FINDINGS;
 const SHA_PREFIX_LEN = 12;

--- a/review-enrichment/src/analyzers/commit-lint.ts
+++ b/review-enrichment/src/analyzers/commit-lint.ts
@@ -16,7 +16,7 @@ import { githubHeaders } from "../github-headers.js";
 import { DEFAULT_MAX_FINDINGS } from "./limits.js";
 
 const GITHUB_API = "https://api.github.com";
-const SLUG_RE = /^[A-Za-z0-9._-]+$/;
+const SLUG_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/; // rejects `..` and other path-traversal segments
 const MAX_COMMITS = 100;
 const MAX_FINDINGS = DEFAULT_MAX_FINDINGS;
 const SHA_PREFIX_LEN = 12;

--- a/review-enrichment/src/analyzers/commit-signature.ts
+++ b/review-enrichment/src/analyzers/commit-signature.ts
@@ -19,7 +19,7 @@ const GITHUB_API = "https://api.github.com";
 // analyzers cap their network round-trips.
 const HISTORY_PER_PAGE = 30;
 // Only repository slugs that look like real `owner/repo` segments are ever interpolated into a request URL.
-const SLUG_RE = /^[A-Za-z0-9._-]+$/;
+const SLUG_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/; // rejects `..` and other path-traversal segments
 
 interface ScanOptions {
   signal?: AbortSignal;

--- a/review-enrichment/src/analyzers/complexity-delta.ts
+++ b/review-enrichment/src/analyzers/complexity-delta.ts
@@ -36,7 +36,7 @@ import { isJsTsPath, scanContentForComplexity } from "./complexity.js";
 import { DEFAULT_MAX_FINDINGS } from "./limits.js";
 
 const GITHUB_API = "https://api.github.com";
-const SLUG_RE = /^[A-Za-z0-9._-]+$/;
+const SLUG_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/; // rejects `..` and other path-traversal segments
 const MAX_FILES = 20;
 const MAX_FINDINGS = DEFAULT_MAX_FINDINGS;
 const MAX_FETCH_BYTES = 1_000_000;

--- a/review-enrichment/src/analyzers/coverage-delta.ts
+++ b/review-enrichment/src/analyzers/coverage-delta.ts
@@ -18,7 +18,7 @@ import { boundedFetchJson } from "../external-fetch.js";
 import { githubHeaders } from "../github-headers.js";
 
 const GITHUB_API = "https://api.github.com";
-const SLUG_RE = /^[A-Za-z0-9._-]+$/;
+const SLUG_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/; // rejects `..` and other path-traversal segments
 const MAX_RUNS_PROBED = 5; // recent successful runs to search for a coverage artifact
 const MAX_ARTIFACT_BYTES = 8 * 1024 * 1024; // skip an artifact zip larger than this (bounded download)
 const MAX_ENTRY_BYTES = 4 * 1024 * 1024; // skip a single uncompressed zip entry larger than this

--- a/review-enrichment/src/analyzers/doc-comment-drift.ts
+++ b/review-enrichment/src/analyzers/doc-comment-drift.ts
@@ -18,7 +18,7 @@ const MAX_SIGNATURE_LINES = 40;
 const MAX_FETCH_BYTES = 1_000_000;
 const SOURCE_RE = /\.(?:ts|tsx|mts|cts|js|jsx|mjs|cjs)$/;
 const SKIP_RE = /(?:\.d\.ts$|\.min\.|\.test\.|\.spec\.|__tests__\/|(?:^|\/)tests?\/)/;
-const SLUG_RE = /^[A-Za-z0-9._-]+$/;
+const SLUG_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/; // rejects `..` and other path-traversal segments
 // Matches a named `function` declaration up to its parameter `(`. A single, non-nested generic clause is allowed;
 // a nested-generic declaration (e.g. `function f<T extends Record<string, string>>(x)`) simply does not match and
 // the function is skipped — a deliberate recall/precision trade-off, never a false positive.

--- a/review-enrichment/src/analyzers/exhaustiveness-drift.ts
+++ b/review-enrichment/src/analyzers/exhaustiveness-drift.ts
@@ -13,7 +13,7 @@ import { isTestPath } from "./test-ratio.js";
 import { DEFAULT_MAX_FINDINGS } from "./limits.js";
 
 const GITHUB_API = "https://api.github.com";
-const SLUG_RE = /^[A-Za-z0-9._-]+$/;
+const SLUG_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/; // rejects `..` and other path-traversal segments
 const MAX_FILES = 10;
 const MAX_FETCHES = 10;
 const MAX_FINDINGS = DEFAULT_MAX_FINDINGS;

--- a/review-enrichment/src/analyzers/flaky-test.ts
+++ b/review-enrichment/src/analyzers/flaky-test.ts
@@ -15,7 +15,7 @@ import { isTestPath } from "./test-ratio.js";
 import { DEFAULT_MAX_FINDINGS } from "./limits.js";
 
 const GITHUB_API = "https://api.github.com";
-const SLUG_RE = /^[A-Za-z0-9._-]+$/;
+const SLUG_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/; // rejects `..` and other path-traversal segments
 const WINDOW_DAYS = 30;
 const WINDOW_LABEL = "30d";
 const MAX_FILES_PROBED = 6;

--- a/review-enrichment/src/analyzers/pending-review-requests.ts
+++ b/review-enrichment/src/analyzers/pending-review-requests.ts
@@ -18,7 +18,7 @@ import { boundedFetchJson } from "../external-fetch.js";
 import { githubHeaders } from "../github-headers.js";
 
 const GITHUB_API = "https://api.github.com";
-const SLUG_RE = /^[A-Za-z0-9._-]+$/;
+const SLUG_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/; // rejects `..` and other path-traversal segments
 const TIMELINE_PER_PAGE = 100;
 const MAX_TIMELINE_PAGES = 5;
 const STALE_THRESHOLD_MS = 48 * 60 * 60 * 1000; // 48 hours

--- a/review-enrichment/src/analyzers/revert-recurrence.ts
+++ b/review-enrichment/src/analyzers/revert-recurrence.ts
@@ -18,7 +18,7 @@ import { isHistoryUninformativePath } from "./history-path.js";
 import { DEFAULT_MAX_FINDINGS } from "./limits.js";
 
 const GITHUB_API = "https://api.github.com";
-const SLUG_RE = /^[A-Za-z0-9._-]+$/;
+const SLUG_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/; // rejects `..` and other path-traversal segments
 const MAX_FILES_PROBED = 5; // bound the per-file commit-history fan-out, matching the other history-class analyzers
 const COMMITS_PER_FILE = 15; // recent commits to inspect per probed file when looking for a revert
 const MAX_REVERT_LOOKUPS = 10; // global cap on revert-commit detail fetches across all probed files

--- a/review-enrichment/src/analyzers/stale-branch.ts
+++ b/review-enrichment/src/analyzers/stale-branch.ts
@@ -16,7 +16,7 @@ import { boundedFetchJson } from "../external-fetch.js";
 import { githubHeaders } from "../github-headers.js";
 
 const GITHUB_API = "https://api.github.com";
-const SLUG_RE = /^[A-Za-z0-9._-]+$/;
+const SLUG_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/; // rejects `..` and other path-traversal segments
 // Below this many commits behind, drifting from the default branch is normal PR life, not a staleness risk.
 const BEHIND_THRESHOLD = 100;
 

--- a/review-enrichment/src/analyzers/undocumented-export.ts
+++ b/review-enrichment/src/analyzers/undocumented-export.ts
@@ -16,7 +16,7 @@ const GITHUB_API = "https://api.github.com";
 const MAX_FILES = 10;
 const MAX_FINDINGS = 30;
 const MAX_FETCH_BYTES = 1_000_000;
-const SLUG_RE = /^[A-Za-z0-9._-]+$/;
+const SLUG_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/; // rejects `..` and other path-traversal segments
 // A public entrypoint barrel — an `index.<js/ts>` source file. Declaration (.d.ts), test, and generated output are
 // excluded: they are not the hand-authored public surface this scan is about.
 const ENTRYPOINT_RE = /(?:^|\/)index\.(?:ts|tsx|mts|cts|js|jsx|mjs|cjs)$/;

--- a/review-enrichment/src/analyzers/unused-export.ts
+++ b/review-enrichment/src/analyzers/unused-export.ts
@@ -18,7 +18,7 @@ import { isTestPath } from "./test-ratio.js";
 import { DEFAULT_MAX_FINDINGS } from "./limits.js";
 
 const GITHUB_API = "https://api.github.com";
-const SLUG_RE = /^[A-Za-z0-9._-]+$/;
+const SLUG_RE = /^[a-zA-Z0-9][a-zA-Z0-9._-]*$/; // rejects `..` and other path-traversal segments
 const MAX_SYMBOLS = 10;
 const MAX_SEARCHES = 10;
 const MAX_FILE_FETCHES = 10;

--- a/review-enrichment/test/approval-integrity.test.ts
+++ b/review-enrichment/test/approval-integrity.test.ts
@@ -192,6 +192,15 @@ test("scanApprovalIntegrity: a malformed repoFullName is skipped, not thrown", a
   assert.deepEqual(findings, []);
 });
 
+test("scanApprovalIntegrity: a dot-segment owner (path-traversal shape) is rejected, not thrown", async () => {
+  // ".." individually satisfies a bare `[A-Za-z0-9._-]+` class; only a first-character requirement catches it.
+  const findings = await scanApprovalIntegrity(
+    req({ repoFullName: "../evil" }),
+    reviewsFetch([review("alice", "APPROVED", "old-sha", "2026-01-01T00:00:00Z")]),
+  );
+  assert.deepEqual(findings, []);
+});
+
 test("scanApprovalIntegrity: a fetch failure yields no finding", async () => {
   const findings = await scanApprovalIntegrity(req(), async () => jsonResponse({ message: "bad" }, 500));
   assert.deepEqual(findings, []);

--- a/review-enrichment/test/blame-link.test.ts
+++ b/review-enrichment/test/blame-link.test.ts
@@ -175,3 +175,12 @@ test("scanBlameLink: no GitHub token → skipped (no finding, no throw)", async 
   );
   assert.deepEqual(findings, []);
 });
+
+test("scanBlameLink: a dot-segment owner (path-traversal shape) is rejected, not thrown", async () => {
+  // ".." individually satisfies a bare `[A-Za-z0-9._-]+` class; only a first-character requirement catches it.
+  const findings = await scanBlameLink(
+    req([{ path: "src/app.ts", status: "modified", patch: modifyPatch(2) }], { repoFullName: "../evil" }),
+    routedFetch({ commitSha: "abcdef1234567890", prNumber: 1 }),
+  );
+  assert.deepEqual(findings, []);
+});

--- a/review-enrichment/test/caller-impact.test.ts
+++ b/review-enrichment/test/caller-impact.test.ts
@@ -360,6 +360,11 @@ test("scanCallerImpact: no token / no headSha / invalid slug / no removed export
     await scanCallerImpact(req(files, { repoFullName: "octo/re po" }), failFetch),
     [],
   );
+  // ".." individually satisfies a bare `[A-Za-z0-9._-]+` class; only a first-character requirement catches it.
+  assert.deepEqual(
+    await scanCallerImpact(req(files, { repoFullName: "../evil" }), failFetch),
+    [],
+  );
   assert.deepEqual(
     await scanCallerImpact(
       req([{ path: "src/utils.ts", patch: ["@@ -0,0 +1,1 @@", "+export function added() {}"].join("\n") }]),

--- a/review-enrichment/test/churn-hotspot.test.ts
+++ b/review-enrichment/test/churn-hotspot.test.ts
@@ -93,6 +93,8 @@ test("scanChurnHotspot: skips lockfiles, binaries, and newly-added files without
 test("scanChurnHotspot: requires a github token and a valid repo slug", async () => {
   assert.deepEqual(await scanChurnHotspot({ repoFullName: "octo/repo", prNumber: 1, files: [{ path: "src/a.ts" }] }, async () => jsonResponse(commits(20, 2))), []);
   assert.deepEqual(await scanChurnHotspot({ repoFullName: "bad slug/x!", prNumber: 1, githubToken: "t", files: [{ path: "src/a.ts" }] }, async () => jsonResponse(commits(20, 2))), []);
+  // ".." individually satisfies a bare `[A-Za-z0-9._-]+` class; only a first-character requirement catches it.
+  assert.deepEqual(await scanChurnHotspot({ repoFullName: "../evil", prNumber: 1, githubToken: "t", files: [{ path: "src/a.ts" }] }, async () => jsonResponse(commits(20, 2))), []);
 });
 
 test("scanChurnHotspot: rejects multi-segment repo slugs without fetching", async () => {

--- a/review-enrichment/test/commit-hygiene.test.ts
+++ b/review-enrichment/test/commit-hygiene.test.ts
@@ -196,6 +196,15 @@ test("scanCommitHygiene: a malformed repoFullName is skipped, not thrown", async
   assert.deepEqual(findings, []);
 });
 
+test("scanCommitHygiene: a dot-segment owner (path-traversal shape) is rejected, not thrown", async () => {
+  // ".." individually satisfies a bare `[A-Za-z0-9._-]+` class; only a first-character requirement catches it.
+  const findings = await scanCommitHygiene(
+    req({ repoFullName: "../evil" }),
+    commitsFetch([commit(SHA_A, "fixup! x")]),
+  );
+  assert.deepEqual(findings, []);
+});
+
 test("scanCommitHygiene: a fetch failure yields no finding", async () => {
   const findings = await scanCommitHygiene(req(), async () => jsonResponse({ message: "bad" }, 500));
   assert.deepEqual(findings, []);

--- a/review-enrichment/test/commit-lint.test.ts
+++ b/review-enrichment/test/commit-lint.test.ts
@@ -87,6 +87,8 @@ test("scanCommitLint: fail-safe — no token, a bad repo slug, or a fetch error 
   assert.deepEqual(await scanCommitLint(req({ githubToken: undefined }), good), []);
   assert.deepEqual(await scanCommitLint(req({ repoFullName: "octo/repo/extra" }), good), []);
   assert.deepEqual(await scanCommitLint(req({ repoFullName: "bad slug!/x" }), good), []);
+  // ".." individually satisfies a bare `[A-Za-z0-9._-]+` class; only a first-character requirement catches it.
+  assert.deepEqual(await scanCommitLint(req({ repoFullName: "../evil" }), good), []);
   const err = async () => new Response("nope", { status: 500 });
   assert.deepEqual(await scanCommitLint(req(), err), []);
 });

--- a/review-enrichment/test/commit-signature.test.ts
+++ b/review-enrichment/test/commit-signature.test.ts
@@ -147,7 +147,9 @@ test("scanCommitSignature fails closed on a malformed repo slug WITHOUT any netw
   // A spy that records invocation: a malformed slug must be rejected BEFORE any GitHub request, so the guard
   // can never query the wrong repository. (A throwing fetch would be swallowed by the analyzer's fail-safe
   // try/catch and could mask a slug that slipped through, so assert the call never happens instead.)
-  for (const repoFullName of ["not-a-slug", "o/r/extra", "/r", "o/", "a/b/c/d"]) {
+  // "../evil"/"o/.."/"o/." each individually satisfy a bare `[A-Za-z0-9._-]+` class (every char in ".."/"." is
+  // allowed); only a first-character requirement on owner AND repo independently catches them.
+  for (const repoFullName of ["not-a-slug", "o/r/extra", "/r", "o/", "a/b/c/d", "../evil", "o/..", "o/."]) {
     let called = false;
     const spyFetch: typeof fetch = async () => {
       called = true;

--- a/review-enrichment/test/complexity-delta.test.ts
+++ b/review-enrichment/test/complexity-delta.test.ts
@@ -129,6 +129,26 @@ test("scanComplexityDelta: rejects multi-segment repo slugs without fetching", a
   assert.equal(called, false);
 });
 
+test("scanComplexityDelta: rejects a dot-segment owner/repo slug without fetching", async () => {
+  // ".." individually satisfies a bare `[A-Za-z0-9._-]+` class; only a first-character requirement catches it.
+  let called = false;
+  const out = await scanComplexityDelta(
+    {
+      repoFullName: "../evil",
+      prNumber: 1,
+      headSha: "abc123",
+      githubToken: "ght",
+      files: [{ path: "src/a.ts", patch: CALC_PATCH }],
+    },
+    async () => {
+      called = true;
+      return fileWith(HEAD_CONTENT)();
+    },
+  );
+  assert.deepEqual(out, []);
+  assert.equal(called, false);
+});
+
 test("scanComplexityDelta: skips non-source, test, and patch-less files without fetching", async () => {
   let called = false;
   const out = await scanComplexityDelta(

--- a/review-enrichment/test/coverage-delta.test.ts
+++ b/review-enrichment/test/coverage-delta.test.ts
@@ -207,6 +207,8 @@ test("scanCoverageDelta: requires a github token, a head sha, and a single valid
   assert.deepEqual(await scanCoverageDelta(req(files, { headSha: undefined }), call), []);
   assert.deepEqual(await scanCoverageDelta(req(files, { repoFullName: "octo/repo/extra" }), call), []);
   assert.deepEqual(await scanCoverageDelta(req(files, { repoFullName: "bad slug/x!" }), call), []);
+  // ".." individually satisfies a bare `[A-Za-z0-9._-]+` class; only a first-character requirement catches it.
+  assert.deepEqual(await scanCoverageDelta(req(files, { repoFullName: "../evil" }), call), []);
 });
 
 test("scanCoverageDelta: a PR that adds no lines never touches the network", async () => {

--- a/review-enrichment/test/doc-comment-drift.test.ts
+++ b/review-enrichment/test/doc-comment-drift.test.ts
@@ -308,6 +308,20 @@ test("scanDocCommentDrift: rejects multi-segment repo slugs without fetching", a
   assert.equal(called, false);
 });
 
+test("scanDocCommentDrift: rejects a dot-segment owner/repo slug without fetching", async () => {
+  // ".." individually satisfies a bare `[A-Za-z0-9._-]+` class; only a first-character requirement catches it.
+  let called = false;
+  const out = await scanDocCommentDrift(
+    { repoFullName: "../evil", prNumber: 1, headSha: "abc123", githubToken: "ght", files: [{ path: "src/a.ts", patch: DRIFT_PATCH }] },
+    async () => {
+      called = true;
+      return fileWith(DRIFTED)();
+    },
+  );
+  assert.deepEqual(out, []);
+  assert.equal(called, false);
+});
+
 test("scanDocCommentDrift: skips non-source and test files without fetching", async () => {
   let called = false;
   const out = await scanDocCommentDrift(

--- a/review-enrichment/test/exhaustiveness-drift.test.ts
+++ b/review-enrichment/test/exhaustiveness-drift.test.ts
@@ -183,6 +183,20 @@ test("scanExhaustivenessDrift: uses the analysis-context fetchText when supplied
   ]);
 });
 
+test("scanExhaustivenessDrift: rejects a dot-segment owner/repo slug without fetching", async () => {
+  // ".." individually satisfies a bare `[A-Za-z0-9._-]+` class; only a first-character requirement catches it.
+  let called = false;
+  const out = await scanExhaustivenessDrift(
+    req([{ path: "src/status.ts", status: "modified", patch: PATCH_ADD_ARCHIVED }], { repoFullName: "../evil" }),
+    async () => {
+      called = true;
+      return new Response(HEAD_UNCOVERED, { status: 200 });
+    },
+  );
+  assert.deepEqual(out, []);
+  assert.equal(called, false);
+});
+
 test("scanExhaustivenessDrift: returns no findings without a GitHub token", async () => {
   const findings = await scanExhaustivenessDrift(
     req([{ path: "src/status.ts", status: "modified", patch: PATCH_ADD_ARCHIVED }], {

--- a/review-enrichment/test/flaky-test.test.ts
+++ b/review-enrichment/test/flaky-test.test.ts
@@ -155,6 +155,20 @@ test("scanFlakyTest: marks partial status when the check-run probe cap is hit", 
   assert.equal(diagnostics.partialReason, "flaky_test_probe_cap");
 });
 
+test("scanFlakyTest: rejects a dot-segment owner/repo slug without fetching", async () => {
+  // ".." individually satisfies a bare `[A-Za-z0-9._-]+` class; only a first-character requirement catches it.
+  let called = false;
+  const out = await scanFlakyTest(
+    req([{ path: "src/app.test.ts", status: "modified" }], { repoFullName: "../evil" }),
+    async () => {
+      called = true;
+      return jsonResponse({ default_branch: "main" });
+    },
+  );
+  assert.deepEqual(out, []);
+  assert.equal(called, false);
+});
+
 test("scanFlakyTest: returns no findings without a GitHub token", async () => {
   const findings = await scanFlakyTest(
     req([{ path: "src/app.test.ts", status: "modified" }], { githubToken: undefined }),

--- a/review-enrichment/test/pending-review-requests.test.ts
+++ b/review-enrichment/test/pending-review-requests.test.ts
@@ -178,6 +178,15 @@ test("scanPendingReviewRequests: a malformed repoFullName is skipped, not thrown
   assert.deepEqual(findings, []);
 });
 
+test("scanPendingReviewRequests: a dot-segment owner (path-traversal shape) is rejected, not thrown", async () => {
+  // ".." individually satisfies a bare `[A-Za-z0-9._-]+` class; only a first-character requirement catches it.
+  const findings = await scanPendingReviewRequests(
+    req({ repoFullName: "../evil" }),
+    async () => jsonResponse({}),
+  );
+  assert.deepEqual(findings, []);
+});
+
 test("scanPendingReviewRequests: the requested-reviewers fetch failing yields no finding", async () => {
   const findings = await scanPendingReviewRequests(req(), async () => jsonResponse({ message: "bad" }, 500));
   assert.deepEqual(findings, []);

--- a/review-enrichment/test/revert-recurrence.test.ts
+++ b/review-enrichment/test/revert-recurrence.test.ts
@@ -190,6 +190,14 @@ test("scanRevertRecurrence: requires a github token and a single valid repo slug
     ),
     [],
   );
+  // ".." individually satisfies a bare `[A-Za-z0-9._-]+` class; only a first-character requirement catches it.
+  assert.deepEqual(
+    await scanRevertRecurrence(
+      { repoFullName: "../evil", prNumber: 1, githubToken: "t", files: [{ path: "src/a.ts", patch: PR_PATCH }] },
+      routed(OVERLAP_LIST, OVERLAP_DETAIL),
+    ),
+    [],
+  );
 });
 
 test("scanRevertRecurrence: rejects multi-segment repo slugs without fetching", async () => {

--- a/review-enrichment/test/stale-branch.test.ts
+++ b/review-enrichment/test/stale-branch.test.ts
@@ -104,6 +104,15 @@ test("scanStaleBranch: a malformed repoFullName is skipped, not thrown", async (
   assert.deepEqual(findings, []);
 });
 
+test("scanStaleBranch: a dot-segment owner (path-traversal shape) is rejected, not thrown", async () => {
+  // ".." individually satisfies a bare `[A-Za-z0-9._-]+` class; only a first-character requirement catches it.
+  const findings = await scanStaleBranch(
+    req({ repoFullName: "../evil" }),
+    routedFetch({ defaultBranch: "main", behindBy: 150, status: "behind" }),
+  );
+  assert.deepEqual(findings, []);
+});
+
 test("scanStaleBranch: the repo-info fetch failing yields no finding (and never calls compare)", async () => {
   let compareCalled = false;
   const findings = await scanStaleBranch(req(), async (url) => {

--- a/review-enrichment/test/undocumented-export.test.ts
+++ b/review-enrichment/test/undocumented-export.test.ts
@@ -203,6 +203,15 @@ test("scanUndocumentedExport: a rejected fetch or a non-OK (404) response yields
   assert.deepEqual(await scanUndocumentedExport(req(files), notOk), []); // resp.ok false → content skipped
 });
 
+test("scanUndocumentedExport: a dot-segment owner/repo slug is rejected, not thrown", async () => {
+  // ".." individually satisfies a bare `[A-Za-z0-9._-]+` class; only a first-character requirement catches it.
+  const findings = await scanUndocumentedExport(
+    req([{ path: "src/index.ts", status: "modified", patch: PATCH }], { repoFullName: "../evil" }),
+    headFetch(HEAD),
+  );
+  assert.deepEqual(findings, []);
+});
+
 test("scanUndocumentedExport: no token or no headSha → skipped (no finding, no throw)", async () => {
   const files = [{ path: "src/index.ts", status: "modified", patch: PATCH }];
   assert.deepEqual(await scanUndocumentedExport(req(files, { githubToken: undefined }), headFetch(HEAD)), []);

--- a/review-enrichment/test/unused-export.test.ts
+++ b/review-enrichment/test/unused-export.test.ts
@@ -156,6 +156,18 @@ test("scanUnusedExport: enforces the maxSearches cap", async () => {
   assert.equal(searches, 10);
 });
 
+test("scanUnusedExport: a dot-segment owner/repo slug is rejected, not thrown", async () => {
+  // ".." individually satisfies a bare `[A-Za-z0-9._-]+` class; only a first-character requirement catches it.
+  const patch = ["@@ -0,0 +1,1 @@", "+export function orphanHelper() {}"].join("\n");
+  const findings = await scanUnusedExport(
+    req([{ path: "src/util.ts", status: "added", patch }], { repoFullName: "../evil" }),
+    async () => {
+      throw new Error("should not fetch");
+    },
+  );
+  assert.deepEqual(findings, []);
+});
+
 test("scanUnusedExport: returns no findings without a GitHub token", async () => {
   const patch = ["@@ -0,0 +1,1 @@", "+export function lonely() {}"].join("\n");
   const findings = await scanUnusedExport(


### PR DESCRIPTION
## Summary

- Hardens `SLUG_RE` in 17 review-enrichment analyzers from the weak `/^[A-Za-z0-9._-]+$/` to `/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/`, matching the two analyzers (`duplication-delta.ts`, `codeowners.ts`) that already use the stricter pattern.
- A bare `[A-Za-z0-9._-]+` class lets a slug segment made entirely of dots (e.g. `owner=".."`) pass validation, since every character in `".."` is individually allowed by that class. These owner/repo values get spliced into a GitHub Contents-API URL passed to `fetch()`/`new URL()`; a leading-dot segment could let a URL parser's dot-segment resolution rewrite the path, sending the request (and the real auth token) somewhere other than the intended `owner/repo`. Requiring an alphanumeric first character closes that gap with no behavior change for any legitimate slug.
- Adds a test to each of the 17 files confirming a `".."`-shaped owner/repo segment is now rejected (fails safe, no finding, never throws) — extending an existing invalid-slug test where one already existed, adding a new one otherwise.
- Also normalizes 3 test files (`exhaustiveness-drift.test.ts`, `flaky-test.test.ts`, `unused-export.test.ts`) from pre-existing mixed CRLF/LF line endings (already present on `main`, unrelated to this change) to plain LF, matching every other file in the package — the mixed endings were tripping `git diff --check` once these files were touched for this PR.

Closes #4955

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused: a single mechanical hardening pass across `review-enrichment/src/analyzers/**` and its tests only — no backend/UI/MCP/docs/dependency/deploy changes mixed in.
- [x] This follows `CONTRIBUTING.md` and does not touch GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] Linked open issue: Closes #4955.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — passes (13910 tests, coverage thresholds met); note none of the 17 changed analyzer/test files are in vitest's coverage `include` scope (only the untouched `review-enrichment/src/analyzers/codeowners.ts` is), so `codecov/patch` has no lines to grade on this diff. REES's own gate, `npm run rees:test`, is the relevant bar here and is fully green (1308/1308, including all 17 new dot-segment tests).
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] New/changed behavior has tests for every new branch: all 17 touched analyzers each get a dedicated test confirming the new first-character requirement rejects a dot-segment slug.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] N/A — no public GitHub comment/text content changed.
- [x] N/A — no auth/cookie/CORS/GitHub App/Cloudflare/session changes.
- [x] N/A — no API/OpenAPI/MCP behavior changed.
- [x] N/A — no UI changes.
- [x] N/A — no visible UI change (see UI Evidence below).
- [x] N/A — no docs/changelog changes needed for a REES-internal hardening pass.

## UI Evidence

Not applicable — this PR only touches `review-enrichment/src/analyzers/**` and `review-enrichment/test/**`, a backend service package with no UI surface.

## Notes

- Mirrors the exact hardened pattern and trailing comment (`// rejects \`..\` and other path-traversal segments`) already used by `codeowners.ts`, kept byte-identical across all 17 files for consistency rather than 17 different phrasings.
- Deliberately a single pass across all 17 files at once, per the issue's explicit request — this was previously deferred twice (PR #4821, PR #4947), each of which touched 3 of these same files but left this fix for one consistent pass instead of a partial one.
- Four files (`churn-hotspot.ts`, `coverage-delta.ts`, `flaky-test.ts`, `revert-recurrence.ts`) guard with `!owner || !repo || !SLUG_RE.test(owner) || !SLUG_RE.test(repo)` but without an explicit `parts.length !== 2` check that the other 13 files have. That's a separate, pre-existing gap unrelated to the dot-segment character-class issue this PR fixes (a 3+ segment `repoFullName` still resolves to the correct first two parts; it isn't a path-traversal risk), so it's left out of this mechanical, single-purpose pass — flagging it here as a possible small follow-up rather than silently leaving it unmentioned.