### PR TITLE
fix(review): avoid overlapping screenshot table extraction

### DIFF
--- a/packages/gittensory-engine/src/review/screenshot-table-gate.ts
+++ b/packages/gittensory-engine/src/review/screenshot-table-gate.ts
@@ -211,6 +211,7 @@ export function extractTableRows(body: string | null | undefined): string[][] {
       rows.push(cells);
       j += 1;
     }
+    i = j - 1;
   }
   return rows;
 }

--- a/src/review/screenshot-table-gate.ts
+++ b/src/review/screenshot-table-gate.ts
@@ -211,6 +211,7 @@ export function extractTableRows(body: string | null | undefined): string[][] {
       rows.push(cells);
       j += 1;
     }
+    i = j - 1;
   }
   return rows;
 }

--- a/test/unit/screenshot-table-gate-engine.test.ts
+++ b/test/unit/screenshot-table-gate-engine.test.ts
@@ -6,6 +6,7 @@ import {
   DEFAULT_SCREENSHOT_TABLE_GATE,
   evaluateScreenshotTableGate,
   extractTableRowImageUrls,
+  extractTableRows,
   hasCommittedImageFile,
   hasImageBearingMarkdownTable,
   hasImageOutsideTable,
@@ -319,6 +320,14 @@ describe("requiredScreenshotMatrixPairs (#4535)", () => {
       { viewport: "Mobile", theme: "Light" },
       { viewport: "Mobile", theme: "Dark" },
     ]);
+  });
+});
+
+describe("extractTableRows", () => {
+  it("extracts a crafted separator-only table once instead of duplicating overlapping regions", () => {
+    const body = Array.from({ length: 40 }, () => "| --- |").join("\n");
+
+    expect(extractTableRows(body)).toHaveLength(38);
   });
 });
 

--- a/test/unit/screenshot-table-gate.test.ts
+++ b/test/unit/screenshot-table-gate.test.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_SCREENSHOT_TABLE_GATE,
   evaluateScreenshotTableGate,
   extractTableRowImageUrls,
+  extractTableRows,
   hasCommittedImageFile,
   hasImageBearingMarkdownTable,
   hasImageOutsideTable,
@@ -318,6 +319,14 @@ describe("requiredScreenshotMatrixPairs (#4535)", () => {
       { viewport: "Mobile", theme: "Light" },
       { viewport: "Mobile", theme: "Dark" },
     ]);
+  });
+});
+
+describe("extractTableRows", () => {
+  it("extracts a crafted separator-only table once instead of duplicating overlapping regions", () => {
+    const body = Array.from({ length: 40 }, () => "| --- |").join("\n");
+
+    expect(extractTableRows(body)).toHaveLength(38);
   });
 });
 


### PR DESCRIPTION
### Motivation
- The matrix-mode table parser could repeatedly rescan overlapping header+separator candidates and materialize the same rows many times, creating a quadratic CPU/memory denial-of-service risk for attacker-controlled PR bodies. 
- The change prevents that excessive re-scanning while preserving the intended matrix detection behavior.

### Description
- Advance the outer scan index past a detected markdown table region in `extractTableRows()` so each table region is processed once instead of being re-scanned from every matching header line; implemented in `src/review/screenshot-table-gate.ts`. 
- Apply the same fix to the duplicated implementation in `packages/gittensory-engine/src/review/screenshot-table-gate.ts` for parity. 
- Add regression tests that assert a crafted separator-only table is extracted once (tests added to both `test/unit/screenshot-table-gate.test.ts` and `test/unit/screenshot-table-gate-engine.test.ts`). 
- Refresh generated Cloudflare Worker types (`worker-configuration.d.ts`) to satisfy the `cf-typegen` drift check.

### Testing
- Ran the targeted unit tests with `npm test -- --run test/unit/screenshot-table-gate.test.ts test/unit/screenshot-table-gate-engine.test.ts`, and the two test files passed (all included assertions succeeded). 
- Ran the targeted coverage command `npm run test:coverage -- --run test/unit/screenshot-table-gate.test.ts test/unit/screenshot-table-gate-engine.test.ts`, where the focused tests passed but the global coverage threshold check failed when v8 reported repository-wide coverage below the required threshold. 
- Attempted the full local gate with `npm run test:ci`; the run exercised many checks but did not complete cleanly in this environment due to external/tooling fallbacks and unrelated suite failures (network/DNS and environment-driven failures outside the scope of this patch). 
- Attempted `npm audit --audit-level=moderate`, which failed due to the registry audit endpoint returning `403 Forbidden` in the environment; no package changes were made by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51eb3585c0832c8c78f3599474eb20)