### PR TITLE
fix(miner): honor --json on purge arg-parse errors

### DIFF
--- a/packages/loopover-miner/lib/purge-cli.js
+++ b/packages/loopover-miner/lib/purge-cli.js
@@ -24,6 +24,7 @@ import {
   countStoreByRepo,
   describeError,
 } from "./store-maintenance.js";
+import { argsWantJson, reportCliFailure } from "./cli-error.js";
 
 const PURGE_USAGE = "Usage: loopover-miner purge --repo <owner/repo> [--dry-run] [--json]";
 
@@ -166,8 +167,7 @@ function renderPurgeSummary(summary) {
 export function runPurge(args, options = {}) {
   const parsed = parsePurgeArgs(args);
   if ("error" in parsed) {
-    console.error(parsed.error);
-    return 2;
+    return reportCliFailure(argsWantJson(args), parsed.error);
   }
 
   if (parsed.dryRun) {

--- a/test/unit/miner-purge-cli.test.ts
+++ b/test/unit/miner-purge-cli.test.ts
@@ -232,6 +232,15 @@ describe("runPurge --dry-run (#5564)", () => {
     expect(error).toHaveBeenCalledWith(expect.stringContaining("Usage: loopover-miner purge"));
   });
 
+  it("emits the {ok:false,error} JSON envelope for an argument error when --json is passed (#5915)", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    expect(runPurge(["--json"])).toBe(2);
+    expect(error).not.toHaveBeenCalled();
+    const result = JSON.parse(String(log.mock.calls[0]?.[0]));
+    expect(result).toEqual({ ok: false, error: expect.stringContaining("Usage: loopover-miner purge") });
+  });
+
   it("opens the real default on-disk stores in dry-run when no resolveDbPaths override is supplied", () => {
     const root = tempDir();
     const previousDirs: Record<string, string | undefined> = {


### PR DESCRIPTION
### Summary

`loopover-miner purge` was already `--json`-aware on its success/dry-run/partial-failure outcomes, but `runPurge`'s top-level arg-parse failure path used a bare `console.error(...); return 2` instead of the shared `reportCliFailure`/`argsWantJson` contract (`cli-error.js`) that the rest of the CLI suite (attempt-cli, claim-ledger-cli, discover-cli, etc.) already uses.

Scripted callers that always pass `--json` and expect `{ok:false,error}` regardless of outcome got plain stderr text instead on a parse failure (e.g. `purge --repo bad-value --json`).

### Behavior

- **With `--json`:** an arg-parse failure now prints `{ "ok": false, "error": "..." }` on stdout and exits 2.
- **Without `--json`:** unchanged — still prints the human-readable message to stderr and exits 2.

### Tests

Added a regression test in `test/unit/miner-purge-cli.test.ts` covering the arg-parse error WITH `--json`, asserting the JSON envelope shape, that nothing is written to stderr, and the exit code. The pre-existing test right above it already covers the non-`--json` stderr arm.

`npx vitest run test/unit/miner-purge-cli.test.ts --coverage --coverage.include='packages/loopover-miner/lib/purge-cli.js'` → 100% statements/branches/functions/lines on the changed file.

Closes #5915
