### PR TITLE
feat(miner): add <NAME>_FILE secrets-file indirection for fleet-mode credentials (#5178)

### DIFF
--- a/packages/gittensory-miner/DEPLOYMENT.md
+++ b/packages/gittensory-miner/DEPLOYMENT.md
@@ -61,10 +61,24 @@ docker run --rm -it \
   doctor
 ```
 
+**Fleet mode — avoid plaintext credentials.** A plain `-e GITHUB_TOKEN` is visible via `docker inspect` on the host. Any credential can instead be supplied via a `<NAME>_FILE` companion pointing at a mounted secret (Docker/Swarm/K8s secret at `/run/secrets/<name>`); the miner reads and trims the file at startup into the plain `<NAME>`:
+
+```sh
+docker run --rm -it \
+  -e GITTENSORY_MINER_CONFIG_DIR=/data/miner \
+  -e GITHUB_TOKEN_FILE=/run/secrets/github_token \
+  --mount type=bind,src=/host/secrets/github_token,dst=/run/secrets/github_token,ro \
+  -v miner-data:/data/miner \
+  gittensory-miner:latest \
+  doctor
+```
+
+Precedence: an explicit plain `GITHUB_TOKEN` always **wins** over `GITHUB_TOKEN_FILE`. An unreadable `_FILE` path is a hard startup error (never a silent empty credential). The same `_FILE` convention applies to the coding-agent credential env vars your configured `MINER_CODING_AGENT_PROVIDER` requires.
+
 The image entrypoint is `gittensory-miner`; pass subcommands after the image name (`status`, `doctor`, `claim`, …).
 
 - **`/data/miner` volume** — holds all SQLite state (`claim-ledger.sqlite3`, `plan-store.sqlite3`, etc.) so containers are disposable. Defaults to `GITTENSORY_MINER_CONFIG_DIR=/data/miner` in the image.
-- **`GITHUB_TOKEN`** — supplied by the operator at run time; the image contains no credentials.
+- **`GITHUB_TOKEN`** (or **`GITHUB_TOKEN_FILE`**) — supplied by the operator at run time; the image contains no credentials.
 - **Scale** — launch additional containers with the same volume (or partitioned config dirs) for parallel attempts.
 
 The repo-root [`docker-compose.yml`](../../docker-compose.yml) documents the **self-hosted review stack** (the `gittensory` API/orb), not the miner CLI. Miners are clients of that stack (or of github.com directly) and do not require it to run locally.

--- a/packages/gittensory-miner/bin/gittensory-miner.js
+++ b/packages/gittensory-miner/bin/gittensory-miner.js
@@ -21,6 +21,12 @@ import {
   startUpdateCheck,
 } from "../lib/update-check.js";
 import { resolveMinerVersion } from "../lib/version.js";
+import { loadFileCredentials } from "../lib/load-file-credentials.js";
+
+// #5178: resolve `<NAME>_FILE` secret-file indirection (GITHUB_TOKEN_FILE, coding-agent credential files) into
+// the plain env vars BEFORE any CLI reads them, so fleet-mode operators can mount Docker/Swarm/K8s secrets
+// instead of passing plaintext credentials that `docker inspect` would expose. Throws on an unreadable file.
+loadFileCredentials();
 
 const cliArgs = process.argv.slice(2);
 

--- a/packages/gittensory-miner/lib/load-file-credentials.d.ts
+++ b/packages/gittensory-miner/lib/load-file-credentials.d.ts
@@ -1,0 +1,9 @@
+/**
+ * Resolve `<NAME>_FILE` secret-file indirection into `<NAME>` in place (fleet-mode Docker/Swarm/K8s secret
+ * mounts). An explicit plain `<NAME>` wins over `<NAME>_FILE`; an unreadable `_FILE` path throws. The secret
+ * value is never logged or returned.
+ */
+export function loadFileCredentials(
+  env?: Record<string, string | undefined>,
+  readFile?: (path: string) => string,
+): void;

--- a/packages/gittensory-miner/lib/load-file-credentials.js
+++ b/packages/gittensory-miner/lib/load-file-credentials.js
@@ -1,0 +1,41 @@
+import { readFileSync } from "node:fs";
+
+// Docker Compose's OWN reserved `_FILE`-suffixed variables -- never a gittensory secret-file. `COMPOSE_FILE`
+// is a colon-delimited list of compose paths (readFileSync always throws on it) and `COMPOSE_ENV_FILE` points
+// at an operator's .env, not a secret. Excluding both by name means we never dereference them (mirrors ORB's
+// src/selfhost/load-file-secrets.ts, added in #4403). A real operator secret is never named exactly one of these.
+const COMPOSE_RESERVED_FILE_VARS = new Set(["COMPOSE_FILE", "COMPOSE_ENV_FILE"]);
+
+/**
+ * Resolve `<NAME>_FILE` secret-file indirection into `<NAME>` for fleet mode, so credentials like
+ * `GITHUB_TOKEN` and the coding-agent credentials can be supplied via a Docker/Swarm/K8s secret mount
+ * (e.g. `-e GITHUB_TOKEN_FILE=/run/secrets/github_token`) instead of a plaintext env var, which is visible
+ * to anyone who can run `docker inspect` on the host. Mirrors ORB's `src/selfhost/load-file-secrets.ts`, with
+ * one deliberate difference for the miner: an unreadable `_FILE` path is a HARD ERROR (deliverable #5) rather
+ * than a silent log-and-continue -- we never start with an empty/undefined credential the operator believes
+ * they supplied.
+ *
+ * Precedence: an explicit plain `<NAME>` ALWAYS wins over `<NAME>_FILE` (documented, never a silent pick).
+ * The resolved secret VALUE is never logged or returned -- it is only written into `env` in place.
+ *
+ * @param {Record<string, string | undefined>} [env] Injectable for tests; defaults to `process.env`.
+ * @param {(path: string) => string} [readFile] Injectable for tests; defaults to `readFileSync(path, "utf8")`.
+ * @returns {void}
+ */
+export function loadFileCredentials(env = process.env, readFile = (path) => readFileSync(path, "utf8")) {
+  for (const key of Object.keys(env)) {
+    if (!key.endsWith("_FILE") || !env[key] || COMPOSE_RESERVED_FILE_VARS.has(key)) continue;
+    const target = key.slice(0, -"_FILE".length);
+    if (env[target]) continue; // an explicit plain value wins over the file
+    let contents;
+    try {
+      contents = readFile(env[key]);
+    } catch (cause) {
+      throw new Error(
+        `Secret file for ${key} is unreadable (${env[key]}); refusing to start with an empty ${target}.`,
+        { cause },
+      );
+    }
+    env[target] = contents.trim();
+  }
+}

--- a/test/unit/miner-load-file-credentials.test.ts
+++ b/test/unit/miner-load-file-credentials.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { loadFileCredentials } from "../../packages/gittensory-miner/lib/load-file-credentials.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("loadFileCredentials (miner fleet-mode secret-file indirection, #5178)", () => {
+  it("leaves an existing plain env var untouched (no regression to today's behavior)", () => {
+    const env: Record<string, string | undefined> = { GITHUB_TOKEN: "plain-tok" };
+    loadFileCredentials(env, () => "from-file");
+    expect(env.GITHUB_TOKEN).toBe("plain-tok");
+  });
+
+  it("resolves <NAME>_FILE into <NAME> (trimmed) when the plain var is unset", () => {
+    const env: Record<string, string | undefined> = { GITHUB_TOKEN_FILE: "/run/secrets/github_token" };
+    const readFile = vi.fn(() => "file-tok\n");
+    loadFileCredentials(env, readFile);
+    expect(env.GITHUB_TOKEN).toBe("file-tok");
+    expect(readFile).toHaveBeenCalledWith("/run/secrets/github_token");
+  });
+
+  it("lets an explicit plain <NAME> win over <NAME>_FILE (documented precedence, no file read)", () => {
+    const env: Record<string, string | undefined> = {
+      GITHUB_TOKEN: "explicit",
+      GITHUB_TOKEN_FILE: "/run/secrets/github_token",
+    };
+    const readFile = vi.fn(() => "file-tok");
+    loadFileCredentials(env, readFile);
+    expect(env.GITHUB_TOKEN).toBe("explicit");
+    expect(readFile).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when neither <NAME> nor <NAME>_FILE is set", () => {
+    const env: Record<string, string | undefined> = { UNRELATED: "x" };
+    loadFileCredentials(env, () => "unused");
+    expect(env.GITHUB_TOKEN).toBeUndefined();
+  });
+
+  it("resolves an empty file to an empty string rather than leaving the credential undefined", () => {
+    const env: Record<string, string | undefined> = { CODING_AGENT_KEY_FILE: "/run/secrets/key" };
+    loadFileCredentials(env, () => "   \n");
+    expect(env.CODING_AGENT_KEY).toBe("");
+  });
+
+  it("throws a clear, path-identifying error when the _FILE path is unreadable (no silent fallthrough)", () => {
+    const env: Record<string, string | undefined> = { GITHUB_TOKEN_FILE: "/run/secrets/missing" };
+    expect(() =>
+      loadFileCredentials(env, () => {
+        throw new Error("ENOENT");
+      }),
+    ).toThrow(/GITHUB_TOKEN_FILE.*\/run\/secrets\/missing/);
+    expect(env.GITHUB_TOKEN).toBeUndefined();
+  });
+
+  it("never dereferences Docker Compose's reserved COMPOSE_FILE / COMPOSE_ENV_FILE vars", () => {
+    const env: Record<string, string | undefined> = {
+      COMPOSE_FILE: "a.yml:b.yml",
+      COMPOSE_ENV_FILE: "/app/.env",
+    };
+    const readFile = vi.fn(() => "should-not-be-read");
+    loadFileCredentials(env, readFile);
+    expect(readFile).not.toHaveBeenCalled();
+    expect(env.COMPOSE).toBeUndefined();
+    expect(env.COMPOSE_ENV).toBeUndefined();
+  });
+
+  it("never logs or returns the resolved secret value — only mutates env in place", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const env: Record<string, string | undefined> = { GITHUB_TOKEN_FILE: "/run/secrets/github_token" };
+    const result = loadFileCredentials(env, () => "super-secret-value");
+    expect(result).toBeUndefined();
+    for (const call of [...errorSpy.mock.calls, ...logSpy.mock.calls]) {
+      expect(JSON.stringify(call)).not.toContain("super-secret-value");
+    }
+  });
+});


### PR DESCRIPTION
## What

Ports ORB's proven `<NAME>_FILE` secrets-file indirection to **gittensory-miner** (Closes #5178). In fleet mode, `-e GITHUB_TOKEN` (and any coding-agent credential) sits in plaintext env, visible to anyone who can `docker inspect` the host. This lets operators supply credentials via a mounted Docker/Swarm/K8s secret instead: `-e GITHUB_TOKEN_FILE=/run/secrets/github_token`.

Mirrors `src/selfhost/load-file-secrets.ts`, with one deliberate miner-side difference: an unreadable `_FILE` path is a **hard error**, never a silent empty credential.

## Changes

- **`lib/load-file-credentials.js`** (+ `.d.ts`, new) — `loadFileCredentials(env?, readFile?)` resolves any `<NAME>_FILE` into `<NAME>` in place. Injectable `env`/`readFile` for tests; defaults to `process.env` + `readFileSync`.
- **`bin/gittensory-miner.js`** — calls `loadFileCredentials()` once at startup, **before** any CLI reads a credential, so `discover`/`manage`/`attempt`/etc. transparently pick up the resolved value.
- **`DEPLOYMENT.md`** — fleet-mode example with the `_FILE` + secret-mount alternative and the precedence/error rules.
- **`test/unit/miner-load-file-credentials.test.ts`** (new) — 8 tests.

## Behavior (per the acceptance criteria)

- **Precedence:** an explicit plain `<NAME>` always **wins** over `<NAME>_FILE` (documented, never a silent pick).
- **Hard error** on a missing/unreadable `_FILE` path, naming the var and path — no silent fallthrough to an empty credential.
- **Never logs the secret value** — only mutates `env` in place (invariant-tested).
- **Compose-safe:** `COMPOSE_FILE` / `COMPOSE_ENV_FILE` (Compose's own reserved `_FILE` vars) are never dereferenced.
- **No regression:** an operator's existing plain-env-var setup is byte-identical.
- **No control-flow touched** — governor/attempt/claim untouched; this is credential-resolution plumbing only.

## Test coverage

8 tests covering every branch: plain-only (no regression), file-only, both-set (plain wins, no file read), neither, empty file → `""`, unreadable → throws with the path, Compose-reserved skipped, and a **no-secret-logging invariant** (spies `console.error`/`console.log`, asserts the value never appears).

`npx vitest run test/unit/miner-load-file-credentials.test.ts` → 8/8 green · `tsc` clean.

> Note: per the issue, `packages/gittensory-miner/**` currently sits outside vitest's `coverage.include`, so `codecov/patch` can't measure it yet — the tests above still hold the 100%-including-invariants bar by hand.

Closes #5178
