### PR TITLE
feat(mcp): expose skipped-PR audit trail as a maintainer MCP tool

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.js
+++ b/packages/loopover-mcp/bin/loopover-mcp.js
@@ -123,7 +123,7 @@ const AGENT_PROFILES = {
     audience: "maintainers preparing low-noise queue and PR review context",
     purpose: "Summarize queue risk, prepare review notes, and draft public guidance for human review.",
     recommendedPrompts: ["loopover_maintainer_queue_triage", "loopover_maintainer_review_prep", "loopover_maintainer_public_guidance"],
-    recommendedTools: ["loopover_get_repo_context", "loopover_get_burden_forecast", "loopover_preflight_pr"],
+    recommendedTools: ["loopover_get_repo_context", "loopover_get_burden_forecast", "loopover_preflight_pr", "loopover_get_skipped_pr_audit"],
     boundaries: [
       "Human-approved only: prepare summaries and draft guidance; do not post comments, label, close, merge, or edit contributor work.",
       "Keep private review context, raw trust context, and authenticated-only evidence out of public snippets.",

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -278,7 +278,7 @@ import { resolveRepositorySettings } from "../settings/repository-settings";
 import { loadPublicRepoFocusManifest, loadRepoFocusManifest, upsertRepoFocusManifest } from "../signals/focus-manifest-loader";
 import { buildRepoOnboardingPackPreviewForRepo } from "../services/repo-onboarding-pack";
 import { generateContributorIssueDrafts } from "../services/contributor-issue-draft";
-import { buildRepoSettingsPreview, type PublicSurfaceSkipReason } from "../signals/settings-preview";
+import { buildRepoSettingsPreview, PUBLIC_SURFACE_SKIP_REASONS, skippedPrAuditRemediation } from "../signals/settings-preview";
 import {
   buildGittensorConfigRecommendation,
   buildRegistrationReadiness,
@@ -418,15 +418,6 @@ async function readRequestBodyWithLimit(request: Request, maxBytes: number): Pro
 
 const MAX_LOCAL_BRANCH_REF_CHARS = 256;
 const MAX_LOCAL_BRANCH_TEXT_CHARS = 4000;
-const PR_VISIBILITY_SKIP_REASONS = [
-  "surface_off",
-  "missing_author",
-  "bot_author",
-  "ignored_author",
-  "maintainer_author",
-  "miner_detection_unavailable",
-  "not_official_gittensor_miner",
-] as const satisfies readonly PublicSurfaceSkipReason[];
 
 const preflightSchema = z.object({
   repoFullName: z.string().min(3).max(PREFLIGHT_LIMITS.repoFullNameChars),
@@ -504,7 +495,7 @@ const skippedPrAuditQuerySchema = z
   .object({
     limit: z.coerce.number().int().optional(),
     repoFullName: z.string().trim().min(3).max(200).optional(),
-    reason: z.enum(PR_VISIBILITY_SKIP_REASONS).optional(),
+    reason: z.enum(PUBLIC_SURFACE_SKIP_REASONS).optional(),
     since: z.string().trim().min(1).max(64).optional(),
   })
   .strict();
@@ -5758,27 +5749,6 @@ async function skippedPrAuditRepoScope(
     return scopedRepoNames.has(requestedRepo.toLowerCase()) ? [requestedRepo] : c.json({ error: "forbidden_repo" }, 403);
   }
   return scope.repositoryFullNames;
-}
-
-function skippedPrAuditRemediation(reason: string): string {
-  switch (reason) {
-    case "surface_off":
-      return "Enable a PR public surface or check runs in repository settings if maintainers want LoopOver to post.";
-    case "missing_author":
-      return "Retry after GitHub provides a resolvable pull request author.";
-    case "bot_author":
-      return "No action needed; bot-authored pull requests are intentionally kept quiet.";
-    case "ignored_author":
-      return "No action needed; the repository manifest explicitly skips review output for this author.";
-    case "maintainer_author":
-      return "Enable maintainer-authored PRs in repository settings only if those PRs should receive public GitHub App output.";
-    case "miner_detection_unavailable":
-      return "Retry after official Gittensor miner detection recovers; LoopOver skips instead of guessing.";
-    case "not_official_gittensor_miner":
-      return "No public action is needed unless the author should be recognized as an official Gittensor miner.";
-    default:
-      return "Review repository settings and installation health before reprocessing the pull request.";
-  }
 }
 
 function toIsoQueryDate(value: string): string | undefined {

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -48,6 +48,7 @@ import {
   getRepoQueueTrendSnapshot,
   listAgentAuditEvents,
   listCheckSummaries,
+  listPrVisibilitySkipAuditEvents,
   listPendingAgentActions,
   listContributorRepoStats,
   listContributorIssues,
@@ -70,6 +71,7 @@ import {
   recordProductUsageEvent,
 } from "../db/repositories";
 import { decidePendingAgentAction } from "../services/agent-approval-queue";
+import { nowIso } from "../utils/json";
 import { buildNotificationFeed } from "../notifications/service";
 import { contributorRepoStatsFromGittensor, fetchGittensorContributorSnapshot } from "../gittensor/api";
 import { getRepositoryCollaboratorPermission } from "../github/app";
@@ -130,6 +132,7 @@ import {
   buildRegistryChangeReport,
   buildRoleContext,
 } from "../signals/engine";
+import { PUBLIC_SURFACE_SKIP_REASONS, skippedPrAuditRemediation, type PublicSurfaceSkipReason } from "../signals/settings-preview";
 import { buildContributorOpenPrMonitor } from "../signals/contributor-open-pr-monitor";
 import { buildLocalBranchAnalysis, findCurrentBranchPullRequest } from "../signals/local-branch";
 import { computeLocalScorerTokens } from "../signals/local-scorer";
@@ -813,6 +816,25 @@ const gatePrecisionOutputSchema = {
   perGateType: z.array(z.unknown()).optional(),
   overall: z.unknown().optional(),
   signals: z.array(z.string()).optional(),
+};
+
+// #5825 - maintainer-authenticated skipped-PR audit trail, mirroring GET /v1/app/skipped-pr-audit's
+// filters (all optional: a bare call returns the caller's own repo-scoped feed). No owner/repo shape
+// here on purpose: unlike ownerRepoShape tools this report can legitimately span every repo the caller
+// is scoped to, so repoFullName narrows rather than requires.
+const skippedPrAuditShape = {
+  repoFullName: z.string().trim().min(1).max(200).optional(),
+  reason: z.enum(PUBLIC_SURFACE_SKIP_REASONS).optional(),
+  since: z.string().trim().min(1).max(64).optional(),
+  limit: z.number().int().positive().optional(),
+};
+
+const skippedPrAuditOutputSchema = {
+  generatedAt: z.string().optional(),
+  limit: z.number().optional(),
+  hasMore: z.boolean().optional(),
+  filters: z.unknown().optional(),
+  items: z.array(z.unknown()).optional(),
 };
 
 const contributorProfileOutputSchema = {
@@ -1677,6 +1699,17 @@ export class LoopoverMcp {
         outputSchema: gatePrecisionOutputSchema,
       },
       async (input) => this.toolResult(await this.getGatePrecision(input)),
+    );
+
+    server.registerTool(
+      "loopover_get_skipped_pr_audit",
+      {
+        description:
+          "Return the skipped-PR audit trail: pull requests LoopOver's automated reviewer intentionally stayed quiet on, each with a reason code and a remediation hint. Optionally filter by repoFullName, reason, or since. Maintainer-authenticated; read-only measurement, not a moderation or override action.",
+        inputSchema: skippedPrAuditShape,
+        outputSchema: skippedPrAuditOutputSchema,
+      },
+      async (input) => this.toolResult(await this.getSkippedPrAudit(input)),
     );
 
     server.registerTool(
@@ -2972,6 +3005,69 @@ export class LoopoverMcp {
     return {
       summary: `LoopOver gate precision for ${fullName}: ${report.overall.blocked} gate blocks, overall false-positive rate ${report.overall.falsePositiveRate ?? "n/a (below sample threshold)"}.`,
       data: report as unknown as Record<string, unknown>,
+    };
+  }
+
+  // #5825 - repo-scope resolution for the skipped-PR audit tool. Mirrors skippedPrAuditRepoScope in
+  // src/api/routes.ts (same underlying loadControlPanelRoleSummary/loadControlPanelAccessScope calls,
+  // same maintainer/owner/operator role gate, same "no filter -> caller's own scoped repos" fallback),
+  // adapted to this file's MCP identity/throw conventions since that route helper is bound to a Hono
+  // ProtectedRouteContext and returns a Response, neither of which fits an MCP tool method. The shared
+  // static `mcp` CLI token is NOT trusted implicitly for this cross-repo maintainer report (unlike the
+  // route's own static identities, which are operator-only Worker secrets) -- it must opt in via the
+  // unscoped MCP_READ_REPO_ALLOWLIST wildcard, matching requireOperatorAccess/requireDiscoveryAccess above.
+  private async requireSkippedPrAuditAccess(requestedRepo: string | undefined): Promise<string[] | undefined> {
+    if (this.identity.kind === "session") {
+      const [summary, scope] = await Promise.all([loadControlPanelRoleSummary(this.env, this.identity.actor), this.loadSessionAccessScope()]);
+      if (!summary.roles.some((role) => role === "maintainer" || role === "owner" || role === "operator")) {
+        throw new Error("Forbidden: maintainer, owner, or operator role is required for the skipped-PR audit.");
+      }
+      if (scope.operator) return requestedRepo ? [requestedRepo] : undefined;
+      if (!requestedRepo) return scope.repositoryFullNames;
+      if (!scope.repositoryFullNames.some((name) => name.toLowerCase() === requestedRepo.toLowerCase())) {
+        throw new Error("Forbidden: session cannot access this repository's skipped-PR audit.");
+      }
+      return [requestedRepo];
+    }
+    if (this.identity.kind === "static" && this.identity.actor === "mcp" && !isMcpReadUnscoped(this.env.MCP_READ_REPO_ALLOWLIST)) {
+      throw new Error("Forbidden: this MCP token is not authorized for the skipped-PR audit.");
+    }
+    return requestedRepo ? [requestedRepo] : undefined;
+  }
+
+  private async getSkippedPrAudit(input: {
+    repoFullName?: string | undefined;
+    reason?: PublicSurfaceSkipReason | undefined;
+    since?: string | undefined;
+    limit?: number | undefined;
+  }): Promise<ToolPayload> {
+    const repoFullNames = await this.requireSkippedPrAuditAccess(input.repoFullName);
+    let sinceIso: string | undefined;
+    if (input.since !== undefined) {
+      const timestamp = Date.parse(input.since);
+      if (!Number.isFinite(timestamp)) throw new Error(`Invalid since: "${input.since}" is not a parseable date.`);
+      sinceIso = new Date(timestamp).toISOString();
+    }
+    const page = await listPrVisibilitySkipAuditEvents(this.env, { limit: input.limit, repoFullNames, reason: input.reason, sinceIso });
+    return {
+      summary: `LoopOver skipped-PR audit: ${page.items.length} event(s) (limit ${page.limit}${page.hasMore ? ", more available" : ""}).`,
+      data: {
+        generatedAt: nowIso(),
+        limit: page.limit,
+        hasMore: page.hasMore,
+        filters: {
+          repoFullName: input.repoFullName ?? null,
+          reason: input.reason ?? null,
+          since: sinceIso ?? null,
+        },
+        items: page.items.map((item) => ({
+          repoFullName: item.repoFullName,
+          pullNumber: item.pullNumber,
+          reason: item.reason,
+          timestamp: item.createdAt,
+          remediation: skippedPrAuditRemediation(item.reason),
+        })),
+      },
     };
   }
 

--- a/src/signals/settings-preview.ts
+++ b/src/signals/settings-preview.ts
@@ -48,6 +48,19 @@ export type PublicSurfaceSkipReason =
   | "miner_detection_unavailable"
   | "not_official_gittensor_miner";
 
+// Canonical reason list, shared by the /v1/app/skipped-pr-audit route's query-param enum and the
+// loopover_get_skipped_pr_audit MCP tool's input enum, so both surfaces stay in lockstep with
+// PublicSurfaceSkipReason instead of maintaining their own copy of this literal list.
+export const PUBLIC_SURFACE_SKIP_REASONS = [
+  "surface_off",
+  "missing_author",
+  "bot_author",
+  "ignored_author",
+  "maintainer_author",
+  "miner_detection_unavailable",
+  "not_official_gittensor_miner",
+] as const satisfies readonly PublicSurfaceSkipReason[];
+
 export type PublicSurfaceAction = "skip" | "comment" | "label" | "check_run" | "none";
 
 export type PublicSurfaceDecisionInput = {
@@ -81,6 +94,31 @@ const SKIP_SUMMARY: Record<PublicSurfaceSkipReason, string> = {
 
 function skipDecision(reason: PublicSurfaceSkipReason): PublicSurfaceDecision {
   return { willComment: false, willLabel: false, willCheckRun: false, skipped: true, skipReason: reason, actions: ["skip"], summary: SKIP_SUMMARY[reason] };
+}
+
+// Maintainer-facing remediation hint for a skipped-PR audit event's reason code. Shared by the
+// /v1/app/skipped-pr-audit route and the loopover_get_skipped_pr_audit MCP tool. Takes a plain string
+// (not PublicSurfaceSkipReason) because audit rows can carry historic/legacy reason values recorded
+// before the current reason set existed; those fall through to the generic default.
+export function skippedPrAuditRemediation(reason: string): string {
+  switch (reason) {
+    case "surface_off":
+      return "Enable a PR public surface or check runs in repository settings if maintainers want LoopOver to post.";
+    case "missing_author":
+      return "Retry after GitHub provides a resolvable pull request author.";
+    case "bot_author":
+      return "No action needed; bot-authored pull requests are intentionally kept quiet.";
+    case "ignored_author":
+      return "No action needed; the repository manifest explicitly skips review output for this author.";
+    case "maintainer_author":
+      return "Enable maintainer-authored PRs in repository settings only if those PRs should receive public GitHub App output.";
+    case "miner_detection_unavailable":
+      return "Retry after official Gittensor miner detection recovers; LoopOver skips instead of guessing.";
+    case "not_official_gittensor_miner":
+      return "No public action is needed unless the author should be recognized as an official Gittensor miner.";
+    default:
+      return "Review repository settings and installation health before reprocessing the pull request.";
+  }
 }
 
 /**

--- a/test/unit/mcp-output-schemas.test.ts
+++ b/test/unit/mcp-output-schemas.test.ts
@@ -38,6 +38,7 @@ const TOOLS_WITH_OUTPUT_SCHEMA = [
   "loopover_get_eligibility_plan",
   "loopover_simulate_open_pr_pressure",
   "loopover_get_gate_precision",
+  "loopover_get_skipped_pr_audit",
 ];
 
 async function connectTestClient(env: Env = createTestEnv(), identity?: AuthIdentity) {

--- a/test/unit/mcp-skipped-pr-audit.test.ts
+++ b/test/unit/mcp-skipped-pr-audit.test.ts
@@ -1,0 +1,262 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { describe, expect, it } from "vitest";
+import { createSessionForGitHubUser, type AuthIdentity } from "../../src/auth/security";
+import { recordAuditEvent, upsertInstallation, upsertRepositoryFromGitHub } from "../../src/db/repositories";
+import { LoopoverMcp } from "../../src/mcp/server";
+import { createTestEnv } from "../helpers/d1";
+
+async function connect(env: Env, identity?: AuthIdentity): Promise<Client> {
+  const server = (identity ? new LoopoverMcp(env, identity) : new LoopoverMcp(env)).createServer();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  const client = new Client({ name: "skipped-pr-audit-test", version: "0.1.0" }, { capabilities: {} });
+  await client.connect(clientTransport);
+  return client;
+}
+
+async function seedOwnedRepo(env: Env, installationId: number, owner: string, name: string): Promise<void> {
+  await upsertInstallation(env, {
+    installation: {
+      id: installationId,
+      account: { login: owner, id: installationId, type: "User" },
+      repository_selection: "selected",
+      permissions: { metadata: "read", pull_requests: "read", issues: "write" },
+      events: ["pull_request", "repository"],
+    },
+  });
+  await upsertRepositoryFromGitHub(env, { name, full_name: `${owner}/${name}`, private: false, default_branch: "main", owner: { login: owner } }, installationId);
+}
+
+type SkippedPrAuditData = {
+  generatedAt: string;
+  limit: number;
+  hasMore: boolean;
+  filters: { repoFullName: string | null; reason: string | null; since: string | null };
+  items: Array<{ repoFullName: string; pullNumber: number; reason: string; timestamp: string; remediation: string }>;
+};
+
+describe("MCP loopover_get_skipped_pr_audit (#5825)", () => {
+  it("returns the default no-filter feed scoped to the caller's own repos", async () => {
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
+    await seedOwnedRepo(env, 101, "repo-owner", "owned-repo");
+    await seedOwnedRepo(env, 202, "victim-org", "secret-repo");
+    await recordAuditEvent(env, {
+      eventType: "github_app.pr_visibility_skipped",
+      actor: "bot-secret",
+      targetKey: "repo-owner/owned-repo#4",
+      outcome: "completed",
+      detail: "bot_author",
+      metadata: { token: "github_pat_should_not_export" },
+      createdAt: "2026-05-28T00:00:02.000Z",
+    });
+    await recordAuditEvent(env, {
+      eventType: "github_app.pr_visibility_skipped",
+      actor: "victim-secret",
+      targetKey: "victim-org/secret-repo#7",
+      outcome: "completed",
+      detail: "maintainer_author",
+      metadata: {},
+      createdAt: "2026-05-28T00:00:05.000Z",
+    });
+
+    const { session } = await createSessionForGitHubUser(env, { login: "repo-owner", id: 101 });
+    const client = await connect(env, { kind: "session", actor: "repo-owner", session });
+    const result = await client.callTool({ name: "loopover_get_skipped_pr_audit", arguments: {} });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as SkippedPrAuditData;
+    expect(data.items).toEqual([expect.objectContaining({ repoFullName: "repo-owner/owned-repo", pullNumber: 4, reason: "bot_author" })]);
+    expect(data.items[0]?.remediation).toContain("intentionally kept quiet");
+    expect(data.limit).toBe(50);
+    expect(data.hasMore).toBe(false);
+    expect(data.filters).toEqual({ repoFullName: null, reason: null, since: null });
+    expect(JSON.stringify(result.content)).not.toContain("github_pat_should_not_export");
+  });
+
+  it("filters by repoFullName, reason, and since independently", async () => {
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "operator" });
+    await seedOwnedRepo(env, 101, "repo-owner", "owned-repo");
+    await recordAuditEvent(env, {
+      eventType: "github_app.pr_visibility_skipped",
+      actor: "a",
+      targetKey: "repo-owner/owned-repo#1",
+      outcome: "completed",
+      detail: "surface_off",
+      metadata: {},
+      createdAt: "2026-05-28T00:00:01.000Z",
+    });
+    await recordAuditEvent(env, {
+      eventType: "github_app.pr_visibility_skipped",
+      actor: "b",
+      targetKey: "repo-owner/owned-repo#2",
+      outcome: "completed",
+      detail: "missing_author",
+      metadata: {},
+      createdAt: "2026-05-28T00:00:02.000Z",
+    });
+
+    const { session } = await createSessionForGitHubUser(env, { login: "operator", id: 999 });
+    const client = await connect(env, { kind: "session", actor: "operator", session });
+
+    const byRepo = await client.callTool({ name: "loopover_get_skipped_pr_audit", arguments: { repoFullName: "repo-owner/owned-repo" } });
+    expect((byRepo.structuredContent as SkippedPrAuditData).items).toHaveLength(2);
+
+    const byReason = await client.callTool({ name: "loopover_get_skipped_pr_audit", arguments: { reason: "missing_author" } });
+    const byReasonData = byReason.structuredContent as SkippedPrAuditData;
+    expect(byReasonData.items).toEqual([expect.objectContaining({ reason: "missing_author", pullNumber: 2 })]);
+    expect(byReasonData.filters.reason).toBe("missing_author");
+
+    const bySince = await client.callTool({ name: "loopover_get_skipped_pr_audit", arguments: { since: "2026-05-28T00:00:01.500Z" } });
+    const bySinceData = bySince.structuredContent as SkippedPrAuditData;
+    expect(bySinceData.items).toEqual([expect.objectContaining({ pullNumber: 2 })]);
+    expect(bySinceData.filters.since).toBe("2026-05-28T00:00:01.500Z");
+  });
+
+  it("clamps limit to the [1, 100] range and reports hasMore across the boundary", async () => {
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "operator" });
+    await seedOwnedRepo(env, 101, "repo-owner", "owned-repo");
+    for (let n = 1; n <= 3; n += 1) {
+      await recordAuditEvent(env, {
+        eventType: "github_app.pr_visibility_skipped",
+        actor: `actor-${n}`,
+        targetKey: `repo-owner/owned-repo#${n}`,
+        outcome: "completed",
+        detail: "surface_off",
+        metadata: {},
+        createdAt: `2026-05-28T00:00:0${n}.000Z`,
+      });
+    }
+    const { session } = await createSessionForGitHubUser(env, { login: "operator", id: 999 });
+    const client = await connect(env, { kind: "session", actor: "operator", session });
+
+    const overLimit = await client.callTool({ name: "loopover_get_skipped_pr_audit", arguments: { limit: 500 } });
+    const overLimitData = overLimit.structuredContent as SkippedPrAuditData;
+    expect(overLimitData.limit).toBe(100);
+    expect(overLimitData.hasMore).toBe(false);
+
+    const underLimit = await client.callTool({ name: "loopover_get_skipped_pr_audit", arguments: { limit: 1 } });
+    const underLimitData = underLimit.structuredContent as SkippedPrAuditData;
+    expect(underLimitData.limit).toBe(1);
+    expect(underLimitData.hasMore).toBe(true);
+    expect(underLimitData.items).toHaveLength(1);
+  });
+
+  it("returns an empty page for a scoped repo with no skipped-PR events", async () => {
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
+    await seedOwnedRepo(env, 101, "repo-owner", "owned-repo");
+    const { session } = await createSessionForGitHubUser(env, { login: "repo-owner", id: 101 });
+    const client = await connect(env, { kind: "session", actor: "repo-owner", session });
+    const result = await client.callTool({ name: "loopover_get_skipped_pr_audit", arguments: {} });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as SkippedPrAuditData;
+    expect(data.items).toEqual([]);
+    expect(data.hasMore).toBe(false);
+  });
+
+  it("forbids a session with no maintainer/owner/operator role", async () => {
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
+    const { session } = await createSessionForGitHubUser(env, { login: "unknown-user", id: 404 });
+    const client = await connect(env, { kind: "session", actor: "unknown-user", session });
+    const result = await client.callTool({ name: "loopover_get_skipped_pr_audit", arguments: {} });
+    expect(result.isError).toBeTruthy();
+    expect(JSON.stringify(result.content)).toMatch(/maintainer, owner, or operator role is required/i);
+  });
+
+  it("allows a non-operator owner session to explicitly request its own scoped repo by name", async () => {
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
+    await seedOwnedRepo(env, 101, "repo-owner", "owned-repo");
+    await recordAuditEvent(env, {
+      eventType: "github_app.pr_visibility_skipped",
+      actor: "a",
+      targetKey: "repo-owner/owned-repo#3",
+      outcome: "completed",
+      detail: "surface_off",
+      metadata: {},
+      createdAt: "2026-05-28T00:00:03.000Z",
+    });
+    const { session } = await createSessionForGitHubUser(env, { login: "repo-owner", id: 101 });
+    const client = await connect(env, { kind: "session", actor: "repo-owner", session });
+    const result = await client.callTool({ name: "loopover_get_skipped_pr_audit", arguments: { repoFullName: "repo-owner/owned-repo" } });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as SkippedPrAuditData;
+    expect(data.items).toEqual([expect.objectContaining({ repoFullName: "repo-owner/owned-repo", pullNumber: 3 })]);
+    expect(data.filters.repoFullName).toBe("repo-owner/owned-repo");
+  });
+
+  it("forbids a maintainer session from requesting a repo outside its scope", async () => {
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
+    await seedOwnedRepo(env, 101, "repo-owner", "owned-repo");
+    await seedOwnedRepo(env, 202, "victim-org", "secret-repo");
+    const { session } = await createSessionForGitHubUser(env, { login: "repo-owner", id: 101 });
+    const client = await connect(env, { kind: "session", actor: "repo-owner", session });
+    const result = await client.callTool({ name: "loopover_get_skipped_pr_audit", arguments: { repoFullName: "victim-org/secret-repo" } });
+    expect(result.isError).toBeTruthy();
+    expect(JSON.stringify(result.content)).toMatch(/cannot access this repository's skipped-pr audit/i);
+  });
+
+  it("rejects an unparseable since value", async () => {
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "operator" });
+    const { session } = await createSessionForGitHubUser(env, { login: "operator", id: 999 });
+    const client = await connect(env, { kind: "session", actor: "operator", session });
+    const result = await client.callTool({ name: "loopover_get_skipped_pr_audit", arguments: { since: "not-a-date" } });
+    expect(result.isError).toBeTruthy();
+    expect(JSON.stringify(result.content)).toMatch(/not a parseable date/i);
+  });
+
+  it("forbids the static mcp identity without the unscoped MCP_READ_REPO_ALLOWLIST opt-in", async () => {
+    const env = createTestEnv({ MCP_READ_REPO_ALLOWLIST: "" });
+    await seedOwnedRepo(env, 101, "repo-owner", "owned-repo");
+    const client = await connect(env);
+    const result = await client.callTool({ name: "loopover_get_skipped_pr_audit", arguments: {} });
+    expect(result.isError).toBeTruthy();
+    expect(JSON.stringify(result.content)).toMatch(/not authorized for the skipped-pr audit/i);
+  });
+
+  it("allows the static mcp identity once MCP_READ_REPO_ALLOWLIST is unscoped", async () => {
+    const env = createTestEnv({ MCP_READ_REPO_ALLOWLIST: "*" });
+    await seedOwnedRepo(env, 101, "repo-owner", "owned-repo");
+    await recordAuditEvent(env, {
+      eventType: "github_app.pr_visibility_skipped",
+      actor: "a",
+      targetKey: "repo-owner/owned-repo#9",
+      outcome: "completed",
+      detail: "not_official_gittensor_miner",
+      metadata: {},
+      createdAt: "2026-05-28T00:00:09.000Z",
+    });
+    const client = await connect(env);
+    const result = await client.callTool({ name: "loopover_get_skipped_pr_audit", arguments: {} });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as SkippedPrAuditData;
+    expect(data.items).toEqual([expect.objectContaining({ pullNumber: 9, reason: "not_official_gittensor_miner" })]);
+  });
+
+  it("scopes the static mcp identity to an explicit repoFullName filter", async () => {
+    const env = createTestEnv({ MCP_READ_REPO_ALLOWLIST: "*" });
+    await seedOwnedRepo(env, 101, "repo-owner", "owned-repo");
+    await seedOwnedRepo(env, 202, "victim-org", "secret-repo");
+    await recordAuditEvent(env, {
+      eventType: "github_app.pr_visibility_skipped",
+      actor: "a",
+      targetKey: "repo-owner/owned-repo#9",
+      outcome: "completed",
+      detail: "not_official_gittensor_miner",
+      metadata: {},
+      createdAt: "2026-05-28T00:00:09.000Z",
+    });
+    await recordAuditEvent(env, {
+      eventType: "github_app.pr_visibility_skipped",
+      actor: "b",
+      targetKey: "victim-org/secret-repo#10",
+      outcome: "completed",
+      detail: "surface_off",
+      metadata: {},
+      createdAt: "2026-05-28T00:00:10.000Z",
+    });
+    const client = await connect(env);
+    const result = await client.callTool({ name: "loopover_get_skipped_pr_audit", arguments: { repoFullName: "repo-owner/owned-repo" } });
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as SkippedPrAuditData;
+    expect(data.items).toEqual([expect.objectContaining({ repoFullName: "repo-owner/owned-repo", pullNumber: 9 })]);
+  });
+});


### PR DESCRIPTION
## Summary

- Add `loopover_get_skipped_pr_audit`, a maintainer-authenticated, read-only MCP tool that surfaces the same skipped-PR audit trail already exposed by `GET /v1/app/skipped-pr-audit` (`listPrVisibilitySkipAuditEvents`), so an MCP client can triage "did the bot look at PR #N, and if not, why" without the dashboard.
- Extracted the shared reason enum (`PUBLIC_SURFACE_SKIP_REASONS`) and the per-reason remediation text (`skippedPrAuditRemediation`) out of `src/api/routes.ts` into `src/signals/settings-preview.ts` (next to `PublicSurfaceSkipReason`) so the HTTP route and the new MCP tool consume one canonical copy instead of two independently-maintained literal lists.
- Added the tool to the `maintainer-triage` MCP agent profile's `recommendedTools`.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

Closes #5825

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- `ui:lint` / `ui:typecheck` / `ui:build` were skipped: this PR touches no files under `apps/loopover-ui/**` — the only production files changed are `src/api/routes.ts`, `src/mcp/server.ts`, `src/signals/settings-preview.ts`, and `packages/loopover-mcp/bin/loopover-mcp.js`. `npm run ui:openapi:check` passed with no drift, confirming the (unchanged) `/v1/app/skipped-pr-audit` request/response shape still matches the generated OpenAPI spec.
- Also ran and confirmed green: `npm run db:migrations:check`, `npm run db:schema-drift:check`, `npm run selfhost:env-reference:check`, `npm run miner:env-reference:check`, `npm run cf-typegen:check`, `npm run manifest:drift-check`, `npm run command-reference:check`, `npm run docs:drift-check`, `npm run engine-parity:drift-check`, `npm run test:engine-parity`, `npm run test:live-gate-parity`, `npm run test:driver-parity` (no DB/env/wrangler-binding/docs changes in this PR, so all no-op green as expected).
- `npm run test:coverage` full run in my local sandbox reports 15 failing tests across 3 files (`selfhost-ams-reporting.test.ts`, `miner-discover-cli.test.ts`, `miner-live-issue-snapshot.test.ts`), all pre-existing and unrelated to this diff: the `sqlite3` CLI binary is not installed in this sandbox (those tests shell out to it), and a real `GITHUB_TOKEN` is present in this shell's env and leaks into tests asserting no-token behavior. Confirmed identical failures on a clean stash of this branch at the same base commit before any of my changes. New coverage confirmed via `test/unit/mcp-skipped-pr-audit.test.ts` (11 cases covering: default no-filter feed scoped to the caller's own repos, each of `repoFullName`/`reason`/`since` filtered independently, `limit` clamped at both the 1 and 100 boundaries, an empty-page result, a session with no maintainer/owner/operator role being forbidden, a non-operator owner explicitly requesting its own scoped repo, a maintainer forbidden from a repo outside its scope, an unparseable `since` value, and the static `mcp` identity both forbidden and allowed depending on `MCP_READ_REPO_ALLOWLIST`) plus the existing `test/unit/mcp-output-schemas.test.ts` and `test/integration/api.test.ts` skipped-pr-audit route coverage, all still green after the shared-constant extraction. Verified via lcov that every new line and branch in `src/mcp/server.ts` (input/output schema, tool registration, `requireSkippedPrAuditAccess`, `getSkippedPrAudit`) and the new/moved code in `src/signals/settings-preview.ts` is hit.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

No UI changes in this PR — the last two Safety checkboxes and the UI Evidence section below are not applicable.

## UI Evidence

Not applicable — this PR only adds a backend/MCP tool with no visible UI, frontend, docs, or extension surface.

## Notes

- The new tool's repo-scope gate (`requireSkippedPrAuditAccess`) mirrors the HTTP route's `skippedPrAuditRepoScope` (same `loadControlPanelRoleSummary`/`loadControlPanelAccessScope` calls, same maintainer/owner/operator role gate, same "no filter → caller's own scoped repos" fallback), reimplemented against this file's MCP identity/throw conventions rather than reused directly, since `skippedPrAuditRepoScope` is bound to a Hono `ProtectedRouteContext` and returns a `Response`, neither of which an MCP tool method can use. The shared static `mcp` CLI token additionally requires the unscoped `MCP_READ_REPO_ALLOWLIST` wildcard opt-in for this tool, matching every other cross-repo/maintainer-report MCP gate in this file (`requireOperatorAccess`, `requireDiscoveryAccess`).
