### PR TITLE
test(miner): add real crash-recovery test for portfolio-queue stuck items

### DIFF
--- a/test/fixtures/miner-concurrent-stores/claim-and-hold-child.mjs
+++ b/test/fixtures/miner-concurrent-stores/claim-and-hold-child.mjs
@@ -1,0 +1,26 @@
+#!/usr/bin/env node
+// Cross-process crash-recovery helper for portfolio-queue's stuck-lease sweep (#4868).
+// Opens the shared queue, claims the next item via dequeueNext() (stamping a real lease), reports the
+// claimed entry, then idles forever without ever marking it done -- simulating a process that claims work
+// and then crashes mid-attempt. The test kills this process (SIGKILL) and asserts the item is left
+// genuinely stuck 'in_progress' until swept, then reclaimable.
+import { initPortfolioQueueStore } from "../../../packages/gittensory-miner/lib/portfolio-queue.js";
+
+const [dbPath] = process.argv.slice(2);
+if (!dbPath) {
+  process.stderr.write("usage: claim-and-hold-child.mjs <dbPath>\n");
+  process.exit(2);
+}
+
+const store = initPortfolioQueueStore(dbPath);
+const entry = store.dequeueNext();
+// dequeueNext()'s own return shape carries no leasedAt (only listInProgress()'s lease-annotated projection
+// does), and the test needs the real stamped lease time to compute expiry windows against.
+const lease = entry
+  ? store.listInProgress().find((row) => row.repoFullName === entry.repoFullName && row.identifier === entry.identifier)
+  : null;
+process.stdout.write(`CLAIMED ${JSON.stringify({ ...entry, leasedAt: lease?.leasedAt ?? null })}\n`);
+
+// Idle forever -- never mark done, never close the store, never exit on its own. The test's SIGKILL is
+// the only thing that ends this process, mirroring a real crash (no cleanup handler runs).
+setInterval(() => {}, 1_000_000);

