### PR TITLE
fix(observability): keep GitHub datasource credentials out of curl argv and child env

### DIFF
--- a/scripts/setup-github-datasource.sh
+++ b/scripts/setup-github-datasource.sh
@@ -20,10 +20,22 @@
 set -euo pipefail
 
 GRAFANA_URL="${GRAFANA_URL:-http://localhost:3000}"
-[ -f .env ] && { set -a; . ./.env; set +a; }
+[ -f .env ] && . ./.env
 : "${GITHUB_TOKEN:?Set GITHUB_TOKEN (a read-only fine-grained PAT) in the environment or .env}"
 : "${GRAFANA_ADMIN_PASSWORD:?Set GRAFANA_ADMIN_PASSWORD in the environment or .env}"
-AUTH="admin:${GRAFANA_ADMIN_PASSWORD}"
+
+TMP_DIR="$(mktemp -d)"
+NETRC_FILE="$TMP_DIR/netrc"
+trap 'rm -rf "$TMP_DIR"' EXIT
+GRAFANA_HOSTPORT="${GRAFANA_URL#*://}"
+GRAFANA_HOSTPORT="${GRAFANA_HOSTPORT%%/*}"
+GRAFANA_HOST="${GRAFANA_HOSTPORT%%:*}"
+printf 'machine %s login %s password %s\n' "$GRAFANA_HOST" admin "$GRAFANA_ADMIN_PASSWORD" >"$NETRC_FILE"
+chmod 600 "$NETRC_FILE"
+
+grafana_curl() {
+  env -u GRAFANA_ADMIN_PASSWORD -u GITHUB_TOKEN curl -sf --netrc-file "$NETRC_FILE" "$@"
+}
 
 payload() {
   cat <<JSON
@@ -34,16 +46,16 @@ JSON
 }
 
 # Idempotent: update in place if a datasource with uid "github" already exists, else create it.
-if curl -sf -u "$AUTH" "$GRAFANA_URL/api/datasources/uid/github" >/dev/null 2>&1; then
+if grafana_curl "$GRAFANA_URL/api/datasources/uid/github" >/dev/null 2>&1; then
   echo "Updating existing GitHub data source…"
-  curl -sf -u "$AUTH" -H 'content-type: application/json' -X PUT \
-    "$GRAFANA_URL/api/datasources/uid/github" -d "$(payload)" >/dev/null
+  payload | grafana_curl -H 'content-type: application/json' -X PUT \
+    "$GRAFANA_URL/api/datasources/uid/github" --data-binary @- >/dev/null
 else
   echo "Creating GitHub data source…"
-  curl -sf -u "$AUTH" -H 'content-type: application/json' -X POST \
-    "$GRAFANA_URL/api/datasources" -d "$(payload)" >/dev/null
+  payload | grafana_curl -H 'content-type: application/json' -X POST \
+    "$GRAFANA_URL/api/datasources" --data-binary @- >/dev/null
 fi
 
 echo "Done. Verifying health…"
-curl -sf -u "$AUTH" -X POST "$GRAFANA_URL/api/datasources/uid/github/health" 2>/dev/null \
+grafana_curl -X POST "$GRAFANA_URL/api/datasources/uid/github/health" 2>/dev/null \
   | grep -q '"status":"OK"' && echo "✓ GitHub data source healthy" || echo "⚠ Added, but health check did not return OK — verify the token scopes."

