### PR TITLE
refactor(queue): extract data-retention pruning into its own module

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -89,7 +89,6 @@ import {
   upsertPullRequestFromGitHub,
   upsertRepositoryFromGitHub,
 } from "../db/repositories";
-import { dedupeSignalSnapshots, pruneExpiredRecords } from "../db/retention";
 import {
   effectiveIssueCapForAccountAge,
   isBelowAccountAgeThreshold,
@@ -414,6 +413,11 @@ import {
   maybeRecloseDisallowedReopen,
   type ReopenRecloseOutcome,
 } from "./review-evasion";
+// #4013 step 7: same shim shape for runRetentionPrune -- imported here for processJob's own internal call
+// below, and re-exported so test/unit/retention.test.ts and test/unit/selfhost-pg-retention.test.ts's
+// existing `import { ... } from "../../src/queue/processors"` keeps working unchanged.
+import { runRetentionPrune } from "./retention";
+export { runRetentionPrune } from "./retention";
 import { isVisualPath } from "../review/visual/paths";
 import { buildCapture, fetchShotContentBlock, hasSuccessfulBotCapture, resolveVisualRoutes, type CaptureRoute } from "../review/visual/capture";
 import {
@@ -1045,38 +1049,6 @@ function reuseOrRefreshLiveCiAggregate(
   const cached = facts.forcedCiAggregateKeys.has(key) ? facts.ciAggregates.get(key) : undefined;
   if (cached) return cached;
   return refreshLiveCiAggregate(env, { repoFullName, facts, prNumber, headSha, baseRef, token, expectedCiContexts, admissionKey });
-}
-
-/**
- * Run (or dry-run) the data-retention prune across the configured log/snapshot tables, plus the
- * signal_snapshots dedup pass (#3810 -- signal_snapshots has no natural dedup, so within its own
- * retention window a key can still accumulate many superseded rows), and audit the combined outcome.
- * The per-table windows live in RETENTION_POLICY; only append-only/superseded tables are pruned.
- */
-export async function runRetentionPrune(
-  env: Env,
-  requestedBy: string,
-  dryRun: boolean,
-): Promise<void> {
-  const results = await pruneExpiredRecords(env, { dryRun });
-  const dedupeResults = await dedupeSignalSnapshots(env, { dryRun });
-  const totalDeleted = results.reduce((sum, result) => sum + result.deleted, 0);
-  const totalDeduped = dedupeResults.reduce((sum, result) => sum + result.deleted, 0);
-  await recordAuditEvent(env, {
-    eventType: "retention.prune",
-    actor: requestedBy,
-    outcome: dryRun ? "completed" : "success",
-    detail: dryRun
-      ? `dry-run: ${totalDeleted} row(s) eligible, ${totalDeduped} duplicate signal_snapshots row(s) eligible`
-      : `pruned ${totalDeleted} row(s), deduped ${totalDeduped} signal_snapshots row(s)`,
-    metadata: {
-      dryRun,
-      totalDeleted,
-      perTable: Object.fromEntries(results.map((r) => [r.table, r.deleted])),
-      totalDeduped,
-      perSignalType: Object.fromEntries(dedupeResults.map((r) => [r.signalType, r.deleted])),
-    },
-  });
 }
 
 const PUBLIC_MANIFEST_POLICY_FINDING_OVERRIDES: Partial<

--- a/src/queue/retention.ts
+++ b/src/queue/retention.ts
@@ -1,0 +1,38 @@
+// Data-retention pruning (#4013 step 7 -- extracted from processors.ts, seventh step of the file's own
+// module-split sequence, after transient-locks.ts, signal-snapshot.ts, duplicate-detection.ts,
+// slop-detection.ts, review-evasion.ts, and ci-resolution.ts). Pure move.
+
+import { recordAuditEvent } from "../db/repositories";
+import { dedupeSignalSnapshots, pruneExpiredRecords } from "../db/retention";
+
+/**
+ * Run (or dry-run) the data-retention prune across the configured log/snapshot tables, plus the
+ * signal_snapshots dedup pass (#3810 -- signal_snapshots has no natural dedup, so within its own
+ * retention window a key can still accumulate many superseded rows), and audit the combined outcome.
+ * The per-table windows live in RETENTION_POLICY; only append-only/superseded tables are pruned.
+ */
+export async function runRetentionPrune(
+  env: Env,
+  requestedBy: string,
+  dryRun: boolean,
+): Promise<void> {
+  const results = await pruneExpiredRecords(env, { dryRun });
+  const dedupeResults = await dedupeSignalSnapshots(env, { dryRun });
+  const totalDeleted = results.reduce((sum, result) => sum + result.deleted, 0);
+  const totalDeduped = dedupeResults.reduce((sum, result) => sum + result.deleted, 0);
+  await recordAuditEvent(env, {
+    eventType: "retention.prune",
+    actor: requestedBy,
+    outcome: dryRun ? "completed" : "success",
+    detail: dryRun
+      ? `dry-run: ${totalDeleted} row(s) eligible, ${totalDeduped} duplicate signal_snapshots row(s) eligible`
+      : `pruned ${totalDeleted} row(s), deduped ${totalDeduped} signal_snapshots row(s)`,
+    metadata: {
+      dryRun,
+      totalDeleted,
+      perTable: Object.fromEntries(results.map((r) => [r.table, r.deleted])),
+      totalDeduped,
+      perSignalType: Object.fromEntries(dedupeResults.map((r) => [r.signalType, r.deleted])),
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- Part of #4013's module-split sequence for `src/queue/processors.ts`. Step 7, after `transient-locks.ts` (#4157), `signal-snapshot.ts` (#4820), `duplicate-detection.ts` (#4823), `slop-detection.ts` (#4946), `review-evasion.ts` (#4957), and `ci-resolution.ts` (#4960).
- Moves `runRetentionPrune` into `src/queue/retention.ts`. Small, fully self-contained function (~30 lines) — its own dependencies (`pruneExpiredRecords`/`dedupeSignalSnapshots`) already lived in a dedicated `../db/retention` module, so this move needed no dependency untangling.
- A re-export shim keeps this file's own internal caller (`processJob`) and the existing `test/unit/retention.test.ts` / `test/unit/selfhost-pg-retention.test.ts` imports from `../../src/queue/processors` working unchanged.

Part of #4013 (more extraction steps remain in the sequence — not closing the tracking issue).

## Test plan
- [x] `npx tsc --noEmit -p .` — zero errors
- [x] `npx vitest run test/unit test/integration` — 696/697 files passed (1 skipped, pre-existing)
- [x] `npm run test:coverage` (unsharded) — 94.46% statements / 93.43% branches / 93.7% functions / 95.04% lines, no threshold failures; `retention.ts` itself is 100% line + branch + function covered
- [x] `npm run docs:drift-check`, `npm run manifest:drift-check`, `npm run engine-parity:drift-check` — all ok
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities