### PR TITLE
fix(selfhost): correct stale gittensory_ metric names in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -403,8 +403,8 @@ REDIS_URL=redis://redis:6379                # REQUIRED for the self-host review 
 #                                            #   host can reasonably go to 8-12 before the loops' own CPU work
 #                                            #   (JSON parsing, diff rendering, AI-response handling) starts
 #                                            #   competing for the cycles the I/O awaits were supposed to free up.
-#                                            #   Watch gittensory_queue_live_pending
-#                                            #   / gittensory_queue_oldest_live_pending_age_seconds after raising it;
+#                                            #   Watch loopover_queue_live_pending
+#                                            #   / loopover_queue_oldest_live_pending_age_seconds after raising it;
 #                                            #   if those stay high, the bottleneck is elsewhere (GitHub rate limit,
 #                                            #   AI latency, Postgres pool -- see PGPOOL_MAX above), not concurrency.
 # QUEUE_BACKGROUND_CONCURRENCY=1             # max low-priority/background jobs allowed to occupy QUEUE_CONCURRENCY slots

--- a/test/unit/env-example-metric-names.test.ts
+++ b/test/unit/env-example-metric-names.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+describe(".env.example metric-name references (#5936)", () => {
+  it("references only the real loopover_ metric prefix, never the stale gittensory_ one, in queue tuning guidance", () => {
+    const env = readFileSync(join(process.cwd(), ".env.example"), "utf8");
+    // Prometheus metric names in this codebase are snake_case (src/selfhost/metrics.ts); a `gittensory_<word>`
+    // shape anywhere in this file is stale doc drift left over from the gittensory -> loopover rebrand -- the
+    // rebranded metric family only ever registers under the `loopover_` prefix.
+    expect(env).not.toMatch(/gittensory_[a-z_]+/);
+    expect(env).toContain("loopover_queue_live_pending");
+    expect(env).toContain("loopover_queue_oldest_live_pending_age_seconds");
+  });
+});


### PR DESCRIPTION
## Summary

- `.env.example`'s `QUEUE_CONCURRENCY` tuning comment told operators to watch `gittensory_queue_live_pending` / `gittensory_queue_oldest_live_pending_age_seconds` — neither metric exists under that prefix. The rebrand only ever registered `loopover_queue_live_pending` (`src/selfhost/metrics.ts`) and `loopover_queue_oldest_live_pending_age_seconds` (same file, and used in `prometheus/rules/alerts.yml`'s real alert expressions).
- Corrects both metric names in the comment block; no other change to the guidance itself.
- Adds a regression test (`test/unit/env-example-metric-names.test.ts`) asserting `.env.example` never references the stale `gittensory_<metric>` shape again, and positively pins the two corrected metric names.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

Closes #5936

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- The local machine is under persistent memory contention from multiple concurrent processes (several other active dev sessions on the same box), and the full `npm run test:ci` chain's local `tsc --noEmit` step OOM-crashes repeatedly regardless of heap tuning (confirmed reproducible even in isolation with a 1.8GB heap). This PR changes zero `.ts`/`.js` source — only `.env.example` (a comment/config file) and one new self-contained test file using patterns already proven elsewhere in the suite (`readFileSync`/`join`/`.env.example`, mirroring `test/unit/selfhost-grafana-sentry-datasource.test.ts`'s own `.env.example` assertion). What I *could* run locally (`actionlint`, `db:migrations:check`, `git diff --check`, `npm audit`, and the new test in isolation via `npx vitest run`) is green; I manually verified the new test actually catches the regression by temporarily reintroducing the stale `gittensory_` names and confirming it fails, then restored the fix and confirmed it passes. CI's `validate`/`validate-code`/`validate-tests` checks run on GitHub's own isolated runners with no such contention and will independently confirm the rest (typecheck included) before merge.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

Not applicable: this is a config-comment + test-only change, no UI/auth/session/API surface touched.

## Notes

-
