### PR TITLE
fix(miner-ui): surface portfolio queue action failures to the operator

### DIFF
--- a/apps/loopover-miner-ui/src/portfolio-queue-actions.test.tsx
+++ b/apps/loopover-miner-ui/src/portfolio-queue-actions.test.tsx
@@ -9,6 +9,7 @@ import {
   releasePortfolioQueueItem,
   requeuePortfolioQueueItem,
   type PortfolioQueueActionItem,
+  type PortfolioQueueActionResult,
 } from "./lib/portfolio-queue-actions";
 import { PortfolioPage, PortfolioQueueActionsSection } from "./routes/portfolio";
 import type { PortfolioQueueResult } from "./lib/portfolio-queue";
@@ -45,6 +46,7 @@ describe("PortfolioQueueActionsSection (#4857)", () => {
     render(
       <PortfolioQueueActionsSection
         result={null}
+        actionResult={null}
         pending={false}
         onRelease={() => undefined}
         onRequeue={() => undefined}
@@ -57,6 +59,7 @@ describe("PortfolioQueueActionsSection (#4857)", () => {
     render(
       <PortfolioQueueActionsSection
         result={{ ok: false, error: "connection refused" }}
+        actionResult={null}
         pending={false}
         onRelease={() => undefined}
         onRequeue={() => undefined}
@@ -71,6 +74,7 @@ describe("PortfolioQueueActionsSection (#4857)", () => {
     render(
       <PortfolioQueueActionsSection
         result={{ ok: true, items: [inProgressItem, doneItem] }}
+        actionResult={null}
         pending={false}
         onRelease={onRelease}
         onRequeue={onRequeue}
@@ -86,12 +90,28 @@ describe("PortfolioQueueActionsSection (#4857)", () => {
     render(
       <PortfolioQueueActionsSection
         result={{ ok: true, items: [inProgressItem] }}
+        actionResult={null}
         pending={true}
         onRelease={() => undefined}
         onRequeue={() => undefined}
       />,
     );
     expect((screen.getByRole("button", { name: "Release" }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("renders a visible error when a queue action fails (#6090)", () => {
+    const failed: PortfolioQueueActionResult = { ok: false, error: "queue_entry_not_in_progress" };
+    render(
+      <PortfolioQueueActionsSection
+        result={{ ok: true, items: [inProgressItem] }}
+        actionResult={failed}
+        pending={false}
+        onRelease={() => undefined}
+        onRequeue={() => undefined}
+      />,
+    );
+    expect(screen.getByRole("alert").textContent).toContain("queue_entry_not_in_progress");
+    expect(screen.getByRole("button", { name: "Release" })).toBeTruthy();
   });
 });
 
@@ -115,6 +135,28 @@ describe("PortfolioPage queue actions (#4857)", () => {
     await waitFor(() => expect(screen.getByRole("button", { name: "Release" })).toBeTruthy());
     fireEvent.click(screen.getByRole("button", { name: "Release" }));
     await waitFor(() => expect(releaseItem).toHaveBeenCalledWith(inProgressItem));
+  });
+
+  it("REGRESSION (#6090): a failing release action renders the error and does not re-fetch items as if it succeeded", async () => {
+    const loadPortfolioQueueItems = vi.fn(async () => ({ ok: true as const, items: [inProgressItem] }));
+    const releaseItem = vi.fn(async (): Promise<PortfolioQueueActionResult> => ({
+      ok: false,
+      error: "queue_entry_not_in_progress",
+    }));
+    render(
+      <PortfolioPage
+        loadPortfolioQueue={loadPortfolioQueue}
+        loadPortfolioQueueItems={loadPortfolioQueueItems}
+        releaseItem={releaseItem}
+        pollIntervalMs={60_000}
+      />,
+    );
+    await waitFor(() => expect(screen.getByRole("button", { name: "Release" })).toBeTruthy());
+    expect(loadPortfolioQueueItems).toHaveBeenCalledTimes(1);
+    fireEvent.click(screen.getByRole("button", { name: "Release" }));
+    await waitFor(() => expect(screen.getByRole("alert").textContent).toContain("queue_entry_not_in_progress"));
+    expect(releaseItem).toHaveBeenCalledWith(inProgressItem);
+    expect(loadPortfolioQueueItems).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/loopover-miner-ui/src/routes/portfolio.tsx
+++ b/apps/loopover-miner-ui/src/routes/portfolio.tsx
@@ -9,8 +9,10 @@ import {
   fetchPortfolioQueueItems,
   requeuePortfolioQueueItem,
   releasePortfolioQueueItem,
+  type PortfolioQueueActionItem,
+  type PortfolioQueueActionResult,
+  type PortfolioQueueItemsResult,
 } from "../lib/portfolio-queue-actions";
-import type { PortfolioQueueActionItem, PortfolioQueueItemsResult } from "../lib/portfolio-queue-actions";
 import { DEFAULT_POLL_INTERVAL_MS, usePolledFetch } from "../lib/use-polled-fetch";
 import { fetchPortfolioQueue, type PortfolioQueueResult, type QueueStatus } from "../lib/portfolio-queue";
 
@@ -94,11 +96,13 @@ export function PortfolioQueueView({ result }: { result: PortfolioQueueResult | 
 
 export function PortfolioQueueActionsSection({
   result,
+  actionResult,
   pending,
   onRelease,
   onRequeue,
 }: {
   result: PortfolioQueueItemsResult | null;
+  actionResult: PortfolioQueueActionResult | null;
   pending: boolean;
   onRelease: (item: PortfolioQueueActionItem) => void;
   onRequeue: (item: PortfolioQueueActionItem) => void;
@@ -106,6 +110,11 @@ export function PortfolioQueueActionsSection({
   return (
     <section className="grid gap-3">
       <h3 className="font-display text-token-base font-semibold">Queue actions</h3>
+      {actionResult !== null && !actionResult.ok ? (
+        <p role="alert" className="text-token-sm text-[var(--danger)]">
+          Queue action failed: {actionResult.error}
+        </p>
+      ) : null}
       {result === null ? (
         <p className="text-token-sm text-muted-foreground">Loading actionable queue items…</p>
       ) : !result.ok ? (
@@ -168,6 +177,7 @@ export function PortfolioPage({
   const [refreshKey, setRefreshKey] = useState(0);
   const [actionPending, setActionPending] = useState(false);
   const [itemsResult, setItemsResult] = useState<PortfolioQueueItemsResult | null>(null);
+  const [actionResult, setActionResult] = useState<PortfolioQueueActionResult | null>(null);
 
   const loadSummary = useCallback(() => loadPortfolioQueue(), [loadPortfolioQueue, refreshKey]);
   const summaryResult = usePolledFetch(loadSummary, pollIntervalMs);
@@ -180,11 +190,14 @@ export function PortfolioPage({
     refreshItems();
   }, [refreshItems]);
 
-  const runQueueAction = (action: () => Promise<unknown>) => {
+  const runQueueAction = (action: () => Promise<PortfolioQueueActionResult>) => {
     setActionPending(true);
-    void action().then(() => {
-      setRefreshKey((key) => key + 1);
-      refreshItems();
+    void action().then((next) => {
+      setActionResult(next);
+      if (next.ok) {
+        setRefreshKey((key) => key + 1);
+        refreshItems();
+      }
       setActionPending(false);
     });
   };
@@ -202,6 +215,7 @@ export function PortfolioPage({
           <PortfolioQueueView result={summaryResult} />
           <PortfolioQueueActionsSection
             result={itemsResult}
+            actionResult={actionResult}
             pending={actionPending}
             onRelease={(item) => runQueueAction(() => releaseItem(item))}
             onRequeue={(item) => runQueueAction(() => requeueItem(item))}


### PR DESCRIPTION
## Summary
- Thread `PortfolioQueueActionResult` through `runQueueAction` instead of discarding it, mirroring `runGovernorAction` in the ledgers route.
- Render `{ok: false}` action failures with the same `role=alert` / danger styling convention used elsewhere in miner-ui.
- Only refresh the queue summary/items on `{ok: true}` — failed actions no longer silently re-fetch as if they succeeded.

Closes #6090

## Test plan
- [x] `npm run ui:kit:build && npx vitest run src/portfolio-queue-actions.test.tsx` (19 tests pass)
- [ ] CI green including miner-ui tests and codecov/patch