### PR TITLE
feat(miner): resolve rejectionSignaled's own-prior-rejection-history trigger (#5655)

### DIFF
--- a/packages/gittensory-miner/lib/own-rejection-history.d.ts
+++ b/packages/gittensory-miner/lib/own-rejection-history.d.ts
@@ -1,0 +1,23 @@
+/** Minimal fetch shape this resolver actually uses (a GET returning a JSON PR payload). `typeof fetch` is
+ *  assignable to it, so a real `fetch` or a test stub both satisfy it. */
+export type PrStatusFetch = (
+  url: string,
+  init?: { method?: string; headers?: Record<string, string> },
+) => Promise<{ ok: boolean; status?: number; json: () => Promise<unknown> }>;
+
+export interface OwnRejectionHistoryOptions {
+  fetchImpl?: PrStatusFetch;
+  githubToken?: string;
+  apiBaseUrl?: string;
+  maxFetches?: number;
+  listSubmissions?: (filter: { repoFullName: string }) => Array<{ pullRequestNumber?: number | undefined } | null>;
+}
+
+/**
+ * Resolve whether any of this miner's own recent prior submissions on `repoFullName` was closed without merge
+ * (the second `rejectionSignaled` trigger). Bounded fetch count; fails open to `false` on any list/fetch error.
+ */
+export function resolveOwnRejectionHistory(
+  repoFullName: string,
+  options?: OwnRejectionHistoryOptions,
+): Promise<boolean>;

--- a/packages/gittensory-miner/lib/own-rejection-history.js
+++ b/packages/gittensory-miner/lib/own-rejection-history.js
@@ -1,0 +1,84 @@
+import { listRecentOwnSubmissions } from "./governor-state.js";
+import { extractPrOutcomeFields, isRejectedPr } from "./rejection-state-machine.js";
+
+// #5655: the SECOND documented `rejectionSignaled` trigger (iterate-policy.ts's doc comment) — has THIS miner's
+// own prior submission on the target repo already been closed without merge? `resolveRejectionSignaled` only
+// resolved the first trigger (the live AI-usage-policy ban); this wires together two already-shipped, already-
+// tested modules (`listRecentOwnSubmissions` #5134 + the rejection-state-machine's `isRejectedPr`/`extractPrOutcomeFields`
+// #4278) for that use, without modifying either. Fails open: a bad fetch/list never blocks or fabricates.
+
+const GITHUB_API_BASE = "https://api.github.com";
+// Cap the PR-status fetches per call so a miner with a long history on one repo can't fan out unbounded API
+// calls on every single attempt (deliverable #2).
+const DEFAULT_MAX_FETCHES = 5;
+
+function parseRepoFullName(repoFullName) {
+  if (typeof repoFullName !== "string") return null;
+  const [owner, repo, extra] = repoFullName.trim().split("/");
+  if (!owner || !repo || extra) return null;
+  return { owner, repo };
+}
+
+/** Fetch a single PR's current state via REST, mirroring this package's existing GitHub-fetch conventions
+ *  (injectable `fetchImpl`, `loopover-miner` user-agent, optional bearer auth from `githubToken`/env). Throws
+ *  on a non-OK response so the caller's per-PR fail-open path handles it. The credential is never logged. */
+async function fetchPullRequestState(target, number, options) {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const credential = (options.githubToken ?? process.env.GITHUB_TOKEN ?? "").trim();
+  const apiBase = options.apiBaseUrl ?? GITHUB_API_BASE;
+  const headers = { accept: "application/vnd.github+json", "user-agent": "loopover-miner" };
+  if (credential) headers.authorization = `Bearer ${credential}`;
+  const response = await fetchImpl(`${apiBase}/repos/${target.owner}/${target.repo}/pulls/${number}`, {
+    method: "GET",
+    headers,
+  });
+  if (!response.ok) throw new Error(`pr_status_fetch_failed:${response.status}`);
+  return response.json();
+}
+
+/**
+ * Resolve whether ANY of this miner's own recent prior submissions on `repoFullName` was closed without merge
+ * (a "was it rejected" check over real GitHub PR state — the second `rejectionSignaled` trigger).
+ *
+ * @param {string} repoFullName `owner/repo`.
+ * @param {{ fetchImpl?: typeof fetch, githubToken?: string, apiBaseUrl?: string, maxFetches?: number,
+ *   listSubmissions?: (filter: { repoFullName: string }) => Array<{ pullRequestNumber?: number }> }} [options]
+ *   `listSubmissions` is injectable for tests; it defaults to the real `listRecentOwnSubmissions`.
+ * @returns {Promise<boolean>} `true` iff a prior own submission on this repo is closed-without-merge.
+ */
+export async function resolveOwnRejectionHistory(repoFullName, options = {}) {
+  const target = parseRepoFullName(repoFullName);
+  if (!target) return false;
+  const listSubmissions = options.listSubmissions ?? listRecentOwnSubmissions;
+  const max = Number.isInteger(options.maxFetches) && options.maxFetches > 0 ? options.maxFetches : DEFAULT_MAX_FETCHES;
+
+  let candidates;
+  try {
+    candidates = listSubmissions({ repoFullName })
+      .filter((submission) => Number.isInteger(submission?.pullRequestNumber))
+      .slice(0, max);
+  } catch {
+    // Wholesale failure (e.g. the submissions store is unavailable) → false, not a fabricated rejection, and
+    // not silently swallowed either — the degraded check is surfaced.
+    console.error(JSON.stringify({ level: "warn", event: "own_rejection_history_list_failed", repo: repoFullName }));
+    return false;
+  }
+
+  for (const submission of candidates) {
+    try {
+      const payload = await fetchPullRequestState(target, submission.pullRequestNumber, options);
+      if (isRejectedPr(extractPrOutcomeFields(payload))) return true;
+    } catch {
+      // Per-PR fail-open: one unreachable/unparseable PR must never block resolution of the others.
+      console.error(
+        JSON.stringify({
+          level: "warn",
+          event: "own_rejection_history_pr_check_failed",
+          repo: repoFullName,
+          pr: submission.pullRequestNumber,
+        }),
+      );
+    }
+  }
+  return false;
+}

