### PR TITLE
test(miner-ui): bring the miner-ui under a real coverage gate

### DIFF
--- a/apps/gittensory-miner-ui/README.md
+++ b/apps/gittensory-miner-ui/README.md
@@ -40,3 +40,11 @@ the repo root is a ready-to-adapt persistent unit for this — a companion to
 `gittensory-miner.service.example` (the loop daemon), not a replacement for it. Its header comment
 carries the full install steps. Like the loop daemon, this is a `Type=simple` service, not a `.timer`
 job — the dashboard is a long-running HTTP server, not a periodic batch task.
+
+## Test coverage
+
+`npm test` runs with `--coverage` enabled (v8 provider) and enforces `vitest.config.ts`'s `coverage.thresholds`
+— a real measured baseline (#4865), not an aspirational target, so CI fails on a genuine regression (e.g. a
+large new feature landing with no tests) rather than staying silently unmeasured the way `apps/**` is by
+default at the repo root. `apps/gittensory-miner-extension` is not yet under this gate — its own test
+instrumentation needs to exist first (see #4865's own scope note).

--- a/apps/gittensory-miner-ui/package.json
+++ b/apps/gittensory-miner-ui/package.json
@@ -11,7 +11,7 @@
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "lint": "eslint .",
-    "test": "vitest run",
+    "test": "vitest run --coverage",
     "format": "prettier --write ."
   },
   "dependencies": {

--- a/apps/gittensory-miner-ui/vitest.config.ts
+++ b/apps/gittensory-miner-ui/vitest.config.ts
@@ -8,5 +8,22 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     include: ["src/**/*.test.{ts,tsx}"],
+    coverage: {
+      provider: "v8",
+      include: ["src/**/*.{ts,tsx}", "vite-*.ts"],
+      exclude: ["src/routeTree.gen.ts", "src/main.tsx"],
+      reporter: ["text", "lcov"],
+      // A real baseline (#4865), not an aspirational target: measured at ~87.65/87.17/78.9/88.79 the day this
+      // was wired up, with a few points of buffer below that so routine formatting/refactor churn doesn't
+      // false-fail. This is a floor meant to catch a genuine regression (a big untested addition), not a
+      // ratchet — raise it incrementally as more of the pre-existing gaps (the three sibling API plugins'
+      // own middleware-wiring layer, __root.tsx's nav shell) get covered over time, per-PR, not in one sweep.
+      thresholds: {
+        statements: 85,
+        branches: 85,
+        functions: 75,
+        lines: 85,
+      },
+    },
   },
 });


### PR DESCRIPTION
## Summary

- Adds a `coverage` block to `apps/gittensory-miner-ui/vitest.config.ts` (v8 provider, `src/**/*.{ts,tsx}` + the root-level `vite-*.ts` plugin files, excluding the TanStack Router-generated `routeTree.gen.ts` and the unit-untestable `main.tsx` entry point).
- Changes the app's `test` script to `vitest run --coverage`, so the gate runs wherever `npm --workspace @loopover/ui-miner run test` already runs (locally and in `npm run ui:test`/`test:ci`) — no new CI step needed.
- Sets `coverage.thresholds` to the real measured baseline the day this was wired up (~87.65% statements / 87.17% branches / 78.9% functions / 88.79% lines), with a small buffer below that so routine churn doesn't false-fail. This is a floor meant to catch a genuine regression, not a ratchet — per #4865's own framing ("establish a coverage baseline"), not "achieve 100% everywhere in one PR."
- Documents this in the app's `README.md`.

## Scope

`apps/gittensory-miner-ui` and `apps/gittensory-miner-extension` are both excluded today via the root `vitest.config.ts`'s blanket `coverage.exclude: ["apps/**"]`. This PR only covers the miner-ui half. The extension has **no vitest setup or test suite at all** yet (confirmed: its `package.json` only has `lint`/`typecheck`/`build` scripts, added by #4866/#5567) — #4865's own boundary note flags this ("extension's test instrumentation may need adjustment first"). Writing that suite from scratch is a separate, larger effort left for a follow-up; this PR does not touch the extension.

Note: two pre-existing sibling API plugin files (`vite-portfolio-queue-api.ts`, `vite-run-state-api.ts`) and `vite-ledgers-api.ts` have real coverage gaps at their own Vite-plugin-wiring layer (`portfolioQueueApiPlugin()`/`runStateApiPlugin()`/`ledgersApiPlugin()` themselves, as opposed to the already-tested `handleXRequest` functions they wrap) — visible in the coverage report but out of scope here; the baseline threshold accounts for them honestly rather than inflating the number.

Advances #4865 (not closing it — the extension half is still open).

## Test plan

- [x] `npm run ui:test` — both apps' full suites pass (33+202 for `gittensory-ui`, 9+103 for miner-ui)
- [x] `npm run ui:typecheck`, `npm run ui:lint` (0 errors), `npm run ui:build`
- [x] `npm run docs:drift-check`
- [x] Verified the gate actually enforces: temporarily raised the `statements` threshold to 99%, confirmed `npm test` fails with `ERROR: Coverage for statements (87.65%) does not meet global threshold (99%)`, then reverted