### PR TITLE
docs(ui): rename gittensory prose to loopover across docs routes

### DIFF
--- a/apps/loopover-ui/src/routes/docs.beta-onboarding.tsx
+++ b/apps/loopover-ui/src/routes/docs.beta-onboarding.tsx
@@ -35,8 +35,8 @@ function BetaOnboarding() {
       <Callout>
         <strong>Product positioning.</strong> LoopOver is a deterministic base-agent and
         control-plane layer for the Gittensor ecosystem. It is{" "}
-        <a href="https://github.com/jsonbored/gittensory" target="_blank" rel="noreferrer">
-          jsonbored/gittensory
+        <a href="https://github.com/jsonbored/loopover" target="_blank" rel="noreferrer">
+          jsonbored/loopover
         </a>
         , independent of{" "}
         <a href="https://github.com/entrius/gittensor" target="_blank" rel="noreferrer">
@@ -59,26 +59,26 @@ function BetaOnboarding() {
           <Link to="/docs/quickstart">Quickstart</Link>.
           <CodeBlock
             code={`npm i -g @loopover/mcp@latest
-gittensory-mcp --help`}
+loopover-mcp --help`}
           />
         </li>
         <li>
           <strong>Sign in.</strong> GitHub Device Flow — no PAT storage.
           <CodeBlock
-            code={`gittensory-mcp login
-gittensory-mcp whoami`}
+            code={`loopover-mcp login
+loopover-mcp whoami`}
           />
         </li>
         <li>
           <strong>Run diagnostics.</strong> Confirms API reachability, auth, source-upload posture,
           and optional local score-preview wiring.
-          <CodeBlock code="gittensory-mcp doctor" />
+          <CodeBlock code="loopover-mcp doctor" />
         </li>
         <li>
           <strong>Plan next work.</strong> Ranked actions, lane context, and blockers —
           copilot-only; does not open PRs or post comments.
           <CodeBlock
-            code={`gittensory-mcp agent plan --login your-login --json
+            code={`loopover-mcp agent plan --login your-login --json
 # optional: --repo owner/repo`}
           />
         </li>
@@ -86,15 +86,15 @@ gittensory-mcp whoami`}
           <strong>Preflight the branch.</strong> Branch blockers, queue pressure, and maintainer-fit
           notes before you push.
           <CodeBlock
-            code={`gittensory-mcp analyze-branch --login your-login --json
-gittensory-mcp preflight --login your-login --json`}
+            code={`loopover-mcp analyze-branch --login your-login --json
+loopover-mcp preflight --login your-login --json`}
           />
         </li>
         <li>
           <strong>Prepare a public-safe packet.</strong> Maintainer-readable PR description with no
           private scoring language.
           <CodeBlock
-            code={`gittensory-mcp agent packet --login your-login --repo owner/repo --json`}
+            code={`loopover-mcp agent packet --login your-login --repo owner/repo --json`}
           />
         </li>
       </ol>

--- a/apps/loopover-ui/src/routes/docs.github-app.tsx
+++ b/apps/loopover-ui/src/routes/docs.github-app.tsx
@@ -10,7 +10,7 @@ export const Route = createFileRoute("/docs/github-app")({
       {
         name: "description",
         content:
-          "How the LoopOver GitHub App reviews pull requests once installed. Self-hosting is the only currently available path; a shared, centrally hosted App is planned as a future offering. The LoopOver Orb Review Agent check plus a review comment posted as gittensory[bot]. Choose repos, configure sticky PR panels, advisory checks, and optional review-agent enforcement.",
+          "How the LoopOver GitHub App reviews pull requests once installed. Self-hosting is the only currently available path; a shared, centrally hosted App is planned as a future offering. The LoopOver Orb Review Agent check plus a review comment posted as loopover[bot]. Choose repos, configure sticky PR panels, advisory checks, and optional review-agent enforcement.",
       },
       { property: "og:title", content: "GitHub App configuration — LoopOver docs" },
       {
@@ -39,7 +39,7 @@ function GithubApp() {
         available path. Each review produces two surfaces: the{" "}
         <strong>LoopOver Orb Review Agent</strong> check run (and the advisory{" "}
         <strong>LoopOver Context</strong> check), and a single review comment posted by{" "}
-        <code>gittensory[bot]</code> that updates in place as the PR evolves. The review behavior
+        <code>loopover[bot]</code> that updates in place as the PR evolves. The review behavior
         below this page's Install section (PR panel, checks, gate modes, config-as-code) is the same
         regardless of which connection mode your self-hosted App uses.
       </p>
@@ -101,8 +101,8 @@ GET /v1/installations/:id/repair`}
       <h2>PR panel</h2>
       <p>
         The PR panel is the review comment the LoopOver app posts on each pull request. It is one
-        sticky comment authored by <code>gittensory[bot]</code> that updates in place — the app
-        edits the same comment instead of adding new ones. It shows a public-safe readiness score,
+        sticky comment authored by <code>loopover[bot]</code> that updates in place — the app edits
+        the same comment instead of adding new ones. It shows a public-safe readiness score,
         concrete signal evidence, and short actions for linked issues, related work, review load,
         validation evidence, open PR queue, contributor context, and Gate result.
       </p>
@@ -341,12 +341,12 @@ review:
         code={`# Roll grounding + the unified comment onto one repo:
 LOOPOVER_REVIEW_GROUNDING="true"
 LOOPOVER_REVIEW_UNIFIED_COMMENT="true"
-LOOPOVER_REVIEW_REPOS="JSONbored/gittensory"`}
+LOOPOVER_REVIEW_REPOS="JSONbored/loopover"`}
       />
 
       <h2>Dogfood mode</h2>
       <p>
-        For repos like <code>JSONbored/gittensory</code> and <code>awesome-claude</code>, enable PR
+        For repos like <code>JSONbored/loopover</code> and <code>awesome-claude</code>, enable PR
         comments, labels, Context, and Gate together to test the full product surface. If another
         maintainer agent can merge quickly, configure that agent to wait for{" "}
         <code>LoopOver Orb Review Agent</code> before merge or close.

--- a/apps/loopover-ui/src/routes/docs.maintainer-self-hosting.tsx
+++ b/apps/loopover-ui/src/routes/docs.maintainer-self-hosting.tsx
@@ -280,7 +280,7 @@ function MaintainerSelfHosting() {
 
       <h2>Moving a repo between hosted and self-host</h2>
       <Callout variant="note" title="Hosted is currently paused">
-        &quot;Hosted&quot; here means the private managed-beta shared <code>gittensory</code> App
+        &quot;Hosted&quot; here means the private managed-beta shared <code>loopover</code> App
         described in <Link to="/docs/github-app">GitHub App configuration</Link> — it previously
         accepted new installs and is currently paused while self-hosted Orb is the primary way to
         run LoopOver. A new centrally hosted offering is planned for the future. "Switching from
@@ -318,7 +318,7 @@ function MaintainerSelfHosting() {
         </li>
         <li>
           Uninstall the shared hosted App from that repo (repo Settings → Integrations → GitHub Apps
-          → gittensory → Uninstall, or the equivalent org-level App settings page) once you&apos;ve
+          → loopover → Uninstall, or the equivalent org-level App settings page) once you&apos;ve
           confirmed the self-host App is reviewing PRs correctly. Leaving both installed means two
           reviewers post competing checks and comments on the same PRs.
         </li>
@@ -354,8 +354,8 @@ function MaintainerSelfHosting() {
       </Callout>
       <p>
         What stays identical for contributors either way: the review still posts as a{" "}
-        <code>gittensory[bot]</code>-style comment (under your own App&apos;s slug once you migrate,
-        not literally <code>gittensory[bot]</code>) plus the same check-run shape, and the gate
+        <code>loopover[bot]</code>-style comment (under your own App&apos;s slug once you migrate,
+        not literally <code>loopover[bot]</code>) plus the same check-run shape, and the gate
         semantics in <Link to="/docs/tuning">Tuning your reviews</Link> and{" "}
         <Link to="/docs/how-reviews-work">How reviews work</Link> are unchanged — only the
         infrastructure and the settings storage location differ.

--- a/apps/loopover-ui/src/routes/docs.mcp-clients.tsx
+++ b/apps/loopover-ui/src/routes/docs.mcp-clients.tsx
@@ -36,18 +36,18 @@ function McpClients() {
       <p>These commands print config only. They do not mutate your local client files.</p>
       <CodeBlock
         lang="bash"
-        code={`gittensory-mcp init-client --print codex
-gittensory-mcp init-client --print claude
-gittensory-mcp init-client --print cursor
-gittensory-mcp init-client --print mcp
-gittensory-mcp init-client --print vscode`}
+        code={`loopover-mcp init-client --print codex
+loopover-mcp init-client --print claude
+loopover-mcp init-client --print cursor
+loopover-mcp init-client --print mcp
+loopover-mcp init-client --print vscode`}
       />
       <p>
         <code>--print mcp</code> uses the same JSON snippet as Claude Desktop and Cursor for other
         stdio MCP hosts that expect the <code>mcpServers</code> shape. Every generated snippet
-        assumes <code>gittensory-mcp</code> is on your <code>PATH</code> (install it globally first,
+        assumes <code>loopover-mcp</code> is on your <code>PATH</code> (install it globally first,
         per <a href="/docs/quickstart">Quickstart</a>) — pass{" "}
-        <code>--command /absolute/path/to/gittensory-mcp</code> if your client doesn't inherit your
+        <code>--command /absolute/path/to/loopover-mcp</code> if your client doesn't inherit your
         shell PATH.
       </p>
 
@@ -55,8 +55,8 @@ gittensory-mcp init-client --print vscode`}
       <CodeBlock
         filename="~/.codex/config.toml"
         lang="toml"
