### PR TITLE
fix(miner): close_pr runs unconditionally before its best-effort comment

### DIFF
--- a/packages/gittensory-engine/src/miner/local-write-tools.ts
+++ b/packages/gittensory-engine/src/miner/local-write-tools.ts
@@ -45,13 +45,15 @@ export function buildOpenPrSpec(input: { repoFullName: string; base: string; hea
 }
 
 /** Close a pull request the miner itself opened (e.g. it lost a claim-conflict adjudication to an earlier
- *  claimant, #4848) -- never used against a PR the miner does not own. `comment`, when supplied, is posted
- *  before the close via a separate `gh pr comment` so the reason survives on the PR even though `gh pr close`
- *  itself has no comment-body flag. */
+ *  claimant, #4848) -- never used against a PR the miner does not own. The close runs FIRST and
+ *  unconditionally -- it's the safety-critical action (never leave a known-losing PR open); `comment`, when
+ *  supplied, is a best-effort follow-up posted only once the close itself succeeds (`gh pr close` has no
+ *  comment-body flag of its own, and a transient `gh pr comment` failure must never mask or block the close
+ *  it's explaining). */
 export function buildClosePrSpec(input: { repoFullName: string; number: number; comment?: string | undefined }): LocalWriteActionSpec {
   const closeCommand = `gh pr close ${input.number} --repo ${sq(input.repoFullName)}`;
   const command = input.comment
-    ? `gh pr comment ${input.number} --repo ${sq(input.repoFullName)} --body ${sq(input.comment)} && ${closeCommand}`
+    ? `${closeCommand} && gh pr comment ${input.number} --repo ${sq(input.repoFullName)} --body ${sq(input.comment)}`
     : closeCommand;
   return spec(
     "close_pr",

--- a/packages/gittensory-miner/lib/claim-conflict-resolver.js
+++ b/packages/gittensory-miner/lib/claim-conflict-resolver.js
@@ -29,6 +29,10 @@ import { buildClosePrSpec } from "@jsonbored/gittensory-engine";
  * Assemble the real competing-claims set from a fetched LiveIssueSnapshot: every OTHER open PR referencing
  * the issue, excluding `selfPrNumber` and any PR authored by `minerLogin` itself (case-insensitive, mirrors
  * checkSubmissionFreshness's own author comparison -- a login can be echoed back with different casing).
+ * Excluding same-author PRs is deliberate, not an edge case slipping through: a miner never competes against
+ * its own work, so if this login somehow has ANOTHER open PR on the same issue (e.g. a retry after a crash
+ * left a stale one behind), that PR is never treated as a competing claim to lose against -- only a genuinely
+ * different claimant's PR can trigger a real close.
  * Pure given its inputs.
  *
  * @param {import("./submission-freshness-check.js").LiveIssueSnapshot | null | undefined} snapshot

--- a/test/unit/local-write-tools.test.ts
+++ b/test/unit/local-write-tools.test.ts
@@ -37,10 +37,10 @@ describe("local write-tool specs (#780)", () => {
     expect(s.command.endsWith("--draft")).toBe(true);
   });
 
-  it("close_pr closes with a preceding comment when one is supplied", () => {
+  it("close_pr closes FIRST (unconditionally), then best-effort comments when one is supplied", () => {
     const s = buildClosePrSpec({ repoFullName: "o/r", number: 7, comment: "Closing: lost the claim to #5" });
     expect(s.action).toBe("close_pr");
-    expect(s.command).toBe("gh pr comment 7 --repo 'o/r' --body 'Closing: lost the claim to #5' && gh pr close 7 --repo 'o/r'");
+    expect(s.command).toBe("gh pr close 7 --repo 'o/r' && gh pr comment 7 --repo 'o/r' --body 'Closing: lost the claim to #5'");
     expect(s.boundary).toBe(LOCAL_WRITE_BOUNDARY);
     expect(s.inputs).toEqual({ repoFullName: "o/r", number: 7, comment: "Closing: lost the claim to #5" });
   });


### PR DESCRIPTION
## Summary
Follow-up to #4848/#5480, addressing a real nit gittensory's own review caught after that PR was already merged.

`buildClosePrSpec` (`packages/gittensory-engine/src/miner/local-write-tools.ts`) chained `gh pr comment && gh pr close` -- if `gh pr comment` failed (e.g. a transient network blip), the `&&` meant `gh pr close` never ran, silently leaving a known-losing PR open. That's the exact outcome claim-conflict resolution exists to prevent.

The close now runs first and unconditionally; the explanatory comment is a best-effort follow-up that only runs once the close itself succeeds, and can never block or mask it.

Also documents (in `claim-conflict-resolver.js`) why `assembleCompetingClaims` deliberately excludes same-author PRs -- a miner never competes against its own retry attempts, per the same reviewer nit.

## Test plan
- [x] `tsc --noEmit --incremental false` clean
- [x] `npx vitest run test/unit test/contract` -- 774/775 passing (1 pre-existing unrelated skip)
- [x] Per-file patch coverage verified: 100% on every changed line in `local-write-tools.ts` and `claim-conflict-resolver.js`
- [x] `npm run docs:drift-check` / `manifest:drift-check` / `engine-parity:drift-check` all clean
- [x] `npm audit --audit-level=moderate` -- 0 vulnerabilities
- [x] `git diff --check` clean