### PR TITLE
fix(webhook): recognize full GitHub issue URL in closing keywords

### DIFF
--- a/packages/loopover-engine/src/signals/predicted-gate-engine.ts
+++ b/packages/loopover-engine/src/signals/predicted-gate-engine.ts
@@ -926,6 +926,12 @@ function extractLinkedIssueNumbers(text: string, repoFullName: string): number[]
   for (const match of text.matchAll(/\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+([\w.-]+\/[\w.-]+)#(\d+)\b/gi)) {
     if (match[1]!.toLowerCase() === target) numbers.push(Number(match[2]));
   }
+  // GitHub's own linker ALSO recognizes the full issue URL form (`KEYWORD https://github.com/owner/repo/issues/N`)
+  // -- a common habit (e.g. pasted from a browser address bar) that the two `#`-anchored forms above never match.
+  // Same same-repo-only rule as the qualified form (#linked-issue-url-form).
+  for (const match of text.matchAll(/\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+https?:\/\/(?:www\.)?github\.com\/([\w.-]+\/[\w.-]+)\/issues\/(\d+)\b/gi)) {
+    if (match[1]!.toLowerCase() === target) numbers.push(Number(match[2]));
+  }
   return [...new Set(numbers.filter((value) => Number.isInteger(value) && value > 0))];
 }
 

