### PR TITLE
fix(release): pin stable ORB tag to merge commit

### DIFF
--- a/.github/workflows/orb-stable-release-tag.yml
+++ b/.github/workflows/orb-stable-release-tag.yml
@@ -27,12 +27,23 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - name: Checkout
+      - name: Checkout the merged release PR commit
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
-          ref: main
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Verify checkout is the merged release PR commit
+        env:
+          MERGE_COMMIT_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          set -euo pipefail
+          checkout_sha="$(git rev-parse HEAD)"
+          if [ "$checkout_sha" != "$MERGE_COMMIT_SHA" ]; then
+            echo "::error::Checked out $checkout_sha, expected merged release PR commit $MERGE_COMMIT_SHA."
+            exit 1
+          fi
 
       - name: Read the released version
         id: version


### PR DESCRIPTION
### Motivation
- The stable ORB tagging workflow previously checked out the mutable `main` tip, which allowed a race where a later commit on `main` could become the content of the stable tag even though a maintainer merged a specific release PR. 
- Preserve the integrity of the reviewed release by ensuring the tag and downstream dispatch come from the exact merge commit that closed the release PR.

### Description
- Update `.github/workflows/orb-stable-release-tag.yml` to check out the merged release PR commit by using `ref: ${{ github.event.pull_request.merge_commit_sha }}` instead of `main`.
- Add a defensive verification step that compares `git rev-parse HEAD` to `github.event.pull_request.merge_commit_sha` and fails early if they differ, preventing manifest reads, tag creation, or dispatch from the wrong commit.
- Preserve the existing idempotency and dispatch logic so the change is a minimal behavioral hardening.

### Testing
- Ran `git diff --check` to validate no whitespace/conflict markers and it succeeded.
- Ran `npm run actionlint` to lint workflows; the run completed successfully (used WASM fallback after network retries to fetch the official setup).
- Verified the workflow file syntax and that the new verification step is present and correctly placed before reading `orb-manifest.json`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5263bf2bdc832c9894f71583a222b8)