### PR TITLE
fix(signals): carry labelPolicy.note through focusManifestPolicyToCompilerOutput

### DIFF
--- a/src/signals/onboarding-pack.ts
+++ b/src/signals/onboarding-pack.ts
@@ -1,4 +1,5 @@
 import { isFocusManifestPublicSafe, type FocusManifestPolicy } from "./focus-manifest";
+import { labelPolicyNote } from "./repo-policy-compiler";
 import { nowIso } from "../utils/json";
 
 export type RepoPolicyContributionLane = {
@@ -99,6 +100,7 @@ export function focusManifestPolicyToCompilerOutput(policy: FocusManifestPolicy)
       preferredLabels: policy.publicSafe.labelPolicy.preferredLabels,
       requiredLabels: [],
       discouragedLabels: [],
+      note: labelPolicyNote(policy.publicSafe.validation.linkedIssuePolicy),
     },
     validationExpectations: policy.publicSafe.validation.expectations,
     readinessWarnings: policy.publicSafe.readinessWarnings,

--- a/src/signals/repo-policy-compiler.ts
+++ b/src/signals/repo-policy-compiler.ts
@@ -112,7 +112,10 @@ function issueDiscoverySummary(preference: FocusManifestLanePreference, summary:
   return "Issue discovery is optional; confirm maintainer scope before filing new issues.";
 }
 
-function labelPolicyNote(linkedIssuePolicy: string): string {
+/** Shared by {@link focusManifestPolicyToCompilerOutput} (onboarding-pack.ts) so both adapters compile the same
+ *  manifest to the same `labelPolicy.note` (#5943). The reverse import there is type-only and erased, so this
+ *  export introduces no runtime cycle. */
+export function labelPolicyNote(linkedIssuePolicy: string): string {
   if (linkedIssuePolicy === "required") return "Link a tracked issue before opening a pull request.";
   if (linkedIssuePolicy === "preferred") return "Link a tracked issue when one exists.";
   return "Use labels to explain accepted scope, not to promise outcomes.";

--- a/test/unit/onboarding-pack.test.ts
+++ b/test/unit/onboarding-pack.test.ts
@@ -5,10 +5,11 @@ import {
 } from "../../src/services/repo-onboarding-pack";
 import { createTestEnv } from "../helpers/d1";
 import { upsertRepositoryFromGitHub } from "../../src/db/repositories";
-import { parseFocusManifestContent } from "../../src/signals/focus-manifest";
+import { compileFocusManifestPolicy, parseFocusManifest, parseFocusManifestContent } from "../../src/signals/focus-manifest";
 import { compileRepoPolicyCompilerOutput } from "../../src/signals/repo-policy-compiler";
 import {
   buildRepoOnboardingPackPreview,
+  focusManifestPolicyToCompilerOutput,
   isRepoOnboardingPackPublicSafe,
   type RepoPolicyCompilerOutput,
 } from "../../src/signals/onboarding-pack";
@@ -261,6 +262,42 @@ describe("buildRepoOnboardingPackPreview", () => {
     });
     expect(preview.droppedPublicItems).toEqual([]);
     expect(isRepoOnboardingPackPublicSafe(preview)).toBe(true);
+  });
+});
+
+// Both adapters compile the SAME FocusManifest into the same RepoPolicyCompilerOutput.labelPolicy shape, so they
+// must not disagree on any field: focusManifestPolicyToCompilerOutput omitted `note` entirely (#5943), silently
+// dropping the linked-issue guidance from registration-readiness's onboardingPackPreview while the direct
+// onboarding-pack API/MCP path (compileRepoPolicyCompilerOutput) kept it.
+describe("focusManifestPolicyToCompilerOutput labelPolicy.note parity (#5943)", () => {
+  const GENERATED_AT = "2026-06-02T12:00:00.000Z";
+
+  it.each([
+    ["required", /tracked issue before opening/i],
+    ["preferred", /when one exists/i],
+    ["optional", /accepted scope/i],
+  ] as const)("linkedIssuePolicy %s yields the same non-null note as compileRepoPolicyCompilerOutput", (linkedIssuePolicy, expected) => {
+    const manifest = parseFocusManifest({ wantedPaths: ["src/"], linkedIssuePolicy });
+    const fromAdapter = focusManifestPolicyToCompilerOutput(
+      compileFocusManifestPolicy("owner/repo", manifest, { generatedAt: GENERATED_AT }),
+    );
+    const fromCompiler = compileRepoPolicyCompilerOutput({ repoFullName: "owner/repo", manifest, generatedAt: GENERATED_AT });
+
+    expect(fromAdapter.labelPolicy?.note).toEqual(expect.any(String));
+    expect(fromAdapter.labelPolicy?.note).toMatch(expected);
+    expect(fromAdapter.labelPolicy?.note).toBe(fromCompiler.labelPolicy?.note);
+  });
+
+  it("leaves every other labelPolicy field untouched (the fix is scoped to note)", () => {
+    const manifest = parseFocusManifest({ wantedPaths: ["src/"], preferredLabels: ["bug"], linkedIssuePolicy: "required" });
+    const output = focusManifestPolicyToCompilerOutput(compileFocusManifestPolicy("owner/repo", manifest, { generatedAt: GENERATED_AT }));
+
+    expect(output.labelPolicy).toEqual({
+      preferredLabels: ["bug"],
+      requiredLabels: [],
+      discouragedLabels: [],
+      note: "Link a tracked issue before opening a pull request.",
+    });
   });
 });
 

