### PR TITLE
feat(miner): retry a transient 5xx in the discovery fanout

### DIFF
--- a/packages/gittensory-miner/lib/opportunity-fanout.d.ts
+++ b/packages/gittensory-miner/lib/opportunity-fanout.d.ts
@@ -38,6 +38,7 @@ export function fetchCandidateIssuesWithSummary(
     apiBaseUrl?: string;
     concurrency?: number;
     perPage?: number;
+    sleepFn?: (ms: number) => Promise<unknown>;
   },
 ): Promise<CandidateIssueSummary>;
 
@@ -48,6 +49,7 @@ export function fetchCandidateIssues(
     apiBaseUrl?: string;
     concurrency?: number;
     perPage?: number;
+    sleepFn?: (ms: number) => Promise<unknown>;
   },
 ): Promise<RawCandidateIssue[]>;
 
@@ -58,6 +60,7 @@ export function searchCandidateIssuesWithSummary(
     apiBaseUrl?: string;
     concurrency?: number;
     perPage?: number;
+    sleepFn?: (ms: number) => Promise<unknown>;
   },
 ): Promise<CandidateIssueSummary>;
 
@@ -68,5 +71,6 @@ export function searchCandidateIssues(
     apiBaseUrl?: string;
     concurrency?: number;
     perPage?: number;
+    sleepFn?: (ms: number) => Promise<unknown>;
   },
 ): Promise<RawCandidateIssue[]>;

--- a/packages/gittensory-miner/lib/opportunity-fanout.js
+++ b/packages/gittensory-miner/lib/opportunity-fanout.js
@@ -1,5 +1,6 @@
 import { Buffer } from "node:buffer";
 import { resolveAiPolicyVerdict } from "@jsonbored/gittensory-engine";
+import { fetchWithRetry } from "./http-retry.js";
 
 const defaultApiBaseUrl = "https://api.github.com";
 const defaultConcurrency = 5;
@@ -101,11 +102,15 @@ function recordRateLimit(summary, response) {
   }
 }
 
