### PR TITLE
fix(review): track lockfile entry nesting so a nested dependencies object can't hide tamper (#5837)

### DIFF
--- a/src/review/lockfile-tamper.ts
+++ b/src/review/lockfile-tamper.ts
@@ -113,8 +113,14 @@ function versionChanged(removed: string | undefined, added: string | undefined):
  *  actively maintained repo's lockfile and is out of scope here. */
 function scanPackageLockPatch(path: string, patch: string): LockfileTamperCandidate[] {
   const byEntry = new Map<string, MutableCandidate>();
-  let currentEntryKey: string | null = null;
-  let currentPackageName: string | null = null;
+  // A single flat currentEntryKey pointer loses the outer entry when a `node_modules/...` entry contains its own
+  // nested `dependencies`/`devDependencies`/`optionalDependencies` sub-object: the nested container header reset
+  // the pointer to null and never restored it, so any resolved/integrity/version line for the SAME outer entry
+  // appearing after the nested object was silently skipped — an attacker could reorder an entry's keys to put
+  // `dependencies` before `resolved`/`integrity` and evade the tamper check entirely (#5837). Track a stack of
+  // brace scopes instead: each object-header line pushes a frame (an entry, or null for a container/root/other),
+  // each closing brace pops one, so closing a nested sub-object restores the enclosing entry as the current one.
+  const scopeStack: Array<{ entryKey: string; packageName: string } | null> = [];
   let sawPackagesEntry = false;
 
   const entryFor = (entryKey: string, packageName: string): MutableCandidate => {
@@ -140,23 +146,26 @@ function scanPackageLockPatch(path: string, patch: string): LockfileTamperCandid
       const key = objectHeader[1]!;
       const nodeModulesPackage = npmPackageFromNodeModulesPath(key);
       if (nodeModulesPackage) {
-        currentEntryKey = key;
-        currentPackageName = nodeModulesPackage;
+        scopeStack.push({ entryKey: key, packageName: nodeModulesPackage });
         sawPackagesEntry = true;
       } else if (!sawPackagesEntry && !CONTAINER_KEYS.has(key)) {
-        currentEntryKey = key;
-        currentPackageName = key;
+        scopeStack.push({ entryKey: key, packageName: key });
       } else {
-        currentEntryKey = null;
-        currentPackageName = null;
+        // A container/root/unrecognized header (incl. a nested dependencies sub-object) — not an entry itself,
+        // but still a brace scope, so push a null frame that a matching closing brace will pop back off.
+        scopeStack.push(null);
       }
       continue;
     }
     if (body === "}" || body.startsWith("},")) {
-      currentEntryKey = null;
-      currentPackageName = null;
+      scopeStack.pop();
     }
-    if (!currentEntryKey || !currentPackageName || line.sign === " ") continue;
+    // The current entry is the innermost open scope IF that scope is an entry (we're directly in its body). A
+    // resolved/integrity/version line nested inside a sub-object (top frame null) is correctly not attributed.
+    const current = scopeStack.length > 0 ? scopeStack[scopeStack.length - 1] : null;
+    if (!current || line.sign === " ") continue;
+    const currentEntryKey = current.entryKey;
+    const currentPackageName = current.packageName;
 
     const resolvedMatch = /^"resolved"\s*:\s*"([^"]*)"/.exec(body);
     const integrityMatch = /^"integrity"\s*:\s*"([^"]*)"/.exec(body);

--- a/test/unit/lockfile-tamper.test.ts
+++ b/test/unit/lockfile-tamper.test.ts
@@ -95,6 +95,71 @@ describe("lockfileTamperRiskFinding", () => {
     expect(finding?.detail).toContain("lodash");
   });
 
