### PR TITLE
fix(ui): widen the ui-kit consumer range past its 1.0.0 pre-release cap

### DIFF
--- a/apps/loopover-miner-ui/package.json
+++ b/apps/loopover-miner-ui/package.json
@@ -15,7 +15,7 @@
     "format": "prettier --write ."
   },
   "dependencies": {
-    "@loopover/ui-kit": ">=0.1.0 <1.0.0",
+    "@loopover/ui-kit": ">=0.1.0 <2.0.0",
     "@tailwindcss/vite": "^4.3.2",
     "@tanstack/react-router": "^1.170.17",
     "react": "^19.2.7",

--- a/apps/loopover-ui/package.json
+++ b/apps/loopover-ui/package.json
@@ -20,7 +20,7 @@
     "format": "prettier --write ."
   },
   "dependencies": {
-    "@loopover/ui-kit": ">=0.1.0 <1.0.0",
+    "@loopover/ui-kit": ">=0.1.0 <2.0.0",
     "@radix-ui/react-accordion": "^1.2.15",
     "@radix-ui/react-alert-dialog": "^1.1.18",
     "@radix-ui/react-aspect-ratio": "^1.1.11",

--- a/package-lock.json
+++ b/package-lock.json
@@ -76,7 +76,7 @@
       "name": "@loopover/ui-miner",
       "version": "0.0.0",
       "dependencies": {
-        "@loopover/ui-kit": ">=0.1.0 <1.0.0",
+        "@loopover/ui-kit": ">=0.1.0 <2.0.0",
         "@tailwindcss/vite": "^4.3.2",
         "@tanstack/react-router": "^1.170.17",
         "react": "^19.2.7",
@@ -486,7 +486,7 @@
       "name": "@loopover/ui",
       "version": "0.0.0",
       "dependencies": {
-        "@loopover/ui-kit": ">=0.1.0 <1.0.0",
+        "@loopover/ui-kit": ">=0.1.0 <2.0.0",
         "@radix-ui/react-accordion": "^1.2.15",
         "@radix-ui/react-alert-dialog": "^1.1.18",
         "@radix-ui/react-aspect-ratio": "^1.1.11",
@@ -15889,7 +15889,7 @@
       "version": "2.0.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@loopover/engine": "^3.1.0",
+        "@loopover/engine": "^1.0.0",
         "@modelcontextprotocol/sdk": "1.29.0",
         "zod": "^4.4.3"
       },
@@ -15920,7 +15920,7 @@
       "version": "2.0.0",
       "license": "AGPL-3.0-only",
       "dependencies": {
-        "@loopover/engine": "^3.1.0",
+        "@loopover/engine": "^3.0.0",
         "@modelcontextprotocol/sdk": "1.29.0",
         "zod": "^4.4.3"
       },


### PR DESCRIPTION
## Summary

- `apps/loopover-ui` and `apps/loopover-miner-ui` both pinned `"@loopover/ui-kit"` to `">=0.1.0 <1.0.0"`, which excludes the ui-kit-v1.0.0 release-please PR's target version and permanently blocks its `npm ci` with `Missing: @loopover/ui-kit@0.2.0 from lock file` (confirmed live on #5826).
- Checked the release's own CHANGELOG first: the only `BREAKING CHANGES` entry for this 1.0.0 cut is the `gittensory-*` → `loopover-*` rename, which both consuming apps have already fully completed (they already import `@loopover/ui-kit` under its new name). So there's no live incompatibility to guard against — the `<1.0.0` ceiling is just stale.
- Widened both to `<2.0.0`, preserving the existing below-next-major convention rather than removing the cap outright.
- Also reconciles a separate, pre-existing drift `npm install` surfaced while regenerating the lockfile: `package-lock.json`'s `@loopover/mcp` and `@loopover/miner` entries still required `@loopover/engine` at `^3.1.0` — a leftover from an earlier release-please regeneration cycle — while their actual `package.json` files (already merged to `main` via #5735/in-flight #5736) declare `^1.0.0`/`^3.0.0`. Harmless today only by coincidence (local engine happens to satisfy both), but worth reconciling since the file was already being touched.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue this PR resolves — maintainer PR fixing a dependency-range defect discovered live on #5826, no linked issue.

## Validation

- [x] `git diff --check`
- [x] `npm run ui:typecheck` — clean, both apps.
- [x] `npm run ui:lint` — 0 errors (145/7 pre-existing warnings in untouched route files, unrelated to this change).
- [ ] `npm run ui:build` — not run locally (full build is slow); `ui:typecheck` + `ui:lint` cover the actual surface touched (a dependency range + regenerated lockfile, no source changes). CI's own `ui:build` step will validate this.
- [ ] `npm run test:coverage` — skipped; `src/**` untouched.
- [ ] `npm run test:workers` / `npm run build:mcp` / `npm run test:mcp-pack` — skipped, unaffected by this change.
- [ ] `npm audit --audit-level=moderate` — no new dependencies added, only a range widened and a lockfile drift reconciled.

If any required check was skipped, explain why:

- No `src/` or application code changed — only two dependency range strings and the lockfile regenerated to match. `typecheck` and `lint` (which both rebuild `@loopover/ui-kit` first) are the relevant checks and are clean; CI's own `ui:build` will provide the final confirmation.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth/cookie/CORS/GitHub App/Cloudflare/session changes include negative-path tests. — N/A.
- [ ] API/OpenAPI/MCP behavior updated/tested. — N/A.
- [ ] UI changes use live API data or real empty/error/loading states. — N/A, no UI behavior changed, only a dependency range.
- [ ] Visible UI changes include a `UI Evidence` section. — N/A, no visible UI change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — this PR does not touch `CHANGELOG.md`.

## Notes

- Discovered while triaging why the `ui-kit` release-please PR (#5826) failed `Build UI preview artifact` even though ui-kit itself has no `@loopover/*` dependencies of its own.