--- a/test/unit/miner-portfolio-queue-crash-recovery.test.ts
+++ b/test/unit/miner-portfolio-queue-crash-recovery.test.ts
@@ -1,0 +1,119 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterEach, describe, expect, it } from "vitest";
+import { initPortfolioQueueStore } from "../../packages/gittensory-miner/lib/portfolio-queue.js";
+import { sweepStuckItems } from "../../packages/gittensory-miner/lib/portfolio-queue-expiry.js";
+
+// Real crash-recovery coverage for portfolio-queue's stuck-item lease/reclaim mechanism (#4868). The
+// existing unit suite (test/unit/miner-portfolio-queue-expiry.test.ts) only exercises sweepStuckItems
+// in-process against fake timers -- it never actually kills a process mid-claim. This spawns a real Node
+// child process that claims the only queued item (stamping a real on-disk lease) and then idles forever
+// (never marks done, never closes cleanly), SIGKILLs it to simulate a crash, and verifies the item is left
+// genuinely stuck 'in_progress' until its lease expires, at which point the sweep reclaims it and it
+// becomes claimable again -- the full crash -> detect -> reclaim -> re-claim cycle.
+//
+// Scope note (per the issue): this only tests portfolio-queue's own single-miner crash/reclaim behavior. It
+// does not touch, and must not be extended into, cross-miner claim-conflict resolution.
+
+const holdChildScript = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "../fixtures/miner-concurrent-stores/claim-and-hold-child.mjs",
+);
+
+const roots: string[] = [];
+const stores: Array<{ close(): void }> = [];
+
+function tempRoot(): { root: string; dbPath: string } {
+  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-crash-recovery-"));
+  roots.push(root);
+  return { root, dbPath: join(root, "portfolio-queue.sqlite3") };
+}
+
+function tempStore(dbPath: string) {
+  const store = initPortfolioQueueStore(dbPath);
+  stores.push(store);
+  return store;
+}
+
+afterEach(() => {
+  for (const store of stores.splice(0)) store.close();
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+type ClaimedEntry = { repoFullName: string; identifier: string; status: string; leasedAt: string };
+
+async function spawnAndWaitForClaim(dbPath: string): Promise<{ child: ChildProcessWithoutNullStreams; claimed: ClaimedEntry }> {
+  const child = spawn(process.execPath, [holdChildScript, dbPath], { stdio: ["pipe", "pipe", "pipe"] });
+  const claimed = await new Promise<ClaimedEntry>((resolve, reject) => {
+    let buffer = "";
+    const onData = (chunk: Buffer | string) => {
+      buffer += chunk.toString();
+      const line = buffer.split("\n").find((entry) => entry.startsWith("CLAIMED "));
+      if (line) {
+        child.stdout.off("data", onData);
+        resolve(JSON.parse(line.slice("CLAIMED ".length)) as ClaimedEntry);
+      }
+    };
+    child.stdout.on("data", onData);
+    child.once("error", reject);
+    child.once("exit", (code) => {
+      if (code !== 0 && code !== null) reject(new Error(`child exited before claiming (${code})`));
+    });
+  });
+  return { child, claimed };
+}
+
+async function killAndWaitForExit(child: ChildProcessWithoutNullStreams): Promise<void> {
+  await new Promise<void>((resolve) => {
+    child.once("exit", () => resolve());
+    child.kill("SIGKILL");
+  });
+}
+
+describe("portfolio-queue crash recovery (#4868)", () => {
+  it("a process killed mid-claim leaves the item stuck in_progress until the lease expires, then it is swept back to queued and re-claimable", async () => {
+    const { dbPath } = tempRoot();
+    const bootstrap = tempStore(dbPath);
+    bootstrap.enqueue({ repoFullName: "acme/widgets", identifier: "pr:1" });
+
+    const { child, claimed } = await spawnAndWaitForClaim(dbPath);
+    expect(claimed).toMatchObject({ repoFullName: "acme/widgets", identifier: "pr:1", status: "in_progress" });
+    const leasedAtMs = Date.parse(claimed.leasedAt);
+    expect(Number.isFinite(leasedAtMs)).toBe(true);
+
+    // Simulate a real crash: SIGKILL, no cleanup handler runs, no markDone/close.
+    await killAndWaitForExit(child);
+
+    // The crash alone does not un-stick the row -- it is still genuinely 'in_progress' on disk.
+    expect(bootstrap.listInProgress()).toEqual([
+      { repoFullName: "acme/widgets", identifier: "pr:1", status: "in_progress", leasedAt: claimed.leasedAt },
+    ]);
+
+    // Sweeping before the lease bound elapses must NOT reclaim it (still within the grace window).
+    const tooSoon = sweepStuckItems(bootstrap, leasedAtMs + 500, 1000);
+    expect(tooSoon).toEqual([]);
+    expect(bootstrap.listInProgress()).toHaveLength(1);
+
+    // Sweeping once the lease bound has elapsed reclaims the crashed process's item back to 'queued'.
+    const reclaimed = sweepStuckItems(bootstrap, leasedAtMs + 1001, 1000);
+    expect(reclaimed).toHaveLength(1);
+    expect(reclaimed[0]).toMatchObject({ repoFullName: "acme/widgets", identifier: "pr:1", status: "queued" });
+    expect(bootstrap.listInProgress()).toEqual([]);
+
+    // Full recovery: the reclaimed item is claimable again, exactly as if it had never been claimed.
+    const reclaimedThenReclaimed = bootstrap.dequeueNext();
+    expect(reclaimedThenReclaimed).toMatchObject({ repoFullName: "acme/widgets", identifier: "pr:1", status: "in_progress" });
+  });
+
+  it("rejects the claim-and-hold-child helper when required args are missing", async () => {
+    const child = spawn(process.execPath, [holdChildScript], { stdio: ["ignore", "pipe", "pipe"] });
+    const exitCode = await new Promise<number | null>((resolve, reject) => {
+      child.once("error", reject);
+      child.once("exit", resolve);
+    });
+    expect(exitCode).toBe(2);
+  });
+});


### PR DESCRIPTION
## Summary

- There was no test for the stuck-`in_progress`-item crash-recovery scenario against a *real* crashed process — the existing suite (`test/unit/miner-portfolio-queue-expiry.test.ts`) only exercises `sweepStuckItems`/`findStuckItems` in-process against fake timers, never an actual killed OS process.
- Adds `test/unit/miner-portfolio-queue-crash-recovery.test.ts`, mirroring the fixture-child-process pattern from `test/unit/miner-worktree-allocator-collisions.test.ts` and `test/unit/miner-concurrent-store-races.test.ts` (#4867, merged): spawn a real Node child process that claims the only queued item via `dequeueNext()` (stamping a real on-disk lease), report the claim, then idle forever with no cleanup handler — simulating a process that claims work and crashes mid-attempt. The test `SIGKILL`s the child and asserts the full recovery cycle:
  1. The crash alone does **not** un-stick the row — it stays genuinely `in_progress` on disk.
  2. Sweeping *before* the lease bound elapses does **not** reclaim it (no premature reclaim).
  3. Sweeping *after* the lease bound elapses reclaims it back to `queued`.
  4. The reclaimed item is claimable again via a fresh `dequeueNext()` — full crash → detect → reclaim → re-claim cycle.
- New fixture: `test/fixtures/miner-concurrent-stores/claim-and-hold-child.mjs` (added to the existing `miner-concurrent-stores` fixtures directory from #4867 rather than a new directory, since it's the same claim-and-race fixture family).
- Per the issue's explicit scope note, this only tests portfolio-queue's own single-miner crash/reclaim behavior (`sweepStuckItems`/`reclaimStuckItem`, already shipped under #4827) — it does not touch, and is not extended into, cross-miner claim-conflict resolution, which stays maintainer-only.

Fixes #4868

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — this change lives entirely under `test/unit/**`/`test/fixtures/**` exercising `packages/gittensory-miner/**`, which sits outside vitest's `coverage.include` glob today, so `codecov/patch` cannot measure it directly — consistent with the existing worktree-allocator/claim-ledger cross-process collision tests.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run build:miner`
- [x] `npm run test:miner-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:test`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

This PR *is* the test addition: 2 new tests (the real crash → sweep → reclaim → re-claim cycle, including both the too-soon-to-sweep and past-the-bound-to-sweep sides of the expiry check; plus a fixture-argument-validation guard), driving the real store via a real spawned-and-killed `node` child process against a real on-disk SQLite file. Ran the new file 4 times in a row locally to check for timing/kill-signal flakiness — stable every time (2/2 passing, ~0.4–0.7s total).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no auth/session/CORS surface touched.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no API/OpenAPI/MCP surface change; test-only addition.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI surface touched.
- [ ] Visible UI changes include a `UI Evidence` section below — N/A, no visible/UI change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — this PR only adds a crash-recovery integration test for the portfolio-queue store; there is no visible UI change.

## Notes

- `dequeueNext()`'s own return shape carries no `leasedAt` field (only `listInProgress()`'s lease-annotated projection does) — the fixture script calls `listInProgress()` right after claiming to capture the real stamped lease time the test needs to compute expiry windows against. This is a pre-existing, intentional asymmetry in `portfolio-queue.js` (not something this PR changes), just something the fixture had to account for.
- No production code in `packages/gittensory-miner/lib/portfolio-queue.js` or `portfolio-queue-expiry.js` is touched — this is purely a test/fixture addition on top of the already-shipped #4827 lease/sweep mechanism.
