### PR TITLE
fix(miner): write acceptance criteria safely

### DIFF
--- a/packages/gittensory-miner/lib/coding-task-spec.js
+++ b/packages/gittensory-miner/lib/coding-task-spec.js
@@ -1,5 +1,5 @@
-import { writeFileSync } from "node:fs";
-import { join } from "node:path";
+import { closeSync, constants as fsConstants, openSync, realpathSync, writeFileSync } from "node:fs";
+import { isAbsolute, join, relative } from "node:path";
 import {
   ACCEPTANCE_CRITERIA_FILENAME,
   buildAcceptanceCriteria,
@@ -108,10 +108,26 @@ export function buildCodingTaskAcceptanceCriteria(issue, feasibility) {
  * @param {import("@jsonbored/gittensory-engine").AcceptanceCriteria} acceptanceCriteria
  * @returns {{ written: boolean, path: string | null }}
  */
+function assertContainedPath(root, path) {
+  const relativePath = relative(root, path);
+  if (relativePath === "" || (!relativePath.startsWith("..") && !isAbsolute(relativePath))) return;
+  throw new Error(`Refusing to write acceptance criteria outside the worktree: ${path}`);
+}
+
 export function writeAcceptanceCriteriaFile(workingDirectory, acceptanceCriteria) {
   if (!shouldWriteAcceptanceCriteria(acceptanceCriteria.verdict)) return { written: false, path: null };
-  const path = join(workingDirectory, ACCEPTANCE_CRITERIA_FILENAME);
-  writeFileSync(path, serializeAcceptanceCriteria(acceptanceCriteria), "utf8");
+  const root = realpathSync(workingDirectory);
+  const path = join(root, ACCEPTANCE_CRITERIA_FILENAME);
+  assertContainedPath(root, path);
+
+  let fd;
+  try {
+    fd = openSync(path, fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_EXCL | fsConstants.O_NOFOLLOW, 0o600);
+    writeFileSync(fd, serializeAcceptanceCriteria(acceptanceCriteria), "utf8");
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
+
   return { written: true, path };
 }
 

--- a/test/unit/miner-coding-task-spec.test.ts
+++ b/test/unit/miner-coding-task-spec.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -170,6 +170,29 @@ describe("writeAcceptanceCriteriaFile (#5132)", () => {
 
     const result = writeAcceptanceCriteriaFile(dir, doc);
     expect(result).toEqual({ written: false, path: null });
+  });
+
+  it("REGRESSION: refuses to follow a pre-existing acceptance-criteria symlink", () => {
+    const dir = tempDir();
+    const outside = join(tempDir(), "victim-config.txt");
+    writeFileSync(outside, "keep-me", "utf8");
+    symlinkSync(outside, join(dir, "acceptance-criteria.json"));
+    const feasibility = buildCodingTaskFeasibility("acme/widgets", issue(), { issues: [issue()], pullRequests: [] }, claimLedger());
+    const doc = buildCodingTaskAcceptanceCriteria(issue(), feasibility);
+
+    expect(() => writeAcceptanceCriteriaFile(dir, doc)).toThrow();
+    expect(readFileSync(outside, "utf8")).toBe("keep-me");
+  });
+
+  it("refuses to overwrite a pre-existing acceptance-criteria file", () => {
+    const dir = tempDir();
+    const path = join(dir, "acceptance-criteria.json");
+    writeFileSync(path, "keep-me", "utf8");
+    const feasibility = buildCodingTaskFeasibility("acme/widgets", issue(), { issues: [issue()], pullRequests: [] }, claimLedger());
+    const doc = buildCodingTaskAcceptanceCriteria(issue(), feasibility);
+
+    expect(() => writeAcceptanceCriteriaFile(dir, doc)).toThrow();
+    expect(readFileSync(path, "utf8")).toBe("keep-me");
   });
 });
 


### PR DESCRIPTION
### Motivation
- The previous writer called `writeFileSync` on a fixed path inside the prepared worktree and would follow symlinks, allowing a malicious repository to cause arbitrary writable files to be clobbered outside the worktree.
- Harden the writer to refuse symlink-following writes and to fail-closed when a pre-existing entry exists at the fixed path.

### Description
- Replace the direct `writeFileSync(join(workingDirectory, ACCEPTANCE_CRITERIA_FILENAME), ...)` with a safe sequence that resolves the worktree root via `realpathSync`, composes the output path, verifies containment, and creates the file with `openSync(... O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW, 0o600)` before writing via the file descriptor and closing it (added `closeSync`, `openSync`, `realpathSync`, and `fsConstants` imports) in `packages/gittensory-miner/lib/coding-task-spec.js`.
- Add an `assertContainedPath` check to ensure the computed output path remains inside the resolved worktree and throw if not.
- Add regression tests in `test/unit/miner-coding-task-spec.test.ts` that verify a pre-existing `acceptance-criteria.json` symlink is not followed (outside file not clobbered) and that an existing file at the path is not overwritten, and update test imports accordingly.

### Testing
- Ran `git diff --check` and it passed.
- Built the miner with `npm run build:miner` and the build succeeded.
- Ran the focused unit tests with `npx vitest run test/unit/miner-coding-task-spec.test.ts` and all tests in that file passed.
- `npm audit --audit-level=moderate` could not be completed in this environment (registry returned 403) and is noted as a non-blocking environment limitation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a538726dd20832ca3fd9bb06c3c5201)