### PR TITLE
fix(ci): build gittensory-engine before ui:build's miner-ui step

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "miner-extension:lint": "npm --workspace @jsonbored/gittensory-miner-extension run lint",
     "miner-extension:typecheck": "npm --workspace @jsonbored/gittensory-miner-extension run typecheck",
     "ui:kit:build": "npm run build --workspace @jsonbored/gittensory-ui-kit",
-    "ui:build": "npm run ui:kit:build && npm run ui:openapi && npm run extension:build && npm run miner-extension:build && npm --workspace @jsonbored/gittensory-ui run build && npm --workspace @jsonbored/gittensory-miner-ui run build",
+    "ui:build": "npm run ui:kit:build && npm run build --workspace @jsonbored/gittensory-engine && npm run ui:openapi && npm run extension:build && npm run miner-extension:build && npm --workspace @jsonbored/gittensory-ui run build && npm --workspace @jsonbored/gittensory-miner-ui run build",
     "ui:preview": "npm run ui:build && wrangler dev --config apps/gittensory-ui/dist/server/wrangler.json --ip 127.0.0.1 --port 4173 --local",
     "ui:lint": "npm run ui:kit:build && npm --workspace @jsonbored/gittensory-ui run lint && npm --workspace @jsonbored/gittensory-miner-ui run lint",
     "ui:typecheck": "npm run ui:kit:build && npm --workspace @jsonbored/gittensory-ui run typecheck && npm --workspace @jsonbored/gittensory-miner-ui run typecheck",


### PR DESCRIPTION
## Summary

- PR #5567 added `npm --workspace @jsonbored/gittensory-miner-ui run build` to the `ui:build` script chain, but `gittensory-miner-ui`'s vite config transitively dynamic-imports `@jsonbored/gittensory-miner`'s `portfolio-dashboard.js` (via `vite-portfolio-queue-api.ts`), which depends on `@jsonbored/gittensory-engine`.
- `ui:build` never builds the engine first, so its `dist/` doesn't exist and vite's config bundler fails: `Failed to resolve entry for package "@jsonbored/gittensory-engine"`.
- This worked by accident inside `npm run test:ci` (an earlier step, `build:miner`, happens to build the engine first in that chain) but fails standalone wherever `ui:build` runs in isolation — confirmed via `ui-preview.yml`'s "Build UI preview artifact" job failing identically on this branch and on an unrelated `renovate/npm-minor-patch` branch at the same time, meaning it's been broken on `main` for every PR touching `apps/gittensory-ui/**` or `packages/**` since #5567 merged.
- `ui:lint`/`ui:typecheck` are unaffected: TS/ESLint resolve `@jsonbored/gittensory-engine` via tsconfig path-mapping to source, not the compiled package entry — confirmed both pass with the engine's `dist/` absent.

## Test plan

- [x] Reproduced the failure locally with a fresh worktree + `npm ci` (no engine `dist/`), confirmed the fix resolves it.
- [x] Full local gate (`npm run test:ci` + `npm audit --audit-level=moderate`) green.