### PR TITLE
feat(miner-mcp): governor-decisions read-only MCP tool (#5159)

### DIFF
--- a/packages/gittensory-miner/README.md
+++ b/packages/gittensory-miner/README.md
@@ -147,7 +147,9 @@ It exposes these read-only tools:
 
 - `gittensory_miner_list_plans` / `gittensory_miner_get_plan` (#5161) — read-only access to the persisted plan store (`planId`, plan DAG, status, `updatedAt`) via `listPlans` / `loadPlan`; `list_plans` takes an optional `status` filter, `get_plan` takes a `planId` and returns an explicit `{ planId, found: false }` for an unknown id. These read the store-backed AMS plan store — distinct from ORB's stateless `gittensory_plan_status` tool.
 
-Further AMS-state-reading tools (status/doctor diagnostics, governor ledger) land as follow-up PRs on top of this server.
+- `gittensory_miner_get_governor_decisions` (#5159) — read-only projection of the local governor decision ledger (`ts`, `eventType`, `repoFullName`, `actionClass`, `decision`, `reason`). Uses an explicit named-column SELECT that excludes `payload_json` — and any future column added to that table — **by construction**, so internal/sensitive payload data can never leak through this read surface. Optional `repoFullName` / `type` filters mirror `gittensory-miner governor list`. Read-only — never writes to or mutates the governor ledger.
+
+Further AMS-state-reading tools (status/doctor diagnostics) land as follow-up PRs on top of this server.
 
 ## Version check
 

--- a/packages/gittensory-miner/bin/gittensory-miner-mcp.d.ts
+++ b/packages/gittensory-miner/bin/gittensory-miner-mcp.d.ts
@@ -40,12 +40,21 @@ export interface MinerMcpServerOptions {
     listPlans(filter?: { status?: string | null }): unknown[];
     close(): void;
   };
+  /**
+   * Override the governor-ledger opener (defaults to initGovernorLedger); injection seam for tests. Typed to the
+   * minimal read surface the governor-decisions tool uses (never appendGovernorEvent).
+   */
+  initGovernorLedger?: () => {
+    readGovernorDecisions(filter?: { repoFullName?: string | null }): unknown[];
+    close(): void;
+  };
 }
 
 /**
  * Build the miner MCP server with its tools registered (gittensory_miner_ping,
  * gittensory_miner_get_portfolio_dashboard, gittensory_miner_list_claims, gittensory_miner_get_audit_feed,
- * gittensory_miner_get_run_state, gittensory_miner_list_plans, gittensory_miner_get_plan). `options` supplies
+ * gittensory_miner_get_run_state, gittensory_miner_list_plans, gittensory_miner_get_plan,
+ * gittensory_miner_get_governor_decisions). `options` supplies
  * test injection seams; production callers pass nothing.
  */
 export function createMinerMcpServer(options?: MinerMcpServerOptions): McpServer;

--- a/packages/gittensory-miner/bin/gittensory-miner-mcp.js
+++ b/packages/gittensory-miner/bin/gittensory-miner-mcp.js
@@ -10,6 +10,11 @@ import {
   normalizeAuditFeedMcpFilter,
 } from "../lib/event-ledger-cli.js";
 import { initEventLedger } from "../lib/event-ledger.js";
+import {
+  collectGovernorLedgerDecisions,
+  normalizeGovernorDecisionMcpFilter,
+} from "../lib/governor-ledger-cli.js";
+import { initGovernorLedger } from "../lib/governor-ledger.js";
 import { collectPortfolioDashboard } from "../lib/portfolio-dashboard.js";
 import { initPortfolioQueueStore } from "../lib/portfolio-queue.js";
 import { initRunStateStore } from "../lib/run-state.js";
@@ -28,7 +33,10 @@ import { PLAN_STATUSES, openPlanStore } from "../lib/plan-store.js";
 //     listRunStates (read-only analog of ORB's gittensory_get_automation_state; no state-set mutation).
 //   - gittensory_miner_list_plans / gittensory_miner_get_plan (#5161): read-only access to the persisted
 //     plan store via plan-store.js's listPlans/loadPlan (distinct from ORB's stateless gittensory_plan_status).
-// Remaining AMS-state-reading tools (status/doctor, governor ledger, etc.) land as follow-ups.
+//   - gittensory_miner_get_governor_decisions (#5159): read-only projection of the governor decision ledger via
+//     collectGovernorLedgerDecisions(); an explicit named-column SELECT that excludes payload_json (and any
+//     future column on that table) by construction; same repo/type filters as `governor list`.
+// Remaining AMS-state-reading tools (status/doctor, etc.) land as follow-ups.
 
 // Read the version from this package's own package.json (always shipped) rather than a hand-synced
 // literal, so a release bump never has a second place to forget -- same approach as the mcp harness.
@@ -211,6 +219,44 @@ export function createMinerMcpServer(options = {}) {
         return { content: [{ type: "text", text: JSON.stringify(result) }] };
       } finally {
         if (ownsStore) store.close();
+      }
+    },
+  );
+  server.registerTool(
+    "gittensory_miner_get_governor_decisions",
+    {
+      description:
+        "Read-only projection of the local governor decision ledger: ts, eventType, repoFullName, actionClass, " +
+        "decision, reason per row. Uses an explicit named-column SELECT that excludes payload_json -- and any " +
+        "future column added to that table -- BY CONSTRUCTION, so internal/sensitive payload data is never " +
+        "returned. Optional repoFullName/type filters mirror `gittensory-miner governor list`. Never writes to " +
+        "or mutates the governor ledger.",
+      inputSchema: {
+        repoFullName: z.string().min(1).optional(),
+        type: z.string().min(1).optional(),
+      },
+    },
+    async (input) => {
+      const ownsLedger = options.initGovernorLedger === undefined;
+      const governorLedger = (options.initGovernorLedger ?? initGovernorLedger)();
+      try {
+        const filter = normalizeGovernorDecisionMcpFilter(input ?? {});
+        const feed = collectGovernorLedgerDecisions(governorLedger, filter);
+        return { content: [{ type: "text", text: JSON.stringify(feed) }] };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: JSON.stringify({
+                error: error instanceof Error ? error.message : String(error),
+              }),
+            },
+          ],
+          isError: true,
+        };
+      } finally {
+        if (ownsLedger) governorLedger.close();
       }
     },
   );

