### PR TITLE
fix(orb): return 503 instead of a bare 500 from the relay register/pull routes

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -3343,7 +3343,18 @@ export function createApp() {
     const auth = c.req.header("authorization") ?? "";
     const secret = auth.startsWith("Bearer ") ? auth.slice(7).trim() : "";
     if (!secret) return c.json({ error: "missing_enrollment_secret" }, 401);
-    const enrollment = await validateOrbRelayEnrollment(c.env, secret);
+    // #4995: validateOrbRelayEnrollment/registerValidatedOrbRelay both touch the DB directly (no error handling
+    // of their own) — an unhandled D1/Postgres error here previously escaped as a bare framework 500 instead of
+    // a clean 503, the same class of gap #orb-broker-500 already fixed for /v1/orb/token's own DB-touching call.
+    // `.catch(...)` on just the two DB-touching calls (rather than wrapping the whole handler in try/catch) so a
+    // genuine broker_error is reported without disturbing every other line's indentation/coverage.
+    const dbBrokerError = (error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(JSON.stringify({ level: "error", event: "orb_relay_register_failed", message: message.slice(0, 200) }));
+      return null;
+    };
+    const enrollment = await validateOrbRelayEnrollment(c.env, secret).catch(dbBrokerError);
+    if (enrollment === null) return c.json({ error: "broker_error" }, 503);
     if ("error" in enrollment) return c.json(enrollment, enrollment.error === "invalid_enrollment" ? 401 : 403);
     const rawBody = await readOrbRelayRegisterBody(c.req.raw, c.req.header("content-length"));
     if (rawBody === null) return c.json({ error: "payload_too_large" }, 413);
@@ -3358,7 +3369,8 @@ export function createApp() {
     if (mode === null) return c.json({ error: "invalid_mode" }, 400);
     const relayUrl = typeof body?.relayUrl === "string" ? body.relayUrl.trim() : "";
     if (mode === "push" && !relayUrl) return c.json({ error: "missing_relay_url" }, 400);
-    const result = await registerValidatedOrbRelay(c.env, enrollment, secret, relayUrl, mode);
+    const result = await registerValidatedOrbRelay(c.env, enrollment, secret, relayUrl, mode).catch(dbBrokerError);
+    if (result === null) return c.json({ error: "broker_error" }, 503);
     if ("error" in result) {
       const status = result.error === "invalid_enrollment" ? 401 : result.error === "installation_not_eligible" ? 403 : result.error === "encryption_unavailable" ? 500 : 400;
       return c.json(result, status);
@@ -3375,7 +3387,19 @@ export function createApp() {
     const auth = c.req.header("authorization") ?? "";
     const secret = auth.startsWith("Bearer ") ? auth.slice(7).trim() : "";
     if (!secret) return c.json({ error: "missing_enrollment_secret" }, 401);
-    const enrollment = await validateOrbRelayEnrollment(c.env, secret);
+    // #4995 (GITTENSORY-1C, orb_relay_drain_http_500): validateOrbRelayEnrollment/pullRelayPending both touch
+    // the DB directly (prune/delete/select, no error handling of their own) — an unhandled D1/Postgres error
+    // here previously escaped as a bare framework 500, which is exactly what the drain client saw repeatedly in
+    // production. The drain client's own in-flight guard and matched poll/request timeout (src/server.ts) were
+    // already correct; the gap was entirely server-side. Same `.catch(...)`-on-the-DB-call shape as the sibling
+    // /v1/orb/relay/register fix above, for the same reason.
+    const dbBrokerError = (error: unknown) => {
+      const message = error instanceof Error ? error.message : String(error);
+      console.error(JSON.stringify({ level: "error", event: "orb_relay_pull_failed", message: message.slice(0, 200) }));
+      return null;
+    };
+    const enrollment = await validateOrbRelayEnrollment(c.env, secret).catch(dbBrokerError);
+    if (enrollment === null) return c.json({ error: "broker_error" }, 503);
     if ("error" in enrollment) return c.json(enrollment, enrollment.error === "invalid_enrollment" ? 401 : 403);
     const rawBody = await readOrbRelayRegisterBody(c.req.raw, c.req.header("content-length"));
     if (rawBody === null) return c.json({ error: "payload_too_large" }, 413);
@@ -3386,7 +3410,8 @@ export function createApp() {
     } catch {
       ack = undefined; // tolerate an empty/invalid body — just no ack this round
     }
-    const events = await pullRelayPending(c.env, enrollment.installationId, { ack });
+    const events = await pullRelayPending(c.env, enrollment.installationId, { ack }).catch(dbBrokerError);
+    if (events === null) return c.json({ error: "broker_error" }, 503);
     return c.json({ events }, 200);
   });
 

--- a/test/integration/orb-relay.test.ts
+++ b/test/integration/orb-relay.test.ts
@@ -113,6 +113,48 @@ describe("POST /v1/orb/relay/register", () => {
     expect(res.status).toBe(401);
     expect(bodyAccesses).toBe(0);
   });
+
+  it("REGRESSION (#4995, same class of gap as GITTENSORY-1C): a DB error inside registerValidatedOrbRelay returns a clean 503 broker_error instead of an unhandled framework 500", async () => {
+    const e = brokeredEnv();
+    const secret = await enroll(e, 8506);
+    const realPrepare = db(e).prepare.bind(db(e));
+    db(e).prepare = ((sql: string) => {
+      const statement = realPrepare(sql);
+      if (!/orb_enrollments/i.test(sql)) return statement;
+      return {
+        ...statement,
+        bind(...values: unknown[]) {
+          const bound = statement.bind(...(values as never[]));
+          // Rejects with a non-Error value (not `new Error(...)`) so this also exercises dbBrokerError's
+          // `String(error)` fallback branch, not just its `error instanceof Error` branch.
+          return { ...bound, run: () => Promise.reject("db unavailable") };
+        },
+      };
+    }) as typeof realPrepare;
+    const res = await app.request("/v1/orb/relay/register", { method: "POST", headers: { authorization: `Bearer ${secret}` }, body: JSON.stringify({ relayUrl: "https://x.example/relay" }) }, e);
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: "broker_error" });
+  });
+
+  it("REGRESSION (#4995): a DB error inside validateOrbRelayEnrollment's own lookup ALSO returns a clean 503 broker_error, not a framework 500 (the earlier of the two DB-touching calls in this handler)", async () => {
+    const e = brokeredEnv();
+    const secret = await enroll(e, 8507);
+    const realPrepare = db(e).prepare.bind(db(e));
+    db(e).prepare = ((sql: string) => {
+      const statement = realPrepare(sql);
+      if (!/select .* from ["`]?orb_enrollments["`]?/i.test(sql)) return statement;
+      return {
+        ...statement,
+        bind(...values: unknown[]) {
+          const bound = statement.bind(...(values as never[]));
+          return { ...bound, first: () => Promise.reject(new Error("db unavailable")) };
+        },
+      };
+    }) as typeof realPrepare;
+    const res = await app.request("/v1/orb/relay/register", { method: "POST", headers: { authorization: `Bearer ${secret}` }, body: JSON.stringify({ relayUrl: "https://x.example/relay" }) }, e);
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: "broker_error" });
+  });
 });
 
 describe("readOrbRelayRegisterBody", () => {
@@ -977,5 +1019,47 @@ describe("POST /v1/orb/relay/pull", () => {
     const bad = await app.request("/v1/orb/relay/pull", { method: "POST", headers: { authorization: `Bearer ${secret}` }, body: "{not json" }, e); // unparseable → catch
     expect(bad.status).toBe(200);
     expect(await bad.json()).toEqual({ events: [{ deliveryId: "keep-1", eventName: "pull_request", rawBody: "{}" }] });
+  });
+
+  it("REGRESSION (#4995, GITTENSORY-1C): a DB error inside pullRelayPending returns a clean 503 broker_error instead of an unhandled framework 500", async () => {
+    const e = brokeredEnv();
+    const secret = await enroll(e, 8505);
+    const realPrepare = db(e).prepare.bind(db(e));
+    db(e).prepare = ((sql: string) => {
+      const statement = realPrepare(sql);
+      if (!/orb_relay_pending/i.test(sql)) return statement;
+      return {
+        ...statement,
+        bind(...values: unknown[]) {
+          const bound = statement.bind(...(values as never[]));
+          // Rejects with a non-Error value (not `new Error(...)`) so this also exercises dbBrokerError's
+          // `String(error)` fallback branch, not just its `error instanceof Error` branch.
+          return { ...bound, all: () => Promise.reject("db unavailable"), run: () => Promise.reject("db unavailable") };
+        },
+      };
+    }) as typeof realPrepare;
+    const res = await app.request("/v1/orb/relay/pull", { method: "POST", headers: { authorization: `Bearer ${secret}` } }, e);
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: "broker_error" });
+  });
+
+  it("REGRESSION (#4995): a DB error inside validateOrbRelayEnrollment's own lookup ALSO returns a clean 503 broker_error, not a framework 500 (the earlier of the two DB-touching calls in this handler)", async () => {
+    const e = brokeredEnv();
+    const secret = await enroll(e, 8508);
+    const realPrepare = db(e).prepare.bind(db(e));
+    db(e).prepare = ((sql: string) => {
+      const statement = realPrepare(sql);
+      if (!/select .* from ["`]?orb_enrollments["`]?/i.test(sql)) return statement;
+      return {
+        ...statement,
+        bind(...values: unknown[]) {
+          const bound = statement.bind(...(values as never[]));
+          return { ...bound, first: () => Promise.reject(new Error("db unavailable")) };
+        },
+      };
+    }) as typeof realPrepare;
+    const res = await app.request("/v1/orb/relay/pull", { method: "POST", headers: { authorization: `Bearer ${secret}` } }, e);
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: "broker_error" });
   });
 });


