### PR TITLE
feat(ui): add one-click advisory to blocking gate ramp control

### DIFF
--- a/apps/gittensory-ui/src/components/site/app-panels/gate-ramp-confirm-dialog.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/gate-ramp-confirm-dialog.tsx
@@ -1,0 +1,82 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import {
+  listRampGateTransitions,
+  RAMP_GATE_DISPLAY_LABELS,
+  type GateRampSettingsSlice,
+} from "@/lib/gate-ramp";
+
+type GateRampConfirmDialogProps = {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  repoFullName: string;
+  settings: GateRampSettingsSlice;
+  busy: boolean;
+  onConfirm: () => void;
+};
+
+/**
+ * Confirmation gate before moving deterministic rules from advisory to blocking (#2218). Lists the exact
+ * sub-gates that will change so maintainers know what becomes merge-blocking.
+ */
+export function GateRampConfirmDialog({
+  open,
+  onOpenChange,
+  repoFullName,
+  settings,
+  busy,
+  onConfirm,
+}: GateRampConfirmDialogProps) {
+  const transitions = listRampGateTransitions(settings);
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Enable blocking gate rules?</AlertDialogTitle>
+          <AlertDialogDescription asChild>
+            <div className="space-y-3 text-left text-token-sm text-muted-foreground">
+              <p>
+                This updates <span className="font-mono text-foreground/90">{repoFullName}</span>{" "}
+                via the same settings mutation as the repository settings editor. Pull requests that
+                trip these gates may be blocked from merging once branch protection requires the
+                Gittensory check.
+              </p>
+              {transitions.length > 0 ? (
+                <ul className="space-y-1 rounded-token border-hairline bg-muted/20 px-3 py-2 font-mono text-token-2xs">
+                  {transitions.map((entry) => (
+                    <li key={entry.key}>
+                      {RAMP_GATE_DISPLAY_LABELS[entry.key]}: {entry.from} → {entry.to}
+                    </li>
+                  ))}
+                </ul>
+              ) : (
+                <p>All ramp gates are already blocking.</p>
+              )}
+            </div>
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={busy}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            disabled={busy || transitions.length === 0}
+            onClick={(event) => {
+              event.preventDefault();
+              onConfirm();
+            }}
+          >
+            {busy ? "Saving…" : "Enable blocking"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}

--- a/apps/gittensory-ui/src/components/site/app-panels/gate-ramp-control.test.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/gate-ramp-control.test.tsx
@@ -1,0 +1,181 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { apiFetch } = vi.hoisted(() => ({ apiFetch: vi.fn() }));
+vi.mock("@/lib/api/request", () => ({ apiFetch: (...args: unknown[]) => apiFetch(...args) }));
+vi.mock("@/lib/api/origin", () => ({ getApiOrigin: () => "https://api.test" }));
+
+const { toastSuccess, toastError } = vi.hoisted(() => ({
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+}));
+vi.mock("sonner", () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccess(...args),
+    error: (...args: unknown[]) => toastError(...args),
+  },
+}));
+
+import { GateRampControl } from "@/components/site/app-panels/gate-ramp-control";
+
+const REVIEWABILITY = [{ pr: "acme/widgets#1" }];
+
+const ADVISORY_SETTINGS = {
+  commentMode: "detected_contributors_only" as const,
+  publicAudienceMode: "oss_maintainer" as const,
+  publicSignalLevel: "standard" as const,
+  publicSurface: "comment_and_label" as const,
+  checkRunMode: "enabled" as const,
+  checkRunDetailLevel: "standard" as const,
+  reviewCheckMode: "required" as const,
+  gatePack: "gittensor" as const,
+  linkedIssueGateMode: "advisory" as const,
+  duplicatePrGateMode: "advisory" as const,
+  qualityGateMode: "advisory" as const,
+  qualityGateMinScore: null,
+  mergeReadinessGateMode: "off" as const,
+  manifestPolicyGateMode: "off" as const,
+  firstTimeContributorGrace: false,
+  slopGateMode: "off" as const,
+  slopGateMinScore: null,
+  slopAiAdvisory: false,
+  autoLabelEnabled: true,
+  gittensorLabel: "gittensor",
+  createMissingLabel: true,
+  includeMaintainerAuthors: false,
+  requireLinkedIssue: false,
+  badgeEnabled: false,
+  publicQualityMetrics: false,
+  commandAuthorization: {},
+  autonomy: {},
+  autoMaintain: { requireApprovals: 1, mergeMethod: "squash" as const },
+  agentPaused: false,
+  agentDryRun: false,
+};
+
+const BLOCKING_SETTINGS = {
+  ...ADVISORY_SETTINGS,
+  linkedIssueGateMode: "block" as const,
+  duplicatePrGateMode: "block" as const,
+  qualityGateMode: "block" as const,
+};
+
+describe("GateRampControl (#2218)", () => {
+  beforeEach(() => {
+    apiFetch.mockReset();
+    toastSuccess.mockReset();
+    toastError.mockReset();
+  });
+
+  it("loads settings and shows advisory phase with ramp switch off", async () => {
+    apiFetch.mockResolvedValue({ ok: true, data: ADVISORY_SETTINGS });
+    render(<GateRampControl reviewability={REVIEWABILITY} />);
+
+    await waitFor(() => expect(screen.getByText(/Advisory/i)).toBeTruthy());
+    const rampSwitch = screen.getByRole("switch", { name: /blocking enforcement/i });
+    expect(rampSwitch.getAttribute("aria-checked")).toBe("false");
+    expect(apiFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/v1/repos/acme/widgets/settings"),
+      expect.objectContaining({ label: "Repository settings" }),
+    );
+  });
+
+  it("opens confirm on switch, saves blocking ramp on confirm, and toasts success", async () => {
+    apiFetch.mockResolvedValueOnce({ ok: true, data: ADVISORY_SETTINGS });
+    render(<GateRampControl reviewability={REVIEWABILITY} />);
+    await waitFor(() => expect(screen.getByRole("switch")).toBeTruthy());
+
+    apiFetch.mockResolvedValueOnce({ ok: true, data: BLOCKING_SETTINGS });
+    fireEvent.click(screen.getByRole("switch"));
+    expect(screen.getByText(/Enable blocking gate rules/i)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: /^Enable blocking$/i }));
+
+    await waitFor(() =>
+      expect(toastSuccess).toHaveBeenCalledWith(
+        "Blocking mode enabled",
+        expect.objectContaining({
+          description: expect.stringContaining("can now block merges"),
+        }),
+      ),
+    );
+
+    const putCall = apiFetch.mock.calls.find(
+      ([, opts]) => (opts as { method?: string })?.method === "PUT",
+    );
+    expect(putCall?.[0]).toContain("/v1/repos/acme/widgets/settings");
+    const body = JSON.parse(String((putCall?.[1] as { body?: string })?.body ?? "{}"));
+    expect(body.linkedIssueGateMode).toBe("block");
+    expect(body.duplicatePrGateMode).toBe("block");
+    expect(body.qualityGateMode).toBe("block");
+    expect(body.commentMode).toBe("detected_contributors_only");
+  });
+
+  it("closes confirm without saving when cancel is clicked", async () => {
+    apiFetch.mockResolvedValueOnce({ ok: true, data: ADVISORY_SETTINGS });
+    render(<GateRampControl reviewability={REVIEWABILITY} />);
+    await waitFor(() => expect(screen.getByRole("switch")).toBeTruthy());
+
+    fireEvent.click(screen.getByRole("switch"));
+    fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+    await waitFor(() => expect(screen.queryByText(/Enable blocking gate rules/i)).toBeNull());
+    expect(
+      apiFetch.mock.calls.filter(([, opts]) => (opts as { method?: string })?.method === "PUT"),
+    ).toHaveLength(0);
+  });
+
+  it("toasts an error when the blocking ramp save fails", async () => {
+    apiFetch.mockResolvedValueOnce({ ok: true, data: ADVISORY_SETTINGS });
+    render(<GateRampControl reviewability={REVIEWABILITY} />);
+    await waitFor(() => expect(screen.getByRole("switch")).toBeTruthy());
+
+    fireEvent.click(screen.getByRole("switch"));
+    apiFetch.mockResolvedValueOnce({ ok: false, message: "403 Forbidden" });
+    fireEvent.click(screen.getByRole("button", { name: /^Enable blocking$/i }));
+
+    await waitFor(() =>
+      expect(toastError).toHaveBeenCalledWith(
+        "Could not enable blocking",
+        expect.objectContaining({ description: "403 Forbidden" }),
+      ),
+    );
+    expect(toastSuccess).not.toHaveBeenCalled();
+  });
+
+  it("disables the switch when the gate is inactive (reviewCheckMode disabled)", async () => {
+    apiFetch.mockResolvedValue({
+      ok: true,
+      data: { ...ADVISORY_SETTINGS, reviewCheckMode: "disabled" },
+    });
+    render(<GateRampControl reviewability={REVIEWABILITY} />);
+
+    await waitFor(() => expect(screen.getByText(/Gate off/i)).toBeTruthy());
+    expect(screen.getByRole("switch")).toHaveProperty("disabled", true);
+  });
+
+  it("shows blocking phase with switch on and disabled when already ramped", async () => {
+    apiFetch.mockResolvedValue({ ok: true, data: BLOCKING_SETTINGS });
+    render(<GateRampControl reviewability={REVIEWABILITY} />);
+
+    await waitFor(() => expect(screen.getByText(/Blocking/i)).toBeTruthy());
+    const rampSwitch = screen.getByRole("switch");
+    expect(rampSwitch.getAttribute("aria-checked")).toBe("true");
+    expect(rampSwitch).toHaveProperty("disabled", true);
+  });
+
+  it("shows a no-repos hint and skips the load call when reviewability is empty", () => {
+    render(<GateRampControl reviewability={[]} />);
+    expect(screen.getByText(/Enter an installed repository to manage the gate ramp/i)).toBeTruthy();
+    expect(apiFetch).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the load error via StateBoundary when the settings fetch fails", async () => {
+    apiFetch.mockResolvedValue({ ok: false, message: "500 Internal Server Error" });
+    render(<GateRampControl reviewability={REVIEWABILITY} />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/Couldn't load repository settings/i)).toBeTruthy(),
+    );
+  });
+});

