### PR TITLE
fix(miner): reject stray positional arguments in calibration-cli

### DIFF
--- a/packages/loopover-miner/lib/calibration-cli.js
+++ b/packages/loopover-miner/lib/calibration-cli.js
@@ -68,7 +68,10 @@ function renderReportText(report) {
  */
 export function runCalibrationCli(args = [], env = process.env) {
   const json = args.includes("--json");
-  const unknown = args.find((token) => token.startsWith("-") && token !== "--json");
+  // This command takes no positional arguments, so anything that is not `--json` is a mistake -- including a
+  // bare positional (`calibration foo`), which a `startsWith("-")` check silently let through (#5834). Mirrors
+  // the strict zero-positional discipline `ledger list` (event-ledger-cli.js) already applies.
+  const unknown = args.find((token) => token !== "--json");
   if (unknown) {
     return reportCliFailure(json, `Unknown option: ${unknown}. ${CALIBRATION_USAGE}`, 1);
   }

--- a/test/unit/miner-calibration-cli.test.ts
+++ b/test/unit/miner-calibration-cli.test.ts
@@ -114,6 +114,23 @@ describe("loopover-miner calibration CLI (#4849)", () => {
     expect(String(err.mock.calls[0]?.[0])).toContain("Unknown option");
   });
 
+  // #5834: the check only rejected tokens starting with "-", so a stray positional was silently ignored and the
+  // command reported a calibration run the operator never asked for. This command takes no positionals at all.
+  it("rejects a stray positional argument with exit code 1 (#5834)", () => {
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(runCalibrationCli(["foo"], envForTempStores())).toBe(1);
+    expect(String(err.mock.calls[0]?.[0])).toContain("Unknown option: foo");
+  });
+
+  it("rejects a stray positional alongside --json, on the JSON error contract (#5834)", () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    const err = vi.spyOn(console, "error").mockImplementation(() => {});
+    expect(runCalibrationCli(["--json", "extra"], envForTempStores())).toBe(1);
+    expect(JSON.parse(String(log.mock.calls[0]?.[0]))).toMatchObject({ ok: false });
+    expect(String(JSON.parse(String(log.mock.calls[0]?.[0])).error)).toContain("Unknown option: extra");
+    expect(err).not.toHaveBeenCalled();
+  });
+
   it("emits JSON when ledger open fails with --json (#4836)", () => {
     const log = vi.spyOn(console, "log").mockImplementation(() => {});
     const err = vi.spyOn(console, "error").mockImplementation(() => {});


### PR DESCRIPTION
## Summary

Closes #5834

`runCalibrationCli` (`packages/loopover-miner/lib/calibration-cli.js`) validated its arguments with:

```js
const unknown = args.find((token) => token.startsWith("-") && token !== "--json");
```

The `startsWith("-")` guard means only an unrecognized **flag** is rejected. A stray **positional** token slips through silently, because this command is never checked against its expected positional count of zero:

- `loopover-miner calibration foo` → runs a full calibration report, ignoring `foo`.
- `loopover-miner calibration --json extra` → same, ignoring `extra`.

Neither reports a problem, so an operator who typos an argument gets a report that looks authoritative while their actual intent was silently discarded.

**Fix:** this command takes no positional arguments at all, so any token other than `--json` is a mistake. Dropping the `startsWith("-")` guard makes the existing check reject flags and positionals alike — keeping this file's established `Unknown option: <token>. ${CALIBRATION_USAGE}` message and the `reportCliFailure(json, ..., 1)` convention rather than introducing a new message shape. Because it reuses `reportCliFailure`, the failure also honors `--json` via the shared CLI error contract (`{ ok: false, error }` on stdout).

This mirrors the strict zero-positional discipline `ledger list` (`packages/loopover-miner/lib/event-ledger-cli.js`) already applies via its `positional.length > 0` rejection — the precedent the issue cites.

## Scope

- [x] Conventional Commit title (`fix(miner): …`).
- [x] Focused: one argument-validation predicate + regression tests. No behavior change to the report itself.
- [x] Follows `CONTRIBUTING.md`; no `site/`/`CNAME`/`lovable` changes; no changelog edit.
- [x] Linked open issue (Closes #5834, above).

## Validation

- [x] `git diff --check` clean.
- [x] `npx vitest run test/unit/miner-calibration-cli.test.ts` — **9 tests passed**.
- [x] Coverage on `packages/loopover-miner/lib/calibration-cli.js` (in Codecov's `coverage.include`): **100% statements (35/35), 100% branch (19/19), 100% functions (6/6), 100% lines (30/30)** — both sides of the widened predicate are exercised.
- [x] Related suites green: `miner-calibration-cli`, `miner-cli`, `miner-event-ledger-cli` — **47 tests passed**.
- [x] Blast radius checked: the only caller is `packages/loopover-miner/bin/loopover-miner.js:114` (`runCalibrationCli(cliArgs.slice(1))`), so a valid `loopover-miner calibration [--json]` invocation passes `[]` / `["--json"]` and is unaffected. No test or code path passes a positional to this command.
- [x] Rebased onto current `main`.

New regression tests:
- `calibration foo` → exit **1** with `Unknown option: foo` on stderr (previously exit 0, silently ignored).
- `calibration --json extra` → exit **1** emitting the JSON error contract `{ ok: false, error: "Unknown option: extra…" }` on stdout and nothing on stderr.

If any required check was skipped, explain why:

- Full `test:ci` not run end-to-end locally (Linux-only steps on Windows). The change-relevant gates — the affected suites and per-file coverage on the touched file — were validated directly and are green.

## Safety

- [x] No secrets, wallets, hotkeys, trust scores, rewards, private rankings, or private maintainer evidence.
- [x] No auth/cookie/CORS/GitHub App/session change. Local, read-only CLI argument validation.
- [x] Fails safe and strictly more conservative: it only turns a previously-silent mistake into an explicit error. No previously-valid invocation (`calibration`, `calibration --json`) changes behavior.
- [x] No API/OpenAPI/MCP change; the exported signature is unchanged (`calibration-cli.d.ts` needs no update).
- [x] No UI changes; no changelog edit.