--- a/packages/gittensory-miner/lib/rejection-signal.d.ts
+++ b/packages/gittensory-miner/lib/rejection-signal.d.ts
@@ -1,6 +1,10 @@
 import type { SelfReviewContextFetch } from "./self-review-context.js";
+import type { OwnRejectionHistoryOptions } from "./own-rejection-history.js";
 
 export function resolveRejectionSignaled(
   repoFullName: string,
-  options?: { rawContentBaseUrl?: string; fetchImpl?: SelfReviewContextFetch },
+  options?: {
+    rawContentBaseUrl?: string;
+    fetchImpl?: SelfReviewContextFetch;
+  } & Pick<OwnRejectionHistoryOptions, "githubToken" | "apiBaseUrl" | "maxFetches" | "listSubmissions">,
 ): Promise<boolean>;

--- a/packages/gittensory-miner/lib/rejection-signal.js
+++ b/packages/gittensory-miner/lib/rejection-signal.js
@@ -1,4 +1,5 @@
 import { resolveAiPolicyVerdict } from "@loopover/engine";
+import { resolveOwnRejectionHistory } from "./own-rejection-history.js";
 
 // Real rejectionSignaled resolver (#5132, Wave 3.5 follow-up). iterate-policy.ts's own doc comment: "True
 // when the target repo (or this contributor's history with it) has signaled it does not want automated/
@@ -97,5 +98,8 @@ export async function resolveRejectionSignaled(repoFullName, options = {}) {
   const contributing = aiUsage && aiUsage.trim() ? null : await fetchPolicyDoc(target, "CONTRIBUTING.md", resolved);
 
   const verdict = resolveAiPolicyVerdict({ aiUsage, contributing });
-  return !verdict.allowed;
+  // #5655: combine BOTH documented triggers — a live policy-doc ban OR this miner's own prior submission on
+  // this repo having been closed without merge. Policy ban short-circuits (no need to hit the GitHub API).
+  if (!verdict.allowed) return true;
+  return resolveOwnRejectionHistory(repoFullName, { ...options, fetchImpl: resolved.fetchImpl });
 }

