### PR TITLE
fix(review): preserve lockfile-tamper entry tracking across nested dependencies (#5837)

### DIFF
--- a/src/review/lockfile-tamper.ts
+++ b/src/review/lockfile-tamper.ts
@@ -113,8 +113,8 @@ function versionChanged(removed: string | undefined, added: string | undefined):
  *  actively maintained repo's lockfile and is out of scope here. */
 function scanPackageLockPatch(path: string, patch: string): LockfileTamperCandidate[] {
   const byEntry = new Map<string, MutableCandidate>();
-  let currentEntryKey: string | null = null;
-  let currentPackageName: string | null = null;
+  let activeEntry: { entryKey: string; packageName: string } | null = null;
+  let innerObjectDepth = 0;
   let sawPackagesEntry = false;
 
   const entryFor = (entryKey: string, packageName: string): MutableCandidate => {
@@ -140,22 +140,29 @@ function scanPackageLockPatch(path: string, patch: string): LockfileTamperCandid
       const key = objectHeader[1]!;
       const nodeModulesPackage = npmPackageFromNodeModulesPath(key);
       if (nodeModulesPackage) {
-        currentEntryKey = key;
-        currentPackageName = nodeModulesPackage;
+        activeEntry = { entryKey: key, packageName: nodeModulesPackage };
+        innerObjectDepth = 0;
         sawPackagesEntry = true;
+      } else if (activeEntry) {
+        innerObjectDepth++;
       } else if (!sawPackagesEntry && !CONTAINER_KEYS.has(key)) {
-        currentEntryKey = key;
-        currentPackageName = key;
+        activeEntry = { entryKey: key, packageName: key };
+        innerObjectDepth = 0;
       } else {
-        currentEntryKey = null;
-        currentPackageName = null;
+        activeEntry = null;
+        innerObjectDepth = 0;
       }
       continue;
     }
     if (body === "}" || body.startsWith("},")) {
-      currentEntryKey = null;
-      currentPackageName = null;
+      if (innerObjectDepth > 0) {
+        innerObjectDepth--;
+      } else {
+        activeEntry = null;
+      }
     }
+    const currentEntryKey = activeEntry?.entryKey ?? null;
+    const currentPackageName = activeEntry?.packageName ?? null;
     if (!currentEntryKey || !currentPackageName || line.sign === " ") continue;
 
     const resolvedMatch = /^"resolved"\s*:\s*"([^"]*)"/.exec(body);

--- a/test/unit/lockfile-tamper.test.ts
+++ b/test/unit/lockfile-tamper.test.ts
@@ -421,4 +421,24 @@ describe("lockfileTamperRiskFinding", () => {
     expect(finding).not.toBeNull();
     expect(finding?.detail).toContain("foo");
   });
+
+  it("tracks tamper signals inside a packages root wrapper and through optionalDependencies sub-objects", () => {
+    const lockPatch = [
+      '@@ -1,12 +1,12 @@',
+      ' "packages": {',
+      '     "node_modules/lodash": {',
+      '       "optionalDependencies": {',
+      '         "left-pad": {',
+      '           "version": "1.0.0"',
+      '         }',
+      '       },',
+      '-      "integrity": "sha512-old=="',
+      '+      "integrity": "sha512-tampered=="',
+      '     }',
+      ' },',
+    ].join("\n");
+    const finding = lockfileTamperRiskFinding([lockfilePatch(lockPatch)]);
+    expect(finding).not.toBeNull();
+    expect(finding?.detail).toContain("lodash");
+  });
 });

--- a/test/unit/lockfile-tamper.test.ts
+++ b/test/unit/lockfile-tamper.test.ts
@@ -368,4 +368,57 @@ describe("lockfileTamperRiskFinding", () => {
     expect(finding?.detail).toContain("evil-pkg");
     expect(finding?.detail).toContain("outside registry.npmjs.org");
   });
+
+  // #5837: a nested "dependencies" sub-object inside a node_modules/... entry must not permanently drop
+  // tracking — resolved/integrity/version lines AFTER that sub-object must still attribute to the outer entry.
+  it("still flags tampered resolved/integrity when a nested dependencies sub-object precedes those fields (#5837)", () => {
+    const lockPatch = [
+      '@@ -1,14 +1,14 @@',
+      '     "node_modules/foo": {',
+      '       "dependencies": {',
+      '         "bar": {',
+      '           "version": "1.0.0"',
+      '         }',
+      '       },',
+      '-      "version": "1.0.0",',
+      '-      "resolved": "https://registry.npmjs.org/foo/-/foo-1.0.0.tgz",',
+      '-      "integrity": "sha512-old=="',
+      '+      "version": "1.0.0",',
+      '+      "resolved": "https://registry.npmjs.org/foo/-/foo-1.0.0.tgz",',
+      '+      "integrity": "sha512-tampered=="',
+      '     },',
+    ].join("\n");
+    const finding = lockfileTamperRiskFinding([lockfilePatch(lockPatch)]);
+    expect(finding).not.toBeNull();
+    expect(finding?.detail).toContain("foo");
+  });
+
+  it("composes nested-dependencies tracking with full-path entry keying for two nested copies of the same package (#5837)", () => {
+    const lockPatch = [
+      '@@ -1,24 +1,24 @@',
+      '     "node_modules/foo": {',
+      '       "dependencies": {',
+      '         "left-pad": {',
+      '           "version": "1.0.0"',
+      '         }',
+      '       },',
+      '       "version": "1.0.0",',
+      '-      "integrity": "sha512-old1=="',
+      '+      "integrity": "sha512-new1=="',
+      '     },',
+      '     "node_modules/bar/node_modules/foo": {',
+      '       "devDependencies": {',
+      '         "left-pad": {',
+      '           "version": "2.0.0"',
+      '         }',
+      '       },',
+      '       "version": "2.0.0",',
+      '-      "integrity": "sha512-old2=="',
+      '+      "integrity": "sha512-tampered2=="',
+      '     },',
+    ].join("\n");
+    const finding = lockfileTamperRiskFinding([lockfilePatch(lockPatch)]);
+    expect(finding).not.toBeNull();
+    expect(finding?.detail).toContain("foo");
+  });
 });


### PR DESCRIPTION
## Summary

Fixes #5837

`scanPackageLockPatch` permanently lost track of the active `node_modules/...` entry when a nested dependencies` sub-object appeared before that entry'\''s own `resolved`/`integrity`/`version` lines. An attacker could reorder keys in a hand-edited diff to evade the lockfile-tamper check.

## Root cause

Entering a nested dependencies: {` header hit the reset branch and cleared `currentEntryKey` without restoring it when the nested object closed. Subsequent `resolved`/`integrity` lines were silently skipped.

## Fix approach

- Track the active package entry separately from inner object nesting depth
- Increment depth on any sub-object header inside an active entry; only clear the entry when its own closing brace is reached (depth zero)
- Regression tests for reordered-key bypass and two nested copies sharing a bare package name

## Impact

Tamper diffs with `dependencies` before `resolved`/`integrity` are now correctly flagged when the lockfile-integrity gate is enabled.

## Risk / tradeoffs

- Scoped to parsing state only — no API or finding-shape changes
- Legacy lockfileVersion 1 bare-name path unchanged (`!sawPackagesEntry` branch)