### PR TITLE
docs(db): rename gittensory prose to loopover in migration headers

### DIFF
--- a/migrations/0029_ai_review_provider_model.sql
+++ b/migrations/0029_ai_review_provider_model.sql
@@ -1,4 +1,4 @@
 -- Config-as-code BYOK provider/model for the AI review (the secret key stays in repository_ai_keys,
--- encrypted; these are the non-secret choices, settable via .gittensory.yml or the maintainer dashboard).
+-- encrypted; these are the non-secret choices, settable via .loopover.yml or the maintainer dashboard).
 ALTER TABLE repository_settings ADD COLUMN ai_review_provider TEXT;
 ALTER TABLE repository_settings ADD COLUMN ai_review_model TEXT;

--- a/migrations/0034_slop_ai_advisory.sql
+++ b/migrations/0034_slop_ai_advisory.sql
@@ -1,5 +1,5 @@
 -- Opt-in AI-assisted slop advisory (the `slopAiAdvisory` capability). When 1 AND slop_gate_mode != 'off', a
 -- free Workers-AI pass adds an ADVISORY-only `ai_slop_advisory` finding for semantic slop the deterministic
 -- detector cannot quantify. It NEVER feeds slopRisk or the gate (only the deterministic core can block).
--- Default 0 (off) preserves existing behavior for every current repo; opt-in via `.gittensory.yml`.
+-- Default 0 (off) preserves existing behavior for every current repo; opt-in via `.loopover.yml`.
 ALTER TABLE repository_settings ADD COLUMN slop_ai_advisory INTEGER NOT NULL DEFAULT 0;

--- a/migrations/0035_pull_request_slop_assessment.sql
+++ b/migrations/0035_pull_request_slop_assessment.sql
@@ -1,7 +1,7 @@
 -- Persist the latest deterministic slop assessment per cached pull request so the maintainer dashboard can
 -- surface a slop score row without re-fetching changed files on every load. Written by the public-surface
 -- processor ONLY when the repo opted into slop (slop_gate_mode != 'off'); NULL means "not assessed". These
--- are gittensory-COMPUTED signals, deliberately omitted from the GitHub-sync upsert's SET clause so a
+-- are loopover-COMPUTED signals, deliberately omitted from the GitHub-sync upsert's SET clause so a
 -- subsequent sync never clobbers them.
 ALTER TABLE pull_requests ADD COLUMN slop_risk INTEGER;
 ALTER TABLE pull_requests ADD COLUMN slop_band TEXT;

