### PR TITLE
fix(miner): honor --json on the discover --dry-run failure path

### DIFF
--- a/packages/loopover-miner/lib/discover-cli.js
+++ b/packages/loopover-miner/lib/discover-cli.js
@@ -200,8 +200,7 @@ export async function runDiscover(args, options = {}) {
       }
       return 0;
     } catch (error) {
-      console.error(error instanceof Error ? error.message : String(error));
-      return 2;
+      return reportCliFailure(parsed.json, describeCliError(error));
     }
   }
 

--- a/test/unit/miner-discover-cli.test.ts
+++ b/test/unit/miner-discover-cli.test.ts
@@ -427,6 +427,25 @@ describe("runDiscover (#4247)", () => {
     expect(error).toHaveBeenCalledWith("github_unreachable");
   });
 
+  it("#5830: --dry-run --json reports fan-out failures as a parseable {ok:false,error} object", async () => {
+    const initPortfolioQueue = vi.fn();
+    const fetchCandidateIssuesWithSummary = vi.fn(async () => {
+      throw new Error("github_unreachable");
+    });
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    const exitCode = await runDiscover(["acme/widgets", "--dry-run", "--json"], {
+      nowMs: NOW,
+      initPortfolioQueue,
+      fetchCandidateIssuesWithSummary,
+    });
+
+    expect(exitCode).toBe(2);
+    expect(initPortfolioQueue).not.toHaveBeenCalled();
+    const payload = JSON.parse(String(log.mock.calls[0]?.[0]));
+    expect(payload).toEqual({ ok: false, error: "github_unreachable" });
+  });
+
   it("#4847: --dry-run stringifies a thrown non-Error value instead of crashing", async () => {
     const fetchCandidateIssuesWithSummary = vi.fn(async () => {
       throw "raw_string_fault";


### PR DESCRIPTION
## Summary

`loopover-miner discover` supports `--json` for scripted callers, and its non-dry-run failure path routes through the shared `reportCliFailure(parsed.json, describeCliError(error))` helper, which emits a `{ ok: false, error }` object on stdout when `--json` is set. The `--dry-run` path (added in #4847) has its own separate catch block that bypasses that helper entirely — it always writes plain text to stderr and returns `2` regardless of `--json`:

```js
} catch (error) {
  console.error(error instanceof Error ? error.message : String(error));
  return 2;
}
```

So `loopover-miner discover <owner/repo> --dry-run --json` on a failure (GitHub API error, invalid target) prints an unparseable plain-text line instead of the JSON object every other failure path in this CLI — including this same command's non-dry-run catch 20 lines later — honors. The fix routes the dry-run catch through the same `reportCliFailure`/`describeCliError` pair (already imported in this file).

Closes #5830

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #5830`).

## Validation

- [x] `git diff --check` — clean
- [ ] `npm run actionlint` — no workflow changes
- [x] `npm run typecheck` — passes (whole project)
- [x] `npm run test:coverage` — the changed catch line is exercised by the new `--dry-run --json` regression test (JSON branch) and the existing `--dry-run` non-json failure tests (stderr branch), so `codecov/patch` on the diff is 100%. `test/unit/miner-discover-cli.test.ts` passes 42/42; the new test fails on the pre-fix code (which used `console.error`) and passes after.
- [ ] `npm run test:workers` — unaffected (no worker changes)
- [x] `npm run build:miner` — passes (`node --check` over the miner CLI incl. `discover-cli.js`)
- [x] `npm run test:miner-pack` — passes (package dry-run ok)
- [ ] `npm run build:mcp` / `test:mcp-pack` — unaffected (no MCP changes)
- [ ] `npm run ui:openapi:check` / `ui:lint` / `ui:typecheck` / `ui:build` — unaffected (no UI/OpenAPI changes)
- [ ] `npm audit --audit-level=moderate` — no dependency changes
- [x] New or changed behavior has unit tests — a `--dry-run --json` failure regression test asserting a parseable `{ ok: false, error }` object; the existing non-json failure tests (Error and non-Error thrown values) continue to pass unchanged

If any required check was skipped, explain why:

- Change is one catch block in `packages/loopover-miner/lib/discover-cli.js` plus its test. `describeCliError` is byte-identical to the previous inline `error instanceof Error ? error.message : String(error)` expression, so the non-`--json` path (stderr text, exit code 2) is behavior-preserving. I additionally ran `npm run engine-parity:drift-check` and the backend drift checks (`docs`, `manifest`, `command-reference`, `selfhost env-reference`), all green.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests — N/A (none).
- [x] API/OpenAPI/MCP behavior is updated and tested where needed — N/A (none).
- [x] UI changes use live API data or real empty/error/loading states — N/A (no UI changes).
- [x] Visible UI changes include a `UI Evidence` section — N/A (no UI/frontend/docs/extension changes).
- [x] Public docs/changelogs are updated where needed — N/A.

## Notes

- The two failure paths (`--dry-run` vs non-dry-run) now emit identical output for the same error and flags, so a scripted caller no longer gets different, sometimes-unparseable output depending on which nearly-identical branch it hits.
