### PR TITLE
fix(review): fold repo into ops_anomaly's Sentry fingerprint

### DIFF
--- a/src/review/ops-wire.ts
+++ b/src/review/ops-wire.ts
@@ -228,7 +228,11 @@ export async function runOpsAlerts(env: Env): Promise<Record<string, string[]>> 
         found[repoFullName] = anomalies;
         // Structured log = loopover's notify path (no Discord/operator webhook exists) AND the Sentry path
         // (level:"error" + an `event` field reaches forwardStructuredLogToSentry). One line per repo.
-        console.error(JSON.stringify({ level: "error", event: "ops_anomaly", repo: repoFullName, at: nowIso(), anomalies }));
+        // `ev: repoFullName` (GITTENSORY-1D/1W): forwardStructuredLogToSentry only fingerprints on the top-level
+        // `event` field unless an `ev` sub-field is present -- without it, every repo's anomalies collapse into
+        // ONE Sentry issue. Confirmed live: one "ops_anomaly" issue mixed a JSONbored/gittensory anomaly with an
+        // unrelated JSONbored/metagraphed review-burst, making both un-triageable from the issue alone.
+        console.error(JSON.stringify({ level: "error", event: "ops_anomaly", ev: repoFullName, repo: repoFullName, at: nowIso(), anomalies }));
         // Experimental PagerDuty paging (#4937): no-op unless LOOPOVER_ENABLE_PAGERDUTY is set AND a routing
         // key resolves for this repo (resolvePagerDutyRoutingKey). ops_anomaly is this codebase's own existing
         // "something needs a human" judgment call -- reusing it here (rather than paging on every
@@ -261,7 +265,8 @@ export async function runOpsAlerts(env: Env): Promise<Record<string, string[]>> 
           incr("loopover_ops_anomaly_total", { repo: repoFullName, kind: "review_failure_burst" });
         }
       } catch (error) {
-        console.error(JSON.stringify({ level: "error", event: "ops_anomaly_repo_error", repo: repoFullName, message: errorMessage(error).slice(0, 200) }));
+        // ev: repoFullName -- same fingerprint-collapse reasoning as the ops_anomaly log above.
+        console.error(JSON.stringify({ level: "error", event: "ops_anomaly_repo_error", ev: repoFullName, repo: repoFullName, message: errorMessage(error).slice(0, 200) }));
       }
     }
   } catch (error) {

--- a/test/unit/ops-wire.test.ts
+++ b/test/unit/ops-wire.test.ts
@@ -274,11 +274,14 @@ describe("runOpsAlerts — cron path over gittensory's outcome data", () => {
     expect(found["owner/repo"]?.some((a) => /gate false-positive spike/.test(a))).toBe(true);
     const logged = errors.mock.calls.map((c) => String(c[0])).find((line) => line.includes("ops_anomaly") && line.includes("owner/repo"));
     expect(logged).toBeDefined();
-    const parsed = JSON.parse(logged!) as { level: string; event: string; repo: string; anomalies: string[] };
+    const parsed = JSON.parse(logged!) as { level: string; event: string; ev: string; repo: string; anomalies: string[] };
     expect(parsed.level).toBe("error");
     expect(parsed.event).toBe("ops_anomaly");
     expect(parsed.repo).toBe("owner/repo");
     expect(parsed.anomalies.some((a) => /missing_linked_issue/.test(a))).toBe(true);
+    // REGRESSION (GITTENSORY-1D/1W): `ev` must be the repo, so forwardStructuredLogToSentry's fingerprint
+    // splits by repo instead of collapsing every repo's anomalies into one Sentry issue.
+    expect(parsed.ev).toBe("owner/repo");
   });
 
   it("emits NO ops_anomaly log when the outcome data is healthy", async () => {
@@ -456,7 +459,10 @@ describe("runOpsAlerts — cron path over gittensory's outcome data", () => {
     const found = await runOpsAlerts(env); // resolves (never throws)
 
     expect(found).toEqual({});
-    expect(errors.mock.calls.map((c) => String(c[0])).some((line) => line.includes("ops_anomaly_repo_error") && line.includes("owner/repo"))).toBe(true);
+    const logged = errors.mock.calls.map((c) => String(c[0])).find((line) => line.includes("ops_anomaly_repo_error") && line.includes("owner/repo"));
+    expect(logged).toBeDefined();
+    // REGRESSION (GITTENSORY-1D/1W): same per-repo fingerprint fix as the ops_anomaly log above.
+    expect((JSON.parse(logged!) as { ev: string }).ev).toBe("owner/repo");
   });
 
   it("fails safe at the top level: a repo-scan error is swallowed (ops_anomaly_error), returns {}", async () => {


### PR DESCRIPTION
## Summary

- `runOpsAlerts` (`src/review/ops-wire.ts`) emits one `console.error({event:"ops_anomaly", repo, ...})` per repo with a detected anomaly, but the payload had no `ev` sub-field — so `forwardStructuredLogToSentry`'s fingerprint fell back to just the top-level `event`, collapsing **every repo's** anomalies into one Sentry issue.
- Confirmed live: GITTENSORY-1D's issue title reads `(JSONbored/gittensory)`, but an actual event inside that **same issue** is tagged `repo=JSONbored/metagraphed` with a completely unrelated anomaly (a review-burst/stuck-CI-retry-storm on a specific PR, vs. a slop-calibration miscalibration for the other repo) — making both un-triageable from the issue alone. GITTENSORY-1W is the same bug's newer event.
- This is the identical fingerprint-collapse pattern already fixed for GITTENSORY-D in #5970, just not yet applied to this call site.
- Fix: set `ev: repoFullName` on the `ops_anomaly` and `ops_anomaly_repo_error` payloads so each repo gets its own issue bucket. Reuses the existing, already-tested `ev`-folding mechanism in `forwardStructuredLogToSentry` — zero changes to `sentry.ts` itself.
- `ops_anomaly_error` (the top-level scan failure, not repo-specific — no `repoFullName` in scope at that catch) is intentionally left as a single bucket.

## Test plan
- [x] Extended the two existing `ops-wire.test.ts` coverage points (`ops_anomaly`, `ops_anomaly_repo_error`) to assert the new `ev` field equals the seeded repo.
- [x] `npm run test:coverage` (unsharded) — full local gate green, no regressions.
- [x] `npm run test:ci` — green.