### PR TITLE
fix(github): fallback to public Orb slug when GITHUB_APP_SLUG is unset

### DIFF
--- a/src/github/pr-actions.ts
+++ b/src/github/pr-actions.ts
@@ -10,6 +10,7 @@ const ISSUE_EVENTS_RECENT_PAGE_LIMIT = 10;
 // earliest reviews on a PR with a long review history and could dismiss (or miss) the wrong one.
 const REVIEW_PAGE_SIZE = 100;
 const REVIEW_PAGE_LIMIT = 10;
+const PUBLIC_GITHUB_APP_SLUG = "gittensory-orb";
 
 // The GitHub write primitives the maintainer auto-maintain layer (#778) uses to act on a PR's STATE — never
 // its source. Thin wrappers over the installation-scoped REST API, mirroring labels.ts / comments.ts. Each
@@ -128,7 +129,8 @@ export async function dismissLatestBotApproval(env: Env, installationId: number,
     const { owner, repo } = splitRepo(repoFullName);
     return await withInstallationTokenRetry(env, installationId, async (token) => {
       const octokit = makeInstallationOctokit(env, token, "live", githubRateLimitAdmissionKeyForInstallation(installationId));
-      const botLogin = `${env.GITHUB_APP_SLUG}[bot]`;
+      const botSlug = env.GITHUB_APP_SLUG?.trim() || PUBLIC_GITHUB_APP_SLUG;
+      const botLogin = `${botSlug}[bot]`;
       // Reviews are returned oldest-first; the LAST matching entry across ALL pages is the bot's most recent
       // APPROVE. Stopping at page 1 would find (or miss) the wrong review on a PR with >100 total reviews.
       let latestApprovalId: number | undefined;

--- a/test/unit/github-pr-actions.test.ts
+++ b/test/unit/github-pr-actions.test.ts
@@ -4,8 +4,8 @@ import { closeIssue, closePullRequest, createIssueComment, createPullRequestRevi
 import { clearInstallationTokenCacheForTest } from "../../src/github/app";
 import { createTestEnv } from "../helpers/d1";
 
-function envWithKey() {
-  return createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem() });
+function envWithKey(overrides: Partial<Env> = {}) {
+  return createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), ...overrides });
 }
 
 describe("GitHub PR action primitives (#778)", () => {
@@ -526,6 +526,48 @@ describe("GitHub PR action primitives (#778)", () => {
     expect(result).toEqual({ dismissed: true });
     expect(calls).toHaveLength(1);
     expect(calls[0]?.body).toMatchObject({ message: "stale approval retracted", event: "DISMISS" });
+  });
+
+  it("REGRESSION (#security): falls back to the public Orb bot when GITHUB_APP_SLUG is unset", async () => {
+    const env = envWithKey();
+    delete (env as Partial<Env>).GITHUB_APP_SLUG;
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url.includes("/access_tokens")) return Response.json({ token: "t" });
+      if (url.includes("/pulls/12/reviews") && !url.includes("/dismissals") && method === "GET") {
+        return Response.json([{ id: 12, state: "APPROVED", user: { login: "gittensory-orb[bot]" } }]);
+      }
+      if (url.includes("/pulls/12/reviews/12/dismissals") && method === "PUT") {
+        calls.push({ url, body: init?.body ? JSON.parse(String(init.body)) : {} });
+        return Response.json({ id: 12, state: "DISMISSED" });
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+
+    await expect(dismissLatestBotApproval(env, 123, "owner/repo", 12, "retract")).resolves.toEqual({ dismissed: true });
+    expect(calls).toHaveLength(1);
+  });
+
+  it("falls back to the public Orb bot when GITHUB_APP_SLUG is blank", async () => {
+    const calls: Array<{ url: string; body: Record<string, unknown> }> = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url.includes("/access_tokens")) return Response.json({ token: "t" });
+      if (url.includes("/pulls/13/reviews") && !url.includes("/dismissals") && method === "GET") {
+        return Response.json([{ id: 13, state: "APPROVED", user: { login: "gittensory-orb[bot]" } }]);
+      }
+      if (url.includes("/pulls/13/reviews/13/dismissals") && method === "PUT") {
+        calls.push({ url, body: init?.body ? JSON.parse(String(init.body)) : {} });
+        return Response.json({ id: 13, state: "DISMISSED" });
+      }
+      return new Response("unexpected", { status: 500 });
+    });
+
+    await expect(dismissLatestBotApproval(envWithKey({ GITHUB_APP_SLUG: "   " }), 123, "owner/repo", 13, "retract")).resolves.toEqual({ dismissed: true });
+    expect(calls).toHaveLength(1);
   });
 
   it("is a no-op when the bot never approved this PR", async () => {


### PR DESCRIPTION
### Motivation
- The stale-approval dismissal path computed the bot login from `env.GITHUB_APP_SLUG` unguarded, which becomes `undefined[bot]` when the env var is removed and prevents dismissal of real Orb approvals, weakening branch-protection integrity. 
- The change restores the intended security behavior by falling back to the publicly-installable Orb slug while preserving self-host behavior when an operator provides their own `GITHUB_APP_SLUG`.

### Description
- Add a `PUBLIC_GITHUB_APP_SLUG = "gittensory-orb"` constant and compute the effective bot login with `env.GITHUB_APP_SLUG?.trim() || PUBLIC_GITHUB_APP_SLUG` inside `dismissLatestBotApproval` so dismissal still targets the real Orb bot when the env var is absent. 
- Update the `dismissLatestBotApproval` implementation to use the trimmed/ fallback slug before scanning reviews. 
- Extend `test/unit/github-pr-actions.test.ts` by allowing env overrides in `envWithKey(...)` and adding regression tests that cover the unset and blank `GITHUB_APP_SLUG` branches which assert that `gittensory-orb[bot]` approvals are still dismissed. 
- Preserve existing behavior when `GITHUB_APP_SLUG` is configured so self-host deployments continue to prefer their configured slug.

### Testing
- Ran the targeted unit test file with `npx vitest run test/unit/github-pr-actions.test.ts`, and the file's tests passed (42 tests passed). 
- Attempted a full coverage run with `npm run test:coverage`, which exercised the test harness but failed global coverage thresholds and encountered long-running unrelated test suites in this environment, so the full unsharded coverage job did not report a green result. 
- Ran `npm run typecheck`, which failed due to pre-existing/unrelated typing issues in other packages and files and not due to the changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53996c9a20832ca6e0d5a4cd7c8cfd)