### PR TITLE
fix(engine): clamp rate-limit retryAfterMs to at most one window on a backward clock

### DIFF
--- a/packages/loopover-engine/src/governor/rate-limit.ts
+++ b/packages/loopover-engine/src/governor/rate-limit.ts
@@ -68,7 +68,10 @@ export function evaluateLocalRateLimit(
 
   const allowed = effectiveCount < limit;
   const remaining = allowed ? limit - effectiveCount - 1 : 0;
-  const retryAfterMs = allowed ? 0 : Math.max(0, resetAtMs - now);
+  // Clamp to at most one window (#5829): `windowElapsed` only detects a FORWARD clock, so if `now` steps BACKWARD
+  // relative to `windowStartMs` (an NTP correction or container/VM clock reset) `resetAtMs - now` grows by the jump
+  // distance on top of `windowMs` — a rolling-window limiter must never report a wait longer than its own window.
+  const retryAfterMs = allowed ? 0 : Math.min(windowMs, Math.max(0, resetAtMs - now));
 
   return { allowed, limit, remaining, resetAtMs, retryAfterMs };
 }

--- a/test/unit/governor-rate-limit-backoff.test.ts
+++ b/test/unit/governor-rate-limit-backoff.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { evaluateLocalRateLimit } from "../../packages/loopover-engine/src/governor/rate-limit.js";
+
+// #5829: rate-limit.ts had no dedicated test — it was only exercised indirectly, never with `nowMs` moving BACKWARD
+// relative to a bucket's `windowStartMs`. These pin `retryAfterMs` to at most one window regardless of clock jumps.
+describe("evaluateLocalRateLimit retryAfterMs clamp (#5829)", () => {
+  const config = { limit: 5, windowMs: 60_000 };
+
+  it("reports no wait when the event is allowed", () => {
+    const decision = evaluateLocalRateLimit({ count: 2, windowStartMs: 0 }, config, 1_000);
+    expect(decision.allowed).toBe(true);
+    expect(decision.retryAfterMs).toBe(0);
+  });
+
+  it("reports the remaining window when blocked under a normal forward clock (no clamp needed)", () => {
+    const decision = evaluateLocalRateLimit({ count: 5, windowStartMs: 0 }, config, 30_000);
+    expect(decision.allowed).toBe(false);
+    // resetAt (0 + 60_000) minus now (30_000) is already within one window, so the clamp is a no-op.
+    expect(decision.retryAfterMs).toBe(30_000);
+  });
+
+  it("clamps retryAfterMs to at most windowMs after a BACKWARD clock jump", () => {
+    // The recorded window start is far AHEAD of `now` — a clock that stepped backward (NTP/VM reset). Pre-fix this
+    // returned resetAt (100_000 + 60_000) - now (0) = 160_000, ~2.6x the configured 60s window.
+    const decision = evaluateLocalRateLimit({ count: 5, windowStartMs: 100_000 }, config, 0);
+    expect(decision.allowed).toBe(false);
+    expect(decision.retryAfterMs).toBe(config.windowMs); // clamped to 60_000, not 160_000
+    expect(decision.retryAfterMs).toBeLessThanOrEqual(config.windowMs);
+  });
+});


### PR DESCRIPTION
## Summary

`evaluateLocalRateLimit` (the Governor's pure rolling-window rate-limit primitive) computes `retryAfterMs` from `resetAtMs - now`, but its `windowElapsed` check only detects a **forward**-moving clock:

```ts
const windowElapsed = now - windowStartMs >= windowMs;
```

If `nowMs` ever steps **backward** relative to a bucket's `windowStartMs` — a real possibility for a `Date.now()`-derived clock across an NTP correction or a container/VM clock reset — `windowElapsed` stays `false`, `effectiveWindowStart` keeps the old `windowStartMs`, and `resetAtMs - now` grows by the full backward-jump distance on top of `windowMs`. A caller blocked right after a half-second backward step on a 60-second window is told to wait **minutes**, worse the larger the jump (#5829).

**Fix:** clamp `retryAfterMs` to at most one `windowMs`, so a rolling-window limiter can never report a wait longer than its own window:

```ts
const retryAfterMs = allowed ? 0 : Math.min(windowMs, Math.max(0, resetAtMs - now));
```

Forward behavior is **unchanged** — when `resetAtMs - now <= windowMs` (the normal case) the clamp is a no-op. This is the minimal, targeted fix the issue asks for; it does not alter the allow/deny or window-reset logic.

The module had **no dedicated test** (it was only exercised indirectly, never with `nowMs` moving backward). This adds `test/unit/governor-rate-limit-backoff.test.ts` covering the three branches of the changed line: allowed (no wait), blocked under a forward clock (clamp is a no-op), and blocked after a backward clock jump (clamped to `windowMs`, not the inflated value).

## Scope

- [x] Conventional Commit title.
- [x] Focused; a single-line fix + its regression test.
- [x] Follows `CONTRIBUTING.md`; no `site/`/`CNAME`/lovable.
- [x] Linked a currently open issue — Closes #5829.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (root + `@loopover/engine` build) clean
- [x] `npm run test:coverage` — the changed line (`rate-limit.ts:71`) is at **100% line + branch** coverage (verified via the v8 JSON report: the `allowed ? 0` branch, and both sides of the `Math.min` clamp). 3 new tests pass.
- [x] Behavior unchanged for existing consumers: `governor-*`, `chokepoint`, and `write-rate-limit` root-vitest suites pass (218 tests) — the clamp is a no-op on a forward clock.
- [x] Rebased onto the latest `main` immediately before pushing — no base conflict.

If any required check was skipped, explain why:

- `actionlint`, `test:workers`, `ui:*`, `npm audit` were not run — this changes one engine source line + a test; no workflow, worker, UI, or dependency surface. The full `npm run test:ci` runs them on CI. (One local unit test, `miner-mcp-governor-decisions`, fails on this Windows box with `EPERM` on temp dirs — a filesystem env flake that does not import rate-limit and passes on Linux CI.)

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, private keys, raw trust scores, private rankings, or private maintainer evidence exposed. Pure numeric-math change to a side-effect-free calculator; no I/O, no persistence.
- [x] Public GitHub text stays sanitized and low-noise.
- [x] No changelog edited.

Auth/CORS/session, API/OpenAPI/MCP, and UI safety boxes are not applicable.
