### PR TITLE
fix(signals): match the .at(-1)/.at(0) idiom in boundary-test-generation

### DIFF
--- a/src/signals/boundary-test-generation.ts
+++ b/src/signals/boundary-test-generation.ts
@@ -32,7 +32,8 @@ export type BoundaryTouch = {
 // true-positive set). Each pattern only matches an ADDED line (a line starting with a single `+`, not `++`
 // which is the `+++ b/file` patch header) so this only ever reacts to genuinely new code, never context lines
 // or the file the diff is against.
-const ARRAY_INDEX_BOUNDS_PATTERN = /\[\s*(?:[\w.]+\.length|[\w.]+\.length\s*-\s*1|-1)\s*\]|\.length\s*(?:-\s*1)?\s*[<>]=?/;
+const ARRAY_INDEX_BOUNDS_PATTERN =
+  /\[\s*(?:[\w.]+\.length|[\w.]+\.length\s*-\s*1|-1)\s*\]|\.length\s*(?:-\s*1)?\s*[<>]=?|\.at\(\s*-?\d+\s*\)/;
 const NULL_OR_UNDEFINED_BRANCH_PATTERN = /(?:===?|!==?)\s*(?:null|undefined)\b|\b(?:null|undefined)\s*(?:===?|!==?)|\?\?|\?\./;
 const EMPTY_COLLECTION_CHECK_PATTERN = /\.length\s*(?:===?|!==?|[<>]=?)\s*0\b|\blen\(.*\)\s*(?:===?|!==?|[<>]=?)\s*0\b|\.(?:isEmpty|is_empty)\s*\(/;
 

--- a/test/unit/boundary-test-generation.test.ts
+++ b/test/unit/boundary-test-generation.test.ts
@@ -12,6 +12,20 @@ describe("detectBoundaryTouches", () => {
     expect(touches[0]).toMatchObject({ path: "src/list.ts", kind: "array_index_bounds" });
   });
 
+  it("detects the .at(-1)/.at(0) last-element idiom as an array/index bounds pattern", () => {
+    expect(detectBoundaryTouches([{ path: "src/list.ts", patch: "+const last = items.at(-1);\n" }])).toHaveLength(1);
+    expect(detectBoundaryTouches([{ path: "src/list.ts", patch: "+const first = items.at(0);\n" }])[0]).toMatchObject({
+      path: "src/list.ts",
+      kind: "array_index_bounds",
+    });
+    expect(detectBoundaryTouches([{ path: "src/list.ts", patch: "+const secondLast = items.at(-2);\n" }])).toHaveLength(1);
+  });
+
+  it("does not match .at(...) with a non-literal (variable) argument", () => {
+    const touches = detectBoundaryTouches([{ path: "src/list.ts", patch: "+const item = items.at(someVariable);\n" }]);
+    expect(touches).toHaveLength(0);
+  });
+
   it("detects a null/undefined branch pattern in an added line", () => {
     const touches = detectBoundaryTouches([{ path: "src/user.ts", patch: "@@ -1,1 +1,2 @@\n+if (user === null) return defaultUser;\n" }]);
     expect(touches).toHaveLength(1);


### PR DESCRIPTION
## Summary

- `ARRAY_INDEX_BOUNDS_PATTERN` in `src/signals/boundary-test-generation.ts` matched bracket-index forms (`arr[arr.length - 1]`, `arr[-1]`) and `.length` comparisons, but not the `Array.prototype.at()` idiom (`arr.at(-1)`, `arr.at(0)`) — the modern equivalent of the exact off-by-one/last-element access this detector exists to catch.
- Added a narrow `.at(<numeric literal>)` alternative to the regex, matching only a literal (optionally negative) integer argument so a bare identifier argument (`items.at(idx)`) — which carries none of the specific boundary signal a literal does — is deliberately left unmatched, per the module's "small and precise" design note (#1972).
- No other pattern, `BOUNDARY_PATTERNS`, `BoundaryPatternKind`, `MAX_TOUCHES`, or the added-line-only scanning changed.

## Scope

- [x] Change is limited to `src/signals/boundary-test-generation.ts` and its test file.
- [x] No changes to `site/`, `CNAME`, `**/lovable/**`, or the changelog.

## Validation

- `npx vitest run test/unit/boundary-test-generation.test.ts` — 29/29 passing (2 new cases: the `.at(-1)`/`.at(0)`/`.at(-2)` positive matches, and the `.at(someVariable)` negative case).
- `npm run typecheck` — clean.
- `npm run test:coverage` (unsharded, full suite) — no new failures; the only failing files are pre-existing environment gaps unrelated to this change (missing `sqlite3` CLI binary in `test/unit/selfhost-ams-reporting.test.ts`, and a couple of flaky miner-CLI tests that fail identically on `main` before this change).

## Safety

- [x] No secrets/wallets/hotkeys/trust scores/reward values touched.
- [x] Pure regex/test change, no auth/CORS surface.

Closes #5843
