### PR TITLE
docs(miner): add unattended scheduling & failure-alerting guidance (#4840)

### DIFF
--- a/packages/gittensory-miner/DEPLOYMENT.md
+++ b/packages/gittensory-miner/DEPLOYMENT.md
@@ -120,6 +120,8 @@ sudo systemctl enable --now gittensory-miner.service
 
 Because `loop` is a **long-running daemon that schedules its own cycles**, it is a persistent `Type=simple` service (with `Restart=on-failure`) — **not** a oneshot unit driven by a `.timer`, unlike the periodic `loopover-docker-prune.*.example` hygiene job in [`systemd/`](../../systemd/). Keep `GITHUB_TOKEN` (and any coding-agent credentials) in a root-owned `0600` `EnvironmentFile`, never in the unit file. Follow the loop with `journalctl -u gittensory-miner -f`; `systemctl stop` sends SIGTERM, which the loop handles cleanly at its next kill-switch check.
 
+The **one-shot** scheduled commands — `manage poll` and `discover` — are the opposite case: each runs to completion and exits, so they belong on a cron entry or a systemd **timer** (with exit-code alerting), not a persistent unit. See [`docs/unattended-scheduling.md`](docs/unattended-scheduling.md).
+
 ## Invariants
 
 - Core miner bookkeeping (claims, plans, queues, ledgers) works offline after install.

--- a/packages/gittensory-miner/docs/unattended-scheduling.md
+++ b/packages/gittensory-miner/docs/unattended-scheduling.md
@@ -1,0 +1,140 @@
+# Unattended scheduling & failure alerting
+
+`gittensory-miner manage poll` and `gittensory-miner discover` are the two commands most likely to run
+**unattended on a schedule**. Unlike `gittensory-miner loop` — a long-running daemon that schedules its own
+cycles and is supervised as a persistent service (see the [systemd section in `../DEPLOYMENT.md`](../DEPLOYMENT.md#bare-host-systemd-no-docker)) —
+`manage poll` and `discover` are **one-shot**: each runs to completion and exits. That makes them a fit for an
+external scheduler (cron or a systemd **timer**), the same one-shot-on-a-timer shape as the
+`loopover-docker-prune.*.example` hygiene job in [`systemd/`](../../../systemd/), not a persistent
+`Type=simple` service.
+
+This page covers scheduling those commands and alerting when one fails.
+
+## Exit-code contract (what to alert on)
+
+Every miner subcommand exits **`0` on success and non-zero on failure** (the CLI's shared error path returns a
+non-zero code for a bad invocation, a store error, or a failed operation). That exit code is the signal to alert
+on — both cron and systemd key their failure handling off it, so **no log scraping is required**.
+
+For machine-readable output, pass `--json`: on failure the command prints a structured
+`{"ok": false, "error": "<reason>"}` object (and still exits non-zero), so a monitoring wrapper can capture both
+the code and the reason:
+
+```sh
+gittensory-miner discover --search "good first issue" --json
+echo "exit: $?"
+```
+
+## cron
+
+A crontab entry runs the command on a fixed schedule. cron does not inherit your login shell's environment, so
+set `PATH` (to reach `node`/`gittensory-miner`) and point `GITTENSORY_MINER_CONFIG_DIR` at a stable state
+directory. Keep `GITHUB_TOKEN` (and any coding-agent credentials) out of the crontab itself — it is world-listable
+via `crontab -l` — by sourcing a root-owned `0600` env file from a wrapper (see below) rather than inlining the
+value:
+
+```cron
+# m h dom mon dow   command
+PATH=/usr/local/bin:/usr/bin:/bin
+GITTENSORY_MINER_CONFIG_DIR=/var/lib/gittensory-miner
+# Fan out discovery every 15 minutes; send any non-zero exit to MAILTO.
+MAILTO=ops@example.com
+*/15 * * * *  gittensory-miner-scheduled.sh discover --search "good first issue" >> /var/log/gittensory-miner/discover.log 2>&1
+
+# Poll a specific PR hourly.
+0 * * * *     gittensory-miner-scheduled.sh manage poll acme/widgets 1234 >> /var/log/gittensory-miner/poll.log 2>&1
+```
+
+**Alerting.** cron mails the job's output to `MAILTO` **only when the command writes to stdout/stderr** — it does
+not alert on exit code alone. For exit-code-driven alerting, wrap the command so a non-zero code triggers your
+notifier explicitly:
+
+```sh
+#!/bin/sh
+# /usr/local/bin/gittensory-miner-scheduled.sh — load credentials, run a miner command, alert on failure.
+set -a; . /etc/gittensory-miner/miner.env; set +a   # root-owned 0600 file holding GITHUB_TOKEN etc.
+if ! gittensory-miner "$@" --json; then
+  code=$?
+  curl -fsS -X POST "$ALERT_WEBHOOK_URL" \
+    -H 'content-type: application/json' \
+    -d "{\"text\":\"gittensory-miner $* failed with exit $code on $(hostname)\"}"
+  exit "$code"
+fi
+```
+
+The wrapper appends `--json` itself, so the crontab lines above stay free of both the flag and the credential.
+
+## systemd timer
+
+A systemd **timer** pairs a one-shot service (the command) with a schedule. Mirror the
+`loopover-docker-prune.{service,timer}.example` pattern in [`systemd/`](../../../systemd/).
+
+`gittensory-miner-discover.service`:
+
+```ini
+[Unit]
+Description=gittensory-miner discovery sweep (one-shot)
+
+[Service]
+Type=oneshot
+# Keep GITHUB_TOKEN (and any coding-agent credentials) in a root-owned 0600 EnvironmentFile, never inline.
+EnvironmentFile=/etc/gittensory-miner/miner.env
+Environment=GITTENSORY_MINER_CONFIG_DIR=/var/lib/gittensory-miner
+ExecStart=/usr/local/bin/gittensory-miner discover --search "good first issue" --json
+# Fire an alert handler unit whenever this service exits non-zero (see below).
+OnFailure=gittensory-miner-alert@%n.service
+```
+
+`gittensory-miner-discover.timer`:
+
+```ini
+[Unit]
+Description=Run gittensory-miner-discover.service every 15 minutes
+
+[Timer]
+OnCalendar=*:0/15
+Persistent=true
+# Spread the run across hosts instead of firing simultaneously.
+RandomizedDelaySec=2m
+
+[Install]
+WantedBy=timers.target
+```
+
+Install and enable the timer (not the service — the timer starts the service):
+
+```sh
+sudo cp gittensory-miner-discover.service gittensory-miner-discover.timer /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now gittensory-miner-discover.timer
+systemctl list-timers gittensory-miner-discover.timer   # confirm the next run
+```
+
+**Alerting.** `OnFailure=` starts the named handler unit whenever the service exits non-zero. A reusable
+templated handler (`%i` expands to the failed unit's name) keeps one alert path for every scheduled command:
+
+```ini
+# gittensory-miner-alert@.service
+[Unit]
+Description=Alert on a failed gittensory-miner unit (%i)
+
+[Service]
+Type=oneshot
+EnvironmentFile=/etc/gittensory-miner/miner.env
+ExecStart=/usr/bin/curl -fsS -X POST ${ALERT_WEBHOOK_URL} \
+  -H 'content-type: application/json' \
+  -d '{"text":"gittensory-miner unit %i failed on %H"}'
+```
+
+`journalctl -u gittensory-miner-discover.service` shows the last run's output; `systemctl status` reports the
+last exit code.
+
+## Choosing between cron and systemd
+
+- **cron** — simplest when a scheduler already runs and you only need `MAILTO` mail or a wrapper alert.
+- **systemd timer** — preferred on a systemd host: `OnCalendar`/`Persistent=true` (catch-up after downtime),
+  `RandomizedDelaySec`, journald log capture, and `OnFailure=` exit-code alerting without a wrapper script.
+
+For the always-on autonomous daemon, use `gittensory-miner loop` as a **persistent** service instead — see
+[`../DEPLOYMENT.md`](../DEPLOYMENT.md#bare-host-systemd-no-docker). For local-state recovery and concurrency
+guarantees, see [`operations-runbook.md`](operations-runbook.md).


### PR DESCRIPTION
## Summary

`gittensory-miner manage poll` and `gittensory-miner discover` are the two commands most likely to run unattended on a schedule, but there was no documented guidance for cron/systemd setup or for alerting when a scheduled run fails.

Adds a focused documentation page, [`docs/unattended-scheduling.md`](docs/unattended-scheduling.md), covering:

- **The exit-code contract** — every subcommand exits non-zero on failure, and `--json` prints a structured `{"ok": false, "error": …}` object, so scheduling/alerting can key off the exit code with no log scraping.
- **cron** — an example crontab (with `PATH` / `GITTENSORY_MINER_CONFIG_DIR`), plus a credential-safe wrapper script that sources a root-owned `0600` env file and alerts (`MAILTO` mail, or an explicit webhook on non-zero exit — since cron only mails on output, not on exit code alone).
- **systemd timer** — a one-shot `.service` + `.timer` pair mirroring the repo's own `loopover-docker-prune.*.example`, with `OnFailure=` exit-code alerting via a reusable templated handler unit.
- **Choosing between them**, and a pointer to the persistent `loop` daemon (`../DEPLOYMENT.md`) for the always-on case — these one-shot commands are deliberately the timer/cron case, not a persistent unit.

A one-line link from DEPLOYMENT.md's systemd section makes it discoverable, right where it already contrasts persistent `loop` against timer-driven jobs.

Closes #4840

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (Closes #4840).

## Validation

- [x] `git diff --check`
- [x] `npm run docs:drift-check` (clean)
- [x] The DEPLOYMENT.md docs-accuracy audit (`deployment-docs-audit`, #5180) passes — the new link resolves on disk and no new env-var/subcommand claims were introduced (21 tests in `miner-deployment-doc*.test.ts` pass).
- [x] `test:miner-pack` allowlist accepts the new `docs/*.md` page (published with the package) and its content trips no secret-content rule.
- [ ] `npm run typecheck` · `test:workers` · `ui:*` — N/A (documentation only; no code).

If any required check was skipped, explain why:

Documentation-only change: a new `docs/*.md` page plus a one-line link in DEPLOYMENT.md. No code, workflow, MCP, OpenAPI, or UI surface is touched.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed. Credential handling in the examples keeps `GITHUB_TOKEN` out of the crontab and in a root-owned `0600` env file; no real token values appear.
- [x] Public GitHub text stays sanitized and low-noise.
- [x] Auth/CORS/session negative-path tests — N/A.
- [x] API/OpenAPI/MCP behavior updated/tested — N/A.
- [x] UI changes use real states — N/A (no UI).
- [x] Visible UI changes include UI Evidence — N/A (no UI).
- [x] Public docs/changelogs updated where needed — this IS the doc; no changelog edit.

## UI Evidence

N/A — documentation only.

## Notes

- The examples deliberately use only credential mechanisms the miner supports today (plain `GITHUB_TOKEN` via an EnvironmentFile / sourced env file). `<NAME>_FILE` secrets indirection (#5178) is not yet merged, so it's intentionally not referenced here.
- systemd-timer syntax mirrors the repo's existing `loopover-docker-prune.{service,timer}.example` so operators see one consistent pattern.
