### PR TITLE
fix(queue): log unrecognized job types instead of silently dropping them

### DIFF
--- a/src/queue/job-dispatch.ts
+++ b/src/queue/job-dispatch.ts
@@ -343,5 +343,21 @@ export async function processJob(env: Env, message: JobMessage): Promise<void> {
       // an empty table). Never throws.
       await retryFailedRelays(env);
       return;
+    default:
+      // Same class of "this job is intentionally not processed" event as the retired-review-job path
+      // (src/index.ts's retired_review_job_ignored) and the DLQ's dlq_message_dead_lettered -- a message.type
+      // that matches no case (a stale message from a renamed/removed job type, a producer/consumer version
+      // skew during a rolling deploy, or a corrupted payload) must never vanish with zero trace. `warn`, not
+      // `error`: this is a non-fatal, expected-to-happen-occasionally drop, not a `queue_message_failed`-class
+      // failure. Never throws -- the caller's ack-after-processJob flow (src/index.ts, src/server.ts) must stay
+      // unaffected; this is an observability addition only, not a behavior change.
+      console.warn(
+        JSON.stringify({
+          level: "warn",
+          event: "unknown_job_type_ignored",
+          jobType: (message as { type: string }).type,
+        }),
+      );
+      return;
   }
 }

--- a/test/unit/job-dispatch.test.ts
+++ b/test/unit/job-dispatch.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from "vitest";
+import { processJob } from "../../src/queue/processors";
+import { createTestEnv } from "../helpers/d1";
+import type { JobMessage } from "../../src/types";
+
+describe("processJob (#5836)", () => {
+  it("logs an unknown_job_type_ignored warning and returns without throwing for an unrecognized message.type", async () => {
+    const env = createTestEnv();
+    const warnings = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+    await expect(
+      processJob(env, { type: "totally-unknown-job-type" } as unknown as JobMessage),
+    ).resolves.toBeUndefined();
+
+    expect(warnings.mock.calls.some((call) => String(call[0]).includes("unknown_job_type_ignored") && String(call[0]).includes("totally-unknown-job-type"))).toBe(true);
+    warnings.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary

- `processJob`'s `switch (message.type)` in `src/queue/job-dispatch.ts` had no `default:` case, so an unrecognized `message.type` (a stale message from a renamed/removed job type, a producer/consumer version skew during a rolling deploy, or a corrupted payload) was acked and dropped with zero observability — no log line, no metric, no audit event.
- Adds a `default:` case that logs a structured `unknown_job_type_ignored` warning (mirroring the existing `retired_review_job_ignored` precedent in `src/index.ts` and the DLQ's `dlq_message_dead_lettered` precedent in `src/queue/dlq.ts`) and returns normally.
- Uses `console.warn` (matching `retired_review_job_ignored`'s non-fatal-but-noteworthy severity), not `console.error`.
- No change to any existing matched `case` branch, and the default case never throws — the existing ack-after-`processJob` flow in `src/index.ts`/`src/server.ts` is unaffected. Observability addition only.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

Closes #5836

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

All ran via `npm run test:ci` (the full local gate) plus `npm audit --audit-level=moderate`, both clean. A dedicated new test (`test/unit/job-dispatch.test.ts`) calls `processJob` with an unrecognized `message.type`, asserting it resolves without throwing and that the new `unknown_job_type_ignored` warning is logged with the job type — the one new branch this PR adds.

If any required check was skipped, explain why:

- N/A — the full `npm run test:ci` chain ran end to end.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

Not applicable: this is a backend queue-dispatch observability fix, not a UI/auth/session change.

## Notes

-
