### PR TITLE
fix(review): stop recomputing the type label on review-family webhooks

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -644,6 +644,13 @@ const PR_PUBLIC_SURFACE_ACTIONS = new Set([
   "edited",
 ]);
 const PR_GATE_CLOSED_ACTIONS = new Set(["closed"]);
+// #4818 follow-up: the three review-family event names `shouldProcessPullRequestPublicSurface` (below) also
+// routes into `maybePublishPrPublicSurface` -- none of them can ever change a PR's title or its own linked-issue
+// list (the only two inputs a TYPE-label decision depends on), yet each carries its OWN independently-timed,
+// independently-stale embedded `pull_request` webhook snapshot. Used ONLY to skip the type-label recompute
+// itself (see `maybePublishPrPublicSurface`'s type-label block) -- every OTHER piece of the public-surface
+// publish (gate re-evaluation, comments, screenshots, …) still needs to run on these events same as before.
+const PR_TYPE_LABEL_IRRELEVANT_EVENT_NAMES = new Set(["pull_request_review", "pull_request_review_comment", "pull_request_review_thread"]);
 const ISSUE_PLAN_COOLDOWN_MS = 10 * 60 * 1000;
 const NOTIFY_EVALUATE_EVENTS_PER_JOB = 100;
 
@@ -5641,6 +5648,7 @@ async function handlePullRequestWebhookEvent(
                 deliveryId,
                 authorType: payloadPullRequest.user?.type,
                 action: payload.action,
+                eventName,
                 baseSha: payloadPullRequest.base?.sha ?? null,
                 liveFacts,
               },
