### PR TITLE
fix(orb): close 5 silent-failure and missing-timeout gaps in the ORB subsystem

### DIFF
--- a/src/orb/broker.ts
+++ b/src/orb/broker.ts
@@ -116,7 +116,7 @@ async function readCachedOrbToken(env: Env, cachedJson: string | null): Promise<
     // failure class (a malformed entry or a decrypt failure, e.g. after TOKEN_ENCRYPTION_SECRET rotation) at
     // warn. Without this, a rotated/mismatched key makes every cached-token read fail permanently and silently,
     // degrading every broker call to a full GitHub token mint forever with zero signal anywhere.
-    console.warn(JSON.stringify({ level: "warn", event: "orb_token_cache_read_failed", message: error instanceof Error ? error.message : String(error).slice(0, 120) }));
+    console.warn(JSON.stringify({ level: "warn", event: "orb_token_cache_read_failed", message: String(error).slice(0, 120) }));
     return null;
   }
 }

--- a/src/orb/broker.ts
+++ b/src/orb/broker.ts
@@ -111,7 +111,12 @@ async function readCachedOrbToken(env: Env, cachedJson: string | null): Promise<
     if (!(Date.parse(entry.expiresAt) - Date.now() >= ORB_TOKEN_CACHE_MIN_REMAINING_MS)) return null;
     const token = await decryptSecret(entry.ciphertext, entry.iv, env.TOKEN_ENCRYPTION_SECRET, entry.salt);
     return { token, expiresAt: entry.expiresAt, permissions: entry.permissions ?? {} };
-  } catch {
+  } catch (error) {
+    // Was silent, unlike this function's mirror-image sibling cacheOrbToken (below), which logs the identical
+    // failure class (a malformed entry or a decrypt failure, e.g. after TOKEN_ENCRYPTION_SECRET rotation) at
+    // warn. Without this, a rotated/mismatched key makes every cached-token read fail permanently and silently,
+    // degrading every broker call to a full GitHub token mint forever with zero signal anywhere.
+    console.warn(JSON.stringify({ level: "warn", event: "orb_token_cache_read_failed", message: error instanceof Error ? error.message : String(error).slice(0, 120) }));
     return null;
   }
 }

