### PR TITLE
fix(release): stop node-workspace from clobbering manual dependency ranges

### DIFF
--- a/apps/gittensory-ui/src/lib/mcp-package.ts
+++ b/apps/gittensory-ui/src/lib/mcp-package.ts
@@ -8,7 +8,7 @@ export const MCP_PACKAGE_REGISTRY_URL = `https://registry.npmjs.org/${MCP_PACKAG
 export const MCP_PACKAGE_NPM_URL = `https://www.npmjs.com/package/${MCP_PACKAGE_NAME}`;
 // Tracks the latest PUBLISHED release: ui:version-audit requires this to equal npm dist-tags.latest, so it is
 // bumped to a new version only AFTER that version publishes (never ahead of npm).
-export const MCP_PACKAGE_KNOWN_LATEST_VERSION = "0.7.1";
+export const MCP_PACKAGE_KNOWN_LATEST_VERSION = "0.9.0";
 export const MCP_MINIMUM_SUPPORTED_VERSION = "0.5.0";
 
 export type NpmPackageMetadata = {

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -25,6 +25,7 @@
   "include-component-in-tag": true,
   "separate-pull-requests": true,
   "pull-request-title-pattern": "chore(release): cut${component} v${version}",
+  "always-link-local": false,
   "plugins": [
     {
       "type": "node-workspace",


### PR DESCRIPTION
## Summary
Root cause of a recurring bug this session: release-please's `node-workspace` plugin defaults to `always-link-local: true`, which force-rewrites every workspace-internal dependency's semver range on **every** regeneration of a release branch — even when the current range already satisfies the sibling's version.

This has repeatedly clobbered deliberate, manually-set constraints on `@loopover/miner`'s and `@loopover/mcp`'s `@loopover/engine` dependency back to a bare `"*"` (most recently caught by the repo's own security scanner on #5730; #5729 before that fixed the same thing once already). It has also separately generated a string of "empty" release PRs (mcp-v0.8.1, mcp-v1.0.1, miner-v2.0.1) that exist purely to speculatively cross-bump a dependency range ahead of the sibling's actual npm publish, with no real content of their own.

## Fix
`always-link-local: false` — a documented top-level manifest option (confirmed against release-please's own JSON schema at `raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json`). With this set, the plugin only touches a workspace dependency's range when the **current** range no longer covers the sibling's version — i.e. only for a genuine breaking change, which is exactly when a deliberate, manually-verified bump is warranted (the judgment call this session has been making by hand every single time this came up).

Also fixes `apps/gittensory-ui/src/lib/mcp-package.ts`'s `MCP_PACKAGE_KNOWN_LATEST_VERSION`, stale against mcp's real just-published 0.9.0 — unrelated to the config change, but blocking this branch's own gate via `ui:version-audit`.

## Test plan
- [x] Validated the JSON key against release-please's official schema (top-level, boolean, matches `always-link-local` exactly)
- [x] `npm run test:ci` green end-to-end
- [x] `npm audit --audit-level=moderate` clean
- [x] Effect will be directly observable on the next release-please run: no more speculative cross-bumps or clobbered manual ranges on `packages/gittensory-miner/package.json` / `packages/gittensory-mcp/package.json`