### PR TITLE
chore(release): bump orb-manifest target to 2.1.0

### DIFF
--- a/orb-manifest.json
+++ b/orb-manifest.json
@@ -1,4 +1,4 @@
 {
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Source of truth for the self-hostable gittensory-orb container image's target release version (ghcr.io/jsonbored/loopover-selfhost). Bumped by a maintainer when a feat/fix/breaking change since the last stable orb-v tag warrants moving to a new target version -- scripts/orb-release-core.mjs and .github/workflows/orb-beta-release.yml read this file to decide what version the next automated beta snapshot targets. Promoting a beta to a stable orb-vX.Y.Z release is still a manual `git tag` -- this manifest only drives the automated beta channel."
 }


### PR DESCRIPTION
## Summary

Bumps \`orb-manifest.json\`'s target version from \`2.0.0\` to \`2.1.0\` -- unblocks the automated daily beta channel (\`orb-beta-release.yml\`) for everything merged since the \`orb-v2.0.0\` stable tag, notably:

- \`feat(selfhost): warn loudly when the private config mount is empty\` (#5977)
- \`fix(review): wire skipAutomationBotAuthors into .loopover.yml config\` (#5986)
- \`fix(review): make size-gate file/line thresholds configurable\` (#5997)
- \`fix(review): give LOOPOVER_DUPLICATE_WINNER a per-repo config override\` (#6005)
- \`fix(review): give LOOPOVER_OPEN_PR_FILE_COLLISION a per-repo config override\` (#6035)

This is intentionally separate from the standing \`release-orb-stable\` PR (#6046), which cuts a real, gated stable tag on merge -- this PR just moves the beta-channel target so a beta can be built and validated before promoting to stable.

## Test plan

- [x] Valid JSON, single-field change, no code paths affected