### PR TITLE
fix(miner-extension): remove dead discoveryIndexUrl config field

### DIFF
--- a/apps/gittensory-miner-extension/README.md
+++ b/apps/gittensory-miner-extension/README.md
@@ -18,6 +18,5 @@ available for the current issue.
 ## Local ranked cache
 
 Laptop-mode installs can paste JSON from a miner `discover` run into the options page. The extension stores that list in
-`chrome.storage.local.rankedCandidates` and looks up the current issue there. A discovery-index URL can be saved for a
-future hosted client path; it is not read yet, so when only unranked hosted metadata would be available the badge
-degrades gracefully by staying hidden.
+`chrome.storage.local.rankedCandidates` and looks up the current issue there. When no ranked signal is cached for the
+current issue, the badge degrades gracefully by staying hidden.

--- a/apps/gittensory-miner-extension/background.js
+++ b/apps/gittensory-miner-extension/background.js
@@ -59,13 +59,11 @@ async function loadIssueOpportunityContext(message) {
 }
 
 async function loadMinerExtensionSettings() {
-  const stored = await chrome.storage.sync.get({ watchedRepos: [], discoveryIndexUrl: "" });
+  const stored = await chrome.storage.sync.get({ watchedRepos: [] });
   const watchedRepos = Array.isArray(stored.watchedRepos)
     ? stored.watchedRepos.map((value) => String(value).trim()).filter(Boolean)
     : [];
-  const discoveryIndexUrl =
-    typeof stored.discoveryIndexUrl === "string" ? stored.discoveryIndexUrl.trim() : "";
-  return { watchedRepos, discoveryIndexUrl };
+  return { watchedRepos };
 }
 
 async function loadRankedCandidates() {

--- a/apps/gittensory-miner-extension/options.html
+++ b/apps/gittensory-miner-extension/options.html
@@ -65,10 +65,6 @@
           <textarea id="watchedRepos" name="watchedRepos" placeholder="owner/repo, one per line"></textarea>
         </label>
         <label>
-          Discovery index URL (optional)
-          <input id="discoveryIndexUrl" name="discoveryIndexUrl" placeholder="https://example.com/discovery-index" />
-        </label>
-        <label>
           Ranked candidates JSON (local cache)
           <textarea
             id="rankedCandidatesJson"

--- a/apps/gittensory-miner-extension/options.js
+++ b/apps/gittensory-miner-extension/options.js
@@ -25,10 +25,9 @@ if (globalThis.__GITTENSORY_MINER_EXTENSION_TEST__) {
 const form = document.querySelector("#settings");
 const status = document.querySelector("#status");
 const watchedRepos = document.querySelector("#watchedRepos");
-const discoveryIndexUrl = document.querySelector("#discoveryIndexUrl");
 const rankedCandidatesJson = document.querySelector("#rankedCandidatesJson");
 
-if (!form || !status || !watchedRepos || !discoveryIndexUrl || !rankedCandidatesJson) {
+if (!form || !status || !watchedRepos || !rankedCandidatesJson) {
   // options.html is not mounted (unit-test harness or partial load).
 } else {
 void refreshSettings();
@@ -38,10 +37,7 @@ form.addEventListener("submit", async (event) => {
   try {
     const repos = parseWatchedRepos(watchedRepos.value);
     const rankedCandidates = parseRankedCandidatesJson(rankedCandidatesJson.value);
-    await chrome.storage.sync.set({
-      watchedRepos: repos,
-      discoveryIndexUrl: discoveryIndexUrl.value.trim(),
-    });
+    await chrome.storage.sync.set({ watchedRepos: repos });
     await chrome.storage.local.set({ rankedCandidates });
     await refreshSettings();
     showStatus(
@@ -56,11 +52,10 @@ form.addEventListener("submit", async (event) => {
 }
 
 async function refreshSettings() {
-  const stored = await chrome.storage.sync.get({ watchedRepos: [], discoveryIndexUrl: "" });
+  const stored = await chrome.storage.sync.get({ watchedRepos: [] });
   const local = await chrome.storage.local.get({ rankedCandidates: [] });
   const repos = Array.isArray(stored.watchedRepos) ? stored.watchedRepos : [];
   watchedRepos.value = repos.join("\n");
-  discoveryIndexUrl.value = typeof stored.discoveryIndexUrl === "string" ? stored.discoveryIndexUrl : "";
   const rankedCandidates = Array.isArray(local.rankedCandidates) ? local.rankedCandidates : [];
   rankedCandidatesJson.value =
     rankedCandidates.length > 0 ? JSON.stringify(rankedCandidates, null, 2) : "";

--- a/test/unit/miner-extension-content.test.ts
+++ b/test/unit/miner-extension-content.test.ts
@@ -7,6 +7,7 @@ const contentScript = readFileSync("apps/gittensory-miner-extension/content.js",
 const backgroundScript = readFileSync("apps/gittensory-miner-extension/background.js", "utf8");
 const badgeScript = readFileSync("apps/gittensory-miner-extension/opportunity-badge.js", "utf8");
 const optionsScript = readFileSync("apps/gittensory-miner-extension/options.js", "utf8");
+const optionsHtml = readFileSync("apps/gittensory-miner-extension/options.html", "utf8");
 const manifest = JSON.parse(readFileSync("apps/gittensory-miner-extension/manifest.json", "utf8"));
 
 const NOW = Date.parse("2026-07-03T12:00:00.000Z");
@@ -146,7 +147,63 @@ describe("miner extension opportunity badge", () => {
     expect(() => internals.parseRankedCandidatesJson("{")).toThrow();
     expect(() => internals.parseRankedCandidatesJson('{"not":"array"}')).toThrow();
   });
+
+  it("REGRESSION (dead-field removal): no discoveryIndexUrl config field remains anywhere in the extension", () => {
+    expect(optionsHtml).not.toMatch(/discoveryIndexUrl/);
+    expect(optionsScript).not.toMatch(/discoveryIndexUrl/);
+    expect(backgroundScript).not.toMatch(/discoveryIndexUrl/);
+  });
+
+  it("saves and restores settings without ever writing or reading discoveryIndexUrl", async () => {
+    const synced: Record<string, unknown> = { watchedRepos: [] };
+    const setCalls: Array<Record<string, unknown>> = [];
+    const elements = {
+      "#settings": createFormMock(),
+      "#status": { textContent: "" },
+      "#watchedRepos": { value: "" },
+      "#rankedCandidatesJson": { value: "" },
+    };
+    const context: Record<string, unknown> = {
+      __GITTENSORY_MINER_EXTENSION_TEST__: true,
+      document: { querySelector: (selector: string) => elements[selector as keyof typeof elements] ?? null },
+      chrome: {
+        storage: {
+          sync: {
+            get: async (defaults: Record<string, unknown>) => ({ ...defaults, ...synced }),
+            set: async (value: Record<string, unknown>) => {
+              setCalls.push(value);
+              Object.assign(synced, value);
+            },
+          },
+          local: { get: async () => ({ rankedCandidates: [] }), set: async () => {} },
+        },
+      },
+      window: { setTimeout: () => 0 },
+    };
+    context.globalThis = context;
+    const vmContext = createContext(context);
+    new Script(optionsScript).runInContext(vmContext);
+
+    elements["#watchedRepos"].value = "JSONbored/gittensory";
+    await elements["#settings"].dispatchSubmit();
+
+    expect(setCalls).toHaveLength(1);
+    expect(setCalls[0]).toEqual({ watchedRepos: ["JSONbored/gittensory"] });
+    expect("discoveryIndexUrl" in synced).toBe(false);
+  });
 });
+
+function createFormMock() {
+  let submitHandler: ((event: { preventDefault: () => void }) => unknown) | null = null;
+  return {
+    addEventListener: (type: string, handler: typeof submitHandler) => {
+      if (type === "submit") submitHandler = handler;
+    },
+    dispatchSubmit: async () => {
+      await submitHandler?.({ preventDefault: () => {} });
+    },
+  };
+}
 
 function createMockContainer() {
   const container = {
@@ -207,7 +264,7 @@ function loadBackgroundInternals({
     chrome: {
       storage: {
         sync: {
-          get: async () => ({ watchedRepos, discoveryIndexUrl: "" }),
+          get: async () => ({ watchedRepos }),
         },
         local: {
           get: async () => ({ rankedCandidates }),
@@ -239,7 +296,7 @@ function loadOptionsInternals() {
     document: { querySelector: () => null },
     chrome: {
       storage: {
-        sync: { get: async () => ({ watchedRepos: [], discoveryIndexUrl: "" }), set: async () => {} },
+        sync: { get: async () => ({ watchedRepos: [] }), set: async () => {} },
         local: { get: async () => ({ rankedCandidates: [] }), set: async () => {} },
       },
     },


### PR DESCRIPTION
## Summary

- `apps/gittensory-miner-extension`'s options page had a "Discovery index URL" field that was saved to `chrome.storage.sync` and loaded back into `loadMinerExtensionSettings()`'s return value, but never actually read anywhere downstream — the extension's own README explicitly acknowledged it ("A discovery-index URL can be saved for a future hosted client path; it is not read yet"). Confirmed dead by tracing every reference: `background.js`'s `loadIssueOpportunityContext` only reads `settings.watchedRepos`, never `settings.discoveryIndexUrl`.
- Per the issue's own guidance ("default to removing it if the hosted discovery plane's fate is still undecided"), removed the field entirely rather than implementing it — the hosted discovery-plane control-plane work is still an open, maintainer-only roadmap epic with no shipped consumer for this URL.
- Removed from: `options.html` (input + label), `options.js` (querySelector, submit-time save, restore-time read), `background.js` (`loadMinerExtensionSettings`'s storage default/destructure/return), and the README's now-inaccurate paragraph describing it.
- `packages/gittensory-engine/src/discovery-index-contract.ts` (an unrelated, real, already-shipped request/response contract for a *different* "discovery index" concept — the hosted-plane API contract, not the extension's dead URL field) is untouched; confirmed via a full-repo grep that no other reference to the removed `discoveryIndexUrl` config field remains anywhere.

Fixes #4861

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — this change lives entirely under `apps/gittensory-miner-extension/**`, which (like the rest of the miner ecosystem) sits outside vitest's `coverage.include` glob today, so `codecov/patch` cannot measure it directly. It is nonetheless fully covered by `test/unit/miner-extension-content.test.ts`, a root-level test file per house convention.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run build:miner`
- [x] `npm run test:miner-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:test`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

Updated `test/unit/miner-extension-content.test.ts`: removed the now-obsolete `discoveryIndexUrl` mock keys from the existing `loadBackgroundInternals`/`loadOptionsInternals` fixtures, added a regression test asserting no `discoveryIndexUrl` string remains anywhere in `options.html`/`options.js`/`background.js` (the deliverable's literal acceptance criterion — "no dead, documented-as-dead config fields remaining"), and added an end-to-end save/restore test driving the real `options.js` submit handler through a `chrome.storage.sync` mock, asserting the persisted object contains only `{ watchedRepos }` and never a `discoveryIndexUrl` key. All 11 tests in the file pass (9 pre-existing + 2 new).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no auth/session/CORS surface touched.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — no public API/OpenAPI/MCP surface change; browser-extension-local `chrome.storage` field removal only.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — the options page continues to read/write real `chrome.storage` data; no mock/demo fallback introduced or removed.
- [ ] Visible UI changes include a `UI Evidence` section below — this is a minor extension-options-page field removal (one `<label>`/`<input>` row deleted from a settings form), not a feature requiring visual review; see Notes.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable per `CONTRIBUTING.md`'s intent for UI Evidence (visible feature changes needing visual review) — this PR only removes one dead, never-functional form field from a browser-extension options page; there is no new or changed visible behavior to demonstrate, only a deletion.

## Notes

- Confirmed genuinely dead (not just unused-looking) by tracing the full data flow: `options.js` saves it → `background.js`'s `loadMinerExtensionSettings()` loads it → but the only caller, `loadIssueOpportunityContext`, destructures and uses `settings.watchedRepos` alone. No other file in the repo reads `settings.discoveryIndexUrl` or the `chrome.storage.sync` key.
- `packages/gittensory-engine/src/discovery-index-contract.ts` and its `DiscoveryIndex*` types are a distinct, already-shipped, unrelated concept (the hosted discovery-plane's own request/response API contract) and are untouched by this PR.
