### PR TITLE
feat(mcp): add gittensory_check_improvement_potential pre-submit tool

### DIFF
--- a/.claude/skills/contributing-to-gittensory/reference.md
+++ b/.claude/skills/contributing-to-gittensory/reference.md
@@ -141,12 +141,18 @@ All tools are metadata-only (no source upload). Run in this order:
 2. `gittensory_validate_linked_issue` — `{owner, repo, issueNumber, plannedChange}` → is the issue
    open, valid, single-owner, solvable by this PR.
 3. `gittensory_check_slop_risk` — `{changedFiles[{path,additions,deletions}], description, tests,
-   testFiles}` → slopRisk 0–100 + band + findings.
-4. `gittensory_lint_pr_text` — `{commitMessages[], prBody, linkedIssue}` → verdict
+   testFiles}` → band + findings.
+4. `gittensory_check_improvement_potential` — `{changedFiles?[{path,additions,deletions}], tests?,
+   testFiles?, patchCoverageDeltaPercent?, complexityDeltas?[{file,line,name,before,after,delta}],
+   duplicationDeltas?[{file,line,duplicateOfLine,lines}]}` → improvementScore + band
+   (insufficient-signal/none/minor/moderate/significant) + findings. The positive-axis mirror of
+   `gittensory_check_slop_risk` — deterministic tier only (no LLM judgment); complexityDeltas/
+   duplicationDeltas are optional precomputed deltas the calling agent supplies, never raw source.
+5. `gittensory_lint_pr_text` — `{commitMessages[], prBody, linkedIssue}` → verdict
    strong/adequate/weak + specific fixes.
-5. `gittensory_validate_config` — `{content, source?}` → normalized manifest fields,
+6. `gittensory_validate_config` — `{content, source?}` → normalized manifest fields,
    warnings, and ok/warn/error status.
-6. `gittensory_predict_gate` — `{login, owner, repo, title, body, labels, linkedIssues}` → predicted
+7. `gittensory_predict_gate` — `{login, owner, repo, title, body, labels, linkedIssues}` → predicted
    conclusion + blockers + warnings + readiness score.
 
 (Auth'd extras: `gittensory_preflight_pr` / `…_local_diff` for lane fit + collision + queue health;

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -154,6 +154,7 @@ import { MAX_FOCUS_MANIFEST_BYTES } from "../signals/focus-manifest";
 import { loadPublicRepoFocusManifest, loadRepoFocusManifest } from "../signals/focus-manifest-loader";
 import { buildPredictedGateVerdict, type PredictedGateVerdict } from "../rules/predicted-gate";
 import { buildIssueSlopAssessment, buildSlopAssessment } from "../signals/slop";
+import { buildStructuralImprovementAssessment } from "../signals/improvement";
 import { buildBoundaryTestGenerationFinding, buildBoundaryTestGenerationSpec } from "../signals/boundary-test-generation";
 import { buildRepoDataQuality } from "../signals/data-quality";
 import { PREFLIGHT_LIMITS } from "../signals/preflight-limits";
@@ -918,6 +919,62 @@ const checkSlopRiskOutputSchema = {
   rubric: z.string().optional(),
 };
 
+// Deterministic structural-improvement counterpart to checkSlopRiskShape (#4746, sub-issue I of epic #4737):
+// the positive-axis mirror of checkSlopRisk, same pure local-metadata contract. changedFiles/tests/testFiles
+// are reused verbatim (same shape as checkSlopRiskShape) so the two signals never disagree about what counts
+// as test evidence. complexityDeltas/duplicationDeltas mirror ComplexityDeltaLike/DuplicationDeltaLike
+// (src/signals/improvement.ts) as already-derived structured deltas — the calling agent computes them from
+// its own local working tree (real before/after content, no reconstructOldContent trick needed) and supplies
+// them here; this tool never reads file content or diffs itself. Every field is optional:
+// buildStructuralImprovementAssessment degrades cleanly to "insufficient-signal" when nothing is supplied
+// (see its own tests), so there is no synthetic "at least one field required" check to duplicate here. No
+// auth required — same choice as checkSlopRisk: a pure function over caller-supplied structured data with no
+// owner/repo/login to scope, and improvementScore carries no gate/blocker power (advisory-only; see
+// improvement.ts's header comment), so there is nothing to gate.
+const checkImprovementPotentialShape = {
+  changedFiles: z
+    .array(z.object({ path: z.string().min(1).max(400), additions: z.number().int().min(0).optional(), deletions: z.number().int().min(0).optional() }))
+    .max(2000)
+    .optional(),
+  tests: z.array(z.string().max(400)).max(2000).optional(),
+  testFiles: z.array(z.string().max(400)).max(2000).optional(),
+  patchCoverageDeltaPercent: z.number().optional(),
+  complexityDeltas: z
+    .array(
+      z.object({
+        file: z.string().min(1).max(400),
+        line: z.number().int().min(1),
+        name: z.string().min(1).max(400),
+        before: z.number().int().min(0),
+        after: z.number().int().min(0),
+        delta: z.number().int(),
+      }),
+    )
+    .max(2000)
+    .optional(),
+  duplicationDeltas: z
+    .array(
+      z.object({
+        file: z.string().min(1).max(400),
+        line: z.number().int().min(1),
+        duplicateOfLine: z.number().int().min(1),
+        lines: z.number().int().min(1),
+      }),
+    )
+    .max(2000)
+    .optional(),
+};
+
+// Unlike checkSlopRiskOutputSchema, the numeric score is NOT blunted: improvementScore has no gate/blocker
+// power (unlike slopRisk, which the blunting explicitly protects from reverse-engineering an evasion of a
+// block — #mcp-slop-blunt), and the whole point of a supply-side pre-submit value signal is to let a miner
+// see how close their planned change is to the next band, so hiding the number would defeat the tool.
+const checkImprovementPotentialOutputSchema = {
+  improvementScore: z.number().optional(),
+  band: z.enum(["insufficient-signal", "none", "minor", "moderate", "significant"]).optional(),
+  findings: z.unknown().optional(),
+};
+
 // Coverage-gap self-check (#2235): pure local-metadata, like checkSlopRisk — the agent supplies its changed
 // paths (plus any test paths) and asks whether the change carries enough test evidence, no source uploaded.
 const checkTestEvidenceShape = {
@@ -1621,6 +1678,17 @@ export class GittensoryMcp {
         outputSchema: checkSlopRiskOutputSchema,
       },
       async (input) => this.toolResult(await this.checkSlopRisk(input)),
+    );
+
+    server.registerTool(
+      "gittensory_check_improvement_potential",
+      {
+        description:
+          "Assess the deterministic structural-improvement potential of a planned change from local diff metadata (paths + line counts) plus optional precomputed complexity/duplication deltas and a patch-coverage delta — an agent-native, source-free positive-signal self-check mirroring gittensory_check_slop_risk. Returns the score, band (insufficient-signal/none/minor/moderate/significant), and actionable findings. Deterministic tier only (no LLM judgment); no repo data needed.",
+        inputSchema: checkImprovementPotentialShape,
+        outputSchema: checkImprovementPotentialOutputSchema,
+      },
+      async (input) => this.toolResult(await this.checkImprovementPotential(input)),
     );
 
     server.registerTool(
@@ -2880,6 +2948,21 @@ export class GittensoryMcp {
     return {
       summary: `Slop risk: ${assessment.band}.`,
       data: { band: assessment.band, findings: assessment.findings } as unknown as Record<string, unknown>,
+    };
+  }
+
+  private async checkImprovementPotential(
+    input: z.infer<z.ZodObject<typeof checkImprovementPotentialShape>>,
+  ): Promise<ToolPayload> {
+    await this.enforceToolRateLimit("gittensory_check_improvement_potential");
+    const assessment = buildStructuralImprovementAssessment(input);
+    return {
+      summary: `Improvement potential: ${assessment.band}.`,
+      data: {
+        improvementScore: assessment.improvementScore,
+        band: assessment.band,
+        findings: assessment.findings,
+      } as unknown as Record<string, unknown>,
     };
   }
 

--- a/test/unit/mcp-check-improvement-potential.test.ts
+++ b/test/unit/mcp-check-improvement-potential.test.ts
@@ -1,0 +1,89 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { describe, expect, it } from "vitest";
+import { GittensoryMcp } from "../../src/mcp/server";
+import { createTestEnv } from "../helpers/d1";
+
+async function connect() {
+  const server = new GittensoryMcp(createTestEnv()).createServer();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  const client = new Client({ name: "gittensory-improvement-potential-test", version: "0.1.0" }, { capabilities: {} });
+  await client.connect(clientTransport);
+  return client;
+}
+
+describe("MCP gittensory_check_improvement_potential (#4746)", () => {
+  it("is registered with a non-empty description and an outputSchema", async () => {
+    const client = await connect();
+    const { tools } = await client.listTools();
+    const tool = tools.find((t) => t.name === "gittensory_check_improvement_potential");
+    expect(tool).toBeDefined();
+    expect(tool?.description?.length ?? 0).toBeGreaterThan(0);
+    expect(tool?.outputSchema).toBeDefined();
+    expect(tool?.outputSchema?.type).toBe("object");
+  });
+
+  it("degrades to insufficient-signal when every input is omitted", async () => {
+    const client = await connect();
+    const result = await client.callTool({ name: "gittensory_check_improvement_potential", arguments: {} });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as { improvementScore: number; band: string; findings: unknown[] };
+    expect(data).toEqual({ improvementScore: 0, band: "insufficient-signal", findings: [] });
+  });
+
+  it("still works from just changedFiles/tests/testFiles when complexityDeltas/duplicationDeltas are omitted", async () => {
+    const client = await connect();
+    const result = await client.callTool({
+      name: "gittensory_check_improvement_potential",
+      arguments: {
+        changedFiles: [
+          { path: "src/widget.ts", additions: 20, deletions: 5 },
+          { path: "test/unit/widget.test.ts", additions: 30, deletions: 0 },
+        ],
+      },
+    });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as { improvementScore: number; band: string; findings: Array<{ code: string }> };
+    expect(data.band).toBe("minor");
+    expect(data.findings.map((f) => f.code)).toEqual(["added_test_evidence"]);
+    // complexityDeltas/duplicationDeltas were never supplied, yet this still produced a real (non-insufficient) band.
+    expect(data.improvementScore).toBeGreaterThan(0);
+  });
+
+  it("reaches `significant` when both structural deltas are supplied, and does NOT blunt improvementScore", async () => {
+    const client = await connect();
+    const result = await client.callTool({
+      name: "gittensory_check_improvement_potential",
+      arguments: {
+        complexityDeltas: [{ file: "src/a.ts", line: 10, name: "foo", before: 12, after: 4, delta: -8 }],
+        duplicationDeltas: [{ file: "src/b.ts", line: 5, duplicateOfLine: 55, lines: 9 }],
+      },
+    });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as { improvementScore: number; band: string; findings: Array<{ code: string }> };
+    expect(data.band).toBe("significant");
+    // Unlike gittensory_check_slop_risk (blunted by design, #mcp-slop-blunt), the raw score IS returned here —
+    // improvementScore has no gate/blocker power, so there is nothing to protect from reverse-engineering.
+    expect(data).toHaveProperty("improvementScore");
+    expect(data.improvementScore).toBe(70);
+    expect(data.findings.map((f) => f.code).sort()).toEqual(["reduced_complexity", "resolved_duplication"]);
+    expect(JSON.stringify(data)).not.toMatch(/wallet|hotkey|coldkey|mnemonic|reward|payout|trust score/i);
+  });
+
+  it("combines a patch-coverage delta with duplication deltas into one aggregate score/band", async () => {
+    const client = await connect();
+    const result = await client.callTool({
+      name: "gittensory_check_improvement_potential",
+      arguments: {
+        patchCoverageDeltaPercent: 8,
+        duplicationDeltas: [{ file: "src/c.ts", line: 3, duplicateOfLine: 30, lines: 6 }],
+      },
+    });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as { improvementScore: number; band: string; findings: Array<{ code: string }> };
+    expect(data.improvementScore).toBe(55);
+    expect(data.band).toBe("moderate");
+    expect(data.findings.map((f) => f.code).sort()).toEqual(["increased_patch_coverage", "resolved_duplication"]);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a new MCP pre-submit tool, `gittensory_check_improvement_potential`, mirroring the existing
  `gittensory_check_slop_risk` tool but for the positive structural-improvement axis (sub-issue I of
  epic #4737). It calls `buildStructuralImprovementAssessment` (`src/signals/improvement.ts`, already
  shipped by #4742/#4822) directly from the MCP layer — no re-derived copy of the scoring math.
- Input is metadata-only, same contract family as `checkSlopRiskShape`: `changedFiles`/`tests`/
  `testFiles` are reused verbatim, plus optional `patchCoverageDeltaPercent`, `complexityDeltas`
  (mirrors `ComplexityDeltaLike`), and `duplicationDeltas` (mirrors `DuplicationDeltaLike`) — all
  already-derived structured deltas the calling agent supplies from its own local working tree. The
  tool never reads file content or diffs itself.
- Output is the same banded shape the deterministic aggregate already returns: `improvementScore` +
  `band` (`insufficient-signal`/`none`/`minor`/`moderate`/`significant`) + `findings`. Unlike
  `checkSlopRisk` (which blunts/omits its raw score to prevent reverse-engineering a gate evasion),
  the raw `improvementScore` **is** returned here — `improvementScore` carries no gate/blocker power
  (advisory-only per `improvement.ts`'s own header comment), so there is nothing to protect, and the
  whole point of a supply-side value signal is to let a contributor see how close a planned change is
  to the next band.
- No auth required, matching `checkSlopRisk`: this is a pure function over caller-supplied structured
  data with no owner/repo/login to scope. Documented inline in the code comment above the new shape.
- Updates `.claude/skills/contributing-to-gittensory/reference.md` §5's numbered tool list: new entry
  placed immediately after `check_slop_risk` (its closest sibling), items renumbered. Also fixes a
  stale doc line found while editing this exact list: the existing `check_slop_risk` entry still
  described a `slopRisk 0-100` return value that the handler stopped returning under the
  `#mcp-slop-blunt` change — corrected to match the real, current output shape.

