### PR TITLE
feat(review): add aggregate fix-handoff block renderer

### DIFF
--- a/src/review/fix-handoff-render.ts
+++ b/src/review/fix-handoff-render.ts
@@ -11,6 +11,10 @@
 // already produced through the public-safe filter (InlineFinding.body/suggestion are sanitized upstream by
 // composeInlineFindings before they ever reach here — this module adds no new free text of its own beyond the
 // fixed label/marker strings below).
+//
+// Also renders the AGGREGATE flavor (#5102): buildFixHandoffAggregateBlock combines every finding into ONE
+// block for a single agent run over the whole PR, instead of one run per finding — same rendering contract,
+// still unwired (see that function's doc comment for why).
 import { LOCAL_WRITE_BOUNDARY } from "../mcp/local-write-tools";
 import type { InlineFinding } from "../services/ai-review";
 
@@ -79,4 +83,49 @@ export function buildFixHandoffBlock(finding: InlineFinding): FixHandoffBlock {
  *  nothing to hand off. */
 export function buildFixHandoffBlocks(findings: InlineFinding[]): FixHandoffBlock[] {
   return findings.map((finding) => buildFixHandoffBlock(finding));
+}
+
+/** A whole PR's findings rendered as ONE fix-handoff block, for a single local-agent run instead of one run per
+ *  finding (#5102). */
+export type FixHandoffAggregateBlock = {
+  findingCount: number;
+  /** The rendered, machine-readable markdown block (fenced items + an HTML comment marker a harness can grep for). */
+  body: string;
+  boundary: string;
+};
+
+/** The HTML comment marker prefixing the rendered aggregate block, distinct from FIX_HANDOFF_MARKER so a
+ *  harness can tell a per-finding block from the aggregate one. */
+const FIX_HANDOFF_AGGREGATE_MARKER = "<!-- loopover:fix-handoff-aggregate -->";
+
+/** One numbered list item for the aggregate block: same location/label/suggestion composition as
+ *  buildFixHandoffBlock, just indented under a shared numbered list instead of standing alone. */
+function fixHandoffAggregateItem(finding: InlineFinding, index: number): string {
+  const hasLine = Number.isInteger(finding.line) && finding.line > 0;
+  const safePath = markdownPathCodeText(finding.path);
+  const location = hasLine ? `${safePath}:${finding.line}` : `${safePath} (no specific line)`;
+  const label = finding.severity === "blocker" ? "Blocker" : "Nit";
+  const suggestion = finding.suggestion?.trim();
+  const suggestionBlock = suggestion ? `\n   \`\`\`\n   ${suggestion.replace(/\n/g, "\n   ")}\n   \`\`\`` : "";
+  return `${index + 1}. **${label} at \`${location}\`** — ${finding.body}${suggestionBlock}`;
+}
+
+/** PURE: combine every current finding into ONE fix-handoff block for a single local-agent run across the
+ *  whole PR (#5102) — the aggregate sibling of buildFixHandoffBlock/buildFixHandoffBlocks, mirroring
+ *  CodeRabbit's split between a per-finding "Prompt for AI Agents" collapsible and an aggregate "Fix all
+ *  issues" prompt (confirmed against live CodeRabbit-reviewed PRs — see #5102). Same boundary-safe,
+ *  content-only contract as the per-finding block: no server-side write, no execution, public-safe by
+ *  construction (every field rendered here was already made public-safe upstream by composeInlineFindings).
+ *  Empty in ⇒ null out — nothing to hand off. Render-only, like buildFixHandoffBlock was before its own
+ *  wiring PR (#4053) — NOT wired into the unified comment here; #5102 leaves per-finding vs aggregate vs
+ *  both as an open placement question for the wiring PR to resolve. */
+export function buildFixHandoffAggregateBlock(findings: InlineFinding[]): FixHandoffAggregateBlock | null {
+  if (findings.length === 0) return null;
+  const body = [
+    FIX_HANDOFF_AGGREGATE_MARKER,
+    `**Fix handoff — ${findings.length} finding${findings.length === 1 ? "" : "s"} across this PR**`,
+    ...findings.map((finding, index) => fixHandoffAggregateItem(finding, index)),
+    `\n_${LOCAL_WRITE_BOUNDARY}_`,
+  ].join("\n");
+  return { findingCount: findings.length, body, boundary: LOCAL_WRITE_BOUNDARY };
 }

--- a/test/unit/fix-handoff-render.test.ts
+++ b/test/unit/fix-handoff-render.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { buildFixHandoffBlock, buildFixHandoffBlocks } from "../../src/review/fix-handoff-render";
+import { buildFixHandoffAggregateBlock, buildFixHandoffBlock, buildFixHandoffBlocks } from "../../src/review/fix-handoff-render";
 import { LOCAL_WRITE_BOUNDARY } from "../../src/mcp/local-write-tools";
 import type { InlineFinding } from "../../src/services/ai-review";
 
@@ -81,5 +81,57 @@ describe("buildFixHandoffBlocks (#2175)", () => {
 
   it("returns an empty array for no findings (no-op)", () => {
     expect(buildFixHandoffBlocks([])).toEqual([]);
+  });
+});
+
+describe("buildFixHandoffAggregateBlock (#5102)", () => {
+  it("returns null for no findings (no-op)", () => {
+    expect(buildFixHandoffAggregateBlock([])).toBeNull();
+  });
+
+  it("combines a single finding into one block with singular wording", () => {
+    const block = buildFixHandoffAggregateBlock([finding()]);
+    expect(block?.findingCount).toBe(1);
+    expect(block?.body).toContain("**Fix handoff — 1 finding across this PR**");
+    expect(block?.body).toContain("1. **Blocker at `src/a.ts:12`** — Null check missing before dereference.");
+  });
+
+  it("combines multiple findings into one numbered block with plural wording", () => {
+    const block = buildFixHandoffAggregateBlock([
+      finding({ path: "a.ts", line: 1, severity: "blocker" }),
+      finding({ path: "b.ts", line: 2, severity: "nit" }),
+    ]);
+    expect(block?.findingCount).toBe(2);
+    expect(block?.body).toContain("**Fix handoff — 2 findings across this PR**");
+    expect(block?.body).toContain("1. **Blocker at `a.ts:1`**");
+    expect(block?.body).toContain("2. **Nit at `b.ts:2`**");
+  });
+
+  it("renders a path-only location when a finding has no commentable line", () => {
+    const block = buildFixHandoffAggregateBlock([finding({ line: 0 })]);
+    expect(block?.body).toContain("src/a.ts (no specific line)");
+    expect(block?.body).not.toContain("src/a.ts:0");
+  });
+
+  it("includes a fenced suggestion block, indented under its list item, when present", () => {
+    const block = buildFixHandoffAggregateBlock([finding({ suggestion: "if (!value) return null;" })]);
+    expect(block?.body).toContain("```\n   if (!value) return null;\n   ```");
+  });
+
+  it("omits the suggestion block entirely when absent or whitespace-only", () => {
+    expect(buildFixHandoffAggregateBlock([finding()])?.body).not.toContain("```");
+    expect(buildFixHandoffAggregateBlock([finding({ suggestion: "   " })])?.body).not.toContain("```");
+  });
+
+  it("always includes the exact LOCAL_WRITE_BOUNDARY text (boundary-safe)", () => {
+    const block = buildFixHandoffAggregateBlock([finding()]);
+    expect(block?.boundary).toBe(LOCAL_WRITE_BOUNDARY);
+    expect(block?.body).toContain(LOCAL_WRITE_BOUNDARY);
+  });
+
+  it("includes the aggregate HTML comment marker, distinct from the per-finding marker", () => {
+    const block = buildFixHandoffAggregateBlock([finding()]);
+    expect(block?.body).toContain("<!-- loopover:fix-handoff-aggregate -->");
+    expect(block?.body).not.toContain("<!-- loopover:fix-handoff -->");
   });
 });


### PR DESCRIPTION
## Summary

- #5102 asks for research + a prototype of a CodeRabbit-style "copy-paste this into your AI agent" fix suggestion. Gittensory already ships the **per-finding** half of this (`buildFixHandoffBlock`/`buildFixHandoffBlocks`, #2175, wired in #4053, behind `LOOPOVER_REVIEW_FIX_HANDOFF` + `review.fixHandoff`) — one collapsible per inline finding. This PR adds the **aggregate** half: `buildFixHandoffAggregateBlock`, which combines every current finding into ONE block for a single agent run over the whole PR, mirroring CodeRabbit's separate "Fix all issues with AI agents" feature.
- Research (real inspection, not assumed): CodeRabbit's per-finding prompt is a `<details><summary>🤖 Prompt for AI Agents</summary>` collapsible containing a plain-text (non-diff) fenced instruction — a generic "verify against current code, fix only still-valid issues" preamble followed by an exact `file:line` reference and the concrete change, confirmed directly against a live `coderabbitai[bot]` review comment (github.com/BAWES-Universe/bawes-new-website/pull/12). The same convention (same emoji, same collapsible shape) also appears from a different vendor bot on github.com/gravitl/netmaker/pull/4083, suggesting it's become a de facto format rather than one vendor's invention. I could not find a public example of CodeRabbit's own aggregate "Fix all issues" feature rendered as plain PR text within the search budget for this PR — every aggregate-style feature I found from other vendors (e.g. Datadog's BitsAI) renders as a clickable app link, not embeddable markdown, which is a real, useful data point for the design: an aggregate block that must survive copy-paste (this repo's own constraint, since gittensory has no app UI to link out to) is a different shape than a "click to open our app" button.
- This PR is the **render slice only** — same split this codebase already used for the per-finding version (`buildFixHandoffBlock` render slice landed in #3834 before its own wiring PR, #4053). `buildFixHandoffAggregateBlock` is pure, tested, and reuses the exact same public-safe/boundary-safe contract (`InlineFinding.body`/`suggestion` are already sanitized upstream by `composeInlineFindings`; same `LOCAL_WRITE_BOUNDARY` no-cloud-write text) — it is not wired into `unified-comment-bridge.ts` yet.
- That's deliberate: #5102 explicitly flags "per-finding vs. aggregate vs. both" and "opt-in vs. on-by-default" as **open questions for the maintainer to decide with real examples in hand**, not something a contributor PR should quietly settle by shipping one answer. This PR supplies the real example (see below) so that call can be made with actual output in front of you, without committing the live comment to an unreviewed layout.

## Real example output

For a held PR with 2 blocking findings (`InlineFinding[]` — same fixture shape the existing `buildFixHandoffBlock` tests use):

```
<!-- loopover:fix-handoff-aggregate -->
**Fix handoff — 2 findings across this PR**
1. **Blocker at `src/auth.ts:42`** — Null check missing before dereferencing `session.user`.
   ```
   if (!session.user) return null;
   ```
2. **Nit at `src/routes/profile.ts:18`** — Prefer the shared `formatDisplayName` helper over inlining the join here.

_This is a suggestion for your own local coding agent to apply — gittensory does not write to your repository._
```

## Recommendation (not implemented here — the maintainer's call per #5102)

Wire this alongside the existing per-finding blocks, gated by the SAME `LOOPOVER_REVIEW_FIX_HANDOFF` + `review.fixHandoff` toggle (no new config surface needed) — a repo that already opted into fix-handoff gets both forms, matching CodeRabbit's own choice to ship both rather than pick one. The per-finding blocks stay useful for reviewing one thing at a time inline; the aggregate block is what a contributor would paste for a single "fix everything this PR flagged" agent run. Happy to do the wiring PR once you confirm the shape above is right.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused (one render function + its tests) and does not mix unrelated changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves — `Closes #5102`.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` — clean
- [x] `npm run test:coverage` — full unsharded run green; the new function's lines and branches (empty list, single vs. plural wording, line vs. no-line, suggestion present/absent, both markers) are covered by `test/unit/fix-handoff-render.test.ts`
- [x] Full `vitest run` unit suite green (`fix-handoff-render`, `fix-handoff-collapsible`, `queue-4` — the suites that already exercise this feature family)

If any required check was skipped, explain why:

- `npm run test:workers`, `build:mcp`, `test:mcp-pack`, `ui:openapi:check`, `ui:lint`, `ui:typecheck`, `ui:build` — not exercised; this change is confined to `src/review/fix-handoff-render.ts` + its test file, touches no Worker binding, MCP surface, OpenAPI schema, or `apps/loopover-ui/**` code, and is not wired into any live code path yet.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, private keys, raw trust scores, private rankings, or private maintainer evidence exposed — the new function renders only fields `InlineFinding` already carries, which are made public-safe upstream by `composeInlineFindings` before they ever reach this renderer (same contract as the existing per-finding block).
- [x] Public GitHub text stays sanitized, low-noise, and implies no compensation guarantees or optimization tactics — reuses the exact `LOCAL_WRITE_BOUNDARY` "gittensory does not write to your repository" text every other local-execution artifact carries.
- [ ] Auth/cookie/CORS/GitHub App/Cloudflare/session — N/A, none changed.
- [ ] API/OpenAPI/MCP — N/A, none changed.
- [ ] UI changes — N/A. This is a backend markdown-block renderer, not wired into `apps/loopover-ui`.
- [ ] Public docs/changelogs — N/A. Not wired into any emission path yet, so the existing `LOOPOVER_REVIEW_FIX_HANDOFF` docs text (which already describes the flag generically) doesn't need updating for a prototype that isn't live.

## Notes

- Anchors: `buildFixHandoffBlock`/`buildFixHandoffBlocks` (`src/review/fix-handoff-render.ts`, #2175/#3834) for the per-finding precedent and render-slice-before-wiring-PR pattern; `buildBetaCollapsible` (`src/signals/engine.ts`, #5096/#5769) for the "shared reusable formatting helper" convention.

Closes #5102
