### PR TITLE
fix(review): scope gittensor opt-in to installed repos

### DIFF
--- a/src/review/gittensor-wire.ts
+++ b/src/review/gittensor-wire.ts
@@ -35,11 +35,13 @@ export function shouldEnableGittensorForRepo(
 
 /**
  * The set of repos (lowercased full names) this self-host instance has opted into the gittensor plugin for --
- * every locally-known repo (listRepositories, deliberately NOT filtered by isRegistered: isRegistered is
+ * every locally installed repo (listRepositories, deliberately NOT filtered by isRegistered: isRegistered is
  * itself DOWNSTREAM of this decision on self-host, see registry/sync.ts's persistRegistrySnapshot, so filtering
  * on it here would be circular -- a repo could never earn its first isRegistered=true) whose manifest sets
- * `experimental.gittensor: true` AND the global env kill-switch is on. A per-repo manifest-load error is
- * skipped (treated as not-opted-in), never aborts the pass -- mirrors selftune-wire.ts's selfTuneRepos.
+ * `experimental.gittensor: true` AND the global env kill-switch is on. Registry-only rows from historical
+ * snapshots are ignored: an external repo's cached manifest must not activate outbound subnet work for this
+ * instance. A per-repo manifest-load error is skipped (treated as not-opted-in), never aborts the pass -- mirrors
+ * selftune-wire.ts's selfTuneRepos.
  * Flag-OFF (default) short-circuits before listing repos or loading a single manifest, so a plain self-host
  * instance makes zero local reads for this and zero outbound gittensor-registry requests (see index.ts).
  */
@@ -48,6 +50,7 @@ export async function gittensorEnabledRepoFullNames(env: Env & { GITTENSORY_EXPE
   const repos = await listRepositories(env);
   const enabled = new Set<string>();
   for (const repo of repos) {
+    if (!repo.isInstalled) continue;
     try {
       const manifest = await loadRepoFocusManifest(env, repo.fullName);
       if (shouldEnableGittensorForRepo(env, manifest.experimental.gittensor)) enabled.add(repo.fullName.toLowerCase());

--- a/test/unit/gittensor-wire.test.ts
+++ b/test/unit/gittensor-wire.test.ts
@@ -11,6 +11,14 @@ async function seedRegisteredRepo(env: Env, fullName: string): Promise<void> {
     .run();
 }
 
+async function seedRegistryOnlyRepo(env: Env, fullName: string): Promise<void> {
+  const [owner, name] = fullName.split("/");
+  await (env.DB as unknown as { prepare: (s: string) => { bind: (...v: unknown[]) => { run: () => Promise<unknown> } } })
+    .prepare("INSERT INTO repositories (full_name, owner, name, is_installed, is_registered) VALUES (?, ?, ?, 0, 1)")
+    .bind(fullName, owner, name)
+    .run();
+}
+
 // Wrap env.DB.prepare so any SQL matching `pattern` throws, exercising a fail-safe catch; every other query
 // delegates to the real test DB unchanged. Mirrors selftune-wiring.test.ts's poisonDbPrepare.
 function poisonDbPrepare(env: Env, pattern: RegExp): void {
@@ -95,6 +103,13 @@ describe("gittensorEnabledRepoFullNames", () => {
     await seedRegisteredRepo(env, "owner/notyetregistered"); // seeded with is_registered=0
     await upsertRepoFocusManifest(env, "owner/notyetregistered", { experimental: { gittensor: true } });
     await expect(gittensorEnabledRepoFullNames(env)).resolves.toEqual(new Set(["owner/notyetregistered"]));
+  });
+
+  it("excludes registry-only repos whose cached manifests opt in (regression for the unscoped registry activation bypass)", async () => {
+    const env = createTestEnv({ GITTENSORY_EXPERIMENTAL_GITTENSOR: "true" });
+    await seedRegistryOnlyRepo(env, "attacker/external");
+    await upsertRepoFocusManifest(env, "attacker/external", { experimental: { gittensor: true } });
+    await expect(gittensorEnabledRepoFullNames(env)).resolves.toEqual(new Set());
   });
 
   it("fails safe per-repo: a manifest-load error is swallowed and the pass still resolves", async () => {


### PR DESCRIPTION
### Motivation
- The self-hosted Gittensor opt-in logic could be triggered by registry-only (cached external) rows, allowing an external repo with `experimental.gittensor: true` to enable global `refresh-registry` work and downstream processing; the change closes this boundary bypass. 

### Description
- Restrict `gittensorEnabledRepoFullNames` to only consider locally installed repos by skipping rows where `repo.isInstalled` is false in `src/review/gittensor-wire.ts`. 
- Clarify the function comment to document that registry-only snapshot rows are intentionally ignored to prevent external cached manifests from activating subnet work. 
- Add a regression unit test in `test/unit/gittensor-wire.test.ts` that seeds a registry-only repo (`is_installed=0,is_registered=1`) with `experimental.gittensor: true` and asserts it is excluded. 
- Preserve the existing behavior of not filtering on `isRegistered` to avoid a chicken-and-egg deadlock for newly-known-but-not-yet-registered installed repos. 

### Testing
- Ran the targeted unit test with `npx vitest run test/unit/gittensor-wire.test.ts --reporter=verbose`, and all tests in that file passed. 
- Executed the repo-local checks (`git diff --check`) as part of validation and it passed. 
- Attempted the full coverage run via `npm run test:coverage`, but the full repository coverage run failed the global coverage thresholds (existing large-suite coverage shortfall in this environment) so a complete unsharded CI pass was not completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a52358b69dc832ca27f4e9c0a8fba7b)