**Explicit non-goal:** the LLM-tier judgment (`ModelReview.valueAssessment`, #4743) is intentionally
**not** attempted in this PR. It's designed to piggyback on the live AI-review call against an
already-opened PR, which does not exist at pre-submit time — see `improvement.ts`'s own header
comment and the parent issue's "technical wrinkle" section. Scoping this tool to the deterministic
tier only is a deliberate choice, not an oversight.

Closes #4746

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy
      changes (3 files: the MCP server, its reference doc, and one new test file).
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or
      `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #4746`).

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — 703 test files / 13925 tests passed (2 skipped), 100% of
      every line and branch added in this diff (verified directly against `coverage/lcov.info`'s
      `DA`/`BRDA` records for the new shape/registration/handler line ranges — zero 0-hit entries).
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] New behavior has tests for the new branch/registration path, including the
      complexityDeltas/duplicationDeltas-omitted degraded path (`insufficient-signal`), a
      changedFiles-only path (`minor`), a combined-structural-signals path (`significant`), and a
      patch-coverage + duplication combination (`moderate`) — plus an explicit assertion that
      `improvementScore` is present (documenting the deliberate divergence from `checkSlopRisk`'s
      blunted output).
- [x] Full `npm run test:ci` run completed end-to-end (all ~40 chained steps, ending in `ui:build`)
      with no failures anywhere.

