### PR TITLE
fix(engine): self-plagiarism election tie fails closed as documented

### DIFF
--- a/packages/loopover-engine/src/governor/self-plagiarism.ts
+++ b/packages/loopover-engine/src/governor/self-plagiarism.ts
@@ -202,7 +202,6 @@ export function selfPlagiarismCheck(
     return buildVerdict(false, "denied", "missing_candidate_submitted_at");
   }
 
-  let bestMatch: OwnSubmissionRecord | undefined;
   let bestSimilarity = 0;
   const nearDuplicates: OwnSubmissionRecord[] = [];
 
@@ -214,7 +213,6 @@ export function selfPlagiarismCheck(
       nearDuplicates.push(prior);
       if (similarity > bestSimilarity) {
         bestSimilarity = similarity;
-        bestMatch = prior;
       }
     }
   }
@@ -241,17 +239,16 @@ export function selfPlagiarismCheck(
     candidateFingerprint,
     nearDuplicates,
   );
-  const matched =
-    winner && winner !== candidateFingerprint
-      ? winner
-      : (bestMatch ?? nearDuplicates[0]!);
+  if (winner === null) {
+    return buildVerdict(false, "denied", "ambiguous_election_tie");
+  }
 
-  const matchedPrint = normalizeFingerprint(matched.fingerprint)!;
+  const matchedPrint = normalizeFingerprint(winner.fingerprint)!;
   return buildVerdict(
     false,
     "throttled",
     "near_duplicate_self_plagiarism",
-    matched,
+    winner,
     bestSimilarity > 0
       ? bestSimilarity
       : fingerprintSimilarity(candidatePrint, matchedPrint),

--- a/packages/loopover-engine/test/self-plagiarism.test.ts
+++ b/packages/loopover-engine/test/self-plagiarism.test.ts
@@ -69,6 +69,25 @@ test("selfPlagiarismCheck: throttles a near-duplicate diff across repos when the
   assert.equal(verdict.matchedSubmission?.repoFullName, "acme/repo-a");
 });
 
+test("selfPlagiarismCheck: fails closed on a genuine election tie among near-duplicate priors", () => {
+  const shared = "shared implementation patch body tie";
+  const tiedPriorFields = {
+    fingerprint: shared,
+    submittedAt: "2026-07-09T12:00:00.000Z",
+    pullRequestNumber: 300,
+    repoFullName: "acme/dup",
+  };
+  const verdict = selfPlagiarismCheck(candidate({ fingerprint: shared }), [
+    prior(tiedPriorFields),
+    prior(tiedPriorFields),
+  ]);
+  assert.deepEqual(verdict, {
+    allowed: false,
+    eventType: "denied",
+    reason: "ambiguous_election_tie",
+  });
+});
+
 test("selfPlagiarismCheck: fails closed on missing or ambiguous fingerprint data", () => {
   assert.deepEqual(selfPlagiarismCheck(candidate({ fingerprint: "  " }), [prior()]), {
     allowed: false,

--- a/test/unit/self-plagiarism.test.ts
+++ b/test/unit/self-plagiarism.test.ts
@@ -417,9 +417,28 @@ describe("selfPlagiarismCheck (#2345)", () => {
     );
     expect(verdict).toMatchObject({
       allowed: false,
-      eventType: "throttled",
-      reason: "near_duplicate_self_plagiarism",
-      matchedSubmission: { repoFullName: "acme/repo-a" },
+      eventType: "denied",
+      reason: "ambiguous_election_tie",
+    });
+    expect(verdict.matchedSubmission).toBeUndefined();
+  });
+
+  it("denies a genuine election tie between two identically-timed near-duplicate priors", () => {
+    const shared = "shared implementation patch body tie";
+    const tiedPriorFields = {
+      fingerprint: shared,
+      submittedAt: "2026-07-09T12:00:00.000Z",
+      pullRequestNumber: 300,
+      repoFullName: "acme/dup",
+    };
+    const verdict = selfPlagiarismCheck(candidate({ fingerprint: shared }), [
+      prior(tiedPriorFields),
+      prior(tiedPriorFields),
+    ]);
+    expect(verdict).toStrictEqual({
+      allowed: false,
+      eventType: "denied",
+      reason: "ambiguous_election_tie",
     });
   });
 
@@ -517,7 +536,7 @@ describe("selfPlagiarismCheck (#2345)", () => {
     expect(verdict.eventType).toBe("throttled");
   });
 
-  it("falls back to the first near-duplicate when winner resolution and bestMatch are absent", () => {
+  it("denies when winner resolution is absent and no repo name breaks the tie", () => {
     const verdict = selfPlagiarismCheck(
       candidate({
         repoFullName: "",
@@ -536,9 +555,12 @@ describe("selfPlagiarismCheck (#2345)", () => {
       ],
       { similarityThreshold: 0 },
     );
-    expect(verdict.eventType).toBe("throttled");
-    expect(verdict.matchedSubmission?.repoFullName).toBe("");
-    expect(verdict.similarity).toBe(0);
+    expect(verdict).toMatchObject({
+      allowed: false,
+      eventType: "denied",
+      reason: "ambiguous_election_tie",
+    });
+    expect(verdict.matchedSubmission).toBeUndefined();
   });
 
   it("defaults claim member number to zero when neither pull nor issue number is present", () => {


### PR DESCRIPTION
## Summary

- `selfPlagiarismCheck` now returns `denied`/`ambiguous_election_tie` when `resolveSelfPlagiarismWinner` finds no single sibling that precedes every other near-duplicate (a genuine timing tie), matching the fail-closed contract `self-plagiarism.ts`'s own module header documents, instead of silently falling back to an arbitrary `throttled` match naming whichever sibling happened to iterate first.
- Added a regression test constructing a genuine 2-way election tie (two priors sharing identical `submittedAt` + `pullRequestNumber` + `repoFullName`) and asserting the `denied`/`ambiguous_election_tie` verdict, plus updated two existing tests that had locked in the old buggy fallback behavior for tie inputs.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — `packages/loopover-engine/src/governor/self-plagiarism.ts` is 100% statement/branch/function/line covered by `test/unit/self-plagiarism.test.ts`
- [x] `npm run build --workspace @loopover/engine` and `npm run test --workspace @loopover/engine` (553 passing)
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- `npm run actionlint`, `npm run test:workers`, `npm run build:mcp`, `npm run test:mcp-pack`, `npm run ui:openapi:check`, `npm run ui:lint`, `npm run ui:typecheck`, `npm run ui:build`, `npm audit --audit-level=moderate` are unaffected by this change (pure `packages/loopover-engine/src` logic, no UI/MCP/worker/dependency surface touched).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. (N/A — no auth/session change)
- [x] API/OpenAPI/MCP behavior is updated and tested where needed. (N/A — no API/MCP surface change)
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. (N/A — no UI change)
- [x] Visible UI changes include a `UI Evidence` section below with screenshots. (N/A — no visible UI change)
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. (N/A)

## Notes

- This is a backend-only fix inside `packages/loopover-engine/src/governor/self-plagiarism.ts` (a pure, IO-free classifier); no visible UI surface, so no `UI Evidence` section is included.

Closes #5926