### PR DESCRIPTION
## Summary

- Fixes #4995: `drainOrbRelay` returned HTTP 500 repeatedly (872 Sentry events, escalating).
- Root cause was **not** what Sentry Seer suggested. Seer proposed adding an in-flight guard and fixing a timeout/poll-interval mismatch — both already exist and are already correct (`drainInFlight` guard in `src/server.ts`, and the 30s poll interval is explicitly matched to `drainOrbRelay`'s own 30s `AbortSignal.timeout`, per that code's own comment). The real gap was entirely server-side: `/v1/orb/relay/register` and `/v1/orb/relay/pull` both call DB-touching functions (`validateOrbRelayEnrollment`, `registerValidatedOrbRelay`, `pullRelayPending`) with no error handling of their own. An unhandled D1/Postgres error inside either one escaped as a bare framework 500 — exactly the class of gap `#orb-broker-500` already closed for `/v1/orb/token`'s own DB-touching call, just never applied to these two sibling routes.
- Fix: `.catch(...)` on just the two DB-touching calls per handler (not a big try/catch wrapping the whole handler), so pre-existing logic/branches keep their original indentation and coverage — genuine DB failures now return a clean `503 { error: "broker_error" }`.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #4995`).

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` locally
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check` (confirms these internal broker routes aren't part of the public OpenAPI surface — no drift)
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- `test:coverage` (full unsharded): not run end-to-end — ran scoped `vitest --coverage` for `test/integration/orb-relay.test.ts` and confirmed via lcov that every line/branch in this diff (both the register and pull handlers' new `.catch()` paths, including the `error instanceof Error` vs `String(error)` branch) is covered — including a second regression test per handler after the first pass showed one call site's error path was untested. The one remaining zero-hit branch in the surrounding function is confirmed pre-existing (same branch was already 0% covered before this diff, verified via `git stash`) and structurally unreachable at this call site given `RegisterResult`'s real producers — not introduced by this change.
- `test:workers` / `build:mcp` / `test:mcp-pack` / `ui:lint` / `ui:typecheck` / `ui:build`: not run — this change touches only `src/api/routes.ts` and its integration test; no Worker-pool, MCP, or UI-component surface changed.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (These are broker-auth routes — negative paths (401/403/413/503) are all covered, including the two new 503 regression tests.)
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. (Checked — not part of the public OpenAPI surface.)
- [ ] UI changes use live API data or real empty/error/loading states. (N/A.)
- [ ] Visible UI changes include a `UI Evidence` section. (N/A.)
- [ ] Public docs/changelogs are updated where needed. (N/A — internal engine behavior; changelog is not edited in a normal PR.)

## Notes

Part of a batch of 13 bug fixes filed from a Sentry-issue triage this session (#4994–#5006). This is #2 by impact.
