### PR TITLE
fix(miner): parse queue item ids from the end so IPv6-literal hosts round-trip (#5924)

### DIFF
--- a/packages/loopover-miner/lib/portfolio-queue-manager.js
+++ b/packages/loopover-miner/lib/portfolio-queue-manager.js
@@ -23,18 +23,18 @@ export function queueItemId(apiBaseUrl, repoFullName, identifier) {
 /** Reverse {@link queueItemId} after engine selection so claims can target SQLite primary keys. */
 export function parseQueueItemId(id) {
   if (typeof id !== "string") throw new Error("invalid_queue_item_id");
-  const firstSeparatorIndex = id.indexOf(ITEM_ID_SEPARATOR);
-  if (firstSeparatorIndex <= 0) throw new Error("invalid_queue_item_id");
-  const rest = id.slice(firstSeparatorIndex + ITEM_ID_SEPARATOR.length);
-  const secondSeparatorIndex = rest.indexOf(ITEM_ID_SEPARATOR);
-  if (secondSeparatorIndex <= 0 || secondSeparatorIndex === rest.length - ITEM_ID_SEPARATOR.length) {
-    throw new Error("invalid_queue_item_id");
-  }
-  return {
-    apiBaseUrl: id.slice(0, firstSeparatorIndex),
-    repoFullName: rest.slice(0, secondSeparatorIndex),
-    identifier: rest.slice(secondSeparatorIndex + ITEM_ID_SEPARATOR.length),
-  };
+  const lastSeparatorIndex = id.lastIndexOf(ITEM_ID_SEPARATOR);
+  if (lastSeparatorIndex <= 0) throw new Error("invalid_queue_item_id");
+  const identifier = id.slice(lastSeparatorIndex + ITEM_ID_SEPARATOR.length);
+  if (!identifier) throw new Error("invalid_queue_item_id");
+  const beforeIdentifier = id.slice(0, lastSeparatorIndex);
+  const secondLastSeparatorIndex = beforeIdentifier.lastIndexOf(ITEM_ID_SEPARATOR);
+  if (secondLastSeparatorIndex <= 0) throw new Error("invalid_queue_item_id");
+  const repoFullName = beforeIdentifier.slice(secondLastSeparatorIndex + ITEM_ID_SEPARATOR.length);
+  if (!repoFullName) throw new Error("invalid_queue_item_id");
+  const apiBaseUrl = beforeIdentifier.slice(0, secondLastSeparatorIndex);
+  if (!apiBaseUrl) throw new Error("invalid_queue_item_id");
+  return { apiBaseUrl, repoFullName, identifier };
 }
 
 /** Coerce caps to finite non-negative integers (mirrors the engine's normalizeCaps posture). */

--- a/test/unit/miner-portfolio-queue-manager.test.ts
+++ b/test/unit/miner-portfolio-queue-manager.test.ts
@@ -66,12 +66,23 @@ describe("entriesToPortfolioQueue() / selectEligibleBatch() (#4285)", () => {
     });
   });
 
+  it("queueItemId/parseQueueItemId round-trip an IPv6-literal apiBaseUrl (#5924)", () => {
+    const apiBaseUrl = "https://[::1]:3000/api/v3";
+    const id = queueItemId(apiBaseUrl, "acme/widgets", "issue-7");
+    expect(parseQueueItemId(id)).toEqual({
+      apiBaseUrl,
+      repoFullName: "acme/widgets",
+      identifier: "issue-7",
+    });
+  });
+
   it("parseQueueItemId rejects a malformed id", () => {
     expect(() => parseQueueItemId(42 as never)).toThrow("invalid_queue_item_id");
     expect(() => parseQueueItemId("no-separators-at-all")).toThrow("invalid_queue_item_id");
     expect(() => parseQueueItemId("https://api.github.com::acme/widgets")).toThrow("invalid_queue_item_id");
     expect(() => parseQueueItemId("::acme/widgets::issue:7")).toThrow("invalid_queue_item_id");
     expect(() => parseQueueItemId("https://api.github.com::acme/widgets::")).toThrow("invalid_queue_item_id");
+    expect(() => parseQueueItemId("https://api.github.com::::issue:7")).toThrow("invalid_queue_item_id");
   });
 
   it("entriesToPortfolioQueue falls back to the github.com default when a row's apiBaseUrl is missing (#5563)", () => {


### PR DESCRIPTION
## Summary

Fixes #5924

`parseQueueItemId` split composite queue-item ids on the **first** ::`, but `apiBaseUrl` is the one field that can legitimately contain ::` (e.g. IPv6 literals like `https://[::1]:3000/api/v3`). That caused silent mis-parsing into wrong `(apiBaseUrl, repoFullName, identifier)` triples, breaking `batchClaim` for self-hosted GHE on IPv6-literal hosts.

## Root cause

`indexOf(::)` matched the ::` inside `[::1]` before the real separator between `apiBaseUrl` and `repoFullName`.

## Fix approach

- Parse from the **last two** separator occurrences instead of the first two
- `queueItemId` (encoder) unchanged — only wrong parses are corrected
- Preserve all existing `invalid_queue_item_id` rejection paths; add empty `repoFullName` case

## Impact

Selected queue items on IPv6-literal-hosted forges now claim the correct SQLite row instead of silently mis-targeting one.

## Risk / tradeoffs

- An `identifier` containing ::` would now mis-split where `apiBaseUrl` previously did — the correct trade-off per #5924 since `repoFullName` never contains ::` and IPv6 literals are accepted by forge config.