### PR TITLE
test(miner): fix stale gittensory identifiers in cross-repo-evaluation test

### DIFF
--- a/test/unit/miner-coding-task-spec.test.ts
+++ b/test/unit/miner-coding-task-spec.test.ts
@@ -282,7 +282,7 @@ describe("buildCodingTaskSpec (#5132)", () => {
     expect(result.instructions).toContain("Detected target-repo stack:");
     expect(result.instructions).toMatch(/javascript|typescript/i);
     expect(result.instructions).toContain("npm");
-    expect(result.instructions).toContain("Do not assume LoopOver/gittensory CI conventions");
+    expect(result.instructions).toContain("Do not assume LoopOver/loopover CI conventions");
     expect(result.instructions).toContain("- test: `");
     expect(result.instructions).toContain("- build: `");
     expect(result.instructions).toContain("- lint: `");
@@ -304,7 +304,7 @@ describe("buildCodingTaskSpec (#5132)", () => {
     expect(result.ready).toBe(true);
     if (!result.ready) throw new Error("expected ready");
     expect(result.instructions).toContain("Detected target-repo stack: stack not detected:");
-    expect(result.instructions).toContain("Do not assume LoopOver/gittensory CI conventions");
+    expect(result.instructions).toContain("Do not assume LoopOver/loopover CI conventions");
     expect(result.instructions).not.toContain("Run these commands before finishing:");
   });
 

--- a/test/unit/miner-cross-repo-evaluation.test.ts
+++ b/test/unit/miner-cross-repo-evaluation.test.ts
@@ -16,7 +16,7 @@ import {
   normalizeCrossRepoFullName,
   parseCrossRepoEvaluationManifest,
   runCrossRepoEvaluation,
-  scanPositiveGittensoryAssumptions,
+  scanPositiveLoopoverAssumptions,
   summarizeCrossRepoEvaluation,
 } from "../../packages/loopover-miner/lib/cross-repo-evaluation.js";
 import type { RepoStackResult } from "../../packages/loopover-miner/lib/stack-detection.js";
@@ -120,20 +120,20 @@ describe("cross-repo evaluation harness (#4788)", () => {
     });
   });
 