-        code={`[mcp_servers.gittensory]
-command = "gittensory-mcp"
+        code={`[mcp_servers.loopover]
+command = "loopover-mcp"
 args = ["--stdio"]`}
       />
 
@@ -66,8 +66,8 @@ args = ["--stdio"]`}
         lang="json"
         code={`{
   "mcpServers": {
-    "gittensory": {
-      "command": "gittensory-mcp",
+    "loopover": {
+      "command": "loopover-mcp",
       "args": ["--stdio"]
     }
   }
@@ -80,8 +80,8 @@ args = ["--stdio"]`}
         lang="json"
         code={`{
   "mcpServers": {
-    "gittensory": {
-      "command": "gittensory-mcp",
+    "loopover": {
+      "command": "loopover-mcp",
       "args": ["--stdio"]
     }
   }
@@ -98,9 +98,9 @@ args = ["--stdio"]`}
         lang="json"
         code={`{
   "servers": {
-    "gittensory": {
+    "loopover": {
       "type": "stdio",
-      "command": "gittensory-mcp",
+      "command": "loopover-mcp",
       "args": ["--stdio"]
     }
   }

--- a/apps/loopover-ui/src/routes/docs.miner-quickstart.tsx
+++ b/apps/loopover-ui/src/routes/docs.miner-quickstart.tsx
@@ -60,18 +60,18 @@ npx -y @loopover/mcp@latest --help
 npm i -g @loopover/mcp@latest
 
 # sign in, confirm identity, check the session
-gittensory-mcp login
-gittensory-mcp whoami --json
-gittensory-mcp status --json
+loopover-mcp login
+loopover-mcp whoami --json
+loopover-mcp status --json
 
 # verify API, auth, and the local scorer before any analysis
-gittensory-mcp doctor --json`}
+loopover-mcp doctor --json`}
       />
       <Callout variant="safety">
         Session tokens are <strong>LoopOver tokens backed by GitHub identity</strong>, not your
         GitHub PATs. Source upload stays disabled (<code>LOOPOVER_UPLOAD_SOURCE=false</code>) and
         local absolute paths are redacted from anything that leaves your machine. Log out anytime
-        with <code>gittensory-mcp logout</code>.
+        with <code>loopover-mcp logout</code>.
       </Callout>
 
       <h2>1. Choose your lane</h2>
@@ -83,8 +83,8 @@ gittensory-mcp doctor --json`}
       </p>
       <CodeBlock
         code={`# what should I work on next, and what lane does this repo support?
-gittensory-mcp agent plan --login your-login --repo owner/repo --json
-gittensory-mcp repo-decision --login your-login --repo owner/repo --json`}
+loopover-mcp agent plan --login your-login --repo owner/repo --json
+loopover-mcp repo-decision --login your-login --repo owner/repo --json`}
       />
       <p>
         The repo&apos;s configured lane comes back as one of these (it is set by the repo&apos;s
@@ -120,9 +120,9 @@ gittensory-mcp repo-decision --login your-login --repo owner/repo --json`}
         then generate the public-safe packet to paste into the PR body.
       </p>
       <CodeBlock
-        code={`gittensory-mcp agent plan --login your-login --repo owner/repo --json
-gittensory-mcp preflight --login your-login --repo owner/repo --base origin/main --validation "passed|npm test|summary" --json
-gittensory-mcp agent packet --login your-login --repo owner/repo --base origin/main --json`}
+        code={`loopover-mcp agent plan --login your-login --repo owner/repo --json
+loopover-mcp preflight --login your-login --repo owner/repo --base origin/main --validation "passed|npm test|summary" --json
+loopover-mcp agent packet --login your-login --repo owner/repo --base origin/main --json`}
       />
 
       <h2>3. Issue-solving PR lane</h2>
@@ -133,9 +133,9 @@ gittensory-mcp agent packet --login your-login --repo owner/repo --base origin/m
       </p>
       <CodeBlock
         code={`# branch named/described so the linked issue is detected, e.g. "Fixes #123"
-gittensory-mcp agent plan --login your-login --repo owner/repo --json
-gittensory-mcp preflight --login your-login --repo owner/repo --base origin/main --branch-eligibility eligible --validation "passed|npm test|summary" --json
-gittensory-mcp agent packet --login your-login --repo owner/repo --base origin/main --json`}
+loopover-mcp agent plan --login your-login --repo owner/repo --json
+loopover-mcp preflight --login your-login --repo owner/repo --base origin/main --branch-eligibility eligible --validation "passed|npm test|summary" --json
+loopover-mcp agent packet --login your-login --repo owner/repo --base origin/main --json`}
       />
 
       <h2>4. Issue discovery lane</h2>
@@ -146,8 +146,8 @@ gittensory-mcp agent packet --login your-login --repo owner/repo --base origin/m
         loops.
       </p>
       <CodeBlock
-        code={`gittensory-mcp agent plan --login your-login --repo owner/repo --objective "find a high-proof issue" --json
-gittensory-mcp decision-pack --login your-login --json`}
+        code={`loopover-mcp agent plan --login your-login --repo owner/repo --objective "find a high-proof issue" --json
+loopover-mcp decision-pack --login your-login --json`}
       />
 
       <h2>5. Docs and context work</h2>
@@ -157,9 +157,9 @@ gittensory-mcp decision-pack --login your-login --json`}
         public-safe artifact regardless of whether the change is code or docs.
       </p>
       <CodeBlock
-        code={`gittensory-mcp agent plan --login your-login --repo owner/repo --json
-gittensory-mcp preflight --login your-login --repo owner/repo --base origin/main --validation "passed|docs build|summary" --json
-gittensory-mcp agent packet --login your-login --repo owner/repo --base origin/main --json`}
+        code={`loopover-mcp agent plan --login your-login --repo owner/repo --json
+loopover-mcp preflight --login your-login --repo owner/repo --base origin/main --validation "passed|docs build|summary" --json
+loopover-mcp agent packet --login your-login --repo owner/repo --base origin/main --json`}
       />
 
       <h2>6. Repo-specific lanes</h2>
