### PR TITLE
test(review): cover extractPreviewUrl host-matching and malformed-URL paths (#5848)

### DIFF
--- a/test/unit/preview-url.test.ts
+++ b/test/unit/preview-url.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { clearGitHubResponseCacheForTest, githubRateLimitAdmissionKeyForInstallation, latestGitHubRestRateLimitObservation } from "../../src/github/client";
-import { getPreviewBuildState } from "../../src/review/visual/preview-url";
+import { extractPreviewUrl, getPreviewBuildState } from "../../src/review/visual/preview-url";
 
 afterEach(() => {
   clearGitHubResponseCacheForTest();
@@ -44,5 +44,39 @@ describe("preview-url GitHub reads", () => {
       resetAt: "2026-06-24T12:10:00.000Z",
       observedAtMs: Date.parse("2026-06-24T12:00:00.000Z"),
     });
+  });
+});
+
+describe("extractPreviewUrl", () => {
+  it("returns null for null, undefined, or empty input", () => {
+    expect(extractPreviewUrl(null)).toBeNull();
+    expect(extractPreviewUrl(undefined)).toBeNull();
+    expect(extractPreviewUrl("")).toBeNull();
+  });
+
+  it("returns null when the text contains no URL at all", () => {
+    expect(extractPreviewUrl("no link here, just prose")).toBeNull();
+  });
+
+  it("returns null when the only URL is not a Cloudflare preview host", () => {
+    expect(extractPreviewUrl("see https://github.com/acme/widgets/pull/1 for details")).toBeNull();
+  });
+
+  it("skips a URL-like substring that fails to parse and falls through to null", () => {
+    expect(extractPreviewUrl("broken http://[not-a-valid-host link")).toBeNull();
+  });
+
+  it("keeps scanning past a non-matching URL to return a later *.workers.dev origin", () => {
+    expect(extractPreviewUrl("ref https://github.com/acme/widgets then https://widgets-preview.acme.workers.dev/home")).toBe(
+      "https://widgets-preview.acme.workers.dev",
+    );
+  });
+
+  it("matches a *.pages.dev host as well as *.workers.dev", () => {
+    expect(extractPreviewUrl("deploy: https://widgets.pages.dev/preview")).toBe("https://widgets.pages.dev");
+  });
+
+  it("matches the host case-insensitively and returns the bare origin without the path", () => {
+    expect(extractPreviewUrl("HTTPS://Widgets.WORKERS.DEV/some/path?x=1")).toBe("https://widgets.workers.dev");
   });
 });


### PR DESCRIPTION
## Summary

Closes #5848.

`extractPreviewUrl` in `src/review/visual/preview-url.ts` is a pure helper that pulls the first Cloudflare-preview (`*.workers.dev` / `*.pages.dev`) origin out of an arbitrary string. It had **zero direct unit tests** - the file's only existing test exercises the network-driven `getPreviewBuildState`, leaving the helper's host-matching and malformed-URL branches (the lowest-covered pure logic in the file, at **54.70% branch**) unverified.

This extends `test/unit/preview-url.test.ts` with an `extractPreviewUrl` `describe` block covering the seven cases from the issue:

1. `null` / `undefined` / `""` -> `null`.
2. A string with no URL at all -> `null`.
3. A string whose only URL is not a preview host -> `null`.
4. A malformed URL-like substring that throws inside `new URL(...)` -> skipped, falls through to `null`.
5. A non-matching URL **followed by** a `*.workers.dev` URL -> returns the matching one (proves the scan does not stop at the first match).
6. A `*.pages.dev` host -> matched.
7. Case-insensitive host matching (`HTTPS://Foo.WORKERS.DEV/path`) returning the bare origin (protocol + host, no path).

**Test-only, no production change.** Every branch of `extractPreviewUrl` (lines 145-161) is now exercised on both arms. The file's remaining async, network-driven functions are explicitly out of scope per the issue.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #5848`).

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint` - no workflow files touched.
- [x] `npm run typecheck`
- [x] `npm run test:coverage` (scoped) - ran `test/unit/preview-url.test.ts` under V8 coverage for `src/review/visual/preview-url.ts`; 8/8 tests pass and every `extractPreviewUrl` branch (lines 145-161) is covered on both arms (verified via the lcov per-branch report).
- [ ] `npm run test:workers` / `build:mcp` / `test:mcp-pack` / `ui:*` - not run: this change edits a single unit test file and touches no worker, MCP, or UI surface.
- [ ] `npm audit --audit-level=moderate` - no dependency changes.
- [x] New behavior has unit tests for new branches and fallback paths - this PR **is** that test coverage.

If any required check was skipped, explain why:

- Test-only change: no `src/**` lines are modified, so `codecov/patch` has no changed lines to score (it passes trivially, as on other test-only contributor PRs). The worker/MCP/UI suites are unaffected because no such code is touched.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, PATs, private keys, raw trust scores, private rankings, or maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized and low-noise.
- [x] Auth/cookie/CORS/GitHub App/Cloudflare/session changes include negative-path tests - n/a, none touched.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed - n/a.
- [x] UI changes use live API data - n/a, no UI change.
- [x] Visible UI changes include a `UI Evidence` section - n/a, no visible UI/frontend/docs/extension change.
- [x] Public docs/changelogs updated where needed - n/a.

## Notes

- Scoped to `extractPreviewUrl` only; the file's async `findPreviewUrlFromChecks` / `findPreviewUrlFromPrComments` / `getPreviewBuildState` network paths are left for a separate follow-up, as the issue notes.
