### PR TITLE
test(miner-extension): bring the miner extension under a real coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,6 +389,10 @@ jobs:
       - name: Extension typecheck
         if: ${{ github.event_name == 'push' || needs.changes.outputs.ui == 'true' }}
         run: npm run extension:typecheck && npm run miner-extension:typecheck
+      # gittensory-extension has no test suite of its own yet; only the miner extension is covered (#4865).
+      - name: Extension tests
+        if: ${{ github.event_name == 'push' || needs.changes.outputs.ui == 'true' }}
+        run: npm run miner-extension:test
       # `npm run ui:build` also regenerates apps/gittensory-ui/public/openapi.json (needed for a
       # standalone build), but this step's trigger condition is a strict subset of "OpenAPI drift
       # check" above (push || ui==true, vs. push || ui==true || uiContract==true), so whenever this

--- a/apps/gittensory-miner-extension/README.md
+++ b/apps/gittensory-miner-extension/README.md
@@ -28,6 +28,14 @@ The extension does not request the `unlimitedStorage` permission, so a paste is 
 being parsed or saved once it exceeds a conservative size bound well under `chrome.storage.local`'s default 10 MiB
 quota, instead of silently failing to save or leaving storage partially written.
 
+## Testing (#4865)
+
+`npm run test` runs the extension's vitest suite (one `*.test.js` file per source file) under a real coverage
+gate — each source file exposes its testable internals on `globalThis` behind a `__GITTENSORY_MINER_EXTENSION_TEST__`
+guard (e.g. `background.js` → `globalThis.__gittensoryMinerBackgroundInternals`), so tests import the file directly
+(a dynamic `import()`, after setting that flag and any needed `chrome.*`/`fetch` mocks) rather than needing a
+separate browser-extension test harness. `vitest.config.ts` documents the measured coverage baseline.
+
 ## Host permissions
 
 `manifest.json` grants `https://github.com/*` (for the issue-page content script) plus loopback host permissions —

