### PR TITLE
feat(review): add OpenAI and Anthropic API key patterns to secret scan

### DIFF
--- a/src/review/secret-patterns.ts
+++ b/src/review/secret-patterns.ts
@@ -53,6 +53,16 @@ export const SECRET_PATTERNS: SecretPattern[] = [
   { name: "voyage_api_key", re: /\b(?:pa|al)-[A-Za-z0-9]{20,}(?![A-Za-z0-9_-])/ },
   // Firecrawl API key: `fc-` + base62 body (alnum only; reject hyphen-continued identifiers).
   { name: "firecrawl_api_key", re: /\bfc-[A-Za-z0-9]{16,}(?![A-Za-z0-9_-])/ },
+  // OpenAI API key: legacy `sk-` + 20 chars + `sk-proj-`/`sk-svcacct-`/`sk-admin-` (project/service-account/
+  // admin keys, all real OpenAI key types since the 2024 key-format change) + a longer body, EITHER SIDE of
+  // the literal `T3BlbkFJ` -- the base64 encoding of "OpenAI" that every `sk-*` key embeds mid-body regardless
+  // of surrounding length (verified against gitleaks' maintained openai-api-key rule). OpenAI has changed the
+  // surrounding body length more than once, so this anchors on the watermark rather than an exact length.
+  { name: "openai_api_key", re: /\bsk-(?:proj-|svcacct-|admin-)?[A-Za-z0-9_-]{20,}T3BlbkFJ[A-Za-z0-9_-]{20,}\b/ },
+  // Anthropic API key: `sk-ant-api03-` + a 95-char base64url body (verified against gitleaks' maintained
+  // anthropic-api-key rule; the body's final 2 chars are always literal `AA`, a base64-padding artifact of
+  // the key's fixed underlying byte length).
+  { name: "anthropic_api_key", re: /\bsk-ant-api03-[A-Za-z0-9_-]{93}AA\b/ },
   { name: "jwt", re: /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/ },
   { name: "seed_or_mnemonic", re: /\b(?:seed phrase|mnemonic)\b/i },
   { name: "bittensor_key", re: /\b(?:hot|cold)key\b\s*[:=]/i },
@@ -214,6 +224,8 @@ export const HARD_SECRET_KINDS = new Set([
   "huggingface_token",
   "voyage_api_key",
   "firecrawl_api_key",
+  "openai_api_key",
+  "anthropic_api_key",
   "jwt",
 ]);
 

--- a/test/unit/content-lane-security-scan.test.ts
+++ b/test/unit/content-lane-security-scan.test.ts
@@ -86,6 +86,23 @@ describe("scanForSecrets", () => {
     expect(scanForSecrets("fc-" + "c".repeat(16) + "-suffix").kinds).not.toContain("firecrawl_api_key");
   });
 
+  it("flags an OpenAI API key (legacy and modern sk-proj- forms)", () => {
+    expect(scanForSecrets("sk-" + "a".repeat(20) + "T3BlbkFJ" + "b".repeat(20)).kinds).toContain("openai_api_key");
+    expect(scanForSecrets("sk-proj-" + "a".repeat(74) + "T3BlbkFJ" + "b".repeat(74)).kinds).toContain("openai_api_key");
+  });
+
+  it("does not flag an sk- prefixed value missing the T3BlbkFJ watermark", () => {
+    expect(scanForSecrets("sk-" + "a".repeat(48)).kinds).not.toContain("openai_api_key");
+  });
+
+  it("flags an Anthropic API key (sk-ant-api03- + 93-char body + AA)", () => {
+    expect(scanForSecrets("sk-ant-api03-" + "a".repeat(93) + "AA").kinds).toContain("anthropic_api_key");
+  });
+
+  it("does not flag an Anthropic-shaped value below the expected body length", () => {
+    expect(scanForSecrets("sk-ant-api03-" + "a".repeat(92) + "AA").kinds).not.toContain("anthropic_api_key");
+  });
+
   it("flags a generic secret/password/token assignment with a high-entropy value", () => {
     expect(scanForSecrets(`secret = "${GENERIC_VALUE}"`).kinds).toContain("generic_secret_assignment");
     expect(scanForSecrets(`api_key: '${GENERIC_VALUE}'`).kinds).toContain("generic_secret_assignment");
@@ -309,6 +326,8 @@ describe("secret-scan parity with the PR-diff gate (secrets-scan.ts)", () => {
     ["huggingface_token", "hf_" + "a".repeat(34)],
     ["voyage_api_key", "pa-" + "aK9xQ2mZw7Ln4Rv8Pt3B"],
     ["firecrawl_api_key", "fc-" + "aK9xQ2mZw7Ln4Rv8"],
+    ["openai_api_key", "sk-" + "a".repeat(20) + "T3BlbkFJ" + "b".repeat(20)],
+    ["anthropic_api_key", "sk-ant-api03-" + "a".repeat(93) + "AA"],
     ["jwt", jwt],
     ["generic_secret_assignment", `secret = "${GENERIC_VALUE}"`],
     ["lowercase-hyphenated mock fixture (not flagged on either side)", 'token: "mock-response-value"'],

--- a/test/unit/secrets-scan.test.ts
+++ b/test/unit/secrets-scan.test.ts
@@ -124,6 +124,44 @@ describe("scanForSecrets — deterministic secret-pattern scanner", () => {
     expect(scanForSecrets("fc-" + "c".repeat(16) + "-suffix").kinds).not.toContain("firecrawl_api_key");
   });
 
+  it("flags a legacy OpenAI API key (sk- + 20 chars + the T3BlbkFJ watermark + 20 chars)", () => {
+    const fakeKey = "sk-" + "a".repeat(20) + "T3BlbkFJ" + "b".repeat(20);
+    expect(scanForSecrets(fakeKey).kinds).toContain("openai_api_key");
+  });
+
+  it.each([
+    ["sk-proj-", "sk-proj-" + "a".repeat(74) + "T3BlbkFJ" + "b".repeat(74)],
+    ["sk-svcacct-", "sk-svcacct-" + "a".repeat(58) + "T3BlbkFJ" + "b".repeat(58)],
+    ["sk-admin-", "sk-admin-" + "a".repeat(58) + "T3BlbkFJ" + "b".repeat(58)],
+  ])("flags a modern OpenAI API key: %s", (_name, fakeKey) => {
+    expect(scanForSecrets(fakeKey).kinds).toContain("openai_api_key");
+  });
+
+  it("does not flag an sk- prefixed value missing the T3BlbkFJ watermark", () => {
+    expect(scanForSecrets("sk-" + "a".repeat(48)).kinds).not.toContain("openai_api_key");
+  });
+
+  it("does not flag an OpenAI-shaped value below the 20-char floor on either side of the watermark", () => {
+    expect(scanForSecrets("sk-" + "a".repeat(19) + "T3BlbkFJ" + "b".repeat(20)).kinds).not.toContain("openai_api_key");
+    expect(scanForSecrets("sk-" + "a".repeat(20) + "T3BlbkFJ" + "b".repeat(19)).kinds).not.toContain("openai_api_key");
+  });
+
+  it("flags an Anthropic API key (sk-ant-api03- + 93-char body + AA)", () => {
+    const fakeKey = "sk-ant-api03-" + "a".repeat(93) + "AA";
+    expect(scanForSecrets(fakeKey).kinds).toContain("anthropic_api_key");
+  });
+
+  it("does not flag an Anthropic-shaped value below the expected body length", () => {
+    expect(scanForSecrets("sk-ant-api03-" + "a".repeat(92) + "AA").kinds).not.toContain("anthropic_api_key");
+  });
+
+  it("does not flag an Anthropic-shaped run that continues one character past the expected body length", () => {
+    // Same overrun shape as the GitLab-token test above: a `\b` terminator correctly rejects a longer run
+    // that happens to contain a 93-char-plus-AA window, since no word boundary follows the extra character.
+    const overrun = "sk-ant-api03-" + "a".repeat(93) + "AA" + "x";
+    expect(scanForSecrets(overrun).kinds).not.toContain("anthropic_api_key");
+  });
+
   it("flags a JWT", () => {
     const fakeJwt = "eyJhbGciOiJIUzI1NiJ9" + "." + "eyJzdWIiOiIxMjM0NTY3ODkwIn0" + "." + "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c";
     expect(scanForSecrets(fakeJwt).kinds).toContain("jwt");


### PR DESCRIPTION
## Summary

- Adds format-precise OpenAI and Anthropic API key patterns to the shared `SECRET_PATTERNS` list (`src/review/secret-patterns.ts`), so a leaked key from either provider is caught by both hard-block scan paths (PR-diff and content-lane). Neither provider had a pattern before, despite the review stack's own BYOK feature storing and using exactly these two providers' keys.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

Ran the full local gate via `npm run test:ci` (all of the above in one command) — green, plus `npm audit --audit-level=moderate` (0 vulnerabilities). Local `npm run test:coverage` shows 100% statement/branch/function/line coverage on `src/review/secret-patterns.ts`.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

If any required check was skipped, explain why:

- Auth/CORS and UI boxes are not applicable — this change is a pure backend detection-pattern addition with no auth/session/UI surface.

## UI Evidence

Not applicable — no visible UI/frontend/docs/extension change.

## Notes

- Both patterns are anchored on structural properties (the `T3BlbkFJ` "OpenAI" watermark; Anthropic's fixed 95-char body) verified against gitleaks' maintained detection rules, rather than an exact key length, since OpenAI has changed key formats more than once.

Closes #5842
