### PR TITLE
fix(selfhost): recognize experimental: as a valid top-level manifest field

### DIFF
--- a/src/selfhost/config-lint.ts
+++ b/src/selfhost/config-lint.ts
@@ -14,6 +14,7 @@ const TOP_LEVEL_FIELDS = [
   "settings",
   "review",
   "features",
+  "experimental",
   "contentLane",
   "repoDocGeneration",
   "reviewRecap",

--- a/test/unit/selfhost-config-lint.test.ts
+++ b/test/unit/selfhost-config-lint.test.ts
@@ -72,6 +72,19 @@ reviewRecap:
     expect(result.recognizedFields).toEqual(["repoDocGeneration"]);
   });
 
+  it("REGRESSION: recognizes a standalone experimental: block instead of flagging it as unknown (#5281)", () => {
+    // experimental is a fully real, actively-parsed top-level manifest field (#5030, the gittensor subnet
+    // plugin) that was missing from this linter's TOP_LEVEL_FIELDS allowlist -- #5030 touched
+    // focus-manifest.ts/index.ts/env.d.ts/gittensor-wire.ts/focus-manifest-loader.ts and the example YAML, but
+    // not this file, so a self-host operator using it got a false "unknown top-level field" warning even
+    // though the field works correctly. Confirmed live: all 3 production self-host repo configs declare it.
+    const result = lintManifestText("experimental:\n  gittensor: true\n");
+
+    expect(result.ok).toBe(true);
+    expect(result.warnings).toEqual([]);
+    expect(result.recognizedFields).toEqual(["experimental"]);
+  });
+
   it("recognizes a standalone reviewRecap: block instead of flagging it as unknown (#1963)", () => {
     const result = lintManifestText("reviewRecap:\n  enabled: true\n  cadenceDays: 14\n");
 


### PR DESCRIPTION
## Summary
#5030 (the gittensor subnet plugin) added a real, actively-parsed `experimental:` top-level manifest block, but never updated `src/selfhost/config-lint.ts`'s `TOP_LEVEL_FIELDS` allowlist — the same class of bug already fixed once in this exact file for `repoDocGeneration` (#3364). All 3 production self-host repo configs declare `experimental: { gittensor: true }` today; running `npm run selfhost:config-lint` against any of them produces a false "unknown top-level field" warning.

## Scope
`src/selfhost/config-lint.ts` (one line), `test/unit/selfhost-config-lint.test.ts` (regression test mirroring the #3364 precedent).

## Validation
- `npm run typecheck` — clean
- `npx vitest run test/unit/selfhost-config-lint.test.ts test/unit/gittensory-config-lint-script.test.ts` — 28/28
- Scoped coverage on `config-lint.ts`: 100% statements/branches/functions/lines
- `npm run docs:drift-check` — clean
- Verified by re-running the CLI against a live production config snapshot after this fix — no false positive on `experimental`

Closes #5281