### PR TITLE
fix(signals): make blockers explain every not-ready registration report (#5946)

### DIFF
--- a/src/signals/registration-readiness.ts
+++ b/src/signals/registration-readiness.ts
@@ -177,6 +177,7 @@ export function buildRegistrationReadiness(input: RegistrationReadinessInput): R
   const blockers = [
     ...(!isRegistered ? ["Repository is not registered in the latest LoopOver registry snapshot."] : []),
     ...(configFragile ? ["Repository config quality is fragile."] : []),
+    ...(configNeedsAttention ? ["Repository config quality needs attention before registration promotion."] : []),
     ...(intakeBlocked ? ["Contributor intake health is blocked."] : []),
   ];
 
@@ -200,7 +201,9 @@ export function buildRegistrationReadiness(input: RegistrationReadinessInput): R
   };
 
   const warnings = [
-    ...(configNeedsAttention ? ["Repository config quality needs attention before registration promotion."] : []),
+    // configNeedsAttention is a blocker (not a warning), mirroring how configFragile is treated — the two
+    // needs-attention tiers of the same configQuality.level stay consistent, and blockers fully explains
+    // ready === false without double-flagging the same fact as a warning (#5946).
     ...(contributorIntakeHealth.level === "strained" ? ["Contributor intake is strained; expect more maintainer triage."] : []),
     ...(settings.publicSurface === "off" ? ["GitHub App public surface is disabled; maintainers will not get comment/label assistance."] : []),
     ...testCoverageHealth.warnings,
@@ -209,7 +212,9 @@ export function buildRegistrationReadiness(input: RegistrationReadinessInput): R
     ...upstreamRegistryDriftWarnings,
   ];
 
-  const ready = blockers.length === 0 && !configFragile && !configNeedsAttention;
+  // configFragile and configNeedsAttention are now both blockers, so blockers.length === 0 alone fully
+  // determines readiness — blockers is the single source of truth for every ready === false reason (#5946).
+  const ready = blockers.length === 0;
 
   return {
     repoFullName,

--- a/test/unit/policy-sanitizer.test.ts
+++ b/test/unit/policy-sanitizer.test.ts
@@ -650,7 +650,9 @@ describe("readiness warnings sanitizer", () => {
       contributorIntakeHealth: { ...base.contributorIntakeHealth, level: "strained" },
     });
 
-    expect(report.warnings).toEqual(expect.arrayContaining(["Repository config quality needs attention before registration promotion.", "Contributor intake is strained; expect more maintainer triage."]));
+    // config-attention is a blocker (not a warning) since #5946; strained-intake stays a warning.
+    expect(report.blockers).toEqual(expect.arrayContaining(["Repository config quality needs attention before registration promotion."]));
+    expect(report.warnings).toEqual(expect.arrayContaining(["Contributor intake is strained; expect more maintainer triage."]));
     expect(report.warnings.join(" ")).not.toMatch(PRIVATE_TERMS_PATTERN);
     expect(report.blockers.join(" ")).not.toMatch(PRIVATE_TERMS_PATTERN);
   });

--- a/test/unit/registration-readiness.test.ts
+++ b/test/unit/registration-readiness.test.ts
@@ -210,9 +210,30 @@ describe("buildRegistrationReadiness", () => {
     });
 
     expect(report.ready).toBe(false);
