### PR TITLE
fix(queue): log unrecognized job types in processJob instead of dropping silently (#5836)

### DIFF
--- a/src/queue/job-dispatch.ts
+++ b/src/queue/job-dispatch.ts
@@ -343,5 +343,20 @@ export async function processJob(env: Env, message: JobMessage): Promise<void> {
       // an empty table). Never throws.
       await retryFailedRelays(env);
       return;
+    default:
+      // An unrecognized job type (a stale queued message from a renamed/removed type, a producer/consumer skew
+      // during a rolling deploy, or a corrupted payload) would otherwise fall through and be acked with zero
+      // trace. Log it — matching the retired_review_job_ignored (src/index.ts) / dlq_message_dead_lettered
+      // (src/queue/dlq.ts) structured-warn precedents — then return normally so the caller's ack flow is
+      // unchanged. Observability only; never throws (#5836). message narrows to `never` here, so read the
+      // runtime type through a cast.
+      console.warn(
+        JSON.stringify({
+          level: "warn",
+          event: "unknown_job_type_ignored",
+          jobType: (message as { type?: unknown }).type,
+        }),
+      );
+      return;
   }
 }

--- a/test/unit/job-dispatch.test.ts
+++ b/test/unit/job-dispatch.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { processJob } from "../../src/queue/job-dispatch";
+import { createTestEnv } from "../helpers/d1";
+import type { JobMessage } from "../../src/types";
+
+describe("processJob unknown job type (#5836)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("logs a structured unknown_job_type_ignored warning and does not throw for an unrecognized type", async () => {
+    const warnLogs: string[] = [];
+    vi.spyOn(console, "warn").mockImplementation((...args: unknown[]) => {
+      warnLogs.push(String(args[0]));
+    });
+
+    const env = createTestEnv();
+    // A type outside the discriminated union — a stale/renamed job or a producer/consumer skew at runtime.
+    const message = { type: "totally-unknown-job-type" } as unknown as JobMessage;
+
+    await expect(processJob(env, message)).resolves.toBeUndefined();
+
+    expect(warnLogs).toHaveLength(1);
+    const log = JSON.parse(warnLogs[0] ?? "{}") as Record<string, unknown>;
+    expect(log).toMatchObject({ level: "warn", event: "unknown_job_type_ignored", jobType: "totally-unknown-job-type" });
+  });
+
+  it("does not log the unknown-type warning for a recognized job type", async () => {
+    const warnLogs: string[] = [];
+    vi.spyOn(console, "warn").mockImplementation((...args: unknown[]) => {
+      warnLogs.push(String(args[0]));
+    });
+
+    const env = createTestEnv();
+    // A recognized type that no-ops safely without external I/O: retryFailedRelays fails open on an empty table.
+    await processJob(env, { type: "retry-orb-relay" } as JobMessage);
+
+    expect(warnLogs.some((line) => line.includes("unknown_job_type_ignored"))).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #5836.

`processJob` in `src/queue/job-dispatch.ts` is the top-level Cloudflare Queues dispatcher — a
`switch (message.type)` that fans out to dozens of handlers with **no `default:` case**. If a `message.type`
doesn't match any `case` (a stale queued message from a renamed/removed job type, a producer/consumer version
skew during a rolling deploy, or a corrupted payload), `processJob` returned silently and the caller
(`src/index.ts`'s `queue()` handler) acked the message with **zero observability** — no log, no metric, no audit
event. This was the only ack-and-drop path in the queue pipeline with no log line, unlike the established
`retired_review_job_ignored` (`src/index.ts`) and `dlq_message_dead_lettered` (`src/queue/dlq.ts`) precedents.

The fix adds a `default:` case that emits a structured `unknown_job_type_ignored` warning
(`{ level: "warn", event: "unknown_job_type_ignored", jobType }`, mirroring those precedents' JSON shape) via
`console.warn`, then returns normally. It **never throws**, so the existing ack-after-`processJob` flow is
unaffected — this is purely an observability addition, not a change to message handling. No existing `case`
branch is touched. (In the `default:` arm `message` narrows to `never`, so the runtime type is read through a
cast.)

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran the full `npm run test:ci` gate (exit 0) plus `npm audit --audit-level=moderate` (0 vulnerabilities). The new `default:` branch is covered by a dedicated test that exercises it (verified via unsharded `npm run test:coverage`).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

Notes on the Safety boxes: this is a backend-only observability addition to a queue dispatcher — no UI, API/OpenAPI, or auth/CORS/session surface. The logged event contains only the job type string (no secrets or private terms). The negative-path testing that applies here is the dispatcher's own: the added test covers both the unknown-type branch (logs + returns without throwing) and a recognized type (no spurious warning).

## UI Evidence

Not applicable — backend-only change to a queue dispatcher; no visible UI, frontend, docs, or extension surface.

## Notes

- The regression test (`test/unit/job-dispatch.test.ts`) imports `processJob` **directly from `../../src/queue/job-dispatch`** — the file this PR changes — so it genuinely exercises the new `default:` branch. It asserts the structured `unknown_job_type_ignored` log (`level`/`event`/`jobType`) is emitted and that `processJob` resolves without throwing, plus a negative case (a recognized `retry-orb-relay` type emits no unknown-type warning).