--- a/apps/gittensory-ui/src/components/site/app-panels/gate-ramp-control.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/gate-ramp-control.tsx
@@ -1,0 +1,240 @@
+import { Loader2, ShieldAlert } from "lucide-react";
+import { useCallback, useEffect, useId, useMemo, useState } from "react";
+import { toast } from "sonner";
+
+import { StatusPill } from "@/components/site/control-primitives";
+import { GateRampConfirmDialog } from "@/components/site/app-panels/gate-ramp-confirm-dialog";
+import { StateBoundary } from "@/components/site/state-views";
+import { Switch } from "@/components/ui/switch";
+import { apiFetch } from "@/lib/api/request";
+import { getApiOrigin } from "@/lib/api/origin";
+import {
+  buildBlockingRampPatch,
+  summarizeGateRamp,
+  type GateRampSettingsSlice,
+} from "@/lib/gate-ramp";
+import {
+  buildMaintainerSettingsSavePayload,
+  type MaintainerSettingsEditable,
+} from "@/lib/maintainer-settings-editable";
+import { extractPreviewRepoOptions, splitRepoFullName } from "@/lib/maintainer-settings-preview";
+
+function repoApiBase(repoFullName: string): string | null {
+  const target = splitRepoFullName(repoFullName);
+  if (!target) return null;
+  return `${getApiOrigin().replace(/\/$/, "")}/v1/repos/${encodeURIComponent(target.owner)}/${encodeURIComponent(target.repo)}`;
+}
+
+const JSON_HEADERS = { Accept: "application/json", "Content-Type": "application/json" };
+const FIELD_CLASS =
+  "mt-1 min-h-10 w-full rounded-token border border-border bg-background/70 px-3 py-2 font-mono text-token-sm text-foreground outline-none transition-colors focus:border-mint";
+const LABEL_CLASS = "font-mono text-token-2xs uppercase tracking-wider text-muted-foreground";
+
+function normalizeLoadedSettings(data: MaintainerSettingsEditable): MaintainerSettingsEditable {
+  return {
+    ...data,
+    autonomy: data.autonomy ?? {},
+    agentPaused: data.agentPaused ?? false,
+    agentDryRun: data.agentDryRun ?? false,
+    autoMaintain: data.autoMaintain ?? { requireApprovals: 1, mergeMethod: "squash" },
+  };
+}
+
+/**
+ * One-click advisory → blocking ramp for the maintainer onboarding surface (#2218). Loads GET /settings,
+ * reflects the current ramp phase, and on confirm merges the blocking patch through PUT /settings (same path
+ * as maintainer-settings.tsx). AlertDialog gates the destructive flip; sonner toasts report save outcomes.
+ */
+export function GateRampControl({ reviewability }: { reviewability: Array<{ pr: string }> }) {
+  const repoOptions = useMemo(() => extractPreviewRepoOptions(reviewability), [reviewability]);
+  const [repoFullName, setRepoFullName] = useState(repoOptions[0] ?? "");
+  const [settings, setSettings] = useState<MaintainerSettingsEditable | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [confirmOpen, setConfirmOpen] = useState(false);
+
+  const switchId = useId();
+  const base = repoApiBase(repoFullName);
+  const hasRepos = repoOptions.length > 0;
+
+  const rampSlice: GateRampSettingsSlice | null = settings
+    ? {
+        reviewCheckMode: settings.reviewCheckMode,
+        linkedIssueGateMode: settings.linkedIssueGateMode,
+        duplicatePrGateMode: settings.duplicatePrGateMode,
+        qualityGateMode: settings.qualityGateMode,
+      }
+    : null;
+
+  const summary = rampSlice ? summarizeGateRamp(rampSlice) : null;
+
+  const load = useCallback(async () => {
+    const apiBase = repoApiBase(repoFullName);
+    if (!apiBase) {
+      setSettings(null);
+      setLoadError(null);
+      return;
+    }
+    setLoadError(null);
+    setLoading(true);
+    const result = await apiFetch<MaintainerSettingsEditable>(`${apiBase}/settings`, {
+      label: "Repository settings",
+      credentials: "include",
+      silentStatus: true,
+    });
+    setSettings(result.ok ? normalizeLoadedSettings(result.data) : null);
+    if (!result.ok) setLoadError(result.message);
+    setLoading(false);
+  }, [repoFullName]);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function saveBlockingRamp() {
+    if (!base || !settings) return;
+    setBusy(true);
+    const payload = buildMaintainerSettingsSavePayload(settings, buildBlockingRampPatch());
+    const result = await apiFetch<MaintainerSettingsEditable>(`${base}/settings`, {
+      method: "PUT",
+      label: "Ramp to blocking",
+      credentials: "include",
+      headers: JSON_HEADERS,
+      body: JSON.stringify(payload),
+    });
+    setBusy(false);
+    setConfirmOpen(false);
+    if (result.ok) {
+      setSettings(normalizeLoadedSettings(result.data));
+      toast.success("Blocking mode enabled", {
+        description: "Linked-issue, duplicate-PR, and quality gates can now block merges.",
+      });
+    } else {
+      toast.error("Could not enable blocking", { description: result.message });
+    }
+  }
+
+  function handleSwitchChange(checked: boolean) {
+    if (!summary?.canRampToBlocking || !checked) return;
+    setConfirmOpen(true);
+  }
+
+  const switchChecked = summary?.isBlocking ?? false;
+  const switchDisabled =
+    busy || loading || !summary || !summary.canRampToBlocking || summary.isBlocking;
+
+  return (
+    <section
+      className="rounded-token border-hairline bg-card p-5"
+      aria-labelledby="gate-ramp-control-title"
+    >
+      <div className="flex flex-wrap items-end justify-between gap-3">
+        <div>
+          <h2 id="gate-ramp-control-title" className="font-display text-token-lg font-semibold">
+            Gate ramp control
+          </h2>
+          <p className="mt-1 text-token-xs text-muted-foreground">
+            After advisory mode is on, ramp deterministic gate rules to blocking in one action —
+            with confirmation before merges can be held.
+          </p>
+        </div>
+        {summary ? (
+          <StatusPill
+            status={summary.isBlocking ? "blocked" : summary.phase === "advisory" ? "info" : "warn"}
+          >
+            {summary.label}
+          </StatusPill>
+        ) : null}
+      </div>
+
+      <label className="mt-4 block max-w-sm">
+        <span className={LABEL_CLASS}>Repository</span>
+        <input
+          value={repoFullName}
+          onChange={(event) => setRepoFullName(event.target.value)}
+          list="gate-ramp-repos"
+          placeholder="owner/repo"
+          className={FIELD_CLASS}
+        />
+        <datalist id="gate-ramp-repos">
+          {repoOptions.map((repo) => (
+            <option key={repo} value={repo} />
+          ))}
+        </datalist>
+        {!hasRepos ? (
+          <span className="mt-1 block text-token-2xs text-muted-foreground">
+            No registered repositories detected yet — type an installed{" "}
+            <code className="font-mono">owner/repo</code>.
+          </span>
+        ) : null}
+      </label>
+
+      <div className="mt-6">
+        <StateBoundary
+          isLoading={Boolean(base) && loading}
+          isError={Boolean(base) && !loading && loadError !== null}
+          isEmpty={false}
+          onRetry={load}
+          onRefresh={load}
+          loadingTitle="Loading gate ramp state…"
+          errorTitle="Couldn't load repository settings"
+          errorDescription={loadError ?? undefined}
+        >
+          {!base ? (
+            <p className="text-token-sm text-muted-foreground">
+              {hasRepos
+                ? "Settings are unavailable for this repository."
+                : "Enter an installed repository to manage the gate ramp."}
+            </p>
+          ) : summary && settings ? (
+            <div className="space-y-4">
+              <p className="text-token-sm text-foreground/90">{summary.description}</p>
+
+              <div className="flex flex-wrap items-center justify-between gap-4 rounded-token border-hairline bg-background/40 px-4 py-3">
+                <div className="flex min-w-0 items-start gap-3">
+                  <ShieldAlert className="mt-0.5 size-4 shrink-0 text-warning" aria-hidden />
+                  <div>
+                    <label htmlFor={switchId} className="text-token-sm font-medium text-foreground">
+                      Blocking enforcement
+                    </label>
+                    <p className="mt-0.5 text-token-2xs text-muted-foreground">
+                      {summary.canRampToBlocking
+                        ? "Off — advisory only. Turn on to block merges when gate findings fire."
+                        : summary.isBlocking
+                          ? "On — deterministic gates are blocking."
+                          : "Unavailable until advisory mode is enabled above."}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  {busy ? (
+                    <Loader2 className="size-4 animate-spin text-muted-foreground" aria-hidden />
+                  ) : null}
+                  <Switch
+                    id={switchId}
+                    checked={switchChecked}
+                    disabled={switchDisabled}
+                    aria-busy={busy}
+                    onCheckedChange={handleSwitchChange}
+                  />
+                </div>
+              </div>
+            </div>
+          ) : null}
+        </StateBoundary>
+      </div>
+
+      {settings && rampSlice ? (
+        <GateRampConfirmDialog
+          open={confirmOpen}
+          onOpenChange={setConfirmOpen}
+          repoFullName={repoFullName}
+          settings={rampSlice}
+          busy={busy}
+          onConfirm={() => void saveBlockingRamp()}
+        />
+      ) : null}
+    </section>
+  );
+}

