### PR TITLE
feat(miner): wire claim-ledger.js's real claimIssue() into the attempt pipeline (#5393)

### DIFF
--- a/packages/gittensory-miner/lib/attempt-cli.js
+++ b/packages/gittensory-miner/lib/attempt-cli.js
@@ -1,10 +1,12 @@
 // CLI dispatch for the real attempt pipeline (#5132, Wave 3.5 -- the final assembly). Wires bin/gittensory-miner.js's
 // `attempt` subcommand to real infrastructure end to end: worktree allocation + real git preparation
-// (worktree-allocator.js + attempt-worktree.js), the four ledgers (claim/event/attempt-log/governor), the
-// real coding-agent driver (#5131) and slop assessor (#5133), a live SelfReviewContext fetch (#5145), a real
-// coding-task spec (#5239), the operator's AmsPolicySpec execution policy (#5249), rejectionSignaled (#5241),
-// and finally a real runMinerAttempt call -- the first point in this epic where a real coding agent actually
-// runs, not just checks-and-reports-blocked.
+// (worktree-allocator.js + attempt-worktree.js), the four ledgers (claim/event/attempt-log/governor), a real
+// soft-claim staked before every attempt (#5393 -- previously only the manual `claim` subcommand ever called
+// claimIssue() for real, so checkSubmissionFreshness's own claim-required check would inevitably abort every
+// real attempt as "stale"), the real coding-agent driver (#5131) and slop assessor (#5133), a live
+// SelfReviewContext fetch (#5145), a real coding-task spec (#5239), the operator's AmsPolicySpec execution
+// policy (#5249), rejectionSignaled (#5241), and finally a real runMinerAttempt call -- the first point in
+// this epic where a real coding agent actually runs, not just checks-and-reports-blocked.
 //
 // KNOWN, DOCUMENTED GAPS (not fabricated -- see attempt-input-builder.js's own header for the full list):
 // governor.killSwitchRepoPaused only checks the GLOBAL env-var kill switch, not yet a real per-repo
