### PR TITLE
feat(selfhost): add --json output mode to loopover-config-lint

### DIFF
--- a/scripts/loopover-config-lint.ts
+++ b/scripts/loopover-config-lint.ts
@@ -8,14 +8,15 @@ import { lintManifestText, type SelfHostConfigLintResult } from "../src/selfhost
 import { MAX_FOCUS_MANIFEST_BYTES } from "../src/signals/focus-manifest";
 
 function usage(): string {
-  return `Usage: npm run selfhost:config-lint -- [path]
+  return `Usage: npm run selfhost:config-lint -- [path] [--json]
 
 Validates a LoopOver focus manifest (.loopover.yml, a per-repo/global self-host
 private-config file, or any equivalent YAML/JSON file with the same shape) and reports
 unrecognized top-level fields and parser warnings, without echoing any of the file's values.
 
 Options:
-  path   Manifest file to lint. Defaults to ".loopover.yml" in the current directory.`;
+  path    Manifest file to lint. Defaults to ".loopover.yml" in the current directory.
+  --json  Print the lint result as JSON instead of the human-formatted report.`;
 }
 
 export function readManifestTextForLint(path: string): string {
@@ -50,7 +51,8 @@ function main(): void {
     console.log(usage());
     return;
   }
-  const path = args[0] ?? ".loopover.yml";
+  const jsonMode = args.includes("--json");
+  const path = args.find((arg) => !arg.startsWith("--")) ?? ".loopover.yml";
   let text;
   try {
     text = readManifestTextForLint(path);
@@ -60,7 +62,7 @@ function main(): void {
     process.exit(1);
   }
   const result = lintManifestText(text);
-  console.log(formatLintReport(path, result));
+  console.log(jsonMode ? JSON.stringify({ path, ...result }, null, 2) : formatLintReport(path, result));
   if (!result.ok) process.exit(1);
 }
 

--- a/test/unit/loopover-config-lint-script.test.ts
+++ b/test/unit/loopover-config-lint-script.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from "node:child_process";
 import { mkdtempSync, mkdirSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -5,6 +6,8 @@ import { describe, expect, it } from "vitest";
 import { formatLintReport, readManifestTextForLint } from "../../scripts/loopover-config-lint";
 import { lintManifestText } from "../../src/selfhost/config-lint";
 import { MAX_FOCUS_MANIFEST_BYTES } from "../../src/signals/focus-manifest";
+
+const TSX_BIN = join(process.cwd(), "node_modules", ".bin", "tsx");
 
 describe("formatLintReport (#2906)", () => {
   it("reports a valid manifest's summary and recognized fields, no warnings", () => {
@@ -93,5 +96,73 @@ describe("readManifestTextForLint (#2923 regression)", () => {
 
       expect(() => readManifestTextForLint(path)).toThrow(`file exceeds ${MAX_FOCUS_MANIFEST_BYTES} bytes: ${path}`);
     });
+  });
+});
+
+describe("loopover-config-lint --json (#5931)", () => {
+  function withTempDir(run: (dir: string) => void): void {
+    const dir = mkdtempSync(join(tmpdir(), "gittensory-config-lint-json-"));
+    try {
+      run(dir);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }
+
+  it("prints a parseable JSON report for a clean manifest and exits 0", () => {
+    withTempDir((dir) => {
+      const path = join(dir, "manifest.yml");
+      writeFileSync(path, "wantedPaths:\n  - src/\n");
+
+      const stdout = execFileSync(TSX_BIN, ["scripts/loopover-config-lint.ts", path, "--json"], {
+        encoding: "utf8",
+      });
+
+      expect(JSON.parse(stdout)).toEqual({
+        path,
+        ok: true,
+        warnings: [],
+        recognizedFields: ["wantedPaths"],
+        summary: "Manifest parsed 1 recognized field.",
+      });
+    });
+  });
+
+  it("prints a parseable JSON report for a manifest with an unknown field and exits 1", () => {
+    withTempDir((dir) => {
+      const path = join(dir, "manifest.yml");
+      writeFileSync(path, "unknownSecretKey: super-secret-value\n");
+
+      let stdout = "";
+      let status = 0;
+      try {
+        stdout = execFileSync(TSX_BIN, ["scripts/loopover-config-lint.ts", path, "--json"], {
+          encoding: "utf8",
+        });
+      } catch (error) {
+        stdout = String((error as { stdout?: string }).stdout ?? "");
+        status = (error as { status?: number }).status ?? 0;
+      }
+
+      expect(status).toBe(1);
+      expect(JSON.parse(stdout)).toEqual({
+        path,
+        ok: false,
+        warnings: [
+          "Manifest contained no recognized focus fields; falling back to deterministic signals.",
+          "Manifest contains unknown top-level field: unknownSecretKey.",
+        ],
+        recognizedFields: [],
+        summary: "Manifest has 2 warnings.",
+      });
+      // Never echoes the raw supplied value into the JSON report either (mirrors formatLintReport's redaction).
+      expect(stdout).not.toContain("super-secret-value");
+    });
+  });
+
+  it("documents --json in the CLI's usage/help text", () => {
+    const stdout = execFileSync(TSX_BIN, ["scripts/loopover-config-lint.ts", "--help"], { encoding: "utf8" });
+
+    expect(stdout).toContain("--json");
   });
 });


### PR DESCRIPTION
## Summary

- `scripts/loopover-config-lint.ts` only printed the human-formatted `formatLintReport()` text; every sibling contributor-facing validator CLI (`loopover-mcp validate-config`, `doctor`, `status`) already supports `--json`. Added a `--json` flag that prints `{ path, ...result }` (the full `SelfHostConfigLintResult`: `ok`, `warnings`, `recognizedFields`, `summary`) instead, keeping the same `process.exit(1)` behavior on `!result.ok` and leaving the default text output and `readManifestTextForLint` error handling unchanged.
- Updated `usage()`'s `Usage:` line and `Options:` block to document `--json`.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — `scripts/**` is excluded from Codecov's `coverage.include`/`codecov.yml` ignore list, so this change carries no patch-coverage obligation; added a real subprocess regression test instead (see below).
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries — extended `test/unit/loopover-config-lint-script.test.ts` with real `tsx scripts/loopover-config-lint.ts ... --json` subprocess invocations covering a clean manifest (`ok: true`, exit 0), a manifest with an unknown field (`ok: false`, exit 1, and confirms the raw value is still never echoed), and that `--help` documents the new flag.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session surface touched.)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/OpenAPI/MCP surface touched.)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI changed.)
- [x] Visible UI changes include a `UI Evidence` section below with screenshots. (N/A — CLI-only change, no visible UI surface.)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Scoped exactly to the issue's requirements: no change to `readManifestTextForLint`'s error-path handling (still plain-text to stderr), no widening of `main()`'s existing `v8 ignore` block beyond the trivial new `--json` branch it already covers as CLI-entrypoint glue.
