### PR TITLE
fix(selfhost): default miner DR scripts to the post-rename config dir

### DIFF
--- a/scripts/backup-miner.sh
+++ b/scripts/backup-miner.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# gittensory-miner local-state backup (#4872): every store is an independent SQLite file directly under
+# loopover-miner local-state backup (#4872): every store is an independent SQLite file directly under
 # LOOPOVER_MINER_CONFIG_DIR (packages/loopover-miner/docs/operations-runbook.md's "Local state at a
 # glance") -- there is no Postgres/Qdrant involved, so this is deliberately a simpler sibling to
 # scripts/backup.sh, not a reuse of it (that script's manifest/multi-target logic has nothing to compose with
@@ -17,7 +17,7 @@
 #   LOOPOVER_MINER_CONFIG_DIR=/data/miner LOOPOVER_MINER_BACKUP_RETAIN=14 sh scripts/backup-miner.sh
 set -eu
 
-STATE_DIR="${LOOPOVER_MINER_CONFIG_DIR:-$HOME/.config/gittensory-miner}"
+STATE_DIR="${LOOPOVER_MINER_CONFIG_DIR:-$HOME/.config/loopover-miner}"
 OUT_DIR="${LOOPOVER_MINER_BACKUP_DIR:-$STATE_DIR/backups}"
 RETAIN="${LOOPOVER_MINER_BACKUP_RETAIN:-7}"
 

--- a/scripts/restore-miner.sh
+++ b/scripts/restore-miner.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# gittensory-miner local-state restore (#4872): the read side of scripts/backup-miner.sh. STOP the miner (and
+# loopover-miner local-state restore (#4872): the read side of scripts/backup-miner.sh. STOP the miner (and
 # any loop/systemd/docker service) before running this -- it overwrites the live state directory and does not
 # detect a running process itself, the same "stop first" precondition operations-runbook.md's "ledger
 # corrupted" scenario already documents for manual recovery.
@@ -15,14 +15,14 @@
 #   sh scripts/restore-miner.sh --yes /path/to/backups/<ts>   # restores a specific backup
 set -eu
 
-STATE_DIR="${LOOPOVER_MINER_CONFIG_DIR:-$HOME/.config/gittensory-miner}"
+STATE_DIR="${LOOPOVER_MINER_CONFIG_DIR:-$HOME/.config/loopover-miner}"
 BACKUP_DIR="${LOOPOVER_MINER_BACKUP_DIR:-$STATE_DIR/backups}"
 
 usage() {
   cat <<USAGE >&2
 Usage: $0 --yes [BACKUP_DIR]
 
-Restores gittensory-miner local state from a backup produced by backup-miner.sh.
+Restores loopover-miner local state from a backup produced by backup-miner.sh.
 
   BACKUP_DIR   A specific timestamped backup directory. Defaults to the newest one
                under \$LOOPOVER_MINER_BACKUP_DIR ($BACKUP_DIR).
@@ -98,4 +98,4 @@ for db in "$SOURCE"/*.sqlite3; do
   echo "[restore-miner] restored $name"
 done
 
-echo "[restore-miner] complete. Run 'gittensory-miner doctor --json' to verify."
+echo "[restore-miner] complete. Run 'loopover-miner doctor --json' to verify."

--- a/test/unit/miner-dr-scripts-config-default.test.ts
+++ b/test/unit/miner-dr-scripts-config-default.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+// Regression guard for #5933: the AMS miner's DR script pair (backup-miner.sh / restore-miner.sh) must default
+// their working directory to the miner's real, current config dir (`~/.config/loopover-miner`, per
+// packages/loopover-miner/lib/local-store.js's resolveLocalStoreDbPath) and NOT the pre-rename
+// `~/.config/gittensory-miner`, so an operator who never sets LOOPOVER_MINER_CONFIG_DIR backs up/restores real
+// state instead of a directory that no longer exists after the rebrand's hard cutover. These are `scripts/**`
+// shell files, outside Codecov's coverage.include, so this content check is their only automated guard for the
+// default (the sibling miner-backup-restore-scripts.test.ts always sets LOOPOVER_MINER_CONFIG_DIR explicitly, so
+// it never exercises the default). Pattern mirrors test/unit/miner-docker-compose.test.ts: readFileSync + assert.
+const SCRIPTS_DIR = join(process.cwd(), "scripts");
+const CURRENT_DEFAULT = "$HOME/.config/loopover-miner";
+
+describe("miner DR scripts default config dir (#5933)", () => {
+  for (const script of ["backup-miner.sh", "restore-miner.sh"]) {
+    const source = readFileSync(join(SCRIPTS_DIR, script), "utf8");
+
+    it(`${script} defaults STATE_DIR to the current ~/.config/loopover-miner`, () => {
+      expect(source).toContain(`STATE_DIR="\${LOOPOVER_MINER_CONFIG_DIR:-${CURRENT_DEFAULT}}"`);
+    });
+
+    it(`${script} carries no pre-rename gittensory-miner residue`, () => {
+      expect(source).not.toContain("gittensory-miner");
+    });
+  }
+});


### PR DESCRIPTION
Closes #5933.

`scripts/backup-miner.sh` and `scripts/restore-miner.sh` defaulted `STATE_DIR` to the **pre-rename** `$HOME/.config/gittensory-miner`. The miner's real current default is `~/.config/loopover-miner` (per `packages/loopover-miner/lib/local-store.js`'s `resolveLocalStoreDbPath`, shared by every store), so an operator who never sets `LOOPOVER_MINER_CONFIG_DIR` would run a backup/restore against a directory that no longer exists after the rebrand's hard cutover — the script exits 1 ("nothing to back up"), easy to miss in an unattended cron/systemd timer.

### Changes
- **`scripts/backup-miner.sh`** / **`scripts/restore-miner.sh`**: `STATE_DIR` default `gittensory-miner` → `loopover-miner` (no dual-read/alias, matching the CHANGELOG's no-migration-shim mandate). Refreshed the describing header/usage comments to the current name (kept the `#4872` issue references).
- **`test/unit/miner-dr-scripts-config-default.test.ts`** (new): the regression guard the issue asks for — reads both scripts and asserts the default fallback is `~/.config/loopover-miner` and that no `gittensory-miner` residue remains. Mirrors `test/unit/miner-docker-compose.test.ts`'s `readFileSync`+assert pattern.

### Validation
- **New regression test passes** (4/4).
- **Existing `test/unit/miner-backup-restore-scripts.test.ts` still green** (14/14) — it always sets `LOOPOVER_MINER_CONFIG_DIR` explicitly, so the default change doesn't affect it.
- `sh -n` clean on both scripts; the `loopover-miner doctor` subcommand referenced in restore output is real (`packages/loopover-miner/bin/loopover-miner.js`).
- Scripts are `scripts/**`, outside Codecov's `coverage.include`, so no patch-coverage gate applies.
- Confirmed no other repo file depends on the old `~/.config/gittensory-miner` default (the two CHANGELOG references are intentional historical notes).