### PR TITLE
fix(ci): authenticate release-please with a PAT instead of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/mcp-release-please.yml
+++ b/.github/workflows/mcp-release-please.yml
@@ -50,13 +50,19 @@ jobs:
         with:
           persist-credentials: false
 
+      # Authenticates as a real account (via RELEASE_PLEASE_TOKEN, a fine-grained PAT) rather than the
+      # default GITHUB_TOKEN. GitHub Apps like github-actions[bot] aren't tracked as repo collaborators,
+      # so PRs/commits it authors were repeatedly re-flagged as needing manual workflow-run approval on
+      # every push, even with the least-restrictive fork-PR-approval setting -- a real collaborator
+      # identity doesn't hit that gate. This also sidesteps the same GITHUB_TOKEN recursion-prevention
+      # rule noted below for tag pushes.
       - name: Run release-please
         id: release
         uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
 
       # release-please's extra-files JSON-path updater doesn't reliably reach package-lock.json's
       # per-workspace version fields (keys containing "/", nested under a manifest-mode component
@@ -72,7 +78,7 @@ jobs:
       # fail on every single engine release PR (confirmed live on the engine-v3.1.0 release PR, #5807).
       - name: Sync package-lock.json and engine-version pin on any release branch
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         run: |
           set -euo pipefail
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
## Summary

- Every release-please PR's own CI (both the "CI" and "UI Preview Build" workflows) was repeatedly landing in `action_required`, needing manual approval on nearly every push -- confirmed live across mcp/engine/miner/ui-kit release PRs today. The repo's fork-PR-approval setting is already at its least restrictive option ("Require approval for first-time contributors"), so that wasn't the cause: `github-actions[bot]` isn't tracked as a repo collaborator (it has access via the Actions token, not a collaborator role), so the approval gate re-triggers on every push instead of clearing after the first approval.
- Switches `release-please-action`'s `token:` and the "Sync package-lock.json and engine-version pin" step's `GH_TOKEN` to a new `RELEASE_PLEASE_TOKEN` repo secret (a fine-grained PAT scoped to Contents/Pull requests/Workflows, added by the repo owner). Authenticating as a real collaborator account should stop triggering that gate.
- Left the four "Dispatch \*publish" steps on `secrets.GITHUB_TOKEN` -- they only call `gh workflow run` (workflow_dispatch), already covered by the job's own `permissions: actions: write`, and don't need the PAT's broader scope.

**Side effect to be aware of:** future release-please PRs will show as authored by the PAT's account instead of `app/github-actions`. Anything that filters release PRs by author (scripts, saved searches, etc.) should switch to matching the `release-please--branches--main--components--*` branch naming instead.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [ ] I linked a currently open issue this PR resolves -- maintainer PR fixing a CI/automation defect discovered live across today's release PRs, no linked issue.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [ ] Everything else in the standard checklist -- skipped, this is a `.github/workflows/**`-only change (one line's secret reference + comments), no `src/`, `test/`, or dependency changes, no new logic surface to exercise beyond workflow-syntax validation.

If any required check was skipped, explain why:

- Workflow-YAML-only change with no code/test/dependency surface. `actionlint` is the relevant local check and passes. The real validation is behavioral (does the next release-please run avoid `action_required`?), which can only be observed once this merges and the workflow runs for real with the new secret.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed. (The PAT itself is a repo secret, referenced only by name -- never the value -- same as the existing `GITHUB_TOKEN` references.)
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth/cookie/CORS/GitHub App/Cloudflare/session changes include negative-path tests. -- N/A, this changes which credential a CI job authenticates with, not application auth/session logic.
- [ ] API/OpenAPI/MCP behavior updated/tested. -- N/A.
- [ ] UI changes use live API data or real empty/error/loading states. -- N/A, no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section. -- N/A, no UI changes.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. -- this PR does not touch `CHANGELOG.md`.

## Notes

- Discovered while manually approving a string of `action_required` workflow runs across today's mcp/engine/miner/ui-kit release PRs; this is the root-cause fix so it stops recurring on every future release.