### PR TITLE
fix/issue 5847

### DIFF
--- a/test/unit/find-opportunities.test.ts
+++ b/test/unit/find-opportunities.test.ts
@@ -14,11 +14,17 @@ import {
   validateFindOpportunitiesInput,
 } from "../../src/mcp/find-opportunities";
 import { upsertRepositoryFromGitHub } from "../../src/db/repositories";
+import { createInstallationToken } from "../../src/github/app";
 import { createTestEnv } from "../helpers/d1";
 
 vi.mock("@loopover/engine", async () => {
   return import("../../packages/loopover-engine/src/index");
 });
+
+vi.mock("../../src/github/app", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../src/github/app")>()),
+  createInstallationToken: vi.fn(async () => "unused-token"),
+}));
 
 const fixtureDir = join(dirname(fileURLToPath(import.meta.url)), "../fixtures/ai-policy");
 
@@ -57,6 +63,8 @@ const issue = (number: number) => ({
 
 afterEach(() => {
   vi.unstubAllGlobals();
+  vi.mocked(createInstallationToken).mockReset();
+  vi.mocked(createInstallationToken).mockImplementation(async () => "unused-token");
 });
 
 describe("validateFindOpportunitiesInput", () => {
@@ -274,5 +282,221 @@ describe("runFindOpportunities", () => {
     const allowed = await runFindOpportunities(env, { targets: [{ owner: "acme", repo: "allowed" }] }, { canAccessRepo: async () => true });
     expect(allowed.status).toBe("ok");
     expect(allowed.ranked).toHaveLength(1);
+  });
+
+  it("returns invalid_request end-to-end when neither targets nor searchQuery are provided", async () => {
+    const env = createTestEnv();
+    const result = await runFindOpportunities(env, {});
+    expect(result).toEqual({
+      status: "invalid_request",
+      ranked: [],
+      totalCandidates: 0,
+      reason: "targets_or_search_query_required",
+    });
+  });
+
+  it("resolves issues via the searchQuery path instead of targets", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "test-token" });
+    const allowedPolicy = readFixture("allowed-silent.md");
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/search/issues?")) {
+        return jsonResponse({ items: [{ ...issue(21), repository: { full_name: "acme/searched" } }] });
+      }
+      if (url.includes("/repos/acme/searched/contents/AI-USAGE.md")) return jsonResponse({}, { status: 404 });
+      if (url.includes("/repos/acme/searched/contents/CONTRIBUTING.md")) return contentResponse(allowedPolicy);
+      return jsonResponse({}, { status: 404 });
+    });
+
+    const result = await runFindOpportunities(env, { searchQuery: "improve docs" });
+
+    expect(result.status).toBe("ok");
+    expect(result.ranked.map((entry) => `${entry.owner}/${entry.repo}#${entry.issueNumber}`)).toEqual(["acme/searched#21"]);
+  });
+
+  it("re-filters searchQuery results through canAccessRepo after retrieval", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "test-token" });
+    const allowedPolicy = readFixture("allowed-silent.md");
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/search/issues?")) {
+        return jsonResponse({
+          items: [
+            { ...issue(22), repository: { full_name: "acme/searched" } },
+            { ...issue(23), repository: { full_name: "acme/other" } },
+          ],
+        });
+      }
+      if (url.includes("/repos/acme/searched/contents/AI-USAGE.md")) return jsonResponse({}, { status: 404 });
+      if (url.includes("/repos/acme/searched/contents/CONTRIBUTING.md")) return contentResponse(allowedPolicy);
+      if (url.includes("/repos/acme/other/contents/AI-USAGE.md")) return jsonResponse({}, { status: 404 });
+      if (url.includes("/repos/acme/other/contents/CONTRIBUTING.md")) return contentResponse(allowedPolicy);
+      return jsonResponse({}, { status: 404 });
+    });
+
+    const result = await runFindOpportunities(
+      env,
+      { searchQuery: "improve docs" },
+      { canAccessRepo: async (repoFullName) => repoFullName === "acme/searched" },
+    );
+
+    expect(result.status).toBe("ok");
+    expect(result.ranked.map((entry) => `${entry.owner}/${entry.repo}`)).toEqual(["acme/searched"]);
+  });
+
+  it("narrows lane fit and reports appliedLane when goalSpec.lane is set", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "test-token" });
+    const allowedPolicy = readFixture("allowed-silent.md");
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/repos/acme/allowed/contents/AI-USAGE.md")) return jsonResponse({}, { status: 404 });
+      if (url.includes("/repos/acme/allowed/contents/CONTRIBUTING.md")) return contentResponse(allowedPolicy);
+      if (url.includes("/repos/acme/allowed/issues?")) return jsonResponse([issue(9)]);
+      return jsonResponse({}, { status: 404 });
+    });
+
+    const unscoped = await runFindOpportunities(env, { targets: [{ owner: "acme", repo: "allowed" }] });
+    const scoped = await runFindOpportunities(env, {
+      targets: [{ owner: "acme", repo: "allowed" }],
+      goalSpec: { lane: "documentation" },
+    });
+
+    expect(unscoped.appliedLane).toBeUndefined();
+    expect(scoped.appliedLane).toBe("documentation");
+    expect(scoped.ranked[0]?.rankScore).toBeLessThan(unscoped.ranked[0]?.rankScore ?? 0);
+  });
+
+  it("builds wantedPaths globs from goalSpec.languages when no lane is set", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "test-token" });
+    const allowedPolicy = readFixture("allowed-silent.md");
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/repos/acme/allowed/contents/AI-USAGE.md")) return jsonResponse({}, { status: 404 });
+      if (url.includes("/repos/acme/allowed/contents/CONTRIBUTING.md")) return contentResponse(allowedPolicy);
+      if (url.includes("/repos/acme/allowed/issues?")) return jsonResponse([issue(11)]);
+      return jsonResponse({}, { status: 404 });
+    });
+
+    const result = await runFindOpportunities(env, {
+      targets: [{ owner: "acme", repo: "allowed" }],
+      goalSpec: { languages: ["typescript"] },
+    });
+
+    expect(result.status).toBe("ok");
+    expect(result.appliedLane).toBeUndefined();
+    expect(result.ranked).toHaveLength(1);
+  });
+
+  it("reports appliedMinRankScore when set, and omits it (and appliedLane) when neither is set", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "test-token" });
+    const allowedPolicy = readFixture("allowed-silent.md");
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/repos/acme/allowed/contents/AI-USAGE.md")) return jsonResponse({}, { status: 404 });
+      if (url.includes("/repos/acme/allowed/contents/CONTRIBUTING.md")) return contentResponse(allowedPolicy);
+      if (url.includes("/repos/acme/allowed/issues?")) return jsonResponse([issue(13)]);
+      return jsonResponse({}, { status: 404 });
+    });
+
+    const withMinScore = await runFindOpportunities(env, {
+      targets: [{ owner: "acme", repo: "allowed" }],
+      goalSpec: { minRankScore: 10 },
+    });
+    expect(withMinScore.appliedMinRankScore).toBe(10);
+    expect(withMinScore.appliedLane).toBeUndefined();
+
+    const bare = await runFindOpportunities(env, { targets: [{ owner: "acme", repo: "allowed" }] });
+    expect(bare.appliedMinRankScore).toBeUndefined();
+    expect(bare.appliedLane).toBeUndefined();
+  });
+
+  it("skips repos without an installation, falls through a failing token mint, and uses the first token that resolves", async () => {
+    const env = createTestEnv();
+    await upsertRepositoryFromGitHub(env, { name: "broken-install", full_name: "acme/broken-install" }, 111);
+    await upsertRepositoryFromGitHub(env, { name: "good-install", full_name: "acme/good-install" }, 222);
+    const bannedPolicy = readFixture("banned-ai-usage.md");
+    const allowedPolicy = readFixture("allowed-silent.md");
+    vi.mocked(createInstallationToken).mockImplementation(async (_env, installationId) => {
+      if (installationId === 111) throw new Error("mint failed");
+      return "good-token";
+    });
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/repos/acme/no-install/contents/AI-USAGE.md")) return contentResponse(bannedPolicy);
+      if (url.includes("/repos/acme/broken-install/contents/AI-USAGE.md")) return contentResponse(bannedPolicy);
+      if (url.includes("/repos/acme/good-install/contents/AI-USAGE.md")) return jsonResponse({}, { status: 404 });
+      if (url.includes("/repos/acme/good-install/contents/CONTRIBUTING.md")) return contentResponse(allowedPolicy);
+      if (url.includes("/repos/acme/good-install/issues?")) return jsonResponse([issue(31)]);
+      return jsonResponse({}, { status: 404 });
+    });
+
+    const result = await runFindOpportunities(env, {
+      targets: [
+        { owner: "acme", repo: "no-install" },
+        { owner: "acme", repo: "broken-install" },
+        { owner: "acme", repo: "good-install" },
+      ],
+    });
+
+    expect(result.status).toBe("ok");
+    expect(result.ranked.map((entry) => `${entry.owner}/${entry.repo}#${entry.issueNumber}`)).toEqual(["acme/good-install#31"]);
+    expect(vi.mocked(createInstallationToken)).toHaveBeenCalledWith(env, 111);
+    expect(vi.mocked(createInstallationToken)).toHaveBeenCalledWith(env, 222);
+  });
+
+  it("continues with a null token when a target has a repo record but no installation to mint against", async () => {
+    const env = createTestEnv();
+    await upsertRepositoryFromGitHub(env, { name: "no-token-install", full_name: "acme/no-token-install" });
+    const allowedPolicy = readFixture("allowed-silent.md");
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/repos/acme/no-token-install/contents/AI-USAGE.md")) return jsonResponse({}, { status: 404 });
+      if (url.includes("/repos/acme/no-token-install/contents/CONTRIBUTING.md")) return contentResponse(allowedPolicy);
+      if (url.includes("/repos/acme/no-token-install/issues?")) return jsonResponse([issue(41)]);
+      return jsonResponse({}, { status: 404 });
+    });
+
+    const result = await runFindOpportunities(env, { targets: [{ owner: "acme", repo: "no-token-install" }] });
+
+    expect(result.status).toBe("ok");
+    expect(result.ranked.map((entry) => `${entry.owner}/${entry.repo}#${entry.issueNumber}`)).toEqual(["acme/no-token-install#41"]);
+    expect(vi.mocked(createInstallationToken)).not.toHaveBeenCalled();
+  });
+
+  it("continues with a null token on the searchQuery path when no public token or targets are configured", async () => {
+    const env = createTestEnv();
+    const allowedPolicy = readFixture("allowed-silent.md");
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/search/issues?")) {
+        return jsonResponse({ items: [{ ...issue(42), repository: { full_name: "acme/searched" } }] });
+      }
+      if (url.includes("/repos/acme/searched/contents/AI-USAGE.md")) return jsonResponse({}, { status: 404 });
+      if (url.includes("/repos/acme/searched/contents/CONTRIBUTING.md")) return contentResponse(allowedPolicy);
+      return jsonResponse({}, { status: 404 });
+    });
+
+    const result = await runFindOpportunities(env, { searchQuery: "improve docs" });
+
+    expect(result.status).toBe("ok");
+    expect(result.ranked.map((entry) => `${entry.owner}/${entry.repo}#${entry.issueNumber}`)).toEqual(["acme/searched#42"]);
+  });
+
+  it("surfaces fetch warnings in the result when GitHub errors on an allowed repo's issues", async () => {
+    const env = createTestEnv({ GITHUB_PUBLIC_TOKEN: "test-token" });
+    const allowedPolicy = readFixture("allowed-silent.md");
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.includes("/repos/acme/allowed/contents/AI-USAGE.md")) return jsonResponse({}, { status: 404 });
+      if (url.includes("/repos/acme/allowed/contents/CONTRIBUTING.md")) return contentResponse(allowedPolicy);
+      if (url.includes("/repos/acme/allowed/issues?")) return jsonResponse({}, { status: 500 });
+      return jsonResponse({}, { status: 404 });
+    });
+
+    const result = await runFindOpportunities(env, { targets: [{ owner: "acme", repo: "allowed" }] });
+
+    expect(result.status).toBe("ok");
+    expect(result.ranked).toEqual([]);
+    expect(result.warnings).toEqual([{ repoFullName: "acme/allowed", stage: "issues", message: "GitHub returned 500" }]);
   });
 });


