### PR TITLE
docs(miner): document MINER_CODING_AGENT_* env vars in README and DEPLOYMENT.md

### DIFF
--- a/packages/gittensory-miner/DEPLOYMENT.md
+++ b/packages/gittensory-miner/DEPLOYMENT.md
@@ -95,6 +95,8 @@ sudo systemctl enable --now gittensory-miner.service
 
 Because `loop` is a **long-running daemon that schedules its own cycles**, it is a persistent `Type=simple` service (with `Restart=on-failure`) — **not** a oneshot unit driven by a `.timer`, unlike the periodic `gittensory-docker-prune.*.example` hygiene job in [`systemd/`](../../systemd/). Keep `GITHUB_TOKEN` (and any coding-agent credentials) in a root-owned `0600` `EnvironmentFile`, never in the unit file. Follow the loop with `journalctl -u gittensory-miner -f`; `systemctl stop` sends SIGTERM, which the loop handles cleanly at its next kill-switch check.
 
+Set the coding-agent provider/model/timeout in that same `EnvironmentFile` — see [README.md § Coding-agent driver configuration](README.md#coding-agent-driver-configuration) for the full `MINER_CODING_AGENT_*` env var reference (accepted provider names, per-provider model vars, the shared CLI timeout).
+
 ## Invariants
 
 - Core miner bookkeeping (claims, plans, queues, ledgers) works offline after install.

--- a/packages/gittensory-miner/README.md
+++ b/packages/gittensory-miner/README.md
@@ -128,6 +128,19 @@ gittensory-miner manage status [--json]
 gittensory-miner manage poll <owner/repo> <pr#> [--branch <name>] [--json]
 ```
 
+## Coding-agent driver configuration
+
+The real coding-agent driver `gittensory-miner attempt`/`loop` runs (#4289) is selected and tuned entirely through env vars:
+
+| Env var | Purpose | Accepted values / default |
+| --- | --- | --- |
+| `MINER_CODING_AGENT_PROVIDER` | Comma-separated provider list; the first *known* name wins (deny-by-default on an unrecognized name). | `noop`, `claude-cli`, `codex-cli`, `agent-sdk`. Default: unset — no provider resolves, so a real attempt fails closed instead of silently picking one. |
+| `MINER_CODING_AGENT_CLAUDE_MODEL` | Model passed to the `claude-cli` provider's `--model` flag. Ignored by every other provider. | Default: unset — the `claude` CLI's own default model. |
+| `MINER_CODING_AGENT_CODEX_MODEL` | Model passed to the `codex-cli` provider's `-m`/`--model` flag (inserted after the `exec` subcommand). Ignored by every other provider. | Default: unset — the `codex` CLI's own default model. |
+| `MINER_CODING_AGENT_TIMEOUT_MS` | Wall-clock kill timeout shared by both CLI providers (`claude-cli`/`codex-cli`); ignored by `noop`/`agent-sdk`. Must be a positive integer or it's ignored. | Default: `120000` (2 minutes). |
+
+See [`docs/coding-agent-driver.md`](docs/coding-agent-driver.md) for how the driver seam itself works (the `CodingAgentDriver` interface, dry-run/paused semantics, the attempt lifecycle) — this section is only the operator-facing "how do I configure it" reference.
+
 ## MCP server
 
 The package ships a second bin entry, `gittensory-miner-mcp`, a minimal [Model Context Protocol](https://modelcontextprotocol.io) stdio server that any MCP-compatible client can connect to:

--- a/test/unit/miner-coding-agent-env-doc.test.ts
+++ b/test/unit/miner-coding-agent-env-doc.test.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import { CODING_AGENT_DRIVER_CONFIG_ENV, CODING_AGENT_DRIVER_NAMES } from "../../packages/gittensory-engine/src/index";
+
+const README_PATH = join(process.cwd(), "packages/gittensory-miner/README.md");
+const DEPLOYMENT_PATH = join(process.cwd(), "packages/gittensory-miner/DEPLOYMENT.md");
+const CLI_SUBPROCESS_DRIVER_PATH = join(
+  process.cwd(),
+  "packages/gittensory-engine/src/miner/cli-subprocess-driver.ts",
+);
+
+// Every env var CODING_AGENT_DRIVER_CONFIG_ENV actually declares as consumed, across every provider --
+// this is the same set driver-factory.ts's own header comment says is "the source of truth" (#5172).
+const CONFIGURED_ENV_VAR_NAMES = [
+  ...new Set(
+    Object.values(CODING_AGENT_DRIVER_CONFIG_ENV).flatMap((entry) => Object.values(entry).filter((v) => v !== undefined)),
+  ),
+];
+
+describe("miner coding-agent driver env var docs (#5172)", () => {
+  it("documents MINER_CODING_AGENT_PROVIDER and every per-provider env var driver-factory.ts declares", () => {
+    const readme = readFileSync(README_PATH, "utf8");
+    expect(readme).toContain("## Coding-agent driver configuration");
+    expect(readme).toContain("MINER_CODING_AGENT_PROVIDER");
+    for (const envVar of CONFIGURED_ENV_VAR_NAMES) {
+      expect(readme).toContain(envVar);
+    }
+  });
+
+  it("documents every accepted MINER_CODING_AGENT_PROVIDER value from CODING_AGENT_DRIVER_NAMES", () => {
+    const readme = readFileSync(README_PATH, "utf8");
+    for (const name of CODING_AGENT_DRIVER_NAMES) {
+      expect(readme).toContain(`\`${name}\``);
+    }
+  });
+
+  it("documents the real default CLI timeout from cli-subprocess-driver.ts", () => {
+    const driverSource = readFileSync(CLI_SUBPROCESS_DRIVER_PATH, "utf8");
+    const match = driverSource.match(/DEFAULT_TIMEOUT_MS\s*=\s*(\d[\d_]*)/);
+    expect(match).not.toBeNull();
+    const defaultTimeoutMs = Number((match?.[1] ?? "").replaceAll("_", ""));
+    expect(defaultTimeoutMs).toBeGreaterThan(0);
+
+    const readme = readFileSync(README_PATH, "utf8");
+    expect(readme).toContain(`\`${defaultTimeoutMs}\``);
+  });
+
+  it("cross-references the README's env var section from DEPLOYMENT.md instead of duplicating it", () => {
+    const deployment = readFileSync(DEPLOYMENT_PATH, "utf8");
+    expect(deployment).toContain("README.md#coding-agent-driver-configuration");
+  });
+
+  it("cross-references docs/coding-agent-driver.md rather than duplicating its interface-level content", () => {
+    const readme = readFileSync(README_PATH, "utf8");
+    const section = readme.slice(
+      readme.indexOf("## Coding-agent driver configuration"),
+      readme.indexOf("## MCP server"),
+    );
+    expect(section).toContain("docs/coding-agent-driver.md");
+  });
+});


