### PR TITLE
chore(claude): add contributor-pipeline-gardening skill

### DIFF
--- a/.claude/skills/contributor-pipeline-gardening/SKILL.md
+++ b/.claude/skills/contributor-pipeline-gardening/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: contributor-pipeline-gardening
+description: >-
+  Daily maintenance of the contributor issue pipeline for JSONbored/gittensory (renaming to
+  loopover) — closing issues that are already done but not marked so, and topping up the
+  contributor-available backlog with well-scoped new issues. Invoke for "run the daily issue
+  gardening", "audit open issues for stale/complete ones", "generate new contributor issues",
+  or any recurring/scheduled run of this process. `reference.md` (next to this file) has the
+  exhaustive label/milestone/template detail — read it before doing real work, not just this file.
+---
+
+# Contributor pipeline gardening — gittensory / loopover
+
+This repo runs on a **steady stream of well-scoped, correctly-labeled issues** for contributors —
+see `.claude/skills/contributing-to-loopover/`. Contributors can only open a PR that links a real,
+open, non-`maintainer-only` issue carrying a `gittensor:*` label. If the pipeline runs dry or fills
+up with stale duplicates, contributors have nothing real to do. This skill is the daily job that
+keeps the pipeline honest: **close what's actually done, keep the backlog stocked with what
+genuinely isn't.**
+
+Every run does two independent passes. Do the stale sweep FIRST — it changes what "the backlog is
+short" even means, so top-up sizing is only accurate after the sweep.
+
+## Pass 1 — stale-issue sweep (do this first, every run)
+
+**The failure mode this catches:** a PR merges and actually finishes an issue's work, but the PR
+body says "Advances #NNNN" or just mentions "(#NNNN)" instead of "Closes #NNNN" — a deliberate
+non-closing reference when real work remains, but sometimes just a missed keyword when the work
+was actually finished. GitHub never auto-closes on a bare reference either way, so the issue sits
+open indefinitely looking like backlog when it isn't. This has already happened repeatedly in this
+repo (a whole "HELD tracker" milestone with 47/48 items silently done, several individual issues) —
+assume it keeps happening, don't assume today's backlog is clean.
+
+**Method — GitHub's cross-reference timeline, not text search:**
+
+1. Pull the full open-issue list: `gh issue list --repo JSONbored/gittensory --state open --limit 1000 --json number,title,labels,milestone,createdAt`.
+2. For every open issue, query which merged PRs ever referenced it, via GraphQL `timelineItems(itemTypes: [CROSS_REFERENCED_EVENT])` → `source { ... on PullRequest { number state merged } }` and `willCloseTarget`. Batch in chunks of ~20 issues per query using aliases (`i1234: issue(number: 1234) { ... }`) to stay under complexity limits.
+   - **Important CLI gotcha:** `gh api graphql -f query=@file` does NOT read from a file — `-f` treats `@file` as a literal string and the query fails with a cryptic parse error. Use **`-F query=@file`** (capital F) instead; only `-F`/`--field` supports the `@filename` file-read syntax.
+3. Any issue where `willCloseTarget=true` on a merged PR but the issue is still open is worth a first look (should have auto-closed and didn't — check why, e.g. merged to a non-default branch). In practice this repo hasn't produced any of these yet; don't assume it stays that way.
+4. Any issue with at least one merged-PR reference and `willCloseTarget=false` is the real target list. For each: **read the actual PR body**, not just its title. Three outcomes:
+   - The PR body says or clearly implies the issue's full scope is done → close the issue (`gh issue close <n> --reason completed --comment "..."`) with a comment naming the PR(s) and, where possible, a direct code check (grep for the file/function/route the issue described) confirming it actually exists. Never close on title-similarity alone — verify against the real diff/body.
+   - The PR body explicitly says it's a partial/narrower fix (look for phrasing like "narrower fix," "part 1 of," "does not build the full X," "Advances #N... not forgotten") → leave the issue open. If useful, add a short comment noting what's already shipped so a contributor doesn't duplicate it.
+   - Ambiguous → default to leaving it open; a false-open costs nothing, a false-close wastes a contributor's time and erodes trust in the label.
+5. If the issue is itself a "tracker" (a markdown checklist of child issue numbers — search open issues for "tracker" or a checklist body), check every child's real state and update the checkboxes to match reality. Only close the tracker itself if literally every child is done; otherwise just fix the checklist and leave it open.
+6. **Migrate away from markdown-checklist trackers going forward.** This repo has native GitHub sub-issues and blocked-by relationships available (confirmed via GraphQL: `addSubIssue`, `addBlockedBy` mutations both work on this repo) — use those for any NEW tracker/epic instead of a hand-maintained checklist, so a child's close is reflected automatically instead of silently drifting. See `reference.md` for the exact mutations.
+
+## Pass 2 — backlog top-up
+
+**Target: keep the repo-wide contributor-available count (unassigned, no `maintainer-only`, carries a `gittensor:*` label) at roughly 30-50, combined with metagraphed's own count** — check the combined total across both repos before deciding how many to add here; don't generate a fixed number blind. Compute it fresh: `gh issue list --state open --limit 1000 --json number,labels,assignees` and filter.
+
+1. **Read `reference.md`'s "what's safe to unleash" framework first.** The single most common mistake is generating architecture/business-decision issues (hosted multi-tenant SaaS design, billing, SLAs, pricing) that must stay `maintainer-only` — this repo has ~90 such issues already correctly gated and the automation must not erode that boundary. Concrete engineering work with a clear existing precedent to follow is the target; open-ended product/business decisions are not.
+2. Pick real gaps to scope from, in priority order:
+   - Existing open epics/roadmap issues in this repo that don't yet have enough decomposed child issues to be actionable (e.g. `ORB - Long Term Features & Improvements`, the review-comment-redesign family, any epic whose own body describes scope with no filed sub-issues yet).
+   - Genuine gaps found by reading the current codebase against a shipped feature's own stated acceptance criteria (the same technique Pass 1 uses to verify closure — used here in reverse, to find what's NOT yet done).
+   - AMS selfhost hardening and the unified AMS+ORB selfhost harness are named standing priorities — see `reference.md` for what's already been investigated there (as of 2026-07-14, no existing issue covers "install both products together"; it needs fresh scoping, not relabeling).
+3. Every new issue gets: the correct existing milestone (create a new one only if none fits — don't dump unrelated work into an ill-fitting bucket), a `gittensor:bug` (0.05x), `gittensor:feature` (0.25x), or `gittensor:priority` (1.5x, reserved for mission-critical/time-sensitive work only — this repo uses it sparingly, unlike metagraphed's looser convention, see `reference.md`) label, plus `help wanted` (the maintainer confirmed this stays as a visibility signal alongside the points label, not a replacement for one).
+4. Every new issue body follows the template in `reference.md` — Context, Requirements, Deliverables, Test Coverage Requirements (this repo's Codecov patch gate is 99%+, hard — every new issue implicitly inherits this unless it's `apps/**`-only UI work), Expected Outcome. No "left to interpretation" scope — the maintainer's own stated preference is that thin/ambiguous issue bodies are worse than fewer, complete ones.
+5. Link relationships using GitHub's native features, not prose: `addSubIssue` to attach a new issue under its parent epic, `addBlockedBy` when an issue genuinely cannot start before another lands. Only use these where a real dependency exists — don't chain issues into an artificial order to look organized.
+6. Quality over the number. If a scan doesn't turn up 30-50 genuinely well-scoped, non-redundant, correctly-boundaried issues combined across both repos on a given day, file fewer rather than pad with weak ones — note the shortfall in the daily digest instead.
+
+## Daily digest
+
+End every run with a short summary (issues closed with why, checklists fixed, new issues filed with
+milestone/label, current contributor-available count before/after, anything ambiguous that was left
+alone on purpose). This is the user's only visibility into a fully-autonomous run — make it
+readable in under a minute.

