### PR TITLE
fix(miner-ui): restrict run-state API to loopback

### DIFF
--- a/apps/gittensory-miner-ui/src/run-state-api.test.ts
+++ b/apps/gittensory-miner-ui/src/run-state-api.test.ts
@@ -16,8 +16,8 @@ function deps(overrides: Partial<RunStateApiDeps> = {}): RunStateApiDeps {
 }
 
 describe("handleRunStateRequest (#4305)", () => {
-  it("serves the run-state rows via the existing run-state.js exports", async () => {
-    const handled = await handleRunStateRequest("GET", "/api/run-state", deps());
+  it("serves the run-state rows via the existing run-state.js exports for loopback clients", async () => {
+    const handled = await handleRunStateRequest("GET", "/api/run-state", deps(), "127.0.0.1");
     expect(handled).toEqual({ status: 200, body: JSON.stringify({ rows }) });
   });
 
@@ -39,6 +39,31 @@ describe("handleRunStateRequest (#4305)", () => {
     );
     expect(handled).toEqual({ status: 200, body: JSON.stringify({ rows: [] }) });
     expect(listed).toBe(false);
+  });
+
+  it("denies non-loopback clients before loading the local store", async () => {
+    let loaded = false;
+    const handled = await handleRunStateRequest(
+      "GET",
+      "/api/run-state",
+      deps({
+        loadRunStateModule: async () => {
+          loaded = true;
+          throw new Error("must not load");
+        },
+      }),
+      "192.168.1.50",
+    );
+    expect(handled).toEqual({
+      status: 403,
+      body: JSON.stringify({ error: "run-state API is only available from loopback clients" }),
+    });
+    expect(loaded).toBe(false);
+  });
+
+  it("allows IPv6-mapped loopback clients", async () => {
+    const handled = await handleRunStateRequest("GET", "/api/run-state", deps(), "::ffff:127.0.0.1");
+    expect(handled).toEqual({ status: 200, body: JSON.stringify({ rows }) });
   });
 
   it("falls through (null) for other paths and non-GET methods", async () => {

--- a/apps/gittensory-miner-ui/vite-run-state-api.ts
+++ b/apps/gittensory-miner-ui/vite-run-state-api.ts
@@ -22,6 +22,16 @@ export type RunStateApiDeps = {
   fileExists: (path: string) => boolean;
 };
 
+function isLoopbackAddress(remoteAddress: string | undefined): boolean {
+  if (remoteAddress === undefined) return true;
+  return (
+    remoteAddress === "::1" ||
+    remoteAddress === "::ffff:127.0.0.1" ||
+    remoteAddress === "127.0.0.1" ||
+    remoteAddress.startsWith("127.")
+  );
+}
+
 const defaultDeps: RunStateApiDeps = {
   loadRunStateModule: () => import("../../packages/gittensory-miner/lib/run-state.js") as Promise<RunStateModule>,
   fileExists: existsSync,
@@ -33,8 +43,12 @@ export async function handleRunStateRequest(
   method: string | undefined,
   url: string | undefined,
   deps: RunStateApiDeps = defaultDeps,
+  remoteAddress?: string,
 ): Promise<{ status: number; body: string } | null> {
   if (url !== "/api/run-state" || (method !== undefined && method !== "GET")) return null;
+  if (!isLoopbackAddress(remoteAddress)) {
+    return { status: 403, body: JSON.stringify({ error: "run-state API is only available from loopback clients" }) };
+  }
   try {
     const runState = await deps.loadRunStateModule();
     // Fresh install: no DB file yet. Serve the empty list WITHOUT initializing the store (that would create
@@ -54,14 +68,14 @@ export function runStateApiPlugin(deps: RunStateApiDeps = defaultDeps): Plugin {
   const attach = (middlewares: {
     use: (
       fn: (
-        req: { method?: string; url?: string },
+        req: { method?: string; socket?: { remoteAddress?: string }; url?: string },
         res: { statusCode: number; setHeader: (k: string, v: string) => void; end: (body: string) => void },
         next: () => void,
       ) => void,
     ) => void;
   }) => {
     middlewares.use((req, res, next) => {
-      void handleRunStateRequest(req.method, req.url, deps).then((handled) => {
+      void handleRunStateRequest(req.method, req.url, deps, req.socket?.remoteAddress).then((handled) => {
         if (!handled) return next();
         res.statusCode = handled.status;
         res.setHeader("Content-Type", "application/json");


### PR DESCRIPTION
### Motivation
- The Vite dev/preview middleware exposed `GET /api/run-state` unauthenticated, leaking local miner run-state rows to any client that can reach the dev server.
- The endpoint read from the local SQLite-backed run-state store and could be reached when Vite was bound to a non-loopback host in container/VM/fleet setups, creating an information disclosure risk.

### Description
- Add a loopback-only guard by introducing `isLoopbackAddress()` and returning `403` for non-loopback remote addresses before loading or touching the local run-state module in `apps/gittensory-miner-ui/vite-run-state-api.ts`.
- Wire the Vite middleware to pass `req.socket?.remoteAddress` into the extracted handler so remote address checks run on dev/preview requests.
- Add regression tests in `apps/gittensory-miner-ui/src/run-state-api.test.ts` that assert non-loopback clients are denied without loading the store and that IPv6-mapped loopback addresses are allowed.
- Preserve the existing fresh-install fast path (serve `[]` if the DB file is absent) and the read-only behavior for loopback clients.

### Testing
- Ran the endpoint unit tests with `npm --workspace @jsonbored/gittensory-miner-ui exec -- vitest run src/run-state-api.test.ts`, and all tests passed.
- Type checking with `npm --workspace @jsonbored/gittensory-miner-ui run typecheck` completed successfully and `eslint` ran without errors (only existing warnings surfaced) via `npm --workspace @jsonbored/gittensory-miner-ui run lint`.
- `git diff --check` produced no trailing whitespace or conflict markers, while `npm audit --audit-level=moderate` failed due to the registry returning `403 Forbidden` (network/registry issue), not a local dependency advisory.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a50be435a18832cacf71339dd32eeb2)