### PR TITLE
fix(review): honor ContentRepoSpec.urlFields in directory-index synthesis

### DIFF
--- a/src/review/content-lane/duplicates.ts
+++ b/src/review/content-lane/duplicates.ts
@@ -537,8 +537,10 @@ function yamlScalar(value: unknown): string {
  * URL lines come from `spec.urlFields` (not a hardcoded list) so they agree with
  * `extractContentDuplicateSignals`'s filtering — custom ContentRepoSpec URL keys must
  * reach the synthesized frontmatter or corpus `urls` stay silently empty (#5941).
+ *
+ * Exported for unit tests so the default-`spec` parameter branch is exercised (#5941 Codecov).
  */
-function contentSignalSourceFromDirectoryEntry(
+export function contentSignalSourceFromDirectoryEntry(
   entry: DirectoryIndexEntry,
   spec: ContentRepoSpec = AWESOME_CLAUDE_CONTENT_SPEC,
 ): string {

--- a/src/review/content-lane/duplicates.ts
+++ b/src/review/content-lane/duplicates.ts
@@ -528,25 +528,20 @@ export type DirectoryIndexEntry = Record<string, unknown> & {
   canonicalUrl?: unknown;
 };
 
-/** URL signal fields read off a directory entry, in order. */
-const DIRECTORY_ENTRY_URL_SIGNAL_FIELDS = [
-  "documentationUrl",
-  "docsUrl",
-  "downloadUrl",
-  "githubUrl",
-  "packageUrl",
-  "repoUrl",
-  "repositoryUrl",
-  "sourceUrl",
-  "websiteUrl",
-] as const;
-
 function yamlScalar(value: unknown): string {
   return JSON.stringify(String(value || ""));
 }
 
-/** Synthesize the per-entry frontmatter block. */
-function contentSignalSourceFromDirectoryEntry(entry: DirectoryIndexEntry): string {
+/**
+ * Synthesize the per-entry frontmatter block for directory-index corpus extraction.
+ * URL lines come from `spec.urlFields` (not a hardcoded list) so they agree with
+ * `extractContentDuplicateSignals`'s filtering — custom ContentRepoSpec URL keys must
+ * reach the synthesized frontmatter or corpus `urls` stay silently empty (#5941).
+ */
+function contentSignalSourceFromDirectoryEntry(
+  entry: DirectoryIndexEntry,
+  spec: ContentRepoSpec = AWESOME_CLAUDE_CONTENT_SPEC,
+): string {
   const lines = [
     "---",
     `title: ${yamlScalar(entry.title)}`,
@@ -554,7 +549,7 @@ function contentSignalSourceFromDirectoryEntry(entry: DirectoryIndexEntry): stri
     `category: ${yamlScalar(entry.category)}`,
     `slug: ${yamlScalar(entry.slug)}`,
   ];
-  for (const field of DIRECTORY_ENTRY_URL_SIGNAL_FIELDS) {
+  for (const field of spec.urlFields) {
     const value = entry[field];
     if (value) lines.push(`${field}: ${yamlScalar(value)}`);
   }
@@ -588,7 +583,7 @@ export function directoryIndexToSignals(
       extractContentDuplicateSignals(
         {
           filePath,
-          content: contentSignalSourceFromDirectoryEntry(entry),
+          content: contentSignalSourceFromDirectoryEntry(entry, spec),
           label: `accepted entry ${filePath}`,
           url: String(entry.canonicalUrl || "") || `${siteUrl}/entry/${String(entry.category)}/${String(entry.slug)}`,
         },

--- a/test/unit/content-lane-duplicates.test.ts
+++ b/test/unit/content-lane-duplicates.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildContentDuplicateReview,
+  contentSignalSourceFromDirectoryEntry,
   directoryIndexToSignals,
   extractContentDuplicateSignals,
   findContentDuplicateMatch,
@@ -872,5 +873,24 @@ describe("per-repo ContentRepoSpec override (a self-hosted curated list re-param
     const signals = directoryIndexToSignals(entries);
     expect(signals[0]?.urls).toEqual(["https://github.com/acme/foo", "https://acme.example"]);
     expect(signals[0]?.urls).not.toContain("https://should-not-appear.example");
+  });
+
+  it("contentSignalSourceFromDirectoryEntry defaults spec to AWESOME_CLAUDE_CONTENT_SPEC and skips empty URL values (#5941)", () => {
+    // One-arg call covers the default-parameter branch; empty-string githubUrl covers the falsy `if (value)` arm.
+    const synthesized = contentSignalSourceFromDirectoryEntry({
+      category: "skills",
+      slug: "foo",
+      title: "Foo",
+      description: "d",
+      githubUrl: "",
+      websiteUrl: "https://acme.example",
+    });
+    expect(synthesized).toContain('websiteUrl: "https://acme.example"');
+    expect(synthesized).not.toContain("githubUrl:");
+    const viaDefaultSpec = extractContentDuplicateSignals({
+      filePath: "content/skills/foo.mdx",
+      content: synthesized,
+    });
+    expect(viaDefaultSpec.urls).toEqual(["https://acme.example"]);
   });
 });

--- a/test/unit/content-lane-duplicates.test.ts
+++ b/test/unit/content-lane-duplicates.test.ts
@@ -837,4 +837,40 @@ describe("per-repo ContentRepoSpec override (a self-hosted curated list re-param
     expect(directoryIndexToSignals(entries)[0]?.urls).toEqual(["https://github.com/o/r"]); // default url fields read githubUrl
     expect(directoryIndexToSignals(entries, {}, customSpec({ urlFields: new Set() }))[0]?.urls).toEqual([]); // custom empty set → none
   });
+
+  // #5941 — before the fix, directory-index synthesis always emitted a hardcoded URL-field list, so a custom
+  // ContentRepoSpec.urlFields set never reached extractContentDuplicateSignals and corpus urls stayed [].
+  it("directoryIndexToSignals emits custom ContentRepoSpec urlFields into corpus urls (regression #5941)", () => {
+    const entries = [
+      {
+        category: "tools",
+        slug: "x",
+        title: "X",
+        description: "d",
+        myLink: "https://example.com/custom",
+        githubUrl: "https://github.com/o/r",
+      },
+    ];
+    const spec = customSpec({ urlFields: new Set(["myLink"]) });
+    const signals = directoryIndexToSignals(entries, {}, spec);
+    expect(signals[0]?.urls).toEqual(["https://example.com/custom"]);
+    expect(signals[0]?.urls).not.toContain("https://github.com/o/r");
+  });
+
+  it("default AWESOME_CLAUDE_CONTENT_SPEC still synthesizes the prior camelCase URL fields unchanged (#5941)", () => {
+    const entries = [
+      {
+        category: "skills",
+        slug: "foo",
+        title: "Foo",
+        description: "d",
+        githubUrl: "https://github.com/acme/foo",
+        websiteUrl: "https://acme.example",
+        myLink: "https://should-not-appear.example",
+      },
+    ];
+    const signals = directoryIndexToSignals(entries);
+    expect(signals[0]?.urls).toEqual(["https://github.com/acme/foo", "https://acme.example"]);
+    expect(signals[0]?.urls).not.toContain("https://should-not-appear.example");
+  });
 });


### PR DESCRIPTION
## Summary

- `contentSignalSourceFromDirectoryEntry` now takes a `ContentRepoSpec` and emits URL frontmatter from `spec.urlFields` instead of a hardcoded field list.
- `directoryIndexToSignals` passes its `spec` through so synthesis and `extractContentDuplicateSignals` agree on URL keys.
- Regression tests cover a custom non-default `urlFields` set (corpus `urls` must contain the custom field) and unchanged default `AWESOME_CLAUDE_CONTENT_SPEC` camelCase behavior.

## Scope

- [x] Conventional Commit title
- [x] Focused bug fix for #5941
- [x] Linked open issue

## Validation

- [x] `npx vitest run test/unit/content-lane-duplicates.test.ts` — 83 passed
- [x] Coverage on `src/review/content-lane/duplicates.ts` — 100% stmts/branches/funcs/lines for this file under that suite

## Safety

- [x] No secrets / wallets / scoring surfaces
- [x] No changelog / site edits

## UI Evidence

N/A — review content-lane backend fix; no UI change.

Closes #5941