### PR TITLE
fix(review): restore engine-parity after gittensory rename drift

### DIFF
--- a/packages/loopover-engine/src/review/guardrail-config.ts
+++ b/packages/loopover-engine/src/review/guardrail-config.ts
@@ -32,7 +32,7 @@ export const ENGINE_DECISION_GUARDRAIL_GLOBS = [
   "src/github/pr-actions.ts",
   "src/github/app.ts",
   "src/github/backfill.ts",
-  // #4197: writes a real commit onto a CONTRIBUTOR's own PR branch (not a branch gittensory owns) — the same
+  // #4197: writes a real commit onto a CONTRIBUTOR's own PR branch (not a branch loopover owns) — the same
   // guardrail tier as pr-actions.ts/app.ts for the same reason, a new GitHub-write surface.
   "src/github/e2e-test-commit.ts",
   "src/scoring/**",

--- a/packages/loopover-engine/src/review/linked-issue-label-propagation.ts
+++ b/packages/loopover-engine/src/review/linked-issue-label-propagation.ts
@@ -10,7 +10,7 @@ export type { LinkedIssueLabelPropagationConfig, LinkedIssueLabelPropagationMapp
 // (replaces the normal bug/feature type label, like priority does) or additive (applied alongside it).
 //
 // PURE config types + normalizer only — no GitHub/fetch/Env-dependent imports. `focus-manifest.ts`'s YAML
-// parser imports this module directly, and `focus-manifest.ts` is itself pulled into the gittensory-ui
+// parser imports this module directly, and `focus-manifest.ts` is itself pulled into the loopover-ui
 // workspace's isolated typecheck (via `apps/loopover-ui/src/lib/registration-workspace.ts`), which has no
 // visibility into the Worker's ambient `Env` type. The actual GitHub fetch orchestrator
 // (`fetchLinkedIssueLabelsForPropagation`) lives in `linked-issue-label-propagation-fetch.ts` instead, kept

--- a/test/unit/finding-taxonomy.test.ts
+++ b/test/unit/finding-taxonomy.test.ts
@@ -23,6 +23,6 @@ describe("finding taxonomy document", () => {
   });
 
   it("uses the stable MCP resource URI", () => {
-    expect(FINDING_TAXONOMY_URI).toBe("gittensory://finding-taxonomy");
+    expect(FINDING_TAXONOMY_URI).toBe("loopover://finding-taxonomy");
   });
 });


### PR DESCRIPTION
## Summary

- Urgent fix: PR #5883 (part of rebrand epic #5705) renamed brand-name prose in `src/review/guardrail-config.ts` and `src/review/linked-issue-label-propagation.ts` but not their byte-identical twins under `packages/loopover-engine/src/review/**`, which `scripts/check-engine-parity.ts` requires to stay in sync. This broke the parity check on `main` (verified by cloning a fresh `main` and running the script directly — 2 real failures).
- Aligns the two engine-side files' comment text with the host copies. No logic changes.
- Also fixes `test/unit/finding-taxonomy.test.ts`, which had a stale hardcoded assertion still expecting the pre-rename `"gittensory://finding-taxonomy"` MCP resource URI literal — the constant itself (`FINDING_TAXONOMY_URI`) was already correctly renamed by #5883; only this one test's pinned expectation had drifted. Every other consumer of this constant imports the symbol, so nothing else was affected.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue this PR resolves — N/A, maintainer-authored hotfix restoring a check broken by an earlier same-day rebrand-cleanup PR (#5705/#5883), no linked-issue gate applies to owner PRs.

## Validation

- [x] `git diff --check`
- [x] `npx tsx scripts/check-engine-parity.ts` — confirms ok (was failing on `main` before this fix)
- [x] `npm run test:coverage` — full unsharded run, 100% green
- [x] Full `npm run test:ci` gate run locally, exit 0

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no such changes.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, comment-only + test-assertion fix, no behavior change.
- [ ] UI changes use live API data or real empty/error/loading states. — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section. — N/A, no UI changes.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs (none touched here).

## Notes

- This is a priority fix for a break on `main`, not part of the normal batched-PR sequence for epic #5705.