### PR TITLE
docs(contributing): add visual-evidence hosting mechanism, fix stale CI-check list

### DIFF
--- a/.claude/skills/contributing-to-gittensory/SKILL.md
+++ b/.claude/skills/contributing-to-gittensory/SKILL.md
@@ -221,12 +221,13 @@ npm audit --audit-level=moderate          # the dependency-review job's local eq
 
 `npm run test:ci` runs, and must pass, **all of**: `actionlint`, `db:migrations:check`,
 `db:schema-drift:check`, `selfhost:env-reference:check`, `selfhost:validate-observability`,
-`cf-typegen:check`, `typecheck`, `test:coverage`, `test:workers`, `build:mcp`, `test:mcp-pack`,
+`cf-typegen:check`, `typecheck`, `test:coverage`, `test:engine-parity`, `test:driver-parity`, the
+`@jsonbored/gittensory-engine` workspace's own test run, `test:workers`, `build:mcp`, `test:mcp-pack`,
 `build:miner`, `test:miner-pack`, `rees:test`, `ui:openapi:check`, `ui:openapi:settings-parity`,
-`ui:version-audit`, `docs:drift-check`, `command-reference:check`, `ui:lint`, `ui:typecheck`,
-`ui:test`, `ui:build`. If any step fails, fix it and re-run — do not push a red tree. (Full
-per-check table in `reference.md`; check `package.json`'s own `test:ci` script if this list and
-that script ever disagree — the script is the source of truth.)
+`ui:version-audit`, `docs:drift-check`, `manifest:drift-check`, `engine-parity:drift-check`,
+`command-reference:check`, `ui:lint`, `ui:typecheck`, `ui:test`, `ui:build`. If any step fails, fix it
+and re-run — do not push a red tree. (Full per-check table in `reference.md`; check `package.json`'s
+own `test:ci` script if this list and that script ever disagree — the script is the source of truth.)
 
 If `ui:lint` fails on formatting, run `npm --workspace @jsonbored/gittensory-ui run format`. If
 `ui:openapi:check` fails, you forgot Phase 4's `ui:openapi`.
@@ -258,6 +259,52 @@ merge instead of a one-shot close.
 ---
 
 ## Phase 7 — Commit and write the PR
+
+**Capturing and hosting visual evidence (any visible UI/frontend change).** The `## UI Evidence` table
+below needs real, clickable thumbnail URLs — here's how to get them when you can't drag-and-drop into
+GitHub's web editor (which needs a human browser session an AI coding tool can't drive end-to-end):
+
+1. **Local dev server:** `npm --prefix apps/gittensory-ui run dev` (Vite forces port **8080** regardless
+   of what you request — use that port in any launch config, or `preview_screenshot`-style tooling just
+   hangs waiting for the server). For an auth-gated page, use the sanctioned local-preview escape hatch
+   instead of real GitHub OAuth: `useSession().signInPreview()` (`apps/gittensory-ui/src/lib/api/session.ts`),
+   gated on `import.meta.env.DEV` — it sets a synthetic session client-side with no network write. Click
+   the "Continue with local preview" button in the sign-in wall rather than calling the hook indirectly
+   (the real `fetchBrowserSession()` call can race in afterward and silently overwrite it back to `null`);
+   overriding `window.fetch` for `/v1/auth/session` to return the same authenticated shape closes that
+   race either way.
+2. **Fixed viewport, never a full-page/`fullPage: true` capture.** gittensory-ui is a **dark-mode-only
+   build** (`apps/gittensory-ui/src/components/site/theme-toggle.tsx` — the toggle was removed; there is
+   no light theme left to force), so there's no theme dimension to multiply out. Capture at whichever
+   viewport(s) your change actually affects — mobile (375×812) and desktop (1280×800) cover most cases;
+   add a caption per state either way (`"Loaded state"`, `"Mobile layout"`, etc., matching the existing
+   caption convention below).
+3. **Host the images on a dedicated branch in your own fork** — never commit them to your feature
+   branch, and never rely on drag-and-drop:
+   ```sh
+   git worktree add ../gittensory-screenshots main
+   cd ../gittensory-screenshots
+   git checkout --orphan screenshots       # first time; `git checkout screenshots` if you already have one
+   git rm -rf . 2>/dev/null
+   cp /path/to/your/*.jpg .                # JPG/PNG only -- SVG is never accepted as review evidence
+   git add *.jpg && git commit -m "screenshots for PR"
+   git push origin screenshots
+   cd -    # your feature branch's working directory was never touched
+   ```
+   Reference each file as `https://raw.githubusercontent.com/<your-fork-owner>/gittensory/screenshots/<file>.jpg`,
+   then embed it with the existing `<a href="URL"><img src="URL" alt="Loaded state" width="240"></a>`
+   thumbnail convention.
+4. **Animated evidence — for effects no static screenshot can show** (a hover-triggered element, a
+   scroll-linked effect, a CSS transition, a drag interaction): record the interaction (an OS screen
+   recording or a Playwright video), convert it to a GIF —
+   ```sh
+   ffmpeg -i recording.mov -vf "fps=12,scale=480:-1:flags=lanczos" -loop 0 hover-before.gif
+   ```
+   (keep it small: a few seconds, ~12fps, ≤480px wide) — and host it the same way as step 3 above; `.gif`
+   is an accepted screenshot-evidence extension the same as `.jpg`/`.png`. This is *additional* evidence
+   for the interaction itself when the change also has an at-rest visual difference worth a static
+   screenshot too — it doesn't replace step 2 for a change that has both kinds of difference, only for a
+   change where the "before"/"after" genuinely cannot be told apart without the motion.
 
 **Commit subject** — Conventional Commit, lowercase scope, specific, no trailing period, ≥15 chars
 and ≥2 real words, **no AI/Claude attribution**:
