### PR TITLE
feat(miner): add a ledger metrics command that renders event-ledger Prometheus text (#4841)

### DIFF
--- a/packages/gittensory-miner/lib/cli.js
+++ b/packages/gittensory-miner/lib/cli.js
@@ -34,6 +34,7 @@ export function printHelp(input) {
       "  gittensory-miner claim release <owner/repo> <issue#> [--json]",
       "  gittensory-miner claim list [--repo <owner/repo>] [--status active|released|expired] [--json]",
       "  gittensory-miner ledger list [--repo <owner/repo>] [--since <seq>] [--type <eventType>] [--json]",
+      "  gittensory-miner ledger metrics                               Print event-ledger counters in Prometheus text format",
       "  gittensory-miner plan list [--status pending|running|completed|failed] [--json]",
       "  gittensory-miner plan show <planId> [--json]",
       "  gittensory-miner governor list [--repo <owner/repo>] [--type allowed|denied|throttled|kill_switch] [--json]",

--- a/packages/gittensory-miner/lib/event-ledger-cli.d.ts
+++ b/packages/gittensory-miner/lib/event-ledger-cli.d.ts
@@ -63,7 +63,14 @@ export function collectEventLedgerAuditFeed(
 
 export function renderLedgerTable(events: LedgerEntry[]): string;
 
+export function renderEventLedgerMetrics(events: readonly LedgerEntry[]): string;
+
 export function runLedgerList(
+  args: string[],
+  options?: { initEventLedger?: () => EventLedger },
+): number;
+
+export function runLedgerMetrics(
   args: string[],
   options?: { initEventLedger?: () => EventLedger },
 ): number;

--- a/packages/gittensory-miner/lib/event-ledger-cli.js
+++ b/packages/gittensory-miner/lib/event-ledger-cli.js
@@ -164,6 +164,46 @@ export function renderLedgerTable(events) {
   return [header, ...lines].join("\n");
 }
 
+const EVENT_LEDGER_METRICS_USAGE = "Usage: gittensory-miner ledger metrics";
+
+// Prometheus metric name for the per-type event-ledger counter. Mirrors the `gittensory_miner_*_total` naming and
+// the HELP/TYPE/label conventions of the engine's renderMinerPredictionMetrics
+// (packages/gittensory-engine/src/miner-prediction-metrics.ts) rather than importing across the package boundary.
+const MINER_EVENTS_TOTAL = "gittensory_miner_events_total";
+
+/** HELP-text escaping — backslash + newline (mirrors miner-prediction-metrics.ts's escapeHelpText). */
+function escapeHelpText(help) {
+  return help.replace(/\\/g, "\\\\").replace(/\n/g, "\\n");
+}
+
+/** Prometheus label-value escaping — backslash, double-quote, newline — so an arbitrary event `type` string can
+ *  never break the metric line (mirrors miner-prediction-metrics.ts's escapeLabelValue). */
+function escapeLabelValue(value) {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, "\\n");
+}
+
+/**
+ * Render event-ledger activity as Prometheus text-exposition counters: one `gittensory_miner_events_total{type}`
+ * series per event type, so a self-hoster's own Grafana/alerting can scrape ledger activity instead of polling
+ * `ledger list --json` (#4841). Pure + side-effect-free — the caller supplies the rows and prints the result;
+ * deterministic (series emitted in sorted type order); always emits HELP/TYPE so an empty ledger is still a
+ * well-formed exposition document.
+ */
+export function renderEventLedgerMetrics(events) {
+  const totalByType = new Map();
+  for (const entry of events) {
+    totalByType.set(entry.type, (totalByType.get(entry.type) ?? 0) + 1);
+  }
+  const lines = [
+    `# HELP ${MINER_EVENTS_TOTAL} ${escapeHelpText("Event-ledger entries the miner has recorded, by event type.")}`,
+    `# TYPE ${MINER_EVENTS_TOTAL} counter`,
+  ];
+  for (const [type, count] of [...totalByType.entries()].sort((a, b) => a[0].localeCompare(b[0]))) {
+    lines.push(`${MINER_EVENTS_TOTAL}{type="${escapeLabelValue(type)}"} ${count}`);
+  }
+  return `${lines.join("\n")}\n`;
+}
+
 function withEventLedger(options, run) {
   const ownsLedger = options.initEventLedger === undefined;
   const eventLedger = (options.initEventLedger ?? initEventLedger)();
@@ -203,8 +243,28 @@ export function runLedgerList(args, options = {}) {
   }
 }
 
+export function runLedgerMetrics(args, options = {}) {
+  if (args.length > 0) {
+    console.error(EVENT_LEDGER_METRICS_USAGE);
+    return 2;
+  }
+
+  try {
+    return withEventLedger(options, (eventLedger) => {
+      // renderEventLedgerMetrics returns a newline-terminated document; console.log re-adds the terminator, so
+      // trim it to emit exactly one trailing newline (mirrors metrics-cli.js's runMetrics).
+      console.log(renderEventLedgerMetrics(eventLedger.readEvents()).trimEnd());
+      return 0;
+    });
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    return 2;
+  }
+}
+
 export function runLedgerCli(subcommand, args, options = {}) {
   if (subcommand === "list") return runLedgerList(args, options);
+  if (subcommand === "metrics") return runLedgerMetrics(args, options);
   console.error(`Unknown ledger subcommand: ${subcommand ?? ""}. ${LEDGER_LIST_USAGE}`);
   return 2;
 }

--- a/test/unit/miner-cli.test.ts
+++ b/test/unit/miner-cli.test.ts
@@ -65,6 +65,7 @@ describe("gittensory-miner CLI helpers", () => {
     expect(text).toContain("gittensory-miner --help");
     expect(text).toContain("gittensory-miner version");
     expect(text).toContain("gittensory-miner metrics");
+    expect(text).toContain("gittensory-miner ledger metrics");
     expect(text).toContain("--no-update-check");
   });
 

--- a/test/unit/miner-event-ledger-cli.test.ts
+++ b/test/unit/miner-event-ledger-cli.test.ts
@@ -9,9 +9,11 @@ import {
 import {
   filterLedgerEvents,
   parseLedgerListArgs,
+  renderEventLedgerMetrics,
   renderLedgerTable,
   runLedgerCli,
   runLedgerList,
+  runLedgerMetrics,
 } from "../../packages/gittensory-miner/lib/event-ledger-cli.js";
 import type { LedgerEntry } from "../../packages/gittensory-miner/lib/event-ledger.d.ts";
 
@@ -24,6 +26,16 @@ function tempLedger() {
   const ledger = initEventLedger(join(root, "event-ledger.sqlite3"));
   ledgers.push(ledger);
   return ledger;
+}
+
+function tempEventDbPath() {
+  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-event-ledger-metrics-"));
+  roots.push(root);
+  return join(root, "event-ledger.sqlite3");
+}
+
+function metricEntry(seq: number, type: string): LedgerEntry {
+  return { id: seq, seq, type, repoFullName: null, payload: {}, createdAt: "2026-07-04T12:00:00.000Z" };
 }
 
 afterEach(() => {
@@ -127,5 +139,110 @@ describe("gittensory-miner event ledger CLI (#2290)", () => {
       }),
     ).toBe(2);
     expect(error).toHaveBeenCalledWith("since must be a non-negative integer seq cursor.");
+  });
+});
+
+describe("gittensory-miner ledger metrics CLI (#4841)", () => {
+  it("renderEventLedgerMetrics emits one sorted gittensory_miner_events_total series per type", () => {
+    const text = renderEventLedgerMetrics([
+      metricEntry(1, "manage_pr_update"),
+      metricEntry(2, "discovered_issue"),
+      metricEntry(3, "manage_pr_update"),
+    ]);
+    expect(text).toContain(
+      "# HELP gittensory_miner_events_total Event-ledger entries the miner has recorded, by event type.",
+    );
+    expect(text).toContain("# TYPE gittensory_miner_events_total counter");
+    // Series are emitted in sorted type order, so "discovered_issue" precedes "manage_pr_update".
+    expect(text).toContain('gittensory_miner_events_total{type="discovered_issue"} 1');
+    expect(text).toContain('gittensory_miner_events_total{type="manage_pr_update"} 2');
+    expect(text.indexOf("discovered_issue")).toBeLessThan(text.indexOf("manage_pr_update"));
+    expect(text.endsWith("\n")).toBe(true);
+  });
+
+  it("renderEventLedgerMetrics still emits a well-formed document for an empty ledger", () => {
+    expect(renderEventLedgerMetrics([])).toBe(
+      "# HELP gittensory_miner_events_total Event-ledger entries the miner has recorded, by event type.\n" +
+        "# TYPE gittensory_miner_events_total counter\n",
+    );
+  });
+
+  it("renderEventLedgerMetrics escapes label-breaking characters in the event type", () => {
+    expect(renderEventLedgerMetrics([metricEntry(1, 'weird"type')])).toContain(
+      'gittensory_miner_events_total{type="weird\\"type"} 1',
+    );
+  });
+
+  it("runLedgerMetrics renders event counters as Prometheus text and returns 0", () => {
+    const eventLedger = tempLedger();
+    eventLedger.appendEvent({ type: "discovered_issue", repoFullName: "acme/widgets", payload: { issueNumber: 1 } });
+    eventLedger.appendEvent({ type: "manage_pr_update", repoFullName: "acme/widgets", payload: { prNumber: 2 } });
+    eventLedger.appendEvent({ type: "manage_pr_update", repoFullName: "acme/other", payload: { prNumber: 3 } });
+
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    expect(runLedgerMetrics([], { initEventLedger: () => eventLedger })).toBe(0);
+
+    const text = String(log.mock.calls[0]?.[0]);
+    expect(text).toContain("# TYPE gittensory_miner_events_total counter");
+    expect(text).toContain('gittensory_miner_events_total{type="discovered_issue"} 1');
+    expect(text).toContain('gittensory_miner_events_total{type="manage_pr_update"} 2');
+    // The output is a single, once-terminated document (no doubled trailing blank line).
+    expect(text.endsWith("\n")).toBe(false);
+  });
+
+  it("runLedgerMetrics opens and closes its own default ledger when none is injected", () => {
+    const dbPath = tempEventDbPath();
+    const seed = initEventLedger(dbPath);
+    seed.appendEvent({ type: "plan_built", payload: { steps: 1 } });
+    seed.close();
+
+    const prev = process.env.GITTENSORY_MINER_EVENT_LEDGER_DB;
+    process.env.GITTENSORY_MINER_EVENT_LEDGER_DB = dbPath;
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    try {
+      expect(runLedgerMetrics([])).toBe(0);
+    } finally {
+      if (prev === undefined) delete process.env.GITTENSORY_MINER_EVENT_LEDGER_DB;
+      else process.env.GITTENSORY_MINER_EVENT_LEDGER_DB = prev;
+    }
+    expect(String(log.mock.calls[0]?.[0])).toContain('gittensory_miner_events_total{type="plan_built"} 1');
+  });
+
+  it("runLedgerMetrics rejects unexpected arguments with a usage error", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    expect(runLedgerMetrics(["--json"], { initEventLedger: () => tempLedger() })).toBe(2);
+    expect(error).toHaveBeenCalledWith("Usage: gittensory-miner ledger metrics");
+  });
+
+  it("runLedgerMetrics surfaces a thrown Error message and exits non-zero", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    expect(
+      runLedgerMetrics([], {
+        initEventLedger: () => {
+          throw new Error("event ledger is locked");
+        },
+      }),
+    ).toBe(2);
+    expect(error).toHaveBeenCalledWith("event ledger is locked");
+  });
+
+  it("runLedgerMetrics stringifies a non-Error throw", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    expect(
+      runLedgerMetrics([], {
+        initEventLedger: () => {
+          throw "event-ledger-unavailable";
+        },
+      }),
+    ).toBe(2);
+    expect(error).toHaveBeenCalledWith("event-ledger-unavailable");
+  });
+
+  it("runLedgerCli dispatches the metrics subcommand", () => {
+    const eventLedger = tempLedger();
+    eventLedger.appendEvent({ type: "plan_built", payload: { steps: 1 } });
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    expect(runLedgerCli("metrics", [], { initEventLedger: () => eventLedger })).toBe(0);
+    expect(String(log.mock.calls[0]?.[0])).toContain('gittensory_miner_events_total{type="plan_built"} 1');
   });
 });


