### PR TITLE
test(miner-extension): bring the browser extension under a real coverage gate (#4865)

### DIFF
--- a/apps/gittensory-miner-extension/README.md
+++ b/apps/gittensory-miner-extension/README.md
@@ -28,6 +28,17 @@ The extension does not request the `unlimitedStorage` permission, so a paste is 
 being parsed or saved once it exceeds a conservative size bound well under `chrome.storage.local`'s default 10 MiB
 quota, instead of silently failing to save or leaving storage partially written.
 
+## Test coverage
+
+`npm test` runs with `--coverage` enabled (v8 provider) and enforces `vitest.config.ts`'s
+`coverage.thresholds` — a measured baseline (#4865), not an aspirational target. The suite imports
+`background.js`, `opportunity-badge.js`, and `toolbar-badge.js` directly (via the existing
+`__GITTENSORY_MINER_EXTENSION_TEST__` hook) so v8 can attribute coverage; the root `test/unit/miner-*.test.ts`
+files remain as broader behavior tests through the `node:vm` harness.
+
+`content.js` and `options.js` are deliberately deferred — they need a jsdom mount harness before
+coverage attribution is meaningful. Raise thresholds per-PR as those scripts get covered.
+
 ## Host permissions
 
 `manifest.json` grants `https://github.com/*` (for the issue-page content script) plus loopback host permissions —

--- a/apps/gittensory-miner-extension/package.json
+++ b/apps/gittensory-miner-extension/package.json
@@ -7,6 +7,10 @@
   "scripts": {
     "build": "node ../../scripts/build-miner-extension.mjs",
     "lint": "node --check background.js && node --check content.js && node --check opportunity-badge.js && node --check options.js && node --check toolbar-badge.js",
-    "typecheck": "npm run lint"
+    "typecheck": "npm run lint",
+    "test": "vitest run --coverage"
+  },
+  "devDependencies": {
+    "vitest": "^4.1.9"
   }
 }

--- a/apps/gittensory-miner-extension/test/background.test.ts
+++ b/apps/gittensory-miner-extension/test/background.test.ts
@@ -1,0 +1,271 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { flush, jsonFetch, loadExtensionModules } from "./helpers.js";
+import {
+  TOOLBAR_BADGE_EMPTY_COLOR,
+  TOOLBAR_BADGE_HAS_DATA_COLOR,
+  TOOLBAR_BADGE_NO_DATA_TEXT,
+} from "../toolbar-badge.js";
+
+const rankedEntry = {
+  repoFullName: "JSONbored/gittensory",
+  issueNumber: 145,
+  rankScore: 0.82,
+  laneFit: 0.9,
+  freshness: 0.8,
+  potential: 0.7,
+  feasibility: 0.75,
+  dupRisk: 0.1,
+};
+
+describe("background service worker", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("returns ready issue context for a watched repo with a cached ranked candidate", async () => {
+    const { backgroundInternals } = await loadExtensionModules({
+      watchedRepos: ["JSONbored/gittensory"],
+      rankedCandidates: [rankedEntry],
+      rankedCandidatesSavedAt: Date.parse("2026-07-10T11:00:00.000Z"),
+    });
+
+    const payload = await backgroundInternals.loadIssueOpportunityContext({
+      owner: "JSONbored",
+      repo: "gittensory",
+      issueNumber: 145,
+    });
+
+    expect(payload.status).toBe("ready");
+    expect(payload.savedAt).toBe(Date.parse("2026-07-10T11:00:00.000Z"));
+    expect((payload.badge as { tier: string }).tier).toBe("High");
+  });
+
+  it("returns repo-not-watched and no-signal states", async () => {
+    const unwatched = await loadExtensionModules({ watchedRepos: ["other/repo"] });
+    const notWatched = await unwatched.backgroundInternals.loadIssueOpportunityContext({
+      owner: "JSONbored",
+      repo: "gittensory",
+      issueNumber: 145,
+    });
+    expect(notWatched.status).toBe("repo-not-watched");
+    expect(notWatched.badge).toBeNull();
+
+    const empty = await loadExtensionModules({
+      watchedRepos: ["JSONbored/gittensory"],
+      rankedCandidates: [],
+    });
+    const noSignal = await empty.backgroundInternals.loadIssueOpportunityContext({
+      owner: "JSONbored",
+      repo: "gittensory",
+      issueNumber: 145,
+    });
+    expect(noSignal.status).toBe("no-signal");
+    expect(noSignal.badge).toBeNull();
+  });
+
+  it("normalizes watched repos and degrades malformed ranked-candidate storage", async () => {
+    const { backgroundInternals } = await loadExtensionModules({
+      watchedRepos: [" JSONbored/gittensory ", "", 42 as unknown as string],
+      rankedCandidates: "bad" as unknown as unknown[],
+      rankedCandidatesSavedAt: "not-a-number" as unknown as number,
+    });
+
+    expect(await backgroundInternals.loadMinerExtensionSettings()).toEqual({
+      watchedRepos: ["JSONbored/gittensory", "42"],
+    });
+    expect(await backgroundInternals.loadRankedCandidates()).toEqual({
+      rankedCandidates: [],
+      savedAt: null,
+    });
+
+    const malformedSettings = await loadExtensionModules({
+      syncGetResult: { watchedRepos: "not-an-array" },
+    });
+    expect(await malformedSettings.backgroundInternals.loadMinerExtensionSettings()).toEqual({
+      watchedRepos: [],
+    });
+  });
+
+  it("syncs ranked candidates from the miner UI and leaves storage untouched on failure", async () => {
+    const candidates = [{ repoFullName: "acme/widgets", issueNumber: 1, rankScore: 0.8 }];
+    const success = await loadExtensionModules({
+      fetchImpl: jsonFetch(200, { candidates }),
+    });
+    const ok = await success.backgroundInternals.syncRankedCandidatesFromMinerUi();
+    expect(ok.ok).toBe(true);
+    expect(ok.count).toBe(1);
+    expect(success.localSetCalls).toHaveLength(1);
+
+    const httpError = await loadExtensionModules({ fetchImpl: jsonFetch(401, {}) });
+    const unauthorized = await httpError.backgroundInternals.syncRankedCandidatesFromMinerUi();
+    expect(unauthorized).toMatchObject({ ok: false, error: "miner UI responded 401" });
+    expect(httpError.localSetCalls).toHaveLength(0);
+
+    const malformed = await loadExtensionModules({ fetchImpl: jsonFetch(200, { candidates: "nope" }) });
+    const badShape = await malformed.backgroundInternals.syncRankedCandidatesFromMinerUi();
+    expect(badShape).toMatchObject({
+      ok: false,
+      error: "miner UI returned an unexpected payload shape",
+    });
+
+    const network = await loadExtensionModules({
+      fetchImpl: (async () => {
+        throw new Error("connection refused");
+      }) as typeof fetch,
+    });
+    const failed = await network.backgroundInternals.syncRankedCandidatesFromMinerUi();
+    expect(failed).toMatchObject({ ok: false, error: "connection refused" });
+  });
+
+  it("falls back to the default miner UI URL when sync storage is empty or malformed", async () => {
+    const empty = await loadExtensionModules({ minerUiUrl: "" });
+    expect(await empty.backgroundInternals.loadMinerUiUrl()).toBe(
+      empty.backgroundInternals.DEFAULT_MINER_UI_URL,
+    );
+
+    const malformed = await loadExtensionModules({ minerUiUrl: 123 as unknown as string });
+    expect(await malformed.backgroundInternals.loadMinerUiUrl()).toBe(
+      malformed.backgroundInternals.DEFAULT_MINER_UI_URL,
+    );
+  });
+
+  it("stringifies non-Error sync failures and issue-context rejections", async () => {
+    const syncFail = await loadExtensionModules({
+      fetchImpl: (async () => {
+        throw "offline";
+      }) as typeof fetch,
+    });
+    const syncResult = await syncFail.backgroundInternals.syncRankedCandidatesFromMinerUi();
+    expect(syncResult).toMatchObject({ ok: false, error: "offline" });
+
+    const mod = await loadExtensionModules({
+      watchedRepos: ["JSONbored/gittensory"],
+      rankedCandidates: [rankedEntry],
+      syncGetThrows: true,
+      syncGetRejectsWith: "storage blew up",
+    });
+    const response = await mod.dispatchMessage({
+      type: mod.backgroundInternals.ISSUE_CONTEXT_MESSAGE,
+      owner: "JSONbored",
+      repo: "gittensory",
+      issueNumber: 145,
+    });
+    expect((response as { ok: boolean; error: string }).error).toBeTruthy();
+  });
+
+  it("matches watched repos case-insensitively", async () => {
+    const { backgroundInternals } = await loadExtensionModules({
+      watchedRepos: ["jsonbored/gittensory"],
+      rankedCandidates: [rankedEntry],
+    });
+    const payload = await backgroundInternals.loadIssueOpportunityContext({
+      owner: "JSONbored",
+      repo: "gittensory",
+      issueNumber: 145,
+    });
+    expect(payload.status).toBe("ready");
+  });
+
+  it("routes runtime messages for ping, issue context, and sync", async () => {
+    const mod = await loadExtensionModules({
+      watchedRepos: ["JSONbored/gittensory"],
+      rankedCandidates: [rankedEntry],
+      fetchImpl: jsonFetch(200, { candidates: [rankedEntry] }),
+    });
+
+    const ping = await mod.dispatchMessage({ type: mod.backgroundInternals.PING_MESSAGE });
+    expect(ping).toEqual({ ok: true, payload: { ready: true } });
+
+    const context = await mod.dispatchMessage({
+      type: mod.backgroundInternals.ISSUE_CONTEXT_MESSAGE,
+      owner: "JSONbored",
+      repo: "gittensory",
+      issueNumber: 145,
+    });
+    expect((context as { payload: { status: string } }).payload.status).toBe("ready");
+
+    const sync = await mod.dispatchMessage({
+      type: mod.backgroundInternals.SYNC_RANKED_CANDIDATES_MESSAGE,
+    });
+    expect((sync as { payload: { ok: boolean } }).payload.ok).toBe(true);
+
+    const ignored = await mod.dispatchMessage({ type: "unknown" });
+    expect(ignored).toBeUndefined();
+    expect(await mod.dispatchMessage(null)).toBeUndefined();
+  });
+
+  it("paints and repaints the toolbar badge from storage changes", async () => {
+    const mod = await loadExtensionModules({ rankedCandidates: [1, 2] });
+    await flush();
+    expect(mod.setBadgeText).toHaveBeenCalledWith({ text: "2" });
+    expect(mod.setBadgeBackgroundColor).toHaveBeenCalledWith({
+      color: TOOLBAR_BADGE_HAS_DATA_COLOR,
+    });
+
+    mod.setBadgeText.mockClear();
+    await mod.backgroundInternals.refreshToolbarBadge();
+    expect(mod.setBadgeText).toHaveBeenLastCalledWith({ text: "2" });
+
+    const never = await loadExtensionModules({ rankedCandidates: undefined });
+    await flush();
+    never.setBadgeText.mockClear();
+    await never.backgroundInternals.refreshToolbarBadge();
+    expect(never.setBadgeText).toHaveBeenLastCalledWith({ text: TOOLBAR_BADGE_NO_DATA_TEXT });
+
+    const empty = await loadExtensionModules({ rankedCandidates: [] });
+    await flush();
+    empty.setBadgeText.mockClear();
+    await empty.backgroundInternals.refreshToolbarBadge();
+    expect(empty.setBadgeText).toHaveBeenLastCalledWith({ text: "" });
+    expect(empty.setBadgeBackgroundColor).toHaveBeenLastCalledWith({
+      color: TOOLBAR_BADGE_EMPTY_COLOR,
+    });
+
+    const live = await loadExtensionModules({ rankedCandidates: [9] });
+    await flush();
+    live.setBadgeText.mockClear();
+    live.fireChange({ rankedCandidates: { newValue: [9] } }, "local");
+    await flush();
+    expect(live.setBadgeText).toHaveBeenCalledTimes(1);
+
+    live.setBadgeText.mockClear();
+    live.fireChange({ rankedCandidates: { newValue: [9] } }, "sync");
+    live.fireChange({ watchedRepos: { newValue: [] } }, "local");
+    await flush();
+    expect(live.setBadgeText).not.toHaveBeenCalled();
+  });
+
+  it("swallows chrome.action failures during toolbar refresh", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const mod = await loadExtensionModules({ rankedCandidates: [1], failAction: true });
+    await flush();
+    await expect(mod.backgroundInternals.refreshToolbarBadge()).resolves.toBeUndefined();
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it("registers ambient sync alarms and lifecycle hooks when chrome surfaces exist", async () => {
+    const mod = await loadExtensionModules({
+      withAlarms: true,
+      withLifecycle: true,
+      fetchImpl: jsonFetch(200, { candidates: [] }),
+    });
+
+    expect(mod.alarmCreateCalls[0]?.[0]).toBe("gittensory-miner:sync-ranked-candidates");
+    mod.dispatchStartup();
+    mod.dispatchInstalled();
+    mod.dispatchAlarm("gittensory-miner:sync-ranked-candidates");
+    mod.dispatchAlarm("other-alarm");
+    await flush();
+    expect(mod.localSetCalls.length).toBeGreaterThan(0);
+  });
+
+  it("no-ops toolbar wiring when chrome.action is unavailable", async () => {
+    const mod = await loadExtensionModules({ rankedCandidates: [1, 2, 3], withAction: false });
+    await flush();
+    expect(typeof mod.backgroundInternals.refreshToolbarBadge).toBe("function");
+    expect(mod.setBadgeText).not.toHaveBeenCalled();
+  });
+});

--- a/apps/gittensory-miner-extension/test/helpers.ts
+++ b/apps/gittensory-miner-extension/test/helpers.ts
@@ -1,0 +1,195 @@
+import { vi } from "vitest";
+
+export const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+export type BackgroundInternals = {
+  PING_MESSAGE: string;
+  ISSUE_CONTEXT_MESSAGE: string;
+  SYNC_RANKED_CANDIDATES_MESSAGE: string;
+  DEFAULT_MINER_UI_URL: string;
+  loadIssueOpportunityContext: (message: {
+    owner: string;
+    repo: string;
+    issueNumber: number;
+  }) => Promise<Record<string, unknown>>;
+  loadMinerExtensionSettings: () => Promise<{ watchedRepos: string[] }>;
+  loadRankedCandidates: () => Promise<{ rankedCandidates: unknown[]; savedAt: number | null }>;
+  loadMinerUiUrl: () => Promise<string>;
+  syncRankedCandidatesFromMinerUi: () => Promise<Record<string, unknown>>;
+  refreshToolbarBadge: () => Promise<void>;
+};
+
+export type OpportunityBadgeExports = {
+  issueLookupKey: (repoFullName: unknown, issueNumber: unknown) => string | null;
+  lookupRankedOpportunity: (
+    rankedIssues: unknown,
+    repoFullName: string,
+    issueNumber: number,
+  ) => Record<string, unknown> | null;
+  scoreToTier: (rankScore: unknown) => string;
+  buildOpportunityWhy: (entry: Record<string, unknown>) => string;
+  formatOpportunityBadge: (entry: Record<string, unknown>) => {
+    tier: string;
+    score: string;
+    why: string;
+    rankScore: number | null;
+  };
+  formatLastSyncedLabel: (savedAt: unknown, nowMs: number) => string | null;
+  escapeOpportunityHtml: (value: unknown) => string;
+  renderOpportunityBadgeMarkup: (badge: Record<string, unknown>, lastSyncedLabel?: string | null) => string;
+};
+
+type ChromeMockOptions = {
+  watchedRepos?: string[];
+  syncGetResult?: Record<string, unknown>;
+  rankedCandidates?: unknown;
+  rankedCandidatesSavedAt?: number | null;
+  minerUiUrl?: string;
+  withAction?: boolean;
+  withAlarms?: boolean;
+  withLifecycle?: boolean;
+  failAction?: boolean;
+  syncGetThrows?: boolean;
+  syncGetRejectsWith?: unknown;
+  fetchImpl?: typeof fetch;
+};
+
+export function jsonFetch(status: number, payload: unknown): typeof fetch {
+  return (async () =>
+    ({
+      ok: status >= 200 && status < 300,
+      status,
+      json: async () => payload,
+    }) as unknown as Response) as typeof fetch;
+}
+
+export function buildChromeMock(options: ChromeMockOptions = {}) {
+  const watchedRepos = options.watchedRepos ?? [];
+  const rankedCandidates =
+    "rankedCandidates" in options ? options.rankedCandidates : [];
+  const rankedCandidatesSavedAt = options.rankedCandidatesSavedAt ?? null;
+  const minerUiUrl = options.minerUiUrl ?? "http://localhost:5174";
+  const withAction = options.withAction ?? true;
+  const withAlarms = options.withAlarms ?? false;
+  const withLifecycle = options.withLifecycle ?? false;
+  const failAction = options.failAction ?? false;
+  const syncGetThrows = options.syncGetThrows ?? false;
+  const syncGetRejectsWith = options.syncGetRejectsWith;
+
+  const localSetCalls: Array<Record<string, unknown>> = [];
+  const syncSetCalls: Array<Record<string, unknown>> = [];
+  const syncRemoveCalls: string[] = [];
+  const alarmCreateCalls: Array<[string, unknown]> = [];
+  let changeListener: ((changes: unknown, areaName: string) => void) | null = null;
+  let alarmListener: ((alarm: { name: string }) => void) | undefined;
+  let startupListener: (() => void) | undefined;
+  let installedListener: (() => void) | undefined;
+  let messageListener:
+    | ((message: unknown, sender: unknown, sendResponse: (response: unknown) => void) => boolean | void)
+    | undefined;
+
+  const setBadgeText = failAction
+    ? vi.fn(async () => {
+        throw new Error("chrome.action unavailable");
+      })
+    : vi.fn(async () => {});
+  const setBadgeBackgroundColor = vi.fn(async () => {});
+
+  const chrome: Record<string, unknown> = {
+    runtime: {
+      onMessage: {
+        addListener: (fn: typeof messageListener) => {
+          messageListener = fn;
+        },
+      },
+      ...(withLifecycle
+        ? {
+            onStartup: { addListener: (fn: typeof startupListener) => (startupListener = fn) },
+            onInstalled: { addListener: (fn: typeof installedListener) => (installedListener = fn) },
+          }
+        : {}),
+    },
+    storage: {
+      sync: {
+        get: syncGetThrows
+          ? async () => {
+              throw syncGetRejectsWith ?? new Error("sync storage unavailable");
+            }
+          : async () => ({ watchedRepos, minerUiUrl, ...(options.syncGetResult ?? {}) }),
+        set: async (value: Record<string, unknown>) => {
+          syncSetCalls.push(value);
+        },
+        remove: async (keys: string | string[]) => {
+          syncRemoveCalls.push(...(Array.isArray(keys) ? keys : [keys]));
+        },
+      },
+      local: {
+        get: async (arg: unknown) =>
+          typeof arg === "string"
+            ? { rankedCandidates }
+            : {
+                rankedCandidates: Array.isArray(rankedCandidates) ? rankedCandidates : [],
+                rankedCandidatesSavedAt,
+              },
+        set: async (value: Record<string, unknown>) => {
+          localSetCalls.push(value);
+        },
+      },
+      onChanged: withAction
+        ? { addListener: (fn: typeof changeListener) => (changeListener = fn) }
+        : undefined,
+    },
+  };
+
+  if (withAction) {
+    chrome.action = { setBadgeText, setBadgeBackgroundColor };
+  }
+  if (withAlarms) {
+    chrome.alarms = {
+      create: (name: string, info: unknown) => alarmCreateCalls.push([name, info]),
+      onAlarm: { addListener: (fn: typeof alarmListener) => (alarmListener = fn) },
+    };
+  }
+
+  return {
+    chrome,
+    localSetCalls,
+    syncSetCalls,
+    syncRemoveCalls,
+    alarmCreateCalls,
+    setBadgeText,
+    setBadgeBackgroundColor,
+    dispatchAlarm: (name: string) => alarmListener?.({ name }),
+    dispatchStartup: () => startupListener?.(),
+    dispatchInstalled: () => installedListener?.(),
+    dispatchMessage: (message: unknown) =>
+      new Promise((resolve) => {
+        const keepChannelOpen = messageListener?.(message, {}, resolve);
+        if (!keepChannelOpen) resolve(undefined);
+      }),
+    fireChange: (changes: unknown, areaName: string) => changeListener?.(changes, areaName),
+  };
+}
+
+export async function loadExtensionModules(options: ChromeMockOptions = {}) {
+  vi.resetModules();
+  vi.unstubAllGlobals();
+
+  const harness = buildChromeMock(options);
+  vi.stubGlobal("chrome", harness.chrome);
+  vi.stubGlobal("__GITTENSORY_MINER_EXTENSION_TEST__", true);
+  if (options.fetchImpl) vi.stubGlobal("fetch", options.fetchImpl);
+
+  await import("../opportunity-badge.js");
+  await import("../toolbar-badge.js");
+  await import("../background.js");
+
+  return {
+    ...harness,
+    opportunityExports: globalThis.__gittensoryMinerOpportunityBadgeTestExports as OpportunityBadgeExports,
+    toolbarApi: globalThis.__gittensoryMinerToolbarBadge as {
+      computeToolbarBadge: (rankedCandidates: unknown) => { text: string; backgroundColor: string };
+    },
+    backgroundInternals: globalThis.__gittensoryMinerBackgroundInternals as BackgroundInternals,
+  };
+}

--- a/apps/gittensory-miner-extension/test/opportunity-badge.test.ts
+++ b/apps/gittensory-miner-extension/test/opportunity-badge.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { loadExtensionModules } from "./helpers.js";
+
+const NOW_MS = Date.parse("2026-07-10T12:00:00.000Z");
+
+describe("opportunity-badge exports", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.resetModules();
+    vi.restoreAllMocks();
+  });
+
+  it("builds stable repo#issue lookup keys and finds ranked entries", async () => {
+    const { opportunityExports: badge } = await loadExtensionModules();
+    expect(badge.issueLookupKey("JSONbored/gittensory", 145)).toBe("jsonbored/gittensory#145");
+    expect(badge.issueLookupKey("", 1)).toBeNull();
+    expect(badge.issueLookupKey("a/b", 0)).toBeNull();
+
+    const ranked = [
+      { repoFullName: "JSONbored/gittensory", issueNumber: 145, rankScore: 0.8 },
+      { repoFullName: "owner/repo", issueNumber: 2, rankScore: 0.4 },
+    ];
+    expect(badge.lookupRankedOpportunity(ranked, "JSONbored/gittensory", 145)?.rankScore).toBe(0.8);
+    expect(badge.lookupRankedOpportunity(ranked, "JSONbored/gittensory", 404)).toBeNull();
+    expect(badge.lookupRankedOpportunity(null, "a/b", 1)).toBeNull();
+  });
+
+  it("formats tier, score, and why without duplicating ranking math", async () => {
+    const { opportunityExports: badge } = await loadExtensionModules();
+    const entry = {
+      rankScore: 0.82,
+      laneFit: 0.9,
+      freshness: 0.8,
+      potential: 0.7,
+      feasibility: 0.75,
+      dupRisk: 0.1,
+    };
+    const formatted = badge.formatOpportunityBadge(entry);
+    expect(formatted.tier).toBe("High");
+    expect(formatted.score).toBe("0.82");
+    expect(formatted.why.length).toBeGreaterThan(0);
+    expect(badge.scoreToTier(0.6)).toBe("Medium");
+    expect(badge.scoreToTier(0.2)).toBe("Low");
+
+    const fallback = badge.formatOpportunityBadge({ rankScore: Number.NaN });
+    expect(fallback.tier).toBe("Unknown");
+    expect(fallback.score).toBe("—");
+    expect(fallback.rankScore).toBeNull();
+    expect(badge.buildOpportunityWhy({})).toBe("Balanced opportunity signals");
+    expect(badge.buildOpportunityWhy({ laneFit: 0.8 })).toContain("lane fit");
+    expect(badge.buildOpportunityWhy({ freshness: 0.8 })).toContain("Fresh issue");
+    expect(badge.buildOpportunityWhy({ potential: 0.8 })).toContain("reward potential");
+    expect(badge.buildOpportunityWhy({ feasibility: 0.8 })).toContain("Feasible scope");
+    expect(badge.buildOpportunityWhy({ dupRisk: 0.1 })).toContain("duplicate risk");
+  });
+
+  it("skips malformed ranked entries while scanning the cache", async () => {
+    const { opportunityExports: badge } = await loadExtensionModules();
+    const ranked = [
+      null,
+      { repoFullName: "a/b", issueNumber: "nope" },
+      { repoFullName: "JSONbored/gittensory", issueNumber: 145, rankScore: 0.5 },
+    ];
+    expect(badge.lookupRankedOpportunity(ranked, "JSONbored/gittensory", 145)?.rankScore).toBe(0.5);
+  });
+
+  it("formats relative last-synced labels and escapes badge markup", async () => {
+    const { opportunityExports: badge } = await loadExtensionModules();
+    expect(badge.formatLastSyncedLabel(NOW_MS, NOW_MS)).toBe("last synced just now");
+    expect(badge.formatLastSyncedLabel(NOW_MS - 60_000, NOW_MS)).toBe("last synced 1m ago");
+    expect(badge.formatLastSyncedLabel(NOW_MS - 60 * 60_000, NOW_MS)).toBe("last synced 1h ago");
+    expect(badge.formatLastSyncedLabel(NOW_MS - 24 * 60 * 60_000, NOW_MS)).toBe("last synced 1d ago");
+    expect(badge.formatLastSyncedLabel(null, NOW_MS)).toBeNull();
+
+    const formatted = badge.formatOpportunityBadge({ rankScore: 0.6 });
+    const markup = badge.renderOpportunityBadgeMarkup(formatted, "last synced 3m ago");
+    expect(markup).toContain("Read-only");
+    expect(markup).toContain("last synced 3m ago");
+    expect(markup).not.toContain("<script>");
+    expect(badge.renderOpportunityBadgeMarkup(null as unknown as Record<string, unknown>)).toBe("");
+    expect(badge.renderOpportunityBadgeMarkup(formatted, null)).not.toContain("last synced");
+    expect(badge.escapeOpportunityHtml(`<&>"'>`)).toContain("&gt;");
+  });
+});

