### PR TITLE
fix(selfhost): attach a pg.Pool error listener to prevent uncaught-exception crashes

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -218,6 +218,22 @@ async function buildPostgresBackend(
   const pg = (await import("pg")).default;
   pg.types.setTypeParser(20, (v: string) => Number.parseInt(v, 10)); // int8 (COUNT) → number, like D1
   const pool = new pg.Pool({ connectionString: url, max: resolvePostgresPoolMax() });
+  // node-postgres crashes the WHOLE process with an uncaught exception if the pool has no "error" listener and
+  // an IDLE client's connection drops (Node's EventEmitter throws on an unhandled "error" event) -- confirmed
+  // live (GITTENSORY-1R/1S): Postgres itself being restarted ("terminating connection due to administrator
+  // command") took the whole app down, which then crash-looped for ~29 minutes hitting waitForPostgres's 30s
+  // boot timeout (GITTENSORY-1T) until Postgres was fully back up. The pool already removes a broken client and
+  // opens a fresh one on the next checkout on its own -- the only thing missing was a listener so Node stops
+  // treating an idle client's connection-level error as unhandled.
+  pool.on("error", (error) => {
+    console.error(
+      JSON.stringify({
+        level: "error",
+        event: "selfhost_pg_pool_error",
+        message: error instanceof Error ? error.message : "unknown error",
+      }),
+    );
+  });
   const db = createPgAdapter(pool);
   const queue = createPgQueue(pool, consume);
   await queue.init();


### PR DESCRIPTION
## Summary

- GITTENSORY-1R/1S (`uncaughtException: terminating connection due to administrator command`, 9 events) and GITTENSORY-1T (`boot: Postgres not ready after 30000ms`, 55 events) are **one incident**, confirmed via matching timestamps/container/release: Postgres itself was restarted (an administrator-issued disconnect, not a crash) at 2026-07-14 06:45:54 UTC while the app held live pooled connections.
- `src/server.ts`'s `buildPostgresBackend` does `const pool = new pg.Pool({...})` with no `.on("error", ...)` listener — confirmed via `grep -rn "new pg.Pool" src/` that this is the only pool construction site in the codebase. This is the well-known node-postgres gotcha: an **idle** client's connection-level error crashes the whole process as an uncaught exception (Node's `EventEmitter` throws when an `"error"` event has no listener).
- That crash then triggered ~29 minutes of boot-retry-crash-looping — each restart hit `waitForPostgres`'s 30s wait, which kept failing since Postgres was itself still mid-restart, until Postgres was fully back up and the container finally booted clean.
- Fix: attach `pool.on("error", ...)` right after construction. The pool already removes a broken client and opens a fresh one on the next checkout on its own — the only thing missing was a listener so Node stops treating an idle client's connection-level error as unhandled. Logs via the same `console.error` JSON convention used throughout the codebase, so the failure still reaches Sentry/Loki, just without taking the whole process down.

## Test plan
- `src/server.ts` is exempt from Codecov patch coverage (`codecov.yml`'s `ignore:` list) and has no dedicated unit-test harness for its boot sequence (it boots the whole app on import) — no new test file, consistent with this file's existing convention.
- [x] `npm run typecheck` — clean.
- [x] `npm run test:coverage` (unsharded) — full local gate green, no regressions.
- [x] `npm run test:ci` — green.