### PR TITLE
fix(selfhost): gate the queue consumer on env readiness at boot

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -334,10 +334,21 @@ async function main(): Promise<void> {
   /* v8 ignore stop */
   const startedAt = Date.now();
 
-  // The queue consumer captures `env`, assigned below (the first job only runs once an HTTP/cron event
-  // arrives, by which point env is set).
+  // The queue consumer captures `env`, assigned further below once the backend/migrations/AI providers are
+  // ready. That used to rest on "the first job only runs once an HTTP/cron event arrives, by which point env
+  // is set" -- false: both queue backends self-heal any foreground job left over-deferred across a restart by
+  // releasing it and kicking the pump ONCE at boot, inside queue construction/init() itself (see
+  // releaseStaleForegroundDeferrals in pg-queue.ts/sqlite-queue.ts), which can invoke consume() well before
+  // `env` below is assigned -- surfacing as a misleading generic job_error ("Cannot read properties of
+  // undefined") right after a container restart whenever a foreground job happened to be sitting deferred at
+  // that moment. Gate on envReady so a boot-time release waits for `env` instead of dereferencing it early.
   let env: Env;
+  let markEnvReady!: () => void;
+  const envReady = new Promise<void>((resolve) => {
+    markEnvReady = resolve;
+  });
   const consume = async (message: JobMessage): Promise<void> => {
+    await envReady;
     try {
       await processJob(env, message);
     } catch (error) {
@@ -637,6 +648,7 @@ async function main(): Promise<void> {
       return binding ? { REVIEW_AUDIT: binding } : {};
     })(),
   } as unknown as Env;
+  markEnvReady();
 
   // GitHub App auth: a successful JWT mint proves GITHUB_APP_PRIVATE_KEY is set and parses as a valid signing
   // key. Without this, an invalid/expired key leaves the review pipeline completely dead while /ready still


### PR DESCRIPTION
## Summary

- The self-host queue consumer closure (`consume` in `src/server.ts`) captures `env`, which isn't assigned until ~250 lines / several awaited boot steps after the queue backend is constructed.
- Both queue backends deliberately self-heal any foreground-priority job left over-deferred across a restart by calling `releaseStaleForegroundDeferrals()` **once at boot** (in addition to its normal periodic sweep), which can call `kickAll()` -> `consume(message)` -> `processJob(env, ...)` before `env` is set, dereferencing `undefined`.
- Surfaces as a misleading generic `job_error` audit event (`TypeError: Cannot read properties of undefined`) right after a container restart, only when a foreground job happened to be sitting deferred and release-eligible at that exact moment — self-heals on the very next retry, masking the real cause.
- Fix: `consume` now awaits an `envReady` promise, resolved immediately after `env` is fully assigned, so an early release just waits instead of dereferencing `env` early. Confined entirely to `server.ts`, which is shared by both queue backends — no changes needed in `pg-queue.ts`/`sqlite-queue.ts`.

Closes #5049

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run test:coverage` (full, unsharded) — 717 files / 14146 tests passed, 0 failures
- [x] `npm run test:ci` (full gate, incl. UI lint/typecheck/test/build, migrations/schema-drift/openapi/docs-drift checks) — green
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- `src/server.ts` is in `codecov.yml`'s ignore list (self-host process entry; validated by the Docker boot smoke test in `.github/workflows/selfhost.yml`, not unit-coverable without booting a real server/subprocess) — no dedicated unit test added for this exact race, consistent with how the rest of that file is handled.