### PR TITLE
fix(miner-governor): require global live opt-in

### DIFF
--- a/packages/gittensory-engine/src/governor/action-mode.ts
+++ b/packages/gittensory-engine/src/governor/action-mode.ts
@@ -23,7 +23,7 @@ export type MinerActionMode = "paused" | "dry_run" | "live";
 export const MINER_LIVE_MODE_OPT_IN = "live";
 
 /** Env var an operator sets (to exactly {@link MINER_LIVE_MODE_OPT_IN}) to opt their own miner instance into
- *  live write execution, independent of any per-repo `.gittensory-miner.yml` opt-in. */
+ *  live write execution. Repo-side opt-in alone is never enough to execute writes. */
 export const MINER_LIVE_MODE_ENV_VAR = "GITTENSORY_MINER_LIVE_MODE";
 
 /** True only when `value` is EXACTLY the {@link MINER_LIVE_MODE_OPT_IN} string -- no truthy coercion, no case
@@ -40,14 +40,16 @@ export function isGlobalMinerLiveModeOptIn(env: Record<string, string | undefine
 /**
  * Resolve the miner's overall action mode. Precedence (safest wins, mirroring `resolveAgentActionMode`):
  * 1. Kill-switch active (either scope, #2341) -> `"paused"` -- always wins, regardless of any live-mode opt-in.
- * 2. An explicit live-mode opt-in from EITHER the operator's global env config OR the target repo's own
- *    `.gittensory-miner.yml` (`MinerGoalSpec.execution.liveModeOptIn`) -> `"live"`.
- * 3. Otherwise -> `"dry_run"`. No config anywhere, or a malformed/partial config that fails to normalize to the
- *    exact opt-in literal, both fall through to this branch -- absence or ambiguity always means dry-run.
+ * 2. BOTH the operator's global env config AND the target repo's own `.gittensory-miner.yml`
+ *    (`MinerGoalSpec.execution.liveModeOptIn`) explicitly opt in -> `"live"`. The repo field is a repo-side
+ *    allowance, not an operator-authored authorization to execute writes under the miner's credentials.
+ * 3. Otherwise -> `"dry_run"`. No config anywhere, either side omitted, or a malformed/partial config that fails
+ *    to normalize to the exact opt-in literal, all fall through to this branch -- absence or ambiguity always
+ *    means dry-run.
  *
  * A target repo that wants to guarantee it never receives live automated writes -- even from an operator whose
- * own miner instance is globally live -- sets its OWN kill-switch (`killSwitch.paused: true`, #2341), which
- * takes precedence over any live-mode opt-in per step 1 above; this module does not duplicate that mechanism.
+ * own miner instance is globally live -- can omit its repo opt-in or set its OWN kill-switch (`killSwitch.paused:
+ * true`, #2341), which takes precedence over any live-mode opt-in per step 1 above.
  */
 export function resolveMinerActionMode(input: {
   killSwitchScope: MinerKillSwitchScope;
@@ -55,7 +57,7 @@ export function resolveMinerActionMode(input: {
   globalLiveModeOptIn: boolean;
 }): MinerActionMode {
   if (isMinerKillSwitchActive(input.killSwitchScope)) return "paused";
-  if (input.globalLiveModeOptIn || isExplicitMinerLiveModeOptIn(input.repoLiveModeOptIn)) return "live";
+  if (input.globalLiveModeOptIn && isExplicitMinerLiveModeOptIn(input.repoLiveModeOptIn)) return "live";
   return "dry_run";
 }
 

--- a/packages/gittensory-engine/test/action-mode.test.ts
+++ b/packages/gittensory-engine/test/action-mode.test.ts
@@ -52,16 +52,23 @@ test("resolveMinerActionMode: malformed/partial opt-in values fail closed to dry
   }
 });
 
