### PR TITLE
feat(miner): paginate discovery issue and search fetches

### DIFF
--- a/packages/gittensory-miner/lib/opportunity-fanout.d.ts
+++ b/packages/gittensory-miner/lib/opportunity-fanout.d.ts
@@ -3,6 +3,8 @@ export type FanoutTarget = {
   repo: string;
 };
 
+export function nextPageUrl(linkHeader: unknown): string | null;
+
 export type RawCandidateIssue = {
   owner: string;
   repo: string;
@@ -38,6 +40,7 @@ export function fetchCandidateIssuesWithSummary(
     apiBaseUrl?: string;
     concurrency?: number;
     perPage?: number;
+    maxPages?: number;
     sleepFn?: (ms: number) => Promise<unknown>;
   },
 ): Promise<CandidateIssueSummary>;
@@ -49,6 +52,7 @@ export function fetchCandidateIssues(
     apiBaseUrl?: string;
     concurrency?: number;
     perPage?: number;
+    maxPages?: number;
     sleepFn?: (ms: number) => Promise<unknown>;
   },
 ): Promise<RawCandidateIssue[]>;
@@ -60,6 +64,7 @@ export function searchCandidateIssuesWithSummary(
     apiBaseUrl?: string;
     concurrency?: number;
     perPage?: number;
+    maxPages?: number;
     sleepFn?: (ms: number) => Promise<unknown>;
   },
 ): Promise<CandidateIssueSummary>;
@@ -71,6 +76,7 @@ export function searchCandidateIssues(
     apiBaseUrl?: string;
     concurrency?: number;
     perPage?: number;
+    maxPages?: number;
     sleepFn?: (ms: number) => Promise<unknown>;
   },
 ): Promise<RawCandidateIssue[]>;

--- a/packages/gittensory-miner/lib/opportunity-fanout.js
+++ b/packages/gittensory-miner/lib/opportunity-fanout.js
@@ -5,6 +5,8 @@ import { fetchWithRetry } from "./http-retry.js";
 const defaultApiBaseUrl = "https://api.github.com";
 const defaultConcurrency = 5;
 const defaultPerPage = 100;
