### PR TITLE
fix(miner): parse queue item ids from the end so IPv6-literal hosts round-trip

### DIFF
--- a/packages/loopover-miner/lib/portfolio-queue-manager.js
+++ b/packages/loopover-miner/lib/portfolio-queue-manager.js
@@ -20,20 +20,29 @@ export function queueItemId(apiBaseUrl, repoFullName, identifier) {
   return `${apiBaseUrl}${ITEM_ID_SEPARATOR}${repoFullName}${ITEM_ID_SEPARATOR}${identifier}`;
 }
 
-/** Reverse {@link queueItemId} after engine selection so claims can target SQLite primary keys. */
+/**
+ * Reverse {@link queueItemId} after engine selection so claims can target SQLite primary keys.
+ *
+ * Splits from the END (the last two separators), not the start: `apiBaseUrl` is the only one of the three
+ * fields that can legitimately contain "::" itself — a self-hosted IPv6-literal host like
+ * `https://[::1]:3000/api/v3` is a form normalizeApiBaseUrl accepts — so a first-occurrence scan silently
+ * tore the id apart inside the host and produced three wrong fields with no error, making batchClaim target
+ * the wrong (apiBaseUrl, repoFullName, identifier) row (#5924). A repo full name never contains "::".
+ */
 export function parseQueueItemId(id) {
   if (typeof id !== "string") throw new Error("invalid_queue_item_id");
-  const firstSeparatorIndex = id.indexOf(ITEM_ID_SEPARATOR);
-  if (firstSeparatorIndex <= 0) throw new Error("invalid_queue_item_id");
-  const rest = id.slice(firstSeparatorIndex + ITEM_ID_SEPARATOR.length);
-  const secondSeparatorIndex = rest.indexOf(ITEM_ID_SEPARATOR);
-  if (secondSeparatorIndex <= 0 || secondSeparatorIndex === rest.length - ITEM_ID_SEPARATOR.length) {
-    throw new Error("invalid_queue_item_id");
-  }
+  const lastSeparatorIndex = id.lastIndexOf(ITEM_ID_SEPARATOR);
+  if (lastSeparatorIndex <= 0) throw new Error("invalid_queue_item_id");
+  const head = id.slice(0, lastSeparatorIndex);
+  const secondToLastSeparatorIndex = head.lastIndexOf(ITEM_ID_SEPARATOR);
+  if (secondToLastSeparatorIndex <= 0) throw new Error("invalid_queue_item_id");
+  const repoFullName = head.slice(secondToLastSeparatorIndex + ITEM_ID_SEPARATOR.length);
+  const identifier = id.slice(lastSeparatorIndex + ITEM_ID_SEPARATOR.length);
+  if (!repoFullName || !identifier) throw new Error("invalid_queue_item_id");
   return {
-    apiBaseUrl: id.slice(0, firstSeparatorIndex),
-    repoFullName: rest.slice(0, secondSeparatorIndex),
-    identifier: rest.slice(secondSeparatorIndex + ITEM_ID_SEPARATOR.length),
+    apiBaseUrl: head.slice(0, secondToLastSeparatorIndex),
+    repoFullName,
+    identifier,
   };
 }
 

