### PR TITLE
feat(miner): resolve rejectionSignaled's own-prior-rejection trigger

### DIFF
--- a/packages/gittensory-miner/lib/rejection-signal.d.ts
+++ b/packages/gittensory-miner/lib/rejection-signal.d.ts
@@ -1,6 +1,29 @@
 import type { SelfReviewContextFetch } from "./self-review-context.js";
 
+type OwnSubmissionsReader = (filter: {
+  repoFullName?: string;
+  limit?: number;
+}) => ReadonlyArray<{ pullRequestNumber?: number | null }>;
+
+export function resolveOwnRejectionHistory(
+  repoFullName: string,
+  options?: {
+    githubToken?: string;
+    apiBaseUrl?: string;
+    maxSubmissions?: number;
+    fetchImpl?: SelfReviewContextFetch;
+    listRecentOwnSubmissions?: OwnSubmissionsReader;
+  },
+): Promise<boolean>;
+
 export function resolveRejectionSignaled(
   repoFullName: string,
-  options?: { rawContentBaseUrl?: string; fetchImpl?: SelfReviewContextFetch },
+  options?: {
+    rawContentBaseUrl?: string;
+    githubToken?: string;
+    apiBaseUrl?: string;
+    maxSubmissions?: number;
+    fetchImpl?: SelfReviewContextFetch;
+    listRecentOwnSubmissions?: OwnSubmissionsReader;
+  },
 ): Promise<boolean>;

--- a/packages/gittensory-miner/lib/rejection-signal.js
+++ b/packages/gittensory-miner/lib/rejection-signal.js
@@ -1,4 +1,6 @@
 import { resolveAiPolicyVerdict } from "@loopover/engine";
+import { listRecentOwnSubmissions } from "./governor-state.js";
+import { resolveRejection } from "./rejection-state-machine.js";
 
 // Real rejectionSignaled resolver (#5132, Wave 3.5 follow-up). iterate-policy.ts's own doc comment: "True
 // when the target repo (or this contributor's history with it) has signaled it does not want automated/
@@ -18,6 +20,11 @@ import { resolveAiPolicyVerdict } from "@loopover/engine";
 
 const DEFAULT_RAW_CONTENT_BASE_URL = "https://raw.githubusercontent.com";
 const MAX_POLICY_DOC_BYTES = 128 * 1024;