--- a/apps/gittensory-miner-extension/background.test.js
+++ b/apps/gittensory-miner-extension/background.test.js
@@ -1,0 +1,341 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/** Builds a fresh chrome mock. Every optional surface (alarms, onStartup, onInstalled, action +
+ *  storage.onChanged) is individually toggleable so both sides of background.js's `if (chrome.X)`
+ *  guards get exercised. */
+function buildChromeMock({ withAlarms = true, withOnStartup = true, withOnInstalled = true, withActionAndOnChanged = true } = {}) {
+  const messageListeners = [];
+  const alarmListeners = [];
+  const startupListeners = [];
+  const installedListeners = [];
+  const storageChangedListeners = [];
+
+  const chrome = {
+    runtime: {
+      onMessage: { addListener: (fn) => messageListeners.push(fn) },
+    },
+    storage: {
+      sync: { get: vi.fn(async (defaults) => ({ ...defaults })) },
+      local: {
+        get: vi.fn(async (defaults) => ({ ...defaults })),
+        set: vi.fn(async () => {}),
+      },
+    },
+    action: withActionAndOnChanged
+      ? { setBadgeText: vi.fn(async () => {}), setBadgeBackgroundColor: vi.fn(async () => {}) }
+      : undefined,
+  };
+  if (withAlarms) {
+    chrome.alarms = {
+      create: vi.fn(),
+      onAlarm: { addListener: (fn) => alarmListeners.push(fn) },
+    };
+  }
+  if (withOnStartup) chrome.runtime.onStartup = { addListener: (fn) => startupListeners.push(fn) };
+  if (withOnInstalled) chrome.runtime.onInstalled = { addListener: (fn) => installedListeners.push(fn) };
+  if (withActionAndOnChanged) {
+    chrome.storage.onChanged = { addListener: (fn) => storageChangedListeners.push(fn) };
+  }
+
+  return { chrome, messageListeners, alarmListeners, startupListeners, installedListeners, storageChangedListeners };
+}
+
+/** Imports a fresh copy of background.js (and its two auto-imported siblings) against the given
+ *  chrome mock. Must use a dynamic import -- a static one would be hoisted above the globalThis
+ *  assignments below and run before __GITTENSORY_MINER_EXTENSION_TEST__ / chrome are set. */
+async function loadBackground(chromeMock) {
+  vi.resetModules();
+  globalThis.__GITTENSORY_MINER_EXTENSION_TEST__ = true;
+  globalThis.chrome = chromeMock.chrome;
+  await import("./background.js");
+  return globalThis.__gittensoryMinerBackgroundInternals;
+}
+
+describe("background.js", () => {
+  afterEach(() => {
+    delete globalThis.chrome;
+    vi.unstubAllGlobals();
+  });
+
+  describe("message routing", () => {
+    it("responds synchronously to a ping message", async () => {
+      const mock = buildChromeMock();
+      const internals = await loadBackground(mock);
+      const sendResponse = vi.fn();
+      const keepChannelOpen = mock.messageListeners[0]({ type: internals.PING_MESSAGE }, {}, sendResponse);
+      expect(sendResponse).toHaveBeenCalledWith({ ok: true, payload: { ready: true } });
+      expect(keepChannelOpen).toBe(false);
+    });
+
+    it("ignores a message with no type", async () => {
+      const mock = buildChromeMock();
+      await loadBackground(mock);
+      const sendResponse = vi.fn();
+      expect(mock.messageListeners[0](null, {}, sendResponse)).toBe(false);
+      expect(mock.messageListeners[0]({}, {}, sendResponse)).toBe(false);
+      expect(sendResponse).not.toHaveBeenCalled();
+    });
+
+    it("returns true (async channel) and resolves an issue-context message", async () => {
+      const mock = buildChromeMock();
+      mock.chrome.storage.sync.get.mockResolvedValue({ watchedRepos: ["owner/repo"] });
+      mock.chrome.storage.local.get.mockResolvedValue({ rankedCandidates: [], rankedCandidatesSavedAt: null });
+      const internals = await loadBackground(mock);
+      const sendResponse = vi.fn();
+      const keepChannelOpen = mock.messageListeners[0](
+        { type: internals.ISSUE_CONTEXT_MESSAGE, owner: "owner", repo: "repo", issueNumber: 1 },
+        {},
+        sendResponse,
+      );
+      expect(keepChannelOpen).toBe(true);
+      await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
+      expect(sendResponse).toHaveBeenCalledWith(expect.objectContaining({ ok: true }));
+    });
+
+    it("responds with ok:false when the issue-context handler throws", async () => {
+      const mock = buildChromeMock();
+      mock.chrome.storage.sync.get.mockRejectedValue(new Error("boom"));
+      const internals = await loadBackground(mock);
+      const sendResponse = vi.fn();
+      mock.messageListeners[0](
+        { type: internals.ISSUE_CONTEXT_MESSAGE, owner: "o", repo: "r", issueNumber: 1 },
+        {},
+        sendResponse,
+      );
+      await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
+      expect(sendResponse).toHaveBeenCalledWith({ ok: false, error: "boom" });
+    });
+
+    it("returns true (async channel) and resolves a sync-ranked-candidates message", async () => {
+      const mock = buildChromeMock();
+      globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ candidates: [] }) });
+      const internals = await loadBackground(mock);
+      const sendResponse = vi.fn();
+      const keepChannelOpen = mock.messageListeners[0]({ type: internals.SYNC_RANKED_CANDIDATES_MESSAGE }, {}, sendResponse);
+      expect(keepChannelOpen).toBe(true);
+      await vi.waitFor(() => expect(sendResponse).toHaveBeenCalled());
+      expect(sendResponse).toHaveBeenCalledWith(expect.objectContaining({ ok: true }));
+      delete globalThis.fetch;
+    });
+
+    it("ignores an unrecognized message type", async () => {
+      const mock = buildChromeMock();
+      await loadBackground(mock);
+      const sendResponse = vi.fn();
+      expect(mock.messageListeners[0]({ type: "some-other-message" }, {}, sendResponse)).toBe(false);
+      expect(sendResponse).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("loadIssueOpportunityContext", () => {
+    it("reports repo-not-watched when the repo isn't in watchedRepos", async () => {
+      const mock = buildChromeMock();
+      mock.chrome.storage.sync.get.mockResolvedValue({ watchedRepos: ["other/repo"] });
+      const internals = await loadBackground(mock);
+      const result = await internals.loadIssueOpportunityContext({ owner: "owner", repo: "repo", issueNumber: 1 });
+      expect(result).toMatchObject({ watched: false, status: "repo-not-watched", badge: null });
+    });
+
+    it("reports no-signal when watched but no ranked entry exists", async () => {
+      const mock = buildChromeMock();
+      mock.chrome.storage.sync.get.mockResolvedValue({ watchedRepos: ["OWNER/REPO"] });
+      mock.chrome.storage.local.get.mockResolvedValue({ rankedCandidates: [], rankedCandidatesSavedAt: null });
+      const internals = await loadBackground(mock);
+      const result = await internals.loadIssueOpportunityContext({ owner: "owner", repo: "repo", issueNumber: 1 });
+      expect(result).toMatchObject({ watched: true, status: "no-signal", badge: null });
+    });
+
+    it("reports ready with a formatted badge when a ranked entry matches", async () => {
+      const mock = buildChromeMock();
+      mock.chrome.storage.sync.get.mockResolvedValue({ watchedRepos: ["owner/repo"] });
+      mock.chrome.storage.local.get.mockResolvedValue({
+        rankedCandidates: [{ repoFullName: "owner/repo", issueNumber: 1, rankScore: 0.9 }],
+        rankedCandidatesSavedAt: 123,
+      });
+      const internals = await loadBackground(mock);
+      const result = await internals.loadIssueOpportunityContext({ owner: "owner", repo: "repo", issueNumber: 1 });
+      expect(result).toMatchObject({ watched: true, status: "ready", savedAt: 123 });
+      expect(result.badge).toMatchObject({ tier: "High" });
+    });
+  });
+
+  describe("loadMinerExtensionSettings", () => {
+    it("trims and filters blank watched repos", async () => {
+      const mock = buildChromeMock();
+      mock.chrome.storage.sync.get.mockResolvedValue({ watchedRepos: [" owner/repo ", "", "  "] });
+      const internals = await loadBackground(mock);
+      expect(await internals.loadMinerExtensionSettings()).toEqual({ watchedRepos: ["owner/repo"] });
+    });
+
+    it("degrades a malformed (non-array) stored value to an empty list", async () => {
+      const mock = buildChromeMock();
+      mock.chrome.storage.sync.get.mockResolvedValue({ watchedRepos: "not-an-array" });
+      const internals = await loadBackground(mock);
+      expect(await internals.loadMinerExtensionSettings()).toEqual({ watchedRepos: [] });
+    });
+  });
+
+  describe("loadRankedCandidates", () => {
+    it("degrades a malformed rankedCandidates value to an empty array with a null savedAt", async () => {
+      const mock = buildChromeMock();
+      mock.chrome.storage.local.get.mockResolvedValue({ rankedCandidates: "nope", rankedCandidatesSavedAt: "nope" });
+      const internals = await loadBackground(mock);
+      expect(await internals.loadRankedCandidates()).toEqual({ rankedCandidates: [], savedAt: null });
+    });
+
+    it("passes through a well-formed value", async () => {
+      const mock = buildChromeMock();
+      mock.chrome.storage.local.get.mockResolvedValue({ rankedCandidates: [{ a: 1 }], rankedCandidatesSavedAt: 999 });
+      const internals = await loadBackground(mock);
+      expect(await internals.loadRankedCandidates()).toEqual({ rankedCandidates: [{ a: 1 }], savedAt: 999 });
+    });
+  });
+
+  describe("loadMinerUiUrl", () => {
+    it("falls back to the default when the stored URL is blank", async () => {
+      const mock = buildChromeMock();
+      mock.chrome.storage.sync.get.mockResolvedValue({ minerUiUrl: "   " });
+      const internals = await loadBackground(mock);
+      expect(await internals.loadMinerUiUrl()).toBe(internals.DEFAULT_MINER_UI_URL);
+    });
+
+    it("trims and returns a stored URL", async () => {
+      const mock = buildChromeMock();
+      mock.chrome.storage.sync.get.mockResolvedValue({ minerUiUrl: " http://example.test  " });
+      const internals = await loadBackground(mock);
+      expect(await internals.loadMinerUiUrl()).toBe("http://example.test");
+    });
+  });
+
+  describe("syncRankedCandidatesFromMinerUi", () => {
+    it("stores candidates and returns ok:true on a well-formed response", async () => {
+      const mock = buildChromeMock();
+      globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ candidates: [{ a: 1 }, { b: 2 }] }) });
+      const internals = await loadBackground(mock);
+      const result = await internals.syncRankedCandidatesFromMinerUi();
+      expect(result).toMatchObject({ ok: true, count: 2 });
+      expect(mock.chrome.storage.local.set).toHaveBeenCalledWith(
+        expect.objectContaining({ rankedCandidates: [{ a: 1 }, { b: 2 }] }),
+      );
+      delete globalThis.fetch;
+    });
+
+    it("returns ok:false without writing storage on a non-2xx response", async () => {
+      const mock = buildChromeMock();
+      globalThis.fetch = vi.fn().mockResolvedValue({ ok: false, status: 500 });
+      const internals = await loadBackground(mock);
+      const result = await internals.syncRankedCandidatesFromMinerUi();
+      expect(result).toMatchObject({ ok: false, error: "miner UI responded 500" });
+      expect(mock.chrome.storage.local.set).not.toHaveBeenCalled();
+      delete globalThis.fetch;
+    });
+
+    it("returns ok:false for a malformed payload shape", async () => {
+      const mock = buildChromeMock();
+      globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ nope: true }) });
+      const internals = await loadBackground(mock);
+      const result = await internals.syncRankedCandidatesFromMinerUi();
+      expect(result).toMatchObject({ ok: false, error: "miner UI returned an unexpected payload shape" });
+      delete globalThis.fetch;
+    });
+
+    it("returns ok:false with the error message when fetch itself throws", async () => {
+      const mock = buildChromeMock();
+      globalThis.fetch = vi.fn().mockRejectedValue(new Error("network down"));
+      const internals = await loadBackground(mock);
+      const result = await internals.syncRankedCandidatesFromMinerUi();
+      expect(result).toMatchObject({ ok: false, error: "network down" });
+      delete globalThis.fetch;
+    });
+  });
+
+  describe("refreshToolbarBadge", () => {
+    it("computes and applies the badge from stored rankedCandidates", async () => {
+      const mock = buildChromeMock();
+      mock.chrome.storage.local.get.mockResolvedValue({ rankedCandidates: [{}, {}] });
+      const internals = await loadBackground(mock);
+      await internals.refreshToolbarBadge();
+      expect(mock.chrome.action.setBadgeText).toHaveBeenCalledWith({ text: "2" });
+      expect(mock.chrome.action.setBadgeBackgroundColor).toHaveBeenCalledWith(expect.objectContaining({ color: expect.any(String) }));
+    });
+
+    it("swallows a chrome.storage failure instead of throwing", async () => {
+      const mock = buildChromeMock();
+      mock.chrome.storage.local.get.mockRejectedValue(new Error("storage error"));
+      const internals = await loadBackground(mock);
+      await expect(internals.refreshToolbarBadge()).resolves.toBeUndefined();
+    });
+  });
+
+  describe("optional-API guards (alarms / onStartup / onInstalled / action+onChanged)", () => {
+    it("wires the alarm + onAlarm listener when chrome.alarms is present, and filters by alarm name", async () => {
+      const mock = buildChromeMock({ withAlarms: true });
+      globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ candidates: [] }) });
+      await loadBackground(mock);
+      expect(mock.chrome.alarms.create).toHaveBeenCalledWith(
+        "gittensory-miner:sync-ranked-candidates",
+        expect.objectContaining({ periodInMinutes: expect.any(Number) }),
+      );
+      expect(mock.alarmListeners).toHaveLength(1);
+      // A differently-named alarm must be ignored (no throw, no extra fetch assertions needed -- just exercises the branch).
+      mock.alarmListeners[0]({ name: "some-other-alarm" });
+      mock.alarmListeners[0]({ name: "gittensory-miner:sync-ranked-candidates" });
+      delete globalThis.fetch;
+    });
+
+    it("skips alarm wiring entirely when chrome.alarms is absent", async () => {
+      const mock = buildChromeMock({ withAlarms: false });
+      await loadBackground(mock);
+      expect(mock.alarmListeners).toHaveLength(0);
+    });
+
+    it("wires onStartup when present and skips it when absent", async () => {
+      const withStartup = buildChromeMock({ withOnStartup: true });
+      globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ candidates: [] }) });
+      await loadBackground(withStartup);
+      expect(withStartup.startupListeners).toHaveLength(1);
+
+      const withoutStartup = buildChromeMock({ withOnStartup: false });
+      await loadBackground(withoutStartup);
+      expect(withoutStartup.startupListeners).toHaveLength(0);
+      delete globalThis.fetch;
+    });
+
+    it("wires onInstalled when present and skips it when absent", async () => {
+      const withInstalled = buildChromeMock({ withOnInstalled: true });
+      globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ candidates: [] }) });
+      await loadBackground(withInstalled);
+      expect(withInstalled.installedListeners).toHaveLength(1);
+
+      const withoutInstalled = buildChromeMock({ withOnInstalled: false });
+      await loadBackground(withoutInstalled);
+      expect(withoutInstalled.installedListeners).toHaveLength(0);
+      delete globalThis.fetch;
+    });
+
+    it("paints the toolbar badge and wires storage.onChanged when action+onChanged are present", async () => {
+      const mock = buildChromeMock({ withActionAndOnChanged: true });
+      mock.chrome.storage.local.get.mockResolvedValue({ rankedCandidates: [{}] });
+      await loadBackground(mock);
+      await vi.waitFor(() => expect(mock.chrome.action.setBadgeText).toHaveBeenCalled());
+      expect(mock.storageChangedListeners).toHaveLength(1);
+
+      mock.chrome.action.setBadgeText.mockClear();
+      // areaName !== "local" must be ignored.
+      mock.storageChangedListeners[0]({ rankedCandidates: {} }, "sync");
+      expect(mock.chrome.action.setBadgeText).not.toHaveBeenCalled();
+      // a "local" change with no rankedCandidates key must also be ignored.
+      mock.storageChangedListeners[0]({ someOtherKey: {} }, "local");
+      expect(mock.chrome.action.setBadgeText).not.toHaveBeenCalled();
+      // a genuine local rankedCandidates change triggers a repaint.
+      mock.storageChangedListeners[0]({ rankedCandidates: {} }, "local");
+      await vi.waitFor(() => expect(mock.chrome.action.setBadgeText).toHaveBeenCalled());
+    });
+
+    it("skips the toolbar-badge paint and onChanged wiring when action or onChanged is absent", async () => {
+      const mock = buildChromeMock({ withActionAndOnChanged: false });
+      await loadBackground(mock);
+      expect(mock.storageChangedListeners).toHaveLength(0);
+    });
+  });
+});

