### PR TITLE
fix(selfhost): mount observability/backup scripts as directories, not single files

### DIFF
--- a/apps/gittensory-ui/src/routes/docs.self-hosting-backup-scaling.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-backup-scaling.tsx
@@ -155,8 +155,8 @@ npm run selfhost:postgres:migrate -- --sqlite /data/gittensory.sqlite --execute`
       </p>
       <CodeBlock
         lang="bash"
-        code={`docker compose --profile backup run --rm backup sh /verify-backup.sh
-docker compose --profile backup run --rm backup sh /verify-backup.sh /backups/postgres/gittensory-<timestamp>.dump`}
+        code={`docker compose --profile backup run --rm backup sh /scripts/verify-backup.sh
+docker compose --profile backup run --rm backup sh /scripts/verify-backup.sh /backups/postgres/gittensory-<timestamp>.dump`}
       />
       <p>
         A healthy run ends with <code>[verify] postgres archive OK: … (N TOC entries)</code> (or{" "}
@@ -173,7 +173,7 @@ docker compose --profile backup run --rm backup sh /verify-backup.sh /backups/po
         code={`docker compose --profile backup run --rm \\
   -e VERIFY_RESTORE_SCRATCH=1 \\
   -e GITTENSORY_VERIFY_SCRATCH_DATABASE_URL=postgres://user:pass@host:5432/gittensory_verify \\
-  backup sh /verify-backup.sh`}
+  backup sh /scripts/verify-backup.sh`}
       />
       <Callout variant="warn">
         The scratch restore runs <code>pg_restore --clean</code> against{" "}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -680,7 +680,15 @@ services:
       # The exporter needs live DB read access to build the redacted snapshot. Grafana does not get this mount.
       - gittensory-data:/appdb:ro
       - grafana-reporting-data:/reporting
-      - ./scripts/export-grafana-reporting-db.sh:/export-grafana-reporting-db.sh:ro
+      # A DIRECTORY bind mount, not a single-file one (#reporting-exporter-stale-bind-mount): a single-file
+      # bind mount pins the container to the file's INODE at container-creation time. `git pull` replaces a
+      # file by writing a new blob then renaming it over the old path -- the old inode still exists on disk
+      # until every reference (including this bind mount) is dropped, so the running container keeps reading
+      # the pre-pull script forever, silently, with no error. Confirmed live: a script change survived
+      # multiple `git pull`s with zero effect until the container was force-recreated. Directory bind mounts
+      # don't have this problem -- they resolve the path fresh on every access, exactly like dashboard
+      # provisioning below already does.
+      - ./scripts:/scripts:ro
     environment:
       # Default SQLite app DB path maps app /data/gittensory.sqlite to exporter /appdb/gittensory.sqlite.
       # If you override DATABASE_PATH, set this to the matching /appdb/<file> path. When DATABASE_URL points at
@@ -698,7 +706,7 @@ services:
       - >-
         apk add --no-cache sqlite postgresql16-client >/dev/null 2>&1 &&
         while true; do
-          sh /export-grafana-reporting-db.sh || echo '[reporting] export failed';
+          sh /scripts/export-grafana-reporting-db.sh || echo '[reporting] export failed';
           interval="$${GRAFANA_REPORTING_EXPORT_INTERVAL_SECONDS:-30}";
           case "$$interval" in ''|*[!0-9]*) interval=30;; esac;
           sleep "$$interval";
@@ -910,9 +918,9 @@ services:
   # ── Backups (--profile backup) ────────────────────────────────────────────
   # Active database backup (Postgres pg_dump or WAL-safe SQLite online backup) + a Qdrant snapshot, on a loop
   # (default daily), kept in the gittensory-backups volume with retention. Run on demand:
-  #   docker compose --profile backup run --rm backup sh /backup.sh
+  #   docker compose --profile backup run --rm backup sh /scripts/backup.sh
   # Verify the newest backup is restorable (pg_restore --list / SQLite integrity_check; opt-in scratch restore):
-  #   docker compose --profile backup run --rm backup sh /verify-backup.sh
+  #   docker compose --profile backup run --rm backup sh /scripts/verify-backup.sh
   backup:
     image: alpine:3.20
     restart: unless-stopped
@@ -932,13 +940,15 @@ services:
       # RW (not :ro) so SQLite's online-backup can use the WAL index; the script only ever reads the DB.
       - gittensory-data:/data
       - gittensory-backups:/backups
