### PR TITLE
feat(miner): add a gittensory-miner migrate command for the local stores

### DIFF
--- a/packages/gittensory-miner/README.md
+++ b/packages/gittensory-miner/README.md
@@ -159,7 +159,7 @@ gittensory-miner doctor
 gittensory-miner status
 ```
 
-`init` creates `~/.config/gittensory-miner/` (or `GITTENSORY_MINER_CONFIG_DIR` / `XDG_CONFIG_HOME` overrides) and a local `laptop-state.sqlite3` bootstrap file. Re-running `init` is idempotent. Pass `--verify-token` to make one authenticated GitHub API call up front and fail fast if `GITHUB_TOKEN` is invalid or missing repository access scopes. `doctor` reports Node, the state directory, SQLite readiness, and whether Docker is installed (informational only).
+`init` creates `~/.config/gittensory-miner/` (or `GITTENSORY_MINER_CONFIG_DIR` / `XDG_CONFIG_HOME` overrides) and a local `laptop-state.sqlite3` bootstrap file. Re-running `init` is idempotent. Pass `--verify-token` to make one authenticated GitHub API call up front and fail fast if `GITHUB_TOKEN` is invalid or missing repository access scopes. `doctor` reports Node, the state directory, SQLite readiness, and whether Docker is installed (informational only). Every local store already applies its own pending schema migrations automatically the moment some other command first opens it, but `migrate` lets an operator proactively bring every EXISTING store file up to date in one pass (e.g. right after upgrading) instead of relying on whichever command happens to touch a given store first; a store file that hasn't been created yet is reported as skipped, not created.
 
 From a local checkout:
 
@@ -203,6 +203,7 @@ gittensory-miner version
 gittensory-miner init [--json] [--verify-token]
 gittensory-miner status [--json]
 gittensory-miner doctor [--json]
+gittensory-miner migrate [--json]
 gittensory-miner manage status [--json]
 gittensory-miner manage poll <owner/repo> <pr#> [--branch <name>] [--json]
 ```

--- a/packages/gittensory-miner/bin/gittensory-miner.js
+++ b/packages/gittensory-miner/bin/gittensory-miner.js
@@ -18,6 +18,7 @@ import { runOrbExportCli } from "../lib/orb-export.js";
 import { installCliSignalHandlers } from "../lib/process-lifecycle.js";
 import { runStateCli } from "../lib/run-state-cli.js";
 import { runInit } from "../lib/laptop-init.js";
