### PR TITLE
fix(miner): bound GitHub reads in the attempt-gating path with a per-request timeout

### DIFF
--- a/packages/loopover-miner/lib/ci-poller.d.ts
+++ b/packages/loopover-miner/lib/ci-poller.d.ts
@@ -23,6 +23,7 @@ export type PollCheckRunsOptions = {
   maxAttempts?: number;
   minIntervalMs?: number;
   maxIntervalMs?: number;
+  requestTimeoutMs?: number;
   sleepFn?: (delayMs: number) => Promise<unknown>;
 };
 

--- a/packages/loopover-miner/lib/ci-poller.js
+++ b/packages/loopover-miner/lib/ci-poller.js
@@ -4,6 +4,7 @@ const defaultApiBaseUrl = "https://api.github.com";
 const defaultMinIntervalMs = 60_000;
 const defaultMaxIntervalMs = 5 * 60_000;
 const defaultMaxAttempts = 1;
+const defaultRequestTimeoutMs = 10_000;
 const githubApiVersion = "2022-11-28";
 
 function normalizeApiBaseUrl(value) {
@@ -37,6 +38,7 @@ function normalizeOptions(options = {}) {
     maxAttempts: normalizePositiveInt(options.maxAttempts, defaultMaxAttempts, 1, 20),
     minIntervalMs: normalizePositiveInt(options.minIntervalMs, defaultMinIntervalMs, 1, 60 * 60_000),
     maxIntervalMs: normalizePositiveInt(options.maxIntervalMs, defaultMaxIntervalMs, 1, 60 * 60_000),
+    requestTimeoutMs: normalizePositiveInt(options.requestTimeoutMs, defaultRequestTimeoutMs, 1, 60_000),
     sleepFn:
       options.sleepFn ??
       ((delayMs) => new Promise((resolve) => setTimeout(resolve, delayMs))),
@@ -85,12 +87,13 @@ function githubError(response, payload) {
 
 async function githubGetJsonResponse(url, options) {
   // Retry transient network errors / 5xx around this single call (#4829), distinct from the poller's own
-  // pending-retry loop; the poller's injected sleepFn keeps tests instant.
+  // pending-retry loop; the poller's injected sleepFn keeps tests instant. requestTimeoutMs bounds each
+  // individual attempt (a stalled connection previously hung this call forever -- #miner-github-read-timeouts).
   const response = await fetchWithRetry(
     options.fetchFn,
     url,
     { method: "GET", headers: githubHeaders(options.githubToken) },
-    { sleepFn: options.sleepFn },
+    { sleepFn: options.sleepFn, timeoutMs: options.requestTimeoutMs },
   );
   const payload = await response.json().catch(() => null);
   if (!response.ok) {

--- a/packages/loopover-miner/lib/http-retry.d.ts
+++ b/packages/loopover-miner/lib/http-retry.d.ts
@@ -8,5 +8,6 @@ export function fetchWithRetry<Response extends { status: number }>(
     maxAttempts?: number;
     sleepFn?: (ms: number) => Promise<unknown>;
     backoffMs?: (attempt: number) => number;
+    timeoutMs?: number;
   },
 ): Promise<Response>;

--- a/packages/loopover-miner/lib/http-retry.js
+++ b/packages/loopover-miner/lib/http-retry.js
@@ -29,12 +29,14 @@ const defaultSleep = (delayMs) => new Promise((resolve) => setTimeout(resolve, d
  * Perform `fetchFn(url, init)` with bounded retry on a transient 5xx response. A 5xx is retried (sleeping
  * `backoffMs(attempt)` between attempts) up to `maxAttempts`; a 2xx/3xx/4xx response is returned immediately, and
  * after the last attempt a lingering 5xx is returned as-is (the caller's own error handling still runs). A THROWN
- * error is NOT retried — it propagates to the caller (the pollers' #4281 failure-mode contract).
+ * error is NOT retried — it propagates to the caller (the pollers' #4281 failure-mode contract). When `timeoutMs`
+ * is given, each attempt gets its own fresh abort timeout (a stalled connection is exactly the kind of network-
+ * level failure #4281 already bubbles unretried, so a timed-out attempt propagates the same way).
  *
  * @param {(url: any, init?: any) => Promise<any>} fetchFn
  * @param {any} url
  * @param {any} [init]
- * @param {{ maxAttempts?: number, sleepFn?: (ms: number) => Promise<unknown>, backoffMs?: (attempt: number) => number }} [options]
+ * @param {{ maxAttempts?: number, sleepFn?: (ms: number) => Promise<unknown>, backoffMs?: (attempt: number) => number, timeoutMs?: number }} [options]
  * @returns {Promise<any>} the fetch response
  */
 export async function fetchWithRetry(fetchFn, url, init, options = {}) {
@@ -43,10 +45,21 @@ export async function fetchWithRetry(fetchFn, url, init, options = {}) {
   const backoffMs = typeof options.backoffMs === "function" ? options.backoffMs : defaultRetryBackoffMs;
   for (let attempt = 1; ; attempt += 1) {
     // A thrown error is intentionally NOT caught here — it propagates to the caller unchanged.
-    const response = await fetchFn(url, init);
+    const response = await fetchOnce(fetchFn, url, init, options.timeoutMs);
     // Retry only transient SERVER errors (5xx). Return 2xx/3xx/4xx immediately; on the final attempt a lingering
     // 5xx is returned as-is.
     if (response.status < 500 || attempt >= maxAttempts) return response;
     await sleepFn(backoffMs(attempt));
   }
+}
+
+// A fresh AbortSignal.timeout() per attempt, never one shared across retries -- reusing a single signal would
+// leave every attempt after the first pre-aborted the instant it fired once. AbortSignal.timeout()'s own internal
+// timer is unref'd (verified: it never keeps a short-lived CLI process alive past its own work), so unlike a raw
+// setTimeout it needs no manual clearTimeout -- mirrors src/github/client.ts's timeoutFetch in the main repo. A
+// no-op passthrough (no `init` copy) when `timeoutMs` is absent/non-positive, so every existing caller that
+// doesn't opt in sees zero behavior change.
+function fetchOnce(fetchFn, url, init, timeoutMs) {
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) return fetchFn(url, init);
+  return fetchFn(url, { ...init, signal: AbortSignal.timeout(timeoutMs) });
 }

--- a/packages/loopover-miner/lib/live-issue-snapshot.d.ts
+++ b/packages/loopover-miner/lib/live-issue-snapshot.d.ts
@@ -12,5 +12,5 @@ export type LiveIssueSnapshotFetch = (
 export function fetchLiveIssueSnapshot(
   repoFullName: string,
   issueNumber: number,
-  options?: { githubToken?: string; graphqlUrl?: string; fetchImpl?: LiveIssueSnapshotFetch },
+  options?: { githubToken?: string; graphqlUrl?: string; fetchImpl?: LiveIssueSnapshotFetch; requestTimeoutMs?: number },
 ): Promise<LiveIssueSnapshot | null>;

--- a/packages/loopover-miner/lib/live-issue-snapshot.js
+++ b/packages/loopover-miner/lib/live-issue-snapshot.js
@@ -10,6 +10,7 @@
 const DEFAULT_GRAPHQL_URL = "https://api.github.com/graphql";
 const GITHUB_API_VERSION = "2022-11-28";
 const MAX_REFERENCING_PRS = 50;
+const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
 
 const LIVE_ISSUE_SNAPSHOT_QUERY = `
   query($owner: String!, $repo: String!, $number: Int!, $maxPrs: Int!) {
@@ -76,7 +77,7 @@ function parseRepoFullName(repoFullName) {
  *
  * @param {string} repoFullName
  * @param {number} issueNumber
- * @param {{ githubToken?: string, graphqlUrl?: string, fetchImpl?: typeof fetch }} [options]
+ * @param {{ githubToken?: string, graphqlUrl?: string, fetchImpl?: typeof fetch, requestTimeoutMs?: number }} [options]
  * @returns {Promise<import("./submission-freshness-check.js").LiveIssueSnapshot | null>}
  */
 export async function fetchLiveIssueSnapshot(repoFullName, issueNumber, options = {}) {
@@ -87,7 +88,12 @@ export async function fetchLiveIssueSnapshot(repoFullName, issueNumber, options 
     typeof options.graphqlUrl === "string" && options.graphqlUrl.trim() ? options.graphqlUrl.trim() : DEFAULT_GRAPHQL_URL;
   const githubToken = options.githubToken ?? process.env.GITHUB_TOKEN ?? "";
   const fetchImpl = options.fetchImpl ?? fetch;
+  const requestTimeoutMs = Number.isInteger(options.requestTimeoutMs) && options.requestTimeoutMs > 0 ? options.requestTimeoutMs : DEFAULT_REQUEST_TIMEOUT_MS;
 
+  // Bounded so a stalled connection can't hang this "never throws" fetcher forever (#miner-github-read-timeouts):
+  // a timeout falls into the SAME catch as any other transport failure, which the caller (checkSubmissionFreshness)
+  // already treats as "live_state_unavailable" -- a fail-closed abort distinct from "issue_closed"/"already_addressed",
+  // never confused with a confirmed-gone issue.
   let response;
   try {
     response = await fetchImpl(graphqlUrl, {
@@ -97,6 +103,7 @@ export async function fetchLiveIssueSnapshot(repoFullName, issueNumber, options 
         query: LIVE_ISSUE_SNAPSHOT_QUERY,
         variables: { owner: target.owner, repo: target.repo, number: issueNumber, maxPrs: MAX_REFERENCING_PRS },
       }),
+      signal: AbortSignal.timeout(requestTimeoutMs),
     });
   } catch {
     return null;

--- a/packages/loopover-miner/lib/pr-disposition-poller.d.ts
+++ b/packages/loopover-miner/lib/pr-disposition-poller.d.ts
@@ -12,6 +12,7 @@ export type PollPrDispositionOptions = {
   maxAttempts?: number;
   minIntervalMs?: number;
   maxIntervalMs?: number;
+  requestTimeoutMs?: number;
   sleepFn?: (delayMs: number) => Promise<void>;
 };
 

--- a/packages/loopover-miner/lib/pr-disposition-poller.js
+++ b/packages/loopover-miner/lib/pr-disposition-poller.js
@@ -15,6 +15,7 @@ const defaultApiBaseUrl = "https://api.github.com";
 const defaultMinIntervalMs = 60_000;
 const defaultMaxIntervalMs = 5 * 60_000;
 const defaultMaxAttempts = 1;
+const defaultRequestTimeoutMs = 10_000;
 const githubApiVersion = "2022-11-28";
 
 function normalizeApiBaseUrl(value) {
@@ -48,6 +49,7 @@ function normalizeOptions(options = {}) {
     maxAttempts: normalizePositiveInt(options.maxAttempts, defaultMaxAttempts, 1, 20),
     minIntervalMs: normalizePositiveInt(options.minIntervalMs, defaultMinIntervalMs, 1, 60 * 60_000),
     maxIntervalMs: normalizePositiveInt(options.maxIntervalMs, defaultMaxIntervalMs, 1, 60 * 60_000),
+    requestTimeoutMs: normalizePositiveInt(options.requestTimeoutMs, defaultRequestTimeoutMs, 1, 60_000),
     sleepFn:
       options.sleepFn ??
       ((delayMs) => new Promise((resolve) => setTimeout(resolve, delayMs))),
@@ -95,9 +97,12 @@ function githubError(response, payload) {
 }
 
 async function fetchPullRequest(target, prNumber, options) {
+  // Bounded so a stalled connection can't hang a poll cycle forever (#miner-github-read-timeouts) -- a fresh
+  // AbortSignal.timeout() per call, matching ci-poller.js's sibling fetchWithRetry treatment.
   const response = await options.fetchFn(apiUrl(options.apiBaseUrl, repoPath(target, `/pulls/${prNumber}`)), {
     method: "GET",
     headers: githubHeaders(options.githubToken),
+    signal: AbortSignal.timeout(options.requestTimeoutMs),
   });
   const payload = await response.json().catch(() => null);
   if (!response.ok) throw githubError(response, payload);

--- a/packages/loopover-miner/lib/self-review-context.d.ts
+++ b/packages/loopover-miner/lib/self-review-context.d.ts
@@ -23,6 +23,7 @@ export type FetchSelfReviewContextOptions = {
   fetchImpl?: SelfReviewContextFetch;
   perPage?: number;
   maxPages?: number;
+  requestTimeoutMs?: number;
 };
 
 export function fetchSelfReviewContext(repoFullName: string, options?: FetchSelfReviewContextOptions): Promise<SelfReviewContextResult>;

--- a/packages/loopover-miner/lib/self-review-context.js
+++ b/packages/loopover-miner/lib/self-review-context.js
@@ -23,6 +23,7 @@ const DEFAULT_RAW_CONTENT_BASE_URL = "https://raw.githubusercontent.com";
 const DEFAULT_GITTENSOR_API_BASE = "https://api.gittensor.io";
 const DEFAULT_PER_PAGE = 100;
 const DEFAULT_MAX_PAGES = 10;
+const DEFAULT_REQUEST_TIMEOUT_MS = 10_000;
 
 // Mirrors src/signals/focus-manifest-loader.ts's MANIFEST_FILE_CANDIDATES exactly -- first candidate that
 // resolves wins, same as the live gate's own lookup order.
@@ -59,11 +60,19 @@ function normalizeOptions(options = {}) {
     maxPages: Number.isInteger(options.maxPages) && options.maxPages > 0 ? options.maxPages : DEFAULT_MAX_PAGES,
     contributorLogin: typeof options.contributorLogin === "string" ? options.contributorLogin.trim() : "",
     linkedIssues: Array.isArray(options.linkedIssues) ? options.linkedIssues.filter((n) => Number.isInteger(n)) : [],
+    requestTimeoutMs: Number.isInteger(options.requestTimeoutMs) && options.requestTimeoutMs > 0 ? options.requestTimeoutMs : DEFAULT_REQUEST_TIMEOUT_MS,
   };
 }
 
+// A fresh AbortSignal.timeout() per call, so a stalled connection can't hang context construction forever
+// (#miner-github-read-timeouts) -- shared by this file's three independent fetch call sites (GitHub REST, raw
+// manifest content, the Gittensor contributor lookup).
+async function fetchWithTimeout(fetchImpl, url, init, timeoutMs) {
+  return fetchImpl(url, { ...init, signal: AbortSignal.timeout(timeoutMs) });
+}
+
 async function githubGetJson(url, resolved) {
-  const response = await resolved.fetchImpl(url, { method: "GET", headers: githubHeaders(resolved.githubToken) });
+  const response = await fetchWithTimeout(resolved.fetchImpl, url, { method: "GET", headers: githubHeaders(resolved.githubToken) }, resolved.requestTimeoutMs);
   const payload = await response.json().catch(() => null);
   return { response, payload };
 }
@@ -250,7 +259,7 @@ async function fetchManifestContent(target, resolved) {
   for (const path of MANIFEST_FILE_CANDIDATES) {
     const url = `${resolved.rawContentBaseUrl}/${encodeURIComponent(target.owner)}/${encodeURIComponent(target.repo)}/HEAD/${path}`;
     try {
-      const response = await resolved.fetchImpl(url, { method: "GET", headers: { accept: "application/json", "user-agent": "loopover-miner" } });
+      const response = await fetchWithTimeout(resolved.fetchImpl, url, { method: "GET", headers: { accept: "application/json", "user-agent": "loopover-miner" } }, resolved.requestTimeoutMs);
       if (response.ok) {
         const text = await readBoundedManifestResponseText(response);
         if (typeof text === "string") return text;
@@ -268,7 +277,7 @@ async function fetchManifestContent(target, resolved) {
 async function fetchConfirmedContributor(login, resolved) {
   if (!login) return false;
   try {
-    const response = await resolved.fetchImpl(`${resolved.gittensorApiBase}/miners`, { method: "GET", headers: { accept: "application/json" } });
+    const response = await fetchWithTimeout(resolved.fetchImpl, `${resolved.gittensorApiBase}/miners`, { method: "GET", headers: { accept: "application/json" } }, resolved.requestTimeoutMs);
     if (!response.ok) return false;
     const payload = await response.json().catch(() => null);
     if (!Array.isArray(payload)) return false;
@@ -308,7 +317,7 @@ function computeInDuplicateCluster(repoFullName, issues, pullRequests, targetIss
  * @param {{
  *   githubToken?: string, contributorLogin?: string, linkedIssues?: number[],
  *   apiBaseUrl?: string, rawContentBaseUrl?: string, gittensorApiBase?: string,
- *   fetchImpl?: typeof fetch, perPage?: number, maxPages?: number,
+ *   fetchImpl?: typeof fetch, perPage?: number, maxPages?: number, requestTimeoutMs?: number,
  * }} [options]
  * @returns {Promise<import("./self-review-context.js").SelfReviewContextResult>}
  */

--- a/test/unit/miner-ci-poller.test.ts
+++ b/test/unit/miner-ci-poller.test.ts
@@ -371,4 +371,43 @@ describe("miner CI check-run poller (#2323)", () => {
       pollCheckRuns("acme/widgets", 12, { apiBaseUrl: API, fetchFn: malformedChecks }),
     ).rejects.toThrow("github_check_runs_malformed");
   });
+
+  it("bounds every GitHub request with a per-attempt AbortSignal timeout, defaulting to 10s (#miner-github-read-timeouts)", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    const fetchFn = vi.fn(async (input: RequestInfo | URL, _init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/repos/acme/widgets/pulls/42")) return prResponse("head-sha");
+      if (url.endsWith("/repos/acme/widgets/commits/head-sha/check-runs?per_page=100&page=1")) {
+        return checksResponse([checkRun("validate", "queued")]); // pending: no re-check-head-sha call
+      }
+      return jsonResponse({}, { status: 404 });
+    });
+
+    await pollCheckRuns("acme/widgets", 42, { apiBaseUrl: API, fetchFn });
+
+    expect(fetchFn).toHaveBeenCalledTimes(2); // head-sha + check-runs
+    expect(timeoutSpy).toHaveBeenCalledTimes(2);
+    expect(timeoutSpy.mock.calls.every(([ms]) => ms === 10_000)).toBe(true);
+    for (const [, init] of fetchFn.mock.calls) {
+      expect((init as RequestInit | undefined)?.signal).toBeInstanceOf(AbortSignal);
+    }
+    timeoutSpy.mockRestore();
+  });
+
+  it("honors a custom requestTimeoutMs instead of the 10s default", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    const fetchFn = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/repos/acme/widgets/pulls/42")) return prResponse("head-sha");
+      if (url.endsWith("/repos/acme/widgets/commits/head-sha/check-runs?per_page=100&page=1")) {
+        return checksResponse([checkRun("validate", "queued")]);
+      }
+      return jsonResponse({}, { status: 404 });
+    });
+
+    await pollCheckRuns("acme/widgets", 42, { apiBaseUrl: API, fetchFn, requestTimeoutMs: 2500 });
+
+    expect(timeoutSpy.mock.calls.every(([ms]) => ms === 2500)).toBe(true);
+    timeoutSpy.mockRestore();
+  });
 });

--- a/test/unit/miner-http-retry.test.ts
+++ b/test/unit/miner-http-retry.test.ts
@@ -7,14 +7,16 @@ const noSleep = () => Promise.resolve();
 function scriptedFetch(script: Array<number | "throw">) {
   let call = 0;
   const calls: unknown[] = [];
-  const fn = async (url: unknown) => {
+  const inits: Array<Record<string, unknown> | undefined> = [];
+  const fn = async (url: unknown, init?: unknown) => {
     calls.push(url);
+    inits.push(init as Record<string, unknown> | undefined);
     const step = script[Math.min(call, script.length - 1)] ?? 200;
     call += 1;
     if (step === "throw") throw new Error("network down");
     return { status: step };
   };
-  return { fn, get calls() { return calls; } };
+  return { fn, get calls() { return calls; }, get inits() { return inits; } };
 }
 
 describe("fetchWithRetry (#4829)", () => {
@@ -78,6 +80,37 @@ describe("fetchWithRetry (#4829)", () => {
     await fetchWithRetry(f.fn, "u", undefined, { maxAttempts: 0.5 as unknown as number, sleepFn, backoffMs: (a) => a * 10 });
     expect(f.calls).toHaveLength(3);
     expect(delays).toEqual([10, 20]);
+  });
+});
+
+describe("fetchWithRetry timeoutMs (#miner-github-read-timeouts)", () => {
+  it("does not inject a signal when timeoutMs is absent (undefined)", async () => {
+    const f = scriptedFetch([200]);
+    await fetchWithRetry(f.fn, "u", { method: "GET" }, { sleepFn: noSleep });
+    expect(f.inits[0]?.signal).toBeUndefined();
+  });
+
+  it("does not inject a signal when timeoutMs is non-positive or non-finite", async () => {
+    const f = scriptedFetch([200, 200, 200]);
+    await fetchWithRetry(f.fn, "u", { method: "GET" }, { sleepFn: noSleep, timeoutMs: 0 });
+    await fetchWithRetry(f.fn, "u", { method: "GET" }, { sleepFn: noSleep, timeoutMs: -5 });
+    await fetchWithRetry(f.fn, "u", { method: "GET" }, { sleepFn: noSleep, timeoutMs: Number.NaN });
+    expect(f.inits.map((i) => i?.signal)).toEqual([undefined, undefined, undefined]);
+  });
+
+  it("injects a fresh AbortSignal per attempt when timeoutMs is positive and finite, without losing the caller's own init fields", async () => {
+    const f = scriptedFetch([500, 500, 200]);
+    await fetchWithRetry(f.fn, "u", { method: "GET", headers: { a: "b" } }, { maxAttempts: 5, sleepFn: noSleep, timeoutMs: 5000 });
+    expect(f.inits).toHaveLength(3);
+    for (const init of f.inits) {
+      expect(init?.signal).toBeInstanceOf(AbortSignal);
+      expect(init?.method).toBe("GET");
+      expect(init?.headers).toEqual({ a: "b" });
+    }
+    // Each retry attempt gets its OWN fresh signal -- reusing one across attempts would leave every attempt
+    // after the first pre-aborted the instant it fired once.
+    expect(f.inits[0]?.signal).not.toBe(f.inits[1]?.signal);
+    expect(f.inits[1]?.signal).not.toBe(f.inits[2]?.signal);
   });
 });
 

--- a/test/unit/miner-live-issue-snapshot.test.ts
+++ b/test/unit/miner-live-issue-snapshot.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { fetchLiveIssueSnapshot } from "../../packages/loopover-miner/lib/live-issue-snapshot.js";
 
 function graphqlResponse(body: unknown, status = 200) {
@@ -154,5 +154,44 @@ describe("fetchLiveIssueSnapshot (#5132)", () => {
       },
     });
     expect(capturedUrl).toBe("https://ghe.example.com/api/graphql");
+  });
+
+  it("bounds the request with a per-attempt AbortSignal timeout, defaulting to 10s (#miner-github-read-timeouts)", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    let capturedSignal: AbortSignal | undefined;
+    const fetchImpl = async (_url: string, init: RequestInit) => {
+      capturedSignal = init.signal as AbortSignal;
+      return { ok: true, status: 200, json: async () => ({ data: { repository: { issue: { state: "OPEN", closedByPullRequestsReferences: { nodes: [] } } } } }) } as Response;
+    };
+
+    await fetchLiveIssueSnapshot("acme/widgets", 7, { fetchImpl });
+
+    expect(timeoutSpy).toHaveBeenCalledWith(10_000);
+    expect(capturedSignal).toBeInstanceOf(AbortSignal);
+    timeoutSpy.mockRestore();
+  });
+
+  it("honors a custom requestTimeoutMs instead of the 10s default", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    const fetchImpl = async () =>
+      ({ ok: true, status: 200, json: async () => ({ data: { repository: { issue: { state: "OPEN", closedByPullRequestsReferences: { nodes: [] } } } } }) }) as Response;
+
+    await fetchLiveIssueSnapshot("acme/widgets", 7, { fetchImpl, requestTimeoutMs: 1500 });
+
+    expect(timeoutSpy).toHaveBeenCalledWith(1500);
+    timeoutSpy.mockRestore();
+  });
+
+  it("falls back to the 10s default when requestTimeoutMs is not a positive integer", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    const fetchImpl = async () =>
+      ({ ok: true, status: 200, json: async () => ({ data: { repository: { issue: { state: "OPEN", closedByPullRequestsReferences: { nodes: [] } } } } }) }) as Response;
+
+    await fetchLiveIssueSnapshot("acme/widgets", 7, { fetchImpl, requestTimeoutMs: 0 });
+    await fetchLiveIssueSnapshot("acme/widgets", 7, { fetchImpl, requestTimeoutMs: -5 });
+    await fetchLiveIssueSnapshot("acme/widgets", 7, { fetchImpl, requestTimeoutMs: 12.5 });
+
+    expect(timeoutSpy.mock.calls).toEqual([[10_000], [10_000], [10_000]]);
+    timeoutSpy.mockRestore();
   });
 });

--- a/test/unit/miner-pr-disposition-poller.test.ts
+++ b/test/unit/miner-pr-disposition-poller.test.ts
@@ -134,6 +134,28 @@ describe("PR disposition poller (#5135)", () => {
     const result = await pollPrDisposition("acme/widgets", 13, { apiBaseUrl: API, fetchFn });
     expect(result).toEqual({ state: "open", merged: false, closedAt: null, attempts: 1 });
   });
+
+  it("bounds the request with a per-attempt AbortSignal timeout, defaulting to 10s (#miner-github-read-timeouts)", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    const fetchFn = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) => prResponse({ state: "open" }));
+
+    await pollPrDisposition("acme/widgets", 14, { apiBaseUrl: API, fetchFn });
+
+    expect(timeoutSpy).toHaveBeenCalledWith(10_000);
+    const [, init] = fetchFn.mock.calls[0]!;
+    expect((init as RequestInit | undefined)?.signal).toBeInstanceOf(AbortSignal);
+    timeoutSpy.mockRestore();
+  });
+
+  it("honors a custom requestTimeoutMs instead of the 10s default", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    const fetchFn = vi.fn(async () => prResponse({ state: "open" }));
+
+    await pollPrDisposition("acme/widgets", 15, { apiBaseUrl: API, fetchFn, requestTimeoutMs: 3000 });
+
+    expect(timeoutSpy).toHaveBeenCalledWith(3000);
+    timeoutSpy.mockRestore();
+  });
 });
 
 describe("classifyPrDisposition (#5135)", () => {

--- a/test/unit/miner-self-review-context.test.ts
+++ b/test/unit/miner-self-review-context.test.ts
@@ -491,4 +491,60 @@ describe("fetchSelfReviewContext (#5145)", () => {
       else process.env.GITHUB_TOKEN = original;
     }
   });
+
+  it("bounds every fetch (GitHub REST, raw manifest, Gittensor contributor lookup) with a per-call AbortSignal timeout, defaulting to 10s (#miner-github-read-timeouts)", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    const capturedSignals: unknown[] = [];
+    const fetchImpl = async (url: string, init?: { signal?: unknown }) => {
+      capturedSignals.push(init?.signal);
+      if (url.includes("api.gittensor.io/miners")) return jsonResponse([{ githubUsername: "miner-bot" }]);
+      if (url.includes("/repos/acme/widgets/issues")) return jsonResponse([]);
+      if (url.includes("/repos/acme/widgets/pulls")) return jsonResponse([]);
+      if (url.includes("/repos/acme/widgets")) return jsonResponse(REPO_PAYLOAD);
+      if (url.includes("raw.githubusercontent.com")) return jsonResponse(null, 404);
+      return jsonResponse(null, 404);
+    };
+
+    await fetchSelfReviewContext("acme/widgets", { fetchImpl: fetchImpl as never, contributorLogin: "miner-bot" });
+
+    // repo + issues + pulls (githubGetJson) + 4 manifest candidates + 1 contributor lookup = 8 calls, every one bounded.
+    expect(capturedSignals.length).toBeGreaterThanOrEqual(7);
+    for (const signal of capturedSignals) expect(signal).toBeInstanceOf(AbortSignal);
+    expect(timeoutSpy.mock.calls.every(([ms]) => ms === 10_000)).toBe(true);
+    timeoutSpy.mockRestore();
+  });
+
+  it("honors a custom requestTimeoutMs instead of the 10s default, across all three fetch call sites", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    const fetchImpl = routedFetch({
+      "api.gittensor.io/miners": () => jsonResponse([]),
+      "/repos/acme/widgets/issues": () => jsonResponse([]),
+      "/repos/acme/widgets/pulls": () => jsonResponse([]),
+      "/repos/acme/widgets": () => jsonResponse(REPO_PAYLOAD),
+      "raw.githubusercontent.com": () => jsonResponse(null, 404),
+    });
+
+    await fetchSelfReviewContext("acme/widgets", { fetchImpl: fetchImpl as never, requestTimeoutMs: 4000 });
+
+    expect(timeoutSpy.mock.calls.length).toBeGreaterThan(0);
+    expect(timeoutSpy.mock.calls.every(([ms]) => ms === 4000)).toBe(true);
+    timeoutSpy.mockRestore();
+  });
+
+  it("falls back to the 10s default when requestTimeoutMs is not a positive integer", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    const fetchImpl = routedFetch({
+      "api.gittensor.io/miners": () => jsonResponse([]),
+      "/repos/acme/widgets/issues": () => jsonResponse([]),
+      "/repos/acme/widgets/pulls": () => jsonResponse([]),
+      "/repos/acme/widgets": () => jsonResponse(REPO_PAYLOAD),
+      "raw.githubusercontent.com": () => jsonResponse(null, 404),
+    });
+
+    await fetchSelfReviewContext("acme/widgets", { fetchImpl: fetchImpl as never, requestTimeoutMs: -3 });
+
+    expect(timeoutSpy.mock.calls.length).toBeGreaterThan(0);
+    expect(timeoutSpy.mock.calls.every(([ms]) => ms === 10_000)).toBe(true);
+    timeoutSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary
- `self-review-context.js`, `live-issue-snapshot.js`, `ci-poller.js`, and `pr-disposition-poller.js` made GitHub REST/GraphQL reads with no per-request timeout, unlike the `AbortController` pattern already established in `update-check.js`. A stalled connection could hang a miner attempt indefinitely.
- Every GitHub-read call site in these 4 files now bounds its fetch with a fresh `AbortSignal.timeout()` per call (Node's own unref'd timer — verified it doesn't keep a short-lived CLI process alive after the work finishes), configurable via `requestTimeoutMs` and defaulting to 10s.
- `ci-poller.js` goes through the shared `fetchWithRetry` helper (`http-retry.js`), so that helper gained an opt-in `timeoutMs` option: each retry attempt gets its **own fresh** signal rather than one shared signal that would leave every attempt after the first pre-aborted the instant it fired once. Fully backward-compatible — existing callers that don't pass `timeoutMs` (e.g. `opportunity-fanout.js`) see zero behavior change.
- `live-issue-snapshot.js`'s `fetchLiveIssueSnapshot` already wraps its whole call in `catch { return null; }` per its documented "never throws" contract. A timeout falls into that same catch as any other transport failure — its only caller, `checkSubmissionFreshness`, already treats a `null` snapshot as `"live_state_unavailable"`, a fail-closed abort distinct from `"issue_closed"`/`"already_addressed"`, so a timeout is never confused with a confirmed-gone issue.
- Deliberately used `AbortSignal.timeout()` (mirroring `src/github/client.ts`'s `timeoutFetch` in the main repo) rather than manually replicating `update-check.js`'s older `AbortController`+`setTimeout`+`clearTimeout` pattern — it's simpler, needs no manual cleanup, and is already the more mature precedent in this same codebase for the identical purpose.

## Test plan
- [x] Extended each of the 4 files' test suites (`miner-self-review-context`, `miner-live-issue-snapshot`, `miner-ci-poller`, `miner-pr-disposition-poller`) plus `miner-http-retry` with tests that spy on `AbortSignal.timeout` to verify: the default (10s) is applied when omitted, a custom `requestTimeoutMs` is honored, an invalid override falls back to the default, and (for the retry helper) each retry attempt gets a fresh signal rather than a reused one.
- [x] `npx vitest run` across all 7 affected test files — 98/98 passed.
- [x] Full local `npm run test:ci` gate green (typecheck, coverage, engine-parity, workers, mcp/miner pack, ui, etc.).

## Follow-up
- `opportunity-fanout.js` also calls `fetchWithRetry` without opting into `timeoutMs` — flagged as a separate follow-up rather than folded into this PR's scope.