### PR TITLE
fix(miner): honor --json on governor pause/resume/status error paths (#5914)

### DIFF
--- a/packages/loopover-miner/lib/governor-pause-cli.js
+++ b/packages/loopover-miner/lib/governor-pause-cli.js
@@ -6,6 +6,7 @@
 // existing single-row scalar-state table, not a new store: a pause flag has no relational key of its own, the
 // same reasoning that table's other scalar fields (rate-limit buckets, cap usage) already rely on.
 
+import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
 import { openGovernorState } from "./governor-state.js";
 
 const GOVERNOR_PAUSE_USAGE = "Usage: loopover-miner governor pause [--reason <text>] [--dry-run] [--json]";
@@ -83,8 +84,7 @@ function renderPauseState(pauseState) {
 export async function runGovernorPause(args, options = {}) {
   const parsed = parseGovernorPauseArgs(args);
   if ("error" in parsed) {
-    console.error(parsed.error);
-    return 2;
+    return reportCliFailure(argsWantJson(args), parsed.error);
   }
 
   if (parsed.dryRun) {
@@ -109,16 +109,14 @@ export async function runGovernorPause(args, options = {}) {
       return 0;
     });
   } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
-    return 2;
+    return reportCliFailure(parsed.json, describeCliError(error));
   }
 }
 
 export async function runGovernorResume(args, options = {}) {
   const parsed = parseGovernorResumeArgs(args);
   if ("error" in parsed) {
-    console.error(parsed.error);
-    return 2;
+    return reportCliFailure(argsWantJson(args), parsed.error);
   }
 
   if (parsed.dryRun) {
@@ -142,16 +140,14 @@ export async function runGovernorResume(args, options = {}) {
       return 0;
     });
   } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
-    return 2;
+    return reportCliFailure(parsed.json, describeCliError(error));
   }
 }
 
 export async function runGovernorStatus(args, options = {}) {
   const parsed = parseNoArgsSubcommand(args, GOVERNOR_STATUS_USAGE);
   if ("error" in parsed) {
-    console.error(parsed.error);
-    return 2;
+    return reportCliFailure(argsWantJson(args), parsed.error);
   }
 
   try {
@@ -165,7 +161,6 @@ export async function runGovernorStatus(args, options = {}) {
       return 0;
     });
   } catch (error) {
-    console.error(error instanceof Error ? error.message : String(error));
-    return 2;
+    return reportCliFailure(parsed.json, describeCliError(error));
   }
 }

--- a/test/unit/miner-governor-pause-cli.test.ts
+++ b/test/unit/miner-governor-pause-cli.test.ts
@@ -266,3 +266,97 @@ describe("loopover-miner governor pause/resume/status CLI (#4851)", () => {
     }
   });
 });
