### PR TITLE
fix(selfhost): retry the container health-status check, not just /ready

### DIFF
--- a/scripts/selfhost-post-update-check.sh
+++ b/scripts/selfhost-post-update-check.sh
@@ -51,7 +51,23 @@ if [ "$ready" -ne 1 ]; then
   exit 1
 fi
 
-status="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$container_id" 2>/dev/null || true)"
+# Same race as the /ready probe above, one layer down: Docker's OWN healthcheck (docker-compose.yml)
+# reports "starting" until its FIRST probe completes, which can still be true here even though /ready
+# already answered 2xx (the two checks run on independent schedules) -- a normal boot must not fail on
+# a state that is expected to resolve on its own within seconds. Only "starting" is worth waiting
+# through; any other non-healthy/running status (unhealthy, exited, restarting, ...) is a real problem
+# and fails immediately rather than burning the full retry budget on something that will not resolve.
+status=""
+for _ in $(seq 1 "$READY_RETRIES"); do
+  status="$(docker inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}' "$container_id" 2>/dev/null || true)"
+  if [ "$status" = "healthy" ] || [ "$status" = "running" ]; then
+    break
+  fi
+  if [ "$status" != "starting" ]; then
+    break
+  fi
+  sleep "$READY_RETRY_DELAY_SECONDS"
+done
 echo "selfhost post-update check: $SERVICE container status=$status"
 if [ "$status" != "healthy" ] && [ "$status" != "running" ]; then
   echo "error: expected healthy or running, got $status" >&2


### PR DESCRIPTION
## Summary

- #5085 fixed the \`/ready\` HTTP probe to retry instead of single-attempt-failing. Deploying that exact fix (live, edge-nl-01, 2026-07-11) immediately surfaced a **second, previously-masked instance of the same bug** right below it: the Docker container health-status check (\`docker inspect ... .State.Health.Status\`) is also a single, non-retrying check, and caught the container in Docker's own transient \`"starting"\` state — Docker's OWN healthcheck re-probes \`/ready\` on an independent \`interval\`/\`start_period\` schedule, so it can still be \`"starting"\` even after the script's own \`/ready\` probe already answered 2xx.
- Before #5085 this was masked: the \`/ready\` probe almost always failed FIRST and immediately, so execution never reached the status check while the container was still genuinely starting.
- Retries only through \`"starting"\` — any other non-healthy/running status (\`unhealthy\`, \`exited\`, \`restarting\`, ...) fails immediately rather than burning the full retry budget on something that will not resolve on its own.

Closes #5089

## Scope

- [x] The PR title follows \`type(scope): short summary\` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows \`CONTRIBUTING.md\`.
- [x] I linked a currently open issue this PR resolves (\`Closes #5089\`).

## Validation

- [x] \`git diff --check\`
- [x] \`bash -n\` + \`shellcheck\` clean (only the same pre-existing, unrelated SC1091 info note)
- [x] \`npm run typecheck\`
- [x] Ran the 3 existing test files that reference this script — all pass unchanged.
- [x] Functionally verified both paths: a status sequence of starting/starting/healthy resolves via retry (confirmed 3 checks), and an immediate \`unhealthy\` status fails in ~0.01s without waiting out the retry budget.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A.)
- [x] UI changes use live API data or real empty/error/loading states. (N/A.)
- [x] Visible UI changes include a \`UI Evidence\` section. (N/A — no UI changed.)
- [x] Public docs/changelogs are updated where needed. (N/A.)