--- a/apps/gittensory-ui/src/components/site/app-panels/maintainer-panel.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/maintainer-panel.tsx
@@ -23,6 +23,7 @@ import { ContributorQualityTable } from "@/components/site/app-panels/contributo
 import type { MaintainerTopContributor } from "@/components/site/app-panels/contributor-quality-table-model";
 import { GateOutcomeCard } from "@/components/site/app-panels/gate-outcome-card";
 import type { GateOutcomeCardData } from "@/components/site/app-panels/gate-outcome-card-model";
+import { GateRampControl } from "@/components/site/app-panels/gate-ramp-control";
 import {
   QueueHealthCard,
   type MaintainerQueueHealth,
@@ -391,6 +392,8 @@ function MaintainerDashboardView({
           <ContributorQualityTable topContributors={data.qualityDashboard.topContributors} />
 
           <ActivationPreview reviewability={data.reviewability} />
+
+          <GateRampControl reviewability={data.reviewability} />
 
           <SurfacePreview
             reviewability={data.reviewability}

--- a/apps/gittensory-ui/src/components/site/app-panels/maintainer-settings.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/maintainer-settings.tsx
@@ -5,53 +5,17 @@ import { StatusPill } from "@/components/site/control-primitives";
 import { apiFetch } from "@/lib/api/request";
 import { getApiOrigin } from "@/lib/api/origin";
 import { extractPreviewRepoOptions, splitRepoFullName } from "@/lib/maintainer-settings-preview";
+import {
+  buildMaintainerSettingsSavePayload,
+  type AgentActionClass,
+  type AutoMergeMethod,
+  type AutonomyLevel,
+  type CommandRole,
+  type GateMode,
+  type MaintainerSettingsEditable,
+} from "@/lib/maintainer-settings-editable";
 
-type GateMode = "off" | "advisory" | "block";
-type CommandRole = "maintainer" | "collaborator" | "pr_author" | "confirmed_miner";
-
-type CommandAuthorization = {
-  default?: CommandRole[];
-  commands?: Record<string, CommandRole[]>;
-};
-
-type MaintainerSettings = {
-  commentMode: "off" | "detected_contributors_only" | "all_prs";
-  publicAudienceMode: "oss_maintainer" | "gittensor_only";
-  publicSignalLevel: "minimal" | "standard";
-  publicSurface: "off" | "comment_and_label" | "comment_only" | "label_only";
-  checkRunMode: "off" | "enabled";
-  checkRunDetailLevel: "minimal" | "standard";
-  // #4618/#5373: a prior gateCheckMode field was a deprecated computed read-back, since removed entirely --
-  // reviewCheckMode is the real, writable authority for whether the review-agent check-run publishes.
-  reviewCheckMode: "required" | "visible" | "disabled";
-  gatePack: "gittensor" | "oss-anti-slop";
-  linkedIssueGateMode: GateMode;
-  duplicatePrGateMode: GateMode;
-  qualityGateMode: GateMode;
-  qualityGateMinScore: number | null;
-  mergeReadinessGateMode: GateMode;
-  manifestPolicyGateMode: GateMode;
-  firstTimeContributorGrace: boolean;
-  slopGateMode: GateMode;
-  slopGateMinScore: number | null;
-  slopAiAdvisory: boolean;
-  autoLabelEnabled: boolean;
-  gittensorLabel: string;
-  createMissingLabel: boolean;
-  includeMaintainerAuthors: boolean;
-  requireLinkedIssue: boolean;
-  badgeEnabled: boolean;
-  publicQualityMetrics: boolean;
-  commandAuthorization: CommandAuthorization;
-  autonomy: Partial<Record<AgentActionClass, AutonomyLevel>>;
-  autoMaintain: { requireApprovals: number; mergeMethod: AutoMergeMethod };
-  agentPaused: boolean;
-  agentDryRun: boolean;
-};
-
-type AutonomyLevel = "observe" | "auto_with_approval" | "auto";
-type AgentActionClass = "review" | "request_changes" | "approve" | "merge" | "close" | "label";
-type AutoMergeMethod = "merge" | "squash" | "rebase";
+type MaintainerSettings = MaintainerSettingsEditable;
 
 const AUTONOMY_LEVELS: AutonomyLevel[] = ["observe", "auto_with_approval", "auto"];
 const AGENT_ACTION_CLASSES: AgentActionClass[] = [
@@ -78,39 +42,8 @@ const COMMAND_ROLES: Array<[CommandRole, string]> = [
   ["confirmed_miner", "confirmed miner"],
 ];
 
-// The maintainer-editable subset, sent verbatim to PUT /settings (which merges onto current settings).
-const EDITABLE_KEYS: Array<keyof MaintainerSettings> = [
-  "commentMode",
-  "publicAudienceMode",
-  "publicSignalLevel",
-  "publicSurface",
-  "checkRunMode",
-  "checkRunDetailLevel",
-  "reviewCheckMode",
-  "gatePack",
-  "linkedIssueGateMode",
-  "duplicatePrGateMode",
-  "qualityGateMode",
-  "qualityGateMinScore",
-  "mergeReadinessGateMode",
-  "manifestPolicyGateMode",
-  "firstTimeContributorGrace",
-  "slopGateMode",
-  "slopGateMinScore",
-  "slopAiAdvisory",
-  "autoLabelEnabled",
-  "gittensorLabel",
-  "createMissingLabel",
-  "includeMaintainerAuthors",
-  "requireLinkedIssue",
-  "badgeEnabled",
-  "publicQualityMetrics",
-  "commandAuthorization",
-  "autonomy",
-  "autoMaintain",
-  "agentPaused",
-  "agentDryRun",
-];
+// The maintainer-editable subset is centralized in maintainer-settings-editable.ts (#2218), shared with
+// gate-ramp-control.tsx's PUT /settings payload builder.
 
 type SelectFieldDef = {
   key: keyof MaintainerSettings;
@@ -340,7 +273,7 @@ export function MaintainerSettings({ reviewability }: { reviewability: Array<{ p
   async function save() {
     if (!base || !settings) return;
     setBusy(true);
-    const payload = Object.fromEntries(EDITABLE_KEYS.map((key) => [key, settings[key]]));
+    const payload = buildMaintainerSettingsSavePayload(settings);
     const result = await apiFetch<MaintainerSettings>(`${base}/settings`, {
       method: "PUT",
       label: "Save repository settings",

--- a/apps/gittensory-ui/src/lib/gate-ramp.test.ts
+++ b/apps/gittensory-ui/src/lib/gate-ramp.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildBlockingRampPatch,
+  deriveGateRampPhase,
+  isBlockingRampComplete,
+  isGateRampActive,
+  listRampGateTransitions,
+  summarizeGateRamp,
+} from "@/lib/gate-ramp";
+
+const ADVISORY_SLICE = {
+  reviewCheckMode: "required" as const,
+  linkedIssueGateMode: "advisory" as const,
+  duplicatePrGateMode: "advisory" as const,
+  qualityGateMode: "advisory" as const,
+};
+
+const BLOCKING_SLICE = {
+  ...ADVISORY_SLICE,
+  linkedIssueGateMode: "block" as const,
+  duplicatePrGateMode: "block" as const,
+  qualityGateMode: "block" as const,
+};
+
+describe("gate-ramp helpers (#2218)", () => {
+  it("treats reviewCheckMode disabled as inactive", () => {
+    const disabled = { ...ADVISORY_SLICE, reviewCheckMode: "disabled" as const };
+    expect(isGateRampActive(disabled)).toBe(false);
+    expect(deriveGateRampPhase(disabled)).toBe("inactive");
+  });
+
+  it("treats reviewCheckMode visible or required as active", () => {
+    expect(isGateRampActive(ADVISORY_SLICE)).toBe(true);
+    expect(isGateRampActive({ ...ADVISORY_SLICE, reviewCheckMode: "visible" })).toBe(true);
+  });
+
+  it("detects advisory and blocking phases from the ramp trio", () => {
+    expect(deriveGateRampPhase(ADVISORY_SLICE)).toBe("advisory");
+    expect(isBlockingRampComplete(ADVISORY_SLICE)).toBe(false);
+    expect(deriveGateRampPhase(BLOCKING_SLICE)).toBe("blocking");
+    expect(isBlockingRampComplete(BLOCKING_SLICE)).toBe(true);
+  });
+
+  it("summarizeGateRamp exposes ramp affordances only in advisory phase", () => {
+    const inactive = summarizeGateRamp({ ...ADVISORY_SLICE, reviewCheckMode: "disabled" });
+    expect(inactive.label).toBe("Gate off");
+    expect(inactive.canRampToBlocking).toBe(false);
+    expect(inactive.isBlocking).toBe(false);
+
+    const advisory = summarizeGateRamp(ADVISORY_SLICE);
+    expect(advisory.label).toBe("Advisory");
+    expect(advisory.canRampToBlocking).toBe(true);
+    expect(advisory.isBlocking).toBe(false);
+
+    const blocking = summarizeGateRamp(BLOCKING_SLICE);
+    expect(blocking.label).toBe("Blocking");
+    expect(blocking.canRampToBlocking).toBe(false);
+    expect(blocking.isBlocking).toBe(true);
+  });
+
+  it("buildBlockingRampPatch flips the deterministic trio to block", () => {
+    expect(buildBlockingRampPatch()).toEqual({
+      linkedIssueGateMode: "block",
+      duplicatePrGateMode: "block",
+      qualityGateMode: "block",
+    });
+  });
+
+  it("listRampGateTransitions lists all three when none are blocking yet", () => {
+    const transitions = listRampGateTransitions(ADVISORY_SLICE);
+    expect(transitions).toHaveLength(3);
+    expect(transitions).toEqual([
+      { key: "linkedIssueGateMode", from: "advisory", to: "block" },
+      { key: "duplicatePrGateMode", from: "advisory", to: "block" },
+      { key: "qualityGateMode", from: "advisory", to: "block" },
+    ]);
+  });
+
+  it("listRampGateTransitions omits gates already at the target mode", () => {
+    const mixed = { ...ADVISORY_SLICE, duplicatePrGateMode: "block" as const };
+    const transitions = listRampGateTransitions(mixed);
+    expect(transitions).toHaveLength(2);
+    expect(transitions.map((t) => t.key)).toEqual(["linkedIssueGateMode", "qualityGateMode"]);
+  });
+
+  it("listRampGateTransitions is empty once every gate is already blocking", () => {
+    expect(listRampGateTransitions(BLOCKING_SLICE)).toEqual([]);
+  });
+});

--- a/apps/gittensory-ui/src/lib/gate-ramp.ts
+++ b/apps/gittensory-ui/src/lib/gate-ramp.ts
@@ -1,0 +1,109 @@
+/**
+ * Advisory → blocking ramp helpers for the maintainer onboarding surface (#2218). Mirrors the deterministic
+ * gate trio that `ActivationPreview`'s POST /activation enables in advisory mode; blocking ramps those same
+ * fields to `block` via the existing PUT /settings merge path (maintainer-settings.tsx).
+ */
+
+export type GateMode = "off" | "advisory" | "block";
+
+/** The three deterministic sub-gates flipped together during the ramp. */
+export const RAMP_DETERMINISTIC_GATE_KEYS = [
+  "linkedIssueGateMode",
+  "duplicatePrGateMode",
+  "qualityGateMode",
+] as const;
+
+export type RampDeterministicGateKey = (typeof RAMP_DETERMINISTIC_GATE_KEYS)[number];
+
+export type GateRampSettingsSlice = {
+  // #4618/#5373: reviewCheckMode is the sole writable authority for whether the check-run publishes at
+  // all (the "disabled" | "visible" | "required" trio) -- the prior computed gateCheckMode field this
+  // helper set once mirrored has since been removed entirely, so ramp activity is gated on this alone.
+  reviewCheckMode: "required" | "visible" | "disabled";
+} & Record<RampDeterministicGateKey, GateMode>;
+
+export type GateRampPhase = "inactive" | "advisory" | "blocking";
+
+export type GateRampSummary = {
+  phase: GateRampPhase;
+  /** Human label for the ramp pill (inactive / advisory / blocking). */
+  label: string;
+  /** Short helper copy under the switch. */
+  description: string;
+  /** Whether the maintainer can attempt the advisory → blocking transition. */
+  canRampToBlocking: boolean;
+  /** Whether blocking is already fully engaged for the ramp trio. */
+  isBlocking: boolean;
+};
+
+const PHASE_LABEL: Record<GateRampPhase, string> = {
+  inactive: "Gate off",
+  advisory: "Advisory",
+  blocking: "Blocking",
+};
+
+const PHASE_DESCRIPTION: Record<GateRampPhase, string> = {
+  inactive:
+    "Enable advisory mode in the activation preview above before ramping deterministic rules to blocking.",
+  advisory:
+    "Deterministic linked-issue, duplicate-PR, and quality gates surface guidance without blocking merges. Flip to blocking when you are ready to enforce.",
+  blocking:
+    "Linked-issue, duplicate-PR, and quality gates can block merges when findings fire. Re-tune individual gates in repository settings below.",
+};
+
+/** Whether the Gittensory review-agent check is actively publishing at all. */
+export function isGateRampActive(settings: GateRampSettingsSlice): boolean {
+  return settings.reviewCheckMode !== "disabled";
+}
+
+/** True when every ramp deterministic sub-gate is set to block. */
+export function isBlockingRampComplete(settings: GateRampSettingsSlice): boolean {
+  return RAMP_DETERMINISTIC_GATE_KEYS.every((key) => settings[key] === "block");
+}
+
+/** Derive the maintainer-facing ramp phase from loaded repository settings. */
+export function deriveGateRampPhase(settings: GateRampSettingsSlice): GateRampPhase {
+  if (!isGateRampActive(settings)) return "inactive";
+  if (isBlockingRampComplete(settings)) return "blocking";
+  return "advisory";
+}
+
+export function summarizeGateRamp(settings: GateRampSettingsSlice): GateRampSummary {
+  const phase = deriveGateRampPhase(settings);
+  const isBlocking = phase === "blocking";
+  return {
+    phase,
+    label: PHASE_LABEL[phase],
+    description: PHASE_DESCRIPTION[phase],
+    canRampToBlocking: phase === "advisory",
+    isBlocking,
+  };
+}
+
+/** Patch applied on confirm: only the ramp trio moves to block; everything else is preserved by PUT merge. */
+export function buildBlockingRampPatch(): Pick<GateRampSettingsSlice, RampDeterministicGateKey> {
+  return {
+    linkedIssueGateMode: "block",
+    duplicatePrGateMode: "block",
+    qualityGateMode: "block",
+  };
+}
+
+/** List gate keys that would change when ramping (for confirm-dialog copy). */
+export function listRampGateTransitions(
+  settings: GateRampSettingsSlice,
+): Array<{ key: RampDeterministicGateKey; from: GateMode; to: GateMode }> {
+  const patch = buildBlockingRampPatch();
+  return RAMP_DETERMINISTIC_GATE_KEYS.map((key) => ({
+    key,
+    from: settings[key],
+    to: patch[key],
+  })).filter((entry) => entry.from !== entry.to);
+}
+
+/** Friendly labels for confirm-dialog rows. */
+export const RAMP_GATE_DISPLAY_LABELS: Record<RampDeterministicGateKey, string> = {
+  linkedIssueGateMode: "Linked issue gate",
+  duplicatePrGateMode: "Duplicate PR gate",
+  qualityGateMode: "Quality / readiness gate",
+};

--- a/apps/gittensory-ui/src/lib/maintainer-settings-editable.test.ts
+++ b/apps/gittensory-ui/src/lib/maintainer-settings-editable.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildMaintainerSettingsSavePayload,
+  MAINTAINER_SETTINGS_EDITABLE_KEYS,
+  type MaintainerSettingsEditable,
+} from "@/lib/maintainer-settings-editable";
+
+const SETTINGS: MaintainerSettingsEditable = {
+  commentMode: "detected_contributors_only",
+  publicAudienceMode: "oss_maintainer",
+  publicSignalLevel: "standard",
+  publicSurface: "comment_and_label",
+  checkRunMode: "enabled",
+  checkRunDetailLevel: "standard",
+  reviewCheckMode: "required",
+  gatePack: "gittensor",
+  linkedIssueGateMode: "advisory",
+  duplicatePrGateMode: "advisory",
+  qualityGateMode: "advisory",
+  qualityGateMinScore: null,
+  mergeReadinessGateMode: "off",
+  manifestPolicyGateMode: "off",
+  firstTimeContributorGrace: false,
+  slopGateMode: "off",
+  slopGateMinScore: null,
+  slopAiAdvisory: false,
+  autoLabelEnabled: true,
+  gittensorLabel: "gittensor",
+  createMissingLabel: true,
+  includeMaintainerAuthors: false,
+  requireLinkedIssue: false,
+  badgeEnabled: false,
+  publicQualityMetrics: false,
+  commandAuthorization: {},
+  autonomy: {},
+  autoMaintain: { requireApprovals: 1, mergeMethod: "squash" },
+  agentPaused: false,
+  agentDryRun: false,
+};
+
+describe("maintainer-settings-editable (#2218)", () => {
+  it("buildMaintainerSettingsSavePayload includes every editable key, verbatim, with no patch", () => {
+    const payload = buildMaintainerSettingsSavePayload(SETTINGS);
+    expect(Object.keys(payload).sort()).toEqual([...MAINTAINER_SETTINGS_EDITABLE_KEYS].sort());
+    expect(payload.linkedIssueGateMode).toBe("advisory");
+    expect(payload.commentMode).toBe("detected_contributors_only");
+  });
+
+  it("buildMaintainerSettingsSavePayload merges a partial patch over the base settings", () => {
+    const payload = buildMaintainerSettingsSavePayload(SETTINGS, {
+      linkedIssueGateMode: "block",
+      duplicatePrGateMode: "block",
+    });
+    expect(payload.linkedIssueGateMode).toBe("block");
+    expect(payload.duplicatePrGateMode).toBe("block");
+    // Untouched fields pass through unchanged.
+    expect(payload.qualityGateMode).toBe("advisory");
+    expect(payload.commentMode).toBe("detected_contributors_only");
+  });
+
+  it("an empty patch object is a no-op (same as omitting it)", () => {
+    expect(buildMaintainerSettingsSavePayload(SETTINGS, {})).toEqual(
+      buildMaintainerSettingsSavePayload(SETTINGS),
+    );
+  });
+});

--- a/apps/gittensory-ui/src/lib/maintainer-settings-editable.ts
+++ b/apps/gittensory-ui/src/lib/maintainer-settings-editable.ts
@@ -1,0 +1,99 @@
+/**
+ * The maintainer-editable repository settings shape, centralized so `maintainer-settings.tsx`'s full editor
+ * and `gate-ramp-control.tsx`'s one-click ramp control (#2218) share one PUT /settings payload builder
+ * instead of two independently-maintained `EDITABLE_KEYS` lists drifting apart.
+ */
+
+export type GateMode = "off" | "advisory" | "block";
+export type CommandRole = "maintainer" | "collaborator" | "pr_author" | "confirmed_miner";
+
+export type CommandAuthorization = {
+  default?: CommandRole[];
+  commands?: Record<string, CommandRole[]>;
+};
+
+export type AutonomyLevel = "observe" | "auto_with_approval" | "auto";
+export type AgentActionClass =
+  "review" | "request_changes" | "approve" | "merge" | "close" | "label";
+export type AutoMergeMethod = "merge" | "squash" | "rebase";
+
+export type MaintainerSettingsEditable = {
+  commentMode: "off" | "detected_contributors_only" | "all_prs";
+  publicAudienceMode: "oss_maintainer" | "gittensor_only";
+  publicSignalLevel: "minimal" | "standard";
+  publicSurface: "off" | "comment_and_label" | "comment_only" | "label_only";
+  checkRunMode: "off" | "enabled";
+  checkRunDetailLevel: "minimal" | "standard";
+  // #4618/#5373: a prior gateCheckMode field was a deprecated computed read-back, since removed entirely --
+  // reviewCheckMode is the real, writable authority for whether the review-agent check-run publishes.
+  reviewCheckMode: "required" | "visible" | "disabled";
+  gatePack: "gittensor" | "oss-anti-slop";
+  linkedIssueGateMode: GateMode;
+  duplicatePrGateMode: GateMode;
+  qualityGateMode: GateMode;
+  qualityGateMinScore: number | null;
+  mergeReadinessGateMode: GateMode;
+  manifestPolicyGateMode: GateMode;
+  firstTimeContributorGrace: boolean;
+  slopGateMode: GateMode;
+  slopGateMinScore: number | null;
+  slopAiAdvisory: boolean;
+  autoLabelEnabled: boolean;
+  gittensorLabel: string;
+  createMissingLabel: boolean;
+  includeMaintainerAuthors: boolean;
+  requireLinkedIssue: boolean;
+  badgeEnabled: boolean;
+  publicQualityMetrics: boolean;
+  commandAuthorization: CommandAuthorization;
+  autonomy: Partial<Record<AgentActionClass, AutonomyLevel>>;
+  autoMaintain: { requireApprovals: number; mergeMethod: AutoMergeMethod };
+  agentPaused: boolean;
+  agentDryRun: boolean;
+};
+
+// The maintainer-editable subset, sent verbatim to PUT /settings (which merges onto current settings).
+export const MAINTAINER_SETTINGS_EDITABLE_KEYS: Array<keyof MaintainerSettingsEditable> = [
+  "commentMode",
+  "publicAudienceMode",
+  "publicSignalLevel",
+  "publicSurface",
+  "checkRunMode",
+  "checkRunDetailLevel",
+  "reviewCheckMode",
+  "gatePack",
+  "linkedIssueGateMode",
+  "duplicatePrGateMode",
+  "qualityGateMode",
+  "qualityGateMinScore",
+  "mergeReadinessGateMode",
+  "manifestPolicyGateMode",
+  "firstTimeContributorGrace",
+  "slopGateMode",
+  "slopGateMinScore",
+  "slopAiAdvisory",
+  "autoLabelEnabled",
+  "gittensorLabel",
+  "createMissingLabel",
+  "includeMaintainerAuthors",
+  "requireLinkedIssue",
+  "badgeEnabled",
+  "publicQualityMetrics",
+  "commandAuthorization",
+  "autonomy",
+  "autoMaintain",
+  "agentPaused",
+  "agentDryRun",
+];
+
+/**
+ * Build the PUT /settings body: every editable key from `settings`, with `patch` merged on top so a caller
+ * (e.g. the gate-ramp control) can flip a handful of fields without hand-copying the other ~25.
+ */
+export function buildMaintainerSettingsSavePayload(
+  settings: MaintainerSettingsEditable,
+  patch: Partial<MaintainerSettingsEditable> = {},
+): Record<string, unknown> {
+  const merged = { ...settings, ...patch };
+  return Object.fromEntries(MAINTAINER_SETTINGS_EDITABLE_KEYS.map((key) => [key, merged[key]]));
+}


### PR DESCRIPTION
## Summary
- The maintainer panel had no one-click way to move a repo from advisory to blocking enforcement — only the full repository settings editor, with no confirmation and no framing of exactly which sub-gates become merge-blocking.
- Adds `GateRampControl` to the maintainer panel (right after the existing activation preview): a switch reflecting the current ramp phase (`inactive` / `advisory` / `blocking`, derived from `reviewCheckMode` + the linked-issue/duplicate-PR/quality gate trio), gated behind an `AlertDialog` confirmation that lists exactly which gates will flip to `block`, saved through the same `PUT /settings` merge path `maintainer-settings.tsx` already uses.
- Extracts the maintainer-editable settings shape and its save-payload builder into a shared `lib/maintainer-settings-editable.ts`, so the new control and the existing settings editor read from one list of editable keys instead of two independently-maintained ones.
- No new API surface, no new dependency — everything routes through the existing `GET/PUT /v1/repos/:owner/:repo/settings` endpoint.

Part of #701.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves — `Closes #2218`.

## Validation

- [x] `git diff --check`
- [x] `npm run ui:kit:build && npm run ui:typecheck` — clean across `@loopover/ui` and `@loopover/ui-miner`.
- [x] `npm run ui:lint` — 0 errors on every touched/new file.
- [x] `npm run ui:test` — full suite green: 221/221 (`@loopover/ui`), 103/103 (`@loopover/ui-miner`). 23 new tests: `gate-ramp.test.ts` (7 — phase derivation, patch building, transition listing), `maintainer-settings-editable.test.ts` (3 — payload building with/without a patch), `gate-ramp-control.test.tsx` (8 — load/advisory display, confirm→save→toast, cancel, save failure, inactive-disabled, already-blocking-disabled, no-repos state, load-error state), plus the existing `maintainer-panel.test.tsx` (4) confirmed no regression.
- [x] `npm run ui:build` — production build succeeds.
- [x] `apps/gittensory-ui/**` sits outside vitest's root `coverage.include` glob, so `codecov/patch` cannot see this diff — test thoroughness is not lowered for that reason (see the branch-by-branch coverage above).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no auth/session/CORS surface touched.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — no new endpoint; the existing `PUT /settings` merge contract is reused unchanged.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks — `StateBoundary` covers loading/error exactly like the sibling `ActivationPreview`/`MaintainerSettings` panels.
- [x] Visible UI changes include a `UI Evidence` section below.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — no docs described this control before; the component's own JSDoc is the source of truth.

## UI Evidence

Captured against a real running dev server (`vite dev`) with Playwright, driving the actual switch → confirm-dialog → save flow end-to-end (not a static mock of the markup):

| Page / Feature | Before (advisory, switch off) | After (blocking, switch on) |
|---|---|---|
| `/app/maintainer` — Gate ramp control | [<img src="https://raw.githubusercontent.com/joaovictor91123/gittensory/screenshots/gate-ramp-before-advisory.png" width="360">](https://raw.githubusercontent.com/joaovictor91123/gittensory/screenshots/gate-ramp-before-advisory.png)<br><sub>before: advisory phase, ramp switch off</sub> | [<img src="https://raw.githubusercontent.com/joaovictor91123/gittensory/screenshots/gate-ramp-after-blocking.png" width="360">](https://raw.githubusercontent.com/joaovictor91123/gittensory/screenshots/gate-ramp-after-blocking.png)<br><sub>after: clicked the switch, confirmed the AlertDialog, blocking phase now active</sub> |

_Click either thumbnail to open the full-size screenshot._

## Notes

- The prior 3-day-old attempt at this issue (#4701) was gate-approved (no blockers, readiness 100/100) but went stale/conflicted before merging. This is a fresh implementation against current `main`, adapted for the removal of the deprecated `gateCheckMode` field (#4618/#5373) since that attempt was opened — `gate-ramp.ts`'s ramp-activity check now derives solely from `reviewCheckMode`.