### PR TITLE
fix(review): canonicalize calibration login lookup

### DIFF
--- a/src/review/predicted-gate-calibration-ledger.ts
+++ b/src/review/predicted-gate-calibration-ledger.ts
@@ -141,13 +141,14 @@ export async function recordPredictedGateCalibration(
 export async function computeContributorCalibration(env: PredictedGateCalibrationEnv, login: string | null | undefined): Promise<ContributorCalibrationSignal | null> {
   const trimmed = login?.trim();
   if (!trimmed) return null;
+  const normalizedLogin = trimmed.toLowerCase();
   try {
     const row = await env.DB.prepare(
       `SELECT COUNT(*) AS sampleSize, COALESCE(AVG(agreed), 0) AS agreementRate
          FROM predicted_gate_calibration_ledger
-        WHERE login = ?`,
+        WHERE lower(login) = ?`,
     )
-      .bind(trimmed)
+      .bind(normalizedLogin)
       .first<{ sampleSize: number; agreementRate: number }>();
     // COUNT(*)/AVG(...) with no GROUP BY always returns exactly one row, even over zero matches (COUNT: 0,
     // AVG: NULL -> COALESCE: 0) -- .first()'s nullable return type is a TypeScript-level formality here, not

--- a/test/unit/predicted-gate-calibration-ledger.test.ts
+++ b/test/unit/predicted-gate-calibration-ledger.test.ts
@@ -220,6 +220,20 @@ describe("computeContributorCalibration — per-login calibration read (#2349)",
     expect(await computeContributorCalibration(env, "someone-else")).toEqual({ sampleSize: 1, agreementRate: 1 });
   });
 
+  it("canonicalizes GitHub login casing so case variants cannot bypass or infer calibration", async () => {
+    const env = createTestEnv();
+    await seedLedgerRow(env, { login: "OctoCat", pullNumber: 1, agreed: false });
+    await seedLedgerRow(env, { login: "octocat", pullNumber: 2, agreed: false });
+    await seedLedgerRow(env, { login: "OCTOCAT", pullNumber: 3, agreed: true });
+    await seedLedgerRow(env, { login: "someone-else", pullNumber: 1, agreed: true });
+
+    const expected = { sampleSize: 3, agreementRate: 1 / 3 };
+    expect(await computeContributorCalibration(env, "OctoCat")).toEqual(expected);
+    expect(await computeContributorCalibration(env, " octocat ")).toEqual(expected);
+    expect(await computeContributorCalibration(env, "OCTOCAT")).toEqual(expected);
+    expect(await computeContributorCalibration(env, "someone-else")).toEqual({ sampleSize: 1, agreementRate: 1 });
+  });
+
   it("aggregates across ALL of a login's history regardless of which repo each pairing came from", async () => {
     const env = createTestEnv();
     await seedLedgerRow(env, { login: "octocat", project: "owner/repo-a", pullNumber: 1, agreed: true });


### PR DESCRIPTION
### Motivation
- Prevent leakage and bypass of a private contributor calibration signal caused by case-sensitive ledger lookups that could be inferred by calling with login casing variants.

### Description
- Canonicalize the requested GitHub login in `computeContributorCalibration` by trimming and lower-casing the input and querying with `WHERE lower(login) = ?` so all case variants map to the same ledger history (`src/review/predicted-gate-calibration-ledger.ts`).
- Add a regression test that seeds mixed-case ledger rows and verifies mixed-case caller inputs resolve to the same aggregate calibration signal (`test/unit/predicted-gate-calibration-ledger.test.ts`).
- Regenerate Cloudflare worker runtime types after the local cf-typegen drift check reported stale output (`worker-configuration.d.ts`).

### Testing
- Ran `npx vitest run test/unit/predicted-gate-calibration-ledger.test.ts`, which passed (24 tests).
- Ran `npm run cf-typegen:check` and regenerated `worker-configuration.d.ts`, and the cf-typegen check passed after regeneration.
- Ran `npm run typecheck`, which failed due to unrelated existing type errors elsewhere in the tree (not introduced by this change), preventing a full `npm run test:ci` green run in this environment.
- Note: `npm audit --audit-level=moderate` returned a registry error (403) in this environment and did not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a535804b074832ca0e0abe6ebfc71b3)