### PR TITLE
fix(queue): complete #5021's cron-path fix -- the fan-out dispatcher itself was still isRegistered-gated

### DIFF
--- a/src/queue/job-dispatch.ts
+++ b/src/queue/job-dispatch.ts
@@ -75,8 +75,13 @@ export async function processJob(env: Env, message: JobMessage): Promise<void> {
       return;
     case "backfill-registered-repos":
       if (!message.repoFullName && message.requestedBy !== "test") {
+        // #5021 retargeted the two downstream entry points (backfillRegisteredRepositories,
+        // enqueueRepositoryOpenDataBackfill) from isRegistered to isInstalled, but this cron-scheduled
+        // fan-out is the actual candidate-selection step for the periodic sweep, and was left on
+        // isRegistered -- an installed-but-not-subnet-registered repo never got a per-repo job dispatched
+        // for it in the first place, so #5021's fix never took effect on the real 30-min cron path.
         const repositories = (await listRepositories(env)).filter(
-          (repo) => repo.isRegistered,
+          (repo) => repo.isInstalled,
         );
         if (repositories.length > 0) {
           const delayStepSeconds =

--- a/test/unit/queue-2.test.ts
+++ b/test/unit/queue-2.test.ts
@@ -3131,11 +3131,15 @@ describe("queue processors", () => {
           "we-promise/sure": { emission_share: 0.02, issue_discovery_share: 0, label_multipliers: {}, trusted_label_pipeline: false },
         },
         { kind: "raw-github", url: "fixture://registry" },
-        "2026-05-25T00:00:00.000Z",
+        "2026-05-23T00:00:00.000Z",
       ),
     );
+    // The cron fan-out now gates on isInstalled, not isRegistered.
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: true, owner: { login: "JSONbored" } }, 9408);
+    await upsertRepositoryFromGitHub(env, { name: "sure", full_name: "we-promise/sure", private: true, owner: { login: "we-promise" } }, 9409);
     vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
       const url = input.toString();
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
       if (url === "https://api.github.com/graphql") {
         return Response.json({
           data: {

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -678,9 +678,12 @@ describe("queue processors", () => {
           "we-promise/sure": { emission_share: 0.02, issue_discovery_share: 0, label_multipliers: {}, trusted_label_pipeline: false },
         },
         { kind: "raw-github", url: "fixture://registry" },
-        "2026-05-25T00:00:00.000Z",
+        "2026-05-23T00:00:00.000Z",
       ),
     );
+    // The cron fan-out now gates on isInstalled, not isRegistered (completes #5021's real cron-path fix).
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: true, owner: { login: "JSONbored" } }, 9405);
+    await upsertRepositoryFromGitHub(env, { name: "sure", full_name: "we-promise/sure", private: true, owner: { login: "we-promise" } }, 9406);
 
     await processJob(env, { type: "backfill-registered-repos", requestedBy: "api", force: true, mode: "full" });
 
@@ -689,6 +692,30 @@ describe("queue processors", () => {
       { type: "backfill-registered-repos", requestedBy: "api", repoFullName: "we-promise/sure", force: true, mode: "full" },
     ]);
     expect(await listRepoSyncStates(env)).toEqual([]);
+  });
+
+  it("#cron-backfill-dispatch-isinstalled: cron fan-out includes an installed-but-not-registered repo and excludes a registered-but-not-installed one", async () => {
+    const sent: import("../../src/types").JobMessage[] = [];
+    const env = createTestEnv({
+      JOBS: {
+        async send(message: import("../../src/types").JobMessage) {
+          sent.push(message);
+        },
+      } as unknown as Queue,
+    });
+    await persistRegistrySnapshot(
+      env,
+      normalizeRegistryPayload(
+        { "acme/registered-only": { emission_share: 0.01, issue_discovery_share: 0, label_multipliers: {}, trusted_label_pipeline: false } },
+        { kind: "raw-github", url: "fixture://registry" },
+        "2026-05-23T00:00:00.000Z",
+      ),
+    );
+    await upsertRepositoryFromGitHub(env, { name: "installed-only", full_name: "acme/installed-only", private: false, owner: { login: "acme" } }, 9407);
+
+    await processJob(env, { type: "backfill-registered-repos", requestedBy: "api" });
+
+    expect(sent).toEqual([expect.objectContaining({ type: "backfill-registered-repos", repoFullName: "acme/installed-only" })]);
   });
 
   it("falls back to inline all-repo backfill when no registered repositories exist", async () => {


### PR DESCRIPTION
## Summary
- #5021 retargeted the two downstream entry points (`backfillRegisteredRepositories`, `enqueueRepositoryOpenDataBackfill`) from `isRegistered` to `isInstalled`, but never touched the actual candidate-selection step for the periodic (30-min) cron sweep.
- `processJob`'s `"backfill-registered-repos"` no-`repoFullName` branch in `src/queue/job-dispatch.ts` still filtered `listRepositories()` on `isRegistered` before ever dispatching a per-repo job.
- Net effect: an installed-but-not-subnet-registered repo never got a per-repo backfill job enqueued for it in the first place — #5021's fix never actually took effect on the real cron path, only on direct/API-triggered single-repo calls.
- Found via a full-codebase audit of remaining `isRegistered` call sites run after #5021 merged, specifically to check whether anything else needed the same treatment.

## Test plan
- [x] Regression test: cron fan-out (no `repoFullName`) includes an installed-but-not-registered repo and excludes a registered-but-not-installed one
- [x] `npm run test:ci` — full local gate, clean (run twice for stability; one unrelated `selfhost-ai.test.ts` subprocess-timing flake on the first run, confirmed passing 165/165 in isolation and on the clean second run)

Part of #5016