### PR TITLE
fix(selfhost): instrument the silent orb-relay-drain reentrancy skip

### DIFF
--- a/src/selfhost/metrics.ts
+++ b/src/selfhost/metrics.ts
@@ -102,6 +102,7 @@ export const DEFAULT_METRIC_META: readonly (readonly [string, MetricMeta])[] = [
   ["loopover_orb_events_exported_total", { help: "Orb events exported from the self-host runtime.", type: "counter" }],
   ["loopover_orb_export_errors_total", { help: "Orb event export errors.", type: "counter" }],
   ["loopover_orb_relay_drains_total", { help: "Orb relay drain outcomes.", type: "counter" }],
+  ["loopover_orb_relay_drain_skipped_total", { help: "Pull-mode orb relay drain ticks skipped because the previous tick was still in flight.", type: "counter" }],
   ["loopover_orb_relay_register_consecutive_failures", { help: "Current consecutive orb relay registration failure streak, reset to 0 on any success.", type: "gauge" }],
   ["loopover_orb_relay_drain_seconds_since_last", { help: "Seconds since the pull-mode orb relay drain loop last completed successfully, or -1 if never (or in push mode).", type: "gauge" }],
   ["loopover_orb_webhook_total", { help: "Orb webhook outcomes.", type: "counter" }],

--- a/src/selfhost/monitored-work.ts
+++ b/src/selfhost/monitored-work.ts
@@ -128,6 +128,31 @@ export async function drainOrbRelayWithMonitor(args: {
   );
 }
 
+// Wraps a recurring drain tick with a re-entrancy guard: if the PREVIOUS tick is still running (a slow broker
+// round-trip, or a slow per-event enqueue write), this tick is skipped rather than piling a second concurrent
+// attempt on top of the first. Previously this skip was completely silent -- no metric, no log -- making it
+// indistinguishable from the timer not having fired at all, which is exactly what a Sentry Cron Monitor
+// "missed check-in" (GITTENSORY-12, 295 occurrences and still recurring) looks like from Sentry's side. A live
+// investigation confirmed the loop itself is healthy (frequent real drains succeed) and the schedule/secret
+// config are both correct, so an occasional silent overlap-skip run is the remaining unverified suspect; this
+// turns it into a real signal instead of an invisible blind spot.
+export function withOrbRelayDrainReentrancyGuard(run: () => Promise<void>): () => Promise<void> {
+  let inFlight = false;
+  return async () => {
+    if (inFlight) {
+      incr("loopover_orb_relay_drain_skipped_total");
+      console.warn(JSON.stringify({ level: "warn", event: "orb_relay_drain_skipped_overlap" }));
+      return;
+    }
+    inFlight = true;
+    try {
+      await run();
+    } finally {
+      inFlight = false;
+    }
+  };
+}
+
 type OrbRelayRegisterEnv = {
   ORB_ENROLLMENT_SECRET?: string | undefined;
   ORB_BROKER_URL?: string | undefined;

--- a/src/server.ts
+++ b/src/server.ts
@@ -87,6 +87,7 @@ import {
   registerOrbRelayWithMonitor,
   runOrbExportWithMonitor,
   runScheduledLoopWithMonitor,
+  withOrbRelayDrainReentrancyGuard,
 } from "./selfhost/monitored-work";
 import {
   currentOtelTraceParent,
@@ -1150,25 +1151,18 @@ async function main(): Promise<void> {
     const { drainOrbRelay } = await import("./orb/broker-client");
     const { enqueueWebhookByEnv } = await import("./github/webhook");
     /* v8 ignore start -- pull-mode relay loop is a live self-host timer; monitor semantics are covered in selfhost tests. */
-    let drainInFlight = false;
-    const drainRelay = async (): Promise<void> => {
-      if (drainInFlight) return;
-      drainInFlight = true;
-      try {
-        await drainOrbRelayWithMonitor({
-          state: relayDrainState,
-          relayEnv: {
-            ORB_ENROLLMENT_SECRET: process.env.ORB_ENROLLMENT_SECRET,
-            ORB_BROKER_URL: process.env.ORB_BROKER_URL,
-          },
-          env,
-          drain: drainOrbRelay,
-          enqueue: enqueueWebhookByEnv,
-        });
-      } finally {
-        drainInFlight = false;
-      }
-    };
+    const drainRelay = withOrbRelayDrainReentrancyGuard(() =>
+      drainOrbRelayWithMonitor({
+        state: relayDrainState,
+        relayEnv: {
+          ORB_ENROLLMENT_SECRET: process.env.ORB_ENROLLMENT_SECRET,
+          ORB_BROKER_URL: process.env.ORB_BROKER_URL,
+        },
+        env,
+        drain: drainOrbRelay,
+        enqueue: enqueueWebhookByEnv,
+      }),
+    );
     void drainRelay().catch((error) =>
       captureError(error, { kind: "orb_relay_drain" }, "orb_relay_drain"),
     );

--- a/test/unit/selfhost-monitored-work.test.ts
+++ b/test/unit/selfhost-monitored-work.test.ts
@@ -18,6 +18,7 @@ import {
   registerOrbRelayWithMonitor,
   runOrbExportWithMonitor,
   runScheduledLoopWithMonitor,
+  withOrbRelayDrainReentrancyGuard,
   type OrbRelayDrainState,
 } from "../../src/selfhost/monitored-work";
 import { drainOrbRelay, type OrbRelayRegistrationState } from "../../src/orb/broker-client";
@@ -485,6 +486,53 @@ describe("self-host monitored recurring work", () => {
       } finally {
         consoleLog.mockRestore();
       }
+    });
+  });
+
+  describe("withOrbRelayDrainReentrancyGuard (GITTENSORY-12 -- make a skipped-overlap tick observable, not silent)", () => {
+    it("skips a concurrent call while the wrapped run is still in flight, counting + logging the overlap instead of staying silent", async () => {
+      let resolveFirst: () => void = () => {};
+      const first = new Promise<void>((resolve) => {
+        resolveFirst = resolve;
+      });
+      const run = vi.fn(() => first);
+      const guarded = withOrbRelayDrainReentrancyGuard(run);
+      const consoleWarn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+
+      const firstCall = guarded(); // not yet resolved -- run() is "in flight"
+      expect(run).toHaveBeenCalledTimes(1);
+
+      await guarded(); // fires while the first call is still pending
+      expect(run).toHaveBeenCalledTimes(1); // the real work was NOT invoked a second time
+      expect(consoleWarn).toHaveBeenCalledWith(
+        JSON.stringify({ level: "warn", event: "orb_relay_drain_skipped_overlap" }),
+      );
+      expect(await renderMetrics()).toContain("loopover_orb_relay_drain_skipped_total 1");
+
+      consoleWarn.mockRestore();
+      resolveFirst();
+      await firstCall;
+    });
+
+    it("runs the real work again once the previous tick has completed -- no overlap once nothing is in flight", async () => {
+      const run = vi.fn().mockResolvedValue(undefined);
+      const guarded = withOrbRelayDrainReentrancyGuard(run);
+
+      await guarded();
+      await guarded();
+      expect(run).toHaveBeenCalledTimes(2); // sequential calls each reach the real work -- no overlap to skip
+      expect(await renderMetrics()).not.toContain("loopover_orb_relay_drain_skipped_total");
+    });
+
+    it("REGRESSION: clears the in-flight flag even when the wrapped run throws, so the NEXT tick is not skipped forever", async () => {
+      const run = vi.fn().mockRejectedValueOnce(new Error("broker down")).mockResolvedValueOnce(undefined);
+      const guarded = withOrbRelayDrainReentrancyGuard(run);
+
+      // The guard itself doesn't swallow errors (the finally only resets the flag) -- callers still see and
+      // handle failures exactly like before this was extracted (server.ts's own .catch() around drainRelay()).
+      await expect(guarded()).rejects.toThrow("broker down");
+      await guarded(); // the flag was still cleared, so this reaches the real work again instead of skipping
+      expect(run).toHaveBeenCalledTimes(2);
     });
   });
 });


