### PR TITLE
feat(selfhost): add a post-deploy auto-pause regression gate

### DIFF
--- a/apps/loopover-ui/src/routes/docs.self-hosting-operations.tsx
+++ b/apps/loopover-ui/src/routes/docs.self-hosting-operations.tsx
@@ -1129,6 +1129,37 @@ docker inspect --format '{{.Config.Image}}' "$(docker compose ps -q loopover)"`}
         .
       </p>
 
+      <h3>Optional: auto-pause on a post-deploy regression</h3>
+      <p>
+        <code>scripts/selfhost-post-update-regression-gate.sh</code> (#5736) goes one step further
+        than the post-update checklist above: it verifies the service doesn&apos;t just come back
+        up, but <em>stays</em> up once real traffic starts flowing. It observes a window of the{" "}
+        <code>loopover</code> service&apos;s own logs for a dead-job spike (every attempt exhausted
+        its retries) and, if the count exceeds a threshold, automatically flips the DB-backed global
+        kill-switch (<code>global_agent_controls.frozen</code>) so a bad deploy that starts silently
+        failing jobs pauses every agent write action fleet-wide instead of accumulating failures
+        until you notice. It never depends on the optional observability profile
+        (Prometheus/Grafana/Loki) being enabled -- it reads the service&apos;s own logs directly,
+        the same way <code>docker compose logs loopover</code> always works regardless of which
+        profiles you&apos;ve opted into. Run it after <code>selfhost-post-update-check.sh</code>{" "}
+        passes, once you&apos;re ready to let real webhook traffic through -- it blocks for the full
+        observation window by design (3 minutes by default):
+      </p>
+      <CodeBlock
+        lang="bash"
+        code={`./scripts/selfhost-post-update-regression-gate.sh
+
+# Tune the observation window and/or the dead-job threshold that triggers the pause
+SELFHOST_REGRESSION_WINDOW_SECONDS=300 SELFHOST_REGRESSION_JOB_DEAD_THRESHOLD=10 \\
+  ./scripts/selfhost-post-update-regression-gate.sh`}
+      />
+      <p>If it trips, clear the pause once you&apos;ve confirmed the regression is fixed:</p>
+      <CodeBlock
+        lang="bash"
+        code={`docker compose exec -T postgres psql -U loopover -d loopover \\
+  -c "UPDATE global_agent_controls SET frozen = 0 WHERE id = 'singleton';"`}
+      />
+
       <h3>Rollback: no dedicated command</h3>
       <p>
         There is no <code>rollback</code> script. Rolling back means re-running one of the two

--- a/scripts/selfhost-post-update-regression-gate.sh
+++ b/scripts/selfhost-post-update-regression-gate.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Post-deploy regression auto-pause gate (#5736).
+#
+# selfhost-post-update-check.sh verifies the service came back up; this verifies it STAYS up once
+# real traffic starts flowing. Observes a window of the loopover service's own logs for a dead-job
+# spike (every attempt exhausted its retries -- `"event":"job_dead"`, emitted regardless of which
+# optional observability profile is enabled, so this never depends on Prometheus/Grafana/Loki being
+# opted into) and, if the count exceeds a threshold, automatically flips the DB-backed global
+# kill-switch (global_agent_controls.frozen, #audit-§5.2) so a bad deploy that starts silently
+# failing jobs pauses every agent write action fleet-wide instead of accumulating failures until a
+# human notices. Run this AFTER selfhost-post-update-check.sh passes, once you're ready to let real
+# webhook traffic through -- it blocks for the full observation window by design.
+#
+#   ./scripts/selfhost-post-update-regression-gate.sh
+#
+# Optional knobs:
+#   SELFHOST_REGRESSION_WINDOW_SECONDS=180   (default) how long to observe before evaluating
+#   SELFHOST_REGRESSION_JOB_DEAD_THRESHOLD=5 (default) dead-job count that triggers the pause
+set -euo pipefail
+
+SERVICE="${SELFHOST_SERVICE:-loopover}"
+POSTGRES_SERVICE="${SELFHOST_POSTGRES_SERVICE:-postgres}"
+POSTGRES_USER_NAME="${POSTGRES_USER:-loopover}"
+POSTGRES_DB_NAME="${POSTGRES_DB:-loopover}"
+WINDOW_SECONDS="${SELFHOST_REGRESSION_WINDOW_SECONDS:-180}"
+THRESHOLD="${SELFHOST_REGRESSION_JOB_DEAD_THRESHOLD:-5}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/selfhost-deploy-common.sh
+. "$SCRIPT_DIR/lib/selfhost-deploy-common.sh"
+
+require_cmd docker
+docker compose version >/dev/null
+
+if [[ ! "$WINDOW_SECONDS" =~ ^[0-9]+$ ]]; then
+  echo "selfhost regression gate: warning — invalid SELFHOST_REGRESSION_WINDOW_SECONDS=$WINDOW_SECONDS (using 180)" >&2
+  WINDOW_SECONDS=180
+fi
+if [[ ! "$THRESHOLD" =~ ^[0-9]+$ ]]; then
+  echo "selfhost regression gate: warning — invalid SELFHOST_REGRESSION_JOB_DEAD_THRESHOLD=$THRESHOLD (using 5)" >&2
+  THRESHOLD=5
+fi
+
+mapfile -t compose_args < <(compose_file_args)
+
+container_id="$(docker compose "${compose_args[@]}" ps -q "$SERVICE" 2>/dev/null || true)"
+if [ -z "$container_id" ]; then
+  echo "error: $SERVICE is not running" >&2
+  exit 1
+fi
+
+# Anchored to NOW, not deploy time: this only ever counts failures from this script's own
+# observation window, never carrying over pre-existing failures from before it started.
+since_marker="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+echo "selfhost regression gate: observing $SERVICE for ${WINDOW_SECONDS}s (auto-pause threshold: >${THRESHOLD} dead jobs)"
+sleep "$WINDOW_SECONDS"
+
+job_dead_count="$(docker compose "${compose_args[@]}" logs --since "$since_marker" "$SERVICE" 2>/dev/null | grep -c '"event":"job_dead"' || true)"
+
+echo "selfhost regression gate: $job_dead_count dead job(s) observed in the last ${WINDOW_SECONDS}s"
+
+if [ "$job_dead_count" -le "$THRESHOLD" ]; then
+  echo "selfhost regression gate: ok (within threshold)"
+  exit 0
+fi
+
+echo "selfhost regression gate: ⚠ $job_dead_count dead job(s) exceeds threshold of $THRESHOLD -- pausing the fleet-wide kill-switch" >&2
+
+if ! docker compose "${compose_args[@]}" exec -T "$POSTGRES_SERVICE" psql -U "$POSTGRES_USER_NAME" -d "$POSTGRES_DB_NAME" -v ON_ERROR_STOP=1 -c \
+  "INSERT INTO global_agent_controls (id, frozen, updated_at, updated_by) VALUES ('singleton', 1, CURRENT_TIMESTAMP, 'selfhost-post-update-regression-gate.sh') ON CONFLICT(id) DO UPDATE SET frozen = excluded.frozen, updated_at = excluded.updated_at, updated_by = excluded.updated_by;" \
+  >/dev/null; then
+  echo "error: failed to write the DB kill-switch -- PAUSE MANUALLY: set AGENT_ACTIONS_PAUSED=true in .env and restart the $SERVICE service, or run the UPDATE above by hand against $POSTGRES_SERVICE" >&2
+  exit 1
+fi
+
+echo "selfhost regression gate: global_agent_controls.frozen = 1 -- every agent write action is now paused fleet-wide until an operator clears it (UPDATE global_agent_controls SET frozen = 0 WHERE id = 'singleton')" >&2
+exit 1

--- a/test/unit/selfhost-post-update-regression-gate-script.test.ts
+++ b/test/unit/selfhost-post-update-regression-gate-script.test.ts
@@ -1,0 +1,189 @@
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { delimiter, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const SCRIPT = resolve("scripts/selfhost-post-update-regression-gate.sh");
+const sandboxDirs: string[] = [];
+
+afterEach(() => {
+  while (sandboxDirs.length > 0) {
+    const dir = sandboxDirs.pop();
+    if (dir) rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function writeExecutable(path: string, contents: string) {
+  writeFileSync(path, contents);
+  chmodSync(path, 0o755);
+}
+
+// Stub `docker` responds to exactly the subcommands the script issues: `compose version` (a no-op
+// readiness probe), `compose ... ps -q <service>` (container id), `compose ... logs --since ...
+// <service>` (the job_dead log lines under test, controlled via DEAD_JOB_LOG_LINES), and
+// `compose ... exec -T postgres psql ...` (the kill-switch write, controlled via PSQL_EXIT_CODE and
+// recorded to PSQL_CALL_LOG so a test can assert on the exact SQL sent).
+function createSandbox() {
+  const base = mkdtempSync(join(tmpdir(), "gittensory-selfhost-regression-gate-"));
+  sandboxDirs.push(base);
+  const bin = join(base, "bin");
+  mkdirSync(bin, { recursive: true });
+  writeFileSync(join(base, "docker-compose.yml"), "services: {}\n");
+
+  writeExecutable(
+    join(bin, "docker"),
+    `#!/usr/bin/env bash
+set -euo pipefail
+if [ "$1" = "compose" ] && [ "$2" = "version" ]; then
+  exit 0
+fi
+if [ "$1" = "compose" ]; then
+  shift
+  # Skip past the -f FILE args compose_file_args emits.
+  args=()
+  while [ $# -gt 0 ]; do
+    args+=("$1")
+    shift
+  done
+  # args now e.g.: -f docker-compose.yml ps -q loopover
+  sub=""
+  for a in "\${args[@]}"; do
+    if [ "$a" = "ps" ] || [ "$a" = "logs" ] || [ "$a" = "exec" ]; then
+      sub="$a"
+      break
+    fi
+  done
+  case "$sub" in
+    ps)
+      if [ "\${SIMULATE_NOT_RUNNING:-}" = "1" ]; then
+        exit 0
+      fi
+      printf 'container-1\\n'
+      exit 0
+      ;;
+    logs)
+      printf '%s' "\${DEAD_JOB_LOG_LINES:-}"
+      exit 0
+      ;;
+    exec)
+      printf '%s\\n' "\${args[*]}" >> "\${PSQL_CALL_LOG:-/dev/null}"
+      exit "\${PSQL_EXIT_CODE:-0}"
+      ;;
+    *)
+      exit 0
+      ;;
+  esac
+fi
+exit 0
+`,
+  );
+
+  writeExecutable(
+    join(bin, "sleep"),
+    `#!/usr/bin/env bash
+exit 0
+`,
+  );
+
+  return { base, bin };
+}
+
+function run(env: Record<string, string>) {
+  const { base, bin } = createSandbox();
+  const psqlCallLog = join(base, "psql-calls.log");
+  const result = spawnSync("bash", [SCRIPT], {
+    cwd: base,
+    encoding: "utf8",
+    env: { ...process.env, PATH: `${bin}${delimiter}${process.env.PATH ?? ""}`, PSQL_CALL_LOG: psqlCallLog, ...env },
+  });
+  let psqlCalls = "";
+  try {
+    psqlCalls = readFileSync(psqlCallLog, "utf8");
+  } catch {
+    psqlCalls = "";
+  }
+  return { ...result, psqlCalls };
+}
+
+describe("selfhost-post-update-regression-gate.sh", () => {
+  it("passes cleanly and never touches the kill-switch when dead-job count is within threshold", () => {
+    const result = run({ DEAD_JOB_LOG_LINES: "" });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("0 dead job(s)");
+    expect(result.stdout).toContain("ok (within threshold)");
+    expect(result.psqlCalls).toBe("");
+  });
+
+  it("stays within threshold at exactly the configured boundary (5 dead jobs, default threshold 5)", () => {
+    const fiveDeadJobs = Array.from({ length: 5 }, () => '{"level":"error","event":"job_dead","id":"x"}').join("\n");
+
+    const result = run({ DEAD_JOB_LOG_LINES: fiveDeadJobs });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stdout).toContain("5 dead job(s)");
+    expect(result.stdout).toContain("ok (within threshold)");
+    expect(result.psqlCalls).toBe("");
+  });
+
+  it("trips the auto-pause and writes the DB kill-switch once the dead-job count exceeds the threshold", () => {
+    const sixDeadJobs = Array.from({ length: 6 }, () => '{"level":"error","event":"job_dead","id":"x"}').join("\n");
+
+    const result = run({ DEAD_JOB_LOG_LINES: sixDeadJobs });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("6 dead job(s) exceeds threshold of 5");
+    expect(result.stderr).toContain("global_agent_controls.frozen = 1");
+    expect(result.psqlCalls).toContain("global_agent_controls");
+    expect(result.psqlCalls).toContain("frozen");
+    expect(result.psqlCalls).toContain("selfhost-post-update-regression-gate.sh");
+  });
+
+  it("respects a configured custom threshold and window", () => {
+    const twoDeadJobs = Array.from({ length: 2 }, () => '{"level":"error","event":"job_dead","id":"x"}').join("\n");
+
+    const result = run({ DEAD_JOB_LOG_LINES: twoDeadJobs, SELFHOST_REGRESSION_JOB_DEAD_THRESHOLD: "1", SELFHOST_REGRESSION_WINDOW_SECONDS: "5" });
+
+    expect(result.status).toBe(1);
+    expect(result.stdout).toContain("observing loopover for 5s (auto-pause threshold: >1 dead jobs)");
+    expect(result.stderr).toContain("2 dead job(s) exceeds threshold of 1");
+  });
+
+  it("reports (and does not crash on) a failed kill-switch write, with manual-pause guidance", () => {
+    const sixDeadJobs = Array.from({ length: 6 }, () => '{"level":"error","event":"job_dead","id":"x"}').join("\n");
+
+    const result = run({ DEAD_JOB_LOG_LINES: sixDeadJobs, PSQL_EXIT_CODE: "1" });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("failed to write the DB kill-switch");
+    expect(result.stderr).toContain("PAUSE MANUALLY");
+    expect(result.stderr).toContain("AGENT_ACTIONS_PAUSED=true");
+  });
+
+  it("falls back to safe defaults for non-numeric window/threshold settings without evaluating them as Bash arithmetic", () => {
+    const marker = join(tmpdir(), `gittensory-regression-gate-injection-${process.pid}`);
+    rmSync(marker, { force: true });
+
+    const result = run({
+      DEAD_JOB_LOG_LINES: "",
+      SELFHOST_REGRESSION_WINDOW_SECONDS: `bad[$(touch ${marker})]`,
+      SELFHOST_REGRESSION_JOB_DEAD_THRESHOLD: `bad[$(touch ${marker})]`,
+    });
+
+    expect(result.status, result.stderr).toBe(0);
+    expect(result.stderr).toContain("invalid SELFHOST_REGRESSION_WINDOW_SECONDS");
+    expect(result.stderr).toContain("invalid SELFHOST_REGRESSION_JOB_DEAD_THRESHOLD");
+    expect(result.stdout).toContain("threshold: >5 dead jobs");
+    // The marker file must never be created -- proves the malicious value was never `eval`'d/interpolated
+    // into an arithmetic context, only ever compared against the numeric-only regex.
+    expect(existsSync(marker)).toBe(false);
+  });
+
+  it("refuses and never sleeps out the observation window when the service is not running", () => {
+    const result = run({ DEAD_JOB_LOG_LINES: "", SIMULATE_NOT_RUNNING: "1" });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain("loopover is not running");
+    expect(result.stdout).not.toContain("observing loopover");
+  });
+});


### PR DESCRIPTION
## Summary
- New `scripts/selfhost-post-update-regression-gate.sh`: complements `selfhost-post-update-check.sh`'s immediate health probe by watching for a regression that only shows up once real traffic starts flowing.
- Observes a configurable window of the `loopover` service's own logs for a dead-job spike (`"event":"job_dead"` -- every attempt that exhausted its retries) and, if the count exceeds a threshold, automatically flips the DB-backed global kill-switch (`global_agent_controls.frozen`) so a bad deploy that starts silently failing jobs pauses every agent write action fleet-wide instead of accumulating failures until an operator notices.
- Deliberately reads the service's own logs directly (not Prometheus) so it never depends on the optional `observability` compose profile being enabled -- every self-host deployment has this regardless of which profiles it opts into.
- Documented in the self-hosting operations guide, alongside the post-update checklist.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx tsx scripts/check-docs-drift.mjs`
- [x] Real end-to-end script execution against a stubbed `docker`/`docker compose` (7 test cases: within-threshold no-op, exact-boundary no-op, over-threshold auto-pause with the actual kill-switch SQL asserted, custom threshold/window, failed kill-switch write with manual-pause guidance, non-numeric-input injection safety, service-not-running refusal)