### PR TITLE
fix(engine): normalize worktree-pool maxConcurrency so a NaN cap can't allocate unbounded

### DIFF
--- a/packages/loopover-engine/src/miner/worktree-pool.ts
+++ b/packages/loopover-engine/src/miner/worktree-pool.ts
@@ -36,6 +36,15 @@ export type AcquireWorktreeResult =
   | { ok: true; state: WorktreePoolState; allocation: WorktreeAllocation }
   | { ok: false; reason: "already_allocated" | "at_capacity"; state: WorktreePoolState };
 
+// Normalize the concurrency cap the same way the sibling limit calculators do (governor/rate-limit.ts,
+// governor/budget-cap.ts, tenant-quota.ts): a NaN/non-finite/negative/fractional `maxConcurrency` arriving from a
+// loosely-typed or untrusted source becomes a non-negative integer, so it can never make a `>=`/subtraction
+// comparison silently fail — a `NaN` cap would otherwise make `length >= NaN` always false and allocate without
+// bound, contradicting the type's "A non-positive cap allocates nothing" contract (#5828).
+function finiteNonNegativeInt(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
 /** True when `attemptId` currently holds an allocation. Pure. */
 export function isWorktreeAllocated(state: WorktreePoolState, attemptId: string): boolean {
   return state.allocations.some((allocation) => allocation.attemptId === attemptId);
@@ -43,7 +52,7 @@ export function isWorktreeAllocated(state: WorktreePoolState, attemptId: string)
 
 /** Slots still available before the concurrency cap (never negative). Pure. */
 export function availableWorktreeSlots(state: WorktreePoolState, config: WorktreePoolConfig): number {
-  return Math.max(0, config.maxConcurrency - state.allocations.length);
+  return Math.max(0, finiteNonNegativeInt(config.maxConcurrency) - state.allocations.length);
 }
 
 /**
@@ -60,7 +69,7 @@ export function acquireWorktree(
   if (isWorktreeAllocated(state, input.attemptId)) {
     return { ok: false, reason: "already_allocated", state };
   }
-  if (state.allocations.length >= config.maxConcurrency) {
+  if (state.allocations.length >= finiteNonNegativeInt(config.maxConcurrency)) {
     return { ok: false, reason: "at_capacity", state };
   }
   const allocation: WorktreeAllocation = {

--- a/test/unit/miner-worktree-pool.test.ts
+++ b/test/unit/miner-worktree-pool.test.ts
@@ -79,3 +79,27 @@ describe("worktree pool allocator (#4297)", () => {
     expect(availableWorktreeSlots(s, { maxConcurrency: 1 })).toBe(0);
   });
 });
+
+describe("worktree pool maxConcurrency normalization (#5828)", () => {
+  it("treats a NaN cap as zero — allocates nothing instead of unbounded", () => {
+    expect(availableWorktreeSlots(EMPTY_WORKTREE_POOL, { maxConcurrency: Number.NaN })).toBe(0);
+    const r = acquireWorktree(EMPTY_WORKTREE_POOL, { maxConcurrency: Number.NaN }, { attemptId: "a", repoPath: REPO });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.reason).toBe("at_capacity");
+  });
+
+  it("treats a negative cap as zero", () => {
+    expect(availableWorktreeSlots(EMPTY_WORKTREE_POOL, { maxConcurrency: -3 })).toBe(0);
+    expect(acquireWorktree(EMPTY_WORKTREE_POOL, { maxConcurrency: -3 }, { attemptId: "a", repoPath: REPO }).ok).toBe(false);
+  });
+
+  it("floors a fractional cap to a whole number of slots", () => {
+    const cfg = { maxConcurrency: 2.7 };
+    expect(availableWorktreeSlots(EMPTY_WORKTREE_POOL, cfg)).toBe(2);
+    const s1 = acquireWorktree(EMPTY_WORKTREE_POOL, cfg, { attemptId: "a", repoPath: REPO });
+    const s2 = s1.ok ? acquireWorktree(s1.state, cfg, { attemptId: "b", repoPath: REPO }) : s1;
+    const s3 = s2.ok ? acquireWorktree(s2.state, cfg, { attemptId: "c", repoPath: REPO }) : s2;
+    expect(s1.ok && s2.ok).toBe(true);
+    expect(s3.ok).toBe(false); // floor(2.7) = 2, so the third slot is at capacity
+  });
+});


### PR DESCRIPTION
## Summary

The worktree-pool allocator's `WorktreePoolConfig.maxConcurrency` is a plain `number` whose contract says *"A non-positive cap allocates nothing."* But a `NaN`/non-finite cap arriving from a loosely-typed or untrusted source broke that contract: `state.allocations.length >= NaN` is always `false`, so `acquireWorktree` would keep granting slots without bound, and `availableWorktreeSlots` returned `NaN`. A fractional cap was also honored verbatim.

This normalizes the cap the same way the sibling limit calculators already do (`governor/rate-limit.ts`, `governor/budget-cap.ts`, `tenant-quota.ts`): a private `finiteNonNegativeInt` folds any `NaN`/non-finite/negative/fractional input to a non-negative integer before the `>=`/subtraction, so the cap can never make the comparison silently fail.

## Changes

- `finiteNonNegativeInt(value)` helper in `worktree-pool.ts`; applied in `availableWorktreeSlots` and `acquireWorktree`.
- Regression tests: NaN cap → 0 slots / `at_capacity`; negative cap → 0; fractional `2.7` → floors to 2 slots.

## Scope

- [x] Narrow, single-purpose change in `packages/loopover-engine/src/miner/`.
- [x] No public API/behavior change for well-formed input.

## Validation

- [x] `npm run typecheck`
- [x] `npx vitest run test/unit/miner-worktree-pool.test.ts` — 10 passed; 100% coverage on the changed lines/branches.
- [x] Rebased onto latest `main`; branch is mergeable-clean.

## Safety

- [x] Pure in-memory logic; no IO, no secrets, no private terms.

Closes #5828