### PR TITLE
fix(review): never co-approve a PR being closed for unlinked-issue farming

### DIFF
--- a/src/settings/agent-actions.ts
+++ b/src/settings/agent-actions.ts
@@ -1096,8 +1096,12 @@ export function planAgentMaintenanceActions(input: AgentActionPlanInput): Planne
   // Never APPROVE a base-conflicting PR: it is closed below (willClose on isConflict), so a "Gittensory approves —
   // safe to merge" review on a PR we're about to close is incoherent (and a stale approval strands the PR if it
   // later goes green). A `behind`/`blocked` PR is fine to approve (it is rebased pre-review or the approval clears
-  // the block); only a hard `dirty` conflict is excluded here. (#ready-needs-mergeable, the #4220 report) */
-  if (reviewGood && !heldForManualReview && !linkedIssueCloseInFlight && !isConflict && acting("approve") && input.pr.reviewDecision !== "APPROVED" && !alreadyApprovedThisHead) {
+  // the block); only a hard `dirty` conflict is excluded here. (#ready-needs-mergeable, the #4220 report)
+  // `unlinkedIssueMatchViolated` is the ONE close path that fires while `reviewGood` is true (a confirmed repeat
+  // unlinked-issue-match closes a green, clean PR) — it must be excluded here for the same reason, or the bot
+  // co-approves the exact farming PR it is closing. Under close `auto_with_approval` the approval lands while the
+  // close is only staged, leaving a bot-approved PR that branch protection can auto-merge before the close runs. */
+  if (reviewGood && !heldForManualReview && !linkedIssueCloseInFlight && !unlinkedIssueMatchViolated && !isConflict && acting("approve") && input.pr.reviewDecision !== "APPROVED" && !alreadyApprovedThisHead) {
     actions.push({
       actionClass: "approve",
       requiresApproval: approval("approve"),

--- a/test/unit/agent-actions.test.ts
+++ b/test/unit/agent-actions.test.ts
@@ -701,6 +701,19 @@ describe("planAgentMaintenanceActions (#778)", () => {
       expect(plan.find((a) => a.actionClass === "close")?.expectedHeadSha).toBe("abc123");
     });
 
+    it("never co-approves a confirmed unlinked-issue-match close — no incoherent 'approves' review on a PR being closed (gate-review finding)", () => {
+      // Before the fix: the auto-approve guard omitted unlinkedIssueMatchViolated — the ONLY reviewGood close
+      // path — so a green/clean confirmed-farming PR got BOTH a bot "Gittensory approves — safe to merge" review
+      // AND a close. Under close autonomy `auto_with_approval` the approval lands immediately while the close is
+      // only staged, leaving a bot-approved farming PR that branch protection's "require approving reviews" could
+      // auto-merge before the staged close is ever actioned — the exact PR the guardrail exists to stop.
+      for (const close of ["auto", "auto_with_approval"] as const) {
+        const plan = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { approve: "auto", close }, ...repeated, pr: { labels: [], mergeableState: "clean", headSha: "abc123" } }));
+        expect(classes(plan)).toContain("close");
+        expect(classes(plan)).not.toContain("approve");
+      }
+    });
+
     it("cites the repeat-specific reason and the standard close message template, tagged closeKind: heuristic (subject to the precision breaker)", () => {
       const action = planAgentMaintenanceActions(input({ conclusion: "success", autonomy: { close: "auto" }, ...repeated, pr: { labels: [] } })).find((a) => a.actionClass === "close");
       expect(action?.reason).toContain("#42");


### PR DESCRIPTION
## Summary

`planAgentMaintenanceActions` (`src/settings/agent-actions.ts`) auto-approves a PR only when it is not on a close path. The guard already excludes every close path that can reach it — gate failure / red CI (via `reviewGood`), base conflict (`!isConflict`), and a linked-issue hard-rule close (`!linkedIssueCloseInFlight`) — **except** `unlinkedIssueMatchViolated`, which is the **one** close path that fires while `reviewGood` is `true` (a confirmed *repeat* unlinked-issue match closes a green, clean PR — see its own disposition branch and the "closes one-shot even on a green, clean, approved PR" test).

As a result, a **confirmed farming PR** that is green + mergeable-clean received **both** a `Gittensory approves — safe to merge` review **and** a close:

- Under close autonomy `auto` the co-approval is incoherent (an approval on a PR we are closing).
- Under close autonomy `auto_with_approval` it is exploitable: the approval lands immediately while the close is only *staged* for a human, leaving a **bot-approved farming PR** that branch protection's "require approving reviews" rule can auto-merge before the staged close is ever actioned — the exact PR the guardrail exists to stop, and precisely the "a stale approval strands the PR" harm the surrounding comment (the same block, lines ~1096–1099) warns about.

**Fix:** add `!unlinkedIssueMatchViolated` to the approve guard, mirroring its sibling close guards on the same line. No other disposition changes.

Verified: the added regression **fails before** the fix (`plan === ['approve','close']`) and **passes after** (`['close']`, no `approve`), under both `auto` and `auto_with_approval` close autonomy. No linked issue: small, self-evident anti-abuse correctness fix (this repo's `linkedIssuePolicy` is `preferred`, not required); rationale above.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue — N/A; self-evident anti-abuse fix, rationale in Summary.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` — not run (no workflow changes)
- [x] `npm run typecheck` — clean (whole project)
- [x] `npm run test:coverage` — scoped to the changed file: **100% lines**, and both branches of the new `!unlinkedIssueMatchViolated` term are covered (existing approve tests cover the false side; the new regression covers the true side). Full unsharded run not executed in this environment.
- [ ] `npm run test:workers` — not run in this environment
- [ ] `npm run build:mcp` / `test:mcp-pack` — not run (no MCP changes)
- [ ] `npm run ui:openapi:check` / `ui:lint` / `ui:typecheck` / `ui:build` — not run (no UI/API changes)
- [ ] `npm audit --audit-level=moderate` — not run (no dependency changes)
- [x] New behavior has a regression test (both `auto` and `auto_with_approval` close autonomy); the full 265-test `agent-actions` suite stays green.

If any required check was skipped, explain why: only the source-relevant checks were run; the UI/workers/MCP/actionlint/audit jobs touch code paths this diff does not change.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, private keys, trust scores, private rankings, or maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized and low-noise (the approve review body is unchanged; this PR only suppresses it on a close path).
- [ ] Auth/cookie/CORS/GitHub App/Cloudflare/session changes — N/A (none changed).
- [ ] API/OpenAPI/MCP behavior — N/A (unchanged).
- [ ] UI changes / UI Evidence — N/A (no visible change).
- [ ] Public docs/changelogs — N/A.

## Notes

This tightens an existing disposition guard only; it removes an approval action on a close path and changes nothing else about the merge/close verdict or ordering.
