### PR TITLE
fix(signals): flag the .at(-1)/.at(0) idiom in boundary-test-generation

### DIFF
--- a/src/signals/boundary-test-generation.ts
+++ b/src/signals/boundary-test-generation.ts
@@ -32,7 +32,11 @@ export type BoundaryTouch = {
 // true-positive set). Each pattern only matches an ADDED line (a line starting with a single `+`, not `++`
 // which is the `+++ b/file` patch header) so this only ever reacts to genuinely new code, never context lines
 // or the file the diff is against.
-const ARRAY_INDEX_BOUNDS_PATTERN = /\[\s*(?:[\w.]+\.length|[\w.]+\.length\s*-\s*1|-1)\s*\]|\.length\s*(?:-\s*1)?\s*[<>]=?/;
+// The `.at(<literal>)` alternative catches the modern `arr.at(-1)` / `arr.at(0)` last-element/off-by-one
+// idiom (bracket forms above miss it). Deliberately only a NUMERIC literal argument (optionally negative):
+// a bare identifier like `.at(idx)` carries none of the specific boundary signal `-1`/`0` does, and matching
+// it would reintroduce the false-positive noise this pattern set is kept small to avoid.
+const ARRAY_INDEX_BOUNDS_PATTERN = /\[\s*(?:[\w.]+\.length|[\w.]+\.length\s*-\s*1|-1)\s*\]|\.length\s*(?:-\s*1)?\s*[<>]=?|\.at\(\s*-?\d+\s*\)/;
 const NULL_OR_UNDEFINED_BRANCH_PATTERN = /(?:===?|!==?)\s*(?:null|undefined)\b|\b(?:null|undefined)\s*(?:===?|!==?)|\?\?|\?\./;
 const EMPTY_COLLECTION_CHECK_PATTERN = /\.length\s*(?:===?|!==?|[<>]=?)\s*0\b|\blen\(.*\)\s*(?:===?|!==?|[<>]=?)\s*0\b|\.(?:isEmpty|is_empty)\s*\(/;
 

--- a/test/unit/boundary-test-generation.test.ts
+++ b/test/unit/boundary-test-generation.test.ts
@@ -12,6 +12,19 @@ describe("detectBoundaryTouches", () => {
     expect(touches[0]).toMatchObject({ path: "src/list.ts", kind: "array_index_bounds" });
   });
 
+  it("detects the modern `.at(<literal>)` last-element/off-by-one idiom as array/index bounds", () => {
+    for (const line of ["+const last = items.at(-1);\n", "+const head = items.at(0);\n", "+const penult = rows.at(-2);\n"]) {
+      const touches = detectBoundaryTouches([{ path: "src/list.ts", patch: line }]);
+      expect(touches).toHaveLength(1);
+      expect(touches[0]?.kind).toBe("array_index_bounds");
+    }
+  });
+
+  it("does NOT flag `.at(<identifier>)` — a non-literal argument carries no off-by-one boundary signal", () => {
+    // Narrow-scope guard (#1972): only a numeric literal argument is a boundary tell; `.at(idx)` is not.
+    expect(detectBoundaryTouches([{ path: "src/list.ts", patch: "+const item = items.at(idx);\n" }])).toHaveLength(0);
+  });
+
   it("detects a null/undefined branch pattern in an added line", () => {
     const touches = detectBoundaryTouches([{ path: "src/user.ts", patch: "@@ -1,1 +1,2 @@\n+if (user === null) return defaultUser;\n" }]);
     expect(touches).toHaveLength(1);


### PR DESCRIPTION
## Summary

`ARRAY_INDEX_BOUNDS_PATTERN` in `src/signals/boundary-test-generation.ts` (the array/index-bounds detector for the `#1972` boundary-safe test-generation signal) matched bracket-index forms (`arr[arr.length - 1]`, `arr[-1]`) and `.length` comparisons, but **not** the modern `Array.prototype.at()` idiom (`arr.at(-1)`, `arr.at(0)`) — the standard JS/TS way to express exactly the last-element/off-by-one access this detector exists to flag. Verified: `ARRAY_INDEX_BOUNDS_PATTERN.test("items.at(-1)")` returned `false`, so that access silently evaded the signal.

## Fix

Add a `\.at\(\s*-?\d+\s*\)` alternative to the pattern. Kept narrow per the module's own stated design principle ("deliberately SMALL and PRECISE — false positives are worse than a narrow true-positive set", `#1972`): only a **numeric literal** argument (optionally negative) matches. A bare identifier like `.at(idx)` carries none of the specific `-1`/`0` boundary signal and matching it would reintroduce the false-positive noise the pattern set is kept small to avoid.

Single-pattern, additive regex change — no change to `NULL_OR_UNDEFINED_BRANCH_PATTERN`, `EMPTY_COLLECTION_CHECK_PATTERN`, `BOUNDARY_PATTERNS`, `BoundaryPatternKind`, `MAX_TOUCHES`, or the added-line-only scanning.

## Tests

Extends `test/unit/boundary-test-generation.test.ts`:

- `array_index_bounds` now fires for `items.at(-1)`, `items.at(0)`, and `rows.at(-2)`.
- A negative test confirms `.at(idx)` (non-literal argument) does **not** trigger the pattern, per the narrow-scope requirement.
- All existing bracket-index / `.length`-comparison tests pass unmodified.

100% patch coverage on the touched line locally.

Closes #5843