### PR TITLE
fix(observability): fix Sentry fingerprinting for 3 fragmented issue groups

### DIFF
--- a/review-enrichment/src/sentry.ts
+++ b/review-enrichment/src/sentry.ts
@@ -309,7 +309,14 @@ export function captureAnalyzerDegradation(error: unknown, context: AnalyzerDegr
     release: activeRelease,
     environment: activeEnvironment,
     },
-    fingerprint: ["rees-analyzer-degraded", context.analyzer],
+    // Group by WHY (partialReason, e.g. "analyzer_timeout"), not WHICH analyzer hit it (#5010): the generic
+    // reasons genuinely share one root cause (the shared, dynamically-shrinking per-analyzer time budget)
+    // regardless of which analyzer's turn it was, so grouping by analyzer name fragmented one condition into
+    // N issues (one per analyzer) that each individually looked small. A reason that IS inherently
+    // analyzer-specific (e.g. "bundlephobia-size_http_error") stays its own issue either way, since the
+    // reason string itself already encodes that specificity -- falls back to analyzer name only on the
+    // defensive case where partialReason is somehow absent.
+    fingerprint: ["rees-analyzer-degraded", context.partialReason ?? context.analyzer],
     tags: {
       event: "rees_analyzer_degraded",
       analyzer: context.analyzer,

--- a/review-enrichment/test/sentry-degradation.test.ts
+++ b/review-enrichment/test/sentry-degradation.test.ts
@@ -100,6 +100,49 @@ test("captureAnalyzerDegradation tags and fingerprints sanitized analyzer failur
   assert.equal(serializedContext.includes("Bearer should_never_be_attached"), false);
 });
 
