### PR TITLE
docs(review): rename gittensory prose to loopover in src/review (batch A)

### DIFF
--- a/src/review/adapters.ts
+++ b/src/review/adapters.ts
@@ -1,6 +1,6 @@
-// Review-adapter factory (reviewbot→gittensory convergence — ADDITIVE infra). Builds the injected adapter
+// Review-adapter factory (reviewbot→loopover convergence — ADDITIVE infra). Builds the injected adapter
 // interfaces the ported review modules expect (src/review/rag.ts `RagInfra` = VectorAdapter / InferenceAdapter /
-// StorageAdapter) from gittensory's ambient `Env` bindings, so the host can wire the ported RAG path without
+// StorageAdapter) from loopover's ambient `Env` bindings, so the host can wire the ported RAG path without
 // the modules depending on Cloudflare bindings directly. This mirrors reviewbot's platform layer — the `cf*`
 // pass-through wrappers + `createCloudflareAdapters` (src/platform/cloudflare/index.ts) and the fail-safe gates
 // in src/platform/access.ts (no Vectorize → no RAG, no AI → no context).
@@ -37,7 +37,7 @@ export function reviewVectorAdapter(vectorize: Vectorize): VectorAdapter {
     },
     query: async (vector, opts) => {
       const res = await vectorize.query(vector, opts as unknown as Parameters<Vectorize["query"]>[1]);
-      // Under `exactOptionalPropertyTypes` (gittensory's stricter tsconfig) the optional `metadata?` cannot be
+      // Under `exactOptionalPropertyTypes` (loopover's stricter tsconfig) the optional `metadata?` cannot be
       // assigned `undefined`, so only attach it when Vectorize returned metadata. Behavior is identical to
       // reviewbot's cfVector — a match with no metadata simply has no `metadata` key.
       return {

--- a/src/review/alerts.ts
+++ b/src/review/alerts.ts
@@ -1,13 +1,13 @@
-// Anomaly alerting (reviewbot→gittensory convergence — ADDITIVE, NATIVE port of reviewbot
+// Anomaly alerting (reviewbot→loopover convergence — ADDITIVE, NATIVE port of reviewbot
 // src/core/alerts.ts). On each cron tick, snapshot agent health and push a THROTTLED Discord alert when
 // something drifts — a manual-rate spike, stuck/failed targets, a DLQ spike, calibration drift, disputed
 // closes, or a config invariant violation — so drift is HEARD ABOUT instead of polled for.
 //
 // SELF-CONTAINED: every type + helper this module needs is defined HERE. No imports from reviewbot. The
-// logic is byte-faithful to the reviewbot source; the only deltas are mechanical guards for gittensory's
+// logic is byte-faithful to the reviewbot source; the only deltas are mechanical guards for loopover's
 // stricter tsconfig (noUncheckedIndexedAccess / exactOptionalPropertyTypes), which do not change behavior.
 //
-// STORAGE: gittensory has no platform/access adapter — `Env` is a global ambient interface with `DB`. The
+// STORAGE: loopover has no platform/access adapter — `Env` is a global ambient interface with `DB`. The
 // `storage(env) => env.DB` helper below mirrors the other native ports (unified-comment-bridge etc.).
 //
 // HEALTH/CALIBRATION INPUTS: computing the D1 health/calibration snapshots is the runtime gate's job
@@ -93,7 +93,7 @@ export interface AlertAgentConfig {
 
 // ── Inlined helpers (byte-faithful from reviewbot src/core/{crypto,util,notify,db}.ts) ───────────
 
-/** Storage seam: gittensory's `Env` is a global ambient interface with `DB`. */
+/** Storage seam: loopover's `Env` is a global ambient interface with `DB`. */
 function storage(env: Env): D1Database {
   return env.DB;
 }

--- a/src/review/auto-apply.ts
+++ b/src/review/auto-apply.ts
@@ -1,4 +1,4 @@
-// Self-improvement "apply" surface (#273–#279, reviewbot→gittensory convergence). The autonomous loop's
+// Self-improvement "apply" surface (#273–#279, reviewbot→loopover convergence). The autonomous loop's
 // (eval → advisor → apply) write side: a per-project store of runtime tunable overrides the loop raises
 // (confidenceFloor / scopeCap) WITHOUT a human editing config + redeploying, plus the soak-gated promotion
 // that flips a SHADOW-queued tightening to LIVE once it passes the gate. Everything here FAILS SAFE: a query
@@ -8,7 +8,7 @@
 // reviewbot. Storage is reached through an inline `storage(env) => env.DB` helper + a minimal D1-shaped
 // interface (no Cloudflare-binding type dependency), matching the runtime's D1 calls byte-for-byte. The pure
 // helpers (sanitize / merge / tightening / promotion gate) are ports of the reviewbot source
-// (src/core/tunables.ts + src/core/auto-apply.ts); the only deltas are mechanical guards for gittensory's
+// (src/core/tunables.ts + src/core/auto-apply.ts); the only deltas are mechanical guards for loopover's
 // stricter tsconfig (noUncheckedIndexedAccess, exactOptionalPropertyTypes), which do not change behavior.
 //
 // DEFERRED INFRA (out of scope here — this ports the pure logic + the D1-shaped store + tests):

--- a/src/review/auto-tune.ts
+++ b/src/review/auto-tune.ts
@@ -1,4 +1,4 @@
-// Autonomous self-improvement — accuracy circuit-breaker (#self-improve, reviewbot→gittensory convergence).
+// Autonomous self-improvement — accuracy circuit-breaker (#self-improve, reviewbot→loopover convergence).
 // The ONE tuning action safe to take unattended: when the gate eval shows merge precision dropping below a
 // floor over a real sample, the system DISABLES its own auto-merge for that project (sets the holdonly flag)
 // so it stops repeating a bad call, and alerts a human. It only ever makes itself MORE cautious — loosening /
@@ -9,7 +9,7 @@
 // reviewbot. The eval-report SHAPE (GateEvalReport/GateEvalRow) and the system-flags accessors
 // (isHoldOnly/setFlag/flagSetAt) are inlined as INJECTED interfaces so this ports the PURE calibration logic
 // without dragging in the engine. The logic is byte-faithful to the reviewbot source (src/core/auto-tune.ts);
-// the only deltas are mechanical guards for gittensory's stricter tsconfig (noUncheckedIndexedAccess,
+// the only deltas are mechanical guards for loopover's stricter tsconfig (noUncheckedIndexedAccess,
 // exactOptionalPropertyTypes), which do not change behavior.
 //
 // DEFERRED INFRA (out of scope here — this ports the pure logic + tests):

--- a/src/review/content-lane/duplicates.ts
+++ b/src/review/content-lane/duplicates.ts
@@ -1,6 +1,6 @@
 // Deterministic duplicate-detection + protected-edit content gate (content-lane primitive).
 //
-// SELF-CONTAINED NATIVE PORT (reviewbot→gittensory convergence). Byte-faithful to reviewbot's
+// SELF-CONTAINED NATIVE PORT (reviewbot→loopover convergence). Byte-faithful to reviewbot's
 // src/agents/awesome-claude/duplicates.ts (itself a faithful port of the live submission-gate
 // duplicates.ts). This module is I/O-free: the caller fetches the accepted corpus
 // (`${PUBLIC_SITE_URL}/data/directory-index.json`) and any earlier-open-PR content, then passes
@@ -9,7 +9,7 @@
 // Normalization, the STRICT-match rule (the only result the gate closes on), the related/legacy
 // classifiers, and the protected-field set are preserved exactly. Over-closing (a false strict
 // duplicate) permanently rejects a legitimate submission, so the strict boundary is unchanged.
-// The only deltas vs the reviewbot source are mechanical guards for gittensory's stricter tsconfig
+// The only deltas vs the reviewbot source are mechanical guards for loopover's stricter tsconfig
 // (noUncheckedIndexedAccess + exactOptionalPropertyTypes) — they do not change behavior.
 //
 // Dedup config (protected fields, URL fields, domain exclusions, multi-entry catalog roots) is sourced from the

--- a/src/review/content-lane/index.ts
+++ b/src/review/content-lane/index.ts
@@ -1,7 +1,7 @@
-// Content-lane public surface (reviewbot→gittensory convergence).
+// Content-lane public surface (reviewbot→loopover convergence).
 //
 // The native, flag-gated content-review primitives for the two CONTENT repos — awesome-claude (a
-// curated list) and metagraphed (a registry) — a different domain from gittensory's code-gate. The
+// curated list) and metagraphed (a registry) — a different domain from loopover's code-gate. The
 // lane only runs when LOOPOVER_REVIEW_CONTENT_LANE is truthy (see ./flag); flag-off the host never reaches
 // these modules.
 //

--- a/src/review/content-lane/netuid-verification.ts
+++ b/src/review/content-lane/netuid-verification.ts
@@ -1,6 +1,6 @@
 // Metagraphed netuid verification (content-lane primitive).
 //
-// SELF-CONTAINED NATIVE PORT (reviewbot→gittensory convergence). Byte-faithful to the taostats /
+// SELF-CONTAINED NATIVE PORT (reviewbot→loopover convergence). Byte-faithful to the taostats /
 // public-registry netuid-identity verification in reviewbot's src/agents/metagraphed/capabilities.ts
 // (fetchSubnetRecord / checkNetuidExists / fetchTaostatsSubnetIdentity).
 //
@@ -13,7 +13,7 @@
 //  2. TAOSTATS on-chain identity (api.taostats.io) — REQUIRES the env secret TAOSTATS_API_KEY (sent
 //     as a raw `Authorization` header, NOT `Bearer`). STRICTLY OPTIONAL + fail-open: returns null
 //     when the key is unset or on any error, so the merge gate falls back to the page-mention +
-//     registry-identity grounding signals. The key is NOT yet declared in gittensory's Env — see the
+//     registry-identity grounding signals. The key is NOT yet declared in loopover's Env — see the
 //     port report; wire it (a Worker secret) to enable signal #2, or leave it unset to disable it.
 //
 // I/O is the injected fetch (`fetchImpl`, default global fetch) + a `readSecret` over a plain env

--- a/src/review/content-lane/orchestrator.ts
+++ b/src/review/content-lane/orchestrator.ts
@@ -1,4 +1,4 @@
-// Deterministic surface-model review orchestrator (no AI — surfaces are structured data; gittensory is the
+// Deterministic surface-model review orchestrator (no AI — surfaces are structured data; loopover is the
 // sole adjudicator). Given a lane spec, the PR's changed files, and an injected file-content loader, it:
 //   1. classifies the PR via classifyRegistryPrScope (entry / provider / not-a-direct-submission),
 //   2. loads the head (+ base, for entries) document content,

--- a/src/review/content-lane/registry-logic.ts
+++ b/src/review/content-lane/registry-logic.ts
@@ -1,6 +1,6 @@
 // Metagraphed registry decision logic (content-lane primitive).
 //
-// SELF-CONTAINED NATIVE PORT (reviewbot→gittensory convergence). Byte-faithful to reviewbot's
+// SELF-CONTAINED NATIVE PORT (reviewbot→loopover convergence). Byte-faithful to reviewbot's
 // src/agents/metagraphed/review-logic.ts (itself a faithful port of the live metagraphed
 // submission-gate). PURE + testable; all I/O (GitHub, registry/taostats API, AI) lives in the
 // caller. The SSRF guard is the shared content-lane safe-url; `Verdict` + `isInternalAutomation
@@ -458,7 +458,7 @@ function fail(reason: string, summary: string, candidate: CandidateLike | null =
 /**
  * Surface validators: a contribution appends ONE entry to `surfaces[]` of a `registry/subnets/<slug>.json`, whose
  * `netuid` lives at the file ROOT (not on each entry). These two deterministic validators (per-entry +
- * whole-document) make gittensory the sole adjudicator; no AI (surfaces are structured data). They take the
+ * whole-document) make loopover the sole adjudicator; no AI (surfaces are structured data). They take the
  * appended entry / parsed document as arguments; the orchestrator resolves "exactly one appended entry" from a
  * head-vs-base diff.
  */
@@ -651,7 +651,7 @@ export function probeFunctionalSurface(
 //
 // A community contribution appends entries to an array field of ONE registry "entry file" (e.g.
 // registry/subnets/<slug>.json::surfaces[]), optionally with one flat companion provider file. To stay MODULAR —
-// many maintainers will install gittensory over wildly different registries — the engine is parameterized by a
+// many maintainers will install loopover over wildly different registries — the engine is parameterized by a
 // RegistryLaneSpec rather than hard-coding metagraphed's paths; metagraphed is just the FIRST spec, and a spec can
 // later be loaded from per-repo .loopover.yml config so a new registry needs config, not a code change.
 

--- a/src/review/content-lane/safe-url.ts
+++ b/src/review/content-lane/safe-url.ts
@@ -1,6 +1,6 @@
 // SSRF-safe URL guard (content-lane primitive).
 //
-// SELF-CONTAINED NATIVE PORT (reviewbot→gittensory convergence). Ported from reviewbot's
+// SELF-CONTAINED NATIVE PORT (reviewbot→loopover convergence). Ported from reviewbot's
 // core/source-url.ts isSafeHttpUrl + isSafeEndpointUrl (the host/IP guard, including the encoded-IP
 // decoding that a dotted-quad regex misses), hardened so a trailing-dot or `*.localhost` host can't
 // dodge the loopback check. PURE — no imports, no I/O.

--- a/src/review/content-lane/scope.ts
+++ b/src/review/content-lane/scope.ts
@@ -1,6 +1,6 @@
 // Content scope classification (content-lane primitive).
 //
-// SELF-CONTAINED NATIVE PORT (reviewbot→gittensory convergence). Byte-faithful to reviewbot's
+// SELF-CONTAINED NATIVE PORT (reviewbot→loopover convergence). Byte-faithful to reviewbot's
 // src/agents/awesome-claude/review-logic.ts (itself a faithful port of the live submission-gate
 // classifyPullRequestFilesForContentReview). PURE — distinguishes ignore (no content entry) vs
 // scope_failure (CLOSE) vs deletion vs review. `slugify` is inlined (a one-liner). The accepted

--- a/src/review/content-lane/security-scan.ts
+++ b/src/review/content-lane/security-scan.ts
@@ -1,6 +1,6 @@
 // Deterministic security/abuse scan for content submissions (content-lane primitive).
 //
-// SELF-CONTAINED NATIVE PORT (reviewbot→gittensory convergence). Byte-faithful to reviewbot's
+// SELF-CONTAINED NATIVE PORT (reviewbot→loopover convergence). Byte-faithful to reviewbot's
 // src/agents/awesome-claude/security-scan.ts + the shared core/secrets-scan.ts. PURE — data in, data out,
 // no I/O.
 //
@@ -83,7 +83,7 @@ function firstSecretLine(text: string): { n: number; kinds: string[] } | null {
 
 /**
  * generic_secret_assignment is a keyword-plus-quoted-value SHAPE heuristic, not a concrete credential format
- * (see ../secret-patterns.ts's HARD_SECRET_KINDS doc comment — split out post-gittensory-PR-#5346, which
+ * (see ../secret-patterns.ts's HARD_SECRET_KINDS doc comment — split out post-loopover-PR-#5346, which
  * auto-closed a legitimate contributor PR over two inert test-fixture strings). Per this file's own header
  * ("only ONE signal is unambiguous enough to hard-close... every other heuristic routes to MANUAL"), a hit
  * here routes to MANUAL, never scanSubmissionContent's auto-close. Its keyword-to-value span can wrap across

--- a/src/review/content-lane/source-evidence.ts
+++ b/src/review/content-lane/source-evidence.ts
@@ -1,6 +1,6 @@
 // Deterministic source-evidence content gate (content-lane primitive).
 //
-// SELF-CONTAINED NATIVE PORT (reviewbot→gittensory convergence). Byte-faithful to reviewbot's
+// SELF-CONTAINED NATIVE PORT (reviewbot→loopover convergence). Byte-faithful to reviewbot's
 // src/agents/awesome-claude/source-evidence.ts. The SSRF guard is the shared content-lane
 // `isSafeHttpUrl` (safe-url.ts); the browser fetch headers and the SHA-256 hash are inlined here.
 //

--- a/src/review/content-lane/spec-resolver.ts
+++ b/src/review/content-lane/spec-resolver.ts
@@ -1,6 +1,6 @@
 // Per-repo RegistryLaneSpec resolution (#2435 — closes the "only metagraphed can use this" gap). Before this,
 // content-lane-wire.ts hard-selected METAGRAPHED_LANE_SPEC for every repo in the LOOPOVER_REVIEW_REPOS
-// allowlist; a different self-hosted maintainer's registry could only be onboarded by editing gittensory's own
+// allowlist; a different self-hosted maintainer's registry could only be onboarded by editing loopover's own
 // TypeScript source. This mirrors resolveConvergedFeature's precedence (review/feature-activation.ts): env
 // kill-switch → per-repo `.loopover.yml` config → allowlist default — but resolves to a whole spec OBJECT (or
 // null/inactive) instead of a boolean, so it lives alongside the content-lane engine rather than in

--- a/src/review/cutover-gate.ts
+++ b/src/review/cutover-gate.ts
@@ -5,7 +5,7 @@
 // ALSO pass for the feature to run on a given PR's repo.
 //
 // Single env var: LOOPOVER_REVIEW_REPOS — a comma-separated allowlist of repo full-names
-// ("owner/repo", e.g. "JSONbored/gittensory,JSONbored/awesome-claude"). A repo activates the converged
+// ("owner/repo", e.g. "JSONbored/loopover,JSONbored/awesome-claude"). A repo activates the converged
 // features ONLY IF (the feature's global flag is ON) AND (the repo is in this allowlist).
 //
 // DEFAULT IS NO REPOS: empty / unset / whitespace-only → false for EVERY repo. So even with every global flag

--- a/src/review/feature-activation.ts
+++ b/src/review/feature-activation.ts
@@ -41,7 +41,7 @@ import type { ConvergedFeatureKey, FocusManifest } from "../signals/focus-manife
 import { loadRepoFocusManifest } from "../signals/focus-manifest-loader";
 
 /**
- * The four per-feature activation precedence shapes actually in use across gittensory's advisory review
+ * The four per-feature activation precedence shapes actually in use across loopover's advisory review
  * capabilities (#4616):
  *  - `"standard"`: `override` fully controls (`true` forces on, `false` forces off); `null` (unset) falls back
  *    to `allowlisted`. rag / reputation / unifiedComment / e2eTests / improvementSignal.

--- a/src/review/finding-taxonomy.ts
+++ b/src/review/finding-taxonomy.ts
@@ -2,7 +2,7 @@ import { FINDING_CATEGORIES } from "./finding-category-classify";
 import { REVIEW_FINDING_SEVERITY_LADDER } from "../signals/focus-manifest";
 
 /** MCP resource URI for the canonical review finding taxonomy (#2225). */
-export const FINDING_TAXONOMY_URI = "gittensory://finding-taxonomy" as const;
+export const FINDING_TAXONOMY_URI = "loopover://finding-taxonomy" as const;
 
 export interface FindingTaxonomyDocument {
   categories: readonly (typeof FINDING_CATEGORIES)[number][];

--- a/src/review/fix-handoff-render.ts
+++ b/src/review/fix-handoff-render.ts
@@ -4,7 +4,7 @@
 // content only, no server-side write, no execution. Mirrors formatInlineBody's severity-label composition
 // (inline-comments.ts) and reuses the exact no-cloud-write boundary text every other local-execution artifact
 // carries (local-write-tools.ts's LOCAL_WRITE_BOUNDARY), so the guarantee reads identically everywhere
-// gittensory hands a contributor something to run themselves.
+// loopover hands a contributor something to run themselves.
 //
 // The caller is responsible for gating emission via shouldEmitFixHandoff (fix-handoff.ts) BEFORE calling into
 // this module — this file is pure rendering, public-safe by construction: it only renders fields the caller

--- a/src/review/gittensor-wire.ts
+++ b/src/review/gittensor-wire.ts
@@ -1,5 +1,5 @@
 // Gittensor experimental-plugin activation wiring. `gittensor` is the first key under the `experimental:`
-// manifest block (EXPERIMENTAL_PLUGIN_KEYS) -- gittensory's original subnet mining-registry/scoring
+// manifest block (EXPERIMENTAL_PLUGIN_KEYS) -- loopover's original subnet mining-registry/scoring
 // integration, now an OPT-IN plugin rather than a core dependency, so a self-host instance with no gittensor
 // affiliation has zero footprint from it (see registry/sync.ts's self-host scoping, which this feeds, and
 // index.ts's cron gate, which skips the registry fetch entirely when nothing is opted in).

--- a/src/review/grounding-wire.ts
+++ b/src/review/grounding-wire.ts
@@ -7,7 +7,7 @@
 // codebase convention (`/^(1|true|yes|on)$/i`, same as isSafetyEnabled / isEnabled).
 //
 // The ported, self-contained grounding engine lives in `./review-grounding`; this file is the thin HOST
-// adapter that supplies its two inputs from data gittensory already has — the cached CI check summaries
+// adapter that supplies its two inputs from data loopover already has — the cached CI check summaries
 // (listCheckSummaries) and a GitHub Contents-API-backed FileFetcher — and renders the prompt text. Fully
 // fail-safe: any missing CI data / fetch error degrades to "no grounding" and the review proceeds on the diff.
 
@@ -76,7 +76,7 @@ export function checkSummaryText(check: CheckSummaryRecord): string {
 type CheckAggregate = { state: "passed" | "failed" | "pending"; passing: string[]; failingDetails: Array<{ name: string; summary?: string }> };
 
 /**
- * Fold gittensory's cached CI check summaries into the compact aggregate the grounding engine renders.
+ * Fold loopover's cached CI check summaries into the compact aggregate the grounding engine renders.
  * `state` is failed if ANY check failed, else pending if ANY check is still running, else passed. A check
  * with no rows at all (`undefined`) means we have no CI signal → the caller passes `undefined` so CI grounding
  * is simply omitted (never asserts a green/red state we can't verify).
@@ -105,7 +105,7 @@ export function buildCheckAggregate(checks: CheckSummaryRecord[]): CheckAggregat
   return { state, passing, failingDetails };
 }
 
-/** Map gittensory's PR file records to the subset the grounding engine reads (filename + status, plus the
+/** Map loopover's PR file records to the subset the grounding engine reads (filename + status, plus the
  *  patch/additions/deletions a MODIFIED file's diffFullyCoversFile check needs to skip a redundant fetch
  *  when the diff already carries the whole file — see review-grounding.ts). */
 function toGroundingFiles(files: PullRequestFileRecord[]): PullRequestFile[] {

--- a/src/review/guardrail-config.ts
+++ b/src/review/guardrail-config.ts
@@ -32,7 +32,7 @@ export const ENGINE_DECISION_GUARDRAIL_GLOBS = [
   "src/github/pr-actions.ts",
   "src/github/app.ts",
   "src/github/backfill.ts",
-  // #4197: writes a real commit onto a CONTRIBUTOR's own PR branch (not a branch gittensory owns) — the same
+  // #4197: writes a real commit onto a CONTRIBUTOR's own PR branch (not a branch loopover owns) — the same
   // guardrail tier as pr-actions.ts/app.ts for the same reason, a new GitHub-write surface.
   "src/github/e2e-test-commit.ts",
   "src/scoring/**",

--- a/src/review/linked-issue-label-propagation-fetch.ts
+++ b/src/review/linked-issue-label-propagation-fetch.ts
@@ -13,7 +13,7 @@ import type { LinkedIssueLabelPropagationMapping } from "../types";
 
 // The GitHub-fetch orchestrator for linked-issue label propagation (#priority-linked-issue-gate), kept
 // deliberately OUT of `linked-issue-label-propagation.ts` (the pure config types + normalizer, imported by
-// `focus-manifest.ts`'s YAML parser and transitively by the gittensory-ui workspace's isolated typecheck via
+// `focus-manifest.ts`'s YAML parser and transitively by the loopover-ui workspace's isolated typecheck via
 // `apps/loopover-ui/src/lib/registration-workspace.ts`). This file's GitHub/fetch imports resolve the
 // Worker's ambient `Env` type, which the UI workspace's tsconfig has no visibility into -- importing them
 // from the pure config file broke `ui:typecheck` by pulling the whole github/app.ts + github/backfill.ts

--- a/src/review/linked-issue-label-propagation.ts
+++ b/src/review/linked-issue-label-propagation.ts
@@ -10,7 +10,7 @@ export type { LinkedIssueLabelPropagationConfig, LinkedIssueLabelPropagationMapp
 // (replaces the normal bug/feature type label, like priority does) or additive (applied alongside it).
 //
 // PURE config types + normalizer only — no GitHub/fetch/Env-dependent imports. `focus-manifest.ts`'s YAML
-// parser imports this module directly, and `focus-manifest.ts` is itself pulled into the gittensory-ui
+// parser imports this module directly, and `focus-manifest.ts` is itself pulled into the loopover-ui
 // workspace's isolated typecheck (via `apps/loopover-ui/src/lib/registration-workspace.ts`), which has no
 // visibility into the Worker's ambient `Env` type. The actual GitHub fetch orchestrator
 // (`fetchLinkedIssueLabelsForPropagation`) lives in `linked-issue-label-propagation-fetch.ts` instead, kept

--- a/src/review/maintainer-recap-wire.ts
+++ b/src/review/maintainer-recap-wire.ts
@@ -13,14 +13,14 @@ import { loadRepoFocusManifest } from "../signals/focus-manifest-loader";
 import { resolveLoopOverSelfRepoFullName } from "../config/gittensory-repo-focus-manifest";
 import { errorMessage } from "../utils/json";
 
-/** A manifest-sourced enable/cadence override (#2250) -- the `maintainerRecap` block of the gittensory
+/** A manifest-sourced enable/cadence override (#2250) -- the `maintainerRecap` block of the loopover
  *  self-repo's `.loopover.yml` (see FocusManifestMaintainerRecapConfig). `present: false` (no block, or the
  *  repo has no manifest at all) means "no override configured", not "disabled" -- the caller falls through to
  *  the env vars in that case, exactly as if this parameter were omitted. */
 export type MaintainerRecapManifestOverride = { present: boolean; enabled: boolean; cadence: RecapCadence };
 
 /** True when the cross-repo maintainer recap digest is enabled. Config-as-code (#2250): a present
- *  `maintainerRecap` manifest block on the gittensory self-repo wins outright; otherwise falls back to the
+ *  `maintainerRecap` manifest block on the loopover self-repo wins outright; otherwise falls back to the
  *  LOOPOVER_MAINTAINER_RECAP env flag (default OFF -- the cron enqueues no job and runMaintainerRecapJob is
  *  never invoked). Truthy env convention matches isOpsEnabled. */
 export function isRecapEnabled(
@@ -119,7 +119,7 @@ async function recapScanRepos(env: Env): Promise<string[]> {
 }
 
 /**
- * Config-as-code override lookup (#2250): read the `maintainerRecap` block off the gittensory self-repo's
+ * Config-as-code override lookup (#2250): read the `maintainerRecap` block off the loopover self-repo's
  * `.loopover.yml` (resolveLoopOverSelfRepoFullName) -- the digest is an operator-level setting, not a
  * per-contributor-repo one, so ONE designated repo's manifest stands in for "the operator's own config" the
  * same way weekly-value-report/ops-alerts/selftune are operator-level, env-gated jobs. A manifest load failure

--- a/src/review/ops-wire.ts
+++ b/src/review/ops-wire.ts
@@ -1,11 +1,11 @@
-// Convergence (ops / observability) — wires the ported alerts + stats observability into gittensory, behind
+// Convergence (ops / observability) — wires the ported alerts + stats observability into loopover, behind
 // the default-OFF `LOOPOVER_REVIEW_OPS` flag. Flag-OFF every export here is a no-op / 404, so the worker is
 // byte-identical to today (the cron enqueues no ops job; the endpoint short-circuits).
 //
-// ADAPTED TO GITTENSORY'S OWN OUTCOME DATA — NOT reviewbot's `review_targets`/`review_audit` (those tables are
+// ADAPTED TO LOOPOVER'S OWN OUTCOME DATA — NOT reviewbot's `review_targets`/`review_audit` (those tables are
 // not populated here). The ported reviewbot modules (src/review/alerts.ts, src/review/stats.ts) are built
-// around `review_targets` + a Discord webhook; gittensory's review-outcome ledger is different, so this module
-// derives the equivalent health/anomaly signals from gittensory's native sources via the EXISTING aggregation
+// around `review_targets` + a Discord webhook; loopover's review-outcome ledger is different, so this module
+// derives the equivalent health/anomaly signals from loopover's native sources via the EXISTING aggregation
 // services (no new queries, no schema change):
 //   • gate_outcomes (#554) — the gate-block ledger; blocked-then-merged = a gate FALSE POSITIVE, plus the
 //     maintainer-OVERRIDE count. Aggregated by services/gate-precision.ts (buildGatePrecisionReport).
@@ -13,7 +13,7 @@
 //     persisted slop band on resolved PRs (slop score discrimination). Aggregated by
 //     services/outcome-calibration.ts (buildRepoOutcomeCalibration).
 //
-// NOTIFY PATH: gittensory has NO Discord / operator webhook (notifications/service.ts is a per-recipient,
+// NOTIFY PATH: loopover has NO Discord / operator webhook (notifications/service.ts is a per-recipient,
 // pull-based BADGE feed — the wrong channel for an operator anomaly). So an anomaly emits a structured
 // `console.error` log line with an `event` field (#orb-ci-stuck-repeat: this was previously `console.warn` with
 // an `ev` field — forwardStructuredLogToSentry, src/selfhost/sentry.ts, only wraps console.log/console.error
@@ -27,7 +27,7 @@
 // DEFERRED (NOT implemented here): the auto-tune / auto-apply config-mutation self-improve loop. The ported
 // pure logic + D1 store already exist in src/review/auto-apply.ts, but actually CLOSING the loop (mutating a
 // live gate's tunables from the cron) is sensitive — it needs the `tunables_overrides` / `_shadow` /
-// `override_audit` D1 tables (none of which exist in gittensory's migrations yet) plus a careful soak/promote
+// `override_audit` D1 tables (none of which exist in loopover's migrations yet) plus a careful soak/promote
 // design. This module is READ-ONLY observability: it reports drift; it never changes what blocks a live PR.
 
 import { findHottestInconclusiveReviewTargetForRepo, findHottestReviewTargetForRepo, listRepositories, sumByokAiUsageForRepoSince } from "../db/repositories";
@@ -91,7 +91,7 @@ export interface RepoOutcomeSnapshot {
 
 /**
  * PURE: human-readable anomalies in one repo's outcome snapshot (empty = healthy). Mirrors the SHAPE of the
- * ported alerts.ts `detectAnomalies` (a list of actionable lines), but over GITTENSORY'S signals:
+ * ported alerts.ts `detectAnomalies` (a list of actionable lines), but over LOOPOVER'S signals:
  *   • a gate type whose blocked-then-merged rate is high (the gate is blocking mergeable PRs);
  *   • the slop score INVERTING (a higher-severity band merging more than a lower one — score not predictive);
  *   • recommendations not panning out (a high negative outcome rate over enough resolved evidence).
@@ -170,7 +170,7 @@ export function worstAnomaly(anomalies: string[]): { line: string; severity: Pag
   return best;
 }
 
-// ── Cron alerts: scan gittensory's outcome data, emit a structured log on drift (flag-gated by the caller) ──
+// ── Cron alerts: scan loopover's outcome data, emit a structured log on drift (flag-gated by the caller) ──
 
 /** The installed repos to scan. Mirrors fanOutAgentRegateSweepJobs's own repo population (#5016): outcome
  *  telemetry (gate precision, slop calibration, review-burst detection) is core review-quality monitoring for
@@ -226,7 +226,7 @@ export async function runOpsAlerts(env: Env): Promise<Record<string, string[]>> 
         const anomalies = detectOutcomeAnomalies({ repoFullName, gatePrecision, calibration, reviewBurst, reviewFailureBurst });
         if (anomalies.length === 0) continue;
         found[repoFullName] = anomalies;
-        // Structured log = gittensory's notify path (no Discord/operator webhook exists) AND the Sentry path
+        // Structured log = loopover's notify path (no Discord/operator webhook exists) AND the Sentry path
         // (level:"error" + an `event` field reaches forwardStructuredLogToSentry). One line per repo.
         console.error(JSON.stringify({ level: "error", event: "ops_anomaly", repo: repoFullName, at: nowIso(), anomalies }));
         // Experimental PagerDuty paging (#4937): no-op unless LOOPOVER_ENABLE_PAGERDUTY is set AND a routing
@@ -295,7 +295,7 @@ export interface OpsStatsPayload {
 }
 
 /**
- * Aggregate gittensory's outcome data across the scanned repos into the stats payload. Read-only (D1 only via
+ * Aggregate loopover's outcome data across the scanned repos into the stats payload. Read-only (D1 only via
  * the existing aggregation services); never any GitHub I/O. Aggregate counts only — never PR content.
  */
 export async function computeOpsStats(env: Env): Promise<OpsStatsPayload> {


### PR DESCRIPTION
## Summary

- Part of the gittensory→loopover rebrand (#5705), phase 8b: rename brand-name prose in comments across `src/review/**` — the reviewbot→loopover convergence-port modules (adapters, alerts, auto-apply/auto-tune, content-lane primitives), cutover-gate, enrichment wiring, feature activation, and related modules. Comment-only, no behavior change.
- Deliberately left untouched: the pre-rename `GITTENSORY_LEGACY_*` check-run name constants and their exact string values (`check-names.ts`), the `'gittensory-native'` `review_audit.source` discriminator used across parity/outcomes tracking (a real DB column value, not prose — renaming it would desync new writes from historically-recorded rows), the `x-gittensory-request-id` header the engine sends to the REES enrichment service, and the `../config/gittensory-repo-focus-manifest` import path (the module itself is still filed under its old name; renaming just the import string would break module resolution).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue this PR resolves — N/A, maintainer-authored rebrand-epic cleanup (#5705), no linked-issue gate applies to owner PRs.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint` (via `npm run test:ci`)
- [x] `npm run typecheck` (via `npm run test:ci`)
- [x] `npm run test:coverage` — full unsharded run, 100% green; comment-only diff, no coverable lines changed
- [x] `npm run test:workers` (via `npm run test:ci`)
- [x] `npm run build:mcp` (via `npm run test:ci`)
- [x] `npm run test:mcp-pack` (via `npm run test:ci`)
- [x] `npm run ui:openapi:check` (via `npm run test:ci`)
- [x] `npm run ui:lint` (via `npm run test:ci`)
- [x] `npm run ui:typecheck` (via `npm run test:ci`)
- [x] `npm run ui:build` (via `npm run test:ci`)
- [x] `npm audit --audit-level=moderate`
- [x] Full `npm run test:ci` gate run locally, exit 0

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no such changes.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, comment-only, no behavior change.
- [ ] UI changes use live API data or real empty/error/loading states. — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section. — N/A, no UI changes.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs (none touched here).

## Notes

- One of several batched PRs covering the bulk-prose portion of rebrand epic #5705. Follows #5881 (docs routes).