### PR TITLE
fix(rebrand): rename gittensory-cli- tmpdir prefix across mcp-cli test family

### DIFF
--- a/test/unit/mcp-cli-doctor.test.ts
+++ b/test/unit/mcp-cli-doctor.test.ts
@@ -24,7 +24,7 @@ describe("loopover-mcp CLI — doctor", () => {
   });
 
   it("runs doctor against a local health/session fixture", async () => {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     const url = await startFixtureServer();
     const secretRoot = join(tempDir, "secret-gittensor");
     const secretConfigDir = join(tempDir, "secret-config");
@@ -104,7 +104,7 @@ describe("loopover-mcp CLI — doctor", () => {
   });
 
   it("uses doctor as a first-run auth checklist when no local session is configured", async () => {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     const url = await startFixtureServer();
     const payload = JSON.parse(
       await runAsync(["doctor", "--cwd", tempDir, "--repo", "JSONbored/gittensory", "--json"], {
@@ -133,7 +133,7 @@ describe("loopover-mcp CLI — doctor", () => {
   });
 
   it("reports a stale global install with an exact upgrade command and npx fallback", async () => {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     const url = await startFixtureServer({ latestVersion: "9.9.9" });
     const payload = JSON.parse(
       await runAsync(["status", "--json"], {
@@ -154,7 +154,7 @@ describe("loopover-mcp CLI — doctor", () => {
   });
 
   it("reports a current install without upgrade guidance", async () => {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     const url = await startFixtureServer({ latestVersion: mcpPackageJson.version, minMcpVersion: "0.5.0" });
     const payload = JSON.parse(
       await runAsync(["status", "--json"], {
@@ -181,7 +181,7 @@ describe("loopover-mcp CLI — doctor", () => {
   });
 
   it("orders prerelease npm versions correctly (release outranks prerelease of the same core)", async () => {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     // Local 0.5.0 (release) vs latest 0.5.0-rc.1 (prerelease) -> local is ahead, not stale.
     const aheadUrl = await startFixtureServer({ latestVersion: "0.5.0-rc.1" });
     const ahead = JSON.parse(
@@ -209,7 +209,7 @@ describe("loopover-mcp CLI — doctor", () => {
   });
 
   it("treats an unavailable npm registry as a warning, not a hard failure", async () => {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     const url = await startFixtureServer({ npmStatus: 500, compatibilityStatus: 404 });
     const status = JSON.parse(
       await runAsync(["status", "--json"], {
@@ -235,7 +235,7 @@ describe("loopover-mcp CLI — doctor", () => {
   });
 
   it("flags a stale install in doctor with upgrade remediation", async () => {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     const url = await startFixtureServer({ latestVersion: oneMinorAboveLocal });
     const payload = JSON.parse(
       await runAsync(["doctor", "--cwd", tempDir, "--repo", "JSONbored/gittensory", "--json"], {
@@ -252,7 +252,7 @@ describe("loopover-mcp CLI — doctor", () => {
   });
 
   it("reports API compatibility as unavailable when the API does not advertise a minimum version", async () => {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     const url = await startFixtureServer({ compatibilityStatus: 404 });
     const payload = JSON.parse(
       await runAsync(["status", "--json"], {
@@ -276,7 +276,7 @@ describe("loopover-mcp CLI — doctor", () => {
   });
 
   it("falls back to legacy health compatibility when the endpoint is unavailable", async () => {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     const url = await startFixtureServer({ compatibilityStatus: 503, minMcpVersion: "0.4.0" });
     const payload = JSON.parse(
       await runAsync(["status", "--json"], {
@@ -290,7 +290,7 @@ describe("loopover-mcp CLI — doctor", () => {
   });
 
   it("uses API recommended package metadata when the npm registry is unavailable", async () => {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     const url = await startFixtureServer({ npmStatus: 500, latestRecommendedMcpVersion: oneMinorAboveLocal });
     const payload = JSON.parse(
       await runAsync(["status", "--json"], {
@@ -309,7 +309,7 @@ describe("loopover-mcp CLI — doctor", () => {
   });
 
   it("flags API compatibility mismatches with upgrade guidance", async () => {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     const url = await startFixtureServer({ minMcpVersion: "9.0.0" });
     const env = {
       LOOPOVER_API_URL: url,
@@ -346,7 +346,7 @@ describe("loopover-mcp CLI — doctor", () => {
   });
 
   it("keeps source upload unsupported and fail-closed in the doctor checklist", async () => {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     const url = await startFixtureServer();
     const payload = JSON.parse(
       await runAsync(["doctor", "--cwd", tempDir, "--repo", "JSONbored/gittensory", "--json"], {
@@ -373,7 +373,7 @@ describe("loopover-mcp CLI — doctor", () => {
   });
 
   it("points missing local repo readiness at an explicit repo-aware doctor command", async () => {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     const url = await startFixtureServer();
     const payload = JSON.parse(
       await runAsync(["doctor", "--cwd", tempDir, "--json"], {
@@ -398,7 +398,7 @@ describe("loopover-mcp CLI — doctor", () => {
   });
 
   it("does not print configured tokens or local absolute paths in status or doctor output", async () => {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     const url = await startFixtureServer({ latestVersion: "9.9.9", minMcpVersion: "9.0.0" });
     const env = {
       LOOPOVER_API_URL: url,
@@ -421,7 +421,7 @@ describe("loopover-mcp CLI — doctor", () => {
   });
 
   it("keeps doctor exit code 0 by default even when a check fails", async () => {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     const url = await startFixtureServer();
     // No token configured -> the auth check fails -> status "needs_attention".
     const payload = JSON.parse(
@@ -436,7 +436,7 @@ describe("loopover-mcp CLI — doctor", () => {
   });
 
   it("exits non-zero from doctor --exit-code when a check fails", async () => {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     const url = await startFixtureServer();
     let exitCode = 0;
     let stdout = "";
@@ -463,7 +463,7 @@ describe("loopover-mcp CLI — doctor", () => {
   });
 
   it("keeps doctor --exit-code at 0 when checks pass", async () => {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     const url = await startFixtureServer();
     // runAsync resolves only on a zero exit code, so reaching the assertion proves exit 0.
     const payload = JSON.parse(

--- a/test/unit/mcp-cli-issue-slop.test.ts
+++ b/test/unit/mcp-cli-issue-slop.test.ts
@@ -14,7 +14,7 @@ describe("loopover-mcp CLI — issue-slop", () => {
   });
 
   async function env() {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     const url = await startFixtureServer();
     return { LOOPOVER_API_URL: url, LOOPOVER_TOKEN: "session-token", LOOPOVER_CONFIG_DIR: tempDir, LOOPOVER_API_TIMEOUT_MS: "1000" };
   }

--- a/test/unit/mcp-cli-lint-pr-text.test.ts
+++ b/test/unit/mcp-cli-lint-pr-text.test.ts
@@ -14,7 +14,7 @@ describe("loopover-mcp CLI — lint-pr-text", () => {
   });
 
   async function env() {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     const url = await startFixtureServer();
     return { LOOPOVER_API_URL: url, LOOPOVER_TOKEN: "session-token", LOOPOVER_CONFIG_DIR: tempDir, LOOPOVER_API_TIMEOUT_MS: "1000" };
   }

--- a/test/unit/mcp-cli-maintain.test.ts
+++ b/test/unit/mcp-cli-maintain.test.ts
@@ -14,7 +14,7 @@ describe("loopover-mcp CLI — maintain (#784)", () => {
   });
 
   async function env() {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     const url = await startFixtureServer();
     return { LOOPOVER_API_URL: url, LOOPOVER_TOKEN: "session-token", LOOPOVER_CONFIG_DIR: tempDir, LOOPOVER_API_TIMEOUT_MS: "1000" };
   }

--- a/test/unit/mcp-cli-packets.test.ts
+++ b/test/unit/mcp-cli-packets.test.ts
@@ -24,7 +24,7 @@ describe("loopover-mcp CLI — packets", () => {
   });
 
   it("caches last-good decision packs and returns explicitly stale local fallback when the API is unavailable", async () => {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     const url = await startFixtureServer();
     const env = {
       LOOPOVER_API_URL: url,
@@ -74,7 +74,7 @@ describe("loopover-mcp CLI — packets", () => {
   });
 
   it("ignores incompatible decision-pack cache entries and clears cache entries on request", async () => {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     const url = await startFixtureServer();
     const env = {
       LOOPOVER_API_URL: url,
@@ -99,7 +99,7 @@ describe("loopover-mcp CLI — packets", () => {
   });
 
   it("lists cached decision packs with safe metadata only", async () => {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     const url = await startFixtureServer();
     const env = {
       LOOPOVER_API_URL: url,
@@ -132,7 +132,7 @@ describe("loopover-mcp CLI — packets", () => {
   });
 
   it("cache list --format ndjson streams one JSON object per cached entry", async () => {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     const url = await startFixtureServer();
     const env = {
       LOOPOVER_API_URL: url,
@@ -156,7 +156,7 @@ describe("loopover-mcp CLI — packets", () => {
   });
 
   it("does not use stale decision-pack cache created by a different local token", async () => {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     const fixtureOptions: { decisionPackStatus?: number } = {};
     const url = await startFixtureServer(fixtureOptions);
     const env = {
@@ -177,7 +177,7 @@ describe("loopover-mcp CLI — packets", () => {
   });
 
   it("does not use stale decision-pack cache for authorization failures", async () => {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     const fixtureOptions: { decisionPackStatus?: number } = {};
     const url = await startFixtureServer(fixtureOptions);
     const env = {
@@ -193,7 +193,7 @@ describe("loopover-mcp CLI — packets", () => {
   });
 
   it("does not use stale decision-pack cache for non-JSON authorization failures", async () => {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     const fixtureOptions: {
       decisionPackStatus?: number;
       decisionPackErrorBody?: string;
@@ -222,7 +222,7 @@ describe("loopover-mcp CLI — packets", () => {
   });
 
   it("does not use stale decision-pack cache when local credentials are missing", async () => {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     const url = await startFixtureServer();
     const env = {
       LOOPOVER_API_URL: url,
@@ -245,7 +245,7 @@ describe("loopover-mcp CLI — packets", () => {
   });
 
   it("runs base-agent CLI commands against API fixtures", async () => {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     const url = await startFixtureServer();
     const env = {
       LOOPOVER_API_URL: url,
@@ -274,7 +274,7 @@ describe("loopover-mcp CLI — packets", () => {
   });
 
   it("prints copy-paste public-safe markdown for agent packet output", async () => {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     git(tempDir, "init");
     git(tempDir, "config", "user.email", "test@example.com");
     git(tempDir, "config", "user.name", "LoopOver Test");
@@ -303,7 +303,7 @@ describe("loopover-mcp CLI — packets", () => {
   });
 
   it("rejects unsafe server-provided packet markdown before non-json output", async () => {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     git(tempDir, "init");
     git(tempDir, "config", "user.email", "test@example.com");
     git(tempDir, "config", "user.name", "LoopOver Test");
@@ -343,7 +343,7 @@ describe("loopover-mcp CLI — packets", () => {
   }, 45000);
 
   it("sends bounded structured validation summaries without local logs", async () => {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     git(tempDir, "init");
     git(tempDir, "config", "user.email", "test@example.com");
     git(tempDir, "config", "user.name", "LoopOver Test");
@@ -437,7 +437,7 @@ describe("loopover-mcp CLI — packets", () => {
   });
 
   it("classifies nonzero validation status phrases as failed", async () => {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     git(tempDir, "init");
     git(tempDir, "config", "user.email", "test@example.com");
     git(tempDir, "config", "user.name", "LoopOver Test");

--- a/test/unit/mcp-cli-review-pr.test.ts
+++ b/test/unit/mcp-cli-review-pr.test.ts
@@ -387,7 +387,7 @@ describe("loopover-mcp CLI — review-pr", () => {
   });
 
   it("requires --login", async () => {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     await expect(runAsync(["review-pr", "--cwd", tempDir], {})).rejects.toThrow(
       /Pass --login/,
     );

--- a/test/unit/mcp-cli-slop-risk.test.ts
+++ b/test/unit/mcp-cli-slop-risk.test.ts
@@ -14,7 +14,7 @@ describe("loopover-mcp CLI — slop-risk", () => {
   });
 
   async function env() {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     const url = await startFixtureServer();
     return { LOOPOVER_API_URL: url, LOOPOVER_TOKEN: "session-token", LOOPOVER_CONFIG_DIR: tempDir, LOOPOVER_API_TIMEOUT_MS: "1000" };
   }

--- a/test/unit/mcp-cli-tools.test.ts
+++ b/test/unit/mcp-cli-tools.test.ts
@@ -23,7 +23,7 @@ describe("loopover-mcp CLI — tools", () => {
   });
 
   it("lists every registered stdio tool with a non-empty description", async () => {
-    configDir = mkdtempSync(join(tmpdir(), "gittensory-cli-tools-"));
+    configDir = mkdtempSync(join(tmpdir(), "loopover-cli-tools-"));
     const apiUrl = await startFixtureServer();
     transport = new StdioClientTransport({
       command: "node",

--- a/test/unit/mcp-cli-validate-config.test.ts
+++ b/test/unit/mcp-cli-validate-config.test.ts
@@ -14,7 +14,7 @@ describe("loopover-mcp CLI — validate-config", () => {
   });
 
   async function env(options: Parameters<typeof startFixtureServer>[0] = {}) {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     const url = await startFixtureServer(options);
     return { LOOPOVER_API_URL: url, LOOPOVER_TOKEN: "session-token", LOOPOVER_CONFIG_DIR: tempDir, LOOPOVER_API_TIMEOUT_MS: "1000" };
   }

--- a/test/unit/support/mcp-cli-harness.ts
+++ b/test/unit/support/mcp-cli-harness.ts
@@ -19,7 +19,7 @@ export function run(args: string[], env: Record<string, string> = {}) {
     env: {
       ...process.env,
       LOOPOVER_API_TIMEOUT_MS: "1000",
-      LOOPOVER_CONFIG_DIR: mkdtempSync(join(tmpdir(), "gittensory-cli-config-")),
+      LOOPOVER_CONFIG_DIR: mkdtempSync(join(tmpdir(), "loopover-cli-config-")),
       ...env,
     },
     stdio: ["ignore", "pipe", "pipe"],
@@ -36,7 +36,7 @@ export function runAsync(args: string[], env: Record<string, string> = {}) {
         env: {
           ...process.env,
           LOOPOVER_API_TIMEOUT_MS: "1000",
-          LOOPOVER_CONFIG_DIR: mkdtempSync(join(tmpdir(), "gittensory-cli-config-")),
+          LOOPOVER_CONFIG_DIR: mkdtempSync(join(tmpdir(), "loopover-cli-config-")),
           ...env,
         },
       },
@@ -56,7 +56,7 @@ export function git(cwd: string, ...args: string[]) {
 }
 
 export function createPacketRepo() {
-  const cwd = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+  const cwd = mkdtempSync(join(tmpdir(), "loopover-cli-"));
   git(cwd, "init");
   git(cwd, "config", "user.email", "test@example.com");
   git(cwd, "config", "user.name", "LoopOver Test");


### PR DESCRIPTION
## Summary
- 9 `test/unit/mcp-cli-*.test.ts` files plus the shared `test/unit/support/mcp-cli-harness.ts` all used `mkdtempSync(tmpdir(), "gittensory-cli-")` (and the `-tools-`/`-config-` variants) as a human-readable temp-dir label. Purely cosmetic, no cross-references to the exact prefix string anywhere.
- Completes the gittensory->loopover rebrand for this convention, which the original test-prose sweep missed since it only covered the `gittensory-miner`/`gittensory-ams` naming, not `gittensory-cli`.

## Test plan
- [x] Targeted vitest run across all 9 affected test files -- 77/77 pass
- [x] Full `npm run test:ci` gate green locally