### PR TITLE
docs(miner): document all sixteen local SQLite stores in DEPLOYMENT.md (#4870)

### DIFF
--- a/packages/gittensory-miner/DEPLOYMENT.md
+++ b/packages/gittensory-miner/DEPLOYMENT.md
@@ -38,14 +38,32 @@ For provider selection and the CLI-specific model/timeout overrides, see
 
    ```text
    ~/.config/gittensory-miner/
-     claim-ledger.sqlite3      # soft issue claims (#2314)
-     plan-store.sqlite3        # persisted MCP plan DAGs (#2318)
-     portfolio-queue.sqlite3   # local portfolio queue
-     event-ledger.sqlite3      # manage-loop audit trail
-     governor-ledger.sqlite3   # governor decisions
+     laptop-state.sqlite3          # laptop-mode setup state, created by `init`
+     portfolio-queue.sqlite3       # prioritized work backlog across tracked repos (#2292)
+     claim-ledger.sqlite3          # soft issue claims (#2314)
+     plan-store.sqlite3            # persisted MCP plan DAGs (#2318)
+     run-state.sqlite3             # per-repo run state (idle/discovering/planning/preparing)
+     event-ledger.sqlite3          # append-only miner-loop event audit trail (#2290)
+     governor-ledger.sqlite3       # append-only governor allow/deny/throttle decisions (#2328)
+     governor-state.sqlite3        # governor cross-attempt counters/state (#5134)
+     attempt-log.sqlite3           # per-attempt coding-agent driver event trace (#4294)
+     worktree-allocator.sqlite3    # git-worktree-per-attempt allocation bookkeeping (#4297)
+     prediction-ledger.sqlite3     # predicted-gate verdicts, for later self-improve scoring (#4263)
+     replay-snapshot.sqlite3       # frozen historical-replay target snapshots (#3010)
+     policy-doc-cache.sqlite3      # ETag cache for discovery's policy-doc fetches (#4842)
+     policy-verdict-cache.sqlite3  # cache of resolved AI-usage-policy verdicts (#4843)
+     deny-hook-synthesis.sqlite3   # synthesized PreToolUse deny-hook proposals (#4522)
+     orb-export.sqlite3            # opt-in anonymized Orb telemetry export state (#4277)
    ```
 
-   Override the directory with `GITTENSORY_MINER_CONFIG_DIR` or `XDG_CONFIG_HOME` (same resolution chain as `@jsonbored/gittensory-mcp`).
+   Not every file appears immediately: `laptop-state` is written by `init`, and each of the others is created
+   the first time its subsystem actually runs (an attempt, a discovery pass, a replay, an Orb export, …), so a
+   fresh install that has only run `status`/`doctor` will show a subset. All sixteen default into this one
+   directory. Override the directory for every store at once with `GITTENSORY_MINER_CONFIG_DIR` or
+   `XDG_CONFIG_HOME` (same resolution chain as `@jsonbored/gittensory-mcp`); every store except `laptop-state.sqlite3`
+   (directory only) also honors its own `GITTENSORY_MINER_<NAME>_DB` path override — e.g.
+   `GITTENSORY_MINER_PORTFOLIO_QUEUE_DB` — to relocate an individual file. `doctor`'s `store-integrity:*` checks
+   report the persistent stores, so it is the quickest way to confirm what exists and is readable on disk.
 
 4. Optional per-repo miner goals: copy [`.gittensory-miner.yml.example`](../../.gittensory-miner.yml.example) to a target repo as `.gittensory-miner.yml`. See [`docs/miner-goal-spec.md`](docs/miner-goal-spec.md).
 


### PR DESCRIPTION
## Summary

`packages/gittensory-miner/DEPLOYMENT.md`'s "expected layout" section listed only 5 of the miner's local SQLite stores (`claim-ledger`, `plan-store`, `portfolio-queue`, `event-ledger`, `governor-ledger`), but the package actually creates **16**. An operator following the doc would miss most of their own on-disk state — the exact problem #4870 reports.

This rewrites the layout to list every store the package creates, each with its filename, a one-line purpose, and its issue ref:

- `laptop-state` (init state), `portfolio-queue` (#2292), `claim-ledger` (#2314), `plan-store` (#2318), `run-state`, `event-ledger` (#2290), `governor-ledger` (#2328), `governor-state` (#5134),
- `attempt-log` (#4294), `worktree-allocator` (#4297), `prediction-ledger` (#4263), `replay-snapshot` (#3010), `policy-doc-cache` (#4842), `policy-verdict-cache` (#4843), `deny-hook-synthesis` (#4522), `orb-export` (#4277).

It also adds two accuracy notes: files are created lazily (only once the relevant subsystem first runs, so a fresh `status`/`doctor`-only install shows a subset), and every store except `laptop-state` honors its own `GITTENSORY_MINER_<NAME>_DB` path override in addition to the directory-level `GITTENSORY_MINER_CONFIG_DIR`.

Every filename and env-var name was verified directly against the store modules in `packages/gittensory-miner/lib` (all 16 `.sqlite3` defaults; none exist outside `lib/`), so the list is complete and exact.

Closes #4870

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (Closes #4870).

## Validation

- [x] `git diff --check`
- [x] `npm run docs:drift-check` (passes — the generated-docs drift check is unaffected)
- [ ] `npm run typecheck` / `test:*` / `build:*` / `ui:*` — N/A: single hand-written Markdown doc change, no code, schema, or generated artifact touched.
- [x] Completeness verified by enumerating every `*.sqlite3` default in `packages/gittensory-miner/lib` (16) and confirming none exist elsewhere in the package.

If any required check was skipped, explain why:

Documentation-only change to one Markdown file (`DEPLOYMENT.md`); it touches no source, tests, schemas, or generated artifacts, so the build/type/UI/coverage checks are N/A.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed (only public store filenames + env-var names, all already in the source).
- [x] Public GitHub text stays sanitized and low-noise.
- [x] Auth/CORS/session negative-path tests — N/A.
- [x] API/OpenAPI/MCP behavior updated/tested — N/A.
- [x] UI changes use real states — N/A (no UI).
- [x] Visible UI changes include UI Evidence — N/A (no UI; a Markdown doc).
- [x] Public docs/changelogs updated where needed; changelogs are only edited for release-prep PRs — this is a docs accuracy fix, not a changelog edit.

## UI Evidence

N/A — Markdown documentation change only.

## Notes

- The layout is presented as the full set with a lazy-creation caveat rather than split into hard "created early / created later" buckets, since exactly when each file first appears depends on which subcommands an operator runs; the caveat keeps the doc accurate without over-claiming per-store timing.
