### PR TITLE
feat(mcp): evaluate rented-loop health for internal ops alerting

### DIFF
--- a/packages/loopover-engine/src/index.ts
+++ b/packages/loopover-engine/src/index.ts
@@ -611,6 +611,14 @@ export {
   type ProgressSnapshot,
 } from "./loop-progress.js";
 export {
+  evaluateLoopHealth,
+  LOOP_HEALTH_WARN_PCT,
+  LOOP_HEALTH_NO_PROGRESS_STREAK,
+  type LoopHealthInput,
+  type LoopHealthReport,
+  type LoopHealthStatus,
+} from "./loop-health.js";
+export {
   buildMetadataRankInput,
   computeMetadataDupRisk,
   computeMetadataFeasibility,

--- a/packages/loopover-engine/src/loop-health.ts
+++ b/packages/loopover-engine/src/loop-health.ts
@@ -1,0 +1,60 @@
+// Loop health / anomaly evaluator (pure) — the alert-rule logic behind internal ops observability for active
+// rented loops (#4808, part of the Rent-a-Loop path #4778). Given one loop's already-computed run metrics it
+// classifies health and flags the anomalies an operator should be alerted on, so a dashboard/alert surface
+// consumes one deterministic verdict instead of re-deriving thresholds per panel. No IO, no transport —
+// mirrors the per-tenant quota evaluator (#4796) and the loop-progress model (#4800).
+
+// A resource is flagged "near" its ceiling at this % of budget consumed; at 100% it escalates to critical.
+export const LOOP_HEALTH_WARN_PCT = 80;
+// Consecutive no-progress iterations before the stall is treated as an anomaly (one flat iteration can be normal).
+export const LOOP_HEALTH_NO_PROGRESS_STREAK = 2;
+
+export type LoopHealthStatus = "healthy" | "degraded" | "critical";
+
+export type LoopHealthInput = {
+  iteration: number;
+  maxIterations?: number | null | undefined;
+  costUsed?: number | null | undefined;
+  costCeiling?: number | null | undefined;
+  noProgressStreak?: number | undefined;
+  errored?: boolean | undefined;
+  stalled?: boolean | undefined;
+};
+
+export type LoopHealthReport = {
+  status: LoopHealthStatus;
+  /** Alert-worthy anomaly codes, e.g. `errored`, `stalled`, `no_progress`, `near_iteration_budget`, `near_cost_ceiling`. */
+  anomalies: string[];
+  /** Iteration budget consumed (0-100), or null when the budget is unknown. */
+  iterationBudgetUsedPct: number | null;
+  /** Cost budget consumed (0-100), or null when the ceiling is unknown. */
+  costUsedPct: number | null;
+};
+
+/** Classify one loop's health and flag its alert-worthy anomalies from already-computed metrics (#4808). Pure. */
+export function evaluateLoopHealth(input: LoopHealthInput): LoopHealthReport {
+  const iterationBudgetUsedPct =
+    input.maxIterations !== null && input.maxIterations !== undefined && input.maxIterations > 0
+      ? Math.min(100, Math.round((input.iteration / input.maxIterations) * 100))
+      : null;
+  const costUsedPct =
+    input.costUsed !== null && input.costUsed !== undefined && input.costCeiling !== null && input.costCeiling !== undefined && input.costCeiling > 0
+      ? Math.min(100, Math.round((input.costUsed / input.costCeiling) * 100))
+      : null;
+
+  const anomalies: string[] = [];
+  if (input.errored === true) anomalies.push("errored");
+  if (input.stalled === true) anomalies.push("stalled");
+  if ((input.noProgressStreak ?? 0) >= LOOP_HEALTH_NO_PROGRESS_STREAK) anomalies.push("no_progress");
+  if (iterationBudgetUsedPct !== null && iterationBudgetUsedPct >= LOOP_HEALTH_WARN_PCT) anomalies.push("near_iteration_budget");
+  if (costUsedPct !== null && costUsedPct >= LOOP_HEALTH_WARN_PCT) anomalies.push("near_cost_ceiling");
+
+  // Critical when a hard ceiling is hit or the loop has errored; degraded when any softer anomaly is present.
+  const critical =
+    input.errored === true ||
+    (iterationBudgetUsedPct !== null && iterationBudgetUsedPct >= 100) ||
+    (costUsedPct !== null && costUsedPct >= 100);
+  const status: LoopHealthStatus = critical ? "critical" : anomalies.length > 0 ? "degraded" : "healthy";
+
+  return { status, anomalies, iterationBudgetUsedPct, costUsedPct };
+}

--- a/src/loop-health.ts
+++ b/src/loop-health.ts
@@ -1,0 +1,5 @@
+// Loop health / anomaly evaluator (#4808) — thin re-export shim. The canonical implementation lives in
+// `@loopover/engine` (packages/loopover-engine/src/loop-health.ts), imported via the relative source path
+// (matching src/loop-progress.ts / src/results-payload.ts) so the published loopover-mcp / loopover-miner
+// CLIs share one evaluator, and so this never depends on the engine's built dist/ during typecheck/test.
+export * from "../packages/loopover-engine/src/loop-health";

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -158,6 +158,7 @@ import { buildSlopAssessment } from "../signals/slop";
 import { validateIdeaSubmission, buildTaskGraph, buildClaimPlan } from "../idea-intake";
 import { buildResultsPayload } from "../results-payload";
 import { buildProgressSnapshot } from "../loop-progress";
+import { evaluateLoopHealth } from "../loop-health";
 import { buildStructuralImprovementAssessment } from "../signals/improvement";
 import { buildBoundaryTestGenerationFinding, buildBoundaryTestGenerationSpec } from "../signals/boundary-test-generation";
 import { buildRepoDataQuality } from "../signals/data-quality";
@@ -999,6 +1000,24 @@ const buildProgressSnapshotOutputSchema = {
   done: z.boolean().optional(),
 };
 
+// Loop health / anomaly evaluator input (#4808): a running loop's already-computed run metrics.
+const evaluateLoopHealthShape = {
+  iteration: z.number().int(),
+  maxIterations: z.number().int().nullable().optional(),
+  costUsed: z.number().nullable().optional(),
+  costCeiling: z.number().nullable().optional(),
+  noProgressStreak: z.number().int().optional(),
+  errored: z.boolean().optional(),
+  stalled: z.boolean().optional(),
+};
+
+const evaluateLoopHealthOutputSchema = {
+  status: z.enum(["healthy", "degraded", "critical"]).optional(),
+  anomalies: z.array(z.string()).optional(),
+  iterationBudgetUsedPct: z.number().nullable().optional(),
+  costUsedPct: z.number().nullable().optional(),
+};
+
 // Deterministic structural-improvement counterpart to checkSlopRiskShape (#4746, sub-issue I of epic #4737):
 // the positive-axis mirror of checkSlopRisk, same pure local-metadata contract. changedFiles/tests/testFiles
 // are reused verbatim (same shape as checkSlopRiskShape) so the two signals never disagree about what counts
@@ -1791,6 +1810,17 @@ export class LoopoverMcp {
         outputSchema: buildProgressSnapshotOutputSchema,
       },
       async (input) => this.toolResult(await this.buildLoopProgress(input)),
+    );
+
+    server.registerTool(
+      "loopover_evaluate_loop_health",
+      {
+        description:
+          "Classify a running rented loop's health and flag its alert-worthy anomalies (#4808) from already-computed run metrics (iteration/cost budgets, no-progress streak, error/stall) — the deterministic alert-rule logic an ops dashboard consumes. Source-free; returns healthy/degraded/critical, anomaly codes, and budget-used percentages.",
+        inputSchema: evaluateLoopHealthShape,
+        outputSchema: evaluateLoopHealthOutputSchema,
+      },
+      async (input) => this.toolResult(await this.evalLoopHealth(input)),
     );
 
     server.registerTool(
@@ -3103,6 +3133,15 @@ export class LoopoverMcp {
     return {
       summary: payload.summary,
       data: payload as unknown as Record<string, unknown>,
+    };
+  }
+
+  private async evalLoopHealth(input: z.infer<z.ZodObject<typeof evaluateLoopHealthShape>>): Promise<ToolPayload> {
+    await this.enforceToolRateLimit("loopover_evaluate_loop_health");
+    const report = evaluateLoopHealth(input);
+    return {
+      summary: `Loop health: ${report.status}, ${report.anomalies.length} anomaly code(s).`,
+      data: report as unknown as Record<string, unknown>,
     };
   }
 

--- a/test/unit/loop-health.test.ts
+++ b/test/unit/loop-health.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import { evaluateLoopHealth, LOOP_HEALTH_WARN_PCT } from "../../packages/loopover-engine/src/loop-health";
+
+describe("evaluateLoopHealth (#4808)", () => {
+  it("is healthy with budget percentages when nothing is anomalous", () => {
+    const r = evaluateLoopHealth({ iteration: 1, maxIterations: 5, costUsed: 10, costCeiling: 100 });
+    expect(r).toEqual({ status: "healthy", anomalies: [], iterationBudgetUsedPct: 20, costUsedPct: 10 });
+  });
+
+  it("leaves budget percentages null when the budgets are unknown or zero", () => {
+    expect(evaluateLoopHealth({ iteration: 3 }).iterationBudgetUsedPct).toBeNull(); // no maxIterations
+    expect(evaluateLoopHealth({ iteration: 3, maxIterations: 0 }).iterationBudgetUsedPct).toBeNull(); // 0 budget
+    expect(evaluateLoopHealth({ iteration: 3, maxIterations: 5, costUsed: 5 }).costUsedPct).toBeNull(); // no ceiling
+    expect(evaluateLoopHealth({ iteration: 3, maxIterations: 5, costUsed: 5, costCeiling: 0 }).costUsedPct).toBeNull(); // 0 ceiling
+  });
+
+  it("flags errored as critical", () => {
+    const r = evaluateLoopHealth({ iteration: 1, maxIterations: 5, errored: true });
+    expect(r.status).toBe("critical");
+    expect(r.anomalies).toContain("errored");
+  });
+
+  it("flags a stall as degraded", () => {
+    const r = evaluateLoopHealth({ iteration: 1, maxIterations: 5, stalled: true });
+    expect(r).toMatchObject({ status: "degraded", anomalies: ["stalled"] });
+  });
+
+  it("flags a no-progress streak at/above the threshold, but not a single flat iteration", () => {
+    expect(evaluateLoopHealth({ iteration: 3, maxIterations: 10, noProgressStreak: 2 }).anomalies).toContain("no_progress");
+    expect(evaluateLoopHealth({ iteration: 3, maxIterations: 10, noProgressStreak: 1 }).anomalies).not.toContain("no_progress");
+  });
+
+  it("warns near a budget and escalates to critical at the ceiling", () => {
+    // 80% iteration budget => degraded warning, not yet critical
+    const warn = evaluateLoopHealth({ iteration: 4, maxIterations: 5 });
+    expect(warn).toMatchObject({ status: "degraded", iterationBudgetUsedPct: LOOP_HEALTH_WARN_PCT });
+    expect(warn.anomalies).toContain("near_iteration_budget");
+    // at/over the iteration ceiling => critical (and the percentage caps at 100)
+    const hit = evaluateLoopHealth({ iteration: 7, maxIterations: 5 });
+    expect(hit).toMatchObject({ status: "critical", iterationBudgetUsedPct: 100 });
+  });
+
+  it("applies the same warn/critical logic to the cost ceiling independently of iterations", () => {
+    const warn = evaluateLoopHealth({ iteration: 1, maxIterations: 10, costUsed: 80, costCeiling: 100 });
+    expect(warn).toMatchObject({ status: "degraded", costUsedPct: 80 });
+    expect(warn.anomalies).toContain("near_cost_ceiling");
+    const hit = evaluateLoopHealth({ iteration: 1, maxIterations: 10, costUsed: 100, costCeiling: 100 });
+    expect(hit.status).toBe("critical");
+  });
+});

--- a/test/unit/mcp-loop-health.test.ts
+++ b/test/unit/mcp-loop-health.test.ts
@@ -1,0 +1,40 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { describe, expect, it } from "vitest";
+import { LoopoverMcp } from "../../src/mcp/server";
+import { createTestEnv } from "../helpers/d1";
+
+async function connect() {
+  const server = new LoopoverMcp(createTestEnv()).createServer();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  const client = new Client({ name: "gittensory-health-test", version: "0.1.0" }, { capabilities: {} });
+  await client.connect(clientTransport);
+  return client;
+}
+
+describe("MCP loopover_evaluate_loop_health", () => {
+  it("returns a healthy verdict for a nominal loop", async () => {
+    const client = await connect();
+    const result = await client.callTool({
+      name: "loopover_evaluate_loop_health",
+      arguments: { iteration: 1, maxIterations: 5, costUsed: 10, costCeiling: 100 },
+    });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as { status: string; anomalies: string[]; iterationBudgetUsedPct: number };
+    expect(data.status).toBe("healthy");
+    expect(data.anomalies).toEqual([]);
+    expect(data.iterationBudgetUsedPct).toBe(20);
+  });
+
+  it("returns a critical verdict with anomaly codes for a failing loop", async () => {
+    const client = await connect();
+    const result = await client.callTool({
+      name: "loopover_evaluate_loop_health",
+      arguments: { iteration: 5, maxIterations: 5, errored: true, noProgressStreak: 3 },
+    });
+    const data = result.structuredContent as { status: string; anomalies: string[] };
+    expect(data.status).toBe("critical");
+    expect(data.anomalies).toEqual(expect.arrayContaining(["errored", "no_progress", "near_iteration_budget"]));
+  });
+});


### PR DESCRIPTION
## Summary

Implements #4808's **alert-rule logic**: classify a running rented loop's health and flag the anomalies an operator should be alerted on, from already-computed run metrics — so an ops dashboard/alert surface consumes one deterministic verdict instead of re-deriving thresholds per panel. Mirrors the per-tenant quota evaluator (#4796) and the loop-progress model (#4800) on the Rent-a-Loop path #4778.

- **new `packages/loopover-engine/src/loop-health.ts`** (pure): `evaluateLoopHealth(metrics)` returns `healthy`/`degraded`/`critical` plus anomaly codes (`errored`, `stalled`, `no_progress`, `near_iteration_budget`, `near_cost_ceiling`) and iteration/cost **budget-used percentages**. A resource near its ceiling (`LOOP_HEALTH_WARN_PCT`) is a soft anomaly (degraded); a hit ceiling or an error is critical. No IO, no transport.
- **new `loopover_evaluate_loop_health` MCP tool** (`src/mcp/server.ts`); `src/loop-health.ts` is a thin re-export shim over the engine module.

Acceptance (#4808): an operator gets a clear at-a-glance status + anomaly flags for a loop — the deterministic alert-rule half that a dashboard consumes, tested at the engine level and end-to-end through the MCP tool.

## Scope

- [x] Conventional Commit title (`feat(mcp): …`).
- [x] Focused: the loop-health evaluator + its tool, on the merged loop-lifecycle chain.
- [x] Follows `CONTRIBUTING.md`; no `site/`/`CNAME`/VitePress.
- [x] Linked open issue: `Closes #4808`.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` clean; `npm --workspace @loopover/engine run build` + `npm run build:mcp` clean
- [x] `npm run test:coverage` on the changed code: `loop-health.ts` **100% lines & branches (37/37)**; the new `src/mcp/server.ts` handler + schema + registration fully covered (all 39 changed lines, both branch sides — diff-verified).
- [x] MCP tool-invariant suites pass with the new tool (`mcp-output-schemas` "outputSchema on EVERY tool" + "schema-valid structured content").
- [x] Tests cover healthy/degraded/critical transitions, each anomaly code, the no-progress-streak threshold, budget-percentage cap and null (unknown/zero budget) paths, and both cost/iteration axes.

If any required check was skipped, explain why:

- Full `test:ci` not run end-to-end locally (Linux-only shell/self-host steps on Windows); the change-relevant gates above were validated directly.

## Safety

- [x] No secrets, wallet/hotkey/coldkey, trust scores, rewards, private rankings, or private maintainer evidence — the verdict is public-safe loop status only, source-free.
- [x] No auth/cookie/CORS/GitHub App/session change (pure function over caller-supplied data).
- [x] MCP behavior added + tested (output schema + schema-valid content).
- [x] No UI changes; no changelog edit.

## Notes

- This is the deterministic alert-rule half of #4808; the dashboard/observability-stack wiring (which the issue notes is gated on #4793's scoped-credential handling) consumes this verdict once that lands.
