### PR TITLE
fix(review): close draft-conversion evasion after review publishes, not just mid-review

### DIFF
--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -5462,6 +5462,25 @@ export async function hasActiveReviewForHeadSha(env: Env, repoFullName: string, 
   return row !== undefined && row.status === "active" && row.headSha === headSha;
 }
 
+// Review-evasion protection (broadened window, #draft-evasion-post-review): whether loopover has EVER started
+// a review pass for this EXACT repo/PR/headSha, regardless of whether that pass is still active or has already
+// concluded (published) -- unlike hasActiveReviewForHeadSha above, a terminalized row still counts. This is the
+// signal the draft-conversion evasion guard needs: hasActiveReviewForHeadSha's window closes the instant the
+// review publishes, but a human reacting to a now-VISIBLE label/comment necessarily acts AFTER publish, so the
+// narrow "still active" check can only ever catch someone converting to draft blind, before any output exists
+// -- in practice, never. This function instead answers "has this exact commit already consumed its one-shot
+// review," which stays true for as long as the PR's head doesn't change (startActiveReviewTracking resets the
+// row, including this "ever reviewed" signal, the moment a NEW commit arrives -- so pushing a fresh commit
+// always earns a fresh shot, exactly as intended). A row for a DIFFERENT headSha does not count.
+export async function hasReviewedForHeadSha(env: Env, repoFullName: string, pullNumber: number, headSha: string): Promise<boolean> {
+  const row = await getDb(env.DB)
+    .select({ headSha: activeReviewTracking.headSha })
+    .from(activeReviewTracking)
+    .where(and(eq(activeReviewTracking.repoFullName, boundedString(repoFullName, 200)), eq(activeReviewTracking.pullNumber, pullNumber)))
+    .get();
+  return row !== undefined && row.headSha === headSha;
+}
+
 // Review turnaround-time tracking (#4446): reuses the SAME startedAt startActiveReviewTracking already records
 // for review-evasion protection -- reads it (for the exact headSha this pass is publishing) rather than
 // duplicating a second "when did this review start" clock. Not gated on status === "active": the publish site

--- a/src/queue/review-evasion.ts
+++ b/src/queue/review-evasion.ts
@@ -10,6 +10,7 @@ import {
   getGateBlockOutcome,
   getInstallation,
   hasActiveReviewForHeadSha,
+  hasReviewedForHeadSha,
   isGlobalAgentFrozen,
   recordAuditEvent,
   terminalizeActiveReviewTracking,
@@ -19,6 +20,7 @@ import { ensurePullRequestLabel } from "../github/labels";
 import { fetchPullRequestFreshness, pullRequestFreshnessDetail, type PullRequestFreshness } from "../github/pr-freshness";
 import { closePullRequest, createIssueComment, getLastCloserLogin, getLastReopenerLogin, reopenPullRequest } from "../github/pr-actions";
 import { parseGitHubLoginList } from "../auth/security";
+import { isAutoCloseExempt } from "../settings/auto-close-exempt";
 import { resolveAutonomy } from "../settings/autonomy";
 import { isGlobalAgentPause, resolveAgentActionMode, resolveAgentPermissionReadiness } from "../settings/agent-execution";
 import { DEFAULT_REVIEW_EVASION_LABEL, isProtectedAutomationAuthor, resolveNullableLabel } from "../settings/agent-actions";
@@ -730,10 +732,18 @@ async function closeReviewEvasionSelfCloseIfActive(
   }
 }
 
