### PR TITLE
chore(orb): bump manifest target version to 0.4.1

### DIFF
--- a/orb-manifest.json
+++ b/orb-manifest.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Source of truth for the self-hostable gittensory-orb container image's target release version (ghcr.io/jsonbored/gittensory-selfhost). Bumped by a maintainer when a feat/fix/breaking change since the last stable orb-v tag warrants moving to a new target version -- scripts/orb-release-core.mjs and .github/workflows/orb-beta-release.yml read this file to decide what version the next automated beta snapshot targets. Promoting a beta to a stable orb-vX.Y.Z release is still a manual `git tag` -- this manifest only drives the automated beta channel."
 }


### PR DESCRIPTION
## Summary

- \`orb-v0.4.0\` was cut stable earlier today (2026-07-11T12:23Z), but \`orb-manifest.json\` was never bumped afterward.
- \`scripts/orb-release-core.mjs\` correctly treats a manifest version equal to the latest stable tag as \"nothing new to target\" and refuses to cut another beta — which silently blocked the automated beta channel for every feat/fix merged since, including the fixes in #5071/#5072 that need to reach the self-host deploy.
- Bumps the manifest to \`0.4.1\` per its own documented maintainer-driven-bump convention. No code/behavior change — pure release-versioning metadata.

## Scope

- [x] The PR title follows \`type(scope): short summary\` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows \`CONTRIBUTING.md\`.
- [x] No linked issue — a pure release-process metadata bump, not a bug fix.

## Validation

- [x] \`git diff --check\`
- [x] \`npm run manifest:drift-check\` (unrelated check, confirmed unaffected)
- Single JSON field change; no src/test surface touched.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.