### PR TITLE
docs(engine): rename gittensory prose to loopover in packages/loopover-engine (batch A)

### DIFF
--- a/packages/loopover-engine/src/advisory/gate-advisory.ts
+++ b/packages/loopover-engine/src/advisory/gate-advisory.ts
@@ -442,7 +442,7 @@ export function evaluateGateCheck(advisoryResult: Advisory, policy: GateCheckPol
 
 function evaluateGateCheckCore(advisoryResult: Advisory, policy: GateCheckPolicy = {}): GateCheckEvaluation {
   const warnings = advisoryResult.findings.filter((finding) => finding.severity === "warning");
-  // App/infra state (repo not synced yet, PR not cached): gittensory cannot evaluate this PR yet, so the
+  // App/infra state (repo not synced yet, PR not cached): loopover cannot evaluate this PR yet, so the
   // gate is NEUTRAL (non-blocking) and re-evaluates automatically on the next sync/webhook. Never block a
   // contributor on the app's OWN state.
   if (advisoryResult.findings.some((finding) => isEvaluationBlocker(finding.code, policy))) {
@@ -530,7 +530,7 @@ function evaluateGateCheckCore(advisoryResult: Advisory, policy: GateCheckPolicy
 
 function isEvaluationBlocker(code: string, policy: GateCheckPolicy): boolean {
   // pre_merge_check_unresolved: an enforced path-gated pre-merge check whose changed-file set could not be
-  // resolved — gittensory cannot evaluate it yet, so the gate is NEUTRAL (held) and re-evaluates on the next
+  // resolved — loopover cannot evaluate it yet, so the gate is NEUTRAL (held) and re-evaluates on the next
   // sync, rather than auto-merging past the unverified requirement or hard-closing on a transient miss. (#review-audit)
   if (code === "repo_not_registered" || code === "repo_not_seen" || code === "pr_not_cached" || code === "pre_merge_check_unresolved") return true;
   // cla_check_unresolved (#2564): the CLA-bot check-run's conclusion could not be resolved. Unlike the codes

--- a/packages/loopover-engine/src/duplicate-winner.ts
+++ b/packages/loopover-engine/src/duplicate-winner.ts
@@ -11,7 +11,7 @@
  * caller can compute the winner ONCE per review run and thread the result boolean consistently into every
  * surface (advisory finding, close reason, slop, panels), so they agree by construction.
  *
- * ELECTION ORDER: compare `linkedIssueClaimedAt`, the time gittensory first observed the PR claiming
+ * ELECTION ORDER: compare `linkedIssueClaimedAt`, the time loopover first observed the PR claiming
  * the issue. GitHub `pull_request.created_at` is intentionally not an ordering signal here: contributors can
  * edit an old placeholder PR to add a linked issue later, so creation time would let backdated claims steal
  * duplicate-winner credit from the PR that actually claimed the issue first. Sparse legacy rows that lack

--- a/packages/loopover-engine/src/focus-manifest.ts
+++ b/packages/loopover-engine/src/focus-manifest.ts
@@ -259,12 +259,12 @@ export type ConvergedFeatureKey = (typeof CONVERGED_FEATURE_KEYS)[number];
  *  `LOOPOVER_REVIEW_REPOS` allowlist default, so an operator who sets nothing keeps today's behavior. */
 export type FocusManifestFeaturesConfig = { present: boolean } & Record<ConvergedFeatureKey, boolean | null>;
 
-/** Optional ecosystem/network integrations under the `experimental:` block — plugins that couple gittensory to
+/** Optional ecosystem/network integrations under the `experimental:` block — plugins that couple loopover to
  *  an external system rather than core review behavior. Starts with `gittensor` (the subnet mining-registry/
- *  scoring integration gittensory originally shipped with); future plugins land in this same array as the
+ *  scoring integration loopover originally shipped with); future plugins land in this same array as the
  *  product broadens beyond gittensor. Deliberately a SEPARATE block from `features:` (converged review
  *  capabilities) — an operator (especially self-host) should be able to see at a glance which toggles are "how
- *  gittensory reviews PRs" vs "which external network/ecosystem this instance opts into." */
+ *  loopover reviews PRs" vs "which external network/ecosystem this instance opts into." */
 export const EXPERIMENTAL_PLUGIN_KEYS = ["gittensor"] as const;
 export type ExperimentalPluginKey = (typeof EXPERIMENTAL_PLUGIN_KEYS)[number];
 
@@ -277,7 +277,7 @@ export type FocusManifestExperimentalConfig = { present: boolean } & Record<Expe
 /**
  * Per-repo registry-review lane configuration (`contentLane:` block, #2435) — lets a self-hosted maintainer
  * configure their OWN registry (structural file-scope patterns + entry-count cap + dedup fields) without a
- * gittensory code change. `entryFileGlob` and `collectionField` are the two REQUIRED fields to build a usable
+ * loopover code change. `entryFileGlob` and `collectionField` are the two REQUIRED fields to build a usable
  * spec; `present` is true only when both are set (a partial config degrades to "not configured," not a broken
  * half-spec — see `parseContentLaneConfig`). `validatorId` optionally references a code-registered domain
  * validator (`review/content-lane/spec-resolver.ts`'s `REGISTRY_VALIDATORS`); omitted ⇒ structural gating only
@@ -344,7 +344,7 @@ export type FocusManifestReviewRecapConfig = {
  * under `maintainerRecap:`. Distinct from `reviewRecap:` above (that is the single-repo digest's own window/
  * enable knob); this instead overrides the LOOPOVER_MAINTAINER_RECAP / LOOPOVER_RECAP_CADENCE env vars
  * that gate the cron-scheduled cross-repo digest (buildMaintainerRecap, #2239 / #2248) — read from the
- * gittensory self-repo's manifest (resolveLoopOverSelfRepoFullName), since the digest is an operator-level
+ * loopover self-repo's manifest (resolveLoopOverSelfRepoFullName), since the digest is an operator-level
  * setting, not a per-contributor-repo one. Mirrors `reviewRecap:` exactly: no DB-backed counterpart, so the
  * parsed value (or the default below when unset) IS the effective value. Not present (or present with no
  * fields set) ⇒ the caller falls back to the env vars, byte-identical to before this override existed.
@@ -485,7 +485,7 @@ export const REVIEW_FINDING_SEVERITY_LADDER = ["critical", "major", "minor", "ni
 
 /**
  * Maintainer overrides for the public review-panel CONTENT, declared under `review:`. Customizes the
- * panel without changing what gittensory measures: a custom public-safe footer lead line, a custom intro
+ * panel without changing what loopover measures: a custom public-safe footer lead line, a custom intro
  * note, and per-row show/hide toggles. The Gittensor attribution + register link is ALWAYS appended to
  * the footer regardless (the growth surface is preserved); maintainer text that fails the public-safe
  * filter is dropped, never published.
@@ -812,7 +812,7 @@ export type VisualConfig = {
   enabled: boolean | null;
   /** `review.visual.theme_storage_key` (#4109): the `localStorage` key the capture pipeline ALSO forces
    *  `theme` into (plus a reload) before rendering, for a target whose theming reads an explicit stored
-   *  preference instead of consulting `prefers-color-scheme` — verified (against gittensory-ui's own
+   *  preference instead of consulting `prefers-color-scheme` — verified (against loopover-ui's own
    *  dark-mode-only build) that `emulateMediaFeatures` alone has zero effect on that class of app, since it
    *  only changes what CSS media queries / `matchMedia` report. null (default) ⇒ no `localStorage` write, no
    *  reload — byte-identical to today. Only takes effect when `themes` is also configured; the key name is
@@ -851,7 +851,7 @@ export type VisualPreviewConfig = {
 export type VisualRoutesConfig = {
   /** `review.visual.routes.paths`: an explicit, always-screenshotted route list. When non-empty, this
    *  REPLACES automatic file-to-route inference entirely — for repos whose routing convention isn't
-   *  gittensory-ui's TanStack file-based one, an explicit list is simpler and more robust than trying to
+   *  loopover-ui's TanStack file-based one, an explicit list is simpler and more robust than trying to
    *  infer one. Empty (default) ⇒ automatic inference (falling back to "/" when nothing matches). */
   paths: string[];
   /** `review.visual.routes.max_routes`: overrides the built-in cap (2) on how many routes get screenshotted
@@ -1547,7 +1547,7 @@ export function featuresConfigToJson(features: FocusManifestFeaturesConfig): Jso
 /**
  * Parse the optional `experimental:` mapping — per-repo activation for optional ecosystem/network plugins
  * (starting with `gittensor`, the subnet mining/scoring integration). Mirrors parseFeaturesConfig's shape and
- * validation; kept as a SEPARATE top-level block from `features:` so plugin integrations that couple gittensory
+ * validation; kept as a SEPARATE top-level block from `features:` so plugin integrations that couple loopover
  * to an external network stay visibly distinct from the converged REVIEW capabilities `features:` toggles, and
  * so future plugins land in the same place without touching `features:`'s semantics.
  */
@@ -2185,7 +2185,7 @@ function parseSettingsOverride(value: JsonValue | undefined, warnings: string[])
   const moderationBannedLabel = normalizeModerationLabel(r.moderationBannedLabel);
   if (moderationBannedLabel !== undefined) out.moderationBannedLabel = moderationBannedLabel;
   // Review-evasion protection (#review-evasion-protection): a contributor closing/converting-to-draft their
-  // own PR while gittensory has an active review pass running is dodging the one-shot review.
+  // own PR while loopover has an active review pass running is dodging the one-shot review.
   const reviewEvasionProtection = normalizeOptionalEnum(r.reviewEvasionProtection, "settings.reviewEvasionProtection", ["off", "close"] as const, warnings);
   if (reviewEvasionProtection !== null) out.reviewEvasionProtection = reviewEvasionProtection;
   // #label-scoping: same load-bearing-null idiom as blacklistLabel above.
@@ -3114,7 +3114,7 @@ export function parseFocusManifest(raw: unknown, source?: FocusManifestSource): 
 
 /**
  * Parse raw manifest file/record content (JSON or YAML). Malformed content degrades to an empty
- * manifest with a warning rather than throwing, so a broken `.gittensory` config never breaks analysis.
+ * manifest with a warning rather than throwing, so a broken `.loopover` config never breaks analysis.
  */
 export function parseFocusManifestContent(content: string | null | undefined, source: FocusManifestSource = "repo_file"): FocusManifest {
   if (content === undefined || content === null || content.trim() === "") return emptyManifest(source);
@@ -3163,7 +3163,7 @@ function normalizePathForMatch(path: string): string {
 
 /**
  * LINEAR-TIME wildcard matcher for a `*`-glob pattern over an already-normalized path. `*` (and a collapsed
- * run of `*`) matches any run of characters INCLUDING `/` (gittensory globs cross slashes). Implemented as a
+ * run of `*`) matches any run of characters INCLUDING `/` (loopover globs cross slashes). Implemented as a
  * prefix + suffix + ordered-substring (indexOf) scan rather than a `.*`-per-star regex: the old regex
  * (`^.*a.*a...$`) backtracks catastrophically on a near-miss path and could hang the gate for an entire repo
  * (a manifest glob with many non-adjacent `*`). This algorithm is O(path × parts) with NO backtracking.

--- a/packages/loopover-engine/src/focus-manifest/guidance.ts
+++ b/packages/loopover-engine/src/focus-manifest/guidance.ts
@@ -20,7 +20,7 @@ function normalizePathForMatch(path: string): string {
 
 /**
  * LINEAR-TIME wildcard matcher for a `*`-glob pattern over an already-normalized path. `*` (and a collapsed
- * run of `*`) matches any run of characters INCLUDING `/` (gittensory globs cross slashes). Implemented as a
+ * run of `*`) matches any run of characters INCLUDING `/` (loopover globs cross slashes). Implemented as a
  * prefix + suffix + ordered-substring (indexOf) scan rather than a `.*`-per-star regex: the old regex
  * (`^.*a.*a...$`) backtracks catastrophically on a near-miss path and could hang the gate for an entire repo
  * (a manifest glob with many non-adjacent `*`). This algorithm is O(path × parts) with NO backtracking.

--- a/packages/loopover-engine/src/index.ts
+++ b/packages/loopover-engine/src/index.ts
@@ -1,7 +1,7 @@
 // Barrel export for @loopover/engine.
 //
 // This package houses the deterministic, side-effect-free logic shared by the LoopOver review-stack
-// backend and the gittensory-miner (scoring preview/model, predicted-gate types, reward-risk, slop signals,
+// backend and the loopover-miner (scoring preview/model, predicted-gate types, reward-risk, slop signals,
 // focus-manifest parse/compile core, duplicate-winner adjudication, and their engine-parity fixtures).
 // More modules land in follow-up issues.
 export { ENGINE_VERSION } from "./version.js";
@@ -193,7 +193,7 @@ export {
   type AcceptanceCriteria,
   type AcceptanceCriteriaInput,
 } from "./miner/acceptance-criteria.js";
-// Pure deny-hook evaluator + rule-proposal synthesis moved out of gittensory-miner (#5667). The miner-lib
+// Pure deny-hook evaluator + rule-proposal synthesis moved out of loopover-miner (#5667). The miner-lib
 // `deny-hooks.js`/`deny-hook-synthesis.js` are now thin wrappers over these (the SQLite proposal store stays in
 // the miner). `synthesizeDenyRuleProposals` takes an injected `nowMs` clock so synthesis is deterministic/pure.
 export {
@@ -775,7 +775,7 @@ export {
 } from "./reward-risk.js";
 
 // Shared subprocess env-allowlist + secret-redaction helpers (#4284) — one source of truth for every driver that
-// spawns a locally-authenticated CLI subprocess (src/selfhost/ai.ts and the coming gittensory-miner drivers).
+// spawns a locally-authenticated CLI subprocess (src/selfhost/ai.ts and the coming loopover-miner drivers).
 export {
   SUBPROCESS_CLI_ENV_ALLOWLIST,
   buildAllowlistedEnv,

--- a/packages/loopover-engine/src/issue-rag-query.ts
+++ b/packages/loopover-engine/src/issue-rag-query.ts
@@ -1,5 +1,5 @@
 // Issue-centric RAG query composition (#2320), extracted from `src/review/issue-rag-wire.ts` (#4254) so the
-// gittensory-miner analyze phase can build the identical retrieval query without importing the review stack.
+// loopover-miner analyze phase can build the identical retrieval query without importing the review stack.
 // Pure, string-only: the miner has no PR diff yet, so retrieval is fed from the issue's title/body/labels
 // while the RAG engine itself stays unchanged (retrieveContext remains Vectorize/D1-bound in `src/review/rag.ts`
 // and is intentionally NOT part of this module).

--- a/packages/loopover-engine/src/local-scorer.ts
+++ b/packages/loopover-engine/src/local-scorer.ts
@@ -1,5 +1,5 @@
 // #782 deterministic local scorer, extracted from src/signals/local-scorer.ts (#4253) so the published
-// gittensory-mcp / gittensory-miner CLIs and the hosted Worker share one implementation. Replicates the
+// loopover-mcp / loopover-miner CLIs and the hosted Worker share one implementation. Replicates the
 // gittensor-root token-scoring view from changed-file METADATA (paths + line counts) — never source content,
 // so the no-upload boundary holds and it runs in every surface. It mirrors buildScorePreview's
 // source/test/non-code classification, so feeding its output back in as `localScorer` (mode external_command)
@@ -56,7 +56,7 @@ export function computeLocalScorerTokens(input: { changedFiles: LocalScorerChang
   const warnings = failed ? ["Local validation reported failures — token scores describe the diff, not a passing build."] : [];
   return {
     mode: "external_command",
-    activeModel: "gittensory-deterministic",
+    activeModel: "loopover-deterministic",
     sourceTokenScore,
     totalTokenScore,
     sourceLines: Math.max(1, sourceTokenScore || totalTokenScore || 1),

--- a/packages/loopover-engine/src/miner-prediction-metrics.ts
+++ b/packages/loopover-engine/src/miner-prediction-metrics.ts
@@ -3,9 +3,9 @@
 // prediction-ledger rows (packages/loopover-miner/lib/prediction-ledger.js `readPredictions`) — optionally
 // joined with their realized outcome — into counters a future dashboard can scrape.
 //
-// Scoped as an on-demand RENDERER, not a live HTTP registry: gittensory-miner is a local CLI, not a daemon, so a
+// Scoped as an on-demand RENDERER, not a live HTTP registry: loopover-miner is a local CLI, not a daemon, so a
 // caller renders this to stdout for its own scrape/cron setup and reads the ledger itself (no data collection of
-// its own lives here — this stays a pure, side-effect-free function like the rest of gittensory-engine). It mirrors
+// its own lives here — this stays a pure, side-effect-free function like the rest of loopover-engine). It mirrors
 // the metric-naming (`loopover_miner_*_total`) and HELP/TYPE/label conventions of src/selfhost/metrics.ts rather
 // than importing across the package boundary.
 //

--- a/packages/loopover-engine/src/miner/acceptance-criteria.ts
+++ b/packages/loopover-engine/src/miner/acceptance-criteria.ts
@@ -8,7 +8,7 @@ import type { FeasibilityGateResult, FeasibilityVerdict } from "../feasibility.j
 // agent "boundary membrane") and the `FeasibilityGateResult` go/raise/avoid verdict (feasibility.ts) — into one
 // document. Producing the document is this module's job; actually writing it into the attempt's worktree is the
 // worktree primitive's (#4269), and handing it to the driver is the driver interface's (#4262) — neither is here,
-// so this stays pure and side-effect-free like the rest of gittensory-engine.
+// so this stays pure and side-effect-free like the rest of loopover-engine.
 //
 // DECISIONS this file makes (per the issue's open questions):
 // - Serialization format: JSON, not markdown. The acceptance criteria are an immutable, checksum-verifiable success

--- a/packages/loopover-engine/src/miner/attempt-log.ts
+++ b/packages/loopover-engine/src/miner/attempt-log.ts
@@ -140,7 +140,7 @@ export function formatAttemptLogJsonl(events: readonly NormalizedAttemptLogEvent
   return events.map((event) => JSON.stringify(event)).join("\n");
 }
 
-/** In-memory appender for tests and local tooling — production persistence uses `gittensory-miner/lib/attempt-log.js`. */
+/** In-memory appender for tests and local tooling — production persistence uses `loopover-miner/lib/attempt-log.js`. */
 export function createAttemptLogBuffer(): {
   append: (event: AttemptLogEvent) => NormalizedAttemptLogEvent;
   events: () => readonly NormalizedAttemptLogEvent[];

--- a/packages/loopover-engine/src/miner/cli-subprocess-driver.ts
+++ b/packages/loopover-engine/src/miner/cli-subprocess-driver.ts
@@ -7,7 +7,7 @@ import { buildAllowlistedEnv, redactSecrets } from "../subprocess-env.js";
 
 // CLI-subprocess CodingAgentDriver (#4266). Implements the CodingAgentDriver seam (#4262) by running the coding
 // agent (`claude`/`codex`) as a subprocess in the attempt's scoped working directory. The spawn primitive is
-// INJECTED (a generalized version of src/selfhost/ai.ts's SpawnFn, redeclared here so gittensory-engine stays
+// INJECTED (a generalized version of src/selfhost/ai.ts's SpawnFn, redeclared here so loopover-engine stays
 // standalone and doesn't import from src/), so the driver is fully testable without a real child process. Two
 // safety primitives are reused from subprocess-env.ts (#4284) rather than re-implemented: the child gets a STRICT
 // allowlisted env (never the full host env — a coding-agent subprocess is prompt-injectable), and any subprocess

--- a/packages/loopover-engine/src/miner/iterate-policy.ts
+++ b/packages/loopover-engine/src/miner/iterate-policy.ts
@@ -3,7 +3,7 @@
 // from the loop MECHANICS (#2333) so the actual thresholds/rules are one small, individually-reviewable, pure
 // artifact -- `decideNextAction` needs no driver, no worktree, no IO to test.
 //
-// STRATEGIC CONSTRAINTS this policy encodes (gittensory-miner-autonomy-roadmap):
+// STRATEGIC CONSTRAINTS this policy encodes (loopover-miner-autonomy-roadmap):
 //   - "never auto-submit (P4) before governor+caps (P5)" -- a mandatory clean predicted-gate PASS is the ONLY
 //     path to `"handoff"`; an ambiguous or errored self-review downgrades to abandon, never optimistically
 //     hands off.

--- a/packages/loopover-engine/src/miner/local-write-tools.ts
+++ b/packages/loopover-engine/src/miner/local-write-tools.ts
@@ -1,4 +1,4 @@
-// #780 miner write-tools. These build ACTION SPECS — gittensory supplies the content; the miner's OWN local
+// #780 miner write-tools. These build ACTION SPECS — loopover supplies the content; the miner's OWN local
 // harness runs the command with its OWN GitHub credentials. LoopOver NEVER performs the write, so source code
 // and the write both stay on the miner's machine: the no-cloud-write boundary holds. Pure + deterministic: every
 // builder returns a self-contained, shell-safe spec and touches nothing.
@@ -6,7 +6,7 @@
 // MOVED HERE FROM src/mcp/local-write-tools.ts (#2337): this module has zero root-specific dependencies (it only
 // ever needed a generic JSON-value type), so it belongs in the shared "brain" layer alongside the rest of the
 // portable engine, not root-only. This is what lets packages/loopover-miner's own real driving-loop entrypoint
-// construct the EXACT SAME open_pr command gittensory's MCP server would return, with zero network round-trip
+// construct the EXACT SAME open_pr command loopover's MCP server would return, with zero network round-trip
 // and zero duplicated/drifting logic: both consumers import the same functions from this one place. Root's
 // src/mcp/local-write-tools.ts is now a thin re-export preserving every existing import path unchanged.
 
@@ -37,7 +37,7 @@ function spec(action: string, description: string, inputs: Record<string, LocalW
   return { action, description, inputs, command, boundary: LOCAL_WRITE_BOUNDARY };
 }
 
-/** Open a PR from a local branch (content typically taken from gittensory's prepare_pr_packet). */
+/** Open a PR from a local branch (content typically taken from loopover's prepare_pr_packet). */
 export function buildOpenPrSpec(input: { repoFullName: string; base: string; head: string; title: string; body: string; draft?: boolean | undefined }): LocalWriteActionSpec {
   const draft = input.draft === true;
   const command = `gh pr create --repo ${sq(input.repoFullName)} --base ${sq(input.base)} --head ${sq(input.head)} --title ${sq(input.title)} --body ${sq(input.body)}${draft ? " --draft" : ""}`;
@@ -101,7 +101,7 @@ export function buildDeleteBranchSpec(input: { branch: string; remote?: boolean 
 // verb that "scaffolds a test file" across vitest/jest/pytest/go test/rspec/cargo test — so `command` here is a
 // safe, informative `echo` of the plan (target files + boundary criteria) rather than a real write, and the
 // actual scaffolding is left to the contributor's OWN agent reading the structured `inputs`. This keeps the same
-// no-cloud-write guarantee as every other spec in this file: gittensory supplies WHAT test cases should exist at
+// no-cloud-write guarantee as every other spec in this file: loopover supplies WHAT test cases should exist at
 // which boundaries, never the test file content or its execution.
 export function buildTestGenSpec(input: {
   repoFullName: string;

--- a/packages/loopover-engine/src/miner/worktree-pool.ts
+++ b/packages/loopover-engine/src/miner/worktree-pool.ts
@@ -4,7 +4,7 @@
 // tears down ONE worktree; this manages the SET of them so two concurrent attempts never collide and a crash
 // can't leak worktree slots forever.
 //
-// Per #4297, the pure allocation logic lives here in gittensory-engine so it is unit-testable WITHOUT touching
+// Per #4297, the pure allocation logic lives here in loopover-engine so it is unit-testable WITHOUT touching
 // a real filesystem or database. The thin bookkeeping wrapper that PERSISTS this state (local SQLite, the same
 // way claim-ledger.js / run-state.js do) is a separate miner-package layer — it holds a WorktreePoolState,
 // calls these pure transitions, and writes the result back. No IO here: every function takes state in and

--- a/packages/loopover-engine/src/prompt-packet.ts
+++ b/packages/loopover-engine/src/prompt-packet.ts
@@ -1,4 +1,4 @@
-// Metadata-only prompt-packet builder (#2321): four analyze-phase text fields scrubbed with the same PUBLIC_UNSAFE_TERMS / PUBLIC_LOCAL_PATH_INLINE vocabulary as src/signals/redaction.ts (duplicated here so gittensory-engine stays standalone).
+// Metadata-only prompt-packet builder (#2321): four analyze-phase text fields scrubbed with the same PUBLIC_UNSAFE_TERMS / PUBLIC_LOCAL_PATH_INLINE vocabulary as src/signals/redaction.ts (duplicated here so loopover-engine stays standalone).
 
 /** Canonical economic/identity term vocabulary (alternation source only — mirrors `PUBLIC_UNSAFE_TERMS`). */
 const PUBLIC_UNSAFE_TERMS = String.raw`(?:reward|score|wallet|hotkey|coldkey|mnemonic|payout|ranking|cohort)\w*|miner[-_\s]?originated|human[-_\s]?originated|farming|raw[-_\s]?trust|trust[-_\s]?score|private[-_\s]?reviewability|reviewability`;

--- a/packages/loopover-engine/src/review/content-lane/content-repo-spec.ts
+++ b/packages/loopover-engine/src/review/content-lane/content-repo-spec.ts
@@ -1,7 +1,7 @@
 // Modular content-repository configuration for the curated-list content lane (the awesome-claude lane and any
 // self-hosted curated list). The curated-list analogue of RegistryLaneSpec (the metagraphed registry lane): a
 // maintainer whose list uses different categories or a different entry-file layout parameterizes the lane via
-// config instead of a gittensory code change. Defaults preserve the awesome-claude behaviour byte-for-byte.
+// config instead of a loopover code change. Defaults preserve the awesome-claude behaviour byte-for-byte.
 //
 // This is a LEAF module (no content-lane imports) so every consumer — scope, duplicates, source-evidence — can
 // import the spec without an import cycle. Fields are added here as each consumer is migrated.

--- a/packages/loopover-engine/src/review/content-lane/flag.ts
+++ b/packages/loopover-engine/src/review/content-lane/flag.ts
@@ -1,10 +1,10 @@
-// Content-lane feature flag (convergence — reviewbot→gittensory content-review port).
+// Content-lane feature flag (convergence — reviewbot→loopover content-review port).
 //
-// gittensory's native code-gate reviews CODE repos. The content lane reviews CONTENT repos — a
+// loopover's native code-gate reviews CODE repos. The content lane reviews CONTENT repos — a
 // curated list (awesome-claude) and a registry (metagraphed) — a different domain with its own
 // deterministic primitives (duplicate detection, source-evidence reachability, security scanning,
 // scope classification, and metagraphed's netuid grounding). The lane is ported as native,
-// self-contained gittensory modules under this directory.
+// self-contained loopover modules under this directory.
 //
 // FLAG-GATED + DEFAULT-OFF: the lane only runs when LOOPOVER_REVIEW_CONTENT_LANE is truthy in the Env.
 // Flag-off, the host never reaches these modules, so the live behavior is byte-identical. At

--- a/packages/loopover-engine/src/review/safe-url.ts
+++ b/packages/loopover-engine/src/review/safe-url.ts
@@ -1,6 +1,6 @@
 // SSRF-safe URL guard (content-lane primitive).
 //
-// SELF-CONTAINED NATIVE PORT (reviewbot→gittensory convergence). Ported from reviewbot's
+// SELF-CONTAINED NATIVE PORT (reviewbot→loopover convergence). Ported from reviewbot's
 // core/source-url.ts isSafeHttpUrl + isSafeEndpointUrl (the host/IP guard, including the encoded-IP
 // decoding that a dotted-quad regex misses), hardened so a trailing-dot or `*.localhost` host can't
 // dodge the loopback check. PURE — no imports, no I/O.

--- a/packages/loopover-engine/test/local-scorer.test.ts
+++ b/packages/loopover-engine/test/local-scorer.test.ts
@@ -16,7 +16,7 @@ test("classifies source / test / non-code disjointly from changed-file metadata"
     ],
   });
   assert.equal(r.mode, "external_command");
-  assert.equal(r.activeModel, "gittensory-deterministic");
+  assert.equal(r.activeModel, "loopover-deterministic");
   assert.equal(r.sourceTokenScore, 12);
   assert.equal(r.testTokenScore, 6);
   assert.equal(r.nonCodeTokenScore, 4);

--- a/src/rules/advisory.ts
+++ b/src/rules/advisory.ts
@@ -910,7 +910,7 @@ function conclusionForSeverity(severity: AdvisorySeverity, findings: AdvisoryFin
 
 function isEvaluationBlocker(code: string, policy: GateCheckPolicy): boolean {
   // pre_merge_check_unresolved: an enforced path-gated pre-merge check whose changed-file set could not be
-  // resolved — gittensory cannot evaluate it yet, so the gate is NEUTRAL (held) and re-evaluates on the next
+  // resolved — loopover cannot evaluate it yet, so the gate is NEUTRAL (held) and re-evaluates on the next
   // sync, rather than auto-merging past the unverified requirement or hard-closing on a transient miss. (#review-audit)
   if (code === "repo_not_registered" || code === "repo_not_seen" || code === "pr_not_cached" || code === "pre_merge_check_unresolved") return true;
   // cla_check_unresolved (#2564): the CLA-bot check-run's conclusion could not be resolved. Unlike the codes

--- a/test/unit/local-scorer.test.ts
+++ b/test/unit/local-scorer.test.ts
@@ -12,7 +12,7 @@ describe("computeLocalScorerTokens (#782)", () => {
     });
     expect(scorer).toMatchObject({
       mode: "external_command",
-      activeModel: "gittensory-deterministic",
+      activeModel: "loopover-deterministic",
       sourceTokenScore: 12,
       testTokenScore: 8,
       nonCodeTokenScore: 6,


### PR DESCRIPTION
## Summary

- Part of the gittensory→loopover rebrand (#5705), phase 8b: rename brand-name prose in comments across 19 `packages/loopover-engine/src/**/*.ts` files (advisory, duplicate detection, focus-manifest, index, issue-rag-query, local-scorer, miner-prediction-metrics, the miner subsystem, prompt-packet, and review content-lane/guardrail modules), plus `src/rules/advisory.ts`. Comment-only, except:
  - `local-scorer.ts`'s `activeModel: "gittensory-deterministic"` value — an internal, non-persisted string with no external consumer besides its own test, updated in the same commit.
  - `src/rules/advisory.ts` and `packages/loopover-engine/src/advisory/gate-advisory.ts` share a deliberately-divergent gate-decision marker pair (`GATE_DECISION_TWIN_PAIR` in `scripts/check-engine-parity.ts`) that must change together in one PR — both renamed here.
- Two files in this batch (`review/guardrail-config.ts`, `review/linked-issue-label-propagation.ts`) are byte-identical twins of already-renamed host files (`src/review/**`); this batch picks up main's already-correct state for them via rebase, so `scripts/check-engine-parity.ts` stays green.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue this PR resolves — N/A, maintainer-authored rebrand-epic cleanup (#5705), no linked-issue gate applies to owner PRs.

## Validation

- [x] `git diff --check`
- [x] `npx tsx scripts/check-engine-parity.ts` — ok (verified with a real base-ref, matching CI)
- [x] `npm run typecheck` — clean

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no such changes.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, comment-only, no behavior change.
- [ ] UI changes use live API data or real empty/error/loading states. — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section. — N/A, no UI changes.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs (none touched here).

## Notes

- One of several batched PRs covering the bulk-prose portion of rebrand epic #5705.