### PR TITLE
docs(config): document the shared.gittensory.yml (_shared) layer on quick-reference surfaces

### DIFF
--- a/apps/gittensory-ui/src/routes/docs.self-hosting-configuration.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-configuration.tsx
@@ -122,6 +122,11 @@ function SelfHostingConfiguration() {
             description:
               "Private self-host only — illustrative fleet global default and per-repo overlay (deep-merge). Never commit real policy into these example paths.",
           },
+          {
+            title: "shared.gittensory.yml",
+            description:
+              "Private self-host only — lowest-priority cross-repo house policy for an operator running many repos (#1959). Write a default once instead of copy-pasting it into every repo's file.",
+          },
         ]}
       />
       <CodeBlock
@@ -163,6 +168,13 @@ cp config/examples/global.gittensory.yml gittensory-config/.gittensory.yml`}
             <code>config/examples/TEMPLATES.md</code>
           </a>{" "}
           — catalog + fleet usage notes
+        </li>
+        <li>
+          <a href="https://github.com/JSONbored/gittensory/blob/main/config/examples/README.md">
+            <code>config/examples/README.md</code>
+          </a>{" "}
+          — the full private-config layout, precedence chain, and deep-merge semantics, including
+          the shared base layer
         </li>
       </ul>
       <p>

--- a/config/examples/TEMPLATES.md
+++ b/config/examples/TEMPLATES.md
@@ -12,6 +12,7 @@ mount (`GITTENSORY_REPO_CONFIG_DIR`).
 | [`gittensory.full.yml`](./gittensory.full.yml) | Exhaustive commented reference — every `gate:`, `settings:`, `review:`, and `features:` field |
 | [`global.gittensory.yml`](./global.gittensory.yml) | **Private only** — illustrative fleet-wide default for a self-host mount |
 | [`repo-override.gittensory.yml`](./repo-override.gittensory.yml) | **Private only** — per-repo overlay deep-merged over `global.gittensory.yml` |
+| [`shared.gittensory.yml`](./shared.gittensory.yml) | **Private only** — lowest-priority cross-repo house policy for multi-repo operators (#1959) |
 
 Canonical copies of the minimal and full templates also live at the repo root as
 [`.gittensory.minimal.yml`](../../.gittensory.minimal.yml) and
@@ -25,6 +26,7 @@ in sync with those files.
 | **Public** | `.gittensory.yml` or `.github/gittensory.yml` in git | Contributors | `wantedPaths`, test expectations, public review presentation |
 | **Private global** | `${GITTENSORY_REPO_CONFIG_DIR}/.gittensory.yml` | Operator only | Shared autonomy baseline, contributor caps, maintainer allowlists |
 | **Private per-repo** | `${GITTENSORY_REPO_CONFIG_DIR}/owner__repo/.gittensory.yml` | Operator only | Repo-specific CI context names, AI mode, overrides |
+| **Private shared base** | `${GITTENSORY_REPO_CONFIG_DIR}/_shared/.gittensory.yml` | Operator only | Lowest-priority cross-repo house policy for an operator running many repos (#1959) — see [README's "Shared base layer" section](./README.md#shared-base-layer-multi-repo-operators-1959) |
 
 When **either** a private global or private per-repo file exists, the loader **never fetches** the
 public repo file for that review — mount private policy deliberately. See [README.md](./README.md)

--- a/config/examples/gittensory.full.yml
+++ b/config/examples/gittensory.full.yml
@@ -16,6 +16,7 @@
 #   gittensory.full.yml     — this file — every gate:/settings:/review:/features: field documented
 #   global.gittensory.yml   — private fleet global default (illustrative placeholders only)
 #   repo-override.gittensory.yml — private per-repo overlay example
+#   shared.gittensory.yml   — private cross-repo house policy, lowest-priority layer (#1959)
 #
 # ============================================================================
 # .gittensory.yml — per-repo configuration for gittensory CI & gittensory review

--- a/config/examples/gittensory.minimal.yml
+++ b/config/examples/gittensory.minimal.yml
@@ -4,9 +4,11 @@
 #
 # WHERE TO COPY (pick one):
 #   PUBLIC REPO — repo root as `.gittensory.yml` (or `.github/gittensory.yml`). Contributors can read it.
-#   PRIVATE SELF-HOST — `${GITTENSORY_REPO_CONFIG_DIR}/.gittensory.yml` (global default) or
-#     `${GITTENSORY_REPO_CONFIG_DIR}/owner__repo/.gittensory.yml` (per-repo override). Never commit real
-#     policy here to a public repo — use the private mount for thresholds, allowlists, and autonomy.
+#   PRIVATE SELF-HOST — `${GITTENSORY_REPO_CONFIG_DIR}/.gittensory.yml` (global default),
+#     `${GITTENSORY_REPO_CONFIG_DIR}/owner__repo/.gittensory.yml` (per-repo override), or
+#     `${GITTENSORY_REPO_CONFIG_DIR}/_shared/.gittensory.yml` (lowest-priority cross-repo base, #1959).
+#     Never commit real policy here to a public repo — use the private mount for thresholds,
+#     allowlists, and autonomy.
 #
 # Canonical copy also lives at the repo root as `.gittensory.minimal.yml` (kept in sync by CI).
 # For every supported field, defaults, and allowed values see `gittensory.full.yml` or


### PR DESCRIPTION
## Summary
The private shared-base layer (#1959, lowest-priority cross-repo house policy for multi-repo operators) is real, shipped, and fully tested — but invisible on every "quick reference" surface: `TEMPLATES.md`'s catalog and layer table, both example-file headers, and the live `docs.self-hosting-configuration.tsx` page all omitted it. They were written ~3 hours before #1959 landed and never revisited. `config/examples/README.md` already documents it correctly and completely — this PR adds it everywhere else and links to README for the full precedence explanation.

## Scope
Doc-only, additive: `config/examples/TEMPLATES.md`, `config/examples/gittensory.full.yml` (header, before the sync marker), `config/examples/gittensory.minimal.yml` (header, before the sync marker), `docs.self-hosting-configuration.tsx`.

## Validation
- `npm run typecheck` — clean
- `npx vitest run test/unit/config-templates.test.ts test/unit/docs-selfhost-activation-paths.test.ts` — 23/23 (confirms the header edits stayed before the byte-sync marker)
- `npm run docs:drift-check` — clean
- `npm run ui:lint` — clean (0 errors)

Closes #5273