### PR TITLE
refactor(rebrand): consolidate and rename hardcoded User-Agent literals

### DIFF
--- a/packages/gittensory-miner/lib/ams-policy.js
+++ b/packages/gittensory-miner/lib/ams-policy.js
@@ -58,7 +58,7 @@ async function fetchRepoAmsPolicyContent(target, resolved) {
   for (const path of AMS_POLICY_SPEC_FILENAMES) {
     const url = `${resolved.rawContentBaseUrl}/${encodeURIComponent(target.owner)}/${encodeURIComponent(target.repo)}/HEAD/${path}`;
     try {
-      const response = await resolved.fetchImpl(url, { method: "GET", headers: { accept: "application/json", "user-agent": "gittensory-miner" } });
+      const response = await resolved.fetchImpl(url, { method: "GET", headers: { accept: "application/json", "user-agent": "loopover-miner" } });
       if (response.ok) {
         const text = await response.text();
         if (typeof text === "string") return text;

--- a/packages/gittensory-miner/lib/ci-poller.js
+++ b/packages/gittensory-miner/lib/ci-poller.js
@@ -60,7 +60,7 @@ function normalizePullNumber(value) {
 function githubHeaders(githubToken) {
   const headers = {
     accept: "application/vnd.github+json",
-    "user-agent": "gittensory-miner",
+    "user-agent": "loopover-miner",
     "x-github-api-version": githubApiVersion,
   };
   if (githubToken) headers.authorization = `Bearer ${githubToken}`;

--- a/packages/gittensory-miner/lib/laptop-init.js
+++ b/packages/gittensory-miner/lib/laptop-init.js
@@ -114,7 +114,7 @@ function resolveCodexAuthPath(env = process.env) {
 function githubHeaders(githubToken) {
   const headers = {
     accept: "application/vnd.github+json",
-    "user-agent": "gittensory-miner",
+    "user-agent": "loopover-miner",
     "x-github-api-version": githubApiVersion,
   };
   const token = typeof githubToken === "string" ? githubToken.trim() : "";

--- a/packages/gittensory-miner/lib/live-issue-snapshot.js
+++ b/packages/gittensory-miner/lib/live-issue-snapshot.js
@@ -32,7 +32,7 @@ function githubGraphqlHeaders(githubToken) {
   const headers = {
     accept: "application/vnd.github+json",
     "content-type": "application/json",
-    "user-agent": "gittensory-miner",
+    "user-agent": "loopover-miner",
     "x-github-api-version": GITHUB_API_VERSION,
   };
   const token = typeof githubToken === "string" ? githubToken.trim() : "";

--- a/packages/gittensory-miner/lib/opportunity-fanout.js
+++ b/packages/gittensory-miner/lib/opportunity-fanout.js
@@ -68,7 +68,7 @@ function targetFromSearchIssue(issue) {
 function githubHeaders(githubToken) {
   const headers = {
     accept: "application/vnd.github+json",
-    "user-agent": "gittensory-miner",
+    "user-agent": "loopover-miner",
     "x-github-api-version": githubApiVersion,
   };
   const token = typeof githubToken === "string" ? githubToken.trim() : "";

--- a/packages/gittensory-miner/lib/pr-disposition-poller.js
+++ b/packages/gittensory-miner/lib/pr-disposition-poller.js
@@ -71,7 +71,7 @@ function normalizePullNumber(value) {
 function githubHeaders(githubToken) {
   const headers = {
     accept: "application/vnd.github+json",
-    "user-agent": "gittensory-miner",
+    "user-agent": "loopover-miner",
     "x-github-api-version": githubApiVersion,
   };
   if (githubToken) headers.authorization = `Bearer ${githubToken}`;

--- a/packages/gittensory-miner/lib/rejection-signal.js
+++ b/packages/gittensory-miner/lib/rejection-signal.js
@@ -36,7 +36,7 @@ function normalizeOptions(options = {}) {
 async function fetchPolicyDoc(target, path, resolved) {
   const url = `${resolved.rawContentBaseUrl}/${encodeURIComponent(target.owner)}/${encodeURIComponent(target.repo)}/HEAD/${path}`;
   try {
-    const response = await resolved.fetchImpl(url, { method: "GET", headers: { accept: "application/json", "user-agent": "gittensory-miner" } });
+    const response = await resolved.fetchImpl(url, { method: "GET", headers: { accept: "application/json", "user-agent": "loopover-miner" } });
     if (!response.ok) return null;
     const text = await response.text();
     return typeof text === "string" ? text : null;

--- a/packages/gittensory-miner/lib/self-review-context.js
+++ b/packages/gittensory-miner/lib/self-review-context.js
@@ -38,7 +38,7 @@ function parseRepoFullName(repoFullName) {
 function githubHeaders(githubToken) {
   const headers = {
     accept: "application/vnd.github+json",
-    "user-agent": "gittensory-miner",
+    "user-agent": "loopover-miner",
     "x-github-api-version": GITHUB_API_VERSION,
   };
   const token = typeof githubToken === "string" ? githubToken.trim() : "";
@@ -216,7 +216,7 @@ async function fetchManifestContent(target, resolved) {
   for (const path of MANIFEST_FILE_CANDIDATES) {
     const url = `${resolved.rawContentBaseUrl}/${encodeURIComponent(target.owner)}/${encodeURIComponent(target.repo)}/HEAD/${path}`;
     try {
-      const response = await resolved.fetchImpl(url, { method: "GET", headers: { accept: "application/json", "user-agent": "gittensory-miner" } });
+      const response = await resolved.fetchImpl(url, { method: "GET", headers: { accept: "application/json", "user-agent": "loopover-miner" } });
       if (response.ok) {
         const text = await response.text();
         if (typeof text === "string") return text;

--- a/scripts/check-mcp-release-due.mjs
+++ b/scripts/check-mcp-release-due.mjs
@@ -140,7 +140,7 @@ async function githubRequest({ token, method, path, body }) {
       accept: "application/vnd.github+json",
       authorization: `Bearer ${token}`,
       "content-type": "application/json",
-      "user-agent": "gittensory-mcp-release-watch",
+      "user-agent": "loopover-mcp-release-watch",
       "x-github-api-version": "2022-11-28",
     },
     body: body ? JSON.stringify(body) : undefined,

--- a/scripts/smoke-production.mjs
+++ b/scripts/smoke-production.mjs
@@ -106,7 +106,7 @@ async function fetchWithTimeout(url, init = {}) {
     return await fetch(url, {
       ...init,
       headers: {
-        "user-agent": "gittensory-production-smoke",
+        "user-agent": "loopover-production-smoke",
         ...(init.headers ?? {}),
       },
       signal: controller.signal,

--- a/src/auth/github-oauth.ts
+++ b/src/auth/github-oauth.ts
@@ -43,7 +43,7 @@ export async function startGitHubDeviceFlow(env: Env): Promise<GitHubDeviceCodeR
     headers: {
       accept: "application/json",
       "content-type": "application/json",
-      "user-agent": "gittensory-api",
+      "user-agent": "loopover-api",
     },
     body: JSON.stringify({
       client_id: env.GITHUB_OAUTH_CLIENT_ID,
@@ -69,7 +69,7 @@ export async function pollGitHubDeviceFlow(env: Env, deviceCode: string) {
     headers: {
       accept: "application/json",
       "content-type": "application/json",
-      "user-agent": "gittensory-api",
+      "user-agent": "loopover-api",
     },
     body: JSON.stringify({
       client_id: env.GITHUB_OAUTH_CLIENT_ID,
@@ -130,7 +130,7 @@ export async function completeGitHubWebOAuth(
     headers: {
       accept: "application/json",
       "content-type": "application/json",
-      "user-agent": "gittensory-api",
+      "user-agent": "loopover-api",
     },
     body: JSON.stringify({
       client_id: env.GITHUB_OAUTH_CLIENT_ID,
@@ -183,7 +183,7 @@ export async function createSessionFromGitHubToken(
     headers: {
       accept: "application/vnd.github+json",
       authorization: `Bearer ${githubToken}`,
-      "user-agent": "gittensory-api",
+      "user-agent": "loopover-api",
       "x-github-api-version": "2022-11-28",
     },
   });
@@ -213,7 +213,7 @@ async function verifyTokenBelongsToApp(env: Env, githubToken: string): Promise<b
       accept: "application/vnd.github+json",
       authorization: `Basic ${btoa(`${env.GITHUB_OAUTH_CLIENT_ID}:${env.GITHUB_OAUTH_CLIENT_SECRET}`)}`,
       "content-type": "application/json",
-      "user-agent": "gittensory-api",
+      "user-agent": "loopover-api",
       "x-github-api-version": "2022-11-28",
     },
     body: JSON.stringify({ access_token: githubToken }),

--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -76,6 +76,7 @@ import {
   githubRateLimitAdmissionKeyForPublicToken,
   githubRateLimitAdmissionKeyForToken,
   isGitHubResponseCacheReplay,
+  PRODUCT_USER_AGENT,
   timeoutFetch,
   type GitHubRateLimitAdmissionKey,
 } from "./client";
@@ -4412,7 +4413,7 @@ function notModifiedResponse(response: Response): GitHubJsonNotModifiedResponse 
 function githubRestHeaders(token?: string, validators?: GitHubConditionalValidators): HeadersInit {
   return {
     accept: "application/vnd.github+json",
-    "user-agent": "gittensory/0.1",
+    "user-agent": PRODUCT_USER_AGENT,
     "x-github-api-version": "2022-11-28",
     ...(validators?.etag ? { "if-none-match": validators.etag } : {}),
     ...(validators?.lastModified ? { "if-modified-since": validators.lastModified } : {}),

--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -29,6 +29,12 @@ const DEFAULT_METADATA_TTL_SECONDS = 10 * 60;
 const DEFAULT_COMMIT_TTL_SECONDS = 15 * 60;
 export const GITHUB_RESPONSE_CACHE_REPLAY_HEADER = "x-gittensory-cache";
 
+/** The single source of truth for the product's outbound User-Agent, used by every raw-`fetch`/`timeoutFetch`
+ *  call across `src/` that identifies itself generically (as opposed to a service-specific variant like the
+ *  self-host or content-lane User-Agent). Consolidates what had drifted into ~16 independently hardcoded
+ *  copies of the same literal. */
+export const PRODUCT_USER_AGENT = "loopover/0.1";
+
 /** The single shared GitHub REST header-builder for every raw-`fetch`/`timeoutFetch` call in `src/` (Octokit
  *  calls set their own headers internally and don't need this). Consolidates four independent, drifted
  *  `githubHeaders` copies that had each grown a different signature (#4610). `token` is optional — a public,
@@ -48,7 +54,7 @@ export function githubHeaders(options: GitHubHeadersOptions = {}): Record<string
   const { token, accept = "application/vnd.github+json", json = false, apiVersion = true } = options;
   return {
     accept,
-    "user-agent": "gittensory/0.1",
+    "user-agent": PRODUCT_USER_AGENT,
     ...(apiVersion ? { "x-github-api-version": "2022-11-28" } : {}),
     ...(json ? { "content-type": "application/json" } : {}),
     ...(token ? { authorization: `Bearer ${token}` } : {}),

--- a/src/github/graphql-cache.ts
+++ b/src/github/graphql-cache.ts
@@ -1,5 +1,6 @@
 import {
   GITHUB_RESPONSE_CACHE_REPLAY_HEADER,
+  PRODUCT_USER_AGENT,
   getGitHubResponseCache,
   timeoutFetch,
   type CachedGitHubResponse,
@@ -85,7 +86,7 @@ function graphQlFetchInit(query: string, token: string, admissionKey?: GitHubRat
     headers: {
       accept: "application/vnd.github+json",
       "content-type": "application/json",
-      "user-agent": "gittensory/0.1",
+      "user-agent": PRODUCT_USER_AGENT,
       authorization: `Bearer ${token}`,
     },
     body: JSON.stringify({ query }),

--- a/src/github/migration-tree.ts
+++ b/src/github/migration-tree.ts
@@ -1,4 +1,4 @@
-import { timeoutFetch, type GitHubRateLimitAdmissionKey } from "./client";
+import { PRODUCT_USER_AGENT, timeoutFetch, type GitHubRateLimitAdmissionKey } from "./client";
 import { repoParts } from "../utils/json";
 
 const GITHUB_FETCH_TIMEOUT_MS = 10_000;
@@ -8,7 +8,7 @@ const MIGRATIONS_PREFIX = "migrations/";
 function ghHeaders(token: string | undefined): Record<string, string> {
   return {
     accept: "application/vnd.github+json",
-    "user-agent": "gittensory/0.1",
+    "user-agent": PRODUCT_USER_AGENT,
     "x-github-api-version": "2022-11-28",
     ...(token ? { authorization: `Bearer ${token}` } : {}),
   };

--- a/src/github/public.ts
+++ b/src/github/public.ts
@@ -1,4 +1,4 @@
-import { githubRateLimitAdmissionKeyForPublicToken, timeoutFetch, type GitHubRateLimitAdmissionKey } from "./client";
+import { githubRateLimitAdmissionKeyForPublicToken, PRODUCT_USER_AGENT, timeoutFetch, type GitHubRateLimitAdmissionKey } from "./client";
 
 export type PublicContributorProfile = {
   login: string;
@@ -66,7 +66,7 @@ export async function fetchPublicContributorProfile(login: string, env?: Pick<En
   const safeLogin = encodeURIComponent(login);
   const headers = {
     accept: "application/vnd.github+json",
-    "user-agent": "gittensory/0.1",
+    "user-agent": PRODUCT_USER_AGENT,
     "x-github-api-version": "2022-11-28",
     // Authenticated requests lift the 60/hr unauthenticated ceiling to 5000/hr so the 500-login evidence
     // loop doesn't exhaust it and silently degrade (mirrors fetchPublicRepoStats) (#790).
@@ -192,7 +192,7 @@ async function fetchRepoStatsFromGitHub(env: Pick<Env, "GITHUB_PUBLIC_TOKEN">, r
   const response = await timeoutFetch(`https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`, {
     headers: {
       accept: "application/vnd.github+json",
-      "user-agent": "gittensory/0.1",
+      "user-agent": PRODUCT_USER_AGENT,
       "x-github-api-version": "2022-11-28",
       ...(env.GITHUB_PUBLIC_TOKEN ? { authorization: `Bearer ${env.GITHUB_PUBLIC_TOKEN}` } : {}),
     },

--- a/src/gittensor/api.ts
+++ b/src/gittensor/api.ts
@@ -1,4 +1,5 @@
 import type { ContributorRepoStatRecord } from "../types";
+import { PRODUCT_USER_AGENT } from "../github/client";
 import { errorMessage } from "../utils/json";
 
 const GITTENSOR_API_BASE = "https://api.gittensor.io";
@@ -282,7 +283,7 @@ async function fetchJson<T>(url: string): Promise<T> {
   const response = await fetch(url, {
     headers: {
       accept: "application/json",
-      "user-agent": "gittensory/0.1",
+      "user-agent": PRODUCT_USER_AGENT,
     },
     signal: AbortSignal.timeout(GITTENSOR_FETCH_TIMEOUT_MS),
   });

--- a/src/orb/app-auth.ts
+++ b/src/orb/app-auth.ts
@@ -11,7 +11,7 @@ function orbHeaders(jwt: string): HeadersInit {
     accept: "application/vnd.github+json",
     authorization: `Bearer ${jwt}`,
     "content-type": "application/json",
-    "user-agent": "gittensory-orb/0.1",
+    "user-agent": "loopover-orb/0.1",
     "x-github-api-version": "2022-11-28",
   };
 }

--- a/src/orb/oauth.ts
+++ b/src/orb/oauth.ts
@@ -13,7 +13,7 @@
 // (read back at token-exchange, never from a request). No request input is echoed into the markup (no injection
 // surface).
 import type { Context } from "hono";
-import { timeoutFetch } from "../github/client";
+import { PRODUCT_USER_AGENT, timeoutFetch } from "../github/client";
 import { GITTENSORY_SITE_URL } from "../github/footer";
 import { isOrbBrokerEnabled, issueOrbEnrollment } from "./broker";
 
@@ -36,7 +36,7 @@ export async function exchangeOrbOAuthCode(env: Env, code: string, fetchImpl: ty
 /** Identify the authenticated maintainer (GET /user with their token). Null on any non-OK / loginless response. */
 export async function fetchOrbOAuthUser(token: string, fetchImpl: typeof fetch = timeoutFetch): Promise<GitHubUser | null> {
   const res = await fetchImpl("https://api.github.com/user", {
-    headers: { authorization: `Bearer ${token}`, accept: "application/vnd.github+json", "user-agent": "gittensory/0.1" },
+    headers: { authorization: `Bearer ${token}`, accept: "application/vnd.github+json", "user-agent": PRODUCT_USER_AGENT },
   });
   const user = (await res.json().catch(() => ({}))) as GitHubUser;
   return res.ok && user.login ? user : null;
@@ -60,7 +60,7 @@ export async function verifyInstallationAdmin(
     return userId === accountId && userLogin.toLowerCase() === accountLogin.toLowerCase();
   }
   const res = await fetchImpl(`https://api.github.com/user/memberships/orgs/${encodeURIComponent(accountLogin)}`, {
-    headers: { authorization: `Bearer ${token}`, accept: "application/vnd.github+json", "user-agent": "gittensory/0.1" },
+    headers: { authorization: `Bearer ${token}`, accept: "application/vnd.github+json", "user-agent": PRODUCT_USER_AGENT },
   });
   if (!res.ok) return false;
   const body = (await res.json().catch(() => ({}))) as GitHubOrgMembership;

--- a/src/orb/relay.ts
+++ b/src/orb/relay.ts
@@ -465,7 +465,7 @@ export async function forwardOrbEvent(
         "x-github-event": args.eventName,
         "x-github-delivery": args.deliveryId,
         "x-orb-signature-256": `sha256=${signature}`,
-        "user-agent": "gittensory-orb/0.1",
+        "user-agent": "loopover-orb/0.1",
       },
       body: args.rawBody,
       signal: AbortSignal.timeout(10_000),

--- a/src/registry/sync.ts
+++ b/src/registry/sync.ts
@@ -1,6 +1,7 @@
 import { and, desc, eq, inArray } from "drizzle-orm";
 import { getDb } from "../db/client";
 import { registrySnapshots, repositories, syncRuns } from "../db/schema";
+import { PRODUCT_USER_AGENT } from "../github/client";
 import type { RegistrySnapshot } from "../types";
 import { errorMessage, jsonString, nowIso, repoParts } from "../utils/json";
 import { normalizeRegistryPayload } from "./normalize";
@@ -35,7 +36,7 @@ export async function refreshRegistry(env: Env): Promise<RegistrySnapshot> {
         const response = await fetch(url, {
           headers: {
             accept: "application/json",
-            "user-agent": "gittensory/0.1",
+            "user-agent": PRODUCT_USER_AGENT,
           },
         });
         if (!response.ok) {

--- a/src/review/content-lane/netuid-verification.ts
+++ b/src/review/content-lane/netuid-verification.ts
@@ -86,7 +86,7 @@ export async function fetchSubnetRecord(
   try {
     const res = await fetchWithRetry(
       `${base}/subnets/${netuid}`,
-      { headers: { accept: "application/json", "user-agent": "gittensory-content-lane" } },
+      { headers: { accept: "application/json", "user-agent": "loopover-content-lane" } },
       fetchImpl,
     );
     if (res.status === 404) return { status: "missing", record: null };

--- a/src/review/enrichment-wire.ts
+++ b/src/review/enrichment-wire.ts
@@ -77,7 +77,7 @@ async function fetchReesPingWithRetry(url: string, secret: string): Promise<Resp
     fetch(url, {
       method: "POST",
       headers: {
-        "user-agent": "gittensory-selfhost/1.0",
+        "user-agent": "loopover-selfhost/1.0",
         authorization: `Bearer ${secret}`,
       },
       signal: AbortSignal.timeout(5000),
@@ -447,7 +447,7 @@ export async function buildReviewEnrichment(
     const response = await fetch(`${base.replace(/\/+$/, "")}/v1/enrich`, {
       method: "POST",
       headers: {
-        "user-agent": "gittensory-selfhost/1.0",
+        "user-agent": "loopover-selfhost/1.0",
         accept: "application/json",
         "content-type": "application/json",
         "x-gittensory-request-id": requestId,

--- a/src/review/grounding-wire.ts
+++ b/src/review/grounding-wire.ts
@@ -12,7 +12,7 @@
 // fail-safe: any missing CI data / fetch error degrades to "no grounding" and the review proceeds on the diff.
 
 import { createInstallationToken } from "../github/app";
-import { githubRateLimitAdmissionKeyForToken, timeoutFetch, type GitHubRateLimitAdmissionKey } from "../github/client";
+import { githubRateLimitAdmissionKeyForToken, PRODUCT_USER_AGENT, timeoutFetch, type GitHubRateLimitAdmissionKey } from "../github/client";
 import { getCachedGroundingFileContent, putCachedGroundingFileContent, recordAuditEvent } from "../db/repositories";
 import type { CheckSummaryRecord, PullRequestFileRecord } from "../types";
 import { repoParts } from "../utils/json";
@@ -185,7 +185,7 @@ export async function makeGithubFileFetcher(env: Env, repoFullName: string, inst
             headers: {
               // raw media type returns the file body directly (no base64 envelope to decode).
               accept: "application/vnd.github.raw+json",
-              "user-agent": "gittensory/0.1",
+              "user-agent": PRODUCT_USER_AGENT,
               "x-github-api-version": "2022-11-28",
               ...(token ? { authorization: `Bearer ${token}` } : {}),
             },

--- a/src/review/rag-index.ts
+++ b/src/review/rag-index.ts
@@ -26,7 +26,7 @@
 // GitHub call, and does no adapter use — the deploy is byte-identical to today.
 
 import { createInstallationToken } from "../github/app";
-import { githubRateLimitAdmissionKeyForToken, timeoutFetch, type GitHubRateLimitAdmissionKey } from "../github/client";
+import { githubRateLimitAdmissionKeyForToken, PRODUCT_USER_AGENT, timeoutFetch, type GitHubRateLimitAdmissionKey } from "../github/client";
 import { incr } from "../selfhost/metrics";
 import { isConfigFile, isDependencyManifestFile } from "../signals/path-matchers";
 import { repoParts } from "../utils/json";
@@ -93,7 +93,7 @@ async function resolveReadToken(env: Env, installationId: number | null | undefi
 function ghHeaders(token: string | undefined, accept: string): Record<string, string> {
   return {
     accept,
-    "user-agent": "gittensory/0.1",
+    "user-agent": PRODUCT_USER_AGENT,
     "x-github-api-version": "2022-11-28",
     ...(token ? { authorization: `Bearer ${token}` } : {}),
   };

--- a/src/review/visual/actions-fallback.ts
+++ b/src/review/visual/actions-fallback.ts
@@ -32,7 +32,7 @@
 // dispatch inputs and surfaces the result as `workflow_run.display_title` in the completion webhook.
 // parseFallbackRunCorrelation reads it back; a run whose title doesn't match this exact shape is ignored
 // (fail-safe -- never guesses a PR from an unrelated run).
-import { timeoutFetch, type GitHubRateLimitAdmissionKey } from "../../github/client";
+import { PRODUCT_USER_AGENT, timeoutFetch, type GitHubRateLimitAdmissionKey } from "../../github/client";
 import { sha256Hex } from "../../utils/crypto";
 import { isSafeHttpUrl } from "../content-lane/safe-url";
 import type { GitHubRepo } from "./preview-url";
@@ -97,7 +97,7 @@ export async function dispatchVisualCaptureFallback(params: {
     const headers = new Headers();
     headers.set("accept", "application/vnd.github+json");
     headers.set("content-type", "application/json");
-    headers.set("user-agent", "gittensory/0.1");
+    headers.set("user-agent", PRODUCT_USER_AGENT);
     headers.set("x-github-api-version", API_VERSION);
     headers.set("authorization", `Bearer ${params.token}`);
     const response = await timeoutFetch(`${base}/actions/workflows/${FALLBACK_WORKFLOW_FILE}/dispatches`, {
@@ -358,7 +358,7 @@ const MAX_FALLBACK_SHOTS = 24;
 function githubApiHeaders(token: string): Headers {
   const headers = new Headers();
   headers.set("accept", "application/vnd.github+json");
-  headers.set("user-agent", "gittensory/0.1");
+  headers.set("user-agent", PRODUCT_USER_AGENT);
   headers.set("x-github-api-version", API_VERSION);
   headers.set("authorization", `Bearer ${token}`);
   return headers;

--- a/src/review/visual/preview-url.ts
+++ b/src/review/visual/preview-url.ts
@@ -15,7 +15,7 @@
 // (resolved via createInstallationToken). Every helper degrades to null/absent on failure — preview
 // discovery must NEVER sink a review.
 
-import { timeoutFetch, type GitHubRateLimitAdmissionKey } from "../../github/client";
+import { PRODUCT_USER_AGENT, timeoutFetch, type GitHubRateLimitAdmissionKey } from "../../github/client";
 
 const DEFAULT_GITHUB_TIMEOUT_MS = 20_000;
 
@@ -46,7 +46,7 @@ async function githubJson<T>(
 ): Promise<T> {
   const headers = new Headers();
   headers.set("accept", "application/vnd.github+json");
-  headers.set("user-agent", "gittensory/0.1");
+  headers.set("user-agent", PRODUCT_USER_AGENT);
   headers.set("x-github-api-version", init.apiVersion || "2022-11-28");
   if (init.token) headers.set("authorization", `Bearer ${init.token}`);
   const response = await timeoutFetch(url, {

--- a/src/selfhost/setup-wizard.ts
+++ b/src/selfhost/setup-wizard.ts
@@ -133,7 +133,7 @@ ${error}<form action="/setup" method="post">
 export async function exchangeManifestCode(code: string, fetchImpl: typeof fetch = timeoutFetch): Promise<AppCredentials> {
   const res = await fetchImpl(`https://api.github.com/app-manifests/${encodeURIComponent(code)}/conversions`, {
     method: "POST",
-    headers: { accept: "application/vnd.github+json", "user-agent": "gittensory-selfhost" },
+    headers: { accept: "application/vnd.github+json", "user-agent": "loopover-selfhost" },
   });
   if (!res.ok) throw new Error(`manifest_exchange_http_${res.status}`);
   return (await res.json()) as AppCredentials;

--- a/src/services/draft.ts
+++ b/src/services/draft.ts
@@ -352,7 +352,7 @@ class GitHubUserApiError extends Error {
 async function githubUserJson<T>(url: string, init: RequestInit & { token: string } = { token: "" }): Promise<T> {
   const headers = new Headers(init.headers);
   headers.set("accept", "application/vnd.github+json");
-  headers.set("user-agent", "gittensory-api");
+  headers.set("user-agent", "loopover-api");
   headers.set("x-github-api-version", GITHUB_API_VERSION);
   /* v8 ignore next -- token-absent arm is unreachable: every caller passes a decrypted user token; the { token: "" } default only guards the type. */
   if (init.token) headers.set("authorization", `Bearer ${init.token}`);

--- a/src/signals/focus-manifest-loader.ts
+++ b/src/signals/focus-manifest-loader.ts
@@ -77,7 +77,7 @@ export async function fetchRepoFocusManifestFile(repoFullName: string): Promise<
   for (const path of MANIFEST_FILE_CANDIDATES) {
     const url = `https://raw.githubusercontent.com/${encodeURIComponent(owner)}/${encodeURIComponent(name)}/HEAD/${path}`;
     try {
-      const response = await fetch(url, { headers: { Accept: "application/json", "User-Agent": "gittensory" } });
+      const response = await fetch(url, { headers: { Accept: "application/json", "User-Agent": "loopover" } });
       if (response.ok) {
         const text = await readBoundedResponseText(response);
         if (text !== null) return text;

--- a/src/upstream/commit.ts
+++ b/src/upstream/commit.ts
@@ -1,10 +1,10 @@
-import { githubRateLimitAdmissionKeyForPublicToken, timeoutFetch } from "../github/client";
+import { githubRateLimitAdmissionKeyForPublicToken, PRODUCT_USER_AGENT, timeoutFetch } from "../github/client";
 import { LOW_REST_RATE_LIMIT_REMAINING, shouldWaitForGitHubRateLimit } from "../github/rate-limit";
 
 function upstreamCommitHeaders(token: string | undefined): Record<string, string> {
   return {
     accept: "application/vnd.github+json",
-    "user-agent": "gittensory/0.1",
+    "user-agent": PRODUCT_USER_AGENT,
     "x-github-api-version": "2022-11-28",
     ...(token ? { authorization: `Bearer ${token}` } : {}),
   };

--- a/test/unit/enrichment-wire.test.ts
+++ b/test/unit/enrichment-wire.test.ts
@@ -246,7 +246,7 @@ describe("buildReviewEnrichment", () => {
     ).toBe("Bearer sek");
     expect(
       (calls[0]!.init.headers as Record<string, string>)["user-agent"],
-    ).toBe("gittensory-selfhost/1.0");
+    ).toBe("loopover-selfhost/1.0");
     expect(
       (calls[0]!.init.headers as Record<string, string>)["x-gittensory-request-id"],
     ).toMatch(/^[-0-9a-fA-Fa-z]+$/);

--- a/test/unit/github-client.test.ts
+++ b/test/unit/github-client.test.ts
@@ -190,7 +190,7 @@ describe("githubHeaders — the single shared GitHub REST header-builder (#4610,
   it("with no options, defaults to the standard accept + pinned api-version and omits content-type/authorization", () => {
     expect(githubHeaders()).toEqual({
       accept: "application/vnd.github+json",
-      "user-agent": "gittensory/0.1",
+      "user-agent": "loopover/0.1",
       "x-github-api-version": "2022-11-28",
     });
   });

--- a/test/unit/miner-init-verify-token.test.ts
+++ b/test/unit/miner-init-verify-token.test.ts
@@ -61,7 +61,7 @@ describe("verifyGithubToken", () => {
         url: "https://example.com/user",
         headers: {
           accept: "application/vnd.github+json",
-          "user-agent": "gittensory-miner",
+          "user-agent": "loopover-miner",
           "x-github-api-version": "2022-11-28",
         },
       },


### PR DESCRIPTION
## Summary
- Add `PRODUCT_USER_AGENT` in `src/github/client.ts` as the single shared constant for the 16 sites across `src/` that had each independently drifted their own copy of the same outbound User-Agent literal (`gittensory/0.1`), fixing the maintainability gap `githubHeaders()`'s own doc comment already claimed was solved.
- Rename the remaining distinct-purpose User-Agent literals to their `loopover-*` equivalents: miner (`packages/gittensory-miner/lib/*.js`, 7 sites), api, selfhost (x2), content-lane, orb (brand prefix only — the `-orb` codename suffix is deliberately untouched pending the still-open ORB-naming question), production-smoke, mcp-release-watch.
- Update 3 stale test assertions that pinned the old literals.
- Deliberately left untouched: `x-gittensory-cache`/`x-gittensory-request-id` header **names** (different header, different concern), `.gittensory-ams.yml`/`.gittensory.yml` config filenames, config-directory paths, CLI bin-command references, and any `packages/gittensory-miner` npm package path — all tracked by their own separate rebrand issues.

Closes #5335

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run test:ci` green (772/774 files passed, 2 pre-existing skips; one single-flight coalescing test flaked once under full parallel load, confirmed passing standalone and on a clean re-run — unrelated to this change)
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] Rebased onto latest `origin/main`, no conflicts
- [x] No generated artifacts require regeneration (no API/schema, wrangler binding, or `env.*` changes)