### PR TITLE
feat(miner): expose the calibration report as a read-only MCP tool

### DIFF
--- a/packages/loopover-miner/README.md
+++ b/packages/loopover-miner/README.md
@@ -255,7 +255,9 @@ It exposes these read-only tools:
 
 - `loopover_miner_status` (#5154) — read-only status + doctor diagnostics, returning `{ status, doctor }`: `status` = package/engine versions (and skew), node version, state-dir + config-file paths, and the resolved coding-agent driver (provider name, the model **env-var NAME** never its value, CLI-present boolean); `doctor` = the checks `loopover-miner doctor` runs (Docker/CLI presence, config validity, …) as `{ name, ok, detail }`. Reuses `collectStatus` / `runDoctorChecks` so it can't drift from the CLI, and returns only names / booleans / paths — never any env-var value, token, or credential.
 
-This completes the read-only AMS MCP tool surface (status, portfolio, claims, event-ledger, governor-ledger, run-state, plan-store).
+- `loopover_miner_get_calibration_report` (#5821) — read-only miner-local prediction-accuracy report: per-project merge/close precision, joining this miner's own recorded gate predictions (prediction ledger) with the realized PR outcomes it later observed (`pr_outcome` events). Wraps `calibration-cli.js`'s existing `toPredictionRecords` / `toOutcomeRecords` mappers and `calibration.js`'s `buildCalibrationReport` composer — no new join/scoring logic. Strictly local and offline; distinct from ORB's hosted, maintainer-authenticated `loopover_get_outcome_calibration` tool, which reads a different (D1) data source.
+
+This completes the read-only AMS MCP tool surface (status, portfolio, claims, event-ledger, governor-ledger, run-state, plan-store, calibration).
 
 ### Client config
 
@@ -276,7 +278,7 @@ This completes the read-only AMS MCP tool surface (status, portfolio, claims, ev
 }
 ```
 
-`loopover` exposes ORB's hosted contributor-workflow tools (issue ranking, PR packet prep, decision packs). `loopover-miner` exposes AMS's own local state-visibility tools listed above (portfolio dashboard, claims, audit feed, run state, plans) — a fully separate, 100% local tool surface with no shared code or network calls between the two. Both follow the same `loopover_*` tool-naming convention (`loopover_...` vs. `loopover_miner_...`), but back onto different stores: ORB's tools read the hosted loopover backend, AMS's tools read this machine's own local SQLite files (see [Local storage](#local-storage)) — a handful of AMS tools even name the ORB tool they mirror (e.g. `loopover_miner_get_run_state` is the read-only analog of `loopover_get_automation_state`) so the relationship is explicit at the point of use, not just here.
+`loopover` exposes ORB's hosted contributor-workflow tools (issue ranking, PR packet prep, decision packs). `loopover-miner` exposes AMS's own local state-visibility tools listed above (portfolio dashboard, claims, audit feed, run state, plans, calibration) — a fully separate, 100% local tool surface with no shared code or network calls between the two. Both follow the same `loopover_*` tool-naming convention (`loopover_...` vs. `loopover_miner_...`), but back onto different stores: ORB's tools read the hosted loopover backend, AMS's tools read this machine's own local SQLite files (see [Local storage](#local-storage)) — a handful of AMS tools even name the ORB tool they mirror (e.g. `loopover_miner_get_run_state` is the read-only analog of `loopover_get_automation_state`) so the relationship is explicit at the point of use, not just here.
 
 ## Version check
 

--- a/packages/loopover-miner/bin/loopover-miner-mcp.d.ts
+++ b/packages/loopover-miner/bin/loopover-miner-mcp.d.ts
@@ -1,5 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { EventLedger } from "../lib/event-ledger.js";
+import type { PredictionLedgerEntry } from "../lib/prediction-ledger.js";
 
 /** The static, non-secret payload the loopover_miner_ping tool always returns, independent of input. */
 export const MINER_PING_STATUS: { status: "ok"; tool: "loopover_miner_ping" };
@@ -52,13 +53,21 @@ export interface MinerMcpServerOptions {
   collectStatus?: () => unknown;
   /** Override the doctor-checks reader (defaults to status.js's runDoctorChecks); injection seam for tests. */
   runDoctorChecks?: () => unknown[];
+  /**
+   * Override the prediction-ledger opener (defaults to the real on-disk ledger); injection seam for tests. Typed
+   * to the minimal read surface the calibration-report tool uses (never appendPrediction).
+   */
+  initPredictionLedger?: () => {
+    readPredictions(filter?: { repoFullName?: string | null }): PredictionLedgerEntry[];
+    close(): void;
+  };
 }
 
 /**
  * Build the miner MCP server with its tools registered (loopover_miner_ping,
  * loopover_miner_get_portfolio_dashboard, loopover_miner_list_claims, loopover_miner_get_audit_feed,
  * loopover_miner_get_run_state, loopover_miner_list_plans, loopover_miner_get_plan,
- * loopover_miner_get_governor_decisions, loopover_miner_status). `options` supplies test injection seams;
- * production callers pass nothing.
+ * loopover_miner_get_governor_decisions, loopover_miner_status, loopover_miner_get_calibration_report). `options`
+ * supplies test injection seams; production callers pass nothing.
  */
 export function createMinerMcpServer(options?: MinerMcpServerOptions): McpServer;

--- a/packages/loopover-miner/bin/loopover-miner-mcp.js
+++ b/packages/loopover-miner/bin/loopover-miner-mcp.js
@@ -16,6 +16,9 @@ import { initRunStateStore } from "../lib/run-state.js";
 import { PLAN_STATUSES, openPlanStore } from "../lib/plan-store.js";
 import { initGovernorLedger } from "../lib/governor-ledger.js";
 import { collectStatus, runDoctorChecks } from "../lib/status.js";
+import { buildCalibrationReport } from "../lib/calibration.js";
+import { toOutcomeRecords, toPredictionRecords } from "../lib/calibration-cli.js";
+import { initPredictionLedger } from "../lib/prediction-ledger.js";
 
 // MCP stdio server for @loopover/miner (scaffold #5153). Mirrors the packages/loopover-mcp
 // harness (MCP SDK server + stdio transport). Tools:
@@ -34,6 +37,10 @@ import { collectStatus, runDoctorChecks } from "../lib/status.js";
 //     governor-ledger.js's readGovernorDecisions -- an explicit named-column read that excludes payload_json.
 //   - loopover_miner_status (#5154): read-only status + doctor diagnostics via status.js's collectStatus/
 //     runDoctorChecks (names/booleans/paths only -- never any env-var value, token, key, or credential).
+//   - loopover_miner_get_calibration_report (#5821): read-only miner-local prediction-accuracy report, joining
+//     the prediction ledger with observed pr_outcome events via calibration-cli.js's existing toPredictionRecords/
+//     toOutcomeRecords mappers and calibration.js's buildCalibrationReport composer (no new join logic). Distinct
+//     from ORB's hosted, maintainer-authenticated loopover_get_outcome_calibration tool.
 
 // Read the version from this package's own package.json (always shipped) rather than a hand-synced
 // literal, so a release bump never has a second place to forget -- same approach as the mcp harness.
@@ -261,6 +268,37 @@ export function createMinerMcpServer(options = {}) {
       const status = (options.collectStatus ?? collectStatus)();
       const doctor = (options.runDoctorChecks ?? runDoctorChecks)();
       return { content: [{ type: "text", text: JSON.stringify({ status, doctor }) }] };
+    },
+  );
+  server.registerTool(
+    "loopover_miner_get_calibration_report",
+    {
+      description:
+        "Read-only miner-local prediction-accuracy report: per-project merge/close precision, joining this " +
+        "miner's own recorded gate predictions (prediction ledger) with the realized PR outcomes it later " +
+        "observed (pr_outcome events). Wraps calibration-cli.js's existing toPredictionRecords/toOutcomeRecords " +
+        "mappers and calibration.js's buildCalibrationReport composer -- no new join/scoring logic, no mutation. " +
+        "Strictly local and offline; distinct from ORB's hosted, maintainer-authenticated " +
+        "loopover_get_outcome_calibration tool, which reads a different (D1) data source. Takes no arguments.",
+      inputSchema: {},
+    },
+    async () => {
+      const ownsPredictionLedger = options.initPredictionLedger === undefined;
+      const ownsEventLedger = options.initEventLedger === undefined;
+      let predictionLedger;
+      let eventLedger;
+      try {
+        predictionLedger = (options.initPredictionLedger ?? initPredictionLedger)();
+        eventLedger = (options.initEventLedger ?? initEventLedger)();
+        const report = buildCalibrationReport(
+          toPredictionRecords(predictionLedger.readPredictions()),
+          toOutcomeRecords(eventLedger.readEvents()),
+        );
+        return { content: [{ type: "text", text: JSON.stringify(report) }] };
+      } finally {
+        if (ownsPredictionLedger) predictionLedger?.close();
+        if (ownsEventLedger) eventLedger?.close();
+      }
     },
   );
   return server;

--- a/packages/loopover-miner/lib/calibration-cli.d.ts
+++ b/packages/loopover-miner/lib/calibration-cli.d.ts
@@ -1,1 +1,9 @@
+import type { PredictedVerdictRecord, ObservedOutcomeRecord } from "./calibration-types.js";
+import type { PredictionLedgerEntry } from "./prediction-ledger.js";
+import type { LedgerEntry } from "./event-ledger.js";
+
 export function runCalibrationCli(args?: string[], env?: Record<string, string | undefined>): number;
+
+export function toPredictionRecords(rows: PredictionLedgerEntry[]): PredictedVerdictRecord[];
+
+export function toOutcomeRecords(events: LedgerEntry[]): ObservedOutcomeRecord[];

--- a/packages/loopover-miner/lib/calibration-cli.js
+++ b/packages/loopover-miner/lib/calibration-cli.js
@@ -11,8 +11,9 @@ import { reportCliFailure, describeCliError } from "./cli-error.js";
 const CALIBRATION_USAGE = "Usage: loopover-miner calibration [--json]";
 
 /** Map prediction-ledger rows to predicted-verdict records: the target id becomes a string key and the recorded
- *  prediction verdict is the `conclusion`. */
-function toPredictionRecords(rows) {
+ *  prediction verdict is the `conclusion`. Exported so callers other than this CLI (the MCP calibration-report
+ *  tool, #5821) can build the identical join without re-implementing the mapping. */
+export function toPredictionRecords(rows) {
   return rows.map((row) => ({
     project: row.repoFullName,
     targetId: String(row.targetId),
@@ -23,8 +24,9 @@ function toPredictionRecords(rows) {
 
 /** Reduce the append-only `pr_outcome` event stream to the LATEST observed outcome per (repo, PR), as
  *  observed-outcome records. `recordedAt` comes from the event's own timestamp (always present), so an outcome is
- *  never dropped for lacking a `closedAt`. Malformed payloads are skipped. */
-function toOutcomeRecords(events) {
+ *  never dropped for lacking a `closedAt`. Malformed payloads are skipped. Exported for the same reason as
+ *  {@link toPredictionRecords} above. */
+export function toOutcomeRecords(events) {
   const latest = new Map();
   for (const event of events) {
     if (event?.type !== MINER_PR_OUTCOME_EVENT) continue;

--- a/test/unit/miner-mcp-calibration-report.test.ts
+++ b/test/unit/miner-mcp-calibration-report.test.ts
@@ -1,0 +1,129 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { afterEach, describe, expect, it } from "vitest";
+import { createMinerMcpServer } from "../../packages/loopover-miner/bin/loopover-miner-mcp.js";
+import { initEventLedger } from "../../packages/loopover-miner/lib/event-ledger.js";
+import { initPredictionLedger } from "../../packages/loopover-miner/lib/prediction-ledger.js";
+
+// loopover_miner_get_calibration_report (#5821): read-only wrapper joining the prediction ledger with pr_outcome
+// events via calibration-cli.js's existing toPredictionRecords/toOutcomeRecords mappers and calibration.js's
+// buildCalibrationReport composer. Driven against REAL temp stores (not fakes) so the has-signal/no-signal
+// assertions exercise the actual join, mirroring miner-mcp-governor-decisions.test.ts's approach.
+
+type Content = { content: Array<{ type: string; text?: string }> };
+type PredictionLedgerHandle = ReturnType<typeof initPredictionLedger>;
+type EventLedgerHandle = ReturnType<typeof initEventLedger>;
+
+const roots: string[] = [];
+function tempPredictionLedger(): PredictionLedgerHandle {
+  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-mcp-calibration-pred-"));
+  roots.push(root);
+  return initPredictionLedger(join(root, "prediction-ledger.sqlite3"));
+}
+function tempEventLedger(): EventLedgerHandle {
+  const root = mkdtempSync(join(tmpdir(), "gittensory-miner-mcp-calibration-event-"));
+  roots.push(root);
+  return initEventLedger(join(root, "event-ledger.sqlite3"));
+}
+afterEach(() => {
+  for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+});
+
+function toolText(result: Content): string {
+  const first = result.content[0];
+  if (!first || first.type !== "text" || typeof first.text !== "string") {
+    throw new Error("expected a single text content block");
+  }
+  return first.text;
+}
+
+async function callCalibrationReport(
+  predictionLedger: PredictionLedgerHandle,
+  eventLedger: EventLedgerHandle,
+): Promise<unknown> {
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  const client = new Client({ name: "miner-mcp-calibration-test", version: "0.0.0" });
+  await Promise.all([
+    createMinerMcpServer({
+      initPredictionLedger: () => predictionLedger,
+      initEventLedger: () => eventLedger,
+    }).connect(serverTransport),
+    client.connect(clientTransport),
+  ]);
+  const result = (await client.callTool({
+    name: "loopover_miner_get_calibration_report",
+    arguments: {},
+  })) as Content;
+  return JSON.parse(toolText(result));
+}
+
+describe("loopover_miner_get_calibration_report (#5821)", () => {
+  it("returns hasSignal: false with no rows when neither store has data (calibration-cli.js's own no-signal branch)", async () => {
+    const predictionLedger = tempPredictionLedger();
+    const eventLedger = tempEventLedger();
+    expect(await callCalibrationReport(predictionLedger, eventLedger)).toEqual({ hasSignal: false, rows: [] });
+  });
+
+  it("joins a decided prediction with its realized outcome into a per-project row (has-signal branch)", async () => {
+    const predictionLedger = tempPredictionLedger();
+    const eventLedger = tempEventLedger();
+    predictionLedger.appendPrediction({
+      repoFullName: "acme/widgets",
+      targetId: 42,
+      conclusion: "merge",
+      pack: "default",
+      engineVersion: "1.0.0",
+    });
+    eventLedger.appendEvent({
+      type: "pr_outcome",
+      repoFullName: "acme/widgets",
+      payload: { prNumber: 42, decision: "merged" },
+    });
+
+    const report = (await callCalibrationReport(predictionLedger, eventLedger)) as {
+      hasSignal: boolean;
+      rows: Array<Record<string, unknown>>;
+    };
+    expect(report.hasSignal).toBe(true);
+    expect(report.rows).toEqual([
+      {
+        project: "acme/widgets",
+        wouldMerge: 1,
+        mergeConfirmed: 1,
+        mergeFalse: 0,
+        wouldClose: 0,
+        closeConfirmed: 0,
+        closeFalse: 0,
+        hold: 0,
+        decided: 1,
+        mergePrecision: 1,
+        closePrecision: null,
+      },
+    ]);
+  });
+
+  it("does NOT count a prediction with no matching realized outcome yet (still pending)", async () => {
+    const predictionLedger = tempPredictionLedger();
+    const eventLedger = tempEventLedger();
+    predictionLedger.appendPrediction({
+      repoFullName: "acme/widgets",
+      targetId: 7,
+      conclusion: "merge",
+      pack: "default",
+      engineVersion: "1.0.0",
+    });
+    expect(await callCalibrationReport(predictionLedger, eventLedger)).toEqual({ hasSignal: false, rows: [] });
+  });
+
+  it("does not close an injected store — the caller retains ownership (mirrors the sibling tools' seam contract)", async () => {
+    const predictionLedger = tempPredictionLedger();
+    const eventLedger = tempEventLedger();
+    await callCalibrationReport(predictionLedger, eventLedger);
+    // If the tool had closed either injected store, this read would throw against a closed native handle.
+    expect(() => predictionLedger.readPredictions()).not.toThrow();
+    expect(() => eventLedger.readEvents()).not.toThrow();
+  });
+});

--- a/test/unit/miner-mcp-contract.test.ts
+++ b/test/unit/miner-mcp-contract.test.ts
@@ -210,6 +210,23 @@ const READ_ONLY_TOOLS: ToolContract[] = [
     corrupt: { initGovernorLedger: () => ({ readGovernorDecisions: readThrows, close() {} }) },
     excluded: ["payload", "payload_json", "reputation", "self_plagiarism", "budget"],
   },
+  {
+    tool: "loopover_miner_get_calibration_report",
+    args: {},
+    valid: {
+      initPredictionLedger: () => ({ readPredictions: () => [], close() {} }),
+      initEventLedger: () => ({ dbPath: "", appendEvent: readThrows, readEvents: () => [], purgeByRepo: readThrows, close() {} }),
+    },
+    missing: {
+      initPredictionLedger: openerThrows,
+      initEventLedger: () => ({ dbPath: "", appendEvent: readThrows, readEvents: () => [], purgeByRepo: readThrows, close() {} }),
+    },
+    corrupt: {
+      initPredictionLedger: () => ({ readPredictions: readThrows, close() {} }),
+      initEventLedger: () => ({ dbPath: "", appendEvent: readThrows, readEvents: () => [], purgeByRepo: readThrows, close() {} }),
+    },
+    excluded: [],
+  },
 ];
 
 describe("read-only AMS MCP tool contract (#5199)", () => {

--- a/test/unit/miner-mcp-scaffold.test.ts
+++ b/test/unit/miner-mcp-scaffold.test.ts
@@ -92,6 +92,7 @@ describe("loopover-miner MCP server (#5153 scaffold)", () => {
     const { tools } = await client.listTools();
     expect(tools.map((tool) => tool.name).sort()).toEqual([
       "loopover_miner_get_audit_feed",
+      "loopover_miner_get_calibration_report",
       "loopover_miner_get_governor_decisions",
       "loopover_miner_get_plan",
       "loopover_miner_get_portfolio_dashboard",


### PR DESCRIPTION
## Summary

- Adds `loopover_miner_get_calibration_report` to the miner's stdio MCP server (`packages/loopover-miner/bin/loopover-miner-mcp.js`), wrapping the existing local prediction-ledger/event-ledger join that already powers `loopover-miner calibration --json`. No new join/scoring logic — an MCP client can now ask for this miner's own merge/close prediction accuracy without shelling out to the CLI.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

Ran the full local gate via `npm run test:ci` — green, plus `npm audit --audit-level=moderate` (0 vulnerabilities). Note: `packages/loopover-miner/bin/**` is not in the Codecov coverage `include` glob (only `packages/loopover-miner/lib/**` is), so this file carries no strict patch-coverage obligation — tests were still written to full parity with the sibling `loopover_miner_get_governor_decisions` tool's coverage (has-signal branch, no-signal branch, store-ownership invariant), plus a new row in the shared `miner-mcp-contract.test.ts` invariant table.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

If any required check was skipped, explain why:

- Auth/CORS and UI boxes are not applicable — this is a local, offline, read-only MCP tool with no auth/session/UI surface (the stdio server has no network listener).

## UI Evidence

Not applicable — no visible UI/frontend/docs/extension change beyond the README's MCP tool list, which is covered by the existing `miner MCP tool documentation parity` test.

## Notes

- Follows the same injection-seam (`options.initPredictionLedger` / `options.initEventLedger`) and explicit store-ownership `finally` pattern as the sibling `loopover_miner_get_governor_decisions` tool.

Closes #5821
