### PR TITLE
docs: fix post-rebrand dead gittensory-* references in contributor docs

### DIFF
--- a/.claude/skills/contributing-to-loopover/SKILL.md
+++ b/.claude/skills/contributing-to-loopover/SKILL.md
@@ -97,9 +97,9 @@ approved, then confirm it's green.
 
 ```sh
 npm install -g @loopover/mcp@latest
-gittensory-mcp login                       # GitHub device flow (for the auth'd preflight tools)
-gittensory-mcp init-client --print codex   # prints TOML for ~/.codex/config.toml ([mcp_servers.gittensory])
-gittensory-mcp init-client --print claude  # or --print cursor — prints the correct config per tool
+loopover-mcp login                       # GitHub device flow (for the auth'd preflight tools)
+loopover-mcp init-client --print codex   # prints TOML for ~/.codex/config.toml ([mcp_servers.gittensory])
+loopover-mcp init-client --print claude  # or --print cursor — prints the correct config per tool
 ```
 
 Use that generator instead of hand-writing config (**Codex uses TOML, Claude/Cursor use JSON** — a
@@ -273,7 +273,7 @@ GitHub's web editor (which needs a human browser session an AI coding tool can't
    (the real `fetchBrowserSession()` call can race in afterward and silently overwrite it back to `null`);
    overriding `window.fetch` for `/v1/auth/session` to return the same authenticated shape closes that
    race either way.
-2. **Fixed viewport, never a full-page/`fullPage: true` capture.** gittensory-ui is a **dark-mode-only
+2. **Fixed viewport, never a full-page/`fullPage: true` capture.** loopover-ui is a **dark-mode-only
    build** (`apps/loopover-ui/src/components/site/theme-toggle.tsx` — the toggle was removed; there is
    no light theme left to force), so there's no theme dimension to multiply out. Capture at whichever
    viewport(s) your change actually affects — mobile (375×812) and desktop (1280×800) cover most cases;

--- a/.claude/skills/contributing-to-loopover/reference.md
+++ b/.claude/skills/contributing-to-loopover/reference.md
@@ -35,7 +35,7 @@ path filter matched; on push to `main`, everything runs.
 | workers | workers-pool vitest | `npm run test:workers` | any failing `test/workers/**` |
 | mcp → build | MCP pkg build | `npm run build:mcp` | MCP package build error |
 | mcp → pack | tarball hygiene | `npm run test:mcp-pack` | unexpected/forbidden file or stale README in the npm tarball |
-| miner → build | miner engine/pkg build | `npm run build:miner` | `@jsonbored/gittensory-{engine,miner}` build error |
+| miner → build | miner engine/pkg build | `npm run build:miner` | `@loopover/{engine,miner}` build error |
 | miner → pack | tarball hygiene | `npm run test:miner-pack` | unexpected/forbidden file in the miner npm tarball |
 | rees → test | review-enrichment-service's own suite | `npm run rees:test` | any failing test under `review-enrichment/` |
 | ui → openapi drift | spec check | `npm run ui:openapi:check` | committed `openapi.json` is stale (run `npm run ui:openapi`) |
@@ -144,9 +144,9 @@ Install + configure (let the CLI print the right config for your tool — **Code
 
 ```sh
 npm install -g @loopover/mcp@latest
-gittensory-mcp login                        # GitHub device flow
-gittensory-mcp init-client --print codex    # → ~/.codex/config.toml  ([mcp_servers.gittensory])
-gittensory-mcp init-client --print claude   # or --print cursor  (→ mcpServers JSON)
+loopover-mcp login                        # GitHub device flow
+loopover-mcp init-client --print codex    # → ~/.codex/config.toml  ([mcp_servers.gittensory])
+loopover-mcp init-client --print claude   # or --print cursor  (→ mcpServers JSON)
 ```
 
 All tools are metadata-only (no source upload). Run in this order:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -248,19 +248,19 @@ Frontend:
 
 Cloudflare/deploy:
 
-- Production UI deploys through the `gittensory-ui` Cloudflare Worker on
+- Production UI deploys through the `loopover-ui` Cloudflare Worker on
   `https://gittensory.aethereal.dev/`.
-- Production API deploys through the `gittensory-api` Cloudflare Worker on
+- Production API deploys through the `loopover-api` Cloudflare Worker on
   `https://gittensory-api.aethereal.dev/`.
 - Cloudflare Workers Builds owns automatic deployments from GitHub for BOTH workers (one connection
   per worker, scoped by build-watch-paths). GitHub Actions are validation/fallback only — do not add
   deploy workflows.
-  - `gittensory-api` deploy command: `npm run deploy:api` (applies pending D1 migrations, then
+  - `loopover-api` deploy command: `npm run deploy:api` (applies pending D1 migrations, then
     `wrangler deploy`). `wrangler d1 migrations apply` is non-interactive in CI and only applies
     PENDING migrations, so schema + code stay in sync on every build. Recommended build-watch-paths —
     include: `src/**`, `wrangler.jsonc`, `migrations/**`, `package.json`, `package-lock.json`,
     `tsconfig*.json`, `drizzle.config.ts`; exclude: `apps/**`, `docs/**`, `**/*.md`.
-  - `gittensory-ui` build command: `npm run build:cloudflare`. Scope its watch-paths to
+  - `loopover-ui` build command: `npm run build:cloudflare`. Scope its watch-paths to
     `apps/loopover-ui/**` (note: the UI build runs `ui:openapi` off the API contract, so rebuild the
     UI after API OpenAPI changes).
 - Do not re-add GitHub Pages or static-site deployment workflows.
@@ -269,7 +269,7 @@ MCP:
 
 - Preserve backwards compatibility where practical.
 - Keep CLI output stable and JSON output parseable.
-- `gittensory-mcp init-client --print` supports `codex`, `claude`, `cursor`, and `mcp` (generic
+- `loopover-mcp init-client --print` supports `codex`, `claude`, `cursor`, and `mcp` (generic
   JSON hosts that use the `mcpServers` shape).
 - MCP package releases are prepared separately and published from protected `mcp-vX.Y.Z` tags.
 

--- a/packages/loopover-miner/README.md
+++ b/packages/loopover-miner/README.md
@@ -209,7 +209,7 @@ contract and provider behavior.
 
 ### Recognizing a stale or missing coding-agent credential
 
-When an attempt fails on a `claude-cli` / `codex-cli` provider, the CLI-subprocess driver folds the CLI's own output into a machine-readable `error` string on the attempt result. The credential/auth failure modes below map that exact string to a symptom and a concrete remediation — mirroring ORB's hosted-side [Recognizing a stale or missing credential](../../apps/loopover-ui/src/routes/docs.self-hosting-ai-providers.tsx) table. Every string is emitted by [`cli-subprocess-driver.ts`](../gittensory-engine/src/miner/cli-subprocess-driver.ts); nothing here is speculative.
+When an attempt fails on a `claude-cli` / `codex-cli` provider, the CLI-subprocess driver folds the CLI's own output into a machine-readable `error` string on the attempt result. The credential/auth failure modes below map that exact string to a symptom and a concrete remediation — mirroring ORB's hosted-side [Recognizing a stale or missing credential](../../apps/loopover-ui/src/routes/docs.self-hosting-ai-providers.tsx) table. Every string is emitted by [`cli-subprocess-driver.ts`](../loopover-engine/src/miner/cli-subprocess-driver.ts); nothing here is speculative.
 
 | Error string / pattern | Symptom | Remediation |
 | --- | --- | --- |
@@ -259,7 +259,7 @@ This completes the read-only AMS MCP tool surface (status, portfolio, claims, ev
 
 ### Client config
 
-`loopover-mcp` (ORB's hosted contributor-workflow tools) and `loopover-miner-mcp` (AMS's own local state-visibility tools above) can run as two separate stdio servers in the same MCP client session — useful for a dual-role operator running both ORB and AMS on the same box. Generate ORB's half with `loopover-mcp init-client --print claude` (see the [`@loopover/mcp` README](../gittensory-mcp/README.md#client-config)); `loopover-miner-mcp` takes no flags, so its entry is just the bin name. Combined, a Claude Desktop / Claude Code style config looks like:
+`loopover-mcp` (ORB's hosted contributor-workflow tools) and `loopover-miner-mcp` (AMS's own local state-visibility tools above) can run as two separate stdio servers in the same MCP client session — useful for a dual-role operator running both ORB and AMS on the same box. Generate ORB's half with `loopover-mcp init-client --print claude` (see the [`@loopover/mcp` README](../loopover-mcp/README.md#client-config)); `loopover-miner-mcp` takes no flags, so its entry is just the bin name. Combined, a Claude Desktop / Claude Code style config looks like:
 
 ```json
 {


### PR DESCRIPTION
## Summary

The `gittensory` → `loopover` rebrand (#5705) renamed the CLI binaries, package directories, and Cloudflare Worker names, but four contributor-facing doc files still cited the pre-rename names. This fixes them against the live source-of-truth:

- **`CONTRIBUTING.md`** — Worker names → `loopover-ui` / `loopover-api` (per `apps/loopover-ui/wrangler.jsonc` and root `wrangler.jsonc`); MCP bin → `loopover-mcp init-client --print` (per `packages/loopover-mcp/package.json`).
- **`packages/loopover-miner/README.md`** — two broken relative links pointing at the renamed `packages/gittensory-engine` / `packages/gittensory-mcp` directories → `packages/loopover-engine` / `packages/loopover-mcp`.
- **`.claude/skills/contributing-to-loopover/SKILL.md`** & **`reference.md`** — copy-pasteable `gittensory-mcp` commands (dead bin) → `loopover-mcp`; the `gittensory-ui` visual-review mention → `loopover-ui`; the dead `@jsonbored/gittensory-{engine,miner}` package names → `@loopover/{engine,miner}`.

## Deliberately left unchanged (verified)

- **`gittensory.aethereal.dev` / `gittensory-api.aethereal.dev` hostnames** — `apps/loopover-ui/wrangler.jsonc` still routes `gittensory.aethereal.dev` and the root config documents the old domain as intentionally still-live post-rebrand (#4765). The fix here is the Worker **name** a contributor looks up in the Cloudflare dashboard, not the live route.
- **`JSONbored/gittensory` repo URLs** and the `screenshots` worktree/branch derived from the repo name — the repo redirect is live and the issue itself keeps these.
- **`[mcp_servers.gittensory]` config key** — the MCP server identifier was not renamed, only its binary.

## Notes

Docs-only (`*.md`) change — outside `codecov.yml`'s `coverage.include`, so the patch/project gates don't fire (expected). Every renamed target already exists on `main`; only the doc text lagged.

Closes #5809