### PR TITLE
fix(miner): stop governor chokepoint gate from burning rate-limit quota on later-stage denials

### DIFF
--- a/packages/loopover-miner/lib/governor-chokepoint.js
+++ b/packages/loopover-miner/lib/governor-chokepoint.js
@@ -14,8 +14,13 @@ import { appendGovernorEvent } from "./governor-ledger.js";
 
 /**
  * Evaluate a write action against the full Governor precedence ladder, persist the resulting ledger event, and
- * advance rate-limit bucket/backoff state when the rate-limit stage actually ran (kill-switch and dry-run
- * short-circuit before rate-limit is evaluated, so bucket state is untouched in those cases).
+ * advance rate-limit bucket/backoff state only for the two outcomes that actually consumed (or were denied at)
+ * the rate-limit stage: a final `"allow"` verdict advances the bucket, and a `"rate_limit"`-stage denial bumps
+ * backoff. Every other stage -- kill-switch, dry-run, budget-cap, non-convergence, reputation-throttle,
+ * self-plagiarism, internal_error -- denies for a reason unrelated to rate limiting and must leave bucket/backoff
+ * state untouched, since no real write happened and the rate-limit stage's own "allowed" sub-verdict (still
+ * present in `decision.detail.rateLimit` once that stage has cleared) does not mean the action was ultimately
+ * allowed.
  *
  * @param {import("@loopover/engine").GovernorChokepointInput} input
  * @param {{ append?: typeof appendGovernorEvent }} [options]
@@ -33,19 +38,17 @@ export function evaluateGovernorChokepointGate(input, options = {}) {
 
   let rateLimitBuckets = input.rateLimitBuckets;
   let rateLimitBackoffAttempts = input.rateLimitBackoffAttempts;
-  if (decision.detail.rateLimit) {
-    if (decision.detail.rateLimit.allowed) {
-      rateLimitBuckets = recordWriteRateLimitAllowed(
-        input.rateLimitBuckets,
-        input.actionClass,
-        input.repoFullName,
-        input.nowMs,
-        input.rateLimitPolicies,
-      );
-      rateLimitBackoffAttempts = clearWriteRateLimitBackoff(input.rateLimitBackoffAttempts, input.actionClass, input.repoFullName);
-    } else {
-      rateLimitBackoffAttempts = recordWriteRateLimitDenied(input.rateLimitBackoffAttempts, input.actionClass, input.repoFullName);
-    }
+  if (decision.stage === "allow") {
+    rateLimitBuckets = recordWriteRateLimitAllowed(
+      input.rateLimitBuckets,
+      input.actionClass,
+      input.repoFullName,
+      input.nowMs,
+      input.rateLimitPolicies,
+    );
+    rateLimitBackoffAttempts = clearWriteRateLimitBackoff(input.rateLimitBackoffAttempts, input.actionClass, input.repoFullName);
+  } else if (decision.stage === "rate_limit") {
+    rateLimitBackoffAttempts = recordWriteRateLimitDenied(input.rateLimitBackoffAttempts, input.actionClass, input.repoFullName);
   }
 
   return { decision, recorded, rateLimitBuckets, rateLimitBackoffAttempts };

--- a/test/unit/miner-governor-chokepoint.test.ts
+++ b/test/unit/miner-governor-chokepoint.test.ts
@@ -144,6 +144,8 @@ describe("evaluateGovernorChokepointGate (#2340)", () => {
     expect(result.decision.stage).toBe("budget_cap");
     expect(result.recorded.eventType).toBe("denied");
     expect(result.decision.detail.convergence).toBeUndefined();
+    expect(result.rateLimitBuckets).toEqual({ global: {}, perRepo: {} });
+    expect(result.rateLimitBackoffAttempts).toEqual({});
   });
 
   it("a non-convergence denial records to the ledger before reputation/self-plagiarism run", () => {
@@ -157,6 +159,8 @@ describe("evaluateGovernorChokepointGate (#2340)", () => {
     expect(result.decision.stage).toBe("non_convergence");
     expect(result.recorded.eventType).toBe("denied");
     expect(result.decision.detail.reputation).toBeUndefined();
+    expect(result.rateLimitBuckets).toEqual({ global: {}, perRepo: {} });
+    expect(result.rateLimitBackoffAttempts).toEqual({});
   });
 
   it("a reputation-throttle denial records to the ledger as throttled before self-plagiarism runs", () => {
@@ -169,6 +173,8 @@ describe("evaluateGovernorChokepointGate (#2340)", () => {
     expect(result.decision.stage).toBe("reputation_throttle");
     expect(result.recorded.eventType).toBe("throttled");
     expect(result.decision.detail.selfPlagiarism).toBeUndefined();
+    expect(result.rateLimitBuckets).toEqual({ global: {}, perRepo: {} });
+    expect(result.rateLimitBackoffAttempts).toEqual({});
   });
 
   it("reputation throttle runs but does not throttle on insufficient history, reaching allow", () => {
@@ -222,6 +228,8 @@ describe("evaluateGovernorChokepointGate (#2340)", () => {
     expect(result.decision.allowed).toBe(false);
     expect(result.decision.stage).toBe("self_plagiarism");
     expect(result.recorded.eventType).toBe("throttled");
+    expect(result.rateLimitBuckets).toEqual({ global: {}, perRepo: {} });
+    expect(result.rateLimitBackoffAttempts).toEqual({});
   });
 
   it("self-plagiarism runs but allows a fingerprint distinct from recent submissions, reaching allow", () => {


### PR DESCRIPTION
Closes #5925

## Summary

- `evaluateGovernorChokepointGate` advanced the rate-limit bucket/backoff state whenever `decision.detail.rateLimit.allowed` was true, but that sub-verdict stays set on the accumulated `decision.detail` once the rate-limit stage clears -- even when a later stage (budget-cap, non-convergence, reputation-throttle, self-plagiarism) ultimately denies the action and no real write happens. Gate the bucket/backoff mutation on the final `decision.stage` instead: only `"allow"` advances the bucket, and only `"rate_limit"` records a denial backoff; every other stage now leaves rate-limit state untouched.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) -- a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This change is scoped to `packages/loopover-miner/lib/governor-chokepoint.js` and its unit test; it does not touch workflows, MCP packaging, UI, or dependencies, so the unrelated checks above were not run locally (targeted `npx vitest run test/unit/miner-governor-chokepoint.test.ts` and the broader `test/unit/miner-*` suite were run instead, all green).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable -- this is a non-UI backend fix (governor rate-limit bucket gating logic in `packages/loopover-miner/lib/governor-chokepoint.js`), no visible UI/frontend/docs/extension surface changed.

## Notes

- Extended the four existing per-stage denial tests (budget-cap, non-convergence, reputation-throttle, self-plagiarism) in `test/unit/miner-governor-chokepoint.test.ts` to assert `rateLimitBuckets`/`rateLimitBackoffAttempts` are returned unchanged from input, and confirmed the existing rate-limit-denial and allow-path tests still cover their respective branches unchanged.
