### PR TITLE
feat(miner): surface rate-limit telemetry in discover output (#4837)

### DIFF
--- a/packages/gittensory-miner/lib/discover-cli.d.ts
+++ b/packages/gittensory-miner/lib/discover-cli.d.ts
@@ -15,12 +15,13 @@ export type ParsedDiscoverArgs =
     }
   | { error: string };
 
-/** The subset of `CandidateIssueSummary` runDiscover actually reads, so callers may inject a fake without
- * fabricating rate-limit telemetry it never touches. A real `fetchCandidateIssuesWithSummary` result satisfies
- * this too, since it is a strict superset. */
+/** The subset of `CandidateIssueSummary` runDiscover actually reads. It surfaces the rate-limit telemetry (#4837),
+ * so a fake must supply it. A real `fetchCandidateIssuesWithSummary` result satisfies this, since it is a superset. */
 export type DiscoverFanOutSummary = {
   issues: RawCandidateIssue[];
   warnings: CandidateIssueWarning[];
+  rateLimitRemaining: number | null;
+  rateLimitResetAt: string | null;
 };
 
 /** The subset of a ranked entry that `renderDiscoverSummary` reads for its top-candidates listing. */
@@ -29,6 +30,8 @@ export type DiscoverRankedEntry = Pick<RankedCandidateIssue, "repoFullName" | "i
 export type DiscoverResult = {
   fanOutCount: number;
   warnings: CandidateIssueWarning[];
+  rateLimitRemaining: number | null;
+  rateLimitResetAt: string | null;
   ranked: DiscoverRankedEntry[];
   enqueueSummary: EnqueueRankedDiscoverySummary;
 };

--- a/packages/gittensory-miner/lib/discover-cli.js
+++ b/packages/gittensory-miner/lib/discover-cli.js
@@ -70,12 +70,22 @@ export function parseDiscoverArgs(args) {
   return { targets, search: options.search, json: options.json };
 }
 
