### PR TITLE
docs+fixes(selfhost/ci/chat): claude token docs, ui-only CI gating fix, chat-qa test fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,7 +282,7 @@ jobs:
       # TS2307 in CI while passing locally against a stale leftover dist/ -- first hit by PR #5082). Now ahead
       # of both.
       - name: Build engine package
-        if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.engine == 'true' }}
+        if: ${{ github.event_name == 'push' || needs.changes.outputs.backend == 'true' || needs.changes.outputs.engine == 'true' || needs.changes.outputs.ui == 'true' }}
         run: npm run build --workspace @jsonbored/gittensory-engine
       # .tsbuildinfo mutates every run (tsc's own incremental state), unlike node_modules above which is
       # immutable per lockfile -- so this needs the run_id-suffixed-key + restore-keys-prefix pattern (always

--- a/.gittensory.yml.example
+++ b/.gittensory.yml.example
@@ -1106,13 +1106,17 @@ settings:
 # an operator who sets nothing keeps today's behavior). Exception: `safety` is force-on-only -- an untrusted
 # repo-controlled `false` is treated as "no opinion" rather than an active force-off (#2269), since a
 # lower-trust actor must never be able to silently defeat the operator's own security-hardening enablement.
-# `e2eTests` (#4190), `screenshots` (#4616), and `improvementSignal` (#4738, foundation phase of the #4737
-# PR-improvement-signal epic) are plain symmetric overrides like rag/reputation/unifiedComment -- none carries
-# a security-hardening or full-file-fetch rationale (unlike safety/grounding) that would justify a force-on/
-# force-off asymmetry. `screenshots` sits UNDER the separate, richer `review.visual.*` block further below
-# (route/preview-URL config, and `review.visual.enabled: false` as an always-available additional force-off);
-# this key only answers "does capture run for this repo at all," the same question its siblings answer for
-# their own feature. `improvementSignal` is activation wiring only for now -- no tier reads the resolved
+# `screenshots` (#4616) is ALSO asymmetric as of #4990: allowlisted is now a hard requirement for force-ON,
+# the same as safety/grounding -- real Browserless rendering cost and a publicly-rendered PR image mean a
+# lower-trust repo must not be able to self-activate capture just by setting this to `true` in its own
+# config; a repo-level `false` can still force it OFF within an allowlisted repo. `screenshots` sits UNDER
+# the separate, richer `review.visual.*` block further below (route/preview-URL config, and
+# `review.visual.enabled: false` as an always-available additional force-off); this key only answers "does
+# capture run for this repo at all," the same question its siblings answer for their own feature.
+# `e2eTests` (#4190) and `improvementSignal` (#4738, foundation phase of the #4737 PR-improvement-signal
+# epic) remain plain symmetric overrides like rag/reputation/unifiedComment -- neither carries a
+# security-hardening or full-file-fetch rationale that would justify a force-on/force-off asymmetry.
+# `improvementSignal` is activation wiring only for now -- no tier reads the resolved
 # value yet.
 # features:
 #   rag: true

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-ai-providers.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-ai-providers.tsx
@@ -186,6 +186,13 @@ CLAUDE_AI_EFFORT=medium`}
         instead:
       </p>
       <CodeBlock code={`docker compose up -d --no-deps gittensory`} />
+      <p>
+        Prefer not pasting the raw token into <code>.env</code>? Write it into{" "}
+        <code>secrets/claude_code_oauth_token.txt</code> instead (see{" "}
+        <Link to="/docs/self-hosting-security">Security</Link>'s secret-file section) and leave{" "}
+        <code>CLAUDE_CODE_OAUTH_TOKEN</code> unset in <code>.env</code> — the same recreate step
+        above picks it up either way.
+      </p>
 
       <h2>Codex (subscription)</h2>
       <p>
@@ -216,7 +223,7 @@ CLAUDE_AI_EFFORT=medium`}
           {
             title: "claude_code_no_oauth_token",
             description:
-              "CLAUDE_CODE_OAUTH_TOKEN is unset. Add it to .env and recreate the service.",
+              "CLAUDE_CODE_OAUTH_TOKEN is unset and no secrets/claude_code_oauth_token.txt file is populated. Set either and recreate the service.",
           },
           {
             title: "claude_code_error_401",

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-security.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-security.tsx
@@ -56,12 +56,12 @@ function SelfHostingSecurity() {
         <code>docker-compose.yml</code> ships native Docker Compose <code>secrets:</code> mounts for
         the highest-value secrets (the GitHub App private key, webhook secret, API/MCP/internal-job
         tokens, the setup token, the two token-encryption master keys, the Orb enrollment secret,
-        and the PagerDuty routing key) — file-mounted at <code>/run/secrets/&lt;name&gt;</code>,
-        never exposed via <code>docker inspect</code> or <code>docker compose config</code> the way
-        a plain <code>environment:</code>/<code>env_file</code> value is. This is purely additive:
-        an inline <code>.env</code> value always takes priority if you set both, so you can migrate
-        one secret at a time, or not at all. See <code>secrets/README.md</code> for the full file
-        list.
+        the PagerDuty routing key, and the Claude Code subscription token) — file-mounted at{" "}
+        <code>/run/secrets/&lt;name&gt;</code>, never exposed via <code>docker inspect</code> or{" "}
+        <code>docker compose config</code> the way a plain <code>environment:</code>/
+        <code>env_file</code> value is. This is purely additive: an inline <code>.env</code> value
+        always takes priority if you set both, so you can migrate one secret at a time, or not at
+        all. See <code>secrets/README.md</code> for the full file list.
       </p>
       <CodeBlock
         filename="shell"

--- a/config/examples/gittensory.full.yml
+++ b/config/examples/gittensory.full.yml
@@ -1119,13 +1119,17 @@ settings:
 # an operator who sets nothing keeps today's behavior). Exception: `safety` is force-on-only -- an untrusted
 # repo-controlled `false` is treated as "no opinion" rather than an active force-off (#2269), since a
 # lower-trust actor must never be able to silently defeat the operator's own security-hardening enablement.
-# `e2eTests` (#4190), `screenshots` (#4616), and `improvementSignal` (#4738, foundation phase of the #4737
-# PR-improvement-signal epic) are plain symmetric overrides like rag/reputation/unifiedComment -- none carries
-# a security-hardening or full-file-fetch rationale (unlike safety/grounding) that would justify a force-on/
-# force-off asymmetry. `screenshots` sits UNDER the separate, richer `review.visual.*` block further below
-# (route/preview-URL config, and `review.visual.enabled: false` as an always-available additional force-off);
-# this key only answers "does capture run for this repo at all," the same question its siblings answer for
-# their own feature. `improvementSignal` is activation wiring only for now -- no tier reads the resolved
+# `screenshots` (#4616) is ALSO asymmetric as of #4990: allowlisted is now a hard requirement for force-ON,
+# the same as safety/grounding -- real Browserless rendering cost and a publicly-rendered PR image mean a
+# lower-trust repo must not be able to self-activate capture just by setting this to `true` in its own
+# config; a repo-level `false` can still force it OFF within an allowlisted repo. `screenshots` sits UNDER
+# the separate, richer `review.visual.*` block further below (route/preview-URL config, and
+# `review.visual.enabled: false` as an always-available additional force-off); this key only answers "does
+# capture run for this repo at all," the same question its siblings answer for their own feature.
+# `e2eTests` (#4190) and `improvementSignal` (#4738, foundation phase of the #4737 PR-improvement-signal
+# epic) remain plain symmetric overrides like rag/reputation/unifiedComment -- neither carries a
+# security-hardening or full-file-fetch rationale that would justify a force-on/force-off asymmetry.
+# `improvementSignal` is activation wiring only for now -- no tier reads the resolved
 # value yet.
 # features:
 #   rag: true

--- a/test/unit/ai-chat-qa.test.ts
+++ b/test/unit/ai-chat-qa.test.ts
@@ -261,13 +261,13 @@ describe("generateChatQaAnswer", () => {
   it("redacts private lane signals from cached rationale before prompting the provider", async () => {
     const run = vi.fn(async () => ({ response: "Public-safe readiness answer." }));
     const env = createTestEnv({ AI_ADVISORY: { run } as unknown as Ai, AI_DAILY_NEURON_BUDGET: "10000" });
+    // publicSafeSummary (not why/blockedBy -- compactChatSignalBundle never reads either of those, by design;
+    // see the redaction-boundary comment above PRIVATE_DECISION_BLOCKER_PATTERN) is the field that actually
+    // reaches the prompt, so it's the one that must exercise the new PRIVATE_LANE_SIGNAL_PATTERN end-to-end.
     const result = await generateChatQaAnswer(env, {
       bundle: bundleFixture(undefined, {
-        why: [
-          "owner/repo: Maintainer cut: 1.",
-          "owner/repo: split lane (direct PR 1, issue-discovery 1); both lanes are useful here.",
-          "owner/repo: direct PR lane share 1 with no hard personal blocker.",
-        ],
+        publicSafeSummary:
+          "Maintainer cut: 1. Split lane (direct PR 1, issue-discovery 1); both lanes are useful here. Direct PR lane share 1 with no hard personal blocker.",
       }),
       question: "what should I know?",
       advisoryAiRouting: ADVISORY_ON,


### PR DESCRIPTION
## Summary

Three fixes, each individually small, bundled here because each was a real blocker discovered while trying to ship the first one (all detailed in Notes):

1. **Docs**: `docs.self-hosting-security.tsx` / `docs.self-hosting-ai-providers.tsx` document the `secrets/claude_code_oauth_token.txt` file alternative for `CLAUDE_CODE_OAUTH_TOKEN` (added to `docker-compose.yml` in #5144). `config/examples/gittensory.full.yml` / `.gittensory.yml.example` (mirrored bodies) fix a stale claim that `screenshots` is a "plain symmetric override" — #4990 made it allowlist-required (force-off only outside the rollout allowlist), same asymmetry as `safety`/`grounding`.
2. **CI**: `.github/workflows/ci.yml`'s `validate-code` "Build engine package" step only ran on `push`, or when `backend`/`engine` changed — not `ui`, even though the very next "UI typecheck" step (gated on `ui`) transitively needs it (`apps/gittensory-ui`'s tsconfig pulls in `src/mcp/local-write-tools.ts`, which imports `@jsonbored/gittensory-engine`). Any PR touching only `apps/gittensory-ui/**` hit `TS2307` here on otherwise-correct code — this PR's own first `validate-code` run did exactly that. Added the missing `ui` condition.
3. **Test fix**: `test/unit/ai-chat-qa.test.ts`'s new lane-signal redaction test (#5149) overrode `action.why`, a field `compactChatSignalBundle()` never reads — by design, raw action rationale/`blockedBy` is omitted entirely from the chat grounding bundle, not merely redacted. The override never reached the prompt, so the test asserted on content that could never appear. `redactGroundingText` and its new `PRIVATE_LANE_SIGNAL_PATTERN` regex were already correct the whole time (proven by the adjacent pure-function unit test, which passed throughout) — this was a test-only bug, not a privacy regression. Pointed the override at `publicSafeSummary`, the field that actually flows into the prompt.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] Each of the three changes is individually small and coherent; bundled because #2 and #3 were genuine blockers surfaced while shipping #1 (see Notes for the exact failing runs).
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] Linked issue — not applicable; owner-authored fixes, not a contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (root)
- [x] `npm run ui:typecheck`
- [x] `npm run ui:lint` (found and auto-fixed one pre-existing-pattern Prettier nit in my own new JSX text; zero errors after)
- [x] `npx tsx scripts/gittensory-config-lint.ts .gittensory.yml.example` and same for `config/examples/gittensory.full.yml` — both pass (pre-existing, unrelated `blockedPaths is retired` warning only)
- [x] `npm run docs:drift-check`
- [x] `npm run actionlint` (workflow YAML change)
- [x] `npx vitest run test/unit/ai-chat-qa.test.ts` — all 31 tests pass after the fix
- [ ] `npm run test:coverage` (full) / `test:workers` / `build:mcp` / `test:mcp-pack` / `ui:openapi:check` / `ui:build` / `npm audit` — not run in full locally; relying on this PR's own CI for the full suite since none of these three changes touch `src/**` production logic (only a workflow file, docs pages, example-config comments, and one test file)

If any required check was skipped, explain why:

- No production `src/**` logic changed anywhere in this diff (the chat-qa fix is test-only; `redactGroundingText` itself is untouched). Relying on CI for the full matrix rather than re-running it all locally given the narrow blast radius.

## Safety

- [x] No secrets, tokens, or private values exposed.
- [x] Public GitHub text stays sanitized.
- [x] The chat-qa test fix directly concerns a privacy-redaction boundary — confirmed the underlying `redactGroundingText`/`PRIVATE_LANE_SIGNAL_PATTERN` logic was already correct and untouched; only the test's fixture override target was wrong. Traced `compactChatSignalBundle()` line-by-line to confirm `why`/`blockedBy` are deliberately never read (only `publicSafeSummary`, `objective`, `summary`, `freshnessWarnings` are), matching the file's own documented design intent.
- [ ] API/OpenAPI/MCP behavior — not applicable.
- [ ] UI changes use live API data — not applicable, static docs content only.
- [x] Public docs are part of this PR.

## UI Evidence

Text-only docs changes (prose + one troubleshooting-row string) — no layout/visual change, no screenshots. The CI/test files are not user-facing.

## Notes

- Companion follow-up to #5144 (secrets migration) and #4990 (screenshot allowlist fix).
- CI-gating bug: this PR's first `validate-code` run failed with `TS2307` — https://github.com/JSONbored/gittensory/actions/runs/29187025975/job/86634920100. Confirmed pre-existing (not caused by this PR's docs diff) by checking `main`'s own `push`-triggered runs pass `validate-code` (the `push` branch of the condition always builds the engine); only a *PR* touching solely `ui`-classified paths hits the gap.
- Chat-qa test bug: after the CI fix above, this PR's `validate-tests (4)` shard still failed — inherited from `main`, which is currently red for the same reason (confirmed via `main`'s last several push runs, e.g. the run for commit `f166c07aa` itself). Traced to the test, not the redaction code; fixed here so both this PR and `main` go green.