### PR TITLE
fix(signals): filter wantedPaths before interpolating focus-area PR guidance

### DIFF
--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -872,7 +872,7 @@ export function deriveContributionLanes(manifest: FocusManifest): ContributionLa
 
   const prEntryGuidance: string[] = [];
   if (safeWanted.length > 0) {
-    prEntryGuidance.push(`Focus changes on maintainer-wanted areas: ${manifest.wantedPaths.slice(0, 5).join(", ")}.`);
+    prEntryGuidance.push(`Focus changes on maintainer-wanted areas: ${safeWanted.slice(0, 5).join(", ")}.`);
   }
   if (manifest.preferredLabels.length > 0) {
     const safeLabels = manifest.preferredLabels.filter(isFocusManifestPublicSafe);

--- a/test/unit/policy-sanitizer.test.ts
+++ b/test/unit/policy-sanitizer.test.ts
@@ -277,6 +277,19 @@ describe("contribution lane output — public-safe via deriveContributionLanes",
     expect(JSON.stringify(lanes)).not.toMatch(FORBIDDEN_POLICY_PATTERN);
   });
 
+  it("still surfaces safe wanted paths in PR guidance when the manifest mixes in a public-unsafe path", () => {
+    // A single public-unsafe wantedPaths entry must not drop the whole "Focus changes on maintainer-wanted
+    // areas" line via the all-or-nothing public-safety filter: the interpolation is built from the filtered
+    // safe paths, so the safe path still surfaces and the unsafe one never appears.
+    const manifest = parseFocusManifest({ wantedPaths: ["src/", "reward-farming/"] });
+    const lanes = deriveContributionLanes(manifest);
+    const focusLine = lanes.prEntryGuidance.find((entry) => entry.startsWith("Focus changes on maintainer-wanted areas:"));
+    expect(focusLine).toBeDefined();
+    expect(focusLine).toContain("src/");
+    expect(focusLine).not.toContain("reward-farming/");
+    expect(JSON.stringify(lanes)).not.toMatch(FORBIDDEN_POLICY_PATTERN);
+  });
+
   it("emits a warning when contribution scope is unclear", () => {
     const manifest = parseFocusManifest({ wantedPaths: [], preferredLabels: [], issueDiscoveryPolicy: "encouraged" });
     const lanes = deriveContributionLanes(manifest);


### PR DESCRIPTION
## Summary

`deriveContributionLanes` in `src/signals/focus-manifest.ts` gated the "Focus changes on maintainer-wanted areas" PR-guidance line on the public-safety-filtered `safeWanted` list, but then interpolated the **raw** `manifest.wantedPaths` into the string it pushed. Because `prEntryGuidance` is later collapsed through the all-or-nothing `isFocusManifestPublicSafe` filter, a single public-unsafe entry anywhere in `wantedPaths` made the whole joined sentence fail that filter, silently dropping the entire guidance line — including the legitimate safe paths it was meant to surface.

The fix interpolates the already-computed `safeWanted` list instead, mirroring the sibling `buildPolicyEntryGuidance` in `packages/loopover-engine/src/focus-manifest.ts`, which documents and already applies this exact pattern (and matches the `#5945` fix at line 692 of this same file). The `safeWanted.length > 0` gate is unchanged; only the interpolated content is now filtered.

Closes #5944

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #5944`).

## Validation

- [x] `git diff --check` — clean
- [ ] `npm run actionlint` — no workflow changes
- [x] `npm run typecheck` — passes (whole project, against the built `@loopover/engine`)
- [x] `npm run test:coverage` — the changed line is exercised by the new regression test **and** existing lane tests; the change is a single interpolation expression (`manifest.wantedPaths` → `safeWanted`) inside an already-covered branch and adds no new branch, so `codecov/patch` on the diff is 100%. The covering suite `test/unit/policy-sanitizer.test.ts` (67 tests) passes; the new test fails on the pre-fix code (asserts the safe path still surfaces) and passes after.
- [ ] `npm run test:workers` — unaffected (no worker changes)
- [ ] `npm run build:mcp` / `test:mcp-pack` — unaffected (no MCP changes)
- [x] `npm run ui:openapi:check` — passes, no drift (pure value change, no schema/route change)
- [ ] `npm run ui:lint` / `ui:typecheck` / `ui:build` — unaffected (no UI app code; `src/**` triggers only the lightweight OpenAPI drift check)
- [ ] `npm audit --audit-level=moderate` — no dependency changes
- [x] New or changed behavior has unit tests — a regression test with a mixed public-safe / public-unsafe `wantedPaths` list asserts `prEntryGuidance` still surfaces the safe path and never contains the unsafe one

If any required check was skipped, explain why:

- Backend-only change touching one line of `src/signals/focus-manifest.ts` plus a regression test in `test/unit/policy-sanitizer.test.ts`. It introduces no workflow, MCP, UI, OpenAPI, or dependency changes, so those gates are unaffected. I additionally ran `npm run engine-parity:drift-check` (ok — this file has no engine twin under `signals/`) and the backend drift checks (`manifest`, `docs`, `command-reference`, `selfhost env-reference`), all green.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests — N/A (none).
- [x] API/OpenAPI/MCP behavior is updated and tested where needed — N/A (behavior-preserving for the default case; no schema change).
- [x] UI changes use live API data or real empty/error/loading states — N/A (no UI changes).
- [x] Visible UI changes include a `UI Evidence` section — N/A (no UI/frontend/docs/extension changes).
- [x] Public docs/changelogs are updated where needed — N/A.

## Notes

- This strengthens the public-safety guarantee already relied on elsewhere: the resulting guidance line is now built purely from paths that individually pass `isFocusManifestPublicSafe`, so it can no longer be dropped wholesale by one unrelated unsafe entry, and no unsafe path can leak into the rendered sentence.
