### PR TITLE
docs(review): fix docs pages that describe checkRunMode/reviewCheckMode backwards

### DIFF
--- a/apps/gittensory-ui/src/routes/docs.github-app.tsx
+++ b/apps/gittensory-ui/src/routes/docs.github-app.tsx
@@ -150,9 +150,9 @@ GET /v1/installations/:id/repair`}
         <code>disabled</code>). <strong>Gittensory Context</strong> is the separate advisory
         companion, controlled by its own <code>checkRunMode</code> (<code>off</code> /{" "}
         <code>enabled</code>) — these two switches are independent axes, not one setting for both
-        checks. <code>checkRunDetailLevel</code> (<code>minimal</code> / <code>standard</code>)
-        only affects <strong>Gittensory Context</strong>'s output depth; it has no effect on the
-        Orb Review Agent check.
+        checks. <code>checkRunDetailLevel</code> (<code>minimal</code> / <code>standard</code>) only
+        affects <strong>Gittensory Context</strong>'s output depth; it has no effect on the Orb
+        Review Agent check.
       </p>
       <p>
         <strong>Gittensory Context</strong> is advisory and should not be required in branch

--- a/apps/gittensory-ui/src/routes/docs.github-app.tsx
+++ b/apps/gittensory-ui/src/routes/docs.github-app.tsx
@@ -145,11 +145,14 @@ GET /v1/installations/:id/repair`}
       <h2>Checks</h2>
       <p>
         The gittensory app publishes its review as check runs.{" "}
-        <strong>Gittensory Orb Review Agent</strong> is the gate result;{" "}
-        <strong>Gittensory Context</strong> is the advisory companion. Both are controlled per repo
-        by <code>checkRunMode</code> (<code>off</code> / <code>enabled</code>), with{" "}
-        <code>checkRunDetailLevel</code> choosing <code>minimal</code>, <code>standard</code>, or{" "}
-        <code>deep</code> output.
+        <strong>Gittensory Orb Review Agent</strong> is the gate result, controlled by{" "}
+        <code>reviewCheckMode</code> (<code>required</code> / <code>visible</code> /{" "}
+        <code>disabled</code>). <strong>Gittensory Context</strong> is the separate advisory
+        companion, controlled by its own <code>checkRunMode</code> (<code>off</code> /{" "}
+        <code>enabled</code>) — these two switches are independent axes, not one setting for both
+        checks. <code>checkRunDetailLevel</code> (<code>minimal</code> / <code>standard</code>)
+        only affects <strong>Gittensory Context</strong>'s output depth; it has no effect on the
+        Orb Review Agent check.
       </p>
       <p>
         <strong>Gittensory Context</strong> is advisory and should not be required in branch