+// Overall pagination cap per fetch path (maxPages × perPage results) to avoid a runaway follow loop (#4831).
+const defaultMaxPages = 10;
 const githubApiVersion = "2022-11-28";
 
 function normalizeLimit(value, fallback, min, max) {
@@ -116,6 +118,39 @@ async function githubGetJson(url, githubToken, summary, options) {
   return { response, payload };
 }
 
+/** Parse a GitHub `Link` header for the `rel="next"` page URL, or null when there is no next page. Pure. */
+export function nextPageUrl(linkHeader) {
+  if (typeof linkHeader !== "string") return null;
+  for (const part of linkHeader.split(",")) {
+    const match = part.match(/<([^>]+)>\s*;\s*rel="next"/);
+    if (match) return match[1];
+  }
+  return null;
+}
+
+/**
+ * Fetch every page starting at `firstUrl`, following the `Link` header's `rel="next"` up to `maxPages` (a cap to
+ * avoid runaway fetches). `extractPage(payload)` pulls one page's item array out of its payload, or returns null
+ * for a malformed payload. Returns `{ items }` on full success, or `{ items, notOk }` / `{ items, badPayload }`
+ * when a page failed — `items` holds whatever was collected from the earlier pages so a later failure never
+ * discards the results already fetched. A thrown error propagates to the caller's try/catch.
+ */
+async function fetchAllPages(firstUrl, githubToken, summary, options, extractPage, maxPages) {
+  const items = [];
+  let url = firstUrl;
+  let pages = 0;
+  while (url && pages < maxPages) {
+    pages += 1;
+    const { response, payload } = await githubGetJson(url, githubToken, summary, options);
+    if (!response.ok) return { items, notOk: response };
+    const page = extractPage(payload);
+    if (page === null) return { items, badPayload: true };
+    items.push(...page);
+    url = nextPageUrl(response.headers.get("link"));
+  }
+  return { items };
+}
+
 function decodeContentPayload(payload) {
   if (!payload || typeof payload !== "object" || Array.isArray(payload)) return null;
   if (typeof payload.content !== "string") return null;
@@ -217,16 +252,17 @@ async function fetchTargetIssues(target, githubToken, options, summary, warnings
     `?state=open&per_page=${options.perPage}`,
   );
   try {
-    const { response, payload } = await githubGetJson(url, githubToken, summary, options);
-    if (!response.ok) {
-      warnings.push(warning(target, "issues", `GitHub returned ${response.status}`));
-      return [];
-    }
-    if (!Array.isArray(payload)) {
-      warnings.push(warning(target, "issues", "GitHub returned a non-array issues payload"));
-      return [];
-    }
-    return payload
+    const { items, notOk, badPayload } = await fetchAllPages(
+      url,
+      githubToken,
+      summary,
+      options,
+      (payload) => (Array.isArray(payload) ? payload : null),
+      options.maxPages,
+    );
+    if (notOk) warnings.push(warning(target, "issues", `GitHub returned ${notOk.status}`));
+    else if (badPayload) warnings.push(warning(target, "issues", "GitHub returned a non-array issues payload"));
+    return items
       .map((issue) => normalizeIssue(target, issue, verdict.source))
       .filter((issue) => issue !== null);
   } catch (error) {
@@ -247,24 +283,20 @@ async function fetchSearchIssues(searchQuery, githubToken, options, summary, war
     `?q=${encodeURIComponent(qualifiedQuery)}&per_page=${options.perPage}`,
   );
   try {
-    const { response, payload } = await githubGetJson(url, githubToken, summary, options);
-    if (!response.ok) {
-      warnings.push({
-        repoFullName: "*",
-        stage: "search",
-        message: `GitHub returned ${response.status}`,
-      });
-      return [];
+    const { items, notOk, badPayload } = await fetchAllPages(
+      url,
+      githubToken,
+      summary,
+      options,
+      (payload) => (payload && typeof payload === "object" && Array.isArray(payload.items) ? payload.items : null),
+      options.maxPages,
+    );
+    if (notOk) {
+      warnings.push({ repoFullName: "*", stage: "search", message: `GitHub returned ${notOk.status}` });
+    } else if (badPayload) {
+      warnings.push({ repoFullName: "*", stage: "search", message: "GitHub returned a non-array search payload" });
     }
-    if (!payload || typeof payload !== "object" || !Array.isArray(payload.items)) {
-      warnings.push({
-        repoFullName: "*",
-        stage: "search",
-        message: "GitHub returned a non-array search payload",
-      });
-      return [];
-    }
-    return payload.items;
+    return items;
   } catch (error) {
     warnings.push({
       repoFullName: "*",
@@ -297,6 +329,7 @@ function normalizeOptions(options = {}) {
         : defaultApiBaseUrl,
     concurrency: normalizeLimit(options.concurrency, defaultConcurrency, 1, 10),
     perPage: normalizeLimit(options.perPage, defaultPerPage, 1, 100),
+    maxPages: normalizeLimit(options.maxPages, defaultMaxPages, 1, 50),
     // Passed through to the per-fetch retry so tests can inject an instant sleep; undefined uses the real backoff.
     sleepFn: typeof options.sleepFn === "function" ? options.sleepFn : undefined,
   };

--- a/test/unit/miner-opportunity-fanout.test.ts
+++ b/test/unit/miner-opportunity-fanout.test.ts
@@ -8,6 +8,7 @@ vi.mock("@jsonbored/gittensory-engine", async () => {
 import {
   fetchCandidateIssues,
   fetchCandidateIssuesWithSummary,
+  nextPageUrl,
   searchCandidateIssuesWithSummary,
 } from "../../packages/gittensory-miner/lib/opportunity-fanout.js";
 
@@ -332,5 +333,131 @@ describe("fetchCandidateIssues (#2307)", () => {
     expect(issuesAttempts).toBe(2); // the 503 was retried, then succeeded
     expect(result.issues.map((entry) => entry.issueNumber)).toEqual([7]); // results kept, not dropped
     expect(result.warnings).toEqual([]); // no warning — the transient blip recovered
+  });
+
+  it("follows Link-header pagination to fetch every page of a repo's issues (#4831)", async () => {
+    let issuesPage = 0;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/contents/AI-USAGE.md")) return jsonResponse({}, { status: 404 });
+      if (url.endsWith("/contents/CONTRIBUTING.md")) return contentResponse("Contributions welcome.");
+      if (url.includes("/repos/acme/big/issues")) {
+        issuesPage += 1;
+        if (issuesPage === 1) {
+          return jsonResponse([issue(1)], {
+            headers: { link: `<${API}/repos/acme/big/issues?state=open&per_page=100&page=2>; rel="next"` },
+          });
+        }
+        return jsonResponse([issue(2)]); // final page, no Link header ⇒ stop
+      }
+      return jsonResponse({}, { status: 404 });
+    });
+
+    const result = await fetchCandidateIssuesWithSummary([{ owner: "acme", repo: "big" }], "token", { apiBaseUrl: API });
+    expect(issuesPage).toBe(2);
+    expect(result.issues.map((entry) => entry.issueNumber)).toEqual([1, 2]);
+    expect(result.warnings).toEqual([]);
+  });
+
+  it("follows Link-header pagination for search results (#4831)", async () => {
+    let searchPage = 0;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      if (String(input).includes("/search/issues")) {
+        searchPage += 1;
+        if (searchPage === 1) {
+          return jsonResponse({ items: [issue(10)] }, {
+            headers: { link: `<${API}/search/issues?q=x&page=2>; rel="next"` },
+          });
+        }
+        return jsonResponse({ items: [issue(20)] });
+      }
+      return jsonResponse({}, { status: 404 });
+    });
+
+    const result = await searchCandidateIssuesWithSummary("label:feature", "token", { apiBaseUrl: API });
+    expect(searchPage).toBe(2);
+    expect(result.issues.map((entry) => entry.issueNumber)).toEqual([10, 20]);
+  });
+
+  it("caps pagination at maxPages to avoid a runaway follow loop (#4831)", async () => {
+    let searchPage = 0;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      if (String(input).includes("/search/issues")) {
+        searchPage += 1;
+        // Every page advertises a next page — only the maxPages cap stops the loop.
+        return jsonResponse({ items: [issue(searchPage)] }, {
+          headers: { link: `<${API}/search/issues?q=x&page=${searchPage + 1}>; rel="next"` },
+        });
+      }
+      return jsonResponse({}, { status: 404 });
+    });
+
+    const result = await searchCandidateIssuesWithSummary("label:feature", "token", { apiBaseUrl: API, maxPages: 2 });
+    expect(searchPage).toBe(2); // stopped at the cap despite an ever-present next link
+    expect(result.issues.map((entry) => entry.issueNumber)).toEqual([1, 2]);
+  });
+
+  it("keeps earlier pages' issues when a later page fails mid-pagination (#4831)", async () => {
+    let issuesPage = 0;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/contents/AI-USAGE.md")) return jsonResponse({}, { status: 404 });
+      if (url.endsWith("/contents/CONTRIBUTING.md")) return contentResponse("Contributions welcome.");
+      if (url.includes("/repos/acme/big/issues")) {
+        issuesPage += 1;
+        if (issuesPage === 1) {
+          return jsonResponse([issue(1)], {
+            headers: { link: `<${API}/repos/acme/big/issues?state=open&per_page=100&page=2>; rel="next"` },
+          });
+        }
+        return jsonResponse({ message: "server error" }, { status: 503 }); // page 2 fails
+      }
+      return jsonResponse({}, { status: 404 });
+    });
+
+    const result = await fetchCandidateIssuesWithSummary([{ owner: "acme", repo: "big" }], "token", {
+      apiBaseUrl: API,
+      sleepFn: () => Promise.resolve(),
+    });
+    expect(result.issues.map((entry) => entry.issueNumber)).toEqual([1]); // page 1 kept, not discarded
+    expect(result.warnings).toEqual([{ repoFullName: "acme/big", stage: "issues", message: "GitHub returned 503" }]);
+  });
+
+  it("warns on a non-array issues payload", async () => {
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/contents/AI-USAGE.md")) return jsonResponse({}, { status: 404 });
+      if (url.endsWith("/contents/CONTRIBUTING.md")) return contentResponse("Contributions welcome.");
+      if (url.includes("/repos/acme/big/issues")) return jsonResponse({ not: "an array" });
+      return jsonResponse({}, { status: 404 });
+    });
+    const result = await fetchCandidateIssuesWithSummary([{ owner: "acme", repo: "big" }], "token", { apiBaseUrl: API });
+    expect(result.issues).toEqual([]);
+    expect(result.warnings).toEqual([
+      { repoFullName: "acme/big", stage: "issues", message: "GitHub returned a non-array issues payload" },
+    ]);
+  });
+
+  it("warns on a non-array search payload", async () => {
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      if (String(input).includes("/search/issues")) return jsonResponse({ not: "items" });
+      return jsonResponse({}, { status: 404 });
+    });
+    const result = await searchCandidateIssuesWithSummary("label:feature", "token", { apiBaseUrl: API });
+    expect(result.issues).toEqual([]);
+    expect(result.warnings).toEqual([
+      { repoFullName: "*", stage: "search", message: "GitHub returned a non-array search payload" },
+    ]);
+  });
+});
+
+describe("nextPageUrl (#4831)", () => {
+  it("extracts the rel=next URL, or null when absent or malformed", () => {
+    expect(
+      nextPageUrl('<https://api.test/x?page=2>; rel="next", <https://api.test/x?page=5>; rel="last"'),
+    ).toBe("https://api.test/x?page=2");
+    expect(nextPageUrl('<https://api.test/x?page=5>; rel="last"')).toBeNull();
+    expect(nextPageUrl(null)).toBeNull();
+    expect(nextPageUrl(undefined)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Discovery fetches requested only a single page (max 100 results) with no `Link`-header follow loop, so a repo with **over 100 open issues**, or a search with **over 100 hits**, silently truncated.

This adds `Link`-header-following pagination to **both** the target-issues fetch and the search-issues fetch in the discovery fanout:
- A pure `nextPageUrl(linkHeader)` parser extracts the `rel="next"` URL.
- A shared `fetchAllPages` loop follows `next` (through the existing `githubGetJson`, so per-fetch retry from #4830 and rate-limit telemetry are unchanged), accumulating results.
- Capped at **`maxPages`** (default 10 → 10 × `perPage` results) to avoid a runaway follow loop.

Behaviour-preserving details:
- A single page with no `Link` header stops after page one (existing behaviour).
- A **mid-pagination failure keeps the pages already fetched** rather than discarding them (a later 5xx/bad payload doesn't lose page 1).

## Scope

- [x] Narrow, one coherent change — a pagination helper + refactor of the two fetch paths onto it + tests
- [x] In scope (`packages/`), no `blockedPaths`, no secrets/private terms; `.d.ts` updated (`nextPageUrl` + `maxPages`)

## Validation

- [x] `npm run typecheck`
- [x] `npm run test:coverage` (full unsharded suite)
- [x] `test/unit/miner-opportunity-fanout.test.ts`: full-pagination for issues and for search (>1 page returns all — the #4831 acceptance), the `maxPages` cap stops a runaway next-link loop, a mid-page failure keeps earlier pages, non-array issue/search payloads warn, and `nextPageUrl` parsing (next / absent / malformed)
- [x] Every added line covered; the existing single-page tests pass unchanged

## Safety

- [x] Read-only: follows GitHub's own `Link` header on existing GET calls; no writes, no new endpoints
- [x] Bounded by `maxPages` so pagination cannot run away; a persistent failure still degrades to a warning
- [x] No secrets, tokens, wallets, trust scores, or reward values in code, tests, or this description

Closes #4831
