### PR TITLE
fix(selfhost): exclude compose secrets from Docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -34,6 +34,10 @@ review-enrichment
 .DS_Store
 *.tsbuildinfo
 # Never ship secrets into the build context
+# Compose secret files live under ./secrets for local self-host deploys; keep raw
+# token values out of Docker build contexts/layers/cache just like .env files.
+secrets
+secrets/**
 .env
 .env.*
 .dev.vars


### PR DESCRIPTION
### Motivation

- The self-hosting docs encourage operators to place high-value secrets under `./secrets/`, but the Docker build context was set to `.` and `.dockerignore` did not exclude `secrets/`, so populated `secrets/*.txt` could be sent to the Docker builder and end up in build layers/cache.  
- Excluding the `secrets/` directory from Docker contexts prevents accidental disclosure of webhook/API/MCP/internal/encryption/PagerDuty tokens during source builds while preserving the documented file-backed secret workflow.

### Description

- Updated `.dockerignore` to explicitly exclude `secrets` and `secrets/**` and added a short explanatory comment about compose secret files.  
- Kept `secrets/README.md` tracked via the existing negation rule so documentation remains in the repo.  
- No application logic or runtime code was changed; this is a build-context-only fix that preserves backward compatibility with inline `.env` values.

### Testing

- Ran an `.dockerignore` matcher check (`node` script) to validate representative paths; `secrets/github_webhook_secret.txt` and `secrets/github_app_private_key.pem` are now ignored while `.env.example` remains included.  
- Ran `git diff --check` which passed.  
- Ran `npm run test:ci`; the full gate run started but failed on an existing `cf-typegen:check` drift (`worker-configuration.d.ts` stale), and `npm audit --audit-level=moderate` could not complete due to the registry audit endpoint returning `403`, so the repo-wide CI gate did not fully complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a527cbf948c832c8ec7623d97b4bd2b)