### PR TITLE
test(miner-extension): bring the browser extension under a real coverage gate

### DIFF
--- a/apps/gittensory-miner-extension/README.md
+++ b/apps/gittensory-miner-extension/README.md
@@ -35,3 +35,13 @@ quota, instead of silently failing to save or leaving storage partially written.
 (#4860). Chrome match patterns cannot pin a port, so `http://localhost/*` is the narrowest grant the platform
 allows; `https` is intentionally omitted because the local miner-ui dev server is plain HTTP. This is the enabling
 permission for live-fetching ranked candidates from the local miner-ui instead of pasting them.
+
+## Tests
+
+`npm run test` (Vitest + v8 coverage) covers every shipped script — `background.js`, `content.js`,
+`opportunity-badge.js`, `options.js`, and `toolbar-badge.js` (#4865). The two DOM-page scripts (`content.js`,
+`options.js`) run under jsdom via a per-file `// @vitest-environment jsdom` docblock; the rest run in Node. Each
+script exposes its otherwise-unexported internals on `globalThis` only when
+`globalThis.__GITTENSORY_MINER_EXTENSION_TEST__` is set (done in `test/setup.js`), so the suite imports the real
+source files directly and v8 attributes true coverage. The suite is wired into the repo's `npm run ui:test`, so it
+runs in CI alongside the other UI workspaces.

--- a/apps/gittensory-miner-extension/package.json
+++ b/apps/gittensory-miner-extension/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "build": "node ../../scripts/build-miner-extension.mjs",
     "lint": "node --check background.js && node --check content.js && node --check opportunity-badge.js && node --check options.js && node --check toolbar-badge.js",
-    "typecheck": "npm run lint"
+    "typecheck": "npm run lint",
+    "test": "vitest run --coverage"
   }
 }

