### PR TITLE
docs(miner): correct three comments describing gaps that no longer exist

### DIFF
--- a/packages/loopover-engine/src/governor/reputation-throttle.ts
+++ b/packages/loopover-engine/src/governor/reputation-throttle.ts
@@ -19,7 +19,9 @@ export type SelfReputationThresholds = {
   minCadenceFactor: number;
 };
 
-/** Conservative built-in defaults; a `.loopover-miner.yml` override is merged over these. */
+/** Conservative built-in defaults. No config-file override surface exists today: `.loopover-miner.yml` parses
+ *  into ams-policy-spec.ts, which carries no reputation fields, so these are overridden only by a partial config
+ *  passed programmatically to {@link resolveSelfReputationThresholds} by a caller that already has one. */
 export const DEFAULT_SELF_REPUTATION_THRESHOLDS: SelfReputationThresholds =
   Object.freeze({
     minSampleSize: 5,
@@ -64,7 +66,8 @@ function round3(value: number): number {
 }
 
 /**
- * Merge a partial (e.g. `.loopover-miner.yml`-sourced) threshold config over the conservative defaults,
+ * Merge a caller-supplied partial threshold config over the conservative defaults (no config-file surface feeds
+ * this today -- see {@link DEFAULT_SELF_REPUTATION_THRESHOLDS}),
  * normalizing every field so a malformed value can never produce a NaN/negative/out-of-range decision. The
  * throttle band is kept well-formed: `floorAtRatio` is pulled to at least `throttleAtRatio` so the interpolation
  * span is never negative.

--- a/packages/loopover-engine/src/miner/iterate-loop.ts
+++ b/packages/loopover-engine/src/miner/iterate-loop.ts
@@ -56,8 +56,10 @@ export type IterateLoopInput = {
   maxTurnsPerIteration: number;
   /** Optional cumulative budget ceiling(s), evaluated every iteration against the real running totals
    *  (attempt-metering.ts's `AttemptMeterTotals`, #5395). Omitted means no additional ceiling beyond what
-   *  `maxIterations * maxTurnsPerIteration` already implies. A breach on any axis (turns/costUsd/wallClockMs
-   *  -- tokens is never real-tracked today) is a HARD, unconditional stop: checked and abandoned on BEFORE
+   *  `maxIterations * maxTurnsPerIteration` already implies. A breach on any axis (turns/costUsd/wallClockMs/
+   *  tokens -- every axis is accumulated from real per-iteration driver usage, tokens included since #5653, and
+   *  is 0 only when the driver genuinely reports no signal) is a HARD, unconditional stop: checked and
+   *  abandoned on BEFORE
    *  self-review even runs, so a same-iteration pass can never bypass the ceiling (this is deliberately NOT
    *  routed through iterate-policy.ts's `costCeilingReached` field, whose own precedence checks a self-review
    *  pass first -- see the loop body's own comment at the check site for why that ordering doesn't fit a hard

--- a/packages/loopover-miner/lib/attempt-runner.js
+++ b/packages/loopover-miner/lib/attempt-runner.js
@@ -20,13 +20,15 @@ import { captureMinerError } from "./sentry.js";
 // (worktree-allocator.js, #4297) -- this module composes the create/review/gate/submit sequence #2337 is
 // actually about, not worktree allocation policy, which is a separate, already-solved concern.
 //
-// KNOWN, DELIBERATE GAP (not silently papered over -- was an injected-but-unwired seam before this module
-// existed, and remains so here):
-//   - `deps.runSlopAssessment` has no production implementation anywhere in this package. The real slop scorer
-//     (src/signals/slop.ts, 518 lines, 5 sibling src/signals/** dependencies) is far larger and more
-//     interconnected than local-write-tools.ts was, so extracting it is separate, substantial scope -- this
-//     function requires a real one be injected rather than silently stubbing a result that would either always
-//     pass (unsafe) or always fail (useless).
+// `deps.runSlopAssessment` stays INJECTED rather than imported here (this module composes the sequence and is
+// agnostic about the scorer behind the seam), but it is no longer unwired: slop-assessment.js (#5133) is its
+// real production binding -- a direct pass-through to the engine's own buildSlopAssessment -- and attempt-cli.js
+// wires that binding in on the production path. The seam was injected-but-unwired when this module was written
+// only because the deterministic scorer was not yet portable; #5133 extracted src/signals/slop.ts's PR-side
+// scorer into packages/loopover-engine/src/signals/slop.ts (byte-parity-verified against the live gate's own
+// copy), closing the gap this header used to document. This function still requires a real implementation be
+// injected rather than silently stubbing a result that would either always pass (unsafe) or always fail
+// (useless).
 //
 // `input.governor`'s cross-attempt state (rate-limit buckets, backoff attempts, budget-cap usage) DOES now
 // persist across separate process invocations (#5134, governor-state.js), via


### PR DESCRIPTION
## Summary

Closes #6059

Three doc comments describe gaps/limitations that are no longer true — the code moved on, the comment didn't. Each was re-verified against current `main` before changing it. None is a behavioral bug; each actively misleads a reader (human or AI agent) scoping work off these files into re-discovering an already-closed gap, or believing a config surface exists that doesn't.

**1. `packages/loopover-miner/lib/attempt-runner.js`** — the `KNOWN, DELIBERATE GAP` header claimed `deps.runSlopAssessment` *"has no production implementation anywhere in this package."*

Verified false: `packages/loopover-miner/lib/slop-assessment.js` (#5133) is a real production binding (a direct pass-through to the engine's `buildSlopAssessment`), and `attempt-cli.js:134` already wires it in as the injected `runSlopAssessment`. The header is corrected to say the seam is still **injected** (that part is deliberate and stays documented — this module composes the sequence and stays agnostic about the scorer) but is no longer **unwired**, and records why it once was: the deterministic scorer only became portable when #5133 extracted `src/signals/slop.ts` into `packages/loopover-engine/src/signals/slop.ts`.

**2. `packages/loopover-engine/src/governor/reputation-throttle.ts`** — `DEFAULT_SELF_REPUTATION_THRESHOLDS` claimed *"a `.loopover-miner.yml` override is merged over these."*

Verified false: `.loopover-miner.yml` parses into `ams-policy-spec.ts`, which has **zero** reputation-related fields, and there is no `reputationThreshold`/`SelfReputationThresholds` reference anywhere in `packages/loopover-miner/`. The described override capability does not exist. `resolveSelfReputationThresholds`'s own doc repeated the same `.loopover-miner.yml` claim, so **both** are corrected to describe the real contract: a caller-supplied partial config. (Fixing only the first would have left the same false claim intact ten lines below, defeating the issue's stated outcome.)

**3. `packages/loopover-engine/src/miner/iterate-loop.ts`** — the `budget` field's doc claimed *"tokens is never real-tracked today."*

Verified false, and self-contradicting within the same file: the accumulation site (~line 134) and `finalMeterTotals`'s own doc (~lines 407-411) both describe real per-iteration token tracking added in #5653. `tokens` is also a real `AttemptBudgetAxis` with a corresponding `AttemptBudget.maxTokens` ceiling (`attempt-metering.ts`), so it is a genuine budget axis.

## Scope

- [x] Conventional Commit title (`docs(miner): …`).
- [x] **Comment-only** — no runtime code changed, per the issue's explicit requirement. Mechanically verified: every added/removed line in the diff is a comment line.
- [x] Each corrected comment keeps its file's existing style and level of detail (issue-number anchors, the same explanatory depth) rather than being shortened into a throwaway one-liner.
- [x] Follows `CONTRIBUTING.md`; no `site/`/`CNAME`/`lovable` changes; no changelog edit.
- [x] Linked open issue (Closes #6059, above).

## Validation

- [x] `git diff --check` clean.
- [x] `npm run typecheck` — exit 0.
- [x] `npm run build:miner` — exit 0.
- [x] Suites for the touched files green: `miner-attempt-runner`, `reputation-throttle`, `reputation-wiring` — **72 tests passed**.
- [x] **No coverage surface**: the diff changes zero executable lines, so no `.ts`/`.js` line/branch coverage can move. Verified mechanically over the whole diff, not just by inspection.

If any required check was skipped, explain why:

- Full `test:ci` not run end-to-end locally (Linux-only steps on Windows).
- `test/unit/iterate-loop-load-test-script.test.ts` fails to parse locally (`SyntaxError`) in this Windows environment. Confirmed **pre-existing on a clean checkout of `main`** with these changes stashed, so it is unrelated to this diff (which cannot introduce a syntax error, being comment-only).

## Safety

- [x] No secrets, wallets, hotkeys, trust scores, rewards, private rankings, or private maintainer evidence.
- [x] No auth/cookie/CORS/GitHub App/session change.
- [x] No behavior change of any kind — comments only. No API/OpenAPI/MCP change; no schema change; no generated artifact affected.
- [x] No UI changes; no changelog edit.
