### PR TITLE
fix(review): add missing duplicationDelta to REES_ANALYZER_NAMES

### DIFF
--- a/src/review/enrichment-analyzer-names.ts
+++ b/src/review/enrichment-analyzer-names.ts
@@ -26,6 +26,7 @@ export const REES_ANALYZER_NAMES = [
   "history",
   "docCommentDrift",
   "duplication",
+  "duplicationDelta",
   "churnHotspot",
   "blameLink",
   "approvalIntegrity",

--- a/test/unit/enrichment-analyzers-taxonomy.test.ts
+++ b/test/unit/enrichment-analyzers-taxonomy.test.ts
@@ -5,6 +5,7 @@ import {
   buildEnrichmentAnalyzersTaxonomyDocument,
   ENRICHMENT_ANALYZERS_URI,
 } from "../../src/review/enrichment-analyzers-taxonomy";
+import { REES_ANALYZER_NAMES } from "../../src/review/enrichment-analyzer-names";
 
 const metadataPath = join(process.cwd(), "review-enrichment/analyzer-metadata.json");
 
@@ -43,5 +44,28 @@ describe("enrichment analyzers taxonomy document", () => {
 
   it("uses the stable MCP resource URI", () => {
     expect(ENRICHMENT_ANALYZERS_URI).toBe("gittensory://enrichment-analyzers");
+  });
+});
+
+describe("REES_ANALYZER_NAMES stays in sync with analyzer-metadata.json", () => {
+  const metadataNames = (
+    JSON.parse(readFileSync(metadataPath, "utf8")) as { analyzers: Array<{ name: string }> }
+  ).analyzers.map((a) => a.name);
+
+  it("covers exactly the analyzers the metadata registry defines (no missing, no extra)", () => {
+    // The canonical name list validates every operator `REES_ANALYZERS` env entry and per-repo
+    // `.loopover.yml review.enrichment` toggle, so an analyzer present in the metadata registry but absent
+    // here is silently un-toggleable/un-selectable. Compared as sets against the registry (the source of
+    // truth) rather than a hardcoded count so a newly-added analyzer can't drift the two apart unnoticed.
+    expect(new Set(REES_ANALYZER_NAMES)).toEqual(new Set(metadataNames));
+  });
+
+  it("includes duplicationDelta alongside duplication (regression for the one-entry gap)", () => {
+    expect(REES_ANALYZER_NAMES).toContain("duplication");
+    expect(REES_ANALYZER_NAMES).toContain("duplicationDelta");
+  });
+
+  it("has no duplicate entries", () => {
+    expect(new Set(REES_ANALYZER_NAMES).size).toBe(REES_ANALYZER_NAMES.length);
   });
 });


### PR DESCRIPTION
## Summary

`REES_ANALYZER_NAMES` in `src/review/enrichment-analyzer-names.ts` is the canonical single-source-of-truth list that validates both the operator `REES_ANALYZERS` env list and per-repo `.loopover.yml` `review.enrichment` toggles. It listed **56** analyzers, but the generated `review-enrichment/analyzer-metadata.json` registry (also surfaced via the MCP taxonomy resource) defines **57** — `"duplicationDelta"` (`defaultEnabled: true`, sitting right next to `"duplication"`) was the one missing entry.

Two concrete, reachable breakages in `src/review/enrichment-wire.ts` as a result:

- `resolveReesAnalyzers` rejected `"duplicationDelta"` as an "invalid" analyzer name for any self-host operator who put it in an explicit `REES_ANALYZERS` env list.
- `resolveEnrichmentAnalyzerSelection` could never let a repo owner toggle `duplicationDelta` per-repo via `.loopover.yml review.enrichment`.

## Fix

Add `"duplicationDelta"` to the list, immediately after `"duplication"` (matching the registry's own ordering), so the canonical list is once again an exact match for the metadata registry.

## Tests

Adds a parity block to `test/unit/enrichment-analyzers-taxonomy.test.ts`:

- `REES_ANALYZER_NAMES` covers **exactly** the analyzers the metadata registry defines — compared as **sets against the registry** (the source of truth), not a hardcoded count, so a newly-added analyzer can't silently drift the two apart again.
- Regression assertion that both `duplication` and `duplicationDelta` are present.
- A no-duplicate-entries guard.

100% patch coverage on the touched module locally.

Closes #5839