### PR TITLE
refactor(infra): rename Cloudflare Queue to loopover-jobs with dual-consume drain

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -275,11 +275,23 @@
       "new_sqlite_classes": ["RateLimiter"],
     },
   ],
+  // Queue rename (#4768): the producer now writes ONLY to the new loopover-jobs queue. The old gittensory-jobs
+  // queue is kept as a consumer below (drain window) so any message already in flight at cutover still gets
+  // processed -- remove the 2 gittensory-jobs* consumer entries once `wrangler queues info gittensory-jobs`
+  // shows it's been empty for a while, then retire the gittensory-jobs/-dlq queues themselves.
+  //
+  // gittensory-webhooks/-dlq are deliberately NOT part of this rename: the WEBHOOKS binding (src/env.d.ts) is
+  // only ever read by enqueueWebhookByEnv's self-host-only code path (gated behind isSelfHostedReviewRuntime,
+  // which is always false on this hosted Worker -- see src/github/webhook.ts) -- direct-review-app webhook
+  // enqueue is retired in favor of the Orb broker's /v1/orb/webhook ingress. The live gittensory-webhooks
+  // queue's consumer binding to this Worker appears to be leftover from before that retirement (0 producers,
+  // confirmed via `wrangler queues info gittensory-webhooks`) -- out of scope to migrate; flagging as a
+  // separate dead-infrastructure cleanup candidate rather than perpetuating it under a new name.
   "queues": {
     "producers": [
       {
         "binding": "JOBS",
-        "queue": "gittensory-jobs",
+        "queue": "loopover-jobs",
       },
     ],
     "consumers": [
@@ -292,7 +304,7 @@
         //    may tighten this to 2 once the sweep fans into tiny per-PR jobs.)
         //  - retry_delay 30: a failed job backs off 30s instead of re-delivering immediately and re-hammering
         //    the already-overloaded path.
-        "queue": "gittensory-jobs",
+        "queue": "loopover-jobs",
         "max_batch_size": 5,
         "max_batch_timeout": 5,
         "max_concurrency": 3,
@@ -300,13 +312,29 @@
         // rather than vanishing silently. The DLQ consumer below picks them up.
         "max_retries": 3,
         "retry_delay": 30,
-        "dead_letter_queue": "gittensory-jobs-dlq",
+        "dead_letter_queue": "loopover-jobs-dlq",
       },
       {
         // DLQ consumer: receives jobs that exhausted all main-queue retries. Logs each dead-lettered
         // job for observability (Cloudflare Workers logs + audit_events) and acks immediately — no
         // further retries (the job already failed max_retries times). max_retries: 0 prevents the
         // DLQ consumer itself from sending messages to a secondary DLQ on handler error.
+        "queue": "loopover-jobs-dlq",
+        "max_batch_size": 10,
+        "max_batch_timeout": 30,
+        "max_retries": 0,
+      },
+      // --- Drain-window consumers for the old gittensory-jobs* queues (#4768) -- remove once confirmed empty ---
+      {
+        "queue": "gittensory-jobs",
+        "max_batch_size": 5,
+        "max_batch_timeout": 5,
+        "max_concurrency": 3,
+        "max_retries": 3,
+        "retry_delay": 30,
+        "dead_letter_queue": "gittensory-jobs-dlq",
+      },
+      {
         "queue": "gittensory-jobs-dlq",
         "max_batch_size": 10,
         "max_batch_timeout": 30,


### PR DESCRIPTION
## Summary
Creates `loopover-jobs` and `loopover-jobs-dlq` (live, empty, verified via `wrangler queues list`), switches the `JOBS` producer binding to write there going forward, and keeps the old `gittensory-jobs`/`-dlq` queues wired as active consumers during the drain window so any message already in flight at cutover still gets processed.

The `queue()` handler in `src/index.ts` needed **zero code changes** — it's already queue-name-agnostic (dispatches by the `-dlq` suffix, not a brand-specific string match), confirmed by reading the dispatch logic directly. This is purely a `wrangler.jsonc` binding change.

**Follow-up (not this PR):** once `wrangler queues info gittensory-jobs` confirms it's drained to zero, remove the 2 old-queue consumer entries and retire `gittensory-jobs`/`-dlq` themselves.

## Deliberately NOT touched: gittensory-webhooks/-dlq
Traced the code path: `enqueueWebhookByEnv` (the only writer of the `WEBHOOKS` binding) returns `"review_unavailable"` immediately via `if (!isSelfHostedReviewRuntime(env))`, before ever reaching `env.WEBHOOKS.send()` — this check is always false on the hosted Cloudflare Worker. `src/env.d.ts`'s own comment confirms: "Cloudflare no longer binds this because hosted reviews are retired." The live `gittensory-webhooks` queue has a consumer bound to this Worker but **0 producers** (confirmed via `wrangler queues info gittensory-webhooks`) — this strongly suggests it's leftover infrastructure from before direct-review-app webhook handling was retired in favor of the Orb broker's `/v1/orb/webhook` ingress. Renaming dead infrastructure under a new name didn't seem right, so this is flagged as a separate cleanup/deletion decision rather than migrated here.

## Test plan
- [x] Full `npm run test:ci` gate green.
- [x] `wrangler queues list` confirms `loopover-jobs`/`loopover-jobs-dlq` exist, live, empty.
- [x] Confirmed via direct code reading that no test hardcodes the `gittensory-jobs` queue name (the dispatch logic being name-agnostic means zero test updates were needed).
- [x] `cf-typegen:check` confirms no drift.

Part of #4768.