### PR TITLE
fix(miner): stake a real claim-ledger claim before running an attempt

### DIFF
--- a/packages/gittensory-miner/lib/attempt-cli.js
+++ b/packages/gittensory-miner/lib/attempt-cli.js
@@ -161,6 +161,7 @@ export async function runAttempt(args, options = {}) {
   let governorLedger = null;
   let allocation = null;
   let worktreeResult = null;
+  let claimed = false;
 
   try {
     allocator = (options.openWorktreeAllocator ?? openWorktreeAllocator)();
@@ -349,6 +350,55 @@ export async function runAttempt(args, options = {}) {
     });
     const governor = buildAttemptGovernorContext(env, amsPolicy.spec);
 
+    // Stake a REAL soft-claim before running the attempt (#5393): checkSubmissionFreshness inside
+    // runMinerAttempt requires this miner to hold an ACTIVE claim on the issue it is about to submit for,
+    // and a concurrent attempt/loop on the same repo+issue must observe an in-flight claim rather than
+    // silently duplicating work. Mirrors the worktree slot's acquire/release lifecycle above -- staked
+    // here, released in `finally` on every terminal outcome. An already-active claim (another in-flight
+    // attempt on this exact issue) blocks this one instead of racing it.
+    const conflictingClaim = claimLedger
+      .listActiveClaims(parsed.repoFullName)
+      .find((existing) => existing.issueNumber === parsed.issueNumber);
+    if (conflictingClaim) {
+      const reason = "claim_conflict";
+      attemptLog.appendAttemptLogEvent({
+        eventType: "attempt_aborted",
+        attemptId,
+        actionClass: "open_pr",
+        mode,
+        reason,
+        payload: { repoFullName: parsed.repoFullName, issueNumber: parsed.issueNumber },
+      });
+      eventLedger.appendEvent({
+        type: "attempt_blocked",
+        repoFullName: parsed.repoFullName,
+        payload: { issueNumber: parsed.issueNumber, reason },
+      });
+      const conflictResult = {
+        outcome: "blocked_claim_conflict",
+        reason,
+        repoFullName: parsed.repoFullName,
+        issueNumber: parsed.issueNumber,
+        minerLogin: parsed.minerLogin,
+        base: parsed.base,
+        mode,
+        attemptId,
+      };
+      if (parsed.json) {
+        console.log(JSON.stringify(conflictResult, null, 2));
+      } else {
+        console.error(
+          `Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: another in-flight attempt already holds an active claim on this issue.`,
+        );
+      }
+      options.onResult?.(conflictResult);
+      return 11;
+    }
+    // No conflict: stake this miner's own active claim. recordClaim is idempotent (a prior released/
+    // expired claim is re-activated in a single atomic statement), so a sequential retry re-claims cleanly.
+    claimLedger.claimIssue(parsed.repoFullName, parsed.issueNumber);
+    claimed = true;
+
     const runAttemptPipeline = options.runMinerAttempt ?? runMinerAttempt;
     const result = await runAttemptPipeline(
       {
@@ -424,6 +474,11 @@ export async function runAttempt(args, options = {}) {
     }
     if (allocation && allocator) allocator.release(attemptId);
     allocator?.close();
+    // Release the soft-claim on every terminal outcome (submitted/abandon/stale/blocked/governed, or a
+    // thrown error), mirroring the worktree slot's unconditional release above. Guarded by `claimed` so
+    // the pre-claim blocks (rejection/worktree-prep/infeasible/claim-conflict) -- which never staked one --
+    // don't touch another attempt's claim.
+    if (claimed) claimLedger.releaseClaim(parsed.repoFullName, parsed.issueNumber);
     claimLedger?.close();
     eventLedger?.close();
     attemptLog?.close();

--- a/test/unit/miner-attempt-cli.test.ts
+++ b/test/unit/miner-attempt-cli.test.ts
@@ -700,4 +700,101 @@ describe("runAttempt (#5132)", () => {
     expect(submittedExit).toBe(0);
     expect(onResult).toHaveBeenLastCalledWith(expect.objectContaining({ outcome: "attempt_submitted", spec: expect.objectContaining({ command: "gh pr create" }) }));
   });
+
+  it("REGRESSION: stakes a real active claim before running the attempt and releases it once the attempt finishes (#5393)", async () => {
+    const { allocator, claimLedger, eventLedger, attemptLog, governorLedger } = tempLedgers();
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const claimIssueSpy = vi.spyOn(claimLedger, "claimIssue");
+    const releaseClaimSpy = vi.spyOn(claimLedger, "releaseClaim");
+    let activeDuringFlight: Array<{ issueNumber: number; status: string }> = [];
+    // The freshness check inside runMinerAttempt reads this same ledger to confirm the miner still holds an
+    // active claim -- capture what it would see while the attempt is in flight.
+    const runMinerAttemptSpy = vi.fn().mockImplementation(async () => {
+      activeDuringFlight = claimLedger.listActiveClaims("acme/widgets");
+      return { outcome: "submitted", spec: { command: "gh pr create", cwd: "/fake", timeoutMs: 1 }, execResult: { code: 0 }, loopResult: {} };
+    });
+
+    const exitCode = await runAttempt(["acme/widgets", "7", "--miner-login", "alice"], {
+      env: { MINER_CODING_AGENT_PROVIDER: "noop" },
+      openWorktreeAllocator: () => allocator,
+      openClaimLedger: () => claimLedger,
+      initEventLedger: () => eventLedger,
+      initAttemptLog: () => attemptLog,
+      initGovernorLedger: () => governorLedger,
+      ...readyPipelineOptions({ runMinerAttempt: runMinerAttemptSpy }),
+    });
+
+    expect(exitCode).toBe(0);
+    // A REAL claim was staked before the attempt ran and was active while it was in flight...
+    expect(claimIssueSpy).toHaveBeenCalledWith("acme/widgets", 7);
+    expect(activeDuringFlight).toHaveLength(1);
+    expect(activeDuringFlight[0]).toMatchObject({ issueNumber: 7, status: "active" });
+    // ...and released once the attempt finished, so `claim list` no longer shows it as active.
+    expect(releaseClaimSpy).toHaveBeenCalledWith("acme/widgets", 7);
+  });
+
+  it("blocks a second concurrent attempt when an active claim already exists on the same repo+issue, without running runMinerAttempt (#5393)", async () => {
+    const { allocator, claimLedger, eventLedger, attemptLog, governorLedger } = tempLedgers();
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const appendAttemptLogEventSpy = vi.spyOn(attemptLog, "appendAttemptLogEvent");
+    const appendEventSpy = vi.spyOn(eventLedger, "appendEvent");
+    const runMinerAttemptSpy = vi.fn();
+    const onResult = vi.fn();
+    // A first, in-flight attempt already holds an active claim on this exact issue.
+    claimLedger.claimIssue("acme/widgets", 7);
+
+    const exitCode = await runAttempt(["acme/widgets", "7", "--miner-login", "alice", "--json"], {
+      env: { MINER_CODING_AGENT_PROVIDER: "noop" },
+      attemptId: "conflicting-attempt",
+      openWorktreeAllocator: () => allocator,
+      openClaimLedger: () => claimLedger,
+      initEventLedger: () => eventLedger,
+      initAttemptLog: () => attemptLog,
+      initGovernorLedger: () => governorLedger,
+      ...readyPipelineOptions({ runMinerAttempt: runMinerAttemptSpy }),
+      onResult,
+    });
+
+    expect(exitCode).toBe(11);
+    expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+      outcome: "blocked_claim_conflict",
+      reason: "claim_conflict",
+      repoFullName: "acme/widgets",
+      issueNumber: 7,
+      minerLogin: "alice",
+      base: "main",
+      mode: "dry_run",
+      attemptId: "conflicting-attempt",
+    });
+    // The duplicate never ran a real attempt against the already-claimed issue.
+    expect(runMinerAttemptSpy).not.toHaveBeenCalled();
+    expect(onResult).toHaveBeenCalledWith(expect.objectContaining({ outcome: "blocked_claim_conflict" }));
+    expect(appendAttemptLogEventSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ eventType: "attempt_aborted", attemptId: "conflicting-attempt", reason: "claim_conflict" }),
+    );
+    expect(appendEventSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "attempt_blocked", repoFullName: "acme/widgets", payload: expect.objectContaining({ issueNumber: 7, reason: "claim_conflict" }) }),
+    );
+  });
+
+  it("blocks a conflicting claim with a human-readable message by default (#5393)", async () => {
+    const { allocator, claimLedger, eventLedger, attemptLog, governorLedger } = tempLedgers();
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const runMinerAttemptSpy = vi.fn();
+    claimLedger.claimIssue("acme/widgets", 7);
+
+    const exitCode = await runAttempt(["acme/widgets", "7", "--miner-login", "alice"], {
+      env: { MINER_CODING_AGENT_PROVIDER: "noop" },
+      openWorktreeAllocator: () => allocator,
+      openClaimLedger: () => claimLedger,
+      initEventLedger: () => eventLedger,
+      initAttemptLog: () => attemptLog,
+      initGovernorLedger: () => governorLedger,
+      ...readyPipelineOptions({ runMinerAttempt: runMinerAttemptSpy }),
+    });
+
+    expect(exitCode).toBe(11);
+    expect(error).toHaveBeenCalledWith(expect.stringContaining("already holds an active claim on this issue"));
+    expect(runMinerAttemptSpy).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Problem

`claim-ledger.js`'s `claimIssue()` — the soft-claim that stops two miners colliding on the same issue — was never called by the automated pipeline. `runAttempt` only *read* existing claims through the freshness check inside `runMinerAttempt`; it never staked one. Because `checkSubmissionFreshness` aborts to `claim_superseded` when no active claim exists for the issue, the real pipeline could never actually reach a submission. The only callers of `claimIssue()` were the manual `gittensory-miner claim` subcommand and an unused convenience wrapper.

## Change

Wire `claimLedger.claimIssue()` into `attempt-cli.js`'s `runAttempt` — the single call site shared by both the `attempt` and `loop` subcommands — right before invoking `runMinerAttempt`, and release it in the existing `finally` block on **every** terminal outcome (submitted / abandon / stale / blocked / governed, or a thrown error). This mirrors how the worktree slot is acquired and released today.

A pre-existing **active** claim on the same repo+issue (another in-flight attempt) now blocks the duplicate with a `blocked_claim_conflict` outcome instead of letting two miners silently race the same issue. `recordClaim` is idempotent, so a sequential retry after a released/expired claim re-claims cleanly.

Scope is confined to the new call site: no change to `claim-ledger.js`'s storage/expiry logic, and cross-miner adjudication stays out of scope (per the issue's boundaries).

## Acceptance criteria

- A real active claim is written before the attempt runs and cleared once it finishes — covered by a regression test asserting the claim is `active` while the attempt is in flight and `releaseClaim` is called on completion.
- A second concurrent attempt on the same repo+issue observes the existing active claim and blocks rather than duplicating work — covered by tests in both `--json` and human-readable modes.

Closes #5393
