### PR TITLE
docs(miner): add Observing your miner Grafana guide (#5190)

### DIFF
--- a/packages/gittensory-miner/docs/coding-agent-driver.md
+++ b/packages/gittensory-miner/docs/coding-agent-driver.md
@@ -99,3 +99,10 @@ runCodingAgentAttempt(options)
 
 The attempt log (JSONL) and the metering totals are the durable, provider-independent record of what happened —
 independent of whichever backend's own transcript, and the input to the miner's manage-phase and self-improve loops.
+
+## Related docs
+
+- [`observability.md`](observability.md) — point Grafana at the miner's local SQLite ledgers and load the usage dashboard ([#5190](https://github.com/JSONbored/gittensory/issues/5190)).
+- [`env-reference.md`](env-reference.md) — env vars including ledger path overrides.
+- [`../DEPLOYMENT.md`](../DEPLOYMENT.md) — laptop vs fleet deployment and state directory layout.
+- [`miner-goal-spec.md`](miner-goal-spec.md) — per-repo `.gittensory-miner.yml` targeting policy.

--- a/packages/gittensory-miner/docs/observability.md
+++ b/packages/gittensory-miner/docs/observability.md
@@ -1,0 +1,218 @@
+# Observing your miner (Grafana + local SQLite ledgers)
+
+Operator guide for pointing Grafana at a running `gittensory-miner` instance's **local SQLite ledgers** — the append-only stores that record coding-agent driver attempts and predicted-gate outcomes. This is **miner-specific** observability; it is distinct from the maintainer-only self-host operations runbook ([#4875](https://github.com/JSONbored/gittensory/issues/4875)), which covers the review stack's broader ops surface.
+
+> **Scope:** Grafana datasource wiring and the miner usage dashboard only. For laptop/fleet deployment, state layout, and CLI diagnostics, see [`../DEPLOYMENT.md`](../DEPLOYMENT.md) and [`coding-agent-driver.md`](coding-agent-driver.md). For env-var overrides on ledger paths, see [`env-reference.md`](env-reference.md).
+
+## What you can see
+
+| Ledger | Default file | Primary tables | Answers |
+|--------|--------------|----------------|---------|
+| **Attempt log** | `attempt-log.sqlite3` | `attempt_log_events` | Per-attempt driver lifecycle (`attempt_started`, `attempt_succeeded`, `attempt_failed`, …), mode, and structured payloads |
+| **Prediction ledger** | `prediction-ledger.sqlite3` | `predictions` | Predicted gate conclusions the miner computed before opening a PR |
+
+Both files are **read-only from Grafana's perspective** — the SQLite datasource plugin opens them for queries; it never writes back.
+
+The planned **`miner-usage.json`** dashboard ([#5185](https://github.com/JSONbored/gittensory/issues/5185)) aggregates attempt success/fail counts, token totals, and cost **per coding-agent provider** (`claude-cli`, `codex-cli`, `agent-sdk`) from these ledgers. Provisioned datasource entries ([#5184](https://github.com/JSONbored/gittensory/issues/5184)) automate the path wiring below; until those land, follow the manual steps.
+
+### Not the ORB review-stack dashboards
+
+If you also run the Gittensory **self-host review stack** with `--profile observability`, Grafana already ships dashboards such as **`Gittensory - AI usage`** (`grafana/dashboards/ai-usage.json`), which query the **review stack's** redacted reporting SQLite export (`uid: gittensory-db`). That answers *review-time AI usage* across configured providers.
+
+The miner dashboard answers a different question: *what did my autonomous miner's coding-agent drivers attempt, and how did predicted gates score those targets?* Keep the two surfaces separate — do not point miner panels at `gittensory-db` or ORB panels at miner ledger files.
+
+## Prerequisites
+
+1. **Grafana** with the [**SQLite**](https://grafana.com/grafana/plugins/frser-sqlite-datasource/) plugin (`frser-sqlite-datasource`). The repo's self-host stack installs it automatically:
+
+   ```sh
+   docker compose --profile observability up -d
+   ```
+
+   (`GF_INSTALL_PLUGINS` in [`docker-compose.yml`](../../../docker-compose.yml) includes `frser-sqlite-datasource`.)
+
+2. **Miner state on disk.** Run `gittensory-miner init` (or any command that touches a ledger) so the SQLite files exist:
+
+   ```sh
+   gittensory-miner status --json   # prints stateDir
+   gittensory-miner doctor --json   # confirms SQLite readiness
+   ```
+
+3. **Resolve your ledger paths** (defaults shown; override with env vars):
+
+   ```text
+   ~/.config/gittensory-miner/attempt-log.sqlite3
+   ~/.config/gittensory-miner/prediction-ledger.sqlite3
+   ```
+
+   | Override env var | Effect |
+   |------------------|--------|
+   | `GITTENSORY_MINER_CONFIG_DIR` | Directory containing both `*.sqlite3` files |
+   | `GITTENSORY_MINER_ATTEMPT_LOG_DB` | Explicit path to attempt log (wins over config dir) |
+   | `GITTENSORY_MINER_PREDICTION_LEDGER_DB` | Explicit path to prediction ledger |
+
+   Quick check:
+
+   ```sh
+   gittensory-miner status --json
+   # stateDir + "/attempt-log.sqlite3" and stateDir + "/prediction-ledger.sqlite3"
+   ```
+
+## Step 1 — Make ledger files visible to Grafana
+
+Grafana must read the **host path** where the miner writes SQLite. Pick the layout that matches your deployment.
+
+### A. Miner on host, Grafana in Docker Compose (typical laptop setup)
+
+Add a read-only bind mount so the Grafana container sees your miner state directory. Create `docker-compose.override.yml` beside the repo's [`docker-compose.yml`](../../../docker-compose.yml):
+
+```yaml
+services:
+  grafana:
+    volumes:
+      - ${HOME}/.config/gittensory-miner:/miner-state:ro
+```
+
+If you use `GITTENSORY_MINER_CONFIG_DIR`, mount that directory instead:
+
+```yaml
+services:
+  grafana:
+    volumes:
+      - /path/to/your/miner-state:/miner-state:ro
+```
+
+Recreate Grafana:
+
+```sh
+docker compose --profile observability up -d grafana
+```
+
+Inside the container, ledger paths become:
+
+```text
+/miner-state/attempt-log.sqlite3
+/miner-state/prediction-ledger.sqlite3
+```
+
+### B. Miner in Docker (fleet mode)
+
+Mount the **same** named volume (or host path) into both the miner container and Grafana. Example override when the miner uses `miner-data` at `/data/miner`:
+
+```yaml
+services:
+  grafana:
+    volumes:
+      - miner-data:/miner-state:ro
+```
+
+Use `/miner-state/attempt-log.sqlite3` and `/miner-state/prediction-ledger.sqlite3` in datasource config below.
+
+## Step 2 — Add SQLite datasources
+
+### Option A — Grafana UI (works today)
+
+Repeat for **each** ledger file (attempt log and prediction ledger):
+
+1. Open Grafana → **Connections** → **Data sources** → **Add data source**.
+2. Search for **SQLite** (`frser-sqlite-datasource`) and select it.
+3. Set **Path** to the container-visible absolute path, e.g. `/miner-state/attempt-log.sqlite3`.
+4. **Save & test** — you should see *Database ok* when the file exists and is readable.
+
+Suggested names (match the upcoming provisioned UIDs in [#5184](https://github.com/JSONbored/gittensory/issues/5184)):
+
+| Datasource name | UID (optional, for dashboard import) | Path (Compose example) |
+|-----------------|----------------------------------------|-------------------------|
+| GittensoryMinerAttemptLog | `gittensory-miner-attempt-log` | `/miner-state/attempt-log.sqlite3` |
+| GittensoryMinerPredictionLedger | `gittensory-miner-prediction-ledger` | `/miner-state/prediction-ledger.sqlite3` |
+
+Sanity queries (**Explore** → pick datasource → **Query**):
+
+```sql
+SELECT event_type, count(*) AS n
+FROM attempt_log_events
+GROUP BY event_type
+ORDER BY n DESC;
+```
+
+```sql
+SELECT conclusion, count(*) AS n
+FROM predictions
+GROUP BY conclusion
+ORDER BY n DESC;
+```
+
+### Option B — Provisioning YAML (automated in [#5184](https://github.com/JSONbored/gittensory/issues/5184))
+
+Until `grafana/provisioning/datasources/miner-*.yml` ships, you can drop files under `grafana/provisioning/datasources/` mirroring the existing [`sqlite.yml`](../../../grafana/provisioning/datasources/sqlite.yml) pattern:
+
+```yaml
+# grafana/provisioning/datasources/miner-attempt-log.yml  (example — paths must match your mount)
+apiVersion: 1
+datasources:
+  - name: GittensoryMinerAttemptLog
+    type: frser-sqlite-datasource
+    uid: gittensory-miner-attempt-log
+    access: proxy
+    editable: true
+    jsonData:
+      path: /miner-state/attempt-log.sqlite3
+```
+
+```yaml
+# grafana/provisioning/datasources/miner-prediction-ledger.yml  (example)
+apiVersion: 1
+datasources:
+  - name: GittensoryMinerPredictionLedger
+    type: frser-sqlite-datasource
+    uid: gittensory-miner-prediction-ledger
+    access: proxy
+    editable: true
+    jsonData:
+      path: /miner-state/prediction-ledger.sqlite3
+```
+
+Restart Grafana after adding provisioning files.
+
+## Step 3 — Load the miner usage dashboard
+
+Once [#5185](https://github.com/JSONbored/gittensory/issues/5185) lands, the dashboard JSON lives at:
+
+```text
+grafana/dashboards/miner-usage.json
+```
+
+### Auto-provisioned (recommended)
+
+The self-host stack already provisions dashboards from `grafana/dashboards/` via [`grafana/provisioning/dashboards/provider.yml`](../../../grafana/provisioning/dashboards/provider.yml). After #5185 merges, starting observability profile picks up **Gittensory Miner — usage** automatically:
+
+```sh
+docker compose --profile observability up -d
+```
+
+Open Grafana → **Dashboards** → folder **Gittensory** → select the miner usage dashboard.
+
+### Manual import (before or without provisioning)
+
+1. **Dashboards** → **New** → **Import**.
+2. **Upload JSON file** → choose `grafana/dashboards/miner-usage.json` from your checkout.
+3. When prompted, map panels to the datasources you created in Step 2 (`gittensory-miner-attempt-log`, `gittensory-miner-prediction-ledger`).
+4. **Import**.
+
+The dashboard exposes a **Provider** template variable (`claude-cli` / `codex-cli` / `agent-sdk`) to filter attempt outcomes, token totals, and cost in one place — unlike ORB's per-provider AI-usage split.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|--------------|-----|
+| *Database ok* fails / file not found | Grafana container cannot see host path | Add the `/miner-state:ro` volume mount; verify path inside container with `docker compose exec grafana ls -l /miner-state` |
+| Empty panels | Miner has not run attempts yet | Run a dry attempt or check `attempt-log.sqlite3` size on disk |
+| `database is locked` | Miner writing while Grafana queries | Normal under load; retry. Ledgers use `busy_timeout`; heavy concurrent writes may still briefly block readers |
+| Plugin missing | Observability profile not used | Ensure `GF_INSTALL_PLUGINS` includes `frser-sqlite-datasource` or install the plugin manually |
+
+## Related docs
+
+- [`coding-agent-driver.md`](coding-agent-driver.md) — what the attempt log records and how drivers plug in.
+- [`../DEPLOYMENT.md`](../DEPLOYMENT.md) — laptop vs fleet layout and volume strategy.
+- [`env-reference.md`](env-reference.md) — ledger path env vars.
+- General self-host operations ([#4875](https://github.com/JSONbored/gittensory/issues/4875)) — review-stack ops; link out rather than duplicating here.

--- a/test/unit/miner-observability-doc.test.ts
+++ b/test/unit/miner-observability-doc.test.ts
@@ -1,0 +1,35 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const repoRoot = process.cwd();
+const observabilityDocPath = join(repoRoot, "packages/gittensory-miner/docs/observability.md");
+const codingAgentDriverDocPath = join(repoRoot, "packages/gittensory-miner/docs/coding-agent-driver.md");
+const minerUsageDashboardPath = join(repoRoot, "grafana/dashboards/miner-usage.json");
+
+describe("miner observability docs (#5190)", () => {
+  it("ships observability.md with concrete Grafana + SQLite setup steps", () => {
+    const doc = readFileSync(observabilityDocPath, "utf8");
+    expect(doc).toContain("# Observing your miner");
+    expect(doc).toContain("frser-sqlite-datasource");
+    expect(doc).toContain("attempt-log.sqlite3");
+    expect(doc).toContain("prediction-ledger.sqlite3");
+    expect(doc).toContain("miner-usage.json");
+    expect(doc).toContain("gittensory-miner-attempt-log");
+    expect(doc).toContain("4875");
+    expect(doc).toContain("link out rather than duplicating here");
+  });
+
+  it("links observability.md from coding-agent-driver.md related docs (invariant: entry resolves)", () => {
+    const driverDoc = readFileSync(codingAgentDriverDocPath, "utf8");
+    expect(driverDoc).toContain("[`observability.md`](observability.md)");
+    expect(existsSync(observabilityDocPath)).toBe(true);
+  });
+
+  it("documents the planned dashboard path even before miner-usage.json lands", () => {
+    const doc = readFileSync(observabilityDocPath, "utf8");
+    expect(doc).toContain("grafana/dashboards/miner-usage.json");
+    // Dashboard ships in #5185 — doc must not assume the file exists yet.
+    expect(existsSync(minerUsageDashboardPath)).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #5190

## Summary

Adds [`packages/gittensory-miner/docs/observability.md`](packages/gittensory-miner/docs/observability.md) — a copy-pasteable operator guide for pointing Grafana at the miner's local SQLite ledgers (`attempt-log.sqlite3`, `prediction-ledger.sqlite3`) and loading the planned **`miner-usage.json`** dashboard. Documentation-only; cross-references [#4875](https://github.com/JSONbored/gittensory/issues/4875) instead of duplicating the maintainer ops runbook.

## Changes

| Area | Change |
|------|--------|
| `packages/gittensory-miner/docs/observability.md` | New guide: prerequisites, Docker volume mounts, SQLite datasource setup (UI + example provisioning YAML), dashboard import, troubleshooting |
| `packages/gittensory-miner/docs/coding-agent-driver.md` | **Related docs** section linking to `observability.md` |
| `test/unit/miner-observability-doc.test.ts` | Doc presence, link resolution, planned dashboard path |

## Doc covers

1. **`frser-sqlite-datasource`** plugin (already in `docker compose --profile observability`)
2. **Ledger paths** — defaults under `~/.config/gittensory-miner/` + env overrides
3. **Docker bind mount** — `${HOME}/.config/gittensory-miner:/miner-state:ro` pattern for host miner + containerized Grafana
4. **Two datasources** — attempt log + prediction ledger (UIDs aligned with upcoming [#5184](https://github.com/JSONbored/gittensory/issues/5184))
5. **Dashboard** — `grafana/dashboards/miner-usage.json` auto/manual import (upcoming [#5185](https://github.com/JSONbored/gittensory/issues/5185))
6. **ORB separation** — contrasts miner usage vs `ai-usage.json` / `gittensory-db`

## Test plan

- [x] `observability.md` contains concrete steps (plugin, paths, SQL sanity queries, compose override)
- [x] `coding-agent-driver.md` links to `observability.md` (invariant: file exists)
- [x] Doc references #4875 with link-out wording, not duplicated runbook prose
- [ ] `npx vitest run test/unit/miner-observability-doc.test.ts`
- [ ] `npm run test:ci`

## Notes

- Issue labels: `help wanted`, `gittensor:feature` — confirm contributor eligibility before opening.
- Independently shippable; becomes fully actionable once [#5184](https://github.com/JSONbored/gittensory/issues/5184) + [#5185](https://github.com/JSONbored/gittensory/issues/5185) land (doc documents manual steps until then).
- No `src/**` changes — Codecov patch gate N/A for this PR.
