### PR TITLE
docs(miner): expand README local storage table (#4876)

### DIFF
--- a/packages/gittensory-miner/README.md
+++ b/packages/gittensory-miner/README.md
@@ -83,16 +83,26 @@ Phase 6 of the same roadmap tracker and hasn't been scaffolded yet. (#4279)
 
 ## Local storage
 
-Four independent local SQLite stores back the commands above. Each keeps its own file, its own table, and its own
-env-var override — this is a DRY pass over their shared path-resolution/open boilerplate (`local-store.js`), not a
-merge into one database. (#4272)
+Independent local SQLite stores back the commands above. Each keeps its own file, its own table(s), and (for most stores) its own env-var override — this is a DRY pass over their shared path-resolution/open boilerplate (`local-store.js`), not a merge into one database. (#4272)
 
-| Store | File | Table | Module | Env var override |
+See [`docs/env-reference.md`](docs/env-reference.md) for the full `GITTENSORY_MINER_*` / `MINER_*` env-var list.
+
+| Store | File | Primary table(s) | Module | Env var override |
 | --- | --- | --- | --- | --- |
+| Laptop bootstrap | `laptop-state.sqlite3` | `laptop_meta` | `laptop-init.js` | `GITTENSORY_MINER_CONFIG_DIR` (path only) |
 | Run state | `run-state.sqlite3` | `miner_run_state` | `run-state.js` | `GITTENSORY_MINER_RUN_STATE_DB` |
 | Claim ledger | `claim-ledger.sqlite3` | `miner_claims` | `claim-ledger.js` | `GITTENSORY_MINER_CLAIM_LEDGER_DB` |
 | Portfolio queue | `portfolio-queue.sqlite3` | `miner_portfolio_queue` | `portfolio-queue.js` | `GITTENSORY_MINER_PORTFOLIO_QUEUE_DB` |
 | Event ledger | `event-ledger.sqlite3` | `miner_event_ledger` | `event-ledger.js` | `GITTENSORY_MINER_EVENT_LEDGER_DB` |
+| Plan store | `plan-store.sqlite3` | `miner_plans` | `plan-store.js` | `GITTENSORY_MINER_PLAN_STORE_DB` |
+| Governor ledger | `governor-ledger.sqlite3` | `governor_events` | `governor-ledger.js` | `GITTENSORY_MINER_GOVERNOR_LEDGER_DB` |
+| Governor state | `governor-state.sqlite3` | `governor_scalar_state`, `governor_reputation_history`, `governor_own_submissions` | `governor-state.js` | `GITTENSORY_MINER_GOVERNOR_STATE_DB` |
+| Attempt log | `attempt-log.sqlite3` | `attempt_log_events` | `attempt-log.js` | `GITTENSORY_MINER_ATTEMPT_LOG_DB` |
+| Prediction ledger | `prediction-ledger.sqlite3` | `predictions` | `prediction-ledger.js` | `GITTENSORY_MINER_PREDICTION_LEDGER_DB` |
+| Replay snapshot | `replay-snapshot.sqlite3` | `replay_snapshots` | `replay-snapshot.js` | `GITTENSORY_MINER_REPLAY_SNAPSHOT_DB` |
+| Deny-hook synthesis | `deny-hook-synthesis.sqlite3` | `deny_rule_proposals` | `deny-hook-synthesis.js` | `GITTENSORY_MINER_DENY_HOOK_SYNTHESIS_DB` |
+| Worktree allocator | `worktree-allocator.sqlite3` | `worktree_slots` | `worktree-allocator.js` | `GITTENSORY_MINER_WORKTREE_ALLOCATOR_DB` |
+| Orb export | `orb-export.sqlite3` | `orb_export_meta` | `orb-export.js` | `GITTENSORY_MINER_ORB_EXPORT_DB` |
 
 Every store resolves its file the same way: the store-specific env var above, else `GITTENSORY_MINER_CONFIG_DIR`,
 else `XDG_CONFIG_HOME` (falling back to `~/.config`), joined with `gittensory-miner/<file>`. Every store also opens

--- a/test/unit/miner-local-store-readme.test.ts
+++ b/test/unit/miner-local-store-readme.test.ts
@@ -4,22 +4,28 @@ import { describe, expect, it } from "vitest";
 
 const readmePath = join(process.cwd(), "packages/gittensory-miner/README.md");
 
-describe("gittensory-miner local storage README (#4272)", () => {
-  it("documents all four local stores together with their file/table/module/env-var", () => {
+describe("gittensory-miner local storage README (#4272, #4876)", () => {
+  it("documents every local SQLite store with file/table/module/env-var", () => {
     const readme = readFileSync(readmePath, "utf8");
     expect(readme).toContain("## Local storage");
-    expect(readme).toContain("run-state.sqlite3");
-    expect(readme).toContain("miner_run_state");
-    expect(readme).toContain("claim-ledger.sqlite3");
-    expect(readme).toContain("miner_claims");
-    expect(readme).toContain("portfolio-queue.sqlite3");
-    expect(readme).toContain("miner_portfolio_queue");
-    expect(readme).toContain("event-ledger.sqlite3");
-    expect(readme).toContain("miner_event_ledger");
-    expect(readme).toContain("GITTENSORY_MINER_RUN_STATE_DB");
-    expect(readme).toContain("GITTENSORY_MINER_CLAIM_LEDGER_DB");
-    expect(readme).toContain("GITTENSORY_MINER_PORTFOLIO_QUEUE_DB");
-    expect(readme).toContain("GITTENSORY_MINER_EVENT_LEDGER_DB");
+    for (const row of [
+      ["laptop-state.sqlite3", "laptop_meta", "laptop-init.js"],
+      ["run-state.sqlite3", "miner_run_state", "run-state.js", "GITTENSORY_MINER_RUN_STATE_DB"],
+      ["claim-ledger.sqlite3", "miner_claims", "claim-ledger.js", "GITTENSORY_MINER_CLAIM_LEDGER_DB"],
+      ["portfolio-queue.sqlite3", "miner_portfolio_queue", "portfolio-queue.js", "GITTENSORY_MINER_PORTFOLIO_QUEUE_DB"],
+      ["event-ledger.sqlite3", "miner_event_ledger", "event-ledger.js", "GITTENSORY_MINER_EVENT_LEDGER_DB"],
+      ["plan-store.sqlite3", "miner_plans", "plan-store.js", "GITTENSORY_MINER_PLAN_STORE_DB"],
+      ["governor-ledger.sqlite3", "governor_events", "governor-ledger.js", "GITTENSORY_MINER_GOVERNOR_LEDGER_DB"],
+      ["governor-state.sqlite3", "governor_scalar_state", "governor-state.js", "GITTENSORY_MINER_GOVERNOR_STATE_DB"],
+      ["attempt-log.sqlite3", "attempt_log_events", "attempt-log.js", "GITTENSORY_MINER_ATTEMPT_LOG_DB"],
+      ["prediction-ledger.sqlite3", "predictions", "prediction-ledger.js", "GITTENSORY_MINER_PREDICTION_LEDGER_DB"],
+      ["replay-snapshot.sqlite3", "replay_snapshots", "replay-snapshot.js", "GITTENSORY_MINER_REPLAY_SNAPSHOT_DB"],
+      ["deny-hook-synthesis.sqlite3", "deny_rule_proposals", "deny-hook-synthesis.js", "GITTENSORY_MINER_DENY_HOOK_SYNTHESIS_DB"],
+      ["worktree-allocator.sqlite3", "worktree_slots", "worktree-allocator.js", "GITTENSORY_MINER_WORKTREE_ALLOCATOR_DB"],
+      ["orb-export.sqlite3", "orb_export_meta", "orb-export.js", "GITTENSORY_MINER_ORB_EXPORT_DB"],
+    ]) {
+      for (const token of row) expect(readme).toContain(token);
+    }
   });
 
   it("documents the PR-portfolio read-time-join decision", () => {


### PR DESCRIPTION
## Summary

- Expand the README **Local storage** table from 4 stores to all 14 SQLite files the miner package creates
- Cross-link `docs/env-reference.md` for env-var overrides
- Extend `miner-local-store-readme.test.ts` to drift-check the full inventory

Closes #4876

## Test plan

- [x] `npx vitest run test/unit/miner-local-store-readme.test.ts`
