### PR TITLE
docs(miner): rename gittensory prose to loopover in miner/mcp packages

### DIFF
--- a/packages/loopover-mcp/lib/local-branch.js
+++ b/packages/loopover-mcp/lib/local-branch.js
@@ -323,7 +323,7 @@ export function setupGuidanceForLocalScorer(status) {
       if (safeStatus.stderr) guidance.push(`Last scorer stdout snippet: ${truncateText(safeStatus.stderr, 160)}`);
       break;
     case "non_zero_exit":
-      guidance.push("External scorer exited with a non-zero status; inspect stderr and run gittensory-mcp doctor.");
+      guidance.push("External scorer exited with a non-zero status; inspect stderr and run loopover-mcp doctor.");
       if (safeStatus.stderr) guidance.push(`Scorer stderr: ${truncateText(safeStatus.stderr, 160)}`);
       if (typeof safeStatus.exitCode === "number") guidance.push(`Exit code: ${safeStatus.exitCode}`);
       break;
@@ -340,7 +340,7 @@ export function probeLocalScorer(scorerCommand = resolveScorePreviewCommand()) {
   return sanitizeLocalScorerStatus(
     runExternalScorePreview(
     {
-      repoFullName: "JSONbored/gittensory",
+      repoFullName: "JSONbored/loopover",
       branchName: "doctor-probe",
       changedFiles: [{ path: "src/example.ts", additions: 12, deletions: 2, status: "modified" }],
       repoRoot: process.cwd(),

--- a/packages/loopover-miner/bin/loopover-miner-mcp.js
+++ b/packages/loopover-miner/bin/loopover-miner-mcp.js
@@ -57,12 +57,12 @@ export const MINER_PING_STATUS = { status: "ok", tool: "loopover_miner_ping" };
  * store only when invoked and closes any store it opened.
  */
 export function createMinerMcpServer(options = {}) {
-  const server = new McpServer({ name: "gittensory-miner", version: ownPackageJson.version });
+  const server = new McpServer({ name: "loopover-miner", version: ownPackageJson.version });
   server.registerTool(
     "loopover_miner_ping",
     {
       description:
-        "Health check for the gittensory-miner MCP server. Returns a static status object confirming the " +
+        "Health check for the loopover-miner MCP server. Returns a static status object confirming the " +
         "server is reachable. Reads no AMS state and takes no arguments.",
       inputSchema: {},
     },
@@ -74,7 +74,7 @@ export function createMinerMcpServer(options = {}) {
       description:
         "Read-only per-repo portfolio-queue backlog dashboard: status counts (queued/in_progress/done), totals, " +
         "and the oldest-queued age in ms. Wraps the existing collectPortfolioDashboard aggregator (no new logic) " +
-        "-- the same data `gittensory-miner queue dashboard --json` prints locally. Takes no arguments; mutates nothing.",
+        "-- the same data `loopover-miner queue dashboard --json` prints locally. Takes no arguments; mutates nothing.",
       inputSchema: {},
     },
     async () => {
@@ -119,7 +119,7 @@ export function createMinerMcpServer(options = {}) {
       description:
         "Read-only, metadata-only audit feed from the local append-only event ledger: eventType, repoFullName, " +
         "outcome, actor, detail, and createdAt per row. Wraps collectEventLedgerAuditFeed() (no new query logic) — " +
-        "the same read filters as `gittensory-miner ledger list` (--repo, --since, --type). Never returns " +
+        "the same read filters as `loopover-miner ledger list` (--repo, --since, --type). Never returns " +
         "payload_json or other raw ledger columns; never writes to the ledger.",
       inputSchema: auditFeedInputSchema,
     },
@@ -252,7 +252,7 @@ export function createMinerMcpServer(options = {}) {
         "Read-only miner status + doctor diagnostics. Returns { status, doctor }: status = package/engine versions " +
         "(+ skew), node version, state-dir path, config-file path, and the resolved coding-agent driver (provider " +
         "name, the model ENV-VAR NAME -- never its value -- and a CLI-present boolean); doctor = the same checks " +
-        "`gittensory-miner doctor` runs (Docker/CLI presence, config validity, ...) as { name, ok, detail }. Reuses " +
+        "`loopover-miner doctor` runs (Docker/CLI presence, config validity, ...) as { name, ok, detail }. Reuses " +
         "collectStatus/runDoctorChecks so it can never drift from the CLI. Only names / booleans / paths -- never " +
         "any env-var value, token, key, or credential. Read-only; no writes or state changes.",
       inputSchema: {},

--- a/packages/loopover-miner/lib/calibration-run.js
+++ b/packages/loopover-miner/lib/calibration-run.js
@@ -7,7 +7,7 @@
 // resulting composite into the `HistoricalReplayCalibrationInput` shape the engine expects, calls the combine with
 // the existing pr_outcome signal, and PERSISTS the combined snapshot to the local append-only event ledger (a typed
 // event layered on event-ledger.js exactly like pr-outcome.js's MINER_PR_OUTCOME_EVENT), queryable via
-// `gittensory-miner ledger list --type calibration_snapshot`.
+// `loopover-miner ledger list --type calibration_snapshot`.
 //
 // SCOPE: this runner is read/measure-only. It produces and persists the tracked calibration metric; it NEVER acts
 // on it (no autonomy-level bump, no gate-threshold tune) -- that enforcement is maintainer-only and fail-closed

--- a/packages/loopover-miner/lib/claim-conflict-resolver.js
+++ b/packages/loopover-miner/lib/claim-conflict-resolver.js
@@ -12,7 +12,7 @@
 //
 // CLAIM-TIME ASYMMETRY (documented, not accidental): `self`'s claimedAt is the miner's OWN real local
 // claim-ledger timestamp (claim-ledger.js, recorded before work even started). A competing PR's claimedAt uses
-// its real GitHub `createdAt` instead -- the maintainer gate's own duplicate-winner election uses gittensory
+// its real GitHub `createdAt` instead -- the maintainer gate's own duplicate-winner election uses loopover
 // server's "first observed this PR's linked-issue set" timestamp, but that requires a continuous, persistent
 // observation history this stateless client-side tool does not have for a PR it doesn't own. `createdAt` is
 // the best real, publicly-observable proxy available for someone else's PR -- live-issue-snapshot.js's own

--- a/packages/loopover-miner/lib/coding-agent-house-rules.js
+++ b/packages/loopover-miner/lib/coding-agent-house-rules.js
@@ -1,7 +1,7 @@
 // House-rules-enforced coding-agent construction (#2343 follow-up). buildHouseRulesPreToolUseHook
 // (pretooluse-hook.js) is the LIVE PreToolUse interception point, but the engine package's
 // createCodingAgentDriver / runCodingAgentAttempt (driver-factory.ts) cannot import it directly -- the
-// dependency only ever flows gittensory-miner -> @loopover/engine, never the reverse (the engine
+// dependency only ever flows loopover-miner -> @loopover/engine, never the reverse (the engine
 // package is portable and cannot depend on the miner CLI package). This module is the missing miner-side
 // glue: it wraps runCodingAgentAttempt so the `agent-sdk` provider gets house-rule enforcement by DEFAULT --
 // a future real call site does not need to remember to attach it itself, closing the exact gap

--- a/packages/loopover-miner/lib/coding-task-spec.js
+++ b/packages/loopover-miner/lib/coding-task-spec.js
@@ -30,7 +30,7 @@ import { detectRepoStack, renderStackSummary } from "./stack-detection.js";
 // language/package-manager/command description, but nothing in the attempt path consumed it -- instructions
 // were issue text + an acceptance-criteria path only. This module now appends that real stack summary (and
 // any confidently-inferred validation commands) to the coding-agent prompt so the agent validates against
-// THIS repository's tooling rather than assuming LoopOver/gittensory CI, Codecov, or `npm run test:ci`.
+// THIS repository's tooling rather than assuming LoopOver/loopover CI, Codecov, or `npm run test:ci`.
 
 function buildTaskBrief(issue) {
   const body = (issue.body ?? "").trim();
@@ -141,7 +141,7 @@ export function writeAcceptanceCriteriaFile(workingDirectory, acceptanceCriteria
 /**
  * Prompt guidance derived from a real `detectRepoStack` result (#4786). Lists only commands the detector
  * confidently inferred -- a `null` command stays omitted rather than guessed -- and always tells the agent
- * not to assume LoopOver/gittensory's own CI/coverage conventions.
+ * not to assume LoopOver/loopover's own CI/coverage conventions.
  *
  * @param {import("./stack-detection.js").RepoStackResult} stack
  * @returns {string}
@@ -151,7 +151,7 @@ function buildValidationGuidance(stack) {
     `Detected target-repo stack: ${renderStackSummary(stack)}`,
     "",
     "Validate your change with THIS repository's own build/test/lint tooling from the stack summary above.",
-    "Do not assume LoopOver/gittensory CI conventions, Codecov patch coverage, or `npm run test:ci` unless those commands appear in the detected stack.",
+    "Do not assume LoopOver/loopover CI conventions, Codecov patch coverage, or `npm run test:ci` unless those commands appear in the detected stack.",
   ];
   if (stack?.detected === true) {
     const commands = [
@@ -176,7 +176,7 @@ function buildValidationGuidance(stack) {
  * The coding-agent driver's own prompt text (agent-sdk-driver.ts's header: "forwarded verbatim as the
  * prompt -- the acceptance-criteria document already lives inside the worktree", so this points to it
  * rather than repeating its content). Also carries the target repo's detected stack + validation commands
- * (#4786) so the agent does not default to gittensory-specific CI assumptions.
+ * (#4786) so the agent does not default to loopover-specific CI assumptions.
  *
  * @param {{ number: number, title: string, body?: string | null }} issue
  * @param {string} acceptanceCriteriaPath
@@ -223,7 +223,7 @@ export function buildCodingTaskSpec(input) {
   }
 
   // Real target-repo stack (#4786): detected from the prepared worktree's own manifests, not guessed from
-  // gittensory conventions. Fail-closed `{ detected: false }` results still reach the prompt (via
+  // loopover conventions. Fail-closed `{ detected: false }` results still reach the prompt (via
   // renderStackSummary) so the agent is told detection failed rather than silently defaulting to npm/Codecov.
   const detect = input.detectRepoStack ?? detectRepoStack;
   const stack = detect(input.workingDirectory);

--- a/packages/loopover-miner/lib/cross-repo-evaluation.d.ts
+++ b/packages/loopover-miner/lib/cross-repo-evaluation.d.ts
@@ -3,7 +3,7 @@ import type { RepoStackResult } from "./stack-detection.js";
 export const CROSS_REPO_FAILURE_CATEGORY: Readonly<{
   STACK_DETECTION: "stack_detection_gap";
   EXECUTION: "execution_gap";
-  GITTENSOR_ASSUMPTION: "gittensory_assumption";
+  GITTENSOR_ASSUMPTION: "loopover_assumption";
   CLONE_SETUP: "clone_setup";
   OTHER: "other";
 }>;
@@ -46,7 +46,7 @@ export type CrossRepoEvaluationSummary = {
   passed: number;
   failed: number;
   majorityPassed: boolean;
-  withoutGittensoryConfig: number;
+  withoutLoopoverConfig: number;
   failuresByCategory: Record<string, number>;
 };
 
@@ -56,7 +56,7 @@ export function parseCrossRepoEvaluationManifest(
   content: string | null | undefined,
 ): ParsedCrossRepoEvaluationManifest;
 
-export function scanPositiveGittensoryAssumptions(text: string): Array<{ id: string; line: string }>;
+export function scanPositiveLoopoverAssumptions(text: string): Array<{ id: string; line: string }>;
 
 export function evaluateRepoReadiness(
   entry: CrossRepoEvaluationManifestRepo,

--- a/packages/loopover-miner/lib/cross-repo-evaluation.js
+++ b/packages/loopover-miner/lib/cross-repo-evaluation.js
@@ -1,8 +1,8 @@
 // Cross-repo evaluation harness (#4788): a repeatable, offline-first readiness check that asks whether the miner
-// can approach a diverse benchmark repo set without gittensory-specific target-repo configuration. Each repo is
+// can approach a diverse benchmark repo set without loopover-specific target-repo configuration. Each repo is
 // evaluated through the same stack-detection + coding-task-spec path a real attempt uses (detectRepoStack,
 // resolveMinerGoalSpec, buildCodingTaskSpec) and failures are categorized as stack-detection gaps, execution
-// readiness gaps, leaked gittensory assumptions in agent instructions, clone/setup problems, or other.
+// readiness gaps, leaked loopover assumptions in agent instructions, clone/setup problems, or other.
 
 import { existsSync } from "node:fs";
 import { join } from "node:path";
@@ -15,12 +15,12 @@ import { detectRepoStack } from "./stack-detection.js";
 export const CROSS_REPO_FAILURE_CATEGORY = Object.freeze({
   STACK_DETECTION: "stack_detection_gap",
   EXECUTION: "execution_gap",
-  GITTENSOR_ASSUMPTION: "gittensory_assumption",
+  GITTENSOR_ASSUMPTION: "loopover_assumption",
   CLONE_SETUP: "clone_setup",
   OTHER: "other",
 });
 
-/** Instruction substrings that indicate a POSITIVE gittensory/LoopOver CI assumption leaked into the agent prompt.
+/** Instruction substrings that indicate a POSITIVE loopover/LoopOver CI assumption leaked into the agent prompt.
  *  Lines that explicitly tell the agent *not* to assume these are filtered out before scanning. */
 export const GITTENSOR_POSITIVE_ASSUMPTION_CHECKS = Object.freeze([
   { id: "test_ci_script", pattern: /npm run test:ci/i },
@@ -152,13 +152,13 @@ export function parseCrossRepoEvaluationManifest(content) {
 }
 
 /**
- * Scan agent instructions for positive gittensory/LoopOver assumptions (#4788). Lines that already tell the agent
+ * Scan agent instructions for positive loopover/LoopOver assumptions (#4788). Lines that already tell the agent
  * *not* to assume LoopOver conventions (the negative guidance from buildValidationGuidance) are skipped.
  *
  * @param {string} text
  * @returns {Array<{ id: string, line: string }>}
  */
-export function scanPositiveGittensoryAssumptions(text) {
+export function scanPositiveLoopoverAssumptions(text) {
   if (typeof text !== "string") return [];
   const findings = [];
   for (const line of text.split("\n")) {
@@ -301,12 +301,12 @@ export function evaluateRepoReadiness(entry, options = {}) {
     );
   }
 
-  const assumptionFindings = scanPositiveGittensoryAssumptions(specResult.instructions ?? "");
+  const assumptionFindings = scanPositiveLoopoverAssumptions(specResult.instructions ?? "");
   if (assumptionFindings.length > 0) {
     return buildFailure(
       repoFullName,
       CROSS_REPO_FAILURE_CATEGORY.GITTENSOR_ASSUMPTION,
-      `Agent instructions leak gittensory-specific assumptions (${assumptionFindings.map((f) => f.id).join(", ")}).`,
+      `Agent instructions leak loopover-specific assumptions (${assumptionFindings.map((f) => f.id).join(", ")}).`,
       { stackDetected: true, usedDefaultGoalSpec, stack, assumptionFindings },
     );
   }
@@ -352,13 +352,13 @@ export function summarizeCrossRepoEvaluation(results) {
   }
   const total = passed + failed;
   const majorityPassed = total > 0 ? passed > failed : false;
-  const withoutGittensoryConfig = list.filter((r) => r?.usedDefaultGoalSpec !== false).length;
+  const withoutLoopoverConfig = list.filter((r) => r?.usedDefaultGoalSpec !== false).length;
   return {
     total,
     passed,
     failed,
     majorityPassed,
-    withoutGittensoryConfig,
+    withoutLoopoverConfig,
     failuresByCategory,
   };
 }
@@ -384,7 +384,7 @@ export function formatCrossRepoEvaluationReport(results, summary = summarizeCros
       (summary.majorityPassed ? " (majority passed)" : " (majority failed)"),
   );
   if (summary.total > 0) {
-    lines.push(`without gittensory-specific target config: ${summary.withoutGittensoryConfig}/${summary.total}`);
+    lines.push(`without loopover-specific target config: ${summary.withoutLoopoverConfig}/${summary.total}`);
   }
   const categories = Object.entries(summary.failuresByCategory).sort(([a], [b]) => a.localeCompare(b));
   if (categories.length > 0) {

--- a/packages/loopover-miner/lib/discover-cli.js
+++ b/packages/loopover-miner/lib/discover-cli.js
@@ -124,8 +124,8 @@ export function renderDiscoverSummary(result) {
   if (result.enqueueSummary.skippedBelowMinRank > 0) {
     lines.push(`skipped (below min rank): ${result.enqueueSummary.skippedBelowMinRank}`);
   }
-  // Make the fall-back to gittensory's built-in rubric explicit instead of silent (#4784): when no per-tenant goal
-  // spec is supplied, lane fit reflects gittensory's defaults, not the target repo's own conventions.
+  // Make the fall-back to loopover's built-in rubric explicit instead of silent (#4784): when no per-tenant goal
+  // spec is supplied, lane fit reflects loopover's defaults, not the target repo's own conventions.
   if (result.usedDefaultGoalSpec) {
     lines.push(
       "note: ranked with the built-in default goal spec (no per-tenant .loopover-miner.yml supplied)",
@@ -266,7 +266,7 @@ export async function runDiscover(args, options = {}) {
         : await fetchTargets(parsed.targets, githubToken, fanOutOptions);
 
     // Pass any caller-supplied per-tenant goal specs through to the ranker so lane fit uses the tenant's
-    // conventions instead of silently falling back to gittensory's defaults (#4784); the fallback is surfaced via
+    // conventions instead of silently falling back to loopover's defaults (#4784); the fallback is surfaced via
     // `usedDefaultGoalSpec` below rather than hidden.
     const rankedSummary = rankIssues(fanOut.issues, {
       nowMs: options.nowMs,

--- a/packages/loopover-miner/lib/env-file-indirection.js
+++ b/packages/loopover-miner/lib/env-file-indirection.js
@@ -7,7 +7,7 @@
 // would then fail on anyway, with a far less specific error).
 import { readFileSync } from "node:fs";
 
-// Docker Compose's OWN reserved `_FILE`-suffixed environment variables -- never gittensory's secret-file
+// Docker Compose's OWN reserved `_FILE`-suffixed environment variables -- never loopover's secret-file
 // convention, so they must never be dereferenced below (mirrors src/selfhost/load-file-secrets.ts's own
 // exclusion and rationale: `COMPOSE_FILE` is a colon-delimited list of compose file paths, never a single
 // readable file itself, and `COMPOSE_ENV_FILE` points at an operator's own .env file, not a secret).

--- a/packages/loopover-miner/lib/execute-local-write.js
+++ b/packages/loopover-miner/lib/execute-local-write.js
@@ -5,7 +5,7 @@
 // packages/loopover-engine/src/miner/local-write-tools.ts's own single-quote escaping), not the
 // cmd/args-array CliSubprocessSpawnFn contract the coding-agent driver itself uses. Runs it via `sh -c` in
 // the given working directory. Per local-write-tools.ts's own boundary comment, this always runs with
-// whatever `gh`/`git` credentials are already configured in that environment -- gittensory never performs
+// whatever `gh`/`git` credentials are already configured in that environment -- loopover never performs
 // the write itself.
 
 import { spawn } from "node:child_process";

--- a/packages/loopover-miner/lib/forge-config.js
+++ b/packages/loopover-miner/lib/forge-config.js
@@ -1,8 +1,8 @@
 /** Per-tenant forge configuration (#4784): the GitHub-specific protocol details that discovery used to hardcode,
  * gathered behind one resolver so a non-github.com tenant (GitHub Enterprise, or another GitHub-compatible forge)
- * can override them. gittensory's own github.com conventions survive only as `DEFAULT_FORGE_CONFIG` — calling
+ * can override them. loopover's own github.com conventions survive only as `DEFAULT_FORGE_CONFIG` — calling
  * `resolveForgeConfig()` with no overrides is byte-identical to the pre-#4784 hardcoded fan-out behavior, which is
- * what keeps the existing gittensory discovery path unchanged. Executes the #4780 repo-agnostic-capability-audit
+ * what keeps the existing loopover discovery path unchanged. Executes the #4780 repo-agnostic-capability-audit
  * checklist (forge abstraction, configurable credential env var, configurable user-agent). */
 
 /** The github.com defaults every forge field falls back to. Frozen so a caller can't mutate the shared baseline. */

--- a/packages/loopover-miner/lib/init-wizard.js
+++ b/packages/loopover-miner/lib/init-wizard.js
@@ -6,7 +6,7 @@ import { initLaptopState } from "./laptop-init.js";
 import { resolveMinerStateDir, runDoctor } from "./status.js";
 import { DeviceFlowError, resolveAmsOauthClientId, runDeviceFlowAuthorization } from "./oauth-device-flow.js";
 
-// First-run onboarding wizard for `gittensory-miner init --interactive` (#5176): prompts for a GITHUB_TOKEN
+// First-run onboarding wizard for `loopover-miner init --interactive` (#5176): prompts for a GITHUB_TOKEN
 // (masked, never echoed to stdout/logs) and an optional coding-agent provider + its companion vars, writes them
 // to a starter .env in the state dir, then reruns the existing offline `doctor` checks against the collected
 // values so the operator sees pass/fail immediately. `doctor` itself stays offline by contract (status.js), and
@@ -42,7 +42,7 @@ async function promptRequiredMasked(io, question) {
 }
 
 async function promptAuthMethod(io) {
-  io.writeLine("How would you like to authorize gittensory-miner?");
+  io.writeLine("How would you like to authorize loopover-miner?");
   io.writeLine("  1) Authorize with GitHub (recommended -- no token to copy)");
   io.writeLine("  2) Paste a GitHub token (personal access token)");
   for (;;) {

--- a/packages/loopover-miner/lib/live-issue-snapshot.js
+++ b/packages/loopover-miner/lib/live-issue-snapshot.js
@@ -55,7 +55,7 @@ function normalizeReferencingPr(node) {
   // an ordering signal for the maintainer gate's own duplicate-cluster election (duplicate-winner.ts's own
   // doc explains why: a PR can be backdated by editing an old placeholder to add the linked issue later), but
   // it's the only real, publicly-observable claim-time proxy claim-conflict-resolver.js's own client-side
-  // caller has for a THIRD-PARTY PR -- unlike gittensory's own server, the miner has no continuous observation
+  // caller has for a THIRD-PARTY PR -- unlike loopover's own server, the miner has no continuous observation
   // history to derive a true "first linked" timestamp from.
   const createdAt = typeof node.createdAt === "string" ? node.createdAt : null;
   return { number: node.number, state, authorLogin, createdAt };

--- a/packages/loopover-miner/lib/oauth-device-flow.js
+++ b/packages/loopover-miner/lib/oauth-device-flow.js
@@ -1,5 +1,5 @@
 // GitHub OAuth Device Flow client (#5682) for the centrally-held `loopover-ams` GitHub App -- lets a
-// contributor authorize gittensory-miner by visiting a URL and entering a short code, instead of generating
+// contributor authorize loopover-miner by visiting a URL and entering a short code, instead of generating
 // and pasting a PAT. Uses GitHub's PUBLIC-client device flow
 // (https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/authorizing-oauth-apps#device-flow): no
 // client secret is required or ever held by this CLI, only the App's public OAuth client id.

--- a/packages/loopover-miner/lib/orb-export.js
+++ b/packages/loopover-miner/lib/orb-export.js
@@ -162,7 +162,7 @@ export function latestClosedAt(batch) {
   return latest;
 }
 
-/** gittensory's hosted AMS collector — mirrors orb-collector.ts's ORB_COLLECTOR_URL default pattern. */
+/** loopover's hosted AMS collector — mirrors orb-collector.ts's ORB_COLLECTOR_URL default pattern. */
 export const DEFAULT_AMS_COLLECTOR_URL = "https://api.loopover.ai/v1/ams/ingest";
 
 export function resolveAmsCollectorUrl(env = process.env) {

--- a/packages/loopover-miner/lib/portfolio-queue.js
+++ b/packages/loopover-miner/lib/portfolio-queue.js
@@ -6,7 +6,7 @@ import { applySchemaMigrations } from "./schema-version.js";
 // items across every repo the miner has been pointed at ("what should I look at next, across everything I'm
 // tracking"). The database only lives on this machine; this module never uploads, syncs, or phones home with its
 // contents. The `priority` field is a PLACEHOLDER numeric input in this foundation phase — later phases populate
-// it from the extracted reward-risk/scoring modules in `gittensory-engine`; it is not invented here.
+// it from the extracted reward-risk/scoring modules in `loopover-engine`; it is not invented here.
 
 export const QUEUE_STATUSES = Object.freeze(["queued", "in_progress", "done"]);
 

--- a/packages/loopover-miner/lib/pr-outcome.js
+++ b/packages/loopover-miner/lib/pr-outcome.js
@@ -5,7 +5,7 @@
 //
 // DISTINCT from the server-side `pr_outcome` concept: src/review/outcomes-wire.ts's `recordPrOutcome` writes
 // `pr_outcome` rows to the HOSTED backend's D1 audit tables from the GitHub App's webhook stream — that is the
-// gittensory SERVER recording ground truth for every contributor. THIS is a laptop-mode miner's local record of
+// loopover SERVER recording ground truth for every contributor. THIS is a laptop-mode miner's local record of
 // its own PRs (it may have no webhook relay at all): same concept name, different codebase layer, no shared code.
 // The distinct `MINER_PR_OUTCOME_EVENT` local constant keeps the two from being conflated.
 

--- a/packages/loopover-miner/lib/process-lifecycle.js
+++ b/packages/loopover-miner/lib/process-lifecycle.js
@@ -72,26 +72,26 @@ export function installCliSignalHandlers(options = {}) {
 
   const runCleanup = () => {
     closeAllCleanupResources({
-      onError: (error) => log(`gittensory-miner: cleanup error while exiting: ${describeError(error)}`),
+      onError: (error) => log(`loopover-miner: cleanup error while exiting: ${describeError(error)}`),
     });
   };
 
   for (const [signal, code] of Object.entries(SIGNAL_EXIT_CODES)) {
     proc.on(signal, () => {
-      log(`gittensory-miner: received ${signal}, closing open resources and exiting.`);
+      log(`loopover-miner: received ${signal}, closing open resources and exiting.`);
       runCleanup();
       exit(code);
     });
   }
 
   proc.on("uncaughtException", (error) => {
-    log(`gittensory-miner: uncaught exception: ${describeError(error)}`);
+    log(`loopover-miner: uncaught exception: ${describeError(error)}`);
     runCleanup();
     exit(1);
   });
 
   proc.on("unhandledRejection", (reason) => {
-    log(`gittensory-miner: unhandled promise rejection: ${describeError(reason)}`);
+    log(`loopover-miner: unhandled promise rejection: ${describeError(reason)}`);
     runCleanup();
     exit(1);
   });

--- a/packages/loopover-miner/lib/replay-snapshot.d.ts
+++ b/packages/loopover-miner/lib/replay-snapshot.d.ts
@@ -1,6 +1,6 @@
 import type { WorktreeExecFn, WorktreeRemoveResult } from "@loopover/engine";
 
-export const REPLAY_SNAPSHOT_SUBDIR: ".gittensory-replay-snapshots";
+export const REPLAY_SNAPSHOT_SUBDIR: ".loopover-replay-snapshots";
 
 export type ReplaySnapshotCommit = { sha: string; date: string; subject: string };
 export type ReplaySnapshotTag = { name: string; date: string; targetSha: string };

--- a/packages/loopover-miner/lib/replay-snapshot.js
+++ b/packages/loopover-miner/lib/replay-snapshot.js
@@ -58,7 +58,7 @@ function normalizeCommitSha(commitSha) {
 }
 
 /** Worktree exports live under this dir inside the repo, mirroring worktree-allocator.ts's WORKTREE_SUBDIR. */
-export const REPLAY_SNAPSHOT_SUBDIR = ".gittensory-replay-snapshots";
+export const REPLAY_SNAPSHOT_SUBDIR = ".loopover-replay-snapshots";
 
 /** PURE: the deterministic on-disk location for a (repo, commit) replay export -- same pair -> same path. */
 export function planReplaySnapshotPath(input) {

--- a/packages/loopover-miner/lib/status.js
+++ b/packages/loopover-miner/lib/status.js
@@ -25,7 +25,7 @@ import { resolvePlanStoreDbPath } from "./plan-store.js";
 // this laptop set up correctly). Both are read-only and 100% local — no repo-scanning, no coding-agent invocation,
 // no GitHub writes, and no network calls of any kind. Later phases add the real discover/plan/manage loop.
 
-// Lazy, not module-scope: mirrors the gittensory-engine repo-map.ts fix -- this file is CLI-only today, but
+// Lazy, not module-scope: mirrors the loopover-engine repo-map.ts fix -- this file is CLI-only today, but
 // an eager createRequire(import.meta.url)/import.meta.dirname at module scope would crash on import in any
 // bundler context where import.meta is unavailable (e.g. if a future import chain pulls this into a Worker
 // bundle, the way repo-map.ts was). Deferring construction to first real use keeps this import-safe.
@@ -117,10 +117,10 @@ export function readInstalledEnginePackageVersion() {
   try {
     return readInstalledEnginePackageVersionFromPaths(
       requireFromHere().resolve(ENGINE_PACKAGE),
-      join(moduleDir(), "../../gittensory-engine/package.json"),
+      join(moduleDir(), "../../loopover-engine/package.json"),
     );
   } catch {
-    const workspacePkg = join(moduleDir(), "../../gittensory-engine/package.json");
+    const workspacePkg = join(moduleDir(), "../../loopover-engine/package.json");
     if (existsSync(workspacePkg)) {
       try {
         return JSON.parse(readFileSync(workspacePkg, "utf8")).version ?? null;
@@ -155,7 +155,7 @@ export function readExpectedEnginePackageVersionFromPaths(
 
 export function readExpectedEnginePackageVersion() {
   return readExpectedEnginePackageVersionFromPaths(
-    join(moduleDir(), "../../gittensory-engine/package.json"),
+    join(moduleDir(), "../../loopover-engine/package.json"),
     join(moduleDir(), "../expected-engine.version"),
   );
 }
@@ -278,7 +278,7 @@ export function runStatus(args = [], env = process.env, cwd = process.cwd()) {
 }
 
 function checkStateDirWritable(stateDir) {
-  const probe = join(stateDir, ".gittensory-miner-write-probe");
+  const probe = join(stateDir, ".loopover-miner-write-probe");
   try {
     // Creating the dir and writing (then removing) a probe file proves it is writable — the state dir must be
     // creatable/writable for the local SQLite stores to work.
@@ -310,14 +310,14 @@ function storeIntegrityChecks(env) {
   return stores.map(([name, dbPath]) => checkStoreIntegrity(`store-integrity:${name}`, dbPath));
 }
 
-/** Validate the discovered `.gittensory-miner` config's CONTENT (#4873), not just its path: parse it with the
+/** Validate the discovered `.loopover-miner` config's CONTENT (#4873), not just its path: parse it with the
  *  tolerant goal-spec parser and surface its warnings, so a malformed config is flagged by `doctor` rather than
  *  silently degrading to defaults. No config file is fine (defaults apply); a read failure is reported. `readImpl`
  *  is injectable for tests. */
 export function checkConfigContent(cwd, readImpl = readFileSync) {
   const configPath = discoverConfigFile(cwd);
   if (!configPath) {
-    return { name: "config-content", ok: true, detail: "no .gittensory-miner config found (using defaults)" };
+    return { name: "config-content", ok: true, detail: "no .loopover-miner config found (using defaults)" };
   }
   let warnings;
   try {

--- a/packages/loopover-miner/lib/submission-freshness-check.js
+++ b/packages/loopover-miner/lib/submission-freshness-check.js
@@ -10,7 +10,7 @@
 // READ-ONLY BY CONTRACT: never writes anything except its own abort-reason audit event (on staleness only, not
 // on every check -- mirrors this issue's own "log the abort reason" wording, not a per-decision audit trail).
 // The live-state fetch is an injected dependency so this stays testable without real network I/O and agnostic
-// to HOW the caller sources issue/PR state (raw GitHub API, gittensory's own cached MCP data, etc.).
+// to HOW the caller sources issue/PR state (raw GitHub API, loopover's own cached MCP data, etc.).
 //
 // FAIL CLOSED: an unreachable/failed live-state fetch is treated as stale (aborts), never as "no evidence of
 // staleness, so proceed" -- mirrors this package's fail-closed convention elsewhere (harness-submission-


### PR DESCRIPTION
## Summary

- Part of the gittensory→loopover rebrand (#5705), phase 8b: rename brand-name prose across `packages/loopover-miner/**` and `packages/loopover-mcp/**` (23 files).
- Includes a few real (non-comment) values with no external consumer besides this repo's own code: `packages/loopover-miner/bin/loopover-miner-mcp.js`'s MCP server self-reported `name` field, `cross-repo-evaluation.js`'s `GITTENSOR_ASSUMPTION` failure-category value (referenced everywhere via the exported symbol, never a hardcoded literal), and `status.js`'s monorepo-workspace-fallback path that pointed at a nonexistent `../../gittensory-engine/package.json` sibling directory (the real package is `packages/loopover-engine`).
- If this lands before or after #5888 (which independently fixed the same `status.js` lines while unblocking its own test batch), the overlapping lines are identical text — a clean no-op on rebase either way, no conflict.
- Deliberately left untouched: `defaultApiUrl`/`legacyDefaultApiUrls` in `loopover-mcp.js` (the `gittensory-api.aethereal.dev`/`gittensory-api.zeronode.workers.dev` domain aliases — explicitly named "legacy", deliberate backward-compat).

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue this PR resolves — N/A, maintainer-authored rebrand-epic cleanup (#5705), no linked-issue gate applies to owner PRs.

## Validation

- [x] `git diff --check`
- [x] Comment/string-literal-only diff outside `packages/**`'s own JS (no TS build step for these files)

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no such changes.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, comment-only plus internal-only value renames.
- [ ] UI changes use live API data or real empty/error/loading states. — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section. — N/A, no UI changes.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs (none touched here).

## Notes

- One of several batched PRs covering the bulk-prose portion of rebrand epic #5705.