### PR TITLE
feat(miner): validate config content in doctor, not just its path

### DIFF
--- a/packages/gittensory-miner/lib/status.d.ts
+++ b/packages/gittensory-miner/lib/status.d.ts
@@ -25,9 +25,11 @@ export function collectStatus(env?: Record<string, string | undefined>, cwd?: st
 
 export function runStatus(args?: string[], env?: Record<string, string | undefined>, cwd?: string): number;
 
-export function runDoctorChecks(env?: Record<string, string | undefined>): DoctorCheck[];
+export function checkConfigContent(cwd: string, readImpl?: (path: string, encoding: "utf8") => string): DoctorCheck;
 
-export function runDoctor(args?: string[], env?: Record<string, string | undefined>): number;
+export function runDoctorChecks(env?: Record<string, string | undefined>, cwd?: string): DoctorCheck[];
+
+export function runDoctor(args?: string[], env?: Record<string, string | undefined>, cwd?: string): number;
 
 export function readInstalledEnginePackageVersionFromPaths(
   resolvedEntry: string,

--- a/packages/gittensory-miner/lib/status.js
+++ b/packages/gittensory-miner/lib/status.js
@@ -2,7 +2,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node
 import { createRequire } from "node:module";
 import { homedir } from "node:os";
 import { join } from "node:path";
-import { CODING_AGENT_DRIVER_CONFIG_ENV, resolveFirstConfiguredCodingAgentDriverName } from "@jsonbored/gittensory-engine";
+import { CODING_AGENT_DRIVER_CONFIG_ENV, parseMinerGoalSpecContent, resolveFirstConfiguredCodingAgentDriverName } from "@jsonbored/gittensory-engine";
 import {
   checkClaudeCliPresent,
   checkCodexCliPresent,
@@ -11,7 +11,7 @@ import {
   findExecutableOnPath,
 } from "./laptop-init.js";
 import { resolveMinerVersion } from "./version.js";
-import { checkStoreIntegrity } from "./store-maintenance.js";
+import { checkStoreIntegrity, describeError } from "./store-maintenance.js";
 import { resolveEventLedgerDbPath } from "./event-ledger.js";
 import { resolveGovernorLedgerDbPath } from "./governor-ledger.js";
 import { resolvePredictionLedgerDbPath } from "./prediction-ledger.js";
@@ -294,9 +294,29 @@ function storeIntegrityChecks(env) {
   return stores.map(([name, dbPath]) => checkStoreIntegrity(`store-integrity:${name}`, dbPath));
 }
 
+/** Validate the discovered `.gittensory-miner` config's CONTENT (#4873), not just its path: parse it with the
+ *  tolerant goal-spec parser and surface its warnings, so a malformed config is flagged by `doctor` rather than
+ *  silently degrading to defaults. No config file is fine (defaults apply); a read failure is reported. `readImpl`
+ *  is injectable for tests. */
+export function checkConfigContent(cwd, readImpl = readFileSync) {
+  const configPath = discoverConfigFile(cwd);
+  if (!configPath) {
+    return { name: "config-content", ok: true, detail: "no .gittensory-miner config found (using defaults)" };
+  }
+  let warnings;
+  try {
+    warnings = parseMinerGoalSpecContent(readImpl(configPath, "utf8")).warnings;
+  } catch (error) {
+    return { name: "config-content", ok: false, detail: `${configPath}: ${describeError(error)}` };
+  }
+  return warnings.length === 0
+    ? { name: "config-content", ok: true, detail: `${configPath}: valid` }
+    : { name: "config-content", ok: false, detail: `${configPath}: ${warnings.join("; ")}` };
+}
+
 /** Run the doctor checks. Returns an array of { name, ok, detail }; only writes a transient probe in the state dir,
  *  never touches the network. */
-export function runDoctorChecks(env = process.env) {
+export function runDoctorChecks(env = process.env, cwd = process.cwd()) {
   const nodeMajor = Number(process.versions.node.split(".")[0]);
   const requiredMajor = requiredNodeMajor();
   const engineVersion = readEngineVersion();
@@ -317,12 +337,13 @@ export function runDoctorChecks(env = process.env) {
     checkDockerPresent(),
     checkClaudeCliPresent({ env }),
     checkCodexCliPresent({ env }),
+    checkConfigContent(cwd),
     ...storeIntegrityChecks(env),
   ];
 }
 
-export function runDoctor(args = [], env = process.env) {
-  const checks = runDoctorChecks(env);
+export function runDoctor(args = [], env = process.env, cwd = process.cwd()) {
+  const checks = runDoctorChecks(env, cwd);
   const failed = checks.filter((check) => !check.ok);
   if (args.includes("--json")) {
     console.log(JSON.stringify({ ok: failed.length === 0, checks }, null, 2));

--- a/test/unit/miner-status.test.ts
+++ b/test/unit/miner-status.test.ts
@@ -5,6 +5,7 @@ import { resolveEventLedgerDbPath } from "../../packages/gittensory-miner/lib/ev
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
   buildEngineVersionSkewCheck,
+  checkConfigContent,
   collectStatus,
   compareInstalledEngineVersion,
   readExpectedEnginePackageVersion,
@@ -82,7 +83,8 @@ describe("gittensory-miner status/doctor (#2288)", () => {
     const log = vi.spyOn(console, "log").mockImplementation(() => {});
     const env = { GITTENSORY_MINER_CONFIG_DIR: join(tempRoot(), "state") };
     initLaptopState(env);
-    const checks = runDoctorChecks(env);
+    const cwd = tempRoot(); // a config-less working dir ⇒ config-content check is a clean pass
+    const checks = runDoctorChecks(env, cwd);
     expect(checks.every((check) => check.ok)).toBe(true);
     expect(checks.map((check) => check.name)).toEqual([
       "node-version",
@@ -93,6 +95,7 @@ describe("gittensory-miner status/doctor (#2288)", () => {
       "docker-present",
       "claude-cli-present",
       "codex-cli-present",
+      "config-content",
       "store-integrity:event-ledger",
       "store-integrity:governor-ledger",
       "store-integrity:prediction-ledger",
@@ -101,7 +104,7 @@ describe("gittensory-miner status/doctor (#2288)", () => {
       "store-integrity:run-state",
       "store-integrity:plan-store",
     ]);
-    expect(runDoctor([], env)).toBe(0);
+    expect(runDoctor([], env, cwd)).toBe(0);
     expect(log).toHaveBeenCalled();
   });
 
@@ -113,6 +116,50 @@ describe("gittensory-miner status/doctor (#2288)", () => {
     const checks = runDoctorChecks(env);
     expect(checks.find((check) => check.name === "store-integrity:event-ledger")?.ok).toBe(false);
     expect(runDoctor([], env)).toBe(1); // a failed check makes doctor exit non-zero
+  });
+
+  describe("checkConfigContent (#4873)", () => {
+    it("is a clean pass when no config file is present (defaults apply)", () => {
+      const result = checkConfigContent(tempRoot());
+      expect(result).toMatchObject({ name: "config-content", ok: true });
+      expect(result.detail).toContain("no .gittensory-miner config");
+    });
+
+    it("passes a well-formed config", () => {
+      const cwd = tempRoot();
+      writeFileSync(join(cwd, ".gittensory-miner.yml"), "wantedPaths:\n  - src\n");
+      const result = checkConfigContent(cwd);
+      expect(result.ok).toBe(true);
+      expect(result.detail).toContain("valid");
+    });
+
+    it("flags a malformed config with the parser's specific warnings", () => {
+      const cwd = tempRoot();
+      // wantedPaths must be a list; a scalar triggers a parser warning rather than a silent default.
+      writeFileSync(join(cwd, ".gittensory-miner.yml"), "wantedPaths: not-a-list\n");
+      const result = checkConfigContent(cwd);
+      expect(result.ok).toBe(false);
+      expect(result.detail).toMatch(/wantedPaths/);
+    });
+
+    it("reports a read failure (config discovered but unreadable)", () => {
+      const cwd = tempRoot();
+      writeFileSync(join(cwd, ".gittensory-miner.yml"), "wantedPaths:\n  - src\n");
+      const throwingRead = () => {
+        throw new Error("EACCES: permission denied");
+      };
+      const result = checkConfigContent(cwd, throwingRead);
+      expect(result.ok).toBe(false);
+      expect(result.detail).toContain("permission denied");
+    });
+  });
+
+  it("doctor flags a malformed config file (#4873)", () => {
+    const env = { GITTENSORY_MINER_CONFIG_DIR: join(tempRoot(), "state") };
+    const cwd = tempRoot();
+    writeFileSync(join(cwd, ".gittensory-miner.yml"), "wantedPaths: not-a-list\n");
+    expect(runDoctorChecks(env, cwd).find((check) => check.name === "config-content")?.ok).toBe(false);
+    expect(runDoctor([], env, cwd)).toBe(1);
   });
 
   it("engine version skew helpers compare installed vs expected semver", () => {


### PR DESCRIPTION
## Summary

`doctor` only reported the discovered `.gittensory-miner` config file's **path** — it never validated the file's **content**, so a malformed config silently degraded to defaults instead of being caught before a run.

This adds a `config-content` doctor check: it parses the discovered config with the engine's tolerant goal-spec parser (`parseMinerGoalSpecContent`) and surfaces its `warnings`, so `doctor` reports **specific, actionable errors** for a malformed config (e.g. *`MinerGoalSpec field "wantedPaths" must be a list; ignoring a string value`*) and exits non-zero.

- No config file present → clean pass (defaults apply).
- Well-formed config → pass.
- Malformed config → **flagged** with the parser's exact warnings.
- Config discovered but unreadable → reported.

`runDoctorChecks` / `runDoctor` now take an optional `cwd` (the config is discovered relative to it), defaulting to `process.cwd()` — backward-compatible.

## Scope

- [x] Narrow, one coherent change — one new doctor check reusing the existing engine parser + config discovery
- [x] In scope (`packages/`), no `blockedPaths`, no secrets/private terms
- [x] `.d.ts` companion updated (new export + the optional `cwd` params)

## Validation

- [x] `npm run typecheck`
- [x] `npm run test:coverage` (full unsharded suite)
- [x] `test/unit/miner-status.test.ts`: `checkConfigContent` unit tests (no config → pass, well-formed → pass, malformed → flagged with the parser's warnings, unreadable → reported), the doctor check list now includes `config-content`, and **`doctor` flags a malformed config file** and exits non-zero
- [x] Every added line covered; no regressions against a clean-`main` baseline (the one Windows-only path-separator test failure is pre-existing and unrelated)

## Safety

- [x] Read-only: parses an already-discovered local config; no network, no writes
- [x] Reuses the engine's existing tolerant parser (no new schema surface); a read failure is caught and reported, never thrown
- [x] No secrets, tokens, wallets, trust scores, or reward values in code, tests, or this description

Closes #4873
