### PR TITLE
docs(miner): fix stale coding-agent-driver.md/house-rules comments

### DIFF
--- a/packages/gittensory-miner/docs/coding-agent-driver.md
+++ b/packages/gittensory-miner/docs/coding-agent-driver.md
@@ -81,24 +81,47 @@ To add a driver beyond the CLI-subprocess and Agent-SDK backends:
    injected backend, asserting identical SHAPE and edge-case handling (not identical output, which is inherently
    non-deterministic across backends).
 
-## A worked attempt lifecycle
+## A worked attempt lifecycle (the real production path)
+
+`runCodingAgentAttempt`/`invokeCodingAgentDriver` (driver-factory.ts/coding-agent-invoke.ts) are real, tested,
+and remain available as a lower-level composable, but **production does not call either of them today**. The
+real construction + invocation path, as actually wired into `packages/gittensory-miner`, is:
 
 ```
-runCodingAgentAttempt(options)
-  ├─ resolveCodingAgentExecutionMode(...)         → paused | dry_run | live
-  ├─ if !codingAgentModeExecutes(mode):           → record a shadow/no-op attempt-log event, return without spawning
-  │     (uses the noop driver stand-in — CLI providers do NOT require spawn/query deps in this branch)
-  ├─ createCodingAgentDriver({ name, ... })        → the configured driver
-  └─ invokeCodingAgentDriver(driver, task, mode, log)
-       ├─ log: attempt started
-       ├─ driver.run(task)                          → edits inside task.workingDirectory only, ≤ task.maxTurns
-       │      └─ (metering accumulates tokens/turns/wallClockMs/costUsd; evaluateAttemptBudget can abort)
-       ├─ log: attempt succeeded | failed           (append-only; formatAttemptLogJsonl dumps the trace)
-       └─ returns CodingAgentDriverResult { ok, changedFiles, summary, transcript?, turnsUsed? }
+constructProductionCodingAgentDriver(env)        (packages/gittensory-miner/lib/coding-agent-construction.js)
+  └─ createCodingAgentDriver({ providerName, spawn, ... })   (driver-factory.ts) → the configured CodingAgentDriver
+       │  (house-rule hooks attached by default for agent-sdk via buildHouseRulesAgentSdkHooks -- see below)
+       └─ becomes IterateLoopDeps.driver, handed to runIterateLoop (iterate-loop.ts)
+
+runIterateLoop(input, deps)                       (packages/gittensory-engine/src/miner/iterate-loop.ts)
+  └─ per iteration, runDriverSafely(input, deps, task):
+       ├─ if !codingAgentModeExecutes(input.mode):  → invokeCodingAgentDriver(deps.driver, mode, task, {...})
+       │     (paused/dry_run only -- records a shadow/no-op attempt-log event, never spawns the real driver)
+       └─ else (live):                              → deps.driver.run(task) directly, NOT via invokeCodingAgentDriver
+              → edits inside task.workingDirectory only, ≤ task.maxTurns
+       ├─ evaluateSelfReviewOutcome(...) → self-review the resulting diff
+       ├─ decideNextActionWithReason(state) → continue | handoff | abandon
+       └─ logDecision(...) records ONE attempt-log event per iteration (continue/handoff/abandon), not a
+              raw driver-start/succeed/fail pair the way invokeCodingAgentDriver's own wrapper would
 ```
 
