### PR TITLE
fix(rees): require auth for /metrics and guard server startup

### DIFF
--- a/review-enrichment/src/server.ts
+++ b/review-enrichment/src/server.ts
@@ -8,6 +8,7 @@
 // Transport + contract here; the analysis lives in brief.ts (orchestrator) + analyzers/*, with each analyzer
 // filling one findings key for renderer/prompt consumption.
 import { serve } from "@hono/node-server";
+import { pathToFileURL } from "node:url";
 import { Hono } from "hono";
 import { normalizeSharedSecret, verifyBearer } from "./auth.js";
 import { buildBrief } from "./brief.js";
@@ -46,7 +47,13 @@ app.get("/health", (c) =>
   c.json({ status: "ok", service: "review-enrichment" }),
 );
 app.get("/ready", (c) => c.json({ ready: true }));
-app.get("/metrics", (c) => c.text(renderMetrics()));
+app.get("/metrics", (c) => {
+  const secret = normalizeSharedSecret(process.env.REES_SHARED_SECRET);
+  if (!secret) return c.json({ error: "service_not_configured" }, 503);
+  if (!verifyBearer(c.req.header("authorization"), secret))
+    return c.json({ error: "unauthorized" }, 401);
+  return c.text(renderMetrics());
+});
 
 function recordEnrichOutcome(status: string, startedAtMs: number): void {
   incr("rees_enrich_requests_total", { status });
@@ -108,22 +115,24 @@ app.post("/v1/enrich", async (c) => {
   }
 });
 
-const port = Number(process.env.PORT ?? "8080");
-serve({ fetch: app.fetch, port }, (info) => {
-  console.log(JSON.stringify({ event: "rees_listening", port: info.port }));
-});
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  const port = Number(process.env.PORT ?? "8080");
+  serve({ fetch: app.fetch, port }, (info) => {
+    console.log(JSON.stringify({ event: "rees_listening", port: info.port }));
+  });
 
-process.on("unhandledRejection", (reason) => {
-  captureUnhandledError(reason, { event: "rees_unhandled_rejection" });
-});
+  process.on("unhandledRejection", (reason) => {
+    captureUnhandledError(reason, { event: "rees_unhandled_rejection" });
+  });
 
-process.on("uncaughtException", (error) => {
-  captureUnhandledError(error, { event: "rees_uncaught_exception" });
-  void flushSentry().finally(() => process.exit(1));
-});
+  process.on("uncaughtException", (error) => {
+    captureUnhandledError(error, { event: "rees_uncaught_exception" });
+    void flushSentry().finally(() => process.exit(1));
+  });
 
-process.on("SIGTERM", () => {
-  void flushSentry().finally(() => process.exit(0));
-});
+  process.on("SIGTERM", () => {
+    void flushSentry().finally(() => process.exit(0));
+  });
+}
 
 export { app };

--- a/review-enrichment/test/server-metrics-auth.test.ts
+++ b/review-enrichment/test/server-metrics-auth.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { after, test } from "node:test";
+
+process.env.REES_SHARED_SECRET = "topsecret";
+
+const { incr } = await import("../dist/metrics.js");
+const { app } = await import("../dist/server.js");
+
+after(() => {
+  delete process.env.REES_SHARED_SECRET;
+});
+
+test("/metrics rejects unauthenticated scrapes when the shared secret is configured", async () => {
+  const response = await app.request("/metrics");
+
+  assert.equal(response.status, 401);
+  assert.deepEqual(await response.json(), { error: "unauthorized" });
+});
+
+test("/metrics returns Prometheus text to callers with the shared bearer secret", async () => {
+  incr("rees_enrich_requests_total", { status: "ok" });
+
+  const response = await app.request("/metrics", {
+    headers: { authorization: "Bearer topsecret" },
+  });
+
+  assert.equal(response.status, 200);
+  assert.match(response.headers.get("content-type") ?? "", /^text\/plain/);
+  assert.match(await response.text(), /# HELP rees_enrich_requests_total/);
+});


### PR DESCRIPTION
### Motivation
- The REES `/metrics` endpoint was exposed without authentication and could be scraped remotely, revealing aggregate telemetry and analyzer health; the service needs to enforce the same shared-bearer auth used by its private API.
- Tests and imports should be able to import the Hono `app` without starting a network listener so route-level tests can run in-process.

### Description
- The `/metrics` route now checks `normalizeSharedSecret(process.env.REES_SHARED_SECRET)` and calls `verifyBearer(...)` before returning Prometheus text via `renderMetrics()` so unauthenticated scrapes are rejected.
- Server startup side effects (calling `serve()` and installing process signal handlers) are wrapped behind a direct-execution guard using `if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href)` so test imports do not open a listener.
- Added a regression test `review-enrichment/test/server-metrics-auth.test.ts` that asserts unauthenticated scrapes receive `401` and authenticated scrapes receive metrics, and adjusted imports (`pathToFileURL`) needed for the startup guard.

### Testing
- Ran `git diff --check` which produced no trailing-whitespace or conflict-marker errors and succeeded.
- Ran the REES test suite via `npm run rees:test` which completed with all tests passing.
- Ran the new route tests directly with `node --test --experimental-strip-types test/server-metrics-auth.test.ts` and they passed locally.
- Attempted `npm audit --audit-level=moderate` but the registry audit endpoint returned `403` in this environment, so the audit could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53eb1cc258832cae39aa507a96859b)