### PR TITLE
fix(review): rate-limit the ci_stuck_review_repeat_suppressed log (#4998)

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -3393,17 +3393,21 @@ async function prReadyForReview(
       // stopped the wasteful re-review, so its OWN existence is the operator-visible signal (via the structured
       // log → Sentry forwarder, forwardStructuredLogToSentry) that a PR's CI has been permanently stuck long
       // enough to need a human — the same "surface an anomaly at error level" convention selfhost_ai_provider_
-      // failed / selfhost_ai_providers_exhausted already use in src/selfhost/ai.ts.
-      console.error(
-        JSON.stringify({
-          level: "error",
-          event: "ci_stuck_review_repeat_suppressed",
-          repo: repoFullName,
-          pullNumber: pr.number,
-          headSha: pr.headSha,
-          deliveryId,
-        }),
-      );
+      // failed / selfhost_ai_providers_exhausted already use in src/selfhost/ai.ts. Rate-limited to once per
+      // (repo, pr, headSha) per day (#4998) — the defer above still runs on every evaluation; only the log is
+      // coalesced, so one permanently-stuck PR doesn't flood Sentry with hundreds of copies of the same signal.
+      if (!(await ciStuckRepeatLogCoalesced(env, repoFullName, pr.number, pr.headSha))) {
+        console.error(
+          JSON.stringify({
+            level: "error",
+            event: "ci_stuck_review_repeat_suppressed",
+            repo: repoFullName,
+            pullNumber: pr.number,
+            headSha: pr.headSha,
+            deliveryId,
+          }),
+        );
+      }
       return false;
     }
     await recordAuditEvent(env, {
@@ -3431,6 +3435,13 @@ async function prReadyForReview(
 const CI_STUCK_FINALIZE_GUARD_EVENT_TYPE = "github_app.review_finalized_ci_stuck_guard";
 const CI_STUCK_FINALIZE_MAX_PER_SHA = 1;
 const CI_STUCK_FINALIZE_GUARD_LOOKBACK_MS = 7 * 24 * 60 * 60 * 1000;
+
+// #4998: the ci_stuck_review_repeat_suppressed log below announces ONE thing (this PR has been stuck long enough
+// that a human should look) -- but the guard it reports on re-fires on EVERY later evaluation of a PR still
+// stuck on the same head SHA (a webhook re-trigger, a sweep pass), which flooded Sentry (650 events over 4 days
+// for a single PR). Rate-limits the LOG only, once per (repo, pr, headSha) per day -- the underlying suppression
+// (the guard immediately above the log call) is untouched and still runs every time.
+const CI_STUCK_REPEAT_LOG_WINDOW_SECONDS = 24 * 60 * 60;
 
 // A required check pending longer than this is treated as STUCK (orphaned / never-completing — e.g. a fork check
 // that will never report). Past it, prReadyForReview stops deferring and finalizes the gate so the PR surfaces
@@ -3466,6 +3477,23 @@ async function putTransientKey(
   } catch {
     // best-effort coalescing only
   }
+}
+
+/** True when the ci_stuck_review_repeat_suppressed log for this exact (repo, pr, headSha) already fired within
+ *  the window -- caller should skip logging (but still perform the actual defer). A missing/unavailable
+ *  transient cache degrades to "never coalesced" (every call logs, matching the pre-#4998 behavior) rather than
+ *  risk silently dropping the one operator-visible signal that a PR is stuck. */
+async function ciStuckRepeatLogCoalesced(
+  env: Env,
+  repoFullName: string,
+  prNumber: number,
+  headSha: string,
+): Promise<boolean> {
+  const key = `ci-stuck-repeat-log:${repoFullName.toLowerCase()}#${prNumber}:${headSha}`;
+  // getTransientKey/putTransientKey are already internally fail-safe (never throw), so no outer try/catch here.
+  if (await getTransientKey(env, key)) return true;
+  await putTransientKey(env, key, "1", CI_STUCK_REPEAT_LOG_WINDOW_SECONDS);
+  return false;
 }
 
 

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -1831,6 +1831,76 @@ describe("queue processors", () => {
     }
   });
 
+  it("REGRESSION (#4998): ci_stuck_review_repeat_suppressed rate-limits its log to once per (repo, pr, headSha) per day -- the defer still runs on every evaluation", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: { pull_requests: "write", checks: "write" }, events: [] } });
+    await upsertRepositoryFromGitHub(env, { name: "agent-repo", full_name: "owner/agent-repo", private: false, owner: { login: "owner" } }, 9001);
+    await upsertRepositorySettings(env, { repoFullName: "owner/agent-repo", autonomy: { merge: "auto", update_branch: "auto" }, aiReviewMode: "off", gatePack: "oss-anti-slop", gateCheckMode: "enabled", reviewCheckMode: "required", checkRunMode: "off", commentMode: "off", publicSurface: "off" });
+    await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Permanently stuck CI", state: "open", user: { login: "contributor" }, head: { sha: "a7" }, base: { ref: "main" }, labels: [], body: "Closes #1" });
+    vi.setSystemTime(new Date("2026-05-28T02:00:00.000Z"));
+    await env.SELFHOST_TRANSIENT_CACHE?.set(
+      "ci-pending-first-seen:owner/agent-repo#7:a7",
+      String(Date.now() - 31 * 60 * 1000),
+      7 * 24 * 3600,
+    );
+    const requiredContextsSpy = vi.spyOn(backfillModule, "fetchRequiredStatusContexts").mockResolvedValue(new Set(["trusted-required-ci"]));
+    const liveCiSpy = vi.spyOn(backfillModule, "fetchLiveCiAggregatePreferGraphQl").mockResolvedValue({
+      ciState: "passed",
+      hasPending: true,
+      hasVisiblePending: false,
+      hasMissingRequiredContext: false,
+      failingDetails: [],
+      nonRequiredFailingDetails: [],
+      ciCompletenessWarning: null,
+    });
+    let liveHeadSha = "a7";
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = (init?.method ?? "GET").toUpperCase();
+      if (url === "https://api.gittensor.io/miners") return Response.json([]);
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (/\/pulls\/7(?:\?|$)/.test(url) && method === "GET") return Response.json({ number: 7, title: "Permanently stuck CI", state: "open", user: { login: "contributor" }, head: { sha: liveHeadSha }, mergeable_state: "clean", labels: [], body: "Closes #1" });
+      if (url.includes("/pulls/7/files")) return Response.json([{ filename: "src/a.ts", status: "modified", additions: 1, deletions: 0, changes: 1, patch: "@@\n+export const ok = true;" }]);
+      if (url.includes("/check-runs") && (method === "POST" || method === "PATCH")) return Response.json({ id: 901 }, { status: method === "POST" ? 201 : 200 });
+      return Response.json({});
+    });
+    const errors = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    try {
+      // 1st evaluation: finalizes for real (pays for one review). 2nd: guarded — defers AND logs (the ONE
+      // Sentry-visible signal). 3rd: guarded again — defers again, but the log is now within the 24h coalesce
+      // window, so it must NOT re-fire.
+      await processJob(env, { type: "agent-regate-pr", deliveryId: "stuck-ci-eval-1", repoFullName: "owner/agent-repo", prNumber: 7, installationId: 9001 });
+      await processJob(env, { type: "agent-regate-pr", deliveryId: "stuck-ci-eval-2", repoFullName: "owner/agent-repo", prNumber: 7, installationId: 9001 });
+      await processJob(env, { type: "agent-regate-pr", deliveryId: "stuck-ci-eval-3", repoFullName: "owner/agent-repo", prNumber: 7, installationId: 9001 });
+
+      const deferred = await env.DB.prepare("select count(*) as n from audit_events where event_type = ? and target_key = ?")
+        .bind("github_app.review_deferred_ci_pending", "owner/agent-repo#7")
+        .first<{ n: number }>();
+      expect(deferred?.n).toBe(2); // both the 2nd AND 3rd evaluations deferred -- suppression itself is unchanged
+      const repeatSuppressedLogs = errors.mock.calls.filter(([line]) => typeof line === "string" && line.includes("ci_stuck_review_repeat_suppressed"));
+      expect(repeatSuppressedLogs).toHaveLength(1); // only the 2nd evaluation's log survives -- the 3rd is coalesced
+
+      // A DIFFERENT head SHA (a new commit) is a fresh key -- its first guarded evaluation must log again, not
+      // inherit the previous SHA's coalesce window.
+      liveHeadSha = "b7";
+      await upsertPullRequestFromGitHub(env, "owner/agent-repo", { number: 7, title: "Permanently stuck CI", state: "open", user: { login: "contributor" }, head: { sha: "b7" }, base: { ref: "main" }, labels: [], body: "Closes #1" });
+      await env.SELFHOST_TRANSIENT_CACHE?.set(
+        "ci-pending-first-seen:owner/agent-repo#7:b7",
+        String(Date.now() - 31 * 60 * 1000),
+        7 * 24 * 3600,
+      );
+      await processJob(env, { type: "agent-regate-pr", deliveryId: "stuck-ci-eval-4", repoFullName: "owner/agent-repo", prNumber: 7, installationId: 9001 });
+      await processJob(env, { type: "agent-regate-pr", deliveryId: "stuck-ci-eval-5", repoFullName: "owner/agent-repo", prNumber: 7, installationId: 9001 });
+      const repeatSuppressedLogsAfterNewSha = errors.mock.calls.filter(([line]) => typeof line === "string" && line.includes("ci_stuck_review_repeat_suppressed"));
+      expect(repeatSuppressedLogsAfterNewSha).toHaveLength(2); // the new SHA's own guarded evaluation logged once
+    } finally {
+      errors.mockRestore();
+      liveCiSpy.mockRestore();
+      requiredContextsSpy.mockRestore();
+    }
+  });
+
   it("REGRESSION (#orb-ci-stuck-repeat, fail-open): a failed guard-audit write does not stop the first stuck-CI finalize from running its review", async () => {
     const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
     await upsertInstallation(env, { action: "created", installation: { id: 9001, account: { login: "owner", id: 1, type: "Organization" }, target_type: "Organization", repository_selection: "selected", permissions: { pull_requests: "write", checks: "write" }, events: [] } });


### PR DESCRIPTION
## Summary

- Fixes #4998: `ci_stuck_review_repeat_suppressed` — a log line that exists specifically to announce "I am suppressing a repeat notification" — fired as its own `console.error` (Sentry-forwarded) on every single suppression: 649 events over 4 days, escalating.
- Root cause matched Sentry Seer's summary directly this time: the `#orb-ci-stuck-repeat` guard (`prReadyForReview`, `src/queue/processors.ts`) correctly caps the expensive part (re-running a full paid AI review) to once per head SHA, but the log announcing that cap re-fires on every later evaluation of the same still-stuck PR — a webhook re-trigger or a sweep pass, at roughly a 5-10 minute cadence based on the raw event timestamps.
- Fix: rate-limit the log only, once per `(repo, pr, headSha)` per day, via the same `SELFHOST_TRANSIENT_CACHE`-backed helper pattern already used by `ciPendingDeferStuck`/`ciReReviewCoalesced` in this file (`getTransientKey`/`putTransientKey`). The underlying defer/suppression behavior is untouched — it still runs on every evaluation; only the Sentry-visible log is coalesced. A new head SHA (a fresh commit) is a fresh key, so a genuinely new incident is never silently swallowed by an old PR's coalesce window.

## Investigation: what's actually wrong with the stuck PR(s) (issue requirement #2)

Pulled the raw event list behind this Sentry issue rather than trusting its title/culprit summary, since `forwardStructuredLogToSentry` groups every `ci_stuck_review_repeat_suppressed` occurrence into **one** Sentry issue regardless of repo/PR/headSha (grouped by the fixed message template) — the issue's displayed "(JSONbored/awesome-claude#4816) headSha=..." is just the **latest** contributing event, not a single PR stuck for 4 days as the issue title implied. Confirmed: PR awesome-claude#4816 itself was only open ~77 minutes end-to-end (created 04:44 UTC, merged 06:01 UTC the same day) — not stuck at all.

The real 649-event history spans **several distinct PRs** across `gittensory` and `awesome-claude` (at least #4343, #4344, #4346, #4349, #4371 in gittensory and #4739, #4745, #4816 in awesome-claude, from a 25-event sample), each re-evaluated repeatedly at a ~5-10 minute cadence while stuck — the exact "steady few-minute cadence" burn pattern the original `#orb-ci-stuck-repeat` guard's own code comment describes, just now visible as noisy logging instead of wasted AI spend.

Checked the most-repeated one, gittensory#4349, directly: it carries a non-required `Contributor trust` check (a third-party Action, `superagent.sh`) that resolved to conclusion `ACTION_REQUIRED` in 3 seconds — but `main`'s actual branch-protection required-status-checks list is only `["Superagent Security Scan", "validate"]`, so that check is not itself the blocker. All sampled PRs eventually merged cleanly once a later commit landed or a required check finally completed, so this is not a permanent hang — it's multiple PRs sitting through a slow-to-settle CI run (or a required check needing a manual fork-Action approval) for anywhere from tens of minutes to a few hours each, during which the sweep/webhook cadence re-evaluates and re-logs. No code change beyond this PR's rate-limit is proposed for that underlying CI-settling latency; it's a candidate follow-up (documented in the parent observability epic) rather than a fix bundled here.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #4998`).

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` locally
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- `test:coverage` (full unsharded): not run end-to-end — ran scoped `vitest --coverage` for `test/unit/queue.test.ts` (159 tests) and confirmed via lcov that every changed line and both branches of the new coalescing guard are covered.
- `actionlint` / `test:workers` / `build:mcp` / `test:mcp-pack` / `ui:openapi:check` / `ui:lint` / `ui:typecheck` / `ui:build` / `npm audit`: not run — this change touches only `src/queue/processors.ts` (an existing transient-cache-backed guard, no new API/schema/binding/dependency surface) and its tests; no workflow, MCP, UI, or dependency-manifest surface changed.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth surface touched.)
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A.)
- [ ] UI changes use live API data or real empty/error/loading states. (N/A.)
- [ ] Visible UI changes include a `UI Evidence` section. (N/A.)
- [ ] Public docs/changelogs are updated where needed. (N/A — internal engine behavior; changelog is not edited in a normal PR.)

## Notes

Part of a batch of 13 bug fixes filed from a Sentry-issue triage this session (#4994–#5006). This is #5 by priority.
