### PR TITLE
chore(ci): remove dead self-hosted-runner label, rename release-notes brand prose

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,6 +1,0 @@
-# actionlint configuration. Declares the project's custom self-hosted runner labels so actionlint does not flag
-# `runs-on: [self-hosted, <label>]` as an unknown label (runner-label rule). The `gittensory` label is the
-# self-hosted runner that runs the self-host nightly maintenance workflow (.github/workflows/self-host-nightly.yml).
-self-hosted-runner:
-  labels:
-    - gittensory

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -2,7 +2,7 @@
 # workflow (.github/workflows/release-selfhost.yml) calls the "Generate release notes content" API
 # with this repo's default branch as context, which groups merged PRs since the previous orb-v tag
 # into the categories below by label. `gittensor:feature` and `gittensor:bug` are applied
-# automatically by gittensory's own review engine on every merged PR, so this works without any
+# automatically by loopover's own review engine on every merged PR, so this works without any
 # separate manual-labeling process.
 #
 # `exclude.authors` matches the exact GitHub API login, which for a bot account includes the `[bot]`


### PR DESCRIPTION
## Summary
- `.github/actionlint.yaml` declared a self-hosted-runner label (`gittensory`) for the self-host-nightly maintenance workflow, but every `runs-on:` line across `.github/workflows/*.yml` (including that workflow itself) runs on `ubuntu-latest`. Confirmed with the maintainer this is dead config from an earlier setup, not a live external runner registration — removed the file outright.
- `.github/release.yml`'s "own review engine" brand-prose comment renamed alongside it.
- Left untouched: the `gittensor:feature`/`gittensor:bug` label-prefix lines (permanent SN74 subnet brand) and the `gittensory-orb[bot]` account-login reference in the same file (the bot's real, not-yet-renamed GitHub login — tracked by #5327).
- The `VITE_GITTENSORY_API_ORIGIN` build-arg's eventual rename timing is tracked via a comment on #4765 (depends on the deferred domain-sunset schedule) rather than resolved here.

Closes #5339

## Test plan
- [x] `npm run actionlint` passes cleanly with the config removed (confirms no workflow references the removed label)
- [x] `npm run typecheck` clean
- [x] `npm run test:ci` green (778/780 test files, 2 pre-existing skips)
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities