### PR TITLE
fix(engine): guard agent-sdk-driver usage fields against malformed non-finite values

### DIFF
--- a/packages/loopover-engine/src/miner/agent-sdk-driver.ts
+++ b/packages/loopover-engine/src/miner/agent-sdk-driver.ts
@@ -82,10 +82,20 @@ function asRecord(value: unknown): Record<string, unknown> | null {
  *  once `usage` exists, but this driver reads `resultMessage` as a loosely-typed record (like every other field
  *  read here), so both are re-validated defensively rather than trusted from an untyped source. Returns
  *  undefined (never a fabricated 0) when `usage` is absent or malformed. */
+// Normalize an untrusted numeric usage field from the Agent SDK result message the same way
+// cli-subprocess-driver.ts's `finiteNonNegativeNumber` does for parsed CLI stdout: a NaN/±Infinity/negative value
+// (a malformed or buggy SDK result message, e.g. `num_turns: -1`) becomes `undefined`, so it can never reach
+// attempt-metering's `accumulateAttemptUsage` — which deliberately throws a RangeError on a non-finite/negative
+// field — and reject the whole iterate loop with the attempt's outcome never logged (#5827).
+function finiteNonNegativeNumber(value: unknown): number | undefined {
+  const n = typeof value === "number" ? value : NaN;
+  return Number.isFinite(n) && n >= 0 ? n : undefined;
+}
+
 function tokensFromResultMessage(resultMessage: Record<string, unknown> | null): number | undefined {
   const usage = asRecord(resultMessage?.usage);
-  const inputTokens = typeof usage?.input_tokens === "number" ? usage.input_tokens : undefined;
-  const outputTokens = typeof usage?.output_tokens === "number" ? usage.output_tokens : undefined;
+  const inputTokens = finiteNonNegativeNumber(usage?.input_tokens);
+  const outputTokens = finiteNonNegativeNumber(usage?.output_tokens);
   if (inputTokens === undefined && outputTokens === undefined) return undefined;
   return (inputTokens ?? 0) + (outputTokens ?? 0);
 }
@@ -175,13 +185,11 @@ export function createAgentSdkCodingAgentDriver(
         };
       }
 
-      const turnsUsed =
-        typeof resultMessage?.num_turns === "number" ? resultMessage.num_turns : undefined;
+      const turnsUsed = finiteNonNegativeNumber(resultMessage?.num_turns);
       // Real dollar cost: the SDK's own SDKResultSuccess/SDKResultError message types both declare
       // `total_cost_usd: number` unconditionally -- present whenever a result message arrived at all, success
       // or not (the session was billed either way), absent only when the stream produced no result message.
-      const costUsd =
-        typeof resultMessage?.total_cost_usd === "number" ? resultMessage.total_cost_usd : undefined;
+      const costUsd = finiteNonNegativeNumber(resultMessage?.total_cost_usd);
       const tokensUsed = tokensFromResultMessage(resultMessage);
       const resultText =
         typeof resultMessage?.result === "string" ? redactSecrets(resultMessage.result) : "";

--- a/test/unit/agent-sdk-driver.test.ts
+++ b/test/unit/agent-sdk-driver.test.ts
@@ -236,6 +236,33 @@ describe("createAgentSdkCodingAgentDriver", () => {
     expect((await nonNumericFields.run(task)).tokensUsed).toBeUndefined();
   });
 
+  it("drops malformed negative / non-finite numeric result fields to undefined so they can't crash attempt metering (#5827)", async () => {
+    // A buggy or malformed SDK result message (num_turns: -1, total_cost_usd: NaN, a negative/Infinite token
+    // count) must never reach attempt-metering's accumulateAttemptUsage -- it throws a RangeError on a
+    // non-finite/negative field, which would reject the whole iterate loop with the attempt's outcome never
+    // logged. Each field is normalized to undefined instead, exactly as a well-formed absent field would be.
+    const driver = driverWith({
+      query: queryYielding([
+        {
+          type: "result",
+          subtype: "success",
+          is_error: false,
+          num_turns: -1,
+          total_cost_usd: Number.NaN,
+          result: "done",
+          usage: { input_tokens: -5, output_tokens: Number.POSITIVE_INFINITY },
+        },
+      ]),
+    });
+
+    const result = await driver.run(task);
+
+    expect(result.ok).toBe(true);
+    expect(result.turnsUsed).toBeUndefined();
+    expect(result.costUsd).toBeUndefined();
+    expect(result.tokensUsed).toBeUndefined();
+  });
+
   it("tokensUsed sums whichever of input/output tokens IS a real number, when only input is present", async () => {
     const driver = driverWith({
       query: queryYielding([


### PR DESCRIPTION
## Summary

The Agent-SDK coding-agent driver reads `num_turns`, `total_cost_usd`, and `usage.input_tokens`/`output_tokens` off a loosely-typed result-message record and forwards them onto the attempt result. A **malformed or buggy** SDK result message — a negative `num_turns: -1`, a `NaN`/`Infinity` cost, a negative/Infinite token count — would flow straight through, and downstream attempt-metering's `accumulateAttemptUsage` throws a `RangeError` on any non-finite/negative field. That rejects the whole iterate loop, so the attempt's outcome is never logged.

The previous `typeof x === "number"` guards let `NaN`/`Infinity`/negatives past (they *are* numbers). This tightens every one of those reads through a single `finiteNonNegativeNumber` helper — the same normalization `cli-subprocess-driver.ts` already applies to parsed CLI stdout — so a malformed field becomes `undefined` (identical to a well-formed absent field) instead of crashing metering.

## Changes

- `finiteNonNegativeNumber(value)` helper in `agent-sdk-driver.ts`; applied to `num_turns`, `total_cost_usd`, and both `usage` token fields via `tokensFromResultMessage`.
- Regression test: a result message with `num_turns: -1`, `total_cost_usd: NaN`, `usage: { input_tokens: -5, output_tokens: Infinity }` asserts `turnsUsed`/`costUsd`/`tokensUsed` all come back `undefined`.

## Scope

- [x] Narrow, single-purpose change in `packages/loopover-engine/src/miner/`.
- [x] No behavior change for well-formed values or absent fields.

## Validation

- [x] `npm run typecheck`
- [x] `npx vitest run test/unit/agent-sdk-driver.test.ts` — 21 passed; both new normalization branches (`!Number.isFinite`, `!(n >= 0)`) covered by the regression test, the valid/non-number/absent legs by existing tests.
- [x] `scripts/check-engine-parity.ts` — ok (not a named twin).
- [x] Rebased onto latest `main`; mergeable-clean.

## Safety

- [x] Pure defensive normalization; no IO, no secrets, no private terms.

Closes #5827