### PR TITLE
fix(docs): sweep remaining gittensory-* rename residue in self-host ops docs

### DIFF
--- a/apps/loopover-ui/src/routes/docs.self-hosting-operations.tsx
+++ b/apps/loopover-ui/src/routes/docs.self-hosting-operations.tsx
@@ -408,9 +408,9 @@ DISCORD_REPO_WEBHOOKS={"owner/repoA":"https://discord.com/api/webhooks/...","own
         <strong>expected steady state, not a leak</strong> — this instance runs{" "}
         <code>scripts/deploy-selfhost-prebuilt.sh</code>, which rebuilds the image from the current
         git checkout on every deploy and intentionally keeps prior layers around in the build cache
-        for faster rebuilds. The <code>loopover-docker-safe-prune</code> systemd timer (below)
-        already runs daily against this exact instance and reclaims it on a schedule, so this is not
-        a number to chase down manually.
+        for faster rebuilds. The <code>loopover-docker-prune</code> systemd timer (below) already
+        runs daily against this exact instance and reclaims it on a schedule, so this is not a
+        number to chase down manually.
       </p>
 
       <h3>When a compose default might need to change</h3>

--- a/packages/loopover-miner/terraform/main.tf
+++ b/packages/loopover-miner/terraform/main.tf
@@ -5,7 +5,7 @@
 #
 # This is the CLI-worker profile — it exposes NO public endpoints by default (unlike the root terraform/ module,
 # which provisions the multi-tenant ORB server behind Caddy on 80/443). After `terraform apply`: SSH in, drop your
-# secrets into a .gittensory-miner.env, and start the miner container against /data/miner. See README.md and
+# secrets into a .loopover-miner.env.example, and start the miner container against /data/miner. See README.md and
 # ../docker-compose.miner.yml / ../DEPLOYMENT.md for the run step.
 
 terraform {

--- a/src/review/repo-agnostic-capability-audit.md
+++ b/src/review/repo-agnostic-capability-audit.md
@@ -5,7 +5,7 @@ or implicitly gittensory-specific assumptions that would need to become per-tena
 the review/merge authority model can be handed to an arbitrary rented repository. This is the checklist
 deliverable for **#5744**; a follow-up implementation issue would turn each open item below into config,
 gittensory's own values surviving only as the default. It mirrors the shape of the miner-side audit in
-[`packages/gittensory-miner/docs/repo-agnostic-capability-audit.md`](../../packages/gittensory-miner/docs/repo-agnostic-capability-audit.md)
+[`packages/loopover-miner/docs/repo-agnostic-capability-audit.md`](../../packages/loopover-miner/docs/repo-agnostic-capability-audit.md)
 (the #4780 audit that #4784 resolved). Audit-and-document only — no code changes here.
 
 ## Summary

--- a/test/unit/self-host-ops-rename-residue.test.ts
+++ b/test/unit/self-host-ops-rename-residue.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+// Regression for #5937: three self-host/ops docs still referenced pre-rename `gittensory-*` names that no
+// longer exist (a dead timer name, a dead cross-repo link, a stale env filename). Each file is grepped for
+// the exact stale string and the verified-correct replacement, following the config-drift pattern in
+// test/unit/miner-docker-compose.test.ts.
+const SELF_HOSTING_OPS_DOC = join(
+  process.cwd(),
+  "apps/loopover-ui/src/routes/docs.self-hosting-operations.tsx",
+);
+const TERRAFORM_MAIN = join(process.cwd(), "packages/loopover-miner/terraform/main.tf");
+const CAPABILITY_AUDIT_DOC = join(process.cwd(), "src/review/repo-agnostic-capability-audit.md");
+
+describe("self-host ops docs rename residue (#5937)", () => {
+  it("names the real loopover-docker-prune timer, not the dead loopover-docker-safe-prune one", () => {
+    const doc = readFileSync(SELF_HOSTING_OPS_DOC, "utf8");
+    expect(doc).not.toContain("loopover-docker-safe-prune");
+    expect(doc).toContain("loopover-docker-prune");
+  });
+
+  it("points the terraform module's header comment at the real env filename, not .gittensory-miner.env", () => {
+    const tf = readFileSync(TERRAFORM_MAIN, "utf8");
+    expect(tf).not.toContain(".gittensory-miner.env");
+    expect(tf).toContain(".loopover-miner.env.example");
+  });
+
+  it("links the capability audit doc at the real post-rename packages/loopover-miner path", () => {
+    const audit = readFileSync(CAPABILITY_AUDIT_DOC, "utf8");
+    expect(audit).not.toContain("packages/gittensory-miner/");
+    expect(audit).toContain(
+      "packages/loopover-miner/docs/repo-agnostic-capability-audit.md",
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- `apps/loopover-ui/src/routes/docs.self-hosting-operations.tsx` line 411 named a dead `loopover-docker-safe-prune` systemd timer in the disk-cleanup prose, self-contradicting the same file's own install snippet a few lines later, which installs the real `loopover-docker-prune` timer (also shipped at `systemd/loopover-docker-prune.timer.example`). Fixed the prose to name the real timer.
- `packages/loopover-miner/terraform/main.tf` line 7's header comment told operators to drop secrets into a pre-rename `.gittensory-miner.env`; the module's own `README.md` and `DEPLOYMENT.md` already use `.loopover-miner.env.example`. Fixed the comment to match.
- `src/review/repo-agnostic-capability-audit.md` line 8 linked to `packages/gittensory-miner/docs/repo-agnostic-capability-audit.md`, a dead 404 — the directory was renamed to `packages/loopover-miner/`. Fixed the link to the real path.
- Added `test/unit/self-host-ops-rename-residue.test.ts`, a grep-based regression test (following the `miner-docker-compose.test.ts` pattern) asserting the three stale strings are gone and the correct replacements are present in all three files.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally — none of the three changed files are in `src/**`'s Codecov `coverage.include` (a UI route, a terraform comment, and a markdown doc), so `codecov/patch` doesn't gate this change directly; the new regression test in `test/unit/` passes and exercises all three fixes.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- `test:workers`, `build:mcp`/`test:mcp-pack`, and `ui:build` weren't re-run standalone for this change since it touches no worker, MCP, or UI-build-affecting code (only doc prose, a terraform comment, and a markdown link) — the full `npm run test:ci` gate run locally covers all of these and was green apart from pre-existing, unrelated local-environment gaps (missing `sqlite3` CLI binary used by an unrelated reporting-DB test, and a stray `GITHUB_TOKEN` env var tripping an unrelated miner test's "no token" branch) that reproduce identically on `main` without this diff.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — this is a text-only fix to prose/comments (a stale identifier in a code sample, a terraform header comment, and a markdown link target). No layout, styling, or rendered visual difference results; the rendered doc page's structure is unchanged.

## Notes

- Closes #5937