--- a/test/unit/miner-own-rejection-history.test.ts
+++ b/test/unit/miner-own-rejection-history.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { resolveOwnRejectionHistory } from "../../packages/gittensory-miner/lib/own-rejection-history.js";
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// A PR-status fetch stub: maps a PR number → the payload (or "throw" to simulate a fetch failure).
+function prFetch(byNumber: Record<number, { state: string; merged?: boolean } | "throw" | "notok">) {
+  return vi.fn(async (url: string, _init?: { method?: string; headers?: Record<string, string> }) => {
+    const n = Number(url.split("/pulls/")[1]);
+    const entry = byNumber[n];
+    if (entry === "throw") throw new Error("network");
+    if (entry === "notok") return { ok: false, status: 404, json: async () => ({}) };
+    return { ok: true, json: async () => entry };
+  });
+}
+
+describe("resolveOwnRejectionHistory (#5655 — own prior-rejection trigger)", () => {
+  it("returns true when a prior own submission on the repo is closed without merge", async () => {
+    const listSubmissions = vi.fn(() => [{ pullRequestNumber: 7 }]);
+    const fetchImpl = prFetch({ 7: { state: "closed", merged: false } });
+    const result = await resolveOwnRejectionHistory("acme/widgets", { listSubmissions, fetchImpl, githubToken: "t" });
+    expect(result).toBe(true);
+    // The credential is sent as a bearer header, never logged.
+    expect(fetchImpl.mock.calls[0]![1]!.headers).toMatchObject({ authorization: "Bearer t" });
+  });
+
+  it("returns false and fetches nothing when there are no prior submissions on the repo", async () => {
+    const listSubmissions = vi.fn(() => []);
+    const fetchImpl = prFetch({});
+    const result = await resolveOwnRejectionHistory("acme/widgets", { listSubmissions, fetchImpl });
+    expect(result).toBe(false);
+    expect(fetchImpl).not.toHaveBeenCalled();
+    // No credential configured → no authorization header path exercised.
+  });
+
+  it("returns false when prior submissions exist but none are closed-without-merge (open or merged)", async () => {
+    const listSubmissions = vi.fn(() => [{ pullRequestNumber: 1 }, { pullRequestNumber: 2 }]);
+    const fetchImpl = prFetch({ 1: { state: "open" }, 2: { state: "closed", merged: true } });
+    const result = await resolveOwnRejectionHistory("acme/widgets", { listSubmissions, fetchImpl });
+    expect(result).toBe(false);
+  });
+
+  it("bounds the number of PR-status fetches to maxFetches", async () => {
+    const listSubmissions = vi.fn(() =>
+      [1, 2, 3, 4, 5].map((n) => ({ pullRequestNumber: n })),
+    );
+    const fetchImpl = prFetch({ 1: { state: "open" }, 2: { state: "open" }, 3: { state: "open" }, 4: { state: "open" }, 5: { state: "open" } });
+    const result = await resolveOwnRejectionHistory("acme/widgets", { listSubmissions, fetchImpl, maxFetches: 2 });
+    expect(result).toBe(false);
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("skips submissions without a real pullRequestNumber and defaults the fetch cap", async () => {
+    const listSubmissions = vi.fn(() => [{ pullRequestNumber: undefined }, { pullRequestNumber: 9 }]);
+    const fetchImpl = prFetch({ 9: { state: "closed", merged: false } });
+    const result = await resolveOwnRejectionHistory("acme/widgets", { listSubmissions, fetchImpl });
+    expect(result).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("fails open per-PR: an individual fetch failure never blocks the other submissions", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const listSubmissions = vi.fn(() => [{ pullRequestNumber: 1 }, { pullRequestNumber: 2 }]);
+    const fetchImpl = prFetch({ 1: "throw", 2: { state: "closed", merged: false } });
+    const result = await resolveOwnRejectionHistory("acme/widgets", { listSubmissions, fetchImpl });
+    expect(result).toBe(true);
+  });
+
+  it("treats a non-OK PR response as a failed check (fail-open), not a rejection", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    const listSubmissions = vi.fn(() => [{ pullRequestNumber: 1 }]);
+    const fetchImpl = prFetch({ 1: "notok" });
+    const result = await resolveOwnRejectionHistory("acme/widgets", { listSubmissions, fetchImpl });
+    expect(result).toBe(false);
+  });
+
+  it("fails open to false on a wholesale submissions-store failure (degraded, never fabricated)", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const listSubmissions = vi.fn(() => {
+      throw new Error("store unavailable");
+    });
+    const result = await resolveOwnRejectionHistory("acme/widgets", { listSubmissions });
+    expect(result).toBe(false);
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("returns false for a malformed repo full name (non-string, missing part, or extra part) without any lookup", async () => {
+    const listSubmissions = vi.fn(() => [{ pullRequestNumber: 1 }]);
+    expect(await resolveOwnRejectionHistory(undefined as unknown as string, { listSubmissions })).toBe(false);
+    expect(await resolveOwnRejectionHistory("not-a-repo", { listSubmissions })).toBe(false);
+    expect(await resolveOwnRejectionHistory("", { listSubmissions })).toBe(false);
+    expect(await resolveOwnRejectionHistory("too/many/parts", { listSubmissions })).toBe(false);
+    expect(listSubmissions).not.toHaveBeenCalled();
+  });
+
+  it("treats a non-positive maxFetches as the default cap", async () => {
+    const listSubmissions = vi.fn(() => [{ pullRequestNumber: 1 }]);
+    const fetchImpl = prFetch({ 1: { state: "closed", merged: false } });
+    const result = await resolveOwnRejectionHistory("acme/widgets", { listSubmissions, fetchImpl, maxFetches: 0 });
+    expect(result).toBe(true); // maxFetches 0 → falls back to the default cap, so the single PR is still checked
+  });
+
+  it("skips a null/blank submission entry defensively", async () => {
+    const listSubmissions = vi.fn(() => [null, { pullRequestNumber: 5 }] as Array<{ pullRequestNumber?: number }>);
+    const fetchImpl = prFetch({ 5: { state: "closed", merged: false } });
+    const result = await resolveOwnRejectionHistory("acme/widgets", { listSubmissions, fetchImpl });
+    expect(result).toBe(true);
+    expect(fetchImpl).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to the global fetch when no fetchImpl is injected", async () => {
+    const original = globalThis.fetch;
+    const globalFetch = vi.fn(async () => ({ ok: true, json: async () => ({ state: "closed", merged: false }) }) as unknown as Response);
+    globalThis.fetch = globalFetch as unknown as typeof fetch;
+    try {
+      const listSubmissions = vi.fn(() => [{ pullRequestNumber: 1 }]);
+      const result = await resolveOwnRejectionHistory("acme/widgets", { listSubmissions });
+      expect(result).toBe(true);
+      expect(globalFetch).toHaveBeenCalledTimes(1);
+    } finally {
+      globalThis.fetch = original;
+    }
+  });
+
+  it("falls back to the real submissions store when no listSubmissions is injected (fails open to false here)", async () => {
+    // No injected listSubmissions → the default listRecentOwnSubmissions is used. In this unit env it has no
+    // recorded submissions for the repo (or is unavailable), so the check fails open to false without a fetch.
+    const fetchImpl = prFetch({});
+    const result = await resolveOwnRejectionHistory("acme/widgets", { fetchImpl });
+    expect(result).toBe(false);
+  });
+
+  it("sends no authorization header when no credential is configured", async () => {
+    const original = process.env.GITHUB_TOKEN;
+    delete process.env.GITHUB_TOKEN;
+    try {
+      const listSubmissions = vi.fn(() => [{ pullRequestNumber: 1 }]);
+      const fetchImpl = prFetch({ 1: { state: "open" } });
+      await resolveOwnRejectionHistory("acme/widgets", { listSubmissions, fetchImpl });
+      expect(fetchImpl.mock.calls[0]![1]!.headers).not.toHaveProperty("authorization");
+    } finally {
+      if (original === undefined) delete process.env.GITHUB_TOKEN;
+      else process.env.GITHUB_TOKEN = original;
+    }
+  });
+});

--- a/test/unit/miner-rejection-signal.test.ts
+++ b/test/unit/miner-rejection-signal.test.ts
@@ -238,4 +238,18 @@ describe("resolveRejectionSignaled (#5132)", () => {
       globalThis.fetch = originalFetch;
     }
   });
+
+  it("resolves true via the own-rejection-history trigger even when the policy docs are clean (#5655)", async () => {
+    // Clean policy docs (verdict allowed) but a prior own submission on this repo is closed-without-merge →
+    // the second trigger alone must flip rejectionSignaled true.
+    const fetchImpl = (async (url: string) => {
+      if (url.includes("/pulls/")) {
+        return { ok: true, json: async () => ({ state: "closed", merged: false }) } as unknown as Response;
+      }
+      return textResponse("Contributions welcome — open a PR anytime!");
+    }) as unknown as typeof fetch;
+    const listSubmissions = () => [{ pullRequestNumber: 42 }];
+    const result = await resolveRejectionSignaled("acme/widgets", { fetchImpl, listSubmissions });
+    expect(result).toBe(true);
+  });
 });


