### PR TITLE
fix(selfhost): attribute embed/vision/advisory AI usage to a real provider

### DIFF
--- a/src/selfhost/ai.ts
+++ b/src/selfhost/ai.ts
@@ -609,6 +609,25 @@ function buildAiUsage(fields: {
   return usage;
 }
 
+/** Classify an AI_EMBED/AI_VISION/AI_ADVISORY base URL into `createOpenAiCompatibleAi`'s existing
+ *  `providerName` set (#ai-usage-provider-attribution): unlike the main review chain (an explicit
+ *  `AI_PROVIDER` selector), these auxiliary bindings accept ANY openai-compatible endpoint with no provider
+ *  knob of their own, so the configured base URL is the only signal available for attributing `ai_usage_events`
+ *  rows to a real provider instead of leaving them permanently unattributed. Recognizes the bundled
+ *  docker-compose `ollama` service and OpenAI's own endpoint; anything else (vLLM, LM Studio, a custom
+ *  hostname) is the honest generic "openai-compatible" bucket rather than a guessed, possibly-wrong label. */
+export function providerNameFromBaseUrl(baseUrl: string | undefined): "ollama" | "openai" | "openai-compatible" {
+  let hostname = "";
+  try {
+    hostname = baseUrl ? new URL(baseUrl).hostname : "";
+  } catch {
+    return "openai-compatible";
+  }
+  if (hostname === "api.openai.com") return "openai";
+  if (hostname.includes("ollama")) return "ollama";
+  return "openai-compatible";
+}
+
 const INPUT_TOKEN_KEYS = ["input_tokens", "inputTokens", "prompt_tokens", "promptTokens"] as const;
 const OUTPUT_TOKEN_KEYS = ["output_tokens", "outputTokens", "completion_tokens", "completionTokens"] as const;
 const TOTAL_TOKEN_KEYS = ["total_tokens", "totalTokens"] as const;

--- a/src/server.ts
+++ b/src/server.ts
@@ -20,6 +20,7 @@ import {
   createSelfHostAi,
   isAiProviderHealthy,
   markAiProviderUnhealthyAtBoot,
+  providerNameFromBaseUrl,
   resolveAiReviewerPlan,
   resolveProviderNames,
   resolveRequiredCliProviders,
@@ -471,6 +472,7 @@ async function main(): Promise<void> {
         baseUrl: process.env.AI_EMBED_BASE_URL,
         apiKey: process.env.AI_EMBED_API_KEY ?? process.env.OPENAI_API_KEY,
         embedModel: process.env.AI_EMBED_MODEL,
+        providerName: providerNameFromBaseUrl(process.env.AI_EMBED_BASE_URL),
       })
     : undefined;
   if (embedAi)
@@ -491,6 +493,7 @@ async function main(): Promise<void> {
         baseUrl: process.env.AI_VISION_BASE_URL,
         apiKey: process.env.AI_VISION_API_KEY ?? process.env.OPENAI_API_KEY,
         model: process.env.AI_VISION_MODEL,
+        providerName: providerNameFromBaseUrl(process.env.AI_VISION_BASE_URL),
       })
     : undefined;
   if (visionAi)
@@ -513,6 +516,7 @@ async function main(): Promise<void> {
         baseUrl: process.env.AI_ADVISORY_BASE_URL,
         apiKey: process.env.AI_ADVISORY_API_KEY,
         model: process.env.AI_ADVISORY_MODEL,
+        providerName: providerNameFromBaseUrl(process.env.AI_ADVISORY_BASE_URL),
       })
     : undefined;
   if (advisoryAi)

