### PR TITLE
docs(api): add operation-level summary to all 78 OpenAPI routes

### DIFF
--- a/apps/loopover-ui/public/openapi.json
+++ b/apps/loopover-ui/public/openapi.json
@@ -8812,12 +8812,6 @@
               "block"
             ]
           },
-          "sizeGateMaxFiles": {
-            "type": "number"
-          },
-          "sizeGateMaxLines": {
-            "type": "number"
-          },
           "lockfileIntegrityGateMode": {
             "type": "string",
             "enum": [
@@ -8850,25 +8844,6 @@
             "type": "array",
             "items": {
               "type": "string"
-            }
-          },
-          "advisoryCheckRuns": {
-            "type": "array",
-            "nullable": true,
-            "items": {
-              "type": "object",
-              "properties": {
-                "name": {
-                  "type": "string"
-                },
-                "appSlug": {
-                  "type": "string"
-                }
-              },
-              "required": [
-                "name",
-                "appSlug"
-              ]
             }
           },
           "copycatGateMode": {
@@ -8965,10 +8940,6 @@
           },
           "aiReviewAllAuthors": {
             "type": "boolean"
-          },
-          "aiReviewConfirmedContributorsOnly": {
-            "type": "boolean",
-            "nullable": true
           },
           "aiReviewCloseConfidence": {
             "type": "number",
@@ -9492,10 +9463,6 @@
               "type": "string"
             }
           },
-          "hardGuardrailGlobsOverridesInvariants": {
-            "type": "boolean",
-            "nullable": true
-          },
           "manualReviewLabel": {
             "type": "string",
             "nullable": true
@@ -9575,14 +9542,6 @@
             "type": "string"
           },
           "skipAutomationBotAuthors": {
-            "type": "string",
-            "enum": [
-              "inherit",
-              "off",
-              "enabled"
-            ]
-          },
-          "duplicateWinnerMode": {
             "type": "string",
             "enum": [
               "inherit",
@@ -9673,6 +9632,47 @@
           "updatedAt": {
             "type": "string",
             "nullable": true
+          },
+          "hardGuardrailGlobsOverridesInvariants": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "aiReviewConfirmedContributorsOnly": {
+            "type": "boolean",
+            "nullable": true
+          },
+          "advisoryCheckRuns": {
+            "type": "array",
+            "nullable": true,
+            "items": {
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string"
+                },
+                "appSlug": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "name",
+                "appSlug"
+              ]
+            }
+          },
+          "sizeGateMaxFiles": {
+            "type": "number"
+          },
+          "sizeGateMaxLines": {
+            "type": "number"
+          },
+          "duplicateWinnerMode": {
+            "type": "string",
+            "enum": [
+              "inherit",
+              "off",
+              "enabled"
+            ]
           }
         },
         "required": [
@@ -10349,10 +10349,6 @@
               "aiReviewAllAuthors": {
                 "type": "boolean"
               },
-              "aiReviewConfirmedContributorsOnly": {
-                "type": "boolean",
-                "nullable": true
-              },
               "commandAuthorization": {
                 "type": "object",
                 "properties": {
@@ -10400,6 +10396,10 @@
                   "defaultAllowed",
                   "commandOverrides"
                 ]
+              },
+              "aiReviewConfirmedContributorsOnly": {
+                "type": "boolean",
+                "nullable": true
               }
             },
             "required": [
@@ -10708,67 +10708,6 @@
               "detailLevel"
             ]
           },
-          "checkRunReadiness": {
-            "type": "object",
-            "nullable": true,
-            "properties": {
-              "readinessBand": {
-                "type": "string",
-                "enum": [
-                  "strong",
-                  "developing",
-                  "early"
-                ]
-              },
-              "components": {
-                "type": "array",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "key": {
-                      "type": "string",
-                      "enum": [
-                        "traceability",
-                        "related_work",
-                        "change_scope",
-                        "validation",
-                        "pr_state",
-                        "queue_pressure"
-                      ]
-                    },
-                    "label": {
-                      "type": "string"
-                    },
-                    "band": {
-                      "type": "string",
-                      "enum": [
-                        "met",
-                        "partial",
-                        "unmet"
-                      ]
-                    },
-                    "evidence": {
-                      "type": "string"
-                    },
-                    "action": {
-                      "type": "string"
-                    }
-                  },
-                  "required": [
-                    "key",
-                    "label",
-                    "band",
-                    "evidence",
-                    "action"
-                  ]
-                }
-              }
-            },
-            "required": [
-              "readinessBand",
-              "components"
-            ]
-          },
           "installPreview": {
             "type": "object",
             "properties": {
@@ -10951,6 +10890,67 @@
           },
           "summary": {
             "type": "string"
+          },
+          "checkRunReadiness": {
+            "type": "object",
+            "nullable": true,
+            "properties": {
+              "readinessBand": {
+                "type": "string",
+                "enum": [
+                  "strong",
+                  "developing",
+                  "early"
+                ]
+              },
+              "components": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "key": {
+                      "type": "string",
+                      "enum": [
+                        "traceability",
+                        "related_work",
+                        "change_scope",
+                        "validation",
+                        "pr_state",
+                        "queue_pressure"
+                      ]
+                    },
+                    "label": {
+                      "type": "string"
+                    },
+                    "band": {
+                      "type": "string",
+                      "enum": [
+                        "met",
+                        "partial",
+                        "unmet"
+                      ]
+                    },
+                    "evidence": {
+                      "type": "string"
+                    },
+                    "action": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "key",
+                    "label",
+                    "band",
+                    "evidence",
+                    "action"
+                  ]
+                }
+              }
+            },
+            "required": [
+              "readinessBand",
+              "components"
+            ]
           }
         },
         "required": [
@@ -13952,7 +13952,8 @@
               }
             }
           }
-        }
+        },
+        "summary": "Basic service health check"
       }
     },
     "/v1/mcp/compatibility": {
@@ -13968,7 +13969,8 @@
               }
             }
           }
