### PR TITLE
feat(miner-extension): grant loopback host permissions for local miner-ui access (#4860)

### DIFF
--- a/apps/gittensory-miner-extension/README.md
+++ b/apps/gittensory-miner-extension/README.md
@@ -27,3 +27,11 @@ omitted entirely for a cache saved before this field existed.
 The extension does not request the `unlimitedStorage` permission, so a paste is rejected with a clear error before
 being parsed or saved once it exceeds a conservative size bound well under `chrome.storage.local`'s default 10 MiB
 quota, instead of silently failing to save or leaving storage partially written.
+
+## Host permissions
+
+`manifest.json` grants `https://github.com/*` (for the issue-page content script) plus loopback host permissions —
+`http://localhost/*` and `http://127.0.0.1/*` — so the extension can reach the operator's own local miner-ui API
+(#4860). Chrome match patterns cannot pin a port, so `http://localhost/*` is the narrowest grant the platform
+allows; `https` is intentionally omitted because the local miner-ui dev server is plain HTTP. This is the enabling
+permission for live-fetching ranked candidates from the local miner-ui instead of pasting them.

--- a/apps/gittensory-miner-extension/manifest.json
+++ b/apps/gittensory-miner-extension/manifest.json
@@ -4,7 +4,7 @@
   "description": "Contributor-facing GitHub issue opportunity signals from a locally configured miner plane.",
   "version": "0.1.0",
   "permissions": ["storage"],
-  "host_permissions": ["https://github.com/*"],
+  "host_permissions": ["https://github.com/*", "http://localhost/*", "http://127.0.0.1/*"],
   "background": {
     "service_worker": "background.js",
     "type": "module"

--- a/test/unit/miner-extension-content.test.ts
+++ b/test/unit/miner-extension-content.test.ts
@@ -46,6 +46,19 @@ describe("miner extension opportunity badge", () => {
     expect(manifest.content_scripts[0].css).toEqual(["styles.css"]);
   });
 
+  it("grants loopback host permissions so the extension can reach the local miner-ui, scoped to localhost only (#4860)", () => {
+    // Chrome match patterns cannot pin a port, so http://localhost/* + http://127.0.0.1/* is the narrowest the
+    // platform allows; https is intentionally omitted (the local miner-ui dev server is plain HTTP).
+    expect(manifest.host_permissions).toContain("http://localhost/*");
+    expect(manifest.host_permissions).toContain("http://127.0.0.1/*");
+    // github.com stays; the loopback grant is additive, not a replacement.
+    expect(manifest.host_permissions).toContain("https://github.com/*");
+    // No broad or non-loopback host is granted alongside it.
+    for (const pattern of manifest.host_permissions) {
+      expect(pattern).toMatch(/^https:\/\/github\.com\/\*$|^http:\/\/(?:localhost|127\.0\.0\.1)\/\*$/);
+    }
+  });
+
   it("detects GitHub issue routes without matching pull requests", () => {
     const internals = loadContentInternals();
     expect(internals.matchGitHubIssueTarget("/JSONbored/gittensory/issues/145")).toEqual({


### PR DESCRIPTION
Closes #4860

## Summary

The miner extension's `manifest.json` `host_permissions` only covered `https://github.com/*`, so the extension
architecturally could not reach `localhost` — which blocks any live-fetch integration with the operator's local
miner-ui. This adds the loopback host permissions that enable localhost access, scoped as narrowly as the platform
allows.

## Change

- **`apps/gittensory-miner-extension/manifest.json`** — `host_permissions` now also grants `http://localhost/*`
  and `http://127.0.0.1/*` (additive; `https://github.com/*` stays).

Scoping rationale:

- **Narrowest the platform allows:** Chrome MV3 match patterns cannot pin a port, so `http://localhost/*` is the
  tightest grant possible for a loopback dev server (a `http://localhost:5174/*` pattern is invalid).
- **HTTP only, loopback only:** `https` is intentionally omitted because the local miner-ui dev server is plain
  HTTP; no broad or non-loopback host is granted.

Scope note: this issue's deliverable is narrowly "updated manifest permissions enabling localhost access." The
live-fetch consumer that will *use* this permission (pulling ranked candidates from the local miner-ui) is a
separate integration; this PR unblocks it by resolving the reachability gap.

## Testing

- `test/unit/miner-extension-content.test.ts` — a new case asserts the manifest grants both loopback patterns,
  keeps the `github.com` grant, and that **every** entry matches only `https://github.com/*` or
  `http://{localhost,127.0.0.1}/*` (so a future edit can't silently widen the grant to an arbitrary host).
- Verified locally (Node 18 sandbox): the manifest is valid JSON and the new assertions pass via a standalone
  driver; no linter errors.

## Note for CI

`npm run test:ci` / `npm run test:coverage` must be run under Node >= 22.13 (this sandbox is Node 18, so vitest
could not be executed here). The changed files live under `apps/**`, outside the Codecov-measured `src/**` /
`lib/**` surface, so they add no patch-coverage burden; the manifest assertion runs as part of the existing unit
suite.
