### PR TITLE
test(github): cover the assignee-403 fallback and its unrelated-error guard (#4999)

### DIFF
--- a/test/unit/github-assignees.test.ts
+++ b/test/unit/github-assignees.test.ts
@@ -75,6 +75,48 @@ describe("GitHub PR assignees (#3182)", () => {
     expect(result).toEqual({ applied: false });
   });
 
+  it("REGRESSION (#4999): GitHub's 'Assigning agents is not supported' 403 degrades to applied:false instead of throwing", async () => {
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/issues/4") && !url.includes("/assignees")) return Response.json({ assignees: [] });
+      // The exact GitHub REST error for assigning a non-collaborator "agent" login via an App installation
+      // token (GITTENSORY-1G, 198 Sentry events) -- this operation can never succeed with this auth model.
+      if (url.includes("/issues/4/assignees") && method === "POST") {
+        return Response.json(
+          {
+            message:
+              "Assigning agents is not supported with GitHub App installation tokens. Use a user token (personal access token or OAuth token) instead. - https://docs.github.com/rest/issues/assignees#add-assignees-to-an-issue",
+          },
+          { status: 403 },
+        );
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+
+    const result = await ensurePullRequestAssignee(createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem() }), 123, "JSONbored/gittensory", 4, "some-agent-login");
+
+    expect(result).toEqual({ applied: false });
+  });
+
+  it("REGRESSION (#4999): an UNRELATED 403 (e.g. a plain permissions rejection) still propagates instead of being silently swallowed", async () => {
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/issues/4") && !url.includes("/assignees")) return Response.json({ assignees: [] });
+      if (url.includes("/issues/4/assignees") && method === "POST") {
+        return Response.json({ message: "Resource not accessible by integration" }, { status: 403 });
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+
+    await expect(
+      ensurePullRequestAssignee(createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem() }), 123, "JSONbored/gittensory", 4, "alice"),
+    ).rejects.toThrow(/Resource not accessible by integration/);
+  });
+
   it("treats a response with no assignees field at all as an empty list, on both the GET and the POST", async () => {
     vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = input.toString();


### PR DESCRIPTION
## Summary

- Fixes #4999: `ensurePullRequestAssignee` was reported failing 100% of the time against GitHub App installation tokens (198 Sentry events, GITTENSORY-1G).
- Investigated before writing anything: this was **already fixed** by [#4167](https://github.com/JSONbored/gittensory/pull/4167) (merged 2026-07-08T09:15:47Z), which added the exact catch Sentry Seer suggested — `ensurePullRequestAssignee` (`src/github/assignees.ts:51-75`) already detects GitHub's specific "Assigning agents is not supported with GitHub App installation tokens" 403 and returns `{ applied: false }` instead of throwing, letting `performAction` fall through to its existing per-login label fallback.
- Confirmed via Sentry directly rather than assuming the fix landed cleanly: the issue's last occurrence was `2026-07-08T18:59:01Z` on release `gittensory-orb@0.4.0-beta.5` — every event predates or is from a build that predates the fix reaching a deployed release. The self-host box's current release (`gittensory-selfhost@a43c918e`, confirmed via a separate, more recent Sentry issue) is built from a commit descending from #4167. Zero occurrences of this error since. This satisfies deliverable #2 ("confirm via Sentry after deploy that this specific error stops recurring").
- What was actually missing: #4167 shipped the fix with **no regression test** for the catch itself — `test/unit/github-assignees.test.ts` had zero coverage on `assignees.ts:63-74` (confirmed via lcov: `BRF:24 BRH:14` before this PR → the whole catch/throw branch was dead in tests). That's deliverable #1 ("regression test reproducing this exact error and asserting the fallback fires") and issue requirement #3 ("don't swallow other errors — a genuine transient failure should still surface"), both still open. This PR adds exactly those two tests. No production code change — `src/github/assignees.ts` is untouched.
- Requirement #2 ("confirm the caller falls through to a label-based equivalent") was already covered independently: `test/unit/agent-action-executor.test.ts:854` ("falls back to a per-login label when GitHub silently drops an ineligible assignee") already exercises `performAction`'s `applied:false` → label-fallback path end-to-end.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #4999`).

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` locally
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- `test:coverage` (full unsharded): not run end-to-end — ran scoped `vitest --coverage` for `test/unit/github-assignees.test.ts` and confirmed via lcov that `src/github/assignees.ts` is now at 100% line and branch coverage (`LF:20 LH:20`, `BRF:24 BRH:24`).
- `actionlint` / `test:workers` / `build:mcp` / `test:mcp-pack` / `ui:openapi:check` / `ui:lint` / `ui:typecheck` / `ui:build` / `npm audit`: not run — this PR adds tests only, under `test/**` (Codecov-exempt), with no `src/**` change and no workflow, MCP, UI, or dependency-manifest surface touched.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth surface changed; this PR only adds tests for an already-shipped fallback.)
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A.)
- [ ] UI changes use live API data or real empty/error/loading states. (N/A.)
- [ ] Visible UI changes include a `UI Evidence` section. (N/A.)
- [ ] Public docs/changelogs are updated where needed. (N/A — internal engine behavior; changelog is not edited in a normal PR.)

## Notes

Part of a batch of 13 bug fixes filed from a Sentry-issue triage this session (#4994–#5006). This is #6 by priority — the underlying bug was already fixed by #4167 before this triage; this PR closes the remaining test-coverage gap.
