### PR TITLE
fix(rebrand): rename double-underscore global identifiers missed by Phase 6

### DIFF
--- a/apps/loopover-extension/content.js
+++ b/apps/loopover-extension/content.js
@@ -182,7 +182,7 @@ function renderActions(body, actions) {
 }
 
 if (globalThis.__LOOPOVER_EXTENSION_TEST__) {
-  globalThis.__gittensoryContentInternals = {
+  globalThis.__loopoverContentInternals = {
     matchGitHubPageTarget,
     matchPullRequestTarget,
     renderPullContext,

--- a/apps/loopover-miner-extension/background.js
+++ b/apps/loopover-miner-extension/background.js
@@ -1,8 +1,8 @@
 import "./opportunity-badge.js";
 import "./toolbar-badge.js";
 
-const badgeApi = globalThis.__gittensoryMinerOpportunityBadge;
-const toolbarBadgeApi = globalThis.__gittensoryMinerToolbarBadge;
+const badgeApi = globalThis.__loopoverMinerOpportunityBadge;
+const toolbarBadgeApi = globalThis.__loopoverMinerToolbarBadge;
 
 const PING_MESSAGE = "gittensory-miner:ping";
 const ISSUE_CONTEXT_MESSAGE = "gittensory-miner:issue-context";
@@ -172,7 +172,7 @@ if (chrome.action && chrome.storage.onChanged) {
 }
 
 if (globalThis.__LOOPOVER_MINER_EXTENSION_TEST__) {
-  globalThis.__gittensoryMinerBackgroundInternals = {
+  globalThis.__loopoverMinerBackgroundInternals = {
     PING_MESSAGE,
     ISSUE_CONTEXT_MESSAGE,
     SYNC_RANKED_CANDIDATES_MESSAGE,

--- a/apps/loopover-miner-extension/content.js
+++ b/apps/loopover-miner-extension/content.js
@@ -1,4 +1,4 @@
-const badgeApi = globalThis.__gittensoryMinerOpportunityBadge;
+const badgeApi = globalThis.__loopoverMinerOpportunityBadge;
 
 const target = matchGitHubIssueTarget(location.pathname);
 
@@ -69,7 +69,7 @@ function renderOpportunityBadge(container, payload, nowMs = Date.now()) {
 }
 
 if (globalThis.__LOOPOVER_MINER_EXTENSION_TEST__) {
-  globalThis.__gittensoryMinerContentInternals = {
+  globalThis.__loopoverMinerContentInternals = {
     matchGitHubIssueTarget,
     findIssueSidebar,
     renderOpportunityBadge,

--- a/apps/loopover-miner-extension/opportunity-badge.js
+++ b/apps/loopover-miner-extension/opportunity-badge.js
@@ -108,8 +108,8 @@ const opportunityBadgeApi = {
   renderOpportunityBadgeMarkup,
 };
 
-globalThis.__gittensoryMinerOpportunityBadge = opportunityBadgeApi;
+globalThis.__loopoverMinerOpportunityBadge = opportunityBadgeApi;
 
 if (globalThis.__LOOPOVER_MINER_EXTENSION_TEST__) {
-  globalThis.__gittensoryMinerOpportunityBadgeTestExports = opportunityBadgeApi;
+  globalThis.__loopoverMinerOpportunityBadgeTestExports = opportunityBadgeApi;
 }

--- a/apps/loopover-miner-extension/options.js
+++ b/apps/loopover-miner-extension/options.js
@@ -52,7 +52,7 @@ function normalizeMinerUiUrl(text) {
 }
 
 if (globalThis.__LOOPOVER_MINER_EXTENSION_TEST__) {
-  globalThis.__gittensoryMinerOptionsInternals = {
+  globalThis.__loopoverMinerOptionsInternals = {
     parseWatchedRepos,
     parseRankedCandidatesJson,
     removeLegacyDiscoveryIndexUrl,

--- a/apps/loopover-miner-extension/test/helpers.ts
+++ b/apps/loopover-miner-extension/test/helpers.ts
@@ -186,10 +186,10 @@ export async function loadExtensionModules(options: ChromeMockOptions = {}) {
 
   return {
     ...harness,
-    opportunityExports: globalThis.__gittensoryMinerOpportunityBadgeTestExports as OpportunityBadgeExports,
-    toolbarApi: globalThis.__gittensoryMinerToolbarBadge as {
+    opportunityExports: globalThis.__loopoverMinerOpportunityBadgeTestExports as OpportunityBadgeExports,
+    toolbarApi: globalThis.__loopoverMinerToolbarBadge as {
       computeToolbarBadge: (rankedCandidates: unknown) => { text: string; backgroundColor: string };
     },
-    backgroundInternals: globalThis.__gittensoryMinerBackgroundInternals as BackgroundInternals,
+    backgroundInternals: globalThis.__loopoverMinerBackgroundInternals as BackgroundInternals,
   };
 }

--- a/apps/loopover-miner-extension/toolbar-badge.js
+++ b/apps/loopover-miner-extension/toolbar-badge.js
@@ -32,9 +32,9 @@ export function computeToolbarBadge(rankedCandidates) {
 }
 
 // Expose on a global too — the background service worker reads this the same way it reads
-// `__gittensoryMinerOpportunityBadge`, so the extension's VM-based test harness (which cannot evaluate ESM
+// `__loopoverMinerOpportunityBadge`, so the extension's VM-based test harness (which cannot evaluate ESM
 // `import` bindings) can drive it without a module loader.
-globalThis.__gittensoryMinerToolbarBadge = {
+globalThis.__loopoverMinerToolbarBadge = {
   computeToolbarBadge,
   TOOLBAR_BADGE_HAS_DATA_COLOR,
   TOOLBAR_BADGE_EMPTY_COLOR,

--- a/test/unit/extension-content.test.ts
+++ b/test/unit/extension-content.test.ts
@@ -88,7 +88,7 @@ function loadContentInternals() {
   context.globalThis = context;
   const vmContext = createContext(context);
   new Script(contentScript).runInContext(vmContext);
-  return vmContext.__gittensoryContentInternals as {
+  return vmContext.__loopoverContentInternals as {
     matchGitHubPageTarget: (
       pathname: string,
     ) => { kind: "pull_request"; owner: string; repo: string; pullNumber: number } | { kind: "issue"; owner: string; repo: string; issueNumber: number } | null;

--- a/test/unit/miner-extension-content.test.ts
+++ b/test/unit/miner-extension-content.test.ts
@@ -231,7 +231,7 @@ describe("miner extension opportunity badge", () => {
     new Script(optionsScript).runInContext(vmContext);
     await flushPromises();
 
-    const internals = vmContext.__gittensoryMinerOptionsInternals as { MAX_RANKED_CANDIDATES_JSON_BYTES: number };
+    const internals = vmContext.__loopoverMinerOptionsInternals as { MAX_RANKED_CANDIDATES_JSON_BYTES: number };
     elements["#rankedCandidatesJson"].value = "x".repeat(internals.MAX_RANKED_CANDIDATES_JSON_BYTES + 1);
     await elements["#settings"].dispatchSubmit();
 
@@ -487,7 +487,7 @@ function loadBadgeInternals() {
   context.globalThis = context;
   const vmContext = createContext(context);
   new Script(badgeScript).runInContext(vmContext);
-  return vmContext.__gittensoryMinerOpportunityBadgeTestExports as {
+  return vmContext.__loopoverMinerOpportunityBadgeTestExports as {
     lookupRankedOpportunity: (ranked: unknown[], repoFullName: string, issueNumber: number) => Record<string, unknown> | null;
     formatOpportunityBadge: (entry: Record<string, unknown>) => { tier: string; score: string; why: string };
     formatLastSyncedLabel: (savedAt: unknown, nowMs: number) => string | null;
@@ -502,7 +502,7 @@ function loadContentInternals() {
   const badge = loadBadgeInternals();
   const context: Record<string, unknown> = {
     __LOOPOVER_MINER_EXTENSION_TEST__: true,
-    __gittensoryMinerOpportunityBadge: badge,
+    __loopoverMinerOpportunityBadge: badge,
     location: { pathname: "/JSONbored/gittensory/pull/146" },
     document: {
       querySelector: () => null,
@@ -514,7 +514,7 @@ function loadContentInternals() {
   context.globalThis = context;
   const vmContext = createContext(context);
   new Script(contentScript).runInContext(vmContext);
-  return vmContext.__gittensoryMinerContentInternals as {
+  return vmContext.__loopoverMinerContentInternals as {
     matchGitHubIssueTarget: (
       pathname: string,
     ) => { kind: "issue"; owner: string; repo: string; issueNumber: number } | null;
@@ -550,7 +550,7 @@ function loadBackgroundInternals({
   new Script(badgeScript).runInContext(vmContext);
   const backgroundForTest = backgroundScript.replace(/^import\s+["'][^"']+["'];\s*/gm, "");
   new Script(backgroundForTest).runInContext(vmContext);
-  return vmContext.__gittensoryMinerBackgroundInternals as {
+  return vmContext.__loopoverMinerBackgroundInternals as {
     loadIssueOpportunityContext: (message: {
       owner: string;
       repo: string;
@@ -579,7 +579,7 @@ function loadOptionsInternals() {
   context.globalThis = context;
   const vmContext = createContext(context);
   new Script(optionsScript).runInContext(vmContext);
-  return vmContext.__gittensoryMinerOptionsInternals as {
+  return vmContext.__loopoverMinerOptionsInternals as {
     parseWatchedRepos: (text: string) => string[];
     parseRankedCandidatesJson: (text: string) => unknown[];
     removeLegacyDiscoveryIndexUrl: () => Promise<void>;

--- a/test/unit/miner-extension-live-fetch.test.ts
+++ b/test/unit/miner-extension-live-fetch.test.ts
@@ -80,7 +80,7 @@ function loadBackgroundWithFakeChrome({
   const vmContext = createContext(context);
   new Script(backgroundScriptForVm()).runInContext(vmContext);
 
-  const internals = vmContext.__gittensoryMinerBackgroundInternals as {
+  const internals = vmContext.__loopoverMinerBackgroundInternals as {
     SYNC_RANKED_CANDIDATES_MESSAGE: string;
     DEFAULT_MINER_UI_URL: string;
     loadMinerUiUrl: () => Promise<string>;

--- a/test/unit/miner-toolbar-badge.test.ts
+++ b/test/unit/miner-toolbar-badge.test.ts
@@ -122,7 +122,7 @@ function loadBackground(
   new Script(opportunityBadgeScript).runInContext(vmContext);
   new Script(toolbarBadgeScript).runInContext(vmContext);
   new Script(backgroundScript).runInContext(vmContext);
-  const internals = vmContext.__gittensoryMinerBackgroundInternals as {
+  const internals = vmContext.__loopoverMinerBackgroundInternals as {
     refreshToolbarBadge: () => Promise<void>;
   };
   return {


### PR DESCRIPTION
## Summary
- Phase 6 (#5750) renamed most internal `gittensory*` code identifiers to `loopover*`, but 6 double-underscore-prefixed window-scoped globals used by the extension/miner-extension test-hook internals were accidentally excluded from both the initial rename pass and the later fix-up pass.
- Renames `__gittensoryMinerOpportunityBadge(TestExports)`, `__gittensoryMinerBackgroundInternals`, `__gittensoryMinerToolbarBadge`, `__gittensoryMinerOptionsInternals`, `__gittensoryMinerContentInternals`, and `__gittensoryContentInternals` to their `__loopover*` equivalents across 11 files (extension/miner-extension source + their unit tests).
- Closes out the remaining scope of rebrand epic #5705 Phase 6.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npx vitest run` — 16230 passed (2 pre-existing local-only failures in `miner-repo-clone.test.ts` unrelated to this change, caused by the local commit-signing gate on temp git repos, not present in CI)
- [x] `npm run docs:drift-check` / `npm run manifest:drift-check` clean
- [x] verified zero remaining matches for the 6 old identifier patterns repo-wide