### PR TITLE
fix(miner): constrain discovery pagination URLs

### DIFF
--- a/packages/gittensory-miner/lib/opportunity-fanout.js
+++ b/packages/gittensory-miner/lib/opportunity-fanout.js
@@ -224,22 +224,38 @@ function searchQueryWithIssueQualifiers(searchQuery, forge) {
   return `${trimmed} ${forge.searchQualifiers}`;
 }
 
-// The URL of the next page from a GitHub Link header (`<url>; rel="next"`), or null when this is the last page.
-function nextPageUrl(response) {
+// The URL of the next page from a GitHub Link header (`<url>; rel="next"`), constrained to the current
+// token-bearing GitHub API endpoint so a forged Link header cannot redirect credentials off-origin.
+function nextPageUrl(response, apiBaseUrl, expectedPath) {
   const linkHeader = response.headers.get("link") ?? "";
   const match = linkHeader.match(/<([^>]+)>;\s*rel="next"/);
-  return match !== null ? match[1] : null;
+  if (match === null) return null;
+
+  let nextUrl;
+  let expectedUrl;
+  try {
+    expectedUrl = new URL(apiUrl(apiBaseUrl, expectedPath));
+    nextUrl = new URL(match[1], expectedUrl);
+  } catch {
+    return null;
+  }
+
+  if (
+    nextUrl.protocol !== "https:" ||
+    nextUrl.origin !== expectedUrl.origin ||
+    nextUrl.pathname !== expectedUrl.pathname
+  ) {
+    return null;
+  }
+  return nextUrl.toString();
 }
 
 async function fetchTargetIssues(target, githubToken, options, summary, warnings) {
   const verdict = await resolveRepoAiPolicy(target, githubToken, options, summary, warnings);
   if (!verdict.allowed) return [];
 
-  let url = apiUrl(
-    options.apiBaseUrl,
-    repoPath(options.forge, target, "/issues"),
-    `?state=open&per_page=${options.perPage}`,
-  );
+  const issuesPath = repoPath(options.forge, target, "/issues");
+  let url = apiUrl(options.apiBaseUrl, issuesPath, `?state=open&per_page=${options.perPage}`);
   const issues = [];
   try {
     for (let page = 0; url !== null && page < options.maxPages; page += 1) {
@@ -256,7 +272,7 @@ async function fetchTargetIssues(target, githubToken, options, summary, warnings
         const normalized = normalizeIssue(target, issue, verdict.source);
         if (normalized !== null) issues.push(normalized);
       }
-      url = nextPageUrl(response);
+      url = nextPageUrl(response, options.apiBaseUrl, issuesPath);
     }
     return issues;
   } catch (error) {
@@ -271,9 +287,10 @@ async function fetchSearchIssues(searchQuery, githubToken, options, summary, war
   const qualifiedQuery = searchQueryWithIssueQualifiers(searchQuery, options.forge);
   if (!qualifiedQuery) return [];
 
+  const searchPath = options.forge.searchEndpoint;
   let url = apiUrl(
     options.apiBaseUrl,
-    options.forge.searchEndpoint,
+    searchPath,
     `?q=${encodeURIComponent(qualifiedQuery)}&per_page=${options.perPage}`,
   );
   const items = [];
@@ -297,7 +314,7 @@ async function fetchSearchIssues(searchQuery, githubToken, options, summary, war
         return items;
       }
       items.push(...payload.items);
-      url = nextPageUrl(response);
+      url = nextPageUrl(response, options.apiBaseUrl, searchPath);
     }
     return items;
   } catch (error) {

--- a/test/unit/miner-opportunity-fanout-pagination.test.ts
+++ b/test/unit/miner-opportunity-fanout-pagination.test.ts
@@ -16,6 +16,15 @@ type DiscoverOptions = {
   apiBaseUrl?: string;
   perPage?: number;
   maxPages?: number;
+  forge?: Record<string, string>;
+};
+
+// A non-default forge (mirrors miner-opportunity-fanout-forge.test.ts's CUSTOM_FORGE): proves the pagination
+// validation is forge-AWARE, not hardcoded to github.com's default repo/search paths (#4784).
+const CUSTOM_FORGE = {
+  apiBaseUrl: "https://ghe.example.com/api/v3",
+  repoPathPrefix: "/repositories",
+  searchEndpoint: "/search/tickets",
 };
 
 // checkJs infers a structurally narrow options type for the fan-out .js module, so pass a typed, non-fresh
@@ -123,6 +132,27 @@ describe("discovery fanout Link-header pagination (#4831)", () => {
     expect(requestedUrls).not.toContain("https://attacker.invalid/collect");
   });
 
+  it("ignores a target-issues Link header whose URL fails to parse, without throwing", async () => {
+    let issuesFetches = 0;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/contents/")) return jsonResponse({}, { status: 404 });
+      if (url.includes("/issues?")) {
+        issuesFetches += 1;
+        // An unterminated IPv6 host literal is one of the few strings the WHATWG URL parser rejects even when
+        // resolved against a valid base (most relative references parse fine) -- exercises nextPageUrl's
+        // `catch { return null }` malformed-URL path, not just the origin/path-mismatch rejection.
+        return pagedResponse([issue(1)], "http://[::1");
+      }
+      throw new Error(`unexpected request: ${url}`);
+    });
+
+    const result = await fetchCandidateIssuesWithSummary(TARGET, "", discoverOptions());
+
+    expect(issuesFetches).toBe(1);
+    expect(result.issues.map((entry) => entry.issueNumber)).toEqual([1]);
+  });
+
   it("ignores target-issues Link headers that switch endpoint paths", async () => {
     const requestedUrls: string[] = [];
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
@@ -139,6 +169,48 @@ describe("discovery fanout Link-header pagination (#4831)", () => {
 
     expect(result.issues.map((entry) => entry.issueNumber)).toEqual([1]);
     expect(requestedUrls).not.toContain(`${API}/repos/acme/widgets/contents/AI-USAGE.md?page=2`);
+  });
+
+  it("follows a same-origin, same-custom-path Link header for a non-default forge (#4784)", async () => {
+    let issuesFetches = 0;
+    const nextUrl = `${CUSTOM_FORGE.apiBaseUrl}/repositories/acme/widgets/issues?state=open&per_page=100&page=2`;
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/contents/")) return jsonResponse({}, { status: 404 });
+      if (url.includes("/repositories/acme/widgets/issues?")) {
+        issuesFetches += 1;
+        if (pageParam(url) === 2) return jsonResponse([issue(2)]);
+        return pagedResponse([issue(1)], nextUrl);
+      }
+      throw new Error(`unexpected request: ${url}`);
+    });
+
+    const result = await fetchCandidateIssuesWithSummary(TARGET, "", discoverOptions({ apiBaseUrl: CUSTOM_FORGE.apiBaseUrl, forge: CUSTOM_FORGE }));
+
+    expect(issuesFetches).toBe(2);
+    expect(result.issues.map((entry) => entry.issueNumber)).toEqual([1, 2]);
+  });
+
+  it("ignores a Link header pointing at github.com's default repo path when the tenant is configured for a custom forge (#4784)", async () => {
+    const requestedUrls: string[] = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      requestedUrls.push(url);
+      if (url.includes("/contents/")) return jsonResponse({}, { status: 404 });
+      if (url.includes("/repositories/acme/widgets/issues?")) {
+        // A crafted (or misconfigured) Link header pointing at the DEFAULT github.com /repos path -- same
+        // origin scheme as the custom forge's own apiBaseUrl would be if it were github.com, but this
+        // tenant's forge is configured with repoPathPrefix "/repositories", so the /repos/... path must
+        // never match `expectedUrl.pathname` and must be rejected, not silently followed.
+        return pagedResponse([issue(1)], `${CUSTOM_FORGE.apiBaseUrl}/repos/acme/widgets/issues?page=2`);
+      }
+      throw new Error(`unexpected request: ${url}`);
+    });
+
+    const result = await fetchCandidateIssuesWithSummary(TARGET, "", discoverOptions({ apiBaseUrl: CUSTOM_FORGE.apiBaseUrl, forge: CUSTOM_FORGE }));
+
+    expect(result.issues.map((entry) => entry.issueNumber)).toEqual([1]);
+    expect(requestedUrls).not.toContain(`${CUSTOM_FORGE.apiBaseUrl}/repos/acme/widgets/issues?page=2`);
   });
 
   it("follows the search Link header across pages and returns every item", async () => {

--- a/test/unit/miner-opportunity-fanout-pagination.test.ts
+++ b/test/unit/miner-opportunity-fanout-pagination.test.ts
@@ -104,6 +104,43 @@ describe("discovery fanout Link-header pagination (#4831)", () => {
     expect(result.issues.map((entry) => entry.issueNumber)).toEqual([1, 2]);
   });
 
+  it("ignores target-issues Link headers that leave the configured API endpoint", async () => {
+    const requestedUrls: string[] = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      requestedUrls.push(url);
+      expect((init?.headers as Record<string, string> | undefined)?.authorization).toBe("Bearer github-token");
+      if (url.includes("/contents/")) return jsonResponse({}, { status: 404 });
+      if (url.includes("/issues?")) {
+        return pagedResponse([issue(1)], "https://attacker.invalid/collect");
+      }
+      throw new Error(`unexpected request: ${url}`);
+    });
+
+    const result = await fetchCandidateIssuesWithSummary(TARGET, "github-token", discoverOptions());
+
+    expect(result.issues.map((entry) => entry.issueNumber)).toEqual([1]);
+    expect(requestedUrls).not.toContain("https://attacker.invalid/collect");
+  });
+
+  it("ignores target-issues Link headers that switch endpoint paths", async () => {
+    const requestedUrls: string[] = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      requestedUrls.push(url);
+      if (url.includes("/contents/")) return jsonResponse({}, { status: 404 });
+      if (url.includes("/issues?")) {
+        return pagedResponse([issue(1)], `${API}/repos/acme/widgets/contents/AI-USAGE.md?page=2`);
+      }
+      throw new Error(`unexpected request: ${url}`);
+    });
+
+    const result = await fetchCandidateIssuesWithSummary(TARGET, "github-token", discoverOptions());
+
+    expect(result.issues.map((entry) => entry.issueNumber)).toEqual([1]);
+    expect(requestedUrls).not.toContain(`${API}/repos/acme/widgets/contents/AI-USAGE.md?page=2`);
+  });
+
   it("follows the search Link header across pages and returns every item", async () => {
     let searchFetches = 0;
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
@@ -141,6 +178,43 @@ describe("discovery fanout Link-header pagination (#4831)", () => {
 
     expect(searchFetches).toBe(2);
     expect(result.issues.map((entry) => entry.issueNumber)).toEqual([1, 2]);
+  });
+
+  it("ignores search Link headers that leave the configured API endpoint", async () => {
+    const requestedUrls: string[] = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      requestedUrls.push(url);
+      expect((init?.headers as Record<string, string> | undefined)?.authorization).toBe("Bearer github-token");
+      if (url.includes("/search/issues?")) {
+        return pagedResponse({ items: [searchItem(1)] }, "https://attacker.invalid/collect");
+      }
+      if (url.includes("/contents/")) return jsonResponse({}, { status: 404 });
+      throw new Error(`unexpected request: ${url}`);
+    });
+
+    const result = await searchCandidateIssuesWithSummary("x", "github-token", discoverOptions());
+
+    expect(result.issues.map((entry) => entry.issueNumber)).toEqual([1]);
+    expect(requestedUrls).not.toContain("https://attacker.invalid/collect");
+  });
+
+  it("ignores search Link headers that use a non-HTTPS URL", async () => {
+    const requestedUrls: string[] = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      requestedUrls.push(url);
+      if (url.includes("/search/issues?")) {
+        return pagedResponse({ items: [searchItem(1)] }, "http://api.test/search/issues?page=2");
+      }
+      if (url.includes("/contents/")) return jsonResponse({}, { status: 404 });
+      throw new Error(`unexpected request: ${url}`);
+    });
+
+    const result = await searchCandidateIssuesWithSummary("x", "github-token", discoverOptions());
+
+    expect(result.issues.map((entry) => entry.issueNumber)).toEqual([1]);
+    expect(requestedUrls).not.toContain("http://api.test/search/issues?page=2");
   });
 
   it("warns and returns what it has when a target-issues page is not an array", async () => {


### PR DESCRIPTION
### Motivation
- Pagination followed raw `Link: rel="next"` URLs and reused GitHub bearer headers unconditionally, allowing a malicious `Link` header to cause token-bearing requests off-origin.
- The change aims to prevent credential leakage while preserving same-origin GitHub pagination behavior.

### Description
- Validate `Link`-header next URLs in `packages/gittensory-miner/lib/opportunity-fanout.js` by parsing the candidate URL and ensuring it is `https`, shares the configured API origin, and matches the expected endpoint path before returning it from `nextPageUrl`.
- Thread the expected endpoint path into pagination calls for both issue and search pagination so `nextPageUrl` can enforce same-endpoint constraints.
- Added regression tests in `test/unit/miner-opportunity-fanout-pagination.test.ts` covering cross-origin, path-switching, and non-HTTPS `Link` headers to assert the code does not follow or request those URLs.

### Testing
- Ran `npx vitest run test/unit/miner-opportunity-fanout-pagination.test.ts` and all tests in that file passed (`14 tests`).
- Ran `npm run build:miner` and the miner package build checks passed locally.
- Attempted `npm run test:ci` but it did not complete because `cf-typegen:check` reported a pre-existing stale `worker-configuration.d.ts` and the full CI gate was therefore not fully green. 
- `npm audit --audit-level=moderate` could not complete due to the registry audit endpoint returning a `403` during the run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a541070ba74832c81916cb6a119aadc)