--- a/apps/gittensory-miner-extension/test/background.test.js
+++ b/apps/gittensory-miner-extension/test/background.test.js
@@ -1,0 +1,382 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+function jsonResponse(body, { ok = true, status = 200 } = {}) {
+  return { ok, status, json: async () => body };
+}
+
+// A configurable chrome mock modelled on the shapes background.js's own guards expect. `minimal` omits every
+// optional surface (alarms/action/onChanged/onStartup/onInstalled) so the "clean no-op in a bare environment"
+// guard branches are exercised too.
+function createChrome({
+  syncStore = {},
+  localStore = {},
+  minimal = false,
+  syncGetThrows = false,
+  syncGetThrowsNonError = false,
+  actionThrows = false,
+} = {}) {
+  const calls = {
+    badgeText: [],
+    badgeColor: [],
+    localSet: [],
+    warn: [],
+    alarmCreate: null,
+    fetched: [],
+  };
+  const listeners = {};
+
+  const chrome = {
+    runtime: {
+      onMessage: { addListener: (fn) => (listeners.message = fn) },
+    },
+    storage: {
+      sync: {
+        get: async (defaults) => {
+          if (syncGetThrows) throw new Error("sync get failed");
+          if (syncGetThrowsNonError) throw "sync get failed (string)"; // a raw string, not an Error
+          return { ...(defaults ?? {}), ...syncStore };
+        },
+        set: async () => {},
+        remove: async () => {},
+      },
+      local: {
+        get: async (arg) => {
+          if (typeof arg === "string") {
+            return { [arg]: arg in localStore ? localStore[arg] : undefined };
+          }
+          return { ...(arg ?? {}), ...localStore };
+        },
+        set: async (value) => {
+          calls.localSet.push(value);
+          Object.assign(localStore, value);
+        },
+      },
+    },
+  };
+
+  if (!minimal) {
+    chrome.action = {
+      setBadgeText: async (value) => {
+        calls.badgeText.push(value);
+        if (actionThrows) throw new Error("chrome.action unavailable");
+      },
+      setBadgeBackgroundColor: async (value) => {
+        calls.badgeColor.push(value);
+      },
+    };
+    chrome.storage.onChanged = { addListener: (fn) => (listeners.changed = fn) };
+    chrome.alarms = {
+      create: (name, options) => (calls.alarmCreate = { name, options }),
+      onAlarm: { addListener: (fn) => (listeners.alarm = fn) },
+    };
+    chrome.runtime.onStartup = { addListener: (fn) => (listeners.startup = fn) };
+    chrome.runtime.onInstalled = { addListener: (fn) => (listeners.installed = fn) };
+  }
+
+  return { chrome, calls, listeners };
+}
+
+async function loadBackground(options = {}) {
+  const built = createChrome(options);
+  const fetchImpl = vi.fn(async (url) => {
+    built.calls.fetched.push(url);
+    return options.fetchResponse ?? jsonResponse({ candidates: [{ repoFullName: "a/b", issueNumber: 1 }] });
+  });
+  if (options.fetchThrows) fetchImpl.mockImplementation(async () => {
+    throw new Error("network down");
+  });
+  if (options.fetchThrowsNonError) fetchImpl.mockImplementation(async () => {
+    throw "network down (string)"; // a raw string, not an Error
+  });
+
+  vi.resetModules();
+  vi.stubGlobal("chrome", built.chrome);
+  vi.stubGlobal("fetch", fetchImpl);
+
+  await import("../background.js");
+  await flush();
+
+  return {
+    ...built,
+    fetchImpl,
+    internals: globalThis.__gittensoryMinerBackgroundInternals,
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+describe("background.js message router (#4859)", () => {
+  let sendResponse;
+  beforeEach(() => {
+    sendResponse = vi.fn();
+  });
+
+  it("ignores messages with no/invalid type and returns false (no async response)", async () => {
+    const bg = await loadBackground();
+    expect(bg.listeners.message(null, {}, sendResponse)).toBe(false);
+    expect(bg.listeners.message({ type: 42 }, {}, sendResponse)).toBe(false);
+    expect(sendResponse).not.toHaveBeenCalled();
+  });
+
+  it("answers a ping synchronously", async () => {
+    const bg = await loadBackground();
+    const ret = bg.listeners.message({ type: "gittensory-miner:ping" }, {}, sendResponse);
+    expect(ret).toBe(false);
+    expect(sendResponse).toHaveBeenCalledWith({ ok: true, payload: { ready: true } });
+  });
+
+  it("resolves issue-context asynchronously and keeps the channel open", async () => {
+    const bg = await loadBackground({
+      syncStore: { watchedRepos: ["JSONbored/gittensory"] },
+      localStore: {
+        rankedCandidates: [{ repoFullName: "JSONbored/gittensory", issueNumber: 145, rankScore: 0.8, laneFit: 0.8 }],
+        rankedCandidatesSavedAt: 111,
+      },
+    });
+    const ret = bg.listeners.message(
+      { type: "gittensory-miner:issue-context", owner: "JSONbored", repo: "gittensory", issueNumber: 145 },
+      {},
+      sendResponse,
+    );
+    expect(ret).toBe(true);
+    await flush();
+    expect(sendResponse).toHaveBeenCalledWith({
+      ok: true,
+      payload: expect.objectContaining({ status: "ready", savedAt: 111 }),
+    });
+  });
+
+  it("reports an error payload when issue-context resolution throws", async () => {
+    const bg = await loadBackground({ syncGetThrows: true });
+    bg.listeners.message(
+      { type: "gittensory-miner:issue-context", owner: "o", repo: "r", issueNumber: 1 },
+      {},
+      sendResponse,
+    );
+    await flush();
+    expect(sendResponse).toHaveBeenCalledWith({ ok: false, error: "sync get failed" });
+  });
+
+  it("stringifies a non-Error thrown during issue-context resolution (String(error) branch)", async () => {
+    const bg = await loadBackground({ syncGetThrowsNonError: true });
+    bg.listeners.message(
+      { type: "gittensory-miner:issue-context", owner: "o", repo: "r", issueNumber: 1 },
+      {},
+      sendResponse,
+    );
+    await flush();
+    expect(sendResponse).toHaveBeenCalledWith({ ok: false, error: "sync get failed (string)" });
+  });
+
+  it("triggers a live sync and returns its result", async () => {
+    const bg = await loadBackground();
+    const ret = bg.listeners.message({ type: "gittensory-miner:sync-ranked-candidates" }, {}, sendResponse);
+    expect(ret).toBe(true);
+    await flush();
+    expect(sendResponse).toHaveBeenCalledWith({ ok: true, payload: expect.objectContaining({ ok: true, count: 1 }) });
+  });
+
+  it("returns false for an unknown message type", async () => {
+    const bg = await loadBackground();
+    expect(bg.listeners.message({ type: "gittensory-miner:unknown" }, {}, sendResponse)).toBe(false);
+  });
+});
+
+describe("background.js loadIssueOpportunityContext", () => {
+  it("returns repo-not-watched when the repo is not in the watch list", async () => {
+    const bg = await loadBackground({ syncStore: { watchedRepos: ["  ", "owner/other"] } });
+    const payload = await bg.internals.loadIssueOpportunityContext({ owner: "o", repo: "r", issueNumber: 1 });
+    expect(payload).toEqual({
+      watched: false,
+      issueNumber: 1,
+      repoFullName: "o/r",
+      badge: null,
+      status: "repo-not-watched",
+    });
+  });
+
+  it("returns no-signal when watched but no ranked candidate matches", async () => {
+    const bg = await loadBackground({
+      syncStore: { watchedRepos: ["JSONbored/gittensory"] },
+      localStore: { rankedCandidates: [] },
+    });
+    const payload = await bg.internals.loadIssueOpportunityContext({
+      owner: "JSONbored",
+      repo: "gittensory",
+      issueNumber: 145,
+    });
+    expect(payload.status).toBe("no-signal");
+    expect(payload.badge).toBeNull();
+  });
+
+  it("returns a ready badge when a watched repo has a cached ranked candidate", async () => {
+    const bg = await loadBackground({
+      syncStore: { watchedRepos: ["JSONbored/gittensory"] },
+      localStore: {
+        rankedCandidates: [{ repoFullName: "JSONbored/gittensory", issueNumber: 145, rankScore: 0.9, potential: 0.8 }],
+        rankedCandidatesSavedAt: 999,
+      },
+    });
+    const payload = await bg.internals.loadIssueOpportunityContext({
+      owner: "JSONbored",
+      repo: "gittensory",
+      issueNumber: 145,
+    });
+    expect(payload.status).toBe("ready");
+    expect(payload.badge.tier).toBe("High");
+    expect(payload.savedAt).toBe(999);
+  });
+});
+
+describe("background.js storage readers", () => {
+  it("loadMinerExtensionSettings trims/filters a watch list and defaults a non-array to empty", async () => {
+    const withList = await loadBackground({ syncStore: { watchedRepos: ["  JSONbored/gittensory  ", ""] } });
+    expect((await withList.internals.loadMinerExtensionSettings()).watchedRepos).toEqual(["JSONbored/gittensory"]);
+
+    const nonArray = await loadBackground({ syncStore: { watchedRepos: "oops" } });
+    expect((await nonArray.internals.loadMinerExtensionSettings()).watchedRepos).toEqual([]);
+  });
+
+  it("loadRankedCandidates degrades a non-array cache and a non-numeric savedAt safely", async () => {
+    const good = await loadBackground({ localStore: { rankedCandidates: [1, 2], rankedCandidatesSavedAt: 7 } });
+    expect(await good.internals.loadRankedCandidates()).toEqual({ rankedCandidates: [1, 2], savedAt: 7 });
+
+    const bad = await loadBackground({ localStore: { rankedCandidates: "nope", rankedCandidatesSavedAt: "nope" } });
+    expect(await bad.internals.loadRankedCandidates()).toEqual({ rankedCandidates: [], savedAt: null });
+  });
+
+  it("loadMinerUiUrl returns the stored URL, or the default for empty/whitespace/non-string values", async () => {
+    const custom = await loadBackground({ syncStore: { minerUiUrl: "http://localhost:9999" } });
+    expect(await custom.internals.loadMinerUiUrl()).toBe("http://localhost:9999");
+
+    const blank = await loadBackground({ syncStore: { minerUiUrl: "   " } });
+    expect(await blank.internals.loadMinerUiUrl()).toBe("http://localhost:5174");
+
+    const nonString = await loadBackground({ syncStore: { minerUiUrl: 42 } });
+    expect(await nonString.internals.loadMinerUiUrl()).toBe("http://localhost:5174");
+  });
+});
+
+describe("background.js syncRankedCandidatesFromMinerUi (#4859)", () => {
+  it("writes fetched candidates to local storage and reports the count", async () => {
+    const bg = await loadBackground({
+      fetchResponse: jsonResponse({ candidates: [{ issueNumber: 1 }, { issueNumber: 2 }] }),
+    });
+    const result = await bg.internals.syncRankedCandidatesFromMinerUi();
+    expect(result).toMatchObject({ ok: true, count: 2, minerUiUrl: "http://localhost:5174" });
+    expect(bg.calls.localSet.at(-1)).toMatchObject({ rankedCandidates: [{ issueNumber: 1 }, { issueNumber: 2 }] });
+  });
+
+  it("returns a typed failure (never throws) on a non-OK response", async () => {
+    const bg = await loadBackground({ fetchResponse: jsonResponse({}, { ok: false, status: 503 }) });
+    const result = await bg.internals.syncRankedCandidatesFromMinerUi();
+    expect(result).toEqual({ ok: false, error: "miner UI responded 503", minerUiUrl: "http://localhost:5174" });
+  });
+
+  it("rejects an unexpected payload shape", async () => {
+    const bg = await loadBackground({ fetchResponse: jsonResponse({ candidates: "not-an-array" }) });
+    const result = await bg.internals.syncRankedCandidatesFromMinerUi();
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/unexpected payload shape/);
+  });
+
+  it("swallows a thrown fetch into a typed failure result", async () => {
+    const bg = await loadBackground({ fetchThrows: true });
+    const result = await bg.internals.syncRankedCandidatesFromMinerUi();
+    expect(result).toEqual({ ok: false, error: "network down", minerUiUrl: "http://localhost:5174" });
+  });
+
+  it("stringifies a non-Error thrown by fetch into a typed failure (String(error) branch)", async () => {
+    const bg = await loadBackground({ fetchThrowsNonError: true });
+    const result = await bg.internals.syncRankedCandidatesFromMinerUi();
+    expect(result).toEqual({
+      ok: false,
+      error: "network down (string)",
+      minerUiUrl: "http://localhost:5174",
+    });
+  });
+});
+
+describe("background.js toolbar-badge wiring (#5193)", () => {
+  it("paints the badge on startup from the current cache", async () => {
+    const bg = await loadBackground({ localStore: { rankedCandidates: [1, 2] } });
+    expect(bg.calls.badgeText).toContainEqual({ text: "2" });
+  });
+
+  it("refreshToolbarBadge maps never-populated / empty / populated caches through chrome.action", async () => {
+    const never = await loadBackground({});
+    never.calls.badgeText.length = 0;
+    await never.internals.refreshToolbarBadge();
+    expect(never.calls.badgeText.at(-1)).toEqual({ text: "–" });
+
+    const populated = await loadBackground({ localStore: { rankedCandidates: [{}, {}, {}, {}] } });
+    populated.calls.badgeText.length = 0;
+    await populated.internals.refreshToolbarBadge();
+    expect(populated.calls.badgeText.at(-1)).toEqual({ text: "4" });
+  });
+
+  it("repaints on a local rankedCandidates change and ignores other keys/areas", async () => {
+    const bg = await loadBackground({ localStore: { rankedCandidates: [9] } });
+    bg.calls.badgeText.length = 0;
+
+    bg.listeners.changed({ rankedCandidates: { newValue: [9] } }, "local");
+    await flush();
+    expect(bg.calls.badgeText).toHaveLength(1);
+
+    bg.calls.badgeText.length = 0;
+    bg.listeners.changed({ rankedCandidates: { newValue: [9] } }, "sync");
+    bg.listeners.changed({ watchedRepos: { newValue: [] } }, "local");
+    await flush();
+    expect(bg.calls.badgeText).toHaveLength(0);
+  });
+
+  it("swallows a rejected chrome.action call so the void-called refresh never leaks a rejection", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const bg = await loadBackground({ localStore: { rankedCandidates: [1] }, actionThrows: true });
+    await expect(bg.internals.refreshToolbarBadge()).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalled();
+  });
+});
+
+describe("background.js ambient refresh wiring", () => {
+  it("registers a periodic alarm and syncs when it fires under the right name", async () => {
+    const bg = await loadBackground();
+    expect(bg.calls.alarmCreate?.options).toEqual({ periodInMinutes: 10 });
+
+    bg.fetchImpl.mockClear();
+    bg.listeners.alarm({ name: "some-other-alarm" });
+    await flush();
+    expect(bg.fetchImpl).not.toHaveBeenCalled();
+
+    bg.listeners.alarm({ name: bg.calls.alarmCreate.name });
+    await flush();
+    expect(bg.fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("syncs on service-worker startup and on install", async () => {
+    const bg = await loadBackground();
+
+    bg.fetchImpl.mockClear();
+    bg.listeners.startup();
+    await flush();
+    expect(bg.fetchImpl).toHaveBeenCalledTimes(1);
+
+    bg.fetchImpl.mockClear();
+    bg.listeners.installed();
+    await flush();
+    expect(bg.fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("is a clean no-op (no paint, no throw) when the optional chrome surfaces are absent", async () => {
+    const bg = await loadBackground({ minimal: true, localStore: { rankedCandidates: [1, 2] } });
+    expect(typeof bg.internals.refreshToolbarBadge).toBe("function");
+    expect(bg.calls.badgeText).toHaveLength(0);
+    expect(bg.listeners.changed).toBeUndefined();
+    expect(bg.listeners.alarm).toBeUndefined();
+  });
+});

--- a/apps/gittensory-miner-extension/test/content.test.js
+++ b/apps/gittensory-miner-extension/test/content.test.js
@@ -1,0 +1,204 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// content.js reads `globalThis.__gittensoryMinerOpportunityBadge` (published by opportunity-badge.js, which the
+// browser loads first) at import time, and its exposed internals reuse it — so import it for its side effect here.
+import "../opportunity-badge.js";
+
+const flush = async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+};
+
+const BADGE_SELECTOR = "[data-gittensory-miner-opportunity-badge]";
+
+function setPath(pathname) {
+  window.history.pushState({}, "", pathname);
+}
+
+// content.js only touches chrome.runtime.sendMessage (from loadOpportunityBadge). Stub it per scenario.
+function stubChrome(sendMessage) {
+  vi.stubGlobal("chrome", { runtime: { sendMessage } });
+}
+
+// Re-run content.js's top level under the current URL + chrome stub, then drain the void-called async mount.
+async function importContent() {
+  vi.resetModules();
+  await import("../content.js");
+  await flush();
+  return globalThis.__gittensoryMinerContentInternals;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  document.body.innerHTML = "";
+  setPath("/");
+});
+
+describe("content.js matchGitHubIssueTarget", () => {
+  let internals;
+  beforeEach(async () => {
+    setPath("/");
+    stubChrome(vi.fn().mockResolvedValue({ ok: false }));
+    internals = await importContent();
+  });
+
+  it("parses an owner/repo/issue path into a typed issue target", () => {
+    expect(internals.matchGitHubIssueTarget("/JSONbored/gittensory/issues/145")).toEqual({
+      kind: "issue",
+      owner: "JSONbored",
+      repo: "gittensory",
+      issueNumber: 145,
+    });
+  });
+
+  it("returns null for non-issue paths, an empty path, and a nullish path", () => {
+    expect(internals.matchGitHubIssueTarget("/JSONbored/gittensory/pull/145")).toBeNull();
+    expect(internals.matchGitHubIssueTarget("/JSONbored/gittensory/issues/")).toBeNull();
+    expect(internals.matchGitHubIssueTarget("")).toBeNull();
+    expect(internals.matchGitHubIssueTarget(null)).toBeNull();
+  });
+});
+
+describe("content.js findIssueSidebar", () => {
+  let internals;
+  beforeEach(async () => {
+    setPath("/");
+    stubChrome(vi.fn().mockResolvedValue({ ok: false }));
+    internals = await importContent();
+  });
+
+  it("returns null when no known sidebar container is present", () => {
+    expect(internals.findIssueSidebar()).toBeNull();
+  });
+
+  it("resolves each known sidebar selector, in priority order", () => {
+    for (const setup of [
+      { id: "partial-discussion-sidebar" },
+      { attr: ["data-testid", "issue-sidebar"] },
+      { cls: "Layout-sidebar" },
+      { cls: "discussion-sidebar" },
+    ]) {
+      document.body.innerHTML = "";
+      const el = document.createElement("div");
+      if (setup.id) el.id = setup.id;
+      if (setup.attr) el.setAttribute(setup.attr[0], setup.attr[1]);
+      if (setup.cls) el.className = setup.cls;
+      document.body.appendChild(el);
+      expect(internals.findIssueSidebar()).toBe(el);
+    }
+  });
+});
+
+describe("content.js renderOpportunityBadge", () => {
+  let internals;
+  beforeEach(async () => {
+    setPath("/");
+    stubChrome(vi.fn().mockResolvedValue({ ok: false }));
+    internals = await importContent();
+  });
+
+  function freshContainer() {
+    const container = document.createElement("aside");
+    container.dataset.gittensoryMinerOpportunityBadge = "true";
+    container.hidden = true;
+    document.body.appendChild(container);
+    return container;
+  }
+
+  it("removes the container when the payload is not watched", () => {
+    const container = freshContainer();
+    internals.renderOpportunityBadge(container, { watched: false });
+    expect(container.isConnected).toBe(false);
+  });
+
+  it("removes the container when there is no badge", () => {
+    const container = freshContainer();
+    internals.renderOpportunityBadge(container, { watched: true, badge: null });
+    expect(container.isConnected).toBe(false);
+  });
+
+  it("removes the container when the badge produces no markup", () => {
+    const container = freshContainer();
+    // A truthy-but-non-object badge passes the guard yet yields an empty markup string.
+    internals.renderOpportunityBadge(container, { watched: true, badge: "not-an-object" });
+    expect(container.isConnected).toBe(false);
+  });
+
+  it("renders escaped markup and reveals the container for a real badge (with a synced label)", () => {
+    const container = freshContainer();
+    const nowMs = Date.parse("2026-07-10T12:00:00.000Z");
+    internals.renderOpportunityBadge(
+      container,
+      { watched: true, badge: { tier: "High", score: "0.81", why: "Strong lane fit" }, savedAt: nowMs - 3 * 60_000 },
+      nowMs,
+    );
+    expect(container.isConnected).toBe(true);
+    expect(container.hidden).toBe(false);
+    expect(container.innerHTML).toContain("LoopOver opportunity");
+    expect(container.innerHTML).toContain("last synced 3m ago");
+  });
+});
+
+describe("content.js mount (top-level side effect)", () => {
+  it("does nothing on a non-issue page (no badge, no message sent)", async () => {
+    setPath("/JSONbored/gittensory/pulls");
+    const sendMessage = vi.fn().mockResolvedValue({ ok: true });
+    stubChrome(sendMessage);
+    await importContent();
+    expect(document.querySelector(BADGE_SELECTOR)).toBeNull();
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it("mounts a badge into the issue sidebar and renders the resolved payload", async () => {
+    setPath("/JSONbored/gittensory/issues/145");
+    const sidebar = document.createElement("div");
+    sidebar.id = "partial-discussion-sidebar";
+    document.body.appendChild(sidebar);
+    stubChrome(
+      vi.fn().mockResolvedValue({
+        ok: true,
+        payload: { watched: true, badge: { tier: "High", score: "0.9", why: "Strong lane fit" }, savedAt: null },
+      }),
+    );
+    await importContent();
+    const badge = sidebar.querySelector(BADGE_SELECTOR);
+    expect(badge).not.toBeNull();
+    expect(badge.hidden).toBe(false);
+    expect(badge.innerHTML).toContain("LoopOver opportunity");
+  });
+
+  it("falls back to a floating badge when no sidebar exists", async () => {
+    setPath("/JSONbored/gittensory/issues/1");
+    stubChrome(
+      vi.fn().mockResolvedValue({
+        ok: true,
+        payload: { watched: true, badge: { tier: "Low", score: "0.20", why: "Balanced opportunity signals" } },
+      }),
+    );
+    await importContent();
+    const badge = document.body.querySelector(BADGE_SELECTOR);
+    expect(badge).not.toBeNull();
+    expect(badge.className).toContain("gittensory-miner-opportunity-badge--floating");
+  });
+
+  it("removes the container when the background responds not-ok", async () => {
+    setPath("/JSONbored/gittensory/issues/7");
+    stubChrome(vi.fn().mockResolvedValue({ ok: false }));
+    await importContent();
+    expect(document.querySelector(BADGE_SELECTOR)).toBeNull();
+  });
+
+  it("does not mount a second badge when one already exists on the page", async () => {
+    setPath("/JSONbored/gittensory/issues/9");
+    const existing = document.createElement("aside");
+    existing.dataset.gittensoryMinerOpportunityBadge = "true";
+    document.body.appendChild(existing);
+    const sendMessage = vi.fn().mockResolvedValue({ ok: true, payload: { watched: true, badge: {} } });
+    stubChrome(sendMessage);
+    await importContent();
+    expect(document.querySelectorAll(BADGE_SELECTOR)).toHaveLength(1);
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+});

--- a/apps/gittensory-miner-extension/test/opportunity-badge.test.js
+++ b/apps/gittensory-miner-extension/test/opportunity-badge.test.js
@@ -1,0 +1,167 @@
+import { describe, expect, it } from "vitest";
+
+// opportunity-badge.js ships as a classic (non-ESM-exporting) content script: importing it for its side effect
+// publishes the helper API on globalThis, exactly as the browser loads it ahead of content.js.
+import "../opportunity-badge.js";
+
+const api = globalThis.__gittensoryMinerOpportunityBadge;
+
+describe("opportunity-badge.js API surface", () => {
+  it("publishes the same object on both the runtime global and the test-exports hook", () => {
+    expect(api).toBeTruthy();
+    expect(globalThis.__gittensoryMinerOpportunityBadgeTestExports).toBe(api);
+  });
+});
+
+describe("issueLookupKey", () => {
+  it("builds a normalized repo#issue key, lower-cased and trimmed", () => {
+    expect(api.issueLookupKey("  JSONbored/Gittensory  ", "145")).toBe("jsonbored/gittensory#145");
+    expect(api.issueLookupKey("owner/repo", 7)).toBe("owner/repo#7");
+  });
+
+  it("returns null for missing repo, non-integer, or non-positive issue numbers", () => {
+    expect(api.issueLookupKey("", 1)).toBeNull();
+    expect(api.issueLookupKey(null, 1)).toBeNull();
+    expect(api.issueLookupKey("owner/repo", "not-a-number")).toBeNull();
+    expect(api.issueLookupKey("owner/repo", 1.5)).toBeNull();
+    expect(api.issueLookupKey("owner/repo", 0)).toBeNull();
+    expect(api.issueLookupKey("owner/repo", -3)).toBeNull();
+  });
+});
+
+describe("lookupRankedOpportunity", () => {
+  const ranked = [
+    null,
+    "not-an-object",
+    { repoFullName: "other/repo", issueNumber: 1 },
+    { repoFullName: "JSONbored/gittensory", issueNumber: 145, rankScore: 0.8 },
+  ];
+
+  it("finds the matching entry by repo#issue key, skipping malformed entries", () => {
+    const match = api.lookupRankedOpportunity(ranked, "jsonbored/gittensory", 145);
+    expect(match?.rankScore).toBe(0.8);
+  });
+
+  it("returns null when the target key is unresolvable", () => {
+    expect(api.lookupRankedOpportunity(ranked, "", 145)).toBeNull();
+  });
+
+  it("returns null when the ranked list is not an array", () => {
+    expect(api.lookupRankedOpportunity(undefined, "owner/repo", 1)).toBeNull();
+  });
+
+  it("returns null when no entry matches", () => {
+    expect(api.lookupRankedOpportunity(ranked, "owner/repo", 999)).toBeNull();
+  });
+});
+
+describe("scoreToTier", () => {
+  it("maps finite scores into High/Medium/Low bands", () => {
+    expect(api.scoreToTier(0.9)).toBe("High");
+    expect(api.scoreToTier(0.75)).toBe("High");
+    expect(api.scoreToTier(0.6)).toBe("Medium");
+    expect(api.scoreToTier(0.5)).toBe("Medium");
+    expect(api.scoreToTier(0.2)).toBe("Low");
+  });
+
+  it("returns Unknown for a non-finite score", () => {
+    expect(api.scoreToTier("nope")).toBe("Unknown");
+    expect(api.scoreToTier(Number.NaN)).toBe("Unknown");
+  });
+});
+
+describe("buildOpportunityWhy", () => {
+  it("surfaces the strongest signals, capped at two, joined with a semicolon", () => {
+    const why = api.buildOpportunityWhy({ laneFit: 0.9, freshness: 0.9, potential: 0.9 });
+    expect(why).toBe("Strong lane fit; Fresh issue");
+  });
+
+  it("recognizes each individual signal threshold", () => {
+    expect(api.buildOpportunityWhy({ potential: 0.7 })).toBe("High reward potential");
+    expect(api.buildOpportunityWhy({ feasibility: 0.7 })).toBe("Feasible scope");
+    expect(api.buildOpportunityWhy({ dupRisk: 0.3 })).toBe("Low duplicate risk");
+  });
+
+  it("falls back to a balanced-signals message when nothing crosses a threshold", () => {
+    expect(api.buildOpportunityWhy({ laneFit: 0.1, dupRisk: 0.9 })).toBe("Balanced opportunity signals");
+  });
+});
+
+describe("formatOpportunityBadge", () => {
+  it("formats tier, a two-decimal score, and passes through the numeric rankScore", () => {
+    expect(api.formatOpportunityBadge({ rankScore: 0.812, laneFit: 0.8 })).toEqual({
+      tier: "High",
+      score: "0.81",
+      why: "Strong lane fit",
+      rankScore: 0.812,
+    });
+  });
+
+  it("degrades a non-finite rankScore to an em-dash score and a null rankScore", () => {
+    const badge = api.formatOpportunityBadge({ rankScore: "n/a" });
+    expect(badge.tier).toBe("Unknown");
+    expect(badge.score).toBe("—");
+    expect(badge.rankScore).toBeNull();
+  });
+});
+
+describe("formatLastSyncedLabel (#5192)", () => {
+  const NOW = Date.parse("2026-07-10T12:00:00.000Z");
+
+  it("buckets the delta the same way ORB's RefreshMeta does", () => {
+    expect(api.formatLastSyncedLabel(NOW, NOW)).toBe("last synced just now");
+    expect(api.formatLastSyncedLabel(NOW - 59_000, NOW)).toBe("last synced just now");
+    expect(api.formatLastSyncedLabel(NOW - 60_000, NOW)).toBe("last synced 1m ago");
+    expect(api.formatLastSyncedLabel(NOW - 59 * 60_000, NOW)).toBe("last synced 59m ago");
+    expect(api.formatLastSyncedLabel(NOW - 60 * 60_000, NOW)).toBe("last synced 1h ago");
+    expect(api.formatLastSyncedLabel(NOW - 23 * 60 * 60_000, NOW)).toBe("last synced 23h ago");
+    expect(api.formatLastSyncedLabel(NOW - 24 * 60 * 60_000, NOW)).toBe("last synced 1d ago");
+  });
+
+  it("clamps a future timestamp to just now rather than a negative delta", () => {
+    expect(api.formatLastSyncedLabel(NOW + 5_000, NOW)).toBe("last synced just now");
+  });
+
+  it("returns null for a missing or invalid timestamp (never the epoch)", () => {
+    expect(api.formatLastSyncedLabel(null, NOW)).toBeNull();
+    expect(api.formatLastSyncedLabel(undefined, NOW)).toBeNull();
+    expect(api.formatLastSyncedLabel(Number.NaN, NOW)).toBeNull();
+    expect(api.formatLastSyncedLabel("", NOW)).toBeNull();
+    expect(api.formatLastSyncedLabel("not-a-timestamp", NOW)).toBeNull();
+  });
+});
+
+describe("escapeOpportunityHtml", () => {
+  it("escapes every HTML-significant character", () => {
+    expect(api.escapeOpportunityHtml(`&<>"'`)).toBe("&amp;&lt;&gt;&quot;&#39;");
+  });
+
+  it("coerces non-strings and leaves safe text untouched", () => {
+    expect(api.escapeOpportunityHtml(42)).toBe("42");
+    expect(api.escapeOpportunityHtml("plain text")).toBe("plain text");
+  });
+});
+
+describe("renderOpportunityBadgeMarkup", () => {
+  const badge = { tier: "High", score: "0.81", why: "Strong lane fit" };
+
+  it("renders the read-only badge markup with escaped, script-free content", () => {
+    const markup = api.renderOpportunityBadgeMarkup(badge);
+    expect(markup).toContain("LoopOver opportunity");
+    expect(markup).toContain("Read-only");
+    expect(markup).toContain("High");
+    expect(markup).not.toContain("<script>");
+  });
+
+  it("includes the last-synced label only when one is present", () => {
+    expect(api.renderOpportunityBadgeMarkup(badge, "last synced 3m ago")).toContain("last synced 3m ago");
+    const without = api.renderOpportunityBadgeMarkup(badge, null);
+    expect(without).not.toContain("last synced");
+    expect(without).not.toContain("NaN");
+  });
+
+  it("returns an empty string for a missing or non-object badge", () => {
+    expect(api.renderOpportunityBadgeMarkup(null)).toBe("");
+    expect(api.renderOpportunityBadgeMarkup("not-an-object")).toBe("");
+  });
+});

--- a/apps/gittensory-miner-extension/test/options.test.js
+++ b/apps/gittensory-miner-extension/test/options.test.js
@@ -1,0 +1,252 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const flush = async () => {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await new Promise((resolve) => setTimeout(resolve, 0));
+};
+
+// The subset of options.html the script queries. Kept in sync with options.html's ids/structure.
+const FORM_MARKUP = `
+  <form id="settings">
+    <textarea id="watchedRepos"></textarea>
+    <input id="minerUiUrl" type="url" />
+    <textarea id="rankedCandidatesJson"></textarea>
+    <button type="submit">Save</button>
+    <button type="button" id="syncNow">Sync</button>
+  </form>
+  <p id="status" role="status"></p>
+`;
+
+// A stateful chrome mock: get merges defaults over the backing store, set mutates it, remove deletes a key.
+function createChrome({ syncStore = {}, localStore = {}, sendMessage } = {}) {
+  const sync = { ...syncStore };
+  const local = { ...localStore };
+  return {
+    storage: {
+      sync: {
+        get: async (defaults) => ({ ...(defaults ?? {}), ...sync }),
+        set: async (value) => Object.assign(sync, value),
+        remove: async (key) => delete sync[key],
+      },
+      local: {
+        get: async (defaults) => ({ ...(defaults ?? {}), ...local }),
+        set: async (value) => Object.assign(local, value),
+      },
+    },
+    runtime: { sendMessage: sendMessage ?? vi.fn() },
+    _sync: sync,
+    _local: local,
+  };
+}
+
+async function importOptions() {
+  vi.resetModules();
+  await import("../options.js");
+  await flush();
+  return globalThis.__gittensoryMinerOptionsInternals;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+  document.body.innerHTML = "";
+});
+
+describe("options.js pure helpers (imported without the options DOM mounted)", () => {
+  let internals;
+  beforeEach(async () => {
+    document.body.innerHTML = ""; // no #settings form → the "not mounted" guard branch runs
+    vi.stubGlobal("chrome", createChrome());
+    internals = await importOptions();
+  });
+
+  it("exposes its internals and constants", () => {
+    expect(internals.MAX_RANKED_CANDIDATES_JSON_BYTES).toBe(8 * 1024 * 1024);
+    expect(internals.DEFAULT_MINER_UI_URL).toBe("http://localhost:5174");
+    expect(internals.SYNC_RANKED_CANDIDATES_MESSAGE).toBe("gittensory-miner:sync-ranked-candidates");
+  });
+
+  it("parseWatchedRepos splits, trims, and drops blanks across newlines and commas", () => {
+    expect(internals.parseWatchedRepos("a/b\n c/d , e/f \n\n")).toEqual(["a/b", "c/d", "e/f"]);
+    expect(internals.parseWatchedRepos("")).toEqual([]);
+    expect(internals.parseWatchedRepos(null)).toEqual([]);
+  });
+
+  it("parseRankedCandidatesJson returns [] for blank, parses an array, and rejects bad shapes", () => {
+    expect(internals.parseRankedCandidatesJson("   ")).toEqual([]);
+    expect(internals.parseRankedCandidatesJson(undefined)).toEqual([]);
+    expect(internals.parseRankedCandidatesJson(null)).toEqual([]);
+    expect(internals.parseRankedCandidatesJson('[{"issueNumber":1}]')).toEqual([{ issueNumber: 1 }]);
+    expect(() => internals.parseRankedCandidatesJson('{"issueNumber":1}')).toThrow(/must be an array/);
+    expect(() => internals.parseRankedCandidatesJson("{not json")).toThrow();
+  });
+
+  it("parseRankedCandidatesJson rejects a payload larger than the storage-quota limit", () => {
+    const huge = JSON.stringify([{ blob: "x".repeat(internals.MAX_RANKED_CANDIDATES_JSON_BYTES) }]);
+    expect(() => internals.parseRankedCandidatesJson(huge)).toThrow(/too large/);
+  });
+
+  it("normalizeMinerUiUrl trims and falls back to the default for empty/whitespace input", () => {
+    expect(internals.normalizeMinerUiUrl("  http://localhost:9999  ")).toBe("http://localhost:9999");
+    expect(internals.normalizeMinerUiUrl("   ")).toBe("http://localhost:5174");
+    expect(internals.normalizeMinerUiUrl(null)).toBe("http://localhost:5174");
+  });
+
+  it("removeLegacyDiscoveryIndexUrl purges the stale synced key (#5343)", async () => {
+    const chrome = createChrome({ syncStore: { discoveryIndexUrl: "http://stale" } });
+    vi.stubGlobal("chrome", chrome);
+    await internals.removeLegacyDiscoveryIndexUrl();
+    expect("discoveryIndexUrl" in chrome._sync).toBe(false);
+  });
+});
+
+describe("options.js options-page form wiring", () => {
+  function mount(chrome) {
+    document.body.innerHTML = FORM_MARKUP;
+    vi.stubGlobal("chrome", chrome);
+  }
+
+  it("hydrates the form from stored settings on load", async () => {
+    mount(
+      createChrome({
+        syncStore: { watchedRepos: ["JSONbored/gittensory", "owner/repo"], minerUiUrl: "http://localhost:9999" },
+        localStore: { rankedCandidates: [{ issueNumber: 1 }] },
+      }),
+    );
+    await importOptions();
+    expect(document.querySelector("#watchedRepos").value).toBe("JSONbored/gittensory\nowner/repo");
+    expect(document.querySelector("#minerUiUrl").value).toBe("http://localhost:9999");
+    expect(document.querySelector("#rankedCandidatesJson").value).toContain('"issueNumber": 1');
+  });
+
+  it("hydrates empty defaults (non-array stored values degrade to empty)", async () => {
+    mount(createChrome({ syncStore: { watchedRepos: "oops" }, localStore: { rankedCandidates: "oops" } }));
+    await importOptions();
+    expect(document.querySelector("#watchedRepos").value).toBe("");
+    expect(document.querySelector("#rankedCandidatesJson").value).toBe("");
+  });
+
+  it("saves watched repos + ranked candidates on submit and reports the count", async () => {
+    const chrome = createChrome();
+    mount(chrome);
+    await importOptions();
+    document.querySelector("#watchedRepos").value = "a/b\nc/d";
+    document.querySelector("#minerUiUrl").value = "http://localhost:7000";
+    document.querySelector("#rankedCandidatesJson").value = '[{"issueNumber":1}]';
+    document.querySelector("#settings").dispatchEvent(new Event("submit", { cancelable: true }));
+    await flush();
+    expect(chrome._sync.watchedRepos).toEqual(["a/b", "c/d"]);
+    expect(chrome._sync.minerUiUrl).toBe("http://localhost:7000");
+    expect(chrome._local.rankedCandidates).toEqual([{ issueNumber: 1 }]);
+    expect(document.querySelector("#status").textContent).toBe(
+      "Saved 2 watched repo(s) and 1 ranked candidate(s).",
+    );
+  });
+
+  it("reports the watching-only message when no ranked candidates are pasted", async () => {
+    const chrome = createChrome();
+    mount(chrome);
+    await importOptions();
+    document.querySelector("#watchedRepos").value = "a/b";
+    document.querySelector("#settings").dispatchEvent(new Event("submit", { cancelable: true }));
+    await flush();
+    expect(document.querySelector("#status").textContent).toBe("Watching 1 repository(ies).");
+  });
+
+  it("surfaces a parse error as status text instead of throwing", async () => {
+    const chrome = createChrome();
+    mount(chrome);
+    await importOptions();
+    document.querySelector("#rankedCandidatesJson").value = '{"issueNumber":1}';
+    document.querySelector("#settings").dispatchEvent(new Event("submit", { cancelable: true }));
+    await flush();
+    expect(document.querySelector("#status").textContent).toBe("Ranked candidates JSON must be an array.");
+  });
+
+  it("syncs ranked candidates from the miner UI on Sync-now (success path)", async () => {
+    const sendMessage = vi
+      .fn()
+      .mockResolvedValue({ ok: true, payload: { ok: true, count: 3, minerUiUrl: "http://localhost:7000" } });
+    const chrome = createChrome({ sendMessage });
+    mount(chrome);
+    await importOptions();
+    document.querySelector("#minerUiUrl").value = "http://localhost:7000";
+    document.querySelector("#syncNow").click();
+    await flush();
+    expect(chrome._sync.minerUiUrl).toBe("http://localhost:7000");
+    expect(document.querySelector("#status").textContent).toBe(
+      "Synced 3 ranked candidate(s) from http://localhost:7000.",
+    );
+  });
+
+  it("reports a fallback message when the miner UI is unreachable on Sync-now", async () => {
+    const sendMessage = vi
+      .fn()
+      .mockResolvedValue({ ok: true, payload: { ok: false, minerUiUrl: "http://localhost:7000", error: "boom" } });
+    mount(createChrome({ sendMessage }));
+    await importOptions();
+    document.querySelector("#minerUiUrl").value = "http://localhost:7000";
+    document.querySelector("#syncNow").click();
+    await flush();
+    expect(document.querySelector("#status").textContent).toContain(
+      "Could not reach the miner UI at http://localhost:7000: boom",
+    );
+  });
+
+  it("stringifies a non-Error thrown during save (String(error) branch)", async () => {
+    const chrome = createChrome();
+    chrome.storage.sync.set = async () => {
+      throw "sync store offline"; // a raw string, not an Error instance
+    };
+    mount(chrome);
+    await importOptions();
+    document.querySelector("#watchedRepos").value = "a/b";
+    document.querySelector("#settings").dispatchEvent(new Event("submit", { cancelable: true }));
+    await flush();
+    expect(document.querySelector("#status").textContent).toBe("sync store offline");
+  });
+
+  it("falls back to the field URL and a generic error when the sync payload omits them", async () => {
+    const sendMessage = vi.fn().mockResolvedValue({ ok: true, payload: { ok: false } });
+    mount(createChrome({ sendMessage }));
+    await importOptions();
+    document.querySelector("#minerUiUrl").value = "http://localhost:7000";
+    document.querySelector("#syncNow").click();
+    await flush();
+    expect(document.querySelector("#status").textContent).toBe(
+      "Could not reach the miner UI at http://localhost:7000: unknown error. Falling back to the pasted JSON below.",
+    );
+  });
+
+  it("surfaces a thrown Sync-now error as status text", async () => {
+    const sendMessage = vi.fn().mockRejectedValue(new Error("channel closed"));
+    mount(createChrome({ sendMessage }));
+    await importOptions();
+    document.querySelector("#syncNow").click();
+    await flush();
+    expect(document.querySelector("#status").textContent).toBe("channel closed");
+  });
+
+  it("stringifies a non-Error thrown during Sync-now (String(error) branch)", async () => {
+    const sendMessage = vi.fn().mockRejectedValue("port disconnected");
+    mount(createChrome({ sendMessage }));
+    await importOptions();
+    document.querySelector("#syncNow").click();
+    await flush();
+    expect(document.querySelector("#status").textContent).toBe("port disconnected");
+  });
+
+  it("clears the status line after its timeout elapses", async () => {
+    const chrome = createChrome();
+    mount(chrome);
+    await importOptions();
+    document.querySelector("#watchedRepos").value = "a/b";
+    document.querySelector("#settings").dispatchEvent(new Event("submit", { cancelable: true }));
+    await flush();
+    expect(document.querySelector("#status").textContent).not.toBe("");
+    await new Promise((resolve) => setTimeout(resolve, 2700));
+    expect(document.querySelector("#status").textContent).toBe("");
+  }, 8000);
+});

--- a/apps/gittensory-miner-extension/test/setup.js
+++ b/apps/gittensory-miner-extension/test/setup.js
@@ -1,0 +1,5 @@
+// These classic (non-bundled) extension scripts expose their internal, otherwise-unexported helpers on
+// `globalThis` only when this flag is set — the same hook the repo's existing node:vm harness uses. Setting it
+// before any test module is imported lets the app-local suite import the real source files directly (so v8 can
+// attribute coverage to them, which a node:vm eval cannot) and reach those internals.
+globalThis.__GITTENSORY_MINER_EXTENSION_TEST__ = true;

--- a/apps/gittensory-miner-extension/test/toolbar-badge.test.js
+++ b/apps/gittensory-miner-extension/test/toolbar-badge.test.js
@@ -1,0 +1,66 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  computeToolbarBadge,
+  TOOLBAR_BADGE_EMPTY_COLOR,
+  TOOLBAR_BADGE_HAS_DATA_COLOR,
+  TOOLBAR_BADGE_NO_DATA_TEXT,
+} from "../toolbar-badge.js";
+
+describe("computeToolbarBadge (toolbar-badge.js, #5193)", () => {
+  it("shows the count with the has-data color when candidates are populated", () => {
+    expect(computeToolbarBadge([{}, {}, {}])).toEqual({
+      text: "3",
+      backgroundColor: TOOLBAR_BADGE_HAS_DATA_COLOR,
+    });
+    expect(computeToolbarBadge([{}])).toEqual({
+      text: "1",
+      backgroundColor: TOOLBAR_BADGE_HAS_DATA_COLOR,
+    });
+  });
+
+  it("clears the text (populated-but-empty state) for an empty array", () => {
+    expect(computeToolbarBadge([])).toEqual({
+      text: "",
+      backgroundColor: TOOLBAR_BADGE_EMPTY_COLOR,
+    });
+  });
+
+  it("shows a dash for the never-populated cache (undefined key)", () => {
+    expect(computeToolbarBadge(undefined)).toEqual({
+      text: TOOLBAR_BADGE_NO_DATA_TEXT,
+      backgroundColor: TOOLBAR_BADGE_EMPTY_COLOR,
+    });
+  });
+
+  it("treats any malformed non-array value as no-data (dash), never a numeric count", () => {
+    for (const malformed of [null, "12", 7, { length: 5 }, true]) {
+      expect(computeToolbarBadge(malformed)).toEqual({
+        text: TOOLBAR_BADGE_NO_DATA_TEXT,
+        backgroundColor: TOOLBAR_BADGE_EMPTY_COLOR,
+      });
+    }
+  });
+
+  it("INVARIANT: no-data (never-written or malformed) never renders as a numeric count", () => {
+    for (const noData of [undefined, null, 0, "", { foo: "bar" }]) {
+      const { text } = computeToolbarBadge(noData);
+      expect(text).not.toMatch(/[0-9]/);
+      expect(text).toBe(TOOLBAR_BADGE_NO_DATA_TEXT);
+    }
+  });
+
+  it("exposes stable named constants so source and tests can never drift", () => {
+    expect(TOOLBAR_BADGE_HAS_DATA_COLOR).toBe("#16a34a");
+    expect(TOOLBAR_BADGE_EMPTY_COLOR).toBe("#6b7280");
+    expect(TOOLBAR_BADGE_NO_DATA_TEXT).toBe("–");
+  });
+
+  it("mirrors the pure map onto the global the background service worker reads", () => {
+    const api = globalThis.__gittensoryMinerToolbarBadge;
+    expect(api.computeToolbarBadge).toBe(computeToolbarBadge);
+    expect(api.TOOLBAR_BADGE_HAS_DATA_COLOR).toBe(TOOLBAR_BADGE_HAS_DATA_COLOR);
+    expect(api.TOOLBAR_BADGE_EMPTY_COLOR).toBe(TOOLBAR_BADGE_EMPTY_COLOR);
+    expect(api.TOOLBAR_BADGE_NO_DATA_TEXT).toBe(TOOLBAR_BADGE_NO_DATA_TEXT);
+  });
+});

--- a/apps/gittensory-miner-extension/vitest.config.ts
+++ b/apps/gittensory-miner-extension/vitest.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    // Default to node (background.js / the pure state maps run there); the two DOM-page scripts opt into jsdom
+    // per-file via a `// @vitest-environment jsdom` docblock (content.test.js / options.test.js).
+    environment: "node",
+    include: ["test/**/*.test.js"],
+    setupFiles: ["test/setup.js"],
+    coverage: {
+      provider: "v8",
+      // Every source script the app ships (#4865). These are classic (non-bundled) extension scripts, so the
+      // suite imports them directly — with the source's own `globalThis.__GITTENSORY_MINER_EXTENSION_TEST__`
+      // internals hook — so v8 attributes real coverage, which the repo's older node:vm harness could not do.
+      include: ["background.js", "content.js", "opportunity-badge.js", "options.js", "toolbar-badge.js"],
+      reporter: ["text", "lcov"],
+      // Measured baseline: 100% statements/functions/lines and 97.89% branches. The only uncovered branches are
+      // the four `if (globalThis.__GITTENSORY_MINER_EXTENSION_TEST__)` test-only export guards (one per script),
+      // whose false arm can never run while this suite's setup file has the flag set. Branch floor sits just under
+      // the measured value so a genuine regression fails CI without flaking on that irreducible remainder.
+      thresholds: {
+        statements: 100,
+        branches: 97,
+        functions: 100,
+        lines: 100,
+      },
+    },
+  },
+});

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "ui:preview": "npm run ui:build && wrangler dev --config apps/gittensory-ui/dist/server/wrangler.json --ip 127.0.0.1 --port 4173 --local",
     "ui:lint": "npm run ui:kit:build && npm --workspace @loopover/ui run lint && npm --workspace @loopover/ui-miner run lint",
     "ui:typecheck": "npm run ui:kit:build && npm --workspace @loopover/ui run typecheck && npm --workspace @loopover/ui-miner run typecheck",
-    "ui:test": "npm run ui:kit:build && npm --workspace @loopover/ui run test && npm --workspace @loopover/ui-miner run test",
+    "ui:test": "npm run ui:kit:build && npm --workspace @loopover/ui run test && npm --workspace @loopover/ui-miner run test && npm --workspace @jsonbored/gittensory-miner-extension run test",
     "ui:openapi": "tsx scripts/write-ui-openapi.ts",
     "ui:openapi:check": "tsx scripts/write-ui-openapi.ts --check",
     "ui:openapi:settings-parity": "tsx scripts/check-openapi-settings-parity.mjs",


### PR DESCRIPTION
## Summary

`apps/gittensory-miner-extension` was excluded from all coverage via the root `vitest.config.ts` blanket
`coverage.exclude: ["apps/**"]`, and its only tests (`test/unit/miner-*.test.ts`) ran the source through a
`node:vm` harness that v8 cannot attribute coverage to. This PR gives the extension a real, measured coverage
gate over **every shipped script**, completing the extension half of #4865 (the miner-ui half shipped in #5613).

- Adds an app-local, **import-based** vitest suite (`apps/gittensory-miner-extension/test/`) that imports the
  real source files directly — via the source's own `globalThis.__GITTENSORY_MINER_EXTENSION_TEST__` internals
  hook — so v8 attributes true coverage. 85 tests across all five scripts:
  `background.js`, `content.js`, `opportunity-badge.js`, `options.js`, `toolbar-badge.js`.
- The two DOM-page scripts (`content.js`, `options.js`) run under jsdom via a per-file
  `// @vitest-environment jsdom` docblock; the rest run in Node.
- Adds `apps/gittensory-miner-extension/vitest.config.ts` (v8; `include` scoped to the five scripts) and
  changes the app's `test` script to `vitest run --coverage`.
- Wires the app's `test` into the root `ui:test`, so the gate runs wherever `npm run ui:test` / `npm run test:ci`
  already run — no new CI step.
- Documents the gate in the app README.

Coverage is 100% statements / 97.89% branches / 100% functions / 100% lines. The only uncovered branches are the
four `if (globalThis.__GITTENSORY_MINER_EXTENSION_TEST__)` test-only export guards (one per script), whose false
arm can never run while the suite's setup file has that flag set. Thresholds are set to that measured baseline
(100 / 97 / 100 / 100) — a regression floor, not an aspirational ratchet.

Closes #4865.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] Focused change; does not mix unrelated backend, UI, MCP, docs, dependency, or deploy changes.
- [x] Follows `CONTRIBUTING.md`; does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] Links a currently open issue this PR closes (#4865). With the miner-ui half already merged (#5613), this
      brings the second and final app under measured coverage, satisfying the deliverable
      ("Both apps under real coverage measurement where technically feasible").

## Validation

- [x] `npm --workspace @jsonbored/gittensory-miner-extension run test` — 85 passing; 100% stmts / 97.89% branches
      / 100% funcs / 100% lines, over the configured floor.
- [x] `npm run ui:test` — full UI chain green (gittensory-ui 244, miner-ui 111, miner-extension 85).

## Safety

- [x] No secrets, wallets, hotkeys/coldkeys, PATs, private keys, trust scores, or private rankings exposed.
- [x] Test-, config-, and README-only change under `apps/gittensory-miner-extension/**`; touches no `src/**`,
      no OpenAPI/MCP/wrangler/migrations, so no generated artifacts are affected.
- [x] No user-visible UI or extension-behavior change (tests + config + docs only).

## Notes

- The existing `node:vm`-based tests in root `test/unit/` remain as behavior tests; this app-local suite's role
  is the coverage instrumentation the `vm` harness structurally cannot provide.