### PR TITLE
feat(miner): route queue next through WIP-cap-aware claimer (#4850)

### DIFF
--- a/packages/gittensory-miner/lib/cli.js
+++ b/packages/gittensory-miner/lib/cli.js
@@ -28,7 +28,7 @@ export function printHelp(input) {
       "  gittensory-miner loop --search <query> --miner-login <login> [--max-cycles <n>] [--cycle-delay-ms <ms>] [--json]",
       "                                                                 Autonomous discover->claim->attempt->reenter loop",
       "  gittensory-miner queue list [--repo <owner/repo>] [--json]    List portfolio backlog rows",
-      "  gittensory-miner queue next [--json]                          Claim the highest-priority queued item",
+      "  gittensory-miner queue next [--global-wip <n>] [--per-repo-wip <n>] [--json]  Claim next item under WIP caps",
       "  gittensory-miner queue claim-batch [--global-wip <n>] [--per-repo-wip <n>] [--json]",
       "  gittensory-miner queue done <owner/repo> <identifier> [--json]",
       "  gittensory-miner queue release <owner/repo> <identifier> [--json]  Return a claimed item to the queue",

--- a/packages/gittensory-miner/lib/portfolio-queue-caps.d.ts
+++ b/packages/gittensory-miner/lib/portfolio-queue-caps.d.ts
@@ -1,0 +1,4 @@
+export function resolvePortfolioQueueCaps(options?: {
+  env?: NodeJS.ProcessEnv;
+  cliCaps?: { globalWipCap?: number; perRepoWipCap?: number };
+}): { globalWipCap: number; perRepoWipCap: number };

--- a/packages/gittensory-miner/lib/portfolio-queue-caps.d.ts
+++ b/packages/gittensory-miner/lib/portfolio-queue-caps.d.ts
@@ -1,4 +1,4 @@
 export function resolvePortfolioQueueCaps(options?: {
-  env?: NodeJS.ProcessEnv;
+  env?: Record<string, string | undefined>;
   cliCaps?: { globalWipCap?: number; perRepoWipCap?: number };
 }): { globalWipCap: number; perRepoWipCap: number };

--- a/packages/gittensory-miner/lib/portfolio-queue-caps.js
+++ b/packages/gittensory-miner/lib/portfolio-queue-caps.js
@@ -1,0 +1,64 @@
+import { existsSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { parse as parseYaml } from "yaml";
+import { normalizePortfolioCaps } from "./portfolio-queue-manager.js";
+import { resolveMinerStateDir } from "./status.js";
+
+const CONFIG_FILE_CANDIDATES = Object.freeze([
+  ".gittensory-miner.yml",
+  ".github/gittensory-miner.yml",
+  ".gittensory-miner.json",
+  ".github/gittensory-miner.json",
+]);
+
+function discoverConfigFile(cwd) {
+  for (const candidate of CONFIG_FILE_CANDIDATES) {
+    const path = join(cwd, candidate);
+    if (existsSync(path)) return path;
+  }
+  return null;
+}
+
+function readConfigCaps(stateDir) {
+  const configPath = discoverConfigFile(stateDir);
+  if (!configPath) return null;
+  try {
+    const raw = configPath.endsWith(".json") ? JSON.parse(readFileSync(configPath, "utf8")) : parseYaml(readFileSync(configPath, "utf8"));
+    const portfolioQueue = raw?.portfolioQueue;
+    if (!portfolioQueue || typeof portfolioQueue !== "object" || Array.isArray(portfolioQueue)) return null;
+    return normalizePortfolioCaps(portfolioQueue);
+  } catch {
+    return null;
+  }
+}
+
+function readEnvCaps(env) {
+  const caps = {};
+  if (typeof env.GITTENSORY_MINER_GLOBAL_WIP_CAP === "string" && env.GITTENSORY_MINER_GLOBAL_WIP_CAP.trim()) {
+    caps.globalWipCap = Number(env.GITTENSORY_MINER_GLOBAL_WIP_CAP);
+  }
+  if (typeof env.GITTENSORY_MINER_PER_REPO_WIP_CAP === "string" && env.GITTENSORY_MINER_PER_REPO_WIP_CAP.trim()) {
+    caps.perRepoWipCap = Number(env.GITTENSORY_MINER_PER_REPO_WIP_CAP);
+  }
+  return Object.keys(caps).length > 0 ? normalizePortfolioCaps(caps) : null;
+}
+
+/**
+ * Resolve WIP caps for portfolio claiming: operator `.gittensory-miner.yml` in the state dir, then env, then CLI
+ * flags (when provided), defaulting to `{ globalWipCap: 1, perRepoWipCap: 1 }`.
+ * @param {{ env?: NodeJS.ProcessEnv, cliCaps?: { globalWipCap?: number, perRepoWipCap?: number } }} [options]
+ */
+export function resolvePortfolioQueueCaps(options = {}) {
+  const env = options.env ?? process.env;
+  let caps = readConfigCaps(resolveMinerStateDir(env)) ?? { globalWipCap: 1, perRepoWipCap: 1 };
+  const envCaps = readEnvCaps(env);
+  if (envCaps) caps = envCaps;
+  const cliCaps = options.cliCaps ?? {};
+  if (cliCaps.globalWipCap !== undefined || cliCaps.perRepoWipCap !== undefined) {
+    caps = normalizePortfolioCaps({
+      globalWipCap: cliCaps.globalWipCap ?? caps.globalWipCap,
+      perRepoWipCap: cliCaps.perRepoWipCap ?? caps.perRepoWipCap,
+    });
+  }
+  return caps;
+}

--- a/packages/gittensory-miner/lib/portfolio-queue-cli.d.ts
+++ b/packages/gittensory-miner/lib/portfolio-queue-cli.d.ts
@@ -45,7 +45,11 @@ export function runQueueList(
 
 export function runQueueNext(
   args: string[],
-  options?: { initPortfolioQueue?: () => PortfolioQueueStore },
+  options?: {
+    env?: Record<string, string | undefined>;
+    dbPath?: string;
+    initPortfolioQueueManager?: (opts: unknown) => PortfolioQueueManager;
+  },
 ): number;
 
 export function runQueueDone(
@@ -66,7 +70,7 @@ export function runQueueRequeue(
 export function runQueueClaimBatch(
   args: string[],
   options?: {
-    env?: NodeJS.ProcessEnv;
+    env?: Record<string, string | undefined>;
     dbPath?: string;
     initPortfolioQueueManager?: (opts: unknown) => PortfolioQueueManager;
   },
@@ -76,7 +80,7 @@ export function runQueueCli(
   subcommand: string | undefined,
   args: string[],
   options?: {
-    env?: NodeJS.ProcessEnv;
+    env?: Record<string, string | undefined>;
     dbPath?: string;
     initPortfolioQueue?: () => PortfolioQueueStore;
     initPortfolioQueueManager?: (opts: unknown) => PortfolioQueueManager;

--- a/packages/gittensory-miner/lib/portfolio-queue-cli.d.ts
+++ b/packages/gittensory-miner/lib/portfolio-queue-cli.d.ts
@@ -8,7 +8,9 @@ export type ParsedQueueListArgs =
     }
   | { error: string };
 
-export type ParsedQueueNextArgs = { json: boolean } | { error: string };
+export type ParsedQueueNextArgs =
+  | { json: boolean; globalWipCap?: number; perRepoWipCap?: number }
+  | { error: string };
 
 export type ParsedQueueDoneArgs =
   | {
@@ -29,7 +31,7 @@ export function parseQueueReleaseArgs(args: string[]): ParsedQueueDoneArgs;
 export function parseQueueRequeueArgs(args: string[]): ParsedQueueDoneArgs;
 
 export type ParsedQueueClaimBatchArgs =
-  | { json: boolean; globalWipCap: number; perRepoWipCap: number }
+  | { json: boolean; globalWipCap?: number; perRepoWipCap?: number }
   | { error: string };
 
 export function parseQueueClaimBatchArgs(args: string[]): ParsedQueueClaimBatchArgs;
@@ -63,13 +65,19 @@ export function runQueueRequeue(
 
 export function runQueueClaimBatch(
   args: string[],
-  options?: { initPortfolioQueueManager?: (opts: unknown) => PortfolioQueueManager },
+  options?: {
+    env?: NodeJS.ProcessEnv;
+    dbPath?: string;
+    initPortfolioQueueManager?: (opts: unknown) => PortfolioQueueManager;
+  },
 ): number;
 
 export function runQueueCli(
   subcommand: string | undefined,
   args: string[],
   options?: {
+    env?: NodeJS.ProcessEnv;
+    dbPath?: string;
     initPortfolioQueue?: () => PortfolioQueueStore;
     initPortfolioQueueManager?: (opts: unknown) => PortfolioQueueManager;
   },

--- a/packages/gittensory-miner/lib/portfolio-queue-cli.js
+++ b/packages/gittensory-miner/lib/portfolio-queue-cli.js
@@ -1,9 +1,11 @@
 import { initPortfolioQueueStore } from "./portfolio-queue.js";
 import { initPortfolioQueueManager } from "./portfolio-queue-manager.js";
+import { resolvePortfolioQueueCaps } from "./portfolio-queue-caps.js";
 import { runPortfolioDashboard } from "./portfolio-dashboard.js";
 
 const QUEUE_LIST_USAGE = "Usage: gittensory-miner queue list [--repo <owner/repo>] [--json]";
-const QUEUE_NEXT_USAGE = "Usage: gittensory-miner queue next [--json]";
+const QUEUE_NEXT_USAGE =
+  "Usage: gittensory-miner queue next [--global-wip <n>] [--per-repo-wip <n>] [--json]";
 const QUEUE_DONE_USAGE = "Usage: gittensory-miner queue done <owner/repo> <identifier> [--json]";
 const QUEUE_RELEASE_USAGE = "Usage: gittensory-miner queue release <owner/repo> <identifier> [--json]";
 const QUEUE_REQUEUE_USAGE = "Usage: gittensory-miner queue requeue <owner/repo> <identifier> [--json]";
@@ -72,13 +74,36 @@ export function parseQueueListArgs(args) {
   return options;
 }
 
-export function parseQueueNextArgs(args) {
-  const parsed = parseJsonFlag(args);
-  if ("error" in parsed) return parsed;
-  if (parsed.positional.length > 0) {
-    return { error: QUEUE_NEXT_USAGE };
+function parsePortfolioQueueCapArgs(args, usage) {
+  const options = { json: false, globalWipCap: undefined, perRepoWipCap: undefined };
+
+  for (let index = 0; index < args.length; index += 1) {
+    const token = args[index];
+    if (token === "--json") {
+      options.json = true;
+      continue;
+    }
+    if (token === "--global-wip" || token === "--per-repo-wip") {
+      const value = Number(args[index + 1]);
+      if (args[index + 1] === undefined || !Number.isFinite(value) || value < 0) {
+        return { error: usage };
+      }
+      if (token === "--global-wip") options.globalWipCap = value;
+      else options.perRepoWipCap = value;
+      index += 1;
+      continue;
+    }
+    if (token.startsWith("-")) {
+      return { error: `Unknown option: ${token}` };
+    }
+    return { error: usage };
   }
-  return { json: parsed.json };
+
+  return options;
+}
+
+export function parseQueueNextArgs(args) {
+  return parsePortfolioQueueCapArgs(args, QUEUE_NEXT_USAGE);
 }
 
 /** Shared `<owner/repo> <identifier> [--json]` parse for the item-targeting subcommands (done/release/requeue).
@@ -183,19 +208,30 @@ export function runQueueNext(args, options = {}) {
     return 2;
   }
 
+  const caps = resolvePortfolioQueueCaps({
+    env: options.env ?? process.env,
+    cliCaps: { globalWipCap: parsed.globalWipCap, perRepoWipCap: parsed.perRepoWipCap },
+  });
+
+  const ownsManager = options.initPortfolioQueueManager === undefined;
+  let manager;
   try {
-    return withPortfolioQueue(options, (portfolioQueue) => {
-      const entry = portfolioQueue.dequeueNext();
-      if (parsed.json) {
-        console.log(JSON.stringify({ entry }, null, 2));
-      } else {
-        console.log(entry ? entry.identifier : "none");
-      }
-      return 0;
+    manager = (options.initPortfolioQueueManager ?? initPortfolioQueueManager)({
+      caps,
+      dbPath: options.dbPath,
     });
+    const entry = manager.claimNextBatch()[0] ?? null;
+    if (parsed.json) {
+      console.log(JSON.stringify({ entry }, null, 2));
+    } else {
+      console.log(entry ? entry.identifier : "none");
+    }
+    return 0;
   } catch (error) {
     console.error(error instanceof Error ? error.message : String(error));
     return 2;
+  } finally {
+    if (ownsManager) manager?.close();
   }
 }
 
@@ -286,26 +322,7 @@ export function runQueueRequeue(args, options = {}) {
 }
 
 export function parseQueueClaimBatchArgs(args) {
-  const options = { json: false, globalWipCap: 1, perRepoWipCap: 1 };
-  for (let index = 0; index < args.length; index += 1) {
-    const token = args[index];
-    if (token === "--json") {
-      options.json = true;
-      continue;
-    }
-    if (token === "--global-wip" || token === "--per-repo-wip") {
-      const value = Number(args[index + 1]);
-      if (args[index + 1] === undefined || !Number.isFinite(value) || value < 0) {
-        return { error: QUEUE_CLAIM_BATCH_USAGE };
-      }
-      if (token === "--global-wip") options.globalWipCap = value;
-      else options.perRepoWipCap = value;
-      index += 1;
-      continue;
-    }
-    return { error: QUEUE_CLAIM_BATCH_USAGE };
-  }
-  return options;
+  return parsePortfolioQueueCapArgs(args, QUEUE_CLAIM_BATCH_USAGE);
 }
 
 /** Claim the next caps-aware batch via the WIP-cap-aware batch claimer (portfolio-queue-manager.js), which also
@@ -319,11 +336,17 @@ export function runQueueClaimBatch(args, options = {}) {
 
   // Open the manager INSIDE the try so a store open failure returns 2 instead of crashing; the finally guards the
   // close with `?.` since the initializer may have thrown before assigning.
+  const caps = resolvePortfolioQueueCaps({
+    env: options.env ?? process.env,
+    cliCaps: { globalWipCap: parsed.globalWipCap, perRepoWipCap: parsed.perRepoWipCap },
+  });
+
   const ownsManager = options.initPortfolioQueueManager === undefined;
   let manager;
   try {
     manager = (options.initPortfolioQueueManager ?? initPortfolioQueueManager)({
-      caps: { globalWipCap: parsed.globalWipCap, perRepoWipCap: parsed.perRepoWipCap },
+      caps,
+      dbPath: options.dbPath,
     });
     const claimed = manager.claimNextBatch();
     if (parsed.json) {

--- a/packages/gittensory-miner/lib/portfolio-queue-manager.js
+++ b/packages/gittensory-miner/lib/portfolio-queue-manager.js
@@ -1,7 +1,7 @@
 // Stateful PortfolioQueueManager (#4285): compose the persisted SQLite portfolio/queue store
 // (portfolio-queue.js, #2292) with the pure engine selector (nextEligibleItems, queue.ts, #2326) so batch
 // claiming respects global/per-repo WIP caps and cross-repo diversification instead of a naive priority-only
-// single-row dequeue. Caps are plain constructor arguments — not wired to .gittensory-miner.yml here.
+// single-row dequeue. Caps resolve via resolvePortfolioQueueCaps() for queue next / claim-batch CLI paths.
 import { nextEligibleItems } from "@jsonbored/gittensory-engine";
 import { initPortfolioQueueStore } from "./portfolio-queue.js";
 import { DEFAULT_MAX_LEASE_MS, sweepStuckItems } from "./portfolio-queue-expiry.js";

--- a/test/unit/miner-portfolio-queue-caps.test.ts
+++ b/test/unit/miner-portfolio-queue-caps.test.ts
@@ -1,0 +1,67 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import { resolvePortfolioQueueCaps } from "../../packages/gittensory-miner/lib/portfolio-queue-caps.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("resolvePortfolioQueueCaps (#4850)", () => {
+  it("defaults to global/per-repo cap of 1", () => {
+    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-portfolio-queue-caps-"));
+    roots.push(root);
+    expect(
+      resolvePortfolioQueueCaps({
+        env: { GITTENSORY_MINER_CONFIG_DIR: root } as NodeJS.ProcessEnv,
+      }),
+    ).toEqual({ globalWipCap: 1, perRepoWipCap: 1 });
+  });
+
+  it("reads portfolioQueue caps from .gittensory-miner.yml in the state dir", () => {
+    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-portfolio-queue-caps-"));
+    roots.push(root);
+    writeFileSync(
+      join(root, ".gittensory-miner.yml"),
+      "portfolioQueue:\n  globalWipCap: 4\n  perRepoWipCap: 2\n",
+      "utf8",
+    );
+    expect(
+      resolvePortfolioQueueCaps({
+        env: { GITTENSORY_MINER_CONFIG_DIR: root } as NodeJS.ProcessEnv,
+      }),
+    ).toEqual({ globalWipCap: 4, perRepoWipCap: 2 });
+  });
+
+  it("env vars override config file and CLI flags override env", () => {
+    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-portfolio-queue-caps-"));
+    roots.push(root);
+    writeFileSync(join(root, ".gittensory-miner.yml"), "portfolioQueue:\n  globalWipCap: 4\n", "utf8");
+    const env = {
+      GITTENSORY_MINER_CONFIG_DIR: root,
+      GITTENSORY_MINER_GLOBAL_WIP_CAP: "3",
+      GITTENSORY_MINER_PER_REPO_WIP_CAP: "2",
+    } as NodeJS.ProcessEnv;
+    expect(resolvePortfolioQueueCaps({ env })).toEqual({ globalWipCap: 3, perRepoWipCap: 2 });
+    expect(
+      resolvePortfolioQueueCaps({
+        env,
+        cliCaps: { globalWipCap: 5 },
+      }),
+    ).toEqual({ globalWipCap: 5, perRepoWipCap: 2 });
+  });
+
+  it("ignores invalid config content and falls back to defaults", () => {
+    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-portfolio-queue-caps-"));
+    roots.push(root);
+    writeFileSync(join(root, ".gittensory-miner.yml"), "not: [valid", "utf8");
+    expect(
+      resolvePortfolioQueueCaps({
+        env: { GITTENSORY_MINER_CONFIG_DIR: root } as NodeJS.ProcessEnv,
+      }),
+    ).toEqual({ globalWipCap: 1, perRepoWipCap: 1 });
+  });
+});

--- a/test/unit/miner-portfolio-queue-caps.test.ts
+++ b/test/unit/miner-portfolio-queue-caps.test.ts
@@ -16,7 +16,7 @@ describe("resolvePortfolioQueueCaps (#4850)", () => {
     roots.push(root);
     expect(
       resolvePortfolioQueueCaps({
-        env: { GITTENSORY_MINER_CONFIG_DIR: root } as NodeJS.ProcessEnv,
+        env: { GITTENSORY_MINER_CONFIG_DIR: root },
       }),
     ).toEqual({ globalWipCap: 1, perRepoWipCap: 1 });
   });
@@ -31,7 +31,7 @@ describe("resolvePortfolioQueueCaps (#4850)", () => {
     );
     expect(
       resolvePortfolioQueueCaps({
-        env: { GITTENSORY_MINER_CONFIG_DIR: root } as NodeJS.ProcessEnv,
+        env: { GITTENSORY_MINER_CONFIG_DIR: root },
       }),
     ).toEqual({ globalWipCap: 4, perRepoWipCap: 2 });
   });
@@ -44,7 +44,7 @@ describe("resolvePortfolioQueueCaps (#4850)", () => {
       GITTENSORY_MINER_CONFIG_DIR: root,
       GITTENSORY_MINER_GLOBAL_WIP_CAP: "3",
       GITTENSORY_MINER_PER_REPO_WIP_CAP: "2",
-    } as NodeJS.ProcessEnv;
+    };
     expect(resolvePortfolioQueueCaps({ env })).toEqual({ globalWipCap: 3, perRepoWipCap: 2 });
     expect(
       resolvePortfolioQueueCaps({
@@ -60,7 +60,7 @@ describe("resolvePortfolioQueueCaps (#4850)", () => {
     writeFileSync(join(root, ".gittensory-miner.yml"), "not: [valid", "utf8");
     expect(
       resolvePortfolioQueueCaps({
-        env: { GITTENSORY_MINER_CONFIG_DIR: root } as NodeJS.ProcessEnv,
+        env: { GITTENSORY_MINER_CONFIG_DIR: root },
       }),
     ).toEqual({ globalWipCap: 1, perRepoWipCap: 1 });
   });

--- a/test/unit/miner-portfolio-queue-cli.test.ts
+++ b/test/unit/miner-portfolio-queue-cli.test.ts
@@ -36,8 +36,10 @@ function tempQueueStore() {
 
 function managerOptions(store: ReturnType<typeof initPortfolioQueueStore>, caps = { globalWipCap: 1, perRepoWipCap: 1 }) {
   return {
-    initPortfolioQueueManager: (opts: { caps?: { globalWipCap: number; perRepoWipCap: number } }) =>
-      initPortfolioQueueManager({ store, caps: opts.caps ?? caps }),
+    initPortfolioQueueManager: (opts: unknown) => {
+      const parsed = opts as { caps?: { globalWipCap: number; perRepoWipCap: number } };
+      return initPortfolioQueueManager({ store, caps: parsed.caps ?? caps });
+    },
   };
 }
 

--- a/test/unit/miner-portfolio-queue-cli.test.ts
+++ b/test/unit/miner-portfolio-queue-cli.test.ts
@@ -6,6 +6,7 @@ import {
   closeDefaultPortfolioQueueStore,
   initPortfolioQueueStore,
 } from "../../packages/gittensory-miner/lib/portfolio-queue.js";
+import { initPortfolioQueueManager } from "../../packages/gittensory-miner/lib/portfolio-queue-manager.js";
 import {
   parseQueueDoneArgs,
   parseQueueListArgs,
@@ -33,6 +34,13 @@ function tempQueueStore() {
   return store;
 }
 
+function managerOptions(store: ReturnType<typeof initPortfolioQueueStore>, caps = { globalWipCap: 1, perRepoWipCap: 1 }) {
+  return {
+    initPortfolioQueueManager: (opts: { caps?: { globalWipCap: number; perRepoWipCap: number } }) =>
+      initPortfolioQueueManager({ store, caps: opts.caps ?? caps }),
+  };
+}
+
 afterEach(() => {
   for (const store of stores.splice(0)) store.close();
   closeDefaultPortfolioQueueStore();
@@ -47,7 +55,12 @@ describe("gittensory-miner portfolio queue CLI (#2292)", () => {
       json: true,
       repoFullName: "acme/widgets",
     });
-    expect(parseQueueNextArgs(["--json"])).toEqual({ json: true });
+    expect(parseQueueNextArgs(["--json"])).toEqual({ json: true, globalWipCap: undefined, perRepoWipCap: undefined });
+    expect(parseQueueNextArgs(["--global-wip", "2", "--json"])).toEqual({
+      json: true,
+      globalWipCap: 2,
+      perRepoWipCap: undefined,
+    });
     expect(parseQueueDoneArgs(["acme/widgets", "issue:42", "--json"])).toEqual({
       repoFullName: "acme/widgets",
       identifier: "issue:42",
@@ -97,35 +110,37 @@ describe("gittensory-miner portfolio queue CLI (#2292)", () => {
     });
   });
 
-  it("runQueueNext claims the highest-priority queued item", () => {
+  it("runQueueNext claims the highest-priority queued item under WIP caps (#4850)", () => {
     const portfolioQueue = tempQueueStore();
     portfolioQueue.enqueue({ repoFullName: "acme/widgets", identifier: "issue:1", priority: 10 });
     portfolioQueue.enqueue({ repoFullName: "acme/widgets", identifier: "issue:2", priority: 90 });
 
     const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
-    expect(
-      runQueueNext([], {
-        initPortfolioQueue: () => portfolioQueue,
-      }),
-    ).toBe(0);
+    expect(runQueueNext([], managerOptions(portfolioQueue))).toBe(0);
     expect(log).toHaveBeenCalledWith("issue:2");
 
     log.mockClear();
-    expect(
-      runQueueNext(["--json"], {
-        initPortfolioQueue: () => portfolioQueue,
-      }),
-    ).toBe(0);
+    expect(runQueueNext([], managerOptions(portfolioQueue))).toBe(0);
+    expect(log).toHaveBeenCalledWith("none");
+
+    log.mockClear();
+    expect(runQueueNext(["--global-wip", "2", "--per-repo-wip", "2", "--json"], managerOptions(portfolioQueue))).toBe(0);
     expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
       entry: expect.objectContaining({ identifier: "issue:1", status: "in_progress" }),
     });
+  });
+
+  it("runQueueNext honors global WIP cap from CLI flags (#4850)", () => {
+    const portfolioQueue = tempQueueStore();
+    portfolioQueue.enqueue({ repoFullName: "acme/widgets", identifier: "issue:1", priority: 10 });
+    portfolioQueue.enqueue({ repoFullName: "acme/widgets", identifier: "issue:2", priority: 20 });
+
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    expect(runQueueNext(["--global-wip", "1"], managerOptions(portfolioQueue))).toBe(0);
+    expect(log).toHaveBeenCalledWith("issue:2");
 
     log.mockClear();
-    expect(
-      runQueueNext([], {
-        initPortfolioQueue: () => portfolioQueue,
-      }),
-    ).toBe(0);
+    expect(runQueueNext(["--global-wip", "1"], managerOptions(portfolioQueue))).toBe(0);
     expect(log).toHaveBeenCalledWith("none");
   });
 
@@ -153,7 +168,7 @@ describe("gittensory-miner portfolio queue CLI (#2292)", () => {
   it("runQueueCli dispatches list, next, and done subcommands", () => {
     const portfolioQueue = tempQueueStore();
     portfolioQueue.enqueue({ repoFullName: "acme/widgets", identifier: "issue:3", priority: 1 });
-    const options = { initPortfolioQueue: () => portfolioQueue };
+    const options = { ...managerOptions(portfolioQueue), initPortfolioQueue: () => portfolioQueue };
     const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
 
     expect(runQueueCli("list", ["--json"], options)).toBe(0);

--- a/test/unit/miner-wire-cli-modules.test.ts
+++ b/test/unit/miner-wire-cli-modules.test.ts
@@ -45,6 +45,11 @@ describe("queue claim-batch — wires the WIP-cap-aware batch claimer (#4833)", 
       globalWipCap: 3,
       perRepoWipCap: 1,
     });
+    expect(parseQueueClaimBatchArgs(["--json"])).toEqual({
+      json: true,
+      globalWipCap: undefined,
+      perRepoWipCap: undefined,
+    });
     expect(parseQueueClaimBatchArgs(["--global-wip", "x"])).toHaveProperty("error");
     expect(parseQueueClaimBatchArgs(["--per-repo-wip", "-1"])).toHaveProperty("error");
     expect(parseQueueClaimBatchArgs(["--bogus"])).toHaveProperty("error");


### PR DESCRIPTION
## Summary
- Route `queue next` through `PortfolioQueueManager.claimNextBatch()` instead of naive `dequeueNext()`.
- Add `resolvePortfolioQueueCaps()` to read `portfolioQueue.globalWipCap` / `perRepoWipCap` from operator `.gittensory-miner.yml` (state dir), with env and CLI flag overrides.
- Extend `queue next` with `--global-wip` / `--per-repo-wip` flags; `claim-batch` now also resolves caps from config when flags are omitted.

Closes #4850

## Test plan
- [x] Unit tests for cap resolution (config, env, CLI precedence)
- [x] `queue next` stops claiming once global WIP cap is reached
- [x] Existing portfolio queue CLI / claim-batch tests pass

Made with [Cursor](https://cursor.com)