### PR TITLE
fix(ui): clarify hero CTA hierarchy, drop duplicate link, fix stale demo data

### DIFF
--- a/apps/gittensory-ui/src/components/site/animated-terminal.tsx
+++ b/apps/gittensory-ui/src/components/site/animated-terminal.tsx
@@ -34,7 +34,7 @@ const DEFAULT_SCENES: TerminalScene[] = [
     { "action": "preflight-branch", "priority": 0.74 },
     { "action": "link-issue",       "priority": 0.61 }
   ],
-  "ruleset_snapshot": "rs_2026_05_29_a1f3",
+  "ruleset_snapshot": "rs_a1f3c9e2",
   "signal_fidelity":  "ready"
 }`,
   },

--- a/apps/gittensory-ui/src/routes/index.tsx
+++ b/apps/gittensory-ui/src/routes/index.tsx
@@ -78,16 +78,16 @@ function Hero() {
           </p>
           <div className="mt-7 flex flex-wrap items-center gap-2">
             <Link
-              to="/docs/maintainer-self-hosting"
-              className="inline-flex h-9 items-center justify-center gap-1.5 whitespace-nowrap rounded-token bg-coral px-4 text-token-sm font-medium text-primary-foreground transition-[filter,transform] duration-150 hover:brightness-110 active:scale-[0.98] focus-ring motion-reduce:transition-none motion-reduce:active:scale-100"
-            >
-              Self-host reviews →
-            </Link>
-            <Link
               to="/docs/quickstart"
               className="inline-flex h-9 items-center justify-center gap-1.5 whitespace-nowrap rounded-token bg-coral px-4 text-token-sm font-medium text-primary-foreground transition-[filter,transform] duration-150 hover:brightness-110 active:scale-[0.98] focus-ring motion-reduce:transition-none motion-reduce:active:scale-100"
             >
               Install MCP →
+            </Link>
+            <Link
+              to="/docs/maintainer-self-hosting"
+              className="inline-flex h-9 items-center justify-center gap-1.5 whitespace-nowrap rounded-token border border-border bg-transparent px-4 text-token-sm font-medium text-foreground transition-colors duration-150 hover:bg-accent focus-ring motion-reduce:transition-none"
+            >
+              Self-host reviews →
             </Link>
             <Link
               to="/docs"
@@ -102,9 +102,6 @@ function Hero() {
           <div className="mt-4 flex flex-wrap items-center gap-x-5 gap-y-2 text-token-xs">
             <Link to="/api" className="text-muted-foreground hover:text-foreground">
               Browse the API →
-            </Link>
-            <Link to="/agents" className="text-muted-foreground hover:text-foreground">
-              For coding agents →
             </Link>
           </div>
         </div>


### PR DESCRIPTION
## Summary
Three cleanups on the homepage hero, found during a design review:

1. **CTA hierarchy**: the hero had two identically-styled `bg-coral` primary buttons ("Self-host reviews", "Install MCP") with no clear priority, and the maintainer-facing button was placed first even though the hero copy ("Mine Gittensor like an engineer, not like a bot") is written for the miner path. Install MCP is now the sole primary CTA (first), Self-host reviews is demoted to the same secondary/outline style already used for "Read the docs" — this exact one-primary + N-secondary pattern is already how `ClosingCta` (same file, bottom of page) styles its own CTAs, so this makes the hero consistent with the rest of the page rather than introducing a new pattern.
2. **Duplicate link removed**: the hero's "For coding agents →" link pointed to `/agents`, the exact same destination as the "For coding agents" card in the "One base layer, three audiences" section immediately below the hero. Dropped from the hero; the audience card (with its own "Open guide →") still covers it.
3. **Stale-looking demo data fixed**: `AnimatedTerminal`'s canned output hardcoded `"ruleset_snapshot": "rs_2026_05_29_a1f3"` — a calendar-dated placeholder in static, illustrative (not live) content that only ages further over time. Replaced with a plain hash-shaped ID with no visible date, since "upstream drift"/ruleset freshness is one of the product's own selling points.

No design-system changes — reuses existing `bg-coral`/border-outline button classes and `text-token-*` typography tokens already established in this file.

## Validation
- `npm run ui:typecheck` / `npm run ui:lint` — clean (0 errors; only pre-existing, unrelated warnings)
- `npm run ui:build` — clean production build
- `npm run cf-typegen:check` / `node scripts/check-docs-drift.mjs` — clean
- Verified visually in a local dev server: button order/styling correct, no layout regression, "three audiences" section below still renders and still covers coding agents independently
- No `src/**` production code changed; UI-only, no Codecov patch obligation