### PR TITLE
fix(miner-extension): clear stale discovery index URL from chrome.storage.sync

### DIFF
--- a/apps/gittensory-miner-extension/options.js
+++ b/apps/gittensory-miner-extension/options.js
@@ -15,10 +15,15 @@ function parseRankedCandidatesJson(text) {
   return parsed;
 }
 
+async function removeLegacyDiscoveryIndexUrl() {
+  await chrome.storage.sync.remove("discoveryIndexUrl");
+}
+
 if (globalThis.__GITTENSORY_MINER_EXTENSION_TEST__) {
   globalThis.__gittensoryMinerOptionsInternals = {
     parseWatchedRepos,
     parseRankedCandidatesJson,
+    removeLegacyDiscoveryIndexUrl,
   };
 }
 
@@ -38,6 +43,7 @@ form.addEventListener("submit", async (event) => {
     const repos = parseWatchedRepos(watchedRepos.value);
     const rankedCandidates = parseRankedCandidatesJson(rankedCandidatesJson.value);
     await chrome.storage.sync.set({ watchedRepos: repos });
+    await removeLegacyDiscoveryIndexUrl();
     await chrome.storage.local.set({ rankedCandidates });
     await refreshSettings();
     showStatus(
@@ -53,6 +59,7 @@ form.addEventListener("submit", async (event) => {
 
 async function refreshSettings() {
   const stored = await chrome.storage.sync.get({ watchedRepos: [] });
+  await removeLegacyDiscoveryIndexUrl();
   const local = await chrome.storage.local.get({ rankedCandidates: [] });
   const repos = Array.isArray(stored.watchedRepos) ? stored.watchedRepos : [];
   watchedRepos.value = repos.join("\n");

--- a/test/unit/miner-extension-content.test.ts
+++ b/test/unit/miner-extension-content.test.ts
@@ -148,15 +148,18 @@ describe("miner extension opportunity badge", () => {
     expect(() => internals.parseRankedCandidatesJson('{"not":"array"}')).toThrow();
   });
 
-  it("REGRESSION (dead-field removal): no discoveryIndexUrl config field remains anywhere in the extension", () => {
+  it("REGRESSION (dead-field removal): no discoveryIndexUrl config field remains in UI or background reads", () => {
     expect(optionsHtml).not.toMatch(/discoveryIndexUrl/);
-    expect(optionsScript).not.toMatch(/discoveryIndexUrl/);
     expect(backgroundScript).not.toMatch(/discoveryIndexUrl/);
   });
 
-  it("saves and restores settings without ever writing or reading discoveryIndexUrl", async () => {
-    const synced: Record<string, unknown> = { watchedRepos: [] };
+  it("removes stale discoveryIndexUrl values from synced options storage", async () => {
+    const synced: Record<string, unknown> = {
+      watchedRepos: [],
+      discoveryIndexUrl: "https://private.example.test/index.json",
+    };
     const setCalls: Array<Record<string, unknown>> = [];
+    const removeCalls: string[] = [];
     const elements = {
       "#settings": createFormMock(),
       "#status": { textContent: "" },
@@ -174,6 +177,10 @@ describe("miner extension opportunity badge", () => {
               setCalls.push(value);
               Object.assign(synced, value);
             },
+            remove: async (key: string) => {
+              removeCalls.push(key);
+              delete synced[key];
+            },
           },
           local: { get: async () => ({ rankedCandidates: [] }), set: async () => {} },
         },
@@ -184,11 +191,17 @@ describe("miner extension opportunity badge", () => {
     const vmContext = createContext(context);
     new Script(optionsScript).runInContext(vmContext);
 
+    await flushPromises();
+    expect(removeCalls).toEqual(["discoveryIndexUrl"]);
+    expect("discoveryIndexUrl" in synced).toBe(false);
+
+    synced.discoveryIndexUrl = "https://private.example.test/index.json";
     elements["#watchedRepos"].value = "JSONbored/gittensory";
     await elements["#settings"].dispatchSubmit();
 
     expect(setCalls).toHaveLength(1);
     expect(setCalls[0]).toEqual({ watchedRepos: ["JSONbored/gittensory"] });
+    expect(removeCalls).toEqual(["discoveryIndexUrl", "discoveryIndexUrl", "discoveryIndexUrl"]);
     expect("discoveryIndexUrl" in synced).toBe(false);
   });
 });
@@ -203,6 +216,10 @@ function createFormMock() {
       await submitHandler?.({ preventDefault: () => {} });
     },
   };
+}
+
+function flushPromises() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
 }
 
 function createMockContainer() {


### PR DESCRIPTION
### Motivation
- Removing the `discoveryIndexUrl` UI left previously-synced values orphaned in `chrome.storage.sync`, creating a privacy/data-retention issue because omitted keys are not deleted by `storage.set`.

### Description
- Add a helper `removeLegacyDiscoveryIndexUrl()` to `apps/gittensory-miner-extension/options.js` that calls `chrome.storage.sync.remove("discoveryIndexUrl")`.
- Invoke the removal during settings refresh and immediately after saving `watchedRepos`, so any stale `discoveryIndexUrl` is cleared on load and on save without reintroducing the UI field.
- Update `test/unit/miner-extension-content.test.ts` to seed a stale `discoveryIndexUrl`, assert it is removed on load, re-seed it, and assert it is removed again on save, and add a small `flushPromises()` helper for async timing.

### Testing
- Ran the unit test file with `npx vitest run test/unit/miner-extension-content.test.ts`, and all tests in that file passed.
- Built the miner package with `npm run build:miner`, which succeeded.
- Attempted the full local gate `npm run test:ci`, but the run surfaced unrelated repo/environment issues (`cf-typegen` drift and an `npm audit` registry error) that prevented a clean full-gate verification in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53a9c45700832cb8691e15fc924692)