### PR TITLE
feat(miner): add backup/restore commands for the local stores

### DIFF
--- a/packages/gittensory-miner/DEPLOYMENT.md
+++ b/packages/gittensory-miner/DEPLOYMENT.md
@@ -149,7 +149,7 @@ Because `loop` is a **long-running daemon that schedules its own cycles**, it is
 - Discovery/ranking primitives that touch GitHub only run when explicitly invoked and only perform documented GETs unless a future command says otherwise.
 - Operators own secret injection; images and packages ship without embedded tokens.
 
-See [`docs/operations-runbook.md`](docs/operations-runbook.md) for operational scenarios: ledger corruption, two miners on one state dir, and post-upgrade schema migration ([#4875](https://github.com/JSONbored/gittensory/issues/4875)).
+See [`docs/operations-runbook.md`](docs/operations-runbook.md) for operational scenarios: ledger corruption, two miners on one state dir, backup/restore, and post-upgrade schema migration ([#4875](https://github.com/JSONbored/gittensory/issues/4875)).
 
 ## Optional hosted discovery plane (opt-in)
 

--- a/packages/gittensory-miner/README.md
+++ b/packages/gittensory-miner/README.md
@@ -171,6 +171,8 @@ gittensory-miner status
 
 `init` creates `~/.config/gittensory-miner/` (or `GITTENSORY_MINER_CONFIG_DIR` / `XDG_CONFIG_HOME` overrides) and a local `laptop-state.sqlite3` bootstrap file. Re-running `init` is idempotent. Pass `--verify-token` to make one authenticated GitHub API call up front and fail fast if `GITHUB_TOKEN` is invalid or missing repository access scopes. `doctor` reports Node, the state directory, SQLite readiness, and whether Docker is installed (informational only). Every local store already applies its own pending schema migrations automatically the moment some other command first opens it, but `migrate` lets an operator proactively bring every EXISTING store file up to date in one pass (e.g. right after upgrading) instead of relying on whichever command happens to touch a given store first; a store file that hasn't been created yet is reported as skipped, not created.
 
+`backup <destDir>` copies every EXISTING store into `destDir` using SQLite's own online backup API (`node:sqlite`'s `backup()`), which is safe to run against a store the miner still has open — never a raw copy of a live database file. `restore <srcDir>` copies files from a previous `backup` back into their real, live paths; it refuses to overwrite an existing destination file unless `--force` is passed, so a restore can never silently clobber current state by accident. Both commands skip (never create) a store with no on-disk file/backup to work from.
+
 From a local checkout:
 
 ```sh
@@ -214,6 +216,8 @@ gittensory-miner init [--json] [--verify-token]
 gittensory-miner status [--json]
 gittensory-miner doctor [--json]
 gittensory-miner migrate [--json]
+gittensory-miner backup <destDir> [--json]
+gittensory-miner restore <srcDir> [--force] [--json]
 gittensory-miner manage status [--json]
 gittensory-miner manage poll <owner/repo> <pr#> [--branch <name>] [--json]
 ```

--- a/packages/gittensory-miner/bin/gittensory-miner.js
+++ b/packages/gittensory-miner/bin/gittensory-miner.js
@@ -21,6 +21,7 @@ import { installCliSignalHandlers } from "../lib/process-lifecycle.js";
 import { runStateCli } from "../lib/run-state-cli.js";
 import { runInit } from "../lib/laptop-init.js";
 import { loadMinerFileSecrets } from "../lib/env-file-indirection.js";
+import { runBackup, runRestore } from "../lib/backup-cli.js";
 import { runMigrate } from "../lib/migrate-cli.js";
 import { runDoctor, runStatus } from "../lib/status.js";
 import {
@@ -73,6 +74,16 @@ if (cliArgs[0] === "doctor") {
 // dispatched here too, before the opportunistic npm-registry update check is ever started.
 if (cliArgs[0] === "migrate") {
   process.exit(runMigrate(cliArgs.slice(1)));
+}
+
+// `backup`/`restore` are strictly local + offline (they only read/write the local SQLite stores), so they are
+// dispatched here too, before the opportunistic npm-registry update check is ever started (#4872).
+if (cliArgs[0] === "backup") {
+  process.exit(await runBackup(cliArgs.slice(1)));
+}
+
+if (cliArgs[0] === "restore") {
+  process.exit(runRestore(cliArgs.slice(1)));
 }
 
 // `metrics` is strictly local + offline like `status`/`doctor` (it reads only the local prediction ledger), so it

--- a/packages/gittensory-miner/docs/operations-runbook.md
+++ b/packages/gittensory-miner/docs/operations-runbook.md
@@ -128,18 +128,22 @@ gittensory-miner status --json
 2. **Backup the whole state directory** (even damaged files help post-mortems):
 
    ```sh
-   cp -a "$STATE_DIR" "${STATE_DIR}.bak.$(date +%Y%m%d%H%M%S)"
+   gittensory-miner backup "${STATE_DIR}.bak.$(date +%Y%m%d%H%M%S)"
    ```
+
+   (A raw `cp -a`/`tar` also works once the miner is stopped, but `backup` needs no stop/start at all — it
+   uses SQLite's online backup API, safe against a store the miner still has open.)
 
 3. Choose a recovery tier:
 
    | Tier | When | Action |
    |------|------|--------|
    | **A — single store reset** | One ledger is corrupt; others healthy; you accept losing that store's history | Remove only the bad `*.sqlite3` (and any `-wal`/`-shm` siblings). Next command recreates an empty store. |
-   | **B — restore from backup** | You have a recent quiesced backup | Stop miner → restore the known-good file → restart. |
+   | **B — restore from backup** | You have a recent quiesced backup | Stop miner → `gittensory-miner restore <backupDir> --force` → restart. |
    | **C — full re-init** | Multiple files suspect or state is disposable | Archive dir → `gittensory-miner init` → reconfigure env/goals. Rebuild claims/plans from GitHub metadata as needed. |
 
-4. **Never copy a live SQLite file** from a running miner as backup — stop first, or use SQLite's `.backup` command:
+4. **Never copy a live SQLite file** from a running miner as backup — stop first, use SQLite's own `.backup`
+   command for a single file, or `gittensory-miner backup <destDir>` for every store at once (same mechanism):
 
    ```sh
    sqlite3 "$DB" ".backup '${DB}.safe-copy'"
@@ -167,9 +171,11 @@ Stores use the lightweight **`schema-version.js`** convention ([#4832](https://g
 
    ```sh
    gittensory-miner doctor --json > /tmp/miner-pre-upgrade-doctor.json
-   STATE_DIR="$(gittensory-miner status --json | jq -r .stateDir)"
-   tar -czf "/tmp/gittensory-miner-state-$(date +%Y%m%d).tar.gz" -C "$(dirname "$STATE_DIR")" "$(basename "$STATE_DIR")"
+   gittensory-miner backup "/tmp/gittensory-miner-backup-$(date +%Y%m%d)" --json
    ```
+
+   (`backup` uses SQLite's own online backup API per store — safe even if a loop is still running against
+   it, unlike a raw `tar`/`cp` of a live database file. See "Scenario: backup/restore" below.)
 
 2. **Stop** supervised loops (`systemctl stop gittensory-miner.service`, `docker compose stop miner`, etc.).
 
@@ -195,7 +201,7 @@ Stores use the lightweight **`schema-version.js`** convention ([#4832](https://g
    gittensory-miner migrate --json   # re-run: every store should now report "up-to-date"
    ```
 
-6. If a migration throws on startup, **do not delete files immediately** — restore the pre-upgrade tarball, pin the previous package version, and file an issue with the failing `user_version` and store filename.
+6. If a migration throws on startup, **do not delete files immediately** — `gittensory-miner restore "/tmp/gittensory-miner-backup-<date>" --force` the pre-upgrade backup, pin the previous package version, and file an issue with the failing `user_version` and store filename.
 
 **Rolling fleet upgrades:** upgrade and restart **one worker/state dir at a time** so isolated workers never share a directory mid-migration.
 

--- a/packages/gittensory-miner/lib/backup-cli.d.ts
+++ b/packages/gittensory-miner/lib/backup-cli.d.ts
@@ -1,0 +1,42 @@
+export type BackupStatus = "skipped" | "backed-up" | "failed";
+export type RestoreStatus = "skipped" | "restored" | "exists" | "failed";
+
+export type BackupResult = {
+  name: string;
+  ok: boolean;
+  status: BackupStatus;
+  detail: string;
+  sourcePath: string;
+  destPath: string;
+};
+
+export type RestoreResult = {
+  name: string;
+  ok: boolean;
+  status: RestoreStatus;
+  detail: string;
+  sourcePath: string;
+  destPath: string;
+};
+
+export type BackupStoreDescriptor = {
+  name: string;
+  resolveDbPath: (env?: Record<string, string | undefined>) => string;
+};
+
+export function runBackupChecks(
+  destDir: string,
+  env?: Record<string, string | undefined>,
+  stores?: BackupStoreDescriptor[],
+): Promise<BackupResult[]>;
+
+export function runRestoreChecks(
+  srcDir: string,
+  env?: Record<string, string | undefined>,
+  force?: boolean,
+  stores?: BackupStoreDescriptor[],
+): RestoreResult[];
+
+export function runBackup(args?: string[], env?: Record<string, string | undefined>): Promise<number>;
+
+export function runRestore(args?: string[], env?: Record<string, string | undefined>): number;

--- a/packages/gittensory-miner/lib/backup-cli.js
+++ b/packages/gittensory-miner/lib/backup-cli.js
@@ -1,0 +1,166 @@
+// Local-store backup/restore for the miner (#4872). No backup/restore tooling existed for AMS state, unlike
+// the main product's dedicated backup scripts -- docs/operations-runbook.md already told operators to hand-run
+// `tar -czf ...` (or SQLite's own `.backup` command, since "never copy a live SQLite file" while the miner is
+// running) as part of the upgrade checklist; this formalizes that into a real command using the SAME safe
+// mechanism the runbook already recommends: node:sqlite's `backup()`, which uses SQLite's online backup API
+// and is safe to run against a store the miner still has open, unlike a naive file copy of a live database.
+// Mirrors migrate-cli.js's store list and per-store isolation (one bad store never aborts the whole sweep).
+import { chmodSync, copyFileSync, existsSync, mkdirSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { DatabaseSync, backup } from "node:sqlite";
+import { resolveLaptopStateDbPath } from "./laptop-init.js";
+import { resolveClaimLedgerDbPath } from "./claim-ledger.js";
+import { resolveEventLedgerDbPath } from "./event-ledger.js";
+import { resolveGovernorLedgerDbPath } from "./governor-ledger.js";
+import { resolvePredictionLedgerDbPath } from "./prediction-ledger.js";
+import { resolvePortfolioQueueDbPath } from "./portfolio-queue.js";
+import { resolveRunStateDbPath } from "./run-state.js";
+import { resolvePlanStoreDbPath } from "./plan-store.js";
+
+const STORES = [
+  { name: "laptop-state", resolveDbPath: resolveLaptopStateDbPath },
+  { name: "event-ledger", resolveDbPath: resolveEventLedgerDbPath },
+  { name: "governor-ledger", resolveDbPath: resolveGovernorLedgerDbPath },
+  { name: "prediction-ledger", resolveDbPath: resolvePredictionLedgerDbPath },
+  { name: "portfolio-queue", resolveDbPath: resolvePortfolioQueueDbPath },
+  { name: "claim-ledger", resolveDbPath: resolveClaimLedgerDbPath },
+  { name: "run-state", resolveDbPath: resolveRunStateDbPath },
+  { name: "plan-store", resolveDbPath: resolvePlanStoreDbPath },
+];
+
+function backupFileName(storeName) {
+  return `${storeName}.sqlite3`;
+}
+
+/**
+ * Back up one store's EXISTING on-disk file, using node:sqlite's online backup API (safe against a store the
+ * miner still has open -- never a raw file copy of a live database). A store that does not exist yet is
+ * skipped, not created.
+ */
+async function backupStore({ name, resolveDbPath }, destDir, env) {
+  // sourcePath/destPath are resolved INSIDE the same try as the backup itself: resolveDbPath is caller-supplied
+  // (injectable for tests) and could throw, and that must still surface as one failed store result rather than
+  // an uncaught exception aborting the whole sweep (the same class of bug migrate-cli.js's own migrateStore
+  // fixed for #4871 -- resolution must never happen outside the try).
+  let sourcePath;
+  let destPath;
+  let sourceDb;
+  try {
+    sourcePath = resolveDbPath(env);
+    destPath = join(destDir, backupFileName(name));
+    if (!existsSync(sourcePath)) {
+      return { name, ok: true, status: "skipped", detail: "not created yet", sourcePath, destPath };
+    }
+    sourceDb = new DatabaseSync(sourcePath, { readOnly: true });
+    const pagesCopied = await backup(sourceDb, destPath);
+    chmodSync(destPath, 0o600);
+    return { name, ok: true, status: "backed-up", detail: `${pagesCopied} page(s)`, sourcePath, destPath };
+  } catch (error) {
+    return {
+      name,
+      ok: false,
+      status: "failed",
+      detail: error instanceof Error ? error.message : String(error),
+      sourcePath: sourcePath ?? null,
+      destPath: destPath ?? null,
+    };
+  } finally {
+    sourceDb?.close();
+  }
+}
+
+/**
+ * Restore one store's file from a previously-created backup directory into its real, live path. The backup
+ * file itself is static (not a live database), so a plain file copy is safe here -- unlike backing up a live
+ * store, restoring never needs the online backup API. Refuses to overwrite an existing destination file unless
+ * `force` is set, so a restore can never silently clobber current state by accident. A store with no matching
+ * backup file in `srcDir` is skipped.
+ */
+function restoreStore({ name, resolveDbPath }, srcDir, env, force) {
+  // sourcePath is a plain join() of caller-controlled strings -- it cannot itself throw, so it's resolved
+  // once, up front, and is always defined by the time the catch below runs. destPath's resolution (via the
+  // injectable, possibly-throwing resolveDbPath) happens INSIDE the try for the same reason backupStore's does.
+  const sourcePath = join(srcDir, backupFileName(name));
+  let destPath;
+  try {
+    destPath = resolveDbPath(env);
+    if (!existsSync(sourcePath)) {
+      return { name, ok: true, status: "skipped", detail: "no backup file found", sourcePath, destPath };
+    }
+    if (existsSync(destPath) && !force) {
+      return {
+        name,
+        ok: false,
+        status: "exists",
+        detail: `${destPath} already exists; pass --force to overwrite`,
+        sourcePath,
+        destPath,
+      };
+    }
+    mkdirSync(dirname(destPath), { recursive: true, mode: 0o700 });
+    copyFileSync(sourcePath, destPath);
+    chmodSync(destPath, 0o600);
+    return { name, ok: true, status: "restored", detail: destPath, sourcePath, destPath };
+  } catch (error) {
+    return {
+      name,
+      ok: false,
+      status: "failed",
+      detail: error instanceof Error ? error.message : String(error),
+      sourcePath,
+      destPath: destPath ?? null,
+    };
+  }
+}
+
+/** `stores` is injectable so tests can exercise a store descriptor's failure paths (e.g. a non-Error throw)
+ *  without depending on real node:sqlite/node:fs error shapes; defaults to the real eight-store list. */
+export async function runBackupChecks(destDir, env = process.env, stores = STORES) {
+  mkdirSync(destDir, { recursive: true, mode: 0o700 });
+  const results = [];
+  for (const store of stores) results.push(await backupStore(store, destDir, env));
+  return results;
+}
+
+export function runRestoreChecks(srcDir, env = process.env, force = false, stores = STORES) {
+  return stores.map((store) => restoreStore(store, srcDir, env, force));
+}
+
+function printResults(results, jsonOutput, ok) {
+  if (jsonOutput) {
+    console.log(JSON.stringify({ ok, stores: results }, null, 2));
+    return;
+  }
+  for (const result of results) {
+    console.log(`${result.ok ? result.status.padEnd(10) : "FAIL      "} ${result.name}: ${result.detail}`);
+  }
+}
+
+export async function runBackup(args = [], env = process.env) {
+  const jsonOutput = args.includes("--json");
+  const destDir = args.find((arg) => !arg.startsWith("-"));
+  if (!destDir) {
+    console.error("Usage: gittensory-miner backup <destDir> [--json]");
+    return 2;
+  }
+  const results = await runBackupChecks(destDir, env);
+  const failed = results.filter((result) => !result.ok);
+  printResults(results, jsonOutput, failed.length === 0);
+  if (failed.length > 0 && !jsonOutput) console.error(`backup: ${failed.length} store(s) failed`);
+  return failed.length === 0 ? 0 : 1;
+}
+
+export function runRestore(args = [], env = process.env) {
+  const jsonOutput = args.includes("--json");
+  const force = args.includes("--force");
+  const srcDir = args.find((arg) => !arg.startsWith("-"));
+  if (!srcDir) {
+    console.error("Usage: gittensory-miner restore <srcDir> [--force] [--json]");
+    return 2;
+  }
+  const results = runRestoreChecks(srcDir, env, force);
+  const failed = results.filter((result) => !result.ok);
+  printResults(results, jsonOutput, failed.length === 0);
+  if (failed.length > 0 && !jsonOutput) console.error(`restore: ${failed.length} store(s) failed`);
+  return failed.length === 0 ? 0 : 1;
+}

--- a/packages/gittensory-miner/lib/cli.js
+++ b/packages/gittensory-miner/lib/cli.js
@@ -20,6 +20,8 @@ export function printHelp(input) {
       "  gittensory-miner status [--json]                              Show installed versions + local state paths",
       "  gittensory-miner doctor [--json]                              Check this laptop is set up correctly",
       "  gittensory-miner migrate [--json]                             Apply pending schema migrations to existing local stores",
+      "  gittensory-miner backup <destDir> [--json]                    Back up existing local stores into destDir",
+      "  gittensory-miner restore <srcDir> [--force] [--json]          Restore local stores from a backup directory",
       "  gittensory-miner metrics                                      Print prediction-calibration counters in Prometheus text format",
       "  gittensory-miner manage status [--json]                       Show managed PR rows from local portfolio + ledger",
       "  gittensory-miner manage poll <owner/repo> <pr#> [--branch <name>] [--dry-run] [--json]",

--- a/test/unit/miner-backup-cli.test.ts
+++ b/test/unit/miner-backup-cli.test.ts
@@ -1,0 +1,270 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { runBackup, runBackupChecks, runRestore, runRestoreChecks } from "../../packages/gittensory-miner/lib/backup-cli.js";
+import { initPortfolioQueueStore, resolvePortfolioQueueDbPath } from "../../packages/gittensory-miner/lib/portfolio-queue.js";
+import { resolveEventLedgerDbPath } from "../../packages/gittensory-miner/lib/event-ledger.js";
+
+const roots: string[] = [];
+
+function tempEnv() {
+  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-backup-"));
+  roots.push(root);
+  return { GITTENSORY_MINER_CONFIG_DIR: join(root, "state"), root };
+}
+
+function tempDestDir() {
+  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-backup-dest-"));
+  roots.push(root);
+  return join(root, "backup");
+}
+
+const STORE_NAMES = [
+  "laptop-state",
+  "event-ledger",
+  "governor-ledger",
+  "prediction-ledger",
+  "portfolio-queue",
+  "claim-ledger",
+  "run-state",
+  "plan-store",
+];
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+describe("gittensory-miner backup/restore (#4872)", () => {
+  it("covers all eight local stores, in a stable order, and skips every one when nothing has been created yet (never creating them as a side effect)", async () => {
+    const { root, ...env } = tempEnv();
+    const destDir = join(root, "backup");
+    const results = await runBackupChecks(destDir, env);
+
+    expect(results.map((result) => result.name)).toEqual(STORE_NAMES);
+    for (const result of results) {
+      expect(result.ok).toBe(true);
+      expect(result.status).toBe("skipped");
+      expect(result.detail).toBe("not created yet");
+      expect(existsSync(result.sourcePath)).toBe(false);
+    }
+  });
+
+  it("backs up an existing store's real data via the safe online-backup API, and restore round-trips it byte-for-byte readable", async () => {
+    const { root, ...env } = tempEnv();
+    const store = initPortfolioQueueStore(resolvePortfolioQueueDbPath(env));
+    store.enqueue({ repoFullName: "acme/widgets", identifier: "issue:1", priority: 5 });
+    store.close();
+
+    const destDir = tempDestDir();
+    const backupResults = await runBackupChecks(destDir, env);
+    const portfolioBackup = backupResults.find((result) => result.name === "portfolio-queue");
+    expect(portfolioBackup).toMatchObject({ ok: true, status: "backed-up" });
+    expect(existsSync(portfolioBackup!.destPath)).toBe(true);
+
+    const restoreEnv = { GITTENSORY_MINER_CONFIG_DIR: join(root, "restored-state") };
+    const restoreResults = runRestoreChecks(destDir, restoreEnv, false);
+    const portfolioRestore = restoreResults.find((result) => result.name === "portfolio-queue");
+    expect(portfolioRestore).toMatchObject({ ok: true, status: "restored" });
+
+    const restoredStore = initPortfolioQueueStore(resolvePortfolioQueueDbPath(restoreEnv));
+    try {
+      expect(restoredStore.listQueue()).toEqual([
+        expect.objectContaining({ repoFullName: "acme/widgets", identifier: "issue:1" }),
+      ]);
+    } finally {
+      restoredStore.close();
+    }
+  });
+
+  it("skips restoring a store with no matching backup file, without touching the real destination", () => {
+    const { root, ...env } = tempEnv();
+    const emptyBackupDir = mkdtempSync(join(tmpdir(), "gittensory-miner-empty-backup-"));
+    roots.push(emptyBackupDir);
+
+    const results = runRestoreChecks(emptyBackupDir, env, false);
+    for (const result of results) {
+      expect(result.ok).toBe(true);
+      expect(result.status).toBe("skipped");
+      expect(result.detail).toBe("no backup file found");
+      expect(existsSync(result.destPath)).toBe(false);
+    }
+  });
+
+  it("refuses to overwrite an existing destination file without --force, and succeeds once --force is passed", async () => {
+    const { root, ...env } = tempEnv();
+    const store = initPortfolioQueueStore(resolvePortfolioQueueDbPath(env));
+    store.enqueue({ repoFullName: "acme/widgets", identifier: "issue:1", priority: 5 });
+    store.close();
+    const destDir = tempDestDir();
+    await runBackupChecks(destDir, env);
+
+    // Restore into the SAME env: the destination already exists (it's the store we just backed up).
+    const withoutForce = runRestoreChecks(destDir, env, false);
+    const portfolioWithoutForce = withoutForce.find((result) => result.name === "portfolio-queue");
+    expect(portfolioWithoutForce).toMatchObject({ ok: false, status: "exists" });
+    expect(portfolioWithoutForce?.detail).toContain("--force");
+
+    const withForce = runRestoreChecks(destDir, env, true);
+    const portfolioWithForce = withForce.find((result) => result.name === "portfolio-queue");
+    expect(portfolioWithForce).toMatchObject({ ok: true, status: "restored" });
+  });
+
+  it("reports a failed backup (and leaves every other store's own result untouched) when one source store file is corrupted", async () => {
+    const { root, ...env } = tempEnv();
+    const eventLedgerPath = resolveEventLedgerDbPath(env);
+    mkdirSync(join(eventLedgerPath, ".."), { recursive: true });
+    writeFileSync(eventLedgerPath, "this is not a sqlite database");
+
+    const destDir = tempDestDir();
+    const results = await runBackupChecks(destDir, env);
+    const eventLedger = results.find((result) => result.name === "event-ledger");
+    const others = results.filter((result) => result.name !== "event-ledger");
+
+    expect(eventLedger?.ok).toBe(false);
+    expect(eventLedger?.status).toBe("failed");
+    expect(typeof eventLedger?.detail).toBe("string");
+    for (const other of others) expect(other.ok).toBe(true);
+  });
+
+  it("reports a failed restore (and leaves every other store's own result untouched) when copying one backup file fails", async () => {
+    const { root, ...env } = tempEnv();
+    const store = initPortfolioQueueStore(resolvePortfolioQueueDbPath(env));
+    store.close();
+    const destDir = tempDestDir();
+    await runBackupChecks(destDir, env);
+
+    // Corrupt the BACKUP FILE itself so the restore copy has something real to fail on, without needing a
+    // permissions trick that may behave differently across CI runners.
+    const backupFilePath = join(destDir, "portfolio-queue.sqlite3");
+    rmSync(backupFilePath);
+    mkdirSync(backupFilePath); // a directory where restore expects to copyFileSync a regular file
+
+    const restoreEnv = { GITTENSORY_MINER_CONFIG_DIR: join(root, "restored-state") };
+    const results = runRestoreChecks(destDir, restoreEnv, false);
+    const portfolioQueue = results.find((result) => result.name === "portfolio-queue");
+    const others = results.filter((result) => result.name !== "portfolio-queue");
+
+    expect(portfolioQueue?.ok).toBe(false);
+    expect(portfolioQueue?.status).toBe("failed");
+    expect(typeof portfolioQueue?.detail).toBe("string");
+    for (const other of others) expect(other.ok).toBe(true);
+  });
+
+  it("restored files are chmod 0600, matching every other store file's permissions", async () => {
+    const { root, ...env } = tempEnv();
+    const store = initPortfolioQueueStore(resolvePortfolioQueueDbPath(env));
+    store.close();
+    const destDir = tempDestDir();
+    await runBackupChecks(destDir, env);
+
+    const restoreEnv = { GITTENSORY_MINER_CONFIG_DIR: join(root, "restored-state") };
+    const results = runRestoreChecks(destDir, restoreEnv, false);
+    const portfolioQueue = results.find((result) => result.name === "portfolio-queue")!;
+    const mode = statSync(portfolioQueue.destPath).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+
+  it("runBackup requires a destDir argument and prints usage on stderr otherwise", async () => {
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(await runBackup([], tempEnv())).toBe(2);
+    expect(errorLog).toHaveBeenCalledWith(expect.stringContaining("Usage: gittensory-miner backup"));
+  });
+
+  it("runRestore requires a srcDir argument and prints usage on stderr otherwise", () => {
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(runRestore([], tempEnv())).toBe(2);
+    expect(errorLog).toHaveBeenCalledWith(expect.stringContaining("Usage: gittensory-miner restore"));
+  });
+
+  it("runBackup prints human-readable text (exit 0) and machine JSON with --json, and exits 1 when a store fails", async () => {
+    const { root, ...healthyEnv } = tempEnv();
+    const destDir = join(root, "backup");
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    expect(await runBackup([destDir], healthyEnv)).toBe(0);
+    expect(String(log.mock.calls[0]?.[0])).toContain("skipped");
+    log.mockClear();
+
+    expect(await runBackup([destDir, "--json"], healthyEnv)).toBe(0);
+    const payload = JSON.parse(String(log.mock.calls[0]?.[0]));
+    expect(payload.ok).toBe(true);
+    expect(payload.stores).toHaveLength(STORE_NAMES.length);
+
+    const { root: brokenRoot, ...brokenEnv } = tempEnv();
+    const eventLedgerPath = resolveEventLedgerDbPath(brokenEnv);
+    mkdirSync(join(eventLedgerPath, ".."), { recursive: true });
+    writeFileSync(eventLedgerPath, "this is not a sqlite database");
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(await runBackup([join(brokenRoot, "backup")], brokenEnv)).toBe(1);
+    expect(errorLog).toHaveBeenCalledWith(expect.stringContaining("1 store(s) failed"));
+  });
+
+  it("runRestore prints human-readable text (exit 0) and machine JSON with --json", async () => {
+    const { root, ...env } = tempEnv();
+    const destDir = join(root, "backup");
+    await runBackup([destDir], env);
+
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const restoreEnv = { GITTENSORY_MINER_CONFIG_DIR: join(root, "restored-state") };
+    expect(runRestore([destDir], restoreEnv)).toBe(0);
+    expect(String(log.mock.calls[0]?.[0])).toContain("skipped");
+    log.mockClear();
+
+    const restoreEnv2 = { GITTENSORY_MINER_CONFIG_DIR: join(root, "restored-state-2") };
+    expect(runRestore([destDir, "--json"], restoreEnv2)).toBe(0);
+    const payload = JSON.parse(String(log.mock.calls[0]?.[0]));
+    expect(payload.ok).toBe(true);
+    expect(payload.stores).toHaveLength(STORE_NAMES.length);
+  });
+
+  it("runRestore itself exits 1 and reports the failure count when a store fails", () => {
+    const { root, ...env } = tempEnv();
+    const store = initPortfolioQueueStore(resolvePortfolioQueueDbPath(env));
+    store.close();
+    const destDir = tempDestDir();
+    return runBackup([destDir], env).then(() => {
+      // Restoring into the SAME env without --force: the destination already exists (the store just backed up).
+      const log = vi.spyOn(console, "log").mockImplementation(() => {});
+      const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+      expect(runRestore([destDir], env)).toBe(1);
+      expect(errorLog).toHaveBeenCalledWith(expect.stringContaining("1 store(s) failed"));
+      log.mockRestore();
+    });
+  });
+
+  it("REGRESSION (gate-caught pattern, same as migrate-cli.js's #4871 fix): a throwing resolveDbPath is caught INSIDE backupStore/restoreStore, reporting one failed store instead of crashing the whole sweep", async () => {
+    const { root, ...env } = tempEnv();
+    const throwingStore = {
+      name: "fake-store",
+      resolveDbPath: () => {
+        throw "boom"; // deliberately non-Error, exercising the ternary's fallback branch too
+      },
+    };
+
+    const backupResults = await runBackupChecks(join(root, "backup"), env, [throwingStore]);
+    expect(backupResults).toEqual([
+      { name: "fake-store", ok: false, status: "failed", detail: "boom", sourcePath: null, destPath: null },
+    ]);
+
+    const restoreResults = runRestoreChecks(join(root, "backup"), env, false, [throwingStore]);
+    expect(restoreResults).toEqual([
+      {
+        name: "fake-store",
+        ok: false,
+        status: "failed",
+        detail: "boom",
+        sourcePath: join(root, "backup", "fake-store.sqlite3"), // resolved before the throwing resolveDbPath call
+        destPath: null,
+      },
+    ]);
+  });
+
+  it("makes no network calls", async () => {
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const { root, ...env } = tempEnv();
+    await runBackupChecks(join(root, "backup"), env);
+    runRestoreChecks(join(root, "backup"), env, false);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

- Zero backup/restore tooling existed for AMS state — `docs/operations-runbook.md` already told operators to
  hand-run `tar -czf ...` or SQLite's own `.backup` command as part of the upgrade/corruption-recovery
  checklists ("never copy a live SQLite file from a running miner as backup"), but nothing automated that
  guidance into a real, testable command.
- Added `packages/gittensory-miner/lib/backup-cli.js` (+ `.d.ts`): `gittensory-miner backup <destDir> [--json]`
  and `gittensory-miner restore <srcDir> [--force] [--json]`, covering all eight local stores (the seven
  `doctor`/`migrate` already track, plus `laptop-state`).
- `backup` uses `node:sqlite`'s exported `backup(sourceDb, destPath)` function for each **existing** store —
  confirmed via direct empirical testing that this uses SQLite's own online backup API, which is safe to run
  against a store the miner still has open, unlike a raw file copy of a live database (exactly the mechanism
  the runbook already recommends via `sqlite3 "$DB" ".backup ..."`, just automated across every store at once).
  A store that hasn't been created yet is skipped, never created as a side effect.
- `restore` copies files from a previous `backup` back into their real, live paths. It refuses to overwrite an
  existing destination file unless `--force` is passed, so a restore can never silently clobber current state
  by accident; a store with no matching backup file in the source directory is skipped.
- Updated `docs/operations-runbook.md`'s existing manual-backup guidance (the pre-upgrade checklist's backup
  step, the ledger-corruption recovery scenario's backup/restore tiers) to use the new commands, and
  `README.md`/`DEPLOYMENT.md` to document them alongside `migrate`.

Fixes #4872

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — `packages/gittensory-miner/lib/**/*.js` **is** included in this repo's `codecov/patch` gate. Targeted coverage run (`--coverage.include` scoped to `backup-cli.js`): **100% statements, 100% branches, 100% functions, 100% lines**.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run build:miner`
- [x] `npm run test:miner-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

Ran the full local gate: `npm run test:ci` (814 test files, 0 failures) and `npm audit --audit-level=moderate` (0 vulnerabilities), both clean on the final rebased commit. Before finalizing, also directly ran the exact `FORBIDDEN_PATH`/`FORBIDDEN_CONTENT` regexes from `scripts/check-miner-package.mjs`/`scripts/forbidden-content.mjs` against the new file's path and every touched file's content (including the three doc files) — zero matches, confirming nothing here trips the miner package's own secret-content packaging guard (a real defect this session caught twice already on unrelated PRs, so worth double-checking proactively every time).

New `test/unit/miner-backup-cli.test.ts` (14 tests): all eight stores reported `skipped` (never created as a side effect) when nothing exists yet; a full real backup→restore round-trip that enqueues real data, backs it up, restores it into a fresh env, and reads the data back out; restore skipping a store with no matching backup file; refusing to overwrite an existing destination without `--force` and succeeding once `--force` is passed; per-store failure isolation for both backup (a corrupted source file) and restore (a filesystem error on the copy step) — every other store's result stays unaffected; restored files end up `chmod 0600`, matching every other store file's permissions; CLI usage-error paths, `--json`/text output, and exit codes for both `runBackup` and `runRestore` (including `runRestore`'s own exit-1-on-failure path); and a no-network-calls invariant.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no auth/session/CORS surface touched (local file/SQLite operations only, no network calls — asserted directly by a "makes no network calls" test).
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — no public API/OpenAPI/MCP surface touched; this is a new local CLI command pair only.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI surface.
- [x] Visible UI changes include a `UI Evidence` section below. — N/A, see below.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — updated `README.md`, `DEPLOYMENT.md`, and `docs/operations-runbook.md`.

## UI Evidence

N/A — this is a local CLI-only change (two new terminal subcommands) with no visible UI surface. No screenshots apply.

## Notes

- Writing thorough tests caught a real bug before it ever shipped: an initial draft resolved each store's
  `resolveDbPath(env)` call **outside** the `try`/`catch` in both `backupStore` and `restoreStore` — a throwing
  resolver would have crashed the whole sweep instead of reporting one failed store, exactly the same class of
  bug already caught and fixed once this session in `migrate-cli.js`'s own `migrateStore` for #4871. Fixed by
  moving resolution inside the `try` in both functions, with a regression test proving a throwing resolver now
  produces a clean per-store failure result instead of an uncaught exception.
- Also simplified `restoreStore`'s error path: its `sourcePath` is a plain `join()` of caller-controlled
  strings, which cannot itself throw, so it's always defined by the time the `catch` block runs — the initial
  `sourcePath ?? null` nullish-fallback was genuinely unreachable dead code. Removed it rather than writing a
  contrived test to force that branch, once a coverage check confirmed it was the one remaining gap.
- Covers the same eight stores `doctor`/`migrate` already track (matching their established store list and
  per-store isolation pattern exactly) — no new store inventory to maintain in a third place.
