### PR TITLE
fix(miner): stop later-stage governor denials from burning rate-limit quota

### DIFF
--- a/packages/loopover-miner/lib/governor-chokepoint.js
+++ b/packages/loopover-miner/lib/governor-chokepoint.js
@@ -1,6 +1,6 @@
 // The Governor chokepoint gate (#2340). Wraps the pure `evaluateGovernorChokepoint` engine decision with the
-// two stateful side effects every caller needs: persisting the resulting ledger event, and (only when the
-// rate-limit stage actually ran) advancing/backing-off the rate-limit bucket state. This is the ONLY sanctioned
+// two stateful side effects every caller needs: persisting the resulting ledger event, and advancing/backing-off
+// the rate-limit bucket state for the actions that genuinely consumed a slot. This is the ONLY sanctioned
 // call site a real write action (open_pr, file_issue, apply_labels, post_eligibility_comment, create_branch,
 // delete_branch, generate_tests) should be gated through.
 
@@ -14,8 +14,9 @@ import { appendGovernorEvent } from "./governor-ledger.js";
 
 /**
  * Evaluate a write action against the full Governor precedence ladder, persist the resulting ledger event, and
- * advance rate-limit bucket/backoff state when the rate-limit stage actually ran (kill-switch and dry-run
- * short-circuit before rate-limit is evaluated, so bucket state is untouched in those cases).
+ * advance rate-limit bucket/backoff state only for the final verdict that actually earned it: a full `"allow"`
+ * consumes a bucket slot and clears backoff, a `"rate_limit"` denial records a backoff attempt, and every other
+ * stage (kill-switch, dry-run, and any later-stage denial) leaves rate-limit state untouched.
  *
  * @param {import("@loopover/engine").GovernorChokepointInput} input
  * @param {{ append?: typeof appendGovernorEvent }} [options]
@@ -33,19 +34,22 @@ export function evaluateGovernorChokepointGate(input, options = {}) {
 
   let rateLimitBuckets = input.rateLimitBuckets;
   let rateLimitBackoffAttempts = input.rateLimitBackoffAttempts;
-  if (decision.detail.rateLimit) {
-    if (decision.detail.rateLimit.allowed) {
-      rateLimitBuckets = recordWriteRateLimitAllowed(
-        input.rateLimitBuckets,
-        input.actionClass,
-        input.repoFullName,
-        input.nowMs,
-        input.rateLimitPolicies,
-      );
-      rateLimitBackoffAttempts = clearWriteRateLimitBackoff(input.rateLimitBackoffAttempts, input.actionClass, input.repoFullName);
-    } else {
-      rateLimitBackoffAttempts = recordWriteRateLimitDenied(input.rateLimitBackoffAttempts, input.actionClass, input.repoFullName);
-    }
+  // Gate on the FINAL stage, never on `decision.detail.rateLimit.allowed`: `detail` accumulates each stage's
+  // result as the ladder advances, so a cleared rate-limit sub-verdict stays `allowed: true` on a decision some
+  // LATER stage (budget cap, non-convergence, reputation throttle, self-plagiarism, internal error) ultimately
+  // denied. Reading it alone burned a bucket slot for a write that never happened, letting a repo that keeps
+  // failing an unrelated stage exhaust its own rate-limit window on phantom writes (#5925).
+  if (decision.stage === "allow") {
+    rateLimitBuckets = recordWriteRateLimitAllowed(
+      input.rateLimitBuckets,
+      input.actionClass,
+      input.repoFullName,
+      input.nowMs,
+      input.rateLimitPolicies,
+    );
+    rateLimitBackoffAttempts = clearWriteRateLimitBackoff(input.rateLimitBackoffAttempts, input.actionClass, input.repoFullName);
+  } else if (decision.stage === "rate_limit") {
+    rateLimitBackoffAttempts = recordWriteRateLimitDenied(input.rateLimitBackoffAttempts, input.actionClass, input.repoFullName);
   }
 
   return { decision, recorded, rateLimitBuckets, rateLimitBackoffAttempts };

--- a/test/unit/miner-governor-chokepoint.test.ts
+++ b/test/unit/miner-governor-chokepoint.test.ts
@@ -63,11 +63,15 @@ function throwingProxy(thrown: unknown): unknown {
 describe("evaluateGovernorChokepointGate (#2340)", () => {
   it("records an allow decision to the ledger and advances the rate-limit bucket", () => {
     const ledger = openLedger();
-    const result = evaluateGovernorChokepointGate(baseInput(), { append: (event) => ledger.appendGovernorEvent(event) });
+    const result = evaluateGovernorChokepointGate(baseInput({ rateLimitBackoffAttempts: { "open_pr:acme/widgets": 2 } }), {
+      append: (event) => ledger.appendGovernorEvent(event),
+    });
 
     expect(result.decision.allowed).toBe(true);
     expect(result.recorded.eventType).toBe("allowed");
     expect(result.rateLimitBuckets.global.open_pr?.count).toBe(1);
+    // Only a genuine allow consumes a slot -- and it clears any backoff the prior denials accrued.
+    expect(result.rateLimitBackoffAttempts["open_pr:acme/widgets"]).toBeUndefined();
     expect(ledger.readGovernorEvents({ repoFullName: "acme/widgets" })).toHaveLength(1);
   });
 
@@ -110,6 +114,43 @@ describe("evaluateGovernorChokepointGate (#2340)", () => {
     expect(result.rateLimitBackoffAttempts["open_pr:acme/widgets"]).toBe(1);
   });
 
+  it("REGRESSION: a denial from a stage after rate-limit never consumes a rate-limit bucket slot (#5925)", () => {
+    const ledger = openLedger();
+    // Every stage that runs AFTER rate-limit on the ladder. Each cleared the rate-limit stage -- so
+    // `detail.rateLimit.allowed` is still true on the final decision -- but no real write happened, so the
+    // bucket must not advance for any of them.
+    const laterStages: Array<{ stage: string; overrides: Record<string, unknown> }> = [
+      { stage: "budget_cap", overrides: { capUsage: { budgetSpent: 100, turnsTaken: 0, elapsedMs: 0 } } },
+      { stage: "non_convergence", overrides: { convergenceInput: { attempts: 5, consecutiveFailures: 5, reenqueues: 0, reachedDone: false } } },
+      { stage: "reputation_throttle", overrides: { reputationHistory: { decided: 10, unfavorable: 8 } } },
+      {
+        stage: "self_plagiarism",
+        overrides: {
+          selfPlagiarismCandidate: { repoFullName: "acme/widgets", fingerprint: "fix auth bug login", submittedAt: "2026-07-11T12:00:00Z" },
+          selfPlagiarismRecentSubmissions: [
+            { repoFullName: "acme/widgets", fingerprint: "fix auth bug login", submittedAt: "2026-07-10T12:00:00Z", pullRequestNumber: 42 },
+          ],
+        },
+      },
+      // A calculator that throws after rate-limit already cleared denies with `internal_error` -- same class:
+      // the accumulated rate-limit sub-verdict says "allowed", but nothing was written.
+      { stage: "internal_error", overrides: { capUsage: null } },
+    ];
+
+    for (const { stage, overrides } of laterStages) {
+      const input = baseInput({ ...overrides, rateLimitBackoffAttempts: { "open_pr:acme/widgets": 2 } });
+      const result = evaluateGovernorChokepointGate(input, { append: (event) => ledger.appendGovernorEvent(event) });
+
+      expect(result.decision.stage).toBe(stage);
+      expect(result.decision.detail.rateLimit?.allowed).toBe(true);
+      expect(result.rateLimitBuckets).toBe(input.rateLimitBuckets);
+      expect(result.rateLimitBuckets).toEqual({ global: {}, perRepo: {} });
+      // Backoff is equally untouched: a later-stage denial neither clears an existing backoff nor records one.
+      expect(result.rateLimitBackoffAttempts).toBe(input.rateLimitBackoffAttempts);
+      expect(result.rateLimitBackoffAttempts).toEqual({ "open_pr:acme/widgets": 2 });
+    }
+  });
+
   it("a caller-supplied rateLimitRandomFn is threaded through to the rate-limit calculator", () => {
     const ledger = openLedger();
     let called = false;
@@ -135,40 +176,38 @@ describe("evaluateGovernorChokepointGate (#2340)", () => {
 
   it("a budget-cap denial records to the ledger as denied before non-convergence runs", () => {
     const ledger = openLedger();
-    const result = evaluateGovernorChokepointGate(
-      baseInput({ capUsage: { budgetSpent: 100, turnsTaken: 0, elapsedMs: 0 }, capLimits: { budget: 100, turns: 100, elapsedMs: 1_000_000 } }),
-      { append: (event) => ledger.appendGovernorEvent(event) },
-    );
+    const input = baseInput({ capUsage: { budgetSpent: 100, turnsTaken: 0, elapsedMs: 0 }, capLimits: { budget: 100, turns: 100, elapsedMs: 1_000_000 } });
+    const result = evaluateGovernorChokepointGate(input, { append: (event) => ledger.appendGovernorEvent(event) });
 
     expect(result.decision.allowed).toBe(false);
     expect(result.decision.stage).toBe("budget_cap");
     expect(result.recorded.eventType).toBe("denied");
     expect(result.decision.detail.convergence).toBeUndefined();
+    expect(result.rateLimitBuckets).toBe(input.rateLimitBuckets);
   });
 
   it("a non-convergence denial records to the ledger before reputation/self-plagiarism run", () => {
     const ledger = openLedger();
-    const result = evaluateGovernorChokepointGate(
-      baseInput({ convergenceInput: { attempts: 5, consecutiveFailures: 5, reenqueues: 0, reachedDone: false } }),
-      { append: (event) => ledger.appendGovernorEvent(event) },
-    );
+    const input = baseInput({ convergenceInput: { attempts: 5, consecutiveFailures: 5, reenqueues: 0, reachedDone: false } });
+    const result = evaluateGovernorChokepointGate(input, { append: (event) => ledger.appendGovernorEvent(event) });
 
     expect(result.decision.allowed).toBe(false);
     expect(result.decision.stage).toBe("non_convergence");
     expect(result.recorded.eventType).toBe("denied");
     expect(result.decision.detail.reputation).toBeUndefined();
+    expect(result.rateLimitBuckets).toBe(input.rateLimitBuckets);
   });
 
   it("a reputation-throttle denial records to the ledger as throttled before self-plagiarism runs", () => {
     const ledger = openLedger();
-    const result = evaluateGovernorChokepointGate(baseInput({ reputationHistory: { decided: 10, unfavorable: 8 } }), {
-      append: (event) => ledger.appendGovernorEvent(event),
-    });
+    const input = baseInput({ reputationHistory: { decided: 10, unfavorable: 8 } });
+    const result = evaluateGovernorChokepointGate(input, { append: (event) => ledger.appendGovernorEvent(event) });
 
     expect(result.decision.allowed).toBe(false);
     expect(result.decision.stage).toBe("reputation_throttle");
     expect(result.recorded.eventType).toBe("throttled");
     expect(result.decision.detail.selfPlagiarism).toBeUndefined();
+    expect(result.rateLimitBuckets).toBe(input.rateLimitBuckets);
   });
 
   it("reputation throttle runs but does not throttle on insufficient history, reaching allow", () => {
@@ -209,19 +248,18 @@ describe("evaluateGovernorChokepointGate (#2340)", () => {
 
   it("a self-plagiarism denial records to the ledger as throttled", () => {
     const ledger = openLedger();
-    const result = evaluateGovernorChokepointGate(
-      baseInput({
-        selfPlagiarismCandidate: { repoFullName: "acme/widgets", fingerprint: "fix auth bug login", submittedAt: "2026-07-11T12:00:00Z" },
-        selfPlagiarismRecentSubmissions: [
-          { repoFullName: "acme/widgets", fingerprint: "fix auth bug login", submittedAt: "2026-07-10T12:00:00Z", pullRequestNumber: 42 },
-        ],
-      }),
-      { append: (event) => ledger.appendGovernorEvent(event) },
-    );
+    const input = baseInput({
+      selfPlagiarismCandidate: { repoFullName: "acme/widgets", fingerprint: "fix auth bug login", submittedAt: "2026-07-11T12:00:00Z" },
+      selfPlagiarismRecentSubmissions: [
+        { repoFullName: "acme/widgets", fingerprint: "fix auth bug login", submittedAt: "2026-07-10T12:00:00Z", pullRequestNumber: 42 },
+      ],
+    });
+    const result = evaluateGovernorChokepointGate(input, { append: (event) => ledger.appendGovernorEvent(event) });
 
     expect(result.decision.allowed).toBe(false);
     expect(result.decision.stage).toBe("self_plagiarism");
     expect(result.recorded.eventType).toBe("throttled");
+    expect(result.rateLimitBuckets).toBe(input.rateLimitBuckets);
   });
 
   it("self-plagiarism runs but allows a fingerprint distinct from recent submissions, reaching allow", () => {


### PR DESCRIPTION
## Summary

`evaluateGovernorChokepointGate` advanced rate-limit bucket state for actions that were never executed.

The engine's `evaluateGovernorChokepoint` accumulates each stage's result into `decision.detail` as the precedence ladder advances. Once the rate-limit stage clears, `decision.detail.rateLimit` stays present with `allowed: true` in the **final** decision — regardless of which later stage ultimately denied the action. The wrapper gated its side effect on that sub-verdict alone:

```js
if (decision.detail.rateLimit) {
  if (decision.detail.rateLimit.allowed) {
    rateLimitBuckets = recordWriteRateLimitAllowed(...);   // fires even when decision.stage === "budget_cap"
```

So a denial from `budget_cap`, `non_convergence`, `reputation_throttle`, or `self_plagiarism` consumed a rate-limit bucket slot for a write that never happened. A repo repeatedly failing one of those stages silently exhausted its own rate-limit window on phantom writes, making it harder to get a genuinely eligible write through once the blocking condition cleared.

The fix gates on the **final** `decision.stage` instead of the accumulated sub-verdict:

```js
if (decision.stage === "allow") {
  rateLimitBuckets = recordWriteRateLimitAllowed(...);
  rateLimitBackoffAttempts = clearWriteRateLimitBackoff(...);
} else if (decision.stage === "rate_limit") {
  rateLimitBackoffAttempts = recordWriteRateLimitDenied(...);
}
```

This also drops the now-redundant nested `detail.rateLimit` existence check — `kill_switch`/`dry_run` short-circuit before the rate-limit stage runs and simply aren't `"allow"`/`"rate_limit"`, so their existing "bucket state untouched" behavior is preserved by construction rather than by a second condition.

Behavior preserved exactly: a genuine `"allow"` still consumes a slot and clears backoff; a real `"rate_limit"` denial still records a backoff attempt; kill-switch and dry-run still leave rate-limit state untouched.

**One case beyond the issue's list, same bug class:** a calculator that throws *after* rate-limit already cleared denies with `stage: "internal_error"` while carrying the same `rateLimit.allowed: true` detail — it burned a slot for the identical reason. Gating on the final stage fixes it in the same stroke, and the regression test covers it alongside the four named stages rather than special-casing the four.

Closes #5925

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate. — see below
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

I am reporting these boxes honestly rather than checking them wholesale. `npm run test:ci` was run and got **green through `actionlint`, `db:migrations:check`, `db:schema-drift:check`, `selfhost:env-reference:check`, `miner:env-reference:check`, `selfhost:validate-observability`, `cf-typegen:check`, and `typecheck`** (it is a serial chain, so each of those passing is what let the next start). It was then interrupted partway through `test:coverage` — with no failures recorded at that point — so I have **not** personally completed the full unsharded `test:coverage`, `test:workers`, the `build:mcp`/`test:mcp-pack`/`ui:*` steps, and I am not claiming them. CI runs all of them on this PR.

What I did verify directly, targeted at this diff:

- **All four suites that touch the changed function pass: 73/73** — `miner-governor-chokepoint`, `miner-governor-chokepoint-persisted` (the `evaluateGovernorChokepointGatePersisted` wrapper, which persists exactly this bucket state), `miner-attempt-runner` (its only production caller, via the persisted wrapper), and `alerts-miner-governor-rate-limit-budget-pressure`.
- **Patch coverage: 100% of changed lines and branches**, measured empirically by intersecting `coverage/lcov.info` `DA`/`BRDA` records with `git diff -U0` rather than reading the whole-file percentage. (The file's one remaining partial branch, `options.append ?? appendGovernorEvent` on line 31, is pre-existing and untouched by this diff.)
- **The regression tests genuinely fail against the pre-fix source** — they are not tests that would pass either way. Reverting `governor-chokepoint.js` alone fails 5 of them, with `rateLimitBuckets` asserting as `{ global: { open_pr: { count: 1 } } }` where `{ global: {}, perRepo: {} }` is expected: the exact phantom increment this PR removes.
- `node --check` on the changed file (what `build:miner` does) passes; `miner:env-reference:check` passed, and this change adds/removes no `env.*` read, so no regenerated artifact is owed.
- The diff touches one miner-lib JS file plus its unit test — no schema, migration, OpenAPI, wrangler binding, MCP, or UI surface — so the steps I did not complete have no path to this change.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — **N/A:** this change touches none of those surfaces; it is confined to the miner-lib Governor wrapper's in-memory rate-limit bucket bookkeeping. (The denial/negative paths it *does* have are covered — every stage of the ladder is asserted.)
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — **N/A:** no API, OpenAPI schema, or MCP tool surface changes; `evaluateGovernorChokepointGate`'s signature and return shape are unchanged.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — **N/A:** no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository. — **N/A:** no visible UI change; the `UI Evidence` section is omitted accordingly.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — No docs needed: the module's own header and the `evaluateGovernorChokepointGate` JSDoc both described the *intended* ("only when the rate-limit stage actually ran") behavior, and are updated here to describe the now-correct, more precise rule.

## Notes

- Distinct from #5829, which fixes `retryAfterMs` clock-skew math inside `rate-limit.ts` itself. This is the cross-stage bucket-consumption bug in the JS wrapper; the engine's pure `evaluateGovernorChokepoint` is not modified.
- The regression test is table-driven over all five later stages rather than four copy-pasted cases, so a stage added to the ladder in future is a one-line addition to the table.
