### PR TITLE
feat(github-app): add a duplicate-overlap table to the check-run details page (#576)

### DIFF
--- a/src/rules/advisory.ts
+++ b/src/rules/advisory.ts
@@ -10,7 +10,7 @@ import type {
   PullRequestRecord,
   RepositoryRecord,
 } from "../types";
-import type { CollisionCluster, CollisionReport } from "../signals/engine";
+import type { CollisionCluster, CollisionItem, CollisionReport } from "../signals/engine";
 import { isDuplicateClusterWinnerByClaim } from "../signals/duplicate-winner";
 import type { GuardrailPathMatch } from "../signals/change-guardrail";
 import { isCodeFile } from "../signals/local-branch";
@@ -355,6 +355,39 @@ function collisionClustersForPull(collisions: CollisionReport, pullNumber: numbe
   );
 }
 
+const COLLISION_ITEM_TYPE_LABEL: Record<CollisionItem["type"], string> = {
+  issue: "issue",
+  pull_request: "PR",
+  recent_merged_pull_request: "merged PR",
+};
+
+/**
+ * A scannable "possible duplicate overlaps" markdown table for the Context check DETAILS page, gated
+ * to `standard` detail (#576). Reuses the SAME collision clusters the inline annotations already use
+ * (collisionClustersForPull), but presents each cluster as one consolidated table row — the other
+ * overlapping issues/PRs, the cluster's risk, and why — instead of the scattered per-file annotations,
+ * so a maintainer can scan the overlaps at a glance on the details page. Public-safe: every item title
+ * and cluster reason is run through sanitizeForCheckRun, the same filter the annotations use. Returns
+ * "" when there is no annotation context or no cluster involves this PR, so `minimal`-detail and
+ * overlap-free PRs are byte-identical to before.
+ */
+function buildCollisionClusterTable(context: CheckRunAnnotationContext | undefined): string {
+  if (!context) return "";
+  const clusters = collisionClustersForPull(context.collisions, context.pullNumber);
+  if (clusters.length === 0) return "";
+  const rows = clusters.map((cluster) => {
+    const others = cluster.items.filter(
+      (item) => !(item.type === "pull_request" && item.number === context.pullNumber),
+    );
+    const overlaps =
+      others
+        .map((item) => `#${item.number} ${sanitizeForCheckRun(item.title)} (${COLLISION_ITEM_TYPE_LABEL[item.type]})`)
+        .join("<br>") || "—";
+    return `| ${overlaps} | ${cluster.risk} | ${sanitizeForCheckRun(cluster.reason)} |`;
+  });
+  return ["### Possible duplicate overlaps", "", "| Overlapping work | Risk | Why |", "| --- | --- | --- |", ...rows].join("\n");
+}
+
 const ANNOTATABLE_PR_FILE_STATUSES = new Set(["added", "changed", "modified"]);
 
 export function firstAddedLineFromPatch(patch: string): number | null {
@@ -471,15 +504,17 @@ export function formatCheckRunOutput(
   let text: string;
   if (detailLevel === "minimal") {
     text = "No detailed findings are published in check runs.";
-  } else if (advisoryResult.findings.length === 0) {
-    text = "No detailed findings are published in check runs.";
   } else {
     const publicLines = advisoryResult.findings.flatMap((f) => {
       if (!f.publicText) return [];
       const label = f.severity === "warning" ? "⚠️" : "ℹ️";
       return [`${label} ${sanitizeForCheckRun(f.publicText)}`];
     });
-    text = publicLines.length === 0 ? "No detailed findings are published in check runs." : publicLines.join("\n");
+    // Standard detail also renders a scannable duplicate-overlap table on the details page (#576).
+    const sections = [publicLines.join("\n"), buildCollisionClusterTable(annotationContext)].filter(
+      (section) => section.length > 0,
+    );
+    text = sections.length === 0 ? "No detailed findings are published in check runs." : sections.join("\n\n");
   }
 
   const { annotations, omittedCount } = buildCheckRunAnnotations(advisoryResult, annotationContext, detailLevel);

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -915,6 +915,154 @@ describe("advisory rules", () => {
     expect(JSON.stringify(annotations)).not.toMatch(/trust score|wallet|hotkey|reward estimate|reviewability/i);
   });
 
+  const dupPr = {
+    repoFullName: repo.fullName,
+    number: 12,
+    title: "Add registry sync",
+    state: "open" as const,
+    authorLogin: "contributor",
+    authorAssociation: "NONE",
+    labels: [],
+    linkedIssues: [],
+  };
+
+  it("formatCheckRunOutput renders a scannable duplicate-overlap table at standard detail, excluding the PR itself (#576)", () => {
+    const advisory = buildPullRequestAdvisory(repo, dupPr);
+    const collisions: CollisionReport = {
+      repoFullName: repo.fullName,
+      generatedAt: "2026-06-10T00:00:00.000Z",
+      summary: { clusterCount: 1, highRiskCount: 1, itemsReviewed: 3 },
+      clusters: [
+        {
+          id: "c1",
+          risk: "high",
+          reason: "Titles/paths share 4 meaningful terms.",
+          items: [
+            { type: "pull_request", number: 12, title: "Add registry sync" },
+            { type: "pull_request", number: 13, title: "Registry sync cleanup" },
+            { type: "issue", number: 7, title: "Registry drifts from upstream" },
+          ],
+        },
+      ],
+    };
+    const output = formatCheckRunOutput(advisory, "standard", { files: [], collisions, pullNumber: 12 });
+    expect(output.text).toContain("### Possible duplicate overlaps");
+    expect(output.text).toContain("| Overlapping work | Risk | Why |");
+    expect(output.text).toContain("#13 Registry sync cleanup (PR)");
+    expect(output.text).toContain("#7 Registry drifts from upstream (issue)");
+    expect(output.text).toContain("| high |");
+    expect(output.text).toContain("Titles/paths share 4 meaningful terms.");
+    // The current PR is never listed as its own overlap.
+    expect(output.text).not.toContain("#12 Add registry sync");
+  });
+
+  it("formatCheckRunOutput labels a recent-merged-PR overlap and its cluster risk (#576)", () => {
+    const advisory = buildPullRequestAdvisory(repo, { ...dupPr, number: 30, title: "Add cache" });
+    const collisions: CollisionReport = {
+      repoFullName: repo.fullName,
+      generatedAt: "2026-06-10T00:00:00.000Z",
+      summary: { clusterCount: 1, highRiskCount: 0, itemsReviewed: 2 },
+      clusters: [
+        {
+          id: "c2",
+          risk: "medium",
+          reason: "Overlaps a recently merged PR.",
+          items: [
+            { type: "pull_request", number: 30, title: "Add cache" },
+            { type: "recent_merged_pull_request", number: 29, title: "Cache layer" },
+          ],
+        },
+      ],
+    };
+    const output = formatCheckRunOutput(advisory, "standard", { files: [], collisions, pullNumber: 30 });
+    expect(output.text).toContain("#29 Cache layer (merged PR)");
+    expect(output.text).toContain("| medium |");
+  });
+
+  it("formatCheckRunOutput omits the overlap table at minimal detail even when clusters exist (#576)", () => {
+    const advisory = buildPullRequestAdvisory(repo, dupPr);
+    const collisions: CollisionReport = {
+      repoFullName: repo.fullName,
+      generatedAt: "2026-06-10T00:00:00.000Z",
+      summary: { clusterCount: 1, highRiskCount: 1, itemsReviewed: 2 },
+      clusters: [
+        {
+          id: "c1",
+          risk: "high",
+          reason: "Overlap.",
+          items: [
+            { type: "pull_request", number: 12, title: "Add registry sync" },
+            { type: "pull_request", number: 13, title: "Registry sync cleanup" },
+          ],
+        },
+      ],
+    };
+    const output = formatCheckRunOutput(advisory, "minimal", { files: [], collisions, pullNumber: 12 });
+    expect(output.text).not.toContain("Possible duplicate overlaps");
+    expect(output.text).toContain("No detailed findings are published");
+  });
+
+  it("formatCheckRunOutput renders no overlap table when no cluster involves this PR, or without any context (#576)", () => {
+    const advisory = buildPullRequestAdvisory(repo, { ...dupPr, number: 99, title: "Unrelated" });
+    const collisions: CollisionReport = {
+      repoFullName: repo.fullName,
+      generatedAt: "2026-06-10T00:00:00.000Z",
+      summary: { clusterCount: 1, highRiskCount: 0, itemsReviewed: 2 },
+      clusters: [
+        {
+          id: "c3",
+          risk: "low",
+          reason: "Other overlap.",
+          items: [
+            { type: "pull_request", number: 12, title: "Add registry sync" },
+            { type: "pull_request", number: 13, title: "Registry sync cleanup" },
+          ],
+        },
+      ],
+    };
+    expect(formatCheckRunOutput(advisory, "standard", { files: [], collisions, pullNumber: 99 }).text).not.toContain(
+      "Possible duplicate overlaps",
+    );
+    expect(formatCheckRunOutput(advisory, "standard").text).not.toContain("Possible duplicate overlaps");
+  });
+
+  it("formatCheckRunOutput shows an em dash when a cluster's only member is the PR itself (#576)", () => {
+    const advisory = buildPullRequestAdvisory(repo, { ...dupPr, title: "Solo" });
+    const collisions: CollisionReport = {
+      repoFullName: repo.fullName,
+      generatedAt: "2026-06-10T00:00:00.000Z",
+      summary: { clusterCount: 1, highRiskCount: 0, itemsReviewed: 1 },
+      clusters: [{ id: "c4", risk: "low", reason: "Self only.", items: [{ type: "pull_request", number: 12, title: "Solo" }] }],
+    };
+    const output = formatCheckRunOutput(advisory, "standard", { files: [], collisions, pullNumber: 12 });
+    expect(output.text).toContain("### Possible duplicate overlaps");
+    expect(output.text).toContain("| — | low |");
+  });
+
+  it("formatCheckRunOutput sanitizes forbidden terms inside the overlap table (#576)", () => {
+    const advisory = buildPullRequestAdvisory(repo, dupPr);
+    const collisions: CollisionReport = {
+      repoFullName: repo.fullName,
+      generatedAt: "2026-06-10T00:00:00.000Z",
+      summary: { clusterCount: 1, highRiskCount: 0, itemsReviewed: 2 },
+      clusters: [
+        {
+          id: "c5",
+          risk: "low",
+          reason: "Shares a reward estimate leak.",
+          items: [
+            { type: "pull_request", number: 12, title: "Add registry sync" },
+            { type: "pull_request", number: 14, title: "wallet drain hotkey" },
+          ],
+        },
+      ],
+    };
+    const text = formatCheckRunOutput(advisory, "standard", { files: [], collisions, pullNumber: 12 }).text;
+    expect(text).toContain("### Possible duplicate overlaps");
+    expect(text).not.toMatch(/wallet|hotkey|reward estimate/i);
+    expect(text).toContain("[context]");
+  });
+
   it("does not flag Missing test evidence when a Cypress/e2e test accompanies a code change (regression)", () => {
     // isTestPath now delegates to the canonical src/signals/test-evidence matcher, which recognizes
     // *.cy./*.e2e./__snapshots__/_spec.rb tests. A stale local copy dropped those branches, so a code


### PR DESCRIPTION
## Summary

At `standard` `checkRunDetailLevel`, the Context check **details page** now renders a scannable **"Possible duplicate overlaps"** markdown table — the overlapping issues/PRs, the cluster's risk, and why — reusing the **same collision clusters** the inline annotations already surface, but consolidated into one table instead of scattered per-file annotations. `minimal` detail and overlap-free PRs are byte-identical to before.

Closes #576.

## Implementation

- New `buildCollisionClusterTable()` in `src/rules/advisory.ts`, called from `formatCheckRunOutput()`'s standard branch. Uses the existing `collisionClustersForPull()` helper; excludes the PR itself from its own overlap list; labels each item type (issue / PR / merged PR).
- **Public-safe:** every item title and cluster reason runs through the existing `sanitizeForCheckRun` filter (the same one the annotations use). A test asserts forbidden terms are redacted.
- Backward-compatible: the standard branch now composes `[findings, overlap-table]` sections, so a PR with findings-but-no-overlap, or overlap-but-no-findings, both render correctly; `minimal` and the no-context path are unchanged.

## Scope note

#576 lists reusing `buildPublicReadinessScore` **and** collision clusters. This PR delivers the **cluster** table — a complete, self-contained, public-safe slice. The **readiness** table is a natural follow-up: it needs readiness (band + components) threaded into the check-run context through the review processor, deliberately kept out of this focused, fully-covered PR.

## Scope

- [x] The PR title follows Conventional Commit format.
- [x] Focused; `src/**` (GitHub App) only, no unrelated changes.
- [x] Follows `CONTRIBUTING.md`; no GitHub Pages/VitePress/`site/`/`CNAME`.
- [x] Linked open issue: Closes #576.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` — 0 errors
- [x] `npm run test:coverage` — `test/unit/rules.test.ts` 99/99 passing; **100% patch coverage** on the changed lines
- [x] New tests cover: the table render + columns, self-exclusion, all three item-type labels (issue / PR / merged PR), `minimal`-omits-it, no-cluster and no-context paths, the em-dash edge (a cluster whose only member is the PR), and forbidden-term sanitization
- No engine-parity impact — `formatCheckRunOutput` is host-only (not part of the `advisory.ts ↔ gate-advisory.ts` gate-decision marker set).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, trust scores, private rankings, or reward values — the table is built only from public issue/PR numbers + titles and the cluster reason, all run through `sanitizeForCheckRun`.
- [x] Public GitHub output stays sanitized and low-noise.
- [x] No API/OpenAPI/schema/migration changes.
