### PR TITLE
docs(core): rename gittensory prose to loopover in remaining src subdirs

### DIFF
--- a/.loopover.yml
+++ b/.loopover.yml
@@ -83,7 +83,7 @@ review:
 # gittensor:priority at once); resolvePrTypeLabel composes every additive match alongside the one exclusive
 # winner, rather than the two categories competing for a single slot.
 #
-# Review-evasion protection: closing or converting-to-draft your OWN PR while gittensory has an active
+# Review-evasion protection: closing or converting-to-draft your OWN PR while loopover has an active
 # review pass running, a prior recorded gate failure, or a repeated ready<->draft cycle on this PR, is
 # treated as dodging the one-shot review rather than an ordinary action (layered OVER the dashboard's
 # own default of "off").

--- a/apps/loopover-ui/public/openapi.json
+++ b/apps/loopover-ui/public/openapi.json
@@ -16944,7 +16944,7 @@
           {
             "schema": {
               "type": "string",
-              "example": "JSONbored/gittensory"
+              "example": "JSONbored/loopover"
             },
             "required": false,
             "description": "Optional repository filter. Browser sessions must have control-panel access to this repo.",

--- a/packages/loopover-engine/src/settings/autonomy.ts
+++ b/packages/loopover-engine/src/settings/autonomy.ts
@@ -1,7 +1,7 @@
 import type { AgentActionClass, AutoMaintainPolicy, AutoMergeMethod, AutonomyLevel, AutonomyPolicy } from "../types/manifest-deps-types.js";
 
 // The graduated autonomy dial (#773), ordered least → most autonomous. Every later agent-layer phase reads
-// this BEFORE acting. `observe` is the deny-by-default floor — gittensory watches but never takes an action.
+// this BEFORE acting. `observe` is the deny-by-default floor — loopover watches but never takes an action.
 // (#4620: `suggest`/`propose` removed -- both were 100% behaviorally identical to `observe`, see
 // AutonomyLevel's own doc comment.)
 export const AUTONOMY_LEVELS = ["observe", "auto_with_approval", "auto"] as const;
@@ -22,7 +22,7 @@ const AUTONOMY_LEVEL_SET = new Set<string>(AUTONOMY_LEVELS);
 /**
  * Resolve the configured autonomy level for one action class on a repo. THE single gate the action layer
  * (#778) consults before any write action. Deny-by-default: an unset (or malformed) action class is
- * `observe` — gittensory observes but never acts. Pure.
+ * `observe` — loopover observes but never acts. Pure.
  */
 export function resolveAutonomy(autonomy: AutonomyPolicy | null | undefined, actionClass: AgentActionClass): AutonomyLevel {
   return autonomy?.[actionClass] ?? DEFAULT_AUTONOMY_LEVEL;

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -2463,7 +2463,7 @@ export function createApp() {
     );
   });
 
