### PR TITLE
feat(miner-ui): add an optional ORB/Grafana footer link to the root layout

### DIFF
--- a/apps/gittensory-miner-ui/README.md
+++ b/apps/gittensory-miner-ui/README.md
@@ -9,3 +9,9 @@ The miner package invariant is client-side only with no required phone-home to b
 local miner CLI can serve later — not a Wrangler deploy target.
 
 Phase 6 data views (run history, portfolio cards) land in follow-up issues after this empty shell.
+
+## Configuration
+
+| Env var                     | Required | Description                                                                                                                                                                                                                                            |
+| --------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `VITE_MINER_UI_GRAFANA_URL` | No       | If set (and non-empty), renders a footer link to your ORB/Grafana dashboard at this URL. Unset ⇒ no link. Must be `VITE_`-prefixed so Vite exposes it to the client bundle. It is a plain navigational link — no token or credential is ever appended. |

--- a/apps/gittensory-miner-ui/src/components/grafana-footer-link.tsx
+++ b/apps/gittensory-miner-ui/src/components/grafana-footer-link.tsx
@@ -1,0 +1,19 @@
+// Optional footer link to an operator's ORB/Grafana dashboard (#5194). Rendered only when the operator sets
+// VITE_MINER_UI_GRAFANA_URL (Vite exposes only VITE_-prefixed vars to the client bundle; a bare name would be
+// undefined at build time). The URL is a plain navigational link — no auth/session token or credential is ever
+// appended, and it is rendered as a normal href attribute (React escapes it, so a misconfigured value cannot
+// inject markup). Renders nothing when the var is unset or empty.
+export function GrafanaFooterLink() {
+  const url = import.meta.env.VITE_MINER_UI_GRAFANA_URL;
+  if (!url) return null;
+  return (
+    <a
+      href={url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="hover-surface rounded-token-sm px-2 py-1 hover:text-foreground"
+    >
+      ORB / Grafana dashboard ↗
+    </a>
+  );
+}

--- a/apps/gittensory-miner-ui/src/grafana-footer-link.test.tsx
+++ b/apps/gittensory-miner-ui/src/grafana-footer-link.test.tsx
@@ -1,0 +1,32 @@
+import { render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GrafanaFooterLink } from "./components/grafana-footer-link";
+
+afterEach(() => vi.unstubAllEnvs());
+
+describe("GrafanaFooterLink (#5194)", () => {
+  it("renders a new-tab link to the configured dashboard URL", () => {
+    vi.stubEnv("VITE_MINER_UI_GRAFANA_URL", "https://grafana.example.internal/d/ams");
+    render(<GrafanaFooterLink />);
+    const link = screen.getByRole("link", { name: /Grafana dashboard/i });
+    expect(link.getAttribute("href")).toBe("https://grafana.example.internal/d/ams");
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
+  it("renders nothing when the env var is unset or empty", () => {
+    vi.stubEnv("VITE_MINER_UI_GRAFANA_URL", "");
+    const { container } = render(<GrafanaFooterLink />);
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByRole("link")).toBeNull();
+  });
+
+  it("uses the URL verbatim as the href — never appends a token or credential", () => {
+    const url = "https://dash.example.internal/grafana";
+    vi.stubEnv("VITE_MINER_UI_GRAFANA_URL", url);
+    render(<GrafanaFooterLink />);
+    const href = screen.getByRole("link").getAttribute("href") ?? "";
+    expect(href).toBe(url); // exact — no `?token=`, no appended session/credential
+    expect(href).not.toMatch(/token|api[_-]?key|secret|session|auth=/i);
+  });
+});

--- a/apps/gittensory-miner-ui/src/routes/__root.tsx
+++ b/apps/gittensory-miner-ui/src/routes/__root.tsx
@@ -1,4 +1,5 @@
 import { Outlet, createRootRoute, Link } from "@tanstack/react-router";
+import { GrafanaFooterLink } from "@/components/grafana-footer-link";
 
 export const Route = createRootRoute({
   component: RootLayout,
@@ -29,6 +30,9 @@ function RootLayout() {
       <main className="mx-auto max-w-5xl px-6 py-8">
         <Outlet />
       </main>
+      <footer className="mx-auto max-w-5xl px-6 py-4 text-token-sm text-muted-foreground">
+        <GrafanaFooterLink />
+      </footer>
     </div>
   );
 }


### PR DESCRIPTION
Renders a footer link to an operator-configured ORB/Grafana dashboard in the miner-ui root layout (#5194).

## Behavior (matches the issue exactly)
- **One optional env var** — `VITE_MINER_UI_GRAFANA_URL`. `VITE_`-prefixed because Vite only exposes `VITE_*` to the client bundle (a bare name would be silently `undefined` at build).
- **Conditional** — the link renders only when the var is set and non-empty; nothing (no placeholder, no disabled link) when unset/empty.
- **New tab** — `target="_blank" rel="noopener noreferrer"`.
- **No credentials** — the URL is rendered verbatim as a plain `href`; no token/session/API key is ever appended.
- **Safe** — rendered as a normal `href` attribute (React escapes it; no `dangerouslySetInnerHTML`), so a misconfigured value cannot inject markup.
- Extracted as a small `GrafanaFooterLink` component; no other footer/layout/auth logic changed. Documented in the miner-ui README.

## Validation
- **`src/grafana-footer-link.test.tsx`** (3 tests): env-set → link with correct `href`/`target`/`rel`; env-unset/empty → nothing renders; invariant → `href` is the URL verbatim with no token/credential appended.
- `tsc` clean (my files); prettier-clean; no secrets. `apps/**` is codecov-ignored, so `codecov/patch` is vacuous — the branch-covering suite ships regardless.

Closes #5194