--- a/apps/gittensory-miner-extension/content.test.js
+++ b/apps/gittensory-miner-extension/content.test.js
@@ -1,0 +1,164 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const BADGE_SELECTOR = "[data-gittensory-miner-opportunity-badge]";
+
+function stubBadgeApi() {
+  globalThis.__gittensoryMinerOpportunityBadge = {
+    formatLastSyncedLabel: (savedAt) => (savedAt ? `last synced ${savedAt}` : null),
+    renderOpportunityBadgeMarkup: (badge, label) =>
+      badge ? `<strong>${badge.tier}</strong>${label ? `<span>${label}</span>` : ""}` : "",
+  };
+}
+
+/** Fresh import of content.js at a given pathname, with chrome.runtime.sendMessage mocked to
+ *  resolve with `sendMessageResult`. Must be a dynamic import so the pathname/mock setup below
+ *  runs before content.js's top-level auto-mount logic reads them. */
+async function loadContentAt(pathname, sendMessageResult) {
+  vi.resetModules();
+  window.history.pushState({}, "", pathname);
+  globalThis.__GITTENSORY_MINER_EXTENSION_TEST__ = true;
+  globalThis.chrome = { runtime: { sendMessage: vi.fn().mockResolvedValue(sendMessageResult) } };
+  stubBadgeApi();
+  await import("./content.js");
+  return globalThis.__gittensoryMinerContentInternals;
+}
+
+describe("content.js", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    delete globalThis.chrome;
+    delete globalThis.__gittensoryMinerOpportunityBadge;
+  });
+
+  describe("matchGitHubIssueTarget", () => {
+    it("matches a GitHub issue URL", async () => {
+      const internals = await loadContentAt("/", { ok: false });
+      expect(internals.matchGitHubIssueTarget("/octocat/hello-world/issues/42")).toEqual({
+        kind: "issue",
+        owner: "octocat",
+        repo: "hello-world",
+        issueNumber: 42,
+      });
+    });
+
+    it("matches with a trailing slash or trailing segment", async () => {
+      const internals = await loadContentAt("/", { ok: false });
+      expect(internals.matchGitHubIssueTarget("/octocat/hello-world/issues/42/")).toMatchObject({ issueNumber: 42 });
+    });
+
+    it("returns null for a non-issue path", async () => {
+      const internals = await loadContentAt("/", { ok: false });
+      expect(internals.matchGitHubIssueTarget("/octocat/hello-world/pulls/42")).toBeNull();
+      expect(internals.matchGitHubIssueTarget("/octocat/hello-world")).toBeNull();
+      expect(internals.matchGitHubIssueTarget(null)).toBeNull();
+    });
+  });
+
+  describe("findIssueSidebar", () => {
+    it("prefers #partial-discussion-sidebar over the other fallbacks", async () => {
+      const internals = await loadContentAt("/", { ok: false });
+      document.body.innerHTML = `
+        <div id="partial-discussion-sidebar"></div>
+        <div data-testid="issue-sidebar"></div>
+      `;
+      expect(internals.findIssueSidebar()?.id).toBe("partial-discussion-sidebar");
+    });
+
+    it("falls back through the remaining selectors in order", async () => {
+      const internals = await loadContentAt("/", { ok: false });
+      document.body.innerHTML = `<div class="Layout-sidebar"></div>`;
+      expect(internals.findIssueSidebar()?.className).toBe("Layout-sidebar");
+    });
+
+    it("returns null when nothing matches", async () => {
+      const internals = await loadContentAt("/", { ok: false });
+      document.body.innerHTML = `<div></div>`;
+      expect(internals.findIssueSidebar()).toBeNull();
+    });
+  });
+
+  describe("renderOpportunityBadge", () => {
+    it("removes the container when the payload isn't watched", async () => {
+      const internals = await loadContentAt("/", { ok: false });
+      const container = document.createElement("aside");
+      document.body.appendChild(container);
+      internals.renderOpportunityBadge(container, { watched: false });
+      expect(document.body.contains(container)).toBe(false);
+    });
+
+    it("removes the container when watched but there's no badge", async () => {
+      const internals = await loadContentAt("/", { ok: false });
+      const container = document.createElement("aside");
+      document.body.appendChild(container);
+      internals.renderOpportunityBadge(container, { watched: true, badge: null });
+      expect(document.body.contains(container)).toBe(false);
+    });
+
+    it("removes the container when the badge API produces no markup", async () => {
+      const internals = await loadContentAt("/", { ok: false });
+      globalThis.__gittensoryMinerOpportunityBadge.renderOpportunityBadgeMarkup = () => "";
+      const container = document.createElement("aside");
+      document.body.appendChild(container);
+      internals.renderOpportunityBadge(container, { watched: true, badge: { tier: "High" } });
+      expect(document.body.contains(container)).toBe(false);
+    });
+
+    it("un-hides the container and fills it with markup when ready, including the last-synced label", async () => {
+      const internals = await loadContentAt("/", { ok: false });
+      const container = document.createElement("aside");
+      container.hidden = true;
+      document.body.appendChild(container);
+      internals.renderOpportunityBadge(container, { watched: true, badge: { tier: "High" }, savedAt: 555 }, 1000);
+      expect(container.hidden).toBe(false);
+      expect(container.innerHTML).toContain("High");
+      expect(container.innerHTML).toContain("last synced 555");
+    });
+  });
+
+  describe("auto-mount on import", () => {
+    it("mounts and populates the badge on a watched, ready issue page", async () => {
+      await loadContentAt("/octocat/hello-world/issues/42", {
+        ok: true,
+        payload: { watched: true, badge: { tier: "High" }, savedAt: 42 },
+      });
+      await vi.waitFor(() => {
+        const el = document.querySelector(BADGE_SELECTOR);
+        expect(el).not.toBeNull();
+        expect(el.hidden).toBe(false);
+      });
+    });
+
+    it("mounts into the issue sidebar host when present, otherwise floats in the body", async () => {
+      document.body.innerHTML = `<div id="partial-discussion-sidebar"></div>`;
+      await loadContentAt("/octocat/hello-world/issues/42", {
+        ok: true,
+        payload: { watched: true, badge: { tier: "High" } },
+      });
+      await vi.waitFor(() => {
+        const el = document.querySelector(BADGE_SELECTOR);
+        expect(el).not.toBeNull();
+        expect(document.getElementById("partial-discussion-sidebar").contains(el)).toBe(true);
+        expect(el.className).not.toContain("--floating");
+      });
+    });
+
+    it("removes the mounted container when the background responds ok:false", async () => {
+      await loadContentAt("/octocat/hello-world/issues/42", { ok: false });
+      await vi.waitFor(() => expect(document.querySelector(BADGE_SELECTOR)).toBeNull());
+    });
+
+    it("does not mount anything on a non-issue page", async () => {
+      await loadContentAt("/octocat/hello-world/pulls/1", { ok: false });
+      expect(document.querySelector(BADGE_SELECTOR)).toBeNull();
+    });
+
+    it("does not mount a second badge if one is already present", async () => {
+      document.body.innerHTML = `<aside ${"data-gittensory-miner-opportunity-badge"}="true"></aside>`;
+      await loadContentAt("/octocat/hello-world/issues/42", { ok: false });
+      expect(document.querySelectorAll(BADGE_SELECTOR)).toHaveLength(1);
+    });
+  });
+});

