### PR TITLE
fix(observability): correct LoopoverOrbExportErrorRateHigh's stale runbook metric name

### DIFF
--- a/prometheus/rules/alerts.yml
+++ b/prometheus/rules/alerts.yml
@@ -386,7 +386,7 @@ groups:
         annotations:
           summary: "loopover Orb export error rate above 5%"
           description: "{{ $value | humanizePercentage }} of Orb usage-event exports failed over the last 15m (sustained 15m). Billable events may not be reaching Orb."
-          runbook: "Verify Orb API credentials/connectivity and check level=error logs around orb export. Recorded-but-unexported events (loopover_orb_events_recorded_total vs _exported_total diverging) confirm a stuck exporter."
+          runbook: "Verify Orb API credentials/connectivity and check level=error logs around orb export. A sustained rise in loopover_orb_export_errors_total while loopover_orb_events_exported_total stays flat confirms a stuck exporter."
 
       - alert: LoopoverWebhookEnqueueFailures
         # A webhook accepted by the receiver but not durably queued becomes GitHub

--- a/test/unit/alerts-metric-name-references.test.ts
+++ b/test/unit/alerts-metric-name-references.test.ts
@@ -1,0 +1,103 @@
+import { readFileSync } from "node:fs";
+import { parse as parseYaml } from "yaml";
+import { describe, expect, it } from "vitest";
+import { DEFAULT_METRIC_META } from "../../src/selfhost/metrics";
+
+// Regression check (#5816): a hand-authored alert annotation (summary/description/runbook) can reference a
+// `loopover_*` metric name that was never registered, or was renamed/removed, without any existing tooling
+// catching it -- scripts/validate-observability-configs.mjs only validates PromQL `expr` syntax, never
+// free-text annotation prose. Scans every `loopover_*`-shaped token in every alert's annotation text and
+// asserts it is either a real registered metric (src/selfhost/metrics.ts's DEFAULT_METRIC_META) or matches
+// one of the documented external-source prefixes (the backup exporter, the opt-in Cloudflare D1 probe, and
+// the miner CLI's own pushed metrics -- none of which register through DEFAULT_METRIC_META).
+
+interface AlertRule {
+  alert: string;
+  annotations?: Record<string, string>;
+}
+interface AlertGroup {
+  name: string;
+  rules: AlertRule[];
+}
+interface AlertsDoc {
+  groups: AlertGroup[];
+}
+
+// Prefixes documented at the top of their respective rule groups in prometheus/rules/alerts.yml as coming
+// from a source other than this process's own in-memory metrics registry.
+const EXTERNAL_METRIC_PREFIXES = ["loopover_backup_", "loopover_d1_", "loopover_miner_"];
+
+const METRIC_TOKEN_PATTERN = /loopover_[a-z0-9_]+\*?/g;
+
+/** Every `loopover_*`-shaped token (a trailing `*` denotes a deliberate label-wildcard family reference, e.g.
+ *  "loopover_jobs_rate_limit_* labels") found across every alert's annotation values. */
+function annotationMetricTokens(doc: AlertsDoc): { alert: string; token: string }[] {
+  const found: { alert: string; token: string }[] = [];
+  for (const group of doc.groups) {
+    for (const rule of group.rules) {
+      for (const text of Object.values(rule.annotations ?? {})) {
+        for (const match of text.matchAll(METRIC_TOKEN_PATTERN)) {
+          found.push({ alert: rule.alert, token: match[0] });
+        }
+      }
+    }
+  }
+  return found;
+}
+
+/** True when `token` resolves to a real metric: an exact match in `registeredNames`, a wildcard prefix
+ *  (trailing `*`) matched by at least one registered name, or one of the documented external prefixes. */
+function isKnownMetricToken(token: string, registeredNames: ReadonlySet<string>): boolean {
+  if (token.endsWith("*")) {
+    const prefix = token.slice(0, -1);
+    return [...registeredNames].some((name) => name.startsWith(prefix));
+  }
+  if (EXTERNAL_METRIC_PREFIXES.some((prefix) => token.startsWith(prefix))) return true;
+  return registeredNames.has(token);
+}
+
+/** Every annotation metric-name reference that resolves to neither a registered metric, a recognized
+ *  wildcard family, nor a documented external prefix -- a dangling/stale reference. */
+function findUnknownMetricReferences(doc: AlertsDoc, registeredNames: ReadonlySet<string>): { alert: string; token: string }[] {
+  return annotationMetricTokens(doc).filter(({ token }) => !isKnownMetricToken(token, registeredNames));
+}
+
+const registeredNames = new Set(DEFAULT_METRIC_META.map(([name]) => name));
+
+describe("alert annotation metric-name references (#5816)", () => {
+  it("references only registered metrics, a recognized wildcard family, or a documented external prefix in the real alerts.yml", () => {
+    const doc = parseYaml(readFileSync("prometheus/rules/alerts.yml", "utf8")) as AlertsDoc;
+    expect(findUnknownMetricReferences(doc, registeredNames)).toEqual([]);
+  });
+
+  it("flags a fabricated, never-registered metric name referenced in an annotation", () => {
+    const fixture: AlertsDoc = {
+      groups: [
+        {
+          name: "fixture-group",
+          rules: [{ alert: "FixtureAlert", annotations: { runbook: "Check loopover_totally_made_up_metric_total for drift." } }],
+        },
+      ],
+    };
+    expect(findUnknownMetricReferences(fixture, registeredNames)).toEqual([{ alert: "FixtureAlert", token: "loopover_totally_made_up_metric_total" }]);
+  });
+
+  it("does not flag a documented external-prefix metric or a wildcard label-family reference", () => {
+    const fixture: AlertsDoc = {
+      groups: [
+        {
+          name: "fixture-group",
+          rules: [
+            {
+              alert: "FixtureExternalAndWildcard",
+              annotations: {
+                runbook: "loopover_backup_files and loopover_d1_database_size_bytes are external. loopover_jobs_rate_limit_* covers the whole family.",
+              },
+            },
+          ],
+        },
+      ],
+    };
+    expect(findUnknownMetricReferences(fixture, registeredNames)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- `LoopoverOrbExportErrorRateHigh`'s runbook annotation in `prometheus/rules/alerts.yml` told operators to compare `loopover_orb_events_recorded_total` against `_exported_total` to confirm a stuck exporter, but no "recorded" counter was ever registered — only `loopover_orb_events_exported_total` and `loopover_orb_export_errors_total` exist (`src/selfhost/orb-collector.ts`, `src/selfhost/metrics.ts`). An operator paged by this alert who followed the runbook literally got an empty Prometheus series.
- Rephrases the runbook to point at the two real metrics already used in the alert's own `expr`, per the issue's own suggested fix — no other change to the alert.
- Adds a general regression check (`test/unit/alerts-metric-name-references.test.ts`) that scans every `loopover_*`-shaped token in every alert's annotation text (`summary`/`description`/`runbook`) across `prometheus/rules/alerts.yml` and asserts each one resolves to a registered metric (`src/selfhost/metrics.ts`'s `DEFAULT_METRIC_META`), a documented external-source prefix (`loopover_backup_*` the backup exporter, `loopover_d1_*` the opt-in Cloudflare D1 probe, `loopover_miner_*` the miner CLI's own pushed metrics), or a recognized label-wildcard family reference (a trailing `*`, e.g. `loopover_jobs_rate_limit_*`).
- The new test includes both the pass case (the real file, confirmed zero dangling references after this fix) and a fail case (a synthetic fixture with a fabricated metric name), proving the checker actually catches this class of drift rather than trivially passing.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

Closes #5816

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- The local machine is under persistent memory contention from multiple concurrent processes on this shared box, and the full `npm run test:ci` chain's local `tsc --noEmit` step OOM-crashes reproducibly. This PR changes zero application `.ts`/`.js` source logic — only a YAML annotation string and one new self-contained test file (`readFileSync`/`yaml`'s `parse`, mirroring `test/unit/alerts-job-failure-ratio-formula.test.ts`'s own `alerts.yml`-parsing pattern already in the suite). What I *could* run locally is green: `actionlint`, `db:migrations:check`, `npm run selfhost:validate-observability` (the existing PromQL/dashboard validator, confirms the YAML edit is still valid), `npm audit`, and the new test file plus a sibling `alerts-*.test.ts` in isolation via `npx vitest run` — all pass, including the fail-case fixture proving the new check works. CI's `validate-code`/`validate-tests` jobs run on GitHub's own isolated runners with no such contention and will independently confirm the rest (typecheck included) before merge — the same pattern used successfully for PR #6079 earlier this session.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

Not applicable: this is an observability-config + test-only change, no UI/auth/session/API surface touched.

## Notes

- Per the issue's own scope note, this does not invent/register a new `loopover_orb_events_recorded_total` metric — the runbook is corrected to describe real, already-registered metrics instead.
