### PR TITLE
test(miner-extension): bring the browser extension under a real coverage gate (#4865)

### DIFF
--- a/apps/gittensory-miner-extension/README.md
+++ b/apps/gittensory-miner-extension/README.md
@@ -35,3 +35,16 @@ quota, instead of silently failing to save or leaving storage partially written.
 (#4860). Chrome match patterns cannot pin a port, so `http://localhost/*` is the narrowest grant the platform
 allows; `https` is intentionally omitted because the local miner-ui dev server is plain HTTP. This is the enabling
 permission for live-fetching ranked candidates from the local miner-ui instead of pasting them.
+
+## Tests & coverage
+
+`npm run test` (`vitest run --coverage`) runs the app-local suite in `test/` and enforces a v8 coverage floor
+(`vitest.config.ts`). It runs wherever `npm run ui:test` / `npm run test:ci` run — no separate CI step. Because
+these are classic (non-bundled) scripts, the tests import the real source files directly (with the source's own
+`globalThis.__GITTENSORY_MINER_EXTENSION_TEST__` internals hook) so coverage attributes to the files, which the
+repo's older `node:vm` harness could not do.
+
+Covered today (#4865): the pure state maps and the background service worker — `toolbar-badge.js`,
+`opportunity-badge.js`, and `background.js`. The two DOM-page scripts — `content.js` (issue-page content script)
+and `options.js` (options-page form) — need a jsdom mount harness and are a documented follow-up; the threshold is
+a real measured baseline (a regression floor), not a target, and should be raised per-PR as those get covered.

--- a/apps/gittensory-miner-extension/package.json
+++ b/apps/gittensory-miner-extension/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "node ../../scripts/build-miner-extension.mjs",
     "lint": "node --check background.js && node --check content.js && node --check opportunity-badge.js && node --check options.js && node --check toolbar-badge.js",
-    "typecheck": "npm run lint"
+    "typecheck": "npm run lint",
+    "test": "vitest run --coverage"
   }
 }

--- a/apps/gittensory-miner-extension/test/background.test.js
+++ b/apps/gittensory-miner-extension/test/background.test.js
@@ -1,0 +1,356 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+function jsonResponse(body, { ok = true, status = 200 } = {}) {
+  return { ok, status, json: async () => body };
+}
+
+// A configurable chrome mock modelled on the shapes background.js's own guards expect. `minimal` omits every
+// optional surface (alarms/action/onChanged/onStartup/onInstalled) so the "clean no-op in a bare environment"
+// guard branches are exercised too.
+function createChrome({
+  syncStore = {},
+  localStore = {},
+  minimal = false,
+  syncGetThrows = false,
+  actionThrows = false,
+} = {}) {
+  const calls = {
+    badgeText: [],
+    badgeColor: [],
+    localSet: [],
+    warn: [],
+    alarmCreate: null,
+    fetched: [],
+  };
+  const listeners = {};
+
+  const chrome = {
+    runtime: {
+      onMessage: { addListener: (fn) => (listeners.message = fn) },
+    },
+    storage: {
+      sync: {
+        get: async (defaults) => {
+          if (syncGetThrows) throw new Error("sync get failed");
+          return { ...(defaults ?? {}), ...syncStore };
+        },
+        set: async () => {},
+        remove: async () => {},
+      },
+      local: {
+        get: async (arg) => {
+          if (typeof arg === "string") {
+            return { [arg]: arg in localStore ? localStore[arg] : undefined };
+          }
+          return { ...(arg ?? {}), ...localStore };
+        },
+        set: async (value) => {
+          calls.localSet.push(value);
+          Object.assign(localStore, value);
+        },
+      },
+    },
+  };
+
+  if (!minimal) {
+    chrome.action = {
+      setBadgeText: async (value) => {
+        calls.badgeText.push(value);
+        if (actionThrows) throw new Error("chrome.action unavailable");
+      },
+      setBadgeBackgroundColor: async (value) => {
+        calls.badgeColor.push(value);
+      },
+    };
+    chrome.storage.onChanged = { addListener: (fn) => (listeners.changed = fn) };
+    chrome.alarms = {
+      create: (name, options) => (calls.alarmCreate = { name, options }),
+      onAlarm: { addListener: (fn) => (listeners.alarm = fn) },
+    };
+    chrome.runtime.onStartup = { addListener: (fn) => (listeners.startup = fn) };
+    chrome.runtime.onInstalled = { addListener: (fn) => (listeners.installed = fn) };
+  }
+
+  return { chrome, calls, listeners };
+}
+
+async function loadBackground(options = {}) {
+  const built = createChrome(options);
+  const fetchImpl = vi.fn(async (url) => {
+    built.calls.fetched.push(url);
+    return options.fetchResponse ?? jsonResponse({ candidates: [{ repoFullName: "a/b", issueNumber: 1 }] });
+  });
+  if (options.fetchThrows) fetchImpl.mockImplementation(async () => {
+    throw new Error("network down");
+  });
+
+  vi.resetModules();
+  vi.stubGlobal("chrome", built.chrome);
+  vi.stubGlobal("fetch", fetchImpl);
+
+  await import("../background.js");
+  await flush();
+
+  return {
+    ...built,
+    fetchImpl,
+    internals: globalThis.__gittensoryMinerBackgroundInternals,
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("background.js message router (#4859)", () => {
+  let sendResponse;
+  beforeEach(() => {
+    sendResponse = vi.fn();
+  });
+
+  it("ignores messages with no/invalid type and returns false (no async response)", async () => {
+    const bg = await loadBackground();
+    expect(bg.listeners.message(null, {}, sendResponse)).toBe(false);
+    expect(bg.listeners.message({ type: 42 }, {}, sendResponse)).toBe(false);
+    expect(sendResponse).not.toHaveBeenCalled();
+  });
+
+  it("answers a ping synchronously", async () => {
+    const bg = await loadBackground();
+    const ret = bg.listeners.message({ type: "gittensory-miner:ping" }, {}, sendResponse);
+    expect(ret).toBe(false);
+    expect(sendResponse).toHaveBeenCalledWith({ ok: true, payload: { ready: true } });
+  });
+
+  it("resolves issue-context asynchronously and keeps the channel open", async () => {
+    const bg = await loadBackground({
+      syncStore: { watchedRepos: ["JSONbored/gittensory"] },
+      localStore: {
+        rankedCandidates: [{ repoFullName: "JSONbored/gittensory", issueNumber: 145, rankScore: 0.8, laneFit: 0.8 }],
+        rankedCandidatesSavedAt: 111,
+      },
+    });
+    const ret = bg.listeners.message(
+      { type: "gittensory-miner:issue-context", owner: "JSONbored", repo: "gittensory", issueNumber: 145 },
+      {},
+      sendResponse,
+    );
+    expect(ret).toBe(true);
+    await flush();
+    expect(sendResponse).toHaveBeenCalledWith({
+      ok: true,
+      payload: expect.objectContaining({ status: "ready", savedAt: 111 }),
+    });
+  });
+
+  it("reports an error payload when issue-context resolution throws", async () => {
+    const bg = await loadBackground({ syncGetThrows: true });
+    bg.listeners.message(
+      { type: "gittensory-miner:issue-context", owner: "o", repo: "r", issueNumber: 1 },
+      {},
+      sendResponse,
+    );
+    await flush();
+    expect(sendResponse).toHaveBeenCalledWith({ ok: false, error: "sync get failed" });
+  });
+
+  it("triggers a live sync and returns its result", async () => {
+    const bg = await loadBackground();
+    const ret = bg.listeners.message({ type: "gittensory-miner:sync-ranked-candidates" }, {}, sendResponse);
+    expect(ret).toBe(true);
+    await flush();
+    expect(sendResponse).toHaveBeenCalledWith({ ok: true, payload: expect.objectContaining({ ok: true, count: 1 }) });
+  });
+
+  it("returns false for an unknown message type", async () => {
+    const bg = await loadBackground();
+    expect(bg.listeners.message({ type: "gittensory-miner:unknown" }, {}, sendResponse)).toBe(false);
+  });
+});
+
+describe("background.js loadIssueOpportunityContext", () => {
+  it("returns repo-not-watched when the repo is not in the watch list", async () => {
+    const bg = await loadBackground({ syncStore: { watchedRepos: ["  ", "owner/other"] } });
+    const payload = await bg.internals.loadIssueOpportunityContext({ owner: "o", repo: "r", issueNumber: 1 });
+    expect(payload).toEqual({
+      watched: false,
+      issueNumber: 1,
+      repoFullName: "o/r",
+      badge: null,
+      status: "repo-not-watched",
+    });
+  });
+
+  it("returns no-signal when watched but no ranked candidate matches", async () => {
+    const bg = await loadBackground({
+      syncStore: { watchedRepos: ["JSONbored/gittensory"] },
+      localStore: { rankedCandidates: [] },
+    });
+    const payload = await bg.internals.loadIssueOpportunityContext({
+      owner: "JSONbored",
+      repo: "gittensory",
+      issueNumber: 145,
+    });
+    expect(payload.status).toBe("no-signal");
+    expect(payload.badge).toBeNull();
+  });
+
+  it("returns a ready badge when a watched repo has a cached ranked candidate", async () => {
+    const bg = await loadBackground({
+      syncStore: { watchedRepos: ["JSONbored/gittensory"] },
+      localStore: {
+        rankedCandidates: [{ repoFullName: "JSONbored/gittensory", issueNumber: 145, rankScore: 0.9, potential: 0.8 }],
+        rankedCandidatesSavedAt: 999,
+      },
+    });
+    const payload = await bg.internals.loadIssueOpportunityContext({
+      owner: "JSONbored",
+      repo: "gittensory",
+      issueNumber: 145,
+    });
+    expect(payload.status).toBe("ready");
+    expect(payload.badge.tier).toBe("High");
+    expect(payload.savedAt).toBe(999);
+  });
+});
+
+describe("background.js storage readers", () => {
+  it("loadMinerExtensionSettings trims/filters a watch list and defaults a non-array to empty", async () => {
+    const withList = await loadBackground({ syncStore: { watchedRepos: ["  JSONbored/gittensory  ", ""] } });
+    expect((await withList.internals.loadMinerExtensionSettings()).watchedRepos).toEqual(["JSONbored/gittensory"]);
+
+    const nonArray = await loadBackground({ syncStore: { watchedRepos: "oops" } });
+    expect((await nonArray.internals.loadMinerExtensionSettings()).watchedRepos).toEqual([]);
+  });
+
+  it("loadRankedCandidates degrades a non-array cache and a non-numeric savedAt safely", async () => {
+    const good = await loadBackground({ localStore: { rankedCandidates: [1, 2], rankedCandidatesSavedAt: 7 } });
+    expect(await good.internals.loadRankedCandidates()).toEqual({ rankedCandidates: [1, 2], savedAt: 7 });
+
+    const bad = await loadBackground({ localStore: { rankedCandidates: "nope", rankedCandidatesSavedAt: "nope" } });
+    expect(await bad.internals.loadRankedCandidates()).toEqual({ rankedCandidates: [], savedAt: null });
+  });
+
+  it("loadMinerUiUrl returns the stored URL, or the default for empty/whitespace/non-string values", async () => {
+    const custom = await loadBackground({ syncStore: { minerUiUrl: "http://localhost:9999" } });
+    expect(await custom.internals.loadMinerUiUrl()).toBe("http://localhost:9999");
+
+    const blank = await loadBackground({ syncStore: { minerUiUrl: "   " } });
+    expect(await blank.internals.loadMinerUiUrl()).toBe("http://localhost:5174");
+
+    const nonString = await loadBackground({ syncStore: { minerUiUrl: 42 } });
+    expect(await nonString.internals.loadMinerUiUrl()).toBe("http://localhost:5174");
+  });
+});
+
+describe("background.js syncRankedCandidatesFromMinerUi (#4859)", () => {
+  it("writes fetched candidates to local storage and reports the count", async () => {
+    const bg = await loadBackground({
+      fetchResponse: jsonResponse({ candidates: [{ issueNumber: 1 }, { issueNumber: 2 }] }),
+    });
+    const result = await bg.internals.syncRankedCandidatesFromMinerUi();
+    expect(result).toMatchObject({ ok: true, count: 2, minerUiUrl: "http://localhost:5174" });
+    expect(bg.calls.localSet.at(-1)).toMatchObject({ rankedCandidates: [{ issueNumber: 1 }, { issueNumber: 2 }] });
+  });
+
+  it("returns a typed failure (never throws) on a non-OK response", async () => {
+    const bg = await loadBackground({ fetchResponse: jsonResponse({}, { ok: false, status: 503 }) });
+    const result = await bg.internals.syncRankedCandidatesFromMinerUi();
+    expect(result).toEqual({ ok: false, error: "miner UI responded 503", minerUiUrl: "http://localhost:5174" });
+  });
+
+  it("rejects an unexpected payload shape", async () => {
+    const bg = await loadBackground({ fetchResponse: jsonResponse({ candidates: "not-an-array" }) });
+    const result = await bg.internals.syncRankedCandidatesFromMinerUi();
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/unexpected payload shape/);
+  });
+
+  it("swallows a thrown fetch into a typed failure result", async () => {
+    const bg = await loadBackground({ fetchThrows: true });
+    const result = await bg.internals.syncRankedCandidatesFromMinerUi();
+    expect(result).toEqual({ ok: false, error: "network down", minerUiUrl: "http://localhost:5174" });
+  });
+});
+
+describe("background.js toolbar-badge wiring (#5193)", () => {
+  it("paints the badge on startup from the current cache", async () => {
+    const bg = await loadBackground({ localStore: { rankedCandidates: [1, 2] } });
+    expect(bg.calls.badgeText).toContainEqual({ text: "2" });
+  });
+
+  it("refreshToolbarBadge maps never-populated / empty / populated caches through chrome.action", async () => {
+    const never = await loadBackground({});
+    never.calls.badgeText.length = 0;
+    await never.internals.refreshToolbarBadge();
+    expect(never.calls.badgeText.at(-1)).toEqual({ text: "–" });
+
+    const populated = await loadBackground({ localStore: { rankedCandidates: [{}, {}, {}, {}] } });
+    populated.calls.badgeText.length = 0;
+    await populated.internals.refreshToolbarBadge();
+    expect(populated.calls.badgeText.at(-1)).toEqual({ text: "4" });
+  });
+
+  it("repaints on a local rankedCandidates change and ignores other keys/areas", async () => {
+    const bg = await loadBackground({ localStore: { rankedCandidates: [9] } });
+    bg.calls.badgeText.length = 0;
+
+    bg.listeners.changed({ rankedCandidates: { newValue: [9] } }, "local");
+    await flush();
+    expect(bg.calls.badgeText).toHaveLength(1);
+
+    bg.calls.badgeText.length = 0;
+    bg.listeners.changed({ rankedCandidates: { newValue: [9] } }, "sync");
+    bg.listeners.changed({ watchedRepos: { newValue: [] } }, "local");
+    await flush();
+    expect(bg.calls.badgeText).toHaveLength(0);
+  });
+
+  it("swallows a rejected chrome.action call so the void-called refresh never leaks a rejection", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const bg = await loadBackground({ localStore: { rankedCandidates: [1] }, actionThrows: true });
+    await expect(bg.internals.refreshToolbarBadge()).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalled();
+  });
+});
+
+describe("background.js ambient refresh wiring", () => {
+  it("registers a periodic alarm and syncs when it fires under the right name", async () => {
+    const bg = await loadBackground();
+    expect(bg.calls.alarmCreate?.options).toEqual({ periodInMinutes: 10 });
+
+    bg.fetchImpl.mockClear();
+    bg.listeners.alarm({ name: "some-other-alarm" });
+    await flush();
+    expect(bg.fetchImpl).not.toHaveBeenCalled();
+
+    bg.listeners.alarm({ name: bg.calls.alarmCreate.name });
+    await flush();
+    expect(bg.fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("syncs on service-worker startup and on install", async () => {
+    const bg = await loadBackground();
+
+    bg.fetchImpl.mockClear();
+    bg.listeners.startup();
+    await flush();
+    expect(bg.fetchImpl).toHaveBeenCalledTimes(1);
+
+    bg.fetchImpl.mockClear();
+    bg.listeners.installed();
+    await flush();
+    expect(bg.fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("is a clean no-op (no paint, no throw) when the optional chrome surfaces are absent", async () => {
+    const bg = await loadBackground({ minimal: true, localStore: { rankedCandidates: [1, 2] } });
+    expect(typeof bg.internals.refreshToolbarBadge).toBe("function");
+    expect(bg.calls.badgeText).toHaveLength(0);
+    expect(bg.listeners.changed).toBeUndefined();
+    expect(bg.listeners.alarm).toBeUndefined();
+  });
+});

--- a/apps/gittensory-miner-extension/test/opportunity-badge.test.js
+++ b/apps/gittensory-miner-extension/test/opportunity-badge.test.js
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+
+// opportunity-badge.js ships as a classic (non-ESM-exporting) content script: importing it for its side effect
+// publishes the helper API on globalThis, exactly as the browser loads it ahead of content.js.
+import "../opportunity-badge.js";
+
+const api = globalThis.__gittensoryMinerOpportunityBadge;
+
+describe("opportunity-badge.js API surface", () => {
+  it("publishes the same object on both the runtime global and the test-exports hook", () => {
+    expect(api).toBeTruthy();
+    expect(globalThis.__gittensoryMinerOpportunityBadgeTestExports).toBe(api);
+  });
+});
+
+describe("issueLookupKey", () => {
+  it("builds a normalized repo#issue key, lower-cased and trimmed", () => {
+    expect(api.issueLookupKey("  JSONbored/Gittensory  ", "145")).toBe("jsonbored/gittensory#145");
+    expect(api.issueLookupKey("owner/repo", 7)).toBe("owner/repo#7");
+  });
+
+  it("returns null for missing repo, non-integer, or non-positive issue numbers", () => {
+    expect(api.issueLookupKey("", 1)).toBeNull();
+    expect(api.issueLookupKey(null, 1)).toBeNull();
+    expect(api.issueLookupKey("owner/repo", "not-a-number")).toBeNull();
+    expect(api.issueLookupKey("owner/repo", 1.5)).toBeNull();
+    expect(api.issueLookupKey("owner/repo", 0)).toBeNull();
+    expect(api.issueLookupKey("owner/repo", -3)).toBeNull();
+  });
+});
+
+describe("lookupRankedOpportunity", () => {
+  const ranked = [
+    null,
+    "not-an-object",
+    { repoFullName: "other/repo", issueNumber: 1 },
+    { repoFullName: "JSONbored/gittensory", issueNumber: 145, rankScore: 0.8 },
+  ];
+
+  it("finds the matching entry by repo#issue key, skipping malformed entries", () => {
+    const match = api.lookupRankedOpportunity(ranked, "jsonbored/gittensory", 145);
+    expect(match?.rankScore).toBe(0.8);
+  });
+
+  it("returns null when the target key is unresolvable", () => {
+    expect(api.lookupRankedOpportunity(ranked, "", 145)).toBeNull();
+  });
+
+  it("returns null when the ranked list is not an array", () => {
+    expect(api.lookupRankedOpportunity(undefined, "owner/repo", 1)).toBeNull();
+  });
+
+  it("returns null when no entry matches", () => {
+    expect(api.lookupRankedOpportunity(ranked, "owner/repo", 999)).toBeNull();
+  });
+});
+
+describe("scoreToTier", () => {
+  it("maps finite scores into High/Medium/Low bands", () => {
+    expect(api.scoreToTier(0.9)).toBe("High");
+    expect(api.scoreToTier(0.75)).toBe("High");
+    expect(api.scoreToTier(0.6)).toBe("Medium");
+    expect(api.scoreToTier(0.5)).toBe("Medium");
+    expect(api.scoreToTier(0.2)).toBe("Low");
+  });
+
+  it("returns Unknown for a non-finite score", () => {
+    expect(api.scoreToTier("nope")).toBe("Unknown");
+    expect(api.scoreToTier(Number.NaN)).toBe("Unknown");
+  });
+});
+
+describe("buildOpportunityWhy", () => {
+  it("surfaces the strongest signals, capped at two, joined with a semicolon", () => {
+    const why = api.buildOpportunityWhy({ laneFit: 0.9, freshness: 0.9, potential: 0.9 });
+    expect(why).toBe("Strong lane fit; Fresh issue");
+  });
+
+  it("recognizes each individual signal threshold", () => {
+    expect(api.buildOpportunityWhy({ potential: 0.7 })).toBe("High reward potential");
+    expect(api.buildOpportunityWhy({ feasibility: 0.7 })).toBe("Feasible scope");
+    expect(api.buildOpportunityWhy({ dupRisk: 0.3 })).toBe("Low duplicate risk");
+  });
+
+  it("falls back to a balanced-signals message when nothing crosses a threshold", () => {
+    expect(api.buildOpportunityWhy({ laneFit: 0.1, dupRisk: 0.9 })).toBe("Balanced opportunity signals");
+  });
+});
+
+describe("formatOpportunityBadge", () => {
+  it("formats tier, a two-decimal score, and passes through the numeric rankScore", () => {
+    expect(api.formatOpportunityBadge({ rankScore: 0.812, laneFit: 0.8 })).toEqual({
+      tier: "High",
+      score: "0.81",
+      why: "Strong lane fit",
+      rankScore: 0.812,
+    });
+  });
+
+  it("degrades a non-finite rankScore to an em-dash score and a null rankScore", () => {
+    const badge = api.formatOpportunityBadge({ rankScore: "n/a" });
+    expect(badge.tier).toBe("Unknown");
+    expect(badge.score).toBe("—");
+    expect(badge.rankScore).toBeNull();
+  });
+});
+
+describe("formatLastSyncedLabel (#5192)", () => {
+  const NOW = Date.parse("2026-07-10T12:00:00.000Z");
+
+  it("buckets the delta the same way ORB's RefreshMeta does", () => {
+    expect(api.formatLastSyncedLabel(NOW, NOW)).toBe("last synced just now");
+    expect(api.formatLastSyncedLabel(NOW - 59_000, NOW)).toBe("last synced just now");
+    expect(api.formatLastSyncedLabel(NOW - 60_000, NOW)).toBe("last synced 1m ago");
+    expect(api.formatLastSyncedLabel(NOW - 59 * 60_000, NOW)).toBe("last synced 59m ago");
+    expect(api.formatLastSyncedLabel(NOW - 60 * 60_000, NOW)).toBe("last synced 1h ago");
+    expect(api.formatLastSyncedLabel(NOW - 23 * 60 * 60_000, NOW)).toBe("last synced 23h ago");
+    expect(api.formatLastSyncedLabel(NOW - 24 * 60 * 60_000, NOW)).toBe("last synced 1d ago");
+  });
+
+  it("clamps a future timestamp to just now rather than a negative delta", () => {
+    expect(api.formatLastSyncedLabel(NOW + 5_000, NOW)).toBe("last synced just now");
+  });
+
+  it("returns null for a missing or invalid timestamp (never the epoch)", () => {
+    expect(api.formatLastSyncedLabel(null, NOW)).toBeNull();
+    expect(api.formatLastSyncedLabel(undefined, NOW)).toBeNull();
+    expect(api.formatLastSyncedLabel(Number.NaN, NOW)).toBeNull();
+    expect(api.formatLastSyncedLabel("", NOW)).toBeNull();
+    expect(api.formatLastSyncedLabel("not-a-timestamp", NOW)).toBeNull();
+  });
+});
+
+describe("escapeOpportunityHtml", () => {
+  it("escapes every HTML-significant character", () => {
+    expect(api.escapeOpportunityHtml(`&<>"'`)).toBe("&amp;&lt;&gt;&quot;&#39;");
+  });
+
+  it("coerces non-strings and leaves safe text untouched", () => {
+    expect(api.escapeOpportunityHtml(42)).toBe("42");
+    expect(api.escapeOpportunityHtml("plain text")).toBe("plain text");
+  });
+});
+
+describe("renderOpportunityBadgeMarkup", () => {
+  const badge = { tier: "High", score: "0.81", why: "Strong lane fit" };
+
+  it("renders the read-only badge markup with escaped, script-free content", () => {
+    const markup = api.renderOpportunityBadgeMarkup(badge);
+    expect(markup).toContain("LoopOver opportunity");
+    expect(markup).toContain("Read-only");
+    expect(markup).toContain("High");
+    expect(markup).not.toContain("<script>");
+  });
+
+  it("includes the last-synced label only when one is present", () => {
+    expect(api.renderOpportunityBadgeMarkup(badge, "last synced 3m ago")).toContain("last synced 3m ago");
+    const without = api.renderOpportunityBadgeMarkup(badge, null);
+    expect(without).not.toContain("last synced");
+    expect(without).not.toContain("NaN");
+  });
+
+  it("returns an empty string for a missing or non-object badge", () => {
+    expect(api.renderOpportunityBadgeMarkup(null)).toBe("");
+    expect(api.renderOpportunityBadgeMarkup("not-an-object")).toBe("");
+  });
+});

--- a/apps/gittensory-miner-extension/test/setup.js
+++ b/apps/gittensory-miner-extension/test/setup.js
@@ -1,0 +1,5 @@
+// These classic (non-bundled) extension scripts expose their internal, otherwise-unexported helpers on
+// `globalThis` only when this flag is set — the same hook the repo's existing node:vm harness uses. Setting it
+// before any test module is imported lets the app-local suite import the real source files directly (so v8 can
+// attribute coverage to them, which a node:vm eval cannot) and reach those internals.
+globalThis.__GITTENSORY_MINER_EXTENSION_TEST__ = true;

--- a/apps/gittensory-miner-extension/test/toolbar-badge.test.js
+++ b/apps/gittensory-miner-extension/test/toolbar-badge.test.js
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  computeToolbarBadge,
+  TOOLBAR_BADGE_EMPTY_COLOR,
+  TOOLBAR_BADGE_HAS_DATA_COLOR,
+  TOOLBAR_BADGE_NO_DATA_TEXT,
+} from "../toolbar-badge.js";
+
+describe("computeToolbarBadge (toolbar-badge.js, #5193)", () => {
+  it("shows the count with the has-data color when candidates are populated", () => {
+    expect(computeToolbarBadge([{}, {}, {}])).toEqual({
+      text: "3",
+      backgroundColor: TOOLBAR_BADGE_HAS_DATA_COLOR,
+    });
+    expect(computeToolbarBadge([{}])).toEqual({
+      text: "1",
+      backgroundColor: TOOLBAR_BADGE_HAS_DATA_COLOR,
+    });
+  });
+
+  it("clears the text (populated-but-empty state) for an empty array", () => {
+    expect(computeToolbarBadge([])).toEqual({
+      text: "",
+      backgroundColor: TOOLBAR_BADGE_EMPTY_COLOR,
+    });
+  });
+
+  it("shows a dash for the never-populated cache (undefined key)", () => {
+    expect(computeToolbarBadge(undefined)).toEqual({
+      text: TOOLBAR_BADGE_NO_DATA_TEXT,
+      backgroundColor: TOOLBAR_BADGE_EMPTY_COLOR,
+    });
+  });
+
+  it("treats any malformed non-array value as no-data (dash), never a numeric count", () => {
+    for (const malformed of [null, "12", 7, { length: 5 }, true]) {
+      expect(computeToolbarBadge(malformed)).toEqual({
+        text: TOOLBAR_BADGE_NO_DATA_TEXT,
+        backgroundColor: TOOLBAR_BADGE_EMPTY_COLOR,
+      });
+    }
+  });
+
+  it("INVARIANT: no-data (never-written or malformed) never renders as a numeric count", () => {
+    for (const noData of [undefined, null, 0, "", { foo: "bar" }]) {
+      const { text } = computeToolbarBadge(noData);
+      expect(text).not.toMatch(/[0-9]/);
+      expect(text).toBe(TOOLBAR_BADGE_NO_DATA_TEXT);
+    }
+  });
+
+  it("exposes stable named constants so source and tests can never drift", () => {
+    expect(TOOLBAR_BADGE_HAS_DATA_COLOR).toBe("#16a34a");
+    expect(TOOLBAR_BADGE_EMPTY_COLOR).toBe("#6b7280");
+    expect(TOOLBAR_BADGE_NO_DATA_TEXT).toBe("–");
+  });
+
+  it("mirrors the pure map onto the global the background service worker reads", () => {
+    const api = globalThis.__gittensoryMinerToolbarBadge;
+    expect(api.computeToolbarBadge).toBe(computeToolbarBadge);
+    expect(api.TOOLBAR_BADGE_HAS_DATA_COLOR).toBe(TOOLBAR_BADGE_HAS_DATA_COLOR);
+    expect(api.TOOLBAR_BADGE_EMPTY_COLOR).toBe(TOOLBAR_BADGE_EMPTY_COLOR);
+    expect(api.TOOLBAR_BADGE_NO_DATA_TEXT).toBe(TOOLBAR_BADGE_NO_DATA_TEXT);
+  });
+});

--- a/apps/gittensory-miner-extension/vitest.config.ts
+++ b/apps/gittensory-miner-extension/vitest.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["test/**/*.test.js"],
+    setupFiles: ["test/setup.js"],
+    coverage: {
+      provider: "v8",
+      // Only the source files this app-local suite actually imports (so v8 attributes real coverage). The two
+      // DOM-page scripts — content.js (issue-page content script) and options.js (options-page form) — need a
+      // jsdom mount harness and are deliberately left for a follow-up (#4865 stays open), mirroring how the
+      // miner-ui half (#5613) shipped a baseline rather than everything at once.
+      include: ["background.js", "opportunity-badge.js", "toolbar-badge.js"],
+      reporter: ["text", "lcov"],
+      // A real measured baseline (#4865: "establish a coverage baseline"), not an aspirational target — a floor
+      // that catches a genuine regression (a big untested addition), with a couple points of buffer below the
+      // measured value (100% statements/functions/lines, 96.63% branches the day this was wired) so routine
+      // refactor churn doesn't false-fail. Raise it incrementally, per-PR, as the deferred DOM-page scripts and
+      // background.js's remaining guard branches get covered.
+      thresholds: {
+        statements: 98,
+        branches: 94,
+        functions: 98,
+        lines: 98,
+      },
+    },
+  },
+});

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "ui:preview": "npm run ui:build && wrangler dev --config apps/gittensory-ui/dist/server/wrangler.json --ip 127.0.0.1 --port 4173 --local",
     "ui:lint": "npm run ui:kit:build && npm --workspace @loopover/ui run lint && npm --workspace @loopover/ui-miner run lint",
     "ui:typecheck": "npm run ui:kit:build && npm --workspace @loopover/ui run typecheck && npm --workspace @loopover/ui-miner run typecheck",
-    "ui:test": "npm run ui:kit:build && npm --workspace @loopover/ui run test && npm --workspace @loopover/ui-miner run test",
+    "ui:test": "npm run ui:kit:build && npm --workspace @loopover/ui run test && npm --workspace @loopover/ui-miner run test && npm --workspace @jsonbored/gittensory-miner-extension run test",
     "ui:openapi": "tsx scripts/write-ui-openapi.ts",
     "ui:openapi:check": "tsx scripts/write-ui-openapi.ts --check",
     "ui:openapi:settings-parity": "tsx scripts/check-openapi-settings-parity.mjs",


### PR DESCRIPTION
## Summary

- `apps/gittensory-miner-extension` was excluded from coverage via the root `vitest.config.ts` blanket
  `coverage.exclude: ["apps/**"]`, and its existing behavior tests (`test/unit/miner-*.test.ts`) run the
  source through a `node:vm` harness, which v8 cannot attribute coverage to. This PR gives the extension a
  real, measured coverage gate — the extension half of #4865 (the miner-ui half shipped in #5613).
- Adds an app-local, **import-based** vitest suite (`apps/gittensory-miner-extension/test/`) that imports the
  real source files directly — using the source's own `globalThis.__GITTENSORY_MINER_EXTENSION_TEST__`
  internals hook — so v8 attributes coverage to the files. Covers the pure state maps and the background
  service worker: `toolbar-badge.js`, `opportunity-badge.js`, and `background.js` (52 tests).
- Adds a `coverage` block + measured baseline `thresholds` to a new `apps/gittensory-miner-extension/vitest.config.ts`
  (v8; `include` scoped to the three covered files), and changes the app's `test` script to `vitest run --coverage`.
- Wires the app's `test` into the root `ui:test`, so the gate runs wherever `npm run ui:test` / `npm run test:ci`
  already run — no new CI step.
- Documents the gate and the deferred scope in the app README.

The two DOM-page scripts — `content.js` (issue-page content script) and `options.js` (options-page form) — need
a jsdom mount harness and are deliberately left for a follow-up. The threshold is a real measured baseline
(100% statements/functions/lines, 96.63% branches the day this was wired), a regression floor with a small
buffer, not an aspirational target — to be raised per-PR as the deferred scripts get covered.

Advances #4865 (not closing it — the `content.js`/`options.js` coverage half is still open).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR advances (#4865) — the extension half of an issue whose
      miner-ui half merged in #5613.

## Validation

- [x] `git diff --check`
- [x] `npm --workspace @jsonbored/gittensory-miner-extension run test` — 52 passing; coverage 100% stmts /
      96.63% branches / 100% funcs / 100% lines, over the configured floor
- [x] `npm run docs:drift-check`
- [ ] `npm run test:ci` (full local gate) — run before merge
- [ ] `npm audit --audit-level=moderate`

If any required check was skipped, explain why:

- This is a test-, config-, and README-only change under `apps/gittensory-miner-extension/**`, which Codecov
  ignores (`apps/**`), so it owes no `codecov/patch` coverage; the new gate is the app's own vitest threshold.
  It touches no `src/**`, no other workspace's source, no OpenAPI/MCP/wrangler/migrations, so those generated
  artifacts and their drift checks are unaffected.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, private keys, trust scores, or private rankings exposed.
- [x] Public GitHub text stays sanitized and low-noise.
- [x] Auth/cookie/CORS/session — n/a (no such changes; the extension makes no write to GitHub).
- [x] API/OpenAPI/MCP — n/a (no behavior change).
- [x] UI changes use real states — n/a (no runtime/UI change; tests + config + docs only).
- [ ] Visible UI changes include a `UI Evidence` section — n/a: no user-visible UI or extension-behavior change.
- [x] Public docs updated (app README); no changelog edited.

## UI Evidence

No visible UI or extension-behavior change. This PR only adds a test suite, a coverage-gate config, a `test`
script, and a dev-facing README section — there is no user-facing surface to screenshot (same as the miner-ui
coverage-gate PR #5613).

## Notes

- The existing `node:vm`-based tests in root `test/unit/` are left in place as behavior tests; the new
  app-local suite's role is coverage instrumentation the `vm` harness structurally cannot provide.