### PR TITLE
feat(ci): bring miner package under Codecov patch gate (#4864)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -29,8 +29,9 @@ comment:
   layout: "condensed_header, diff, flags, files"
   require_changes: false
 
-# Coverage is collected by vitest (v8) over src/**; mirror its exclusions so the
-# Codecov total matches the local report.
+# Coverage is collected by vitest (v8) over src/**, packages/gittensory-engine/src/**,
+# and packages/gittensory-miner/lib/**; mirror its exclusions so the Codecov total
+# matches the local report.
 ignore:
   - "src/env.d.ts"
   - "apps/**"

--- a/test/unit/codecov-policy.test.ts
+++ b/test/unit/codecov-policy.test.ts
@@ -75,6 +75,16 @@ describe("Codecov policy", () => {
     expect(testResultsUploadWith.fail_ci_if_error).toBe(false);
   });
 
+  it("measures miner lib changes for codecov patch coverage (#4864)", () => {
+    const vitestConfig = readFileSync("vitest.config.ts", "utf8");
+    expect(vitestConfig).toMatch(/packages\/gittensory-miner\/lib\/\*\*\/\*\.js/);
+
+    const config = readYaml("codecov.yml");
+    const ignore = config.ignore;
+    if (!Array.isArray(ignore)) throw new Error("codecov.yml ignore must be an array");
+    expect(ignore.some((entry) => typeof entry === "string" && entry.includes("gittensory-miner"))).toBe(false);
+  });
+
   it("uploads fork PR coverage tokenlessly instead of silently skipping it", () => {
     // Fork PRs cannot read secrets.CODECOV_TOKEN. Previously the token-gated upload steps simply
     // excluded forks with no replacement, so codecov/patch had no report to compare against and fell

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -26,7 +26,12 @@ export default defineConfig({
     ...(junitPath ? { outputFile: { junit: junitPath } } : {}),
     coverage: {
       provider: "v8",
-      include: ["src/**/*.ts", "packages/gittensory-engine/src/**/*.ts", "review-enrichment/src/analyzers/codeowners.ts"],
+      include: [
+        "src/**/*.ts",
+        "packages/gittensory-engine/src/**/*.ts",
+        "packages/gittensory-miner/lib/**/*.js",
+        "review-enrichment/src/analyzers/codeowners.ts",
+      ],
       exclude: ["src/env.d.ts", "apps/**"],
       // Emit lcov for Codecov to compute patch (changed-lines) coverage.
       reporter: ["text", "lcov"],


### PR DESCRIPTION
## Summary

Adds `packages/gittensory-miner/lib/**/*.js` to the vitest v8 coverage `include` list so changed miner library lines appear in the uploaded `lcov.info` report. Codecov's existing 99% `patch` gate then applies to miner diffs the same way it already does for `src/**` and `packages/gittensory-engine/src/**`.

Miner tests already run in CI (`test:miner-pack`, path-filtered validate-tests); this closes the gap where those tests could pass without any patch-coverage obligation on miner code.

Closes #4864

## Changes

| Area | Change |
|------|--------|
| `vitest.config.ts` | Include `packages/gittensory-miner/lib/**/*.js` in coverage collection |
| `codecov.yml` | Document miner lib as a measured path (no new `ignore` entries) |
| `test/unit/codecov-policy.test.ts` | Regression: miner lib is in vitest include and not codecov-ignored |

## Scope notes

- **Measured:** `packages/gittensory-miner/lib/**/*.js` only — same pattern as engine's `src/**` focus; thin `bin/` entrypoints stay out of the include list (mirrors how `src/server.ts` is codecov-ignored).
- **This PR:** config + policy test only — no miner runtime changes. Patch coverage on this PR itself applies only to the test file under `test/**` (codecov-ignored) and non-`src/**` config files.
- **Follow-on PRs** that touch miner lib must hit 99% patch coverage (lines **and** branches) on changed hunks, same bar as backend `src/**`.

## Test plan

- [x] `npm run test:unit -- test/unit/codecov-policy.test.ts`
- [ ] `npm run test:ci` (full gate)
- [ ] `npm run test:coverage` — confirm merged lcov lists `packages/gittensory-miner/lib/**` paths
- [ ] After merge: open a small miner-lib PR and confirm `codecov/patch` evaluates changed miner lines

## Notes

- Issue labels: `help wanted`, `gittensor:priority`, `gittensor:feature` — confirm contributor eligibility before opening.
- `.claude/skills/contributing-to-gittensory/reference.md` still says coverage include is `src/**/*.ts` only; a separate doc tweak may be warranted after this lands.
- Existing miner unit tests under `test/unit/miner-*.test.ts` already import from `packages/gittensory-miner/lib/**`; no new behavioral tests required for this wiring change.
