### PR TITLE
fix/issue 5934

### DIFF
--- a/scripts/export-miner-prometheus-textfile.sh
+++ b/scripts/export-miner-prometheus-textfile.sh
@@ -19,7 +19,7 @@ set -eu
 # aborting the whole export -- Prometheus treats an absent series as "no data", not an error, so a partial
 # export is strictly better than a stale-forever or entirely-missing one.
 
-MINER_BIN="${LOOPOVER_MINER_BIN:-gittensory-miner}"
+MINER_BIN="${LOOPOVER_MINER_BIN:-loopover-miner}"
 OUT_FILE="${LOOPOVER_MINER_PROMETHEUS_TEXTFILE:-/var/lib/node_exporter/textfile_collector/gittensory_miner.prom}"
 TMP_FILE="${OUT_FILE}.tmp"
 

--- a/test/unit/export-miner-prometheus-textfile-script.test.ts
+++ b/test/unit/export-miner-prometheus-textfile-script.test.ts
@@ -1,0 +1,101 @@
+import { execFileSync } from "node:child_process";
+import { chmodSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+// export-miner-prometheus-textfile.sh (#4839): regression for #5934, where the script's default MINER_BIN
+// fallback pointed at `gittensory-miner`, a binary the package never installs (its real `bin` entry is
+// `loopover-miner`). With no LOOPOVER_MINER_BIN override -- the script's own documented zero-config usage --
+// every `export_family` call hit "command not found" and, being fail-open per family, silently produced an
+// empty .prom file instead of erroring loudly.
+
+const tmpRoots: string[] = [];
+
+function tmpRoot(): string {
+  const dir = mkdtempSync(join(tmpdir(), "miner-prometheus-textfile-"));
+  tmpRoots.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  for (const dir of tmpRoots.splice(0)) rmSync(dir, { force: true, recursive: true });
+});
+
+/** A fake `loopover-miner` that answers each of the script's four subcommands with distinguishable text, so
+ *  tests can assert the export actually reached it (as opposed to falling back to a nonexistent binary). */
+function fakeMinerBin(root: string, name = "loopover-miner"): string {
+  const bin = join(root, "bin");
+  execFileSync("mkdir", ["-p", bin]);
+  const path = join(bin, name);
+  writeFileSync(
+    path,
+    `#!/bin/sh
+case "$1 $2" in
+  "metrics ") echo "fake_prediction_calibration 1" ;;
+  "queue metrics") echo "fake_portfolio_queue 1" ;;
+  "ledger metrics") echo "fake_event_ledger 1" ;;
+  "governor metrics") echo "fake_governor 1" ;;
+  *) echo "unexpected args: $*" >&2; exit 2 ;;
+esac
+`,
+  );
+  chmodSync(path, 0o755);
+  return bin;
+}
+
+function runExport(outFile: string, env: Record<string, string> = {}): { stdout: string; stderr: string } {
+  try {
+    const stdout = execFileSync("sh", ["scripts/export-miner-prometheus-textfile.sh"], {
+      cwd: process.cwd(),
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        LOOPOVER_MINER_PROMETHEUS_TEXTFILE: outFile,
+        ...env,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    return { stdout, stderr: "" };
+  } catch (error) {
+    const err = error as { stdout?: Buffer; stderr?: Buffer };
+    return { stdout: err.stdout?.toString() ?? "", stderr: err.stderr?.toString() ?? "" };
+  }
+}
+
+describe("export-miner-prometheus-textfile.sh (#5934)", () => {
+  it("defaults MINER_BIN to loopover-miner, not the nonexistent gittensory-miner", () => {
+    const script = readFileSync(join(process.cwd(), "scripts/export-miner-prometheus-textfile.sh"), "utf8");
+    expect(script).toMatch(/MINER_BIN="\$\{LOOPOVER_MINER_BIN:-loopover-miner\}"/);
+  });
+
+  it("REGRESSION: with no LOOPOVER_MINER_BIN override, invokes the real loopover-miner binary and populates every family", () => {
+    const root = tmpRoot();
+    const bin = fakeMinerBin(root);
+    const outFile = join(root, "out", "miner.prom");
+
+    const result = runExport(outFile, { PATH: `${bin}:${process.env.PATH ?? ""}` });
+
+    expect(result.stderr).not.toMatch(/export failed/);
+    const content = readFileSync(outFile, "utf8");
+    expect(content).toContain("fake_prediction_calibration 1");
+    expect(content).toContain("fake_portfolio_queue 1");
+    expect(content).toContain("fake_event_ledger 1");
+    expect(content).toContain("fake_governor 1");
+  });
+
+  it("still honors an explicit LOOPOVER_MINER_BIN override", () => {
+    const root = tmpRoot();
+    const bin = fakeMinerBin(root, "custom-miner-bin");
+    const outFile = join(root, "out", "miner.prom");
+
+    const result = runExport(outFile, {
+      PATH: process.env.PATH ?? "",
+      LOOPOVER_MINER_BIN: join(bin, "custom-miner-bin"),
+    });
+
+    expect(result.stderr).not.toMatch(/export failed/);
+    const content = readFileSync(outFile, "utf8");
+    expect(content).toContain("fake_prediction_calibration 1");
+  });
+});


### PR DESCRIPTION
- **docs(miner): AMS storage-abstraction research — datastore backend comparison (#5760)**
- **fix(rebrand): full-cutover rename remaining internal gittensory runtime identifiers (#5761)**
- **refactor(engine): extract the pull-request-target-key parser into loopover-engine (#5762)**
- **docs(miner): AMS auth/identity research — hosted login-layer options (#5764)**
- **fix(rebrand): full-cutover rename miner/AMS per-repo and operator config filenames (#5765)**
- **feat(api): add post-merge incident reporting for already-merged PRs (#5766)**
- **fix(review): trim the Improvement signal row to a concise value rating (#5767)**
- **fix(rebrand): full-cutover rename Prometheus/Alertmanager/Grafana observability identifiers (#5768)**
- **feat(review): add a shared beta-collapsible convention for the PR comment (#5769)**
- **docs(engine): verify git mv rename recognition in coverage tooling (#5770)**
- **fix(review): never render a ❌ for a non-Gittensor contributor (#5100) (#5774)**
- **feat(engine): extract content-lane's pure leaf modules to loopover-engine (#5775)**
- **fix(api): audit registered-vs-installed dashboard/digest copy (#5026) (#5776)**
- **feat(engine): extract settings leaf modules to loopover-engine (#5779)**
- **refactor(engine): move the unlinked-issue candidate pre-filter into the shared engine (#5778)**
- **feat(engine): add a load-testing harness for iterate-loop under concurrent load (#5781)**
- **docs(spec): idea-intake bridge schema (#5783)**
- **docs(engine): document the deliberate gate-advisory twin divergence (#5784)**
- **feat(selfhost): optional Infisical secrets management for self-host deploys (#5785)**
- **refactor(queue): extract the public-comment merge-facts derivation from maybePublishPrPublicSurface (#4607) (#5787)**
- **feat(review): add aggregate fix-handoff block renderer (#5788)**
- **feat(miner): pre-execution feasibility check for freeform ideas (#5789)**
- **feat(review): synthesize the 'Contributor next steps' collapsible into a prioritized step (#5791)**
- **feat(mcp): add the idea-intake bridge and loopover_intake_idea tool (#5792)**
- **feat(miner): add cross-repo evaluation harness (#4788) (#5790)**
- **docs(selfhost): design doc for the scheduled docs-drift audit sweep (#3048) (#5794)**
- **feat(mcp): route ideas through intake into a loop claim plan (#5795)**
- **feat(mcp): deliver a completed loop iteration as a customer results payload (#5797)**
- **feat(mcp): stream loop progress to the customer via a progress snapshot (#5798)**
- **refactor(engine): extract signals engine with re-export shim (#4884) (#5800)**
- **feat(engine): per-tenant resource quota evaluation (#5801)**
- **feat(mcp): evaluate when a rented loop should escalate to a human (#5806)**
- **docs(engine): document the nine governor primitives in the package README (#5851)**
- **docs(gardening): correct contributor-available target to per-repo, not combined (#5808)**
- **fix(signals): require a code file before manifest_missing_tests fires (#5852)**
- **fix(miner): list queue dashboard in cli.js help text (#5853)**
- **docs: privacy audit of AMS telemetry/export surfaces for cross-tenant leakage (#5759)**
- **feat(selfhost): add n8n workflows and MinIO object storage compose profiles (#1219) (#5777)**
- **feat(miner): honor kill-switch mid-attempt during iterate-loop (#5799)**
- **feat(engine): per-tenant configuration layer (#5804)**
- **feat(selfhost): bridge fleet-mode miner state to the ams-observability exporter (#5844)**
- **docs(engine): add a Tenant quota README section (#5860)**
- **fix(engine): clamp rate-limit retryAfterMs to at most one window on a backward clock (#5855)**
- **fix(review): recognize export const enum and abstract class in impact-symbols (#5858)**
- **test(review): cover review-diff.ts non-positive-budget guard and header count defaults (#5857)**
- **fix(ci): sync miner engine-version pin on the engine release branch (#5856)**
- **test(selfhost): cover jobCoalesceKey missing-field fallbacks for 6 job types (#5862)**
- **fix(queue): cap backlog-convergence re-review attempts per head SHA (#5859)**
- **docs(engine): document the Rent-a-Loop pipeline modules (#5868)**
- **fix(review): exclude maintainer PRs from the slop-discrimination alert (#5863)**
- **test(miner): rename gittensory-miner/ams prose to loopover-miner/ams (#5874)**
- **chore(release): cut engine v3.1.0 (#5807)**
- **test(miner): rename gittensory-miner/ams prose to loopover-miner/ams (batch 2) (#5878)**
- **docs(ui): rename gittensory prose to loopover across docs routes (#5881)**
- **docs(review): rename gittensory prose to loopover in src/review (batch A) (#5883)**
- **chore(release): cut mcp v2.0.0 (#5735)**
- **fix(review): restore engine-parity after gittensory rename drift (#5892)**
- **docs(review): rename gittensory prose to loopover in src/review (batch B) (#5886)**
- **fix(test): stop hardcoding the current miner version as a golden value (#5891)**
- **docs: rename gittensory prose to loopover in README and config example (#5901)**
- **test(miner): rename gittensory-miner/ams prose to loopover-miner/ams (batch 3) (#5888)**
- **docs(db): rename gittensory prose to loopover in migration headers (#5900)**
- **fix(ui): widen the ui-kit consumer range past its 1.0.0 pre-release cap (#5904)**
- **fix(config): resync .loopover.yml.example with loopover.full.yml (#5908)**
- **docs(engine): rename gittensory prose to loopover in packages/loopover-engine (batch B) (#5898)**
- **docs(miner): rename gittensory prose to loopover in miner/mcp packages (#5899)**
- **fix(agent): make the fleet-wide DB freeze absolute, drop the per-repo bypass (#5912)**
- **chore(release): cut engine v3.1.1 (#5910)**
- **fix(github): migrate repo identity on a GitHub repository rename webhook**
- **test(miner): fix stale gittensory identifiers in cross-repo-evaluation test**
- **chore(release): cut ui-kit v1.0.0 (#5911)**
- **fix(ci): authenticate release-please with a PAT instead of GITHUB_TOKEN**
- **test(miner): fix two more stale gittensory literals from #5899**
- **fix(test): match miner-cross-repo-evaluation.test.ts to the renamed loopover API**
- **chore(release): cut mcp v3.0.0**
- **chore(release): sync package-lock.json**
- **docs(core): rename gittensory prose to loopover in signals/selfhost/services**
- **fix(core): update test fixtures for renamed self-repo/webhook-map keys**
- **fix(core): fix second stale repo-name fixture in review-recap.test.ts**
- **chore(release): cut miner v3.0.0**
- **chore(release): sync package-lock.json**
- **fix(github): extend repo-rename identity migration to review/audit tables**
- **docs(core): rename gittensory prose to loopover in remaining src subdirs (#5895)**
- **feat(gate): configurable advisory check-runs so a stuck external status never freezes the gate (#4372)**
- **test(gate): pin the advisory-hold cache-invalidation guarantee end-to-end (#4372)**
- **docs(engine): rename gittensory prose to loopover in packages/loopover-engine (batch A) (#5897)**
- **docs: fix post-rebrand dead gittensory-* references in contributor docs (#5884)**
- **docs(skill): document the extension lint/typecheck CI checks omitted from the table and test:ci (#5894)**
- **fix(github): extend repo-rename identity migration to analytics tables (#5953)**
- **fix(docs): rename stale gittensory reference in miner MCP client-config doc (#5957)**
- **fix(rebrand): rename gittensory-cli- tmpdir prefix across mcp-cli test family (#5958)**
- **fix(rebrand): rename gittensory-app.env default output path (#5959)**
- **fix(github): extend repo-rename identity migration to REES/parity tables (#5954)**
- **fix(rebrand): rename x-gittensory-request-id header to x-loopover-request-id (#5960)**
- **feat(review): add OpenAI and Anthropic API key patterns to secret scan**
- **feat(ci): upload loopover-ui bundle stats to Codecov**
- **fix(rebrand): rename gittensory-repo-focus-manifest.ts module**
- **feat(miner): expose the calibration report as a read-only MCP tool**
- **feat(mcp): expose skipped-PR audit trail as a maintainer MCP tool**
- **feat(mcp): expose repo registration readiness as a read-only MCP tool**
- **chore(release): cut orb-v2.0.0**
- **fix(rebrand): rename gittensory-mcp prose cluster and fix release-candidate binary name**
- **fix(rebrand): rename stale JSONbored/gittensory reference in fallback-manifest comment**
- **fix(rebrand): rename gittensory-mcp CLI snippets and JSON keys in apps/loopover-ui**
- **fix(review): treat a blank consentPhrase as unset in evaluateClaCheck (#5838)**
- **fix(review): sanitize control characters in RAG chunk text before Postgres insert**
- **fix(selfhost): preserve stack traces and split fingerprints for RAG/enrichment Sentry captures**
- **fix(review): scan added lines whose content starts with ++ for secrets (#5942) (#5952)**
- **fix(signals): filter public-unsafe wantedPaths/preferredLabels from manifest findings (#5967)**
- **fix(queue): scan patch-less copied/changed/unchanged files for secrets (#5947) (#5951)**
- **fix(selfhost): default MINER_BIN to loopover-miner in prometheus textfile export**
