### PR TITLE
fix(ci): sync miner engine-version pin on the engine release branch

### DIFF
--- a/.github/workflows/mcp-release-please.yml
+++ b/.github/workflows/mcp-release-please.yml
@@ -64,7 +64,13 @@ jobs:
       # engine-v0.2.0 dry runs left it stale, breaking npm ci with "Missing: <pkg>@<version> from
       # lock file"). Patches it directly on whichever release branch(es) release-please just
       # created/updated, using the same branch naming convention its own commits already rely on.
-      - name: Sync package-lock.json on any release branch
+      #
+      # The engine branch also needs packages/loopover-miner/expected-engine.version bumped to match
+      # packages/loopover-engine/package.json's new version: release-please's engine component only
+      # ever touches files under packages/loopover-engine/**, so it can never update that cross-package
+      # pin itself -- scripts/check-engine-parity.ts's checkMinerEngineVersionPinSync would otherwise
+      # fail on every single engine release PR (confirmed live on the engine-v3.1.0 release PR, #5807).
+      - name: Sync package-lock.json and engine-version pin on any release branch
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -90,6 +96,17 @@ jobs:
               git add package-lock.json
               git commit -m "chore(release): sync package-lock.json"
               git push origin "HEAD:$branch"
+            fi
+            if [ "$component" = "engine" ]; then
+              engine_version="$(node -p "require('./packages/loopover-engine/package.json').version")"
+              printf '%s\n' "$engine_version" > packages/loopover-miner/expected-engine.version
+              if git diff --quiet packages/loopover-miner/expected-engine.version; then
+                echo "expected-engine.version already in sync on $branch."
+              else
+                git add packages/loopover-miner/expected-engine.version
+                git commit -m "chore(release): sync miner engine-version pin"
+                git push origin "HEAD:$branch"
+              fi
             fi
           done
 


### PR DESCRIPTION
## Summary

- The engine release-please branch (e.g. #5807, engine v3.1.0) fails `test:engine-parity` every time, because `scripts/check-engine-parity.ts`'s `checkMinerEngineVersionPinSync` requires `packages/loopover-miner/expected-engine.version` to match `packages/loopover-engine/package.json`'s version, but release-please's `engine` component only ever touches files under `packages/loopover-engine/**` — it has no way to update that cross-package pin.
- Extends the existing "sync package-lock.json on any release branch" step in `mcp-release-please.yml` to also write the pin file whenever the engine branch's version changes, reusing the same fetch/checkout/commit-if-changed pattern already used for the lockfile.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue this PR resolves — maintainer PR fixing a CI defect discovered live on #5807, no linked issue.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [ ] `npm run typecheck` — skipped, no `.ts`/source files touched (workflow-YAML-only change).
- [ ] `npm run test:coverage` — skipped, `src/**` untouched, not covered by Codecov patch, no new branches introduced.
- [ ] `npm run test:workers` / `npm run build:mcp` / `npm run test:mcp-pack` / `npm run ui:*` — skipped, none of these are affected by a `.github/workflows/**`-only change.
- [ ] `npm audit --audit-level=moderate` — skipped, no dependency changes.
- [ ] New or changed behavior has unit/integration tests — the added bash step isn't unit-testable in isolation; validated by dry-running the equivalent `node -p`/`printf`/`git diff --quiet` logic locally against a scratch git repo before pushing.

If any required check was skipped, explain why:

- This is a `.github/workflows/**`-only change (no `src/`, `test/`, or dependency changes), so the JS/TS build, typecheck, coverage, and UI checks have no surface to exercise. `actionlint` (the workflow-syntax validator) passed, and the new bash block's version-read/write/diff logic was manually dry-run locally.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no such changes.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no API/OpenAPI/MCP changes.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section. — N/A, no UI changes.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — this PR does not touch `CHANGELOG.md`.

## Notes

- Discovered while triaging why the `engine` release-please PR (#5807) had cascading `validate-tests` failures despite a clean merge state.