### PR TITLE
fix(miner): bound opportunity-fanout's GitHub reads with a per-request timeout

### DIFF
--- a/packages/loopover-miner/lib/opportunity-fanout.d.ts
+++ b/packages/loopover-miner/lib/opportunity-fanout.d.ts
@@ -20,6 +20,7 @@ export type FanoutOptions = {
   rateLimitHighWaterMark?: number;
   perPage?: number;
   maxPages?: number;
+  requestTimeoutMs?: number;
   sleepFn?: (ms: number) => Promise<unknown>;
   policyDocCache?: PolicyDocCache | null;
   policyVerdictCache?: PolicyVerdictCache | null;

--- a/packages/loopover-miner/lib/opportunity-fanout.js
+++ b/packages/loopover-miner/lib/opportunity-fanout.js
@@ -15,6 +15,7 @@ const defaultPerPage = 100;
 // Follow the GitHub Link header past the first page so a repo/search with >100 open issues isn't silently
 // truncated (#4831); cap the follow loop so a pathological Link chain can't run away.
 const defaultMaxPages = 10;
+const defaultRequestTimeoutMs = 10_000;
 
 function normalizeLimit(value, fallback, min, max) {
   if (!Number.isFinite(value)) return fallback;
@@ -123,11 +124,13 @@ async function githubGetJson(url, githubToken, summary, options, extraHeaders = 
   // Retry a transient 5xx from GitHub before dropping this target's results for the whole run (#4830) — the same
   // discipline as the CI/gate-verdict pollers. A thrown network error still propagates to each caller's try/catch.
   // `extraHeaders` carries per-call additions (e.g. a policy-doc If-None-Match, #4842) on top of the base auth set.
+  // requestTimeoutMs bounds each individual attempt so a stalled connection can't hang discovery forever
+  // (#miner-github-read-timeouts) -- fetchWithRetry gives each retry its own fresh AbortSignal.timeout().
   const response = await fetchWithRetry(
     fetch,
     url,
     { method: "GET", headers: { ...githubHeaders(githubToken, options.forge), ...extraHeaders } },
-    { sleepFn: options?.sleepFn },
+    { sleepFn: options?.sleepFn, timeoutMs: options?.requestTimeoutMs },
   );
   recordRateLimit(summary, response);
   const payload = await response.json().catch(() => null);
@@ -503,6 +506,7 @@ function normalizeOptions(options = {}) {
     ),
     perPage: normalizeLimit(options.perPage, defaultPerPage, 1, 100),
     maxPages: normalizeLimit(options.maxPages, defaultMaxPages, 1, 100),
+    requestTimeoutMs: normalizeLimit(options.requestTimeoutMs, defaultRequestTimeoutMs, 1, 60_000),
     // Passed through to the per-fetch retry so tests can inject an instant sleep; undefined uses the real backoff.
     sleepFn: typeof options.sleepFn === "function" ? options.sleepFn : undefined,
     // Optional local ETag cache for policy-doc revalidation (#4842). Absent (null) => every policy doc is fetched

--- a/test/unit/miner-opportunity-fanout.test.ts
+++ b/test/unit/miner-opportunity-fanout.test.ts
@@ -333,4 +333,66 @@ describe("fetchCandidateIssues (#2307)", () => {
     expect(result.issues.map((entry) => entry.issueNumber)).toEqual([7]); // results kept, not dropped
     expect(result.warnings).toEqual([]); // no warning — the transient blip recovered
   });
+
+  it("bounds every GitHub request with a per-attempt AbortSignal timeout, defaulting to 10s (#miner-github-read-timeouts)", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    const fetchSpy = vi.fn(async (input: RequestInfo | URL, _init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/contents/AI-USAGE.md")) return jsonResponse({}, { status: 404 });
+      if (url.endsWith("/contents/CONTRIBUTING.md")) return contentResponse("Contributions welcome.");
+      if (url.includes("/repos/acme/blip/issues?")) return jsonResponse([issue(7)]);
+      return jsonResponse({}, { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    await fetchCandidateIssuesWithSummary([{ owner: "acme", repo: "blip" }], "token", { apiBaseUrl: API });
+
+    expect(fetchSpy.mock.calls.length).toBeGreaterThanOrEqual(3); // AI-USAGE.md + CONTRIBUTING.md + issues
+    expect(timeoutSpy.mock.calls.length).toBe(fetchSpy.mock.calls.length);
+    expect(timeoutSpy.mock.calls.every(([ms]) => ms === 10_000)).toBe(true);
+    for (const [, init] of fetchSpy.mock.calls) {
+      expect((init as RequestInit | undefined)?.signal).toBeInstanceOf(AbortSignal);
+    }
+    timeoutSpy.mockRestore();
+  });
+
+  it("honors a custom requestTimeoutMs instead of the 10s default", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/contents/AI-USAGE.md")) return jsonResponse({}, { status: 404 });
+      if (url.endsWith("/contents/CONTRIBUTING.md")) return contentResponse("Contributions welcome.");
+      if (url.includes("/repos/acme/blip/issues?")) return jsonResponse([issue(7)]);
+      return jsonResponse({}, { status: 404 });
+    });
+
+    await fetchCandidateIssuesWithSummary([{ owner: "acme", repo: "blip" }], "token", {
+      apiBaseUrl: API,
+      requestTimeoutMs: 3000,
+    });
+
+    expect(timeoutSpy.mock.calls.length).toBeGreaterThan(0);
+    expect(timeoutSpy.mock.calls.every(([ms]) => ms === 3000)).toBe(true);
+    timeoutSpy.mockRestore();
+  });
+
+  it("falls back to the 10s default when requestTimeoutMs is not finite", async () => {
+    const timeoutSpy = vi.spyOn(AbortSignal, "timeout");
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url.endsWith("/contents/AI-USAGE.md")) return jsonResponse({}, { status: 404 });
+      if (url.endsWith("/contents/CONTRIBUTING.md")) return contentResponse("Contributions welcome.");
+      if (url.includes("/repos/acme/blip/issues?")) return jsonResponse([issue(7)]);
+      return jsonResponse({}, { status: 404 });
+    });
+
+    await fetchCandidateIssuesWithSummary([{ owner: "acme", repo: "blip" }], "token", {
+      apiBaseUrl: API,
+      requestTimeoutMs: Number.NaN,
+    });
+
+    expect(timeoutSpy.mock.calls.length).toBeGreaterThan(0);
+    expect(timeoutSpy.mock.calls.every(([ms]) => ms === 10_000)).toBe(true);
+    timeoutSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary
- Follow-up to #6091, flagged as out-of-scope there: `opportunity-fanout.js`'s `githubGetJson` calls the shared `fetchWithRetry` helper (`http-retry.js`) but didn't pass its `timeoutMs` option, so a stalled connection during discovery could still hang indefinitely — the same class of gap already fixed in the 4 sibling attempt-gating pollers.
- Added a `defaultRequestTimeoutMs` constant and a `requestTimeoutMs` field to `normalizeOptions` (reusing this file's own existing `normalizeLimit` clamp helper, matching its established style), then wired `timeoutMs: options?.requestTimeoutMs` into the `fetchWithRetry` call alongside the existing `sleepFn` passthrough.
- `fetchWithRetry` already gives each retry attempt its own fresh `AbortSignal.timeout()` (from #6091) — nothing about its own contract needed to change here, just opting this caller in.

## Test plan
- [x] Extended `test/unit/miner-opportunity-fanout.test.ts` with 3 tests spying on `AbortSignal.timeout`: the 10s default is applied across every GitHub request a discovery run makes (AI-USAGE.md, CONTRIBUTING.md, issues), a custom `requestTimeoutMs` is honored, and a non-finite override falls back to the default.
- [x] `npx vitest run` across all 6 opportunity-fanout test files — 58/58 passed.
- [x] `--coverage --coverage.include=packages/loopover-miner/lib/opportunity-fanout.js` — new lines fully covered (remaining gaps are pre-existing, unrelated to this diff).
- [x] Full local `npm run test:ci` gate green.