### PR TITLE
fix(review): never render a ❌ for a non-Gittensor contributor (#5100)

### DIFF
--- a/src/review/unified-comment-bridge.ts
+++ b/src/review/unified-comment-bridge.ts
@@ -116,12 +116,15 @@ export function verdictToRecommendation(verdict: Verdict): ReviewRecommendation 
 function rowState(resultCell: string): UnifiedSignalRow["state"] {
   if (resultCell.startsWith("✅")) return "ok";
   if (resultCell.startsWith("❌")) return "fail";
+  // A leading ℹ️ is an explicit neutral/informational marker (e.g. "no public Gittensor match", "none detected") —
+  // it must map to the `info` state, not fall through to `warn`, so a non-blocking row never renders as ⚠️.
+  if (resultCell.startsWith("ℹ️")) return "info";
   return "warn";
 }
 
 /** Strip the leading status icon from a result cell so it is not duplicated next to the unified icon. */
 function rowResultText(resultCell: string): string {
-  return resultCell.replace(/^[✅⚠️❌]+\s*/u, "").trim();
+  return resultCell.replace(/^[✅⚠️❌ℹ️]+\s*/u, "").trim();
 }
 
 /** Map the legacy panel signal rows → the unified table's rows (label/state/result/evidence). The

--- a/src/review/unified-comment.ts
+++ b/src/review/unified-comment.ts
@@ -198,7 +198,7 @@ export interface UnifiedReviewInput {
 /** One row of the readiness signal table (loopover side, host-provided; the engine adds Code review). */
 export interface UnifiedSignalRow {
   label: string;
-  state: "ok" | "warn" | "fail";
+  state: "ok" | "warn" | "fail" | "info";
   /** Short result text, e.g. "Linked", "25/25". */
   result?: string;
   /** Evidence cell, e.g. "#1372". */
@@ -296,7 +296,9 @@ const STATUS_META: Record<UnifiedCommentStatus, { alert: string; square: string;
   blocked: { alert: "CAUTION", square: "🟥", icon: "🛑" },
 };
 
-const SIGNAL_ICON: Record<UnifiedSignalRow["state"], string> = { ok: "✅", warn: "⚠️", fail: "❌" };
+// `info` is a neutral/grey state — informational, NEVER implying a warning (⚠️) or failure (❌). It backs rows like a
+// non-Gittensor contributor match or "no improvement detected" that are advisory context, not a reason to flag the PR.
+const SIGNAL_ICON: Record<UnifiedSignalRow["state"], string> = { ok: "✅", warn: "⚠️", fail: "❌", info: "ℹ️" };
 
 /** Derive the single unified status from reviewbot's decision/recs/CI + the host override. */
 export function deriveUnifiedStatus(input: UnifiedReviewInput, ctx: UnifiedCommentContext = {}): UnifiedCommentStatus {

--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -4957,8 +4957,11 @@ function contributorContextPanelResult(
   const login = pr.authorLogin ?? profile.login;
   const githubLink = `[${sanitizePanelText(login)}](${githubProfileUrl(login)})`;
   if (!confirmedMiner) {
+    // #5100 bug fix: a ❌ (hard-failure icon everywhere else in this table) directly contradicted the adjacent
+    // "not a blocker" text — every non-Gittensor contributor, the majority of PR authors on most repos, saw a red
+    // X on their own PR for something that was never a failure. This is a neutral/informational state, never ❌.
     return {
-      result: "❌ No public Gittensor match",
+      result: "ℹ️ No public Gittensor match",
       evidence: `${githubLink}; not a blocker.`,
       action: "No action.",
     };

--- a/test/unit/queue-4.test.ts
+++ b/test/unit/queue-4.test.ts
@@ -3016,7 +3016,9 @@ describe("queue processors", () => {
       // unified renderer's table only surfaces the first 3 of each row's 4 cells (Label/Result/Evidence, not
       // Action) — same as the adjacent "Gate result" row, which also never shows its own 4th cell here — so this
       // asserts against the 3 columns this renderer actually prints, not the row's full cells array.
-      expect(postedBody).toContain("| Improvement | ⚠️ ℹ️ None detected | value: none |");
+      // #5100: the "none detected" band is informational — a single neutral ℹ️. It formerly rendered "⚠️ ℹ️" (a
+      // warn icon prepended by the bridge PLUS an un-stripped legacy ℹ️ — a visible double-icon bug now fixed).
+      expect(postedBody).toContain("| Improvement | ℹ️ None detected | value: none |");
       // Public-safe regardless: no internal trust/economics fields leak through this new row either.
       expect(postedBody).not.toMatch(/wallet|hotkey|coldkey|reward|trust score/i);
     } finally {
@@ -3194,7 +3196,8 @@ describe("queue processors", () => {
       // The quadrant rating ("risk: low · value: none") threaded from the REAL slopBand computed this pass
       // (missingTestEvidence only, slopRisk 15 -> band "low") IS the concise Evidence cell (#5101) -- proving
       // processors.ts's hoisted slopBand reaches the rendered comment, not just computed and discarded.
-      expect(postedBody).toContain("| Improvement | ⚠️ ℹ️ None detected | risk: low · value: none |");
+      // #5100: single neutral ℹ️ (was the "⚠️ ℹ️" double-icon bug — see the sibling assertion above).
+      expect(postedBody).toContain("| Improvement | ℹ️ None detected | risk: low · value: none |");
       // Public-safe regardless: no internal trust/economics fields leak through the new quadrant clause either.
       expect(postedBody).not.toMatch(/wallet|hotkey|coldkey|reward|trust score/i);
     } finally {

--- a/test/unit/unified-comment-bridge.test.ts
+++ b/test/unit/unified-comment-bridge.test.ts
@@ -78,8 +78,18 @@ describe("panelRowsToSignalRows", () => {
   });
 
   it("maps a ❌ result cell to fail", () => {
-    const rows = panelRowsToSignalRows([{ key: "contributorContext", cells: ["Contributor context", "❌ No public Gittensor match", "octocat; not a blocker.", "No action."] }]);
+    const rows = panelRowsToSignalRows([{ key: "linkedIssue", cells: ["Linked issue", "❌ Missing linked issue", "no closes/fixes reference", "Link an issue."] }]);
     expect(rows[0]?.state).toBe("fail");
+  });
+
+  // #5100: a leading ℹ️ is a neutral/informational marker (e.g. a non-Gittensor contributor, "none detected") — it must
+  // map to the `info` state, NOT fall through to `warn`, and the icon must be stripped so it isn't doubled in the render.
+  it("maps a ℹ️ result cell to the neutral info state and strips the leading icon", () => {
+    const rows = panelRowsToSignalRows([
+      { key: "contributorContext", cells: ["Contributor context", "ℹ️ No public Gittensor match", "octocat; not a blocker.", "No action."] },
+    ]);
+    expect(rows[0]?.state).toBe("info");
+    expect(rows[0]?.result).toBe("No public Gittensor match");
   });
 });
 


### PR DESCRIPTION
## Summary

The readiness signal table had a row that visually contradicted its own evidence: for any author with no public Gittensor match, the **Contributor context** row rendered `❌ No public Gittensor match` — a hard-failure ❌ (the same icon the table uses for real blockers) — right next to evidence that literally said *"not a blocker."* Every non-Gittensor contributor, i.e. the majority of PR authors on most repos, saw a red X on their own PR for something that was never a failure.

The root cause is that the unified signal table only had three states — `ok` (✅) / `warn` (⚠️) / `fail` (❌) — with **no neutral state**, so a non-blocking row had nowhere to land but a warning or a failure. This PR adds a proper neutral **`info` (ℹ️)** state and routes the contributor row through it.

This is issue #5100's explicitly-independent bug fix ("the ❌→✅/neutral fix as its own clearly-flagged bug fix ... should ship even if the rest of the table redesign takes longer"). The broader table redesign, row-cutting, and Points Forecast — which #5100 lists as open questions for the maintainer — are addressed as **written recommendations** at the bottom of this description, not implemented, since they are the maintainer's call.

### The fix

- **`src/signals/engine.ts`** — `contributorContextPanelResult`: the non-confirmed branch now returns `ℹ️ No public Gittensor match` (was `❌ …`). Evidence and action are unchanged; it was always "not a blocker."
- **`src/review/unified-comment.ts`** — added `info` to the `UnifiedSignalRow["state"]` union and `info: "ℹ️"` to `SIGNAL_ICON`. A neutral/grey state that never implies ⚠️ or ❌.
- **`src/review/unified-comment-bridge.ts`** — `rowState` maps a leading `ℹ️` to `info` (instead of falling through to `warn`), and `rowResultText` now strips a leading `ℹ️` too.

### Bonus: a latent double-icon bug this also fixes

Because `ℹ️` previously fell through to `warn` **and** wasn't in the icon-strip set, the Improvement "none detected" row rendered as **`⚠️ ℹ️ None detected`** in the unified comment — a warning icon *plus* an un-stripped legacy ℹ️, two icons for one informational row. With the neutral state it renders as a single, correct `ℹ️ None detected`.

### Before → after (rendered signal table row)

```
Before:  | Contributor context | ❌ No public Gittensor match | octocat; not a blocker. |
After:   | Contributor context | ℹ️ No public Gittensor match | octocat; not a blocker. |

Before:  | Improvement | ⚠️ ℹ️ None detected | value: none |
After:   | Improvement | ℹ️ None detected     | value: none |
```

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves — `Closes #5100`.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (clean)
- [x] `npm run test:coverage` on the changed files — every changed line and both branches of the new `ℹ️` mapping are exercised (bridge `rowState`/`rowResultText`, the `SIGNAL_ICON` literal, and the non-confirmed contributor branch); `codecov/patch` diff is at 100%.
- [x] Full `vitest run` unit + integration suite green.
- [x] `npm run test:engine-parity` + `npm run test:live-gate-parity` green (the golden-comment comparison jobs — confirms no fixture rendered the old icons).
- [ ] `npm run test:workers`, `build:mcp`, `test:mcp-pack`, `ui:openapi:check`, `ui:lint`, `ui:typecheck`, `ui:build` — not exercised; this change is confined to `src/review` + `src/signals` comment rendering and touches no Worker binding, MCP surface, OpenAPI schema, or `apps/loopover-ui/**` code.

If any required check was skipped, explain why:

- The MCP/UI/OpenAPI/workers checks are for surfaces this PR does not touch. The relevant gate — typecheck, the full unit/integration suite, the parity golden-comparison jobs, and `codecov/patch` on the diff — is green locally.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, private keys, raw trust scores, private rankings, or private maintainer evidence exposed. (The changed row surfaces only a public GitHub username and a "not a blocker" note; queue-4's `not.toMatch(/wallet|hotkey|coldkey|reward|trust score/i)` assertion still passes over the rendered comment.)
- [x] Public GitHub text stays sanitized, low-noise, and implies no compensation guarantees or optimization tactics.
- [ ] Auth/cookie/CORS/GitHub App/Cloudflare/session — N/A, none changed.
- [ ] API/OpenAPI/MCP — N/A, none changed.
- [ ] UI changes — N/A. This renders a **PR-comment Markdown table** (backend), not an `apps/loopover-ui` page, so no UI Evidence screenshots apply. Before/after table rendering shown above.
- [ ] Public docs/changelogs — N/A.

## Notes

Per #5100's deliverables, the analysis it asks for (the parts that are maintainer decisions, not contributor changes):

### Recommendation — which of the three low-value rows to cut

- **Cut "Validation posture"** (`validationEvidence`). It restates the test/coverage signal that the dedicated coverage/test-evidence collapsible already presents in more detail — the same signal shown twice, exactly the redundancy #5100 flags.
- **Cut "Contributor workload"** (`openPrQueue` key). It surfaces the author's concurrent open-PR count, which is already conveyed — where it is actually actionable (collision risk) — by the open-PR/related-work signal. As a standalone row it is low-actionability noise.
- **Keep "Change scope"** (`reviewLoad`). It is the one row a maintainer uses to size review effort (size label / draft state / linked-issue burden) and is not redundant with anything else visible.

Net: three rows → one, raising signal density without losing anything a maintainer reads. Happy to do the cut in a follow-up once you confirm the call.

### Recommendation — Points Forecast: keep as a prototype, do not ship yet

A pre-merge "projected points" row would combine the repo's `emissionShare` / `labelMultipliers` (from `RepositoryRecord.registryConfig`) with the PR's current type-label. The data sources exist, but the **scoring algorithm it would forecast is Gittensor's, external to this repo** — any formula we commit to here can silently drift from the real one and would read as a payout promise (a public-safe-wording violation). Recommendation: **prototype only**, gated behind a flag and worded strictly as a non-guaranteed estimate, until it can be validated against Gittensor's actual scoring. Not in this PR.

### Note — surfacing per-repo credibility/score in the contributor row

#5100 also suggests replacing the confirmed-contributor evidence with the author's per-repo credibility/score from `GittensorContributorSnapshot.repositories[]`. That snapshot is **not currently threaded into `contributorContextPanelResult`** (its args are `pr`/`profile`/`detection`/`confirmedMiner`), so surfacing it is a small plumbing change best done as its own PR once the row redesign above is agreed. This PR ships the flagged ❌-contradiction fix, which stands on its own.

Closes #5100
