### PR TITLE
docs(engine): document the deliberate gate-advisory twin divergence

### DIFF
--- a/packages/loopover-engine/src/advisory/gate-advisory.ts
+++ b/packages/loopover-engine/src/advisory/gate-advisory.ts
@@ -1,3 +1,11 @@
+// Gate-decision advisory logic — ENGINE copy. This is an intentionally-divergent twin of the host
+// src/rules/advisory.ts (#4518; keep-divergent decision recorded for #4881). This slimmed re-implementation uses
+// predicted-gate-types + ../scoring/label-match and deliberately imports none of ../signals/engine, isCodeFile, or
+// isTestPath, so @loopover/engine — and the CLI packages that consume it (packages/loopover-miner,
+// packages/loopover-mcp) — never pull the ~5,800-line signals/engine subsystem into their dependency graph. The
+// core gate-decision functions are kept structurally in lock-step with the host copy by
+// scripts/check-engine-parity.ts (GATE_DECISION_CORE_MARKERS); do NOT converge to a single source until that
+// dependency-graph constraint is solved — see #4881.
 import { randomUUID } from "node:crypto";
 import type {
   Advisory,

--- a/src/rules/advisory.ts
+++ b/src/rules/advisory.ts
@@ -1,3 +1,21 @@
+// Gate-decision advisory logic — HOST copy. This is an intentionally-divergent twin of the engine's
+// packages/loopover-engine/src/advisory/gate-advisory.ts (#4518; keep-divergent decision recorded for #4881). The
+// two are deliberately NOT converged to a single source.
+//
+// Why kept divergent: this host copy reaches into the full signals subsystem — `isCodeFile`
+// (../signals/local-branch, which transitively pulls the whole review-scoring / GitHub-API graph), `isTestPath`
+// (../signals/test-evidence), `labelMatchesPattern` (../scoring/preview), and the CollisionCluster/CollisionReport
+// types from the ~5,800-line ../signals/engine. The engine twin is a slimmed re-implementation (slim
+// predicted-gate-types + ../scoring/label-match, importing none of signals/engine) precisely so @loopover/engine —
+// and the CLI packages that depend on it (packages/loopover-miner, packages/loopover-mcp) — never drag
+// signals/engine and its subsystem into their dependency graph.
+//
+// What keeps this safe: scripts/check-engine-parity.ts (GATE_DECISION_CORE_MARKERS) asserts BOTH files still export
+// the core gate-decision functions (evaluateGateCheck / evaluateGateCheckCore / isConfiguredGateBlocker /
+// buildPullRequestAdvisory), so the gate *decision* stays in lock-step even though the surrounding types and
+// imports diverge. Do NOT converge these into a single shim until the dependency-graph-size constraint is solved
+// (e.g. a shared type-only module carrying CollisionReport without dragging the signals implementation along) — see
+// #4881.
 import type {
   Advisory,
   AdvisoryConclusion,


### PR DESCRIPTION
## Summary

Records the **converge-or-keep decision** for the gate-decision advisory twin pair (#4881), and documents it clearly for future contributors — the issue's deliverable ("a clear, documented decision — converge or keep-divergent — for every twin pair in this area").

**Decision: keep divergent.** The pair `src/rules/advisory.ts` (host) ↔ `packages/loopover-engine/src/advisory/gate-advisory.ts` (engine) is the one explicitly documented as deliberately divergent, so the issue's boundary applies: *"Don't converge the deliberately-divergent pair without first solving the dependency-graph-size problem it exists to avoid."*

This PR adds a header comment to **both** twins explaining:
- **Why they diverge:** the host copy reaches into the full signals subsystem — `isCodeFile` (`../signals/local-branch`, which transitively pulls the whole review-scoring / GitHub-API graph), `isTestPath`, `labelMatchesPattern` (`../scoring/preview`), and the `CollisionCluster`/`CollisionReport` types from the ~5,800-line `../signals/engine`. The engine copy is a slimmed re-implementation (slim `predicted-gate-types` + `../scoring/label-match`, importing none of `signals/engine`), precisely so `@loopover/engine` — and the CLI packages that consume it (`packages/loopover-miner`, `packages/loopover-mcp`) — never drag `signals/engine` and its subsystem into their dependency graph.
- **What keeps it safe:** `scripts/check-engine-parity.ts` (`GATE_DECISION_CORE_MARKERS`) asserts both files still export the core gate-decision functions (`evaluateGateCheck` / `evaluateGateCheckCore` / `isConfiguredGateBlocker` / `buildPullRequestAdvisory`), so the gate *decision* stays in lock-step even as the surrounding types/plumbing diverge.
- **The deferred alternative:** converging into one shim must wait until the dependency-graph constraint is solved (e.g. a shared type-only module carrying `CollisionReport` without dragging the signals implementation along).

**No gate-decision behavior changes** — this is a **comment-only** diff (+26 lines of documentation, zero code changes), which directly satisfies the issue's hard acceptance criterion ("this is the one phase where 'no behavior change' needs to be actively verified"). The host-vs-engine advisory-parity suites still pass identically, and the engine-parity check still reports all pairs agree.

> Note: this touches `src/rules/advisory.ts` (a guardrail path), so I expect the gate to hold it for maintainer review — which is appropriate, since the deliverable is a documented design decision.

## Scope

- [x] Conventional Commit title.
- [x] Focused; no unrelated changes.
- [x] Follows `CONTRIBUTING.md`; no `site/`/`CNAME`/lovable.
- [x] Linked a currently open issue — Closes #4881.

## Validation

- [x] `git diff --check` (comment-only; verified no non-comment line changed on either file)
- [x] `npm run typecheck` (root + `@loopover/engine` build) clean
- [x] Behavior unchanged: `advisory-live-parity`, `live-gate-parity`, `gate-check-policy`, `advisory-ai-routing-call-sites` all pass (136 tests) — the host and engine twins still produce identical gate decisions
- [x] `scripts/check-engine-parity.ts` passes (`20 pairs agree`; core `GATE_DECISION_CORE_MARKERS` intact)
- [x] `npm run command-reference:check` (unaffected)
- [x] Rebased/verified against the latest `main` immediately before pushing — no base conflict

Codecov `patch` has no coverable lines to measure (the diff is entirely comments).

If any required check was skipped, explain why:

- `actionlint`, `test:workers`, `ui:*`, `npm audit` were not run — no workflow, worker, UI, or dependency surface changed. The full `npm run test:ci` runs them on CI.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, private keys, raw trust scores, private rankings, or private maintainer evidence exposed. Documentation only; behavior byte-for-byte unchanged.
- [x] Public GitHub text stays sanitized and low-noise.
- [x] No changelog edited.

Auth/CORS/session, API/OpenAPI/MCP, and UI safety boxes are not applicable.
