### PR TITLE
fix(selfhost): preserve stack traces and split fingerprints for RAG/enrichment Sentry captures

### DIFF
--- a/src/review/enrichment-wire.ts
+++ b/src/review/enrichment-wire.ts
@@ -9,6 +9,7 @@
 import { extractLinkedIssueNumbers, getIssue } from "../db/repositories";
 import { sanitizePublicComment } from "../queue-intelligence";
 import { incr, observe } from "../selfhost/metrics";
+import { errorStack } from "../utils/json";
 import { neutralizePromptInjection } from "./prompt-injection";
 import { REES_ANALYZER_NAMES, REES_ANALYZER_NAME_SET, type ReesAnalyzerName } from "./enrichment-analyzer-names";
 import type { PullRequestFileRecord } from "../types";
@@ -492,10 +493,11 @@ export async function buildReviewEnrichment(
         JSON.stringify({
           level: "error",
           event: "review_context_fetch_failed",
+          contextType: "enrichment",
+          ev: "enrichment_http_error",
           repository: input.repoFullName,
           pullNumber: input.prNumber,
           headShaPrefix: headShaPrefix(input.headSha),
-          contextType: "enrichment",
           status: response.status,
           statusText: response.statusText,
           requestId,
@@ -550,10 +552,11 @@ export async function buildReviewEnrichment(
       JSON.stringify({
         level: "error",
         event: "review_context_fetch_failed",
+        contextType: "enrichment",
+        ev: isTimeout ? "enrichment_timeout" : "enrichment_exception",
         repository: input.repoFullName,
         pullNumber: input.prNumber,
         headShaPrefix: headShaPrefix(input.headSha),
-        contextType: "enrichment",
         requestId,
         timeoutMs,
         analyzerBudgetMs,
@@ -563,6 +566,7 @@ export async function buildReviewEnrichment(
         authHeaderSent: authConfigured,
         authSecretNormalized,
         message: String(error).slice(0, 200),
+        stack: errorStack(error),
       }),
     );
     return undefined; // timeout / network / parse ⇒ fail-safe; review proceeds without the brief

--- a/src/review/rag.ts
+++ b/src/review/rag.ts
@@ -21,6 +21,8 @@
 // agent-config + the engine) + the Cloudflare bindings, and belong to the host's review path — not this
 // additive module. The host injects concrete adapters at the call site.
 
+import { errorStack } from "../utils/json";
+
 // ── Injected infra interfaces (inlined from reviewbot src/platform/types.ts) ──────────────────────
 // These mirror the platform-adapter shapes so the host can pass its Vectorize/self-host-AI/D1-backed
 // implementations unchanged; nothing here depends on env bindings.
@@ -413,7 +415,7 @@ export async function embedTexts(
           ev: "rag_embed_batch_degraded",
           batchSize: batch.length,
           failedCount,
-          ...(batchError ? { message: String(batchError).slice(0, 200) } : {}),
+          ...(batchError ? { message: String(batchError).slice(0, 200), stack: errorStack(batchError) } : {}),
         }),
       );
     }
@@ -461,7 +463,7 @@ export async function upsertChunks(infra: RagInfra, project: string, repo: strin
     return embedded.length;
   } catch (error) {
     // ERROR level (#3894): see embedTexts's catch above -- same invisible-to-Sentry fix, same umbrella.
-    console.error(JSON.stringify({ level: "error", event: "review_context_fetch_failed", contextType: "rag", ev: "rag_upsert_error", message: String(error).slice(0, 200) }));
+    console.error(JSON.stringify({ level: "error", event: "review_context_fetch_failed", contextType: "rag", ev: "rag_upsert_error", message: String(error).slice(0, 200), stack: errorStack(error) }));
     return 0;
   }
 }
@@ -490,7 +492,7 @@ export async function deleteChunksForPaths(infra: RagInfra, project: string, rep
     }
   } catch (error) {
     // ERROR level (#3894): see embedTexts's catch above -- same invisible-to-Sentry fix, same umbrella.
-    console.error(JSON.stringify({ level: "error", event: "review_context_fetch_failed", contextType: "rag", ev: "rag_delete_error", message: String(error).slice(0, 200) }));
+    console.error(JSON.stringify({ level: "error", event: "review_context_fetch_failed", contextType: "rag", ev: "rag_delete_error", message: String(error).slice(0, 200), stack: errorStack(error) }));
   }
 }
 
