### PR TITLE
fix(selfhost): tag the fleet compose image loopover-miner:latest

### DIFF
--- a/packages/loopover-miner/docker-compose.miner.yml
+++ b/packages/loopover-miner/docker-compose.miner.yml
@@ -1,4 +1,4 @@
-# docker-compose for gittensory-miner (AMS) fleet mode (#5177).
+# docker-compose for loopover-miner (AMS) fleet mode (#5177).
 #
 # Runs the miner as a long-lived CLI worker instead of a hand-assembled `docker run`. Build context is the
 # MONOREPO ROOT (../..) because the Dockerfile needs the full workspace on disk before `npm ci` — see the
@@ -24,8 +24,8 @@ services:
     build:
       context: ../..
       dockerfile: packages/loopover-miner/Dockerfile
-    image: gittensory-miner:latest
-    # ENTRYPOINT is `gittensory-miner`; `run` is the continuous fleet-worker loop.
+    image: loopover-miner:latest
+    # ENTRYPOINT is `loopover-miner`; `run` is the continuous fleet-worker loop.
     command: ["run"]
     restart: unless-stopped
     # Operator-supplied secrets/config (GITHUB_TOKEN, optional provider keys). Copy the .example, fill it in,

--- a/test/unit/miner-docker-compose.test.ts
+++ b/test/unit/miner-docker-compose.test.ts
@@ -25,6 +25,13 @@ describe("docker-compose.miner.yml (#5177)", () => {
     expect(miner.command).toContain("run");
   });
 
+  it("tags the built image with the post-rename name (loopover-miner:latest)", () => {
+    // Regression for #5935: the image tag must match the Dockerfile's `loopover-miner` ENTRYPOINT and the name
+    // every other fleet-mode doc uses (DEPLOYMENT.md, k8s/miner-deployment.yaml), not the pre-rename
+    // `gittensory-miner:latest`, so `docker images` cross-references from those docs actually resolve.
+    expect(compose.services.miner.image).toBe("loopover-miner:latest");
+  });
+
   it("persists state on a named volume and restarts unless stopped", () => {
     const miner = compose.services.miner;
     expect(miner.restart).toBe("unless-stopped");


### PR DESCRIPTION
Closes #5935.

`packages/loopover-miner/docker-compose.miner.yml` still tagged the built image `gittensory-miner:latest` (and referenced the old name in its header/entrypoint comments), while the `Dockerfile`'s real `ENTRYPOINT` is `loopover-miner` and every other fleet-mode doc (`DEPLOYMENT.md`, `k8s/miner-deployment.yaml`) uses `loopover-miner:latest`. An operator who builds via this file then sees `gittensory-miner:latest` in `docker images`, silently breaking those cross-references.

### Changes
- **`docker-compose.miner.yml`**: `image:` → `loopover-miner:latest`; entrypoint comment → `loopover-miner`; and the file-header comment refreshed to the current name for consistency (no functional/tag residue left).
- **`test/unit/miner-docker-compose.test.ts`**: extended the existing suite (per the issue) with an assertion that `miner.image` is `loopover-miner:latest`.

### Validation
- Full suite passes (6/6).
- **Proved the new assertion catches the regression**: temporarily reverting the tag to `gittensory-miner:latest` makes exactly that test fail, then passes again once restored — as the issue's Test Coverage Requirements ask.
- `packages/**` YAML + `test/**`, both outside Codecov's `coverage.include`, so no patch-coverage gate applies.