### PR TITLE
fix(miner): use camelCase readOnly in checkStoreIntegrity's DatabaseSync open

### DIFF
--- a/packages/gittensory-miner/lib/store-maintenance.js
+++ b/packages/gittensory-miner/lib/store-maintenance.js
@@ -43,7 +43,10 @@ export function classifyIntegrityRows(rows) {
 /**
  * Run `PRAGMA integrity_check` on a single store file. A store that does not exist yet is healthy by absence
  * (nothing to corrupt). Never throws: a store that cannot be opened or read is reported as not-ok, so one bad
- * store cannot abort the whole doctor sweep.
+ * store cannot abort the whole doctor sweep. Opens the connection driver-enforced read-only -- `readOnly`
+ * (camelCase) is the only option key node:sqlite recognizes for this; the lowercase `readonly` is silently
+ * ignored and opens read-write instead (the exact gotcha claim-ledger.js's own openClaimLedgerReadOnly already
+ * documents), which would defeat the read-only guarantee this function's own docs claim.
  * @param {string} name - the check label (e.g. "event-ledger").
  * @param {string} dbPath - the store file path.
  * @returns {{ name: string, ok: boolean, detail: string }}
@@ -54,7 +57,7 @@ export function checkStoreIntegrity(name, dbPath) {
   }
   let db;
   try {
-    db = new DatabaseSync(dbPath, { readonly: true });
+    db = new DatabaseSync(dbPath, { readOnly: true });
     const { ok, note } = classifyIntegrityRows(db.prepare("PRAGMA integrity_check").all());
     return { name, ok, detail: `${dbPath}: ${note}` };
   } catch (error) {

--- a/test/unit/miner-store-maintenance.test.ts
+++ b/test/unit/miner-store-maintenance.test.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { DatabaseSync } from "node:sqlite";
@@ -85,6 +85,34 @@ describe("checkStoreIntegrity (#4834)", () => {
     // assigned) — exercises the open-failure path and the no-handle-to-close branch.
     const result = checkStoreIntegrity("event-ledger", tempDir());
     expect(result.ok).toBe(false);
+  });
+
+  it("REGRESSION: pins the camelCase `readOnly` option key, never the lowercase `readonly` node:sqlite silently ignores", () => {
+    // node:sqlite's DatabaseSync only recognizes `readOnly` (camelCase) for a driver-enforced read-only
+    // connection; the lowercase `readonly` key is silently ignored and the connection opens read-write instead
+    // -- the exact gotcha claim-ledger.js's own openClaimLedgerReadOnly already documents and pins. A source-text
+    // check (rather than only a live-connection assertion below) means a future edit that reintroduces the wrong
+    // casing fails immediately, without needing to reason about SQLite's own error-message wording.
+    const source = readFileSync("packages/gittensory-miner/lib/store-maintenance.js", "utf8");
+    expect(source).toContain("new DatabaseSync(dbPath, { readOnly: true })");
+    expect(source).not.toMatch(/new DatabaseSync\(dbPath,\s*\{\s*readonly:/);
+  });
+
+  it("REGRESSION: a connection opened the same way checkStoreIntegrity does genuinely rejects a write", () => {
+    // Mirrors claim-ledger.test.ts's own "readOnly vs. readonly key gotcha" regression test: proves the driver
+    // itself enforces read-only for this exact option shape, so checkStoreIntegrity's connection can never
+    // silently mutate the store file it's meant to only inspect.
+    const path = join(tempDir(), "healthy.sqlite3");
+    const setup = new DatabaseSync(path);
+    setup.exec("CREATE TABLE t (id INTEGER)");
+    setup.close();
+
+    const readOnlyConnection = new DatabaseSync(path, { readOnly: true });
+    try {
+      expect(() => readOnlyConnection.exec("INSERT INTO t (id) VALUES (1)")).toThrow(/readonly/i);
+    } finally {
+      readOnlyConnection.close();
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- Found in passing while auditing the miner's local stores: `checkStoreIntegrity()` in `store-maintenance.js` opens its connection with `new DatabaseSync(dbPath, { readonly: true })` — lowercase `readonly`. node:sqlite's `DatabaseSync` only recognizes the camelCase `readOnly` option; the lowercase key is silently ignored, so the connection actually opens **read-write**, not read-only.
- Harmless today — the function only ever runs `PRAGMA integrity_check` (a read) — but it defeats the driver-enforced read-only guarantee the function's own docs claim, and the exact same casing footgun is already documented (correctly avoided) in `claim-ledger.js`'s `openClaimLedgerReadOnly`.
- Fix: `{ readonly: true }` → `{ readOnly: true }`.
- Adds a source-text regression test pinning the exact casing (mutation-verified: reverting the fix makes the test fail), plus a live-connection test proving the same option shape genuinely rejects a write, mirroring `claim-ledger.test.ts`'s own existing regression test for the identical gotcha.

## Test plan
- [x] `npx tsc --noEmit --incremental false`
- [x] `npx vitest run test/unit test/contract` (794 files, 15479 tests passed, 1 pre-existing skip)
- [x] Coverage-verified: the fixed line and both new tests are 100% exercised
- [x] Mutation-tested: reverting the fix makes the new regression test fail with the expected assertion
- [x] `npm run docs:drift-check`, `manifest:drift-check`, `engine-parity:drift-check`, `miner:env-reference:check`
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] `npm run build` (packages/gittensory-miner) — `node --check` on all lib files
- [x] Rebased on latest `origin/main`