### PR TITLE
fix(selfhost): widen 2 more GitHub-id columns found via a live-schema sweep

### DIFF
--- a/src/selfhost/pg-adapter.ts
+++ b/src/selfhost/pg-adapter.ts
@@ -162,10 +162,10 @@ export const GITHUB_ID_BIGINT_WIDENING_SQL = [
  *  mirroring tuneGithubRateLimitObservationsAutovacuum's shape exactly. Must run AFTER migrations (every table
  *  above has to exist by then, so a mid-batch "relation does not exist" is not a realistic failure mode here);
  *  best-effort by design -- a failure here must not stop the self-host from booting. Postgres's simple-query
- *  protocol runs this whole multi-statement string as one implicit transaction, so either all 19 ALTERs commit
- *  together or (on any single failure) none do -- fine given every ALTER is independently idempotent and this
- *  reruns unconditionally on every boot: a failed attempt just retries whole next boot instead of leaving a
- *  partially-widened, inconsistent state. */
+ *  protocol runs this whole multi-statement string as one implicit transaction, so either every ALTER in the
+ *  list commits together or (on any single failure) none do -- fine given each ALTER is independently
+ *  idempotent and this reruns unconditionally on every boot: a failed attempt just retries the whole batch
+ *  next boot instead of leaving a partially-widened, inconsistent state. */
 export async function widenGithubIdColumnsToBigint(db: D1Database): Promise<void> {
   await db.exec(GITHUB_ID_BIGINT_WIDENING_SQL).catch((error: unknown) => {
     console.error(

--- a/src/selfhost/pg-adapter.ts
+++ b/src/selfhost/pg-adapter.ts
@@ -138,6 +138,7 @@ export async function tuneGithubRateLimitObservationsAutovacuum(db: D1Database):
 export const GITHUB_ID_BIGINT_WIDENING_SQL = [
   "ALTER TABLE installations ALTER COLUMN id TYPE bigint",
   "ALTER TABLE installations ALTER COLUMN account_id TYPE bigint",
+  "ALTER TABLE installations ALTER COLUMN app_id TYPE bigint",
   "ALTER TABLE repositories ALTER COLUMN installation_id TYPE bigint",
   "ALTER TABLE advisories ALTER COLUMN check_run_id TYPE bigint",
   "ALTER TABLE webhook_events ALTER COLUMN installation_id TYPE bigint",
@@ -149,6 +150,7 @@ export const GITHUB_ID_BIGINT_WIDENING_SQL = [
   "ALTER TABLE review_targets ALTER COLUMN installation_id TYPE bigint",
   "ALTER TABLE orb_webhook_events ALTER COLUMN installation_id TYPE bigint",
   "ALTER TABLE orb_github_installations ALTER COLUMN installation_id TYPE bigint",
+  "ALTER TABLE orb_github_installations ALTER COLUMN account_id TYPE bigint",
   "ALTER TABLE orb_pr_outcomes ALTER COLUMN installation_id TYPE bigint",
   "ALTER TABLE orb_enrollments ALTER COLUMN installation_id TYPE bigint",
   "ALTER TABLE orb_enrollments ALTER COLUMN maintainer_github_id TYPE bigint",

--- a/test/unit/selfhost-pg-adapter-github-id-widening.test.ts
+++ b/test/unit/selfhost-pg-adapter-github-id-widening.test.ts
@@ -24,6 +24,11 @@ describe("GITHUB_ID_BIGINT_WIDENING_SQL (#selfhost-github-id-overflow)", () => {
     expect(GITHUB_ID_BIGINT_WIDENING_SQL).toContain("ALTER TABLE github_agent_command_answers ALTER COLUMN response_comment_id TYPE bigint");
   });
 
+  it("covers the two columns found via the live-schema sweep (added by later ALTER TABLE ADD COLUMN migrations, not the original CREATE TABLE statements)", () => {
+    expect(GITHUB_ID_BIGINT_WIDENING_SQL).toContain("ALTER TABLE installations ALTER COLUMN app_id TYPE bigint");
+    expect(GITHUB_ID_BIGINT_WIDENING_SQL).toContain("ALTER TABLE orb_github_installations ALTER COLUMN account_id TYPE bigint");
+  });
+
   it("is additive-only DDL, never destructive", () => {
     expect(GITHUB_ID_BIGINT_WIDENING_SQL).not.toMatch(/DROP|DELETE|TRUNCATE/i);
   });

--- a/test/unit/selfhost-pg-adapter-github-id-widening.test.ts
+++ b/test/unit/selfhost-pg-adapter-github-id-widening.test.ts
@@ -13,7 +13,7 @@ function mockDb(execImpl: (sql: string) => Promise<unknown>): D1Database {
 describe("GITHUB_ID_BIGINT_WIDENING_SQL (#selfhost-github-id-overflow)", () => {
   it("widens every known GitHub-native-id column to bigint, one ALTER per statement", () => {
     const statements = GITHUB_ID_BIGINT_WIDENING_SQL.split(";").map((s) => s.trim()).filter(Boolean);
-    expect(statements.length).toBeGreaterThanOrEqual(18);
+    expect(statements.length).toBeGreaterThanOrEqual(20);
     for (const statement of statements) {
       expect(statement.toUpperCase()).toMatch(/^ALTER TABLE \w+ ALTER COLUMN \w+ TYPE bigint$/i);
     }


### PR DESCRIPTION
## Summary

Follow-up to #5059 / #5060 (merged): after that PR merged, I ran one more, more-thorough check directly against the live edge-nl-01 Postgres schema (`information_schema.columns` for every remaining `integer` column shaped like an id) rather than trusting the migration-file grep alone. It caught two the first pass missed:

- `installations.app_id` -- GitHub's own numeric App id, added by a later `ALTER TABLE ... ADD COLUMN` migration (0071), not the original `CREATE TABLE` the first grep matched against.
- `orb_github_installations.account_id` -- same shape, added by migration 0077.

Everything else the live-schema query surfaced was either the one already-excluded local-counter exception (`orb_signals.id`) or Postgres's own system catalogs (`pg_locks`, `pg_stat_activity`, etc.) -- confirmed nothing else is missing.

Both statements were dry-run validated against production before being written into code, then applied directly (the underlying bug is live and actively occurring, same as #5059/#5060).

Closes #5070

## Test plan

- [x] `npm run typecheck` -- clean
- [x] `selfhost-pg-adapter-github-id-widening.test.ts` -- explicit `toContain` assertions for both new columns, not just the length/shape check
- [x] `npm run test:coverage` (full, unsharded) -- 719 files / 14227 tests passed, 0 failures
- [x] `npm audit --audit-level=moderate` -- 0 vulnerabilities
- [x] Both `ALTER` statements dry-run validated then applied against the live edge-nl-01 Postgres schema
- `src/selfhost/pg-adapter.ts` is in `codecov.yml`'s ignore list (Postgres runtime adapter) -- patch-coverage gate does not block on this PR
