### PR TITLE
test(miner): rename gittensory-miner/ams prose to loopover-miner/ams (batch 2)

### DIFF
--- a/packages/loopover-miner/lib/laptop-init.js
+++ b/packages/loopover-miner/lib/laptop-init.js
@@ -58,7 +58,7 @@ export function checkLaptopStateSqlite(env = process.env) {
     return {
       name: "laptop-state-sqlite",
       ok: false,
-      detail: `${dbPath}: not found (run gittensory-miner init)`,
+      detail: `${dbPath}: not found (run loopover-miner init)`,
     };
   }
   try {

--- a/test/unit/miner-governor-action-mode.test.ts
+++ b/test/unit/miner-governor-action-mode.test.ts
@@ -78,7 +78,7 @@ describe("resolveMinerActionModeGate (#2342)", () => {
 
 describe("recordMinerDryRunShadow (#2342)", () => {
   it("records the would-be action to the governor ledger without executing anything", () => {
-    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-governor-action-mode-"));
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-governor-action-mode-"));
     roots.push(root);
     const ledger = initGovernorLedger(join(root, "governor-ledger.sqlite3"));
     ledgers.push(ledger);

--- a/test/unit/miner-governor-chokepoint-persisted.test.ts
+++ b/test/unit/miner-governor-chokepoint-persisted.test.ts
@@ -15,7 +15,7 @@ const roots: string[] = [];
 const closeables: Array<{ close(): void }> = [];
 
 function tempStore() {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-governor-chokepoint-persisted-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-governor-chokepoint-persisted-"));
   roots.push(root);
   const governorState = openGovernorState(join(root, "governor-state.sqlite3"));
   const ledger = initGovernorLedger(join(root, "governor-ledger.sqlite3"));

--- a/test/unit/miner-governor-chokepoint.test.ts
+++ b/test/unit/miner-governor-chokepoint.test.ts
@@ -38,7 +38,7 @@ afterEach(() => {
 });
 
 function openLedger() {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-governor-chokepoint-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-governor-chokepoint-"));
   roots.push(root);
   const ledger = initGovernorLedger(join(root, "governor-ledger.sqlite3"));
   ledgers.push(ledger);

--- a/test/unit/miner-governor-kill-switch.test.ts
+++ b/test/unit/miner-governor-kill-switch.test.ts
@@ -49,7 +49,7 @@ describe("checkMinerKillSwitch (#2341)", () => {
 
 describe("recordMinerKillSwitchTransition (#2341)", () => {
   it("records a tripped transition to the governor ledger and resuming records a second row", () => {
-    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-governor-kill-switch-"));
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-governor-kill-switch-"));
     roots.push(root);
     const ledger = initGovernorLedger(join(root, "governor-ledger.sqlite3"));
     ledgers.push(ledger);
@@ -73,7 +73,7 @@ describe("recordMinerKillSwitchTransition (#2341)", () => {
   });
 
   it("a transition with no repoFullName supplied records a null repoFullName, not an omitted or undefined one", () => {
-    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-governor-kill-switch-no-repo-"));
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-governor-kill-switch-no-repo-"));
     roots.push(root);
     const ledger = initGovernorLedger(join(root, "governor-ledger.sqlite3"));
     ledgers.push(ledger);
@@ -90,7 +90,7 @@ describe("recordMinerKillSwitchTransition (#2341)", () => {
   });
 
   it("is a no-op and appends nothing when the scope has not changed", () => {
-    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-governor-kill-switch-noop-"));
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-governor-kill-switch-noop-"));
     roots.push(root);
     const ledger = initGovernorLedger(join(root, "governor-ledger.sqlite3"));
     ledgers.push(ledger);

--- a/test/unit/miner-governor-ledger-cli.test.ts
+++ b/test/unit/miner-governor-ledger-cli.test.ts
@@ -21,7 +21,7 @@ const roots: string[] = [];
 const ledgers: Array<{ close(): void }> = [];
 
 function tempLedger() {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-governor-ledger-cli-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-governor-ledger-cli-"));
   roots.push(root);
   const ledger = initGovernorLedger(join(root, "governor-ledger.sqlite3"));
   ledgers.push(ledger);
@@ -35,7 +35,7 @@ afterEach(() => {
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
 
-describe("gittensory-miner governor ledger CLI (#2328)", () => {
+describe("loopover-miner governor ledger CLI (#2328)", () => {
   it("parseGovernorListArgs validates argv", () => {
     expect(parseGovernorListArgs([])).toEqual({
       json: false,
@@ -157,7 +157,7 @@ describe("gittensory-miner governor ledger CLI (#2328)", () => {
   });
 
   it("runGovernorCli dispatches pause, resume, and status to governor-pause-cli.js (#4851)", async () => {
-    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-governor-ledger-cli-pause-"));
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-governor-ledger-cli-pause-"));
     roots.push(root);
     const { openGovernorState } = await import("../../packages/loopover-miner/lib/governor-state.js");
     const governorState = openGovernorState(join(root, "governor-state.sqlite3"));

--- a/test/unit/miner-governor-ledger.test.ts
+++ b/test/unit/miner-governor-ledger.test.ts
@@ -20,7 +20,7 @@ const roots: string[] = [];
 const ledgers: Array<{ close(): void }> = [];
 
 function tempLedger() {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-governor-ledger-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-governor-ledger-"));
   roots.push(root);
   const ledger = initGovernorLedger(join(root, "nested", "governor-ledger.sqlite3"));
   ledgers.push(ledger);
@@ -33,7 +33,7 @@ afterEach(() => {
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
 
-describe("gittensory-miner governor ledger (#2328)", () => {
+describe("loopover-miner governor ledger (#2328)", () => {
   it("resolves the DB path from env override, miner config dir, XDG config, then the home default", () => {
     expect(resolveGovernorLedgerDbPath({ LOOPOVER_MINER_GOVERNOR_LEDGER_DB: "/custom/g.sqlite3" })).toBe(
       "/custom/g.sqlite3",
@@ -195,7 +195,7 @@ describe("gittensory-miner governor ledger (#2328)", () => {
   });
 
   it("uses the default singleton ledger helpers and closes cleanly", () => {
-    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-governor-default-"));
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-governor-default-"));
     roots.push(root);
     const previousConfigDir = process.env.LOOPOVER_MINER_CONFIG_DIR;
     process.env.LOOPOVER_MINER_CONFIG_DIR = root;

--- a/test/unit/miner-governor-open-pr.test.ts
+++ b/test/unit/miner-governor-open-pr.test.ts
@@ -20,7 +20,7 @@ afterEach(() => {
 
 describe("evaluateOpenPrSelfPlagiarism (#2345)", () => {
   it("records a throttled open_pr denial to the governor ledger with the matched prior submission", () => {
-    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-governor-open-pr-"));
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-governor-open-pr-"));
     roots.push(root);
     const ledger = initGovernorLedger(join(root, "governor-ledger.sqlite3"));
     ledgers.push(ledger);
@@ -57,7 +57,7 @@ describe("evaluateOpenPrSelfPlagiarism (#2345)", () => {
   });
 
   it("accepts a bare numeric selfPlagiarismConfig threshold", () => {
-    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-governor-open-pr-num-"));
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-governor-open-pr-num-"));
     roots.push(root);
     const ledger = initGovernorLedger(join(root, "governor-ledger.sqlite3"));
     ledgers.push(ledger);

--- a/test/unit/miner-governor-run-halt.test.ts
+++ b/test/unit/miner-governor-run-halt.test.ts
@@ -28,7 +28,7 @@ const HEALTHY_CONVERGENCE = { attempts: 1, consecutiveFailures: 0, reenqueues: 0
 
 describe("evaluateRunLoopBoundaryGate (#2347)", () => {
   it("releases an in-flight portfolio item and records a halt when a flapping run is detected", () => {
-    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-governor-run-halt-"));
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-governor-run-halt-"));
     roots.push(root);
     const ledger = initGovernorLedger(join(root, "governor-ledger.sqlite3"));
     ledgers.push(ledger);
@@ -72,7 +72,7 @@ describe("evaluateRunLoopBoundaryGate (#2347)", () => {
   });
 
   it("halts immediately on a budget-cap breach at the next iteration boundary", () => {
-    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-governor-run-halt-budget-"));
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-governor-run-halt-budget-"));
     roots.push(root);
     const ledger = initGovernorLedger(join(root, "governor-ledger.sqlite3"));
     ledgers.push(ledger);
@@ -93,7 +93,7 @@ describe("evaluateRunLoopBoundaryGate (#2347)", () => {
   });
 
   it("never halts or records a halt for a healthy run under both signals", () => {
-    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-governor-run-halt-healthy-"));
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-governor-run-halt-healthy-"));
     roots.push(root);
     const ledger = initGovernorLedger(join(root, "governor-ledger.sqlite3"));
     ledgers.push(ledger);
@@ -115,7 +115,7 @@ describe("evaluateRunLoopBoundaryGate (#2347)", () => {
   });
 
   it("does not re-append ledger rows while a prior halt remains latched", () => {
-    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-governor-run-halt-latched-"));
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-governor-run-halt-latched-"));
     roots.push(root);
     const ledger = initGovernorLedger(join(root, "governor-ledger.sqlite3"));
     ledgers.push(ledger);

--- a/test/unit/miner-governor-state.test.ts
+++ b/test/unit/miner-governor-state.test.ts
@@ -16,7 +16,7 @@ const roots: string[] = [];
 const states: Array<{ close(): void }> = [];
 
 function tempState() {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-governor-state-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-governor-state-"));
   roots.push(root);
   const state = openGovernorState(join(root, "governor-state.sqlite3"));
   states.push(state);
@@ -132,7 +132,7 @@ describe("governor-state pause/resume control surface (#4851)", () => {
   });
 
   it("migrates an on-disk file created before the pause columns existed", () => {
-    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-governor-state-premigration-"));
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-governor-state-premigration-"));
     roots.push(root);
     const dbPath = join(root, "governor-state.sqlite3");
 
@@ -164,7 +164,7 @@ describe("governor-state pause/resume control surface (#4851)", () => {
   });
 
   it("reopening an already-migrated file is a safe no-op (column-presence guard)", () => {
-    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-governor-state-remigrate-"));
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-governor-state-remigrate-"));
     roots.push(root);
     const dbPath = join(root, "governor-state.sqlite3");
     const first = openGovernorState(dbPath);
@@ -178,7 +178,7 @@ describe("governor-state pause/resume control surface (#4851)", () => {
   });
 
   it("REGRESSION: adds each missing pause column independently, not just when `paused` alone is absent", () => {
-    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-governor-state-partial-migration-"));
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-governor-state-partial-migration-"));
     roots.push(root);
     const dbPath = join(root, "governor-state.sqlite3");
 
@@ -269,7 +269,7 @@ describe("governor-state reputation history (#5134)", () => {
     });
 
     it("migrates an existing pre-#5563 file, backfilling api_base_url and preserving every row", () => {
-      const root = mkdtempSync(join(tmpdir(), "gittensory-miner-governor-state-legacy-"));
+      const root = mkdtempSync(join(tmpdir(), "loopover-miner-governor-state-legacy-"));
       roots.push(root);
       const dbPath = join(root, "legacy.sqlite3");
       const legacy = new DatabaseSync(dbPath);
@@ -305,7 +305,7 @@ describe("governor-state reputation history (#5134)", () => {
     });
 
     it("REGRESSION: a legacy row violating the rebuilt table's NOT NULL columns is dropped, not a migration-aborting crash", () => {
-      const root = mkdtempSync(join(tmpdir(), "gittensory-miner-governor-state-legacy-corrupt-"));
+      const root = mkdtempSync(join(tmpdir(), "loopover-miner-governor-state-legacy-corrupt-"));
       roots.push(root);
       const dbPath = join(root, "legacy-corrupt.sqlite3");
       const legacy = new DatabaseSync(dbPath);
@@ -345,7 +345,7 @@ describe("governor-state reputation history (#5134)", () => {
     });
 
     it("migration is idempotent: reopening an already-migrated file doesn't rebuild the table again", () => {
-      const root = mkdtempSync(join(tmpdir(), "gittensory-miner-governor-state-idempotent-"));
+      const root = mkdtempSync(join(tmpdir(), "loopover-miner-governor-state-idempotent-"));
       roots.push(root);
       const dbPath = join(root, "state.sqlite3");
       const first = openGovernorState(dbPath);
@@ -411,7 +411,7 @@ describe("governor-state module-level default singleton (#5134)", () => {
   });
 
   it("loadPauseState/savePauseState module-level wrappers round-trip through the default singleton (#4851)", () => {
-    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-governor-state-singleton-"));
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-governor-state-singleton-"));
     roots.push(root);
     vi.stubEnv("LOOPOVER_MINER_GOVERNOR_STATE_DB", join(root, "governor-state.sqlite3"));
     expect(loadPauseState()).toEqual({ paused: false, reason: null, pausedAt: null });
@@ -421,7 +421,7 @@ describe("governor-state module-level default singleton (#5134)", () => {
   });
 
   it("loadReputationHistory/saveReputationHistory module-level wrappers round-trip through the default singleton, forwarding apiBaseUrl (#5563)", () => {
-    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-governor-state-singleton-reputation-"));
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-governor-state-singleton-reputation-"));
     roots.push(root);
     vi.stubEnv("LOOPOVER_MINER_GOVERNOR_STATE_DB", join(root, "governor-state.sqlite3"));
     expect(loadReputationHistory("acme/widgets", "https://ghe.example.com/api/v3")).toEqual({

--- a/test/unit/miner-governor-write-rate-limit.test.ts
+++ b/test/unit/miner-governor-write-rate-limit.test.ts
@@ -20,7 +20,7 @@ afterEach(() => {
 
 describe("evaluateWriteRateLimitGate (#2344)", () => {
   it("records an allowed write to the governor ledger and advances both buckets", () => {
-    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-governor-write-rate-limit-"));
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-governor-write-rate-limit-"));
     roots.push(root);
     const ledger = initGovernorLedger(join(root, "governor-ledger.sqlite3"));
     ledgers.push(ledger);
@@ -49,7 +49,7 @@ describe("evaluateWriteRateLimitGate (#2344)", () => {
   });
 
   it("schedules a jittered retry and records a throttled denial without advancing buckets", () => {
-    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-governor-write-rate-limit-deny-"));
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-governor-write-rate-limit-deny-"));
     roots.push(root);
     const ledger = initGovernorLedger(join(root, "governor-ledger.sqlite3"));
     ledgers.push(ledger);

--- a/test/unit/miner-harness-submission-trigger.test.ts
+++ b/test/unit/miner-harness-submission-trigger.test.ts
@@ -19,7 +19,7 @@ const roots: string[] = [];
 const closers: Array<{ close(): void }> = [];
 
 function tempEventLedger() {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-harness-trigger-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-harness-trigger-"));
   roots.push(root);
   const ledger = initEventLedger(join(root, "db.sqlite3"));
   closers.push(ledger);

--- a/test/unit/miner-init-verify-token.test.ts
+++ b/test/unit/miner-init-verify-token.test.ts
@@ -7,7 +7,7 @@ import { runInit, verifyGithubToken } from "../../packages/loopover-miner/lib/la
 const tempDirs = new Set<string>();
 
 function makeTempEnv() {
-  const configDir = mkdtempSync(join(tmpdir(), "gittensory-miner-init-"));
+  const configDir = mkdtempSync(join(tmpdir(), "loopover-miner-init-"));
   tempDirs.add(configDir);
   return {
     env: {

--- a/test/unit/miner-init-wizard.test.ts
+++ b/test/unit/miner-init-wizard.test.ts
@@ -17,7 +17,7 @@ import { runCliResult } from "./support/miner-cli-harness";
 const roots: string[] = [];
 
 function tempRoot() {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-init-wizard-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-init-wizard-"));
   roots.push(root);
   return root;
 }
@@ -65,7 +65,7 @@ async function typeLine(inStream: Readable, text: string) {
   inStream.emit("data", Buffer.from("\n"));
 }
 
-describe("gittensory-miner init --interactive wizard (#5176)", () => {
+describe("loopover-miner init --interactive wizard (#5176)", () => {
   it("renderWizardEnvFile renders sourceable KEY=value lines in insertion order, or empty for no entries", () => {
     expect(renderWizardEnvFile([])).toBe("");
     expect(renderWizardEnvFile([["GITHUB_TOKEN", "ghp_x"]])).toBe("GITHUB_TOKEN=ghp_x\n");
@@ -315,7 +315,7 @@ describe("gittensory-miner init --interactive wizard (#5176)", () => {
     });
   });
 
-  it("e2e: `gittensory-miner init --interactive` dispatches to the wizard, not the non-interactive path", () => {
+  it("e2e: `loopover-miner init --interactive` dispatches to the wizard, not the non-interactive path", () => {
     // No stdin input is piped, so the wizard blocks on its first prompt and the process is torn down once
     // Node detects the unsettled top-level await -- this only asserts the CLI routes `--interactive` to the
     // wizard (distinct prompt text, distinct code path) without hanging; the full multi-turn prompt flow is

--- a/test/unit/miner-laptop-init.test.ts
+++ b/test/unit/miner-laptop-init.test.ts
@@ -21,7 +21,7 @@ import {
 const roots: string[] = [];
 
 function tempRoot() {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-init-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-init-"));
   roots.push(root);
   return root;
 }
@@ -32,7 +32,7 @@ afterEach(() => {
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
 
-describe("gittensory-miner laptop init (#2329)", () => {
+describe("loopover-miner laptop init (#2329)", () => {
   it("resolves the laptop SQLite path from the state-dir override and XDG fallback", () => {
     expect(resolveLaptopStateDbPath({ LOOPOVER_MINER_CONFIG_DIR: "/custom/state" }))
       .toBe("/custom/state/laptop-state.sqlite3");
@@ -78,7 +78,7 @@ describe("gittensory-miner laptop init (#2329)", () => {
     const env = { LOOPOVER_MINER_CONFIG_DIR: join(root, "state") };
     const check = checkLaptopStateSqlite(env);
     expect(check.ok).toBe(false);
-    expect(check.detail).toContain("gittensory-miner init");
+    expect(check.detail).toContain("loopover-miner init");
   });
 
   it("doctor sqlite check reports unreadable files", () => {

--- a/test/unit/miner-local-store-readme.test.ts
+++ b/test/unit/miner-local-store-readme.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from "vitest";
 
 const readmePath = join(process.cwd(), "packages/loopover-miner/README.md");
 
-describe("gittensory-miner local storage README (#4272, #4876)", () => {
+describe("loopover-miner local storage README (#4272, #4876)", () => {
   it("documents every local SQLite store with file/table/module/env-var", () => {
     const readme = readFileSync(readmePath, "utf8");
     expect(readme).toContain("## Local storage");

--- a/test/unit/miner-local-store.test.ts
+++ b/test/unit/miner-local-store.test.ts
@@ -26,7 +26,7 @@ const roots: string[] = [];
 const dbs: Array<{ close(): void }> = [];
 
 function tempRoot(): string {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-local-store-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-local-store-"));
   roots.push(root);
   return root;
 }
@@ -40,7 +40,7 @@ afterEach(() => {
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
 
-describe("gittensory-miner shared local-store helper (#4272)", () => {
+describe("loopover-miner shared local-store helper (#4272)", () => {
   it("resolveLocalStoreDbPath prefers the explicit env var, then config dir, then XDG, then the home default", () => {
     expect(
       resolveLocalStoreDbPath("thing.sqlite3", "LOOPOVER_MINER_THING_DB", {

--- a/test/unit/miner-loop-cli.test.ts
+++ b/test/unit/miner-loop-cli.test.ts
@@ -22,7 +22,7 @@ const roots: string[] = [];
 const postRunClosers: Array<{ close(): void }> = [];
 
 function tempPath(prefix: string) {
-  const root = mkdtempSync(join(tmpdir(), `gittensory-miner-${prefix}-`));
+  const root = mkdtempSync(join(tmpdir(), `loopover-miner-${prefix}-`));
   roots.push(root);
   return join(root, "db.sqlite3");
 }

--- a/test/unit/miner-loop-closure.test.ts
+++ b/test/unit/miner-loop-closure.test.ts
@@ -23,7 +23,7 @@ const mockQueue = (entries: Array<{ status?: unknown }>): { listQueue: () => typ
 const roots: string[] = [];
 
 function tempRoot(): string {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-loop-closure-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-loop-closure-"));
   roots.push(root);
   return root;
 }

--- a/test/unit/miner-loop-reentry.test.ts
+++ b/test/unit/miner-loop-reentry.test.ts
@@ -17,7 +17,7 @@ const roots: string[] = [];
 const closers: Array<{ close(): void }> = [];
 
 function tempPath(prefix: string) {
-  const root = mkdtempSync(join(tmpdir(), `gittensory-miner-${prefix}-`));
+  const root = mkdtempSync(join(tmpdir(), `loopover-miner-${prefix}-`));
   roots.push(root);
   return join(root, "db.sqlite3");
 }

--- a/test/unit/miner-manage-status.test.ts
+++ b/test/unit/miner-manage-status.test.ts
@@ -32,7 +32,7 @@ const roots: string[] = [];
 const stores: Array<{ close(): void }> = [];
 
 function tempStores() {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-manage-status-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-manage-status-"));
   roots.push(root);
   const portfolioQueue = initPortfolioQueueStore(join(root, "portfolio-queue.sqlite3"));
   const eventLedger = initEventLedger(join(root, "event-ledger.sqlite3"));
@@ -50,7 +50,7 @@ afterEach(() => {
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
 
-describe("gittensory-miner manage status (#2325)", () => {
+describe("loopover-miner manage status (#2325)", () => {
   it("parses and formats managed PR identifiers", () => {
     expect(parseManagedPrIdentifier("pr:42")).toBe(42);
     expect(parseManagedPrIdentifier("issue:42")).toBeNull();
@@ -222,7 +222,7 @@ describe("gittensory-miner manage status (#2325)", () => {
   });
 
   it("runManageStatus prints the PR table + run portfolio table, and JSON output additive to the existing rows key (#4279)", () => {
-    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-manage-status-cli-"));
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-manage-status-cli-"));
     roots.push(root);
     const portfolioQueue = initPortfolioQueueStore(join(root, "portfolio-queue.sqlite3"));
     const eventLedger = initEventLedger(join(root, "event-ledger.sqlite3"));

--- a/test/unit/miner-mcp-audit-feed.test.ts
+++ b/test/unit/miner-mcp-audit-feed.test.ts
@@ -22,7 +22,7 @@ const roots: string[] = [];
 const ledgers: Array<{ close(): void }> = [];
 
 function tempLedger() {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-mcp-audit-feed-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-mcp-audit-feed-"));
   roots.push(root);
   const ledger = initEventLedger(join(root, "event-ledger.sqlite3"));
   ledgers.push(ledger);

--- a/test/unit/miner-mcp-contract.test.ts
+++ b/test/unit/miner-mcp-contract.test.ts
@@ -74,7 +74,7 @@ const PLANTED_SECRET = "EXAMPLE_TOKEN=not-a-real-secret";
 // like miner-mcp-governor-decisions.test.ts — the exclusion assertion then exercises the actual named-column SQL.
 const governorRoots: string[] = [];
 function seededGovernorLedger(): ReturnType<typeof initGovernorLedger> {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-mcp-contract-governor-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-mcp-contract-governor-"));
   governorRoots.push(root);
   const ledger = initGovernorLedger(join(root, "governor-ledger.sqlite3"));
   ledger.appendGovernorEvent({

--- a/test/unit/miner-mcp-governor-decisions.test.ts
+++ b/test/unit/miner-mcp-governor-decisions.test.ts
@@ -16,7 +16,7 @@ type GovernorLedgerHandle = ReturnType<typeof initGovernorLedger>;
 
 const roots: string[] = [];
 function tempGovernorLedger(): GovernorLedgerHandle {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-mcp-governor-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-mcp-governor-"));
   roots.push(root);
   return initGovernorLedger(join(root, "governor-ledger.sqlite3"));
 }

--- a/test/unit/miner-mcp-scaffold.test.ts
+++ b/test/unit/miner-mcp-scaffold.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../../packages/loopover-miner/bin/loopover-miner-mcp.js";
 import { collectPortfolioDashboard } from "../../packages/loopover-miner/lib/portfolio-dashboard.js";
 
-// Tests for the gittensory-miner MCP server: the #5153 ping scaffold and the #5155 read-only
+// Tests for the loopover-miner MCP server: the #5153 ping scaffold and the #5155 read-only
 // portfolio-dashboard tool. Drives the real server over an in-memory transport (no child process); the
 // dashboard tool's store opener and clock are injected so no on-disk AMS state is required.
 
@@ -86,7 +86,7 @@ function fakeLedger(rows: Array<{ repoFullName: string; status: string }>): Fake
   };
 }
 
-describe("gittensory-miner MCP server (#5153 scaffold)", () => {
+describe("loopover-miner MCP server (#5153 scaffold)", () => {
   it("exposes the ping, portfolio-dashboard, and list-claims tools", async () => {
     const client = await connectedClient();
     const { tools } = await client.listTools();

--- a/test/unit/miner-migrate-cli.test.ts
+++ b/test/unit/miner-migrate-cli.test.ts
@@ -10,7 +10,7 @@ import { resolveEventLedgerDbPath } from "../../packages/loopover-miner/lib/even
 const roots: string[] = [];
 
 function tempEnv() {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-migrate-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-migrate-"));
   roots.push(root);
   return { LOOPOVER_MINER_CONFIG_DIR: join(root, "state") };
 }
@@ -30,7 +30,7 @@ afterEach(() => {
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
 
-describe("gittensory-miner migrate (#4871)", () => {
+describe("loopover-miner migrate (#4871)", () => {
   it("covers the exact same seven stores doctor's store-integrity sweep covers, in the same order, and skips every one when nothing has been created yet", () => {
     const env = tempEnv();
     const results = runMigrateChecks(env);

--- a/test/unit/miner-package-skeleton.test.ts
+++ b/test/unit/miner-package-skeleton.test.ts
@@ -67,9 +67,9 @@ describe("loopover-miner package skeleton (#2287)", () => {
     expect(runCapture(["--version", "--no-update-check"])).toContain("@loopover/miner/");
     expect(
       runCapture(["--version", "--no-update-check"], {
-        LOOPOVER_MINER_VERSION: "gittensory-miner-fleet@abc1234",
+        LOOPOVER_MINER_VERSION: "loopover-miner-fleet@abc1234",
       }),
-    ).toContain("gittensory-miner-fleet@abc1234");
+    ).toContain("loopover-miner-fleet@abc1234");
   });
 
   it("documents foundation scope and local checkout install paths in the README", () => {


### PR DESCRIPTION
## Summary

- Part of the gittensory→loopover rebrand (#5705), phase 8b: rename remaining test-title prose. This batch covers 26 `test/unit/*.ts` files (governor, init, local-store, loop, mcp, and migrate clusters) whose `describe()`/`it()` titles, `mkdtempSync` tmpdir prefixes, and inline comments still used the bare `gittensory-miner`/`gittensory-ams` strings as human-readable labels.
- Also fixes a real stale string this sweep surfaced: `packages/loopover-miner/lib/laptop-init.js`'s doctor-check detail message still said `"run gittensory-miner init"`, telling self-hosters to run a CLI command that no longer exists (the real bin is `loopover-miner`). Test assertion updated in the same commit.
- No other functional/runtime identifier changes — purely test-label and comment prose.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue this PR resolves — N/A, maintainer-authored rebrand-epic cleanup (#5705), no linked-issue gate applies to owner PRs.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint` (via `npm run test:ci`)
- [x] `npm run typecheck` (via `npm run test:ci`)
- [x] `npm run test:coverage` — full unsharded run, 100% green; test-only diff plus one already-covered source line
- [x] `npm run test:workers` (via `npm run test:ci`)
- [x] `npm run build:mcp` (via `npm run test:ci`)
- [x] `npm run test:mcp-pack` (via `npm run test:ci`)
- [x] `npm run ui:openapi:check` (via `npm run test:ci`)
- [x] `npm run ui:lint` (via `npm run test:ci`)
- [x] `npm run ui:typecheck` (via `npm run test:ci`)
- [x] `npm run ui:build` (via `npm run test:ci`)
- [x] `npm audit --audit-level=moderate`
- [x] Full `npm run test:ci` gate run locally, exit 0

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no such changes.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no behavior change.
- [ ] UI changes use live API data or real empty/error/loading states. — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section. — N/A, no UI changes.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs (none touched here).

## Notes

- One of several batched PRs covering the ~150 remaining `describe()`/tmpdir-prefix renames tracked in rebrand epic #5705. Follows #5874 (batch 1).