-        }
+        },
+        "summary": "Public API and MCP compatibility metadata"
       }
     },
     "/v1/public/stats": {
@@ -13990,7 +13992,8 @@
           "503": {
             "description": "Public stats are temporarily unavailable"
           }
-        }
+        },
+        "summary": "Public homepage lifetime stats and gate accuracy"
       }
     },
     "/v1/public/github/repos/{owner}/{repo}/stats": {
@@ -14030,7 +14033,8 @@
           "503": {
             "description": "GitHub repository stats are unavailable"
           }
-        }
+        },
+        "summary": "Public GitHub stars/forks for an allowlisted repository"
       }
     },
     "/v1/public/repos/{owner}/{repo}/quality": {
@@ -14070,7 +14074,8 @@
           "503": {
             "description": "Public quality metrics are temporarily unavailable"
           }
-        }
+        },
+        "summary": "Public per-repo review-quality metrics for an opted-in repository"
       }
     },
     "/v1/registry/snapshot": {
@@ -14094,7 +14099,8 @@
           {
             "LoopOverSessionCookie": []
           }
-        ]
+        ],
+        "summary": "Latest Gittensor registry snapshot"
       }
     },
     "/v1/registry/changes": {
@@ -14118,7 +14124,8 @@
           {
             "LoopOverSessionCookie": []
           }
-        ]
+        ],
+        "summary": "Diff between the two latest registry snapshots"
       }
     },
     "/v1/scoring/model": {
@@ -14142,7 +14149,8 @@
           {
             "LoopOverSessionCookie": []
           }
-        ]
+        ],
+        "summary": "Latest private scoring model snapshot"
       }
     },
     "/v1/upstream/status": {
@@ -14166,7 +14174,8 @@
           {
             "LoopOverSessionCookie": []
           }
-        ]
+        ],
+        "summary": "Upstream Gittensor source and ruleset drift status"
       }
     },
     "/v1/upstream/ruleset": {
@@ -14193,7 +14202,8 @@
           {
             "LoopOverSessionCookie": []
           }
-        ]
+        ],
+        "summary": "Latest normalized upstream Gittensor ruleset snapshot"
       }
     },
     "/v1/upstream/drift": {
@@ -14236,7 +14246,8 @@
           {
             "LoopOverSessionCookie": []
           }
-        ]
+        ],
+        "summary": "Open and historical upstream drift reports"
       }
     },
     "/v1/scoring/preview": {
@@ -14263,7 +14274,8 @@
           {
             "LoopOverSessionCookie": []
           }
-        ]
+        ],
+        "summary": "Preview a private scoring computation for sample input"
       }
     },
     "/v1/sync/status": {
@@ -14287,7 +14299,8 @@
           {
             "LoopOverSessionCookie": []
           }
-        ]
+        ],
+        "summary": "Repository and installation sync status"
       }
     },
     "/v1/readiness": {
@@ -14311,7 +14324,8 @@
           {
             "LoopOverSessionCookie": []
           }
-        ]
+        ],
+        "summary": "Operational readiness summary for the hosted API"
       }
     },
     "/v1/installations": {
@@ -14356,21 +14370,12 @@
           {
             "LoopOverSessionCookie": []
           }
-        ]
+        ],
+        "summary": "List GitHub App installations and their health"
       }
     },
     "/v1/installations/{id}/health": {
       "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "id",
-            "in": "path"
-          }
-        ],
         "responses": {
           "200": {
             "description": "GitHub App installation health",
@@ -14393,11 +14398,7 @@
           {
             "LoopOverSessionCookie": []
           }
-        ]
-      }
-    },
-    "/v1/installations/{id}/repair": {
-      "get": {
+        ],
         "parameters": [
           {
             "schema": {
@@ -14408,6 +14409,11 @@
             "in": "path"
           }
         ],
+        "summary": "GitHub App installation health for one installation"
+      }
+    },
+    "/v1/installations/{id}/repair": {
+      "get": {
         "responses": {
           "200": {
             "description": "GitHub App installation repair diagnostics",
@@ -14430,11 +14436,7 @@
           {
             "LoopOverSessionCookie": []
           }
-        ]
-      }
-    },
-    "/v1/installations/{id}/repair/refresh": {
-      "post": {
+        ],
         "parameters": [
           {
             "schema": {
@@ -14445,6 +14447,11 @@
             "in": "path"
           }
         ],
+        "summary": "GitHub App installation repair diagnostics"
+      }
+    },
+    "/v1/installations/{id}/repair/refresh": {
+      "post": {
         "responses": {
           "200": {
             "description": "Refreshed GitHub App installation repair diagnostics",
@@ -14467,7 +14474,18 @@
           {
             "LoopOverSessionCookie": []
           }
-        ]
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "summary": "Refresh GitHub App installation repair diagnostics"
       }
     },
     "/v1/app/notification-model": {
@@ -14606,7 +14624,8 @@
           {
             "LoopOverSessionCookie": []
           }
-        ]
+        ],
+        "summary": "Opt-in notification model and PWA-readiness metadata"
       }
     },
     "/v1/repos": {
@@ -14633,29 +14652,12 @@
           {
             "LoopOverSessionCookie": []
           }
-        ]
+        ],
+        "summary": "List known repositories"
       }
     },
     "/v1/repos/{owner}/{repo}": {
       "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "owner",
-            "in": "path"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "repo",
-            "in": "path"
-          }
-        ],
         "responses": {
           "200": {
             "description": "Repository detail",
@@ -14678,11 +14680,7 @@
           {
             "LoopOverSessionCookie": []
           }
-        ]
-      }
-    },
-    "/v1/repos/{owner}/{repo}/intelligence": {
-      "get": {
+        ],
         "parameters": [
           {
             "schema": {
@@ -14701,6 +14699,11 @@
             "in": "path"
           }
         ],
+        "summary": "Repository detail"
+      }
+    },
+    "/v1/repos/{owner}/{repo}/intelligence": {
+      "get": {
         "responses": {
           "200": {
             "description": "Canonical repository intelligence bundle",
@@ -14720,11 +14723,7 @@
           {
             "LoopOverSessionCookie": []
           }
-        ]
-      }
-    },
-    "/v1/repos/{owner}/{repo}/issue-quality": {
-      "get": {
+        ],
         "parameters": [
           {
             "schema": {
@@ -14743,6 +14742,11 @@
             "in": "path"
           }
         ],
+        "summary": "Canonical repository intelligence bundle"
+      }
+    },
+    "/v1/repos/{owner}/{repo}/issue-quality": {
+      "get": {
         "responses": {
           "200": {
             "description": "Cached or computed issue quality report for the repo",
@@ -14765,11 +14769,7 @@
           {
             "LoopOverSessionCookie": []
           }
-        ]
-      }
-    },
-    "/v1/repos/{owner}/{repo}/outcome-patterns": {
-      "get": {
+        ],
         "parameters": [
           {
             "schema": {
@@ -14788,6 +14788,11 @@
             "in": "path"
           }
         ],
+        "summary": "Cached or computed issue quality report for a repository"
+      }
+    },
+    "/v1/repos/{owner}/{repo}/outcome-patterns": {
+      "get": {
         "responses": {
           "200": {
             "description": "Cached or freshly-computed per-repo accepted/rejected PR outcome patterns with freshness envelope and explicit evidence-completeness",
@@ -14810,11 +14815,7 @@
           {
             "LoopOverSessionCookie": []
           }
-        ]
-      }
-    },
-    "/v1/repos/{owner}/{repo}/registration-readiness": {
-      "get": {
+        ],
         "parameters": [
           {
             "schema": {
@@ -14833,6 +14834,11 @@
             "in": "path"
           }
         ],
+        "summary": "Accepted/rejected PR outcome patterns for a repository"
+      }
+    },
+    "/v1/repos/{owner}/{repo}/registration-readiness": {
+      "get": {
         "responses": {
           "200": {
             "description": "Gittensor registration readiness signal for repo owners",
@@ -14852,11 +14858,7 @@
           {
             "LoopOverSessionCookie": []
           }
-        ]
-      }
-    },
-    "/v1/repos/{owner}/{repo}/gittensor-config-recommendation": {
-      "get": {
+        ],
         "parameters": [
           {
             "schema": {
@@ -14875,6 +14877,11 @@
             "in": "path"
           }
         ],
+        "summary": "Gittensor registration readiness signal for a repo owner"
+      }
+    },
+    "/v1/repos/{owner}/{repo}/gittensor-config-recommendation": {
+      "get": {
         "responses": {
           "200": {
             "description": "Private Gittensor config recommendation for repo owners",
@@ -14894,11 +14901,7 @@
           {
             "LoopOverSessionCookie": []
           }
-        ]
-      }
-    },
-    "/v1/repos/{owner}/{repo}/focus-manifest": {
-      "get": {
+        ],
         "parameters": [
           {
             "schema": {
@@ -14917,6 +14920,11 @@
             "in": "path"
           }
         ],
+        "summary": "Recommended .loopover.yml additions for a repo owner"
+      }
+    },
+    "/v1/repos/{owner}/{repo}/focus-manifest": {
+      "get": {
         "responses": {
           "200": {
             "description": "Repo focus manifest and compiled policy for maintainers",
@@ -14942,9 +14950,7 @@
           {
             "LoopOverSessionCookie": []
           }
-        ]
-      },
-      "put": {
+        ],
         "parameters": [
           {
             "schema": {
@@ -14963,6 +14969,9 @@
             "in": "path"
           }
         ],
+        "summary": "Repo focus manifest and compiled policy for maintainers"
+      },
+      "put": {
         "responses": {
           "200": {
             "description": "Persist API-backed focus manifest for a repo",
@@ -14991,11 +15000,7 @@
           {
             "LoopOverSessionCookie": []
           }
-        ]
-      }
-    },
-    "/v1/repos/{owner}/{repo}/focus-manifest/refresh": {
-      "post": {
+        ],
         "parameters": [
           {
             "schema": {
@@ -15014,6 +15019,11 @@
             "in": "path"
           }
         ],
+        "summary": "Persist an API-backed focus manifest for a repo"
+      }
+    },
+    "/v1/repos/{owner}/{repo}/focus-manifest/refresh": {
+      "post": {
         "responses": {
           "200": {
             "description": "Refresh the persisted focus manifest cache from the repo file",
@@ -15039,11 +15049,7 @@
           {
             "LoopOverSessionCookie": []
           }
-        ]
-      }
-    },
-    "/v1/repos/{owner}/{repo}/agent/audit-feed": {
-      "get": {
+        ],
         "parameters": [
           {
             "schema": {
@@ -15062,6 +15068,11 @@
             "in": "path"
           }
         ],
+        "summary": "Refresh the persisted focus manifest cache from the repo file"
+      }
+    },
+    "/v1/repos/{owner}/{repo}/agent/audit-feed": {
+      "get": {
         "responses": {
           "200": {
             "description": "Maintainer-scoped agent audit feed (#784): executed actions + approval-queue decisions, newest first, public-safe action posture only. Supports ?since=ISO-8601&limit=1-200. ?pull=N opts into the unfiltered sibling query: every audit_events row for that one PR's targetKey (no eventType restriction), still maintainer-gated and detail-sanitized the same way.",
@@ -15185,7 +15196,2461 @@
           {
             "LoopOverSessionCookie": []
           }
-        ]
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "owner",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "repo",
+            "in": "path"
+          }
+        ],
+        "summary": "Maintainer-scoped agent audit feed of executed actions and decisions"
+      }
+    },
+    "/v1/app/self-dogfood/registration-pack": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Private self-dogfood registration pack for the LoopOver repo",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient role for maintainer-only self-dogfood report"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Private self-dogfood registration pack for the LoopOver repo itself"
+      }
+    },
+    "/v1/repos/{owner}/{repo}/self-dogfood-registration-pack": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Private self-dogfood registration pack when repo matches configured LoopOver target",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient role or repo is not the configured self-dogfood target"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "owner",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "repo",
+            "in": "path"
+          }
+        ],
+        "summary": "Private self-dogfood registration pack for the configured target repo"
+      }
+    },
+    "/v1/repos/{owner}/{repo}/onboarding-pack/preview": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Preview-only repo onboarding pack for accepted repositories",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Insufficient role"
+          },
+          "404": {
+            "description": "Repository is not accepted or preview unavailable"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "owner",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "repo",
+            "in": "path"
+          }
+        ],
+        "summary": "Preview-only repo onboarding pack for an accepted repository"
+      }
+    },
+    "/v1/repos/{owner}/{repo}/contributor-issue-drafts/generate": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Generate maintainer-reviewed contributor issue drafts from repo policy (dry-run by default)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request or explicit create without dryRun false"
+          },
+          "403": {
+            "description": "Insufficient role"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "owner",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "repo",
+            "in": "path"
+          }
+        ],
+        "summary": "Generate maintainer-reviewed contributor issue drafts from repo policy"
+      }
+    },
+    "/v1/repos/{owner}/{repo}/settings": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "LoopOver repository automation settings",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RepositorySettings"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "owner",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "repo",
+            "in": "path"
+          }
+        ],
+        "summary": "LoopOver repository automation settings"
+      }
+    },
+    "/v1/repos/{owner}/{repo}/settings-preview": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Maintainer dry-run preview of the public surface decision for a sample PR (no GitHub mutation)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RepoSettingsPreview"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid settings preview request"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "owner",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "repo",
+            "in": "path"
+          }
+        ],
+        "summary": "Dry-run preview of the public surface decision for a sample PR"
+      }
+    },
+    "/v1/repos/{owner}/{repo}/pulls/{number}/maintainer-packet": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "PR-specific maintainer review packet",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PullRequestMaintainerPacket"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "owner",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "repo",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "number",
+            "in": "path"
+          }
+        ],
+        "summary": "PR-specific maintainer review packet"
+      }
+    },
+    "/v1/repos/{owner}/{repo}/pulls/{number}/reviewability": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Private PR reviewability score and maintainer action",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PullRequestReviewability"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "owner",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "repo",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "number",
+            "in": "path"
+          }
+        ],
+        "summary": "Private PR reviewability score and recommended maintainer action"
+      }
+    },
+    "/v1/contributors/{login}/profile": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Contributor evidence profile",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContributorProfile"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "login",
+            "in": "path"
+          }
+        ],
+        "summary": "Contributor evidence profile"
+      }
+    },
+    "/v1/contributors/{login}/decision-pack": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Canonical private contributor decision pack. May carry freshness 'stale' or 'rebuilding' when a background rebuild is in progress.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContributorDecisionPack"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Decision pack snapshot is missing; a background rebuild has been requested",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DecisionPackRefreshNeeded"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "login",
+            "in": "path"
+          }
+        ],
+        "summary": "Canonical private contributor decision pack"
+      }
+    },
+    "/v1/contributors/{login}/open-pr-monitor": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Contributor open-PR monitor with classifications and public-safe next-step packets from cached metadata.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ContributorOpenPrMonitor"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "login",
+            "in": "path"
+          }
+        ],
+        "summary": "Contributor open-PR monitor with classifications and next steps"
+      }
+    },
+    "/v1/contributors/{login}/repos/{owner}/{repo}/decision": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Repo-specific contributor decision from decision pack. May carry freshness 'stale' or 'rebuilding'.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RepoDecisionResponse"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Decision pack snapshot is missing; a background rebuild has been requested",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DecisionPackRefreshNeeded"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "login",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "owner",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "repo",
+            "in": "path"
+          }
+        ],
+        "summary": "Repo-specific contributor decision from the decision pack"
+      }
+    },
+    "/v1/preflight/pr": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Submission preflight result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PreflightResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid preflight input"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Submission preflight result for a pull request"
+      }
+    },
+    "/v1/preflight/local-diff": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Local diff preflight result",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LocalDiffPreflightResult"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid local diff preflight input"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Local diff preflight result"
+      }
+    },
+    "/v1/local/branch-analysis": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Private local branch analysis for MCP clients",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LocalBranchAnalysis"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid local branch analysis input"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Private local branch analysis for MCP clients"
+      }
+    },
+    "/v1/agent/runs": {
+      "post": {
+        "responses": {
+          "202": {
+            "description": "Copilot-only agent run queued",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentRunBundle"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid agent run request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Queue a Copilot-only agent run"
+      },
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "example": "jsonbored"
+            },
+            "required": true,
+            "description": "GitHub login that owns the agent runs.",
+            "name": "actorLogin",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "example": "50"
+            },
+            "required": false,
+            "description": "Maximum run bundles to return, clamped from 1 to 100.",
+            "name": "limit",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Recent agent run bundles for an authenticated actor",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "runs": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/components/schemas/AgentRunBundle"
+                      }
+                    }
+                  },
+                  "required": [
+                    "runs"
+                  ]
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Missing actor login"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "List recent agent run bundles for an authenticated actor"
+      }
+    },
+    "/v1/agent/runs/{id}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Persisted agent run bundle",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentRunBundle"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Agent run not found"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "summary": "Persisted agent run bundle"
+      }
+    },
+    "/v1/agent/plan-next-work": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Agent run completed with deterministic ranked actions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentRunBundle"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Agent run needs snapshot refresh",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentRunBundle"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid agent request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Plan the agent's next ranked actions"
+      }
+    },
+    "/v1/agent/preflight-branch": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Agent run completed with deterministic ranked actions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentRunBundle"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Agent run needs snapshot refresh",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentRunBundle"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid agent request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Preflight the agent's current local branch"
+      }
+    },
+    "/v1/agent/prepare-pr-packet": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Agent run completed with deterministic ranked actions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentRunBundle"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Agent run needs snapshot refresh",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentRunBundle"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid agent request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Prepare a PR packet for the agent's branch"
+      }
+    },
+    "/v1/agent/explain-blockers": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Agent run completed with deterministic ranked actions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentRunBundle"
+                }
+              }
+            }
+          },
+          "202": {
+            "description": "Agent run needs snapshot refresh",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AgentRunBundle"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid agent request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Explain blockers preventing the agent's next action"
+      }
+    },
+    "/v1/bounties": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Known bounty records",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/Bounty"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "List known bounty records"
+      }
+    },
+    "/v1/bounties/{id}/advisory": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Bounty lifecycle advisory",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BountyAdvisory"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Bounty not found"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "summary": "Bounty lifecycle advisory"
+      }
+    },
+    "/v1/bounties/{id}/lifecycle": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Bounty lifecycle transition history",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BountyLifecycleEvents"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Bounty not found"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "parameters": [
+          {
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "summary": "Bounty lifecycle transition history"
+      }
+    },
+    "/v1/github/webhook": {
+      "post": {
+        "responses": {
+          "202": {
+            "description": "Webhook queued"
+          },
+          "401": {
+            "description": "Invalid webhook signature"
+          }
+        },
+        "summary": "GitHub webhook ingestion endpoint"
+      }
+    },
+    "/v1/orb/ingest": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Batch accepted; returns { accepted: number }"
+          },
+          "400": {
+            "description": "Malformed JSON or invalid payload shape"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Batch ingest endpoint for self-hosted ORB reviewers"
+      }
+    },
+    "/v1/auth/github/start": {
+      "get": {
+        "responses": {
+          "302": {
+            "description": "Redirects to GitHub web OAuth"
+          },
+          "503": {
+            "description": "GitHub OAuth app secret is not configured"
+          }
+        },
+        "summary": "Start GitHub web OAuth"
+      }
+    },
+    "/v1/auth/github/callback": {
+      "get": {
+        "responses": {
+          "302": {
+            "description": "Completes GitHub web OAuth and redirects to the app"
+          }
+        },
+        "summary": "Complete GitHub web OAuth"
+      }
+    },
+    "/v1/auth/github/device/start": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Auth request completed"
+          },
+          "201": {
+            "description": "Auth session created"
+          },
+          "400": {
+            "description": "Invalid auth request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "429": {
+            "description": "Rate limited"
+          }
+        },
+        "summary": "Start GitHub device-flow authentication"
+      }
+    },
+    "/v1/auth/github/device/poll": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Auth request completed"
+          },
+          "201": {
+            "description": "Auth session created"
+          },
+          "400": {
+            "description": "Invalid auth request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "429": {
+            "description": "Rate limited"
+          }
+        },
+        "summary": "Poll a pending GitHub device-flow authentication"
+      }
+    },
+    "/v1/auth/github/session": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Auth request completed"
+          },
+          "201": {
+            "description": "Auth session created"
+          },
+          "400": {
+            "description": "Invalid auth request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "429": {
+            "description": "Rate limited"
+          }
+        },
+        "summary": "Exchange a completed auth flow for a LoopOver session"
+      }
+    },
+    "/v1/auth/logout": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Auth request completed"
+          },
+          "201": {
+            "description": "Auth session created"
+          },
+          "400": {
+            "description": "Invalid auth request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "429": {
+            "description": "Rate limited"
+          }
+        },
+        "summary": "Log out of the current LoopOver session"
+      }
+    },
+    "/v1/auth/extension/session": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Auth request completed"
+          },
+          "201": {
+            "description": "Auth session created"
+          },
+          "400": {
+            "description": "Invalid auth request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "429": {
+            "description": "Rate limited"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Create an extension-scoped LoopOver session"
+      }
+    },
+    "/v1/auth/session": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Current auth session, or signed_out when no app session is present"
+          }
+        },
+        "summary": "Current auth session, or signed-out state"
+      }
+    },
+    "/v1/app/overview": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Live app overview assembled from backend data",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient role"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Live app overview assembled from backend data"
+      }
+    },
+    "/v1/app/roles": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Live app API response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Roles available to the current app session"
+      }
+    },
+    "/v1/app/miner-dashboard": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Live app API response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Live miner dashboard data"
+      }
+    },
+    "/v1/app/maintainer-dashboard": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Live app API response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Live maintainer dashboard data"
+      }
+    },
+    "/v1/app/operator-dashboard": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Live app API response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Live operator dashboard data"
+      }
+    },
+    "/v1/app/commands": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Live app API response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Available @loopover chat commands"
+      }
+    },
+    "/v1/app/commands/usefulness": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Live app API response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Usefulness feedback summary for @loopover chat commands"
+      }
+    },
+    "/v1/app/digest": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Live app API response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Live digest summary for the current app session"
+      }
+    },
+    "/v1/app/analytics/daily-rollups": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Live app API response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Daily analytics rollups"
+      }
+    },
+    "/v1/app/analytics/mcp-compatibility": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "Live app API response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "MCP client compatibility analytics"
+      }
+    },
+    "/v1/app/selfhost/queue/dead/{id}/replay": {
+      "post": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "example": "812"
+            },
+            "required": true,
+            "description": "Dead-letter job id.",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Job replayed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid job id"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient app role (operator only)"
+          },
+          "404": {
+            "description": "Dead-letter job not found"
+          },
+          "501": {
+            "description": "This deployment's queue backend does not expose dead-letter admin"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Replay one self-host dead-letter queue job"
+      }
+    },
+    "/v1/app/selfhost/queue/dead/{id}": {
+      "delete": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "example": "812"
+            },
+            "required": true,
+            "description": "Dead-letter job id.",
+            "name": "id",
+            "in": "path"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Job deleted",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid job id"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient app role (operator only)"
+          },
+          "404": {
+            "description": "Dead-letter job not found"
+          },
+          "501": {
+            "description": "This deployment's queue backend does not expose dead-letter admin"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Delete one self-host dead-letter queue job"
+      }
+    },
+    "/v1/app/selfhost/queue/dead": {
+      "delete": {
+        "responses": {
+          "200": {
+            "description": "Dead-letter jobs purged",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient app role (operator only)"
+          },
+          "501": {
+            "description": "This deployment's queue backend does not expose dead-letter admin"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Purge all self-host dead-letter queue jobs"
+      },
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "example": "25"
+            },
+            "required": false,
+            "description": "Maximum rows to return, clamped from 1 to 100.",
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "example": "0"
+            },
+            "required": false,
+            "description": "Pagination offset, floored to 0.",
+            "name": "offset",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated dead-letter jobs for the self-host queue backend",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid query"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient app role (operator only)"
+          },
+          "501": {
+            "description": "This deployment's queue backend does not expose dead-letter admin (e.g. Cloudflare)"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "List paginated self-host dead-letter queue jobs"
+      }
+    },
+    "/v1/app/analytics/weekly-value-report": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "public",
+                "operator"
+              ],
+              "example": "public"
+            },
+            "required": false,
+            "description": "Report variant. Operator reports require the operator app role.",
+            "name": "variant",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "example": "7"
+            },
+            "required": false,
+            "description": "Report window in days, clamped from 1 to 31.",
+            "name": "days",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "json",
+                "markdown"
+              ],
+              "example": "markdown"
+            },
+            "required": false,
+            "description": "Response format. Omit or use json for the structured report; use markdown for copy-ready text.",
+            "name": "format",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Weekly value report as structured JSON or copy-ready Markdown",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "nullable": true
+                  }
+                }
+              },
+              "text/markdown": {
+                "schema": {
+                  "type": "string",
+                  "example": "# Weekly LoopOver value report\n\n## Adoption metrics\n- Active users: 4\n"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient app role for requested report variant"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Weekly value report as JSON or Markdown"
+      }
+    },
+    "/v1/app/skipped-pr-audit": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "example": "50"
+            },
+            "required": false,
+            "description": "Maximum rows to return, clamped from 1 to 100.",
+            "name": "limit",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "example": "JSONbored/loopover"
+            },
+            "required": false,
+            "description": "Optional repository filter. Browser sessions must have control-panel access to this repo.",
+            "name": "repoFullName",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "enum": [
+                "surface_off",
+                "missing_author",
+                "bot_author",
+                "ignored_author",
+                "maintainer_author",
+                "miner_detection_unavailable",
+                "not_official_gittensor_miner"
+              ],
+              "example": "not_official_gittensor_miner"
+            },
+            "required": false,
+            "description": "Optional PR skip reason filter.",
+            "name": "reason",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "example": "2026-05-30T00:00:00.000Z"
+            },
+            "required": false,
+            "description": "Optional lower timestamp bound.",
+            "name": "since",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Private bounded audit export for skipped PR public-surface decisions",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkippedPrAuditExport"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid query"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient app role or repository scope"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Private bounded audit export for skipped PR public-surface decisions"
+      }
+    },
+    "/v1/app/commands/preview": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Maintainer dry-run preview of a sanitized @loopover command response (no GitHub mutation)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommandPreviewResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Insufficient app role"
+          },
+          "404": {
+            "description": "Command not found"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Dry-run preview of a sanitized @loopover command response"
+      }
+    },
+    "/v1/app/commands/feedback": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Live app mutation or preview response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Submit usefulness feedback for a @loopover chat command"
+      }
+    },
+    "/v1/app/digest/subscriptions": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Live app mutation or preview response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request"
+          },
+          "401": {
+            "description": "Unauthorized"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Manage digest notification subscriptions"
+      }
+    },
+    "/v1/extension/pull-context": {
+      "get": {
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "example": "JSONbored"
+            },
+            "required": true,
+            "description": "Repository owner",
+            "name": "owner",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "example": "loopover"
+            },
+            "required": true,
+            "description": "Repository name",
+            "name": "repo",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "string",
+              "minLength": 1,
+              "example": "120"
+            },
+            "required": true,
+            "description": "Pull request number",
+            "name": "pullNumber",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Browser extension PR context overlay payload",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "additionalProperties": {
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid pull context query"
+          },
+          "401": {
+            "description": "Unauthorized"
+          },
+          "403": {
+            "description": "Extension-scoped session required"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Browser extension PR context overlay payload"
+      }
+    },
+    "/v1/internal/jobs/refresh-registry": {
+      "post": {
+        "responses": {
+          "202": {
+            "description": "Registry refresh queued"
+          },
+          "401": {
+            "description": "Invalid internal token"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Queue an internal Gittensor registry refresh job"
+      }
+    },
+    "/v1/internal/jobs/backfill-registered-repos": {
+      "post": {
+        "responses": {
+          "202": {
+            "description": "Registered repo backfill queued"
+          },
+          "401": {
+            "description": "Invalid internal token"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Queue an internal registered-repo backfill job"
+      }
+    },
+    "/v1/internal/jobs/backfill-repo-segment": {
+      "post": {
+        "responses": {
+          "202": {
+            "description": "Repository segment backfill queued"
+          },
+          "400": {
+            "description": "Invalid segment request"
+          },
+          "401": {
+            "description": "Invalid internal token"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Queue an internal repository segment backfill job"
+      }
+    },
+    "/v1/internal/jobs/backfill-pr-details": {
+      "post": {
+        "responses": {
+          "202": {
+            "description": "Open PR detail backfill queued"
+          },
+          "400": {
+            "description": "Invalid PR detail backfill request"
+          },
+          "401": {
+            "description": "Invalid internal token"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Queue an internal open PR detail backfill job"
+      }
+    },
+    "/v1/internal/jobs/generate-review-recap": {
+      "post": {
+        "responses": {
+          "202": {
+            "description": "Maintainer review recap digest queued (#1963)"
+          },
+          "400": {
+            "description": "Missing repoFullName"
+          },
+          "401": {
+            "description": "Invalid internal token"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Queue an internal maintainer review recap digest job"
+      }
+    },
+    "/v1/internal/jobs/refresh-scoring-model": {
+      "post": {
+        "responses": {
+          "202": {
+            "description": "Internal job queued"
+          },
+          "401": {
+            "description": "Invalid internal token"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Queue an internal scoring model refresh job"
+      }
+    },
+    "/v1/internal/jobs/refresh-upstream-drift": {
+      "post": {
+        "responses": {
+          "202": {
+            "description": "Internal job queued"
+          },
+          "401": {
+            "description": "Invalid internal token"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Queue an internal upstream drift refresh job"
+      }
+    },
+    "/v1/internal/jobs/file-upstream-drift-issues": {
+      "post": {
+        "responses": {
+          "202": {
+            "description": "Internal job queued"
+          },
+          "401": {
+            "description": "Invalid internal token"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Queue an internal job to file upstream drift issues"
+      }
+    },
+    "/v1/internal/jobs/build-contributor-evidence": {
+      "post": {
+        "responses": {
+          "202": {
+            "description": "Internal job queued"
+          },
+          "401": {
+            "description": "Invalid internal token"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Queue an internal contributor evidence build job"
+      }
+    },
+    "/v1/internal/jobs/build-contributor-decision-packs": {
+      "post": {
+        "responses": {
+          "202": {
+            "description": "Internal job queued"
+          },
+          "401": {
+            "description": "Invalid internal token"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Queue an internal contributor decision pack build job"
+      }
+    },
+    "/v1/internal/jobs/build-burden-forecasts": {
+      "post": {
+        "responses": {
+          "202": {
+            "description": "Internal job queued"
+          },
+          "401": {
+            "description": "Invalid internal token"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Queue an internal burden forecast build job"
+      }
+    },
+    "/v1/internal/jobs/generate-signal-snapshots": {
+      "post": {
+        "responses": {
+          "202": {
+            "description": "Internal job queued"
+          },
+          "401": {
+            "description": "Invalid internal token"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Queue an internal signal snapshot generation job"
+      }
+    },
+    "/v1/internal/jobs/generate-weekly-value-report": {
+      "post": {
+        "responses": {
+          "202": {
+            "description": "Internal job queued"
+          },
+          "401": {
+            "description": "Invalid internal token"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Queue an internal weekly value report generation job"
+      }
+    },
+    "/v1/internal/jobs/repair-data-fidelity": {
+      "post": {
+        "responses": {
+          "202": {
+            "description": "Internal job queued"
+          },
+          "401": {
+            "description": "Invalid internal token"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Queue an internal data fidelity repair job"
+      }
+    },
+    "/v1/internal/bounties/import": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "Bounty snapshot imported"
+          },
+          "401": {
+            "description": "Invalid internal token"
+          }
+        },
+        "security": [
+          {
+            "LoopOverBearer": []
+          },
+          {
+            "LoopOverSessionCookie": []
+          }
+        ],
+        "summary": "Import an internal bounty snapshot"
       }
     },
     "/v1/repos/{owner}/{repo}/pulls/{number}/incident-reports": {
@@ -15309,7 +17774,8 @@
           {
             "LoopOverSessionCookie": []
           }
-        ]
+        ],
+        "summary": "Record a post-merge incident report for a pull request"
       }
     },
     "/v1/app/incident-reports": {
@@ -15419,2372 +17885,8 @@
           {
             "LoopOverSessionCookie": []
           }
-        ]
-      }
-    },
-    "/v1/app/self-dogfood/registration-pack": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "Private self-dogfood registration pack for the LoopOver repo",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "nullable": true
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Insufficient role for maintainer-only self-dogfood report"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/repos/{owner}/{repo}/self-dogfood-registration-pack": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "owner",
-            "in": "path"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "repo",
-            "in": "path"
-          }
         ],
-        "responses": {
-          "200": {
-            "description": "Private self-dogfood registration pack when repo matches configured LoopOver target",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "nullable": true
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Insufficient role or repo is not the configured self-dogfood target"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/repos/{owner}/{repo}/onboarding-pack/preview": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "owner",
-            "in": "path"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "repo",
-            "in": "path"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Preview-only repo onboarding pack for accepted repositories",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "nullable": true
-                  }
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Insufficient role"
-          },
-          "404": {
-            "description": "Repository is not accepted or preview unavailable"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/repos/{owner}/{repo}/contributor-issue-drafts/generate": {
-      "post": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "owner",
-            "in": "path"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "repo",
-            "in": "path"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Generate maintainer-reviewed contributor issue drafts from repo policy (dry-run by default)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "nullable": true
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid request or explicit create without dryRun false"
-          },
-          "403": {
-            "description": "Insufficient role"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/repos/{owner}/{repo}/settings": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "owner",
-            "in": "path"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "repo",
-            "in": "path"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "LoopOver repository automation settings",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RepositorySettings"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/repos/{owner}/{repo}/settings-preview": {
-      "post": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "owner",
-            "in": "path"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "repo",
-            "in": "path"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Maintainer dry-run preview of the public surface decision for a sample PR (no GitHub mutation)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RepoSettingsPreview"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid settings preview request"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/repos/{owner}/{repo}/pulls/{number}/maintainer-packet": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "owner",
-            "in": "path"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "repo",
-            "in": "path"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "number",
-            "in": "path"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "PR-specific maintainer review packet",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PullRequestMaintainerPacket"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/repos/{owner}/{repo}/pulls/{number}/reviewability": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "owner",
-            "in": "path"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "repo",
-            "in": "path"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "number",
-            "in": "path"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Private PR reviewability score and maintainer action",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PullRequestReviewability"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/contributors/{login}/profile": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "login",
-            "in": "path"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Contributor evidence profile",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ContributorProfile"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/contributors/{login}/decision-pack": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "login",
-            "in": "path"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Canonical private contributor decision pack. May carry freshness 'stale' or 'rebuilding' when a background rebuild is in progress.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ContributorDecisionPack"
-                }
-              }
-            }
-          },
-          "202": {
-            "description": "Decision pack snapshot is missing; a background rebuild has been requested",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DecisionPackRefreshNeeded"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/contributors/{login}/open-pr-monitor": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "login",
-            "in": "path"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Contributor open-PR monitor with classifications and public-safe next-step packets from cached metadata.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ContributorOpenPrMonitor"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/contributors/{login}/repos/{owner}/{repo}/decision": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "login",
-            "in": "path"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "owner",
-            "in": "path"
-          },
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "repo",
-            "in": "path"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Repo-specific contributor decision from decision pack. May carry freshness 'stale' or 'rebuilding'.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/RepoDecisionResponse"
-                }
-              }
-            }
-          },
-          "202": {
-            "description": "Decision pack snapshot is missing; a background rebuild has been requested",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/DecisionPackRefreshNeeded"
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/preflight/pr": {
-      "post": {
-        "responses": {
-          "200": {
-            "description": "Submission preflight result",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/PreflightResult"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid preflight input"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/preflight/local-diff": {
-      "post": {
-        "responses": {
-          "200": {
-            "description": "Local diff preflight result",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LocalDiffPreflightResult"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid local diff preflight input"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/local/branch-analysis": {
-      "post": {
-        "responses": {
-          "200": {
-            "description": "Private local branch analysis for MCP clients",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/LocalBranchAnalysis"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid local branch analysis input"
-          },
-          "401": {
-            "description": "Unauthorized"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/agent/runs": {
-      "post": {
-        "responses": {
-          "202": {
-            "description": "Copilot-only agent run queued",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AgentRunBundle"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid agent run request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      },
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string",
-              "minLength": 1,
-              "example": "jsonbored"
-            },
-            "required": true,
-            "description": "GitHub login that owns the agent runs.",
-            "name": "actorLogin",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "example": "50"
-            },
-            "required": false,
-            "description": "Maximum run bundles to return, clamped from 1 to 100.",
-            "name": "limit",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Recent agent run bundles for an authenticated actor",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "properties": {
-                    "runs": {
-                      "type": "array",
-                      "items": {
-                        "$ref": "#/components/schemas/AgentRunBundle"
-                      }
-                    }
-                  },
-                  "required": [
-                    "runs"
-                  ]
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Missing actor login"
-          },
-          "401": {
-            "description": "Unauthorized"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/agent/runs/{id}": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "id",
-            "in": "path"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Persisted agent run bundle",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AgentRunBundle"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Agent run not found"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/agent/plan-next-work": {
-      "post": {
-        "responses": {
-          "200": {
-            "description": "Agent run completed with deterministic ranked actions",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AgentRunBundle"
-                }
-              }
-            }
-          },
-          "202": {
-            "description": "Agent run needs snapshot refresh",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AgentRunBundle"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid agent request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/agent/preflight-branch": {
-      "post": {
-        "responses": {
-          "200": {
-            "description": "Agent run completed with deterministic ranked actions",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AgentRunBundle"
-                }
-              }
-            }
-          },
-          "202": {
-            "description": "Agent run needs snapshot refresh",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AgentRunBundle"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid agent request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/agent/prepare-pr-packet": {
-      "post": {
-        "responses": {
-          "200": {
-            "description": "Agent run completed with deterministic ranked actions",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AgentRunBundle"
-                }
-              }
-            }
-          },
-          "202": {
-            "description": "Agent run needs snapshot refresh",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AgentRunBundle"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid agent request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/agent/explain-blockers": {
-      "post": {
-        "responses": {
-          "200": {
-            "description": "Agent run completed with deterministic ranked actions",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AgentRunBundle"
-                }
-              }
-            }
-          },
-          "202": {
-            "description": "Agent run needs snapshot refresh",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/AgentRunBundle"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid agent request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/bounties": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "Known bounty records",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Bounty"
-                  }
-                }
-              }
-            }
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/bounties/{id}/advisory": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "id",
-            "in": "path"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Bounty lifecycle advisory",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BountyAdvisory"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Bounty not found"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/bounties/{id}/lifecycle": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string"
-            },
-            "required": true,
-            "name": "id",
-            "in": "path"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Bounty lifecycle transition history",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/BountyLifecycleEvents"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Bounty not found"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/github/webhook": {
-      "post": {
-        "responses": {
-          "202": {
-            "description": "Webhook queued"
-          },
-          "401": {
-            "description": "Invalid webhook signature"
-          }
-        }
-      }
-    },
-    "/v1/orb/ingest": {
-      "post": {
-        "responses": {
-          "200": {
-            "description": "Batch accepted; returns { accepted: number }"
-          },
-          "400": {
-            "description": "Malformed JSON or invalid payload shape"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/auth/github/start": {
-      "get": {
-        "responses": {
-          "302": {
-            "description": "Redirects to GitHub web OAuth"
-          },
-          "503": {
-            "description": "GitHub OAuth app secret is not configured"
-          }
-        }
-      }
-    },
-    "/v1/auth/github/callback": {
-      "get": {
-        "responses": {
-          "302": {
-            "description": "Completes GitHub web OAuth and redirects to the app"
-          }
-        }
-      }
-    },
-    "/v1/auth/github/device/start": {
-      "post": {
-        "responses": {
-          "200": {
-            "description": "Auth request completed"
-          },
-          "201": {
-            "description": "Auth session created"
-          },
-          "400": {
-            "description": "Invalid auth request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "429": {
-            "description": "Rate limited"
-          }
-        }
-      }
-    },
-    "/v1/auth/github/device/poll": {
-      "post": {
-        "responses": {
-          "200": {
-            "description": "Auth request completed"
-          },
-          "201": {
-            "description": "Auth session created"
-          },
-          "400": {
-            "description": "Invalid auth request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "429": {
-            "description": "Rate limited"
-          }
-        }
-      }
-    },
-    "/v1/auth/github/session": {
-      "post": {
-        "responses": {
-          "200": {
-            "description": "Auth request completed"
-          },
-          "201": {
-            "description": "Auth session created"
-          },
-          "400": {
-            "description": "Invalid auth request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "429": {
-            "description": "Rate limited"
-          }
-        }
-      }
-    },
-    "/v1/auth/logout": {
-      "post": {
-        "responses": {
-          "200": {
-            "description": "Auth request completed"
-          },
-          "201": {
-            "description": "Auth session created"
-          },
-          "400": {
-            "description": "Invalid auth request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "429": {
-            "description": "Rate limited"
-          }
-        }
-      }
-    },
-    "/v1/auth/extension/session": {
-      "post": {
-        "responses": {
-          "200": {
-            "description": "Auth request completed"
-          },
-          "201": {
-            "description": "Auth session created"
-          },
-          "400": {
-            "description": "Invalid auth request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "429": {
-            "description": "Rate limited"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/auth/session": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "Current auth session, or signed_out when no app session is present"
-          }
-        }
-      }
-    },
-    "/v1/app/overview": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "Live app overview assembled from backend data",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "nullable": true
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "403": {
-            "description": "Insufficient role"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/app/roles": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "Live app API response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "nullable": true
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/app/miner-dashboard": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "Live app API response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "nullable": true
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/app/maintainer-dashboard": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "Live app API response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "nullable": true
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/app/operator-dashboard": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "Live app API response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "nullable": true
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/app/commands": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "Live app API response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "nullable": true
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/app/commands/usefulness": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "Live app API response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "nullable": true
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/app/digest": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "Live app API response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "nullable": true
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/app/analytics/daily-rollups": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "Live app API response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "nullable": true
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/app/analytics/mcp-compatibility": {
-      "get": {
-        "responses": {
-          "200": {
-            "description": "Live app API response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "nullable": true
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/app/selfhost/queue/dead/{id}/replay": {
-      "post": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string",
-              "example": "812"
-            },
-            "required": true,
-            "description": "Dead-letter job id.",
-            "name": "id",
-            "in": "path"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Job replayed",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "nullable": true
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid job id"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "403": {
-            "description": "Insufficient app role (operator only)"
-          },
-          "404": {
-            "description": "Dead-letter job not found"
-          },
-          "501": {
-            "description": "This deployment's queue backend does not expose dead-letter admin"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/app/selfhost/queue/dead/{id}": {
-      "delete": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string",
-              "example": "812"
-            },
-            "required": true,
-            "description": "Dead-letter job id.",
-            "name": "id",
-            "in": "path"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Job deleted",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "nullable": true
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid job id"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "403": {
-            "description": "Insufficient app role (operator only)"
-          },
-          "404": {
-            "description": "Dead-letter job not found"
-          },
-          "501": {
-            "description": "This deployment's queue backend does not expose dead-letter admin"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/app/selfhost/queue/dead": {
-      "delete": {
-        "responses": {
-          "200": {
-            "description": "Dead-letter jobs purged",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "nullable": true
-                  }
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "403": {
-            "description": "Insufficient app role (operator only)"
-          },
-          "501": {
-            "description": "This deployment's queue backend does not expose dead-letter admin"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      },
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string",
-              "example": "25"
-            },
-            "required": false,
-            "description": "Maximum rows to return, clamped from 1 to 100.",
-            "name": "limit",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "example": "0"
-            },
-            "required": false,
-            "description": "Pagination offset, floored to 0.",
-            "name": "offset",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Paginated dead-letter jobs for the self-host queue backend",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "nullable": true
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid query"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "403": {
-            "description": "Insufficient app role (operator only)"
-          },
-          "501": {
-            "description": "This deployment's queue backend does not expose dead-letter admin (e.g. Cloudflare)"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/app/analytics/weekly-value-report": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string",
-              "enum": [
-                "public",
-                "operator"
-              ],
-              "example": "public"
-            },
-            "required": false,
-            "description": "Report variant. Operator reports require the operator app role.",
-            "name": "variant",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "example": "7"
-            },
-            "required": false,
-            "description": "Report window in days, clamped from 1 to 31.",
-            "name": "days",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "enum": [
-                "json",
-                "markdown"
-              ],
-              "example": "markdown"
-            },
-            "required": false,
-            "description": "Response format. Omit or use json for the structured report; use markdown for copy-ready text.",
-            "name": "format",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Weekly value report as structured JSON or copy-ready Markdown",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "nullable": true
-                  }
-                }
-              },
-              "text/markdown": {
-                "schema": {
-                  "type": "string",
-                  "example": "# Weekly LoopOver value report\n\n## Adoption metrics\n- Active users: 4\n"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "403": {
-            "description": "Insufficient app role for requested report variant"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/app/skipped-pr-audit": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string",
-              "example": "50"
-            },
-            "required": false,
-            "description": "Maximum rows to return, clamped from 1 to 100.",
-            "name": "limit",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "example": "JSONbored/loopover"
-            },
-            "required": false,
-            "description": "Optional repository filter. Browser sessions must have control-panel access to this repo.",
-            "name": "repoFullName",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "enum": [
-                "surface_off",
-                "missing_author",
-                "bot_author",
-                "ignored_author",
-                "maintainer_author",
-                "miner_detection_unavailable",
-                "not_official_gittensor_miner"
-              ],
-              "example": "not_official_gittensor_miner"
-            },
-            "required": false,
-            "description": "Optional PR skip reason filter.",
-            "name": "reason",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "example": "2026-05-30T00:00:00.000Z"
-            },
-            "required": false,
-            "description": "Optional lower timestamp bound.",
-            "name": "since",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Private bounded audit export for skipped PR public-surface decisions",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/SkippedPrAuditExport"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid query"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "403": {
-            "description": "Insufficient app role or repository scope"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/app/commands/preview": {
-      "post": {
-        "responses": {
-          "200": {
-            "description": "Maintainer dry-run preview of a sanitized @loopover command response (no GitHub mutation)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/CommandPreviewResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "403": {
-            "description": "Insufficient app role"
-          },
-          "404": {
-            "description": "Command not found"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/app/commands/feedback": {
-      "post": {
-        "responses": {
-          "200": {
-            "description": "Live app mutation or preview response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "nullable": true
-                  }
-                }
-              }
-            }
-          },
-          "201": {
-            "description": "Created",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "nullable": true
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/app/digest/subscriptions": {
-      "post": {
-        "responses": {
-          "200": {
-            "description": "Live app mutation or preview response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "nullable": true
-                  }
-                }
-              }
-            }
-          },
-          "201": {
-            "description": "Created",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "nullable": true
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid request"
-          },
-          "401": {
-            "description": "Unauthorized"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/extension/pull-context": {
-      "get": {
-        "parameters": [
-          {
-            "schema": {
-              "type": "string",
-              "minLength": 1,
-              "example": "JSONbored"
-            },
-            "required": true,
-            "description": "Repository owner",
-            "name": "owner",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "minLength": 1,
-              "example": "loopover"
-            },
-            "required": true,
-            "description": "Repository name",
-            "name": "repo",
-            "in": "query"
-          },
-          {
-            "schema": {
-              "type": "string",
-              "minLength": 1,
-              "example": "120"
-            },
-            "required": true,
-            "description": "Pull request number",
-            "name": "pullNumber",
-            "in": "query"
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "Browser extension PR context overlay payload",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "type": "object",
-                  "additionalProperties": {
-                    "nullable": true
-                  }
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Invalid pull context query"
-          },
-          "401": {
-            "description": "Unauthorized"
-          },
-          "403": {
-            "description": "Extension-scoped session required"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/internal/jobs/refresh-registry": {
-      "post": {
-        "responses": {
-          "202": {
-            "description": "Registry refresh queued"
-          },
-          "401": {
-            "description": "Invalid internal token"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/internal/jobs/backfill-registered-repos": {
-      "post": {
-        "responses": {
-          "202": {
-            "description": "Registered repo backfill queued"
-          },
-          "401": {
-            "description": "Invalid internal token"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/internal/jobs/backfill-repo-segment": {
-      "post": {
-        "responses": {
-          "202": {
-            "description": "Repository segment backfill queued"
-          },
-          "400": {
-            "description": "Invalid segment request"
-          },
-          "401": {
-            "description": "Invalid internal token"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/internal/jobs/backfill-pr-details": {
-      "post": {
-        "responses": {
-          "202": {
-            "description": "Open PR detail backfill queued"
-          },
-          "400": {
-            "description": "Invalid PR detail backfill request"
-          },
-          "401": {
-            "description": "Invalid internal token"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/internal/jobs/generate-review-recap": {
-      "post": {
-        "responses": {
-          "202": {
-            "description": "Maintainer review recap digest queued (#1963)"
-          },
-          "400": {
-            "description": "Missing repoFullName"
-          },
-          "401": {
-            "description": "Invalid internal token"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/internal/jobs/refresh-scoring-model": {
-      "post": {
-        "responses": {
-          "202": {
-            "description": "Internal job queued"
-          },
-          "401": {
-            "description": "Invalid internal token"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/internal/jobs/refresh-upstream-drift": {
-      "post": {
-        "responses": {
-          "202": {
-            "description": "Internal job queued"
-          },
-          "401": {
-            "description": "Invalid internal token"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/internal/jobs/file-upstream-drift-issues": {
-      "post": {
-        "responses": {
-          "202": {
-            "description": "Internal job queued"
-          },
-          "401": {
-            "description": "Invalid internal token"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/internal/jobs/build-contributor-evidence": {
-      "post": {
-        "responses": {
-          "202": {
-            "description": "Internal job queued"
-          },
-          "401": {
-            "description": "Invalid internal token"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/internal/jobs/build-contributor-decision-packs": {
-      "post": {
-        "responses": {
-          "202": {
-            "description": "Internal job queued"
-          },
-          "401": {
-            "description": "Invalid internal token"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/internal/jobs/build-burden-forecasts": {
-      "post": {
-        "responses": {
-          "202": {
-            "description": "Internal job queued"
-          },
-          "401": {
-            "description": "Invalid internal token"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/internal/jobs/generate-signal-snapshots": {
-      "post": {
-        "responses": {
-          "202": {
-            "description": "Internal job queued"
-          },
-          "401": {
-            "description": "Invalid internal token"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/internal/jobs/generate-weekly-value-report": {
-      "post": {
-        "responses": {
-          "202": {
-            "description": "Internal job queued"
-          },
-          "401": {
-            "description": "Invalid internal token"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/internal/jobs/repair-data-fidelity": {
-      "post": {
-        "responses": {
-          "202": {
-            "description": "Internal job queued"
-          },
-          "401": {
-            "description": "Invalid internal token"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
-      }
-    },
-    "/v1/internal/bounties/import": {
-      "post": {
-        "responses": {
-          "200": {
-            "description": "Bounty snapshot imported"
-          },
-          "401": {
-            "description": "Invalid internal token"
-          }
-        },
-        "security": [
-          {
-            "LoopOverBearer": []
-          },
-          {
-            "LoopOverSessionCookie": []
-          }
-        ]
+        "summary": "Record a post-merge incident report (internal operator)"
       }
     }
   },

--- a/src/openapi/spec.ts
+++ b/src/openapi/spec.ts
@@ -160,6 +160,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/health",
+    summary: "Basic service health check",
     responses: {
       200: { description: "Service health", content: { "application/json": { schema: HealthSchema } } },
     },
@@ -167,6 +168,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/mcp/compatibility",
+    summary: "Public API and MCP compatibility metadata",
     responses: {
       200: { description: "Public-safe API and MCP compatibility metadata", content: { "application/json": { schema: McpCompatibilitySchema } } },
     },
@@ -174,6 +176,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/public/stats",
+    summary: "Public homepage lifetime stats and gate accuracy",
     responses: {
       200: { description: "Public-safe homepage stats: lifetime PRs handled/merged/closed, gate + slop blocks, and reversal-grounded accuracy. Aggregate counts only.", content: { "application/json": { schema: PublicStatsSchema } } },
       404: { description: "Public stats are disabled (LOOPOVER_PUBLIC_STATS off)" },
@@ -183,6 +186,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/public/github/repos/{owner}/{repo}/stats",
+    summary: "Public GitHub stars/forks for an allowlisted repository",
     request: { params: z.object({ owner: z.string(), repo: z.string() }) },
     responses: {
       200: { description: "Public GitHub repository stars/forks for the website chrome; PUBLIC_REPO_STATS_ALLOWLIST must explicitly include the owner/repo.", content: { "application/json": { schema: PublicRepoStatsSchema } } },
@@ -193,6 +197,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/public/repos/{owner}/{repo}/quality",
+    summary: "Public per-repo review-quality metrics for an opted-in repository",
     request: { params: z.object({ owner: z.string(), repo: z.string() }) },
     responses: {
       200: {
@@ -207,6 +212,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/registry/snapshot",
+    summary: "Latest Gittensor registry snapshot",
     responses: {
       200: { description: "Latest Gittensor registry snapshot", content: { "application/json": { schema: RegistrySnapshotSchema } } },
     },
@@ -214,6 +220,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/registry/changes",
+    summary: "Diff between the two latest registry snapshots",
     responses: {
       200: { description: "Diff between latest registry snapshots", content: { "application/json": { schema: RegistryChangeReportSchema } } },
     },
@@ -221,6 +228,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/scoring/model",
+    summary: "Latest private scoring model snapshot",
     responses: {
       200: { description: "Latest private scoring model snapshot", content: { "application/json": { schema: ScoringModelSnapshotSchema } } },
     },
@@ -228,6 +236,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/upstream/status",
+    summary: "Upstream Gittensor source and ruleset drift status",
     responses: {
       200: { description: "Upstream Gittensor source/ruleset drift status", content: { "application/json": { schema: UpstreamStatusSchema } } },
     },
@@ -235,6 +244,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/upstream/ruleset",
+    summary: "Latest normalized upstream Gittensor ruleset snapshot",
     responses: {
       200: { description: "Latest normalized upstream Gittensor ruleset snapshot", content: { "application/json": { schema: UpstreamRulesetSnapshotSchema } } },
       404: { description: "No upstream ruleset snapshot has been built yet" },
@@ -243,6 +253,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/upstream/drift",
+    summary: "Open and historical upstream drift reports",
     responses: {
       200: {
         description: "Open and historical upstream drift reports",
@@ -261,6 +272,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "post",
     path: "/v1/scoring/preview",
+    summary: "Preview a private scoring computation for sample input",
     responses: {
       200: { description: "Private scoring preview artifact", content: { "application/json": { schema: ScorePreviewSchema } } },
       400: { description: "Invalid scoring preview input" },
@@ -269,6 +281,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/sync/status",
+    summary: "Repository and installation sync status",
     responses: {
       200: { description: "Repository and installation sync status", content: { "application/json": { schema: SyncStatusSchema } } },
     },
@@ -276,6 +289,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/readiness",
+    summary: "Operational readiness summary for the hosted API",
     responses: {
       200: { description: "Operational readiness summary for hosted API, signal fidelity, and public-review preparation", content: { "application/json": { schema: ReadinessSchema } } },
     },
@@ -283,6 +297,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/installations",
+    summary: "List GitHub App installations and their health",
     responses: {
       200: {
         description: "GitHub App installations and health",
@@ -300,6 +315,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/installations/{id}/health",
+    summary: "GitHub App installation health for one installation",
     request: { params: z.object({ id: z.string() }) },
     responses: {
       200: { description: "GitHub App installation health", content: { "application/json": { schema: InstallationHealthSchema } } },
@@ -309,6 +325,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/installations/{id}/repair",
+    summary: "GitHub App installation repair diagnostics",
     request: { params: z.object({ id: z.string() }) },
     responses: {
       200: { description: "GitHub App installation repair diagnostics", content: { "application/json": { schema: InstallationRepairSchema } } },
@@ -318,6 +335,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "post",
     path: "/v1/installations/{id}/repair/refresh",
+    summary: "Refresh GitHub App installation repair diagnostics",
     request: { params: z.object({ id: z.string() }) },
     responses: {
       200: { description: "Refreshed GitHub App installation repair diagnostics", content: { "application/json": { schema: InstallationRepairSchema } } },
@@ -327,6 +345,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/app/notification-model",
+    summary: "Opt-in notification model and PWA-readiness metadata",
     responses: {
       200: {
         description: "Opt-in notification model and PWA-readiness metadata for control-panel routes",
@@ -366,6 +385,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/repos",
+    summary: "List known repositories",
     responses: {
       200: { description: "Known repositories", content: { "application/json": { schema: RepositorySchema.array() } } },
     },
@@ -373,6 +393,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/repos/{owner}/{repo}",
+    summary: "Repository detail",
     request: { params: z.object({ owner: z.string(), repo: z.string() }) },
     responses: {
       200: { description: "Repository detail", content: { "application/json": { schema: RepositorySchema } } },
@@ -382,6 +403,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/repos/{owner}/{repo}/intelligence",
+    summary: "Canonical repository intelligence bundle",
     request: { params: z.object({ owner: z.string(), repo: z.string() }) },
     responses: {
       200: { description: "Canonical repository intelligence bundle", content: { "application/json": { schema: RepoIntelligenceSchema } } },
@@ -390,6 +412,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/repos/{owner}/{repo}/issue-quality",
+    summary: "Cached or computed issue quality report for a repository",
     request: { params: z.object({ owner: z.string(), repo: z.string() }) },
     responses: {
       200: { description: "Cached or computed issue quality report for the repo", content: { "application/json": { schema: IssueQualityResponseSchema } } },
@@ -399,6 +422,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/repos/{owner}/{repo}/outcome-patterns",
+    summary: "Accepted/rejected PR outcome patterns for a repository",
     request: { params: z.object({ owner: z.string(), repo: z.string() }) },
     responses: {
       200: { description: "Cached or freshly-computed per-repo accepted/rejected PR outcome patterns with freshness envelope and explicit evidence-completeness", content: { "application/json": { schema: RepoOutcomePatternsResponseSchema } } },
@@ -408,6 +432,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/repos/{owner}/{repo}/registration-readiness",
+    summary: "Gittensor registration readiness signal for a repo owner",
     request: { params: z.object({ owner: z.string(), repo: z.string() }) },
     responses: {
       200: { description: "Gittensor registration readiness signal for repo owners", content: { "application/json": { schema: RegistrationReadinessSchema } } },
@@ -416,6 +441,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/repos/{owner}/{repo}/gittensor-config-recommendation",
+    summary: "Recommended .loopover.yml additions for a repo owner",
     request: { params: z.object({ owner: z.string(), repo: z.string() }) },
     responses: {
       200: { description: "Private Gittensor config recommendation for repo owners", content: { "application/json": { schema: GittensorConfigRecommendationSchema } } },
@@ -424,6 +450,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/repos/{owner}/{repo}/focus-manifest",
+    summary: "Repo focus manifest and compiled policy for maintainers",
     request: { params: z.object({ owner: z.string(), repo: z.string() }) },
     responses: {
       200: { description: "Repo focus manifest and compiled policy for maintainers", content: { "application/json": { schema: z.record(z.string(), z.unknown()) } } },
@@ -433,6 +460,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "post",
     path: "/v1/repos/{owner}/{repo}/focus-manifest/refresh",
+    summary: "Refresh the persisted focus manifest cache from the repo file",
     request: { params: z.object({ owner: z.string(), repo: z.string() }) },
     responses: {
       200: { description: "Refresh the persisted focus manifest cache from the repo file", content: { "application/json": { schema: z.record(z.string(), z.unknown()) } } },
@@ -442,6 +470,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "put",
     path: "/v1/repos/{owner}/{repo}/focus-manifest",
+    summary: "Persist an API-backed focus manifest for a repo",
     request: { params: z.object({ owner: z.string(), repo: z.string() }) },
     responses: {
       200: { description: "Persist API-backed focus manifest for a repo", content: { "application/json": { schema: z.record(z.string(), z.unknown()) } } },
@@ -452,6 +481,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/repos/{owner}/{repo}/agent/audit-feed",
+    summary: "Maintainer-scoped agent audit feed of executed actions and decisions",
     request: { params: z.object({ owner: z.string(), repo: z.string() }) },
     responses: {
       200: {
@@ -498,6 +528,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "post",
     path: "/v1/repos/{owner}/{repo}/pulls/{number}/incident-reports",
+    summary: "Record a post-merge incident report for a pull request",
     request: {
       params: z.object({ owner: z.string(), repo: z.string(), number: z.string() }),
       body: {
@@ -527,6 +558,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "post",
     path: "/v1/app/incident-reports",
+    summary: "Record a post-merge incident report (internal operator)",
     request: {
       body: {
         content: {
@@ -557,6 +589,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/app/self-dogfood/registration-pack",
+    summary: "Private self-dogfood registration pack for the LoopOver repo itself",
     responses: {
       200: { description: "Private self-dogfood registration pack for the LoopOver repo", content: { "application/json": { schema: z.record(z.string(), z.unknown()) } } },
       403: { description: "Insufficient role for maintainer-only self-dogfood report" },
@@ -565,6 +598,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/repos/{owner}/{repo}/self-dogfood-registration-pack",
+    summary: "Private self-dogfood registration pack for the configured target repo",
     request: { params: z.object({ owner: z.string(), repo: z.string() }) },
     responses: {
       200: { description: "Private self-dogfood registration pack when repo matches configured LoopOver target", content: { "application/json": { schema: z.record(z.string(), z.unknown()) } } },
@@ -574,6 +608,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/repos/{owner}/{repo}/onboarding-pack/preview",
+    summary: "Preview-only repo onboarding pack for an accepted repository",
     request: { params: z.object({ owner: z.string(), repo: z.string() }) },
     responses: {
       200: { description: "Preview-only repo onboarding pack for accepted repositories", content: { "application/json": { schema: z.record(z.string(), z.unknown()) } } },
@@ -584,6 +619,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "post",
     path: "/v1/repos/{owner}/{repo}/contributor-issue-drafts/generate",
+    summary: "Generate maintainer-reviewed contributor issue drafts from repo policy",
     request: { params: z.object({ owner: z.string(), repo: z.string() }) },
     responses: {
       200: { description: "Generate maintainer-reviewed contributor issue drafts from repo policy (dry-run by default)", content: { "application/json": { schema: z.record(z.string(), z.unknown()) } } },
@@ -594,6 +630,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/repos/{owner}/{repo}/settings",
+    summary: "LoopOver repository automation settings",
     request: { params: z.object({ owner: z.string(), repo: z.string() }) },
     responses: {
       200: { description: "LoopOver repository automation settings", content: { "application/json": { schema: RepositorySettingsSchema } } },
@@ -602,6 +639,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "post",
     path: "/v1/repos/{owner}/{repo}/settings-preview",
+    summary: "Dry-run preview of the public surface decision for a sample PR",
     request: { params: z.object({ owner: z.string(), repo: z.string() }) },
     responses: {
       200: { description: "Maintainer dry-run preview of the public surface decision for a sample PR (no GitHub mutation)", content: { "application/json": { schema: RepoSettingsPreviewSchema } } },
@@ -611,6 +649,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/repos/{owner}/{repo}/pulls/{number}/maintainer-packet",
+    summary: "PR-specific maintainer review packet",
     request: { params: z.object({ owner: z.string(), repo: z.string(), number: z.string() }) },
     responses: {
       200: { description: "PR-specific maintainer review packet", content: { "application/json": { schema: PullRequestMaintainerPacketSchema } } },
@@ -619,6 +658,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/repos/{owner}/{repo}/pulls/{number}/reviewability",
+    summary: "Private PR reviewability score and recommended maintainer action",
     request: { params: z.object({ owner: z.string(), repo: z.string(), number: z.string() }) },
     responses: {
       200: { description: "Private PR reviewability score and maintainer action", content: { "application/json": { schema: PullRequestReviewabilitySchema } } },
@@ -627,6 +667,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/contributors/{login}/profile",
+    summary: "Contributor evidence profile",
     request: { params: z.object({ login: z.string() }) },
     responses: {
       200: { description: "Contributor evidence profile", content: { "application/json": { schema: ContributorProfileSchema } } },
@@ -635,6 +676,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/contributors/{login}/decision-pack",
+    summary: "Canonical private contributor decision pack",
     request: { params: z.object({ login: z.string() }) },
     responses: {
       200: {
@@ -647,6 +689,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/contributors/{login}/open-pr-monitor",
+    summary: "Contributor open-PR monitor with classifications and next steps",
     request: { params: z.object({ login: z.string() }) },
     responses: {
       200: {
@@ -658,6 +701,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/contributors/{login}/repos/{owner}/{repo}/decision",
+    summary: "Repo-specific contributor decision from the decision pack",
     request: { params: z.object({ login: z.string(), owner: z.string(), repo: z.string() }) },
     responses: {
       200: { description: "Repo-specific contributor decision from decision pack. May carry freshness 'stale' or 'rebuilding'.", content: { "application/json": { schema: RepoDecisionResponseSchema } } },
@@ -667,6 +711,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "post",
     path: "/v1/preflight/pr",
+    summary: "Submission preflight result for a pull request",
     responses: {
       200: { description: "Submission preflight result", content: { "application/json": { schema: PreflightResultSchema } } },
       400: { description: "Invalid preflight input" },
@@ -675,6 +720,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "post",
     path: "/v1/preflight/local-diff",
+    summary: "Local diff preflight result",
     responses: {
       200: { description: "Local diff preflight result", content: { "application/json": { schema: LocalDiffPreflightResultSchema } } },
       400: { description: "Invalid local diff preflight input" },
@@ -683,6 +729,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "post",
     path: "/v1/local/branch-analysis",
+    summary: "Private local branch analysis for MCP clients",
     responses: {
       200: { description: "Private local branch analysis for MCP clients", content: { "application/json": { schema: LocalBranchAnalysisSchema } } },
       400: { description: "Invalid local branch analysis input" },
@@ -692,6 +739,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "post",
     path: "/v1/agent/runs",
+    summary: "Queue a Copilot-only agent run",
     responses: {
       202: { description: "Copilot-only agent run queued", content: { "application/json": { schema: AgentRunBundleSchema } } },
       400: { description: "Invalid agent run request" },
@@ -701,6 +749,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/agent/runs",
+    summary: "List recent agent run bundles for an authenticated actor",
     request: {
       query: z.object({
         actorLogin: z.string().min(1).openapi({
@@ -732,16 +781,23 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/agent/runs/{id}",
+    summary: "Persisted agent run bundle",
     request: { params: z.object({ id: z.string() }) },
     responses: {
       200: { description: "Persisted agent run bundle", content: { "application/json": { schema: AgentRunBundleSchema } } },
       404: { description: "Agent run not found" },
     },
   });
-  for (const path of ["/v1/agent/plan-next-work", "/v1/agent/preflight-branch", "/v1/agent/prepare-pr-packet", "/v1/agent/explain-blockers"]) {
+  for (const { path, summary } of [
+    { path: "/v1/agent/plan-next-work", summary: "Plan the agent's next ranked actions" },
+    { path: "/v1/agent/preflight-branch", summary: "Preflight the agent's current local branch" },
+    { path: "/v1/agent/prepare-pr-packet", summary: "Prepare a PR packet for the agent's branch" },
+    { path: "/v1/agent/explain-blockers", summary: "Explain blockers preventing the agent's next action" },
+  ]) {
     registry.registerPath({
       method: "post",
       path,
+      summary,
       responses: {
         200: { description: "Agent run completed with deterministic ranked actions", content: { "application/json": { schema: AgentRunBundleSchema } } },
         202: { description: "Agent run needs snapshot refresh", content: { "application/json": { schema: AgentRunBundleSchema } } },
@@ -753,6 +809,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/bounties",
+    summary: "List known bounty records",
     responses: {
       200: { description: "Known bounty records", content: { "application/json": { schema: BountySchema.array() } } },
     },
@@ -760,6 +817,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/bounties/{id}/advisory",
+    summary: "Bounty lifecycle advisory",
     request: { params: z.object({ id: z.string() }) },
     responses: {
       200: { description: "Bounty lifecycle advisory", content: { "application/json": { schema: BountyAdvisorySchema } } },
@@ -769,6 +827,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/bounties/{id}/lifecycle",
+    summary: "Bounty lifecycle transition history",
     request: { params: z.object({ id: z.string() }) },
     responses: {
       200: { description: "Bounty lifecycle transition history", content: { "application/json": { schema: BountyLifecycleEventsSchema } } },
@@ -778,6 +837,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "post",
     path: "/v1/github/webhook",
+    summary: "GitHub webhook ingestion endpoint",
     responses: {
       202: { description: "Webhook queued" },
       401: { description: "Invalid webhook signature" },
@@ -786,6 +846,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "post",
     path: "/v1/orb/ingest",
+    summary: "Batch ingest endpoint for self-hosted ORB reviewers",
     responses: {
       200: { description: "Batch accepted; returns { accepted: number }" },
       400: { description: "Malformed JSON or invalid payload shape" },
@@ -794,6 +855,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/auth/github/start",
+    summary: "Start GitHub web OAuth",
     responses: {
       302: { description: "Redirects to GitHub web OAuth" },
       503: { description: "GitHub OAuth app secret is not configured" },
@@ -802,14 +864,22 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/auth/github/callback",
+    summary: "Complete GitHub web OAuth",
     responses: {
       302: { description: "Completes GitHub web OAuth and redirects to the app" },
     },
   });
-  for (const path of ["/v1/auth/github/device/start", "/v1/auth/github/device/poll", "/v1/auth/github/session", "/v1/auth/logout", "/v1/auth/extension/session"]) {
+  for (const { path, summary } of [
+    { path: "/v1/auth/github/device/start", summary: "Start GitHub device-flow authentication" },
+    { path: "/v1/auth/github/device/poll", summary: "Poll a pending GitHub device-flow authentication" },
+    { path: "/v1/auth/github/session", summary: "Exchange a completed auth flow for a LoopOver session" },
+    { path: "/v1/auth/logout", summary: "Log out of the current LoopOver session" },
+    { path: "/v1/auth/extension/session", summary: "Create an extension-scoped LoopOver session" },
+  ]) {
     registry.registerPath({
       method: "post",
       path,
+      summary,
       responses: {
         200: { description: "Auth request completed" },
         201: { description: "Auth session created" },
@@ -822,6 +892,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/auth/session",
+    summary: "Current auth session, or signed-out state",
     responses: {
       200: { description: "Current auth session, or signed_out when no app session is present" },
     },
@@ -829,26 +900,28 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/app/overview",
+    summary: "Live app overview assembled from backend data",
     responses: {
       200: { description: "Live app overview assembled from backend data", content: { "application/json": { schema: z.record(z.string(), z.unknown()) } } },
       401: { description: "Unauthorized" },
       403: { description: "Insufficient role" },
     },
   });
-  for (const path of [
-    "/v1/app/roles",
-    "/v1/app/miner-dashboard",
-    "/v1/app/maintainer-dashboard",
-    "/v1/app/operator-dashboard",
-    "/v1/app/commands",
-    "/v1/app/commands/usefulness",
-    "/v1/app/digest",
-    "/v1/app/analytics/daily-rollups",
-    "/v1/app/analytics/mcp-compatibility",
+  for (const { path, summary } of [
+    { path: "/v1/app/roles", summary: "Roles available to the current app session" },
+    { path: "/v1/app/miner-dashboard", summary: "Live miner dashboard data" },
+    { path: "/v1/app/maintainer-dashboard", summary: "Live maintainer dashboard data" },
+    { path: "/v1/app/operator-dashboard", summary: "Live operator dashboard data" },
+    { path: "/v1/app/commands", summary: "Available @loopover chat commands" },
+    { path: "/v1/app/commands/usefulness", summary: "Usefulness feedback summary for @loopover chat commands" },
+    { path: "/v1/app/digest", summary: "Live digest summary for the current app session" },
+    { path: "/v1/app/analytics/daily-rollups", summary: "Daily analytics rollups" },
+    { path: "/v1/app/analytics/mcp-compatibility", summary: "MCP client compatibility analytics" },
   ]) {
     registry.registerPath({
       method: "get",
       path,
+      summary,
       responses: {
         200: { description: "Live app API response", content: { "application/json": { schema: z.record(z.string(), z.unknown()) } } },
         401: { description: "Unauthorized" },
@@ -858,6 +931,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "post",
     path: "/v1/app/selfhost/queue/dead/{id}/replay",
+    summary: "Replay one self-host dead-letter queue job",
     request: {
       params: z.object({
         id: z.string().openapi({ param: { description: "Dead-letter job id." }, example: "812" }),
@@ -875,6 +949,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "delete",
     path: "/v1/app/selfhost/queue/dead/{id}",
+    summary: "Delete one self-host dead-letter queue job",
     request: {
       params: z.object({
         id: z.string().openapi({ param: { description: "Dead-letter job id." }, example: "812" }),
@@ -892,6 +967,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "delete",
     path: "/v1/app/selfhost/queue/dead",
+    summary: "Purge all self-host dead-letter queue jobs",
     responses: {
       200: { description: "Dead-letter jobs purged", content: { "application/json": { schema: z.record(z.string(), z.unknown()) } } },
       401: { description: "Unauthorized" },
@@ -902,6 +978,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/app/selfhost/queue/dead",
+    summary: "List paginated self-host dead-letter queue jobs",
     request: {
       query: z.object({
         limit: z.string().optional().openapi({
@@ -925,6 +1002,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/app/analytics/weekly-value-report",
+    summary: "Weekly value report as JSON or Markdown",
     request: {
       query: z.object({
         variant: z.enum(["public", "operator"]).optional().openapi({
@@ -964,6 +1042,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/app/skipped-pr-audit",
+    summary: "Private bounded audit export for skipped PR public-surface decisions",
     request: {
       query: z.object({
         limit: z.string().optional().openapi({
@@ -994,6 +1073,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "post",
     path: "/v1/app/commands/preview",
+    summary: "Dry-run preview of a sanitized @loopover command response",
     responses: {
       200: { description: "Maintainer dry-run preview of a sanitized @loopover command response (no GitHub mutation)", content: { "application/json": { schema: CommandPreviewResponseSchema } } },
       400: { description: "Invalid request" },
@@ -1002,10 +1082,14 @@ export function buildOpenApiSpec() {
       404: { description: "Command not found" },
     },
   });
-  for (const path of ["/v1/app/commands/feedback", "/v1/app/digest/subscriptions"]) {
+  for (const { path, summary } of [
+    { path: "/v1/app/commands/feedback", summary: "Submit usefulness feedback for a @loopover chat command" },
+    { path: "/v1/app/digest/subscriptions", summary: "Manage digest notification subscriptions" },
+  ]) {
     registry.registerPath({
       method: "post",
       path,
+      summary,
       responses: {
         200: { description: "Live app mutation or preview response", content: { "application/json": { schema: z.record(z.string(), z.unknown()) } } },
         201: { description: "Created", content: { "application/json": { schema: z.record(z.string(), z.unknown()) } } },
@@ -1017,6 +1101,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "get",
     path: "/v1/extension/pull-context",
+    summary: "Browser extension PR context overlay payload",
     request: {
       query: z.object({
         owner: z.string().min(1).openapi({ param: { description: "Repository owner" }, example: "JSONbored" }),
@@ -1034,6 +1119,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "post",
     path: "/v1/internal/jobs/refresh-registry",
+    summary: "Queue an internal Gittensor registry refresh job",
     responses: {
       202: { description: "Registry refresh queued" },
       401: { description: "Invalid internal token" },
@@ -1042,6 +1128,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "post",
     path: "/v1/internal/jobs/backfill-registered-repos",
+    summary: "Queue an internal registered-repo backfill job",
     responses: {
       202: { description: "Registered repo backfill queued" },
       401: { description: "Invalid internal token" },
@@ -1050,6 +1137,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "post",
     path: "/v1/internal/jobs/backfill-repo-segment",
+    summary: "Queue an internal repository segment backfill job",
     responses: {
       202: { description: "Repository segment backfill queued" },
       400: { description: "Invalid segment request" },
@@ -1059,6 +1147,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "post",
     path: "/v1/internal/jobs/backfill-pr-details",
+    summary: "Queue an internal open PR detail backfill job",
     responses: {
       202: { description: "Open PR detail backfill queued" },
       400: { description: "Invalid PR detail backfill request" },
@@ -1068,26 +1157,28 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "post",
     path: "/v1/internal/jobs/generate-review-recap",
+    summary: "Queue an internal maintainer review recap digest job",
     responses: {
       202: { description: "Maintainer review recap digest queued (#1963)" },
       400: { description: "Missing repoFullName" },
       401: { description: "Invalid internal token" },
     },
   });
-  for (const path of [
-    "/v1/internal/jobs/refresh-scoring-model",
-    "/v1/internal/jobs/refresh-upstream-drift",
-    "/v1/internal/jobs/file-upstream-drift-issues",
-    "/v1/internal/jobs/build-contributor-evidence",
-    "/v1/internal/jobs/build-contributor-decision-packs",
-    "/v1/internal/jobs/build-burden-forecasts",
-    "/v1/internal/jobs/generate-signal-snapshots",
-    "/v1/internal/jobs/generate-weekly-value-report",
-    "/v1/internal/jobs/repair-data-fidelity",
+  for (const { path, summary } of [
+    { path: "/v1/internal/jobs/refresh-scoring-model", summary: "Queue an internal scoring model refresh job" },
+    { path: "/v1/internal/jobs/refresh-upstream-drift", summary: "Queue an internal upstream drift refresh job" },
+    { path: "/v1/internal/jobs/file-upstream-drift-issues", summary: "Queue an internal job to file upstream drift issues" },
+    { path: "/v1/internal/jobs/build-contributor-evidence", summary: "Queue an internal contributor evidence build job" },
+    { path: "/v1/internal/jobs/build-contributor-decision-packs", summary: "Queue an internal contributor decision pack build job" },
+    { path: "/v1/internal/jobs/build-burden-forecasts", summary: "Queue an internal burden forecast build job" },
+    { path: "/v1/internal/jobs/generate-signal-snapshots", summary: "Queue an internal signal snapshot generation job" },
+    { path: "/v1/internal/jobs/generate-weekly-value-report", summary: "Queue an internal weekly value report generation job" },
+    { path: "/v1/internal/jobs/repair-data-fidelity", summary: "Queue an internal data fidelity repair job" },
   ]) {
     registry.registerPath({
       method: "post",
       path,
+      summary,
       responses: {
         202: { description: "Internal job queued" },
         401: { description: "Invalid internal token" },
@@ -1097,6 +1188,7 @@ export function buildOpenApiSpec() {
   registry.registerPath({
     method: "post",
     path: "/v1/internal/bounties/import",
+    summary: "Import an internal bounty snapshot",
     responses: {
       200: { description: "Bounty snapshot imported" },
       401: { description: "Invalid internal token" },

--- a/test/unit/openapi.test.ts
+++ b/test/unit/openapi.test.ts
@@ -143,4 +143,19 @@ describe("OpenAPI contract", () => {
       }
     }
   });
+
+  it("gives every operation a non-empty summary (#5810)", () => {
+    const spec = buildOpenApiSpec();
+    const paths = Object.entries(spec.paths ?? {});
+    expect(paths.length).toBeGreaterThan(0);
+    let operationCount = 0;
+    for (const [path, methods] of paths) {
+      for (const [method, operation] of Object.entries(methods as Record<string, { summary?: string }>)) {
+        operationCount += 1;
+        expect(operation.summary, `${method.toUpperCase()} ${path} is missing a summary`).toEqual(expect.any(String));
+        expect(operation.summary!.length > 0, `${method.toUpperCase()} ${path} has an empty summary`).toBe(true);
+      }
+    }
+    expect(operationCount).toBeGreaterThanOrEqual(78);
+  });
 });


### PR DESCRIPTION
## Summary

- Add a concise operation-level `summary` to every one of the 78 `registry.registerPath({...})` calls in `src/openapi/spec.ts`, so the generated `openapi.json` / API browser shows a human-readable title per operation instead of only per-response descriptions.
- For the 5 call sites that register multiple paths from a shared loop, give each path its own distinct summary (via an array of `{ path, summary }` pairs) rather than one generic string reused across siblings.
- Add a regression test (`test/unit/openapi.test.ts`) that iterates every path/method in the built spec and asserts `summary` is a non-empty string, so a future route added without one fails loudly.
- Regenerate `apps/loopover-ui/public/openapi.json` via `npm run ui:openapi`.
- Closes #5810

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [ ] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [ ] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## Notes

- No auth/session/UI behavior changes in this PR — it only adds `summary` metadata fields to existing route registrations, so the Auth/negative-path and UI Evidence checklist items are not applicable.
- `src/openapi/spec.ts` is inside `coverage.include`; the new test exercises every changed `summary:` field by construction (it iterates the full built spec), and local `npm run test:coverage` reports 100% statements/lines/functions on the file with no new branch gaps introduced by this diff.
- The 5 loop-based call sites (agent actions, auth flows, app dashboards, app mutations, internal jobs) previously shared one options object per loop; converting the loop input from a plain string array to an array of `{ path, summary }` pairs keeps each path's summary accurate without duplicating the `registerPath` call per path.
