### PR TITLE
feat(services): wire computeFindingAcceptance into the operator dashboard

### DIFF
--- a/src/services/operator-dashboard.ts
+++ b/src/services/operator-dashboard.ts
@@ -29,7 +29,7 @@ import type {
 import { computeFleetAnalytics, type FleetAnalytics } from "../orb/analytics";
 import { computeAgentHealth, computeCalibration, type AgentHealth, type Calibration } from "../review/ops";
 import { computeGateEval, type GateEvalReport } from "../review/parity";
-import { computeCycleTimeAggregate, type CycleTimeAggregate } from "../review/stats";
+import { computeCycleTimeAggregate, computeFindingAcceptance, type CycleTimeAggregate } from "../review/stats";
 import { loadUpstreamStatus, type UpstreamStatus } from "../upstream/ruleset";
 import { nowIso } from "../utils/json";
 import { buildRecommendationQualityReport, type RecommendationQualityReport } from "./recommendation-quality-report";
@@ -46,6 +46,17 @@ export type OperatorDashboardNoiseMetric = {
   label: string;
   value: number;
   spark: number[];
+};
+
+/** Finding acceptance rate (#1967), reshaped for the dashboard's `AcceptanceRateCard` (see
+ *  apps/gittensory-ui/src/components/site/app-panels/acceptance-rate-card.tsx). The card's field names
+ *  (windowDays/accepted/total/rate) intentionally differ from `FindingAcceptanceAggregate`'s
+ *  (flagged/addressed/unaddressed/acceptanceRate) — this is the UI-facing shape, mapped in buildOperatorDashboardPayload. */
+export type OperatorDashboardFindingAcceptance = {
+  windowDays: number;
+  accepted: number;
+  total: number;
+  rate: number | null;
 };
 
 export type OperatorDashboardPayload = {
@@ -76,6 +87,9 @@ export type OperatorDashboardPayload = {
   // Slop-band calibration (#2196): org-wide per-band merge/close rates over resolved PRs carrying a persisted
   // slop band — is the deterministic slop score predictive? Bands only, never raw scores. Fails safe to empty.
   slopCalibration: SlopOutcomeCalibration;
+  // Finding acceptance rate (#1967): share of gate-flagged (hold|close) PRs later merged, reshaped to the
+  // AcceptanceRateCard's field names. Fails safe to an empty aggregate (rate: null) on any read error.
+  acceptance: OperatorDashboardFindingAcceptance;
 };
 
 const USAGE_WINDOW_DAYS = 7;
@@ -111,6 +125,7 @@ export async function buildOperatorDashboardPayload(
     calibration,
     agentHealth,
     slopCalibration,
+    findingAcceptance,
   ] = await Promise.all([
     listRepositories(env),
     listInstallations(env),
@@ -135,6 +150,9 @@ export async function buildOperatorDashboardPayload(
     computeCalibration(env, operatorAgentConfig(env)),
     computeAgentHealth(env, operatorAgentConfig(env)),
     buildOrgSlopCalibration(env),
+    // #1967: reuse the existing finding-acceptance aggregate (no new compute); fails safe to an empty
+    // aggregate on any read error.
+    computeFindingAcceptance(env, { days: GATE_ANALYTICS_WINDOW_DAYS, nowMs: Date.now() }),
   ]);
   const weeklyValueReport = buildWeeklyValueReport({
     generatedAt: nowIso(),
@@ -154,6 +172,13 @@ export async function buildOperatorDashboardPayload(
   });
   const installedRepos = repositories.filter((repo: RepositoryRecord) => repo.isInstalled).length;
   const registeredRepos = repositories.filter((repo: RepositoryRecord) => repo.isRegistered).length;
+  // #1967: map FindingAcceptanceAggregate's field names onto the AcceptanceRateCard's expected shape.
+  const acceptance: OperatorDashboardFindingAcceptance = {
+    windowDays: GATE_ANALYTICS_WINDOW_DAYS,
+    accepted: findingAcceptance.addressed,
+    total: findingAcceptance.flagged,
+    rate: findingAcceptance.acceptanceRate,
+  };
   return {
     generatedAt: nowIso(),
     metrics: [
@@ -239,6 +264,7 @@ export async function buildOperatorDashboardPayload(
     calibration,
     agentHealth,
     slopCalibration,
+    acceptance,
   };
 }
 

--- a/test/unit/operator-dashboard.test.ts
+++ b/test/unit/operator-dashboard.test.ts
@@ -61,6 +61,8 @@ describe("operator dashboard payload", () => {
       overallMergeRate: null,
       discriminates: null,
     });
+    // #1967/#5213: no review_audit signal → the acceptance card's zero-flagged (null-rate) branch.
+    expect(payload.acceptance).toEqual({ windowDays: 90, accepted: 0, total: 0, rate: null });
     // Empty fleet → instanceCount 0, null precision card ("—"), no-outlier delta.
     expect(payload.fleetMetrics.instanceCount).toBe(0);
     expect(payload.metrics).toEqual(
@@ -187,6 +189,21 @@ describe("operator dashboard payload", () => {
     const payload = await buildOperatorDashboardPayload(env);
     expect(payload.fleetMetrics.gamingPatternFlags.map((f) => f.instanceId)).toEqual(["farmer"]);
     expect(payload.metrics).toEqual(expect.arrayContaining([expect.objectContaining({ label: "Fleet gaming-pattern flags", value: "1", delta: "farmer" })]));
+  });
+
+  it("wires computeFindingAcceptance into the dashboard's acceptance card shape (#1967/#5213)", async () => {
+    const env = createTestEnv();
+    await env.DB.prepare(
+      `INSERT INTO review_audit (id, project, target_id, event_type, decision, source, created_at) VALUES
+        ('gd1', 'owner/repo', 'owner/repo#1', 'gate_decision', 'close', 'test', '2026-06-10T10:00:00Z'),
+        ('po1', 'owner/repo', 'owner/repo#1', 'pr_outcome', 'merged', 'test', '2026-06-10T12:00:00Z'),
+        ('gd2', 'owner/repo', 'owner/repo#2', 'gate_decision', 'hold', 'test', '2026-06-11T10:00:00Z'),
+        ('po2', 'owner/repo', 'owner/repo#2', 'pr_outcome', 'closed', 'test', '2026-06-11T12:00:00Z')`,
+    ).run();
+    const payload = await buildOperatorDashboardPayload(env);
+    // 2 flagged (hold|close), 1 addressed (merged) → mapped to the card's windowDays/accepted/total/rate shape,
+    // not the raw aggregate's flagged/addressed/unaddressed/acceptanceRate field names.
+    expect(payload.acceptance).toEqual({ windowDays: 90, accepted: 1, total: 2, rate: 0.5 });
   });
 
   it("clamps unsupported window values to the default 7d lookback (#2199)", () => {


### PR DESCRIPTION
## Summary

- `AcceptanceRateCard` on `/app/analytics` has shown its "not yet available" empty state since #2197 landed because nothing populated the `acceptance` field it expects. `computeFindingAcceptance` (#1967) was fully implemented but only wired into `computeStats`/`StatsPayload`, which powers a route (`handleStats`/`GET /stats/data`) that the dashboard doesn't read from.
- This PR wires `computeFindingAcceptance` into `buildOperatorDashboardPayload` (`src/services/operator-dashboard.ts`), the function that actually feeds the operator dashboard, following the exact `Promise.all` + fail-safe-aggregate pattern already used for `computeCycleTimeAggregate`/`computeGateEval` in that file.
- Maps `FindingAcceptanceAggregate`'s field names (`flagged`/`addressed`/`unaddressed`/`acceptanceRate`) onto the UI card's expected shape (`windowDays`/`accepted`/`total`/`rate`) via a new `OperatorDashboardFindingAcceptance` type, and adds `acceptance` to `OperatorDashboardPayload`.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

All of the above ran as part of the full `npm run test:ci` gate.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/CORS/session changes.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (`OperatorDashboardPayload`'s response is a loose/generic OpenAPI schema; regenerated `apps/gittensory-ui/public/openapi.json` and it is byte-identical.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (No UI files changed — `AcceptanceRateCard` already consumed this exact shape.)
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots — N/A, this PR touches no UI files; it only populates a backend field an already-shipped UI component already renders.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Backend-only wiring change. `AcceptanceRateCard` and its tests (`acceptance-rate-card.test.tsx`) required no changes, as anticipated in the issue.
- Regenerated `npm run ui:openapi`; output is byte-identical since `/v1/app/operator-dashboard`'s OpenAPI schema is a generic `additionalProperties` object, not a field-enumerated schema.

Closes #5213
