### PR TITLE
docs(engine): document the readinessMode/readinessMinScore engine-layer rename

### DIFF
--- a/packages/gittensory-engine/src/focus-manifest.ts
+++ b/packages/gittensory-engine/src/focus-manifest.ts
@@ -83,6 +83,10 @@ export type FocusManifestGateConfig = {
   pack: GatePolicyPack | null;
   linkedIssue: GateRuleMode | null;
   duplicates: GateRuleMode | null;
+  /** `gate.readiness.mode`/`gate.readiness.minScore` -- this engine-layer pair folds into
+   *  `RepositorySettings.qualityGateMode`/`qualityGateMinScore` (src/signals/focus-manifest.ts), a third
+   *  spelling of the same concept alongside the yml key name; the `readiness` gate is distinct from the
+   *  separate `mergeReadiness` composite gate above. */
   readinessMode: GateRuleMode | null;
   readinessMinScore: number | null;
   slopMode: GateRuleMode | null;


### PR DESCRIPTION
## Summary
\`FocusManifestGateConfig\`'s \`readinessMode\`/\`readinessMinScore\` fold into \`RepositorySettings.qualityGateMode\`/\`qualityGateMinScore\` — a third spelling of the same concept the yml-key rename already covers via \`check-docs-drift.mjs\`'s alias manifest, but undocumented at the engine-layer type itself (unlike its sibling \`checkMode\` two lines above, which does cross-reference its DB counterpart).

Deliberately did **not** add a \`check-docs-drift.mjs\` enforcement entry — that script's own \`FOCUS_MANIFEST_SKIP_TOP_LEVEL_FIELDS\` comment already documents this exact renaming pattern class as intentionally non-exhaustive. Also skipped mirroring on \`predicted-gate-types.ts\` — that type comments zero fields (not even its own \`checkMode\`), so adding one only to \`readinessMode\` there would be inconsistent with its established style.

## Scope
Comment-only, one file.

## Validation
- \`npm --workspace @jsonbored/gittensory-engine run build\` — clean
- \`npm run typecheck\` — clean

Closes #5285