### PR TITLE
fix(selfhost): retry the /ready probe in selfhost-post-update-check.sh instead of a single attempt

### DIFF
--- a/scripts/selfhost-post-update-check.sh
+++ b/scripts/selfhost-post-update-check.sh
@@ -30,9 +30,24 @@ if [ -z "$container_id" ]; then
   exit 1
 fi
 
+# Retry, don't single-probe: `docker compose up -d` returns as soon as the container STARTS, well before
+# the app inside has bound its port -- a single immediate curl reliably false-fails on a normal boot. Budget
+# matches the gittensory service's own Docker healthcheck start_period (60s, docker-compose.yml) plus margin,
+# polling often enough that a normal ~15-20s boot returns almost immediately once actually ready.
+READY_RETRIES="${SELFHOST_READY_RETRIES:-45}"
+READY_RETRY_DELAY_SECONDS="${SELFHOST_READY_RETRY_DELAY_SECONDS:-2}"
+
 echo "selfhost post-update check: probing $READY_URL"
-if ! curl -sf "$READY_URL" >/dev/null; then
-  echo "error: $READY_URL did not return HTTP 2xx" >&2
+ready=0
+for _ in $(seq 1 "$READY_RETRIES"); do
+  if curl -sf "$READY_URL" >/dev/null; then
+    ready=1
+    break
+  fi
+  sleep "$READY_RETRY_DELAY_SECONDS"
+done
+if [ "$ready" -ne 1 ]; then
+  echo "error: $READY_URL did not return HTTP 2xx after $READY_RETRIES attempts ($((READY_RETRIES * READY_RETRY_DELAY_SECONDS))s)" >&2
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

- \`docker compose up -d\` returns as soon as the container **starts**, well before the app inside has finished booting and bound its port — a single immediate \`curl -sf\` reliably false-failed on a completely normal deploy. Hit twice today deploying today's other fixes.
- The \`gittensory\` service's own Docker healthcheck (\`docker-compose.yml\`) already documents and tolerates exactly this: \`start_period: 60s\` "tolerates the Postgres cold start." \`selfhost-post-update-check.sh\` had no equivalent tolerance.
- Replaced the single probe with a bounded retry loop (default 45 × 2s = 90s, over the documented 60s \`start_period\`), configurable via \`SELFHOST_READY_RETRIES\`/\`SELFHOST_READY_RETRY_DELAY_SECONDS\`.

Closes #5085

## Scope

- [x] The PR title follows \`type(scope): short summary\` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows \`CONTRIBUTING.md\`.
- [x] I linked a currently open issue this PR resolves (\`Closes #5085\`).

## Validation

- [x] \`git diff --check\`
- [x] \`bash -n\` + \`shellcheck\` clean (only a pre-existing, unrelated SC1091 info note on the sourced lib file)
- [x] \`npm run typecheck\`
- [x] Ran the 3 existing test files that reference this script (\`docs-selfhost-update-rollback.test.ts\`, \`docs-selfhost-git-deploy-hygiene.test.ts\`, \`selfhost-update-script.test.ts\`) — all pass unchanged.
- [x] Functionally verified the retry loop against local mock servers: one that returns 503 twice then 200 (succeeds on the 3rd attempt), and one that never responds (exhausts retries, exits non-zero with a clear message).
- [ ] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — this is a bash deploy script under \`scripts/**\`, which Codecov's patch gate does not measure (only \`src/**\` is measured); verified via the functional checks above instead of a vitest unit test, matching how the pre-existing tests for this file (stub-based, doc-hygiene) already treat it.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A.)
- [x] UI changes use live API data or real empty/error/loading states. (N/A.)
- [x] Visible UI changes include a \`UI Evidence\` section. (N/A — no UI changed.)
- [x] Public docs/changelogs are updated where needed. (N/A — the operator-facing docs already reference this script by name only, no specific retry-count claim to keep in sync.)