+const DEFAULT_GITHUB_API_BASE_URL = "https://api.github.com";
+// Bound the per-attempt fan-out of PR-status fetches: only the N most recent own-submissions on this repo are
+// checked, so a miner with a long history on one repo can't trigger an unbounded burst of GitHub API calls on
+// every single attempt (#5655 req 2).
+const DEFAULT_MAX_OWN_SUBMISSIONS = 10;
 
 function parseRepoFullName(repoFullName) {
   if (typeof repoFullName !== "string") return null;
@@ -80,12 +87,84 @@ async function fetchPolicyDoc(target, path, resolved) {
 }
 
 /**
- * Resolve whether the target repo has an explicit, live AI-usage-policy ban -- the first of
- * `rejectionSignaled`'s two documented triggers. Returns `false` (never throws) on any fetch/parse failure,
- * matching resolveAiPolicyVerdict's own fail-open default for an absent/unreadable policy doc.
+ * Resolve `rejectionSignaled`'s SECOND documented trigger: whether a prior submission from THIS miner on this
+ * exact repo was closed WITHOUT a merge. Reads this miner's own recorded submissions
+ * (governor-state.js's `listRecentOwnSubmissions`), fetches each one's live `GET /pulls/{n}` state, and
+ * classifies it via rejection-state-machine.js's `resolveRejection`. Returns true if ANY is a rejection.
+ *
+ * Fail-open, never fabricated: an individual unreachable/unparseable PR is skipped so it can't block the
+ * others, and a wholesale failure to even list submissions resolves to `false` — a DEGRADED check surfaced via
+ * a warning, never silently asserted as "definitely no rejection". `githubToken`/`apiBaseUrl`/`maxSubmissions`/
+ * `fetchImpl`/`listRecentOwnSubmissions` are injectable purely for testability; every real caller uses the
+ * defaults (`process.env.GITHUB_TOKEN`, the public API, `node:fetch`, the real governor-state reader).
  *
  * @param {string} repoFullName
- * @param {{ rawContentBaseUrl?: string, fetchImpl?: import("./self-review-context.js").SelfReviewContextFetch }} [options]
+ * @param {{ githubToken?: string, apiBaseUrl?: string, maxSubmissions?: number,
+ *   fetchImpl?: import("./self-review-context.js").SelfReviewContextFetch,
+ *   listRecentOwnSubmissions?: typeof listRecentOwnSubmissions }} [options]
+ * @returns {Promise<boolean>}
+ */
+export async function resolveOwnRejectionHistory(repoFullName, options = {}) {
+  const target = parseRepoFullName(repoFullName);
+  if (!target) return false;
+
+  const listSubmissions = options.listRecentOwnSubmissions ?? listRecentOwnSubmissions;
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const githubToken = (typeof options.githubToken === "string" ? options.githubToken : process.env.GITHUB_TOKEN ?? "").trim();
+  const apiBaseUrl =
+    typeof options.apiBaseUrl === "string" && options.apiBaseUrl.trim() ? options.apiBaseUrl.trim() : DEFAULT_GITHUB_API_BASE_URL;
+  const maxSubmissions =
+    Number.isInteger(options.maxSubmissions) && options.maxSubmissions > 0 ? options.maxSubmissions : DEFAULT_MAX_OWN_SUBMISSIONS;
+
+  let submissions;
+  try {
+    submissions = listSubmissions({ repoFullName, limit: maxSubmissions });
+  } catch (error) {
+    // Wholesale failure: surface the degraded check, resolve false (never fabricated as a rejection).
+    console.warn(
+      JSON.stringify({
+        level: "warn",
+        event: "own_rejection_history_unavailable",
+        repoFullName,
+        detail: error instanceof Error ? error.message : String(error),
+      }),
+    );
+    return false;
+  }
+
+  const prNumbers = (Array.isArray(submissions) ? submissions : [])
+    .map((submission) => submission?.pullRequestNumber)
+    .filter((prNumber) => Number.isInteger(prNumber) && prNumber > 0)
+    .slice(0, maxSubmissions);
+
+  const headers = { accept: "application/vnd.github+json", "user-agent": "loopover-miner" };
+  if (githubToken) headers.authorization = `Bearer ${githubToken}`;
+
+  for (const prNumber of prNumbers) {
+    try {
+      const url = `${apiBaseUrl}/repos/${encodeURIComponent(target.owner)}/${encodeURIComponent(target.repo)}/pulls/${prNumber}`;
+      const response = await fetchImpl(url, { method: "GET", headers });
+      if (!response.ok) continue;
+      const payload = await response.json();
+      // No gate/duplicate signal here (unavailable and unneeded) — just "was it closed without merge".
+      if (resolveRejection(payload, undefined, { repoFullName, prNumber }) !== null) return true;
+    } catch {
+      // Fail-open per PR: one unreachable/unparseable submission must never block the others.
+    }
+  }
+  return false;
+}
+
+/**
+ * Resolve `rejectionSignaled` from BOTH of its documented triggers (matching iterate-policy.ts's own doc
+ * comment for the first time): `true` when EITHER the target repo has an explicit, live AI-usage-policy ban,
+ * OR a prior submission from this same miner on this exact repo was closed without merge. Returns `false`
+ * (never throws) on any fetch/parse failure, matching each underlying resolver's fail-open default.
+ *
+ * @param {string} repoFullName
+ * @param {{ rawContentBaseUrl?: string, githubToken?: string, apiBaseUrl?: string, maxSubmissions?: number,
+ *   fetchImpl?: import("./self-review-context.js").SelfReviewContextFetch,
+ *   listRecentOwnSubmissions?: typeof listRecentOwnSubmissions }} [options]
  * @returns {Promise<boolean>}
  */
 export async function resolveRejectionSignaled(repoFullName, options = {}) {
@@ -93,9 +172,13 @@ export async function resolveRejectionSignaled(repoFullName, options = {}) {
   if (!target) return false;
   const resolved = normalizeOptions(options);
 
+  // Trigger 1: an explicit, live AI-usage-policy ban.
   const aiUsage = await fetchPolicyDoc(target, "AI-USAGE.md", resolved);
   const contributing = aiUsage && aiUsage.trim() ? null : await fetchPolicyDoc(target, "CONTRIBUTING.md", resolved);
-
   const verdict = resolveAiPolicyVerdict({ aiUsage, contributing });
-  return !verdict.allowed;
+  if (!verdict.allowed) return true;
+
+  // Trigger 2: a prior submission from this same miner on this exact repo was closed without merge. Only checked
+  // when trigger 1 is clear, so a repo that already bans AI contributions costs zero extra PR-status fetches.
+  return resolveOwnRejectionHistory(repoFullName, options);
 }

--- a/test/unit/miner-rejection-signal.test.ts
+++ b/test/unit/miner-rejection-signal.test.ts
@@ -4,7 +4,10 @@ vi.mock("@loopover/engine", async () => {
   return import("../../packages/gittensory-engine/src/index");
 });
 
-import { resolveRejectionSignaled } from "../../packages/gittensory-miner/lib/rejection-signal.js";
+import {
+  resolveOwnRejectionHistory,
+  resolveRejectionSignaled,
+} from "../../packages/gittensory-miner/lib/rejection-signal.js";
 
 // resolveRejectionSignaled fetches plain markdown text (AI-USAGE.md/CONTRIBUTING.md), never JSON, so
 // json() is never actually called -- it's here only to satisfy SelfReviewContextFetch's response shape.
@@ -237,5 +240,158 @@ describe("resolveRejectionSignaled (#5132)", () => {
     } finally {
       globalThis.fetch = originalFetch;
     }
+  });
+});
+
+// ── #5655: rejectionSignaled's SECOND trigger — this miner's own prior rejection on the repo ─────────────
+function prJson(body: unknown, status = 200) {
+  return { ok: status >= 200 && status < 300, status, text: async () => "", json: async () => body };
+}
+/** A fetch that maps a `/pulls/{n}` URL to a scripted PR payload (or a thrown/!ok failure). */
+function pullsFetch(byNumber: Record<number, () => ReturnType<typeof prJson>>) {
+  return async (url: string) => {
+    const match = /\/pulls\/(\d+)/.exec(url);
+    const n = match ? Number(match[1]) : NaN;
+    const responder = byNumber[n];
+    if (!responder) return prJson({}, 404);
+    return responder();
+  };
+}
+const closedUnmerged = { state: "closed", merged: false, closed_at: "2026-07-01T00:00:00Z" };
+const mergedPr = { state: "closed", merged: true, merged_at: "2026-07-01T00:00:00Z" };
+const openPr = { state: "open", merged: false };
+const subs = (...nums: (number | null)[]) => () => nums.map((pullRequestNumber) => ({ pullRequestNumber }));
+
+describe("resolveOwnRejectionHistory (#5655)", () => {
+  const base = { githubToken: "t", apiBaseUrl: "https://api.example.test" };
+
+  it("returns false for an unparseable repoFullName", async () => {
+    expect(await resolveOwnRejectionHistory("not-a-repo", base)).toBe(false);
+  });
+
+  it("returns false when this miner has no recorded submissions on the repo", async () => {
+    const listRecentOwnSubmissions = subs();
+    expect(await resolveOwnRejectionHistory("acme/widgets", { ...base, listRecentOwnSubmissions, fetchImpl: pullsFetch({}) })).toBe(false);
+  });
+
+  it("returns true when ANY prior submission's PR is closed without a merge", async () => {
+    const listRecentOwnSubmissions = subs(10, 11);
+    const fetchImpl = pullsFetch({ 10: () => prJson(openPr), 11: () => prJson(closedUnmerged) });
+    expect(await resolveOwnRejectionHistory("acme/widgets", { ...base, listRecentOwnSubmissions, fetchImpl })).toBe(true);
+  });
+
+  it("does NOT count a merged PR as a rejection (closed+merged is a success, not a rejection)", async () => {
+    const listRecentOwnSubmissions = subs(10);
+    const fetchImpl = pullsFetch({ 10: () => prJson(mergedPr) });
+    expect(await resolveOwnRejectionHistory("acme/widgets", { ...base, listRecentOwnSubmissions, fetchImpl })).toBe(false);
+  });
+
+  it("does NOT count a still-open PR as a rejection", async () => {
+    const listRecentOwnSubmissions = subs(10);
+    const fetchImpl = pullsFetch({ 10: () => prJson(openPr) });
+    expect(await resolveOwnRejectionHistory("acme/widgets", { ...base, listRecentOwnSubmissions, fetchImpl })).toBe(false);
+  });
+
+  it("skips submissions with no real pullRequestNumber (never fetches them)", async () => {
+    const listRecentOwnSubmissions = subs(null, 0 as unknown as number);
+    const fetchImpl = vi.fn(pullsFetch({}));
+    expect(await resolveOwnRejectionHistory("acme/widgets", { ...base, listRecentOwnSubmissions, fetchImpl })).toBe(false);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("fails open on an individual PR fetch (non-ok, or throwing) — one bad PR never blocks the others", async () => {
+    const listRecentOwnSubmissions = subs(10, 11, 12);
+    const fetchImpl = pullsFetch({
+      10: () => prJson({}, 500), // non-ok → skipped
+      11: () => { throw new Error("network"); }, // throws → skipped
+      12: () => prJson(closedUnmerged), // still evaluated → rejection
+    });
+    expect(await resolveOwnRejectionHistory("acme/widgets", { ...base, listRecentOwnSubmissions, fetchImpl })).toBe(true);
+  });
+
+  it("fails open (false) + surfaces a warning when it cannot even list submissions", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const listRecentOwnSubmissions = () => { throw new Error("db locked"); };
+    expect(await resolveOwnRejectionHistory("acme/widgets", { ...base, listRecentOwnSubmissions, fetchImpl: pullsFetch({}) })).toBe(false);
+    expect(warn).toHaveBeenCalled();
+    expect(JSON.stringify(warn.mock.calls)).toContain("own_rejection_history_unavailable");
+    warn.mockRestore();
+  });
+
+  it("surfaces the warning even when the listing failure is a non-Error throw", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const listRecentOwnSubmissions = () => { throw "db-string-fault"; };
+    expect(await resolveOwnRejectionHistory("acme/widgets", { ...base, listRecentOwnSubmissions, fetchImpl: pullsFetch({}) })).toBe(false);
+    expect(JSON.stringify(warn.mock.calls)).toContain("db-string-fault");
+    warn.mockRestore();
+  });
+
+  it("treats a non-array listing result as no submissions (defensive) and never fetches", async () => {
+    const fetchImpl = vi.fn(pullsFetch({}));
+    expect(
+      await resolveOwnRejectionHistory("acme/widgets", { ...base, listRecentOwnSubmissions: (() => null) as never, fetchImpl }),
+    ).toBe(false);
+    expect(fetchImpl).not.toHaveBeenCalled();
+  });
+
+  it("bounds the PR-status fetches to maxSubmissions even when more submissions exist", async () => {
+    const listRecentOwnSubmissions = vi.fn(subs(1, 2, 3, 4, 5));
+    const fetchImpl = vi.fn(pullsFetch({ 1: () => prJson(openPr), 2: () => prJson(openPr) }));
+    await resolveOwnRejectionHistory("acme/widgets", { ...base, listRecentOwnSubmissions, fetchImpl, maxSubmissions: 2 });
+    expect(listRecentOwnSubmissions).toHaveBeenCalledWith({ repoFullName: "acme/widgets", limit: 2 });
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
+  });
+
+  it("sends an authenticated, well-formed GET to the PR endpoint", async () => {
+    const fetchImpl = vi.fn(pullsFetch({ 7: () => prJson(openPr) }));
+    await resolveOwnRejectionHistory("acme/widgets", { ...base, listRecentOwnSubmissions: subs(7), fetchImpl });
+    const [url, init] = fetchImpl.mock.calls[0] as [string, { method: string; headers: Record<string, string> }];
+    expect(url).toBe("https://api.example.test/repos/acme/widgets/pulls/7");
+    expect(init.method).toBe("GET");
+    expect(init.headers.authorization).toBe("Bearer t");
+  });
+});
+
+describe("resolveRejectionSignaled combines both triggers (#5655)", () => {
+  it("short-circuits to true on a policy ban WITHOUT any own-history fetch", async () => {
+    const listRecentOwnSubmissions = vi.fn(subs(10));
+    const fetchImpl = async (url: string) => {
+      if (url.includes("AI-USAGE.md")) return prJson({}, 200) as never; // handled as text below
+      return prJson(closedUnmerged);
+    };
+    const routed = routedFetch({
+      "AI-USAGE.md": () => textResponse("No AI-generated pull requests, please."),
+      "CONTRIBUTING.md": () => textResponse("Welcome!"),
+    });
+    void fetchImpl;
+    const result = await resolveRejectionSignaled("acme/widgets", { fetchImpl: routed, listRecentOwnSubmissions });
+    expect(result).toBe(true);
+    expect(listRecentOwnSubmissions).not.toHaveBeenCalled();
+  });
+
+  it("returns true when there is no policy ban but a prior own submission was rejected", async () => {
+    const combined = async (url: string) => {
+      if (url.includes("AI-USAGE.md")) return textResponse("AI contributions welcome.") as never;
+      if (url.includes("CONTRIBUTING.md")) return textResponse("Welcome!") as never;
+      return prJson(closedUnmerged) as never;
+    };
+    const result = await resolveRejectionSignaled("acme/widgets", {
+      fetchImpl: combined,
+      listRecentOwnSubmissions: subs(10),
+    });
+    expect(result).toBe(true);
+  });
+
+  it("returns false when neither trigger fires", async () => {
+    const combined = async (url: string) => {
+      if (url.includes("AI-USAGE.md")) return textResponse("AI contributions welcome.") as never;
+      if (url.includes("CONTRIBUTING.md")) return textResponse("Welcome!") as never;
+      return prJson(mergedPr) as never;
+    };
+    const result = await resolveRejectionSignaled("acme/widgets", {
+      fetchImpl: combined,
+      listRecentOwnSubmissions: subs(10),
+    });
+    expect(result).toBe(false);
   });
 });


