### PR TITLE
fix(auth): fail open when the rate-limit Durable Object errors (#5000)

### DIFF
--- a/src/auth/rate-limit.ts
+++ b/src/auth/rate-limit.ts
@@ -58,11 +58,22 @@ export async function enforceRateLimit(c: Context<{ Bindings: Env }>, routeClass
   if (!c.env.RATE_LIMITER) return null;
   const config = CONFIG[routeClass];
   const key = await rateLimitKey(c, routeClass);
-  const id = c.env.RATE_LIMITER.idFromName(key);
-  const decisionResponse = await c.env.RATE_LIMITER.get(id).fetch("https://rate-limit/check", {
-    method: "POST",
-    body: JSON.stringify({ key, ...config }),
-  });
+  let decisionResponse: Response;
+  try {
+    const id = c.env.RATE_LIMITER.idFromName(key);
+    decisionResponse = await c.env.RATE_LIMITER.get(id).fetch("https://rate-limit/check", {
+      method: "POST",
+      body: JSON.stringify({ key, ...config }),
+    });
+  } catch (error) {
+    // Fail OPEN (#5000): this middleware runs on every route ahead of the handler's own try/catch, and no
+    // app.onError is registered anywhere -- an uncaught Durable Object hiccup (eviction, migration, a
+    // rolling-deploy blip) previously escaped as Hono's bare, unstructured 500 for whatever route the caller
+    // happened to be hitting, indistinguishable from a real application bug in that route. The rate limiter
+    // exists to protect the app, not crash the request it's supposed to be gating.
+    console.error(JSON.stringify({ level: "error", event: "rate_limit_check_failed", routeClass, message: error instanceof Error ? error.message : String(error) }));
+    return null;
+  }
   const decision = (await decisionResponse.json().catch(() => ({}))) as Partial<RateLimitDecision>;
   if (decisionResponse.status !== 429) {
     c.res.headers.set("x-ratelimit-limit", String(decision.limit ?? config.limit));
@@ -70,12 +81,16 @@ export async function enforceRateLimit(c: Context<{ Bindings: Env }>, routeClass
     if (decision.resetAt) c.res.headers.set("x-ratelimit-reset", decision.resetAt);
     return null;
   }
+  // Best-effort: the 429 itself must still reach the caller even if this audit write fails (#5000, same
+  // fail-open reasoning as the DO call above).
   await recordAuditEvent(c.env, {
     eventType: "rate_limit.denied",
     actor: await actorHint(c),
     route: c.req.path,
     outcome: "denied",
     metadata: { routeClass, retryAfterSeconds: decision.retryAfterSeconds ?? null },
+  }).catch((error) => {
+    console.warn(JSON.stringify({ level: "warn", event: "rate_limit_denied_audit_failed", routeClass, message: error instanceof Error ? error.message : String(error) }));
   });
   return c.json(
     {

--- a/test/unit/auth.test.ts
+++ b/test/unit/auth.test.ts
@@ -479,6 +479,85 @@ describe("private-beta auth and rate limiting", () => {
     expect(JSON.parse(tokenAudit?.metadata_json ?? "{}")).toMatchObject({ retryAfterSeconds: 17 });
   });
 
+  it("REGRESSION (#5000): fails OPEN when the rate-limit Durable Object itself throws, instead of crashing the request with a bare framework 500", async () => {
+    const throwingLimiter = {
+      idFromName(name: string) {
+        return name;
+      },
+      get() {
+        return {
+          async fetch() {
+            throw new Error("Durable Object reset");
+          },
+        };
+      },
+    };
+    const env = createTestEnv({ RATE_LIMITER: throwingLimiter as unknown as DurableObjectNamespace });
+    const errors = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await expect(enforceRateLimit(fakeContext(env, "/v1/orb/token", { "cf-connecting-ip": "203.0.113.9" }), "strict")).resolves.toBeNull();
+
+    expect(errors.mock.calls.some(([line]) => typeof line === "string" && line.includes("rate_limit_check_failed") && line.includes("\"routeClass\":\"strict\""))).toBe(true);
+    errors.mockRestore();
+  });
+
+  it("REGRESSION (#5000): still fails open when the Durable Object rejects with a non-Error value", async () => {
+    const throwingLimiter = {
+      idFromName(name: string) {
+        return name;
+      },
+      get() {
+        return {
+          async fetch() {
+            // Deliberately a non-Error rejection -- exercises the `error instanceof Error` false branch in the fail-open catch below.
+            throw "not an Error instance";
+          },
+        };
+      },
+    };
+    const env = createTestEnv({ RATE_LIMITER: throwingLimiter as unknown as DurableObjectNamespace });
+    const errors = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await expect(enforceRateLimit(fakeContext(env, "/v1/orb/token", { "cf-connecting-ip": "203.0.113.10" }), "strict")).resolves.toBeNull();
+
+    expect(errors.mock.calls.some(([line]) => typeof line === "string" && line.includes("rate_limit_check_failed") && line.includes("not an Error instance"))).toBe(true);
+    errors.mockRestore();
+  });
+
+  it("REGRESSION (#5000): a failed rate_limit.denied audit write does not stop the 429 itself from reaching the caller", async () => {
+    const deniedEnv = createTestEnv({ RATE_LIMITER: rateLimiterNamespace({ status: 429, body: { resetAt: "2026-05-25T00:04:00.000Z" } }) as unknown as DurableObjectNamespace });
+    const realPrepare = deniedEnv.DB.prepare.bind(deniedEnv.DB);
+    deniedEnv.DB.prepare = ((sql: string) => {
+      if (/^insert into "?audit_events"?/i.test(sql)) throw new Error("poisoned query");
+      return realPrepare(sql);
+    }) as typeof deniedEnv.DB.prepare;
+    const warnings = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const response = await enforceRateLimit(fakeContext(deniedEnv, "/v1/local/branch-analysis", { "cf-connecting-ip": "203.0.113.44" }), "expensive");
+
+    expect(response?.status).toBe(429);
+    await expect(response?.json()).resolves.toMatchObject({ error: "rate_limited", routeClass: "expensive" });
+    expect(warnings.mock.calls.some(([line]) => typeof line === "string" && line.includes("rate_limit_denied_audit_failed") && line.includes("poisoned query"))).toBe(true);
+    warnings.mockRestore();
+  });
+
+  it("REGRESSION (#5000): still fails open on a non-Error audit-write rejection", async () => {
+    const deniedEnv = createTestEnv({ RATE_LIMITER: rateLimiterNamespace({ status: 429, body: { resetAt: "2026-05-25T00:05:00.000Z" } }) as unknown as DurableObjectNamespace });
+    const realPrepare = deniedEnv.DB.prepare.bind(deniedEnv.DB);
+    deniedEnv.DB.prepare = ((sql: string) => {
+      // Deliberately a non-Error throw -- exercises the `error instanceof Error` false branch in the fail-open catch below.
+      if (/^insert into "?audit_events"?/i.test(sql)) throw "not an Error instance";
+      return realPrepare(sql);
+    }) as typeof deniedEnv.DB.prepare;
+    const warnings = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    const response = await enforceRateLimit(fakeContext(deniedEnv, "/v1/local/branch-analysis", { "cf-connecting-ip": "203.0.113.45" }), "expensive");
+
+    expect(response?.status).toBe(429);
+    expect(warnings.mock.calls.some(([line]) => typeof line === "string" && line.includes("rate_limit_denied_audit_failed") && line.includes("not an Error instance"))).toBe(true);
+    warnings.mockRestore();
+  });
+
   it("starts GitHub device flow and rejects malformed provider responses", async () => {
     const env = createTestEnv({ GITHUB_OAUTH_CLIENT_ID: "client-id" });
     vi.stubGlobal("fetch", async () =>


### PR DESCRIPTION
## Summary

- Fixes #5000: `orb_broker_unavailable` — 95 Sentry events over 10+ days, mixing "(500)", "(503)", and "The operation was aborted due to timeout" messages, still occurring after the earlier `#orb-broker-500` fix (commit `65de78ec6`, 2026-07-05) had already deployed.
- The issue's own investigation correctly ruled out re-applying Seer's suggested fix, but its premise about *where* to look was off by one layer, worth correcting: `orb_broker_unavailable` is not logged by the **server** hosting `/v1/orb/token` — it's logged **client-side**, in `mintInstallationToken` (`src/github/app.ts:277-285`), whenever a self-hosted box's own outbound call to the central broker (`fetchBrokeredInstallationToken`, `src/orb/broker-client.ts:58-86`) fails for any reason. That client function faithfully echoes whatever HTTP status (or network/timeout error) it receives — `Orb broker token exchange failed (${response.status}).` — so the "500 vs 503 vs timeout" mix in Sentry is just three different failure shapes reaching the client, not three different application bugs.
- Traced the **server** side exhaustively instead (`app.post("/v1/orb/token", ...)` in `src/api/routes.ts:3311-3337`, `brokerOrbToken` in `src/orb/broker.ts`, `readOrbRelayRegisterBody` in `src/orb/relay.ts`): every throw path inside the route's own try/catch, and `readOrbRelayRegisterBody` itself, is already correctly hardened — confirming the issue's finding that re-wrapping this handler again would add nothing (satisfies requirement #3: "don't just re-wrap the outer handler").
- Found the actual remaining gap **outside** the route entirely: `enforceRateLimit` (`src/auth/rate-limit.ts:57`), registered as global middleware (`app.use("*", ...)` in `routes.ts:904-909`) ahead of every route's own error handling — including `/v1/orb/token`, classified `"strict"` (every call hits it). It calls the `RATE_LIMITER` Durable Object via `.fetch()` with **no try/catch**, and the app registers **no `app.onError` handler anywhere** (`src/index.ts` exports `{ fetch: app.fetch, ... }` unwrapped). A Durable Object hiccup — eviction, migration, a rolling-deploy blip, all real, intermittent, Cloudflare-side conditions — throws uncaught here, escapes the entire middleware chain, and Hono's *default* error handling returns a bare, unstructured `500` for whatever route the caller happened to be hitting. This is indistinguishable from an application bug in that specific route, but it isn't one — it's shared infrastructure sitting upstream of *every* route, not just the orb ones.
- Fix: fail open. A DO-check failure now logs a structured `rate_limit_check_failed` and lets the request through (`return null`) instead of throwing — the rate limiter's job is to protect the app, not crash the request it's gating. Same treatment for the (rarer) `rate_limit.denied` audit write inside the 429 path: a failed audit write no longer prevents the 429 itself from reaching the caller.

## Requirement #1 (issue): which events are pre- vs post-fix?

Pulled the raw per-event timestamps rather than trusting the issue's summary. Events from 2026-06-29 through roughly 2026-07-05 predate `#orb-broker-500`'s fix, as expected. Events continuing through 2026-07-09 (after that fix shipped) are consistent with this middleware-layer gap, which `#orb-broker-500` never touched — it only hardened `readOrbRelayRegisterBody`. No evidence of a deploy-lag gap; the central Worker auto-deploys on merge (Cloudflare Workers Builds).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #5000`).

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` locally
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- `test:coverage` (full unsharded): not run end-to-end — ran scoped `vitest --coverage` for `test/unit/auth.test.ts` (24 tests) plus `test/integration/routes-errors.test.ts` + `test/integration/api.test.ts` (85 tests combined) and confirmed via lcov that every changed line and branch (including both sides of the `error instanceof Error` ternary in each new catch) is covered.
- `actionlint` / `test:workers` / `build:mcp` / `test:mcp-pack` / `ui:openapi:check` / `ui:lint` / `ui:typecheck` / `ui:build` / `npm audit`: not run — this change touches only `src/auth/rate-limit.ts` (existing middleware, no new API/schema/binding/dependency surface) and its tests; no workflow, MCP, UI, or dependency-manifest surface changed.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (This IS the rate-limit/auth middleware — the negative paths are exactly the two new fail-open regression tests plus their non-Error-rejection variants.)
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no request/response shape changed on the happy path; a DO failure now degrades to "not rate-limited" instead of a 500, which is strictly more available, not a new contract.)
- [ ] UI changes use live API data or real empty/error/loading states. (N/A.)
- [ ] Visible UI changes include a `UI Evidence` section. (N/A.)
- [ ] Public docs/changelogs are updated where needed. (N/A — internal engine behavior; changelog is not edited in a normal PR.)

## Notes

Part of a batch of 13 bug fixes filed from a Sentry-issue triage this session (#4994–#5006). This is #7 by priority. This middleware runs ahead of *every* route (not just orb endpoints) — the fix should reduce bare, unstructured 500s fleet-wide whenever the rate-limiter's Durable Object has a transient hiccup, not just for this one signal.
