### PR TITLE
fix(engine): normalize worktree-pool maxConcurrency so a NaN cap can't allocate unbounded

### DIFF
--- a/packages/loopover-engine/src/miner/worktree-pool.ts
+++ b/packages/loopover-engine/src/miner/worktree-pool.ts
@@ -36,6 +36,15 @@ export type AcquireWorktreeResult =
   | { ok: true; state: WorktreePoolState; allocation: WorktreeAllocation }
   | { ok: false; reason: "already_allocated" | "at_capacity"; state: WorktreePoolState };
 
+// Normalize the concurrency cap the same way the sibling limit calculators do (governor/rate-limit.ts,
+// governor/budget-cap.ts, tenant-quota.ts): a NaN/non-finite/negative/fractional `maxConcurrency` arriving from a
+// loosely-typed or untrusted source becomes a non-negative integer, so it can never make a `>=`/subtraction
+// comparison silently fail — a `NaN` cap would otherwise make `length >= NaN` always false and allocate without
+// bound, contradicting the type's "A non-positive cap allocates nothing" contract (#5828).
+function finiteNonNegativeInt(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
 /** True when `attemptId` currently holds an allocation. Pure. */
 export function isWorktreeAllocated(state: WorktreePoolState, attemptId: string): boolean {
   return state.allocations.some((allocation) => allocation.attemptId === attemptId);
@@ -43,7 +52,7 @@ export function isWorktreeAllocated(state: WorktreePoolState, attemptId: string)
 
 /** Slots still available before the concurrency cap (never negative). Pure. */
 export function availableWorktreeSlots(state: WorktreePoolState, config: WorktreePoolConfig): number {
-  return Math.max(0, config.maxConcurrency - state.allocations.length);
+  return Math.max(0, finiteNonNegativeInt(config.maxConcurrency) - state.allocations.length);
 }
 
 /**
@@ -60,7 +69,7 @@ export function acquireWorktree(
   if (isWorktreeAllocated(state, input.attemptId)) {
     return { ok: false, reason: "already_allocated", state };
   }
-  if (state.allocations.length >= config.maxConcurrency) {
+  if (state.allocations.length >= finiteNonNegativeInt(config.maxConcurrency)) {
     return { ok: false, reason: "at_capacity", state };
   }
   const allocation: WorktreeAllocation = {

--- a/test/unit/miner-worktree-pool.test.ts
+++ b/test/unit/miner-worktree-pool.test.ts
@@ -79,3 +79,27 @@ describe("worktree pool allocator (#4297)", () => {
     expect(availableWorktreeSlots(s, { maxConcurrency: 1 })).toBe(0);
   });
 });
+
+describe("worktree pool maxConcurrency normalization (#5828)", () => {
+  it("treats a NaN cap as zero — allocates nothing instead of unbounded", () => {
+    expect(availableWorktreeSlots(EMPTY_WORKTREE_POOL, { maxConcurrency: Number.NaN })).toBe(0);
+    const r = acquireWorktree(EMPTY_WORKTREE_POOL, { maxConcurrency: Number.NaN }, { attemptId: "a", repoPath: REPO });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("at_capacity");
+  });
+
+  it("treats a negative cap as zero", () => {
+    expect(availableWorktreeSlots(EMPTY_WORKTREE_POOL, { maxConcurrency: -3 })).toBe(0);
+    expect(acquireWorktree(EMPTY_WORKTREE_POOL, { maxConcurrency: -3 }, { attemptId: "a", repoPath: REPO }).ok).toBe(false);
+  });
+
+  it("floors a fractional cap to a whole number of slots", () => {
+    const cfg = { maxConcurrency: 2.7 };
+    expect(availableWorktreeSlots(EMPTY_WORKTREE_POOL, cfg)).toBe(2);
+    const s1 = acquireWorktree(EMPTY_WORKTREE_POOL, cfg, { attemptId: "a", repoPath: REPO });
+    const s2 = s1.ok ? acquireWorktree(s1.state, cfg, { attemptId: "b", repoPath: REPO }) : s1;
+    const s3 = s2.ok ? acquireWorktree(s2.state, cfg, { attemptId: "c", repoPath: REPO }) : s2;
+    expect(s1.ok && s2.ok).toBe(true);
+    expect(s3.ok).toBe(false); // floor(2.7) = 2, so the third slot is at capacity
+  });
+});


### PR DESCRIPTION
## Summary

`worktree-pool.ts`'s `availableWorktreeSlots` and `acquireWorktree` compared allocations against a **raw** `config.maxConcurrency`:

```ts
export function availableWorktreeSlots(state, config): number {
  return Math.max(0, config.maxConcurrency - state.allocations.length);
}
// acquireWorktree:
if (state.allocations.length >= config.maxConcurrency) { return { ok: false, reason: "at_capacity", state }; }
```

If `config.maxConcurrency` is ever `NaN` — e.g. a caller derives it from `Number(someUnparsableConfigValue)` upstream without guarding — every comparison against it is `false` (`length >= NaN` is always `false`), so `at_capacity` never fires and the pool **allocates worktrees without bound**, directly contradicting the type's own documented contract ("A non-positive cap allocates nothing"). `availableWorktreeSlots` also returns `NaN`, silently breaking any caller (dashboard/scheduler) that treats its return as a real remaining-slots count (#5828).

**Fix:** normalize `maxConcurrency` via the same `finiteNonNegativeInt` pattern the sibling limit calculators in this package already use — `governor/rate-limit.ts`, `governor/budget-cap.ts`, and `tenant-quota.ts` — at both call sites, so a `NaN`/non-finite/negative/fractional cap becomes a non-negative integer (`NaN`/negative → `0` = "allocates nothing"; `2.7` → `2`). `worktree-pool.ts` was the one module in this family that skipped it.

The file's tests only exercised a normal positive cap and a shrunk (still finite, still positive) cap. This adds the missing cases: a `NaN` cap allocates nothing (no unbounded allocation), a negative cap is treated as zero, and a fractional cap floors to a whole number of slots.

## Scope

- [x] Conventional Commit title.
- [x] Focused; a defensive-normalization fix + its tests.
- [x] Follows `CONTRIBUTING.md`; no `site/`/`CNAME`/lovable.
- [x] Linked a currently open issue — Closes #5828.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (root + `@loopover/engine` build) clean
- [x] `npm run test:coverage` — every changed line (the `finiteNonNegativeInt` helper's `Number.isFinite` ternary, and both normalized call sites) is at **100% line + branch** coverage via the v8 JSON report; 3 new tests pass alongside the 7 existing ones.
- [x] Existing positive-cap behavior is unchanged — the normalization is a no-op for a valid finite non-negative integer cap.
- [x] Rebased onto the latest `main` immediately before pushing — no base conflict.

If any required check was skipped, explain why:

- `actionlint`, `test:workers`, `ui:*`, `npm audit` were not run — this changes one engine source file + its test; no workflow, worker, UI, or dependency surface. The full `npm run test:ci` runs them on CI.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, private keys, raw trust scores, private rankings, or private maintainer evidence exposed. Pure defensive input normalization in a side-effect-free scheduler; no I/O, no persistence.
- [x] Public GitHub text stays sanitized and low-noise.
- [x] No changelog edited.

Auth/CORS/session, API/OpenAPI/MCP, and UI safety boxes are not applicable.
