### PR TITLE
fix(rebrand): rename gittensory-mcp CLI snippets and JSON keys in apps/loopover-ui

### DIFF
--- a/apps/loopover-ui/src/components/site/ams-observability-callout.tsx
+++ b/apps/loopover-ui/src/components/site/ams-observability-callout.tsx
@@ -1,6 +1,6 @@
 import { Callout } from "@/components/site/primitives";
 
-// AMS (gittensory-miner) observability cross-reference (#5191). A dual-role self-hoster running both ORB (the
+// AMS (loopover-miner) observability cross-reference (#5191). A dual-role self-hoster running both ORB (the
 // review service) and AMS (the miner) on one box otherwise has no in-app pointer from the operations / quickstart /
 // workflow docs to the miner's observability setup. Keeping the callout — and its link target — in one place keeps
 // the wording byte-identical across all three routes instead of relying on three hand-copied copies staying in sync.
@@ -16,7 +16,7 @@ export const AMS_OBSERVABILITY_DOC_URL =
 export function AmsObservabilityCallout() {
   return (
     <Callout variant="note" title="Running the miner on this box too?">
-      If you also run <strong>AMS</strong> (the <code>gittensory-miner</code>) on this host, see{" "}
+      If you also run <strong>AMS</strong> (the <code>loopover-miner</code>) on this host, see{" "}
       <a href={AMS_OBSERVABILITY_DOC_URL} target="_blank" rel="noopener noreferrer">
         Observing your miner
       </a>{" "}

--- a/apps/loopover-ui/src/components/site/animated-terminal.tsx
+++ b/apps/loopover-ui/src/components/site/animated-terminal.tsx
@@ -14,7 +14,7 @@ const DEFAULT_SCENES: TerminalScene[] = [
     output: "→ GitHub Device Flow opened… authorized as octocat",
   },
   {
-    prompt: "gittensory-mcp analyze-branch --login octocat --json",
+    prompt: "loopover-mcp analyze-branch --login octocat --json",
     output: `{
   "lane": "maintainer",
   "branch_blockers": ["unsquashed-commits", "missing-issue-link"],
@@ -27,7 +27,7 @@ const DEFAULT_SCENES: TerminalScene[] = [
 }`,
   },
   {
-    prompt: "gittensory-mcp agent plan --login octocat --json",
+    prompt: "loopover-mcp agent plan --login octocat --json",
     output: `{
   "plan": [
     { "action": "clean-open-prs",   "priority": 0.91 },
@@ -86,7 +86,7 @@ export function AnimatedTerminal({
   return (
     <div className={cn("rounded-token border border-border bg-background", className)}>
       <div className="flex items-center justify-between border-b border-border px-3 py-1.5">
-        <span className="font-mono text-token-2xs text-muted-foreground">~ gittensory-mcp</span>
+        <span className="font-mono text-token-2xs text-muted-foreground">~ loopover-mcp</span>
         <div className="flex items-center gap-1.5">
           {scenes.map((_, i) => (
             <span

--- a/apps/loopover-ui/src/components/site/api/try-it.tsx
+++ b/apps/loopover-ui/src/components/site/api/try-it.tsx
@@ -314,7 +314,7 @@ export function TryIt({ op, server }: { op: OpenApiOperation; server: string }) 
       {op.requiresAuth && !token && (
         <Callout variant="safety">
           <strong>No PATs.</strong> Signed-in browsers use the HttpOnly session cookie. Paste a
-          LoopOver token from <code>gittensory-mcp login</code> only for manual bearer testing.
+          LoopOver token from <code>loopover-mcp login</code> only for manual bearer testing.
         </Callout>
       )}
 

--- a/apps/loopover-ui/src/lib/csv-export.ts
+++ b/apps/loopover-ui/src/lib/csv-export.ts
@@ -59,5 +59,5 @@ export function operatorDashboardToCsvRows(data: AnalyticsLedgerCsvInput): strin
 
 export function exportOperatorDashboardCsv(data: AnalyticsLedgerCsvInput): void {
   const day = new Date().toISOString().slice(0, 10);
-  downloadCsvText(`gittensory-analytics-${day}.csv`, toCsv(operatorDashboardToCsvRows(data)));
+  downloadCsvText(`loopover-analytics-${day}.csv`, toCsv(operatorDashboardToCsvRows(data)));
 }

--- a/apps/loopover-ui/src/lib/miner-commands.ts
+++ b/apps/loopover-ui/src/lib/miner-commands.ts
@@ -33,7 +33,7 @@ export function buildMinerCommandActions(input: {
     {
       id: "status",
       label: "Status",
-      command: "gittensory-mcp status --json",
+      command: "loopover-mcp status --json",
       state: "ready",
       copyable: true,
       boundary: "local-mcp",
@@ -41,7 +41,7 @@ export function buildMinerCommandActions(input: {
     {
       id: "doctor",
       label: "Doctor",
-      command: "gittensory-mcp doctor --json",
+      command: "loopover-mcp doctor --json",
       state: "ready",
       copyable: true,
       boundary: "local-mcp",
@@ -49,7 +49,7 @@ export function buildMinerCommandActions(input: {
     {
       id: "plan",
       label: "Plan",
-      command: `gittensory-mcp agent plan --login ${login} --json`,
+      command: `loopover-mcp agent plan --login ${login} --json`,
       state: hasLogin ? "ready" : "needs_login",
       copyable: hasLogin,
       boundary: "local-mcp",
@@ -57,7 +57,7 @@ export function buildMinerCommandActions(input: {
     {
       id: "preflight",
       label: "Preflight",
-      command: `gittensory-mcp preflight --login ${login} --repo ${repoFullName} --base origin/main --json`,
+      command: `loopover-mcp preflight --login ${login} --repo ${repoFullName} --base origin/main --json`,
       state: hasLogin && hasRepo ? "ready" : hasLogin ? "needs_repo" : "needs_login",
       copyable: hasLogin && hasRepo,
       boundary: "local-mcp",
@@ -65,7 +65,7 @@ export function buildMinerCommandActions(input: {
     {
       id: "packet",
       label: "Packet",
-      command: `gittensory-mcp agent packet --login ${login} --repo ${repoFullName} --base origin/main --json`,
+      command: `loopover-mcp agent packet --login ${login} --repo ${repoFullName} --base origin/main --json`,
       state: hasLogin && hasRepo ? "ready" : hasLogin ? "needs_repo" : "needs_login",
       copyable: hasLogin && hasRepo,
       boundary: "local-mcp",

--- a/apps/loopover-ui/src/routes/agents.tsx
+++ b/apps/loopover-ui/src/routes/agents.tsx
@@ -67,7 +67,7 @@ function AgentsPage() {
               Run the MCP as a local stdio process, or connect to the remote MCP at the Worker.
             </p>
             <div className="mt-4">
-              <CodeBlock code={`gittensory-mcp --stdio`} />
+              <CodeBlock code={`loopover-mcp --stdio`} />
               <div className="mt-2">
                 <CodeBlock code={`npx -y @loopover/mcp@latest --stdio`} />
               </div>
@@ -103,11 +103,11 @@ function AgentsPage() {
             </p>
             <div className="mt-4">
               <CodeBlock
-                code={`gittensory-mcp doctor
-gittensory-mcp status
-gittensory-mcp init-client --print codex
-gittensory-mcp init-client --print claude
-gittensory-mcp init-client --print cursor`}
+                code={`loopover-mcp doctor
+loopover-mcp status
+loopover-mcp init-client --print codex
+loopover-mcp init-client --print claude
+loopover-mcp init-client --print cursor`}
               />
             </div>
           </Card>

--- a/apps/loopover-ui/src/routes/api.index.tsx
+++ b/apps/loopover-ui/src/routes/api.index.tsx
@@ -40,8 +40,8 @@ function ApiOverview() {
 
       <div className="mt-8 space-y-5">
         <Callout variant="safety">
-          <strong>Auth.</strong> Use a LoopOver session token from <code>gittensory-mcp login</code>
-          . Never paste a GitHub PAT. Tokens you use in this reference live only in{" "}
+          <strong>Auth.</strong> Use a LoopOver session token from <code>loopover-mcp login</code>.
+          Never paste a GitHub PAT. Tokens you use in this reference live only in{" "}
           <code>localStorage</code> on this device and can be cleared instantly.
         </Callout>
 

--- a/apps/loopover-ui/src/routes/app.index.tsx
+++ b/apps/loopover-ui/src/routes/app.index.tsx
@@ -425,7 +425,7 @@ function RecentActivity({ runs }: { runs: RecentRun[] }) {
 
 const ONBOARDING_STEPS = [
   { id: "install", label: "Install the MCP package" },
-  { id: "doctor", label: "Run gittensory-mcp doctor" },
+  { id: "doctor", label: "Run loopover-mcp doctor" },
   { id: "workbench", label: "Explore the Workbench tabs" },
   { id: "run", label: "Open an agent run" },
 ] as const;

--- a/apps/loopover-ui/src/routes/index.tsx
+++ b/apps/loopover-ui/src/routes/index.tsx
@@ -379,8 +379,8 @@ function Install() {
           </div>
           <NpmInstall className="mt-3" />
           <pre className="mt-3 overflow-x-auto rounded-token border-hairline bg-background p-3 font-mono text-token-xs leading-token-relaxed text-foreground/90">
-            {`gittensory-mcp login
-gittensory-mcp analyze-branch --login your-login --json`}
+            {`loopover-mcp login
+loopover-mcp analyze-branch --login your-login --json`}
           </pre>
         </div>
         <div className="rounded-token border-hairline bg-card/40 p-4">
@@ -457,8 +457,8 @@ const CLIENT_TABS: Array<{
     filename: "terminal",
     lang: "bash",
     snippet: `npm i -g @loopover/mcp@latest
-gittensory-mcp login
-gittensory-mcp analyze-branch --login your-login --json`,
+loopover-mcp login
+loopover-mcp analyze-branch --login your-login --json`,
   },
   {
     id: "codex",
@@ -466,7 +466,7 @@ gittensory-mcp analyze-branch --login your-login --json`,
     audience: "Agents",
     filename: "~/.codex/config.toml",
     lang: "toml",
-    snippet: `[mcp_servers.gittensory]
+    snippet: `[mcp_servers.loopover]
 command = "npx"
 args = ["-y", "@loopover/mcp@latest", "--stdio"]`,
   },
@@ -478,7 +478,7 @@ args = ["-y", "@loopover/mcp@latest", "--stdio"]`,
     lang: "json",
     snippet: `{
   "mcpServers": {
-    "gittensory": {
+    "loopover": {
       "command": "npx",
       "args": ["-y", "@loopover/mcp@latest", "--stdio"]
     }
@@ -493,7 +493,7 @@ args = ["-y", "@loopover/mcp@latest", "--stdio"]`,
     lang: "json",
     snippet: `{
   "mcpServers": {
-    "gittensory": {
+    "loopover": {
       "command": "npx",
       "args": ["-y", "@loopover/mcp@latest", "--stdio"]
     }

--- a/apps/loopover-ui/src/routes/miners.tsx
+++ b/apps/loopover-ui/src/routes/miners.tsx
@@ -124,7 +124,7 @@ function MinersPage() {
               backed by your GitHub identity.
             </p>
             <div className="mt-4">
-              <CodeBlock code={`gittensory-mcp login\ngittensory-mcp whoami`} />
+              <CodeBlock code={`loopover-mcp login\nloopover-mcp whoami`} />
             </div>
           </Card>
           <Card>
@@ -134,7 +134,7 @@ function MinersPage() {
               Lane fit, repo targets, freshness, and the ranked next actions that move you forward.
             </p>
             <div className="mt-4">
-              <CodeBlock code={`gittensory-mcp agent plan --login your-login --json`} />
+              <CodeBlock code={`loopover-mcp agent plan --login your-login --json`} />
             </div>
           </Card>
           <Card>
@@ -146,7 +146,7 @@ function MinersPage() {
             </p>
             <div className="mt-4">
               <CodeBlock
-                code={`gittensory-mcp analyze-branch --login your-login --json\ngittensory-mcp preflight --login your-login --json`}
+                code={`loopover-mcp analyze-branch --login your-login --json\nloopover-mcp preflight --login your-login --json`}
               />
             </div>
           </Card>
@@ -158,7 +158,7 @@ function MinersPage() {
               Private signals stay local.
             </p>
             <div className="mt-4">
-              <CodeBlock code={`gittensory-mcp agent packet --json`} />
+              <CodeBlock code={`loopover-mcp agent packet --json`} />
             </div>
           </Card>
         </div>

--- a/test/unit/miner-dashboard-commands.test.ts
+++ b/test/unit/miner-dashboard-commands.test.ts
@@ -20,7 +20,7 @@ describe("miner dashboard command actions", () => {
       true,
     );
     expect(commands.find((command) => command.id === "plan")).toMatchObject({
-      command: "gittensory-mcp agent plan --login JSONbored --json",
+      command: "loopover-mcp agent plan --login JSONbored --json",
       state: "ready",
       copyable: true,
     });
@@ -28,13 +28,13 @@ describe("miner dashboard command actions", () => {
       commands.find((command) => command.id === "preflight"),
     ).toMatchObject({
       command:
-        "gittensory-mcp preflight --login JSONbored --repo JSONbored/gittensory --base origin/main --json",
+        "loopover-mcp preflight --login JSONbored --repo JSONbored/gittensory --base origin/main --json",
       state: "ready",
       copyable: true,
     });
     expect(commands.find((command) => command.id === "packet")).toMatchObject({
       command:
-        "gittensory-mcp agent packet --login JSONbored --repo JSONbored/gittensory --base origin/main --json",
+        "loopover-mcp agent packet --login JSONbored --repo JSONbored/gittensory --base origin/main --json",
       state: "ready",
       copyable: true,
     });
@@ -73,7 +73,7 @@ describe("miner dashboard command actions", () => {
     const serialized = JSON.stringify(commands);
 
     expect(commands.find((command) => command.id === "plan")).toMatchObject({
-      command: "gittensory-mcp agent plan --login your-login --json",
+      command: "loopover-mcp agent plan --login your-login --json",
       copyable: false,
       state: "needs_login",
     });
@@ -98,7 +98,7 @@ describe("miner dashboard command actions", () => {
     const preflight = commands.find((command) => command.id === "preflight");
     expect(preflight).toMatchObject({
       command:
-        "gittensory-mcp preflight --login trust-score --repo metamask/wallet-adapter --base origin/main --json",
+        "loopover-mcp preflight --login trust-score --repo metamask/wallet-adapter --base origin/main --json",
       copyable: true,
       state: "ready",
     });
@@ -106,6 +106,6 @@ describe("miner dashboard command actions", () => {
     expect(preflight?.command).not.toContain("[redacted]");
 
     const plan = commands.find((command) => command.id === "plan");
-    expect(plan).toMatchObject({ command: "gittensory-mcp agent plan --login trust-score --json", copyable: true });
+    expect(plan).toMatchObject({ command: "loopover-mcp agent plan --login trust-score --json", copyable: true });
   });
 });


### PR DESCRIPTION
## Summary
- Completes the rebrand for the marketing-site MCP quickstart snippets (bash CLI commands, TOML/JSON config examples) across 8 files under `apps/loopover-ui` that the original `docs/*.tsx`-scoped prose sweep missed since they live outside `docs/`: `animated-terminal.tsx`, `api/try-it.tsx`, `lib/miner-commands.ts`, `routes/{agents,api.index,app.index,index,miners}.tsx`.
- Also renames the stale `gittensory-miner` prose reference in `ams-observability-callout.tsx` and the `gittensory-analytics-*.csv` export filename in `csv-export.ts` (both discovered via the same audit, same category).
- Coordinated with `test/unit/miner-dashboard-commands.test.ts`, which asserts the exact `loopover-mcp ...` command strings `miner-commands.ts` produces.
- Left untouched (confirmed permanent exceptions): `try-it.tsx`'s `LEGACY_STORAGE_KEY` and `app.index.tsx`'s legacy onboarding `useLocalStorage` key -- both deliberate one-time migration fallbacks from an earlier PR.

## Test plan
- [x] Targeted vitest run across `miner-dashboard-commands.test.ts`, `try-it.test.ts`, `csv-export.test.ts` -- all pass
- [x] `npm --workspace @loopover/ui run lint` clean (fixed a prettier-formatting knock-on in `api.index.tsx` from the shorter string)
- [x] Full `npm run test:ci` gate green locally