### PR TITLE
refactor(infra): retire the drained gittensory-jobs/-dlq queues

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -275,18 +275,15 @@
       "new_sqlite_classes": ["RateLimiter"],
     },
   ],
-  // Queue rename (#4768): the producer now writes ONLY to the new loopover-jobs queue. The old gittensory-jobs
-  // queue is kept as a consumer below (drain window) so any message already in flight at cutover still gets
-  // processed -- remove the 2 gittensory-jobs* consumer entries once `wrangler queues info gittensory-jobs`
-  // shows it's been empty for a while, then retire the gittensory-jobs/-dlq queues themselves.
+  // Queue rename (#4768): the producer writes to loopover-jobs. The old gittensory-jobs/-dlq drain-window
+  // consumers were removed once `wrangler queues info gittensory-jobs` confirmed 0 producers and the queue
+  // fully drained -- those two queues are retired (no longer bound here at all).
   //
-  // gittensory-webhooks/-dlq are deliberately NOT part of this rename: the WEBHOOKS binding (src/env.d.ts) is
-  // only ever read by enqueueWebhookByEnv's self-host-only code path (gated behind isSelfHostedReviewRuntime,
-  // which is always false on this hosted Worker -- see src/github/webhook.ts) -- direct-review-app webhook
-  // enqueue is retired in favor of the Orb broker's /v1/orb/webhook ingress. The live gittensory-webhooks
-  // queue's consumer binding to this Worker appears to be leftover from before that retirement (0 producers,
-  // confirmed via `wrangler queues info gittensory-webhooks`) -- out of scope to migrate; flagging as a
-  // separate dead-infrastructure cleanup candidate rather than perpetuating it under a new name.
+  // gittensory-webhooks/-dlq were never part of this rename: the WEBHOOKS binding (src/env.d.ts) is only ever
+  // read by enqueueWebhookByEnv's self-host-only code path (gated behind isSelfHostedReviewRuntime, which is
+  // always false on this hosted Worker -- see src/github/webhook.ts) -- direct-review-app webhook enqueue is
+  // retired in favor of the Orb broker's /v1/orb/webhook ingress. Those two queues had 0 producers (leftover
+  // from before that retirement) and were deleted outright rather than renamed.
   "queues": {
     "producers": [
       {
@@ -320,22 +317,6 @@
         // further retries (the job already failed max_retries times). max_retries: 0 prevents the
         // DLQ consumer itself from sending messages to a secondary DLQ on handler error.
         "queue": "loopover-jobs-dlq",
-        "max_batch_size": 10,
-        "max_batch_timeout": 30,
-        "max_retries": 0,
-      },
-      // --- Drain-window consumers for the old gittensory-jobs* queues (#4768) -- remove once confirmed empty ---
-      {
-        "queue": "gittensory-jobs",
-        "max_batch_size": 5,
-        "max_batch_timeout": 5,
-        "max_concurrency": 3,
-        "max_retries": 3,
-        "retry_delay": 30,
-        "dead_letter_queue": "gittensory-jobs-dlq",
-      },
-      {
-        "queue": "gittensory-jobs-dlq",
         "max_batch_size": 10,
         "max_batch_timeout": 30,
         "max_retries": 0,


### PR DESCRIPTION
## Summary
The old `gittensory-jobs`/`-dlq` drain-window consumers (added in #5558) are removed now that `wrangler queues info gittensory-jobs` confirms 0 producers and the queue has fully drained — the `JOBS` producer has been writing exclusively to `loopover-jobs` since that PR merged.

Once this deploys, the actual Cloudflare-side queue objects will be deleted directly (they can't be deleted while a consumer binding still references them — that binding goes away when this config deploys).

## Test plan
- [x] `wrangler queues info gittensory-jobs` confirmed 0 producers before removing the consumer entries.
- [x] Full `npm run test:ci` gate green.
- [x] `cf-typegen:check` clean after rebase.

Closes #4768.