### PR TITLE
chore(orb): bump the beta-channel target to 0.6.0

### DIFF
--- a/orb-manifest.json
+++ b/orb-manifest.json
@@ -1,4 +1,4 @@
 {
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "Source of truth for the self-hostable gittensory-orb container image's target release version (ghcr.io/jsonbored/gittensory-selfhost). Bumped by a maintainer when a feat/fix/breaking change since the last stable orb-v tag warrants moving to a new target version -- scripts/orb-release-core.mjs and .github/workflows/orb-beta-release.yml read this file to decide what version the next automated beta snapshot targets. Promoting a beta to a stable orb-vX.Y.Z release is still a manual `git tag` -- this manifest only drives the automated beta channel."
 }


### PR DESCRIPTION
## Summary

`orb-manifest.json`'s version is the sole gate on the fully-unattended ORB beta pipeline (`scripts/orb-release-core.mjs`: `due = commitsSinceLastTag.length > 0 && !targetAlreadyStable`). It still declared `0.5.0`, and `orb-v0.5.0` already shipped as the stable tag yesterday — so `targetAlreadyStable` was true and the beta pipeline correctly refused to cut anything, no matter how many commits landed since.

This is a standalone, manifest-only bump — **not** a `release-orb-stable`-headed PR. That distinction matters: `orb-stable-release-tag.yml` fires on *any* merge of a PR from the `release-orb-stable` branch and immediately tags a real stable release + dispatches the human-gated build. This PR is a plain branch, so merging it only updates the JSON file — `orb-v0.5.0` stays the stable tag, untouched. Once merged, the beta pipeline unblocks and can cut `orb-v0.6.0-beta.1` on its own, fully unattended (confirmed: `release-beta` has zero required reviewers, unlike `release`).

## Test plan

- [x] `npx vitest run test/unit/orb-release.test.ts` — 39/39 passing
- [x] `npm run typecheck` — clean
- [x] One-line data change, no logic touched