### PR TITLE
fix(github): finish @gittensory -> @loopover cutover in gittensory-engine + regen openapi.json

### DIFF
--- a/apps/gittensory-ui/public/openapi.json
+++ b/apps/gittensory-ui/public/openapi.json
@@ -1,9 +1,9 @@
 {
   "openapi": "3.0.3",
   "info": {
-    "title": "Gittensory API",
+    "title": "LoopOver API",
     "version": "0.1.0",
-    "description": "Backend API for Gittensory advisory checks and Gittensor repository context."
+    "description": "Backend API for LoopOver advisory checks and Gittensor repository context."
   },
   "components": {
     "schemas": {
@@ -9160,15 +9160,15 @@
               },
               "chatQa": {
                 "type": "boolean",
-                "description": "Opt the `@gittensory chat <question>` grounded Q&A surface (#4595) into local Ollama inference. Ollama-first: unlike the four capabilities above, it declines instead of falling back to the frontier env.AI when env.AI_ADVISORY is unconfigured, unless `chatQaFrontierFallback` is also enabled. Co-requisite: set `commandRateLimitPolicy` to `hold` (it defaults to `off` fleet-wide) so the tighter `commandRateLimitAiMaxPerWindow` ceiling actually throttles this cost-bearing command."
+                "description": "Opt the `@loopover chat <question>` grounded Q&A surface (#4595) into local Ollama inference. Ollama-first: unlike the four capabilities above, it declines instead of falling back to the frontier env.AI when env.AI_ADVISORY is unconfigured, unless `chatQaFrontierFallback` is also enabled. Co-requisite: set `commandRateLimitPolicy` to `hold` (it defaults to `off` fleet-wide) so the tighter `commandRateLimitAiMaxPerWindow` ceiling actually throttles this cost-bearing command."
               },
               "chatQaFrontierFallback": {
                 "type": "boolean",
-                "description": "Opt-in only (#4595 follow-up): when true, `@gittensory chat` falls back to the shared frontier env.AI chain if env.AI_ADVISORY is unconfigured, instead of declining. Meaningless unless `chatQa` is also true. Default false -- a self-hoster without a local GPU may enable this to use their own frontier subscription/tokens for chat instead."
+                "description": "Opt-in only (#4595 follow-up): when true, `@loopover chat` falls back to the shared frontier env.AI chain if env.AI_ADVISORY is unconfigured, instead of declining. Meaningless unless `chatQa` is also true. Default false -- a self-hoster without a local GPU may enable this to use their own frontier subscription/tokens for chat instead."
               },
               "intentRouting": {
                 "type": "boolean",
-                "description": "Opt a closed-set intent-classification router (#4596) into unrecognized `@gittensory` mentions: maps a free-text question to the closest existing Q&A command (never an action command) instead of the plain did-you-mean hint. Ollama-only, same as chatQa. Co-requisite: set `commandRateLimitPolicy` to `hold`."
+                "description": "Opt a closed-set intent-classification router (#4596) into unrecognized `@loopover` mentions: maps a free-text question to the closest existing Q&A command (never an action command) instead of the plain did-you-mean hint. Ollama-only, same as chatQa. Co-requisite: set `commandRateLimitPolicy` to `hold`."
               }
             },
             "required": [
@@ -13889,7 +13889,7 @@
       "GittensoryBearer": {
         "type": "http",
         "scheme": "bearer",
-        "description": "Static API/MCP token, GitHub device-flow Gittensory session token, or extension-scoped Gittensory session token where supported. GitHub personal access tokens are not accepted."
+        "description": "Static API/MCP token, GitHub device-flow LoopOver session token, or extension-scoped LoopOver session token where supported. GitHub personal access tokens are not accepted."
       },
       "GittensorySessionCookie": {
         "type": "apiKey",
@@ -15153,7 +15153,7 @@
       "get": {
         "responses": {
           "200": {
-            "description": "Private self-dogfood registration pack for the Gittensory repo",
+            "description": "Private self-dogfood registration pack for the LoopOver repo",
             "content": {
               "application/json": {
                 "schema": {
@@ -15183,7 +15183,7 @@
       "get": {
         "responses": {
           "200": {
-            "description": "Private self-dogfood registration pack when repo matches configured Gittensory target",
+            "description": "Private self-dogfood registration pack when repo matches configured LoopOver target",
             "content": {
               "application/json": {
                 "schema": {
@@ -15333,7 +15333,7 @@
       "get": {
         "responses": {
           "200": {
-            "description": "Gittensory repository automation settings",
+            "description": "LoopOver repository automation settings",
             "content": {
               "application/json": {
                 "schema": {
@@ -16900,7 +16900,7 @@
               "text/markdown": {
                 "schema": {
                   "type": "string",
-                  "example": "# Weekly Gittensory value report\n\n## Adoption metrics\n- Active users: 4\n"
+                  "example": "# Weekly LoopOver value report\n\n## Adoption metrics\n- Active users: 4\n"
                 }
               }
             }
@@ -17010,7 +17010,7 @@
       "post": {
         "responses": {
           "200": {
-            "description": "Maintainer dry-run preview of a sanitized @gittensory command response (no GitHub mutation)",
+            "description": "Maintainer dry-run preview of a sanitized @loopover command response (no GitHub mutation)",
             "content": {
               "application/json": {
                 "schema": {

--- a/apps/gittensory-ui/src/components/site/app-panels/maintainer-settings.tsx
+++ b/apps/gittensory-ui/src/components/site/app-panels/maintainer-settings.tsx
@@ -389,8 +389,8 @@ export function MaintainerSettings({ reviewability }: { reviewability: Array<{ p
           <div>
             <h3 className={LABEL_CLASS}>Command authorization</h3>
             <p className="mt-1 text-token-2xs text-muted-foreground">
-              Default roles allowed to run any <code className="font-mono">@loopover</code>{" "}
-              command. Per-command overrides (edited via the focus manifest) are shown below.
+              Default roles allowed to run any <code className="font-mono">@loopover</code> command.
+              Per-command overrides (edited via the focus manifest) are shown below.
             </p>
             <div className="mt-2 flex flex-wrap gap-3">
               {COMMAND_ROLES.map(([role, roleLabel]) => (

--- a/apps/gittensory-ui/src/routes/app.runs.tsx
+++ b/apps/gittensory-ui/src/routes/app.runs.tsx
@@ -230,8 +230,8 @@ function AgentRuns() {
             Agent runs
           </h1>
           <p className="mt-1 max-w-2xl text-token-sm text-muted-foreground">
-            Unified feed of MCP, API, and @loopover runs. Each entry carries a ruleset snapshot
-            and a public/private boundary.
+            Unified feed of MCP, API, and @loopover runs. Each entry carries a ruleset snapshot and
+            a public/private boundary.
           </p>
         </div>
         <div className="flex flex-wrap items-center gap-2">

--- a/apps/gittensory-ui/src/routes/docs.tuning.tsx
+++ b/apps/gittensory-ui/src/routes/docs.tuning.tsx
@@ -150,13 +150,12 @@ function Tuning() {
           <code>LOOPOVER_REVIEW_CONTINUOUS</code> — fleet-wide default AI review re-trigger cadence.
           Off by default (one-shot): AI-generated content (main review, slop advisory, linked-issue
           satisfaction) is produced once per PR and never regenerated automatically afterward — only
-          an explicit maintainer retrigger (the PR-panel checkbox, or{" "}
-          <code>@loopover review</code> as a maintainer) spends a fresh call. Truthy switches the
-          fleet default to continuous — every push/CI-completion/sweep re-runs AI content
-          generation. A repo's own <code>review.auto_review.cadence</code> in{" "}
-          <code>.loopover.yml</code> always overrides this default, in either direction. Never
-          affects the deterministic gate (CI status, mergeability, static-rule blockers), which
-          always re-evaluates regardless.
+          an explicit maintainer retrigger (the PR-panel checkbox, or <code>@loopover review</code>{" "}
+          as a maintainer) spends a fresh call. Truthy switches the fleet default to continuous —
+          every push/CI-completion/sweep re-runs AI content generation. A repo's own{" "}
+          <code>review.auto_review.cadence</code> in <code>.loopover.yml</code> always overrides
+          this default, in either direction. Never affects the deterministic gate (CI status,
+          mergeability, static-rule blockers), which always re-evaluates regardless.
         </li>
         <li>
           <code>LOOPOVER_REVIEW_RAG</code> — retrieval-augmented context: queries the codebase
@@ -185,9 +184,9 @@ function Tuning() {
           maintainer's own past false-positive dismissals) and demotes or drops it before the
           unified comment renders. A maintainer records a signal with{" "}
           <code>@loopover resolve [finding-code]</code> (or a whole-PR{" "}
-          <code>@loopover resolve</code> ack). Advisory-only by construction — never applied to
-          gate blockers, so it can never change the merge/close disposition. Also requires the
-          per-repo <code>review.memory: true</code> opt-in in <code>.loopover.yml</code>. Per-PR.
+          <code>@loopover resolve</code> ack). Advisory-only by construction — never applied to gate
+          blockers, so it can never change the merge/close disposition. Also requires the per-repo{" "}
+          <code>review.memory: true</code> opt-in in <code>.loopover.yml</code>. Per-PR.
         </li>
         <li>
           <code>LOOPOVER_REVIEW_REPUTATION</code> — submitter-reputation spend control. A new,
@@ -283,12 +282,12 @@ function Tuning() {
           blocks.
         </li>
         <li>
-          <code>block</code> — the finding can become a hard{" "}
-          <code>LoopOver Orb Review Agent</code> blocker. A block outcome fails the gate for any
-          author identically — confirmed-Gittensor-contributor status doesn&apos;t change{" "}
-          <em>who</em> can be blocked, only the mode chooses <em>which</em> deterministic checks are
-          active. Confirmed status is carried through for on-chain scoring, a separate concern from
-          the gate&apos;s own merge/close decision.
+          <code>block</code> — the finding can become a hard <code>LoopOver Orb Review Agent</code>{" "}
+          blocker. A block outcome fails the gate for any author identically —
+          confirmed-Gittensor-contributor status doesn&apos;t change <em>who</em> can be blocked,
+          only the mode chooses <em>which</em> deterministic checks are active. Confirmed status is
+          carried through for on-chain scoring, a separate concern from the gate&apos;s own
+          merge/close decision.
         </li>
       </ul>
       <p>
@@ -479,8 +478,8 @@ function Tuning() {
           <code>publicSignalLevel</code> — <code>minimal</code> / <code>standard</code> (default).
         </li>
         <li>
-          <code>checkRunMode</code> — publishes the <strong>LoopOver Context</strong> check (not
-          the <strong>Orb Review Agent</strong> gate check, which is <code>reviewCheckMode</code>):{" "}
+          <code>checkRunMode</code> — publishes the <strong>LoopOver Context</strong> check (not the{" "}
+          <strong>Orb Review Agent</strong> gate check, which is <code>reviewCheckMode</code>):{" "}
           <code>off</code> (default) / <code>enabled</code>. Pair with{" "}
           <code>checkRunDetailLevel</code> (<code>minimal</code> (default) / <code>standard</code>).
         </li>

--- a/packages/gittensory-engine/src/focus-manifest.ts
+++ b/packages/gittensory-engine/src/focus-manifest.ts
@@ -607,7 +607,7 @@ export type FocusManifestReviewConfig = {
    *  (default, absent) ⇒ byte-identical to today. Net-new vs the changed-files-summary (#1957) and effort-score
    *  (#1955) knobs. (#2047) */
   commentVerbosity: CommentVerbosity | null;
-  /** `review.e2e_test_delivery` (#4197, part of the #4189 epic): how a `@gittensory generate-tests` result is
+  /** `review.e2e_test_delivery` (#4197, part of the #4189 epic): how a `@loopover generate-tests` result is
    *  delivered once `features.e2eTests` is on. `"comment"` (default, null/absent) posts the generated test as
    *  a reply comment only — no write access to the PR branch. `"commit"` pushes it as a real commit onto the
    *  PR's own head branch (git/trees -> git/commits -> a ref UPDATE, mirroring `repo-doc-pr.ts`'s write
@@ -619,7 +619,7 @@ export type FocusManifestReviewConfig = {
   /** `review.e2e_test_auto_trigger` (#4196, part of the #4189 epic): opts THIS repo into the `manifest_missing_tests`
    *  auto-trigger, which promotes that advisory finding into an actual unprompted generation run whenever a PR looks
    *  like it needs tests -- separate from `features.e2eTests`, which only unlocks the maintainer-initiated paths
-   *  (the `@gittensory generate-tests` command and the PR-panel checkbox). Deliberately independent and OFF by
+   *  (the `@loopover generate-tests` command and the PR-panel checkbox). Deliberately independent and OFF by
    *  default: enabling `e2eTests` for on-demand use must never, by itself, start firing generation unprompted on
    *  every under-tested PR (the exact loophole this field closes) -- a maintainer who *wants* the auto-trigger opts
    *  in explicitly per repo. null/false (default, absent) ⇒ the auto-trigger never fires, even with e2eTests on;
@@ -692,7 +692,7 @@ export type E2eTestDeliveryMode = (typeof E2E_TEST_DELIVERY_MODES)[number];
 /** `review.auto_review.cadence` (#one-shot-review-cadence). `one_shot` = the AI-generated content (main review,
  *  slop advisory, linked-issue satisfaction) is produced once per PR and never automatically regenerated
  *  afterward — not on a new push, not on CI-check completion, not on a scheduled sweep tick; only an explicit
- *  maintainer retrigger (the PR-panel checkbox or `@gittensory review` as a maintainer) spends a fresh call.
+ *  maintainer retrigger (the PR-panel checkbox or `@loopover review` as a maintainer) spends a fresh call.
  *  `continuous` = the traditional behavior — every trigger re-runs AI content generation, subject to each
  *  feature's own head-SHA cache. Orthogonal to `aiReviewMode`'s enforcement-strictness axis (off/advisory/
  *  block) — the deterministic gate (CI status, mergeability, static-rule blockers) is NEVER affected by this
@@ -2090,7 +2090,7 @@ function parseSettingsOverride(value: JsonValue | undefined, warnings: string[],
     const contributorCapCancelCi = normalizeOptionalBoolean(r.contributorCapCancelCi, "settings.contributorCapCancelCi", warnings);
     if (contributorCapCancelCi !== null) out.contributorCapCancelCi = contributorCapCancelCi;
   }
-  // Review-request nagging cooldown (#2463): throttle a contributor repeatedly pinging @gittensory for review.
+  // Review-request nagging cooldown (#2463): throttle a contributor repeatedly pinging @loopover for review.
   const reviewNagPolicy = normalizeOptionalEnum(r.reviewNagPolicy, "settings.reviewNagPolicy", ["off", "hold", "close"] as const, warnings);
   if (reviewNagPolicy !== null) out.reviewNagPolicy = reviewNagPolicy;
   const reviewNagMaxPings = normalizeOptionalPositiveInteger(r.reviewNagMaxPings, "settings.reviewNagMaxPings", warnings);
@@ -2108,7 +2108,7 @@ function parseSettingsOverride(value: JsonValue | undefined, warnings: string[],
     if (reviewNagLabel !== null) out.reviewNagLabel = reviewNagLabel;
   }
   // Maintainer-mention nag moderation (#label-scoping): GitHub logins ALSO throttled under the review-nag
-  // cooldown above, on top of the bot's own @gittensory handle. Only set it when at least one VALID login
+  // cooldown above, on top of the bot's own @loopover handle. Only set it when at least one VALID login
   // survives normalization, so a malformed block never blanks the DB-configured list via the resolver's
   // `{...dbSettings, ...manifest.settings}` overlay (same reasoning as autoCloseExemptLogins below).
   if (r.reviewNagMonitoredMentions !== undefined) {
@@ -2178,7 +2178,7 @@ function parseSettingsOverride(value: JsonValue | undefined, warnings: string[],
   }
   const newAccountLabel = normalizeOptionalString(r.newAccountLabel, "settings.newAccountLabel", warnings);
   if (newAccountLabel !== null) out.newAccountLabel = newAccountLabel;
-  // Per-command @gittensory rate limit (#2560): generalizes review-nag's cooldown pattern to every command.
+  // Per-command @loopover rate limit (#2560): generalizes review-nag's cooldown pattern to every command.
   const commandRateLimitPolicy = normalizeOptionalEnum(r.commandRateLimitPolicy, "settings.commandRateLimitPolicy", ["off", "hold"] as const, warnings);
   if (commandRateLimitPolicy !== null) out.commandRateLimitPolicy = commandRateLimitPolicy;
   const commandRateLimitMaxPerWindow = normalizeOptionalPositiveInteger(r.commandRateLimitMaxPerWindow, "settings.commandRateLimitMaxPerWindow", warnings);

--- a/packages/gittensory-engine/src/types/manifest-deps-types.ts
+++ b/packages/gittensory-engine/src/types/manifest-deps-types.ts
@@ -112,14 +112,14 @@ export type AdvisoryAiRoutingConfig = {
   e2eTestGen: boolean;
   planner: boolean;
   summaries: boolean;
-  /** Grounded `@gittensory chat <question>` LLM Q&A (#4595). Ollama-first: declines when off or when
+  /** Grounded `@loopover chat <question>` LLM Q&A (#4595). Ollama-first: declines when off or when
    *  env.AI_ADVISORY is unconfigured and {@link chatQaFrontierFallback} is not also enabled. Default false. */
   chatQa: boolean;
   /** Opt-in ONLY (#4595 follow-up): when true, chat falls back to the shared frontier env.AI chain if
    *  env.AI_ADVISORY is unconfigured, instead of declining. Meaningless unless {@link chatQa} is also true.
    *  Default false. */
   chatQaFrontierFallback: boolean;
-  /** Closed-set intent-classification router for unrecognized `@gittensory` mentions (#4596). Ollama-only,
+  /** Closed-set intent-classification router for unrecognized `@loopover` mentions (#4596). Ollama-only,
    *  same as chatQa. Default false. */
   intentRouting: boolean;
 };
@@ -407,13 +407,13 @@ export type RepositorySettings = {
    *  explicit `false` (opt back out) is distinguishable from "not configured" for that fallback. */
   contributorCapCancelCi?: boolean | null | undefined;
   /** Review-request nagging cooldown (#2463, anti-abuse): throttle a contributor repeatedly pinging
-   *  `@gittensory` (any command) on this repo. `"off"` (default) is a no-op; `"hold"` posts a deterministic
+   *  `@loopover` (any command) on this repo. `"off"` (default) is a no-op; `"hold"` posts a deterministic
    *  cooldown reply and takes no further action; `"close"` additionally closes the thread (PR threads only in
    *  v1 — a plain issue thread degrades to `"hold"` behavior until #2493's `closeIssue` primitive lands).
    *  Always populated by the DB layer (default `"off"`); optional so existing settings fixtures/callers need
    *  not be touched. */
   reviewNagPolicy?: "off" | "hold" | "close" | undefined;
-  /** Review-nag cooldown (#2463): how many `@gittensory` pings a contributor may make on this repo within
+  /** Review-nag cooldown (#2463): how many `@loopover` pings a contributor may make on this repo within
    *  {@link reviewNagCooldownDays} before the (N+1)th is throttled. Always populated by the DB layer (default
    *  `3`); optional so existing settings fixtures/callers need not be touched. Only meaningful when
    *  {@link reviewNagPolicy} is not `"off"`. */
@@ -428,9 +428,9 @@ export type RepositorySettings = {
    *  fixtures/callers need not be touched. */
   reviewNagLabel?: string | null | undefined;
   /** Maintainer-mention nag moderation: GitHub logins to ALSO throttle under the review-nag cooldown when the
-   *  thread author repeatedly @-mentions them (on top of the bot's own `@gittensory` handle) -- e.g. a
+   *  thread author repeatedly @-mentions them (on top of the bot's own `@loopover` handle) -- e.g. a
    *  maintainer login instead of the bot, for a contributor who keeps tagging a specific person for review.
-   *  Counted independently per mentioned login and independently of the `@gittensory` counter, but reuses the
+   *  Counted independently per mentioned login and independently of the `@loopover` counter, but reuses the
    *  SAME {@link reviewNagPolicy}/{@link reviewNagMaxPings}/{@link reviewNagCooldownDays}/{@link reviewNagLabel}
    *  thresholds/action/label -- one cooldown policy, multiple watched mention targets. `[]`/undefined (default)
    *  = no logins watched, zero behavior change. Never fires for the repo owner, admin logins, automation bots,
@@ -481,8 +481,8 @@ export type RepositorySettings = {
    *  configurable-with-fallback shape. Always populated by the DB layer (default `"new-account"`); optional so
    *  existing settings fixtures/callers need not be touched. */
   newAccountLabel?: string | undefined;
-  /** Per-command @gittensory rate limit (#2560, anti-abuse): generalizes the review-nag cooldown's counting
-   *  pattern (the audit-events ledger) to EVERY `@gittensory` command, keyed by `(actor, command, targetKey)` --
+  /** Per-command @loopover rate limit (#2560, anti-abuse): generalizes the review-nag cooldown's counting
+   *  pattern (the audit-events ledger) to EVERY `@loopover` command, keyed by `(actor, command, targetKey)` --
    *  independent of, and complementary to, review-nag's own narrower thread-author-only scope. `"off"` (default)
    *  is a no-op; `"hold"` posts a deterministic cooldown reply and skips the command's own dispatch. Always
    *  populated by the DB layer (default `"off"`); optional so existing settings fixtures/callers need not be


### PR DESCRIPTION
## Summary
- PR #5715 renamed the mention command's dispatch regex (`src/github/commands.ts`) but its `@gittensory`-scoped sweep never reached `packages/gittensory-engine/` — a separate source root — leaving several `@gittensory <command>` syntax examples live in JSDoc comments (`focus-manifest.ts`, `types/manifest-deps-types.ts`).
- Those JSDoc comments feed the generated OpenAPI schema descriptions, so `apps/gittensory-ui/public/openapi.json` was stale (still had the pre-rebrand `"Gittensory API"` title) and failing `ui:openapi:check`.
- Regenerates `openapi.json` from current source now that both are consistent.

## Test plan
- [x] `npx tsx scripts/write-ui-openapi.ts --check` passes
- [x] `grep -rn "@gittensory" --include="*.ts"` across the repo returns zero matches
- [x] Confirmed the `Gittensor` subnet/token name (a distinct, unrelated identifier) was not touched