### PR TITLE
Wire selfPlagiarismCandidate/selfPlagiarismRecentSubmissions into Governor chokepoint (#5676)

### DIFF
--- a/packages/gittensory-engine/src/miner/iterate-loop.ts
+++ b/packages/gittensory-engine/src/miner/iterate-loop.ts
@@ -245,6 +245,7 @@ function buildHandoffPacket(input: IterateLoopInput, verdict: SelfReviewVerdict,
     diffSummary: driverResult.summary,
     selfReviewVerdict: verdict,
     attemptLogReference: input.attemptId,
+    changedFiles: driverResult.changedFiles.map((path) => ({ path })),
   };
 }
 

--- a/packages/gittensory-engine/src/miner/iterate-policy.ts
+++ b/packages/gittensory-engine/src/miner/iterate-policy.ts
@@ -20,7 +20,7 @@
 // once `.gittensory-miner.yml` defines autonomy fields -- that wiring is explicitly left to a later phase; this
 // module's `decideNextAction` is autonomy-level-agnostic today.
 
-import type { SelfReviewVerdict } from "./self-review-adapter.js";
+import type { SelfReviewChangedFile, SelfReviewVerdict } from "./self-review-adapter.js";
 
 /** The three outcomes `decideNextAction` may reach. */
 export type IterateLoopAction = "continue" | "handoff" | "abandon";
@@ -94,6 +94,10 @@ export type HandoffPacket = {
   /** Reference into the attempt-log primitive (`packages/gittensory-engine/src/miner/attempt-log.ts`) for this
    *  attempt's full decision trail. */
   attemptLogReference: string;
+  /** Real changed-file paths from the passing iteration's driver result -- the honest fingerprint source for
+   *  self-plagiarism (#5676) and post-submission own-submission history (#5655). Same shape as
+   *  `AttemptDiffState.changedFiles` (self-review-adapter.ts). */
+  changedFiles: readonly SelfReviewChangedFile[];
 };
 
 export type IterateLoopDecision = {

--- a/packages/gittensory-engine/test/harness-submission-trigger.test.ts
+++ b/packages/gittensory-engine/test/harness-submission-trigger.test.ts
@@ -52,6 +52,7 @@ function handoffPacket(verdictOverrides: Partial<SelfReviewVerdict> = {}): Hando
     diffSummary: "added retry logic",
     selfReviewVerdict: selfReviewVerdict(verdictOverrides),
     attemptLogReference: "attempt-1",
+    changedFiles: [{ path: "src/upload.ts" }],
   };
 }
 

