### PR TITLE
fix(review): retry a 503 REES startup ping before escalating (#5006)

### DIFF
--- a/src/review/enrichment-wire.ts
+++ b/src/review/enrichment-wire.ts
@@ -53,6 +53,32 @@ function sharedSecretWasNormalized(
   return (normalized ?? "") !== raw;
 }
 
+// REES's own /v1/ping returns 503 specifically to mean "not configured/ready yet" (server.ts: no
+// REES_SHARED_SECRET set on that side) -- the same benign startup-ordering race probeReesSecretAtStartup's
+// catch block already extends grace to for a refused connection (GITTENSORY-1J: 7 Sentry events, all in one
+// ~5h window, never recurring -- consistent with a one-time deploy/restart race, not a persistent
+// misconfiguration). Retry a few times before escalating; any other status is final on the first response.
+const REES_PING_NOT_READY_RETRIES = 2;
+const REES_PING_NOT_READY_RETRY_DELAY_MS = 500;
+
+async function fetchReesPingWithRetry(url: string, secret: string): Promise<Response> {
+  const request = () =>
+    fetch(url, {
+      method: "POST",
+      headers: {
+        "user-agent": "gittensory-selfhost/1.0",
+        authorization: `Bearer ${secret}`,
+      },
+      signal: AbortSignal.timeout(5000),
+    });
+  let response = await request();
+  for (let attempt = 0; attempt < REES_PING_NOT_READY_RETRIES && response.status === 503; attempt += 1) {
+    await new Promise((resolve) => setTimeout(resolve, REES_PING_NOT_READY_RETRY_DELAY_MS));
+    response = await request();
+  }
+  return response;
+}
+
 // Set true once the startup probe confirms REES rejects the shared secret (401/403). Once set,
 // buildReviewEnrichment skips every /v1/enrich call for the rest of this process's lifetime instead of
 // repeating a call that's confirmed to fail on every PR review, each one logging review_context_fetch_failed.
@@ -104,17 +130,7 @@ export function probeReesSecretAtStartup(env: Env): void {
   // Probe asynchronously — never block the server from starting.
   void (async () => {
     try {
-      const response = await fetch(
-        `${base.replace(/\/+$/, "")}/v1/ping`,
-        {
-          method: "POST",
-          headers: {
-            "user-agent": "gittensory-selfhost/1.0",
-            authorization: `Bearer ${sharedSecret}`,
-          },
-          signal: AbortSignal.timeout(5000),
-        },
-      );
+      const response = await fetchReesPingWithRetry(`${base.replace(/\/+$/, "")}/v1/ping`, sharedSecret);
       if (response.ok) {
         console.log(
           JSON.stringify({

--- a/test/unit/enrichment-wire.test.ts
+++ b/test/unit/enrichment-wire.test.ts
@@ -144,6 +144,46 @@ describe("probeReesSecretAtStartup", () => {
     errSpy.mockRestore();
   });
 
+  it("REGRESSION (#5006, GITTENSORY-1J): retries a 503 ('not ready yet') a few times before escalating to rees_ping_error", async () => {
+    const fetchSpy = vi.fn(async () => ({ ok: false, status: 503 }) as Response);
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    probeReesSecretAtStartup(env({ REES_URL: "https://rees.example", REES_SHARED_SECRET: "s3cret" }));
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+    expect(fetchSpy).toHaveBeenCalledTimes(3); // the first attempt + 2 retries, all still 503
+    const parsed = errSpy.mock.calls.map((c) => JSON.parse(c[0] as string));
+    expect(parsed.some((p) => p.event === "rees_ping_error" && p.status === 503)).toBe(true);
+    errSpy.mockRestore();
+  });
+
+  it("REGRESSION (#5006): a 503 that clears on retry succeeds without ever escalating to rees_ping_error", async () => {
+    let calls = 0;
+    const fetchSpy = vi.fn(async () => {
+      calls += 1;
+      return (calls < 2 ? { ok: false, status: 503 } : { ok: true }) as Response;
+    });
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    probeReesSecretAtStartup(env({ REES_URL: "https://rees.example", REES_SHARED_SECRET: "s3cret" }));
+    await new Promise((resolve) => setTimeout(resolve, 1100));
+    expect(fetchSpy).toHaveBeenCalledTimes(2);
+    expect(logSpy.mock.calls.some((c) => JSON.parse(c[0] as string).event === "rees_ping_ok")).toBe(true);
+    expect(errSpy).not.toHaveBeenCalled();
+    logSpy.mockRestore();
+    errSpy.mockRestore();
+  });
+
+  it("does not retry a non-503 non-ok status — a single attempt is final", async () => {
+    const fetchSpy = vi.fn(async () => ({ ok: false, status: 500 }) as Response);
+    globalThis.fetch = fetchSpy as unknown as typeof fetch;
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    probeReesSecretAtStartup(env({ REES_URL: "https://rees.example", REES_SHARED_SECRET: "s3cret" }));
+    await flush();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    errSpy.mockRestore();
+  });
+
   it("warns rees_ping_error (not throw) when the fetch itself rejects — REES may not be up yet", async () => {
     const fetchSpy = vi.fn(async () => {
       throw new Error("connect ECONNREFUSED");


### PR DESCRIPTION
## Summary

- Fixes #5006: REES's `/v1/ping` startup probe returned an unexpected 503 (GITTENSORY-1J, 7 events, all in a single ~5 hour window on 2026-07-08/09, never recurring since).
- Root cause: `REES's server.ts` `/v1/ping` handler returns 503 with exactly one meaning — `if (!secret) return c.json({ error: "service_not_configured" }, 503);` — i.e. REES's own `REES_SHARED_SECRET` isn't populated yet on that side. The engine's startup probe (`probeReesSecretAtStartup`, `src/review/enrichment-wire.ts`) already has an explicit, documented tolerance for the *sibling* benign startup race — a refused connection ("REES may not be up yet at engine start", logged at `warn`, never Sentry-visible) — but treated a 503 identically to a genuine unexpected error, escalating to `console.error` (Sentry-visible) on the very first response with zero tolerance.
- Requirement #2 (correlate with other REES issues in this batch): checked — GITTENSORY-15's window (2026-07-02–07-05) and this one (2026-07-08–07-09) don't overlap, so this isn't the same deploy/restart window as another issue in this batch. It's its own event, standing on its own evidence (7 events in one clustered window, zero since) — consistent with a one-time deploy/restart timing race on the self-host operator's side, not a persistent misconfiguration.
- Fix: retry a 503 specifically (any other status is still final immediately) up to twice, 500ms apart, before escalating — mirroring the same "retry the ambiguous-but-likely-transient case before treating it as a real problem" pattern used throughout this session's other fixes (#4998, #5000, #5003). A persistent 503 (e.g. a genuine, ongoing misconfiguration) still correctly escalates after the retries exhaust.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #5006`).

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` locally
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- `test:coverage` (full unsharded): not run end-to-end — ran scoped `vitest --coverage` for `test/unit/enrichment-wire.test.ts` (51 tests) and confirmed via lcov that every changed line and both branches of the new retry loop are covered.
- `actionlint` / `test:workers` / `build:mcp` / `test:mcp-pack` / `ui:openapi:check` / `ui:lint` / `ui:typecheck` / `ui:build` / `npm audit`: not run — this change touches only `src/review/enrichment-wire.ts` (existing fire-and-forget startup probe, no new API/schema/binding/dependency surface) and its tests; no workflow, MCP, UI, or dependency-manifest surface changed.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — this is a startup diagnostic probe, not an auth surface; a persistent-503 negative test and a genuine-401/403-mismatch test are both preserved/unaffected.)
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A.)
- [ ] UI changes use live API data or real empty/error/loading states. (N/A.)
- [ ] Visible UI changes include a `UI Evidence` section. (N/A.)
- [ ] Public docs/changelogs are updated where needed. (N/A — internal engine behavior; changelog is not edited in a normal PR.)

## Notes

Part of a batch of 13 bug fixes filed from a Sentry-issue triage this session (#4994–#5006). This is #13 and the last by priority.