@@ -7331,6 +7339,12 @@ async function maybePublishPrPublicSurface(
     deliveryId: string;
     authorType?: string | undefined;
     action?: string | undefined;
+    // #4818 follow-up: the GitHub webhook event name (`pull_request`, `pull_request_review`, …), distinct from
+    // `action` above -- `action: "edited"` alone can't tell a `pull_request` title edit apart from a
+    // `pull_request_review` comment edit, and only the type-label block needs this distinction (see
+    // `PR_TYPE_LABEL_IRRELEVANT_EVENT_NAMES`). Omitted (sweep / manual-retrigger callers) is never in that
+    // set, so those paths are unaffected.
+    eventName?: string | undefined;
     baseSha?: string | null | undefined;
     previewPollAttempt?: number | undefined;
     skipAiReview?: boolean | undefined;
@@ -7576,11 +7590,19 @@ async function maybePublishPrPublicSurface(
   // label, so a type label would violate it same as a comment would. `typeLabelsEnabled` itself is
   // computed earlier (see its declaration above prelimHasPublicOutput) so gittensor_only's silence
   // promise can gate the public-surface computation too, not just this label decision (#gate-only-type-labels).
+  // #4818 follow-up: skip the recompute ENTIRELY (not merely the ambiguous branch) for a review-family
+  // trigger -- it can't legitimately change the answer, and its embedded PR snapshot is exactly the class of
+  // stale input that caused #4818. Nothing is lost, only deferred to the next pull_request-native event or the
+  // periodic sweep (which reaches this same code with `eventName` unset, so it is never excluded). Computed
+  // once and reused by both the gate below and the skip-reason ternary in the `else` branch, rather than
+  // re-evaluating `webhook.eventName ?? ""` twice for the identical answer.
+  const isReviewFamilyEvent = PR_TYPE_LABEL_IRRELEVANT_EVENT_NAMES.has(webhook.eventName ?? "");
   if (
     typeLabelsEnabled &&
     !settings.agentPaused &&
     decision.skipReason !== "miner_detection_unavailable" &&
-    decision.skipReason !== "not_official_gittensor_miner"
+    decision.skipReason !== "not_official_gittensor_miner" &&
+    !isReviewFamilyEvent
   ) {
     // Per-PR mutual exclusion (#regression-safe-propagation, mirrors the agent-maintenance claim at #2129
     // below in maybeRunAgentMaintenance): a merge fans out into a BURST of near-simultaneous webhook
@@ -7709,11 +7731,13 @@ async function maybePublishPrPublicSurface(
       }
     }
   } else {
-    const skipReason = settings.agentPaused
-      ? "agent_paused"
-      : decision.skipReason === "miner_detection_unavailable" || decision.skipReason === "not_official_gittensor_miner"
-        ? decision.skipReason
-        : "typeLabelsEnabled_false";
+    const skipReason = isReviewFamilyEvent
+      ? "irrelevant_review_family_event"
+      : settings.agentPaused
+        ? "agent_paused"
+        : decision.skipReason === "miner_detection_unavailable" || decision.skipReason === "not_official_gittensor_miner"
+          ? decision.skipReason
+          : "typeLabelsEnabled_false";
     await logTypeLabelSkip(env, repoFullName, pr.number, skipReason);
   }
 

--- a/test/unit/queue-5.test.ts
+++ b/test/unit/queue-5.test.ts
@@ -5832,6 +5832,135 @@ describe("queue processors", () => {
       expect(events.results).toEqual([{ outcome: "denied", detail: "lock_contended" }]);
     });
 
+    describe("review-family events never touch the type label (#4818 follow-up)", () => {
+      const REVIEW_FAMILY_WEBHOOKS: Array<{ eventName: string; action: string; extra?: Record<string, unknown> }> = [
+        { eventName: "pull_request_review", action: "submitted", extra: { review: { state: "approved", user: { login: "maintainer" }, submitted_at: "2026-07-11T02:26:36.000Z" } } },
+        { eventName: "pull_request_review_comment", action: "created", extra: { comment: { id: 1, user: { login: "maintainer" } } } },
+        { eventName: "pull_request_review_thread", action: "resolved", extra: { thread: { comments: [] } } },
+      ];
+
+      for (const webhook of REVIEW_FAMILY_WEBHOOKS) {
+        it(`skips the type-label recompute entirely (never even fetches the linked issue) on a ${webhook.eventName}:${webhook.action} webhook`, async () => {
+          const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+          await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+          await upsertRepositorySettings(env, {
+            repoFullName: "JSONbored/gittensory",
+            commentMode: "off",
+            publicSurface: "label_only",
+            autoLabelEnabled: true,
+            createMissingLabel: false,
+            checkRunMode: "off",
+            gateCheckMode: "enabled", reviewCheckMode: "required",
+            linkedIssueGateMode: "off",
+            aiReviewMode: "off",
+            linkedIssueLabelPropagation: {
+              enabled: true,
+              mode: "exclusive_type_label",
+              mappings: [{ issueLabel: "gittensor:feature", prLabel: "gittensor:feature", removeOtherTypeLabels: true }],
+            },
+          });
+          const seen = { posted: [] as string[], removed: [] as string[], issueFetches: 0 };
+          stubPropagationFetch(4818, 2192, seen, () => Response.json({ number: 2192, state: "closed", closed_at: "2026-07-11T02:26:25Z", user: { login: "JSONbored" }, labels: ["gittensor:feature"] }));
+
+          await processJob(env, {
+            type: "github-webhook",
+            deliveryId: `review-family-skip-${webhook.eventName}`,
+            eventName: webhook.eventName,
+            payload: {
+              action: webhook.action,
+              installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+              repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+              pull_request: {
+                number: 4818,
+                title: "feat(ui): confidence-calibration curve card on the analytics dashboard",
+                state: "open",
+                // The exact #4818 shape: this event's own embedded snapshot predates the merge (null merged_at)
+                // even though the linked issue is already closed -- if this reached the label block at all, it
+                // would hit the ambiguous branch. It must never get that far.
+                merged_at: null,
+                user: { login: "andriypolanski" },
+                author_association: "NONE",
+                head: { sha: "sha4818" },
+                labels: [],
+                body: "Closes #2192",
+              },
+              ...(webhook.extra ?? {}),
+            },
+          });
+
+          expect(seen.issueFetches).toBe(0);
+          expect(seen.posted).toEqual([]);
+          expect(seen.removed).toEqual([]);
+          const events = await env.DB.prepare(
+            `select outcome, detail from audit_events where event_type = 'github_app.type_label_decision' and target_key = 'JSONbored/gittensory#4818'`,
+          ).all();
+          expect(events.results).toEqual([{ outcome: "denied", detail: "irrelevant_review_family_event" }]);
+        });
+      }
+
+      it("REGRESSION (#4818 shape): a pull_request_review webhook leaves an already-correctly-propagated label untouched, where a same-shaped pull_request webhook would have hit the ambiguous branch", async () => {
+        const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+        await upsertRepositoryFromGitHub(env, { name: "widget", full_name: "acme/widget", private: false, owner: { login: "acme" } }, 123);
+        await upsertRepositorySettings(env, {
+          repoFullName: "acme/widget",
+          commentMode: "off",
+          publicSurface: "label_only",
+          autoLabelEnabled: true,
+          createMissingLabel: false,
+          checkRunMode: "off",
+          gateCheckMode: "enabled", reviewCheckMode: "required",
+          linkedIssueGateMode: "off",
+          aiReviewMode: "off",
+          linkedIssueLabelPropagation: {
+            enabled: true,
+            mode: "exclusive_type_label",
+            mappings: [{ issueLabel: "gittensor:feature", prLabel: "gittensor:feature", removeOtherTypeLabels: true }],
+          },
+        });
+        const seen = { posted: [] as string[], removed: [] as string[], issueFetches: 0 };
+        stubPropagationFetch(9001, 501, seen, () => Response.json({ number: 501, state: "open", user: { login: "contributor" }, labels: ["gittensor:feature"] }));
+
+        // Pass 1: PR opened while the issue is still open -- propagates gittensor:feature correctly.
+        await processJob(env, {
+          type: "github-webhook",
+          deliveryId: "pass-1-opened",
+          eventName: "pull_request",
+          payload: {
+            action: "opened",
+            installation: { id: 123, account: { login: "acme", id: 1, type: "User" } },
+            repository: { name: "widget", full_name: "acme/widget", private: false, owner: { login: "acme" } },
+            pull_request: { number: 9001, title: "fix: some bug", state: "open", user: { login: "contributor" }, author_association: "NONE", head: { sha: "sha9001a" }, labels: [], body: "Closes #501" },
+          },
+        });
+        expect(seen.posted).toEqual(["gittensor:feature"]);
+        // Pass 1's own mutual-exclusivity cleanup (feature applied -> bug/priority removed from the type-label
+        // set) -- captured here so pass 2's assertions below can prove it added NOTHING further, not just that
+        // the array happens to be empty.
+        const removedAfterPass1 = [...seen.removed].sort();
+        expect(removedAfterPass1).toEqual(["gittensor:bug", "gittensor:priority"]);
+
+        // Pass 2: a review submitted with a stale, pre-merge embedded snapshot (merged_at: null) arriving after
+        // the issue has since closed -- the exact #4818 race. Must be skipped entirely, not reach the ambiguous
+        // branch (which a same-shaped pull_request webhook would).
+        await processJob(env, {
+          type: "github-webhook",
+          deliveryId: "pass-2-stale-review",
+          eventName: "pull_request_review",
+          payload: {
+            action: "submitted",
+            installation: { id: 123, account: { login: "acme", id: 1, type: "User" } },
+            repository: { name: "widget", full_name: "acme/widget", private: false, owner: { login: "acme" } },
+            pull_request: { number: 9001, title: "fix: some bug", state: "open", merged_at: null, user: { login: "contributor" }, author_association: "NONE", head: { sha: "sha9001a" }, labels: [], body: "Closes #501" },
+            review: { state: "approved", user: { login: "maintainer" }, submitted_at: "2026-07-11T02:26:36.000Z" },
+          },
+        });
+
+        // Still exactly the one post + the one cleanup from pass 1 -- pass 2 added nothing further.
+        expect(seen.posted).toEqual(["gittensor:feature"]);
+        expect(seen.removed).toEqual(removedAfterPass1);
+      });
+    });
+
     it("never fetches a linked issue and keeps normal behavior when propagation is left at its default (disabled) (#priority-linked-issue-gate)", async () => {
       // Deliberately NOT "JSONbored/gittensory" (unlike its two sibling tests above): this repo's own
       // `.gittensory.yml` now enables propagation for itself (#priority-linked-issue-gate-ownership


### PR DESCRIPTION
## Summary

- Follow-up to #4975/#4980: excludes `pull_request_review`, `pull_request_review_comment`, and `pull_request_review_thread` webhooks from the type-label recompute entirely. None of the three can ever change a PR's title or its linked-issue list — the only two inputs the label decision depends on — yet each was still reaching the recompute with its own independently-stale embedded PR snapshot, which is the exact mechanism #4818 exploited. #4980 fixed the one discovered symptom of that staleness (an ambiguous null `prMergedAt`); this shrinks the risk surface structurally so future not-yet-discovered staleness paths in these three event types can't reach the decision at all, rather than continuing to patch each one as it's found.
- Nothing is lost: a genuine title/linked-issue change is still caught by the next `pull_request`-native event (opened/reopened/synchronize/ready_for_review/edited/closed) or the periodic sweep — bounded delay, not a lost update.
- Also audited and confirmed clean (documented in #4986, no code change needed): the sweep/cross-reference path can't reach this block for a non-open PR; the manual panel-retrigger path reads a DB row (protected by this codebase's `undefined`-omits-the-column upsert convention), not a webhook snapshot; `/pulls/{n}`/`/issues/{n}` reads are excluded from both the response cache and unsafe single-flight coalescing; exactly one code path writes these labels anywhere in `src/`.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #4986`).

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` locally
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- `test:coverage` (full unsharded): not run end-to-end locally — ran scoped `vitest --coverage` for `test/unit/queue-2.test.ts` + `test/unit/queue-5.test.ts` (the two files that exercise this code path) and confirmed via lcov that every line/branch touched by this diff is covered (the one remaining 0-hit line in the surrounding function is a pre-existing, untouched `catch` block, not part of this change). Also ran `npm run test:changed`: 7949 tests passed. CI's own `codecov/patch` run is authoritative for the final number.
- `test:workers` / `build:mcp` / `test:mcp-pack` / `ui:openapi:check` / `ui:lint` / `ui:typecheck` / `ui:build`: not run — this change touches only `src/queue/processors.ts` and its test file, no UI/MCP/Worker-pool/OpenAPI-surface changes.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session surface touched; new tests explicitly cover the "review-family event, no fetch, no label write" negative path for all 3 excluded event types plus a combined regression test.)
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A.)
- [ ] UI changes use live API data or real empty/error/loading states. (N/A — no UI changes.)
- [ ] Visible UI changes include a `UI Evidence` section. (N/A — no UI changes.)
- [ ] Public docs/changelogs are updated where needed. (N/A — internal engine behavior; changelog is not edited in a normal PR.)

## Notes

- Prompted directly by a question about why the type label was recomputing on a review-submission event in the first place — the honest answer was "it never needed to, it was just riding along on a bigger shared function with no relevance gate of its own." This PR adds that gate.
