### PR TITLE
test(review): add direct unit suite for review-thread-findings (#5846)

### DIFF
--- a/test/unit/review-thread-findings.test.ts
+++ b/test/unit/review-thread-findings.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+import { buildReviewThreadBlocker, reviewThreadBlockerFinding, type ReviewThreadBlocker } from "../../src/review/review-thread-findings";
+
+describe("buildReviewThreadBlocker", () => {
+  it("returns null when there are no comments", () => {
+    expect(buildReviewThreadBlocker({ comments: [] })).toBeNull();
+  });
+
+  it("returns null when every comment is empty or whitespace-only", () => {
+    expect(buildReviewThreadBlocker({ comments: [{ body: "" }, { body: "   " }, { body: null }, { body: undefined }] })).toBeNull();
+  });
+
+  it("picks the scanner-marker comment over an earlier non-scanner comment and parses its markdown priority/title", () => {
+    const blocker = buildReviewThreadBlocker({
+      path: "src/app.ts",
+      line: 12,
+      comments: [
+        { body: "just a human note", authorLogin: "alice", url: "https://gh/1" },
+        { body: "<!-- brin-pr-finding fp=abc -->\n**P1:** Guard the null branch", authorLogin: "review-bot", url: "https://gh/2" },
+      ],
+    });
+    expect(blocker).toEqual({
+      title: "Guard the null branch",
+      priority: "P1",
+      path: "src/app.ts",
+      line: 12,
+      authorLogin: "review-bot",
+      url: "https://gh/2",
+      scannerFinding: true,
+    });
+  });
+
+  it("also treats a superagent-finding-fingerprint marker as a scanner comment", () => {
+    const blocker = buildReviewThreadBlocker({
+      comments: [{ body: "<!-- superagent-finding-fingerprint: deadbeef -->\nSomething", authorLogin: "bot", url: null }],
+    });
+    expect(blocker?.scannerFinding).toBe(true);
+  });
+
+  it("falls back to the first comment and parses an XML priority/title when no scanner marker is present", () => {
+    const blocker = buildReviewThreadBlocker({
+      comments: [{ body: "<priority>P2</priority><title>Broken layout</title>", authorLogin: "carol", url: "https://gh/3" }],
+    });
+    expect(blocker).toMatchObject({
+      title: "Broken layout",
+      priority: "P2",
+      authorLogin: "carol",
+      url: "https://gh/3",
+      scannerFinding: false,
+    });
+  });
+
+  it("uses the first meaningful line as the title (skipping comment/details/summary/fence lines) and omits priority when none is present", () => {
+    const blocker = buildReviewThreadBlocker({
+      comments: [{ body: "<!-- hidden -->\n<details>\n<summary>context</summary>\n```\nUnresolved: needs a real fix here" }],
+    });
+    expect(blocker?.title).toBe("Unresolved: needs a real fix here");
+    expect(blocker).not.toHaveProperty("priority");
+  });
+
+  it("falls back to the literal \"review thread\" title when the body has no meaningful line", () => {
+    const blocker = buildReviewThreadBlocker({
+      comments: [{ body: "<!-- only a comment -->\n```\n```" }],
+    });
+    expect(blocker?.title).toBe("review thread");
+  });
+});
+
+describe("reviewThreadBlockerFinding", () => {
+  const base: ReviewThreadBlocker = { title: "Guard the null branch", scannerFinding: false };
+
+  it("prefixes the actor and priority and appends a path:line location when all are present", () => {
+    const finding = reviewThreadBlockerFinding({ ...base, authorLogin: "review-bot", priority: "P1", path: "src/app.ts", line: 12 });
+    expect(finding.code).toBe("review_thread_unresolved");
+    expect(finding.severity).toBe("critical");
+    expect(finding.title).toBe("review-bot review thread unresolved: P1 Guard the null branch (src/app.ts:12)");
+    expect(finding.detail).toContain("at src/app.ts:12");
+  });
+
+  it("uses a path-only location when the line is missing", () => {
+    const finding = reviewThreadBlockerFinding({ ...base, path: "src/app.ts" });
+    expect(finding.title).toBe("review thread unresolved: Guard the null branch (src/app.ts)");
+    expect(finding.detail).toContain("at src/app.ts");
+  });
+
+  it("uses a path-only location when the line is zero or not finite", () => {
+    expect(reviewThreadBlockerFinding({ ...base, path: "src/app.ts", line: 0 }).title).toBe(
+      "review thread unresolved: Guard the null branch (src/app.ts)",
+    );
+    expect(reviewThreadBlockerFinding({ ...base, path: "src/app.ts", line: Number.NaN }).title).toBe(
+      "review thread unresolved: Guard the null branch (src/app.ts)",
+    );
+  });
+
+  it("emits no actor, priority, or location when the blocker carries none of them (line without a path is ignored)", () => {
+    const finding = reviewThreadBlockerFinding({ ...base, line: 12 });
+    expect(finding.title).toBe("review thread unresolved: Guard the null branch");
+    expect(finding.detail).not.toContain(" at ");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #5846.

`buildReviewThreadBlocker` and `reviewThreadBlockerFinding` in `src/review/review-thread-findings.ts` turn unresolved GitHub review-thread comments into a gate-blocking advisory finding. Neither had a direct unit test - they were exercised only incidentally through the `src/github/backfill.ts` and `src/queue/processors.ts` call sites, which never hit most of the parsing branches, leaving the file at **56.82% branch coverage (25/44)**.

This adds `test/unit/review-thread-findings.test.ts`, importing both functions directly and covering the four requirement groups from the issue:

- **`buildReviewThreadBlocker`**: no-comments and all-empty/whitespace comments return `null`; a scanner-marker comment (`<!-- brin-pr-finding` / `superagent-finding-fingerprint:`) is picked over an earlier non-scanner comment, and `scannerFinding` is set to `true`/`false` accordingly.
- **`reviewThreadTitle`**: the markdown `**P1:** ...` path, the XML `<priority>/<title>` fallback, the first-meaningful-line fallback (skipping HTML-comment / `<details>` / `<summary>` / code-fence lines), and the literal `"review thread"` last-resort fallback.
- **`reviewThreadPriority`**: priority present (markdown and XML) vs. absent (omitted from the built blocker via the `...(priority ? { priority } : {})` spread).
- **`reviewThreadBlockerFinding` + `reviewThreadLocation`**: `path:line` vs. path-only vs. no-location; a zero / non-finite line falling back to path-only; and the actor / priority prefixes present vs. absent.

**Test-only, no production change.** The file goes from 56.82% to **100% line / 95.45% branch** coverage; the two residual branches are provably-dead `?? ""` fallbacks on comment bodies the earlier non-empty filter already guarantees.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #5846`).

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` - no workflow files touched.
- [x] `npm run typecheck`
- [x] `npm run test:coverage` (scoped) - ran the new suite under V8 coverage for `src/review/review-thread-findings.ts`; 11/11 tests pass, file at 100% line / 95.45% branch.
- [ ] `npm run test:workers` / `build:mcp` / `test:mcp-pack` / `ui:*` - not run: this change adds a single unit test file and touches no worker, MCP, or UI surface.
- [ ] `npm audit --audit-level=moderate` - no dependency changes.
- [x] New behavior has unit tests for new branches and fallback paths - this PR **is** that test coverage.

If any required check was skipped, explain why:

- Test-only change: no `src/**` lines are modified, so `codecov/patch` has no changed lines to score (it passes trivially, as on other test-only contributor PRs). The worker/MCP/UI suites are unaffected because no such code is touched.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, private keys, raw trust scores, private rankings, or maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized and low-noise.
- [x] Auth/cookie/CORS/GitHub App/Cloudflare/session changes include negative-path tests - n/a, none touched.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed - n/a.
- [x] UI changes use live API data - n/a, no UI change.
- [x] Visible UI changes include a `UI Evidence` section - n/a, no visible UI/frontend/docs/extension change.
- [x] Public docs/changelogs updated where needed - n/a.

## Notes

- `packages/loopover-engine/src/review/review-thread-findings.ts` only re-exports the `REVIEW_THREAD_BLOCKER_CODE` constant, so this gap is scoped entirely to `src/review/review-thread-findings.ts`.