--- a/apps/gittensory-ui/src/routes/docs.how-reviews-work.tsx
+++ b/apps/gittensory-ui/src/routes/docs.how-reviews-work.tsx
@@ -299,8 +299,8 @@ function HowReviewsWork() {
         <strong>Gittensory Context</strong> check, not the Orb Review Agent gate check:{" "}
         <code>checkRunMode</code> (<code>off</code> / <code>enabled</code>) publishes it, and{" "}
         <code>checkRunDetailLevel</code> (<code>minimal</code> / <code>standard</code>) sets how
-        much the check summary spells out. <strong>Gittensory Orb Review Agent</strong> is
-        published separately, controlled by <code>reviewCheckMode</code> (see above).
+        much the check summary spells out. <strong>Gittensory Orb Review Agent</strong> is published
+        separately, controlled by <code>reviewCheckMode</code> (see above).
       </p>
 
       <h2>Putting it together</h2>

--- a/apps/gittensory-ui/src/routes/docs.how-reviews-work.tsx
+++ b/apps/gittensory-ui/src/routes/docs.how-reviews-work.tsx
@@ -295,11 +295,12 @@ function HowReviewsWork() {
         </li>
       </ul>
       <p>
-        The check run can carry the same signals at adjustable depth: <code>checkRunMode</code> (
-        <code>off</code> / <code>enabled</code>) publishes the{" "}
-        <strong>Gittensory Orb Review Agent</strong> check, and <code>checkRunDetailLevel</code> (
-        <code>minimal</code> / <code>standard</code> / <code>deep</code>) sets how much the check
-        summary spells out.
+        The check run can carry the same signals at adjustable depth — but this is the{" "}
+        <strong>Gittensory Context</strong> check, not the Orb Review Agent gate check:{" "}
+        <code>checkRunMode</code> (<code>off</code> / <code>enabled</code>) publishes it, and{" "}
+        <code>checkRunDetailLevel</code> (<code>minimal</code> / <code>standard</code>) sets how
+        much the check summary spells out. <strong>Gittensory Orb Review Agent</strong> is
+        published separately, controlled by <code>reviewCheckMode</code> (see above).
       </p>
 
       <h2>Putting it together</h2>

--- a/apps/gittensory-ui/src/routes/docs.tuning.tsx
+++ b/apps/gittensory-ui/src/routes/docs.tuning.tsx
@@ -472,9 +472,11 @@ function Tuning() {
           <code>publicSignalLevel</code> — <code>minimal</code> / <code>standard</code> (default).
         </li>
         <li>
-          <code>checkRunMode</code> — check-run publishing: <code>off</code> (default) /{" "}
-          <code>enabled</code>. Pair with <code>checkRunDetailLevel</code> (<code>minimal</code>{" "}
-          (default) / <code>standard</code> / <code>deep</code>).
+          <code>checkRunMode</code> — publishes the <strong>Gittensory Context</strong> check
+          (not the <strong>Orb Review Agent</strong> gate check, which is{" "}
+          <code>reviewCheckMode</code>): <code>off</code> (default) / <code>enabled</code>. Pair
+          with <code>checkRunDetailLevel</code> (<code>minimal</code> (default) /{" "}
+          <code>standard</code>).
         </li>
         <li>
           <code>publicSurface</code> — <code>off</code> / <code>comment_and_label</code> (default) /{" "}

--- a/apps/gittensory-ui/src/routes/docs.tuning.tsx
+++ b/apps/gittensory-ui/src/routes/docs.tuning.tsx
@@ -472,11 +472,10 @@ function Tuning() {
           <code>publicSignalLevel</code> — <code>minimal</code> / <code>standard</code> (default).
         </li>
         <li>
-          <code>checkRunMode</code> — publishes the <strong>Gittensory Context</strong> check
-          (not the <strong>Orb Review Agent</strong> gate check, which is{" "}
-          <code>reviewCheckMode</code>): <code>off</code> (default) / <code>enabled</code>. Pair
-          with <code>checkRunDetailLevel</code> (<code>minimal</code> (default) /{" "}
-          <code>standard</code>).
+          <code>checkRunMode</code> — publishes the <strong>Gittensory Context</strong> check (not
+          the <strong>Orb Review Agent</strong> gate check, which is <code>reviewCheckMode</code>):{" "}
+          <code>off</code> (default) / <code>enabled</code>. Pair with{" "}
+          <code>checkRunDetailLevel</code> (<code>minimal</code> (default) / <code>standard</code>).
         </li>
         <li>
           <code>publicSurface</code> — <code>off</code> / <code>comment_and_label</code> (default) /{" "}

--- a/src/review/repo-profile.ts
+++ b/src/review/repo-profile.ts
@@ -55,10 +55,12 @@ export type RepoProfileCommands = {
 };
 
 export type RepoProfileContributionWorkflow = {
-  /** Whether the review gate publishes a check at all, derived from `settings.reviewCheckMode` -- the actual
-   *  runtime authority for check publication (#2852); `gateCheckMode`/`checkRunMode` are legacy fields kept
-   *  only for API/back-compat display and no longer drive this decision. Reuses the EXISTING settings
-   *  resolver rather than re-deriving gate presence from raw repo files. */
+  /** Whether the review gate (the "Gittensory Orb Review Agent" check) publishes a check at all, derived
+   *  from `settings.reviewCheckMode` -- the actual runtime authority for that check's publication (#2852).
+   *  `gateCheckMode` is a genuinely legacy, deprecated read-back field (#4618) kept only for API/back-compat
+   *  display and no longer drives anything. `checkRunMode` is NOT legacy -- it's a live, independent field
+   *  that governs the SEPARATE "Gittensory Context" check, unrelated to this one. Reuses the EXISTING
+   *  settings resolver rather than re-deriving gate presence from raw repo files. */
   gatePublishesCheck: boolean;
   linkedIssuePolicy: "required" | "preferred" | "optional";
   requireLinkedIssue: boolean;

--- a/src/types.ts
+++ b/src/types.ts
@@ -706,6 +706,11 @@ export type RepositorySettings = {
   commentMode: "off" | "detected_contributors_only" | "all_prs";
   publicAudienceMode: "oss_maintainer" | "gittensor_only";
   publicSignalLevel: "minimal" | "standard";
+  /** Publishes the SEPARATE, always-advisory "Gittensory Context" check-run (#2691) -- entirely independent
+   *  of {@link reviewCheckMode}, which governs the "Gittensory Orb Review Agent" gate check. Despite the
+   *  similar name and shape, this is NOT a sibling/legacy-alias of reviewCheckMode; the two checks are
+   *  different check-runs with different controlling fields (a mismatch already caused real doc drift --
+   *  see the disambiguation in README's "Check-run and comment surfaces" section). */
   checkRunMode: "off" | "enabled";
   // #4620: "deep" removed -- it was never wired to any different behavior than "standard" (formatCheckRunOutput
   // and buildCheckRunAnnotations in rules/advisory.ts both branch only on `=== "minimal"` vs not).


### PR DESCRIPTION
## Summary
- `docs.how-reviews-work.tsx:298-301` claimed `checkRunMode` publishes the "Gittensory Orb Review Agent" check — backwards; it publishes "Gittensory Context".
- `docs.github-app.tsx:149-152` claimed both checks are controlled by `checkRunMode` — false for the Gate check, and self-contradicts the same file's own correct statement 15 lines later that `reviewCheckMode` is the gate's authority.
- `src/review/repo-profile.ts`'s `gatePublishesCheck` doc lumped live `checkRunMode` in with genuinely-deprecated `gateCheckMode` as "legacy" — scoped that claim correctly.
- Added a JSDoc to `checkRunMode` (previously had none) cross-referencing `reviewCheckMode`.
- Removed the stale `deep` `checkRunDetailLevel` option from 3 docs pages — the type was narrowed to `minimal | standard` in #4620, "deep" was never removed from prose.

## Scope
Docs/comment-only: `docs.how-reviews-work.tsx`, `docs.github-app.tsx`, `docs.tuning.tsx`, `src/review/repo-profile.ts`, `src/types.ts`.

## Validation
- `npm run typecheck` — clean
- `npm run ui:typecheck` — clean
- `npx vitest run test/unit/docs-github-app.test.ts test/unit/check-docs-drift-script.test.ts` — 35/35 passing (the existing assertions on unchanged nearby text still hold)
- `npm run docs:drift-check` — clean

## Safety
No behavior change, docs/comments only.

Closes #5283