### PR TITLE
fix(api): allow the gittensory-ui dev-server port in CORS

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -5698,9 +5698,13 @@ const DEFAULT_CORS_ORIGINS = [
   "http://localhost:3000",
   "http://localhost:4173",
   "http://localhost:5173",
+  // gittensory-ui's dev server (@lovable.dev/vite-tanstack-config) binds 8080, not Vite's 5173 default —
+  // without this, every local/preview dev server is CORS-blocked from /health and shows a false "API unreachable" banner.
+  "http://localhost:8080",
   "http://127.0.0.1:3000",
   "http://127.0.0.1:4173",
   "http://127.0.0.1:5173",
+  "http://127.0.0.1:8080",
 ] as const;
 
 function allowedCorsOrigin(env: Env, origin: string | undefined): string | null {

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -92,6 +92,17 @@ describe("api routes", () => {
     expect(dynamicPreflight.status).toBe(204);
     expect(dynamicPreflight.headers.get("access-control-allow-origin")).toBe("https://preview.gittensory.test");
 
+    // REGRESSION: gittensory-ui's dev server (@lovable.dev/vite-tanstack-config) binds 8080, not Vite's 5173
+    // default — without this in DEFAULT_CORS_ORIGINS, every local/preview dev server is CORS-blocked from
+    // /health and the ApiStatusBanner falsely reports "API unreachable" even when the API is healthy.
+    const devPortPreflight = await app.request("/health", { method: "OPTIONS", headers: { origin: "http://localhost:8080" } }, env);
+    expect(devPortPreflight.status).toBe(204);
+    expect(devPortPreflight.headers.get("access-control-allow-origin")).toBe("http://localhost:8080");
+
+    const devPortLoopbackPreflight = await app.request("/health", { method: "OPTIONS", headers: { origin: "http://127.0.0.1:8080" } }, env);
+    expect(devPortLoopbackPreflight.status).toBe(204);
+    expect(devPortLoopbackPreflight.headers.get("access-control-allow-origin")).toBe("http://127.0.0.1:8080");
+
     const health = await app.request("/health", {}, env);
     expect(health.status).toBe(200);
     await expect(health.json()).resolves.toMatchObject({


### PR DESCRIPTION
## Summary
Root cause of the "API unreachable" banner appearing on every local/preview load of gittensory-ui: its dev server (`@lovable.dev/vite-tanstack-config`) binds port **8080**, not Vite's 5173 default, but `DEFAULT_CORS_ORIGINS` in `src/api/routes.ts` only listed 3000/4173/5173 (+ their `127.0.0.1` equivalents). Every dev/preview build was CORS-blocked from `/health`, so `ApiStatusBanner` reported the API as unreachable regardless of whether it was actually healthy — verified the deployed API itself responds `200` in well under a second.

Fix: added `http://localhost:8080` / `http://127.0.0.1:8080` to `DEFAULT_CORS_ORIGINS`.

## Validation
- `npx vitest run test/integration/api.test.ts` — new regression assertions for the `/health` preflight from `localhost:8080` and `127.0.0.1:8080` pass
- `npm run typecheck` — clean
- `npm run test:coverage` (unsharded) — full suite green
- `npm audit --audit-level=moderate` — 0 vulnerabilities
- `npm run cf-typegen:check` / `npm run ui:openapi:check` / `npm run docs:drift-check` — all clean, no drift
- No generated artifacts needed regenerating (no wrangler binding/var, schema, or migration touched)

## Safety
- No secrets, no access-control changes — purely adds a known-safe localhost dev origin to an existing allowlist alongside the other standard local dev ports already there.