--- a/apps/gittensory-miner-extension/opportunity-badge.test.js
+++ b/apps/gittensory-miner-extension/opportunity-badge.test.js
@@ -1,0 +1,212 @@
+import { beforeAll, describe, expect, it } from "vitest";
+
+let api;
+
+beforeAll(async () => {
+  globalThis.__GITTENSORY_MINER_EXTENSION_TEST__ = true;
+  await import("./opportunity-badge.js");
+  api = globalThis.__gittensoryMinerOpportunityBadgeTestExports;
+});
+
+describe("issueLookupKey", () => {
+  it("builds a lowercase repo#number key", () => {
+    expect(api.issueLookupKey("Owner/Repo", 42)).toBe("owner/repo#42");
+  });
+
+  it("returns null for a blank repo", () => {
+    expect(api.issueLookupKey("  ", 42)).toBeNull();
+  });
+
+  it("returns null for a non-integer issue number", () => {
+    expect(api.issueLookupKey("owner/repo", 1.5)).toBeNull();
+  });
+
+  it("returns null for a zero or negative issue number", () => {
+    expect(api.issueLookupKey("owner/repo", 0)).toBeNull();
+    expect(api.issueLookupKey("owner/repo", -3)).toBeNull();
+  });
+});
+
+describe("lookupRankedOpportunity", () => {
+  const entries = [
+    { repoFullName: "owner/repo", issueNumber: 42, rankScore: 0.9 },
+    { repoFullName: "owner/other", issueNumber: 7, rankScore: 0.2 },
+  ];
+
+  it("finds the matching entry case-insensitively", () => {
+    expect(api.lookupRankedOpportunity(entries, "Owner/Repo", 42)).toBe(entries[0]);
+  });
+
+  it("returns null when no entry matches", () => {
+    expect(api.lookupRankedOpportunity(entries, "owner/repo", 999)).toBeNull();
+  });
+
+  it("returns null when rankedIssues is not an array", () => {
+    expect(api.lookupRankedOpportunity(null, "owner/repo", 42)).toBeNull();
+  });
+
+  it("returns null when the lookup key itself is invalid", () => {
+    expect(api.lookupRankedOpportunity(entries, "", 42)).toBeNull();
+  });
+
+  it("skips non-object entries without throwing", () => {
+    expect(api.lookupRankedOpportunity([null, 5, "x", entries[0]], "owner/repo", 42)).toBe(entries[0]);
+  });
+});
+
+describe("scoreToTier", () => {
+  it("labels a high score", () => {
+    expect(api.scoreToTier(0.75)).toBe("High");
+    expect(api.scoreToTier(0.9)).toBe("High");
+  });
+
+  it("labels a medium score", () => {
+    expect(api.scoreToTier(0.5)).toBe("Medium");
+    expect(api.scoreToTier(0.74)).toBe("Medium");
+  });
+
+  it("labels a low score", () => {
+    expect(api.scoreToTier(0.49)).toBe("Low");
+    expect(api.scoreToTier(0)).toBe("Low");
+  });
+
+  it("labels a non-finite score as Unknown", () => {
+    expect(api.scoreToTier(Number.NaN)).toBe("Unknown");
+    expect(api.scoreToTier(undefined)).toBe("Unknown");
+  });
+});
+
+describe("buildOpportunityWhy", () => {
+  it("lists every reason that clears its threshold, capped at two", () => {
+    const why = api.buildOpportunityWhy({
+      laneFit: 0.8,
+      freshness: 0.8,
+      potential: 0.8,
+      feasibility: 0.8,
+      dupRisk: 0.1,
+    });
+    expect(why).toBe("Strong lane fit; Fresh issue");
+  });
+
+  it("falls back to a balanced-signals message when nothing clears its threshold", () => {
+    const why = api.buildOpportunityWhy({
+      laneFit: 0.1,
+      freshness: 0.1,
+      potential: 0.1,
+      feasibility: 0.1,
+      dupRisk: 0.9,
+    });
+    expect(why).toBe("Balanced opportunity signals");
+  });
+
+  it("includes the low-duplicate-risk reason when dupRisk clears its own (inverted) threshold", () => {
+    const why = api.buildOpportunityWhy({
+      laneFit: 0,
+      freshness: 0,
+      potential: 0,
+      feasibility: 0,
+      dupRisk: 0.2,
+    });
+    expect(why).toBe("Low duplicate risk");
+  });
+});
+
+describe("formatOpportunityBadge", () => {
+  it("formats a finite rank score to two decimal places", () => {
+    const badge = api.formatOpportunityBadge({
+      rankScore: 0.856,
+      laneFit: 0.8,
+      freshness: 0,
+      potential: 0,
+      feasibility: 0,
+      dupRisk: 0.9,
+    });
+    expect(badge).toMatchObject({ tier: "High", score: "0.86", rankScore: 0.856 });
+  });
+
+  it("degrades score to an em dash and rankScore to null when non-finite", () => {
+    const badge = api.formatOpportunityBadge({
+      rankScore: Number.NaN,
+      laneFit: 0,
+      freshness: 0,
+      potential: 0,
+      feasibility: 0,
+      dupRisk: 0.9,
+    });
+    expect(badge).toMatchObject({ tier: "Unknown", score: "—", rankScore: null });
+  });
+});
+
+describe("formatLastSyncedLabel", () => {
+  it("returns null for a non-numeric savedAt", () => {
+    expect(api.formatLastSyncedLabel(undefined, Date.now())).toBeNull();
+    expect(api.formatLastSyncedLabel(Number.NaN, Date.now())).toBeNull();
+  });
+
+  it("labels just now for sub-minute deltas", () => {
+    expect(api.formatLastSyncedLabel(1000, 30_000)).toBe("last synced just now");
+  });
+
+  it("labels minutes for sub-hour deltas", () => {
+    expect(api.formatLastSyncedLabel(0, 5 * 60_000)).toBe("last synced 5m ago");
+  });
+
+  it("labels hours for sub-day deltas", () => {
+    expect(api.formatLastSyncedLabel(0, 3 * 60 * 60_000)).toBe("last synced 3h ago");
+  });
+
+  it("labels days beyond 24h", () => {
+    expect(api.formatLastSyncedLabel(0, 2 * 24 * 60 * 60_000)).toBe("last synced 2d ago");
+  });
+
+  it("clamps a marginally-future savedAt to zero delta instead of a negative age", () => {
+    expect(api.formatLastSyncedLabel(10_000, 9_000)).toBe("last synced just now");
+  });
+});
+
+describe("escapeOpportunityHtml", () => {
+  it("escapes every HTML-sensitive character", () => {
+    expect(api.escapeOpportunityHtml(`<b>"a" & 'b'</b>`)).toBe(
+      "&lt;b&gt;&quot;a&quot; &amp; &#39;b&#39;&lt;/b&gt;",
+    );
+  });
+
+  it("stringifies a non-string value first", () => {
+    expect(api.escapeOpportunityHtml(42)).toBe("42");
+  });
+});
+
+describe("renderOpportunityBadgeMarkup", () => {
+  it("returns an empty string for a missing/non-object badge", () => {
+    expect(api.renderOpportunityBadgeMarkup(null, null)).toBe("");
+    expect(api.renderOpportunityBadgeMarkup("x", null)).toBe("");
+  });
+
+  it("renders the badge markup with the last-synced line when a label is given", () => {
+    const markup = api.renderOpportunityBadgeMarkup(
+      { tier: "High", score: "0.90", why: "Strong lane fit" },
+      "last synced 2m ago",
+    );
+    expect(markup).toContain("High");
+    expect(markup).toContain("0.90");
+    expect(markup).toContain("Strong lane fit");
+    expect(markup).toContain("last synced 2m ago");
+  });
+
+  it("omits the last-synced line entirely when no label is given", () => {
+    const markup = api.renderOpportunityBadgeMarkup(
+      { tier: "Low", score: "0.10", why: "Balanced opportunity signals" },
+      null,
+    );
+    expect(markup).not.toContain("gittensory-miner-opportunity-badge__synced");
+  });
+
+  it("escapes badge field content so untrusted text cannot inject markup", () => {
+    const markup = api.renderOpportunityBadgeMarkup(
+      { tier: "<script>", score: "0.10", why: "x" },
+      null,
+    );
+    expect(markup).not.toContain("<script>");
+    expect(markup).toContain("&lt;script&gt;");
+  });
+});

