### PR TITLE
feat(mcp): expose .loopover.yml config recommendations as a read-only MCP tool

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.js
+++ b/packages/loopover-mcp/bin/loopover-mcp.js
@@ -137,7 +137,7 @@ const AGENT_PROFILES = {
     audience: "repository owners preparing intake readiness and onboarding plans",
     purpose: "Review registration readiness, focus manifests, docs/onboarding gaps, and manual setup actions.",
     recommendedPrompts: ["loopover_repo_owner_intake_readiness", "loopover_repo_owner_focus_manifest_review", "loopover_repo_owner_onboarding_pack"],
-    recommendedTools: ["loopover_get_repo_context", "loopover_get_issue_quality", "loopover_get_registration_readiness"],
+    recommendedTools: ["loopover_get_repo_context", "loopover_get_issue_quality", "loopover_get_registration_readiness", "loopover_get_config_recommendation"],
     boundaries: [
       "Human-approved only: review, explain, and draft setup plans; do not push config, label issues, post comments, close issues, or publish public output.",
       "Separate public readiness guidance from private maintainer or authenticated owner context.",

--- a/src/api/routes.ts
+++ b/src/api/routes.ts
@@ -4960,7 +4960,7 @@ async function buildSelfDogfoodRegistrationPackResponse(env: Env) {
   };
 }
 
-async function buildGittensorConfigRecommendationResponse(env: Env, fullName: string) {
+export async function buildGittensorConfigRecommendationResponse(env: Env, fullName: string) {
   /* v8 ignore start -- Config recommendation route-level shaping over covered signal helpers. */
   // Intentionally the raw DB settings, not resolveRepositorySettings's merged view: this tool recommends what
   // to ADD to .loopover.yml based on the repo's currently-active (dashboard/API-configured) behavior — using

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -104,7 +104,7 @@ import { loadMaintainerNoiseReport, maintainerNoiseSummary } from "../services/m
 import { loadLabelAudit, labelAuditSummary } from "../services/label-audit";
 import { loadMaintainerLaneReport, maintainerLaneSummary } from "../services/maintainer-lane";
 import { buildRepoOnboardingPackPreviewForRepo } from "../services/repo-onboarding-pack";
-import { buildRegistrationReadinessResponse } from "../api/routes";
+import { buildRegistrationReadinessResponse, buildGittensorConfigRecommendationResponse } from "../api/routes";
 import { loadGatePrecisionReport } from "../services/gate-precision";
 import { buildUnavailableQueueTrendReport } from "../services/queue-trends";
 import {
@@ -806,6 +806,18 @@ const registrationReadinessOutputSchema = {
   policyReadiness: z.unknown().optional(),
   onboardingPackPreview: z.unknown().optional(),
   blockers: z.array(z.string()).optional(),
+  warnings: z.array(z.string()).optional(),
+  dataQuality: z.unknown().optional(),
+};
+
+const configRecommendationOutputSchema = {
+  repoFullName: z.string().optional(),
+  generatedAt: z.string().optional(),
+  privateOnly: z.boolean().optional(),
+  current: z.unknown().optional(),
+  recommended: z.unknown().optional(),
+  tradeoffs: z.array(z.string()).optional(),
+  reasons: z.array(z.string()).optional(),
   warnings: z.array(z.string()).optional(),
   dataQuality: z.unknown().optional(),
 };
@@ -1691,6 +1703,17 @@ export class LoopoverMcp {
         outputSchema: registrationReadinessOutputSchema,
       },
       async (input) => this.toolResult(await this.getRegistrationReadiness(input)),
+    );
+
+    server.registerTool(
+      "loopover_get_config_recommendation",
+      {
+        description:
+          "Return recommended .loopover.yml additions for a repository, derived from the repo's live, currently-active configured behavior (the raw dashboard/API-configured settings, not a yml-merged view — so the recommendation never compares itself against an override that already exists). Advisory only, not a write action.",
+        inputSchema: ownerRepoShape,
+        outputSchema: configRecommendationOutputSchema,
+      },
+      async (input) => this.toolResult(await this.getConfigRecommendation(input)),
     );
 
     server.registerTool(
@@ -2805,6 +2828,19 @@ export class LoopoverMcp {
       summary: report.ready
         ? `LoopOver registration readiness for ${fullName}: ready (preview-only, not a registration action).`
         : `LoopOver registration readiness for ${fullName}: not ready — ${report.blockers.length} blocker(s) (preview-only, not a registration action).`,
+      data: report as unknown as Record<string, unknown>,
+    };
+  }
+
+  private async getConfigRecommendation(input: { owner: string; repo: string }): Promise<ToolPayload> {
+    const fullName = `${input.owner}/${input.repo}`;
+    await this.requireRepoAccess(fullName);
+    const report = await buildGittensorConfigRecommendationResponse(this.env, fullName);
+    return {
+      summary:
+        report.warnings.length > 0
+          ? `LoopOver .loopover.yml recommendation for ${fullName}: ${report.warnings.length} warning(s) to review alongside the recommendation (advisory only, not a write action).`
+          : `LoopOver .loopover.yml recommendation for ${fullName}: recommendation generated with no outstanding warnings (advisory only, not a write action).`,
       data: report as unknown as Record<string, unknown>,
     };
   }

--- a/test/unit/mcp-config-recommendation.test.ts
+++ b/test/unit/mcp-config-recommendation.test.ts
@@ -1,0 +1,90 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import { describe, expect, it } from "vitest";
+import { createSessionForGitHubUser, type AuthIdentity } from "../../src/auth/security";
+import { persistRepoGithubTotalsSnapshot, upsertRepositoryFromGitHub } from "../../src/db/repositories";
+import { LoopoverMcp } from "../../src/mcp/server";
+import { normalizeRegistryPayload } from "../../src/registry/normalize";
+import { persistRegistrySnapshot } from "../../src/registry/sync";
+import { createTestEnv } from "../helpers/d1";
+
+async function connect(env: Env, identity?: AuthIdentity): Promise<Client> {
+  const server = (identity ? new LoopoverMcp(env, identity) : new LoopoverMcp(env)).createServer();
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  const client = new Client({ name: "config-recommendation-test", version: "0.1.0" }, { capabilities: {} });
+  await client.connect(clientTransport);
+  return client;
+}
+
+describe("loopover_get_config_recommendation MCP tool (#5823)", () => {
+  it("returns a clean recommendation with no warnings for a repo LoopOver has never seen", async () => {
+    const env = createTestEnv();
+    const client = await connect(env);
+    const result = await client.callTool({ name: "loopover_get_config_recommendation", arguments: { owner: "unknown-owner", repo: "unknown-repo" } });
+
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as Record<string, unknown>;
+    expect(data).toMatchObject({
+      repoFullName: "unknown-owner/unknown-repo",
+      privateOnly: true,
+      current: null,
+      warnings: [],
+    });
+    expect(Array.isArray(data.reasons)).toBe(true);
+    expect((data.reasons as unknown[]).length).toBeGreaterThan(0);
+    expect(result.content).toEqual([
+      expect.objectContaining({ text: expect.stringMatching(/\.loopover\.yml recommendation for unknown-owner\/unknown-repo: recommendation generated with no outstanding warnings/i) }),
+    ]);
+    expect(JSON.stringify(data)).not.toMatch(/hotkey|coldkey|wallet|payout(?!s\b)/i);
+  });
+
+  it("returns a recommendation with at least one warning for a registered repo whose intake is blocked", async () => {
+    const env = createTestEnv();
+    await persistRegistrySnapshot(
+      env,
+      normalizeRegistryPayload(
+        {
+          "owner/gap-repo": { emission_share: 0, issue_discovery_share: 0, label_multipliers: {}, trusted_label_pipeline: true, maintainer_cut: 0 },
+        },
+        { kind: "raw-github", url: "fixture://config-recommendation-gap" },
+        "2026-05-26T00:00:00.000Z",
+      ),
+    );
+    await upsertRepositoryFromGitHub(env, { name: "gap-repo", full_name: "owner/gap-repo", private: false, owner: { login: "owner" }, default_branch: "main" });
+    await persistRepoGithubTotalsSnapshot(env, {
+      id: "gap-repo-totals",
+      repoFullName: "owner/gap-repo",
+      openIssuesTotal: 500,
+      openPullRequestsTotal: 300,
+      mergedPullRequestsTotal: 0,
+      closedUnmergedPullRequestsTotal: 0,
+      labelsTotal: 0,
+      sourceKind: "github",
+      fetchedAt: "2026-05-26T00:00:00.000Z",
+      payload: {},
+    });
+
+    const client = await connect(env);
+    const result = await client.callTool({ name: "loopover_get_config_recommendation", arguments: { owner: "owner", repo: "gap-repo" } });
+
+    expect(result.isError).toBeFalsy();
+    const data = result.structuredContent as Record<string, unknown>;
+    expect(data).toMatchObject({ repoFullName: "owner/gap-repo", privateOnly: true });
+    expect(data.recommended).toBeTruthy();
+    expect((data.warnings as unknown[]).length).toBeGreaterThan(0);
+    expect(result.content).toEqual([expect.objectContaining({ text: expect.stringMatching(/\.loopover\.yml recommendation for owner\/gap-repo: \d+ warning\(s\) to review/i) })]);
+    expect(JSON.stringify(data)).not.toMatch(/hotkey|coldkey|wallet/i);
+  });
+
+  it("forbids a session that cannot access the repository", async () => {
+    const env = createTestEnv({ ADMIN_GITHUB_LOGINS: "" });
+    await upsertRepositoryFromGitHub(env, { name: "private-repo", full_name: "victim-org/private-repo", private: false, owner: { login: "victim-org" } });
+    const { session } = await createSessionForGitHubUser(env, { login: "someone-else", id: 999 });
+    const client = await connect(env, { kind: "session", actor: "someone-else", session });
+    const result = await client.callTool({ name: "loopover_get_config_recommendation", arguments: { owner: "victim-org", repo: "private-repo" } });
+
+    expect(result.isError).toBe(true);
+    expect(JSON.stringify(result.content)).toMatch(/cannot access this repository/i);
+  });
+});

--- a/test/unit/mcp-output-schemas.test.ts
+++ b/test/unit/mcp-output-schemas.test.ts
@@ -17,6 +17,7 @@ const TOOLS_WITH_OUTPUT_SCHEMA = [
   "loopover_get_maintainer_lane",
   "loopover_get_repo_onboarding_pack",
   "loopover_get_registration_readiness",
+  "loopover_get_config_recommendation",
   "loopover_get_burden_forecast",
   "loopover_get_repo_outcome_patterns",
   "loopover_get_outcome_calibration",


### PR DESCRIPTION
## Summary

- Add a new read-only MCP tool `loopover_get_config_recommendation` to `src/mcp/server.ts`, wrapping the existing `buildGittensorConfigRecommendationResponse` (`src/api/routes.ts`) exactly like the sibling `loopover_get_registration_readiness`/`loopover_get_label_audit` tools, so MCP clients can fetch `.loopover.yml` recommendations without direct REST access.
- Register the new tool in the `repo-owner-intake` MCP client profile's `recommendedTools` list (`packages/loopover-mcp/bin/loopover-mcp.js`), since that profile's stated purpose already names config recommendations but had no tool for it.
- Closes #5823

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- No UI changes in this PR (MCP server + CLI profile config only), so the UI Evidence section is not applicable.
- The tool wraps the existing `buildGittensorConfigRecommendationResponse` handler unmodified (aside from exporting it) — no changes to the underlying recommendation logic, per the issue's explicit instruction not to reimplement `buildGittensorConfigRecommendation`.
- Auth: uses `requireRepoAccess`, matching the real REST route's auth tier (no additional gate) and the precedent set by the already-shipped `loopover_get_registration_readiness` tool, which exposes adjacent economics-adjacent data at the same tier.
- The tool's summary line branches on `report.warnings.length` (not `reasons.length`, which is always non-empty by construction) so both the "no outstanding warnings" and "warning(s) to review" branches are genuinely reachable and are each covered by a dedicated test.
