### PR TITLE
docs(claude): gardening backlog floor is continuous + milestone/relationship discipline

### DIFF
--- a/.claude/skills/contributor-pipeline-gardening/SKILL.md
+++ b/.claude/skills/contributor-pipeline-gardening/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: contributor-pipeline-gardening
 description: >-
-  Daily maintenance of the contributor issue pipeline for JSONbored/gittensory (renaming to
-  loopover) — closing issues that are already done but not marked so, and topping up the
-  contributor-available backlog with well-scoped new issues. Invoke for "run the daily issue
-  gardening", "audit open issues for stale/complete ones", "generate new contributor issues",
-  or any recurring/scheduled run of this process. `reference.md` (next to this file) has the
-  exhaustive label/milestone/template detail — read it before doing real work, not just this file.
+  Maintenance of the contributor issue pipeline for JSONbored/gittensory (renamed to loopover) —
+  closing issues that are already done but not marked so, and keeping the contributor-available
+  backlog at its 50-100+ steady-state floor with well-scoped new issues. Runs every ~8h via the
+  scheduled task (raised from daily on 2026-07-15 so the floor is maintained continuously, not
+  caught up once a day). Invoke for "run the issue gardening", "audit open issues for
+  stale/complete ones", "generate new contributor issues", or any recurring/scheduled run of this
+  process. `reference.md` (next to this file) has the exhaustive label/milestone/template detail —
+  read it before doing real work, not just this file.
 ---
 
 # Contributor pipeline gardening — gittensory / loopover
@@ -46,17 +48,19 @@ assume it keeps happening, don't assume today's backlog is clean.
 
 ## Pass 2 — backlog top-up
 