--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -7877,16 +7877,24 @@ export function extractLinkedIssueNumbersWithOverflow(text: string, repoFullName
 
   const linkedIssues: number[] = [];
   const seen = new Set<number>();
-  // Matches both GitHub's bare `KEYWORD #N` and fully-qualified `KEYWORD owner/repo#N` closing syntax (#3862) --
-  // the qualified form only counts when owner/repo case-insensitively matches THIS repo; a reference to a
-  // different repo closes an issue there, not here, and must not spoof a same-repo linked-issue match.
-  for (const match of text.matchAll(/\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+(?:([\w.-]+\/[\w.-]+)#|#)(\d+)\b/gi)) {
+  // Matches GitHub's bare `KEYWORD #N`, fully-qualified `KEYWORD owner/repo#N` (#3862), and full-URL
+  // `KEYWORD https://github.com/owner/repo/issues/N` closing syntax -- the last form is GitHub's own linker
+  // ALSO recognizes it (confirmed via the GraphQL closingIssuesReferences field), but this regex previously
+  // required a literal `#`, so a contributor pasting the full issue URL (a common habit, e.g. from a browser
+  // address bar) silently produced zero linked issues and tripped the "no linked issue" hard-rule close on a
+  // PR that genuinely had one (#draft-evasion... no, #linked-issue-url-form). Both the qualified and URL forms
+  // only count when owner/repo case-insensitively matches THIS repo -- a reference to a different repo closes
+  // an issue there, not here, and must not spoof a same-repo linked-issue match.
+  for (const match of text.matchAll(
+    /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+(?:https?:\/\/(?:www\.)?github\.com\/(?<urlOwner>[\w.-]+\/[\w.-]+)\/issues\/(?<urlNum>\d+)|(?<qualOwner>[\w.-]+\/[\w.-]+)#(?<qualNum>\d+)|#(?<bareNum>\d+))\b/gi,
+  )) {
     const matchStart = match.index!;
     const matchEnd = matchStart + match[0].length;
     if (inlineCodeSpanRanges.some((range) => matchStart < range.end && matchEnd > range.start)) continue;
-    const owner = match[1];
+    const groups = match.groups!;
+    const owner = groups.urlOwner ?? groups.qualOwner;
     if (owner && owner.toLowerCase() !== target) continue;
-    const value = Number(match[2]);
+    const value = Number(groups.urlNum ?? groups.qualNum ?? groups.bareNum);
     if (!Number.isInteger(value) || value <= 0 || seen.has(value)) continue;
     seen.add(value);
     if (linkedIssues.length >= normalizedLimit) return { numbers: linkedIssues, overflow: true };

--- a/test/unit/db-parsers.test.ts
+++ b/test/unit/db-parsers.test.ts
@@ -90,6 +90,22 @@ describe("database row parser hardening", () => {
     expect(extractLinkedIssueNumbers("Fixes #1\nCloses owner/repo#1\nResolves owner/repo#2", "owner/repo")).toEqual([1, 2]);
   });
 
+  it("REGRESSION (#linked-issue-url-form): recognizes the full GitHub issue URL closing form GitHub's own linker also accepts", () => {
+    // The exact real-world shape this was missed for: `Closes https://github.com/owner/repo/issues/N`.
+    expect(extractLinkedIssueNumbers("Closes https://github.com/owner/repo/issues/5914", "owner/repo")).toEqual([5914]);
+    // http (not just https) and a leading www. subdomain are both accepted.
+    expect(extractLinkedIssueNumbers("Fixes http://github.com/owner/repo/issues/1", "owner/repo")).toEqual([1]);
+    expect(extractLinkedIssueNumbers("Resolves https://www.github.com/owner/repo/issues/2", "owner/repo")).toEqual([2]);
+    // Case-insensitive, matching GitHub's own repo-name matching -- same as the qualified `owner/repo#N` form.
+    expect(extractLinkedIssueNumbers("Closes https://github.com/Owner/Repo/issues/7", "owner/repo")).toEqual([7]);
+    // A DIFFERENT repo's URL must not spoof a same-repo linked issue, same rule as the qualified form.
+    expect(extractLinkedIssueNumbers("Closes https://github.com/other/repo/issues/99", "owner/repo")).toEqual([]);
+    // URL, qualified, and bare forms mix freely and dedupe together.
+    expect(extractLinkedIssueNumbers("Fixes #1\nCloses https://github.com/owner/repo/issues/2\nResolves owner/repo#3", "owner/repo")).toEqual([1, 2, 3]);
+    // Still respects the inline-code-span exclusion, same as every other closing-keyword form.
+    expect(extractLinkedIssueNumbers("Fixes `not a directive` https://github.com/owner/repo/issues/42", "owner/repo")).toEqual([]);
+  });
+
   it("REGRESSION (#3862): a stored PR using ONLY the qualified `Closes owner/repo#N` form is not flagged as unlinked", async () => {
     const env = createTestEnv();
     await upsertPullRequestFromGitHub(env, "owner/repo", {

--- a/test/unit/predicted-gate-engine-branch-coverage.test.ts
+++ b/test/unit/predicted-gate-engine-branch-coverage.test.ts
@@ -421,6 +421,11 @@ describe("predicted-gate engine branch coverage (#2283)", () => {
     expect(internals.extractLinkedIssueNumbers("closes other/repo#9", REPO.fullName)).not.toContain(9);
     expect(internals.extractLinkedIssueNumbers(`closes ${REPO.fullName}#9`, REPO.fullName)).toContain(9);
 
+    // REGRESSION (#linked-issue-url-form): the full GitHub issue URL closing form, which GitHub's own linker
+    // also recognizes, must not silently extract zero linked issues.
+    expect(internals.extractLinkedIssueNumbers(`closes https://github.com/${REPO.fullName}/issues/11`, REPO.fullName)).toContain(11);
+    expect(internals.extractLinkedIssueNumbers(`closes https://github.com/other/repo/issues/11`, REPO.fullName)).not.toContain(11);
+
     const issueQuality: IssueQualityReport = {
       repoFullName: REPO.fullName,
       generatedAt: "2026-01-01T00:00:00.000Z",


### PR DESCRIPTION
## Summary
- The linked-issue extractor (`extractLinkedIssueNumbersWithOverflow` in `src/db/repositories.ts`, plus its engine-parity twin in `packages/loopover-engine/src/signals/predicted-gate-engine.ts`) only recognized bare `Closes #N` and qualified `Closes owner/repo#N` closing-keyword forms.
- It never matched the full GitHub issue URL form (`Closes https://github.com/owner/repo/issues/N`) — a form GitHub's own linker does recognize (confirmed via the GraphQL `closingIssuesReferences` field).
- A contributor pasting the full URL (a common habit, e.g. copied from a browser address bar) silently produced zero linked issues, which could trip the "no linked issue" hard-rule close on a PR that genuinely had one linked. This is what happened to PRs #5994 and #5985 (reported via Discord).
- Fixed by adding URL-form recognition to both extractors, preserving the existing same-repo-only enforcement and inline-code-span exclusion.

## Test plan
- [x] `npm run test:ci` (full local gate) green
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] New regression tests in `test/unit/db-parsers.test.ts` and `test/unit/predicted-gate-engine-branch-coverage.test.ts` covering https/http, `www.` subdomain, case-insensitive owner/repo, cross-repo rejection, mixed-form dedup, and inline-code-span exclusion
- [x] Spot-checked `coverage/lcov.info` DA/BRDA records for the new lines in both files — 100% line and branch coverage, no zero-hit branches