### PR TITLE
fix(engine): normalize worktree-pool maxConcurrency so a NaN cap can't disable it

### DIFF
--- a/packages/loopover-engine/src/miner/worktree-pool.ts
+++ b/packages/loopover-engine/src/miner/worktree-pool.ts
@@ -41,9 +41,18 @@ export function isWorktreeAllocated(state: WorktreePoolState, attemptId: string)
   return state.allocations.some((allocation) => allocation.attemptId === attemptId);
 }
 
+/** Normalize a possibly-untrusted concurrency cap before it gates allocation: a non-finite (`NaN`/`Infinity`),
+ *  negative, or fractional `maxConcurrency` can never disable the cap or yield a `NaN` slot count — it floors to
+ *  a non-negative integer, so an invalid value behaves as the documented non-positive cap (allocates nothing).
+ *  Mirrors the `finiteNonNegativeInt` discipline already applied in governor/rate-limit.ts, governor/budget-cap.ts,
+ *  and tenant-quota.ts (#5828). */
+function finiteNonNegativeInt(value: number): number {
+  return Number.isFinite(value) ? Math.max(0, Math.floor(value)) : 0;
+}
+
 /** Slots still available before the concurrency cap (never negative). Pure. */
 export function availableWorktreeSlots(state: WorktreePoolState, config: WorktreePoolConfig): number {
-  return Math.max(0, config.maxConcurrency - state.allocations.length);
+  return Math.max(0, finiteNonNegativeInt(config.maxConcurrency) - state.allocations.length);
 }
 
 /**
@@ -60,7 +69,7 @@ export function acquireWorktree(
   if (isWorktreeAllocated(state, input.attemptId)) {
     return { ok: false, reason: "already_allocated", state };
   }
-  if (state.allocations.length >= config.maxConcurrency) {
+  if (state.allocations.length >= finiteNonNegativeInt(config.maxConcurrency)) {
     return { ok: false, reason: "at_capacity", state };
   }
   const allocation: WorktreeAllocation = {

--- a/test/unit/miner-worktree-pool.test.ts
+++ b/test/unit/miner-worktree-pool.test.ts
@@ -78,4 +78,38 @@ describe("worktree pool allocator (#4297)", () => {
     const s = acquired(acquired(EMPTY_WORKTREE_POOL, "a"), "b");
     expect(availableWorktreeSlots(s, { maxConcurrency: 1 })).toBe(0);
   });
+
+  it("treats a NaN maxConcurrency as a zero cap instead of disabling the limit", () => {
+    const cfg = { maxConcurrency: NaN };
+    expect(availableWorktreeSlots(EMPTY_WORKTREE_POOL, cfg)).toBe(0);
+    const r = acquireWorktree(EMPTY_WORKTREE_POOL, cfg, { attemptId: "a", repoPath: REPO });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("at_capacity");
+  });
+
+  it("treats a negative maxConcurrency as a zero cap", () => {
+    const cfg = { maxConcurrency: -1 };
+    expect(availableWorktreeSlots(EMPTY_WORKTREE_POOL, cfg)).toBe(0);
+    const r = acquireWorktree(EMPTY_WORKTREE_POOL, cfg, { attemptId: "a", repoPath: REPO });
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.reason).toBe("at_capacity");
+  });
+
+  it("floors a fractional maxConcurrency to the nearest integer", () => {
+    const cfg = { maxConcurrency: 2.5 };
+    expect(availableWorktreeSlots(EMPTY_WORKTREE_POOL, cfg)).toBe(2);
+    const one = acquireWorktree(EMPTY_WORKTREE_POOL, cfg, { attemptId: "a", repoPath: REPO });
+    expect(one.ok).toBe(true);
+    if (!one.ok) return;
+    const two = acquireWorktree(one.state, cfg, { attemptId: "b", repoPath: REPO });
+    expect(two.ok).toBe(true);
+    if (!two.ok) return;
+    expect(availableWorktreeSlots(two.state, cfg)).toBe(0);
+    const three = acquireWorktree(two.state, cfg, { attemptId: "c", repoPath: REPO });
+    expect(three.ok).toBe(false);
+    if (three.ok) return;
+    expect(three.reason).toBe("at_capacity");
+  });
 });


### PR DESCRIPTION
## Summary

`availableWorktreeSlots` and `acquireWorktree` in `packages/loopover-engine/src/miner/worktree-pool.ts` read `WorktreePoolConfig.maxConcurrency` directly in their comparisons with no normalization. If the cap arrives as `NaN` (e.g. a caller derives it from `Number(someUnparsableConfigValue)` and doesn't guard the result), every comparison against it is `false` — `length >= NaN` never holds — so `at_capacity` never fires and the pool allocates worktrees **without bound**, directly contradicting the type's own documented contract ("A non-positive cap allocates nothing"). `availableWorktreeSlots` also returns `NaN`, breaking any caller that treats it as a real remaining-slots count.

The fix adds a small `finiteNonNegativeInt` helper (mirroring the exact pattern already used in `governor/rate-limit.ts`, `governor/budget-cap.ts`, and `tenant-quota.ts` in this same package) and normalizes `config.maxConcurrency` through it at both read sites: a non-finite or negative cap floors to `0` (the documented "allocates nothing" behavior), and a fractional cap floors down. No public signature or behavior change for a valid positive cap.

Closes #5828

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #5828`).

## Validation

- [x] `git diff --check` — clean
- [ ] `npm run actionlint` — no workflow changes
- [x] `npm run typecheck` — passes (whole project, against the rebuilt `@loopover/engine`)
- [x] `npm run test:coverage` — the two changed engine lines and both arms of the new `finiteNonNegativeInt` (finite→floor, non-finite→0) are exercised by the new regression tests plus the existing positive-cap tests, so `codecov/patch` on the diff is 100%. `test/unit/miner-worktree-pool.test.ts` passes 10/10; the new NaN and fractional cases fail on the pre-fix code and pass after. `packages/loopover-engine` own suite: 553/553.
- [ ] `npm run test:workers` — unaffected (pure in-memory engine scheduling logic, no worker changes)
- [ ] `npm run build:mcp` / `test:mcp-pack` — unaffected (no MCP changes)
- [ ] `npm run ui:openapi:check` / `ui:lint` / `ui:typecheck` / `ui:build` — unaffected (no UI/OpenAPI/route changes)
- [ ] `npm audit --audit-level=moderate` — no dependency changes
- [x] New or changed behavior has unit tests — regression tests for `maxConcurrency: NaN`, `-1`, and a fractional value, asserting the pool refuses allocation (or floors correctly) in each case

If any required check was skipped, explain why:

- Change is confined to one engine module (`worktree-pool.ts`, +the helper) plus its test. It introduces no workflow, MCP, UI, OpenAPI, or dependency changes. I additionally ran `npm run engine-parity:drift-check` (ok — this module is engine-only, not a `src/{review,settings,signals}` twin) and the backend drift checks (`docs`, `manifest`, `command-reference`, `selfhost env-reference`), all green.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests — N/A (none).
- [x] API/OpenAPI/MCP behavior is updated and tested where needed — N/A (none).
- [x] UI changes use live API data or real empty/error/loading states — N/A (no UI changes).
- [x] Visible UI changes include a `UI Evidence` section — N/A (no UI/frontend/docs/extension changes).
- [x] Public docs/changelogs are updated where needed — N/A.

## Notes

- The normalization matches the module's existing "non-positive cap allocates nothing" contract exactly — an invalid cap now behaves identically to a documented `0` cap rather than silently disabling the limit — so no caller relying on the current documented semantics changes behavior; only the previously-undefined invalid-input case is now defined.
