### PR TITLE
fix(selfhost): validate ready retry settings

### DIFF
--- a/scripts/selfhost-post-update-check.sh
+++ b/scripts/selfhost-post-update-check.sh
@@ -36,6 +36,15 @@ fi
 # polling often enough that a normal ~15-20s boot returns almost immediately once actually ready.
 READY_RETRIES="${SELFHOST_READY_RETRIES:-45}"
 READY_RETRY_DELAY_SECONDS="${SELFHOST_READY_RETRY_DELAY_SECONDS:-2}"
+if [[ ! "$READY_RETRIES" =~ ^[0-9]+$ ]]; then
+  echo "selfhost post-update check: warning — invalid SELFHOST_READY_RETRIES=$READY_RETRIES (using 45)" >&2
+  READY_RETRIES=45
+fi
+if [[ ! "$READY_RETRY_DELAY_SECONDS" =~ ^[0-9]+$ ]]; then
+  echo "selfhost post-update check: warning — invalid SELFHOST_READY_RETRY_DELAY_SECONDS=$READY_RETRY_DELAY_SECONDS (using 2)" >&2
+  READY_RETRY_DELAY_SECONDS=2
+fi
+READY_TIMEOUT_SECONDS=$((10#$READY_RETRIES * 10#$READY_RETRY_DELAY_SECONDS))
 
 echo "selfhost post-update check: probing $READY_URL"
 ready=0
@@ -47,7 +56,7 @@ for _ in $(seq 1 "$READY_RETRIES"); do
   sleep "$READY_RETRY_DELAY_SECONDS"
 done
 if [ "$ready" -ne 1 ]; then
-  echo "error: $READY_URL did not return HTTP 2xx after $READY_RETRIES attempts ($((READY_RETRIES * READY_RETRY_DELAY_SECONDS))s)" >&2
+  echo "error: $READY_URL did not return HTTP 2xx after $READY_RETRIES attempts (${READY_TIMEOUT_SECONDS}s)" >&2
   exit 1
 fi
 

--- a/test/unit/selfhost-post-update-check-script.test.ts
+++ b/test/unit/selfhost-post-update-check-script.test.ts
@@ -1,0 +1,103 @@
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const SCRIPT = resolve("scripts/selfhost-post-update-check.sh");
+const sandboxDirs: string[] = [];
+
+afterEach(() => {
+  while (sandboxDirs.length > 0) {
+    const dir = sandboxDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function writeExecutable(path: string, contents: string) {
+  writeFileSync(path, contents);
+  chmodSync(path, 0o755);
+}
+
+function createSandbox() {
+  const base = mkdtempSync(join(tmpdir(), "gittensory-selfhost-post-update-"));
+  sandboxDirs.push(base);
+  const bin = join(base, "bin");
+  mkdirSync(bin, { recursive: true });
+  writeFileSync(join(base, "docker-compose.yml"), "services: {}\n");
+
+  writeExecutable(
+    join(bin, "docker"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = "compose" ] && [ "$2" = "version" ]; then
+  exit 0
+fi
+if [ "$1" = "compose" ] && [ "$4" = "ps" ] && [ "$5" = "-q" ]; then
+  printf 'container-1\\n'
+  exit 0
+fi
+if [ "$1" = "inspect" ] && [ "$2" = "--format" ]; then
+  if [[ "$3" == *'.State.Health'* ]]; then
+    printf 'healthy\\n'
+  else
+    printf 'ghcr.io/jsonbored/gittensory-selfhost:test\\n'
+  fi
+  exit 0
+fi
+exit 0
+`,
+  );
+
+  writeExecutable(
+    join(bin, "curl"),
+    `#!/usr/bin/env bash
+exit "\${CURL_STATUS:-0}"
+`,
+  );
+
+  writeExecutable(
+    join(bin, "sleep"),
+    `#!/usr/bin/env bash
+exit 0
+`,
+  );
+
+  return { base, bin };
+}
+
+function run(env: Record<string, string>) {
+  const { base, bin } = createSandbox();
+  return spawnSync("bash", [SCRIPT], {
+    cwd: base,
+    encoding: "utf8",
+    env: { ...process.env, PATH: `${bin}${delimiter}${process.env.PATH ?? ""}`, ...env },
+  });
+}
+
+describe("selfhost-post-update-check.sh", () => {
+  it("falls back for non-numeric readiness retry settings without evaluating them as Bash arithmetic", () => {
+    const marker = join(tmpdir(), `gittensory-ready-injection-${process.pid}`);
+    rmSync(marker, { force: true });
+
+    const result = run({
+      SELFHOST_READY_RETRIES: `ready[$(touch ${marker})]`,
+      SELFHOST_READY_RETRY_DELAY_SECONDS: `ready[$(touch ${marker})]`,
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stderr).toContain("invalid SELFHOST_READY_RETRIES");
+    expect(result.stderr).toContain("invalid SELFHOST_READY_RETRY_DELAY_SECONDS");
+    expect(existsSync(marker)).toBe(false);
+  });
+
+  it("reports failed readiness using the validated retry budget", () => {
+    const result = run({
+      CURL_STATUS: "22",
+      SELFHOST_READY_RETRIES: "2",
+      SELFHOST_READY_RETRY_DELAY_SECONDS: "3",
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("after 2 attempts (6s)");
+  });
+});


### PR DESCRIPTION
### Motivation

- The self-host post-update readiness probe accepted `SELFHOST_READY_RETRIES` and `SELFHOST_READY_RETRY_DELAY_SECONDS` directly from the environment and used them in a Bash arithmetic expansion, allowing arithmetic-expression/command-substitution injection on the failure path.
- The intent is to harden the probe against malicious or malformed env values while preserving the existing retry behaviour and messages.

### Description

- Validate `SELFHOST_READY_RETRIES` and `SELFHOST_READY_RETRY_DELAY_SECONDS` as decimal integers and emit a warning and fallback to safe defaults when invalid in `scripts/selfhost-post-update-check.sh`.
- Compute a prevalidated `READY_TIMEOUT_SECONDS` using `10#` to force decimal interpretation and use it in the readiness failure message to avoid evaluating untrusted input inside `$((...))`.
- Replace the vulnerable inline arithmetic expansion in the error message with the precomputed `READY_TIMEOUT_SECONDS` and reuse the sanitized `READY_RETRIES`/`READY_RETRY_DELAY_SECONDS` values for loop/sleep calls.
- Add a regression unit test `test/unit/selfhost-post-update-check-script.test.ts` that runs the real script with mocked `docker`, `curl`, and `sleep` to assert non-numeric injection strings do not execute and that the validated timeout calculation is reported; also regenerate `worker-configuration.d.ts` to satisfy local drift checks.

### Testing

- Ran `npx vitest run test/unit/selfhost-post-update-check-script.test.ts` and the two new tests passed.
- Ran `git diff --check` and the local formatting/checks for the changed files passed.
- Ran `npm run cf-typegen` to regenerate Cloudflare runtime types and committed the updated `worker-configuration.d.ts` successfully.
- Attempted the full gate `npm run test:ci` and `npm audit --audit-level=moderate`; `test:ci` reached `test:coverage` where unrelated existing test-suite failures appeared and the run was stopped, and `npm audit` returned a `403 Forbidden` from the registry audit endpoint (these are unrelated to the patch itself).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a525c303994832c8512690053a904f1)