### PR TITLE
fix(scripts): build gittensory-engine before typecheck in test:ci/validate

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,11 +81,11 @@
     "test:smoke:observability:metrics": "node scripts/smoke-observability-metrics.mjs",
     "test:smoke:browser:install": "playwright install chromium",
     "test:smoke:browser": "node scripts/smoke-ui-browser.mjs",
-    "test:ci": "git diff --check && npm run actionlint && npm run db:migrations:check && npm run db:schema-drift:check && npm run selfhost:env-reference:check && npm run miner:env-reference:check && npm run selfhost:validate-observability && npm run cf-typegen:check && npm run typecheck && npm run test:coverage && npm run test:engine-parity && npm run test:driver-parity && npm run test --workspace @jsonbored/gittensory-engine && npm run test:workers && npm run build:mcp && npm run test:mcp-pack && npm run build:miner && npm run test:miner-pack && npm run rees:test && npm run ui:openapi:check && npm run ui:openapi:settings-parity && npm run ui:version-audit && npm run docs:drift-check && npm run manifest:drift-check && npm run engine-parity:drift-check && npm run command-reference:check && npm run ui:lint && npm run ui:typecheck && npm run ui:test && npm run ui:build",
+    "test:ci": "git diff --check && npm run actionlint && npm run db:migrations:check && npm run db:schema-drift:check && npm run selfhost:env-reference:check && npm run miner:env-reference:check && npm run selfhost:validate-observability && npm run cf-typegen:check && npm run build --workspace @jsonbored/gittensory-engine && npm run typecheck && npm run test:coverage && npm run test:engine-parity && npm run test:driver-parity && npm run test --workspace @jsonbored/gittensory-engine && npm run test:workers && npm run build:mcp && npm run test:mcp-pack && npm run build:miner && npm run test:miner-pack && npm run rees:test && npm run ui:openapi:check && npm run ui:openapi:settings-parity && npm run ui:version-audit && npm run docs:drift-check && npm run manifest:drift-check && npm run engine-parity:drift-check && npm run command-reference:check && npm run ui:lint && npm run ui:typecheck && npm run ui:test && npm run ui:build",
     "test:release": "npm run test:ci && npm run changelog:check",
     "test:release:mcp": "npm run test:ci",
     "test:watch": "vitest",
-    "validate": "npm run typecheck && npm run test:coverage"
+    "validate": "npm run build --workspace @jsonbored/gittensory-engine && npm run typecheck && npm run test:coverage"
   },
   "dependencies": {
     "@asteasolutions/zod-to-openapi": "^8.5.0",


### PR DESCRIPTION
## Summary
- `@jsonbored/gittensory-engine`'s `dist/` is gitignored and only exists after its own build step. `ci.yml` already builds it before "Typecheck" and "Test with coverage" (its "Build engine package" step, with an explicit comment on why), but the local `test:ci` / `validate` npm scripts never did the same.
- Found while investigating a spurious local `npm run typecheck` failure (`Property 'totalCostUsd' does not exist on type 'IterateLoopResult'`) that did not reproduce on a fresh checkout or in real CI -- root cause: a locally-built `dist/` predating a recent source change to `IterateLoopResult`, which `npm run typecheck` alone can never detect or fix since it never rebuilds the workspace dependency.
- Adds `npm run build --workspace @jsonbored/gittensory-engine` immediately before `npm run typecheck` in both `test:ci` and `validate`, matching CI's actual dependency order.

## Test plan
- [x] `node -e "JSON.parse(...)"` confirms `package.json` stays valid JSON
- [x] Manually reproduced: staled `gittensory-engine`'s dist relative to its source, confirmed `npm run typecheck` alone fails; rebuilding via `npm run build --workspace @jsonbored/gittensory-engine` (the command now inserted into the script) resolves it
- [x] This is a text-only `package.json` script reorder -- no source/behavior change, nothing else to test