+
+describe("governor pause/resume/status --json error contract (#5914)", () => {
+  it("runGovernorPause emits the JSON envelope on a parse error and never opens the store", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const openGovernorStateFn = vi.fn();
+
+    expect(await runGovernorPause(["--verbose", "--json"], { openGovernorState: openGovernorStateFn })).toBe(2);
+    expect(openGovernorStateFn).not.toHaveBeenCalled();
+    expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({ ok: false, error: "Unknown option: --verbose" });
+  });
+
+  it("runGovernorPause emits the JSON envelope when the governor state throws", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    expect(
+      await runGovernorPause(["--json"], {
+        openGovernorState: () => {
+          throw new Error("disk full");
+        },
+      }),
+    ).toBe(2);
+    expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({ ok: false, error: "disk full" });
+  });
+
+  it("runGovernorResume emits the JSON envelope on a parse error rejected before --json is reached", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    // `extra` aborts the parse before the parser ever sees --json, so the envelope can only come from
+    // argsWantJson(args) reading raw argv -- parsed.json would be unavailable here.
+    expect(await runGovernorResume(["extra", "--json"])).toBe(2);
+    const envelope = JSON.parse(String(log.mock.calls[0]?.[0]));
+    expect(envelope.ok).toBe(false);
+    expect(envelope.error).toContain("Usage: loopover-miner governor resume");
+  });
+
+  it("runGovernorResume emits the JSON envelope when the governor state throws", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    expect(
+      await runGovernorResume(["--json"], {
+        openGovernorState: () => {
+          throw new Error("disk full");
+        },
+      }),
+    ).toBe(2);
+    expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({ ok: false, error: "disk full" });
+  });
+
+  it("runGovernorStatus emits the JSON envelope on a parse error", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    expect(await runGovernorStatus(["extra", "--json"])).toBe(2);
+    const envelope = JSON.parse(String(log.mock.calls[0]?.[0]));
+    expect(envelope.ok).toBe(false);
+    expect(envelope.error).toContain("Usage: loopover-miner governor status");
+  });
+
+  it("runGovernorStatus emits the JSON envelope when the governor state throws", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    expect(
+      await runGovernorStatus(["--json"], {
+        openGovernorState: () => {
+          throw new Error("disk full");
+        },
+      }),
+    ).toBe(2);
+    expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toEqual({ ok: false, error: "disk full" });
+  });
+
+  it("keeps non-JSON error paths on stderr as plain text", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+
+    expect(await runGovernorPause(["--verbose"])).toBe(2);
+    expect(await runGovernorResume(["extra"])).toBe(2);
+    expect(await runGovernorStatus(["extra"])).toBe(2);
+    expect(
+      await runGovernorStatus([], {
+        openGovernorState: () => {
+          throw new Error("disk full");
+        },
+      }),
+    ).toBe(2);
+
+    expect(log).not.toHaveBeenCalled();
+    expect(error.mock.calls.map((call) => String(call[0]))).toEqual([
+      "Unknown option: --verbose",
+      expect.stringContaining("Usage: loopover-miner governor resume"),
+      expect.stringContaining("Usage: loopover-miner governor status"),
+      "disk full",
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

- `governor-pause-cli.js` was the last CLI module in `packages/loopover-miner/lib/` that never adopted the shared `cli-error.js` failure contract: `runGovernorPause`, `runGovernorResume`, and `runGovernorStatus` each handled their parse-error and catch-error paths with a raw `console.error(...); return 2;`. So `loopover-miner governor pause|resume|status --json` printed plain text to **stderr** on any error path instead of the documented `{ok:false,error}` envelope on **stdout**, breaking scripted/MCP consumers that always pass `--json` and expect JSON regardless of outcome.
- Routes all **6** of those error paths through `reportCliFailure(...)`, matching the reference implementation in `claim-ledger-cli.js:222,253` and the same shape already used by `plan-store-cli.js`, `run-state-cli.js`, `event-ledger-cli.js`, `portfolio-queue-cli.js`, and 10 other sibling modules.
- Parse-error paths pass `argsWantJson(args)` (raw argv) and catch paths pass `parsed.json`, exactly as the siblings do. This distinction is load-bearing, not an inconsistency: a parse failure returns `{error}` with **no** `.json` field, and a token can abort the parse *before* `--json` is ever read — `loopover-miner governor resume extra --json` is a real case, and it has a dedicated test.
- Behavior on non-`--json` invocations is unchanged: plain text to stderr, exit code 2. `reportCliFailure`'s default `exitCode` is already 2, so every path returns the same code it did before.

Closes #5914

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [ ] `npm run actionlint`
- [x] `npm run typecheck`
- [ ] `npm run test:coverage`
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- **Unchecked boxes are checks I did not run locally, listed honestly rather than assumed.** The change is confined to one miner `lib/*.js` module and its unit test; the unrun checks cover surfaces this diff does not touch — no workflow files (`actionlint`), no worker/MCP/OpenAPI/UI files (`test:workers`, `build:mcp`, `test:mcp-pack`, `ui:*`), no migrations, schema, `wrangler.jsonc` bindings, or `env.*` reads (so no `cf-typegen` / env-reference regeneration is owed). CI runs all of them regardless.
- **`test:coverage`:** I ran the changed file's coverage scoped rather than the full unsharded suite. Result on `packages/loopover-miner/lib/governor-pause-cli.js`: **100% statements (93/93), 100% branches (53/53), 100% lines** — the whole file, so every changed line and branch is covered by construction. The 4 changed statements themselves introduce no new conditionals.
- **`typecheck`:** `tsc --noEmit` exits 0 on the full workspace.
- **The regression tests fail on the unfixed code — verified, not assumed.** Reverting only `governor-pause-cli.js` to `main` and re-running the new `#5914` block fails **6 of 7** tests with `SyntaxError: "undefined" is not valid JSON` (nothing reaches stdout, because the old code wrote to stderr). The 7th (`keeps non-JSON error paths on stderr as plain text`) passes both before and after **by design** — it is the behavior-preservation test pinning the unchanged non-`--json` contract.
- **Blast radius checked:** `runGovernorPause`/`runGovernorResume`/`runGovernorStatus` have exactly one non-test consumer — `governor-ledger-cli.js:150-152`, which dispatches `governor pause|resume|status`. Its suite (`test/unit/miner-governor-ledger-cli.test.ts`) passes unchanged. `apps/loopover-miner-ui/vite-governor-api.ts` only references the module in a comment and reads governor-state directly; nothing shells out to this CLI to parse its output. `node --check` passes (what `build:miner` does).

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [ ] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [ ] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

The four unchecked Safety boxes are **not applicable** to this diff, so they are left unchecked rather than checked as a formality: it touches no auth/cookie/CORS/App/Cloudflare/session surface, no API/OpenAPI/MCP behavior, and no UI — so there is no `UI Evidence` to attach. The `--json` error envelope is an existing documented contract this module was not honoring; no public doc changes, and no changelog edit (not a release-prep PR).

## Notes

- The error-path *messages* are unchanged — only their destination and framing on `--json` runs. `describeCliError` reproduces the previous `error instanceof Error ? error.message : String(error)` normalization exactly, so the non-Error throw path keeps stringifying identically (still covered by the pre-existing tests at `miner-governor-pause-cli.test.ts`).
- I deliberately did **not** extract the repeated `if ("error" in parsed) return reportCliFailure(argsWantJson(args), parsed.error);` into a local helper: all 15 sibling CLI modules inline this exact pattern, and matching the established convention keeps `governor-pause-cli.js` diffable against its siblings. For the same reason I did not add an inline comment explaining `argsWantJson(args)` vs `parsed.json` — that rationale is documented once at the definition site (`cli-error.js:19`) and no sibling repeats it; this PR's Summary records the reasoning instead.