@@ -127,11 +129,13 @@ export function buildAttemptDeps(env, ledgers) {
 
 /**
  * Run the `attempt` CLI subcommand end to end: resolveRejectionSignaled (before consuming a worktree slot) ->
- * acquire a concurrency slot -> assemble real AttemptDeps -> prepare a REAL git worktree -> fetch a real
+ * check for + stake a real soft-claim on the target issue (#5393, also before consuming a slot) -> acquire a
+ * concurrency slot -> assemble real AttemptDeps -> prepare a REAL git worktree -> fetch a real
  * SelfReviewContext -> build a real coding-task spec (blocks on an infeasible verdict) -> resolve the real
  * AmsPolicySpec execution policy -> assemble the real IterateLoopInput + Governor context -> call
- * runMinerAttempt for real. The worktree is cleaned up (or retained, per the real outcome) in `finally`.
- * See this file's header for the documented gaps (per-repo kill-switch pause, real convergence history).
+ * runMinerAttempt for real. The worktree is cleaned up (or retained, per the real outcome) and the claim
+ * released, in `finally`. See this file's header for the documented gaps (per-repo kill-switch pause, real
+ * convergence history).
  */
 export async function runAttempt(args, options = {}) {
   const parsed = parseAttemptArgs(args);
@@ -161,6 +165,7 @@ export async function runAttempt(args, options = {}) {
   let governorLedger = null;
   let allocation = null;
   let worktreeResult = null;
+  let claimed = false;
 
   try {
     allocator = (options.openWorktreeAllocator ?? openWorktreeAllocator)();
@@ -210,6 +215,56 @@ export async function runAttempt(args, options = {}) {
       options.onResult?.(rejectedResult);
       return 5;
     }
+
+    // Real soft-claim staking (#5393): checked/staked BEFORE acquiring a worktree slot, mirroring
+    // rejectionSignaled's own "don't consume a slot on work already known to be a no-go" rationale. Before
+    // this, nothing in the automated pipeline ever called claimLedger.claimIssue() for real -- only the
+    // manual `gittensory-miner claim` subcommand did -- so checkSubmissionFreshness (which REQUIRES an
+    // active claim to already exist by submission time, see submission-freshness-check.js) would inevitably
+    // abort every real attempt as "stale" regardless of how well the coding-agent loop went. A pre-existing
+    // ACTIVE claim on this exact repo+issue (from a prior invocation on this same machine, or a manual claim)
+    // means work is already in flight -- observe it and stop rather than silently duplicating it, instead of
+    // discovering the conflict only after spending a full worktree-prep + coding-agent run.
+    const existingClaim = claimLedger
+      .listClaims({ repoFullName: parsed.repoFullName, status: "active" })
+      .find((claim) => claim.issueNumber === parsed.issueNumber);
+    if (existingClaim) {
+      const reason = "already_claimed";
+      attemptLog.appendAttemptLogEvent({
+        eventType: "attempt_aborted",
+        attemptId,
+        actionClass: "open_pr",
+        mode,
+        reason,
+        payload: { repoFullName: parsed.repoFullName, issueNumber: parsed.issueNumber },
+      });
+      eventLedger.appendEvent({
+        type: "attempt_blocked",
+        repoFullName: parsed.repoFullName,
+        payload: { issueNumber: parsed.issueNumber, reason },
+      });
+      const alreadyClaimedResult = {
+        outcome: "blocked_already_claimed",
+        reason,
+        repoFullName: parsed.repoFullName,
+        issueNumber: parsed.issueNumber,
+        minerLogin: parsed.minerLogin,
+        base: parsed.base,
+        mode,
+        attemptId,
+      };
+      if (parsed.json) {
+        console.log(JSON.stringify(alreadyClaimedResult, null, 2));
+      } else {
+        console.error(
+          `Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: an active claim already exists in this machine's claim ledger.`,
+        );
+      }
+      options.onResult?.(alreadyClaimedResult);
+      return 11;
+    }
+    claimLedger.claimIssue(parsed.repoFullName, parsed.issueNumber, `attempt ${attemptId}`);
+    claimed = true;
 
     allocation = allocator.acquire(attemptId, parsed.repoFullName);
 
@@ -424,6 +479,12 @@ export async function runAttempt(args, options = {}) {
     }
     if (allocation && allocator) allocator.release(attemptId);
     allocator?.close();
+    // Mirrors the allocator's own acquire/release lifecycle above: a claim staked for real at the top of
+    // this function is released on every terminal outcome (submitted/abandon/stale/blocked/governed) and on
+    // every early-abort path reached AFTER staking it, so this miner's own soft-claim never outlives the
+    // attempt that made it. Never "expired" here -- that status is reserved for a claim whose owner never
+    // came back to release it at all (claim-ledger-expiry.js's own sweep), not a normal completion.
+    if (claimed && claimLedger) claimLedger.releaseClaim(parsed.repoFullName, parsed.issueNumber);
     claimLedger?.close();
     eventLedger?.close();
     attemptLog?.close();

--- a/test/unit/miner-attempt-cli.test.ts
+++ b/test/unit/miner-attempt-cli.test.ts
@@ -561,6 +561,179 @@ describe("runAttempt (#5132)", () => {
     expect(log).toHaveBeenCalled();
   });
 
+  describe("real soft-claim staking (#5393)", () => {
+    it("REGRESSION: stakes a real claim before acquiring the worktree slot, and releases it on a submitted outcome", async () => {
+      const { allocator, claimLedger, eventLedger, attemptLog, governorLedger } = tempLedgers();
+      vi.spyOn(console, "log").mockImplementation(() => undefined);
+      const claimIssueSpy = vi.spyOn(claimLedger, "claimIssue");
+      const releaseClaimSpy = vi.spyOn(claimLedger, "releaseClaim");
+      let claimDuringRun;
+      const runMinerAttemptSpy = vi.fn().mockImplementation(async () => {
+        // Peek at real ledger state from mid-pipeline -- proves the claim was staked BEFORE runMinerAttempt
+        // was ever called, not just eventually released after the fact.
+        claimDuringRun = claimLedger.listClaims({ repoFullName: "acme/widgets", status: "active" });
+        return { outcome: "submitted", spec: { command: "gh pr create", cwd: "/fake", timeoutMs: 1 }, execResult: { code: 0 }, loopResult: {} };
+      });
+
+      const exitCode = await runAttempt(["acme/widgets", "7", "--miner-login", "alice", "--json"], {
+        env: { MINER_CODING_AGENT_PROVIDER: "noop" },
+        attemptId: "claim-regression-attempt",
+        openWorktreeAllocator: () => allocator,
+        openClaimLedger: () => claimLedger,
+        initEventLedger: () => eventLedger,
+        initAttemptLog: () => attemptLog,
+        initGovernorLedger: () => governorLedger,
+        ...readyPipelineOptions({ runMinerAttempt: runMinerAttemptSpy }),
+      });
+
+      expect(exitCode).toBe(0);
+      expect(claimIssueSpy).toHaveBeenCalledWith("acme/widgets", 7, "attempt claim-regression-attempt");
+      expect(claimDuringRun).toEqual([
+        expect.objectContaining({ repoFullName: "acme/widgets", issueNumber: 7, status: "active" }),
+      ]);
+      // Released for real once the attempt finished -- not left dangling for the next invocation to trip over.
+      // (runAttempt's own `finally` already closed claimLedger by now, so this checks the spy, not the
+      // now-closed object -- reusing a closed ledger throws "statement has been finalized".)
+      expect(releaseClaimSpy).toHaveBeenCalledWith("acme/widgets", 7);
+    });
+
+    it.each([
+      ["abandon", { outcome: "abandon", loopResult: {} }],
+      ["stale", { outcome: "stale", reason: "expired", loopResult: {} }],
+      ["blocked", { outcome: "blocked", decision: { allow: false }, loopResult: {} }],
+      ["governed", { outcome: "governed", decision: { allowed: false }, loopResult: {} }],
+    ] as const)("releases the real claim on a real %s outcome, not just on submitted", async (_label, mockResult) => {
+      const { allocator, claimLedger, eventLedger, attemptLog, governorLedger } = tempLedgers();
+      vi.spyOn(console, "log").mockImplementation(() => undefined);
+      const releaseClaimSpy = vi.spyOn(claimLedger, "releaseClaim");
+
+      await runAttempt(["acme/widgets", "7", "--miner-login", "alice", "--json"], {
+        env: { MINER_CODING_AGENT_PROVIDER: "noop" },
+        openWorktreeAllocator: () => allocator,
+        openClaimLedger: () => claimLedger,
+        initEventLedger: () => eventLedger,
+        initAttemptLog: () => attemptLog,
+        initGovernorLedger: () => governorLedger,
+        ...readyPipelineOptions({ runMinerAttempt: async () => mockResult }),
+      });
+
+      expect(releaseClaimSpy).toHaveBeenCalledWith("acme/widgets", 7);
+    });
+
+    it("blocks with blocked_already_claimed (exit 11) when an active claim already exists, before ever acquiring a worktree slot", async () => {
+      const { allocator, claimLedger, eventLedger, attemptLog, governorLedger } = tempLedgers();
+      const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+      const acquireSpy = vi.spyOn(allocator, "acquire");
+      const appendAttemptLogEventSpy = vi.spyOn(attemptLog, "appendAttemptLogEvent");
+      const runMinerAttemptSpy = vi.fn();
+      // Staked BEFORE the spy is installed below, so the spy only observes calls made by runAttempt itself,
+      // not this test's own setup call.
+      claimLedger.claimIssue("acme/widgets", 7, "staked by a prior invocation");
+      const claimIssueSpy = vi.spyOn(claimLedger, "claimIssue");
+      const dbPath = claimLedger.dbPath;
+
+      const exitCode = await runAttempt(["acme/widgets", "7", "--miner-login", "alice", "--json"], {
+        env: { MINER_CODING_AGENT_PROVIDER: "noop" },
+        attemptId: "already-claimed-attempt",
+        openWorktreeAllocator: () => allocator,
+        openClaimLedger: () => claimLedger,
+        initEventLedger: () => eventLedger,
+        initAttemptLog: () => attemptLog,
+        initGovernorLedger: () => governorLedger,
+        resolveRejectionSignaled: async () => false,
+        runMinerAttempt: runMinerAttemptSpy,
+      });
+
+      expect(exitCode).toBe(11);
+      expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+        outcome: "blocked_already_claimed",
+        reason: "already_claimed",
+        repoFullName: "acme/widgets",
+        issueNumber: 7,
+        minerLogin: "alice",
+        base: "main",
+        mode: "dry_run",
+        attemptId: "already-claimed-attempt",
+      });
+      // No worktree slot was ever acquired for an issue we already know is being worked on.
+      expect(acquireSpy).not.toHaveBeenCalled();
+      // The pre-existing claim was observed, not re-staked/refreshed by this invocation.
+      expect(claimIssueSpy).not.toHaveBeenCalled();
+      expect(runMinerAttemptSpy).not.toHaveBeenCalled();
+      expect(appendAttemptLogEventSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ eventType: "attempt_aborted", attemptId: "already-claimed-attempt", reason: "already_claimed" }),
+      );
+      // The pre-existing claim (made by "a prior invocation") is left completely untouched -- this invocation
+      // never staked its own claim, so it has nothing to release. runAttempt's own `finally` already closed
+      // claimLedger, so re-open the same on-disk file fresh to inspect real persisted state.
+      const inspectLedger = openClaimLedger(dbPath);
+      closeables.push(inspectLedger);
+      expect(inspectLedger.listClaims({ repoFullName: "acme/widgets", status: "active" })).toEqual([
+        expect.objectContaining({ note: "staked by a prior invocation" }),
+      ]);
+    });
+
+    it("blocks with a human-readable message by default when an active claim already exists", async () => {
+      const { allocator, claimLedger, eventLedger, attemptLog, governorLedger } = tempLedgers();
+      const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+      claimLedger.claimIssue("acme/widgets", 7);
+
+      const exitCode = await runAttempt(["acme/widgets", "7", "--miner-login", "alice"], {
+        env: { MINER_CODING_AGENT_PROVIDER: "noop" },
+        openWorktreeAllocator: () => allocator,
+        openClaimLedger: () => claimLedger,
+        initEventLedger: () => eventLedger,
+        initAttemptLog: () => attemptLog,
+        initGovernorLedger: () => governorLedger,
+        resolveRejectionSignaled: async () => false,
+        runMinerAttempt: vi.fn(),
+      });
+
+      expect(exitCode).toBe(11);
+      expect(error).toHaveBeenCalledWith(expect.stringContaining("an active claim already exists"));
+    });
+
+    it("REGRESSION: releases the staked claim even when worktree preparation fails after staking it", async () => {
+      const { allocator, claimLedger, eventLedger, attemptLog, governorLedger } = tempLedgers();
+      vi.spyOn(console, "log").mockImplementation(() => undefined);
+      const releaseClaimSpy = vi.spyOn(claimLedger, "releaseClaim");
+
+      await runAttempt(["acme/widgets", "7", "--miner-login", "alice", "--json"], {
+        env: { MINER_CODING_AGENT_PROVIDER: "noop" },
+        openWorktreeAllocator: () => allocator,
+        openClaimLedger: () => claimLedger,
+        initEventLedger: () => eventLedger,
+        initAttemptLog: () => attemptLog,
+        initGovernorLedger: () => governorLedger,
+        resolveRejectionSignaled: async () => false,
+        prepareAttemptWorktree: async () => ({ ok: false, error: "git_clone_failed" }),
+        cleanupAttemptWorktree: vi.fn(),
+      });
+
+      // Staked before worktree preparation ran, and the block path's `finally` still released it -- the
+      // claim never outlives a failed attempt.
+      expect(releaseClaimSpy).toHaveBeenCalledWith("acme/widgets", 7);
+    });
+
+    it("never calls releaseClaim when the rejection-signaled block is hit before any claim is staked", async () => {
+      const { allocator, claimLedger, eventLedger, attemptLog, governorLedger } = tempLedgers();
+      vi.spyOn(console, "error").mockImplementation(() => undefined);
+      const releaseClaimSpy = vi.spyOn(claimLedger, "releaseClaim");
+
+      await runAttempt(["acme/widgets", "7", "--miner-login", "alice"], {
+        env: { MINER_CODING_AGENT_PROVIDER: "noop" },
+        openWorktreeAllocator: () => allocator,
+        openClaimLedger: () => claimLedger,
+        initEventLedger: () => eventLedger,
+        initAttemptLog: () => attemptLog,
+        initGovernorLedger: () => governorLedger,
+        resolveRejectionSignaled: async () => true,
+      });
+
+      expect(releaseClaimSpy).not.toHaveBeenCalled();
+    });
+  });
+
   it("REGRESSION: reports a real block and releases the worktree slot when worktree preparation fails", async () => {
     const { allocator, claimLedger, eventLedger, attemptLog, governorLedger } = tempLedgers();
     const log = vi.spyOn(console, "log").mockImplementation(() => undefined);


### PR DESCRIPTION
## Summary

- `claim-ledger.js`'s `claimIssue()` (the soft-claim mechanism meant to prevent two miners on the same machine from colliding on the same issue) was never called by the real attempt pipeline. `attempt-runner.js` only ever reads existing claims (`checkSubmissionFreshness`'s freshness check) -- the only real callers of `.claimIssue(` anywhere were the manual `gittensory-miner claim` subcommand and the module's own unused convenience wrapper.
- **This was a real, severe gap, not just a coordination nicety**: `submission-freshness-check.js`'s `checkSubmissionFreshness` (called from inside `runMinerAttempt`, right before `open_pr`) *already requires* an active claim to exist for the exact repo+issue at submission time -- if none is found, it aborts as `"stale"` (`claim_superseded`). Since nothing in the automated pipeline ever staked a real claim, **every real attempt was destined to fail at the freshness check** regardless of how well the coding-agent loop went, unless an operator had manually pre-staked a claim via the `claim` subcommand first.
- `runAttempt` now, right after the `rejectionSignaled` check and **before acquiring a worktree slot** (mirroring that same "don't consume a slot on work already known to be a no-go" rationale):
  1. Checks for a pre-existing **active** claim on the exact repo+issue. If one exists (from a prior invocation on this same machine, or a manual `claim`), blocks with a new `blocked_already_claimed` outcome (**exit code 11**) -- observing the existing claim and stopping, rather than silently duplicating a full worktree-prep + coding-agent run only to discover the conflict at the very end.
  2. Otherwise stakes a real claim via `claimLedger.claimIssue(repoFullName, issueNumber, "attempt <attemptId>")`.
- The claim is released in `finally` on every terminal outcome (`submitted`/`abandon`/`stale`/`blocked`/`governed`) and every early-abort path reached after staking it (e.g. worktree-prep failure) -- mirroring the worktree-allocator's own acquire/release lifecycle exactly. Never "expired" -- that status is reserved for a claim whose owner never came back at all (`claim-ledger-expiry.js`'s own sweep).
- `loop-cli.js` delegates to this same `runAttempt`, so it's covered automatically with no separate wiring needed.
- Does not change `claim-ledger.js`'s own storage/expiry logic at all -- only wires its already-built `claimIssue()`/`listClaims()`/`releaseClaim()` into a new real call site, per the issue's own boundaries. Real cross-miner claim adjudication (who wins a contested claim across *different* machines) stays entirely out of scope.

