### PR TITLE
fix(selfhost): stop claude-code from treating its own review call as an interactive plan or a prompt injection

### DIFF
--- a/src/selfhost/ai.ts
+++ b/src/selfhost/ai.ts
@@ -505,6 +505,21 @@ async function isolatedCliCwd(): Promise<string> {
   return mkdtemp(join(tmpdir(), "gittensory-ai-"));
 }
 
+/** Write `systemAppend` into `cwd` (the SAME per-call isolated temp dir already used for the subprocess's
+ *  cwd, so it shares that directory's lifecycle) and return its path, for `--append-system-prompt-file`.
+ *  Keeps repo review instructions out of argv/`ps aux` (#3951's concern) WITHOUT falling back to smuggling
+ *  them into the stdin prompt body, which claude-code's own safety training can flag as a prompt-injection
+ *  pattern (a labeled "ADDITIONAL SYSTEM INSTRUCTIONS:" block inside otherwise-untrusted content) instead of
+ *  genuine first-party configuration -- confirmed live via ai_review_provider_unparseable_exhausted events
+ *  where the model refused with exactly that reasoning (#observability-plan-mode-injection-lookalike). */
+async function writeClaudeSystemPromptFile(cwd: string, systemAppend: string): Promise<string> {
+  const { writeFile } = await import("node:fs/promises");
+  const { join } = await import("node:path");
+  const path = join(cwd, "system-append.txt");
+  await writeFile(path, systemAppend, "utf8");
+  return path;
+}
+
 /** Pull the assistant's final text out of a CLI's JSON output (Claude Code `{result}` or Codex JSONL). */
 export function extractCliText(stdout: string): string {
   const trimmed = stdout.trim();
@@ -864,14 +879,25 @@ export function createClaudeCodeAi(parentEnv: Record<string, string | undefined>
           OTEL_METRIC_EXPORT_INTERVAL: parentEnv.OTEL_METRIC_EXPORT_INTERVAL,
         });
         const systemAppend = normalizedSystemAppend(options);
-        const prompt = prependCliSystemAppend(toCliPrompt(options, systemAppend), systemAppend);
+        const prompt = toCliPrompt(options, systemAppend);
         const spawn = spawnImpl ?? (await defaultSpawn());
