### PR TITLE
fix(signals): require a code file before manifest_missing_tests fires

### DIFF
--- a/packages/loopover-engine/src/focus-manifest/guidance.ts
+++ b/packages/loopover-engine/src/focus-manifest/guidance.ts
@@ -3,6 +3,7 @@ import type {
   FocusManifestFinding,
   FocusManifestGuidance,
 } from "../types/predicted-gate-types.js";
+import { isCodeFile } from "../signals/path-matchers.js";
 
 const FOCUS_MANIFEST_TERMS = /\b(reward\w*|score\w*|wallets?|hotkeys?|coldkeys?|seed[-\s]?phrases?|mnemonics?|private[-\s]?keys?|farming|payouts?|rankings?|raw[-\s]?trust(?:[-\s]?scores?)?|trust[-\s]?scores?|private[-\s]?reviewability|reviewability(?:[-\s]?internals?)?|private[-\s]?scoreability|scoreability|public[-\s]?score[-\s]?(?:estimate|prediction|claim)s?|estimated[-\s]?scores?|score[-\s]?(?:estimate|prediction|preview)s?)\b/i;
 const FOCUS_MANIFEST_LOCAL_PATH_PATTERN = new RegExp(String.raw`/Users/|/home/|/root/|/var/|/opt/|/tmp/|/private/|[A-Za-z]:[\\/]Users[\\/]|[A-Za-z]:[\\/]Program Files[\\/]`, "i");