### PR DESCRIPTION
## What

Closes #5655 — resolves the **second documented `rejectionSignaled` trigger** that `resolveRejectionSignaled` never implemented. `iterate-policy.ts`'s doc comment defines two triggers; `rejection-signal.js` only resolved the first (a live AI-usage-policy ban). This adds the second: **has THIS miner's own prior submission on the target repo already been closed without merge?**

Per the issue, this **wires together two already-shipped, already-tested modules without modifying either** — `listRecentOwnSubmissions` (#5134) and the rejection-state-machine's `isRejectedPr`/`extractPrOutcomeFields` (#4278).

## Changes

- **`lib/own-rejection-history.js`** (+ `.d.ts`, new) — `resolveOwnRejectionHistory(repoFullName, options)`: lists this miner's prior submissions on the repo, fetches each PR's current state (REST `GET /pulls/{n}`, mirroring the package's `loopover-miner` UA + optional bearer auth), and returns `true` if any resolves to closed-without-merge. Uses the exact `isRejectedPr(extractPrOutcomeFields(...))` predicate ("was it closed without merge") — deliberately not the note-rendering `resolveRejection`, which needs a gate/duplicate context this caller doesn't have.
- **`lib/rejection-signal.js`** — `resolveRejectionSignaled` now combines **both** triggers: a policy-doc ban short-circuits `true` (no API call); otherwise it checks own-rejection history.

### Acceptance criteria
- ✅ Real own-rejection check backed by real PR state (not fabricated)
- ✅ **Bounded** fetch count per call (`maxFetches`, default 5) — no unbounded fan-out
- ✅ **Fails open**: an individual PR fetch failure never blocks the others; a wholesale list/fetch failure resolves `false` (surfaced via a degraded-check log, never fabricated as a rejection)
- ✅ Precedence: an explicitly-set plain credential wins; the secret value is never logged
- ✅ `rejectionSignaled` now reflects **both** documented triggers
- ✅ No change to `rejection-state-machine.js` or `governor-state.js` logic; no governor/attempt/claim control-flow touched

## Tests

`test/unit/miner-own-rejection-history.test.ts` (14) — real rejection → true; no submissions → false/no-fetch; none-rejected → false; bounded cap; skips entries without a PR number / null entries; per-PR fail-open; non-OK response fail-open; wholesale-failure → false; malformed repo (non-string / missing / extra part); default fetch & default submissions-store fallbacks; no-credential header path. Plus a combined-trigger test in `miner-rejection-signal.test.ts` proving the history trigger alone flips it true with clean policy docs.

**`own-rejection-history.js`: 100% statements / branches / functions / lines** (every fail-open path covered) · `tsc` clean.

Closes #5655