-test("resolveMinerActionMode: the exact repo-side opt-in flips to live", () => {
+test("resolveMinerActionMode: the exact repo-side opt-in alone stays dry_run without operator opt-in", () => {
   assert.equal(
     resolveMinerActionMode({ killSwitchScope: "none", repoLiveModeOptIn: "live", globalLiveModeOptIn: false }),
-    "live",
+    "dry_run",
   );
 });
 
-test("resolveMinerActionMode: the global operator opt-in alone also flips to live", () => {
+test("resolveMinerActionMode: the global operator opt-in alone also stays dry_run without repo opt-in", () => {
   assert.equal(
     resolveMinerActionMode({ killSwitchScope: "none", repoLiveModeOptIn: undefined, globalLiveModeOptIn: true }),
+    "dry_run",
+  );
+});
+
+test("resolveMinerActionMode: both repo and operator opt-ins are required for live", () => {
+  assert.equal(
+    resolveMinerActionMode({ killSwitchScope: "none", repoLiveModeOptIn: "live", globalLiveModeOptIn: true }),
     "live",
   );
 });

--- a/packages/gittensory-engine/test/chokepoint.test.ts
+++ b/packages/gittensory-engine/test/chokepoint.test.ts
@@ -12,7 +12,7 @@ function baseInput(overrides: Partial<GovernorChokepointInput> = {}): GovernorCh
     killSwitchGlobal: false,
     killSwitchRepoPaused: false,
     liveModeGlobalOptIn: true,
-    liveModeRepoOptIn: undefined,
+    liveModeRepoOptIn: "live",
     rateLimitBuckets: { global: {}, perRepo: {} },
     rateLimitBackoffAttempts: {},
     capUsage: { budgetSpent: 0, turnsTaken: 0, elapsedMs: 0 },
@@ -195,8 +195,15 @@ test("fail-closed: a self-plagiarism calculator error denies rather than silentl
   assert.match(decision.reason, /self_plagiarism_calculator_error/);
 });
 
-test("the repo-side live opt-in alone (no global env opt-in) is sufficient to reach the resource stages", () => {
+test("the repo-side live opt-in alone (no global env opt-in) stays dry_run before resource stages", () => {
   const decision = evaluateGovernorChokepoint(baseInput({ liveModeGlobalOptIn: false, liveModeRepoOptIn: "live" }));
+  assert.equal(decision.mode, "dry_run");
+  assert.equal(decision.stage, "dry_run");
+  assert.equal(decision.allowed, false);
+});
+
+test("both repo-side and global live opt-ins are required to reach the resource stages", () => {
+  const decision = evaluateGovernorChokepoint(baseInput({ liveModeGlobalOptIn: true, liveModeRepoOptIn: "live" }));
   assert.equal(decision.mode, "live");
   assert.equal(decision.allowed, true);
 });

--- a/packages/gittensory-miner/lib/governor-action-mode.js
+++ b/packages/gittensory-miner/lib/governor-action-mode.js
@@ -1,6 +1,6 @@
 // Governor dry-run-by-default gate (#2342). Resolves the miner's overall action mode (paused > dry_run > live,
 // "safest wins") and records dry-run SHADOW actions to the append-only governor ledger. A freshly-configured
-// miner defaults to dry_run -- live execution requires an explicit, hard-to-fat-finger opt-in.
+// miner defaults to dry_run -- live execution requires explicit, hard-to-fat-finger operator and repo opt-ins.
 
 import {
   buildMinerDryRunGovernorLedgerEvent,
@@ -13,7 +13,7 @@ import { appendGovernorEvent } from "./governor-ledger.js";
 /**
  * Resolve the miner's overall action mode from the kill-switch scope (see `checkMinerKillSwitch` in
  * `./governor-kill-switch.js`), the repo's own `.gittensory-miner.yml` opt-in, and the operator's global env
- * opt-in.
+ * opt-in. Both sides must opt in before real writes execute; repo config alone only preserves dry-run.
  *
  * @param {object} input
  * @param {import("@jsonbored/gittensory-engine").MinerKillSwitchScope} input.killSwitchScope

--- a/test/unit/miner-attempt-runner.test.ts
+++ b/test/unit/miner-attempt-runner.test.ts
@@ -103,7 +103,7 @@ function allowingGovernorContext(overrides: Record<string, unknown> = {}) {
     killSwitchGlobal: false,
     killSwitchRepoPaused: false,
     liveModeGlobalOptIn: true,
-    liveModeRepoOptIn: undefined,
+    liveModeRepoOptIn: "live",
     rateLimitBuckets: { global: {}, perRepo: {} },
     rateLimitBackoffAttempts: {},
     capUsage: { budgetSpent: 0, turnsTaken: 0, elapsedMs: 0 },

--- a/test/unit/miner-governor-action-mode.test.ts
+++ b/test/unit/miner-governor-action-mode.test.ts
@@ -26,16 +26,26 @@ describe("resolveMinerActionModeGate (#2342)", () => {
     });
   });
 
-  it("the repo's exact opt-in flips to live", () => {
+  it("the repo's exact opt-in alone stays dry_run without operator opt-in", () => {
     expect(resolveMinerActionModeGate({ killSwitchScope: "none", repoLiveModeOptIn: "live", env: {} })).toEqual({
-      mode: "live",
-      executes: true,
+      mode: "dry_run",
+      executes: false,
     });
   });
 
-  it("the operator's global env opt-in alone also flips to live", () => {
+  it("the operator's global env opt-in alone also stays dry_run without repo opt-in", () => {
     expect(
       resolveMinerActionModeGate({ killSwitchScope: "none", env: { GITTENSORY_MINER_LIVE_MODE: "live" } }),
+    ).toEqual({ mode: "dry_run", executes: false });
+  });
+
+  it("requires both repo and operator opt-ins for live execution", () => {
+    expect(
+      resolveMinerActionModeGate({
+        killSwitchScope: "none",
+        repoLiveModeOptIn: "live",
+        env: { GITTENSORY_MINER_LIVE_MODE: "live" },
+      }),
     ).toEqual({ mode: "live", executes: true });
   });
 
@@ -55,7 +65,10 @@ describe("resolveMinerActionModeGate (#2342)", () => {
     const original = process.env.GITTENSORY_MINER_LIVE_MODE;
     try {
       process.env.GITTENSORY_MINER_LIVE_MODE = "live";
-      expect(resolveMinerActionModeGate({ killSwitchScope: "none" })).toEqual({ mode: "live", executes: true });
+      expect(resolveMinerActionModeGate({ killSwitchScope: "none", repoLiveModeOptIn: "live" })).toEqual({
+        mode: "live",
+        executes: true,
+      });
     } finally {
       if (original === undefined) delete process.env.GITTENSORY_MINER_LIVE_MODE;
       else process.env.GITTENSORY_MINER_LIVE_MODE = original;

--- a/test/unit/miner-governor-chokepoint-persisted.test.ts
+++ b/test/unit/miner-governor-chokepoint-persisted.test.ts
@@ -44,7 +44,7 @@ function baseInput(overrides: Record<string, unknown> = {}) {
     killSwitchGlobal: false,
     killSwitchRepoPaused: false,
     liveModeGlobalOptIn: true,
-    liveModeRepoOptIn: undefined,
+    liveModeRepoOptIn: "live",
     capLimits: { budget: 100, turns: 100, elapsedMs: 1_000_000 },
     convergenceInput: { attempts: 0, consecutiveFailures: 0, reenqueues: 0, reachedDone: false },
     ...overrides,

--- a/test/unit/miner-governor-chokepoint.test.ts
+++ b/test/unit/miner-governor-chokepoint.test.ts
@@ -22,7 +22,7 @@ function baseInput(overrides: Record<string, unknown> = {}) {
     killSwitchGlobal: false,
     killSwitchRepoPaused: false,
     liveModeGlobalOptIn: true,
-    liveModeRepoOptIn: undefined,
+    liveModeRepoOptIn: "live",
     rateLimitBuckets: { global: {}, perRepo: {} },
     rateLimitBackoffAttempts: {},
     capUsage: { budgetSpent: 0, turnsTaken: 0, elapsedMs: 0 },


### PR DESCRIPTION
### Motivation
- Close a safety gap where a repository's `.gittensory-miner.yml` `execution.liveModeOptIn: "live"` could enable real miner writes without the operator explicitly opting the miner into live mode. 
- Align runtime behavior with the documented/type-level safety boundary that the operator must opt in globally and the repo must opt in on its side before live writes execute.

### Description
- Require both operator global opt-in and repo manifest opt-in for live mode by changing the resolver from an `OR` to an `AND` (`resolveMinerActionMode` now requires `globalLiveModeOptIn && repoLiveModeOptIn === "live"`).
- Update comments and the miner wrapper (`packages/gittensory-miner/lib/governor-action-mode.js`) to document that the repo field is an allowance, not a standalone authorization.
- Update tests in `packages/gittensory-engine` and `packages/gittensory-miner` to assert that repo-only and global-only opt-ins remain `dry_run` and that both opt-ins are required for `live` execution.
- Regenerate Cloudflare worker runtime types (`worker-configuration.d.ts`) to satisfy local drift checks.

### Testing
- Ran `npm --workspace @jsonbored/gittensory-engine run build` and the engine build succeeded. 
- Ran the engine unit suite (`npm run test --workspace @jsonbored/gittensory-engine`) and targeted vitest files (`npx vitest run test/unit/miner-governor-action-mode.test.ts test/unit/miner-governor-chokepoint.test.ts`) and they passed. 
- Ran `npm run cf-typegen` which regenerated `worker-configuration.d.ts` successfully. 
- Attempted the full local gate `npm run test:ci` but it encountered unrelated long-running/timeout failures in other integration/queue/backfill tests and network-dependent `actionlint` setup issues, so the full gate was not completed here; `npm audit --audit-level=moderate` also failed with a registry 403 during the audit step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a535804ef80832cabacace99e1363b0)