--- a/packages/gittensory-engine/test/iterate-loop.test.ts
+++ b/packages/gittensory-engine/test/iterate-loop.test.ts
@@ -150,6 +150,7 @@ test("handoff: a clean predicted-gate pass on the first iteration hands off, wit
   assert.equal(result.handoffPacket?.selfReviewVerdict.predictedGateVerdict.conclusion, "success");
   assert.equal(result.handoffPacket?.selfReviewVerdict.passesPredictedGate, true);
   assert.equal(result.handoffPacket?.attemptLogReference, "attempt-1");
+  assert.deepEqual(result.handoffPacket?.changedFiles, [{ path: "src/upload.ts" }]);
 
   assert.equal(events.filter((event) => event.eventType === "attempt_started").length, 1);
   assert.equal(events.filter((event) => event.eventType === "attempt_succeeded").length, 1);

--- a/packages/gittensory-miner/lib/attempt-cli.js
+++ b/packages/gittensory-miner/lib/attempt-cli.js
@@ -9,8 +9,10 @@
 // checkSubmissionFreshness cannot see (two miners submitting almost simultaneously).
 //
 // KNOWN, DOCUMENTED GAPS (not fabricated -- see attempt-input-builder.js's own header for the full list):
-// governor.reputationHistory/selfPlagiarismCandidate/selfPlagiarismRecentSubmissions are omitted (chokepoint.ts's
-// own design treats that as "skip that stage entirely"). governor.convergenceInput is now a real per-issue
+// governor.reputationHistory is omitted (chokepoint.ts's own design treats that as "skip that stage entirely").
+// governor.selfPlagiarismCandidate/selfPlagiarismRecentSubmissions are also omitted here -- attempt-runner.js
+// late-augments both from the real handoff packet + governor-state.js immediately before the chokepoint call
+// (#5676). governor.convergenceInput is now a real per-issue
 // portfolio-queue.js read (#5654), not a placeholder.
 
 import { fingerprintFromChangedFiles, resolveCodingAgentModeFromConfig, resolveFirstConfiguredCodingAgentDriverName } from "@loopover/engine";

--- a/packages/gittensory-miner/lib/attempt-input-builder.js
+++ b/packages/gittensory-miner/lib/attempt-input-builder.js
@@ -6,9 +6,11 @@ import { isGlobalMinerKillSwitch, isGlobalMinerLiveModeOptIn } from "@loopover/e
 // same discipline as coding-task-spec.js's own composers.
 //
 // KNOWN, DOCUMENTED GAPS (not fabricated -- explicitly left as real, narrow follow-ups):
-//   - governor.reputationHistory/selfPlagiarismCandidate/selfPlagiarismRecentSubmissions are omitted, which
-//     chokepoint.ts's own design treats as "skip that stage entirely" -- an honest absence, not a fabricated
-//     "clean" verdict.
+//   - governor.reputationHistory is omitted, which chokepoint.ts's own design treats as "skip that stage
+//     entirely" -- an honest absence, not a fabricated "clean" verdict.
+//   - governor.selfPlagiarismCandidate/selfPlagiarismRecentSubmissions are deliberately omitted here -- they
+//     depend on the handoff packet's real changedFiles, which only exist after runIterateLoop inside
+//     attempt-runner.js. That module late-augments both fields immediately before the chokepoint call (#5676).
 //
 // governor.convergenceInput is now a REAL per-issue attempt-history query (#5654): the caller (attempt-cli.js)
 // reads it from portfolio-queue.js's own getAttemptHistory and passes it in here, this composer staying pure

--- a/packages/gittensory-miner/lib/attempt-runner.js
+++ b/packages/gittensory-miner/lib/attempt-runner.js
@@ -1,7 +1,7 @@
-import { buildOpenPrSpec } from "@loopover/engine";
-import { runIterateLoop } from "@loopover/engine";
+import { buildOpenPrSpec, fingerprintFromChangedFiles, runIterateLoop } from "@loopover/engine";
 import { checkSubmissionFreshness } from "./submission-freshness-check.js";
 import { evaluateGovernorChokepointGatePersisted } from "./governor-chokepoint-persisted.js";
+import { listRecentOwnSubmissions } from "./governor-state.js";
 import { prepareOpenPrSubmission } from "./harness-submission-trigger.js";
 
 // The real driving-loop entrypoint (#2337): the missing link between #2333's iterate-loop orchestrator and an
@@ -31,10 +31,11 @@ import { prepareOpenPrSubmission } from "./harness-submission-trigger.js";
 // evaluateGovernorChokepointGatePersisted -- callers no longer need to hand-thread honest empty/zero defaults
 // on every invocation; `capUsage` is loaded from that same store but its post-attempt save stays the caller's
 // job (see governor-chokepoint-persisted.js's own header for why: nothing computes "the next capUsage" from a
-// verdict, only the attempt's real outcome does). Reputation/self-plagiarism state also has real persistence
-// primitives (governor-state.js) but isn't auto-loaded here yet -- `input.governor.reputationHistory`/
-// `selfPlagiarismCandidate`/`selfPlagiarismRecentSubmissions` are still caller-supplied optional fields on
-// GovernorChokepointInput, same as before.
+// verdict, only the attempt's real outcome does). Reputation history still isn't auto-loaded here yet --
+// `input.governor.reputationHistory` remains a caller-supplied optional field on GovernorChokepointInput.
+// Self-plagiarism inputs ARE now late-augmented here immediately before the chokepoint call (#5676): the
+// prospective fingerprint comes from the real handoff packet's changedFiles (same as attempt-cli.js's
+// recordOwnSubmission write path) and recent history from governor-state.js's listRecentOwnSubmissions.
 
 /** True once the loop reaches handoff AND every downstream gate (freshness, submission, governor) allows. */
 export const ATTEMPT_OUTCOMES = Object.freeze(["abandon", "stale", "blocked", "governed", "submitted"]);
@@ -65,6 +66,31 @@ function assertInput(input) {
   if (!["clean", "low", "elevated", "high"].includes(input.slopThreshold)) throw new Error("invalid_slop_threshold");
   if (!["observe", "enforce"].includes(input.submissionMode)) throw new Error("invalid_submission_mode");
   if (!input.governor || typeof input.governor !== "object") throw new Error("invalid_governor_context");
+}
+
+/**
+ * Late-augment the Governor chokepoint with real self-plagiarism inputs (#5676). The handoff packet's
+ * changedFiles are the only honest source for the prospective fingerprint -- same normalization as
+ * attempt-cli.js's post-submission recordOwnSubmission call. When there are no changed files, both fields
+ * stay omitted so chokepoint.ts's self-plagiarism stage is skipped (not fail-closed on an empty fingerprint).
+ *
+ * @param {import("@loopover/engine").HandoffPacket | undefined} handoffPacket
+ * @param {string} repoFullName
+ * @param {number} nowMs
+ * @param {typeof listRecentOwnSubmissions} listRecentSubmissions
+ */
+function buildSelfPlagiarismChokepointFields(handoffPacket, repoFullName, nowMs, listRecentSubmissions) {
+  const changedFiles = handoffPacket?.changedFiles?.map((file) => file.path) ?? [];
+  const fingerprint = fingerprintFromChangedFiles(changedFiles);
+  if (!fingerprint) return {};
+  return {
+    selfPlagiarismCandidate: {
+      repoFullName,
+      fingerprint,
+      submittedAt: new Date(nowMs).toISOString(),
+    },
+    selfPlagiarismRecentSubmissions: listRecentSubmissions({ repoFullName }),
+  };
 }
 
 /**
@@ -141,6 +167,14 @@ export async function runMinerAttempt(input, deps) {
     return { outcome: "blocked", decision: submission.decision, loopResult };
   }
 
+  const listRecentSubmissions = deps.governorState?.listRecentOwnSubmissions ?? listRecentOwnSubmissions;
+  const selfPlagiarismFields = buildSelfPlagiarismChokepointFields(
+    handoffPacket,
+    input.loopInput.repoFullName,
+    deps.nowMs,
+    listRecentSubmissions,
+  );
+
   const governed = evaluateGovernorChokepointGatePersisted(
     {
       actionClass: "open_pr",
@@ -148,6 +182,7 @@ export async function runMinerAttempt(input, deps) {
       nowMs: deps.nowMs,
       wouldBeAction: submission.openPrInput,
       ...input.governor,
+      ...selfPlagiarismFields,
     },
     {
       ...(deps.governorLedgerAppend ? { append: deps.governorLedgerAppend } : {}),

--- a/test/unit/miner-attempt-runner.test.ts
+++ b/test/unit/miner-attempt-runner.test.ts
@@ -293,6 +293,67 @@ describe("runMinerAttempt (#2337) — the real create->review->gate->submit pipe
     vi.unstubAllEnvs();
   });
 
+  it("REGRESSION (#5676): a near-duplicate submission (same changed-files fingerprint as a prior own submission) is throttled at the Governor chokepoint", async () => {
+    const deps = baseDeps({ nowMs: 20_000 });
+    deps.governorState.recordOwnSubmission({
+      repoFullName: "acme/widgets",
+      fingerprint: "src/a.ts,src/b.ts",
+      submittedAt: new Date(10_000).toISOString(),
+      pullRequestNumber: 41,
+      issueNumber: 6,
+    });
+
+    const result = await runMinerAttempt(
+      baseAttemptInput({
+        loopInput: passingLoopInput({ attemptId: "attempt-dup" }),
+      }),
+      {
+        ...deps,
+        driver: driverReturning(okDriverResult(["src/b.ts", "src/a.ts"])),
+      },
+    );
+
+    expect(result.outcome).toBe("governed");
+    if (result.outcome !== "governed") throw new Error("expected governed");
+    expect(result.decision.stage).toBe("self_plagiarism");
+    expect(result.decision.allowed).toBe(false);
+  });
+
+  it("REGRESSION (#5676): a genuinely distinct submission passes self-plagiarism and reaches submitted", async () => {
+    const deps = baseDeps({ nowMs: 20_000 });
+    deps.governorState.recordOwnSubmission({
+      repoFullName: "acme/widgets",
+      fingerprint: "src/a.ts,src/b.ts",
+      submittedAt: new Date(10_000).toISOString(),
+      pullRequestNumber: 41,
+      issueNumber: 6,
+    });
+
+    const result = await runMinerAttempt(
+      baseAttemptInput({
+        loopInput: passingLoopInput({ attemptId: "attempt-distinct" }),
+      }),
+      {
+        ...deps,
+        driver: driverReturning(okDriverResult(["src/x.ts", "src/y.ts"])),
+      },
+    );
+
+    expect(result.outcome).toBe("submitted");
+    if (result.outcome !== "submitted") throw new Error("expected submitted");
+  });
+
+  it("REGRESSION (#5676): an empty changed-files set omits selfPlagiarismCandidate so the stage is skipped, not fail-closed", async () => {
+    const deps = baseDeps();
+    const result = await runMinerAttempt(baseAttemptInput(), {
+      ...deps,
+      driver: driverReturning(okDriverResult([])),
+    });
+
+    expect(result.outcome).toBe("submitted");
+    if (result.outcome !== "submitted") throw new Error("expected submitted");
+  });
+
   it("REGRESSION (#5134/#5203): a rate limit consumed by one runMinerAttempt call is honored by the next, via the shared governor-state store -- this is what the missing wiring bug looked like", async () => {
     const deps = baseDeps();
     const policies = {


### PR DESCRIPTION
## Summary
- Late-augment `attempt-runner.js` with `selfPlagiarismCandidate` (`fingerprintFromChangedFiles` over the handoff packet) and `selfPlagiarismRecentSubmissions` (`listRecentOwnSubmissions`) immediately before `evaluateGovernorChokepointGatePersisted`
- Thread `changedFiles` through `HandoffPacket` so the chokepoint and `recordOwnSubmission` share the same honest diff source (the prior write path in `attempt-cli.js` was reading a field that did not exist yet)
- Regression tests: near-duplicate throttled, distinct allowed, empty changed-files skips the stage

Closes #5676

## Test plan
- [x] `npm test -- test/unit/miner-attempt-runner.test.ts` (18/18 pass)
- [x] `npm run typecheck`
- [ ] CI green (validate, validate-code, codecov/patch >= 99%)

Made with [Cursor](https://cursor.com)