### PR TITLE
fix(review): log a bounded response snippet on unparseable AI output

### DIFF
--- a/src/services/ai-review.ts
+++ b/src/services/ai-review.ts
@@ -1007,6 +1007,11 @@ function isSubscriptionCliTimeout(error: unknown): boolean {
   return error instanceof Error && error.message === "subscription_cli_timeout";
 }
 
+/** Cap on the diagnostic prefix logged for an unparseable model response (#observability-unparseable) -- long
+ *  enough to tell a markdown-fenced/truncated-mid-JSON/plain-prose response apart, short enough to never dump
+ *  a large chunk of model output into Sentry/audit context. */
+const UNPARSEABLE_RESPONSE_SNIPPET_MAX_CHARS = 400;
+
 /** One reviewer opinion (whichever provider `env.AI` resolves to — self-host Codex/Claude Code/etc, or the
  *  legacy Workers-AI pair) with a per-slot reliable fallback and a 3× retry on the primary. */
 async function runWorkersOpinion(
@@ -1037,7 +1042,7 @@ async function runWorkersOpinion(
   // logs are warn (noisy retries, skipped by the central Sentry forwarder); the exhausted summary is error (#26).
   let lastError: unknown;
   let lastUnparseable:
-    | { model: string; attempt: number; responseChars: number; hasJsonObject: boolean }
+    | { model: string; attempt: number; responseChars: number; hasJsonObject: boolean; responseSnippet: string }
     | undefined;
   const models = fallback && fallback !== primary ? [primary, fallback] : [primary];
   for (const [modelIndex, model] of models.entries()) {
@@ -1085,10 +1090,15 @@ async function runWorkersOpinion(
           return { review: parsed };
         }
         const hasJsonObject = Boolean(extractLastJsonObject(text));
-        const status = text.trim() ? "unparseable_output" : "empty_output";
+        const trimmedText = text.trim();
+        const status = trimmedText ? "unparseable_output" : "empty_output";
         diagnostics.push({ model, attempt, status, responseChars: text.length, hasJsonObject, ...usageFields });
-        if (text.trim()) {
-          lastUnparseable = { model, attempt, responseChars: text.length, hasJsonObject };
+        if (trimmedText) {
+          // NOT added to the diagnostics entry above: reviewDiagnostics flows into result/Sentry context that
+          // must never carry raw provider text (see the "withholds unsafe provider and reviewer fallback text"
+          // test) -- logged here instead, which reaches only the structured-log Sentry forwarder, never `result`.
+          const responseSnippet = trimmedText.slice(0, UNPARSEABLE_RESPONSE_SNIPPET_MAX_CHARS);
+          lastUnparseable = { model, attempt, responseChars: text.length, hasJsonObject, responseSnippet };
           console.warn(
             JSON.stringify({
               level: "warn",
@@ -1097,6 +1107,7 @@ async function runWorkersOpinion(
               attempt,
               responseChars: text.length,
               hasJsonObject,
+              responseSnippet,
             }),
           );
         }
@@ -1149,6 +1160,7 @@ async function runWorkersOpinion(
         attempt: lastUnparseable.attempt,
         responseChars: lastUnparseable.responseChars,
         hasJsonObject: lastUnparseable.hasJsonObject,
+        responseSnippet: lastUnparseable.responseSnippet,
       }),
     );
   }

--- a/test/unit/ai-review.test.ts
+++ b/test/unit/ai-review.test.ts
@@ -8,6 +8,7 @@ import {
   resolveEffectiveAiReviewPlan,
   runGittensoryAiReview,
   type AiContentBlock,
+  type AiReviewDiagnostic,
   type GittensoryAiReviewInput,
 } from "../../src/services/ai-review";
 import { createTestEnv } from "../helpers/d1";
@@ -3081,7 +3082,7 @@ describe("pure helpers", () => {
     warnSpy.mockRestore();
   });
 
-  it("logs unparseable exhaustion separately when the model runs but returns unparseable output", async () => {
+  it("logs unparseable exhaustion separately when the model runs but returns unparseable output, including a response snippet for diagnosis (#observability-unparseable)", async () => {
     const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
     const run = vi.fn(async () => ({ response: "not json at all" }));
     const env = createTestEnv({ AI: { run } as unknown as Ai });
@@ -3092,12 +3093,33 @@ describe("pure helpers", () => {
         .map((c) => c[0])
         .some((l) => typeof l === "string" && l.includes("ai_review_provider_exhausted")),
     ).toBe(false);
-    expect(
-      logSpy.mock.calls
-        .map((c) => c[0])
-        .some((l) => typeof l === "string" && l.includes("ai_review_provider_unparseable_exhausted")),
-    ).toBe(true);
+    const exhausted = logSpy.mock.calls
+      .map((c) => c[0])
+      .find((l) => typeof l === "string" && l.includes("ai_review_provider_unparseable_exhausted"));
+    expect(exhausted).toBeDefined();
+    expect(JSON.parse(exhausted as string)).toMatchObject({
+      event: "ai_review_provider_unparseable_exhausted",
+      responseSnippet: "not json at all",
+    });
     logSpy.mockRestore();
+  });
+
+  it("truncates the unparseable-output response snippet to 400 chars instead of logging the full response (#observability-unparseable), and never puts it on the returned diagnostics (#4111-style public/private boundary)", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const longResponse = "not json, ".repeat(60); // 600 chars, well over the 400-char cap
+    const run = vi.fn(async () => ({ response: longResponse }));
+    const env = createTestEnv({ AI: { run } as unknown as Ai });
+    const diagnostics: AiReviewDiagnostic[] = [];
+    await runWorkersOpinion(env, "primary-model", "primary-model", "sys", "user", 256, diagnostics);
+    // reviewDiagnostics flows into result/Sentry context that must never carry raw provider text (see the
+    // "withholds unsafe provider and reviewer fallback text" test) -- the snippet only ever reaches the log.
+    expect(diagnostics[0]).not.toHaveProperty("responseSnippet");
+    const firstWarn = warnSpy.mock.calls
+      .map((c) => c[0])
+      .find((l) => typeof l === "string" && l.includes("ai_review_provider_unparseable_output"));
+    expect(JSON.parse(firstWarn as string).responseSnippet).toBe(longResponse.slice(0, 400));
+    expect(JSON.parse(firstWarn as string).responseSnippet.length).toBe(400);
+    warnSpy.mockRestore();
   });
 
   it("applies the default daily neuron budget when none is configured", async () => {


### PR DESCRIPTION
## Summary

- `ai_review_provider_unparseable_exhausted` ([GITTENSORY-Z](https://jsonbored.sentry.io/issues/GITTENSORY-Z)) has been firing since 2026-07-01 (83+ occurrences, still ongoing after confirming this isn't downstream of the P0 claude-code timeout outage — it kept firing hours into the post-fix clean-boot window). The logged fields (`model`, `attempt`, `responseChars`, `hasJsonObject`) give no way to tell WHY the model's output didn't parse — markdown-fenced JSON, a mid-object truncation, a plain-prose refusal, etc. Sentry's own Seer analysis on this issue independently suggested the same fix: log a truncated response prefix.
- Added a 400-char bounded snippet (`UNPARSEABLE_RESPONSE_SNIPPET_MAX_CHARS`) to `runWorkersOpinion`'s per-attempt `console.warn` and exhaustion `console.log` in `src/services/ai-review.ts`, so the next occurrence carries enough content to actually diagnose.
- **Safety constraint found and respected**: my first attempt added the snippet to the `AiReviewDiagnostic` array (`reviewDiagnostics`) too, which broke an existing test (`"single + BYOK: withholds unsafe provider and reviewer fallback text"`) — that array flows into `result`/public Sentry context, which must never carry raw provider text. The snippet now reaches ONLY the direct structured-log path (→ Sentry, internal-only), never `reviewDiagnostics`/`result`.

Closes #5071

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #5071`).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — this is a pure additive logging change (no new branches beyond what existing tests already cover); ran the affected file directly plus the repo's `test:changed` selection (3693 tests) and the full unsharded gate earlier in this session on a sibling branch off the same `main` — all green.
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — added a truncation test and a public/private-boundary regression test (`reviewDiagnostics` never carries `responseSnippet`) alongside the existing unparseable-exhaustion test.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth surface touched.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A.)
- [x] UI changes use live API data or real empty/error/loading states. (N/A — no UI changed.)
- [x] Visible UI changes include a `UI Evidence` section. (N/A — backend-only.)
- [x] Public docs/changelogs are updated where needed. (N/A.)

## Notes

The snippet is a model's OWN response text (never PR diff/repo content), truncated to 400 chars, and reaches only Sentry (internal, operator-only) — never a public surface.