### PR TITLE
feat(miner): publish operational files (DEPLOYMENT.md, docs, Dockerfile, schema) in the npm package (#4874)

### DIFF
--- a/packages/gittensory-miner/package.json
+++ b/packages/gittensory-miner/package.json
@@ -30,6 +30,10 @@
   "files": [
     "bin",
     "lib",
+    "docs",
+    "schema",
+    "DEPLOYMENT.md",
+    "Dockerfile",
     "expected-engine.version"
   ],
   "scripts": {

--- a/scripts/check-miner-package.mjs
+++ b/scripts/check-miner-package.mjs
@@ -11,8 +11,20 @@ const ALLOWED = [
   /^package\.json$/,
   /^README\.md$/,
   /^expected-engine\.version$/,
+  // Operational material shipped for `npm install -g` users so the quickstart doesn't require a repo visit (#4874):
+  /^DEPLOYMENT\.md$/,
+  /^Dockerfile$/,
+  /^docs\/[a-z0-9-]+\.md$/,
+  /^schema\/[a-z0-9.-]+\.json$/,
 ];
-const REQUIRED = ["bin/gittensory-miner.js", "package.json"];
+const REQUIRED = [
+  "bin/gittensory-miner.js",
+  "package.json",
+  // The operational files #4874 shipped — asserted present so they can never silently drop out of the package again.
+  "DEPLOYMENT.md",
+  "Dockerfile",
+  "schema/miner-goal-spec.schema.json",
+];
 const FORBIDDEN_PATH = /(^|\/)(\.dev\.vars|\.env|\.npmrc|.*\.pem|.*private.*key.*|.*secret.*)$/i;
 const FORBIDDEN_CONTENT =
   /(BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY|github_pat_[A-Za-z0-9_]+|gh[pousr]_[A-Za-z0-9_]+|gts_[0-9a-f]{64}|[A-Z0-9_]*(TOKEN|SECRET|PRIVATE_KEY)=)/;
@@ -30,6 +42,9 @@ export function validateMinerPackFileList(files, readContent) {
   }
   if (!paths.some((file) => /^lib\/([a-z0-9-]+\/)?[a-z0-9-]+\.js$/.test(file))) {
     throw new Error("Miner package is missing lib/*.js artifacts");
+  }
+  if (!paths.some((file) => /^docs\/[a-z0-9-]+\.md$/.test(file))) {
+    throw new Error("Miner package is missing docs/*.md operational documentation");
   }
   return paths;
 }

--- a/test/unit/check-miner-package.test.ts
+++ b/test/unit/check-miner-package.test.ts
@@ -85,7 +85,14 @@ describe("check-miner-package script", () => {
 
   it("rejects a package missing lib artifacts", () => {
     const result = runChecker({
-      CHECK_MINER_PACK_TEST_FILES: JSON.stringify(["package.json", "bin/gittensory-miner.js"]),
+      // Every REQUIRED file present so the check reaches (and fails on) the lib-artifacts guard specifically.
+      CHECK_MINER_PACK_TEST_FILES: JSON.stringify([
+        "package.json",
+        "bin/gittensory-miner.js",
+        "DEPLOYMENT.md",
+        "Dockerfile",
+        "schema/miner-goal-spec.schema.json",
+      ]),
       CHECK_MINER_PACK_TEST_CONTENT: "{}",
     });
     expect(result.status).toBe(1);
@@ -100,5 +107,65 @@ describe("check-miner-package script", () => {
     });
     expect(result.status).toBe(1);
     expect(result.out).toContain("Secret-like content found in miner package file:");
+  });
+
+  describe("operational files (#4874)", () => {
+    // A complete, valid package including the operational material — DEPLOYMENT.md, the Dockerfile, a docs/*.md,
+    // and the schema — is accepted.
+    const FULL_PACKAGE = [
+      "package.json",
+      "bin/gittensory-miner.js",
+      "lib/cli.js",
+      "DEPLOYMENT.md",
+      "Dockerfile",
+      "docs/coding-agent-driver.md",
+      "schema/miner-goal-spec.schema.json",
+    ];
+
+    it("accepts DEPLOYMENT.md, the Dockerfile, docs/*.md, and schema/*.json", () => {
+      const result = runChecker({
+        CHECK_MINER_PACK_TEST_FILES: JSON.stringify(FULL_PACKAGE),
+        CHECK_MINER_PACK_TEST_CONTENT: "operational docs, nothing secret",
+      });
+      expect(result.status).toBe(0);
+      expect(result.out).toMatch(/^Miner package dry-run ok:/);
+      expect(result.out).toContain("DEPLOYMENT.md");
+      expect(result.out).toContain("docs/coding-agent-driver.md");
+      expect(result.out).toContain("schema/miner-goal-spec.schema.json");
+    });
+
+    it("requires DEPLOYMENT.md to be published (regression guard for #4874)", () => {
+      const result = runChecker({
+        CHECK_MINER_PACK_TEST_FILES: JSON.stringify(FULL_PACKAGE.filter((f) => f !== "DEPLOYMENT.md")),
+        CHECK_MINER_PACK_TEST_CONTENT: "ok",
+      });
+      expect(result.status).toBe(1);
+      expect(result.out).toContain("Miner package is missing required file: DEPLOYMENT.md");
+    });
+
+    it("requires at least one docs/*.md file to be published", () => {
+      const result = runChecker({
+        CHECK_MINER_PACK_TEST_FILES: JSON.stringify(FULL_PACKAGE.filter((f) => !f.startsWith("docs/"))),
+        CHECK_MINER_PACK_TEST_CONTENT: "ok",
+      });
+      expect(result.status).toBe(1);
+      expect(result.out).toContain("Miner package is missing docs/*.md operational documentation");
+    });
+
+    it("keeps the docs allowlist tight — a non-.md or nested docs file is still rejected", () => {
+      const nonMarkdown = runChecker({
+        CHECK_MINER_PACK_TEST_FILES: JSON.stringify([...FULL_PACKAGE, "docs/notes.txt"]),
+        CHECK_MINER_PACK_TEST_CONTENT: "ok",
+      });
+      expect(nonMarkdown.status).toBe(1);
+      expect(nonMarkdown.out).toContain("Unexpected file in miner package: docs/notes.txt");
+
+      const nested = runChecker({
+        CHECK_MINER_PACK_TEST_FILES: JSON.stringify([...FULL_PACKAGE, "docs/nested/guide.md"]),
+        CHECK_MINER_PACK_TEST_CONTENT: "ok",
+      });
+      expect(nested.status).toBe(1);
+      expect(nested.out).toContain("Unexpected file in miner package: docs/nested/guide.md");
+    });
   });
 });


### PR DESCRIPTION
## Summary

The published `@jsonbored/gittensory-miner` package's `files` list was `["bin", "lib", "expected-engine.version"]`, so an `npm install -g` user — the README's own quickstart path — had no access to the package's operational material (`DEPLOYMENT.md`, the `docs/` directory, the `Dockerfile`, or the `schema/` directory) without separately visiting the GitHub repo.

This ships that material with the package:

- **`package.json`** — adds `docs`, `schema`, `DEPLOYMENT.md`, and `Dockerfile` to `files`.
- **`scripts/check-miner-package.mjs`** (the `test:miner-pack` gate, an allowlist over the packed file set) — extends `ALLOWED` to permit those paths (`DEPLOYMENT.md`, `Dockerfile`, `docs/*.md`, `schema/*.json`), adds `DEPLOYMENT.md` / `Dockerfile` / `schema/miner-goal-spec.schema.json` to `REQUIRED`, and adds a `docs/*.md` presence check — so the operational files are now a *published guarantee*, asserted on every pack, not just a one-time addition that could silently regress.
- **Tests** — a complete package (incl. the operational files) is accepted; each of DEPLOYMENT.md and a docs file being absent is rejected with a specific message; and the docs allowlist stays tight (a non-`.md` or nested docs file is still rejected).

Verified against the real `npm pack --dry-run` output: all four categories now appear in the packed set and pass the check. The allowlist is deliberately kept narrow (only `docs/*.md` and `schema/*.json`, not arbitrary nested paths), consistent with the existing `lib/` flattening discipline.

Closes #4874

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (Closes #4874).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:miner-pack` logic verified: the real `npm pack --dry-run` file list (205 files) fed through `check-miner-package.mjs` passes and includes `DEPLOYMENT.md`, `Dockerfile`, `docs/*.md`, and `schema/miner-goal-spec.schema.json`. Unit tests in `check-miner-package.test.ts` (fixed 1 order-affected case + 4 new operational-file cases) pass; the sole failing case (`passes on the real workspace package`) is a pre-existing Windows-only `npm`-spawn issue that fails identically on `main` and passes on CI/Linux.
- [ ] `npm run test:workers` · `build:mcp` · `ui:*` — N/A (miner package `files` + its pack-check script/tests only).

If any required check was skipped, explain why:

Change is confined to the miner package's `files` list, the `test:miner-pack` check script, and that script's unit tests. No worker `src/**`, workflow, MCP, OpenAPI, or UI surface is touched.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed. The pack check's existing secret-content scan runs over every newly-published file; the operational files were confirmed free of secret-like patterns, and the scan now guards them on every pack.
- [x] Public GitHub text stays sanitized and low-noise.
- [x] Auth/CORS/session negative-path tests — N/A.
- [x] API/OpenAPI/MCP behavior updated/tested — N/A.
- [x] UI changes use real states — N/A (no UI).
- [x] Visible UI changes include UI Evidence — N/A.
- [x] Public docs/changelogs updated where needed — N/A (publishes existing docs; no changelog edit).

## UI Evidence

N/A — packaging change, no UI.

## Notes

- The operational files are added to `REQUIRED` (not just `ALLOWED`) so the pack check now fails if any of them is ever dropped from the package again — turning #4874 into an enforced invariant rather than a one-off fix.
- `README.md` is already published (npm includes it by default); only the four categories the issue named were missing.
