### PR TITLE
refactor(extension): rename remaining Gittensory brand-prose in runtime UI

### DIFF
--- a/apps/gittensory-extension/content.js
+++ b/apps/gittensory-extension/content.js
@@ -27,9 +27,9 @@ function mountOverlay(target) {
   container.innerHTML = `
     <div class="gittensory-overlay__header">
       <span class="gittensory-overlay__mark">G</span>
-      <span>Gittensory</span>
+      <span>LoopOver</span>
       <span class="gittensory-overlay__privacy">Private</span>
-      <button type="button" class="gittensory-overlay__refresh" aria-label="Refresh Gittensory context">Refresh</button>
+      <button type="button" class="gittensory-overlay__refresh" aria-label="Refresh LoopOver context">Refresh</button>
     </div>
     <div class="gittensory-overlay__body">Loading private context...</div>
   `;

--- a/apps/gittensory-extension/options.html
+++ b/apps/gittensory-extension/options.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Gittensory Extension</title>
+    <title>LoopOver Extension</title>
     <style>
       body {
         margin: 0;
@@ -63,8 +63,8 @@
   </head>
   <body>
     <main>
-      <h1>Gittensory extension</h1>
-      <p>Paste an extension session token from the Gittensory app. Session tokens stay in browser local storage, are never synced, and GitHub personal access tokens are rejected.</p>
+      <h1>LoopOver extension</h1>
+      <p>Paste an extension session token from the LoopOver app. Session tokens stay in browser local storage, are never synced, and GitHub personal access tokens are rejected.</p>
       <form id="settings">
         <label>
           API origin

--- a/apps/gittensory-miner-extension/opportunity-badge.js
+++ b/apps/gittensory-miner-extension/opportunity-badge.js
@@ -81,7 +81,7 @@ function renderOpportunityBadgeMarkup(badge, lastSyncedLabel) {
   return `
     <div class="gittensory-miner-opportunity-badge__header">
       <span class="gittensory-miner-opportunity-badge__mark">G</span>
-      <span>Gittensory opportunity</span>
+      <span>LoopOver opportunity</span>
       <span class="gittensory-miner-opportunity-badge__read-only">Read-only</span>
     </div>
     <div class="gittensory-miner-opportunity-badge__score">

--- a/apps/gittensory-miner-extension/options.html
+++ b/apps/gittensory-miner-extension/options.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Gittensory Miner Extension</title>
+    <title>LoopOver Miner Extension</title>
     <style>
       body {
         margin: 0;
@@ -54,7 +54,7 @@
   </head>
   <body>
     <main>
-      <h1>Gittensory miner extension</h1>
+      <h1>LoopOver miner extension</h1>
       <p>
         Configure which repositories this contributor-facing extension should watch on GitHub issue pages. This is a
         separate product surface from the maintainer overlay at <code>apps/gittensory-extension/</code>.

--- a/test/unit/miner-extension-content.test.ts
+++ b/test/unit/miner-extension-content.test.ts
@@ -94,7 +94,7 @@ describe("miner extension opportunity badge", () => {
       status: "ready",
     });
     expect(container.hidden).toBe(false);
-    expect(container.innerHTML).toContain("Gittensory opportunity");
+    expect(container.innerHTML).toContain("LoopOver opportunity");
     expect(container.innerHTML).toContain(formatted.tier);
 
     const missing = createMockContainer();


### PR DESCRIPTION
## Summary
Renames the literal display text (visible labels, aria-labels, page titles, headings, body copy) in the maintainer overlay's injected panel and options page, and the miner extension's opportunity badge and options page, from "Gittensory" to "LoopOver" — these were the on-page text a user actually sees, left untouched by #5329's own literal deliverables (manifests, API origin, build script, download link).

## Deliberately unchanged
- CSS class names and dataset attributes (`gittensory-overlay__*`, `data-gittensory-pr-context`, etc.) — internal identifiers, not brand-prose, matching the existing convention (see `auth.js`'s `GITTENSORY_SESSION_PATTERN`).
- The real `apps/gittensory-extension/` directory-path reference in the miner options page's body copy.

## Test plan
- [x] Full `npm run test:ci` gate green.
- [x] Fixed the one test assertion (`miner-extension-content.test.ts`) that checked the renamed badge text.

Closes #5533.