### PR TITLE
fix(signals): populate labelPolicy.note in focusManifestPolicyToCompilerOutput (#5943)

### DIFF
--- a/src/signals/onboarding-pack.ts
+++ b/src/signals/onboarding-pack.ts
@@ -1,4 +1,5 @@
 import { isFocusManifestPublicSafe, type FocusManifestPolicy } from "./focus-manifest";
+import { labelPolicyNote } from "./repo-policy-compiler";
 import { nowIso } from "../utils/json";
 
 export type RepoPolicyContributionLane = {
@@ -99,6 +100,7 @@ export function focusManifestPolicyToCompilerOutput(policy: FocusManifestPolicy)
       preferredLabels: policy.publicSafe.labelPolicy.preferredLabels,
       requiredLabels: [],
       discouragedLabels: [],
+      note: labelPolicyNote(policy.publicSafe.validation.linkedIssuePolicy),
     },
     validationExpectations: policy.publicSafe.validation.expectations,
     readinessWarnings: policy.publicSafe.readinessWarnings,

--- a/src/signals/repo-policy-compiler.ts
+++ b/src/signals/repo-policy-compiler.ts
@@ -112,7 +112,7 @@ function issueDiscoverySummary(preference: FocusManifestLanePreference, summary:
   return "Issue discovery is optional; confirm maintainer scope before filing new issues.";
 }
 
-function labelPolicyNote(linkedIssuePolicy: string): string {
+export function labelPolicyNote(linkedIssuePolicy: string): string {
   if (linkedIssuePolicy === "required") return "Link a tracked issue before opening a pull request.";
   if (linkedIssuePolicy === "preferred") return "Link a tracked issue when one exists.";
   return "Use labels to explain accepted scope, not to promise outcomes.";

--- a/test/unit/onboarding-pack.test.ts
+++ b/test/unit/onboarding-pack.test.ts
@@ -5,10 +5,11 @@ import {
 } from "../../src/services/repo-onboarding-pack";
 import { createTestEnv } from "../helpers/d1";
 import { upsertRepositoryFromGitHub } from "../../src/db/repositories";
-import { parseFocusManifestContent } from "../../src/signals/focus-manifest";
+import { parseFocusManifestContent, compileFocusManifestPolicy, parseFocusManifest } from "../../src/signals/focus-manifest";
 import { compileRepoPolicyCompilerOutput } from "../../src/signals/repo-policy-compiler";
 import {
   buildRepoOnboardingPackPreview,
+  focusManifestPolicyToCompilerOutput,
   isRepoOnboardingPackPublicSafe,
   type RepoPolicyCompilerOutput,
 } from "../../src/signals/onboarding-pack";
@@ -59,6 +60,20 @@ const POLICY_COMPILER_FIXTURE: RepoPolicyCompilerOutput = {
     "Private owner note: only maintainers should see internal calibration context.",
   ],
 };
+
+describe("focusManifestPolicyToCompilerOutput (#5943)", () => {
+  it("matches compileRepoPolicyCompilerOutput's labelPolicy.note for the same manifest", () => {
+    const repoFullName = "octo/widgets";
+    const manifest = parseFocusManifest({ wantedPaths: ["src/"], linkedIssuePolicy: "required" });
+    const generatedAt = "2026-01-01T00:00:00.000Z";
+    const viaCompiler = compileRepoPolicyCompilerOutput({ repoFullName, manifest, generatedAt });
+    const viaAdapter = focusManifestPolicyToCompilerOutput(
+      compileFocusManifestPolicy(repoFullName, manifest, { generatedAt }),
+    );
+    expect(viaAdapter.labelPolicy?.note).toBe(viaCompiler.labelPolicy?.note);
+    expect(viaAdapter.labelPolicy?.note).toBe("Link a tracked issue before opening a pull request.");
+  });
+});
 
 describe("buildRepoOnboardingPackPreview", () => {
   it("cross-links policy compiler output into onboarding pack inputs for issue 248", () => {

--- a/test/unit/registration-readiness.test.ts
+++ b/test/unit/registration-readiness.test.ts
@@ -305,6 +305,7 @@ describe("buildRegistrationReadiness", () => {
     expect(report.onboardingPackPreview?.previewOnly).toBe(true);
     expect(report.onboardingPackPreview?.repoFullName).toBe("octo/manifest");
     expect(report.onboardingPackPreview?.contributionLanes.length).toBeGreaterThan(0);
+    expect(report.onboardingPackPreview?.labelPolicy.note).toBe("Link a tracked issue before opening a pull request.");
     expect(JSON.stringify(report.onboardingPackPreview)).not.toMatch(FORBIDDEN_PUBLIC_LANGUAGE);
   });
 


### PR DESCRIPTION
## Summary

Fixes #5943

Two adapters compile `FocusManifestPolicy` into `RepoPolicyCompilerOutput`, but only `compileRepoPolicyCompilerOutput` populated `labelPolicy.note`. The registration-readiness report uses `focusManifestPolicyToCompilerOutput`, so `onboardingPackPreview.labelPolicy.note` was always `null` — silently dropping linked-issue-policy guidance.

## Root cause

`focusManifestPolicyToCompilerOutput` omitted `labelPolicy.note` while its sibling adapter called the private `labelPolicyNote()` helper.

## Fix approach

- Export `labelPolicyNote` from `repo-policy-compiler.ts`
- Reuse it in `focusManifestPolicyToCompilerOutput` with the same `linkedIssuePolicy` input
- Cross-adapter parity test + registration-readiness end-to-end assertion

## Impact

Repo owners evaluating registration readiness now see the same linked-issue guidance text as the direct onboarding-pack API/MCP path.

## Risk / tradeoffs

- Minimal: reuses existing helper logic unchanged; no other field mappings touched.