### PR TITLE
fix(mcp): make decision-pack and repo-decision CLI commands honor --help

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.js
+++ b/packages/loopover-mcp/bin/loopover-mcp.js
@@ -2160,7 +2160,21 @@ async function issueSlopCli(args) {
   for (const finding of payload.findings ?? []) process.stdout.write(`- ${finding.title}: ${finding.detail}\n`);
 }
 
+function printDecisionPackHelp() {
+  process.stdout.write(
+    [
+      "Usage: loopover-mcp decision-pack --login <github-login> [--json]",
+      "",
+      "Fetch the cached (or freshly built) contributor decision pack for a GitHub login.",
+      "Mirrors the loopover_get_decision_pack MCP tool and GET /v1/contributors/{login}/decision-pack. No source upload.",
+      "",
+      "Pass --json for machine-readable output.",
+    ].join("\n") + "\n",
+  );
+}
+
 async function decisionPackCli(options) {
+  if (options.help === true) return printDecisionPackHelp();
   const login = options.login ?? process.env.LOOPOVER_LOGIN ?? process.env.GITHUB_LOGIN;
   if (!login) throw new Error("Pass --login <github-login> or set LOOPOVER_LOGIN.");
   const payload = await getDecisionPackWithCache(login);
@@ -2173,7 +2187,21 @@ async function decisionPackCli(options) {
   if (payload.cache?.rerunGuidance) process.stdout.write(`Rerun when: ${payload.cache.rerunGuidance}\n`);
 }
 
+function printRepoDecisionHelp() {
+  process.stdout.write(
+    [
+      "Usage: loopover-mcp repo-decision --login <github-login> --repo owner/repo [--json]",
+      "",
+      "Fetch the cached (or freshly built) repo decision for a GitHub login and repo.",
+      "Mirrors the loopover_explain_repo_decision MCP tool. No source upload.",
+      "",
+      "Pass --json for machine-readable output.",
+    ].join("\n") + "\n",
+  );
+}
+
 async function repoDecisionCli(options) {
+  if (options.help === true) return printRepoDecisionHelp();
   const login = options.login ?? process.env.LOOPOVER_LOGIN ?? process.env.GITHUB_LOGIN;
   if (!login) throw new Error("Pass --login <github-login> or set LOOPOVER_LOGIN.");
   const repoFullName = options.repo;

--- a/test/unit/mcp-cli-packets.test.ts
+++ b/test/unit/mcp-cli-packets.test.ts
@@ -73,6 +73,20 @@ describe("loopover-mcp CLI — packets", () => {
     });
   });
 
+  it("prints decision-pack help without requiring --login or making a network call", () => {
+    const help = run(["decision-pack", "--help"]);
+    expect(help).toMatch(/Usage: loopover-mcp decision-pack/);
+    expect(help).toMatch(/loopover_get_decision_pack/);
+    expect(help).toMatch(/contributor decision pack/);
+  });
+
+  it("prints repo-decision help without requiring --login/--repo or making a network call", () => {
+    const help = run(["repo-decision", "--help"]);
+    expect(help).toMatch(/Usage: loopover-mcp repo-decision/);
+    expect(help).toMatch(/loopover_explain_repo_decision/);
+    expect(help).toMatch(/repo decision/);
+  });
+
   it("ignores incompatible decision-pack cache entries and clears cache entries on request", async () => {
     tempDir = mkdtempSync(join(tmpdir(), "loopover-cli-"));
     const url = await startFixtureServer();


### PR DESCRIPTION
## Summary

- `decisionPackCli` and `repoDecisionCli` in `packages/loopover-mcp/bin/loopover-mcp.js` were wired into `runCli`'s dispatch table and `CLI_COMMAND_SPEC` like every other single-purpose subcommand, but unlike `reviewPrCli`, `lintPrTextCli`, `validateConfigCli`, `slopRiskCli`, and `issueSlopCli`, neither one checked for `--help`, so `loopover-mcp decision-pack --help` fell straight into the `--login` requirement and threw a login error instead of printing usage.
- Adds `printDecisionPackHelp()` / `printRepoDecisionHelp()` and short-circuits both commands on `options.help === true` (the same pattern `reviewPrCli` already uses, since both commands receive pre-parsed `options` from `runCli`, not raw `args`). No other behavior changed.

Closes #5927

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- `packages/loopover-mcp/**` is outside this repo's Codecov `coverage.include` (see `vitest.config.ts`), so `codecov/patch` does not numerically measure this change. Behavioral regression coverage is enforced instead by the `test/unit/mcp-cli-*.test.ts` subprocess suite (run via `test:mcp-pack`/`test:ci`), which now asserts both `--help` invocations print usage and exit 0 without requiring `--login`/`--repo` or making a network call. `npm run test:coverage` passed the full unsharded suite except a pre-existing, unrelated failure in `test/unit/selfhost-ams-reporting.test.ts` caused by this local environment lacking the `sqlite3` binary — reproduces identically with this change stashed out.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

Not applicable: no auth/cookie/CORS/session code was touched, and this is a CLI-only change with no UI surface.

## UI Evidence

Not applicable — this is a CLI-only change (`packages/loopover-mcp/bin/loopover-mcp.js`), no UI/frontend/docs surface changed.

## Notes

- The two new `printDecisionPackHelp()` / `printRepoDecisionHelp()` functions mirror the wording and structure of the existing `print*Help` functions in the same file (`printReviewPrHelp`, `printLintPrTextHelp`, etc.), including the "No source upload." / "Pass --json for machine-readable output." lines and their `Usage:` line taken verbatim from `printHelp()`'s top-level usage listing.