### PR DESCRIPTION
- **docs(miner): AMS storage-abstraction research — datastore backend comparison (#5760)**
- **fix(rebrand): full-cutover rename remaining internal gittensory runtime identifiers (#5761)**
- **refactor(engine): extract the pull-request-target-key parser into loopover-engine (#5762)**
- **docs(miner): AMS auth/identity research — hosted login-layer options (#5764)**
- **fix(rebrand): full-cutover rename miner/AMS per-repo and operator config filenames (#5765)**
- **feat(api): add post-merge incident reporting for already-merged PRs (#5766)**
- **fix(review): trim the Improvement signal row to a concise value rating (#5767)**
- **fix(rebrand): full-cutover rename Prometheus/Alertmanager/Grafana observability identifiers (#5768)**
- **feat(review): add a shared beta-collapsible convention for the PR comment (#5769)**
- **docs(engine): verify git mv rename recognition in coverage tooling (#5770)**
- **fix(review): never render a ❌ for a non-Gittensor contributor (#5100) (#5774)**
- **feat(engine): extract content-lane's pure leaf modules to loopover-engine (#5775)**
- **fix(api): audit registered-vs-installed dashboard/digest copy (#5026) (#5776)**
- **feat(engine): extract settings leaf modules to loopover-engine (#5779)**
- **refactor(engine): move the unlinked-issue candidate pre-filter into the shared engine (#5778)**
- **feat(engine): add a load-testing harness for iterate-loop under concurrent load (#5781)**
- **docs(spec): idea-intake bridge schema (#5783)**
- **docs(engine): document the deliberate gate-advisory twin divergence (#5784)**
- **feat(selfhost): optional Infisical secrets management for self-host deploys (#5785)**
- **refactor(queue): extract the public-comment merge-facts derivation from maybePublishPrPublicSurface (#4607) (#5787)**
- **feat(review): add aggregate fix-handoff block renderer (#5788)**
- **feat(miner): pre-execution feasibility check for freeform ideas (#5789)**
- **feat(review): synthesize the 'Contributor next steps' collapsible into a prioritized step (#5791)**
- **feat(mcp): add the idea-intake bridge and loopover_intake_idea tool (#5792)**
- **feat(miner): add cross-repo evaluation harness (#4788) (#5790)**
- **docs(selfhost): design doc for the scheduled docs-drift audit sweep (#3048) (#5794)**
- **feat(mcp): route ideas through intake into a loop claim plan (#5795)**
- **feat(mcp): deliver a completed loop iteration as a customer results payload (#5797)**
- **feat(mcp): stream loop progress to the customer via a progress snapshot (#5798)**
- **refactor(engine): extract signals engine with re-export shim (#4884) (#5800)**
- **feat(engine): per-tenant resource quota evaluation (#5801)**
- **feat(mcp): evaluate when a rented loop should escalate to a human (#5806)**
- **docs(engine): document the nine governor primitives in the package README (#5851)**
- **docs(gardening): correct contributor-available target to per-repo, not combined (#5808)**
- **fix(signals): require a code file before manifest_missing_tests fires (#5852)**
- **fix(miner): list queue dashboard in cli.js help text (#5853)**
- **docs: privacy audit of AMS telemetry/export surfaces for cross-tenant leakage (#5759)**
- **feat(selfhost): add n8n workflows and MinIO object storage compose profiles (#1219) (#5777)**
- **feat(miner): honor kill-switch mid-attempt during iterate-loop (#5799)**
- **feat(engine): per-tenant configuration layer (#5804)**
- **feat(selfhost): bridge fleet-mode miner state to the ams-observability exporter (#5844)**
- **docs(engine): add a Tenant quota README section (#5860)**
- **fix(engine): clamp rate-limit retryAfterMs to at most one window on a backward clock (#5855)**
- **fix(review): recognize export const enum and abstract class in impact-symbols (#5858)**
- **test(review): cover review-diff.ts non-positive-budget guard and header count defaults (#5857)**
- **fix(ci): sync miner engine-version pin on the engine release branch (#5856)**
- **test(selfhost): cover jobCoalesceKey missing-field fallbacks for 6 job types (#5862)**
- **fix(queue): cap backlog-convergence re-review attempts per head SHA (#5859)**
- **docs(engine): document the Rent-a-Loop pipeline modules (#5868)**
- **fix(review): exclude maintainer PRs from the slop-discrimination alert (#5863)**
- **test(miner): rename gittensory-miner/ams prose to loopover-miner/ams (#5874)**
- **chore(release): cut engine v3.1.0 (#5807)**
- **test(miner): rename gittensory-miner/ams prose to loopover-miner/ams (batch 2) (#5878)**
- **test(mcp): cover find-opportunities searchQuery, goal-spec, and token-fallback paths (#5847)**
