### PR TITLE
fix(queue): widen rag-index fan-out to match the regate-sweep candidate set

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -1159,24 +1159,25 @@ export async function runRagIndexJob(
   await indexRepo(env, project, repo);
 }
 
-// Enqueue one per-repo FULL re-index job for every registered + cutover-allowlisted repo (mirrors the
-// signal-snapshot / agent-regate fan-out: a delayed per-repo queue message so each repo's index runs as its own
-// bounded, retryable job rather than one giant tick). Only allowlisted repos are indexed — retrieval is gated the
-// same way, so indexing a non-converged repo would only burn the free-tier vector budget for no benefit.
+// Enqueue one per-repo FULL re-index job for every RAG-active repo, candidates drawn from ALL known repos plus the
+// cutover allowlist (mirrors the agent-regate fan-out: a delayed per-repo queue message so each repo's index runs
+// as its own bounded, retryable job rather than one giant tick). Only RAG-active repos are indexed — retrieval is
+// gated the same way, so indexing a non-converged repo would only burn the free-tier vector budget for no benefit.
 async function fanOutRagIndexJobs(
   env: Env,
   requestedBy: "schedule" | "api" | "webhook" | "test",
 ): Promise<void> {
-  // Candidate repos = the webhook-REGISTERED repos UNION the maintainer's CONFIGURED repos (LOOPOVER_REVIEW_REPOS).
-  // The union is the fix for the brokered self-host: a maintainer's repos are is_registered=0 (never went through the
-  // registration webhook), so a registered-only fan-out never indexed them — leaving reviews without codebase context.
-  // Deduped case-insensitively (a repo can be both registered AND configured). Each is then filtered by whether RAG is
-  // active for it (`features.rag` override → LOOPOVER_REVIEW_REPOS allowlist default), so nothing extra is indexed.
+  // Candidate repos = ALL known repos UNION the maintainer's CONFIGURED repos (LOOPOVER_REVIEW_REPOS) — mirrors
+  // fanOutAgentRegateSweepJobs's own candidate set exactly (#5024). Filtering to isRegistered-only left an
+  // installed-but-never-registered repo (the brokered self-host case: is_registered=0, never went through the
+  // registration webhook) out of the candidate pool entirely, so even a per-repo `features.rag` override could never
+  // resurface it — the regate sweep still reviewed that repo, just without codebase-context retrieval. Deduped
+  // case-insensitively (a repo can be both known AND configured). Each candidate is then filtered by whether RAG is
+  // active for it (`features.rag` override → LOOPOVER_REVIEW_REPOS allowlist default) just below, so this widens
+  // ELIGIBILITY only — the convergedFeatureActive gate below is what actually controls indexing spend.
   const repositoriesByKey = new Map((await listRepositories(env)).map((repo) => [repo.fullName.toLowerCase(), repo]));
   const byKey = new Map<string, { fullName: string; installationId?: number }>();
-  for (const repo of [...repositoriesByKey.values()].filter(
-    (r) => r.isRegistered,
-  ))
+  for (const repo of repositoriesByKey.values())
     byKey.set(repo.fullName.toLowerCase(), { fullName: repo.fullName, ...(typeof repo.installationId === "number" ? { installationId: repo.installationId } : {}) });
   for (const fullName of listConvergenceRepos(env)) {
     const repo = repositoriesByKey.get(fullName.toLowerCase());

--- a/test/unit/rag-index.test.ts
+++ b/test/unit/rag-index.test.ts
@@ -906,6 +906,27 @@ describe("rag-index-repo job dispatch (processors.ts wiring)", () => {
     expect(sent.filter((m) => (m as { repoFullName?: string }).repoFullName === "JSONbored/gittensory").length).toBe(1);
   });
 
+  it("cron fan-out includes an INSTALLED, non-registered, non-allowlisted repo once a features.rag override opts it in (#5024)", async () => {
+    const sent: import("../../src/types").JobMessage[] = [];
+    const env = createTestEnv({
+      LOOPOVER_REVIEW_RAG: "true",
+      LOOPOVER_REVIEW_REPOS: "", // empty allowlist — this repo must be discoverable without it
+      JOBS: { async send(message: import("../../src/types").JobMessage) { sent.push(message); } } as unknown as Queue,
+    });
+    // Installed via the GitHub App (installationId set ⇒ is_installed=1) but never went through the registration
+    // webhook — is_registered stays 0 (registerRepo() is deliberately NOT called), and it's not in the allowlist
+    // either. Before this fix, fanOutRagIndexJobs's candidate pool was isRegistered-repos UNION the static
+    // allowlist, so this repo was never even a candidate — the per-repo features.rag override below could never
+    // resurface it, unlike fanOutAgentRegateSweepJobs's candidate set (ALL listRepositories()), which the regate
+    // sweep already covers this exact repo through.
+    await upsertRepositoryFromGitHub(env, { name: "widgets", full_name: "owner/widgets", private: false, owner: { login: "owner" } }, 456);
+    await upsertRepoFocusManifest(env, "owner/widgets", { features: { rag: true } });
+
+    await processJob(env, { type: "rag-index-repo", requestedBy: "schedule" });
+
+    expect(sent).toEqual([{ type: "rag-index-repo", requestedBy: "schedule", repoFullName: "owner/widgets", installationId: 456 }]);
+  });
+
   it("FLAG-OFF cron fan-out is a no-op (no per-repo jobs enqueued, no fan-out audit)", async () => {
     const sent: import("../../src/types").JobMessage[] = [];
     const env = createTestEnv({


### PR DESCRIPTION
## Summary

- `fanOutRagIndexJobs` (the RAG-index cron fan-out) built its candidate pool from `isRegistered` repos UNION the `LOOPOVER_REVIEW_REPOS` allowlist, unlike `fanOutAgentRegateSweepJobs` (the regate sweep) which unions ALL `listRepositories()`. An installed-but-never-registered, non-allowlisted repo (the brokered self-host case: `is_registered=0`) was never even a fan-out candidate, so a per-repo `features.rag` manifest override could never resurface it — the repo still got reviewed via the regate sweep, just without codebase-context retrieval.
- Drop the `isRegistered` filter so the candidate set matches `fanOutAgentRegateSweepJobs` exactly: ALL known repos UNION the allowlist. The existing `convergedFeatureActive(env, repo, "rag")` filter is untouched, so this widens ELIGIBILITY only, not indexing spend.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session surface touched.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no public API/schema change.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI change.)
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. (N/A — backend-only change, no visible UI surface.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (N/A — no doc-visible behavior change.)

## UI Evidence

N/A — backend-only change to the RAG-index cron fan-out candidate resolution; no UI surface.

## Notes

- Regression test added in `test/unit/rag-index.test.ts`: an installed (`installationId` set), non-registered, non-allowlisted repo with a `features.rag: true` manifest override is now included in the cron fan-out, matching `fanOutAgentRegateSweepJobs`'s coverage. Verified the new test fails on the pre-fix code and passes after.

Closes #5024
