### PR TITLE
feat(mcp): wire gittensory_feasibility_gate's claimStatus to the local claim ledger (#5157)

### DIFF
--- a/packages/gittensory-mcp/bin/gittensory-mcp.js
+++ b/packages/gittensory-mcp/bin/gittensory-mcp.js
@@ -201,7 +201,7 @@ const feasibilityGateShape = {
   duplicateClusterRisk: z.enum(["none", "low", "medium", "high"]),
   issueStatus: z.enum(["ready", "needs_proof", "hold", "do_not_use", "duplicate", "invalid", "missing"]),
   found: z.boolean().optional(),
-  // Optional: when both are supplied AND a local AMS install's claim ledger is present (#5157), claimStatus is
+  // Optional: when both are supplied AND a local gittensory-miner install's claim ledger is present (#5157), claimStatus is
   // read from that ledger instead of trusting this caller-supplied value. Omitting either falls back to
   // today's caller-supplied-string behavior unchanged.
   repoFullName: z.string().min(1).optional(),
@@ -211,21 +211,34 @@ const feasibilityGateShape = {
 /**
  * Read-only lookup of the caller's own claim status from a local gittensory-miner install's claim ledger
  * (#5157), so `gittensory_feasibility_gate` isn't purely trusting a caller-supplied `claimStatus` string.
- * Returns `null` (never throws) when there is nothing to look up: no repo/issue supplied, no local AMS
- * install detected (the ledger DB file doesn't exist -- checked via `existsSync` BEFORE opening anything, so
- * this never creates the ledger file/table as a side effect of an advisory-only tool), or the sibling
- * `@jsonbored/gittensory-miner` package isn't resolvable at all (a standalone gittensory-mcp install with no
- * miner alongside it). The caller falls back to its own supplied `claimStatus` in every `null` case. This
- * tool never calls recordClaim/releaseClaim/expireClaim -- read-only, and it never gains any ability to
- * block, cancel, or override a claim or attempt; real claim-conflict authority stays entirely with #4848's
- * maintainer-only path.
+ * Returns `null` (fall back to the caller-supplied value unchanged) only when there is genuinely nothing to
+ * look up: no repo/issue supplied, no local install detected (the ledger DB file doesn't exist -- checked
+ * via `existsSync` BEFORE opening anything, so this never creates the ledger file/table as a side effect of
+ * an advisory-only tool), or the sibling `@jsonbored/gittensory-miner` package isn't resolvable at all (a
+ * standalone gittensory-mcp install with no miner alongside it). When the ledger DB file DOES exist (a real
+ * local install IS present) but reading it fails -- corrupt, locked, permission denied -- this returns
+ * `"unknown"` rather than silently falling back to a caller-supplied string that ground-truth data (which we
+ * know exists but can't currently read) might contradict; `"unknown"` is an existing, honest claimStatus
+ * value the calculator already understands, not a guess. This tool never calls
+ * recordClaim/releaseClaim/expireClaim -- read-only, and it never gains any ability to block, cancel, or
+ * override a claim or attempt; real claim-conflict authority stays entirely with #4848's maintainer-only
+ * path.
  */
 async function resolveLedgerClaimStatus(repoFullName, issueNumber) {
   if (!repoFullName || !issueNumber) return null;
+  let claimLedgerModule;
   try {
-    const { resolveClaimLedgerDbPath, openClaimLedger } = await import("@jsonbored/gittensory-miner/lib/claim-ledger.js");
-    const dbPath = resolveClaimLedgerDbPath();
-    if (!existsSync(dbPath)) return null;
+    claimLedgerModule = await import("@jsonbored/gittensory-miner/lib/claim-ledger.js");
+  } catch {
+    /* v8 ignore next -- gittensory-miner genuinely unresolvable (not installed alongside gittensory-mcp); not
+       reproducible in this monorepo's workspace-hoisted test environment, where the sibling package always
+       resolves */
+    return null;
+  }
+  const { resolveClaimLedgerDbPath, openClaimLedger } = claimLedgerModule;
+  const dbPath = resolveClaimLedgerDbPath();
+  if (!existsSync(dbPath)) return null;
+  try {
     const ledger = openClaimLedger(dbPath);
     try {
       const activeClaims = ledger.listActiveClaims(repoFullName);
@@ -234,10 +247,10 @@ async function resolveLedgerClaimStatus(repoFullName, issueNumber) {
       ledger.close();
     }
   } catch {
-    /* v8 ignore next -- gittensory-miner genuinely unresolvable (not installed alongside gittensory-mcp); not
-       reproducible in this monorepo's workspace-hoisted test environment, where the sibling package always
-       resolves */
-    return null;
+    // The ledger DB file exists (a real local install IS present) but reading it failed -- corrupt, locked,
+    // or a permission error. Never silently trust a caller-supplied string that could contradict ground
+    // truth we know exists but can't currently read; "unknown" surfaces that honestly instead of guessing.
+    return "unknown";
   }
 }
 

--- a/packages/gittensory-mcp/bin/gittensory-mcp.js
+++ b/packages/gittensory-mcp/bin/gittensory-mcp.js
@@ -201,7 +201,45 @@ const feasibilityGateShape = {
   duplicateClusterRisk: z.enum(["none", "low", "medium", "high"]),
   issueStatus: z.enum(["ready", "needs_proof", "hold", "do_not_use", "duplicate", "invalid", "missing"]),
   found: z.boolean().optional(),
+  // Optional: when both are supplied AND a local AMS install's claim ledger is present (#5157), claimStatus is
+  // read from that ledger instead of trusting this caller-supplied value. Omitting either falls back to
+  // today's caller-supplied-string behavior unchanged.
+  repoFullName: z.string().min(1).optional(),
+  issueNumber: z.number().int().positive().optional(),
 };
+
+/**
+ * Read-only lookup of the caller's own claim status from a local gittensory-miner install's claim ledger
+ * (#5157), so `gittensory_feasibility_gate` isn't purely trusting a caller-supplied `claimStatus` string.
+ * Returns `null` (never throws) when there is nothing to look up: no repo/issue supplied, no local AMS
+ * install detected (the ledger DB file doesn't exist -- checked via `existsSync` BEFORE opening anything, so
+ * this never creates the ledger file/table as a side effect of an advisory-only tool), or the sibling
+ * `@jsonbored/gittensory-miner` package isn't resolvable at all (a standalone gittensory-mcp install with no
+ * miner alongside it). The caller falls back to its own supplied `claimStatus` in every `null` case. This
+ * tool never calls recordClaim/releaseClaim/expireClaim -- read-only, and it never gains any ability to
+ * block, cancel, or override a claim or attempt; real claim-conflict authority stays entirely with #4848's
+ * maintainer-only path.
+ */
+async function resolveLedgerClaimStatus(repoFullName, issueNumber) {
+  if (!repoFullName || !issueNumber) return null;
+  try {
+    const { resolveClaimLedgerDbPath, openClaimLedger } = await import("@jsonbored/gittensory-miner/lib/claim-ledger.js");
+    const dbPath = resolveClaimLedgerDbPath();
+    if (!existsSync(dbPath)) return null;
+    const ledger = openClaimLedger(dbPath);
+    try {
+      const activeClaims = ledger.listActiveClaims(repoFullName);
+      return activeClaims.some((claim) => claim.issueNumber === issueNumber) ? "claimed" : "unclaimed";
+    } finally {
+      ledger.close();
+    }
+  } catch {
+    /* v8 ignore next -- gittensory-miner genuinely unresolvable (not installed alongside gittensory-mcp); not
+       reproducible in this monorepo's workspace-hoisted test environment, where the sibling package always
+       resolves */
+    return null;
+  }
+}
 
 const findOpportunitiesShape = {
   targets: z
@@ -521,7 +559,7 @@ const STDIO_TOOL_DESCRIPTORS = [
   },
   {
     name: "gittensory_feasibility_gate",
-    description: "Pure local go/raise/avoid feasibility verdict from claim status, duplicate-cluster risk, and issue quality/lifecycle status — the same discriminants the analyze-phase feasibility gate branches on. No API round-trip.",
+    description: "Pure local go/raise/avoid feasibility verdict from claim status, duplicate-cluster risk, and issue quality/lifecycle status — the same discriminants the analyze-phase feasibility gate branches on. When repoFullName/issueNumber are supplied and a local gittensory-miner install's claim ledger is present, claimStatus is read from that ledger instead of the caller-supplied value; otherwise falls back to the caller-supplied claimStatus unchanged. Advisory-only — never blocks, cancels, or overrides a claim or attempt; real claim-conflict resolution authority stays with the maintainer-only path. No API round-trip.",
   },
 ];
 
@@ -1194,11 +1232,13 @@ server.registerTool(
     description: stdioToolDescription("gittensory_feasibility_gate"),
     inputSchema: feasibilityGateShape,
   },
-  ({ claimStatus, duplicateClusterRisk, issueStatus, found }) =>
-    toolResult(
+  async ({ claimStatus, duplicateClusterRisk, issueStatus, found, repoFullName, issueNumber }) => {
+    const ledgerClaimStatus = await resolveLedgerClaimStatus(repoFullName, issueNumber);
+    return toolResult(
       "Gittensory feasibility gate.",
-      buildFeasibilityVerdict({ claimStatus, duplicateClusterRisk, issueStatus, found }),
-    ),
+      buildFeasibilityVerdict({ claimStatus: ledgerClaimStatus ?? claimStatus, duplicateClusterRisk, issueStatus, found }),
+    );
+  },
 );
 
 // ── Resources: decision-pack, doctor, compatibility, changelog (#292) ─────────

--- a/test/unit/mcp-feasibility-gate.test.ts
+++ b/test/unit/mcp-feasibility-gate.test.ts
@@ -1,6 +1,6 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
@@ -188,6 +188,33 @@ describe("gittensory_feasibility_gate: local claim-ledger sourcing (#5157)", () 
     const data = result.structuredContent as Record<string, unknown>;
     expect(data.verdict).toBe("avoid");
     expect(data.avoidReasons).toEqual(["claim_status_solved"]);
+  });
+
+  it("regression: reports claimStatus 'unknown' (never silently trusts the caller-supplied value) when the ledger DB file exists but is unreadable/corrupt", async () => {
+    // A real local install IS present (the DB file exists) but it isn't a valid SQLite file -- reading it
+    // must fail loudly into "unknown", not silently fall back to the caller's (unverifiable) claimStatus.
+    // Using a caller-supplied "solved" here is the discriminating case: if the old buggy behavior (silently
+    // falling back to the caller-supplied value on ANY read error) were still present, this would produce an
+    // "avoid" verdict (claim_status_solved). "unknown" triggers neither avoid nor raise on its own, so the
+    // fixed behavior produces "go" instead -- these two outcomes are distinguishable, unlike using
+    // "unclaimed" as the caller-supplied value (which would coincidentally also yield "go" either way).
+    writeFileSync(ledgerDbPath, "not a sqlite database");
+    await connectWithLedgerDb(ledgerDbPath);
+
+    const result = await ledgerClient.callTool({
+      name: "gittensory_feasibility_gate",
+      arguments: {
+        claimStatus: "solved",
+        duplicateClusterRisk: "none",
+        issueStatus: "ready",
+        repoFullName: "acme/widgets",
+        issueNumber: 42,
+      },
+    });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as Record<string, unknown>;
+    expect(data.verdict).toBe("go");
+    expect(data.avoidReasons).toEqual([]);
   });
 
   it("falls back to the caller-supplied claimStatus unchanged when repoFullName/issueNumber are omitted", async () => {

--- a/test/unit/mcp-feasibility-gate.test.ts
+++ b/test/unit/mcp-feasibility-gate.test.ts
@@ -4,6 +4,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { openClaimLedger } from "../../packages/gittensory-miner/lib/claim-ledger.js";
 
 const bin = join(process.cwd(), "packages/gittensory-mcp/bin/gittensory-mcp.js");
 
@@ -94,5 +95,149 @@ describe("gittensory_feasibility_gate stdio tool (#4270)", () => {
     expect(result.isError).toBeFalsy();
     const text = JSON.stringify(result);
     expect(text).not.toMatch(/hotkey|coldkey|wallet|mnemonic|payout|reward/i);
+  });
+});
+
+describe("gittensory_feasibility_gate: local claim-ledger sourcing (#5157)", () => {
+  let ledgerRoot: string;
+  let ledgerDbPath: string;
+  let ledgerClient: Client;
+  let ledgerTransport: StdioClientTransport;
+  let ledgerConfigDir: string;
+
+  async function connectWithLedgerDb(dbPath: string | undefined) {
+    ledgerConfigDir = mkdtempSync(join(tmpdir(), "gittensory-feasibility-gate-ledger-"));
+    const env: Record<string, string> = { ...(process.env as Record<string, string>), GITTENSORY_CONFIG_DIR: ledgerConfigDir };
+    if (dbPath !== undefined) env.GITTENSORY_MINER_CLAIM_LEDGER_DB = dbPath;
+    else delete env.GITTENSORY_MINER_CLAIM_LEDGER_DB;
+    ledgerTransport = new StdioClientTransport({ command: "node", args: [bin, "--stdio"], env });
+    ledgerClient = new Client({ name: "feasibility-gate-ledger-test", version: "0.0.1" });
+    await ledgerClient.connect(ledgerTransport);
+  }
+
+  beforeEach(() => {
+    ledgerRoot = mkdtempSync(join(tmpdir(), "gittensory-feasibility-gate-ledger-db-"));
+    ledgerDbPath = join(ledgerRoot, "claim-ledger.sqlite3");
+  });
+
+  afterEach(async () => {
+    await ledgerClient?.close().catch(() => undefined);
+    if (ledgerConfigDir) rmSync(ledgerConfigDir, { recursive: true, force: true });
+    if (ledgerRoot) rmSync(ledgerRoot, { recursive: true, force: true });
+  });
+
+  it("regression: prefers ledger-backed truth (claimed) over a contradicting caller-supplied claimStatus", async () => {
+    const ledger = openClaimLedger(ledgerDbPath);
+    ledger.claimIssue("acme/widgets", 42, "in progress");
+    ledger.close();
+    await connectWithLedgerDb(ledgerDbPath);
+
+    const result = await ledgerClient.callTool({
+      name: "gittensory_feasibility_gate",
+      arguments: {
+        claimStatus: "unclaimed", // caller-supplied, contradicts the real ledger state
+        duplicateClusterRisk: "none",
+        issueStatus: "ready",
+        repoFullName: "acme/widgets",
+        issueNumber: 42,
+      },
+    });
+    expect(result.isError).toBeFalsy();
+    // claimStatus: "claimed" triggers a "raise" verdict (claim_status_claimed) in the calculator -- the
+    // important assertion is that THIS ran, not the "go" path the caller's "unclaimed" lie would have produced.
+    const data = result.structuredContent as Record<string, unknown>;
+    expect(data.verdict).toBe("raise");
+    expect(data.raiseReasons).toEqual(["claim_status_claimed"]);
+  });
+
+  it("sources claimStatus: unclaimed from the ledger when no active claim matches the issue, overriding a contradicting caller-supplied value", async () => {
+    const ledger = openClaimLedger(ledgerDbPath);
+    ledger.claimIssue("acme/widgets", 99, "someone else's issue"); // a DIFFERENT issue is claimed
+    ledger.close();
+    await connectWithLedgerDb(ledgerDbPath);
+
+    const result = await ledgerClient.callTool({
+      name: "gittensory_feasibility_gate",
+      arguments: {
+        claimStatus: "solved", // caller-supplied, would normally trigger an avoid verdict
+        duplicateClusterRisk: "none",
+        issueStatus: "ready",
+        repoFullName: "acme/widgets",
+        issueNumber: 42, // NOT the claimed issue -- ledger says unclaimed
+      },
+    });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as Record<string, unknown>;
+    expect(data.verdict).toBe("go");
+  });
+
+  it("falls back to the caller-supplied claimStatus unchanged when the ledger DB file does not exist (no local install detected)", async () => {
+    await connectWithLedgerDb(join(ledgerRoot, "does-not-exist.sqlite3"));
+
+    const result = await ledgerClient.callTool({
+      name: "gittensory_feasibility_gate",
+      arguments: {
+        claimStatus: "solved",
+        duplicateClusterRisk: "none",
+        issueStatus: "ready",
+        repoFullName: "acme/widgets",
+        issueNumber: 42,
+      },
+    });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as Record<string, unknown>;
+    expect(data.verdict).toBe("avoid");
+    expect(data.avoidReasons).toEqual(["claim_status_solved"]);
+  });
+
+  it("falls back to the caller-supplied claimStatus unchanged when repoFullName/issueNumber are omitted", async () => {
+    const ledger = openClaimLedger(ledgerDbPath);
+    ledger.claimIssue("acme/widgets", 42, "irrelevant -- no repo/issue supplied");
+    ledger.close();
+    await connectWithLedgerDb(ledgerDbPath);
+
+    const result = await ledgerClient.callTool({
+      name: "gittensory_feasibility_gate",
+      arguments: { claimStatus: "solved", duplicateClusterRisk: "none", issueStatus: "ready" },
+    });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as Record<string, unknown>;
+    expect(data.verdict).toBe("avoid");
+    expect(data.avoidReasons).toEqual(["claim_status_solved"]);
+  });
+
+  it("invariant: never writes to the claim ledger and never gains blocking/override authority (advisory-only output shape unchanged)", async () => {
+    const setupLedger = openClaimLedger(ledgerDbPath);
+    setupLedger.claimIssue("acme/widgets", 42, "pre-existing claim");
+    const before = setupLedger.listClaims();
+    setupLedger.close();
+    await connectWithLedgerDb(ledgerDbPath);
+
+    const result = await ledgerClient.callTool({
+      name: "gittensory_feasibility_gate",
+      arguments: {
+        claimStatus: "unclaimed",
+        duplicateClusterRisk: "none",
+        issueStatus: "ready",
+        repoFullName: "acme/widgets",
+        issueNumber: 42,
+      },
+    });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as Record<string, unknown>;
+    expect(Object.keys(data).sort()).toEqual(["avoidReasons", "raiseReasons", "summary", "verdict"]);
+
+    const inspectLedger = openClaimLedger(ledgerDbPath);
+    const after = inspectLedger.listClaims();
+    inspectLedger.close();
+    expect(after).toEqual(before);
+  });
+
+  it("tool description documents the ledger-sourcing behavior and advisory-only guarantee", async () => {
+    await connectWithLedgerDb(undefined);
+    const { tools } = await ledgerClient.listTools();
+    const tool = tools.find((t) => t.name === "gittensory_feasibility_gate");
+    expect(tool?.description).toContain("Advisory-only");
+    expect(tool?.description).toContain("local gittensory-miner install's claim ledger");
   });
 });


### PR DESCRIPTION
## Summary

- `gittensory_feasibility_gate` in `packages/gittensory-mcp/bin/gittensory-mcp.js` took `claimStatus` as a purely caller-supplied string -- the pure feasibility calculator was never actually connected to real local claim state, even though `packages/gittensory-miner/lib/claim-ledger.js` already tracks it.
- Adds optional `repoFullName`/`issueNumber` inputs to `feasibilityGateShape`. When both are supplied AND a local `gittensory-miner` install's claim ledger DB file exists, `claimStatus` is now read from that ledger (an active claim on the exact issue -> `"claimed"`, otherwise `"unclaimed"`) instead of trusting the caller-supplied value.
- **Strictly read-only, by construction**: the ledger DB file's existence is checked via `existsSync` *before* opening anything, so this advisory-only tool never creates the ledger as a side effect. It never calls `recordClaim`/`releaseClaim`/`expireClaim`, and never gains any ability to block, cancel, or override a claim or attempt -- real claim-conflict resolution authority stays entirely with the maintainer-only path (#4848), unaffected.
- Falls back to today's caller-supplied-string behavior, completely unchanged, when `repoFullName`/`issueNumber` are omitted, the ledger DB file doesn't exist (no local install detected), or `@jsonbored/gittensory-miner` isn't resolvable at all.
- When the ledger DB file **does** exist (a real local install IS present) but reading it fails -- corrupt, locked, permission denied -- this reports the existing `claimStatus: "unknown"` value instead of silently falling back to a caller-supplied string that might contradict ground truth we know exists but can't currently read.
- The feasibility calculator's own decision logic (`buildFeasibilityVerdict`) is completely untouched -- this diff only changes where `claimStatus` is *sourced* from.
- Updated the tool's description to document the ledger-sourcing behavior and reaffirm it's advisory-only with no claim-conflict authority.

## Resubmission note

This is a resubmission of #5361, which the review gate held/closed on a legitimate finding (not a false positive this time): the original `catch` block swallowed *every* error from opening/querying the ledger, not just "package not found" -- so a corrupt or locked ledger DB file would have silently fallen back to a possibly-wrong caller-supplied `claimStatus`. Fixed by narrowing the fallback to genuinely "nothing to check" cases (missing inputs, missing DB file, unresolvable package) and reporting `"unknown"` -- an existing, neutral claimStatus value the calculator already understands -- for an existing-but-unreadable ledger, with a new regression test covering exactly that discriminating case.

## Test plan

- [x] `npx vitest run test/unit/mcp-feasibility-gate.test.ts` -- 13/13 passing (6 pre-existing + 7 new), spawning the real MCP server subprocess via stdio and pointing `GITTENSORY_MINER_CLAIM_LEDGER_DB` at fixture SQLite files built with `openClaimLedger`/`claimIssue` from the miner package directly. Covers: ledger-backed `"claimed"` overriding a contradicting caller-supplied value, ledger-backed `"unclaimed"` overriding a contradicting caller-supplied value, fallback when the DB file doesn't exist, **the new regression: `"unknown"` (not a silent caller-supplied fallback) when the DB file exists but is corrupt**, fallback when `repoFullName`/`issueNumber` are omitted, a no-write invariant, and the updated tool description.
- [x] `npm run typecheck` -- clean.
- [x] `npm run build:mcp` -- clean.
- [x] `npm run docs:drift-check` -- clean.
- [x] Swept the full diff for `gh[pousr]_`/`github_pat_`/`sk-`/`gts_`/`AKIA`/private-key/`TOKEN=`/`SECRET=` patterns -- zero matches.
- [ ] `packages/gittensory-mcp/**` currently sits outside vitest's `coverage.include` glob, so `codecov/patch` cannot measure this change yet -- treating the tests above as the enforced house standard regardless. The outer `catch` for "gittensory-miner genuinely unresolvable" stays `/* v8 ignore */`, unreproducible in this monorepo's workspace-hoisted test environment.
- [ ] Did not run the full unsharded `npm run test:coverage` locally (shared/resource-contended machine); relying on the targeted test run above plus `npm run typecheck`/`build:mcp`.

Fixes #5157.