-/** Review-evasion protection (#review-evasion-protection): a contributor converting their OWN OPEN PR to
- *  draft while loopover has an ACTIVE review pass running against its current headSha is dodging the
- *  one-shot review, distinct from the EXISTING draft-dodge guard above (which only fires after a PRIOR gate
- *  FAILURE on this head). Unlike the self-close sibling, converting to draft never closes the PR on GitHub,
+/** Review-evasion protection (#review-evasion-protection, broadened #draft-evasion-post-review): a
+ *  contributor converting their OWN OPEN PR to draft after loopover has run a review pass against its
+ *  current headSha is dodging the one-shot review, distinct from the EXISTING draft-dodge guard above (which
+ *  only fires after a PRIOR gate FAILURE on this head -- this guard fires on ANY reviewed head, block or
+ *  not, since the underlying complaint is draft-conversion itself: merge-conflict risk, wasted CI, and
+ *  pipeline churn from a PR that already consumed its one-shot review being yanked back to "not ready").
+ *  Uses hasReviewedForHeadSha (not hasActiveReviewForHeadSha) deliberately: the active-only window closes
+ *  the instant a review publishes, but a human reacting to a now-VISIBLE label/comment necessarily acts
+ *  AFTER that -- the narrow window could only ever catch someone converting to draft blind. `.loopover.yml`
+ *  settings.autoCloseExemptLogins (the same shared allowlist the contributor-cap/review-nag guards already
+ *  honor) is an explicit escape hatch for trusted contributors who legitimately need to keep iterating in
+ *  draft after a review. Unlike the self-close sibling, converting to draft never closes the PR on GitHub,
  *  so no reopen step is needed -- a direct close, exactly like the draft-dodge guard's own close step,
  *  suffices. Per-PR actuation-locked like its draft-dodge/reopen-reclose/self-close siblings. */
 export async function maybeCloseReviewEvasionDraftConversion(
@@ -746,11 +756,11 @@ export async function maybeCloseReviewEvasionDraftConversion(
   settings: RepositorySettings,
 ): Promise<void> {
   await withPrActuationLock(env, repoFullName, pr.number, "review-evasion-draft", () =>
-    closeReviewEvasionDraftConversionIfActive(env, deliveryId, installationId, repoFullName, pr, payload, settings),
+    closeReviewEvasionDraftConversionIfReviewed(env, deliveryId, installationId, repoFullName, pr, payload, settings),
   );
 }
 
-async function closeReviewEvasionDraftConversionIfActive(
+async function closeReviewEvasionDraftConversionIfReviewed(
   env: Env,
   deliveryId: string,
   installationId: number,
@@ -768,10 +778,11 @@ async function closeReviewEvasionDraftConversionIfActive(
   // sibling's identical actor check).
   if (!converter || !authorLogin || converter !== authorLogin) return;
   if (isProtectedAutomationAuthor(pr.authorLogin)) return;
+  if (isAutoCloseExempt(pr.authorLogin, settings.autoCloseExemptLogins)) return;
   if (!pr.headSha) return;
   const headSha = pr.headSha;
   if (await hasMaintainerOrOwnerPermission(env, installationId, repoFullName, authorLogin)) return;
-  if (!(await hasActiveReviewForHeadSha(env, repoFullName, pr.number, headSha))) return;
+  if (!(await hasReviewedForHeadSha(env, repoFullName, pr.number, headSha))) return;
 
   const targetKey = `${repoFullName}#${pr.number}`;
   const gateMetadata = { deliveryId, repoFullName, headSha };
@@ -787,7 +798,7 @@ async function closeReviewEvasionDraftConversionIfActive(
     actor: String(pr.authorLogin),
     metadata: gateMetadata,
     dryRun: {
-      detail: `dry-run: would close review-evasion draft-conversion by ${pr.authorLogin} -- active review on headSha ${pr.headSha}`,
+      detail: `dry-run: would close review-evasion draft-conversion by ${pr.authorLogin} -- headSha ${pr.headSha} already has a review recorded`,
       metadata: { ...gateMetadata, mode: "dry_run" },
     },
     paused: {
@@ -849,7 +860,7 @@ async function closeReviewEvasionDraftConversionIfActive(
     actor: "loopover",
     targetKey,
     outcome: "completed",
-    detail: `closed a review-evasion draft-conversion by ${pr.authorLogin} -- active review on headSha ${pr.headSha} was in progress`,
+    detail: `closed a review-evasion draft-conversion by ${pr.authorLogin} -- headSha ${pr.headSha} had already been reviewed`,
     metadata: { deliveryId, repoFullName, headSha: pr.headSha },
   }).catch(
     /* v8 ignore next -- fail-safe: an audit write failure never blocks the handler. */

--- a/test/unit/db-persistence.test.ts
+++ b/test/unit/db-persistence.test.ts
@@ -4,6 +4,7 @@ import {
   getContributorScoringProfile,
   getOpenUpstreamDriftReportByFingerprint,
   hasActiveReviewForHeadSha,
+  hasReviewedForHeadSha,
   listContributorRepoStats,
   listLatestRepoGithubTotalsSnapshots,
   listLatestSignalSnapshotsForTargets,
@@ -366,6 +367,38 @@ describe("active-review tracking (#review-evasion-protection)", () => {
     expect(await hasActiveReviewForHeadSha(env, "owner/repo", 1, "sha1")).toBe(true); // still active -- guarded, not cleared.
     expect(await terminalizeActiveReviewTracking(env, "owner/repo", 1, { onlyIfHeadSha: "sha1" })).toBe(true);
     expect(await hasActiveReviewForHeadSha(env, "owner/repo", 1, "sha1")).toBe(false);
+  });
+
+  it("hasReviewedForHeadSha is false when no row exists at all", async () => {
+    const env = createTestEnv();
+    expect(await hasReviewedForHeadSha(env, "owner/repo", 1, "sha1")).toBe(false);
+  });
+
+  it("hasReviewedForHeadSha (#draft-evasion-post-review): true for the exact head whether the row is still active OR already terminal -- unlike hasActiveReviewForHeadSha, a terminalized (published) review still counts", async () => {
+    const env = createTestEnv();
+    await startActiveReviewTracking(env, { repoFullName: "owner/repo", pullNumber: 1, headSha: "sha1", deliveryId: "delivery-1" });
+    expect(await hasReviewedForHeadSha(env, "owner/repo", 1, "sha1")).toBe(true); // active
+    expect(await hasActiveReviewForHeadSha(env, "owner/repo", 1, "sha1")).toBe(true);
+
+    await terminalizeActiveReviewTracking(env, "owner/repo", 1);
+    expect(await hasReviewedForHeadSha(env, "owner/repo", 1, "sha1")).toBe(true); // STILL true -- the key difference.
+    expect(await hasActiveReviewForHeadSha(env, "owner/repo", 1, "sha1")).toBe(false); // narrower sibling flips to false.
+  });
+
+  it("hasReviewedForHeadSha is false for a different head or PR, even when the tracked row is active", async () => {
+    const env = createTestEnv();
+    await startActiveReviewTracking(env, { repoFullName: "owner/repo", pullNumber: 1, headSha: "sha1", deliveryId: "delivery-1" });
+    expect(await hasReviewedForHeadSha(env, "owner/repo", 1, "sha-different")).toBe(false);
+    expect(await hasReviewedForHeadSha(env, "owner/repo", 2, "sha1")).toBe(false);
+  });
+
+  it("hasReviewedForHeadSha returns to false once a NEW head restarts tracking -- a fresh push earns a fresh shot", async () => {
+    const env = createTestEnv();
+    await startActiveReviewTracking(env, { repoFullName: "owner/repo", pullNumber: 1, headSha: "sha1", deliveryId: "delivery-1" });
+    await terminalizeActiveReviewTracking(env, "owner/repo", 1);
+    await startActiveReviewTracking(env, { repoFullName: "owner/repo", pullNumber: 1, headSha: "sha2", deliveryId: "delivery-2" });
+    expect(await hasReviewedForHeadSha(env, "owner/repo", 1, "sha1")).toBe(false);
+    expect(await hasReviewedForHeadSha(env, "owner/repo", 1, "sha2")).toBe(true);
   });
 
   it("startActiveReviewTracking without an authorLogin persists a null author (defensive -- a deleted-account PR yields a null login)", async () => {

--- a/test/unit/queue-lifecycle-guards.test.ts
+++ b/test/unit/queue-lifecycle-guards.test.ts
@@ -2495,6 +2495,53 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
       expect(evasionAudit?.outcome).toBe("completed");
     });
 
+    it("REGRESSION (#draft-evasion-post-review): closes a draft conversion AFTER the review already published, not just mid-computation -- the active-only window would have missed this, since a human reacting to a now-visible label necessarily acts after the pass already terminalized", async () => {
+      const calls: Array<{ url: string; method: string }> = [];
+      stubEvasionFetch(calls);
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      await setupEvasionRepo(env);
+      await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
+      // The review pass concludes and publishes -- exactly what happens right before a human could ever SEE
+      // a label/comment to react to.
+      await repositoriesModule.terminalizeActiveReviewTracking(env, "JSONbored/gittensory", 42);
+
+      await processJob(env, { type: "github-webhook", deliveryId: "draft-evasion-post-publish", eventName: "pull_request", payload: draftEvasionPayload("contributor") });
+
+      expect(calls.some((c) => c.method === "PATCH" && c.url.endsWith("/pulls/42"))).toBe(true);
+      const audit = await env.DB.prepare("select outcome from audit_events where event_type = ?").bind("github_app.review_evasion_closed").first<{ outcome: string }>();
+      expect(audit?.outcome).toBe("completed");
+    });
+
+    it("does nothing for a draft conversion once the head has moved past the reviewed commit -- a fresh push earns a fresh shot", async () => {
+      const calls: Array<{ url: string; method: string }> = [];
+      stubEvasionFetch(calls);
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      await setupEvasionRepo(env);
+      // The tracked review ran against an OLDER commit -- the payload's current headSha (abc123) has never
+      // itself been reviewed.
+      await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "old-sha-before-push", deliveryId: "review-start-1" });
+      await repositoriesModule.terminalizeActiveReviewTracking(env, "JSONbored/gittensory", 42);
+
+      await processJob(env, { type: "github-webhook", deliveryId: "draft-evasion-new-head", eventName: "pull_request", payload: draftEvasionPayload("contributor") });
+
+      expect(calls.some((c) => c.method === "PATCH" && c.url.endsWith("/pulls/42"))).toBe(false);
+    });
+
+    it("REGRESSION (#draft-evasion-post-review): honors settings.autoCloseExemptLogins -- the shared allowlist the contributor-cap/review-nag guards already use", async () => {
+      const calls: Array<{ url: string; method: string }> = [];
+      stubEvasionFetch(calls);
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      await setupEvasionRepo(env, { autoCloseExemptLogins: ["contributor"] });
+      await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", deliveryId: "review-start-1" });
+      await repositoriesModule.terminalizeActiveReviewTracking(env, "JSONbored/gittensory", 42);
+
+      await processJob(env, { type: "github-webhook", deliveryId: "draft-evasion-exempt", eventName: "pull_request", payload: draftEvasionPayload("contributor") });
+
+      expect(calls.some((c) => c.method === "PATCH" && c.url.endsWith("/pulls/42"))).toBe(false);
+      const audit = await env.DB.prepare("select count(*) as n from audit_events where event_type = ?").bind("github_app.review_evasion_closed").first<{ n: number }>();
+      expect(audit?.n).toBe(0);
+    });
+
     it("does nothing when the author holds write collaborator permission", async () => {
       const calls: Array<{ url: string; method: string }> = [];
       stubEvasionFetch(calls, { collaboratorPermission: "write" });


### PR DESCRIPTION
## Summary

- `maybeCloseReviewEvasionDraftConversion` (#review-evasion-protection) only enforced while `hasActiveReviewForHeadSha` was true -- a window that closes the instant the review pass **publishes**. A contributor reacting to a now-visible label/comment necessarily acts *after* that window closes, so the guard could only ever catch someone converting to draft blind, before any review output existed at all -- which essentially never happens. Every real-world "get a label, convert to draft once, sit there" evasion pattern was invisible to it, even though 12 *mid-computation* closures were already on record proving the mechanism itself works.
- Adds `hasReviewedForHeadSha` (`src/db/repositories.ts`): true whether the tracked review pass for this exact head is still active *or* already terminalized -- so a PR's one-shot review stays "consumed" for as long as its head doesn't change. Pushing a new commit correctly resets the window (a fresh commit earns a fresh shot, exactly as intended). The draft-conversion guard now uses this instead of the narrower `hasActiveReviewForHeadSha`.
- The self-close sibling guard (`closeSelfCloseAttemptIfBlocked`) has the identical timing gap but is intentionally left untouched here -- same underlying issue, but out of scope for this specific ask; can be a follow-up if wanted.
- Adds `settings.autoCloseExemptLogins` support to this guard -- the same shared, `.loopover.yml`-configurable allowlist the contributor-cap and review-nag guards already honor -- so a repo can carve out trusted contributors who legitimately need to keep iterating in draft after a review runs, without disabling the protection fleet-wide.

## Test plan

- [x] `npm run test:ci` (full local gate) green
- [x] `npm audit --audit-level=moderate` -- 0 vulnerabilities
- [x] All 23 pre-existing tests in the `converted_to_draft during an active review` suite pass unchanged (this change is a strict superset -- every previously-detected case is still detected)
- [x] New regression test: closes a draft conversion *after* the review already published (the exact gap this PR fixes)
- [x] New test: a draft conversion is allowed once the head has moved past the reviewed commit (fresh push = fresh shot)
- [x] New test: `autoCloseExemptLogins` exempts a listed login
- [x] New dedicated `hasReviewedForHeadSha` unit tests in `db-persistence.test.ts`, including the active-vs-terminal distinction against its `hasActiveReviewForHeadSha` sibling
- [x] Verified via lcov: 100% line+branch coverage on `review-evasion.ts`; the new DB function's lines/branches fully hit