### PR TITLE
fix(miner): share repo-clone.js's path-safety validation across owner/repo CLI parsers

### DIFF
--- a/packages/loopover-miner/lib/attempt-cli.js
+++ b/packages/loopover-miner/lib/attempt-cli.js
@@ -27,6 +27,7 @@ import { initEventLedger } from "./event-ledger.js";
 import { initAttemptLog } from "./attempt-log.js";
 import { initGovernorLedger } from "./governor-ledger.js";
 import { openWorktreeAllocator } from "./worktree-allocator.js";
+import { isValidRepoSegment } from "./repo-clone.js";
 import { REJECTION_REASON_AI_USAGE_POLICY_BAN, REJECTION_REASON_OWN_SUBMISSION_REJECTED, resolveRejectionSignaled } from "./rejection-signal.js";
 import { cleanupAttemptWorktree, prepareAttemptWorktree } from "./attempt-worktree.js";
 import { fetchSelfReviewContext } from "./self-review-context.js";
@@ -46,6 +47,7 @@ function parseRepoTarget(value) {
   const trimmed = typeof value === "string" ? value.trim() : "";
   const [owner, repo, extra] = trimmed.split("/");
   if (!owner || !repo || extra !== undefined) return null;
+  if (!isValidRepoSegment(owner) || !isValidRepoSegment(repo)) return null;
   return `${owner}/${repo}`;
 }
 

--- a/packages/loopover-miner/lib/claim-ledger-cli.js
+++ b/packages/loopover-miner/lib/claim-ledger-cli.js
@@ -1,5 +1,6 @@
 import { CLAIM_STATUSES, openClaimLedger } from "./claim-ledger.js";
 import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
+import { isValidRepoSegment } from "./repo-clone.js";
 
 const CLAIM_CLAIM_USAGE =
   "Usage: loopover-miner claim claim <owner/repo> <issue#> [--note <text>] [--api-base-url <url>] [--dry-run] [--json]";
