### PR TITLE
docs: rename AI-contributor tooling and meta-docs for LoopOver

### DIFF
--- a/.claude/skills/contributing-to-loopover/SKILL.md
+++ b/.claude/skills/contributing-to-loopover/SKILL.md
@@ -1,18 +1,18 @@
 ---
-name: contributing-to-gittensory
+name: contributing-to-loopover
 description: >-
   Use when writing, testing, or preparing ANY code contribution or pull request to the
   JSONbored/gittensory repo — picking/validating an issue, implementing a change, writing tests
-  that pass Codecov, running the local CI gate, predicting the gittensory gate, and formatting the
-  commit + PR. gittensory reviews PRs ONE-SHOT via the gittensory gate (a GitHub App / CI) plus a
+  that pass Codecov, running the local CI gate, predicting the loopover gate, and formatting the
+  commit + PR. loopover reviews PRs ONE-SHOT via the loopover gate (a GitHub App / CI) plus a
   strict CI suite with Codecov (99% patch coverage, hard); there is no review back-and-forth, so a
   PR must be correct, fully tested, house-style-compliant, and green before it is pushed. Invoke
-  for any "contribute to / open a PR against / fix a bug in / add a feature to gittensory" task.
+  for any "contribute to / open a PR against / fix a bug in / add a feature to loopover" task.
 ---
 
-# Contributing to gittensory — the one-shot PR playbook
+# Contributing to LoopOver — the one-shot PR playbook
 
-gittensory merges through an **automated, one-shot review**: the gittensory gate (a GitHub App that
+LoopOver merges through an **automated, one-shot review**: the loopover gate (a GitHub App that
 posts a check run + a single review verdict) and a **strict CI suite gated by Codecov**. There is no
 human ping-pong and no "fix it in review" — **the PR must be perfect before you push.** This skill is
 the end-to-end procedure to make that happen with AI tools (Claude Code / Codex).
@@ -27,7 +27,7 @@ the gate config, the MCP tools, test helpers, the commit/PR rubric). Read it whe
 
 ## What the gate does to your PR — it merges and closes, automatically
 
-gittensory's review engine has **real autonomy** here — it is **not advisory**. Within ~2 minutes of
+LoopOver's review engine has **real autonomy** here — it is **not advisory**. Within ~2 minutes of
 your PR's checks settling, for a **contributor** PR (you are not the repo owner or an automation bot)
 it takes a one-shot disposition:
 
@@ -93,7 +93,7 @@ approve the run, so the checks sit *unverified* for a bit — that is **expected
 an unverified-CI PR (it does **not** close it). Don't open a duplicate; wait for the run to be
 approved, then confirm it's green.
 
