### PR TITLE
test(miner): rename gittensory-miner/ams prose to loopover-miner/ams

### DIFF
--- a/packages/loopover-miner/scripts/benchmark.mjs
+++ b/packages/loopover-miner/scripts/benchmark.mjs
@@ -114,7 +114,7 @@ export function runLocalStoreBenchmark(options = {}) {
 
 /** Render benchmark results as a stable, greppable text report (no locale-dependent number formatting). */
 export function formatBenchmarkReport(results) {
-  const lines = ["gittensory-miner benchmark", ""];
+  const lines = ["loopover-miner benchmark", ""];
   for (const result of results) {
     lines.push(
       `${result.name}: median ${result.medianMs.toFixed(2)}ms over ${result.iterations} runs, ` +

--- a/test/unit/check-miner-package.test.ts
+++ b/test/unit/check-miner-package.test.ts
@@ -40,13 +40,13 @@ describe("check-miner-package script", () => {
       CHECK_MINER_PACK_TEST_FILES: JSON.stringify([
         "package.json",
         "bin/loopover-miner.js",
-        "bin/gittensory-miner-backdoor.js",
+        "bin/loopover-miner-backdoor.js",
         "lib/cli.js",
       ]),
       CHECK_MINER_PACK_TEST_CONTENT: "console.log('not secret');",
     });
     expect(result.status).toBe(1);
-    expect(result.out).toContain("Unexpected file in miner package: bin/gittensory-miner-backdoor.js");
+    expect(result.out).toContain("Unexpected file in miner package: bin/loopover-miner-backdoor.js");
   });
 
   it("REGRESSION (#3704 caused main to go red, fixed by flattening lib/ instead of widening this allowlist): rejects a lib module nested one level under a subdirectory", () => {

--- a/test/unit/coding-agent-miner.test.ts
+++ b/test/unit/coding-agent-miner.test.ts
@@ -660,7 +660,7 @@ describe("lint-guarded edit wrapper (#4276)", () => {
     ]);
   });
 
-  it("guardChangedFiles reports a node --check syntax error in a gittensory-miner JS file", async () => {
+  it("guardChangedFiles reports a node --check syntax error in a loopover-miner JS file", async () => {
     const { spawn } = recordingSpawn({
       "node --check packages/loopover-miner/lib/cli.js": {
         code: 1,

--- a/test/unit/mcp-miner-prompts.test.ts
+++ b/test/unit/mcp-miner-prompts.test.ts
@@ -22,7 +22,7 @@ async function connectTestClient() {
   const mcpServer = new LoopoverMcp(createTestEnv()).createServer();
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
   await mcpServer.connect(serverTransport);
-  const client = new Client({ name: "gittensory-miner-test", version: "0.1.0" }, { capabilities: {} });
+  const client = new Client({ name: "loopover-miner-test", version: "0.1.0" }, { capabilities: {} });
   await client.connect(clientTransport);
   return { client, mcpServer };
 }

--- a/test/unit/miner-ams-policy.test.ts
+++ b/test/unit/miner-ams-policy.test.ts
@@ -17,7 +17,7 @@ afterEach(() => {
 });
 
 function tempRoot() {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-ams-policy-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-ams-policy-"));
   roots.push(root);
   return root;
 }

--- a/test/unit/miner-attempt-log.test.ts
+++ b/test/unit/miner-attempt-log.test.ts
@@ -21,7 +21,7 @@ const roots: string[] = [];
 const logs: Array<{ close(): void }> = [];
 
 function tempAttemptLog() {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-attempt-log-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-attempt-log-"));
   roots.push(root);
   const log = initAttemptLog(join(root, "nested", "attempt-log.sqlite3"));
   logs.push(log);
@@ -41,7 +41,7 @@ afterEach(() => {
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
 
-describe("gittensory-miner attempt log (#4294)", () => {
+describe("loopover-miner attempt log (#4294)", () => {
   it("resolves the DB path from env override, miner config dir, XDG config, then the home default", () => {
     expect(resolveAttemptLogDbPath({ LOOPOVER_MINER_ATTEMPT_LOG_DB: "/custom/a.sqlite3" })).toBe(
       "/custom/a.sqlite3",
@@ -211,7 +211,7 @@ describe("gittensory-miner attempt log (#4294)", () => {
   });
 
   it("uses the default singleton helpers and closes cleanly", () => {
-    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-attempt-log-default-"));
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-attempt-log-default-"));
     roots.push(root);
     const previousConfigDir = process.env.LOOPOVER_MINER_CONFIG_DIR;
     process.env.LOOPOVER_MINER_CONFIG_DIR = root;
@@ -252,7 +252,7 @@ describe("gittensory-miner attempt log (#4294)", () => {
   });
 
   it("migrates a pre-#5185 on-disk file missing provider/cost_usd/tokens_used columns", () => {
-    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-attempt-log-migrate-"));
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-attempt-log-migrate-"));
     roots.push(root);
     const dbPath = join(root, "attempt-log.sqlite3");
     const raw = new DatabaseSync(dbPath);
@@ -294,7 +294,7 @@ describe("gittensory-miner attempt log (#4294)", () => {
   });
 
   it("re-opening an already-migrated file is a no-op: no duplicate/failing ALTER TABLE", () => {
-    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-attempt-log-reopen-"));
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-attempt-log-reopen-"));
     roots.push(root);
     const dbPath = join(root, "attempt-log.sqlite3");
 

--- a/test/unit/miner-attempt-runner.test.ts
+++ b/test/unit/miner-attempt-runner.test.ts
@@ -27,7 +27,7 @@ const roots: string[] = [];
 const closers: Array<{ close(): void }> = [];
 
 function tempEventLedger() {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-attempt-runner-events-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-attempt-runner-events-"));
   roots.push(root);
   const ledger = initEventLedger(join(root, "db.sqlite3"));
   closers.push(ledger);
@@ -35,7 +35,7 @@ function tempEventLedger() {
 }
 
 function tempGovernorLedger() {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-attempt-runner-governor-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-attempt-runner-governor-"));
   roots.push(root);
   const ledger = initGovernorLedger(join(root, "governor-ledger.sqlite3"));
   closers.push(ledger);
@@ -45,7 +45,7 @@ function tempGovernorLedger() {
 // Isolated per test: without this, evaluateGovernorChokepointGatePersisted's own default-store fallback
 // would open the REAL ~/.config/loopover-miner/governor-state.sqlite3 on whatever machine runs these tests.
 function tempGovernorState() {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-attempt-runner-governor-state-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-attempt-runner-governor-state-"));
   roots.push(root);
   const state = openGovernorState(join(root, "governor-state.sqlite3"));
   closers.push(state);
@@ -280,7 +280,7 @@ describe("runMinerAttempt (#2337) — the real create->review->gate->submit pipe
   });
 
   it("falls back to the real default governor-ledger append when governorLedgerAppend is omitted", async () => {
-    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-attempt-runner-default-governor-"));
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-attempt-runner-default-governor-"));
     roots.push(root);
     vi.stubEnv("LOOPOVER_MINER_GOVERNOR_LEDGER_DB", join(root, "default-governor.sqlite3"));
     const deps = baseDeps();
@@ -293,7 +293,7 @@ describe("runMinerAttempt (#2337) — the real create->review->gate->submit pipe
   });
 
   it("falls back to the real default governor-state store when governorState is omitted", async () => {
-    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-attempt-runner-default-governor-state-"));
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-attempt-runner-default-governor-state-"));
     roots.push(root);
     vi.stubEnv("LOOPOVER_MINER_GOVERNOR_STATE_DB", join(root, "default-governor-state.sqlite3"));
     const deps = baseDeps();
@@ -413,7 +413,7 @@ describe("runMinerAttempt — real self-plagiarism wiring into the chokepoint (#
   it("reads the real default governor-state store when no governorState dep is supplied (production path)", async () => {
     // deps omit governorState, so BOTH the chokepoint's own default-store fallback AND this module's late
     // augmentation read the same env-pointed store; a matching prior submission there throttles.
-    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-attempt-runner-default-gs-"));
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-attempt-runner-default-gs-"));
     roots.push(root);
     vi.stubEnv("LOOPOVER_MINER_GOVERNOR_STATE_DB", join(root, "governor-state.sqlite3"));
     recordOwnSubmission({

--- a/test/unit/miner-attempt-worktree.test.ts
+++ b/test/unit/miner-attempt-worktree.test.ts
@@ -57,7 +57,7 @@ describe("createRealWorktreeExec (#5132)", () => {
 
 describe("prepareAttemptWorktree / cleanupAttemptWorktree (#5132)", () => {
   it("REGRESSION: worktreePath is a real, checked-out git repo on a real branch, not an empty directory", async () => {
-    const root = tempRoot("gittensory-miner-attempt-worktree-");
+    const root = tempRoot("loopover-miner-attempt-worktree-");
     const originPath = initOriginRepo(root);
     const cloneBaseDir = join(root, "cache");
 
@@ -75,7 +75,7 @@ describe("prepareAttemptWorktree / cleanupAttemptWorktree (#5132)", () => {
   });
 
   it("removes a succeeded attempt's worktree but retains a failed one's, per the engine's own retention policy", async () => {
-    const root = tempRoot("gittensory-miner-attempt-worktree-cleanup-");
+    const root = tempRoot("loopover-miner-attempt-worktree-cleanup-");
     const originPath = initOriginRepo(root);
     const cloneBaseDir = join(root, "cache");
 
@@ -93,7 +93,7 @@ describe("prepareAttemptWorktree / cleanupAttemptWorktree (#5132)", () => {
   });
 
   it("returns ok:false when the base clone cannot be prepared, without attempting git worktree add", async () => {
-    const root = tempRoot("gittensory-miner-attempt-worktree-clonefail-");
+    const root = tempRoot("loopover-miner-attempt-worktree-clonefail-");
     const cloneBaseDir = join(root, "cache");
     const execSpy = vi.fn();
 
@@ -111,7 +111,7 @@ describe("prepareAttemptWorktree / cleanupAttemptWorktree (#5132)", () => {
   });
 
   it("returns ok:false with git's real stderr when git worktree add fails (e.g. an unknown base branch)", async () => {
-    const root = tempRoot("gittensory-miner-attempt-worktree-addfail-");
+    const root = tempRoot("loopover-miner-attempt-worktree-addfail-");
     const originPath = initOriginRepo(root);
     const cloneBaseDir = join(root, "cache");
 

--- a/test/unit/miner-backup-restore-scripts.test.ts
+++ b/test/unit/miner-backup-restore-scripts.test.ts
@@ -13,7 +13,7 @@ import { afterEach, describe, expect, it } from "vitest";
 const tmpRoots: string[] = [];
 
 function tmpRoot(): string {
-  const dir = mkdtempSync(join(tmpdir(), "gittensory-miner-backup-"));
+  const dir = mkdtempSync(join(tmpdir(), "loopover-miner-backup-"));
   tmpRoots.push(dir);
   return dir;
 }

--- a/test/unit/miner-benchmark-script.test.ts
+++ b/test/unit/miner-benchmark-script.test.ts
@@ -9,7 +9,7 @@ import {
   runRankingBenchmark,
 } from "../../packages/loopover-miner/scripts/benchmark.mjs";
 
-describe("gittensory-miner benchmark script (#4845)", () => {
+describe("loopover-miner benchmark script (#4845)", () => {
   it("REGRESSION: synthetic candidate generation is byte-for-byte deterministic across calls", () => {
     expect(buildSyntheticCandidates(50)).toEqual(buildSyntheticCandidates(50));
   });
@@ -63,7 +63,7 @@ describe("gittensory-miner benchmark script (#4845)", () => {
       ]),
     ).toBe(
       [
-        "gittensory-miner benchmark",
+        "loopover-miner benchmark",
         "",
         "discovery-fanout-ranking: median 12.35ms over 5 runs, 40502 ops/sec (n=500)",
         "local-store-read-write: median 8.00ms over 5 runs, 125000 ops/sec (n=1000)",
@@ -77,7 +77,7 @@ describe("gittensory-miner benchmark script (#4845)", () => {
       encoding: "utf8",
     });
     expect(result.status).toBe(0);
-    expect(result.stdout).toContain("gittensory-miner benchmark");
+    expect(result.stdout).toContain("loopover-miner benchmark");
     expect(result.stdout).toContain("discovery-fanout-ranking:");
     expect(result.stdout).toContain("local-store-read-write:");
   });

--- a/test/unit/miner-calibration-cli.test.ts
+++ b/test/unit/miner-calibration-cli.test.ts
@@ -47,7 +47,7 @@ function seedOutcomeEvent(
   ledger.close();
 }
 
-describe("gittensory-miner calibration CLI (#4849)", () => {
+describe("loopover-miner calibration CLI (#4849)", () => {
   it("joins a merge prediction with a merged outcome and renders the per-project accuracy", () => {
     const env = envForTempStores();
     seedPrediction(env, 42, "merge");

--- a/test/unit/miner-calibration-types.test.ts
+++ b/test/unit/miner-calibration-types.test.ts
@@ -12,7 +12,7 @@ import type {
   PredictedVerdictRecord,
 } from "../../packages/loopover-miner/lib/calibration.js";
 
-describe("gittensory-miner calibration types scaffold (#2332)", () => {
+describe("loopover-miner calibration types scaffold (#2332)", () => {
   const predicted: PredictedVerdictRecord = {
     targetId: "pr:JSONbored/gittensory#42",
     project: "JSONbored/gittensory",

--- a/test/unit/miner-claim-ledger-expiry.test.ts
+++ b/test/unit/miner-claim-ledger-expiry.test.ts
@@ -16,7 +16,7 @@ const roots: string[] = [];
 const ledgers: Array<{ close(): void }> = [];
 
 function tempLedger() {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-claim-expiry-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-claim-expiry-"));
   roots.push(root);
   const ledger = openClaimLedger(join(root, "claim-ledger.sqlite3"));
   ledgers.push(ledger);
@@ -43,7 +43,7 @@ afterEach(() => {
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
 
-describe("gittensory-miner claim ledger expiry (#2316)", () => {
+describe("loopover-miner claim ledger expiry (#2316)", () => {
   it("documents a 14-day default max age", () => {
     expect(DEFAULT_MAX_CLAIM_AGE_MS).toBe(14 * 24 * 60 * 60 * 1000);
   });

--- a/test/unit/miner-claim-ledger-readme.test.ts
+++ b/test/unit/miner-claim-ledger-readme.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 
 const readmePath = join(process.cwd(), "packages/loopover-miner/README.md");
 
-describe("gittensory-miner claim ledger README (#2291)", () => {
+describe("loopover-miner claim ledger README (#2291)", () => {
   it("documents the foundation claim ledger API surface", () => {
     const readme = readFileSync(readmePath, "utf8");
     expect(readme).toContain("openClaimLedger");

--- a/test/unit/miner-claim-ledger.test.ts
+++ b/test/unit/miner-claim-ledger.test.ts
@@ -21,7 +21,7 @@ const roots: string[] = [];
 const ledgers: Array<{ close(): void }> = [];
 
 function tempLedger() {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-claim-ledger-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-claim-ledger-"));
   roots.push(root);
   const ledger = openClaimLedger(join(root, "nested", "claim-ledger.sqlite3"));
   ledgers.push(ledger);
@@ -37,7 +37,7 @@ afterEach(() => {
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
 
-describe("gittensory-miner claim ledger (#2314)", () => {
+describe("loopover-miner claim ledger (#2314)", () => {
   it("exposes the frozen status vocabulary", () => {
     expect(CLAIM_STATUSES).toEqual(["active", "released", "expired"]);
     expect(Object.isFrozen(CLAIM_STATUSES)).toBe(true);
@@ -466,7 +466,7 @@ describe("gittensory-miner claim ledger (#2314)", () => {
 });
 
 function tempRoot() {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-claim-default-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-claim-default-"));
   roots.push(root);
   return root;
 }

--- a/test/unit/miner-cli-doctor-checks.test.ts
+++ b/test/unit/miner-cli-doctor-checks.test.ts
@@ -11,7 +11,7 @@ import {
 
 const roots: string[] = [];
 function tempRoot() {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-clicheck-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-clicheck-"));
   roots.push(root);
   return root;
 }
@@ -19,7 +19,7 @@ afterEach(() => {
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
 
-describe("gittensory-miner doctor — coding-agent CLI checks (#4304)", () => {
+describe("loopover-miner doctor — coding-agent CLI checks (#4304)", () => {
   it("claude: present + authenticated when the OAuth token is set", () => {
     const check = checkClaudeCliPresent({ env: { CLAUDE_CODE_OAUTH_TOKEN: "present" }, resolveClaudePath: () => "/usr/bin/claude" });
     expect(check).toMatchObject({ name: "claude-cli-present", ok: true });
@@ -346,7 +346,7 @@ describe("gittensory-miner doctor — coding-agent CLI checks (#4304)", () => {
   });
 });
 
-describe("gittensory-miner doctor — credential presence checks (#5170)", () => {
+describe("loopover-miner doctor — credential presence checks (#5170)", () => {
   describe("checkGitHubTokenPresent", () => {
     it("passes when GITHUB_TOKEN is set and non-empty", () => {
       const check = checkGitHubTokenPresent({ GITHUB_TOKEN: "ghp_present" });

--- a/test/unit/miner-cli-e2e.test.ts
+++ b/test/unit/miner-cli-e2e.test.ts
@@ -30,7 +30,7 @@ afterEach(async () => {
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
 
-describe("gittensory-miner true CLI end-to-end flows (#4869)", () => {
+describe("loopover-miner true CLI end-to-end flows (#4869)", () => {
   it("bootstraps local state and reports status + doctor through the real binary", async () => {
     const configDir = tempEnvPrefix();
     roots.push(configDir);

--- a/test/unit/miner-coding-task-spec.test.ts
+++ b/test/unit/miner-coding-task-spec.test.ts
@@ -21,7 +21,7 @@ afterEach(() => {
 });
 
 function tempDir() {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-coding-task-spec-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-coding-task-spec-"));
   roots.push(root);
   // Resolved once here, not just inside writeAcceptanceCriteriaFile: os.tmpdir() can itself sit behind a
   // symlink (e.g. macOS's /var -> /private/var), so a RAW mkdtempSync path wouldn't byte-match the realpath

--- a/test/unit/miner-concurrent-store-races.test.ts
+++ b/test/unit/miner-concurrent-store-races.test.ts
@@ -26,7 +26,7 @@ const dequeueChildScript = join(
 const roots: string[] = [];
 
 function tempRoot(): { root: string; dbPath: string } {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-concurrent-races-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-concurrent-races-"));
   roots.push(root);
   return { root, dbPath: join(root, "store.sqlite3") };
 }

--- a/test/unit/miner-credential-troubleshooting-readme.test.ts
+++ b/test/unit/miner-credential-troubleshooting-readme.test.ts
@@ -46,7 +46,7 @@ function firstColumnErrorTokens(section: string): string[] {
   return tokens;
 }
 
-describe("gittensory-miner credential-troubleshooting README (#5175)", () => {
+describe("loopover-miner credential-troubleshooting README (#5175)", () => {
   it("adds the credential-troubleshooting section covering the three required failure modes", () => {
     const section = readCredentialSection();
     expect(section).toContain("Error string / pattern");

--- a/test/unit/miner-deployment-docs-audit.test.ts
+++ b/test/unit/miner-deployment-docs-audit.test.ts
@@ -20,7 +20,7 @@ const DEPLOYMENT_MD = resolve(MINER_DIR, "DEPLOYMENT.md");
 const BIN_DIR = resolve(MINER_DIR, "bin");
 const BIN_ENTRY = resolve(BIN_DIR, "loopover-miner.js");
 const LIB_DIR = resolve(MINER_DIR, "lib");
-// gittensory-miner's coding-agent driver construction (MINER_CODING_AGENT_*) is implemented in the
+// loopover-miner's coding-agent driver construction (MINER_CODING_AGENT_*) is implemented in the
 // gittensory-engine package it depends on, not under packages/loopover-miner/** -- an env var read only
 // there would otherwise false-positive as undocumented-in-code. Source (not dist/, which is gitignored and
 // may not be built) so this stays accurate on a fresh checkout without a build step.
@@ -54,7 +54,7 @@ const ALWAYS_IN_SYNC: DeploymentDocsReality = {
   isRegisteredCommand: () => true,
 };
 
-describe("gittensory-miner DEPLOYMENT.md docs-accuracy audit (#5180)", () => {
+describe("loopover-miner DEPLOYMENT.md docs-accuracy audit (#5180)", () => {
   const markdown = readFileSync(DEPLOYMENT_MD, "utf8");
   const claims = {
     envVars: extractEnvVarClaims(markdown),
@@ -70,7 +70,7 @@ describe("gittensory-miner DEPLOYMENT.md docs-accuracy audit (#5180)", () => {
 
   it("REGRESSION: sees env var reads implemented in gittensory-engine's miner source, not just packages/loopover-miner/**", () => {
     // MINER_CODING_AGENT_CLAUDE_MODEL / MINER_CODING_AGENT_CODEX_MODEL / MINER_CODING_AGENT_TIMEOUT_MS are
-    // read in packages/loopover-engine/src/miner/driver-factory.ts, a real dependency of gittensory-miner
+    // read in packages/loopover-engine/src/miner/driver-factory.ts, a real dependency of loopover-miner
     // for coding-agent driver construction -- scanning only LIB_DIR/BIN_DIR previously false-flagged them
     // as undocumented-in-code even though they are genuinely live, functioning env vars.
     const reality = buildLiveReality();
@@ -131,7 +131,7 @@ describe("gittensory-miner DEPLOYMENT.md docs-accuracy audit (#5180)", () => {
     expect(isRepoRelativePath("http://example.com")).toBe(false);
     expect(isRepoRelativePath("#anchor")).toBe(false);
     expect(isRepoRelativePath("mailto:ops@example.com")).toBe(false);
-    expect(isRepoRelativePath("~/.config/gittensory-miner")).toBe(false);
+    expect(isRepoRelativePath("~/.config/loopover-miner")).toBe(false);
     expect(isRepoRelativePath("/data/miner")).toBe(false);
   });
 

--- a/test/unit/miner-discover-cli.test.ts
+++ b/test/unit/miner-discover-cli.test.ts
@@ -23,7 +23,7 @@ const roots: string[] = [];
 const stores: Array<{ close(): void }> = [];
 
 function tempQueueStore() {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-discover-cli-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-discover-cli-"));
   roots.push(root);
   const store = initPortfolioQueueStore(join(root, "portfolio-queue.sqlite3"));
   stores.push(store);
@@ -34,7 +34,7 @@ function tempQueueStore() {
 // that only cares about the fan-out/rank/enqueue path (#4842). runDiscover doesn't own an injected store, so the
 // afterEach hook below closes it.
 function tempPolicyDocCacheStore() {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-discover-cli-pdc-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-discover-cli-pdc-"));
   roots.push(root);
   const store = initPolicyDocCacheStore(join(root, "policy-doc-cache.sqlite3"));
   stores.push(store);
@@ -43,7 +43,7 @@ function tempPolicyDocCacheStore() {
 
 // Same reasoning as tempPolicyDocCacheStore above, for the policy-verdict cache (#4843).
 function tempPolicyVerdictCacheStore() {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-discover-cli-pvc-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-discover-cli-pvc-"));
   roots.push(root);
   const store = initPolicyVerdictCacheStore(join(root, "policy-verdict-cache.sqlite3"));
   stores.push(store);
@@ -52,7 +52,7 @@ function tempPolicyVerdictCacheStore() {
 
 // Same reasoning as tempPolicyDocCacheStore above, for the ranked-candidates snapshot store (#4859 prerequisite).
 function tempRankedCandidatesStore() {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-discover-cli-rc-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-discover-cli-rc-"));
   roots.push(root);
   const store = initRankedCandidatesStore(join(root, "ranked-candidates.sqlite3"));
   stores.push(store);
@@ -570,7 +570,7 @@ describe("runDiscover (#4247)", () => {
   });
 
   it("opens and closes the default on-disk portfolio queue when no override is supplied", async () => {
-    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-discover-cli-default-"));
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-discover-cli-default-"));
     roots.push(root);
     const dbPath = join(root, "portfolio-queue.sqlite3");
     const previousDbPath = process.env.LOOPOVER_MINER_PORTFOLIO_QUEUE_DB;
@@ -759,7 +759,7 @@ describe("runDiscover (#4247)", () => {
   });
 
   it("opens and closes the default on-disk policy-doc cache when no override is supplied", async () => {
-    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-discover-cli-pdc-default-"));
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-discover-cli-pdc-default-"));
     roots.push(root);
     const cacheDbPath = join(root, "policy-doc-cache.sqlite3");
     const previousCacheDbPath = process.env.LOOPOVER_MINER_POLICY_DOC_CACHE_DB;
@@ -829,7 +829,7 @@ describe("runDiscover (#4247)", () => {
   });
 
   it("opens and closes the default on-disk policy-verdict cache when no override is supplied", async () => {
-    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-discover-cli-pvc-default-"));
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-discover-cli-pvc-default-"));
     roots.push(root);
     const cacheDbPath = join(root, "policy-verdict-cache.sqlite3");
     const previousCacheDbPath = process.env.LOOPOVER_MINER_POLICY_VERDICT_CACHE_DB;
@@ -939,7 +939,7 @@ describe("runDiscover (#4247)", () => {
   });
 
   it("opens and closes the default on-disk ranked-candidates store when no override is supplied", async () => {
-    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-discover-cli-rc-default-"));
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-discover-cli-rc-default-"));
     roots.push(root);
     const rankedCandidatesDbPath = join(root, "ranked-candidates.sqlite3");
     const previousDbPath = process.env.LOOPOVER_MINER_RANKED_CANDIDATES_DB;

--- a/test/unit/miner-env-file-indirection.test.ts
+++ b/test/unit/miner-env-file-indirection.test.ts
@@ -129,7 +129,7 @@ describe("loadMinerFileSecrets (#5178)", () => {
 
   describe("wired into the real CLI entry point (bin/loopover-miner.js)", () => {
     it("resolves GITHUB_TOKEN_FILE end-to-end: status --json reports it without ever printing the value", () => {
-      const root = mkdtempSync(join(tmpdir(), "gittensory-miner-file-secret-"));
+      const root = mkdtempSync(join(tmpdir(), "loopover-miner-file-secret-"));
       roots.push(root);
       const secretPath = join(root, "github_token");
       writeFileSync(secretPath, "ghp_end_to_end_value\n");

--- a/test/unit/miner-event-ledger-readme.test.ts
+++ b/test/unit/miner-event-ledger-readme.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 
 const readmePath = join(process.cwd(), "packages/loopover-miner/README.md");
 
-describe("gittensory-miner event ledger README (#2322)", () => {
+describe("loopover-miner event ledger README (#2322)", () => {
   it("documents the append-only event ledger API surface", () => {
     const readme = readFileSync(readmePath, "utf8");
     expect(readme).toContain("initEventLedger");

--- a/test/unit/miner-event-ledger.test.ts
+++ b/test/unit/miner-event-ledger.test.ts
@@ -12,7 +12,7 @@ const roots: string[] = [];
 const ledgers: Array<{ close(): void }> = [];
 
 function tempLedger() {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-event-ledger-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-event-ledger-"));
   roots.push(root);
   const ledger = initEventLedger(join(root, "nested", "event-ledger.sqlite3"));
   ledgers.push(ledger);
@@ -25,7 +25,7 @@ afterEach(() => {
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
 
-describe("gittensory-miner event ledger (#2290)", () => {
+describe("loopover-miner event ledger (#2290)", () => {
   it("resolves the DB path from env override, miner config dir, XDG config, then the home default", () => {
     expect(resolveEventLedgerDbPath({ LOOPOVER_MINER_EVENT_LEDGER_DB: "/custom/e.sqlite3" })).toBe(
       "/custom/e.sqlite3",

--- a/test/unit/miner-execute-local-write.test.ts
+++ b/test/unit/miner-execute-local-write.test.ts
@@ -41,7 +41,7 @@ describe("executeLocalWrite (#5132)", () => {
   });
 
   it("runs in the given working directory and inherits the given env", async () => {
-    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-execute-local-write-"));
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-execute-local-write-"));
     roots.push(root);
     const resolvedRoot = realpathSync(root);
     const result = await executeLocalWrite(spec("pwd"), { cwd: resolvedRoot, env: { ...process.env, PATH: process.env.PATH ?? "" } });

--- a/test/unit/miner-goal-spec-resolver.test.ts
+++ b/test/unit/miner-goal-spec-resolver.test.ts
@@ -16,7 +16,7 @@ afterEach(() => {
 });
 
 function tempRepo() {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-goal-spec-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-goal-spec-"));
   roots.push(root);
   return root;
 }


### PR DESCRIPTION
## Summary

- Part of the gittensory→loopover rebrand (#5705), phase 8b: rename remaining test-title prose. This batch covers 26 `test/unit/*.ts` files whose `describe()`/`it()` titles, `mkdtempSync`/`tempRoot` tmpdir prefixes, and inline comments still used the bare `gittensory-miner`/`gittensory-ams` strings as human-readable labels.
- Also fixes two real stale strings this sweep surfaced: `packages/loopover-miner/scripts/benchmark.mjs`'s printed banner still said `"gittensory-miner benchmark"`, and `check-miner-package.test.ts`'s "rejects an unexpected miner bin that matches the package name prefix" test used a `bin/gittensory-miner-backdoor.js` fixture filename that no longer actually matches the real package prefix (`loopover-miner`), so it wasn't testing what its title claimed.
- No functional/runtime identifier changes — purely test-label and comment prose, plus the one banner-string fix above (with matching test assertion updated in the same commit).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue this PR resolves — N/A, maintainer-authored rebrand-epic cleanup (#5705), no linked-issue gate applies to owner PRs.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint` (via `npm run test:ci`)
- [x] `npm run typecheck` (via `npm run test:ci`)
- [x] `npm run test:coverage` — full unsharded run, 100% green; test-only diff so `codecov/patch` has no measurable `src/**` lines beyond the existing-covered benchmark.mjs line
- [x] `npm run test:workers` (via `npm run test:ci`)
- [x] `npm run build:mcp` (via `npm run test:ci`)
- [x] `npm run test:mcp-pack` (via `npm run test:ci`)
- [x] `npm run ui:openapi:check` (via `npm run test:ci`)
- [x] `npm run ui:lint` (via `npm run test:ci`)
- [x] `npm run ui:typecheck` (via `npm run test:ci`)
- [x] `npm run ui:build` (via `npm run test:ci`)
- [x] `npm audit --audit-level=moderate`
- [x] Full `npm run test:ci` gate run locally, exit 0

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no such changes.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no behavior change.
- [ ] UI changes use live API data or real empty/error/loading states. — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section. — N/A, no UI changes.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs (none touched here).

## Notes

- One of several batched PRs covering the ~150 remaining `describe()`/tmpdir-prefix renames tracked in rebrand epic #5705.