### PR DESCRIPTION
## Summary

The event ledger is a structured audit trail, but the only way to consume it is `gittensory-miner ledger list --json` — there is no scrape surface a self-hoster's own Grafana/Prometheus/alerting can ingest without polling that command and re-parsing its output (#4841).

This adds a `gittensory-miner ledger metrics` subcommand that renders the event ledger as Prometheus text-exposition counters:

```
# HELP gittensory_miner_events_total Event-ledger entries the miner has recorded, by event type.
# TYPE gittensory_miner_events_total counter
gittensory_miner_events_total{type="discovered_issue"} 12
gittensory_miner_events_total{type="manage_pr_update"} 3
```

One `gittensory_miner_events_total{type}` series per event type, so a new ledger entry is observable on the next scrape without polling `ledger list`. A scrape wrapper or cron job runs the command and serves/redirects its stdout.

The renderer mirrors the metric-naming and HELP/TYPE/label conventions of the engine's existing `renderMinerPredictionMetrics` (`packages/gittensory-engine/src/miner-prediction-metrics.ts`) — the same pattern the `metrics` command already uses for prediction-calibration counters. It is pure and side-effect-free (the caller supplies the rows and prints the result), deterministic (series sorted by type), and always emits HELP/TYPE so an empty ledger is still a well-formed document. Like `ledger list`, the command is strictly local and offline: it reads only the local event ledger and makes no network calls.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate. Every changed line and branch here is covered (verified via `coverage/lcov.info` BRDA intersected with `git diff -U0`).
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This is an isolated `packages/gittensory-miner/lib` change (the event-ledger CLI plus its `--help` line) with no worker, MCP, OpenAPI, or UI surface. The checks that actually exercise it were run locally and are green: `git diff --check`, `npm run actionlint`, `npm run typecheck`, `npm run test:coverage` (changed lines and branches at 100%), `npm run build:miner` (`node --check` over the miner lib), `npm run miner:env-reference:check` (confirms the change adds no new `env.*` read, so the env-reference doc is unchanged), and `npm audit --audit-level=moderate`. The `test:workers`, `build:mcp`, `test:mcp-pack`, and `ui:*` jobs do not touch this package and are covered by this PR's CI.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- No UI/API/MCP/OpenAPI surface changes — this is a CLI-only, offline addition, so the auth/CORS negative-path and UI-evidence boxes are not applicable.
- Tests cover every new line and branch: the renderer (sorted multi-type output, the empty ledger, label-value escaping), `runLedgerMetrics` (render + exit 0, its own default-ledger open/close path, the unexpected-argument usage error, and both the `Error` and non-`Error` catch arms), the `runLedgerCli metrics` dispatch, and the new `--help` line.

Closes #4841
