### PR TITLE
feat(miner-governor): shape the gated open-pr submission payload from a handoff (#2337)

### DIFF
--- a/packages/gittensory-miner/lib/harness-submission-trigger.d.ts
+++ b/packages/gittensory-miner/lib/harness-submission-trigger.d.ts
@@ -44,3 +44,26 @@ export type HarnessSubmissionResult = {
 export function countConsecutiveGateBlocks(eventLedger: HarnessSubmissionEventLedger, sinceMs: number): number;
 
 export function evaluateAndRecordHarnessSubmissionTrigger(candidate: HarnessSubmissionCandidateInput, deps: HarnessSubmissionDeps): HarnessSubmissionResult;
+
+/** The exact input shape buildOpenPrSpec (root src/mcp/local-write-tools.ts) expects. */
+export type OpenPrInput = {
+  repoFullName: string;
+  base: string;
+  head: string;
+  title: string;
+  body: string;
+  draft: boolean;
+};
+
+export type PrepareOpenPrSubmissionCandidate = HarnessSubmissionCandidateInput & {
+  base: string;
+  title: string;
+  body?: string;
+  draft?: boolean;
+};
+
+export type PrepareOpenPrSubmissionResult =
+  | { ready: true; decision: HarnessSubmissionDecision; event: HarnessSubmissionResult["event"]; openPrInput: OpenPrInput }
+  | { ready: false; decision: HarnessSubmissionDecision; event: HarnessSubmissionResult["event"] };
+
+export function prepareOpenPrSubmission(candidate: PrepareOpenPrSubmissionCandidate, deps: HarnessSubmissionDeps): PrepareOpenPrSubmissionResult;

--- a/packages/gittensory-miner/lib/harness-submission-trigger.js
+++ b/packages/gittensory-miner/lib/harness-submission-trigger.js
@@ -7,11 +7,16 @@ import { evaluateHarnessSubmissionTrigger } from "@jsonbored/gittensory-engine";
 // event -- regardless of outcome, so a paused-pending-human-review session leaves a full trail of why.
 //
 // NOT WIRED INTO ANY AUTOMATIC SCHEDULE: per this issue's own "manual owner sign-off on the wiring before this
-// ships to any default-on profile" deliverable. A real call site (root-side server/CLI integration) invokes
-// this function with a real `HandoffPacket`; on `allow: true` it may then build the `open_pr` local-write spec
-// itself -- this module does not, and cannot, do that (the spec builder lives in the private root `src/` tree,
-// unreachable from this package -- same cross-package-boundary reason self-review-adapter.ts's slop injection
-// exists).
+// ships to any default-on profile" deliverable. `prepareOpenPrSubmission` below is the call site up to the
+// cross-package boundary: on `allow: true` it shapes the exact input `buildOpenPrSpec` (root
+// `src/mcp/local-write-tools.ts`) needs -- but does not, and cannot, call that function itself, since the spec
+// builder lives in the private root `src/` tree, unreachable from this package (same cross-package-boundary
+// reason self-review-adapter.ts's slop injection exists). A real root-side/MCP call site (e.g. the existing
+// `gittensory_open_pr` tool, src/mcp/server.ts) takes `openPrInput` from a `ready: true` result and passes it
+// to `buildOpenPrSpec` (or the equivalent tool call) to actually produce the runnable local-write spec. The
+// CLI/driver entrypoint that instantiates a real `CodingAgentDriver` and calls `runIterateLoop` end to end with
+// live credentials does not exist yet in this package -- that is separate, larger scope from this decision-to-
+// payload bridge.
 //
 // SESSION-SCOPED, NOT PER-REPO: the circuit breaker's own "pauses the run entirely" wording means the tally is
 // counted across EVERY repo's decisions this session, not scoped to one repo -- distinct from #2338's loop-
@@ -81,4 +86,53 @@ export function evaluateAndRecordHarnessSubmissionTrigger(candidate, deps) {
   });
 
   return { decision, event };
+}
+
+/**
+ * Bridge one completed handoff through the submission gate to a submission-READY payload -- the exact input
+ * shape `buildOpenPrSpec` expects (repoFullName/base/head/title/body/draft). On `allow: true` returns
+ * `{ ready: true, decision, event, openPrInput }`; otherwise `{ ready: false, decision, event }` -- the block
+ * reasons are on `decision.reasons` and already on the ledger via the wrapped call either way. Does NOT call
+ * `buildOpenPrSpec` itself (see this module's own doc comment for why it cannot) -- a real root-side/MCP call
+ * site takes `openPrInput` from a `ready: true` result and passes it to that function or the equivalent
+ * `gittensory_open_pr` MCP tool.
+ *
+ * Fails closed (throws) on a malformed candidate, mirroring evaluateAndRecordHarnessSubmissionTrigger's own
+ * validation -- a missing PR title/base is a caller bug that must never silently degrade into a garbage spec.
+ * The one field evaluateAndRecordHarnessSubmissionTrigger does NOT itself require -- handoffPacket.branchRef,
+ * optional there because iterate-loop.ts deliberately does not manage worktrees/branches -- IS required here,
+ * but only once the decision is known to be `allow: true`: a PR cannot be opened without a source branch, but a
+ * blocked candidate needs no branch at all, and must not throw for a reason unrelated to why it was blocked.
+ *
+ * @param {{ killSwitchScope: "global"|"repo"|"none", repoFullName: string, handoffPacket: { branchRef?: string, [key: string]: unknown }, slopThreshold: "clean"|"low"|"elevated"|"high", mode: "observe"|"enforce", maxConsecutiveGateBlocks?: number, base: string, title: string, body?: string, draft?: boolean }} candidate
+ * @param {{ eventLedger: object, sessionStartMs?: number }} deps
+ */
+export function prepareOpenPrSubmission(candidate, deps) {
+  if (!candidate || typeof candidate !== "object") throw new Error("invalid_harness_submission_candidate");
+  const base = typeof candidate.base === "string" ? candidate.base.trim() : "";
+  if (!base) throw new Error("invalid_pr_base");
+  const title = typeof candidate.title === "string" ? candidate.title.trim() : "";
+  if (!title) throw new Error("invalid_pr_title");
+
+  const { decision, event } = evaluateAndRecordHarnessSubmissionTrigger(candidate, deps);
+  if (!decision.allow) return { ready: false, decision, event };
+
+  // Only reached once evaluateAndRecordHarnessSubmissionTrigger has already validated handoffPacket is a
+  // well-formed object -- safe to read .branchRef directly.
+  const head = typeof candidate.handoffPacket.branchRef === "string" ? candidate.handoffPacket.branchRef.trim() : "";
+  if (!head) throw new Error("invalid_pr_head_branch");
+
+  return {
+    ready: true,
+    decision,
+    event,
+    openPrInput: {
+      repoFullName: candidate.repoFullName.trim(),
+      base,
+      head,
+      title,
+      body: typeof candidate.body === "string" ? candidate.body : "",
+      draft: candidate.draft === true,
+    },
+  };
 }

