### PR TITLE
refactor(rebrand): update GitHub App slug to loopover-orb

### DIFF
--- a/src/services/subnet-interface.ts
+++ b/src/services/subnet-interface.ts
@@ -9,7 +9,7 @@ const SUBNET_INTERFACE_SCHEMA_VERSION = "1.0";
 // below). Hardcoded like the other product-identity constants in this file (not env-driven): it's the same
 // stable, real app across every deployment of this descriptor, independent of which credentials any one
 // Worker instance happens to hold for its own operational purposes.
-const PUBLIC_GITHUB_APP_SLUG = "gittensory-orb";
+const PUBLIC_GITHUB_APP_SLUG = "loopover-orb";
 
 // Curated, contribution-relevant MCP tools surfaced to agents/devs who discover gittensor via metagraphed.
 // Names mirror src/mcp/server.ts registrations; the list is intentionally a miner-facing subset (not all 33).

--- a/test/integration/subnet-interface.test.ts
+++ b/test/integration/subnet-interface.test.ts
@@ -18,7 +18,7 @@ describe("public subnet-interface descriptor route", () => {
         mcp: { endpoint: "https://gittensory-api.aethereal.dev/mcp", transport: "http" },
         // The publicly installable App slug is a stable hardcoded product identity now (see
         // subnet-interface.ts) -- independent of the Worker's own GITHUB_APP_SLUG, which no longer exists.
-        githubApp: { slug: "gittensory-orb", installUrl: "https://github.com/apps/gittensory-orb" },
+        githubApp: { slug: "loopover-orb", installUrl: "https://github.com/apps/loopover-orb" },
       },
     });
   });

--- a/test/unit/subnet-interface.test.ts
+++ b/test/unit/subnet-interface.test.ts
@@ -16,8 +16,8 @@ describe("buildSubnetInterfaceDescriptor", () => {
     expect(descriptor.interfaces.mcp.endpoint).toBe("https://gittensory-api.aethereal.dev/mcp");
     expect(descriptor.interfaces.mcp.transport).toBe("http");
     // The publicly installable App slug is a stable hardcoded product identity, not derived from any Worker
-    // var (the old review App's GITHUB_APP_SLUG was removed; gittensory-orb is the real, current, installable App).
-    expect(descriptor.interfaces.githubApp).toMatchObject({ kind: "github_app", slug: "gittensory-orb", installUrl: "https://github.com/apps/gittensory-orb" });
+    // var (the old review App's GITHUB_APP_SLUG was removed; loopover-orb is the real, current, installable App).
+    expect(descriptor.interfaces.githubApp).toMatchObject({ kind: "github_app", slug: "loopover-orb", installUrl: "https://github.com/apps/loopover-orb" });
 
     const toolNames = descriptor.interfaces.mcp.tools.map((tool) => tool.name);
     expect(toolNames).toContain("gittensory_get_decision_pack");


### PR DESCRIPTION
## Summary

- Closes #4772. The GitHub App itself was renamed "Gittensory Orb" → "Loopover ORB" directly in GitHub settings (confirmed resulting slug: `loopover-orb`, via a live fetch to `https://github.com/apps/loopover-orb`) — an in-place rename, not a new App registration, so existing installations and webhook deliveries are unaffected (keyed by the App's immutable ID, not its slug).
- Also updated on GitHub's side as part of the same change:
  - Homepage URL → `https://loopover.ai`
  - A **second** OAuth callback URL added for `https://api.loopover.ai/v1/orb/oauth/callback` (the old `gittensory-api.aethereal.dev` one stays registered until the `PUBLIC_API_ORIGIN` flip lands separately)
  - Webhook URL → `https://api.loopover.ai/v1/orb/webhook` (safe immediately — that domain already routes to the same live Worker as the old one, from the earlier domain-wiring work)
- Code-side, the only real reference to the App's actual slug is `PUBLIC_GITHUB_APP_SLUG` in `src/services/subnet-interface.ts` — a hardcoded product-identity constant (not env-driven) used to build the install-URL descriptor served to the Bittensor subnet registry. Updated it + the two tests asserting its value.

## What was deliberately NOT touched

- Every other mention of `gittensory-orb`/`gittensory-orb[bot]` across the test suite (self-authored-detection fixtures, webhook sender-login test data) belongs to a **different, already-fully-deleted** review App (its own `GITHUB_APP_SLUG` env var was removed from `wrangler.jsonc` back on 2026-07-12). Those are arbitrary, internally-consistent test strings unrelated to the Orb App's real identity, not production values.
- `apps/gittensory-ui/src/routes/docs.self-hosting-release-checklist.tsx`'s `gittensory-orb@0.1.0` Sentry-release-id mention is a historical record of an actual past release and is deliberately never edited, same as `CHANGELOG.md`.

## Test plan

- [x] Full local gate (`npm run test:ci` + `npm audit --audit-level=moderate`) green.
- [x] Confirmed via a live fetch to `https://github.com/apps/loopover-orb` that the App rename produced exactly the expected slug before touching any code.