+// The rate-limit line surfaces the telemetry the fanout already records (#4837) so an operator sees how close a
+// `discover` run is to being throttled without running a separate command. `unknown` covers the no-fetch/no-header
+// case where the fanout captured no remaining count.
+function renderRateLimitLine(result) {
+  const remaining = result.rateLimitRemaining === null ? "unknown" : String(result.rateLimitRemaining);
+  const resetSuffix = result.rateLimitResetAt === null ? "" : ` (resets ${result.rateLimitResetAt})`;
+  return `rate-limit remaining: ${remaining}${resetSuffix}`;
+}
+
 export function renderDiscoverSummary(result) {
   const lines = [
     `fanned out: ${result.fanOutCount} candidate issue(s)`,
     `ai-policy warnings: ${result.warnings.length}`,
     `ranked: ${result.ranked.length}`,
     `enqueued: ${result.enqueueSummary.enqueued}`,
+    renderRateLimitLine(result),
   ];
   if (result.enqueueSummary.skippedBelowMinRank > 0) {
     lines.push(`skipped (below min rank): ${result.enqueueSummary.skippedBelowMinRank}`);
@@ -120,6 +130,8 @@ export async function runDiscover(args, options = {}) {
     const result = {
       fanOutCount: fanOut.issues.length,
       warnings: fanOut.warnings,
+      rateLimitRemaining: fanOut.rateLimitRemaining,
+      rateLimitResetAt: fanOut.rateLimitResetAt,
       ranked: rankedSummary.issues,
       enqueueSummary,
     };

--- a/test/unit/miner-discover-cli.test.ts
+++ b/test/unit/miner-discover-cli.test.ts
@@ -108,6 +108,8 @@ describe("renderDiscoverSummary (#4247)", () => {
     const text = renderDiscoverSummary({
       fanOutCount: 2,
       warnings: [{ repoFullName: "acme/banned", stage: "policy:AI-USAGE.md", message: "denied" }],
+      rateLimitRemaining: 4993,
+      rateLimitResetAt: "2026-07-09T13:00:00.000Z",
       ranked: [
         { repoFullName: "acme/widgets", issueNumber: 1, title: "Add retry helper", rankScore: 0.8 },
         { repoFullName: "acme/widgets", issueNumber: 2, title: "Fix flaky test", rankScore: 0.4 },
@@ -118,6 +120,7 @@ describe("renderDiscoverSummary (#4247)", () => {
     expect(text).toContain("ai-policy warnings: 1");
     expect(text).toContain("ranked: 2");
     expect(text).toContain("enqueued: 2");
+    expect(text).toContain("rate-limit remaining: 4993 (resets 2026-07-09T13:00:00.000Z)");
     expect(text).toContain("acme/widgets#1  score=0.8000  Add retry helper");
     expect(text).not.toContain("skipped (below min rank)");
   });
@@ -126,6 +129,8 @@ describe("renderDiscoverSummary (#4247)", () => {
     const text = renderDiscoverSummary({
       fanOutCount: 1,
       warnings: [],
+      rateLimitRemaining: null,
+      rateLimitResetAt: null,
       ranked: [
         {
           repoFullName: "acme/widgets",
@@ -154,6 +159,8 @@ describe("renderDiscoverSummary (#4247)", () => {
     const withSkips = renderDiscoverSummary({
       fanOutCount: 1,
       warnings: [],
+      rateLimitRemaining: null,
+      rateLimitResetAt: null,
       ranked: [{ repoFullName: "acme/widgets", issueNumber: 1, title: "x", rankScore: 0.1 }],
       enqueueSummary: { enqueued: 0, skippedBelowMinRank: 1, skippedInvalid: 0, eventsAppended: 0 },
     });
@@ -162,10 +169,46 @@ describe("renderDiscoverSummary (#4247)", () => {
     const empty = renderDiscoverSummary({
       fanOutCount: 0,
       warnings: [],
+      rateLimitRemaining: null,
+      rateLimitResetAt: null,
       ranked: [],
       enqueueSummary: { enqueued: 0, skippedBelowMinRank: 0, skippedInvalid: 0, eventsAppended: 0 },
     });
     expect(empty).toContain("no candidates found.");
+  });
+
+  it("surfaces rate-limit telemetry, and reports 'unknown' when the fanout captured none (#4837)", () => {
+    const withTelemetry = renderDiscoverSummary({
+      fanOutCount: 0,
+      warnings: [],
+      rateLimitRemaining: 12,
+      rateLimitResetAt: "2026-07-09T13:30:00.000Z",
+      ranked: [],
+      enqueueSummary: { enqueued: 0, skippedBelowMinRank: 0, skippedInvalid: 0, eventsAppended: 0 },
+    });
+    expect(withTelemetry).toContain("rate-limit remaining: 12 (resets 2026-07-09T13:30:00.000Z)");
+
+    // A remaining count of zero must still print the number, not fall through to "unknown".
+    const throttled = renderDiscoverSummary({
+      fanOutCount: 0,
+      warnings: [],
+      rateLimitRemaining: 0,
+      rateLimitResetAt: null,
+      ranked: [],
+      enqueueSummary: { enqueued: 0, skippedBelowMinRank: 0, skippedInvalid: 0, eventsAppended: 0 },
+    });
+    expect(throttled).toContain("rate-limit remaining: 0");
+    expect(throttled).not.toContain("resets");
+
+    const noTelemetry = renderDiscoverSummary({
+      fanOutCount: 0,
+      warnings: [],
+      rateLimitRemaining: null,
+      rateLimitResetAt: null,
+      ranked: [],
+      enqueueSummary: { enqueued: 0, skippedBelowMinRank: 0, skippedInvalid: 0, eventsAppended: 0 },
+    });
+    expect(noTelemetry).toContain("rate-limit remaining: unknown");
   });
 });
 
@@ -178,6 +221,8 @@ describe("runDiscover (#4247)", () => {
         fanOutIssue({ issueNumber: 2, title: "Fix flaky test", labels: ["help wanted"] }),
       ],
       warnings: [],
+      rateLimitRemaining: 4987,
+      rateLimitResetAt: "2026-07-09T13:00:00.000Z",
     }));
     const searchCandidateIssuesWithSummary = vi.fn(async () => {
       throw new Error("must not be called for repo-target mode");
@@ -203,6 +248,9 @@ describe("runDiscover (#4247)", () => {
     expect(payload.fanOutCount).toBe(2);
     expect(payload.enqueueSummary.enqueued).toBe(2);
     expect(payload.ranked.map((entry: { issueNumber: number }) => entry.issueNumber)).toEqual([1, 2]);
+    // The fanout's rate-limit telemetry is surfaced verbatim in --json output (#4837).
+    expect(payload.rateLimitRemaining).toBe(4987);
+    expect(payload.rateLimitResetAt).toBe("2026-07-09T13:00:00.000Z");
 
     const queued = portfolioQueue.listQueue("acme/widgets");
     expect(queued.map((entry) => entry.identifier).sort()).toEqual(["issue:1", "issue:2"]);
@@ -216,6 +264,8 @@ describe("runDiscover (#4247)", () => {
     const searchCandidateIssuesWithSummary = vi.fn(async (query: string) => ({
       issues: [fanOutIssue({ issueNumber: 9, title: `Result for ${query}` })],
       warnings: [],
+      rateLimitRemaining: null,
+      rateLimitResetAt: null,
     }));
 
     const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
@@ -237,6 +287,8 @@ describe("runDiscover (#4247)", () => {
     const fetchCandidateIssuesWithSummary = vi.fn(async () => ({
       issues: [fanOutIssue()],
       warnings: [],
+      rateLimitRemaining: 3200,
+      rateLimitResetAt: "2026-07-09T13:00:00.000Z",
     }));
 
     const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
@@ -249,6 +301,7 @@ describe("runDiscover (#4247)", () => {
     expect(exitCode).toBe(0);
     const text = String(log.mock.calls[0]?.[0]);
     expect(text).toContain("fanned out: 1 candidate issue(s)");
+    expect(text).toContain("rate-limit remaining: 3200 (resets 2026-07-09T13:00:00.000Z)");
     expect(text).toContain("top candidates:");
   });
 
@@ -290,6 +343,8 @@ describe("runDiscover (#4247)", () => {
       const fetchCandidateIssuesWithSummary = vi.fn(async () => ({
         issues: [fanOutIssue({ issueNumber: 5 })],
         warnings: [],
+        rateLimitRemaining: null,
+        rateLimitResetAt: null,
       }));
       vi.spyOn(console, "log").mockImplementation(() => undefined);
 


### PR DESCRIPTION
## Summary

- The discovery fanout already records GitHub rate-limit `remaining`/`reset` internally (`recordRateLimit` in `opportunity-fanout.js`), and `fetchCandidateIssuesWithSummary`/`searchCandidateIssuesWithSummary` return it on their summary — but `runDiscover` dropped it, so an operator had no visibility into how close a `discover` run was to being throttled without invoking a separate command.
- This surfaces that already-computed telemetry in both `discover` output modes: a `rate-limit remaining: <n> (resets <iso>)` line in the human-readable summary (rendering `unknown` when the fanout captured no count, e.g. no fetch happened or the header was absent), and the raw `rateLimitRemaining`/`rateLimitResetAt` fields in `--json` output.
- No fetch/parse behavior changes — this is pure plumbing of an existing value through to the command's result.

Closes #4837

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` — no workflow files changed.
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — 100% line and branch coverage on every changed line in `discover-cli.js` (the only remaining uncovered branches in the file are pre-existing and untouched by this PR).
- [ ] `npm run test:workers` — no worker/Cloudflare code changed.
- [ ] `npm run build:mcp` — no MCP code changed.
- [ ] `npm run test:mcp-pack` — no MCP package changed.
- [ ] `npm run ui:openapi:check` — no API routes or OpenAPI schemas changed.
- [ ] `npm run ui:lint` — no UI code changed.
- [ ] `npm run ui:typecheck` — no UI code changed.
- [ ] `npm run ui:build` — no UI code changed.
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Unchecked Validation items are inapplicable to this change: it touches only `packages/gittensory-miner/lib/discover-cli.{js,d.ts}` and its unit test — no workflows, MCP, workers, API/OpenAPI, or UI. `build:miner` (`node --check`) passes for the changed lib file. The changed-line coverage was verified against `coverage/lcov.info`: both sides of each new `=== null` branch (a numeric/ISO value vs. the `null`/`unknown` fallback, plus a `0`-remaining case that must still print rather than read as `unknown`) are exercised.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests — no such changes in this PR.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed — no API/OpenAPI/MCP surface changed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks — no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section — not applicable; this is a CLI-only change with no visual surface.
- [ ] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs — no doc snapshots the `discover` output text, so nothing drifts.

## Notes

- The human-readable line is appended to the base summary lines so it prints in every path, including the empty-result path. The rate-limit values are surfaced verbatim from the fanout summary — `runDiscover` does not recompute or re-derive them.