-        const args = ["--print", "--output-format", "json", "--model", claudeModel, "--permission-mode", "plan", "--effort", effort, "--disallowedTools", "Bash,Edit,Write,WebFetch,WebSearch"];
+        const cwd = await isolatedCliCwd();
+        // bypassPermissions (not "plan"): --disallowedTools already forbids every mutating/networked tool, so
+        // nothing left needs an interactive approval prompt -- and this call has no TTY to answer one anyway.
+        // "plan" activates Claude Code's full interactive Plan-Mode WORKFLOW (explore, draft a plan, wait for
+        // ExitPlanMode approval), not just a permission restriction, which confused the model into treating a
+        // one-shot review request as an interactive planning session instead of returning a JSON verdict
+        // (#observability-plan-mode-injection-lookalike, live in ai_review_provider_unparseable_exhausted).
+        const args = ["--print", "--output-format", "json", "--model", claudeModel, "--permission-mode", "bypassPermissions", "--effort", effort, "--disallowedTools", "Bash,Edit,Write,WebFetch,WebSearch"];
+        // A dedicated system-prompt-file channel (not textual stdin-prepending) marks repo instructions
+        // unambiguously SYSTEM rather than author-controlled content -- see writeClaudeSystemPromptFile's doc
+        // comment for why the textual-prepend approach this replaces was itself the bug.
+        if (systemAppend) args.push("--append-system-prompt-file", await writeClaudeSystemPromptFile(cwd, systemAppend));
         attempted = true;
         const { stdout, code, stderr, timedOut, stalledNoOutput } = await spawn(
           "claude",
           args,
-          { env, input: prompt, timeoutMs, firstOutputTimeoutMs, cwd: await isolatedCliCwd() },
+          { env, input: prompt, timeoutMs, firstOutputTimeoutMs, cwd },
         );
         stdoutForMetrics = stdout;
         if (timedOut && stalledNoOutput) {

--- a/test/unit/selfhost-ai.test.ts
+++ b/test/unit/selfhost-ai.test.ts
@@ -1,4 +1,4 @@
-import { chmodSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -1279,7 +1279,7 @@ describe("subscription CLI helpers + fail-safe", () => {
     expect(seen[seen.indexOf("--effort") + 1]).toBe("medium");
   });
 
-  it("Claude Code keeps systemAppend out of argv and supplies it through stdin once (#1471)", async () => {
+  it("Claude Code passes systemAppend through --append-system-prompt-file, never argv or stdin (#observability-plan-mode-injection-lookalike, was #1471/#3951)", async () => {
     const systemAppend = "REPOSITORY REVIEW INSTRUCTIONS: Follow async-error conventions.";
     let seen: string[] = [];
     let capturedInput = "";
@@ -1295,18 +1295,36 @@ describe("subscription CLI helpers + fail-safe", () => {
       ],
       systemAppend,
     });
-    expect(seen).not.toContain("--append-system-prompt");
+    // Never the literal value in argv (`ps aux` visibility, #3951) and never smuggled into stdin behind an
+    // "ADDITIONAL SYSTEM INSTRUCTIONS:" label (the pattern claude-code's own safety training flagged as a
+    // prompt injection in production, #observability-plan-mode-injection-lookalike) -- only a short file path.
     expect(seen).not.toContain(systemAppend);
+    expect(capturedInput).not.toContain("ADDITIONAL SYSTEM INSTRUCTIONS:");
+    expect(capturedInput).not.toContain(systemAppend);
     expect(capturedInput).toContain("Base system.");
     expect(capturedInput).toContain("Review this diff.");
-    expect(countOccurrences(capturedInput, systemAppend)).toBe(1);
+    const flagIndex = seen.indexOf("--append-system-prompt-file");
+    expect(flagIndex).toBeGreaterThan(-1);
+    const filePath = seen[flagIndex + 1] as string;
+    expect(readFileSync(filePath, "utf8")).toBe(systemAppend);
 
     await createClaudeCodeAi({ CLAUDE_CODE_OAUTH_TOKEN: "t" }, cap).run("", {
       prompt: "Review this diff.",
       systemAppend: "   ",
     });
-    expect(seen).not.toContain("--append-system-prompt");
+    expect(seen).not.toContain("--append-system-prompt-file");
     expect(capturedInput).toBe("Review this diff.");
+  });
+
+  it("Claude Code runs with --permission-mode bypassPermissions, not plan (#observability-plan-mode-injection-lookalike): disallowedTools already forbids every mutating tool, and 'plan' activates the interactive Plan-Mode workflow instead of just restricting permissions", async () => {
+    let seen: string[] = [];
+    const cap: StubSpawn = async (_c, a) => {
+      seen = a;
+      return { stdout: JSON.stringify({ type: "result", result: "ok" }), code: 0 };
+    };
+    await createClaudeCodeAi({ CLAUDE_CODE_OAUTH_TOKEN: "t" }, cap).run("", { prompt: "x" });
+    expect(seen[seen.indexOf("--permission-mode") + 1]).toBe("bypassPermissions");
+    expect(seen).not.toContain("plan");
   });
 
   it("chat-only CLIs reject embeds so the chain routes embeddings to an embed-capable provider (Claude review + ollama embed)", async () => {


### PR DESCRIPTION
## Summary

Root-caused live via two real `ai_review_provider_unparseable_output` events minutes apart (visible for the first time thanks to #5071's diagnostic snippet), where the model explicitly refused to review, citing:

> "Two things are going on that don't line up: 1. **Plan Mode is active**... 2. But the bulk of your message is a..."

> "I want to flag something... this turn contains a very large embedded block claiming to be '**ADDITIONAL SYSTEM INSTRUCTIONS**'... Layered on top of that is a 'Plan Mode' wr[apper]..."

Two compounding bugs in `createClaudeCodeAi` (`src/selfhost/ai.ts`):

1. **`--permission-mode plan`** has been passed to every `claude` invocation since the self-host stack's original commit (2026-06-24, `0325fb1e`). This activates the full interactive Plan-Mode *workflow* (explore → draft a plan → wait for `ExitPlanMode` approval), not just a read-only permission restriction — `--disallowedTools Bash,Edit,Write,WebFetch,WebSearch` already forbids every mutating/networked tool, so nothing needing that framing remains. Switched to `bypassPermissions`, matching the "no TTY to answer a permission prompt, `--disallowedTools` is the real boundary" intent this call already had.
2. **`systemAppend`** (repo-level review instructions from `.gittensory.yml`) was textually prepended into the stdin prompt behind a literal `"ADDITIONAL SYSTEM INSTRUCTIONS:\n"` header. This was implemented correctly in #1471 / PR #2954 via the real `--append-system-prompt` flag, then regressed by a later commit (`85999110`, "keep Claude review instructions out of argv", #3951) that moved it back to textual stdin-smuggling to avoid the content appearing in `ps aux` — inadvertently recreating the textbook shape of a prompt-injection attack (a labeled "system instructions" block inside otherwise-untrusted content), which claude-code's own safety training correctly flags as suspicious. Now written to a file inside the same per-call isolated temp dir already used for the subprocess's `cwd`, passed via `--append-system-prompt-file` — resolves #3951's original argv-visibility concern via the CLI's own file-based mechanism instead of textual smuggling.

`codex` is unaffected: it uses `--sandbox read-only`, not `--permission-mode`, and has no CLI-native system-prompt-file equivalent (per #1471's own documented limitation) — keeps its existing textual-prepend approach unchanged.

This has likely been silently degrading `claude-code` review quality for ~3 weeks.

Closes #5079

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #5079`).

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` (full unsharded `npm run test:ci`, all green) — the only uncovered line in `ai.ts` (a `buildProvider` switch default) predates this diff.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — rewrote the stale test that asserted the old (buggy) textual-smuggling behavior, added a dedicated `--permission-mode bypassPermissions` regression test, and verify the written system-prompt-file's on-disk content directly.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth surface touched.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A.)
- [x] UI changes use live API data or real empty/error/loading states. (N/A — no UI changed.)
- [x] Visible UI changes include a `UI Evidence` section. (N/A — backend-only.)
- [x] Public docs/changelogs are updated where needed. (N/A.)

## Notes

`bypassPermissions` is safe here specifically because `--disallowedTools` already forbids every tool that would otherwise need an interactive approval; nothing new is granted.