### PR TITLE
fix(rebrand): rename gittensory-mcp prose cluster and fix release-candidate binary name

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -18,7 +18,7 @@ For conduct issues, use the expectations in `CODE_OF_CONDUCT.md`.
 
 ## Useful Issue Details
 
-- LoopOver MCP version from `gittensory-mcp status`
+- LoopOver MCP version from `loopover-mcp status`
 - command used, with tokens and local paths removed
 - sanitized error message
 - repository owner/name when relevant

--- a/scripts/check-mcp-release-candidate.mjs
+++ b/scripts/check-mcp-release-candidate.mjs
@@ -77,13 +77,13 @@ function packedCliSmoke() {
     if (run("npm", ["--prefix", temp, "install", tarball]).status !== 0) {
       return { ok: false, code: "cli_smoke_failed", message: "Installing the packed tarball into a temp project failed." };
     }
-    const binName = onWindows ? "gittensory-mcp.cmd" : "gittensory-mcp";
+    const binName = onWindows ? "loopover-mcp.cmd" : "loopover-mcp";
     const bin = join(temp, "node_modules", ".bin", binName);
     const smoke = run(bin, ["--help"]);
     if (smoke.status !== 0) {
-      return { ok: false, code: "cli_smoke_failed", message: "Packed gittensory-mcp --help did not exit cleanly." };
+      return { ok: false, code: "cli_smoke_failed", message: "Packed loopover-mcp --help did not exit cleanly." };
     }
-    return { ok: true, code: "cli_smoke_ok", message: "Packed gittensory-mcp --help runs cleanly from the installed tarball." };
+    return { ok: true, code: "cli_smoke_ok", message: "Packed loopover-mcp --help runs cleanly from the installed tarball." };
   } finally {
     if (temp) rmSync(temp, { recursive: true, force: true });
     rmSync(tarball, { force: true });

--- a/test/unit/mcp-cli-analyze-branch.test.ts
+++ b/test/unit/mcp-cli-analyze-branch.test.ts
@@ -2,7 +2,7 @@ import { rmSync } from "node:fs";
 import { afterEach, describe, expect, it } from "vitest";
 import { closeFixtureServer, createPacketRepo, localBranchAnalysisFixture, runAsync, startFixtureServer } from "./support/mcp-cli-harness";
 
-describe("gittensory-mcp CLI — analyze-branch --format table", () => {
+describe("loopover-mcp CLI — analyze-branch --format table", () => {
   let tempDir: string | null = null;
 
   afterEach(async () => {

--- a/test/unit/mcp-cli-maintainer-noise.test.ts
+++ b/test/unit/mcp-cli-maintainer-noise.test.ts
@@ -16,7 +16,7 @@ let apiUrl: string;
 let capturedRequests: Array<{ url: string; method: string }>;
 
 async function connect() {
-  configDir = mkdtempSync(join(tmpdir(), "gittensory-maintainer-noise-"));
+  configDir = mkdtempSync(join(tmpdir(), "loopover-maintainer-noise-"));
   capturedRequests = [];
   apiUrl = await startFixtureServer({
     onApiRequest: (request) => {
@@ -72,7 +72,7 @@ describe("loopover_get_maintainer_noise stdio proxy", () => {
     expect(text).toContain("medium");
   });
 
-  it("lists the tool via gittensory-mcp tools", () => {
+  it("lists the tool via loopover-mcp tools", () => {
     const payload = JSON.parse(run(["tools", "--json"])) as {
       tools: Array<{ name: string; description: string }>;
     };

--- a/test/unit/mcp-cli-profiles.test.ts
+++ b/test/unit/mcp-cli-profiles.test.ts
@@ -6,7 +6,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import { closeFixtureServer, run, runAsync, startFixtureServer } from "./support/mcp-cli-harness";
 import mcpPackageJson from "../../packages/loopover-mcp/package.json";
 
-describe("gittensory-mcp CLI — profiles", () => {
+describe("loopover-mcp CLI — profiles", () => {
   let tempDir: string | null = null;
 
   afterEach(async () => {
@@ -16,7 +16,7 @@ describe("gittensory-mcp CLI — profiles", () => {
   });
 
   it("stores, switches, and reports named MCP profiles without mixing sessions", async () => {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     const requests: Array<{ url: string | undefined; authorization: string | undefined }> = [];
     const url = await startFixtureServer({
       onApiRequest: (request) => requests.push({ url: request.url, authorization: request.headers.authorization }),
@@ -54,11 +54,11 @@ describe("gittensory-mcp CLI — profiles", () => {
         expect.objectContaining({ url: "/v1/auth/session", authorization: "Bearer session-okto" }),
       ]),
     );
-    expect(JSON.stringify(list)).not.toMatch(/session-jsonbored|session-okto|github-jsonbored|github-okto|gittensory-cli-/);
+    expect(JSON.stringify(list)).not.toMatch(/session-jsonbored|session-okto|github-jsonbored|github-okto|loopover-cli-/);
   }, 45_000);
 
   it("profile list --format ndjson streams one JSON object per profile (and --json stays pretty)", () => {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     const configPath = join(tempDir, "config.json");
     // Two credential-free profiles (default + active "beta"); profile list needs only names to enumerate,
     // so the fixture carries no session token — the streaming format is what this exercises.
@@ -94,7 +94,7 @@ describe("gittensory-mcp CLI — profiles", () => {
   });
 
   it("keeps environment tokens ahead of active profile sessions", async () => {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     const requests: Array<{ url: string | undefined; authorization: string | undefined }> = [];
     const url = await startFixtureServer({
       onApiRequest: (request) => requests.push({ url: request.url, authorization: request.headers.authorization }),
@@ -116,7 +116,7 @@ describe("gittensory-mcp CLI — profiles", () => {
   });
 
   it("removes the default profile without rehydrating its legacy session token", async () => {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     const configPath = join(tempDir, "config.json");
     writeFileSync(
       configPath,
@@ -148,7 +148,7 @@ describe("gittensory-mcp CLI — profiles", () => {
   });
 
   it("logs out only the selected profile and reports missing profiles safely", async () => {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     const requests: Array<{ url: string | undefined; authorization: string | undefined }> = [];
     const url = await startFixtureServer({
       onApiRequest: (request) => requests.push({ url: request.url, authorization: request.headers.authorization }),
@@ -179,11 +179,11 @@ describe("gittensory-mcp CLI — profiles", () => {
     expect(doctor.profile).toMatchObject({ name: "missing", configured: false });
     expect(doctor.checks).toEqual(expect.arrayContaining([expect.objectContaining({ name: "auth", status: "fail" })]));
     expect(requests).toEqual(expect.arrayContaining([expect.objectContaining({ url: "/v1/auth/logout", authorization: "Bearer session-jsonbored" })]));
-    expect(JSON.stringify({ logout, list, missingStatus, doctor })).not.toMatch(/session-jsonbored|session-okto|github-jsonbored|github-okto|gittensory-cli-/);
+    expect(JSON.stringify({ logout, list, missingStatus, doctor })).not.toMatch(/session-jsonbored|session-okto|github-jsonbored|github-okto|loopover-cli-/);
   }, 45_000);
 
   it("reports package status and prints the packaged changelog", async () => {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     const url = await startFixtureServer();
     const status = JSON.parse(
       await runAsync(["status", "--json"], {
@@ -204,7 +204,7 @@ describe("gittensory-mcp CLI — profiles", () => {
   });
 
   it("sends redacted MCP package telemetry headers to the API", async () => {
-    tempDir = mkdtempSync(join(tmpdir(), "gittensory-cli-"));
+    tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     const requests: Array<{ url: string | undefined; headers: IncomingMessage["headers"] }> = [];
     const url = await startFixtureServer({ onApiRequest: (request) => requests.push({ url: request.url, headers: request.headers }) });
 

--- a/test/unit/mcp-tool-rename-aliases.test.ts
+++ b/test/unit/mcp-tool-rename-aliases.test.ts
@@ -18,7 +18,7 @@ let transport: StdioClientTransport;
 let configDir: string;
 
 async function connect(apiUrl: string) {
-  configDir = mkdtempSync(join(tmpdir(), "gittensory-rename-alias-"));
+  configDir = mkdtempSync(join(tmpdir(), "loopover-rename-alias-"));
   transport = new StdioClientTransport({
     command: "node",
     args: [bin, "--stdio"],
@@ -63,7 +63,7 @@ describe("MCP legacy alias retirement (#4777) — discovery invariants", () => {
     }
   });
 
-  it("`gittensory-mcp tools --json` reports the same 37-tool count the live server registers", async () => {
+  it("`loopover-mcp tools --json` reports the same 37-tool count the live server registers", async () => {
     const { tools } = await client.listTools();
     const payload = JSON.parse(run(["tools", "--json"])) as { count: number; tools: Array<{ name: string }> };
     expect(payload.count).toBe(tools.length);

--- a/test/unit/miner-mcp-tool-docs-parity.test.ts
+++ b/test/unit/miner-mcp-tool-docs-parity.test.ts
@@ -41,7 +41,7 @@ describe("miner MCP tool documentation parity (#5162)", () => {
     expect(mcpSection).toContain("payload_json");
   });
 
-  it("relates AMS's local MCP tools to the hosted gittensory-mcp tools", () => {
+  it("relates AMS's local MCP tools to the hosted loopover-mcp tools", () => {
     const readme = readFileSync(README_PATH, "utf8");
     const mcpSection = readme.slice(readme.indexOf("## MCP server"), readme.indexOf("## Version check"));
     expect(mcpSection).toContain("local SQLite");


### PR DESCRIPTION
## Summary
- Renames the remaining `gittensory-mcp` prose across `SUPPORT.md` and 5 `test/unit/mcp-*.test.ts` describe/it-block titles and `mkdtempSync` tmpdir prefixes (`gittensory-cli-maintainer-noise-`, `gittensory-rename-alias-`), completing the rebrand for this pattern that the earlier bulk-prose sweep missed since it only covered `gittensory-miner`/`gittensory-ams`.
- Fixes a real bug in `scripts/check-mcp-release-candidate.mjs`: its packed-CLI smoke test looked for a binary literally named `gittensory-mcp`(`.cmd`), but `packages/loopover-mcp/package.json`'s `bin` field is now `loopover-mcp` -- the smoke test would fail to find the binary if actually run. This script isn't part of `test:ci` (a separate manual release-prep script via `npm run mcp:release-candidate`), so it wasn't blocking CI, but it was genuinely broken.
- Explicitly left untouched (confirmed non-load-bearing/permanent): `gittensory_`-prefixed retired-tool-name literals in `mcp-tool-rename-aliases.test.ts` (the whole point of that test is verifying these OLD names are rejected), arbitrary fixture repo names (`"JSONbored/gittensory"`), and `CHANGELOG.md` entries (never edited in a normal PR per house rules).

## Test plan
- [x] Targeted vitest run across all 5 affected test files -- 28/28 pass
- [x] Full `npm run test:ci` gate green locally