### PR TITLE
fix(review): compare inconclusive as text so Postgres doesn't 500 (#4997)

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -2830,7 +2830,13 @@ export async function findHottestInconclusiveReviewTargetForRepo(
         eq(aiUsageEvents.feature, "ai_review_pr"),
         gte(aiUsageEvents.createdAt, sinceIso),
         sql`json_extract(${aiUsageEvents.metadataJson}, '$.repoFullName') = ${repoFullName}`,
-        sql`json_extract(${aiUsageEvents.metadataJson}, '$.inconclusive') = 1`,
+        // #4997: `inconclusive` is stored as a JSON boolean. SQLite's json_extract surfaces a JSON boolean as the
+        // SQL integer 1/0, but the self-host Postgres translation of json_extract (pg-dialect.ts) rewrites this to
+        // `->>'inconclusive'`, which ALWAYS returns text -- comparing that text to a bare integer literal throws a
+        // Postgres type-mismatch error on every call. CAST to TEXT first so both backends compare text to text:
+        // SQLite's CAST(1 AS TEXT) = '1' (identical to the old `= 1` semantics), Postgres's `->>'inconclusive'`
+        // already yields 'true'/'false'.
+        sql`CAST(json_extract(${aiUsageEvents.metadataJson}, '$.inconclusive') AS TEXT) IN ('1', 'true')`,
       ),
     )
     .groupBy(pullNumberExpr)

