### PR TITLE
fix(miner): route queue next through the WIP-cap-aware claimer

### DIFF
--- a/packages/gittensory-miner/docs/miner-goal-spec.md
+++ b/packages/gittensory-miner/docs/miner-goal-spec.md
@@ -44,7 +44,9 @@ Issue labels a miner must skip.
 
 ### `maxConcurrentClaims` (integer `>= 1`, default: `1`)
 
-Maximum issues one miner may hold claimed on this repo at once.
+Maximum issues one miner may hold claimed on this repo at once. Enforced as `gittensory-miner queue next`'s
+per-repo WIP cap (#4850): discovered from the CWD's `.gittensory-miner.yml`, same as `status`/`doctor`'s own
+config-file lookup, falling back to an unbounded cap only when no config file exists at all.
 
 ### `issueDiscoveryPolicy` (`encouraged` | `neutral` | `discouraged`, default: `neutral`)
 

--- a/packages/gittensory-miner/lib/portfolio-queue-cli.d.ts
+++ b/packages/gittensory-miner/lib/portfolio-queue-cli.d.ts
@@ -1,3 +1,4 @@
+import type { PortfolioCaps } from "@jsonbored/gittensory-engine";
 import type { PortfolioQueueStore, QueueEntry } from "./portfolio-queue.js";
 import type { PortfolioQueueManager } from "./portfolio-queue-manager.js";
 
@@ -41,9 +42,18 @@ export function runQueueList(
   options?: { initPortfolioQueue?: () => PortfolioQueueStore },
 ): number;
 
+export function resolveQueueNextCaps(
+  cwd?: string,
+  deps?: { existsSync?: (path: string) => boolean; readFileSync?: (path: string, encoding: "utf8") => string },
+): PortfolioCaps;
+
 export function runQueueNext(
   args: string[],
-  options?: { initPortfolioQueue?: () => PortfolioQueueStore },
+  options?: {
+    initPortfolioQueueManager?: (opts: unknown) => PortfolioQueueManager;
+    resolveQueueNextCaps?: (cwd?: string) => PortfolioCaps;
+    cwd?: string;
+  },
 ): number;
 
 export function runQueueDone(
@@ -72,5 +82,7 @@ export function runQueueCli(
   options?: {
     initPortfolioQueue?: () => PortfolioQueueStore;
     initPortfolioQueueManager?: (opts: unknown) => PortfolioQueueManager;
+    resolveQueueNextCaps?: (cwd?: string) => PortfolioCaps;
+    cwd?: string;
   },
 ): number;

--- a/packages/gittensory-miner/lib/portfolio-queue-cli.js
+++ b/packages/gittensory-miner/lib/portfolio-queue-cli.js
@@ -1,6 +1,30 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { discoverMinerGoalSpecPath, parseMinerGoalSpecContent } from "@jsonbored/gittensory-engine";
 import { initPortfolioQueueStore } from "./portfolio-queue.js";
 import { initPortfolioQueueManager } from "./portfolio-queue-manager.js";
 import { runPortfolioDashboard } from "./portfolio-dashboard.js";
+
+// No MinerGoalSpec field bounds the portfolio-wide (cross-repo) WIP count today, so `queue next` (#4850) only
+// enforces the per-repo cap from config; this stands in for "no cap" without tripping the caps-aware selector's
+// own `cap === 0` ⇒ "claim nothing" rule (queue.ts), which a non-finite/undefined value would.
+const UNBOUNDED_WIP_CAP = Number.MAX_SAFE_INTEGER;
+
+/**
+ * Resolve `queue next`'s per-repo WIP cap from the CWD's discovered `.gittensory-miner.yml` (mirrors status.js's
+ * own config-file discovery), reusing `maxConcurrentClaims` -- already documented as "max issues a single miner
+ * may hold claimed on this repo at once" -- rather than inventing a new field. Falls back to an effectively
+ * unbounded cap when NO config file exists at all, so an operator who has never configured a cap keeps today's
+ * uncapped `queue next` behavior unchanged; the cap only applies once a config file is actually present (#4850).
+ */
+export function resolveQueueNextCaps(cwd = process.cwd(), deps = {}) {
+  const exists = deps.existsSync ?? existsSync;
+  const read = deps.readFileSync ?? readFileSync;
+  const relativePath = discoverMinerGoalSpecPath((candidate) => exists(join(cwd, candidate)));
+  if (!relativePath) return { globalWipCap: UNBOUNDED_WIP_CAP, perRepoWipCap: UNBOUNDED_WIP_CAP };
+  const { spec } = parseMinerGoalSpecContent(read(join(cwd, relativePath), "utf8"));
+  return { globalWipCap: UNBOUNDED_WIP_CAP, perRepoWipCap: spec.maxConcurrentClaims };
+}
 
 const QUEUE_LIST_USAGE = "Usage: gittensory-miner queue list [--repo <owner/repo>] [--json]";
 const QUEUE_NEXT_USAGE = "Usage: gittensory-miner queue next [--json]";
@@ -176,6 +200,8 @@ export function runQueueList(args, options = {}) {
   }
 }
 
+/** Claim the single next eligible item via the WIP-cap-aware claimer (portfolio-queue-manager.js's
+ *  `claimNext()`), respecting the per-repo cap configured via `.gittensory-miner.yml` (#4850). */
 export function runQueueNext(args, options = {}) {
   const parsed = parseQueueNextArgs(args);
   if ("error" in parsed) {
@@ -183,19 +209,25 @@ export function runQueueNext(args, options = {}) {
     return 2;
   }
 
+  // Open the manager INSIDE the try so a store/config-read failure returns 2 instead of crashing; the finally
+  // guards the close with `?.` since the initializer may have thrown before assigning (mirrors claim-batch).
+  const ownsManager = options.initPortfolioQueueManager === undefined;
+  let manager;
   try {
-    return withPortfolioQueue(options, (portfolioQueue) => {
-      const entry = portfolioQueue.dequeueNext();
-      if (parsed.json) {
-        console.log(JSON.stringify({ entry }, null, 2));
-      } else {
-        console.log(entry ? entry.identifier : "none");
-      }
-      return 0;
-    });
+    const caps = (options.resolveQueueNextCaps ?? resolveQueueNextCaps)(options.cwd);
+    manager = (options.initPortfolioQueueManager ?? initPortfolioQueueManager)({ caps });
+    const entry = manager.claimNext();
+    if (parsed.json) {
+      console.log(JSON.stringify({ entry }, null, 2));
+    } else {
+      console.log(entry ? entry.identifier : "none");
+    }
+    return 0;
   } catch (error) {
     console.error(error instanceof Error ? error.message : String(error));
     return 2;
+  } finally {
+    if (ownsManager) manager?.close();
   }
 }
 

--- a/packages/gittensory-miner/lib/portfolio-queue-manager.d.ts
+++ b/packages/gittensory-miner/lib/portfolio-queue-manager.d.ts
@@ -34,6 +34,7 @@ export type PortfolioQueueManager = {
   markFailed(repoFullName: string, identifier: string): QueueEntry | null;
   reclaimStuckItems(maxLeaseMs?: number): QueueEntry[];
   claimNextBatch(): QueueEntry[];
+  claimNext(): QueueEntry | null;
   close(): void;
 };
 

--- a/packages/gittensory-miner/lib/portfolio-queue-manager.js
+++ b/packages/gittensory-miner/lib/portfolio-queue-manager.js
@@ -1,7 +1,8 @@
 // Stateful PortfolioQueueManager (#4285): compose the persisted SQLite portfolio/queue store
 // (portfolio-queue.js, #2292) with the pure engine selector (nextEligibleItems, queue.ts, #2326) so batch
-// claiming respects global/per-repo WIP caps and cross-repo diversification instead of a naive priority-only
-// single-row dequeue. Caps are plain constructor arguments — not wired to .gittensory-miner.yml here.
+// (and, since #4850, single-item) claiming respects global/per-repo WIP caps and cross-repo diversification
+// instead of a naive priority-only single-row dequeue. Caps are plain constructor arguments here -- reading
+// them from .gittensory-miner.yml is the caller's job (portfolio-queue-cli.js's runQueueNext, for #4850).
 import { nextEligibleItems } from "@jsonbored/gittensory-engine";
 import { initPortfolioQueueStore } from "./portfolio-queue.js";
 import { DEFAULT_MAX_LEASE_MS, sweepStuckItems } from "./portfolio-queue-expiry.js";
@@ -104,6 +105,15 @@ export function initPortfolioQueueManager(options = {}) {
       // instead of permanently consuming a WIP slot and starving the queue.
       sweepStuckItems(store, Date.now(), staleLeaseMs);
       return store.batchClaim((entries) => selectEligibleBatch(entries, caps));
+    },
+    /** Claim exactly the single highest-priority eligible item under the same caps-aware, diversified selection
+     *  `claimNextBatch()` uses -- the caps-respecting counterpart to the old naive single-row `dequeueNext()`
+     *  (#4850). Slicing the selector's result to one keeps every cap/diversification rule identical; it never
+     *  claims more than the one item the caller asked for. Returns null when nothing is eligible. */
+    claimNext() {
+      sweepStuckItems(store, Date.now(), staleLeaseMs);
+      const claimed = store.batchClaim((entries) => selectEligibleBatch(entries, caps).slice(0, 1));
+      return claimed[0] ?? null;
     },
     close() {
       store.close();

--- a/test/unit/miner-portfolio-queue-cli.test.ts
+++ b/test/unit/miner-portfolio-queue-cli.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -6,6 +6,7 @@ import {
   closeDefaultPortfolioQueueStore,
   initPortfolioQueueStore,
 } from "../../packages/gittensory-miner/lib/portfolio-queue.js";
+import { initPortfolioQueueManager } from "../../packages/gittensory-miner/lib/portfolio-queue-manager.js";
 import {
   parseQueueDoneArgs,
   parseQueueListArgs,
@@ -13,6 +14,7 @@ import {
   parseQueueReleaseArgs,
   parseQueueRequeueArgs,
   renderQueueTable,
+  resolveQueueNextCaps,
   runQueueCli,
   runQueueDone,
   runQueueList,
@@ -22,12 +24,19 @@ import {
 } from "../../packages/gittensory-miner/lib/portfolio-queue-cli.js";
 import type { QueueEntry } from "../../packages/gittensory-miner/lib/portfolio-queue.d.ts";
 
+const UNBOUNDED_CAPS = { globalWipCap: Number.MAX_SAFE_INTEGER, perRepoWipCap: Number.MAX_SAFE_INTEGER };
+
 const roots: string[] = [];
 const stores: Array<{ close(): void }> = [];
 
-function tempQueueStore() {
+function tempRoot() {
   const root = mkdtempSync(join(tmpdir(), "gittensory-miner-portfolio-queue-cli-"));
   roots.push(root);
+  return root;
+}
+
+function tempQueueStore() {
+  const root = tempRoot();
   const store = initPortfolioQueueStore(join(root, "portfolio-queue.sqlite3"));
   stores.push(store);
   return store;
@@ -97,15 +106,18 @@ describe("gittensory-miner portfolio queue CLI (#2292)", () => {
     });
   });
 
-  it("runQueueNext claims the highest-priority queued item", () => {
+  it("runQueueNext claims the highest-priority queued item, uncapped by default (no config file present)", () => {
     const portfolioQueue = tempQueueStore();
     portfolioQueue.enqueue({ repoFullName: "acme/widgets", identifier: "issue:1", priority: 10 });
     portfolioQueue.enqueue({ repoFullName: "acme/widgets", identifier: "issue:2", priority: 90 });
+    const manager = initPortfolioQueueManager({ store: portfolioQueue, caps: UNBOUNDED_CAPS });
+    const cwd = tempRoot(); // isolated, config-less working dir -- never depend on the real repo's own filesystem
 
     const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
     expect(
       runQueueNext([], {
-        initPortfolioQueue: () => portfolioQueue,
+        initPortfolioQueueManager: () => manager,
+        cwd,
       }),
     ).toBe(0);
     expect(log).toHaveBeenCalledWith("issue:2");
@@ -113,20 +125,115 @@ describe("gittensory-miner portfolio queue CLI (#2292)", () => {
     log.mockClear();
     expect(
       runQueueNext(["--json"], {
-        initPortfolioQueue: () => portfolioQueue,
+        initPortfolioQueueManager: () => manager,
+        cwd,
       }),
     ).toBe(0);
     expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
       entry: expect.objectContaining({ identifier: "issue:1", status: "in_progress" }),
     });
 
+    // Both same-repo items are now claimed with no per-repo cap in force -- "none" left because the queue is
+    // genuinely empty, not because of any WIP cap.
     log.mockClear();
     expect(
       runQueueNext([], {
-        initPortfolioQueue: () => portfolioQueue,
+        initPortfolioQueueManager: () => manager,
+        cwd,
       }),
     ).toBe(0);
     expect(log).toHaveBeenCalledWith("none");
+  });
+
+  describe("WIP-cap-aware queue next (#4850)", () => {
+    it("stops claiming once the configured per-repo cap is reached, leaving a second same-repo item queued", () => {
+      const portfolioQueue = tempQueueStore();
+      portfolioQueue.enqueue({ repoFullName: "acme/widgets", identifier: "issue:1", priority: 10 });
+      portfolioQueue.enqueue({ repoFullName: "acme/widgets", identifier: "issue:2", priority: 90 });
+      const manager = initPortfolioQueueManager({
+        store: portfolioQueue,
+        caps: { globalWipCap: UNBOUNDED_CAPS.globalWipCap, perRepoWipCap: 1 },
+      });
+
+      const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+      expect(runQueueNext([], { initPortfolioQueueManager: () => manager })).toBe(0);
+      expect(log).toHaveBeenCalledWith("issue:2"); // the higher-priority item claims the repo's one WIP slot
+
+      log.mockClear();
+      expect(runQueueNext([], { initPortfolioQueueManager: () => manager })).toBe(0);
+      expect(log).toHaveBeenCalledWith("none"); // capped, even though issue:1 is still queued and eligible otherwise
+
+      expect(portfolioQueue.listQueue("acme/widgets").find((entry) => entry.identifier === "issue:1")?.status).toBe(
+        "queued",
+      );
+    });
+
+    it("resolveQueueNextCaps falls back to an effectively unbounded cap when no config file exists", () => {
+      const root = tempRoot();
+      expect(resolveQueueNextCaps(root)).toEqual(UNBOUNDED_CAPS);
+    });
+
+    it("resolveQueueNextCaps reads the per-repo cap from maxConcurrentClaims in a discovered .gittensory-miner.yml", () => {
+      const root = tempRoot();
+      writeFileSync(join(root, ".gittensory-miner.yml"), "maxConcurrentClaims: 3\n");
+      expect(resolveQueueNextCaps(root)).toEqual({ globalWipCap: UNBOUNDED_CAPS.globalWipCap, perRepoWipCap: 3 });
+    });
+
+    it("resolveQueueNextCaps falls back to MinerGoalSpec's own default (1) when a config file exists but omits maxConcurrentClaims", () => {
+      const root = tempRoot();
+      writeFileSync(join(root, ".gittensory-miner.yml"), "minerEnabled: true\n");
+      expect(resolveQueueNextCaps(root)).toEqual({ globalWipCap: UNBOUNDED_CAPS.globalWipCap, perRepoWipCap: 1 });
+    });
+
+    it("resolveQueueNextCaps checks the documented discovery order, preferring .gittensory-miner.yml over the .github/ and .json variants", () => {
+      const root = tempRoot();
+      mkdirSync(join(root, ".github"), { recursive: true });
+      writeFileSync(join(root, ".github", "gittensory-miner.yml"), "maxConcurrentClaims: 9\n");
+      writeFileSync(join(root, ".gittensory-miner.yml"), "maxConcurrentClaims: 2\n");
+      expect(resolveQueueNextCaps(root).perRepoWipCap).toBe(2);
+    });
+
+    it("runQueueNext resolves caps from process.cwd() by default and from an injected resolveQueueNextCaps override", () => {
+      const portfolioQueue = tempQueueStore();
+      portfolioQueue.enqueue({ repoFullName: "acme/widgets", identifier: "issue:1", priority: 10 });
+      const manager = initPortfolioQueueManager({ store: portfolioQueue, caps: { globalWipCap: 1, perRepoWipCap: 1 } });
+      let receivedCwd = null;
+
+      const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+      expect(
+        runQueueNext([], {
+          initPortfolioQueueManager: () => manager,
+          resolveQueueNextCaps: (cwd) => {
+            receivedCwd = cwd;
+            return { globalWipCap: 1, perRepoWipCap: 1 };
+          },
+        }),
+      ).toBe(0);
+      expect(log).toHaveBeenCalledWith("issue:1");
+      expect(receivedCwd).toBeUndefined();
+    });
+
+    it("returns 2 (not a crash) when caps resolution throws", () => {
+      const errorLog = vi.spyOn(console, "error").mockImplementation(() => undefined);
+      const code = runQueueNext([], {
+        resolveQueueNextCaps: () => {
+          throw new Error("bad_config");
+        },
+      });
+      expect(code).toBe(2);
+      expect(errorLog).toHaveBeenCalledWith("bad_config");
+    });
+
+    it("formats a non-Error thrown value into the error message (defensive fallback)", () => {
+      const errorLog = vi.spyOn(console, "error").mockImplementation(() => undefined);
+      const code = runQueueNext([], {
+        resolveQueueNextCaps: () => {
+          throw "boom"; // deliberately non-Error, exercising the ternary's fallback branch
+        },
+      });
+      expect(code).toBe(2);
+      expect(errorLog).toHaveBeenCalledWith("boom");
+    });
   });
 
   it("runQueueDone marks an item done and rejects missing entries", () => {


### PR DESCRIPTION
## Summary

- A WIP-cap-aware, diversified batch claimer (`portfolio-queue-manager.js`'s `claimNextBatch()`, built for #4285)
  already existed and was wired into `queue claim-batch` — but the CLI's actual `queue next` (the subcommand
  miners run to claim one item) still called `portfolio-queue.js`'s naive, uncapped `dequeueNext()` directly, and
  the cap had no config-file path at all (`portfolio-queue-manager.js`'s own top-of-file comment stated this
  outright: "Caps are plain constructor arguments — not wired to `.gittensory-miner.yml` here.").
- Added `claimNext()` to `portfolio-queue-manager.js`: it reuses the *exact same* caps-aware, cross-repo
  diversified selection logic `claimNextBatch()` uses (`selectEligibleBatch`), just sliced to the single
  highest-priority eligible item, inside the same `store.batchClaim` transaction — no duplicated selection logic,
  no engine changes.
- `queue next` (`runQueueNext` in `portfolio-queue-cli.js`) now opens the manager (mirroring `queue claim-batch`'s
  own open/close discipline) and calls `claimNext()` instead of the raw store's `dequeueNext()`.
- The per-repo cap comes from a new `resolveQueueNextCaps()` helper that discovers and reads `.gittensory-miner.yml`
  from the CWD (mirroring `status.js`'s own `.gittensory-miner.yml` discovery order exactly) and reuses the
  **existing** `MinerGoalSpec` field `maxConcurrentClaims` — already documented as "max issues a single miner may
  hold claimed on this repo at once," and confirmed (via `grep`) to be completely unread anywhere in the miner
  package before this PR — rather than inventing a new config field. This keeps the PR's footprint entirely
  inside `packages/gittensory-miner/**`; **zero changes to `packages/gittensory-engine/src/miner-goal-spec.ts`**.
- When no config file exists at all, the per-repo cap falls back to `Number.MAX_SAFE_INTEGER` (effectively
  unbounded), so an operator who has never configured `maxConcurrentClaims` sees **exactly the same** `queue next`
  behavior as before this PR — the cap only takes effect once a config file is actually present. (There is no
  existing `MinerGoalSpec` field for a cross-repo *global* WIP cap, so the global cap is left unbounded for
  `queue next` in this PR; only the per-repo cap the issue's config wiring targets is enforced.)

Fixes #4850

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — `packages/gittensory-miner/lib/**/*.js` **is** included in this repo's `codecov/patch` gate. Rather than just trusting "tests pass," I cross-referenced `git diff`'s unified hunks against the LCOV `DA`/`BRDA` records from a targeted coverage run (`--coverage.include` scoped to the two touched `lib/` files): every line/branch the coverage report flagged as uncovered was verified, line-by-line, to be pre-existing code the diff never touches (e.g. `runQueueDone`/`runQueueList`/`parseQueueItemId`'s own unrelated error paths); the new `claimNext()`, `resolveQueueNextCaps()`, and the rewritten `runQueueNext()` body have full line and branch coverage, confirmed down to individual branch IDs (including both the `Error` and non-`Error` exception-formatting sides of the fallback ternary).
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

Ran the full local gate: `npm run test:ci` (799 test files, 0 failures — specifically checked for any regression in `loop-cli`/queue-related test files, none found) and `npm audit --audit-level=moderate` (0 vulnerabilities), both clean on the final commit.

`test/unit/miner-portfolio-queue-cli.test.ts` (25 tests, up from 17): updated the pre-existing "claims the highest-priority queued item" test to construct an explicit unbounded-cap manager (preserving its exact prior assertions — two same-repo claims still both succeed with no config file present) and added a new "WIP-cap-aware queue next (#4850)" block: cap enforcement leaving a second same-repo item queued (not claimed) once the configured cap is reached; `resolveQueueNextCaps`'s no-config fallback, its reading of `maxConcurrentClaims` from a discovered config file, its fallback to `MinerGoalSpec`'s own default (1) when a config file exists but omits the field, and its adherence to the documented `.gittensory-miner.yml` → `.github/gittensory-miner.yml` → `.json` discovery order; `runQueueNext`'s injectable `resolveQueueNextCaps`/`cwd` options; and both the `Error` and non-`Error` branches of the exception-formatting fallback.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no auth/session/CORS surface touched (local SQLite + local config-file read only).
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — no public API/OpenAPI/MCP surface touched; this changes an internal CLI subcommand's claiming behavior only.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI surface.
- [x] Visible UI changes include a `UI Evidence` section below. — N/A, see below.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — updated `docs/miner-goal-spec.md`'s `maxConcurrentClaims` section to document it's now enforced.

## UI Evidence

N/A — this is a local CLI-only behavior change (how `queue next` selects the next item to claim) with no visible UI surface. No screenshots apply.

## Notes

- Deliberately did **not** touch `loop-cli.js`, which also calls `dequeueNext()` directly (in 4 places, for the
  autonomous discover→claim→attempt→reenter loop) — the issue's acceptance criteria is scoped to the `queue next`
  CLI subcommand specifically ("Setting a WIP cap in config and running `queue next` repeatedly stops claiming
  once the cap is reached"), and wiring the same cap-aware claimer into the loop is a distinct, larger surface
  (the loop's claim-then-attempt-then-reenter cycle has its own retry/backoff semantics around `dequeueNext()`
  worth reviewing on its own) better suited to a separate, focused follow-up if wanted.
- Reused the existing `maxConcurrentClaims` field instead of adding a new one specifically to avoid touching
  `packages/gittensory-engine/src/miner-goal-spec.ts` (a `src/**` Codecov-covered file) for this PR — if a
  maintainer wants a distinct field name or a separate global-cap config surface, that's straightforward to layer
  on top of `resolveQueueNextCaps()` without touching the claiming logic itself.
