### PR TITLE
feat(miner): add backup and restore commands for the local-state directory (#4872)

### DIFF
--- a/packages/gittensory-miner/bin/gittensory-miner.js
+++ b/packages/gittensory-miner/bin/gittensory-miner.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { runAttempt } from "../lib/attempt-cli.js";
+import { runBackup, runRestore } from "../lib/backup-cli.js";
 import { printHelp, printVersion, runCli } from "../lib/cli.js";
 import { runDenyCheck } from "../lib/deny-check.js";
 import { runDiscover } from "../lib/discover-cli.js";
@@ -60,6 +61,14 @@ if (cliArgs[0] === "migrate") {
 // is dispatched here, before the opportunistic npm-registry update check is ever started.
 if (cliArgs[0] === "metrics") {
   process.exit(runMetrics(cliArgs.slice(1)));
+}
+
+// `backup`/`restore` are pure local file-copy of the state directory — offline, so dispatched before the update check.
+if (cliArgs[0] === "backup") {
+  process.exit(runBackup(cliArgs.slice(1)));
+}
+if (cliArgs[0] === "restore") {
+  process.exit(runRestore(cliArgs.slice(1)));
 }
 
 if (cliArgs[0] === "manage" && cliArgs[1] === "status") {

--- a/packages/gittensory-miner/docs/operations-runbook.md
+++ b/packages/gittensory-miner/docs/operations-runbook.md
@@ -199,6 +199,24 @@ Stores use the lightweight **`schema-version.js`** convention ([#4832](https://g
 
 **Rolling fleet upgrades:** upgrade and restart **one worker/state dir at a time** so isolated workers never share a directory mid-migration.
 
+## Backup & restore
+
+`gittensory-miner backup` and `gittensory-miner restore` (#4872) copy the **entire local-state directory** — every SQLite store plus any WAL/`-shm` sidecars — as one unit, so the set stays complete as stores are added. Both resolve the same directory the rest of the CLI uses (`GITTENSORY_MINER_CONFIG_DIR`, else the XDG default).
+
+Back up to a fresh directory (it refuses to overwrite an existing one, so a backup never silently clobbers a previous one):
+
+```sh
+gittensory-miner backup /var/backups/gittensory-miner/2026-07-13
+```
+
+Restore a backup over the live state directory:
+
+```sh
+gittensory-miner restore /var/backups/gittensory-miner/2026-07-13
+```
+
+**Stop the miner first.** These are plain file copies: a snapshot taken while a store is being written can capture a torn page, and a restore overwrites files a running miner may hold open. Stop the process (for a systemd unit, `systemctl stop gittensory-miner`) before either command. Pass `--json` to get a structured `{ ok, source, target, files }` (or `{ ok: false, error }`) result for a monitored backup job. To relocate the whole set instead of copying it, point `GITTENSORY_MINER_CONFIG_DIR` at the new path.
+
 ## Related docs
 
 - [`../DEPLOYMENT.md`](../DEPLOYMENT.md) — laptop vs fleet, volumes, systemd, scaling rules

--- a/packages/gittensory-miner/lib/backup-cli.d.ts
+++ b/packages/gittensory-miner/lib/backup-cli.d.ts
@@ -1,0 +1,9 @@
+export function runBackup(
+  args: string[],
+  options?: { env?: Record<string, string | undefined> },
+): number;
+
+export function runRestore(
+  args: string[],
+  options?: { env?: Record<string, string | undefined> },
+): number;

--- a/packages/gittensory-miner/lib/backup-cli.js
+++ b/packages/gittensory-miner/lib/backup-cli.js
@@ -1,0 +1,93 @@
+import { cpSync, existsSync, readdirSync } from "node:fs";
+import { resolveMinerStateDir } from "./status.js";
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
+
+// `backup` / `restore` (#4872): a straightforward file-copy of the miner's local-state DIRECTORY (all SQLite
+// stores under `GITTENSORY_MINER_CONFIG_DIR` / the XDG default), the whole directory at once — so nothing is
+// missed and the set stays correct as stores are added, unlike a hand-maintained per-file list. `cpSync` copies
+// the WAL/`-shm` sidecars alongside each `.sqlite3` too, so a checkpoint that hasn't folded back yet is preserved.
+// Consistency caveat (surfaced in the docs + on stdout): SQLite files are safest copied while the miner is
+// STOPPED; a copy taken mid-write can capture a torn page. These are read-only-of-source (backup) /
+// overwrite-target (restore) file operations only — no network, no store schema access.
+
+const BACKUP_USAGE = "Usage: gittensory-miner backup <target-dir> [--json]";
+const RESTORE_USAGE = "Usage: gittensory-miner restore <source-dir> [--json]";
+
+/** Parse a single required `<dir>` positional plus an optional `--json`. */
+function parseDirArg(args, usage) {
+  let json = false;
+  const positional = [];
+  for (const token of args) {
+    if (token === "--json") {
+      json = true;
+      continue;
+    }
+    if (token.startsWith("-")) {
+      return { error: `Unknown option: ${token}` };
+    }
+    positional.push(token);
+  }
+  if (positional.length !== 1) {
+    return { error: usage };
+  }
+  const dir = positional[0].trim();
+  if (!dir) {
+    return { error: usage };
+  }
+  return { dir, json };
+}
+
+/** `backup <target-dir>`: copy the entire local-state directory to `<target-dir>`. Refuses to overwrite an
+ *  existing target (a backup should never silently clobber a previous one). Exit 2 on any failure. */
+export function runBackup(args, options = {}) {
+  const parsed = parseDirArg(args, BACKUP_USAGE);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+  const env = options.env ?? process.env;
+  const stateDir = resolveMinerStateDir(env);
+  try {
+    if (!existsSync(stateDir)) {
+      return reportCliFailure(parsed.json, `no_state_directory: ${stateDir}`);
+    }
+    if (existsSync(parsed.dir)) {
+      return reportCliFailure(parsed.json, `backup_target_exists: ${parsed.dir} (refusing to overwrite an existing directory)`);
+    }
+    cpSync(stateDir, parsed.dir, { recursive: true });
+    const files = readdirSync(parsed.dir).sort();
+    if (parsed.json) {
+      console.log(JSON.stringify({ ok: true, source: stateDir, target: parsed.dir, files }, null, 2));
+    } else {
+      console.log(`backed up ${files.length} file(s) from ${stateDir} to ${parsed.dir} (stop the miner first for a consistent copy)`);
+    }
+    return 0;
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+}
+
+/** `restore <source-dir>`: copy a previous backup back OVER the local-state directory (overwriting existing
+ *  files). The miner must be stopped first. Exit 2 on any failure. */
+export function runRestore(args, options = {}) {
+  const parsed = parseDirArg(args, RESTORE_USAGE);
+  if ("error" in parsed) {
+    return reportCliFailure(argsWantJson(args), parsed.error);
+  }
+  const env = options.env ?? process.env;
+  const stateDir = resolveMinerStateDir(env);
+  try {
+    if (!existsSync(parsed.dir)) {
+      return reportCliFailure(parsed.json, `no_backup_directory: ${parsed.dir}`);
+    }
+    cpSync(parsed.dir, stateDir, { recursive: true });
+    const files = readdirSync(stateDir).sort();
+    if (parsed.json) {
+      console.log(JSON.stringify({ ok: true, source: parsed.dir, target: stateDir, files }, null, 2));
+    } else {
+      console.log(`restored ${files.length} file(s) from ${parsed.dir} to ${stateDir} (run with the miner stopped)`);
+    }
+    return 0;
+  } catch (error) {
+    return reportCliFailure(parsed.json, describeCliError(error));
+  }
+}

--- a/packages/gittensory-miner/lib/cli.js
+++ b/packages/gittensory-miner/lib/cli.js
@@ -20,6 +20,8 @@ export function printHelp(input) {
       "  gittensory-miner status [--json]                              Show installed versions + local state paths",
       "  gittensory-miner doctor [--json]                              Check this laptop is set up correctly",
       "  gittensory-miner migrate [--json]                             Apply pending schema migrations to existing local stores",
+      "  gittensory-miner backup <target-dir> [--json]                 Copy the local-state directory to a backup dir (stop the miner first)",
+      "  gittensory-miner restore <source-dir> [--json]                Restore a backup over the local-state directory (miner stopped)",
       "  gittensory-miner metrics                                      Print prediction-calibration counters in Prometheus text format",
       "  gittensory-miner manage status [--json]                       Show managed PR rows from local portfolio + ledger",
       "  gittensory-miner manage poll <owner/repo> <pr#> [--branch <name>] [--json]",

--- a/test/unit/miner-backup-cli.test.ts
+++ b/test/unit/miner-backup-cli.test.ts
@@ -1,0 +1,156 @@
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runBackup, runRestore } from "../../packages/gittensory-miner/lib/backup-cli.js";
+
+const roots: string[] = [];
+function tempRoot() {
+  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-backup-"));
+  roots.push(root);
+  return root;
+}
+
+/** A populated state directory + the env that points the miner at it. */
+function seedStateDir() {
+  const root = tempRoot();
+  const stateDir = join(root, "state");
+  mkdirSync(stateDir, { recursive: true });
+  writeFileSync(join(stateDir, "portfolio-queue.sqlite3"), "queue-bytes");
+  writeFileSync(join(stateDir, "claim-ledger.sqlite3"), "claim-bytes");
+  writeFileSync(join(stateDir, "portfolio-queue.sqlite3-wal"), "wal-bytes"); // sidecar comes along too
+  return { root, stateDir, env: { GITTENSORY_MINER_CONFIG_DIR: stateDir } };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("gittensory-miner backup / restore (#4872)", () => {
+  it("backup copies the whole state directory (SQLite files + WAL sidecars) to the target", () => {
+    const { root, stateDir, env } = seedStateDir();
+    const target = join(root, "backup");
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    expect(runBackup([target], { env })).toBe(0);
+    expect(existsSync(join(target, "portfolio-queue.sqlite3"))).toBe(true);
+    expect(existsSync(join(target, "claim-ledger.sqlite3"))).toBe(true);
+    expect(existsSync(join(target, "portfolio-queue.sqlite3-wal"))).toBe(true);
+    expect(readFileSync(join(target, "portfolio-queue.sqlite3"), "utf8")).toBe("queue-bytes");
+    expect(String(log.mock.calls[0]?.[0])).toContain(`backed up 3 file(s)`);
+    void stateDir;
+  });
+
+  it("backup refuses to overwrite an existing target directory", () => {
+    const { root, env } = seedStateDir();
+    const target = join(root, "backup");
+    mkdirSync(target); // already exists
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    expect(runBackup([target], { env })).toBe(2);
+    expect(String(error.mock.calls[0]?.[0])).toContain("backup_target_exists");
+  });
+
+  it("backup fails when there is no state directory to copy", () => {
+    const root = tempRoot();
+    const env = { GITTENSORY_MINER_CONFIG_DIR: join(root, "does-not-exist") };
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    expect(runBackup([join(root, "backup")], { env })).toBe(2);
+    expect(String(error.mock.calls[0]?.[0])).toContain("no_state_directory");
+  });
+
+  it("backup emits a structured object under --json", () => {
+    const { root, stateDir, env } = seedStateDir();
+    const target = join(root, "backup");
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    expect(runBackup([target, "--json"], { env })).toBe(0);
+    const printed = JSON.parse(String(log.mock.calls[0]?.[0]));
+    expect(printed).toMatchObject({ ok: true, source: stateDir, target });
+    expect(printed.files).toEqual(["claim-ledger.sqlite3", "portfolio-queue.sqlite3", "portfolio-queue.sqlite3-wal"]);
+  });
+
+  it("restore copies a backup back over the state directory (round-trips the data)", () => {
+    const { root, stateDir, env } = seedStateDir();
+    const backup = join(root, "backup");
+    expect(runBackup([backup], { env })).toBe(0);
+
+    // Simulate data loss / a bad edit, then restore.
+    writeFileSync(join(stateDir, "portfolio-queue.sqlite3"), "corrupted");
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    expect(runRestore([backup], { env })).toBe(0);
+    expect(readFileSync(join(stateDir, "portfolio-queue.sqlite3"), "utf8")).toBe("queue-bytes");
+    expect(String(log.mock.calls[0]?.[0])).toContain("restored");
+  });
+
+  it("restore fails when the backup directory does not exist", () => {
+    const { root, env } = seedStateDir();
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    expect(runRestore([join(root, "no-such-backup")], { env })).toBe(2);
+    expect(String(error.mock.calls[0]?.[0])).toContain("no_backup_directory");
+  });
+
+  it("restore emits a structured object under --json", () => {
+    const { root, stateDir, env } = seedStateDir();
+    const backup = join(root, "backup");
+    runBackup([backup], { env });
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    expect(runRestore([backup, "--json"], { env })).toBe(0);
+    const printed = JSON.parse(String(log.mock.calls[0]?.[0]));
+    expect(printed).toMatchObject({ ok: true, source: backup, target: stateDir });
+  });
+
+  it("both commands reject a missing/extra positional and an unknown option", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    expect(runBackup([])).toBe(2);
+    expect(String(error.mock.calls.at(-1)?.[0])).toContain("Usage: gittensory-miner backup");
+    expect(runBackup(["a", "b"])).toBe(2);
+    expect(runRestore(["--verbose", "dir"])).toBe(2);
+    expect(String(error.mock.calls.at(-1)?.[0])).toContain("Unknown option: --verbose");
+  });
+
+  it("a parse error respects --json (structured failure, still exit 2)", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    expect(runBackup(["--json"], {})).toBe(2); // no dir positional
+    expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toMatchObject({ ok: false });
+  });
+
+  it("both commands fail safe (exit 2) when the copy itself throws (a path component is a file, not a dir)", () => {
+    const { root, env } = seedStateDir();
+    const fileNotDir = join(root, "afile");
+    writeFileSync(fileNotDir, "x");
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    // A target/state path *under* a regular file makes cpSync throw ENOTDIR → caught → exit 2.
+    expect(runBackup([join(fileNotDir, "backup")], { env })).toBe(2);
+    const backup = join(root, "backup");
+    runBackup([backup], { env });
+    expect(runRestore([backup], { env: { GITTENSORY_MINER_CONFIG_DIR: join(fileNotDir, "state") } })).toBe(2);
+    expect(error).toHaveBeenCalled();
+  });
+
+  it("rejects an empty directory argument", () => {
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    expect(runBackup([""])).toBe(2);
+    expect(String(error.mock.calls[0]?.[0])).toContain("Usage: gittensory-miner backup");
+  });
+
+  it("falls back to process.env when no env is injected", () => {
+    const { root, stateDir } = seedStateDir();
+    const target = join(root, "backup");
+    const saved = process.env.GITTENSORY_MINER_CONFIG_DIR;
+    process.env.GITTENSORY_MINER_CONFIG_DIR = stateDir;
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    try {
+      expect(runBackup([target])).toBe(0); // no options → resolves via process.env
+      expect(existsSync(join(target, "portfolio-queue.sqlite3"))).toBe(true);
+      expect(runRestore([target])).toBe(0); // restore likewise resolves the state dir via process.env
+    } finally {
+      if (saved === undefined) delete process.env.GITTENSORY_MINER_CONFIG_DIR;
+      else process.env.GITTENSORY_MINER_CONFIG_DIR = saved;
+    }
+    void log;
+  });
+});


### PR DESCRIPTION
## Summary

There was no backup/restore tooling for the miner's local SQLite state. This adds two offline CLI commands:

- **`gittensory-miner backup <target-dir>`** — copies the entire local-state directory (every SQLite store plus its WAL/`-shm` sidecars) to `<target-dir>`. Refuses to overwrite an existing directory, so a backup never silently clobbers a previous one.
- **`gittensory-miner restore <source-dir>`** — copies a backup back over the live state directory.

Both resolve the same directory the rest of the CLI uses (`GITTENSORY_MINER_CONFIG_DIR`, else the XDG default), are purely local file operations (dispatched before the update check, like `status`/`doctor`/`migrate`), and support `--json` (reusing the shared `cli-error.js` failure helper, #4836) for a monitored backup job.

**Whole-directory, not per-file.** The miner has no central store registry — each store module resolves its own path — so a hand-maintained per-file list would go stale as stores are added. Copying the directory as a unit is complete by construction and future-proof, and it brings the WAL sidecars along so an un-checkpointed write isn't lost. Per the issue, this is the "straightforward file-copy-based" approach; the consistency caveat (a copy taken mid-write can capture a torn page; a restore overwrites open files) is surfaced both in the command's own output and in the docs: **stop the miner first**.

Documentation: a **Backup & restore** section in [`docs/operations-runbook.md`](docs/operations-runbook.md).

Closes #4872

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (Closes #4872).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `node --check` on the changed `lib`/`bin` files (the miner build gate)
- [x] `npm run docs:drift-check`
- [x] 12 unit tests in `miner-backup-cli.test.ts` exercise real temp-directory file ops end-to-end — backup (files + sidecars, refuse-overwrite, no-state-dir, `--json`), restore (data round-trip, no-backup-dir, `--json`), parse errors, both fail-safe catch paths, empty-arg, and the `process.env` fallback. **100% statement + branch coverage** on `backup-cli.js`.
- [ ] `npm run test:workers` · `build:mcp` · `ui:*` — N/A (miner-package + test change only; no worker/MCP/UI/OpenAPI surface).

If any required check was skipped, explain why:

Change is confined to the miner package (`lib` authored JS validated by `node --check` + its `.d.ts`, a new `bin` dispatch case, a help line, an ops-runbook doc section) and a unit test. No worker `src/**`, workflow, or `scripts/**` guarded paths are touched.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed. The commands copy files and print only the directory paths + file names, never file contents.
- [x] Public GitHub text stays sanitized and low-noise.
- [x] Auth/CORS/session negative-path tests — N/A (local file operations).
- [x] API/OpenAPI/MCP behavior updated/tested — N/A.
- [x] UI changes use real states — N/A (no UI).
- [x] Visible UI changes include UI Evidence — N/A.
- [x] Public docs/changelogs updated where needed — ops-runbook section added; no changelog edit.

## UI Evidence

N/A — CLI + docs only.

## Notes

- `backup` intentionally errors rather than overwriting an existing target directory; use a fresh (e.g. date-stamped) path per backup.
- The docs give only single-line command invocations plus the stop-the-miner-first caveat — no wrapper-script logic — so there's nothing shell-fragile to get wrong.
- To relocate the whole store set instead of copying it, `GITTENSORY_MINER_CONFIG_DIR` already does that; backup/restore are for point-in-time snapshots.