--- a/apps/gittensory-miner-extension/options.test.js
+++ b/apps/gittensory-miner-extension/options.test.js
@@ -1,0 +1,242 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const FORM_HTML = `
+  <form id="settings">
+    <textarea id="watchedRepos" name="watchedRepos"></textarea>
+    <input id="minerUiUrl" name="minerUiUrl" type="url" />
+    <textarea id="rankedCandidatesJson" name="rankedCandidatesJson"></textarea>
+    <button type="submit">Save</button>
+    <button type="button" id="syncNow">Sync ranked candidates now</button>
+  </form>
+  <p id="status" role="status"></p>
+`;
+
+function buildChromeMock() {
+  return {
+    storage: {
+      sync: {
+        get: vi.fn(async (defaults) => ({ ...defaults })),
+        set: vi.fn(async () => {}),
+        remove: vi.fn(async () => {}),
+      },
+      local: {
+        get: vi.fn(async (defaults) => ({ ...defaults })),
+        set: vi.fn(async () => {}),
+      },
+    },
+    runtime: { sendMessage: vi.fn() },
+  };
+}
+
+/** Fresh import of options.js. `mountForm` controls whether options.html's form is present before
+ *  import -- options.js takes a different top-level branch when it's absent (unit-test harness). */
+async function loadOptions({ mountForm = true, chrome = buildChromeMock() } = {}) {
+  vi.resetModules();
+  document.body.innerHTML = mountForm ? FORM_HTML : "";
+  globalThis.__GITTENSORY_MINER_EXTENSION_TEST__ = true;
+  globalThis.chrome = chrome;
+  await import("./options.js");
+  return { internals: globalThis.__gittensoryMinerOptionsInternals, chrome };
+}
+
+describe("options.js", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+  });
+
+  afterEach(() => {
+    delete globalThis.chrome;
+  });
+
+  describe("parseWatchedRepos", () => {
+    it("splits on newlines and commas, trimming and dropping blanks", async () => {
+      const { internals } = await loadOptions({ mountForm: false });
+      expect(internals.parseWatchedRepos("owner/a\n owner/b ,owner/c\n\n")).toEqual([
+        "owner/a",
+        "owner/b",
+        "owner/c",
+      ]);
+    });
+
+    it("returns an empty array for a nullish/blank input", async () => {
+      const { internals } = await loadOptions({ mountForm: false });
+      expect(internals.parseWatchedRepos(undefined)).toEqual([]);
+      expect(internals.parseWatchedRepos("   ")).toEqual([]);
+    });
+  });
+
+  describe("parseRankedCandidatesJson", () => {
+    it("returns an empty array for blank text", async () => {
+      const { internals } = await loadOptions({ mountForm: false });
+      expect(internals.parseRankedCandidatesJson("  ")).toEqual([]);
+    });
+
+    it("parses a well-formed JSON array", async () => {
+      const { internals } = await loadOptions({ mountForm: false });
+      expect(internals.parseRankedCandidatesJson('[{"a":1}]')).toEqual([{ a: 1 }]);
+    });
+
+    it("throws for malformed JSON", async () => {
+      const { internals } = await loadOptions({ mountForm: false });
+      expect(() => internals.parseRankedCandidatesJson("{not json")).toThrow();
+    });
+
+    it("throws when the parsed JSON is not an array", async () => {
+      const { internals } = await loadOptions({ mountForm: false });
+      expect(() => internals.parseRankedCandidatesJson('{"a":1}')).toThrow("must be an array");
+    });
+
+    it("throws when the payload exceeds the byte-size limit", async () => {
+      const { internals } = await loadOptions({ mountForm: false });
+      const huge = `[${"1,".repeat(internals.MAX_RANKED_CANDIDATES_JSON_BYTES)}1]`;
+      expect(() => internals.parseRankedCandidatesJson(huge)).toThrow(/too large/);
+    });
+  });
+
+  describe("normalizeMinerUiUrl", () => {
+    it("falls back to the default for blank input", async () => {
+      const { internals } = await loadOptions({ mountForm: false });
+      expect(internals.normalizeMinerUiUrl("  ")).toBe(internals.DEFAULT_MINER_UI_URL);
+      expect(internals.normalizeMinerUiUrl(undefined)).toBe(internals.DEFAULT_MINER_UI_URL);
+    });
+
+    it("trims and returns a non-blank URL", async () => {
+      const { internals } = await loadOptions({ mountForm: false });
+      expect(internals.normalizeMinerUiUrl(" http://x.test ")).toBe("http://x.test");
+    });
+  });
+
+  describe("removeLegacyDiscoveryIndexUrl", () => {
+    it("removes the legacy sync key", async () => {
+      const { internals, chrome } = await loadOptions({ mountForm: false });
+      await internals.removeLegacyDiscoveryIndexUrl();
+      expect(chrome.storage.sync.remove).toHaveBeenCalledWith("discoveryIndexUrl");
+    });
+  });
+
+  describe("without the options form mounted (unit-test harness path)", () => {
+    it("does not throw when the form elements are absent", async () => {
+      await expect(loadOptions({ mountForm: false })).resolves.toBeDefined();
+    });
+  });
+
+  describe("with the options form mounted", () => {
+    it("hydrates the form from chrome.storage on load", async () => {
+      const chrome = buildChromeMock();
+      chrome.storage.sync.get.mockResolvedValue({ watchedRepos: ["owner/a", "owner/b"], minerUiUrl: "http://x.test" });
+      chrome.storage.local.get.mockResolvedValue({ rankedCandidates: [{ a: 1 }] });
+      await loadOptions({ chrome });
+      await vi.waitFor(() => expect(document.getElementById("watchedRepos").value).toBe("owner/a\nowner/b"));
+      expect(document.getElementById("minerUiUrl").value).toBe("http://x.test");
+      expect(document.getElementById("rankedCandidatesJson").value).toContain('"a": 1');
+    });
+
+    it("shows an empty ranked-candidates field when storage has none", async () => {
+      const chrome = buildChromeMock();
+      await loadOptions({ chrome });
+      await vi.waitFor(() => expect(chrome.storage.local.get).toHaveBeenCalled());
+      expect(document.getElementById("rankedCandidatesJson").value).toBe("");
+    });
+
+    it("saves the form on submit and shows a save-with-candidates status", async () => {
+      const chrome = buildChromeMock();
+      await loadOptions({ chrome });
+      await vi.waitFor(() => expect(chrome.storage.sync.get).toHaveBeenCalled());
+
+      document.getElementById("watchedRepos").value = "owner/repo";
+      document.getElementById("rankedCandidatesJson").value = '[{"repoFullName":"owner/repo","issueNumber":1}]';
+      document.getElementById("settings").dispatchEvent(new window.Event("submit", { cancelable: true, bubbles: true }));
+
+      await vi.waitFor(() =>
+        expect(chrome.storage.local.set).toHaveBeenCalledWith(
+          expect.objectContaining({ rankedCandidates: [{ repoFullName: "owner/repo", issueNumber: 1 }] }),
+        ),
+      );
+      await vi.waitFor(() => expect(document.getElementById("status").textContent).toContain("1 ranked candidate"));
+    });
+
+    it("saves the form on submit and shows a watching-only status when no candidates were pasted", async () => {
+      const chrome = buildChromeMock();
+      await loadOptions({ chrome });
+      await vi.waitFor(() => expect(chrome.storage.sync.get).toHaveBeenCalled());
+
+      document.getElementById("watchedRepos").value = "owner/repo";
+      document.getElementById("settings").dispatchEvent(new window.Event("submit", { cancelable: true, bubbles: true }));
+
+      await vi.waitFor(() => expect(document.getElementById("status").textContent).toBe("Watching 1 repository(ies)."));
+    });
+
+    it("shows the parse error instead of saving when the pasted JSON is malformed", async () => {
+      const chrome = buildChromeMock();
+      await loadOptions({ chrome });
+      await vi.waitFor(() => expect(chrome.storage.sync.get).toHaveBeenCalled());
+      chrome.storage.local.set.mockClear();
+
+      document.getElementById("rankedCandidatesJson").value = "{not json";
+      document.getElementById("settings").dispatchEvent(new window.Event("submit", { cancelable: true, bubbles: true }));
+
+      await vi.waitFor(() => expect(document.getElementById("status").textContent).not.toBe(""));
+      expect(chrome.storage.local.set).not.toHaveBeenCalled();
+    });
+
+    it("sync-now saves the URL, requests a sync, and shows the synced count on success", async () => {
+      const chrome = buildChromeMock();
+      chrome.runtime.sendMessage.mockResolvedValue({
+        payload: { ok: true, count: 3, minerUiUrl: "http://miner.test" },
+      });
+      await loadOptions({ chrome });
+      await vi.waitFor(() => expect(chrome.storage.sync.get).toHaveBeenCalled());
+
+      document.getElementById("minerUiUrl").value = "http://miner.test";
+      document.getElementById("syncNow").dispatchEvent(new window.Event("click", { bubbles: true }));
+
+      await vi.waitFor(() =>
+        expect(document.getElementById("status").textContent).toBe("Synced 3 ranked candidate(s) from http://miner.test."),
+      );
+    });
+
+    it("sync-now shows the paste-fallback message when the background reports a failure", async () => {
+      const chrome = buildChromeMock();
+      chrome.runtime.sendMessage.mockResolvedValue({
+        payload: { ok: false, error: "miner UI responded 500", minerUiUrl: "http://miner.test" },
+      });
+      await loadOptions({ chrome });
+      await vi.waitFor(() => expect(chrome.storage.sync.get).toHaveBeenCalled());
+
+      document.getElementById("syncNow").dispatchEvent(new window.Event("click", { bubbles: true }));
+
+      await vi.waitFor(() =>
+        expect(document.getElementById("status").textContent).toContain("Could not reach the miner UI"),
+      );
+      expect(document.getElementById("status").textContent).toContain("Falling back to the pasted JSON below");
+    });
+
+    it("sync-now shows the raw error message when sendMessage itself rejects", async () => {
+      const chrome = buildChromeMock();
+      chrome.runtime.sendMessage.mockRejectedValue(new Error("channel closed"));
+      await loadOptions({ chrome });
+      await vi.waitFor(() => expect(chrome.storage.sync.get).toHaveBeenCalled());
+
+      document.getElementById("syncNow").dispatchEvent(new window.Event("click", { bubbles: true }));
+
+      await vi.waitFor(() => expect(document.getElementById("status").textContent).toBe("channel closed"));
+    });
+
+    it("clears the status message after its timeout", async () => {
+      vi.useFakeTimers();
+      try {
+        const chrome = buildChromeMock();
+        await loadOptions({ chrome });
+        document.getElementById("watchedRepos").value = "owner/repo";
+        document.getElementById("settings").dispatchEvent(new window.Event("submit", { cancelable: true, bubbles: true }));
+        await vi.waitFor(() => expect(document.getElementById("status").textContent).not.toBe(""), {
+          timeout: 1000,
+        });
+        await vi.advanceTimersByTimeAsync(3000);
+        expect(document.getElementById("status").textContent).toBe("");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+});

--- a/apps/gittensory-miner-extension/package.json
+++ b/apps/gittensory-miner-extension/package.json
@@ -7,6 +7,11 @@
   "scripts": {
     "build": "node ../../scripts/build-miner-extension.mjs",
     "lint": "node --check background.js && node --check content.js && node --check opportunity-badge.js && node --check options.js && node --check toolbar-badge.js",
-    "typecheck": "npm run lint"
+    "typecheck": "npm run lint",
+    "test": "vitest run --coverage"
+  },
+  "devDependencies": {
+    "jsdom": "^28.1.0",
+    "vitest": "^4.1.9"
   }
 }

--- a/apps/gittensory-miner-extension/toolbar-badge.test.js
+++ b/apps/gittensory-miner-extension/toolbar-badge.test.js
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  computeToolbarBadge,
+  TOOLBAR_BADGE_EMPTY_COLOR,
+  TOOLBAR_BADGE_HAS_DATA_COLOR,
+  TOOLBAR_BADGE_NO_DATA_TEXT,
+} from "./toolbar-badge.js";
+
+describe("computeToolbarBadge", () => {
+  it("shows a dash when rankedCandidates was never populated (undefined)", () => {
+    expect(computeToolbarBadge(undefined)).toEqual({
+      text: TOOLBAR_BADGE_NO_DATA_TEXT,
+      backgroundColor: TOOLBAR_BADGE_EMPTY_COLOR,
+    });
+  });
+
+  it("shows a dash for a malformed non-array value, never a count", () => {
+    expect(computeToolbarBadge("not-an-array")).toEqual({
+      text: TOOLBAR_BADGE_NO_DATA_TEXT,
+      backgroundColor: TOOLBAR_BADGE_EMPTY_COLOR,
+    });
+  });
+
+  it("shows cleared/empty text for a populated-but-empty array (distinct from never-populated)", () => {
+    expect(computeToolbarBadge([])).toEqual({ text: "", backgroundColor: TOOLBAR_BADGE_EMPTY_COLOR });
+  });
+
+  it("shows the count with the has-data color for a populated array", () => {
+    expect(computeToolbarBadge([{}, {}, {}])).toEqual({
+      text: "3",
+      backgroundColor: TOOLBAR_BADGE_HAS_DATA_COLOR,
+    });
+  });
+});

--- a/apps/gittensory-miner-extension/vitest.config.ts
+++ b/apps/gittensory-miner-extension/vitest.config.ts
@@ -1,0 +1,24 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "jsdom",
+    globals: true,
+    include: ["*.test.js"],
+    coverage: {
+      provider: "v8",
+      include: ["background.js", "content.js", "opportunity-badge.js", "options.js", "toolbar-badge.js"],
+      reporter: ["text", "lcov"],
+      // A real baseline (#4865), not an aspirational target -- see apps/gittensory-miner-ui/vitest.config.ts's
+      // identical framing. Measured at 99.2% statements / 92.1% branches / 95.12% functions / 100% lines the
+      // day this was wired up, with a small buffer below that so routine churn doesn't false-fail. This is a
+      // floor meant to catch a genuine regression, not a ratchet to ceremonially raise every PR.
+      thresholds: {
+        statements: 97,
+        branches: 89,
+        functions: 92,
+        lines: 97,
+      },
+    },
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,354 @@
     },
     "apps/gittensory-miner-extension": {
       "name": "@jsonbored/gittensory-miner-extension",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "devDependencies": {
+        "jsdom": "^28.1.0",
+        "vitest": "^4.1.9"
+      }
+    },
+    "apps/gittensory-miner-extension/node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "apps/gittensory-miner-extension/node_modules/@csstools/color-helpers": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.0.tgz",
+      "integrity": "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "apps/gittensory-miner-extension/node_modules/@csstools/css-calc": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.1.tgz",
+      "integrity": "sha512-DtdHlgXh5ZkA43cwBcAm+huzgJiwx3ZTWVjBs94kwz2xKqSimDA3lBgCjphYgwgVUMWatSM0pDd8TILB1yrVVg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "apps/gittensory-miner-extension/node_modules/@csstools/css-color-parser": {
+      "version": "4.1.9",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.9.tgz",
+      "integrity": "sha512-paQcIaOO53Rk5+YrBaBjm/SgrV4INImjo2BT1DtQRYr+XeTRbeAYlS+jxXp9drqvKmtFnWRJKIalDLhZZDu42A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.0",
+        "@csstools/css-calc": "^3.2.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "apps/gittensory-miner-extension/node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "apps/gittensory-miner-extension/node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "apps/gittensory-miner-extension/node_modules/cssstyle": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.2.0.tgz",
+      "integrity": "sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.0.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.28",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "apps/gittensory-miner-extension/node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "apps/gittensory-miner-extension/node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "apps/gittensory-miner-extension/node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "apps/gittensory-miner-extension/node_modules/jsdom": {
+      "version": "28.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
+      "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.31",
+        "@asamuzakjp/dom-selector": "^6.8.1",
+        "@bramus/specificity": "^2.4.2",
+        "@exodus/bytes": "^1.11.0",
+        "cssstyle": "^6.0.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "undici": "^7.21.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "apps/gittensory-miner-extension/node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "apps/gittensory-miner-extension/node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "apps/gittensory-miner-extension/node_modules/tldts": {
+      "version": "7.4.8",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.8.tgz",
+      "integrity": "sha512-htwgN/8KRB3z3vnC0BOETVh2m499g5GmyTK9Wq5JBLX3FNz6tSBveAd+fQhzy9hkjif8vy2jwDMR1sGhLtZl2A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.8"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "apps/gittensory-miner-extension/node_modules/tldts-core": {
+      "version": "7.4.8",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.8.tgz",
+      "integrity": "sha512-c1P7u0EhACHj7lPy4MJm8iTFEU8+nB0LCtddH0fhP7noaVoXAqafMtOOeX+ulpuPBqnrRgRhw494RICT3mbhnw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "apps/gittensory-miner-extension/node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "apps/gittensory-miner-extension/node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "apps/gittensory-miner-extension/node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "apps/gittensory-miner-extension/node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "apps/gittensory-miner-extension/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "apps/gittensory-miner-extension/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "apps/gittensory-miner-ui": {
       "name": "@loopover/ui-miner",
@@ -919,28 +1266,6 @@
         "win32"
       ]
     },
