### PR TITLE
fix(engine): auto-maintain sibling-package engine dependency ranges

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -15,6 +15,12 @@
   "include-component-in-tag": true,
   "separate-pull-requests": true,
   "pull-request-title-pattern": "chore(release): cut${component} v${version}",
+  "plugins": [
+    {
+      "type": "node-workspace",
+      "merge": false
+    }
+  ],
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Fixes" },


### PR DESCRIPTION
## Summary
- \`gittensory-mcp\` and \`gittensory-miner\` both pinned \`"@jsonbored/gittensory-engine": ">=0.1.0 <1.0.0"\`.
  Engine's upcoming 1.0.0 release (#4686) falls outside that upper bound, breaking \`npm ci\` with
  \`Missing: @jsonbored/gittensory-engine@0.2.0 from lock file\` -- the exact recurrence the \`<1.0.0\` cap
  guaranteed, since it was itself a manual fix (#4179) for the same bug at the 0.1.0 -> 0.2.0 bump.
- \`gittensory-mcp\` (a live, published package): widened to \`"^0.2.0"\`. Also enables release-please's
  **\`node-workspace\`** plugin (\`merge: false\`, matching this repo's existing \`separate-pull-requests: true\`),
  which automatically rewrites a workspace-local caret dependency's target version every time the package it
  points at gets bumped -- so this exact fix should never need to be repeated by hand again for mcp, on any
  future engine bump, major or otherwise.
- \`gittensory-miner\`: widened to \`"*"\`. Unlike mcp, \`@jsonbored/gittensory-miner\` has never actually been
  published (\`npm view\` 404s), so it has no real external consumer today and no version-range supply-chain
  exposure -- \`"*"\` is the standard idiom for a same-monorepo-only workspace dependency. Deliberately **not**
  onboarding miner into release-please management here since that's a separate release-process decision;
  flagging it as a follow-up worth a deliberate call, not bundling it into this fix.

## Test plan
- [x] \`rm -rf node_modules && npm ci\` resolves cleanly (was failing before this change)
- [x] \`npx tsc --noEmit -p .\` clean
- [x] \`npm run test --workspace @jsonbored/gittensory-engine\`: 349/349 pass
- [x] Full unsharded \`npm run test:coverage\`: 704 files / 13935 tests passed, 0 failed
- [x] \`npm run build:mcp\`, \`npm run build:miner\`, \`npm run test:mcp-pack\`, \`npm run test:miner-pack\` all pass
- [x] \`npm run docs:drift-check\`, \`manifest:drift-check\`, \`engine-parity:drift-check\` all pass
- [x] \`npm audit --audit-level=moderate\`: 0 vulnerabilities