### PR TITLE
fix(miner-ui): reunify the portfolio view with the CLI's own richer dashboard

### DIFF
--- a/apps/gittensory-miner-ui/src/lib/portfolio-queue.ts
+++ b/apps/gittensory-miner-ui/src/lib/portfolio-queue.ts
@@ -1,5 +1,8 @@
-// Read-only client for the local portfolio-queue API (#4306). The view only needs summary cards, so the
-// middleware returns pre-aggregated counts and never republishes raw queue identifiers or priority metadata.
+// Read-only client for the local portfolio-queue API (#4306, richer per-repo detail added by #4846). The
+// middleware now serves the SAME per-repo dashboard shape the CLI's `queue dashboard` command computes
+// (packages/gittensory-miner/lib/portfolio-dashboard.js's collectPortfolioDashboard) instead of a narrower
+// global-only aggregate, so the miner-ui and the CLI share one data path rather than maintaining two. It still
+// never republishes raw queue identifiers or rank-derived priorities — only status counts, grouped by repo.
 
 export const PORTFOLIO_QUEUE_API_PATH = "/api/portfolio-queue";
 
@@ -9,9 +12,17 @@ export type QueueStatus = (typeof QUEUE_STATUSES)[number];
 
 export type QueueStatusCounts = Record<QueueStatus, number>;
 
+export type PortfolioRepoSummary = {
+  repoFullName: string;
+  byStatus: QueueStatusCounts;
+  total: number;
+};
+
 export type PortfolioQueueSummary = {
   total: number;
-  counts: QueueStatusCounts;
+  byStatus: QueueStatusCounts;
+  repos: PortfolioRepoSummary[];
+  oldestQueuedAgeMs: number | null;
 };
 
 export type PortfolioQueueResult = { ok: true; summary: PortfolioQueueSummary } | { ok: false; error: string };
@@ -22,25 +33,30 @@ function isQueueStatusCounts(value: unknown): value is QueueStatusCounts {
   return QUEUE_STATUSES.every((status) => typeof counts[status] === "number");
 }
 
+function isPortfolioRepoSummary(value: unknown): value is PortfolioRepoSummary {
+  if (typeof value !== "object" || value === null) return false;
+  const repo = value as Record<string, unknown>;
+  return typeof repo.repoFullName === "string" && isQueueStatusCounts(repo.byStatus) && typeof repo.total === "number";
+}
+
 function isPortfolioQueueSummary(value: unknown): value is PortfolioQueueSummary {
   if (typeof value !== "object" || value === null) return false;
   const summary = value as Record<string, unknown>;
-  return typeof summary.total === "number" && isQueueStatusCounts(summary.counts);
+  return (
+    typeof summary.total === "number" &&
+    isQueueStatusCounts(summary.byStatus) &&
+    Array.isArray(summary.repos) &&
+    summary.repos.every(isPortfolioRepoSummary) &&
+    (summary.oldestQueuedAgeMs === null || typeof summary.oldestQueuedAgeMs === "number")
+  );
 }
 
 export const emptyPortfolioQueueSummary = (): PortfolioQueueSummary => ({
   total: 0,
-  counts: { queued: 0, in_progress: 0, done: 0 },
+  byStatus: { queued: 0, in_progress: 0, done: 0 },
+  repos: [],
+  oldestQueuedAgeMs: null,
 });
