### PR TITLE
docs(self-hosting): fix stale blockedPaths and hardGuardrailGlobs claims

### DIFF
--- a/.gittensory.yml.example
+++ b/.gittensory.yml.example
@@ -48,18 +48,21 @@
 # ----------------------------------------------------------------------------
 # 1. FOCUS / GUARDRAILS (focus manifest)
 # ----------------------------------------------------------------------------
-# Declares the repo's work areas and off-limits paths. These feed deterministic
-# findings (e.g. manifest_blocked_path, manifest_missing_tests) and — when
-# `gate.manifestPolicy: block` is set below — can become enforceable blockers.
+# Declares the repo's work areas and off-limits paths. wantedPaths/blockedPaths feed advisory-only
+# guidance findings; testExpectations/linkedIssuePolicy feed manifest_missing_tests and
+# manifest_linked_issue_required, which — when `gate.manifestPolicy: block` is set below — can become
+# enforceable blockers. Hard path HOLDS are a separate mechanism: settings.hardGuardrailGlobs, below.
 
 # Work areas the maintainer wants. PRs touching these are preferred/encouraged.
 # Glob list. Default: [] (no preference).
 wantedPaths:
   - "src/**"
 
-# Paths off-limits to contributors. Touching one yields a manifest_blocked_path
-# finding (enforceable when `gate.manifestPolicy: block`).
-# Glob list. Default: [] (nothing blocked).
+# Paths off-limits to contributors — CONTRIBUTOR-FACING GUIDANCE ONLY. Touching one surfaces in
+# onboarding guidance and gittensory's own risk-reason commentary; it never blocks, holds, or produces
+# a gate finding, even under gate.manifestPolicy: block. The only mechanism that actually holds a PR
+# for a touched path is settings.hardGuardrailGlobs, below.
+# Glob list. Default: [] (nothing listed).
 blockedPaths:
   - "vendor/**"
   - ".github/workflows/**"
@@ -660,9 +663,11 @@ settings:
   # of this setting. Bool. Default: false.
   closeOwnerAuthors: false
 
-  # Hard manual-review path guardrails are config-as-code only. Omit or use [] for no path guardrails;
-  # set concrete globs when otherwise-mergeable PRs touching those paths must be held for a person.
-  # This never falls back to hidden engine path defaults.
+  # Hard manual-review path guardrails are config-as-code only. Configured globs are ADDED to a fixed
+  # set of built-in invariant guardrails (config-as-code files, CI workflows/scripts, and core
+  # engine-decision paths — see DEFAULT_HARD_GUARDRAIL_GLOBS in src/review/guardrail-config.ts) that
+  # always apply and can never be disabled from here. Omit or use [] to rely on just those built-in
+  # invariants, with no repo-specific additions.
   hardGuardrailGlobs: []
 
   # Require a linked issue on every PR (dashboard equivalent of the toggle that

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-configuration.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-configuration.tsx
@@ -84,9 +84,11 @@ function SelfHostingConfiguration() {
         same fields — so a value written under both <code>gate.duplicates</code> and{" "}
         <code>settings.duplicates</code> resolves to whatever <code>gate.duplicates</code> says. One
         exception to the whole precedence chain: hard path guardrails (
-        <code>settings.hardGuardrailGlobs</code>) are config-as-code only — omitted or empty means
-        no path guardrails, never a hidden engine fallback, regardless of what the database row or
-        defaults would otherwise imply.
+        <code>settings.hardGuardrailGlobs</code>) are config-as-code only — a configured list ADDS
+        repo-specific globs on top of a fixed set of built-in invariant guardrails (config-as-code
+        files, CI workflows/scripts, and core engine-decision paths) that always apply and can never
+        be disabled. Omitted or empty means only those built-in invariants hold, regardless of what
+        the database row or defaults would otherwise imply.
       </p>
       <p>
         This page covers the environment layer and the shape of the config file. For the full field