@@ -124,6 +125,7 @@ export function buildFocusManifestGuidance(args: {
   const linkedIssueCount = Math.max(0, args.linkedIssueCount ?? 0);
   const testFileCount = Math.max(0, args.testFileCount ?? 0);
   const passedValidationCount = Math.max(0, args.passedValidationCount ?? 0);
+  const codeFileCount = changedPaths.filter(isCodeFile).length;
 
   const matchedWantedPaths = matchedPatterns(changedPaths, manifest.wantedPaths);
   const preferredLabelHits = manifest.preferredLabels.filter((label) => labels.includes(label.toLowerCase()));
@@ -201,7 +203,7 @@ export function buildFocusManifestGuidance(args: {
     publicNextSteps.push("Link a tracked issue if one exists; the maintainer prefers linked issues.");
   }
 
-  if (manifest.testExpectations.length > 0 && testFileCount === 0 && passedValidationCount === 0) {
+  if (manifest.testExpectations.length > 0 && codeFileCount > 0 && testFileCount === 0 && passedValidationCount === 0) {
     const safeExpectations = manifest.testExpectations.filter(isFocusManifestPublicSafe).slice(0, 3);
     const expectationDetail = safeExpectations.length > 0 ? ` Expected evidence: ${safeExpectations.join("; ")}.` : "";
     findings.push({

--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -85,7 +85,7 @@ import { DEFAULT_LINKED_ISSUE_HARD_RULES } from "../review/linked-issue-hard-rul
 import { DEFAULT_UNLINKED_ISSUE_GUARDRAIL } from "../review/unlinked-issue-guardrail-config";
 import { DEFAULT_ADVISORY_AI_ROUTING } from "../review/advisory-ai-routing-config";
 import { DEFAULT_SCREENSHOT_TABLE_GATE } from "../review/screenshot-table-gate";
-import { classifyChangedFile } from "./path-matchers";
+import { classifyChangedFile, isCodeFile } from "./path-matchers";
 import {
   EMPTY_AUTO_REVIEW_CONFIG,
   EMPTY_MAX_FINDINGS_CONFIG,
@@ -658,6 +658,7 @@ export function buildFocusManifestGuidance(args: {
   const hasNoIssueRationale = args.hasNoIssueRationale ?? false;
   const testFileCount = Math.max(0, args.testFileCount ?? 0);
   const passedValidationCount = Math.max(0, args.passedValidationCount ?? 0);
+  const codeFileCount = changedPaths.filter(isCodeFile).length;
 
   const matchedWantedPaths = matchedPatterns(changedPaths, manifest.wantedPaths);
   const preferredLabelHits = manifest.preferredLabels.filter((label) => labels.includes(label.toLowerCase()));
@@ -735,7 +736,7 @@ export function buildFocusManifestGuidance(args: {
     publicNextSteps.push("Link a tracked issue if one exists; the maintainer prefers linked issues.");
   }
 
-  if (manifest.testExpectations.length > 0 && testFileCount === 0 && passedValidationCount === 0) {
+  if (manifest.testExpectations.length > 0 && codeFileCount > 0 && testFileCount === 0 && passedValidationCount === 0) {
     const safeExpectations = manifest.testExpectations.filter(isFocusManifestPublicSafe).slice(0, 3);
     const expectationDetail = safeExpectations.length > 0 ? ` Expected evidence: ${safeExpectations.join("; ")}.` : "";
     findings.push({

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -660,6 +660,25 @@ describe("buildFocusManifestGuidance", () => {
     expect(guidance.findings.some((finding) => finding.code === "manifest_missing_tests")).toBe(false);
   });
 
+  it("REGRESSION (#manifest-missing-tests-docs-only-false-positive): does not require tests when the change touches no code files", () => {
+    // A content/docs-only PR (e.g. a catalog registry .mdx entry) has nothing a test could meaningfully cover,
+    // so it must not trip manifest_missing_tests just because no test file or validation evidence exists --
+    // mirrors the codeFileCount > 0 guard local_diff_missing_tests already applies (predicted-gate-engine.ts).
+    const guidance = buildFocusManifestGuidance({ manifest: wanted, changedPaths: ["docs/readme.md"], linkedIssueCount: 1, testFileCount: 0, passedValidationCount: 0 });
+    expect(guidance.findings.some((finding) => finding.code === "manifest_missing_tests")).toBe(false);
+  });
+
+  it("still requires tests when the change mixes code with docs and neither tests nor validation evidence exist", () => {
+    const guidance = buildFocusManifestGuidance({
+      manifest: wanted,
+      changedPaths: ["docs/readme.md", "src/x.ts"],
+      linkedIssueCount: 1,
+      testFileCount: 0,
+      passedValidationCount: 0,
+    });
+    expect(guidance.findings.some((finding) => finding.code === "manifest_missing_tests")).toBe(true);
+  });
+
   it("notes when issue-discovery is discouraged", () => {
     const guidance = buildFocusManifestGuidance({ manifest: wanted, changedPaths: ["src/x.ts"], labels: ["bug"], linkedIssueCount: 1, testFileCount: 1 });
     expect(guidance.findings.some((finding) => finding.code === "manifest_issue_discovery_discouraged")).toBe(true);

--- a/test/unit/predicted-gate-engine-coverage.test.ts
+++ b/test/unit/predicted-gate-engine-coverage.test.ts
@@ -821,6 +821,32 @@ describe("predicted-gate engine module coverage (#2283)", () => {
     });
     expect(missingTests.findings.some((f) => f.code === "manifest_missing_tests")).toBe(true);
     expect(missingTests.findings.find((f) => f.code === "manifest_missing_tests")?.detail).not.toContain("wallet");
+
+    // REGRESSION (#manifest-missing-tests-docs-only-false-positive): a docs/content-only change has nothing a
+    // test could cover, so it must not trip manifest_missing_tests just because no test file or validation
+    // evidence exists.
+    const docsOnlyNoFalsePositive = buildFocusManifestGuidance({
+      manifest: {
+        present: true,
+        source: "repo_file",
+        wantedPaths: [],
+        preferredLabels: [],
+        linkedIssuePolicy: "optional",
+        testExpectations: ["paste your wallet hotkey here"],
+        issueDiscoveryPolicy: "neutral",
+        maintainerNotes: [],
+        publicNotes: [],
+        gate: { present: true } as FocusManifest["gate"],
+        settings: {},
+        review: { present: true, preMergeChecks: [] },
+        warnings: [],
+      },
+      changedPaths: ["content/registry/new-entry.mdx"],
+      linkedIssueCount: 1,
+      testFileCount: 0,
+      passedValidationCount: 0,
+    });
+    expect(docsOnlyNoFalsePositive.findings.some((f) => f.code === "manifest_missing_tests")).toBe(false);
   });
 
   it("covers remaining codecov patch branch arms in ported engine modules", () => {

--- a/test/unit/queue-2.test.ts
+++ b/test/unit/queue-2.test.ts
@@ -4028,7 +4028,11 @@ describe("queue processors", () => {
     await upsertPullRequestFile(env, {
       repoFullName: "JSONbored/gittensory",
       pullNumber: 47,
-      path: "README.md",
+      // A code file, deliberately -- this test's subject is whether an ignored-bot author still trips the
+      // deterministic manifestPolicyGateMode gate, not manifest_missing_tests' own code-vs-docs trigger
+      // (see the codeFileCount > 0 guard in buildFocusManifestGuidance). A docs-only path would no longer
+      // trip the finding at all and silently stop testing this test's actual subject.
+      path: "src/example.ts",
       status: "modified",
       additions: 1,
       deletions: 1,


### PR DESCRIPTION
## Summary

- `manifest_missing_tests` fired on any PR with configured test expectations and no changed test file, even when the PR touched no code at all. Real production evidence: on JSONbored/awesome-claude, this check blocked 18 PRs and 9 merged anyway (50% false-positive rate), overwhelmingly single-file `.mdx`/`README.md` catalog-registration PRs with nothing a test could cover.
- The sibling `local_diff_missing_tests` check already guards on `codeFileCount > 0`; this PR ports the same guard to both `buildFocusManifestGuidance` implementations (`src/signals/focus-manifest.ts` and the `packages/loopover-engine` copy) so they stay in sync.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] Linked issue — N/A. Maintainer-authored fix found via a production ops-anomaly detector, not a contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — 851 passed, 0 failed (full unsharded run). Both branches of the new `codeFileCount > 0` guard are exercised: fires when a code file exists, does not fire on a docs/content-only change, still fires on a mixed code+docs change.
- [ ] `npm run test:workers` — not run, see note below
- [ ] `npm run build:mcp` / `npm run test:mcp-pack` — not run, see note below
- [ ] `npm run ui:openapi:check` / `ui:lint` / `ui:typecheck` / `ui:build` — not run, see note below
- [x] `npm audit --audit-level=moderate` — clean, 0 vulnerabilities
- [x] New/changed behavior has unit/integration tests for both branches of the new condition, plus a regression test for the reported false-positive

If any required check was skipped, explain why:

- `test:workers`, `build:mcp`/`test:mcp-pack`, and the `ui:*` checks were not run. This change is confined to `src/signals/focus-manifest.ts`, `packages/loopover-engine/src/focus-manifest/guidance.ts`, and their unit tests — no Workers runtime, MCP package, API route, OpenAPI schema, or UI code is touched. Ran `npm run test:coverage` (unsharded) and `npm run test:engine-parity` instead, which exercise this exact code path end-to-end and confirmed no golden-fixture drift.

## Safety

- [x] No secrets, wallets, hotkeys, coldkeys, trust scores, or reward values touched.
- [x] Public GitHub finding text (title/detail/action strings) is unchanged in content — only the trigger condition changed.
- Auth/CORS/GitHub App/Cloudflare/session, API/OpenAPI/MCP, UI, and docs/changelog: not applicable, none touched.

## UI Evidence

N/A — no UI/frontend/docs change.

## Notes

- A pre-existing test (`test/unit/queue-2.test.ts`) was incidentally relying on this exact bug: its fixture used a `README.md`-only changed file to test an unrelated "an ignored-bot author still gets the deterministic gate" behavior. Fixed the fixture to use a code file so it continues to test its actual subject instead of silently depending on the false positive.