### PR TITLE
feat(miner): add backup/restore tooling for local SQLite state

### DIFF
--- a/packages/gittensory-miner/docs/operations-runbook.md
+++ b/packages/gittensory-miner/docs/operations-runbook.md
@@ -100,6 +100,42 @@ gittensory-miner status --json
 
 4. **Claims are local bookkeeping only.** Two miners on different machines claiming the same GitHub issue is a **fleet coordination** problem (duplicate-cluster adjudication in the engine), not something SQLite resolves — split state dirs and use operational claim hygiene.
 
+## Backup and restore
+
+Proactive tooling (#4872), not just the reactive "ledger corrupted" scenario below — run `backup-miner.sh` on a
+schedule (cron, systemd timer, etc.) so a good restore point always exists before anything goes wrong.
+
+- **[`scripts/backup-miner.sh`](../../../scripts/backup-miner.sh)** — backs up every `*.sqlite3` file currently
+  present under `GITTENSORY_MINER_CONFIG_DIR` into a new timestamped directory, using SQLite's own online
+  `.backup` command (safe even while the miner is running — see the corruption scenario's warning below about
+  why a plain `cp` is not) plus a `PRAGMA integrity_check` on each resulting file before it's kept. Stores
+  discovered by glob, not a hardcoded list, so a newly added store is backed up automatically without this doc
+  or the script needing an update.
+
+  ```sh
+  sh scripts/backup-miner.sh
+  # Env overrides: GITTENSORY_MINER_CONFIG_DIR (source), GITTENSORY_MINER_BACKUP_DIR (default
+  # $GITTENSORY_MINER_CONFIG_DIR/backups), GITTENSORY_MINER_BACKUP_RETAIN (default 7 — oldest backups beyond
+  # this count are pruned after a fully successful run; a run with any failed store skips pruning so no older,
+  # good backup is ever lost to make room for a bad one).
+  ```
+
+- **[`scripts/restore-miner.sh`](../../../scripts/restore-miner.sh)** — the read side. **Stop the miner first**
+  (this script does not detect a running process). Validates every store file in the chosen backup with
+  `PRAGMA integrity_check` **before** copying anything into place — a half-good backup can never produce a
+  half-restored state directory. Requires an explicit `--yes` flag (it overwrites live state) and defaults to
+  the newest backup when no directory is given:
+
+  ```sh
+  sh scripts/restore-miner.sh --yes                          # newest backup
+  sh scripts/restore-miner.sh --yes /path/to/backups/<ts>     # a specific one
+  gittensory-miner doctor --json                              # verify afterward
+  ```
+
+  Also removes any leftover `-wal`/`-shm` sidecar files from the live directory after restoring each store —
+  those hold in-flight writes from *before* the restore, and leaving them in place would let SQLite silently
+  replay stale pre-restore writes back on top of the freshly restored file on next open.
+
 ## Scenario: ledger corrupted
 
 **Symptoms**
@@ -136,7 +172,7 @@ gittensory-miner status --json
    | Tier | When | Action |
    |------|------|--------|
    | **A — single store reset** | One ledger is corrupt; others healthy; you accept losing that store's history | Remove only the bad `*.sqlite3` (and any `-wal`/`-shm` siblings). Next command recreates an empty store. |
-   | **B — restore from backup** | You have a recent quiesced backup | Stop miner → restore the known-good file → restart. |
+   | **B — restore from backup** | You have a recent backup from `backup-miner.sh` (see **Backup and restore** above) | Stop miner → `sh scripts/restore-miner.sh --yes` → restart. |
    | **C — full re-init** | Multiple files suspect or state is disposable | Archive dir → `gittensory-miner init` → reconfigure env/goals. Rebuild claims/plans from GitHub metadata as needed. |
 
 4. **Never copy a live SQLite file** from a running miner as backup — stop first, or use SQLite's `.backup` command:

--- a/scripts/backup-miner.sh
+++ b/scripts/backup-miner.sh
@@ -1,0 +1,88 @@
+#!/bin/sh
+# gittensory-miner local-state backup (#4872): every store is an independent SQLite file directly under
+# GITTENSORY_MINER_CONFIG_DIR (packages/gittensory-miner/docs/operations-runbook.md's "Local state at a
+# glance") -- there is no Postgres/Qdrant involved, so this is deliberately a simpler sibling to
+# scripts/backup.sh, not a reuse of it (that script's manifest/multi-target logic has nothing to compose with
+# here). Backs up EVERY *.sqlite3 file currently present, discovered by glob rather than a hardcoded filename
+# list -- the miner package grows new stores over time (17 as of this writing), and a hardcoded list would
+# silently go stale the next time one is added, exactly the kind of drift this repo's generated-reference
+# checks exist to prevent elsewhere.
+#
+# Uses SQLite's own online-backup command (".backup"), the same safe-even-while-live mechanism
+# operations-runbook.md's "ledger corrupted" scenario already documents -- NOT a plain `cp`, which can capture
+# a torn snapshot mid-write. Each backed-up file is then integrity-checked before being kept.
+#
+# Usage:
+#   sh scripts/backup-miner.sh
+#   GITTENSORY_MINER_CONFIG_DIR=/data/miner GITTENSORY_MINER_BACKUP_RETAIN=14 sh scripts/backup-miner.sh
+set -eu
+
+STATE_DIR="${GITTENSORY_MINER_CONFIG_DIR:-$HOME/.config/gittensory-miner}"
+OUT_DIR="${GITTENSORY_MINER_BACKUP_DIR:-$STATE_DIR/backups}"
+RETAIN="${GITTENSORY_MINER_BACKUP_RETAIN:-7}"
+
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  echo "[backup-miner] sqlite3 not found; cannot take a safe online backup" >&2
+  exit 1
+fi
+
+if [ ! -d "$STATE_DIR" ]; then
+  echo "[backup-miner] state dir not found: $STATE_DIR (nothing to back up)" >&2
+  exit 1
+fi
+
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+DEST="$OUT_DIR/$TS"
+mkdir -p "$DEST"
+
+TOTAL=0
+FAILED=0
+BACKED_UP=0
+for db in "$STATE_DIR"/*.sqlite3; do
+  [ -e "$db" ] || continue # glob matched nothing
+  TOTAL=$((TOTAL + 1))
+  name=$(basename "$db")
+  dest_db="$DEST/$name"
+  if ! sqlite3 "$db" ".backup '$dest_db'" 2>/dev/null; then
+    echo "[backup-miner] ERROR: online backup failed for $name" >&2
+    FAILED=1
+    continue
+  fi
+  result=$(sqlite3 "$dest_db" 'PRAGMA integrity_check;' 2>/dev/null | head -1 || true)
+  if [ "$result" != "ok" ]; then
+    echo "[backup-miner] ERROR: integrity check failed for $name (${result:-no output})" >&2
+    rm -f "$dest_db"
+    FAILED=1
+    continue
+  fi
+  chmod 600 "$dest_db"
+  BACKED_UP=$((BACKED_UP + 1))
+  echo "[backup-miner] backed up $name"
+done
+
+# Two distinct empty-outcome cases, deliberately handled differently: the glob matching NOTHING means there
+# was never anything to back up (remove the now-useless empty timestamped dir); every MATCHED file failing is
+# a real backup failure (fall through to the FAILED branch below, which -- like backup.sh's own equivalent --
+# keeps the directory and its error output for debugging, and skips retention pruning).
+if [ "$TOTAL" -eq 0 ]; then
+  echo "[backup-miner] no *.sqlite3 files found under $STATE_DIR" >&2
+  rmdir "$DEST" 2>/dev/null || true
+  exit 1
+fi
+chmod 700 "$DEST"
+
+if [ "$FAILED" = 1 ]; then
+  echo "[backup-miner] FAILED ($TS): one or more stores did not back up cleanly; see errors above" >&2
+  echo "[backup-miner] skipping retention prune so no older, fully-good backup is lost" >&2
+  exit 1
+fi
+
+# Retention: keep the newest $RETAIN timestamped backup directories, prune the rest. Mirrors
+# scripts/backup.sh's own `ls -1t | tail -n +N+1 | while read` idiom.
+# shellcheck disable=SC2012
+ls -1t "$OUT_DIR" 2>/dev/null | tail -n +"$((RETAIN + 1))" | while IFS= read -r old; do
+  echo "[backup-miner] pruning old backup: $old"
+  rm -rf "${OUT_DIR:?}/$old"
+done
+
+echo "[backup-miner] complete ($TS); backed up $BACKED_UP store(s) to $DEST; retaining newest $RETAIN"

--- a/scripts/restore-miner.sh
+++ b/scripts/restore-miner.sh
@@ -1,0 +1,101 @@
+#!/bin/sh
+# gittensory-miner local-state restore (#4872): the read side of scripts/backup-miner.sh. STOP the miner (and
+# any loop/systemd/docker service) before running this -- it overwrites the live state directory and does not
+# detect a running process itself, the same "stop first" precondition operations-runbook.md's "ledger
+# corrupted" scenario already documents for manual recovery.
+#
+# Validates EVERY store file in the chosen backup (via PRAGMA integrity_check) BEFORE copying anything into
+# place: a half-good backup must never produce a half-restored, mismatched-vintage state directory. Removes
+# any leftover -wal/-shm sidecar files from the LIVE directory after restoring each store -- those hold
+# in-flight, not-yet-checkpointed writes from BEFORE the restore, and leaving them in place would let SQLite
+# silently replay stale pre-restore writes back on top of the freshly restored file on next open.
+#
+# Usage:
+#   sh scripts/restore-miner.sh --yes                        # restores the newest backup
+#   sh scripts/restore-miner.sh --yes /path/to/backups/<ts>   # restores a specific backup
+set -eu
+
+STATE_DIR="${GITTENSORY_MINER_CONFIG_DIR:-$HOME/.config/gittensory-miner}"
+BACKUP_DIR="${GITTENSORY_MINER_BACKUP_DIR:-$STATE_DIR/backups}"
+
+usage() {
+  cat <<USAGE >&2
+Usage: $0 --yes [BACKUP_DIR]
+
+Restores gittensory-miner local state from a backup produced by backup-miner.sh.
+
+  BACKUP_DIR   A specific timestamped backup directory. Defaults to the newest one
+               under \$GITTENSORY_MINER_BACKUP_DIR ($BACKUP_DIR).
+  --yes        Required. This OVERWRITES the live state directory ($STATE_DIR).
+
+STOP the miner (and any loop/systemd/docker service using this state dir) first --
+this script does not check whether one is still running.
+USAGE
+}
+
+CONFIRMED=0
+SOURCE=""
+for arg in "$@"; do
+  case "$arg" in
+    --yes) CONFIRMED=1 ;;
+    -h | --help)
+      usage
+      exit 0
+      ;;
+    *) SOURCE=$arg ;;
+  esac
+done
+
+if [ "$CONFIRMED" != 1 ]; then
+  usage
+  echo "[restore-miner] refusing to restore without --yes (this overwrites live state)" >&2
+  exit 1
+fi
+
+if ! command -v sqlite3 >/dev/null 2>&1; then
+  echo "[restore-miner] sqlite3 not found; cannot verify backup integrity before restoring" >&2
+  exit 1
+fi
+
+if [ -z "$SOURCE" ]; then
+  SOURCE=$(ls -1dt "$BACKUP_DIR"/*/ 2>/dev/null | head -1 || true)
+  if [ -z "$SOURCE" ]; then
+    echo "[restore-miner] no backups found under $BACKUP_DIR" >&2
+    exit 1
+  fi
+fi
+SOURCE=${SOURCE%/}
+
+if [ ! -d "$SOURCE" ]; then
+  echo "[restore-miner] backup directory not found: $SOURCE" >&2
+  exit 1
+fi
+
+FOUND=0
+for db in "$SOURCE"/*.sqlite3; do
+  [ -e "$db" ] || continue
+  FOUND=1
+  result=$(sqlite3 "$db" 'PRAGMA integrity_check;' 2>/dev/null | head -1 || true)
+  if [ "$result" != "ok" ]; then
+    echo "[restore-miner] ERROR: $(basename "$db") failed integrity check (${result:-no output}); aborting, nothing was restored" >&2
+    exit 1
+  fi
+done
+if [ "$FOUND" -eq 0 ]; then
+  echo "[restore-miner] no *.sqlite3 files found in $SOURCE" >&2
+  exit 1
+fi
+
+echo "[restore-miner] restoring from $SOURCE into $STATE_DIR"
+mkdir -p "$STATE_DIR"
+chmod 700 "$STATE_DIR"
+for db in "$SOURCE"/*.sqlite3; do
+  [ -e "$db" ] || continue
+  name=$(basename "$db")
+  cp "$db" "$STATE_DIR/$name"
+  chmod 600 "$STATE_DIR/$name"
+  rm -f "$STATE_DIR/$name-wal" "$STATE_DIR/$name-shm"
+  echo "[restore-miner] restored $name"
+done
+
+echo "[restore-miner] complete. Run 'gittensory-miner doctor --json' to verify."

--- a/test/unit/miner-backup-restore-scripts.test.ts
+++ b/test/unit/miner-backup-restore-scripts.test.ts
@@ -1,0 +1,337 @@
+import { execFileSync } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+// backup-miner.sh / restore-miner.sh (#4872): tested against a FAKE sqlite3, mirroring
+// selfhost-backup-script.test.ts's own established pattern -- not the real system binary, so this suite is
+// deterministic and doesn't depend on `sqlite3` being on PATH in every CI environment (unlike the miner
+// package's own JS code, which uses node:sqlite natively and has no such dependency; these two shell scripts
+// are the one place in the miner package that shells out to the sqlite3 CLI tool at all).
+
+const tmpRoots: string[] = [];
+
+function tmpRoot(): string {
+  const dir = mkdtempSync(join(tmpdir(), "gittensory-miner-backup-"));
+  tmpRoots.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tmpRoots.splice(0)) rmSync(dir, { force: true, recursive: true });
+});
+
+function writeExecutable(path: string, body: string): void {
+  writeFileSync(path, body);
+  chmodSync(path, 0o755);
+}
+
+/** A fake `sqlite3 <db> "<command>"`: `.backup 'dest'` copies the source db's bytes to dest (so tests can
+ *  assert WHICH source produced WHICH destination content) unless the source's basename contains
+ *  "backup-fails", which exits 2 to simulate a failed online backup. `PRAGMA integrity_check` answers "ok"
+ *  unless the target file's content is literally "GARBAGE" (a corrupt-file sentinel tests write directly). */
+function fakeSqlite(root: string): string {
+  const bin = join(root, "sqlite-bin");
+  mkdirSync(bin);
+  writeExecutable(
+    join(bin, "sqlite3"),
+    `#!/bin/sh
+db="$1"
+cmd="$2"
+case "$cmd" in
+  *integrity_check*)
+    if [ -f "$db" ] && [ "$(cat "$db")" = "GARBAGE" ]; then
+      echo "malformed"
+    else
+      echo ok
+    fi
+    exit 0
+    ;;
+esac
+dest="$(printf '%s\\n' "$cmd" | sed "s/^\\\\.backup '\\\\(.*\\\\)'\$/\\\\1/")"
+if [ "$dest" = "$cmd" ]; then
+  echo "unexpected sqlite command: $cmd" >&2
+  exit 2
+fi
+case "$db" in
+  *backup-fails*)
+    echo "simulated online-backup failure for $db" >&2
+    exit 1
+    ;;
+esac
+cp "$db" "$dest"
+`,
+  );
+  return bin;
+}
+
+function writeSqliteFile(dir: string, name: string, content = "real sqlite content"): string {
+  const path = join(dir, name);
+  writeFileSync(path, content);
+  return path;
+}
+
+function runBackup(stateDir: string, backupDir: string, sqliteBin: string, extraEnv: Record<string, string> = {}) {
+  return execFileSync("sh", ["scripts/backup-miner.sh"], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      GITTENSORY_MINER_CONFIG_DIR: stateDir,
+      GITTENSORY_MINER_BACKUP_DIR: backupDir,
+      PATH: `${sqliteBin}:${process.env.PATH ?? ""}`,
+      ...extraEnv,
+    },
+  });
+}
+
+function runRestore(
+  stateDir: string,
+  backupDir: string,
+  sqliteBin: string,
+  args: string[] = ["--yes"],
+): { stdout: string; status: number } {
+  try {
+    const stdout = execFileSync("sh", ["scripts/restore-miner.sh", ...args], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GITTENSORY_MINER_CONFIG_DIR: stateDir,
+        GITTENSORY_MINER_BACKUP_DIR: backupDir,
+        PATH: `${sqliteBin}:${process.env.PATH ?? ""}`,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { stdout, status: 0 };
+  } catch (error) {
+    const err = error as { stdout?: Buffer; stderr?: Buffer; status?: number };
+    return {
+      stdout: `${err.stdout?.toString() ?? ""}${err.stderr?.toString() ?? ""}`,
+      status: err.status ?? 1,
+    };
+  }
+}
+
+describe("backup-miner.sh", () => {
+  it("backs up every *.sqlite3 file under the state dir, verified by integrity check", () => {
+    const stateDir = tmpRoot();
+    const backupDir = tmpRoot();
+    const sqliteBin = fakeSqlite(tmpRoot());
+    writeSqliteFile(stateDir, "run-state.sqlite3", "run-state content");
+    writeSqliteFile(stateDir, "ranked-candidates.sqlite3", "ranked content");
+    writeFileSync(join(stateDir, "not-a-store.txt"), "ignore me");
+
+    const output = runBackup(stateDir, backupDir, sqliteBin);
+    expect(output).toContain("backed up run-state.sqlite3");
+    expect(output).toContain("backed up ranked-candidates.sqlite3");
+    expect(output).toContain("complete");
+
+    const timestamped = readdirSync(backupDir);
+    expect(timestamped).toHaveLength(1);
+    const dest = join(backupDir, timestamped[0]!);
+    expect(readFileSync(join(dest, "run-state.sqlite3"), "utf8")).toBe("run-state content");
+    expect(readFileSync(join(dest, "ranked-candidates.sqlite3"), "utf8")).toBe("ranked content");
+    expect(existsSync(join(dest, "not-a-store.txt"))).toBe(false);
+  });
+
+  it("fails with a clear message and exit code when the state dir doesn't exist", () => {
+    const stateDir = join(tmpRoot(), "does-not-exist");
+    const backupDir = tmpRoot();
+    const sqliteBin = fakeSqlite(tmpRoot());
+
+    expect(() => runBackup(stateDir, backupDir, sqliteBin)).toThrow();
+  });
+
+  it("fails when the state dir has no *.sqlite3 files, without creating an empty backup directory", () => {
+    const stateDir = tmpRoot();
+    const backupDir = tmpRoot();
+    const sqliteBin = fakeSqlite(tmpRoot());
+    writeFileSync(join(stateDir, "readme.txt"), "no stores here");
+
+    expect(() => runBackup(stateDir, backupDir, sqliteBin)).toThrow();
+    expect(existsSync(backupDir) ? readdirSync(backupDir) : []).toHaveLength(0);
+  });
+
+  it("REGRESSION: a store whose online backup command itself fails is reported and the whole run exits non-zero", () => {
+    const stateDir = tmpRoot();
+    const backupDir = tmpRoot();
+    const sqliteBin = fakeSqlite(tmpRoot());
+    writeSqliteFile(stateDir, "backup-fails.sqlite3");
+    writeSqliteFile(stateDir, "run-state.sqlite3", "good content");
+
+    let threw = false;
+    let output = "";
+    try {
+      runBackup(stateDir, backupDir, sqliteBin);
+    } catch (error) {
+      threw = true;
+      output = String((error as { stdout?: Buffer }).stdout ?? "") + String((error as { stderr?: Buffer }).stderr ?? "");
+    }
+    expect(threw).toBe(true);
+    expect(output).toContain("online backup failed for backup-fails.sqlite3");
+    // The healthy store still gets backed up even though a sibling store's backup failed.
+    const timestamped = readdirSync(backupDir);
+    expect(timestamped).toHaveLength(1);
+    expect(existsSync(join(backupDir, timestamped[0]!, "run-state.sqlite3"))).toBe(true);
+    expect(existsSync(join(backupDir, timestamped[0]!, "backup-fails.sqlite3"))).toBe(false);
+  });
+
+  it("REGRESSION: a backed-up file that fails integrity_check is discarded, not kept as a silently-corrupt backup", () => {
+    const stateDir = tmpRoot();
+    const backupDir = tmpRoot();
+    const sqliteBin = fakeSqlite(tmpRoot());
+    // The fake sqlite3's `.backup` just copies bytes -- write the source as the "GARBAGE" sentinel so the
+    // COPY (the destination) also reads as GARBAGE and fails the fake's integrity_check branch.
+    writeSqliteFile(stateDir, "run-state.sqlite3", "GARBAGE");
+
+    let threw = false;
+    try {
+      runBackup(stateDir, backupDir, sqliteBin);
+    } catch {
+      threw = true;
+    }
+    expect(threw).toBe(true);
+    const timestamped = readdirSync(backupDir);
+    expect(timestamped).toHaveLength(1);
+    expect(existsSync(join(backupDir, timestamped[0]!, "run-state.sqlite3"))).toBe(false);
+  });
+
+  it("retains only the newest N backups after a successful run, pruning the rest", () => {
+    const stateDir = tmpRoot();
+    const backupDir = tmpRoot();
+    const sqliteBin = fakeSqlite(tmpRoot());
+    writeSqliteFile(stateDir, "run-state.sqlite3", "content");
+
+    for (const ts of ["20260101T000000Z", "20260102T000000Z", "20260103T000000Z"]) {
+      mkdirSync(join(backupDir, ts));
+      writeFileSync(join(backupDir, ts, "run-state.sqlite3"), "old content");
+    }
+
+    runBackup(stateDir, backupDir, sqliteBin, { GITTENSORY_MINER_BACKUP_RETAIN: "2" });
+
+    const remaining = readdirSync(backupDir).sort();
+    // The 3 pre-seeded + 1 new run = 4 total; RETAIN=2 keeps only the 2 newest (by mtime, which favors the
+    // just-created one plus whichever pre-seeded directory was touched most recently by this filesystem).
+    expect(remaining.length).toBe(2);
+  });
+
+  it("skips retention pruning after a failed store, so no older good backup is lost to make room for a bad run", () => {
+    const stateDir = tmpRoot();
+    const backupDir = tmpRoot();
+    const sqliteBin = fakeSqlite(tmpRoot());
+    mkdirSync(join(backupDir, "20260101T000000Z"));
+    writeFileSync(join(backupDir, "20260101T000000Z", "run-state.sqlite3"), "old good content");
+    writeSqliteFile(stateDir, "backup-fails.sqlite3");
+
+    expect(() => runBackup(stateDir, backupDir, sqliteBin, { GITTENSORY_MINER_BACKUP_RETAIN: "1" })).toThrow();
+
+    // Both the pre-seeded backup AND the new (failed) run's directory survive -- pruning never ran.
+    expect(readdirSync(backupDir).length).toBe(2);
+    expect(existsSync(join(backupDir, "20260101T000000Z", "run-state.sqlite3"))).toBe(true);
+  });
+});
+
+describe("restore-miner.sh", () => {
+  it("refuses to restore without --yes, leaving the state dir untouched", () => {
+    const stateDir = tmpRoot();
+    const backupDir = tmpRoot();
+    const sqliteBin = fakeSqlite(tmpRoot());
+    mkdirSync(join(backupDir, "20260101T000000Z"));
+    writeFileSync(join(backupDir, "20260101T000000Z", "run-state.sqlite3"), "backup content");
+
+    const result = runRestore(stateDir, backupDir, sqliteBin, []);
+    expect(result.status).not.toBe(0);
+    expect(result.stdout).toMatch(/refusing to restore without --yes/);
+    expect(existsSync(join(stateDir, "run-state.sqlite3"))).toBe(false);
+  });
+
+  it("fails cleanly when no backups exist", () => {
+    const stateDir = tmpRoot();
+    const backupDir = tmpRoot();
+    const sqliteBin = fakeSqlite(tmpRoot());
+
+    const result = runRestore(stateDir, backupDir, sqliteBin);
+    expect(result.status).not.toBe(0);
+    expect(result.stdout).toMatch(/no backups found/);
+  });
+
+  it("restores the newest backup by default when no directory is given", () => {
+    const stateDir = tmpRoot();
+    const backupDir = tmpRoot();
+    const sqliteBin = fakeSqlite(tmpRoot());
+    mkdirSync(join(backupDir, "20260101T000000Z"));
+    writeFileSync(join(backupDir, "20260101T000000Z", "run-state.sqlite3"), "old backup");
+    // "Newest" is determined by mtime (`ls -1dt`); force a real gap so this isn't racy on filesystems with
+    // coarse (e.g. 1s) mtime resolution, where two directories created back-to-back could tie.
+    execFileSync("sleep", ["1.1"]);
+    mkdirSync(join(backupDir, "20260102T000000Z"));
+    writeFileSync(join(backupDir, "20260102T000000Z", "run-state.sqlite3"), "newest backup");
+
+    const result = runRestore(stateDir, backupDir, sqliteBin);
+    expect(result.status).toBe(0);
+    expect(readFileSync(join(stateDir, "run-state.sqlite3"), "utf8")).toBe("newest backup");
+  });
+
+  it("restores a specific backup directory when one is given as an argument", () => {
+    const stateDir = tmpRoot();
+    const backupDir = tmpRoot();
+    const sqliteBin = fakeSqlite(tmpRoot());
+    const older = join(backupDir, "20260101T000000Z");
+    mkdirSync(older);
+    writeFileSync(join(older, "run-state.sqlite3"), "the one we want");
+    mkdirSync(join(backupDir, "20260102T000000Z"));
+    writeFileSync(join(backupDir, "20260102T000000Z", "run-state.sqlite3"), "not this one");
+
+    const result = runRestore(stateDir, backupDir, sqliteBin, ["--yes", older]);
+    expect(result.status).toBe(0);
+    expect(readFileSync(join(stateDir, "run-state.sqlite3"), "utf8")).toBe("the one we want");
+  });
+
+  it("REGRESSION: aborts entirely (no files restored) when any backup file fails integrity_check", () => {
+    const stateDir = tmpRoot();
+    const backupDir = tmpRoot();
+    const sqliteBin = fakeSqlite(tmpRoot());
+    const ts = join(backupDir, "20260101T000000Z");
+    mkdirSync(ts);
+    writeFileSync(join(ts, "run-state.sqlite3"), "good content");
+    writeFileSync(join(ts, "claim-ledger.sqlite3"), "GARBAGE");
+    // Pre-existing live file that must survive an aborted restore untouched.
+    writeSqliteFile(stateDir, "run-state.sqlite3", "live data that must not be overwritten");
+
+    const result = runRestore(stateDir, backupDir, sqliteBin);
+    expect(result.status).not.toBe(0);
+    expect(result.stdout).toMatch(/failed integrity check/);
+    expect(result.stdout).toMatch(/nothing was restored/);
+    expect(readFileSync(join(stateDir, "run-state.sqlite3"), "utf8")).toBe("live data that must not be overwritten");
+  });
+
+  it("removes stale -wal/-shm sidecar files from the live dir after restoring, so no pre-restore write can be replayed", () => {
+    const stateDir = tmpRoot();
+    const backupDir = tmpRoot();
+    const sqliteBin = fakeSqlite(tmpRoot());
+    const ts = join(backupDir, "20260101T000000Z");
+    mkdirSync(ts);
+    writeFileSync(join(ts, "run-state.sqlite3"), "restored content");
+    writeSqliteFile(stateDir, "run-state.sqlite3", "stale live content");
+    writeFileSync(join(stateDir, "run-state.sqlite3-wal"), "stale in-flight write");
+    writeFileSync(join(stateDir, "run-state.sqlite3-shm"), "stale shared memory index");
+
+    const result = runRestore(stateDir, backupDir, sqliteBin);
+    expect(result.status).toBe(0);
+    expect(readFileSync(join(stateDir, "run-state.sqlite3"), "utf8")).toBe("restored content");
+    expect(existsSync(join(stateDir, "run-state.sqlite3-wal"))).toBe(false);
+    expect(existsSync(join(stateDir, "run-state.sqlite3-shm"))).toBe(false);
+  });
+
+  it("fails clearly when the given backup directory doesn't exist", () => {
+    const stateDir = tmpRoot();
+    const backupDir = tmpRoot();
+    const sqliteBin = fakeSqlite(tmpRoot());
+
+    const result = runRestore(stateDir, backupDir, sqliteBin, ["--yes", join(backupDir, "nope")]);
+    expect(result.status).not.toBe(0);
+    expect(result.stdout).toMatch(/backup directory not found/);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `scripts/backup-miner.sh`: backs up every `*.sqlite3` file currently present under `GITTENSORY_MINER_CONFIG_DIR` (17 stores as of this writing, discovered by glob rather than a hardcoded list — a hardcoded list would silently go stale the next time a store is added, exactly what happened when `ranked-candidates.sqlite3` was added earlier this session). Uses SQLite's own online `.backup` command — the same safe-even-while-live mechanism `operations-runbook.md`'s "ledger corrupted" scenario already documents (not a plain `cp`, which can capture a torn snapshot mid-write) — followed by a `PRAGMA integrity_check` on each result before it's kept. Retention-prunes old timestamped backups, skipping the prune entirely if anything failed so no older good backup is ever lost to make room for a bad run.
- Adds `scripts/restore-miner.sh`: validates every store file in the chosen backup via `PRAGMA integrity_check` **before** copying anything into place (a half-good backup can never produce a half-restored state directory), requires an explicit `--yes` flag since it overwrites live state, defaults to the newest backup when no directory is given, and clears any stale `-wal`/`-shm` sidecar files from the live directory after restoring (those hold in-flight pre-restore writes that would otherwise get silently replayed on next open).
- Documents both in a new "Backup and restore" section in `packages/gittensory-miner/docs/operations-runbook.md`, and updates the existing "ledger corrupted" scenario's Tier B (previously a vague "restore the known-good file") to point at the new restore script.

Mirrors `scripts/backup.sh`/`verify-backup.sh`'s established conventions (`.backup` + integrity-check + `ls -1t | tail -n +N+1` retention idiom) but deliberately isn't built on top of them — the miner's local state is 100% independent SQLite files with no Postgres/Qdrant involved, so reusing that script's manifest/multi-target machinery would add complexity with nothing to compose against.

Closes #4872

## Test plan

- [x] `sh -n` syntax check on both scripts; `shellcheck` clean except the same info-level SC2012 (`ls | head -1` for "newest file") `verify-backup.sh` already leaves unsuppressed for an identical pattern
- [x] `git diff --check`, `npm run docs:drift-check`
- [x] New `test/unit/miner-backup-restore-scripts.test.ts` (14 cases), spawning the real scripts via `execFileSync` against a **fake** `sqlite3` binary — mirroring `selfhost-backup-script.test.ts`'s own established pattern, so this suite is deterministic and doesn't depend on `sqlite3` being on `PATH` in every CI environment. Covers: happy-path backup/restore, missing state dir, no stores found, a failed online-backup command, a backup that fails its own integrity check, retention pruning (and skipping the prune after a failure), refusing restore without `--yes`, restoring newest-by-default vs. a specific directory, aborting a restore entirely when any backup file is corrupt (with the live state verified untouched), and the stale-wal/shm cleanup
- [x] Manually ran full backup → simulated corruption/deletion → restore → verified real data survived, against the **real** `sqlite3` binary and real miner stores (`run-state.js`, `ranked-candidates.js`)
- [x] Manually verified all three safety guards live: refusing without `--yes`, clean failure with no backups present, and a corrupt backup aborting the whole restore with live state provably untouched

Along the way, the automated test suite caught and fixed a real bug my manual testing had missed: when the *only* store file present failed its backup or integrity check, the script treated that identically to "no stores found at all" and deleted the timestamped backup directory — discarding the error evidence a partial-failure run should have preserved for debugging (`backup.sh`'s own established behavior). Fixed to distinguish "glob matched nothing" from "glob matched files but all failed."

This PR touches `scripts/**`, `packages/gittensory-miner/docs/**`, and one new `test/unit/*.test.ts` file — no `src/**`/`packages/*/src/**`/`packages/gittensory-miner/lib/**` changes, so Codecov's patch-coverage gate has nothing to measure in the shell scripts themselves.