### PR TITLE
test(signals): cover panelSummary's gateHeld-no-summary fallback

### DIFF
--- a/test/unit/signals-coverage.test.ts
+++ b/test/unit/signals-coverage.test.ts
@@ -1478,6 +1478,29 @@ describe("signal coverage edge cases", () => {
     expect(actionRequiredComment).toContain("Gittensory cannot evaluate this PR until installation state is repaired.");
     expect(actionRequiredComment).toContain("> | Gate result | ⚠️ App action required | Install/config needs attention. | Fix app config. |");
 
+    // REGRESSION: gateHeld's panelSummary falls back to a literal default when NO gate was passed at all --
+    // gateConclusion then resolves via fallbackGateConclusion's `!args.repo` arm to "neutral" (gateHeld-only,
+    // unlike "action_required" above which is ALSO gateBlocking and never reaches this fallback), and
+    // args.gate?.summary is undefined (no gate object exists to read a summary from), so the literal default
+    // text renders instead of a provided/derived summary.
+    const heldNoSummaryComment = buildPublicPrIntelligenceComment({env: {},
+      repo: null,
+      pr: { ...currentPr, linkedIssues: [99], body: "Fixes #99" },
+      profile,
+      detection,
+      queueHealth: buildQueueHealth(directRepo, [], [currentPr], buildCollisionReport(directRepo.fullName, [], [currentPr])),
+      collisions: buildCollisionReport(directRepo.fullName, [], [currentPr]),
+      preflight: buildPreflightResult(
+        { repoFullName: directRepo.fullName, title: "Fix isolated issue", body: "Fixes #99", linkedIssues: [99] },
+        directRepo,
+        [],
+        [currentPr],
+      ),
+      settings: gateSettings,
+    });
+    expect(heldNoSummaryComment).toContain("> [!WARNING]");
+    expect(heldNoSummaryComment).toContain("LoopOver is holding this PR for maintainer review.");
+
     const duplicateAdvisoryComment = buildPublicPrIntelligenceComment({env: {},
       repo: directRepo,
       pr: currentPr,


### PR DESCRIPTION
## Summary

Follow-up to the now-merged #5468 (check-run/PR-comment brand rename). That PR's codecov/patch check flagged `src/signals/engine.ts`'s `panelSummary` ternary as only partially covered on the line it happened to rename — a pre-existing gap surfaced by touching the line, not a regression introduced by it, but worth closing regardless since it turned out no test at all exercised this fallback string.

Root cause: `"action_required"` makes gate evaluation BOTH `gateBlocking` and `gateHeld` true, and the ternary checks `gateBlocking` first — so the one existing `action_required` test in this file only ever reached the `gateBlocking` branch, never `gateHeld`'s own `"... is holding this PR for maintainer review."` literal fallback. That fallback only renders when `args.gate` is entirely absent (not just missing a `summary`, since the type requires `summary: string`), which requires `repo: null` so `gateConclusion` resolves to `"neutral"` via `fallbackGateConclusion`'s `!args.repo` arm instead. Same pattern as an existing adjacent test for the sibling `buildPublicPrPanelSignalRows` function (`test/unit/signals-coverage.test.ts:816-818`).

No production code changes — test-only.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run test:ci` green (786/788 test files, 2 pre-existing skips)
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] Verified via unsharded `npm run test:coverage` that `src/signals/engine.ts` is now at 99.26%/98.06% (stmt/branch), with the target lines no longer in the uncovered list