### PR TITLE
fix(review): recognize export const enum and abstract class in impact-symbols

### DIFF
--- a/src/review/impact-symbols.ts
+++ b/src/review/impact-symbols.ts
@@ -34,13 +34,21 @@ const JS_TS_RE = /\.(ts|tsx|js|jsx|mjs|cjs)$/i;
 // name is still useful context even though the import site may not use it). Deliberately narrower than
 // rag.ts's BOUNDARY_RE (which also matches un-exported declarations, since RAG chunking cares about ANY
 // logical boundary, not just the public API).
+//
+// The `enum` alternative is `(?:const\s+)?enum` and sits BEFORE the bare `const|let|var` one on purpose: an
+// `export const enum Foo` must be captured as the enum named `Foo`, not matched by `const|let|var` capturing
+// the literal word "enum" as the name. `class` allows an optional `abstract` prefix so `export abstract class
+// Foo` (and `export default abstract class Foo`) is captured, not silently dropped. Group order —
+// function(1), class(2), enum(3), const/let/var(4), interface(5), type(6) — keeps function/class in groups
+// 1/2 so boundaryKindForMatch stays a two-check-then-default; the reordering only moves groups that all map
+// to the "export" kind anyway.
 const EXPORTED_DECLARATION_RE =
-  /^export\s+(?:default\s+)?(?:async\s+)?(?:function\*?\s+([\w$]+)|class\s+([\w$]+)|(?:const|let|var)\s+([\w$]+)|interface\s+([\w$]+)|type\s+([\w$]+)|enum\s+([\w$]+))/;
+  /^export\s+(?:default\s+)?(?:async\s+)?(?:function\*?\s+([\w$]+)|(?:abstract\s+)?class\s+([\w$]+)|(?:const\s+)?enum\s+([\w$]+)|(?:const|let|var)\s+([\w$]+)|interface\s+([\w$]+)|type\s+([\w$]+))/;
 
 function boundaryKindForMatch(m: RegExpMatchArray): RagBoundary {
-  if (m[2] !== undefined) return "class"; // class NAME
+  if (m[2] !== undefined) return "class"; // (abstract) class NAME
   if (m[1] !== undefined) return "function"; // function NAME
-  return "export"; // const/let/var/interface/type/enum
+  return "export"; // (const) enum / const/let/var / interface / type
 }
 
 /**

--- a/test/unit/impact-symbols.test.ts
+++ b/test/unit/impact-symbols.test.ts
@@ -49,6 +49,36 @@ describe("extractSymbolsFromPatch", () => {
     ]);
   });
 
+  it("extracts `export const enum Foo` as the enum name Foo, not a symbol literally named `enum`", () => {
+    // Regression: the bare `const|let|var` alternative used to match `const enum` first and capture the word
+    // "enum" as the name. The `(?:const\s+)?enum` alternative now takes precedence for this shape.
+    expect(extractSymbolsFromPatch("src/dir.ts", addPatch("export const enum Direction {"))).toEqual([
+      { name: "Direction", kind: "export" },
+    ]);
+  });
+
+  it("still treats a real `export const enumValue = 1` as a const boundary, not an enum", () => {
+    // `enum\s+` requires whitespace after `enum`, so an identifier that merely STARTS with "enum" falls
+    // through to the const/let/var alternative — the fix must not over-capture.
+    expect(extractSymbolsFromPatch("src/util.ts", addPatch("export const enumValue = 1;"))).toEqual([
+      { name: "enumValue", kind: "export" },
+    ]);
+  });
+
+  it("extracts `export abstract class Foo` (previously dropped entirely) as a class", () => {
+    // Regression: there was no `abstract` alternative, so an added/changed abstract base class contributed
+    // zero symbols to the impact map.
+    expect(extractSymbolsFromPatch("src/base.ts", addPatch("export abstract class Foo {"))).toEqual([
+      { name: "Foo", kind: "class" },
+    ]);
+  });
+
+  it("extracts `export default abstract class Foo` as a class (mirrors the default-prefix handling)", () => {
+    expect(extractSymbolsFromPatch("src/base.ts", addPatch("export default abstract class Foo {"))).toEqual([
+      { name: "Foo", kind: "class" },
+    ]);
+  });
+
   it("extracts multiple distinct symbols from the same patch", () => {
     const patch = [
       "@@ -1,2 +1,4 @@",


### PR DESCRIPTION
## Summary

`EXPORTED_DECLARATION_RE` in `src/review/impact-symbols.ts` — the deterministic changed-symbol extractor feeding the impact-map computation (#2183) — had two regex-variant gaps:

1. **`export const enum Direction {}`** matched the bare `(?:const|let|var)\s+([\w$]+)` alternative *before* the `enum` one, capturing the literal word `"enum"` as the symbol name instead of `Direction`.
2. **`export abstract class Foo {}`** matched no alternative at all (there was no `abstract` handling), so an added/changed abstract base class contributed **zero** symbols to the impact map.

## Fix

- Add a `(?:const\s+)?enum\s+([\w$]+)` alternative **ahead of** `const|let|var`, so `const enum` is captured as the enum's real name. `enum\s+` requires trailing whitespace, so a real `export const enumValue = 1` (identifier merely starting with "enum") still falls through to the const boundary — no over-capture.
- Add an optional `(?:abstract\s+)?` prefix to the `class` alternative, covering `export abstract class Foo` and `export default abstract class Foo` (mirroring the existing `default`-prefix handling).
- Group order keeps `function`/`class` in groups 1/2, so **`boundaryKindForMatch` is unchanged** — the reordering only moves groups that all resolve to the `"export"` kind. Public signatures and the empty/unparseable-patch fail-safe are untouched.

## Tests

Extends `test/unit/impact-symbols.test.ts` with regressions for both fixes — `export const enum Direction` → `{ name: "Direction", kind: "export" }` (asserting the *correct* name, not merely that it matches), `export abstract class Foo` and `export default abstract class Foo` → `{ name: "Foo", kind: "class" }`, plus a guard that `export const enumValue = 1` stays a const boundary. All prior declaration-form tests pass unchanged. 100% patch coverage (statements/branches/functions/lines) on the touched module locally.

No regression to previously-working behavior beyond the two corrected cases.

Closes #5841