If any required check was skipped, explain why:

- Nothing was skipped, but one full `npm run test:ci` run's embedded `test:coverage` step showed a
  transient anomaly (702 test files instead of the expected 703, missing exactly this PR's new test
  file, with no error/crash logged and the file untouched on disk). Two independent standalone
  `npm run test:coverage` re-runs (before and after rebasing onto latest `main`) both cleanly showed
  703/705 files passing, including the new file at 100% line/branch coverage. Flagging this
  transparently in case it recurs in CI; I could not identify a root cause tied to this PR's code
  (which has no forking/pooling/environment interaction — it's a schema declaration, a tool
  registration, and a straight-line handler with zero branches of its own).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores,
      private rankings, or private maintainer evidence are exposed (new tests assert the JSON output
      never matches a forbidden-terms pattern; all MCP tool output already passes through the shared
      `redactSensitiveForMcp` redaction in `toolResult`).
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or
      optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests —
      N/A, no auth/session changes in this PR.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section — N/A, no UI/frontend surface touched by
      this PR (backend MCP tool + a reference doc's text list).
- [x] Public docs updated where needed (`reference.md` §5); `CHANGELOG.md` intentionally not touched.

## Notes

- No UI Evidence section included: this PR has no visible UI/frontend component (no `apps/**` files
  touched).
- Followed `src/mcp/server.ts`'s `gittensory_check_slop_risk` registration/handler as the exact
  template per the parent issue's guidance, including its comment style, rate-limiting call
  (`enforceToolRateLimit`), and `toolResult` wrapping.
