### PR TITLE
fix/issue 5847

### DIFF
--- a/test/unit/find-opportunities.test.ts
+++ b/test/unit/find-opportunities.test.ts
@@ -13,11 +13,21 @@ import {
   runFindOpportunities,
   validateFindOpportunitiesInput,
 } from "../../src/mcp/find-opportunities";
+import { createInstallationToken } from "../../src/github/app";
 import { upsertRepositoryFromGitHub } from "../../src/db/repositories";
+import { rankCandidateIssuesWithSummary } from "../../packages/loopover-miner/lib/opportunity-ranker.js";
 import { createTestEnv } from "../helpers/d1";
 
 vi.mock("@loopover/engine", async () => {
   return import("../../packages/loopover-engine/src/index");
+});
+vi.mock("../../src/github/app", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/github/app")>()),
+  createInstallationToken: vi.fn(),
+}));
+vi.mock("../../packages/loopover-miner/lib/opportunity-ranker.js", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../../packages/loopover-miner/lib/opportunity-ranker.js")>();
+  return { ...actual, rankCandidateIssuesWithSummary: vi.fn(actual.rankCandidateIssuesWithSummary) };
 });
 
 const fixtureDir = join(dirname(fileURLToPath(import.meta.url)), "../fixtures/ai-policy");
