### PR TITLE
feat(ui): add network-vs-API error distinction and loading skeletons to StateBoundary

### DIFF
--- a/apps/gittensory-ui/src/components/site/state-views.test.tsx
+++ b/apps/gittensory-ui/src/components/site/state-views.test.tsx
@@ -1,0 +1,138 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const { notifyApiFailure } = vi.hoisted(() => ({ notifyApiFailure: vi.fn() }));
+vi.mock("@/lib/api/request", () => ({
+  notifyApiFailure: (...args: unknown[]) => notifyApiFailure(...args),
+}));
+vi.mock("sonner", () => ({ toast: Object.assign(vi.fn(), { success: vi.fn(), error: vi.fn() }) }));
+
+import { ErrorState, StateBoundary } from "@/components/site/state-views";
+
+describe("ErrorState network-vs-API distinction (#793)", () => {
+  it("uses the generic 'couldn't load' copy when no errorKind is given (unchanged default)", () => {
+    render(<ErrorState />);
+    expect(screen.getByText("Couldn't load this")).toBeTruthy();
+  });
+
+  it("uses connectivity-specific copy for a network errorKind", () => {
+    render(<ErrorState errorKind="network" />);
+    expect(screen.getByText("Can't reach the server")).toBeTruthy();
+  });
+
+  it("uses connectivity-specific copy for a timeout errorKind too", () => {
+    render(<ErrorState errorKind="timeout" />);
+    expect(screen.getByText("Can't reach the server")).toBeTruthy();
+  });
+
+  it("falls back to the generic copy for an http errorKind", () => {
+    render(<ErrorState errorKind="http" />);
+    expect(screen.getByText("Couldn't load this")).toBeTruthy();
+  });
+
+  it("lets an explicit title/description override the errorKind-derived copy", () => {
+    render(<ErrorState errorKind="network" title="Custom title" description="Custom description" />);
+    expect(screen.getByText("Custom title")).toBeTruthy();
+    expect(screen.getByText("Custom description")).toBeTruthy();
+    expect(screen.queryByText("Can't reach the server")).toBeNull();
+  });
+});
+
+describe("StateBoundary loadingSkeleton (#793)", () => {
+  it("renders the default spinner LoadingState when no skeleton is given", () => {
+    render(
+      <StateBoundary isLoading>
+        <div>content</div>
+      </StateBoundary>,
+    );
+    expect(screen.getByRole("status")).toBeTruthy();
+    expect(screen.queryByText("content")).toBeNull();
+  });
+
+  it("renders the provided skeleton instead of the spinner when loading", () => {
+    render(
+      <StateBoundary isLoading loadingSkeleton={<div data-testid="skeleton">placeholder</div>}>
+        <div>content</div>
+      </StateBoundary>,
+    );
+    expect(screen.getByTestId("skeleton")).toBeTruthy();
+    expect(screen.queryByRole("status")).toBeNull();
+    expect(screen.queryByText("content")).toBeNull();
+  });
+});
+
+describe("StateBoundary errorKind passthrough (#793)", () => {
+  it("keeps the pre-#793 default error copy when no errorKind is given", () => {
+    render(
+      <StateBoundary isError>
+        <div>content</div>
+      </StateBoundary>,
+    );
+    expect(screen.getByText("Couldn't load data")).toBeTruthy();
+  });
+
+  it("falls through to ErrorState's network-aware copy when errorKind is network and no override is given", () => {
+    render(
+      <StateBoundary isError errorKind="network">
+        <div>content</div>
+      </StateBoundary>,
+    );
+    expect(screen.getByText("Can't reach the server")).toBeTruthy();
+    expect(screen.queryByText("Couldn't load data")).toBeNull();
+  });
+
+  it("lets an explicit errorTitle/errorDescription win even with a network errorKind", () => {
+    render(
+      <StateBoundary
+        isError
+        errorKind="network"
+        errorTitle="Custom title"
+        errorDescription="Custom description"
+      >
+        <div>content</div>
+      </StateBoundary>,
+    );
+    expect(screen.getByText("Custom title")).toBeTruthy();
+    expect(screen.getByText("Custom description")).toBeTruthy();
+  });
+
+  it("passes the real errorKind (not a hardcoded 'network') to the error-failure notifier", () => {
+    render(
+      <StateBoundary isError errorKind="http" errorLabel="Widgets">
+        <div>content</div>
+      </StateBoundary>,
+    );
+    expect(notifyApiFailure).toHaveBeenCalledWith(expect.objectContaining({ kind: "http" }));
+  });
+
+  it("defaults the notifier kind to 'network' when no errorKind is given, matching pre-#793 behavior", () => {
+    render(
+      <StateBoundary isError errorLabel="Widgets">
+        <div>content</div>
+      </StateBoundary>,
+    );
+    expect(notifyApiFailure).toHaveBeenCalledWith(expect.objectContaining({ kind: "network" }));
+  });
+});
+
+describe("StateBoundary retry/refresh actions (#793 regression guard)", () => {
+  it("still invokes onRetry from the error state's retry button", () => {
+    const onRetry = vi.fn();
+    render(
+      <StateBoundary isError onRetry={onRetry}>
+        <div>content</div>
+      </StateBoundary>,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /try again/i }));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders children unchanged when neither loading, error, nor empty", () => {
+    render(
+      <StateBoundary>
+        <div>content</div>
+      </StateBoundary>,
+    );
+    expect(screen.getByText("content")).toBeTruthy();
+  });
+});