@@ -170,8 +170,8 @@ gittensory-mcp agent packet --login your-login --repo owner/repo --base origin/m
         before you commit to a path.
       </p>
       <CodeBlock
-        code={`gittensory-mcp repo-decision --login your-login --repo owner/repo --json
-gittensory-mcp analyze-branch --login your-login --repo owner/repo --base origin/main --pending-merged-prs 3 --expected-open-prs 0 --scenario-note "after the queue clears" --json`}
+        code={`loopover-mcp repo-decision --login your-login --repo owner/repo --json
+loopover-mcp analyze-branch --login your-login --repo owner/repo --base origin/main --pending-merged-prs 3 --expected-open-prs 0 --scenario-note "after the queue clears" --json`}
       />
 
       <h2>Validation expectations (every lane)</h2>
@@ -183,8 +183,8 @@ gittensory-mcp analyze-branch --login your-login --repo owner/repo --base origin
         validation, not a guess.
       </p>
       <CodeBlock
-        code={`gittensory-mcp doctor --json
-gittensory-mcp preflight --login your-login --repo owner/repo --base origin/main --validation "passed|npm test|summary" --json`}
+        code={`loopover-mcp doctor --json
+loopover-mcp preflight --login your-login --repo owner/repo --base origin/main --validation "passed|npm test|summary" --json`}
       />
       <Callout variant="safety">
         The PR packet from <code>agent packet</code> is <strong>public-safe</strong>: it is scrubbed

