### PR TITLE
feat(miner): add committed profiling/benchmarks for the miner package (#4845)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "selfhost:env-reference:check": "node scripts/gen-selfhost-env-reference.mjs --check",
     "miner:env-reference": "node packages/gittensory-miner/scripts/generate-env-reference.mjs",
     "miner:env-reference:check": "node packages/gittensory-miner/scripts/generate-env-reference.mjs --check",
+    "miner:bench": "node packages/gittensory-miner/scripts/benchmark.mjs",
     "command-reference": "node scripts/gen-command-reference.mjs",
     "command-reference:check": "node scripts/gen-command-reference.mjs --check",
     "selfhost:validate-observability": "node scripts/validate-observability-configs.mjs",

--- a/packages/gittensory-miner/README.md
+++ b/packages/gittensory-miner/README.md
@@ -144,6 +144,8 @@ See [`DEPLOYMENT.md`](DEPLOYMENT.md) for laptop vs fleet deployment.
 
 See [`docs/operations-runbook.md`](docs/operations-runbook.md) for SQLite concurrency guarantees, corruption recovery, multi-process collision response, and post-upgrade ledger migration ([#4875](https://github.com/JSONbored/gittensory/issues/4875)).
 
+See [`benchmarks/`](benchmarks/README.md) for the committed micro-benchmark suite over the discovery-fanout and local-store read/write paths — run `npm run miner:bench` and compare against `benchmarks/baseline.json` ([#4845](https://github.com/JSONbored/gittensory/issues/4845)).
+
 ### Laptop-mode quickstart
 
 Zero-infra local install — no Docker, Redis, or Postgres required:

--- a/packages/gittensory-miner/benchmarks/README.md
+++ b/packages/gittensory-miner/benchmarks/README.md
@@ -11,7 +11,7 @@ npm run miner:bench                     # human table, compared to the committed
 npm run miner:bench -- --json           # machine-readable results
 npm run miner:bench -- --iterations 500 # more samples for a steadier number
 npm run miner:bench -- --update-baseline# regenerate benchmarks/baseline.json on THIS machine
-npm run miner:bench -- --check          # exit non-zero if any case regressed > tolerance (default 25%)
+npm run miner:bench -- --check          # exit non-zero if any case regressed > tolerance (default 25%) or is uncheckable
 ```
 
 The script itself lives at [`../scripts/benchmark.mjs`](../scripts/benchmark.mjs); the pure timing/stats/report
@@ -39,3 +39,10 @@ stores, and the engine's JSON import attributes that the fanout pulls in). On an
 runtime** (Node version, CPU) — they are a relative regression signal, not an absolute spec. Regenerate it on your
 own machine/CI with `--update-baseline` before relying on `--check`. Because timing is inherently machine-dependent,
 `--check` is intended for on-demand/local use and is deliberately **not** wired into the required CI gate.
+
+**Known gap — committed baseline is Node-18-generated.** The committed `baseline.json` was captured on Node
+v18.19.1, below the package's own **Node >= 22.13** requirement, so the three runtime-dependent cases
+(`discovery_fanout_scheduler`, `local_store_write`, `local_store_read`) are recorded as `unavailable` rather than
+real numbers. A non-`ok` baseline case carries no regression signal, so `--check` now **fails loudly** on any such
+case (rather than silently passing it) and tells you to regenerate. Run `npm run miner:bench -- --update-baseline`
+on Node >= 22.13 to capture all six cases as `ok` and commit the refreshed snapshot.

--- a/packages/gittensory-miner/benchmarks/README.md
+++ b/packages/gittensory-miner/benchmarks/README.md
@@ -1,0 +1,41 @@
+# gittensory-miner benchmarks (#4845)
+
+A small, committed micro-benchmark suite so a future change to the miner has a baseline to compare against — is
+discovery/claiming getting faster or slower? It covers the two hot paths the issue names: the **discovery fanout**
+and the **local-store read/write** path.
+
+## Run it
+
+```sh
+npm run miner:bench                     # human table, compared to the committed baseline
+npm run miner:bench -- --json           # machine-readable results
+npm run miner:bench -- --iterations 500 # more samples for a steadier number
+npm run miner:bench -- --update-baseline# regenerate benchmarks/baseline.json on THIS machine
+npm run miner:bench -- --check          # exit non-zero if any case regressed > tolerance (default 25%)
+```
+
+The script itself lives at [`../scripts/benchmark.mjs`](../scripts/benchmark.mjs); the pure timing/stats/report
+helpers are in [`../scripts/benchmark-harness.mjs`](../scripts/benchmark-harness.mjs) (unit-tested in
+`test/unit/miner-benchmark-harness.test.ts`).
+
+## Cases
+
+| Case | Group | What it measures |
+| --- | --- | --- |
+| `discovery_throttle_resolve` | discovery-fanout | the rate-limit-aware concurrency decision the fanout re-evaluates every worker iteration (#4844) |
+| `forge_config_resolve` | discovery-fanout | per-fanout forge-config resolution (#4784) |
+| `http_retry_passthrough` | discovery-fanout | the per-request retry wrapper every fanout fetch goes through (#4829) |
+| `discovery_fanout_scheduler` | discovery-fanout | the real bounded-concurrency scheduler that drives the fanout over many repos |
+| `local_store_write` | local-store | one `appendEvent` per iteration against a temp SQLite event ledger |
+| `local_store_read` | local-store | `readEvents` over a 500-row temp SQLite event ledger |
+
+The last three exercise library code that needs the package's own runtime (**Node >= 22.13** — `node:sqlite` for the
+stores, and the engine's JSON import attributes that the fanout pulls in). On an older Node they are recorded as
+`unavailable` rather than crashing the run, and the lighter fanout-internal cases still produce real numbers.
+
+## The baseline
+
+[`baseline.json`](baseline.json) is a committed snapshot. **The numbers are only comparable within the same
+runtime** (Node version, CPU) — they are a relative regression signal, not an absolute spec. Regenerate it on your
+own machine/CI with `--update-baseline` before relying on `--check`. Because timing is inherently machine-dependent,
+`--check` is intended for on-demand/local use and is deliberately **not** wired into the required CI gate.

--- a/packages/gittensory-miner/benchmarks/baseline.json
+++ b/packages/gittensory-miner/benchmarks/baseline.json
@@ -1,0 +1,58 @@
+{
+  "note": "Machine-dependent micro-benchmark baseline for the gittensory-miner package (#4845). Numbers are only comparable within the same runtime; regenerate on yours with: npm run miner:bench -- --update-baseline",
+  "nodeVersion": "v18.19.1",
+  "generatedAt": "2026-07-13T00:39:43.992Z",
+  "results": [
+    {
+      "name": "discovery_throttle_resolve",
+      "group": "discovery-fanout",
+      "status": "ok",
+      "iterations": 300,
+      "meanMs": 0.004,
+      "medianMs": 0.0041,
+      "minMs": 0.0004,
+      "maxMs": 0.0517,
+      "opsPerSec": 250427.4268
+    },
+    {
+      "name": "forge_config_resolve",
+      "group": "discovery-fanout",
+      "status": "ok",
+      "iterations": 300,
+      "meanMs": 0.0657,
+      "medianMs": 0.0635,
+      "minMs": 0.0604,
+      "maxMs": 0.1609,
+      "opsPerSec": 15225.6664
+    },
+    {
+      "name": "http_retry_passthrough",
+      "group": "discovery-fanout",
+      "status": "ok",
+      "iterations": 300,
+      "meanMs": 0.0114,
+      "medianMs": 0.0104,
+      "minMs": 0.0064,
+      "maxMs": 0.0858,
+      "opsPerSec": 87376.7552
+    },
+    {
+      "name": "discovery_fanout_scheduler",
+      "group": "discovery-fanout",
+      "status": "unavailable",
+      "reason": "Unexpected token 'with'"
+    },
+    {
+      "name": "local_store_write",
+      "group": "local-store",
+      "status": "unavailable",
+      "reason": "No such built-in module: node:sqlite"
+    },
+    {
+      "name": "local_store_read",
+      "group": "local-store",
+      "status": "unavailable",
+      "reason": "No such built-in module: node:sqlite"
+    }
+  ]
+}

--- a/packages/gittensory-miner/scripts/benchmark-harness.d.mts
+++ b/packages/gittensory-miner/scripts/benchmark-harness.d.mts
@@ -49,6 +49,12 @@ export type BenchmarkComparison = {
   regressed: boolean;
 };
 
+/** A case that cannot be regression-checked, with a human-readable reason (non-`ok` current run or baseline). */
+export type UncheckableCase = {
+  name: string;
+  reason: string;
+};
+
 export type RunBenchmarkOptions = {
   iterations?: number;
   warmup?: number;
@@ -78,6 +84,11 @@ export declare function compareToBaseline(
   baseline: BenchmarkBaselineDocument | null | undefined,
   options?: { tolerance?: number },
 ): BenchmarkComparison[];
+
+export declare function findUncheckableCases(
+  results: BenchmarkResultLike[],
+  baseline: BenchmarkBaselineDocument | null | undefined,
+): UncheckableCase[];
 
 export declare function renderBaselineDocument(
   results: BenchmarkResultLike[],

--- a/packages/gittensory-miner/scripts/benchmark-harness.d.mts
+++ b/packages/gittensory-miner/scripts/benchmark-harness.d.mts
@@ -1,0 +1,85 @@
+/** Type declarations for the dependency-free micro-benchmark harness (#4845). Ships as a sibling `.d.mts` (the
+ * same pattern as `generate-env-reference.d.mts`) so the harness's `.mjs` gets types without a build step. */
+
+export type BenchmarkSummary = {
+  iterations: number;
+  totalMs: number;
+  meanMs: number;
+  medianMs: number;
+  minMs: number;
+  maxMs: number;
+  opsPerSec: number;
+};
+
+/** The fully-timed result `runBenchmark` produces (always `status: "ok"`). */
+export type BenchmarkResult = BenchmarkSummary & {
+  name: string;
+  group: string;
+  status: "ok";
+};
+
+/** A loose result/baseline-entry shape accepted by the reporting/comparison helpers: a non-`ok` case may omit the
+ * timing fields and instead carry a `reason`, so every metric is optional and `status` is an open string. */
+export type BenchmarkResultLike = {
+  name: string;
+  status: string;
+  group?: string;
+  iterations?: number;
+  totalMs?: number;
+  meanMs?: number;
+  medianMs?: number;
+  minMs?: number;
+  maxMs?: number;
+  opsPerSec?: number;
+  reason?: string | null;
+};
+
+export type BenchmarkBaselineDocument = {
+  results?: BenchmarkResultLike[];
+  note?: string;
+  nodeVersion?: string | null;
+  generatedAt?: string | null;
+};
+
+export type BenchmarkComparison = {
+  name: string;
+  baseline: number | null;
+  current: number | null;
+  deltaPct: number | null;
+  regressed: boolean;
+};
+
+export type RunBenchmarkOptions = {
+  iterations?: number;
+  warmup?: number;
+  now?: () => number;
+  group?: string;
+};
+
+export type BaselineDocumentMeta = {
+  nodeVersion?: string | null;
+  generatedAt?: string | null;
+};
+
+export declare function roundMetric(value: number): number;
+
+export declare function summarizeDurations(durationsMs: number[]): BenchmarkSummary;
+
+export declare function runBenchmark(
+  name: string,
+  fn: () => unknown | Promise<unknown>,
+  options?: RunBenchmarkOptions,
+): Promise<BenchmarkResult>;
+
+export declare function formatBenchmarkReport(results: BenchmarkResultLike[]): string;
+
+export declare function compareToBaseline(
+  results: BenchmarkResultLike[],
+  baseline: BenchmarkBaselineDocument | null | undefined,
+  options?: { tolerance?: number },
+): BenchmarkComparison[];
+
+export declare function renderBaselineDocument(
+  results: BenchmarkResultLike[],
+  meta?: BaselineDocumentMeta,
+): string;

--- a/packages/gittensory-miner/scripts/benchmark-harness.mjs
+++ b/packages/gittensory-miner/scripts/benchmark-harness.mjs
@@ -93,9 +93,37 @@ export function compareToBaseline(results, baseline, options = {}) {
         regressed: false,
       };
     }
+    // A legitimately zero-mean baseline (an all-zero-duration run below clock granularity) has no meaningful
+    // ratio, so it reports a 0% delta rather than dividing by zero. This can in principle mask a real slowdown
+    // from 0 -> nonzero; such a case is a signal the iteration count is too low to time, not a silent pass —
+    // regenerate the baseline with more `--iterations` so the case produces a nonzero mean.
     const deltaPct = base.meanMs > 0 ? (result.meanMs - base.meanMs) / base.meanMs : 0;
     return { name: result.name, baseline: base.meanMs, current: result.meanMs, deltaPct, regressed: deltaPct > tolerance };
   });
+}
+
+/**
+ * Identify cases a `--check` run cannot meaningfully regression-check (#4845): a case that did not produce an `ok`
+ * result in this run (no current number), or whose committed baseline entry exists but is non-`ok` (nothing to
+ * compare against). `compareToBaseline` reports both as `regressed: false`, so without this a non-`ok` committed
+ * baseline would silently disable regression detection for that case. A brand-new case that ran `ok` but is absent
+ * from the baseline is NOT flagged — it is simply new and cannot regress yet. Returns `{ name, reason }[]`.
+ */
+export function findUncheckableCases(results, baseline) {
+  const baselineByName = new Map((baseline?.results ?? []).map((entry) => [entry.name, entry]));
+  const uncheckable = [];
+  for (const result of results) {
+    const base = baselineByName.get(result.name);
+    const currentOk = result.status === "ok";
+    const baselineOk = base ? base.status === "ok" : false;
+    if (currentOk && baselineOk) continue;
+    if (currentOk && !base) continue;
+    const reason = !currentOk
+      ? `current run is ${result.status}${result.reason ? ` (${result.reason})` : ""}`
+      : `baseline is ${base.status}${base.reason ? ` (${base.reason})` : ""}`;
+    uncheckable.push({ name: result.name, reason });
+  }
+  return uncheckable;
 }
 
 /** Serialize results into the committed baseline document shape (rounded numbers + provenance metadata). */

--- a/packages/gittensory-miner/scripts/benchmark-harness.mjs
+++ b/packages/gittensory-miner/scripts/benchmark-harness.mjs
@@ -1,0 +1,128 @@
+import { performance } from "node:perf_hooks";
+
+// Pure micro-benchmark harness for the miner package (#4845): timing, summary statistics, human/JSON reporting,
+// and baseline comparison. Deliberately dependency-free (only `node:perf_hooks`) and side-effect-free so it can be
+// unit-tested with an injected clock and reused by `benchmark.mjs`. It measures; it never decides pass/fail on its
+// own (the caller applies a tolerance) so a timing wobble can't become a flaky hard failure.
+
+const defaultNow = () => performance.now();
+
+function median(sortedAscending) {
+  const mid = Math.floor(sortedAscending.length / 2);
+  return sortedAscending.length % 2 === 0
+    ? (sortedAscending[mid - 1] + sortedAscending[mid]) / 2
+    : sortedAscending[mid];
+}
+
+/** Round to 4 decimal places so committed baselines stay stable against sub-microsecond jitter. */
+export function roundMetric(value) {
+  return Math.round(value * 1e4) / 1e4;
+}
+
+/** Summary statistics for a list of per-iteration durations (ms). An empty list yields all-zero stats. */
+export function summarizeDurations(durationsMs) {
+  const sorted = [...durationsMs].sort((a, b) => a - b);
+  const iterations = sorted.length;
+  if (iterations === 0) {
+    return { iterations: 0, totalMs: 0, meanMs: 0, medianMs: 0, minMs: 0, maxMs: 0, opsPerSec: 0 };
+  }
+  const totalMs = sorted.reduce((sum, value) => sum + value, 0);
+  const meanMs = totalMs / iterations;
+  return {
+    iterations,
+    totalMs,
+    meanMs,
+    medianMs: median(sorted),
+    minMs: sorted[0],
+    maxMs: sorted[iterations - 1],
+    opsPerSec: meanMs > 0 ? 1000 / meanMs : 0,
+  };
+}
+
+/**
+ * Time `fn` over `iterations` runs (after `warmup` untimed runs), collecting per-iteration durations from the
+ * injectable `now` clock. Returns `{ name, group, status: "ok", ...summary }`. `fn` may be sync or async.
+ */
+export async function runBenchmark(name, fn, options = {}) {
+  const iterations = Number.isInteger(options.iterations) && options.iterations > 0 ? options.iterations : 100;
+  const warmup = Number.isInteger(options.warmup) && options.warmup >= 0 ? options.warmup : 10;
+  const now = typeof options.now === "function" ? options.now : defaultNow;
+  const group = typeof options.group === "string" ? options.group : "";
+
+  for (let index = 0; index < warmup; index += 1) await fn();
+  const durations = [];
+  for (let index = 0; index < iterations; index += 1) {
+    const start = now();
+    await fn();
+    durations.push(now() - start);
+  }
+  return { name, group, status: "ok", ...summarizeDurations(durations) };
+}
+
+/** One-line-per-case human report. Non-`ok` cases print their status/reason instead of numbers. */
+export function formatBenchmarkReport(results) {
+  return results
+    .map((result) => {
+      if (result.status !== "ok") {
+        return `${result.name.padEnd(30)} ${result.status}${result.reason ? `: ${result.reason}` : ""}`;
+      }
+      return (
+        `${result.name.padEnd(30)} ${roundMetric(result.meanMs)} ms mean  ` +
+        `${roundMetric(result.medianMs)} ms median  ${Math.round(result.opsPerSec)} ops/s  (n=${result.iterations})`
+      );
+    })
+    .join("\n");
+}
+
+/**
+ * Compare current results against a committed baseline by name. A case regresses when its mean time exceeds the
+ * baseline mean by more than `tolerance` (default 25%). Cases missing from the baseline, or not `ok`, are reported
+ * with `deltaPct: null` and `regressed: false` — never a failure, so a newly-added case can't break a check run.
+ */
+export function compareToBaseline(results, baseline, options = {}) {
+  const tolerance = typeof options.tolerance === "number" ? options.tolerance : 0.25;
+  const baselineByName = new Map((baseline?.results ?? []).map((entry) => [entry.name, entry]));
+  return results.map((result) => {
+    const base = baselineByName.get(result.name);
+    if (result.status !== "ok" || !base || base.status !== "ok" || typeof base.meanMs !== "number") {
+      return {
+        name: result.name,
+        baseline: base && typeof base.meanMs === "number" ? base.meanMs : null,
+        current: result.status === "ok" ? result.meanMs : null,
+        deltaPct: null,
+        regressed: false,
+      };
+    }
+    const deltaPct = base.meanMs > 0 ? (result.meanMs - base.meanMs) / base.meanMs : 0;
+    return { name: result.name, baseline: base.meanMs, current: result.meanMs, deltaPct, regressed: deltaPct > tolerance };
+  });
+}
+
+/** Serialize results into the committed baseline document shape (rounded numbers + provenance metadata). */
+export function renderBaselineDocument(results, meta = {}) {
+  const rendered = results.map((result) =>
+    result.status === "ok"
+      ? {
+          name: result.name,
+          group: result.group ?? "",
+          status: "ok",
+          iterations: result.iterations,
+          meanMs: roundMetric(result.meanMs),
+          medianMs: roundMetric(result.medianMs),
+          minMs: roundMetric(result.minMs),
+          maxMs: roundMetric(result.maxMs),
+          opsPerSec: roundMetric(result.opsPerSec),
+        }
+      : { name: result.name, group: result.group ?? "", status: result.status, reason: result.reason ?? null },
+  );
+  const document = {
+    note:
+      "Machine-dependent micro-benchmark baseline for the gittensory-miner package (#4845). " +
+      "Numbers are only comparable within the same runtime; regenerate on yours with: " +
+      "npm run miner:bench -- --update-baseline",
+    nodeVersion: meta.nodeVersion ?? null,
+    generatedAt: meta.generatedAt ?? null,
+    results: rendered,
+  };
+  return `${JSON.stringify(document, null, 2)}\n`;
+}

--- a/packages/gittensory-miner/scripts/benchmark.mjs
+++ b/packages/gittensory-miner/scripts/benchmark.mjs
@@ -12,6 +12,7 @@ import { resolveForgeConfig } from "../lib/forge-config.js";
 import { fetchWithRetry } from "../lib/http-retry.js";
 import {
   compareToBaseline,
+  findUncheckableCases,
   formatBenchmarkReport,
   renderBaselineDocument,
   runBenchmark,
@@ -29,6 +30,16 @@ import {
 const HERE = dirname(fileURLToPath(import.meta.url));
 const DEFAULT_BASELINE_PATH = resolve(HERE, "../benchmarks/baseline.json");
 
+// Per-case work sizes and defaults, named so a future tuner can see the intent rather than a bare literal. Each is
+// chosen to push the timed unit well above clock granularity (steadier numbers) without making a run slow.
+const THROTTLE_SWEEP_MAX_REMAINING = 300; // rate-limit-remaining values the throttle decision is swept across
+const CONFIG_BATCH_SIZE = 50; // forge-config / http-retry calls batched per timed iteration
+const SCHEDULER_ITEM_COUNT = 500; // items fed to the fanout scheduler / events seeded for the read case
+const FANOUT_CONCURRENCY = 5; // in-flight worker cap the scheduler benchmark drives
+const DEFAULT_ITERATIONS = 100;
+const DEFAULT_WARMUP = 10;
+const DEFAULT_REGRESSION_TOLERANCE = 0.25; // a case regresses when its mean exceeds baseline by more than this
+
 /** Each case's `make()` returns `{ fn, teardown? }`, or throws to mark the case unavailable in this environment. */
 const CASES = [
   {
@@ -37,9 +48,9 @@ const CASES = [
     make() {
       // The rate-limit-aware concurrency decision the fanout re-evaluates on every worker-loop iteration (#4844).
       const fn = () => {
-        for (let remaining = 0; remaining <= 300; remaining += 3) {
+        for (let remaining = 0; remaining <= THROTTLE_SWEEP_MAX_REMAINING; remaining += 3) {
           resolveThrottledConcurrency(
-            5,
+            FANOUT_CONCURRENCY,
             remaining,
             DEFAULT_RATE_LIMIT_LOW_WATER_MARK,
             DEFAULT_RATE_LIMIT_HIGH_WATER_MARK,
@@ -57,7 +68,7 @@ const CASES = [
       // granularity and the number is steadier.
       const overrides = { apiBaseUrl: "https://ghe.example.com/api/v3", userAgent: "gittensory-bench" };
       const fn = () => {
-        for (let index = 0; index < 50; index += 1) {
+        for (let index = 0; index < CONFIG_BATCH_SIZE; index += 1) {
           resolveForgeConfig(overrides);
           resolveForgeConfig({});
         }
@@ -74,7 +85,7 @@ const CASES = [
       const okFetch = async () => ({ status: 200 });
       const instantSleep = async () => {};
       const fn = async () => {
-        for (let index = 0; index < 50; index += 1) {
+        for (let index = 0; index < CONFIG_BATCH_SIZE; index += 1) {
           await fetchWithRetry(okFetch, "https://api.example.com/x", undefined, { sleepFn: instantSleep });
         }
       };
@@ -88,10 +99,10 @@ const CASES = [
       // The real bounded-concurrency scheduler that drives the fanout over many repos. Requires the package runtime
       // (the module imports the engine, which uses JSON import attributes).
       const { mapWithConcurrency } = await import("../lib/opportunity-fanout.js");
-      const items = Array.from({ length: 500 }, (_unused, index) => index);
+      const items = Array.from({ length: SCHEDULER_ITEM_COUNT }, (_unused, index) => index);
       const instantSleep = async () => {};
       const fn = async () => {
-        await mapWithConcurrency(items, 5, async (value) => value * 2, () => 5, instantSleep);
+        await mapWithConcurrency(items, FANOUT_CONCURRENCY, async (value) => value * 2, () => FANOUT_CONCURRENCY, instantSleep);
       };
       return { fn };
     },
@@ -127,7 +138,7 @@ const CASES = [
       const { initEventLedger } = await import("../lib/event-ledger.js"); // requires node:sqlite (Node >= 22.5)
       const root = mkdtempSync(join(tmpdir(), "gittensory-miner-bench-read-"));
       const ledger = initEventLedger(join(root, "event-ledger.sqlite3"));
-      for (let index = 0; index < 500; index += 1) {
+      for (let index = 0; index < SCHEDULER_ITEM_COUNT; index += 1) {
         ledger.appendEvent({ type: "discovered_issue", repoFullName: "acme/widgets", payload: { n: index } });
       }
       const fn = () => {
@@ -149,9 +160,9 @@ export function parseBenchmarkArgs(argv) {
     json: false,
     update: false,
     check: false,
-    iterations: 100,
-    warmup: 10,
-    tolerance: 0.25,
+    iterations: DEFAULT_ITERATIONS,
+    warmup: DEFAULT_WARMUP,
+    tolerance: DEFAULT_REGRESSION_TOLERANCE,
     baselinePath: DEFAULT_BASELINE_PATH,
   };
   for (let index = 0; index < argv.length; index += 1) {
@@ -215,7 +226,11 @@ function readBaseline(baselinePath) {
   if (!existsSync(baselinePath)) return null;
   try {
     return JSON.parse(readFileSync(baselinePath, "utf8"));
-  } catch {
+  } catch (error) {
+    // Surface the parse failure instead of swallowing it: a corrupted baseline must not look identical to "no
+    // baseline", which would silently disable regression checking on a bad commit (#4845).
+    const detail = error instanceof Error ? error.message : String(error);
+    process.stderr.write(`benchmark: failed to parse baseline at ${baselinePath}: ${detail}\n`);
     return null;
   }
 }
@@ -260,7 +275,19 @@ async function main(argv) {
           "\n",
       );
     }
-    if (options.check && regressions.length > 0) process.exit(1);
+    // A non-`ok` current run or a non-`ok` committed baseline yields `regressed: false`, so a `--check` that only
+    // looked at regressions would silently pass a baseline that cannot detect regressions for those cases (#4845).
+    // Fail `--check` loudly instead, pointing at the supported-runtime regeneration that produces a full baseline.
+    const uncheckable = options.check ? findUncheckableCases(results, baseline) : [];
+    if (options.check && uncheckable.length > 0) {
+      process.stderr.write(
+        "\nUncheckable cases (no regression signal; regenerate the baseline on the package-supported runtime " +
+          "(Node >= 22.13) with `npm run miner:bench -- --update-baseline`):\n" +
+          uncheckable.map((entry) => `  ${entry.name}: ${entry.reason}`).join("\n") +
+          "\n",
+      );
+    }
+    if (options.check && (regressions.length > 0 || uncheckable.length > 0)) process.exit(1);
   } else if (options.check) {
     process.stderr.write("benchmark: no baseline to check against; run with --update-baseline first.\n");
     process.exit(1);

--- a/packages/gittensory-miner/scripts/benchmark.mjs
+++ b/packages/gittensory-miner/scripts/benchmark.mjs
@@ -1,0 +1,272 @@
+#!/usr/bin/env node
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import {
+  DEFAULT_RATE_LIMIT_HIGH_WATER_MARK,
+  DEFAULT_RATE_LIMIT_LOW_WATER_MARK,
+  resolveThrottledConcurrency,
+} from "../lib/discovery-throttle.js";
+import { resolveForgeConfig } from "../lib/forge-config.js";
+import { fetchWithRetry } from "../lib/http-retry.js";
+import {
+  compareToBaseline,
+  formatBenchmarkReport,
+  renderBaselineDocument,
+  runBenchmark,
+} from "./benchmark-harness.mjs";
+
+// Committed micro-benchmark suite for the miner package (#4845), covering the two hot paths the issue names: the
+// discovery fanout and the local-store read/write path. Runs on demand (`npm run miner:bench`) and produces a
+// comparable, repeatable number per case, plus a committed baseline (`benchmarks/baseline.json`) to compare against.
+//
+// The two heaviest cases exercise real library code that requires the package's own runtime (Node >= 22.13:
+// `node:sqlite` for the stores, JSON import attributes in the engine that the fanout pulls in). They are imported
+// LAZILY and guarded, so this script still runs — and the lighter fanout-internal cases still produce real numbers —
+// on any Node, degrading an unavailable case to a recorded `unavailable` status instead of crashing.
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const DEFAULT_BASELINE_PATH = resolve(HERE, "../benchmarks/baseline.json");
+
+/** Each case's `make()` returns `{ fn, teardown? }`, or throws to mark the case unavailable in this environment. */
+const CASES = [
+  {
+    name: "discovery_throttle_resolve",
+    group: "discovery-fanout",
+    make() {
+      // The rate-limit-aware concurrency decision the fanout re-evaluates on every worker-loop iteration (#4844).
+      const fn = () => {
+        for (let remaining = 0; remaining <= 300; remaining += 3) {
+          resolveThrottledConcurrency(
+            5,
+            remaining,
+            DEFAULT_RATE_LIMIT_LOW_WATER_MARK,
+            DEFAULT_RATE_LIMIT_HIGH_WATER_MARK,
+          );
+        }
+      };
+      return { fn };
+    },
+  },
+  {
+    name: "forge_config_resolve",
+    group: "discovery-fanout",
+    make() {
+      // Per-fanout forge-config resolution (#4784). Batched per iteration so the timed unit is well above clock
+      // granularity and the number is steadier.
+      const overrides = { apiBaseUrl: "https://ghe.example.com/api/v3", userAgent: "gittensory-bench" };
+      const fn = () => {
+        for (let index = 0; index < 50; index += 1) {
+          resolveForgeConfig(overrides);
+          resolveForgeConfig({});
+        }
+      };
+      return { fn };
+    },
+  },
+  {
+    name: "http_retry_passthrough",
+    group: "discovery-fanout",
+    make() {
+      // The per-request retry wrapper every fanout fetch goes through (#4829); a 2xx returns on the first attempt.
+      // Batched per iteration so the timed unit is well above clock granularity.
+      const okFetch = async () => ({ status: 200 });
+      const instantSleep = async () => {};
+      const fn = async () => {
+        for (let index = 0; index < 50; index += 1) {
+          await fetchWithRetry(okFetch, "https://api.example.com/x", undefined, { sleepFn: instantSleep });
+        }
+      };
+      return { fn };
+    },
+  },
+  {
+    name: "discovery_fanout_scheduler",
+    group: "discovery-fanout",
+    async make() {
+      // The real bounded-concurrency scheduler that drives the fanout over many repos. Requires the package runtime
+      // (the module imports the engine, which uses JSON import attributes).
+      const { mapWithConcurrency } = await import("../lib/opportunity-fanout.js");
+      const items = Array.from({ length: 500 }, (_unused, index) => index);
+      const instantSleep = async () => {};
+      const fn = async () => {
+        await mapWithConcurrency(items, 5, async (value) => value * 2, () => 5, instantSleep);
+      };
+      return { fn };
+    },
+  },
+  {
+    name: "local_store_write",
+    group: "local-store",
+    async make() {
+      const { initEventLedger } = await import("../lib/event-ledger.js"); // requires node:sqlite (Node >= 22.5)
+      const root = mkdtempSync(join(tmpdir(), "gittensory-miner-bench-write-"));
+      const ledger = initEventLedger(join(root, "event-ledger.sqlite3"));
+      let counter = 0;
+      const fn = () => {
+        ledger.appendEvent({
+          type: "discovered_issue",
+          repoFullName: "acme/widgets",
+          payload: { n: counter++ },
+        });
+      };
+      return {
+        fn,
+        teardown: () => {
+          ledger.close();
+          rmSync(root, { recursive: true, force: true });
+        },
+      };
+    },
+  },
+  {
+    name: "local_store_read",
+    group: "local-store",
+    async make() {
+      const { initEventLedger } = await import("../lib/event-ledger.js"); // requires node:sqlite (Node >= 22.5)
+      const root = mkdtempSync(join(tmpdir(), "gittensory-miner-bench-read-"));
+      const ledger = initEventLedger(join(root, "event-ledger.sqlite3"));
+      for (let index = 0; index < 500; index += 1) {
+        ledger.appendEvent({ type: "discovered_issue", repoFullName: "acme/widgets", payload: { n: index } });
+      }
+      const fn = () => {
+        ledger.readEvents({ repoFullName: "acme/widgets" });
+      };
+      return {
+        fn,
+        teardown: () => {
+          ledger.close();
+          rmSync(root, { recursive: true, force: true });
+        },
+      };
+    },
+  },
+];
+
+export function parseBenchmarkArgs(argv) {
+  const options = {
+    json: false,
+    update: false,
+    check: false,
+    iterations: 100,
+    warmup: 10,
+    tolerance: 0.25,
+    baselinePath: DEFAULT_BASELINE_PATH,
+  };
+  for (let index = 0; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (token === "--json") options.json = true;
+    else if (token === "--update-baseline") options.update = true;
+    else if (token === "--check") options.check = true;
+    else if (token === "--iterations") options.iterations = readPositiveInt(argv[(index += 1)], options.iterations);
+    else if (token === "--warmup") options.warmup = readPositiveInt(argv[(index += 1)], options.warmup);
+    else if (token === "--tolerance") options.tolerance = readNumber(argv[(index += 1)], options.tolerance);
+    else if (token === "--baseline") options.baselinePath = argv[(index += 1)] ?? options.baselinePath;
+    else return { error: `Unknown option: ${token}` };
+  }
+  return options;
+}
+
+function readPositiveInt(raw, fallback) {
+  const value = Number(raw);
+  return Number.isInteger(value) && value > 0 ? value : fallback;
+}
+
+function readNumber(raw, fallback) {
+  const value = Number(raw);
+  return Number.isFinite(value) ? value : fallback;
+}
+
+/** Run every case, degrading an unavailable/erroring case to a recorded status rather than aborting the suite. */
+export async function runAllBenchmarks({ iterations, warmup } = {}) {
+  const results = [];
+  for (const benchCase of CASES) {
+    let made;
+    try {
+      made = await benchCase.make();
+    } catch (error) {
+      results.push({
+        name: benchCase.name,
+        group: benchCase.group,
+        status: "unavailable",
+        reason: error instanceof Error ? error.message.split("\n")[0] : String(error),
+      });
+      continue;
+    }
+    try {
+      const result = await runBenchmark(benchCase.name, made.fn, { iterations, warmup, group: benchCase.group });
+      results.push(result);
+    } catch (error) {
+      results.push({
+        name: benchCase.name,
+        group: benchCase.group,
+        status: "errored",
+        reason: error instanceof Error ? error.message.split("\n")[0] : String(error),
+      });
+    } finally {
+      if (typeof made.teardown === "function") await made.teardown();
+    }
+  }
+  return results;
+}
+
+function readBaseline(baselinePath) {
+  if (!existsSync(baselinePath)) return null;
+  try {
+    return JSON.parse(readFileSync(baselinePath, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+async function main(argv) {
+  const options = parseBenchmarkArgs(argv);
+  if ("error" in options) {
+    process.stderr.write(
+      `${options.error}\nUsage: node scripts/benchmark.mjs [--json] [--iterations N] [--warmup N] [--update-baseline] [--check] [--tolerance F] [--baseline PATH]\n`,
+    );
+    process.exit(2);
+  }
+
+  const results = await runAllBenchmarks({ iterations: options.iterations, warmup: options.warmup });
+
+  if (options.update) {
+    const document = renderBaselineDocument(results, {
+      nodeVersion: process.version,
+      generatedAt: new Date().toISOString(),
+    });
+    writeFileSync(options.baselinePath, document);
+    process.stdout.write(`benchmark: wrote baseline to ${options.baselinePath}\n`);
+    return;
+  }
+
+  if (options.json) {
+    process.stdout.write(`${JSON.stringify({ results }, null, 2)}\n`);
+  } else {
+    process.stdout.write(`${formatBenchmarkReport(results)}\n`);
+  }
+
+  const baseline = readBaseline(options.baselinePath);
+  if (baseline) {
+    const comparisons = compareToBaseline(results, baseline, { tolerance: options.tolerance });
+    const regressions = comparisons.filter((entry) => entry.regressed);
+    if (!options.json && regressions.length > 0) {
+      process.stderr.write(
+        `\nRegressions (> ${Math.round(options.tolerance * 100)}% over baseline):\n` +
+          regressions
+            .map((entry) => `  ${entry.name}: ${entry.current} ms vs ${entry.baseline} ms baseline`)
+            .join("\n") +
+          "\n",
+      );
+    }
+    if (options.check && regressions.length > 0) process.exit(1);
+  } else if (options.check) {
+    process.stderr.write("benchmark: no baseline to check against; run with --update-baseline first.\n");
+    process.exit(1);
+  }
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1] ?? "").href) {
+  await main(process.argv.slice(2));
+}

--- a/test/unit/miner-benchmark-harness.test.ts
+++ b/test/unit/miner-benchmark-harness.test.ts
@@ -114,12 +114,12 @@ describe("gittensory-miner benchmark harness (#4845)", () => {
     it("flags a case that regressed beyond the tolerance", () => {
       const [entry] = compareToBaseline([{ name: "fast", status: "ok", meanMs: 14 }], baseline, { tolerance: 0.25 });
       expect(entry).toMatchObject({ name: "fast", baseline: 10, current: 14, regressed: true });
-      expect(entry.deltaPct).toBeCloseTo(0.4, 5);
+      expect(entry?.deltaPct).toBeCloseTo(0.4, 5);
     });
 
     it("does not flag a case within tolerance (default 25%)", () => {
       const [entry] = compareToBaseline([{ name: "fast", status: "ok", meanMs: 11 }], baseline);
-      expect(entry.regressed).toBe(false);
+      expect(entry?.regressed).toBe(false);
     });
 
     it("treats a zero-mean baseline as a 0% delta", () => {

--- a/test/unit/miner-benchmark-harness.test.ts
+++ b/test/unit/miner-benchmark-harness.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   compareToBaseline,
+  findUncheckableCases,
   formatBenchmarkReport,
   renderBaselineDocument,
   roundMetric,
@@ -146,6 +147,55 @@ describe("gittensory-miner benchmark harness (#4845)", () => {
       expect(compareToBaseline([{ name: "x", status: "ok", meanMs: 1 }], null)).toEqual([
         { name: "x", baseline: null, current: 1, deltaPct: null, regressed: false },
       ]);
+    });
+  });
+
+  describe("findUncheckableCases", () => {
+    const baseline = {
+      results: [
+        { name: "ok_case", status: "ok", meanMs: 10 },
+        { name: "stale_unavailable", status: "unavailable", reason: "no node:sqlite" },
+      ],
+    };
+
+    it("flags a case whose committed baseline is non-ok even when it ran ok now", () => {
+      const uncheckable = findUncheckableCases(
+        [
+          { name: "ok_case", status: "ok", meanMs: 9 },
+          { name: "stale_unavailable", status: "ok", meanMs: 3 },
+        ],
+        baseline,
+      );
+      expect(uncheckable).toEqual([
+        { name: "stale_unavailable", reason: "baseline is unavailable (no node:sqlite)" },
+      ]);
+    });
+
+    it("flags a case that did not run ok in the current run", () => {
+      const uncheckable = findUncheckableCases(
+        [{ name: "ok_case", status: "unavailable", reason: "no node:sqlite" }],
+        baseline,
+      );
+      expect(uncheckable).toEqual([
+        { name: "ok_case", reason: "current run is unavailable (no node:sqlite)" },
+      ]);
+    });
+
+    it("omits the reason detail when a non-ok status carries no reason", () => {
+      const uncheckable = findUncheckableCases([{ name: "ok_case", status: "errored" }], baseline);
+      expect(uncheckable).toEqual([{ name: "ok_case", reason: "current run is errored" }]);
+    });
+
+    it("does not flag a brand-new case that ran ok but is absent from the baseline", () => {
+      expect(findUncheckableCases([{ name: "brand_new", status: "ok", meanMs: 1 }], baseline)).toEqual([]);
+    });
+
+    it("does not flag a case that is ok in both the run and the baseline", () => {
+      expect(findUncheckableCases([{ name: "ok_case", status: "ok", meanMs: 10 }], baseline)).toEqual([]);
+    });
+
+    it("tolerates a null/empty baseline document (new cases are not uncheckable)", () => {
+      expect(findUncheckableCases([{ name: "ok_case", status: "ok", meanMs: 1 }], null)).toEqual([]);
     });
   });
 

--- a/test/unit/miner-benchmark-harness.test.ts
+++ b/test/unit/miner-benchmark-harness.test.ts
@@ -1,0 +1,205 @@
+import { describe, expect, it } from "vitest";
+import {
+  compareToBaseline,
+  formatBenchmarkReport,
+  renderBaselineDocument,
+  roundMetric,
+  runBenchmark,
+  summarizeDurations,
+} from "../../packages/gittensory-miner/scripts/benchmark-harness.mjs";
+
+describe("gittensory-miner benchmark harness (#4845)", () => {
+  describe("summarizeDurations", () => {
+    it("returns all-zero stats for an empty sample", () => {
+      expect(summarizeDurations([])).toEqual({
+        iterations: 0,
+        totalMs: 0,
+        meanMs: 0,
+        medianMs: 0,
+        minMs: 0,
+        maxMs: 0,
+        opsPerSec: 0,
+      });
+    });
+
+    it("computes mean/median (odd length) and ops/sec", () => {
+      const stats = summarizeDurations([2, 1, 3]);
+      expect(stats).toMatchObject({ iterations: 3, totalMs: 6, meanMs: 2, medianMs: 2, minMs: 1, maxMs: 3 });
+      expect(stats.opsPerSec).toBeCloseTo(500, 5);
+    });
+
+    it("averages the two middle values for an even-length median", () => {
+      expect(summarizeDurations([10, 20, 30, 40]).medianMs).toBe(25);
+    });
+
+    it("reports zero ops/sec when every duration is zero", () => {
+      expect(summarizeDurations([0, 0]).opsPerSec).toBe(0);
+    });
+  });
+
+  describe("runBenchmark", () => {
+    it("times each iteration with the injected clock, after warmup, and labels the group", async () => {
+      let tick = 0;
+      const calls: string[] = [];
+      // now() is called twice per timed iteration (start, end); advance 5ms across each pair.
+      const now = () => {
+        tick += 5;
+        return tick;
+      };
+      const result = await runBenchmark(
+        "case",
+        () => {
+          calls.push("run");
+        },
+        { iterations: 3, warmup: 2, now, group: "grp" },
+      );
+      // 2 warmup + 3 timed invocations of fn.
+      expect(calls).toHaveLength(5);
+      expect(result).toMatchObject({ name: "case", group: "grp", status: "ok", iterations: 3, meanMs: 5, medianMs: 5 });
+    });
+
+    it("falls back to defaults for non-positive iterations/warmup", async () => {
+      let runs = 0;
+      const now = (() => {
+        let t = 0;
+        return () => (t += 1);
+      })();
+      const result = await runBenchmark(
+        "defaults",
+        () => {
+          runs += 1;
+        },
+        { iterations: 0, warmup: -1, now },
+      );
+      // default iterations=100 + default warmup=10.
+      expect(runs).toBe(110);
+      expect(result.iterations).toBe(100);
+      expect(result.group).toBe("");
+    });
+
+    it("awaits an async fn", async () => {
+      let done = false;
+      const now = (() => {
+        let t = 0;
+        return () => (t += 1);
+      })();
+      await runBenchmark(
+        "async",
+        async () => {
+          await Promise.resolve();
+          done = true;
+        },
+        { iterations: 1, warmup: 0, now },
+      );
+      expect(done).toBe(true);
+    });
+  });
+
+  describe("roundMetric", () => {
+    it("rounds to four decimal places", () => {
+      expect(roundMetric(0.0066123)).toBe(0.0066);
+      expect(roundMetric(152516.60984)).toBe(152516.6098);
+    });
+  });
+
+  describe("compareToBaseline", () => {
+    const baseline = {
+      results: [
+        { name: "fast", status: "ok", meanMs: 10 },
+        { name: "zero", status: "ok", meanMs: 0 },
+        { name: "was_unavailable", status: "unavailable" },
+      ],
+    };
+
+    it("flags a case that regressed beyond the tolerance", () => {
+      const [entry] = compareToBaseline([{ name: "fast", status: "ok", meanMs: 14 }], baseline, { tolerance: 0.25 });
+      expect(entry).toMatchObject({ name: "fast", baseline: 10, current: 14, regressed: true });
+      expect(entry.deltaPct).toBeCloseTo(0.4, 5);
+    });
+
+    it("does not flag a case within tolerance (default 25%)", () => {
+      const [entry] = compareToBaseline([{ name: "fast", status: "ok", meanMs: 11 }], baseline);
+      expect(entry.regressed).toBe(false);
+    });
+
+    it("treats a zero-mean baseline as a 0% delta", () => {
+      const [entry] = compareToBaseline([{ name: "zero", status: "ok", meanMs: 5 }], baseline);
+      expect(entry).toMatchObject({ deltaPct: 0, regressed: false });
+    });
+
+    it("never flags a non-ok current, a missing baseline, or a non-ok baseline", () => {
+      const comparisons = compareToBaseline(
+        [
+          { name: "fast", status: "unavailable" },
+          { name: "brand_new", status: "ok", meanMs: 3 },
+          { name: "was_unavailable", status: "ok", meanMs: 3 },
+        ],
+        baseline,
+      );
+      expect(comparisons.every((entry) => entry.regressed === false)).toBe(true);
+      expect(comparisons[0]).toMatchObject({ current: null, baseline: 10, deltaPct: null });
+      expect(comparisons[1]).toMatchObject({ current: 3, baseline: null, deltaPct: null });
+      expect(comparisons[2]).toMatchObject({ baseline: null, deltaPct: null });
+    });
+
+    it("tolerates a null/empty baseline document", () => {
+      expect(compareToBaseline([{ name: "x", status: "ok", meanMs: 1 }], null)).toEqual([
+        { name: "x", baseline: null, current: 1, deltaPct: null, regressed: false },
+      ]);
+    });
+  });
+
+  describe("formatBenchmarkReport", () => {
+    it("renders ok cases with numbers and non-ok cases with status/reason", () => {
+      const report = formatBenchmarkReport([
+        { name: "a", status: "ok", meanMs: 0.5, medianMs: 0.4, opsPerSec: 2000, iterations: 100 },
+        { name: "b", status: "unavailable", reason: "no node:sqlite" },
+        { name: "c", status: "errored" },
+      ]);
+      expect(report).toContain("a");
+      expect(report).toContain("ms mean");
+      expect(report).toContain("b");
+      expect(report).toContain("unavailable: no node:sqlite");
+      expect(report).toContain("c");
+      expect(report).toContain("errored");
+    });
+  });
+
+  describe("renderBaselineDocument", () => {
+    it("rounds ok results, preserves non-ok status/reason, and records provenance metadata", () => {
+      const doc = JSON.parse(
+        renderBaselineDocument(
+          [
+            {
+              name: "a",
+              group: "discovery-fanout",
+              status: "ok",
+              iterations: 200,
+              meanMs: 0.006612,
+              medianMs: 0.0057,
+              minMs: 0.0041,
+              maxMs: 0.1329,
+              opsPerSec: 152516.6098,
+            },
+            { name: "b", group: "local-store", status: "unavailable", reason: "no node:sqlite" },
+            { name: "c", status: "errored" },
+          ],
+          { nodeVersion: "v22.13.0", generatedAt: "2026-01-01T00:00:00.000Z" },
+        ),
+      );
+      expect(doc.nodeVersion).toBe("v22.13.0");
+      expect(doc.generatedAt).toBe("2026-01-01T00:00:00.000Z");
+      expect(doc.note).toContain("#4845");
+      expect(doc.results[0]).toMatchObject({ name: "a", status: "ok", meanMs: 0.0066 });
+      expect(doc.results[1]).toMatchObject({ name: "b", status: "unavailable", reason: "no node:sqlite" });
+      expect(doc.results[2]).toMatchObject({ name: "c", group: "", status: "errored", reason: null });
+    });
+
+    it("defaults provenance metadata to null when omitted", () => {
+      const doc = JSON.parse(renderBaselineDocument([]));
+      expect(doc.nodeVersion).toBeNull();
+      expect(doc.generatedAt).toBeNull();
+      expect(doc.results).toEqual([]);
+    });
+  });
+});


### PR DESCRIPTION
Closes #4845 

## Summary

There was no profiling or benchmark data anywhere for the miner package, so a future change had no baseline to
tell whether discovery/claiming got faster or slower. This adds a small, committed micro-benchmark suite covering
the two hot paths the issue names — the **discovery fanout** and the **local-store read/write** path — plus a
committed baseline result and an on-demand runner.

## What's in it

- **`packages/gittensory-miner/scripts/benchmark-harness.mjs`** — a pure, dependency-free timing/stats/report
  harness (`summarizeDurations`, `runBenchmark` with an injectable clock, `formatBenchmarkReport`,
  `compareToBaseline`, `renderBaselineDocument`, `roundMetric`). It measures only; the caller applies a tolerance,
  so a timing wobble can never become a hard failure on its own.
- **`packages/gittensory-miner/scripts/benchmark.mjs`** — the runnable suite (`npm run miner:bench`) with flags
  `--json`, `--iterations N`, `--warmup N`, `--update-baseline`, `--check`, `--tolerance F`, `--baseline PATH`.
  Cases:
  - `discovery_throttle_resolve`, `forge_config_resolve`, `http_retry_passthrough` — real fanout-internal hot
    paths (#4844 / #4784 / #4829); importable on any Node, so they produce a real committed number today.
  - `discovery_fanout_scheduler` — the real bounded-concurrency scheduler (`mapWithConcurrency`).
  - `local_store_write` / `local_store_read` — real `appendEvent` / `readEvents` against a temp SQLite event
    ledger.

  The last three exercise code that needs the package's own runtime (**Node >= 22.13** — `node:sqlite` for the
  stores; the engine's JSON import attributes that the fanout imports). They are lazily imported and guarded, so an
  unavailable case is recorded as `unavailable` rather than crashing the run.
- **`packages/gittensory-miner/benchmarks/baseline.json`** — the committed baseline result (rounded numbers +
  `nodeVersion` / `generatedAt` provenance).
- **`packages/gittensory-miner/benchmarks/README.md`** — how to run, the case table, and the machine-dependence
  caveat.
- **`package.json`** — adds the `miner:bench` script.
- **`packages/gittensory-miner/README.md`** — a pointer to the suite.

## Design notes

- **Why `--check` is not wired into the required CI gate:** timing is machine-dependent, and micro-benchmark
  numbers jitter. A hard timing gate would be flaky, so `--check` is on-demand only; the acceptance criterion
  ("runs in CI or on demand and produces a comparable, repeatable number") is met by the on-demand runner + the
  committed baseline.
- **Scope:** the new files live under `scripts/` and `benchmarks/`, i.e. outside `packages/gittensory-miner/lib/**`,
  so they add no `src/**`/`lib/**` Codecov surface. The pure harness is unit-tested regardless.

## Testing

- `test/unit/miner-benchmark-harness.test.ts` — covers `summarizeDurations` (empty / odd / even / all-zero),
  `runBenchmark` (injected clock, warmup counting, defaults, async fn), `roundMetric`, `compareToBaseline`
  (regressed / within-tolerance / zero baseline / non-ok / missing / null document), `formatBenchmarkReport`, and
  `renderBaselineDocument` (rounding, non-ok passthrough, provenance defaults).
- Verified locally (Node 18 sandbox): `node --check` on both scripts; a standalone driver reproducing every
  harness assertion passed; `npm run miner:bench` renders the report + baseline comparison; `--check` exits
  non-zero on a regression; an unknown flag exits 2; `npm run miner:env-reference:check` is unaffected.

## Note for the reviewer / CI

The committed `baseline.json` was generated in a **Node 18** sandbox, where the three runtime-agnostic
fanout-internal cases produce real numbers and the three Node-22-only cases (`discovery_fanout_scheduler`,
`local_store_write`, `local_store_read`) are recorded as `unavailable`. Regenerate on the package's own runtime to
capture all six:

```sh
npm run miner:bench -- --update-baseline
```

`npm run test:ci` and `npm run test:coverage` must be run under Node >= 22.13 (the sandbox is Node 18, so vitest
could not be executed here).