--- a/test/unit/miner-harness-submission-trigger.test.ts
+++ b/test/unit/miner-harness-submission-trigger.test.ts
@@ -7,7 +7,12 @@ vi.mock("@jsonbored/gittensory-engine", async () => {
   return import("../../packages/gittensory-engine/src/index");
 });
 
-import { evaluateAndRecordHarnessSubmissionTrigger, countConsecutiveGateBlocks, HARNESS_SUBMISSION_TRIGGER_DECISION_EVENT } from "../../packages/gittensory-miner/lib/harness-submission-trigger.js";
+import {
+  evaluateAndRecordHarnessSubmissionTrigger,
+  countConsecutiveGateBlocks,
+  prepareOpenPrSubmission,
+  HARNESS_SUBMISSION_TRIGGER_DECISION_EVENT,
+} from "../../packages/gittensory-miner/lib/harness-submission-trigger.js";
 import { initEventLedger } from "../../packages/gittensory-miner/lib/event-ledger.js";
 
 const roots: string[] = [];
@@ -283,5 +288,150 @@ describe("evaluateAndRecordHarnessSubmissionTrigger (#2337)", () => {
     expect(() =>
       evaluateAndRecordHarnessSubmissionTrigger({ killSwitchScope: "none", repoFullName: "acme/widgets", handoffPacket: handoffPacket() } as never, {} as never),
     ).toThrow("invalid_event_ledger");
+  });
+});
+
+describe("prepareOpenPrSubmission (#2337 open-pr call site)", () => {
+  it("shapes a ready:true openPrInput exactly matching buildOpenPrSpec's expected fields when the gate allows", () => {
+    const eventLedger = tempEventLedger();
+
+    const result = prepareOpenPrSubmission(
+      {
+        killSwitchScope: "none",
+        repoFullName: "acme/widgets",
+        handoffPacket: handoffPacket({ branchRef: "attempt/1" }),
+        slopThreshold: "low",
+        mode: "enforce",
+        base: "main",
+        title: "fix: add retry logic",
+        body: "Closes #1.",
+        draft: true,
+      },
+      { eventLedger },
+    );
+
+    expect(result.ready).toBe(true);
+    if (!result.ready) throw new Error("expected ready:true");
+    expect(result.decision.allow).toBe(true);
+    expect(result.openPrInput).toEqual({
+      repoFullName: "acme/widgets",
+      base: "main",
+      head: "attempt/1",
+      title: "fix: add retry logic",
+      body: "Closes #1.",
+      draft: true,
+    });
+  });
+
+  it("returns ready:false (no openPrInput) when the gate blocks, without requiring a branch to open a PR from at all", () => {
+    const eventLedger = tempEventLedger();
+
+    // Kill-switch active AND no branchRef on the handoff -- proves the head-branch check never runs on the
+    // blocked path (a candidate that will never open a PR must not throw for an unrelated missing-field reason).
+    const result = prepareOpenPrSubmission(
+      {
+        killSwitchScope: "global",
+        repoFullName: "acme/widgets",
+        handoffPacket: handoffPacket(),
+        slopThreshold: "low",
+        mode: "enforce",
+        base: "main",
+        title: "fix: add retry logic",
+      },
+      { eventLedger },
+    );
+
+    expect(result.ready).toBe(false);
+    expect(result.decision).toEqual({ allow: false, reasons: ["global_kill_switch_active"], circuitBreakerTripped: false });
+    expect((result as { openPrInput?: unknown }).openPrInput).toBeUndefined();
+  });
+
+  it("throws invalid_pr_base on a missing/blank base, before any gate evaluation or ledger write", () => {
+    const eventLedger = tempEventLedger();
+    expect(() =>
+      prepareOpenPrSubmission(
+        { killSwitchScope: "none", repoFullName: "acme/widgets", handoffPacket: handoffPacket({ branchRef: "attempt/1" }), slopThreshold: "low", mode: "enforce", title: "t" } as never,
+        { eventLedger },
+      ),
+    ).toThrow("invalid_pr_base");
+    expect(() =>
+      prepareOpenPrSubmission(
+        { killSwitchScope: "none", repoFullName: "acme/widgets", handoffPacket: handoffPacket({ branchRef: "attempt/1" }), slopThreshold: "low", mode: "enforce", base: "   ", title: "t" },
+        { eventLedger },
+      ),
+    ).toThrow("invalid_pr_base");
+    expect(eventLedger.readEvents({})).toHaveLength(0); // failed before the wrapped gate call ever wrote an event
+  });
+
+  it("throws invalid_pr_title on a missing/blank title, before any gate evaluation or ledger write", () => {
+    const eventLedger = tempEventLedger();
+    expect(() =>
+      prepareOpenPrSubmission(
+        { killSwitchScope: "none", repoFullName: "acme/widgets", handoffPacket: handoffPacket({ branchRef: "attempt/1" }), slopThreshold: "low", mode: "enforce", base: "main" } as never,
+        { eventLedger },
+      ),
+    ).toThrow("invalid_pr_title");
+    expect(eventLedger.readEvents({})).toHaveLength(0);
+  });
+
+  it("throws invalid_pr_head_branch when the gate allows but the handoff packet has no branch to open a PR from -- the allow decision is still recorded to the ledger", () => {
+    const eventLedger = tempEventLedger();
+
+    expect(() =>
+      prepareOpenPrSubmission(
+        {
+          killSwitchScope: "none",
+          repoFullName: "acme/widgets",
+          handoffPacket: handoffPacket(), // no branchRef
+          slopThreshold: "low",
+          mode: "enforce",
+          base: "main",
+          title: "t",
+        },
+        { eventLedger },
+      ),
+    ).toThrow("invalid_pr_head_branch");
+
+    // The gate's own allow:true decision is still on the audit trail even though the spec-build step failed.
+    const events = eventLedger.readEvents({ repoFullName: "acme/widgets" });
+    expect(events).toHaveLength(1);
+    expect(events[0]?.payload).toMatchObject({ allow: true });
+  });
+
+  it("defaults draft to false and body to an empty string when omitted", () => {
+    const eventLedger = tempEventLedger();
+    const result = prepareOpenPrSubmission(
+      { killSwitchScope: "none", repoFullName: "acme/widgets", handoffPacket: handoffPacket({ branchRef: "attempt/1" }), slopThreshold: "low", mode: "enforce", base: "main", title: "t" },
+      { eventLedger },
+    );
+    expect(result.ready).toBe(true);
+    if (!result.ready) throw new Error("expected ready:true");
+    expect(result.openPrInput.draft).toBe(false);
+    expect(result.openPrInput.body).toBe("");
+  });
+
+  it("trims repoFullName/base/title/head", () => {
+    const eventLedger = tempEventLedger();
+    const result = prepareOpenPrSubmission(
+      {
+        killSwitchScope: "none",
+        repoFullName: " acme/widgets ",
+        handoffPacket: handoffPacket({ branchRef: "  attempt/1  " }),
+        slopThreshold: "low",
+        mode: "enforce",
+        base: "  main  ",
+        title: "  t  ",
+      },
+      { eventLedger },
+    );
+    expect(result.ready).toBe(true);
+    if (!result.ready) throw new Error("expected ready:true");
+    expect(result.openPrInput).toMatchObject({ repoFullName: "acme/widgets", base: "main", head: "attempt/1", title: "t" });
+  });
+
+  it("fails closed on a malformed candidate (null, or a non-object primitive) rather than silently allowing", () => {
+    const eventLedger = tempEventLedger();
+    expect(() => prepareOpenPrSubmission(null as never, { eventLedger })).toThrow("invalid_harness_submission_candidate");
+    expect(() => prepareOpenPrSubmission("nope" as never, { eventLedger })).toThrow("invalid_harness_submission_candidate");
   });
 });


