### PR TITLE
fix(api): audit registered-vs-installed dashboard/digest copy

### DIFF
--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -4748,11 +4748,18 @@ function buildDigestItems(args: {
   rateLimits: Awaited<ReturnType<typeof listLatestGitHubRateLimitObservations>>;
 }) {
   const items: Array<{ kind: "summary" | "review-now" | "queue" | "drift" | "install"; title: string; detail: string; meta?: string }> = [];
+  // Lead with `installed` (repos this instance actually operates on) rather than `registered` (gittensor-subnet
+  // membership, an opt-in plugin -- see gittensor-wire.ts). "0 registered" is the normal, expected headline for
+  // any operator who hasn't opted into the gittensor plugin and must not read as broken (#5026).
+  const installed = args.repositories.filter((repo) => repo.isInstalled).length;
   const registered = args.repositories.filter((repo) => repo.isRegistered).length;
   items.push({
     kind: "summary",
-    title: `${registered} registered repositories tracked`,
-    detail: `${args.repositories.length} repositories are present in the local LoopOver data cache.`,
+    title: `${installed} installed repositories tracked`,
+    detail:
+      registered > 0
+        ? `${args.repositories.length} repositories are present in the local LoopOver data cache; ${registered} registered with the gittensor plugin.`
+        : `${args.repositories.length} repositories are present in the local LoopOver data cache.`,
     meta: "registry",
   });
   const unhealthy = args.health.filter((record) => record.status !== "healthy");

--- a/src/services/operator-dashboard.ts
+++ b/src/services/operator-dashboard.ts
@@ -184,7 +184,13 @@ export async function buildOperatorDashboardPayload(
     metrics: [
       { label: "Active sessions", value: String(activeSessions), delta: "browser + CLI/MCP" },
       { label: "Installations", value: String(installations.length), delta: `${installedRepos} installed repos` },
-      { label: "Registered repos", value: String(registeredRepos), delta: registry ? `${registry.repoCount} in latest registry` : "registry missing" },
+      {
+        label: "Registered repos",
+        value: String(registeredRepos),
+        // A null registry is the normal, expected state for any operator who hasn't opted into the
+        // gittensor plugin (see gittensor-wire.ts) -- "missing" reads as broken when it isn't (#5026).
+        delta: registry ? `${registry.repoCount} in latest registry` : "gittensor plugin not enabled",
+      },
       { label: "Digest subscriptions", value: String(digestSubscriptions), delta: "store-only" },
       { label: "Product events", value: String(usageSummary.totalEvents), delta: `last ${windowDays} days` },
       { label: "Active users", value: String(usageSummary.activeActors), delta: `hashed, last ${windowDays} days` },

--- a/test/integration/api.test.ts
+++ b/test/integration/api.test.ts
@@ -509,6 +509,72 @@ describe("api routes", () => {
     expect(legacyPerRepoDrift.status).toBe(404);
   });
 
+  it("reads registered-repo copy as an honest, non-alarming state whether or not the gittensor plugin is opted into (#5026)", async () => {
+    const app = createApp();
+
+    // No registry snapshot ever persisted: the normal, expected state for an operator who hasn't opted
+    // into the gittensor plugin. "registered: 0" must not read as broken.
+    const unregisteredEnv = createTestEnv();
+    await upsertRepositoryFromGitHub(
+      unregisteredEnv,
+      { name: "installed-only", full_name: "acme/installed-only", private: false, owner: { login: "acme" }, default_branch: "main" },
+      321,
+    );
+    const unregisteredOperator = await app.request("/v1/app/operator-dashboard", { headers: apiHeaders(unregisteredEnv) }, unregisteredEnv);
+    expect(unregisteredOperator.status).toBe(200);
+    await expect(unregisteredOperator.json()).resolves.toMatchObject({
+      metrics: expect.arrayContaining([
+        expect.objectContaining({ label: "Registered repos", value: "0", delta: "gittensor plugin not enabled" }),
+      ]),
+    });
+    const unregisteredDigest = await app.request("/v1/app/digest", { headers: apiHeaders(unregisteredEnv) }, unregisteredEnv);
+    expect(unregisteredDigest.status).toBe(200);
+    await expect(unregisteredDigest.json()).resolves.toMatchObject({
+      items: expect.arrayContaining([
+        expect.objectContaining({
+          kind: "summary",
+          title: "1 installed repositories tracked",
+          detail: "1 repositories are present in the local LoopOver data cache.",
+        }),
+      ]),
+    });
+
+    // A registry snapshot IS persisted (gittensor plugin opted in somewhere): both copy surfaces should
+    // report the registered count honestly instead of the unregistered-branch wording.
+    const registeredEnv = createTestEnv();
+    await upsertRepositoryFromGitHub(
+      registeredEnv,
+      { name: "installed-and-registered", full_name: "acme/installed-and-registered", private: false, owner: { login: "acme" }, default_branch: "main" },
+      654,
+    );
+    await persistRegistrySnapshot(
+      registeredEnv,
+      normalizeRegistryPayload(
+        { "acme/installed-and-registered": { emission_share: 0.01, issue_discovery_share: 0, label_multipliers: {}, trusted_label_pipeline: false } },
+        { kind: "raw-github", url: "fixture://registered-registry" },
+        "2026-06-01T00:00:00.000Z",
+      ),
+    );
+    const registeredOperator = await app.request("/v1/app/operator-dashboard", { headers: apiHeaders(registeredEnv) }, registeredEnv);
+    expect(registeredOperator.status).toBe(200);
+    await expect(registeredOperator.json()).resolves.toMatchObject({
+      metrics: expect.arrayContaining([
+        expect.objectContaining({ label: "Registered repos", value: "1", delta: "1 in latest registry" }),
+      ]),
+    });
+    const registeredDigest = await app.request("/v1/app/digest", { headers: apiHeaders(registeredEnv) }, registeredEnv);
+    expect(registeredDigest.status).toBe(200);
+    await expect(registeredDigest.json()).resolves.toMatchObject({
+      items: expect.arrayContaining([
+        expect.objectContaining({
+          kind: "summary",
+          title: "1 installed repositories tracked",
+          detail: "1 repositories are present in the local LoopOver data cache; 1 registered with the gittensor plugin.",
+        }),
+      ]),
+    });
+  });
+
   it("serves upstream ruleset status, ruleset snapshots, and drift reports through private APIs", async () => {
     const app = createApp();
     const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "public-token" });
@@ -2351,7 +2417,7 @@ describe("api routes", () => {
     const emptyOperator = await app.request("/v1/app/operator-dashboard", { headers: apiHeaders(emptyEnv) }, emptyEnv);
     expect(emptyOperator.status).toBe(200);
     await expect(emptyOperator.json()).resolves.toMatchObject({
-      metrics: expect.arrayContaining([expect.objectContaining({ label: "Registered repos", delta: "registry missing" })]),
+      metrics: expect.arrayContaining([expect.objectContaining({ label: "Registered repos", delta: "gittensor plugin not enabled" })]),
       recommendationQuality: expect.objectContaining({
         empty: true,
         sparse: false,


### PR DESCRIPTION
## Summary

- Audits the "registered vs installed" dashboard/digest copy per #5016's final phase: since the gittensor plugin is now opt-in (#5028–#5025 all landed), `registeredRepos: 0` is the normal, expected state for most self-host operators and must not read as broken.
- `buildDigestItems` (`src/api/routes.ts`) now leads its summary item with `installed` repos — the correct "repos this instance operates on" signal — and only mentions the registered count when it's nonzero, instead of headlining `0 registered repositories tracked`.
- `buildOperatorDashboardPayload` (`src/services/operator-dashboard.ts`) replaces the `"registry missing"` delta (implies something is broken) with `"gittensor plugin not enabled"` (accurately describes why no registry snapshot has been persisted) when `registry` is `null`.
- `src/services/weekly-value-report.ts` was audited too and needs no change — its "Coverage: N registered repo(s)..." copy is already neutral at zero.
- No functional change: `isRegistered`/`isInstalled` computation and every other metric are untouched — wording only.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

Fixes #5026

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

All ran via `npm run test:ci` (the full local gate) plus `npm audit --audit-level=moderate`, both clean.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

Not applicable: this is a backend JSON copy change (digest/dashboard API response strings), not a rendered UI change — the generic `Stat` tile component that displays these fields is untouched.

## Notes

- Added a dedicated integration test (`test/integration/api.test.ts`) covering both branches for each changed conditional: no registry snapshot / zero registered repos, and a persisted registry snapshot / nonzero registered repos, asserting the exact copy on both `/v1/app/digest` and `/v1/app/operator-dashboard`.
- Updated the one pre-existing assertion that hardcoded the old `"registry missing"` string to match the new wording.
