### PR TITLE
fix(selfhost): only escalate the final AI-provider retry attempt to Sentry (#5046)

### DIFF
--- a/src/review/planner.ts
+++ b/src/review/planner.ts
@@ -113,10 +113,14 @@ async function runPlannerModel(env: Env, system: string, user: string): Promise<
   if (!ai || typeof ai.run !== "function") return { text: null };
   const gatewayId = env.AI_GATEWAY_ID?.trim();
   const extra = gatewayId ? { gateway: { id: gatewayId } } : undefined;
-  for (const model of [BEST_REVIEW_MODELS[0], RELIABLE_FALLBACK_MODELS[0]]) {
+  const models = [BEST_REVIEW_MODELS[0], RELIABLE_FALLBACK_MODELS[0]];
+  for (const [modelIndex, model] of models.entries()) {
     for (let attempt = 0; attempt < 2; attempt += 1) {
       try {
-        const result = await ai.run(model, { max_tokens: PLANNER_MAX_TOKENS, temperature: 0.2, messages: [{ role: "system", content: system }, { role: "user", content: user }] }, extra);
+        // #5046: this loop has no logging of its own -- the provider's own error log is the ONLY visibility
+        // into a failure here, so the truly last attempt must stay Sentry-visible (finalAttempt unset/true);
+        // every earlier attempt is about to be retried and can log quietly.
+        const result = await ai.run(model, { max_tokens: PLANNER_MAX_TOKENS, temperature: 0.2, messages: [{ role: "system", content: system }, { role: "user", content: user }], finalAttempt: attempt === 1 && modelIndex === models.length - 1 }, extra);
         const text = coerceAiText(result).trim();
         if (text) return { text, usage: coerceAiUsage(result) };
       } catch {

--- a/src/selfhost/ai.ts
+++ b/src/selfhost/ai.ts
@@ -40,6 +40,15 @@ interface AiRunOptions {
   repoFullName?: string;
   pullNumber?: number;
   attempt?: number;
+  // True (or omitted, the safe default) when this is the LAST attempt the caller's own retry loop will make —
+  // false marks an attempt the caller is about to retry. logSelfHostAiProviderFailed uses this to log at warn
+  // (a retried attempt is not yet a real problem) instead of error (Sentry-visible) for a non-final attempt,
+  // matching the "per-attempt=warn, exhausted=error" policy runWorkersOpinion's OWN logging already documents
+  // (#26) -- previously this file's error log fired on every single attempt regardless, amplifying one review's
+  // 3x-retry-per-model into up to 6 separate Sentry events for what the caller treats as one failure (#5046).
+  // Callers with no retry loop of their own (a single ai.run() call) leave this unset, so their one attempt IS
+  // final and stays loud, unchanged from before this field existed.
+  finalAttempt?: boolean;
   // `.gittensory.yml` `review.ai_model` (#selfhost-ai-model-override): per-repo override for the subscription
   // CLI providers, resolved by the caller from the repo's manifest and forwarded here so this file makes no
   // manifest fetch of its own. Each field is read ONLY by its matching provider's `.run()` (claude-code reads
@@ -786,10 +795,16 @@ function logSelfHostAiProviderFailed(input: {
   repoFullName?: string | undefined;
   pullNumber?: number | undefined;
   attempt?: number | undefined;
+  finalAttempt?: boolean | undefined;
 }): void {
-  console.error(
+  // #5046: only the FINAL attempt of a caller's own retry loop is Sentry-visible (error); a retried attempt logs
+  // at warn (still in Workers Logs, but not forwarded) -- explicit `false` is the only thing that quiets it, so
+  // a single-shot caller that never sets this field keeps today's always-loud behavior.
+  const level = input.finalAttempt === false ? "warn" : "error";
+  const log = level === "warn" ? console.warn : console.error;
+  log(
     JSON.stringify({
-      level: "error",
+      level,
       event: "selfhost_ai_provider_failed",
       provider: input.provider,
       model: input.model || "default",
@@ -884,6 +899,7 @@ export function createClaudeCodeAi(parentEnv: Record<string, string | undefined>
           repoFullName: options.repoFullName,
           pullNumber: options.pullNumber,
           attempt: options.attempt,
+          finalAttempt: options.finalAttempt,
         });
         throw error;
       } finally {
@@ -982,6 +998,7 @@ export function createCodexAi(
           repoFullName: options.repoFullName,
           pullNumber: options.pullNumber,
           attempt: options.attempt,
+          finalAttempt: options.finalAttempt,
         });
         throw error;
       } finally {

--- a/src/services/ai-review.ts
+++ b/src/services/ai-review.ts
@@ -1069,6 +1069,10 @@ async function runWorkersOpinion(
             ...(correlation?.openaiCompatibleModel !== undefined ? { openaiCompatibleModel: correlation.openaiCompatibleModel } : {}),
             ...(correlation?.anthropicModel !== undefined ? { anthropicModel: correlation.anthropicModel } : {}),
             attempt,
+            // #5046: only the truly last attempt (last model, last retry) should escalate to Sentry via the
+            // provider's own error log -- every earlier attempt in this loop is about to be retried, and this
+            // loop's own per-attempt warn below is already the correct signal for those.
+            finalAttempt: attempt === 2 && modelIndex === models.length - 1,
           },
           extra,
         );
@@ -1790,6 +1794,9 @@ async function runDualAiTieBreakJudgeCall(
               : {}),
             ...(correlation?.pullNumber !== undefined ? { pullNumber: correlation.pullNumber } : {}),
             attempt,
+            // #5046: same reasoning as runWorkersOpinion above -- only the truly last attempt escalates the
+            // provider's own error log to Sentry.
+            finalAttempt: attempt === 2 && modelIndex === models.length - 1,
           },
           extra,
         );

--- a/src/services/ai-slop.ts
+++ b/src/services/ai-slop.ts
@@ -147,12 +147,20 @@ async function runWorkersSlopOpinion(env: Env, system: string, user: string, max
   const gatewayId = env.AI_GATEWAY_ID?.trim();
   const extra: AiGatewayOptions | undefined = gatewayId ? { gateway: { id: gatewayId } } : undefined;
   // Primary then a reliable per-slot fallback (distinct model families), 3× retry each before giving up.
-  for (const model of WORKERS_SLOP_MODELS) {
+  for (const [modelIndex, model] of WORKERS_SLOP_MODELS.entries()) {
     for (let attempt = 0; attempt < WORKERS_SLOP_ATTEMPTS_PER_MODEL; attempt += 1) {
       try {
+        // #5046: this loop has no logging of its own -- the provider's own error log is the ONLY visibility
+        // into a failure here, so the truly last attempt must stay Sentry-visible (finalAttempt unset/true);
+        // every earlier attempt is about to be retried and can log quietly.
         const result = await ai.run(
           model,
-          { max_tokens: maxTokens, temperature: 0, messages: [{ role: "system", content: system }, { role: "user", content: user }] },
+          {
+            max_tokens: maxTokens,
+            temperature: 0,
+            messages: [{ role: "system", content: system }, { role: "user", content: user }],
+            finalAttempt: attempt === WORKERS_SLOP_ATTEMPTS_PER_MODEL - 1 && modelIndex === WORKERS_SLOP_MODELS.length - 1,
+          },
           extra,
         );
         const parsed = parseSlopOpinion(coerceAiText(result));

--- a/test/unit/selfhost-ai.test.ts
+++ b/test/unit/selfhost-ai.test.ts
@@ -472,6 +472,47 @@ describe("createChainAi (fallback)", () => {
     expect(logged.attempt).toBeUndefined();
     errorSpy.mockRestore();
   });
+
+  it("REGRESSION (#5046): finalAttempt:false logs the provider failure at warn, not error (a retried attempt is not yet Sentry-worthy)", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const failing: StubSpawn = async () => ({ stdout: "", code: 1, stderr: "transient" });
+
+    await expect(createClaudeCodeAi({ CLAUDE_CODE_OAUTH_TOKEN: "t" }, failing).run("m", { prompt: "x", attempt: 0, finalAttempt: false })).rejects.toThrow();
+
+    expect(errorSpy).not.toHaveBeenCalled();
+    const logged = JSON.parse(String(warnSpy.mock.calls[0]?.[0]));
+    expect(logged).toMatchObject({ level: "warn", event: "selfhost_ai_provider_failed", attempt: 0 });
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  it("REGRESSION (#5046): finalAttempt:true (the exhausted attempt) still logs the provider failure at error", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const failing: StubSpawn = async () => ({ stdout: "", code: 1, stderr: "final" });
+
+    await expect(createClaudeCodeAi({ CLAUDE_CODE_OAUTH_TOKEN: "t" }, failing).run("m", { prompt: "x", attempt: 2, finalAttempt: true })).rejects.toThrow();
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    const logged = JSON.parse(String(errorSpy.mock.calls[0]?.[0]));
+    expect(logged).toMatchObject({ level: "error", event: "selfhost_ai_provider_failed", attempt: 2 });
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  it("REGRESSION (#5046): a single-shot caller that never sets finalAttempt keeps today's always-loud behavior", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const failing: StubSpawn = async () => ({ stdout: "", code: 1, stderr: "single shot" });
+
+    await expect(createClaudeCodeAi({ CLAUDE_CODE_OAUTH_TOKEN: "t" }, failing).run("m", { prompt: "x" })).rejects.toThrow();
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    errorSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
 });
 
 describe("AI provider request duration/error metrics (#4367)", () => {


### PR DESCRIPTION
## Summary

- Fixes #5046, filed from live re-triage of the Sentry dashboard after this session's earlier 13-bug batch: `GITTENSORY-K` (`selfhost_ai_provider_failed: claude_stalled_no_output`) is still climbing (2077+ events) despite Fix #4994/PR #5013 already shipping and deploying — confirmed the deployed self-host release (`gittensory-selfhost@6b52b207`) is a descendant of that fix commit, so this is not a deploy-lag artifact.
- Root cause: pulled raw events and found several sharing the exact same `jobId`/`trace_id`, with `attempt: 0`, `attempt: 1`, etc. — one single review job, retrying internally, with **every individual attempt** independently reaching Sentry as its own `console.error`. `runWorkersOpinion` (`src/services/ai-review.ts`) retries up to 3× per model × up to 2 models (6 attempts max) — and its own per-attempt log (`ai_review_provider_attempt_failed`) is deliberately `console.warn`, with an explicit comment citing #26: "Per-attempt logs are warn (noisy retries, skipped by the central Sentry forwarder); the exhausted summary is error." But `logSelfHostAiProviderFailed` (`src/selfhost/ai.ts`), called from inside `createClaudeCodeAi`/`createCodexAi`'s own catch blocks on every throw, ignored that policy entirely and escalated every attempt — the two layers disagreed, and the lower one always wins since Sentry sees it either way. Fix #4994 made each individual attempt fail faster (good, real, needed) but never touched this separate over-escalation.
- Checked whether a blind fix (always downgrade to warn) was safe: it isn't. `src/review/planner.ts` and `src/services/ai-slop.ts` have their own retry loops (2× and 3× respectively) with **zero logging of their own** — they rely entirely on this same low-level log for any Sentry visibility into a persistent failure. A blanket downgrade would have made them silently blind.
- Fix: thread `finalAttempt?: boolean` through `AiRunOptions`, mirroring the existing `attempt`/`jobId` correlation fields (`#codex-timeout-fields` — same optional, purely-observational pattern). `logSelfHostAiProviderFailed` logs at `warn` only when `finalAttempt === false`; unset (any single-shot caller) or `true` stays `error`, so nothing loses visibility by default. `runWorkersOpinion`, the dual-AI tie-break judge call, `runPlannerModel`, and `runWorkersSlopOpinion` all compute it as `attempt === maxAttempts - 1 && modelIndex === models.length - 1` and pass it through.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #5046`).

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` locally
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- `test:coverage` (full unsharded): not run end-to-end — ran scoped `vitest --coverage` for the five touched test files (453 tests total: `selfhost-ai.test.ts`, `ai-review.test.ts`, `ai-review-advisory.test.ts`, `planner.test.ts`, `ai-slop.test.ts`) and confirmed via lcov that every changed line and both branches of every new `finalAttempt` expression are covered — the `ai-review.ts`/`planner.ts`/`ai-slop.ts` boolean expressions were already naturally exercised (both truthy and falsy) by the existing retry/exhaustion test suites; three new dedicated regression tests in `selfhost-ai.test.ts` pin the actual behavior change (warn vs error vs unset-stays-loud).
- `actionlint` / `test:workers` / `build:mcp` / `test:mcp-pack` / `ui:openapi:check` / `ui:lint` / `ui:typecheck` / `ui:build` / `npm audit`: not run — this change touches only existing internal AI-provider plumbing (no new API/schema/binding/dependency surface) and its tests; no workflow, MCP, UI, or dependency-manifest surface changed.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth surface touched.)
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A.)
- [ ] UI changes use live API data or real empty/error/loading states. (N/A.)
- [ ] Visible UI changes include a `UI Evidence` section. (N/A.)
- [ ] Public docs/changelogs are updated where needed. (N/A — internal engine behavior; changelog is not edited in a normal PR.)

## Notes

Follow-up from this session's earlier 13-bug Sentry triage batch (#4994–#5006) — found while re-checking the live dashboard after that batch shipped. The `claude_stalled_no_output` events themselves are expected/correct (Fix #4994 working as designed: fast-detecting a real, occasional external CLI hang); this PR addresses the separate, over-eager escalation of every retry within that detection.