-    "node_modules/@anthropic-ai/sdk": {
-      "version": "0.110.0",
-      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.110.0.tgz",
-      "integrity": "sha512-hOP4bNYXDFHDxxiEgzlILXrxZIYCDnhe8sry0RDRKD/QnsEpvZcQpablCdm9X/WuD/YgOiSIkkqsL1mLLlTqJw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "json-schema-to-ts": "^3.1.1",
-        "standardwebhooks": "^1.0.0"
-      },
-      "bin": {
-        "anthropic-ai-sdk": "bin/cli"
-      },
-      "peerDependencies": {
-        "zod": "^3.25.0 || ^4.0.0"
-      },
-      "peerDependenciesMeta": {
-        "zod": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@apm-js-collab/code-transformer": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.15.0.tgz",
@@ -1593,13 +1918,6 @@
         "node": ">=16"
       }
     },
-    "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260702.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260702.1.tgz",
-      "integrity": "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA==",
-      "license": "MIT OR Apache-2.0",
-      "peer": true
-    },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -1770,6 +2088,7 @@
       "version": "1.11.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
       "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1791,6 +2110,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
       "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3229,6 +3549,7 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.6.tgz",
       "integrity": "sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -3687,6 +4008,7 @@
       "version": "0.138.0",
       "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.138.0.tgz",
       "integrity": "sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==",