-      - ./scripts/backup.sh:/backup.sh:ro
-      - ./scripts/verify-backup.sh:/verify-backup.sh:ro
-      # Shared url_decode/pgpass_escape helpers (#2910), sourced by both scripts above via
-      # `. "$(dirname "$0")/selfhost-pg-url.sh"` -- must be mounted at container root alongside them so that
-      # dirname-relative resolution finds it at /selfhost-pg-url.sh, the same way it finds
-      # scripts/selfhost-pg-url.sh when either script is run directly from a repo checkout.
-      - ./scripts/selfhost-pg-url.sh:/selfhost-pg-url.sh:ro
+      # A DIRECTORY bind mount, not individual-file mounts (#reporting-exporter-stale-bind-mount): a
+      # single-file bind mount pins the container to that file's INODE at container-creation time, so a
+      # later `git pull` (which replaces a file via write-new-then-rename, not an in-place edit) leaves the
+      # running container reading the pre-pull script forever with no error -- confirmed live on the
+      # reporting-exporter service, which had exactly this mount shape. Mounting the directory also
+      # naturally satisfies backup.sh/verify-backup.sh's own `. "$(dirname "$0")/selfhost-pg-url.sh"`
+      # dirname-relative sourcing: invoked as /scripts/backup.sh, dirname resolves to /scripts, finding
+      # /scripts/selfhost-pg-url.sh right alongside it -- the same layout a bare repo checkout already has.
+      - ./scripts:/scripts:ro
     # `docker compose run --rm backup sh /backup.sh` (or /verify-backup.sh) REPLACES `command:`, not
     # `entrypoint:`, so the package install must live in the entrypoint or an on-demand run gets a bare
     # container with no pg_restore/sqlite3/psql. The entrypoint installs packages once, then `exec "$@"`
@@ -954,7 +964,7 @@ services:
     command:
       - sh
       - -c
-      - "while true; do sh /backup.sh || echo '[backup] run failed'; sleep ${BACKUP_INTERVAL_SECONDS:-86400}; done"
+      - "while true; do sh /scripts/backup.sh || echo '[backup] run failed'; sleep ${BACKUP_INTERVAL_SECONDS:-86400}; done"
 
   # Read-only backup freshness exporter. It serves file-age metrics from the retained backup volume so
   # Prometheus can alert on missing or stale database backups without Grafana reading the live app DB.
@@ -965,13 +975,15 @@ services:
     profiles: ["backup"]
     volumes:
       - gittensory-backups:/backups:ro
-      - ./scripts/backup-metrics.sh:/backup-metrics.sh:ro
+      # Directory mount, not a single-file one -- same #reporting-exporter-stale-bind-mount rationale as
+      # the backup service above.
+      - ./scripts:/scripts:ro
     expose:
       - "9101"
     command:
       - /bin/sh
       - -c
-      - "apk add --no-cache busybox-extras && sh /backup-metrics.sh"
+      - "apk add --no-cache busybox-extras && sh /scripts/backup-metrics.sh"
     healthcheck:
       test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:9101/metrics | grep -q '^gittensory_backup_latest_timestamp_seconds'"]
       interval: 30s

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Self-host backup: active DB backup (Postgres dump or online SQLite backup) + a Qdrant snapshot, with retention.
 # Run by the `backup` compose service (--profile backup) on a loop, or on demand:
-#   docker compose --profile backup run --rm backup sh /backup.sh
+#   docker compose --profile backup run --rm backup sh /scripts/backup.sh
 # Backups land in the `gittensory-backups` volume at /backups/{postgres,sqlite,qdrant}.
 set -eu
 

--- a/scripts/verify-backup.sh
+++ b/scripts/verify-backup.sh
@@ -5,8 +5,8 @@
 # temp copy. An OPT-IN scratch restore (VERIFY_RESTORE_SCRATCH=1 + a dedicated scratch DB URL) additionally
 # restores the Postgres dump into a throwaway database and runs a sanity query — it refuses to touch the live
 # database. Run on demand (newest backup, or a specific file):
-#   docker compose --profile backup run --rm backup sh /verify-backup.sh
-#   docker compose --profile backup run --rm backup sh /verify-backup.sh /backups/postgres/gittensory-<ts>.dump
+#   docker compose --profile backup run --rm backup sh /scripts/verify-backup.sh
+#   docker compose --profile backup run --rm backup sh /scripts/verify-backup.sh /backups/postgres/gittensory-<ts>.dump
 set -eu
 
 OUT=${BACKUP_OUT_DIR:-/backups}

