### PR TITLE
fix(queue): migrate data-fidelity repair from isRegistered to isInstalled

### DIFF
--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -4364,7 +4364,10 @@ export async function repairDataFidelity(
       segmentsByRepo.set(segment.repoFullName, complete);
     }
   }
-  const registeredRepos = repositories.filter((repo) => repo.isRegistered);
+  // #5020: cache hygiene for cached labels/issues/PRs has nothing to do with subnet economics -- scope to
+  // repos this instance actually operates on (isInstalled), matching #5021's retarget of the underlying
+  // backfill job this function dispatches.
+  const registeredRepos = repositories.filter((repo) => repo.isInstalled);
   const freshnessSlo = buildFreshnessSloReport({
     repoCount: registeredRepos.length,
     segments,

--- a/test/unit/queue.test.ts
+++ b/test/unit/queue.test.ts
@@ -752,9 +752,12 @@ describe("queue processors", () => {
           "we-promise/sure": { emission_share: 0.02, issue_discovery_share: 0, label_multipliers: {}, trusted_label_pipeline: false },
         },
         { kind: "raw-github", url: "fixture://registry" },
-        "2026-05-25T00:00:00.000Z",
+        "2026-05-23T00:00:00.000Z",
       ),
     );
+    // repairDataFidelity now gates on isInstalled, not isRegistered (#5020).
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: true, owner: { login: "JSONbored" } }, 9410);
+    await upsertRepositoryFromGitHub(env, { name: "sure", full_name: "we-promise/sure", private: true, owner: { login: "we-promise" } }, 9411);
 
     await upsertRepoSyncSegment(env, completeSegment("JSONbored/gittensory", "labels"));
     await upsertRepoSyncSegment(env, completeSegment("JSONbored/gittensory", "open_issues"));
@@ -768,6 +771,35 @@ describe("queue processors", () => {
         expect.objectContaining({ type: "generate-signal-snapshots", repoFullName: "JSONbored/gittensory" }),
       ]),
     );
+  });
+
+  it("dispatches fidelity repair by isInstalled, not isRegistered (#5020 regression)", async () => {
+    const sent: import("../../src/types").JobMessage[] = [];
+    const env = createTestEnv({
+      JOBS: {
+        async send(message: import("../../src/types").JobMessage) {
+          sent.push(message);
+        },
+      } as unknown as Queue,
+    });
+    // Installed but not gittensor-subnet-registered: cache hygiene for cached labels/issues/PRs has
+    // nothing to do with subnet economics, so this repo MUST still be covered.
+    await upsertRepositoryFromGitHub(env, { name: "installed-not-registered", full_name: "acme/installed-not-registered", private: false, owner: { login: "acme" } }, 9415);
+    // Subnet-registered but not installed on this instance: this repo must NOT be covered.
+    await persistRegistrySnapshot(
+      env,
+      normalizeRegistryPayload(
+        { "acme/registered-not-installed": { emission_share: 0.01, issue_discovery_share: 0, label_multipliers: {}, trusted_label_pipeline: false } },
+        { kind: "raw-github", url: "fixture://registry" },
+        "2026-05-23T00:00:00.000Z",
+      ),
+    );
+
+    await processJob(env, { type: "repair-data-fidelity", requestedBy: "api" });
+
+    const repairedRepos = sent.map((message) => (message as { repoFullName?: string }).repoFullName);
+    expect(repairedRepos).toContain("acme/installed-not-registered");
+    expect(repairedRepos).not.toContain("acme/registered-not-installed");
   });
 
   it("marks fidelity repair completed when only signal refreshes are needed", async () => {
@@ -790,9 +822,12 @@ describe("queue processors", () => {
           "we-promise/sure": { emission_share: 0.02, issue_discovery_share: 0, label_multipliers: {}, trusted_label_pipeline: false },
         },
         { kind: "raw-github", url: "fixture://registry" },
-        "2026-05-25T00:00:00.000Z",
+        "2026-05-23T00:00:00.000Z",
       ),
     );
+    // repairDataFidelity now gates on isInstalled, not isRegistered (#5020).
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: true, owner: { login: "JSONbored" } }, 9412);
+    await upsertRepositoryFromGitHub(env, { name: "sure", full_name: "we-promise/sure", private: true, owner: { login: "we-promise" } }, 9413);
     for (const repoFullName of ["JSONbored/gittensory", "we-promise/sure"]) {
       await upsertRepoSyncSegment(env, completeSegment(repoFullName, "labels"));
       await upsertRepoSyncSegment(env, completeSegment(repoFullName, "open_issues"));
@@ -838,9 +873,11 @@ describe("queue processors", () => {
       normalizeRegistryPayload(
         { "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0, label_multipliers: {}, trusted_label_pipeline: false } },
         { kind: "raw-github", url: "fixture://registry" },
-        "2026-05-25T00:00:00.000Z",
+        "2026-05-23T00:00:00.000Z",
       ),
     );
+    // repairDataFidelity now gates on isInstalled, not isRegistered (#5020).
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: true, owner: { login: "JSONbored" } }, 9414);
     await upsertRepoSyncSegment(env, completeSegment("JSONbored/gittensory", "labels"));
     await upsertRepoSyncSegment(env, completeSegment("JSONbored/gittensory", "open_issues"));
     await upsertRepoSyncSegment(env, completeSegment("JSONbored/gittensory", "open_pull_requests"));


### PR DESCRIPTION
## Summary
- `repairDataFidelity` (src/queue/processors.ts) filtered `repositories.filter(isRegistered)` to decide which repos' cached labels/issues/PRs get freshness-checked and repaired.
- This is pure cache hygiene for any repo gittensory reviews — unrelated to gittensor-subnet economics — and it drives dispatch of the `backfill-registered-repos` job family, which #5021 already retargeted to `isInstalled`. Both should agree on the same scoping signal.

## Test plan
- [x] New regression test mirroring #5019/#5022's shape: an installed-not-registered repo is included in the repair dispatch, a registered-not-installed repo is excluded — verified the test actually fails without the fix
- [x] `npm run test:ci` — full local gate, clean (one unrelated `miner-repo-clone.test.ts` git-subprocess timing flake under parallel load, confirmed passing 11/11 in isolation)

Closes #5020