### PR DESCRIPTION
## Summary

- GITTENSORY-12 (Sentry Cron Monitor "missed check-in" on `orb-relay-drain`, 295 occurrences, still actively recurring) — investigated live on the dedicated server via SSH rather than guessing from code alone.
- Confirmed the drain loop itself is healthy: `docker logs` shows frequent, real `orb_relay_drained` events with non-trivial batch sizes, and `ORB_ENROLLMENT_SECRET_FILE` resolves into `ORB_ENROLLMENT_SECRET` correctly at boot (`loadFileSecrets()`, no `selfhost_secret_file_unreadable` errors). Also confirmed Sentry Crons has no sub-minute schedule granularity (smallest unit is `minute`), so the code's 30s poll interval vs. the declared 1-minute schedule is intentional headroom, not a bug.
- The remaining, previously-unverifiable suspect: `server.ts`'s pull-mode `drainRelay()` had a `drainInFlight` reentrancy guard that silently no-ops — zero log, zero metric — whenever the previous tick is still running (a slow broker round-trip, or a slow per-event DB write). That is indistinguishable from the timer not firing at all, which is exactly what a "missed check-in" looks like from Sentry's side.
- Extracted the guard into a new `withOrbRelayDrainReentrancyGuard()` helper in `src/selfhost/monitored-work.ts` (real test coverage, matching this file's existing pattern of testable core logic + untested `server.ts` wiring) that increments a new `loopover_orb_relay_drain_skipped_total` counter and logs a `console.warn` (Loki-visible; deliberately not Sentry-forwarded, since an overlap-skip is an expected safety behavior, not an error) on every skip.
- This does not change retry/timeout architecture and adds no new alerting channel — it turns an existing, currently-invisible blind spot into a real signal that can be correlated against the Postgres-connection hiccups already visible in GITTENSORY-1T/1R/1S.

## Test plan
- [x] New unit tests in `test/unit/selfhost-monitored-work.test.ts`: skips a concurrent call while in flight (counts + logs), runs normally again once free, and clears the in-flight flag even when the wrapped run throws (so the next tick isn't skipped forever).
- [x] `npm run test:coverage` (unsharded) — full local gate green, no regressions.
- [x] `npm run test:ci` — green.