--- a/packages/gittensory-miner/lib/governor-ledger-cli.d.ts
+++ b/packages/gittensory-miner/lib/governor-ledger-cli.d.ts
@@ -1,4 +1,4 @@
-import type { GovernorLedger, GovernorLedgerEntry } from "./governor-ledger.js";
+import type { GovernorDecisionEntry, GovernorLedger, GovernorLedgerEntry } from "./governor-ledger.js";
 
 export type GovernorLedgerEventType = "allowed" | "denied" | "throttled" | "kill_switch";
 
@@ -16,6 +16,33 @@ export function filterGovernorEvents(
   events: GovernorLedgerEntry[],
   options?: { type?: string | null },
 ): GovernorLedgerEntry[];
+
+export const GOVERNOR_DECISION_ENTRY_FIELDS: readonly [
+  "ts",
+  "eventType",
+  "repoFullName",
+  "actionClass",
+  "decision",
+  "reason",
+];
+
+export type GovernorDecisionMcpFilterInput = {
+  repoFullName?: string | null;
+  type?: string | null;
+};
+
+export function normalizeGovernorDecisionMcpFilter(input?: GovernorDecisionMcpFilterInput): {
+  repoFullName: string | null;
+  type: GovernorLedgerEventType | null;
+};
+
+export function collectGovernorLedgerDecisions(
+  governorLedger: Pick<GovernorLedger, "readGovernorDecisions">,
+  filter?: { repoFullName?: string | null; type?: string | null },
+): {
+  repoFullName?: string;
+  decisions: GovernorDecisionEntry[];
+};
 
 export function renderGovernorTable(events: GovernorLedgerEntry[]): string;
 