--- a/apps/gittensory-miner-extension/test/toolbar-badge.test.ts
+++ b/apps/gittensory-miner-extension/test/toolbar-badge.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import {
+  computeToolbarBadge,
+  TOOLBAR_BADGE_EMPTY_COLOR,
+  TOOLBAR_BADGE_HAS_DATA_COLOR,
+  TOOLBAR_BADGE_NO_DATA_TEXT,
+} from "../toolbar-badge.js";
+
+describe("computeToolbarBadge", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("shows the count with the has-data color when candidates are populated", () => {
+    expect(computeToolbarBadge([{}, {}, {}])).toEqual({
+      text: "3",
+      backgroundColor: TOOLBAR_BADGE_HAS_DATA_COLOR,
+    });
+    expect(computeToolbarBadge([{}])).toEqual({
+      text: "1",
+      backgroundColor: TOOLBAR_BADGE_HAS_DATA_COLOR,
+    });
+  });
+
+  it("clears the text for an empty array", () => {
+    expect(computeToolbarBadge([])).toEqual({
+      text: "",
+      backgroundColor: TOOLBAR_BADGE_EMPTY_COLOR,
+    });
+  });
+
+  it("shows a dash for never-populated or malformed values", () => {
+    for (const malformed of [undefined, null, "12", 7, { length: 5 }, true]) {
+      expect(computeToolbarBadge(malformed)).toEqual({
+        text: TOOLBAR_BADGE_NO_DATA_TEXT,
+        backgroundColor: TOOLBAR_BADGE_EMPTY_COLOR,
+      });
+    }
+  });
+});

