### PR TITLE
feat(miner): add a .gittensory-miner.env.example starter file

### DIFF
--- a/.gittensory-miner.env.example
+++ b/.gittensory-miner.env.example
@@ -1,0 +1,56 @@
+# gittensory-miner — starter env file
+#
+# Copy this to `.gittensory-miner.env` (gitignored), fill in GITHUB_TOKEN, then either `source` it or
+# point docker-compose / systemd at it — see packages/gittensory-miner/DEPLOYMENT.md:
+#
+#   cp .gittensory-miner.env.example .gittensory-miner.env
+#
+# Every value below is a SAMPLE placeholder — never commit real secrets. For the generated,
+# always-current table of every miner env var and its default, see
+# packages/gittensory-miner/docs/env-reference.md (regenerate with `npm run miner:env-reference`).
+
+# =============================================================================
+# 1. Required
+# =============================================================================
+# GitHub token (a PAT or an App installation token) the miner uses for issue discovery and PR-outcome
+# polling. Discovery/attempt runs that reach GitHub fail without it. Keep it out of source control.
+GITHUB_TOKEN=ghp_your_token_here
+
+# =============================================================================
+# 2. Coding agent
+# =============================================================================
+# Which local coding-agent CLI the miner drives for attempts (e.g. claude-code, codex). Leave unset to
+# use the package default resolved at run time.
+# MINER_CODING_AGENT_PROVIDER=claude-code
+
+# =============================================================================
+# 3. Optional overrides — defaults are fine for a single-machine install
+# =============================================================================
+# By default all local state lives under GITTENSORY_MINER_CONFIG_DIR (else $XDG_CONFIG_HOME, else
+# ~/.config), in a gittensory-miner/ subdirectory. Set the base dir, or any individual store path,
+# only to relocate state (e.g. onto a dedicated volume).
+# GITTENSORY_MINER_CONFIG_DIR=/var/lib/gittensory-miner
+
+# Repo clones and git worktrees created during attempts:
+# GITTENSORY_MINER_REPO_CLONE_DIR=/var/lib/gittensory-miner/clones
+# GITTENSORY_MINER_WORKTREE_DIR=/var/lib/gittensory-miner/worktrees
+
+# Per-store SQLite file overrides (each defaults to a file under the config dir above):
+# GITTENSORY_MINER_CLAIM_LEDGER_DB=
+# GITTENSORY_MINER_PORTFOLIO_QUEUE_DB=
+# GITTENSORY_MINER_EVENT_LEDGER_DB=
+# GITTENSORY_MINER_RUN_STATE_DB=
+# GITTENSORY_MINER_PLAN_STORE_DB=
+# GITTENSORY_MINER_PREDICTION_LEDGER_DB=
+# GITTENSORY_MINER_GOVERNOR_LEDGER_DB=
+# GITTENSORY_MINER_GOVERNOR_STATE_DB=
+# GITTENSORY_MINER_ATTEMPT_LOG_DB=
+# GITTENSORY_MINER_ORB_EXPORT_DB=
+# GITTENSORY_MINER_REPLAY_SNAPSHOT_DB=
+# GITTENSORY_MINER_WORKTREE_ALLOCATOR_DB=
+# GITTENSORY_MINER_DENY_HOOK_SYNTHESIS_DB=
+
+# Misc:
+# GITTENSORY_MINER_AMS_POLICY_PATH=          # path to an AMS policy file
+# GITTENSORY_MINER_NO_UPDATE_CHECK=1         # disable the startup npm-registry version nudge
+# GITTENSORY_MINER_VERSION=                  # override the reported version (testing only)


### PR DESCRIPTION
Adds the consolidated `.gittensory-miner.env.example` starter file — which `docker-compose.miner.yml` and `packages/gittensory-miner/DEPLOYMENT.md` already tell operators to `cp`, but which did not exist yet. It's the miner counterpart to the repo's existing `.env.selfhost.example`.

## What this adds
A single new repo-root file enumerating every operator-facing miner env var in one copy-pasteable place, grouped by purpose:
- **Required:** `GITHUB_TOKEN` (verified read in `discover-cli.js`, `manage-poll.js`, `self-review-context.js`, `live-issue-snapshot.js`).
- **Coding agent:** `MINER_CODING_AGENT_PROVIDER`.
- **Optional overrides:** all 19 `GITTENSORY_MINER_*` state-dir / per-store-DB-path / behavior vars, commented out with a note that they default under `GITTENSORY_MINER_CONFIG_DIR`.

## Accuracy
The var set is taken from the generated authoritative reference (`packages/gittensory-miner/docs/env-reference.md`) plus `GITHUB_TOKEN` (which the prefix-scoped generator doesn't capture but the miner genuinely reads). Coding-agent model/timeout names were deliberately **excluded** — they are not `process.env` reads anywhere in the tree, so listing them as env vars would be wrong. The file header points at `docs/env-reference.md` as the always-current source.

## Validation
- New file only; no runtime code. Not gitignored (trackable).
- `docs:drift-check`, `check-miner-package`, `miner:env-reference:check`, `git diff --check`: all clean. Rebased onto latest main.

Closes #5173