--- a/packages/gittensory-miner/lib/governor-ledger-cli.js
+++ b/packages/gittensory-miner/lib/governor-ledger-cli.js
@@ -66,6 +66,58 @@ export function filterGovernorEvents(events, options = {}) {
   return events.filter((entry) => entry.eventType === type);
 }
 
+/** Decision-log columns exposed by the governor-decisions MCP tool (#5159) -- never payload_json. */
+export const GOVERNOR_DECISION_ENTRY_FIELDS = Object.freeze([
+  "ts",
+  "eventType",
+  "repoFullName",
+  "actionClass",
+  "decision",
+  "reason",
+]);
+
+/**
+ * Normalize optional MCP/JSON filter args for the governor-decisions tool into the shape `governor list`
+ * already supports (repo + event type). Mirrors normalizeAuditFeedMcpFilter's validation style (#5159).
+ */
+export function normalizeGovernorDecisionMcpFilter(input = {}) {
+  if (input === null || typeof input !== "object" || Array.isArray(input)) {
+    throw new Error("filter must be an object");
+  }
+  const filter = { repoFullName: null, type: null };
+  if (input.repoFullName !== undefined && input.repoFullName !== null) {
+    const repo = parseRepoArg(String(input.repoFullName), "repoFullName must be in owner/repo form.");
+    if ("error" in repo) throw new Error(repo.error);
+    filter.repoFullName = repo.repoFullName;
+  }
+  if (input.type !== undefined && input.type !== null) {
+    const trimmed = String(input.type).trim();
+    if (!GOVERNOR_LEDGER_EVENT_TYPES.includes(trimmed)) {
+      throw new Error(
+        `Invalid type: ${trimmed}. Expected one of ${GOVERNOR_LEDGER_EVENT_TYPES.join(", ")}.`,
+      );
+    }
+    filter.type = trimmed;
+  }
+  return filter;
+}
+
+/**
+ * Read-only governor decision-log projection shared by the MCP governor-decisions tool (#5159). Reads through
+ * the ledger's explicit-column readGovernorDecisions() (payload_json excluded by construction) and applies the
+ * same optional event-type filter `governor list` supports.
+ */
+export function collectGovernorLedgerDecisions(governorLedger, filter = {}) {
+  const decisions = filterGovernorEvents(
+    governorLedger.readGovernorDecisions({ repoFullName: filter.repoFullName }),
+    { type: filter.type },
+  );
+  return {
+    ...(filter.repoFullName ? { repoFullName: filter.repoFullName } : {}),
+    decisions,
+  };
+}
+
 function display(value) {
   if (value === null || value === undefined) return "-";
   return String(value);

--- a/packages/gittensory-miner/lib/governor-ledger.d.ts
+++ b/packages/gittensory-miner/lib/governor-ledger.d.ts
@@ -22,10 +22,24 @@ export type ReadGovernorEventsFilter = {
   repoFullName?: string | null;
 };
 
+export type ReadGovernorDecisionsFilter = {
+  repoFullName?: string | null;
+};
+
+export type GovernorDecisionEntry = {
+  ts: string;
+  eventType: string;
+  repoFullName: string | null;
+  actionClass: string;
+  decision: string;
+  reason: string;
+};
+
 export type GovernorLedger = {
   dbPath: string;
   appendGovernorEvent(event: AppendGovernorEventInput): GovernorLedgerEntry;
   readGovernorEvents(filter?: ReadGovernorEventsFilter): GovernorLedgerEntry[];
+  readGovernorDecisions(filter?: ReadGovernorDecisionsFilter): GovernorDecisionEntry[];
   close(): void;
 };
 

--- a/packages/gittensory-miner/lib/governor-ledger.js
+++ b/packages/gittensory-miner/lib/governor-ledger.js
@@ -67,6 +67,22 @@ function rowToEntry(row) {
 }
 
 /**
+ * Projects one governor_events row selected via the decision-only column allowlist (no payload_json) into the
+ * public decision-log shape. Kept separate from rowToEntry (which also parses payload) so this read path can
+ * never surface the payload column by construction (#5159).
+ */
+function decisionRowToEntry(row) {
+  return {
+    ts: row.ts,
+    eventType: row.event_type,
+    repoFullName: row.repo_full_name,
+    actionClass: row.action_class,
+    decision: row.decision,
+    reason: row.reason,
+  };
+}
+
+/**
  * Opens the append-only governor ledger, creating the table on first use. Rows are returned in ascending `id`
  * order (insertion order). (#2328)
  */
@@ -103,6 +119,14 @@ export function initGovernorLedger(dbPath = resolveGovernorLedgerDbPath()) {
   const readByRepoStatement = db.prepare(
     "SELECT * FROM governor_events WHERE repo_full_name = ? ORDER BY id ASC",
   );
+  // Decision-log projection (#5159): an explicit named-column SELECT so payload_json (and any future column
+  // added to this table, e.g. by #5134) is excluded from this read path BY CONSTRUCTION, never by post-filter.
+  const readAllDecisionsStatement = db.prepare(
+    "SELECT ts, event_type, repo_full_name, action_class, decision, reason FROM governor_events ORDER BY id ASC",
+  );
+  const readByRepoDecisionsStatement = db.prepare(
+    "SELECT ts, event_type, repo_full_name, action_class, decision, reason FROM governor_events WHERE repo_full_name = ? ORDER BY id ASC",
+  );
 
   return {
     dbPath: resolvedPath,
@@ -127,6 +151,14 @@ export function initGovernorLedger(dbPath = resolveGovernorLedgerDbPath()) {
           ? readAllStatement.all()
           : readByRepoStatement.all(repoFullName);
       return rows.map(rowToEntry);
+    },
+    readGovernorDecisions(filter = {}) {
+      const repoFullName = normalizeOptionalRepoFullName(filter.repoFullName);
+      const rows =
+        repoFullName === undefined
+          ? readAllDecisionsStatement.all()
+          : readByRepoDecisionsStatement.all(repoFullName);
+      return rows.map(decisionRowToEntry);
     },
     close() {
       db.close();

--- a/test/unit/miner-mcp-governor-decisions.test.ts
+++ b/test/unit/miner-mcp-governor-decisions.test.ts
@@ -1,0 +1,301 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@jsonbored/gittensory-engine", async () => {
+  return import("../../packages/gittensory-engine/src/index");
+});
+
+import { createMinerMcpServer } from "../../packages/gittensory-miner/bin/gittensory-miner-mcp.js";
+import {
+  closeDefaultGovernorLedger,
+  initGovernorLedger,
+} from "../../packages/gittensory-miner/lib/governor-ledger.js";
+import {
+  collectGovernorLedgerDecisions,
+  GOVERNOR_DECISION_ENTRY_FIELDS,
+  normalizeGovernorDecisionMcpFilter,
+} from "../../packages/gittensory-miner/lib/governor-ledger-cli.js";
+
+type Content = { content: Array<{ type: string; text?: string }>; isError?: boolean };
+
+const roots: string[] = [];
+const ledgers: Array<{ close(): void }> = [];
+
+function tempLedger() {
+  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-mcp-governor-decisions-"));
+  roots.push(root);
+  const ledger = initGovernorLedger(join(root, "governor-ledger.sqlite3"));
+  ledgers.push(ledger);
+  return ledger;
+}
+
+afterEach(() => {
+  for (const ledger of ledgers.splice(0)) ledger.close();
+  closeDefaultGovernorLedger();
+  vi.restoreAllMocks();
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+async function connectedClient(governorLedger: ReturnType<typeof initGovernorLedger>): Promise<Client> {
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "miner-mcp-governor-decisions-test", version: "0.0.0" });
+  await Promise.all([
+    createMinerMcpServer({ initGovernorLedger: () => governorLedger }).connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
+  return client;
+}
+
+function toolText(result: Content): string {
+  const first = result.content[0];
+  if (!first || first.type !== "text" || typeof first.text !== "string") {
+    throw new Error("expected a single text content block");
+  }
+  return first.text;
+}
+
+// Seeds two acme/widgets rows (allowed, denied) and one acme/other row. Every payload carries a would-be-secret
+// blob plus the exact field names #5134 is adding to payload_json (reputation / self_plagiarism / budget), so a
+// leak of any of them through the projection is caught by the invariant tests below.
+function seedDecisions(governorLedger: ReturnType<typeof initGovernorLedger>) {
+  governorLedger.appendGovernorEvent({
+    eventType: "allowed",
+    repoFullName: "acme/widgets",
+    actionClass: "analyze",
+    decision: "allow",
+    reason: "within budget",
+    payload: { rule: "budget_ok", secretBlob: "must-not-leak" },
+  });
+  governorLedger.appendGovernorEvent({
+    eventType: "denied",
+    repoFullName: "acme/widgets",
+    actionClass: "write",
+    decision: "block",
+    reason: "kill switch active",
+    payload: { rule: "global_kill_switch", reputation: 0.1, budget: 5, self_plagiarism: true },
+  });
+  governorLedger.appendGovernorEvent({
+    eventType: "denied",
+    repoFullName: "acme/other",
+    actionClass: "write",
+    decision: "block",
+    reason: "other repo",
+    payload: { rule: "house_rule" },
+  });
+}
+
+describe("governor ledger decision projection (#5159)", () => {
+  it("readGovernorDecisions returns the six decision columns only and never the payload (by construction)", () => {
+    const ledger = tempLedger();
+    seedDecisions(ledger);
+    const decisions = ledger.readGovernorDecisions();
+    expect(decisions).toEqual([
+      {
+        ts: expect.any(String),
+        eventType: "allowed",
+        repoFullName: "acme/widgets",
+        actionClass: "analyze",
+        decision: "allow",
+        reason: "within budget",
+      },
+      {
+        ts: expect.any(String),
+        eventType: "denied",
+        repoFullName: "acme/widgets",
+        actionClass: "write",
+        decision: "block",
+        reason: "kill switch active",
+      },
+      {
+        ts: expect.any(String),
+        eventType: "denied",
+        repoFullName: "acme/other",
+        actionClass: "write",
+        decision: "block",
+        reason: "other repo",
+      },
+    ]);
+    for (const decision of decisions) {
+      expect(Object.keys(decision).sort()).toEqual([...GOVERNOR_DECISION_ENTRY_FIELDS].sort());
+      expect(JSON.stringify(decision)).not.toContain("payload");
+      expect(JSON.stringify(decision)).not.toContain("must-not-leak");
+    }
+  });
+
+  it("readGovernorDecisions filters by repo via the explicit-column SELECT (repo branch)", () => {
+    const ledger = tempLedger();
+    seedDecisions(ledger);
+    expect(ledger.readGovernorDecisions({ repoFullName: "acme/other" }).map((d) => d.reason)).toEqual([
+      "other repo",
+    ]);
+  });
+
+  it("readGovernorDecisions returns an empty array before any append", () => {
+    const ledger = tempLedger();
+    expect(ledger.readGovernorDecisions({ repoFullName: "acme/widgets" })).toEqual([]);
+  });
+});
+
+describe("normalizeGovernorDecisionMcpFilter (#5159)", () => {
+  it("defaults to null filters when no input is given", () => {
+    expect(normalizeGovernorDecisionMcpFilter()).toEqual({ repoFullName: null, type: null });
+  });
+
+  it("mirrors governor list repo + type filter semantics", () => {
+    expect(normalizeGovernorDecisionMcpFilter({ repoFullName: "acme/widgets", type: "denied" })).toEqual({
+      repoFullName: "acme/widgets",
+      type: "denied",
+    });
+  });
+
+  it("treats explicit null repo/type as unset", () => {
+    expect(normalizeGovernorDecisionMcpFilter({ repoFullName: null, type: null })).toEqual({
+      repoFullName: null,
+      type: null,
+    });
+  });
+
+  it("rejects a non-object filter, a bad repo, and an unknown event type", () => {
+    expect(() =>
+      normalizeGovernorDecisionMcpFilter(null as unknown as Record<string, unknown>),
+    ).toThrow("filter must be an object");
+    expect(() =>
+      normalizeGovernorDecisionMcpFilter(42 as unknown as Record<string, unknown>),
+    ).toThrow("filter must be an object");
+    expect(() =>
+      normalizeGovernorDecisionMcpFilter([] as unknown as Record<string, unknown>),
+    ).toThrow("filter must be an object");
+    expect(() => normalizeGovernorDecisionMcpFilter({ repoFullName: "bad" })).toThrow(
+      "Repository must be in owner/repo form.",
+    );
+    expect(() => normalizeGovernorDecisionMcpFilter({ type: "bogus" })).toThrow(/Invalid type/);
+  });
+});
+
+describe("collectGovernorLedgerDecisions (#5159)", () => {
+  it("wraps decisions without a repoFullName key when no repo filter is set (default filter)", () => {
+    const ledger = tempLedger();
+    seedDecisions(ledger);
+    const feed = collectGovernorLedgerDecisions(ledger);
+    expect(feed).not.toHaveProperty("repoFullName");
+    expect(feed.decisions.map((d) => d.eventType)).toEqual(["allowed", "denied", "denied"]);
+  });
+
+  it("includes the repoFullName key and applies the type filter when both are set", () => {
+    const ledger = tempLedger();
+    seedDecisions(ledger);
+    const feed = collectGovernorLedgerDecisions(ledger, { repoFullName: "acme/widgets", type: "denied" });
+    expect(feed.repoFullName).toBe("acme/widgets");
+    expect(feed.decisions.map((d) => d.reason)).toEqual(["kill switch active"]);
+  });
+});
+
+describe("gittensory_miner_get_governor_decisions (#5159)", () => {
+  it("is registered on the miner MCP server", async () => {
+    const ledger = tempLedger();
+    const client = await connectedClient(ledger);
+    const { tools } = await client.listTools();
+    expect(tools.map((tool) => tool.name)).toContain("gittensory_miner_get_governor_decisions");
+  });
+
+  it("returns decision-log rows with repo + type filters", async () => {
+    const ledger = tempLedger();
+    seedDecisions(ledger);
+    const client = await connectedClient(ledger);
+    const result = (await client.callTool({
+      name: "gittensory_miner_get_governor_decisions",
+      arguments: { repoFullName: "acme/widgets", type: "denied" },
+    })) as Content;
+    const payload = JSON.parse(toolText(result));
+    expect(payload.repoFullName).toBe("acme/widgets");
+    expect(payload.decisions).toEqual([
+      {
+        ts: expect.any(String),
+        eventType: "denied",
+        repoFullName: "acme/widgets",
+        actionClass: "write",
+        decision: "block",
+        reason: "kill switch active",
+      },
+    ]);
+  });
+
+  it("returns an empty decisions array for an empty ledger", async () => {
+    const ledger = tempLedger();
+    const client = await connectedClient(ledger);
+    const result = (await client.callTool({
+      name: "gittensory_miner_get_governor_decisions",
+      arguments: {},
+    })) as Content;
+    expect(JSON.parse(toolText(result))).toEqual({ decisions: [] });
+  });
+
+  it("is structurally identical to collectGovernorLedgerDecisions() — the wrapper adds no drift (invariant)", async () => {
+    const ledger = tempLedger();
+    seedDecisions(ledger);
+    const filter = normalizeGovernorDecisionMcpFilter({ repoFullName: "acme/widgets" });
+    const client = await connectedClient(ledger);
+    const result = (await client.callTool({
+      name: "gittensory_miner_get_governor_decisions",
+      arguments: { repoFullName: "acme/widgets" },
+    })) as Content;
+    expect(JSON.parse(toolText(result))).toEqual(collectGovernorLedgerDecisions(ledger, filter));
+  });
+
+  it("never exposes payload_json or the #5134 payload fields (reputation / self-plagiarism / budget) (invariant)", async () => {
+    const ledger = tempLedger();
+    seedDecisions(ledger);
+    const client = await connectedClient(ledger);
+    const result = (await client.callTool({
+      name: "gittensory_miner_get_governor_decisions",
+      arguments: {},
+    })) as Content;
+    const payload = JSON.parse(toolText(result));
+    for (const decision of payload.decisions) {
+      expect(Object.keys(decision).sort()).toEqual([...GOVERNOR_DECISION_ENTRY_FIELDS].sort());
+      for (const banned of [
+        "payload_json",
+        "payload",
+        "reputation",
+        "selfPlagiarism",
+        "self_plagiarism",
+        "budget",
+      ]) {
+        expect(decision).not.toHaveProperty(banned);
+      }
+    }
+    const serialized = JSON.stringify(payload);
+    expect(serialized).not.toContain("must-not-leak");
+    expect(serialized).not.toContain("self_plagiarism");
+    expect(serialized).not.toContain("reputation");
+  });
+
+  it("only reads — never reaches a mutating governor-ledger method (invariant)", async () => {
+    const ledger = tempLedger();
+    seedDecisions(ledger);
+    const readGovernorDecisions = vi.spyOn(ledger, "readGovernorDecisions");
+    const appendGovernorEvent = vi.spyOn(ledger, "appendGovernorEvent");
+    const client = await connectedClient(ledger);
+    await client.callTool({
+      name: "gittensory_miner_get_governor_decisions",
+      arguments: { type: "denied" },
+    });
+    expect(readGovernorDecisions).toHaveBeenCalled();
+    expect(appendGovernorEvent).not.toHaveBeenCalled();
+  });
+
+  it("returns an MCP error for an unknown event type", async () => {
+    const ledger = tempLedger();
+    const client = await connectedClient(ledger);
+    const result = (await client.callTool({
+      name: "gittensory_miner_get_governor_decisions",
+      arguments: { type: "bogus" },
+    })) as Content;
+    expect(result.isError).toBe(true);
+    expect(toolText(result)).toMatch(/Invalid type/i);
+  });
+});

--- a/test/unit/miner-mcp-scaffold.test.ts
+++ b/test/unit/miner-mcp-scaffold.test.ts
@@ -92,6 +92,7 @@ describe("gittensory-miner MCP server (#5153 scaffold)", () => {
     const { tools } = await client.listTools();
     expect(tools.map((tool) => tool.name).sort()).toEqual([
       "gittensory_miner_get_audit_feed",
+      "gittensory_miner_get_governor_decisions",
       "gittensory_miner_get_plan",
       "gittensory_miner_get_portfolio_dashboard",
       "gittensory_miner_get_run_state",


### PR DESCRIPTION
Adds `gittensory_miner_get_governor_decisions`, a read-only MCP tool on
`gittensory-miner-mcp` exposing the local governor decision ledger as a
metadata-only projection: `ts`, `eventType`, `repoFullName`, `actionClass`,
`decision`, `reason` per row.

The projection excludes `payload_json` BY CONSTRUCTION: a new explicit
named-column read path (`readGovernorDecisions`) on governor-ledger.js selects
only the six decision columns -- never `SELECT *` -- so the sensitive payload
column (which #5134 is actively expanding with reputation/self-plagiarism/budget
state) can never leak through this surface, verified by a dedicated invariant
test. Optional `repoFullName`/`type` filters mirror `gittensory-miner governor
list`; the ledger write path and governor decision logic are untouched.

Closes #5159