@@ -57,6 +67,8 @@ const issue = (number: number) => ({
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.mocked(createInstallationToken).mockReset();
+  vi.mocked(rankCandidateIssuesWithSummary).mockClear();
 });
 
 describe("validateFindOpportunitiesInput", () => {
@@ -274,5 +286,232 @@ describe("runFindOpportunities", () => {
     const allowed = await runFindOpportunities(env, { targets: [{ owner: "acme", repo: "allowed" }] }, { canAccessRepo: async () => true });
     expect(allowed.status).toBe("ok");
     expect(allowed.ranked).toHaveLength(1);
+  });
+
+  it("resolves the searchQuery path and applies the post-search canAccessRepo filter", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "test-token" });
+    const allowedPolicy = readFixture("allowed-silent.md");
+    const searchIssue = (number: number, repo: string) => ({
+      number,
+      title: `Issue ${number}`,
+      labels: ["good first issue"],
+      comments: 1,
+      created_at: "2026-07-01T00:00:00Z",
+      updated_at: "2026-07-01T01:00:00Z",
+      html_url: `https://github.com/acme/${repo}/issues/${number}`,
+      repository_url: `https://api.github.com/repos/acme/${repo}`,
+    });
+
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/search/issues?")) return jsonResponse({ items: [searchIssue(51, "searched"), searchIssue(52, "blocked")] });
+      if (url.includes("/repos/acme/searched/contents/AI-USAGE.md")) return jsonResponse({}, { status: 404 });
+      if (url.includes("/repos/acme/searched/contents/CONTRIBUTING.md")) return contentResponse(allowedPolicy);
+      if (url.includes("/repos/acme/blocked/contents/AI-USAGE.md")) return jsonResponse({}, { status: 404 });
+      if (url.includes("/repos/acme/blocked/contents/CONTRIBUTING.md")) return contentResponse(allowedPolicy);
+      return jsonResponse({}, { status: 404 });
+    });
+
+    const result = await runFindOpportunities(
+      env,
+      { searchQuery: "test coverage" },
+      { canAccessRepo: async (repoFullName) => repoFullName === "acme/searched" },
+    );
+
+    expect(result.status).toBe("ok");
+    expect(result.totalCandidates).toBe(1);
+    expect(result.ranked.map((entry) => `${entry.owner}/${entry.repo}#${entry.issueNumber}`)).toEqual(["acme/searched#51"]);
+  });
+
+  it("applies goalSpec.lane and languages to the ranker and reports appliedLane", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "test-token" });
+    const allowedPolicy = readFixture("allowed-silent.md");
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/repos/acme/allowed/contents/AI-USAGE.md")) return jsonResponse({}, { status: 404 });
+      if (url.includes("/repos/acme/allowed/contents/CONTRIBUTING.md")) return contentResponse(allowedPolicy);
+      if (url.includes("/repos/acme/allowed/issues?")) return jsonResponse([issue(31)]);
+      return jsonResponse({}, { status: 404 });
+    });
+
+    const result = await runFindOpportunities(env, {
+      targets: [{ owner: "acme", repo: "allowed" }],
+      goalSpec: { lane: "docs", languages: ["TS", " js "] },
+    });
+
+    expect(result.status).toBe("ok");
+    expect(result.appliedLane).toBe("docs");
+    const lastCall = vi.mocked(rankCandidateIssuesWithSummary).mock.calls.at(-1);
+    expect(lastCall?.[1]?.goalSpecsByRepo).toEqual({
+      "acme/allowed": expect.objectContaining({
+        preferredLabels: ["docs"],
+        wantedPaths: ["**/*.ts", "**/*.js"],
+      }),
+    });
+  });
+
+  it("builds a goal spec from lane alone, with no wantedPaths when languages are absent", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "test-token" });
+    const allowedPolicy = readFixture("allowed-silent.md");
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/repos/acme/allowed/contents/AI-USAGE.md")) return jsonResponse({}, { status: 404 });
+      if (url.includes("/repos/acme/allowed/contents/CONTRIBUTING.md")) return contentResponse(allowedPolicy);
+      if (url.includes("/repos/acme/allowed/issues?")) return jsonResponse([issue(32)]);
+      return jsonResponse({}, { status: 404 });
+    });
+
+    const result = await runFindOpportunities(env, {
+      targets: [{ owner: "acme", repo: "allowed" }],
+      goalSpec: { lane: "docs" },
+    });
+
+    expect(result.appliedLane).toBe("docs");
+    const lastCall = vi.mocked(rankCandidateIssuesWithSummary).mock.calls.at(-1);
+    expect(lastCall?.[1]?.goalSpecsByRepo).toEqual({
+      "acme/allowed": expect.objectContaining({ preferredLabels: ["docs"], wantedPaths: [] }),
+    });
+  });
+
+  it("builds a goal spec from languages alone, with no preferredLabels when lane is absent", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "test-token" });
+    const allowedPolicy = readFixture("allowed-silent.md");
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/repos/acme/allowed/contents/AI-USAGE.md")) return jsonResponse({}, { status: 404 });
+      if (url.includes("/repos/acme/allowed/contents/CONTRIBUTING.md")) return contentResponse(allowedPolicy);
+      if (url.includes("/repos/acme/allowed/issues?")) return jsonResponse([issue(33)]);
+      return jsonResponse({}, { status: 404 });
+    });
+
+    const result = await runFindOpportunities(env, {
+      targets: [{ owner: "acme", repo: "allowed" }],
+      goalSpec: { languages: ["go"] },
+    });
+
+    expect(result.appliedLane).toBeUndefined();
+    const lastCall = vi.mocked(rankCandidateIssuesWithSummary).mock.calls.at(-1);
+    expect(lastCall?.[1]?.goalSpecsByRepo).toEqual({
+      "acme/allowed": expect.objectContaining({ preferredLabels: [], wantedPaths: ["**/*.go"] }),
+    });
+  });
+
+  it("proceeds with an anonymous token when minting never runs but a target repo is still known", async () => {
+    const env = createTestEnv();
+    await upsertRepositoryFromGitHub(env, { name: "known", full_name: "acme/known" });
+    const allowedPolicy = readFixture("allowed-silent.md");
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/repos/acme/known/contents/AI-USAGE.md")) return jsonResponse({}, { status: 404 });
+      if (url.includes("/repos/acme/known/contents/CONTRIBUTING.md")) return contentResponse(allowedPolicy);
+      if (url.includes("/repos/acme/known/issues?")) return jsonResponse([issue(71)]);
+      return jsonResponse({}, { status: 404 });
+    });
+
+    const result = await runFindOpportunities(env, { targets: [{ owner: "acme", repo: "known" }] });
+
+    expect(createInstallationToken).not.toHaveBeenCalled();
+    expect(result.status).toBe("ok");
+    expect(result.ranked.map((entry) => `${entry.owner}/${entry.repo}#${entry.issueNumber}`)).toEqual(["acme/known#71"]);
+  });
+
+  it("performs an anonymous search when no GitHub token is configured", async () => {
+    const env = createTestEnv();
+    const allowedPolicy = readFixture("allowed-silent.md");
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/search/issues?")) {
+        return jsonResponse({
+          items: [
+            {
+              number: 81,
+              title: "Issue 81",
+              labels: [],
+              comments: 0,
+              created_at: "2026-07-01T00:00:00Z",
+              updated_at: "2026-07-01T01:00:00Z",
+              html_url: "https://github.com/acme/anon/issues/81",
+              repository_url: "https://api.github.com/repos/acme/anon",
+            },
+          ],
+        });
+      }
+      if (url.includes("/repos/acme/anon/contents/AI-USAGE.md")) return jsonResponse({}, { status: 404 });
+      if (url.includes("/repos/acme/anon/contents/CONTRIBUTING.md")) return contentResponse(allowedPolicy);
+      return jsonResponse({}, { status: 404 });
+    });
+
+    const result = await runFindOpportunities(env, { searchQuery: "anon search" });
+
+    expect(result.status).toBe("ok");
+    expect(result.ranked.map((entry) => `${entry.owner}/${entry.repo}#${entry.issueNumber}`)).toEqual(["acme/anon#81"]);
+  });
+
+  it("reports appliedMinRankScore when set and omits both applied fields when absent", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "test-token" });
+    const allowedPolicy = readFixture("allowed-silent.md");
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/repos/acme/allowed/contents/AI-USAGE.md")) return jsonResponse({}, { status: 404 });
+      if (url.includes("/repos/acme/allowed/contents/CONTRIBUTING.md")) return contentResponse(allowedPolicy);
+      if (url.includes("/repos/acme/allowed/issues?")) return jsonResponse([issue(41)]);
+      return jsonResponse({}, { status: 404 });
+    });
+
+    const withMinScore = await runFindOpportunities(env, {
+      targets: [{ owner: "acme", repo: "allowed" }],
+      goalSpec: { minRankScore: 5 },
+    });
+    expect(withMinScore.appliedMinRankScore).toBe(5);
+    expect(withMinScore.appliedLane).toBeUndefined();
+
+    const bare = await runFindOpportunities(env, { targets: [{ owner: "acme", repo: "allowed" }] });
+    expect(bare.appliedMinRankScore).toBeUndefined();
+    expect(bare.appliedLane).toBeUndefined();
+  });
+
+  it("falls back through the installation-token loop, skipping repos with no installation and repos whose mint fails", async () => {
+    const env = createTestEnv();
+    await upsertRepositoryFromGitHub(env, { name: "no-install", full_name: "acme/no-install" });
+    await upsertRepositoryFromGitHub(env, { name: "broken", full_name: "acme/broken" }, 111);
+    await upsertRepositoryFromGitHub(env, { name: "allowed", full_name: "acme/allowed" }, 222);
+
+    vi.mocked(createInstallationToken).mockImplementation(async (_env, installationId) => {
+      if (installationId === 111) throw new Error("mint failed");
+      return "resolved-token";
+    });
+
+    const allowedPolicy = readFixture("allowed-silent.md");
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/repos/acme/allowed/contents/AI-USAGE.md")) return jsonResponse({}, { status: 404 });
+      if (url.includes("/repos/acme/allowed/contents/CONTRIBUTING.md")) return contentResponse(allowedPolicy);
+      if (url.includes("/repos/acme/allowed/issues?")) return jsonResponse([issue(61)]);
+      return jsonResponse({}, { status: 404 });
+    });
+
+    const result = await runFindOpportunities(env, {
+      targets: [
+        { owner: "acme", repo: "no-install" },
+        { owner: "acme", repo: "broken" },
+        { owner: "acme", repo: "allowed" },
+      ],
+    });
+
+    expect(createInstallationToken).toHaveBeenCalledWith(env, 111);
+    expect(createInstallationToken).toHaveBeenCalledWith(env, 222);
+    expect(result.status).toBe("ok");
+    expect(result.ranked.map((entry) => `${entry.owner}/${entry.repo}#${entry.issueNumber}`)).toEqual(["acme/allowed#61"]);
+  });
+
+  it("returns invalid_request end-to-end when neither targets nor searchQuery are provided", async () => {
+    const env = createTestEnv();
+    const result = await runFindOpportunities(env, {});
+    expect(result).toEqual({
+      status: "invalid_request",
+      ranked: [],
+      totalCandidates: 0,
+      reason: "targets_or_search_query_required",
+    });
   });
 });