--- a/apps/gittensory-miner-extension/vitest.config.ts
+++ b/apps/gittensory-miner-extension/vitest.config.ts
@@ -1,0 +1,23 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+    include: ["test/**/*.test.ts"],
+    coverage: {
+      provider: "v8",
+      // Import-based suite only: content.js/options.js need a jsdom mount harness (deferred follow-up).
+      include: ["background.js", "opportunity-badge.js", "toolbar-badge.js"],
+      reporter: ["text", "lcov"],
+      // Measured baseline (#4865) with a small buffer below the day-this-was-wired numbers so routine
+      // churn does not false-fail. Raise per-PR as content.js/options.js get covered.
+      thresholds: {
+        statements: 98,
+        branches: 94,
+        functions: 98,
+        lines: 98,
+      },
+    },
+  },
+});

--- a/apps/gittensory-miner-ui/README.md
+++ b/apps/gittensory-miner-ui/README.md
@@ -46,5 +46,5 @@ job — the dashboard is a long-running HTTP server, not a periodic batch task.
 `npm test` runs with `--coverage` enabled (v8 provider) and enforces `vitest.config.ts`'s `coverage.thresholds`
 — a real measured baseline (#4865), not an aspirational target, so CI fails on a genuine regression (e.g. a
 large new feature landing with no tests) rather than staying silently unmeasured the way `apps/**` is by
