### PR TITLE
feat(review): synthesize the 'Contributor next steps' collapsible into a prioritized step

### DIFF
--- a/src/signals/engine.ts
+++ b/src/signals/engine.ts
@@ -4261,9 +4261,22 @@ function reviewContextBody(args: PublicSafeCollapsibleArgs): string[] {
   ];
 }
 
-/** "Contributor next steps" body — the deduped actionable steps (or a fallback when none). */
-function contributorNextStepsBody(nextSteps: string[]): string[] {
-  return nextSteps.length > 0 ? [...new Set(nextSteps)].map((step) => `- ${step}`) : ["- Keep the PR focused and include validation evidence before maintainer review."];
+/** "Contributor next steps" body (#5097). The Signals table's own Action column already lists every one of these
+ *  actions verbatim, so a flat re-listing here added nothing a reader hadn't already seen — which is why it read
+ *  as low-value. Instead this leads with the single highest-priority step as a "Start here" synthesis (the one
+ *  thing the flat table does not say) and points back to the table for the remainder, so the underlying signal
+ *  (`publicSafeNextSteps`: the maintainer-lane note, the readiness actions, the finding actions) is preserved in
+ *  full above while this collapsible finally earns its place. Falls back to the generic line when there are no
+ *  steps at all. */
+export function contributorNextStepsBody(nextSteps: string[]): string[] {
+  const deduped = [...new Set(nextSteps)];
+  if (deduped.length === 0) return ["- Keep the PR focused and include validation evidence before maintainer review."];
+  const [first, ...rest] = deduped;
+  if (rest.length === 0) return [`- **Start here:** ${first}`];
+  return [
+    `- **Start here:** ${first}`,
+    `- Then work through the remaining ${rest.length} step${rest.length === 1 ? "" : "s"} in the Signals table above.`,
+  ];
 }
 
 /** #5096: one reusable convention for EXPERIMENTAL ("beta") collapsibles in the public PR comment, so a reader
@@ -4590,7 +4603,7 @@ export function buildPublicPrIntelligenceComment(args: {
     "<details>",
     "<summary>Contributor next steps</summary>",
     "",
-    ...(nextSteps.length > 0 ? [...new Set(nextSteps)].map((step) => `- ${step}`) : ["- Keep the PR focused and include validation evidence before maintainer review."]),
+    ...contributorNextStepsBody(nextSteps),
     "",
     "</details>",
     "",

--- a/test/unit/unified-comment-parity.test.ts
+++ b/test/unit/unified-comment-parity.test.ts
@@ -7,6 +7,7 @@ import {
   buildPublicPrPanelSignalRows,
   buildPublicSafeCollapsibles,
   buildQueueHealth,
+  contributorNextStepsBody,
   detectGittensorContributor,
 } from "../../src/signals/engine";
 import { buildUnifiedCommentBody } from "../../src/review/unified-comment-bridge";
@@ -168,6 +169,39 @@ describe("converged comment ↔ legacy panel parity (#unified-comment)", () => {
     // The "Contributor next steps" body is single-sourced with the legacy panel's deduped next-steps list.
     const nextSteps = collapsibles.find((section) => section.title === "Contributor next steps")!;
     expect(nextSteps.body.length).toBeGreaterThan(0);
+  });
+
+  describe("contributorNextStepsBody redesign (#5097)", () => {
+    it("leads with a prioritized 'Start here' step and points to the table for the rest", () => {
+      expect(contributorNextStepsBody(["Add a linked issue.", "Fix the failing check.", "Add tests."])).toEqual([
+        "- **Start here:** Add a linked issue.",
+        "- Then work through the remaining 2 steps in the Signals table above.",
+      ]);
+    });
+
+    it("uses the singular 'step' when exactly one remains", () => {
+      expect(contributorNextStepsBody(["Add a linked issue.", "Fix the failing check."])).toEqual([
+        "- **Start here:** Add a linked issue.",
+        "- Then work through the remaining 1 step in the Signals table above.",
+      ]);
+    });
+
+    it("shows only the single step when there is exactly one", () => {
+      expect(contributorNextStepsBody(["Add a linked issue."])).toEqual(["- **Start here:** Add a linked issue."]);
+    });
+
+    it("dedupes repeated steps before prioritizing", () => {
+      expect(contributorNextStepsBody(["Add tests.", "Add tests.", "Fix the check."])).toEqual([
+        "- **Start here:** Add tests.",
+        "- Then work through the remaining 1 step in the Signals table above.",
+      ]);
+    });
+
+    it("falls back to the generic line when there are no steps at all", () => {
+      expect(contributorNextStepsBody([])).toEqual([
+        "- Keep the PR focused and include validation evidence before maintainer review.",
+      ]);
+    });
   });
 
   it("the legacy panel still renders 'Maintainer notes' inline (private section is unchanged, just not shared)", () => {


### PR DESCRIPTION
## Summary

The "Contributor next steps" collapsible re-listed the exact same `action` text already shown verbatim in the Signals table's own Action column, so it added nothing a careful reader hadn't already seen — which is why it read as low-value (#5097). This redesigns it (option **b** from the issue) to **earn its place**: it leads with the single highest-priority step as a **"Start here"** synthesis — the one thing the flat table does not say — and points back to the table for the remainder, so no underlying signal is lost.

## Written comparison (cut vs. redesign)

| | (a) Cut entirely | **(b) Redesign → prioritized synthesis (chosen)** |
|---|---|---|
| Removes the redundant flat re-list | ✅ | ✅ |
| Adds something the table doesn't already say | ❌ (nothing left) | ✅ a single "do this first" priority |
| Preserves the underlying signal | Signal only in the table | Full signal in the table **and** a synthesized lead here |
| Risk | Loses a section a maintainer may scan for the *first* action | Minimal — behavior is otherwise unchanged |

I chose **(b)** because the issue's expected outcome is "either it's gone, or it earns its place by saying something the table doesn't already say," and a prioritized "Start here" is genuinely new information (the flat table gives no ordering). `publicSafeNextSteps` is unchanged, so the maintainer-lane note + readiness actions + finding actions are all still computed and still rendered in full in the table above.

### Example output for representative PR states

**Clean PR (no actions)** — unchanged fallback:
```
- Keep the PR focused and include validation evidence before maintainer review.
```

**PR with 2 blockers** (e.g. missing linked issue + a failing check):
```
Before:  - Add a linked issue.
         - Fix the failing check.
After:   - **Start here:** Add a linked issue.
         - Then work through the remaining 1 step in the Signals table above.
```

**Maintainer-lane PR** (lead is the maintainer-lane context line, remaining actions pointed to the table):
```
- **Start here:** Treat this as maintainer-lane context rather than normal contributor-lane activity.
- Then work through the remaining 2 steps in the Signals table above.
```

## No dependency lost

- Both render sites — the converged comment (`buildPublicSafeCollapsibles`) and the legacy panel (`buildPublicPrIntelligenceComment`) — now route through the shared `contributorNextStepsBody`, so they can never diverge (the parity test asserts this).
- `publicSafeNextSteps` (the underlying signal) is untouched; nothing downstream reads the collapsible's rendered body as a data source (it's a display-only string), and there is no OpenAPI schema for the collapsible body.

## Scope

- [x] Conventional Commit title.
- [x] Focused; no unrelated changes.
- [x] Follows `CONTRIBUTING.md`; no `site/`/`CNAME`/lovable.
- [x] Linked a currently open issue — Closes #5097.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (root + `@loopover/engine` build) clean
- [x] `npm run test:coverage` — every changed line of `contributorNextStepsBody` (empty / single / multi-step, singular vs plural, dedup) is at **100% line + branch** coverage; 5 new deterministic assertions in `unified-comment-parity.test.ts` lock in the "Start here" format, and the existing converged-vs-legacy parity test still passes (both sites single-sourced).
- [x] Broader comment-consumer suites pass unchanged (`signals-coverage`, `scenario-summary`, `github-commands`, `mcp-release-candidate` — 141 tests).
- [x] `scripts/check-engine-parity.ts` passes (`contributorNextStepsBody` is not a parity marker); docs-drift + `command-reference:check` pass.
- [x] Rebased onto the latest `main` immediately before pushing — no base conflict.

If any required check was skipped, explain why:

- `actionlint`, `test:workers`, `ui:*`, `npm audit` were not run — no workflow, worker, UI, or dependency surface changed. The full `npm run test:ci` runs them on CI.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, private keys, raw trust scores, private rankings, or private maintainer evidence exposed. Public-safe filtering (`containsPrivatePublicTerm`, `publicSafePreflightFindings`) is unchanged; this only reshapes already-public-safe strings.
- [x] Public GitHub text stays sanitized and low-noise.
- [x] No changelog edited.

Auth/CORS/session, API/OpenAPI/MCP, and UI safety boxes are not applicable.
