### PR TITLE
fix(miner): route `queue next` through the WIP-cap-aware claimer

### DIFF
--- a/packages/gittensory-miner/lib/portfolio-queue-cli.d.ts
+++ b/packages/gittensory-miner/lib/portfolio-queue-cli.d.ts
@@ -44,7 +44,15 @@ export function runQueueList(
 
 export function runQueueNext(
   args: string[],
-  options?: { initPortfolioQueue?: () => PortfolioQueueStore },
+  options?: {
+    initPortfolioQueue?: () => PortfolioQueueStore;
+    initPortfolioQueueManager?: (init: {
+      store?: PortfolioQueueStore;
+      caps?: { globalWipCap: number; perRepoWipCap: number };
+    }) => PortfolioQueueManager;
+    resolveMinerGoalSpec?: (repoPath: string) => { spec: { maxConcurrentClaims: number } };
+    cwd?: string;
+  },
 ): number;
 
 export function runQueueDone(

--- a/packages/gittensory-miner/lib/portfolio-queue-cli.js
+++ b/packages/gittensory-miner/lib/portfolio-queue-cli.js
@@ -1,7 +1,18 @@
 import { initPortfolioQueueStore } from "./portfolio-queue.js";
 import { initPortfolioQueueManager } from "./portfolio-queue-manager.js";
 import { runPortfolioDashboard } from "./portfolio-dashboard.js";
+import { resolveMinerGoalSpec } from "./miner-goal-spec.js";
 import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
+
+/**
+ * The operator's configured WIP cap for `queue next` (#4850): `maxConcurrentClaims` from their own
+ * `.gittensory-miner.yml` in the working directory. Never throws — a missing/malformed file degrades to the
+ * schema default (1). `resolveMinerGoalSpec`/`cwd` are injectable for tests.
+ */
+function resolveConfiguredWipCap(options) {
+  const resolve = options.resolveMinerGoalSpec ?? resolveMinerGoalSpec;
+  return resolve(options.cwd ?? process.cwd()).spec.maxConcurrentClaims;
+}
 
 const QUEUE_LIST_USAGE = "Usage: gittensory-miner queue list [--repo <owner/repo>] [--json]";
 const QUEUE_NEXT_USAGE = "Usage: gittensory-miner queue next [--dry-run] [--json]";
@@ -192,14 +203,24 @@ export function runQueueNext(args, options = {}) {
     if (parsed.json) {
       console.log(JSON.stringify(dryRunResult, null, 2));
     } else {
-      console.log("DRY RUN: would dequeue the highest-priority queued item. No portfolio-queue write was made.");
+      console.log(
+        "DRY RUN: would claim the next eligible queued item, subject to the configured WIP cap. No portfolio-queue write was made.",
+      );
     }
     return 0;
   }
 
+  // Route through the WIP-cap-aware claimer (portfolio-queue-manager.js) instead of the naive uncapped
+  // `dequeueNext()` (#4850), capped by `maxConcurrentClaims` from the operator's own `.gittensory-miner.yml`, so
+  // running `queue next` repeatedly stops claiming once the cap's worth of items are in flight.
+  const wipCap = resolveConfiguredWipCap(options);
   try {
     return withPortfolioQueue(options, (portfolioQueue) => {
-      const entry = portfolioQueue.dequeueNext();
+      const manager = (options.initPortfolioQueueManager ?? initPortfolioQueueManager)({
+        store: portfolioQueue,
+        caps: { globalWipCap: wipCap, perRepoWipCap: wipCap },
+      });
+      const entry = manager.claimNext();
       if (parsed.json) {
         console.log(JSON.stringify({ entry }, null, 2));
       } else {

--- a/packages/gittensory-miner/lib/portfolio-queue-manager.d.ts
+++ b/packages/gittensory-miner/lib/portfolio-queue-manager.d.ts
@@ -34,6 +34,7 @@ export type PortfolioQueueManager = {
   markFailed(repoFullName: string, identifier: string): QueueEntry | null;
   reclaimStuckItems(maxLeaseMs?: number): QueueEntry[];
   claimNextBatch(): QueueEntry[];
+  claimNext(): QueueEntry | null;
   close(): void;
 };
 

--- a/packages/gittensory-miner/lib/portfolio-queue-manager.js
+++ b/packages/gittensory-miner/lib/portfolio-queue-manager.js
@@ -105,6 +105,17 @@ export function initPortfolioQueueManager(options = {}) {
       sweepStuckItems(store, Date.now(), staleLeaseMs);
       return store.batchClaim((entries) => selectEligibleBatch(entries, caps));
     },
+    /**
+     * Claim the single next-eligible item under the caps — the caps-aware counterpart to the naive `dequeueNext()`,
+     * for the `queue next` CLI path (#4850). Reclaims orphaned leases first (like `claimNextBatch`), then claims at
+     * most one item; returns it, or `null` when the queue is empty OR the WIP cap is already reached (so calling it
+     * repeatedly stops claiming once `globalWipCap` in-flight items exist).
+     */
+    claimNext() {
+      sweepStuckItems(store, Date.now(), staleLeaseMs);
+      const [claimed] = store.batchClaim((entries) => selectEligibleBatch(entries, caps).slice(0, 1));
+      return claimed ?? null;
+    },
     close() {
       store.close();
     },

--- a/test/unit/miner-portfolio-queue-cli.test.ts
+++ b/test/unit/miner-portfolio-queue-cli.test.ts
@@ -20,7 +20,7 @@ import {
   runQueueRelease,
   runQueueRequeue,
 } from "../../packages/gittensory-miner/lib/portfolio-queue-cli.js";
-import type { QueueEntry } from "../../packages/gittensory-miner/lib/portfolio-queue.d.ts";
+import type { PortfolioQueueStore, QueueEntry } from "../../packages/gittensory-miner/lib/portfolio-queue.d.ts";
 
 const roots: string[] = [];
 const stores: Array<{ close(): void }> = [];
@@ -98,35 +98,46 @@ describe("gittensory-miner portfolio queue CLI (#2292)", () => {
     });
   });
 
-  it("runQueueNext claims the highest-priority queued item", () => {
+  // Inject the operator's configured WIP cap (`maxConcurrentClaims`) so `queue next`'s caps-aware claim (#4850) is
+  // exercised deterministically without a real `.gittensory-miner.yml` on disk.
+  const nextOptions = (store: PortfolioQueueStore, maxConcurrentClaims: number) => ({
+    initPortfolioQueue: () => store,
+    resolveMinerGoalSpec: () => ({ spec: { maxConcurrentClaims } }),
+  });
+
+  it("runQueueNext claims the highest-priority queued item (within the WIP cap)", () => {
     const portfolioQueue = tempQueueStore();
     portfolioQueue.enqueue({ repoFullName: "acme/widgets", identifier: "issue:1", priority: 10 });
     portfolioQueue.enqueue({ repoFullName: "acme/widgets", identifier: "issue:2", priority: 90 });
 
     const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
-    expect(
-      runQueueNext([], {
-        initPortfolioQueue: () => portfolioQueue,
-      }),
-    ).toBe(0);
+    // A cap of 3 leaves room for both claims plus the empty follow-up, so the sequential behavior is unchanged.
+    expect(runQueueNext([], nextOptions(portfolioQueue, 3))).toBe(0);
     expect(log).toHaveBeenCalledWith("issue:2");
 
     log.mockClear();
-    expect(
-      runQueueNext(["--json"], {
-        initPortfolioQueue: () => portfolioQueue,
-      }),
-    ).toBe(0);
+    expect(runQueueNext(["--json"], nextOptions(portfolioQueue, 3))).toBe(0);
     expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
       entry: expect.objectContaining({ identifier: "issue:1", status: "in_progress" }),
     });
 
     log.mockClear();
-    expect(
-      runQueueNext([], {
-        initPortfolioQueue: () => portfolioQueue,
-      }),
-    ).toBe(0);
+    expect(runQueueNext([], nextOptions(portfolioQueue, 3))).toBe(0);
+    expect(log).toHaveBeenCalledWith("none");
+  });
+
+  it("#4850: runQueueNext stops claiming once the configured WIP cap is reached", () => {
+    const portfolioQueue = tempQueueStore();
+    portfolioQueue.enqueue({ repoFullName: "acme/widgets", identifier: "issue:1", priority: 10 });
+    portfolioQueue.enqueue({ repoFullName: "acme/widgets", identifier: "issue:2", priority: 90 });
+
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    // Cap of 1: the first call claims the highest-priority item, the second stops (one item already in flight).
+    expect(runQueueNext([], nextOptions(portfolioQueue, 1))).toBe(0);
+    expect(log).toHaveBeenCalledWith("issue:2");
+
+    log.mockClear();
+    expect(runQueueNext([], nextOptions(portfolioQueue, 1))).toBe(0);
     expect(log).toHaveBeenCalledWith("none");
   });
 
@@ -140,7 +151,7 @@ describe("gittensory-miner portfolio queue CLI (#2292)", () => {
 
     log.mockClear();
     expect(runQueueNext(["--dry-run"], { initPortfolioQueue: initPortfolioQueueSpy })).toBe(0);
-    expect(String(log.mock.calls[0]?.[0])).toContain("DRY RUN: would dequeue the highest-priority queued item");
+    expect(String(log.mock.calls[0]?.[0])).toContain("DRY RUN: would claim the next eligible queued item");
 
     log.mockClear();
     expect(

--- a/test/unit/miner-portfolio-queue-manager.test.ts
+++ b/test/unit/miner-portfolio-queue-manager.test.ts
@@ -114,3 +114,31 @@ describe("initPortfolioQueueManager().claimNextBatch() (#4285)", () => {
     expect(claimed.map((entry) => entry.identifier)).toEqual(["two"]);
   });
 });
+
+describe("initPortfolioQueueManager().claimNext() (#4850)", () => {
+  it("claims the single highest-priority eligible item, then stops once the WIP cap is reached", () => {
+    const manager = memoryManager({ globalWipCap: 1, perRepoWipCap: 1 });
+    manager.enqueue({ repoFullName: "acme/widgets", identifier: "issue:1", priority: 10 });
+    manager.enqueue({ repoFullName: "acme/widgets", identifier: "issue:2", priority: 90 });
+
+    // First claim takes the highest-priority item; the cap of 1 then blocks any further claim.
+    expect(manager.claimNext()?.identifier).toBe("issue:2");
+    expect(manager.claimNext()).toBeNull();
+  });
+
+  it("resumes claiming once an in-flight item is marked done, freeing a WIP slot", () => {
+    const manager = memoryManager({ globalWipCap: 1, perRepoWipCap: 1 });
+    manager.enqueue({ repoFullName: "acme/widgets", identifier: "issue:1", priority: 10 });
+    manager.enqueue({ repoFullName: "acme/widgets", identifier: "issue:2", priority: 90 });
+
+    expect(manager.claimNext()?.identifier).toBe("issue:2");
+    expect(manager.claimNext()).toBeNull();
+    manager.markDone("acme/widgets", "issue:2");
+    expect(manager.claimNext()?.identifier).toBe("issue:1");
+  });
+
+  it("returns null on an empty queue", () => {
+    const manager = memoryManager({ globalWipCap: 3, perRepoWipCap: 3 });
+    expect(manager.claimNext()).toBeNull();
+  });
+});


### PR DESCRIPTION
## What

`gittensory-miner queue next` called the naive, uncapped `dequeueNext()` directly, bypassing the WIP-cap-aware batch claimer (`portfolio-queue-manager.js`), and the WIP cap wasn't honored from the miner's own config. Per #4850.

- **New `claimNext()` on the manager** — the caps-aware, single-item counterpart to `claimNextBatch()`. Like the batch path, it reclaims orphaned leases first, then claims **at most one** item respecting the caps, returning it or `null`.
- **`queue next` now routes through it**, capped by **`maxConcurrentClaims`** read from the operator's own `.gittensory-miner.yml` (via `resolveMinerGoalSpec`; missing/malformed → the schema default of 1). So running `queue next` repeatedly **stops claiming once the cap's worth of items are in flight**, and resumes once one is marked done — the acceptance criterion.

Single-repo priority ordering is preserved (the highest-priority eligible item is claimed first); the cap is the only added constraint.

## Tests

- `miner-portfolio-queue-manager.test.ts`: `claimNext()` claims one under the cap, returns `null` at the cap, resumes after `markDone`, and on an empty queue.
- `miner-portfolio-queue-cli.test.ts`: `queue next` claims highest-priority within the cap, **stops at the configured cap** (#4850), and the dry-run path is unchanged.

Verified locally: `tsc --noEmit` clean; the engine cap primitive (`nextEligibleItems`) confirmed to return nothing once `in_progress ≥ globalWipCap`. (The full vitest suite for these files runs in CI — they transitively import the engine's native `web-tree-sitter` dep, which isn't available in this sandbox.)

Fixes #4850