-  describe("scanPositiveGittensoryAssumptions", () => {
+  describe("scanPositiveLoopoverAssumptions", () => {
     it("ignores non-strings and negative guidance lines", () => {
-      expect(scanPositiveGittensoryAssumptions(null as never)).toEqual([]);
+      expect(scanPositiveLoopoverAssumptions(null as never)).toEqual([]);
       const text = [
         "Do not assume LoopOver/gittensory CI conventions or `npm run test:ci`.",
         "Run npm run test:ci before finishing.",
       ].join("\n");
-      expect(scanPositiveGittensoryAssumptions(text)).toEqual([
+      expect(scanPositiveLoopoverAssumptions(text)).toEqual([
         { id: "test_ci_script", line: "Run npm run test:ci before finishing." },
       ]);
     });
 
     it("detects other positive assumption markers", () => {
-      const findings = scanPositiveGittensoryAssumptions(
+      const findings = scanPositiveLoopoverAssumptions(
         ["Ensure codecov/patch is green.", "Label with gittensor:bug.", "Wait for the loopover gate."].join("\n"),
       );
       expect(findings.map((f) => f.id).sort()).toEqual(["codecov_patch", "gittensor_label", "loopover_gate"]);
@@ -223,7 +223,7 @@ describe("cross-repo evaluation harness (#4788)", () => {
       expect(result.reason).toBe("boom");
     });
 
-    it("passes end-to-end for a plain Node repo without gittensory-specific target config", () => {
+    it("passes end-to-end for a plain Node repo without loopover-specific target config", () => {
       const repoPath = tempRepo({
         "package.json": pkg({ scripts: { test: "node --test" } }),
       });
@@ -302,7 +302,7 @@ describe("cross-repo evaluation harness (#4788)", () => {
       expect(summary.total).toBe(4);
       expect(summary.passed).toBe(2);
       expect(summary.majorityPassed).toBe(false);
-      expect(summary.withoutGittensoryConfig).toBe(4);
+      expect(summary.withoutLoopoverConfig).toBe(4);
       expect(summary.failuresByCategory[CROSS_REPO_FAILURE_CATEGORY.STACK_DETECTION]).toBe(1);
       expect(summary.failuresByCategory[CROSS_REPO_FAILURE_CATEGORY.EXECUTION]).toBe(1);
     });
@@ -332,7 +332,7 @@ describe("cross-repo evaluation harness (#4788)", () => {
           "FAIL acme/bad [clone_setup] missing clone",
           "",
           "summary: 1/2 passed (majority failed)",
-          "without gittensory-specific target config: 2/2",
+          "without loopover-specific target config: 2/2",
           "",
           "failures by category:",
           "- clone_setup: 1",

--- a/test/unit/miner-replay-snapshot.test.ts
+++ b/test/unit/miner-replay-snapshot.test.ts
@@ -234,7 +234,7 @@ describe("exportReplaySnapshot (#3010)", () => {
     );
     expect(store.getSnapshot("acme/widgets", "abc123")).toBeNull();
     const removeCall = calls.find((c) => c.args[0] === "worktree" && c.args[1] === "remove");
-    expect(removeCall?.args).toEqual(["worktree", "remove", "--force", "/repo/.gittensory-replay-snapshots/abc123"]);
+    expect(removeCall?.args).toEqual(["worktree", "remove", "--force", "/repo/.loopover-replay-snapshots/abc123"]);
   });
 
   it("removes the worktree and rethrows the ORIGINAL error (not a cleanup error) when a git read after the worktree exists fails", async () => {
@@ -395,9 +395,9 @@ describe("exportReplaySnapshot (#3010)", () => {
 describe("removeReplaySnapshotWorktree (#3010)", () => {
   it("delegates to the shared removeWorktree primitive", async () => {
     const { exec, calls } = scriptedExec([{ match: () => true, result: ok() }]);
-    const result = await removeReplaySnapshotWorktree(exec, "/repo", "/repo/.gittensory-replay-snapshots/abc123");
+    const result = await removeReplaySnapshotWorktree(exec, "/repo", "/repo/.loopover-replay-snapshots/abc123");
     expect(result).toEqual({ ok: true, removed: true });
-    expect(calls[0]?.args).toEqual(["worktree", "remove", "--force", "/repo/.gittensory-replay-snapshots/abc123"]);
+    expect(calls[0]?.args).toEqual(["worktree", "remove", "--force", "/repo/.loopover-replay-snapshots/abc123"]);
   });
 });
 
@@ -407,7 +407,7 @@ describe("openReplaySnapshotStore (#3010) — round-trip persistence", () => {
     const saved = store.saveSnapshot({
       repoFullName: "acme/widgets",
       commitSha: "abc123",
-      worktreePath: "/repo/.gittensory-replay-snapshots/abc123",
+      worktreePath: "/repo/.loopover-replay-snapshots/abc123",
       targetDate: "2026-01-05T00:00:00+00:00",
       commits: [{ sha: "abc123", date: "2026-01-05T00:00:00+00:00", subject: "t" }],
       tags: [{ name: "v1", date: "2026-01-01T00:00:00+00:00", targetSha: "abc000" }],
@@ -423,7 +423,7 @@ describe("openReplaySnapshotStore (#3010) — round-trip persistence", () => {
     const saved = store.saveSnapshot({
       repoFullName: "acme/widgets",
       commitSha: "abc123",
-      worktreePath: "/repo/.gittensory-replay-snapshots/abc123",
+      worktreePath: "/repo/.loopover-replay-snapshots/abc123",
       targetDate: "2026-01-05T00:00:00+00:00",
       commits: [],
       tags: [],


### PR DESCRIPTION
## Summary

- #5899 renamed `scanPositiveGittensoryAssumptions` → `scanPositiveLoopoverAssumptions` and the summary field `withoutGittensoryConfig` → `withoutLoopoverConfig` in `packages/loopover-miner/lib/cross-repo-evaluation.js`, but missed the consuming test file.
- This broke `npm run typecheck` on main (missing export → cascading implicit-`any`) and one assertion (a stale report-text literal), discovered while rebasing an unrelated PR onto main.
- Fixed `test/unit/miner-cross-repo-evaluation.test.ts` to use the renamed identifiers/text.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npx vitest run test/unit/miner-cross-repo-evaluation.test.ts` — 29/29 passing
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities