### PR TITLE
fix(miner): tighten package bin allowlist

### DIFF
--- a/scripts/check-miner-package.mjs
+++ b/scripts/check-miner-package.mjs
@@ -5,7 +5,8 @@ import { spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
 const ALLOWED = [
-  /^bin\/gittensory-miner(-[a-z0-9-]+)?\.(js|d\.ts)$/,
+  /^bin\/gittensory-miner\.js$/,
+  /^bin\/gittensory-miner-mcp\.(js|d\.ts)$/,
   /^lib\/[a-z0-9-]+\.(js|d\.ts)$/,
   /^package\.json$/,
   /^README\.md$/,

--- a/test/unit/check-miner-package.test.ts
+++ b/test/unit/check-miner-package.test.ts
@@ -35,6 +35,20 @@ describe("check-miner-package script", () => {
     expect(result.out).toContain("Unexpected file in miner package: scripts/extra.mjs");
   });
 
+  it("rejects an unexpected miner bin that matches the package name prefix", () => {
+    const result = runChecker({
+      CHECK_MINER_PACK_TEST_FILES: JSON.stringify([
+        "package.json",
+        "bin/gittensory-miner.js",
+        "bin/gittensory-miner-backdoor.js",
+        "lib/cli.js",
+      ]),
+      CHECK_MINER_PACK_TEST_CONTENT: "console.log('not secret');",
+    });
+    expect(result.status).toBe(1);
+    expect(result.out).toContain("Unexpected file in miner package: bin/gittensory-miner-backdoor.js");
+  });
+
   it("REGRESSION (#3704 caused main to go red, fixed by flattening lib/ instead of widening this allowlist): rejects a lib module nested one level under a subdirectory", () => {
     const result = runChecker({
       CHECK_MINER_PACK_TEST_FILES: JSON.stringify([


### PR DESCRIPTION
### Motivation
- The prior allowlist accepted any `bin/gittensory-miner-*` file which could let unexpected or malicious bin scripts (e.g. `bin/gittensory-miner-backdoor.js`) pass the packaging guard; the change restores a strict allowlist of the exact intended CLI artifacts.

### Description
- Replace the wildcard `bin/gittensory-miner(-...)?` pattern with exact allowed entries `bin/gittensory-miner.js` and `bin/gittensory-miner-mcp.(js|d.ts)` in `scripts/check-miner-package.mjs` so only the known bin artifacts are accepted.
- Keep the existing `lib/*`, `package.json`, `README.md`, and `expected-engine.version` allow rules and the forbidden-path/content checks unchanged.
- Add a regression unit test in `test/unit/check-miner-package.test.ts` that asserts an unexpected prefixed bin (`bin/gittensory-miner-backdoor.js`) is rejected even when its content is non-secret.

### Testing
- Ran `npx vitest run test/unit/check-miner-package.test.ts` and the updated unit suite passed locally (9 tests all green).
- Ran `npm run -s test:miner-pack` and it passed for the real package; a manual invocation with `CHECK_MINER_PACK_TEST_FILES` that included `bin/gittensory-miner-backdoor.js` produced `Unexpected file in miner package: bin/gittensory-miner-backdoor.js` as expected.
- Ran `git diff --check` which reported no issues.
- Attempted `npm run test:ci`, but the run stopped on `cf-typegen:check` complaining `worker-configuration.d.ts` is stale (unrelated to this change); `npm audit --audit-level=moderate` also failed due to the registry audit endpoint returning HTTP 403.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a53ace04308832cbeacd135908e1e91)