--- a/test/unit/miner-portfolio-queue-manager.test.ts
+++ b/test/unit/miner-portfolio-queue-manager.test.ts
@@ -72,6 +72,26 @@ describe("entriesToPortfolioQueue() / selectEligibleBatch() (#4285)", () => {
     expect(() => parseQueueItemId("https://api.github.com::acme/widgets")).toThrow("invalid_queue_item_id");
     expect(() => parseQueueItemId("::acme/widgets::issue:7")).toThrow("invalid_queue_item_id");
     expect(() => parseQueueItemId("https://api.github.com::acme/widgets::")).toThrow("invalid_queue_item_id");
+    expect(() => parseQueueItemId("https://api.github.com::::issue:7")).toThrow("invalid_queue_item_id");
+  });
+
+  it("REGRESSION: queueItemId/parseQueueItemId round-trip an apiBaseUrl containing '::' (IPv6-literal host, #5924)", () => {
+    // The host itself contains "::", so a first-occurrence scan split inside `[::1]` and silently returned
+    // { apiBaseUrl: "https://[", repoFullName: "1]:3000/api/v3", identifier: "acme/widgets::issue-7" }.
+    const apiBaseUrl = "https://[::1]:3000/api/v3";
+    const id = queueItemId(apiBaseUrl, "acme/widgets", "issue-7");
+
+    expect(parseQueueItemId(id)).toEqual({ apiBaseUrl, repoFullName: "acme/widgets", identifier: "issue-7" });
+  });
+
+  it("parseQueueItemId round-trips other multi-separator apiBaseUrl forms without special-casing IPv6 (#5924)", () => {
+    for (const apiBaseUrl of ["https://[::ffff:10.0.0.1]:8443/api/v3", "https://[2001:db8::1]/api/v3", "https://[::]:3000/api/v3"]) {
+      expect(parseQueueItemId(queueItemId(apiBaseUrl, "acme/widgets", "issue:7"))).toEqual({
+        apiBaseUrl,
+        repoFullName: "acme/widgets",
+        identifier: "issue:7",
+      });
+    }
   });
 
   it("entriesToPortfolioQueue falls back to the github.com default when a row's apiBaseUrl is missing (#5563)", () => {


### PR DESCRIPTION
## Summary

`parseQueueItemId` split the composite queue-item id on the **first** `"::"`, but `apiBaseUrl` — the first field — is the one field that can legitimately contain `"::"` itself.

A self-hosted GHE `apiBaseUrl` can be an IPv6 literal, e.g. `https://[::1]:3000/api/v3`, a form `resolveForgeConfig`/`normalizeApiBaseUrl` accept. `indexOf` finds the `"::"` inside `[::1]` before the real separator, so the id parsed "successfully" into three silently-wrong fields with no error raised:

```
id:     https://[::1]:3000/api/v3::acme/widgets::issue-7
before: { apiBaseUrl: 'https://[', repoFullName: '1]:3000/api/v3', identifier: 'acme/widgets::issue-7' }
after:  { apiBaseUrl: 'https://[::1]:3000/api/v3', repoFullName: 'acme/widgets', identifier: 'issue-7' }
```

That id is the only thing `selectEligibleBatch`'s output threads back into `store.batchClaim()`, so a selected item on an IPv6-literal-hosted repo claimed the wrong `(apiBaseUrl, repoFullName, identifier)` triple — matching an unrelated row or none at all, silently breaking the batch-claim path for that host.

The fix parses from the **end** (the last two separators) instead of the first two. This isn't an IPv6 special case: `apiBaseUrl` is structurally the only field that can contain the separator as legitimate content (a repo full name never contains `"::"`), so anchoring to the end makes the encoding unambiguous for *any* `apiBaseUrl` value. `queueItemId` is unchanged — the encoder was already correct.

All existing `invalid_queue_item_id` rejections are preserved by construction, and each is still covered: a `42` non-string, `no-separators-at-all`, a single-separator id, an empty `apiBaseUrl` (`::acme/widgets::issue:7`), and an empty `identifier` (`...::acme/widgets::`). I added one more rejection case the end-anchored parse makes reachable — an empty `repoFullName` (`https://api.github.com::::issue:7`).

Closes #5924

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate. — see below
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

Reporting these honestly rather than checking them wholesale. I ran `git diff --check`, `npm run typecheck`, `npm audit --audit-level=moderate`, and the targeted suite; I did **not** personally complete the full unsharded `test:coverage`, `test:workers`, `build:mcp`/`test:mcp-pack`, or the `ui:*` steps on this branch, so I am not claiming them. CI runs all of them here.

What I verified directly, targeted at this diff:

- **`test/unit/miner-portfolio-queue-manager.test.ts`: 14/14 pass.** `parseQueueItemId` has no consumers outside this module and this test (verified by grep across the repo), so the blast radius is contained.
- **Patch coverage: 100% of changed lines and branches**, measured by intersecting `coverage/lcov.info` `DA`/`BRDA` records with `git diff -U0` rather than trusting a whole-file percentage.
- **The regression tests genuinely fail against the pre-fix source** — reverting `portfolio-queue-manager.js` alone fails both new cases with `expected { apiBaseUrl: 'https://[', …(2) }`, reproducing the issue's documented output exactly.
- `node --check` on the changed file (what `build:miner` does) passes. The change adds/removes no `env.*` read, so no regenerated artifact is owed; it touches one miner-lib JS file plus its unit test — no schema, migration, OpenAPI, wrangler binding, MCP, or UI surface.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — **N/A:** none of those surfaces are touched; this is a pure string-parsing fix in a miner-lib module. (Its own negative paths — every `invalid_queue_item_id` rejection — are covered.)
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — **N/A:** no API, OpenAPI schema, or MCP tool surface changes; `parseQueueItemId`'s signature and return shape are unchanged, and its `.d.ts` needs no edit.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — **N/A:** no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository. — **N/A:** no visible UI change; the `UI Evidence` section is omitted accordingly.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — No docs owed; the `parseQueueItemId` doc comment is updated in place to record why the parse is end-anchored.

## Notes

- The trade-off this makes explicit: an `identifier` containing `"::"` would now mis-split where `apiBaseUrl` previously did. That is the correct direction — `apiBaseUrl` has a real, reachable multi-`"::"` form (IPv6 literals) that the forge config accepts, while `repoFullName` cannot contain `"::"` at all, and it is the trade-off #5924 specifies.
- `queueItemId` (the encoder) is deliberately untouched, so every id already persisted keeps parsing identically — the only ids whose parse *changes* are the ones that were being parsed wrongly.
