### PR TITLE
fix(selfhost): default miner prometheus export script to the real bin name

### DIFF
--- a/scripts/export-miner-prometheus-textfile.sh
+++ b/scripts/export-miner-prometheus-textfile.sh
@@ -2,7 +2,7 @@
 set -eu
 
 # Miner Prometheus textfile export (#4839): the miner CLI already emits four Prometheus text-exposition
-# documents -- `gittensory-miner metrics` (prediction calibration), `queue metrics` (portfolio-queue),
+# documents -- `loopover-miner metrics` (prediction calibration), `queue metrics` (portfolio-queue),
 # `ledger metrics` (event ledger), and `governor metrics` (rate-limit/cap-usage pressure) -- but none of them
 # is a long-running HTTP server Prometheus can scrape directly; each is a one-shot CLI command. This script
 # bridges the two with the standard node_exporter "textfile collector" pattern: run all four, concatenate their
@@ -19,7 +19,7 @@ set -eu
 # aborting the whole export -- Prometheus treats an absent series as "no data", not an error, so a partial
 # export is strictly better than a stale-forever or entirely-missing one.
 
-MINER_BIN="${LOOPOVER_MINER_BIN:-gittensory-miner}"
+MINER_BIN="${LOOPOVER_MINER_BIN:-loopover-miner}"
 OUT_FILE="${LOOPOVER_MINER_PROMETHEUS_TEXTFILE:-/var/lib/node_exporter/textfile_collector/gittensory_miner.prom}"
 TMP_FILE="${OUT_FILE}.tmp"
 

--- a/test/unit/miner-prometheus-textfile-export.test.ts
+++ b/test/unit/miner-prometheus-textfile-export.test.ts
@@ -1,0 +1,24 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+// Regression guard for #5934: scripts/export-miner-prometheus-textfile.sh bridges the miner's one-shot metrics
+// CLI into a node_exporter textfile-collector .prom. Its default MINER_BIN must be the package's real bin entry
+// `loopover-miner` (packages/loopover-miner/package.json), NOT the pre-rename `gittensory-miner`, which is not an
+// installable binary after the rebrand's hard cutover -- an operator running the script with no LOOPOVER_MINER_BIN
+// override would otherwise hit `command not found` (exit 127) and, since export_family is fail-open, silently
+// produce an empty .prom on every run. This is a `scripts/**` file outside Codecov's coverage.include, so this
+// content check is its guard. Pattern mirrors test/unit/miner-docker-compose.test.ts: readFileSync + assert.
+const SCRIPT = readFileSync(join(process.cwd(), "scripts/export-miner-prometheus-textfile.sh"), "utf8");
+
+describe("export-miner-prometheus-textfile.sh default MINER_BIN (#5934)", () => {
+  it("defaults MINER_BIN to the real bin entry loopover-miner", () => {
+    expect(SCRIPT).toContain('MINER_BIN="${LOOPOVER_MINER_BIN:-loopover-miner}"');
+  });
+
+  it("no longer references the pre-rename gittensory-miner binary", () => {
+    // The hyphenated binary name specifically -- the OUT_FILE default filename `gittensory_miner.prom`
+    // (underscore) is a separate cosmetic naming choice deliberately left unchanged by #5934.
+    expect(SCRIPT).not.toContain("gittensory-miner");
+  });
+});


### PR DESCRIPTION
Closes #5934.

`scripts/export-miner-prometheus-textfile.sh` defaulted `MINER_BIN` to `gittensory-miner`, which is not an installable binary after the rebrand's hard cutover — the package's real `bin` entry is `loopover-miner`. An operator running the script with no `LOOPOVER_MINER_BIN` override (the documented usage) hits `command not found` (exit 127) on the first call, and because `export_family` is fail-open, all four metric families silently fail and the `.prom` is never populated.

### Changes
- **`scripts/export-miner-prometheus-textfile.sh`**: `MINER_BIN` default `gittensory-miner` → `loopover-miner`. Refreshed the one matching `` `gittensory-miner metrics` `` command reference in the header comment. The `LOOPOVER_MINER_BIN` override mechanism is unchanged.
- **`test/unit/miner-prometheus-textfile-export.test.ts`** (new): the regression guard the issue asks for — `readFileSync` + assert the default `MINER_BIN` is `loopover-miner` and the hyphenated `gittensory-miner` binary name is gone. Mirrors `test/unit/miner-docker-compose.test.ts`.

### OUT_FILE decision
Per the issue's note, I **deliberately left** `OUT_FILE`'s default filename `…/gittensory_miner.prom` unchanged. It is a cosmetic filename, not a functional break like the binary — renaming it would silently move where the textfile lands and could break operators' existing node_exporter/dashboard wiring keyed on that path. The regression test asserts on the hyphenated *binary* name only, so it does not touch this separate underscore filename.

### Validation
- New regression test passes (2/2); `sh -n` clean on the script.
- Confirmed `loopover-miner` is the real bin entry (`packages/loopover-miner/package.json`) and no existing test asserted the old default.
- `scripts/**` is outside Codecov's `coverage.include`, so no patch-coverage gate applies.