### PR TITLE
fix/issue 5840

### DIFF
--- a/src/signals/extension-contributor-context.ts
+++ b/src/signals/extension-contributor-context.ts
@@ -1,4 +1,5 @@
 import type { ContributorOpportunity, PublicReadinessScore } from "./engine";
+import { PUBLIC_UNSAFE_TERMS } from "./redaction";
 
 // ─── Contributor-context payloads for the browser extension (#556) ───────────────────────────────
 // The contributor (miner) side of the extension overlay. Every payload here is PUBLIC-SAFE and self-
@@ -20,9 +21,13 @@ export function contributorReadinessBand(total: number): ContributorReadinessBan
 // Defense-in-depth public-safe redaction for any free-form text that reaches the contributor overlay.
 // The upstream builders are already contributor-facing, but every string is re-checked here and any
 // forbidden private term (reward/wallet/key material/raw trust score/etc.) is redacted rather than
-// leaked. Kept local (no import) so this module stays cycle-free and the API never 500s on a stray term.
-const FORBIDDEN_EXTENSION_TERMS =
-  /\b(?:rewards?|payouts?|farming|wallets?|hotkeys?|coldkeys?|seed[-\s]?phrases?|mnemonics?|private[-\s]?keys?|raw[-\s]?trust(?:[-\s]?scores?)?|trust[-\s]?scores?|score[-\s]?(?:estimate|preview|prediction)s?|estimated[-\s]?scores?|scoreability|private[-\s]?reviewability|reviewability[-\s]?internals?|private[-\s]?rankings?)\b/gi;
+// leaked. Composed from the canonical `PUBLIC_UNSAFE_TERMS` alternation (redaction.ts) plus a couple of
+// extension-only terms that aren't part of that shared vocabulary, so this list can't silently drift
+// from the canonical public/private boundary again (#5840). Only the plain string constant is imported
+// (not the whole redaction module), and redaction.ts has no imports of its own, so this stays cycle-free.
+const FORBIDDEN_EXTENSION_ONLY_TERMS = String.raw`seed[-\s]?phrases?|private[-\s]?keys?`;
+
+const FORBIDDEN_EXTENSION_TERMS = new RegExp(String.raw`\b(?:${PUBLIC_UNSAFE_TERMS}|${FORBIDDEN_EXTENSION_ONLY_TERMS})\b`, "gi");
 
 export function redactExtensionText(text: string): string {
   return text.replace(FORBIDDEN_EXTENSION_TERMS, "[redacted]").replace(/\s+/g, " ").trim();

--- a/test/unit/extension-contributor-context.test.ts
+++ b/test/unit/extension-contributor-context.test.ts
@@ -6,9 +6,11 @@ import {
   contributorReadinessBand,
   redactExtensionText,
 } from "../../src/signals/extension-contributor-context";
+import { isPublicSafeText } from "../../src/signals/redaction";
 import type { ContributorOpportunity, PublicReadinessScore } from "../../src/signals/engine";
 
-const FORBIDDEN_PUBLIC_TERMS = /wallet|hotkey|coldkey|mnemonic|reward|payout|farming|raw trust|trust score|scoreability|reviewability internals|private ranking/i;
+const FORBIDDEN_PUBLIC_TERMS =
+  /wallet|hotkey|coldkey|mnemonic|reward|payout|farming|raw trust|trust score|scoreability|reviewability|cohort|ranking|miner-originated|human-originated/i;
 
 function opportunity(over: Partial<ContributorOpportunity> = {}): ContributorOpportunity {
   return {
@@ -58,6 +60,52 @@ describe("redactExtensionText", () => {
 
   it("leaves safe text untouched", () => {
     expect(redactExtensionText("Maintainer-created issue, good fit.")).toBe("Maintainer-created issue, good fit.");
+  });
+
+  it("redacts a bare cohort reference (#5840)", () => {
+    expect(redactExtensionText("Cohort diagnostics flagged this PR")).toBe("[redacted] diagnostics flagged this PR");
+  });
+
+  it("redacts a bare ranking reference (#5840)", () => {
+    expect(redactExtensionText("Your ranking dropped this week")).toBe("Your [redacted] dropped this week");
+  });
+
+  it("redacts miner-originated and human-originated (#5840)", () => {
+    expect(redactExtensionText("This looks miner-originated, not human-originated")).toBe(
+      "This looks [redacted], not [redacted]",
+    );
+  });
+
+  it("redacts a standalone reviewability reference, not just the compound phrases (#5840)", () => {
+    expect(redactExtensionText("Reviewability is limited right now")).toBe("[redacted] is limited right now");
+  });
+});
+
+describe("FORBIDDEN_EXTENSION_TERMS drift guard (#5840)", () => {
+  it("redacts a representative sample of every canonical PUBLIC_UNSAFE_TERMS entry, so this module can't silently drift from the shared public/private boundary again", () => {
+    const samples = [
+      "Your reward is pending.",
+      "Your score is pending.",
+      "Check your wallet balance.",
+      "Rotate your hotkey.",
+      "Rotate your coldkey.",
+      "Keep the mnemonic safe.",
+      "The payout is scheduled.",
+      "Your ranking dropped this week.",
+      "Cohort diagnostics flagged this PR.",
+      "This looks miner-originated, not human-originated.",
+      "We detected farming behavior.",
+      "This uses raw trust internally.",
+      "The trust score moved.",
+      "This is private reviewability data.",
+      "Reviewability is limited right now.",
+    ];
+
+    for (const sample of samples) {
+      // Sanity check: confirm the sample really is flagged unsafe by the canonical pattern.
+      expect(isPublicSafeText(sample)).toBe(false);
+      expect(isPublicSafeText(redactExtensionText(sample))).toBe(true);
+    }
   });
 });
 


### PR DESCRIPTION
- **docs(miner): AMS storage-abstraction research — datastore backend comparison (#5760)**
- **fix(rebrand): full-cutover rename remaining internal gittensory runtime identifiers (#5761)**
- **refactor(engine): extract the pull-request-target-key parser into loopover-engine (#5762)**
- **docs(miner): AMS auth/identity research — hosted login-layer options (#5764)**
- **fix(rebrand): full-cutover rename miner/AMS per-repo and operator config filenames (#5765)**
- **feat(api): add post-merge incident reporting for already-merged PRs (#5766)**
- **fix(review): trim the Improvement signal row to a concise value rating (#5767)**
- **fix(rebrand): full-cutover rename Prometheus/Alertmanager/Grafana observability identifiers (#5768)**
- **feat(review): add a shared beta-collapsible convention for the PR comment (#5769)**
- **docs(engine): verify git mv rename recognition in coverage tooling (#5770)**
- **fix(review): never render a ❌ for a non-Gittensor contributor (#5100) (#5774)**
- **feat(engine): extract content-lane's pure leaf modules to loopover-engine (#5775)**
- **fix(api): audit registered-vs-installed dashboard/digest copy (#5026) (#5776)**
- **feat(engine): extract settings leaf modules to loopover-engine (#5779)**
- **refactor(engine): move the unlinked-issue candidate pre-filter into the shared engine (#5778)**
- **feat(engine): add a load-testing harness for iterate-loop under concurrent load (#5781)**
- **docs(spec): idea-intake bridge schema (#5783)**
- **docs(engine): document the deliberate gate-advisory twin divergence (#5784)**
- **feat(selfhost): optional Infisical secrets management for self-host deploys (#5785)**
- **refactor(queue): extract the public-comment merge-facts derivation from maybePublishPrPublicSurface (#4607) (#5787)**
- **feat(review): add aggregate fix-handoff block renderer (#5788)**
- **feat(miner): pre-execution feasibility check for freeform ideas (#5789)**
- **feat(review): synthesize the 'Contributor next steps' collapsible into a prioritized step (#5791)**
- **feat(mcp): add the idea-intake bridge and loopover_intake_idea tool (#5792)**
- **feat(miner): add cross-repo evaluation harness (#4788) (#5790)**
- **docs(selfhost): design doc for the scheduled docs-drift audit sweep (#3048) (#5794)**
- **feat(mcp): route ideas through intake into a loop claim plan (#5795)**
- **feat(mcp): deliver a completed loop iteration as a customer results payload (#5797)**
- **feat(mcp): stream loop progress to the customer via a progress snapshot (#5798)**
- **refactor(engine): extract signals engine with re-export shim (#4884) (#5800)**
- **feat(engine): per-tenant resource quota evaluation (#5801)**
- **feat(mcp): evaluate when a rented loop should escalate to a human (#5806)**
- **docs(engine): document the nine governor primitives in the package README (#5851)**
- **docs(gardening): correct contributor-available target to per-repo, not combined (#5808)**
- **fix(signals): require a code file before manifest_missing_tests fires (#5852)**
- **fix(miner): list queue dashboard in cli.js help text (#5853)**
- **docs: privacy audit of AMS telemetry/export surfaces for cross-tenant leakage (#5759)**
- **feat(selfhost): add n8n workflows and MinIO object storage compose profiles (#1219) (#5777)**
- **feat(miner): honor kill-switch mid-attempt during iterate-loop (#5799)**
- **feat(engine): per-tenant configuration layer (#5804)**
- **feat(selfhost): bridge fleet-mode miner state to the ams-observability exporter (#5844)**
- **docs(engine): add a Tenant quota README section (#5860)**
- **fix(engine): clamp rate-limit retryAfterMs to at most one window on a backward clock (#5855)**
- **fix(review): recognize export const enum and abstract class in impact-symbols (#5858)**
- **test(review): cover review-diff.ts non-positive-budget guard and header count defaults (#5857)**
- **fix(ci): sync miner engine-version pin on the engine release branch (#5856)**
- **test(selfhost): cover jobCoalesceKey missing-field fallbacks for 6 job types (#5862)**
- **fix(queue): cap backlog-convergence re-review attempts per head SHA (#5859)**
- **docs(engine): document the Rent-a-Loop pipeline modules (#5868)**
- **fix(review): exclude maintainer PRs from the slop-discrimination alert (#5863)**
- **test(miner): rename gittensory-miner/ams prose to loopover-miner/ams (#5874)**
- **chore(release): cut engine v3.1.0 (#5807)**
- **test(miner): rename gittensory-miner/ams prose to loopover-miner/ams (batch 2) (#5878)**
- **docs(ui): rename gittensory prose to loopover across docs routes (#5881)**
- **docs(review): rename gittensory prose to loopover in src/review (batch A) (#5883)**
- **chore(release): cut mcp v2.0.0 (#5735)**
- **fix(review): restore engine-parity after gittensory rename drift (#5892)**
- **fix(signals): compose extension redaction terms from PUBLIC_UNSAFE_TERMS**
