### PR TITLE
fix(rebrand): rename gittensory-app.env default output path

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -928,7 +928,7 @@ async function main(): Promise<void> {
           try {
             const creds = await exchangeManifestCode(code);
             const outPath =
-              process.env.SETUP_OUTPUT_PATH ?? "/data/gittensory-app.env";
+              process.env.SETUP_OUTPUT_PATH ?? "/data/loopover-app.env";
             writeFileSync(outPath, credentialsToEnv(creds), { mode: 0o600 });
             console.log(
               JSON.stringify({


### PR DESCRIPTION
## Summary
- `src/server.ts`'s GitHub App manifest-creation callback fell back to `/data/gittensory-app.env` when `SETUP_OUTPUT_PATH` isn't set. Renamed to `/data/loopover-app.env` to complete the self-host setup-wizard full-cutover rename.
- `src/server.ts` is Codecov-exempt (`codecov.yml`); no test exercises this exact literal-path fallback directly.

## Test plan
- [x] Full `npm run test:ci` gate green locally