### PR TITLE
feat(observability): add an AMS attempts & predictions Grafana dashboard

### DIFF
--- a/grafana/dashboards/miner-usage.json
+++ b/grafana/dashboards/miner-usage.json
@@ -1,0 +1,366 @@
+{
+  "uid": "loopover-miner-usage",
+  "title": "LoopOver \u2014 AMS (miner) attempts & predictions",
+  "tags": [
+    "loopover",
+    "ams",
+    "miner",
+    "observability"
+  ],
+  "timezone": "browser",
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "",
+  "time": {
+    "from": "now-7d",
+    "to": "now"
+  },
+  "description": "AMS (gittensory-miner) attempt outcomes and prediction/readiness activity, read from the redacted AMS SQLite reporting exports (#5185).",
+  "links": [],
+  "panels": [
+    {
+      "id": 1,
+      "type": "stat",
+      "title": "Total attempts",
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "ams-attempt-log"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "blue"
+          }
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT count(DISTINCT attempt_id) AS value FROM attempt_log_events WHERE unixepoch(created_at) >= ${__from:date:seconds} AND unixepoch(created_at) < ${__to:date:seconds}",
+          "rawQueryText": "SELECT count(DISTINCT attempt_id) AS value FROM attempt_log_events WHERE unixepoch(created_at) >= ${__from:date:seconds} AND unixepoch(created_at) < ${__to:date:seconds}"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Succeeded",
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "ams-attempt-log"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "green"
+          }
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT count(*) AS value FROM attempt_log_events WHERE event_type = 'attempt_succeeded' AND unixepoch(created_at) >= ${__from:date:seconds} AND unixepoch(created_at) < ${__to:date:seconds}",
+          "rawQueryText": "SELECT count(*) AS value FROM attempt_log_events WHERE event_type = 'attempt_succeeded' AND unixepoch(created_at) >= ${__from:date:seconds} AND unixepoch(created_at) < ${__to:date:seconds}"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "stat",
+      "title": "Failed",
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "ams-attempt-log"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 12,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "red"
+          }
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT count(*) AS value FROM attempt_log_events WHERE event_type = 'attempt_failed' AND unixepoch(created_at) >= ${__from:date:seconds} AND unixepoch(created_at) < ${__to:date:seconds}",
+          "rawQueryText": "SELECT count(*) AS value FROM attempt_log_events WHERE event_type = 'attempt_failed' AND unixepoch(created_at) >= ${__from:date:seconds} AND unixepoch(created_at) < ${__to:date:seconds}"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "type": "stat",
+      "title": "Aborted",
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "ams-attempt-log"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 18,
+        "y": 0
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "orange"
+          }
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT count(*) AS value FROM attempt_log_events WHERE event_type = 'attempt_aborted' AND unixepoch(created_at) >= ${__from:date:seconds} AND unixepoch(created_at) < ${__to:date:seconds}",
+          "rawQueryText": "SELECT count(*) AS value FROM attempt_log_events WHERE event_type = 'attempt_aborted' AND unixepoch(created_at) >= ${__from:date:seconds} AND unixepoch(created_at) < ${__to:date:seconds}"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "type": "piechart",
+      "title": "Attempt outcomes",
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "ams-attempt-log"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 5
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "values": [
+            "value"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT event_type AS metric, count(*) AS value FROM attempt_log_events WHERE event_type IN ('attempt_succeeded','attempt_failed','attempt_aborted') AND unixepoch(created_at) >= ${__from:date:seconds} AND unixepoch(created_at) < ${__to:date:seconds} GROUP BY event_type",
+          "rawQueryText": "SELECT event_type AS metric, count(*) AS value FROM attempt_log_events WHERE event_type IN ('attempt_succeeded','attempt_failed','attempt_aborted') AND unixepoch(created_at) >= ${__from:date:seconds} AND unixepoch(created_at) < ${__to:date:seconds} GROUP BY event_type"
+        }
+      ]
+    },
+    {
+      "id": 6,
+      "type": "piechart",
+      "title": "Attempts by execution mode",
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "ams-attempt-log"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 5
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "values": [
+            "value"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT mode AS metric, count(DISTINCT attempt_id) AS value FROM attempt_log_events WHERE unixepoch(created_at) >= ${__from:date:seconds} AND unixepoch(created_at) < ${__to:date:seconds} GROUP BY mode",
+          "rawQueryText": "SELECT mode AS metric, count(DISTINCT attempt_id) AS value FROM attempt_log_events WHERE unixepoch(created_at) >= ${__from:date:seconds} AND unixepoch(created_at) < ${__to:date:seconds} GROUP BY mode"
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "type": "table",
+      "title": "Top action classes",
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "ams-attempt-log"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 5
+      },
+      "fieldConfig": {
+        "defaults": {}
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT action_class, count(*) AS events FROM attempt_log_events WHERE unixepoch(created_at) >= ${__from:date:seconds} AND unixepoch(created_at) < ${__to:date:seconds} GROUP BY action_class ORDER BY events DESC LIMIT 15",
+          "rawQueryText": "SELECT action_class, count(*) AS events FROM attempt_log_events WHERE unixepoch(created_at) >= ${__from:date:seconds} AND unixepoch(created_at) < ${__to:date:seconds} GROUP BY action_class ORDER BY events DESC LIMIT 15"
+        }
+      ]
+    },
+    {
+      "id": 8,
+      "type": "stat",
+      "title": "Total predictions",
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "ams-prediction-ledger"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 0,
+        "y": 13
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "purple"
+          }
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT count(*) AS value FROM predictions WHERE unixepoch(ts) >= ${__from:date:seconds} AND unixepoch(ts) < ${__to:date:seconds}",
+          "rawQueryText": "SELECT count(*) AS value FROM predictions WHERE unixepoch(ts) >= ${__from:date:seconds} AND unixepoch(ts) < ${__to:date:seconds}"
+        }
+      ]
+    },
+    {
+      "id": 9,
+      "type": "stat",
+      "title": "Avg readiness score",
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "ams-prediction-ledger"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 6,
+        "x": 6,
+        "y": 13
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "color": {
+            "mode": "fixed",
+            "fixedColor": "blue"
+          }
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT avg(readiness_score) AS value FROM predictions WHERE readiness_score IS NOT NULL AND unixepoch(ts) >= ${__from:date:seconds} AND unixepoch(ts) < ${__to:date:seconds}",
+          "rawQueryText": "SELECT avg(readiness_score) AS value FROM predictions WHERE readiness_score IS NOT NULL AND unixepoch(ts) >= ${__from:date:seconds} AND unixepoch(ts) < ${__to:date:seconds}"
+        }
+      ]
+    },
+    {
+      "id": 10,
+      "type": "piechart",
+      "title": "Predictions by conclusion",
+      "datasource": {
+        "type": "frser-sqlite-datasource",
+        "uid": "ams-prediction-ledger"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 13
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short"
+        }
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "right",
+          "values": [
+            "value"
+          ]
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "queryType": "table",
+          "queryText": "SELECT conclusion AS metric, count(*) AS value FROM predictions WHERE unixepoch(ts) >= ${__from:date:seconds} AND unixepoch(ts) < ${__to:date:seconds} GROUP BY conclusion",
+          "rawQueryText": "SELECT conclusion AS metric, count(*) AS value FROM predictions WHERE unixepoch(ts) >= ${__from:date:seconds} AND unixepoch(ts) < ${__to:date:seconds} GROUP BY conclusion"
+        }
+      ]
+    },
+    {
+      "id": 11,
+      "type": "text",
+      "title": "Data scope",
+      "gridPos": {
+        "h": 4,
+        "w": 24,
+        "x": 0,
+        "y": 21
+      },
+      "options": {
+        "mode": "markdown",
+        "content": "This dashboard reads the **redacted** AMS reporting exports (`ams-attempt-log`, `ams-prediction-ledger`), which are the only AMS sources Grafana is permitted to mount (see `export-ams-reporting-db.sh`, #5184). Per-provider token/cost breakdowns are **not shown** here because that detail lives in the attempt log's `payload_json`, which the reporting export deliberately drops for privacy \u2014 so `provider`, tokens, and cost are absent from the datasource. The panels above surface every attempt-outcome and prediction signal the redacted exports **do** expose."
+      }
+    }
+  ]
+}