-    expect(report.warnings).toEqual(
-      expect.arrayContaining(["Repository config quality needs attention before registration promotion.", "Contributor intake is strained; expect more maintainer triage."]),
-    );
+    // "needs attention" is a blocker (mirroring "fragile"), not a warning; the strained-intake note stays a warning.
+    expect(report.blockers).toContain("Repository config quality needs attention before registration promotion.");
+    expect(report.warnings).toEqual(expect.arrayContaining(["Contributor intake is strained; expect more maintainer triage."]));
+    expect(report.warnings).not.toContain("Repository config quality needs attention before registration promotion.");
+  });
+
+  // #5946: with config "needs attention" as the ONLY gating condition (everything else healthy), the report was
+  // ready === false while blockers was []. blockers must now fully explain ready === false on its own.
+  it("lists config-needs-attention in blockers when it is the only gating condition (regression for #5946)", () => {
+    const repo = repoFor("octo/attention", configFor({ repo: "octo/attention" }));
+    const base = signalsFor(repo, [], [], [label("bug")]);
+    const report = buildRegistrationReadiness({
+      repoFullName: repo.fullName,
+      repo,
+      settings: settingsFor(repo.fullName),
+      installation: healthyInstall,
+      ...base,
+      configQuality: { ...base.configQuality, level: "needs_attention" },
+    });
+
+    expect(report.ready).toBe(false);
+    expect(report.blockers).toContain("Repository config quality needs attention before registration promotion.");
+    expect(report.blockers.length).toBeGreaterThan(0);
+    expect(report.warnings).not.toContain("Repository config quality needs attention before registration promotion.");
   });
 
   it("keeps the report free of forbidden public language", () => {


### PR DESCRIPTION
## Summary

Closes #5946.

`buildRegistrationReadiness` (`src/signals/registration-readiness.ts`) computed
`ready = blockers.length === 0 && !configFragile && !configNeedsAttention`, but `configNeedsAttention` only ever
appeared in `warnings`, never in `blockers`. So when `configQuality.level === "needs_attention"` and every other
input (`isRegistered`, `configFragile`, `intakeBlocked`) is healthy, the report returned `ready: false` while
`blockers` was `[]` — an empty list that contradicts the field's implied contract as "the reasons registration
isn't ready." A maintainer-facing caller rendering "why can't I register?" from `blockers` alone would see nothing,
and would have to separately cross-reference `warnings` and re-derive that one of them is actually gating `ready`.

The fix follows the approach the issue prefers, mirroring how the sibling "fragile" tier of the same
`configQuality.level` is already handled (fragile is a blocker, not a warning, and is not duplicated in `warnings`):

- Add `configNeedsAttention` to `blockers` (right after `configFragile`, keeping the two tiers of the same field
  adjacent).
- Remove its now-duplicate `warnings` entry, so the same fact isn't flagged as both — matching the `configFragile`
  precedent, which appears only in `blockers`.
- Simplify `ready` to `blockers.length === 0`, since `configFragile` and `configNeedsAttention` are now both
  blockers. `blockers` is now the single source of truth for every `ready === false` reason.

`directPrReadiness`, `issueDiscoveryReadiness`, and every other field's logic are unchanged — the fix is scoped
strictly to the `blockers`/`ready` consistency for the `configNeedsAttention` condition.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran the full `npm run test:ci` gate (exit 0) plus `npm audit --audit-level=moderate` (0 vulnerabilities). The new `configNeedsAttention` blocker branch is covered on both arms (needs-attention present and absent) via the unsharded `npm run test:coverage`; the `ready` line has no branch.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

Notes on the Safety boxes: this is a pure, private/API-first advisory report builder with **no** UI, API/OpenAPI, or auth/CORS/session surface. `RegistrationReadinessReport` is explicitly advisory and never emitted to public GitHub. The `policy-sanitizer.test.ts` invariant that asserts these report fields contain no private terms is preserved (updated to check the config-attention message in its new `blockers` home while keeping both private-terms assertions).

## UI Evidence

Not applicable — backend-only change to a deterministic report builder; no visible UI, frontend, docs, or extension surface.

## Notes

- Tests: `test/unit/registration-readiness.test.ts` — the existing "config attention and strained intake" test now asserts the config-attention message is in `blockers` (and *not* in `warnings`), and a new `regression for #5946` test covers the config-needs-attention-only scenario, asserting non-empty `blockers` explains `ready === false`. `test/unit/policy-sanitizer.test.ts` — the "config-attention warnings free of private terms" invariant is updated to assert the message in `blockers` and the strained-intake note in `warnings`, keeping both `PRIVATE_TERMS_PATTERN` checks.
- `test/unit/registration-workspace-ui.test.ts` already placed this message in `blockers` in its fixtures — consistent with this change and unmodified.
