### PR TITLE
fix(test): stop hardcoding the current miner version as a golden value

### DIFF
--- a/test/unit/miner-cli.test.ts
+++ b/test/unit/miner-cli.test.ts
@@ -101,7 +101,10 @@ describe("loopover-miner CLI helpers", () => {
       "../../packages/loopover-miner/package.json",
       { with: { type: "json" } }
     );
-    expect(packageJson.default.version).toBe("2.0.0");
+    const { resolveMinerVersion } = await import(
+      "../../packages/loopover-miner/lib/version.js"
+    );
+    expect(resolveMinerVersion({})).toBe(packageJson.default.version);
   });
 });
 
@@ -318,9 +321,13 @@ describe("loopover-miner startup update check (#2331)", () => {
     );
   });
 
-  it("serves --version without blocking when update checks are disabled", () => {
+  it("serves --version without blocking when update checks are disabled", async () => {
+    const packageJson = await import(
+      "../../packages/loopover-miner/package.json",
+      { with: { type: "json" } }
+    );
     const output = runCapture(["--version", "--no-update-check"]);
-    expect(output).toContain("@loopover/miner/2.0.0");
+    expect(output).toContain(`@loopover/miner/${packageJson.default.version}`);
   });
 
   it("serves --help immediately without waiting for a slow registry check", async () => {


### PR DESCRIPTION
## Summary

- `test/unit/miner-cli.test.ts` had two tests that hardcoded the miner package's *current* real version (`"2.0.0"`) as a literal expectation, instead of comparing against the actual live `packages/loopover-miner/package.json` version. That means both tests were guaranteed to fail on every future miner version bump — confirmed live on the miner-v3.0.0 release PR (#5736).
- `packages/loopover-mcp`'s equivalent test (`mcp-cli-basics.test.ts:121`) already does this correctly (`` `@loopover/mcp/${mcpPackageJson.version}` ``, read dynamically). This PR matches that existing pattern for miner instead of inventing something new.
- Grepped `test/unit/*.test.ts` for the same anti-pattern elsewhere; everything else that hardcodes a semver-shaped literal is a synthetic fixture value passed into a pure function (e.g. `bumpVersion("0.4.2", ...)`, `apiVersion` which is a separate stable API-schema constant, not a package version) — this was the only real instance of a golden-pinned live package version.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue this PR resolves — maintainer PR fixing a test defect discovered live on #5736, no linked issue.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck` (after rebuilding `@loopover/engine`, whose `dist/` was stale in this worktree for an unrelated reason)
- [x] `npx vitest run test/unit/miner-cli.test.ts` — 24/24 passing
- [ ] `npm run test:coverage` — skipped; `test/**` is not measured by Codecov (`src/**` only), and no `src/` files changed.
- [ ] `npm run test:workers` / `npm run build:mcp` / `npm run test:mcp-pack` / `npm run ui:*` — skipped, unaffected by a single `test/unit/**` file change.
- [ ] `npm audit --audit-level=moderate` — skipped, no dependency changes.

If any required check was skipped, explain why:

- This change is scoped to one existing test file (`test/unit/miner-cli.test.ts`), no `src/`, dependency, or UI changes, so the full coverage/build/UI checks have no new surface to exercise. The affected test file itself was run directly and passes.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A.
- [ ] UI changes use live API data or real empty/error/loading states. — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section. — N/A, no UI changes.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — this PR does not touch `CHANGELOG.md`.

## Notes

- Discovered while triaging why the `miner` release-please PR (#5736) failed `validate-tests (2)` even after the engine-dependency-ordering issue was resolved.