@@ -606,7 +608,7 @@ export async function retrieveContextWithMetrics(
     // ERROR level (#5 review observability): emit so the central Sentry forwarder captures a broken RAG backend
     // (qdrant/embedder down) — retrieval degrades the review to diff-only, and this was previously a no-`level`
     // console.log invisible to Sentry. Keeps the `ev` tag for log continuity.
-    console.error(JSON.stringify({ level: "error", event: "review_context_fetch_failed", contextType: "rag", ev: "rag_retrieve_error", message: String(error).slice(0, 200) }));
+    console.error(JSON.stringify({ level: "error", event: "review_context_fetch_failed", contextType: "rag", ev: "rag_retrieve_error", message: String(error).slice(0, 200), stack: errorStack(error) }));
     return emptyRagRetrievalResult(configuredMinScore);
   }
 }
@@ -698,7 +700,7 @@ export async function readChunkTexts(storage: StorageAdapter, project: string, r
     for (const r of rows.results ?? []) map.set(r.id, r.text);
   } catch (error) {
     // ERROR level (#3894): see embedTexts's catch above -- same invisible-to-Sentry fix, same umbrella.
-    console.error(JSON.stringify({ level: "error", event: "review_context_fetch_failed", contextType: "rag", ev: "rag_chunk_read_error", message: String(error).slice(0, 200) }));
+    console.error(JSON.stringify({ level: "error", event: "review_context_fetch_failed", contextType: "rag", ev: "rag_chunk_read_error", message: String(error).slice(0, 200), stack: errorStack(error) }));
   }
   return map;
 }

