### PR TITLE
test(commands): cover the intent-router ask/chat question-threading branch

### DIFF
--- a/test/unit/queue-5.test.ts
+++ b/test/unit/queue-5.test.ts
@@ -1343,6 +1343,42 @@ describe("queue processors", () => {
       expect(seen.comments[0]).not.toContain("Did you mean");
     });
 
+    it("#4596: re-routing to ask/chat threads the original free text through as the command's own question (not dropped)", async () => {
+      const env = createTestEnv({
+        GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem(),
+        AI_ADVISORY: { run: async () => ({ response: '{"command": "ask"}' }) } as unknown as Ai,
+      });
+      await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 315, title: "Rate limit target", state: "open", user: { login: "oktofeesh1" }, author_association: "NONE", labels: [], body: "" });
+      const seen = { comments: [] as string[] };
+      vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = input.toString();
+        const method = init?.method ?? "GET";
+        if (url.includes("raw.githubusercontent.com") && url.includes(".gittensory.yml")) {
+          return new Response("settings:\n  advisoryAiRouting:\n    intentRouting: true\n", { status: 200 });
+        }
+        if (url.includes("/access_tokens")) return Response.json({ token: "fake-installation-token" });
+        if (url.includes("/collaborators/") && url.includes("/permission")) return Response.json({ permission: "maintain" });
+        if (url.includes("/issues/315/comments") && method === "GET") return Response.json([]);
+        if (url.includes("/issues/315/comments") && method === "POST") {
+          seen.comments.push(String(JSON.parse(String(init?.body ?? "{}")).body ?? ""));
+          return Response.json({ id: seen.comments.length }, { status: 201 });
+        }
+        return new Response("not found", { status: 404 });
+      });
+      await processJob(env, {
+        type: "github-webhook",
+        deliveryId: "intent-routing-ask-question-threaded",
+        eventName: "issue_comment",
+        payload: mentionPayload(315, "@gittensory what should I fix first?"),
+      });
+      expect(seen.comments).toHaveLength(1);
+      expect(seen.comments[0]).toContain('Interpreted "what should I fix first?" as `@gittensory ask`');
+      // ask's own card only prints this fallback when its question is empty/undefined -- its absence proves
+      // command.unrecognizedText actually reached `ask` as its question rather than being dropped by the
+      // reroute (unlike blockers/next-action/etc., ask and chat are the only two commands that take one).
+      expect(seen.comments[0]).not.toContain("No specific question was provided");
+    });
+
     it("#4596: falls through to the existing did-you-mean hint end-to-end when intentRouting is off, the default", async () => {
       const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
       await upsertPullRequestFromGitHub(env, "JSONbored/gittensory", { number: 310, title: "Rate limit target", state: "open", user: { login: "oktofeesh1" }, author_association: "NONE", labels: [], body: "" });


### PR DESCRIPTION
## Summary

Follow-up to #4596 (PR #5036, merged): Codecov's `codecov/patch` check flagged one partial branch in `processors.ts` at merge time (98.80% vs the 99% target) — advisory-only for this maintainer PR, so it merged, but worth closing properly rather than leaving it.

The gap: `question: matchedCommand === "ask" || matchedCommand === "chat" ? command.unrecognizedText : undefined` — all 3 existing `#4596` integration tests only ever reroute an unrecognized mention to `"blockers"`, so the `true` side of this ternary (rerouting to `ask`/`chat` specifically, the only two commands that take a free-text question) was never exercised. That's the one behavior in this line that actually matters: does the contributor's original text survive the reroute into the target command's own `question` field, or get silently dropped.

Added one integration test rerouting to `ask` and asserting the resulting card does NOT show `"No specific question was provided"` (the marker `ask` renders when its question is empty/undefined) — proving the text threaded through correctly.

Test-only change; no production code touched.

## Test plan

- [x] `npm run typecheck` — clean
- [x] New test run in isolation — passes, confirmed via direct `lcov.info` inspection that the previously-0-hit branch at `processors.ts:12516` is now hit on both sides
- [x] `npm run test:coverage` (full, unsharded) — 718 files / 14203 tests passed, 0 failures
- [x] `npm run test:ci` (full gate) — green
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities