### PR TITLE
fix(chat): target publicSafeSummary in the private-lane-signal redaction test

### DIFF
--- a/test/unit/ai-chat-qa.test.ts
+++ b/test/unit/ai-chat-qa.test.ts
@@ -262,12 +262,11 @@ describe("generateChatQaAnswer", () => {
     const run = vi.fn(async () => ({ response: "Public-safe readiness answer." }));
     const env = createTestEnv({ AI_ADVISORY: { run } as unknown as Ai, AI_DAILY_NEURON_BUDGET: "10000" });
     const result = await generateChatQaAnswer(env, {
+      // publicSafeSummary (unlike why/blockedBy, dropped from the grounding bundle entirely -- #5106) is the
+      // one action field that still reaches redactGroundingText, so it's the field this test must seed.
       bundle: bundleFixture(undefined, {
-        why: [
-          "owner/repo: Maintainer cut: 1.",
-          "owner/repo: split lane (direct PR 1, issue-discovery 1); both lanes are useful here.",
-          "owner/repo: direct PR lane share 1 with no hard personal blocker.",
-        ],
+        publicSafeSummary:
+          "owner/repo: Maintainer cut: 1. owner/repo: split lane (direct PR 1, issue-discovery 1); both lanes are useful here. owner/repo: direct PR lane share 1 with no hard personal blocker.",
       }),
       question: "what should I know?",
       advisoryAiRouting: ADVISORY_ON,


### PR DESCRIPTION
## Summary
- Fixes a test currently failing on `main` (CI red since the #5149/#5106 merge sequence).
- #5149's private-lane-signal redaction test seeded the private-lane phrasing into the action's `why` field. #5106 (merged earlier the same session) had already dropped `why`/`blockedBy` from the grounding bundle entirely as a stronger data-minimization boundary. Neither PR conflicted textually, but combined, the test now asserts on content that never reaches the prompt.
- Retargets the test fixture to `publicSafeSummary`, the one action field #5106 still forwards through `redactGroundingText` — restores the test's actual intent (private-lane phrasing gets redacted before the prompt is built) against current behavior.

## Validation
- `npx vitest run test/unit/ai-chat-qa.test.ts` — 31/31 passing (was 1 failing on main).
- `npm run typecheck` — clean.
- Test-only change; no `src/**` production code touched.