### PR TITLE
fix(review): add expression index for case-insensitive calibration login lookup

### DIFF
--- a/migrations/0147_predicted_gate_calibration_ledger_login_lower_idx.sql
+++ b/migrations/0147_predicted_gate_calibration_ledger_login_lower_idx.sql
@@ -1,0 +1,5 @@
+-- Keep the contributor-triggered calibration read indexed after login casing canonicalization (#2349).
+-- SQLite/D1 cannot use the plain (login, created_at) index for WHERE lower(login) = ?, so this matching
+-- expression index preserves case-insensitive lookup semantics without scanning the insert-only ledger.
+CREATE INDEX IF NOT EXISTS predicted_gate_calibration_ledger_login_lower_idx
+  ON predicted_gate_calibration_ledger(lower(login), created_at);

--- a/test/unit/predicted-gate-calibration-ledger.test.ts
+++ b/test/unit/predicted-gate-calibration-ledger.test.ts
@@ -234,6 +234,26 @@ describe("computeContributorCalibration — per-login calibration read (#2349)",
     expect(await computeContributorCalibration(env, "someone-else")).toEqual({ sampleSize: 1, agreementRate: 1 });
   });
 
+  it("uses the matching lower(login) expression index for canonicalized calibration lookups", async () => {
+    const env = createTestEnv();
+
+    const idx = await env.DB.prepare("SELECT name FROM sqlite_master WHERE type='index' AND name = ?")
+      .bind("predicted_gate_calibration_ledger_login_lower_idx")
+      .first<{ name: string }>();
+    expect(idx?.name).toBe("predicted_gate_calibration_ledger_login_lower_idx");
+
+    const plan = await env.DB.prepare(
+      `EXPLAIN QUERY PLAN SELECT COUNT(*) AS sampleSize, COALESCE(AVG(agreed), 0) AS agreementRate
+         FROM predicted_gate_calibration_ledger
+        WHERE lower(login) = ?`,
+    )
+      .bind("octocat")
+      .all<{ detail: string }>();
+    const detail = (plan.results ?? []).map((row) => row.detail).join(" ");
+    expect(detail).toContain("predicted_gate_calibration_ledger_login_lower_idx");
+    expect(detail).not.toContain("SCAN predicted_gate_calibration_ledger");
+  });
+
   it("aggregates across ALL of a login's history regardless of which repo each pairing came from", async () => {
     const env = createTestEnv();
     await seedLedgerRow(env, { login: "octocat", project: "owner/repo-a", pullNumber: 1, agreed: true });


### PR DESCRIPTION
### Motivation
- The canonicalization change in the calibration read used `lower(login) = ?` which prevents SQLite/D1 from using the existing `(login, created_at)` index and makes contributor-triggerable reads scan the entire insert-only ledger, risking availability as the ledger grows.
- A matching expression index preserves the intended case-insensitive lookup semantics while restoring indexed performance for the read path.

### Description
- Add a new migration `0146_predicted_gate_calibration_ledger_login_lower_idx.sql` that creates an expression index on `lower(login), created_at` for the `predicted_gate_calibration_ledger` table to match the `WHERE lower(login) = ?` lookup.
- Add a regression test in `test/unit/predicted-gate-calibration-ledger.test.ts` that asserts the index `predicted_gate_calibration_ledger_login_lower_idx` exists and that `EXPLAIN QUERY PLAN` for the canonicalized query uses that index rather than scanning the table.
- Refresh generated Worker runtime types (`worker-configuration.d.ts`) to satisfy the local `cf-typegen` checks.

### Testing
- Ran `npx vitest run test/unit/predicted-gate-calibration-ledger.test.ts`, and the unit test file passed (25 tests).
- Ran `npm run db:migrations:check`, which reported migrations are contiguous and the next free number is available (`0147`).
- Ran `git diff --check`, which passed with no issues reported for the change set.
- Ran `npm run test:ci`, which failed during `tsc --noEmit` on unrelated, pre-existing type errors (missing `@jsonbored/gittensory-engine` module/types and implicit-any errors in miner tests), so the full CI gate could not be completed locally.
- Ran `npm audit --audit-level=moderate`, which failed due to the npm registry audit endpoint returning `403 Forbidden` (external registry error).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a536d6f3c20832c8c2fa67fc8f9f0b3)