--- a/apps/gittensory-ui/src/routes/docs.tuning.tsx
+++ b/apps/gittensory-ui/src/routes/docs.tuning.tsx
@@ -85,9 +85,10 @@ function Tuning() {
         <li>built-in safe defaults.</li>
       </ul>
       <p>
-        Path holds are explicit config-as-code only: omitted or empty{" "}
-        <code>settings.hardGuardrailGlobs</code> means no path guardrails, not a hidden engine
-        fallback.
+        Path holds are explicit config-as-code only: a configured{" "}
+        <code>settings.hardGuardrailGlobs</code> ADDS repo-specific globs on top of a fixed set of
+        built-in invariant guardrails that always apply and can never be disabled. Omitted or empty
+        means only those built-in invariants hold.
       </p>
       <p>
         The friendly <code>gate:</code> block in <code>.gittensory.yml</code> is a typed alias for

--- a/config/examples/gittensory.full.yml
+++ b/config/examples/gittensory.full.yml
@@ -61,18 +61,21 @@
 # ----------------------------------------------------------------------------
 # 1. FOCUS / GUARDRAILS (focus manifest)
 # ----------------------------------------------------------------------------
-# Declares the repo's work areas and off-limits paths. These feed deterministic
-# findings (e.g. manifest_blocked_path, manifest_missing_tests) and — when
-# `gate.manifestPolicy: block` is set below — can become enforceable blockers.
+# Declares the repo's work areas and off-limits paths. wantedPaths/blockedPaths feed advisory-only
+# guidance findings; testExpectations/linkedIssuePolicy feed manifest_missing_tests and
+# manifest_linked_issue_required, which — when `gate.manifestPolicy: block` is set below — can become
+# enforceable blockers. Hard path HOLDS are a separate mechanism: settings.hardGuardrailGlobs, below.
 
 # Work areas the maintainer wants. PRs touching these are preferred/encouraged.
 # Glob list. Default: [] (no preference).
 wantedPaths:
   - "src/**"
 
-# Paths off-limits to contributors. Touching one yields a manifest_blocked_path
-# finding (enforceable when `gate.manifestPolicy: block`).
-# Glob list. Default: [] (nothing blocked).
+# Paths off-limits to contributors — CONTRIBUTOR-FACING GUIDANCE ONLY. Touching one surfaces in
+# onboarding guidance and gittensory's own risk-reason commentary; it never blocks, holds, or produces
+# a gate finding, even under gate.manifestPolicy: block. The only mechanism that actually holds a PR
+# for a touched path is settings.hardGuardrailGlobs, below.
+# Glob list. Default: [] (nothing listed).
 blockedPaths:
   - "vendor/**"
   - ".github/workflows/**"
@@ -673,9 +676,11 @@ settings:
   # of this setting. Bool. Default: false.
   closeOwnerAuthors: false
 
-  # Hard manual-review path guardrails are config-as-code only. Omit or use [] for no path guardrails;
-  # set concrete globs when otherwise-mergeable PRs touching those paths must be held for a person.
-  # This never falls back to hidden engine path defaults.
+  # Hard manual-review path guardrails are config-as-code only. Configured globs are ADDED to a fixed
+  # set of built-in invariant guardrails (config-as-code files, CI workflows/scripts, and core
+  # engine-decision paths — see DEFAULT_HARD_GUARDRAIL_GLOBS in src/review/guardrail-config.ts) that
+  # always apply and can never be disabled from here. Omit or use [] to rely on just those built-in
+  # invariants, with no repo-specific additions.
   hardGuardrailGlobs: []
 
   # Require a linked issue on every PR (dashboard equivalent of the toggle that


### PR DESCRIPTION
## Summary
Two documentation-drift bugs found while investigating a security-scanner finding ("Legacy blockedPaths guardrails are silently disabled") about commit f13d95c / #2974:

1. **#2974 removing legacy `blockedPaths` enforcement was a deliberate, well-reasoned architecture decision** (single authoritative path-hold control: `settings.hardGuardrailGlobs`), not an accidental regression — so the security finding's proposed patch (re-adding a compatibility shim) is not being applied; it would reintroduce the exact dual-system drift #2974 eliminated.
2. **But two config example files never caught up to that decision**: `.gittensory.yml.example` and `config/examples/gittensory.full.yml` still describe `blockedPaths` as producing an "enforceable... finding" — false, and contradicts the already-correct prose docs page. An operator copying either example would believe they have protection they don't have.
3. **A second, related staleness found while in the area**: those same two example files plus two docs pages (`docs.self-hosting-configuration.tsx`, `docs.tuning.tsx`) claimed an empty/omitted `settings.hardGuardrailGlobs` means "no path guardrails, never a hidden engine fallback" — but #3943 (3 days after that comment was written) added `DEFAULT_HARD_GUARDRAIL_GLOBS`, a fixed set of built-in invariant guardrails that always apply regardless of repo settings. The docs never caught up.

## Changes
- `.gittensory.yml.example` + `config/examples/gittensory.full.yml`: corrected the `blockedPaths` and `hardGuardrailGlobs` comments to match actual runtime behavior and the already-correct prose docs.
- `docs.self-hosting-configuration.tsx` + `docs.tuning.tsx`: corrected the "never a hidden engine fallback" claim.

## Validation
- `npx vitest run test/unit/focus-manifest.test.ts test/unit/check-docs-drift-script.test.ts test/unit/selfhost-config-examples.test.ts test/unit/prompt-injection.test.ts test/unit/focus-manifest-validation.test.ts test/unit/config-templates.test.ts` — 730/730 passing
- `node scripts/check-docs-drift.mjs` — clean
- `npm run ui:typecheck` / `npm run ui:lint` — clean (only pre-existing, unrelated warnings)
- `npm run cf-typegen:check` — clean
- No `src/**` production code changed; docs/config-example only.