### PR TITLE
fix(miner): document --dry-run in governor pause/resume usage banner

### DIFF
--- a/packages/loopover-miner/lib/governor-ledger-cli.js
+++ b/packages/loopover-miner/lib/governor-ledger-cli.js
@@ -16,8 +16,8 @@ const GOVERNOR_LIST_USAGE =
 
 const GOVERNOR_SUBCOMMAND_USAGE = [
   GOVERNOR_LIST_USAGE,
-  "       loopover-miner governor pause [--reason <text>] [--json]",
-  "       loopover-miner governor resume [--json]",
+  "       loopover-miner governor pause [--reason <text>] [--dry-run] [--json]",
+  "       loopover-miner governor resume [--dry-run] [--json]",
   "       loopover-miner governor status [--json]",
   "       loopover-miner governor metrics",
 ].join("\n");

--- a/test/unit/miner-governor-ledger-cli.test.ts
+++ b/test/unit/miner-governor-ledger-cli.test.ts
@@ -141,7 +141,12 @@ describe("loopover-miner governor ledger CLI (#2328)", () => {
     const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
     expect(await runGovernorCli("tail", [])).toBe(2);
     expect(String(error.mock.calls[0]?.[0])).toContain("Unknown governor subcommand");
-    expect(String(error.mock.calls[0]?.[0])).toContain("governor pause");
+    expect(String(error.mock.calls[0]?.[0])).toContain(
+      "loopover-miner governor pause [--reason <text>] [--dry-run] [--json]",
+    );
+    expect(String(error.mock.calls[0]?.[0])).toContain(
+      "loopover-miner governor resume [--dry-run] [--json]",
+    );
 
     error.mockClear();
     log.mockClear();


### PR DESCRIPTION
## Summary
- `GOVERNOR_SUBCOMMAND_USAGE` in `packages/loopover-miner/lib/governor-ledger-cli.js` documented `governor pause` and `governor resume` without `--dry-run`, even though both subcommands genuinely accept and honor it (see the authoritative `GOVERNOR_PAUSE_USAGE` / `GOVERNOR_RESUME_USAGE` constants in `governor-pause-cli.js`).
- This banner is what a user sees on an `Unknown governor subcommand` error, so it was silently under-documenting a real, working flag.
- Updated the two banner lines to include `[--dry-run]`, matching the per-command usage strings exactly.

## Test plan
- Extended the existing `runGovernorCli dispatches list and rejects unknown subcommands` test in `test/unit/miner-governor-ledger-cli.test.ts` to assert the full banner text (not just a substring) for both the pause and resume lines, including `--dry-run`.
- `npx vitest run test/unit/miner-governor-ledger-cli.test.ts` — 6/6 passing.
- `npx vitest run --coverage --pool=forks test/unit/miner-governor-ledger-cli.test.ts` — the changed lines in `governor-ledger-cli.js` are fully exercised (module-level array literal, hit on every test run).
- `npm run typecheck` — clean.

Closes #5916
