### PR TITLE
feat(miner-hands): wire real self-plagiarism data into the Governor chokepoint

### DIFF
--- a/packages/gittensory-engine/src/miner/iterate-loop.ts
+++ b/packages/gittensory-engine/src/miner/iterate-loop.ts
@@ -245,6 +245,7 @@ function buildHandoffPacket(input: IterateLoopInput, verdict: SelfReviewVerdict,
     diffSummary: driverResult.summary,
     selfReviewVerdict: verdict,
     attemptLogReference: input.attemptId,
+    changedFiles: driverResult.changedFiles.map((path) => ({ path })),
   };
 }
 

--- a/packages/gittensory-engine/src/miner/iterate-policy.ts
+++ b/packages/gittensory-engine/src/miner/iterate-policy.ts
@@ -94,6 +94,10 @@ export type HandoffPacket = {
   /** Reference into the attempt-log primitive (`packages/gittensory-engine/src/miner/attempt-log.ts`) for this
    *  attempt's full decision trail. */
   attemptLogReference: string;
+  /** The passing attempt's changed-file paths, carried through so the submission layer can fingerprint the real
+   *  diff (own-submission recording + self-plagiarism throttle, #5655/#5676) without re-reading the worktree.
+   *  Optional so hand-built packets (e.g. harness fixtures) need not supply it. */
+  changedFiles?: readonly { path: string }[] | undefined;
 };
 
 export type IterateLoopDecision = {

--- a/packages/gittensory-miner/lib/attempt-runner.js
+++ b/packages/gittensory-miner/lib/attempt-runner.js
@@ -1,7 +1,8 @@
-import { buildOpenPrSpec } from "@loopover/engine";
+import { buildOpenPrSpec, fingerprintFromChangedFiles } from "@loopover/engine";
 import { runIterateLoop } from "@loopover/engine";
 import { checkSubmissionFreshness } from "./submission-freshness-check.js";
 import { evaluateGovernorChokepointGatePersisted } from "./governor-chokepoint-persisted.js";
+import { listRecentOwnSubmissions } from "./governor-state.js";
 import { prepareOpenPrSubmission } from "./harness-submission-trigger.js";
 
 // The real driving-loop entrypoint (#2337): the missing link between #2333's iterate-loop orchestrator and an
@@ -31,10 +32,12 @@ import { prepareOpenPrSubmission } from "./harness-submission-trigger.js";
 // evaluateGovernorChokepointGatePersisted -- callers no longer need to hand-thread honest empty/zero defaults
 // on every invocation; `capUsage` is loaded from that same store but its post-attempt save stays the caller's
 // job (see governor-chokepoint-persisted.js's own header for why: nothing computes "the next capUsage" from a
-// verdict, only the attempt's real outcome does). Reputation/self-plagiarism state also has real persistence
-// primitives (governor-state.js) but isn't auto-loaded here yet -- `input.governor.reputationHistory`/
-// `selfPlagiarismCandidate`/`selfPlagiarismRecentSubmissions` are still caller-supplied optional fields on
-// GovernorChokepointInput, same as before.
+// verdict, only the attempt's real outcome does). Self-plagiarism state is now wired here (#5676): the
+// prospective submission's real diff `selfPlagiarismCandidate` (fingerprintFromChangedFiles over the handoff
+// packet's changed files) and the miner's real `selfPlagiarismRecentSubmissions` (governor-state.js's
+// listRecentOwnSubmissions) are computed late -- right before the chokepoint call, after handoff, where the
+// changed files first exist -- and passed in, so chokepoint.ts's selfPlagiarismCheck finally runs on real data.
+// `input.governor.reputationHistory` remains a caller-supplied optional field, not auto-loaded here yet.
 
 /** True once the loop reaches handoff AND every downstream gate (freshness, submission, governor) allows. */
 export const ATTEMPT_OUTCOMES = Object.freeze(["abandon", "stale", "blocked", "governed", "submitted"]);
@@ -141,6 +144,31 @@ export async function runMinerAttempt(input, deps) {
     return { outcome: "blocked", decision: submission.decision, loopResult };
   }
 
+  // Late-augment the self-plagiarism inputs (#5676): the prospective submission's real diff fingerprint and the
+  // miner's real recent-submission history only exist HERE, after handoff -- attempt-cli.js's single early
+  // governor snapshot (buildAttemptGovernorContext) is built before any changed files exist, so it cannot carry
+  // them. This finally feeds chokepoint.ts's selfPlagiarismCheck, which was previously always skipped for lack of
+  // data. Read the history from the SAME governor-state store the chokepoint itself uses (deps.governorState when
+  // provided, else the persisted default via the module-level export). Fail open on a read failure so a
+  // history-store hiccup never blocks an otherwise-allowed real submission.
+  /* v8 ignore next -- buildHandoffPacket always populates changedFiles; the `?? []` only guards a hand-built packet */
+  const changedFilePaths = (handoffPacket.changedFiles ?? []).map((file) => file.path);
+  const selfPlagiarismCandidate = {
+    repoFullName: input.loopInput.repoFullName,
+    fingerprint: fingerprintFromChangedFiles(changedFilePaths),
+    // The prospective submission's own time is "now" -- selfPlagiarismCheck needs a real submittedAt on the
+    // candidate (it denies a candidate lacking one) and uses it for earliest-claimant election vs the priors.
+    submittedAt: new Date(deps.nowMs).toISOString(),
+  };
+  let selfPlagiarismRecentSubmissions;
+  try {
+    selfPlagiarismRecentSubmissions = deps.governorState
+      ? deps.governorState.listRecentOwnSubmissions({ repoFullName: input.loopInput.repoFullName })
+      : listRecentOwnSubmissions({ repoFullName: input.loopInput.repoFullName });
+  } catch {
+    selfPlagiarismRecentSubmissions = [];
+  }
+
   const governed = evaluateGovernorChokepointGatePersisted(
     {
       actionClass: "open_pr",
@@ -148,6 +176,8 @@ export async function runMinerAttempt(input, deps) {
       nowMs: deps.nowMs,
       wouldBeAction: submission.openPrInput,
       ...input.governor,
+      selfPlagiarismCandidate,
+      selfPlagiarismRecentSubmissions,
     },
     {
       ...(deps.governorLedgerAppend ? { append: deps.governorLedgerAppend } : {}),

--- a/test/unit/miner-attempt-runner.test.ts
+++ b/test/unit/miner-attempt-runner.test.ts
@@ -10,8 +10,18 @@ vi.mock("@loopover/engine", async () => {
 import { runMinerAttempt } from "../../packages/gittensory-miner/lib/attempt-runner.js";
 import { initEventLedger } from "../../packages/gittensory-miner/lib/event-ledger.js";
 import { initGovernorLedger } from "../../packages/gittensory-miner/lib/governor-ledger.js";
-import { openGovernorState } from "../../packages/gittensory-miner/lib/governor-state.js";
-import { parseFocusManifest, type CodingAgentDriver, type CodingAgentDriverResult } from "../../packages/gittensory-engine/src/index";
+import {
+  closeDefaultGovernorState,
+  listRecentOwnSubmissions,
+  openGovernorState,
+  recordOwnSubmission,
+} from "../../packages/gittensory-miner/lib/governor-state.js";
+import {
+  fingerprintFromChangedFiles,
+  parseFocusManifest,
+  type CodingAgentDriver,
+  type CodingAgentDriverResult,
+} from "../../packages/gittensory-engine/src/index";
 
 const roots: string[] = [];
 const closers: Array<{ close(): void }> = [];
@@ -44,6 +54,8 @@ function tempGovernorState() {
 
 afterEach(() => {
   for (const closer of closers.splice(0)) closer.close();
+  closeDefaultGovernorState();
+  vi.unstubAllEnvs();
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
 
@@ -345,5 +357,76 @@ describe("runMinerAttempt (#2337) — the real create->review->gate->submit pipe
     await expect(runMinerAttempt(input, { ...full, claimLedger: undefined } as never)).rejects.toThrow("invalid_claim_ledger");
     await expect(runMinerAttempt(input, { ...full, eventLedger: undefined } as never)).rejects.toThrow("invalid_event_ledger");
     await expect(runMinerAttempt(input, { ...full, nowMs: Number.NaN } as never)).rejects.toThrow("invalid_now_ms");
+  });
+});
+
+describe("runMinerAttempt — real self-plagiarism wiring into the chokepoint (#5676)", () => {
+  const FILES = ["src/upload.ts", "src/retry.ts"];
+  // The prospective submission's own time (candidate.submittedAt = new Date(nowMs)). Kept AFTER every prior below
+  // so the prior wins the earliest-near-duplicate election and the current candidate is the one throttled.
+  const NOW_MS = Date.parse("2026-07-14T00:00:00.000Z");
+
+  function stateWithPriorSubmission(fingerprintFiles: string[]) {
+    const state = tempGovernorState();
+    state.recordOwnSubmission({
+      repoFullName: "acme/widgets",
+      fingerprint: fingerprintFromChangedFiles(fingerprintFiles),
+      submittedAt: "2026-07-13T00:00:00.000Z", // earlier than NOW_MS → the prior is the earliest claimant
+      pullRequestNumber: 41,
+    });
+    return state;
+  }
+
+  it("REGRESSION: a near-duplicate of a prior own submission is throttled by the real chokepoint", async () => {
+    // Prior submission touched the exact same files → identical diff fingerprint → Jaccard similarity 1.0.
+    const governorState = stateWithPriorSubmission(FILES);
+    const deps = baseDeps({ governorState, driver: driverReturning(okDriverResult(FILES)), nowMs: NOW_MS });
+    const result = await runMinerAttempt(baseAttemptInput(), deps);
+    expect(result.outcome).toBe("governed");
+    if (result.outcome !== "governed") throw new Error("expected governed");
+    expect(result.decision.allowed).toBe(false);
+  });
+
+  it("a genuinely distinct submission is NOT throttled and submits normally", async () => {
+    // Prior submission touched unrelated files → disjoint token set → low similarity → allowed.
+    const governorState = stateWithPriorSubmission(["docs/CHANGELOG.md", "README.md"]);
+    const deps = baseDeps({ governorState, driver: driverReturning(okDriverResult(FILES)), nowMs: NOW_MS });
+    const result = await runMinerAttempt(baseAttemptInput(), deps);
+    expect(result.outcome).toBe("submitted");
+  });
+
+  it("an empty own-submission history never throttles (selfPlagiarismCheck no-ops on no priors)", async () => {
+    const result = await runMinerAttempt(baseAttemptInput(), baseDeps());
+    expect(result.outcome).toBe("submitted");
+  });
+
+  it("fails open: a history-store read failure never blocks an otherwise-allowed submission", async () => {
+    const state = tempGovernorState();
+    const throwingState = Object.create(state);
+    throwingState.listRecentOwnSubmissions = () => {
+      throw new Error("db locked");
+    };
+    const result = await runMinerAttempt(baseAttemptInput(), baseDeps({ governorState: throwingState }));
+    expect(result.outcome).toBe("submitted");
+  });
+
+  it("reads the real default governor-state store when no governorState dep is supplied (production path)", async () => {
+    // deps omit governorState, so BOTH the chokepoint's own default-store fallback AND this module's late
+    // augmentation read the same env-pointed store; a matching prior submission there throttles.
+    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-attempt-runner-default-gs-"));
+    roots.push(root);
+    vi.stubEnv("GITTENSORY_MINER_GOVERNOR_STATE_DB", join(root, "governor-state.sqlite3"));
+    recordOwnSubmission({
+      repoFullName: "acme/widgets",
+      fingerprint: fingerprintFromChangedFiles(FILES),
+      submittedAt: "2026-07-13T00:00:00.000Z",
+    });
+    expect(listRecentOwnSubmissions({ repoFullName: "acme/widgets" })).toHaveLength(1);
+    const { governorState: _omit, ...deps } = baseDeps({
+      driver: driverReturning(okDriverResult(FILES)),
+      nowMs: NOW_MS,
+    });
+    const result = await runMinerAttempt(baseAttemptInput(), deps as never);
+    expect(result.outcome).toBe("governed");
   });
 });


### PR DESCRIPTION
## What & why

Closes #5676.

`chokepoint.ts`'s `selfPlagiarismCheck` — a fully built, tested pure classifier comparing a prospective submission's diff fingerprint against the miner's own recent submissions via token-set Jaccard similarity — was **always skipped in production**, because `GovernorChokepointInput.selfPlagiarismCandidate` / `selfPlagiarismRecentSubmissions` were never supplied by any real caller (`attempt-runner.js`'s own header named this exact gap). This wires them, so one of the Governor's own documented defense layers finally runs on real data before Wave 5's paid rented-loop context.

## How

- **`attempt-runner.js`** — at the `open_pr` chokepoint call, **late-augment** the governor input (requirement 3): the prospective submission's real diff fingerprint (`fingerprintFromChangedFiles` over the handoff packet's changed files) becomes `selfPlagiarismCandidate`, and the miner's real `listRecentOwnSubmissions({ repoFullName })` (read from the **same** `governor-state.js` store the chokepoint itself uses) becomes `selfPlagiarismRecentSubmissions`. This must happen here, after handoff — `attempt-cli.js`'s single early governor snapshot (`buildAttemptGovernorContext`) is built before any changed files exist. **Fail-open:** a history-read failure degrades to `[]` so it never blocks an otherwise-allowed submission.
- **`iterate-loop.ts` / `iterate-policy.ts`** — the handoff packet now carries the passing attempt's changed files (`HandoffPacket.changedFiles`, populated by `buildHandoffPacket`). This is the field the fingerprinting has always read (`attempt-cli.js`'s own-submission recording, #5655); it did not previously exist on the packet, so that read silently yielded an empty set. Made **optional** so hand-built packets (harness fixtures) need not supply it.

## Acceptance criteria

- [x] A real submission's fingerprint and the miner's real recent-submission history both reach the chokepoint call
- [x] A near-duplicate submission (by real Jaccard similarity) is measurably throttled in a real chokepoint evaluation (regression test)
- [x] A genuinely distinct submission is not throttled
- [x] `self-plagiarism.ts`'s own threshold / election logic is untouched (out of scope)

## Tests

`test/unit/miner-attempt-runner.test.ts` (all pass; 100% of the changed lines/branches on `attempt-runner.js`): a near-duplicate of a prior own submission (identical fingerprint, candidate timestamped after the prior so the prior wins the earliest-claimant election) is **throttled** (`governed`, `allowed: false`); a genuinely distinct submission **submits**; an empty own-submission history never throttles; a history-store read failure **fails open**; and the production default-store path (no injected `governorState`) is exercised. `tsc --noEmit`, the `@loopover/engine` suite, and the existing attempt-cli / iterate-loop / harness suites stay green.
