### PR TITLE
chore(types): mark gateCheckMode @deprecated at every declaration site

### DIFF
--- a/apps/gittensory-ui/src/components/site/app-panels/activation-preview.test.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/activation-preview.test.tsx
@@ -96,7 +96,6 @@ describe("ActivationPreview", () => {
       ok: true,
       data: {
         repoFullName: "acme/widgets",
-        gateCheckMode: "enabled",
         reviewCheckMode: "required",
         checkRunMode: "enabled",
         linkedIssueGateMode: "advisory",

--- a/apps/gittensory-ui/src/components/site/app-panels/activation-preview.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/activation-preview.tsx
@@ -34,7 +34,6 @@ type ActivationPreviewResponse = {
 
 type ActivationResponse = {
   repoFullName: string;
-  gateCheckMode: string;
   reviewCheckMode: string;
   checkRunMode: string;
   linkedIssueGateMode: string;

--- a/packages/gittensory-engine/src/types/manifest-deps-types.ts
+++ b/packages/gittensory-engine/src/types/manifest-deps-types.ts
@@ -155,6 +155,8 @@ export type RepositorySettings = {
   publicSignalLevel: "minimal" | "standard";
   checkRunMode: "off" | "enabled";
   checkRunDetailLevel: "minimal" | "standard";
+  /** @deprecated (#4618, tracked for removal in #5373) computed read-back of {@link reviewCheckMode}
+   *  below, kept only for API/dashboard back-compat display -- read `reviewCheckMode` instead. */
   gateCheckMode: "off" | "enabled";
   /** Scheduled re-gate sweep candidate ordering (#3815). `staleness` (default) picks whichever open PR the
    *  sweep has gone longest WITHOUT re-gating (see selectRegateCandidates), which is what gives the sweep its

--- a/src/openapi/schemas.ts
+++ b/src/openapi/schemas.ts
@@ -670,6 +670,8 @@ export const RepositorySettingsSchema = z
     publicSignalLevel: z.enum(["minimal", "standard"]),
     checkRunMode: z.enum(["off", "enabled"]),
     checkRunDetailLevel: z.enum(["minimal", "standard"]),
+    // @deprecated (#4618, tracked for removal in #5373): computed read-back of reviewCheckMode kept only
+    // for API/dashboard back-compat display -- read reviewCheckMode instead.
     gateCheckMode: z.enum(["off", "enabled"]),
     regateSweepOrderMode: z.enum(["staleness", "oldest-first"]),
     reviewCheckMode: z.enum(["required", "visible", "disabled"]),
@@ -885,6 +887,8 @@ export const RepoSettingsPreviewSchema = z
       publicSignalLevel: z.enum(["minimal", "standard"]),
       checkRunMode: z.enum(["off", "enabled"]),
       checkRunDetailLevel: z.enum(["minimal", "standard"]),
+      // @deprecated (#4618, tracked for removal in #5373): computed read-back of reviewCheckMode kept only
+      // for API/dashboard back-compat display -- read reviewCheckMode instead.
       gateCheckMode: z.enum(["off", "enabled"]),
       regateSweepOrderMode: z.enum(["staleness", "oldest-first"]),
       reviewCheckMode: z.enum(["required", "visible", "disabled"]),
@@ -1288,6 +1292,8 @@ export const InstallationRepairSchema = z
           commentMode: z.enum(["off", "detected_contributors_only", "all_prs"]),
           publicAudienceMode: z.enum(["oss_maintainer", "gittensor_only"]),
           checkRunMode: z.enum(["off", "enabled"]),
+          // @deprecated (#4618, tracked for removal in #5373): computed read-back of reviewCheckMode kept only
+          // for API/dashboard back-compat display -- read reviewCheckMode instead.
           gateCheckMode: z.enum(["off", "enabled"]),
           reviewCheckMode: z.enum(["required", "visible", "disabled"]),
           autoProjectMilestoneMatch: z.enum(["off", "suggest", "auto"]).optional(),
@@ -2207,6 +2213,8 @@ export const RegistrationReadinessSchema = z
       commentMode: z.enum(["off", "detected_contributors_only", "all_prs"]),
       publicAudienceMode: z.enum(["oss_maintainer", "gittensor_only"]),
       checkRunMode: z.enum(["off", "enabled"]),
+      // @deprecated (#4618, tracked for removal in #5373): computed read-back of reviewCheckMode kept only
+      // for API/dashboard back-compat display -- read reviewCheckMode instead.
       gateCheckMode: z.enum(["off", "enabled"]),
       reviewCheckMode: z.enum(["required", "visible", "disabled"]),
       autoProjectMilestoneMatch: z.enum(["off", "suggest", "auto"]).optional(),

--- a/src/services/maintainer-activation.ts
+++ b/src/services/maintainer-activation.ts
@@ -19,6 +19,8 @@ export type MaintainerActivationPreview = {
   repoFullName: string;
   generatedAt: string;
   // What's on today, so the UI can show the current state next to the one-click ramp.
+  /** @deprecated (#4618, tracked for removal in #5373) sourced from the computed read-back
+   *  `RepositorySettings["gateCheckMode"]` -- kept only for API/dashboard back-compat display. */
   currentGateMode: RepositorySettings["gateCheckMode"];
   aiReviewConfigured: boolean;
   evaluatedCount: number;

--- a/src/signals/registration-readiness.ts
+++ b/src/signals/registration-readiness.ts
@@ -36,6 +36,8 @@ export type GithubAppBehavior = {
   commentMode: RepositorySettings["commentMode"];
   publicAudienceMode: RepositorySettings["publicAudienceMode"];
   checkRunMode: RepositorySettings["checkRunMode"];
+  /** @deprecated (#4618, tracked for removal in #5373) computed read-back of {@link reviewCheckMode} kept
+   *  only for API/dashboard back-compat display -- read `reviewCheckMode` instead. */
   gateCheckMode: RepositorySettings["gateCheckMode"];
   reviewCheckMode: RepositorySettings["reviewCheckMode"];
   quietByDefault: boolean;

--- a/src/signals/settings-preview.ts
+++ b/src/signals/settings-preview.ts
@@ -191,6 +191,8 @@ export type RepoSettingsPreview = {
     publicSignalLevel: RepositorySettings["publicSignalLevel"];
     checkRunMode: RepositorySettings["checkRunMode"];
     checkRunDetailLevel: RepositorySettings["checkRunDetailLevel"];
+    /** @deprecated (#4618, tracked for removal in #5373) computed read-back of {@link reviewCheckMode}
+     *  kept only for API/dashboard back-compat display -- read `reviewCheckMode` instead. */
     gateCheckMode: RepositorySettings["gateCheckMode"];
     regateSweepOrderMode: RepositorySettings["regateSweepOrderMode"];
     reviewCheckMode: RepositorySettings["reviewCheckMode"];

--- a/src/types.ts
+++ b/src/types.ts
@@ -715,10 +715,10 @@ export type RepositorySettings = {
   // #4620: "deep" removed -- it was never wired to any different behavior than "standard" (formatCheckRunOutput
   // and buildCheckRunAnnotations in rules/advisory.ts both branch only on `=== "minimal"` vs not).
   checkRunDetailLevel: "minimal" | "standard";
-  /** Legacy shadow of {@link reviewCheckMode} (#2852), deprecated (#4618): a computed read-back value only,
-   *  for API/dashboard back-compat display. `"enabled"` when `reviewCheckMode !== "disabled"`, else `"off"`
-   *  -- see getRepositorySettings/upsertRepositorySettings in db/repositories.ts. No write path accepts this
-   *  field anymore; set {@link reviewCheckMode} directly instead. */
+  /** @deprecated (#4618, tracked for removal in #5373) Legacy shadow of {@link reviewCheckMode} (#2852): a
+   *  computed read-back value only, for API/dashboard back-compat display. `"enabled"` when
+   *  `reviewCheckMode !== "disabled"`, else `"off"` -- see getRepositorySettings/upsertRepositorySettings in
+   *  db/repositories.ts. No write path accepts this field anymore; set {@link reviewCheckMode} directly instead. */
   gateCheckMode: "off" | "enabled";
   /** Scheduled re-gate sweep candidate ordering (#3815). `staleness` (default) picks whichever open PR the
    *  sweep has gone longest WITHOUT re-gating (see selectRegateCandidates), which is what gives the sweep its


### PR DESCRIPTION
## Summary
Stage 1 of #5373's two-stage plan (`gateCheckMode` is a computed read-back of `reviewCheckMode`, deprecated since #4618).

- #4618 already made `gateCheckMode` derived-only with narrative comments explaining it in most places, but several public-surface type declarations never got an explicit `@deprecated` marker on the field itself: `RepositorySettings` (`src/types.ts`), `GithubAppBehavior` (`registration-readiness.ts`), the settings-preview response shape, `MaintainerActivationPreview.currentGateMode`, the `gittensory-engine` package's own `RepositorySettings` copy, and all 4 OpenAPI response schema definitions. Added `@deprecated` (or a matching plain comment where the file has no JSDoc-tag precedent, i.e. the Zod schema file) at each site pointing to `reviewCheckMode`.
- Found and removed one genuinely dead field along the way: the UI's local `ActivationResponse.gateCheckMode` was declared but never read anywhere in `activation-preview.tsx` -- confirmed via grep, removed from both the type and its test fixture.
- No behavior change: verified the regenerated `openapi.json` is byte-identical (plain comments only, no `.describe()`/`.openapi()` metadata added).

Stage 2 (the actual DB column + full removal, 447 occurrences across 48 files) is intentionally out of scope here and tracked separately per #5373.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:lint`
- [x] `npm run docs:drift-check`
- [x] `npm run ui:openapi:check` (confirms zero drift -- plain comments don't affect the generated schema)
- [x] `test/unit/registration-readiness.test.ts`, `test/unit/repo-policy-readiness.test.ts`, `test/unit/settings-preview.test.ts`, `test/unit/maintainer-settings-preview-ui.test.ts`, `test/unit/backfill.test.ts`, `test/unit/backfill-2.test.ts`, and the UI's `activation-preview` test -- all green