@@ -294,6 +341,8 @@ the Validation evidence + a linked, currently-open issue is exactly what makes `
 - [ ] MCP: `predict_gate` = pass, `check_slop_risk` = low, `lint_pr_text` = strong; no advisory findings left.
 - [ ] Conventional Commit subject (no AI attribution); `.github/pull_request_template.md` filled honestly —
       the Scope + Validation + Safety boxes, and the UI Evidence table for any visual change.
+- [ ] If the change is only visible in motion (hover/scroll/transition): a before/after GIF alongside the
+      static screenshots, per Phase 7's "Animated evidence" step.
 - [ ] No changelog edit; no `site/`/`CNAME`/`lovable` changes.
 
 If every box is checked, the PR has the best possible chance of a one-shot approve-and-merge. If any

--- a/.claude/skills/contributing-to-gittensory/reference.md
+++ b/.claude/skills/contributing-to-gittensory/reference.md
@@ -53,6 +53,21 @@ path filter matched; on push to `main`, everything runs.
 workflow in this repo. There is **no** root-level Prettier gate — Prettier is enforced only inside
 `ui:lint` (so it only bites `apps/gittensory-ui/**`).
 
+**Local-only checks with no separate named CI status — `npm run test:ci` is the only thing that catches
+these for a normal PR:**
+
+| Local command | Why it's not in the table above |
+|---|---|
+| `npm run test:engine-parity`, `npm run test:driver-parity` | Plain `test/contract/*.test.ts` files — no dedicated CI job, but they DO run in CI as part of whichever `test (1/2)` shard happens to contain them (sharded `vitest run`). |
+| `npm run test --workspace @jsonbored/gittensory-engine` | The engine package's own `node --test` suite. **Not run by `ci.yml` on a PR at all** — only by `.github/workflows/publish-engine.yml` at release time. A regression here is invisible to Codecov and to every PR-gating CI check; `test:ci` locally is the only pre-merge signal. |
+| `npm run manifest:drift-check`, `npm run engine-parity:drift-check` | Appear in `test:ci` only — not in `ci.yml` under any job. |
+
+This is a real, previously-hit gap, not a hypothetical: a past PR shipped a genuine, undetected
+`codecov/patch`-adjacent regression in the engine package specifically because `test --workspace
+@jsonbored/gittensory-engine` isn't part of `ci.yml`. If your change touches
+`packages/gittensory-engine/**`, running `npm run test:ci` locally (not just watching the PR's CI
+checks go green) is the only way to know you didn't break it.
+
 ---
 
 ## 2. Codecov — the real coverage gate (`codecov.yml`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,8 +136,12 @@ Every PR should include:
 - The exact validation commands run from the repo root.
 - JPG/JPEG or PNG screenshot evidence for visible UI, frontend, docs, or extension changes,
   attached in the PR description as organized, captioned, clickable thumbnails. SVG screenshots
-  are not accepted as review evidence, and recordings are supplemental rather than a replacement
-  for screenshots. Do not commit review-only screenshots or recordings to the repository.
+  are not accepted as review evidence. Recordings/GIFs are supplemental to (never a replacement
+  for) static screenshots for anything a still image CAN show — but for an effect a static image
+  genuinely cannot show (a hover-triggered element, a scroll-linked effect, a transition), a
+  before/after GIF is the required primary evidence for that specific interaction, alongside the
+  usual static screenshots for whatever else the change affects. Do not commit review-only
+  screenshots or recordings to the repository.
 - API/OpenAPI/MCP contract notes for schema or behavior changes.
 - Migration, deploy, secret, or Cloudflare configuration notes when relevant.
 - Security/privacy notes for auth, cookies, CORS, GitHub App output, user identity, or contributor
@@ -228,8 +232,11 @@ Frontend:
 - API Try It may still support manual bearer-token testing.
 - Visible UI changes need a `Screenshots` or `UI Evidence` section in the PR description. Use
   GitHub-hosted JPG/JPEG or PNG screenshots only; SVG screenshots are not accepted as review
-  evidence. Recordings can be included as supplemental context, but screenshots are still expected
-  for visual review.
+  evidence. Recordings/GIFs are supplemental for anything a static screenshot can already show, but
+  are the required primary evidence for an effect only visible in motion (hover, scroll-linked,
+  transition/animation) — a still image can't show it, so don't force one. See the
+  `.claude/skills/contributing-to-gittensory` skill (Phase 7) for exactly how to capture and host
+  either kind of evidence.
 - Arrange screenshots in a small table or grid with a short state/title such as "Loaded state",
   "Empty state", "Error state", "Mobile layout", or "PR sidebar". Each screenshot should be a small
   thumbnail that links to the full-size upload. Use HTML thumbnails like


### PR DESCRIPTION
## Summary
- `SKILL.md`/`CONTRIBUTING.md` required a before/after screenshot table for visual PRs but never explained how to actually get a hosted URL for the image -- a real gap an AI coding tool hit directly in an earlier session (captured a screenshot, had no way to embed it). Adds a "Capturing and hosting visual evidence" section to `SKILL.md` Phase 7: dev-server bootstrap (`npm --prefix apps/gittensory-ui run dev`, port 8080), the existing `signInPreview()` local-preview auth recipe, fixed-viewport guidance (gittensory-ui is dark-mode-only per `theme-toggle.tsx` -- no theme dimension to force, unlike metagraphed), and the dedicated orphan-branch-on-your-fork hosting mechanism (mirroring metagraphed's own skill, which already solves this).
- Adds a GIF/recording step for effects a static screenshot genuinely can't show (hover-triggered elements, scroll-linked effects, transitions) -- required primary evidence for that specific interaction, not just "supplemental." Updates `CONTRIBUTING.md`'s two recording mentions to match.
- Fixes a real inaccuracy: `SKILL.md` Phase 5 and `reference.md` §1 both claimed to list everything `npm run test:ci` runs but were missing 5 real steps (`test:engine-parity`, `test:driver-parity`, the `@jsonbored/gittensory-engine` workspace's own test run, `manifest:drift-check`, `engine-parity:drift-check`). Verified against `.github/workflows/*.yml`: 3 of those 5 have **no separate named CI check at all** -- only `npm run test:ci` locally catches a regression there (the engine package's own test suite is only otherwise run by the separate, release-time `publish-engine.yml`).

Closes #5114

## Test plan
- Docs-only change (`.claude/skills/**`, `CONTRIBUTING.md`) -- no `src/**` touched, no coverage obligation.
- `git diff --check`, `npm run docs:drift-check`, `npm run command-reference:check` all clean.
- Cross-checked the "missing CI checks" claim directly against `.github/workflows/ci.yml` and `publish-engine.yml` rather than assuming.