--- a/test/unit/selfhost-observability-config.test.ts
+++ b/test/unit/selfhost-observability-config.test.ts
@@ -110,13 +110,13 @@ describe("self-host observability trace config", () => {
     expect(backupExporter.volumes).toEqual(
       expect.arrayContaining([
         "gittensory-backups:/backups:ro",
-        "./scripts/backup-metrics.sh:/backup-metrics.sh:ro",
+        "./scripts:/scripts:ro",
       ]),
     );
     expect(backupExporter.command).toEqual([
       "/bin/sh",
       "-c",
-      "apk add --no-cache busybox-extras && sh /backup-metrics.sh",
+      "apk add --no-cache busybox-extras && sh /scripts/backup-metrics.sh",
     ]);
     expect(backupExporter.healthcheck?.test).toEqual([
       "CMD-SHELL",


### PR DESCRIPTION
## Summary

Found while verifying the Reviews & PRs dashboard fix (#5234): the `reporting-exporter` service bind-mounted `export-grafana-reporting-db.sh` as a **single file**. Docker pins a single-file bind mount to that file's inode at container-creation time — `git pull` replaces a file by writing a new blob then renaming it over the old path, so the running container kept reading the pre-pull script indefinitely with **no error**. Confirmed live: a script edit had zero effect across several `git pull`s on the deployment server until the container was force-recreated (`docker compose up -d --force-recreate --no-deps reporting-exporter`) — verified via `md5sum` mismatch between the host file and what the running container actually saw.

The same mount shape existed on the `backup` and `backup-exporter` services, for `backup.sh`, `verify-backup.sh`, `selfhost-pg-url.sh`, and `backup-metrics.sh` — meaning a backup-script fix would silently never take effect either, without anyone noticing until a real restore was needed.

## Fix

Switched all of these to directory bind mounts (`./scripts:/scripts:ro`), which resolve paths fresh on every access instead of pinning an inode — the same pattern `grafana/dashboards` already used (a directory mount), which is exactly why the dashboard JSON itself always updated correctly on this same deployment while the exporter script silently didn't.

Bonus: the directory mount also naturally satisfies `backup.sh`/`verify-backup.sh`'s existing `. "$(dirname "$0")/selfhost-pg-url.sh"` dirname-relative sourcing (invoked as `/scripts/backup.sh`, `dirname` resolves to `/scripts`, finding `/scripts/selfhost-pg-url.sh` right alongside it) — removing the need for the old comment explaining why that file had to be mounted at container root.

## Scope

- [x] Conventional Commit title.
- [x] Focused to the mount-shape bug across the 2 affected services; no unrelated changes.
- [x] Follows `CONTRIBUTING.md`.
- [ ] Linked issue — not applicable; owner-authored fix discovered during live verification of a prior PR.

## Validation

- [x] `git diff --check`
- [x] `docker compose -f docker-compose.yml config --quiet`
- [x] `node scripts/validate-observability-configs.mjs`
- [x] `sh -n scripts/backup.sh` / `sh -n scripts/verify-backup.sh`
- [x] `npx vitest run test/unit/selfhost-observability-config.test.ts` — 4/4 pass (updated the one assertion on the old mount/command shape)
- [x] `npm run ui:typecheck` / `ui:lint` (for the one docs page's usage-comment update)
- [x] `npm run docs:drift-check`
- [x] **Live-verified on the deployment server**: force-recreated `reporting-exporter`, confirmed via `md5sum` that the container now sees the current script, confirmed a fresh export completes successfully and the new `issues` table populates correctly.

If any required check was skipped, explain why:

- No `src/**` production logic changed — this is entirely `docker-compose.yml`, shell-script comments, one doc page's code-block text, and one test's fixture expectations.

## Safety

- [x] No secrets, tokens, or private values exposed.
- [x] Public GitHub text stays sanitized.
- [x] Public docs updated (`docs.self-hosting-backup-scaling.tsx`'s usage examples).

## UI Evidence

Not applicable — a docs-page code-sample text change only, no visual/layout difference.

## Notes

This is a real, previously-unnoticed operational gap: any self-hoster who edited `export-grafana-reporting-db.sh`, `backup.sh`, `verify-backup.sh`, or `backup-metrics.sh` and expected `git pull` alone to pick it up would have been silently running stale logic indefinitely, with the container reporting healthy the whole time.