### PR TITLE
feat(miner-ui): rebuild the Overview page from live miner state

### DIFF
--- a/apps/gittensory-miner-ui/src/app.test.tsx
+++ b/apps/gittensory-miner-ui/src/app.test.tsx
@@ -1,12 +1,79 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
-import { IndexPage } from "./routes/index";
+import type { LedgersResult } from "./lib/ledgers";
+import type { PortfolioQueueResult } from "./lib/portfolio-queue";
+import type { RunHistoryResult } from "./lib/run-history";
+import { IndexPage, OverviewView } from "./routes/index";
 
-describe("miner ui shell", () => {
-  it("renders the empty dashboard overview copy", () => {
-    render(<IndexPage />);
-    expect(screen.getByRole("heading", { name: "Dashboard shell ready" })).toBeTruthy();
-    expect(screen.getByText(/Run-history and portfolio views/i)).toBeTruthy();
+const runsOk: RunHistoryResult = {
+  ok: true,
+  rows: [
+    { repoFullName: "acme/widgets", state: "discovering", updatedAt: "2026-07-10T06:00:00.000Z" },
+    { repoFullName: "acme/gadgets", state: "idle", updatedAt: "2026-07-10T05:00:00.000Z" },
+  ],
+};
+const portfolioOk: PortfolioQueueResult = {
+  ok: true,
+  summary: { total: 5, byStatus: { queued: 2, in_progress: 1, done: 2 }, repos: [], oldestQueuedAgeMs: null },
+};
+const claimsOk: LedgersResult = {
+  ok: true,
+  summary: {
+    claims: { total: 4, byStatus: { active: 3, released: 1, expired: 0 } },
+    events: { total: 0, byType: {}, recent: [] },
+    governor: { total: 0, byEventType: {} },
+  },
+};
+
+const statValue = (label: string) => screen.getByText(label).nextElementSibling?.textContent;
+
+describe("OverviewView (#4853)", () => {
+  it("summarizes run activity, portfolio queue, and claims from live data", () => {
+    render(<OverviewView runs={runsOk} portfolio={portfolioOk} claims={claimsOk} />);
+    expect(statValue("Repositories tracked")).toBe("2");
+    expect(statValue("Currently working")).toBe("1"); // the idle repo is excluded
+    expect(statValue("Total items")).toBe("5");
+    expect(statValue("Queued")).toBe("2");
+    expect(statValue("In progress")).toBe("1");
+    expect(statValue("Done")).toBe("2");
+    expect(statValue("Active")).toBe("3");
+    expect(statValue("Total recorded")).toBe("4");
+  });
+
+  it("shows an independent loading message per card before data arrives", () => {
+    render(<OverviewView runs={null} portfolio={null} claims={null} />);
+    expect(screen.getByText(/Loading run state/i)).toBeTruthy();
+    expect(screen.getByText(/Loading the portfolio queue/i)).toBeTruthy();
+    expect(screen.getByText(/Loading the claim ledger/i)).toBeTruthy();
+  });
+
+  it("degrades each card independently: an errored source shows an alert while the others still render", () => {
+    render(
+      <OverviewView
+        runs={{ ok: false, error: "down" }}
+        portfolio={portfolioOk}
+        claims={{ ok: false, error: "down" }}
+      />,
+    );
+    expect(screen.getAllByRole("alert")).toHaveLength(2); // runs + claims errored
+    expect(statValue("Total items")).toBe("5"); // portfolio still renders
+  });
+});
+
+describe("IndexPage (#4853)", () => {
+  it("loads all three sources through injected loaders and renders the summary", async () => {
+    render(
+      <IndexPage
+        loadRuns={async () => runsOk}
+        loadPortfolio={async () => portfolioOk}
+        loadClaims={async () => claimsOk}
+        pollIntervalMs={100_000}
+      />,
+    );
+    expect(screen.getByRole("heading", { name: "Overview" })).toBeTruthy();
+    await waitFor(() => expect(statValue("Repositories tracked")).toBe("2"));
+    expect(statValue("Total items")).toBe("5");
+    expect(statValue("Active")).toBe("3");
   });
 });

--- a/apps/gittensory-miner-ui/src/routes/index.tsx
+++ b/apps/gittensory-miner-ui/src/routes/index.tsx
@@ -2,22 +2,147 @@ import { createFileRoute } from "@tanstack/react-router";
 
 import { Card, CardContent, CardHeader } from "@jsonbored/gittensory-ui-kit/components/card";
 
+import { fetchLedgers, type LedgersResult } from "../lib/ledgers";
+import { fetchPortfolioQueue, type PortfolioQueueResult } from "../lib/portfolio-queue";
+import { fetchRunStates, type RunHistoryResult } from "../lib/run-history";
+import { DEFAULT_POLL_INTERVAL_MS, usePolledFetch } from "../lib/use-polled-fetch";
+
 export const Route = createFileRoute("/")({
   component: IndexPage,
 });
 
-export function IndexPage() {
+// Overview dashboard (#4853): replaces the Phase-6 placeholder with a live, at-a-glance summary of real miner
+// state — run activity, portfolio queue, and claims — aggregated from the same local read-only APIs the dedicated
+// views use (run-state, portfolio-queue, ledgers). Each card degrades independently: it shows its own loading or
+// error message without taking the others down. Live-refreshed on the shared poll cadence (#4856).
+
+/** One metric line inside a summary card. */
+function Stat({ label, value, tone }: { label: string; value: string | number; tone?: string }) {
+  return (
+    <div className="flex items-baseline justify-between gap-4">
+      <span className="text-token-sm text-muted-foreground">{label}</span>
+      <span className={`font-display text-token-lg font-semibold ${tone ?? "text-foreground"}`}>{value}</span>
+    </div>
+  );
+}
+
+function SummaryCard({ title, children }: { title: string; children: React.ReactNode }) {
   return (
     <Card>
       <CardHeader>
-        <h2 className="font-display text-token-lg font-semibold">Dashboard shell ready</h2>
+        <h3 className="font-display text-token-base font-semibold">{title}</h3>
       </CardHeader>
-      <CardContent>
-        <p className="max-w-2xl text-token-sm leading-token-relaxed text-muted-foreground">
-          This package is the empty Phase 6 scaffold for a local, read-only miner dashboard. Run-history and portfolio
-          views will mount here in follow-up issues once the local data-access layer is wired.
-        </p>
-      </CardContent>
+      <CardContent className="grid gap-2">{children}</CardContent>
     </Card>
   );
+}
+
+function Fallback({ state, subject }: { state: "loading" | "error"; subject: string }) {
+  return state === "loading" ? (
+    <p className="text-token-sm text-muted-foreground">Loading {subject}…</p>
+  ) : (
+    <p role="alert" className="text-token-sm text-[var(--danger)]">
+      Could not read {subject}.
+    </p>
+  );
+}
+
+export function OverviewRunsCard({ runs }: { runs: RunHistoryResult | null }) {
+  return (
+    <SummaryCard title="Run activity">
+      {runs === null ? (
+        <Fallback state="loading" subject="run state" />
+      ) : !runs.ok ? (
+        <Fallback state="error" subject="run state" />
+      ) : (
+        <>
+          <Stat label="Repositories tracked" value={runs.rows.length} />
+          <Stat
+            label="Currently working"
+            value={runs.rows.filter((row) => row.state !== "idle").length}
+            tone="text-[var(--success)]"
+          />
+        </>
+      )}
+    </SummaryCard>
+  );
+}
+
+export function OverviewPortfolioCard({ portfolio }: { portfolio: PortfolioQueueResult | null }) {
+  return (
+    <SummaryCard title="Portfolio queue">
+      {portfolio === null ? (
+        <Fallback state="loading" subject="the portfolio queue" />
+      ) : !portfolio.ok ? (
+        <Fallback state="error" subject="the portfolio queue" />
+      ) : (
+        <>
+          <Stat label="Total items" value={portfolio.summary.total} />
+          <Stat label="Queued" value={portfolio.summary.byStatus.queued} />
+          <Stat label="In progress" value={portfolio.summary.byStatus.in_progress} tone="text-[var(--warning)]" />
+          <Stat label="Done" value={portfolio.summary.byStatus.done} tone="text-[var(--success)]" />
+        </>
+      )}
+    </SummaryCard>
+  );
+}
+
+export function OverviewClaimsCard({ claims }: { claims: LedgersResult | null }) {
+  return (
+    <SummaryCard title="Claims">
+      {claims === null ? (
+        <Fallback state="loading" subject="the claim ledger" />
+      ) : !claims.ok ? (
+        <Fallback state="error" subject="the claim ledger" />
+      ) : (
+        <>
+          <Stat label="Active" value={claims.summary.claims.byStatus.active} tone="text-[var(--success)]" />
+          <Stat label="Total recorded" value={claims.summary.claims.total} />
+        </>
+      )}
+    </SummaryCard>
+  );
+}
+
+export function OverviewView({
+  runs,
+  portfolio,
+  claims,
+}: {
+  runs: RunHistoryResult | null;
+  portfolio: PortfolioQueueResult | null;
+  claims: LedgersResult | null;
+}) {
+  return (
+    <div className="grid gap-6">
+      <div>
+        <h2 className="font-display text-token-lg font-semibold">Overview</h2>
+        <p className="text-token-sm text-muted-foreground">
+          A live, read-only snapshot of the miner&apos;s current state, refreshed automatically.
+        </p>
+      </div>
+      <div className="grid gap-4 sm:grid-cols-3">
+        <OverviewRunsCard runs={runs} />
+        <OverviewPortfolioCard portfolio={portfolio} />
+        <OverviewClaimsCard claims={claims} />
+      </div>
+    </div>
+  );
+}
+
+export function IndexPage({
+  loadRuns = fetchRunStates,
+  loadPortfolio = fetchPortfolioQueue,
+  loadClaims = fetchLedgers,
+  pollIntervalMs = DEFAULT_POLL_INTERVAL_MS,
+}: {
+  loadRuns?: () => Promise<RunHistoryResult>;
+  loadPortfolio?: () => Promise<PortfolioQueueResult>;
+  loadClaims?: () => Promise<LedgersResult>;
+  pollIntervalMs?: number;
+}) {
+  const runs = usePolledFetch(loadRuns, pollIntervalMs);
+  const portfolio = usePolledFetch(loadPortfolio, pollIntervalMs);
+  const claims = usePolledFetch(loadClaims, pollIntervalMs);
+  return <OverviewView runs={runs} portfolio={portfolio} claims={claims} />;
 }


### PR DESCRIPTION
## What

Replaces the miner-ui's stale Phase-6 placeholder Overview with a real, at-a-glance dashboard, per #4853.

- Summarizes **run activity** (repositories tracked / currently working), **portfolio-queue status** (total + queued/in-progress/done), and **claims** (active / total) in three summary cards.
- Aggregated from the **same local read-only APIs** the dedicated views already use — `run-state`, `portfolio-queue`, and the `ledgers` API — so there's one shared data path, no new endpoints.
- **Live-refreshed** on the shared poll cadence (`usePolledFetch`, #4856), and each card **degrades independently**: a source that's loading or errored shows its own message without taking the other cards down.
- Built with the shared `@jsonbored/gittensory-ui-kit` components (#4966/#4967) — no hardcoded styling.

## Tests

`src/app.test.tsx` rewritten (4 tests): populated summary (all three cards' stats), independent per-card loading state, independent error degradation (one source errors, the others still render), and `IndexPage` loading all three sources through injected loaders.

Verified locally: full miner-ui suite green (57 tests), `tsc --noEmit` clean.

Fixes #4853