--- a/apps/loopover-ui/src/routes/docs.miner-workflow.tsx
+++ b/apps/loopover-ui/src/routes/docs.miner-workflow.tsx
@@ -34,7 +34,7 @@ export function MinerWorkflow() {
         <>
           Pull a decision pack — lane context, repo targets to pursue or avoid, freshness, and
           ranked next actions.
-          <CodeBlock code={`gittensory-mcp agent plan --login your-login --json`} />
+          <CodeBlock code={`loopover-mcp agent plan --login your-login --json`} />
         </>
       ),
       maintainer: (
@@ -54,7 +54,7 @@ export function MinerWorkflow() {
         <>
           Metadata-only branch analysis on the current branch — refs, changed-file metadata, labels,
           linked issues, commit messages, validation summaries.
-          <CodeBlock code={`gittensory-mcp analyze-branch --login your-login --json`} />
+          <CodeBlock code={`loopover-mcp analyze-branch --login your-login --json`} />
         </>
       ),
       maintainer: (
@@ -74,7 +74,7 @@ export function MinerWorkflow() {
         <>
           Combine branch analysis with account/queue context to surface branch blockers, account
           blockers, and maintainer-fit notes.
-          <CodeBlock code={`gittensory-mcp preflight --login your-login --json`} />
+          <CodeBlock code={`loopover-mcp preflight --login your-login --json`} />
         </>
       ),
       maintainer: (
@@ -94,7 +94,7 @@ export function MinerWorkflow() {
         <>
           Produce a public-safe PR packet — a description that reads cleanly to maintainers, with no
           private scoring or risk language leaking out.
-          <CodeBlock code={`gittensory-mcp agent packet --json`} />
+          <CodeBlock code={`loopover-mcp agent packet --json`} />
         </>
       ),
       maintainer: (

--- a/apps/loopover-ui/src/routes/docs.owner-checklist.tsx
+++ b/apps/loopover-ui/src/routes/docs.owner-checklist.tsx
@@ -51,7 +51,7 @@ function OwnerChecklist() {
 GET /v1/repos/:owner/:repo/gittensor-config-recommendation`}
       />
       <CodeBlock
-        code={`gittensory-mcp init-client --print claude --agent-profile repo-owner-intake`}
+        code={`loopover-mcp init-client --print claude --agent-profile repo-owner-intake`}
       />
 
       <h2>1. Repository registration</h2>

--- a/apps/loopover-ui/src/routes/docs.privacy-security.tsx
+++ b/apps/loopover-ui/src/routes/docs.privacy-security.tsx
@@ -81,7 +81,7 @@ function PrivacySecurity() {
       </p>
       <CodeBlock
         code={`# Per-PR features run only when the flag is ON and the repo is allowlisted.
-LOOPOVER_REVIEW_REPOS="JSONbored/gittensory"   # per-repo cutover allowlist (default: none)
+LOOPOVER_REVIEW_REPOS="JSONbored/loopover"   # per-repo cutover allowlist (default: none)
 LOOPOVER_REVIEW_SAFETY="true"                  # prompt-injection defang + secret-leak scan
 LOOPOVER_REVIEW_GROUNDING="true"               # CI status + full changed-file content
 LOOPOVER_REVIEW_RAG="true"                     # codebase vector-index context (needs index)

--- a/apps/loopover-ui/src/routes/docs.quickstart.tsx
+++ b/apps/loopover-ui/src/routes/docs.quickstart.tsx
@@ -51,21 +51,21 @@ npm i -g @loopover/mcp@latest`}
         Flow and exchanges the result for a LoopOver session token.
       </p>
       <CodeBlock
-        code={`gittensory-mcp login
-gittensory-mcp whoami
-gittensory-mcp status`}
+        code={`loopover-mcp login
+loopover-mcp whoami
+loopover-mcp status`}
       />
       <Callout variant="safety">
         Session tokens are <strong>LoopOver tokens backed by GitHub identity</strong>, not your
-        GitHub PATs. You can log out anytime with <code>gittensory-mcp logout</code>.
+        GitHub PATs. You can log out anytime with <code>loopover-mcp logout</code>.
       </Callout>
 
       <h2>3. Run your first analysis</h2>
       <p>Analyze the current branch with metadata only. No source ever leaves your machine.</p>
       <CodeBlock
-        code={`gittensory-mcp doctor
-gittensory-mcp analyze-branch --login your-login --json
-gittensory-mcp preflight --login your-login --json`}
+        code={`loopover-mcp doctor
+loopover-mcp analyze-branch --login your-login --json
+loopover-mcp preflight --login your-login --json`}
       />
 
       <h2>4. Wire it into your coding agent</h2>
@@ -76,9 +76,9 @@ gittensory-mcp preflight --login your-login --json`}
         <a href="/docs/beta-onboarding">Beta onboarding</a>.
       </p>
       <CodeBlock
-        code={`gittensory-mcp init-client --print codex
-gittensory-mcp init-client --print claude
-gittensory-mcp init-client --print cursor`}
+        code={`loopover-mcp init-client --print codex
+loopover-mcp init-client --print claude
+loopover-mcp init-client --print cursor`}
       />
     </DocsPage>
   );

--- a/apps/loopover-ui/src/routes/docs.self-hosting-ai-providers.tsx
+++ b/apps/loopover-ui/src/routes/docs.self-hosting-ai-providers.tsx
@@ -201,7 +201,7 @@ CLAUDE_AI_EFFORT=medium`}
         the running container so the file lands on the volume the image expects (
         <code>/data/codex</code>, mounted at <code>~/.codex</code>):
       </p>
-      <CodeBlock code={`docker compose exec gittensory codex auth`} />
+      <CodeBlock code={`docker compose exec loopover codex auth`} />
       <p>
         This also needs the explicit opt-in shown in the fallback example above (
         <code>LOOPOVER_ENABLE_UNSAFE_CODEX_REVIEWER=1</code>) — see the Subscription CLI safety note

--- a/apps/loopover-ui/src/routes/docs.self-hosting-backup-scaling.tsx
+++ b/apps/loopover-ui/src/routes/docs.self-hosting-backup-scaling.tsx
@@ -156,7 +156,7 @@ npm run selfhost:postgres:migrate -- --sqlite /data/loopover.sqlite --execute`}
       <CodeBlock
         lang="bash"
         code={`docker compose --profile backup run --rm backup sh /scripts/verify-backup.sh
-docker compose --profile backup run --rm backup sh /scripts/verify-backup.sh /backups/postgres/gittensory-<timestamp>.dump`}
+docker compose --profile backup run --rm backup sh /scripts/verify-backup.sh /backups/postgres/loopover-<timestamp>.dump`}
       />
       <p>
         A healthy run ends with <code>[verify] postgres archive OK: … (N TOC entries)</code> (or{" "}

--- a/apps/loopover-ui/src/routes/docs.self-hosting-configuration.tsx
+++ b/apps/loopover-ui/src/routes/docs.self-hosting-configuration.tsx
@@ -142,35 +142,35 @@ cp config/examples/global.loopover.yml loopover-config/.loopover.yml`}
         Keep anti-abuse thresholds, maintainer allowlists, and autonomy dials in the{" "}
         <strong>private</strong> mount — not in a public <code>.loopover.yml</code> contributors can
         read. <code>config/examples/TEMPLATES.md</code> documents the public-vs-private split and
-        how to apply the templates to <code>gittensory</code>, <code>awesome-claude</code>, and{" "}
+        how to apply the templates to <code>loopover</code>, <code>awesome-claude</code>, and{" "}
         <code>metagraphed</code> without committing private policy. Lint before deploy:{" "}
         <code>npx tsx scripts/loopover-config-lint.ts path/to/.loopover.yml</code>.
       </Callout>
       <p>Authoritative copies in git:</p>
       <ul>
         <li>
-          <a href="https://github.com/JSONbored/gittensory/blob/main/config/examples/loopover.minimal.yml">
+          <a href="https://github.com/JSONbored/loopover/blob/main/config/examples/loopover.minimal.yml">
             <code>config/examples/loopover.minimal.yml</code>
           </a>
         </li>
         <li>
-          <a href="https://github.com/JSONbored/gittensory/blob/main/config/examples/loopover.full.yml">
+          <a href="https://github.com/JSONbored/loopover/blob/main/config/examples/loopover.full.yml">
             <code>config/examples/loopover.full.yml</code>
           </a>{" "}
           (same body as{" "}
-          <a href="https://github.com/JSONbored/gittensory/blob/main/.loopover.yml.example">
+          <a href="https://github.com/JSONbored/loopover/blob/main/.loopover.yml.example">
             <code>.loopover.yml.example</code>
           </a>
           )
         </li>
         <li>
-          <a href="https://github.com/JSONbored/gittensory/blob/main/config/examples/TEMPLATES.md">
+          <a href="https://github.com/JSONbored/loopover/blob/main/config/examples/TEMPLATES.md">
             <code>config/examples/TEMPLATES.md</code>
           </a>{" "}
           — catalog + fleet usage notes
         </li>
         <li>
-          <a href="https://github.com/JSONbored/gittensory/blob/main/config/examples/README.md">
+          <a href="https://github.com/JSONbored/loopover/blob/main/config/examples/README.md">
             <code>config/examples/README.md</code>
           </a>{" "}
           — the full private-config layout, precedence chain, and deep-merge semantics, including
@@ -187,7 +187,7 @@ cp config/examples/global.loopover.yml loopover-config/.loopover.yml`}
         filename=".env"
         code={`PUBLIC_API_ORIGIN=https://reviews.example.com
 GITHUB_APP_ID=123456
-GITHUB_APP_SLUG=my-gittensory-app
+GITHUB_APP_SLUG=my-loopover-app
 GITHUB_APP_PRIVATE_KEY_FILE=/run/secrets/github-app-private-key.pem
 GITHUB_WEBHOOK_SECRET=<random-webhook-secret>
 
@@ -207,7 +207,7 @@ INTERNAL_JOB_TOKEN=<random-32-byte-token>`}
       </p>
       <Callout variant="warn" title="MCP_ACTUATION_REPO_ALLOWLIST">
         <code>LOOPOVER_MCP_TOKEN</code> is a shared, end-user-obtainable CLI credential (the normal
-        alternative to <code>gittensory-mcp login</code>), so it must not implicitly stage actions
+        alternative to <code>loopover-mcp login</code>), so it must not implicitly stage actions
         (merges, closes, approvals) on every repo the App happens to be installed on.{" "}
         <code>MCP_ACTUATION_REPO_ALLOWLIST</code> scopes it to an explicit,
         comma/whitespace-separated <code>owner/repo</code> list —{" "}

--- a/apps/loopover-ui/src/routes/docs.self-hosting-docs-audit.tsx
+++ b/apps/loopover-ui/src/routes/docs.self-hosting-docs-audit.tsx
@@ -40,7 +40,7 @@ function SelfHostingDocsAudit() {
     >
       <Callout variant="note" title="Scope (#1829)">
         This page is the in-repo paper trail for the self-host docs audit under roadmap{" "}
-        <a href="https://github.com/JSONbored/gittensory/issues/1819">#1819</a>. REES analyzer
+        <a href="https://github.com/JSONbored/loopover/issues/1819">#1819</a>. REES analyzer
         metadata generation is tracked separately on the REES roadmap — the analyzer reference page
         covers names and shapes; auto-generated metadata tables are out of scope here.
       </Callout>
@@ -110,7 +110,7 @@ function SelfHostingDocsAudit() {
       <h2>Defaults, optional services, and experimental surfaces</h2>
       <ul>
         <li>
-          <strong>Core stack (default):</strong> gittensory + Redis + SQLite on the mounted data
+          <strong>Core stack (default):</strong> loopover + Redis + SQLite on the mounted data
           volume; <code>SELFHOST_DEPLOYMENT_MODE=dry-run</code> in{" "}
           <code>.env.selfhost.example</code>.
         </li>

--- a/apps/loopover-ui/src/routes/docs.self-hosting-github-app.tsx
+++ b/apps/loopover-ui/src/routes/docs.self-hosting-github-app.tsx
@@ -162,7 +162,7 @@ SELFHOST_SETUP_TOKEN=change-this-long-random-value  # unlocks /setup for a fresh
       <CodeBlock
         filename=".env"
         code={`GITHUB_APP_ID=123456
-GITHUB_APP_SLUG=my-gittensory-app
+GITHUB_APP_SLUG=my-loopover-app
 GITHUB_APP_PRIVATE_KEY_FILE=/run/secrets/github-app-private-key.pem
 GITHUB_WEBHOOK_SECRET=<same-secret-configured-on-the-app>`}
       />

--- a/apps/loopover-ui/src/routes/docs.self-hosting-operations.tsx
+++ b/apps/loopover-ui/src/routes/docs.self-hosting-operations.tsx
@@ -574,7 +574,7 @@ volumes:
         code={`# Your Sentry project DSN — never commit this to git
 SENTRY_DSN=https://examplePublicKey@o0.ingest.sentry.io/0
 SENTRY_ENVIRONMENT=production
-SENTRY_SERVER_NAME=gittensory-us-east
+SENTRY_SERVER_NAME=loopover-us-east
 SENTRY_RELEASE=gittensory-selfhost@2026.07.05
 # Optional: sample review tracing spans (0.05 = 5%)
 # SENTRY_TRACES_SAMPLE_RATE=0.05`}
@@ -605,7 +605,7 @@ SENTRY_RELEASE=gittensory-selfhost@2026.07.05
 VITE_SENTRY_ENVIRONMENT=production
 # Match the release id the ui-sentry-release workflow uploaded for this commit,
 # or symbolication won't find the matching source maps:
-VITE_SENTRY_RELEASE=gittensory-ui@<short-sha>`}
+VITE_SENTRY_RELEASE=loopover-ui@<short-sha>`}
       />
       <p>
         Every browser event is scrubbed before it leaves the box: request cookies, headers, and body
