### PR TITLE
docs(miner): document coding-agent env vars

### DIFF
--- a/packages/gittensory-miner/DEPLOYMENT.md
+++ b/packages/gittensory-miner/DEPLOYMENT.md
@@ -10,6 +10,19 @@ Two form factors for running `@jsonbored/gittensory-miner`: **laptop mode** (sin
 | **Setup**        | `npm install -g @jsonbored/gittensory-miner` or workspace build                                | `docker build` + `docker run` with env + volume (see below)                       |
 | **Footprint**    | One Node process, local disk for ledgers/queues                                                | One container per worker; scale horizontally by adding containers                 |
 
+## Coding-agent provider configuration
+
+For provider selection and model/timeout knobs, see the README section on
+[coding-agent driver configuration](README.md#coding-agent-driver-configuration) and the
+interface-level contract in [`docs/coding-agent-driver.md`](docs/coding-agent-driver.md).
+The short version is:
+
+- `MINER_CODING_AGENT_PROVIDER` is a comma-separated preference list; the first configured name wins.
+- Valid provider names are `noop`, `claude-cli`, `codex-cli`, and `agent-sdk`.
+- `MINER_CODING_AGENT_CLAUDE_MODEL` and `MINER_CODING_AGENT_CODEX_MODEL` only affect their matching CLI providers.
+- `MINER_CODING_AGENT_TIMEOUT_MS` only affects the CLI providers and falls back to `120000` ms when unset or invalid.
+- `noop` and `agent-sdk` ignore the model and timeout knobs.
+
 ## Laptop mode walkthrough
 
 1. Install Node.js 22.13+ and the package:

--- a/packages/gittensory-miner/README.md
+++ b/packages/gittensory-miner/README.md
@@ -114,6 +114,20 @@ npm --workspace @jsonbored/gittensory-miner run build
 npm link --workspace @jsonbored/gittensory-miner
 ```
 
+### Coding-agent driver configuration
+
+The production driver is selected by `MINER_CODING_AGENT_PROVIDER`. The value is a comma-separated preference list:
+the first configured name wins, unknown names are skipped, and an empty/unset list leaves production driver
+construction fail-closed. See [`docs/coding-agent-driver.md`](docs/coding-agent-driver.md) for the interface-level
+contract and provider behavior.
+
+| Env var | Accepted values | Default / behavior |
+| --- | --- | --- |
+| `MINER_CODING_AGENT_PROVIDER` | `noop`, `claude-cli`, `codex-cli`, `agent-sdk` | Unset / empty means no provider is configured; the miner fails closed until a valid provider name is supplied. |
+| `MINER_CODING_AGENT_CLAUDE_MODEL` | Any Claude model string accepted by the local `claude` CLI | Unset means `claude-cli` uses the CLI's own default model. Ignored by `noop`, `codex-cli`, and `agent-sdk`. |
+| `MINER_CODING_AGENT_CODEX_MODEL` | Any Codex model string accepted by the local `codex` CLI | Unset means `codex-cli` uses the CLI's own default model. Ignored by `noop`, `claude-cli`, and `agent-sdk`. |
+| `MINER_CODING_AGENT_TIMEOUT_MS` | Positive integer milliseconds | Unset or invalid falls back to the CLI driver's default wall-clock timeout of `120000` ms. Ignored by `noop` and `agent-sdk`. |
+
 ## Commands
 
 ```sh


### PR DESCRIPTION
## Summary

- Document the miner's coding-agent provider env vars in the README and DEPLOYMENT guide.
- Cross-reference the interface-level contract in `docs/coding-agent-driver.md`.
- Closes #5172.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [ ] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Docs-only change; the remaining application/build/test checks are not applicable to this patch.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — docs-only Markdown updates; no screenshots are needed.

## Notes

- Updated `packages/gittensory-miner/README.md` and `packages/gittensory-miner/DEPLOYMENT.md`.
- Refers readers to `docs/coding-agent-driver.md` for the interface contract.