--- a/.claude/skills/contributor-pipeline-gardening/reference.md
+++ b/.claude/skills/contributor-pipeline-gardening/reference.md
@@ -1,0 +1,141 @@
+# Contributor pipeline gardening — reference (gittensory / loopover)
+
+## Product shape (so generated issues land in the right place)
+
+Two products, self-host-first:
+
+- **AMS (Autonomous Miner System)** — `packages/gittensory-miner` (npm: `@loopover/miner`) +
+  `packages/gittensory-engine` (npm: `@loopover/engine`, shared core also used by ORB) +
+  `apps/gittensory-miner-ui` + `apps/gittensory-miner-extension`. The contributor/miner side: finds
+  issues, plans, writes code, opens PRs, autonomously. Self-host (a local Miner Node) is the only
+  shipped deployment target; hosted AMS is a later phase (see "AMS/ORB Cloud Readiness" below).
+- **ORB (Owner/One-shot Review Brain)** — `src/**` (the Worker app: `src/review`, `src/queue`,
+  `src/signals`, etc). The maintainer side: automates PR review, merge/close disposition, summaries.
+  Self-hosted only today (see `.claude/skills/contributing-to-loopover` / `gittensory-deployment-models`
+  equivalent context) — no hosted Orb yet, deliberately, ~1-2 months out at the time of writing.
+- Directory names under `packages/` still say `gittensory-*`; only the npm package **names** have
+  moved to `@loopover/*` so far (as of 2026-07-14). Check both independently, don't assume one implies
+  the other — the repo itself renames `gittensory` → `loopover` on ~2026-07-15; re-verify current
+  naming before hardcoding either name into a new issue body.
+
+**Standing priorities named by the maintainer (2026-07-14), not yet issue-backed:**
+- **AMS selfhost hardening, round 2.** Miner Wave 4 ("AMS Hardening & Packaging") fully closed
+  (151/151) on 2026-07-14 — that backlog is empty, not hiding more maintainer-only work. Getting more
+  requires a fresh gap-audit (read the current `packages/gittensory-miner`/`-engine` code against what
+  Wave 4 already covered — coverage gate, ledger races, MCP scaffolding — and find what's still
+  genuinely thin), not relabeling existing issues.
+- **Unified AMS+ORB self-host harness** — letting one operator install/run both products together in
+  one system, to "close the loop" as both maintainer and contributor. Searched exhaustively
+  (2026-07-14): no existing issue, open or closed, covers this — not verbatim, not conceptually. The
+  closest real thread is #4878-#4884 (extracting ORB's core review logic into `gittensory-engine`,
+  the same package AMS's miner logic already lives in) — that's the actual prerequisite plumbing, not
+  the harness itself. This needs fresh scoping: read the current self-host `docker-compose.yml`
+  (already supports optional profiles — `ollama`, `observability`, `postgres`, `rees`, etc.) and design
+  how an AMS-miner profile/service could sit alongside it, then file a real epic + sub-issues.
+
+## Milestone taxonomy (as of 2026-07-14 — re-check before trusting, this moves fast)
+
+| Milestone | Nature | Contributor-open? |
+|---|---|---|
+| `Miner Wave N — <theme>` (no suffix) | A finished or active AMS-hardening-style wave | Mostly yes once released |
+| `Miner Wave N — <theme> (maintainer)` | Business/legal/architecture track (currently Wave 5, Rent-a-Loop) | Mostly no — but check individual issues, some concrete implementation sub-tasks are deliberately carved out and unlocked even inside a `(maintainer)`-titled milestone |
+| `AMS Cloud Readiness (maintainer)` | Hosted **multi-tenant SaaS** AMS — NOT the same thing as "AMS selfhost hardening" despite the name similarity | Mostly no (architecture/billing/SLA decisions) — a handful of pure research-spike/audit/load-test issues are deliberately contributor-eligible; check labels per-issue |
+| `ORB Cloud Readiness (maintainer)` | Same shape, for ORB's hosted SaaS story | Mostly no, same caveat — the first several issues in this milestone (#4878-4884-style, "extract X into gittensory-engine") are often pure refactors miscategorized here, not actually tenant/business-specific — read the body, not just the milestone |
+| `ORB - Long Term Features & Improvements` | Grab-bag: some genuine self-host feature/bug work, some product-design epics awaiting maintainer subjective calls | Mixed — read each body |
+| `LoopOver Rebrand Migration (maintainer)` | Brand/infra cutover | No |
+| Unmilestoned | Orphans | Usually fine to fold into the closest-fitting existing milestone above rather than leave adrift |
+
+**Don't invent a new milestone reflexively.** Only create one when a new body of work genuinely
+doesn't fit any existing bucket (the unified-harness epic, once scoped, likely needs its own).
+
+## What's safe to unleash — the actual test
+
+A concrete engineering task is safe to hand to a contributor when:
+- It has a clear existing precedent to follow in the codebase (another file/module/pattern already
+  does the analogous thing), so "how" isn't itself an open design question.
+- It doesn't require a business/product decision (pricing, ToS, what to charge, whether to build a
+  feature at all) — those stay `maintainer-only` regardless of how mechanical the code itself would be.
+- It doesn't touch trust/safety-critical global state (kill-switches, blacklists/allowlists, the gate's
+  own merge/close authority) without a maintainer-reviewed design first — audit/enumerate is fine to
+  hand off, the actual fix usually isn't, on the first pass.
+- It doesn't require access to something a contributor structurally can't have (a private dedicated
+  server's gitignored config, live SaaS-dashboard clicking in a vendor's own UI like Sentry's
+  integrations page) — those are maintainer-executed ops tasks, not GitHub issues at all, or need to
+  be scoped as "wire the repo-side code that a maintainer will then configure," not "configure the
+  live service."
+- It doesn't presuppose an undecided architecture question (e.g., don't file 10 issues building out
+  Kubernetes/Helm hosted-fleet tooling while "should we build hosted at all, and when" is still
+  unresolved) — file the decision-scoping issue first, as `maintainer-only`, and only decompose into
+  contributor work once the direction is real.
+
+When genuinely unsure, default to `maintainer-only` — a wrongly-locked issue costs one manual unlock
+later; a wrongly-unlocked one costs a contributor's wasted PR and possibly a bad precedent.
+
+## Labels
+
+- `gittensor:bug` — 0.05x multiplier. Bug fixes.
+- `gittensor:feature` — 0.25x multiplier. New feature/functionality work, linked to a feature issue.
+- `gittensor:priority` — 1.5x multiplier. **Scarce, by explicit convention** — reserved for
+  mission-critical or time-sensitive work, applied sparingly (historically ~2 issues at a time out of
+  dozens). This is a materially different norm than metagraphed's own convention (see that repo's
+  reference doc) — don't cross-pollinate the two repos' label discipline without being asked.
+- `help wanted` — always paired alongside a `gittensor:*` label on a newly-unlocked issue (confirmed
+  2026-07-14: the maintainer wants this kept, it "enhances visibility" and isn't redundant with the
+  points label).
+- `maintainer-only` + `roadmap` (paired) — the "held" signal. Remove **both** together when unlocking
+  an issue; adding only one without the other is inconsistent with this repo's own convention.
+- Never add anything beyond the above to a gardening-generated issue (no `visual`, `orb`, `docker`,
+  etc. unless the issue is unambiguously visual/UI, in which case pair `visual` + `gittensor:*` +
+  `help wanted` exactly as the existing convention already does for visual bounties).
+
+## Issue body template (Wave-4-batch house style — use for new feature/bug work)
+
+```md
+## Context
+<what exists today, cite real file paths / function names, why this matters>
+
+## Requirements
+<concrete, testable requirements — no "TBD" or "explore options" for anything actually decidable now>
+
+## Deliverables
+- [ ] <concrete artifact 1>
+- [ ] <concrete artifact 2>
+
+## Test Coverage Requirements
+<explicit 99%+ Codecov patch target / 100% target including invariants + a regression test for any
+fix — note explicitly if the touched paths are outside coverage.include, e.g. apps/**, so a future
+reader isn't confused about why Codecov doesn't gate it>
+
+## Expected Outcome
+<what's true after this ships that wasn't true before>
+
+## Links & Resources
+<related issues, the files to anchor on>
+```
+
+For pure architecture/design/spec issues (the kind that stay `maintainer-only`), use the lighter
+Problem/Area/Proposal/Deliverables/Resources/Boundaries shape instead — see any `AMS Cloud Readiness`
+issue (e.g. #5215-5230) for the exact pattern. Gardening-generated contributor issues should almost
+always be the heavier template; the light one is for issues you're explicitly NOT unlocking.
+
+## Native relationship linking (GraphQL — confirmed working on this repo, 2026-07-14)
+
+Prefer these over a markdown checklist for any new tracker/epic:
+
+```graphql
+mutation { addSubIssue(input: { issueId: "<parent node id>", subIssueId: "<child node id>" }) { issue { number } } }
+mutation { addBlockedBy(input: { issueId: "<blocked node id>", blockedById: "<blocker node id>" }) { issue { number } } }
+```
+
+Get an issue's GraphQL node ID via `gh api graphql -f query='query { repository(owner:"JSONbored", name:"gittensory") { issue(number: N) { id } } }'` (note: literal query strings without file interpolation are fine with `-f`; only the `@file` file-read syntax requires `-F`).
+
+## gh CLI gotchas already hit doing this work
+
+- `gh api graphql -f query=@file.txt` silently fails to read the file — use `-F query=@file.txt`.
+- `gh issue close` has no `--comment-file` flag — use `-c "$(cat file.md)"` (double-quoted, so the
+  command substitution's output — including any backticks in the comment text — is treated as one
+  literal argument, not re-parsed by bash).
+- Never embed a body/comment string containing backticks directly inside a `python3 -c "..."`
+  double-quoted bash argument — bash attempts command substitution on the backticks before Python
+  ever sees them. Write the content to a file with the Write tool first, then read it back via
+  `$(cat file)` inside double quotes, or pass `--body-file`/`--comment` reading from that file.


### PR DESCRIPTION
## Summary
- Adds `.claude/skills/contributor-pipeline-gardening/` (SKILL.md + reference.md): the daily process for auditing open issues for stale/already-shipped ones (GraphQL cross-reference of merged PRs against open issues, verified against actual PR bodies before closing) and topping up the contributor-available backlog with well-scoped, correctly-labeled, correctly-milestoned new issues.
- This is the durable, repo-committed context a scheduled automation reads each run, since a fresh scheduled run has no memory of any prior session. Captures the milestone taxonomy, the maintainer-vs-contributor safety framework, the labeling rules, the issue body template, and the native GitHub sub-issue/blocked-by linking convention (confirmed available on this repo via GraphQL) to replace the markdown-checklist tracker pattern that caused today's stale-tracker findings.
- Notes the two standing, not-yet-issue-backed priorities named by the maintainer: AMS selfhost hardening round 2 (Wave 4's backlog is fully drained), and a unified AMS+ORB self-host harness (confirmed no existing issue covers this — needs fresh scoping).

## Test plan
- [x] Docs-only change under `.claude/`; no `src/` changes, no CI/coverage impact.