### PR TITLE
feat(miner): honor kill-switch mid-attempt during iterate-loop

### DIFF
--- a/packages/loopover-engine/src/index.ts
+++ b/packages/loopover-engine/src/index.ts
@@ -263,6 +263,7 @@ export {
 export {
   runIterateLoop,
   type IterateLoopDeps,
+  type IterateLoopShouldAbort,
   type IterateLoopInput,
   type IterateLoopIterationRecord,
   type IterateLoopOutcome,

--- a/packages/loopover-engine/src/miner/iterate-loop.ts
+++ b/packages/loopover-engine/src/miner/iterate-loop.ts
@@ -86,6 +86,15 @@ export type IterateLoopInput = {
   rejectionSignaled: boolean;
 };
 
+/** Optional cooperative abort probed BEFORE every driver invocation (#5670). A bare `true` or
+ *  `{ abort: true }` abandons with `kill_switch_engaged` without calling the driver for that iteration. */
+export type IterateLoopShouldAbort =
+  | boolean
+  | {
+      abort: boolean;
+      reason?: string | undefined;
+    };
+
 export type IterateLoopDeps = {
   driver: CodingAgentDriver;
   runSlopAssessment: SelfReviewAdapterDeps["runSlopAssessment"];
@@ -94,6 +103,8 @@ export type IterateLoopDeps = {
    *  injected-dependency discipline elsewhere (never a hardcoded `Date.now()` a test can't control). Defaults
    *  to the real `Date.now` when omitted. */
   nowMs?: (() => number) | undefined;
+  /** Mid-iteration kill-switch / pause probe (#5670). Omitted = never abort mid-loop (pre-#5670 behavior). */
+  shouldAbort?: (() => IterateLoopShouldAbort) | undefined;
 };
 
 /** The terminal outcomes a full loop run can end in -- never `"continue"`, which is only ever a per-iteration,
@@ -186,8 +197,39 @@ function attemptLogEventTypeForDecision(decision: IterateLoopDecision): AttemptL
   // reads as aborted; a genuine failure to converge (ceiling reached, or stuck with no progress) reads as
   // failed. Both are still `action: "abandon"` in the decision itself -- this is only a coarser attempt-log
   // classification layered on top, for the fixed six-value ATTEMPT_LOG_EVENT_TYPES vocabulary.
-  if (decision.abandonReason === "rejection_signaled" || decision.abandonReason === "self_review_ambiguous") return "attempt_aborted";
+  if (
+    decision.abandonReason === "rejection_signaled" ||
+    decision.abandonReason === "self_review_ambiguous" ||
+    decision.abandonReason === "kill_switch_engaged"
+  ) {
+    return "attempt_aborted";
+  }
   return "attempt_failed";
+}
+
+function resolveShouldAbort(deps: IterateLoopDeps): { abort: boolean; reason: string } {
+  if (typeof deps.shouldAbort !== "function") {
+    return { abort: false, reason: "" };
+  }
+  const raw = deps.shouldAbort();
+  if (typeof raw === "boolean") {
+    return {
+      abort: raw,
+      reason: raw
+        ? "Kill-switch engaged mid-attempt; abandoning without starting another driver iteration."
+        : "",
+    };
+  }
+  if (raw && typeof raw === "object" && raw.abort === true) {
+    return {
+      abort: true,
+      reason:
+        typeof raw.reason === "string" && raw.reason.trim()
+          ? raw.reason.trim()
+          : "Kill-switch engaged mid-attempt; abandoning without starting another driver iteration.",
+    };
+  }
+  return { abort: false, reason: "" };
 }
 
 /** A logging failure must never crash the loop or alter its decision -- mirrors the governor-ledger and
@@ -318,6 +360,39 @@ async function runIterateLoopCore(input: IterateLoopInput, deps: IterateLoopDeps
   let totalCostUsd = 0;
 
   for (let iterationNumber = 1; iterationNumber <= maxIterations; iterationNumber += 1) {
+    // Cooperative mid-iteration halt (#5670): probed BEFORE each driver call so a kill-switch that trips
+    // after iteration N prevents iteration N+1 (and prevents the first iteration when already tripped).
+    // Hard SIGKILL of an in-flight driver call is intentionally out of scope — matching #5437's budget
+    // abort, which also stops between iterations rather than interrupting a running LLM turn.
+    const abort = resolveShouldAbort(deps);
+    if (abort.abort) {
+      const decision: IterateLoopDecision = {
+        action: "abandon",
+        abandonReason: "kill_switch_engaged",
+        reason: abort.reason,
+      };
+      safeAppendAttemptLogEvent(deps, {
+        eventType: "attempt_aborted",
+        attemptId: input.attemptId,
+        actionClass: "iterate_loop",
+        mode: input.mode,
+        reason: decision.reason,
+        payload: {
+          iterationNumber: iterationNumber - 1,
+          action: decision.action,
+          abandonReason: decision.abandonReason,
+        },
+      });
+      return {
+        outcome: "abandon",
+        finalDecision: decision,
+        iterationsUsed: iterationNumber - 1,
+        totalTurnsUsed,
+        totalCostUsd,
+        iterations,
+      };
+    }
+
     const iterationStartMs = nowMs();
     const driverResult = await runDriverSafely(input, deps, {
       attemptId: input.attemptId,

--- a/packages/loopover-engine/src/miner/iterate-policy.ts
+++ b/packages/loopover-engine/src/miner/iterate-policy.ts
@@ -27,7 +27,15 @@ export type IterateLoopAction = "continue" | "handoff" | "abandon";
 
 /** Every distinct reason `decideNextAction` can abandon for -- kept as a closed literal union so a caller
  *  recording the decision (the attempt-log primitive, per #2333) has a stable, exhaustive vocabulary. */
-export type AbandonReason = "rejection_signaled" | "self_review_ambiguous" | "max_iterations_reached" | "cost_ceiling_reached" | "no_progress";
+export type AbandonReason =
+  | "rejection_signaled"
+  | "self_review_ambiguous"
+  | "max_iterations_reached"
+  | "cost_ceiling_reached"
+  | "no_progress"
+  /** Mid-attempt emergency stop (#5670): kill-switch (or operator pause acting as a stop signal) tripped
+   *  between iterate-loop iterations — cooperative, not a hard SIGKILL of an in-flight driver call. */
+  | "kill_switch_engaged";
 
 /**
  * The self-review outcome as the policy needs it -- narrower than the full {@link SelfReviewVerdict} (self-

--- a/packages/loopover-engine/test/iterate-loop.test.ts
+++ b/packages/loopover-engine/test/iterate-loop.test.ts
@@ -406,3 +406,53 @@ test("a logging failure never crashes the loop or alters its decision", async ()
 
   assert.equal(result.outcome, "handoff", "the tool call is still decided correctly even though every audit write failed");
 });
+
+test("abandon (kill_switch_engaged): shouldAbort before the first driver call abandons with zero iterations (#5670)", async () => {
+  let driverCalled = false;
+  const { deps, events } = collectingDeps({
+    driver: {
+      async run() {
+        driverCalled = true;
+        return okResult();
+      },
+    },
+    shouldAbort: () => true,
+  });
+  const result = await runIterateLoop(passingInput({ maxIterations: 3 }), deps);
+
+  assert.equal(result.outcome, "abandon");
+  assert.equal(result.finalDecision.abandonReason, "kill_switch_engaged");
+  assert.equal(result.iterationsUsed, 0);
+  assert.equal(driverCalled, false);
+  assert.equal(events.some((event) => event.eventType === "attempt_aborted"), true);
+});
+
+test("abandon (kill_switch_engaged): shouldAbort after iteration 1 prevents iteration 2 (#5670 mid-iteration)", async () => {
+  let probes = 0;
+  let callCount = 0;
+  // Same duplicate-PR fixture as the no_progress test: iter 1 fails predicted-gate and continues.
+  const pullRequests: PullRequestRecord[] = [openPr(42, "Retry uploads on 5xx responses", [7])];
+  const { deps } = collectingDeps({
+    driver: {
+      async run() {
+        callCount += 1;
+        return okResult(["src/upload.ts"], 2);
+      },
+    },
+    shouldAbort: () => {
+      probes += 1;
+      return probes > 1 ? { abort: true, reason: "operator tripped kill mid-run" } : false;
+    },
+  });
+  const result = await runIterateLoop(
+    passingInput({ maxIterations: 5, reviewContext: baseReviewContext({ pullRequests }) }),
+    deps,
+  );
+
+  assert.equal(result.outcome, "abandon");
+  assert.equal(result.finalDecision.abandonReason, "kill_switch_engaged");
+  assert.match(result.finalDecision.reason, /operator tripped kill mid-run/);
+  assert.equal(callCount, 1);
+  assert.equal(result.iterationsUsed, 1);
+  assert.equal(probes, 2);
+});

--- a/packages/loopover-miner/lib/attempt-cli.js
+++ b/packages/loopover-miner/lib/attempt-cli.js
@@ -32,7 +32,7 @@ import { cleanupAttemptWorktree, prepareAttemptWorktree } from "./attempt-worktr
 import { fetchSelfReviewContext } from "./self-review-context.js";
 import { buildCodingTaskSpec } from "./coding-task-spec.js";
 import { resolveAmsPolicy } from "./ams-policy.js";
-import { checkMinerKillSwitch } from "./governor-kill-switch.js";
+import { checkMinerKillSwitch, recordMinerKillSwitchTransition } from "./governor-kill-switch.js";
 import { buildAttemptGovernorContext, buildAttemptLoopInput } from "./attempt-input-builder.js";
 import { getAttemptHistory } from "./portfolio-queue.js";
 import { loadReputationHistory, recordOwnSubmission } from "./governor-state.js";
@@ -388,7 +388,38 @@ export async function runAttempt(args, options = {}) {
     const repoPaused = minerGoalSpec.spec.killSwitch.paused;
 
     const checkKillSwitch = options.checkMinerKillSwitch ?? checkMinerKillSwitch;
-    const killSwitchScope = checkKillSwitch({ env, repoPaused }).scope;
+    let killSwitchScope = checkKillSwitch({ env, repoPaused }).scope;
+    let previousKillSwitchScope = killSwitchScope;
+
+    const resolveLiveKillSwitch = () => {
+      // Re-read the YAML flag each probe so an on-disk unpause/pause is reflected mid-attempt (#5670).
+      const liveRepoPaused = resolveGoalSpec(worktreeResult.repoPath).spec.killSwitch.paused;
+      const live = checkKillSwitch({ env, repoPaused: liveRepoPaused });
+      if (live.scope !== previousKillSwitchScope) {
+        try {
+          recordMinerKillSwitchTransition({
+            repoFullName: parsed.repoFullName,
+            actionClass: "attempt",
+            previousScope: previousKillSwitchScope,
+            scope: live.scope,
+          });
+        } catch {
+          // Ledger append must never crash an aborting attempt.
+        }
+        previousKillSwitchScope = live.scope;
+      }
+      killSwitchScope = live.scope;
+      return live;
+    };
+
+    const shouldAbort = () => {
+      const live = resolveLiveKillSwitch();
+      if (!live.active) return false;
+      return {
+        abort: true,
+        reason: `Kill-switch (${live.scope}) engaged mid-attempt; abandoning without starting another driver iteration.`,
+      };
+    };
 
     const loopInput = buildAttemptLoopInput({
       codingTaskSpec,
@@ -435,7 +466,11 @@ export async function runAttempt(args, options = {}) {
         submissionMode: amsPolicy.spec.submissionMode,
         governor,
       },
-      deps,
+      {
+        ...deps,
+        shouldAbort,
+        resolveKillSwitchScope: () => resolveLiveKillSwitch().scope,
+      },
     );
 
     worktreeResult.attemptOk = result.outcome === "submitted";
@@ -510,6 +545,9 @@ export async function runAttempt(args, options = {}) {
       // on any iteration this attempt ran, never fabricated.
       totalTokensUsed: result.loopResult.finalMeterTotals.tokens,
       iterationsUsed: result.loopResult.iterationsUsed,
+      ...(result.outcome === "abandon" && result.loopResult.finalDecision?.abandonReason
+        ? { abandonReason: result.loopResult.finalDecision.abandonReason }
+        : {}),
       ...("reason" in result ? { reason: result.reason } : {}),
       ...("decision" in result ? { decision: result.decision } : {}),
       ...("spec" in result ? { spec: result.spec } : {}),

--- a/packages/loopover-miner/lib/attempt-runner.d.ts
+++ b/packages/loopover-miner/lib/attempt-runner.d.ts
@@ -47,6 +47,10 @@ export type AttemptDeps = {
   sessionStartMs?: number;
   nowMs: number;
   executeLocalWrite: (spec: LocalWriteActionSpec) => Promise<unknown>;
+  /** Mid-attempt kill-switch probe threaded into `runIterateLoop` (#5670). */
+  shouldAbort?: () => import("@loopover/engine").IterateLoopShouldAbort;
+  /** Live kill-switch scope resolver after handoff (#5670); defaults to the frozen attempt-start scope. */
+  resolveKillSwitchScope?: () => "global" | "repo" | "none";
 };
 
 export type AttemptResult =

--- a/packages/loopover-miner/lib/attempt-runner.js
+++ b/packages/loopover-miner/lib/attempt-runner.js
@@ -99,6 +99,8 @@ function assertInput(input) {
  *   sessionStartMs?: number,
  *   nowMs: number,
  *   executeLocalWrite: (spec: import("@loopover/engine").LocalWriteActionSpec) => Promise<unknown>,
+ *   shouldAbort?: () => import("@loopover/engine").IterateLoopShouldAbort,
+ *   resolveKillSwitchScope?: () => "global"|"repo"|"none",
  * }} deps
  */
 export async function runMinerAttempt(input, deps) {
@@ -109,6 +111,7 @@ export async function runMinerAttempt(input, deps) {
     driver: deps.driver,
     runSlopAssessment: deps.runSlopAssessment,
     appendAttemptLogEvent: deps.appendAttemptLogEvent,
+    ...(typeof deps.shouldAbort === "function" ? { shouldAbort: deps.shouldAbort } : {}),
   });
 
   if (loopResult.outcome === "abandon") {
@@ -116,6 +119,28 @@ export async function runMinerAttempt(input, deps) {
   }
 
   const handoffPacket = loopResult.handoffPacket;
+
+  // Re-check kill-switch AFTER handoff and BEFORE any write (#5670) when a live resolver is supplied.
+  // Without a live resolver, preserve pre-#5670 behavior: the frozen attempt-start scope is threaded into
+  // prepareOpenPrSubmission / the submission gate (which itself denies active kill scopes).
+  if (typeof deps.resolveKillSwitchScope === "function") {
+    const liveKillSwitchScope = deps.resolveKillSwitchScope();
+    if (liveKillSwitchScope !== "none") {
+      return {
+        outcome: "abandon",
+        loopResult: {
+          ...loopResult,
+          outcome: "abandon",
+          finalDecision: {
+            action: "abandon",
+            abandonReason: "kill_switch_engaged",
+            reason: `Kill-switch (${liveKillSwitchScope}) engaged after handoff; refusing to open a PR.`,
+          },
+          handoffPacket: undefined,
+        },
+      };
+    }
+  }
 
   const freshness = await checkSubmissionFreshness(
     { repoFullName: input.loopInput.repoFullName, issueNumber: input.issueNumber, minerLogin: input.minerLogin },

--- a/packages/loopover-miner/lib/loop-cli.js
+++ b/packages/loopover-miner/lib/loop-cli.js
@@ -311,14 +311,35 @@ export async function runLoop(args, options = {}) {
       const killSwitch = checkKillSwitchFn({ env });
       if (killSwitch.active) {
         haltReason = `kill_switch_${killSwitch.scope}`;
-        cycles.push({ cycle: cycleIndex, outcome: "halted", reason: haltReason });
+        // Release the in-flight claim so left state is defined (#5670 / mirrors run-halt's markFailed).
+        if (claimed) {
+          portfolioQueue.markFailed(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
+        }
+        cycles.push({
+          cycle: cycleIndex,
+          outcome: "halted",
+          reason: haltReason,
+          ...(claimed
+            ? { repoFullName: claimed.repoFullName, identifier: claimed.identifier }
+            : {}),
+        });
         break;
       }
 
       const pauseState = governorState.loadPauseState();
       if (pauseState.paused) {
         haltReason = "paused";
-        cycles.push({ cycle: cycleIndex, outcome: "halted", reason: haltReason });
+        if (claimed) {
+          portfolioQueue.markFailed(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
+        }
+        cycles.push({
+          cycle: cycleIndex,
+          outcome: "halted",
+          reason: haltReason,
+          ...(claimed
+            ? { repoFullName: claimed.repoFullName, identifier: claimed.identifier }
+            : {}),
+        });
         break;
       }
 
@@ -410,6 +431,9 @@ export async function runLoop(args, options = {}) {
       // different iteration budget) and is requeued -- a genuinely stuck item is caught by non-convergence
       // (reenqueues threshold) rather than silently retried forever.
       const permanentBlock = attemptOutcome === "blocked_rejection_signaled";
+      // Mid-attempt kill-switch abandon (#5670): stop the outer loop immediately instead of waiting for the
+      // next between-cycle probe, and treat the item like any other re-queued abandon via markFailed below.
+      const killSwitchAbandon = lastResult?.abandonReason === "kill_switch_engaged";
 
       if (submitted || permanentBlock) {
         // Both terminal -- a submitted PR is done, and a repo-wide AI-usage-policy ban never resolves on retry --
@@ -419,6 +443,20 @@ export async function runLoop(args, options = {}) {
         // Any other blocked/abandoned/stale/governed outcome may resolve on a later retry, so requeue it; markFailed
         // records the re-enqueue + consecutive failure the non-convergence detector reads on the next cycle.
         portfolioQueue.markFailed(claimed.repoFullName, claimed.identifier, claimed.apiBaseUrl);
+      }
+
+      if (killSwitchAbandon) {
+        const liveKill = checkKillSwitchFn({ env });
+        haltReason = liveKill.active ? `kill_switch_${liveKill.scope}` : "kill_switch_engaged";
+        cycles.push({
+          cycle: cycleIndex,
+          outcome: "halted",
+          reason: haltReason,
+          repoFullName: claimed.repoFullName,
+          identifier: claimed.identifier,
+          attemptOutcome,
+        });
+        break;
       }
 
       let reentryOutcome = "other";

--- a/test/unit/miner-attempt-runner.test.ts
+++ b/test/unit/miner-attempt-runner.test.ts
@@ -429,4 +429,36 @@ describe("runMinerAttempt — real self-plagiarism wiring into the chokepoint (#
     const result = await runMinerAttempt(baseAttemptInput(), deps as never);
     expect(result.outcome).toBe("governed");
   });
+
+  it("honors shouldAbort before the first driver iteration and refuses to open a PR (#5670)", async () => {
+    const executeLocalWrite = vi.fn(async () => ({ ranAt: 10_000 }));
+    const driver = vi.fn(async () => okDriverResult());
+    const result = await runMinerAttempt(
+      baseAttemptInput(),
+      baseDeps({
+        driver: { run: driver },
+        shouldAbort: () => ({ abort: true, reason: "kill already engaged" }),
+        executeLocalWrite,
+      }),
+    );
+    expect(result.outcome).toBe("abandon");
+    expect(result.loopResult.finalDecision.abandonReason).toBe("kill_switch_engaged");
+    expect(result.loopResult.iterationsUsed).toBe(0);
+    expect(driver).not.toHaveBeenCalled();
+    expect(executeLocalWrite).not.toHaveBeenCalled();
+  });
+
+  it("re-checks kill-switch after handoff and refuses open_pr (#5670)", async () => {
+    const executeLocalWrite = vi.fn(async () => ({ ranAt: 10_000 }));
+    const result = await runMinerAttempt(
+      baseAttemptInput({ killSwitchScope: "none" }),
+      baseDeps({
+        resolveKillSwitchScope: () => "global",
+        executeLocalWrite,
+      }),
+    );
+    expect(result.outcome).toBe("abandon");
+    expect(result.loopResult.finalDecision.abandonReason).toBe("kill_switch_engaged");
+    expect(executeLocalWrite).not.toHaveBeenCalled();
+  });
 });

--- a/test/unit/miner-loop-cli.test.ts
+++ b/test/unit/miner-loop-cli.test.ts
@@ -810,4 +810,50 @@ describe("runLoop (#5135)", () => {
     });
     for (const spy of jsonCloseSpies) expect(spy).toHaveBeenCalledTimes(1);
   });
+
+  it("halts immediately when an attempt returns kill_switch_engaged mid-run (#5670)", async () => {
+    const { eventLedger, governorLedger, portfolioQueue, runState, governorState, paths } = tempStores();
+    portfolioQueue.enqueue({ repoFullName: "acme/widgets", identifier: "issue:7" });
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    let killActive = false;
+    const runAttemptSpy = vi.fn(async (_args: string[], options: { onResult?: (result: unknown) => void }) => {
+      killActive = true;
+      options.onResult?.({
+        outcome: "attempt_abandon",
+        abandonReason: "kill_switch_engaged",
+        totalTurnsUsed: 1,
+        totalCostUsd: 0,
+      });
+      return 0;
+    });
+
+    const exitCode = await runLoop(["acme/widgets", "--miner-login", "alice", "--json", "--max-cycles", "3"], {
+      openGovernorState: () => governorState,
+      initEventLedger: () => eventLedger,
+      initGovernorLedger: () => governorLedger,
+      initPortfolioQueue: () => portfolioQueue,
+      initRunStateStore: () => runState,
+      runDiscover: async () => 0,
+      runAttempt: runAttemptSpy,
+      ...readyLoopOptions({
+        checkMinerKillSwitch: () =>
+          killActive ? { scope: "global" as const, active: true } : { scope: "none" as const, active: false },
+      }),
+    });
+
+    expect(exitCode).toBe(0);
+    expect(runAttemptSpy).toHaveBeenCalledTimes(1);
+    const printed = JSON.parse(String(log.mock.calls[0]?.[0]));
+    expect(printed.haltReason).toBe("kill_switch_global");
+    expect(printed.cycles.at(-1)).toMatchObject({
+      outcome: "halted",
+      reason: "kill_switch_global",
+      identifier: "issue:7",
+      attemptOutcome: "attempt_abandon",
+    });
+    // Claim released back to queued via markFailed — reopen after runLoop closes its handles.
+    const reopened = initPortfolioQueueStore(paths.portfolioQueuePath);
+    expect(reopened.listQueue()[0]).toMatchObject({ identifier: "issue:7", status: "queued" });
+    reopened.close();
+  });
 });


### PR DESCRIPTION
## Summary

Closes #5670.

Makes the existing miner kill-switch reliable for a **running rented loop**, not only between outer `loop` cycles:

- Cooperative abort in `runIterateLoop` **before each driver iteration** (`shouldAbort` → `abandonReason: kill_switch_engaged`)
- Live kill-switch re-resolve after handoff and before `open_pr`
- Outer `loop` exits immediately on a mid-attempt kill abandon and **releases** the in-flight queue claim via `markFailed` (defined left state; no PR write)

Post-kill state (conservative, matching public #4782 intent and existing pause/kill conventions): attempt abandoned / aborted, no handoff write, queue item re-queued, governor kill-switch ledger transition recorded when scope changes. Ops runbook remains #4809 (out of scope).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`
- [x] I linked a currently open issue this PR resolves (`Closes #5670`)

## Validation

- [x] `npm run build --workspace @loopover/engine`
- [x] `node --test packages/loopover-engine/test/iterate-loop.test.ts` (30/30)
- [x] `npx vitest run test/unit/miner-attempt-runner.test.ts test/unit/miner-loop-cli.test.ts` (48/48)
- Mid-iteration and between-iteration kill paths covered by new unit tests (engine probe + attempt-runner wiring + outer loop halt/release)

If any required check was skipped, explain why:

- Full `npm run test:ci` not re-run locally in this session (heavy); changed surfaces covered by the focused suites above and CI will run the full gate.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed
- [x] Public GitHub text stays sanitized and does not imply compensation guarantees
- [x] No UI changes (No visual impact / no UI Evidence section required)
- [x] Does not edit `CHANGELOG.md` / maintainer-only governance prose for #4782 / #4809 runbook

## Notes

Hard SIGKILL of an in-flight LLM driver turn is intentionally out of scope (same cooperative boundary as the existing mid-attempt budget abort). Trigger remains env/`killSwitch.paused` YAML; `governor pause` remains the durable operator stop for a running daemon between polls of this probe.


Made with [Cursor](https://cursor.com)