@@ -643,7 +643,7 @@ VITE_SENTRY_RELEASE=gittensory-ui@<short-sha>`}
           {
             title: "Contexts (full scrubbed detail)",
             description:
-              "gittensory (engine captures), review (failed reviews), log (structured console lines), sentry_monitor (cron failures), otel (active trace ids). Secrets, tokens, bodies, diffs, prompts, and review text are redacted before send.",
+              "loopover (engine captures), review (failed reviews), log (structured console lines), sentry_monitor (cron failures), otel (active trace ids). Secrets, tokens, bodies, diffs, prompts, and review text are redacted before send.",
           },
           {
             title: "Subsystems",
@@ -773,7 +773,7 @@ VITE_SENTRY_RELEASE=gittensory-ui@<short-sha>`}
       <h2>Sentry server name</h2>
       <p>
         <code>SENTRY_SERVER_NAME</code> sets a clean, human name for this instance in Sentry (for
-        example <code>gittensory-us-east</code>). Unset defaults to the OS hostname — never the
+        example <code>loopover-us-east</code>). Unset defaults to the OS hostname — never the
         public-origin URL. Set this explicitly if you run more than one instance and want to tell
         their Sentry events apart at a glance instead of matching container hostnames.
       </p>

--- a/apps/loopover-ui/src/routes/docs.self-hosting-quickstart.tsx
+++ b/apps/loopover-ui/src/routes/docs.self-hosting-quickstart.tsx
@@ -125,8 +125,8 @@ LOOPOVER_IMAGE=ghcr.io/jsonbored/loopover-selfhost@sha256:... ./scripts/deploy-s
       </p>
       <Callout variant="note" title="Building from source instead">
         Contributors and anyone customizing the Dockerfile can still build locally —{" "}
-        <code>docker compose up -d --build</code> builds the <code>gittensory</code> service from
-        the checkout instead of pulling a published image. Everything else in this quickstart (env,
+        <code>docker compose up -d --build</code> builds the <code>loopover</code> service from the
+        checkout instead of pulling a published image. Everything else in this quickstart (env,
         health checks, GitHub App) is identical either way. Two build-args trim the image:{" "}
         <code>--build-arg INSTALL_AI_CLIS=false</code> skips the Claude Code/Codex CLIs (default{" "}
         <code>true</code>), and <code>--build-arg INSTALL_VISUAL_REVIEW=true</code> adds{" "}
@@ -271,7 +271,7 @@ cp config/examples/global.loopover.yml loopover-config/owner__my-repo/.loopover.
       <CodeBlock
         lang="text"
         code={`ENABLED BY DEFAULT (no flags needed)
-  gittensory app + Redis        SQLite database, dry-run-friendly, Orb telemetry (see Callout below)
+  loopover app + Redis        SQLite database, dry-run-friendly, Orb telemetry (see Callout below)
 
 RECOMMENDED FOR PRODUCTION (opt-in)
   --profile postgres             shared/multi-instance database (pgvector-capable)

--- a/apps/loopover-ui/src/routes/docs.self-hosting-release-checklist.tsx
+++ b/apps/loopover-ui/src/routes/docs.self-hosting-release-checklist.tsx
@@ -81,7 +81,7 @@ git push origin orb-v0.1.0`}
           {
             title: "1. Smoke matrix green",
             description:
-              "Every applicable scenario in the matrix below passes against a locally built candidate image (docker buildx build --load -t gittensory:rc-candidate .).",
+              "Every applicable scenario in the matrix below passes against a locally built candidate image (docker buildx build --load -t loopover:rc-candidate .).",
           },
           {
             title: "2. Image-contents audit reviewed",
@@ -238,7 +238,7 @@ git push origin orb-v0.1.0`}
                 .
               </td>
               <td className="py-2 align-top text-muted-foreground">
-                Only the <code>gittensory</code> service restarts (<code>--no-deps</code>);{" "}
+                Only the <code>loopover</code> service restarts (<code>--no-deps</code>);{" "}
                 <code>.env</code>, data volumes, and <code>loopover-config/</code> are untouched;{" "}
                 <code>/ready</code> returns 200 after the health-check wait.
               </td>
@@ -262,7 +262,7 @@ git push origin orb-v0.1.0`}
                 (Postgres, Redis, Qdrant, Grafana) already up.
               </td>
               <td className="py-2 align-top text-muted-foreground">
-                Only the <code>gittensory</code> container recreates; profile-service containers and
+                Only the <code>loopover</code> container recreates; profile-service containers and
                 their volumes are never touched.
               </td>
             </tr>
@@ -298,8 +298,8 @@ git push origin orb-v0.1.0`}
       <CodeBlock
         lang="bash"
         code={`# Build (or use a published tag) once, then run each scenario against the same image:
-docker buildx build --load -t gittensory:rc-candidate .
-./scripts/smoke-selfhost.sh gittensory:rc-candidate`}
+docker buildx build --load -t loopover:rc-candidate .
+./scripts/smoke-selfhost.sh loopover:rc-candidate`}
       />
 
       <h3>Direct GitHub App mode (default)</h3>
@@ -316,7 +316,7 @@ SELFHOST_SMOKE_EXTRA_VOLUMES="\${TEST_APP_PRIVATE_KEY_PATH}:/run/secrets/github-
 SELFHOST_SMOKE_EXTRA_ENV="GITHUB_APP_ID=123456
 GITHUB_APP_PRIVATE_KEY_FILE=/run/secrets/github-app-private-key.pem" \\
 SELFHOST_SMOKE_FORBID_EVENTS="selfhost_orb_export_error,selfhost_orb_relay_register" \\
-./scripts/smoke-selfhost.sh gittensory:rc-candidate`}
+./scripts/smoke-selfhost.sh loopover:rc-candidate`}
       />
       <p>
         <code>selfhost_orb_relay_register</code> must NOT appear here — relay registration is
@@ -344,7 +344,7 @@ SELFHOST_SMOKE_EXTRA_ENV="ORB_ENROLLMENT_SECRET=\${TEST_ENROLLMENT_SECRET}
 PUBLIC_API_ORIGIN=https://selfhost-smoke.example" \\
 SELFHOST_SMOKE_EXPECT_EVENTS="selfhost_orb_relay_register" \\
 SELFHOST_SMOKE_FORBID_EVENTS="selfhost_orb_relay_register_failed" \\
-./scripts/smoke-selfhost.sh gittensory:rc-candidate
+./scripts/smoke-selfhost.sh loopover:rc-candidate
 
 # Pull mode -- no PUBLIC_API_ORIGIN needed; the container polls the broker outbound instead of
 # exposing an inbound endpoint. The right fit for NAT/tailnet operators with no public ingress.
@@ -352,7 +352,7 @@ SELFHOST_SMOKE_EXTRA_ENV="ORB_ENROLLMENT_SECRET=\${TEST_ENROLLMENT_SECRET}
 ORB_RELAY_MODE=pull" \\
 SELFHOST_SMOKE_EXPECT_EVENTS="selfhost_orb_relay_register" \\
 SELFHOST_SMOKE_FORBID_EVENTS="selfhost_orb_relay_register_failed" \\
-./scripts/smoke-selfhost.sh gittensory:rc-candidate`}
+./scripts/smoke-selfhost.sh loopover:rc-candidate`}
       />
 
       <h3>Air-gapped / no-telemetry mode</h3>
