### PR TITLE
fix(miner): stop hooks check --tool/--input consuming an adjacent flag as their value

### DIFF
--- a/packages/loopover-miner/lib/deny-check.js
+++ b/packages/loopover-miner/lib/deny-check.js
@@ -34,12 +34,14 @@ export function parseDenyCheckArgs(args) {
     }
     if (token === "--tool" || token === "--name") {
       const tool = args[++index];
-      if (!tool) return { error: "Missing value for --tool." };
+      if (!tool || tool.startsWith("-")) return { error: "Missing value for --tool." };
       options.tool = tool;
       continue;
     }
     if (token === "--input") {
-      const parsed = parseToolInput(args[++index]);
+      const raw = args[++index];
+      if (!raw || raw.startsWith("-")) return { error: "Missing value for --input." };
+      const parsed = parseToolInput(raw);
       if ("error" in parsed) return { error: parsed.error };
       options.input = parsed.value;
       continue;

--- a/test/unit/miner-cli-deny-check.test.ts
+++ b/test/unit/miner-cli-deny-check.test.ts
@@ -27,6 +27,18 @@ describe("loopover-miner hooks check command", () => {
     });
   });
 
+  it("parseDenyCheckArgs rejects a flag consumed as another flag's value (#5833)", () => {
+    // --tool/--input must not swallow an adjacent flag as their value; each reports the specific
+    // "Missing value" error rather than falling through to the generic usage string.
+    expect(parseDenyCheckArgs(["--tool"])).toEqual({ error: "Missing value for --tool." });
+    expect(parseDenyCheckArgs(["--tool", "--input", "{}"])).toEqual({ error: "Missing value for --tool." });
+    expect(parseDenyCheckArgs(["--name", "--json"])).toEqual({ error: "Missing value for --tool." });
+    expect(parseDenyCheckArgs(["--tool", "Write", "--input"])).toEqual({ error: "Missing value for --input." });
+    expect(parseDenyCheckArgs(["--tool", "Write", "--input", "--json"])).toEqual({
+      error: "Missing value for --input.",
+    });
+  });
+
   it("runDenyCheck exits 1 when a built-in rule blocks the call", () => {
     const error = vi.spyOn(console, "error").mockImplementation(() => undefined);
     expect(


### PR DESCRIPTION
## Summary

`parseDenyCheckArgs` in `packages/loopover-miner/lib/deny-check.js` consumed the next token unconditionally for its `--tool`/`--name` and `--input` branches, with no check that the consumed token is itself a flag. So `loopover-miner hooks check --tool --input '{}'` silently set `options.tool = "--input"`, and the loop's next iteration hit the literal `'{}'` — which matches no known flag and doesn't start with `-` — falling through to the generic `DENY_CHECK_USAGE` string instead of the specific, actionable `Missing value for --tool.` error this file already uses for the same class of mistake.

Every sibling flag parser in this package already guards this: `attempt-cli.js` (`if (!value || value.startsWith("-")) ...`) and `claim-ledger-cli.js` (four instances). This PR adds that same guard to both value-consuming branches, rejecting `--input`'s value **before** it is JSON-parsed. Messages reuse this file's existing conventions (`Missing value for --tool.` / `Missing value for --input.`, the latter already emitted by `parseToolInput` for a missing value).

Closes #5833

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (`Closes #5833`).

## Validation

- [x] `git diff --check` — clean
- [ ] `npm run actionlint` — no workflow changes
- [x] `npm run typecheck` — passes (whole project)
- [x] `npm run test:coverage` — both arms of **both** new guards are exercised (`!value` via `--tool` / `--tool Write --input` with no value; `value.startsWith("-")` via `--tool --input {}`, `--name --json`, and `--tool Write --input --json`), and the pass-through arm by the existing valid-parse tests, so `codecov/patch` on the diff is 100% branch-counted. `test/unit/miner-cli-deny-check.test.ts` passes 5/5; the new test fails on the pre-fix code and passes after, with all four pre-existing tests unchanged and green on both.
- [ ] `npm run test:workers` — unaffected (no worker changes)
- [x] `npm run build:miner` — passes (`node --check` over the miner CLI incl. `deny-check.js`)
- [x] `npm run test:miner-pack` — passes (package dry-run ok)
- [ ] `npm run build:mcp` / `test:mcp-pack` — unaffected (no MCP changes)
- [ ] `npm run ui:openapi:check` / `ui:lint` / `ui:typecheck` / `ui:build` — unaffected (no UI/OpenAPI changes)
- [ ] `npm audit --audit-level=moderate` — no dependency changes
- [x] New or changed behavior has unit tests — a regression test covering a flag consumed as `--tool`'s value, as `--name`'s value, and as `--input`'s value, plus both missing-value cases, each asserting the specific "Missing value" error rather than the generic usage fallback

If any required check was skipped, explain why:

- Change is two guard conditions in `packages/loopover-miner/lib/deny-check.js` plus its test. It introduces no workflow, MCP, UI, OpenAPI, or dependency changes. I additionally ran `npm run engine-parity:drift-check` and the backend drift checks (`docs`, `manifest`, `command-reference`, `selfhost env-reference`), all green.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests — N/A (none).
- [x] API/OpenAPI/MCP behavior is updated and tested where needed — N/A (none).
- [x] UI changes use live API data or real empty/error/loading states — N/A (no UI changes).
- [x] Visible UI changes include a `UI Evidence` section — N/A (no UI/frontend/docs/extension changes).
- [x] Public docs/changelogs are updated where needed — N/A.

## Notes

- Behavior is unchanged for every well-formed invocation: the guard only fires where the parser previously mis-assigned a flag as a value (or had no value at all), so the existing tests pass untouched. `hooks check` now reports the same specific, actionable error the rest of the package's flag parsers already give.
