### PR TITLE
fix(signals): filter public-unsafe wantedPaths/preferredLabels from manifest findings

### DIFF
--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -685,11 +685,16 @@ export function buildFocusManifestGuidance(args: {
   }
 
   if (manifest.wantedPaths.length > 0 && matchedWantedPaths.length === 0 && changedPaths.length > 0) {
+    // Public-safety filter before interpolation (#5945) -- mirrors safeExpectations below. manifest.wantedPaths
+    // is maintainer-authored and never public-safety-checked upstream; without this, a public-unsafe pattern
+    // would leak verbatim into a contributor-facing finding.
+    const safeWantedPaths = manifest.wantedPaths.filter(isFocusManifestPublicSafe).slice(0, 5);
+    const wantedPathsDetail = safeWantedPaths.length > 0 ? ` (${safeWantedPaths.join(", ")})` : "";
     findings.push({
       code: "manifest_off_focus",
       severity: "warning",
       title: "Change is outside maintainer-wanted areas",
-      detail: `No changed path matches the maintainer-wanted patterns (${manifest.wantedPaths.slice(0, 5).join(", ")}).`,
+      detail: `No changed path matches the maintainer-wanted patterns${wantedPathsDetail}.`,
       action: "Refocus the change onto a maintainer-wanted area or explain why this out-of-focus work is needed.",
     });
     publicNextSteps.push("Refocus onto the maintainer-wanted areas, or explain why this out-of-focus change is needed.");
@@ -706,11 +711,20 @@ export function buildFocusManifestGuidance(args: {
   }
 
   if (manifest.preferredLabels.length > 0 && preferredLabelHits.length === 0) {
+    // Public-safety filter before interpolation (#5945) -- mirrors safeExpectations below. Unlike
+    // manifest_off_focus, this finding's ENTIRE detail is built from the label list, so a zero-safe-entries
+    // fallback needs its own sentence, not just a dropped parenthetical -- the title text already says the
+    // same thing and is a static, always-public-safe string.
+    const safePreferredLabels = manifest.preferredLabels.filter(isFocusManifestPublicSafe).slice(0, 5);
+    const preferredLabelsDetail =
+      safePreferredLabels.length > 0
+        ? `Maintainer prefers labels: ${safePreferredLabels.join(", ")}.`
+        : "No maintainer-preferred label applied.";
     findings.push({
       code: "manifest_missing_preferred_label",
       severity: "info",
       title: "No maintainer-preferred label applied",
-      detail: `Maintainer prefers labels: ${manifest.preferredLabels.slice(0, 5).join(", ")}.`,
+      detail: preferredLabelsDetail,
       action: "Consider applying a maintainer-preferred label so triage stays aligned.",
     });
     publicNextSteps.push(`Consider a maintainer-preferred label (${manifest.preferredLabels.slice(0, 3).join(", ")}).`);

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -647,6 +647,28 @@ describe("buildFocusManifestGuidance", () => {
     expect(missingTests?.detail).not.toContain("wallet");
   });
 
+  it("filters public-unsafe wantedPaths/preferredLabels entries out of finding details (#5945)", () => {
+    // manifest_off_focus and manifest_missing_preferred_label interpolate wantedPaths/preferredLabels
+    // directly into contributor-facing detail text -- both are maintainer-authored and must be filtered
+    // through isFocusManifestPublicSafe before interpolation, same as testExpectations above (#3304).
+    const unsafeManifest = parseFocusManifest({ wantedPaths: ["wallet-onboarding/"], preferredLabels: ["reward-tracking"] });
+    const guidance = buildFocusManifestGuidance({
+      manifest: unsafeManifest,
+      changedPaths: ["src/x.ts"],
+      labels: [],
+      linkedIssueCount: 1,
+      testFileCount: 1,
+    });
+
+    const offFocus = guidance.findings.find((finding) => finding.code === "manifest_off_focus");
+    expect(offFocus?.detail).toBe("No changed path matches the maintainer-wanted patterns.");
+    expect(offFocus?.detail).not.toContain("wallet");
+
+    const missingLabel = guidance.findings.find((finding) => finding.code === "manifest_missing_preferred_label");
+    expect(missingLabel?.detail).toBe("No maintainer-preferred label applied.");
+    expect(missingLabel?.detail).not.toContain("reward");
+  });
+
   it("treats passing validation as satisfying test expectations", () => {
     const guidance = buildFocusManifestGuidance({ manifest: wanted, changedPaths: ["src/x.ts"], linkedIssueCount: 1, testFileCount: 0, passedValidationCount: 2 });
     expect(guidance.findings.some((finding) => finding.code === "manifest_missing_tests")).toBe(false);

--- a/test/unit/local-branch.test.ts
+++ b/test/unit/local-branch.test.ts
@@ -1660,6 +1660,40 @@ describe("local branch analysis", () => {
     expect(JSON.stringify(analysis.prPacket)).not.toMatch(/reward|score|wallet|hotkey|farming|payout|ranking|trust score/i);
   });
 
+  it("does not leak public-unsafe wantedPaths/preferredLabels through localFindings (#5945)", () => {
+    // manifestGuidance.findings is mapped verbatim into localFindings (the actual /v1 API + MCP
+    // exposure path), so a maintainer-authored public-unsafe wantedPaths/preferredLabels entry must
+    // already be filtered out of the finding detail upstream in buildFocusManifestGuidance -- this
+    // closes the contributor-facing exposure path, not just the guidance-builder unit above.
+    const analysis = buildLocalBranchAnalysis({
+      input: {
+        login: "oktofeesh1",
+        repoFullName: "entrius/allways-ui",
+        branchName: "fix-cache",
+        body: "Fixes #7",
+        changedFiles: [{ path: "src/cache.ts", additions: 4, deletions: 0, status: "modified" }],
+        focusManifest: {
+          source: "repo_file",
+          wantedPaths: ["wallet-onboarding/"],
+          preferredLabels: ["reward-tracking"],
+        },
+      },
+      repo,
+      issues: [{ repoFullName: repo.fullName, number: 7, title: "Cache refresh", state: "open", labels: [], linkedPrs: [] }],
+      pullRequests: [],
+      profile,
+      outcomeHistory,
+      scoringSnapshot,
+      scoringProfile,
+    });
+
+    const offFocus = analysis.localFindings.find((finding) => finding.code === "manifest_off_focus");
+    expect(offFocus?.detail).not.toContain("wallet");
+    const missingLabel = analysis.localFindings.find((finding) => finding.code === "manifest_missing_preferred_label");
+    expect(missingLabel?.detail).not.toContain("reward");
+    expect(JSON.stringify(analysis.localFindings)).not.toMatch(/wallet|reward/i);
+  });
+
   it("ignores a malformed focus manifest without breaking analysis", () => {
     const analysis = buildLocalBranchAnalysis({
       input: {


### PR DESCRIPTION
## Summary

- `manifest_off_focus` and `manifest_missing_preferred_label` interpolated `manifest.wantedPaths`/`manifest.preferredLabels` directly into contributor-facing finding `detail` text without the `isFocusManifestPublicSafe` filter already applied to `testExpectations` in the sibling `manifest_missing_tests` finding, letting a maintainer-authored public-unsafe term leak through `LocalBranchAnalysis.localFindings` (the `/v1` API + MCP exposure path) to contributors.
- Both findings now filter through `isFocusManifestPublicSafe` before interpolation, mirroring the existing `safeExpectations` pattern. `manifest_off_focus` drops the parenthetical when nothing is safe to show; `manifest_missing_preferred_label` falls back to a static "No maintainer-preferred label applied." sentence since its entire detail is built from the label list.
- `publicNextSteps.push(...)` in both blocks is left unchanged since it is already protected by the downstream `.filter(isFocusManifestPublicSafe)` applied when `safeNextSteps` is constructed.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This local Windows dev environment cannot run `wrangler` (`cf-typegen:check` fails with a pre-existing, change-unrelated `spawnSync wrangler ENOENT`), which blocks the chained `npm run test:ci` from reaching later steps locally. Each step was therefore run individually: `git diff --check`, `actionlint`, `db:migrations:check`, `db:schema-drift:check`, `selfhost:env-reference:check`, `miner:env-reference:check`, `selfhost:validate-observability`, engine build, `typecheck`, `test:engine-parity`, `test:live-gate-parity`, and `test:driver-parity` all pass clean on this branch. `test:coverage` was verified scoped to every test file that exercises the two changed source files (`focus-manifest.ts`, `local-branch.ts`), showing 100% coverage on every changed line/branch — the full unsharded run also hits unrelated pre-existing local flakiness (missing `sqlite3` CLI on PATH, subprocess-timing tests) in ~51 files outside this diff's scope, none of which touch `focus-manifest.ts`/`local-branch.ts`.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below — N/A, no UI change.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

N/A — backend-only fix, no visible UI change.

## Notes

- Closes #5945