@@ -366,7 +366,7 @@ SELFHOST_SMOKE_FORBID_EVENTS="selfhost_orb_relay_register_failed" \\
         lang="bash"
         code={`SELFHOST_SMOKE_EXTRA_ENV="ORB_AIR_GAP=true" \\
 SELFHOST_SMOKE_FORBID_EVENTS="selfhost_orb_export_error,selfhost_orb_relay_register" \\
-./scripts/smoke-selfhost.sh gittensory:rc-candidate`}
+./scripts/smoke-selfhost.sh loopover:rc-candidate`}
       />
 
       <h3>AI provider: Claude Code / Codex / both</h3>
@@ -383,14 +383,14 @@ SELFHOST_SMOKE_EXTRA_ENV="AI_PROVIDER=claude-code
 CLAUDE_CODE_OAUTH_TOKEN=\${TEST_CLAUDE_TOKEN}" \\
 SELFHOST_SMOKE_EXPECT_EVENTS="selfhost_ai_provider" \\
 SELFHOST_SMOKE_FORBID_EVENTS="selfhost_ai_cli_missing" \\
-./scripts/smoke-selfhost.sh gittensory:rc-candidate
+./scripts/smoke-selfhost.sh loopover:rc-candidate
 
 # Codex only (requires the fail-closed opt-in)
 SELFHOST_SMOKE_EXTRA_ENV="AI_PROVIDER=codex
 LOOPOVER_ENABLE_UNSAFE_CODEX_REVIEWER=1" \\
 SELFHOST_SMOKE_EXPECT_EVENTS="selfhost_ai_provider" \\
 SELFHOST_SMOKE_FORBID_EVENTS="selfhost_ai_cli_missing" \\
-./scripts/smoke-selfhost.sh gittensory:rc-candidate
+./scripts/smoke-selfhost.sh loopover:rc-candidate
 
 # Codex primary, Claude Code fallback
 SELFHOST_SMOKE_EXTRA_ENV="AI_PROVIDER=codex,claude-code
@@ -400,7 +400,7 @@ CLAUDE_CODE_OAUTH_TOKEN=\${TEST_CLAUDE_TOKEN}
 LOOPOVER_ENABLE_UNSAFE_CODEX_REVIEWER=1" \\
 SELFHOST_SMOKE_EXPECT_EVENTS="selfhost_ai_provider" \\
 SELFHOST_SMOKE_FORBID_EVENTS="selfhost_ai_cli_missing" \\
-./scripts/smoke-selfhost.sh gittensory:rc-candidate`}
+./scripts/smoke-selfhost.sh loopover:rc-candidate`}
       />
       <Callout variant="note">
         These need real credentials to reach a genuinely healthy <code>/ready</code> (it probes the
@@ -418,10 +418,10 @@ SELFHOST_SMOKE_FORBID_EVENTS="selfhost_ai_cli_missing" \\
       <CodeBlock
         lang="bash"
         code={`docker network create gt-pg-smoke
-docker run -d --name gt-pg --network gt-pg-smoke -e POSTGRES_PASSWORD=devpw -e POSTGRES_DB=gittensory postgres:16-alpine
+docker run -d --name gt-pg --network gt-pg-smoke -e POSTGRES_PASSWORD=devpw -e POSTGRES_DB=loopover postgres:16-alpine
 SELFHOST_SMOKE_NETWORK=gt-pg-smoke \\
-SELFHOST_SMOKE_EXTRA_ENV="DATABASE_URL=postgres://postgres:devpw@gt-pg:5432/gittensory" \\
-./scripts/smoke-selfhost.sh gittensory:rc-candidate
+SELFHOST_SMOKE_EXTRA_ENV="DATABASE_URL=postgres://postgres:devpw@gt-pg:5432/loopover" \\
+./scripts/smoke-selfhost.sh loopover:rc-candidate
 docker rm -f gt-pg && docker network rm gt-pg-smoke`}
       />
       <Callout variant="safety">
@@ -439,7 +439,7 @@ docker rm -f gt-pg && docker network rm gt-pg-smoke`}
       <CodeBlock
         lang="bash"
         code={`SELFHOST_SMOKE_EXPECT_EVENTS="selfhost_redis_ready" \\
-./scripts/smoke-selfhost.sh gittensory:rc-candidate
+./scripts/smoke-selfhost.sh loopover:rc-candidate
 
 # With Qdrant RAG:
 docker network create gt-rag-smoke
@@ -447,7 +447,7 @@ docker run -d --name gt-qdrant --network gt-rag-smoke qdrant/qdrant:v1.18.2
 SELFHOST_SMOKE_NETWORK=gt-rag-smoke \\
 SELFHOST_SMOKE_EXTRA_ENV="QDRANT_URL=http://gt-qdrant:6333" \\
 SELFHOST_SMOKE_EXPECT_EVENTS="selfhost_vectorize" \\
-./scripts/smoke-selfhost.sh gittensory:rc-candidate
+./scripts/smoke-selfhost.sh loopover:rc-candidate
 docker rm -f gt-qdrant && docker network rm gt-rag-smoke`}
       />
 
@@ -551,7 +551,7 @@ docker rm -f gt-qdrant && docker network rm gt-rag-smoke`}
               "docker-compose.override.yml(.example) and any host-specific compose profile config live outside the image entirely; the image only ever contains the application bundle plus its declared runtime dependencies.",
           },
           {
-            title: "apps/ (gittensory-ui) and test/ — excluded from the build context",
+            title: "apps/ (loopover-ui) and test/ — excluded from the build context",
             description:
               "Already in .dockerignore alongside the existing exclusions (shipped ahead of this checklist, in the same #1819 hardening pass): the self-host bundle's only entry point is src/server.ts and npm ci only reads the root package*.json, so the UI workspace app and the test suite are never read during the image build (~11MB of this repo's ~22MB tracked-file footprint kept out).",
           },
@@ -608,7 +608,7 @@ docker images ghcr.io/jsonbored/loopover-selfhost:orb-v0.1.0 --format '{{.Size}}
           {
             title: "The escape hatch already exists",
             description:
-              "An operator who wants a smaller image without the AI CLIs can build it themselves today: docker compose build --build-arg INSTALL_AI_CLIS=false gittensory. Nothing about shipping one default image forecloses adding a published minimal tag later.",
+              "An operator who wants a smaller image without the AI CLIs can build it themselves today: docker compose build --build-arg INSTALL_AI_CLIS=false loopover. Nothing about shipping one default image forecloses adding a published minimal tag later.",
           },
         ]}
       />
@@ -640,7 +640,7 @@ docker pull ghcr.io/jsonbored/loopover-selfhost:orb-v0.1.0
 
 Multi-arch (linux/amd64 + linux/arm64). See https://gittensory.aethereal.dev/docs/maintainer-self-hosting for setup.
 Includes the Claude Code / Codex subscription CLIs by default; credentials stay runtime-only.
-Sentry release id baked into the image: \`gittensory-orb@0.1.0\`.
+Sentry release id baked into the image: \`loopover-orb@0.1.0\`.
 
 ## First stable release
 
@@ -654,7 +654,7 @@ The \`latest\` tag now points here.
 - Redis cache (required in every mode).
 - Claude Code and Codex AI providers, including a provider chain with fallback.
 - Health/readiness endpoints (\`/health\`, \`/ready\`, \`/metrics\`) and the documented log-event contract.
-- Rollback to a prior image tag and one-service (\`gittensory\` only) restart, via
+- Rollback to a prior image tag and one-service (\`loopover\` only) restart, via
   \`scripts/deploy-selfhost-image.sh\` / \`scripts/deploy-selfhost-prebuilt.sh\`.
 
 ## Experimental

--- a/apps/loopover-ui/src/routes/docs.self-hosting-releases.tsx
+++ b/apps/loopover-ui/src/routes/docs.self-hosting-releases.tsx
@@ -91,7 +91,7 @@ docker pull ghcr.io/jsonbored/loopover-selfhost:latest`}
         <li>
           Pull and restart with <code>scripts/deploy-selfhost-image.sh</code> (or rebuild the
           checkout with <code>scripts/deploy-selfhost-prebuilt.sh</code>) — both restart only the{" "}
-          <code>gittensory</code> service (<code>--no-deps</code>) and wait for it to report{" "}
+          <code>loopover</code> service (<code>--no-deps</code>) and wait for it to report{" "}
           <code>healthy</code> before returning, instead of a bare <code>docker compose up -d</code>{" "}
           that returns as soon as the container starts.
         </li>
@@ -114,7 +114,7 @@ curl http://localhost:8787/ready
         <code>LOOPOVER_VERSION</code> from the checked-out commit (
         <code>git rev-parse --short=8 HEAD</code>) unless you set <code>SENTRY_RELEASE</code>{" "}
         yourself. A plain{" "}
