### PR TITLE
test(review): cover extractPreviewUrl branches in preview-url (#5848)

### DIFF
--- a/test/unit/preview-url.test.ts
+++ b/test/unit/preview-url.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { clearGitHubResponseCacheForTest, githubRateLimitAdmissionKeyForInstallation, latestGitHubRestRateLimitObservation } from "../../src/github/client";
-import { getPreviewBuildState } from "../../src/review/visual/preview-url";
+import { extractPreviewUrl, getPreviewBuildState } from "../../src/review/visual/preview-url";
 
 afterEach(() => {
   clearGitHubResponseCacheForTest();
@@ -44,5 +44,52 @@ describe("preview-url GitHub reads", () => {
       resetAt: "2026-06-24T12:10:00.000Z",
       observedAtMs: Date.parse("2026-06-24T12:00:00.000Z"),
     });
+  });
+});
+
+describe("extractPreviewUrl", () => {
+  it.each([
+    ["null", null],
+    ["undefined", undefined],
+    ["empty string", ""],
+  ])("returns null for falsy input (%s)", (_label, input) => {
+    expect(extractPreviewUrl(input)).toBeNull();
+  });
+
+  it("returns null when the text contains no URL at all", () => {
+    expect(extractPreviewUrl("deploy is still pending, no link yet")).toBeNull();
+  });
+
+  it("returns null when the only URL is not a Cloudflare-preview host", () => {
+    expect(extractPreviewUrl("see https://github.com/acme/widgets for details")).toBeNull();
+  });
+
+  it("skips a malformed URL-like substring that throws in new URL(...) and falls through to null", () => {
+    // `http://[` matches the URL regex but throws inside `new URL(...)` (unterminated IPv6 host),
+    // so the catch arm is taken and the scan falls through to null (#5848).
+    expect(extractPreviewUrl("preview: http://[ oops")).toBeNull();
+  });
+
+  it("skips a malformed URL and still returns a later valid preview match", () => {
+    // The malformed substring hits the catch arm, then the loop continues to the valid host.
+    expect(extractPreviewUrl("http://[ then https://pr-1.app.workers.dev/route")).toBe(
+      "https://pr-1.app.workers.dev",
+    );
+  });
+
+  it("returns the base origin for a *.workers.dev link, dropping the path and query", () => {
+    expect(extractPreviewUrl("build ready at https://pr-12.myapp.workers.dev/some/path?x=1")).toBe(
+      "https://pr-12.myapp.workers.dev",
+    );
+  });
+
+  it("returns the base origin for a *.pages.dev link", () => {
+    expect(extractPreviewUrl("https://feature-x.docs.pages.dev")).toBe("https://feature-x.docs.pages.dev");
+  });
+
+  it("skips a non-preview URL that precedes the matching one (multi-match ordering)", () => {
+    expect(
+      extractPreviewUrl("https://github.com/acme/widgets/pull/7 and https://pr-3.site.pages.dev/preview"),
+    ).toBe("https://pr-3.site.pages.dev");
   });
 });


### PR DESCRIPTION
## Summary

`extractPreviewUrl` (`src/review/visual/preview-url.ts:145`) is a pure helper that pulls the first Cloudflare-preview (`*.workers.dev` / `*.pages.dev`) origin out of an arbitrary string. It was only exercised indirectly through `findPreviewUrlFromChecks` / `findPreviewUrlFromPrComments`, with **zero direct unit tests**, leaving the file at ~54% branch coverage — the lowest `src/**` file outside the intentionally-ignored `src/server.ts`.

This adds a focused `describe("extractPreviewUrl", ...)` block to the existing `test/unit/preview-url.test.ts` that exercises every branch of the function:

- falsy input — `null`, `undefined`, and `""` → `null` (the `!text` arm);
- a string with no URL at all → `null` (the `!matches` arm);
- a URL whose host is not a preview host (`github.com`) → `null` (the host-suffix false arm);
- a malformed URL-like substring that throws inside `new URL(...)` (`http://[`) → skipped via the `catch`, both **alone** (falls through to `null`) and **followed by a valid match** (falls through to the later preview URL);
- a `*.workers.dev` and a `*.pages.dev` link → the base origin, with path/query dropped (both suffixes in the `PREVIEW_HOST_SUFFIXES.some(...)` check);
- multi-match ordering where a non-preview URL precedes the preview one → the preview origin is returned.

Closes #5848

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [ ] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- This is a **test-only** change: the only file touched is `test/unit/preview-url.test.ts`, which lives under `test/**` and is ignored by Codecov, so there is no `codecov/patch` obligation and no `src/**` line changes. Coverage was run scoped to the affected module — all 11 cases pass and `extractPreviewUrl` (lines 145–161) now has full line **and** branch coverage (every `?`/`&&`/`??` and `if` arm exercised, verified via the v8/lcov `BRDA` report). `typecheck` and `git diff --check` are clean. The UI / MCP / workers / OpenAPI / actionlint / audit checks are not affected by adding a unit test and were left to CI.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests. — N/A, no auth/session/CORS surface touched.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed. — N/A, no API/OpenAPI/MCP change.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks. — N/A, no UI change.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots. — N/A, no visible change (test-only).
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- Pure test addition, no production code changed. Reproduce locally with `npx vitest run test/unit/preview-url.test.ts --coverage --coverage.include='src/review/visual/preview-url.ts'`.