--- a/src/selfhost/sentry.ts
+++ b/src/selfhost/sentry.ts
@@ -492,7 +492,9 @@ function namedCaptureError(error: unknown, eventName?: string): Error {
  *  Sentry's default stack-trace-based grouping fragments the SAME logical failure into separate issues whenever
  *  it is captured from more than one call site (e.g. two different functions each constructing the identical
  *  `new Error("...")` message), which is exactly what happened to GITTENSORY-5/10 and GITTENSORY-C/W before this.
- *  Mirrors forwardStructuredLogToSentry's identical `scope.setFingerprint(["loopover-log", event])` discipline. */
+ *  Mirrors forwardStructuredLogToSentry's identical `scope.setFingerprint(["loopover-log", event, ev?])`
+ *  discipline (the `ev` sub-field, when present, further splits one broad `event` slug shared by several call
+ *  sites into separate issues per actual failure mode -- see that function's own comment). */
 export function captureError(
   error: unknown,
   context?: Record<string, unknown>,
@@ -633,6 +635,13 @@ export function forwardStructuredLogToSentry(line: unknown, fromErrorSink = fals
   // Sentry's own native level string (setLevel below) — critical maps back to "fatal", its Sentry-native spelling.
   const severity = loopoverSeverity === "critical" ? "fatal" : loopoverSeverity === "warning" ? "warning" : loopoverSeverity === "info" ? "info" : "error";
   const event = typeof obj.event === "string" ? obj.event : undefined;
+  // Many call sites share one broad `event` slug (e.g. every RAG failure mode logs `event:
+  // "review_context_fetch_failed"`) and rely on a finer-grained `ev` field to distinguish WHICH failure it
+  // actually was (rag_upsert_error vs. rag_retrieve_error vs. ...). Fold `ev` into both the title and the
+  // fingerprint below when present, so genuinely different failures never collapse into one misleading issue
+  // bucket that mixes their causes together (confirmed in the wild: GITTENSORY-D's own event history mixes a
+  // context-length-overflow case with an unrelated Postgres NUL-byte-rejection case).
+  const subEvent = typeof obj.ev === "string" ? obj.ev : undefined;
   // Lead the Sentry title with the real failure detail (message → error), not just the event slug, so an operator
   // sees WHAT broke straight from the issue list instead of having to open the context blob.
   const detail = typeof obj.message === "string" ? obj.message : typeof obj.error === "string" ? obj.error : undefined;
@@ -650,7 +659,7 @@ export function forwardStructuredLogToSentry(line: unknown, fromErrorSink = fals
       .filter(Boolean)
       .join(" ") || "(no message — see the log context)");
   const errorEvent = new Error(value);
-  errorEvent.name = event ?? "LoopOverLog";
+  errorEvent.name = event ? (subEvent ? `${event}/${subEvent}` : event) : "LoopOverLog";
   // This exception is synthetic: it was minted from a console line, never thrown at the failing code. Strip the
   // wrapper stack so Sentry does not attribute forwarded operational issues to this forwarding helper.
   errorEvent.stack = `${errorEvent.name}: ${value}`;
@@ -660,8 +669,8 @@ export function forwardStructuredLogToSentry(line: unknown, fromErrorSink = fals
     scope.setContext("log", safeObj);
     if (event) safeObj.event = event;
     applyOperationalTags(scope, safeObj);
-    // Group recurrences of ONE failure into a single issue (by event, not the variable detail in the value).
-    if (event) scope.setFingerprint(["loopover-log", event]);
+    // Group recurrences of ONE failure into a single issue (by event + ev, not the variable detail in the value).
+    if (event) scope.setFingerprint(["loopover-log", event, ...(subEvent ? [subEvent] : [])]);
     // Sentry uses event.transaction as the issue culprit fallback when the stack has no frames; point it at the
     // operational event slug rather than the forwarding helper.
     if (event)

--- a/src/utils/json.ts
+++ b/src/utils/json.ts
@@ -24,6 +24,16 @@ export function strippedErrorMessage(error: unknown, fallback: string): string {
   return message.replace(/^Error: /, "") || fallback;
 }
 
+/** A truncated stack trace for structured-log JSON context, when the caught value is a real Error. Sentry's
+ *  generic console-forwarder (sentry.ts's forwardStructuredLogToSentry) never sees the original Error object,
+ *  only the already-`JSON.stringify`d line — this is the only way a stack reaches Sentry for a fail-safe catch
+ *  that logs rather than calling captureError directly (console.error is always auto-forwarded, so an explicit
+ *  captureError call alongside it would double-capture the same failure). Capped short: a full stack rarely adds
+ *  diagnostic value over the first several frames and would bloat every log line. */
+export function errorStack(error: unknown, maxLength = 500): string | undefined {
+  return error instanceof Error && error.stack ? error.stack.slice(0, maxLength) : undefined;
+}
+
 export function normalizeRepoFullName(value: string): string {
   return value.trim();
 }

--- a/test/unit/json-utils.test.ts
+++ b/test/unit/json-utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { errorMessage, jsonString, normalizeRepoFullName, nowIso, parseJson, repoParts, strippedErrorMessage } from "../../src/utils/json";
+import { errorMessage, errorStack, jsonString, normalizeRepoFullName, nowIso, parseJson, repoParts, strippedErrorMessage } from "../../src/utils/json";
 
 describe("JSON and string utility helpers", () => {
   it("keeps JSON parsing and stringification fallbacks explicit", () => {
@@ -27,6 +27,18 @@ describe("JSON and string utility helpers", () => {
     expect(errorMessage("string failure", "fallback failure")).toBe("fallback failure");
     expect(strippedErrorMessage(new Error("Error: wrapped failure"), "fallback failure")).toBe("wrapped failure");
     expect(strippedErrorMessage("string failure", "fallback failure")).toBe("fallback failure");
+  });
+
+  it("errorStack extracts a real Error's stack, truncated, and returns undefined for anything else (#5010-observability)", () => {
+    const err = new Error("boom");
+    expect(errorStack(err)).toBe(err.stack?.slice(0, 500));
+    expect(errorStack(err, 5)).toBe(err.stack?.slice(0, 5));
+    expect(errorStack("string failure")).toBeUndefined();
+    expect(errorStack(null)).toBeUndefined();
+    expect(errorStack(undefined)).toBeUndefined();
+    const noStack = new Error("no stack");
+    (noStack as { stack?: string | undefined }).stack = undefined;
+    expect(errorStack(noStack)).toBeUndefined();
   });
 
   it("repoParts trims outer whitespace before splitting, matching normalizeRepoFullName", () => {

--- a/test/unit/selfhost-sentry.test.ts
+++ b/test/unit/selfhost-sentry.test.ts
@@ -981,6 +981,42 @@ describe("forwardStructuredLogToSentry — central console.log → Sentry error 
     expect(mocks.scope.setFingerprint).toHaveBeenCalledWith(["loopover-log", "orb_broker_unavailable"]);
   });
 
+  it("REGRESSION (GITTENSORY-D): further splits the fingerprint + title by the `ev` sub-field, so several call sites sharing one broad `event` slug don't collapse into one misleading issue", async () => {
+    await initSentry({ SENTRY_DSN: "d" } as unknown as NodeJS.ProcessEnv);
+    forwardStructuredLogToSentry(
+      JSON.stringify({
+        level: "error",
+        event: "review_context_fetch_failed",
+        ev: "rag_upsert_error",
+        message: "invalid byte sequence for encoding \"UTF8\": 0x00",
+      }),
+    );
+    expect(lastCapturedError().name).toBe("review_context_fetch_failed/rag_upsert_error");
+    expect(mocks.scope.setFingerprint).toHaveBeenCalledWith([
+      "loopover-log",
+      "review_context_fetch_failed",
+      "rag_upsert_error",
+    ]);
+  });
+
+  it("falls back to the plain event-only fingerprint + title when `ev` is absent (unchanged behavior)", async () => {
+    await initSentry({ SENTRY_DSN: "d" } as unknown as NodeJS.ProcessEnv);
+    forwardStructuredLogToSentry(
+      JSON.stringify({ level: "error", event: "review_context_fetch_failed", message: "no sub-event here" }),
+    );
+    expect(lastCapturedError().name).toBe("review_context_fetch_failed");
+    expect(mocks.scope.setFingerprint).toHaveBeenCalledWith(["loopover-log", "review_context_fetch_failed"]);
+  });
+
+  it("ignores a non-string `ev` field (treats it the same as absent)", async () => {
+    await initSentry({ SENTRY_DSN: "d" } as unknown as NodeJS.ProcessEnv);
+    forwardStructuredLogToSentry(
+      JSON.stringify({ level: "error", event: "review_context_fetch_failed", ev: 42, message: "m" }),
+    );
+    expect(lastCapturedError().name).toBe("review_context_fetch_failed");
+    expect(mocks.scope.setFingerprint).toHaveBeenCalledWith(["loopover-log", "review_context_fetch_failed"]);
+  });
+
   it("strips the synthetic wrapper stack so the issue culprit is not forwardStructuredLogToSentry", async () => {
     await initSentry({ SENTRY_DSN: "d" } as unknown as NodeJS.ProcessEnv);
     forwardStructuredLogToSentry(


### PR DESCRIPTION
## Summary
Two confirmed instrumentation gaps found while investigating the recurring `GITTENSORY-D` production issue (see #5969 for the actual bug that issue was masking):

1. **Fingerprint collapse**: 7 distinct error call sites (5 in `rag.ts`, 2 in `enrichment-wire.ts`) share one top-level `event` field (`review_context_fetch_failed`), and `forwardStructuredLogToSentry` fingerprinted only on that field -- merging genuinely different failures into one misleading Sentry issue. Confirmed in the wild: a prior fix's own comment (`rag.ts:357`) attributes `GITTENSORY-D` to a context-length overflow, while the specific event analyzed for #5969 was an unrelated Postgres NUL-byte rejection -- both got bucketed under the same issue. Now folds the existing `ev` sub-field into both the Sentry issue title and the fingerprint when present, so each failure mode gets its own issue going forward. Added `ev` to `enrichment-wire.ts`'s 2 sites too (previously missing) for full coverage across all 7.
2. **Stack traces discarded**: these catch blocks reduce the caught `Error` to a truncated message string before logging, and the generic console-forwarder never has the original `Error` object to begin with -- by design, it only ever sees an already-`JSON.stringify`d line. Added a new `errorStack()` helper (`src/utils/json.ts`, alongside the existing `errorMessage`/`strippedErrorMessage`) and included it in the logged JSON context wherever available.

**Explicitly did NOT** add a parallel `captureError()` call at these sites: `console.error` is unconditionally auto-forwarded to Sentry (confirmed via `src/selfhost/sentry.ts`'s `installStructuredLogForwarding`), so an explicit capture alongside the existing `console.error` would double-report every single failure.

## Test plan
- [x] 3 new tests in `test/unit/selfhost-sentry.test.ts`: `ev` splits the fingerprint + title, falls back cleanly when absent, ignores a non-string `ev`
- [x] New test in `test/unit/json-utils.test.ts` covering `errorStack`'s Error/non-Error/no-stack/truncation branches
- [x] `test/unit/enrichment-wire.test.ts` and `test/unit/rag.test.ts` both pass unchanged (158 tests), confirming no behavior regression
- [x] `npm run typecheck` clean
- [x] Full `npm run test:ci` gate green locally