### PR TITLE
docs(engine): record the scoring/rules twin convergence decision

### DIFF
--- a/packages/loopover-engine/docs/scoring-rules-twin-convergence.md
+++ b/packages/loopover-engine/docs/scoring-rules-twin-convergence.md
@@ -1,0 +1,79 @@
+# Scoring / rules twin convergence — decision record (#4881)
+
+The gate-decision "scoring/rules" logic has historically existed as hand-maintained **twin files** — one
+under the backend's `src/`, one under `@loopover/engine` — kept in sync by hand so the published
+`loopover-miner` / `loopover-mcp` CLIs can reach the same logic without importing the whole backend.
+This record captures the converge-or-keep-divergent decision for each remaining pair, per #4881. It is a
+decision, not a blanket policy: each pair was evaluated on its own.
+
+## Inventory
+
+### Already converged (host is a thin re-export shim over the engine) — keep as-is
+
+These pairs no longer diverge; the `src/` file is a thin shim and the single source of truth lives in the
+engine:
+
+| Host (shim) | Engine source of truth |
+| --- | --- |
+| `src/rules/predicted-gate.ts` | `packages/loopover-engine/src/predicted-gate.ts` |
+| `src/scoring/model.ts` | `packages/loopover-engine/src/scoring/model.ts` |
+| `src/scoring/preview.ts` | `packages/loopover-engine/src/scoring/preview.ts` |
+| `src/scoring/pending-pr-scenarios.ts` | `packages/loopover-engine/src/scoring/pending-pr-scenarios.ts` |
+
+No action: converging these was safe (the shared logic's dependencies were already engine-resident), so
+they are single-source with a shim and need no further work.
+
+### Remaining hand-maintained twin — **decision: keep divergent**
+
+| Host | Engine |
+| --- | --- |
+| `src/rules/advisory.ts` | `packages/loopover-engine/src/advisory/gate-advisory.ts` |
+
+This is the pair registered as `GATE_DECISION_TWIN_PAIR` in `scripts/check-engine-parity.ts`, the one pair
+that pair-registry guards with co-edit-or-version-bump enforcement rather than a byte-parity check.
+
+## Why the advisory twin stays divergent
+
+The two copies are deliberately **not** the same implementation, and converging them to one source would
+regress the very dependency-graph constraint the split exists to protect.
+
+The host copy (`src/rules/advisory.ts`) is wired into the full backend subsystem — its imports include:
+
+- `../signals/engine` (`CollisionCluster` / `CollisionReport`) — the ~5.8k-line signals-engine file,
+- `../signals/local-branch` (`isCodeFile`),
+- `../signals/test-evidence` (`isTestPath`),
+- `../scoring/preview` (`labelMatchesPattern`),
+
+alongside `duplicate-winner` and `change-guardrail`.
+
+The engine copy (`gate-advisory.ts`) deliberately imports **none** of those heavy modules. It draws its
+collision types from the slim `../types/predicted-gate-types`, matches labels through the small
+`../scoring/label-match` module instead of `scoring/preview`, and carries its own check-run sanitizer and
+default thresholds.
+
+If the engine copy were replaced by an import of the host copy, `@loopover/engine` — and therefore the
+published `loopover-miner` and `loopover-mcp` CLIs that depend on it — would transitively pull in
+`signals/engine`, `local-branch`, `test-evidence`, and `scoring/preview`. That is exactly the backend
+bloat the miner's dependency graph must not carry, and it is the "dependency-graph-size problem" #4881
+flags as the blocker to solve *before* converging.
+
+The alternative #4881 raises — a shared **type-only** import — does not resolve it either: the divergence
+is in *runtime* dependencies (collision-report building, `isCodeFile` / `isTestPath` classification, label
+matching), not just shared types. A type-only boundary would let both sides agree on shapes but would not
+let the engine reuse the host's runtime logic without dragging the heavy imports along.
+
+## Consequences and the co-edit obligation
+
+Because this pair stays divergent, contributors who change gate-decision behavior must edit **both** copies
+together (or bump the engine version and the `packages/loopover-miner/expected-engine.version` pin). This is
+enforced mechanically by `scripts/check-engine-parity.ts` (`GATE_DECISION_TWIN_PAIR` +
+`checkGateDecisionVersionBump` + the `GATE_DECISION_CORE_MARKERS` presence check), so a one-sided edit fails
+CI rather than silently drifting.
+
+## When to revisit
+
+Converge the advisory twin only once its heavy dependencies are themselves engine-resident as slim modules —
+i.e. after the collision-report building, `isCodeFile` / `isTestPath` classification, and label matching that
+`advisory.ts` relies on are extracted into `@loopover/engine` without pulling `signals/engine` along. At that
+point a single engine-hosted advisory source could serve both the backend and the miner without bloating the
+miner's dependency graph, and this decision should be reopened.


### PR DESCRIPTION
## Summary

Records the converge-or-keep-divergent **decision** #4881 asks for, one per scoring/rules `src/` ↔ `@loopover/engine` twin, as a decision record under `packages/loopover-engine/docs/`.

- **Already converged** (host is a thin shim, single-source): `src/rules/predicted-gate.ts`, `src/scoring/model.ts`, `src/scoring/preview.ts`, `src/scoring/pending-pr-scenarios.ts` — no action needed.
- **Remaining hand-maintained twin — decision: keep divergent:** `src/rules/advisory.ts` ↔ `packages/loopover-engine/src/advisory/gate-advisory.ts` (the `GATE_DECISION_TWIN_PAIR` guarded in `scripts/check-engine-parity.ts`).

The rationale is grounded in the actual imports: the host copy pulls `signals/engine`, `signals/local-branch`, `signals/test-evidence`, and `scoring/preview`; the engine copy deliberately imports **none** of them (slim `predicted-gate-types` + `scoring/label-match`). Collapsing to one source would drag the whole signals-engine into the published `loopover-miner`/`loopover-mcp` dependency graph — the exact bloat the split exists to avoid, and the "dependency-graph-size problem" the issue names. A type-only shared import doesn't resolve it (the divergence is in *runtime* deps, not types). The record also documents the co-edit obligation the parity script already enforces, and the criteria for revisiting.

Closes #4881

## Scope

- [x] Conventional Commit title (`docs(engine): …`).
- [x] Focused — a single decision-record doc, no code/behavior change.
- [x] Follows `CONTRIBUTING.md`; no `site/`/`CNAME`/VitePress.
- [x] Linked open issue: `Closes #4881`.

## Validation

- [x] `git diff --check` clean
- [x] `npm run docs:drift-check` passes
- [x] Every claim verified against the current tree (host/engine import sets, the already-shimmed pairs, the `GATE_DECISION_TWIN_PAIR` + version-bump enforcement, `expected-engine.version`).

If any required check was skipped, explain why:

- Docs-only change (one Markdown file, no `src/`/`packages/**/src` code) → no `typecheck`, coverage, `ui:*`, OpenAPI, migration, or workflow surface. Codecov `patch` has no coverable lines.

## Safety

- [x] No secrets, wallet/hotkey/coldkey, trust scores, rewards, private rankings, or private maintainer evidence — the doc describes module dependency structure only.
- [x] No public GitHub comment text change.
- [x] No auth/CORS/GitHub App/Cloudflare/session change.
- [x] No API/OpenAPI/MCP behavior change.
- [x] No UI change.
- [x] Documentation added under `packages/loopover-engine/docs/`; no changelog edit.
