### PR TITLE
test(miner): add regression coverage for the two-tier stalled-output timeout

### DIFF
--- a/test/unit/cli-subprocess-driver.test.ts
+++ b/test/unit/cli-subprocess-driver.test.ts
@@ -473,4 +473,55 @@ describe("createCliSubprocessCodingAgentDriver (#4266)", () => {
       expect(result.costUsd).toBe(0.06);
     });
   });
+
+  describe("two-tier stalled-output timeout regression (#5196 — guards the #4994/#5053 CLI-stall outage)", () => {
+    it("surfaces a distinct 'stalled' error (not a full timeout) when the CLI emits zero stdout past firstOutputTimeoutMs", async () => {
+      // #4994/#5053: a claude/codex process that produced NO output was killed only at the full timeoutMs, masking
+      // the stall as a generic timeout. The fast-fail first-output deadline must report it distinctly instead.
+      const { spawn } = fakeSpawn({ stdout: "", code: null, timedOut: true, stalledNoOutput: true });
+      const driver = createCliSubprocessCodingAgentDriver({
+        command: "claude",
+        spawn,
+        timeoutMs: 120_000,
+        firstOutputTimeoutMs: 5_000,
+      });
+      const result = await driver.run(TASK);
+      expect(result.ok).toBe(false);
+      expect(result.error).toBe("claude_stalled_no_output");
+      expect(result.summary).toBe("claude stalled with no stdout within 5000ms");
+      // Distinctness guard: a stall must never be conflated with the generic full-timeout error.
+      expect(result.error).not.toContain("_timeout_");
+    });
+
+    it("does NOT kill a slow-but-producing run: output before firstOutputTimeoutMs clears the stall timer and it completes normally", async () => {
+      // A run that emits at least one byte before the first-output deadline is healthy — a real spawn clears the
+      // first-output timer on that byte, so `stalledNoOutput` is never set and the driver returns success.
+      const { spawn } = fakeSpawn({ stdout: "warming up... done", code: 0 });
+      const driver = createCliSubprocessCodingAgentDriver({
+        command: "claude",
+        spawn,
+        timeoutMs: 120_000,
+        firstOutputTimeoutMs: 5_000,
+      });
+      const result = await driver.run(TASK);
+      expect(result.ok).toBe(true);
+      expect(result.transcript).toBe("warming up... done");
+    });
+
+    it("preserves the pre-existing full-timeout path unchanged when output was produced but the process never exits (regression guard)", async () => {
+      // Once output has cleared the stall timer, a process that runs past the full timeoutMs must still yield the
+      // generic `_timeout_` error — the new fast-fail path must not alter the old full-timeout behavior.
+      const { spawn } = fakeSpawn({ stdout: "partial output, still working", code: null, timedOut: true });
+      const driver = createCliSubprocessCodingAgentDriver({
+        command: "claude",
+        spawn,
+        timeoutMs: 5_000,
+        firstOutputTimeoutMs: 1_000,
+      });
+      const result = await driver.run(TASK);
+      expect(result.ok).toBe(false);
+      expect(result.error).toBe("claude_timeout_5000ms");
+      expect(result.error).not.toContain("stalled");
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Adds the missing regression coverage (#5196) for the **two-tier stalled-output timeout** on the CLI-subprocess coding-agent driver (`packages/gittensory-engine/src/miner/cli-subprocess-driver.ts`). The `firstOutputTimeoutMs` fast-fail path — added after the #4994/#5053 production outage where a zero-output `claude`/`codex` process was only killed at the full `timeoutMs` and masked as a generic timeout — had no dedicated test of its own.

Three cases, using the driver's existing injected-spawn fake, named to map to the #4994/#5053 outage:

1. **Stall** — zero stdout past `firstOutputTimeoutMs` ⇒ asserts the distinct `claude_stalled_no_output` error + summary, and that it is **not** conflated with the generic `_timeout_` error.
2. **Slow but producing** — output before the first-output deadline ⇒ asserts it is **not** killed early and completes normally.
3. **Full-timeout regression guard** — output produced, then no exit before the full `timeoutMs` ⇒ asserts the pre-existing `claude_timeout_5000ms` path is **unchanged** (the new fast-fail didn't alter the old behavior).

**Test-only**, layered on the already-merged timeout feature; touches only the driver's own test file — no driver/attempt/governor control-flow changes.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused (one test file) and does not mix unrelated changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves — `Closes #5196`.

## Validation

- [x] `git diff --check`
- [x] `npx vitest run test/unit/cli-subprocess-driver.test.ts` — 42 pass (existing + the 3 new cases)
- [x] `typecheck` clean on the changed file
- [x] Rebased onto latest `main` (clean); diff is exactly one file

If any required check was skipped, explain why:

- Test-only change (`test/**`). No `src/**`/`apps/**`/package changes, so Codecov (which ignores `test/**`) and the UI/MCP jobs are path-skipped; there is no product code to cover.

## Safety

- [x] No secrets, wallets, hotkeys, coldkeys, PATs, private keys, raw trust scores, private rankings, or maintainer evidence are exposed — the fake spawn returns only synthetic stdout.
- [x] Public GitHub text stays sanitized and low-noise.
- [x] No changelog edited.

## Notes

- Asserts the *distinctness* invariant the feature exists to provide (stall vs full timeout must be separately countable in logs/Sentry), not just the happy path.

Closes #5196