-**Install the gittensory MCP** — your pre-submit oracle that predicts the gate before you push:
+**Install the loopover MCP** — your pre-submit oracle that predicts the gate before you push:
 
 ```sh
 npm install -g @jsonbored/gittensory-mcp@latest
@@ -239,7 +239,7 @@ named **`Gittensory Orb Review Agent`** — watch both go green/passing.
 
 ---
 
-## Phase 6 — Predict the gittensory gate before you push
+## Phase 6 — Predict the loopover gate before you push
 
 Run the MCP predictor with your actual PR shape:
 

--- a/.claude/skills/contributing-to-loopover/reference.md
+++ b/.claude/skills/contributing-to-loopover/reference.md
@@ -1,4 +1,4 @@
-# gittensory contribution — deep reference
+# LoopOver contribution — deep reference
 
 Exhaustive tables and patterns behind the `SKILL.md` playbook. Read the section you need; you don't
 need all of it for every change. All commands run from the repo root unless noted.
@@ -85,7 +85,7 @@ checks go green) is the only way to know you didn't break it.
 
 ---
 
-## 3. The gittensory gate — it auto-MERGES and auto-CLOSES (not advisory)
+## 3. The loopover gate — it auto-MERGES and auto-CLOSES (not advisory)
 
 The engine reviews every PR and **acts on it** with autonomy (`src/settings/agent-actions.ts`
 `planAgentMaintenanceActions`). A scheduled sweep re-evaluates open PRs roughly every ~2 minutes, so a
@@ -290,7 +290,7 @@ boxes (auth/CORS **negative-path tests**, no-secrets) and the **UI Evidence** th
 
 ---
 
-## 9. What gittensory does NOT accept (from `CONTRIBUTING.md`)
+## 9. What LoopOver does NOT accept (from `CONTRIBUTING.md`)
 
 - `site/`, `CNAME`, VitePress/old static-docs surfaces; `**/lovable/**`.
 - Broad rewrites / framework swaps / redesigns without a maintainer-approved issue.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,13 @@
-# gittensory — AI contributor guide
+# LoopOver — AI contributor guide
 
 Loaded automatically by AI coding tools: **Codex** reads this `AGENTS.md`; **Claude Code** reads
 `CLAUDE.md` (a symlink to this file) and additionally auto-loads the on-demand skill at
-`.claude/skills/contributing-to-gittensory/`.
+`.claude/skills/contributing-to-loopover/`.
 
 **Before writing ANY code contribution or pull request to this repo, read and follow the skill:**
 
-- `.claude/skills/contributing-to-gittensory/SKILL.md` — the one-shot-PR playbook (phases + checklist)
-- `.claude/skills/contributing-to-gittensory/reference.md` — exhaustive tables (CI, Codecov, the gate, tests, style)
+- `.claude/skills/contributing-to-loopover/SKILL.md` — the one-shot-PR playbook (phases + checklist)
+- `.claude/skills/contributing-to-loopover/reference.md` — exhaustive tables (CI, Codecov, the gate, tests, style)
 
 That skill is the **single source of truth** for how to contribute here. Keep it updated as the
 process evolves — edits to those files improve both Claude Code and Codex.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ owner or an automation bot):
 
 So **get it green and correct before you push**: run the full local gate (`npm run test:ci`), keep your
 branch current with `main` (a conflict closes the PR), and link an eligible issue. If you use Claude
-Code or Codex, the `.claude/skills/contributing-to-gittensory` skill (and the root `AGENTS.md`) encode
+Code or Codex, the `.claude/skills/contributing-to-loopover` skill (and the root `AGENTS.md`) encode
 the whole procedure step by step.
 
 ## How Reviews Work (timing, one-shot, and asking for review)
@@ -235,7 +235,7 @@ Frontend:
   evidence. Recordings/GIFs are supplemental for anything a static screenshot can already show, but
   are the required primary evidence for an effect only visible in motion (hover, scroll-linked,
   transition/animation) — a still image can't show it, so don't force one. See the
-  `.claude/skills/contributing-to-gittensory` skill (Phase 7) for exactly how to capture and host
+  `.claude/skills/contributing-to-loopover` skill (Phase 7) for exactly how to capture and host
   either kind of evidence.
 - Arrange screenshots in a small table or grid with a short state/title such as "Loaded state",
   "Empty state", "Error state", "Mobile layout", or "PR sidebar". Each screenshot should be a small

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -2,10 +2,10 @@
 
 ## Gittensor Scoring References
 
-Gittensory includes TypeScript scoring estimators and model snapshots informed by public Gittensor scoring behavior and documentation from `entrius/gittensor`.
+LoopOver includes TypeScript scoring estimators and model snapshots informed by public Gittensor scoring behavior and documentation from `entrius/gittensor`.
 
 - Upstream project: `entrius/gittensor`
 - Upstream license observed locally: MIT
-- Use in Gittensory: no Python modules are vendored into the Worker backend; Gittensory stores normalized model constants and implements deterministic advisory estimators in TypeScript.
+- Use in LoopOver: no Python modules are vendored into the Worker backend; LoopOver stores normalized model constants and implements deterministic advisory estimators in TypeScript.
 
 Any optional local MCP score preview may invoke a user-configured local Gittensor checkout. That checkout remains separate from this repository.

--- a/scripts/check-schema-drift.mjs
+++ b/scripts/check-schema-drift.mjs
@@ -30,7 +30,7 @@ const MIGRATIONS_DIR = process.env.CHECK_SCHEMA_DRIFT_DIR || "migrations";
 
 // Feature/aggregate tables that intentionally live ONLY in migrations/ and are accessed via raw SQL
 // (env.DB.prepare(...)) rather than through a Drizzle sqliteTable declaration -- the house pattern documented
-// in .claude/skills/contributing-to-gittensory/reference.md ("core tables use Drizzle; feature/aggregate
+// in .claude/skills/contributing-to-loopover/reference.md ("core tables use Drizzle; feature/aggregate
 // tables use raw-SQL migrations"). Each of these is confirmed (by direct inspection at the time this check
 // was added) to be actively read/written via raw SQL elsewhere in src/ -- this is not a dead-table allowlist,
 // it is a declared exception to "every migrated table must have a matching schema.ts declaration". Adding a

--- a/src/review/repo-skill-render.ts
+++ b/src/review/repo-skill-render.ts
@@ -1,6 +1,6 @@
 // Repo-skill content rendering (#3001, part of the repo-doc generation roadmap #2993). Extends AGENTS.md/CLAUDE.md
 // generation (#3000) to conditionally propose a Claude Code / Codex skill file -- this repo's own
-// `.claude/skills/contributing-to-gittensory/SKILL.md` (frontmatter `name`/`description` + a procedural body) is
+// `.claude/skills/contributing-to-loopover/SKILL.md` (frontmatter `name`/`description` + a procedural body) is
 // the concrete convention being replicated for OTHER repos.
 //
 // TRIGGER, NOT UNCONDITIONAL: a skill file is only warranted when a repo's contribution workflow is complex
@@ -56,7 +56,7 @@ function repoOnlyName(repoFullName: string): string {
 }
 
 /** The skill's `name:` frontmatter value -- also the containing directory name, per this repo's own convention
- *  (`.claude/skills/contributing-to-gittensory/`, directory name === frontmatter `name`). */
+ *  (`.claude/skills/contributing-to-loopover/`, directory name === frontmatter `name`). */
 export function repoSkillName(repoFullName: string): string {
   return `contributing-to-${sanitizeSkillNameSegment(repoOnlyName(repoFullName))}`;
 }


