### PR TITLE
ci: run UI validation for packages/gittensory-ui-kit changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,6 +72,7 @@ jobs:
               - 'apps/gittensory-ui/**'
               - 'apps/gittensory-miner-ui/**'
               - 'apps/gittensory-extension/**'
+              - 'packages/gittensory-ui-kit/**'
               - 'scripts/build-extension.mjs'
               - 'package.json'
               - 'package-lock.json'


### PR DESCRIPTION
### Motivation
- Ensure changes to the shared UI package run the full UI validation (lint/typecheck/test/build) because the UI apps now depend on `@jsonbored/gittensory-ui-kit`.

### Description
- Add `packages/gittensory-ui-kit/**` to the `ui` filter in `.github/workflows/ci.yml` so UI-kit-only PRs set `needs.changes.outputs.ui` and trigger the UI build/lint/typecheck/test steps.

### Testing
- Ran `git diff --check`, which passed.
- Ran `npm run actionlint`, which passed (used the WASM fallback when actionlint setup retried due to DNS issues).
- Attempted `npm run test:ci`, which did not reach the UI checks because `npm run cf-typegen:check` reported existing `worker-configuration.d.ts` drift unrelated to this change.
- Attempted `npm audit --audit-level=moderate`, which was blocked by the npm registry audit endpoint returning `403 Forbidden` in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5232e36ca4832cbe3bd236ec7a9e49)