-  // Repo gittensory settings (gate config, AI-review mode/provider/model — NON-secret; the BYOK key is
+  // Repo loopover settings (gate config, AI-review mode/provider/model — NON-secret; the BYOK key is
   // never here). Maintainer DATA: session callers must be a verified maintainer of THIS repo (per-repo
   // scope), so a maintainer of repo A cannot read repo B's config. Server-to-server tokens are exempt.
   app.get("/v1/repos/:owner/:repo/settings", async (c) => {
@@ -3691,7 +3691,7 @@ export function createApp() {
 
   // #predicted-live-gate-agreement (maintainer review-stack x AMS integration audit, 2026-07-09): how often the
   // MCP predict_gate/explain_gate_disposition verdict agrees with the REAL gate decision a contributor's PR
-  // later receives -- a DIFFERENT question than /v1/internal/parity's reviewbot-vs-gittensory migration parity
+  // later receives -- a DIFFERENT question than /v1/internal/parity's reviewbot-vs-loopover migration parity
   // (see src/review/predicted-gate-agreement.ts's module header). Same gate/auth contract as /v1/internal/parity:
   // bearer-gated by the `/v1/internal/*` middleware, 404 when LOOPOVER_REVIEW_PARITY_AUDIT is off so the
   // endpoint does not exist on a deploy not running this telemetry family. Aggregate counts only — no PR
@@ -5843,7 +5843,7 @@ const DEFAULT_CORS_ORIGINS = [
   "http://localhost:3000",
   "http://localhost:4173",
   "http://localhost:5173",
-  // gittensory-ui's dev server (@lovable.dev/vite-tanstack-config) binds 8080, not Vite's 5173 default —
+  // loopover-ui's dev server (@lovable.dev/vite-tanstack-config) binds 8080, not Vite's 5173 default —
   // without this, every local/preview dev server is CORS-blocked from /health and shows a false "API unreachable" banner.
   "http://localhost:8080",
   "http://127.0.0.1:3000",

--- a/src/auth/github-oauth.ts
+++ b/src/auth/github-oauth.ts
@@ -170,7 +170,7 @@ export async function createSessionFromGitHubToken(
 ): Promise<{ token: string; login: string; expiresAt: string; scopes: string[] }> {
   // A caller-supplied token (the github_token_exchange route) carries no proof it was minted for THIS
   // OAuth app. Without an audience check, any token a victim issued to an unrelated app would mint a
-  // gittensory session as that login. The device/web flows skip this — they minted the token themselves.
+  // loopover session as that login. The device/web flows skip this — they minted the token themselves.
   if (options.verifyAppAudience && !(await verifyTokenBelongsToApp(env, githubToken))) {
     await recordAuditEvent(env, {
       eventType: "auth.github_session",

--- a/src/config/gittensory-repo-focus-manifest.ts
+++ b/src/config/gittensory-repo-focus-manifest.ts
@@ -1,5 +1,5 @@
 /**
- * Bundled fallback for JSONbored/gittensory when the repo file is not yet reachable
+ * Bundled fallback for JSONbored/loopover when the repo file is not yet reachable
  * (local dev, pre-merge branches). Keep aligned with `.loopover.yml` at repo root.
  */
 export const LOOPOVER_REPO_FOCUS_MANIFEST_YAML = `# LoopOver repo focus manifest — machine-readable contributor policy for this project.
@@ -87,7 +87,7 @@ review:
 # gittensor:priority at once); resolvePrTypeLabel composes every additive match alongside the one exclusive
 # winner, rather than the two categories competing for a single slot.
 #
-# Review-evasion protection: closing or converting-to-draft your OWN PR while gittensory has an active
+# Review-evasion protection: closing or converting-to-draft your OWN PR while loopover has an active
 # review pass running, a prior recorded gate failure, or a repeated ready<->draft cycle on this PR, is
 # treated as dodging the one-shot review rather than an ordinary action (layered OVER the dashboard's
 # own default of "off").
@@ -127,7 +127,7 @@ maintainerNotes:
   - Cosmetic UI-only polish without API wiring or maintainer-approved issue context should be redirected to backend or operator-facing work.
 `;
 
-export const GITTENSOR_SELF_REPO_DEFAULT = "JSONbored/gittensory";
+export const GITTENSOR_SELF_REPO_DEFAULT = "JSONbored/loopover";
 
 export function resolveLoopOverSelfRepoFullName(env: { LOOPOVER_DRIFT_ISSUE_REPO?: string }): string {
   const configured = env.LOOPOVER_DRIFT_ISSUE_REPO?.trim();

--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -3551,7 +3551,7 @@ export async function countByokAiEventsForRepoSince(env: Env, repoFullName: stri
 }
 
 /**
- * #hosted-ai-usage-observability: the ONLY AI activity the HOSTED gittensory-api Worker can ever have is a
+ * #hosted-ai-usage-observability: the ONLY AI activity the HOSTED loopover-api Worker can ever have is a
  * maintainer's own BYOK call (the legacy Workers-AI-binding path is retired; `env.AI` is undefined there) --
  * yet nothing previously read back the real token/cost columns migration 0109 added to `ai_usage_events` for
  * the hosted deployment specifically (the one dashboard built for this, orb-ai-usage.json, is wired
@@ -5413,7 +5413,7 @@ export async function getGateBlockOutcome(
   return { headSha: row.headSha, blockerCodes: parseJson<string[]>(row.blockerCodesJson, []), overridden: row.overridden };
 }
 
-// Review-evasion protection (#review-evasion-protection): idempotently mark that gittensory started a fresh
+// Review-evasion protection (#review-evasion-protection): idempotently mark that loopover started a fresh
 // review pass for repoFullName#pullNumber at headSha, BEFORE any cost-bearing AI-review work begins. A
 // redelivery/retry for the SAME headSha while the row is still active is a true no-op (startedAt/deliveryId
 // are preserved); a NEW headSha (a fresh commit) or a previously-terminalized row is overwritten with fresh
@@ -5449,7 +5449,7 @@ export async function startActiveReviewTracking(
     });
 }
 
-// Review-evasion protection: whether gittensory has an ACTIVE review pass recorded for this EXACT
+// Review-evasion protection: whether loopover has an ACTIVE review pass recorded for this EXACT
 // repo/PR/headSha -- the read side the closed/converted_to_draft evasion guards check before treating a
 // contributor's action as evasion. A row for a DIFFERENT headSha (or a terminalized row) does not count --
 // the active window is scoped to the specific commit under review.
@@ -6202,7 +6202,7 @@ function toPullRequestRecordFromRow(row: typeof pullRequests.$inferSelect): Pull
     mergeBlockedSha: row.mergeBlockedSha,
     mergeBlockedReason: row.mergeBlockedReason,
     approvedHeadSha: row.approvedHeadSha,
-    // Read straight from the row, NEVER the GitHub payload — this is a gittensory-internal sweep marker.
+    // Read straight from the row, NEVER the GitHub payload — this is a loopover-internal sweep marker.
     lastRegatedAt: row.lastRegatedAt,
     lastPublishedSurfaceSha: row.lastPublishedSurfaceSha,
     linkedIssueHardRuleViolatedAt: row.linkedIssueHardRuleViolatedAt,
@@ -7593,7 +7593,7 @@ function normalizeReviewNagPolicy(value: string | null | undefined): "off" | "ho
 // #4011: default-ON, the deliberate exception to every other field in this file defaulting conservatively
 // (off/false/advisory). A repo that hasn't discovered and explicitly set this field got ZERO self-close/
 // draft-dodge/repeated-cycling protection under the old "off" default -- a real, already-exploited gaming
-// vector (see gittensory-ai-review-repeat-spend-and-draft-gaming-fix). Any value other than the explicit
+// vector (see loopover-ai-review-repeat-spend-and-draft-gaming-fix). Any value other than the explicit
 // opt-out "off" (including undefined/garbage) now resolves to "close": protected unless a repo deliberately
 // turns it off, not unprotected unless a repo discovers and turns it on. This is the ONLY reachable default
 // for this field -- the raw schema.ts column-level DEFAULT and the SQLite DDL default are never reached by

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -12,7 +12,7 @@ export const installations = sqliteTable("installations", {
   accountId: integer("account_id").notNull(),
   // The GitHub App this installation belongs to (#selfhost-app-id). Nullable: only `installation` events (and
   // the App-installation API refresh) carry it, so existing rows backfill lazily. Lets a backend tell its OWN
-  // installations from a SECOND gittensory App installed on the same account (cloud + self-host side by side).
+  // installations from a SECOND loopover App installed on the same account (cloud + self-host side by side).
   appId: integer("app_id"),
   targetType: text("target_type").notNull(),
   repositorySelection: text("repository_selection"),
@@ -80,7 +80,7 @@ export const repositorySettings = sqliteTable("repository_settings", {
   // Linked-issue satisfaction gate (#1961/#3906). off = the assessment never runs (byte-identical to today,
   // and the default); advisory = it runs and renders in the comment but never blocks; block = an above-
   // confidence-floor "unaddressed" verdict additionally becomes a hard blocker. See src/rules/advisory.ts's
-  // isConfiguredGateBlocker (linked_issue_scope_mismatch) and gittensory-gate-setting-wiring for the pattern.
+  // isConfiguredGateBlocker (linked_issue_scope_mismatch) and loopover-gate-setting-wiring for the pattern.
   linkedIssueSatisfactionGateMode: text("linked_issue_satisfaction_gate_mode").notNull().default("off"),
   firstTimeContributorGrace: integer("first_time_contributor_grace", { mode: "boolean" }).notNull().default(false),
   slopGateMinScore: integer("slop_gate_min_score"),
@@ -453,38 +453,38 @@ export const pullRequests = sqliteTable(
     linkedIssueClaimedAt: text("linked_issue_claimed_at"),
     lastSeenOpenAt: text("last_seen_open_at"),
     payloadJson: text("payload_json").notNull().default("{}"),
-    // Latest deterministic slop assessment (gittensory-computed; written separately from the GitHub sync).
+    // Latest deterministic slop assessment (loopover-computed; written separately from the GitHub sync).
     slopRisk: integer("slop_risk"),
     slopBand: text("slop_band"),
     // RC3 terminal-fail merges: failed-merge attempt count + the head SHA at which the merge is terminally
     // blocked (perms/required-check/conflict) so the planner stops planning a merge. Keyed to head SHA → a new
-    // commit auto-clears it. gittensory-computed (executor-written), omitted from the GitHub-sync SET clause.
+    // commit auto-clears it. loopover-computed (executor-written), omitted from the GitHub-sync SET clause.
     mergeAttemptCount: integer("merge_attempt_count").notNull().default(0),
     mergeBlockedSha: text("merge_blocked_sha"),
     mergeBlockedReason: text("merge_blocked_reason"),
     // Review-evasion: repeated ready<->draft cycling (#gaming-tactic-draft-cycle). Counts every converted_to_draft
     // webhook ever processed for this PR NUMBER -- deliberately NOT scoped to head SHA like mergeAttemptCount,
     // since cycling back to draft after a fresh push is exactly the same evasion shape a new commit must not
-    // reset. gittensory-computed (webhook-written), omitted from the GitHub-sync SET clause.
+    // reset. loopover-computed (webhook-written), omitted from the GitHub-sync SET clause.
     draftConversionCount: integer("draft_conversion_count").notNull().default(0),
     // Re-approval idempotency: the head SHA the bot last auto-approved. The planner skips the `approve`
     // disposition while approved_head_sha == headSha (this commit is already approved). Keyed to head SHA → a
-    // new commit makes the bot re-approve the new code. gittensory-computed (executor-written), omitted from
+    // new commit makes the bot re-approve the new code. loopover-computed (executor-written), omitted from
     // the GitHub-sync SET clause so a later sync cannot clobber it. (Mirrors merge_blocked_sha.)
     approvedHeadSha: text("approved_head_sha"),
     // Sweep convergence: the timestamp the scheduled re-gate sweep last recomputed this PR. selectRegateCandidates
     // orders the sweep by THIS marker (not GitHub's updated_at) so it advances through all open PRs even when the
-    // review WRITE that would bump updated_at is suppressed (dry-run / paused). gittensory-computed (sweep-written),
+    // review WRITE that would bump updated_at is suppressed (dry-run / paused). loopover-computed (sweep-written),
     // omitted from the GitHub-sync SET clause so a later sync cannot clobber it. (Mirrors approved_head_sha.)
     lastRegatedAt: text("last_regated_at"),
     // Draining guard for backlog-convergence-sweep (#4502), mirroring lastRegatedAt but scoped to THIS sweep --
     // stamped at dispatch by sweepRepoBacklogConvergence, read by fanOutBacklogConvergenceSweepJobs to skip a
     // repo whose prior fan-out is still draining. Kept separate from lastRegatedAt so the two differently-cadenced
-    // sweeps' in-flight signals never conflate. gittensory-computed, omitted from the GitHub-sync SET clause.
+    // sweeps' in-flight signals never conflate. loopover-computed, omitted from the GitHub-sync SET clause.
     lastBacklogConvergenceRegatedAt: text("last_backlog_convergence_regated_at"),
     // Public-surface marker: the head SHA at which the public surface (comment/label/check-run) was LAST published.
     // Used for reporting and stale-surface diagnostics, not as a hard sweep skip; GitHub comments/checks can still
-    // be stale or partial while this marker matches headSha. gittensory-computed (publish-written), omitted from
+    // be stale or partial while this marker matches headSha. loopover-computed (publish-written), omitted from
     // the GitHub-sync SET clause so a later sync cannot clobber it. (Mirrors approved_head_sha.)
     lastPublishedSurfaceSha: text("last_published_surface_sha"),
     // Linked-issue hard-rule violation memory (#linked-issue-hard-rule-persistence). The FIRST time this PR NUMBER
@@ -494,7 +494,7 @@ export const pullRequests = sqliteTable(
     // ADDITIONALLY alongside resolveLinkedIssueHardRule's own live re-parse so a contributor cannot dodge the
     // flag-then-close verification window by stripping the closing reference from the body, or by the linked
     // issue's live state changing (e.g. unassigned), between the flagging pass and the verification pass.
-    // gittensory-computed (planner-written), omitted from the GitHub-sync SET clause so a later sync cannot clobber
+    // loopover-computed (planner-written), omitted from the GitHub-sync SET clause so a later sync cannot clobber
     // it.
     linkedIssueHardRuleViolatedAt: text("linked_issue_hard_rule_violated_at"),
     // The specific rule reason text captured at the moment of the FIRST violation (mirrors merge_blocked_reason's
@@ -506,7 +506,7 @@ export const pullRequests = sqliteTable(
     // shot) for this PR. Lets the deterministic screenshotTableGate treat a successful automated capture as
     // equivalent evidence to a hand-authored before/after table. Keyed to head SHA (mirrors approved_head_sha /
     // last_published_surface_sha) -- a new commit re-arms the requirement until capture succeeds again for the
-    // new head. gittensory-computed (publish-written), omitted from the GitHub-sync SET clause so a later sync
+    // new head. loopover-computed (publish-written), omitted from the GitHub-sync SET clause so a later sync
     // cannot clobber it.
     visualCaptureSatisfiedSha: text("visual_capture_satisfied_sha"),
     createdAt: text("created_at").notNull().$defaultFn(() => nowIso()),
@@ -819,7 +819,7 @@ export const gateOutcomes = sqliteTable(
 );
 
 // Review-evasion active-review tracking (#review-evasion-protection): one row per (repo, PR), recording that
-// gittensory started a fresh review pass against a specific headSha before any cost-bearing AI-review work
+// loopover started a fresh review pass against a specific headSha before any cost-bearing AI-review work
 // begins. Read by the closed/converted_to_draft webhook handlers to tell a contributor evading the one-shot
 // review mid-pass apart from an ordinary close/draft conversion after the review already concluded. `status`
 // flips 'active' -> 'terminal' once the pass concludes (published, PR closed/merged, head moved, or evasion

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -164,7 +164,7 @@ declare global {
     /** Webhook secret for the central LoopOver Orb GitHub App (#1255) — distinct from the review app's
      *  GITHUB_WEBHOOK_SECRET. Verifies inbound POST /v1/orb/webhook deliveries. Inject as a wrangler secret. */
     ORB_GITHUB_WEBHOOK_SECRET?: string;
-    /** The central Orb GitHub App's OWN credentials (separate from the gittensory review App above). Inject as
+    /** The central Orb GitHub App's OWN credentials (separate from the loopover review App above). Inject as
      *  wrangler secrets. Used to mint the Orb App JWT → list installations + mint short-lived installation tokens
      *  (the token-broker). CLIENT_ID/SECRET drive the OAuth onboarding flow. */
     ORB_GITHUB_APP_ID?: string;
@@ -179,7 +179,7 @@ declare global {
      *  key. Cloud never sets it ⇒ inert there. See src/orb/broker-client. (A secret — never commit a real value.) */
     ORB_ENROLLMENT_SECRET?: string;
     /** Override the Orb broker base URL the self-host client calls (default https://api.loopover.ai);
-     *  point at a private gittensory deployment if you self-host the broker too. */
+     *  point at a private loopover deployment if you self-host the broker too. */
     ORB_BROKER_URL?: string;
     /** The retired review App's own credentials. Optional: that App has been fully deleted — cloud no longer
      *  mints tokens or verifies check-run ownership with it (review execution is self-host-only now, brokered
@@ -220,7 +220,7 @@ declare global {
     LOOPOVER_AUTO_FILE_DRIFT_ISSUES?: string;
     LOOPOVER_DRIFT_ISSUE_REPO?: string;
     LOOPOVER_DRIFT_ISSUE_TOKEN?: string;
-    /** Comma-separated GitHub logins assigned to filed upstream-drift issues (default: the gittensory
+    /** Comma-separated GitHub logins assigned to filed upstream-drift issues (default: the loopover
      *  maintainer). Lets a self-host operator route drift issues to their own team. */
     LOOPOVER_DRIFT_ISSUE_ASSIGNEES?: string;
     /** Comma-separated GitHub bot logins ADDITIONALLY trusted to author review-thread blockers via scanner
@@ -357,7 +357,7 @@ declare global {
      *  unset/false reads NO reputation, records NOTHING, and leaves the AI-spend gate byte-identical (the new
      *  branch is unreachable when off). */
     LOOPOVER_REVIEW_REPUTATION?: string;
-    /** Convergence (ops / observability): when truthy, gittensory's OWN review-outcome data drives two
+    /** Convergence (ops / observability): when truthy, loopover's OWN review-outcome data drives two
      *  operator surfaces — (1) on the cron tick, an anomaly scan over the gate-block ledger + recommendation /
      *  slop calibration emits a structured `ops_anomaly` log when something drifts (gate false-positive spike,
      *  slop score inverting, a recommendation negative-rate spike); and (2) a bearer-gated
@@ -423,7 +423,7 @@ declare global {
      *  reviewer; a generic hard blocker (e.g. a committed secret) is always preserved over a surface "merge". */
     LOOPOVER_REVIEW_CONTENT_LANE?: string;
     /** Convergence (self-improve / auto-tune): when truthy, the ported self-improvement loop
-     *  (src/review/auto-tune.ts + auto-apply.ts) runs on the cron tick over gittensory's OWN review-outcome
+     *  (src/review/auto-tune.ts + auto-apply.ts) runs on the cron tick over loopover's OWN review-outcome
      *  data — it computes tuning recommendations, SHADOW-SOAKS any STRICTLY-TIGHTENING recommendation in the
      *  `tunables_overrides_shadow` table, and AUTO-PROMOTES it to `tunables_overrides` ONLY after the soak
      *  window passes the gate (tightening + evidence + soaked). Every action is recorded to `override_audit`.
@@ -431,20 +431,20 @@ declare global {
      *  (isStrictlyTightening + evaluateShadowPromotion enforce the direction). Default OFF — unset/false means
      *  the cron enqueues NO selftune job (does ZERO tuning work, reads/writes NO override), so the worker is
      *  byte-identical to today. NOTE: config-application is DEFERRED — a promoted override is NOT yet read by
-     *  the live gate-config resolution (gittensory has no confidenceFloor/scopeCap tunable and its native
+     *  the live gate-config resolution (loopover has no confidenceFloor/scopeCap tunable and its native
      *  signal measures gate false positives, a loosening direction); the shadow-soak + audit + recommendation
      *  recording are wired, reading a promoted override into the live gate is a noted follow-up that must not
      *  risk loosening the gate. See src/review/selftune-wire.ts. */
     LOOPOVER_REVIEW_SELFTUNE?: string;
     /** Experimental `gittensor` plugin (the `experimental:` manifest block, first key): the operator-level
-     *  kill-switch for gittensory's original subnet mining-registry/scoring integration, now opt-in rather than
+     *  kill-switch for loopover's original subnet mining-registry/scoring integration, now opt-in rather than
      *  a core dependency. ANDed with the per-repo `.loopover.yml experimental.gittensor` opt-in -- neither
      *  alone is sufficient, and unlike `features:` there is no LOOPOVER_REVIEW_REPOS allowlist fallback.
      *  Default OFF -- flag-OFF (or every repo unset), refresh-registry is never enqueued (see src/index.ts) and
      *  a self-host box makes zero outbound contact with the gittensor subnet registry. See
      *  src/review/gittensor-wire.ts. */
     LOOPOVER_EXPERIMENTAL_GITTENSOR?: string;
-    /** Maintainer recap digest (#1963, #2248): when truthy, a cross-repo RecapReport -- gittensory's OWN
+    /** Maintainer recap digest (#1963, #2248): when truthy, a cross-repo RecapReport -- loopover's OWN
      *  gate-precision + outcome-calibration data folded across every scanned repo (buildMaintainerRecap,
      *  #2239) -- is delivered to Discord on a cron cadence. LOOPOVER_RECAP_CADENCE ("daily" | "weekly",
      *  default "weekly"; an invalid value falls back to "weekly") picks how often; LOOPOVER_RECAP_HOUR
@@ -539,7 +539,7 @@ declare global {
      *  monitor. Presence of this AND the two vars below IS the enablement switch (see isD1SizeProbeEnabled,
      *  src/selfhost/d1-size-probe.ts) -- unset/blank ⇒ the probe never runs, byte-identical to today. Most
      *  self-host operators run their own SQLite/Postgres backend and have no Cloudflare D1 to watch; this is
-     *  for whichever deployment owns a real D1 worth monitoring (including gittensory's own central cloud
+     *  for whichever deployment owns a real D1 worth monitoring (including loopover's own central cloud
      *  database, the one that hit its ~10GB cap on 2026-07-06). */
     CLOUDFLARE_D1_MONITOR_ACCOUNT_ID?: string;
     /** The D1 database id (uuid) to monitor. See CLOUDFLARE_D1_MONITOR_ACCOUNT_ID. */

--- a/src/github/app.ts
+++ b/src/github/app.ts
@@ -345,7 +345,7 @@ async function mintInstallationToken(
 
 /**
  * Dual-app webhook safety (#selfhost-app-id): TRUE when a delivery's installation belongs to a DIFFERENT
- * gittensory App than this backend's own (`GITHUB_APP_ID`), e.g. the cloud App and a self-host App installed on
+ * loopover App than this backend's own (`GITHUB_APP_ID`), e.g. the cloud App and a self-host App installed on
  * the same account during the migration. FAIL-OPEN by construction — returns FALSE (process the webhook) whenever
  * we cannot be certain it is foreign: no configured own id, an unparseable own id, or an unknown installation
  * app_id (existing rows backfill lazily). It returns TRUE only on a POSITIVE numeric mismatch, so it can never

--- a/src/github/backfill.ts
+++ b/src/github/backfill.ts
@@ -2942,7 +2942,7 @@ async function reduceLiveCiAggregate(
   // expected-checks list against.
   const ciCompletenessWarning =
     !enforceRequiredOnly && ciState === "passed"
-      ? "CI resolved to passed with no branch-protection required checks configured — gittensory cannot verify every expected workflow ran on this commit (a path-filtered or misconfigured workflow that never triggers is indistinguishable from one that doesn't exist). Configure branch protection or an expected-checks list for full CI-completeness verification."
+      ? "CI resolved to passed with no branch-protection required checks configured — loopover cannot verify every expected workflow ran on this commit (a path-filtered or misconfigured workflow that never triggers is indistinguishable from one that doesn't exist). Configure branch protection or an expected-checks list for full CI-completeness verification."
       : null;
   // A partial/paginated read can't tell "never appears" from "appears on a page we didn't fetch" -- only a
   // COMPLETE read's absence is a confident signal worth a short surfacing cap (#selfhost-ci-deferral-staleness).
@@ -3161,7 +3161,7 @@ export async function fetchLiveCiAggregatePreferGraphQl(
 
 /**
  * Fetch a PR's LIVE `mergeable_state` (clean / dirty / blocked / unstable / behind / has_hooks / unknown). The
- * STORED value lags GitHub's async recompute — e.g. right after gittensory[bot]'s own APPROVE flips a `blocked`
+ * STORED value lags GitHub's async recompute — e.g. right after loopover[bot]'s own APPROVE flips a `blocked`
  * PR to `clean`, the stored row is still `blocked`, which stops an otherwise-eligible PR from auto-merging
  * (observed: green+approved PRs stuck OPEN at `mergeState=CLEAN`). The auto-maintain planner uses this so the
  * merge decision sees the CURRENT state. `unknown` (GitHub still computing) ⇒ caller treats as not-yet-clean and
@@ -3958,9 +3958,9 @@ function isTrustedScannerReviewThreadAuthor(env: Env, login: string | null | und
 
 // Match only OUR OWN app bot login (a `${GITHUB_APP_SLUG}` / `${GITHUB_APP_SLUG}-orb[bot]` PREFIX), never a
 // third-party slug that merely ENDS in `-${GITHUB_APP_SLUG}[bot]`. Anchored to `^`: a `\b` boundary also fires
-// after a hyphen, so the prior `\bgittensory…` misclassified e.g. `evil-gittensory[bot]` as our own author and
+// after a hyphen, so the prior `\bloopover…` misclassified e.g. `evil-loopover[bot]` as our own author and
 // dropped its review-thread comment as a self-authored non-blocker (fail-open) instead of evaluating it as
-// external. Derived from `env.GITHUB_APP_SLUG` (#4615) rather than a hardcoded "gittensory" literal -- every
+// external. Derived from `env.GITHUB_APP_SLUG` (#4615) rather than a hardcoded "loopover" literal -- every
 // other "is this our own bot" check in the codebase already does this (self-authored.ts, pr-actions.ts,
 // comments.ts, processors.ts) -- so a self-hoster who renamed their App still recognizes its own comments.
 export function isOwnReviewThreadAuthor(env: Env, login: string | null | undefined): boolean {

--- a/src/github/client.ts
+++ b/src/github/client.ts
@@ -27,7 +27,7 @@ const DEFAULT_METADATA_TTL_SECONDS = 10 * 60;
 // briefly. Long enough to dedup the two upstream ref→SHA resolves that fire in the SAME hourly window (scoring +
 // drift), short enough that the pinned SHA is never meaningfully stale.
 const DEFAULT_COMMIT_TTL_SECONDS = 15 * 60;
-export const GITHUB_RESPONSE_CACHE_REPLAY_HEADER = "x-gittensory-cache";
+export const GITHUB_RESPONSE_CACHE_REPLAY_HEADER = "x-loopover-cache";
 
 /** The single source of truth for the product's outbound User-Agent, used by every raw-`fetch`/`timeoutFetch`
  *  call across `src/` that identifies itself generically (as opposed to a service-specific variant like the

--- a/src/github/e2e-test-commit.ts
+++ b/src/github/e2e-test-commit.ts
@@ -4,11 +4,11 @@
 // existing ref (`PATCH git/refs/{ref}`) instead of creating a new branch/PR.
 //
 // Deliberately narrower in scope than repo-doc-pr.ts: this writes to SOMEONE ELSE'S branch (the PR author's),
-// not a branch gittensory itself owns, so it carries a materially bigger blast radius — see #4195's
+// not a branch loopover itself owns, so it carries a materially bigger blast radius — see #4195's
 // maintainer-only authorization tier and the miner-scoring safeguard below, both required before this is ever
 // invoked for real.
 //
-// SCORING-INTEGRITY SAFEGUARD (#4201): gittensory does not compute the authoritative Gittensor score itself —
+// SCORING-INTEGRITY SAFEGUARD (#4201): loopover does not compute the authoritative Gittensor score itself —
 // it is computed by external validators reading the merged PR directly from GitHub. A commit this module
 // pushes onto a CONFIRMED MINER's PR branch would be indistinguishable, to that external validator, from a
 // line the miner wrote themselves, inflating their apparent contribution. `isMinerAuthoredBranch` must be
@@ -30,7 +30,7 @@ export type E2eTestCommitResult =
  *  wants a different location can move the file after it lands; this module has no per-repo convention to
  *  read (that is a possible future enhancement, not required for this first delivery mode). */
 export function defaultE2eTestFilePath(prNumber: number): string {
-  return `e2e/gittensory-pr-${prNumber}.spec.ts`;
+  return `e2e/loopover-pr-${prNumber}.spec.ts`;
 }
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,8 +42,8 @@ export { RateLimiter };
 export default {
   fetch: app.fetch,
   async queue(batch: MessageBatch<JobMessage>, env: Env): Promise<void> {
-    // Both dead-letter queues (the maintenance lane's gittensory-jobs-dlq and the webhook lane's
-    // gittensory-webhooks-dlq, #1276) drain through the same observability + self-heal consumer.
+    // Both dead-letter queues (the maintenance lane's loopover-jobs-dlq and the webhook lane's
+    // loopover-webhooks-dlq, #1276) drain through the same observability + self-heal consumer.
     if (batch.queue?.endsWith("-dlq")) {
       await processDlqBatch(batch, env, { redriveWebhooks: isSelfHostedReviewRuntime(env) });
       return;
@@ -224,7 +224,7 @@ async function enqueueScheduledJobs(env: Env, controller: ScheduledController): 
     jobs.push({ type: "refresh-scoring-model", requestedBy: "schedule" });
     jobs.push({ type: "refresh-upstream-drift", requestedBy: "schedule" });
     jobs.push({ type: "rollup-product-usage", requestedBy: "schedule", days: 7 });
-    // Convergence (ops / observability, flag LOOPOVER_REVIEW_OPS). Hourly anomaly scan over gittensory's own
+    // Convergence (ops / observability, flag LOOPOVER_REVIEW_OPS). Hourly anomaly scan over loopover's own
     // review-outcome data. Enqueued ONLY when the flag is ON — flag-OFF (default) this job is never created,
     // so the cron tick does ZERO new work and the enqueued set is byte-identical to today.
     if (selfHostedReviews && isOpsEnabled(env)) jobs.push({ type: "ops-alerts", requestedBy: "schedule" });
@@ -234,7 +234,7 @@ async function enqueueScheduledJobs(env: Env, controller: ScheduledController): 
     // created, so the cron tick does ZERO new work and the enqueued set is byte-identical to today.
     if (selfHostedReviews && isSweepWatchdogEnabled(env)) jobs.push({ type: "sweep-liveness-watchdog", requestedBy: "schedule" });
     // Convergence (self-improve / auto-tune, flag LOOPOVER_REVIEW_SELFTUNE). Hourly self-improvement tick over
-    // gittensory's own review-outcome data: compute tuning recommendations, shadow-soak any strictly-tightening
+    // loopover's own review-outcome data: compute tuning recommendations, shadow-soak any strictly-tightening
     // one, and auto-promote it to live only after the soak window passes the gate (TIGHTENING-ONLY, audited).
     // Enqueued ONLY when the flag is ON — flag-OFF (default) this job is never created, so the cron tick does
     // ZERO new tuning work and the enqueued set is byte-identical to today.
@@ -257,7 +257,7 @@ async function enqueueScheduledJobs(env: Env, controller: ScheduledController): 
   // Maintainer recap digest (#1963, #2248/#2250; flag LOOPOVER_MAINTAINER_RECAP). Cross-repo RecapReport
   // delivered to Discord on a configurable cadence (LOOPOVER_RECAP_CADENCE=daily|weekly, default weekly) at
   // the configured hour/day-of-week (LOOPOVER_RECAP_HOUR / LOOPOVER_RECAP_DAY). Enable/cadence can ALSO be
-  // set as code via the gittensory self-repo's `.loopover.yml maintainerRecap:` block (config-as-code parity,
+  // set as code via the loopover self-repo's `.loopover.yml maintainerRecap:` block (config-as-code parity,
   // #2250) -- a present manifest block wins over the env vars; absent, the env vars decide exactly as before.
   // Enqueued ONLY when this tick matches the resolved cadence -- disabled (the default) this job is never
   // created, so the cron tick does ZERO new work and the enqueued set is byte-identical to today.

--- a/src/notifications/service.ts
+++ b/src/notifications/service.ts
@@ -84,7 +84,7 @@ export async function detectIssueWatchEvents(env: Env, repoFullName: string, iss
     // Don't ping the maintainer who opened the issue about their own issue.
     .filter((watcher) => watcher.login.toLowerCase() !== authorLogin);
 
-  // Access gate: a gittensory-tracked PUBLIC repo fans out to every matching watcher (the miner use case);
+  // Access gate: a loopover-tracked PUBLIC repo fans out to every matching watcher (the miner use case);
   // a PRIVATE — or untracked/unknown — repo only to watchers who can access it, so private-repo issues never
   // reach a non-collaborator. The repo is the same for all watchers, so resolve it once and only pay the
   // per-watcher access check on the private path.

--- a/src/openapi/spec.ts
+++ b/src/openapi/spec.ts
@@ -972,7 +972,7 @@ export function buildOpenApiSpec() {
         }),
         repoFullName: z.string().optional().openapi({
           param: { description: "Optional repository filter. Browser sessions must have control-panel access to this repo." },
-          example: "JSONbored/gittensory",
+          example: "JSONbored/loopover",
         }),
         reason: z.enum(["surface_off", "missing_author", "bot_author", "ignored_author", "maintainer_author", "miner_detection_unavailable", "not_official_gittensor_miner"]).optional().openapi({
           param: { description: "Optional PR skip reason filter." },

--- a/src/orb/app-auth.ts
+++ b/src/orb/app-auth.ts
@@ -1,7 +1,7 @@
 // LoopOver Orb central GitHub App (#1255) — App authentication. Mints the Orb App JWT (RS256, signed with the
 // Orb App's OWN private key), lists the App's installations, and mints short-lived installation tokens. This is
 // the token-broker foundation: a maintainer's self-hosted container (after enrollment) exchanges for one of these
-// installation tokens to act on its own repos. Modeled on src/github/app.ts (the gittensory review App's auth),
+// installation tokens to act on its own repos. Modeled on src/github/app.ts (the loopover review App's auth),
 // parameterized to the ORB_GITHUB_* credentials so the two Apps stay isolated.
 import { timeoutFetch } from "../github/client";
 import { signRs256Jwt } from "../utils/crypto";

--- a/src/orb/broker-client.ts
+++ b/src/orb/broker-client.ts
@@ -1,6 +1,6 @@
 // Self-host BROKER CLIENT (#1255). A self-hosted engine exchanges its operator-issued enrollment secret for a
 // short-lived GitHub installation token from the central Orb (POST /v1/orb/token), so it can act on its own repos
-// WITHOUT ever holding a GitHub App private key (gittensory holds the Orb App key centrally and mints on demand —
+// WITHOUT ever holding a GitHub App private key (loopover holds the Orb App key centrally and mints on demand —
 // the das-github-mirror model). Used by createInstallationToken in broker mode; the installation-token CACHE lives
 // with the App-key path in src/github/app.ts (one mint per ~hour per installation, broker or local).
 //
@@ -9,7 +9,7 @@
 
 import { incr } from "../selfhost/metrics";
 
-/** The Orb's hosted broker base; override (ORB_BROKER_URL) only to point at a private gittensory deployment. */
+/** The Orb's hosted broker base; override (ORB_BROKER_URL) only to point at a private loopover deployment. */
 const DEFAULT_BROKER_URL = "https://api.loopover.ai";
 // The broker's cold token mint can take many seconds when GitHub is throttling the App; allow headroom so the one
 // uncached mint completes and populates the broker-side cache (steady-state cache hits return in well under a second).

--- a/src/orb/broker.ts
+++ b/src/orb/broker.ts
@@ -1,6 +1,6 @@
 // LoopOver Orb central GitHub App (#1255) — the token-broker. A maintainer's self-hosted container exchanges a
 // one-time enrollment secret for short-lived GitHub installation tokens, so it can act on its own repos WITHOUT
-// ever holding the Orb App private key (gittensory holds it centrally and mints on demand).
+// ever holding the Orb App private key (loopover holds it centrally and mints on demand).
 //
 // Trust model (das-github-mirror): the OPERATOR is the authority. An enrollment is issued only for an install the
 // operator has already opted in (registered=1) via the internal-token-gated POST /v1/internal/orb/enrollments;

--- a/src/orb/oauth.ts
+++ b/src/orb/oauth.ts
@@ -114,10 +114,10 @@ function shell(heading: string, inner: string): string {
   return `<!doctype html><html lang="en"><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/><title>${heading}</title><style>*{box-sizing:border-box}body{margin:0;min-height:100vh;display:flex;align-items:center;justify-content:center;background:#0b0b0d;color:#e7e7ea;font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif}.card{max-width:34rem;margin:1.5rem;padding:2.75rem;background:#16161a;border:1px solid #2a2a30;border-radius:14px;text-align:center}h1{font-size:1.35rem;font-weight:600;margin:0 0 .7rem}p{font-size:.95rem;line-height:1.6;color:#a8a8b0;margin:0 0 1.6rem}a{display:inline-block;padding:.6rem 1.4rem;background:#1f6feb;color:#fff;text-decoration:none;border-radius:8px;font-size:.9rem}code{background:#0b0b0d;border:1px solid #2a2a30;border-radius:6px;padding:.15rem .4rem;font-size:.85rem}pre{background:#0b0b0d;border:1px solid #2a2a30;border-radius:8px;padding:1rem;overflow:auto;text-align:left;color:#7ee787;font-size:.9rem;user-select:all}</style></head><body><div class="card"><h1>${heading}</h1>${inner}</div></body></html>`;
 }
 
-// The Orb App itself stays a single centrally-hosted hub (broker.ts: gittensory holds the App key centrally
+// The Orb App itself stays a single centrally-hosted hub (broker.ts: loopover holds the App key centrally
 // and mints tokens on demand) -- that part is architecturally fixed. This link is just where the browser lands
 // after OAuth, so it follows the SAME self-hoster-configurable pattern as maintainerControlPanelUrl one
-// file-family over (github/footer.ts): env.PUBLIC_SITE_ORIGIN when set, else the public gittensory dashboard
+// file-family over (github/footer.ts): env.PUBLIC_SITE_ORIGIN when set, else the public loopover dashboard
 // (#4615).
 function landingPage(env: Env, heading: string, message: string): string {
   const dashboardOrigin = (env.PUBLIC_SITE_ORIGIN ?? LOOPOVER_SITE_URL).replace(/\/$/, "");

--- a/src/orb/webhook.ts
+++ b/src/orb/webhook.ts
@@ -1,7 +1,7 @@
 // LoopOver Orb central GitHub App (#1255) — inbound webhook receiver (POST /v1/orb/webhook).
 //
 // The central Orb App is a SEPARATE GitHub App that maintainers INSTALL (one shared app, like
-// das-github-mirror's). GitHub delivers its install + PR/review events here, to gittensory-api. This is the
+// das-github-mirror's). GitHub delivers its install + PR/review events here, to loopover-api. This is the
 // data spine for the homepage fleet metrics (reviews initiated / merged / closed / reversals).
 //
 // PR1 scope: receive + verify (the Orb App's OWN webhook secret) + dedup + record. NO processing yet — the

--- a/src/queue/dlq.ts
+++ b/src/queue/dlq.ts
@@ -8,7 +8,7 @@ const DLQ_DEAD_LETTERED_METRIC = "loopover_dlq_dead_lettered_total";
 const DLQ_REDRIVEN_METRIC = "loopover_dlq_redriven_total";
 
 /**
- * DLQ consumer for both `gittensory-jobs-dlq` (maintenance lane) and `gittensory-webhooks-dlq` (the
+ * DLQ consumer for both `loopover-jobs-dlq` (maintenance lane) and `loopover-webhooks-dlq` (the
  * webhook lane added with the dedicated WEBHOOKS queue, #1276). Called when a job exhausts all retries
  * on its main queue and is dead-lettered. Logs every dropped job and records an audit event so the drop
  * is observable rather than silent (countRecentDeadLetters surfaces the rate). Always acks — no further

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -1229,7 +1229,7 @@ const RAG_REINDEX_MAX_PATHS = 100;
  * an incremental re-index of the PR's changed files so the index reflects the new default-branch state. No-op when
  * the flag is off, the repo isn't allowlisted, the action isn't a merge-close, or there are no changed paths.
  *
- * INCREMENTAL TRIGGER NOTE: gittensory does not (yet) subscribe to raw `push` events — the merged-PR close is the
+ * INCREMENTAL TRIGGER NOTE: loopover does not (yet) subscribe to raw `push` events — the merged-PR close is the
  * available signal that "code landed on the default branch". If a `push` handler is added later, that is the
  * stronger trigger (it also catches direct-to-default-branch commits); enqueue the same `rag-index-repo` job with
  * the pushed paths there. The slow-cadence cron full re-index (index.ts) is the backstop that catches anything
@@ -2666,7 +2666,7 @@ async function runAgentMaintenancePlanAndExecute(
   // (markPullRequestLinkedIssueHardRuleViolated is a no-op once already set) so a LATER pass can't lose it to a
   // body edit or a linked issue's live state changing -- see mergeLinkedIssueHardRuleWithPersistedViolation's own
   // doc comment for the full dodge-window rationale. Best-effort write: a D1 hiccup here only means this ONE
-  // confirmed violation isn't remembered, matching every other gittensory-computed marker write in this file
+  // confirmed violation isn't remembered, matching every other loopover-computed marker write in this file
   // (mergeBlockedSha, draftConversionCount, lastRegatedAt).
   if (liveLinkedIssueHardRule?.violated === true) {
     await markPullRequestLinkedIssueHardRuleViolated(env, repoFullName, pr.number, liveLinkedIssueHardRule.reason ?? "the linked issue is not eligible for a community PR").catch(() => undefined);
@@ -5154,7 +5154,7 @@ async function maybeHandleInstallationDeletedWebhookEvent(
 
 /**
  * Dual-app safety (#selfhost-app-id): acks and skips a delivery whose installation belongs to a DIFFERENT
- * gittensory App than this backend's own (cloud + self-host installed on the same account), so neither
+ * loopover App than this backend's own (cloud + self-host installed on the same account), so neither
  * backend acts on the other's installation. Returns `true` when handled (the caller must return
  * immediately), `false` otherwise. Extracted from processGitHubWebhook (#4607) — pure code motion, no
  * behavior change.
@@ -5166,7 +5166,7 @@ async function maybeHandleForeignAppInstallationWebhookEvent(
   payload: GitHubWebhookPayload,
   installationAppId: number | null,
 ): Promise<boolean> {
-  // Dual-app safety (#selfhost-app-id): if this delivery's installation belongs to a DIFFERENT gittensory App
+  // Dual-app safety (#selfhost-app-id): if this delivery's installation belongs to a DIFFERENT loopover App
   // (cloud + self-host installed on the same account), ack it without processing so neither backend acts on the
   // other's installation. FAIL-OPEN — an unknown/own-matching app_id always processes, so the LIVE single-app
   // path is byte-identical. Signature verification (per-App secret) is the primary isolation; this is the
@@ -5637,7 +5637,7 @@ async function handlePullRequestWebhookEvent(
       /* v8 ignore next -- best-effort: the guarded CAS update never rejects against a healthy D1, and a cleanup failure here must never block the webhook. */
       await terminalizeActiveReviewTracking(env, repoFullName, pr.number).catch(() => undefined);
     }
-    // Reopen-prevention (#one-shot-reopen): a CONTRIBUTOR may not reopen a PR that gittensory or a maintainer
+    // Reopen-prevention (#one-shot-reopen): a CONTRIBUTOR may not reopen a PR that loopover or a maintainer
     // closed — closes are one-shot (resubmit, don't reopen). If a non-maintainer reopened a PR whose last close
     // was by the bot / repo owner / admin, re-close it and skip the re-review. Self-closes (the contributor
     // closed their own PR) stay reopenable; the bot's own nightly-re-review reopens are exempt. A contended
@@ -5761,7 +5761,7 @@ async function handlePullRequestWebhookEvent(
       actionMode: await resolveRepoActionMode(env, settings),
     });
     // Review-evasion protection (#review-evasion-protection): a contributor closing their OWN PR while
-    // gittensory has an ACTIVE review pass running is dodging the one-shot review, not making an ordinary
+    // loopover has an ACTIVE review pass running is dodging the one-shot review, not making an ordinary
     // close. Runs regardless of the general draft-dodge/reopen-reclose gates above -- it is its own
     // independent enforcement, config-gated on settings.reviewEvasionProtection (close by default, #4011).
     if (payload.action === "closed" && installationId) {
@@ -7428,7 +7428,7 @@ export async function runScreenshotTableVisionForAdvisory(
  * pass from -- so a fully-green required CI rollup counts as evidence too. Without this, a fully-automated,
  * CI-green, docs-only regen PR (the #4719 false positive) fails this check merely because its templated
  * body never happens to contain a "tested"/"validated" word. `ciState === "passed"` already excludes
- * gittensory's own Gate/Context check-runs (`BOT_OWNED_CHECK_NAMES`, github/backfill.ts), so this can never
+ * loopover's own Gate/Context check-runs (`BOT_OWNED_CHECK_NAMES`, github/backfill.ts), so this can never
  * be satisfied by the very check-run this signal feeds into.
  */
 async function resolveManifestPassedValidationCount(
@@ -8046,7 +8046,7 @@ async function maybePublishPrPublicSurface(
   }
 
   // Respect the per-repo agent pause: suppress all public surface mutations (label, comment, context
-  // check run) so a paused repo sees no gittensory-authored GitHub content. The review-agent check
+  // check run) so a paused repo sees no loopover-authored GitHub content. The review-agent check
   // run still posts so the required-check status is not broken (#agent-pause).
   if (settings.agentPaused)
     decision = {
@@ -9925,7 +9925,7 @@ async function maybePublishPrPublicSurface(
     };
     let deterministicBody: string;
     // Convergence (Stage D): when the unified-review-comment flag is ON, render the single converged comment
-    // (gittensory shape + reviewbot's review folded in). The gate stays authoritative (passed as `decision`),
+    // (loopover shape + reviewbot's review folded in). The gate stays authoritative (passed as `decision`),
     // and the body carries the SAME panel marker so the upsert updates in place. Flag-OFF (default) keeps the
     // legacy panel byte-identical. Only the comment lane is affected; the gate check-run/labels/audit are not.
     //

--- a/src/queue/review-evasion.ts
+++ b/src/queue/review-evasion.ts
@@ -322,7 +322,7 @@ async function closeDraftDodgeAttemptIfBlocked(
  *  pass; a plain boolean can't distinguish "evaluated, not blocked" from "reclosed, stop here". */
 export type ReopenRecloseOutcome = "reclosed" | "allowed";
 
-/** Reopen-prevention (#one-shot-reopen): re-close a contributor's reopen of a PR that gittensory / a maintainer
+/** Reopen-prevention (#one-shot-reopen): re-close a contributor's reopen of a PR that loopover / a maintainer
  *  closed (closes are one-shot). Returns "reclosed" when it re-closed (caller skips the re-review). Exempt: the
  *  bot's own re-review reopens, owner/admin reopens, and a contributor reopening a PR they CLOSED THEMSELVES.
  *  Per-PR actuation-locked (#2135/#2447): a concurrent delivery for the same PR must not evaluate + potentially
@@ -378,7 +378,7 @@ async function recloseDisallowedReopenIfNeeded(
     );
   };
   if (await hasMaintainerPermission(reopener)) return false; // owner / admin / write collaborators may reopen
-  // A non-maintainer reopened: re-close ONLY if gittensory or a maintainer closed it (one-shot). A contributor
+  // A non-maintainer reopened: re-close ONLY if loopover or a maintainer closed it (one-shot). A contributor
   // reopening a PR they closed themselves is allowed (fail-open on an unknown closer).
   const closerResult = await getLastCloserLogin(
     env,
@@ -534,7 +534,7 @@ async function hasMaintainerOrOwnerPermission(env: Env, installationId: number, 
 }
 
 /** Review-evasion protection (#review-evasion-protection): a CONTRIBUTOR closing their OWN PR while
- *  gittensory has an ACTIVE review pass running against its current headSha is dodging the one-shot review,
+ *  loopover has an ACTIVE review pass running against its current headSha is dodging the one-shot review,
  *  not making an ordinary close. GitHub lets a contributor reopen a PR they closed themselves but NOT one
  *  closed by a maintainer or the App (#one-shot-reopen) -- so this reopens the PR (as the App) and
  *  immediately re-closes it (as the App), converting the contributor's own close into an App-authored,
@@ -731,7 +731,7 @@ async function closeReviewEvasionSelfCloseIfActive(
 }
 
 /** Review-evasion protection (#review-evasion-protection): a contributor converting their OWN OPEN PR to
- *  draft while gittensory has an ACTIVE review pass running against its current headSha is dodging the
+ *  draft while loopover has an ACTIVE review pass running against its current headSha is dodging the
  *  one-shot review, distinct from the EXISTING draft-dodge guard above (which only fires after a PRIOR gate
  *  FAILURE on this head). Unlike the self-close sibling, converting to draft never closes the PR on GitHub,
  *  so no reopen step is needed -- a direct close, exactly like the draft-dodge guard's own close step,

--- a/src/rules/advisory.ts
+++ b/src/rules/advisory.ts
@@ -910,7 +910,7 @@ function conclusionForSeverity(severity: AdvisorySeverity, findings: AdvisoryFin
 
 function isEvaluationBlocker(code: string, policy: GateCheckPolicy): boolean {
   // pre_merge_check_unresolved: an enforced path-gated pre-merge check whose changed-file set could not be
-  // resolved — gittensory cannot evaluate it yet, so the gate is NEUTRAL (held) and re-evaluates on the next
+  // resolved — loopover cannot evaluate it yet, so the gate is NEUTRAL (held) and re-evaluates on the next
   // sync, rather than auto-merging past the unverified requirement or hard-closing on a transient miss. (#review-audit)
   if (code === "repo_not_registered" || code === "repo_not_seen" || code === "pr_not_cached" || code === "pre_merge_check_unresolved") return true;
   // cla_check_unresolved (#2564): the CLA-bot check-run's conclusion could not be resolved. Unlike the codes

--- a/src/rules/advisory.ts
+++ b/src/rules/advisory.ts
@@ -910,7 +910,7 @@ function conclusionForSeverity(severity: AdvisorySeverity, findings: AdvisoryFin
 
 function isEvaluationBlocker(code: string, policy: GateCheckPolicy): boolean {
   // pre_merge_check_unresolved: an enforced path-gated pre-merge check whose changed-file set could not be
-  // resolved — loopover cannot evaluate it yet, so the gate is NEUTRAL (held) and re-evaluates on the next
+  // resolved — gittensory cannot evaluate it yet, so the gate is NEUTRAL (held) and re-evaluates on the next
   // sync, rather than auto-merging past the unverified requirement or hard-closing on a transient miss. (#review-audit)
   if (code === "repo_not_registered" || code === "repo_not_seen" || code === "pr_not_cached" || code === "pre_merge_check_unresolved") return true;
   // cla_check_unresolved (#2564): the CLA-bot check-run's conclusion could not be resolved. Unlike the codes

--- a/src/scoring/model.ts
+++ b/src/scoring/model.ts
@@ -98,10 +98,10 @@ export async function refreshScoringModelSnapshot(env: Env): Promise<ScoringMode
     const unmodeled = findUnmodeledUpstreamConstants(constantsResult.value);
     constantsPayload = { parsedConstantCount: Object.keys(parsed).length, sourceBytes: constantsResult.value.length, unmodeledUpstreamConstants: unmodeled };
     warnings.push(...activeModelWarnings(parsed));
-    // Make staleness visible: upstream defines scoring constants gittensory does not yet model.
+    // Make staleness visible: upstream defines scoring constants loopover does not yet model.
     if (unmodeled.length > 0) {
       warnings.push(
-        `Upstream gittensor defines ${unmodeled.length} scoring constant(s) gittensory does not yet model: ${unmodeled.slice(0, 12).join(", ")}${unmodeled.length > 12 ? ", …" : ""}. Scoring may be behind upstream.`,
+        `Upstream gittensor defines ${unmodeled.length} scoring constant(s) loopover does not yet model: ${unmodeled.slice(0, 12).join(", ")}${unmodeled.length > 12 ? ", …" : ""}. Scoring may be behind upstream.`,
       );
     }
   } else {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,4 @@
-// Self-host Node entry (#980). Runs gittensory's SAME Worker handlers on Node. Backends are pluggable:
+// Self-host Node entry (#980). Runs loopover's SAME Worker handlers on Node. Backends are pluggable:
 //   • DB:    SQLite (node:sqlite, default) OR Postgres (DATABASE_URL=postgres://… → shared, multi-instance).
 //   • Queue: durable SQLite queue OR a Postgres queue (FOR UPDATE SKIP LOCKED).
 //   • Redis: required transient review state + fixed-window rate limiter.
@@ -126,7 +126,7 @@ interface Backend {
 }
 
 /** Retry a Postgres connection until it succeeds (up to maxWaitMs). Prevents crash-restart loops when
- *  gittensory starts before Postgres is ready (common in `--profile postgres` compose stacks). */
+ *  loopover starts before Postgres is ready (common in `--profile postgres` compose stacks). */
 async function waitForPostgres(url: string, maxWaitMs = 30_000): Promise<void> {
   const pg = (await import("pg")).default;
   const start = Date.now();
@@ -160,7 +160,7 @@ async function waitForPostgres(url: string, maxWaitMs = 30_000): Promise<void> {
 }
 
 /** Retry an async readiness operation with backoff until it succeeds (up to maxWaitMs). Prevents a
- *  crash-restart loop when gittensory starts before a dependency (e.g. Qdrant) is accepting connections —
+ *  crash-restart loop when loopover starts before a dependency (e.g. Qdrant) is accepting connections —
  *  Qdrant's init is a single fetch with no retry, so a slow-starting --profile qdrant container would
  *  otherwise take the whole process down. */
 async function retryUntilReady(
@@ -401,7 +401,7 @@ async function main(): Promise<void> {
       }),
     );
 
-  // Public-origin advisory (JSONbored/gittensory#4180): warn LOUDLY at boot if PUBLIC_API_ORIGIN/
+  // Public-origin advisory (JSONbored/loopover#4180): warn LOUDLY at boot if PUBLIC_API_ORIGIN/
   // PUBLIC_SITE_ORIGIN look like a private/internal hostname, so an operator doesn't run for weeks with every
   // visual-capture screenshot silently rendering as a broken image in public PR comments.
   const publicOriginOpts = {
@@ -1011,7 +1011,7 @@ async function main(): Promise<void> {
 
   backend.queue.start();
 
-  // Cron — gittensory ticks ~every 2 minutes; drive the SAME scheduled handler.
+  // Cron — loopover ticks ~every 2 minutes; drive the SAME scheduled handler.
   const intervalMs = Number(process.env.CRON_INTERVAL_MS ?? 120_000);
   /* v8 ignore start -- self-host entrypoint timers start a live server; monitor semantics are covered in selfhost tests. */
   const cron = setInterval(() => {

--- a/src/settings/agent-actions.ts
+++ b/src/settings/agent-actions.ts
@@ -18,7 +18,7 @@ const DEFAULT_SLOP_GATE_MIN_SCORE = 60;
 
 // The bucket labels the layer applies to reflect the gate verdict. These are generic fallbacks only; self-host
 // operators can rename or disable them via config-as-code so engine behavior never depends on project-specific
-// `gittensory:*` labels.
+// `loopover:*` labels.
 export const AGENT_LABEL_READY = "ready-to-merge";
 export const AGENT_LABEL_CHANGES = "changes-requested";
 // Default label applied to a blacklisted contributor's PR (#1425). NOT hardcoded into the action — it is

--- a/src/settings/autonomy.ts
+++ b/src/settings/autonomy.ts
@@ -1,7 +1,7 @@
 import type { AgentActionClass, AutoMaintainPolicy, AutoMergeMethod, AutonomyLevel, AutonomyPolicy } from "../types";
 
 // The graduated autonomy dial (#773), ordered least → most autonomous. Every later agent-layer phase reads
-// this BEFORE acting. `observe` is the deny-by-default floor — gittensory watches but never takes an action.
+// this BEFORE acting. `observe` is the deny-by-default floor — loopover watches but never takes an action.
 // (#4620: `suggest`/`propose` removed -- both were 100% behaviorally identical to `observe`, see
 // AutonomyLevel's own doc comment.)
 export const AUTONOMY_LEVELS = ["observe", "auto_with_approval", "auto"] as const;
@@ -22,7 +22,7 @@ const AUTONOMY_LEVEL_SET = new Set<string>(AUTONOMY_LEVELS);
 /**
  * Resolve the configured autonomy level for one action class on a repo. THE single gate the action layer
  * (#778) consults before any write action. Deny-by-default: an unset (or malformed) action class is
- * `observe` — gittensory observes but never acts. Pure.
+ * `observe` — loopover observes but never acts. Pure.
  */
 export function resolveAutonomy(autonomy: AutonomyPolicy | null | undefined, actionClass: AgentActionClass): AutonomyLevel {
   return autonomy?.[actionClass] ?? DEFAULT_AUTONOMY_LEVEL;

--- a/src/types.ts
+++ b/src/types.ts
@@ -198,7 +198,7 @@ export type JobMessage =
       deliveryId: string;
     }
   | {
-      // Convergence (ops / observability, flag-gated by LOOPOVER_REVIEW_OPS). Scan gittensory's review-outcome data
+      // Convergence (ops / observability, flag-gated by LOOPOVER_REVIEW_OPS). Scan loopover's review-outcome data
       // (gate-block ledger + recommendation/slop calibration) and emit a structured `ops_anomaly` log on drift.
       // Enqueued hourly by the cron ONLY when the flag is ON (index.ts), so flag-OFF this job never exists.
       type: "ops-alerts";
@@ -224,7 +224,7 @@ export type JobMessage =
     }
   | {
       // Convergence (self-improve / auto-tune, flag-gated by LOOPOVER_REVIEW_SELFTUNE). Run the ported
-      // self-improvement loop over gittensory's review-outcome data — compute tuning recommendations,
+      // self-improvement loop over loopover's review-outcome data — compute tuning recommendations,
       // SHADOW-SOAK any strictly-tightening one, and AUTO-PROMOTE it to live only after the soak window passes
       // the gate; every action is audited. TIGHTENING-ONLY. Enqueued hourly by the cron ONLY when the flag is
       // ON (index.ts), so flag-OFF this job never exists.
@@ -526,8 +526,8 @@ export type PullRequestRecord = {
   reviewDecision?: string | null | undefined;
   body?: string | null | undefined;
   /** GitHub's own PR creation time (`pull_request.created_at`) — the ground-truth order contributors actually
-   *  opened their PRs in, independent of when gittensory's own webhook/sweep pipeline happened to observe or
-   *  process this PR. NOT the same as {@link linkedIssueClaimedAt} (gittensory's own sync-time). Preferred for
+   *  opened their PRs in, independent of when loopover's own webhook/sweep pipeline happened to observe or
+   *  process this PR. NOT the same as {@link linkedIssueClaimedAt} (loopover's own sync-time). Preferred for
    *  duplicate-cluster winner election when present on both sides being compared (#dup-winner). */
   createdAt?: string | null | undefined;
   updatedAt?: string | null | undefined;
@@ -1021,7 +1021,7 @@ export type RepositorySettings = {
    *  touched. */
   contributorCapLabel?: string | null | undefined;
   /** Cancel in-flight CI runs on a contributor_cap close (#2462, anti-abuse): when true, after a PR is
-   *  auto-closed for exceeding {@link contributorOpenPrCap}, gittensory lists and cancels that PR's
+   *  auto-closed for exceeding {@link contributorOpenPrCap}, loopover lists and cancels that PR's
    *  in-progress/queued Actions runs at its head SHA. Requires the App installation to have granted
    *  `actions: write` -- degrades gracefully (skipped + logged, never blocks the close) when it hasn't.
    *  `null`/undefined (the DB-layer default) means "unset" and falls back to the
@@ -1059,7 +1059,7 @@ export type RepositorySettings = {
    *  or a login on {@link autoCloseExemptLogins}. */
   reviewNagMonitoredMentions?: string[] | undefined;
   /** Shared repo-scoped exemption list (#2463, anti-abuse): GitHub logins that are NEVER throttled or closed by
-   *  gittensory's deterministic anti-abuse mechanisms (review-nag and the per-contributor open-item cap above),
+   *  loopover's deterministic anti-abuse mechanisms (review-nag and the per-contributor open-item cap above),
    *  on top of the standing owner/admin/automation-bot exemption. Always populated by the DB layer (default
    *  `[]`); optional so existing settings fixtures/callers need not be touched. */
   autoCloseExemptLogins?: string[] | undefined;
@@ -1081,7 +1081,7 @@ export type RepositorySettings = {
    *  apply one manual-review label without enabling ready/changes-requested disposition labels. */
   manualReviewLabel?: string | null | undefined;
   /** Optional review-state label names. Config-as-code only; each `null` disables that specific label. These are
-   *  deliberately generic defaults rather than `gittensory:*` names so self-hosters can opt into their own
+   *  deliberately generic defaults rather than `loopover:*` names so self-hosters can opt into their own
    *  taxonomy without inheriting project-specific labels. */
   readyToMergeLabel?: string | null | undefined;
   changesRequestedLabel?: string | null | undefined;
@@ -1171,7 +1171,7 @@ export type RepositorySettings = {
    *  optional so existing settings fixtures/callers need not be touched. */
   skipAutomationBotAuthors?: "inherit" | "off" | "enabled" | undefined;
   /** Review-evasion protection (#review-evasion-protection): a contributor closing or converting their OWN
-   *  PR to draft while gittensory has an ACTIVE review pass running against it is dodging the one-shot
+   *  PR to draft while loopover has an ACTIVE review pass running against it is dodging the one-shot
    *  review process. The effective default is `"close"` as of #4011 (see `normalizeReviewEvasionProtection`
    *  in `db/repositories.ts`) -- `"off"` is now an explicit opt-out, not the default. `"close"` reopens (if
    *  needed) and re-closes as the App -- a close the contributor cannot themselves reopen (#one-shot-reopen)
@@ -1379,7 +1379,7 @@ export type ContributorBlacklistEntry = {
 };
 
 /** Agent-layer graduated autonomy (#773), least → most autonomous. `observe` is the deny-by-default floor:
- *  gittensory watches but never acts. `auto_with_approval` executes behind a human approval gate (#779);
+ *  loopover watches but never acts. `auto_with_approval` executes behind a human approval gate (#779);
  *  `auto` executes directly. (#4620: `suggest`/`propose` were removed here -- the doc comment promised
  *  distinct "surface guidance/concrete proposals without executing" behavior, but every read site
  *  (`isActingAutonomyLevel`/`autonomyRequiresApproval`) only ever distinguished acting from non-acting, so
@@ -1940,7 +1940,7 @@ export type GateOutcomeRecord = {
 };
 
 // Review memory (#2178, data-model slice of #1964). One row per (repoFullName, category, pathGlob,
-// patternHash) — a maintainer-dismissed finding shape gittensory should suppress/demote if it recurs.
+// patternHash) — a maintainer-dismissed finding shape loopover should suppress/demote if it recurs.
 // Privacy: repo + category (the finding's own deterministic `code`) + a path glob + a message HASH ONLY —
 // never the raw finding message/title, never an actor's trust/reward fields.
 export type ReviewSuppressionRecord = {
@@ -2583,7 +2583,7 @@ export type MaintainerRecapRepo = {
   cohorts?: { miner: MaintainerRecapCohortCounts; human: MaintainerRecapCohortCounts } | undefined;
 };
 
-/** A serializable maintainer recap: a window of gittensory's OWN review-outcome data folded across repos.
+/** A serializable maintainer recap: a window of loopover's OWN review-outcome data folded across repos.
  *  Foundation for the #1963 recap digest — the pure data-shaping seam only (no delivery, no scheduling).
  *  Distinct from {@link ReviewRecap} (single-repo, sourced from gate merge-precision predictions); this is
  *  multi-repo and sourced from the gate-precision + outcome-calibration aggregators. (#2239) */

--- a/src/upstream/ruleset.ts
+++ b/src/upstream/ruleset.ts
@@ -1149,7 +1149,7 @@ function githubDriftIssueTitle(report: UpstreamDriftReportRecord): string {
 }
 
 /**
- * Who upstream-drift issues are assigned to. Defaults to the gittensory maintainer, but a self-host operator
+ * Who upstream-drift issues are assigned to. Defaults to the loopover maintainer, but a self-host operator
  * can set LOOPOVER_DRIFT_ISSUE_ASSIGNEES (comma-separated logins; empty/whitespace = the default) so drift
  * issues land on THEIR team instead of a login that doesn't exist on their fork. Pairs with the existing
  * LOOPOVER_DRIFT_ISSUE_REPO override.

--- a/src/upstream/unmodeled-scoring-drift.ts
+++ b/src/upstream/unmodeled-scoring-drift.ts
@@ -35,7 +35,7 @@ export async function syncUnmodeledScoringConstantDrift(
       ...existing,
       status: "resolved",
       severity: "low",
-      summary: "All upstream scoring constants are modeled in gittensory.",
+      summary: "All upstream scoring constants are modeled in loopover.",
       updatedAt: now,
       payload: {
         ...existing.payload,
@@ -55,7 +55,7 @@ export async function syncUnmodeledScoringConstantDrift(
     commitSha: null,
   };
   const unmodeled = [...args.unmodeledConstants].sort();
-  const summary = `Upstream defines ${unmodeled.length} scoring constant(s) gittensory does not model: ${unmodeled.slice(0, 12).join(", ")}${unmodeled.length > 12 ? ", …" : ""}`;
+  const summary = `Upstream defines ${unmodeled.length} scoring constant(s) loopover does not model: ${unmodeled.slice(0, 12).join(", ")}${unmodeled.length > 12 ? ", …" : ""}`;
   const severity: UpstreamDriftSeverity = unmodeled.length >= 3 ? "high" : "medium";
   const affectedAreas: UpstreamDriftArea[] = ["scoring_model"];
   const report: UpstreamDriftReportRecord = {
@@ -72,7 +72,7 @@ export async function syncUnmodeledScoringConstantDrift(
     payload: {
       kind: "unmodeled_scoring_constants",
       unmodeledUpstreamConstants: unmodeled,
-      changes: [`${unmodeled.length} upstream scoring constant(s) are not modeled in gittensory`],
+      changes: [`${unmodeled.length} upstream scoring constant(s) are not modeled in loopover`],
       source,
       recommendedFollowUp: SCORING_MODEL_FOLLOW_UP,
     },

--- a/test/unit/e2e-test-commit.test.ts
+++ b/test/unit/e2e-test-commit.test.ts
@@ -28,7 +28,7 @@ const baseArgs = {
 
 describe("defaultE2eTestFilePath", () => {
   it("namespaces the generated file by PR number", () => {
-    expect(defaultE2eTestFilePath(42)).toBe("e2e/gittensory-pr-42.spec.ts");
+    expect(defaultE2eTestFilePath(42)).toBe("e2e/loopover-pr-42.spec.ts");
   });
 });
 
@@ -68,7 +68,7 @@ describe("commitE2eTestToPrBranch (#4197)", () => {
     expect(result).toEqual({ status: "committed", commitSha: "new-commit-sha", htmlUrl: `https://github.com/${REPO}/commit/new-commit-sha` });
 
     const treeCall = calls.find((c) => c.url.endsWith("/git/trees"));
-    expect(treeCall?.body).toMatchObject({ base_tree: "base-tree-sha", tree: [{ path: "e2e/gittensory-pr-42.spec.ts", mode: "100644", type: "blob", content: TEST_SOURCE }] });
+    expect(treeCall?.body).toMatchObject({ base_tree: "base-tree-sha", tree: [{ path: "e2e/loopover-pr-42.spec.ts", mode: "100644", type: "blob", content: TEST_SOURCE }] });
 
     const commitCall = calls.find((c) => c.url.endsWith("/git/commits") && c.method === "POST");
     expect(commitCall?.body).toMatchObject({ tree: "new-tree-sha", parents: ["head-commit-sha"] });


### PR DESCRIPTION
## Summary

- Part of the gittensory→loopover rebrand (#5705), phase 8b: rename brand-name prose in comments across 30 files spanning the remaining `src/**` subdirectories not covered by the review/signals/selfhost/services batches (api, auth, config, db, env.d.ts, github, index.ts, integrations, notifications, openapi, orb, queue, rules, scoring, server.ts, settings, types.ts, upstream).
- **Not purely comment-only** — three hunks change real runtime string literals, each already covered by existing tests that reference the value via its exported symbol (so they stay correct across the rename) or by an updated literal assertion in this same commit:
  - `src/github/client.ts`: `GITHUB_RESPONSE_CACHE_REPLAY_HEADER` (`"x-gittensory-cache"` → `"x-loopover-cache"`) — a diagnostic cache-hit header used only within this worker's own request/response cycle (never a cross-service contract); every consumer (`src/github/graphql-cache.ts`, `test/unit/github-client.test.ts`, `test/unit/github-graphql-cache.test.ts`) imports the exported constant rather than hardcoding the string, so they stay correct automatically.
  - `src/config/gittensory-repo-focus-manifest.ts`: `GITTENSOR_SELF_REPO_DEFAULT` (`"JSONbored/gittensory"` → `"JSONbored/loopover"`) — matches the real renamed GitHub repo. `test/unit/gittensory-focus-manifest.test.ts` asserts against the exported symbol, not a hardcoded literal, so it stays correct. Also required a matching prose rename in the root `.loopover.yml` (checked byte-identical to this file's bundled YAML constant by the same test) and `config/examples/loopover.full.yml`'s twin `.loopover.yml.example` — both included here.
  - `src/github/e2e-test-commit.ts`: `defaultE2eTestFilePath` (`e2e/gittensory-pr-N.spec.ts` → `e2e/loopover-pr-N.spec.ts`) — the generated e2e test file path committed to a contributor's branch; no external config depends on this specific prefix (verified via repo-wide grep). `test/unit/e2e-test-commit.test.ts`'s two literal-value assertions are updated in this same commit.
- Includes the matching `packages/loopover-engine/src/settings/autonomy.ts` twin fix so `scripts/check-engine-parity.ts` stays passing. `src/rules/advisory.ts`'s prose is deliberately left untouched here — it shares a gate-decision marker pair with `packages/loopover-engine/src/advisory/gate-advisory.ts` (already renamed in #5897), and the parity script requires both sides change together in one PR; #5897 will own that pair.
- Deliberately left untouched: `GITTENSORY_LEGACY_*` check-run name constants, `GITTENSORY-[A-Z0-9]+` Sentry issue slugs, the `gittensory.aethereal.dev`/`gittensory-api.aethereal.dev` domain aliases, the `gittensory-selfhost` container-image tag.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue this PR resolves — N/A, maintainer-authored rebrand-epic cleanup (#5705), no linked-issue gate applies to owner PRs.

## Validation

- [x] `git diff --check`
- [x] `npx tsx scripts/check-engine-parity.ts` — ok
- [x] `npm run typecheck` — clean
- [x] Targeted vitest runs confirming: `test/unit/gittensory-focus-manifest.test.ts` (13/13), `test/unit/e2e-test-commit.test.ts` (10/10), `test/unit/config-templates.test.ts` (19/19)

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no such changes.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed — the three functional literal changes above are covered by existing/updated tests.
- [ ] UI changes use live API data or real empty/error/loading states. — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section. — N/A, no UI changes.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs (none touched here).

## Notes

- One of several batched PRs covering the bulk-prose portion of rebrand epic #5705.