### PR TITLE
fix(review): treat a blank consentPhrase as unset in evaluateClaCheck (#5838)

### DIFF
--- a/packages/loopover-engine/src/review/cla-check.ts
+++ b/packages/loopover-engine/src/review/cla-check.ts
@@ -50,8 +50,13 @@ export function evaluateClaCheck(
   config: ClaCheckConfig,
   ctx: { body?: string | null | undefined; checkRunConclusion?: string | null | undefined },
 ): AdvisoryFinding[] {
-  if (config.consentPhrase === null && config.checkRunName === null) return []; // nothing configured ⇒ no finding
-  const phraseSatisfied = config.consentPhrase !== null && (ctx.body ?? "").toLowerCase().includes(config.consentPhrase.toLowerCase());
+  // A blank/whitespace-only consentPhrase is treated as unset (null), mirroring the config-as-code path's
+  // normalizeOptionalString (packages/loopover-engine/src/focus-manifest.ts): otherwise `"".includes("")` (or
+  // any body `.includes("")`) is unconditionally true, silently satisfying consent for every PR — the DB-backed
+  // dashboard `claConsentPhrase` field has no non-empty validation and reaches here via `?? null` unchanged (#5838).
+  const consentPhrase = config.consentPhrase !== null && config.consentPhrase.trim().length > 0 ? config.consentPhrase : null;
+  if (consentPhrase === null && config.checkRunName === null) return []; // nothing configured ⇒ no finding
+  const phraseSatisfied = consentPhrase !== null && (ctx.body ?? "").toLowerCase().includes(consentPhrase.toLowerCase());
   const checkRunSatisfied = config.checkRunName !== null && (ctx.checkRunConclusion === "success" || ctx.checkRunConclusion === "neutral");
   if (phraseSatisfied || checkRunSatisfied) return [];
   // A configured check-run whose conclusion is unresolved: cannot confirm OR deny consent via that method, so
@@ -69,7 +74,7 @@ export function evaluateClaCheck(
     ];
   }
   const missing: string[] = [];
-  if (config.consentPhrase !== null) missing.push(`the PR description must contain "${config.consentPhrase}"`);
+  if (consentPhrase !== null) missing.push(`the PR description must contain "${consentPhrase}"`);
   if (config.checkRunName !== null) missing.push(`the "${config.checkRunName}" check must pass`);
   return [
     {

--- a/src/review/cla-check.ts
+++ b/src/review/cla-check.ts
@@ -50,8 +50,13 @@ export function evaluateClaCheck(
   config: ClaCheckConfig,
   ctx: { body?: string | null | undefined; checkRunConclusion?: string | null | undefined },
 ): AdvisoryFinding[] {
-  if (config.consentPhrase === null && config.checkRunName === null) return []; // nothing configured ⇒ no finding
-  const phraseSatisfied = config.consentPhrase !== null && (ctx.body ?? "").toLowerCase().includes(config.consentPhrase.toLowerCase());
+  // A blank/whitespace-only consentPhrase is treated as unset (null), mirroring the config-as-code path's
+  // normalizeOptionalString (packages/loopover-engine/src/focus-manifest.ts): otherwise `"".includes("")` (or
+  // any body `.includes("")`) is unconditionally true, silently satisfying consent for every PR — the DB-backed
+  // dashboard `claConsentPhrase` field has no non-empty validation and reaches here via `?? null` unchanged (#5838).
+  const consentPhrase = config.consentPhrase !== null && config.consentPhrase.trim().length > 0 ? config.consentPhrase : null;
+  if (consentPhrase === null && config.checkRunName === null) return []; // nothing configured ⇒ no finding
+  const phraseSatisfied = consentPhrase !== null && (ctx.body ?? "").toLowerCase().includes(consentPhrase.toLowerCase());
   const checkRunSatisfied = config.checkRunName !== null && (ctx.checkRunConclusion === "success" || ctx.checkRunConclusion === "neutral");
   if (phraseSatisfied || checkRunSatisfied) return [];
   // A configured check-run whose conclusion is unresolved: cannot confirm OR deny consent via that method, so
@@ -69,7 +74,7 @@ export function evaluateClaCheck(
     ];
   }
   const missing: string[] = [];
-  if (config.consentPhrase !== null) missing.push(`the PR description must contain "${config.consentPhrase}"`);
+  if (consentPhrase !== null) missing.push(`the PR description must contain "${consentPhrase}"`);
   if (config.checkRunName !== null) missing.push(`the "${config.checkRunName}" check must pass`);
   return [
     {

--- a/test/unit/cla-check.test.ts
+++ b/test/unit/cla-check.test.ts
@@ -73,6 +73,33 @@ describe("evaluateClaCheck (#2564)", () => {
     });
   });
 
+  // #5838: a blank/whitespace-only consentPhrase must normalize to null (unset), matching the config-as-code
+  // path's normalizeOptionalString — otherwise `body.includes("")` is unconditionally true, silently satisfying
+  // CLA consent for every PR (a gate bypass reachable via a fat-fingered blank save of the dashboard field).
+  describe("blank consentPhrase normalizes to unset (regression for #5838)", () => {
+    it("an empty-string consentPhrase as the ONLY configured method → nothing configured, no finding (not auto-satisfied)", () => {
+      expect(evaluateClaCheck(config({ consentPhrase: "" }), { body: "no consent statement here" })).toEqual([]);
+    });
+
+    it("a whitespace-only consentPhrase as the ONLY configured method → nothing configured, no finding", () => {
+      expect(evaluateClaCheck(config({ consentPhrase: "   " }), { body: "no consent statement here" })).toEqual([]);
+    });
+
+    it("an empty-string consentPhrase with a configured check-run behaves as if the phrase were null (unresolved → HOLD)", () => {
+      const out = evaluateClaCheck(config({ consentPhrase: "", checkRunName: "CLA Assistant Lite" }), { body: "no phrase here", checkRunConclusion: undefined });
+      expect(out).toHaveLength(1);
+      expect(out[0]?.code).toBe(CLA_CHECK_UNRESOLVED_CODE);
+    });
+
+    it("an empty-string consentPhrase with a resolved-failing check-run → cla_consent_missing lists only the check, never the blank phrase", () => {
+      const out = evaluateClaCheck(config({ consentPhrase: "", checkRunName: "CLA Assistant Lite" }), { body: "no phrase here", checkRunConclusion: "failure" });
+      expect(out).toHaveLength(1);
+      expect(out[0]?.code).toBe(CLA_CONSENT_MISSING_CODE);
+      expect(out[0]?.detail).toContain('the "CLA Assistant Lite" check must pass');
+      expect(out[0]?.detail).not.toContain("the PR description must contain");
+    });
+  });
+
   describe("either-method contract (both configured)", () => {
     it("phrase satisfied, check-run unresolved → satisfied (phrase alone decides; no hold)", () => {
       const out = evaluateClaCheck(config({ consentPhrase: "agree to the CLA", checkRunName: "CLA Assistant Lite" }), {

--- a/test/unit/predicted-gate-engine-branch-coverage.test.ts
+++ b/test/unit/predicted-gate-engine-branch-coverage.test.ts
@@ -118,6 +118,12 @@ describe("predicted-gate engine branch coverage (#2283)", () => {
     expect(evaluateClaCheck({ consentPhrase: "I agree", checkRunName: "CLA Bot" }, { body: "nope", checkRunConclusion: undefined })[0]?.code).toBe(
       CLA_CHECK_UNRESOLVED_CODE,
     );
+    // #5838: a blank/whitespace-only consentPhrase normalizes to null (unset), so it never auto-satisfies consent.
+    expect(evaluateClaCheck({ consentPhrase: "", checkRunName: null }, { body: "no consent here" })).toEqual([]);
+    expect(evaluateClaCheck({ consentPhrase: "   ", checkRunName: null }, { body: "no consent here" })).toEqual([]);
+    expect(evaluateClaCheck({ consentPhrase: "", checkRunName: "CLA Bot" }, { body: "nope", checkRunConclusion: undefined })[0]?.code).toBe(
+      CLA_CHECK_UNRESOLVED_CODE,
+    );
     expect(guardrailPathMatches(["src/a.ts"], ["src/a.ts"])).toEqual([{ path: "src/a.ts", glob: "src/a.ts" }]);
     expect(guardrailPathMatches(["other.ts"], ["src/a.ts"])).toEqual([]);
     const pathological = "src/*-*-*-final.ts";


### PR DESCRIPTION
## Summary

Closes #5838.

`evaluateClaCheck` (`src/review/cla-check.ts`) computed
`phraseSatisfied = config.consentPhrase !== null && (ctx.body ?? "").toLowerCase().includes(config.consentPhrase.toLowerCase())`.
When `consentPhrase` is the **empty string `""`** (distinct from `null`/unset), `"" !== null` is `true` and
`body.includes("")` is **unconditionally `true`**, so phrase-match detection silently satisfied CLA consent for
**every** PR — a real gate bypass.

This is reachable in practice: `claConsentPhrase` is a dashboard/API-settable field defined in
`src/openapi/schemas.ts` as `z.string().nullable().optional()` with **no non-empty validation**, and it flows into
`evaluateClaCheck`'s config unmodified — `src/queue/processors.ts` passes `consentPhrase: settings.claConsentPhrase ?? null`,
where `?? null` only substitutes for `undefined`/`null`, not `""`. A maintainer who saves a blank value on this field
(without also turning `claMode` off) silently disables the entire CLA gate, with no warning anywhere.

The fix normalizes a blank/whitespace-only `consentPhrase` to `null` once at the top of `evaluateClaCheck` and threads
the normalized value through every use site, mirroring the config-as-code path's `normalizeOptionalString`
(`packages/loopover-engine/src/focus-manifest.ts`), which already treats an empty/whitespace-only string as `null`. A
blank phrase now behaves identically to leaving the field unset: the check-run method (if configured) decides,
otherwise no finding is produced — closing the gap that existed only on the DB-backed, dashboard-settable path.

The fix is applied identically to both hand-duplicated twins (`src/review/cla-check.ts` and
`packages/loopover-engine/src/review/cla-check.ts`) so the engine-parity check stays green.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran the full `npm run test:ci` gate (exit 0) plus `npm audit --audit-level=moderate` (0 vulnerabilities). Both twin copies of `cla-check.ts` measured at 100% patch coverage (lines and branches) on the changed lines via the unsharded `npm run test:coverage`.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

Notes on the Safety boxes: this is a deterministic, side-effect-free evaluator change with **no** UI, API/OpenAPI, or auth/CORS/session surface — the negative-path testing that applies here is the CLA-consent gate's own negative paths, which are covered: the new tests assert that a blank/whitespace-only `consentPhrase` does **not** auto-satisfy consent and instead defers to the check-run method (hold) or produces `cla_consent_missing`, exactly as an unset phrase would. No public-facing text or forbidden terms are added.

## UI Evidence

Not applicable — backend-only change to a deterministic evaluator; no visible UI, frontend, docs, or extension surface.

## Notes

- New/updated tests: `test/unit/cla-check.test.ts` gains a `blank consentPhrase normalizes to unset (regression for #5838)` block covering the empty-string and whitespace-only cases in both the phrase-only and phrase+check-run configurations, asserting the blank phrase never appears in the `cla_consent_missing` detail text. `test/unit/predicted-gate-engine-branch-coverage.test.ts` gains the equivalent cases against the `@loopover/engine` twin so both Codecov-measured copies hit 100% branch coverage on the changed lines.
- The existing non-empty `consentPhrase` behavior (the documented "either method holds" contract, the unresolved-check-run hold, and the `cla_consent_missing`/`cla_check_unresolved` codes) is unchanged.
