### PR TITLE
fix(orb): add per-row identifying context to relay bulk-delete drop logs

### DIFF
--- a/src/orb/relay.ts
+++ b/src/orb/relay.ts
@@ -266,8 +266,21 @@ const RELAY_PENDING_MAX_PER_INSTALLATION = 500;
 
 export type RelayPendingEvent = { deliveryId: string; eventName: string; rawBody: string };
 
+// Bulk-delete drop logs (this function and retryFailedRelays below) sample at most this many rows' identifying
+// info — an operator needs to see WHICH installation(s) lost events without a direct DB query, but a busy prune
+// can span hundreds of rows, so the log payload itself must stay bounded.
+const RELAY_DROP_LOG_SAMPLE_SIZE = 20;
+
 /** Drop pull-mode rows that exceeded the raw-body retention window, even if their engine never polls. */
 async function pruneRelayPending(env: Env): Promise<number> {
+  // Sampled BEFORE the delete: a plain DELETE reports only a count, and the rows are unrecoverable once gone.
+  // Same WHERE predicate as the delete below, capped so a large backlog can't inflate the log payload.
+  const expiring = await env.DB
+    .prepare(
+      "SELECT delivery_id, event_name, installation_id FROM orb_relay_pending WHERE created_at < datetime('now', '-' || ? || ' hours') ORDER BY created_at, delivery_id LIMIT ?",
+    )
+    .bind(RELAY_PENDING_TTL_HOURS, RELAY_DROP_LOG_SAMPLE_SIZE)
+    .all<{ delivery_id: string; event_name: string; installation_id: number }>();
   const pruned = await env.DB
     .prepare("DELETE FROM orb_relay_pending WHERE created_at < datetime('now', '-' || ? || ' hours')")
     .bind(RELAY_PENDING_TTL_HOURS)
@@ -275,7 +288,13 @@ async function pruneRelayPending(env: Env): Promise<number> {
   // Make pull-mode loss VISIBLE too (parity with the push-path drop): a pruned row is a webhook a long-down tailnet
   // container never drained — emit an alertable error-level log (distinct event name) so it leaves a Sentry trace.
   if (pruned.meta.changes > 0) {
-    console.error(JSON.stringify({ level: "error", event: "orb_relay_pending_dropped", message: `${pruned.meta.changes} pull-mode webhook(s) expired undrained after ${RELAY_PENDING_TTL_HOURS}h`, count: pruned.meta.changes }));
+    console.error(JSON.stringify({
+      level: "error",
+      event: "orb_relay_pending_dropped",
+      message: `${pruned.meta.changes} pull-mode webhook(s) expired undrained after ${RELAY_PENDING_TTL_HOURS}h`,
+      count: pruned.meta.changes,
+      sample: expiring.results.map((r) => ({ deliveryId: r.delivery_id, eventName: r.event_name, installationId: r.installation_id })),
+    }));
   }
   return pruned.meta.changes;
 }
@@ -387,7 +406,14 @@ export async function storeRelayFailure(
  *  is removed. Never throws — a bad DB row or a persistently-down container is dropped (with an alertable log,
  *  below) after exhaustion. */
 export async function retryFailedRelays(env: Env, opts?: { fetchImpl?: typeof fetch }): Promise<void> {
-  // Prune rows whose TTL has elapsed or whose attempt budget is exhausted.
+  // Prune rows whose TTL has elapsed or whose attempt budget is exhausted. Sampled BEFORE the delete (see
+  // pruneRelayPending above) so the drop log can name WHICH events were given up on.
+  const expiring = await env.DB
+    .prepare(
+      "SELECT delivery_id, event_name, installation_id FROM orb_relay_failures WHERE expires_at < datetime('now') OR attempts >= ? ORDER BY created_at, delivery_id LIMIT ?",
+    )
+    .bind(RELAY_RETRY_MAX_ATTEMPTS, RELAY_DROP_LOG_SAMPLE_SIZE)
+    .all<{ delivery_id: string; event_name: string; installation_id: number }>();
   const pruned = await env.DB
     .prepare("DELETE FROM orb_relay_failures WHERE expires_at < datetime('now') OR attempts >= ?")
     .bind(RELAY_RETRY_MAX_ATTEMPTS)
@@ -396,7 +422,13 @@ export async function retryFailedRelays(env: Env, opts?: { fetchImpl?: typeof fe
   // retries exhausted) — e.g. a container down for over an hour. Emit an alertable structured log so the loss
   // leaves a trace instead of vanishing silently.
   if (pruned.meta.changes > 0) {
-    console.error(JSON.stringify({ level: "error", event: "orb_relay_events_dropped", message: `${pruned.meta.changes} relay event(s) dropped after ${RELAY_RETRY_MAX_ATTEMPTS} retries or 1h TTL`, count: pruned.meta.changes }));
+    console.error(JSON.stringify({
+      level: "error",
+      event: "orb_relay_events_dropped",
+      message: `${pruned.meta.changes} relay event(s) dropped after ${RELAY_RETRY_MAX_ATTEMPTS} retries or 1h TTL`,
+      count: pruned.meta.changes,
+      sample: expiring.results.map((r) => ({ deliveryId: r.delivery_id, eventName: r.event_name, installationId: r.installation_id })),
+    }));
   }
   // Skip rows still inside their per-failure backoff window (#1950): a row whose last attempt was under
   // RELAY_RETRY_BACKOFF_MINUTES ago waits for a later tick, so a down container is not re-POSTed every ~2 min.

--- a/test/integration/orb-relay.test.ts
+++ b/test/integration/orb-relay.test.ts
@@ -527,8 +527,29 @@ describe("retryFailedRelays", () => {
     await retryFailedRelays(e);
     const row = await db(e).prepare("SELECT delivery_id FROM orb_relay_failures WHERE delivery_id='exhausted-1'").first();
     expect(row ?? null).toBeNull(); // pruned on the DELETE pass before the SELECT
-    // The drop is no longer silent OR warn-only — an alertable level:error log reaches the Sentry forwarder.
-    expect(errLog.mock.calls.some(([line]) => String(line).includes("orb_relay_events_dropped") && String(line).includes('"level":"error"'))).toBe(true);
+    // The drop is no longer silent OR warn-only — an alertable level:error log reaches the Sentry forwarder, and
+    // now names the dropped row so an operator can tell WHICH installation lost an event (#relay-drop-context).
+    const line = String(errLog.mock.calls.find(([l]) => String(l).includes("orb_relay_events_dropped"))?.[0]);
+    expect(line).toContain('"level":"error"');
+    expect(line).toContain('"deliveryId":"exhausted-1"');
+    expect(line).toContain('"eventName":"pull_request"');
+    expect(line).toContain('"installationId":9300');
+  });
+
+  it("caps the drop-log sample while `count` still reports the true total (#relay-drop-context)", async () => {
+    const e = brokeredEnv();
+    const errLog = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    for (let i = 0; i < 25; i += 1) {
+      await db(e)
+        .prepare("INSERT INTO orb_relay_failures (delivery_id, event_name, installation_id, raw_body, attempts) VALUES (?, ?, ?, ?, ?)")
+        .bind(`cap-${String(i).padStart(2, "0")}`, "pull_request", 9301, "{}", 5)
+        .run();
+    }
+    await retryFailedRelays(e);
+    const line = errLog.mock.calls.find(([l]) => String(l).includes("orb_relay_events_dropped"))?.[0];
+    const parsed = JSON.parse(String(line)) as { count: number; sample: unknown[] };
+    expect(parsed.count).toBe(25); // the real total, from the DELETE itself
+    expect(parsed.sample).toHaveLength(20); // capped at RELAY_DROP_LOG_SAMPLE_SIZE, not an unbounded dump
   });
 
   it("PRUNES expired rows (expires_at in the past) without attempting to forward", async () => {
@@ -844,8 +865,29 @@ describe("pullRelayPending", () => {
     expect(events.map((ev) => ev.deliveryId)).toEqual(["fresh-1"]); // the 25h-old row was pruned (TTL 24h)
     const stale = await db(e).prepare("SELECT delivery_id FROM orb_relay_pending WHERE delivery_id='stale-1'").first();
     expect(stale ?? null).toBeNull();
-    // Pull-mode loss is now traced for the operator at error level (parity with the push-path drop).
-    expect(errLog.mock.calls.some(([line]) => String(line).includes("orb_relay_pending_dropped") && String(line).includes('"level":"error"'))).toBe(true);
+    // Pull-mode loss is now traced for the operator at error level (parity with the push-path drop), and names
+    // the dropped row so an operator can tell WHICH installation lost a webhook (#relay-drop-context).
+    const line = String(errLog.mock.calls.find(([l]) => String(l).includes("orb_relay_pending_dropped"))?.[0]);
+    expect(line).toContain('"level":"error"');
+    expect(line).toContain('"deliveryId":"stale-1"');
+    expect(line).toContain('"eventName":"pull_request"');
+    expect(line).toContain('"installationId":9706');
+  });
+
+  it("caps the drop-log sample while `count` still reports the true total (#relay-drop-context)", async () => {
+    const e = brokeredEnv();
+    const errLog = vi.spyOn(console, "error").mockImplementation(() => undefined);
+    for (let i = 0; i < 25; i += 1) {
+      await db(e)
+        .prepare("INSERT INTO orb_relay_pending (delivery_id, installation_id, event_name, raw_body, created_at) VALUES (?, ?, ?, ?, datetime('now', '-25 hours'))")
+        .bind(`cap-${String(i).padStart(2, "0")}`, 9707, "pull_request", "{}")
+        .run();
+    }
+    await pullRelayPending(e, 9707);
+    const line = errLog.mock.calls.find(([l]) => String(l).includes("orb_relay_pending_dropped"))?.[0];
+    const parsed = JSON.parse(String(line)) as { count: number; sample: unknown[] };
+    expect(parsed.count).toBe(25); // the real total, from the DELETE itself
+    expect(parsed.sample).toHaveLength(20); // capped at RELAY_DROP_LOG_SAMPLE_SIZE, not an unbounded dump
   });
 });
 


### PR DESCRIPTION
## Summary
- `pruneRelayPending` and `retryFailedRelays`'s prune step each dropped expired/exhausted `orb_relay_pending`/`orb_relay_failures` rows with a bulk `DELETE` and logged only a bare count (`orb_relay_pending_dropped` / `orb_relay_events_dropped`), unlike this same file's `logRelayTransientSkip`, which already names `deliveryId`/`eventName`/`installationId` per event.
- An operator seeing one of these alertable `level:error` logs had no way to tell WHICH installation(s) lost webhook events without a direct DB query.
- Both prune paths now run a `SELECT` (identical `WHERE` predicate as the delete, capped at `RELAY_DROP_LOG_SAMPLE_SIZE` = 20 rows) immediately before the `DELETE`, and include that sample in the existing structured log alongside the already-accurate `count`.
- Deliberately NOT using `DELETE ... RETURNING` for this: I could not confirm Cloudflare D1 supports it (SQLite has had `RETURNING` since 3.35, and this codebase's Postgres self-host path already uses it elsewhere via `pg-queue.ts`, but Cloudflare's own D1 docs neither confirm nor deny it), and this is hot relay code for the central Orb broker — a bad assumption here would break `enqueueRelayPending`/`pullRelayPending`/`retryFailedRelays` outright. Both tables are architecturally kept small (TTL + per-installation caps), so the extra `SELECT` is cheap.

## Test plan
- [x] Extended both existing drop-log tests to assert the sample carries the correct `deliveryId`/`eventName`/`installationId`.
- [x] Added a new test per prune path proving the sample is capped at 20 while `count` still reports the true total (25 rows inserted, `sample.length === 20`, `count === 25`).
- [x] `npx vitest run test/integration/orb-relay.test.ts test/unit/orb-relay-policy.test.ts` — 90/90 passed.
- [x] `--coverage --coverage.include=src/orb/relay.ts` — 100% statements/branches/functions/lines.
- [x] Full local `npm run test:ci` gate green.