### PR TITLE
chore: fix gittensory -> loopover rename residue in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LoopOver
 
-_Formerly LoopOver._
+_Formerly Gittensory._
 
 <p align="center">
   <a href="https://github.com/JSONbored/loopover/actions/workflows/ci.yml"><img alt="CI" src="https://github.com/JSONbored/loopover/actions/workflows/ci.yml/badge.svg" /></a>

--- a/config/examples/README.md
+++ b/config/examples/README.md
@@ -6,7 +6,7 @@ contains no real policy, thresholds, logins, or repo names — copy what you nee
 mounted config directory and edit it there (never in this repo).
 
 See **[TEMPLATES.md](./TEMPLATES.md)** for the full template catalog (minimal + exhaustive
-`gittensory.yml` starters, public-vs-private usage, and fleet notes for `gittensory`,
+`loopover.yml` starters, public-vs-private usage, and fleet notes for `loopover`,
 `awesome-claude`, and `metagraphed` without committing private policy).
 
 The private config directory is read by `src/selfhost/private-config.ts` and is kept **out of the

--- a/config/examples/TEMPLATES.md
+++ b/config/examples/TEMPLATES.md
@@ -69,7 +69,7 @@ Point `LOOPOVER_REPO_CONFIG_DIR` at that directory (default `/config` in `docker
 These patterns apply to common JSONbored repos. **Do not copy real maintainer logins or thresholds
 into public git** — use the private mount for anything marked *private* below.
 
-### `JSONbored/gittensory` (dogfooding)
+### `JSONbored/loopover` (dogfooding)
 
 - **Public** `.loopover.yml` in the repo: work-area guardrails, test expectations, gate dimensions
   contributors should understand.
@@ -89,7 +89,7 @@ into public git** — use the private mount for anything marked *private* below.
 
 ### `JSONbored/metagraphed` (sibling product repo)
 
-- Same split as `gittensory`: public manifest for transparent contributor guidance; private mount
+- Same split as `loopover`: public manifest for transparent contributor guidance; private mount
   for thresholds and maintainer-only rules.
 - Use `repo-override.loopover.yml` when one repo needs different `expectedCiContexts` or
   `gate.checkMode: disabled` while sharing a fleet-wide `global.loopover.yml` baseline.


### PR DESCRIPTION
Closes #6074. Small, mechanical, prose-only.

## Summary
- `README.md:3` read *"Formerly LoopOver."* — self-referential nonsense; now correctly credits the actual former name, Gittensory.
- `config/examples/README.md` referred to the manifest starter as `gittensory.yml` and named `gittensory` in a fleet-notes list, inconsistent with the SAME file's own line 17 ("The canonical manifest filename is **`.loopover.yml`**").
- `config/examples/TEMPLATES.md` had a `### \`JSONbored/gittensory\` (dogfooding)` section heading and a `"Same split as \`gittensory\`"` reference — both should say `loopover`/`JSONbored/loopover`, matching every other template reference in the same file (`.loopover.yml`, `loopover.minimal.yml`, `loopover-config/`, etc.).

## Deliberately NOT touched
- The docs badge domain (`gittensory.aethereal.dev`) — per prior rename-status context, the website/cloud-presentation layer is a distinct, intentionally-hardcoded surface from the engine rename; I don't have confirmation this domain itself was renamed (vs. the GitHub repo/npm packages/directory paths, which were), so changing it risked breaking a real working link rather than fixing residue. Flagging rather than guessing.
- The legacy comment renderer's `<!-- gittensory-pr-panel:v1 -->` HTML marker — this is load-bearing for the comment-upsert match logic (`markerAliases()`), so a straight rename risks orphaning in-flight PR comments; it needs an additive alias, not a rename, and is better handled alongside whatever comes out of #6073 (the legacy-renderer-retirement investigation) rather than as an isolated prose fix.

## Test plan
- [x] `npm run docs:drift-check` — pass
- [x] `git diff --check` clean
- [x] Grepped every root doc (`SUPPORT.md`, `CODE_OF_CONDUCT.md`, `SECURITY.md`, `CONTRIBUTING.md`, `AGENTS.md`) for the same self-referential rename bug — none found