### PR TITLE
feat(miner): surface a codex auth-freshness remediation detail in doctor (#5166)

### DIFF
--- a/packages/gittensory-miner/lib/laptop-init.js
+++ b/packages/gittensory-miner/lib/laptop-init.js
@@ -160,11 +160,17 @@ export function checkCodexCliPresent(options = {}) {
   } catch {
     // auth.json missing or unreadable — codex would fail for lack of credentials at call time.
   }
-  return {
-    name: "codex-cli-present",
-    ok: true,
-    detail: authed ? `found at ${codexPath} (authenticated)` : `found at ${codexPath} (not authenticated: run \`codex auth\`)`,
-  };
+  if (authed) {
+    return { name: "codex-cli-present", ok: true, detail: `found at ${codexPath} (authenticated)` };
+  }
+  // codex-cli IS the configured driver but auth.json is missing/expired: a more specific, actionable remediation
+  // than the generic advisory below, mirroring ORB's codexAuthReadinessProbe/assertCodexAuthConfigured wording
+  // (#5166). `ok` stays true either way (unchanged by this issue, see #5165) since the CLI itself IS present --
+  // only the CLI-absent case is a hard doctor failure.
+  const detail = codingAgentProviderConfiguredFor(env, "codex-cli")
+    ? `found at ${codexPath} but auth.json is missing or expired — run \`codex auth\` to authenticate before attempts run`
+    : `found at ${codexPath} (not authenticated: run \`codex auth\`)`;
+  return { name: "codex-cli-present", ok: true, detail };
 }
 
 export function runInit(args = [], env = process.env) {

--- a/test/unit/miner-cli-doctor-checks.test.ts
+++ b/test/unit/miner-cli-doctor-checks.test.ts
@@ -131,6 +131,56 @@ describe("gittensory-miner doctor — coding-agent CLI checks (#4304)", () => {
       expect(check.detail).toBe("found at /usr/bin/codex (authenticated)");
     });
 
+    it("codex: auth-freshness remediation -- names the exact remediation step when codex-cli is configured and auth.json is missing", () => {
+      const check = checkCodexCliPresent({
+        env: { MINER_CODING_AGENT_PROVIDER: "codex-cli" },
+        resolveCodexPath: () => "/usr/bin/codex",
+        resolveCodexAuthPath: () => join(tempRoot(), "does-not-exist.json"),
+      });
+      expect(check.ok).toBe(true);
+      expect(check.detail).toBe(
+        "found at /usr/bin/codex but auth.json is missing or expired — run `codex auth` to authenticate before attempts run",
+      );
+    });
+
+    it("codex: auth-freshness remediation -- no remediation message when codex-cli is configured and auth.json IS present", () => {
+      const authFile = join(tempRoot(), "auth.json");
+      writeFileSync(authFile, "{}");
+      const check = checkCodexCliPresent({
+        env: { MINER_CODING_AGENT_PROVIDER: "codex-cli" },
+        resolveCodexPath: () => "/usr/bin/codex",
+        resolveCodexAuthPath: () => authFile,
+      });
+      expect(check.detail).toBe("found at /usr/bin/codex (authenticated)");
+      expect(check.detail).not.toContain("run `codex auth`");
+    });
+
+    it("codex: auth-freshness remediation -- a DIFFERENT provider configured keeps the generic advisory message unchanged", () => {
+      const check = checkCodexCliPresent({
+        env: { MINER_CODING_AGENT_PROVIDER: "claude-cli" },
+        resolveCodexPath: () => "/usr/bin/codex",
+        resolveCodexAuthPath: () => join(tempRoot(), "does-not-exist.json"),
+      });
+      expect(check.detail).toBe("found at /usr/bin/codex (not authenticated: run `codex auth`)");
+    });
+
+    it("invariant: the unconfigured-provider message shape never changes regardless of auth.json state", () => {
+      const authMissing = checkCodexCliPresent({
+        env: {},
+        resolveCodexPath: () => "/usr/bin/codex",
+        resolveCodexAuthPath: () => join(tempRoot(), "does-not-exist.json"),
+      });
+      const authPresentFile = join(tempRoot(), "auth.json");
+      writeFileSync(authPresentFile, "{}");
+      const authPresent = checkCodexCliPresent({
+        env: {},
+        resolveCodexPath: () => "/usr/bin/codex",
+        resolveCodexAuthPath: () => authPresentFile,
+      });
+      expect(authMissing.detail).toBe("found at /usr/bin/codex (not authenticated: run `codex auth`)");
+      expect(authPresent.detail).toBe("found at /usr/bin/codex (authenticated)");
+    });
+
     it("invariant: an unconfigured (or differently-configured) provider's CLI check is never reported as ok: false regardless of CLI presence", () => {
       const missingUnconfigured = checkClaudeCliPresent({ env: {}, resolveClaudePath: () => null });
       const presentUnconfigured = checkClaudeCliPresent({ env: {}, resolveClaudePath: () => "/usr/bin/claude" });


### PR DESCRIPTION
## Summary

- `checkCodexCliPresent` in `packages/gittensory-miner/lib/laptop-init.js` already stats `auth.json` for readability, but reported the same generic advisory string regardless of whether `codex-cli` is actually the configured driver. Now that #5165 landed the provider-gating this depends on, this issue narrows the codex-specific message further.
- When `MINER_CODING_AGENT_PROVIDER === "codex-cli"` and `auth.json` is missing or unreadable, the check now surfaces a specific, actionable remediation: `found at <path> but auth.json is missing or expired — run \`codex auth\` to authenticate before attempts run`.
- The unconfigured (or differently-configured) case's message is completely unchanged: `found at <path> (not authenticated: run \`codex auth\`)`.
- No new subprocess execution or network call -- this only refines the message text of an already-existing filesystem-stat-based check.
- `ok`'s gating logic itself is untouched (owned entirely by #5165) -- this is a message-quality refinement for the already-`ok: true` (CLI-present-but-unauthenticated) case, not a behavioral bug fix.

## Test plan

- [x] `npx vitest run test/unit/miner-cli-doctor-checks.test.ts` -- 20/20 passing, including 4 new cases: the codex-configured + auth-missing remediation message, the codex-configured + auth-present case (no remediation text), a different-provider-configured case keeping the generic message unchanged, and an invariant that the unconfigured-provider message shape never changes regardless of `auth.json` state.
- [x] `npm run typecheck` -- clean.
- [x] `npm run build:miner` -- clean (`node --check` on every shipped miner lib file passes).
- [x] `npm run docs:drift-check` -- clean.
- [ ] `packages/gittensory-miner/**` currently sits outside vitest's `coverage.include` glob (per the issue's own Codecov-visibility note), so `codecov/patch` cannot measure this change yet -- treating the tests above as the enforced house standard regardless, per the issue's instructions.
- [ ] Did not run the full unsharded `npm run test:coverage` locally (shared/resource-contended machine); relying on the targeted test run above plus `npm run typecheck`/`build:miner`.

Fixes #5166.