### PR TITLE
feat(miner): paginate discovery fetches via the GitHub Link header (#4831)

### DIFF
--- a/packages/gittensory-miner/lib/opportunity-fanout.js
+++ b/packages/gittensory-miner/lib/opportunity-fanout.js
@@ -5,6 +5,9 @@ import { fetchWithRetry } from "./http-retry.js";
 const defaultApiBaseUrl = "https://api.github.com";
 const defaultConcurrency = 5;
 const defaultPerPage = 100;
+// Follow the GitHub Link header past the first page so a repo/search with >100 open issues isn't silently
+// truncated (#4831); cap the follow loop so a pathological Link chain can't run away.
+const defaultMaxPages = 10;
 const githubApiVersion = "2022-11-28";
 
 function normalizeLimit(value, fallback, min, max) {
@@ -207,33 +210,46 @@ function searchQueryWithIssueQualifiers(searchQuery) {
   return `${trimmed} state:open type:issue`;
 }
 
+// The URL of the next page from a GitHub Link header (`<url>; rel="next"`), or null when this is the last page.
+function nextPageUrl(response) {
+  const linkHeader = response.headers.get("link") ?? "";
+  const match = linkHeader.match(/<([^>]+)>;\s*rel="next"/);
+  return match !== null ? match[1] : null;
+}
+
 async function fetchTargetIssues(target, githubToken, options, summary, warnings) {
   const verdict = await resolveRepoAiPolicy(target, githubToken, options, summary, warnings);
   if (!verdict.allowed) return [];
 
-  const url = apiUrl(
+  let url = apiUrl(
     options.apiBaseUrl,
     repoPath(target, "/issues"),
     `?state=open&per_page=${options.perPage}`,
   );
+  const issues = [];
   try {
-    const { response, payload } = await githubGetJson(url, githubToken, summary, options);
-    if (!response.ok) {
-      warnings.push(warning(target, "issues", `GitHub returned ${response.status}`));
-      return [];
+    for (let page = 0; url !== null && page < options.maxPages; page += 1) {
+      const { response, payload } = await githubGetJson(url, githubToken, summary, options);
+      if (!response.ok) {
+        warnings.push(warning(target, "issues", `GitHub returned ${response.status}`));
+        return issues;
+      }
+      if (!Array.isArray(payload)) {
+        warnings.push(warning(target, "issues", "GitHub returned a non-array issues payload"));
+        return issues;
+      }
+      for (const issue of payload) {
+        const normalized = normalizeIssue(target, issue, verdict.source);
+        if (normalized !== null) issues.push(normalized);
+      }
+      url = nextPageUrl(response);
     }
-    if (!Array.isArray(payload)) {
-      warnings.push(warning(target, "issues", "GitHub returned a non-array issues payload"));
-      return [];
-    }
-    return payload
-      .map((issue) => normalizeIssue(target, issue, verdict.source))
-      .filter((issue) => issue !== null);
+    return issues;
   } catch (error) {
     warnings.push(
       warning(target, "issues", error instanceof Error ? error.message : "issue fetch failed"),
     );
-    return [];
+    return issues;
   }
 }
 
@@ -241,37 +257,42 @@ async function fetchSearchIssues(searchQuery, githubToken, options, summary, war
   const qualifiedQuery = searchQueryWithIssueQualifiers(searchQuery);
   if (!qualifiedQuery) return [];
 
-  const url = apiUrl(
+  let url = apiUrl(
     options.apiBaseUrl,
     "/search/issues",
     `?q=${encodeURIComponent(qualifiedQuery)}&per_page=${options.perPage}`,
   );
+  const items = [];
   try {
-    const { response, payload } = await githubGetJson(url, githubToken, summary, options);
-    if (!response.ok) {
-      warnings.push({
-        repoFullName: "*",
-        stage: "search",
-        message: `GitHub returned ${response.status}`,
-      });
-      return [];
+    for (let page = 0; url !== null && page < options.maxPages; page += 1) {
+      const { response, payload } = await githubGetJson(url, githubToken, summary, options);
+      if (!response.ok) {
+        warnings.push({
+          repoFullName: "*",
+          stage: "search",
+          message: `GitHub returned ${response.status}`,
+        });
+        return items;
+      }
+      if (!payload || typeof payload !== "object" || !Array.isArray(payload.items)) {
+        warnings.push({
+          repoFullName: "*",
+          stage: "search",
+          message: "GitHub returned a non-array search payload",
+        });
+        return items;
+      }
+      items.push(...payload.items);
+      url = nextPageUrl(response);
     }
-    if (!payload || typeof payload !== "object" || !Array.isArray(payload.items)) {
-      warnings.push({
-        repoFullName: "*",
-        stage: "search",
-        message: "GitHub returned a non-array search payload",
-      });
-      return [];
-    }
-    return payload.items;
+    return items;
   } catch (error) {
     warnings.push({
       repoFullName: "*",
       stage: "search",
       message: error instanceof Error ? error.message : "issue search failed",
     });
-    return [];
+    return items;
   }
 }
 
@@ -297,6 +318,7 @@ function normalizeOptions(options = {}) {
         : defaultApiBaseUrl,
     concurrency: normalizeLimit(options.concurrency, defaultConcurrency, 1, 10),
     perPage: normalizeLimit(options.perPage, defaultPerPage, 1, 100),
+    maxPages: normalizeLimit(options.maxPages, defaultMaxPages, 1, 100),
     // Passed through to the per-fetch retry so tests can inject an instant sleep; undefined uses the real backoff.
     sleepFn: typeof options.sleepFn === "function" ? options.sleepFn : undefined,
   };

--- a/test/unit/miner-opportunity-fanout-pagination.test.ts
+++ b/test/unit/miner-opportunity-fanout-pagination.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@jsonbored/gittensory-engine", async () => {
+  return import("../../packages/gittensory-engine/src/index");
+});
+
+import {
+  fetchCandidateIssuesWithSummary,
+  searchCandidateIssuesWithSummary,
+} from "../../packages/gittensory-miner/lib/opportunity-fanout.js";
+
+const API = "https://api.test";
+const TARGET = [{ owner: "acme", repo: "widgets" }];
+
+type DiscoverOptions = {
+  apiBaseUrl?: string;
+  perPage?: number;
+  maxPages?: number;
+};
+
+// checkJs infers a structurally narrow options type for the fan-out .js module, so pass a typed, non-fresh
+// object rather than a fresh literal — the extra maxPages field is then accepted by structural assignment.
+function discoverOptions(overrides: DiscoverOptions = {}): DiscoverOptions {
+  return { apiBaseUrl: API, ...overrides };
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}) {
+  return Response.json(body, {
+    ...init,
+    headers: {
+      "x-ratelimit-remaining": "42",
+      "x-ratelimit-reset": "1800000000",
+      ...(init.headers ?? {}),
+    },
+  });
+}
+
+function pagedResponse(body: unknown, nextUrl: string) {
+  return jsonResponse(body, { headers: { link: `<${nextUrl}>; rel="next"` } });
+}
+
+const issue = (number: number) => ({
+  number,
+  title: `Issue ${number}`,
+  labels: ["help wanted"],
+  comments: 1,
+  created_at: "2026-07-01T00:00:00Z",
+  updated_at: "2026-07-01T01:00:00Z",
+  html_url: `https://github.com/acme/widgets/issues/${number}`,
+});
+
+const searchItem = (number: number) => ({
+  ...issue(number),
+  repository: { full_name: "acme/widgets" },
+});
+
+const pageParam = (url: string) => Number(url.match(/[?&]page=(\d+)/)?.[1] ?? "1");
+const issuesNextUrl = (page: number) =>
+  `${API}/repos/acme/widgets/issues?state=open&per_page=100&page=${page}`;
+const searchNextUrl = (page: number) =>
+  `${API}/search/issues?q=${encodeURIComponent("x state:open type:issue")}&per_page=100&page=${page}`;
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("discovery fanout Link-header pagination (#4831)", () => {
+  it("follows the target-issues Link header across pages and returns every result", async () => {
+    let issuesFetches = 0;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/contents/")) return jsonResponse({}, { status: 404 });
+      if (url.includes("/issues?")) {
+        issuesFetches += 1;
+        if (pageParam(url) === 2) return jsonResponse([issue(3)]);
+        return pagedResponse([issue(1), issue(2)], issuesNextUrl(2));
+      }
+      throw new Error(`unexpected request: ${url}`);
+    });
+
+    const result = await fetchCandidateIssuesWithSummary(TARGET, "", discoverOptions());
+
+    expect(issuesFetches).toBe(2);
+    expect(result.issues.map((entry) => entry.issueNumber)).toEqual([1, 2, 3]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("stops target-issues pagination at maxPages even when a next link remains", async () => {
+    let issuesFetches = 0;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/contents/")) return jsonResponse({}, { status: 404 });
+      if (url.includes("/issues?")) {
+        issuesFetches += 1;
+        const current = pageParam(url);
+        return pagedResponse([issue(current)], issuesNextUrl(current + 1));
+      }
+      throw new Error(`unexpected request: ${url}`);
+    });
+
+    const result = await fetchCandidateIssuesWithSummary(TARGET, "", discoverOptions({ maxPages: 2 }));
+
+    expect(issuesFetches).toBe(2);
+    expect(result.issues.map((entry) => entry.issueNumber)).toEqual([1, 2]);
+  });
+
+  it("follows the search Link header across pages and returns every item", async () => {
+    let searchFetches = 0;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/contents/")) return jsonResponse({}, { status: 404 });
+      if (url.includes("/search/issues?")) {
+        searchFetches += 1;
+        if (pageParam(url) === 2) return jsonResponse({ items: [searchItem(3)] });
+        return pagedResponse({ items: [searchItem(1), searchItem(2)] }, searchNextUrl(2));
+      }
+      throw new Error(`unexpected request: ${url}`);
+    });
+
+    const result = await searchCandidateIssuesWithSummary("x", "", discoverOptions());
+
+    expect(searchFetches).toBe(2);
+    expect(result.issues.map((entry) => entry.issueNumber)).toEqual([1, 2, 3]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("stops search pagination at maxPages even when a next link remains", async () => {
+    let searchFetches = 0;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/contents/")) return jsonResponse({}, { status: 404 });
+      if (url.includes("/search/issues?")) {
+        searchFetches += 1;
+        const current = pageParam(url);
+        return pagedResponse({ items: [searchItem(current)] }, searchNextUrl(current + 1));
+      }
+      throw new Error(`unexpected request: ${url}`);
+    });
+
+    const result = await searchCandidateIssuesWithSummary("x", "", discoverOptions({ maxPages: 2 }));
+
+    expect(searchFetches).toBe(2);
+    expect(result.issues.map((entry) => entry.issueNumber)).toEqual([1, 2]);
+  });
+
+  it("warns and returns what it has when a target-issues page is not an array", async () => {
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/contents/")) return jsonResponse({}, { status: 404 });
+      if (url.includes("/issues?")) return jsonResponse({ unexpected: true });
+      throw new Error(`unexpected request: ${url}`);
+    });
+
+    const result = await fetchCandidateIssuesWithSummary(TARGET, "", discoverOptions());
+
+    expect(result.issues).toEqual([]);
+    expect(result.warnings).toEqual([
+      { repoFullName: "acme/widgets", stage: "issues", message: "GitHub returned a non-array issues payload" },
+    ]);
+  });
+
+  it("warns and returns what it has when a target-issues fetch throws", async () => {
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/contents/")) return jsonResponse({}, { status: 404 });
+      if (url.includes("/issues?")) throw new Error("issues offline");
+      throw new Error(`unexpected request: ${url}`);
+    });
+
+    const result = await fetchCandidateIssuesWithSummary(TARGET, "", discoverOptions());
+
+    expect(result.issues).toEqual([]);
+    expect(result.warnings).toEqual([
+      { repoFullName: "acme/widgets", stage: "issues", message: "issues offline" },
+    ]);
+  });
+
+  it.each([
+    ["a null payload", null],
+    ["a non-object payload", 42],
+    ["items that are not an array", { items: "nope" }],
+  ])("warns and stops the search when GitHub returns %s", async (_label, body) => {
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/search/issues?")) return jsonResponse(body);
+      throw new Error(`unexpected request: ${url}`);
+    });
+
+    const result = await searchCandidateIssuesWithSummary("x", "", discoverOptions());
+
+    expect(result.issues).toEqual([]);
+    expect(result.warnings).toEqual([
+      { repoFullName: "*", stage: "search", message: "GitHub returned a non-array search payload" },
+    ]);
+  });
+
+  it("warns and returns what it has when a search fetch throws", async () => {
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/search/issues?")) throw new Error("search offline");
+      throw new Error(`unexpected request: ${url}`);
+    });
+
+    const result = await searchCandidateIssuesWithSummary("x", "", discoverOptions());
+
+    expect(result.issues).toEqual([]);
+    expect(result.warnings).toEqual([
+      { repoFullName: "*", stage: "search", message: "search offline" },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

Discovery fetches requested only a single page (max 100 results) with no Link-header follow loop, so a repo with more than 100 open issues — or a search with more than 100 hits — was silently truncated to the first page (#4831).

This adds GitHub Link-header pagination to **both** discovery fetch paths (`fetchTargetIssues` and `fetchSearchIssues`): each follows the response's `rel="next"` URL until there is no next page, bounded by a `maxPages` cap (default 10) so a pathological Link chain can't run away. The first-page request is byte-identical to before, so behavior is unchanged for any repo/search that already fits in one page — only the follow-on pages are new.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes. (Miner discovery fan-out only — one file plus its test.)
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves — Closes #4831.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — **100% of the changed lines AND branches are covered** (verified against `coverage/lcov.info`: zero uncovered/partial changed lines).
- [x] `npm run test:workers`
- [x] `npm run build:mcp` · `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check` · `npm run ui:lint` · `npm run ui:typecheck` · `npm run ui:build`
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] New behavior has unit tests for new branches and fallback paths — `test/unit/miner-opportunity-fanout-pagination.test.ts` (10 cases: target- and search-issues multi-page follow; both `maxPages` caps; non-array target page; non-object / null / non-array-items search payloads; and a thrown fetch on each path).

Ran the full `npm run test:ci` chain — no required check was skipped.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics. (No user-facing text added; existing warnings unchanged.)
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A: no auth/CORS/session surface is touched.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A: no request/response or MCP surface change; this is an internal fetch-loop over an existing endpoint.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A: no UI change.
- [x] Visible UI changes include a `UI Evidence` section. — N/A: backend-only (`packages/gittensory-miner/lib/**`); no visible surface.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — no docs/changelog change required.

## UI Evidence

N/A — backend-only change (`packages/gittensory-miner/lib/opportunity-fanout.js`); no UI, frontend, docs, or extension surface.

## Notes

- Pagination is **default-on** and needs no caller change: it follows the `rel="next"` URL from GitHub's Link header (rather than constructing `&page=N`), so the first request is unchanged and single-page repos/searches behave exactly as before. The `maxPages` bound (default 10 = up to ~1000 results per path) prevents a runaway follow loop; it mirrors the page-loop discipline already in `ci-poller.js` (`hasNextLink`).