--- a/test/unit/selfhost-grafana-github-datasource.test.ts
+++ b/test/unit/selfhost-grafana-github-datasource.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe("Grafana GitHub data source", () => {
+  it("keeps GITHUB_TOKEN and GRAFANA_ADMIN_PASSWORD out of curl argv and child environments", () => {
+    const script = readFileSync(join(process.cwd(), "scripts/setup-github-datasource.sh"), "utf8");
+
+    expect(script).not.toContain("set -a");
+    expect(script).not.toContain('AUTH="admin:${GRAFANA_ADMIN_PASSWORD}"');
+    expect(script).not.toContain('-u "$AUTH"');
+    expect(script).not.toContain('-d "$(payload)"');
+    expect(script).toContain('--netrc-file "$NETRC_FILE"');
+    expect(script).toContain("--data-binary @-");
+    expect(script).toMatch(/env -u GRAFANA_ADMIN_PASSWORD -u GITHUB_TOKEN curl/);
+  });
+
+  it("is executable, matching setup-sentry-datasource.sh's own mode", () => {
+    const mode = statSync(join(process.cwd(), "scripts/setup-github-datasource.sh")).mode;
+    // Owner-execute bit (0o100).
+    expect(mode & 0o100).not.toBe(0);
+  });
+
+  it("remains idempotent (update-vs-create) and preserves the health check after the credential-handling rewrite", () => {
+    const script = readFileSync(join(process.cwd(), "scripts/setup-github-datasource.sh"), "utf8");
+
+    expect(script).toContain("api/datasources/uid/github");
+    expect(script).toMatch(/-X PUT/);
+    expect(script).toMatch(/-X POST/);
+    expect(script).toContain("secureJsonData");
+    expect(script).toContain("accessToken");
+    expect(script).toContain("/health");
+  });
+});


### PR DESCRIPTION
## Summary

- `scripts/setup-github-datasource.sh` had the identical secret-leak pattern that PR #5489 fixed in its sibling `scripts/setup-sentry-datasource.sh`: sourcing `.env` with `set -a` exported `GITHUB_TOKEN`/`GRAFANA_ADMIN_PASSWORD` into every child process's environment, `curl -u "$AUTH"` put `GRAFANA_ADMIN_PASSWORD` on the process argv (visible to any local user via `ps aux`), and `-d "$(payload)"` put the GitHub token in argv too.
- Applied the identical fix #5489 shipped: drop `set -a` on the `.env` source (plain `. ./.env`), authenticate via a temporary permissioned `netrc` file with `--netrc-file` instead of `-u "$AUTH"`, pipe the JSON payload to curl over stdin via `--data-binary @-` instead of `-d "$(payload)"`, and wrap curl in a `grafana_curl()` helper that additionally does `env -u GRAFANA_ADMIN_PASSWORD -u GITHUB_TOKEN` as defense in depth.
- Idempotent update-vs-create behavior and the health check are unchanged.
- No dedicated test file existed for `setup-github-datasource.sh` before this PR (only two incidental cross-references from the Sentry script's own test file). Added `test/unit/selfhost-grafana-github-datasource.test.ts` with a regression test mirroring the one #5489 added for the Sentry script, plus an executable-mode check and a behavior-preservation check (idempotent PUT/POST, `secureJsonData`/`accessToken`, health check all still present).

## Scope

- [x] In scope (`scripts/`, `test/`), narrow, single coherent change
- [x] No secrets, tokens, or private terms added anywhere
- [x] Mirrors an existing, already-open sibling PR's (#5489) exact pattern — no new design decisions

## Validation

- [x] `bash -n scripts/setup-github-datasource.sh` — clean syntax
- [x] `npx vitest run test/unit/selfhost-grafana-github-datasource.test.ts test/unit/selfhost-grafana-sentry-datasource.test.ts` — 12/12 passing
- [x] `npm run test:ci` — full local gate green (794 test files / 15408 tests passed, 12 skipped)
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] Confirmed behavior preserved: idempotent datasource GET/PUT/POST and health-check still run, secrets no longer in argv or inherited child environments

## Safety

- [x] No secrets in code/comments/tests
- [x] Executable bit preserved (`0o100`, verified by the new test)
- [x] `scripts/` and `test/` are Codecov-exempt per this repo's `codecov.yml` (`src/**` only) — no patch-coverage obligation, but ran the full gate anyway

Follow-up to #5489 (same author/account, same bug class, same fix pattern) — no separate tracking issue exists for this narrow mirrored fix, matching #5489's own precedent (also unlinked).