### PR TITLE
docs(settings): disclose that agentDryRun doesn't stop AI/LLM spend

### DIFF
--- a/.gittensory.yml.example
+++ b/.gittensory.yml.example
@@ -688,7 +688,8 @@ settings:
   # Bool. Default: false.
   agentPaused: false
 
-  # Dry-run / shadow mode: compute everything but take no public action.
+  # Dry-run / shadow mode: suppresses the terminal GitHub-side write only. AI/LLM review calls still
+  # execute and still incur their normal provider cost -- this is NOT a cost-free preview.
   # Bool. Default: false.
   agentDryRun: false
 

--- a/apps/gittensory-ui/src/components/site/app-panels/maintainer-settings.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/maintainer-settings.tsx
@@ -561,7 +561,7 @@ export function MaintainerSettings({ reviewability }: { reviewability: Array<{ p
               />
               <ToggleControl
                 label="Dry-run / shadow mode"
-                hint="Record what the agent would do, without performing it"
+                hint="Suppress GitHub writes only — AI review calls still run and still cost tokens"
                 value={settings.agentDryRun}
                 onChange={(v) => setField("agentDryRun", v)}
               />

--- a/config/examples/gittensory.full.yml
+++ b/config/examples/gittensory.full.yml
@@ -701,7 +701,8 @@ settings:
   # Bool. Default: false.
   agentPaused: false
 
-  # Dry-run / shadow mode: compute everything but take no public action.
+  # Dry-run / shadow mode: suppresses the terminal GitHub-side write only. AI/LLM review calls still
+  # execute and still incur their normal provider cost -- this is NOT a cost-free preview.
   # Bool. Default: false.
   agentDryRun: false
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1089,7 +1089,10 @@ export type RepositorySettings = {
    *  global env switch overrides this too). Default false. */
   agentPaused?: boolean | undefined;
   /** Per-repo dry-run/shadow mode (#776): when true, the action layer records what it WOULD do without
-   *  performing any GitHub mutation. Default false. */
+   *  performing any GitHub mutation -- but this is NOT a cost-free preview: AI/LLM review calls still
+   *  execute and still incur their normal provider cost (deliberate design tagged `#token-bleed-spend-gate`
+   *  in `ai-review-orchestration.ts`/`agent-orchestrator.ts`/`processors.ts`; every spend gate checks only
+   *  `agentPaused`, never this field). Default false. */
   agentDryRun?: boolean | undefined;
   /** Per-repo override of the global DB-backed agent freeze (#4372): when true, this repo's actions execute
    *  even while `global_agent_controls.frozen` is set, so an operator can re-activate one repo at a time


### PR DESCRIPTION
## Summary
- `agentDryRun`'s doc comment, the maintainer-dashboard toggle hint, and both yml example files all implied a cost-free preview.
- In reality every AI/LLM spend gate checks only `agentPaused`, never `agentDryRun` — dry-run still executes real, billed review calls and only suppresses the terminal GitHub write.
- Fixes the copy at all three surfaces a maintainer actually reads. No behavior change (the spend-gate design is deliberate, `#token-bleed-spend-gate`).

## Scope
Docs/copy only: `src/types.ts`, `apps/gittensory-ui/.../maintainer-settings.tsx`, `.gittensory.yml.example`, `config/examples/gittensory.full.yml`.

## Validation
- `npm run typecheck` — clean
- `npx vitest run test/unit/config-templates.test.ts` — 18/18 passing (yml template sync intact)
- `npm run docs:drift-check` — clean
- `npm run ui:typecheck` / `npm run ui:lint` — clean (0 errors)

## Safety
No logic change, no new surface, no secrets.

Closes #5286