### PR TITLE
fix(miner): enforce maxConcurrentClaims before claiming an issue

### DIFF
--- a/packages/loopover-miner/lib/attempt-cli.js
+++ b/packages/loopover-miner/lib/attempt-cli.js
@@ -447,8 +447,54 @@ export async function runAttempt(args, options = {}) {
     const reputationHistory = readReputationHistory(parsed.repoFullName);
     const governor = buildAttemptGovernorContext(env, amsPolicy.spec, repoPaused, convergenceInput, reputationHistory);
 
+    // Real maxConcurrentClaims enforcement (#6056): the repo's .loopover-miner.yml cap is parsed and
+    // validated by resolveMinerGoalSpec above, but must be honored here before recording a new soft-claim.
+    const activeClaims = claimLedger.listActiveClaims(parsed.repoFullName);
+    if (activeClaims.length >= minerGoalSpec.spec.maxConcurrentClaims) {
+      const reason = "max_concurrent_claims_exceeded";
+      attemptLog.appendAttemptLogEvent({
+        eventType: "attempt_aborted",
+        attemptId,
+        actionClass: "open_pr",
+        mode,
+        reason,
+        payload: {
+          repoFullName: parsed.repoFullName,
+          issueNumber: parsed.issueNumber,
+          maxConcurrentClaims: minerGoalSpec.spec.maxConcurrentClaims,
+          activeClaimCount: activeClaims.length,
+        },
+      });
+      eventLedger.appendEvent({
+        type: "attempt_blocked",
+        repoFullName: parsed.repoFullName,
+        payload: { issueNumber: parsed.issueNumber, reason },
+      });
+      const blockedResult = {
+        outcome: "blocked_max_concurrent_claims",
+        reason,
+        maxConcurrentClaims: minerGoalSpec.spec.maxConcurrentClaims,
+        activeClaimCount: activeClaims.length,
+        repoFullName: parsed.repoFullName,
+        issueNumber: parsed.issueNumber,
+        minerLogin: parsed.minerLogin,
+        base: parsed.base,
+        mode,
+        attemptId,
+      };
+      if (parsed.json) {
+        console.log(JSON.stringify(blockedResult, null, 2));
+      } else {
+        console.error(
+          `Attempt for ${parsed.repoFullName}#${parsed.issueNumber} is blocked: this repo's maxConcurrentClaims cap (${minerGoalSpec.spec.maxConcurrentClaims}) is already met (${activeClaims.length} active claim(s)).`,
+        );
+      }
+      options.onResult?.(blockedResult);
+      return 11;
+    }
+
     // Real soft-claim (#5393): recorded once we've committed to a real attempt (past feasibility), so a
-    // sibling miner process on this machine sees it via claimLedger.listClaims/listActiveClaims while this
+    // sibling miner process on this machine sees it via claimLedger.listActiveClaims while this
     // attempt is in flight. Released in `finally` on every terminal outcome -- mirrors the worktree
     // allocation slot's own acquire-then-always-release pattern below. The real claimedAt this returns is
     // ALSO this miner's own claim-time for the post-submission conflict check further down (#4848).

--- a/test/unit/miner-attempt-cli.test.ts
+++ b/test/unit/miner-attempt-cli.test.ts
@@ -1580,6 +1580,27 @@ describe("runAttempt: maxConcurrentClaims enforcement (#6056)", () => {
     });
   });
 