-        <code>docker compose pull gittensory &amp;&amp; docker compose up -d gittensory</code> still
+        <code>docker compose pull loopover &amp;&amp; docker compose up -d loopover</code> still
         works, but skips the health-check wait loop and input validation both scripts provide.
       </Callout>
 
@@ -128,8 +128,8 @@ curl http://localhost:8787/ready
       </p>
       <CodeBlock
         lang="bash"
-        code={`docker compose build --build-arg INSTALL_AI_CLIS=true gittensory
-docker compose up -d gittensory`}
+        code={`docker compose build --build-arg INSTALL_AI_CLIS=true loopover
+docker compose up -d loopover`}
       />
 
       <h2>Sentry source maps</h2>

--- a/apps/loopover-ui/src/routes/docs.self-hosting-security.tsx
+++ b/apps/loopover-ui/src/routes/docs.self-hosting-security.tsx
@@ -258,14 +258,14 @@ SELFHOST_USE_INFISICAL=1 ./scripts/deploy-selfhost-prebuilt.sh`}
           {
             title: "Bring your own reverse proxy",
             description:
-              "Skip both profiles and put an existing nginx/Traefik/ALB in front of the gittensory service's own port instead.",
+              "Skip both profiles and put an existing nginx/Traefik/ALB in front of the loopover service's own port instead.",
           },
         ]}
       />
 
       <h3>Caddy: automatic HTTPS with Let's Encrypt</h3>
       <p>
-        The <code>caddy</code> profile runs Caddy 2 in front of the <code>gittensory</code> service,
+        The <code>caddy</code> profile runs Caddy 2 in front of the <code>loopover</code> service,
         terminating TLS on <code>80</code>/<code>443</code>/<code>443/udp</code> (the last for
         HTTP/3) and obtaining a Let's Encrypt certificate automatically for whatever domain you set.
         It needs a real DNS record: point <code>DOMAIN</code> at this host's public IP{" "}
@@ -279,7 +279,7 @@ SELFHOST_USE_INFISICAL=1 ./scripts/deploy-selfhost-prebuilt.sh`}
       </p>
       <CodeBlock filename=".env" code={`DOMAIN=reviews.yourcompany.com`} />
       <p>
-        The shipped <code>caddy/Caddyfile</code> reverse-proxies to <code>gittensory:8787</code> on
+        The shipped <code>caddy/Caddyfile</code> reverse-proxies to <code>loopover:8787</code> on
         the compose network, forwards the real client IP, enables compression, sets standard
         security headers (HSTS, <code>X-Content-Type-Options</code>, <code>X-Frame-Options</code>, a
         strict referrer policy), and logs as JSON to stderr:
@@ -287,7 +287,7 @@ SELFHOST_USE_INFISICAL=1 ./scripts/deploy-selfhost-prebuilt.sh`}
       <CodeBlock
         filename="caddy/Caddyfile"
         code={`{$DOMAIN} {
-	reverse_proxy gittensory:8787 {
+	reverse_proxy loopover:8787 {
 		header_up X-Forwarded-For {remote_host}
 		header_up X-Real-IP {remote_host}
 	}
@@ -315,7 +315,7 @@ SELFHOST_USE_INFISICAL=1 ./scripts/deploy-selfhost-prebuilt.sh`}
         about it, which is expected.
       </p>
       <Callout variant="warn" title="Remove the app's own port mapping">
-        The <code>gittensory</code> service's compose entry has a direct{" "}
+        The <code>loopover</code> service's compose entry has a direct{" "}
         <code>{`ports: ["\${PORT:-8787}:8787"]`}</code> mapping with a comment marking exactly this:
         remove it once Caddy is your public listener, or the app stays reachable on{" "}
         <code>:8787</code> with no TLS, bypassing the proxy entirely and defeating the whole point
@@ -340,7 +340,7 @@ SELFHOST_USE_INFISICAL=1 ./scripts/deploy-selfhost-prebuilt.sh`}
       <h3>Already run a reverse proxy or load balancer?</h3>
       <p>
         Skip the <code>caddy</code> profile entirely. Remove the same direct <code>ports:</code>{" "}
-        mapping from the <code>gittensory</code> service, keep it on the compose network (or publish{" "}
+        mapping from the <code>loopover</code> service, keep it on the compose network (or publish{" "}
         <code>8787</code> bound to a private interface your existing proxy can reach), and terminate
         TLS the way you already do for everything else — nginx, Traefik, an AWS ALB, a Cloudflare
         Tunnel. Whatever fronts it just needs to forward to port <code>8787</code> and preserve the
@@ -360,8 +360,8 @@ SELFHOST_USE_INFISICAL=1 ./scripts/deploy-selfhost-prebuilt.sh`}
 TS_EXTRA_ARGS=          # optional, e.g. --advertise-tags=tag:self-host`}
       />
       <Callout variant="warn" title="Unlike Caddy, keep the app's port mapping">
-        Tailscale doesn't replace the <code>gittensory</code> service's listener the way Caddy does
-        — it adds a new network interface to the <em>host</em>. Docker's default{" "}
+        Tailscale doesn't replace the <code>loopover</code> service's listener the way Caddy does —
+        it adds a new network interface to the <em>host</em>. Docker's default{" "}
         <code>{`ports: ["\${PORT:-8787}:8787"]`}</code> mapping publishes to all of the host's
         interfaces, so once Tailscale is up, that same mapping is what makes port <code>8787</code>{" "}
         reachable at the host's tailnet IP too —{" "}

--- a/apps/loopover-ui/src/routes/docs.self-hosting-troubleshooting.tsx
+++ b/apps/loopover-ui/src/routes/docs.self-hosting-troubleshooting.tsx
@@ -206,21 +206,21 @@ sum by (class) (rate(loopover_github_graphql_cache_total[15m]))`}
           deployment&apos;s configuration.
         </li>
         <li>
-          A dimension-mismatch error means the existing <code>gittensory</code> collection (the
-          fixed collection name self-host always uses) was created with a different embedding model
-          than the one currently configured (<code>AI_EMBED_MODEL</code>). Recreating it — delete
-          the collection and let the next index run recreate it at the current width — is the fix,
-          but it temporarily removes ALL indexed RAG context for every repo until re-indexing
-          completes, so treat it as a deliberate, disruptive step, not a routine one.
+          A dimension-mismatch error means the existing <code>loopover</code> collection (the fixed
+          collection name self-host always uses) was created with a different embedding model than
+          the one currently configured (<code>AI_EMBED_MODEL</code>). Recreating it — delete the
+          collection and let the next index run recreate it at the current width — is the fix, but
+          it temporarily removes ALL indexed RAG context for every repo until re-indexing completes,
+          so treat it as a deliberate, disruptive step, not a routine one.
         </li>
       </ul>
       <CodeBlock
         lang="bash"
-        code={`curl "$QDRANT_URL/collections/gittensory"
+        code={`curl "$QDRANT_URL/collections/loopover"
 docker compose --profile qdrant ps qdrant
 
 # Only after confirming a dimension mismatch is the actual cause:
-curl -X DELETE "$QDRANT_URL/collections/gittensory"`}
+curl -X DELETE "$QDRANT_URL/collections/loopover"`}
       />
 
       <h2>Orb export or relay problems</h2>

--- a/apps/loopover-ui/src/routes/docs.troubleshooting.tsx
+++ b/apps/loopover-ui/src/routes/docs.troubleshooting.tsx
@@ -34,9 +34,9 @@ function Troubleshooting() {
     >
       <h2>Health checks</h2>
       <CodeBlock
-        code={`gittensory-mcp doctor
-gittensory-mcp status
-gittensory-mcp whoami`}
+        code={`loopover-mcp doctor
+loopover-mcp status
+loopover-mcp whoami`}
       />
       <p>Or hit the public API endpoint directly to confirm reachability:</p>
       <CodeBlock lang="http" code={`GET https://api.loopover.ai/health`} />
@@ -44,7 +44,7 @@ gittensory-mcp whoami`}
       <h2>Self-host Docker observability</h2>
       <p>
         The Docker stack exposes three different operator signals: structured logs from the{" "}
-        <code>gittensory</code> container, Prometheus metrics at <code>/metrics</code>, and optional
+        <code>loopover</code> container, Prometheus metrics at <code>/metrics</code>, and optional
         OpenTelemetry traces through the observability profile. Metrics answer <em>how much</em>{" "}
         work is happening; traces answer <em>where time went</em> inside a review job.
       </p>
@@ -75,7 +75,7 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318`}
       <h3>Login hangs on device flow</h3>
       <p>
         Confirm you can reach <code>github.com/login/device</code> in your browser. Re-run{" "}
