### PR TITLE
fix(ci): build the engine package before the self-host Postgres integration test

### DIFF
--- a/.github/workflows/selfhost.yml
+++ b/.github/workflows/selfhost.yml
@@ -74,6 +74,15 @@ jobs:
       - name: Install deps
         run: npm ci --ignore-scripts
 
+      # Same #ci-engine-build-order fix as ci.yml (see its "Build engine package" step): the Postgres
+      # integration test's import graph now reaches @jsonbored/gittensory-engine transitively (#5117 moved
+      # local-write action specs there; src/mcp/local-write-tools.ts re-exports them). That package's
+      # dist/ is gitignored and only exists after this build step, so the test fails to resolve the
+      # package's exports without it -- this workflow never needed the engine package built before, so it
+      # never had this step; it does now.
+      - name: Build engine package
+        run: npm run build --workspace @jsonbored/gittensory-engine
+
       - name: Postgres integration test (real PG)
         run: PG_TEST_URL=postgres://postgres:devpw@localhost:5432/gittensory npx vitest run test/integration/selfhost-pg.test.ts
 


### PR DESCRIPTION
## Summary

- `.github/workflows/selfhost.yml`'s "build + boot smoke test" job runs the Postgres integration test (`test/integration/selfhost-pg.test.ts`) right after `npm ci --ignore-scripts`, with no step building `@jsonbored/gittensory-engine`'s `dist/` output first.
- That test's import graph now reaches the engine package transitively: it imports `processJob` from `src/queue/processors.ts`, which imports `src/mcp/local-write-tools.ts`, which (since #5117 moved local-write action specs into the shared engine package) re-exports from `@jsonbored/gittensory-engine`. The package's `dist/` is gitignored and only exists after `npm run build --workspace @jsonbored/gittensory-engine` — this workflow never had that step because it never needed it before.
- Same `#ci-engine-build-order` bug class `ci.yml`'s own "Build engine package" step exists to prevent (see its comment, first hit by PR #5082, fixed by #5093 for Typecheck/coverage) — just missed in this separate workflow.
- Discovered as a side effect while opening an unrelated PR (#5121, Docker Compose secrets) that happens to touch `docker-compose.yml`, one of this workflow's trigger paths — it's the first PR to actually exercise `selfhost.yml` since #5117 landed, surfacing a break that's been latent on `main` since then. Confirmed this is not required-check-blocking (only `validate` + `Superagent Security Scan` are required) and not caused by that PR's own diff, so fixing it here as its own focused change instead.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] Maintainer/own-branch PR — no linked issue; this is a CI-only fix for a regression discovered this session, landed directly.

## Validation

- [x] `npm run actionlint` — clean.
- [x] Reproduced the exact CI failure locally: removed `packages/gittensory-engine/dist`, ran `npx vitest run test/integration/selfhost-pg.test.ts`, got the identical `Failed to resolve entry for package "@jsonbored/gittensory-engine"` error at `src/review/fix-handoff-render.ts:14:1` / `src/mcp/local-write-tools.ts:8:1`.
- [x] Rebuilt via `npm run build --workspace @jsonbored/gittensory-engine` (the exact command now added to the workflow), re-ran the test: resolves cleanly, 6 tests skip (no `PG_TEST_URL` locally — expected, matches the test file's own documented local-run instructions).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — CI workflow change only.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A.)
- [x] No UI change — UI Evidence section not applicable.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.