--- a/src/orb/oauth.ts
+++ b/src/orb/oauth.ts
@@ -22,7 +22,7 @@ type GitHubOrgMembership = { role?: string; state?: string; organization?: { id?
 
 /** Exchange the OAuth code for the maintainer's access token using the ORB App's OAuth credentials. Null when the
  *  credentials aren't configured or GitHub returns no token. */
-export async function exchangeOrbOAuthCode(env: Env, code: string, fetchImpl: typeof fetch = fetch): Promise<string | null> {
+export async function exchangeOrbOAuthCode(env: Env, code: string, fetchImpl: typeof fetch = timeoutFetch): Promise<string | null> {
   if (!env.ORB_GITHUB_CLIENT_ID || !env.ORB_GITHUB_CLIENT_SECRET) return null;
   const res = await fetchImpl("https://github.com/login/oauth/access_token", {
     method: "POST",

--- a/src/orb/webhook.ts
+++ b/src/orb/webhook.ts
@@ -77,7 +77,7 @@ export async function handleOrbWebhook(c: Context<{ Bindings: Env }>): Promise<R
     // Was silent (a status:"error" DB row only, no log) unlike this same subsystem's other broker-error catches
     // (orb_broker_mint_failed, orb_relay_register_failed, orb_relay_pull_failed in src/api/routes.ts), which all
     // log a structured error so the failure reaches Sentry/Loki instead of only being visible via a DB query.
-    console.error(JSON.stringify({ level: "error", event: "orb_webhook_processing_failed", ...eventMeta, message: error instanceof Error ? error.message : String(error).slice(0, 200) }));
+    console.error(JSON.stringify({ level: "error", event: "orb_webhook_processing_failed", ...eventMeta, message: String(error).slice(0, 200) }));
     await recordOrbWebhookEvent(c.env, { ...eventMeta, status: "error" });
     return c.json({ error: "processing_failed", deliveryId }, 500);
   }

--- a/src/orb/webhook.ts
+++ b/src/orb/webhook.ts
@@ -73,7 +73,11 @@ export async function handleOrbWebhook(c: Context<{ Bindings: Env }>): Promise<R
   try {
     await upsertOrbInstallation(c.env, eventName, payload);
     await recordOrbPrOutcome(c.env, eventName, payload);
-  } catch {
+  } catch (error) {
+    // Was silent (a status:"error" DB row only, no log) unlike this same subsystem's other broker-error catches
+    // (orb_broker_mint_failed, orb_relay_register_failed, orb_relay_pull_failed in src/api/routes.ts), which all
+    // log a structured error so the failure reaches Sentry/Loki instead of only being visible via a DB query.
+    console.error(JSON.stringify({ level: "error", event: "orb_webhook_processing_failed", ...eventMeta, message: error instanceof Error ? error.message : String(error).slice(0, 200) }));
     await recordOrbWebhookEvent(c.env, { ...eventMeta, status: "error" });
     return c.json({ error: "processing_failed", deliveryId }, 500);
   }

--- a/src/queue/job-dispatch.ts
+++ b/src/queue/job-dispatch.ts
@@ -33,6 +33,7 @@ import { isRagEnabled } from "../review/rag-wire";
 import { processSubmitDraft } from "../services/draft";
 import { retryFailedRelays } from "../orb/relay";
 import { syncBrokeredInstalledRepos } from "../orb/installed-repos-sync";
+import { incr } from "../selfhost/metrics";
 import { generateSignalSnapshots } from "./signal-snapshot";
 import { runRetentionPrune } from "./retention";
 // The 15 handlers below have no reason to move -- each is only reachable via this dispatcher (or, for
@@ -70,9 +71,18 @@ export async function processJob(env: Env, message: JobMessage): Promise<void> {
     case "refresh-registry":
       await refreshRegistry(env);
       return;
-    case "sync-brokered-installed-repos":
-      await syncBrokeredInstalledRepos(env);
+    case "sync-brokered-installed-repos": {
+      const syncResult = await syncBrokeredInstalledRepos(env);
+      // syncBrokeredInstalledRepos is deliberately fail-safe (never throws -- a miss self-heals on the next
+      // scheduled tick), which also means this call site is the ONLY place a failure can ever become visible.
+      // Previously the result was discarded outright, so a sustained broker/GitHub outage here silently stopped
+      // repo-list convergence with zero signal in Sentry, Loki, or Prometheus.
+      if (syncResult.status === "failed") {
+        incr("loopover_orb_installed_repos_sync_failures_total");
+        console.error(JSON.stringify({ level: "error", event: "orb_installed_repos_sync_failed", reason: syncResult.reason }));
+      }
       return;
+    }
     case "backfill-registered-repos":
       if (!message.repoFullName && message.requestedBy !== "test") {
         // #5021 retargeted the two downstream entry points (backfillRegisteredRepositories,

--- a/src/selfhost/metrics.ts
+++ b/src/selfhost/metrics.ts
@@ -101,6 +101,7 @@ export const DEFAULT_METRIC_META: readonly (readonly [string, MetricMeta])[] = [
   ["loopover_rag_pipeline_errors_total", { help: "RAG index-population pipeline errors (repo/path indexing), by op.", type: "counter" }],
   ["loopover_orb_events_exported_total", { help: "Orb events exported from the self-host runtime.", type: "counter" }],
   ["loopover_orb_export_errors_total", { help: "Orb event export errors.", type: "counter" }],
+  ["loopover_orb_installed_repos_sync_failures_total", { help: "Brokered installed-repos sync failures (broker/GitHub errors during the cron sync).", type: "counter" }],
   ["loopover_orb_relay_drains_total", { help: "Orb relay drain outcomes.", type: "counter" }],
   ["loopover_orb_relay_drain_skipped_total", { help: "Pull-mode orb relay drain ticks skipped because the previous tick was still in flight.", type: "counter" }],
   ["loopover_orb_relay_register_consecutive_failures", { help: "Current consecutive orb relay registration failure streak, reset to 0 on any success.", type: "gauge" }],

--- a/src/selfhost/orb-collector.ts
+++ b/src/selfhost/orb-collector.ts
@@ -210,13 +210,21 @@ export async function exportOrbBatch(db: D1Database, batchSize = 200, fetchFn: t
         ...(collectorToken ? { authorization: `Bearer ${collectorToken}` } : {}),
       },
       body,
+      // Matches every other broker HTTP call in this subsystem (drainOrbRelay's 30s, fetchAllInstallationRepos's
+      // 20s) -- an unbounded await here could hang the whole hourly export tick forever on a wedged connection.
+      signal: AbortSignal.timeout(30_000),
     });
     if (!res.ok) {
       incr("loopover_orb_export_errors_total");
+      console.error(JSON.stringify({ level: "error", event: "orb_export_failed", status: res.status }));
       return 0;
     }
-  } catch {
+  } catch (error) {
+    // Was silent beyond the counter -- this catch also swallows the error rather than rethrowing, so
+    // withSentryMonitor's own capture (wrapping this call in monitored-work.ts) never sees it either; a hung/
+    // failed export tick was previously indistinguishable from "nothing new to export" in both Sentry and Loki.
     incr("loopover_orb_export_errors_total");
+    console.error(JSON.stringify({ level: "error", event: "orb_export_failed", message: error instanceof Error ? error.message : String(error).slice(0, 200) }));
     return 0;
   }
 

--- a/src/selfhost/orb-collector.ts
+++ b/src/selfhost/orb-collector.ts
@@ -224,7 +224,7 @@ export async function exportOrbBatch(db: D1Database, batchSize = 200, fetchFn: t
     // withSentryMonitor's own capture (wrapping this call in monitored-work.ts) never sees it either; a hung/
     // failed export tick was previously indistinguishable from "nothing new to export" in both Sentry and Loki.
     incr("loopover_orb_export_errors_total");
-    console.error(JSON.stringify({ level: "error", event: "orb_export_failed", message: error instanceof Error ? error.message : String(error).slice(0, 200) }));
+    console.error(JSON.stringify({ level: "error", event: "orb_export_failed", message: String(error).slice(0, 200) }));
     return 0;
   }
 

--- a/test/integration/orb-broker.test.ts
+++ b/test/integration/orb-broker.test.ts
@@ -118,10 +118,15 @@ describe("brokerOrbToken", () => {
     await seedInstall(e, 304, { registered: 1 });
     const { secret } = (await issueOrbEnrollment(e, 304)) as { secret: string };
     const fetchCalls = countingTokenFetch("2026-06-25T08:00:00Z");
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     expect(await brokerOrbToken(e, secret)).toMatchObject({ token: "ghs_minted_1" });
     await db(e).prepare("UPDATE orb_enrollments SET cached_token_json = ? WHERE installation_id = 304").bind(JSON.stringify({ ciphertext: "bad", iv: "bad", salt: null, expiresAt: "2026-06-25T08:00:00Z" })).run();
     expect(await brokerOrbToken(e, secret)).toMatchObject({ token: "ghs_minted_2" });
+    // REGRESSION: the unreadable-cache decrypt failure above was silent -- now logs a structured warning (matching
+    // cacheOrbToken's own write-failure log below), so a rotated/mismatched TOKEN_ENCRYPTION_SECRET is visible
+    // instead of silently degrading every broker call to a full re-mint forever.
+    expect(warn.mock.calls.map((c) => String(c[0])).some((line) => line.includes("orb_token_cache_read_failed"))).toBe(true);
     await db(e).prepare("UPDATE orb_enrollments SET cached_token_json = ? WHERE installation_id = 304").bind(JSON.stringify({ ciphertext: "bad", iv: "bad", salt: null, expiresAt: "2026-06-25T07:05:00Z" })).run();
     expect(await brokerOrbToken(e, secret)).toMatchObject({ token: "ghs_minted_3" });
     expect(fetchCalls()).toBe(3);

--- a/test/integration/orb-oauth.test.ts
+++ b/test/integration/orb-oauth.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { createApp } from "../../src/api/routes";
+import * as githubClientModule from "../../src/github/client";
 import { exchangeOrbOAuthCode, fetchOrbOAuthUser, verifyInstallationAdmin } from "../../src/orb/oauth";
 import { createTestEnv, type TestD1Database } from "../helpers/d1";
 
@@ -86,6 +87,14 @@ describe("exchangeOrbOAuthCode + fetchOrbOAuthUser", () => {
   it("user fetch returns the user on ok, null on a non-ok / loginless response", async () => {
     expect(await fetchOrbOAuthUser("t", asFetch(async () => Response.json({ login: "alice", id: 1 })))).toEqual({ login: "alice", id: 1 });
     expect(await fetchOrbOAuthUser("t", asFetch(async () => new Response("no", { status: 401 })))).toBeNull();
+  });
+
+  it("REGRESSION: defaults to the bounded timeoutFetch, not raw fetch, matching its two siblings above (fetchOrbOAuthUser/verifyInstallationAdmin already did)", async () => {
+    const timeoutFetchSpy = vi.spyOn(githubClientModule, "timeoutFetch").mockResolvedValue(Response.json({ access_token: "ghu_x" }));
+    const env = { ORB_GITHUB_CLIENT_ID: "id", ORB_GITHUB_CLIENT_SECRET: "sec" } as Env;
+    expect(await exchangeOrbOAuthCode(env, "c")).toBe("ghu_x"); // no explicit fetchImpl -- exercises the default
+    expect(timeoutFetchSpy).toHaveBeenCalledWith("https://github.com/login/oauth/access_token", expect.objectContaining({ method: "POST" }));
+    timeoutFetchSpy.mockRestore();
   });
 });
 

--- a/test/integration/orb-webhook.test.ts
+++ b/test/integration/orb-webhook.test.ts
@@ -59,7 +59,7 @@ describe("handleOrbWebhook (POST /v1/orb/webhook)", () => {
     // recorded on the row, so the failure reaches Sentry/Loki instead of only being visible via a DB query.
     const logged = errors.mock.calls.map((c) => String(c[0])).find((line) => line.includes("orb_webhook_processing_failed"));
     expect(logged).toBeDefined();
-    expect(JSON.parse(logged!)).toMatchObject({ level: "error", event: "orb_webhook_processing_failed", deliveryId: "up-err", eventName: "installation", installationId: 42, message: "boom" });
+    expect(JSON.parse(logged!)).toMatchObject({ level: "error", event: "orb_webhook_processing_failed", deliveryId: "up-err", eventName: "installation", installationId: 42, message: "Error: boom" });
     errors.mockRestore();
   });
 

--- a/test/integration/orb-webhook.test.ts
+++ b/test/integration/orb-webhook.test.ts
@@ -1,5 +1,5 @@
 import type { Context } from "hono";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { createApp } from "../../src/api/routes";
 import { handleOrbWebhook } from "../../src/orb/webhook";
 import { createTestEnv, type TestD1Database } from "../helpers/d1";
@@ -50,10 +50,17 @@ describe("handleOrbWebhook (POST /v1/orb/webhook)", () => {
       prepare: (sql: string) =>
         sql.includes("orb_github_installations") ? { bind: () => ({ run: () => Promise.reject(new Error("boom")) }) } : real.prepare(sql),
     };
+    const errors = vi.spyOn(console, "error").mockImplementation(() => undefined);
     const res = await post(e, INSTALL, { delivery: "up-err" });
     expect(res.status).toBe(500);
     const stored = await (real as unknown as TestD1Database).prepare("SELECT status FROM orb_webhook_events WHERE delivery_id=?").bind("up-err").first<{ status: string }>();
     expect(stored?.status).toBe("error"); // not suppressed → GitHub can retry
+    // REGRESSION: was silent beyond the DB row -- now logs a structured error with the same identifying fields
+    // recorded on the row, so the failure reaches Sentry/Loki instead of only being visible via a DB query.
+    const logged = errors.mock.calls.map((c) => String(c[0])).find((line) => line.includes("orb_webhook_processing_failed"));
+    expect(logged).toBeDefined();
+    expect(JSON.parse(logged!)).toMatchObject({ level: "error", event: "orb_webhook_processing_failed", deliveryId: "up-err", eventName: "installation", installationId: 42, message: "boom" });
+    errors.mockRestore();
   });
 
   it("400 when the GitHub delivery or event header is missing", async () => {

--- a/test/unit/queue-2.test.ts
+++ b/test/unit/queue-2.test.ts
@@ -2208,6 +2208,18 @@ describe("queue processors", () => {
     backfillSpy.mockRestore();
   });
 
+  it("REGRESSION: logs a structured error when the brokered installed-repos sync fails, instead of discarding the failure silently", async () => {
+    const env = createTestEnv({ ORB_ENROLLMENT_SECRET: "orb-secret" });
+    vi.stubGlobal("fetch", async () => new Response("nope", { status: 403 }));
+    const errors = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    await processJob(env, { type: "sync-brokered-installed-repos", requestedBy: "schedule" });
+
+    const logged = errors.mock.calls.map((c) => String(c[0])).find((line) => line.includes("orb_installed_repos_sync_failed"));
+    expect(logged).toBeDefined();
+    expect(JSON.parse(logged!)).toMatchObject({ level: "error", event: "orb_installed_repos_sync_failed", reason: expect.stringContaining("403") });
+  });
+
   it("REGRESSION: scheduled sweeps refresh stale open-PR rows so missed webhooks cannot hide PRs from repair", async () => {
     const sent: import("../../src/types").JobMessage[] = [];
     const env = createTestEnv({

--- a/test/unit/selfhost-orb-collector.test.ts
+++ b/test/unit/selfhost-orb-collector.test.ts
@@ -1,5 +1,5 @@
 import { DatabaseSync } from "node:sqlite";
-import { describe, expect, it, beforeEach, afterEach } from "vitest";
+import { describe, expect, it, beforeEach, afterEach, vi } from "vitest";
 import { createD1Adapter, nodeSqliteDriver } from "../../src/selfhost/d1-adapter";
 import { bucketReasonCode, exportOrbBatch, getOrCreateAnonSecret } from "../../src/selfhost/orb-collector";
 import { resetMetrics, renderMetrics } from "../../src/selfhost/metrics";
@@ -185,16 +185,40 @@ describe("exportOrbBatch() — always-on; reads review_audit, ships anonymized r
     const db = makeDb();
     await audit(db, "o/r", 1, "gate_decision", "merge", "2026-01-01T00:00:00Z");
     await audit(db, "o/r", 1, "pr_outcome", "merged", "2026-01-01T01:00:00Z");
+    const errors = vi.spyOn(console, "error").mockImplementation(() => undefined);
     expect(await exportOrbBatch(db, 200, async () => new Response(null, { status: 503 }))).toBe(0);
     expect(await renderMetrics()).toContain("loopover_orb_export_errors_total");
+    // REGRESSION: was silent beyond the counter -- now logs a structured error so a failing export tick reaches
+    // Sentry/Loki instead of being indistinguishable from "nothing new to export" in either tool.
+    const logged = errors.mock.calls.map((c) => String(c[0])).find((line) => line.includes("orb_export_failed"));
+    expect(logged).toBeDefined();
+    expect(JSON.parse(logged!)).toMatchObject({ level: "error", event: "orb_export_failed", status: 503 });
+    errors.mockRestore();
   });
 
   it("returns 0 + increments error counter when the collector is unreachable", async () => {
     const db = makeDb();
     await audit(db, "o/r", 1, "gate_decision", "merge", "2026-01-01T00:00:00Z");
     await audit(db, "o/r", 1, "pr_outcome", "merged", "2026-01-01T01:00:00Z");
+    const errors = vi.spyOn(console, "error").mockImplementation(() => undefined);
     expect(await exportOrbBatch(db, 200, async () => { throw new Error("ECONNREFUSED"); })).toBe(0);
     expect(await renderMetrics()).toContain("loopover_orb_export_errors_total");
+    const logged = errors.mock.calls.map((c) => String(c[0])).find((line) => line.includes("orb_export_failed"));
+    expect(logged).toBeDefined();
+    expect(JSON.parse(logged!)).toMatchObject({ level: "error", event: "orb_export_failed", message: "ECONNREFUSED" });
+    errors.mockRestore();
+  });
+
+  it("REGRESSION: the export POST carries a bounded timeout, so a wedged collector connection cannot hang the hourly tick forever", async () => {
+    const db = makeDb();
+    await audit(db, "o/r", 1, "gate_decision", "merge", "2026-01-01T00:00:00Z");
+    await audit(db, "o/r", 1, "pr_outcome", "merged", "2026-01-01T01:00:00Z");
+    let seenSignal: AbortSignal | undefined;
+    await exportOrbBatch(db, 200, async (_url, init) => {
+      seenSignal = init?.signal ?? undefined;
+      return new Response(null, { status: 200 });
+    });
+    expect(seenSignal).toBeInstanceOf(AbortSignal);
   });
 
   it("signs the batch and respects batchSize", async () => {

--- a/test/unit/selfhost-orb-collector.test.ts
+++ b/test/unit/selfhost-orb-collector.test.ts
@@ -205,7 +205,7 @@ describe("exportOrbBatch() — always-on; reads review_audit, ships anonymized r
     expect(await renderMetrics()).toContain("loopover_orb_export_errors_total");
     const logged = errors.mock.calls.map((c) => String(c[0])).find((line) => line.includes("orb_export_failed"));
     expect(logged).toBeDefined();
-    expect(JSON.parse(logged!)).toMatchObject({ level: "error", event: "orb_export_failed", message: "ECONNREFUSED" });
+    expect(JSON.parse(logged!)).toMatchObject({ level: "error", event: "orb_export_failed", message: "Error: ECONNREFUSED" });
     errors.mockRestore();
   });
 


### PR DESCRIPTION
## Summary

An Explore-agent audit of `src/orb/*.ts` and its self-host callers, requested to make the ORB system "fully instrumented." Each finding below was independently verified against the actual code (and, where relevant, a working sibling call site in the same file already doing the right thing) before being fixed — this brings the outliers into line with the codebase's own established convention, not a new one.

1. **`src/queue/job-dispatch.ts`** — discarded `syncBrokeredInstalledRepos`'s fail-safe result entirely (`await syncBrokeredInstalledRepos(env); return;`). Since that function is deliberately fail-safe (never throws), this call site was the *only* place its failure could ever become visible — a sustained broker/GitHub outage silently stopped repo-list convergence with zero signal in Sentry, Loki, or Prometheus. Now logs + increments a counter on `status: "failed"`.
2. **`src/orb/webhook.ts`** — the catch around `upsertOrbInstallation`/`recordOrbPrOutcome` recorded a DB row but never logged, unlike its three siblings in `src/api/routes.ts` (`orb_broker_mint_failed`, `orb_relay_register_failed`, `orb_relay_pull_failed`), which all log a structured error on the identical class of failure. This is "the data spine for the homepage fleet metrics" per its own header comment — the highest-volume Orb endpoint.
3. **`src/selfhost/orb-collector.ts`** — the hourly export POST had no timeout, unlike every other broker HTTP call in this subsystem (`drainOrbRelay`'s 30s, `fetchAllInstallationRepos`'s 20s). Added one, and while there also completed its own catch blocks' logging (they were silent beyond a metric counter — the new timeout makes them more likely to actually fire in practice, since a wedged connection would previously just hang forever without ever reaching either catch).
4. **`src/orb/oauth.ts`** — `exchangeOrbOAuthCode` defaulted to raw, unbounded `fetch` while its two siblings in the same file (`fetchOrbOAuthUser`, `verifyInstallationAdmin`) already default to the bounded `timeoutFetch`. Confirmed safe to match (`timeoutFetch`'s budget-gating only triggers when a caller explicitly opts in via `githubSkipNetworkWhen`, which none of these three do).
5. **`src/orb/broker.ts`** — `readCachedOrbToken`'s catch was silent, unlike its mirror-image sibling `cacheOrbToken`, which logs the identical failure class (`orb_token_cache_write_failed`) at `warn`. A rotated/mismatched `TOKEN_ENCRYPTION_SECRET` degraded every broker call to a full re-mint, permanently and silently.

## Test plan
- [x] Extended existing coverage for all 5 (each already had a test file/case that reached the exact failure branch — added assertions on the new logging rather than writing net-new fixture setups). Verified the new `oauth.ts` timeoutFetch-default test actually catches a regression (temporarily reverted the source fix and confirmed the test fails, then restored it).
- [x] `npm run test:coverage` (unsharded) — full local gate green, no regressions.
- [x] `npm run test:ci` — green.