### PR TITLE
refactor(engine): extract sanitizePublicComment into gittensory-engine

### DIFF
--- a/packages/gittensory-engine/src/index.ts
+++ b/packages/gittensory-engine/src/index.ts
@@ -203,6 +203,9 @@ export {
   type DenyVerdict,
   type ProposedToolCall,
 } from "./miner/deny-hooks.js";
+// Pure public-comment redaction moved out of src/github/commands.ts (#4882) -- side-effect-free string logic
+// with high fan-in; the command layer now re-exports it from here.
+export { sanitizePublicComment } from "./public-comment-redaction.js";
 export {
   DEFAULT_SYNTHESIS_CONFIG,
   PROPOSAL_STATUSES,

--- a/packages/gittensory-engine/src/public-comment-redaction.ts
+++ b/packages/gittensory-engine/src/public-comment-redaction.ts
@@ -1,0 +1,43 @@
+// Public-comment redaction (#4882): the pure, deterministic pass that strips private scoring/credibility/
+// reward context out of any text before it is echoed into a public GitHub comment. Extracted out of the
+// I/O-heavy `src/github/commands.ts` command layer -- it is genuinely side-effect-free string logic (no D1, no
+// Env, no network) with the highest fan-in of that file's stranded pure helpers (10+ consumers across the
+// review-stack), so it belongs in the shared engine where the self-host backend and the miner can both reuse it
+// without depending on the whole command layer. Behavior is byte-for-byte identical to the pre-extraction
+// implementation.
+
+/** Redact private reviewability terminology unless it is part of a literal `@loopover reviewability` command
+ *  invocation (which is a public command name, safe to echo). Internal helper for {@link sanitizePublicComment}. */
+function sanitizeReviewabilityTerm(value: string): string {
+  return value.replace(/\breviewability\b/gi, (match, offset, fullText: string) => {
+    const prefix = fullText.slice(Math.max(0, offset - "@loopover ".length), offset).toLowerCase();
+    return prefix.endsWith("@loopover ") ? match : "private context";
+  });
+}
+
+/**
+ * Redact private, never-public scoring/credibility/reward/ranking context from a string bound for a public
+ * GitHub comment, replacing each such phrase with the neutral marker `private context`. Pure and deterministic:
+ * identical input always yields identical output, no IO. The catch-all passes collapse residual numeric score
+ * transitions and repeated `private context` runs left behind by an earlier phrase replacement.
+ */
+export function sanitizePublicComment(value: string): string {
+  const sanitized = value
+    .replace(/\bopen pr count\s+\d+\s+exceeds threshold\s+\d+\b\.?/gi, "private context")
+    .replace(/\bopen pr count is at or below\s+\d+\b/gi, "private context")
+    .replace(/\bmerged pr count\s+\d+\s+is below upstream floor\s+\d+\b\.?/gi, "private context")
+    .replace(/\bissue-discovery history\s*\(\s*\d+\s+valid solved,\s*credibility\s+[-+]?\d+(?:\.\d+)?\s*\)\s+is below upstream floors\s*\(\s*\d+\s+valid solved,\s*[-+]?\d+(?:\.\d+)?\s+credibility\s*\)\.?/gi, "private context")
+    .replace(/\bcredibility\s+[-+]?\d+(?:\.\d+)?\s+is below floor\s+[-+]?\d+(?:\.\d+)?\b\.?/gi, "private context")
+    .replace(/\b(?:effective|projected|estimated) score(?: changes?)?\b(?:\s+from)?\s+[-+]?\d+(?:\.\d+)?\s*(?:->|→|to)\s*[-+]?\d+(?:\.\d+)?/gi, "private context")
+    .replace(/\b(raw trust scores?|trust scores?|wallets?|hotkeys?|coldkeys?|seed phrases?|mnemonics?)\b/gi, "private context")
+    .replace(/\b(public score estimates?|estimated scores?|score estimates?|estimated rewards?|rewards?|reward estimates?|payouts?|farming|scoreability|score previews?|projected score changes?)\b/gi, "private context")
+    .replace(/\b(private reviewability|reviewability internals?)\b/gi, "private context")
+    .replace(/\b(private rankings?|rankings?)\b/gi, "private context")
+    .replace(/\b(?:open_pr_pressure|closed_pr_credibility|low_credibility|maintainer_lane|inactive_or_unknown_lane|issue_discovery_only|merged_pr_history_floor|issue_discovery_validity_floor)\b/gi, "private context")
+    .replace(/\b(?:credibility(?: updates?)?|closed pr credibility|low credibility|open pr pressure)\b/gi, "private context")
+    // Catch-all: a phrase replacement above (e.g. "score estimate"/"score preview") can leave a bare
+    // numeric score transition behind ("private context 32.5 -> 41.2"); redact those residual numbers too.
+    .replace(/\bprivate context\b\s+[-+]?\d+(?:\.\d+)?\s*(?:->|→|to)\s*[-+]?\d+(?:\.\d+)?/gi, "private context")
+    .replace(/\blikely_duplicate\b/gi, "possible overlap with existing work");
+  return sanitizeReviewabilityTerm(sanitized).replace(/private context(?:,\s*private context)+/gi, "private context");
+}

--- a/src/github/commands.ts
+++ b/src/github/commands.ts
@@ -1,3 +1,4 @@
+import { sanitizePublicComment } from "@loopover/engine";
 import { AGENT_COMMAND_COMMENT_MARKER } from "./comments";
 import {
   buildDidYouMeanSections,
@@ -1838,33 +1839,10 @@ function sanitizeFeedbackAnswerId(answerId: string): string {
   return answerId.replace(/[^A-Za-z0-9_.:-]/g, "").slice(0, 120);
 }
 
-export function sanitizePublicComment(value: string): string {
-  const sanitized = value
-    .replace(/\bopen pr count\s+\d+\s+exceeds threshold\s+\d+\b\.?/gi, "private context")
-    .replace(/\bopen pr count is at or below\s+\d+\b/gi, "private context")
-    .replace(/\bmerged pr count\s+\d+\s+is below upstream floor\s+\d+\b\.?/gi, "private context")
-    .replace(/\bissue-discovery history\s*\(\s*\d+\s+valid solved,\s*credibility\s+[-+]?\d+(?:\.\d+)?\s*\)\s+is below upstream floors\s*\(\s*\d+\s+valid solved,\s*[-+]?\d+(?:\.\d+)?\s+credibility\s*\)\.?/gi, "private context")
-    .replace(/\bcredibility\s+[-+]?\d+(?:\.\d+)?\s+is below floor\s+[-+]?\d+(?:\.\d+)?\b\.?/gi, "private context")
-    .replace(/\b(?:effective|projected|estimated) score(?: changes?)?\b(?:\s+from)?\s+[-+]?\d+(?:\.\d+)?\s*(?:->|→|to)\s*[-+]?\d+(?:\.\d+)?/gi, "private context")
-    .replace(/\b(raw trust scores?|trust scores?|wallets?|hotkeys?|coldkeys?|seed phrases?|mnemonics?)\b/gi, "private context")
-    .replace(/\b(public score estimates?|estimated scores?|score estimates?|estimated rewards?|rewards?|reward estimates?|payouts?|farming|scoreability|score previews?|projected score changes?)\b/gi, "private context")
-    .replace(/\b(private reviewability|reviewability internals?)\b/gi, "private context")
-    .replace(/\b(private rankings?|rankings?)\b/gi, "private context")
-    .replace(/\b(?:open_pr_pressure|closed_pr_credibility|low_credibility|maintainer_lane|inactive_or_unknown_lane|issue_discovery_only|merged_pr_history_floor|issue_discovery_validity_floor)\b/gi, "private context")
-    .replace(/\b(?:credibility(?: updates?)?|closed pr credibility|low credibility|open pr pressure)\b/gi, "private context")
-    // Catch-all: a phrase replacement above (e.g. "score estimate"/"score preview") can leave a bare
-    // numeric score transition behind ("private context 32.5 -> 41.2"); redact those residual numbers too.
-    .replace(/\bprivate context\b\s+[-+]?\d+(?:\.\d+)?\s*(?:->|→|to)\s*[-+]?\d+(?:\.\d+)?/gi, "private context")
-    .replace(/\blikely_duplicate\b/gi, "possible overlap with existing work");
-  return sanitizeReviewabilityTerm(sanitized).replace(/private context(?:,\s*private context)+/gi, "private context");
-}
-
-function sanitizeReviewabilityTerm(value: string): string {
-  return value.replace(/\breviewability\b/gi, (match, offset, fullText: string) => {
-    const prefix = fullText.slice(Math.max(0, offset - "@loopover ".length), offset).toLowerCase();
-    return prefix.endsWith("@loopover ") ? match : "private context";
-  });
-}
+// sanitizePublicComment + its sanitizeReviewabilityTerm helper were extracted to gittensory-engine's
+// public-comment-redaction.ts (#4882) -- pure, high-fan-in string logic. Imported at the top of this file and
+// re-exported here so every existing consumer's `../github/commands` import path is unchanged.
+export { sanitizePublicComment };
 
 /** @internal Exported for unit tests of ask citation helpers. */
 export const githubCommandsInternals = {

--- a/test/unit/public-comment-redaction.test.ts
+++ b/test/unit/public-comment-redaction.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "vitest";
+// #4882: the public-comment redactor was extracted out of src/github/commands.ts into gittensory-engine. This
+// suite drives the moved module directly (proving portability + covering the engine source) and asserts the
+// redaction behavior is byte-for-byte what the command layer relied on.
+import { sanitizePublicComment } from "../../packages/gittensory-engine/src/public-comment-redaction";
+
+describe("sanitizePublicComment (extracted to @loopover/engine, #4882)", () => {
+  it("redacts private scoring / credibility / threshold phrases to 'private context'", () => {
+    expect(sanitizePublicComment("open pr count 12 exceeds threshold 10.")).toBe("private context");
+    expect(sanitizePublicComment("open pr count is at or below 5")).toBe("private context");
+    expect(sanitizePublicComment("merged pr count 3 is below upstream floor 8.")).toBe("private context");
+    expect(sanitizePublicComment("credibility -2.5 is below floor -1.0.")).toBe("private context");
+    expect(
+      sanitizePublicComment(
+        "issue-discovery history (2 valid solved, credibility -3) is below upstream floors (5 valid solved, -1 credibility).",
+      ),
+    ).toBe("private context");
+  });
+
+  it("redacts reward/wallet/ranking/internal-key terminology (surrounding text preserved)", () => {
+    expect(sanitizePublicComment("your estimated rewards and payouts")).toBe("your private context and private context");
+    // Comma-separated markers collapse to a single 'private context' via the dedup pass.
+    expect(sanitizePublicComment("raw trust scores, wallets, hotkeys, coldkeys")).toBe("private context");
+    expect(sanitizePublicComment("private rankings")).toBe("private context");
+    expect(sanitizePublicComment("open_pr_pressure and low_credibility")).toBe("private context and private context");
+    expect(sanitizePublicComment("likely_duplicate")).toBe("possible overlap with existing work");
+  });
+
+  it("redacts a score transition and collapses a residual bare numeric transition + repeated markers", () => {
+    // "estimated score from 32.5 -> 41.2" → phrase redaction, then the catch-all eats the residual numbers.
+    expect(sanitizePublicComment("estimated score from 32.5 -> 41.2")).toBe("private context");
+    expect(sanitizePublicComment("score preview 10 to 20")).toBe("private context");
+    // Repeated adjacent markers collapse to a single one.
+    expect(sanitizePublicComment("rewards, payouts")).toBe("private context");
+  });
+
+  it("redacts a bare 'reviewability' but keeps the literal @loopover reviewability command name", () => {
+    expect(sanitizePublicComment("check the reviewability internals")).toBe("check the private context");
+    // A bare 'reviewability' NOT preceded by '@loopover ' (and not caught by an earlier phrase) is redacted.
+    expect(sanitizePublicComment("the reviewability of this PR")).toBe("the private context of this PR");
+    expect(sanitizePublicComment("run @loopover reviewability to see it")).toBe(
+      "run @loopover reviewability to see it",
+    );
+  });
+
+  it("leaves ordinary text untouched (pure, no false positives)", () => {
+    expect(sanitizePublicComment("Thanks for the contribution — merged!")).toBe(
+      "Thanks for the contribution — merged!",
+    );
+    expect(sanitizePublicComment("")).toBe("");
+  });
+});


### PR DESCRIPTION
Closes #4882

## What

Extracts `sanitizePublicComment` (and its private `sanitizeReviewabilityTerm` helper) out of the I/O-heavy `src/github/commands.ts` command layer into a dedicated pure module in the shared engine:

- **new** `packages/gittensory-engine/src/public-comment-redaction.ts` — the redactor, verbatim.
- **barrel** `packages/gittensory-engine/src/index.ts` — re-exports `sanitizePublicComment`.
- **shim** `src/github/commands.ts` — imports it from `@loopover/engine` and re-exports it, so every existing `../github/commands` import path stays byte-for-byte unchanged.
- **new** `test/unit/public-comment-redaction.test.ts` — engine-level suite locking the redaction contract.

## Why

Per #4882 (sweep for pure logic stranded inside I/O-bound files), `sanitizePublicComment` is the strongest candidate in `commands.ts`:

- **Genuinely pure** — deterministic `String.replace` chains, no D1 / no `Env` / no network.
- **Highest fan-in** — it is imported *back out* of the command module by 10+ consumers across the review stack (api/routes, footer, mcp/server, notifications, queue/processors, queue-intelligence, review/enrichment-wire, review/planner, scenarios). Living in the command layer forced all of them to depend on the whole I/O module just to reach one string function.

Relocating it into the engine lets the self-host backend and the miner reuse the redactor directly, without pulling in the command layer.

## Behavior

Identical. The move is verbatim; the only edits are the `import` + `export` wiring. The new suite covers every redaction branch — threshold/credibility phrases, reward/wallet/ranking/internal-key terminology, residual numeric score-transition collapse, the `@loopover reviewability` command-name carve-out, and the pass-through of ordinary text — at **100% line and branch** on the moved module.

## Follow-up candidates (same sweep)

For future PRs under #4882, other pure, side-effect-free helpers still stranded in `commands.ts`: `suggestCommand`, `isMaintainerAssociation`, `isMaintainerOnlyCommand`, `isAiCostBearingCommand`. Each is an isolated, testable string/predicate function with the same extraction profile.
