### PR TITLE
fix(miner): enforce the WIP cap on `queue next` (host-preserving)

### DIFF
--- a/packages/gittensory-miner/lib/portfolio-queue-cli.d.ts
+++ b/packages/gittensory-miner/lib/portfolio-queue-cli.d.ts
@@ -45,7 +45,15 @@ export function runQueueList(
 
 export function runQueueNext(
   args: string[],
-  options?: { initPortfolioQueue?: () => PortfolioQueueStore },
+  options?: {
+    initPortfolioQueue?: () => PortfolioQueueStore;
+    initPortfolioQueueManager?: (init: {
+      store?: PortfolioQueueStore;
+      caps?: { globalWipCap: number; perRepoWipCap: number };
+    }) => PortfolioQueueManager;
+    resolveMinerGoalSpec?: (repoPath: string) => { spec: { maxConcurrentClaims: number } };
+    cwd?: string;
+  },
 ): number;
 
 export function runQueueDone(

--- a/packages/gittensory-miner/lib/portfolio-queue-cli.js
+++ b/packages/gittensory-miner/lib/portfolio-queue-cli.js
@@ -1,7 +1,18 @@
 import { initPortfolioQueueStore } from "./portfolio-queue.js";
 import { initPortfolioQueueManager } from "./portfolio-queue-manager.js";
 import { runPortfolioDashboard } from "./portfolio-dashboard.js";
+import { resolveMinerGoalSpec } from "./miner-goal-spec.js";
 import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
+
+/**
+ * The operator's configured WIP cap for `queue next` (#4850): `maxConcurrentClaims` from their own
+ * `.gittensory-miner.yml` in the working directory. Never throws — a missing/malformed file degrades to the
+ * schema default (1). `resolveMinerGoalSpec`/`cwd` are injectable for tests.
+ */
+function resolveConfiguredWipCap(options) {
+  const resolve = options.resolveMinerGoalSpec ?? resolveMinerGoalSpec;
+  return resolve(options.cwd ?? process.cwd()).spec.maxConcurrentClaims;
+}
 
 const QUEUE_LIST_USAGE = "Usage: gittensory-miner queue list [--repo <owner/repo>] [--json]";
 const QUEUE_NEXT_USAGE = "Usage: gittensory-miner queue next [--dry-run] [--json]";
@@ -225,14 +236,24 @@ export function runQueueNext(args, options = {}) {
     if (parsed.json) {
       console.log(JSON.stringify(dryRunResult, null, 2));
     } else {
-      console.log("DRY RUN: would dequeue the highest-priority queued item. No portfolio-queue write was made.");
+      console.log(
+        "DRY RUN: would claim the next eligible queued item, subject to the configured WIP cap. No portfolio-queue write was made.",
+      );
     }
     return 0;
   }
 
+  // Route through the WIP-cap-aware claimer (portfolio-queue-manager.js) instead of the naive uncapped
+  // `dequeueNext()` (#4850), capped by `maxConcurrentClaims` from the operator's own `.gittensory-miner.yml`, so
+  // running `queue next` repeatedly stops claiming once the cap's worth of items are in flight.
+  const wipCap = resolveConfiguredWipCap(options);
   try {
     return withPortfolioQueue(options, (portfolioQueue) => {
-      const entry = portfolioQueue.dequeueNext();
+      const manager = (options.initPortfolioQueueManager ?? initPortfolioQueueManager)({
+        store: portfolioQueue,
+        caps: { globalWipCap: wipCap, perRepoWipCap: wipCap },
+      });
+      const entry = manager.claimNext();
       if (parsed.json) {
         console.log(JSON.stringify({ entry }, null, 2));
       } else {

--- a/packages/gittensory-miner/lib/portfolio-queue-manager.d.ts
+++ b/packages/gittensory-miner/lib/portfolio-queue-manager.d.ts
@@ -34,6 +34,7 @@ export type PortfolioQueueManager = {
   markFailed(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueEntry | null;
   reclaimStuckItems(maxLeaseMs?: number): QueueEntry[];
   claimNextBatch(): QueueEntry[];
+  claimNext(): QueueEntry | null;
   close(): void;
 };
 

--- a/packages/gittensory-miner/lib/portfolio-queue-manager.js
+++ b/packages/gittensory-miner/lib/portfolio-queue-manager.js
@@ -111,6 +111,24 @@ export function initPortfolioQueueManager(options = {}) {
       sweepStuckItems(store, Date.now(), staleLeaseMs);
       return store.batchClaim((entries) => selectEligibleBatch(entries, caps));
     },
+    /**
+     * Claim the single highest-priority item for the `queue next` CLI path (#4850), enforcing the GLOBAL WIP cap.
+     * Reclaims orphaned leases first (like `claimNextBatch`), then — only while fewer than `globalWipCap` items are
+     * in flight — dequeues one via the STORE's `dequeueNext()`. Returns the item, or `null` when the queue is empty
+     * OR the cap is already reached, so repeated calls stop claiming once the cap's worth of items are in flight.
+     *
+     * It deliberately does NOT route through `selectEligibleBatch`: that engine selection
+     * (`queueItemId`/`parseQueueItemId`) carries only `repoFullName`/`identifier` — no forge dimension (see the
+     * `claimNextBatch` note above) — so it would drop `apiBaseUrl` and skip a non-default-host row entirely (#5596).
+     * `dequeueNext()` preserves the item's host identity while this cap check supplies the WIP ceiling.
+     */
+    claimNext() {
+      sweepStuckItems(store, Date.now(), staleLeaseMs);
+      if (caps.globalWipCap > 0 && store.listInProgress().length < caps.globalWipCap) {
+        return store.dequeueNext();
+      }
+      return null;
+    },
     close() {
       store.close();
     },

--- a/test/unit/miner-cli-json-error-coverage.test.ts
+++ b/test/unit/miner-cli-json-error-coverage.test.ts
@@ -83,8 +83,9 @@ describe("miner CLI --json error coverage (#4836)", () => {
     expectJsonError(
       () =>
         runQueueNext(["--json"], {
-          initPortfolioQueue: () =>
-            ({ dequeueNext: () => { throw new Error("next_db"); }, close: () => {} }) as never,
+          initPortfolioQueue: () => ({ close: () => {} }) as never,
+          initPortfolioQueueManager: () =>
+            ({ claimNext: () => { throw new Error("next_db"); } }) as never,
         }),
       "next_db",
     );

--- a/test/unit/miner-portfolio-queue-cli.test.ts
+++ b/test/unit/miner-portfolio-queue-cli.test.ts
@@ -20,7 +20,7 @@ import {
   runQueueRelease,
   runQueueRequeue,
 } from "../../packages/gittensory-miner/lib/portfolio-queue-cli.js";
-import type { QueueEntry } from "../../packages/gittensory-miner/lib/portfolio-queue.d.ts";
+import type { PortfolioQueueStore, QueueEntry } from "../../packages/gittensory-miner/lib/portfolio-queue.d.ts";
 
 const roots: string[] = [];
 const stores: Array<{ close(): void }> = [];
@@ -99,35 +99,46 @@ describe("gittensory-miner portfolio queue CLI (#2292)", () => {
     });
   });
 
-  it("runQueueNext claims the highest-priority queued item", () => {
+  // Inject the operator's configured WIP cap (`maxConcurrentClaims`) so `queue next`'s caps-aware claim (#4850) is
+  // exercised deterministically without a real `.gittensory-miner.yml` on disk.
+  const nextOptions = (store: PortfolioQueueStore, maxConcurrentClaims: number) => ({
+    initPortfolioQueue: () => store,
+    resolveMinerGoalSpec: () => ({ spec: { maxConcurrentClaims } }),
+  });
+
+  it("runQueueNext claims the highest-priority queued item (within the WIP cap)", () => {
     const portfolioQueue = tempQueueStore();
     portfolioQueue.enqueue({ repoFullName: "acme/widgets", identifier: "issue:1", priority: 10 });
     portfolioQueue.enqueue({ repoFullName: "acme/widgets", identifier: "issue:2", priority: 90 });
 
     const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
-    expect(
-      runQueueNext([], {
-        initPortfolioQueue: () => portfolioQueue,
-      }),
-    ).toBe(0);
+    // A cap of 3 leaves room for both claims plus the empty follow-up, so the sequential behavior is unchanged.
+    expect(runQueueNext([], nextOptions(portfolioQueue, 3))).toBe(0);
     expect(log).toHaveBeenCalledWith("issue:2");
 
     log.mockClear();
-    expect(
-      runQueueNext(["--json"], {
-        initPortfolioQueue: () => portfolioQueue,
-      }),
-    ).toBe(0);
+    expect(runQueueNext(["--json"], nextOptions(portfolioQueue, 3))).toBe(0);
     expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
       entry: expect.objectContaining({ identifier: "issue:1", status: "in_progress" }),
     });
 
     log.mockClear();
-    expect(
-      runQueueNext([], {
-        initPortfolioQueue: () => portfolioQueue,
-      }),
-    ).toBe(0);
+    expect(runQueueNext([], nextOptions(portfolioQueue, 3))).toBe(0);
+    expect(log).toHaveBeenCalledWith("none");
+  });
+
+  it("#4850: runQueueNext stops claiming once the configured WIP cap is reached", () => {
+    const portfolioQueue = tempQueueStore();
+    portfolioQueue.enqueue({ repoFullName: "acme/widgets", identifier: "issue:1", priority: 10 });
+    portfolioQueue.enqueue({ repoFullName: "acme/widgets", identifier: "issue:2", priority: 90 });
+
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    // Cap of 1: the first call claims the highest-priority item, the second stops (one item already in flight).
+    expect(runQueueNext([], nextOptions(portfolioQueue, 1))).toBe(0);
+    expect(log).toHaveBeenCalledWith("issue:2");
+
+    log.mockClear();
+    expect(runQueueNext([], nextOptions(portfolioQueue, 1))).toBe(0);
     expect(log).toHaveBeenCalledWith("none");
   });
 
@@ -141,7 +152,7 @@ describe("gittensory-miner portfolio queue CLI (#2292)", () => {
 
     log.mockClear();
     expect(runQueueNext(["--dry-run"], { initPortfolioQueue: initPortfolioQueueSpy })).toBe(0);
-    expect(String(log.mock.calls[0]?.[0])).toContain("DRY RUN: would dequeue the highest-priority queued item");
+    expect(String(log.mock.calls[0]?.[0])).toContain("DRY RUN: would claim the next eligible queued item");
 
     log.mockClear();
     expect(

--- a/test/unit/miner-portfolio-queue-manager.test.ts
+++ b/test/unit/miner-portfolio-queue-manager.test.ts
@@ -124,3 +124,39 @@ describe("initPortfolioQueueManager().claimNextBatch() (#4285)", () => {
     expect(claimed.map((entry) => entry.identifier)).toEqual(["two"]);
   });
 });
+
+describe("initPortfolioQueueManager().claimNext() (#4850)", () => {
+  it("claims the single highest-priority eligible item, then stops once the WIP cap is reached", () => {
+    const manager = memoryManager({ globalWipCap: 1, perRepoWipCap: 1 });
+    manager.enqueue({ repoFullName: "acme/widgets", identifier: "issue:1", priority: 10 });
+    manager.enqueue({ repoFullName: "acme/widgets", identifier: "issue:2", priority: 90 });
+
+    // First claim takes the highest-priority item; the cap of 1 then blocks any further claim.
+    expect(manager.claimNext()?.identifier).toBe("issue:2");
+    expect(manager.claimNext()).toBeNull();
+  });
+
+  it("resumes claiming once an in-flight item is marked done, freeing a WIP slot", () => {
+    const manager = memoryManager({ globalWipCap: 1, perRepoWipCap: 1 });
+    manager.enqueue({ repoFullName: "acme/widgets", identifier: "issue:1", priority: 10 });
+    manager.enqueue({ repoFullName: "acme/widgets", identifier: "issue:2", priority: 90 });
+
+    expect(manager.claimNext()?.identifier).toBe("issue:2");
+    expect(manager.claimNext()).toBeNull();
+    manager.markDone("acme/widgets", "issue:2");
+    expect(manager.claimNext()?.identifier).toBe("issue:1");
+  });
+
+  it("returns null on an empty queue", () => {
+    const manager = memoryManager({ globalWipCap: 3, perRepoWipCap: 3 });
+    expect(manager.claimNext()).toBeNull();
+  });
+
+  it("preserves host identity (apiBaseUrl) — a non-default-host row is claimed, not skipped (#5596)", () => {
+    const manager = memoryManager({ globalWipCap: 1, perRepoWipCap: 1 });
+    manager.enqueue({ repoFullName: "acme/enterprise", identifier: "issue:1", apiBaseUrl: "https://ghe.example.com/api/v3" });
+    const claimed = manager.claimNext();
+    expect(claimed?.identifier).toBe("issue:1");
+    expect(claimed?.apiBaseUrl).toBe("https://ghe.example.com/api/v3");
+  });
+});


### PR DESCRIPTION
## What

`gittensory-miner queue next` claimed via the naive `dequeueNext()` with no regard for a WIP cap. Per #4850, it now enforces `maxConcurrentClaims` from the operator's own `.gittensory-miner.yml` — while **preserving each item's forge host identity (`apiBaseUrl`)**.

- **New `claimNext()` on the manager** — reclaims orphaned leases first (like `claimNextBatch`), then, **only while fewer than `globalWipCap` items are in flight**, dequeues the single highest-priority item via the store's `dequeueNext()`; otherwise returns `null`. So running `queue next` repeatedly stops once the cap's worth of items are in flight, and resumes after one is marked done.
- **`queue next` routes through it**, capped by `maxConcurrentClaims` (via `resolveMinerGoalSpec`; missing/malformed → schema default 1).

### Why not the batch selector

It deliberately does **not** route through `selectEligibleBatch`: that engine selection (`queueItemId`/`parseQueueItemId`) carries only `repoFullName`/`identifier` — no forge dimension (per the existing `claimNextBatch` note) — so it would drop `apiBaseUrl` and **skip a non-default-host (e.g. GitHub Enterprise) row entirely, printing `none`**. `dequeueNext()` preserves host identity; the WIP-count check supplies the cap ceiling.

## Tests

`miner-portfolio-queue-manager.test.ts`: `claimNext()` claims one under the cap, stops at the cap, resumes after `markDone`, returns `null` when empty, and **claims a non-default-host row with its `apiBaseUrl` preserved (#5596)**. `miner-portfolio-queue-cli.test.ts`: `queue next` claims highest-priority within the cap and stops at the configured cap. `miner-cli-json-error-coverage.test.ts`: its `queue next` JSON-error case injects via the manager.

Verified: `tsc --noEmit` clean; `claimNext`'s cap+host logic confirmed standalone (it now uses only store methods — no engine dependency). Full vitest suites run in CI.

Fixes #4850