### PR DESCRIPTION
## Summary
Renames genuine brand-prose mentions of "gittensory" to "LoopOver" across `AGENTS.md`/`CLAUDE.md` (the AI-contributor guide auto-loaded by Codex and Claude Code), the `.claude/skills/contributing-to-gittensory/` skill directory (renamed to `contributing-to-loopover/`, including its own frontmatter `name:` field and cross-references in `CONTRIBUTING.md` and `scripts/check-schema-drift.mjs`), and `THIRD_PARTY_NOTICES.md`.

As with the earlier docs-copy pass (#5376), every not-yet-renamed technical identifier is left untouched: npm package names, check-run names, the `.gittensory.yml` config filename, `GITTENSORY_`-prefixed env vars, the repo path, and MCP tool names -- each is tracked by its own separate rebrand issue.

## Found and deliberately left alone
`src/review/repo-skill-render.ts`'s `REPO_SKILL_MARKER_START`/`END` constants (`<!-- gittensory-skill-doc:start/end -->`) are live, externally-persisted HTML comment markers already baked into other repos' generated skill files by this feature's own refresh mechanism (confirmed wired up via `src/github/repo-doc-pr.ts`). Renaming them risks breaking refresh for any repo where this has already run -- the same class of risk as the check-run-name and visual-capture-fallback.yml rebrand issues. Only the file's descriptive comments referencing the skill directory path were updated.

`CONVERGENCE_RUNBOOK.md` is excluded pending a maintainer decision on whether an internal engineering runbook is in scope for this rebrand pass at all.

## Test plan
- [x] `npm run typecheck`
- [x] Comprehensive sweep confirming zero remaining `contributing-to-gittensory` references anywhere in the repo
- [x] Confirmed the 4 test files referencing `AGENTS.md`/`CLAUDE.md` all test the *generic* repo-doc-generation feature for arbitrary external target repos, not this repo's own root files -- none needed changes
- [x] Full `test:ci` gate green end-to-end

Closes #5334.