+import { runMigrate } from "../lib/migrate-cli.js";
 import { runDoctor, runStatus } from "../lib/status.js";
 import {
   awaitOpportunisticUpdateCheck,
@@ -47,6 +48,12 @@ if (cliArgs[0] === "status") {
 
 if (cliArgs[0] === "doctor") {
   process.exit(runDoctor(cliArgs.slice(1)));
+}
+
+// `migrate` is strictly local + offline like `status`/`doctor` (it only opens the local SQLite stores), so it is
+// dispatched here too, before the opportunistic npm-registry update check is ever started.
+if (cliArgs[0] === "migrate") {
+  process.exit(runMigrate(cliArgs.slice(1)));
 }
 
 // `metrics` is strictly local + offline like `status`/`doctor` (it reads only the local prediction ledger), so it

--- a/packages/gittensory-miner/docs/operations-runbook.md
+++ b/packages/gittensory-miner/docs/operations-runbook.md
@@ -175,18 +175,24 @@ Stores use the lightweight **`schema-version.js`** convention ([#4832](https://g
 
 3. **Install** the new version (`npm install -g @jsonbored/gittensory-miner@latest`, rebuild image, …). The CLI prints a one-line npm upgrade nudge when behind registry latest — informational only.
 
-4. **Start** one miner process. On first store open, pending migrations apply automatically (today: e.g. `portfolio-queue` adds `leased_at` when upgrading from pre-#4827 files).
+4. **Migrate**, before starting any miner process, so every existing store is brought up to date in one
+   deliberate pass instead of relying on whichever command happens to open a given store first:
 
-5. **Verify**:
+   ```sh
+   gittensory-miner migrate --json
+   ```
+
+   (Pending migrations still apply automatically on first open regardless — e.g. `portfolio-queue` adds
+   `leased_at` when upgrading from pre-#4827 files — `migrate` is the proactive, explicit alternative to
+   waiting for that implicit path. A store file that hasn't been created yet is reported as skipped, not
+   created; `migrate` never bootstraps fresh state.)
+
+5. **Start** one miner process, then **verify**:
 
    ```sh
    gittensory-miner doctor --json
    gittensory-miner status --json
-   # Optional: inspect schema versions
-   for f in "$STATE_DIR"/*.sqlite3; do
-     echo "== $f =="
-     sqlite3 "$f" "PRAGMA user_version;"
-   done
+   gittensory-miner migrate --json   # re-run: every store should now report "up-to-date"
    ```
 
 6. If a migration throws on startup, **do not delete files immediately** — restore the pre-upgrade tarball, pin the previous package version, and file an issue with the failing `user_version` and store filename.

--- a/packages/gittensory-miner/lib/cli.js
+++ b/packages/gittensory-miner/lib/cli.js
@@ -17,6 +17,7 @@ export function printHelp(input) {
       "  gittensory-miner init [--json] [--verify-token]              Bootstrap laptop-mode local SQLite state",
       "  gittensory-miner status [--json]                              Show installed versions + local state paths",
       "  gittensory-miner doctor [--json]                              Check this laptop is set up correctly",
+      "  gittensory-miner migrate [--json]                             Apply pending schema migrations to existing local stores",
       "  gittensory-miner metrics                                      Print prediction-calibration counters in Prometheus text format",
       "  gittensory-miner manage status [--json]                       Show managed PR rows from local portfolio + ledger",
       "  gittensory-miner manage poll <owner/repo> <pr#> [--branch <name>] [--json]",

--- a/packages/gittensory-miner/lib/migrate-cli.d.ts
+++ b/packages/gittensory-miner/lib/migrate-cli.d.ts
@@ -1,0 +1,24 @@
+export type MigrateStatus = "skipped" | "up-to-date" | "migrated" | "failed";
+
+export type MigrateResult = {
+  name: string;
+  dbPath: string;
+  ok: boolean;
+  status: MigrateStatus;
+  detail: string;
+  versionBefore: number | null;
+  versionAfter: number | null;
+};
+
+export type MigrateStoreDescriptor = {
+  name: string;
+  resolveDbPath: (env?: Record<string, string | undefined>) => string;
+  open: (dbPath: string) => { close: () => void };
+};
+
+export function runMigrateChecks(
+  env?: Record<string, string | undefined>,
+  stores?: MigrateStoreDescriptor[],
+): MigrateResult[];
+
+export function runMigrate(args?: string[], env?: Record<string, string | undefined>): number;

--- a/packages/gittensory-miner/lib/migrate-cli.js
+++ b/packages/gittensory-miner/lib/migrate-cli.js
@@ -1,0 +1,111 @@
+// Proactive schema-migration runner for the miner's local SQLite stores (#4871). Every store already applies
+// its own pending migrations (schema-version.js's applySchemaMigrations) as a side effect of being opened by
+// whatever command happens to touch it first -- this command instead lets an operator PROACTIVELY bring every
+// known store's EXISTING on-disk file up to date in one pass (e.g. right after upgrading, or before starting a
+// fleet), without needing to guess which command happens to touch which store first. Mirrors status.js's
+// storeIntegrityChecks [name, resolve*DbPath(env)] store list exactly (same seven stores `doctor` already
+// covers), but actually OPENS each store (rather than a read-only integrity probe) so its real open/init
+// function's migration path runs for real. A store file that does not exist yet is skipped, not created --
+// "migrate" brings existing files up to date; it is not another way to bootstrap fresh state (that's `init`).
+import { existsSync } from "node:fs";
+import { DatabaseSync } from "node:sqlite";
+import { readSchemaVersion } from "./schema-version.js";
+import { openClaimLedger, resolveClaimLedgerDbPath } from "./claim-ledger.js";
+import { initEventLedger, resolveEventLedgerDbPath } from "./event-ledger.js";
+import { initGovernorLedger, resolveGovernorLedgerDbPath } from "./governor-ledger.js";
+import { initPredictionLedger, resolvePredictionLedgerDbPath } from "./prediction-ledger.js";
+import { initPortfolioQueueStore, resolvePortfolioQueueDbPath } from "./portfolio-queue.js";
+import { initRunStateStore, resolveRunStateDbPath } from "./run-state.js";
+import { openPlanStore, resolvePlanStoreDbPath } from "./plan-store.js";
+
+const STORES = [
+  { name: "event-ledger", resolveDbPath: resolveEventLedgerDbPath, open: initEventLedger },
+  { name: "governor-ledger", resolveDbPath: resolveGovernorLedgerDbPath, open: initGovernorLedger },
+  { name: "prediction-ledger", resolveDbPath: resolvePredictionLedgerDbPath, open: initPredictionLedger },
+  { name: "portfolio-queue", resolveDbPath: resolvePortfolioQueueDbPath, open: initPortfolioQueueStore },
+  { name: "claim-ledger", resolveDbPath: resolveClaimLedgerDbPath, open: openClaimLedger },
+  { name: "run-state", resolveDbPath: resolveRunStateDbPath, open: initRunStateStore },
+  { name: "plan-store", resolveDbPath: resolvePlanStoreDbPath, open: openPlanStore },
+];
+
+/** Read a store file's stamped schema version without ever creating it -- matches checkStoreIntegrity's
+ *  "not created yet" convention: an absent file has nothing to report a version for. */
+function peekSchemaVersion(dbPath) {
+  const db = new DatabaseSync(dbPath, { readOnly: true });
+  try {
+    return readSchemaVersion(db);
+  } finally {
+    db.close();
+  }
+}
+
+/**
+ * Bring one store's EXISTING on-disk schema up to date. Never throws: a store that fails to open/migrate is
+ * reported as a failed result so one bad store cannot abort the whole sweep, matching doctor's per-store
+ * isolation. A store file that does not exist yet is reported as a clean skip (nothing to migrate), never
+ * created as a side effect of running this command.
+ * @returns {{ name: string, dbPath: string, ok: boolean, status: "skipped"|"up-to-date"|"migrated"|"failed", detail: string, versionBefore: number|null, versionAfter: number|null }}
+ */
+function migrateStore({ name, resolveDbPath, open }, env) {
+  const dbPath = resolveDbPath(env);
+  if (!existsSync(dbPath)) {
+    return {
+      name,
+      dbPath,
+      ok: true,
+      status: "skipped",
+      detail: "not created yet",
+      versionBefore: null,
+      versionAfter: null,
+    };
+  }
+  // versionBefore is read INSIDE the same try as the migration itself: a corrupted file can throw on this very
+  // first read (a store that can't even be opened has no readable version either), and that must still surface
+  // as one failed store result rather than an uncaught exception aborting the whole sweep.
+  let versionBefore = null;
+  try {
+    versionBefore = peekSchemaVersion(dbPath);
+    const store = open(dbPath);
+    store.close();
+    const versionAfter = peekSchemaVersion(dbPath);
+    return {
+      name,
+      dbPath,
+      ok: true,
+      status: versionAfter > versionBefore ? "migrated" : "up-to-date",
+      detail: `v${versionBefore} -> v${versionAfter}`,
+      versionBefore,
+      versionAfter,
+    };
+  } catch (error) {
+    return {
+      name,
+      dbPath,
+      ok: false,
+      status: "failed",
+      detail: error instanceof Error ? error.message : String(error),
+      versionBefore,
+      versionAfter: versionBefore,
+    };
+  }
+}
+
+/** `stores` is injectable so tests can exercise a store descriptor's failure paths (e.g. a non-Error throw)
+ *  without depending on real node:sqlite error shapes; defaults to the real seven-store list. */
+export function runMigrateChecks(env = process.env, stores = STORES) {
+  return stores.map((store) => migrateStore(store, env));
+}
+
+export function runMigrate(args = [], env = process.env) {
+  const results = runMigrateChecks(env);
+  const failed = results.filter((result) => !result.ok);
+  if (args.includes("--json")) {
+    console.log(JSON.stringify({ ok: failed.length === 0, stores: results }, null, 2));
+  } else {
+    for (const result of results) {
+      console.log(`${result.ok ? result.status.padEnd(10) : "FAIL      "} ${result.name}: ${result.detail}`);
+    }
+    if (failed.length > 0) console.error(`migrate: ${failed.length} store(s) failed`);
+  }
+  return failed.length === 0 ? 0 : 1;
+}

--- a/test/unit/miner-cli.test.ts
+++ b/test/unit/miner-cli.test.ts
@@ -65,6 +65,7 @@ describe("gittensory-miner CLI helpers", () => {
     expect(text).toContain("gittensory-miner --help");
     expect(text).toContain("gittensory-miner version");
     expect(text).toContain("gittensory-miner metrics");
+    expect(text).toContain("gittensory-miner migrate [--json]");
     expect(text).toContain("gittensory-miner ledger metrics");
     expect(text).toContain("--no-update-check");
   });

--- a/test/unit/miner-migrate-cli.test.ts
+++ b/test/unit/miner-migrate-cli.test.ts
@@ -1,0 +1,164 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runMigrate, runMigrateChecks } from "../../packages/gittensory-miner/lib/migrate-cli.js";
+import { initPortfolioQueueStore, resolvePortfolioQueueDbPath } from "../../packages/gittensory-miner/lib/portfolio-queue.js";
+import { resolveEventLedgerDbPath } from "../../packages/gittensory-miner/lib/event-ledger.js";
+
+const roots: string[] = [];
+
+function tempEnv() {
+  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-migrate-"));
+  roots.push(root);
+  return { GITTENSORY_MINER_CONFIG_DIR: join(root, "state") };
+}
+
+const STORE_NAMES = [
+  "event-ledger",
+  "governor-ledger",
+  "prediction-ledger",
+  "portfolio-queue",
+  "claim-ledger",
+  "run-state",
+  "plan-store",
+];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("gittensory-miner migrate (#4871)", () => {
+  it("covers the exact same seven stores doctor's store-integrity sweep covers, in the same order, and skips every one when nothing has been created yet", () => {
+    const env = tempEnv();
+    const results = runMigrateChecks(env);
+
+    expect(results.map((result) => result.name)).toEqual(STORE_NAMES);
+    for (const result of results) {
+      expect(result.ok).toBe(true);
+      expect(result.status).toBe("skipped");
+      expect(result.detail).toBe("not created yet");
+      expect(result.versionBefore).toBeNull();
+      expect(result.versionAfter).toBeNull();
+      // Invariant: a skip must never create the file as a side effect -- migrate brings EXISTING stores up
+      // to date, it is not another way to bootstrap fresh state.
+      expect(existsSync(result.dbPath)).toBe(false);
+    }
+  });
+
+  it("reports 'up-to-date' for a store that was freshly initialized at its current target schema version", () => {
+    const env = tempEnv();
+    initPortfolioQueueStore(resolvePortfolioQueueDbPath(env)).close();
+
+    const results = runMigrateChecks(env);
+    const portfolioQueue = results.find((result) => result.name === "portfolio-queue");
+
+    expect(portfolioQueue?.status).toBe("up-to-date");
+    expect(portfolioQueue?.ok).toBe(true);
+    expect(portfolioQueue?.versionBefore).toBe(portfolioQueue?.versionAfter);
+    expect(portfolioQueue?.versionBefore).toBeGreaterThan(0);
+  });
+
+  it("actually migrates a pre-existing older-schema portfolio-queue file, bumping its stamped version and adding the missing column", () => {
+    const env = tempEnv();
+    const dbPath = resolvePortfolioQueueDbPath(env);
+    mkdirSync(dirname(dbPath), { recursive: true });
+
+    // Hand-build the PRE-#4832 baseline shape: no `leased_at` column, stamped at schema version 1 (the
+    // baseline), simulating a real operator's on-disk file from before the leased_at migration existed.
+    const seedDb = new DatabaseSync(dbPath);
+    seedDb.exec(`
+      CREATE TABLE miner_portfolio_queue (
+        repo_full_name TEXT NOT NULL,
+        identifier TEXT NOT NULL,
+        priority REAL NOT NULL DEFAULT 0,
+        status TEXT NOT NULL DEFAULT 'queued' CHECK (status IN ('queued', 'in_progress', 'done')),
+        enqueued_at TEXT NOT NULL,
+        PRIMARY KEY (repo_full_name, identifier)
+      )
+    `);
+    seedDb.exec("PRAGMA user_version = 1");
+    seedDb.close();
+
+    const results = runMigrateChecks(env);
+    const portfolioQueue = results.find((result) => result.name === "portfolio-queue");
+
+    expect(portfolioQueue).toMatchObject({ ok: true, status: "migrated", versionBefore: 1, versionAfter: 2 });
+
+    const verifyDb = new DatabaseSync(dbPath, { readOnly: true });
+    try {
+      expect(
+        verifyDb.prepare("PRAGMA table_info(miner_portfolio_queue)").all().some((column) => column.name === "leased_at"),
+      ).toBe(true);
+      expect(verifyDb.prepare("PRAGMA user_version").get()?.user_version).toBe(2);
+    } finally {
+      verifyDb.close();
+    }
+  });
+
+  it("reports a failed store (and leaves every other store's own result untouched) when one store file is corrupted", () => {
+    const env = tempEnv();
+    const eventLedgerPath = resolveEventLedgerDbPath(env);
+    mkdirSync(dirname(eventLedgerPath), { recursive: true });
+    writeFileSync(eventLedgerPath, "this is not a sqlite database");
+
+    const results = runMigrateChecks(env);
+    const eventLedger = results.find((result) => result.name === "event-ledger");
+    const others = results.filter((result) => result.name !== "event-ledger");
+
+    expect(eventLedger?.ok).toBe(false);
+    expect(eventLedger?.status).toBe("failed");
+    expect(typeof eventLedger?.detail).toBe("string");
+    for (const other of others) expect(other.ok).toBe(true);
+  });
+
+  it("formats a non-Error thrown value into a detail string (defensive fallback: real node:sqlite failures always throw Error, but the fallback path is still real code)", () => {
+    const env = tempEnv();
+    const dbPath = join(dirname(resolvePortfolioQueueDbPath(env)), "fake-store.sqlite3");
+    mkdirSync(dirname(dbPath), { recursive: true });
+    new DatabaseSync(dbPath).close(); // a valid, openable, empty sqlite file (schema version 0)
+
+    const results = runMigrateChecks(env, [
+      {
+        name: "fake-store",
+        resolveDbPath: () => dbPath,
+        open: () => {
+          throw "boom"; // deliberately non-Error, exercising the ternary's fallback branch
+        },
+      },
+    ]);
+
+    expect(results).toEqual([
+      { name: "fake-store", dbPath, ok: false, status: "failed", detail: "boom", versionBefore: 0, versionAfter: 0 },
+    ]);
+  });
+
+  it("runMigrate prints human-readable text (exit 0) and machine JSON with --json, and exits 1 when a store fails", () => {
+    const healthyEnv = tempEnv();
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    expect(runMigrate([], healthyEnv)).toBe(0);
+    expect(String(log.mock.calls[0]?.[0])).toContain("skipped");
+    log.mockClear();
+
+    expect(runMigrate(["--json"], healthyEnv)).toBe(0);
+    const payload = JSON.parse(String(log.mock.calls[0]?.[0]));
+    expect(payload.ok).toBe(true);
+    expect(payload.stores).toHaveLength(STORE_NAMES.length);
+
+    const brokenEnv = tempEnv();
+    const eventLedgerPath = resolveEventLedgerDbPath(brokenEnv);
+    mkdirSync(dirname(eventLedgerPath), { recursive: true });
+    writeFileSync(eventLedgerPath, "this is not a sqlite database");
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(runMigrate([], brokenEnv)).toBe(1);
+    expect(errorLog).toHaveBeenCalledWith(expect.stringContaining("1 store(s) failed"));
+  });
+
+  it("makes no network calls", () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    runMigrateChecks(tempEnv());
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Every local SQLite store the miner uses (`event-ledger`, `governor-ledger`, `prediction-ledger`,
  `portfolio-queue`, `claim-ledger`, `run-state`, `plan-store`) already applies its own pending schema
  migrations (`schema-version.js`'s `applySchemaMigrations`, from #4832, confirmed shipped and already wired
  into all seven stores' `init`/`open` functions) automatically as a side effect of being opened by whatever
  command happens to touch it first — but there was no way to *proactively* bring every existing store up to
  date in one deliberate pass (e.g. right after upgrading, or before starting a fleet) without guessing which
  command touches which store.
- Added `packages/gittensory-miner/lib/migrate-cli.js` (+ a matching hand-written `.d.ts`), wired as a new
  `gittensory-miner migrate [--json]` command. It mirrors `status.js`'s `storeIntegrityChecks` `[name,
  resolve*DbPath(env)]` list exactly — same seven stores, same order — but instead of a read-only integrity
  probe, it actually *opens* each store that already exists on disk (via that store's own real `init`/`open`
  function), so its real migration path runs, then reports the schema version before/after per store. A store
  file that hasn't been created yet is reported as a clean `skipped`, never created as a side effect — `migrate`
  brings *existing* state up to date; it does not bootstrap new state (that's `init`'s job).
- Wired the dispatch in `bin/gittensory-miner.js` (same local/offline early-dispatch block as `status`/`doctor`)
  and added the command to `cli.js`'s `--help` text, `README.md`'s command list, and `docs/operations-runbook.md`,
  where the existing "migrate ledgers after a package upgrade" scenario previously told an operator to just
  "start one miner process" and rely on implicit migration, or hand-loop `sqlite3 ... PRAGMA user_version` to
  check versions — now updated to reference `gittensory-miner migrate --json` as the explicit, proactive step.

Fixes #4871

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — `packages/gittensory-miner/lib/**/*.js` **is** included in this repo's `codecov/patch` gate (unlike `apps/gittensory-miner-ui`/`apps/gittensory-miner-extension`, which are excluded). Ran `npx vitest run test/unit/miner-migrate-cli.test.ts --coverage --coverage.include="packages/gittensory-miner/lib/migrate-cli.js"` directly against the new file: **100% statements, 100% branches, 100% functions, 100% lines**.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

Ran the full local gate: `npm run test:ci` (799 test files, 0 failures, including `build:miner`/`test:miner-pack` picking up the two new `lib/` files via the package's existing `"files": ["bin", "lib", ...]` glob with no changes needed there) and `npm audit --audit-level=moderate` (0 vulnerabilities), both clean on the final rebased commit.

New test file `test/unit/miner-migrate-cli.test.ts` (7 tests): every store skipped (not created) on a fresh state dir, with an explicit assertion the files are never created as a side effect; a freshly-initialized store reporting `up-to-date` at its already-current version; a hand-built pre-#4832-shape `portfolio-queue` file (baseline table, no `leased_at` column, `user_version = 1`) actually migrating to version 2 with the column added, verified via a fresh read; a corrupted store file reported as one `failed` result without aborting the other six stores' results; the human-text vs `--json` output shapes and the exit-1-on-failure path; and a dedicated branch-coverage test injecting a fake store descriptor whose `open()` throws a non-`Error` value, to cover the `error instanceof Error ? ... : String(error)` fallback branch that real `node:sqlite` failures never exercise (they always throw `Error`). Also added one assertion to the existing `miner-cli.test.ts` help-text test.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no auth/session/CORS surface touched (local SQLite files only, no network calls — asserted directly by a "makes no network calls" test).
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — no public API/OpenAPI/MCP surface touched; this is a new local CLI subcommand only.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI surface.
- [x] Visible UI changes include a `UI Evidence` section below. — N/A, see below.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — updated `README.md` and `docs/operations-runbook.md`.

## UI Evidence

N/A — this is a local CLI-only change (a new terminal subcommand) with no visible UI surface. No screenshots apply.

## Notes

- Writing thorough tests before ever opening a PR caught three real defects that a shallower test pass would have missed:
  1. `versionBefore` was originally read **outside** the `try`/`catch` in `migrateStore` — a corrupted store file threw uncaught right there, crashing the entire sweep instead of reporting that one store as a failed result (caught by the "corrupted store" test; fixed by moving the read inside the same `try`).
  2. Used `readonly: true` instead of the correct `readOnly` `DatabaseSyncOptions` key. Node's `node:sqlite` **silently ignores** the misspelled key rather than throwing or warning — confirmed empirically with a small repro script (a `DatabaseSync` opened with `{ readonly: true }` happily accepted a write). Fixed in the new code. Note: `packages/gittensory-miner/lib/store-maintenance.js`'s pre-existing, already-shipped `checkStoreIntegrity` has this exact same typo — out of scope for this focused PR since it's a different file/concern (and harmless there in practice, since `PRAGMA integrity_check` never writes regardless), but flagging it here in case a maintainer wants a tiny separate follow-up.
  3. A branch-coverage check (not just "tests pass") surfaced that the `error instanceof Error ? ... : String(error)` fallback branch had zero coverage, since every real `node:sqlite` failure throws a genuine `Error`. Made the store list an injectable parameter (`runMigrateChecks(env, stores = STORES)`, matching this codebase's established DI-for-testability convention) so a dedicated test could exercise that branch directly with a fake non-`Error` throw.