--- a/test/unit/selfhost-grafana-miner-usage-dashboard.test.ts
+++ b/test/unit/selfhost-grafana-miner-usage-dashboard.test.ts
@@ -1,0 +1,74 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+type Panel = {
+  id?: number;
+  type?: string;
+  title?: string;
+  datasource?: { type?: string; uid?: string };
+  options?: { content?: string };
+  targets?: { queryText?: string; rawQueryText?: string }[];
+};
+type Dashboard = { uid: string; title: string; tags: string[]; panels: Panel[] };
+
+const dashboardPath = join(process.cwd(), "grafana/dashboards/miner-usage.json");
+const readDashboard = (): Dashboard => JSON.parse(readFileSync(dashboardPath, "utf8")) as Dashboard;
+
+// The redacted AMS reporting exports (export-ams-reporting-db.sh, #5184) drop payload_json and everything derived
+// from it (provider/cost/tokens). None of those must ever appear in a query, or the panel would silently
+// reference a column the datasource does not have.
+const REDACTED_OR_ABSENT = ["payload_json", "reason", "provider", "cost", "tokens", "token"];
+const AMS_UIDS = new Set(["ams-attempt-log", "ams-prediction-ledger"]);
+
+const queries = (d = readDashboard()): string[] =>
+  d.panels.flatMap((p) => (p.targets ?? []).map((t) => t.queryText ?? "").filter(Boolean));
+
+describe("LoopOver — AMS (miner) usage dashboard (#5185)", () => {
+  it("declares the expected uid/title/tags", () => {
+    const d = readDashboard();
+    expect(d.uid).toBe("loopover-miner-usage");
+    expect(d.title).toMatch(/AMS/);
+    expect(d.tags).toEqual(expect.arrayContaining(["ams", "miner", "observability"]));
+  });
+
+  it("every query panel reads ONLY the redacted AMS SQLite datasources (never scrapes Prometheus or mounts live ledgers)", () => {
+    for (const panel of readDashboard().panels) {
+      if (panel.type === "text") continue;
+      expect(panel.datasource?.type, panel.title).toBe("frser-sqlite-datasource");
+      expect(AMS_UIDS.has(panel.datasource?.uid ?? ""), `${panel.title}: ${panel.datasource?.uid}`).toBe(true);
+    }
+  });
+
+  it("queries only the two real reporting tables and only their existing (redacted-export) columns", () => {
+    for (const q of queries()) {
+      expect(/\bFROM\s+(attempt_log_events|predictions)\b/.test(q), q).toBe(true);
+    }
+  });
+
+  it("INVARIANT: no query references a redacted/absent column — payload_json and its derivations (provider/cost/tokens) are never queried", () => {
+    for (const q of queries()) {
+      for (const col of REDACTED_OR_ABSENT) {
+        expect(q.includes(col), `query must not reference '${col}': ${q}`).toBe(false);
+      }
+    }
+  });
+
+  it("uses the engine's real attempt-outcome event_type values, not invented ones", () => {
+    const all = queries().join("\n");
+    expect(all).toContain("attempt_succeeded");
+    expect(all).toContain("attempt_failed");
+    expect(all).toContain("attempt_aborted");
+  });
+
+  it("documents the data-scope limitation (why no per-provider cost/token panels) in a note panel", () => {
+    const note = readDashboard().panels.find((p) => p.type === "text");
+    expect(note?.options?.content).toMatch(/payload_json/);
+    expect(note?.options?.content).toMatch(/provider|cost|token/i);
+  });
+
+  it("gives every panel a unique id", () => {
+    const ids = readDashboard().panels.map((p) => p.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+});


### PR DESCRIPTION
Adds `grafana/dashboards/miner-usage.json` (#5185) so an operator running AMS (`gittensory-miner`) can see attempt outcomes and prediction/readiness activity in Grafana, alongside the existing ORB dashboards. Mirrors the existing dashboards' structure and reads **only the redacted AMS SQLite reporting exports** (`ams-attempt-log` / `ams-prediction-ledger`) — never Prometheus, never the live ledgers (req 5).

## Panels
- **Attempts** — total, succeeded / failed / aborted, an attempt-outcome breakdown, and an execution-mode (`paused`/`dry_run`/`live`) breakdown, plus top action classes.
- **Predictions** — total, average readiness score, and predictions-by-conclusion.

## Scope note (why no per-provider token/cost panels)
Reqs 2–4 ask for per-provider success/fail, token totals, and cost. Those fields are **not available in the mandated datasource**: `scripts/export-ams-reporting-db.sh` (#5184) deliberately **drops `payload_json`** from the reporting export for privacy, so `provider`, token counts, and cost never reach the `ams-attempt-log` datasource. Rather than query columns that don't exist (a broken/empty dashboard), this dashboard surfaces every attempt-outcome and prediction signal the redacted exports **do** expose, and a **"Data scope" note panel** documents the omission for operators.

## Validation
- `test/unit/selfhost-grafana-miner-usage-dashboard.test.ts` (**7/7**): asserts uid/title/tags, that every query panel uses the AMS SQLite datasources, that queries only read the two real reporting tables, that they use the engine's real `attempt_*` event-type values, and — an **invariant** — that **no query references a redacted/absent column** (`payload_json`/`provider`/`cost`/`tokens`), so no panel can silently reference a column the export lacks.
- `npm run selfhost:validate-observability`: **OK** (dashboard JSON shape valid).
- `git diff --check`: clean. Cut from latest `main`.

Closes #5185
