### PR TITLE
docs(miner): publish a measured CPU/RAM/disk sizing table for laptop vs fleet mode

### DIFF
--- a/packages/gittensory-miner/DEPLOYMENT.md
+++ b/packages/gittensory-miner/DEPLOYMENT.md
@@ -154,6 +154,9 @@ Want the dashboard too? [`systemd/gittensory-miner-ui.service.example`](../../sy
 
 See [`docs/operations-runbook.md`](docs/operations-runbook.md) for operational scenarios: ledger corruption, two miners on one state dir, and post-upgrade schema migration ([#4875](https://github.com/JSONbored/gittensory/issues/4875)).
 
+See [`docs/sizing.md`](docs/sizing.md) for measured CPU/RAM/disk numbers for laptop mode vs. fleet mode at
+different worker counts, with the exact commands used to reproduce them.
+
 ## Optional hosted discovery plane (opt-in)
 
 The Phase 6 **hosted discovery-index** is **off by default** — unlike Orb fleet export (`ORB_AIR_GAP` is the only opt-out). Operators who want cross-fleet metadata queries or soft-claim coordination must opt in explicitly. See [`docs/discovery-plane-operator-guide.md`](docs/discovery-plane-operator-guide.md) ([#4309](https://github.com/JSONbored/gittensory/issues/4309), placeholder until [#4300](https://github.com/JSONbored/gittensory/issues/4300) / [#4301](https://github.com/JSONbored/gittensory/issues/4301) / [#4302](https://github.com/JSONbored/gittensory/issues/4302) ship).

--- a/packages/gittensory-miner/README.md
+++ b/packages/gittensory-miner/README.md
@@ -161,6 +161,9 @@ See [`DEPLOYMENT.md`](DEPLOYMENT.md) for laptop vs fleet deployment.
 
 See [`docs/operations-runbook.md`](docs/operations-runbook.md) for SQLite concurrency guarantees, corruption recovery, multi-process collision response, and post-upgrade ledger migration ([#4875](https://github.com/JSONbored/gittensory/issues/4875)).
 
+See [`docs/sizing.md`](docs/sizing.md) for measured CPU/RAM/disk numbers across laptop mode and fleet mode at
+different worker counts.
+
 ### Laptop-mode quickstart
 
 Zero-infra local install — no Docker, Redis, or Postgres required:

--- a/packages/gittensory-miner/docs/sizing.md
+++ b/packages/gittensory-miner/docs/sizing.md
@@ -1,0 +1,96 @@
+# gittensory-miner resource sizing
+
+Real, measured CPU/RAM/disk numbers for laptop mode and fleet mode, so an operator can size a host or
+cluster from data instead of guessing. Neither the operational-runbook issue nor the local-stores
+documentation commits to this — this doc is scoped strictly to the numbers and how they were captured.
+
+## Measurement environment
+
+- Linux x86_64 sandbox, 4 vCPU, 9.5 GiB RAM.
+- Node.js 24 (the version the [`Dockerfile`](../Dockerfile) builds on; the host running the laptop-mode
+  measurements below used the repo's own pinned Node 22.13+ requirement).
+- Absolute numbers are host-dependent — treat these as a rough sense of scale, not a hard target. Re-run the
+  exact commands below on your own hardware for numbers specific to it.
+
+## Workload measured
+
+Both modes measure `gittensory-miner init` (laptop mode only) followed by `gittensory-miner discover
+<owner/repo> [<owner/repo>...] --json` against real, small public repositories (`octocat/Hello-World`,
+`octocat/Spoon-Knife`) with **no `GITHUB_TOKEN`** — real, unauthenticated GitHub GET requests, metadata
+fan-out + deterministic ranking, no writes.
+
+**Deliberately excluded: a live `attempt` cycle.** Sizing a real coding-agent attempt would need an
+operator-supplied `GITHUB_TOKEN` and coding-agent CLI credentials, and creates a real branch/PR against a real
+target repository — not something to spend for a resource-sizing exercise, and not reproducible by a reviewer
+without supplying their own credentials. `discover` is measured instead because it is the dominant,
+always-run, network- and CPU-bound phase every mode exercises identically; `attempt`'s resource profile is
+dominated by the operator's chosen coding-agent CLI process, not by anything this package controls.
+
+## Methodology
+
+- **Laptop mode CPU/RAM**: GNU `/usr/bin/time -v` around the CLI process directly (no container).
+- **Laptop mode disk**: `du -sh`/`du -ah` on the resolved `GITTENSORY_MINER_CONFIG_DIR` after the run.
+- **Fleet mode CPU/RAM**: `docker stats --no-stream` polled once per second per container while each worker
+  ran `discover` followed by a `sleep` tail (so short-lived containers stay observable long enough to sample);
+  the reported number is the peak observed sample per container.
+- **Fleet mode disk**: `du -sh`/`du -ah` on each worker's mounted `/data/miner` volume after the run, via a
+  disposable `alpine` container mounting the same named volume.
+- **N=4 isolation**: per `docker-compose.miner.yml`'s own documented warning, N replicas sharing one volume
+  corrupt/contend on the SQLite ledgers — so N=4 here means **four separate named volumes** (`docker run -d -v
+  miner-n<i>:/data/miner ...` per worker), the same isolation pattern the compose file itself recommends, not
+  a single shared-volume `--scale`.
+
+### Exact commands (laptop mode)
+
+```sh
+GITTENSORY_MINER_CONFIG_DIR=/tmp/sizing-laptop /usr/bin/time -v \
+  node packages/gittensory-miner/bin/gittensory-miner.js init --json
+
+GITTENSORY_MINER_CONFIG_DIR=/tmp/sizing-laptop /usr/bin/time -v \
+  node packages/gittensory-miner/bin/gittensory-miner.js discover octocat/Hello-World --dry-run --json
+
+du -sh /tmp/sizing-laptop
+```
+
+### Exact commands (fleet mode, N=1 shown; N=4 repeats the `docker run` with 4 distinct names/volumes)
+
+```sh
+docker build -f packages/gittensory-miner/Dockerfile -t gittensory-miner:sizing .
+
+docker volume create miner-sizing-1
+docker run -d --name miner-sizing-1 -v miner-sizing-1:/data/miner --entrypoint sh gittensory-miner:sizing \
+  -c "gittensory-miner discover octocat/Hello-World octocat/Spoon-Knife --json > /tmp/out.json 2>&1; sleep 20"
+
+for i in $(seq 1 20); do
+  docker stats --no-stream --format '{{.Container}}\t{{.CPUPerc}}\t{{.MemUsage}}' miner-sizing-1
+done
+
+docker run --rm -v miner-sizing-1:/data alpine du -ah /data
+```
+
+## Results
+
+| Mode | Workers | Peak CPU | Peak RAM | Disk (per worker) | Environment |
+| --- | --- | --- | --- | --- | --- |
+| Laptop (`init`) | 1 | 125% (short burst, Node startup) | 74 MB | — | Sandbox above |
+| Laptop (`discover`, 1 repo, 90 issues) | 1 | 16% (network-bound) | 98 MB | 100 KB (5 SQLite files after `init` + `discover`) | Sandbox above |
+| Fleet (Docker, `discover`, 2 repos) | 1 | 54% (short burst) | 46 MB | 92 KB (4 SQLite files) | Sandbox above, `gittensory-miner:sizing` image (333 MB) |
+| Fleet (Docker, `discover`, 2 repos) | 4 (isolated volumes) | 5–38% per worker (bursts did not line up across workers) | 34–45 MB per worker | 92 KB per worker (368 KB total across 4 isolated volumes) | Sandbox above |
+
+**Takeaways:**
+
+- `discover`'s CPU cost is dominated by waiting on GitHub's API, not local computation — laptop mode measured
+  16% CPU utilization over a 5.6s wall-clock run.
+- Per-worker memory (46 MB for fleet mode, 74–98 MB for the laptop-mode CLI process) did not measurably change
+  between N=1 and N=4 — each worker is an independent Node process with no shared heap, so four isolated
+  workers cost roughly 4× one worker's footprint, not more.
+- Local SQLite disk usage is small (under 100 KB per worker for this workload) and grows with the number of
+  distinct stores a command touches, not with fan-out volume — `discover` alone never touches the larger
+  per-attempt stores (`attempt-log.sqlite3`, `worktree-allocator.sqlite3`, etc.), which only grow once real
+  attempts run.
+- The 333 MB fleet image is dominated by the Node 24 base image and `node_modules`; `npm prune --omit=dev` in
+  the Dockerfile already strips dev dependencies from the runtime stage.
+
+See [`DEPLOYMENT.md`](../DEPLOYMENT.md) for the laptop-mode and fleet-mode setup walkthroughs these numbers
+apply to, and [`docs/operations-runbook.md`](operations-runbook.md) for operational scenarios beyond initial
+sizing.


### PR DESCRIPTION
## Summary

- Neither the operational-runbook issue (#4875) nor the local-stores documentation issue (#4870) commits to
  publishing real, measured resource numbers — both are scoped to narrative/reference content, not a sizing
  table. Operators had no data-backed answer to "how much CPU/RAM/disk does one laptop-mode run need, and how
  does that scale in fleet mode?"
- Added `packages/gittensory-miner/docs/sizing.md` with real, measured numbers for both modes, the exact
  reproduction commands, and the measurement environment, so the numbers are reproducible and falsifiable by a
  reviewer — not asserted from memory.
- **Workload measured**: `gittensory-miner init` (laptop mode only) followed by `gittensory-miner discover
  <owner/repo>... --json` against real, small public repos (`octocat/Hello-World`, `octocat/Spoon-Knife`) with
  no `GITHUB_TOKEN` — real unauthenticated GitHub GETs, metadata fan-out + ranking, zero writes.
- **Deliberately excluded a live `attempt` cycle**: that needs operator-supplied `GITHUB_TOKEN` + coding-agent
  CLI credentials and writes a real branch/PR to a real target repo — not something to spend for a
  resource-sizing exercise, and not reproducible by a reviewer without their own credentials. `discover` is
  measured instead as the dominant, always-run, network-bound phase every mode exercises identically.
- **Laptop mode**: measured directly with GNU `/usr/bin/time -v` around the CLI process (no container).
- **Fleet mode**: built the real `packages/gittensory-miner/Dockerfile` image and measured with `docker stats
  --no-stream` polled once per second per container, at N=1 and N=4 workers. Per `docker-compose.miner.yml`'s
  own documented warning that N replicas sharing one volume corrupt/contend on the SQLite ledgers, N=4 here
  means **four separate named volumes** (`docker run -d -v miner-n<i>:/data/miner ...` per worker) — the same
  isolation pattern the compose file itself recommends, not a single shared-volume `--scale`.
- **Disk**: `du -sh`/`du -ah` on the resolved state dir (laptop mode) or each worker's mounted volume via a
  disposable `alpine` container (fleet mode), after the run.

### Measured results

| Mode | Workers | Peak CPU | Peak RAM | Disk (per worker) |
| --- | --- | --- | --- | --- |
| Laptop (`init`) | 1 | 125% (short Node-startup burst) | 74 MB | — |
| Laptop (`discover`, 1 repo, 90 issues) | 1 | 16% (network-bound) | 98 MB | 100 KB |
| Fleet/Docker (`discover`, 2 repos) | 1 | 54% (short burst) | 46 MB | 92 KB |
| Fleet/Docker (`discover`, 2 repos) | 4 (isolated volumes) | 5–38% per worker | 34–45 MB per worker | 92 KB per worker |

Measured on a 4 vCPU / 9.5 GiB RAM Linux sandbox — see `docs/sizing.md` for the full methodology, exact
commands, environment caveat, and takeaways (per-worker memory does not measurably change between N=1 and N=4
since each worker is an independent Node process with no shared heap; CPU is dominated by waiting on GitHub's
API, not local computation).

Fixes #5182

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` — N/A: this is a docs-only deliverable with no `src/**` logic change and no new measurement script/helper added (the issue's own Test Coverage Requirements only apply "if any measurement script or helper is added to produce the numbers" — none was; the numbers were captured with ad-hoc, documented shell commands, all reproduced exactly in the doc itself).
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run build:miner`
- [x] `npm run test:miner-pack` — confirmed `docs/sizing.md` packs correctly into the published `@loopover/miner` tarball.
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — N/A, docs-only.

Ran the full local gate: `npm run test:ci` (0 failures) and `npm audit --audit-level=moderate` (0 vulnerabilities), both clean on the final commit. Also directly ran the exact `FORBIDDEN_PATH`/`FORBIDDEN_CONTENT` regexes from `scripts/check-miner-package.mjs`/`scripts/forbidden-content.mjs` against every new/touched file — zero matches.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, docs-only, no auth/session/CORS surface touched.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. — no public API/OpenAPI/MCP surface touched.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI surface.
- [x] Visible UI changes include a `UI Evidence` section below. — N/A, see below.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — added `docs/sizing.md`, cross-linked from `README.md` and `DEPLOYMENT.md`.

## UI Evidence

N/A — this is a docs-only change with no visible UI surface. No screenshots apply.

## Notes

- Deliberately did not fold broader operational-runbook content into this PR, per the issue's own scope note —
  strictly the sizing table, methodology, and reproduction commands.
- All numbers in this PR were captured by directly running the commands shown in `docs/sizing.md`'s
  "Methodology" section against this repo's own `Dockerfile`/CLI on the environment described — none were
  estimated, interpolated, or asserted from memory.