-**Target: keep this repo's own contributor-available count (unassigned, no `maintainer-only`, carries a `gittensor:*` label) at 50-100+, independently of metagraphed's count** — this is NOT a combined/shared pool across the two repos; each repo needs its own 50-100+ on its own goals. Compute it fresh: `gh issue list --state open --limit 1000 --json number,labels,assignees` and filter.
+**Target: keep this repo's own contributor-available count (unassigned, no `maintainer-only`, carries a `gittensor:*` label) at 50-100+, AT ALL TIMES, independently of metagraphed's count** — this is a steady-state floor to maintain continuously, not a one-time catch-up, and NOT a combined/shared pool across the two repos; each repo needs its own 50-100+ on its own goals. Compute it fresh: `gh issue list --state open --limit 1000 --json number,labels,assignees` and filter.
+
+**If the count is meaningfully under floor, keep sourcing issues until it clears (or a pass genuinely turns up no more real, non-duplicate gaps) — don't stop at a modest first batch.** "Quality over volume" (point 6 below) means don't pad with weak/duplicate/vague issues, it does not mean stopping early once *a* well-scoped batch is filed. When under floor: extend an already-proven, well-precedented vein first if one exists (e.g. a REST/GraphQL/MCP parity sweep with many remaining candidates — the fastest path to more verified, non-padded issues), then dispatch parallel subsystem-audit agents across distinct areas of the codebase once that's exhausted.
 
 1. **Read `reference.md`'s "what's safe to unleash" framework first.** The single most common mistake is generating architecture/business-decision issues (hosted multi-tenant SaaS design, billing, SLAs, pricing) that must stay `maintainer-only` — this repo has ~90 such issues already correctly gated and the automation must not erode that boundary. Concrete engineering work with a clear existing precedent to follow is the target; open-ended product/business decisions are not.
 2. Pick real gaps to scope from, in priority order:
    - Existing open epics/roadmap issues in this repo that don't yet have enough decomposed child issues to be actionable (e.g. `ORB - Long Term Features & Improvements`, the review-comment-redesign family, any epic whose own body describes scope with no filed sub-issues yet).
    - Genuine gaps found by reading the current codebase against a shipped feature's own stated acceptance criteria (the same technique Pass 1 uses to verify closure — used here in reverse, to find what's NOT yet done).
    - AMS selfhost hardening is a named standing priority — see `reference.md`. The unified AMS+ORB selfhost harness is now scoped and issue-backed (#5996, epic #6012) as of 2026-07-15 — check its sub-issues' completion state before assuming this still needs fresh scoping.
-3. Every new issue gets: the correct existing milestone (creating a new one requires a genuinely-unfitting body of work AND is a much higher bar than it sounds — see `reference.md`'s milestone-discipline note; when in doubt, fold into the closest existing bucket and say so rather than create one), a `gittensor:bug` (0.05x), `gittensor:feature` (0.25x), or `gittensor:priority` (1.5x, reserved for mission-critical/time-sensitive work only — this repo uses it sparingly, unlike metagraphed's looser convention, see `reference.md`) label, plus `help wanted` (the maintainer confirmed this stays as a visibility signal alongside the points label, not a replacement for one).
+3. **Every new issue gets a real milestone — no issue ships unmilestoned.** Default to the correct existing milestone (see `reference.md`'s milestone taxonomy). Creating a new one requires a genuinely-unfitting body of work AND is a much higher bar than it sounds — see `reference.md`'s milestone-discipline note; when in doubt, fold into the closest existing bucket and say so. A new milestone is justified when nothing existing fits AND the work is either a real major initiative or a recurring category that will keep needing a home (e.g. `Miner Wave 4.5 — AMS Hardening Round 2`, created 2026-07-15 for the recurring post-Wave-4 gap-audit rounds this skill files each run) — a one-off oddity alone isn't enough. Also apply a `gittensor:bug` (0.05x), `gittensor:feature` (0.25x), or `gittensor:priority` (1.5x, reserved for mission-critical/time-sensitive work only — this repo uses it sparingly, unlike metagraphed's looser convention, see `reference.md`) label, plus `help wanted` (the maintainer confirmed this stays as a visibility signal alongside the points label, not a replacement for one).
 4. Every new issue body follows the template in `reference.md` — Context, Requirements, Deliverables, Test Coverage Requirements (this repo's Codecov patch gate is 99%+, hard — every new issue implicitly inherits this unless it's `apps/**`-only UI work), Expected Outcome. No "left to interpretation" scope — the maintainer's own stated preference is that thin/ambiguous issue bodies are worse than fewer, complete ones. **The review gate only enforces what the issue text explicitly says** — see `reference.md`'s dedicated section on this; any deliverable with a file-type/path/format constraint (docs as website pages vs. markdown, native relationships vs. checklists, etc.) needs that constraint stated as an explicit, standalone rule, not left implied by Context.
-5. Link relationships using GitHub's native features, not prose: `addSubIssue` to attach a new issue under its parent epic, `addBlockedBy` when an issue genuinely cannot start before another lands. Only use these where a real dependency exists — don't chain issues into an artificial order to look organized.
-6. Quality over the number. If a scan doesn't turn up enough genuinely well-scoped, non-redundant, correctly-boundaried issues in this repo alone to keep its own count in the 50-100+ range on a given day, file fewer rather than pad with weak ones — note the shortfall in the daily digest instead.
+5. **Check every new batch for real relationships, then link them with GitHub's native features, not prose or a checklist:** `addSubIssue` to attach a new issue under its parent epic, `addBlockedBy` when an issue genuinely cannot start before another lands. The check itself is the discipline — most independent bug-fix/feature-parity issues (e.g. a batch of REST/GraphQL-mirror additions) genuinely have no dependency on each other, and forcing a link where none exists is worse than no link. Only connect issues where a contributor would actually be blocked or misled by working them out of order.
+6. Quality over the number in what gets filed — don't pad with weak, duplicate, or vaguely-scoped issues just to hit a count. This is NOT license to stop early: if the repo is meaningfully under the 50-100 floor, keep sourcing real, well-scoped issues (see the "if under floor" note above) until it clears or a pass genuinely turns up nothing left to scope — only then note a shortfall in the digest.
 
 ## Daily digest
 

--- a/.claude/skills/contributor-pipeline-gardening/reference.md
+++ b/.claude/skills/contributor-pipeline-gardening/reference.md
@@ -40,19 +40,27 @@ Two products, self-host-first:
 |---|---|---|
 | `Miner Wave N — <theme>` (no suffix) | A finished or active AMS-hardening-style wave | Mostly yes once released |
 | `Miner Wave N — <theme> (maintainer)` | Business/legal/architecture track (currently Wave 5, Rent-a-Loop) | Mostly no — but check individual issues, some concrete implementation sub-tasks are deliberately carved out and unlocked even inside a `(maintainer)`-titled milestone |
+| `Miner Wave 4.5 — AMS Hardening Round 2` | **New, created 2026-07-15.** The home for recurring post-Wave-4 gap-audit findings in `packages/loopover-miner`/`packages/loopover-engine` — correctness bugs, unenforced documented contracts, stale comments, small hardening gaps. Every future "AMS selfhost hardening round N" audit files here, not a fresh milestone each time. | Yes — same shape as Wave 4's own contributor-open issues |
 | `AMS Cloud Readiness (maintainer)` | Hosted **multi-tenant SaaS** AMS — NOT the same thing as "AMS selfhost hardening" despite the name similarity | Mostly no (architecture/billing/SLA decisions) — a handful of pure research-spike/audit/load-test issues are deliberately contributor-eligible; check labels per-issue |
 | `ORB Cloud Readiness (maintainer)` | Same shape, for ORB's hosted SaaS story | Mostly no, same caveat — the first several issues in this milestone (#4878-4884-style, "extract X into gittensory-engine") are often pure refactors miscategorized here, not actually tenant/business-specific — read the body, not just the milestone |
 | `ORB - Long Term Features & Improvements` | Grab-bag: some genuine self-host feature/bug work, some product-design epics awaiting maintainer subjective calls | Mixed — read each body |
 | `LoopOver Rebrand Migration (maintainer)` | Brand/infra cutover | No |
-| Unmilestoned | Orphans | Usually fine to fold into the closest-fitting existing milestone above rather than leave adrift |
+| Unmilestoned | Should be rare — every gardening-generated issue gets a real milestone (see below) | If you find one, fold it into the closest-fitting existing milestone rather than leave it adrift |
 
-**Don't invent a new milestone reflexively — confirmed the hard way, 2026-07-15.** When scoping the
-unified AMS+ORB harness epic (#6012) into an 11-issue docs-porting body of work, a new milestone was
-created for it; the maintainer immediately reverted this and folded the epic into the existing
-`ORB - Long Term Features & Improvements` grab-bag instead. Treat "this genuinely doesn't fit any
-existing bucket" as a much higher bar than it sounds — even an epic-sized new initiative should
-default to the closest existing milestone unless explicitly told otherwise. If a new milestone still
-seems warranted, propose it and wait for confirmation rather than creating it unilaterally.
+**Every gardening-generated issue gets a milestone — none ship unmilestoned.** Default to the
+closest-fitting existing one. Creating a new milestone is a much higher bar than it sounds — confirmed
+the hard way, 2026-07-15: when scoping the unified AMS+ORB harness epic (#6012) into an 11-issue
+docs-porting body of work, a new milestone was created for it; the maintainer immediately reverted
+this and folded the epic into the existing `ORB - Long Term Features & Improvements` grab-bag instead.
+A new milestone is warranted only when nothing existing fits AND the work is either a genuinely major
+initiative or a **recurring category that will keep needing a home** — the latter is why `Miner Wave
+4.5 — AMS Hardening Round 2` (above) was created the same day as the #6012 revert, for the opposite
+reason: this skill's own AMS-hardening gap-audits recur every run now (see the raised cadence in
+`SKILL.md`), so a durable bucket is the correct call, not a one-off exception. A single one-off oddity
+alone is not enough justification. When genuinely unsure and the call is high-stakes (a new milestone,
+not routine label/relationship choices), it's fine to propose 1-2 options — but default to deciding and
+documenting the reasoning (in the issue body or milestone description) rather than blocking a run on
+confirmation, per the maintainer's own stated preference (2026-07-15): "figure it out yourself."
 
 ## What's safe to unleash — the actual test
 
@@ -157,6 +165,15 @@ issue (e.g. #5215-5230) for the exact pattern. Gardening-generated contributor i
 always be the heavier template; the light one is for issues you're explicitly NOT unlocking.
 
 ## Native relationship linking (GraphQL — confirmed working on this repo, 2026-07-14)
+
+**Check every new batch of issues for a real dependency before moving on — this is a required step,
+not an optional nicety** (reinforced by the maintainer, 2026-07-15: relationship links "can be
+valuable/important in guiding users to work on specific things in the correct order"). Most batches of
+independent bug-fixes or parity additions (e.g. a set of REST/GraphQL-mirror issues, each adding one
+unrelated field) genuinely have no dependency on each other — in that case the correct outcome of the
+check is "no links needed," not a forced one. Reserve `addBlockedBy` for a real case where working an
+issue out of order would waste a contributor's time or produce broken intermediate state, and
+`addSubIssue` for anything that's genuinely a piece of a parent epic/tracker.
 
 Prefer these over a markdown checklist for any new tracker/epic:
 


### PR DESCRIPTION
## Summary
- The contributor-pipeline-gardening skill's 50-100+ per-repo target is a steady-state floor to maintain continuously (scheduled task cadence raised from daily to every 8h same day), not a one-time catch-up — a top-up pass should keep sourcing real, well-scoped issues until the floor clears rather than stopping at a modest first batch.
- Every gardening-generated issue now must get a real milestone (adds `Miner Wave 4.5 — AMS Hardening Round 2` as the durable home for recurring post-Wave-4 gap-audit findings, since Wave 4 itself is closed at 151/151).
- Reinforces that checking for real GitHub-native `blocked-by`/sub-issue relationships is a required step on every new batch (most independent bug-fix/parity batches genuinely need none — the check itself is the discipline).

## Test plan
- [x] Docs-only change under `.claude/skills/**` — no code/schema/UI touched, outside Codecov's `src/**` coverage scope.