### PR TITLE
feat(miner-deployment): add <NAME>_FILE secrets-file indirection for fleet mode

### DIFF
--- a/packages/gittensory-miner/bin/gittensory-miner.js
+++ b/packages/gittensory-miner/bin/gittensory-miner.js
@@ -2,6 +2,7 @@
 import { runAttempt } from "../lib/attempt-cli.js";
 import { printHelp, printVersion, runCli } from "../lib/cli.js";
 import { runDenyCheck } from "../lib/deny-check.js";
+import { loadFileSecrets } from "../lib/load-file-secrets.js";
 import { runDiscover } from "../lib/discover-cli.js";
 import { runFeasibilityCli } from "../lib/feasibility-cli.js";
 import { runGovernorCli } from "../lib/governor-ledger-cli.js";
@@ -24,6 +25,10 @@ import {
 import { resolveMinerVersion } from "../lib/version.js";
 
 const cliArgs = process.argv.slice(2);
+
+// Resolve `<NAME>_FILE` secret mounts (Docker/K8s) into `<NAME>` before ANY command reads the env, so a
+// file-supplied GITHUB_TOKEN / coding-agent credential is never required to be a plaintext env var (#5178).
+loadFileSecrets();
 
 // `init`, `status`, and `doctor` are strictly local, offline commands — their contract is to make NO network calls.
 // Dispatch them BEFORE the opportunistic npm-registry update check is even started, so they can never reach that

--- a/packages/gittensory-miner/lib/load-file-secrets.d.ts
+++ b/packages/gittensory-miner/lib/load-file-secrets.d.ts
@@ -1,0 +1,10 @@
+/**
+ * Resolve `<NAME>_FILE` env vars (Docker/Kubernetes secret mounts) into `<NAME>` at miner startup. An explicit
+ * `<NAME>` wins — including an explicit EMPTY value (presence is tested, not truthiness, so `GITHUB_TOKEN=` is
+ * never clobbered by the file). Compose-reserved `_FILE` vars are ignored; an unreadable file is logged and
+ * skipped, never thrown. `env`/`readFile` are injectable for tests; real callers use `process.env` + `readFileSync`.
+ */
+export function loadFileSecrets(
+  env?: Record<string, string | undefined>,
+  readFile?: (path: string) => string,
+): void;

--- a/packages/gittensory-miner/lib/load-file-secrets.js
+++ b/packages/gittensory-miner/lib/load-file-secrets.js
@@ -1,0 +1,54 @@
+import { readFileSync } from "node:fs";
+
+// Resolve `<NAME>_FILE` env vars (Docker/Swarm/Kubernetes secret mounts) into `<NAME>` at miner startup, so an
+// operator can supply GITHUB_TOKEN (and coding-agent credentials) via a mounted file instead of a plaintext env
+// var visible through `docker inspect`. Ported from the review stack's proven pattern (src/selfhost/
+// load-file-secrets.ts, #4403) into the miner package (#5178). Call once, before any command reads the env.
+
+// Docker Compose's OWN reserved `_FILE`-suffixed variables — never a gittensory secret-file convention, so they
+// must never be dereferenced: `COMPOSE_FILE` is a colon-delimited list of compose paths (not a readable single
+// file), and `COMPOSE_ENV_FILE` points at an operator's .env file, not a secret. A real credential is never
+// named exactly one of these.
+const COMPOSE_RESERVED_FILE_VARS = new Set([
+  "COMPOSE_FILE",
+  "COMPOSE_ENV_FILE",
+]);
+
+/**
+ * For every `<NAME>_FILE` env var, read its file and set `<NAME>` to the trimmed contents — unless `<NAME>` is
+ * already set explicitly (an explicit value always wins) or the var is a Compose-reserved name. An unreadable
+ * file is logged and skipped rather than throwing, so one bad mount never crashes startup. `env`/`readFile` are
+ * injectable purely for tests; every real caller uses the defaults, so this is byte-identical at runtime.
+ * @param {Record<string, string | undefined>} [env]
+ * @param {(path: string) => string} [readFile]
+ * @returns {void}
+ */
+export function loadFileSecrets(
+  env = process.env,
+  readFile = (path) => readFileSync(path, "utf8"),
+) {
+  for (const key of Object.keys(env)) {
+    if (
+      !key.endsWith("_FILE") ||
+      !env[key] ||
+      COMPOSE_RESERVED_FILE_VARS.has(key)
+    )
+      continue;
+    const target = key.slice(0, -"_FILE".length);
+    // An explicit value wins — INCLUDING an explicit empty string. Test `!== undefined` (presence), not
+    // truthiness: `GITHUB_TOKEN=` set alongside `GITHUB_TOKEN_FILE=…` is a deliberate empty value the file
+    // must not silently overwrite. (A plain-truthiness check here would treat `''` as unset — the defect.)
+    if (env[target] !== undefined) continue;
+    try {
+      env[target] = readFile(env[key]).trim();
+    } catch {
+      console.error(
+        JSON.stringify({
+          level: "error",
+          event: "miner_secret_file_unreadable",
+          var: key,
+        }),
+      );
+    }
+  }
+}

--- a/test/unit/miner-load-file-secrets.test.ts
+++ b/test/unit/miner-load-file-secrets.test.ts
@@ -1,0 +1,107 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { loadFileSecrets } from "../../packages/gittensory-miner/lib/load-file-secrets.js";
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("loadFileSecrets (#5178)", () => {
+  it("resolves a <NAME>_FILE var into <NAME> with the trimmed file contents", () => {
+    const env: Record<string, string | undefined> = {
+      GITHUB_TOKEN_FILE: "/run/secrets/gh",
+    };
+    const readFile = vi.fn((path: string) =>
+      path === "/run/secrets/gh" ? "  file-sourced-value\n" : "",
+    );
+    loadFileSecrets(env, readFile);
+    expect(env.GITHUB_TOKEN).toBe("file-sourced-value");
+    expect(readFile).toHaveBeenCalledWith("/run/secrets/gh");
+  });
+
+  it("leaves non-_FILE vars untouched", () => {
+    const env: Record<string, string | undefined> = {
+      PATH: "/usr/bin",
+      GITHUB_TOKEN: "already",
+    };
+    const readFile = vi.fn(() => "unused");
+    loadFileSecrets(env, readFile);
+    expect(env).toEqual({ PATH: "/usr/bin", GITHUB_TOKEN: "already" });
+    expect(readFile).not.toHaveBeenCalled();
+  });
+
+  it("skips a _FILE var with an empty value", () => {
+    const env: Record<string, string | undefined> = {
+      ANTHROPIC_API_KEY_FILE: "",
+    };
+    const readFile = vi.fn(() => "x");
+    loadFileSecrets(env, readFile);
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(readFile).not.toHaveBeenCalled();
+  });
+
+  it("never dereferences Compose-reserved _FILE vars", () => {
+    const env: Record<string, string | undefined> = {
+      COMPOSE_FILE: "a.yml:b.yml",
+      COMPOSE_ENV_FILE: "/x/.env",
+    };
+    const readFile = vi.fn(() => "x");
+    loadFileSecrets(env, readFile);
+    expect(env.COMPOSE).toBeUndefined();
+    expect(env.COMPOSE_ENV).toBeUndefined();
+    expect(readFile).not.toHaveBeenCalled();
+  });
+
+  it("lets an explicit <NAME> win over the file", () => {
+    const env: Record<string, string | undefined> = {
+      GITHUB_TOKEN: "explicit",
+      GITHUB_TOKEN_FILE: "/run/secrets/gh",
+    };
+    const readFile = vi.fn(() => "from_file");
+    loadFileSecrets(env, readFile);
+    expect(env.GITHUB_TOKEN).toBe("explicit");
+    expect(readFile).not.toHaveBeenCalled();
+  });
+
+  it("respects an explicit EMPTY value — never overwrites it from the file (presence, not truthiness)", () => {
+    const env: Record<string, string | undefined> = {
+      GITHUB_TOKEN: "",
+      GITHUB_TOKEN_FILE: "/run/secrets/gh",
+    };
+    const readFile = vi.fn(() => "from_file");
+    loadFileSecrets(env, readFile);
+    expect(env.GITHUB_TOKEN).toBe(""); // the deliberate empty value stands; the file must not clobber it
+    expect(readFile).not.toHaveBeenCalled();
+  });
+
+  it("logs and skips an unreadable secret file instead of throwing", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const env: Record<string, string | undefined> = {
+      OPENAI_API_KEY_FILE: "/missing",
+    };
+    const readFile = vi.fn(() => {
+      throw new Error("ENOENT");
+    });
+    expect(() => loadFileSecrets(env, readFile)).not.toThrow();
+    expect(env.OPENAI_API_KEY).toBeUndefined();
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("miner_secret_file_unreadable"),
+    );
+  });
+
+  it("defaults to process.env and the real filesystem when called with no arguments", () => {
+    const dir = mkdtempSync(join(tmpdir(), "miner-secret-"));
+    const file = join(dir, "token");
+    writeFileSync(file, "  value-from-real-fs\n");
+    process.env.MINER_TEST_TOKEN_FILE = file;
+    delete process.env.MINER_TEST_TOKEN;
+    try {
+      loadFileSecrets();
+      expect(process.env.MINER_TEST_TOKEN).toBe("value-from-real-fs");
+    } finally {
+      delete process.env.MINER_TEST_TOKEN;
+      delete process.env.MINER_TEST_TOKEN_FILE;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
Ports the review stack's proven `load-file-secrets` pattern (`src/selfhost/load-file-secrets.ts`, #4403) into the miner (#5178): at startup, resolve every `<NAME>_FILE` env var (Docker/Kubernetes secret mount) into `<NAME>` by reading the file — so `GITHUB_TOKEN` and coding-agent credentials can be supplied via a mounted file instead of a plaintext env var visible through `docker inspect`. Wired once in `bin/gittensory-miner.js` before any command reads the env.

## Correctness — explicit values win, including an explicit EMPTY string
This is the defect that closed a prior same-issue attempt (#5264): a plain-truthiness check (`if (env[target])`) treats `GITHUB_TOKEN=` as *unset* and lets the file **clobber** the operator's deliberate empty value. This version tests **presence** (`env[target] !== undefined`), so an explicit empty value stands and the file never overwrites it. Compose-reserved `_FILE` vars are ignored; an unreadable file is logged and skipped, never thrown.

## Validation
- **`test/unit/miner-load-file-secrets.test.ts`** (8 tests, **100% branch**): resolves a `<NAME>_FILE` into `<NAME>` (trimmed); leaves non-`_FILE` vars untouched; skips an empty `_FILE` value; never dereferences Compose-reserved vars; **an explicit non-empty AND an explicit empty value both win over the file** (the regression); logs+skips an unreadable file; and defaults to `process.env`+real-fs on a no-arg call.
- `tsc` typecheck clean; prettier-clean; no hardcoded credentials. `packages/gittensory-miner/**` is outside vitest's `coverage.include`, so `codecov/patch` is vacuous — the 100%-branch suite is shipped regardless.

Closes #5178