### PR TITLE
refactor(engine): extract the pull-request-target-key parser into loopover-engine

### DIFF
--- a/packages/loopover-engine/src/index.ts
+++ b/packages/loopover-engine/src/index.ts
@@ -707,3 +707,7 @@ export {
 // hashing both Orb's self-host collector and AMS's export path use before repo/PR identifiers leave the
 // instance.
 export { generateAnonSecret, hmacAnonymize } from "./telemetry/anonymize.js";
+
+// Pure PR-target-key parser (#4882) -- parses `"<owner>/<repo>#<number>"` into its parts; extracted so the
+// D1-heavy repositories access layer no longer carries this stranded pure logic.
+export { parsePullRequestTargetKey } from "./parse-pull-request-target-key.js";

--- a/packages/loopover-engine/src/parse-pull-request-target-key.ts
+++ b/packages/loopover-engine/src/parse-pull-request-target-key.ts
@@ -1,0 +1,23 @@
+/**
+ * Parse a pull-request target key of the form `"<owner>/<repo>#<number>"` into its repo
+ * full-name and pull-number parts. Pure string parsing: returns `null` for any malformed
+ * input -- falsy input, a missing / leading / trailing `#`, a repo half without a `/`, or a
+ * non-integer / non-positive pull number.
+ */
+export function parsePullRequestTargetKey(
+  targetKey: string | null | undefined,
+): { repoFullName: string; pullNumber: number } | null {
+  if (!targetKey) return null;
+  const delimiter = targetKey.lastIndexOf("#");
+  if (delimiter <= 0 || delimiter === targetKey.length - 1) return null;
+  const repoFullName = targetKey.slice(0, delimiter);
+  const pullNumber = Number(targetKey.slice(delimiter + 1));
+  if (
+    !repoFullName.includes("/") ||
+    !Number.isInteger(pullNumber) ||
+    pullNumber <= 0
+  ) {
+    return null;
+  }
+  return { repoFullName, pullNumber };
+}

--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -1,3 +1,4 @@
+import { parsePullRequestTargetKey } from "@loopover/engine";
 import { and, asc, desc, eq, gte, inArray, not, or, sql, type SQL } from "drizzle-orm";
 import { getDb } from "./client";
 import {
@@ -3352,16 +3353,6 @@ function uniqueRepoNames(values: string[]): string[] {
     result.push(value);
   }
   return result;
-}
-
-function parsePullRequestTargetKey(targetKey: string | null | undefined): { repoFullName: string; pullNumber: number } | null {
-  if (!targetKey) return null;
-  const delimiter = targetKey.lastIndexOf("#");
-  if (delimiter <= 0 || delimiter === targetKey.length - 1) return null;
-  const repoFullName = targetKey.slice(0, delimiter);
-  const pullNumber = Number(targetKey.slice(delimiter + 1));
-  if (!repoFullName.includes("/") || !Number.isInteger(pullNumber) || pullNumber <= 0) return null;
-  return { repoFullName, pullNumber };
 }
 
 function maxIso(left: string | null | undefined, right: string | null | undefined): string | null {

--- a/test/unit/parse-pull-request-target-key.test.ts
+++ b/test/unit/parse-pull-request-target-key.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+// #4882: the pure PR-target-key parser now lives in loopover-engine, extracted out of the D1-heavy
+// repositories access layer. This suite drives it through the engine's public barrel and exercises every
+// branch so the moved code carries its own coverage.
+import { parsePullRequestTargetKey } from "../../packages/loopover-engine/src/index";
+
+describe("parsePullRequestTargetKey (#4882)", () => {
+  it("returns null for falsy input", () => {
+    expect(parsePullRequestTargetKey(null)).toBeNull();
+    expect(parsePullRequestTargetKey(undefined)).toBeNull();
+    expect(parsePullRequestTargetKey("")).toBeNull();
+  });
+
+  it("returns null when there is no '#', or it is leading or trailing", () => {
+    expect(parsePullRequestTargetKey("owner/repo")).toBeNull();
+    expect(parsePullRequestTargetKey("#5")).toBeNull();
+    expect(parsePullRequestTargetKey("owner/repo#")).toBeNull();
+  });
+
+  it("returns null when the repo half has no '/'", () => {
+    expect(parsePullRequestTargetKey("owner#5")).toBeNull();
+  });
+
+  it("returns null when the pull number is not a positive integer", () => {
+    expect(parsePullRequestTargetKey("owner/repo#abc")).toBeNull();
+    expect(parsePullRequestTargetKey("owner/repo#1.5")).toBeNull();
+    expect(parsePullRequestTargetKey("owner/repo#0")).toBeNull();
+    expect(parsePullRequestTargetKey("owner/repo#-3")).toBeNull();
+  });
+
+  it("parses a well-formed target key", () => {
+    expect(parsePullRequestTargetKey("owner/repo#42")).toEqual({
+      repoFullName: "owner/repo",
+      pullNumber: 42,
+    });
+  });
+
+  it("splits on the last '#' so a repo name containing '#' still parses", () => {
+    expect(parsePullRequestTargetKey("owner/re#po#7")).toEqual({
+      repoFullName: "owner/re#po",
+      pullNumber: 7,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Extracts the pure `parsePullRequestTargetKey` parser out of the D1-query-heavy `src/db/repositories.ts` and into `@loopover/engine` as a standalone, independently-tested function — the "sweep for pure logic stranded inside I/O-bound files" work from #4882. The parser (`"<owner>/<repo>#<number>"` → `{ repoFullName, pullNumber } | null`) has zero side effects, zero imports, and was module-private with only two in-file call sites, so it moves cleanly: the engine gains the function + a barrel export, and `repositories.ts` imports it (no behavior change at the two call sites).

Identified in the same file during the sweep and left as follow-up candidates (kept out to honor "one direction of movement per PR"): `intersectionCount`, `maxIso`, `escapeSqlLikePattern`.

Closes #4882

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #4882`).

## Validation

- [x] `git diff --check` — clean
- [ ] `npm run actionlint` — no workflow changes
- [x] `npm run typecheck` — passes (whole project; the new `@loopover/engine` import in `repositories.ts` resolves against the built engine)
- [x] `npm run test:coverage` — the new suite `test/unit/parse-pull-request-target-key.test.ts` drives the moved function through the engine barrel and covers **100% of statements/branches/functions/lines** on `parse-pull-request-target-key.ts` (verified via `coverage-summary.json`); `codecov/patch` measures only the diff, and the two consumer call sites are unchanged
- [ ] `npm run test:workers` — unaffected (no worker changes)
- [ ] `npm run build:mcp` / `test:mcp-pack` — unaffected (no MCP changes)
- [ ] `npm run ui:openapi:check` / `ui:lint` / `ui:typecheck` / `ui:build` — unaffected (no UI/OpenAPI changes)
- [ ] `npm audit --audit-level=moderate` — no dependency changes
- [x] New or changed behavior has unit tests for new branches — every branch of the parser (falsy input, missing/leading/trailing `#`, repo half without `/`, non-integer / non-positive pull number, valid, and last-`#` split) is exercised

If any required check was skipped, explain why:

- This is an isolated pure-function extraction touching only `src/db/repositories.ts` (−1 def, +1 import) and `packages/loopover-engine/src/**` (+ a test). It introduces no workflow, MCP, UI, OpenAPI, or dependency changes, so those gates are unaffected. I validated the parts that touch the change: whole-project `typecheck`, the engine build, the engine's own suite (550/550), and the new function's test at 100% coverage.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests — N/A (none).
- [x] API/OpenAPI/MCP behavior is updated and tested where needed — N/A (none).
- [x] UI changes use live API data or real empty/error/loading states — N/A (no UI changes).
- [x] Visible UI changes include a `UI Evidence` section — N/A (no UI/frontend/docs/extension changes).
- [x] Public docs/changelogs are updated where needed — N/A.

## Notes

- Pattern mirrors the merged engine extractions (e.g. #5701 deny-hook, #4252–#4254): new engine module + barrel export + a test that drives the moved code through the engine's public barrel so it carries its own coverage. `src/db` is outside `check-engine-parity`'s scope (`review`/`settings`/`signals` + named twins), so no parity twin is introduced.