--- a/migrations/0042_agent_autonomy.sql
+++ b/migrations/0042_agent_autonomy.sql
@@ -1,5 +1,5 @@
 -- Agent-layer autonomy dial (#773, Wave 2 Phase 0). Per-action-class autonomy level stored as a JSON map
 -- (action class -> observe|suggest|propose|auto_with_approval|auto). Default '{}' = deny-by-default: every
--- action class resolves to `observe` (gittensory watches but never acts) until a maintainer opts in. The
+-- action class resolves to `observe` (loopover watches but never acts) until a maintainer opts in. The
 -- single source the action layer (#778) reads via resolveAutonomy. Additive; existing repos are unaffected.
 ALTER TABLE repository_settings ADD COLUMN autonomy_json TEXT NOT NULL DEFAULT '{}';

--- a/migrations/0047_self_improve_tunables.sql
+++ b/migrations/0047_self_improve_tunables.sql
@@ -12,7 +12,7 @@
 --   • override_audit            — recordOverrideAudit / listOverrideAudit
 -- (mirrors the reviewbot canonical tables; the columns + names match the bound queries exactly.)
 --
--- NOTE (config-application DEFERRED): gittensory's gate has NO confidenceFloor / scopeCap tunable and its
+-- NOTE (config-application DEFERRED): loopover's gate has NO confidenceFloor / scopeCap tunable and its
 -- native outcome signal measures gate FALSE POSITIVES (a loosening direction), so a promoted override here is
 -- NOT YET read by the live gate-config resolution — see src/review/selftune-wire.ts. These tables back the
 -- shadow-soak + audit + recommendation recording; reading a promoted override into the live gate is a noted

--- a/migrations/0049_review_audit_parity.sql
+++ b/migrations/0049_review_audit_parity.sql
@@ -4,7 +4,7 @@
 -- cutover from reviewbot to the gittensory-native review, we must PROVE the gittensory-native gate decision
 -- matches reviewbot's on the SAME PR at the SAME COMMIT. computeGateParity / computeGateEval read this table.
 --
--- gittensory has no `review_audit` table of its own (the ported parity.ts reads reviewbot's schema — see the
+-- loopover has no `review_audit` table of its own (the ported parity.ts reads reviewbot's schema — see the
 -- LIVE-USE PREREQUISITE note in parity.ts). This migration introduces exactly the columns those pure functions
 -- read, with the two LATER-migration columns parity.ts called out — `source` (which writer made the decision)
 -- and `head_sha` (which commit it was made on) — present from the start so the self-join works:
@@ -37,7 +37,7 @@ CREATE TABLE IF NOT EXISTS review_audit (
   -- the authoritative writer added during the deploy-time dual-run. The parity self-join is per-source.
   source TEXT NOT NULL DEFAULT 'gittensory-native',
   -- The commit the decision was made on. computeGateParity REQUIRES this non-null and joins on it so
-  -- reviewbot@shaA is never compared to gittensory@shaB. Nullable in the schema (a decision with no head_sha
+  -- reviewbot@shaA is never compared to loopover@shaB. Nullable in the schema (a decision with no head_sha
   -- is recorded but excluded from pairing), matching parity's `head_sha IS NOT NULL` filter.
   head_sha TEXT,
   -- The reasonCode for this decision (computeGateParity reads it as `summary` for the per-reasonCode breakdown).

--- a/migrations/0050_review_targets.sql
+++ b/migrations/0050_review_targets.sql
@@ -1,6 +1,6 @@
 -- #preconv-state (convergence prep): the review-target state machine + DECISION CACHE.
 --
--- This is the single missing stateful table in the reviewbot → gittensory state migration (#1025). gittensory
+-- This is the single missing stateful table in the reviewbot → loopover state migration (#1025). loopover
 -- already provisioned submitter_stats (0046), tunables_overrides/_shadow + override_audit (0047), and
 -- review_audit (0049) — but had no review_targets, even though already-ported code reads it:
 --   - src/review/ops.ts (computeAgentHealth: SELECT ... FROM review_targets; reversal join
@@ -19,7 +19,7 @@
 -- Schema = reviewbot's full accumulated review_targets (its 0001 + 0003/0005/0006/0007/0010 ALTERs folded into
 -- one CREATE). Natural key (project, kind, repo, number) == the PK id `${project}:${kind}:${repo}#${number}`.
 -- Kept raw-SQL-only (matching the 0046–0049 parity-store convention); deliberately NOT added to the Drizzle
--- schema, and the reviewbot FK review_audit.target_id → review_targets(id) is OMITTED (gittensory's review_audit
+-- schema, and the reviewbot FK review_audit.target_id → review_targets(id) is OMITTED (loopover's review_audit
 -- already dropped it, so the two tables stay decoupled and bulk copy needs no ordering FK).
 --
 -- Privacy: internal review state only — no PR content, no trust/reward internals beyond the gate verdict.

--- a/migrations/0051_repo_chunks.sql
+++ b/migrations/0051_repo_chunks.sql
@@ -16,7 +16,7 @@
 -- (ON CONFLICT(id) target; vector ids and the storage PK are GLOBAL — the chunk id already embeds the
 -- namespace, see chunkId() in rag.ts), and `updated_at` carries the conflict touch.
 --
--- The vector EMBEDDING itself lives in Vectorize (the `gittensory-review-rag` index), NOT here — this table is
+-- The vector EMBEDDING itself lives in Vectorize (the `loopover-review-rag` index), NOT here — this table is
 -- only the chunk text + light addressing metadata. Vectorize is the index; repo_chunks is the source-of-truth
 -- text the retrieved vector ids resolve back to.
 --

--- a/migrations/0052_pr_merge_attempt_terminal.sql
+++ b/migrations/0052_pr_merge_attempt_terminal.sql
@@ -4,7 +4,7 @@
 -- (method not allowed) / 409 (required check absent) / conflict throws, the action is recorded as an `error`
 -- audit row, but the pull_requests row stays plannable — so EVERY webhook + every scheduled re-gate sweep
 -- re-plans the same merge and it fails again, with no cap and no backoff. (reviewbot parity: review_targets'
--- attempt_count + terminal_at, which gittensory's normalized planner path never had.)
+-- attempt_count + terminal_at, which loopover's normalized planner path never had.)
 --
 -- AFTER: a non-transient merge failure marks the PR terminally merge-blocked FOR THE CURRENT HEAD SHA. The
 -- planner skips planning a merge while merge_blocked_sha == headSha, and the executor caps retries via

--- a/migrations/0056_orb_events.sql
+++ b/migrations/0056_orb_events.sql
@@ -1,4 +1,4 @@
--- Gittensory Orb (#1219): local outcome-signal store. Records the gate verdict and
+-- Loopover Orb (#1219): local outcome-signal store. Records the gate verdict and
 -- final outcome (merged / closed) for every PR the engine reviewed. Used by the Orb
 -- export job to batch-send calibration signals to the central collector (opt-in) or
 -- to keep them local for operator-only analysis (ORB_AIR_GAP=true).

--- a/migrations/0057_orb_installations.sql
+++ b/migrations/0057_orb_installations.sql
@@ -1,4 +1,4 @@
--- Gittensory Orb (#1219): tracks which repos have the Orb GitHub App installed.
+-- Loopover Orb (#1219): tracks which repos have the Orb GitHub App installed.
 -- `removed_at IS NULL` = currently installed; set on uninstall/removal events.
 CREATE TABLE IF NOT EXISTS orb_installations (
   id              INTEGER PRIMARY KEY,

--- a/migrations/0058_orb_signals.sql
+++ b/migrations/0058_orb_signals.sql
@@ -1,4 +1,4 @@
--- Gittensory Orb (#1219): central collector store. Receives anonymized outcome signal batches
+-- Loopover Orb (#1219): central collector store. Receives anonymized outcome signal batches
 -- from self-hosted instances running exportOrbBatch. repo_hash and pr_hash are HMAC-anonymized
 -- by the sender — no repo names, owner identifiers, or PR content is stored here.
 CREATE TABLE IF NOT EXISTS orb_signals (

--- a/migrations/0060_orb_fleet_collector.sql
+++ b/migrations/0060_orb_fleet_collector.sql
@@ -1,4 +1,4 @@
--- Gittensory Orb (#1255): turn Orb into the central fleet-calibration collector.
+-- Loopover Orb (#1255): turn Orb into the central fleet-calibration collector.
 --
 -- Retire the per-instance Orb GitHub App pipeline (orb_events / orb_installations were written by the
 -- now-removed /orb/webhook handler). Each self-hosted instance already records de-noised ground truth in

--- a/migrations/0061_orb_instances.sql
+++ b/migrations/0061_orb_instances.sql
@@ -1,4 +1,4 @@
--- Gittensory Orb (#1255) — instance registration gate, modeled on das-github-mirror's `registered=false`
+-- Loopover Orb (#1255) — instance registration gate, modeled on das-github-mirror's `registered=false`
 -- default. Every self-host instance that POSTs anonymized batches to /v1/orb/ingest is recorded here on
 -- first contact, but its signals only count toward fleet calibration once an operator REGISTERS it
 -- (registered=1). This is the fleet's trust anchor: ingest stays open + frictionless (no shared secret —

--- a/migrations/0062_pr_last_regated_at.sql
+++ b/migrations/0062_pr_last_regated_at.sql
@@ -13,7 +13,7 @@
 -- the next-stalest — full coverage of all open PRs in ceil(open/SWEEP_MAX_PRS) sweeps, convergent regardless of
 -- suppression. The GitHub-updatedAt freshness window is kept ONLY as the "don't race an in-flight webhook" guard.
 --
--- last_regated_at is gittensory-computed (sweep-written), keyed to the PR (not the head SHA), and OMITTED from
+-- last_regated_at is loopover-computed (sweep-written), keyed to the PR (not the head SHA), and OMITTED from
 -- the upsertPullRequestFromGitHub SET clause so a later GitHub sync cannot clobber it. Mirrors approved_head_sha
 -- (0053) / merge_blocked_sha (0052). Nullable / no default → backward-compatible (existing rows = NULL = never
 -- swept = maximally stale = picked first).

--- a/migrations/0064_orb_webhook_events.sql
+++ b/migrations/0064_orb_webhook_events.sql
@@ -1,4 +1,4 @@
--- Gittensory Orb central GitHub App (#1255) — webhook delivery dedup + audit for POST /v1/orb/webhook.
+-- Loopover Orb central GitHub App (#1255) — webhook delivery dedup + audit for POST /v1/orb/webhook.
 -- The central Orb App is a SEPARATE GitHub App from the review app, with its OWN webhook secret and its OWN
 -- delivery IDs, so it gets its OWN dedup table (not webhook_events) — a GitHub delivery_id is only unique per
 -- App, so sharing one table across two Apps could collide. This receiver just verifies + records (PR1);

--- a/migrations/0065_orb_github_installations.sql
+++ b/migrations/0065_orb_github_installations.sql
@@ -1,4 +1,4 @@
--- Gittensory Orb central GitHub App (#1255) — installation registry. One row per install of the shared Orb
+-- Loopover Orb central GitHub App (#1255) — installation registry. One row per install of the shared Orb
 -- App, maintained from the verified /v1/orb/webhook installation events. This is what onboarding + the
 -- token-broker (later PRs) read to know which installations exist, who owns them, and whether an operator has
 -- registered them. registered=0 by default — the Mirror-style manual-onboarding gate (an install is RECORDED

--- a/migrations/0067_orb_pr_outcomes.sql
+++ b/migrations/0067_orb_pr_outcomes.sql
@@ -1,4 +1,4 @@
--- Gittensory Orb central GitHub App (#1255) — terminal pull-request outcomes (merged | closed) observed via
+-- Loopover Orb central GitHub App (#1255) — terminal pull-request outcomes (merged | closed) observed via
 -- the central App's webhook. The raw material for the global "proof of power" homepage counter (total merged /
 -- closed across ALL registered maintainer repos, das-github-mirror style). Aggregated only over REGISTERED
 -- installations. Idempotent on (repo, pr_number): a redelivery or a reopen→close cycle overwrites the latest

--- a/migrations/0068_orb_enrollments.sql
+++ b/migrations/0068_orb_enrollments.sql
@@ -1,4 +1,4 @@
--- Gittensory Orb central GitHub App (#1255) — the token-broker enrollment ledger. A maintainer authorizes the
+-- Loopover Orb central GitHub App (#1255) — the token-broker enrollment ledger. A maintainer authorizes the
 -- Orb App (OAuth) and is bound, server-side, to a SPECIFIC installation they administer; their self-hosted
 -- container is then issued a one-time enrollment secret (stored HASHED, never plaintext) which it exchanges for
 -- short-lived installation tokens. installation_id is written here at the OAuth callback after an authority

--- a/migrations/0071_installations_app_id.sql
+++ b/migrations/0071_installations_app_id.sql
@@ -1,5 +1,5 @@
 -- Dual-app identity (#selfhost-app-id): record which GitHub App an installation belongs to, so a backend can
--- tell its OWN installations from a SECOND gittensory App installed on the same account (cloud + self-host
+-- tell its OWN installations from a SECOND loopover App installed on the same account (cloud + self-host
 -- running side by side during the migration). Nullable: only `installation` events and the App-installation API
 -- refresh carry app_id, so existing rows backfill lazily on their next event. The webhook entry fails OPEN — an
 -- unknown app_id always processes — so this column is byte-identical until it is populated.

--- a/migrations/0072_contributor_blacklist.sql
+++ b/migrations/0072_contributor_blacklist.sql
@@ -1,5 +1,5 @@
 -- Per-repo contributor blacklist (#1425, anti-abuse): a JSON array of banned-login entries
 -- ({ login, reason?, evidence?, addedAt? }) the converged engine deterministically closes a PR/issue against,
--- ahead of any merit/CI/AI analysis. Layered like other settings (.gittensory.yml > DB) and unioned with the
+-- ahead of any merit/CI/AI analysis. Layered like other settings (.loopover.yml > DB) and unioned with the
 -- shared/global list at the point of use. Defaults to an empty list, so existing rows are byte-identical.
 ALTER TABLE repository_settings ADD COLUMN contributor_blacklist_json TEXT NOT NULL DEFAULT '[]';

--- a/migrations/0080_pr_last_published_surface_sha.sql
+++ b/migrations/0080_pr_last_published_surface_sha.sql
@@ -2,6 +2,6 @@
 -- published. The scheduled re-gate sweep skips re-reviewing + re-publishing a PR while
 -- last_published_surface_sha === head_sha (the surface is already current). Keyed to the head SHA so a push /
 -- rebase / force-push (new head) no longer matches → the next sweep re-reviews + re-publishes the new code.
--- NULL = never published. gittensory-computed (publish-written); like approved_head_sha / merge_blocked_sha it is
+-- NULL = never published. loopover-computed (publish-written); like approved_head_sha / merge_blocked_sha it is
 -- omitted from the GitHub-sync SET clause so a later sync cannot clobber it.
 ALTER TABLE pull_requests ADD COLUMN last_published_surface_sha TEXT;

--- a/migrations/0091_review_nag_cooldown.sql
+++ b/migrations/0091_review_nag_cooldown.sql
@@ -1,4 +1,4 @@
--- Review-request nagging cooldown (#2463, anti-abuse): throttle a contributor repeatedly pinging @gittensory.
+-- Review-request nagging cooldown (#2463, anti-abuse): throttle a contributor repeatedly pinging @loopover.
 -- Defaults are byte-identical to today: review_nag_policy defaults to 'off' (disabled), so existing rows see no
 -- behavior change. review_nag_max_pings / review_nag_cooldown_days / review_nag_label only take effect once a
 -- repo opts in by setting the policy to 'hold' or 'close'.
@@ -6,6 +6,6 @@ ALTER TABLE repository_settings ADD COLUMN review_nag_policy TEXT NOT NULL DEFAU
 ALTER TABLE repository_settings ADD COLUMN review_nag_max_pings INTEGER NOT NULL DEFAULT 3;
 ALTER TABLE repository_settings ADD COLUMN review_nag_cooldown_days INTEGER NOT NULL DEFAULT 5;
 ALTER TABLE repository_settings ADD COLUMN review_nag_label TEXT NOT NULL DEFAULT 'review-nag-cooldown';
--- Shared repo-scoped exemption list (#2463): GitHub logins never throttled/closed by gittensory's deterministic
+-- Shared repo-scoped exemption list (#2463): GitHub logins never throttled/closed by loopover's deterministic
 -- anti-abuse mechanisms, on top of the standing owner/admin/automation-bot exemption. Defaults to an empty list.
 ALTER TABLE repository_settings ADD COLUMN auto_close_exempt_logins_json TEXT NOT NULL DEFAULT '[]';

--- a/migrations/0097_command_rate_limit.sql
+++ b/migrations/0097_command_rate_limit.sql
@@ -1,5 +1,5 @@
--- Per-command @gittensory rate limit (#2560, anti-abuse): generalizes the review-nag cooldown's audit-ledger
--- counting pattern to EVERY @gittensory command, not just review-request pings. Independent of and complementary
+-- Per-command @loopover rate limit (#2560, anti-abuse): generalizes the review-nag cooldown's audit-ledger
+-- counting pattern to EVERY @loopover command, not just review-request pings. Independent of and complementary
 -- to review-nag (that stays scoped to the thread's own author; this covers any actor invoking any command).
 -- Defaults are byte-identical to today: command_rate_limit_policy defaults to 'off' (disabled), so existing
 -- repos see no behavior change until they opt in. The AI-cost-bearing commands (ask/blockers/preflight/

--- a/migrations/0100_review_nag_monitored_mentions.sql
+++ b/migrations/0100_review_nag_monitored_mentions.sql
@@ -1,6 +1,6 @@
--- Maintainer-mention nag moderation (#label-scoping): extends the existing @gittensory review-nag cooldown
+-- Maintainer-mention nag moderation (#label-scoping): extends the existing @loopover review-nag cooldown
 -- (review_nag_policy/review_nag_max_pings/review_nag_cooldown_days/review_nag_label) to ALSO throttle a
 -- contributor who repeatedly @-mentions a configured maintainer login, counted independently per mentioned
--- login and independently of the @gittensory counter. Default '[]' (no logins watched), so existing repos see
+-- login and independently of the @loopover counter. Default '[]' (no logins watched), so existing repos see
 -- no behavior change until they opt in.
 ALTER TABLE repository_settings ADD COLUMN review_nag_monitored_mentions_json TEXT NOT NULL DEFAULT '[]';

--- a/migrations/0102_fix_linked_issue_gate_mode_default.sql
+++ b/migrations/0102_fix_linked_issue_gate_mode_default.sql
@@ -3,7 +3,7 @@
 -- backfill that flipped any 'advisory' row to 'block' for repos with gate_check_mode='enabled'), even
 -- though missing a linked issue is only ever supposed to be advisory unless a maintainer explicitly opts
 -- into blocking. The application-level fallback (src/db/repositories.ts) and every documented default
--- (.gittensory.yml.example, docs.tuning.tsx, the settings API schema) already say 'advisory' -- only the
+-- (.loopover.yml.example, docs.tuning.tsx, the settings API schema) already say 'advisory' -- only the
 -- persisted column value drifted.
 --
 -- #gate-review-2727 round 1: require_linked_issue = 0 alone does NOT prove drift. linkedIssueGateMode and

--- a/migrations/0113_review_evasion_protection.sql
+++ b/migrations/0113_review_evasion_protection.sql
@@ -1,5 +1,5 @@
 -- Review-evasion protection (#review-evasion-protection): a contributor closing or converting their OWN PR
--- to draft while gittensory has an ACTIVE review pass running against it is dodging the one-shot review
+-- to draft while loopover has an ACTIVE review pass running against it is dodging the one-shot review
 -- process, not making an ordinary close. active_review_tracking durably records that a fresh review pass
 -- started for a specific repo/PR/headSha BEFORE any cost-bearing AI-review work begins, so the closed/
 -- converted_to_draft webhook handlers can tell evasion (a close during an active pass) apart from an
@@ -22,7 +22,7 @@ CREATE UNIQUE INDEX IF NOT EXISTS active_review_tracking_pr_unique ON active_rev
 -- Per-repo review-evasion settings, layered the same way as every other anti-abuse mechanism in this file
 -- (contributorCap/blacklist/reviewNag): reviewEvasionProtection is off by default (zero behavior change for
 -- an install that hasn't opted in); reviewEvasionLabel is NOT NULL with a string default (mirrors
--- blacklist_label/review_nag_label -- the "no label" case is a `.gittensory.yml`-only override, never
+-- blacklist_label/review_nag_label -- the "no label" case is a `.loopover.yml`-only override, never
 -- persisted); reviewEvasionComment defaults to posting the explanation comment, matching the existing
 -- draft-dodge/reopen-reclose guards' unconditional explanation comment.
 ALTER TABLE repository_settings ADD COLUMN review_evasion_protection TEXT NOT NULL DEFAULT 'off';

--- a/migrations/0116_regate_sweep_order_mode.sql
+++ b/migrations/0116_regate_sweep_order_mode.sql
@@ -1,3 +1,3 @@
 -- Opt-in oldest-first ordering mode for the scheduled re-gate sweep (#3815). Default 'staleness' (existing
--- behavior, unchanged) — a repo opts into 'oldest-first' explicitly via the dashboard/API or .gittensory.yml.
+-- behavior, unchanged) — a repo opts into 'oldest-first' explicitly via the dashboard/API or .loopover.yml.
 ALTER TABLE repository_settings ADD COLUMN regate_sweep_order_mode TEXT NOT NULL DEFAULT 'staleness';

--- a/migrations/0119_ai_slop_cache.sql
+++ b/migrations/0119_ai_slop_cache.sql
@@ -1,4 +1,4 @@
--- AI slop advisory cache (mirrors ai_review_cache, #74/#98/#112): runGittensoryAiSlopAdvisory makes a real
+-- AI slop advisory cache (mirrors ai_review_cache, #74/#98/#112): runLoopoverAiSlopAdvisory makes a real
 -- LLM call (up to 6 free-tier attempts, or one BYOK call) with NO caching, so every scheduled re-gate sweep
 -- tick re-spends it for every open PR with slopAiAdvisory on, even at an unchanged head SHA -- confirmed in
 -- production: 1,469 ai_slop_pr calls in 24h across 3 repos, 110 of them on a single PR. Unlike ai_review_cache,

--- a/migrations/0127_agent_global_freeze_override.sql
+++ b/migrations/0127_agent_global_freeze_override.sql
@@ -3,8 +3,8 @@
 -- has no per-repo scoping today -- flipping it affects every repo at once, which is what caused a real
 -- multi-repo incident (live merges/closes fired for repos that were meant to stay paused). This column lets an
 -- operator keep the global DB kill-switch ON as the safe default while opting ONE repo at a time back into live
--- execution via that repo's `.gittensory.yml` (`settings.agentGlobalFreezeOverride: true`), the same
--- global-default + per-repo-override shape every other gittensory setting already uses.
+-- execution via that repo's `.loopover.yml` (`settings.agentGlobalFreezeOverride: true`), the same
+-- global-default + per-repo-override shape every other loopover setting already uses.
 --
 -- Deliberately does NOT touch `AGENT_ACTIONS_PAUSED` (isGlobalAgentPause): that env-var hard stop is checked
 -- independently and remains absolute -- no per-repo setting may ever bypass it. A repo's own `agent_paused =

--- a/migrations/0134_pr_last_backlog_convergence_regated_at.sql
+++ b/migrations/0134_pr_last_backlog_convergence_regated_at.sql
@@ -11,6 +11,6 @@
 -- #audit-sweep-dispatch-stamp), and fanOutBacklogConvergenceSweepJobs's resolution loop skips a repo whose
 -- freshest stamp is within the sweep's own draining window (isRegateSweepDraining, BACKLOG_CONVERGENCE_SWEEP_FRESHNESS_MS).
 --
--- gittensory-computed (sweep-written), keyed to the PR, omitted from upsertPullRequestFromGitHub's SET clause so
+-- loopover-computed (sweep-written), keyed to the PR, omitted from upsertPullRequestFromGitHub's SET clause so
 -- a later GitHub sync cannot clobber it. Nullable / no default -> backward-compatible.
 ALTER TABLE pull_requests ADD COLUMN last_backlog_convergence_regated_at TEXT;

--- a/migrations/0137_predicted_gate_calls.sql
+++ b/migrations/0137_predicted_gate_calls.sql
@@ -1,5 +1,5 @@
 -- #predicted-live-gate-agreement (maintainer review-stack x AMS integration audit, 2026-07-09): the data
--- substrate for measuring how often the MCP `gittensory_predict_gate`/`gittensory_explain_gate_disposition`
+-- substrate for measuring how often the MCP `loopover_predict_gate`/`loopover_explain_gate_disposition`
 -- verdict agrees with the REAL gate decision the same contributor's PR later receives.
 --
 -- WHY A NEW TABLE, NOT A `review_audit` ROW: `predictGateShape` has no PR-number field (it is an explicit

--- a/migrations/0140_ai_review_low_confidence_disposition.sql
+++ b/migrations/0140_ai_review_low_confidence_disposition.sql
@@ -4,5 +4,5 @@
 -- unconditional-close drift from commit 311b7613d/#1781 back to a safe default) routes the would-be close
 -- through the existing held-for-manual-review mechanism instead of one-shot-closing; 'one_shot' keeps
 -- today's unconditional-close behavior (opt-in); 'advisory_only' drops a sub-floor finding to fully
--- non-blocking. See src/rules/advisory.ts's isConfiguredGateBlocker and gittensory-gate-setting-wiring.
+-- non-blocking. See src/rules/advisory.ts's isConfiguredGateBlocker and loopover-gate-setting-wiring.
 ALTER TABLE repository_settings ADD COLUMN ai_review_low_confidence_disposition TEXT NOT NULL DEFAULT 'hold_for_review';

--- a/migrations/0148_ams_signals.sql
+++ b/migrations/0148_ams_signals.sql
@@ -1,4 +1,4 @@
--- Gittensory AMS (#5681) — central telemetry collector store, mirroring orb_signals' pattern for the miner
+-- Loopover AMS (#5681) — central telemetry collector store, mirroring orb_signals' pattern for the miner
 -- product. Receives anonymized PR-outcome batches from opt-in AMS instances (orb-export.js). repo_hash and
 -- pr_hash are HMAC-anonymized by the sender before this table ever sees them — no repo names, owner
 -- identifiers, or PR content is stored here. A separate table from orb_signals rather than a shared

--- a/migrations/0149_ams_instances.sql
+++ b/migrations/0149_ams_instances.sql
@@ -1,4 +1,4 @@
--- Gittensory AMS (#5681) — instance registration gate, mirroring orb_instances (see that table's own
+-- Loopover AMS (#5681) — instance registration gate, mirroring orb_instances (see that table's own
 -- migration for the full trust-model rationale). Every AMS instance that POSTs an anonymized batch to
 -- /v1/ams/ingest is recorded here on first contact, but signals only count toward any future AMS-side
 -- aggregate until an operator explicitly registers it (registered=1) — same das-github-mirror-modeled


### PR DESCRIPTION
## Summary

- Part of the gittensory→loopover rebrand (#5705), phase 8b: rename brand-name prose in the comment-only `-- ` headers of 35 migration files. DDL itself is untouched, including the two `'gittensory-native'` `source` column `DEFAULT` clauses in `0049_review_audit_parity.sql` and `0126_contributor_gate_history.sql` — a real `review_audit`/`contributor_gate_history` provenance discriminator value that other code compares against exactly, not prose.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue this PR resolves — N/A, maintainer-authored rebrand-epic cleanup (#5705), no linked-issue gate applies to owner PRs.

## Validation

- [x] `git diff --check`
- [x] `npm run db:migrations:check` — 152 migrations OK, contiguous, no new duplicates
- [x] `npm run db:schema-drift:check` — schema.ts matches migrations/

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no such changes.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, comment-only, no schema change.
- [ ] UI changes use live API data or real empty/error/loading states. — N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section. — N/A, no UI changes.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs (none touched here).

## Notes

- Final batch of the bulk-prose portion of rebrand epic #5705.