### PR TITLE
test(miner-governor): close codecov/patch gap on kill-switch's repoFullName fallback

### DIFF
--- a/test/unit/miner-governor-kill-switch.test.ts
+++ b/test/unit/miner-governor-kill-switch.test.ts
@@ -72,6 +72,23 @@ describe("recordMinerKillSwitchTransition (#2341)", () => {
     expect(rows[0]?.id).toBeLessThan(rows[1]?.id ?? 0);
   });
 
+  it("a transition with no repoFullName supplied records a null repoFullName, not an omitted or undefined one", () => {
+    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-governor-kill-switch-no-repo-"));
+    roots.push(root);
+    const ledger = initGovernorLedger(join(root, "governor-ledger.sqlite3"));
+    ledgers.push(ledger);
+
+    const tripped = recordMinerKillSwitchTransition(
+      { actionClass: "open_pr", previousScope: "none", scope: "global" },
+      { append: (event) => ledger.appendGovernorEvent(event) },
+    );
+
+    expect(tripped?.repoFullName).toBeNull();
+    const rows = ledger.readGovernorEvents({});
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.repoFullName).toBeNull();
+  });
+
   it("is a no-op and appends nothing when the scope has not changed", () => {
     const root = mkdtempSync(join(tmpdir(), "gittensory-miner-governor-kill-switch-noop-"));
     roots.push(root);


### PR DESCRIPTION
## Summary

Follow-up to #2341 (#5012, merged). That PR landed with `codecov/patch` actually **failing** at 92.30% -- I only discovered this by checking the raw PR checks after the fact, since my own verification during that PR relied on the engine package's separate `node:test` suite, which is invisible to Codecov. Only files with a corresponding `packages/gittensory-miner/lib/` wrapper exercised by a root-level vitest test (via the `vi.mock("@jsonbored/gittensory-engine", ...)` source-redirect pattern) are actually measured by Codecov -- `kill-switch.ts` has exactly that (`governor-kill-switch.js` + `test/unit/miner-governor-kill-switch.test.ts`), so the gap was real and reachable, not a scope-exclusion artifact.

The one partial branch: `buildMinerKillSwitchTransitionGovernorLedgerEvent`'s `input.repoFullName ?? null` (kill-switch.ts:69) never took its null-producing side -- the root test's only transition-recording assertions always supplied a `repoFullName`, and the one test that omitted it never reached that line (it was a same-scope no-op, returning `null` earlier). Added a genuine scope-changing transition with `repoFullName` omitted, asserting the ledger row lands with `repoFullName: null`.

## Validation

```
npx vitest run test/unit/miner-governor-kill-switch.test.ts --coverage --coverage.include="packages/gittensory-engine/src/governor/kill-switch.ts"
```

- 6/6 tests pass.
- `kill-switch.ts`: 100.00% stmts / 100.00% branch / 100.00% funcs / 100.00% lines (was 92.85% branch / 92.30% Codecov patch).

Test-only change, no production code touched.

## Test plan

- [x] All 6 tests in the affected file pass.
- [x] Measured branch coverage on the touched file is 100%, via the same vitest + source-redirect path Codecov itself reads.