## Test plan

- [x] `npx vitest run test/unit/miner-attempt-cli.test.ts` -- 54/55 passing (1 pre-existing, unrelated Windows-only EPERM cleanup-timing failure on `reports an unexpected allocator failure...`, confirmed via `git stash` to exist identically without this PR's changes). New `describe("real soft-claim staking (#5393)", ...)` block covers: a regression proving the claim is staked (peeked at real ledger state from inside the `runMinerAttempt` mock) before it's ever called and released after a submitted outcome, `it.each` over abandon/stale/blocked/governed all releasing the claim, the `blocked_already_claimed` block (exit 11, no worktree slot acquired, the pre-existing claim left untouched, `claimIssue` never re-called), its human-readable message form, a regression that the claim is still released when worktree preparation fails after staking it, and confirmation that `releaseClaim` is never called when the rejection-signaled block is hit *before* any claim is staked.
- [x] `npx vitest run test/unit/miner-loop-cli.test.ts` -- 15/15 passing (unaffected, confirming `loop-cli.js`'s delegation to `runAttempt` picks up this change with no changes needed there).
- [x] `npm run typecheck` -- clean.
- [x] `npm run build:miner` -- clean.
- [x] `npm run docs:drift-check` -- clean.
- [x] Swept the full diff for secret-shaped patterns -- zero matches.
- [x] Manually verified isolated coverage of `attempt-cli.js`'s changed lines is 100% -- the file's only uncovered lines (confirmed via `coverage-final.json`) are all pre-existing, untouched code (unused `buildAttemptDeps` closures never invoked by these unit tests, the real `process.env`/`prepareAttemptWorktree` default fallbacks, and the pre-existing infeasible-block's non-JSON message branch).
- [ ] Did not run the full unsharded `npm run test:coverage` locally (shared/resource-contended machine); relying on the targeted test runs above plus the isolated-coverage check.

Fixes #5393.