### PR TITLE
fix(observability): keep github scope repo-bound

### DIFF
--- a/grafana/dashboards/github-prs.json
+++ b/grafana/dashboards/github-prs.json
@@ -15,13 +15,13 @@
         "label": "Scope",
         "type": "query",
         "datasource": { "type": "frser-sqlite-datasource", "uid": "gittensory-db" },
-        "description": "Dynamic, never hardcoded: built from whichever repos are actually tracked in this self-hoster's own reporting DB. 'All repos' assumes a single-owner setup (the same assumption the dashboard's own GitHub-search-syntax scope always required, since GitHub search can't OR multiple repo: qualifiers in one query) — it widens to org:<owner> of the first tracked repo. A self-hoster tracking repos across multiple owners should pick a specific repo instead of 'All repos'.",
+        "description": "Dynamic, never hardcoded: built from the repositories tracked in this self-hoster's own reporting DB. Each option is an explicit repo:<owner>/<repo> GitHub search qualifier; the dashboard deliberately does not synthesize an org-wide \"All repos\" option because the GitHub datasource token may be able to read private repositories that are not tracked locally.",
         "query": {
           "queryType": "table",
-          "queryText": "SELECT * FROM (SELECT 0 AS ord, 'All repos' AS \"__text\", (SELECT 'org:' || substr(repo, 1, instr(repo, '/') - 1) FROM review_targets LIMIT 1) AS \"__value\" UNION ALL SELECT 1 AS ord, repo AS \"__text\", 'repo:' || repo AS \"__value\" FROM (SELECT DISTINCT repo FROM review_targets ORDER BY repo)) ORDER BY ord, \"__text\"",
-          "rawQueryText": "SELECT * FROM (SELECT 0 AS ord, 'All repos' AS \"__text\", (SELECT 'org:' || substr(repo, 1, instr(repo, '/') - 1) FROM review_targets LIMIT 1) AS \"__value\" UNION ALL SELECT 1 AS ord, repo AS \"__text\", 'repo:' || repo AS \"__value\" FROM (SELECT DISTINCT repo FROM review_targets ORDER BY repo)) ORDER BY ord, \"__text\""
+          "queryText": "SELECT 1 AS ord, repo AS \"__text\", 'repo:' || repo AS \"__value\" FROM (SELECT DISTINCT repo FROM review_targets ORDER BY repo)",
+          "rawQueryText": "SELECT 1 AS ord, repo AS \"__text\", 'repo:' || repo AS \"__value\" FROM (SELECT DISTINCT repo FROM review_targets ORDER BY repo)"
         },
-        "current": { "text": "All repos", "value": "org:JSONbored" },
+        "current": { "text": "JSONbored/gittensory", "value": "repo:JSONbored/gittensory" },
         "includeAll": false,
         "multi": false,
         "refresh": 2,

--- a/test/unit/selfhost-grafana-dashboard.test.ts
+++ b/test/unit/selfhost-grafana-dashboard.test.ts
@@ -536,9 +536,10 @@ describe("github-prs.json: $scope is dynamic, never a hardcoded repo list (2026-
     expect(scope?.datasource?.type).toBe("frser-sqlite-datasource");
     expect(scope?.query?.rawQueryText).toContain("review_targets");
     expect(scope?.query?.rawQueryText).not.toContain("JSONbored");
+    expect(scope?.query?.rawQueryText).not.toContain("org:");
   });
 
-  (sqliteCliAvailable ? it : it.skip)("builds 'All repos' as org:<owner> of the first tracked repo, plus one repo: option per distinct tracked repo", () => {
+  (sqliteCliAvailable ? it : it.skip)("builds only explicit repo-scoped options and never an org-wide All repos value", () => {
     const root = tmpRoot();
     const db = join(root, "reporting.sqlite");
     sqlite(
@@ -553,6 +554,8 @@ describe("github-prs.json: $scope is dynamic, never a hardcoded repo list (2026-
     if (!rawQueryText) throw new Error("missing $scope rawQueryText");
     const rows = sqlite(db, rawQueryText).split("\n");
 
-    expect(rows).toEqual(["0|All repos|org:acme", "1|acme/gadgets|repo:acme/gadgets", "1|acme/widgets|repo:acme/widgets"]);
+    expect(rows).toEqual(["1|acme/gadgets|repo:acme/gadgets", "1|acme/widgets|repo:acme/widgets"]);
+    expect(rows.join("\n")).not.toContain("org:acme");
+    expect(rows.join("\n")).not.toContain("All repos");
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent the Grafana GitHub panels from accepting an implicit org-wide `org:<owner>` value that could expose metadata for repositories the reporting DB does not track. 
- Replace the synthesized "All repos" option with explicit `repo:<owner>/<repo>` qualifiers so dashboard queries are strictly bounded to tracked repositories.

### Description
- Change `grafana/dashboards/github-prs.json` to remove the synthesized `All repos`/`org:` option and emit only explicit `repo:<owner>/<repo>` entries from `review_targets`, and update the variable description and default current value accordingly. 
- Update `test/unit/selfhost-grafana-dashboard.test.ts` to assert the scope query is query-backed but never contains `org:` or `All repos`, and add a regression test that verifies only repo-scoped rows are produced. 
- Regenerate Cloudflare worker runtime types via the `cf-typegen` step, producing an updated `worker-configuration.d.ts` so the `cf-typegen:check` remains current.

### Testing
- Ran the dashboard unit test file with `npx vitest run test/unit/selfhost-grafana-dashboard.test.ts` and all tests in that file passed. 
- Ran `npm run selfhost:validate-observability` to validate Grafana dashboards and Prometheus alert rules and it reported the observability configs are valid. 
- Ran `npm run cf-typegen` which updated `worker-configuration.d.ts` to keep runtime types in sync. 
- Ran `npm run test:ci` which progressed through several pre-checks but stopped at `tsc --noEmit` (`npm run typecheck`) due to existing TypeScript errors in unrelated files, so the full CI gate did not complete successfully. 
- Ran `npm audit --audit-level=moderate` but the registry audit endpoint returned `403 Forbidden`, so the security audit step could not be completed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a539ca59550832c8330151051c0f154)