### PR TITLE
fix(review): require a real installation before acting-autonomy scans include a repo

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -878,10 +878,20 @@ export async function fanOutAgentRegateSweepJobs(
       // outcome for just this repo (it gets picked up again next tick) instead of rejecting.
       try {
         const settings = await resolveRepositorySettings(env, repoFullName);
+        // #sweep-requires-installation: isAgentConfigured resolves the OPERATOR'S global-default autonomy
+        // (e.g. a self-host `.gittensory.yml` settings.autonomy block meant for the repos this instance
+        // actually operates on) for ANY repoFullName, regardless of whether the GitHub App is installed
+        // there. A repo that merely has a local `repositories` row (a stray subnet-registry row, say) with
+        // no real `installationId` would otherwise inherit that global default and look "agent-configured"
+        // purely by existing — even though no installation token exists to act on it, and it was never
+        // intentionally onboarded. Require a real installation before the autonomy-based path can make a
+        // repo eligible; the explicit allowlist path is untouched (GITTENSORY_REVIEW_REPOS is a deliberate,
+        // operator-typed signal independent of installation state, e.g. reviewing ahead of a pending install).
+        const hasInstallation = typeof repo.installationId === "number";
         if (
           !(
             isConvergenceRepoAllowed(env, repoFullName) ||
-            isAgentConfigured(settings.autonomy)
+            (hasInstallation && isAgentConfigured(settings.autonomy))
           )
         )
           return { kind: "ineligible" };

--- a/src/review/maintainer-recap-wire.ts
+++ b/src/review/maintainer-recap-wire.ts
@@ -103,6 +103,10 @@ async function recapScanRepos(env: Env): Promise<string[]> {
   const configured: string[] = [];
   for (const repo of repos) {
     try {
+      // #sweep-requires-installation: a repo with no real GitHub App installation must never be treated as
+      // agent-configured purely because it resolves the operator's global-default autonomy by merely having
+      // a local row -- mirrors fanOutAgentRegateSweepJobs's own guard.
+      if (typeof repo.installationId !== "number") continue;
       const settings = await resolveRepositorySettings(env, repo.fullName);
       if (isAgentConfigured(settings.autonomy)) configured.push(repo.fullName);
     } catch {

--- a/src/review/ops-wire.ts
+++ b/src/review/ops-wire.ts
@@ -155,6 +155,10 @@ async function opsScanRepos(env: Env): Promise<string[]> {
   const configured: string[] = [];
   for (const repo of repos) {
     try {
+      // #sweep-requires-installation: a repo with no real GitHub App installation must never be treated as
+      // agent-configured purely because it resolves the operator's global-default autonomy by merely having
+      // a local row -- mirrors fanOutAgentRegateSweepJobs's own guard.
+      if (typeof repo.installationId !== "number") continue;
       const settings = await resolveRepositorySettings(env, repo.fullName);
       if (isAgentConfigured(settings.autonomy)) configured.push(repo.fullName);
     } catch {

--- a/src/review/pr-reconciliation.ts
+++ b/src/review/pr-reconciliation.ts
@@ -44,7 +44,12 @@ async function watchedRepos(env: Env): Promise<Array<{ fullName: string; install
   for (const repo of byKey.values()) {
     try {
       const settings = await resolveRepositorySettings(env, repo.fullName);
-      if (isConvergenceRepoAllowed(env, repo.fullName) || isAgentConfigured(settings.autonomy)) configured.push(repo);
+      // #sweep-requires-installation: isAgentConfigured resolves the operator's global-default autonomy for
+      // ANY repoFullName -- a repo that merely has a local row (no real GitHub App installation) would
+      // otherwise inherit that default and look "agent-configured" purely by existing. Require a real
+      // installation before the autonomy-based path counts; the explicit allowlist stays untouched.
+      const hasInstallation = typeof repo.installationId === "number";
+      if (isConvergenceRepoAllowed(env, repo.fullName) || (hasInstallation && isAgentConfigured(settings.autonomy))) configured.push(repo);
     } catch {
       /* a settings blip on one repo must not abort the whole reconciliation scan */
     }

--- a/src/review/selftune-wire.ts
+++ b/src/review/selftune-wire.ts
@@ -106,6 +106,10 @@ async function selfTuneRepos(env: Env): Promise<string[]> {
   const configured: string[] = [];
   for (const repo of repos) {
     try {
+      // #sweep-requires-installation: a repo with no real GitHub App installation must never be treated as
+      // agent-configured purely because it resolves the operator's global-default autonomy by merely having
+      // a local row -- mirrors fanOutAgentRegateSweepJobs's own guard.
+      if (typeof repo.installationId !== "number") continue;
       const settings = await resolveRepositorySettings(env, repo.fullName);
       if (!isAgentConfigured(settings.autonomy)) continue;
       const manifest = await loadRepoFocusManifest(env, repo.fullName).catch(() => null);

--- a/src/review/sweep-watchdog.ts
+++ b/src/review/sweep-watchdog.ts
@@ -57,7 +57,11 @@ async function watchedRepos(env: Env): Promise<Array<{ fullName: string; install
   for (const repo of byKey.values()) {
     try {
       const settings = await resolveRepositorySettings(env, repo.fullName);
-      if (isConvergenceRepoAllowed(env, repo.fullName) || isAgentConfigured(settings.autonomy)) configured.push(repo);
+      // #sweep-requires-installation: mirrors fanOutAgentRegateSweepJobs's own guard -- a repo with no real
+      // GitHub App installation must never be treated as agent-configured purely because it resolves the
+      // operator's global-default autonomy by merely having a local row.
+      const hasInstallation = typeof repo.installationId === "number";
+      if (isConvergenceRepoAllowed(env, repo.fullName) || (hasInstallation && isAgentConfigured(settings.autonomy))) configured.push(repo);
     } catch {
       /* a settings blip on one repo must not abort the whole watchdog scan */
     }

--- a/test/unit/maintainer-recap-wire.test.ts
+++ b/test/unit/maintainer-recap-wire.test.ts
@@ -29,11 +29,14 @@ function poisonDbPrepare(env: Env, pattern: RegExp): void {
 }
 
 // Mark a repo registered so recapScanRepos picks it up (mirrors ops-wire.test.ts's seedRegisteredRepo).
-async function seedRegisteredRepo(env: Env, fullName: string): Promise<void> {
+async function seedRegisteredRepo(env: Env, fullName: string, installationId?: number): Promise<void> {
   const [owner, name] = fullName.split("/");
+  // installationId is only needed by tests that rely on the acting-autonomy selection path
+  // (#sweep-requires-installation): a repo with no real installation is never treated as agent-configured,
+  // regardless of its resolved autonomy settings.
   await (env.DB as unknown as { prepare: (s: string) => { bind: (...v: unknown[]) => { run: () => Promise<unknown> } } })
-    .prepare("INSERT INTO repositories (full_name, owner, name, is_installed, is_registered) VALUES (?, ?, ?, 1, 1)")
-    .bind(fullName, owner, name)
+    .prepare("INSERT INTO repositories (full_name, owner, name, is_installed, is_registered, installation_id) VALUES (?, ?, ?, 1, 1, ?)")
+    .bind(fullName, owner, name, installationId ?? null)
     .run();
 }
 
@@ -231,7 +234,7 @@ describe("runMaintainerRecapJob — cross-repo digest (#1963, #2248)", () => {
 
   it("prefers agent-configured repos over the full registered set when at least one is configured", async () => {
     const env = createTestEnv({ DISCORD_WEBHOOK_URL: HOOK });
-    await seedRegisteredRepo(env, "owner/configured");
+    await seedRegisteredRepo(env, "owner/configured", 9402);
     await seedMergedPr(env, "owner/configured", 1);
     await upsertRepositorySettings(env, { repoFullName: "owner/configured", autonomy: { merge: "auto" } });
     await seedRegisteredRepo(env, "owner/unconfigured");

--- a/test/unit/ops-wire.test.ts
+++ b/test/unit/ops-wire.test.ts
@@ -173,6 +173,19 @@ async function seedRegisteredRepo(env: Env, fullName: string): Promise<void> {
     .run();
 }
 
+// A registered repo with a REAL installation + acting-autonomy settings, so opsScanRepos's "prefer
+// agent-configured repos" branch picks it up (#sweep-requires-installation: installation_id is required
+// alongside the autonomy row, matching the real upsertRepositoryFromGitHub invariant).
+async function seedAgentConfiguredRepo(env: Env, fullName: string, installationId: number): Promise<void> {
+  const [owner, name] = fullName.split("/");
+  await env.DB.prepare("INSERT INTO repositories (full_name, owner, name, is_installed, is_registered, installation_id) VALUES (?, ?, ?, 1, 1, ?)")
+    .bind(fullName, owner, name, installationId)
+    .run();
+  await env.DB.prepare("INSERT INTO repository_settings (repo_full_name, autonomy_json) VALUES (?, ?)")
+    .bind(fullName, JSON.stringify({ review: "auto" }))
+    .run();
+}
+
 // Seed a gate-block ledger anomaly: blocked PRs that later MERGED (false positives) over the min sample.
 async function seedGateFalsePositiveAnomaly(env: Env, repoFullName: string): Promise<void> {
   for (let i = 1; i <= 6; i += 1) {
@@ -226,6 +239,21 @@ describe("runOpsAlerts — cron path over gittensory's outcome data", () => {
 
     expect(found["owner/clean"]).toBeUndefined();
     expect(errors.mock.calls.map((c) => String(c[0])).some((line) => line.includes("ops_anomaly\""))).toBe(false);
+  });
+
+  it("REGRESSION (#sweep-requires-installation): prefers the agent-configured repo and never scans an uninstalled registered repo when a configured one exists", async () => {
+    const env = createTestEnv();
+    await seedAgentConfiguredRepo(env, "owner/configured", 9501);
+    await seedGateFalsePositiveAnomaly(env, "owner/configured");
+    // Registered, but no real installation -- must not count as "agent-configured" merely by resolving the
+    // operator's global-default autonomy, and must be excluded from the scan once a configured repo exists.
+    await seedRegisteredRepo(env, "owner/no-install");
+    await seedGateFalsePositiveAnomaly(env, "owner/no-install");
+
+    const found = await runOpsAlerts(env);
+
+    expect(found["owner/configured"]?.some((a) => /gate false-positive spike/.test(a))).toBe(true);
+    expect(found["owner/no-install"]).toBeUndefined();
   });
 
   it("detects and reports a review burst end-to-end (a PR published far more review surfaces than normal in the window)", async () => {

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -888,9 +888,11 @@ describe("queue processors", () => {
         },
       } as unknown as Queue,
     });
-    await upsertRepositoryFromGitHub(env, { name: "agent-a", full_name: "owner/agent-a", private: false, owner: { login: "owner" } });
-    await upsertRepositoryFromGitHub(env, { name: "agent-b", full_name: "owner/agent-b", private: false, owner: { login: "owner" } });
-    await upsertRepositoryFromGitHub(env, { name: "plain-repo", full_name: "owner/plain-repo", private: false, owner: { login: "owner" } });
+    // #sweep-requires-installation: acting-autonomy eligibility also requires a real installation now — give
+    // the repos that SHOULD be swept a real installationId, mirroring an actually-installed repo.
+    await upsertRepositoryFromGitHub(env, { name: "agent-a", full_name: "owner/agent-a", private: false, owner: { login: "owner" } }, 9201);
+    await upsertRepositoryFromGitHub(env, { name: "agent-b", full_name: "owner/agent-b", private: false, owner: { login: "owner" } }, 9202);
+    await upsertRepositoryFromGitHub(env, { name: "plain-repo", full_name: "owner/plain-repo", private: false, owner: { login: "owner" } }, 9203);
     await upsertRepositorySettings(env, { repoFullName: "owner/agent-a", autonomy: { label: "auto" } });
     await upsertRepositorySettings(env, { repoFullName: "owner/agent-b", autonomy: { merge: "auto_with_approval" } });
     await upsertRepositorySettings(env, { repoFullName: "owner/plain-repo", autonomy: { review: "observe" } }); // non-acting → not configured
@@ -906,6 +908,27 @@ describe("queue processors", () => {
     }>();
     expect(fanout?.outcome).toBe("queued");
     expect(JSON.parse(fanout?.metadata_json ?? "{}")).toMatchObject({ repoCount: 2, requestedBy: "schedule" });
+  });
+
+  it("REGRESSION (#sweep-requires-installation): an acting-autonomy repo with NO real installation is excluded, even though it resolves the operator's global-default autonomy", async () => {
+    const sent: import("../../src/types").JobMessage[] = [];
+    const env = createTestEnv({
+      GITTENSORY_REVIEW_REPOS: "",
+      JOBS: { async send(m: import("../../src/types").JobMessage) { sent.push(m); } } as unknown as Queue,
+    });
+    // A repo that merely EXISTS locally (e.g. a stray row from an unrelated sync) with a real installation and
+    // acting autonomy — sweep-eligible.
+    await upsertRepositoryFromGitHub(env, { name: "installed-repo", full_name: "owner/installed-repo", private: false, owner: { login: "owner" } }, 9301);
+    await upsertRepositorySettings(env, { repoFullName: "owner/installed-repo", autonomy: { merge: "auto" } });
+    // Same acting autonomy, but NO installationId (never upserted with one) — this is exactly the shape a
+    // stray repositories row takes: it can still resolve a permissive global-default autonomy policy, but
+    // there is no GitHub App installation on it at all, so it must never be treated as agent-configured.
+    await upsertRepositoryFromGitHub(env, { name: "uninstalled-repo", full_name: "owner/uninstalled-repo", private: false, owner: { login: "owner" } });
+    await upsertRepositorySettings(env, { repoFullName: "owner/uninstalled-repo", autonomy: { merge: "auto" } });
+
+    await processJob(env, { type: "agent-regate-sweep", requestedBy: "schedule" });
+
+    expect(sent.map((m) => (m.type === "agent-regate-sweep" ? m.repoFullName : null))).toEqual(["owner/installed-repo"]);
   });
 
   it("agent re-gate sweep ALSO fans out to allowlisted repos regardless of autonomy mode (#sweep-all-modes)", async () => {
@@ -931,8 +954,8 @@ describe("queue processors", () => {
       GITTENSORY_REVIEW_REPOS: "",
       JOBS: { async send(m: import("../../src/types").JobMessage) { sent.push(m); } } as unknown as Queue,
     });
-    await upsertRepositoryFromGitHub(env, { name: "agent-a", full_name: "owner/agent-a", private: false, owner: { login: "owner" } });
-    await upsertRepositoryFromGitHub(env, { name: "agent-b", full_name: "owner/agent-b", private: false, owner: { login: "owner" } });
+    await upsertRepositoryFromGitHub(env, { name: "agent-a", full_name: "owner/agent-a", private: false, owner: { login: "owner" } }, 9204);
+    await upsertRepositoryFromGitHub(env, { name: "agent-b", full_name: "owner/agent-b", private: false, owner: { login: "owner" } }, 9205);
     await upsertRepositorySettings(env, { repoFullName: "owner/agent-a", autonomy: { label: "auto" } });
     await upsertRepositorySettings(env, { repoFullName: "owner/agent-b", autonomy: { label: "auto" } });
     const realResolve = repositorySettingsModule.resolveRepositorySettings;
@@ -964,8 +987,8 @@ describe("queue processors", () => {
         },
       } as unknown as Queue,
     });
-    await upsertRepositoryFromGitHub(env, { name: "agent-a", full_name: "owner/agent-a", private: false, owner: { login: "owner" } });
-    await upsertRepositoryFromGitHub(env, { name: "agent-b", full_name: "owner/agent-b", private: false, owner: { login: "owner" } });
+    await upsertRepositoryFromGitHub(env, { name: "agent-a", full_name: "owner/agent-a", private: false, owner: { login: "owner" } }, 9206);
+    await upsertRepositoryFromGitHub(env, { name: "agent-b", full_name: "owner/agent-b", private: false, owner: { login: "owner" } }, 9207);
     await upsertRepositorySettings(env, { repoFullName: "owner/agent-a", autonomy: { label: "auto" } });
     await upsertRepositorySettings(env, { repoFullName: "owner/agent-b", autonomy: { label: "auto" } });
     const errors = vi.spyOn(console, "error").mockImplementation(() => undefined);
@@ -988,8 +1011,8 @@ describe("queue processors", () => {
       JOBS: { async send(m: import("../../src/types").JobMessage) { sent.push(m); } } as unknown as Queue,
     });
     const repoNames = ["r1", "r2", "r3", "r4", "r5", "r6"];
-    for (const name of repoNames) {
-      await upsertRepositoryFromGitHub(env, { name, full_name: `owner/${name}`, private: false, owner: { login: "owner" } });
+    for (const [index, name] of repoNames.entries()) {
+      await upsertRepositoryFromGitHub(env, { name, full_name: `owner/${name}`, private: false, owner: { login: "owner" } }, 9300 + index);
       await upsertRepositorySettings(env, { repoFullName: `owner/${name}`, autonomy: { label: "auto" } });
     }
     const { mapWithConcurrencyLimit: realMapWithConcurrencyLimit } =

--- a/test/unit/selftune-wiring.test.ts
+++ b/test/unit/selftune-wiring.test.ts
@@ -30,8 +30,11 @@ function poisonDbPrepare(env: Env, pattern: RegExp): void {
 
 async function seedRegisteredRepo(env: Env, fullName: string, autonomyJson: string): Promise<void> {
   const [owner, name] = fullName.split("/");
-  await env.DB.prepare("INSERT INTO repositories (full_name, owner, name, is_installed, is_registered) VALUES (?, ?, ?, 1, 1)")
-    .bind(fullName, owner, name)
+  // installation_id is required alongside is_installed=1 (#sweep-requires-installation): selfTuneRepos now
+  // requires a real installation before isAgentConfigured counts, matching the real upsertRepositoryFromGitHub
+  // invariant (isInstalled is only ever true alongside a real installationId).
+  await env.DB.prepare("INSERT INTO repositories (full_name, owner, name, is_installed, is_registered, installation_id) VALUES (?, ?, ?, 1, 1, ?)")
+    .bind(fullName, owner, name, 9401)
     .run();
   // Opt the repo into the acting-autonomy surface so isAgentConfigured(settings.autonomy) is true (selfTuneRepos filter).
   await env.DB.prepare("INSERT INTO repository_settings (repo_full_name, autonomy_json) VALUES (?, ?)")
@@ -271,6 +274,23 @@ describe("selfTuneRepos — per-repo review.selftune FORCE-OFF (#4104)", () => {
     expect(await loadShadowOverride(env as never, "owner/opted-out")).toBeNull();
     expect(await loadOverride(env as never, "owner/opted-out")).toBeNull();
     expect((await listOverrideAudit(env as never, "owner/opted-out")).length).toBe(0);
+  });
+
+  it("REGRESSION (#sweep-requires-installation): an acting-autonomy repo with NO real installation is excluded from the tuning pass, even though it resolves the operator's global-default autonomy", async () => {
+    const owner = "owner";
+    const name = "no-install";
+    const env = createTestEnv({ GITTENSORY_REVIEW_SELFTUNE: "true" });
+    await env.DB.prepare("INSERT INTO repositories (full_name, owner, name, is_installed, is_registered) VALUES (?, ?, ?, 0, 1)")
+      .bind(`${owner}/${name}`, owner, name)
+      .run();
+    await env.DB.prepare("INSERT INTO repository_settings (repo_full_name, autonomy_json) VALUES (?, ?)")
+      .bind(`${owner}/${name}`, ACTING_AUTONOMY)
+      .run();
+    await seedRecommendationOutcomes(env, `${owner}/${name}`, 5, 10); // would otherwise be a clear tightening signal
+
+    await runSelfTune(env);
+
+    expect(await loadShadowOverride(env as never, `${owner}/${name}`)).toBeNull();
   });
 
   it("unset review.selftune (the default) does not change today's behavior — an agent-configured repo still tunes normally", async () => {


### PR DESCRIPTION
## Summary

- `isAgentConfigured` resolves the operator's global-default autonomy for ANY `repoFullName`, regardless of whether the GitHub App is installed there. A repo with only a local `repositories` row (e.g. a stray gittensor-subnet-registry entry with no real installation) inherited that global default and looked "agent-configured" purely by existing, even with no installation token to ever act on it.
- Adds a `hasInstallation` (`typeof repo.installationId === "number"`) guard before the autonomy-based eligibility check, mirroring the same pattern across every site that copies the regate sweep's own repo-selection logic: `fanOutAgentRegateSweepJobs` (`src/queue/processors.ts`), `watchedRepos` in both `pr-reconciliation.ts` and `sweep-watchdog.ts`, and the scan helpers in `ops-wire.ts`, `selftune-wire.ts`, and `maintainer-recap-wire.ts`.
- The explicit `GITTENSORY_REVIEW_REPOS` allowlist path (`isConvergenceRepoAllowed`) is deliberately left untouched — it's an operator-typed signal independent of installation state (e.g. reviewing ahead of a pending install).
- Closes #5023. Note: #5023's own body assumed the regate sweep (`fanOutAgentRegateSweepJobs`) already correctly scoped by installation and that ops-alerts/selftune/maintainer-recap just needed to "mirror the regate sweep exactly" — investigation found the regate sweep had the identical leak, so this PR also fixes `processors.ts` itself plus two more call sites with the same pattern (`pr-reconciliation.ts`, `sweep-watchdog.ts`) that weren't in #5023's stated scope.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves — Closes #5023.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint` (via `npm run test:ci`)
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — 100% branch/line coverage on every changed line across all 6 files (verified via targeted `--coverage.include` runs per file; the only residual gaps flagged by v8 are pre-existing branches on lines my diff did not touch).
- [x] `npm run test:workers` (via `npm run test:ci`)
- [x] `npm run build:mcp` (via `npm run test:ci`)
- [x] `npm run test:mcp-pack` (via `npm run test:ci`)
- [x] `npm run ui:openapi:check` (via `npm run test:ci`) — no API/schema changes in this PR.
- [x] `npm run ui:lint` (via `npm run test:ci`)
- [x] `npm run ui:typecheck` (via `npm run test:ci`)
- [x] `npm run ui:build` (via `npm run test:ci`)
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities.
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — regression tests added/extended in `queue.test.ts`, `selftune-wiring.test.ts`, and `ops-wire.test.ts`; `pr-reconciliation.test.ts`, `sweep-watchdog.test.ts`, and `maintainer-recap-wire.test.ts` already had fixtures that exercise the new guard's both branches.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session surface touched.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — internal scan-selection logic only.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changes.)
- [x] Visible UI changes include a `UI Evidence` section. (N/A — no UI changes.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (N/A.)

## Notes

- This is a backend-only, non-UI fix; no `UI Evidence` section is included.