--- a/apps/gittensory-ui/src/components/site/state-views.test.tsx
+++ b/apps/gittensory-ui/src/components/site/state-views.test.tsx
@@ -31,7 +31,9 @@ describe("ErrorState network-vs-API distinction (#793)", () => {
   });
 
   it("lets an explicit title/description override the errorKind-derived copy", () => {
-    render(<ErrorState errorKind="network" title="Custom title" description="Custom description" />);
+    render(
+      <ErrorState errorKind="network" title="Custom title" description="Custom description" />,
+    );
     expect(screen.getByText("Custom title")).toBeTruthy();
     expect(screen.getByText("Custom description")).toBeTruthy();
     expect(screen.queryByText("Can't reach the server")).toBeNull();

--- a/apps/gittensory-ui/src/components/site/state-views.tsx
+++ b/apps/gittensory-ui/src/components/site/state-views.tsx
@@ -1,9 +1,13 @@
-import { Loader2, Inbox, AlertTriangle, RefreshCw } from "lucide-react";
+import { Loader2, Inbox, AlertTriangle, RefreshCw, WifiOff } from "lucide-react";
 import { useCallback, useEffect, useState, type ReactNode } from "react";
 import { toast } from "sonner";
 
 import { cn } from "@/lib/utils";
-import { notifyApiFailure } from "@/lib/api/request";
+import { notifyApiFailure, type ApiFailureKind } from "@/lib/api/request";
+
+/** `errorKind`s that mean "we never reached the server" as opposed to "the server answered with an
+ *  error" — StateBoundary/ErrorState use this to show connectivity-specific copy and iconography (#793). */
+const NETWORK_ERROR_KINDS: ReadonlySet<ApiFailureKind> = new Set(["network", "timeout"]);
 
 /**
  * Shared state primitives so every panel/route renders a consistent
@@ -140,8 +144,9 @@ export function StateActionButton({
 }
 
 export function ErrorState({
-  title = "Couldn't load this",
-  description = "Something went wrong fetching this data. You can retry, or come back in a moment. If this keeps happening, check status or try again shortly.",
+  title,
+  description,
+  errorKind,
   onRetry,
   retryLabel = "Try again",
   secondaryAction,
@@ -150,18 +155,34 @@ export function ErrorState({
 }: {
   title?: string;
   description?: ReactNode;
+  /** Distinguishes "couldn't reach the server at all" from "the server answered with an error" (#793).
+   *  Only changes the default `title`/`description` — an explicit `title`/`description` always wins. */
+  errorKind?: ApiFailureKind;
   onRetry?: () => void;
   retryLabel?: string;
   secondaryAction?: ReactNode;
   toastOnRetry?: boolean;
   className?: string;
 }) {
+  const isNetworkIssue = errorKind !== undefined && NETWORK_ERROR_KINDS.has(errorKind);
+  const resolvedTitle = title ?? (isNetworkIssue ? "Can't reach the server" : "Couldn't load this");
+  const resolvedDescription =
+    description ??
+    (isNetworkIssue
+      ? "We couldn't reach the API — check your connection and retry. This is a connectivity issue, not a problem with the data itself."
+      : "Something went wrong fetching this data. You can retry, or come back in a moment. If this keeps happening, check status or try again shortly.");
   return (
     <Shell
       role="alert"
-      icon={<AlertTriangle className="size-5 text-warning" aria-hidden />}
-      title={title}
-      description={description}
+      icon={
+        isNetworkIssue ? (
+          <WifiOff className="size-5 text-warning" aria-hidden />
+        ) : (
+          <AlertTriangle className="size-5 text-warning" aria-hidden />
+        )
+      }
+      title={resolvedTitle}
+      description={resolvedDescription}
       action={
         onRetry && (
           <StateActionButton
@@ -218,10 +239,12 @@ export function StateBoundary({
   isEmpty,
   loadingTitle = "Loading data…",
   loadingDescription = "Fetching the latest available signals for this view.",
+  loadingSkeleton,
   emptyTitle = "No data available yet",
   emptyDescription = "This view has no records to show. Refresh when the source data is available.",
-  errorTitle = "Couldn't load data",
-  errorDescription = "The data source did not respond. Retry the request, or check back once the service has recovered.",
+  errorTitle,
+  errorDescription,
+  errorKind,
   onRetry,
   onRefresh,
   errorLabel,
@@ -232,38 +255,58 @@ export function StateBoundary({
   isEmpty?: boolean;
   loadingTitle?: string;
   loadingDescription?: ReactNode;
+  /** Content-shaped placeholder (build with `@/components/ui/skeleton`) shown instead of the generic
+   *  spinner while loading, so the layout doesn't jump once data arrives (#793). */
+  loadingSkeleton?: ReactNode;
   emptyTitle?: string;
   emptyDescription?: ReactNode;
   errorTitle?: string;
   errorDescription?: ReactNode;
+  /** Distinguishes "couldn't reach the server at all" from "the server answered with an error" (#793). */
+  errorKind?: ApiFailureKind;
   onRetry?: () => void;
   onRefresh?: () => void;
   /** When provided, surfaces a global API-failure toast with a Retry action. */
   errorLabel?: string;
   children: ReactNode;
 }) {
+  const isNetworkIssue = errorKind !== undefined && NETWORK_ERROR_KINDS.has(errorKind);
+  // Preserve the pre-#793 defaults exactly when no errorKind is given; when one is given and the caller
+  // didn't override the copy, fall through to ErrorState's own network-aware defaults instead.
+  const resolvedErrorTitle = errorTitle ?? (isNetworkIssue ? undefined : "Couldn't load data");
+  const resolvedErrorDescription =
+    errorDescription ??
+    (isNetworkIssue
+      ? undefined
+      : "The data source did not respond. Retry the request, or check back once the service has recovered.");
+
   // When this boundary flips into the error state, surface a toast with Retry.
   useEffect(() => {
     if (isError && errorLabel) {
       notifyApiFailure({
         label: errorLabel,
-        kind: "network",
+        kind: errorKind ?? "network",
         message:
-          typeof errorDescription === "string" ? errorDescription : "Data source did not respond.",
+          typeof resolvedErrorDescription === "string"
+            ? resolvedErrorDescription
+            : "Data source did not respond.",
         retry: onRetry,
       });
     }
-  }, [isError, errorLabel, errorDescription, onRetry]);
+  }, [isError, errorLabel, errorKind, resolvedErrorDescription, onRetry]);
 
   if (isLoading) {
-    return <LoadingState title={loadingTitle} description={loadingDescription} />;
+    return (
+      loadingSkeleton ?? <LoadingState title={loadingTitle} description={loadingDescription} />
+    );
   }
 
   if (isError) {
     return (
       <ErrorState
-        title={errorTitle}
-        description={errorDescription}
+        title={resolvedErrorTitle}
+        description={resolvedErrorDescription}
+        errorKind={errorKind}
         onRetry={onRetry}
         toastOnRetry={false}
         secondaryAction={

--- a/apps/gittensory-ui/src/lib/api/use-api-resource.test.ts
+++ b/apps/gittensory-ui/src/lib/api/use-api-resource.test.ts
@@ -36,3 +36,43 @@ describe("useApiResource loadedAt (#2219)", () => {
     expect(result.current.loadedAt).toBeNull();
   });
 });
+
+describe("useApiResource errorKind/errorStatus (#793)", () => {
+  it("carries the apiFetch failure kind and status through to the error state", async () => {
+    apiFetch.mockResolvedValue({
+      ok: false,
+      kind: "http",
+      message: "500 Internal Server Error",
+      status: 500,
+      durationMs: 5,
+    });
+    const { result } = renderHook(() => useApiResource("/v1/thing", "Thing"));
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current).toMatchObject({ errorKind: "http", errorStatus: 500 });
+  });
+
+  it("carries a network failure kind with no status", async () => {
+    apiFetch.mockResolvedValue({ ok: false, kind: "network", message: "fetch failed", durationMs: 5 });
+    const { result } = renderHook(() => useApiResource("/v1/thing", "Thing"));
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current).toMatchObject({ errorKind: "network", errorStatus: undefined });
+  });
+
+  it("carries a timeout failure kind", async () => {
+    apiFetch.mockResolvedValue({ ok: false, kind: "timeout", message: "Request timed out", durationMs: 5 });
+    const { result } = renderHook(() => useApiResource("/v1/thing", "Thing"));
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    expect(result.current).toMatchObject({ errorKind: "timeout" });
+  });
+
+  it("leaves errorKind undefined for the synthetic disabled sentinel", async () => {
+    const { result } = renderHook(() =>
+      useApiResource("/v1/thing", "Thing", undefined, { enabled: false }),
+    );
+    await waitFor(() => expect(result.current.status).toBe("error"));
+    const state = result.current;
+    if (state.status !== "error") throw new Error("expected error status");
+    expect(state.error).toBe("disabled");
+    expect(state.errorKind).toBeUndefined();
+  });
+});

--- a/apps/gittensory-ui/src/lib/api/use-api-resource.test.ts
+++ b/apps/gittensory-ui/src/lib/api/use-api-resource.test.ts
@@ -52,14 +52,24 @@ describe("useApiResource errorKind/errorStatus (#793)", () => {
   });
 
   it("carries a network failure kind with no status", async () => {
-    apiFetch.mockResolvedValue({ ok: false, kind: "network", message: "fetch failed", durationMs: 5 });
+    apiFetch.mockResolvedValue({
+      ok: false,
+      kind: "network",
+      message: "fetch failed",
+      durationMs: 5,
+    });
     const { result } = renderHook(() => useApiResource("/v1/thing", "Thing"));
     await waitFor(() => expect(result.current.status).toBe("error"));
     expect(result.current).toMatchObject({ errorKind: "network", errorStatus: undefined });
   });
 
   it("carries a timeout failure kind", async () => {
-    apiFetch.mockResolvedValue({ ok: false, kind: "timeout", message: "Request timed out", durationMs: 5 });
+    apiFetch.mockResolvedValue({
+      ok: false,
+      kind: "timeout",
+      message: "Request timed out",
+      durationMs: 5,
+    });
     const { result } = renderHook(() => useApiResource("/v1/thing", "Thing"));
     await waitFor(() => expect(result.current.status).toBe("error"));
     expect(result.current).toMatchObject({ errorKind: "timeout" });

--- a/apps/gittensory-ui/src/lib/api/use-api-resource.ts
+++ b/apps/gittensory-ui/src/lib/api/use-api-resource.ts
@@ -1,12 +1,20 @@
 import { useCallback, useEffect, useState } from "react";
 
 import { getApiOrigin } from "./origin";
-import { apiFetch } from "./request";
+import { apiFetch, type ApiFailureKind } from "./request";
 
 type ResourceState<T> =
   | { status: "loading"; data: null; error: null; loadedAt: null }
   | { status: "ready"; data: T; error: null; loadedAt: number }
-  | { status: "error"; data: null; error: string; loadedAt: null };
+  | {
+      status: "error";
+      data: null;
+      error: string;
+      /** Absent for the synthetic "disabled" sentinel below — only real `apiFetch` failures carry one (#793). */
+      errorKind?: ApiFailureKind;
+      errorStatus?: number;
+      loadedAt: null;
+    };
 
 type UseApiResourceOptions = {
   enabled?: boolean;
@@ -42,7 +50,14 @@ export function useApiResource<T>(
     if (result.ok) {
       setState({ status: "ready", data: result.data, error: null, loadedAt: Date.now() });
     } else {
-      setState({ status: "error", data: null, error: result.message, loadedAt: null });
+      setState({
+        status: "error",
+        data: null,
+        error: result.message,
+        errorKind: result.kind,
+        errorStatus: result.status,
+        loadedAt: null,
+      });
     }
   }, [enabled, label, path, token]);
 

--- a/apps/gittensory-ui/src/routes/app.runs.tsx
+++ b/apps/gittensory-ui/src/routes/app.runs.tsx
@@ -24,7 +24,9 @@ import {
 } from "@/components/site/control-primitives";
 import { useApiResource } from "@/lib/api/use-api-resource";
 import { useSession } from "@/lib/api/session";
-import { EmptyState } from "@/components/site/state-views";
+import { EmptyState, StateBoundary } from "@/components/site/state-views";
+import { RefreshMeta } from "@/components/site/refresh-meta";
+import { Skeleton } from "@/components/ui/skeleton";
 import { useLocalStorage } from "@/lib/use-local-storage";
 import { cn } from "@/lib/utils";
 import { SnapshotReplayCard } from "@/components/site/snapshot-replay";
@@ -232,139 +234,149 @@ function AgentRuns() {
             and a public/private boundary.
           </p>
         </div>
-        <StatusPill status={sourceStatus}>{sourceLabel}</StatusPill>
+        <div className="flex flex-wrap items-center gap-2">
+          <StatusPill status={sourceStatus}>{sourceLabel}</StatusPill>
+          <RefreshMeta loadedAt={liveRuns.loadedAt} onRefresh={liveRuns.reload} />
+        </div>
       </header>
 
-      {canUseLiveRuns && liveRuns.status === "error" && liveRuns.error !== "disabled" && (
-        <div className="rounded-token border border-warning/30 bg-warning/5 p-3 text-token-xs text-warning">
-          Live runs are unavailable right now ({liveRuns.error}).
-        </div>
-      )}
-
-      <div className="rounded-token border border-border bg-transparent p-3">
-        <div className="flex flex-wrap items-center gap-2">
-          <div className="inline-flex items-center gap-1.5 font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
-            <Filter className="size-3.5" />
-            Status
-          </div>
-          <div className="flex flex-wrap gap-1">
-            {STATUS_FILTERS.map((s) => (
-              <Chip key={s} active={status === s} onClick={() => setStatus(s)}>
-                {s}
-              </Chip>
-            ))}
-          </div>
-          <span aria-hidden className="ml-2 hidden accent-divider-v-tall sm:inline-block" />
-          <div className="inline-flex items-center gap-1.5 font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
-            Kind
-          </div>
-          <div className="flex flex-wrap gap-1">
-            {KIND_FILTERS.map((k) => (
-              <Chip key={k} active={kind === k} onClick={() => setKind(k)}>
-                {k}
-              </Chip>
-            ))}
-          </div>
-          <div className="ml-auto inline-flex items-center gap-2 rounded-token border border-border bg-background/40 px-2">
-            <Search className="size-3.5 text-muted-foreground" />
-            <input
-              value={q}
-              onChange={(e) => setQ(e.target.value)}
-              placeholder="Search runs…"
-              className="w-40 border-0 bg-transparent py-1 text-token-sm outline-none placeholder:text-muted-foreground"
-            />
-          </div>
-        </div>
-      </div>
-
-      <SavedViews
-        current={{ status, kind, q }}
-        onApply={(v) =>
-          navigate({
-            search: () => ({
-              status: v.status === "all" ? undefined : v.status,
-              kind: v.kind === "all" ? undefined : v.kind,
-              q: v.q ? v.q : undefined,
-            }),
-            replace: true,
-          })
-        }
-      />
-
-      <div className="text-token-2xs text-muted-foreground">
-        Showing {filtered.length} of {runs.length}
-      </div>
-
-      {filtered.length === 0 ? (
-        <ul className="space-y-2">
-          <li>
-            <EmptyState
-              title="No runs match these filters"
-              description="Try clearing the status or kind filter, or search by repo or run id."
-              action={
-                <button
-                  type="button"
-                  onClick={() => {
-                    setStatus("all");
-                    setKind("all");
-                    setQ("");
-                    toast("Filters cleared", {
-                      description: "Showing all available agent runs again.",
-                    });
-                  }}
-                  className="inline-flex min-w-0 items-center justify-center rounded-token border border-border bg-transparent px-3 py-1.5 text-center text-token-xs font-medium text-foreground transition-all duration-150 hover:bg-accent focus-ring motion-reduce:transition-none motion-reduce:active:scale-100 active:scale-[0.98]"
-                >
-                  Clear filters
-                </button>
-              }
-            />
-          </li>
-        </ul>
-      ) : (
+      <StateBoundary
+        isLoading={canUseLiveRuns && liveRuns.status === "loading"}
+        isError={canUseLiveRuns && liveRuns.status === "error" && liveRuns.error !== "disabled"}
+        errorKind={liveRuns.status === "error" ? liveRuns.errorKind : undefined}
+        errorDescription={liveRuns.status === "error" ? liveRuns.error : undefined}
+        onRetry={liveRuns.reload}
+        onRefresh={liveRuns.reload}
+        loadingTitle="Loading agent runs…"
+        loadingSkeleton={<RunsListSkeleton />}
+      >
         <div className="space-y-5">
-          {grouped.map((bucket) => (
-            <section key={bucket.label} aria-label={bucket.label}>
-              <h2 className="sticky top-[6.25rem] z-[1] -mx-1 mb-2 bg-background/85 px-1 py-1 font-mono text-token-2xs uppercase tracking-wider text-muted-foreground backdrop-blur">
-                {bucket.label} · {bucket.runs.length}
-              </h2>
-              <ul className="space-y-2">
-                {bucket.runs.map((r) => (
-                  <li key={r.id}>
+          <div className="rounded-token border border-border bg-transparent p-3">
+            <div className="flex flex-wrap items-center gap-2">
+              <div className="inline-flex items-center gap-1.5 font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
+                <Filter className="size-3.5" />
+                Status
+              </div>
+              <div className="flex flex-wrap gap-1">
+                {STATUS_FILTERS.map((s) => (
+                  <Chip key={s} active={status === s} onClick={() => setStatus(s)}>
+                    {s}
+                  </Chip>
+                ))}
+              </div>
+              <span aria-hidden className="ml-2 hidden accent-divider-v-tall sm:inline-block" />
+              <div className="inline-flex items-center gap-1.5 font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
+                Kind
+              </div>
+              <div className="flex flex-wrap gap-1">
+                {KIND_FILTERS.map((k) => (
+                  <Chip key={k} active={kind === k} onClick={() => setKind(k)}>
+                    {k}
+                  </Chip>
+                ))}
+              </div>
+              <div className="ml-auto inline-flex items-center gap-2 rounded-token border border-border bg-background/40 px-2">
+                <Search className="size-3.5 text-muted-foreground" />
+                <input
+                  value={q}
+                  onChange={(e) => setQ(e.target.value)}
+                  placeholder="Search runs…"
+                  className="w-40 border-0 bg-transparent py-1 text-token-sm outline-none placeholder:text-muted-foreground"
+                />
+              </div>
+            </div>
+          </div>
+
+          <SavedViews
+            current={{ status, kind, q }}
+            onApply={(v) =>
+              navigate({
+                search: () => ({
+                  status: v.status === "all" ? undefined : v.status,
+                  kind: v.kind === "all" ? undefined : v.kind,
+                  q: v.q ? v.q : undefined,
+                }),
+                replace: true,
+              })
+            }
+          />
+
+          <div className="text-token-2xs text-muted-foreground">
+            Showing {filtered.length} of {runs.length}
+          </div>
+
+          {filtered.length === 0 ? (
+            <ul className="space-y-2">
+              <li>
+                <EmptyState
+                  title="No runs match these filters"
+                  description="Try clearing the status or kind filter, or search by repo or run id."
+                  action={
                     <button
                       type="button"
-                      onClick={() => setSelected(r.id)}
-                      aria-current={selectedId === r.id ? "true" : undefined}
-                      className={cn(
-                        "grid w-full grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 rounded-token border bg-transparent p-3 text-left transition-all duration-150 focus-ring motion-reduce:transition-none motion-reduce:active:scale-100 active:scale-[0.99]",
-                        selectedId === r.id
-                          ? "border-mint/40 bg-mint/[0.04]"
-                          : "border-border hover:border-foreground/30",
-                      )}
+                      onClick={() => {
+                        setStatus("all");
+                        setKind("all");
+                        setQ("");
+                        toast("Filters cleared", {
+                          description: "Showing all available agent runs again.",
+                        });
+                      }}
+                      className="inline-flex min-w-0 items-center justify-center rounded-token border border-border bg-transparent px-3 py-1.5 text-center text-token-xs font-medium text-foreground transition-all duration-150 hover:bg-accent focus-ring motion-reduce:transition-none motion-reduce:active:scale-100 active:scale-[0.98]"
                     >
-                      <StatusPill status={SIGNAL[r.signal_fidelity]}>
-                        {r.signal_fidelity}
-                      </StatusPill>
-                      <div className="min-w-0">
-                        <div className="truncate text-token-sm">{r.kind}</div>
-                        <div className="mt-0.5 flex flex-wrap items-center gap-2 text-token-2xs text-muted-foreground">
-                          <span className="font-mono">{r.id}</span>
-                          <span>·</span>
-                          <span>{r.source}</span>
-                          <span>·</span>
-                          <span>{r.repo}</span>
-                        </div>
-                      </div>
-                      <div className="text-right font-mono text-token-2xs text-muted-foreground">
-                        {new Date(r.created_at).toUTCString().slice(5, 22)}
-                      </div>
+                      Clear filters
                     </button>
-                  </li>
-                ))}
-              </ul>
-            </section>
-          ))}
+                  }
+                />
+              </li>
+            </ul>
+          ) : (
+            <div className="space-y-5">
+              {grouped.map((bucket) => (
+                <section key={bucket.label} aria-label={bucket.label}>
+                  <h2 className="sticky top-[6.25rem] z-[1] -mx-1 mb-2 bg-background/85 px-1 py-1 font-mono text-token-2xs uppercase tracking-wider text-muted-foreground backdrop-blur">
+                    {bucket.label} · {bucket.runs.length}
+                  </h2>
+                  <ul className="space-y-2">
+                    {bucket.runs.map((r) => (
+                      <li key={r.id}>
+                        <button
+                          type="button"
+                          onClick={() => setSelected(r.id)}
+                          aria-current={selectedId === r.id ? "true" : undefined}
+                          className={cn(
+                            "grid w-full grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-3 rounded-token border bg-transparent p-3 text-left transition-all duration-150 focus-ring motion-reduce:transition-none motion-reduce:active:scale-100 active:scale-[0.99]",
+                            selectedId === r.id
+                              ? "border-mint/40 bg-mint/[0.04]"
+                              : "border-border hover:border-foreground/30",
+                          )}
+                        >
+                          <StatusPill status={SIGNAL[r.signal_fidelity]}>
+                            {r.signal_fidelity}
+                          </StatusPill>
+                          <div className="min-w-0">
+                            <div className="truncate text-token-sm">{r.kind}</div>
+                            <div className="mt-0.5 flex flex-wrap items-center gap-2 text-token-2xs text-muted-foreground">
+                              <span className="font-mono">{r.id}</span>
+                              <span>·</span>
+                              <span>{r.source}</span>
+                              <span>·</span>
+                              <span>{r.repo}</span>
+                            </div>
+                          </div>
+                          <div className="text-right font-mono text-token-2xs text-muted-foreground">
+                            {new Date(r.created_at).toUTCString().slice(5, 22)}
+                          </div>
+                        </button>
+                      </li>
+                    ))}
+                  </ul>
+                </section>
+              ))}
+            </div>
+          )}
         </div>
-      )}
+      </StateBoundary>
 
       <RunDrawer
         run={selected}
@@ -591,6 +603,23 @@ function SavedViews({
           Save view
         </button>
       )}
+    </div>
+  );
+}
+
+/** Content-shaped loading placeholder for the filter bar + run list, so the layout doesn't jump once
+ *  the first page of runs arrives (#793). Row count is arbitrary — just enough to fill the viewport. */
+function RunsListSkeleton() {
+  return (
+    <div className="space-y-5" aria-hidden>
+      <Skeleton className="h-11 w-full rounded-token" />
+      <ul className="space-y-2">
+        {Array.from({ length: 5 }, (_, index) => (
+          <li key={index}>
+            <Skeleton className="h-14 w-full rounded-token" />
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Several routes had minimal state handling: no retry, no way to tell "we couldn't reach the server" apart from "the server answered with an error", and no content-shaped loading placeholder — `app.runs.tsx` in particular rendered its loading state identically to a genuinely-empty one (it showed "No runs match these filters" before the first fetch had even completed).
- `useApiResource` now surfaces the underlying `apiFetch` failure `kind`/`status`, and `StateBoundary`/`ErrorState` use it to render distinct copy + iconography for a connectivity failure (`WifiOff`, "Can't reach the server") vs a server-side error (`AlertTriangle`, generic "Couldn't load data"). `StateBoundary` also accepts an optional `loadingSkeleton` to replace the generic spinner with a content-shaped placeholder.
- Both additions are purely additive and backward-compatible — every existing `StateBoundary`/`ErrorState`/`useApiResource` consumer (app.analytics, app.operator, the maintainer/owner/miner/digest/commands panels, dead-letter-queue-panel, notification-readiness-card) keeps its current default copy unless it opts in to the new props.
- Wired the new primitives into `app.runs.tsx`, the most minimal of the routes named in the issue: replaced the old ad-hoc "Live runs are unavailable" banner with a proper `StateBoundary` (retry, network-aware error copy, loading skeleton), and added a `RefreshMeta` "last refresh" label + manual refresh button to the header.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

Closes #793

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` — ran as part of `npm run test:ci`, passed
- [ ] `npm run db:migrations:check` / `db:schema-drift:check` / `selfhost:env-reference:check` — ran as part of `npm run test:ci`, passed (no DB/env changes in this PR)
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally (this PR only touches `apps/gittensory-ui/**`, which Codecov's `src/**`-only patch rule does not gate, but the new/changed logic is covered by new and updated tests)
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:test`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- `npm run cf-typegen:check` (part of `npm run test:ci`) fails locally on this Windows dev machine with a `wrangler ENOENT` — `scripts/gen-cf-typegen.mjs` calls `execFileSync("wrangler", ...)` without `shell: true`, which cannot invoke npm's `.cmd` shim on Windows (confirmed in isolation, independent of any change in this PR — reproduces with a bare `execFileSync("wrangler", ["--version"])` on a clean checkout). This PR makes no Cloudflare/`wrangler.jsonc` changes; the check runs fine on the actual CI (Linux runners).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session/CORS surface touched.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no backend/API route changes; `errorKind`/`errorStatus` are client-side fields derived from the existing `apiFetch` result shape.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (N/A.)

## UI Evidence

All captured against `app.runs.tsx` with a mocked authenticated session and a mocked `/v1/agent/runs` response, so each state is genuinely reachable rather than staged.

| State / title | JPG/PNG evidence |
| --- | --- |
| Loading (content-shaped skeleton, replaces the old spinner-only state) | <a href="https://raw.githubusercontent.com/claytonlin1110/gittensory/screenshots/app-runs-loading-skeleton.png"><img src="https://raw.githubusercontent.com/claytonlin1110/gittensory/screenshots/app-runs-loading-skeleton.png" alt="Loading skeleton" width="240"></a> |
| Network error (new: distinct copy + WifiOff icon + retry) | <a href="https://raw.githubusercontent.com/claytonlin1110/gittensory/screenshots/app-runs-network-error.png"><img src="https://raw.githubusercontent.com/claytonlin1110/gittensory/screenshots/app-runs-network-error.png" alt="Network error state" width="240"></a> |
| HTTP error (generic copy + AlertTriangle icon + retry) | <a href="https://raw.githubusercontent.com/claytonlin1110/gittensory/screenshots/app-runs-http-error.png"><img src="https://raw.githubusercontent.com/claytonlin1110/gittensory/screenshots/app-runs-http-error.png" alt="HTTP error state" width="240"></a> |
| HTTP error, mobile layout (375×812) | <a href="https://raw.githubusercontent.com/claytonlin1110/gittensory/screenshots/app-runs-mobile-http-error.png"><img src="https://raw.githubusercontent.com/claytonlin1110/gittensory/screenshots/app-runs-mobile-http-error.png" alt="HTTP error state, mobile" width="240"></a> |

## Notes

- Scoped to the shared primitives (`state-views.tsx`, `use-api-resource.ts`) plus `app.runs.tsx`, the route with the most clearly minimal state handling of the ones named in the issue. `app.workbench.tsx`'s panels (miner/playground/commands/digest) and `app.operator.tsx`/`app.analytics.tsx` already use `StateBoundary`; they pick up the network-vs-API distinction and skeleton support automatically the next time they're touched, with no migration required since both additions are opt-in.
