### PR TITLE
fix(review): treat a blank consentPhrase as unset in evaluateClaCheck

### DIFF
--- a/src/review/cla-check.ts
+++ b/src/review/cla-check.ts
@@ -50,8 +50,12 @@ export function evaluateClaCheck(
   config: ClaCheckConfig,
   ctx: { body?: string | null | undefined; checkRunConclusion?: string | null | undefined },
 ): AdvisoryFinding[] {
-  if (config.consentPhrase === null && config.checkRunName === null) return []; // nothing configured ⇒ no finding
-  const phraseSatisfied = config.consentPhrase !== null && (ctx.body ?? "").toLowerCase().includes(config.consentPhrase.toLowerCase());
+  // A blank/whitespace-only consentPhrase is treated as unset (null), the same as the config-as-code path
+  // (focus-manifest normalizeOptionalString) already does — otherwise `"".includes("")` would make phrase
+  // detection unconditionally satisfied and silently bypass the CLA gate for every PR.
+  const consentPhrase = config.consentPhrase !== null && config.consentPhrase.trim() !== "" ? config.consentPhrase : null;
+  if (consentPhrase === null && config.checkRunName === null) return []; // nothing configured ⇒ no finding
+  const phraseSatisfied = consentPhrase !== null && (ctx.body ?? "").toLowerCase().includes(consentPhrase.toLowerCase());
   const checkRunSatisfied = config.checkRunName !== null && (ctx.checkRunConclusion === "success" || ctx.checkRunConclusion === "neutral");
   if (phraseSatisfied || checkRunSatisfied) return [];
   // A configured check-run whose conclusion is unresolved: cannot confirm OR deny consent via that method, so
@@ -69,7 +73,7 @@ export function evaluateClaCheck(
     ];
   }
   const missing: string[] = [];
-  if (config.consentPhrase !== null) missing.push(`the PR description must contain "${config.consentPhrase}"`);
+  if (consentPhrase !== null) missing.push(`the PR description must contain "${consentPhrase}"`);
   if (config.checkRunName !== null) missing.push(`the "${config.checkRunName}" check must pass`);
   return [
     {

--- a/test/unit/cla-check.test.ts
+++ b/test/unit/cla-check.test.ts
@@ -113,4 +113,30 @@ describe("evaluateClaCheck (#2564)", () => {
       expect(out[0]?.code).toBe(CLA_CHECK_UNRESOLVED_CODE);
     });
   });
+
+  // #5838: a blank/whitespace-only consentPhrase must be treated as unset, not as an always-matching "" that
+  // silently satisfies CLA consent for every PR (`"".includes("")` is unconditionally true).
+  describe("empty/whitespace-only consentPhrase normalization (#5838)", () => {
+    it("an empty-string consentPhrase does NOT unconditionally satisfy consent — it behaves as if unset", () => {
+      // With the bug, `"".includes("")` made phraseSatisfied true and returned []. Now the blank phrase is
+      // dropped, so a configured-but-failing check-run leaves consent missing (the phrase is not even listed).
+      const out = evaluateClaCheck(config({ consentPhrase: "", checkRunName: "CLA Assistant Lite" }), {
+        body: "no consent statement here",
+        checkRunConclusion: "failure",
+      });
+      expect(out).toHaveLength(1);
+      expect(out[0]?.code).toBe(CLA_CONSENT_MISSING_CODE);
+      expect(out[0]?.detail).toContain('the "CLA Assistant Lite" check must pass');
+      expect(out[0]?.detail).not.toContain("PR description must contain");
+    });
+
+    it("a whitespace-only consentPhrase with no other method configured yields no finding, exactly like null", () => {
+      expect(evaluateClaCheck(config({ consentPhrase: "   " }), { body: "anything at all" })).toEqual([]);
+    });
+
+    it("REGRESSION: a real non-empty consentPhrase still decides consent (either-method contract unchanged)", () => {
+      expect(evaluateClaCheck(config({ consentPhrase: "I agree" }), { body: "... I AGREE ..." })).toEqual([]);
+      expect(evaluateClaCheck(config({ consentPhrase: "I agree" }), { body: "nope" })).toHaveLength(1);
+    });
+  });
 });


### PR DESCRIPTION
Closes #5838. A gate-bypass fix in `src/review/cla-check.ts`.

`evaluateClaCheck` computed `phraseSatisfied = config.consentPhrase !== null && (ctx.body ?? "").toLowerCase().includes(config.consentPhrase.toLowerCase())`. An **empty-string** `consentPhrase` (distinct from `null`/unset) makes `"".includes("")` **unconditionally true**, so phrase detection silently satisfies CLA consent for *every* PR. This is reachable in practice: the dashboard/API-settable `claConsentPhrase` (`z.string().nullable().optional()`, no non-empty validation) flows in unmodified, and `?? null` at the call site only substitutes for `undefined`/`null`, not `""`.

**Fix:** normalize a blank/whitespace-only `consentPhrase` to `null` once at the top of `evaluateClaCheck`, and use that normalized value at all three sites — mirroring the config-as-code path (focus-manifest `normalizeOptionalString`) which already treats empty/whitespace as `null`. A blank phrase now behaves exactly as if unset: with a check-run configured, the check-run path decides; with nothing else configured, it returns `[]` (nothing configured), never a silent bypass.

Scoped strictly to `consentPhrase` input normalization — the escalation/severity contract (`CLA_CONSENT_MISSING_CODE`/`CLA_CHECK_UNRESOLVED_CODE`), the either-method-holds logic, and `isConfiguredGateBlocker` are untouched. Adds regression tests for `consentPhrase: ""` and `"   "` (asserting no unconditional satisfaction) plus a non-empty regression. **100% statements/branches/functions/lines** on the touched file (verified locally: vitest coverage + engine build + `tsc --noEmit` clean on the changed file).