### PR TITLE
test(settings): fix a spy call-count flake in selftune-readback.test.ts

### DIFF
--- a/test/unit/selftune-readback.test.ts
+++ b/test/unit/selftune-readback.test.ts
@@ -70,7 +70,12 @@ describe("resolveRepositorySettings — self-tune override overlay (flag-gated)"
     const repo = "acme/fallback";
     await env.DB.prepare("INSERT INTO repositories (full_name, owner, name, is_installed, is_registered) VALUES (?, 'acme', 'fallback', 1, 1)").bind(repo).run();
 
+    // mockClear immediately after spyOn: under heavy parallel load a prior attempt of THIS test can time out
+    // (vitest's global retry: 1) while its body is still in flight (JS can't cancel an in-flight async
+    // function), and vi.spyOn on an already-spied method reuses the same mock's call history -- without this,
+    // an abandoned first attempt's call leaks into the retry's count and toHaveBeenCalledOnce() flakes.
     const getGlobalSpy = vi.spyOn(repositories, "getGlobalContributorBlacklist").mockRejectedValue(new Error("transient DB issue"));
+    getGlobalSpy.mockClear();
 
     try {
       const settings = await resolveRepositorySettings(env, repo);


### PR DESCRIPTION
## Summary

- `test/unit/selftune-readback.test.ts`'s "uses fallback [] when shared/global blacklist read rejects" test intermittently failed under heavy parallel load with `expected "getGlobalContributorBlacklist" to be called once, but got 2 times`.
- Root cause: `resolveRepositorySettings` calls `getGlobalContributorBlacklist(env).catch(() => [])` exactly once (`src/settings/repository-settings.ts:38`) — the implementation is correct. The flake comes from `vitest.config.ts`'s global `retry: 1` interacting with `vi.spyOn`: when a slow first attempt hits the 15000ms timeout, vitest starts a retry while the first attempt's async body is still running in the background (JS cannot cancel an in-flight async function). `vi.spyOn` on an already-spied method reuses the same mock's `mock.calls` history, so a call from the abandoned first attempt can leak into the retry's count.
- Fix: call `getGlobalSpy.mockClear()` immediately after creating the spy, before invoking `resolveRepositorySettings`, so the assertion only ever counts calls from the attempt that's actually running.

Closes #5065

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] Ran the affected test file directly (`test/unit/selftune-readback.test.ts`), all 8 tests pass. Test-only change under `test/**`, which Codecov's patch gate does not measure (only `src/**` is measured).
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries. (N/A — this PR only hardens an existing test's isolation; no production behavior changed.)

If any required check was skipped, explain why:

- This is a test-only change (no `src/**` touched), so `ui:*`/`build:mcp`/`test:mcp-pack`/`test:workers`/coverage-threshold checks are unaffected by the diff; the full local gate was already run clean earlier in the same session on a sibling branch off the same `main`.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — test-only change.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A.)
- [x] Visible UI changes include a `UI Evidence` section below. (N/A — no UI changed.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (N/A.)