### PR TITLE
fix/issue 5928

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.js
+++ b/packages/loopover-mcp/bin/loopover-mcp.js
@@ -586,9 +586,35 @@ function stdioToolDescription(name) {
   return tool.description;
 }
 
+/** Shared CLI failure output (#5928): mirrors @loopover/miner's cli-error.js contract so a `--json`
+ *  invocation of this CLI never lets a thrown error escape as a raw Node stack trace — when `--json`
+ *  is set, emit a parseable `{ ok: false, error }` object on stdout; otherwise log plain text to stderr. */
+function reportCliFailure(wantsJson, message) {
+  if (wantsJson) {
+    console.log(JSON.stringify({ ok: false, error: message }, null, 2));
+  } else {
+    console.error(message);
+  }
+}
+
+/** True when `--json` (or `--json=...`) appears anywhere in argv, ahead of any parsed option result. */
+function argsWantJson(args) {
+  return args.some((arg) => arg === "--json" || arg?.startsWith("--json="));
+}
+
+/** Normalize a thrown value to a safe error string for CLI output. */
+function describeCliError(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
 if (cliArgs[0] && cliArgs[0] !== "--stdio") {
-  const exitCode = await runCli(cliArgs);
-  process.exit(typeof exitCode === "number" ? exitCode : 0);
+  try {
+    const exitCode = await runCli(cliArgs);
+    process.exit(typeof exitCode === "number" ? exitCode : 0);
+  } catch (error) {
+    reportCliFailure(argsWantJson(cliArgs), describeCliError(error));
+    process.exit(1);
+  }
 }
 
 const server = new McpServer({

--- a/test/unit/mcp-cli-basics.test.ts
+++ b/test/unit/mcp-cli-basics.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, expect, it } from "vitest";
-import { closeFixtureServer, createPacketRepo, run, runAsync, startFixtureServer } from "./support/mcp-cli-harness";
+import { closeFixtureServer, createPacketRepo, run, runAsync, runExpectingFailure, startFixtureServer } from "./support/mcp-cli-harness";
 import mcpPackageJson from "../../packages/loopover-mcp/package.json";
 
 describe("loopover-mcp CLI — basics", () => {
@@ -160,6 +160,27 @@ describe("loopover-mcp CLI — basics", () => {
   it("guides unknown commands to --help", () => {
     expect(() => run(["bogus-command"])).toThrow(/Unknown command: bogus-command/);
     expect(() => run(["bogus-command"])).toThrow(/loopover-mcp --help/);
+  });
+
+  it("emits a parseable { ok: false, error } object on stdout for --json failures instead of a raw stack trace (#5928)", () => {
+    const unknownCommand = runExpectingFailure(["bogus-command", "--json"]);
+    expect(unknownCommand.status).not.toBe(0);
+    expect(unknownCommand.stderr).toBe("");
+    expect(JSON.parse(unknownCommand.stdout)).toMatchObject({ ok: false, error: expect.stringMatching(/Unknown command: bogus-command/) });
+
+    const missingLogin = runExpectingFailure(["preflight", "--json"]);
+    expect(missingLogin.status).not.toBe(0);
+    expect(JSON.parse(missingLogin.stdout)).toMatchObject({ ok: false, error: expect.stringMatching(/Pass --login <github-login> or set LOOPOVER_LOGIN/) });
+
+    const badProfile = runExpectingFailure(["init-client", "--print", "codex", "--agent-profile", "autopilot", "--json"]);
+    expect(badProfile.status).not.toBe(0);
+    expect(JSON.parse(badProfile.stdout)).toMatchObject({ ok: false, error: expect.stringMatching(/Unsupported agent profile/) });
+
+    // the non-`--json` path is unchanged: plain text on stderr, nothing on stdout.
+    const plainFailure = runExpectingFailure(["bogus-command"]);
+    expect(plainFailure.status).not.toBe(0);
+    expect(plainFailure.stdout).toBe("");
+    expect(plainFailure.stderr).toMatch(/Unknown command: bogus-command/);
   });
 
   it("suggests the closest command for a near-miss typo", () => {

--- a/test/unit/support/mcp-cli-harness.ts
+++ b/test/unit/support/mcp-cli-harness.ts
@@ -14,16 +14,24 @@ export async function closeFixtureServer() {
 }
 
 export function run(args: string[], env: Record<string, string> = {}) {
-  return execFileSync("node", [bin, ...args], {
-    encoding: "utf8",
-    env: {
-      ...process.env,
-      LOOPOVER_API_TIMEOUT_MS: "1000",
-      LOOPOVER_CONFIG_DIR: mkdtempSync(join(tmpdir(), "loopover-cli-config-")),
-      ...env,
-    },
-    stdio: ["ignore", "pipe", "pipe"],
-  });
+  try {
+    return execFileSync("node", [bin, ...args], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        LOOPOVER_API_TIMEOUT_MS: "1000",
+        LOOPOVER_CONFIG_DIR: mkdtempSync(join(tmpdir(), "loopover-cli-config-")),
+        ...env,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (error) {
+    // A failing command's message may now land on stdout (the --json contract) or stderr (plain text) --
+    // fold both into the thrown Error's message so callers can keep matching it with toThrow(/regex/).
+    const failure = error as NodeJS.ErrnoException & { stdout?: string };
+    if (failure instanceof Error && failure.stdout) failure.message = `${failure.message}\n${failure.stdout}`;
+    throw failure;
+  }
 }
 
 export function runAsync(args: string[], env: Record<string, string> = {}) {
@@ -42,13 +50,34 @@ export function runAsync(args: string[], env: Record<string, string> = {}) {
       },
       (error, stdout, stderr) => {
         if (error) {
-          reject(new Error(`${error.message}\n${stderr}`));
+          reject(new Error(`${error.message}\n${stdout}\n${stderr}`));
           return;
         }
         resolve(stdout);
       },
     );
   });
+}
+
+/** Run a command expected to fail and return its exit code + both streams, instead of throwing --
+ *  for asserting the shape of the failure output itself (e.g. the --json `{ ok: false, error }` contract). */
+export function runExpectingFailure(args: string[], env: Record<string, string> = {}) {
+  try {
+    execFileSync("node", [bin, ...args], {
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        LOOPOVER_API_TIMEOUT_MS: "1000",
+        LOOPOVER_CONFIG_DIR: mkdtempSync(join(tmpdir(), "loopover-cli-config-")),
+        ...env,
+      },
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+  } catch (error) {
+    const failure = error as NodeJS.ErrnoException & { status?: number | null; stdout?: string; stderr?: string };
+    return { status: failure.status ?? null, stdout: failure.stdout ?? "", stderr: failure.stderr ?? "" };
+  }
+  throw new Error(`expected \`node ${bin} ${args.join(" ")}\` to fail`);
 }
 
 export function git(cwd: string, ...args: string[]) {


### PR DESCRIPTION
- **docs(miner): AMS storage-abstraction research — datastore backend comparison (#5760)**
- **fix(rebrand): full-cutover rename remaining internal gittensory runtime identifiers (#5761)**
- **refactor(engine): extract the pull-request-target-key parser into loopover-engine (#5762)**
- **docs(miner): AMS auth/identity research — hosted login-layer options (#5764)**
- **fix(rebrand): full-cutover rename miner/AMS per-repo and operator config filenames (#5765)**
- **feat(api): add post-merge incident reporting for already-merged PRs (#5766)**
- **fix(review): trim the Improvement signal row to a concise value rating (#5767)**
- **fix(rebrand): full-cutover rename Prometheus/Alertmanager/Grafana observability identifiers (#5768)**
- **feat(review): add a shared beta-collapsible convention for the PR comment (#5769)**
- **docs(engine): verify git mv rename recognition in coverage tooling (#5770)**
- **fix(review): never render a ❌ for a non-Gittensor contributor (#5100) (#5774)**
- **feat(engine): extract content-lane's pure leaf modules to loopover-engine (#5775)**
- **fix(api): audit registered-vs-installed dashboard/digest copy (#5026) (#5776)**
- **feat(engine): extract settings leaf modules to loopover-engine (#5779)**
- **refactor(engine): move the unlinked-issue candidate pre-filter into the shared engine (#5778)**
- **feat(engine): add a load-testing harness for iterate-loop under concurrent load (#5781)**
- **docs(spec): idea-intake bridge schema (#5783)**
- **docs(engine): document the deliberate gate-advisory twin divergence (#5784)**
- **feat(selfhost): optional Infisical secrets management for self-host deploys (#5785)**
- **refactor(queue): extract the public-comment merge-facts derivation from maybePublishPrPublicSurface (#4607) (#5787)**
- **feat(review): add aggregate fix-handoff block renderer (#5788)**
- **feat(miner): pre-execution feasibility check for freeform ideas (#5789)**
- **feat(review): synthesize the 'Contributor next steps' collapsible into a prioritized step (#5791)**
- **feat(mcp): add the idea-intake bridge and loopover_intake_idea tool (#5792)**
- **feat(miner): add cross-repo evaluation harness (#4788) (#5790)**
- **docs(selfhost): design doc for the scheduled docs-drift audit sweep (#3048) (#5794)**
- **feat(mcp): route ideas through intake into a loop claim plan (#5795)**
- **feat(mcp): deliver a completed loop iteration as a customer results payload (#5797)**
- **feat(mcp): stream loop progress to the customer via a progress snapshot (#5798)**
- **refactor(engine): extract signals engine with re-export shim (#4884) (#5800)**
- **feat(engine): per-tenant resource quota evaluation (#5801)**
- **feat(mcp): evaluate when a rented loop should escalate to a human (#5806)**
- **docs(engine): document the nine governor primitives in the package README (#5851)**
- **docs(gardening): correct contributor-available target to per-repo, not combined (#5808)**
- **fix(signals): require a code file before manifest_missing_tests fires (#5852)**
- **fix(miner): list queue dashboard in cli.js help text (#5853)**
- **docs: privacy audit of AMS telemetry/export surfaces for cross-tenant leakage (#5759)**
- **feat(selfhost): add n8n workflows and MinIO object storage compose profiles (#1219) (#5777)**
- **feat(miner): honor kill-switch mid-attempt during iterate-loop (#5799)**
- **feat(engine): per-tenant configuration layer (#5804)**
- **feat(selfhost): bridge fleet-mode miner state to the ams-observability exporter (#5844)**
- **docs(engine): add a Tenant quota README section (#5860)**
- **fix(engine): clamp rate-limit retryAfterMs to at most one window on a backward clock (#5855)**
- **fix(review): recognize export const enum and abstract class in impact-symbols (#5858)**
- **test(review): cover review-diff.ts non-positive-budget guard and header count defaults (#5857)**
- **fix(ci): sync miner engine-version pin on the engine release branch (#5856)**
- **test(selfhost): cover jobCoalesceKey missing-field fallbacks for 6 job types (#5862)**
- **fix(queue): cap backlog-convergence re-review attempts per head SHA (#5859)**
- **docs(engine): document the Rent-a-Loop pipeline modules (#5868)**
- **fix(review): exclude maintainer PRs from the slop-discrimination alert (#5863)**
- **test(miner): rename gittensory-miner/ams prose to loopover-miner/ams (#5874)**
- **chore(release): cut engine v3.1.0 (#5807)**
- **test(miner): rename gittensory-miner/ams prose to loopover-miner/ams (batch 2) (#5878)**
- **docs(ui): rename gittensory prose to loopover across docs routes (#5881)**
- **docs(review): rename gittensory prose to loopover in src/review (batch A) (#5883)**
- **chore(release): cut mcp v2.0.0 (#5735)**
- **fix(review): restore engine-parity after gittensory rename drift (#5892)**
- **docs(review): rename gittensory prose to loopover in src/review (batch B) (#5886)**
- **fix(test): stop hardcoding the current miner version as a golden value (#5891)**
- **docs: rename gittensory prose to loopover in README and config example (#5901)**
- **test(miner): rename gittensory-miner/ams prose to loopover-miner/ams (batch 3) (#5888)**
- **docs(db): rename gittensory prose to loopover in migration headers (#5900)**
- **fix(ui): widen the ui-kit consumer range past its 1.0.0 pre-release cap (#5904)**
- **fix(config): resync .loopover.yml.example with loopover.full.yml (#5908)**
- **docs(engine): rename gittensory prose to loopover in packages/loopover-engine (batch B) (#5898)**
- **docs(miner): rename gittensory prose to loopover in miner/mcp packages (#5899)**
- **fix(agent): make the fleet-wide DB freeze absolute, drop the per-repo bypass (#5912)**
- **chore(release): cut engine v3.1.1 (#5910)**
- **fix(github): migrate repo identity on a GitHub repository rename webhook**
- **test(miner): fix stale gittensory identifiers in cross-repo-evaluation test**
- **chore(release): cut ui-kit v1.0.0 (#5911)**
- **fix(ci): authenticate release-please with a PAT instead of GITHUB_TOKEN**
- **test(miner): fix two more stale gittensory literals from #5899**
- **fix(test): match miner-cross-repo-evaluation.test.ts to the renamed loopover API**
- **chore(release): cut mcp v3.0.0**
- **chore(release): sync package-lock.json**
- **docs(core): rename gittensory prose to loopover in signals/selfhost/services**
- **fix(core): update test fixtures for renamed self-repo/webhook-map keys**
- **fix(core): fix second stale repo-name fixture in review-recap.test.ts**
- **chore(release): cut miner v3.0.0**
- **chore(release): sync package-lock.json**
- **fix(github): extend repo-rename identity migration to review/audit tables**
- **docs(core): rename gittensory prose to loopover in remaining src subdirs (#5895)**
- **feat(gate): configurable advisory check-runs so a stuck external status never freezes the gate (#4372)**
- **test(gate): pin the advisory-hold cache-invalidation guarantee end-to-end (#4372)**
- **docs(engine): rename gittensory prose to loopover in packages/loopover-engine (batch A) (#5897)**
- **docs: fix post-rebrand dead gittensory-* references in contributor docs (#5884)**
- **docs(skill): document the extension lint/typecheck CI checks omitted from the table and test:ci (#5894)**
- **fix(github): extend repo-rename identity migration to analytics tables (#5953)**
- **fix(docs): rename stale gittensory reference in miner MCP client-config doc (#5957)**
- **fix(rebrand): rename gittensory-cli- tmpdir prefix across mcp-cli test family (#5958)**
- **fix(rebrand): rename gittensory-app.env default output path (#5959)**
- **fix(github): extend repo-rename identity migration to REES/parity tables (#5954)**
- **fix(rebrand): rename x-gittensory-request-id header to x-loopover-request-id (#5960)**
- **feat(review): add OpenAI and Anthropic API key patterns to secret scan**
- **feat(ci): upload loopover-ui bundle stats to Codecov**
- **fix(rebrand): rename gittensory-repo-focus-manifest.ts module**
- **feat(miner): expose the calibration report as a read-only MCP tool**
- **feat(mcp): expose skipped-PR audit trail as a maintainer MCP tool**
- **feat(mcp): expose repo registration readiness as a read-only MCP tool**
- **chore(release): cut orb-v2.0.0**
- **fix(rebrand): rename gittensory-mcp prose cluster and fix release-candidate binary name**
- **fix(rebrand): rename stale JSONbored/gittensory reference in fallback-manifest comment**
- **fix(rebrand): rename gittensory-mcp CLI snippets and JSON keys in apps/loopover-ui**
- **fix(review): treat a blank consentPhrase as unset in evaluateClaCheck (#5838)**
- **fix(review): sanitize control characters in RAG chunk text before Postgres insert**
- **fix(selfhost): preserve stack traces and split fingerprints for RAG/enrichment Sentry captures**
- **fix(review): scan added lines whose content starts with ++ for secrets (#5942) (#5952)**
- **fix(signals): filter public-unsafe wantedPaths/preferredLabels from manifest findings (#5967)**
- **fix(queue): scan patch-less copied/changed/unchanged files for secrets (#5947) (#5951)**
- **feat(selfhost): warn loudly when the private config mount is empty**
- **fix(review): apply the prompt-injection reputation override before the minSample guard (#5975)**
- **fix(review): hash a JSON payload in linkedIssueSatisfactionCacheInputFingerprint (#5976)**
- **fix(selfhost): give structural AI-provider config errors a long circuit-breaker cooldown**
- **docs(miner): point the discovery-plane operator guide at the now-shipped discovery-index contract (#5978)**
- **feat(selfhost): add a --json output mode to loopover-config-lint (#5931) (#5979)**
- **docs(engine): add TSDoc to goal-model.ts (#5981)**
- **fix(signals): filter wantedPaths before interpolating focus-area PR guidance (#5987)**
- **fix(mcp): make loopover-mcp CLI failures respect --json**
