### PR TITLE
docs(engine): rename gittensory prose to loopover in packages/loopover-engine (batch B)

### DIFF
--- a/packages/loopover-engine/src/reward-risk.ts
+++ b/packages/loopover-engine/src/reward-risk.ts
@@ -1,5 +1,5 @@
 // Deterministic reward/risk reasoning signals, extracted to `@loopover/engine` (#2281) so the
-// gittensory-miner can rank candidate work locally with the same logic the maintainer-side gate computes.
+// loopover-miner can rank candidate work locally with the same logic the maintainer-side gate computes.
 //
 // Unlike the earlier self-contained extractions, reward-risk sits on top of the maintainer signal stack in
 // `packages/loopover-engine/src/signals/engine.ts` (#4884; monorepo shim at `src/signals/engine.ts`).
@@ -925,7 +925,7 @@ function pickIssueTimestamp(issue: IssueRecord): string | null {
   return null;
 }
 
-/** Unknown/unparseable timestamps floor freshness (parity with gittensory-engine opportunity-freshness.ts). */
+/** Unknown/unparseable timestamps floor freshness (parity with loopover-engine opportunity-freshness.ts). */
 function issueAgeDays(value: string | null): number {
   if (!value) return Number.POSITIVE_INFINITY;
   const parsed = Date.parse(value);

--- a/packages/loopover-engine/src/scoring/model.ts
+++ b/packages/loopover-engine/src/scoring/model.ts
@@ -99,7 +99,7 @@ export function parsePythonNumberConstants(source: string, options: { knownOnly?
 }
 
 /**
- * Upstream operational/infra constants gittensory intentionally does not model in score previews.
+ * Upstream operational/infra constants loopover intentionally does not model in score previews.
  * They are not scoring dimensions — surfacing them as "unmodeled drift" is noise (#809).
  */
 const NON_SCORING_UPSTREAM_CONSTANT_NAMES = new Set([
@@ -120,12 +120,12 @@ const NON_SCORING_UPSTREAM_CONSTANT_NAMES = new Set([
   // false-positive unmodeled-scoring-drift warning (#809).
   "EMISSION_SHARE_TOLERANCE",
   // Fallback weight applied by the validator's load_programming_language_weights() for extensions absent from
-  // the JSON file; gittensory reads the JSON directly and does not track this loader default (#1692).
+  // the JSON file; loopover reads the JSON directly and does not track this loader default (#1692).
   "DEFAULT_PROGRAMMING_LANGUAGE_WEIGHT",
 ]);
 
 /**
- * Numeric constant names upstream gittensor defines that gittensory's scoring engine does NOT model.
+ * Numeric constant names upstream gittensor defines that loopover's scoring engine does NOT model.
  * The normal parse is `knownOnly` (it keeps only constants we already encode), which silently hides
  * upstream ADDITIONS — e.g. a newly-introduced time-decay constant. Surfacing these makes scoring
  * staleness visible: if upstream adds a scoring dimension, an operator sees it instead of the gate

--- a/packages/loopover-engine/src/settings/auto-close-exempt.ts
+++ b/packages/loopover-engine/src/settings/auto-close-exempt.ts
@@ -1,4 +1,4 @@
-// Shared repo-scoped exemption list (#2463) for gittensory's deterministic anti-abuse auto-close/throttle
+// Shared repo-scoped exemption list (#2463) for loopover's deterministic anti-abuse auto-close/throttle
 // mechanisms — currently the review-nag cooldown; intended to be reused by the per-contributor open-item cap
 // (#2270) once that lands, rather than each feature growing its own duplicate whitelist. A maintainer-named
 // GitHub login here is NEVER throttled or closed by either mechanism, on top of the standing owner/admin/

--- a/packages/loopover-engine/src/signals/duplicate-winner.ts
+++ b/packages/loopover-engine/src/signals/duplicate-winner.ts
@@ -1,7 +1,7 @@
 /**
  * Duplicate-winner adjudication (#dup-winner) — thin re-export shim (#4251). This file and
  * `../duplicate-winner.ts` were accidental byte-identical forks living inside the same package (not a
- * `src/`-vs-engine extraction pair; both copies were already inside `gittensory-engine`). The top-level module
+ * `src/`-vs-engine extraction pair; both copies were already inside `loopover-engine`). The top-level module
  * is the source of truth; see its doc comment for the full election-order rationale (claim-time election,
  * anti-backdating semantics). Kept as a re-export (not deleted) so `advisory/gate-advisory.ts`'s existing
  * `../signals/duplicate-winner.js` import keeps resolving without a call-site change.

--- a/packages/loopover-engine/src/signals/engine.ts
+++ b/packages/loopover-engine/src/signals/engine.ts
@@ -4459,7 +4459,7 @@ export function buildPublicPrIntelligenceComment(args: {
   const gateHeld = gateEnabled && (gateConclusion === "neutral" || gateConclusion === "action_required");
   const missingLinkedIssue = args.pr.linkedIssues.length === 0 && !hasClearNoIssueRationale(args.pr);
   const confirmedMiner = isOfficialContributorDetection(args.detection);
-  // Author with no Gittensor footprint at all (not detected via official API or cache): gittensory's
+  // Author with no Gittensor footprint at all (not detected via official API or cache): loopover's
   // contribution analysis is for Gittensor contributors, so fire MINIMALLY — a brief welcome + the
   // earn invite — instead of the full readiness panel. A KNOWN contributor (official or cached) still
   // gets the full review. The always-on footer CTA appears either way, so every PR keeps marketing.
@@ -4619,7 +4619,7 @@ export function buildPublicPrIntelligenceComment(args: {
   ].join("\n");
 }
 
-/** Minimal public comment for a non-registered contributor. gittensory's readiness/contribution
+/** Minimal public comment for a non-registered contributor. loopover's readiness/contribution
  *  analysis is for registered Gittensor contributors, so we skip the panel and post a brief welcome
  *  + earn invite; the always-on footer CTA does the conversion. Carries the same panel marker so it
  *  updates in place if the author later registers (the full panel then replaces it). */
@@ -4652,7 +4652,7 @@ export type PublicPrPanelSignalRow = { key: ReviewFieldKey; cells: [string, stri
  * Build the public PR panel's readiness signal rows (the `allRows` table) as a PURE function, from the
  * SAME inputs `buildPublicPrIntelligenceComment` uses. It calls the same private panel helpers, so the rows
  * are byte-identical to the legacy panel's. Exposed for the unified-comment bridge (convergence) so the
- * converged comment surfaces gittensory's exact signals; the legacy path is unchanged. The `key` lets the
+ * converged comment surfaces loopover's exact signals; the legacy path is unchanged. The `key` lets the
  * caller honor `.loopover.yml review.fields` visibility the same way the legacy renderer does.
  */
 export function buildPublicPrPanelSignalRows(args: {

--- a/packages/loopover-engine/src/signals/path-matchers.ts
+++ b/packages/loopover-engine/src/signals/path-matchers.ts
@@ -1,7 +1,7 @@
 import { isCodeFile, isTestPath } from "./test-evidence.js";
 
 // Pure, deterministic path matchers for slop classification (#561), extracted to
-// `@loopover/engine` (#4252) so the published gittensory-mcp/gittensory-miner CLIs can depend on
+// `@loopover/engine` (#4252) so the published loopover-mcp/loopover-miner CLIs can depend on
 // the same source instead of hand-porting it. Siblings to `isTestFile` / `isTestPath`: they identify changed
 // files that are NOT genuine hand-authored effort — machine-generated output, vendored/imported third-party
 // code, minified bundles, dependency lockfiles, and docs — so slop signals can tell a padded diff from real
@@ -16,7 +16,7 @@ export function isTestFile(file: string): boolean {
   return isTestPath(file);
 }
 
-// isCodeFile is the single source of truth the published gittensory-mcp/gittensory-miner CLIs also
+// isCodeFile is the single source of truth the published loopover-mcp/loopover-miner CLIs also
 // depend on — defined once in test-evidence.ts alongside the isSourcePath/isTestPath pair it composes,
 // re-exported here so this file's existing callers don't change.
 export { isCodeFile };

--- a/packages/loopover-engine/src/signals/test-evidence.ts
+++ b/packages/loopover-engine/src/signals/test-evidence.ts
@@ -36,7 +36,7 @@ const EXTENDED_SOURCE_EXTENSION = /\.(php|cpp|cc|c|h|hpp|m|vue|svelte|astro|dart
 /** cs/swift/groovy/kts plus php, C/C++/Objective-C, vue/svelte/astro, and dart — see isSourcePath for the
  *  canonical JVM/.NET/Swift/Groovy/Kotlin-script matcher kept symmetric with isTestPath. Generated Dart part
  *  files (.g.dart/.freezed.dart/.gr.dart) stay non-code (#3724). The single source of truth both the Worker
- *  (src/signals/path-matchers.ts) and the published @loopover/mcp/gittensory-miner CLIs delegate
+ *  (src/signals/path-matchers.ts) and the published @loopover/mcp/loopover-miner CLIs delegate
  *  to, so the three previously-independent hand-ports can't silently drift from each other again. */
 export function isCodeFile(file: string): boolean {
   if (isSourcePath(file)) return true;

--- a/packages/loopover-engine/src/signals/unlinked-issue-candidates.ts
+++ b/packages/loopover-engine/src/signals/unlinked-issue-candidates.ts
@@ -6,7 +6,7 @@
 // just to save an AI call.
 //
 // Extracted out of `src/signals/unlinked-issue-candidates.ts` into the shared engine (#4883) so the published
-// gittensory-miner/gittensory-mcp CLIs can run the identical recall pass the maintainer gate uses, instead of
+// loopover-miner/loopover-mcp CLIs can run the identical recall pass the maintainer gate uses, instead of
 // a driftable second copy; `src/signals/unlinked-issue-candidates.ts` is now a thin re-export shim (imported
 // via relative source path, matching this repo's existing engine-consumption convention — see src/signals/slop.ts).
 

--- a/packages/loopover-engine/src/subprocess-env.ts
+++ b/packages/loopover-engine/src/subprocess-env.ts
@@ -1,6 +1,6 @@
 // Shared subprocess env-allowlist + secret-redaction helpers (#4284). Any driver that spawns a locally-authenticated
 // CLI (the review `claude`/`codex` subprocess in src/selfhost/ai.ts, and the coding-agent drivers coming in
-// gittensory-miner) needs the SAME two safety primitives: hand the child a STRICT allowlisted env (never the full
+// loopover-miner) needs the SAME two safety primitives: hand the child a STRICT allowlisted env (never the full
 // worker/host env, which can carry runtime credentials into a prompt-injectable subprocess), and redact well-known
 // secret shapes out of the child's untrusted stderr before it reaches logs. This module is the single engine-hosted
 // source of truth for both, so those callers depend on one implementation instead of copy-pasting the pattern.

--- a/packages/loopover-engine/src/tenant-config.ts
+++ b/packages/loopover-engine/src/tenant-config.ts
@@ -1,6 +1,6 @@
 // Per-tenant configuration layer (pure) — #4787, part of the Rent-a-Loop path #4778.
 //
-// A customer's own autonomy/config, scoped strictly to their rented repo and independent of gittensory's own
+// A customer's own autonomy/config, scoped strictly to their rented repo and independent of loopover's own
 // configuration. Deterministic and side-effect-free: it resolves a tenant's effective config from the defaults
 // plus their overrides, and holds per-tenant configs in an IMMUTABLE store. Isolation is guaranteed by
 // construction — every resolve returns a NEW config with freshly-copied collections, and every store update

--- a/packages/loopover-engine/src/types/manifest-deps-types.ts
+++ b/packages/loopover-engine/src/types/manifest-deps-types.ts
@@ -410,7 +410,7 @@ export type RepositorySettings = {
    *  touched. */
   contributorCapLabel?: string | null | undefined;
   /** Cancel in-flight CI runs on a contributor_cap close (#2462, anti-abuse): when true, after a PR is
-   *  auto-closed for exceeding {@link contributorOpenPrCap}, gittensory lists and cancels that PR's
+   *  auto-closed for exceeding {@link contributorOpenPrCap}, loopover lists and cancels that PR's
    *  in-progress/queued Actions runs at its head SHA. Requires the App installation to have granted
    *  `actions: write` -- degrades gracefully (skipped + logged, never blocks the close) when it hasn't.
    *  `null`/undefined (the DB-layer default) means "unset" and falls back to the
@@ -448,7 +448,7 @@ export type RepositorySettings = {
    *  or a login on {@link autoCloseExemptLogins}. */
   reviewNagMonitoredMentions?: string[] | undefined;
   /** Shared repo-scoped exemption list (#2463, anti-abuse): GitHub logins that are NEVER throttled or closed by
-   *  gittensory's deterministic anti-abuse mechanisms (review-nag and the per-contributor open-item cap above),
+   *  loopover's deterministic anti-abuse mechanisms (review-nag and the per-contributor open-item cap above),
    *  on top of the standing owner/admin/automation-bot exemption. Always populated by the DB layer (default
    *  `[]`); optional so existing settings fixtures/callers need not be touched. */
   autoCloseExemptLogins?: string[] | undefined;
@@ -470,7 +470,7 @@ export type RepositorySettings = {
    *  apply one manual-review label without enabling ready/changes-requested disposition labels. */
   manualReviewLabel?: string | null | undefined;
   /** Optional review-state label names. Config-as-code only; each `null` disables that specific label. These are
-   *  deliberately generic defaults rather than `gittensory:*` names so self-hosters can opt into their own
+   *  deliberately generic defaults rather than `loopover:*` names so self-hosters can opt into their own
    *  taxonomy without inheriting project-specific labels. */
   readyToMergeLabel?: string | null | undefined;
   changesRequestedLabel?: string | null | undefined;
@@ -548,7 +548,7 @@ export type RepositorySettings = {
    *  the global config's `bannedLabel` (itself defaulting to `"mod:banned"`). */
   moderationBannedLabel?: string | undefined;
   /** Review-evasion protection (#review-evasion-protection): a contributor closing or converting their OWN
-   *  PR to draft while gittensory has an ACTIVE review pass running against it is dodging the one-shot
+   *  PR to draft while loopover has an ACTIVE review pass running against it is dodging the one-shot
    *  review process. `"off"` (the default) disables detection entirely; `"close"` reopens (if needed) and
    *  re-closes as the App -- a close the contributor cannot themselves reopen (#one-shot-reopen) -- applies
    *  the configured label/comment, and records a `review_evasion` moderation strike. */

--- a/packages/loopover-engine/test/ai-policy-map.test.ts
+++ b/packages/loopover-engine/test/ai-policy-map.test.ts
@@ -64,7 +64,7 @@ test("resolveAiPolicyVerdict still lets non-empty AI-USAGE.md take precedence", 
 
 test("resolveAiPolicyFatigueVerdict returns no fatigue signal for quiet metadata", () => {
   const verdict = resolveAiPolicyFatigueVerdict({
-    repoFullName: "JSONbored/gittensory",
+    repoFullName: "JSONbored/loopover",
     now: NOW,
     docs: { aiUsage: null, contributing: "Please write tests and keep PRs focused." },
     pullRequests: [
@@ -92,7 +92,7 @@ test("resolveAiPolicyFatigueVerdict returns no fatigue signal for quiet metadata
 
 test("resolveAiPolicyFatigueVerdict detects fatigue-only metadata without hard skipping", () => {
   const verdict = resolveAiPolicyFatigueVerdict({
-    repoFullName: "JSONbored/gittensory",
+    repoFullName: "JSONbored/loopover",
     now: NOW,
     docs: { aiUsage: null, contributing: "Please keep changes focused." },
     pullRequests: [
@@ -123,7 +123,7 @@ test("resolveAiPolicyFatigueVerdict detects fatigue-only metadata without hard s
 
 test("resolveAiPolicyFatigueVerdict treats watch-level evidence as deprioritize, not skip", () => {
   const verdict = resolveAiPolicyFatigueVerdict({
-    repoFullName: "JSONbored/gittensory",
+    repoFullName: "JSONbored/loopover",
     now: NOW,
     docs: { aiUsage: null, contributing: "Normal contribution guide." },
     pullRequests: [aiPr({ id: "single", maintainerResponse: "neutral", reviewDecision: "none" })],
@@ -138,7 +138,7 @@ test("resolveAiPolicyFatigueVerdict treats watch-level evidence as deprioritize,
 
 test("resolveAiPolicyFatigueVerdict keeps formal bans authoritative over fatigue", () => {
   const verdict = resolveAiPolicyFatigueVerdict({
-    repoFullName: "JSONbored/gittensory",
+    repoFullName: "JSONbored/loopover",
     now: NOW,
     docs: { aiUsage: "AI-generated PRs are rejected.", contributing: null },
     pullRequests: [
@@ -165,7 +165,7 @@ test("resolveAiPolicyFatigueVerdict keeps formal bans authoritative over fatigue
 
 test("resolveAiPolicyFatigueVerdict ignores doc changes that are already formal ban phrases", () => {
   const verdict = resolveAiPolicyFatigueVerdict({
-    repoFullName: "JSONbored/gittensory",
+    repoFullName: "JSONbored/loopover",
     now: NOW,
     docs: { aiUsage: null, contributing: "Current policy has no formal ban." },
     docChanges: [
@@ -184,7 +184,7 @@ test("resolveAiPolicyFatigueVerdict ignores doc changes that are already formal 
 
 test("resolveAiPolicyFatigueVerdict ignores AI language outside policy docs", () => {
   const verdict = resolveAiPolicyFatigueVerdict({
-    repoFullName: "JSONbored/gittensory",
+    repoFullName: "JSONbored/loopover",
     now: NOW,
     docs: { aiUsage: null, contributing: "Normal guide." },
     pullRequests: [],
@@ -213,7 +213,7 @@ test("resolveAiPolicyFatigueVerdict ignores AI language outside policy docs", ()
 
 test("resolveAiPolicyFatigueVerdict recency-weights doc language", () => {
   const fresh = resolveAiPolicyFatigueVerdict({
-    repoFullName: "JSONbored/gittensory",
+    repoFullName: "JSONbored/loopover",
     now: NOW,
     docs: { aiUsage: null, contributing: "Normal guide." },
     docChanges: [
@@ -225,7 +225,7 @@ test("resolveAiPolicyFatigueVerdict recency-weights doc language", () => {
     ],
   });
   const stale = resolveAiPolicyFatigueVerdict({
-    repoFullName: "JSONbored/gittensory",
+    repoFullName: "JSONbored/loopover",
     now: NOW,
     docs: { aiUsage: null, contributing: "Normal guide." },
     docChanges: [
@@ -244,7 +244,7 @@ test("resolveAiPolicyFatigueVerdict recency-weights doc language", () => {
 
 test("resolveAiPolicyFatigueVerdict reuses fresh cache entries", () => {
   const cache = createAiPolicyFatigueCacheEntry({
-    repoFullName: "JSONbored/Gittensory",
+    repoFullName: "JSONbored/Loopover",
     computedAt: "2026-07-04T12:00:00Z",
     verdict: {
       level: "deprioritize",
@@ -262,14 +262,14 @@ test("resolveAiPolicyFatigueVerdict reuses fresh cache entries", () => {
     },
   });
   const verdict = resolveAiPolicyFatigueVerdict({
-    repoFullName: "JSONbored/gittensory",
+    repoFullName: "JSONbored/loopover",
     now: NOW,
     docs: { aiUsage: null, contributing: "Normal guide." },
     cache,
     pullRequests: [aiPr({ id: "ignored-by-cache" })],
   });
 
-  assert.equal(cache.repoFullName, "jsonbored/gittensory");
+  assert.equal(cache.repoFullName, "jsonbored/loopover");
   assert.equal(cache.computedAt, "2026-07-04T12:00:00.000Z");
   assert.equal(verdict.fatigue?.level, "deprioritize");
   assert.equal(verdict.fatigue?.score, 0.5);
@@ -292,7 +292,7 @@ test("resolveAiPolicyFatigueVerdict recomputes fresh cache entries for other rep
     },
   });
   const verdict = resolveAiPolicyFatigueVerdict({
-    repoFullName: "JSONbored/gittensory",
+    repoFullName: "JSONbored/loopover",
     now: NOW,
     docs: { aiUsage: null, contributing: "Normal guide." },
     cache,
@@ -307,7 +307,7 @@ test("resolveAiPolicyFatigueVerdict recomputes fresh cache entries for other rep
 
 test("describeAiPolicyFatigueCache reports fresh, expired, missing, and malformed entries", () => {
   const cache = createAiPolicyFatigueCacheEntry({
-    repoFullName: "JSONbored/Gittensory",
+    repoFullName: "JSONbored/Loopover",
     computedAt: "2026-07-04T12:00:00Z",
     verdict: {
       level: "watch",
@@ -319,14 +319,14 @@ test("describeAiPolicyFatigueCache reports fresh, expired, missing, and malforme
   });
 
   assert.deepEqual(describeAiPolicyFatigueCache(cache, NOW), {
-    repoFullName: "jsonbored/gittensory",
+    repoFullName: "jsonbored/loopover",
     computedAt: "2026-07-04T12:00:00.000Z",
     expiresAt: "2026-07-05T12:00:00.000Z",
     ageHours: 12,
     fresh: true,
   });
   assert.deepEqual(describeAiPolicyFatigueCache(cache, "2026-07-06T00:00:00Z"), {
-    repoFullName: "jsonbored/gittensory",
+    repoFullName: "jsonbored/loopover",
     computedAt: "2026-07-04T12:00:00.000Z",
     expiresAt: "2026-07-05T12:00:00.000Z",
     ageHours: 36,
@@ -372,11 +372,11 @@ test("createAiPolicyFatigueCacheEntry rejects malformed repo keys", () => {
 
 test("resolveAiPolicyFatigueVerdict recomputes expired cache entries", () => {
   const verdict = resolveAiPolicyFatigueVerdict({
-    repoFullName: "JSONbored/gittensory",
+    repoFullName: "JSONbored/loopover",
     now: NOW,
     docs: { aiUsage: null, contributing: "Normal guide." },
     cache: {
-      repoFullName: "jsonbored/gittensory",
+      repoFullName: "jsonbored/loopover",
       computedAt: "2026-07-01T00:00:00Z",
       verdict: {
         level: "defer",
@@ -396,7 +396,7 @@ test("resolveAiPolicyFatigueVerdict recomputes expired cache entries", () => {
 
 test("resolveAiPolicyFatigueVerdict recognizes AI-attribution aliases from metadata only", () => {
   const verdict = resolveAiPolicyFatigueVerdict({
-    repoFullName: "JSONbored/gittensory",
+    repoFullName: "JSONbored/loopover",
     now: NOW,
     docs: { aiUsage: null, contributing: "Normal guide." },
     pullRequests: [
@@ -414,7 +414,7 @@ test("resolveAiPolicyFatigueVerdict recognizes AI-attribution aliases from metad
 
 test("resolveAiPolicyFatigueVerdict ignores open and merged AI-attributed PRs for rejection fatigue", () => {
   const verdict = resolveAiPolicyFatigueVerdict({
-    repoFullName: "JSONbored/gittensory",
+    repoFullName: "JSONbored/loopover",
     now: NOW,
     docs: { aiUsage: null, contributing: "Normal guide." },
     pullRequests: [
@@ -431,7 +431,7 @@ test("resolveAiPolicyFatigueVerdict ignores open and merged AI-attributed PRs fo
 
 test("resolveAiPolicyFatigueVerdict handles malformed timestamps with conservative weights", () => {
   const verdict = resolveAiPolicyFatigueVerdict({
-    repoFullName: "JSONbored/gittensory",
+    repoFullName: "JSONbored/loopover",
     now: "not a date",
     docs: { aiUsage: null, contributing: "Normal guide." },
     pullRequests: [aiPr({ closedAt: "not a date", createdAt: null })],
@@ -445,7 +445,7 @@ test("resolveAiPolicyFatigueVerdict handles malformed timestamps with conservati
 
 test("renderAiPolicyFatigueMarkdown renders deterministic observability output", () => {
   const verdict = resolveAiPolicyFatigueVerdict({
-    repoFullName: "JSONbored/gittensory",
+    repoFullName: "JSONbored/loopover",
     now: NOW,
     docs: { aiUsage: null, contributing: "Normal guide." },
     pullRequests: [aiPr({ id: "pr-1" }), aiPr({ id: "pr-2" })],
@@ -495,7 +495,7 @@ test("renderAiPolicyFatigueMarkdown escapes summaries and policy source fields",
 
 test("resolveAiPolicyFatigueVerdict is byte-stable for the same metadata", () => {
   const input = {
-    repoFullName: "JSONbored/gittensory",
+    repoFullName: "JSONbored/loopover",
     now: NOW,
     docs: { aiUsage: null, contributing: "Normal guide." },
     pullRequests: [aiPr({ id: "a" }), aiPr({ id: "b" })],

--- a/packages/loopover-engine/test/gate-advisory-ai-review-low-confidence-disposition.test.ts
+++ b/packages/loopover-engine/test/gate-advisory-ai-review-low-confidence-disposition.test.ts
@@ -17,8 +17,8 @@ function consensusAdvisory(confidence: number): Advisory {
   return {
     id: "advisory-1",
     targetType: "pull_request",
-    targetKey: "JSONbored/gittensory#1",
-    repoFullName: "JSONbored/gittensory",
+    targetKey: "JSONbored/loopover#1",
+    repoFullName: "JSONbored/loopover",
     conclusion: "action_required",
     severity: "critical",
     title: "LoopOver review",

--- a/packages/loopover-engine/test/gate-verdict-calibration.test.ts
+++ b/packages/loopover-engine/test/gate-verdict-calibration.test.ts
@@ -109,7 +109,7 @@ test("resolveGateVerdictCalibrationConfig warns and fails closed on malformed op
 test("ingestGateVerdictCalibrationSignals accepts only currently opted-in structured dimensions", () => {
   const ingestion = ingestGateVerdictCalibrationSignals([
     {
-      repoFullName: "JSONbored/Gittensory",
+      repoFullName: "JSONbored/Loopover",
       replayRunId: "replay-1",
       gateRunId: "gate-1",
       optedIn: true,
@@ -124,7 +124,7 @@ test("ingestGateVerdictCalibrationSignals accepts only currently opted-in struct
 
   assert.deepEqual(ingestion.rejected, []);
   assert.equal(ingestion.accepted.length, 1);
-  assert.equal(ingestion.accepted[0]!.repoFullName, "jsonbored/gittensory");
+  assert.equal(ingestion.accepted[0]!.repoFullName, "jsonbored/loopover");
   assert.equal(ingestion.accepted[0]!.score, 0.466667);
   assert.deepEqual(ingestion.accepted[0]!.dimensions, [
     { dimension: "correctness", outcome: "pass", confidence: 1, score: 1 },
@@ -136,7 +136,7 @@ test("ingestGateVerdictCalibrationSignals accepts only currently opted-in struct
 test("ingestGateVerdictCalibrationSignals rejects a mid-flight opt-out at ingestion time", () => {
   const ingestion = ingestGateVerdictCalibrationSignals([
     {
-      repoFullName: "jsonbored/gittensory",
+      repoFullName: "jsonbored/loopover",
       replayRunId: "replay-2",
       gateRunId: "gate-2",
       optedIn: false,
@@ -147,7 +147,7 @@ test("ingestGateVerdictCalibrationSignals rejects a mid-flight opt-out at ingest
   assert.deepEqual(ingestion.accepted, []);
   assert.deepEqual(ingestion.rejected, [
     {
-      repoFullName: "jsonbored/gittensory",
+      repoFullName: "jsonbored/loopover",
       replayRunId: "replay-2",
       gateRunId: "gate-2",
       reason: "not_opted_in",
@@ -165,7 +165,7 @@ test("ingestGateVerdictCalibrationSignals rejects malformed repo and run identif
       dimensions: [{ dimension: "correctness", outcome: "pass" }],
     },
     {
-      repoFullName: "jsonbored/gittensory",
+      repoFullName: "jsonbored/loopover",
       replayRunId: "",
       gateRunId: "gate\nbad",
       optedIn: true,
@@ -177,7 +177,7 @@ test("ingestGateVerdictCalibrationSignals rejects malformed repo and run identif
   assert.deepEqual(ingestion.rejected, [
     { repoFullName: "not a repo", replayRunId: "replay-3", gateRunId: "gate-3", reason: "invalid_repo" },
     {
-      repoFullName: "jsonbored/gittensory",
+      repoFullName: "jsonbored/loopover",
       replayRunId: "",
       gateRunId: "gate\nbad",
       reason: "invalid_run_id",
@@ -188,7 +188,7 @@ test("ingestGateVerdictCalibrationSignals rejects malformed repo and run identif
 test("ingestGateVerdictCalibrationSignals drops unknown dimensions/outcomes and rejects empty structured rows", () => {
   const ingestion = ingestGateVerdictCalibrationSignals([
     {
-      repoFullName: "jsonbored/gittensory",
+      repoFullName: "jsonbored/loopover",
       replayRunId: "replay-4",
       gateRunId: "gate-4",
       optedIn: true,
@@ -202,7 +202,7 @@ test("ingestGateVerdictCalibrationSignals drops unknown dimensions/outcomes and 
   assert.deepEqual(ingestion.accepted, []);
   assert.deepEqual(ingestion.rejected, [
     {
-      repoFullName: "jsonbored/gittensory",
+      repoFullName: "jsonbored/loopover",
       replayRunId: "replay-4",
       gateRunId: "gate-4",
       reason: "empty_dimensions",
@@ -213,7 +213,7 @@ test("ingestGateVerdictCalibrationSignals drops unknown dimensions/outcomes and 
 test("ingestGateVerdictCalibrationSignals maps aliases and keeps the stricter duplicate dimension outcome", () => {
   const ingestion = ingestGateVerdictCalibrationSignals([
     {
-      repoFullName: "jsonbored/gittensory",
+      repoFullName: "jsonbored/loopover",
       replayRunId: "replay-5",
       gateRunId: "gate-5",
       optedIn: true,
@@ -241,7 +241,7 @@ test("ingestGateVerdictCalibrationSignals maps aliases and keeps the stricter du
 test("ingestGateVerdictCalibrationSignals normalizes malformed dates to null", () => {
   const ingestion = ingestGateVerdictCalibrationSignals([
     {
-      repoFullName: "jsonbored/gittensory",
+      repoFullName: "jsonbored/loopover",
       replayRunId: "replay-6",
       gateRunId: "gate-6",
       optedIn: true,
@@ -267,7 +267,7 @@ test("computeGateVerdictCompositeCalibrationScore combines objective-anchor, pai
     pairwise,
     gateVerdicts: [
       {
-        repoFullName: "JSONbored/Gittensory",
+        repoFullName: "JSONbored/Loopover",
         replayRunId: "replay-7",
         gateRunId: "gate-7",
         optedIn: true,
@@ -285,7 +285,7 @@ test("computeGateVerdictCompositeCalibrationScore combines objective-anchor, pai
   assert.equal(result.structuredGateVerdictScore, 0.75);
   assert.deepEqual(result.weights, { objectiveAnchor: 0.5, pairwiseJudge: 0.25, structuredGateVerdict: 0.25 });
   assert.equal(result.compositeScore, 0.7125);
-  assert.deepEqual(result.audit.contributingRepos.map((repo) => repo.repoFullName), ["jsonbored/gittensory"]);
+  assert.deepEqual(result.audit.contributingRepos.map((repo) => repo.repoFullName), ["jsonbored/loopover"]);
 });
 
 test("computeGateVerdictCompositeCalibrationScore renormalizes when pairwise or structured signals are unavailable", () => {
@@ -308,7 +308,7 @@ test("computeGateVerdictCompositeCalibrationScore carries rejected rows into the
     pairwise: 0.5,
     gateVerdicts: [
       {
-        repoFullName: "jsonbored/gittensory",
+        repoFullName: "jsonbored/loopover",
         replayRunId: "replay-8",
         gateRunId: "gate-8",
         optedIn: false,
@@ -320,7 +320,7 @@ test("computeGateVerdictCompositeCalibrationScore carries rejected rows into the
   assert.deepEqual(result.audit.contributingRepos, []);
   assert.deepEqual(result.audit.rejected, [
     {
-      repoFullName: "jsonbored/gittensory",
+      repoFullName: "jsonbored/loopover",
       replayRunId: "replay-8",
       gateRunId: "gate-8",
       reason: "not_opted_in",
@@ -368,7 +368,7 @@ test("computeGateVerdictCompositeCalibrationScore does not expose raw review tex
     pairwise: 0.5,
     gateVerdicts: [
       {
-        repoFullName: "jsonbored/gittensory",
+        repoFullName: "jsonbored/loopover",
         replayRunId: "replay-10",
         gateRunId: "gate-10",
         optedIn: true,
@@ -395,7 +395,7 @@ test("renderGateVerdictCalibrationAuditMarkdown renders aggregate scores and con
     pairwise: 0.75,
     gateVerdicts: [
       {
-        repoFullName: "jsonbored/gittensory",
+        repoFullName: "jsonbored/loopover",
         replayRunId: "replay-11",
         gateRunId: "gate-11",
         optedIn: true,
@@ -411,7 +411,7 @@ test("renderGateVerdictCalibrationAuditMarkdown renders aggregate scores and con
 
   assert.ok(markdown.startsWith("# Structured Gate-Verdict Calibration\n\nComposite score:"));
   assert.match(markdown, /## Component Scores\n\n- objectiveAnchor: 0\.500000\n- pairwiseJudge: 0\.750000/u);
-  assert.match(markdown, /### jsonbored\/gittensory/u);
+  assert.match(markdown, /### jsonbored\/loopover/u);
   assert.match(markdown, /\| correctness \| pass \| 1\.000000 \| 1\.000000 \|/u);
   assert.match(markdown, /\| tests \| warn \| 1\.000000 \| 0\.500000 \|/u);
 });
@@ -436,7 +436,7 @@ test("renderGateVerdictCalibrationAuditMarkdown includes rejected rows for audit
     pairwise: 0.5,
     gateVerdicts: [
       {
-        repoFullName: "jsonbored/gittensory",
+        repoFullName: "jsonbored/loopover",
         replayRunId: "replay-12",
         gateRunId: "gate-12",
         optedIn: false,
@@ -447,7 +447,7 @@ test("renderGateVerdictCalibrationAuditMarkdown includes rejected rows for audit
   const markdown = renderGateVerdictCalibrationAuditMarkdown(result);
 
   assert.match(markdown, /\| Repo \| Replay run \| Gate run \| Reason \|/u);
-  assert.match(markdown, /\| jsonbored\/gittensory \| replay-12 \| gate-12 \| not\\_opted\\_in \|/u);
+  assert.match(markdown, /\| jsonbored\/loopover \| replay-12 \| gate-12 \| not\\_opted\\_in \|/u);
 });
 
 test("renderGateVerdictCalibrationAuditMarkdown escapes markdown controls and collapses newlines", () => {
@@ -484,7 +484,7 @@ test("computeGateVerdictCompositeCalibrationScore sanitizes pre-ingested audit r
   const gateVerdicts = {
     accepted: [
       {
-        repoFullName: "JSONbored/Gittensory",
+        repoFullName: "JSONbored/Loopover",
         replayRunId: " replay-13 ",
         gateRunId: "gate-13",
         observedAt: "not an ISO timestamp",
@@ -499,7 +499,7 @@ test("computeGateVerdictCompositeCalibrationScore sanitizes pre-ingested audit r
     ],
     rejected: [
       {
-        repoFullName: "JSONbored/Gittensory",
+        repoFullName: "JSONbored/Loopover",
         replayRunId: "replay-13",
         gateRunId: "gate-13",
         reason: "not_opted_in",
@@ -517,7 +517,7 @@ test("computeGateVerdictCompositeCalibrationScore sanitizes pre-ingested audit r
   assert.equal(result.structuredGateVerdictScore, 1);
   assert.deepEqual(result.audit.contributingRepos, [
     {
-      repoFullName: "jsonbored/gittensory",
+      repoFullName: "jsonbored/loopover",
       replayRunId: "replay-13",
       gateRunId: "gate-13",
       observedAt: null,
@@ -527,7 +527,7 @@ test("computeGateVerdictCompositeCalibrationScore sanitizes pre-ingested audit r
   ]);
   assert.deepEqual(result.audit.rejected, [
     {
-      repoFullName: "jsonbored/gittensory",
+      repoFullName: "jsonbored/loopover",
       replayRunId: "replay-13",
       gateRunId: "gate-13",
       reason: "not_opted_in",
@@ -553,7 +553,7 @@ test("computeGateVerdictCompositeCalibrationScore ignores malformed pre-ingested
         dimensions: [{ dimension: "correctness", outcome: "pass", confidence: 1 }],
       },
       {
-        repoFullName: "jsonbored/gittensory",
+        repoFullName: "jsonbored/loopover",
         replayRunId: "replay-14",
         gateRunId: "gate-14",
         observedAt: "2026-07-04T17:00:00.000Z",
@@ -563,7 +563,7 @@ test("computeGateVerdictCompositeCalibrationScore ignores malformed pre-ingested
     ],
     rejected: [
       {
-        repoFullName: "jsonbored/gittensory",
+        repoFullName: "jsonbored/loopover",
         replayRunId: "replay-14",
         gateRunId: "gate-14",
         reason: "privateMetadata",

--- a/packages/loopover-engine/test/iterate-loop.test.ts
+++ b/packages/loopover-engine/test/iterate-loop.test.ts
@@ -306,7 +306,7 @@ test("immediate abandon: finalMeterTotals/budgetBreaches are the honest zero/emp
   assert.deepEqual(result.budgetBreaches, []);
 });
 
-test("REGRESSION: a hard budget ceiling abandons even on the same iteration a passing self-review would have produced (ceiling wins, not pass) -- gittensory review #5437", async () => {
+test("REGRESSION: a hard budget ceiling abandons even on the same iteration a passing self-review would have produced (ceiling wins, not pass) -- loopover review #5437", async () => {
   let selfReviewRan = false;
   const { deps } = collectingDeps({
     driver: driverReturning(okResult(["src/upload.ts"], 999)),

--- a/packages/loopover-engine/test/track-record-summary.test.ts
+++ b/packages/loopover-engine/test/track-record-summary.test.ts
@@ -109,7 +109,7 @@ test("computeTrackRecordSummary derives a positive public record from matching o
     outcomes: [
       {
         id: 11,
-        repoFullName: "jsonbored/gittensory",
+        repoFullName: "jsonbored/loopover",
         authorLogin: "minerone",
         state: "merged",
         createdAt: "2026-06-01T00:00:00Z",


### PR DESCRIPTION
## Summary

- Part of the gittensory→loopover rebrand (#5705), phase 8b: rename brand-name prose in comments across 16 `packages/loopover-engine/src/**/*.ts` files (reward-risk, scoring, settings, tenant-config, subprocess-env, remaining signals modules) plus 5 `packages/loopover-engine/test/*.ts` files whose assertions/titles referenced example repo names.
- `src/settings/autonomy.ts` and `src/signals/change-guardrail.ts`'s engine-side twins are intentionally excluded from this batch — their fixes already ship in the open `#5895` (remaining-src) and `#5896` (signals/selfhost/services) PRs, to avoid two PRs editing the same lines. This batch will pick up those already-correct engine copies on its next rebase after either merges. Verified `scripts/check-engine-parity.ts` passes as-is.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue this PR resolves — N/A, maintainer-authored rebrand-epic cleanup (#5705), no linked-issue gate applies to owner PRs.

## Validation

- [x] `git diff --check`
- [x] `npx tsx scripts/check-engine-parity.ts` — ok
- [x] `npm run typecheck` — clean

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no such changes.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, comment-only, no behavior change.
- [ ] UI changes use live API data or real empty/error/loading states. — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section. — N/A, no UI changes.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs (none touched here).

## Notes

- One of several batched PRs covering the bulk-prose portion of rebrand epic #5705. If this merges before #5895/#5896, rebase those two before pushing (their engine-twin fixes for autonomy.ts/change-guardrail.ts become no-ops but stay correct).