### PR TITLE
feat(miner): respect --json on CLI error paths

### DIFF
--- a/packages/gittensory-miner/lib/attempt-cli.js
+++ b/packages/gittensory-miner/lib/attempt-cli.js
@@ -13,6 +13,7 @@
 // query (attempt-log.js's schema has no repo+issue index, and reenqueue counts aren't tracked anywhere yet).
 
 import { resolveCodingAgentModeFromConfig } from "@jsonbored/gittensory-engine";
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
 import { constructProductionCodingAgentDriver } from "./coding-agent-construction.js";
 import { runSlopAssessment } from "./slop-assessment.js";
 import { fetchLiveIssueSnapshot } from "./live-issue-snapshot.js";
@@ -139,8 +140,7 @@ export function buildAttemptDeps(env, ledgers) {
 export async function runAttempt(args, options = {}) {
   const parsed = parseAttemptArgs(args);
   if ("error" in parsed) {
-    console.error(parsed.error);
-    return 2;
+    return reportCliFailure(argsWantJson(args), parsed.error);
   }
 
   const env = options.env ?? process.env;
@@ -149,10 +149,11 @@ export async function runAttempt(args, options = {}) {
   const mode = resolveMode({ env, agentDryRun: !parsed.live });
 
   if (mode === "paused") {
-    console.error(
+    return reportCliFailure(
+      parsed.json,
       `Coding-agent execution is globally paused (MINER_CODING_AGENT_PAUSED). Not running attempt for ${parsed.repoFullName}#${parsed.issueNumber}.`,
+      3,
     );
-    return 3;
   }
 
   const attemptId = options.attemptId ?? `${parsed.repoFullName.replace("/", "_")}-${parsed.issueNumber}-${nowMs}`;
@@ -222,9 +223,12 @@ export async function runAttempt(args, options = {}) {
       const buildDeps = options.buildAttemptDeps ?? buildAttemptDeps;
       deps = buildDeps(env, { claimLedger, eventLedger, attemptLog, governorLedger, nowMs });
     } catch (error) {
-      const reason = error instanceof Error ? error.message : String(error);
-      console.error(`Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: ${reason}`);
-      return 3;
+      const reason = describeCliError(error);
+      return reportCliFailure(
+        parsed.json,
+        `Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: ${reason}`,
+        3,
+      );
     }
 
     // Real worktree preparation (repo-clone.js + attempt-worktree.js, #5237): the allocator above only
@@ -461,8 +465,7 @@ export async function runAttempt(args, options = {}) {
         return 2;
     }
   } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
-    return 2;
+    return reportCliFailure(parsed.json, describeCliError(error));
   } finally {
     // worktreeResult.attemptOk is set to the REAL runMinerAttempt outcome (submitted = true) once that call
     // happens; every earlier blocked path (rejection/worktree-prep-failure/infeasible) never sets it, since

--- a/packages/gittensory-miner/lib/calibration-cli.js
+++ b/packages/gittensory-miner/lib/calibration-cli.js
@@ -6,6 +6,7 @@ import { buildCalibrationReport } from "./calibration.js";
 import { initEventLedger, resolveEventLedgerDbPath } from "./event-ledger.js";
 import { MINER_PR_OUTCOME_EVENT } from "./pr-outcome.js";
 import { initPredictionLedger, resolvePredictionLedgerDbPath } from "./prediction-ledger.js";
+import { reportCliFailure } from "./cli-error.js";
 
 const CALIBRATION_USAGE = "Usage: gittensory-miner calibration [--json]";
 
@@ -67,8 +68,7 @@ export function runCalibrationCli(args = [], env = process.env) {
   const json = args.includes("--json");
   const unknown = args.find((token) => token.startsWith("-") && token !== "--json");
   if (unknown) {
-    console.error(`Unknown option: ${unknown}. ${CALIBRATION_USAGE}`);
-    return 1;
+    return reportCliFailure(json, `Unknown option: ${unknown}. ${CALIBRATION_USAGE}`, 1);
   }
 
   const predictionStore = initPredictionLedger(resolvePredictionLedgerDbPath(env));

--- a/packages/gittensory-miner/lib/claim-ledger-cli.js
+++ b/packages/gittensory-miner/lib/claim-ledger-cli.js
@@ -1,4 +1,5 @@
 import { CLAIM_STATUSES, openClaimLedger } from "./claim-ledger.js";
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
 
 const CLAIM_CLAIM_USAGE =
   "Usage: gittensory-miner claim claim <owner/repo> <issue#> [--note <text>] [--json]";
@@ -183,8 +184,7 @@ function withClaimLedger(options, run) {
 export function runClaimClaim(args, options = {}) {
   const parsed = parseClaimClaimArgs(args);
   if ("error" in parsed) {
-    console.error(parsed.error);
-    return 2;
+    return reportCliFailure(argsWantJson(args), parsed.error);
   }
 
   try {
@@ -202,24 +202,21 @@ export function runClaimClaim(args, options = {}) {
       return 0;
     });
   } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
-    return 2;
+    return reportCliFailure(parsed.json, describeCliError(error));
   }
 }
 
 export function runClaimRelease(args, options = {}) {
   const parsed = parseClaimReleaseArgs(args);
   if ("error" in parsed) {
-    console.error(parsed.error);
-    return 2;
+    return reportCliFailure(argsWantJson(args), parsed.error);
   }
 
   try {
     return withClaimLedger(options, (claimLedger) => {
       const claim = claimLedger.releaseClaim(parsed.repoFullName, parsed.issueNumber);
       if (!claim) {
-        console.error("claim_not_found");
-        return 2;
+        return reportCliFailure(parsed.json, "claim_not_found");
       }
       if (parsed.json) {
         console.log(JSON.stringify({ claim }, null, 2));
@@ -229,16 +226,14 @@ export function runClaimRelease(args, options = {}) {
       return 0;
     });
   } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
-    return 2;
+    return reportCliFailure(parsed.json, describeCliError(error));
   }
 }
 
 export function runClaimList(args, options = {}) {
   const parsed = parseClaimListArgs(args);
   if ("error" in parsed) {
-    console.error(parsed.error);
-    return 2;
+    return reportCliFailure(argsWantJson(args), parsed.error);
   }
 
   try {
@@ -255,8 +250,7 @@ export function runClaimList(args, options = {}) {
       return 0;
     });
   } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
-    return 2;
+    return reportCliFailure(parsed.json, describeCliError(error));
   }
 }
 
@@ -264,6 +258,5 @@ export function runClaimCli(subcommand, args, options = {}) {
   if (subcommand === "claim") return runClaimClaim(args, options);
   if (subcommand === "release") return runClaimRelease(args, options);
   if (subcommand === "list") return runClaimList(args, options);
-  console.error(`Unknown claim subcommand: ${subcommand ?? ""}. ${CLAIM_LIST_USAGE}`);
-  return 2;
+  return reportCliFailure(argsWantJson(args), `Unknown claim subcommand: ${subcommand ?? ""}. ${CLAIM_LIST_USAGE}`);
 }

--- a/packages/gittensory-miner/lib/cli-error.d.ts
+++ b/packages/gittensory-miner/lib/cli-error.d.ts
@@ -1,0 +1,3 @@
+export function reportCliFailure(wantsJson: boolean, message: string, exitCode?: number): number;
+export function argsWantJson(args: readonly string[]): boolean;
+export function describeCliError(error: unknown): string;

--- a/packages/gittensory-miner/lib/cli-error.js
+++ b/packages/gittensory-miner/lib/cli-error.js
@@ -1,0 +1,27 @@
+/** Shared CLI failure output (#4836): when `--json` is set, emit a parseable `{ ok: false, error }` object on
+ *  stdout (matching each command's success-path JSON stream); otherwise log plain text to stderr. */
+
+/**
+ * @param {boolean} wantsJson
+ * @param {string} message
+ * @param {number} [exitCode]
+ * @returns {number}
+ */
+export function reportCliFailure(wantsJson, message, exitCode = 2) {
+  if (wantsJson) {
+    console.log(JSON.stringify({ ok: false, error: message }, null, 2));
+  } else {
+    console.error(message);
+  }
+  return exitCode;
+}
+
+/** True when argv includes `--json` (used on parse-error paths before a full parse result exists). */
+export function argsWantJson(args) {
+  return args.includes("--json");
+}
+
+/** Normalize a thrown value to a safe error string for CLI output. */
+export function describeCliError(error) {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/gittensory-miner/lib/cli.js
+++ b/packages/gittensory-miner/lib/cli.js
@@ -1,3 +1,5 @@
+import { argsWantJson, reportCliFailure } from "./cli-error.js";
+
 export function printVersion(input) {
   console.log(`${input.packageName}/${input.packageVersion} (node ${process.version})`);
 }
@@ -55,6 +57,6 @@ export function printHelp(input) {
 
 export function runCli(cliArgs, input) {
   const command = cliArgs[0] ?? "";
-  console.error(`Unknown command: ${command}. Run ${input.packageName} --help.`);
-  return 1;
+  const message = `Unknown command: ${command}. Run ${input.packageName} --help.`;
+  return reportCliFailure(argsWantJson(cliArgs), message, 1);
 }

--- a/packages/gittensory-miner/lib/deny-check.js
+++ b/packages/gittensory-miner/lib/deny-check.js
@@ -1,4 +1,5 @@
 import { evaluateDenyHooks } from "./deny-hooks.js";
+import { argsWantJson, reportCliFailure } from "./cli-error.js";
 
 const DENY_CHECK_USAGE =
   "Usage: gittensory-miner hooks check --tool <name> --input <json> [--json]";
@@ -59,8 +60,7 @@ export function parseDenyCheckArgs(args) {
 export function runDenyCheck(args) {
   const parsed = parseDenyCheckArgs(args);
   if ("error" in parsed) {
-    console.error(parsed.error);
-    return 2;
+    return reportCliFailure(argsWantJson(args), parsed.error);
   }
 
   const verdict = evaluateDenyHooks({ name: parsed.tool, input: parsed.input });

--- a/packages/gittensory-miner/lib/discover-cli.js
+++ b/packages/gittensory-miner/lib/discover-cli.js
@@ -10,6 +10,7 @@ import { initPolicyDocCacheStore } from "./policy-doc-cache.js";
 import { initPolicyVerdictCacheStore } from "./policy-verdict-cache.js";
 import { enqueueRankedDiscovery } from "./portfolio-discovery.js";
 import { initPortfolioQueueStore } from "./portfolio-queue.js";
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
 
 const DISCOVER_USAGE =
   "Usage: gittensory-miner discover <owner/repo> [<owner/repo>...] | --search <query> [--json] [--api-base-url <url>] [--token-env <VAR>]";
@@ -138,8 +139,7 @@ export function renderDiscoverSummary(result) {
 export async function runDiscover(args, options = {}) {
   const parsed = parseDiscoverArgs(args);
   if ("error" in parsed) {
-    console.error(parsed.error);
-    return 2;
+    return reportCliFailure(argsWantJson(args), parsed.error);
   }
 
   // Credential env var is per-tenant (#4784): a `--token-env FORGE_PAT` flag (or `options.tokenEnv`) reads a
@@ -222,8 +222,7 @@ export async function runDiscover(args, options = {}) {
     }
     return 0;
   } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
-    return 2;
+    return reportCliFailure(parsed.json, describeCliError(error));
   } finally {
     if (ownsPortfolioQueue) portfolioQueue.close();
     if (ownsPolicyDocCache && policyDocCache) policyDocCache.close();

--- a/packages/gittensory-miner/lib/event-ledger-cli.js
+++ b/packages/gittensory-miner/lib/event-ledger-cli.js
@@ -1,4 +1,5 @@
 import { initEventLedger } from "./event-ledger.js";
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
 
 const LEDGER_LIST_USAGE =
   "Usage: gittensory-miner ledger list [--repo <owner/repo>] [--since <seq>] [--type <eventType>] [--json]";
@@ -217,8 +218,7 @@ function withEventLedger(options, run) {
 export function runLedgerList(args, options = {}) {
   const parsed = parseLedgerListArgs(args);
   if ("error" in parsed) {
-    console.error(parsed.error);
-    return 2;
+    return reportCliFailure(argsWantJson(args), parsed.error);
   }
 
   try {
@@ -238,15 +238,13 @@ export function runLedgerList(args, options = {}) {
       return 0;
     });
   } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
-    return 2;
+    return reportCliFailure(parsed.json, describeCliError(error));
   }
 }
 
 export function runLedgerMetrics(args, options = {}) {
   if (args.length > 0) {
-    console.error(EVENT_LEDGER_METRICS_USAGE);
-    return 2;
+    return reportCliFailure(argsWantJson(args), EVENT_LEDGER_METRICS_USAGE);
   }
 
   try {
@@ -257,14 +255,12 @@ export function runLedgerMetrics(args, options = {}) {
       return 0;
     });
   } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
-    return 2;
+    return reportCliFailure(argsWantJson(args), describeCliError(error));
   }
 }
 
 export function runLedgerCli(subcommand, args, options = {}) {
   if (subcommand === "list") return runLedgerList(args, options);
   if (subcommand === "metrics") return runLedgerMetrics(args, options);
-  console.error(`Unknown ledger subcommand: ${subcommand ?? ""}. ${LEDGER_LIST_USAGE}`);
-  return 2;
+  return reportCliFailure(argsWantJson(args), `Unknown ledger subcommand: ${subcommand ?? ""}. ${LEDGER_LIST_USAGE}`);
 }

--- a/packages/gittensory-miner/lib/feasibility-cli.js
+++ b/packages/gittensory-miner/lib/feasibility-cli.js
@@ -2,6 +2,7 @@
  * `buildFeasibilityVerdict` composer. Purely local — no network, no filesystem — so it never needs the
  * npm-registry update check other subcommands opt into. */
 import { buildFeasibilityVerdict } from "@jsonbored/gittensory-engine";
+import { argsWantJson, reportCliFailure } from "./cli-error.js";
 
 const CLAIM_STATUSES = ["unclaimed", "claimed", "solved", "unknown"];
 const DUPLICATE_CLUSTER_RISKS = ["none", "low", "medium", "high"];
@@ -59,8 +60,7 @@ export function parseFeasibilityArgs(args) {
 export function runFeasibilityCli(args, options = {}) {
   const parsed = parseFeasibilityArgs(args);
   if ("error" in parsed) {
-    console.error(parsed.error);
-    return 2;
+    return reportCliFailure(argsWantJson(args), parsed.error);
   }
 
   const buildVerdict = options.buildFeasibilityVerdict ?? buildFeasibilityVerdict;

--- a/packages/gittensory-miner/lib/governor-ledger-cli.js
+++ b/packages/gittensory-miner/lib/governor-ledger-cli.js
@@ -1,4 +1,6 @@
 /** Must match `GOVERNOR_LEDGER_EVENT_TYPES` in `@jsonbored/gittensory-engine`. */
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
+
 const GOVERNOR_LEDGER_EVENT_TYPES = Object.freeze([
   "allowed",
   "denied",
@@ -109,8 +111,7 @@ async function withGovernorLedger(options, run) {
 export async function runGovernorList(args, options = {}) {
   const parsed = parseGovernorListArgs(args);
   if ("error" in parsed) {
-    console.error(parsed.error);
-    return 2;
+    return reportCliFailure(argsWantJson(args), parsed.error);
   }
 
   try {
@@ -129,13 +130,11 @@ export async function runGovernorList(args, options = {}) {
       return 0;
     });
   } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
-    return 2;
+    return reportCliFailure(parsed.json, describeCliError(error));
   }
 }
 
 export async function runGovernorCli(subcommand, args, options = {}) {
   if (subcommand === "list") return runGovernorList(args, options);
-  console.error(`Unknown governor subcommand: ${subcommand ?? ""}. ${GOVERNOR_LIST_USAGE}`);
-  return 2;
+  return reportCliFailure(argsWantJson(args), `Unknown governor subcommand: ${subcommand ?? ""}. ${GOVERNOR_LIST_USAGE}`);
 }

--- a/packages/gittensory-miner/lib/laptop-init.js
+++ b/packages/gittensory-miner/lib/laptop-init.js
@@ -3,6 +3,7 @@ import { homedir } from "node:os";
 import { delimiter, join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
 import { applySchemaMigrations } from "./schema-version.js";
+import { reportCliFailure } from "./cli-error.js";
 
 const githubApiBaseUrl = "https://api.github.com";
 const githubApiVersion = "2022-11-28";
@@ -307,8 +308,7 @@ export async function runInit(args = [], env = process.env) {
   if (verifyToken) {
     verification = await verifyGithubToken({ githubToken: env.GITHUB_TOKEN ?? "" });
     if (!verification.ok) {
-      console.error(verification.detail);
-      return 1;
+      return reportCliFailure(jsonOutput, verification.detail, 1);
     }
   }
 

--- a/packages/gittensory-miner/lib/loop-cli.js
+++ b/packages/gittensory-miner/lib/loop-cli.js
@@ -26,6 +26,7 @@
 // attempt-input-builder.js's header already flags as out of scope here).
 
 import { checkMinerKillSwitch } from "./governor-kill-switch.js";
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
 import { evaluateRunLoopBoundaryGate } from "./governor-run-halt.js";
 import { openGovernorState } from "./governor-state.js";
 import { initGovernorLedger } from "./governor-ledger.js";
@@ -195,8 +196,7 @@ function zeroConvergence() {
 export async function runLoop(args, options = {}) {
   const parsed = parseLoopArgs(args);
   if ("error" in parsed) {
-    console.error(parsed.error);
-    return 2;
+    return reportCliFailure(argsWantJson(args), parsed.error);
   }
 
   const env = options.env ?? process.env;
@@ -208,10 +208,11 @@ export async function runLoop(args, options = {}) {
   try {
     governorState = (options.openGovernorState ?? openGovernorState)();
   } catch (error) {
-    console.error(
-      `Loop refuses to start: governor state cannot be loaded: ${error instanceof Error ? error.message : String(error)}`,
+    return reportCliFailure(
+      parsed.json,
+      `Loop refuses to start: governor state cannot be loaded: ${describeCliError(error)}`,
+      3,
     );
-    return 3;
   }
 
   const eventLedger = (options.initEventLedger ?? initEventLedger)();
@@ -469,8 +470,7 @@ export async function runLoop(args, options = {}) {
     }
     return 0;
   } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
-    return 2;
+    return reportCliFailure(parsed.json, describeCliError(error));
   } finally {
     governorState.close();
     eventLedger.close();

--- a/packages/gittensory-miner/lib/manage-poll.js
+++ b/packages/gittensory-miner/lib/manage-poll.js
@@ -5,6 +5,7 @@ import {
   formatManagedPrIdentifier,
 } from "./manage-status.js";
 import { initPortfolioQueueStore } from "./portfolio-queue.js";
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
 
 const MANAGE_POLL_USAGE =
   "Usage: gittensory-miner manage poll <owner/repo> <pr#> [--branch <name>] [--json]";
@@ -162,8 +163,7 @@ export async function recordManagePollSnapshot(input, options = {}) {
 export async function runManagePoll(args = [], options = {}) {
   const parsed = parseManagePollArgs(args);
   if ("error" in parsed) {
-    console.error(parsed.error);
-    return 2;
+    return reportCliFailure(argsWantJson(args), parsed.error);
   }
 
   const ownsEventLedger = options.initEventLedger === undefined;
@@ -201,8 +201,7 @@ export async function runManagePoll(args = [], options = {}) {
     }
     return 0;
   } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
-    return 2;
+    return reportCliFailure(parsed.json, describeCliError(error));
   } finally {
     if (ownsEventLedger) eventLedger.close();
     if (ownsPortfolioQueue) portfolioQueue.close();

--- a/packages/gittensory-miner/lib/manage-status.js
+++ b/packages/gittensory-miner/lib/manage-status.js
@@ -1,6 +1,7 @@
 import { initEventLedger } from "./event-ledger.js";
 import { initPortfolioQueueStore } from "./portfolio-queue.js";
 import { initRunStateStore } from "./run-state.js";
+import { argsWantJson, reportCliFailure } from "./cli-error.js";
 
 /** Event vocabulary for manage-phase PR snapshots written by manage poll. (#2325) */
 export const MANAGE_PR_UPDATE_EVENT = "manage_pr_update";
@@ -207,8 +208,7 @@ export function parseManageStatusArgs(args = []) {
 export function runManageStatus(args = [], options = {}) {
   const parsed = parseManageStatusArgs(args);
   if ("error" in parsed) {
-    console.error(parsed.error);
-    return 2;
+    return reportCliFailure(argsWantJson(args), parsed.error);
   }
 
   const ownsPortfolioQueue = options.initPortfolioQueue === undefined;

--- a/packages/gittensory-miner/lib/metrics-cli.js
+++ b/packages/gittensory-miner/lib/metrics-cli.js
@@ -1,5 +1,6 @@
 import { renderMinerPredictionMetrics } from "@jsonbored/gittensory-engine";
 import { initPredictionLedger } from "./prediction-ledger.js";
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
 
 // `metrics` (#4838): render the miner's prediction-calibration counters as Prometheus text-exposition to stdout,
 // for a scrape wrapper or cron redirect. The counters are produced by the engine's already-built
@@ -33,8 +34,7 @@ function withPredictionLedger(options, run) {
 
 export function runMetrics(args, options = {}) {
   if (args.length > 0) {
-    console.error(METRICS_USAGE);
-    return 2;
+    return reportCliFailure(argsWantJson(args), METRICS_USAGE);
   }
 
   try {
@@ -45,7 +45,6 @@ export function runMetrics(args, options = {}) {
       return 0;
     });
   } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
-    return 2;
+    return reportCliFailure(argsWantJson(args), describeCliError(error));
   }
 }

--- a/packages/gittensory-miner/lib/orb-export.js
+++ b/packages/gittensory-miner/lib/orb-export.js
@@ -5,6 +5,7 @@ import { DatabaseSync } from "node:sqlite";
 import { createHmac, randomBytes } from "node:crypto";
 import { readPrOutcomes } from "./pr-outcome.js";
 import { initEventLedger } from "./event-ledger.js";
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
 
 // Optional anonymized Orb telemetry export (#4277). The self-host Orb collector (src/selfhost/orb-collector.ts,
 // #1255) is ALWAYS-ON for a maintainer's own instance; a miner runs on a third-party contributor's laptop with a
@@ -157,8 +158,7 @@ export function parseOrbExportArgs(args) {
 export function runOrbExportCli(args, options = {}) {
   const parsed = parseOrbExportArgs(args);
   if ("error" in parsed) {
-    console.error(parsed.error);
-    return 2;
+    return reportCliFailure(argsWantJson(args), parsed.error);
   }
 
   // Open the stores INSIDE the try so a bad config path / SQLite open failure returns 2 instead of crashing the
@@ -180,8 +180,7 @@ export function runOrbExportCli(args, options = {}) {
     else console.log(`${batch.length} anonymized event(s)`);
     return 0;
   } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
-    return 2;
+    return reportCliFailure(parsed.json, describeCliError(error));
   } finally {
     if (ownsStore) store?.close();
     if (ownsLedger) eventLedger?.close();

--- a/packages/gittensory-miner/lib/plan-store-cli.js
+++ b/packages/gittensory-miner/lib/plan-store-cli.js
@@ -1,4 +1,5 @@
 import { PLAN_STATUSES, openPlanStore } from "./plan-store.js";
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
 
 const PLAN_LIST_USAGE =
   "Usage: gittensory-miner plan list [--status pending|running|completed|failed] [--json]";
@@ -101,8 +102,7 @@ function withPlanStore(options, run) {
 export function runPlanList(args, options = {}) {
   const parsed = parsePlanListArgs(args);
   if ("error" in parsed) {
-    console.error(parsed.error);
-    return 2;
+    return reportCliFailure(argsWantJson(args), parsed.error);
   }
 
   try {
@@ -116,24 +116,21 @@ export function runPlanList(args, options = {}) {
       return 0;
     });
   } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
-    return 2;
+    return reportCliFailure(parsed.json, describeCliError(error));
   }
 }
 
 export function runPlanShow(args, options = {}) {
   const parsed = parsePlanShowArgs(args);
   if ("error" in parsed) {
-    console.error(parsed.error);
-    return 2;
+    return reportCliFailure(argsWantJson(args), parsed.error);
   }
 
   try {
     return withPlanStore(options, (planStore) => {
       const plan = planStore.loadPlan(parsed.planId);
       if (!plan) {
-        console.error("plan_not_found");
-        return 2;
+        return reportCliFailure(parsed.json, "plan_not_found");
       }
       if (parsed.json) {
         console.log(JSON.stringify({ plan }, null, 2));
@@ -143,14 +140,12 @@ export function runPlanShow(args, options = {}) {
       return 0;
     });
   } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
-    return 2;
+    return reportCliFailure(parsed.json, describeCliError(error));
   }
 }
 
 export function runPlanCli(subcommand, args, options = {}) {
   if (subcommand === "list") return runPlanList(args, options);
   if (subcommand === "show") return runPlanShow(args, options);
-  console.error(`Unknown plan subcommand: ${subcommand ?? ""}. ${PLAN_LIST_USAGE}`);
-  return 2;
+  return reportCliFailure(argsWantJson(args), `Unknown plan subcommand: ${subcommand ?? ""}. ${PLAN_LIST_USAGE}`);
 }

--- a/packages/gittensory-miner/lib/portfolio-dashboard.js
+++ b/packages/gittensory-miner/lib/portfolio-dashboard.js
@@ -9,6 +9,7 @@
 // collector below is factored so it is directly reusable once such a channel exists.
 
 import { initPortfolioQueueStore } from "./portfolio-queue.js";
+import { argsWantJson, reportCliFailure } from "./cli-error.js";
 
 const QUEUE_STATUS_KEYS = ["queued", "in_progress", "done"];
 
@@ -90,8 +91,7 @@ export function parsePortfolioDashboardArgs(args = []) {
 export function runPortfolioDashboard(args = [], options = {}) {
   const parsed = parsePortfolioDashboardArgs(args);
   if ("error" in parsed) {
-    console.error(parsed.error);
-    return 2;
+    return reportCliFailure(argsWantJson(args), parsed.error);
   }
   const ownsQueue = options.initPortfolioQueue === undefined;
   const portfolioQueue = (options.initPortfolioQueue ?? initPortfolioQueueStore)();

--- a/packages/gittensory-miner/lib/portfolio-queue-cli.js
+++ b/packages/gittensory-miner/lib/portfolio-queue-cli.js
@@ -1,6 +1,7 @@
 import { initPortfolioQueueStore } from "./portfolio-queue.js";
 import { initPortfolioQueueManager } from "./portfolio-queue-manager.js";
 import { runPortfolioDashboard } from "./portfolio-dashboard.js";
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
 
 const QUEUE_LIST_USAGE = "Usage: gittensory-miner queue list [--repo <owner/repo>] [--json]";
 const QUEUE_NEXT_USAGE = "Usage: gittensory-miner queue next [--json]";
@@ -156,8 +157,7 @@ function withPortfolioQueue(options, run) {
 export function runQueueList(args, options = {}) {
   const parsed = parseQueueListArgs(args);
   if ("error" in parsed) {
-    console.error(parsed.error);
-    return 2;
+    return reportCliFailure(argsWantJson(args), parsed.error);
   }
 
   try {
@@ -171,16 +171,14 @@ export function runQueueList(args, options = {}) {
       return 0;
     });
   } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
-    return 2;
+    return reportCliFailure(parsed.json, describeCliError(error));
   }
 }
 
 export function runQueueNext(args, options = {}) {
   const parsed = parseQueueNextArgs(args);
   if ("error" in parsed) {
-    console.error(parsed.error);
-    return 2;
+    return reportCliFailure(argsWantJson(args), parsed.error);
   }
 
   try {
@@ -194,24 +192,21 @@ export function runQueueNext(args, options = {}) {
       return 0;
     });
   } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
-    return 2;
+    return reportCliFailure(parsed.json, describeCliError(error));
   }
 }
 
 export function runQueueDone(args, options = {}) {
   const parsed = parseQueueDoneArgs(args);
   if ("error" in parsed) {
-    console.error(parsed.error);
-    return 2;
+    return reportCliFailure(argsWantJson(args), parsed.error);
   }
 
   try {
     return withPortfolioQueue(options, (portfolioQueue) => {
       const entry = portfolioQueue.markDone(parsed.repoFullName, parsed.identifier);
       if (!entry) {
-        console.error("queue_entry_not_found");
-        return 2;
+        return reportCliFailure(parsed.json, "queue_entry_not_found");
       }
       if (parsed.json) {
         console.log(JSON.stringify({ entry }, null, 2));
@@ -221,8 +216,7 @@ export function runQueueDone(args, options = {}) {
       return 0;
     });
   } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
-    return 2;
+    return reportCliFailure(parsed.json, describeCliError(error));
   }
 }
 
@@ -231,16 +225,14 @@ export function runQueueDone(args, options = {}) {
 export function runQueueRelease(args, options = {}) {
   const parsed = parseQueueReleaseArgs(args);
   if ("error" in parsed) {
-    console.error(parsed.error);
-    return 2;
+    return reportCliFailure(argsWantJson(args), parsed.error);
   }
 
   try {
     return withPortfolioQueue(options, (portfolioQueue) => {
       const entry = portfolioQueue.reclaimStuckItem(parsed.repoFullName, parsed.identifier);
       if (!entry) {
-        console.error("queue_entry_not_in_progress");
-        return 2;
+        return reportCliFailure(parsed.json, "queue_entry_not_in_progress");
       }
       if (parsed.json) {
         console.log(JSON.stringify({ entry }, null, 2));
@@ -250,8 +242,7 @@ export function runQueueRelease(args, options = {}) {
       return 0;
     });
   } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
-    return 2;
+    return reportCliFailure(parsed.json, describeCliError(error));
   }
 }
 
@@ -261,16 +252,14 @@ export function runQueueRelease(args, options = {}) {
 export function runQueueRequeue(args, options = {}) {
   const parsed = parseQueueRequeueArgs(args);
   if ("error" in parsed) {
-    console.error(parsed.error);
-    return 2;
+    return reportCliFailure(argsWantJson(args), parsed.error);
   }
 
   try {
     return withPortfolioQueue(options, (portfolioQueue) => {
       const entry = portfolioQueue.requeueItem(parsed.repoFullName, parsed.identifier);
       if (!entry) {
-        console.error("queue_entry_not_requeuable");
-        return 2;
+        return reportCliFailure(parsed.json, "queue_entry_not_requeuable");
       }
       if (parsed.json) {
         console.log(JSON.stringify({ entry }, null, 2));
@@ -280,8 +269,7 @@ export function runQueueRequeue(args, options = {}) {
       return 0;
     });
   } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
-    return 2;
+    return reportCliFailure(parsed.json, describeCliError(error));
   }
 }
 
@@ -313,8 +301,7 @@ export function parseQueueClaimBatchArgs(args) {
 export function runQueueClaimBatch(args, options = {}) {
   const parsed = parseQueueClaimBatchArgs(args);
   if ("error" in parsed) {
-    console.error(parsed.error);
-    return 2;
+    return reportCliFailure(argsWantJson(args), parsed.error);
   }
 
   // Open the manager INSIDE the try so a store open failure returns 2 instead of crashing; the finally guards the
@@ -333,8 +320,7 @@ export function runQueueClaimBatch(args, options = {}) {
     }
     return 0;
   } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
-    return 2;
+    return reportCliFailure(parsed.json, describeCliError(error));
   } finally {
     if (ownsManager) manager?.close();
   }
@@ -348,6 +334,5 @@ export function runQueueCli(subcommand, args, options = {}) {
   if (subcommand === "requeue") return runQueueRequeue(args, options);
   if (subcommand === "claim-batch") return runQueueClaimBatch(args, options);
   if (subcommand === "dashboard") return runPortfolioDashboard(args, options);
-  console.error(`Unknown queue subcommand: ${subcommand ?? ""}. ${QUEUE_LIST_USAGE}`);
-  return 2;
+  return reportCliFailure(argsWantJson(args), `Unknown queue subcommand: ${subcommand ?? ""}. ${QUEUE_LIST_USAGE}`);
 }

--- a/packages/gittensory-miner/lib/run-state-cli.js
+++ b/packages/gittensory-miner/lib/run-state-cli.js
@@ -1,4 +1,5 @@
 import { RUN_STATES, getRunState, setRunState } from "./run-state.js";
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
 
 const STATE_GET_USAGE = "Usage: gittensory-miner state get <owner/repo> [--json]";
 const STATE_SET_USAGE =
@@ -76,8 +77,7 @@ export function parseStateSetArgs(args) {
 export function runStateGet(args) {
   const parsed = parseStateGetArgs(args);
   if ("error" in parsed) {
-    console.error(parsed.error);
-    return 2;
+    return reportCliFailure(argsWantJson(args), parsed.error);
   }
 
   try {
@@ -89,16 +89,14 @@ export function runStateGet(args) {
     }
     return 0;
   } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
-    return 2;
+    return reportCliFailure(parsed.json, describeCliError(error));
   }
 }
 
 export function runStateSet(args) {
   const parsed = parseStateSetArgs(args);
   if ("error" in parsed) {
-    console.error(parsed.error);
-    return 2;
+    return reportCliFailure(argsWantJson(args), parsed.error);
   }
 
   try {
@@ -110,14 +108,12 @@ export function runStateSet(args) {
     }
     return 0;
   } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
-    return 2;
+    return reportCliFailure(parsed.json, describeCliError(error));
   }
 }
 
 export function runStateCli(subcommand, args) {
   if (subcommand === "get") return runStateGet(args);
   if (subcommand === "set") return runStateSet(args);
-  console.error(`Unknown state subcommand: ${subcommand ?? ""}. ${STATE_GET_USAGE}`);
-  return 2;
+  return reportCliFailure(argsWantJson(args), `Unknown state subcommand: ${subcommand ?? ""}. ${STATE_GET_USAGE}`);
 }

--- a/test/unit/miner-cli-error.test.ts
+++ b/test/unit/miner-cli-error.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  argsWantJson,
+  describeCliError,
+  reportCliFailure,
+} from "../../packages/gittensory-miner/lib/cli-error.js";
+
+describe("cli-error (#4836)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("reportCliFailure logs plain text to stderr when --json is absent", () => {
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    expect(reportCliFailure(false, "bad args")).toBe(2);
+    expect(err).toHaveBeenCalledWith("bad args");
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it("reportCliFailure emits parseable JSON on stdout when --json is set", () => {
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    expect(reportCliFailure(true, "bad args", 2)).toBe(2);
+    expect(log).toHaveBeenCalledWith(JSON.stringify({ ok: false, error: "bad args" }, null, 2));
+    expect(err).not.toHaveBeenCalled();
+  });
+
+  it("argsWantJson detects --json in argv", () => {
+    expect(argsWantJson(["discover", "acme/widgets", "--json"])).toBe(true);
+    expect(argsWantJson(["discover", "acme/widgets"])).toBe(false);
+  });
+
+  it("describeCliError normalizes thrown values", () => {
+    expect(describeCliError(new Error("boom"))).toBe("boom");
+    expect(describeCliError("plain")).toBe("plain");
+  });
+});

--- a/test/unit/miner-cli.test.ts
+++ b/test/unit/miner-cli.test.ts
@@ -81,6 +81,19 @@ describe("gittensory-miner CLI helpers", () => {
     );
   });
 
+  it("emits JSON for unknown commands when --json is set (#4836)", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    expect(
+      runCli(["mystery", "--json"], { packageName: "@jsonbored/gittensory-miner" }),
+    ).toBe(1);
+    expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+      ok: false,
+      error: "Unknown command: mystery. Run @jsonbored/gittensory-miner --help.",
+    });
+    expect(error).not.toHaveBeenCalled();
+  });
+
   it("keeps the CLI version source aligned with package metadata", async () => {
     const packageJson = await import(
       "../../packages/gittensory-miner/package.json",

--- a/test/unit/miner-event-ledger-cli.test.ts
+++ b/test/unit/miner-event-ledger-cli.test.ts
@@ -210,8 +210,18 @@ describe("gittensory-miner ledger metrics CLI (#4841)", () => {
 
   it("runLedgerMetrics rejects unexpected arguments with a usage error", () => {
     const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
     expect(runLedgerMetrics(["--json"], { initEventLedger: () => tempLedger() })).toBe(2);
+    expect(error).not.toHaveBeenCalled();
+    expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+      ok: false,
+      error: "Usage: gittensory-miner ledger metrics",
+    });
+    error.mockClear();
+    log.mockClear();
+    expect(runLedgerMetrics(["--nope"], { initEventLedger: () => tempLedger() })).toBe(2);
     expect(error).toHaveBeenCalledWith("Usage: gittensory-miner ledger metrics");
+    expect(log).not.toHaveBeenCalled();
   });
 
   it("runLedgerMetrics surfaces a thrown Error message and exits non-zero", () => {

--- a/test/unit/miner-init-verify-token.test.ts
+++ b/test/unit/miner-init-verify-token.test.ts
@@ -278,4 +278,22 @@ describe("runInit", () => {
       "GITHUB_TOKEN verification failed: Bad credentials",
     );
   });
+
+  it("emits JSON when token verification fails with --json (#4836)", async () => {
+    const { env } = makeTempEnv();
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      mockJsonResponse({ message: "Bad credentials" }, { status: 401 }),
+    );
+
+    const exitCode = await runInit(["--json", "--verify-token"], env);
+
+    expect(exitCode).toBe(1);
+    expect(JSON.parse(String(logSpy.mock.calls[0]?.[0]))).toEqual({
+      ok: false,
+      error: "GITHUB_TOKEN verification failed: Bad credentials",
+    });
+    expect(errorSpy).not.toHaveBeenCalled();
+  });
 });

--- a/test/unit/miner-metrics-cli.test.ts
+++ b/test/unit/miner-metrics-cli.test.ts
@@ -85,8 +85,18 @@ describe("gittensory-miner metrics CLI (#4838)", () => {
 
   it("runMetrics rejects unexpected arguments with a usage error", () => {
     const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
     expect(runMetrics(["--json"], { initPredictionLedger: () => tempLedger() })).toBe(2);
+    expect(error).not.toHaveBeenCalled();
+    expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+      ok: false,
+      error: "Usage: gittensory-miner metrics",
+    });
+    error.mockClear();
+    log.mockClear();
+    expect(runMetrics(["--nope"], { initPredictionLedger: () => tempLedger() })).toBe(2);
     expect(error).toHaveBeenCalledWith("Usage: gittensory-miner metrics");
+    expect(log).not.toHaveBeenCalled();
   });
 
   it("runMetrics surfaces a thrown Error message and exits non-zero", () => {

--- a/test/unit/miner-portfolio-dashboard.test.ts
+++ b/test/unit/miner-portfolio-dashboard.test.ts
@@ -86,5 +86,13 @@ describe("runPortfolioDashboard (#4287)", () => {
     const err = vi.spyOn(console, "error").mockImplementation(() => {});
     expect(runPortfolioDashboard(["--bad"], { initPortfolioQueue: () => store })).toBe(2);
     expect(String(err.mock.calls[0]?.[0])).toContain("Unknown option");
+    log.mockClear();
+    err.mockClear();
+    expect(runPortfolioDashboard(["--bad", "--json"], { initPortfolioQueue: () => store })).toBe(2);
+    expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+      ok: false,
+      error: expect.stringContaining("Unknown option"),
+    });
+    expect(err).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Add shared `cli-error` helper (`reportCliFailure`, `argsWantJson`, `describeCliError`) so miner CLI failure paths emit `{ ok: false, error }` on stdout when `--json` is set, matching each command's success-path JSON stream.
- Wire the helper across miner subcommands (discover, queue, claim, ledger, plan, governor, state, manage, attempt, loop, feasibility, calibration, orb export, hooks check, init verify-token, unknown command).
- Add unit tests for the helper plus `--json` failure coverage in portfolio dashboard, init verify-token, and unknown-command paths.

Closes #4836

## Test plan
- [x] `npx vitest run test/unit/miner-cli-error.test.ts test/unit/miner-cli.test.ts test/unit/miner-portfolio-dashboard.test.ts test/unit/miner-init-verify-token.test.ts`
- [x] `npx vitest run test/unit/miner-discover-cli.test.ts test/unit/miner-manage-poll.test.ts test/unit/miner-manage-status.test.ts test/unit/miner-orb-export.test.ts test/unit/miner-calibration-cli.test.ts test/unit/miner-cli-deny-check.test.ts test/unit/miner-wire-cli-modules.test.ts`