### PR TITLE
fix(miner): status --json reports the real installed engine version

### DIFF
--- a/packages/gittensory-miner/lib/status.d.ts
+++ b/packages/gittensory-miner/lib/status.d.ts
@@ -53,3 +53,5 @@ export function buildEngineVersionSkewCheck(
   readInstalled?: () => string | null,
   readExpected?: () => string | null,
 ): DoctorCheck;
+
+export function buildEngineVersionDisplay(readInstalled?: () => string | null): string | null;

--- a/packages/gittensory-miner/lib/status.js
+++ b/packages/gittensory-miner/lib/status.js
@@ -60,15 +60,30 @@ export function resolveMinerStateDir(env = process.env) {
   return join(configHome, "gittensory-miner");
 }
 
-// The pinned @jsonbored/gittensory-engine version this miner is built against, read from the miner's own declared
-// dependency. (The engine package's `exports` map blocks `require("<pkg>/package.json")`, and its built `dist` may
-// be absent depending on build order, so the declared-dependency version is the reliable, always-available source.)
-function readEngineVersion() {
+/**
+ * The REAL installed @jsonbored/gittensory-engine version, for `status`'s own display. Prefers `readInstalled`
+ * (the actually-resolved semver from node_modules/the monorepo workspace, the same real resolution `doctor`'s
+ * engine-version-skew check already relies on) -- a self-hoster asking "what's installed" wants the real
+ * answer, not the declared dependency RANGE ("*" in this monorepo, which tells them nothing). Falls back to
+ * the declared range only if real resolution genuinely comes up empty (the engine package's `exports` map
+ * blocks `require("<pkg>/package.json")` in some resolution orders, and its built `dist` may be absent
+ * depending on build order) -- still better than reporting nothing at all.
+ *
+ * Exported + injectable (mirrors `buildEngineVersionSkewCheck`'s own `readInstalled` param): real resolution
+ * succeeding is the only realistic case in a working install, so the fallback path needs a way to force it.
+ */
+export function buildEngineVersionDisplay(readInstalled = readInstalledEnginePackageVersion) {
+  const installed = readInstalled();
+  if (installed) return installed;
   try {
     return requireFromHere()("../package.json").dependencies?.[ENGINE_PACKAGE] ?? null;
   } catch {
     return null;
   }
+}
+
+function readEngineVersion() {
+  return buildEngineVersionDisplay();
 }
 
 export function readInstalledEnginePackageVersionFromPaths(

--- a/test/unit/miner-status.test.ts
+++ b/test/unit/miner-status.test.ts
@@ -4,6 +4,7 @@ import { dirname, join } from "node:path";
 import { resolveEventLedgerDbPath } from "../../packages/gittensory-miner/lib/event-ledger.js";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  buildEngineVersionDisplay,
   buildEngineVersionSkewCheck,
   checkConfigContent,
   collectStatus,
@@ -57,6 +58,24 @@ describe("gittensory-miner status/doctor (#2288)", () => {
     expect(status.engine.name).toBe("@jsonbored/gittensory-engine");
     expect(status.stateDir).toBe(join(root, "state"));
     expect(status.configFile).toBe(join(root, ".gittensory-miner.yml")); // discovered
+  });
+
+  it("REGRESSION: collectStatus reports the REAL installed engine version, not the declared dependency range", () => {
+    const root = tempRoot();
+    const status = collectStatus({ GITTENSORY_MINER_CONFIG_DIR: join(root, "state") }, root);
+    // The monorepo declares "*" for this workspace dependency -- a self-hoster asking "what's installed"
+    // needs the real resolved semver (matching what doctor's own engine-version-skew check already shows),
+    // not the meaningless declared range.
+    expect(status.engine.version).toBe(readInstalledEnginePackageVersion());
+    expect(status.engine.version).not.toBe("*");
+  });
+
+  it("buildEngineVersionDisplay prefers a real resolved version when available", () => {
+    expect(buildEngineVersionDisplay(() => "9.9.9")).toBe("9.9.9");
+  });
+
+  it("REGRESSION: buildEngineVersionDisplay falls back to the declared dependency range when real resolution comes up empty", () => {
+    expect(buildEngineVersionDisplay(() => null)).toBe("*");
   });
 
   it("collectStatus prefers GITTENSORY_MINER_VERSION over package.json (#4310)", () => {


### PR DESCRIPTION
## Summary
`status --json`'s `engine.version` was reading the miner's own declared dependency range (`"*"` in this monorepo) rather than the actually-installed version -- meaningless output for a self-hoster asking "what's installed." `doctor`'s own `engine-version-skew` check already resolves the real version successfully (`readInstalledEnginePackageVersion()`), right next to it. `status` now uses the same real resolution, falling back to the declared range only if that genuinely comes up empty.

Exported the resolution logic as `buildEngineVersionDisplay` (injectable `readInstalled` param), mirroring the existing `buildEngineVersionSkewCheck` pattern, so the fallback path has a real test -- forcing real resolution to fail in a working monorepo install isn't otherwise possible.

Found this doing a real end-to-end operational smoke test of the CLI (`init`/`status`/`doctor`/`attempt`/`loop` against a live repo with a real GitHub token), not a code-only review.

## Test plan
- [x] `tsc --noEmit --incremental false` clean
- [x] `npx vitest run test/unit` -- 750/750 test files passing
- [x] Patch coverage verified line-by-line: both new lines covered on both branch sides (`31, 1`)
- [x] `npm audit --audit-level=moderate` -- 0 vulnerabilities
- [x] `git diff --check` clean
- [x] Manually re-ran `gittensory-miner status --json` in a scratch home dir -- now shows `"version": "1.0.0"` instead of `"*"`