### PR DESCRIPTION
- **docs(miner): AMS storage-abstraction research — datastore backend comparison (#5760)**
- **fix(rebrand): full-cutover rename remaining internal gittensory runtime identifiers (#5761)**
- **refactor(engine): extract the pull-request-target-key parser into loopover-engine (#5762)**
- **docs(miner): AMS auth/identity research — hosted login-layer options (#5764)**
- **fix(rebrand): full-cutover rename miner/AMS per-repo and operator config filenames (#5765)**
- **feat(api): add post-merge incident reporting for already-merged PRs (#5766)**
- **fix(review): trim the Improvement signal row to a concise value rating (#5767)**
- **fix(rebrand): full-cutover rename Prometheus/Alertmanager/Grafana observability identifiers (#5768)**
- **feat(review): add a shared beta-collapsible convention for the PR comment (#5769)**
- **docs(engine): verify git mv rename recognition in coverage tooling (#5770)**
- **fix(review): never render a ❌ for a non-Gittensor contributor (#5100) (#5774)**
- **feat(engine): extract content-lane's pure leaf modules to loopover-engine (#5775)**
- **fix(api): audit registered-vs-installed dashboard/digest copy (#5026) (#5776)**
- **feat(engine): extract settings leaf modules to loopover-engine (#5779)**
- **refactor(engine): move the unlinked-issue candidate pre-filter into the shared engine (#5778)**
- **feat(engine): add a load-testing harness for iterate-loop under concurrent load (#5781)**
- **docs(spec): idea-intake bridge schema (#5783)**
- **docs(engine): document the deliberate gate-advisory twin divergence (#5784)**
- **feat(selfhost): optional Infisical secrets management for self-host deploys (#5785)**
- **refactor(queue): extract the public-comment merge-facts derivation from maybePublishPrPublicSurface (#4607) (#5787)**
- **feat(review): add aggregate fix-handoff block renderer (#5788)**
- **feat(miner): pre-execution feasibility check for freeform ideas (#5789)**
- **feat(review): synthesize the 'Contributor next steps' collapsible into a prioritized step (#5791)**
- **feat(mcp): add the idea-intake bridge and loopover_intake_idea tool (#5792)**
- **feat(miner): add cross-repo evaluation harness (#4788) (#5790)**
- **docs(selfhost): design doc for the scheduled docs-drift audit sweep (#3048) (#5794)**
- **feat(mcp): route ideas through intake into a loop claim plan (#5795)**
- **feat(mcp): deliver a completed loop iteration as a customer results payload (#5797)**
- **feat(mcp): stream loop progress to the customer via a progress snapshot (#5798)**
- **refactor(engine): extract signals engine with re-export shim (#4884) (#5800)**
- **feat(engine): per-tenant resource quota evaluation (#5801)**
- **feat(mcp): evaluate when a rented loop should escalate to a human (#5806)**
- **docs(engine): document the nine governor primitives in the package README (#5851)**
- **docs(gardening): correct contributor-available target to per-repo, not combined (#5808)**
- **fix(signals): require a code file before manifest_missing_tests fires (#5852)**
- **fix(miner): list queue dashboard in cli.js help text (#5853)**
- **docs: privacy audit of AMS telemetry/export surfaces for cross-tenant leakage (#5759)**
- **feat(selfhost): add n8n workflows and MinIO object storage compose profiles (#1219) (#5777)**
- **feat(miner): honor kill-switch mid-attempt during iterate-loop (#5799)**
- **feat(engine): per-tenant configuration layer (#5804)**
- **feat(selfhost): bridge fleet-mode miner state to the ams-observability exporter (#5844)**
- **docs(engine): add a Tenant quota README section (#5860)**
- **fix(engine): clamp rate-limit retryAfterMs to at most one window on a backward clock (#5855)**
- **fix(review): recognize export const enum and abstract class in impact-symbols (#5858)**
- **test(review): cover review-diff.ts non-positive-budget guard and header count defaults (#5857)**
- **fix(ci): sync miner engine-version pin on the engine release branch (#5856)**
- **test(selfhost): cover jobCoalesceKey missing-field fallbacks for 6 job types (#5862)**
- **fix(queue): cap backlog-convergence re-review attempts per head SHA (#5859)**
- **docs(engine): document the Rent-a-Loop pipeline modules (#5868)**
- **test(mcp): cover find-opportunities searchQuery, goal-spec, and token-fallback paths**