--- a/test/unit/registration-readiness.test.ts
+++ b/test/unit/registration-readiness.test.ts
@@ -308,6 +308,32 @@ describe("buildRegistrationReadiness", () => {
     expect(JSON.stringify(report.onboardingPackPreview)).not.toMatch(FORBIDDEN_PUBLIC_LANGUAGE);
   });
 
+  // #5943: focusManifestPolicyToCompilerOutput dropped labelPolicy.note, so this preview always rendered
+  // note: null — silently losing the linked-issue guidance the same manifest produces via the direct
+  // onboarding-pack API/MCP path (compileRepoPolicyCompilerOutput).
+  it("onboardingPackPreview surfaces labelPolicy.note from the manifest's linkedIssuePolicy (#5943)", () => {
+    const repo = repoFor("octo/note", configFor({ repo: "octo/note" }));
+    const readinessFor = (linkedIssuePolicy: "required" | "preferred" | "optional") =>
+      buildRegistrationReadiness({
+        repoFullName: repo.fullName,
+        repo,
+        settings: settingsFor(repo.fullName),
+        installation: healthyInstall,
+        ...signalsFor(repo, [], [], [label("bug")]),
+        focusManifest: parseFocusManifest({ wantedPaths: ["src/signals/"], linkedIssuePolicy }),
+      });
+
+    expect(readinessFor("required").onboardingPackPreview?.labelPolicy.note).toBe(
+      "Link a tracked issue before opening a pull request.",
+    );
+    expect(readinessFor("preferred").onboardingPackPreview?.labelPolicy.note).toBe(
+      "Link a tracked issue when one exists.",
+    );
+    expect(readinessFor("optional").onboardingPackPreview?.labelPolicy.note).toBe(
+      "Use labels to explain accepted scope, not to promise outcomes.",
+    );
+  });
+
   it("onboardingPackPreview strips unsafe public notes via the policy compiler pipeline", () => {
     const repo = repoFor("octo/unsafe", configFor({ repo: "octo/unsafe" }));
     const report = buildRegistrationReadiness({


### PR DESCRIPTION
## Summary

Closes #5943

Two adapters compile the same `FocusManifestPolicy` into the same `RepoPolicyCompilerOutput.labelPolicy` shape, and disagreed on one field:

- `compileRepoPolicyCompilerOutput` (`src/signals/repo-policy-compiler.ts`) — the direct onboarding-pack API route + MCP tool path — sets `note: labelPolicyNote(policy.publicSafe.validation.linkedIssuePolicy)`.
- `focusManifestPolicyToCompilerOutput` (`src/signals/onboarding-pack.ts`) — used by `buildRegistrationReadiness`'s `onboardingPackPreview` — **omitted `note` entirely**.

The adapter's own doc comment says it adapts a compiled policy "into the `RepoPolicyCompilerOutput` shape expected by `buildRepoOnboardingPackPreview`", so the two should agree for the same manifest. Because it didn't, `sanitizeLabelPolicy` received `note: undefined` and emitted `null` — so the registration-readiness report (surfaced to repo owners evaluating whether to register) **always** showed `labelPolicy.note: null`, silently losing the linked-issue guidance (e.g. *"Link a tracked issue before opening a pull request."*) that the very same manifest produces via the direct API/MCP path.

**Fix:** `export` the existing `labelPolicyNote` helper and reuse it as-is from the adapter. Per the issue's first suggested approach (the more minimal diff): the reverse import in `repo-policy-compiler.ts` is **type-only** and erased at compile time, so this introduces no runtime cycle. The helper's three `linkedIssuePolicy` branches are unchanged and not duplicated, and no other field mapping in `focusManifestPolicyToCompilerOutput` is touched.

## Scope

- [x] Conventional Commit title (`fix(signals): …`).
- [x] Focused: one missing field + regression tests. No other mapping, no logic change to `labelPolicyNote`.
- [x] Follows `CONTRIBUTING.md`; no `site/`/`CNAME`/`lovable` changes; no changelog edit.
- [x] Linked open issue (Closes #5943, above).

## Validation

- [x] `git diff --check` clean.
- [x] `npm run typecheck` — exit 0.
- [x] Focused suites green: `onboarding-pack`, `registration-readiness`, `repo-policy-compiler`, `policy-sanitizer`, `self-dogfood-registration-pack`, `focus-manifest` — **763 tests passed**. These are the complete blast radius: `focusManifestPolicyToCompilerOutput` has exactly one caller (`registration-readiness.ts:174`), and every test file importing `buildRegistrationReadiness` is included.
- [x] Patch coverage verified against `coverage/lcov.info` for the exact changed lines: `labelPolicyNote`'s body is covered (hits 30/23/18) and `focusManifestPolicyToCompilerOutput` is covered (hits 10). No uncovered changed lines.
- [x] Rebased onto current `main`.

New tests:
- `labelPolicy.note` **parity** across both adapters for all three `linkedIssuePolicy` values (`required` / `preferred` / `optional`) — asserts a non-null note that is byte-identical to `compileRepoPolicyCompilerOutput`'s, covering every `labelPolicyNote` branch.
- An invariant that every other `labelPolicy` field is untouched (the fix is scoped to `note`).
- End-to-end via `buildRegistrationReadiness`: `onboardingPackPreview.labelPolicy.note` is no longer always `null`.

If any required check was skipped, explain why:

- Full `test:ci` not run end-to-end locally (Linux-only steps on Windows; the repo's full suite is not reliable under this environment). The change-relevant gates — typecheck, the complete affected-suite set, and per-line patch coverage — were validated directly and are green.
- `ui:openapi:check` reports stale **on a clean checkout of `main`** in this environment (pre-existing, unrelated to this diff, which changes a runtime value and no schema), so no regenerated artifact is included — deliberately avoiding unrelated churn.

## Safety

- [x] No secrets, wallets, hotkeys, trust scores, rewards, private rankings, or private maintainer evidence.
- [x] No auth/cookie/CORS/GitHub App/session change (pure in-memory adapter over an already-compiled, public-safe policy).
- [x] Public-surface safe: the note still flows through `sanitizeLabelPolicy` → `safeOptionalPublicText`, and the text is the identical string the direct onboarding-pack path already publishes. `registration-readiness`'s forbidden-public-language assertions remain green.
- [x] No API/OpenAPI schema change (`labelPolicy.note` already exists in the type and schema; only its runtime value is corrected).
- [x] No UI changes; no changelog edit.