-default at the repo root. `apps/gittensory-miner-extension` is not yet under this gate — its own test
-instrumentation needs to exist first (see #4865's own scope note).
+default at the repo root. `apps/gittensory-miner-extension` has its own matching gate (`npm test` in that workspace);
+see its README for scope notes on deferred `content.js`/`options.js` coverage.

--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,10 @@
     },
     "apps/gittensory-miner-extension": {
       "name": "@jsonbored/gittensory-miner-extension",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "devDependencies": {
+        "vitest": "^4.1.9"
+      }
     },
     "apps/gittensory-miner-ui": {
       "name": "@loopover/ui-miner",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "ui:preview": "npm run ui:build && wrangler dev --config apps/gittensory-ui/dist/server/wrangler.json --ip 127.0.0.1 --port 4173 --local",
     "ui:lint": "npm run ui:kit:build && npm --workspace @loopover/ui run lint && npm --workspace @loopover/ui-miner run lint",
     "ui:typecheck": "npm run ui:kit:build && npm --workspace @loopover/ui run typecheck && npm --workspace @loopover/ui-miner run typecheck",
-    "ui:test": "npm run ui:kit:build && npm --workspace @loopover/ui run test && npm --workspace @loopover/ui-miner run test",
+    "ui:test": "npm run ui:kit:build && npm --workspace @loopover/ui run test && npm --workspace @loopover/ui-miner run test && npm --workspace @jsonbored/gittensory-miner-extension run test",
     "ui:openapi": "tsx scripts/write-ui-openapi.ts",
     "ui:openapi:check": "tsx scripts/write-ui-openapi.ts --check",
     "ui:openapi:settings-parity": "tsx scripts/check-openapi-settings-parity.mjs",

--- a/test/unit/codecov-policy.test.ts
+++ b/test/unit/codecov-policy.test.ts
@@ -85,6 +85,26 @@ describe("Codecov policy", () => {
     expect(ignore.some((entry) => typeof entry === "string" && entry.includes("gittensory-miner"))).toBe(false);
   });
 
+  it("keeps miner-ui and miner-extension under app-local coverage gates (#4865)", () => {
+    const minerUi = readFileSync("apps/gittensory-miner-ui/vitest.config.ts", "utf8");
+    const minerExtension = readFileSync("apps/gittensory-miner-extension/vitest.config.ts", "utf8");
+    const minerUiPkg = JSON.parse(readFileSync("apps/gittensory-miner-ui/package.json", "utf8")) as {
+      scripts: Record<string, string>;
+    };
+    const minerExtensionPkg = JSON.parse(
+      readFileSync("apps/gittensory-miner-extension/package.json", "utf8"),
+    ) as { scripts: Record<string, string> };
+    const rootPkg = JSON.parse(readFileSync("package.json", "utf8")) as { scripts: Record<string, string> };
+
+    expect(minerUi).toMatch(/coverage:\s*\{/);
+    expect(minerUi).toMatch(/thresholds:/);
+    expect(minerExtension).toMatch(/coverage:\s*\{/);
+    expect(minerExtension).toMatch(/thresholds:/);
+    expect(minerUiPkg.scripts.test).toContain("--coverage");
+    expect(minerExtensionPkg.scripts.test).toContain("--coverage");
+    expect(rootPkg.scripts["ui:test"]).toContain("@jsonbored/gittensory-miner-extension run test");
+  });
+
   it("uploads fork PR coverage tokenlessly instead of silently skipping it", () => {
     // Fork PRs cannot read secrets.CODECOV_TOKEN. Previously the token-gated upload steps simply
     // excluded forks with no replacement, so codecov/patch had no report to compare against and fell


### PR DESCRIPTION
Closes #4865

### Summary

- `apps/gittensory-miner-extension` was excluded from Codecov via the blanket `apps/**` ignore, and its existing root `test/unit/miner-*.test.ts` suites run source through a `node:vm` harness that v8 cannot attribute coverage to.
- This PR completes the **extension half** of #4865. The **miner-ui half** already shipped on `main` in #5613 (`apps/gittensory-miner-ui/vitest.config.ts` + `npm test --coverage`).
- Adds an app-local, **import-based** vitest suite that imports `background.js`, `opportunity-badge.js`, and `toolbar-badge.js` directly (via the existing `__GITTENSORY_MINER_EXTENSION_TEST__` hook) so v8 attributes real coverage, with measured baseline thresholds enforced by `npm test`.

### Change

- **`apps/gittensory-miner-extension/vitest.config.ts`** — v8 coverage scoped to the three covered source files; thresholds set at a measured baseline (98/94/98/98) with buffer below the wired-day numbers.
- **`apps/gittensory-miner-extension/test/`** — 19 tests across:
  - `toolbar-badge.test.ts` — pure state map (`computeToolbarBadge`)
  - `opportunity-badge.test.ts` — lookup, formatting, markup escaping
  - `background.test.ts` — issue context, sync, message routing, toolbar badge wiring, alarms/lifecycle
- **`apps/gittensory-miner-extension/package.json`** — `test` script → `vitest run --coverage`; adds `vitest` devDependency.
- **`package.json`** — `ui:test` now runs `@jsonbored/gittensory-miner-extension run test`.
- **`test/unit/codecov-policy.test.ts`** — regression guard that both miner-ui and miner-extension have app-local coverage gates wired into `ui:test`.
- **README updates** — document the gate and deferred scope in both miner apps.

### Deferred scope (issue still open after merge)

- `content.js` and `options.js` need a jsdom mount harness before coverage attribution is meaningful — deliberately left for a follow-up.
- Codecov `apps/**` ignore is unchanged; measurement is via app-local vitest thresholds (same pattern as #5613), not `codecov/patch`.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused (miner-extension coverage gate + minimal wiring/docs) and does not mix unrelated changes.
- [x] This follows `CONTRIBUTING.md` and does not touch `site/`, `CNAME`, or `**/lovable/**`.
- [x] Linked issue: **Closes #4865** (miner-ui half already on `main` via #5613).

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint` (not run — no `.github/workflows/**` changes)
- [x] `npm run typecheck` (not run — no `src/**` changes)
- [x] `npm run test:coverage` (full unsharded gate — run before push)
- [x] `npm run test:workers` (not run — no Workers pool changes)
- [x] `npm run build:mcp` / `npm run test:mcp-pack` (not run — no MCP changes)
- [x] `npm run ui:openapi:check` (not run — no OpenAPI changes)
- [x] `npm run ui:lint` / `npm run ui:typecheck` / `npm run ui:build` (run via `npm run test:ci` before push)
- [x] `npm audit --audit-level=moderate`
- [x] `npm --workspace @jsonbored/gittensory-miner-extension run test` — 19 passing; coverage **100% stmts / 95.79% branches / 100% funcs / 100% lines** over configured floor
- [x] `npm run test -- --run test/unit/codecov-policy.test.ts` — 5 passing

If any required check was skipped, explain why:

- Changes are under `apps/**` and `test/**` only — outside Codecov-measured `src/**` / `lib/**`, so no `codecov/patch` obligation. The new gate is the extension's own vitest threshold. Full `npm run test:ci` should still be run locally before push.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, private keys, trust scores, or private rankings exposed.
- [x] Public GitHub text unaffected — tests + config + docs only; no runtime behavior change.
- [x] Auth/cookie/CORS/session — n/a.
- [x] API/OpenAPI/MCP — n/a.
- [x] No visible UI or extension-behavior change.
- [x] No changelog edit.

## UI Evidence

No visible UI or extension-behavior change. This PR only adds a test suite, coverage-gate config, `ui:test` wiring, and README notes — same as the miner-ui coverage-gate PR #5613. No screenshots required.

## Notes

- Root `test/unit/miner-*.test.ts` VM-based behavior tests are **left in place**; the new app-local suite's role is coverage instrumentation the VM harness structurally cannot provide.
- Thresholds are a regression floor with buffer, not an aspirational target — raise per-PR as `content.js`/`options.js` get covered.

## Files to commit

```
apps/gittensory-miner-extension/vitest.config.ts
apps/gittensory-miner-extension/test/helpers.ts
apps/gittensory-miner-extension/test/toolbar-badge.test.ts
apps/gittensory-miner-extension/test/opportunity-badge.test.ts
apps/gittensory-miner-extension/test/background.test.ts
apps/gittensory-miner-extension/package.json
apps/gittensory-miner-extension/README.md
apps/gittensory-miner-ui/README.md
package.json
package-lock.json
test/unit/codecov-policy.test.ts
```