+test("captureAnalyzerDegradation groups by partialReason (WHY), not analyzer name (WHICH), so the same reason from different analyzers is one issue (#5010)", () => {
+  const sentry = sentryHarness();
+
+  captureAnalyzerDegradation(new Error("analyzer_timeout"), {
+    analyzer: "installScript",
+    repoFullName: "JSONbored/gittensory",
+    prNumber: 7,
+    headSha: "abc123",
+    timeoutMs: 1400,
+    partialReason: "analyzer_timeout",
+  } as never);
+  captureAnalyzerDegradation(new Error("analyzer_timeout"), {
+    analyzer: "nativeBuild",
+    repoFullName: "JSONbored/gittensory",
+    prNumber: 8,
+    headSha: "def456",
+    timeoutMs: 1400,
+    partialReason: "analyzer_timeout",
+  } as never);
+
+  // Same fingerprint from two DIFFERENT analyzers: both group into one Sentry issue.
+  assert.deepEqual(sentry.fingerprints, [
+    ["rees-analyzer-degraded", "analyzer_timeout"],
+    ["rees-analyzer-degraded", "analyzer_timeout"],
+  ]);
+  // The specific analyzer is still fully visible via the tag -- only the GROUPING changed.
+  assert.equal(sentry.tags.analyzer, "nativeBuild");
+});
+
+test("captureAnalyzerDegradation falls back to analyzer name when partialReason is absent", () => {
+  const sentry = sentryHarness();
+
+  captureAnalyzerDegradation(new Error("boom"), {
+    analyzer: "dependency",
+    repoFullName: "JSONbored/gittensory",
+    prNumber: 7,
+    headSha: "abc123",
+    timeoutMs: 8000,
+  });
+
+  assert.deepEqual(sentry.fingerprints, [["rees-analyzer-degraded", "dependency"]]);
+});
+
 test("captureAnalyzerDegradation filters tag values before sending them", () => {
   const sentry = sentryHarness();
   const secretLikeValue = ["ghp", "abcdefghijklmnopqrstuvwxyz1234567890"].join("_");

--- a/src/selfhost/sentry.ts
+++ b/src/selfhost/sentry.ts
@@ -444,7 +444,11 @@ function namedCaptureError(error: unknown, eventName?: string): Error {
 }
 
 /** Capture an error with optional structured context. No-op when Sentry is off. `eventName`, when given, becomes
- *  the Sentry issue title's prefix (see {@link namedCaptureError}) instead of the generic "Error". */
+ *  the Sentry issue title's prefix (see {@link namedCaptureError}) AND the grouping fingerprint (#5010) --
+ *  Sentry's default stack-trace-based grouping fragments the SAME logical failure into separate issues whenever
+ *  it is captured from more than one call site (e.g. two different functions each constructing the identical
+ *  `new Error("...")` message), which is exactly what happened to GITTENSORY-5/10 and GITTENSORY-C/W before this.
+ *  Mirrors forwardStructuredLogToSentry's identical `scope.setFingerprint(["gittensory-log", event])` discipline. */
 export function captureError(
   error: unknown,
   context?: Record<string, unknown>,
@@ -454,13 +458,15 @@ export function captureError(
   Sentry.withScope((scope) => {
     setOtelTraceScope(scope);
     if (context) { const safeContext = hashedInstallationContext(context); scope.setContext("gittensory", safeContext); applyOperationalTags(scope, safeContext); }
+    if (eventName) scope.setFingerprint(["gittensory-error", eventName]);
     Sentry!.captureException(namedCaptureError(error, eventName));
   });
 }
 
 /** Capture a failed review at ERROR level, tagged by repo/PR/SHA for triage. A review that cannot be produced is a
  *  real failure the maintainer must SEE — not a warning that hides in the noise. No-op when off. `eventName`, when
- *  given, becomes the Sentry issue title's prefix (see {@link namedCaptureError}) instead of the generic "Error". */
+ *  given, becomes the Sentry issue title's prefix AND the grouping fingerprint -- see {@link captureError}'s
+ *  identical discipline and #5010. */
 export function captureReviewFailure(
   error: unknown,
   context?: Record<string, unknown>,
@@ -475,6 +481,7 @@ export function captureReviewFailure(
       scope.setContext("review", safeContext);
       applyOperationalTags(scope, safeContext);
     }
+    if (eventName) scope.setFingerprint(["gittensory-review-failure", eventName]);
     Sentry!.captureException(namedCaptureError(error, eventName));
   });
 }

--- a/test/unit/selfhost-sentry.test.ts
+++ b/test/unit/selfhost-sentry.test.ts
@@ -578,14 +578,15 @@ describe("enabled when SENTRY_DSN is set", () => {
     expect(mocks.captureException).toHaveBeenCalledTimes(2);
   });
 
-  it("captureError with an eventName renames the captured Error so the Sentry title isn't the generic 'Error'", async () => {
+  it("captureError with an eventName renames the captured Error so the Sentry title isn't the generic 'Error', and groups it by that same name (#5010)", async () => {
     await initSentry({ SENTRY_DSN: "d" } as unknown as NodeJS.ProcessEnv);
     captureError(new Error("self-host queue processing lease expired"), { kind: "job_dead" }, "processing_timeout");
     expect(lastCapturedError().name).toBe("processing_timeout");
     expect(lastCapturedError().message).toBe("self-host queue processing lease expired");
+    expect(mocks.scope.setFingerprint).toHaveBeenCalledWith(["gittensory-error", "processing_timeout"]);
   });
 
-  it("captureError without an eventName leaves a caught exception's own name untouched", async () => {
+  it("captureError without an eventName leaves a caught exception's own name untouched, and never overrides Sentry's default grouping", async () => {
     await initSentry({ SENTRY_DSN: "d" } as unknown as NodeJS.ProcessEnv);
     class HttpError extends Error {
       constructor(message: string) {
@@ -595,12 +596,20 @@ describe("enabled when SENTRY_DSN is set", () => {
     }
     captureError(new HttpError("merge already in progress"), { kind: "agent_merge_blocked" });
     expect(lastCapturedError().name).toBe("HttpError");
+    expect(mocks.scope.setFingerprint).not.toHaveBeenCalled();
   });
 
-  it("captureReviewFailure with an eventName renames the captured Error the same way captureError does", async () => {
+  it("captureReviewFailure with an eventName renames the captured Error and groups it the same way captureError does (#5010) -- this is what consolidates the same failure captured from two different call sites (GITTENSORY-5/10, GITTENSORY-C/W) into one issue", async () => {
     await initSentry({ SENTRY_DSN: "d" } as unknown as NodeJS.ProcessEnv);
     captureReviewFailure(new Error("AI review inconclusive — no usable verdict for the PR head"), { repo: "o/r" }, "ai_review_inconclusive");
     expect(lastCapturedError().name).toBe("ai_review_inconclusive");
+    expect(mocks.scope.setFingerprint).toHaveBeenCalledWith(["gittensory-review-failure", "ai_review_inconclusive"]);
+  });
+
+  it("captureReviewFailure without an eventName never overrides Sentry's default grouping", async () => {
+    await initSentry({ SENTRY_DSN: "d" } as unknown as NodeJS.ProcessEnv);
+    captureReviewFailure(new Error("rev"), { repo: "o/r" });
+    expect(mocks.scope.setFingerprint).not.toHaveBeenCalled();
   });
 
   it("captureError/captureReviewFailure with an eventName still names a non-Error value's synthesized Error", async () => {


### PR DESCRIPTION
## Summary

Three distinct root causes were each fragmented across multiple separate Sentry issues, diluting their apparent severity (each fragment individually looked small) and defeating "existing issue" alert-trigger logic (each fragment is technically a separate "new" issue the first time it appears).

1. **REES's \`captureAnalyzerDegradation\`** fingerprinted by WHICH analyzer hit a condition (\`context.analyzer\`), not WHY (\`context.partialReason\`) — so \`"analyzer_timeout"\` fragmented into a separate issue per analyzer (installScript, nativeBuild, license, ...), even though they share one root cause: the shared, dynamically-shrinking per-analyzer time budget under heavy concurrent fan-out (confirmed while investigating GITTENSORY-V/18/S/13 — all four turned out to already be fixed or inherent third-party flakiness, but the fragmentation itself was still real and worth fixing for future occurrences). Now groups by \`partialReason\`, falling back to analyzer name only when \`partialReason\` is absent. A reason that IS inherently analyzer-specific (e.g. \`"bundlephobia-size_http_error"\`) still gets its own issue, since the reason string already encodes that specificity.
2. **\`captureError\`/\`captureReviewFailure\`'s** optional \`eventName\` (added earlier this session for Sentry issue titles, #5058) now also sets an explicit fingerprint when provided, mirroring \`forwardStructuredLogToSentry\`'s existing \`scope.setFingerprint(["gittensory-log", event])\` discipline. This is what actually fixes GITTENSORY-5/10 ("PR public-surface publish failed") and GITTENSORY-C/W ("AI review did not produce public notes") going forward — both pairs were fragmented because Sentry's default stack-trace-based grouping treated the same message captured from two different functions as two different issues.

Closes #5010

## Scope

- [x] The PR title follows \`type(scope): short summary\` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows \`CONTRIBUTING.md\`.
- [x] I linked a currently open issue this PR resolves (\`Closes #5010\`).

## Validation

- [x] \`git diff --check\`
- [x] \`npm run actionlint\`
- [x] \`npm run typecheck\`
- [x] \`npm run test:coverage\` (full unsharded \`npm run test:ci\`, all green)
- [x] \`npm run test:workers\`
- [x] \`npm run build:mcp\`
- [x] \`npm run test:mcp-pack\`
- [x] \`npm run ui:openapi:check\`
- [x] \`npm run ui:lint\`
- [x] \`npm run ui:typecheck\`
- [x] \`npm run ui:build\`
- [x] \`npm audit --audit-level=moderate\`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — added regression tests for the new grouping-by-reason behavior (and the fallback-to-analyzer-name case) in REES's \`sentry-degradation.test.ts\`, and for the new fingerprint-set-when-eventName-provided / not-set-when-absent behavior in \`selfhost-sentry.test.ts\`. Also ran the full REES suite (\`npm run rees:test\`, 1318 tests) since this touches \`review-enrichment/\`.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A.)
- [x] UI changes use live API data or real empty/error/loading states. (N/A.)
- [x] Visible UI changes include a \`UI Evidence\` section. (N/A — backend-only.)
- [x] Public docs/changelogs are updated where needed. (N/A.)