### PR TITLE
fix(miner): resolve tempDir through realpathSync in coding-task-spec tests

### DIFF
--- a/test/unit/miner-coding-task-spec.test.ts
+++ b/test/unit/miner-coding-task-spec.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, readFileSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -23,7 +23,11 @@ afterEach(() => {
 function tempDir() {
   const root = mkdtempSync(join(tmpdir(), "gittensory-miner-coding-task-spec-"));
   roots.push(root);
-  return root;
+  // Resolved once here, not just inside writeAcceptanceCriteriaFile: os.tmpdir() can itself sit behind a
+  // symlink (e.g. macOS's /var -> /private/var), so a RAW mkdtempSync path wouldn't byte-match the realpath
+  // writeAcceptanceCriteriaFile's own symlink defense already resolves to internally -- resolving here keeps
+  // every test's own path expectations meaningful on every platform, not just Linux CI runners.
+  return realpathSync(root);
 }
 
 function issue(overrides: Record<string, unknown> = {}) {


### PR DESCRIPTION
## Summary
`writeAcceptanceCriteriaFile` (#5322, already merged) resolves `workingDirectory` through `realpathSync` before building the acceptance-criteria path -- a correct symlink defense. Its own tests, though, compared the result against a raw `mkdtempSync` path. On macOS, `os.tmpdir()` sits behind `/var -> /private/var`, so the raw and realpath-resolved paths never byte-matched, failing two tests locally (Linux CI runners don't have this symlink, so this never showed up there).

Discovered incidentally while rebasing an unrelated PR (#4848) onto main and running the local suite.

Fix: resolve once in the shared `tempDir()` test helper, so every test's own path expectation stays meaningful on any platform.

## Test plan
- [x] `tsc --noEmit --incremental false` clean
- [x] `npx vitest run test/unit/miner-coding-task-spec.test.ts` -- 16/16 passing (was 2 failing locally before this fix)
- [x] `npx vitest run test/unit test/contract` -- 771/772 passing (1 pre-existing unrelated skip)
- [x] `npm run docs:drift-check` / `manifest:drift-check` / `engine-parity:drift-check` all clean
- [x] `npm audit --audit-level=moderate` -- 0 vulnerabilities
- [x] `git diff --check` clean