### PR TITLE
fix(mcp): document LOOPOVER_LOGIN / GITHUB_LOGIN in loopover-mcp --help

### DIFF
--- a/packages/loopover-mcp/bin/loopover-mcp.js
+++ b/packages/loopover-mcp/bin/loopover-mcp.js
@@ -2603,6 +2603,7 @@ function printHelp() {
   LOOPOVER_PROFILE
   LOOPOVER_CONFIG_PATH or LOOPOVER_CONFIG_DIR
   LOOPOVER_API_TOKEN, LOOPOVER_MCP_TOKEN, LOOPOVER_TOKEN, or a session from loopover-mcp login
+  LOOPOVER_LOGIN or GITHUB_LOGIN (default --login for analyze-branch, preflight, review-pr, decision-pack, repo-decision, and agent plan/packet)
   GITHUB_TOKEN for non-interactive login bootstrap
   GITTENSOR_SCORE_PREVIEW_CMD
   GITTENSOR_ROOT

--- a/test/unit/mcp-cli-tools.test.ts
+++ b/test/unit/mcp-cli-tools.test.ts
@@ -74,4 +74,11 @@ describe("loopover-mcp CLI — tools", () => {
       expect(tool.description.trim().length).toBeGreaterThan(0);
     }
   });
+
+  it("documents LOOPOVER_LOGIN / GITHUB_LOGIN in the --help Environment block (#5930)", () => {
+    const help = run(["--help"]);
+    expect(help).toContain("Environment:");
+    // Six subcommands resolve the login from LOOPOVER_LOGIN (then GITHUB_LOGIN); help must list it.
+    expect(help).toMatch(/LOOPOVER_LOGIN or GITHUB_LOGIN/);
+  });
 });


### PR DESCRIPTION
Fixes #5930.

Six subcommands (`analyze-branch`/`preflight`, `review-pr`, `decision-pack`, `repo-decision`, and agent `plan`/`packet`) resolve the GitHub login from `options.login ?? process.env.LOOPOVER_LOGIN ?? process.env.GITHUB_LOGIN` and, when missing, throw `Pass --login <github-login> or set LOOPOVER_LOGIN.` — but the `--help` `Environment:` block never listed `LOOPOVER_LOGIN`.

Adds `LOOPOVER_LOGIN or GITHUB_LOGIN` (with the commands it applies to) to the Environment block, plus a test asserting `--help` documents it. Test passes; typecheck clean.