### PR TITLE
fix(miner): reject unknown migrate CLI arguments instead of ignoring them

### DIFF
--- a/packages/loopover-miner/lib/migrate-cli.js
+++ b/packages/loopover-miner/lib/migrate-cli.js
@@ -10,6 +10,7 @@
 import { existsSync } from "node:fs";
 import { DatabaseSync } from "node:sqlite";
 import { readSchemaVersion } from "./schema-version.js";
+import { argsWantJson, reportCliFailure } from "./cli-error.js";
 import { openClaimLedger, resolveClaimLedgerDbPath } from "./claim-ledger.js";
 import { initEventLedger, resolveEventLedgerDbPath } from "./event-ledger.js";
 import { initGovernorLedger, resolveGovernorLedgerDbPath } from "./governor-ledger.js";
@@ -17,6 +18,8 @@ import { initPredictionLedger, resolvePredictionLedgerDbPath } from "./predictio
 import { initPortfolioQueueStore, resolvePortfolioQueueDbPath } from "./portfolio-queue.js";
 import { initRunStateStore, resolveRunStateDbPath } from "./run-state.js";
 import { openPlanStore, resolvePlanStoreDbPath } from "./plan-store.js";
+
+const MIGRATE_USAGE = "Usage: loopover-miner migrate [--json]";
 
 const STORES = [
   { name: "event-ledger", resolveDbPath: resolveEventLedgerDbPath, open: initEventLedger },
@@ -97,9 +100,16 @@ export function runMigrateChecks(env = process.env, stores = STORES) {
 }
 
 export function runMigrate(args = [], env = process.env) {
+  const json = argsWantJson(args);
+  // Validated BEFORE any store is opened: a typo'd flag must fail fast rather than silently run a full
+  // migration sweep that ignored what the operator actually typed (#5917). `--json` is the only flag this
+  // command takes, so anything else -- an unrecognized flag or a stray positional -- is rejected.
+  const unknown = args.find((token) => token !== "--json");
+  if (unknown !== undefined) return reportCliFailure(json, `Unknown option: ${unknown}. ${MIGRATE_USAGE}`, 2);
+
   const results = runMigrateChecks(env);
   const failed = results.filter((result) => !result.ok);
-  if (args.includes("--json")) {
+  if (json) {
     console.log(JSON.stringify({ ok: failed.length === 0, stores: results }, null, 2));
   } else {
     for (const result of results) {

--- a/test/unit/miner-migrate-cli.test.ts
+++ b/test/unit/miner-migrate-cli.test.ts
@@ -161,6 +161,40 @@ describe("loopover-miner migrate (#4871)", () => {
     expect(errorLog).toHaveBeenCalledWith(expect.stringContaining("1 store(s) failed"));
   });
 
+  it("REGRESSION: runMigrate rejects an unknown flag with exit 2 instead of silently migrating (#5917)", () => {
+    const env = tempEnv();
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(runMigrate(["--dryrun"], env)).toBe(2);
+    expect(errorLog).toHaveBeenCalledWith("Unknown option: --dryrun. Usage: loopover-miner migrate [--json]");
+    // Fails fast: no store was swept, so no per-store line was ever printed.
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it("REGRESSION: runMigrate rejects a stray positional argument with exit 2 (#5917)", () => {
+    const env = tempEnv();
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(runMigrate(["event-ledger"], env)).toBe(2);
+    expect(errorLog).toHaveBeenCalledWith("Unknown option: event-ledger. Usage: loopover-miner migrate [--json]");
+    expect(log).not.toHaveBeenCalled();
+  });
+
+  it("an unknown-argument rejection honors the --json contract on stdout (#5917)", () => {
+    const env = tempEnv();
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const errorLog = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    expect(runMigrate(["--dryrun", "--json"], env)).toBe(2);
+    expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({
+      ok: false,
+      error: "Unknown option: --dryrun. Usage: loopover-miner migrate [--json]",
+    });
+    expect(errorLog).not.toHaveBeenCalled();
+  });
+
   it("makes no network calls", () => {
     const fetchSpy = vi.spyOn(globalThis, "fetch");
     runMigrateChecks(tempEnv());


### PR DESCRIPTION
## Summary

`runMigrate`'s only arg inspection was `if (args.includes("--json"))`, so every other token was silently ignored: `loopover-miner migrate --dryrun` ran a full migration sweep across all seven stores and exited `0`, with no hint that the flag the operator typed did nothing.

`runMigrate` now validates its `args` against the known flag set before any store is opened:

```js
const json = argsWantJson(args);
const unknown = args.find((token) => token !== "--json");
if (unknown !== undefined) return reportCliFailure(json, `Unknown option: ${unknown}. ${MIGRATE_USAGE}`, 2);
```

`--json` is the only flag this command takes, so anything else — an unrecognized flag *or* a stray positional — is rejected. Validation happens **before** `runMigrateChecks`, so it genuinely fails fast rather than migrating and then complaining; the tests assert no per-store line was printed.

This reuses the established sibling pattern rather than inventing one: `calibration-cli.js` is the closest structural twin (same `Usage: loopover-miner <command> [--json]` surface) and already emits `Unknown option: <token>. <USAGE>` via the shared `reportCliFailure`/`argsWantJson` helpers in `cli-error.js`. Exit code is **2**, per this issue's "explicit `Unknown option: <token>` error (exit 2)" and matching `governor-pause-cli.js`, `feasibility-cli.js`, and `claim-ledger-cli.js`.

Using `reportCliFailure` also means the rejection **honors the `--json` contract** — `migrate --dryrun --json` emits `{ "ok": false, "error": "Unknown option: --dryrun. …" }` on stdout instead of bare text on stderr, consistent with the direction of the sibling AMS `--json`-contract issues (#5914/#5915) rather than adding a new path that bypasses it.

Existing behavior is untouched: `[]` and `["--json"]` still return `0`, a failed store still returns `1`, and both the human-readable and JSON success renderings are unchanged.

Closes #5917

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate. — see below
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

Reporting these honestly rather than checking them wholesale. I ran `git diff --check`, `npm run typecheck`, `npm audit --audit-level=moderate`, and the targeted suite; I did **not** personally complete the full unsharded `test:coverage`, `test:workers`, `build:mcp`/`test:mcp-pack`, or the `ui:*` steps, so I am not claiming them. CI runs all of them here.

What I verified directly, targeted at this diff:

- **`test/unit/miner-migrate-cli.test.ts`: 10/10 pass.** `runMigrate`'s only other consumer is the `bin/loopover-miner.js` dispatch (`process.exit(runMigrate(cliArgs.slice(1)))`), verified by grep; its return type stays `number`, so `migrate-cli.d.ts` needs no change.
- **Patch coverage: 100% of changed lines and branches** (both arms of the new `unknown !== undefined` check), measured by intersecting `coverage/lcov.info` `DA`/`BRDA` records with `git diff -U0`.
- **The three new tests genuinely fail against the pre-fix source** — reverting `migrate-cli.js` alone fails all three, since the old code returned `0` and swept every store for `["--dryrun"]`.
- `node --check` on the changed file (what `build:miner` does) passes. No `env.*` read is added or removed, so no regenerated artifact is owed; the diff is one miner-lib JS file plus its unit test — no schema, migration, OpenAPI, wrangler binding, MCP, or UI surface.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — **N/A:** none of those surfaces are touched; this is CLI argument validation in a miner-lib module. (Its own negative paths — unknown flag, stray positional, and the `--json` error rendering — are all covered by new tests.)
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — **N/A:** no API, OpenAPI schema, or MCP tool surface changes.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — **N/A:** no UI changes.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository. — **N/A:** no visible UI change; the `UI Evidence` section is omitted accordingly.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs. — No docs owed: the new `MIGRATE_USAGE` string is itself the user-facing surface, and the command reference is generated from the `bin` dispatch, which is unchanged.

## Notes

- `calibration-cli.js` passes an explicit `1` to `reportCliFailure` for its own unknown-option path, which is the outlier among the miner CLI modules; this follows the issue's stated exit-2 convention and `reportCliFailure`'s own default, matching `governor-pause-cli.js` / `feasibility-cli.js` / `claim-ledger-cli.js`.
- `migrate --json --json` is still accepted (both tokens are the known flag) — the check rejects unknown tokens, it does not newly police duplicates, which would be a behavior change outside this issue's scope.
