### PR TITLE
fix(review): sanitize control characters in RAG chunk text before Postgres insert

### DIFF
--- a/src/review/rag.ts
+++ b/src/review/rag.ts
@@ -185,6 +185,13 @@ export interface ChunkOpts {
 export function chunkFile(path: string, text: string, namespace = "", opts?: ChunkOpts): RagChunk[] {
   const kind = classifyRepoFile(path);
   if (kind === "skip" || !text.trim()) return [];
+  // Strip Unicode control characters (excluding tab/LF/CR, meaningful in source text) before any chunk
+  // is built. Postgres TEXT columns hard-reject a literal NUL byte ("invalid byte sequence for encoding
+  // UTF8: 0x00") -- TextDecoder passes NUL through unchanged (it's valid UTF-8), so a file containing
+  // one poisoned every chunk built from it, permanently: blob_sha only advances on success, so the same
+  // file re-failed the whole upsert batch (up to 49 otherwise-good chunks rolled back with it) on every
+  // push and cron retry (GITTENSORY-D).
+  text = text.replace(/(?![\t\n\r])\p{Cc}/gu, " ");
   // Clamp to safe ranges: chunkChars must be >= 1 (a 0/negative budget makes newlineChunks loop forever on an
   // oversized file — a misconfig DOS) and overlap must be < chunkChars (else `end - overlap` can't advance).
   // (#rag-verify infinite-loop guard)

--- a/test/unit/rag.test.ts
+++ b/test/unit/rag.test.ts
@@ -195,6 +195,20 @@ describe("rag: per-file chunking", () => {
     expect(chunkFile("src/a.ts", "   ")).toEqual([]);
   });
 
+  it("REGRESSION (GITTENSORY-D): strips a NUL byte instead of letting it reach the chunk (Postgres TEXT columns reject it outright)", () => {
+    const chunks = chunkFile("src/a.ts", "export const x = 1;\0\n");
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0]?.text.includes("\0")).toBe(false);
+    expect(chunks[0]?.text).toBe("export const x = 1; \n");
+  });
+
+  it("REGRESSION (GITTENSORY-D): strips other control characters too, but preserves tab/newline/CR (meaningful in source text)", () => {
+    const text = chunkFile("src/a.ts", "export const x = 1;\t// SOH:\x01 US:\x1f DEL:\x7f\r\n")[0]?.text ?? "";
+    expect(text).not.toMatch(/[\x01\x1f\x7f]/);
+    expect(text).toContain("\t");
+    expect(text).toContain("\r\n");
+  });
+
   it("REGRESSION (#4996): filters out an individual whitespace-only chunk, even though the whole file is non-empty (the most plausible cause of production ai_embed_http_400s)", () => {
     // chunkChars=10, overlap=0: chunk0 = 10 X's, chunk1 = 10 SPACES (whitespace-only -- must be dropped),
     // chunk2 = 10 Y's. Non-JS path (.py) so this exercises newlineChunks, the chunker actually used in prod


### PR DESCRIPTION
## Summary
- Root cause of the recurring `GITTENSORY-D` production error (`invalid byte sequence for encoding "UTF8": 0x00`, 538 occurrences over 2.5 weeks and counting): a repo file containing a literal NUL byte poisoned every RAG chunk built from it, permanently. Postgres `TEXT` columns hard-reject `0x00`, but `TextDecoder` passes it through unchanged since NUL is technically valid UTF-8. Since `blob_sha` only advances on success, the same file re-failed the whole `upsertChunks` batch (up to 49 otherwise-good chunks rolled back with it, since one transaction covers a 50-chunk batch) on every push and cron retry, indefinitely.
- Fix: strip Unicode control characters in `chunkFile` -- the single, centralized entry point all chunking (both `chunkJsTs` and `newlineChunks`) flows through -- excluding tab/LF/CR, which are meaningful in real source text (this is code/doc content, not comment prose). Matches the existing control-character sanitization convention already used in `src/github/commands.ts`, `src/review/unified-comment-bridge.ts`, and `src/services/ai-review.ts` for the same class of problem in different contexts.

## Test plan
- [x] Two new regression tests in `test/unit/rag.test.ts`: a NUL byte is stripped and doesn't reach the chunk; other control characters (SOH, US, DEL) are also stripped while tab/LF/CR are preserved
- [x] Full `test/unit/rag.test.ts` suite (100 tests) passes
- [x] `npm run typecheck` clean
- [x] Full `npm run test:ci` gate green locally