### PR TITLE
fix(miner): reject dash-prefixed baseBranch/remoteUrl in repo-clone (#5923)

### DIFF
--- a/packages/loopover-miner/lib/repo-clone.js
+++ b/packages/loopover-miner/lib/repo-clone.js
@@ -37,6 +37,11 @@ function isPathTraversalSegment(segment) {
   return segment === "." || segment === "..";
 }
 
+// Reject values that git would interpret as options when passed as argv (e.g. `--upload-pack=...`).
+function isUnsafeGitArgValue(value) {
+  return typeof value === "string" && value.startsWith("-");
+}
+
 function normalizeRepoFullName(repoFullName) {
   if (typeof repoFullName !== "string") throw new Error("invalid_repo_full_name");
   const [owner, repo, extra] = repoFullName.trim().split("/");
@@ -81,9 +86,16 @@ export async function ensureRepoCloned(repoFullName, options = {}) {
   const timeoutMs = Number.isFinite(options.timeoutMs) ? options.timeoutMs : 120_000;
   const runGit = options.runGit ?? defaultRunGit;
 
+  if (isUnsafeGitArgValue(baseBranch)) {
+    return { ok: false, repoPath, error: "invalid_base_branch" };
+  }
+
   if (!existsSync(repoPath)) {
     mkdirSync(join(cloneBaseDir, target.owner), { recursive: true, mode: 0o700 });
     const cloneUrl = typeof options.remoteUrl === "string" && options.remoteUrl.trim() ? options.remoteUrl.trim() : `https://github.com/${target.owner}/${target.repo}.git`;
+    if (isUnsafeGitArgValue(cloneUrl)) {
+      return { ok: false, repoPath, error: "invalid_remote_url" };
+    }
     const cloned = await runGit(["clone", cloneUrl, repoPath], cloneBaseDir, timeoutMs);
     if (!cloned.ok) return { ok: false, repoPath, error: cloned.stderr || "git_clone_failed" };
     return { ok: true, repoPath };

--- a/test/unit/miner-repo-clone.test.ts
+++ b/test/unit/miner-repo-clone.test.ts
@@ -147,4 +147,35 @@ describe("ensureRepoCloned (#5132)", () => {
     expect(result.ok).toBe(false);
     expect(result.error).toBe("git_clone_failed");
   });
+
+  it("rejects a dash-prefixed baseBranch before invoking git (#5923)", async () => {
+    const root = tempRoot("loopover-miner-repo-clone-unsafe-branch-");
+    const originPath = initOriginRepo(root);
+    const cloneBaseDir = join(root, "cache");
+    await ensureRepoCloned("acme/widgets", { cloneBaseDir, remoteUrl: originPath });
+
+    let runGitCalls = 0;
+    const runGit = async () => {
+      runGitCalls += 1;
+      return { ok: true, stdout: "", stderr: "" };
+    };
+    const result = await ensureRepoCloned("acme/widgets", { cloneBaseDir, remoteUrl: originPath, baseBranch: "--force", runGit });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("invalid_base_branch");
+    expect(runGitCalls).toBe(0);
+  });
+
+  it("rejects a dash-prefixed remoteUrl before invoking git (#5923)", async () => {
+    const root = tempRoot("loopover-miner-repo-clone-unsafe-url-");
+    const cloneBaseDir = join(root, "cache");
+    let runGitCalls = 0;
+    const runGit = async () => {
+      runGitCalls += 1;
+      return { ok: true, stdout: "", stderr: "" };
+    };
+    const result = await ensureRepoCloned("acme/widgets", { cloneBaseDir, remoteUrl: "--upload-pack=evil", runGit });
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe("invalid_remote_url");
+    expect(runGitCalls).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #5923

`ensureRepoCloned()` already hardens `owner`/`repo` against path traversal, but `baseBranch` and caller-supplied `remoteUrl` were only trimmed before being passed into `git` argv. Values beginning with `-` are a well-known git argument-injection vector (e.g. `--upload-pack=...` on clone, `--force` on checkout).

## Root cause

`packages/loopover-miner/lib/repo-clone.js` validated repo segments strictly but forwarded untrusted string options directly to `runGit()` without checking for option-prefix values.

## Fix approach

- Add `isUnsafeGitArgValue()` to reject values starting with `-`
- Return `{ ok: false, error: invalid_base_branch | invalid_remote_url }` before any `runGit` call
- Regression tests assert `runGit` is never invoked for unsafe inputs

## Impact

Closes the git argument-injection gap for this reusable clone primitive without changing behavior for legitimately-formed branch names or URLs.

## Risk / tradeoffs

- Minimal: only rejects values that git itself would treat as options; default derived URLs and normal branch names are unaffected.