### PR TITLE
fix(signals): scope cross-repo PR pressure by isInstalled, not isRegistered

### DIFF
--- a/src/signals/local-branch.ts
+++ b/src/signals/local-branch.ts
@@ -619,10 +619,13 @@ function buildObservedPullRequestScenarios(args: {
   nowMs?: number | undefined;
 }): ObservedPullRequestScenarios {
   const repoByName = new Map((args.repositories ?? []).map((repo) => [repo.fullName.toLowerCase(), repo]));
-  const registeredRepos = new Set((args.repositories ?? []).filter((repo) => repo.isRegistered).map((repo) => repo.fullName.toLowerCase()));
+  // Cross-repo PR-pressure scoping is generic PR-hygiene, unrelated to gittensor-subnet membership: an
+  // installed-but-not-registered repo's own open PRs must not be silently excluded just because some
+  // unrelated repo elsewhere in the instance happens to be subnet-registered.
+  const installedRepos = new Set((args.repositories ?? []).filter((repo) => repo.isInstalled).map((repo) => repo.fullName.toLowerCase()));
   const scopedPullRequests = args.pullRequests.filter((pr) => {
     if (!sameLogin(pr.authorLogin, args.login)) return false;
-    if (registeredRepos.size > 0) return registeredRepos.has(pr.repoFullName.toLowerCase());
+    if (installedRepos.size > 0) return installedRepos.has(pr.repoFullName.toLowerCase());
     return sameRepo(pr.repoFullName, args.repoFullName);
   });
   let approvedOrMergeable = 0;

--- a/test/unit/local-branch.test.ts
+++ b/test/unit/local-branch.test.ts
@@ -556,6 +556,80 @@ describe("local branch analysis", () => {
     expect(JSON.stringify(analysis.prPacket)).not.toMatch(/reward|score|wallet|hotkey|farming|payout|ranking|trust score/i);
   });
 
+  it("#5016 audit: includes an installed-but-not-subnet-registered repo's PRs in cross-repo scoping", () => {
+    const installedNotRegistered: RepositoryRecord = { ...repo, fullName: "we-promise/sure", owner: "we-promise", name: "sure", isRegistered: false };
+    const analysis = buildLocalBranchAnalysis({
+      input: {
+        login: "oktofeesh1",
+        repoFullName: repo.fullName,
+        body: "Fixes #7",
+        changedFiles: [{ path: "src/cache.ts", additions: 12, deletions: 1, status: "modified" }],
+        validation: [{ command: "npm test -- cache", status: "passed" }],
+        localScorer: { mode: "external_command", sourceTokenScore: 42, totalTokenScore: 60, sourceLines: 42 },
+      },
+      repo,
+      repositories: [repo, installedNotRegistered],
+      issues: [{ repoFullName: repo.fullName, number: 7, title: "Cache edge", state: "open", labels: ["bug"], linkedPrs: [] }],
+      pullRequests: [],
+      contributorPullRequests: [
+        {
+          repoFullName: installedNotRegistered.fullName,
+          number: 2,
+          title: "Installed-but-unregistered branch",
+          state: "open",
+          authorLogin: "oktofeesh1",
+          authorAssociation: "CONTRIBUTOR",
+          reviewDecision: "APPROVED",
+          labels: [],
+          linkedIssues: [],
+        },
+      ],
+      profile,
+      outcomeHistory: { ...outcomeHistory, totals: { ...outcomeHistory.totals, openPullRequests: 1 } },
+      scoringSnapshot,
+      scoringProfile,
+    });
+
+    expect(analysis.observedPullRequestScenarios.approvedOrMergeable).toBe(1);
+  });
+
+  it("#5016 audit: excludes a subnet-registered-but-not-installed repo's PRs from cross-repo scoping", () => {
+    const registeredNotInstalled: RepositoryRecord = { ...repo, fullName: "acme/other", owner: "acme", name: "other", isInstalled: false };
+    const analysis = buildLocalBranchAnalysis({
+      input: {
+        login: "oktofeesh1",
+        repoFullName: repo.fullName,
+        body: "Fixes #7",
+        changedFiles: [{ path: "src/cache.ts", additions: 12, deletions: 1, status: "modified" }],
+        validation: [{ command: "npm test -- cache", status: "passed" }],
+        localScorer: { mode: "external_command", sourceTokenScore: 42, totalTokenScore: 60, sourceLines: 42 },
+      },
+      repo,
+      repositories: [repo, registeredNotInstalled],
+      issues: [{ repoFullName: repo.fullName, number: 7, title: "Cache edge", state: "open", labels: ["bug"], linkedPrs: [] }],
+      pullRequests: [],
+      contributorPullRequests: [
+        {
+          repoFullName: registeredNotInstalled.fullName,
+          number: 3,
+          title: "Registered-but-uninstalled branch",
+          state: "open",
+          authorLogin: "oktofeesh1",
+          authorAssociation: "CONTRIBUTOR",
+          reviewDecision: "APPROVED",
+          labels: [],
+          linkedIssues: [],
+        },
+      ],
+      profile,
+      outcomeHistory: { ...outcomeHistory, totals: { ...outcomeHistory.totals, openPullRequests: 1 } },
+      scoringSnapshot,
+      scoringProfile,
+    });
+
+    expect(analysis.observedPullRequestScenarios.approvedOrMergeable).toBe(0);
+  });
+
   it("falls back to same-repo observed PR scenarios when the registered repo list is unavailable", () => {
     const analysis = buildLocalBranchAnalysis({
       input: {


### PR DESCRIPTION
## Summary
- `buildObservedPullRequestScenarios` (`src/signals/local-branch.ts`) scoped a contributor's cross-repo open-PR pressure (approved/mergeable, stale, closed, draft, blocked, maintainer-lane counts feeding the local-branch scenario preview) to subnet-registered repos only.
- This is generic PR-hygiene scoping — no gittensor-subnet economics involved — so an installed-but-not-subnet-registered repo's own open PRs were silently excluded from a contributor's pressure model whenever they also touched an unrelated registered repo elsewhere on the instance, and a registered-but-not-installed repo's PRs were wrongly pulled into scope.
- Found via the epic #5016 `isRegistered`/`isInstalled` exhaustive audit, not one of the originally-tracked sub-issues.

## Test plan
- [x] Added `#5016 audit: includes an installed-but-not-subnet-registered repo's PRs in cross-repo scoping` (positive regression)
- [x] Added `#5016 audit: excludes a subnet-registered-but-not-installed repo's PRs from cross-repo scoping` (negative regression)
- [x] `test/unit/local-branch.test.ts` — 58/58 passed
- [x] Full local gate (`npm run test:ci` + `npm audit --audit-level=moderate`) green: 16032 passed, 0 failed

Advances #5016