+      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
@@ -5200,6 +5522,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5216,6 +5539,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5232,6 +5556,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5248,6 +5573,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5264,6 +5590,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5280,6 +5607,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5296,6 +5624,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5312,6 +5641,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5328,6 +5658,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5344,6 +5675,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5360,6 +5692,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5376,6 +5709,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5392,6 +5726,7 @@
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -5410,6 +5745,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5426,6 +5762,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5469,6 +5806,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@sec-ant/readable-stream": {
@@ -5623,13 +5961,6 @@
       "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
       "dev": true,
       "license": "CC0-1.0"
-    },
-    "node_modules/@stablelib/base64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
-      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
@@ -6542,6 +6873,7 @@
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
       "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -6687,13 +7019,6 @@
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "license": "MIT"
     },
-    "node_modules/@types/gensync": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@types/gensync/-/gensync-1.0.5.tgz",
-      "integrity": "sha512-MbsRCT7mTikHwKZ0X+LVUTLRrZZRLipTuXEO9qOYO+zmjMVk81axyClMROf6uoPD9MRVu46bx8zoR0Ad9q3NAg==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/@types/jsesc": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@types/jsesc/-/jsesc-2.5.1.tgz",
@@ -6720,7 +7045,7 @@
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
       "integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/node": "*",
@@ -6752,7 +7077,7 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -6762,7 +7087,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -7380,48 +7705,6 @@
         "node": "^22.18.0 || >=24.11.0"
       }
     },
-    "node_modules/agents/node_modules/@babel/compat-data": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-8.0.0.tgz",
-      "integrity": "sha512-DOjnob/cXOUgDOozCDeq/aK2p5y8dUIVdf6tNhEV1HQRd6I8aQ4f4fbtHRVEvb6lP3BGomrKHiS8ICAASSVQSw==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/agents/node_modules/@babel/core": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-8.0.1.tgz",
-      "integrity": "sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/code-frame": "^8.0.0",
-        "@babel/generator": "^8.0.0",
-        "@babel/helper-compilation-targets": "^8.0.0",
-        "@babel/helpers": "^8.0.0",
-        "@babel/parser": "^8.0.0",
-        "@babel/template": "^8.0.0",
-        "@babel/traverse": "^8.0.0",
-        "@babel/types": "^8.0.0",
-        "@types/gensync": "^1.0.5",
-        "convert-source-map": "^2.0.0",
-        "empathic": "^2.0.1",
-        "gensync": "^1.0.0-beta.2",
-        "import-meta-resolve": "^4.2.0",
-        "json5": "^2.2.3",
-        "obug": "^2.1.1",
-        "semver": "^7.7.3"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/babel"
-      }
-    },
     "node_modules/agents/node_modules/@babel/generator": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0.tgz",
@@ -7446,23 +7729,6 @@
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^8.0.0"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/agents/node_modules/@babel/helper-compilation-targets": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-8.0.0.tgz",
-      "integrity": "sha512-JwculLABZvyPvyLBpwU/E/IbH2uM3mnxNtIJpxnIfb24y1PrdVxK5Dqjle4DpgqpGRnwgC7G8IkzPdSXZrO1Ew==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/compat-data": "^8.0.0",
-        "@babel/helper-validator-option": "^8.0.0",
-        "browserslist": "^4.24.0",
-        "lru-cache": "^11.0.0",
-        "semver": "^7.7.3"
       },
       "engines": {
         "node": "^22.18.0 || >=24.11.0"
@@ -7583,30 +7849,6 @@
         "node": "^22.18.0 || >=24.11.0"
       }
     },
-    "node_modules/agents/node_modules/@babel/helper-validator-option": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-8.0.0.tgz",
-      "integrity": "sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
-    "node_modules/agents/node_modules/@babel/helpers": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-8.0.0.tgz",
-      "integrity": "sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/template": "^8.0.0",
-        "@babel/types": "^8.0.0"
-      },
-      "engines": {
-        "node": "^22.18.0 || >=24.11.0"
-      }
-    },
     "node_modules/agents/node_modules/@babel/parser": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0.tgz",
@@ -7707,16 +7949,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/agents/node_modules/lru-cache": {
-      "version": "11.5.1",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
-      "license": "BlueOak-1.0.0",
-      "peer": true,
-      "engines": {
-        "node": "20 || >=22"
       }
     },
     "node_modules/agents/node_modules/nanoid": {
@@ -8692,7 +8924,7 @@
       "version": "0.4.5",
       "resolved": "https://registry.npmjs.org/crossws/-/crossws-0.4.5.tgz",
       "integrity": "sha512-wUR89x/Rw7/8t+vn0CmGDYM9TD6VtARGb0LD5jq2wjtMy1vCP4M+sm6N6TigWeTYvnA8MoW29NqqXD0ep0rfBA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "srvx": ">=0.11.5"
@@ -9302,16 +9534,6 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "license": "MIT"
-    },
-    "node_modules/empathic": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
-      "integrity": "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==",
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=14"
-      }
     },
     "node_modules/encodeurl": {
       "version": "2.0.0",
@@ -10122,13 +10344,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-sha256": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
-      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
-      "license": "Unlicense",
-      "peer": true
-    },
     "node_modules/fast-uri": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
@@ -10390,6 +10605,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -11011,17 +11227,6 @@
       "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
       "license": "MIT"
     },
-    "node_modules/import-meta-resolve": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
-      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
-      "license": "MIT",
-      "peer": true,
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/wooorm"
-      }
-    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -11402,20 +11607,6 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/json-schema-to-ts": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
-      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@babel/runtime": "^7.18.3",
-        "ts-algebra": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      }
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -12282,6 +12473,7 @@
       "version": "3.3.12",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
       "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -12962,6 +13154,7 @@
       "version": "8.5.16",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
       "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -13771,6 +13964,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.4.tgz",
       "integrity": "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@oxc-project/types": "=0.138.0",
@@ -14246,17 +14440,6 @@
       "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
       "license": "MIT"
     },
-    "node_modules/standardwebhooks": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
-      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@stablelib/base64": "^1.0.0",
-        "fast-sha256": "^1.3.0"
-      }
-    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -14633,13 +14816,6 @@
         "tree-sitter-wasms": "^0.1.11"
       }
     },
-    "node_modules/ts-algebra": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
-      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -14690,7 +14866,7 @@
       "version": "4.22.5",
       "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.5.tgz",
       "integrity": "sha512-F7JnSfPl5ASt6LqwWyUQ3T8BwN3q0eQEbFMYa2iRWaVQmmudo0d7fRmwM4O002gsvW1bs0yBYioutsAjqLJMvQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "~0.28.0"
@@ -14749,7 +14925,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -15015,6 +15191,7 @@
       "version": "8.1.4",
       "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
       "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1266,6 +1266,28 @@
         "win32"
       ]
     },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.110.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.110.0.tgz",
+      "integrity": "sha512-hOP4bNYXDFHDxxiEgzlILXrxZIYCDnhe8sry0RDRKD/QnsEpvZcQpablCdm9X/WuD/YgOiSIkkqsL1mLLlTqJw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@apm-js-collab/code-transformer": {
       "version": "0.15.0",
       "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.15.0.tgz",
@@ -1917,6 +1939,13 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/@cloudflare/workers-types": {
+      "version": "4.20260702.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260702.1.tgz",
+      "integrity": "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA==",
+      "license": "MIT OR Apache-2.0",
+      "peer": true
     },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
@@ -5962,6 +5991,13 @@
       "dev": true,
       "license": "CC0-1.0"
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -7019,6 +7055,13 @@
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "license": "MIT"
     },
+    "node_modules/@types/gensync": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/gensync/-/gensync-1.0.5.tgz",
+      "integrity": "sha512-MbsRCT7mTikHwKZ0X+LVUTLRrZZRLipTuXEO9qOYO+zmjMVk81axyClMROf6uoPD9MRVu46bx8zoR0Ad9q3NAg==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/jsesc": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@types/jsesc/-/jsesc-2.5.1.tgz",
@@ -7705,6 +7748,48 @@
         "node": "^22.18.0 || >=24.11.0"
       }
     },
