### PR TITLE
test(miner): rename gittensory-miner/ams prose to loopover-miner/ams (batch 3)

### DIFF
--- a/packages/loopover-miner/lib/status.js
+++ b/packages/loopover-miner/lib/status.js
@@ -25,7 +25,7 @@ import { resolvePlanStoreDbPath } from "./plan-store.js";
 // this laptop set up correctly). Both are read-only and 100% local — no repo-scanning, no coding-agent invocation,
 // no GitHub writes, and no network calls of any kind. Later phases add the real discover/plan/manage loop.
 
-// Lazy, not module-scope: mirrors the gittensory-engine repo-map.ts fix -- this file is CLI-only today, but
+// Lazy, not module-scope: mirrors the loopover-engine repo-map.ts fix -- this file is CLI-only today, but
 // an eager createRequire(import.meta.url)/import.meta.dirname at module scope would crash on import in any
 // bundler context where import.meta is unavailable (e.g. if a future import chain pulls this into a Worker
 // bundle, the way repo-map.ts was). Deferring construction to first real use keeps this import-safe.
@@ -117,10 +117,10 @@ export function readInstalledEnginePackageVersion() {
   try {
     return readInstalledEnginePackageVersionFromPaths(
       requireFromHere().resolve(ENGINE_PACKAGE),
-      join(moduleDir(), "../../gittensory-engine/package.json"),
+      join(moduleDir(), "../../loopover-engine/package.json"),
     );
   } catch {
-    const workspacePkg = join(moduleDir(), "../../gittensory-engine/package.json");
+    const workspacePkg = join(moduleDir(), "../../loopover-engine/package.json");
     if (existsSync(workspacePkg)) {
       try {
         return JSON.parse(readFileSync(workspacePkg, "utf8")).version ?? null;
@@ -155,7 +155,7 @@ export function readExpectedEnginePackageVersionFromPaths(
 
 export function readExpectedEnginePackageVersion() {
   return readExpectedEnginePackageVersionFromPaths(
-    join(moduleDir(), "../../gittensory-engine/package.json"),
+    join(moduleDir(), "../../loopover-engine/package.json"),
     join(moduleDir(), "../expected-engine.version"),
   );
 }
@@ -278,7 +278,7 @@ export function runStatus(args = [], env = process.env, cwd = process.cwd()) {
 }
 
 function checkStateDirWritable(stateDir) {
-  const probe = join(stateDir, ".gittensory-miner-write-probe");
+  const probe = join(stateDir, ".loopover-miner-write-probe");
   try {
     // Creating the dir and writing (then removing) a probe file proves it is writable — the state dir must be
     // creatable/writable for the local SQLite stores to work.
@@ -310,14 +310,14 @@ function storeIntegrityChecks(env) {
   return stores.map(([name, dbPath]) => checkStoreIntegrity(`store-integrity:${name}`, dbPath));
 }
 
-/** Validate the discovered `.gittensory-miner` config's CONTENT (#4873), not just its path: parse it with the
+/** Validate the discovered `.loopover-miner` config's CONTENT (#4873), not just its path: parse it with the
  *  tolerant goal-spec parser and surface its warnings, so a malformed config is flagged by `doctor` rather than
  *  silently degrading to defaults. No config file is fine (defaults apply); a read failure is reported. `readImpl`
  *  is injectable for tests. */
 export function checkConfigContent(cwd, readImpl = readFileSync) {
   const configPath = discoverConfigFile(cwd);
   if (!configPath) {
-    return { name: "config-content", ok: true, detail: "no .gittensory-miner config found (using defaults)" };
+    return { name: "config-content", ok: true, detail: "no .loopover-miner config found (using defaults)" };
   }
   let warnings;
   try {

--- a/test/unit/miner-plan-store.test.ts
+++ b/test/unit/miner-plan-store.test.ts
@@ -15,7 +15,7 @@ const roots: string[] = [];
 const stores: Array<{ close(): void }> = [];
 
 function tempStore() {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-plan-store-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-plan-store-"));
   roots.push(root);
   const store = openPlanStore(join(root, "nested", "plan-store.sqlite3"));
   stores.push(store);
@@ -35,7 +35,7 @@ const PLAN: PlanDag = {
   ],
 };
 
-describe("gittensory-miner plan store (#2318)", () => {
+describe("loopover-miner plan store (#2318)", () => {
   it("exposes the frozen plan-status vocabulary", () => {
     expect(PLAN_STATUSES).toEqual(["pending", "running", "completed", "failed"]);
     expect(Object.isFrozen(PLAN_STATUSES)).toBe(true);
@@ -157,7 +157,7 @@ describe("gittensory-miner plan store (#2318)", () => {
   });
 
   it("fails closed on an out-of-vocabulary status column (legacy/foreign row without the CHECK)", () => {
-    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-plan-store-"));
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-plan-store-"));
     roots.push(root);
     const dbPath = join(root, "legacy.sqlite3");
     // Simulate a legacy/foreign table created before the status CHECK constraint, holding an invalid status.

--- a/test/unit/miner-policy-doc-cache.test.ts
+++ b/test/unit/miner-policy-doc-cache.test.ts
@@ -11,7 +11,7 @@ const roots: string[] = [];
 const stores: Array<{ close(): void }> = [];
 
 function tempDbPath(): string {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-policy-doc-cache-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-policy-doc-cache-"));
   roots.push(root);
   return join(root, "policy-doc-cache.sqlite3");
 }
@@ -44,7 +44,7 @@ describe("resolvePolicyDocCacheDbPath (#4842)", () => {
   });
 });
 
-describe("gittensory-miner policy-doc cache store (#4842)", () => {
+describe("loopover-miner policy-doc cache store (#4842)", () => {
   it("returns null for a URL that has never been cached", () => {
     expect(openStore().get(URL)).toBeNull();
   });

--- a/test/unit/miner-policy-verdict-cache.test.ts
+++ b/test/unit/miner-policy-verdict-cache.test.ts
@@ -12,7 +12,7 @@ const roots: string[] = [];
 const stores: Array<{ close(): void }> = [];
 
 function tempDbPath(): string {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-policy-verdict-cache-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-policy-verdict-cache-"));
   roots.push(root);
   return join(root, "policy-verdict-cache.sqlite3");
 }
@@ -46,7 +46,7 @@ describe("resolvePolicyVerdictCacheDbPath (#4843)", () => {
   });
 });
 
-describe("gittensory-miner policy-verdict cache store (#4843)", () => {
+describe("loopover-miner policy-verdict cache store (#4843)", () => {
   it("returns null for a repo that has never been cached", () => {
     expect(openStore().get(REPO)).toBeNull();
   });

--- a/test/unit/miner-portfolio-discovery.test.ts
+++ b/test/unit/miner-portfolio-discovery.test.ts
@@ -17,7 +17,7 @@ const roots: string[] = [];
 const stores: Array<{ close(): void }> = [];
 
 function tempQueueStore() {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-portfolio-discovery-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-portfolio-discovery-"));
   roots.push(root);
   const store = initPortfolioQueueStore(join(root, "portfolio-queue.sqlite3"));
   stores.push(store);
@@ -25,7 +25,7 @@ function tempQueueStore() {
 }
 
 function tempEventLedger() {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-portfolio-discovery-ledger-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-portfolio-discovery-ledger-"));
   roots.push(root);
   const ledger = initEventLedger(join(root, "event-ledger.sqlite3"));
   stores.push(ledger);
@@ -50,7 +50,7 @@ afterEach(() => {
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
 
-describe("gittensory-miner portfolio discovery (#2292)", () => {
+describe("loopover-miner portfolio discovery (#2292)", () => {
   it("returns a zero summary for empty input without touching the queue", () => {
     const queueStore = tempQueueStore();
     expect(enqueueRankedDiscovery([], { queueStore })).toEqual({

--- a/test/unit/miner-portfolio-queue-crash-recovery.test.ts
+++ b/test/unit/miner-portfolio-queue-crash-recovery.test.ts
@@ -27,7 +27,7 @@ const roots: string[] = [];
 const stores: Array<{ close(): void }> = [];
 
 function tempRoot(): { root: string; dbPath: string } {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-crash-recovery-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-crash-recovery-"));
   roots.push(root);
   return { root, dbPath: join(root, "portfolio-queue.sqlite3") };
 }

--- a/test/unit/miner-portfolio-queue-expiry.test.ts
+++ b/test/unit/miner-portfolio-queue-expiry.test.ts
@@ -15,7 +15,7 @@ const roots: string[] = [];
 const stores: Array<{ close(): void }> = [];
 
 function tempStore() {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-portfolio-expiry-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-portfolio-expiry-"));
   roots.push(root);
   const store = initPortfolioQueueStore(join(root, "portfolio-queue.sqlite3"));
   stores.push(store);

--- a/test/unit/miner-portfolio-queue.test.ts
+++ b/test/unit/miner-portfolio-queue.test.ts
@@ -25,7 +25,7 @@ const roots: string[] = [];
 const stores: Array<{ close(): void }> = [];
 
 function tempStore() {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-portfolio-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-portfolio-"));
   roots.push(root);
   const store = initPortfolioQueueStore(join(root, "nested", "portfolio-queue.sqlite3"));
   stores.push(store);
@@ -40,7 +40,7 @@ afterEach(() => {
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
 
-describe("gittensory-miner portfolio/queue store (#2292)", () => {
+describe("loopover-miner portfolio/queue store (#2292)", () => {
   it("exposes the frozen status vocabulary", () => {
     expect(QUEUE_STATUSES).toEqual(["queued", "in_progress", "done"]);
     expect(Object.isFrozen(QUEUE_STATUSES)).toBe(true);
@@ -184,7 +184,7 @@ describe("gittensory-miner portfolio/queue store (#2292)", () => {
   });
 
   it("module-level markFailed delegates to the default portfolio-queue store (#2347)", () => {
-    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-portfolio-default-"));
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-portfolio-default-"));
     roots.push(root);
     vi.stubEnv("LOOPOVER_MINER_PORTFOLIO_QUEUE_DB", join(root, "portfolio-queue.sqlite3"));
     enqueue({ repoFullName: "o/a", identifier: "work", priority: 1 });
@@ -210,7 +210,7 @@ describe("gittensory-miner portfolio/queue store (#2292)", () => {
   });
 
   it("module-level markDone delegates to the default portfolio-queue store", () => {
-    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-portfolio-default-"));
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-portfolio-default-"));
     roots.push(root);
     vi.stubEnv("LOOPOVER_MINER_PORTFOLIO_QUEUE_DB", join(root, "portfolio-queue.sqlite3"));
     enqueue({ repoFullName: "o/a", identifier: "work", priority: 1 });
@@ -289,7 +289,7 @@ describe("gittensory-miner portfolio/queue store (#2292)", () => {
     });
 
     it("migrates an existing pre-#5563 file (already at the leased_at v2 shape), backfilling api_base_url and preserving every row", () => {
-      const root = mkdtempSync(join(tmpdir(), "gittensory-miner-portfolio-legacy-"));
+      const root = mkdtempSync(join(tmpdir(), "loopover-miner-portfolio-legacy-"));
       roots.push(root);
       const dbPath = join(root, "legacy.sqlite3");
       const legacy = new DatabaseSync(dbPath);
@@ -329,7 +329,7 @@ describe("gittensory-miner portfolio/queue store (#2292)", () => {
     });
 
     it("REGRESSION: a legacy row violating the rebuilt table's status CHECK constraint is dropped, not a migration-aborting crash", () => {
-      const root = mkdtempSync(join(tmpdir(), "gittensory-miner-portfolio-legacy-corrupt-"));
+      const root = mkdtempSync(join(tmpdir(), "loopover-miner-portfolio-legacy-corrupt-"));
       roots.push(root);
       const dbPath = join(root, "legacy-corrupt.sqlite3");
       const legacy = new DatabaseSync(dbPath);
@@ -456,7 +456,7 @@ describe("gittensory-miner portfolio/queue store (#2292)", () => {
     });
 
     it("module-level getAttemptHistory delegates to the default portfolio-queue store", () => {
-      const root = mkdtempSync(join(tmpdir(), "gittensory-miner-portfolio-default-"));
+      const root = mkdtempSync(join(tmpdir(), "loopover-miner-portfolio-default-"));
       roots.push(root);
       vi.stubEnv("LOOPOVER_MINER_PORTFOLIO_QUEUE_DB", join(root, "portfolio-queue.sqlite3"));
       enqueue({ repoFullName: "o/a", identifier: "work", priority: 1 });
@@ -476,7 +476,7 @@ describe("gittensory-miner portfolio/queue store (#2292)", () => {
     });
 
     it("migrates an existing pre-#5654 file (already at the api_base_url v3 shape) by backfilling the counters to 0, preserving every row", () => {
-      const root = mkdtempSync(join(tmpdir(), "gittensory-miner-portfolio-legacy-v3-"));
+      const root = mkdtempSync(join(tmpdir(), "loopover-miner-portfolio-legacy-v3-"));
       roots.push(root);
       const dbPath = join(root, "legacy-v3.sqlite3");
       const legacy = new DatabaseSync(dbPath);
@@ -526,7 +526,7 @@ describe("gittensory-miner portfolio/queue store (#2292)", () => {
       // Mirrors the leased_at migration's own defensive column-presence guard one migration index up: a file
       // that already has the three new columns (e.g. from a partially-applied prior migration attempt) must
       // not crash re-adding columns that already exist -- each of the three checks must independently skip.
-      const root = mkdtempSync(join(tmpdir(), "gittensory-miner-portfolio-legacy-partial-v4-"));
+      const root = mkdtempSync(join(tmpdir(), "loopover-miner-portfolio-legacy-partial-v4-"));
       roots.push(root);
       const dbPath = join(root, "legacy-partial-v4.sqlite3");
       const legacy = new DatabaseSync(dbPath);

--- a/test/unit/miner-prediction-ledger.test.ts
+++ b/test/unit/miner-prediction-ledger.test.ts
@@ -7,7 +7,7 @@ import { initPredictionLedger, resolvePredictionLedgerDbPath } from "../../packa
 const ledgers: Array<{ close: () => void }> = [];
 const roots: string[] = [];
 function tempLedger() {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-prediction-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-prediction-"));
   roots.push(root);
   const ledger = initPredictionLedger(join(root, "prediction-ledger.sqlite3"));
   ledgers.push(ledger);

--- a/test/unit/miner-pretooluse-hook.test.ts
+++ b/test/unit/miner-pretooluse-hook.test.ts
@@ -26,7 +26,7 @@ afterEach(() => {
 });
 
 function openLedger() {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-pretooluse-hook-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-pretooluse-hook-"));
   roots.push(root);
   const ledger = initGovernorLedger(join(root, "governor-ledger.sqlite3"));
   ledgers.push(ledger);

--- a/test/unit/miner-process-lifecycle.test.ts
+++ b/test/unit/miner-process-lifecycle.test.ts
@@ -48,7 +48,7 @@ afterEach(() => {
   vi.restoreAllMocks();
 });
 
-describe("gittensory-miner process lifecycle / crash-safety (#4826)", () => {
+describe("loopover-miner process lifecycle / crash-safety (#4826)", () => {
   it("registerCleanupResource ignores null and undefined but still returns a callable no-op", () => {
     expect(cleanupResourceCount()).toBe(0);
     expect(() => registerCleanupResource(null)()).not.toThrow();

--- a/test/unit/miner-ranked-candidates.test.ts
+++ b/test/unit/miner-ranked-candidates.test.ts
@@ -14,7 +14,7 @@ import {
 const roots: string[] = [];
 
 function tempRoot(): string {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-ranked-candidates-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-ranked-candidates-"));
   roots.push(root);
   return root;
 }
@@ -40,7 +40,7 @@ const fullCandidate = {
   dupRisk: 0.1,
 };
 
-describe("gittensory-miner ranked-candidates store (#4859 prerequisite)", () => {
+describe("loopover-miner ranked-candidates store (#4859 prerequisite)", () => {
   it("resolves the DB path from env override, miner config dir, XDG config, then the home default", () => {
     expect(resolveRankedCandidatesDbPath({ LOOPOVER_MINER_RANKED_CANDIDATES_DB: "/custom/ranked.sqlite3" })).toBe(
       "/custom/ranked.sqlite3",

--- a/test/unit/miner-rejection-state-machine.test.ts
+++ b/test/unit/miner-rejection-state-machine.test.ts
@@ -10,7 +10,7 @@ import {
 const CONTEXT = { repoFullName: "JSONbored/gittensory", prNumber: 4278 } as const;
 const closedUnmerged = { state: "closed", merged: false, merged_at: null, closed_at: "2026-07-09T18:00:00Z" };
 
-describe("gittensory-miner rejection state machine (#4278)", () => {
+describe("loopover-miner rejection state machine (#4278)", () => {
   it("extracts terminal-outcome fields from a full PR payload", () => {
     expect(extractPrOutcomeFields(closedUnmerged)).toEqual({
       state: "closed",

--- a/test/unit/miner-rejection-templates.test.ts
+++ b/test/unit/miner-rejection-templates.test.ts
@@ -7,7 +7,7 @@ import {
 
 const CONTEXT = { repoFullName: "JSONbored/gittensory", prNumber: 2751 } as const;
 
-describe("gittensory-miner rejection templates (#2324)", () => {
+describe("loopover-miner rejection templates (#2324)", () => {
   it("exposes the frozen reason vocabulary", () => {
     expect(REJECTION_REASONS).toEqual(["gate_close", "maintainer_close_no_reason", "superseded_by_duplicate"]);
     expect(Object.isFrozen(REJECTION_REASONS)).toBe(true);

--- a/test/unit/miner-replay-objective-anchor.test.ts
+++ b/test/unit/miner-replay-objective-anchor.test.ts
@@ -10,7 +10,7 @@ import {
   scoreObjectiveAnchor,
 } from "../../packages/loopover-miner/lib/replay-objective-anchor.js";
 
-describe("gittensory-miner replay objective-anchor scoring (#3012)", () => {
+describe("loopover-miner replay objective-anchor scoring (#3012)", () => {
   it("exposes a frozen change-kind vocabulary and weights that sum to 1", () => {
     expect(Object.isFrozen(CHANGE_KINDS)).toBe(true);
     expect(CHANGE_KINDS).toContain("feature");

--- a/test/unit/miner-replay-snapshot.test.ts
+++ b/test/unit/miner-replay-snapshot.test.ts
@@ -57,7 +57,7 @@ function happyPathScripts(overrides: Array<{ match: (args: readonly string[]) =>
 let stores: Array<{ close(): void }> = [];
 let roots: string[] = [];
 function tempStore() {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-replay-snapshot-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-replay-snapshot-"));
   roots.push(root);
   const store = openReplaySnapshotStore(join(root, "db.sqlite3"));
   stores.push(store);
@@ -380,7 +380,7 @@ describe("exportReplaySnapshot (#3010)", () => {
   });
 
   it("falls back to the default (env-resolved) store when deps.store is omitted", async () => {
-    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-replay-snapshot-default-"));
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-replay-snapshot-default-"));
     roots.push(root);
     vi.stubEnv("LOOPOVER_MINER_REPLAY_SNAPSHOT_DB", join(root, "default.sqlite3"));
     const { exec } = scriptedExec(happyPathScripts());

--- a/test/unit/miner-replay-task-generation.test.ts
+++ b/test/unit/miner-replay-task-generation.test.ts
@@ -18,7 +18,7 @@ const CONTEXT = {
   revealedIssueNumbers: [250, 300],
 };
 
-describe("gittensory-miner leakage-safe replay task generation (#3011)", () => {
+describe("loopover-miner leakage-safe replay task generation (#3011)", () => {
   it("exposes a frozen recency-pool vocabulary and a stable placeholder", () => {
     expect(Object.isFrozen(RECENCY_POOLS)).toBe(true);
     expect(RECENCY_POOLS).toEqual(["recent", "older"]);

--- a/test/unit/miner-repo-clone.test.ts
+++ b/test/unit/miner-repo-clone.test.ts
@@ -62,7 +62,7 @@ describe("resolveRepoCloneBaseDir / resolveRepoCloneDir (#5132)", () => {
 
 describe("ensureRepoCloned (#5132)", () => {
   it("clones a real repo on first use, and fetches + hard-resets an existing clone to pick up new commits", async () => {
-    const root = tempRoot("gittensory-miner-repo-clone-");
+    const root = tempRoot("loopover-miner-repo-clone-");
     const originPath = initOriginRepo(root);
     const cloneBaseDir = join(root, "cache");
 
@@ -83,7 +83,7 @@ describe("ensureRepoCloned (#5132)", () => {
   });
 
   it("respects a non-default baseBranch on the fetch+reset path", async () => {
-    const root = tempRoot("gittensory-miner-repo-clone-branch-");
+    const root = tempRoot("loopover-miner-repo-clone-branch-");
     const originPath = initOriginRepo(root);
     execFileSync("git", ["checkout", "-b", "develop"], { cwd: originPath, stdio: "ignore" });
     const cloneBaseDir = join(root, "cache");
@@ -102,7 +102,7 @@ describe("ensureRepoCloned (#5132)", () => {
   });
 
   it("returns ok:false with the real git stderr when the clone URL doesn't resolve", async () => {
-    const root = tempRoot("gittensory-miner-repo-clone-fail-");
+    const root = tempRoot("loopover-miner-repo-clone-fail-");
     const cloneBaseDir = join(root, "cache");
     const result = await ensureRepoCloned("acme/does-not-exist", { cloneBaseDir, remoteUrl: join(root, "nonexistent-origin"), timeoutMs: 5000 });
     expect(result.ok).toBe(false);
@@ -110,7 +110,7 @@ describe("ensureRepoCloned (#5132)", () => {
   });
 
   it("returns ok:false on a fetch failure without touching the existing clone (injected runGit)", async () => {
-    const root = tempRoot("gittensory-miner-repo-clone-fetchfail-");
+    const root = tempRoot("loopover-miner-repo-clone-fetchfail-");
     const originPath = initOriginRepo(root);
     const cloneBaseDir = join(root, "cache");
     const first = await ensureRepoCloned("acme/widgets", { cloneBaseDir, remoteUrl: originPath });
@@ -123,7 +123,7 @@ describe("ensureRepoCloned (#5132)", () => {
   });
 
   it("returns ok:false on a checkout failure and a reset failure (injected runGit)", async () => {
-    const root = tempRoot("gittensory-miner-repo-clone-checkoutfail-");
+    const root = tempRoot("loopover-miner-repo-clone-checkoutfail-");
     const originPath = initOriginRepo(root);
     const cloneBaseDir = join(root, "cache");
     await ensureRepoCloned("acme/widgets", { cloneBaseDir, remoteUrl: originPath });
@@ -140,7 +140,7 @@ describe("ensureRepoCloned (#5132)", () => {
   });
 
   it("returns ok:false with a fallback error message on a clone failure with no stderr (injected runGit)", async () => {
-    const root = tempRoot("gittensory-miner-repo-clone-nostderr-");
+    const root = tempRoot("loopover-miner-repo-clone-nostderr-");
     const cloneBaseDir = join(root, "cache");
     const runGit = async () => ({ ok: false, stdout: "", stderr: "" });
     const result = await ensureRepoCloned("acme/widgets", { cloneBaseDir, remoteUrl: "unused", runGit });

--- a/test/unit/miner-run-state.test.ts
+++ b/test/unit/miner-run-state.test.ts
@@ -16,7 +16,7 @@ import {
 const roots: string[] = [];
 
 function tempRoot(): string {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-run-state-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-run-state-"));
   roots.push(root);
   return root;
 }
@@ -29,7 +29,7 @@ afterEach(() => {
   }
 });
 
-describe("gittensory-miner run-state store (#2289)", () => {
+describe("loopover-miner run-state store (#2289)", () => {
   it("keeps the package engine floor aligned with unflagged node:sqlite support", () => {
     const packageJson = JSON.parse(
       readFileSync("packages/loopover-miner/package.json", "utf8"),

--- a/test/unit/miner-status.test.ts
+++ b/test/unit/miner-status.test.ts
@@ -23,7 +23,7 @@ import { initLaptopState } from "../../packages/loopover-miner/lib/laptop-init.j
 const roots: string[] = [];
 
 function tempRoot() {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-status-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-status-"));
   roots.push(root);
   return root;
 }
@@ -42,7 +42,7 @@ function fakeBinDir(name: string): string {
   return dir;
 }
 
-describe("gittensory-miner status/doctor (#2288)", () => {
+describe("loopover-miner status/doctor (#2288)", () => {
   it("resolves the state dir from the config-dir override, XDG, then the home default", () => {
     expect(resolveMinerStateDir({ LOOPOVER_MINER_CONFIG_DIR: "/custom/state" })).toBe("/custom/state");
     expect(resolveMinerStateDir({ XDG_CONFIG_HOME: "/xdg" })).toBe("/xdg/loopover-miner");
@@ -81,11 +81,11 @@ describe("gittensory-miner status/doctor (#2288)", () => {
     const status = collectStatus(
       {
         LOOPOVER_MINER_CONFIG_DIR: "/s",
-        LOOPOVER_MINER_VERSION: "gittensory-miner-fleet@deadbeef",
+        LOOPOVER_MINER_VERSION: "loopover-miner-fleet@deadbeef",
       },
       tempRoot(),
     );
-    expect(status.package.version).toBe("gittensory-miner-fleet@deadbeef");
+    expect(status.package.version).toBe("loopover-miner-fleet@deadbeef");
   });
 
   it("runStatus prints human-readable text (0) and machine JSON with --json", () => {
@@ -144,7 +144,7 @@ describe("gittensory-miner status/doctor (#2288)", () => {
     it("is a clean pass when no config file is present (defaults apply)", () => {
       const result = checkConfigContent(tempRoot());
       expect(result).toMatchObject({ name: "config-content", ok: true });
-      expect(result.detail).toContain("no .gittensory-miner config");
+      expect(result.detail).toContain("no .loopover-miner config");
     });
 
     it("passes a well-formed config", () => {

--- a/test/unit/miner-terraform-module.test.ts
+++ b/test/unit/miner-terraform-module.test.ts
@@ -13,7 +13,7 @@ const variablesTf = readFileSync(`${DIR}/variables.tf`, "utf8");
 const outputsTf = readFileSync(`${DIR}/outputs.tf`, "utf8");
 const readme = readFileSync(`${DIR}/README.md`, "utf8");
 
-describe("gittensory-miner fleet-mode Terraform module (#5183)", () => {
+describe("loopover-miner fleet-mode Terraform module (#5183)", () => {
   it("uses the same Hetzner Cloud provider as the root module (consistency)", () => {
     expect(mainTf).toMatch(/source\s*=\s*"hetznercloud\/hcloud"/);
     expect(mainTf).toMatch(/provider\s+"hcloud"/);

--- a/test/unit/miner-version.test.ts
+++ b/test/unit/miner-version.test.ts
@@ -4,7 +4,7 @@ import {
   resolveMinerVersion,
 } from "../../packages/loopover-miner/lib/version.js";
 
-describe("gittensory-miner version resolution (#4310)", () => {
+describe("loopover-miner version resolution (#4310)", () => {
   it("defaults to the package.json semver when LOOPOVER_MINER_VERSION is unset", () => {
     expect(MINER_PACKAGE_VERSION).toMatch(/^\d+\.\d+\.\d+$/);
     expect(resolveMinerVersion({})).toBe(MINER_PACKAGE_VERSION);
@@ -14,8 +14,8 @@ describe("gittensory-miner version resolution (#4310)", () => {
 
   it("prefers a nonblank LOOPOVER_MINER_VERSION override (fleet Docker build ref)", () => {
     expect(
-      resolveMinerVersion({ LOOPOVER_MINER_VERSION: "gittensory-miner-fleet@abc1234" }),
-    ).toBe("gittensory-miner-fleet@abc1234");
+      resolveMinerVersion({ LOOPOVER_MINER_VERSION: "loopover-miner-fleet@abc1234" }),
+    ).toBe("loopover-miner-fleet@abc1234");
     expect(
       resolveMinerVersion({ LOOPOVER_MINER_VERSION: " 0.9.0-beta.1 " }),
     ).toBe("0.9.0-beta.1");

--- a/test/unit/miner-worktree-allocator-collisions.test.ts
+++ b/test/unit/miner-worktree-allocator-collisions.test.ts
@@ -25,7 +25,7 @@ type AcquireChildResult = {
 };
 
 function tempPaths() {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-worktree-collisions-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-worktree-collisions-"));
   roots.push(root);
   return {
     root,
@@ -133,7 +133,7 @@ afterEach(() => {
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
 
-describe("gittensory-miner worktree allocator collisions (#4298)", () => {
+describe("loopover-miner worktree allocator collisions (#4298)", () => {
   it("returns distinct worktree paths when multiple processes acquire simultaneously", async () => {
     const paths = tempPaths();
     const maxConcurrency = 5;

--- a/test/unit/miner-worktree-allocator.test.ts
+++ b/test/unit/miner-worktree-allocator.test.ts
@@ -14,7 +14,7 @@ const roots: string[] = [];
 const allocators: Array<{ close(): void }> = [];
 
 function tempAllocator(options: { maxConcurrency?: number; processPid?: number } = {}) {
-  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-worktree-allocator-"));
+  const root = mkdtempSync(join(tmpdir(), "loopover-miner-worktree-allocator-"));
   roots.push(root);
   const allocator = openWorktreeAllocator({
     dbPath: join(root, "worktree-allocator.sqlite3"),
@@ -33,7 +33,7 @@ afterEach(() => {
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
 });
 
-describe("gittensory-miner worktree allocator scaffolding (#4298)", () => {
+describe("loopover-miner worktree allocator scaffolding (#4298)", () => {
   it("resolves DB and worktree base paths from env overrides", () => {
     expect(
       resolveWorktreeAllocatorDbPath({ LOOPOVER_MINER_WORKTREE_ALLOCATOR_DB: "/custom/alloc.sqlite3" }),

--- a/test/unit/opportunity-fanout-policy-doc-cache.test.ts
+++ b/test/unit/opportunity-fanout-policy-doc-cache.test.ts
@@ -252,7 +252,7 @@ describe("opportunity fan-out policy-doc conditional-GET cache (#4842)", () => {
   });
 
   it("persists the ETag across two runs with the real on-disk store, then serves a 304", async () => {
-    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-policy-doc-cache-fanout-"));
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-policy-doc-cache-fanout-"));
     roots.push(root);
     const dbPath = join(root, "policy-doc-cache.sqlite3");
     const store = initPolicyDocCacheStore(dbPath);

--- a/test/unit/opportunity-fanout-policy-verdict-cache.test.ts
+++ b/test/unit/opportunity-fanout-policy-verdict-cache.test.ts
@@ -284,7 +284,7 @@ describe("opportunity fan-out policy-verdict cache (#4843)", () => {
   });
 
   it("persists across two runs with the real on-disk store, reusing the verdict on an unchanged ETag", async () => {
-    const root = mkdtempSync(join(tmpdir(), "gittensory-miner-policy-verdict-cache-fanout-"));
+    const root = mkdtempSync(join(tmpdir(), "loopover-miner-policy-verdict-cache-fanout-"));
     roots.push(root);
     const dbPath = join(root, "policy-verdict-cache.sqlite3");
     const store = initPolicyVerdictCacheStore(dbPath);

--- a/test/unit/selfhost-ams-reporting.test.ts
+++ b/test/unit/selfhost-ams-reporting.test.ts
@@ -11,7 +11,7 @@ import { afterEach, describe, expect, it } from "vitest";
 const tmpRoots: string[] = [];
 
 function tmpRoot(): string {
-  const dir = mkdtempSync(join(tmpdir(), "gittensory-ams-reporting-"));
+  const dir = mkdtempSync(join(tmpdir(), "loopover-ams-reporting-"));
   tmpRoots.push(dir);
   return dir;
 }


### PR DESCRIPTION
## Summary

- Part of the gittensory→loopover rebrand (#5705), phase 8b: rename remaining test-title prose. This final batch covers 26 `test/unit/*.ts` files (plan-store, policy caches, portfolio-queue, prediction-ledger, replay, repo-clone, worktree-allocator, and the opportunity-fanout/selfhost-ams clusters) whose `describe()`/`it()` titles and `mkdtempSync`/`tempRoot` tmpdir prefixes still used the bare `gittensory-miner`/`gittensory-ams` strings.
- Also fixes real stale strings this sweep surfaced in `packages/loopover-miner/lib/status.js`: a monorepo-workspace-fallback path (`readInstalledEnginePackageVersion`/`readExpectedEnginePackageVersion`) that pointed at `../../gittensory-engine/package.json` — a directory that no longer exists (the real package is `packages/loopover-engine`), so this fallback silently returned `null` instead of the real version when node_modules resolution fails in monorepo dev mode — plus a stale `"no .gittensory-miner config found"` doctor-check message and an unused write-probe filename. Test assertion updated in the same commit.
- No other functional/runtime identifier changes — purely test-label and comment prose, plus the status.js fixes above.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue this PR resolves — N/A, maintainer-authored rebrand-epic cleanup (#5705), no linked-issue gate applies to owner PRs.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint` (via `npm run test:ci`)
- [x] `npm run typecheck` (via `npm run test:ci`)
- [x] `npm run test:coverage` — full unsharded run, 100% green
- [x] `npm run test:workers` (via `npm run test:ci`)
- [x] `npm run build:mcp` (via `npm run test:ci`)
- [x] `npm run test:mcp-pack` (via `npm run test:ci`)
- [x] `npm run ui:openapi:check` (via `npm run test:ci`)
- [x] `npm run ui:lint` (via `npm run test:ci`)
- [x] `npm run ui:typecheck` (via `npm run test:ci`)
- [x] `npm run ui:build` (via `npm run test:ci`)
- [x] `npm audit --audit-level=moderate`
- [x] Full `npm run test:ci` gate run locally, exit 0

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no such changes.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no behavior change.
- [ ] UI changes use live API data or real empty/error/loading states. — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section. — N/A, no UI changes.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs (none touched here).

## Notes

- Final batch of the `describe()`/tmpdir-prefix renames tracked in rebrand epic #5705 (item 1 of 2). Follows #5874, #5878.