-async function githubGetJson(url, githubToken, summary) {
-  const response = await fetch(url, {
-    method: "GET",
-    headers: githubHeaders(githubToken),
-  });
+async function githubGetJson(url, githubToken, summary, options) {
+  // Retry a transient 5xx from GitHub before dropping this target's results for the whole run (#4830) — the same
+  // discipline as the CI/gate-verdict pollers. A thrown network error still propagates to each caller's try/catch.
+  const response = await fetchWithRetry(
+    fetch,
+    url,
+    { method: "GET", headers: githubHeaders(githubToken) },
+    { sleepFn: options?.sleepFn },
+  );
   recordRateLimit(summary, response);
   const payload = await response.json().catch(() => null);
   return { response, payload };
@@ -130,7 +135,7 @@ async function fetchRepoDoc(target, path, githubToken, options, summary, warning
     repoPath(target, `/contents/${encodeURIComponent(path)}`),
   );
   try {
-    const { response, payload } = await githubGetJson(url, githubToken, summary);
+    const { response, payload } = await githubGetJson(url, githubToken, summary, options);
     if (response.status === 404) return null;
     if (!response.ok) {
       warnings.push(warning(target, `policy:${path}`, `GitHub returned ${response.status}`));
@@ -212,7 +217,7 @@ async function fetchTargetIssues(target, githubToken, options, summary, warnings
     `?state=open&per_page=${options.perPage}`,
   );
   try {
-    const { response, payload } = await githubGetJson(url, githubToken, summary);
+    const { response, payload } = await githubGetJson(url, githubToken, summary, options);
     if (!response.ok) {
       warnings.push(warning(target, "issues", `GitHub returned ${response.status}`));
       return [];
@@ -242,7 +247,7 @@ async function fetchSearchIssues(searchQuery, githubToken, options, summary, war
     `?q=${encodeURIComponent(qualifiedQuery)}&per_page=${options.perPage}`,
   );
   try {
-    const { response, payload } = await githubGetJson(url, githubToken, summary);
+    const { response, payload } = await githubGetJson(url, githubToken, summary, options);
     if (!response.ok) {
       warnings.push({
         repoFullName: "*",
@@ -292,6 +297,8 @@ function normalizeOptions(options = {}) {
         : defaultApiBaseUrl,
     concurrency: normalizeLimit(options.concurrency, defaultConcurrency, 1, 10),
     perPage: normalizeLimit(options.perPage, defaultPerPage, 1, 100),
+    // Passed through to the per-fetch retry so tests can inject an instant sleep; undefined uses the real backoff.
+    sleepFn: typeof options.sleepFn === "function" ? options.sleepFn : undefined,
   };
 }
 

--- a/test/unit/miner-opportunity-fanout.test.ts
+++ b/test/unit/miner-opportunity-fanout.test.ts
@@ -181,7 +181,7 @@ describe("fetchCandidateIssues (#2307)", () => {
         { owner: "acme", repo: "up" },
       ],
       "token",
-      { apiBaseUrl: API },
+      { apiBaseUrl: API, sleepFn: () => Promise.resolve() }, // instant retry: a persistent 503 still warns
     );
 
     expect(result.issues.map((entry) => entry.issueNumber)).toEqual([11]);
@@ -301,11 +301,36 @@ describe("fetchCandidateIssues (#2307)", () => {
 
     const result = await searchCandidateIssuesWithSummary("label:feature", "token", {
       apiBaseUrl: API,
+      sleepFn: () => Promise.resolve(), // instant retry: a persistent 502 still warns
     });
 
     expect(result.issues).toEqual([]);
     expect(result.warnings).toEqual([
       { repoFullName: "*", stage: "search", message: "GitHub returned 502" },
     ]);
+  });
+
+  it("retries a transient 5xx and keeps the target's issues instead of dropping them (#4830)", async () => {
+    let issuesAttempts = 0;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/contents/AI-USAGE.md")) return jsonResponse({}, { status: 404 });
+      if (url.endsWith("/contents/CONTRIBUTING.md")) return contentResponse("Contributions welcome.");
+      if (url.includes("/repos/acme/blip/issues?")) {
+        issuesAttempts += 1;
+        if (issuesAttempts === 1) return jsonResponse({ message: "server error" }, { status: 503 }); // a blip
+        return jsonResponse([issue(7)]);
+      }
+      return jsonResponse({}, { status: 404 });
+    });
+
+    const result = await fetchCandidateIssuesWithSummary([{ owner: "acme", repo: "blip" }], "token", {
+      apiBaseUrl: API,
+      sleepFn: () => Promise.resolve(),
+    });
+
+    expect(issuesAttempts).toBe(2); // the 503 was retried, then succeeded
+    expect(result.issues.map((entry) => entry.issueNumber)).toEqual([7]); // results kept, not dropped
+    expect(result.warnings).toEqual([]); // no warning — the transient blip recovered
   });
 });


### PR DESCRIPTION
## Summary

A network blip while fetching a repo's policy docs or target issues was silently swallowed into a warning, **dropping that repo's results for the entire `discover` run** — with no retry.

This wraps the discovery fanout's single shared fetch helper (`githubGetJson`) with the same `fetchWithRetry` discipline the CI and gate-verdict pollers already use (**#4829**): a transient **5xx response** is retried with bounded exponential backoff before the repo is dropped, so a brief blip recovers instead of losing results. Since every fanout fetch (policy docs, target issues, search issues) goes through that one helper, the retry covers all three paths with a single wiring point.

- A `4xx`/`404` is returned immediately (no retry).
- A **thrown network error still propagates** to each caller's `try/catch`, unchanged.
- `sleepFn` is threaded through `normalizeOptions` so tests inject an instant retry; a **persistent 5xx still warns** after the retries are exhausted (existing behaviour preserved).

## Scope

- [x] Narrow, one coherent change — wrap the one shared fetch helper + thread `sleepFn` + tests
- [x] Reuses the already-merged `fetchWithRetry` (#4829); no new retry logic
- [x] In scope (`packages/`), no `blockedPaths`, no secrets/private terms; `.d.ts` updated

## Validation

- [x] `npm run typecheck`
- [x] `npm run test:coverage` (full unsharded suite)
- [x] `test/unit/miner-opportunity-fanout.test.ts`: a **transient 5xx is retried and the target's issues are kept** (not dropped, no warning) — the #4830 acceptance; the existing persistent-5xx tests still warn (after instant retries) unchanged
- [x] Every added line covered; the persistent-5xx tests inject an instant `sleepFn` so they stay fast

## Safety

- [x] Read-only: wraps existing GET calls; no writes, no new endpoints; rate-limit telemetry recording is unchanged
- [x] Bounded attempts + capped backoff; a persistent failure still degrades to a warning as before
- [x] No secrets, tokens, wallets, trust scores, or reward values in code, tests, or this description

Closes #4830