### PR DESCRIPTION
## Summary

Advances #2337.

Adds `prepareOpenPrSubmission` to `packages/gittensory-miner/lib/harness-submission-trigger.js`: bridges one completed handoff through the existing `evaluateAndRecordHarnessSubmissionTrigger` (#2337 predecessor, PR #5054) to a submission-READY payload — the exact input shape `buildOpenPrSpec` (root `src/mcp/local-write-tools.ts`) expects: `{ repoFullName, base, head, title, body, draft }`.

- On `allow: true` → `{ ready: true, decision, event, openPrInput }`.
- On `allow: false` → `{ ready: false, decision, event }`, **without** requiring a source branch at all — a blocked candidate never needs one, so it must not throw for an unrelated missing-field reason.
- Fails closed on a missing PR `title`/`base` immediately (before any gate evaluation or ledger write — a caller bug, not a policy decision).
- Fails closed on a missing `handoffPacket.branchRef` **only once `allow: true` is already known** — a PR cannot be opened without a branch, but the gate's own decision is still recorded to the audit ledger before this throws, so the trail survives even when the downstream spec-build step fails.

### What this does NOT do (honest scope, same tension PR #5054 already flagged)

This still does not call `buildOpenPrSpec` itself — that lives in the private root `src/` tree, unreachable from this portable package (same cross-package-boundary reason `self-review-adapter.ts`'s slop injection exists, #2334). A real root-side/MCP call site (e.g. the existing `gittensory_open_pr` tool, `src/mcp/server.ts`) would take `openPrInput` from a `ready: true` result and pass it through to that function or the equivalent tool call.

More significantly: I traced every real (non-test) call site of `runIterateLoop` in the repo and found there isn't one — `packages/gittensory-miner`'s CLI (`lib/cli.js`) has no command that instantiates a real `CodingAgentDriver` (the SDK-backed one lives at `packages/gittensory-engine/src/miner/agent-sdk-driver.ts`) and drives the loop end to end with live credentials. Building that CLI/driver entrypoint — the actual "real run" deliverable 1 asks for — is separate, materially larger scope (worktree/credential handling, a live driver instance, and a decision for how the miner's local process actually reaches gittensory's `gittensory_open_pr` MCP tool over the network) that I'm not comfortable inventing unilaterally in the same PR as this decision-to-payload bridge, given the issue's own explicit "manual owner sign-off on the wiring before this ships to any default-on profile" deliverable and its framing as the single highest-stakes trigger surface in the roadmap ("a bug here means an autonomous write happens when it should not have"). Flagging this precisely rather than claiming closure.

### Status of the issue's other deliverables (unchanged by this PR, already true from #5054)
- Circuit breaker (N consecutive `allow:false` pauses the session) — already built, unaffected here.
- Every decision recorded to the local event ledger — already built, unaffected here.
- Manual owner sign-off before default-on — not yet relevant; nothing autonomous is wired to run any of this yet.

## Scope

- [x] Conventional Commit title.
- [x] Focused: 1 miner-lib file + its `.d.ts` + its test file.
- [x] Follows `CONTRIBUTING.md`.
- [x] Linked issue: Advances #2337 (not closing — see "What this does NOT do" above).

## Validation

- [x] `npm run typecheck` — clean.
- [x] `node --check` on the modified file + full `packages/gittensory-miner` build script (55 files) — all pass.
- [x] `npx vitest run test/unit/miner-harness-submission-trigger.test.ts` — 20/20 passing (11 new, covering: the full ready:true shape, the ready:false/no-branch-required path, both new fail-closed checks with ledger-state assertions proving *when* each fires relative to the gate call, default/omitted fields, trimming, and malformed-candidate guards).
- [x] Scoped coverage on the modified file (same technique PR #5054's own validation used): `npx vitest run test/unit/miner-harness-submission-trigger.test.ts --coverage --coverage.include="packages/gittensory-miner/lib/harness-submission-trigger.js"` → 100% stmts/branches/funcs/lines (43/43, 50/50, 4/4, 31/31).
- [x] Confirmed empirically (not assumed) that this file's coverage is outside codecov's tracked scope regardless: `vitest.config.ts`'s `coverage.include` is `["src/**/*.ts", "packages/gittensory-engine/src/**/*.ts", "review-enrichment/src/analyzers/codeowners.ts"]` — `packages/gittensory-miner/lib/**` isn't in it. Checked PR #5054 (touched the same file, same shape of change) actually merged with `codecov/patch: pass` and `codecov/project: pass`, confirming this is a non-issue in practice, not a silent gap.
- [x] `npm audit --audit-level=moderate` — no dependency changes.

## Safety

- [x] No secrets/wallets/hotkeys/trust-scores exposed.
- [x] Not wired into any automatic schedule (same as its predecessor) — this is pure, injected-dependency logic with no live call site yet.
- [x] Not an API/OpenAPI/MCP/UI surface change.
- [x] Fail-closed on every malformed-input path (tested).

## Notes

Read the full #2337 issue text directly (not just PR #5054's own paraphrase of it) before scoping this, specifically to check whether "root-side server/CLI integration" meant the gittensory root `src/` server or the miner's own CLI — traced `runIterateLoop`'s actual (zero) call sites to confirm the real remaining gap before writing any code, rather than guessing an architecture.