### PR TITLE
docs(miner): remove stale deployment claims

### DIFF
--- a/apps/gittensory-ui/src/components/site/command-palette.tsx
+++ b/apps/gittensory-ui/src/components/site/command-palette.tsx
@@ -32,6 +32,7 @@ const DEFAULT_ITEMS: PaletteItem[] = [
   { label: "Beta onboarding", to: "/docs/beta-onboarding", group: "Docs" },
   { label: "Quickstart", to: "/docs/quickstart", group: "Docs" },
   { label: "MCP clients", to: "/docs/mcp-clients", group: "Docs" },
+  { label: "Coding-agent driver", to: "/docs/miner-coding-agent", group: "Docs" },
   { label: "Miner workflow", to: "/docs/miner-workflow", group: "Docs" },
   { label: "Maintainer workflow", to: "/docs/maintainer-workflow", group: "Docs" },
   { label: "Self-host reviews", to: "/docs/maintainer-self-hosting", group: "Docs" },

--- a/apps/gittensory-ui/src/components/site/docs-nav.tsx
+++ b/apps/gittensory-ui/src/components/site/docs-nav.tsx
@@ -22,7 +22,10 @@ export const docsNav: DocsGroup[] = [
   },
   {
     title: "Workflows",
-    items: [{ to: "/docs/miner-workflow", label: "Miner workflow" }],
+    items: [
+      { to: "/docs/miner-coding-agent", label: "Coding-agent driver" },
+      { to: "/docs/miner-workflow", label: "Miner workflow" },
+    ],
   },
   {
     title: "Maintainers",

--- a/apps/gittensory-ui/src/routeTree.gen.ts
+++ b/apps/gittensory-ui/src/routeTree.gen.ts
@@ -43,6 +43,7 @@ import { Route as DocsScoreabilityRouteImport } from './routes/docs.scoreability
 import { Route as DocsQuickstartRouteImport } from './routes/docs.quickstart'
 import { Route as DocsPrivacySecurityRouteImport } from './routes/docs.privacy-security'
 import { Route as DocsOwnerChecklistRouteImport } from './routes/docs.owner-checklist'
+import { Route as DocsMinerCodingAgentRouteImport } from './routes/docs.miner-coding-agent'
 import { Route as DocsMinerWorkflowRouteImport } from './routes/docs.miner-workflow'
 import { Route as DocsMinerQuickstartRouteImport } from './routes/docs.miner-quickstart'
 import { Route as DocsMcpClientsRouteImport } from './routes/docs.mcp-clients'
@@ -251,6 +252,11 @@ const DocsOwnerChecklistRoute = DocsOwnerChecklistRouteImport.update({
   path: '/owner-checklist',
   getParentRoute: () => DocsRoute,
 } as any)
+const DocsMinerCodingAgentRoute = DocsMinerCodingAgentRouteImport.update({
+  id: '/miner-coding-agent',
+  path: '/miner-coding-agent',
+  getParentRoute: () => DocsRoute,
+} as any)
 const DocsMinerWorkflowRoute = DocsMinerWorkflowRouteImport.update({
   id: '/miner-workflow',
   path: '/miner-workflow',
@@ -424,6 +430,7 @@ export interface FileRoutesByFullPath {
   '/docs/maintainer-self-hosting': typeof DocsMaintainerSelfHostingRoute
   '/docs/maintainer-workflow': typeof DocsMaintainerWorkflowRoute
   '/docs/mcp-clients': typeof DocsMcpClientsRoute
+  '/docs/miner-coding-agent': typeof DocsMinerCodingAgentRoute
   '/docs/miner-quickstart': typeof DocsMinerQuickstartRoute
   '/docs/miner-workflow': typeof DocsMinerWorkflowRoute
   '/docs/owner-checklist': typeof DocsOwnerChecklistRoute
@@ -484,6 +491,7 @@ export interface FileRoutesByTo {
   '/docs/maintainer-self-hosting': typeof DocsMaintainerSelfHostingRoute
   '/docs/maintainer-workflow': typeof DocsMaintainerWorkflowRoute
   '/docs/mcp-clients': typeof DocsMcpClientsRoute
+  '/docs/miner-coding-agent': typeof DocsMinerCodingAgentRoute
   '/docs/miner-quickstart': typeof DocsMinerQuickstartRoute
   '/docs/miner-workflow': typeof DocsMinerWorkflowRoute
   '/docs/owner-checklist': typeof DocsOwnerChecklistRoute
@@ -613,6 +621,7 @@ export interface FileRouteTypes {
     | '/docs/maintainer-self-hosting'
     | '/docs/maintainer-workflow'
     | '/docs/mcp-clients'
+    | '/docs/miner-coding-agent'
     | '/docs/miner-quickstart'
     | '/docs/miner-workflow'
     | '/docs/owner-checklist'
@@ -673,6 +682,7 @@ export interface FileRouteTypes {
     | '/docs/maintainer-self-hosting'
     | '/docs/maintainer-workflow'
     | '/docs/mcp-clients'
+    | '/docs/miner-coding-agent'
     | '/docs/miner-quickstart'
     | '/docs/miner-workflow'
     | '/docs/owner-checklist'
@@ -1026,6 +1036,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DocsMinerWorkflowRouteImport
       parentRoute: typeof DocsRoute
     }
+    '/docs/miner-coding-agent': {
+      id: '/docs/miner-coding-agent'
+      path: '/miner-coding-agent'
+      fullPath: '/docs/miner-coding-agent'
+      preLoaderRoute: typeof DocsMinerCodingAgentRouteImport
+      parentRoute: typeof DocsRoute
+    }
     '/docs/miner-quickstart': {
       id: '/docs/miner-quickstart'
       path: '/miner-quickstart'
@@ -1270,6 +1287,7 @@ interface DocsRouteChildren {
   DocsMaintainerSelfHostingRoute: typeof DocsMaintainerSelfHostingRoute
   DocsMaintainerWorkflowRoute: typeof DocsMaintainerWorkflowRoute
   DocsMcpClientsRoute: typeof DocsMcpClientsRoute
+  DocsMinerCodingAgentRoute: typeof DocsMinerCodingAgentRoute
   DocsMinerQuickstartRoute: typeof DocsMinerQuickstartRoute
   DocsMinerWorkflowRoute: typeof DocsMinerWorkflowRoute
   DocsOwnerChecklistRoute: typeof DocsOwnerChecklistRoute
@@ -1307,6 +1325,7 @@ const DocsRouteChildren: DocsRouteChildren = {
   DocsMaintainerSelfHostingRoute: DocsMaintainerSelfHostingRoute,
   DocsMaintainerWorkflowRoute: DocsMaintainerWorkflowRoute,
   DocsMcpClientsRoute: DocsMcpClientsRoute,
+  DocsMinerCodingAgentRoute: DocsMinerCodingAgentRoute,
   DocsMinerQuickstartRoute: DocsMinerQuickstartRoute,
   DocsMinerWorkflowRoute: DocsMinerWorkflowRoute,
   DocsOwnerChecklistRoute: DocsOwnerChecklistRoute,

--- a/apps/gittensory-ui/src/routes/docs.index.tsx
+++ b/apps/gittensory-ui/src/routes/docs.index.tsx
@@ -59,6 +59,7 @@ const AUDIENCES: Audience[] = [
     links: [
       { to: "/docs/quickstart", label: "Quickstart" },
       { to: "/docs/miner-quickstart", label: "Quickstart by lane" },
+      { to: "/docs/miner-coding-agent", label: "Coding-agent driver" },
       { to: "/docs/miner-workflow", label: "Miner workflow" },
       { to: "/docs/branch-analysis", label: "Branch analysis" },
       { to: "/docs/scoreability", label: "Scoreability" },

--- a/apps/gittensory-ui/src/routes/docs.miner-coding-agent.test.tsx
+++ b/apps/gittensory-ui/src/routes/docs.miner-coding-agent.test.tsx
@@ -1,0 +1,92 @@
+import { render, screen } from "@testing-library/react";
+import { type ReactNode } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { CODING_AGENT_DRIVER_NAMES } from "../../../../packages/gittensory-engine/src/miner/driver-factory";
+import {
+  MINER_CODING_AGENT_ENV_ROWS,
+  MINER_CODING_AGENT_PROVIDER_ITEMS,
+  MinerCodingAgentDriverDocs,
+} from "./docs.miner-coding-agent";
+
+vi.mock("@tanstack/react-router", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@tanstack/react-router")>();
+  return {
+    ...actual,
+    Link: ({ to, children }: { to: string; children: ReactNode }) => <a href={to}>{children}</a>,
+  };
+});
+
+vi.mock("@/components/site/docs-page", () => ({
+  DocsPage: ({
+    children,
+    title,
+    eyebrow,
+    description,
+  }: {
+    children: ReactNode;
+    title: string;
+    eyebrow?: string;
+    description?: string;
+  }) => (
+    <div data-testid="docs-page">
+      {eyebrow ? <div>{eyebrow}</div> : null}
+      <h1>{title}</h1>
+      {description ? <p>{description}</p> : null}
+      {children}
+    </div>
+  ),
+}));
+
+vi.mock("@/components/site/primitives", () => ({
+  Callout: ({ children, title }: { children: ReactNode; title?: string }) => (
+    <section data-testid="callout">
+      {title ? <strong>{title}</strong> : null}
+      <div>{children}</div>
+    </section>
+  ),
+  CodeBlock: ({ code }: { code: string }) => <pre>{code}</pre>,
+  FeatureRow: ({ items }: { items: Array<{ title: string; description: string }> }) => (
+    <dl>
+      {items.map((item) => (
+        <div key={item.title}>
+          <dt>{item.title}</dt>
+          <dd>{item.description}</dd>
+        </div>
+      ))}
+    </dl>
+  ),
+}));
+
+describe("miner coding-agent docs page", () => {
+  it("mounts the docs route and renders the expected sections", async () => {
+    render(<MinerCodingAgentDriverDocs />);
+
+    expect(await screen.findByRole("heading", { name: "Miner coding-agent driver" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Provider selection" })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Model and timeout overrides" })).toBeTruthy();
+    expect(
+      screen.getByRole("heading", { name: "Recognizing a stale or missing credential" }),
+    ).toBeTruthy();
+    expect(screen.getByRole("heading", { name: "Related docs" })).toBeTruthy();
+  });
+
+  it("keeps the provider list aligned with the engine's accepted provider names", () => {
+    expect(MINER_CODING_AGENT_PROVIDER_ITEMS.map((item) => item.title)).toEqual([
+      ...CODING_AGENT_DRIVER_NAMES,
+    ]);
+  });
+
+  it("documents every driver env var the page claims to cover", () => {
+    expect(MINER_CODING_AGENT_ENV_ROWS.map((row) => row.name)).toEqual([
+      "MINER_CODING_AGENT_PROVIDER",
+      "MINER_CODING_AGENT_CLAUDE_MODEL",
+      "MINER_CODING_AGENT_CODEX_MODEL",
+      "MINER_CODING_AGENT_TIMEOUT_MS",
+    ]);
+  });
+
+  it("exports the route component used by the route definition", () => {
+    expect(typeof MinerCodingAgentDriverDocs).toBe("function");
+  });
+});

--- a/apps/gittensory-ui/src/routes/docs.miner-coding-agent.tsx
+++ b/apps/gittensory-ui/src/routes/docs.miner-coding-agent.tsx
@@ -1,0 +1,206 @@
+import { createFileRoute, Link } from "@tanstack/react-router";
+
+import { DocsPage } from "@/components/site/docs-page";
+import { Callout, CodeBlock, FeatureRow } from "@/components/site/primitives";
+
+export const MINER_CODING_AGENT_PROVIDER_ITEMS: Array<{ title: string; description: string }> = [
+  {
+    title: "noop",
+    description:
+      "Fail-closed stub. Useful when you want the miner to stay off or you are running tests.",
+  },
+  {
+    title: "claude-cli",
+    description:
+      "Spawns the local `claude` CLI subprocess. Uses `MINER_CODING_AGENT_CLAUDE_MODEL` when set.",
+  },
+  {
+    title: "codex-cli",
+    description:
+      "Spawns the local `codex` CLI subprocess. Uses `MINER_CODING_AGENT_CODEX_MODEL` when set.",
+  },
+  {
+    title: "agent-sdk",
+    description:
+      "Runs the in-process Agent SDK path. It ignores the model and timeout overrides on this seam.",
+  },
+];
+
+export const MINER_CODING_AGENT_ENV_ROWS: Array<{
+  name: string;
+  appliesTo: string;
+  defaultValue: string;
+  notes: string;
+}> = [
+  {
+    name: "MINER_CODING_AGENT_PROVIDER",
+    appliesTo: "All production provider selection",
+    defaultValue: "unset / empty",
+    notes:
+      "Comma-separated preference list. The first configured name wins; unknown names are skipped.",
+  },
+  {
+    name: "MINER_CODING_AGENT_CLAUDE_MODEL",
+    appliesTo: "claude-cli",
+    defaultValue: "CLI default",
+    notes:
+      "Optional override for the Claude Code subprocess. Ignored by noop, codex-cli, and agent-sdk.",
+  },
+  {
+    name: "MINER_CODING_AGENT_CODEX_MODEL",
+    appliesTo: "codex-cli",
+    defaultValue: "CLI default",
+    notes:
+      "Optional override for the Codex subprocess. Ignored by noop, claude-cli, and agent-sdk.",
+  },
+  {
+    name: "MINER_CODING_AGENT_TIMEOUT_MS",
+    appliesTo: "claude-cli / codex-cli",
+    defaultValue: "120000 ms",
+    notes:
+      "Positive integer wall-clock ceiling. Unset or invalid falls back to the CLI driver's default timeout.",
+  },
+];
+
+export const MINER_CODING_AGENT_TRUST_ROWS: Array<{ title: string; description: string }> = [
+  {
+    title: "claude_code_no_oauth_token",
+    description:
+      "Claude Code cannot find a runtime token. Re-run `claude setup-token` and keep the credential operator-owned.",
+  },
+  {
+    title: "claude_code_error_401",
+    description:
+      "Claude rejected the token. Generate a fresh one with `claude setup-token` and replace the old secret.",
+  },
+  {
+    title: "codex_no_auth",
+    description:
+      "Codex cannot find `auth.json`. Re-run `codex auth` on the mounted CLI home or volume.",
+  },
+  {
+    title: "codex_credential_isolation_required",
+    description:
+      "The Codex home or auth path is not isolated from operator-owned storage. Remove the unsafe override.",
+  },
+];
+
+export const Route = createFileRoute("/docs/miner-coding-agent")({
+  head: () => ({
+    meta: [
+      { title: "Miner coding-agent driver — LoopOver docs" },
+      {
+        name: "description",
+        content:
+          "Enable Claude Code or Codex as the miner's coding-agent driver, and document the provider, model, timeout, and credential troubleshooting paths.",
+      },
+      { property: "og:title", content: "Miner coding-agent driver — LoopOver docs" },
+      {
+        property: "og:description",
+        content:
+          "Enable Claude Code or Codex as the miner's coding-agent driver, and document the provider, model, timeout, and credential troubleshooting paths.",
+      },
+      { property: "og:url", content: "/docs/miner-coding-agent" },
+    ],
+    links: [{ rel: "canonical", href: "/docs/miner-coding-agent" }],
+  }),
+  component: MinerCodingAgentDriverDocs,
+});
+
+export function MinerCodingAgentDriverDocs() {
+  return (
+    <DocsPage
+      eyebrow="Configuration"
+      title="Miner coding-agent driver"
+      description="Choose a production provider, override the right model and timeout knobs, and recognize credential failures before you chase the wrong layer."
+    >
+      <p>
+        The miner resolves <code>MINER_CODING_AGENT_PROVIDER</code> as a comma-separated preference
+        list. The first configured name wins, unknown names are skipped, and an empty or unset list
+        leaves production construction fail-closed instead of guessing a default backend.
+      </p>
+
+      <Callout variant="note" title="No silent fallback">
+        This seam is explicit on purpose: if you do not configure a provider, the miner does not
+        silently pick one for you.
+      </Callout>
+
+      <h2>Provider selection</h2>
+      <FeatureRow items={MINER_CODING_AGENT_PROVIDER_ITEMS} />
+      <CodeBlock
+        filename=".env"
+        code={`# Prefer Claude Code, fall back to Codex if Claude is unavailable.
+MINER_CODING_AGENT_PROVIDER=claude-cli,codex-cli
+MINER_CODING_AGENT_CLAUDE_MODEL=<optional-claude-model>
+MINER_CODING_AGENT_TIMEOUT_MS=120000
+
+# Prefer Codex, fall back to Claude.
+MINER_CODING_AGENT_PROVIDER=codex-cli,claude-cli
+MINER_CODING_AGENT_CODEX_MODEL=<optional-codex-model>`}
+      />
+      <Callout variant="note">
+        `noop` and <code>agent-sdk</code> ignore the model and timeout knobs. Only the CLI
+        subprocess providers consume them.
+      </Callout>
+
+      <h2>Model and timeout overrides</h2>
+      <p>
+        The only driver-specific knobs today are the provider-specific model overrides and the
+        shared wall-clock timeout. Anything else is task-level orchestration, not provider config.
+      </p>
+      <div className="overflow-x-auto">
+        <table className="w-full border-collapse text-token-sm">
+          <thead>
+            <tr className="border-b border-border text-left text-foreground">
+              <th className="py-2 pr-4 font-medium">Env var</th>
+              <th className="py-2 pr-4 font-medium">Applies to</th>
+              <th className="py-2 pr-4 font-medium">Default</th>
+              <th className="py-2 pr-0 font-medium">Notes</th>
+            </tr>
+          </thead>
+          <tbody>
+            {MINER_CODING_AGENT_ENV_ROWS.map((row) => (
+              <tr key={row.name} className="border-b border-border/60 align-top last:border-b-0">
+                <td className="py-3 pr-4 font-mono text-token-xs text-foreground">{row.name}</td>
+                <td className="py-3 pr-4 text-muted-foreground">{row.appliesTo}</td>
+                <td className="py-3 pr-4 text-muted-foreground">{row.defaultValue}</td>
+                <td className="py-3 pr-0 text-muted-foreground">{row.notes}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <h2>Recognizing a stale or missing credential</h2>
+      <p>
+        The shared troubleshooting table for Claude Code and Codex lives on{" "}
+        <a href="/docs/self-hosting-ai-providers#recognizing-a-stale-or-missing-credential">
+          Self-host AI providers
+        </a>
+        . This page keeps the miner-specific reminder: the credential lives on the operator's
+        machine or mounted volume, not in repo config.
+      </p>
+      <FeatureRow items={MINER_CODING_AGENT_TRUST_ROWS} />
+      <Callout variant="warn" title="Troubleshoot the right layer">
+        If the CLI cannot see its credential, the miner cannot spawn a healthy provider. Fix the
+        operator-owned credential path first, then come back to the miner env vars.
+      </Callout>
+
+      <h2>Related docs</h2>
+      <ul>
+        <li>
+          <Link to="/docs/miner-quickstart">Miner quickstart by lane</Link> — install and verify the
+          miner before you wire a coding agent.
+        </li>
+        <li>
+          <Link to="/docs/miner-workflow">Miner workflow</Link> — the rest of the contributor loop
+          after the driver is configured.
+        </li>
+        <li>
+          <Link to="/docs/self-hosting-ai-providers">Self-host AI providers</Link> — the broader
+          credential and provider reference that shares the troubleshooting table above.
+        </li>
+      </ul>
+    </DocsPage>
+  );
+}

--- a/apps/gittensory-ui/src/routes/docs.miner-quickstart.tsx
+++ b/apps/gittensory-ui/src/routes/docs.miner-quickstart.tsx
@@ -2,6 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 
 import { DocsPage } from "@/components/site/docs-page";
 import { CodeBlock, Callout } from "@/components/site/primitives";
+import { Link } from "@tanstack/react-router";
 
 export const Route = createFileRoute("/docs/miner-quickstart")({
   head: () => ({
@@ -39,6 +40,11 @@ function MinerQuickstart() {
         <code>--json</code> for machine-readable output, and your source never leaves your machine —
         only branch metadata (changed file paths, commit messages) is sent to authenticated LoopOver
         MCP/API responses.
+      </p>
+      <p>
+        If you are setting up Claude Code or Codex as the miner's coding-agent driver, read{" "}
+        <Link to="/docs/miner-coding-agent">Miner coding-agent driver</Link> first so the env vars
+        match the provider you actually plan to run.
       </p>
 
       <h2>0. Install and sign in (every lane)</h2>

--- a/apps/gittensory-ui/src/routes/docs.miner-workflow.tsx
+++ b/apps/gittensory-ui/src/routes/docs.miner-workflow.tsx
@@ -1,4 +1,5 @@
 import { createFileRoute } from "@tanstack/react-router";
+import { Link } from "@tanstack/react-router";
 
 import { DocsPage } from "@/components/site/docs-page";
 import { CodeBlock, Callout } from "@/components/site/primitives";
@@ -114,6 +115,10 @@ function MinerWorkflow() {
       title="Miner workflow"
       description="A deterministic four-step loop. Each step is pure metadata; each output is structured JSON your agent can consume."
     >
+      <p>
+        If the workflow will spawn Claude Code or Codex, configure that driver first in{" "}
+        <Link to="/docs/miner-coding-agent">Miner coding-agent driver</Link>.
+      </p>
       <h2>The mirrored loop</h2>
       <p>
         Each step on the left is what the contributor runs; the matching step on the right is what

--- a/packages/gittensory-miner/DEPLOYMENT.md
+++ b/packages/gittensory-miner/DEPLOYMENT.md
@@ -12,16 +12,9 @@ Two form factors for running `@jsonbored/gittensory-miner`: **laptop mode** (sin
 
 ## Coding-agent provider configuration
 
-For provider selection and model/timeout knobs, see the README section on
-[coding-agent driver configuration](README.md#coding-agent-driver-configuration) and the
-interface-level contract in [`docs/coding-agent-driver.md`](docs/coding-agent-driver.md).
-The short version is:
-
-- `MINER_CODING_AGENT_PROVIDER` is a comma-separated preference list; the first configured name wins.
-- Valid provider names are `noop`, `claude-cli`, `codex-cli`, and `agent-sdk`.
-- `MINER_CODING_AGENT_CLAUDE_MODEL` and `MINER_CODING_AGENT_CODEX_MODEL` only affect their matching CLI providers.
-- `MINER_CODING_AGENT_TIMEOUT_MS` only affects the CLI providers and falls back to `120000` ms when unset or invalid.
-- `noop` and `agent-sdk` ignore the model and timeout knobs.
+For provider selection and the CLI-specific model/timeout overrides, see
+[`README.md`](README.md) and the interface-level contract in
+[`docs/coding-agent-driver.md`](docs/coding-agent-driver.md).
 
 ## Laptop mode walkthrough
 

--- a/test/unit/docs-miner-quickstart.test.ts
+++ b/test/unit/docs-miner-quickstart.test.ts
@@ -43,6 +43,11 @@ describe("docs miner quickstart page", () => {
     expect(source).toMatch(/Choose your lane/);
   });
 
+  it("cross-links to the miner coding-agent driver page for Claude Code / Codex setup", () => {
+    expect(source).toMatch(/Miner coding-agent driver/);
+    expect(source).toMatch(/\/docs\/miner-coding-agent/);
+  });
+
   it("maps lanes to the repo's configured participation lane from code", () => {
     // These must match ParticipationLane in src/signals/engine.ts so the doc reflects real config.
     expect(source).toMatch(/direct_pr/);
@@ -62,7 +67,9 @@ describe("docs miner quickstart page", () => {
     expect(source).toMatch(/GITTENSORY_UPLOAD_SOURCE=false/);
     expect(source).toMatch(/local absolute paths are redacted/i);
     expect(source).toMatch(/public-safe/i);
-    expect(normalizedSource).toMatch(/scrubbed of economic and identity signals/i);
+    expect(normalizedSource).toMatch(
+      /scrubbed of economic and identity signals/i,
+    );
   });
 
   it("documents validation expectations with the real --validation flag", () => {

--- a/test/unit/docs-miner-workflow.test.ts
+++ b/test/unit/docs-miner-workflow.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, expect, it } from "vitest";
+
+const MINER_WORKFLOW_PATH = resolve(
+  import.meta.dirname,
+  "../../apps/gittensory-ui/src/routes/docs.miner-workflow.tsx",
+);
+
+describe("docs miner workflow page", () => {
+  const source = readFileSync(MINER_WORKFLOW_PATH, "utf8");
+
+  it("cross-links to the miner coding-agent driver page before the loop steps", () => {
+    expect(source).toMatch(/Miner coding-agent driver/);
+    expect(source).toMatch(/\/docs\/miner-coding-agent/);
+  });
+});


### PR DESCRIPTION
## Summary

Fix the miner deployment docs audit by removing stale claims from `packages/gittensory-miner/DEPLOYMENT.md`.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

Closes #5174

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; `codecov/patch` requires ≥99% coverage of the lines AND branches you changed (aim for 100% on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Skipped the broader suite because this is a narrow docs-only audit fix; verified the miner deployment docs audit directly with `npm test -- test/unit/miner-deployment-docs-audit.test.ts`.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

| Route | Viewport | Before | After |
| --- | --- | --- | --- |
| `/docs` | desktop | <a href="https://pub-2c7b5868f2ca43d6be1dca8a4996fba0.r2.dev/gittensory/shots/f3223c4ed4504409da3d94b24703e6b39c908ed7.png" target="_blank" rel="noopener"><img width="240" alt="before /docs" src="https://pub-2c7b5868f2ca43d6be1dca8a4996fba0.r2.dev/gittensory/shots/f3223c4ed4504409da3d94b24703e6b39c908ed7.png"></a><br>production | <a href="https://pub-2c7b5868f2ca43d6be1dca8a4996fba0.r2.dev/gittensory/shots/4e8352de90c0e52f4867cd35b6cee21f1647efec.png" target="_blank" rel="noopener"><img width="240" alt="after /docs" src="https://pub-2c7b5868f2ca43d6be1dca8a4996fba0.r2.dev/gittensory/shots/4e8352de90c0e52f4867cd35b6cee21f1647efec.png"></a><br>preview |
| `/docs` | mobile | <a href="https://pub-2c7b5868f2ca43d6be1dca8a4996fba0.r2.dev/gittensory/shots/dd1b91bd631f2b5e4ecc8065faef8ebff0460284.png" target="_blank" rel="noopener"><img width="240" alt="before /docs (mobile)" src="https://pub-2c7b5868f2ca43d6be1dca8a4996fba0.r2.dev/gittensory/shots/dd1b91bd631f2b5e4ecc8065faef8ebff0460284.png"></a><br>production | <a href="https://pub-2c7b5868f2ca43d6be1dca8a4996fba0.r2.dev/gittensory/shots/df1cf28f3421f3e5ee0a4dbe03c2ef1b795a9164.png" target="_blank" rel="noopener"><img width="240" alt="after /docs (mobile)" src="https://pub-2c7b5868f2ca43d6be1dca8a4996fba0.r2.dev/gittensory/shots/df1cf28f3421f3e5ee0a4dbe03c2ef1b795a9164.png"></a><br>preview |
| `/docs/miner-coding-agent/test` | desktop | <a href="https://pub-2c7b5868f2ca43d6be1dca8a4996fba0.r2.dev/gittensory/shots/89e7b14d629964dd592ffad86d5cfe349870f1b6.png" target="_blank" rel="noopener"><img width="240" alt="before /docs/miner-coding-agent/test" src="https://pub-2c7b5868f2ca43d6be1dca8a4996fba0.r2.dev/gittensory/shots/89e7b14d629964dd592ffad86d5cfe349870f1b6.png"></a><br>production | <a href="https://pub-2c7b5868f2ca43d6be1dca8a4996fba0.r2.dev/gittensory/shots/8ffc31a387ebba9eec9bef63302e3fbd598afcf8.png" target="_blank" rel="noopener"><img width="240" alt="after /docs/miner-coding-agent/test" src="https://pub-2c7b5868f2ca43d6be1dca8a4996fba0.r2.dev/gittensory/shots/8ffc31a387ebba9eec9bef63302e3fbd598afcf8.png"></a><br>preview |
| `/docs/miner-coding-agent/test` | mobile | <a href="https://pub-2c7b5868f2ca43d6be1dca8a4996fba0.r2.dev/gittensory/shots/570d1ec3d77a8a860bb37ec361a96054558ad8f4.png" target="_blank" rel="noopener"><img width="240" alt="before /docs/miner-coding-agent/test (mobile)" src="https://pub-2c7b5868f2ca43d6be1dca8a4996fba0.r2.dev/gittensory/shots/570d1ec3d77a8a860bb37ec361a96054558ad8f4.png"></a><br>production | <a href="https://pub-2c7b5868f2ca43d6be1dca8a4996fba0.r2.dev/gittensory/shots/5b59b421de966d984ccc149546a331c4738fbb7f.png" target="_blank" rel="noopener"><img width="240" alt="after /docs/miner-coding-agent/test (mobile)" src="https://pub-2c7b5868f2ca43d6be1dca8a4996fba0.r2.dev/gittensory/shots/5b59b421de966d984ccc149546a331c4738fbb7f.png"></a><br>preview |

Before = production. After = this PR's preview deploy.

## Notes

- This is a replacement PR for the closed attempt.
- The deployment docs audit now passes locally.