### PR DESCRIPTION
## Summary
- The coding-agent driver (`MINER_CODING_AGENT_PROVIDER`, `MINER_CODING_AGENT_CLAUDE_MODEL`, `MINER_CODING_AGENT_CODEX_MODEL`, `MINER_CODING_AGENT_TIMEOUT_MS`) is already production-wired via `driver-factory.ts`, but neither `packages/gittensory-miner/README.md` nor `DEPLOYMENT.md` mentioned any of these four env vars — only `docs/coding-agent-driver.md`'s interface-level documentation existed, leaving a real operator-facing setup gap.
- Adds a new "Coding-agent driver configuration" section to `README.md`: all four vars, accepted values (`noop`/`claude-cli`/`codex-cli`/`agent-sdk`) and defaults, cross-referencing `docs/coding-agent-driver.md` for the internal driver-seam documentation instead of duplicating it.
- Cross-references that new section from `DEPLOYMENT.md`'s bare-host/systemd walkthrough (where operators already set `GITHUB_TOKEN` and coding-agent credentials) rather than duplicating the table there.
- No source or runtime behavior changes — documentation only.

## Test plan
- [x] New `test/unit/miner-coding-agent-env-doc.test.ts`: imports `CODING_AGENT_DRIVER_NAMES`/`CODING_AGENT_DRIVER_CONFIG_ENV` directly from `packages/gittensory-engine/src/index` and asserts the README documents every accepted provider name and every declared per-provider env var; reads the real `DEFAULT_TIMEOUT_MS` out of `cli-subprocess-driver.ts` and asserts the documented default matches it; asserts the `DEPLOYMENT.md` cross-reference and the `docs/coding-agent-driver.md` cross-reference both exist. Fails if the docs and the real driver-factory source ever drift apart.
- [x] `npm run typecheck` passes.
- [x] `npm run docs:drift-check` passes.
- [x] Targeted vitest run of the new/adjacent doc tests passes.

Closes #5172