### PR TITLE
fix(rebrand): rename x-gittensory-request-id header to x-loopover-request-id

### DIFF
--- a/review-enrichment/src/server.ts
+++ b/review-enrichment/src/server.ts
@@ -95,7 +95,7 @@ app.post("/v1/enrich", async (c) => {
     }
 
     const brief = await buildBrief(parsed.payload, undefined, {
-      requestId: c.req.header("x-gittensory-request-id") ?? c.req.header("x-request-id"),
+      requestId: c.req.header("x-loopover-request-id") ?? c.req.header("x-request-id"),
       traceId: traceIdFromTraceparent(c.req.header("traceparent")),
     });
     recordEnrichOutcome("ok", startedAtMs);

--- a/src/review/enrichment-wire.ts
+++ b/src/review/enrichment-wire.ts
@@ -450,7 +450,7 @@ export async function buildReviewEnrichment(
         "user-agent": "loopover-selfhost/1.0",
         accept: "application/json",
         "content-type": "application/json",
-        "x-gittensory-request-id": requestId,
+        "x-loopover-request-id": requestId,
         ...(sharedSecret ? { authorization: `Bearer ${sharedSecret}` } : {}),
       },
       body: JSON.stringify({

--- a/test/unit/enrichment-wire.test.ts
+++ b/test/unit/enrichment-wire.test.ts
@@ -248,7 +248,7 @@ describe("buildReviewEnrichment", () => {
       (calls[0]!.init.headers as Record<string, string>)["user-agent"],
     ).toBe("loopover-selfhost/1.0");
     expect(
-      (calls[0]!.init.headers as Record<string, string>)["x-gittensory-request-id"],
+      (calls[0]!.init.headers as Record<string, string>)["x-loopover-request-id"],
     ).toMatch(/^[-0-9a-fA-Fa-z]+$/);
     expect((calls[0]!.init.headers as Record<string, string>).accept).toBe(
       "application/json",


### PR DESCRIPTION
## Summary
- Renamed the `x-gittensory-request-id` HTTP header to `x-loopover-request-id`, coordinated across all 3 places it's referenced: the sender (`src/review/enrichment-wire.ts`, main engine calling into review-enrichment), the receiver (`review-enrichment/src/server.ts`, which also falls back to the generic `x-request-id`), and the covering test.
- Completes the full-cutover rename of this cross-service wire contract between the main engine and the separately-deployed review-enrichment service.

## Test plan
- [x] `npx vitest run test/unit/enrichment-wire.test.ts` -- 58/58 pass
- [x] Full `npm run test:ci` gate green locally