### PR TITLE
test(selfhost): cover jobCoalesceKey missing-field fallbacks for 6 job types

### DIFF
--- a/test/unit/selfhost-queue-common.test.ts
+++ b/test/unit/selfhost-queue-common.test.ts
@@ -929,6 +929,18 @@ describe("self-host queue common helpers", () => {
     parse.mockRestore();
   });
 
+  it("uses each job type's missing-field fallback tokens when optional fields are absent (#5850)", () => {
+    // A payload carrying only `type` (no repo/mode/segment/cursor/login/day) must coalesce to the type's
+    // literal fallback key rather than null-ing or duplicating — the normalizers return null on a missing
+    // field, so the `?? "<fallback>"` arm is taken. boolFlag(undefined) === "0".
+    expect(jobCoalesceKey(payload({ type: "backfill-registered-repos" }))).toBe("backfill-registered-repos:all:default:0");
+    expect(jobCoalesceKey(payload({ type: "backfill-repo-segment" }))).toBe("backfill-repo-segment:unknown:unknown:default:0:start");
+    expect(jobCoalesceKey(payload({ type: "backfill-pr-details" }))).toBe("backfill-pr-details:unknown:default:start");
+    expect(jobCoalesceKey(payload({ type: "generate-review-recap" }))).toBe("generate-review-recap:all");
+    expect(jobCoalesceKey(payload({ type: "refresh-contributor-activity" }))).toBe("refresh-contributor-activity:unknown:all");
+    expect(jobCoalesceKey(payload({ type: "rollup-product-usage" }))).toBe("rollup-product-usage:latest:default");
+  });
+
   it("coalesces CI-completion webhooks with sorted pull numbers", () => {
     expect(jobCoalesceKey(payload({ type: "agent-regate-pr", repoFullName: "JSONbored/Gittensory", prNumber: 7 }))).toBe("agent-regate-pr:jsonbored/gittensory#7");
     expect(jobCoalesceKey(payload({ type: "agent-regate-pr", repoFullName: "JSONbored/Gittensory" }))).toBeNull();


### PR DESCRIPTION
Fixes #5850.

`jobCoalesceKey` (src/selfhost/queue-common.ts) maps a job payload to a coalesce key. For several job types it fills a missing optional field with a literal fallback token (`normalizedX(...) ?? "<fallback>"`) so the job still coalesces to a stable slot instead of null-ing (and duplicating). Those fallback arms had no direct coverage.

Test-only (no production change): adds one case asserting the exact fallback key when the optional fields are absent, for six job types:

- `backfill-registered-repos` → `…:all:default:0`
- `backfill-repo-segment` → `…:unknown:unknown:default:0:start`
- `backfill-pr-details` → `…:unknown:default:start`
- `generate-review-recap` → `…:all`
- `refresh-contributor-activity` → `…:unknown:all`
- `rollup-product-usage` → `…:latest:default`

All 85 tests in the file pass; typecheck clean.