-The attempt log (JSONL) and the metering totals are the durable, provider-independent record of what happened —
-independent of whichever backend's own transcript, and the input to the miner's manage-phase and self-improve loops.
+The attempt log (JSONL) is the durable, provider-independent record of what happened, independent of whichever
+backend's own transcript, and the input to the miner's manage-phase and self-improve loops.
+
+`packages/gittensory-miner/lib/coding-agent-house-rules.js`'s `runHouseRulesEnforcedCodingAgentAttempt` (a
+drop-in wrapper over `runCodingAgentAttempt`) exists for a caller that wants the alternate, non-iterate-loop
+path with house-rule enforcement built in by default -- no such caller exists in production today either; the
+real house-rule enforcement for the live `agent-sdk` provider happens via `buildHouseRulesAgentSdkHooks`,
+attached directly in `constructProductionCodingAgentDriver`.
+
+**Metering:** `attempt-metering.ts`'s `accumulateAttemptUsage`/`meterAttemptUsage`/`evaluateAttemptBudget`
+(tokens/turns/wallClockMs/costUsd, with mid-attempt budget-abort) have **zero production callers** as of this
+writing -- see [#5395](https://github.com/JSONbored/gittensory/issues/5395) for the tracked decision on
+whether to wire them in for real or remove them. What IS real today: `iterate-loop.ts` sums each iteration's
+real `driverResult.turnsUsed`/`costUsd` into `IterateLoopResult.totalTurnsUsed`/`totalCostUsd`, which
+`packages/gittensory-miner/lib/loop-cli.js` uses to increment the governor's persisted `GovernorCapUsage`
+between loop cycles -- an after-the-fact, cross-cycle total, not the per-iteration mid-attempt abort
+`attempt-metering.ts` was designed to provide.
 
 ## Related docs
 

--- a/packages/gittensory-miner/lib/coding-agent-house-rules.js
+++ b/packages/gittensory-miner/lib/coding-agent-house-rules.js
@@ -7,12 +7,18 @@
 // a future real call site does not need to remember to attach it itself, closing the exact gap
 // buildHouseRulesPreToolUseHook's own doc comment already anticipated ("the live interception wiring itself").
 //
-// This does not build a CLI entrypoint -- nothing in this package constructs a coding-agent driver in
-// production yet (verified: no caller of createCodingAgentDriver/runCodingAgentAttempt exists anywhere in
-// packages/gittensory-miner today). That is separate, larger follow-up work. What this DOES guarantee: once
-// such a call site exists, it only has to call `runHouseRulesEnforcedCodingAgentAttempt` (a drop-in
-// replacement for the engine's own `runCodingAgentAttempt`) to get real, unbypassable house-rule enforcement
-// automatically, rather than depending on that future author to remember to wire hooks by hand.
+// This does not build a CLI entrypoint. UPDATE (#5135/#5396): a real production call site now exists --
+// packages/gittensory-miner/lib/coding-agent-construction.js's `constructProductionCodingAgentDriver` calls
+// `createCodingAgentDriver` directly -- but it does NOT go through `runCodingAgentAttempt` or this module's
+// own `runHouseRulesEnforcedCodingAgentAttempt` wrapper below; the real invocation path is
+// `constructProductionCodingAgentDriver` -> the resulting driver becomes `IterateLoopDeps.driver` -> consumed
+// by `runIterateLoop` (packages/gittensory-engine/src/miner/iterate-loop.ts). House-rule enforcement for the
+// live `agent-sdk` provider is instead attached directly there, via this module's own
+// `buildHouseRulesAgentSdkHooks` export (called from `constructProductionCodingAgentDriver` -- so the
+// DEFAULT-attachment guarantee below still holds, just through a different real call site than originally
+// anticipated). `runHouseRulesEnforcedCodingAgentAttempt` itself remains real, tested, and callable, but has
+// no production caller today -- it's a lower-level composable for a hypothetical caller that wants the
+// non-iterate-loop path, not something this package currently needs.
 
 import { runCodingAgentAttempt } from "@jsonbored/gittensory-engine";
 import { buildHouseRulesPreToolUseHook } from "./pretooluse-hook.js";


### PR DESCRIPTION
## Summary
Closes #5396. Pure doc/comment fix, no code behavior changes.

- `coding-agent-driver.md`'s "worked attempt lifecycle" described `runCodingAgentAttempt`/`invokeCodingAgentDriver` as the real production entrypoint — neither has a production caller. Rewrites it to show the real path: `constructProductionCodingAgentDriver` → `createCodingAgentDriver` → the resulting driver becomes `IterateLoopDeps.driver`, consumed by `runIterateLoop`, which calls `deps.driver.run(task)` directly in live mode (`invokeCodingAgentDriver` is only used for the non-executing paused/dry_run shadow-event path).
- Corrects the metering claim to point at #5395's tracked decision instead of asserting `attempt-metering.ts` is live.
- `coding-agent-house-rules.js`'s own header still asserted "no caller of `createCodingAgentDriver`/`runCodingAgentAttempt` exists anywhere in packages/gittensory-miner today" — false since #5131's `coding-agent-construction.js` calls `createCodingAgentDriver` directly. Updated to describe the real call path and where house-rule enforcement (`buildHouseRulesAgentSdkHooks`) actually gets attached today.

## Test plan
- [x] `node --check` on the touched `.js` file
- [x] `npx vitest run test/unit/coding-agent-miner.test.ts` — 57 tests pass (unaffected, pure comment change)
- [x] `git diff --check` — clean