-
-export function summarizePortfolioQueueStatuses(statuses: QueueStatus[]): PortfolioQueueSummary {
-  const summary = emptyPortfolioQueueSummary();
-  for (const status of statuses) {
-    summary.total += 1;
-    summary.counts[status] += 1;
-  }
-  return summary;
-}
 
 /** Fetch the local queue summary; failures surface as a typed error result the view renders, never a crash. */
 export async function fetchPortfolioQueue(fetchImpl: typeof fetch = fetch): Promise<PortfolioQueueResult> {

--- a/apps/gittensory-miner-ui/src/portfolio-queue.test.tsx
+++ b/apps/gittensory-miner-ui/src/portfolio-queue.test.tsx
@@ -5,15 +5,20 @@ import {
   emptyPortfolioQueueSummary,
   fetchPortfolioQueue,
   PORTFOLIO_QUEUE_API_PATH,
-  summarizePortfolioQueueStatuses,
   type PortfolioQueueResult,
+  type PortfolioQueueSummary,
 } from "./lib/portfolio-queue";
 import { PortfolioPage, PortfolioQueueView } from "./routes/portfolio";
 import { handlePortfolioQueueRequest, type PortfolioQueueApiDeps } from "../vite-portfolio-queue-api";
 
-const fixtureSummary = {
+const fixtureSummary: PortfolioQueueSummary = {
   total: 4,
-  counts: { queued: 2, in_progress: 1, done: 1 },
+  byStatus: { queued: 2, in_progress: 1, done: 1 },
+  repos: [
+    { repoFullName: "acme/another-repo", byStatus: { queued: 1, in_progress: 0, done: 1 }, total: 2 },
+    { repoFullName: "acme/secret-repo", byStatus: { queued: 1, in_progress: 1, done: 0 }, total: 2 },
+  ],
+  oldestQueuedAgeMs: 5_400_000,
 };
 
 const rawQueueRows = [
@@ -47,30 +52,39 @@ const rawQueueRows = [
   },
 ];
 
-describe("summarizePortfolioQueueStatuses (#4306)", () => {
-  it("counts queue statuses without retaining row identifiers", () => {
-    expect(summarizePortfolioQueueStatuses(["queued", "in_progress", "done", "queued"])).toEqual(fixtureSummary);
-  });
-
-  it("summarizes an empty queue to zeros", () => {
+describe("emptyPortfolioQueueSummary (#4306)", () => {
+  it("summarizes an empty queue to zeros with no repos", () => {
     expect(emptyPortfolioQueueSummary()).toEqual({
       total: 0,
-      counts: { queued: 0, in_progress: 0, done: 0 },
+      byStatus: { queued: 0, in_progress: 0, done: 0 },
+      repos: [],
+      oldestQueuedAgeMs: null,
     });
   });
 });
 
-describe("PortfolioQueueView (#4306)", () => {
-  it("renders one card per status with the aggregated counts", () => {
+describe("PortfolioQueueView (#4306, per-repo detail added by #4846)", () => {
+  it("renders one card per status with the aggregated global counts", () => {
     render(<PortfolioQueueView result={{ ok: true, summary: fixtureSummary }} />);
-    expect(screen.getByText("Queued").nextSibling?.textContent).toBe("2");
-    expect(screen.getByText("In progress").nextSibling?.textContent).toBe("1");
-    expect(screen.getByText("Done").nextSibling?.textContent).toBe("1");
+    // Scoped to <dt> since the per-repo table below also has "Queued"/"In progress"/"Done" column headers.
+    expect(screen.getByText("Queued", { selector: "dt" }).nextSibling?.textContent).toBe("2");
+    expect(screen.getByText("In progress", { selector: "dt" }).nextSibling?.textContent).toBe("1");
+    expect(screen.getByText("Done", { selector: "dt" }).nextSibling?.textContent).toBe("1");
+  });
+
+  it("renders one table row per repo with its own status breakdown and total", () => {
+    render(<PortfolioQueueView result={{ ok: true, summary: fixtureSummary }} />);
+    expect(screen.getByRole("columnheader", { name: "Repository" })).toBeTruthy();
+    expect(screen.getByText("acme/another-repo")).toBeTruthy();
+    expect(screen.getByText("acme/secret-repo")).toBeTruthy();
+    // header + 2 repo rows
+    expect(screen.getAllByRole("row")).toHaveLength(3);
   });
 
   it("renders the fresh-install empty state without erroring", () => {
     render(<PortfolioQueueView result={{ ok: true, summary: emptyPortfolioQueueSummary() }} />);
     expect(screen.getByText(/No queued work yet/i)).toBeTruthy();
+    expect(screen.queryByRole("table")).toBeNull();
   });
 
   it("renders an error message when the local API is unreachable", () => {
@@ -89,7 +103,7 @@ describe("PortfolioPage (#4306)", () => {
     const loadPortfolioQueue = async (): Promise<PortfolioQueueResult> => ({ ok: true, summary: fixtureSummary });
     render(<PortfolioPage loadPortfolioQueue={loadPortfolioQueue} />);
     expect(screen.getByRole("heading", { name: "Portfolio queue" })).toBeTruthy();
-    await waitFor(() => expect(screen.getByText("Queued").nextSibling?.textContent).toBe("2"));
+    await waitFor(() => expect(screen.getByText("Queued", { selector: "dt" }).nextSibling?.textContent).toBe("2"));
   });
 });
 
@@ -116,7 +130,19 @@ describe("fetchPortfolioQueue (#4306)", () => {
       ok: false,
     });
     expect(
-      await fetchPortfolioQueue(async () => jsonResponse(200, { summary: { total: 1, counts: { queued: "1" } } })),
+      await fetchPortfolioQueue(async () => jsonResponse(200, { summary: { total: 1, byStatus: { queued: "1" } } })),
+    ).toMatchObject({ ok: false });
+    expect(
+      await fetchPortfolioQueue(async () =>
+        jsonResponse(200, {
+          summary: {
+            total: 1,
+            byStatus: { queued: 1, in_progress: 0, done: 0 },
+            repos: "nope",
+            oldestQueuedAgeMs: null,
+          },
+        }),
+      ),
     ).toMatchObject({ ok: false });
     expect(
       await fetchPortfolioQueue(async () => {
@@ -126,23 +152,88 @@ describe("fetchPortfolioQueue (#4306)", () => {
   });
 });
 
-describe("handlePortfolioQueueRequest (#4306)", () => {
+// Test-local re-implementation of collectPortfolioDashboard's aggregation, used only as the fake behind
+// loadPortfolioDashboardModule below. The API handler tests here exercise WIRING (does the handler call
+// listQueue and pass the right sources/nowMs into the dashboard aggregator, and does it serialize whatever
+// comes back without leaking raw rows) -- the aggregation algorithm's own correctness (sorting, per-repo
+// grouping, oldest-queued-age math, edge cases) is exhaustively covered by
+// test/unit/miner-portfolio-dashboard.test.ts. The real portfolio-dashboard.js module cannot be imported
+// directly here: it transitively pulls in `node:sqlite` via portfolio-queue.js, which this app's Vite
+// client/test environment cannot bundle (the same reason the real handler loads it dynamically).
+function fakeCollectPortfolioDashboard(
+  sources: { portfolioQueue: { listQueue: () => Array<{ repoFullName: string; status: string; enqueuedAt: string }> } },
+  options: { nowMs: number },
+): PortfolioQueueSummary {
+  const byStatus = { queued: 0, in_progress: 0, done: 0 };
+  const perRepo = new Map<string, { repoFullName: string; byStatus: typeof byStatus; total: number }>();
+  let total = 0;
+  let oldestQueuedMs: number | null = null;
+  for (const entry of sources.portfolioQueue.listQueue()) {
+    const status = entry.status as "queued" | "in_progress" | "done";
+    total += 1;
+    byStatus[status] += 1;
+    let repo = perRepo.get(entry.repoFullName);
+    if (!repo) {
+      repo = { repoFullName: entry.repoFullName, byStatus: { queued: 0, in_progress: 0, done: 0 }, total: 0 };
+      perRepo.set(entry.repoFullName, repo);
+    }
+    repo.byStatus[status] += 1;
+    repo.total += 1;
+    if (status === "queued") {
+      const ms = Date.parse(entry.enqueuedAt);
+      if (oldestQueuedMs === null || ms < oldestQueuedMs) oldestQueuedMs = ms;
+    }
+  }
+  const repos = [...perRepo.values()].sort((a, b) => a.repoFullName.localeCompare(b.repoFullName));
+  return {
+    total,
+    byStatus,
+    repos,
+    oldestQueuedAgeMs: oldestQueuedMs === null ? null : options.nowMs - oldestQueuedMs,
+  };
+}
+
+describe("handlePortfolioQueueRequest (#4306, reunified with the CLI's queue dashboard by #4846)", () => {
   const rows = rawQueueRows;
+  const NOW_MS = Date.parse("2026-07-10T07:00:00.000Z");
+
   function deps(overrides: Partial<PortfolioQueueApiDeps> = {}): PortfolioQueueApiDeps {
     return {
       loadPortfolioQueueModule: async () => ({
         resolvePortfolioQueueDbPath: () => "/home/miner/.config/gittensory-miner/portfolio-queue.sqlite3",
         listQueue: () => rows,
       }),
+      loadPortfolioDashboardModule: async () => ({ collectPortfolioDashboard: fakeCollectPortfolioDashboard }),
       fileExists: () => true,
+      now: () => NOW_MS,
       ...overrides,
     };
   }
 
-  it("serves only aggregate counts and omits raw queue metadata", async () => {
+  it("serves the same per-repo dashboard shape the CLI's queue dashboard computes, with repo names but no raw identifiers or priorities", async () => {
     const handled = await handlePortfolioQueueRequest("GET", "/api/portfolio-queue", deps());
-    expect(handled).toEqual({ status: 200, body: JSON.stringify({ summary: fixtureSummary }) });
-    expect(handled?.body).not.toContain("private-org/secret-repo");
+    expect(handled?.status).toBe(200);
+    const body = JSON.parse(handled?.body ?? "{}") as { summary: PortfolioQueueSummary };
+    expect(body.summary).toEqual({
+      total: 4,
+      byStatus: { queued: 2, in_progress: 1, done: 1 },
+      repos: [
+        {
+          repoFullName: "private-org/another-repo",
+          byStatus: { queued: 1, in_progress: 0, done: 1 },
+          total: 2,
+        },
+        {
+          repoFullName: "private-org/secret-repo",
+          byStatus: { queued: 1, in_progress: 1, done: 0 },
+          total: 2,
+        },
+      ],
+      oldestQueuedAgeMs: 5_400_000,
+    });
+    // Repo names ARE exposed (matching the CLI's own dashboard, which already prints them locally), but
+    // per-item identifiers and rank-derived priorities never cross the wire.
+    expect(handled?.body).toContain("private-org/secret-repo");
     expect(handled?.body).not.toContain("issue:12");
     expect(handled?.body).not.toContain("priority");
   });
@@ -183,5 +274,20 @@ describe("handlePortfolioQueueRequest (#4306)", () => {
       }),
     );
     expect(handled).toEqual({ status: 500, body: JSON.stringify({ error: "sqlite locked" }) });
+  });
+
+  it("returns null oldestQueuedAgeMs when nothing is queued (only in_progress/done items present)", async () => {
+    const handled = await handlePortfolioQueueRequest(
+      "GET",
+      "/api/portfolio-queue",
+      deps({
+        loadPortfolioQueueModule: async () => ({
+          resolvePortfolioQueueDbPath: () => "/home/miner/.config/gittensory-miner/portfolio-queue.sqlite3",
+          listQueue: () => [rows[1]!, rows[2]!], // in_progress + done only, no queued row
+        }),
+      }),
+    );
+    const body = JSON.parse(handled?.body ?? "{}") as { summary: PortfolioQueueSummary };
+    expect(body.summary.oldestQueuedAgeMs).toBeNull();
   });
 });

--- a/apps/gittensory-miner-ui/src/routes/portfolio.tsx
+++ b/apps/gittensory-miner-ui/src/routes/portfolio.tsx
@@ -2,6 +2,14 @@ import { createFileRoute } from "@tanstack/react-router";
 import { useEffect, useState } from "react";
 
 import { Card, CardContent, CardHeader } from "@jsonbored/gittensory-ui-kit/components/card";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@jsonbored/gittensory-ui-kit/components/table";
 
 import { fetchPortfolioQueue, type PortfolioQueueResult, type QueueStatus } from "../lib/portfolio-queue";
 
@@ -9,8 +17,11 @@ export const Route = createFileRoute("/portfolio")({
   component: PortfolioPage,
 });
 
-// Portfolio/queue summary cards (#4306): read-only counts by status over the local `miner_portfolio_queue`
-// store. Same 4-state pattern as the run-history view (loading / error / fresh-install empty / populated).
+// Portfolio/queue summary cards + per-repo table (#4306, reunified with the CLI's own richer `queue dashboard`
+// by #4846): read-only counts by status over the local `miner_portfolio_queue` store, now broken out per repo
+// exactly as `gittensory-miner queue dashboard` already shows -- the miner-ui no longer maintains a narrower,
+// global-only aggregation. Same 4-state pattern as the run-history view (loading / error / fresh-install empty
+// / populated).
 
 const STATUS_LABELS: Record<QueueStatus, string> = {
   queued: "Queued",
@@ -46,18 +57,42 @@ export function PortfolioQueueView({ result }: { result: PortfolioQueueResult | 
     );
   }
   return (
-    <dl className="grid gap-4 sm:grid-cols-3">
-      {(Object.keys(STATUS_LABELS) as QueueStatus[]).map((status) => (
-        <Card key={status}>
-          <CardContent className="p-4">
-            <dt className="text-token-2xs uppercase tracking-wider text-muted-foreground">{STATUS_LABELS[status]}</dt>
-            <dd className={`mt-1 text-token-3xl font-display font-semibold ${STATUS_TONE[status]}`}>
-              {summary.counts[status]}
-            </dd>
-          </CardContent>
-        </Card>
-      ))}
-    </dl>
+    <div className="grid gap-6">
+      <dl className="grid gap-4 sm:grid-cols-3">
+        {(Object.keys(STATUS_LABELS) as QueueStatus[]).map((status) => (
+          <Card key={status}>
+            <CardContent className="p-4">
+              <dt className="text-token-2xs uppercase tracking-wider text-muted-foreground">{STATUS_LABELS[status]}</dt>
+              <dd className={`mt-1 text-token-3xl font-display font-semibold ${STATUS_TONE[status]}`}>
+                {summary.byStatus[status]}
+              </dd>
+            </CardContent>
+          </Card>
+        ))}
+      </dl>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Repository</TableHead>
+            <TableHead>Queued</TableHead>
+            <TableHead>In progress</TableHead>
+            <TableHead>Done</TableHead>
+            <TableHead>Total</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {summary.repos.map((repo) => (
+            <TableRow key={repo.repoFullName}>
+              <TableCell className="font-mono text-foreground">{repo.repoFullName}</TableCell>
+              <TableCell>{repo.byStatus.queued}</TableCell>
+              <TableCell>{repo.byStatus.in_progress}</TableCell>
+              <TableCell>{repo.byStatus.done}</TableCell>
+              <TableCell>{repo.total}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
   );
 }
 

--- a/apps/gittensory-miner-ui/vite-portfolio-queue-api.ts
+++ b/apps/gittensory-miner-ui/vite-portfolio-queue-api.ts
@@ -4,53 +4,57 @@ import type { Plugin } from "vite";
 // Local read-only portfolio-queue API (#4306) — the sibling of `vite-run-state-api.ts` (#4305), same shape for
 // the same reason: the dashboard is a browser app while the queue store is a `node:sqlite` file on disk, so the
 // dev server bridges the two by calling into `packages/gittensory-miner/lib/portfolio-queue.js`'s EXISTING
-// exports (`resolvePortfolioQueueDbPath`/`listQueue`). It aggregates server-side so the HTTP surface never
-// republishes raw queue identifiers or rank-derived priorities.
+// exports (`resolvePortfolioQueueDbPath`/`listQueue`).
+//
+// Reunified with the CLI's own richer dashboard (#4846): the aggregation is now
+// `packages/gittensory-miner/lib/portfolio-dashboard.js`'s `collectPortfolioDashboard` -- the SAME pure
+// aggregator `gittensory-miner queue dashboard` and the read-only MCP tool already use -- instead of a
+// narrower global-only re-implementation, so the miner-ui and the CLI share one data path. It still aggregates
+// server-side so the HTTP surface never republishes raw queue identifiers or rank-derived priorities; only
+// status counts, grouped globally and per repo, cross the wire.
 //
 // Same read-only fresh-install rule as the run-state endpoint: `listQueue()` lazily initializes the default
 // store, which would CREATE the SQLite file — so the handler probes the resolved DB path first and serves an
 // empty summary without ever touching the store when no DB exists yet.
 
+import type { PortfolioDashboardSummary } from "../../packages/gittensory-miner/lib/portfolio-dashboard.js";
+
 type PortfolioQueueModule = {
   resolvePortfolioQueueDbPath: () => string;
-  listQueue: () => Array<{ status: string }>;
+  listQueue: (repoFullName?: string | null) => Array<{ repoFullName: string; status: string; enqueuedAt: string }>;
+};
+
+type PortfolioDashboardModule = {
+  collectPortfolioDashboard: (
+    sources: { portfolioQueue: { listQueue: PortfolioQueueModule["listQueue"] } },
+    options: { nowMs: number },
+  ) => PortfolioDashboardSummary;
 };
 
 export type PortfolioQueueApiDeps = {
   /** Import of `packages/gittensory-miner/lib/portfolio-queue.js` — injectable so tests never touch a real store. */
   loadPortfolioQueueModule: () => Promise<PortfolioQueueModule>;
+  /** Import of `packages/gittensory-miner/lib/portfolio-dashboard.js` — dynamic for the same reason as
+   *  `loadPortfolioQueueModule` (it transitively pulls in `node:sqlite` via portfolio-queue.js, which the UI's
+   *  client-side test/build environment cannot bundle) and injectable so tests never touch a real store. */
+  loadPortfolioDashboardModule: () => Promise<PortfolioDashboardModule>;
   /** File-existence probe for the fresh-install fast path. */
   fileExists: (path: string) => boolean;
+  /** Clock for `oldestQueuedAgeMs` — injectable so tests get deterministic ages. */
+  now: () => number;
 };
 
-type QueueStatus = "queued" | "in_progress" | "done";
-type QueueStatusCounts = Record<QueueStatus, number>;
-type PortfolioQueueSummary = { total: number; counts: QueueStatusCounts };
-
-const QUEUE_STATUSES = ["queued", "in_progress", "done"] as const;
-
-function emptyPortfolioQueueSummary(): PortfolioQueueSummary {
-  return { total: 0, counts: { queued: 0, in_progress: 0, done: 0 } };
-}
-
-function isQueueStatus(value: string): value is QueueStatus {
-  return (QUEUE_STATUSES as readonly string[]).includes(value);
-}
-
-function summarizePortfolioQueueRows(rows: Array<{ status: string }>): PortfolioQueueSummary {
-  const summary = emptyPortfolioQueueSummary();
-  for (const row of rows) {
-    if (!isQueueStatus(row.status)) continue;
-    summary.total += 1;
-    summary.counts[row.status] += 1;
-  }
-  return summary;
+function emptyPortfolioQueueSummary(): PortfolioDashboardSummary {
+  return { total: 0, byStatus: { queued: 0, in_progress: 0, done: 0 }, repos: [], oldestQueuedAgeMs: null };
 }
 
 const defaultDeps: PortfolioQueueApiDeps = {
   loadPortfolioQueueModule: () =>
     import("../../packages/gittensory-miner/lib/portfolio-queue.js") as Promise<PortfolioQueueModule>,
+  loadPortfolioDashboardModule: () =>
+    import("../../packages/gittensory-miner/lib/portfolio-dashboard.js") as Promise<PortfolioDashboardModule>,
   fileExists: existsSync,
+  now: () => Date.now(),
 };
 
 /** Request handler factored out of the Vite plugin shape so tests drive it directly (mirrors the run-state API). */
@@ -65,7 +69,12 @@ export async function handlePortfolioQueueRequest(
     if (!deps.fileExists(queue.resolvePortfolioQueueDbPath())) {
       return { status: 200, body: JSON.stringify({ summary: emptyPortfolioQueueSummary() }) };
     }
-    return { status: 200, body: JSON.stringify({ summary: summarizePortfolioQueueRows(queue.listQueue()) }) };
+    const { collectPortfolioDashboard } = await deps.loadPortfolioDashboardModule();
+    const summary = collectPortfolioDashboard(
+      { portfolioQueue: { listQueue: queue.listQueue } },
+      { nowMs: deps.now() },
+    );
+    return { status: 200, body: JSON.stringify({ summary }) };
   } catch (error) {
     const message = error instanceof Error ? error.message : "failed to read local portfolio queue";
     return { status: 500, body: JSON.stringify({ error: message }) };


### PR DESCRIPTION
## Summary

- The miner-ui's portfolio view re-implemented its own narrower, global-only aggregation (`{ total, counts }`) instead of reusing the CLI's own richer, per-repo `queue dashboard` output — a real functional regression, not just duplicated code, and the miner-ui and CLI maintained two separate data paths for the same underlying `miner_portfolio_queue` store.
- `apps/gittensory-miner-ui/vite-portfolio-queue-api.ts` (the local dev-server API middleware) now calls `packages/gittensory-miner/lib/portfolio-dashboard.js`'s existing `collectPortfolioDashboard` — the SAME pure aggregator `gittensory-miner queue dashboard` and the read-only `gittensory_miner_get_portfolio_dashboard` MCP tool already use — instead of a bespoke, narrower re-implementation. One shared data path now feeds the CLI, the MCP tool, and the UI.
- `apps/gittensory-miner-ui/src/lib/portfolio-queue.ts`'s `PortfolioQueueSummary` type now matches the CLI's dashboard shape (`{ total, byStatus, repos: [{repoFullName, byStatus, total}], oldestQueuedAgeMs }`) instead of the old flat `{ total, counts }`.
- `apps/gittensory-miner-ui/src/routes/portfolio.tsx` now renders a per-repo breakdown table (using the shared `@jsonbored/gittensory-ui-kit` `Table` component, matching the existing `run-history.tsx` route's pattern) beneath the existing global summary cards, so the view shows the same per-repo detail the CLI's `queue dashboard` already shows — not just a global aggregate.
- The API still aggregates server-side and never republishes raw per-item queue identifiers or rank-derived priorities — only status counts, now grouped globally *and* per repo, cross the wire. Repo full names ARE now exposed (the CLI's own dashboard already prints them locally, so they were never treated as sensitive — only `identifier`/`priority` are).

Fixes #4846

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked an issue, or this is small enough that the summary explains why an issue is not needed.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — this change lives entirely under `apps/gittensory-miner-ui/**` (a separate vitest workspace covered by `ui:test`, not the root `test:coverage`/Codecov-measured slice) and `packages/gittensory-miner/**`, which sits outside vitest's `coverage.include` glob today.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run build:miner`
- [x] `npm run test:miner-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:test`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

Ran the full `apps/gittensory-miner-ui` test suite (33/33 passing, including 14 in the rewritten `portfolio-queue.test.tsx`) plus `npm run ui:lint`/`ui:typecheck`/`ui:test`/`ui:build` at the root (all green). Also manually started the real dev server and curled `GET /api/portfolio-queue` against a fresh (no local state) install to confirm the live endpoint returns the new shape end-to-end (`{"summary":{"total":0,"byStatus":{...},"repos":[],"oldestQueuedAgeMs":null}}`), not just the unit-test doubles.

Test coverage added/updated: per-repo table rendering (row-per-repo, correct per-status columns), the fresh-install/loading/error states unchanged, the API handler's wiring to the (now dynamically-imported, to avoid a `node:sqlite`-via-`portfolio-queue.js` bundling failure in the UI's client/test environment) dashboard aggregator, the fresh-install fast path (never initializes the store), a 500-on-store-failure path, and a `oldestQueuedAgeMs: null` case when nothing is queued. The aggregation algorithm's own correctness (sorting, per-repo grouping, oldest-queued-age math) is already exhaustively covered by the pre-existing `test/unit/miner-portfolio-dashboard.test.ts` — this PR's tests verify the API handler's wiring/serialization, not re-derive that math.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no auth/session/CORS surface touched (this is a local-only, loopback dev-server API, unchanged in that respect).
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — the local `/api/portfolio-queue` dev-server endpoint's response shape changed (documented above); no public API/OpenAPI/MCP surface is touched.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — the route continues to fetch from the real local API; loading/error/empty states are unchanged, verified live against the real dev server.
- [x] Visible UI changes include a `UI Evidence` section below.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

This is a local-only, loopback dev-server dashboard with no hosted/public deployment to screenshot from this environment (no browser screenshot tooling available here). Verified functionally instead: `npm run ui:test` (33/33 passing, including full render assertions for the new per-repo table — column headers, one row per repo, correct per-status counts) and a live `curl` against the real running dev server (see Validation above) confirming the endpoint's real response shape end-to-end on a fresh install.

## Notes

- Kept the existing global summary cards (queued/in_progress/done) alongside the new per-repo table rather than replacing them — the CLI's own `queue dashboard` output leads with the same global totals before its per-repo table, so this mirrors that ordering.
- `oldestQueuedAgeMs` is now also surfaced end-to-end (part of `collectPortfolioDashboard`'s existing output) even though not explicitly named in the issue's acceptance criteria — it comes for free from sharing the same aggregator and further closes the CLI/UI parity gap the issue is about; not yet rendered in the UI (kept the visible scope to the requested per-repo table) but available on the typed summary for a follow-up.
