### PR TITLE
feat(selfhost): add claude code token to native Docker secrets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -164,7 +164,8 @@ GITTENSORY_REVIEW_DRAFT=false
 #
 # RECOMMENDED over pasting secret values into this file at all: docker-compose.yml's native `secrets:`
 # mounts (secrets/README.md) cover the Core secrets above plus TOKEN_ENCRYPTION_SECRET,
-# DRAFT_TOKEN_ENCRYPTION_SECRET, SELFHOST_SETUP_TOKEN, ORB_ENROLLMENT_SECRET, and PAGERDUTY_ROUTING_KEY.
+# DRAFT_TOKEN_ENCRYPTION_SECRET, SELFHOST_SETUP_TOKEN, ORB_ENROLLMENT_SECRET, PAGERDUTY_ROUTING_KEY,
+# and CLAUDE_CODE_OAUTH_TOKEN.
 # Run `./scripts/selfhost-init-secrets.sh` once, then write each real value into its file under secrets/
 # instead of uncommenting the var here — an inline .env value always takes priority if you set both, so
 # migrating is safe to do one secret at a time.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -130,6 +130,7 @@ services:
       DRAFT_TOKEN_ENCRYPTION_SECRET_FILE: "${DRAFT_TOKEN_ENCRYPTION_SECRET_FILE:-/run/secrets/draft_token_encryption_secret}"
       ORB_ENROLLMENT_SECRET_FILE: "${ORB_ENROLLMENT_SECRET_FILE:-/run/secrets/orb_enrollment_secret}"
       PAGERDUTY_ROUTING_KEY_FILE: "${PAGERDUTY_ROUTING_KEY_FILE:-/run/secrets/pagerduty_routing_key}"
+      CLAUDE_CODE_OAUTH_TOKEN_FILE: "${CLAUDE_CODE_OAUTH_TOKEN_FILE:-/run/secrets/claude_code_oauth_token}"
       # Uncomment for Qdrant RAG vector store (--profile qdrant):
       # QDRANT_URL: http://qdrant:6333
       # Uncomment for Ollama AI (--profile ollama):
@@ -169,6 +170,7 @@ services:
       - draft_token_encryption_secret
       - orb_enrollment_secret
       - pagerduty_routing_key
+      - claude_code_oauth_token
     depends_on:
       redis:
         condition: service_healthy
@@ -1004,6 +1006,8 @@ secrets:
     file: ./secrets/orb_enrollment_secret.txt
   pagerduty_routing_key:
     file: ./secrets/pagerduty_routing_key.txt
+  claude_code_oauth_token:
+    file: ./secrets/claude_code_oauth_token.txt
 
 volumes:
   gittensory-data:

--- a/scripts/selfhost-init-secrets.sh
+++ b/scripts/selfhost-init-secrets.sh
@@ -42,6 +42,7 @@ SECRET_FILES=(
   "draft_token_encryption_secret.txt"
   "orb_enrollment_secret.txt"
   "pagerduty_routing_key.txt"
+  "claude_code_oauth_token.txt"
 )
 
 mkdir -p "$SECRETS_DIR"

--- a/secrets/README.md
+++ b/secrets/README.md
@@ -66,6 +66,7 @@ see the tradeoff explained above for why `600` breaks the app's own ability to r
 | `draft_token_encryption_secret.txt` | `DRAFT_TOKEN_ENCRYPTION_SECRET_FILE` | AES-256-GCM secret for the contributor OAuth token (draft flow). |
 | `orb_enrollment_secret.txt` | `ORB_ENROLLMENT_SECRET_FILE` | One-time enrollment secret for brokered Orb mode. |
 | `pagerduty_routing_key.txt` | `PAGERDUTY_ROUTING_KEY_FILE` | PagerDuty Events API v2 routing key (experimental paging integration). |
+| `claude_code_oauth_token.txt` | `CLAUDE_CODE_OAUTH_TOKEN_FILE` | Claude Code subscription OAuth token (from `claude setup-token`), used when `AI_PROVIDER=claude-code`. |
 
 This is not the full list of every secret-shaped env var the stack supports (AI provider API keys,
 Discord/Slack webhooks, Postgres/Grafana credentials for their optional profiles, etc.) — it covers


### PR DESCRIPTION
## Summary

- Adds `CLAUDE_CODE_OAUTH_TOKEN` to the native Docker Compose secrets convention (`docker-compose.yml`, `scripts/selfhost-init-secrets.sh`, `secrets/README.md`, `.env.example`) — it was the last core self-host secret still requiring an inline `.env` value.
- No application code change needed: the existing generic `<NAME>_FILE` loader (`src/selfhost/load-file-secrets.ts`) already resolves any `_FILE`-suffixed var, confirmed by reading it before making this change.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] Linked issue — not applicable; this is an owner-authored infra/config PR, not a contributor PR subject to the linked-issue gate.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` — skipped, see note below
- [ ] `npm run test:workers` — skipped, see note below
- [ ] `npm run build:mcp` — skipped, see note below
- [ ] `npm run test:mcp-pack` — skipped, see note below
- [ ] `npm run ui:openapi:check` — skipped, see note below
- [ ] `npm run ui:lint` — skipped, see note below
- [ ] `npm run ui:typecheck` — skipped, see note below
- [ ] `npm run ui:build` — skipped, see note below
- [x] `npm audit --audit-level=moderate`
- [ ] New or changed behavior has unit/integration tests — not applicable, see note below

If any required check was skipped, explain why:

- This diff touches only `docker-compose.yml`, `scripts/selfhost-init-secrets.sh`, `secrets/README.md`, and `.env.example` — no `src/**`, `apps/gittensory-ui/**`, or API/schema files, and adds zero application code (the generic secret-file loader already covers this var). Codecov's patch gate only measures `src/**`, so there's no coverage obligation here. Ran the checks that actually apply to what changed instead: `docker compose -f docker-compose.yml config --quiet` (valid), `npm run selfhost:env-reference:check` (clean — confirms no new literal `env.SOMETHING` read was introduced), `npm run docs:drift-check` (clean), and `bash -n scripts/selfhost-init-secrets.sh` (valid). Skipped the UI/MCP/miner/workers suites since none of their inputs changed.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed — confirmed by grepping the full working tree for the real token value before pushing.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth/cookie/CORS/GitHub App/Cloudflare/session negative-path tests — not applicable, no such change.
- [ ] API/OpenAPI/MCP behavior updated — not applicable.
- [ ] UI changes use live API data — not applicable, no UI change.
- [x] Public docs are updated where needed (`secrets/README.md`, `.env.example`).

## UI Evidence

Not applicable — no visible UI/frontend change.

## Notes

- This completes the file-secret migration for every core self-host secret used by the always-on `gittensory` service (see `secrets/README.md`'s table) — `CLAUDE_CODE_OAUTH_TOKEN` was the only one left requiring an inline `.env` value.
- Follow-up (server-side, outside this PR's diff): after merge, populate `secrets/claude_code_oauth_token.txt` on deployments that opt into this and remove the now-redundant `CLAUDE_CODE_OAUTH_TOKEN=` line from `.env`.