+    "node_modules/agents/node_modules/@babel/compat-data": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-8.0.0.tgz",
+      "integrity": "sha512-DOjnob/cXOUgDOozCDeq/aK2p5y8dUIVdf6tNhEV1HQRd6I8aQ4f4fbtHRVEvb6lP3BGomrKHiS8ICAASSVQSw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/agents/node_modules/@babel/core": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-8.0.1.tgz",
+      "integrity": "sha512-5FgxM4dLQpMJHSiVATk8foW263dVHQHBVpXYiimNECVWG01f4nFyEbQixeT6Mwvg7TayREJ2gpKl3o2RoMdnqw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^8.0.0",
+        "@babel/generator": "^8.0.0",
+        "@babel/helper-compilation-targets": "^8.0.0",
+        "@babel/helpers": "^8.0.0",
+        "@babel/parser": "^8.0.0",
+        "@babel/template": "^8.0.0",
+        "@babel/traverse": "^8.0.0",
+        "@babel/types": "^8.0.0",
+        "@types/gensync": "^1.0.5",
+        "convert-source-map": "^2.0.0",
+        "empathic": "^2.0.1",
+        "gensync": "^1.0.0-beta.2",
+        "import-meta-resolve": "^4.2.0",
+        "json5": "^2.2.3",
+        "obug": "^2.1.1",
+        "semver": "^7.7.3"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
     "node_modules/agents/node_modules/@babel/generator": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-8.0.0.tgz",
@@ -7729,6 +7814,23 @@
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/agents/node_modules/@babel/helper-compilation-targets": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-8.0.0.tgz",
+      "integrity": "sha512-JwculLABZvyPvyLBpwU/E/IbH2uM3mnxNtIJpxnIfb24y1PrdVxK5Dqjle4DpgqpGRnwgC7G8IkzPdSXZrO1Ew==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/compat-data": "^8.0.0",
+        "@babel/helper-validator-option": "^8.0.0",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^11.0.0",
+        "semver": "^7.7.3"
       },
       "engines": {
         "node": "^22.18.0 || >=24.11.0"
@@ -7849,6 +7951,30 @@
         "node": "^22.18.0 || >=24.11.0"
       }
     },
+    "node_modules/agents/node_modules/@babel/helper-validator-option": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-8.0.0.tgz",
+      "integrity": "sha512-U4Dybxh4WESWHt5XhBeExi4DrY0/DNK1aHpQbsrQXCUbFHuMweT0TpLEWKvaraV2Y6fS+ZXunsZ8zIuZIgvF2Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
+    "node_modules/agents/node_modules/@babel/helpers": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-8.0.0.tgz",
+      "integrity": "sha512-wfbi91pM3py96oIiJEz7qIpyXDytgr9zQC1HEWwlGNVRAEmItuU/0a41ZUKu1sJGyhhOIpc4t5vk4PYzt8wpsg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/template": "^8.0.0",
+        "@babel/types": "^8.0.0"
+      },
+      "engines": {
+        "node": "^22.18.0 || >=24.11.0"
+      }
+    },
     "node_modules/agents/node_modules/@babel/parser": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-8.0.0.tgz",
@@ -7949,6 +8075,16 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/agents/node_modules/lru-cache": {
+      "version": "11.5.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+      "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+      "license": "BlueOak-1.0.0",
+      "peer": true,
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/agents/node_modules/nanoid": {
@@ -9535,6 +9671,16 @@
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "license": "MIT"
     },
+    "node_modules/empathic": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/empathic/-/empathic-2.0.1.tgz",
+      "integrity": "sha512-YGRs8knHhKHVShLkFET/rWAU8kmHbOV5LwN938RHI0pljAJ1Gf6SzXsSmRaEzcXTtOOmVqJ5+WtQPL5uigY50Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/encodeurl": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
@@ -10343,6 +10489,13 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense",
+      "peer": true
     },
     "node_modules/fast-uri": {
       "version": "3.1.2",
@@ -11227,6 +11380,17 @@
       "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
       "license": "MIT"
     },
+    "node_modules/import-meta-resolve": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/import-meta-resolve/-/import-meta-resolve-4.2.0.tgz",
+      "integrity": "sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
@@ -11607,6 +11771,20 @@
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/json-schema-traverse": {
       "version": "1.0.0",
@@ -14440,6 +14618,17 @@
       "integrity": "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==",
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -14815,6 +15004,13 @@
       "dependencies": {
         "tree-sitter-wasms": "^0.1.11"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "miner-extension:build": "npm --workspace @jsonbored/gittensory-miner-extension run build",
     "miner-extension:lint": "npm --workspace @jsonbored/gittensory-miner-extension run lint",
     "miner-extension:typecheck": "npm --workspace @jsonbored/gittensory-miner-extension run typecheck",
+    "miner-extension:test": "npm --workspace @jsonbored/gittensory-miner-extension run test",
     "ui:kit:build": "npm run build --workspace @loopover/ui-kit",
     "ui:build": "npm run ui:kit:build && npm run build --workspace @loopover/engine && npm run ui:openapi && npm run extension:build && npm run miner-extension:build && npm --workspace @loopover/ui run build && npm --workspace @loopover/ui-miner run build",
     "ui:preview": "npm run ui:build && wrangler dev --config apps/gittensory-ui/dist/server/wrangler.json --ip 127.0.0.1 --port 4173 --local",


### PR DESCRIPTION
## Summary

- `apps/gittensory-miner-extension` had zero test coverage — excluded via the root vitest config's blanket `apps/**` ignore, and its five source files' `__GITTENSORY_MINER_EXTENSION_TEST__`-gated internals-exposure hooks (already wired in by whoever built #4866/#5567) went unused.
- Adds a real vitest suite: one `*.test.js` per source file (`background.js`, `content.js`, `opportunity-badge.js`, `options.js`, `toolbar-badge.js`), running under `jsdom`. Each test file sets `globalThis.__GITTENSORY_MINER_EXTENSION_TEST__ = true` plus whatever `chrome.*`/`fetch`/DOM mocks that file needs, then does a **dynamic** `import()` (a static import would be hoisted above that setup) to get a fresh module instance per scenario via `vi.resetModules()`.
- Exercises both sides of every branch that matters: each of `background.js`'s optional-API guards (`chrome.alarms`, `chrome.runtime.onStartup`/`onInstalled`, `chrome.action` + `chrome.storage.onChanged`) present vs. absent; every error path (`syncRankedCandidatesFromMinerUi`'s non-2xx / malformed-payload / thrown-fetch cases; `options.js`'s malformed-JSON / oversized-payload / rejected-`sendMessage` cases); the "never populated" vs. "populated but empty" vs. "populated" three-way distinction in `toolbar-badge.js`.
- This is the second half of #4865 — the miner-ui half landed in #5613, which explicitly scoped the extension out ("no vitest setup or test suite at all yet... a separate, larger effort left for a follow-up").
- Wires `miner-extension:test` into `.github/workflows/ci.yml` right alongside the existing `extension:lint`/`miner-extension:lint`/`typecheck` steps (same trigger condition), and adds the matching `miner-extension:test` script to the root `package.json`.
- Coverage thresholds in the new `vitest.config.ts` are set to the real measured baseline (99.2% statements / 92.1% branches / 95.12% functions / 100% lines) with a small buffer below, mirroring `apps/gittensory-miner-ui/vitest.config.ts`'s identical framing from #5613 — a floor to catch a genuine regression, not a ratchet.
- Documents the testing approach in the app's `README.md`.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

Closes #4865

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run db:migrations:check` / `db:schema-drift:check` / `selfhost:env-reference:check` (no DB/env changes in this PR; ran as part of `npm run test:ci`)
- [x] `npm run typecheck`
- [x] `npm run test:coverage` (this PR only touches `apps/gittensory-miner-extension/**`, which Codecov's `src/**`-only patch rule does not gate — coverage here is enforced locally via the new `vitest.config.ts` thresholds instead, matching the miner-ui half's precedent)
- [x] `npm run miner-extension:test` — 96 tests, all passing, coverage thresholds met
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- `npm run cf-typegen:check` (part of `npm run test:ci`) fails locally on this Windows dev machine with a `wrangler ENOENT` — `scripts/gen-cf-typegen.mjs` calls `execFileSync("wrangler", ...)` without `shell: true`, which cannot invoke npm's `.cmd` shim on Windows (reproduces in isolation, independent of any change in this PR). This PR makes no Cloudflare/`wrangler.jsonc` changes; the check runs fine on the actual CI (Linux runners). Every other step in `npm run test:ci` ran and passed before that point.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session/CORS surface touched; this is test-only + CI wiring.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI-visible change; this PR adds tests and CI wiring only.)
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots. **N/A for this PR** — it has no visible UI surface (pure test coverage + CI config), so no screenshot evidence applies.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (README.md updated with a short "Testing" section; no changelog edit.)

## Notes

- `gittensory-extension` (the sibling maintainer-facing extension) still has no test suite of its own — out of scope for #4865, which only names the miner-ui and miner-extension.