### PR DESCRIPTION
`rejectionSignaled` has **two** documented triggers (see `iterate-policy.ts`'s own doc comment), but `rejection-signal.js` only resolved the first — a live AI-usage-policy ban. The second — *a prior submission from this same miner on this exact repo was closed without merge* — was explicitly left as a documented gap in the file's own header. This wires it up, using exactly the two already-shipped, already-tested modules that header names.

## What this adds
- **`resolveOwnRejectionHistory(repoFullName, options)`** — lists this miner's own recorded submissions on the repo (`governor-state.js`'s `listRecentOwnSubmissions`), fetches each one's live `GET /pulls/{n}` state, and classifies it via `rejection-state-machine.js`'s `resolveRejection` (no gate/duplicate signal — just "was it closed without a merge"). Returns `true` if **any** prior submission was rejected.
- **`resolveRejectionSignaled`** now combines **both** triggers: `true` when EITHER the live policy-doc ban OR the own-rejection-history check fires. Trigger 2 is only checked when trigger 1 is clear, so a repo that already bans AI contributions costs zero extra PR-status fetches.

## Requirements
- **Bounded** (req 2): only the `N` most recent submissions on the repo are fetched per call (`maxSubmissions`, default 10), so a long history can't fan out unbounded API calls on every attempt.
- **Fails open** (req 3): an individual unreachable/unparseable PR is skipped so it can't block the others; a wholesale failure to even list submissions resolves to `false` and **surfaces a warning** — never fabricated as "no rejection", never silently asserted as "definitely none".
- **No change** to `rejection-state-machine.js`'s classification or `governor-state.js`'s own recording (req 5) — this only wires the two together for a new caller.
- Real GitHub PR state, authenticated + injectable exactly like `live-issue-snapshot.js`.

## Validation
- `test/unit/miner-rejection-signal.test.ts`: **29/29** — covers rejected/merged/open PRs, missing PR numbers, per-PR fail-open (non-ok + throw), wholesale fail-open + warning (incl. non-Error throw), the fetch bound, the authenticated request shape, and the combined resolver's short-circuit + both-trigger paths.
- New code is **100% patch-covered** (the only uncovered branch is pre-existing `normalizeOptions`).
- `node scripts/check-miner-package.mjs`: OK. `git diff --check`: clean. Cut from latest `main`; single lib file + `.d.ts` + its test.

Closes #5655
