### PR TITLE
feat(miner): add a ledger scrape Prometheus surface for the event ledger

### DIFF
--- a/packages/gittensory-miner/lib/cli.js
+++ b/packages/gittensory-miner/lib/cli.js
@@ -34,6 +34,7 @@ export function printHelp(input) {
       "  gittensory-miner claim release <owner/repo> <issue#> [--json]",
       "  gittensory-miner claim list [--repo <owner/repo>] [--status active|released|expired] [--json]",
       "  gittensory-miner ledger list [--repo <owner/repo>] [--since <seq>] [--type <eventType>] [--json]",
+      "  gittensory-miner ledger scrape                                Print event-ledger counts as Prometheus text",
       "  gittensory-miner plan list [--status pending|running|completed|failed] [--json]",
       "  gittensory-miner plan show <planId> [--json]",
       "  gittensory-miner governor list [--repo <owner/repo>] [--type allowed|denied|throttled|kill_switch] [--json]",

--- a/packages/gittensory-miner/lib/event-ledger-cli.d.ts
+++ b/packages/gittensory-miner/lib/event-ledger-cli.d.ts
@@ -68,6 +68,11 @@ export function runLedgerList(
   options?: { initEventLedger?: () => EventLedger },
 ): number;
 
+export function runLedgerScrape(
+  args: string[],
+  options?: { initEventLedger?: () => EventLedger },
+): number;
+
 export function runLedgerCli(
   subcommand: string | undefined,
   args: string[],

--- a/packages/gittensory-miner/lib/event-ledger-cli.js
+++ b/packages/gittensory-miner/lib/event-ledger-cli.js
@@ -1,4 +1,5 @@
 import { initEventLedger } from "./event-ledger.js";
+import { renderEventLedgerMetrics } from "./event-ledger-metrics.js";
 
 const LEDGER_LIST_USAGE =
   "Usage: gittensory-miner ledger list [--repo <owner/repo>] [--since <seq>] [--type <eventType>] [--json]";
@@ -203,8 +204,31 @@ export function runLedgerList(args, options = {}) {
   }
 }
 
+const LEDGER_SCRAPE_USAGE = "Usage: gittensory-miner ledger scrape";
+
+// A Prometheus-scrape surface for the event ledger (#4841): render event-ledger entry counts by type as Prometheus
+// text-exposition to stdout, so a self-hoster's Grafana/alerting can scrape event activity instead of polling
+// `ledger list --json`. Read-only.
+export function runLedgerScrape(args, options = {}) {
+  const unknown = args.find((token) => token.startsWith("-"));
+  if (unknown) {
+    console.error(`Unknown option: ${unknown}. ${LEDGER_SCRAPE_USAGE}`);
+    return 2;
+  }
+  try {
+    return withEventLedger(options, (eventLedger) => {
+      process.stdout.write(renderEventLedgerMetrics(eventLedger.readEvents()));
+      return 0;
+    });
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 2;
+  }
+}
+
 export function runLedgerCli(subcommand, args, options = {}) {
   if (subcommand === "list") return runLedgerList(args, options);
+  if (subcommand === "scrape") return runLedgerScrape(args, options);
   console.error(`Unknown ledger subcommand: ${subcommand ?? ""}. ${LEDGER_LIST_USAGE}`);
   return 2;
 }

--- a/packages/gittensory-miner/lib/event-ledger-metrics.d.ts
+++ b/packages/gittensory-miner/lib/event-ledger-metrics.d.ts
@@ -1,0 +1,2 @@
+export const MINER_EVENTS_TOTAL: string;
+export function renderEventLedgerMetrics(events: ReadonlyArray<{ type: string }>): string;

--- a/packages/gittensory-miner/lib/event-ledger-metrics.js
+++ b/packages/gittensory-miner/lib/event-ledger-metrics.js
@@ -1,0 +1,40 @@
+// Event-ledger scrape surface (#4841): a pure Prometheus text-exposition renderer that turns the miner's local
+// event-ledger audit trail into scrape-able counters, so a self-hoster's Grafana/alerting can ingest event activity
+// without polling `ledger list --json`. Side-effect-free — a caller reads the ledger and prints this — mirroring the
+// metric-naming (`gittensory_miner_*_total`) and HELP/TYPE/escaping conventions of the miner prediction renderer
+// (packages/gittensory-engine/src/miner-prediction-metrics.ts).
+
+export const MINER_EVENTS_TOTAL = "gittensory_miner_events_total";
+
+/** HELP text escapes backslash and newline. */
+function escapeHelpText(help) {
+  return help.replace(/\\/g, "\\\\").replace(/\n/g, "\\n");
+}
+
+/** Prometheus label-value escaping (backslash, double-quote, newline) so an arbitrary event type can never break
+ *  the line. */
+function escapeLabelValue(value) {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n");
+}
+
+/**
+ * Render event-ledger entries as Prometheus text-exposition format: one `gittensory_miner_events_total{type="..."}`
+ * counter per distinct event type, emitted in sorted order for deterministic output. Always emits HELP/TYPE, so the
+ * surface is well-formed even for an empty ledger.
+ * @param {ReadonlyArray<{ type: string }>} events
+ * @returns {string}
+ */
+export function renderEventLedgerMetrics(events) {
+  const totalByType = new Map();
+  for (const event of events) {
+    totalByType.set(event.type, (totalByType.get(event.type) ?? 0) + 1);
+  }
+
+  const lines = [];
+  lines.push(`# HELP ${MINER_EVENTS_TOTAL} ${escapeHelpText("Entries recorded in the miner's local event ledger, by event type.")}`);
+  lines.push(`# TYPE ${MINER_EVENTS_TOTAL} counter`);
+  for (const [type, count] of [...totalByType.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+    lines.push(`${MINER_EVENTS_TOTAL}{type="${escapeLabelValue(type)}"} ${count}`);
+  }
+  return `${lines.join("\n")}\n`;
+}

--- a/test/unit/miner-event-ledger-scrape.test.ts
+++ b/test/unit/miner-event-ledger-scrape.test.ts
@@ -1,0 +1,115 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { initEventLedger } from "../../packages/gittensory-miner/lib/event-ledger.js";
+import {
+  runLedgerCli,
+  runLedgerScrape,
+} from "../../packages/gittensory-miner/lib/event-ledger-cli.js";
+import { renderEventLedgerMetrics } from "../../packages/gittensory-miner/lib/event-ledger-metrics.js";
+
+const roots: string[] = [];
+const ledgers: Array<{ close(): void }> = [];
+
+function tempLedger() {
+  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-event-scrape-"));
+  roots.push(root);
+  const ledger = initEventLedger(join(root, "event-ledger.sqlite3"));
+  ledgers.push(ledger);
+  return ledger;
+}
+
+function captureStdout(): { text: () => string } {
+  const chunks: string[] = [];
+  vi.spyOn(process.stdout, "write").mockImplementation((chunk: unknown) => {
+    chunks.push(String(chunk));
+    return true;
+  });
+  return { text: () => chunks.join("") };
+}
+
+afterEach(() => {
+  for (const ledger of ledgers.splice(0)) ledger.close();
+  vi.restoreAllMocks();
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("renderEventLedgerMetrics (#4841)", () => {
+  it("counts events by type as sorted Prometheus counters", () => {
+    const text = renderEventLedgerMetrics([
+      { type: "manage_pr_update" },
+      { type: "discovered_issue" },
+      { type: "manage_pr_update" },
+    ]);
+    expect(text).toContain("# HELP gittensory_miner_events_total");
+    expect(text).toContain("# TYPE gittensory_miner_events_total counter");
+    const body = text.split("\n");
+    // sorted by type: discovered_issue before manage_pr_update
+    const discoveredIdx = body.findIndex((l) => l.includes('type="discovered_issue"'));
+    const manageIdx = body.findIndex((l) => l.includes('type="manage_pr_update"'));
+    expect(discoveredIdx).toBeGreaterThan(-1);
+    expect(discoveredIdx).toBeLessThan(manageIdx);
+    expect(text).toContain('gittensory_miner_events_total{type="discovered_issue"} 1');
+    expect(text).toContain('gittensory_miner_events_total{type="manage_pr_update"} 2');
+    expect(text.endsWith("\n")).toBe(true);
+  });
+
+  it("emits a well-formed empty surface (HELP/TYPE only) with no events", () => {
+    const text = renderEventLedgerMetrics([]);
+    expect(text).toContain("# TYPE gittensory_miner_events_total counter");
+    expect(text).not.toContain('gittensory_miner_events_total{');
+  });
+
+  it("escapes special characters in an event type label", () => {
+    const text = renderEventLedgerMetrics([{ type: 'we"ird\\type' }]);
+    expect(text).toContain('gittensory_miner_events_total{type="we\\"ird\\\\type"} 1');
+  });
+});
+
+describe("gittensory-miner ledger scrape (#4841)", () => {
+  it("prints the event-ledger Prometheus surface to stdout", () => {
+    const eventLedger = tempLedger();
+    eventLedger.appendEvent({ type: "discovered_issue", repoFullName: "acme/widgets", payload: { issueNumber: 1 } });
+    eventLedger.appendEvent({ type: "manage_pr_update", repoFullName: "acme/widgets", payload: { prNumber: 2 } });
+    const out = captureStdout();
+
+    expect(runLedgerScrape([], { initEventLedger: () => eventLedger })).toBe(0);
+    const text = out.text();
+    expect(text).toContain('gittensory_miner_events_total{type="discovered_issue"} 1');
+    expect(text).toContain('gittensory_miner_events_total{type="manage_pr_update"} 1');
+  });
+
+  it("is reachable through the ledger subcommand dispatcher", () => {
+    const eventLedger = tempLedger();
+    eventLedger.appendEvent({ type: "plan_built", payload: { steps: 1 } });
+    const out = captureStdout();
+
+    expect(runLedgerCli("scrape", [], { initEventLedger: () => eventLedger })).toBe(0);
+    expect(out.text()).toContain('gittensory_miner_events_total{type="plan_built"} 1');
+  });
+
+  it("rejects an unknown option with exit code 2", () => {
+    const err = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    expect(runLedgerScrape(["--bogus"], { initEventLedger: () => tempLedger() })).toBe(2);
+    expect(String(err.mock.calls[0]?.[0])).toContain("Unknown option");
+  });
+
+  it("surfaces a store failure (Error) as exit code 2", () => {
+    const err = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const boom = () => {
+      throw new Error("store unavailable");
+    };
+    expect(runLedgerScrape([], { initEventLedger: boom })).toBe(2);
+    expect(String(err.mock.calls[0]?.[0])).toContain("store unavailable");
+  });
+
+  it("surfaces a non-Error store failure as exit code 2", () => {
+    const err = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const boom = () => {
+      throw "raw failure string"; // non-Error throw ⇒ String(error) branch
+    };
+    expect(runLedgerScrape([], { initEventLedger: boom })).toBe(2);
+    expect(String(err.mock.calls[0]?.[0])).toContain("raw failure string");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #4841

- The miner's event ledger is a structured audit trail, but it was pull-only via `ledger list --json` — a self-hoster had no scrape surface for their own Grafana or alerting to ingest event activity (#4841).
- Adds a pure `renderEventLedgerMetrics` renderer (`packages/gittensory-miner/lib/event-ledger-metrics.js`) that turns event-ledger entries into Prometheus text-exposition — one `gittensory_miner_events_total{type="..."}` counter per distinct event type, emitted in sorted order, always with HELP/TYPE so an empty ledger is still well-formed.
- Adds a `gittensory-miner ledger scrape` subcommand that reads the local event ledger (read-only) and writes those counters to **stdout**, suitable for a Prometheus scrape wrapper or a cron redirect — a consumption path beyond `ledger list --json`.
- Mirrors the metric-naming (`gittensory_miner_*_total`), HELP/TYPE, and label-escaping conventions of the existing miner prediction renderer; the renderer is pure and side-effect-free.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves — Closes #4841.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — verified the new `event-ledger-metrics.js` at **100% line + branch** coverage and every added line in `event-ledger-cli.js` (the `runLedgerScrape` command + dispatch) covered, via the v8 JSON report; 8 unit tests cover the renderer (sorted counts, empty surface, label escaping), the `scrape` command, dispatch through `runLedgerCli`, the unknown-option path, and both the Error and non-Error store-failure paths.
- [x] `npm run command-reference:check` (green — the added help line does not desync the generated command reference).

If any required check was skipped, explain why:

- `actionlint`, `test:workers`, `build:mcp` / `test:mcp-pack`, `ui:openapi:check`, `ui:lint` / `ui:typecheck` / `ui:build`, and `npm audit` were not run because this change touches **only** `packages/gittensory-miner/**` and `test/**` — no workflow, worker, MCP, OpenAPI/API, UI, or dependency surface for those jobs. The full `npm run test:ci` runs all of them on CI.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed. The surface emits only event-type counts from the operator's own local ledger; event types are label-escaped so an arbitrary type can never break the exposition format.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Public docs/changelogs are updated where needed; no changelog is edited (this is not a release-prep PR).

Auth/CORS/session, API/OpenAPI/MCP, and UI safety boxes are not applicable — this PR changes none of those surfaces.
