### PR TITLE
feat(miner-hands): feed the Governor a real per-issue convergence history

### DIFF
--- a/packages/gittensory-miner/lib/attempt-cli.d.ts
+++ b/packages/gittensory-miner/lib/attempt-cli.d.ts
@@ -13,6 +13,7 @@ import type { resolveAmsPolicy } from "./ams-policy.js";
 import type { checkMinerKillSwitch } from "./governor-kill-switch.js";
 import type { resolveMinerGoalSpec } from "./miner-goal-spec.js";
 import type { ClaimConflictResult, resolveClaimConflict } from "./claim-conflict-resolver.js";
+import type { getAttemptHistory } from "./portfolio-queue.js";
 
 type CommonAttemptResultFields = {
   repoFullName: string;
@@ -91,6 +92,9 @@ export type RunAttemptOptions = {
   resolveMinerGoalSpec?: typeof resolveMinerGoalSpec;
   runMinerAttempt?: typeof runMinerAttempt;
   resolveClaimConflict?: typeof resolveClaimConflict;
+  /** Real per-issue attempt-history read (#5654), injectable for tests; defaults to the portfolio queue's
+   *  own getAttemptHistory over the default store. */
+  getAttemptHistory?: typeof getAttemptHistory;
   /** Invoked with the real structured result at every return point, in addition to (never instead of) the
    *  plain exit-code return -- the loop orchestrator's real hook into what actually happened. */
   onResult?: (result: AttemptCliResult) => void;

--- a/packages/gittensory-miner/lib/attempt-cli.js
+++ b/packages/gittensory-miner/lib/attempt-cli.js
@@ -8,9 +8,9 @@
 // claim-conflict resolution (#4848, claim-conflict-resolver.js) for the narrow race window
 // checkSubmissionFreshness cannot see (two miners submitting almost simultaneously).
 //
-// KNOWN, DOCUMENTED GAPS (not fabricated -- see attempt-input-builder.js's own header for the full list):
-// governor.convergenceInput is an honest first-attempt-shaped literal, not a real per-issue attempt-history
-// query (attempt-log.js's schema has no repo+issue index, and reenqueue counts aren't tracked anywhere yet).
+// governor.convergenceInput is now a REAL per-issue attempt-history query (#5654): this file reads the
+// portfolio-queue's real attempt/reenqueue/failure counts (portfolio-queue.js's getAttemptHistory) and threads
+// them into buildAttemptGovernorContext, so the already-built non-convergence detector finally sees real data.
 
 import { resolveCodingAgentModeFromConfig, resolveFirstConfiguredCodingAgentDriverName } from "@loopover/engine";
 import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
@@ -33,6 +33,7 @@ import { buildCodingTaskSpec } from "./coding-task-spec.js";
 import { resolveAmsPolicy } from "./ams-policy.js";
 import { checkMinerKillSwitch } from "./governor-kill-switch.js";
 import { buildAttemptGovernorContext, buildAttemptLoopInput } from "./attempt-input-builder.js";
+import { getAttemptHistory } from "./portfolio-queue.js";
 import { runMinerAttempt } from "./attempt-runner.js";
 
 const ATTEMPT_USAGE =
@@ -399,7 +400,20 @@ export async function runAttempt(args, options = {}) {
       amsPolicySpec: amsPolicy.spec,
       branchRef: worktreeResult.branchName,
     });
-    const governor = buildAttemptGovernorContext(env, amsPolicy.spec, repoPaused);
+    // Real per-issue convergence history (#5654): read this exact item's attempt/reenqueue/failure counts from
+    // the portfolio queue (keyed the same `issue:<n>` way portfolio-discovery.js enqueues it) and thread them
+    // into the Governor context, so the non-convergence detector sees real data instead of a first-attempt
+    // literal. Fail-open: a read failure (or an item the queue has never seen) leaves convergenceInput
+    // undefined, which buildAttemptGovernorContext resolves to the honest "fresh" first-attempt shape -- a
+    // governance signal must never fail an attempt on its own, matching this pipeline's other fail-open reads.
+    const readAttemptHistory = options.getAttemptHistory ?? getAttemptHistory;
+    let convergenceInput;
+    try {
+      convergenceInput = readAttemptHistory(parsed.repoFullName, `issue:${parsed.issueNumber}`);
+    } catch {
+      convergenceInput = undefined;
+    }
+    const governor = buildAttemptGovernorContext(env, amsPolicy.spec, repoPaused, convergenceInput);
 
     // Real soft-claim (#5393): recorded once we've committed to a real attempt (past feasibility), so a
     // sibling miner process on this machine sees it via claimLedger.listClaims/listActiveClaims while this

--- a/packages/gittensory-miner/lib/attempt-input-builder.d.ts
+++ b/packages/gittensory-miner/lib/attempt-input-builder.d.ts
@@ -1,4 +1,10 @@
-import type { AmsPolicySpec, CodingAgentExecutionMode, IterateLoopInput, SelfReviewContext } from "@loopover/engine";
+import type {
+  AmsPolicySpec,
+  CodingAgentExecutionMode,
+  IterateLoopInput,
+  PortfolioConvergenceInput,
+  SelfReviewContext,
+} from "@loopover/engine";
 import type { AttemptGovernorContext } from "./attempt-runner.js";
 import type { CodingTaskSpecResult } from "./coding-task-spec.js";
 
@@ -6,6 +12,7 @@ export function buildAttemptGovernorContext(
   env: Record<string, string | undefined>,
   amsPolicySpec: AmsPolicySpec,
   repoPaused?: boolean,
+  convergenceInput?: PortfolioConvergenceInput,
 ): AttemptGovernorContext;
 
 export type BuildAttemptLoopInputInput = {

--- a/packages/gittensory-miner/lib/attempt-input-builder.js
+++ b/packages/gittensory-miner/lib/attempt-input-builder.js
@@ -6,13 +6,13 @@ import { isGlobalMinerKillSwitch, isGlobalMinerLiveModeOptIn } from "@loopover/e
 // same discipline as coding-task-spec.js's own composers.
 //
 // KNOWN, DOCUMENTED GAPS (not fabricated -- explicitly left as real, narrow follow-ups):
-//   - governor.convergenceInput is a first-attempt-shaped literal ({ attempts: 0, consecutiveFailures: 0,
-//     reenqueues: 0, reachedDone: false }), not a real per-issue query. attempt-log.js's schema has no
-//     repo+issue index (attemptId embeds a timestamp, so it's not a stable group key), and reenqueue counts
-//     aren't tracked ANYWHERE yet (non-convergence.ts's own header says that belongs on the portfolio-queue
-//     table once it grows attempt-history columns -- a real, separate schema change, not something to fake
-//     here). This literal is only ever an UNDER-estimate (reads "fresh, no prior failures" even on a real
-//     Nth attempt), which fails toward LETTING an attempt through, not blocking one -- documented, not silent.
+//   - governor.convergenceInput is now a REAL per-issue query (#5654): the caller reads the portfolio-queue's
+//     attempt-history columns (portfolio-queue.js's getAttemptHistory) and threads the resulting
+//     PortfolioConvergenceInput in through this composer's `convergenceInput` parameter, so the already-built
+//     non-convergence detector finally sees real attempt/reenqueue/failure counts instead of a permanent
+//     first-attempt literal. This composer stays pure -- it just forwards whatever the caller resolved,
+//     defaulting to the honest first-attempt shape ({ attempts: 0, ... }) when nothing is supplied (an item
+//     the queue has never seen, which reads as a converging first-look, not a fabricated history).
 //   - governor.reputationHistory/selfPlagiarismCandidate/selfPlagiarismRecentSubmissions are omitted, which
 //     chokepoint.ts's own design treats as "skip that stage entirely" -- an honest absence, not a fabricated
 //     "clean" verdict.
@@ -26,18 +26,24 @@ import { isGlobalMinerKillSwitch, isGlobalMinerLiveModeOptIn } from "@loopover/e
  * (miner-goal-spec.js's resolveMinerGoalSpec) -- this composer stays pure and just threads whatever the
  * caller already resolved through; passing nothing keeps the prior fails-open-on-that-axis-only behavior.
  *
+ * `convergenceInput` (#5654) is the caller's already-resolved real per-issue attempt history (from
+ * portfolio-queue.js's getAttemptHistory) -- this composer stays pure and just forwards it. Omitting it (an
+ * item the queue has never seen) falls back to the honest first-attempt shape, which the non-convergence
+ * detector reads as a converging first-look, not a fabricated history.
+ *
  * @param {Record<string, string | undefined>} env
  * @param {import("@loopover/engine").AmsPolicySpec} amsPolicySpec
  * @param {boolean} [repoPaused]
+ * @param {import("@loopover/engine").PortfolioConvergenceInput} [convergenceInput]
  * @returns {import("./attempt-runner.js").AttemptGovernorContext}
  */
-export function buildAttemptGovernorContext(env, amsPolicySpec, repoPaused) {
+export function buildAttemptGovernorContext(env, amsPolicySpec, repoPaused, convergenceInput) {
   return {
     killSwitchGlobal: isGlobalMinerKillSwitch(env),
     killSwitchRepoPaused: repoPaused,
     liveModeGlobalOptIn: isGlobalMinerLiveModeOptIn(env),
     capLimits: amsPolicySpec.capLimits,
-    convergenceInput: { attempts: 0, consecutiveFailures: 0, reenqueues: 0, reachedDone: false },
+    convergenceInput: convergenceInput ?? { attempts: 0, consecutiveFailures: 0, reenqueues: 0, reachedDone: false },
   };
 }
 

--- a/packages/gittensory-miner/lib/portfolio-queue.d.ts
+++ b/packages/gittensory-miner/lib/portfolio-queue.d.ts
@@ -1,3 +1,5 @@
+import type { PortfolioConvergenceInput } from "@loopover/engine";
+
 export type QueueStatus = "queued" | "in_progress" | "done";
 
 export type QueueEntry = {
@@ -35,6 +37,7 @@ export type PortfolioQueueStore = {
   markFailed(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueEntry | null;
   reclaimStuckItem(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueEntry | null;
   requeueItem(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueEntry | null;
+  getAttemptHistory(repoFullName: string, identifier: string, apiBaseUrl?: string): PortfolioConvergenceInput;
   batchClaim(
     selectFn: (
       entries: QueueEntry[],
@@ -58,5 +61,11 @@ export function listQueue(repoFullName?: string | null): QueueEntry[];
 export function markDone(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueEntry | null;
 
 export function markFailed(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueEntry | null;
+
+export function getAttemptHistory(
+  repoFullName: string,
+  identifier: string,
+  apiBaseUrl?: string,
+): PortfolioConvergenceInput;
 
 export function closeDefaultPortfolioQueueStore(): void;

--- a/packages/gittensory-miner/lib/portfolio-queue.js
+++ b/packages/gittensory-miner/lib/portfolio-queue.js
@@ -147,6 +147,28 @@ export function initPortfolioQueueStore(dbPath = resolvePortfolioQueueDbPath()) 
       migrationDb.exec("DROP TABLE miner_portfolio_queue");
       migrationDb.exec("ALTER TABLE miner_portfolio_queue_v3 RENAME TO miner_portfolio_queue");
     },
+    // v3 -> v4 (#5654): add the attempt-history columns the non-convergence detector
+    // (packages/gittensory-engine/src/portfolio/non-convergence.ts) has always needed but never had real data
+    // for -- `attempts` (bumped on every claim), `consecutive_failures` (bumped on a requeue/reclaim that did
+    // NOT reach done, reset to 0 on markDone), and `reenqueues` (bumped on every transition back to 'queued'
+    // without reaching done). Additive, defaulted, and defensive (per-column table_info presence check -- the
+    // same idiom the leased_at migration above uses) so a file that already ran an ad-hoc ALTER is not
+    // re-altered into a duplicate-column error. `reachedDone` needs no column -- it is just `status = 'done'`.
+    (migrationDb) => {
+      const columns = migrationDb
+        .prepare("PRAGMA table_info(miner_portfolio_queue)")
+        .all()
+        .map((column) => column.name);
+      if (!columns.includes("attempts")) {
+        migrationDb.exec("ALTER TABLE miner_portfolio_queue ADD COLUMN attempts INTEGER NOT NULL DEFAULT 0");
+      }
+      if (!columns.includes("consecutive_failures")) {
+        migrationDb.exec("ALTER TABLE miner_portfolio_queue ADD COLUMN consecutive_failures INTEGER NOT NULL DEFAULT 0");
+      }
+      if (!columns.includes("reenqueues")) {
+        migrationDb.exec("ALTER TABLE miner_portfolio_queue ADD COLUMN reenqueues INTEGER NOT NULL DEFAULT 0");
+      }
+    },
   ]);
 
   // `rowid` is a stable, unique key assigned once at first insert (re-enqueue updates in place, never re-inserts),
@@ -175,7 +197,7 @@ export function initPortfolioQueueStore(dbPath = resolvePortfolioQueueDbPath()) 
   // Claiming stamps `leased_at` with the caller-supplied claim time; leaving 'in_progress' (done/failed/reclaim)
   // clears it back to NULL so only genuinely in-flight rows carry a lease.
   const dequeueStatement = db.prepare(`
-    UPDATE miner_portfolio_queue SET status = 'in_progress', leased_at = ?
+    UPDATE miner_portfolio_queue SET status = 'in_progress', leased_at = ?, attempts = attempts + 1
     WHERE rowid = (
       SELECT rowid FROM miner_portfolio_queue WHERE status = 'queued' ${ORDER} LIMIT 1
     )
@@ -183,13 +205,19 @@ export function initPortfolioQueueStore(dbPath = resolvePortfolioQueueDbPath()) 
   `);
   // RETURNING (rather than a separate post-UPDATE SELECT) makes the "nothing to mark done" case observable
   // directly from one atomic statement.
+  // Reaching 'done' resets the consecutive-failure streak to 0 (an item that finally converged is no longer
+  // failing) -- exactly the "reset to 0 on any progress" semantics classifyPortfolioConvergence documents.
   const markDoneStatement = db.prepare(`
-    UPDATE miner_portfolio_queue SET status = 'done', leased_at = NULL
+    UPDATE miner_portfolio_queue SET status = 'done', leased_at = NULL, consecutive_failures = 0
     WHERE api_base_url = ? AND repo_full_name = ? AND identifier = ? AND status <> 'done'
     RETURNING *
   `);
+  // Releasing an in-flight item back to 'queued' for a halted run (#2347) is a failed attempt that never
+  // reached done: bump BOTH the reenqueue count and the consecutive-failure streak (identical to the stuck-item
+  // reclaim below -- same queued <- in_progress-without-done transition the non-convergence detector counts).
   const markFailedStatement = db.prepare(`
-    UPDATE miner_portfolio_queue SET status = 'queued', leased_at = NULL
+    UPDATE miner_portfolio_queue
+    SET status = 'queued', leased_at = NULL, reenqueues = reenqueues + 1, consecutive_failures = consecutive_failures + 1
     WHERE api_base_url = ? AND repo_full_name = ? AND identifier = ? AND status = 'in_progress'
     RETURNING *
   `);
@@ -203,24 +231,34 @@ export function initPortfolioQueueStore(dbPath = resolvePortfolioQueueDbPath()) 
   const listInProgressStatement = db.prepare(
     `SELECT * FROM miner_portfolio_queue WHERE status = 'in_progress' ${ORDER}`,
   );
+  // The stuck-item reclaim sweep (#4827): same queued <- in_progress-without-done transition as markFailed, so
+  // it bumps the reenqueue count AND the consecutive-failure streak. Repeated reclaims of an item that never
+  // reaches done are exactly the non-convergent loop classifyPortfolioConvergence is built to catch (#5654).
   const reclaimStatement = db.prepare(`
-    UPDATE miner_portfolio_queue SET status = 'queued', leased_at = NULL
+    UPDATE miner_portfolio_queue
+    SET status = 'queued', leased_at = NULL, reenqueues = reenqueues + 1, consecutive_failures = consecutive_failures + 1
     WHERE api_base_url = ? AND repo_full_name = ? AND identifier = ? AND status = 'in_progress'
     RETURNING *
   `);
   // Requeue only ever targets a COMPLETED ('done') row — an in-flight item is released via reclaimStatement, and
   // an already-'queued' item is a no-op — so a caller's manual requeue can never disturb an active claim. The
   // row keeps its rowid/enqueued_at, so it re-enters the queue at its original FIFO position, not the back.
+  // Manual requeue of a COMPLETED item (#4828): it re-enters the queue, so bump the reenqueue count -- but NOT
+  // the consecutive-failure streak, since the attempt being requeued DID reach done (a re-attempt of a success
+  // is not a failure). markDone already reset the streak to 0 when it finished.
   const requeueStatement = db.prepare(`
-    UPDATE miner_portfolio_queue SET status = 'queued', leased_at = NULL
+    UPDATE miner_portfolio_queue SET status = 'queued', leased_at = NULL, reenqueues = reenqueues + 1
     WHERE api_base_url = ? AND repo_full_name = ? AND identifier = ? AND status = 'done'
     RETURNING *
   `);
   const claimTargetStatement = db.prepare(`
-    UPDATE miner_portfolio_queue SET status = 'in_progress', leased_at = ?
+    UPDATE miner_portfolio_queue SET status = 'in_progress', leased_at = ?, attempts = attempts + 1
     WHERE api_base_url = ? AND repo_full_name = ? AND identifier = ? AND status = 'queued'
     RETURNING *
   `);
+  const getAttemptHistoryStatement = db.prepare(
+    "SELECT status, attempts, consecutive_failures, reenqueues FROM miner_portfolio_queue WHERE api_base_url = ? AND repo_full_name = ? AND identifier = ?",
+  );
 
   return {
     dbPath: resolvedPath,
@@ -268,6 +306,28 @@ export function initPortfolioQueueStore(dbPath = resolvePortfolioQueueDbPath()) 
         ? listAllStatement.all()
         : listRepoStatement.all(normalizeRepoFullName(repoFullName));
       return rows.map(rowToEntry);
+    },
+    /**
+     * A real `PortfolioConvergenceInput` (#5654) for one item, read straight from the attempt-history columns:
+     * total `attempts`, `consecutiveFailures` since the last done, `reenqueues` without reaching done, and
+     * `reachedDone` (just `status === 'done'`, never a stored flag -- invariant, not fabricated). An item this
+     * store has never seen reads as a genuine first attempt (`{ attempts: 0, ... }`), the same honest "fresh"
+     * the Governor caller assumed before this existed -- a missing row is a converging first-look, not an
+     * invented history. Feeds the already-built non-convergence detector (`classifyPortfolioConvergence`).
+     */
+    getAttemptHistory(repoFullName, identifier, apiBaseUrl) {
+      const row = getAttemptHistoryStatement.get(
+        normalizeApiBaseUrl(apiBaseUrl),
+        normalizeRepoFullName(repoFullName),
+        normalizeIdentifier(identifier),
+      );
+      if (!row) return { attempts: 0, consecutiveFailures: 0, reenqueues: 0, reachedDone: false };
+      return {
+        attempts: row.attempts,
+        consecutiveFailures: row.consecutive_failures,
+        reenqueues: row.reenqueues,
+        reachedDone: row.status === "done",
+      };
     },
     markDone(repoFullName, identifier, apiBaseUrl) {
       const row = markDoneStatement.get(
@@ -342,6 +402,11 @@ export function markDone(repoFullName, identifier, apiBaseUrl) {
 
 export function markFailed(repoFullName, identifier, apiBaseUrl) {
   return getDefaultPortfolioQueueStore().markFailed(repoFullName, identifier, apiBaseUrl);
+}
+
+/** Module-level read of one item's real `PortfolioConvergenceInput` (#5654), against the default store. */
+export function getAttemptHistory(repoFullName, identifier, apiBaseUrl) {
+  return getDefaultPortfolioQueueStore().getAttemptHistory(repoFullName, identifier, apiBaseUrl);
 }
 
 export function closeDefaultPortfolioQueueStore() {

--- a/test/unit/miner-attempt-cli.test.ts
+++ b/test/unit/miner-attempt-cli.test.ts
@@ -13,6 +13,7 @@ import { closeDefaultAttemptLog, initAttemptLog } from "../../packages/gittensor
 import type { AttemptLog } from "../../packages/gittensory-miner/lib/attempt-log.js";
 import { closeDefaultGovernorLedger, initGovernorLedger } from "../../packages/gittensory-miner/lib/governor-ledger.js";
 import { closeDefaultWorktreeAllocator, openWorktreeAllocator } from "../../packages/gittensory-miner/lib/worktree-allocator.js";
+import { closeDefaultPortfolioQueueStore } from "../../packages/gittensory-miner/lib/portfolio-queue.js";
 import { buildAttemptDeps, parseAttemptArgs, runAttempt } from "../../packages/gittensory-miner/lib/attempt-cli.js";
 import type { PrepareAttemptWorktreeResult } from "../../packages/gittensory-miner/lib/attempt-worktree.js";
 import { DEFAULT_AMS_POLICY_SPEC, DEFAULT_MINER_GOAL_SPEC, parseFocusManifest } from "../../packages/gittensory-engine/src/index";
@@ -90,7 +91,9 @@ afterEach(() => {
   closeDefaultEventLedger();
   closeDefaultAttemptLog();
   closeDefaultGovernorLedger();
+  closeDefaultPortfolioQueueStore();
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
 
@@ -1203,5 +1206,89 @@ describe("runAttempt: real claim-ledger wiring (#5393)", () => {
     });
 
     expect(claimIssueSpy).not.toHaveBeenCalled();
+  });
+
+  it("REGRESSION (#5654): threads the real portfolio-queue attempt history into the Governor convergenceInput", async () => {
+    const { allocator, claimLedger, eventLedger, attemptLog, governorLedger } = tempLedgers();
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const getAttemptHistorySpy = vi
+      .fn()
+      .mockReturnValue({ attempts: 4, consecutiveFailures: 3, reenqueues: 3, reachedDone: false });
+    const runMinerAttemptSpy = vi.fn().mockResolvedValue({ outcome: "abandon", loopResult: {} });
+
+    await runAttempt(["acme/widgets", "7", "--miner-login", "alice", "--json"], {
+      env: { MINER_CODING_AGENT_PROVIDER: "noop" },
+      openWorktreeAllocator: () => allocator,
+      openClaimLedger: () => claimLedger,
+      initEventLedger: () => eventLedger,
+      initAttemptLog: () => attemptLog,
+      initGovernorLedger: () => governorLedger,
+      getAttemptHistory: getAttemptHistorySpy,
+      ...readyPipelineOptions({ runMinerAttempt: runMinerAttemptSpy }),
+    });
+
+    // Read keyed the same `issue:<n>` way portfolio-discovery.js enqueues it, and forwarded verbatim.
+    expect(getAttemptHistorySpy).toHaveBeenCalledWith("acme/widgets", "issue:7");
+    expect(runMinerAttemptSpy.mock.calls[0]![0].governor.convergenceInput).toEqual({
+      attempts: 4,
+      consecutiveFailures: 3,
+      reenqueues: 3,
+      reachedDone: false,
+    });
+  });
+
+  it("#5654: falls back to the honest first-attempt convergenceInput when the history read throws (fail-open)", async () => {
+    const { allocator, claimLedger, eventLedger, attemptLog, governorLedger } = tempLedgers();
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const runMinerAttemptSpy = vi.fn().mockResolvedValue({ outcome: "abandon", loopResult: {} });
+
+    await runAttempt(["acme/widgets", "7", "--miner-login", "alice", "--json"], {
+      env: { MINER_CODING_AGENT_PROVIDER: "noop" },
+      openWorktreeAllocator: () => allocator,
+      openClaimLedger: () => claimLedger,
+      initEventLedger: () => eventLedger,
+      initAttemptLog: () => attemptLog,
+      initGovernorLedger: () => governorLedger,
+      getAttemptHistory: () => {
+        throw new Error("db locked");
+      },
+      ...readyPipelineOptions({ runMinerAttempt: runMinerAttemptSpy }),
+    });
+
+    // A governance signal must never fail an attempt: a throwing read degrades to the honest "fresh" shape.
+    expect(runMinerAttemptSpy.mock.calls[0]![0].governor.convergenceInput).toEqual({
+      attempts: 0,
+      consecutiveFailures: 0,
+      reenqueues: 0,
+      reachedDone: false,
+    });
+  });
+
+  it("#5654: defaults to the REAL portfolio-queue getAttemptHistory when none is injected", async () => {
+    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-attempt-cli-cq-"));
+    roots.push(root);
+    vi.stubEnv("GITTENSORY_MINER_PORTFOLIO_QUEUE_DB", join(root, "portfolio-queue.sqlite3"));
+    const { allocator, claimLedger, eventLedger, attemptLog, governorLedger } = tempLedgers();
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const runMinerAttemptSpy = vi.fn().mockResolvedValue({ outcome: "abandon", loopResult: {} });
+
+    await runAttempt(["acme/widgets", "7", "--miner-login", "alice", "--json"], {
+      env: { MINER_CODING_AGENT_PROVIDER: "noop" },
+      openWorktreeAllocator: () => allocator,
+      openClaimLedger: () => claimLedger,
+      initEventLedger: () => eventLedger,
+      initAttemptLog: () => attemptLog,
+      initGovernorLedger: () => governorLedger,
+      // getAttemptHistory deliberately omitted -- exercises the real module-level default over an empty store.
+      ...readyPipelineOptions({ runMinerAttempt: runMinerAttemptSpy }),
+    });
+
+    // The empty default store has never seen this item, so the real read returns the honest first-attempt shape.
+    expect(runMinerAttemptSpy.mock.calls[0]![0].governor.convergenceInput).toEqual({
+      attempts: 0,
+      consecutiveFailures: 0,
+      reenqueues: 0,
+      reachedDone: false,
+    });
   });
 });

--- a/test/unit/miner-attempt-input-builder.test.ts
+++ b/test/unit/miner-attempt-input-builder.test.ts
@@ -58,9 +58,19 @@ describe("buildAttemptGovernorContext (#5132)", () => {
     expect(ctx.killSwitchRepoPaused).toBeUndefined();
   });
 
-  it("REGRESSION: convergenceInput is an honest first-attempt-shaped literal, not fabricated real history", () => {
+  it("defaults convergenceInput to the honest first-attempt shape when the caller omits it (#5654)", () => {
+    // An item the portfolio queue has never seen (no real history supplied) reads as a converging first-look,
+    // not a fabricated history.
     const ctx = buildAttemptGovernorContext({}, DEFAULT_AMS_POLICY_SPEC);
     expect(ctx.convergenceInput).toEqual({ attempts: 0, consecutiveFailures: 0, reenqueues: 0, reachedDone: false });
+  });
+
+  it("forwards the caller's real convergenceInput unchanged when supplied (#5654)", () => {
+    // The composer stays pure -- it threads whatever the caller resolved from the portfolio queue straight
+    // through, so the non-convergence detector finally sees real attempt/reenqueue/failure counts.
+    const real = { attempts: 5, consecutiveFailures: 3, reenqueues: 4, reachedDone: false };
+    const ctx = buildAttemptGovernorContext({}, DEFAULT_AMS_POLICY_SPEC, false, real);
+    expect(ctx.convergenceInput).toEqual(real);
   });
 
   it("omits rateLimitBuckets/rateLimitBackoffAttempts/capUsage so the persisted governor-state store auto-supplies them", () => {

--- a/test/unit/miner-portfolio-queue.test.ts
+++ b/test/unit/miner-portfolio-queue.test.ts
@@ -8,11 +8,13 @@ import {
   closeDefaultPortfolioQueueStore,
   dequeueNext,
   enqueue,
+  getAttemptHistory,
   initPortfolioQueueStore,
   markDone,
   markFailed,
   resolvePortfolioQueueDbPath,
 } from "../../packages/gittensory-miner/lib/portfolio-queue.js";
+import { classifyPortfolioConvergence } from "../../packages/gittensory-engine/src/index";
 
 const roots: string[] = [];
 const stores: Array<{ close(): void }> = [];
@@ -321,6 +323,100 @@ describe("gittensory-miner portfolio/queue store (#2292)", () => {
       expect(geEntry.apiBaseUrl).toBe("https://ghe.example.com/api/v3");
     });
 
+    it("migrates a pre-#5654 file (leased_at+forge v3 shape) by adding the attempt-history columns and preserving rows", () => {
+      // A v3-shaped file (post-forge, pre-attempt-history) gains the v4 columns without disturbing the existing
+      // row (mirrors the leased_at / forge migration tests above). Covers the ADD-COLUMN (true) branch.
+      const root = mkdtempSync(join(tmpdir(), "gittensory-miner-portfolio-v3-"));
+      roots.push(root);
+      const dbPath = join(root, "v3.sqlite3");
+      const legacy = new DatabaseSync(dbPath);
+      legacy.exec(`
+        CREATE TABLE miner_portfolio_queue (
+          api_base_url TEXT NOT NULL,
+          repo_full_name TEXT NOT NULL,
+          identifier TEXT NOT NULL,
+          priority REAL NOT NULL DEFAULT 0,
+          status TEXT NOT NULL DEFAULT 'queued' CHECK (status IN ('queued', 'in_progress', 'done')),
+          enqueued_at TEXT NOT NULL,
+          leased_at TEXT,
+          PRIMARY KEY (api_base_url, repo_full_name, identifier)
+        )
+      `);
+      legacy.exec("PRAGMA user_version = 3");
+      legacy.exec(
+        "INSERT INTO miner_portfolio_queue (api_base_url, repo_full_name, identifier, priority, status, enqueued_at, leased_at) VALUES ('https://api.github.com', 'acme/widgets', 'issue:5', 3, 'queued', '2026-01-01T00:00:00.000Z', NULL)",
+      );
+      legacy.close();
+
+      const store = initPortfolioQueueStore(dbPath);
+      stores.push(store);
+      // Existing row preserved (the base entry shape is unchanged -- counters are surfaced only via getAttemptHistory).
+      expect(store.listQueue("acme/widgets")).toEqual([
+        {
+          apiBaseUrl: "https://api.github.com",
+          repoFullName: "acme/widgets",
+          identifier: "issue:5",
+          priority: 3,
+          status: "queued",
+          enqueuedAt: "2026-01-01T00:00:00.000Z",
+        },
+      ]);
+      // The migrated row starts with a fresh 0/0/0 history, and the counters work after migration.
+      expect(store.getAttemptHistory("acme/widgets", "issue:5")).toEqual({
+        attempts: 0,
+        consecutiveFailures: 0,
+        reenqueues: 0,
+        reachedDone: false,
+      });
+      store.dequeueNext();
+      expect(store.getAttemptHistory("acme/widgets", "issue:5")).toMatchObject({ attempts: 1 });
+    });
+
+    it("is defensive: a file already carrying the attempt-history columns is not re-altered (idempotent v4 migration)", () => {
+      // A v3-versioned file that already ran the ADD COLUMNs (e.g. an ad-hoc ALTER) must not hit a
+      // duplicate-column error -- the per-column table_info presence check skips each already-present column.
+      // Covers the skip (false) branch of all three column checks.
+      const root = mkdtempSync(join(tmpdir(), "gittensory-miner-portfolio-v4-preadded-"));
+      roots.push(root);
+      const dbPath = join(root, "preadded.sqlite3");
+      const legacy = new DatabaseSync(dbPath);
+      legacy.exec(`
+        CREATE TABLE miner_portfolio_queue (
+          api_base_url TEXT NOT NULL,
+          repo_full_name TEXT NOT NULL,
+          identifier TEXT NOT NULL,
+          priority REAL NOT NULL DEFAULT 0,
+          status TEXT NOT NULL DEFAULT 'queued' CHECK (status IN ('queued', 'in_progress', 'done')),
+          enqueued_at TEXT NOT NULL,
+          leased_at TEXT,
+          attempts INTEGER NOT NULL DEFAULT 0,
+          consecutive_failures INTEGER NOT NULL DEFAULT 0,
+          reenqueues INTEGER NOT NULL DEFAULT 0,
+          PRIMARY KEY (api_base_url, repo_full_name, identifier)
+        )
+      `);
+      // Still marked pre-v4, so the v4 migration runs and must no-op each ALTER rather than error.
+      legacy.exec("PRAGMA user_version = 3");
+      legacy.exec(
+        "INSERT INTO miner_portfolio_queue (api_base_url, repo_full_name, identifier, priority, status, enqueued_at, attempts, consecutive_failures, reenqueues) VALUES ('https://api.github.com', 'acme/widgets', 'issue:9', 1, 'queued', '2026-01-01T00:00:00.000Z', 4, 2, 3)",
+      );
+      legacy.close();
+
+      let opened: ReturnType<typeof initPortfolioQueueStore> | undefined;
+      expect(() => {
+        opened = initPortfolioQueueStore(dbPath);
+      }).not.toThrow();
+      const store = opened!;
+      stores.push(store);
+      // The pre-existing counter values survived: the ALTERs were skipped, not re-run with a DEFAULT-0 wipe.
+      expect(store.getAttemptHistory("acme/widgets", "issue:9")).toEqual({
+        attempts: 4,
+        consecutiveFailures: 2,
+        reenqueues: 3,
+        reachedDone: false,
+      });
+    });
+
     it("REGRESSION: a legacy row violating the rebuilt table's status CHECK constraint is dropped, not a migration-aborting crash", () => {
       const root = mkdtempSync(join(tmpdir(), "gittensory-miner-portfolio-legacy-corrupt-"));
       roots.push(root);
@@ -356,6 +452,122 @@ describe("gittensory-miner portfolio/queue store (#2292)", () => {
       stores.push(store);
       // The corrupt row was dropped, not migrated -- only the valid row survived the rebuild.
       expect(store.listQueue().map((entry) => entry.repoFullName)).toEqual(["acme/widgets"]);
+    });
+  });
+
+  describe("attempt-history for the non-convergence detector (#5654)", () => {
+    it("returns an all-zero first-attempt shape for an item the queue has never seen", () => {
+      // A missing row reads as a genuine first look (converging), never a fabricated history.
+      expect(tempStore().getAttemptHistory("o/a", "issue:1")).toEqual({
+        attempts: 0,
+        consecutiveFailures: 0,
+        reenqueues: 0,
+        reachedDone: false,
+      });
+    });
+
+    it("counts an attempt on claim and only flips reachedDone once the item is done", () => {
+      const store = tempStore();
+      store.enqueue({ repoFullName: "o/a", identifier: "issue:1", priority: 1 });
+      expect(store.getAttemptHistory("o/a", "issue:1")).toMatchObject({ attempts: 0, reachedDone: false });
+      store.dequeueNext(); // claim -> attempts 1
+      expect(store.getAttemptHistory("o/a", "issue:1")).toMatchObject({ attempts: 1, reachedDone: false });
+      store.markDone("o/a", "issue:1");
+      expect(store.getAttemptHistory("o/a", "issue:1")).toMatchObject({
+        attempts: 1,
+        consecutiveFailures: 0,
+        reachedDone: true,
+      });
+    });
+
+    it("bumps reenqueues + the failure streak on markFailed and reclaim, and resets the streak on markDone", () => {
+      const store = tempStore();
+      store.enqueue({ repoFullName: "o/a", identifier: "issue:1", priority: 1 });
+      // claim + markFailed (halted run): a failed attempt back to queued.
+      store.dequeueNext();
+      store.markFailed("o/a", "issue:1");
+      expect(store.getAttemptHistory("o/a", "issue:1")).toMatchObject({
+        attempts: 1,
+        reenqueues: 1,
+        consecutiveFailures: 1,
+        reachedDone: false,
+      });
+      // claim + reclaim (stuck sweep): a second failed attempt, both counters climb.
+      store.dequeueNext();
+      store.reclaimStuckItem("o/a", "issue:1");
+      expect(store.getAttemptHistory("o/a", "issue:1")).toMatchObject({
+        attempts: 2,
+        reenqueues: 2,
+        consecutiveFailures: 2,
+      });
+      // claim + markDone: the failure streak resets to 0 (progress), attempts keeps climbing, reenqueues holds.
+      store.dequeueNext();
+      expect(store.markDone("o/a", "issue:1")?.status).toBe("done");
+      expect(store.getAttemptHistory("o/a", "issue:1")).toMatchObject({
+        attempts: 3,
+        reenqueues: 2,
+        consecutiveFailures: 0,
+        reachedDone: true,
+      });
+    });
+
+    it("bumps only reenqueues (not the failure streak) when a completed item is manually requeued", () => {
+      const store = tempStore();
+      store.enqueue({ repoFullName: "o/a", identifier: "issue:1", priority: 1 });
+      store.dequeueNext();
+      store.markDone("o/a", "issue:1");
+      expect(store.requeueItem("o/a", "issue:1")?.status).toBe("queued");
+      // Requeuing a DONE item re-enqueues it (reenqueues 1) but is not a failure (streak stays 0); reachedDone
+      // flips back to false because the row is queued again.
+      expect(store.getAttemptHistory("o/a", "issue:1")).toMatchObject({
+        attempts: 1,
+        reenqueues: 1,
+        consecutiveFailures: 0,
+        reachedDone: false,
+      });
+    });
+
+    it("batchClaim counts an attempt on each claimed item", () => {
+      const store = tempStore();
+      store.enqueue({ repoFullName: "o/a", identifier: "issue:1", priority: 1 });
+      const claimed = store.batchClaim((entries) =>
+        entries.map((entry) => ({ repoFullName: entry.repoFullName, identifier: entry.identifier, apiBaseUrl: entry.apiBaseUrl })),
+      );
+      expect(claimed).toHaveLength(1);
+      expect(store.getAttemptHistory("o/a", "issue:1")).toMatchObject({ attempts: 1 });
+    });
+
+    it("REGRESSION: a genuinely non-convergent item (repeated reclaim, never done) now classifies as non_convergent", () => {
+      const store = tempStore();
+      store.enqueue({ repoFullName: "o/a", identifier: "issue:1", priority: 1 });
+      // Three claim -> reclaim cycles without ever reaching done: exactly the loop the detector is built to catch.
+      for (let cycle = 0; cycle < 3; cycle += 1) {
+        store.dequeueNext();
+        store.reclaimStuckItem("o/a", "issue:1");
+      }
+      const input = store.getAttemptHistory("o/a", "issue:1");
+      expect(input).toMatchObject({ attempts: 3, reenqueues: 3, consecutiveFailures: 3, reachedDone: false });
+      // The first time real portfolio-queue data drives the already-built detector to a real non-convergent verdict.
+      expect(classifyPortfolioConvergence(input).status).toBe("non_convergent");
+    });
+
+    it("reachedDone reflects only status === 'done', never a fabricated flag", () => {
+      const store = tempStore();
+      store.enqueue({ repoFullName: "o/a", identifier: "issue:1", priority: 1 });
+      expect(store.getAttemptHistory("o/a", "issue:1").reachedDone).toBe(false); // queued
+      store.dequeueNext();
+      expect(store.getAttemptHistory("o/a", "issue:1").reachedDone).toBe(false); // in_progress
+      store.markDone("o/a", "issue:1");
+      expect(store.getAttemptHistory("o/a", "issue:1").reachedDone).toBe(true); // done
+    });
+
+    it("module-level getAttemptHistory delegates to the default portfolio-queue store", () => {
+      const root = mkdtempSync(join(tmpdir(), "gittensory-miner-portfolio-default-"));
+      roots.push(root);
+      vi.stubEnv("GITTENSORY_MINER_PORTFOLIO_QUEUE_DB", join(root, "portfolio-queue.sqlite3"));
+      enqueue({ repoFullName: "o/a", identifier: "issue:1", priority: 1 });
+      dequeueNext();
+      expect(getAttemptHistory("o/a", "issue:1")).toMatchObject({ attempts: 1, reachedDone: false });
     });
   });
 });


### PR DESCRIPTION
## What & why

Closes #5654.

`classifyPortfolioConvergence` (gittensory-engine's non-convergence detector, #4286) has been fully built and tested since Wave 3, but it has **never seen real data**: `buildAttemptGovernorContext` hardcoded `convergenceInput` to a first-attempt-shaped literal (`{ attempts: 0, consecutiveFailures: 0, reenqueues: 0, reachedDone: false }`) on every call — a documented placeholder, because the portfolio-queue table tracked no attempt-history columns. This PR makes that data **real**, so the detector finally catches a stuck/looping item instead of always reading "fresh, no prior failures". (A Wave 5 multi-tenant prerequisite: a paying tenant's looping task should be caught, not silently retried forever on their compute budget.)

## How

- **Schema** (`portfolio-queue.js`) — an additive `v3 -> v4` migration adds `attempts`, `consecutive_failures`, and `reenqueues` (all `INTEGER NOT NULL DEFAULT 0`), guarded by the same per-column `PRAGMA table_info` presence check the `leased_at` migration already uses, so a file that already ran an ad-hoc `ALTER` is never re-altered into a duplicate-column error.
- **Counters** — `attempts` bumps on every claim (`dequeueNext`/`batchClaim`); `reenqueues` **and** `consecutive_failures` bump on every `in_progress -> queued` transition that did **not** reach done (`markFailed`, the stuck-item reclaim sweep — exactly the "cycling queued → in_progress → queued without ever reaching done" the detector's own header names); `reenqueues` **alone** bumps on a manual requeue of a `done` item (a re-attempt of a success is not a failure); `consecutive_failures` **resets to 0** on `markDone`. `reachedDone` needs no column — it is just `status === 'done'`.
- **Read** — `getAttemptHistory(repoFullName, identifier, apiBaseUrl)` returns a real `PortfolioConvergenceInput`. An item the queue has never seen reads as an honest first-attempt shape (a converging first-look), never a fabricated history.
- **Wiring** — `attempt-cli.js` reads this exact item's real history (keyed the same `issue:<n>` way `portfolio-discovery.js` enqueues it) and threads it into `buildAttemptGovernorContext`, which stays **pure** and just forwards it. **Fail-open:** a read failure degrades to the honest first-attempt shape, so a governance signal never fails an attempt on its own.

## Acceptance criteria

- [x] `miner_portfolio_queue` gains real attempt-history columns via a normal additive migration
- [x] Attempts / reenqueues / consecutive-failures counters update correctly on claim / requeue / reclaim / done
- [x] A real read function returns a genuine `PortfolioConvergenceInput`
- [x] `buildAttemptGovernorContext` receives and forwards the real data instead of the hardcoded literal
- [x] `non-convergence.ts`'s classifier itself is untouched

## Tests

`test/unit/miner-portfolio-queue.test.ts`, `miner-attempt-input-builder.test.ts`, `miner-attempt-cli.test.ts` (all pass; every changed line and both sides of every new branch covered):

1. **Schema migration** — a pre-#5654 (`leased_at`+forge `v3`) file gains the columns and preserves its row; and a defensive test proving a file that already carries the columns is **not** re-altered (idempotent, per-column skip).
2. **Counter correctness** — full `claim -> requeue -> reclaim -> done` sequences, including a **REGRESSION** proving a genuinely non-convergent item (repeated reclaim, never done) now produces a `PortfolioConvergenceInput` that `classifyPortfolioConvergence` classifies as `non_convergent` — the first real exercise of that detector.
3. **`reachedDone` invariant** — only ever `status === 'done'`, never fabricated.
4. **Wiring** — the real history is threaded into the Governor `convergenceInput`; fail-open falls back to the honest shape when the read throws; and the real module-level default is used when none is injected.

`tsc --noEmit` is clean and the existing suites stay green.
