### PR TITLE
chore(queue): remove 3 orphaned imports from processors.ts

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -248,7 +248,6 @@ import {
 import {
   DEFAULT_AUTO_MAINTAIN_POLICY,
   autonomyRequiresApproval,
-  isActingAutonomyLevel,
   isAgentConfigured,
   resolveAutonomy,
 } from "../settings/autonomy";
@@ -302,7 +301,6 @@ import { resolveGlobalContributorOpenItemCap, resolveGlobalContributorOpenItemCa
 import { detectMigrationCollisions, extractMigrationNumber, KNOWN_MIGRATION_DUPLICATES } from "../db/migration-collisions";
 import { listMigrationFilenamesAtRef } from "../github/migration-tree";
 import {
-  applyModerationEscalationForRule,
   executeAgentMaintenanceActions,
   executeIssueMaintenanceActions,
   pendingClosureLabelApplied,
@@ -522,7 +520,6 @@ import { classifyConfigurationCommandRequest } from "../github/configuration-com
 import { summarizeEffectiveConfig } from "../settings/effective-config-summary";
 import {
   buildReviewGroundingText,
-  checkSummaryText as checkFailureSummaryText,
   isGroundingEnabled,
   makeGithubFileFetcher,
 } from "../review/grounding-wire";


### PR DESCRIPTION
## Summary
- \`isActingAutonomyLevel\`, \`applyModerationEscalationForRule\`, and \`checkSummaryText\` (imported aliased
  as \`checkFailureSummaryText\`) have zero remaining call sites in \`src/queue/processors.ts\` -- leftover
  from an earlier module extraction (#4013). \`SlopBand\` was also checked and still has a real use site, so
  it's left in place.

## Test plan
- [x] \`npx tsc --noEmit -p .\` clean
- [x] Full unsharded \`npm run test:coverage\`: 703 files / 13933 tests passed, 0 failed
- [x] \`npm run docs:drift-check\`, \`manifest:drift-check\`, \`engine-parity:drift-check\` all pass
- [x] \`npm audit --audit-level=moderate\`: 0 vulnerabilities