@@ -12,7 +13,7 @@ function parseRepoArg(value, usage) {
   if (!value) return { error: usage };
   const trimmed = value.trim();
   const [owner, repo, extra] = trimmed.split("/");
-  if (!owner || !repo || extra !== undefined) {
+  if (!owner || !repo || extra !== undefined || !isValidRepoSegment(owner) || !isValidRepoSegment(repo)) {
     return { error: "Repository must be in owner/repo form." };
   }
   return { repoFullName: `${owner}/${repo}` };

--- a/packages/loopover-miner/lib/claim-ledger.js
+++ b/packages/loopover-miner/lib/claim-ledger.js
@@ -1,6 +1,7 @@
 import { DatabaseSync } from "node:sqlite";
 import { DEFAULT_FORGE_CONFIG } from "./forge-config.js";
 import { normalizeLocalStoreDbPath, openLocalStoreDb, resolveLocalStoreDbPath } from "./local-store.js";
+import { isValidRepoSegment } from "./repo-clone.js";
 import { applySchemaMigrations } from "./schema-version.js";
 import { CLAIM_LEDGER_PURGE_SPEC, purgeStoreByRepo } from "./store-maintenance.js";
 
@@ -27,6 +28,7 @@ function normalizeRepoFullName(repoFullName) {
   if (typeof repoFullName !== "string") throw new Error("invalid_repo_full_name");
   const [owner, repo, extra] = repoFullName.trim().split("/");
   if (!owner || !repo || extra !== undefined) throw new Error("invalid_repo_full_name");
+  if (!isValidRepoSegment(owner) || !isValidRepoSegment(repo)) throw new Error("invalid_repo_full_name");
   return `${owner}/${repo}`;
 }
 

--- a/packages/loopover-miner/lib/cross-repo-evaluation.js
+++ b/packages/loopover-miner/lib/cross-repo-evaluation.js
@@ -8,7 +8,7 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { buildCodingTaskSpec } from "./coding-task-spec.js";
 import { resolveMinerGoalSpec } from "./miner-goal-spec.js";
-import { resolveRepoCloneDir } from "./repo-clone.js";
+import { isPathTraversalSegment, REPO_SEGMENT_PATTERN, resolveRepoCloneDir } from "./repo-clone.js";
 import { detectRepoStack } from "./stack-detection.js";
 
 /** Failure taxonomy surfaced in per-repo reports (#4788). */
@@ -33,14 +33,8 @@ export const DEFAULT_CROSS_REPO_MANIFEST_RELATIVE_PATH = "benchmarks/cross-repo/
 export const MAX_CROSS_REPO_MANIFEST_BYTES = 65_536;
 export const MAX_CROSS_REPO_MANIFEST_REPOS = 100;
 
-const REPO_SEGMENT_PATTERN = /^[A-Za-z0-9._-]+$/;
-
 function cloneEmptyManifest(warnings = []) {
   return { present: false, manifest: { repos: [] }, warnings };
-}
-
-function isPathTraversalSegment(segment) {
-  return segment === "." || segment === "..";
 }
 
 /** Canonical `owner/repo` with exactly one slash and safe segments; anything else → null. */

--- a/packages/loopover-miner/lib/event-ledger-cli.js
+++ b/packages/loopover-miner/lib/event-ledger-cli.js
@@ -1,5 +1,6 @@
 import { initEventLedger } from "./event-ledger.js";
 import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
+import { isValidRepoSegment } from "./repo-clone.js";
 
 const LEDGER_LIST_USAGE =
   "Usage: loopover-miner ledger list [--repo <owner/repo>] [--since <seq>] [--type <eventType>] [--json]";
@@ -8,7 +9,7 @@ function parseRepoArg(value, usage) {
   if (!value) return { error: usage };
   const trimmed = value.trim();
   const [owner, repo, extra] = trimmed.split("/");
-  if (!owner || !repo || extra !== undefined) {
+  if (!owner || !repo || extra !== undefined || !isValidRepoSegment(owner) || !isValidRepoSegment(repo)) {
     return { error: "Repository must be in owner/repo form." };
   }
   return { repoFullName: `${owner}/${repo}` };

--- a/packages/loopover-miner/lib/repo-clone.js
+++ b/packages/loopover-miner/lib/repo-clone.js
@@ -31,10 +31,17 @@ export function resolveRepoCloneBaseDir(env = process.env) {
 // GitHub owner/repo names are restricted to alphanumerics, hyphens, underscores, and periods, and are never
 // exactly "." or ".." -- both are rejected here so a value like "../foo" can't make resolveRepoCloneDir's
 // join(cloneBaseDir, owner, repo) escape the intended clone directory (a real path-traversal finding).
-const REPO_SEGMENT_PATTERN = /^[A-Za-z0-9._-]+$/;
+// Exported so every other owner/repo parser in this package (#5831) shares this one definition instead of
+// duplicating or under-validating it.
+export const REPO_SEGMENT_PATTERN = /^[A-Za-z0-9._-]+$/;
 
-function isPathTraversalSegment(segment) {
+export function isPathTraversalSegment(segment) {
   return segment === "." || segment === "..";
+}
+
+/** A single owner/repo path segment is safe to use: matches the allowed character set and isn't `.`/`..`. */
+export function isValidRepoSegment(segment) {
+  return typeof segment === "string" && REPO_SEGMENT_PATTERN.test(segment) && !isPathTraversalSegment(segment);
 }
 
 // Reject values that git would interpret as options when passed as argv (e.g. `--upload-pack=...`).

--- a/test/unit/miner-attempt-cli.test.ts
+++ b/test/unit/miner-attempt-cli.test.ts
@@ -165,6 +165,17 @@ describe("parseAttemptArgs (#5132)", () => {
     });
   });
 
+  // #5831: repo-clone.js's path-safety validation (character set + no "."/".." segments) must also gate
+  // this CLI's own early parser, not just the downstream prepareWorktree -> repo-clone.js call.
+  it("rejects a repo target with an unsafe path-traversal or invalid-character segment", () => {
+    expect(parseAttemptArgs(["owner/..", "7", "--miner-login", "alice"])).toEqual({
+      error: "Repository must be in owner/repo form: owner/..",
+    });
+    expect(parseAttemptArgs(["owner/repo baz", "7", "--miner-login", "alice"])).toEqual({
+      error: "Repository must be in owner/repo form: owner/repo baz",
+    });
+  });
+
   it("rejects a non-positive or non-integer issue number", () => {
     expect(parseAttemptArgs(["acme/widgets", "0", "--miner-login", "alice"])).toEqual({
       error: "Issue number must be a positive integer: 0",

--- a/test/unit/miner-claim-ledger-cli.test.ts
+++ b/test/unit/miner-claim-ledger-cli.test.ts
@@ -58,6 +58,14 @@ describe("loopover-miner claim ledger CLI (#4290)", () => {
     expect(parseClaimClaimArgs(["acme", "42"])).toEqual({
       error: "Repository must be in owner/repo form.",
     });
+    // #5831: an unsafe path-traversal/character-set segment must be rejected here too, matching
+    // repo-clone.js's own validation, instead of being persisted as a claim-ledger key unvalidated.
+    expect(parseClaimClaimArgs(["acme/..", "42"])).toEqual({
+      error: "Repository must be in owner/repo form.",
+    });
+    expect(parseClaimClaimArgs(["acme/repo baz", "42"])).toEqual({
+      error: "Repository must be in owner/repo form.",
+    });
     expect(parseClaimClaimArgs(["acme/widgets", "0"])).toEqual({
       error: "issue number must be a positive integer.",
     });

--- a/test/unit/miner-claim-ledger.test.ts
+++ b/test/unit/miner-claim-ledger.test.ts
@@ -131,6 +131,15 @@ describe("loopover-miner claim ledger (#2314)", () => {
     expect(() => ledger.listClaims({ status: "bogus" as never })).toThrow("invalid_status");
   });
 
+  // #5831: an unsafe path-traversal/invalid-character segment must be rejected here too, matching
+  // repo-clone.js's own validation, instead of being silently accepted and persisted as a ledger key.
+  it("rejects a repoFullName with a path-traversal or invalid-character segment", () => {
+    const ledger = tempLedger();
+    expect(() => ledger.recordClaim({ repoFullName: "o/..", issueNumber: 1 })).toThrow("invalid_repo_full_name");
+    expect(() => ledger.recordClaim({ repoFullName: "../etc", issueNumber: 1 })).toThrow("invalid_repo_full_name");
+    expect(() => ledger.recordClaim({ repoFullName: "o/repo baz", issueNumber: 1 })).toThrow("invalid_repo_full_name");
+  });
+
   it("claim-then-list, then release, excludes released rows from the active-only filter (#3354)", () => {
     const ledger = tempLedger();
     ledger.recordClaim({ repoFullName: "o/a", issueNumber: 10 });

--- a/test/unit/miner-event-ledger-cli.test.ts
+++ b/test/unit/miner-event-ledger-cli.test.ts
@@ -66,6 +66,20 @@ describe("loopover-miner event ledger CLI (#2290)", () => {
     });
   });
 
+  // #5831: --repo's own parser must reject the same class of malformed/unsafe identifier repo-clone.js
+  // already rejects, not just "missing slash" -- an invalid value was previously accepted unvalidated.
+  it("rejects an unsafe --repo value", () => {
+    expect(parseLedgerListArgs(["--repo", "acme"])).toEqual({
+      error: "Repository must be in owner/repo form.",
+    });
+    expect(parseLedgerListArgs(["--repo", "acme/.."])).toEqual({
+      error: "Repository must be in owner/repo form.",
+    });
+    expect(parseLedgerListArgs(["--repo", "acme/repo baz"])).toEqual({
+      error: "Repository must be in owner/repo form.",
+    });
+  });
+
   it("filterLedgerEvents and renderLedgerTable format rows", () => {
     const events: LedgerEntry[] = [
       {


### PR DESCRIPTION
Closes #5831

## Summary

- `repo-clone.js` and `cross-repo-evaluation.js` each independently validate `owner/repo` strings with a character-set + no-`.`/`..`-segment check before ever joining them into a filesystem path or comparing them.
- Several other owner/repo parsers in the same package (`attempt-cli.js`'s `parseRepoTarget`, `claim-ledger-cli.js`/`event-ledger-cli.js`'s `parseRepoArg`, `claim-ledger.js`'s `normalizeRepoFullName`) only checked "exactly one slash, both halves non-empty" — no character-set or traversal-segment restriction.
- An invalid value (e.g. `owner/..` or a value containing a space) either produced a confusing downstream error instead of the same clear, immediate rejection the "missing slash" case already gets, or — for the claim/event ledgers, which have no downstream re-validation — was silently accepted and persisted as a ledger key.

## What changed

- Exported `REPO_SEGMENT_PATTERN` / `isPathTraversalSegment` from `repo-clone.js` (the existing precedent), plus a new `isValidRepoSegment(segment)` convenience helper combining both checks.
- Removed `cross-repo-evaluation.js`'s duplicate copy of the pattern/helper in favor of importing from `repo-clone.js`.
- Applied `isValidRepoSegment` at the four weaker call sites (`attempt-cli.js`, `claim-ledger-cli.js`, `event-ledger-cli.js`, `claim-ledger.js`), preserving each file's existing error-reporting shape — this only tightens what counts as valid, it does not change how a rejection is reported.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves.

## Validation

- [x] `git diff --check`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` (full local run; pre-existing Windows-only environment failures unrelated to this change — docker-prune script exec-mode checks, path-separator/CRLF differences — are the only failures present, matching the baseline on a clean checkout)
- [x] Regression tests added in `test/unit/miner-attempt-cli.test.ts`, `test/unit/miner-claim-ledger-cli.test.ts`, `test/unit/miner-event-ledger-cli.test.ts`, and `test/unit/miner-claim-ledger.test.ts` covering a path-traversal segment (`owner/..`) and an invalid-character segment (a value containing a space), each expecting the same rejection the existing "missing slash" case already gets.
- [x] Existing malformed-input tests for every touched file continue to pass unmodified.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise.
- [x] No auth/cookie/CORS/GitHub App/Cloudflare/session changes in this PR.
- [x] Not applicable: no API/OpenAPI/MCP schema change (internal CLI validation tightening only).
- [x] Not applicable: no UI change.
- [x] No public docs/changelog changes needed for this fix.