-        <code>gittensory-mcp login</code> and paste the new code.
+        <code>loopover-mcp login</code> and paste the new code.
       </p>
 
       <h3>“Stale fidelity” warning</h3>
@@ -92,7 +92,7 @@ OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318`}
 
       <h3>401 Unauthorized from the API</h3>
       <p>
-        Your LoopOver session expired. Run <code>gittensory-mcp login</code> again. Static bearer
+        Your LoopOver session expired. Run <code>loopover-mcp login</code> again. Static bearer
         tokens are not user-facing.
       </p>
 

--- a/apps/loopover-ui/src/routes/docs.upstream-drift.tsx
+++ b/apps/loopover-ui/src/routes/docs.upstream-drift.tsx
@@ -45,8 +45,8 @@ function UpstreamDrift() {
       <Callout>
         <strong>Upstream relationship.</strong> <code>entrius/gittensor</code> is the upstream
         project LoopOver analyzes. LoopOver is{" "}
-        <a href="https://github.com/jsonbored/gittensory" target="_blank" rel="noreferrer">
-          jsonbored/gittensory
+        <a href="https://github.com/jsonbored/loopover" target="_blank" rel="noreferrer">
+          jsonbored/loopover
         </a>{" "}
         — an independent base-agent layer for the Gittensor ecosystem, not affiliated with the
         official subnet.

--- a/test/unit/docs-beta-onboarding.test.ts
+++ b/test/unit/docs-beta-onboarding.test.ts
@@ -12,8 +12,8 @@ describe("docs beta onboarding page", () => {
   const normalizedSource = source.replace(/\s+/g, " ");
 
   it("documents miner MCP flow through packet", () => {
-    expect(source).toMatch(/gittensory-mcp login/);
-    expect(source).toMatch(/gittensory-mcp doctor/);
+    expect(source).toMatch(/loopover-mcp login/);
+    expect(source).toMatch(/loopover-mcp doctor/);
     expect(source).toMatch(/agent plan/);
     expect(source).toMatch(/preflight/);
     expect(source).toMatch(/agent packet/);

--- a/test/unit/docs-miner-quickstart.test.ts
+++ b/test/unit/docs-miner-quickstart.test.ts
@@ -13,17 +13,17 @@ describe("docs miner quickstart page", () => {
 
   it("documents the full miner loop: install, auth, doctor, plan, preflight, packet", () => {
     expect(source).toMatch(/@loopover\/mcp/);
-    expect(source).toMatch(/gittensory-mcp login/);
-    expect(source).toMatch(/gittensory-mcp whoami/);
-    expect(source).toMatch(/gittensory-mcp status/);
-    expect(source).toMatch(/gittensory-mcp doctor/);
+    expect(source).toMatch(/loopover-mcp login/);
+    expect(source).toMatch(/loopover-mcp whoami/);
+    expect(source).toMatch(/loopover-mcp status/);
+    expect(source).toMatch(/loopover-mcp doctor/);
     expect(source).toMatch(/agent plan --login/);
-    expect(source).toMatch(/gittensory-mcp preflight --login/);
+    expect(source).toMatch(/loopover-mcp preflight --login/);
     expect(source).toMatch(/agent packet --login/);
   });
 
   it("uses CLI commands that match the current MCP package syntax", () => {
-    // Real flags from `gittensory-mcp --help` — guards against drift in documented syntax.
+    // Real flags from `loopover-mcp --help` — guards against drift in documented syntax.
     expect(source).toMatch(/--repo owner\/repo/);
     expect(source).toMatch(/--base origin\/main/);
     expect(source).toMatch(/--branch-eligibility eligible/);

--- a/test/unit/docs-selfhost-update-rollback.test.ts
+++ b/test/unit/docs-selfhost-update-rollback.test.ts
@@ -27,12 +27,12 @@ describe("self-host update + rollback docs (#1823)", () => {
     expect(operations).toContain("Migrations are forward-only");
   });
 
-  it("deploy scripts restart only gittensory with --no-deps", () => {
+  it("deploy scripts restart only loopover with --no-deps", () => {
     expect(imageScript).toContain('up -d --no-build --no-deps "$SERVICE"');
     expect(prebuiltScript).toContain('up -d --no-deps "$SERVICE"');
   });
 
-  it("prebuilt deploy builds the gittensory-engine workspace before bundling (#4530)", () => {
+  it("prebuilt deploy builds the loopover-engine workspace before bundling (#4530)", () => {
     // packages/loopover-engine/dist/ is gitignored and built via `tsc`; `npm ci --ignore-scripts`
     // never triggers that build on its own, so anything that imports the engine (e.g.
     // packages/loopover-miner) fails to resolve during the --all bundle unless this runs first.


### PR DESCRIPTION
## Summary

- Part of the gittensory→loopover rebrand (#5705), phase 8b: rename brand-name prose across 22 docs route `.tsx` files under `apps/loopover-ui` (self-hosting guides, MCP client docs, quickstart, troubleshooting, release checklist, etc.).
- Several examples had genuinely gone stale rather than being purely cosmetic — the docker-compose service is already named `loopover` (not `gittensory`) and the miner/mcp CLI binaries are already `loopover-miner`/`loopover-mcp`, so a handful of copy-pasteable command examples in the docs were telling self-hosters to run commands that no longer exist. Fixed those to match the real current names.
- Updated 3 doc-content assertion tests (`docs-beta-onboarding.test.ts`, `docs-miner-quickstart.test.ts`, `docs-selfhost-update-rollback.test.ts`) whose expected strings/titles still referenced the old command names — they were asserting against text this PR corrects.
- Left untouched (deliberate, permanent): the `gittensory-selfhost` container-image legacy tag examples, and the `gittensory.aethereal.dev` / `gittensory-api.aethereal.dev` domain aliases.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue this PR resolves — N/A, maintainer-authored rebrand-epic cleanup (#5705), no linked-issue gate applies to owner PRs.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint` (via `npm run test:ci`)
- [x] `npm run typecheck` (via `npm run test:ci`)
- [x] `npm run test:coverage` — full unsharded run, 100% green; docs/test-only diff, no `src/**` lines changed
- [x] `npm run test:workers` (via `npm run test:ci`)
- [x] `npm run build:mcp` (via `npm run test:ci`)
- [x] `npm run test:mcp-pack` (via `npm run test:ci`)
- [x] `npm run ui:openapi:check` (via `npm run test:ci`)
- [x] `npm run ui:lint` (via `npm run test:ci`)
- [x] `npm run ui:typecheck` (via `npm run test:ci`)
- [x] `npm run ui:build` (via `npm run test:ci`)
- [x] `npm audit --audit-level=moderate`
- [x] Full `npm run test:ci` gate run locally, exit 0

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no such changes.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no behavior change; `openapi.json` untouched.
- [ ] UI changes use live API data or real empty/error/loading states. — N/A, text-only doc content changes, no UI evidence needed (no visual/layout change).
- [ ] Visible UI changes include a `UI Evidence` section. — N/A, text-only prose changes, not a visual/layout change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs (none touched here).

## Notes

- One of several batched PRs covering the bulk-prose portion of rebrand epic #5705.