### PR TITLE
fix(release): allow an empty commit when cutting the ORB stable Release PR

### DIFF
--- a/.github/workflows/orb-stable-release-pr.yml
+++ b/.github/workflows/orb-stable-release-pr.yml
@@ -105,7 +105,11 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git checkout -B release-orb-stable
           git add orb-manifest.json
-          git commit -m "chore(release): cut orb-v${NEXT_VERSION}"
+          # --allow-empty: orb-manifest.json's version can already equal the proposed nextVersion (the common
+          # case right after a maintainer hand-bumps it ahead of landing the commits that warrant it) -- the
+          # branch/PR must still get created/refreshed as the reviewable release marker even when there's no
+          # manifest diff to stage.
+          git commit --allow-empty -m "chore(release): cut orb-v${NEXT_VERSION}"
           git remote set-url origin "https://github.com/${GITHUB_REPOSITORY}.git"
           gh auth setup-git
           git push --force origin release-orb-stable


### PR DESCRIPTION
## Summary

- Follow-up to #5063. Confirmed live on the very first real `orb-stable-release-pr` run: `orb-manifest.json` already declared `"0.4.0"`, and `buildOrbStableReleaseReport`'s inferred next version was also `0.4.0` (the common case right after a maintainer hand-bumps the manifest ahead of landing the commits that warrant it) -- so writing the "proposed" version produced a byte-identical file, `git add` staged nothing, and `git commit` failed outright before the push/PR-create steps ever ran.
- Fix: `git commit --allow-empty` -- the branch/PR is the reviewable release marker regardless of whether the manifest content actually changes.
- Verified the fix live: re-dispatched `orb-stable-release-pr.yml` against this fix branch directly (`workflow_dispatch` with `--ref`) and it succeeded, correctly opening #5066 (`chore(release): cut orb-v0.4.0`) with the full commit list since `orb-v0.3.0` in the body.

Maintainer PR (JSONbored) -- no linked issue per the repo's maintainer exception.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused (one workflow file, one line changed plus a comment).
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] Maintainer PR -- no linked issue required.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] Live-verified against the real repo: re-ran the fixed workflow via `workflow_dispatch --ref` on this branch, confirmed it now succeeds and opens a correct Release PR (#5066).
- [x] `npm audit --audit-level=moderate` -- 0 vulnerabilities (no dependency changes).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A -- CI workflow only.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (N/A.)

## Notes

- Backend/CI-infra-only one-line fix; no `UI Evidence` section.