### PR TITLE
fix(selfhost): remove Claude reviewer tools

### DIFF
--- a/src/selfhost/ai.ts
+++ b/src/selfhost/ai.ts
@@ -882,13 +882,26 @@ export function createClaudeCodeAi(parentEnv: Record<string, string | undefined>
         const prompt = toCliPrompt(options, systemAppend);
         const spawn = spawnImpl ?? (await defaultSpawn());
         const cwd = await isolatedCliCwd();
-        // bypassPermissions (not "plan"): --disallowedTools already forbids every mutating/networked tool, so
-        // nothing left needs an interactive approval prompt -- and this call has no TTY to answer one anyway.
-        // "plan" activates Claude Code's full interactive Plan-Mode WORKFLOW (explore, draft a plan, wait for
-        // ExitPlanMode approval), not just a permission restriction, which confused the model into treating a
-        // one-shot review request as an interactive planning session instead of returning a JSON verdict
-        // (#observability-plan-mode-injection-lookalike, live in ai_review_provider_unparseable_exhausted).
-        const args = ["--print", "--output-format", "json", "--model", claudeModel, "--permission-mode", "bypassPermissions", "--effort", effort, "--disallowedTools", "Bash,Edit,Write,WebFetch,WebSearch"];
+        // Keep bypassPermissions (not "plan") only to avoid a headless approval prompt; the actual boundary is
+        // tool removal. --tools "" removes every built-in tool, --strict-mcp-config prevents user/home MCP config
+        // from loading, and mcp__* is a defense-in-depth deny for CLIs that still have MCP tools available. This
+        // avoids a brittle mutating-tool denylist while preserving the one-shot JSON review flow.
+        const args = [
+          "--print",
+          "--output-format",
+          "json",
+          "--model",
+          claudeModel,
+          "--permission-mode",
+          "bypassPermissions",
+          "--effort",
+          effort,
+          "--tools",
+          "",
+          "--strict-mcp-config",
+          "--disallowedTools",
+          "mcp__*",
+        ];
         // A dedicated system-prompt-file channel (not textual stdin-prepending) marks repo instructions
         // unambiguously SYSTEM rather than author-controlled content -- see writeClaudeSystemPromptFile's doc
         // comment for why the textual-prepend approach this replaces was itself the bug.

--- a/test/unit/selfhost-ai.test.ts
+++ b/test/unit/selfhost-ai.test.ts
@@ -1316,7 +1316,7 @@ describe("subscription CLI helpers + fail-safe", () => {
     expect(capturedInput).toBe("Review this diff.");
   });
 
-  it("Claude Code runs with --permission-mode bypassPermissions, not plan (#observability-plan-mode-injection-lookalike): disallowedTools already forbids every mutating tool, and 'plan' activates the interactive Plan-Mode workflow instead of just restricting permissions", async () => {
+  it("Claude Code disables all built-in and MCP tools while keeping bypassPermissions headless (#observability-plan-mode-injection-lookalike)", async () => {
     let seen: string[] = [];
     const cap: StubSpawn = async (_c, a) => {
       seen = a;
@@ -1325,6 +1325,10 @@ describe("subscription CLI helpers + fail-safe", () => {
     await createClaudeCodeAi({ CLAUDE_CODE_OAUTH_TOKEN: "t" }, cap).run("", { prompt: "x" });
     expect(seen[seen.indexOf("--permission-mode") + 1]).toBe("bypassPermissions");
     expect(seen).not.toContain("plan");
+    expect(seen[seen.indexOf("--tools") + 1]).toBe("");
+    expect(seen).toContain("--strict-mcp-config");
+    expect(seen[seen.indexOf("--disallowedTools") + 1]).toBe("mcp__*");
+    expect(seen[seen.indexOf("--disallowedTools") + 1]).not.toContain("Bash");
   });
 
   it("chat-only CLIs reject embeds so the chain routes embeddings to an embed-capable provider (Claude review + ollama embed)", async () => {


### PR DESCRIPTION
### Motivation

- Close a security regression where the Claude Code review subprocess used `--permission-mode bypassPermissions` with a brittle mutating-tool denylist, allowing unlisted tools (including MCP tools) to run via prompt injection. 
- Ensure the review subprocess remains headless and JSON-only while preventing any built-in or user/home MCP tools from loading and removing the fragile denylist boundary.

### Description

- Replace the brittle mutating-tool denylist with explicit tool removal and MCP hardening by adding `--tools ""`, `--strict-mcp-config`, and using `--disallowedTools mcp__*` when spawning the `claude` subprocess. 
- Preserve `--permission-mode bypassPermissions` for headless operation but remove all built-in tools and prevent user/home MCP config from loading as a defense-in-depth boundary. 
- Use the dedicated system-prompt-file path via `--append-system-prompt-file` (no change in behavior) and keep the one-shot JSON review flow intact. 
- Update the focused unit test to assert the hardened argv shape (no `plan`, `--tools ""`, `--strict-mcp-config`, and `--disallowedTools mcp__*`).

### Testing

- Ran `npm run selfhost:env-reference:check` and it passed. 
- Ran the focused unit tests with `npx vitest run test/unit/selfhost-ai.test.ts -t "Claude Code"` and `npx vitest run test/unit/selfhost-ai.test.ts`, both completed successfully (tests passing for the changed path). 
- Ran `npm run typecheck` and it passed. 
- Attempted `npm run test:coverage` (full suite) but the broader suite exceeded the available execution window in this environment and was not completed. 
- Attempted `npm audit --audit-level=moderate` but the registry audit endpoint returned `403 Forbidden` in this execution environment, so the audit did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a524e4c9ca4832c891b2aab8c989815)