### PR TITLE
docs: rewrite marketing and docs copy for LoopOver

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,6 +1,6 @@
 # Code Of Conduct
 
-Gittensory is maintained as a direct, technical, evidence-first project. We expect contributors,
+LoopOver is maintained as a direct, technical, evidence-first project. We expect contributors,
 maintainers, and users to keep discussions focused on the work, the proof, and the production
 impact.
 
@@ -23,7 +23,7 @@ impact.
   credit or farm Gittensor rewards.
 - Posting secrets, private contributor evidence, private maintainer evidence, wallet details,
   hotkeys, coldkeys, raw trust scores, or private rankings publicly.
-- Misrepresenting Gittensory output as guaranteed compensation, guaranteed ranking, or financial
+- Misrepresenting LoopOver output as guaranteed compensation, guaranteed ranking, or financial
   advice.
 - Evading review boundaries by reopening closed work without addressing the stated reason.
 - Attempting to bypass authentication, rate limits, GitHub App permissions, or Cloudflare Worker

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Gittensory is a Cloudflare Workers, TanStack Start, GitHub App, and MCP project for
+LoopOver is a Cloudflare Workers, TanStack Start, GitHub App, and MCP project for
 Gittensor OSS contribution intelligence. Contributions need to protect that scope: private
 signals stay private, public GitHub output stays sanitized, and production surfaces must stay
 wired to real backend behavior.
@@ -11,7 +11,7 @@ closed without an extended review cycle.
 
 ## What Happens to Your PR (reviewed and acted on automatically)
 
-gittensory reviews every PR with an automated gate (a GitHub App) and **acts on the outcome within a
+LoopOver reviews every PR with an automated gate (a GitHub App) and **acts on the outcome within a
 few minutes** — there is no extended human back-and-forth. For a contributor PR (you are not the repo
 owner or an automation bot):
 
@@ -31,7 +31,7 @@ the whole procedure step by step.
 
 ## How Reviews Work (timing, one-shot, and asking for review)
 
-**Timing is typical, not an SLA.** When the gittensory maintainer agent is operating, most PRs are
+**Timing is typical, not an SLA.** When the LoopOver maintainer agent is operating, most PRs are
 reviewed and auto-merged or auto-closed within **~1 hour of CI finishing**. When the agent is paused or
 under maintenance, manual review **typically takes 24–48 hours, depending on volume**. These are
 observations, not commitments or a service-level guarantee — reviews happen when they happen.
@@ -305,7 +305,7 @@ Config as code (`.gittensory.yml`) — every repository setting is controllable 
 - Precedence: `.gittensory.yml` `gate:` > `.gittensory.yml` `settings:` > dashboard repository settings >
   safe defaults; unset fields fall back to the next layer. The committed root `.gittensory.yml` is the
   worked example. Resolved once in `resolveRepositorySettings`, so the whole app honours the file.