+  it("REGRESSION: reports a human-readable message when the cap is already met", async () => {
+    const { allocator, claimLedger, eventLedger, attemptLog, governorLedger } = tempLedgers();
+    const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    claimLedger.claimIssue("acme/widgets", 99, "other-attempt");
+
+    const exitCode = await runAttempt(["acme/widgets", "7", "--miner-login", "alice"], {
+      env: { MINER_CODING_AGENT_PROVIDER: "noop" },
+      openWorktreeAllocator: () => allocator,
+      openClaimLedger: () => claimLedger,
+      initEventLedger: () => eventLedger,
+      initAttemptLog: () => attemptLog,
+      initGovernorLedger: () => governorLedger,
+      ...readyPipelineOptions(),
+    });
+
+    expect(exitCode).toBe(11);
+    expect(error).toHaveBeenCalledWith(
+      expect.stringContaining("maxConcurrentClaims cap (1) is already met (1 active claim(s))"),
+    );
+  });
+
   it("REGRESSION: honors --json on the maxConcurrentClaims rejection path", async () => {
     const { allocator, claimLedger, eventLedger, attemptLog, governorLedger } = tempLedgers();
     const onResult = vi.fn();

--- a/test/unit/miner-attempt-cli.test.ts
+++ b/test/unit/miner-attempt-cli.test.ts
@@ -1547,3 +1547,105 @@ describe("runAttempt: real claim-ledger wiring (#5393)", () => {
     expect(recordTransitionSpy).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("runAttempt: maxConcurrentClaims enforcement (#6056)", () => {
+  it("REGRESSION: rejects a new claim when the repo cap is already met (default maxConcurrentClaims: 1)", async () => {
+    const { allocator, claimLedger, eventLedger, attemptLog, governorLedger } = tempLedgers();
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    claimLedger.claimIssue("acme/widgets", 99, "other-attempt");
+    const claimIssueSpy = vi.spyOn(claimLedger, "claimIssue");
+
+    const exitCode = await runAttempt(["acme/widgets", "7", "--miner-login", "alice", "--json"], {
+      env: { MINER_CODING_AGENT_PROVIDER: "noop" },
+      openWorktreeAllocator: () => allocator,
+      openClaimLedger: () => claimLedger,
+      initEventLedger: () => eventLedger,
+      initAttemptLog: () => attemptLog,
+      initGovernorLedger: () => governorLedger,
+      ...readyPipelineOptions({
+        runMinerAttempt: async () => ({ outcome: "abandon", loopResult: fakeLoopResult() }),
+      }),
+    });
+
+    expect(exitCode).toBe(11);
+    expect(claimIssueSpy).not.toHaveBeenCalled();
+    const payload = JSON.parse(String(log.mock.calls.at(-1)?.[0]));
+    expect(payload).toMatchObject({
+      outcome: "blocked_max_concurrent_claims",
+      reason: "max_concurrent_claims_exceeded",
+      maxConcurrentClaims: 1,
+      activeClaimCount: 1,
+      repoFullName: "acme/widgets",
+      issueNumber: 7,
+    });
+  });
+
+  it("REGRESSION: honors --json on the maxConcurrentClaims rejection path", async () => {
+    const { allocator, claimLedger, eventLedger, attemptLog, governorLedger } = tempLedgers();
+    const onResult = vi.fn();
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    claimLedger.claimIssue("acme/widgets", 99, "other-attempt");
+
+    const exitCode = await runAttempt(["acme/widgets", "7", "--miner-login", "alice", "--json"], {
+      env: { MINER_CODING_AGENT_PROVIDER: "noop" },
+      openWorktreeAllocator: () => allocator,
+      openClaimLedger: () => claimLedger,
+      initEventLedger: () => eventLedger,
+      initAttemptLog: () => attemptLog,
+      initGovernorLedger: () => governorLedger,
+      ...readyPipelineOptions(),
+      onResult,
+    });
+
+    expect(exitCode).toBe(11);
+    expect(onResult).toHaveBeenLastCalledWith(expect.objectContaining({ outcome: "blocked_max_concurrent_claims" }));
+  });
+
+  it("REGRESSION: proceeds when active claims are below the configured cap", async () => {
+    const { allocator, claimLedger, eventLedger, attemptLog, governorLedger } = tempLedgers();
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const claimIssueSpy = vi.spyOn(claimLedger, "claimIssue");
+    claimLedger.claimIssue("acme/widgets", 99, "other-attempt");
+
+    const exitCode = await runAttempt(["acme/widgets", "7", "--miner-login", "alice", "--json"], {
+      env: { MINER_CODING_AGENT_PROVIDER: "noop" },
+      openWorktreeAllocator: () => allocator,
+      openClaimLedger: () => claimLedger,
+      initEventLedger: () => eventLedger,
+      initAttemptLog: () => attemptLog,
+      initGovernorLedger: () => governorLedger,
+      ...readyPipelineOptions({
+        resolveMinerGoalSpec: () => ({
+          present: true,
+          spec: { ...DEFAULT_MINER_GOAL_SPEC, maxConcurrentClaims: 2 },
+          warnings: [],
+        }),
+        runMinerAttempt: async () => ({ outcome: "abandon", loopResult: fakeLoopResult() }),
+      }),
+    });
+
+    expect(exitCode).toBe(7);
+    expect(claimIssueSpy).toHaveBeenCalledWith("acme/widgets", 7, expect.stringMatching(/^attempt:/));
+  });
+
+  it("REGRESSION: proceeds with the default cap when there are zero prior active claims", async () => {
+    const { allocator, claimLedger, eventLedger, attemptLog, governorLedger } = tempLedgers();
+    vi.spyOn(console, "log").mockImplementation(() => undefined);
+    const claimIssueSpy = vi.spyOn(claimLedger, "claimIssue");
+
+    const exitCode = await runAttempt(["acme/widgets", "7", "--miner-login", "alice", "--json"], {
+      env: { MINER_CODING_AGENT_PROVIDER: "noop" },
+      openWorktreeAllocator: () => allocator,
+      openClaimLedger: () => claimLedger,
+      initEventLedger: () => eventLedger,
+      initAttemptLog: () => attemptLog,
+      initGovernorLedger: () => governorLedger,
+      ...readyPipelineOptions({
+        runMinerAttempt: async () => ({ outcome: "abandon", loopResult: fakeLoopResult() }),
+      }),
+    });
+
+    expect(exitCode).toBe(7);
+    expect(claimIssueSpy).toHaveBeenCalledWith("acme/widgets", 7, expect.stringMatching(/^attempt:/));
+  });
+});


### PR DESCRIPTION
## Summary
- Enforce the repo-scoped `maxConcurrentClaims` cap in `attempt-cli.js` by counting active claims via `listActiveClaims` before `claimIssue`.
- When the cap is met, abort cleanly with a `--json`-contract-compliant `blocked_max_concurrent_claims` outcome (exit 11), matching the existing pre-claim abort pattern.
- Add regression tests covering cap met, cap not met, default-with-zero-prior-claims, and `--json` on the rejection path.

Closes #6056

## Test plan
- [x] `npm test -- test/unit/miner-attempt-cli.test.ts` (all maxConcurrentClaims tests pass)
- [ ] CI green including codecov/patch