### PR TITLE
fix(github): retry the transient 405 'Merge already in progress' race (#5003)

### DIFF
--- a/src/services/merge-failure.ts
+++ b/src/services/merge-failure.ts
@@ -33,6 +33,15 @@ function isBaseBranchMovedMessage(message: string): boolean {
   return /base branch was modified/i.test(message);
 }
 
+/** True for the transient "Merge already in progress" 405 (GITTENSORY-1K) — another merge request for the
+ *  SAME PR (a manual click, a concurrent duplicate job) is already being processed by GitHub. Not a policy
+ *  rejection: the in-flight merge either lands (making this retry a no-op once the PR is no longer open) or
+ *  fails (making a retry the right move), so it resolves the same way isBaseBranchMovedMessage's TOCTOU race
+ *  does — re-attempt rather than hold. */
+function isMergeAlreadyInProgressMessage(message: string): boolean {
+  return /merge already in progress/i.test(message);
+}
+
 function isConvergenceForbiddenMessage(message: string): boolean {
   return /resource not accessible by integration|secondary rate limit|api rate limit|abuse detection/i.test(message);
 }
@@ -55,6 +64,7 @@ export function classifyMergeFailure(error: unknown): { terminal: boolean; reaso
   // A 405 "Base branch was modified" is a benign TOCTOU race, not a policy rejection — retry against the new base
   // (the executor caps retries at MERGE_RETRY_CAP before escalating to the same terminal hold).
   if (status === 405 && isBaseBranchMovedMessage(message)) return { terminal: false, reason: `base branch moved during merge — retrying: ${message}` };
+  if (status === 405 && isMergeAlreadyInProgressMessage(message)) return { terminal: false, reason: `a merge for this PR was already in progress — retrying: ${message}` };
   if (status === 405) return { terminal: true, reason: `merge not allowed (405 — repo merge policy forbids an automated merge): ${message}` };
   if (status === 409) return { terminal: true, reason: `merge conflict / required check absent (409): ${message}` };
   if (isMergeConflictMessage(message)) return { terminal: true, reason: `branch conflicts with base — contributor must rebase: ${message}` };

--- a/test/unit/merge-failure.test.ts
+++ b/test/unit/merge-failure.test.ts
@@ -13,6 +13,12 @@ describe("classifyMergeFailure", () => {
     expect(result.reason).toMatch(/base branch moved/i);
   });
 
+  it("REGRESSION (#5003, GITTENSORY-1K): retries the transient 405 'Merge already in progress' race instead of holding it", () => {
+    const result = classifyMergeFailure(httpError(405, "Merge already in progress"));
+    expect(result.terminal).toBe(false);
+    expect(result.reason).toMatch(/already in progress/i);
+  });
+
   it("still treats a policy 405 (required reviews/checks) as terminal", () => {
     const result = classifyMergeFailure(httpError(405, "At least 1 approving review is required by reviewers with write access."));
     expect(result.terminal).toBe(true);


### PR DESCRIPTION
## Summary

- Fixes #5003: two low-volume GitHub API edge cases — `Merge already in progress` (GITTENSORY-1K, 2 events) and a rate-limit hit during an assignee retry (GITTENSORY-1M, 1 event).

**Requirement #1 (`Merge already in progress`):** `classifyMergeFailure` (`src/services/merge-failure.ts`) already has a documented precedent for exactly this shape — `isBaseBranchMovedMessage` special-cases the benign "Base branch was modified" 405 as retryable (`terminal: false`), while every other 405 falls through to terminal. "Merge already in progress" is the same class of race: another merge request for the same PR is already being processed by GitHub — not a policy rejection, resolves on its own once the in-flight merge settles. Added `isMergeAlreadyInProgressMessage`, matching the existing pattern exactly (same file, same shape, same `MERGE_RETRY_CAP`-bounded retry via `handleMergeFailure` in `agent-action-executor.ts`, unchanged).

**Requirement #2 (rate-limit during assignee retry):** confirmed `ensurePullRequestAssignee`'s octokit client already threads `githubRateLimitAdmissionKeyForInstallation(installationId)` through `makeInstallationOctokit` — the same shared rate-limit-budget convention every other `src/github/` call site uses. The one captured GITTENSORY-1M event is from `2026-07-09T21:41:51Z`, on release `gittensory-orb@0.4.0-beta.13` — *after* #4167's 403-handling fix (2026-07-08) had already deployed. Seer's own root-cause read ("high queue load causes excessive concurrent GitHub API calls per installation, exhausting the rate limit") matches: this is a single, isolated rate-limit event from ordinary contention during a burst, not a new bug — the call already follows the standard rate-limit-aware conventions, and GitHub's own limiter self-resets within the hour. No code change proposed for this half; documented in the issue.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #5003`).

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` locally
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- `test:coverage` (full unsharded): not run end-to-end — ran scoped `vitest --coverage` for `test/unit/merge-failure.test.ts` and confirmed via lcov that `src/services/merge-failure.ts` is at 100% line and branch coverage (`LF:18 LH:18`, `BRF:24 BRH:24`). Also ran `test/unit/agent-action-executor.test.ts` (176 tests combined) to confirm the executor's merge-retry wiring is unaffected.
- `actionlint` / `test:workers` / `build:mcp` / `test:mcp-pack` / `ui:openapi:check` / `ui:lint` / `ui:typecheck` / `ui:build` / `npm audit`: not run — this change touches only `src/services/merge-failure.ts` (a pure classification function, no new API/schema/binding/dependency surface) and its tests; no workflow, MCP, UI, or dependency-manifest surface changed.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth surface touched; the existing terminal-405 negative test is preserved and still passes.)
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A.)
- [ ] UI changes use live API data or real empty/error/loading states. (N/A.)
- [ ] Visible UI changes include a `UI Evidence` section. (N/A.)
- [ ] Public docs/changelogs are updated where needed. (N/A — internal engine behavior; changelog is not edited in a normal PR.)

## Notes

Part of a batch of 13 bug fixes filed from a Sentry-issue triage this session (#4994–#5006). This is #10 by priority.
