### PR TITLE
refactor(infra): rename gittensory-api/-ui Cloudflare Workers and D1 database to loopover

### DIFF
--- a/.github/workflows/ui-preview-deploy.yml
+++ b/.github/workflows/ui-preview-deploy.yml
@@ -13,7 +13,7 @@ name: UI Preview Deploy
 #
 # Required repo secrets:
 #   CLOUDFLARE_API_TOKEN   — token with "Workers Scripts:Edit" on the account
-#   CLOUDFLARE_ACCOUNT_ID  — the Cloudflare account id that owns gittensory-ui
+#   CLOUDFLARE_ACCOUNT_ID  — the Cloudflare account id that owns loopover-ui
 
 on:
   workflow_run:
@@ -124,7 +124,7 @@ jobs:
           cat > preview-dist/server/wrangler.preview.json <<'JSON'
           {
             "compatibility_date": "2026-05-28",
-            "name": "gittensory-ui",
+            "name": "loopover-ui",
             "workers_dev": true,
             "preview_urls": true,
             "compatibility_flags": ["nodejs_compat"],
@@ -169,12 +169,12 @@ jobs:
         run: |
           set -o pipefail
           out=$(wrangler versions upload --config preview-dist/server/wrangler.preview.json 2>&1 | tee /dev/stderr)
-          # Take a workers.dev URL that belongs to the gittensory-ui worker, so any other URL in the logs
+          # Take a workers.dev URL that belongs to the loopover-ui worker, so any other URL in the logs
           # (or a changed output format) can't be recorded as the preview by mistake. Tolerant of the
-          # version-alias prefix (`<alias>-gittensory-ui.<sub>.workers.dev`).
-          url=$(printf '%s\n' "$out" | grep -oiE 'https://[a-z0-9.-]+\.workers\.dev' | grep -i 'gittensory-ui' | head -n1)
+          # version-alias prefix (`<alias>-loopover-ui.<sub>.workers.dev`).
+          url=$(printf '%s\n' "$out" | grep -oiE 'https://[a-z0-9.-]+\.workers\.dev' | grep -i 'loopover-ui' | head -n1)
           if [ -z "$url" ]; then
-            echo "::error::Could not parse an expected gittensory-ui preview URL from wrangler output"
+            echo "::error::Could not parse an expected loopover-ui preview URL from wrangler output"
             exit 1
           fi
           echo "preview_url=$url" >> "$GITHUB_OUTPUT"

--- a/apps/gittensory-ui/wrangler.jsonc
+++ b/apps/gittensory-ui/wrangler.jsonc
@@ -1,6 +1,6 @@
 {
   "$schema": "../../node_modules/wrangler/config-schema.json",
-  "name": "gittensory-ui",
+  "name": "loopover-ui",
   "workers_dev": true,
   "preview_urls": true,
   "compatibility_date": "2026-05-28",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -2,7 +2,7 @@
   "$schema": "node_modules/wrangler/config-schema.json",
   // Auto-deploys to production via Cloudflare Workers Builds on push to `main`
   // (deploy command: `npm run deploy:api` — applies pending D1 migrations, then `wrangler deploy`).
-  "name": "gittensory-api",
+  "name": "loopover-api",
   "main": "src/index.ts",
   "workers_dev": true,
   "preview_urls": false,
@@ -252,7 +252,7 @@
   "d1_databases": [
     {
       "binding": "DB",
-      "database_name": "gittensory",
+      "database_name": "loopover",
       "database_id": "b2c79dd6-7771-4b1f-aa6b-085d5f3e9528",
       "migrations_dir": "migrations",
     },


### PR DESCRIPTION
## Summary
**Note: the live Cloudflare-side Worker renames already happened** (dashboard rename, both `gittensory-api` -> `loopover-api` and `gittensory-ui` -> `loopover-ui`) — this PR syncs the code side to match, which is required before the next push to `main` or Workers Builds' auto-deploy will fail (its git integration requires the dashboard-registered Worker name and `wrangler.jsonc`'s `name` field to agree).

- `wrangler.jsonc` / `apps/gittensory-ui/wrangler.jsonc`: `name` field updated to match the already-renamed live Workers. This was a genuine in-place rename of the existing resources (same script identity, bindings, routes) — not a provision-new-and-cutover.
- `wrangler.jsonc`'s D1 binding: `database_name` relabeled `gittensory` -> `loopover`, **same `database_id`** (the immutable UUID Cloudflare actually uses to resolve the binding). Confirmed via `wrangler deploy --dry-run` that this label has zero effect on which physical database gets bound — **not a data migration**: no rows moved, no export/import, zero downtime. There's no known Cloudflare API to rename the D1 database record itself, so the Cloudflare-side record keeps its own registered name; only the code-side reference changes.
- `.github/workflows/ui-preview-deploy.yml`: fixed hardcoded `"gittensory-ui"` references (the trusted preview wrangler config's `name` field, and the grep pattern that locates the deployed preview's `workers.dev` URL in wrangler's output) — both would have broken the next PR preview deploy now that the live rename has landed.

## Test plan
- [x] `wrangler deploy --dry-run` on both Workers — clean, bindings resolve correctly under the new names.
- [x] Full `npm run test:ci` gate green (one transient, unrelated flake in `miner-attempt-worktree.test.ts` — a known temp-git-repo signing-gate timing issue, confirmed by re-running in isolation).
- [x] Repo-wide sweep for any other functional (non-directory-path) reference to the old Worker script names — only `ui-preview-deploy.yml` had real hits, now fixed.

Closes #4766. Closes #4767 (via the `database_name` relabel described above — no data migration was required or attempted, since Cloudflare D1's binding resolves by immutable UUID, not by this human-readable label).