--- a/test/unit/selfhost-ai.test.ts
+++ b/test/unit/selfhost-ai.test.ts
@@ -2,7 +2,7 @@ import { chmodSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "
 import { tmpdir } from "node:os";
 import { delimiter, join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { assertNoLegacySharedAiEnv, buildProvider, claudeErrorStatus, codexErrorFromStdout, createAnthropicAi, createChainAi, createClaudeCodeAi, createCodexAi, createOpenAiCompatibleAi, createSelfHostAi, extractCliText, extractCliUsage, isAiProviderHealthy, markAiProviderUnhealthyAtBoot, resetAiProviderCircuitBreakerForTest, resetAiProviderHealthForTest, resolveAiReviewerPlan, resolveClaudeCliTimeoutMs, resolveClaudeFirstOutputTimeoutMs, resolveCodexAuthPath, resolveCodexCliTimeoutMs, resolveCodexEffort, resolveCodexFirstOutputTimeoutMs, resolveEffort, resolveModel, resolveProviderNames, resolveRequiredCliProviders, resolveSubscriptionCliPath, redactSecrets, routeProviders, shouldMarkAiProviderUnhealthyAtBoot, subscriptionCliEnv, withAdvisoryAiEnv, __selfHostAiInternals } from "../../src/selfhost/ai";
+import { assertNoLegacySharedAiEnv, buildProvider, claudeErrorStatus, codexErrorFromStdout, createAnthropicAi, createChainAi, createClaudeCodeAi, createCodexAi, createOpenAiCompatibleAi, createSelfHostAi, extractCliText, extractCliUsage, isAiProviderHealthy, markAiProviderUnhealthyAtBoot, providerNameFromBaseUrl, resetAiProviderCircuitBreakerForTest, resetAiProviderHealthForTest, resolveAiReviewerPlan, resolveClaudeCliTimeoutMs, resolveClaudeFirstOutputTimeoutMs, resolveCodexAuthPath, resolveCodexCliTimeoutMs, resolveCodexEffort, resolveCodexFirstOutputTimeoutMs, resolveEffort, resolveModel, resolveProviderNames, resolveRequiredCliProviders, resolveSubscriptionCliPath, redactSecrets, routeProviders, shouldMarkAiProviderUnhealthyAtBoot, subscriptionCliEnv, withAdvisoryAiEnv, __selfHostAiInternals } from "../../src/selfhost/ai";
 import { labelSelfHostReviewerModel, labelSelfHostReviewerModels } from "../../src/selfhost/ai-config";
 import { renderMetrics, resetMetrics } from "../../src/selfhost/metrics";
 
@@ -213,6 +213,15 @@ describe("createOpenAiCompatibleAi (#979)", () => {
     ));
     const out = await createOpenAiCompatibleAi({ baseUrl: "http://o/v1", embedModel: "bge-m3" }).run("m", { text: ["hello"] });
     expect(out).toEqual({ data: [[0.1]], usage: { model: "bge-m3", inputTokens: 7, totalTokens: 7 } });
+  });
+
+  it("providerNameFromBaseUrl classifies the bundled Ollama service, OpenAI's endpoint, and any other host generically (#ai-usage-provider-attribution)", () => {
+    expect(providerNameFromBaseUrl("http://ollama:11434/v1")).toBe("ollama");
+    expect(providerNameFromBaseUrl("https://my-ollama-box.internal:11434/v1")).toBe("ollama");
+    expect(providerNameFromBaseUrl("https://api.openai.com/v1")).toBe("openai");
+    expect(providerNameFromBaseUrl("https://my-vllm-box.internal/v1")).toBe("openai-compatible");
+    expect(providerNameFromBaseUrl(undefined)).toBe("openai-compatible");
+    expect(providerNameFromBaseUrl("not a url")).toBe("openai-compatible");
   });
 
   it("buildAiUsage omits every undefined field and includes every defined one (direct unit test — costUsd/effort/an-undefined-model are never both exercised through the 3 real call sites)", () => {


### PR DESCRIPTION
## Summary

Follow-up to #5247, found during its own live-deploy verification on edge-nl-01.

#5247 fixed `createOpenAiCompatibleAi` to return real `usage.provider` attribution, but
`src/server.ts`'s 3 call sites that actually construct the `AI_EMBED`/`AI_VISION`/`AI_ADVISORY`
bindings never passed `providerName` at all — confirmed live by triggering a real RAG-indexing
pass on edge-nl-01 right after deploying #5247: the new `embeddings` rows correctly showed the
real model (`bge-m3:latest`, not the old hardcoded placeholder) but `provider` was still blank on
every row, since `opts.providerName` was `undefined` at the source.

These 3 bindings deliberately accept *any* openai-compatible endpoint with no explicit provider
selector (unlike the main review chain's `AI_PROVIDER`), so there's no existing knob to read a
provider name from. Added `providerNameFromBaseUrl()` to classify the configured base URL into the
same closed `"ollama" | "openai" | "openai-compatible"` set `createOpenAiCompatibleAi` already uses
— recognizing the bundled docker-compose `ollama` service and OpenAI's own endpoint, and falling
back to the honest generic bucket for anything else (vLLM, LM Studio, a custom hostname) rather than
guessing.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run test:ci` — full local gate green
- [x] New unit test covers all 4 classification branches (ollama by hostname substring, openai's
      exact hostname, a generic other host, and the undefined/malformed-URL fallback)
- [x] Live-verified on edge-nl-01 after deploying this fix: a manually triggered RAG-index pass
      produced a fresh `embeddings` row with `provider = 'ollama', model = 'bge-m3:latest'`, and an
      organic `screenshot_table_vision` row landed with `provider = 'ollama', model =
      'qwen3-vl:8b-instruct'` — both were previously always blank on `provider`.