### PR TITLE
fix(review): enforce miner-scoped breakers

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -2796,10 +2796,18 @@ async function runAgentMaintenancePlanAndExecute(
   // Each read is independent and fail-open (isHoldOnly / isCloseHoldOnly read false until a breaker actually
   // engages), so the common path is byte-identical (both downgrades return the plan unchanged). The chaining is
   // extracted into the pure applyPrecisionBreakers below so it is unit-tested directly.
+  const breakerMinerAuthored = pr.authorLogin
+    ? (
+        await getCachedOfficialMinerDetection(env, pr.authorLogin, {
+          targetKey: `${repoFullName}#${pr.number}`,
+          deliveryId,
+        })
+      ).status === "confirmed"
+    : false;
   const breakerOnPlan = applyPrecisionBreakers(
     planned,
-    await isHoldOnly(env, repoFullName),
-    await isCloseHoldOnly(env, repoFullName),
+    await isHoldOnly(env, repoFullName, breakerMinerAuthored),
+    await isCloseHoldOnly(env, repoFullName, breakerMinerAuthored),
     {
       manualReviewLabel: settings.manualReviewLabel,
       readyToMergeLabel: settings.readyToMergeLabel,
@@ -2846,6 +2854,10 @@ async function runAgentMaintenancePlanAndExecute(
     conclusion: gate.conclusion,
     action: disposition.actionClass,
     reasonCode: disposition.blockerClass === "none" ? gate.conclusion : disposition.blockerClass,
+    // #2352: this row is the ACTUAL autonomous disposition that the precision breaker evaluates, so preserve
+    // the same miner-authored scope as the gate-check audit row below. Omitting it defaults to non-miner and can
+    // erase a prior miner-authored prediction for the same head.
+    minerAuthored: breakerMinerAuthored,
   });
   // #2349 (PR 1): additive per-contributor calibration data, gated identically to recordNativeGateDecision
   // above -- see src/review/contributor-calibration.ts's doc comment. Currently write-only; nothing reads

--- a/src/review/outcomes-wire.ts
+++ b/src/review/outcomes-wire.ts
@@ -60,14 +60,22 @@ function flagTruthy(v: string | null | undefined): boolean {
 
 /** Is auto-merge disabled (would-merge → hold) for this project (or globally)? Fail-OPEN (false) on a DB error.
  *  This is the read the merge path consults to downgrade a would-MERGE into a HOLD. */
-export async function isHoldOnly(env: Env, project: string): Promise<boolean> {
+export async function isHoldOnly(
+  env: Env,
+  project: string,
+  minerAuthored = false,
+): Promise<boolean> {
   try {
     const res = await env.DB.prepare(
       "SELECT key, value FROM system_flags",
     ).all<{ key: string; value: string }>();
     const set = new Set<string>();
     for (const r of res.results ?? []) if (flagTruthy(r.value)) set.add(r.key);
-    return set.has("holdonly:global") || set.has(`holdonly:${project}`);
+    return (
+      set.has("holdonly:global") ||
+      set.has(`holdonly:${project}`) ||
+      (minerAuthored && set.has(`holdonly:${minerBreakerScope(project)}`))
+    );
   } catch (error) {
     console.warn(
       JSON.stringify({
@@ -86,6 +94,7 @@ export async function isHoldOnly(env: Env, project: string): Promise<boolean> {
 export async function isCloseHoldOnly(
   env: Env,
   project: string,
+  minerAuthored = false,
 ): Promise<boolean> {
   try {
     const res = await env.DB.prepare(
@@ -93,7 +102,11 @@ export async function isCloseHoldOnly(
     ).all<{ key: string; value: string }>();
     const set = new Set<string>();
     for (const r of res.results ?? []) if (flagTruthy(r.value)) set.add(r.key);
-    return set.has("closehold:global") || set.has(`closehold:${project}`);
+    return (
+      set.has("closehold:global") ||
+      set.has(`closehold:${project}`) ||
+      (minerAuthored && set.has(`closehold:${minerBreakerScope(project)}`))
+    );
   } catch (error) {
     console.warn(
       JSON.stringify({

--- a/test/unit/outcomes-wire.test.ts
+++ b/test/unit/outcomes-wire.test.ts
@@ -526,6 +526,17 @@ describe("isHoldOnly + createFlagStore (system_flags, migration 0054)", () => {
     expect(await isHoldOnly(env, "any/repo")).toBe(true);
   });
 
+  it("enforces a miner-scoped holdonly flag only for confirmed miner-authored PRs", async () => {
+    const env = createTestEnv();
+    const flags = createFlagStore(env);
+    await flags.setFlag("holdonly:owner/repo:miner", true);
+
+    expect(await isHoldOnly(env, "owner/repo")).toBe(false);
+    expect(await isHoldOnly(env, "owner/repo", false)).toBe(false);
+    expect(await isHoldOnly(env, "owner/repo", true)).toBe(true);
+    expect(await isHoldOnly(env, "owner/other", true)).toBe(false);
+  });
+
   it("flagSetAt round-trips the updated_at and is null when unset", async () => {
     const env = createTestEnv();
     const flags = createFlagStore(env);
@@ -550,6 +561,17 @@ describe("isCloseHoldOnly + createFlagStore.isCloseHoldOnly (closehold:<scope>, 
     // global close breaker applies to every project.
     await flags.setFlag("closehold:global", true);
     expect(await isCloseHoldOnly(env, "any/repo")).toBe(true);
+  });
+
+  it("enforces a miner-scoped closehold flag only for confirmed miner-authored PRs", async () => {
+    const env = createTestEnv();
+    const flags = createFlagStore(env);
+    await flags.setFlag("closehold:owner/repo:miner", true);
+
+    expect(await isCloseHoldOnly(env, "owner/repo")).toBe(false);
+    expect(await isCloseHoldOnly(env, "owner/repo", false)).toBe(false);
+    expect(await isCloseHoldOnly(env, "owner/repo", true)).toBe(true);
+    expect(await isCloseHoldOnly(env, "owner/other", true)).toBe(false);
   });
 
   it("createFlagStore.isCloseHoldOnly reads the per-project closehold key (not the global one)", async () => {


### PR DESCRIPTION
### Motivation
- A miner-scoped auto-tune pass started writing per-project flags suffixed with `:miner`, but the live merge/close decision path only checked unsuffixed flags, so miner-authored PRs could still be auto-merged/closed despite a miner-only breaker engaging. 
- The autonomous-action audit write omitted the `minerAuthored` field, risking overwriting miner-scoped audit rows and losing the miner-scoped signal.

### Description
- Added an optional `minerAuthored` parameter to `isHoldOnly` and `isCloseHoldOnly` and made those readers also check the suffixed `:<repo>:miner` flags via `minerBreakerScope` when the caller indicates a miner-authored PR. 
- In the live planner (`runAgentMaintenancePlanAndExecute`) resolve whether the PR author is a confirmed miner using `getCachedOfficialMinerDetection`, pass that boolean into `isHoldOnly`/`isCloseHoldOnly`, and use it when evaluating precision breakers so miner-scoped flags actually affect miner-originated actions. 
- Preserve `minerAuthored` on the actual autonomous disposition audit row by passing the resolved miner scope into `recordNativeGateDecision` so audit/state stays consistent with the evaluation scope. 
- Added unit tests in `test/unit/outcomes-wire.test.ts` that assert miner-scoped `holdonly`/`closehold` flags only apply for confirmed miner-authored PRs and that existing flag behaviour remains unchanged.

### Testing
- Ran `git diff --check` to validate whitespace/conflict hygiene; no issues found. 
- Ran type-checking with `npm run typecheck`; it succeeded with no TS errors. 
- Ran unit tests `npx vitest run test/unit/outcomes-wire.test.ts test/unit/parity-wire.test.ts`; both test files passed (all relevant assertions succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5358060128832c8db43cd69a3e53d4)