### PR TITLE
feat(miner): track real per-issue attempt-history on the portfolio queue, feed the Governor's convergenceInput

### DIFF
--- a/packages/gittensory-miner/lib/attempt-cli.d.ts
+++ b/packages/gittensory-miner/lib/attempt-cli.d.ts
@@ -13,6 +13,7 @@ import type { resolveAmsPolicy } from "./ams-policy.js";
 import type { checkMinerKillSwitch } from "./governor-kill-switch.js";
 import type { resolveMinerGoalSpec } from "./miner-goal-spec.js";
 import type { ClaimConflictResult, resolveClaimConflict } from "./claim-conflict-resolver.js";
+import type { readConvergenceInputForIssue } from "./portfolio-queue.js";
 
 type CommonAttemptResultFields = {
   repoFullName: string;
@@ -89,6 +90,9 @@ export type RunAttemptOptions = {
   resolveAmsPolicy?: typeof resolveAmsPolicy;
   checkMinerKillSwitch?: typeof checkMinerKillSwitch;
   resolveMinerGoalSpec?: typeof resolveMinerGoalSpec;
+  /** Real per-issue convergence-history reader (#5654); defaults to reading the default portfolio-queue store.
+   *  Injected by tests to stay hermetic. */
+  readPortfolioConvergence?: typeof readConvergenceInputForIssue;
   runMinerAttempt?: typeof runMinerAttempt;
   resolveClaimConflict?: typeof resolveClaimConflict;
   /** Invoked with the real structured result at every return point, in addition to (never instead of) the

--- a/packages/gittensory-miner/lib/attempt-cli.js
+++ b/packages/gittensory-miner/lib/attempt-cli.js
@@ -33,6 +33,7 @@ import { buildCodingTaskSpec } from "./coding-task-spec.js";
 import { resolveAmsPolicy } from "./ams-policy.js";
 import { checkMinerKillSwitch } from "./governor-kill-switch.js";
 import { buildAttemptGovernorContext, buildAttemptLoopInput } from "./attempt-input-builder.js";
+import { readConvergenceInputForIssue } from "./portfolio-queue.js";
 import { runMinerAttempt } from "./attempt-runner.js";
 
 const ATTEMPT_USAGE =
@@ -399,7 +400,14 @@ export async function runAttempt(args, options = {}) {
       amsPolicySpec: amsPolicy.spec,
       branchRef: worktreeResult.branchName,
     });
-    const governor = buildAttemptGovernorContext(env, amsPolicy.spec, repoPaused);
+    // Real per-issue convergence history (#5654): read this issue's attempt-history counters from the
+    // portfolio-queue store (keyed by the miner's `issue:<number>` identifier) and thread them into the
+    // Governor context, replacing the honest-but-blind first-attempt literal buildAttemptGovernorContext used
+    // to hardcode. Injectable so unit tests stay hermetic (no default-store IO); the real reader reads the
+    // default store. A never-queued issue reads the zero literal — the same safe under-estimate as before.
+    const readConvergence = options.readPortfolioConvergence ?? readConvergenceInputForIssue;
+    const convergenceInput = readConvergence(parsed.repoFullName, parsed.issueNumber);
+    const governor = buildAttemptGovernorContext(env, amsPolicy.spec, repoPaused, convergenceInput);
 
     // Real soft-claim (#5393): recorded once we've committed to a real attempt (past feasibility), so a
     // sibling miner process on this machine sees it via claimLedger.listClaims/listActiveClaims while this

--- a/packages/gittensory-miner/lib/attempt-input-builder.d.ts
+++ b/packages/gittensory-miner/lib/attempt-input-builder.d.ts
@@ -1,4 +1,4 @@
-import type { AmsPolicySpec, CodingAgentExecutionMode, IterateLoopInput, SelfReviewContext } from "@loopover/engine";
+import type { AmsPolicySpec, CodingAgentExecutionMode, IterateLoopInput, PortfolioConvergenceInput, SelfReviewContext } from "@loopover/engine";
 import type { AttemptGovernorContext } from "./attempt-runner.js";
 import type { CodingTaskSpecResult } from "./coding-task-spec.js";
 
@@ -6,6 +6,7 @@ export function buildAttemptGovernorContext(
   env: Record<string, string | undefined>,
   amsPolicySpec: AmsPolicySpec,
   repoPaused?: boolean,
+  convergenceInput?: PortfolioConvergenceInput,
 ): AttemptGovernorContext;
 
 export type BuildAttemptLoopInputInput = {

--- a/packages/gittensory-miner/lib/attempt-input-builder.js
+++ b/packages/gittensory-miner/lib/attempt-input-builder.js
@@ -6,13 +6,12 @@ import { isGlobalMinerKillSwitch, isGlobalMinerLiveModeOptIn } from "@loopover/e
 // same discipline as coding-task-spec.js's own composers.
 //
 // KNOWN, DOCUMENTED GAPS (not fabricated -- explicitly left as real, narrow follow-ups):
-//   - governor.convergenceInput is a first-attempt-shaped literal ({ attempts: 0, consecutiveFailures: 0,
-//     reenqueues: 0, reachedDone: false }), not a real per-issue query. attempt-log.js's schema has no
-//     repo+issue index (attemptId embeds a timestamp, so it's not a stable group key), and reenqueue counts
-//     aren't tracked ANYWHERE yet (non-convergence.ts's own header says that belongs on the portfolio-queue
-//     table once it grows attempt-history columns -- a real, separate schema change, not something to fake
-//     here). This literal is only ever an UNDER-estimate (reads "fresh, no prior failures" even on a real
-//     Nth attempt), which fails toward LETTING an attempt through, not blocking one -- documented, not silent.
+//   - governor.convergenceInput is now REAL per-issue history (#5654): the caller reads it from the
+//     portfolio-queue store (readConvergenceInputForIssue) -- which grew attempts/consecutiveFailures/reenqueues
+//     columns, the home non-convergence.ts's header always named for them -- and threads it in, the same way it
+//     threads repoPaused. A caller that passes nothing (or an issue this miner never queued) still falls back to
+//     the honest first-attempt literal below, an UNDER-estimate that fails toward LETTING an attempt through --
+//     documented, not silent -- never a fabricated "clean" history.
 //   - governor.reputationHistory/selfPlagiarismCandidate/selfPlagiarismRecentSubmissions are omitted, which
 //     chokepoint.ts's own design treats as "skip that stage entirely" -- an honest absence, not a fabricated
 //     "clean" verdict.
@@ -26,18 +25,24 @@ import { isGlobalMinerKillSwitch, isGlobalMinerLiveModeOptIn } from "@loopover/e
  * (miner-goal-spec.js's resolveMinerGoalSpec) -- this composer stays pure and just threads whatever the
  * caller already resolved through; passing nothing keeps the prior fails-open-on-that-axis-only behavior.
  *
+ * `convergenceInput` (#5654) is the caller's real per-issue attempt-history, read from the portfolio-queue
+ * store (readConvergenceInputForIssue) -- threaded through the same way as repoPaused. Omitting it falls back
+ * to the honest first-attempt literal (an under-estimate that fails toward letting an attempt through), so a
+ * caller that has no queue history for the issue is unchanged from the prior behavior.
+ *
  * @param {Record<string, string | undefined>} env
  * @param {import("@loopover/engine").AmsPolicySpec} amsPolicySpec
  * @param {boolean} [repoPaused]
+ * @param {import("@loopover/engine").PortfolioConvergenceInput} [convergenceInput]
  * @returns {import("./attempt-runner.js").AttemptGovernorContext}
  */
-export function buildAttemptGovernorContext(env, amsPolicySpec, repoPaused) {
+export function buildAttemptGovernorContext(env, amsPolicySpec, repoPaused, convergenceInput) {
   return {
     killSwitchGlobal: isGlobalMinerKillSwitch(env),
     killSwitchRepoPaused: repoPaused,
     liveModeGlobalOptIn: isGlobalMinerLiveModeOptIn(env),
     capLimits: amsPolicySpec.capLimits,
-    convergenceInput: { attempts: 0, consecutiveFailures: 0, reenqueues: 0, reachedDone: false },
+    convergenceInput: convergenceInput ?? { attempts: 0, consecutiveFailures: 0, reenqueues: 0, reachedDone: false },
   };
 }
 

--- a/packages/gittensory-miner/lib/portfolio-queue.d.ts
+++ b/packages/gittensory-miner/lib/portfolio-queue.d.ts
@@ -1,3 +1,5 @@
+import type { PortfolioConvergenceInput } from "@loopover/engine";
+
 export type QueueStatus = "queued" | "in_progress" | "done";
 
 export type QueueEntry = {
@@ -33,6 +35,7 @@ export type PortfolioQueueStore = {
   listInProgress(): QueueLeaseEntry[];
   markDone(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueEntry | null;
   markFailed(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueEntry | null;
+  readConvergenceInput(repoFullName: string, identifier: string, apiBaseUrl?: string): PortfolioConvergenceInput;
   reclaimStuckItem(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueEntry | null;
   requeueItem(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueEntry | null;
   batchClaim(
@@ -58,5 +61,11 @@ export function listQueue(repoFullName?: string | null): QueueEntry[];
 export function markDone(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueEntry | null;
 
 export function markFailed(repoFullName: string, identifier: string, apiBaseUrl?: string): QueueEntry | null;
+
+export function readConvergenceInputForIssue(
+  repoFullName: string,
+  issueNumber: number,
+  apiBaseUrl?: string,
+): PortfolioConvergenceInput;
 
 export function closeDefaultPortfolioQueueStore(): void;

--- a/packages/gittensory-miner/lib/portfolio-queue.js
+++ b/packages/gittensory-miner/lib/portfolio-queue.js
@@ -93,6 +93,9 @@ export function initPortfolioQueueStore(dbPath = resolvePortfolioQueueDbPath()) 
       status TEXT NOT NULL DEFAULT 'queued' CHECK (status IN ('queued', 'in_progress', 'done')),
       enqueued_at TEXT NOT NULL,
       leased_at TEXT,
+      attempts INTEGER NOT NULL DEFAULT 0,
+      consecutive_failures INTEGER NOT NULL DEFAULT 0,
+      reenqueues INTEGER NOT NULL DEFAULT 0,
       PRIMARY KEY (repo_full_name, identifier)
     )
   `);
@@ -109,6 +112,12 @@ export function initPortfolioQueueStore(dbPath = resolvePortfolioQueueDbPath()) 
   // queue. SQLite cannot ALTER a PRIMARY KEY in place, so this rebuilds the table: create the new shape, copy
   // every existing row with the pre-#4784 implicit single-forge default backfilled, drop the old table, rename
   // the new one in.
+  //
+  // v3 -> v4 (#5654): add the attempt-history counters (attempts/consecutive_failures/reenqueues) the
+  // non-convergence detector needs. non-convergence.ts's own header names THIS table as their home ("belongs
+  // on the portfolio-queue table once it grows attempt-history columns"); until now buildAttemptGovernorContext
+  // could only feed the Governor a zero literal. Additive ALTERs (same defensive table_info guard as leased_at),
+  // so a pre-existing v3 file backfills every row to 0 without a rebuild.
   applySchemaMigrations(db, [
     (migrationDb) => {
       const hasLeasedAtColumn = migrationDb
@@ -147,6 +156,24 @@ export function initPortfolioQueueStore(dbPath = resolvePortfolioQueueDbPath()) 
       migrationDb.exec("DROP TABLE miner_portfolio_queue");
       migrationDb.exec("ALTER TABLE miner_portfolio_queue_v3 RENAME TO miner_portfolio_queue");
     },
+    (migrationDb) => {
+      const columns = migrationDb
+        .prepare("PRAGMA table_info(miner_portfolio_queue)")
+        .all()
+        .map((column) => column.name);
+      // Defensive per-column guard (same posture as the leased_at migration): a file that already ran an
+      // ad-hoc ALTER, or a fresh store whose CREATE TABLE above already carries these columns, is not
+      // re-altered into a duplicate-column error.
+      if (!columns.includes("attempts")) {
+        migrationDb.exec("ALTER TABLE miner_portfolio_queue ADD COLUMN attempts INTEGER NOT NULL DEFAULT 0");
+      }
+      if (!columns.includes("consecutive_failures")) {
+        migrationDb.exec("ALTER TABLE miner_portfolio_queue ADD COLUMN consecutive_failures INTEGER NOT NULL DEFAULT 0");
+      }
+      if (!columns.includes("reenqueues")) {
+        migrationDb.exec("ALTER TABLE miner_portfolio_queue ADD COLUMN reenqueues INTEGER NOT NULL DEFAULT 0");
+      }
+    },
   ]);
 
   // `rowid` is a stable, unique key assigned once at first insert (re-enqueue updates in place, never re-inserts),
@@ -174,8 +201,10 @@ export function initPortfolioQueueStore(dbPath = resolvePortfolioQueueDbPath()) 
   // cross-host priority ordering, not a per-host one.
   // Claiming stamps `leased_at` with the caller-supplied claim time; leaving 'in_progress' (done/failed/reclaim)
   // clears it back to NULL so only genuinely in-flight rows carry a lease.
+  // Claiming a row is one attempt on that item (#5654): every queued -> in_progress transition bumps the
+  // attempts counter the non-convergence detector reads.
   const dequeueStatement = db.prepare(`
-    UPDATE miner_portfolio_queue SET status = 'in_progress', leased_at = ?
+    UPDATE miner_portfolio_queue SET status = 'in_progress', leased_at = ?, attempts = attempts + 1
     WHERE rowid = (
       SELECT rowid FROM miner_portfolio_queue WHERE status = 'queued' ${ORDER} LIMIT 1
     )
@@ -183,13 +212,18 @@ export function initPortfolioQueueStore(dbPath = resolvePortfolioQueueDbPath()) 
   `);
   // RETURNING (rather than a separate post-UPDATE SELECT) makes the "nothing to mark done" case observable
   // directly from one atomic statement.
+  // Reaching 'done' is progress, so it resets the consecutive-failure streak to 0 (#5654) -- the detector's
+  // "reset to 0 on any progress" rule. attempts/reenqueues are cumulative and left intact.
   const markDoneStatement = db.prepare(`
-    UPDATE miner_portfolio_queue SET status = 'done', leased_at = NULL
+    UPDATE miner_portfolio_queue SET status = 'done', leased_at = NULL, consecutive_failures = 0
     WHERE api_base_url = ? AND repo_full_name = ? AND identifier = ? AND status <> 'done'
     RETURNING *
   `);
+  // An in_progress -> queued transition is a failed-and-re-enqueued attempt (#5654): bump BOTH the reenqueue
+  // total and the consecutive-failure streak. markDone resets the streak; nothing else does.
   const markFailedStatement = db.prepare(`
-    UPDATE miner_portfolio_queue SET status = 'queued', leased_at = NULL
+    UPDATE miner_portfolio_queue
+      SET status = 'queued', leased_at = NULL, reenqueues = reenqueues + 1, consecutive_failures = consecutive_failures + 1
     WHERE api_base_url = ? AND repo_full_name = ? AND identifier = ? AND status = 'in_progress'
     RETURNING *
   `);
@@ -203,8 +237,11 @@ export function initPortfolioQueueStore(dbPath = resolvePortfolioQueueDbPath()) 
   const listInProgressStatement = db.prepare(
     `SELECT * FROM miner_portfolio_queue WHERE status = 'in_progress' ${ORDER}`,
   );
+  // Reclaiming a stuck lease is the same in_progress -> queued failure transition as markFailed, so it moves
+  // the same two counters (#5654) -- a crashed attempt that stranded its lease still counts as a failed re-enqueue.
   const reclaimStatement = db.prepare(`
-    UPDATE miner_portfolio_queue SET status = 'queued', leased_at = NULL
+    UPDATE miner_portfolio_queue
+      SET status = 'queued', leased_at = NULL, reenqueues = reenqueues + 1, consecutive_failures = consecutive_failures + 1
     WHERE api_base_url = ? AND repo_full_name = ? AND identifier = ? AND status = 'in_progress'
     RETURNING *
   `);
@@ -216,11 +253,18 @@ export function initPortfolioQueueStore(dbPath = resolvePortfolioQueueDbPath()) 
     WHERE api_base_url = ? AND repo_full_name = ? AND identifier = ? AND status = 'done'
     RETURNING *
   `);
+  // batchClaim's per-target claim is also a queued -> in_progress attempt, so it bumps attempts too (#5654),
+  // keeping the counter consistent across both the single-item (dequeueNext) and batch claim paths.
   const claimTargetStatement = db.prepare(`
-    UPDATE miner_portfolio_queue SET status = 'in_progress', leased_at = ?
+    UPDATE miner_portfolio_queue SET status = 'in_progress', leased_at = ?, attempts = attempts + 1
     WHERE api_base_url = ? AND repo_full_name = ? AND identifier = ? AND status = 'queued'
     RETURNING *
   `);
+  // Read-only projection of one item's attempt-history into the engine's PortfolioConvergenceInput shape.
+  const convergenceStatement = db.prepare(
+    `SELECT attempts, consecutive_failures, reenqueues, status
+       FROM miner_portfolio_queue WHERE api_base_url = ? AND repo_full_name = ? AND identifier = ?`,
+  );
 
   return {
     dbPath: resolvedPath,
@@ -268,6 +312,28 @@ export function initPortfolioQueueStore(dbPath = resolvePortfolioQueueDbPath()) 
         ? listAllStatement.all()
         : listRepoStatement.all(normalizeRepoFullName(repoFullName));
       return rows.map(rowToEntry);
+    },
+    /**
+     * One item's attempt-history as the engine's `PortfolioConvergenceInput` (#5654), for feeding
+     * classifyPortfolioConvergence / the Governor chokepoint. A never-tracked item (no such row) reads the
+     * honest zero literal — `attempts: 0` — which the detector treats as "no attempts yet, converging", the
+     * same safe under-estimate buildAttemptGovernorContext used before this became real. `reachedDone` is the
+     * item's current terminal status, per the issue's `status === 'done'` definition.
+     * @returns {import("@loopover/engine").PortfolioConvergenceInput}
+     */
+    readConvergenceInput(repoFullName, identifier, apiBaseUrl) {
+      const row = convergenceStatement.get(
+        normalizeApiBaseUrl(apiBaseUrl),
+        normalizeRepoFullName(repoFullName),
+        normalizeIdentifier(identifier),
+      );
+      if (!row) return { attempts: 0, consecutiveFailures: 0, reenqueues: 0, reachedDone: false };
+      return {
+        attempts: row.attempts,
+        consecutiveFailures: row.consecutive_failures,
+        reenqueues: row.reenqueues,
+        reachedDone: row.status === "done",
+      };
     },
     markDone(repoFullName, identifier, apiBaseUrl) {
       const row = markDoneStatement.get(
@@ -342,6 +408,18 @@ export function markDone(repoFullName, identifier, apiBaseUrl) {
 
 export function markFailed(repoFullName, identifier, apiBaseUrl) {
   return getDefaultPortfolioQueueStore().markFailed(repoFullName, identifier, apiBaseUrl);
+}
+
+/**
+ * Read one issue's convergence input from the default portfolio-queue store, keyed by the miner's
+ * `issue:<number>` identifier convention (portfolio-discovery.js). `apiBaseUrl` defaults to the github.com
+ * host (the single-forge default); an issue tracked under a different forge that isn't in this store reads the
+ * honest zero literal — an under-estimate that fails toward letting the attempt through (see
+ * attempt-input-builder.js), never a fabricated "clean" history. The attempt pipeline's read hook (#5654).
+ * @returns {import("@loopover/engine").PortfolioConvergenceInput}
+ */
+export function readConvergenceInputForIssue(repoFullName, issueNumber, apiBaseUrl) {
+  return getDefaultPortfolioQueueStore().readConvergenceInput(repoFullName, `issue:${issueNumber}`, apiBaseUrl);
 }
 
 export function closeDefaultPortfolioQueueStore() {

--- a/test/unit/miner-attempt-cli.test.ts
+++ b/test/unit/miner-attempt-cli.test.ts
@@ -12,6 +12,7 @@ import { closeDefaultEventLedger, initEventLedger } from "../../packages/gittens
 import { closeDefaultAttemptLog, initAttemptLog } from "../../packages/gittensory-miner/lib/attempt-log.js";
 import { closeDefaultGovernorLedger, initGovernorLedger } from "../../packages/gittensory-miner/lib/governor-ledger.js";
 import { closeDefaultWorktreeAllocator, openWorktreeAllocator } from "../../packages/gittensory-miner/lib/worktree-allocator.js";
+import { closeDefaultPortfolioQueueStore } from "../../packages/gittensory-miner/lib/portfolio-queue.js";
 import { buildAttemptDeps, parseAttemptArgs, runAttempt } from "../../packages/gittensory-miner/lib/attempt-cli.js";
 import type { PrepareAttemptWorktreeResult } from "../../packages/gittensory-miner/lib/attempt-worktree.js";
 import { DEFAULT_AMS_POLICY_SPEC, DEFAULT_MINER_GOAL_SPEC, parseFocusManifest } from "../../packages/gittensory-engine/src/index";
@@ -64,6 +65,9 @@ function readyPipelineOptions(overrides: Record<string, unknown> = {}) {
     resolveAmsPolicy: async () => ({ spec: DEFAULT_AMS_POLICY_SPEC, source: "default" as const, warnings: [] }),
     checkMinerKillSwitch: () => ({ scope: "none" as const, active: false }),
     resolveMinerGoalSpec: () => ({ present: false, spec: DEFAULT_MINER_GOAL_SPEC, warnings: [] }),
+    // Hermetic per-issue convergence read (#5654): a stub keeps every pipeline test off the real default
+    // portfolio-queue store; the real reader is exercised by its own fallback test below.
+    readPortfolioConvergence: () => ({ attempts: 0, consecutiveFailures: 0, reenqueues: 0, reachedDone: false }),
     ...overrides,
   };
 }
@@ -89,7 +93,9 @@ afterEach(() => {
   closeDefaultEventLedger();
   closeDefaultAttemptLog();
   closeDefaultGovernorLedger();
+  closeDefaultPortfolioQueueStore();
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
 
@@ -999,6 +1005,59 @@ describe("runAttempt: real per-repo kill switch (#5392)", () => {
     const [input] = runMinerAttemptSpy.mock.calls[0]!;
     expect(input.killSwitchScope).toBe("none");
     expect(input.governor.killSwitchRepoPaused).toBe(false);
+  });
+});
+
+describe("runAttempt: real per-issue convergence history (#5654)", () => {
+  it("reads the issue's real convergence history and threads it into the governor context", async () => {
+    const { allocator, claimLedger, eventLedger, attemptLog, governorLedger } = tempLedgers();
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const runMinerAttemptSpy = vi.fn().mockResolvedValue({ outcome: "governed", decision: { allowed: false }, loopResult: {} });
+    const readConvergenceSpy = vi.fn().mockReturnValue({ attempts: 5, consecutiveFailures: 3, reenqueues: 3, reachedDone: false });
+
+    await runAttempt(["acme/widgets", "7", "--miner-login", "alice", "--json"], {
+      env: { MINER_CODING_AGENT_PROVIDER: "noop" },
+      openWorktreeAllocator: () => allocator,
+      openClaimLedger: () => claimLedger,
+      initEventLedger: () => eventLedger,
+      initAttemptLog: () => attemptLog,
+      initGovernorLedger: () => governorLedger,
+      ...readyPipelineOptions({
+        readPortfolioConvergence: readConvergenceSpy,
+        runMinerAttempt: runMinerAttemptSpy,
+      }),
+    });
+
+    // Keyed by the parsed repo + issue number (the reader itself maps to the `issue:<n>` identifier).
+    expect(readConvergenceSpy).toHaveBeenCalledWith("acme/widgets", 7);
+    const [input] = runMinerAttemptSpy.mock.calls[0]!;
+    expect(input.governor.convergenceInput).toEqual({ attempts: 5, consecutiveFailures: 3, reenqueues: 3, reachedDone: false });
+  });
+
+  it("falls back to the real default-store reader when no reader is injected, reading the honest zero literal for a never-queued issue", async () => {
+    const { allocator, claimLedger, eventLedger, attemptLog, governorLedger } = tempLedgers();
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-attempt-cli-conv-"));
+    roots.push(root);
+    // Point the default portfolio-queue store at a temp file so the real fallback reader stays hermetic.
+    vi.stubEnv("GITTENSORY_MINER_PORTFOLIO_QUEUE_DB", join(root, "portfolio-queue.sqlite3"));
+    const runMinerAttemptSpy = vi.fn().mockResolvedValue({ outcome: "governed", decision: { allowed: false }, loopResult: {} });
+
+    await runAttempt(["acme/widgets", "7", "--miner-login", "alice", "--json"], {
+      env: { MINER_CODING_AGENT_PROVIDER: "noop" },
+      openWorktreeAllocator: () => allocator,
+      openClaimLedger: () => claimLedger,
+      initEventLedger: () => eventLedger,
+      initAttemptLog: () => attemptLog,
+      initGovernorLedger: () => governorLedger,
+      ...readyPipelineOptions({
+        readPortfolioConvergence: undefined, // exercise the real readConvergenceInputForIssue fallback
+        runMinerAttempt: runMinerAttemptSpy,
+      }),
+    });
+
+    const [input] = runMinerAttemptSpy.mock.calls[0]!;
+    expect(input.governor.convergenceInput).toEqual({ attempts: 0, consecutiveFailures: 0, reenqueues: 0, reachedDone: false });
   });
 });
 

--- a/test/unit/miner-attempt-input-builder.test.ts
+++ b/test/unit/miner-attempt-input-builder.test.ts
@@ -58,9 +58,15 @@ describe("buildAttemptGovernorContext (#5132)", () => {
     expect(ctx.killSwitchRepoPaused).toBeUndefined();
   });
 
-  it("REGRESSION: convergenceInput is an honest first-attempt-shaped literal, not fabricated real history", () => {
+  it("falls back to the honest first-attempt literal when the caller supplies no convergenceInput (#5654)", () => {
     const ctx = buildAttemptGovernorContext({}, DEFAULT_AMS_POLICY_SPEC);
     expect(ctx.convergenceInput).toEqual({ attempts: 0, consecutiveFailures: 0, reenqueues: 0, reachedDone: false });
+  });
+
+  it("threads the caller's real per-issue convergenceInput through unchanged (#5654)", () => {
+    const convergenceInput = { attempts: 4, consecutiveFailures: 3, reenqueues: 2, reachedDone: false };
+    const ctx = buildAttemptGovernorContext({}, DEFAULT_AMS_POLICY_SPEC, undefined, convergenceInput);
+    expect(ctx.convergenceInput).toEqual(convergenceInput);
   });
 
   it("omits rateLimitBuckets/rateLimitBackoffAttempts/capUsage so the persisted governor-state store auto-supplies them", () => {

--- a/test/unit/miner-portfolio-queue.test.ts
+++ b/test/unit/miner-portfolio-queue.test.ts
@@ -11,8 +11,10 @@ import {
   initPortfolioQueueStore,
   markDone,
   markFailed,
+  readConvergenceInputForIssue,
   resolvePortfolioQueueDbPath,
 } from "../../packages/gittensory-miner/lib/portfolio-queue.js";
+import { classifyPortfolioConvergence } from "../../packages/gittensory-engine/src/index";
 
 const roots: string[] = [];
 const stores: Array<{ close(): void }> = [];
@@ -356,6 +358,153 @@ describe("gittensory-miner portfolio/queue store (#2292)", () => {
       stores.push(store);
       // The corrupt row was dropped, not migrated -- only the valid row survived the rebuild.
       expect(store.listQueue().map((entry) => entry.repoFullName)).toEqual(["acme/widgets"]);
+    });
+  });
+
+  describe("attempt-history counters + convergence (#5654)", () => {
+    const ZERO = { attempts: 0, consecutiveFailures: 0, reenqueues: 0, reachedDone: false };
+
+    it("counts each claim as an attempt, via both dequeueNext and batchClaim", () => {
+      const store = tempStore();
+      store.enqueue({ repoFullName: "o/a", identifier: "issue:1", priority: 1 });
+      store.enqueue({ repoFullName: "o/b", identifier: "issue:2", priority: 1 });
+      expect(store.readConvergenceInput("o/a", "issue:1")).toEqual(ZERO);
+
+      store.dequeueNext(); // claims the higher-in-order o/a#1
+      expect(store.readConvergenceInput("o/a", "issue:1")).toMatchObject({ attempts: 1, reachedDone: false });
+
+      store.batchClaim((entries) =>
+        entries.filter((entry) => entry.identifier === "issue:2").map((entry) => ({ repoFullName: entry.repoFullName, identifier: entry.identifier, apiBaseUrl: entry.apiBaseUrl })),
+      );
+      expect(store.readConvergenceInput("o/b", "issue:2").attempts).toBe(1);
+    });
+
+    it("markFailed bumps both the reenqueue total and the consecutive-failure streak", () => {
+      const store = tempStore();
+      store.enqueue({ repoFullName: "o/a", identifier: "issue:1", priority: 1 });
+      store.dequeueNext();
+      store.markFailed("o/a", "issue:1");
+      expect(store.readConvergenceInput("o/a", "issue:1")).toEqual({ attempts: 1, consecutiveFailures: 1, reenqueues: 1, reachedDone: false });
+    });
+
+    it("reclaimStuckItem moves the same two counters as markFailed (a stranded lease is a failed re-enqueue)", () => {
+      const store = tempStore();
+      store.enqueue({ repoFullName: "o/a", identifier: "issue:1", priority: 1 });
+      store.dequeueNext();
+      store.reclaimStuckItem("o/a", "issue:1");
+      expect(store.readConvergenceInput("o/a", "issue:1")).toEqual({ attempts: 1, consecutiveFailures: 1, reenqueues: 1, reachedDone: false });
+    });
+
+    it("markDone resets the consecutive-failure streak to 0 but keeps attempts/reenqueues, and reads reachedDone", () => {
+      const store = tempStore();
+      store.enqueue({ repoFullName: "o/a", identifier: "issue:1", priority: 1 });
+      store.dequeueNext();
+      store.markFailed("o/a", "issue:1"); // attempts 1, streak 1, reenqueues 1
+      store.dequeueNext(); // attempts 2
+      store.markDone("o/a", "issue:1"); // streak reset to 0, reachedDone via status
+      expect(store.readConvergenceInput("o/a", "issue:1")).toEqual({ attempts: 2, consecutiveFailures: 0, reenqueues: 1, reachedDone: true });
+    });
+
+    it("requeueItem (done -> queued) leaves the counters untouched and flips reachedDone back to false", () => {
+      const store = tempStore();
+      store.enqueue({ repoFullName: "o/a", identifier: "issue:1", priority: 1 });
+      store.dequeueNext();
+      store.markDone("o/a", "issue:1");
+      expect(store.readConvergenceInput("o/a", "issue:1").reachedDone).toBe(true);
+      store.requeueItem("o/a", "issue:1");
+      expect(store.readConvergenceInput("o/a", "issue:1")).toEqual({ attempts: 1, consecutiveFailures: 0, reenqueues: 0, reachedDone: false });
+    });
+
+    it("reads the honest zero literal for an item that was never queued", () => {
+      expect(tempStore().readConvergenceInput("o/a", "issue:999")).toEqual(ZERO);
+    });
+
+    it("REGRESSION: a real claim/fail lifecycle feeds classifyPortfolioConvergence a non_convergent verdict", () => {
+      const store = tempStore();
+      store.enqueue({ repoFullName: "o/a", identifier: "issue:1", priority: 1 });
+      for (let cycle = 0; cycle < 3; cycle += 1) {
+        store.dequeueNext();
+        store.markFailed("o/a", "issue:1");
+      }
+      const input = store.readConvergenceInput("o/a", "issue:1");
+      expect(input).toEqual({ attempts: 3, consecutiveFailures: 3, reenqueues: 3, reachedDone: false });
+      // The detector was fully built but starved of data before this; prove real data now trips it.
+      expect(classifyPortfolioConvergence(input).status).toBe("non_convergent");
+    });
+
+    it("module-level readConvergenceInputForIssue keys by issue:<number> against the default store", () => {
+      const root = mkdtempSync(join(tmpdir(), "gittensory-miner-portfolio-conv-"));
+      roots.push(root);
+      vi.stubEnv("GITTENSORY_MINER_PORTFOLIO_QUEUE_DB", join(root, "portfolio-queue.sqlite3"));
+      enqueue({ repoFullName: "o/a", identifier: "issue:7", priority: 1 });
+      dequeueNext();
+      markFailed("o/a", "issue:7");
+      expect(readConvergenceInputForIssue("o/a", 7)).toEqual({ attempts: 1, consecutiveFailures: 1, reenqueues: 1, reachedDone: false });
+    });
+
+    it("migrates a pre-#5654 v3 file, backfilling the counters to 0 while preserving the row", () => {
+      const root = mkdtempSync(join(tmpdir(), "gittensory-miner-portfolio-v3-"));
+      roots.push(root);
+      const dbPath = join(root, "legacy-v3.sqlite3");
+      const legacy = new DatabaseSync(dbPath);
+      legacy.exec(`
+        CREATE TABLE miner_portfolio_queue (
+          api_base_url TEXT NOT NULL,
+          repo_full_name TEXT NOT NULL,
+          identifier TEXT NOT NULL,
+          priority REAL NOT NULL DEFAULT 0,
+          status TEXT NOT NULL DEFAULT 'queued' CHECK (status IN ('queued', 'in_progress', 'done')),
+          enqueued_at TEXT NOT NULL,
+          leased_at TEXT,
+          PRIMARY KEY (api_base_url, repo_full_name, identifier)
+        )
+      `);
+      legacy.exec("PRAGMA user_version = 3");
+      legacy.exec(
+        "INSERT INTO miner_portfolio_queue (api_base_url, repo_full_name, identifier, priority, status, enqueued_at, leased_at) VALUES ('https://api.github.com', 'acme/widgets', 'issue:5', 3, 'queued', '2026-01-01T00:00:00.000Z', NULL)",
+      );
+      legacy.close();
+
+      const store = initPortfolioQueueStore(dbPath);
+      stores.push(store);
+      expect(store.readConvergenceInput("acme/widgets", "issue:5")).toEqual(ZERO);
+      expect(store.listQueue("acme/widgets")).toHaveLength(1);
+    });
+
+    it("the v4 migration is idempotent when a v3 file already carries the counter columns (no reset, no crash)", () => {
+      const root = mkdtempSync(join(tmpdir(), "gittensory-miner-portfolio-v3-cols-"));
+      roots.push(root);
+      const dbPath = join(root, "legacy-v3-with-cols.sqlite3");
+      const legacy = new DatabaseSync(dbPath);
+      legacy.exec(`
+        CREATE TABLE miner_portfolio_queue (
+          api_base_url TEXT NOT NULL,
+          repo_full_name TEXT NOT NULL,
+          identifier TEXT NOT NULL,
+          priority REAL NOT NULL DEFAULT 0,
+          status TEXT NOT NULL DEFAULT 'queued' CHECK (status IN ('queued', 'in_progress', 'done')),
+          enqueued_at TEXT NOT NULL,
+          leased_at TEXT,
+          attempts INTEGER NOT NULL DEFAULT 0,
+          consecutive_failures INTEGER NOT NULL DEFAULT 0,
+          reenqueues INTEGER NOT NULL DEFAULT 0,
+          PRIMARY KEY (api_base_url, repo_full_name, identifier)
+        )
+      `);
+      legacy.exec("PRAGMA user_version = 3");
+      legacy.exec(
+        "INSERT INTO miner_portfolio_queue (api_base_url, repo_full_name, identifier, priority, status, enqueued_at, attempts, consecutive_failures, reenqueues) VALUES ('https://api.github.com', 'acme/widgets', 'issue:5', 3, 'queued', '2026-01-01T00:00:00.000Z', 2, 1, 1)",
+      );
+      legacy.close();
+
+      let opened: ReturnType<typeof initPortfolioQueueStore> | undefined;
+      expect(() => {
+        opened = initPortfolioQueueStore(dbPath);
+      }).not.toThrow();
+      const store = opened!;
+      stores.push(store);
+      // The pre-existing counter values survived — the additive ALTERs were skipped, not re-run to reset them.
+      expect(store.readConvergenceInput("acme/widgets", "issue:5")).toEqual({ attempts: 2, consecutiveFailures: 1, reenqueues: 1, reachedDone: false });
     });
   });
 });


### PR DESCRIPTION
Closes #5654

## Summary
`buildAttemptGovernorContext` hardcoded a first-attempt-shaped `convergenceInput`
(`{ attempts: 0, consecutiveFailures: 0, reenqueues: 0, reachedDone: false }`), so the
fully-built `non-convergence` detector never received real data and could never flag a
stuck item. `non-convergence.ts`'s own header names the portfolio-queue table as the home
for these counts once it "grows attempt-history columns" — this PR grows them.

- **Schema (v3 → v4):** additive `attempts` / `consecutive_failures` / `reenqueues` columns
  on `miner_portfolio_queue`, via the store's existing `applySchemaMigrations` convention.
  Defensive per-column `table_info` guard (same posture as the `leased_at` migration), so a
  pre-existing v3 file backfills every row to 0 without a rebuild.
- **Counters:**
  - each claim (`dequeueNext` + `batchClaim`) → `attempts + 1`
  - each `in_progress → queued` transition (`markFailed`, `reclaimStuckItem`) → `reenqueues + 1`
    and `consecutive_failures + 1`
  - `markDone` → resets `consecutive_failures` to 0 (progress), keeps attempts/reenqueues
  - `requeueItem` (done → queued) leaves counters untouched
- **Read:** `store.readConvergenceInput(repoFullName, identifier, apiBaseUrl?)` returns the
  engine's `PortfolioConvergenceInput`; `reachedDone` = `status === 'done'` (per the issue).
  A never-queued item reads the honest zero literal.
- **Wiring:** `buildAttemptGovernorContext` gains an optional `convergenceInput` param
  (threaded like `repoPaused`); `attempt-cli.js` reads it via the new module-level
  `readConvergenceInputForIssue(repoFullName, issueNumber)` (keyed by the `issue:<n>`
  identifier convention) and passes it in. Injectable so unit tests stay hermetic.

Out of scope (unchanged, per the issue): detector thresholds and reputation-history logic.

## Honest boundaries (not fabricated)
- Omitting `convergenceInput`, or an issue this miner never queued, still falls back to the
  zero literal — an under-estimate that fails toward *letting* an attempt through, never a
  fabricated "clean" history.
- `readConvergenceInputForIssue` defaults `apiBaseUrl` to github.com (the single-forge
  default); a non-github forge not present in the store reads the same safe zero literal.

## Validation (run from repo root)
- `npx vitest run test/unit/miner-portfolio-queue.test.ts test/unit/miner-attempt-input-builder.test.ts test/unit/miner-attempt-cli.test.ts`
- `npm run typecheck`
- `npm run test:coverage` (patch coverage ≥ 99% on the changed lines)

## Tests added
- portfolio-queue: attempt counting (dequeue + batchClaim), markFailed/reclaim streak+reenqueue,
  markDone streak reset, requeue no-op, zero-literal for unknown item, v3→v4 backfill migration,
  idempotent v4 when columns pre-exist, and a **regression** proving a real claim/fail lifecycle
  drives `classifyPortfolioConvergence` to `non_convergent`.
- input-builder: real `convergenceInput` threads through; fallback literal when omitted.
- attempt-cli: real read threaded into `governor.convergenceInput`; real default-store fallback.