### PR TITLE
feat(miner-extension): show a last-synced label on the opportunity badge

### DIFF
--- a/apps/gittensory-miner-extension/README.md
+++ b/apps/gittensory-miner-extension/README.md
@@ -18,5 +18,8 @@ available for the current issue.
 ## Local ranked cache
 
 Laptop-mode installs can paste JSON from a miner `discover` run into the options page. The extension stores that list in
-`chrome.storage.local.rankedCandidates` and looks up the current issue there. When no ranked signal is cached for the
-current issue, the badge degrades gracefully by staying hidden.
+`chrome.storage.local.rankedCandidates`, alongside a `chrome.storage.local.rankedCandidatesSavedAt` timestamp updated on
+every save, and looks up the current issue there. When no ranked signal is cached for the current issue, the badge
+degrades gracefully by staying hidden. The badge itself shows a "last synced" relative-time label (mirroring ORB's
+shared `RefreshMeta` component's thresholds) so a contributor can tell how stale the pasted data is; the label is
+omitted entirely for a cache saved before this field existed.

--- a/apps/gittensory-miner-extension/background.js
+++ b/apps/gittensory-miner-extension/background.js
@@ -39,7 +39,7 @@ async function loadIssueOpportunityContext(message) {
     };
   }
 
-  const rankedCandidates = await loadRankedCandidates();
+  const { rankedCandidates, savedAt } = await loadRankedCandidates();
   const rankedEntry = badgeApi.lookupRankedOpportunity(rankedCandidates, repoFullName, message.issueNumber);
   if (!rankedEntry) {
     return {
@@ -56,6 +56,7 @@ async function loadIssueOpportunityContext(message) {
     issueNumber: message.issueNumber,
     repoFullName,
     badge: badgeApi.formatOpportunityBadge(rankedEntry),
+    savedAt,
     status: "ready",
   };
 }
@@ -68,9 +69,14 @@ async function loadMinerExtensionSettings() {
   return { watchedRepos };
 }
 
+// Reads rankedCandidates alongside its savedAt sync timestamp (#5192). `savedAt` degrades to `null`
+// (never NaN) when absent -- e.g. data written before this field existed, or storage was cleared.
 async function loadRankedCandidates() {
-  const stored = await chrome.storage.local.get({ rankedCandidates: [] });
-  return Array.isArray(stored.rankedCandidates) ? stored.rankedCandidates : [];
+  const stored = await chrome.storage.local.get({ rankedCandidates: [], rankedCandidatesSavedAt: null });
+  return {
+    rankedCandidates: Array.isArray(stored.rankedCandidates) ? stored.rankedCandidates : [],
+    savedAt: typeof stored.rankedCandidatesSavedAt === "number" ? stored.rankedCandidatesSavedAt : null,
+  };
 }
 
 // Toolbar-icon badge (#5193). Reads `rankedCandidates` WITHOUT a default so `undefined` still means

--- a/apps/gittensory-miner-extension/content.js
+++ b/apps/gittensory-miner-extension/content.js
@@ -53,12 +53,13 @@ async function loadOpportunityBadge(container, target) {
   renderOpportunityBadge(container, response.payload);
 }
 
-function renderOpportunityBadge(container, payload) {
+function renderOpportunityBadge(container, payload, nowMs = Date.now()) {
   if (!payload?.watched || !payload?.badge) {
     container.remove();
     return;
   }
-  const markup = badgeApi?.renderOpportunityBadgeMarkup?.(payload.badge);
+  const lastSyncedLabel = badgeApi?.formatLastSyncedLabel?.(payload.savedAt, nowMs) ?? null;
+  const markup = badgeApi?.renderOpportunityBadgeMarkup?.(payload.badge, lastSyncedLabel);
   if (!markup) {
     container.remove();
     return;

--- a/apps/gittensory-miner-extension/opportunity-badge.js
+++ b/apps/gittensory-miner-extension/opportunity-badge.js
@@ -45,6 +45,20 @@ function formatOpportunityBadge(entry) {
   };
 }
 
+// Mirrors ORB's shared RefreshMeta component's relative-time thresholds/format
+// (packages/gittensory-ui-kit/src/utils.ts's relativeTimeFromNow: just now / Xm ago / Xh ago / Xd ago),
+// reimplemented here because this content script ships unbundled and cannot import that package (#5192).
+function formatLastSyncedLabel(savedAt, nowMs) {
+  if (typeof savedAt !== "number" || !Number.isFinite(savedAt)) return null;
+  const deltaSeconds = Math.max(0, Math.floor((Number(nowMs) - savedAt) / 1000));
+  if (deltaSeconds < 60) return "last synced just now";
+  const minutes = Math.floor(deltaSeconds / 60);
+  if (minutes < 60) return `last synced ${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `last synced ${hours}h ago`;
+  return `last synced ${Math.floor(hours / 24)}d ago`;
+}
+
 function escapeOpportunityHtml(value) {
   return String(value).replace(/[&<>"']/g, (char) => {
     switch (char) {
@@ -62,7 +76,7 @@ function escapeOpportunityHtml(value) {
   });
 }
 
-function renderOpportunityBadgeMarkup(badge) {
+function renderOpportunityBadgeMarkup(badge, lastSyncedLabel) {
   if (!badge || typeof badge !== "object") return "";
   return `
     <div class="gittensory-miner-opportunity-badge__header">
@@ -75,6 +89,11 @@ function renderOpportunityBadgeMarkup(badge) {
       <span>${escapeOpportunityHtml(badge.score)}</span>
     </div>
     <p class="gittensory-miner-opportunity-badge__why">${escapeOpportunityHtml(badge.why)}</p>
+    ${
+      lastSyncedLabel
+        ? `<p class="gittensory-miner-opportunity-badge__synced">${escapeOpportunityHtml(lastSyncedLabel)}</p>`
+        : ""
+    }
   `;
 }
 
@@ -84,6 +103,7 @@ const opportunityBadgeApi = {
   scoreToTier,
   buildOpportunityWhy,
   formatOpportunityBadge,
+  formatLastSyncedLabel,
   escapeOpportunityHtml,
   renderOpportunityBadgeMarkup,
 };

--- a/apps/gittensory-miner-extension/options.js
+++ b/apps/gittensory-miner-extension/options.js
@@ -48,7 +48,7 @@ form.addEventListener("submit", async (event) => {
     const repos = parseWatchedRepos(watchedRepos.value);
     const rankedCandidates = parseRankedCandidatesJson(rankedCandidatesJson.value);
     await chrome.storage.sync.set({ watchedRepos: repos });
-    await chrome.storage.local.set({ rankedCandidates });
+    await chrome.storage.local.set({ rankedCandidates, rankedCandidatesSavedAt: Date.now() });
     await refreshSettings();
     showStatus(
       rankedCandidates.length > 0

--- a/apps/gittensory-miner-extension/styles.css
+++ b/apps/gittensory-miner-extension/styles.css
@@ -62,3 +62,9 @@
   color: rgba(244, 247, 245, 0.78);
   margin: 0;
 }
+
+.gittensory-miner-opportunity-badge__synced {
+  color: rgba(244, 247, 245, 0.55);
+  font-size: 11px;
+  margin: 6px 0 0;
+}

--- a/test/unit/miner-extension-content.test.ts
+++ b/test/unit/miner-extension-content.test.ts
@@ -153,6 +153,145 @@ describe("miner extension opportunity badge", () => {
     expect(backgroundScript).not.toMatch(/discoveryIndexUrl/);
   });
 
+  it("formats a relative 'last synced' label across the same buckets as ORB's RefreshMeta, clamping missing/invalid input to null (#5192)", () => {
+    const badge = loadBadgeInternals();
+    const NOW_MS = Date.parse("2026-07-10T12:00:00.000Z");
+
+    expect(badge.formatLastSyncedLabel(NOW_MS, NOW_MS)).toBe("last synced just now");
+    expect(badge.formatLastSyncedLabel(NOW_MS - 59_000, NOW_MS)).toBe("last synced just now");
+    expect(badge.formatLastSyncedLabel(NOW_MS - 60_000, NOW_MS)).toBe("last synced 1m ago");
+    expect(badge.formatLastSyncedLabel(NOW_MS - 59 * 60_000, NOW_MS)).toBe("last synced 59m ago");
+    expect(badge.formatLastSyncedLabel(NOW_MS - 60 * 60_000, NOW_MS)).toBe("last synced 1h ago");
+    expect(badge.formatLastSyncedLabel(NOW_MS - 23 * 60 * 60_000, NOW_MS)).toBe("last synced 23h ago");
+    expect(badge.formatLastSyncedLabel(NOW_MS - 24 * 60 * 60_000, NOW_MS)).toBe("last synced 1d ago");
+    expect(badge.formatLastSyncedLabel(NOW_MS + 5_000, NOW_MS)).toBe("last synced just now");
+
+    expect(badge.formatLastSyncedLabel(null, NOW_MS)).toBeNull();
+    expect(badge.formatLastSyncedLabel(undefined, NOW_MS)).toBeNull();
+    expect(badge.formatLastSyncedLabel(Number.NaN, NOW_MS)).toBeNull();
+    expect(badge.formatLastSyncedLabel("not-a-timestamp", NOW_MS)).toBeNull();
+    // Invariant: a falsy-but-coercible-to-0 value must never be read as "the epoch", i.e. a real timestamp.
+    expect(badge.formatLastSyncedLabel("", NOW_MS)).toBeNull();
+  });
+
+  it("renders the last-synced label inside the badge markup when present, and omits it (no NaN, no crash) when absent (#5192)", () => {
+    const ranked = rankCandidateIssues([rawIssue()], { nowMs: NOW })[0]!;
+    const badge = loadBadgeInternals();
+    const formatted = badge.formatOpportunityBadge(ranked);
+
+    const withLabel = badge.renderOpportunityBadgeMarkup(formatted, "last synced 3m ago");
+    expect(withLabel).toContain("last synced 3m ago");
+    expect(withLabel).toContain(formatted.tier);
+
+    const withoutLabel = badge.renderOpportunityBadgeMarkup(formatted, null);
+    expect(withoutLabel).not.toContain("last synced");
+    expect(withoutLabel).not.toContain("NaN");
+    // Invariant: adding/omitting the sync label never touches the ranking-derived fields.
+    expect(withoutLabel).toContain(formatted.tier);
+    expect(withoutLabel).toContain(formatted.score);
+  });
+
+  it("plumbs savedAt from background context through content.js into a rendered 'last synced' label (#5192)", () => {
+    const internals = loadContentInternals();
+    const container = createMockContainer();
+    const ranked = rankCandidateIssues([rawIssue()], { nowMs: NOW })[0]!;
+    const badge = loadBadgeInternals();
+    const formatted = badge.formatOpportunityBadge(ranked);
+    const savedAt = NOW - 5 * 60_000;
+
+    internals.renderOpportunityBadge(container, { watched: true, badge: formatted, savedAt, status: "ready" }, NOW);
+    expect(container.innerHTML).toContain("last synced 5m ago");
+  });
+
+  it("regression: a cache saved before savedAt existed renders the badge without a sync label instead of crashing or showing NaN (#5192)", () => {
+    const internals = loadContentInternals();
+    const container = createMockContainer();
+    const ranked = rankCandidateIssues([rawIssue()], { nowMs: NOW })[0]!;
+    const badge = loadBadgeInternals();
+    const formatted = badge.formatOpportunityBadge(ranked);
+
+    internals.renderOpportunityBadge(container, { watched: true, badge: formatted, status: "ready" }, NOW);
+    expect(container.hidden).toBe(false);
+    expect(container.innerHTML).not.toContain("last synced");
+    expect(container.innerHTML).not.toContain("NaN");
+  });
+
+  it("includes savedAt in the ready background payload and omits it when there's no ranked signal (#5192)", async () => {
+    const ranked = rankCandidateIssues([rawIssue()], { nowMs: NOW });
+    const savedAt = NOW - 60_000;
+    const ready = loadBackgroundInternals({
+      watchedRepos: ["JSONbored/gittensory"],
+      rankedCandidates: ranked,
+      rankedCandidatesSavedAt: savedAt,
+    });
+    const readyPayload = await ready.loadIssueOpportunityContext({
+      owner: "JSONbored",
+      repo: "gittensory",
+      issueNumber: 145,
+    });
+    expect(readyPayload.status).toBe("ready");
+    expect(readyPayload.savedAt).toBe(savedAt);
+
+    const noSignal = loadBackgroundInternals({
+      watchedRepos: ["JSONbored/gittensory"],
+      rankedCandidates: [],
+      rankedCandidatesSavedAt: savedAt,
+    });
+    const noSignalPayload = await noSignal.loadIssueOpportunityContext({
+      owner: "JSONbored",
+      repo: "gittensory",
+      issueNumber: 145,
+    });
+    expect(noSignalPayload.status).toBe("no-signal");
+    expect(noSignalPayload.badge).toBeNull();
+  });
+
+  it("writes a rankedCandidatesSavedAt timestamp alongside rankedCandidates on every save, including re-paste/overwrite (#5192)", async () => {
+    const localSetCalls: Array<Record<string, unknown>> = [];
+    let fakeNowMs = Date.parse("2026-07-10T12:00:00.000Z");
+    const elements = {
+      "#settings": createFormMock(),
+      "#status": { textContent: "" },
+      "#watchedRepos": { value: "JSONbored/gittensory" },
+      "#rankedCandidatesJson": { value: "[]" },
+    };
+    const context: Record<string, unknown> = {
+      __GITTENSORY_MINER_EXTENSION_TEST__: true,
+      Date: { now: () => fakeNowMs },
+      document: { querySelector: (selector: string) => elements[selector as keyof typeof elements] ?? null },
+      chrome: {
+        storage: {
+          sync: { get: async () => ({ watchedRepos: [] }), set: async () => {}, remove: async () => {} },
+          local: {
+            get: async () => ({ rankedCandidates: [] }),
+            set: async (value: Record<string, unknown>) => {
+              localSetCalls.push(value);
+            },
+          },
+        },
+      },
+      window: { setTimeout: () => 0 },
+    };
+    context.globalThis = context;
+    const vmContext = createContext(context);
+    new Script(optionsScript).runInContext(vmContext);
+    await flushPromises();
+
+    await elements["#settings"].dispatchSubmit();
+    fakeNowMs = Date.parse("2026-07-10T12:05:00.000Z");
+    await elements["#settings"].dispatchSubmit();
+
+    expect(localSetCalls).toHaveLength(2);
+    expect(localSetCalls[0]).toEqual({
+      rankedCandidates: [],
+      rankedCandidatesSavedAt: Date.parse("2026-07-10T12:00:00.000Z"),
+    });
+    expect(localSetCalls[1]).toEqual({
+      rankedCandidates: [],
+      rankedCandidatesSavedAt: Date.parse("2026-07-10T12:05:00.000Z"),
+    });
+  });
+
   it("purges a discoveryIndexUrl value already synced by an older extension version, on load and on save", async () => {
     const synced: Record<string, unknown> = {
       watchedRepos: [],
@@ -251,7 +390,11 @@ function loadBadgeInternals() {
   return vmContext.__gittensoryMinerOpportunityBadgeTestExports as {
     lookupRankedOpportunity: (ranked: unknown[], repoFullName: string, issueNumber: number) => Record<string, unknown> | null;
     formatOpportunityBadge: (entry: Record<string, unknown>) => { tier: string; score: string; why: string };
-    renderOpportunityBadgeMarkup: (badge: { tier: string; score: string; why: string }) => string;
+    formatLastSyncedLabel: (savedAt: unknown, nowMs: number) => string | null;
+    renderOpportunityBadgeMarkup: (
+      badge: { tier: string; score: string; why: string },
+      lastSyncedLabel?: string | null,
+    ) => string;
   };
 }
 
@@ -275,13 +418,18 @@ function loadContentInternals() {
     matchGitHubIssueTarget: (
       pathname: string,
     ) => { kind: "issue"; owner: string; repo: string; issueNumber: number } | null;
-    renderOpportunityBadge: (container: ReturnType<typeof createMockContainer>, payload: unknown) => void;
+    renderOpportunityBadge: (
+      container: ReturnType<typeof createMockContainer>,
+      payload: unknown,
+      nowMs?: number,
+    ) => void;
   };
 }
 
 function loadBackgroundInternals({
   watchedRepos = [] as string[],
   rankedCandidates = [] as unknown[],
+  rankedCandidatesSavedAt = null as number | null,
 } = {}) {
   const context: Record<string, unknown> = {
     __GITTENSORY_MINER_EXTENSION_TEST__: true,
@@ -291,7 +439,7 @@ function loadBackgroundInternals({
           get: async () => ({ watchedRepos }),
         },
         local: {
-          get: async () => ({ rankedCandidates }),
+          get: async () => ({ rankedCandidates, rankedCandidatesSavedAt }),
         },
       },
       runtime: { onMessage: { addListener: () => {} } },
@@ -310,6 +458,7 @@ function loadBackgroundInternals({
     }) => Promise<{
       status: string;
       badge: { tier: string; why: string } | null;
+      savedAt?: number | null;
     }>;
   };
 }


### PR DESCRIPTION
## Summary

- The miner extension's opportunity badge (`apps/gittensory-miner-extension/opportunity-badge.js`) previously gave a contributor no signal at all about how stale their pasted `discover`-run data was — the badge could be showing a ranked candidate synced minutes or days ago with no way to tell which.
- `options.js` now writes a `rankedCandidatesSavedAt` timestamp (`Date.now()`) to `chrome.storage.local` alongside `rankedCandidates` on every save, including a re-paste/overwrite of previously-saved data.
- `background.js`'s `loadIssueOpportunityContext` reads that timestamp back and includes it (as `savedAt`) in the `ready` message payload sent to the content script.
- `opportunity-badge.js` gets a new `formatLastSyncedLabel(savedAt, nowMs)` helper that reimplements the same relative-time thresholds/format as ORB's shared `RefreshMeta` component (`packages/gittensory-ui-kit/src/utils.ts`'s `relativeTimeFromNow`: "just now" / "Xm ago" / "Xh ago" / "Xd ago") — reimplemented locally because this content script ships unbundled and cannot import that package.
- `content.js`'s `renderOpportunityBadge` now takes an injectable `nowMs` (defaulting to `Date.now()`), computes the label, and renders it inside the badge markup as a `.gittensory-miner-opportunity-badge__synced` line.
- A cache saved before this field existed (or with an invalid/missing `savedAt`) degrades gracefully: the label is simply omitted, never `NaN` or a crash.

Fixes #5192

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — this change lives entirely under `apps/gittensory-miner-extension/**` and its dedicated test file `test/unit/miner-extension-content.test.ts`, outside vitest's root `coverage.include` glob (only root `src/**` is Codecov-measured), so `codecov/patch` cannot see this diff.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

Ran the full local gate: `npm run test:ci` (796 test files / 15400+ tests, all green) and `npm audit --audit-level=moderate` (0 vulnerabilities), both clean on the final rebased commit.

Test coverage added to `test/unit/miner-extension-content.test.ts` (18 tests total in the file, up from 10): `formatLastSyncedLabel` across every relative-time bucket (just now / 1m / 59m / 1h / 23h / 1d, plus a small-positive-skew clamp), and an explicit invariant that `null`/`undefined`/`NaN`/a non-numeric string/an empty string all degrade to `null` rather than being misread as epoch-zero (`Number("")` coerces to `0`, which is finite — this was caught live while writing the test and fixed by requiring `typeof savedAt === "number"` rather than a bare `Number.isFinite` coercion); `renderOpportunityBadgeMarkup` with and without a label, asserting the ranking-derived fields (`tier`/`score`) are unaffected either way; `content.js`'s `renderOpportunityBadge` plumbing `savedAt` + an injected `nowMs` through to the rendered label; a regression test for a pre-existing cache with no `savedAt` field rendering cleanly with no label and no `NaN`; `background.js` including `savedAt` in the `ready` payload and omitting it when there's no ranked signal; and `options.js` writing a fresh `rankedCandidatesSavedAt` on every save, including a second save with a different value to prove it's rewritten on overwrite, not just written once.

This branch was rebased past a concurrent PR (#5511, merged as `ec7d4c24`) that touched the same two files (`options.js` and this test file) to add a `discoveryIndexUrl` legacy-purge feature; the rebase conflict was resolved by keeping both sets of changes/tests, and a real gap the merge exposed (a test's `chrome.storage.sync` mock missing the `remove` method now called from `refreshSettings()`) was fixed in the same commit.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no auth/session/CORS surface touched (local `chrome.storage` only).
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — no public API/OpenAPI/MCP surface touched; the extension's internal message payload shape change (`savedAt` added) is covered by the tests above.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — the badge continues to render from the real `chrome.storage.local` cache; the missing-`savedAt` fallback is a real degrade path, not a mock.
- [x] Visible UI changes include a `UI Evidence` section below.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — updated `apps/gittensory-miner-extension/README.md`'s "Local ranked cache" section.

## UI Evidence

This is a browser extension content script injected into `github.com/*/*/issues/*` pages — there is no hosted/public deployment to screenshot from this environment (no browser screenshot tooling available here). Verified functionally instead: `npm run test:ci` includes the full `test/unit/miner-extension-content.test.ts` suite (18/18 passing), including a direct assertion that `renderOpportunityBadgeMarkup`/`renderOpportunityBadge` produce markup literally containing `last synced 5m ago`-style text alongside the existing tier/score/why badge content, and that the label is cleanly absent (no `NaN`) when `savedAt` is missing.

## Notes

- Kept the label as a single extra line inside the existing badge markup (`.gittensory-miner-opportunity-badge__synced`, styled muted/small to match the existing `__read-only` treatment) rather than a separate UI element, since the badge is already a compact fixed/sidebar-anchored card.
- Scope was kept to the badge itself per the issue's boundary #6 ("do not touch any ranking/scoring logic... only render a relative-time label next to the badge") — the options page itself does not display `rankedCandidatesSavedAt`, since the issue only asked for it on the GitHub issue-page badge.