--- a/test/unit/db-parsers.test.ts
+++ b/test/unit/db-parsers.test.ts
@@ -8,6 +8,7 @@ import {
   countRecentAuditEventsForActorAndTarget,
   countRecentAuditEventsForActorInRepo,
   countRecentAuditEventsForActorInRepoWithTargetSuffix,
+  findHottestInconclusiveReviewTargetForRepo,
   findHottestReviewTargetForRepo,
   hasAuditEventForDelivery,
   hasAuditEventForHeadSha,
@@ -24,6 +25,7 @@ import {
   markPullRequestsRegated,
   markPullRequestsBacklogConvergenceRegated,
   markPullRequestSurfacePublished,
+  recordAiUsageEvent,
   recordAuditEvent,
   recordWebhookEvent,
   upsertOfficialMinerDetection,
@@ -746,6 +748,39 @@ describe("database row parser hardening", () => {
       targetKey: "owner/foo_bar#1",
       count: 3,
     });
+  });
+
+  it("findHottestInconclusiveReviewTargetForRepo counts only inconclusive:true calls, scoped to ONE repo (#4997 regression: the JSON-boolean comparison must exclude inconclusive:false, not just miss on total volume)", async () => {
+    const env = createTestEnv();
+    const record = (repoFullName: string, pullNumber: number, inconclusive: boolean) =>
+      recordAiUsageEvent(env, {
+        feature: "ai_review_pr",
+        model: "self-host:claude-code",
+        status: "ok",
+        estimatedNeurons: 100,
+        metadata: { repoFullName, pullNumber, inconclusive },
+      });
+    // owner/repo#1: 3 inconclusive calls -- the hottest inconclusive target for this repo.
+    await record("owner/repo", 1, true);
+    await record("owner/repo", 1, true);
+    await record("owner/repo", 1, true);
+    // owner/repo#1 ALSO has 2 successful (non-inconclusive) calls on the SAME PR -- must not inflate the count.
+    await record("owner/repo", 1, false);
+    await record("owner/repo", 1, false);
+    // owner/repo#2: only 1 inconclusive call -- must not win over #1.
+    await record("owner/repo", 2, true);
+    // A different repo's inconclusive calls must not leak into this repo's count.
+    await record("owner/other", 1, true);
+    await record("owner/other", 1, true);
+
+    const hottest = await findHottestInconclusiveReviewTargetForRepo(env, "owner/repo", "2020-01-01T00:00:00.000Z");
+    expect(hottest).toEqual({ targetKey: "owner/repo#1", count: 3 });
+
+    // A cutoff after all the recorded events must find nothing.
+    expect(await findHottestInconclusiveReviewTargetForRepo(env, "owner/repo", "2099-01-01T00:00:00.000Z")).toBeNull();
+    // A repo with only non-inconclusive calls must find nothing.
+    await record("owner/all-ok", 1, false);
+    expect(await findHottestInconclusiveReviewTargetForRepo(env, "owner/all-ok", "2020-01-01T00:00:00.000Z")).toBeNull();
   });
 
   it("hasAuditEventForDelivery finds a matching deliveryId inside metadata_json, scoped to actor+eventType+targetKey (#2560)", async () => {

--- a/test/unit/selfhost-pg-dialect.test.ts
+++ b/test/unit/selfhost-pg-dialect.test.ts
@@ -31,6 +31,19 @@ describe("pg-dialect (#977 SQLite → Postgres)", () => {
     expect(translateFunctions("json_extract(meta, '$.mode')")).toBe("((meta)::jsonb ->> 'mode')");
   });
 
+  it("REGRESSION (#4997): a JSON-boolean json_extract comparison survives translation as text-to-text, not text-to-integer", () => {
+    // findHottestInconclusiveReviewTargetForRepo (repositories.ts) compares a stored JSON boolean. SQLite's
+    // json_extract surfaces a JSON boolean as the SQL integer 1/0, but Postgres's `->>` ALWAYS returns text --
+    // comparing that text against a bare integer literal (the original `= 1`) throws a Postgres type-mismatch
+    // error on every call. CAST to TEXT first so the comparison is valid on both backends.
+    const translated = translateFunctions("CAST(json_extract(metadata_json, '$.inconclusive') AS TEXT) IN ('1', 'true')");
+    expect(translated).toBe("CAST(((metadata_json)::jsonb ->> 'inconclusive') AS TEXT) IN ('1', 'true')");
+    // No bare-integer comparison against a json_extract/->> expression should remain anywhere in the codebase --
+    // this is the ONE call site, and it's fixed. (Documents the invariant the fix restores; not itself testing
+    // translateFunctions with anything new.)
+    expect(translated).not.toMatch(/->>\s*'[a-z]+'\s*\)?\s*=\s*\d/);
+  });
+
   it("translates INSERT OR IGNORE / REPLACE to ON CONFLICT", () => {
     expect(translateInsertOr("INSERT OR IGNORE INTO t (a) VALUES (?)")).toBe("INSERT INTO t (a) VALUES (?) ON CONFLICT DO NOTHING");
     const replace = translateInsertOr("INSERT OR REPLACE INTO system_flags (key, value, updated_at) VALUES (?, '1', CURRENT_TIMESTAMP)");


### PR DESCRIPTION
## Summary

- Fixes #4997: `ops_anomaly_repo_error: Failed query...` fired 396 times over 3 days, escalating, still firing at filing time.
- Sentry Seer's summary suggested replacing the query with the working `findHottestReviewTargetForRepo` pattern — traced both instead: `findHottestInconclusiveReviewTargetForRepo` (`src/db/repositories.ts`) compares `json_extract(metadata_json, '$.inconclusive') = 1` (a bare integer literal). SQLite's `json_extract` surfaces a JSON boolean as SQL integer 1/0 (so this worked fine in tests/cloud), but the self-host Postgres translation (`src/selfhost/pg-dialect.ts`) rewrites `json_extract(...)` to `->>`, which **always** returns text — comparing that text to a bare integer literal throws a Postgres type-mismatch error on every invocation. Confirmed via grep this is the only `json_extract(...) = <bare integer>` comparison anywhere in the codebase; every other comparison already binds a string parameter.
- Fix: `CAST(json_extract(...) AS TEXT) IN ('1', 'true')` — text-to-text on both backends. SQLite: `CAST(1 AS TEXT) = '1'` (byte-identical to the old `= 1` semantics). Postgres: `->>'inconclusive'` already yields `'true'`/`'false'`.
- Extra finding (issue requirement #3): `runOpsAlerts`/`computeOpsStats` run all four per-repo anomaly checks through one `Promise.all`, so this one query throwing discarded `gatePrecision`/`calibration`/`reviewBurst` too — this bug silently blinded **every** anomaly detector (not just the review-failure-burst one) for every repo with any AI review activity on self-host, every scan tick.
- Extra finding (issue requirement #2): the captured `vouchdev/vouch` repo tag is a real, independently-owned open-source project (verified via the GitHub API) — `opsScanRepos` only scans rows from this install's own `repositories` table, so this is a genuine third-party self-host operator's registered repo, not stale/test data or a query-bug artifact. Confirms the bug affects every self-host operator, not just this install.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #4997`).

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` locally
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- `test:coverage` (full unsharded): not run end-to-end — ran scoped `vitest --coverage` for `test/unit/db-parsers.test.ts` + `test/unit/ops-wire.test.ts` + `test/unit/selfhost-pg-dialect.test.ts` (94 tests) and confirmed via lcov that both branches of the changed function's null-guard are covered.
- `actionlint` / `test:workers` / `build:mcp` / `test:mcp-pack` / `ui:openapi:check` / `ui:lint` / `ui:typecheck` / `ui:build` / `npm audit`: not run — this change touches only `src/db/repositories.ts` (a query-text change inside an existing Drizzle `sql` template, no new API/schema/binding/dependency surface) and its tests; no workflow, MCP, UI, or dependency-manifest surface changed.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth surface touched.)
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A.)
- [ ] UI changes use live API data or real empty/error/loading states. (N/A.)
- [ ] Visible UI changes include a `UI Evidence` section. (N/A.)
- [ ] Public docs/changelogs are updated where needed. (N/A — internal engine behavior; changelog is not edited in a normal PR.)

## Notes

Part of a batch of 13 bug fixes filed from a Sentry-issue triage this session (#4994–#5006). This is #4 by priority.
