### PR TITLE
feat(miner): add _FILE secrets indirection for fleet credentials (#5178)

### DIFF
--- a/packages/gittensory-miner/.gittensory-miner.env.example
+++ b/packages/gittensory-miner/.gittensory-miner.env.example
@@ -4,8 +4,11 @@
 #
 # Required: a GitHub token the miner uses to read issues and open PRs.
 GITHUB_TOKEN=
+# Fleet mode alternative: mount a Docker/K8s secret and set GITHUB_TOKEN_FILE=/run/secrets/github_token
+# instead of GITHUB_TOKEN (plain env wins when both are set). See DEPLOYMENT.md.
 # Optional: only for the coding-agent providers you enable (claude-cli / codex-cli / agent-sdk).
 ANTHROPIC_API_KEY=
 OPENAI_API_KEY=
+# claude-cli: CLAUDE_CODE_OAUTH_TOKEN= or CLAUDE_CODE_OAUTH_TOKEN_FILE=/run/secrets/claude_oauth
 # Note: the state dir is fixed at /data/miner (the Dockerfile default + the compose volume mount), so it is
 # intentionally NOT an override here — see the comment in docker-compose.miner.yml.

--- a/packages/gittensory-miner/DEPLOYMENT.md
+++ b/packages/gittensory-miner/DEPLOYMENT.md
@@ -68,6 +68,23 @@ docker run --rm -it \
   doctor
 ```
 
+For Docker Swarm / Kubernetes, prefer mounting secrets as files instead of plain `-e` values (which appear in `docker inspect`). The CLI resolves `<NAME>_FILE` into `<NAME>` at startup for `GITHUB_TOKEN` and the active coding-agent provider's credential env vars (`lib/load-file-credentials.js`):
+
+```sh
+docker run --rm -it \
+  -e GITTENSORY_MINER_CONFIG_DIR=/data/miner \
+  -e GITHUB_TOKEN_FILE=/run/secrets/github_token \
+  -e MINER_CODING_AGENT_PROVIDER=claude-cli \
+  -e CLAUDE_CODE_OAUTH_TOKEN_FILE=/run/secrets/claude_oauth \
+  -v miner-data:/data/miner \
+  -v /run/secrets/github_token:/run/secrets/github_token:ro \
+  -v /run/secrets/claude_oauth:/run/secrets/claude_oauth:ro \
+  gittensory-miner:latest \
+  doctor
+```
+
+**Precedence:** when both `<NAME>` and `<NAME>_FILE` are set, the plain env var wins (including an explicit empty value). When only `<NAME>_FILE` is set, the file contents (trimmed) become the effective credential. An unreadable `_FILE` path fails immediately with an error naming the path — the miner never silently falls through to an empty credential.
+
 The image entrypoint is `gittensory-miner`; pass subcommands after the image name (`status`, `doctor`, `claim`, …).
 
 - **`/data/miner` volume** — holds all SQLite state (`claim-ledger.sqlite3`, `plan-store.sqlite3`, etc.) so containers are disposable. Defaults to `GITTENSORY_MINER_CONFIG_DIR=/data/miner` in the image.

--- a/packages/gittensory-miner/bin/gittensory-miner.js
+++ b/packages/gittensory-miner/bin/gittensory-miner.js
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { loadFileCredentials } from "../lib/load-file-credentials.js";
 import { runAttempt } from "../lib/attempt-cli.js";
 import { printHelp, printVersion, runCli } from "../lib/cli.js";
 import { runDenyCheck } from "../lib/deny-check.js";
@@ -25,6 +26,9 @@ import {
   startUpdateCheck,
 } from "../lib/update-check.js";
 import { resolveMinerVersion } from "../lib/version.js";
+
+// Fleet-mode secret mounts: resolve `<NAME>_FILE` into `<NAME>` before any subcommand reads credentials (#5178).
+loadFileCredentials(process.env);
 
 // Register signal + crash handlers once, before any command runs, so an interrupted run closes its open ledgers
 // cleanly instead of dying mid-write (#4826). Covers every subcommand below, including the local ones.

--- a/packages/gittensory-miner/docs/config-precedence.md
+++ b/packages/gittensory-miner/docs/config-precedence.md
@@ -80,6 +80,18 @@ There is **no `.gittensory-miner.yml` forge block** today; `--api-base-url` foll
 
 Explicit per-store env **wins** over config dir; config dir **wins** over XDG. No CLI or goal-spec override.
 
+### Fleet credential files (`<NAME>_FILE`)
+
+**Sources:** plain `<NAME>` env var and companion `<NAME>_FILE` path (`lib/load-file-credentials.js`, invoked from `bin/gittensory-miner.js` before any subcommand).
+
+**Order (mirrors ORB self-host `load-file-secrets.ts`):**
+
+1. Truthy plain `<NAME>` env var wins (including when both plain and `_FILE` are set).
+2. Else when only `<NAME>_FILE` is set, trimmed file contents become `<NAME>`.
+3. Unreadable `_FILE` path → process exits with an error naming the path (no silent empty fallback).
+
+**Scope today:** `GITHUB_TOKEN` always; plus `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY` for the configured `MINER_CODING_AGENT_PROVIDER`. Codex-cli uses `auth.json` at `resolveCodexAuthPath` instead of a secret env var.
+
 ## Known gaps / inconsistencies
 
 - **No unified precedence** across yml + env + CLI for a single knob — each concern owns its resolver.

--- a/packages/gittensory-miner/lib/load-file-credentials.d.ts
+++ b/packages/gittensory-miner/lib/load-file-credentials.d.ts
@@ -1,0 +1,19 @@
+export declare const ALWAYS_FILE_CREDENTIAL_ENV_VARS: readonly string[];
+export declare const PROVIDER_FILE_CREDENTIAL_ENV_VARS: Readonly<
+  Record<string, readonly string[]>
+>;
+
+export function resolveFileCredentialEnvVarNames(
+  env: Record<string, string | undefined>,
+): readonly string[];
+
+export function resolveFileCredential(
+  env: Record<string, string | undefined>,
+  name: string,
+  readFile: (path: string) => string,
+): "env" | "file" | "absent";
+
+export function loadFileCredentials(
+  env?: Record<string, string | undefined>,
+  options?: { readFile?: (path: string) => string },
+): void;

--- a/packages/gittensory-miner/lib/load-file-credentials.js
+++ b/packages/gittensory-miner/lib/load-file-credentials.js
@@ -1,0 +1,76 @@
+import { readFileSync } from "node:fs";
+import { resolveFirstConfiguredCodingAgentDriverName } from "@jsonbored/gittensory-engine";
+
+/** Env vars whose `<NAME>_FILE` companion may be dereferenced at CLI startup (#5178). `GITHUB_TOKEN` is always
+ *  eligible; coding-agent credential env vars are added only for the configured provider. Codex-cli authenticates
+ *  via a readable `auth.json` (see `resolveCodexAuthPath`) rather than a secret env var, so it has no `_FILE`
+ *  pair here. */
+export const ALWAYS_FILE_CREDENTIAL_ENV_VARS = Object.freeze(["GITHUB_TOKEN"]);
+
+/** Per-provider credential env vars that support `<NAME>_FILE` indirection when that provider is active. */
+export const PROVIDER_FILE_CREDENTIAL_ENV_VARS = Object.freeze({
+  "claude-cli": Object.freeze(["CLAUDE_CODE_OAUTH_TOKEN"]),
+  "agent-sdk": Object.freeze(["CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_API_KEY"]),
+  "codex-cli": Object.freeze([]),
+  noop: Object.freeze([]),
+});
+
+/**
+ * Credential env var names whose `_FILE` companions may be read for the current `env` snapshot.
+ *
+ * @param {Record<string, string | undefined>} env
+ * @returns {readonly string[]}
+ */
+export function resolveFileCredentialEnvVarNames(env) {
+  const provider = resolveFirstConfiguredCodingAgentDriverName(env)?.trim().toLowerCase() ?? null;
+  const providerVars =
+    provider && provider in PROVIDER_FILE_CREDENTIAL_ENV_VARS
+      ? PROVIDER_FILE_CREDENTIAL_ENV_VARS[provider]
+      : [];
+  return [...ALWAYS_FILE_CREDENTIAL_ENV_VARS, ...providerVars];
+}
+
+/**
+ * Resolve one credential from its optional `<NAME>_FILE` companion. Precedence matches
+ * `src/selfhost/load-file-secrets.ts`: when the plain `<NAME>` env var is already set to a truthy value, it wins.
+ * When only `<NAME>_FILE` is set, the trimmed file contents become `<NAME>`.
+ *
+ * @param {Record<string, string | undefined>} env
+ * @param {string} name
+ * @param {(path: string) => string} readFile
+ * @returns {"env" | "file" | "absent"}
+ */
+export function resolveFileCredential(env, name, readFile) {
+  if (env[name]) {
+    return "env";
+  }
+
+  const fileVar = `${name}_FILE`;
+  const filePath = env[fileVar];
+  if (typeof filePath !== "string" || !filePath.trim()) {
+    return "absent";
+  }
+
+  const resolvedPath = filePath.trim();
+  try {
+    env[name] = readFile(resolvedPath).trim();
+    return "file";
+  } catch (error) {
+    const reason = error instanceof Error ? error.message : String(error);
+    throw new Error(`credential file unreadable: ${fileVar}=${resolvedPath} (${reason})`);
+  }
+}
+
+/**
+ * Dereference `<NAME>_FILE` into `<NAME>` for fleet-mode secrets. Mutates `env` in place (typically
+ * `process.env`). Throws on an unreadable `_FILE` path — never silently falls through to an empty credential.
+ *
+ * @param {Record<string, string | undefined>} [env]
+ * @param {{ readFile?: (path: string) => string }} [options]
+ */
+export function loadFileCredentials(env = process.env, options = {}) {
+  const readFile = options.readFile ?? ((path) => readFileSync(path, "utf8"));
+  for (const name of resolveFileCredentialEnvVarNames(env)) {
+    resolveFileCredential(env, name, readFile);
+  }
+}

--- a/test/unit/miner-load-file-credentials.test.ts
+++ b/test/unit/miner-load-file-credentials.test.ts
@@ -52,7 +52,10 @@ describe("resolveFileCredentialEnvVarNames (#5178)", () => {
 
 describe("resolveFileCredential (#5178)", () => {
   it("keeps a plain env credential when both plain and _FILE are set", () => {
-    const env = { GITHUB_TOKEN: "from-env", GITHUB_TOKEN_FILE: "/run/secrets/github_token" };
+    const env: Record<string, string | undefined> = {
+      GITHUB_TOKEN: "from-env",
+      GITHUB_TOKEN_FILE: "/run/secrets/github_token",
+    };
     const readFile = vi.fn(() => "from-file");
     expect(resolveFileCredential(env, "GITHUB_TOKEN", readFile)).toBe("env");
     expect(readFile).not.toHaveBeenCalled();
@@ -60,14 +63,14 @@ describe("resolveFileCredential (#5178)", () => {
   });
 
   it("reads _FILE when the plain env var is unset", () => {
-    const path = tempSecretFile("ghp_from_file\n");
-    const env = { GITHUB_TOKEN_FILE: path };
+    const path = tempSecretFile("token-from-file\n");
+    const env: Record<string, string | undefined> = { GITHUB_TOKEN_FILE: path };
     expect(resolveFileCredential(env, "GITHUB_TOKEN", (p) => readFileSync(p, "utf8"))).toBe("file");
-    expect(env.GITHUB_TOKEN).toBe("ghp_from_file");
+    expect(env.GITHUB_TOKEN).toBe("token-from-file");
   });
 
   it("throws with the file path when _FILE is set but unreadable", () => {
-    const env = { GITHUB_TOKEN_FILE: "/run/secrets/missing" };
+    const env: Record<string, string | undefined> = { GITHUB_TOKEN_FILE: "/run/secrets/missing" };
     expect(() => resolveFileCredential(env, "GITHUB_TOKEN", () => {
       throw new Error("ENOENT");
     })).toThrow("credential file unreadable: GITHUB_TOKEN_FILE=/run/secrets/missing");
@@ -80,8 +83,8 @@ describe("resolveFileCredential (#5178)", () => {
   });
 
   it("never returns or logs the secret value through the source indicator", () => {
-    const path = tempSecretFile("super-secret-value");
-    const env = { GITHUB_TOKEN_FILE: path };
+    const path = tempSecretFile("credential-value");
+    const env: Record<string, string | undefined> = { GITHUB_TOKEN_FILE: path };
     const source = resolveFileCredential(env, "GITHUB_TOKEN", (p) => readFileSync(p, "utf8"));
     expect(source).toBe("file");
     expect(["env", "file", "absent"]).toContain(source);
@@ -90,27 +93,27 @@ describe("resolveFileCredential (#5178)", () => {
 
 describe("loadFileCredentials (#5178)", () => {
   it("REGRESSION: plain-env fleet setup keeps working unchanged", () => {
-    const env = {
-      GITHUB_TOKEN: "ghp_plain",
+    const env: Record<string, string | undefined> = {
+      GITHUB_TOKEN: "plain-github-token",
       MINER_CODING_AGENT_PROVIDER: "claude-cli",
-      CLAUDE_CODE_OAUTH_TOKEN: "oauth_plain",
+      CLAUDE_CODE_OAUTH_TOKEN: "plain-oauth-token",
     };
     loadFileCredentials(env, { readFile: vi.fn(() => "should-not-run") });
-    expect(env.GITHUB_TOKEN).toBe("ghp_plain");
-    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe("oauth_plain");
+    expect(env.GITHUB_TOKEN).toBe("plain-github-token");
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe("plain-oauth-token");
   });
 
   it("resolves GITHUB_TOKEN and the active provider credential from _FILE mounts", () => {
-    const githubPath = tempSecretFile("ghp_file");
-    const claudePath = tempSecretFile("oauth_file\n");
-    const env = {
+    const githubPath = tempSecretFile("github-from-file");
+    const claudePath = tempSecretFile("oauth-from-file\n");
+    const env: Record<string, string | undefined> = {
       MINER_CODING_AGENT_PROVIDER: "claude-cli",
       GITHUB_TOKEN_FILE: githubPath,
       CLAUDE_CODE_OAUTH_TOKEN_FILE: claudePath,
     };
     loadFileCredentials(env);
-    expect(env.GITHUB_TOKEN).toBe("ghp_file");
-    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe("oauth_file");
+    expect(env.GITHUB_TOKEN).toBe("github-from-file");
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe("oauth-from-file");
   });
 
   it("fails fast when any configured _FILE path is unreadable", () => {
@@ -125,8 +128,8 @@ describe("loadFileCredentials (#5178)", () => {
 
   it("lets doctor see GITHUB_TOKEN after _FILE resolution (#5178 + #5170)", async () => {
     const { checkGitHubTokenPresent } = await import("../../packages/gittensory-miner/lib/status.js");
-    const path = tempSecretFile("ghp_doctor");
-    const env = { GITHUB_TOKEN_FILE: path };
+    const path = tempSecretFile("doctor-token");
+    const env: Record<string, string | undefined> = { GITHUB_TOKEN_FILE: path };
     loadFileCredentials(env);
     expect(checkGitHubTokenPresent(env).ok).toBe(true);
   });

--- a/test/unit/miner-load-file-credentials.test.ts
+++ b/test/unit/miner-load-file-credentials.test.ts
@@ -1,0 +1,133 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@jsonbored/gittensory-engine", async () => {
+  return import("../../packages/gittensory-engine/src/index");
+});
+
+import {
+  loadFileCredentials,
+  resolveFileCredential,
+  resolveFileCredentialEnvVarNames,
+} from "../../packages/gittensory-miner/lib/load-file-credentials.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function tempSecretFile(contents: string) {
+  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-file-creds-"));
+  roots.push(root);
+  const path = join(root, "secret.txt");
+  writeFileSync(path, contents);
+  return path;
+}
+
+describe("resolveFileCredentialEnvVarNames (#5178)", () => {
+  it("always includes GITHUB_TOKEN and adds Claude vars for claude-cli", () => {
+    expect(resolveFileCredentialEnvVarNames({ MINER_CODING_AGENT_PROVIDER: "claude-cli" })).toEqual([
+      "GITHUB_TOKEN",
+      "CLAUDE_CODE_OAUTH_TOKEN",
+    ]);
+  });
+
+  it("adds both Claude credential env vars for agent-sdk", () => {
+    expect(resolveFileCredentialEnvVarNames({ MINER_CODING_AGENT_PROVIDER: "agent-sdk" })).toEqual([
+      "GITHUB_TOKEN",
+      "CLAUDE_CODE_OAUTH_TOKEN",
+      "ANTHROPIC_API_KEY",
+    ]);
+  });
+
+  it("includes only GITHUB_TOKEN for codex-cli (auth.json is separate)", () => {
+    expect(resolveFileCredentialEnvVarNames({ MINER_CODING_AGENT_PROVIDER: "codex-cli" })).toEqual([
+      "GITHUB_TOKEN",
+    ]);
+  });
+});
+
+describe("resolveFileCredential (#5178)", () => {
+  it("keeps a plain env credential when both plain and _FILE are set", () => {
+    const env = { GITHUB_TOKEN: "from-env", GITHUB_TOKEN_FILE: "/run/secrets/github_token" };
+    const readFile = vi.fn(() => "from-file");
+    expect(resolveFileCredential(env, "GITHUB_TOKEN", readFile)).toBe("env");
+    expect(readFile).not.toHaveBeenCalled();
+    expect(env.GITHUB_TOKEN).toBe("from-env");
+  });
+
+  it("reads _FILE when the plain env var is unset", () => {
+    const path = tempSecretFile("ghp_from_file\n");
+    const env = { GITHUB_TOKEN_FILE: path };
+    expect(resolveFileCredential(env, "GITHUB_TOKEN", (p) => readFileSync(p, "utf8"))).toBe("file");
+    expect(env.GITHUB_TOKEN).toBe("ghp_from_file");
+  });
+
+  it("throws with the file path when _FILE is set but unreadable", () => {
+    const env = { GITHUB_TOKEN_FILE: "/run/secrets/missing" };
+    expect(() => resolveFileCredential(env, "GITHUB_TOKEN", () => {
+      throw new Error("ENOENT");
+    })).toThrow("credential file unreadable: GITHUB_TOKEN_FILE=/run/secrets/missing");
+    expect(env.GITHUB_TOKEN).toBeUndefined();
+  });
+
+  it("returns absent when neither plain nor _FILE is set", () => {
+    const env = {};
+    expect(resolveFileCredential(env, "GITHUB_TOKEN", vi.fn())).toBe("absent");
+  });
+
+  it("never returns or logs the secret value through the source indicator", () => {
+    const path = tempSecretFile("super-secret-value");
+    const env = { GITHUB_TOKEN_FILE: path };
+    const source = resolveFileCredential(env, "GITHUB_TOKEN", (p) => readFileSync(p, "utf8"));
+    expect(source).toBe("file");
+    expect(["env", "file", "absent"]).toContain(source);
+  });
+});
+
+describe("loadFileCredentials (#5178)", () => {
+  it("REGRESSION: plain-env fleet setup keeps working unchanged", () => {
+    const env = {
+      GITHUB_TOKEN: "ghp_plain",
+      MINER_CODING_AGENT_PROVIDER: "claude-cli",
+      CLAUDE_CODE_OAUTH_TOKEN: "oauth_plain",
+    };
+    loadFileCredentials(env, { readFile: vi.fn(() => "should-not-run") });
+    expect(env.GITHUB_TOKEN).toBe("ghp_plain");
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe("oauth_plain");
+  });
+
+  it("resolves GITHUB_TOKEN and the active provider credential from _FILE mounts", () => {
+    const githubPath = tempSecretFile("ghp_file");
+    const claudePath = tempSecretFile("oauth_file\n");
+    const env = {
+      MINER_CODING_AGENT_PROVIDER: "claude-cli",
+      GITHUB_TOKEN_FILE: githubPath,
+      CLAUDE_CODE_OAUTH_TOKEN_FILE: claudePath,
+    };
+    loadFileCredentials(env);
+    expect(env.GITHUB_TOKEN).toBe("ghp_file");
+    expect(env.CLAUDE_CODE_OAUTH_TOKEN).toBe("oauth_file");
+  });
+
+  it("fails fast when any configured _FILE path is unreadable", () => {
+    const env = {
+      MINER_CODING_AGENT_PROVIDER: "claude-cli",
+      GITHUB_TOKEN_FILE: "/missing/github",
+    };
+    expect(() => loadFileCredentials(env, { readFile: () => { throw new Error("ENOENT"); } })).toThrow(
+      "GITHUB_TOKEN_FILE=/missing/github",
+    );
+  });
+
+  it("lets doctor see GITHUB_TOKEN after _FILE resolution (#5178 + #5170)", async () => {
+    const { checkGitHubTokenPresent } = await import("../../packages/gittensory-miner/lib/status.js");
+    const path = tempSecretFile("ghp_doctor");
+    const env = { GITHUB_TOKEN_FILE: path };
+    loadFileCredentials(env);
+    expect(checkGitHubTokenPresent(env).ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add \lib/load-file-credentials.js\ to resolve \GITHUB_TOKEN_FILE\ and provider credential \_FILE\ companions into plain env vars at CLI startup (plain env wins; unreadable paths fail fast).
- Wire resolution in \in/gittensory-miner.js\ before any subcommand so \doctor\ and attempts see mounted secrets.
- Update \DEPLOYMENT.md\, \.gittensory-miner.env.example\, and \docs/config-precedence.md\ with fleet-mode guidance.

Closes #5178

## Test plan
- [x] \
pm test -- test/unit/miner-load-file-credentials.test.ts\ (12 tests)
- [x] \
pm test -- test/unit/miner-cli-doctor-checks.test.ts\ (unchanged, passes with resolved credentials)
- [ ] CI validate-code + validate-tests shards


Made with [Cursor](https://cursor.com)