### PR TITLE
fix(review): treat an empty consent phrase as unconfigured, not auto-satisfied

### DIFF
--- a/src/review/cla-check.ts
+++ b/src/review/cla-check.ts
@@ -50,8 +50,12 @@ export function evaluateClaCheck(
   config: ClaCheckConfig,
   ctx: { body?: string | null | undefined; checkRunConclusion?: string | null | undefined },
 ): AdvisoryFinding[] {
-  if (config.consentPhrase === null && config.checkRunName === null) return []; // nothing configured ⇒ no finding
-  const phraseSatisfied = config.consentPhrase !== null && (ctx.body ?? "").toLowerCase().includes(config.consentPhrase.toLowerCase());
+  // An empty-string consentPhrase is not a usable detection method: a case-insensitive `.includes("")` matches
+  // EVERY body, which would silently satisfy CLA consent for every PR. Treat it as "phrase detection not
+  // configured" (same as null) — so it never satisfies consent, and never emits a nonsensical `must contain ""`.
+  const consentPhrase = config.consentPhrase === "" ? null : config.consentPhrase;
+  if (consentPhrase === null && config.checkRunName === null) return []; // nothing configured ⇒ no finding
+  const phraseSatisfied = consentPhrase !== null && (ctx.body ?? "").toLowerCase().includes(consentPhrase.toLowerCase());
   const checkRunSatisfied = config.checkRunName !== null && (ctx.checkRunConclusion === "success" || ctx.checkRunConclusion === "neutral");
   if (phraseSatisfied || checkRunSatisfied) return [];
   // A configured check-run whose conclusion is unresolved: cannot confirm OR deny consent via that method, so
@@ -69,7 +73,7 @@ export function evaluateClaCheck(
     ];
   }
   const missing: string[] = [];
-  if (config.consentPhrase !== null) missing.push(`the PR description must contain "${config.consentPhrase}"`);
+  if (consentPhrase !== null) missing.push(`the PR description must contain "${consentPhrase}"`);
   if (config.checkRunName !== null) missing.push(`the "${config.checkRunName}" check must pass`);
   return [
     {

--- a/test/unit/cla-check.test.ts
+++ b/test/unit/cla-check.test.ts
@@ -113,4 +113,24 @@ describe("evaluateClaCheck (#2564)", () => {
       expect(out[0]?.code).toBe(CLA_CHECK_UNRESOLVED_CODE);
     });
   });
+
+  // Regression: an empty-string consentPhrase (distinct from null) must NOT unconditionally satisfy consent —
+  // `"".includes("")`/any `body.includes("")` is always true, which previously bypassed CLA for every PR. An
+  // empty phrase is treated as "phrase detection not configured" (same as null).
+  describe("empty-string consentPhrase is treated as not configured (regression)", () => {
+    it("does NOT satisfy consent: an empty phrase alongside a failing check-run still fails, and never lists a nonsensical empty phrase", () => {
+      const out = evaluateClaCheck(config({ consentPhrase: "", checkRunName: "CLA Assistant Lite" }), {
+        body: "any body at all",
+        checkRunConclusion: "failure",
+      });
+      expect(out).toHaveLength(1);
+      expect(out[0]?.code).toBe(CLA_CONSENT_MISSING_CODE);
+      expect(out[0]?.detail).toContain('the "CLA Assistant Lite" check must pass');
+      expect(out[0]?.detail).not.toContain('must contain ""');
+    });
+
+    it("with no other method configured, an empty phrase is 'nothing configured' → no finding (not a silent bypass, not a nonsensical failure)", () => {
+      expect(evaluateClaCheck(config({ consentPhrase: "" }), { body: "anything" })).toEqual([]);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Closes #5838

`evaluateClaCheck` (`src/review/cla-check.ts`) computed `phraseSatisfied = config.consentPhrase !== null && (ctx.body ?? "").toLowerCase().includes(config.consentPhrase.toLowerCase())`. When `consentPhrase` is the **empty string `""`** (distinct from `null` — `claConsentPhrase` is a dashboard/API-settable `z.string().nullable()` field), `"" !== null` is `true` and any `body.includes("")` is unconditionally `true`, so `phraseSatisfied` was **always true** — silently satisfying CLA consent for every PR, even one whose configured CLA check-run was *failing*.

**Fix:** normalize an empty `consentPhrase` to `null` at the top of the function, so it is treated as "phrase detection not configured" (the same as `null`) — it never satisfies consent, and never emits a nonsensical `the PR description must contain ""` requirement. This matches the field's documented contract (*"`null` ⇒ phrase-match detection is not configured"*).

## Scope

- [x] Conventional Commit title (`fix(review): …`).
- [x] Focused: one-function correctness fix + regression tests.
- [x] Follows `CONTRIBUTING.md`; no `site/`/`CNAME`/VitePress.
- [x] Linked open issue (Closes #5838, above).

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` clean
- [x] `npm run test:coverage` on `src/review/cla-check.ts`: **100% lines & branches (25/25)** — the new empty-vs-non-empty normalization branch is covered by the added tests; existing tests cover the null/non-empty paths.
- [x] Regression tests: an empty phrase + a failing check-run now hard-fails (`cla_consent_missing`) listing **only** the check-run (never `must contain ""`); an empty phrase with no other method configured is "nothing configured" → no finding.

If any required check was skipped, explain why:

- Full `test:ci` not run end-to-end locally (Linux-only shell/self-host steps on Windows); the change-relevant gates (typecheck, focused coverage, the cla-check suite) were validated directly.

## Safety

- [x] No secrets, wallets, hotkeys, trust scores, rewards, private rankings, or private maintainer evidence. This tightens a consent bypass (fails safe: an empty phrase no longer auto-satisfies CLA).
- [x] No auth/cookie/CORS/GitHub App/session change (pure evaluator over caller-supplied data).
- [x] No API/OpenAPI/MCP behavior change.
- [x] No UI changes; no changelog edit.
