### PR TITLE
feat(ui): responsive tables + accessibility pass on the maintainer/owner panels

### DIFF
--- a/apps/gittensory-ui/src/components/site/app-panels/activation-preview.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/activation-preview.tsx
@@ -250,14 +250,23 @@ function ActivationPreviewBody({
       ) : null}
 
       {preview.samples.length > 0 ? (
-        <div className="overflow-hidden rounded-token border-hairline">
-          <table className="w-full text-left text-token-xs">
+        <div className="overflow-x-auto rounded-token border-hairline">
+          <table className="w-full min-w-[520px] text-left text-token-xs">
+            <caption className="sr-only">Activation preview samples</caption>
             <thead className="border-b-hairline font-mono uppercase tracking-wider text-muted-foreground">
               <tr>
-                <th className="px-3 py-2 font-normal">PR</th>
-                <th className="px-3 py-2 font-normal">Title</th>
-                <th className="px-3 py-2 font-normal">Severity</th>
-                <th className="px-3 py-2 font-normal">Findings</th>
+                <th scope="col" className="px-3 py-2 font-normal">
+                  PR
+                </th>
+                <th scope="col" className="px-3 py-2 font-normal">
+                  Title
+                </th>
+                <th scope="col" className="px-3 py-2 font-normal">
+                  Severity
+                </th>
+                <th scope="col" className="px-3 py-2 font-normal">
+                  Findings
+                </th>
               </tr>
             </thead>
             <tbody>

--- a/apps/gittensory-ui/src/components/site/app-panels/contributor-quality-table.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/contributor-quality-table.tsx
@@ -18,7 +18,7 @@ export function ContributorQualityTable({
   return (
     <section className="rounded-token border-hairline bg-card p-5">
       <div className="flex items-center justify-between gap-3">
-        <h2 className="font-display text-token-lg font-semibold">
+        <h2 id="contributor-quality-heading" className="font-display text-token-lg font-semibold">
           Top contributors by quality band
         </h2>
         <BoundaryBadge boundary="public" />
@@ -31,12 +31,21 @@ export function ContributorQualityTable({
         />
       ) : (
         <div className="mt-4 overflow-x-auto">
-          <table className="w-full min-w-[420px] text-left text-token-sm">
+          <table
+            aria-labelledby="contributor-quality-heading"
+            className="w-full min-w-[420px] text-left text-token-sm"
+          >
             <thead>
               <tr className="border-b-hairline font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
-                <th className="py-2 pr-3 font-normal">Contributor</th>
-                <th className="py-2 pr-3 font-normal">Band</th>
-                <th className="py-2 font-normal">Open PRs</th>
+                <th scope="col" className="py-2 pr-3 font-normal">
+                  Contributor
+                </th>
+                <th scope="col" className="py-2 pr-3 font-normal">
+                  Band
+                </th>
+                <th scope="col" className="py-2 font-normal">
+                  Open PRs
+                </th>
               </tr>
             </thead>
             <tbody>

--- a/apps/gittensory-ui/src/components/site/app-panels/maintainer-panel.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/maintainer-panel.tsx
@@ -335,57 +335,81 @@ function MaintainerDashboardView({
 
           <section className="rounded-token border-hairline bg-card p-5">
             <div className="flex items-center justify-between">
-              <h2 className="font-display text-token-lg font-semibold">Reviewability queue</h2>
+              <h2
+                id="reviewability-queue-heading"
+                className="font-display text-token-lg font-semibold"
+              >
+                Reviewability queue
+              </h2>
               <span className="font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
                 private
               </span>
             </div>
-            <table className="mt-4 w-full text-left text-token-sm">
-              <thead>
-                <tr className="border-b-hairline font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
-                  <th className="py-2 pr-3 font-normal">PR</th>
-                  <th className="py-2 pr-3 font-normal">Title</th>
-                  <th className="py-2 pr-3 font-normal">Author</th>
-                  <th className="py-2 pr-3 font-normal">Bucket</th>
-                  <th className="py-2 pr-3 font-normal">Slop</th>
-                  <th className="py-2 font-normal">Reason</th>
-                </tr>
-              </thead>
-              <tbody>
-                {data.reviewability.map((row) => (
-                  <tr
-                    key={row.pr}
-                    className="border-b-hairline last:border-b-0 transition-colors hover:bg-muted/40"
-                  >
-                    <td className="py-2 pr-3 font-mono text-token-xs text-foreground/90">
-                      {row.pr}
-                    </td>
-                    <td className="py-2 pr-3">{row.title}</td>
-                    <td className="py-2 pr-3 text-token-xs text-muted-foreground">{row.author}</td>
-                    <td className="py-2 pr-3">
-                      <StatusPill status={BUCKET_TONE[row.bucket] ?? "info"}>
-                        {row.bucket}
-                      </StatusPill>
-                    </td>
-                    <td className="py-2 pr-3">
-                      {row.slop ? (
-                        <StatusPill status={SLOP_BAND_TONE[row.slop.band] ?? "info"}>
-                          {row.slop.band} {row.slop.risk}
-                        </StatusPill>
-                      ) : (
-                        <span
-                          className="text-token-xs text-muted-foreground"
-                          title="Slop detection is off for this repo, or this PR has not been assessed yet."
-                        >
-                          —
-                        </span>
-                      )}
-                    </td>
-                    <td className="py-2 text-token-xs text-muted-foreground">{row.reason}</td>
+            <div className="mt-4 overflow-x-auto">
+              <table
+                aria-labelledby="reviewability-queue-heading"
+                className="w-full min-w-[640px] text-left text-token-sm"
+              >
+                <thead>
+                  <tr className="border-b-hairline font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
+                    <th scope="col" className="py-2 pr-3 font-normal">
+                      PR
+                    </th>
+                    <th scope="col" className="py-2 pr-3 font-normal">
+                      Title
+                    </th>
+                    <th scope="col" className="py-2 pr-3 font-normal">
+                      Author
+                    </th>
+                    <th scope="col" className="py-2 pr-3 font-normal">
+                      Bucket
+                    </th>
+                    <th scope="col" className="py-2 pr-3 font-normal">
+                      Slop
+                    </th>
+                    <th scope="col" className="py-2 font-normal">
+                      Reason
+                    </th>
                   </tr>
-                ))}
-              </tbody>
-            </table>
+                </thead>
+                <tbody>
+                  {data.reviewability.map((row) => (
+                    <tr
+                      key={row.pr}
+                      className="border-b-hairline last:border-b-0 transition-colors hover:bg-muted/40"
+                    >
+                      <td className="py-2 pr-3 font-mono text-token-xs text-foreground/90">
+                        {row.pr}
+                      </td>
+                      <td className="py-2 pr-3">{row.title}</td>
+                      <td className="py-2 pr-3 text-token-xs text-muted-foreground">
+                        {row.author}
+                      </td>
+                      <td className="py-2 pr-3">
+                        <StatusPill status={BUCKET_TONE[row.bucket] ?? "info"}>
+                          {row.bucket}
+                        </StatusPill>
+                      </td>
+                      <td className="py-2 pr-3">
+                        {row.slop ? (
+                          <StatusPill status={SLOP_BAND_TONE[row.slop.band] ?? "info"}>
+                            {row.slop.band} {row.slop.risk}
+                          </StatusPill>
+                        ) : (
+                          <span
+                            className="text-token-xs text-muted-foreground"
+                            title="Slop detection is off for this repo, or this PR has not been assessed yet."
+                          >
+                            —
+                          </span>
+                        )}
+                      </td>
+                      <td className="py-2 text-token-xs text-muted-foreground">{row.reason}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
           </section>
 
           <GateOutcomeCard breakdown={data.qualityDashboard.gateOutcomeBreakdown} />
@@ -716,13 +740,20 @@ export function PreviewResult({
       )}
 
       {preview.installation?.permissionRemediation.length ? (
-        <div className="overflow-hidden rounded-token border-hairline">
-          <table className="w-full text-left text-token-xs">
+        <div className="overflow-x-auto rounded-token border-hairline">
+          <table className="w-full min-w-[420px] text-left text-token-xs">
+            <caption className="sr-only">Permission remediation</caption>
             <thead className="border-b-hairline font-mono uppercase tracking-wider text-muted-foreground">
               <tr>
-                <th className="px-3 py-2 font-normal">Permission</th>
-                <th className="px-3 py-2 font-normal">Current</th>
-                <th className="px-3 py-2 font-normal">Required</th>
+                <th scope="col" className="px-3 py-2 font-normal">
+                  Permission
+                </th>
+                <th scope="col" className="px-3 py-2 font-normal">
+                  Current
+                </th>
+                <th scope="col" className="px-3 py-2 font-normal">
+                  Required
+                </th>
               </tr>
             </thead>
             <tbody>

--- a/apps/gittensory-ui/src/components/site/app-panels/owner-panel.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/owner-panel.tsx
@@ -82,10 +82,14 @@ export function OwnerPanel() {
             </p>
           </div>
           <div className="w-full sm:w-64">
-            <label className="font-mono text-token-2xs uppercase tracking-wider text-muted-foreground">
+            <label
+              htmlFor="owner-repo"
+              className="font-mono text-token-2xs uppercase tracking-wider text-muted-foreground"
+            >
               Repository
             </label>
             <Input
+              id="owner-repo"
               value={repo}
               onChange={(e) => setRepo(e.target.value)}
               className="mt-1 font-mono text-token-xs"


### PR DESCRIPTION
## What & why

Closes #794 for the maintainer/owner surfaces. The frontend audit flagged that the maintainer console's tables assume desktop width and lack table a11y semantics. This is a pure layout + semantics pass — **no behavior change**.

### Responsive (mobile)
The maintainer console's tables broke on narrow viewports:
- **Reviewability queue** (6 columns) had **no** horizontal-scroll container — `w-full` squished every column and wrapped titles into many lines.
- **Permission remediation** and **activation samples** tables used `overflow-hidden`, which **clips** the trailing columns off with no way to reach them.

Each table is now wrapped in `overflow-x-auto` with a readable `min-w-[…]`, so it scrolls horizontally on mobile instead of clipping/cramping — mirroring the `overflow-x-auto` pattern the `contributor-quality-table` in the same directory already uses.

### Accessibility
- `scope="col"` on every maintainer/owner table header cell.
- An accessible name for each table: `aria-labelledby` to the visible heading where one exists (Reviewability queue, Top contributors), an `sr-only <caption>` where none does (permission remediation, activation samples).
- The owner panel's **Repository** input is now associated with its `<label>` via `htmlFor`/`id` (it was a bare sibling label before).

The card/grid panels in this area already collapse responsively (`sm:grid-cols-*`) and already mark decorative icons `aria-hidden`, so they're left untouched.

## Visual evidence (mobile, 390px)

**Reviewability queue — before vs after**

| | Before | After |
|---|---|---|
| **Dark** | [<img src="https://raw.githubusercontent.com/jeffrey701/gittensory/pr-shots-794/shots/794/queue-before-dark.png" width="300" />](https://raw.githubusercontent.com/jeffrey701/gittensory/pr-shots-794/shots/794/queue-before-dark.png) | [<img src="https://raw.githubusercontent.com/jeffrey701/gittensory/pr-shots-794/shots/794/queue-after-dark.png" width="300" />](https://raw.githubusercontent.com/jeffrey701/gittensory/pr-shots-794/shots/794/queue-after-dark.png) |
| **Light** | [<img src="https://raw.githubusercontent.com/jeffrey701/gittensory/pr-shots-794/shots/794/queue-before-light.png" width="300" />](https://raw.githubusercontent.com/jeffrey701/gittensory/pr-shots-794/shots/794/queue-before-light.png) | [<img src="https://raw.githubusercontent.com/jeffrey701/gittensory/pr-shots-794/shots/794/queue-after-light.png" width="300" />](https://raw.githubusercontent.com/jeffrey701/gittensory/pr-shots-794/shots/794/queue-after-light.png) |

Before: `w-full` squeezes 6 columns into the viewport, wrapping each title to 5–6 lines. After: columns keep a readable width and the table scrolls horizontally within its container.

## Tests

`npm run ui:lint`, `ui:typecheck`, and the affected component suites (`maintainer-panel`, `maintainer-panel-slop`, `activation-preview`, `contributor-quality-table`) all pass; the full `@loopover/ui` unit suite stays green. `apps/**` is outside the coverage gate, but the changes are covered by the existing panel render tests (which assert the headings/rows these tables render).