+  // #5837: a nested dependencies sub-object inside an entry, appearing BEFORE the entry's own
+  // resolved/integrity/version lines (key order reversed from real npm output), must not make the parser lose
+  // track of the outer entry — otherwise a reordered-key tamper diff evades detection entirely.
+  it("still detects tamper when the entry's dependencies sub-object precedes its resolved/integrity/version (regression for #5837)", () => {
+    const lockPatch = [
+      '@@ -100,12 +100,12 @@',
+      '     "node_modules/lodash": {',
+      '       "dependencies": {',
+      '-        "helper": "^1.0.0"',
+      '+        "helper": "^1.0.1"',
+      '       },',
+      '-      "version": "4.17.20",',
+      '-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",',
+      '-      "integrity": "sha512-oldoldold=="',
+      '+      "version": "4.17.20",',
+      '+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",',
+      '+      "integrity": "sha512-tamperedtampered=="',
+      '     },',
+    ].join("\n");
+    // resolved/integrity changed but version did NOT — the classic tamper tell, here after a nested sub-object.
+    const finding = lockfileTamperRiskFinding([lockfilePatch(lockPatch)]);
+    expect(finding).not.toBeNull();
+    expect(finding?.code).toBe("lockfile_tamper_risk");
+    expect(finding?.detail).toContain("lodash");
+  });
+
+  // #5837 + #2692: two distinct entries share the bare name "foo" (a nested duplicate under bar), each carrying
+  // its own dependencies sub-object. The full-path entry keying (#2692) and the nesting-depth fix must compose:
+  // the genuine bump on the top-level foo must NOT mask the unbumped resolved/integrity edit on the nested foo.
+  it("keeps two same-named entries independent when each also has a nested dependencies object (#5837 + #2692)", () => {
+    const lockPatch = [
+      '@@ -200,20 +200,20 @@',
+      '     "node_modules/foo": {',
+      '       "dependencies": {',
+      '-        "dep": "^1.0.0"',
+      '+        "dep": "^1.1.0"',
+      '       },',
+      '-      "version": "1.0.0",',
+      '-      "resolved": "https://registry.npmjs.org/foo/-/foo-1.0.0.tgz",',
+      '-      "integrity": "sha512-fooold=="',
+      '+      "version": "1.1.0",',
+      '+      "resolved": "https://registry.npmjs.org/foo/-/foo-1.1.0.tgz",',
+      '+      "integrity": "sha512-foonew=="',
+      '     },',
+      '     "node_modules/bar/node_modules/foo": {',
+      '       "dependencies": {',
+      '-        "dep": "^2.0.0"',
+      '+        "dep": "^2.0.1"',
+      '       },',
+      '-      "version": "2.0.0",',
+      '-      "resolved": "https://registry.npmjs.org/foo/-/foo-2.0.0.tgz",',
+      '-      "integrity": "sha512-nestedold=="',
+      '+      "version": "2.0.0",',
+      '+      "resolved": "https://registry.npmjs.org/foo/-/foo-2.0.0.tgz",',
+      '+      "integrity": "sha512-nestedtampered=="',
+      '     },',
+    ].join("\n");
+    // Top-level foo bumped legitimately (all three change); the nested foo's integrity changed with NO version
+    // bump — still flagged, because the two entries are keyed by their distinct full paths, not the shared name.
+    const finding = lockfileTamperRiskFinding([lockfilePatch(lockPatch)]);
+    expect(finding).not.toBeNull();
+    expect(finding?.code).toBe("lockfile_tamper_risk");
+    expect(finding?.detail).toContain("foo");
+  });
+
   it("triggers on a resolved URL outside the npm registry, even with a version bump", () => {
     const lockPatch = [
       '@@ -100,8 +100,8 @@',


### PR DESCRIPTION
## Summary

Closes #5837.

`scanPackageLockPatch` in `src/review/lockfile-tamper.ts` is the heuristic line-based scanner that flags the
classic supply-chain tell: a `resolved`/`integrity` value changed for a `package-lock.json` entry **without** that
same entry's own `"version"` genuinely changing. It tracked "which entry am I inside" with a single flat
`currentEntryKey`/`currentPackageName` pointer.

A real `node_modules/...` entry frequently contains its **own nested** `dependencies` /
`devDependencies` / `optionalDependencies` sub-object. Once inside the `packages` tree, hitting that nested
container header fell into the `else` branch and reset the pointer to `null` — and it was **never restored** when
the nested object closed. Any `resolved`/`integrity`/`version` line for the same outer entry appearing *after* the
nested sub-object was then silently skipped by the current-entry guard.

Today's npm output always orders `version`/`resolved`/`integrity` **before** `dependencies` within an entry, so
legitimate diffs never trip this. But nothing enforces that ordering: an attacker hand-crafting a tamper diff
could simply **reorder the entry's keys** so `dependencies` precedes `resolved`/`integrity`, defeating the tamper
detector entirely for that entry.

**Fix:** replace the flat pointer with a **stack of brace scopes**. Each object-header line pushes a frame (an
entry, or `null` for a container/root/other header); each closing brace pops one. Closing a nested sub-object
therefore restores the **enclosing entry** as the current one, so subsequent `resolved`/`integrity`/`version`
lines are still attributed to it regardless of key order. This is a parsing/state-tracking correction only:

- Entries stay keyed by their full `node_modules/...` path (#2692), so two same-named entries under different
  nesting paths remain independent.
- The legacy lockfileVersion-1 bare-name `dependencies` tree (`!sawPackagesEntry` branch) is unchanged.
- `LockfileTamperCandidate`'s shape, the module's public API, and the gate/finding wiring
  (`isConfiguredGateBlocker`) are untouched.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- Ran the full `npm run test:ci` gate plus `npm audit --audit-level=moderate` (0 vulnerabilities). `scanPackageLockPatch` is at 100% branch coverage on the changed lines (unsharded `npm run test:coverage`); the two new regression tests were confirmed to FAIL against the pre-fix source, so they genuinely pin the bug.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

Notes on the Safety boxes: this is a backend-only parsing correction to a deterministic supply-chain scanner — no UI, API/OpenAPI, or auth/CORS/session surface. The negative-path testing that applies is the scanner's own: the added tests cover the tamper-detected path (reordered keys), and the existing suite already covers the no-finding legitimate-bump path (unchanged and still passing). The fix strengthens a security check rather than relaxing one.

## UI Evidence

Not applicable — backend-only change to a diff parser; no visible UI, frontend, docs, or extension surface.

## Notes

- Regression tests (`test/unit/lockfile-tamper.test.ts`): (1) a `node_modules/lodash` entry whose `dependencies` sub-object precedes its `resolved`/`integrity`/`version` lines (key order reversed from real npm output) — asserts the unbumped-integrity tamper signal is still detected; (2) two distinct entries sharing the bare name `foo` (`node_modules/foo` and `node_modules/bar/node_modules/foo`), each with its own `dependencies` sub-object — the legitimate bump on the top-level `foo` does not mask the unbumped integrity edit on the nested `foo`, confirming the #2692 full-path keying and this nesting fix compose. Both new tests were verified to fail on the pre-fix source.
