### PR TITLE
feat(miner-extension): reject oversized pasted ranked-candidates JSON before saving

### DIFF
--- a/apps/gittensory-miner-extension/README.md
+++ b/apps/gittensory-miner-extension/README.md
@@ -23,3 +23,7 @@ every save, and looks up the current issue there. When no ranked signal is cache
 degrades gracefully by staying hidden. The badge itself shows a "last synced" relative-time label (mirroring ORB's
 shared `RefreshMeta` component's thresholds) so a contributor can tell how stale the pasted data is; the label is
 omitted entirely for a cache saved before this field existed.
+
+The extension does not request the `unlimitedStorage` permission, so a paste is rejected with a clear error before
+being parsed or saved once it exceeds a conservative size bound well under `chrome.storage.local`'s default 10 MiB
+quota, instead of silently failing to save or leaving storage partially written.

--- a/apps/gittensory-miner-extension/options.js
+++ b/apps/gittensory-miner-extension/options.js
@@ -7,17 +7,21 @@ function parseWatchedRepos(text) {
 
 // This extension does not request the "unlimitedStorage" permission, so chrome.storage.local is capped at its
 // default 10 MiB (QUOTA_BYTES) quota shared across every key -- an unbounded paste can silently fail to save
-// or leave storage in a partial state (#4863). Checked against the raw pasted text's UTF-16 length (not a
-// TextEncoder byte count) so this stays a plain, portable JS check usable from an unbundled content script;
-// it's a conservative proxy for the eventual serialized size, with headroom under the 10 MiB quota.
-const MAX_RANKED_CANDIDATES_JSON_CHARS = 8 * 1024 * 1024;
+// or leave storage in a partial state (#4863). Measured with TextEncoder against the actual serialized UTF-8
+// byte size, NOT the pasted text's UTF-16 .length -- a char count undercounts any multibyte content (e.g. a
+// non-ASCII repo/issue title), so a payload that passes a char-based check could still exceed the real quota at
+// chrome.storage.local.set, recreating the exact silent-failure bug this guard exists to prevent. TextEncoder is
+// a standard Web API available in both the real extension runtime and this repo's node:vm test harness (once
+// injected into the sandbox context).
+const MAX_RANKED_CANDIDATES_JSON_BYTES = 8 * 1024 * 1024;
 
 function parseRankedCandidatesJson(text) {
   const trimmed = String(text ?? "").trim();
   if (!trimmed) return [];
-  if (trimmed.length > MAX_RANKED_CANDIDATES_JSON_CHARS) {
+  const byteLength = new TextEncoder().encode(trimmed).length;
+  if (byteLength > MAX_RANKED_CANDIDATES_JSON_BYTES) {
     throw new Error(
-      `Ranked candidates JSON is too large (${trimmed.length.toLocaleString()} characters; limit ${MAX_RANKED_CANDIDATES_JSON_CHARS.toLocaleString()}). Paste a smaller discover-run export.`,
+      `Ranked candidates JSON is too large (${byteLength.toLocaleString()} bytes; limit ${MAX_RANKED_CANDIDATES_JSON_BYTES.toLocaleString()}). Paste a smaller discover-run export.`,
     );
   }
   const parsed = JSON.parse(trimmed);
@@ -41,7 +45,7 @@ if (globalThis.__GITTENSORY_MINER_EXTENSION_TEST__) {
     parseWatchedRepos,
     parseRankedCandidatesJson,
     removeLegacyDiscoveryIndexUrl,
-    MAX_RANKED_CANDIDATES_JSON_CHARS,
+    MAX_RANKED_CANDIDATES_JSON_BYTES,
   };
 }
 

--- a/apps/gittensory-miner-extension/options.js
+++ b/apps/gittensory-miner-extension/options.js
@@ -5,9 +5,21 @@ function parseWatchedRepos(text) {
     .filter(Boolean);
 }
 
+// This extension does not request the "unlimitedStorage" permission, so chrome.storage.local is capped at its
+// default 10 MiB (QUOTA_BYTES) quota shared across every key -- an unbounded paste can silently fail to save
+// or leave storage in a partial state (#4863). Checked against the raw pasted text's UTF-16 length (not a
+// TextEncoder byte count) so this stays a plain, portable JS check usable from an unbundled content script;
+// it's a conservative proxy for the eventual serialized size, with headroom under the 10 MiB quota.
+const MAX_RANKED_CANDIDATES_JSON_CHARS = 8 * 1024 * 1024;
+
 function parseRankedCandidatesJson(text) {
   const trimmed = String(text ?? "").trim();
   if (!trimmed) return [];
+  if (trimmed.length > MAX_RANKED_CANDIDATES_JSON_CHARS) {
+    throw new Error(
+      `Ranked candidates JSON is too large (${trimmed.length.toLocaleString()} characters; limit ${MAX_RANKED_CANDIDATES_JSON_CHARS.toLocaleString()}). Paste a smaller discover-run export.`,
+    );
+  }
   const parsed = JSON.parse(trimmed);
   if (!Array.isArray(parsed)) {
     throw new Error("Ranked candidates JSON must be an array.");
@@ -29,6 +41,7 @@ if (globalThis.__GITTENSORY_MINER_EXTENSION_TEST__) {
     parseWatchedRepos,
     parseRankedCandidatesJson,
     removeLegacyDiscoveryIndexUrl,
+    MAX_RANKED_CANDIDATES_JSON_CHARS,
   };
 }
 

--- a/test/unit/miner-extension-content.test.ts
+++ b/test/unit/miner-extension-content.test.ts
@@ -151,7 +151,7 @@ describe("miner extension opportunity badge", () => {
   it("rejects a pasted ranked-candidates JSON payload over the storage-size bound with a clear error, before ever attempting to parse it (#4863)", () => {
     const internals = loadOptionsInternals();
     const oversized = "not valid json but that must not matter".padEnd(
-      internals.MAX_RANKED_CANDIDATES_JSON_CHARS + 1,
+      internals.MAX_RANKED_CANDIDATES_JSON_BYTES + 1,
       "x",
     );
 
@@ -167,11 +167,23 @@ describe("miner extension opportunity badge", () => {
 
   it("accepts a pasted ranked-candidates JSON payload exactly at the storage-size bound (#4863)", () => {
     const internals = loadOptionsInternals();
-    const padding = "x".repeat(internals.MAX_RANKED_CANDIDATES_JSON_CHARS - 4);
+    const padding = "x".repeat(internals.MAX_RANKED_CANDIDATES_JSON_BYTES - 4);
     const atLimit = `["${padding}"]`;
-    expect(atLimit).toHaveLength(internals.MAX_RANKED_CANDIDATES_JSON_CHARS);
+    expect(atLimit).toHaveLength(internals.MAX_RANKED_CANDIDATES_JSON_BYTES);
 
     expect(internals.parseRankedCandidatesJson(atLimit)).toEqual([padding]);
+  });
+
+  it("REGRESSION (gate-caught): measures real UTF-8 byte size, not UTF-16 character count, so multibyte content can't sneak past the bound (#4863)", () => {
+    const internals = loadOptionsInternals();
+    // "é" is 1 UTF-16 code unit but 2 UTF-8 bytes -- a char-length check would see roughly half the real byte
+    // size and wrongly accept a payload that actually exceeds the quota once chrome.storage.local serializes it.
+    const halfLimitCharCount = Math.floor(internals.MAX_RANKED_CANDIDATES_JSON_BYTES / 2) + 10;
+    const padding = "é".repeat(halfLimitCharCount);
+    const payload = `["${padding}"]`;
+
+    expect(payload.length).toBeLessThan(internals.MAX_RANKED_CANDIDATES_JSON_BYTES);
+    expect(() => internals.parseRankedCandidatesJson(payload)).toThrow(/too large/i);
   });
 
   it("regression: an oversized paste surfaces its error through the save flow and never reaches chrome.storage.local.set (#4863)", async () => {
@@ -184,6 +196,7 @@ describe("miner extension opportunity badge", () => {
     };
     const context: Record<string, unknown> = {
       __GITTENSORY_MINER_EXTENSION_TEST__: true,
+      TextEncoder,
       document: { querySelector: (selector: string) => elements[selector as keyof typeof elements] ?? null },
       chrome: {
         storage: {
@@ -203,8 +216,8 @@ describe("miner extension opportunity badge", () => {
     new Script(optionsScript).runInContext(vmContext);
     await flushPromises();
 
-    const internals = vmContext.__gittensoryMinerOptionsInternals as { MAX_RANKED_CANDIDATES_JSON_CHARS: number };
-    elements["#rankedCandidatesJson"].value = "x".repeat(internals.MAX_RANKED_CANDIDATES_JSON_CHARS + 1);
+    const internals = vmContext.__gittensoryMinerOptionsInternals as { MAX_RANKED_CANDIDATES_JSON_BYTES: number };
+    elements["#rankedCandidatesJson"].value = "x".repeat(internals.MAX_RANKED_CANDIDATES_JSON_BYTES + 1);
     await elements["#settings"].dispatchSubmit();
 
     expect(elements["#status"].textContent).toMatch(/too large/i);
@@ -321,6 +334,7 @@ describe("miner extension opportunity badge", () => {
     const context: Record<string, unknown> = {
       __GITTENSORY_MINER_EXTENSION_TEST__: true,
       Date: { now: () => fakeNowMs },
+      TextEncoder,
       document: { querySelector: (selector: string) => elements[selector as keyof typeof elements] ?? null },
       chrome: {
         storage: {
@@ -370,6 +384,7 @@ describe("miner extension opportunity badge", () => {
     };
     const context: Record<string, unknown> = {
       __GITTENSORY_MINER_EXTENSION_TEST__: true,
+      TextEncoder,
       document: { querySelector: (selector: string) => elements[selector as keyof typeof elements] ?? null },
       chrome: {
         storage: {
@@ -529,6 +544,7 @@ function loadBackgroundInternals({
 function loadOptionsInternals() {
   const context: Record<string, unknown> = {
     __GITTENSORY_MINER_EXTENSION_TEST__: true,
+    TextEncoder,
     document: { querySelector: () => null },
     chrome: {
       storage: {
@@ -545,6 +561,6 @@ function loadOptionsInternals() {
     parseWatchedRepos: (text: string) => string[];
     parseRankedCandidatesJson: (text: string) => unknown[];
     removeLegacyDiscoveryIndexUrl: () => Promise<void>;
-    MAX_RANKED_CANDIDATES_JSON_CHARS: number;
+    MAX_RANKED_CANDIDATES_JSON_BYTES: number;
   };
 }

--- a/test/unit/miner-extension-content.test.ts
+++ b/test/unit/miner-extension-content.test.ts
@@ -148,6 +148,69 @@ describe("miner extension opportunity badge", () => {
     expect(() => internals.parseRankedCandidatesJson('{"not":"array"}')).toThrow();
   });
 
+  it("rejects a pasted ranked-candidates JSON payload over the storage-size bound with a clear error, before ever attempting to parse it (#4863)", () => {
+    const internals = loadOptionsInternals();
+    const oversized = "not valid json but that must not matter".padEnd(
+      internals.MAX_RANKED_CANDIDATES_JSON_CHARS + 1,
+      "x",
+    );
+
+    expect(() => internals.parseRankedCandidatesJson(oversized)).toThrow(/too large/i);
+    // Invariant: the size check runs before JSON.parse, so an oversized-but-invalid payload fails on size,
+    // not on a JSON syntax error -- proven by using text that isn't valid JSON at all.
+    try {
+      internals.parseRankedCandidatesJson(oversized);
+    } catch (error) {
+      expect(String(error)).not.toMatch(/Unexpected token/i);
+    }
+  });
+
+  it("accepts a pasted ranked-candidates JSON payload exactly at the storage-size bound (#4863)", () => {
+    const internals = loadOptionsInternals();
+    const padding = "x".repeat(internals.MAX_RANKED_CANDIDATES_JSON_CHARS - 4);
+    const atLimit = `["${padding}"]`;
+    expect(atLimit).toHaveLength(internals.MAX_RANKED_CANDIDATES_JSON_CHARS);
+
+    expect(internals.parseRankedCandidatesJson(atLimit)).toEqual([padding]);
+  });
+
+  it("regression: an oversized paste surfaces its error through the save flow and never reaches chrome.storage.local.set (#4863)", async () => {
+    const localSetCalls: Array<Record<string, unknown>> = [];
+    const elements = {
+      "#settings": createFormMock(),
+      "#status": { textContent: "" },
+      "#watchedRepos": { value: "JSONbored/gittensory" },
+      "#rankedCandidatesJson": { value: "" },
+    };
+    const context: Record<string, unknown> = {
+      __GITTENSORY_MINER_EXTENSION_TEST__: true,
+      document: { querySelector: (selector: string) => elements[selector as keyof typeof elements] ?? null },
+      chrome: {
+        storage: {
+          sync: { get: async () => ({ watchedRepos: [] }), set: async () => {}, remove: async () => {} },
+          local: {
+            get: async () => ({ rankedCandidates: [] }),
+            set: async (value: Record<string, unknown>) => {
+              localSetCalls.push(value);
+            },
+          },
+        },
+      },
+      window: { setTimeout: () => 0 },
+    };
+    context.globalThis = context;
+    const vmContext = createContext(context);
+    new Script(optionsScript).runInContext(vmContext);
+    await flushPromises();
+
+    const internals = vmContext.__gittensoryMinerOptionsInternals as { MAX_RANKED_CANDIDATES_JSON_CHARS: number };
+    elements["#rankedCandidatesJson"].value = "x".repeat(internals.MAX_RANKED_CANDIDATES_JSON_CHARS + 1);
+    await elements["#settings"].dispatchSubmit();
+
+    expect(elements["#status"].textContent).toMatch(/too large/i);
+    expect(localSetCalls).toHaveLength(0);
+  });
+
   it("REGRESSION (dead-field removal): no discoveryIndexUrl config field remains in the UI or background reads", () => {
     expect(optionsHtml).not.toMatch(/discoveryIndexUrl/);
     expect(backgroundScript).not.toMatch(/discoveryIndexUrl/);
@@ -482,5 +545,6 @@ function loadOptionsInternals() {
     parseWatchedRepos: (text: string) => string[];
     parseRankedCandidatesJson: (text: string) => unknown[];
     removeLegacyDiscoveryIndexUrl: () => Promise<void>;
+    MAX_RANKED_CANDIDATES_JSON_CHARS: number;
   };
 }


### PR DESCRIPTION
## Summary

- The miner extension accepted an arbitrarily large pasted JSON blob into the options page's ranked-candidates
  textarea with no size bound at all. The extension does not request the `unlimitedStorage` permission, so
  `chrome.storage.local` is capped at its default ~10 MiB `QUOTA_BYTES` quota shared across every key — an
  oversized paste could silently fail to save (Chrome rejects the `set()` call) or leave storage in a partial
  state, with no clear feedback to the contributor about why.
- `options.js`'s `parseRankedCandidatesJson` now measures the pasted text's real **UTF-8 byte size** via
  `new TextEncoder().encode(trimmed).length` and rejects anything over a new `MAX_RANKED_CANDIDATES_JSON_BYTES`
  bound (8 MiB) **before** attempting `JSON.parse` — so an oversized-but-invalid paste fails with a clear
  "too large" error rather than a confusing JSON syntax error, and a valid-but-oversized paste never reaches
  `chrome.storage.local.set` at all.
- `TextEncoder` is a standard Web API available in both the real (unbundled) extension runtime and, once
  injected into the sandbox context, this repo's `node:vm`-based unit-test harness for these scripts — it is
  not present in a bare `vm.createContext({})` by default, which the test helpers now account for.

Fixes #4863

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — this change lives entirely under `apps/gittensory-miner-extension/**` and its dedicated test file `test/unit/miner-extension-content.test.ts`, outside vitest's root `coverage.include` glob (only root `src/**` is Codecov-measured), so `codecov/patch` cannot see this diff.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

Ran the full local gate: `npm run test:ci` (798 test files, 0 failures) and `npm audit --audit-level=moderate` (0 vulnerabilities), both clean on the final commit.

Test coverage added to `test/unit/miner-extension-content.test.ts` (now 22 tests total, up from 18): rejecting a payload one byte over the bound with a clear "too large" error, and specifically asserting the size check fires before `JSON.parse` runs (proven with a non-JSON oversized string, checking the thrown error is not a JSON syntax error); accepting a payload of exactly the boundary byte length; a regression test driving the real form-submit save flow end-to-end with an oversized paste, asserting the error surfaces through `showStatus` and `chrome.storage.local.set` is never called (zero partial writes); and a dedicated regression test using `"é"`-character padding (1 UTF-16 code unit but 2 UTF-8 bytes each), sized so it would have wrongly *passed* a naive character-length check while its real byte size exceeds the bound — proving multibyte content can't sneak past the guard.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no auth/session/CORS surface touched (local `chrome.storage` only).
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — no public API/OpenAPI/MCP surface touched; this only guards a local `chrome.storage.local` write path.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — the error path is driven through the real `parseRankedCandidatesJson`/`showStatus` code, not a mock of the validation itself.
- [x] Visible UI changes include a `UI Evidence` section below.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — updated `apps/gittensory-miner-extension/README.md`'s "Local ranked cache" section.

## UI Evidence

This is a browser extension options page — there is no hosted/public deployment to screenshot from this
environment (no browser screenshot tooling available here). Verified functionally instead: `npm run test:ci`
includes the full `test/unit/miner-extension-content.test.ts` suite (22/22 passing), including a regression test
that drives the real options-page save flow with an oversized paste and asserts the visible status message
matches `/too large/i` while `chrome.storage.local.set` is never invoked.

## Notes

- A first attempt at this issue (PR #5525) was correctly auto-closed by the Gittensory gate: it measured the
  pasted text's UTF-16 `.length` (character count) instead of actual byte size, so a payload full of multibyte
  characters could pass the check yet still exceed the real `chrome.storage.local` quota once serialized,
  recreating the exact silent-failure bug the guard exists to prevent. This PR fixes that by measuring real
  UTF-8 bytes via `TextEncoder` instead, with the `"é"`-padding regression test above proving the fix — that
  same input would have passed the old, incorrect check.
- Did not request the `unlimitedStorage` permission as an alternative fix; the issue's proposal was a bounded,
  validated paste path with a clear error, not expanding the extension's storage footprint.