-- The config chooses **what** gittensory does (gate on/off, blockers, comments, labels, surface, panel
+- The config chooses **what** LoopOver does (gate on/off, blockers, comments, labels, surface, panel
   content); it never changes **who** can be blocked — only confirmed Gittensor contributors are ever
   hard-blocked, and the footer's Gittensor attribution/register link always remains.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Gittensory
+# LoopOver
+
+_Formerly Gittensory._
 
 <p align="center">
   <a href="https://github.com/JSONbored/gittensory/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/JSONbored/gittensory/actions/workflows/ci.yml/badge.svg" /></a>
@@ -8,7 +10,7 @@
   <a href="https://gittensor.io/miners/repository?name=JSONbored/gittensory"><img alt="Gittensor impact" src="https://api.gittensor.io/repos/JSONbored%2Fgittensory/badge.svg" /></a>
 </p>
 
-Gittensory is a deterministic control plane for Gittensor OSS contribution work.
+LoopOver is a deterministic control plane for Gittensor OSS contribution work.
 
 It helps contributors plan cleaner work, helps maintainers review with less public noise, and keeps private scoring, wallet, hotkey, and reviewability context out of public GitHub output.
 
@@ -18,7 +20,7 @@ It is not a Gittensor explorer, public leaderboard, reward-farming bot, wallet d
 
 ## Privacy Boundary
 
-Gittensory keeps sensitive context private by default.
+LoopOver keeps sensitive context private by default.
 
 - MCP local branch analysis sends metadata, not source contents.
 - Public GitHub comments never include wallet, hotkey, reward estimate, private ranking, raw trust score, or reviewability context.
@@ -29,7 +31,7 @@ See [Privacy and security](https://gittensory.aethereal.dev/docs/privacy-securit
 
 ## Review Capabilities
 
-Gittensory CI and gittensory review score, gate, and comment on pull requests. The review algorithm is open-source; operators tune behavior through per-repo settings and the `GITTENSORY_REVIEW_*` feature flags, every one of which ships **OFF** and is opt-in per repo.
+LoopOver CI and LoopOver review score, gate, and comment on pull requests. The review algorithm is open-source; operators tune behavior through per-repo settings and the `GITTENSORY_REVIEW_*` feature flags, every one of which ships **OFF** and is opt-in per repo.
 
 - **Safety scan** — defangs untrusted PR title/body/diff (prompt-injection neutralization) before the AI reviewer reads them, and scans the diff for leaked secrets, surfacing a `secret_leak` blocker.
 - **CI + full-file grounding** — grounds the AI reviewer with the PR's finished CI status and the full post-change content of the changed files, so claims are verified against reality instead of predicted.
@@ -65,7 +67,7 @@ See [Tuning your reviews](https://gittensory.aethereal.dev/docs/tuning) for the 
 | Engine package    | [`@jsonbored/gittensory-engine`](packages/gittensory-engine/README.md) — shared deterministic logic for the review stack and miner |
 | Miner package     | [`@jsonbored/gittensory-miner`](packages/gittensory-miner/README.md) — local foundation CLI for the autonomous miner runtime        |
 | API               | [API browser](https://gittensory.aethereal.dev/api) and [OpenAPI JSON](https://gittensory-api.aethereal.dev/openapi.json)          |
-| GitHub App        | [Install](https://github.com/apps/gittensory/installations/new) and [setup docs](https://gittensory.aethereal.dev/docs/github-app) |
+| GitHub App        | [Setup docs](https://gittensory.aethereal.dev/docs/github-app) — self-hosting is the only currently available path |
 | Browser extension | [Extension page](https://gittensory.aethereal.dev/extension)                                                                       |
 
 ## MCP Install

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,8 +11,8 @@ include only the minimum reproduction details needed to verify the issue.
 
 ## Privacy Posture
 
-- Gittensory does not store user GitHub PATs.
-- Browser auth uses GitHub OAuth and an HttpOnly Gittensory session cookie. CLI/MCP auth uses the
+- LoopOver does not store user GitHub PATs.
+- Browser auth uses GitHub OAuth and an HttpOnly LoopOver session cookie. CLI/MCP auth uses the
   existing GitHub Device Flow and bearer session token.
 - Public PR comments are sanitized and only posted for officially confirmed Gittensor miners when
   the installed repository settings allow them.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -27,6 +27,6 @@ For conduct issues, use the expectations in `CODE_OF_CONDUCT.md`.
 
 ## Expected Response Posture
 
-Gittensory is maintained as a Cloudflare Worker, frontend, GitHub App, and agent-integration
+LoopOver is maintained as a Cloudflare Worker, frontend, GitHub App, and agent-integration
 project. Support should keep the same boundaries as the product: no public wallet data, no raw
 trust scores, no public reward estimates, and no source-code upload by default.

--- a/apps/gittensory-ui/src/routes/docs.ai-summaries.tsx
+++ b/apps/gittensory-ui/src/routes/docs.ai-summaries.tsx
@@ -6,17 +6,17 @@ import { Callout } from "@/components/site/primitives";
 export const Route = createFileRoute("/docs/ai-summaries")({
   head: () => ({
     meta: [
-      { title: "AI summaries — Gittensory docs" },
+      { title: "AI summaries — LoopOver docs" },
       {
         name: "description",
         content:
-          "How Gittensory uses AI: only over deterministic signals, never as a source of truth, with strict public/private boundaries.",
+          "How LoopOver uses AI: only over deterministic signals, never as a source of truth, with strict public/private boundaries.",
       },
-      { property: "og:title", content: "AI summaries — Gittensory docs" },
+      { property: "og:title", content: "AI summaries — LoopOver docs" },
       {
         property: "og:description",
         content:
-          "How Gittensory uses AI: only over deterministic signals, never as a source of truth, with strict public/private boundaries.",
+          "How LoopOver uses AI: only over deterministic signals, never as a source of truth, with strict public/private boundaries.",
       },
       { property: "og:url", content: "/docs/ai-summaries" },
     ],
@@ -34,7 +34,7 @@ function AiSummariesDoc() {
     >
       <h2>The rule</h2>
       <p>
-        Gittensory is deterministic. When AI summaries are enabled, they sit
+        LoopOver is deterministic. When AI summaries are enabled, they sit
         <em> on top of</em> the structured response — they never replace it, never add facts that
         aren&apos;t in the response, and never change ranked actions, blockers, or scoreability
         numbers.

--- a/apps/gittensory-ui/src/routes/docs.beta-onboarding.tsx
+++ b/apps/gittensory-ui/src/routes/docs.beta-onboarding.tsx
@@ -6,13 +6,13 @@ import { CodeBlock, Callout } from "@/components/site/primitives";
 export const Route = createFileRoute("/docs/beta-onboarding")({
   head: () => ({
     meta: [
-      { title: "Beta onboarding — Gittensory docs" },
+      { title: "Beta onboarding — LoopOver docs" },
       {
         name: "description",
         content:
           "Role-based beta paths for miners, maintainers, repo owners, and operators — first useful action, not just API reference.",
       },
-      { property: "og:title", content: "Beta onboarding — Gittensory docs" },
+      { property: "og:title", content: "Beta onboarding — LoopOver docs" },
       {
         property: "og:description",
         content:
@@ -30,10 +30,10 @@ function BetaOnboarding() {
     <DocsPage
       eyebrow="Get started"
       title="Beta onboarding by role"
-      description="Pick the lane that matches you. Each path ends in a concrete first win — install, configure, or read a report — without treating Gittensory as an official Gittensor product surface."
+      description="Pick the lane that matches you. Each path ends in a concrete first win — install, configure, or read a report — without treating LoopOver as an official Gittensor product surface."
     >
       <Callout>
-        <strong>Product positioning.</strong> Gittensory is a deterministic base-agent and
+        <strong>Product positioning.</strong> LoopOver is a deterministic base-agent and
         control-plane layer for the Gittensor ecosystem. It is{" "}
         <a href="https://github.com/jsonbored/gittensory" target="_blank" rel="noreferrer">
           jsonbored/gittensory
@@ -51,7 +51,7 @@ function BetaOnboarding() {
         Miners and contributors use the local MCP package. Source contents stay on your machine but
         branch metadata (such as branch names, SHAs, changed file paths, commit messages, validation
         details, labels, body text, linked issues, and scenario notes) is sent to authenticated
-        Gittensory MCP/API responses for analysis and packet preparation.
+        LoopOver MCP/API responses for analysis and packet preparation.
       </p>
       <ol>
         <li>

--- a/apps/gittensory-ui/src/routes/docs.branch-analysis.tsx
+++ b/apps/gittensory-ui/src/routes/docs.branch-analysis.tsx
@@ -6,13 +6,13 @@ import { CodeBlock, Callout } from "@/components/site/primitives";
 export const Route = createFileRoute("/docs/branch-analysis")({
   head: () => ({
     meta: [
-      { title: "Branch analysis — Gittensory docs" },
+      { title: "Branch analysis — LoopOver docs" },
       {
         name: "description",
         content:
           "Metadata-only analysis of a branch. Inputs, outputs, and the privacy boundary explained.",
       },
-      { property: "og:title", content: "Branch analysis — Gittensory docs" },
+      { property: "og:title", content: "Branch analysis — LoopOver docs" },
       {
         property: "og:description",
         content:
@@ -30,7 +30,7 @@ function BranchAnalysis() {
     <DocsPage
       eyebrow="Core concepts"
       title="Branch analysis"
-      description="Gittensory analyzes branches using metadata only. Your source code never leaves your machine."
+      description="LoopOver analyzes branches using metadata only. Your source code never leaves your machine."
     >
       <h2>Inputs</h2>
       <ul>

--- a/apps/gittensory-ui/src/routes/docs.github-app.tsx
+++ b/apps/gittensory-ui/src/routes/docs.github-app.tsx
@@ -3,22 +3,20 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { DocsPage } from "@/components/site/docs-page";
 import { CodeBlock, Callout } from "@/components/site/primitives";
 
-const GITHUB_APP_INSTALL_URL = "https://github.com/apps/gittensory/installations/new";
-
 export const Route = createFileRoute("/docs/github-app")({
   head: () => ({
     meta: [
-      { title: "GitHub App configuration — Gittensory docs" },
+      { title: "GitHub App configuration — LoopOver docs" },
       {
         name: "description",
         content:
-          "How the Gittensory GitHub App reviews pull requests once installed — self-hosted (recommended) or via the private managed-beta shared app. The Gittensory Orb Review Agent check plus a review comment posted as gittensory[bot]. Choose repos, configure sticky PR panels, advisory checks, and optional review-agent enforcement.",
+          "How the LoopOver GitHub App reviews pull requests once installed. Self-hosting is the only currently available path; a shared, centrally hosted App is planned as a future offering. The Gittensory Orb Review Agent check plus a review comment posted as gittensory[bot]. Choose repos, configure sticky PR panels, advisory checks, and optional review-agent enforcement.",
       },
-      { property: "og:title", content: "GitHub App configuration — Gittensory docs" },
+      { property: "og:title", content: "GitHub App configuration — LoopOver docs" },
       {
         property: "og:description",
         content:
-          "How the Gittensory GitHub App reviews pull requests once installed — self-hosted (recommended) or via the private managed-beta shared app. Choose repos, configure sticky PR panels, advisory checks, and optional review-agent enforcement.",
+          "How the LoopOver GitHub App reviews pull requests once installed. Self-hosting is the only currently available path; a shared, centrally hosted App is planned as a future offering. Choose repos, configure sticky PR panels, advisory checks, and optional review-agent enforcement.",
       },
       { property: "og:url", content: "/docs/github-app" },
     ],
@@ -32,59 +30,34 @@ function GithubApp() {
     <DocsPage
       eyebrow="Workflows"
       title="GitHub App configuration"
-      description="Install a Gittensory GitHub App on a repo so it reviews your pull requests, then choose whether it should stay advisory or enforce repo-configured PR quality rules."
+      description="Install a LoopOver GitHub App on a repo so it reviews your pull requests, then choose whether it should stay advisory or enforce repo-configured PR quality rules."
     >
       <p>
-        Once installed, a <strong>Gittensory GitHub App reviews every pull request</strong> on the
-        repos you select — whether that's your own self-hosted App (recommended; see{" "}
-        <Link to="/docs/maintainer-self-hosting">self-hosting setup</Link>) or, for private
-        managed-beta operators, the shared <code>gittensory</code> App below. Each review produces
-        two surfaces: the <strong>Gittensory Orb Review Agent</strong> check run (and the advisory{" "}
+        Once installed, a <strong>LoopOver GitHub App reviews every pull request</strong> on the
+        repos you select. Self-hosting your own App (see{" "}
+        <Link to="/docs/maintainer-self-hosting">self-hosting setup</Link>) is the only currently
+        available path. Each review produces two surfaces: the{" "}
+        <strong>Gittensory Orb Review Agent</strong> check run (and the advisory{" "}
         <strong>Gittensory Context</strong> check), and a single review comment posted by{" "}
         <code>gittensory[bot]</code> that updates in place as the PR evolves. The review behavior
-        below this page's Install section (PR panel, checks, gate modes, config-as-code) applies
-        identically whichever App you install — but the App's{" "}
-        <em>install steps and required permissions differ</em>, since a self-hosted App needs write
-        access the shared App does not.
+        below this page's Install section (PR panel, checks, gate modes, config-as-code) is the same
+        regardless of which connection mode your self-hosted App uses.
       </p>
 
       <h2>Install</h2>
       <p>
-        <strong>Self-hosting is the recommended, default path.</strong> Run the review stack
+        <strong>Self-hosting is the only currently available path.</strong> Run the review stack
         yourself, then install your own GitHub App on exactly the repos you choose using the
         self-host setup wizard. The direct App's required permissions and events are covered in{" "}
         <Link to="/docs/self-hosting-github-app">GitHub App and Orb</Link> — use that page's
-        checklist, not the one below, for a self-hosted install.
+        checklist for a self-hosted install.
       </p>
-      <p>
-        The shared <code>gittensory</code> App is <strong>private / managed-beta only</strong> — it
-        is not open for general public install. If you've been invited into the managed beta, start
-        from{" "}
-        <a href={GITHUB_APP_INSTALL_URL} target="_blank" rel="noreferrer">
-          the GitHub App install flow
-        </a>
-        , then choose only the repositories you want Gittensory to see.
-      </p>
-      <ol>
-        <li>Open the install flow and pick the owning account.</li>
-        <li>
-          Choose selected repositories instead of all repositories unless you are onboarding an org.
-        </li>
-        <li>
-          Approve <code>Metadata: read</code>, <code>Pull requests: read</code>, and{" "}
-          <code>Issues: write</code>. Enable <code>Checks: write</code> when Context or review-agent
-          check runs are enabled.
-        </li>
-        <li>
-          Keep webhook events enabled for <code>issues</code>, <code>issue_comment</code>,{" "}
-          <code>pull_request</code>, and <code>repository</code>.
-        </li>
-      </ol>
-      <Callout variant="note">
-        This checklist is for the shared managed-beta App only. A self-hosted App needs{" "}
-        <code>Pull requests: write</code> (not read) and <code>Checks: write</code> is mandatory,
-        not optional — see <Link to="/docs/self-hosting-github-app">GitHub App and Orb</Link> for
-        the direct App's exact permission and event list.
+      <Callout variant="note" title="Shared, centrally hosted App: not currently available">
+        LoopOver previously ran a private managed-beta shared App that repo owners could install
+        directly, without self-hosting. That shared install path is currently paused while
+        self-hosted Orb is the primary way to run LoopOver — a new centrally hosted offering is
+        planned for the future. If you previously used the shared managed-beta App, see{" "}
+        <Link to="/docs/maintainer-self-hosting">self-hosting setup</Link> to move your repos over.
       </Callout>
 
       <h2>First 10 minutes</h2>
@@ -120,14 +93,14 @@ GET /v1/installations/:id/repair`}
 
       <h2>Default posture</h2>
       <p>
-        Gittensory is advisory-first. Public comments, labels, the Context check, and the
-        review-agent check are controlled per repo. Missing issue links, non-Gittensor contributors,
-        busy queues, and weak overlap signals do not block merge by default.
+        LoopOver is advisory-first. Public comments, labels, the Context check, and the review-agent
+        check are controlled per repo. Missing issue links, non-Gittensor contributors, busy queues,
+        and weak overlap signals do not block merge by default.
       </p>
 
       <h2>PR panel</h2>
       <p>
-        The PR panel is the review comment the gittensory app posts on each pull request. It is one
+        The PR panel is the review comment the LoopOver app posts on each pull request. It is one
         sticky comment authored by <code>gittensory[bot]</code> that updates in place — the app
         edits the same comment instead of adding new ones. It shows a public-safe readiness score,
         concrete signal evidence, and short actions for linked issues, related work, review load,
@@ -144,7 +117,7 @@ GET /v1/installations/:id/repair`}
 
       <h2>Checks</h2>
       <p>
-        The gittensory app publishes its review as check runs.{" "}
+        The LoopOver app publishes its review as check runs.{" "}
         <strong>Gittensory Orb Review Agent</strong> is the gate result, controlled by{" "}
         <code>reviewCheckMode</code> (<code>required</code> / <code>visible</code> /{" "}
         <code>disabled</code>). <strong>Gittensory Context</strong> is the separate advisory
@@ -168,7 +141,7 @@ GET /v1/installations/:id/repair`}
 
       <h2>Gate modes</h2>
       <p>
-        The deterministic gate is the heart of the gittensory review. Its master switch is{" "}
+        The deterministic gate is the heart of the LoopOver review. Its master switch is{" "}
         <code>reviewCheckMode</code> (<code>required</code> / <code>visible</code> /{" "}
         <code>disabled</code>); each dimension then refines an already-enabled gate with a tri-state
         mode — <code>off</code> (not evaluated), <code>advisory</code> (surfaced, never blocks), or{" "}
@@ -256,7 +229,7 @@ GET /v1/installations/:id/repair`}
         Every setting can be committed to <code>.gittensory.yml</code> at the repo root instead of,
         or layered over, the dashboard. Precedence is <code>.gittensory.yml</code> &gt; repository
         settings &gt; safe defaults; an unset field falls back to the next layer. It only chooses{" "}
-        <em>what</em> Gittensory does — a configured blocker gates every author identically,
+        <em>what</em> LoopOver does — a configured blocker gates every author identically,
         regardless of config.
       </p>
       <CodeBlock
@@ -287,9 +260,8 @@ review:
         always remain on the footer.
       </p>
       <p>
-        The per-repo settings above choose <em>what</em> Gittensory does on each PR. The next
-        section covers the deployment-wide capability switches that turn whole review features on or
-        off.
+        The per-repo settings above choose <em>what</em> LoopOver does on each PR. The next section
+        covers the deployment-wide capability switches that turn whole review features on or off.
       </p>
 
       <h2>
@@ -387,8 +359,7 @@ GITTENSORY_REVIEW_REPOS="JSONbored/gittensory"`}
       </p>
       <p>
         If the install route changes, check the deployed <code>GITHUB_APP_SLUG</code> before
-        publishing setup copy. Self-hosted deployments use whatever slug you chose during setup; for
-        the shared managed-beta app the expected slug is <code>gittensory</code>.
+        publishing setup copy. Self-hosted deployments use whatever slug you chose during setup.
       </p>
 
       <p>
@@ -400,7 +371,7 @@ GITTENSORY_REVIEW_REPOS="JSONbored/gittensory"`}
       </p>
 
       <Callout variant="safety">
-        Gittensory's GitHub App never requests source push, never stores repository contents, and
+        LoopOver's GitHub App never requests source push, never stores repository contents, and
         never publishes wallet, hotkey, payout, trust, reward, or private scoring language.
       </Callout>
     </DocsPage>

--- a/apps/gittensory-ui/src/routes/docs.gittensory-commands.tsx
+++ b/apps/gittensory-ui/src/routes/docs.gittensory-commands.tsx
@@ -11,13 +11,13 @@ import {
 export const Route = createFileRoute("/docs/gittensory-commands")({
   head: () => ({
     meta: [
-      { title: "@gittensory command reference — Gittensory docs" },
+      { title: "@gittensory command reference — LoopOver docs" },
       {
         name: "description",
         content:
           "Every @gittensory PR and issue comment command: syntax, default authorization roles, and the hard boundary between auto-review and the one-shot gate.",
       },
-      { property: "og:title", content: "@gittensory command reference — Gittensory docs" },
+      { property: "og:title", content: "@gittensory command reference — LoopOver docs" },
       {
         property: "og:description",
         content:

--- a/apps/gittensory-ui/src/routes/docs.how-reviews-work.tsx
+++ b/apps/gittensory-ui/src/routes/docs.how-reviews-work.tsx
@@ -6,17 +6,17 @@ import { CodeBlock, Callout } from "@/components/site/primitives";
 export const Route = createFileRoute("/docs/how-reviews-work")({
   head: () => ({
     meta: [
-      { title: "How reviews work — Gittensory docs" },
+      { title: "How reviews work — LoopOver docs" },
       {
         name: "description",
         content:
-          "How gittensory reviews a pull request: the deterministic gate, the dual-AI review and consensus, the unified review comment, and the signals behind a verdict.",
+          "How LoopOver reviews a pull request: the deterministic gate, the dual-AI review and consensus, the unified review comment, and the signals behind a verdict.",
       },
-      { property: "og:title", content: "How reviews work — Gittensory docs" },
+      { property: "og:title", content: "How reviews work — LoopOver docs" },
       {
         property: "og:description",
         content:
-          "How gittensory reviews a pull request: the deterministic gate, the dual-AI review and consensus, the unified review comment, and the signals behind a verdict.",
+          "How LoopOver reviews a pull request: the deterministic gate, the dual-AI review and consensus, the unified review comment, and the signals behind a verdict.",
       },
       { property: "og:url", content: "/docs/how-reviews-work" },
     ],
@@ -30,11 +30,11 @@ function HowReviewsWork() {
     <DocsPage
       eyebrow="Reviews"
       title="How reviews work"
-      description="What gittensory does when a pull request opens — the gate, the dual-AI review and consensus, and the single comment that surfaces it."
+      description="What LoopOver does when a pull request opens — the gate, the dual-AI review and consensus, and the single comment that surfaces it."
     >
       <h2>The shape of a review</h2>
       <p>
-        When a pull request opens or updates, <strong>gittensory CI</strong> runs a review in two
+        When a pull request opens or updates, <strong>LoopOver CI</strong> runs a review in two
         layers and reports the result in one place:
       </p>
       <ol>

--- a/apps/gittensory-ui/src/routes/docs.index.tsx
+++ b/apps/gittensory-ui/src/routes/docs.index.tsx
@@ -7,17 +7,17 @@ import { DocsPage } from "@/components/site/docs-page";
 export const Route = createFileRoute("/docs/")({
   head: () => ({
     meta: [
-      { title: "Documentation — Gittensory" },
+      { title: "Documentation — LoopOver" },
       {
         name: "description",
         content:
-          "Start with the quickstart, set up your MCP client, and learn how Gittensory keeps maintainer surfaces quiet.",
+          "Start with the quickstart, set up your MCP client, and learn how LoopOver keeps maintainer surfaces quiet.",
       },
-      { property: "og:title", content: "Documentation — Gittensory" },
+      { property: "og:title", content: "Documentation — LoopOver" },
       {
         property: "og:description",
         content:
-          "Start with the quickstart, set up your MCP client, and learn how Gittensory keeps maintainer surfaces quiet.",
+          "Start with the quickstart, set up your MCP client, and learn how LoopOver keeps maintainer surfaces quiet.",
       },
       { property: "og:url", content: "/docs" },
     ],

--- a/apps/gittensory-ui/src/routes/docs.maintainer-install-trust.tsx
+++ b/apps/gittensory-ui/src/routes/docs.maintainer-install-trust.tsx
@@ -7,20 +7,20 @@ import { MAINTAINER_COMMAND_LIST, PUBLIC_COMMAND_LIST } from "@/lib/command-refe
 export const Route = createFileRoute("/docs/maintainer-install-trust")({
   head: () => ({
     meta: [
-      { title: "Maintainer install and trust guide — Gittensory docs" },
+      { title: "Maintainer install and trust guide — LoopOver docs" },
       {
         name: "description",
         content:
-          "Self-host and install a Gittensory GitHub App as a maintainer, verify trust boundaries, preview public output, and decide when GitHub App checks are safe to enable. Self-hosting is the recommended default path; the shared App is private managed-beta only.",
+          "Self-host and install a LoopOver GitHub App as a maintainer, verify trust boundaries, preview public output, and decide when GitHub App checks are safe to enable. Self-hosting is the only currently available path.",
       },
       {
         property: "og:title",
-        content: "Maintainer install and trust guide — Gittensory docs",
+        content: "Maintainer install and trust guide — LoopOver docs",
       },
       {
         property: "og:description",
         content:
-          "Self-host and install a Gittensory GitHub App as a maintainer, verify trust boundaries, preview public output, and decide when GitHub App checks are safe to enable. Self-hosting is the recommended default path; the shared App is private managed-beta only.",
+          "Self-host and install a LoopOver GitHub App as a maintainer, verify trust boundaries, preview public output, and decide when GitHub App checks are safe to enable. Self-hosting is the only currently available path.",
       },
       { property: "og:url", content: "/docs/maintainer-install-trust" },
     ],
@@ -34,29 +34,31 @@ function MaintainerInstallTrust() {
     <DocsPage
       eyebrow="Launch guide"
       title="Maintainer install and trust guide"
-      description="A maintainer-first checklist for self-hosting and installing a GitHub App, keeping public output safe, authorizing commands, using the browser extension, and rejecting weak Gittensory-driven PRs."
+      description="A maintainer-first checklist for self-hosting and installing a GitHub App, keeping public output safe, authorizing commands, using the browser extension, and rejecting weak LoopOver-driven PRs."
     >
       <Callout variant="safety" title="Trust posture">
-        Gittensory is advisory-first. It may help you review contribution readiness, but it does not
+        LoopOver is advisory-first. It may help you review contribution readiness, but it does not
         replace human maintainer judgment, expose private scoreability signals, or make reward,
         payout, wallet, hotkey, or trust-score claims in public surfaces.
       </Callout>
 
       <h2>Install the App</h2>
       <p>
-        <strong>Self-hosting is the recommended, default path.</strong> Start from{" "}
+        <strong>Self-hosting is the only currently available path.</strong> Start from{" "}
         <Link to="/docs/maintainer-self-hosting">self-hosting setup</Link> — the direct App's
         required permissions and events are covered in{" "}
-        <Link to="/docs/self-hosting-github-app">GitHub App and Orb</Link>, not the checklist below.
-        Either way, keep the first rollout narrow until the repo owner has verified permissions,
-        webhook delivery, and public copy.
+        <Link to="/docs/self-hosting-github-app">GitHub App and Orb</Link>. Keep the first rollout
+        narrow until the repo owner has verified permissions, webhook delivery, and public copy.
       </p>
-      <p>
-        The checklist below is for the shared <strong>private / managed-beta only</strong> App — see{" "}
-        <Link to="/docs/github-app">GitHub App configuration</Link> for the install flow.
-      </p>
+      <Callout variant="note" title="Shared, centrally hosted App: not currently available">
+        LoopOver previously ran a private managed-beta shared App with its own install checklist
+        below. That shared install path is currently paused while self-hosted Orb is the primary way
+        to run LoopOver — a new centrally hosted offering is planned for the future. The checklist
+        below reflects the shared App's permission set and is kept for when that offering returns;
+        use the self-hosting checklist above for a self-hosted install today.
+      </Callout>
       <ol>
-        <li>Install Gittensory on one test repository or a selected repository set.</li>
+        <li>Install LoopOver on one test repository or a selected repository set.</li>
         <li>
           Approve <code>Metadata: read</code>, <code>Pull requests: read</code>, and{" "}
           <code>Issues: write</code>. Add <code>Checks: write</code> only when Context or
@@ -73,7 +75,7 @@ function MaintainerInstallTrust() {
       </ol>
       <Callout variant="note">
         A self-hosted direct App needs <code>Pull requests: write</code> (not read) and{" "}
-        <code>Checks: write</code> is mandatory, not optional — this checklist's permissions are
+        <code>Checks: write</code> is mandatory, not optional — the numbered checklist above is
         scoped to the shared managed-beta App only.
       </Callout>
       <CodeBlock
@@ -219,12 +221,12 @@ API unavailable or stale data
       </p>
       <p>
         If the repo enables <strong>Gittensory Orb Review Agent</strong>, document which blockers
-        are enforced and why. Otherwise, treat Gittensory output as reviewer context only.
+        are enforced and why. Otherwise, treat LoopOver output as reviewer context only.
       </p>
 
-      <h2>Reject weak Gittensory-driven PRs</h2>
+      <h2>Reject weak LoopOver-driven PRs</h2>
       <p>
-        Maintainers should request changes or close PRs that misuse Gittensory output. The tool is a
+        Maintainers should request changes or close PRs that misuse LoopOver output. The tool is a
         contribution operating layer, not a guarantee that work deserves merge.
       </p>
       <ul>

--- a/apps/gittensory-ui/src/routes/docs.maintainer-self-hosting.tsx
+++ b/apps/gittensory-ui/src/routes/docs.maintainer-self-hosting.tsx
@@ -6,17 +6,17 @@ import { Callout, FeatureRow } from "@/components/site/primitives";
 export const Route = createFileRoute("/docs/maintainer-self-hosting")({
   head: () => ({
     meta: [
-      { title: "Self-hosted reviews — Gittensory docs" },
+      { title: "Self-hosted reviews — LoopOver docs" },
       {
         name: "description",
         content:
-          "A maintainer guide to self-hosting the Gittensory review service, with dedicated pages for setup, configuration, AI, REES, RAG, operations, releases, security, and troubleshooting.",
+          "A maintainer guide to self-hosting the LoopOver review service, with dedicated pages for setup, configuration, AI, REES, RAG, operations, releases, security, and troubleshooting.",
       },
-      { property: "og:title", content: "Self-hosted reviews — Gittensory docs" },
+      { property: "og:title", content: "Self-hosted reviews — LoopOver docs" },
       {
         property: "og:description",
         content:
-          "A maintainer guide to self-hosting the Gittensory review service, with dedicated pages for setup, configuration, AI, REES, RAG, operations, releases, security, and troubleshooting.",
+          "A maintainer guide to self-hosting the LoopOver review service, with dedicated pages for setup, configuration, AI, REES, RAG, operations, releases, security, and troubleshooting.",
       },
       { property: "og:url", content: "/docs/maintainer-self-hosting" },
     ],
@@ -113,7 +113,7 @@ function MaintainerSelfHosting() {
     <DocsPage
       eyebrow="Maintainers"
       title="Self-hosted reviews"
-      description="Run the Gittensory review service on your own infrastructure, with your own data store, GitHub App, AI provider, enrichment service, observability, and private repo policy."
+      description="Run the LoopOver review service on your own infrastructure, with your own data store, GitHub App, AI provider, enrichment service, observability, and private repo policy."
     >
       <Callout variant="safety" title="Self-hosting is a maintainer surface">
         Treat the self-host stack like production infrastructure. Keep secrets out of images and
@@ -279,15 +279,22 @@ function MaintainerSelfHosting() {
       </p>
 
       <h2>Moving a repo between hosted and self-host</h2>
-      <p>
+      <Callout variant="note" title="Hosted is currently paused">
         &quot;Hosted&quot; here means the private managed-beta shared <code>gittensory</code> App
-        described in <Link to="/docs/github-app">GitHub App configuration</Link> — a repo installed
-        there is reviewed by gittensory&apos;s own cloud Worker and its own database.
-        &quot;Self-host&quot; means your own container from{" "}
+        described in <Link to="/docs/github-app">GitHub App configuration</Link> — it previously
+        accepted new installs and is currently paused while self-hosted Orb is the primary way to
+        run LoopOver. A new centrally hosted offering is planned for the future. "Switching from
+        hosted to self-host" below still applies to any repo already installed on the hosted App;
+        "switching back to hosted" isn't possible until hosted installs reopen, but the steps are
+        kept here for when they do.
+      </Callout>
+      <p>
+        A repo installed on the hosted App is reviewed by LoopOver&apos;s own cloud Worker and its
+        own database. &quot;Self-host&quot; means your own container from{" "}
         <Link to="/docs/self-hosting-quickstart">Quickstart</Link>, with its own GitHub App (or
         brokered Orb enrollment) and its own data store. There is{" "}
-        <strong>no automated migration path between the two</strong> today — moving a repo is a
-        manual App swap plus re-creating whatever settings you had, not a toggle.
+        <strong>no automated migration path between the two</strong> — moving a repo is a manual App
+        swap plus re-creating whatever settings you had, not a toggle.
       </p>
 
       <h3>Switching a repo from hosted to self-host</h3>
@@ -301,7 +308,7 @@ function MaintainerSelfHosting() {
           Create <strong>your own</strong> GitHub App via the self-host{" "}
           <Link to="/docs/self-hosting-github-app">setup wizard</Link> (or brokered Orb enrollment).
           You cannot repoint the existing shared hosted App at your self-host container — the shared
-          App&apos;s credentials belong to gittensory&apos;s cloud Worker, and{" "}
+          App&apos;s credentials belong to LoopOver&apos;s cloud Worker, and{" "}
           <code>src/selfhost/setup-wizard.ts</code> always mints a distinct App tied to your
           instance&apos;s own webhook URL.
         </li>
@@ -319,7 +326,7 @@ function MaintainerSelfHosting() {
 
       <h3>What does not carry over automatically</h3>
       <p>
-        Hosted-side settings live in gittensory&apos;s own cloud database, keyed by repo full name —{" "}
+        Hosted-side settings live in LoopOver&apos;s own cloud database, keyed by repo full name —{" "}
         <code>resolveRepositorySettings</code> (<code>src/settings/repository-settings.ts</code>)
         reads them from <code>env.DB</code>, which is a completely different database instance than
         your self-host container&apos;s. A self-host instance has no access to, and no import path
@@ -339,7 +346,7 @@ function MaintainerSelfHosting() {
         App starts reviewing, with nothing to re-enter.
       </p>
       <Callout variant="warn" title="Review history does not move">
-        Past review comments, check-run history, and any per-PR state gittensory recorded while the
+        Past review comments, check-run history, and any per-PR state LoopOver recorded while the
         hosted App was active stay wherever they were created — GitHub comments and check runs are
         never deleted or copied by an uninstall/install, but nothing in the self-host database is
         backfilled from the hosted side. A migrated repo starts its self-host review history from
@@ -356,8 +363,9 @@ function MaintainerSelfHosting() {
 
       <h3>Switching a repo from self-host back to hosted</h3>
       <p>
-        The reverse migration has the same shape and the same gap: uninstall your self-host App from
-        the repo, install the shared hosted App (if you have managed-beta access — see{" "}
+        Hosted installs are currently paused — this direction isn't possible until the shared App
+        reopens (see the callout above). Once it does, the reverse migration has the same shape and
+        the same gap: uninstall your self-host App from the repo, install the shared hosted App (see{" "}
         <Link to="/docs/github-app">GitHub App configuration</Link>), and re-create any DB-backed
         settings on the hosted side. <code>.gittensory.yml</code> again carries over for free since
         it travels with the repo; nothing else does. Your self-host instance&apos;s data volumes are

--- a/apps/gittensory-ui/src/routes/docs.maintainer-workflow.tsx
+++ b/apps/gittensory-ui/src/routes/docs.maintainer-workflow.tsx
@@ -8,17 +8,17 @@ import { MAINTAINER_COMMAND_LIST, PUBLIC_COMMAND_LIST } from "@/lib/command-refe
 export const Route = createFileRoute("/docs/maintainer-workflow")({
   head: () => ({
     meta: [
-      { title: "Maintainer workflow — Gittensory docs" },
+      { title: "Maintainer workflow — LoopOver docs" },
       {
         name: "description",
         content:
-          "How to use Gittensory in a repo: confirmed-miner labels, sticky sanitized comments, on-demand @gittensory commands.",
+          "How to use LoopOver in a repo: confirmed-miner labels, sticky sanitized comments, on-demand @gittensory commands.",
       },
-      { property: "og:title", content: "Maintainer workflow — Gittensory docs" },
+      { property: "og:title", content: "Maintainer workflow — LoopOver docs" },
       {
         property: "og:description",
         content:
-          "How to use Gittensory in a repo: confirmed-miner labels, sticky sanitized comments, on-demand @gittensory commands.",
+          "How to use LoopOver in a repo: confirmed-miner labels, sticky sanitized comments, on-demand @gittensory commands.",
       },
       { property: "og:url", content: "/docs/maintainer-workflow" },
     ],

--- a/apps/gittensory-ui/src/routes/docs.mcp-clients.tsx
+++ b/apps/gittensory-ui/src/routes/docs.mcp-clients.tsx
@@ -6,17 +6,17 @@ import { CodeBlock, Callout } from "@/components/site/primitives";
 export const Route = createFileRoute("/docs/mcp-clients")({
   head: () => ({
     meta: [
-      { title: "MCP client setup — Gittensory docs" },
+      { title: "MCP client setup — LoopOver docs" },
       {
         name: "description",
         content:
-          "Wire the Gittensory MCP into Codex, Claude Desktop, Cursor, or any MCP-aware client over stdio or remote.",
+          "Wire the LoopOver MCP into Codex, Claude Desktop, Cursor, or any MCP-aware client over stdio or remote.",
       },
-      { property: "og:title", content: "MCP client setup — Gittensory docs" },
+      { property: "og:title", content: "MCP client setup — LoopOver docs" },
       {
         property: "og:description",
         content:
-          "Wire the Gittensory MCP into Codex, Claude Desktop, Cursor, or any MCP-aware client over stdio or remote.",
+          "Wire the LoopOver MCP into Codex, Claude Desktop, Cursor, or any MCP-aware client over stdio or remote.",
       },
       { property: "og:url", content: "/docs/mcp-clients" },
     ],
@@ -30,7 +30,7 @@ function McpClients() {
     <DocsPage
       eyebrow="Get started"
       title="MCP client setup"
-      description="Configure your coding agent to talk to the Gittensory MCP. Pick stdio for local agents, remote for cloud agents."
+      description="Configure your coding agent to talk to the LoopOver MCP. Pick stdio for local agents, remote for cloud agents."
     >
       <h2>Generate config</h2>
       <p>These commands print config only. They do not mutate your local client files.</p>

--- a/apps/gittensory-ui/src/routes/docs.miner-quickstart.tsx
+++ b/apps/gittensory-ui/src/routes/docs.miner-quickstart.tsx
@@ -6,13 +6,13 @@ import { CodeBlock, Callout } from "@/components/site/primitives";
 export const Route = createFileRoute("/docs/miner-quickstart")({
   head: () => ({
     meta: [
-      { title: "Miner quickstart by lane — Gittensory docs" },
+      { title: "Miner quickstart by lane — LoopOver docs" },
       {
         name: "description",
         content:
           "Pick a contribution lane, install @jsonbored/gittensory-mcp, sign in, and run plan → preflight → packet. Lane-by-lane commands with JSON output and redaction notes.",
       },
-      { property: "og:title", content: "Miner quickstart by lane — Gittensory docs" },
+      { property: "og:title", content: "Miner quickstart by lane — LoopOver docs" },
       {
         property: "og:description",
         content:
@@ -33,19 +33,19 @@ function MinerQuickstart() {
       description="Choose how you want to contribute, then follow the same loop — install, sign in, doctor, plan, preflight, packet — with the flags that fit your lane. About five minutes per lane."
     >
       <p>
-        Gittensory is copilot-only. It ranks and explains your options and drafts public-safe PR
+        LoopOver is copilot-only. It ranks and explains your options and drafts public-safe PR
         packets. It does not edit code, open PRs, or post comments for you, it makes no earnings
         promises, and it never predicts a public number. Every command below also accepts{" "}
         <code>--json</code> for machine-readable output, and your source never leaves your machine —
-        only branch metadata (changed file paths, commit messages) is sent to authenticated
-        Gittensory MCP/API responses.
+        only branch metadata (changed file paths, commit messages) is sent to authenticated LoopOver
+        MCP/API responses.
       </p>
 
       <h2>0. Install and sign in (every lane)</h2>
       <p>
         The MCP is published as <code>@jsonbored/gittensory-mcp</code>. Run it with <code>npx</code>{" "}
-        or install it globally, then authenticate with GitHub Device Flow — Gittensory never asks
-        for a Personal Access Token.
+        or install it globally, then authenticate with GitHub Device Flow — LoopOver never asks for
+        a Personal Access Token.
       </p>
       <CodeBlock
         code={`# install (one-off, or global)
@@ -61,7 +61,7 @@ gittensory-mcp status --json
 gittensory-mcp doctor --json`}
       />
       <Callout variant="safety">
-        Session tokens are <strong>Gittensory tokens backed by GitHub identity</strong>, not your
+        Session tokens are <strong>LoopOver tokens backed by GitHub identity</strong>, not your
         GitHub PATs. Source upload stays disabled (<code>GITTENSORY_UPLOAD_SOURCE=false</code>) and
         local absolute paths are redacted from anything that leaves your machine. Log out anytime
         with <code>gittensory-mcp logout</code>.

--- a/apps/gittensory-ui/src/routes/docs.miner-workflow.tsx
+++ b/apps/gittensory-ui/src/routes/docs.miner-workflow.tsx
@@ -7,12 +7,12 @@ import { WorkflowMirror, type MirroredStep } from "@/components/site/workflow-mi
 export const Route = createFileRoute("/docs/miner-workflow")({
   head: () => ({
     meta: [
-      { title: "Miner workflow — Gittensory docs" },
+      { title: "Miner workflow — LoopOver docs" },
       {
         name: "description",
         content: "Plan → analyze → preflight → packet. The four-step miner loop with the MCP CLI.",
       },
-      { property: "og:title", content: "Miner workflow — Gittensory docs" },
+      { property: "og:title", content: "Miner workflow — LoopOver docs" },
       {
         property: "og:description",
         content: "Plan → analyze → preflight → packet. The four-step miner loop with the MCP CLI.",

--- a/apps/gittensory-ui/src/routes/docs.owner-checklist.tsx
+++ b/apps/gittensory-ui/src/routes/docs.owner-checklist.tsx
@@ -6,13 +6,13 @@ import { CodeBlock, Callout } from "@/components/site/primitives";
 export const Route = createFileRoute("/docs/owner-checklist")({
   head: () => ({
     meta: [
-      { title: "Repo-owner onboarding checklist — Gittensory docs" },
+      { title: "Repo-owner onboarding checklist — LoopOver docs" },
       {
         name: "description",
         content:
           "A pre-flight checklist for repo owners: registration, config quality, labels, issue quality, contribution lanes, validation, maintainer capacity, and the public/private boundary — with honest tradeoffs.",
       },
-      { property: "og:title", content: "Repo-owner onboarding checklist — Gittensory docs" },
+      { property: "og:title", content: "Repo-owner onboarding checklist — LoopOver docs" },
       {
         property: "og:description",
         content:
@@ -30,10 +30,10 @@ function OwnerChecklist() {
     <DocsPage
       eyebrow="Repo owners"
       title="Repo-owner onboarding checklist"
-      description="Work through this before you invite Gittensory contribution traffic. It mirrors the readiness report exactly, so each item is something the platform actually checks — and each comes with the honest tradeoff you are opting into."
+      description="Work through this before you invite LoopOver contribution traffic. It mirrors the readiness report exactly, so each item is something the platform actually checks — and each comes with the honest tradeoff you are opting into."
     >
       <p>
-        Gittensory is <strong>quiet by default</strong>: it installs without posting comments or
+        LoopOver is <strong>quiet by default</strong>: it installs without posting comments or
         adding labels until you turn those surfaces on. This checklist is what to confirm first.
         Everything owner-only runs through the private API or the{" "}
         <Link to="/app/owner">owner console</Link>; readiness is reported as bands and statuses,
@@ -56,7 +56,7 @@ GET /v1/repos/:owner/:repo/gittensor-config-recommendation`}
 
       <h2>1. Repository registration</h2>
       <p>
-        Confirm the repo is in the current Gittensory registry. If it is not, that is the first{" "}
+        Confirm the repo is in the current LoopOver registry. If it is not, that is the first{" "}
         <code>blocker</code> in the readiness report and nothing else applies yet. Register and
         review from the <Link to="/app/owner">owner console</Link>.
       </p>

--- a/apps/gittensory-ui/src/routes/docs.privacy-security.tsx
+++ b/apps/gittensory-ui/src/routes/docs.privacy-security.tsx
@@ -6,17 +6,17 @@ import { CodeBlock, Callout } from "@/components/site/primitives";
 export const Route = createFileRoute("/docs/privacy-security")({
   head: () => ({
     meta: [
-      { title: "Privacy & security — Gittensory docs" },
+      { title: "Privacy & security — LoopOver docs" },
       {
         name: "description",
         content:
-          "Gittensory's privacy posture: metadata-only MCP, no PATs, no wallet, no source upload, sanitized public output.",
+          "LoopOver's privacy posture: metadata-only MCP, no PATs, no wallet, no source upload, sanitized public output.",
       },
-      { property: "og:title", content: "Privacy & security — Gittensory docs" },
+      { property: "og:title", content: "Privacy & security — LoopOver docs" },
       {
         property: "og:description",
         content:
-          "Gittensory's privacy posture: metadata-only MCP, no PATs, no wallet, no source upload, sanitized public output.",
+          "LoopOver's privacy posture: metadata-only MCP, no PATs, no wallet, no source upload, sanitized public output.",
       },
       { property: "og:url", content: "/docs/privacy-security" },
     ],
@@ -46,7 +46,7 @@ function PrivacySecurity() {
 
       <h2>Open algorithm, private tuning</h2>
       <p>
-        Gittensory's review engine is built so the{" "}
+        LoopOver's review engine is built so the{" "}
         <strong>logic is public but the dial settings are not</strong>. The deterministic gate, the
         scoring signals, the slop detector, the grounding/RAG context builders, and the comment
         renderer all live in the open source tree — anyone can read exactly how a verdict is

--- a/apps/gittensory-ui/src/routes/docs.quickstart.tsx
+++ b/apps/gittensory-ui/src/routes/docs.quickstart.tsx
@@ -6,13 +6,13 @@ import { CodeBlock, Callout } from "@/components/site/primitives";
 export const Route = createFileRoute("/docs/quickstart")({
   head: () => ({
     meta: [
-      { title: "Quickstart — Gittensory docs" },
+      { title: "Quickstart — LoopOver docs" },
       {
         name: "description",
         content:
           "Install @jsonbored/gittensory-mcp, sign in with GitHub Device Flow, and analyze your branch in two commands.",
       },
-      { property: "og:title", content: "Quickstart — Gittensory docs" },
+      { property: "og:title", content: "Quickstart — LoopOver docs" },
       {
         property: "og:description",
         content:
@@ -47,8 +47,8 @@ npm i -g @jsonbored/gittensory-mcp@latest`}
 
       <h2>2. Sign in (GitHub Device Flow)</h2>
       <p>
-        Gittensory never asks for a Personal Access Token. The CLI walks you through GitHub's Device
-        Flow and exchanges the result for a Gittensory session token.
+        LoopOver never asks for a Personal Access Token. The CLI walks you through GitHub's Device
+        Flow and exchanges the result for a LoopOver session token.
       </p>
       <CodeBlock
         code={`gittensory-mcp login
@@ -56,7 +56,7 @@ gittensory-mcp whoami
 gittensory-mcp status`}
       />
       <Callout variant="safety">
-        Session tokens are <strong>Gittensory tokens backed by GitHub identity</strong>, not your
+        Session tokens are <strong>LoopOver tokens backed by GitHub identity</strong>, not your
         GitHub PATs. You can log out anytime with <code>gittensory-mcp logout</code>.
       </Callout>
 

--- a/apps/gittensory-ui/src/routes/docs.scoreability.tsx
+++ b/apps/gittensory-ui/src/routes/docs.scoreability.tsx
@@ -6,13 +6,13 @@ import { Callout, CodeBlock } from "@/components/site/primitives";
 export const Route = createFileRoute("/docs/scoreability")({
   head: () => ({
     meta: [
-      { title: "Scoreability — Gittensory docs" },
+      { title: "Scoreability — LoopOver docs" },
       {
         name: "description",
         content:
           "Scoreability scenarios explained: current gated, underlying potential, clean-gate, after-pending-merges, linked-issue-fixed, best-reasonable. Estimates only.",
       },
-      { property: "og:title", content: "Scoreability — Gittensory docs" },
+      { property: "og:title", content: "Scoreability — LoopOver docs" },
       {
         property: "og:description",
         content:
@@ -30,7 +30,7 @@ function Scoreability() {
     <DocsPage
       eyebrow="Core concepts"
       title="Scoreability"
-      description="Gittensory projects how scoreable your branch is under several scenarios. These are estimates, never guarantees."
+      description="LoopOver projects how scoreable your branch is under several scenarios. These are estimates, never guarantees."
     >
       <h2>The seven scenarios</h2>
       <p>

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-ai-providers.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-ai-providers.tsx
@@ -6,17 +6,17 @@ import { Callout, CodeBlock, FeatureRow } from "@/components/site/primitives";
 export const Route = createFileRoute("/docs/self-hosting-ai-providers")({
   head: () => ({
     meta: [
-      { title: "Self-host AI providers — Gittensory docs" },
+      { title: "Self-host AI providers — LoopOver docs" },
       {
         name: "description",
         content:
-          "Configure AI providers for self-hosted Gittensory reviews, including Anthropic, OpenAI-compatible endpoints, Ollama, Claude Code, and Codex.",
+          "Configure AI providers for self-hosted LoopOver reviews, including Anthropic, OpenAI-compatible endpoints, Ollama, Claude Code, and Codex.",
       },
-      { property: "og:title", content: "Self-host AI providers — Gittensory docs" },
+      { property: "og:title", content: "Self-host AI providers — LoopOver docs" },
       {
         property: "og:description",
         content:
-          "Configure AI providers for self-hosted Gittensory reviews, including Anthropic, OpenAI-compatible endpoints, Ollama, Claude Code, and Codex.",
+          "Configure AI providers for self-hosted LoopOver reviews, including Anthropic, OpenAI-compatible endpoints, Ollama, Claude Code, and Codex.",
       },
       { property: "og:url", content: "/docs/self-hosting-ai-providers" },
     ],

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-backup-scaling.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-backup-scaling.tsx
@@ -6,17 +6,17 @@ import { Callout, CodeBlock, FeatureRow } from "@/components/site/primitives";
 export const Route = createFileRoute("/docs/self-hosting-backup-scaling")({
   head: () => ({
     meta: [
-      { title: "Self-host backup and scaling — Gittensory docs" },
+      { title: "Self-host backup and scaling — LoopOver docs" },
       {
         name: "description",
         content:
-          "Back up and scale the self-hosted Gittensory review service with SQLite, Litestream, Postgres, Redis, and restore checks.",
+          "Back up and scale the self-hosted LoopOver review service with SQLite, Litestream, Postgres, Redis, and restore checks.",
       },
-      { property: "og:title", content: "Self-host backup and scaling — Gittensory docs" },
+      { property: "og:title", content: "Self-host backup and scaling — LoopOver docs" },
       {
         property: "og:description",
         content:
-          "Back up and scale the self-hosted Gittensory review service with SQLite, Litestream, Postgres, Redis, and restore checks.",
+          "Back up and scale the self-hosted LoopOver review service with SQLite, Litestream, Postgres, Redis, and restore checks.",
       },
       { property: "og:url", content: "/docs/self-hosting-backup-scaling" },
     ],

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-configuration.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-configuration.tsx
@@ -7,13 +7,13 @@ import { SELFHOST_ENV_REFERENCE_MARKDOWN } from "@/lib/selfhost-env-reference";
 export const Route = createFileRoute("/docs/self-hosting-configuration")({
   head: () => ({
     meta: [
-      { title: "Self-host configuration — Gittensory docs" },
+      { title: "Self-host configuration — LoopOver docs" },
       {
         name: "description",
         content:
           "Configure the self-host review service: env vars, private repo config, feature flags, review modes, and safe defaults.",
       },
-      { property: "og:title", content: "Self-host configuration — Gittensory docs" },
+      { property: "og:title", content: "Self-host configuration — LoopOver docs" },
       {
         property: "og:description",
         content:
@@ -533,17 +533,17 @@ features:
       />
       <Callout variant="warn" title="Remove the branch-protection requirement first">
         Before switching to <code>disabled</code>, remove <code>Gittensory Orb Review Agent</code>{" "}
-        from this repo&apos;s branch-protection or ruleset required-status-checks list — Gittensory
+        from this repo&apos;s branch-protection or ruleset required-status-checks list — LoopOver
         cannot do this on your behalf, and leaving it required with nothing to satisfy it means
         GitHub shows a pending status forever. Keep your real CI/Codecov/security checks required;
-        this setting only ever affects Gittensory&apos;s own check-run.
+        this setting only ever affects LoopOver&apos;s own check-run.
       </Callout>
       <p>
         For a repo that has never been configured, the default is <code>disabled</code>; an
         already-configured repo keeps its current effective behavior. Self-hosters running
         high-volume autonomous review should prefer <code>visible</code> or <code>disabled</code>{" "}
-        over <code>required</code> — Gittensory&apos;s own merge/close decisions never depend on
-        this check either way.
+        over <code>required</code> — LoopOver&apos;s own merge/close decisions never depend on this
+        check either way.
       </p>
 
       <h3>Other gate-only fields</h3>
@@ -551,7 +551,7 @@ features:
         <li>
           <code>gate.cla</code> — sub-object for the CLA gate (<code>gate.claMode</code>, documented
           on <Link to="/docs/tuning">Tuning your reviews</Link>): <code>consentPhrase</code> (a
-          case-insensitive substring gittensory looks for in the PR description),{" "}
+          case-insensitive substring LoopOver looks for in the PR description),{" "}
           <code>checkRunName</code> (an existing CLA-bot check-run name that also satisfies
           consent), and <code>checkRunAppSlug</code> (the trusted App slug required to have produced
           that check-run, so a contributor-controlled same-name check can&apos;t satisfy a blocking
@@ -666,8 +666,8 @@ features:
 
       <h3>contentLane</h3>
       <p>
-        Lets a self-hosted maintainer point Gittensory at their own structured registry (a
-        subnet/plugin/package catalog, for example) without a Gittensory code change — reviewing
+        Lets a self-hosted maintainer point LoopOver at their own structured registry (a
+        subnet/plugin/package catalog, for example) without a LoopOver code change — reviewing
         additions to a data file the same way it reviews code. Unconfigured by default; uncomment
         and set at least <code>entryFileGlob</code> and <code>collectionField</code> (both required
         — the whole block is ignored with a warning if either is missing).
@@ -687,9 +687,9 @@ features:
 
       <h3>repoDocGeneration</h3>
       <p>
-        Lets gittensory open a pull request that refreshes this repo&apos;s own{" "}
-        <code>AGENTS.md</code>/<code>CLAUDE.md</code> (and, additively, a skill file) on a schedule
-        — never a direct commit. Disabled by default: an unconfigured repo, or an explicit{" "}
+        Lets LoopOver open a pull request that refreshes this repo&apos;s own <code>AGENTS.md</code>
+        /<code>CLAUDE.md</code> (and, additively, a skill file) on a schedule — never a direct
+        commit. Disabled by default: an unconfigured repo, or an explicit{" "}
         <code>enabled: false</code>, means no repo-doc refresh ever runs for it.
       </p>
       <CodeBlock

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-docs-audit.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-docs-audit.tsx
@@ -12,13 +12,13 @@ import {
 export const Route = createFileRoute("/docs/self-hosting-docs-audit")({
   head: () => ({
     meta: [
-      { title: "Self-host docs accuracy audit — Gittensory docs" },
+      { title: "Self-host docs accuracy audit — LoopOver docs" },
       {
         name: "description",
         content:
           "Checklist mapping self-host website docs to runtime sources of truth — compose defaults, env vars, releases, observability, backup, and drift guards.",
       },
-      { property: "og:title", content: "Self-host docs accuracy audit — Gittensory docs" },
+      { property: "og:title", content: "Self-host docs accuracy audit — LoopOver docs" },
       {
         property: "og:description",
         content:

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-github-app.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-github-app.tsx
@@ -6,17 +6,17 @@ import { Callout, CodeBlock, FeatureRow } from "@/components/site/primitives";
 export const Route = createFileRoute("/docs/self-hosting-github-app")({
   head: () => ({
     meta: [
-      { title: "Self-host GitHub App and Orb — Gittensory docs" },
+      { title: "Self-host GitHub App and Orb — LoopOver docs" },
       {
         name: "description",
         content:
-          "Connect a self-hosted Gittensory review service to GitHub with your own direct GitHub App (the default, recommended path) or private managed-beta brokered Orb enrollment.",
+          "Connect a self-hosted LoopOver review service to GitHub with your own direct GitHub App (the default, recommended path) or private managed-beta brokered Orb enrollment.",
       },
-      { property: "og:title", content: "Self-host GitHub App and Orb — Gittensory docs" },
+      { property: "og:title", content: "Self-host GitHub App and Orb — LoopOver docs" },
       {
         property: "og:description",
         content:
-          "Connect a self-hosted Gittensory review service to GitHub with your own direct GitHub App (the default, recommended path) or private managed-beta brokered Orb enrollment.",
+          "Connect a self-hosted LoopOver review service to GitHub with your own direct GitHub App (the default, recommended path) or private managed-beta brokered Orb enrollment.",
       },
       { property: "og:url", content: "/docs/self-hosting-github-app" },
     ],
@@ -38,7 +38,7 @@ function SelfHostingGithubApp() {
           {
             title: "Direct GitHub App (recommended default)",
             description:
-              "Your self-host stores its own App id, slug, private key, and webhook secret, and mints installation tokens directly. No shared quota, no dependency on gittensory's own infrastructure to process a review.",
+              "Your self-host stores its own App id, slug, private key, and webhook secret, and mints installation tokens directly. No shared quota, no dependency on LoopOver's own infrastructure to process a review.",
           },
           {
             title: "Brokered Orb (private/managed-beta only)",
@@ -48,10 +48,10 @@ function SelfHostingGithubApp() {
         ]}
       />
       <Callout variant="safety">
-        Direct App mode is the public default: it costs gittensory nothing to support and can't
-        overrun a shared rate-limit budget. Brokered mode routes every token mint through
-        gittensory's own infrastructure and GitHub API quota — every external brokered install is
-        gittensory's rate-limit and reliability problem, not just the operator's, so it stays
+        Direct App mode is the public default: it costs LoopOver nothing to support and can't
+        overrun a shared rate-limit budget. Brokered mode routes every token mint through LoopOver's
+        own infrastructure and GitHub API quota — every external brokered install is LoopOver's
+        rate-limit and reliability problem, not just the operator's, so it stays
         private/managed-beta until the safeguards below are in place.
       </Callout>
 
@@ -172,7 +172,7 @@ GITHUB_WEBHOOK_SECRET=<same-secret-configured-on-the-app>`}
         These are two independent things people conflate because they're both "Orb": anonymized
         fleet-calibration <strong>telemetry export</strong> (enabled by default, works in either
         connection mode) and <strong>token brokerage</strong> (optional, private/managed-beta only,
-        lets your self-host get installation tokens from gittensory instead of holding its own App
+        lets your self-host get installation tokens from LoopOver instead of holding its own App
         key). Choosing Direct App mode does not opt you out of telemetry, and it's what makes{" "}
         <Link to="/">the homepage counters</Link> and cross-fleet gate calibration reflect direct
         installs, not just brokered ones.
@@ -187,7 +187,7 @@ GITHUB_WEBHOOK_SECRET=<same-secret-configured-on-the-app>`}
           {
             title: "What's never exported",
             description:
-              "Repo/owner/PR names, commit SHAs, source code, diffs, comments, or logins. Repo/PR identifiers are HMAC-anonymized by default with a per-instance secret gittensory's own collector never holds.",
+              "Repo/owner/PR names, commit SHAs, source code, diffs, comments, or logins. Repo/PR identifiers are HMAC-anonymized by default with a per-instance secret LoopOver's own collector never holds.",
           },
           {
             title: "Disabling it",
@@ -200,16 +200,16 @@ GITHUB_WEBHOOK_SECRET=<same-secret-configured-on-the-app>`}
         Repo/PR identifiers are HMAC-anonymized by <strong>default</strong> (
         <code>ORB_ANONYMIZE=true</code>), not unconditionally — an operator can set{" "}
         <code>ORB_ANONYMIZE=false</code> to export raw repo/PR names instead. There's no scenario
-        where gittensory's own hosted collector needs raw names; the toggle exists for an operator
+        where LoopOver's own hosted collector needs raw names; the toggle exists for an operator
         running their <strong>own</strong> collector (see <code>ORB_COLLECTOR_URL</code> below) who
         wants readable identifiers in their own infrastructure. Leave this at the default unless you
         control the collector end.
       </Callout>
       <p>
-        <code>ORB_COLLECTOR_URL</code> overrides the export endpoint — default gittensory's hosted
+        <code>ORB_COLLECTOR_URL</code> overrides the export endpoint — default LoopOver's hosted
         collector, or point it at your own private collector if you're aggregating telemetry
-        yourself instead of sending it to gittensory. <code>ORB_COLLECTOR_TOKEN</code> is the bearer
-        credential for that private collector; leave it unset when using gittensory's own hosted
+        yourself instead of sending it to LoopOver. <code>ORB_COLLECTOR_TOKEN</code> is the bearer
+        credential for that private collector; leave it unset when using LoopOver's own hosted
         collector, which accepts unauthenticated, rate-limited, aggregate-only exports.
       </p>
 
@@ -264,14 +264,14 @@ ORB_RELAY_MODE=pull  # or omit for push (the default) -- see "Choosing a relay m
       <Callout variant="warn" title="Brokered mode operational risks">
         Before enabling this for anyone outside a controlled managed-beta cohort, weigh: (1){" "}
         <strong>rate-limit blast radius</strong> — every brokered install's GitHub API traffic draws
-        from token pools gittensory manages, so one misbehaving or high-volume install can degrade
+        from token pools LoopOver manages, so one misbehaving or high-volume install can degrade
         every other brokered install; (2) <strong>quota management</strong> — there is no automatic
         per-install cap on how much of that shared budget one enrollment can consume; (3){" "}
-        <strong>support burden</strong> — a broken brokered install looks like a gittensory outage
-        to its operator, not a self-host misconfiguration, and lands as a support request on
-        gittensory directly; (4) <strong>abuse/misconfiguration risk</strong> — an enrollment secret
-        that leaks or a misconfigured relay can mint tokens or receive webhook traffic for repos the
-        intended operator doesn't control.
+        <strong>support burden</strong> — a broken brokered install looks like a LoopOver outage to
+        its operator, not a self-host misconfiguration, and lands as a support request on LoopOver
+        directly; (4) <strong>abuse/misconfiguration risk</strong> — an enrollment secret that leaks
+        or a misconfigured relay can mint tokens or receive webhook traffic for repos the intended
+        operator doesn't control.
       </Callout>
 
       <h2>Minimum broker safeguards before a public rollout</h2>

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-operations.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-operations.tsx
@@ -6,17 +6,17 @@ import { Callout, CodeBlock, FeatureRow } from "@/components/site/primitives";
 export const Route = createFileRoute("/docs/self-hosting-operations")({
   head: () => ({
     meta: [
-      { title: "Self-host operations — Gittensory docs" },
+      { title: "Self-host operations — LoopOver docs" },
       {
         name: "description",
         content:
-          "Operate the self-hosted Gittensory review service: readiness, metrics, logs, dashboards, jobs, queues, routine checks, safe updates/rollback, and clean uninstall/decommissioning.",
+          "Operate the self-hosted LoopOver review service: readiness, metrics, logs, dashboards, jobs, queues, routine checks, safe updates/rollback, and clean uninstall/decommissioning.",
       },
-      { property: "og:title", content: "Self-host operations — Gittensory docs" },
+      { property: "og:title", content: "Self-host operations — LoopOver docs" },
       {
         property: "og:description",
         content:
-          "Operate the self-hosted Gittensory review service: readiness, metrics, logs, dashboards, jobs, queues, routine checks, safe updates/rollback, and clean uninstall/decommissioning.",
+          "Operate the self-hosted LoopOver review service: readiness, metrics, logs, dashboards, jobs, queues, routine checks, safe updates/rollback, and clean uninstall/decommissioning.",
       },
       { property: "og:url", content: "/docs/self-hosting-operations" },
     ],
@@ -1143,7 +1143,7 @@ docker inspect --format '{{.Config.Image}}' "$(docker compose ps -q gittensory)"
         <strong>no self-service revocation endpoint today</strong> — the &quot;Minimum broker
         safeguards&quot; checklist on that page lists a revocation path as a prerequisite for a
         public brokered rollout that has not shipped yet. An enrollment record (
-        <code>orb_enrollments</code>) lives in gittensory&apos;s own central database, not your
+        <code>orb_enrollments</code>) lives in LoopOver&apos;s own central database, not your
         container, and nothing in this codebase writes a <code>revoked_at</code> value to it outside
         of tests. Practical steps until that exists:
       </p>

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-quickstart.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-quickstart.tsx
@@ -6,17 +6,17 @@ import { Callout, CodeBlock, FeatureRow } from "@/components/site/primitives";
 export const Route = createFileRoute("/docs/self-hosting-quickstart")({
   head: () => ({
     meta: [
-      { title: "Self-hosting quickstart — Gittensory docs" },
+      { title: "Self-hosting quickstart — LoopOver docs" },
       {
         name: "description",
         content:
-          "Bring up the Gittensory self-host review service, run readiness checks, and choose the first safe rollout mode.",
+          "Bring up the LoopOver self-host review service, run readiness checks, and choose the first safe rollout mode.",
       },
-      { property: "og:title", content: "Self-hosting quickstart — Gittensory docs" },
+      { property: "og:title", content: "Self-hosting quickstart — LoopOver docs" },
       {
         property: "og:description",
         content:
-          "Bring up the Gittensory self-host review service, run readiness checks, and choose the first safe rollout mode.",
+          "Bring up the LoopOver self-host review service, run readiness checks, and choose the first safe rollout mode.",
       },
       { property: "og:url", content: "/docs/self-hosting-quickstart" },
     ],
@@ -197,7 +197,7 @@ review_context_fetch_failed   # REES/RAG/grounding context failure`}
           {
             title: "Gate activation (DB or private config)",
             description:
-              "Turns on the Gittensory check-run and deterministic gate rules for a repo. One-click via the control panel or POST /v1/repos/:owner/:repo/activation; or set gate.checkMode / gate.enabled in a mounted private .gittensory.yml.",
+              "Turns on the LoopOver check-run and deterministic gate rules for a repo. One-click via the control panel or POST /v1/repos/:owner/:repo/activation; or set gate.checkMode / gate.enabled in a mounted private .gittensory.yml.",
           },
           {
             title: "is_registered (Gittensor registry)",
@@ -230,7 +230,7 @@ cp config/examples/global.gittensory.yml gittensory-config/owner__my-repo/.gitte
       />
       <p>
         Sign in to the control panel (<code>ADMIN_GITHUB_LOGINS</code> must include your GitHub
-        login), open the repo workspace, preview what Gittensory would have flagged on recent PRs,
+        login), open the repo workspace, preview what LoopOver would have flagged on recent PRs,
         then enable advisory mode in one click — the same patch as:
       </p>
       <CodeBlock

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-rag.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-rag.tsx
@@ -6,17 +6,17 @@ import { Callout, CodeBlock, FeatureRow } from "@/components/site/primitives";
 export const Route = createFileRoute("/docs/self-hosting-rag")({
   head: () => ({
     meta: [
-      { title: "Self-host RAG indexing — Gittensory docs" },
+      { title: "Self-host RAG indexing — LoopOver docs" },
       {
         name: "description",
         content:
-          "Configure retrieval-augmented review context for self-hosted Gittensory with embeddings, Qdrant, indexing jobs, and cold-index behavior.",
+          "Configure retrieval-augmented review context for self-hosted LoopOver with embeddings, Qdrant, indexing jobs, and cold-index behavior.",
       },
-      { property: "og:title", content: "Self-host RAG indexing — Gittensory docs" },
+      { property: "og:title", content: "Self-host RAG indexing — LoopOver docs" },
       {
         property: "og:description",
         content:
-          "Configure retrieval-augmented review context for self-hosted Gittensory with embeddings, Qdrant, indexing jobs, and cold-index behavior.",
+          "Configure retrieval-augmented review context for self-hosted LoopOver with embeddings, Qdrant, indexing jobs, and cold-index behavior.",
       },
       { property: "og:url", content: "/docs/self-hosting-rag" },
     ],

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-rees-analyzers.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-rees-analyzers.tsx
@@ -7,17 +7,17 @@ import { REES_ANALYZERS, REES_ANALYZER_NAMES, REES_PROFILES } from "@/lib/rees-a
 export const Route = createFileRoute("/docs/self-hosting-rees-analyzers")({
   head: () => ({
     meta: [
-      { title: "REES analyzer reference — Gittensory docs" },
+      { title: "REES analyzer reference — LoopOver docs" },
       {
         name: "description",
         content:
-          "Reference for every REES analyzer available to self-hosted Gittensory review engines, including analyzer names, inputs, network behavior, and findings.",
+          "Reference for every REES analyzer available to self-hosted LoopOver review engines, including analyzer names, inputs, network behavior, and findings.",
       },
-      { property: "og:title", content: "REES analyzer reference — Gittensory docs" },
+      { property: "og:title", content: "REES analyzer reference — LoopOver docs" },
       {
         property: "og:description",
         content:
-          "Reference for every REES analyzer available to self-hosted Gittensory review engines, including analyzer names, inputs, network behavior, and findings.",
+          "Reference for every REES analyzer available to self-hosted LoopOver review engines, including analyzer names, inputs, network behavior, and findings.",
       },
       { property: "og:url", content: "/docs/self-hosting-rees-analyzers" },
     ],

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-rees.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-rees.tsx
@@ -7,17 +7,17 @@ import { REES_ANALYZER_NAMES } from "@/lib/rees-analyzers";
 export const Route = createFileRoute("/docs/self-hosting-rees")({
   head: () => ({
     meta: [
-      { title: "REES enrichment — Gittensory docs" },
+      { title: "REES enrichment — LoopOver docs" },
       {
         name: "description",
         content:
-          "Configure REES for self-hosted Gittensory reviews, including service auth, analyzer selection, result visibility, and troubleshooting.",
+          "Configure REES for self-hosted LoopOver reviews, including service auth, analyzer selection, result visibility, and troubleshooting.",
       },
-      { property: "og:title", content: "REES enrichment — Gittensory docs" },
+      { property: "og:title", content: "REES enrichment — LoopOver docs" },
       {
         property: "og:description",
         content:
-          "Configure REES for self-hosted Gittensory reviews, including service auth, analyzer selection, result visibility, and troubleshooting.",
+          "Configure REES for self-hosted LoopOver reviews, including service auth, analyzer selection, result visibility, and troubleshooting.",
       },
       { property: "og:url", content: "/docs/self-hosting-rees" },
     ],

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-release-checklist.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-release-checklist.tsx
@@ -6,13 +6,13 @@ import { Callout, CodeBlock, FeatureRow } from "@/components/site/primitives";
 export const Route = createFileRoute("/docs/self-hosting-release-checklist")({
   head: () => ({
     meta: [
-      { title: "First release checklist — Gittensory docs" },
+      { title: "First release checklist — LoopOver docs" },
       {
         name: "description",
         content:
           "Versioning and trigger for the first stable self-host image, the smoke-test matrix (direct App, brokered, air-gapped, each AI provider, SQLite/Postgres, Redis/Qdrant), an image-contents audit, the full-vs-minimal variant decision, and the GitHub Release notes template.",
       },
-      { property: "og:title", content: "First release checklist — Gittensory docs" },
+      { property: "og:title", content: "First release checklist — LoopOver docs" },
       {
         property: "og:description",
         content:

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-releases.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-releases.tsx
@@ -6,17 +6,17 @@ import { Callout, CodeBlock, FeatureRow } from "@/components/site/primitives";
 export const Route = createFileRoute("/docs/self-hosting-releases")({
   head: () => ({
     meta: [
-      { title: "Self-host releases and images — Gittensory docs" },
+      { title: "Self-host releases and images — LoopOver docs" },
       {
         name: "description",
         content:
-          "Use official Gittensory self-host images, tags, source maps, custom builds, release notes, and upgrade checks.",
+          "Use official LoopOver self-host images, tags, source maps, custom builds, release notes, and upgrade checks.",
       },
-      { property: "og:title", content: "Self-host releases and images — Gittensory docs" },
+      { property: "og:title", content: "Self-host releases and images — LoopOver docs" },
       {
         property: "og:description",
         content:
-          "Use official Gittensory self-host images, tags, source maps, custom builds, release notes, and upgrade checks.",
+          "Use official LoopOver self-host images, tags, source maps, custom builds, release notes, and upgrade checks.",
       },
       { property: "og:url", content: "/docs/self-hosting-releases" },
     ],

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-security.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-security.tsx
@@ -6,17 +6,17 @@ import { Callout, CodeBlock, FeatureRow } from "@/components/site/primitives";
 export const Route = createFileRoute("/docs/self-hosting-security")({
   head: () => ({
     meta: [
-      { title: "Self-host security — Gittensory docs" },
+      { title: "Self-host security — LoopOver docs" },
       {
         name: "description",
         content:
-          "Secure the self-hosted Gittensory review service: secrets, private rules, network exposure, public output boundaries, REES, AI credentials, and observability.",
+          "Secure the self-hosted LoopOver review service: secrets, private rules, network exposure, public output boundaries, REES, AI credentials, and observability.",
       },
-      { property: "og:title", content: "Self-host security — Gittensory docs" },
+      { property: "og:title", content: "Self-host security — LoopOver docs" },
       {
         property: "og:description",
         content:
-          "Secure the self-hosted Gittensory review service: secrets, private rules, network exposure, public output boundaries, REES, AI credentials, and observability.",
+          "Secure the self-hosted LoopOver review service: secrets, private rules, network exposure, public output boundaries, REES, AI credentials, and observability.",
       },
       { property: "og:url", content: "/docs/self-hosting-security" },
     ],

--- a/apps/gittensory-ui/src/routes/docs.self-hosting-troubleshooting.tsx
+++ b/apps/gittensory-ui/src/routes/docs.self-hosting-troubleshooting.tsx
@@ -6,17 +6,17 @@ import { CodeBlock, FeatureRow } from "@/components/site/primitives";
 export const Route = createFileRoute("/docs/self-hosting-troubleshooting")({
   head: () => ({
     meta: [
-      { title: "Self-host troubleshooting — Gittensory docs" },
+      { title: "Self-host troubleshooting — LoopOver docs" },
       {
         name: "description",
         content:
-          "Troubleshoot self-hosted Gittensory reviews: webhook delivery, AI unavailable, REES silent, RAG empty, queue stuck, GitHub rate limits, Qdrant, Orb, AI provider circuit breakers, and readiness failures.",
+          "Troubleshoot self-hosted LoopOver reviews: webhook delivery, AI unavailable, REES silent, RAG empty, queue stuck, GitHub rate limits, Qdrant, Orb, AI provider circuit breakers, and readiness failures.",
       },
-      { property: "og:title", content: "Self-host troubleshooting — Gittensory docs" },
+      { property: "og:title", content: "Self-host troubleshooting — LoopOver docs" },
       {
         property: "og:description",
         content:
-          "Troubleshoot self-hosted Gittensory reviews: webhook delivery, AI unavailable, REES silent, RAG empty, queue stuck, GitHub rate limits, Qdrant, Orb, AI provider circuit breakers, and readiness failures.",
+          "Troubleshoot self-hosted LoopOver reviews: webhook delivery, AI unavailable, REES silent, RAG empty, queue stuck, GitHub rate limits, Qdrant, Orb, AI provider circuit breakers, and readiness failures.",
       },
       { property: "og:url", content: "/docs/self-hosting-troubleshooting" },
     ],

--- a/apps/gittensory-ui/src/routes/docs.troubleshooting.tsx
+++ b/apps/gittensory-ui/src/routes/docs.troubleshooting.tsx
@@ -6,13 +6,13 @@ import { Callout, CodeBlock } from "@/components/site/primitives";
 export const Route = createFileRoute("/docs/troubleshooting")({
   head: () => ({
     meta: [
-      { title: "Troubleshooting — Gittensory docs" },
+      { title: "Troubleshooting — LoopOver docs" },
       {
         name: "description",
         content:
           "Diagnose MCP/CLI issues with doctor, status, and whoami. Common errors and fixes.",
       },
-      { property: "og:title", content: "Troubleshooting — Gittensory docs" },
+      { property: "og:title", content: "Troubleshooting — LoopOver docs" },
       {
         property: "og:description",
         content:
@@ -92,14 +92,14 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318`}
 
       <h3>401 Unauthorized from the API</h3>
       <p>
-        Your Gittensory session expired. Run <code>gittensory-mcp login</code> again. Static bearer
+        Your LoopOver session expired. Run <code>gittensory-mcp login</code> again. Static bearer
         tokens are not user-facing.
       </p>
 
       <h2 id="api-status">API status &amp; offline mode</h2>
       <p>
-        The site continuously monitors the Gittensory API and surfaces problems through a banner
-        under the header and a single deduped toast with a <strong>Recheck</strong> button.
+        The site continuously monitors the LoopOver API and surfaces problems through a banner under
+        the header and a single deduped toast with a <strong>Recheck</strong> button.
       </p>
       <h3 id="offline">You're offline</h3>
       <p>

--- a/apps/gittensory-ui/src/routes/docs.tsx
+++ b/apps/gittensory-ui/src/routes/docs.tsx
@@ -6,17 +6,17 @@ import { DocsToc } from "@/components/site/docs-toc";
 export const Route = createFileRoute("/docs")({
   head: () => ({
     meta: [
-      { title: "Docs — Gittensory" },
+      { title: "Docs — LoopOver" },
       {
         name: "description",
         content:
-          "Documentation for Gittensory: install, MCP client setup, miner/maintainer workflows, GitHub App, branch analysis, scoreability, drift, privacy.",
+          "Documentation for LoopOver: install, MCP client setup, miner/maintainer workflows, GitHub App, branch analysis, scoreability, drift, privacy.",
       },
-      { property: "og:title", content: "Docs — Gittensory" },
+      { property: "og:title", content: "Docs — LoopOver" },
       {
         property: "og:description",
         content:
-          "Documentation for Gittensory: install, MCP client setup, miner/maintainer workflows, GitHub App, branch analysis, scoreability, drift, privacy.",
+          "Documentation for LoopOver: install, MCP client setup, miner/maintainer workflows, GitHub App, branch analysis, scoreability, drift, privacy.",
       },
     ],
   }),

--- a/apps/gittensory-ui/src/routes/docs.tuning.tsx
+++ b/apps/gittensory-ui/src/routes/docs.tuning.tsx
@@ -6,17 +6,17 @@ import { CodeBlock, Callout } from "@/components/site/primitives";
 export const Route = createFileRoute("/docs/tuning")({
   head: () => ({
     meta: [
-      { title: "Tuning your reviews — Gittensory docs" },
+      { title: "Tuning your reviews — LoopOver docs" },
       {
         name: "description",
         content:
-          "Configure Gittensory CI and Gittensory review: gate modes, score thresholds, guardrails, and feature flags via .gittensory.yml and repo settings.",
+          "Configure LoopOver CI and LoopOver review: gate modes, score thresholds, guardrails, and feature flags via .gittensory.yml and repo settings.",
       },
-      { property: "og:title", content: "Tuning your reviews — Gittensory docs" },
+      { property: "og:title", content: "Tuning your reviews — LoopOver docs" },
       {
         property: "og:description",
         content:
-          "Configure Gittensory CI and Gittensory review: gate modes, score thresholds, guardrails, and feature flags via .gittensory.yml and repo settings.",
+          "Configure LoopOver CI and LoopOver review: gate modes, score thresholds, guardrails, and feature flags via .gittensory.yml and repo settings.",
       },
       { property: "og:url", content: "/docs/tuning" },
     ],
@@ -30,12 +30,12 @@ function Tuning() {
     <DocsPage
       eyebrow="Operating"
       title="Tuning your reviews"
-      description="How to configure Gittensory CI and Gittensory review — gate modes, score thresholds, guardrails, and feature flags — through .gittensory.yml and your repo settings."
+      description="How to configure LoopOver CI and LoopOver review — gate modes, score thresholds, guardrails, and feature flags — through .gittensory.yml and your repo settings."
     >
       <h2>How configuration fits together</h2>
       <p>
-        <strong>Gittensory review</strong> is the engine that scores, gates, and comments on your
-        pull requests. You shape its behavior in two places, and you never have to touch the review
+        <strong>LoopOver review</strong> is the engine that scores, gates, and comments on your pull
+        requests. You shape its behavior in two places, and you never have to touch the review
         algorithm itself:
       </p>
       <ul>
@@ -93,7 +93,7 @@ function Tuning() {
       <p>
         The friendly <code>gate:</code> block in <code>.gittensory.yml</code> is a typed alias for
         the gate-related fields and wins over the generic <code>settings:</code> block for those
-        same fields. Gittensory looks for the manifest at the first match of{" "}
+        same fields. LoopOver looks for the manifest at the first match of{" "}
         <code>.gittensory.yml</code> → <code>.github/gittensory.yml</code> →{" "}
         <code>.gittensory.json</code> → <code>.github/gittensory.json</code>.
       </p>

--- a/apps/gittensory-ui/src/routes/docs.upstream-drift.tsx
+++ b/apps/gittensory-ui/src/routes/docs.upstream-drift.tsx
@@ -6,17 +6,17 @@ import { CodeBlock, Callout } from "@/components/site/primitives";
 export const Route = createFileRoute("/docs/upstream-drift")({
   head: () => ({
     meta: [
-      { title: "Upstream drift — Gittensory docs" },
+      { title: "Upstream drift — LoopOver docs" },
       {
         name: "description",
         content:
-          "Gittensory tracks versioned upstream Gittensor source/ruleset snapshots, hashes semantic payloads, and warns when assumptions drift.",
+          "LoopOver tracks versioned upstream Gittensor source/ruleset snapshots, hashes semantic payloads, and warns when assumptions drift.",
       },
-      { property: "og:title", content: "Upstream drift — Gittensory docs" },
+      { property: "og:title", content: "Upstream drift — LoopOver docs" },
       {
         property: "og:description",
         content:
-          "Gittensory tracks versioned upstream Gittensor source/ruleset snapshots, hashes semantic payloads, and warns when assumptions drift.",
+          "LoopOver tracks versioned upstream Gittensor source/ruleset snapshots, hashes semantic payloads, and warns when assumptions drift.",
       },
       { property: "og:url", content: "/docs/upstream-drift" },
     ],
@@ -30,11 +30,11 @@ function UpstreamDrift() {
     <DocsPage
       eyebrow="Core concepts"
       title="Upstream drift"
-      description="Gittensor moves. Gittensory tracks every meaningful change to scoring, registry, and issue-discovery so your decisions stay grounded."
+      description="Gittensor moves. LoopOver tracks every meaningful change to scoring, registry, and issue-discovery so your decisions stay grounded."
     >
       <h2>How drift works</h2>
       <p>
-        Gittensory stores versioned snapshots of the Gittensor source and ruleset from{" "}
+        LoopOver stores versioned snapshots of the Gittensor source and ruleset from{" "}
         <a href="https://github.com/entrius/gittensor" target="_blank" rel="noreferrer">
           entrius/gittensor:test
         </a>
@@ -44,7 +44,7 @@ function UpstreamDrift() {
 
       <Callout>
         <strong>Upstream relationship.</strong> <code>entrius/gittensor</code> is the upstream
-        project Gittensory analyzes. Gittensory is{" "}
+        project LoopOver analyzes. LoopOver is{" "}
         <a href="https://github.com/jsonbored/gittensory" target="_blank" rel="noreferrer">
           jsonbored/gittensory
         </a>{" "}

--- a/test/unit/docs-beta-onboarding.test.ts
+++ b/test/unit/docs-beta-onboarding.test.ts
@@ -24,7 +24,7 @@ describe("docs beta onboarding page", () => {
     expect(source).toMatch(/branch metadata/);
     expect(source).toMatch(/changed file paths/);
     expect(source).toMatch(/commit messages/);
-    expect(normalizedSource).toMatch(/authenticated Gittensory MCP\/API responses/);
+    expect(normalizedSource).toMatch(/authenticated LoopOver MCP\/API responses/);
     expect(source).not.toMatch(/Metadata stays on your machine/);
   });
 

--- a/test/unit/docs-github-app.test.ts
+++ b/test/unit/docs-github-app.test.ts
@@ -10,14 +10,10 @@ const GITHUB_APP_DOCS_PATH = resolve(
 describe("docs GitHub App setup page", () => {
   const source = readFileSync(GITHUB_APP_DOCS_PATH, "utf8");
 
-  it("documents the install route, permissions, events, and setup verification", () => {
-    expect(source).toMatch(/https:\/\/github\.com\/apps\/gittensory\/installations\/new/);
-    expect(source).toMatch(/Metadata: read/);
-    expect(source).toMatch(/Pull requests: read/);
-    expect(source).toMatch(/Issues: write/);
-    expect(source).toMatch(/Checks: write/);
-    expect(source).toMatch(/issue_comment/);
-    expect(source).toMatch(/pull_request/);
+  it("documents self-hosting as the only currently available install path, and setup verification", () => {
+    expect(source).not.toMatch(/https:\/\/github\.com\/apps\/gittensory\/installations\/new/);
+    expect(source).toMatch(/Self-hosting is the only currently available path/);
+    expect(source).toMatch(/Shared, centrally hosted App: not currently available/);
     expect(source).toMatch(/GET \/v1\/installations/);
     expect(source).toMatch(/GET \/v1\/repos\/:owner\/:repo\/registration-readiness/);
     expect(source).toMatch(/POST \/v1\/repos\/:owner\/:repo\/settings-preview/);


### PR DESCRIPTION
## Summary
- Renames genuine brand-prose mentions of "gittensory" to "LoopOver" across the README, all 35 docs-site route pages, and the 4 community health files (CONTRIBUTING/SECURITY/SUPPORT/CODE_OF_CONDUCT).
- Deliberately leaves every not-yet-renamed technical identifier untouched: npm package names (`@jsonbored/gittensory-*`), the check-run names (`Gittensory Orb Review Agent`/`Gittensory Context`/`Gittensory Gate`), the bot's GitHub login (`gittensory[bot]`), the `.gittensory.yml` config filename, `GITTENSORY_`-prefixed env vars, the repo path, and the `gittensory.aethereal.dev`/`gittensory-api.aethereal.dev` domains -- each is tracked by its own separate rebrand issue, and renaming them in docs now would describe a system that doesn't exist yet.
- `gittensor` (no trailing Y, the permanent Bittensor SN74 subnet brand) is untouched everywhere -- verified via balanced before/after occurrence counts across the full diff.
- Adds a "Formerly Gittensory" continuity note near the top of the README.

## Also fixes (found along the way)
Three docs pages (GitHub App configuration, maintainer install/trust guide, maintainer self-hosting) advertised installing a "shared managed-beta" GitHub App at a literal install URL for an App that was fully deleted earlier in this rebrand. Reframed as "currently paused, self-hosting is the only available path today, a new centrally hosted offering is planned for the future" rather than deleting the content outright, so it's ready to reactivate when that offering ships.

## Test plan
- [x] `npm run typecheck`
- [x] Independent diff-level verification: every technical identifier's occurrence count is identical before/after (check-run names, bot login, npm packages, config filename, env vars, domains); `gittensor` (no-Y) count unchanged (6/6)
- [x] Updated 2 pre-existing tests whose assertions targeted the now-intentionally-removed dead install checklist / old brand string (`docs-github-app.test.ts`, `docs-beta-onboarding.test.ts`)
- [x] `npm run ui:lint` / `ui:typecheck` / `ui:test` / `ui:build` all green
- [x] `npm run docs:drift-check`, `manifest:drift-check`, `engine-parity:drift-check`, `command-reference:check` all green
- [x] Full `test:ci` gate green (one `ai-summaries.test.ts` timeout under local full-suite parallel load confirmed as a pre-existing, environment-load-dependent flake -- passes standalone in ~2.4s, unrelated to this diff)

Closes #4763.