### PR TITLE
fix(selfhost): open Grafana's port for --profile observability, opt-in

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,80 @@
+# ORB self-host server — Terraform module
+
+Provisions a single Hetzner Cloud VPS for the **ORB** self-host stack (the persistent HTTP review service), with
+Docker + Docker Compose pre-installed via cloud-init and a persistent volume mounted at `/data` for the SQLite DB
+and Litestream WAL segments.
+
+It is **not** the [`packages/loopover-miner/terraform/`](../packages/loopover-miner/terraform/) module, which
+provisions a fleet-mode AMS miner host and exposes no public endpoints. This module serves public HTTP(S), so its
+firewall opens the Caddy ports to the internet and keeps everything else admin-scoped.
+
+## What it creates
+
+| Resource                   | Purpose                                                                                        |
+| -------------------------- | ---------------------------------------------------------------------------------------------- |
+| `hcloud_server`            | One Ubuntu 24.04 VM (`server_type` default `cx22` = 2 vCPU / 4 GB, sufficient for <50 reviews/day) |
+| `hcloud_firewall`          | Inbound 22 (admin), 80 + 443/tcp + 443/udp (public, Caddy), 8787 (admin), 3000 (admin, opt-in)   |
+| `hcloud_volume` (+ attach) | Persistent ext4 volume mounted at `/data` so the DB and WAL survive re-provisioning              |
+| `hcloud_ssh_key`           | Your SSH public key, for access                                                                  |
+
+## Prerequisites
+
+- [Terraform](https://developer.hashicorp.com/terraform/install) `>= 1.6`
+- A Hetzner Cloud project + API token (console.hetzner.cloud → Security → API Tokens)
+- An SSH key pair
+
+## Usage
+
+```sh
+cd terraform
+
+export TF_VAR_hcloud_token="…"                       # or set it in a *.tfvars file (never commit it)
+terraform init
+terraform plan  -var "ssh_public_key=$(cat ~/.ssh/id_ed25519.pub)"
+terraform apply -var "ssh_public_key=$(cat ~/.ssh/id_ed25519.pub)"
+```
+
+Useful variables (see [`variables.tf`](variables.tf) for all): `server_type`, `location`, `volume_size_gb`,
+`admin_ip_allowlist` (restrict this to your IP in production), `expose_grafana`.
+
+## After apply — start the stack
+
+The module provisions the **host**; you finish setup over SSH (secrets never live in Terraform state):
+
+1. `terraform output ssh_command` → SSH in.
+2. Clone the repo and copy [`../.env.example`](../.env.example) → `.env` — it is the exhaustive reference for
+   every variable the stack reads.
+3. `docker compose up -d` (or `docker compose --profile postgres --profile caddy up -d`).
+
+## Reaching Grafana (`--profile observability`)
+
+`docker compose --profile observability up -d` publishes Grafana on the host at `3000:3000`. Because the
+observability profile is itself opt-in, the firewall does **not** open port 3000 by default — a default-open port
+for a service most operators never start would widen the attack surface for nothing. Pick one:
+
+**SSH tunnel (default, nothing to change).** Keep 3000 closed and forward it over your existing SSH access:
+
+```sh
+ssh -L 3000:localhost:3000 ubuntu@$(terraform output -raw server_ipv4)
+# then browse http://localhost:3000
+```
+
+**Open the port to your own IP.** Set `expose_grafana = true` and re-apply. The rule is always scoped to
+`admin_ip_allowlist` — never `0.0.0.0/0` like the public Caddy ports — so restrict that allowlist to your own
+IP(s) first, or you will publish Grafana to the internet:
+
+```sh
+terraform apply \
+  -var "ssh_public_key=$(cat ~/.ssh/id_ed25519.pub)" \
+  -var "expose_grafana=true" \
+  -var 'admin_ip_allowlist=["203.0.113.4/32"]'
+```
+
+## Outputs
+
+| Output          | Description                            |
+| --------------- | -------------------------------------- |
+| `server_ipv4`   | Public IPv4 of the server              |
+| `server_ipv6`   | Public IPv6 of the server              |
+| `ssh_command`   | Ready-to-run SSH command               |
+| `volume_device` | Block device path for the data volume  |

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -66,6 +66,20 @@ resource "hcloud_firewall" "gittensory" {
     port       = "8787"
     source_ips = var.admin_ip_allowlist
   }
+
+  # Grafana (`docker compose --profile observability`, which publishes 3000:3000 on the host). Opt-in via
+  # var.expose_grafana because the observability profile is itself opt-in — a default-open port for a service
+  # most operators never start would widen the attack surface for nothing. Left off, Grafana stays reachable
+  # over an SSH tunnel (see README.md). Allowlist-scoped like 8787, never 0.0.0.0/0 like the Caddy ports.
+  dynamic "rule" {
+    for_each = var.expose_grafana ? [1] : []
+    content {
+      direction  = "in"
+      protocol   = "tcp"
+      port       = "3000"
+      source_ips = var.admin_ip_allowlist
+    }
+  }
 }
 
 # ── Persistent volume for /data (SQLite DB + Litestream WAL) ──────────────────

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -32,3 +32,9 @@ variable "admin_ip_allowlist" {
   type        = list(string)
   default     = ["0.0.0.0/0", "::/0"]
 }
+
+variable "expose_grafana" {
+  description = "Open Grafana's port (3000) to admin_ip_allowlist for `docker compose --profile observability`. Defaults to false: observability is itself an opt-in profile, and Grafana is otherwise reachable over an SSH tunnel (see README.md). Never opened publicly — the rule is always allowlist-scoped."
+  type        = bool
+  default     = false
+}

--- a/test/unit/root-terraform-grafana-firewall.test.ts
+++ b/test/unit/root-terraform-grafana-firewall.test.ts
@@ -1,0 +1,53 @@
+import { readFileSync } from "node:fs";
+
+import { describe, expect, it } from "vitest";
+
+// Static structural checks for the root ORB Terraform module's Grafana exposure (#5818). docker-compose.yml's
+// `grafana` service (--profile observability) publishes 3000:3000 on the host, but the firewall had no rule for
+// it — not even an admin-scoped one — so an operator following main.tf's own documented flow (provision, then
+// `docker compose --profile observability up -d`) got a timed-out connection with no explanation. These lock in
+// the SAFETY-CRITICAL invariants a `terraform validate` can't see: the port is opt-in, and it can never be
+// opened to the public. Mirrors the pattern in test/unit/miner-terraform-module.test.ts.
+
+const DIR = "terraform";
+const mainTf = readFileSync(`${DIR}/main.tf`, "utf8");
+const variablesTf = readFileSync(`${DIR}/variables.tf`, "utf8");
+const readme = readFileSync(`${DIR}/README.md`, "utf8");
+const dockerCompose = readFileSync("docker-compose.yml", "utf8");
+
+/** The `dynamic "rule"` block that gates Grafana's port, body included. */
+const grafanaRule = /dynamic\s+"rule"\s*\{[\s\S]*?for_each\s*=\s*var\.expose_grafana[\s\S]*?\n {2}\}/.exec(mainTf)?.[0] ?? "";
+
+describe("root Terraform module — Grafana firewall (#5818)", () => {
+  it("still matches the compose service it exists for: grafana publishes 3000 under the observability profile", () => {
+    // If this drifts, the firewall rule below is guarding the wrong port.
+    expect(dockerCompose).toMatch(/grafana:[\s\S]*?profiles:\s*\["observability"\]/);
+    expect(dockerCompose).toMatch(/grafana:[\s\S]*?ports:[\s\S]*?"3000:3000"/);
+  });
+
+  it("opens Grafana's port 3000, gated by var.expose_grafana", () => {
+    expect(grafanaRule, "a dynamic rule gated on var.expose_grafana must exist").not.toBe("");
+    expect(grafanaRule).toMatch(/port\s*=\s*"3000"/);
+    expect(grafanaRule).toMatch(/protocol\s*=\s*"tcp"/);
+    expect(grafanaRule).toMatch(/direction\s*=\s*"in"/);
+  });
+
+  it("INVARIANT: Grafana's port is admin-allowlist-scoped — never opened to the public like the Caddy ports", () => {
+    expect(grafanaRule).toMatch(/source_ips\s*=\s*var\.admin_ip_allowlist/);
+    expect(grafanaRule).not.toMatch(/0\.0\.0\.0\/0/);
+    expect(grafanaRule).not.toMatch(/::\/0/);
+  });
+
+  it("INVARIANT: exposure is opt-in — expose_grafana is a bool defaulting to false", () => {
+    const variable = /variable\s+"expose_grafana"\s*\{[\s\S]*?\n\}/.exec(variablesTf)?.[0] ?? "";
+    expect(variable, "expose_grafana must be declared").not.toBe("");
+    expect(variable).toMatch(/type\s*=\s*bool/);
+    expect(variable).toMatch(/default\s*=\s*false/);
+    expect(variable).toMatch(/description\s*=/); // every var in this file documents itself
+  });
+
+  it("documents both access paths, including a runnable SSH-tunnel command for the closed default", () => {
+    expect(readme).toMatch(/ssh -L 3000:localhost:3000/);
+    expect(readme).toContain("expose_grafana");
+  });
+});


### PR DESCRIPTION
## Summary

Closes #5818

`terraform/main.tf`'s `hcloud_firewall.gittensory` opened exactly four things: TCP/22 (SSH), TCP/80 + TCP/443 + UDP/443 (Caddy), and TCP/8787 (`admin_ip_allowlist`-scoped). Verified against the file: **no rule for port 3000**.

`docker-compose.yml`'s `grafana` service — `profiles: ["observability"]`, `ports: ["3000:3000"]` — publishes Grafana directly on the host. So an operator following `main.tf`'s **own documented flow** (provision the VPS, then `docker compose --profile observability up -d`, a combination the self-hosting docs list as supported) ends up with Grafana bound to the public interface and no path through the cloud firewall to reach it — not even from their own IP. The failure mode is a timed-out connection with no explanation.

**Fix — opt-in, never public.** The rule is gated behind a new `var.expose_grafana` (bool, default `false`) rather than opened unconditionally: the observability profile is itself opt-in, so a default-open port for a service most operators never start would widen the attack surface for nothing. When enabled, the rule is scoped to `var.admin_ip_allowlist`, matching port 8787's existing pattern — never `0.0.0.0/0`/`::/0` like the public Caddy ports. This is the config-as-code resolution the issue's first requirement asks for, with the toggle its second requirement asks for.

Left at the default, Grafana stays reachable over an SSH tunnel. The new **`terraform/README.md`** (this module had none, unlike `packages/loopover-miner/terraform/`) documents both access paths — including the runnable `ssh -L 3000:localhost:3000 …` command — alongside what gets provisioned, the deploy steps `main.tf`'s header already described, and the outputs. It mirrors the miner module README's shape.

## Scope

- [x] Conventional Commit title (`fix(selfhost): …`).
- [x] Focused: one firewall rule + its gating variable + the module README the issue asks for + a structural test.
- [x] Additive and default-inert: with `expose_grafana` at its `false` default, the generated plan is **byte-identical** to today's — no existing rule, resource, or output is touched.
- [x] Follows `CONTRIBUTING.md`; no `site/`/`CNAME`/`lovable` changes; no changelog edit.
- [x] Linked open issue (Closes #5818, above).

## Validation

- [x] `git diff --check` clean.
- [x] **HCL syntax validated with a real parser.** `terraform` is not installed in this environment and — as the issue notes — the repo has no `terraform validate`/`plan` CI step for the root module, so a syntax error here would ship silently. I parsed all three `.tf` files with `python-hcl2`: `main.tf`, `variables.tf`, `outputs.tf` all parse, and the new block parses to exactly the intended shape: `dynamic "rule"` → `for_each = ${var.expose_grafana ? [1] : []}` → `content` = `{direction "in", protocol "tcp", port "3000", source_ips ${var.admin_ip_allowlist}}`.
- [x] New tests green (5), plus the sibling Terraform/self-host suites — `miner-terraform-module`, `self-host-ops-rename-residue` — **16 tests passed**.
- [x] **Proved the tests catch the bug**: reverted only the `.tf` changes and confirmed the three fix-dependent tests fail (rule missing, not allowlist-scoped, variable absent), then pass again with the fix restored.
- [x] Rebased onto current `main`.

The test locks the invariants a syntax check cannot see, mirroring `test/unit/miner-terraform-module.test.ts`:
- The rule exists and is gated on `var.expose_grafana`.
- **INVARIANT:** it is `admin_ip_allowlist`-scoped and contains no `0.0.0.0/0`/`::/0` — it can never be silently made public.
- **INVARIANT:** `expose_grafana` is a `bool` defaulting to `false`, with a description (matching this file's self-documenting style).
- It pins the rule to the compose service it exists for (grafana still publishes `3000:3000` under `profiles: ["observability"]`), so if that drifts, the rule guarding the wrong port fails CI.
- The README documents both access paths, including the SSH-tunnel command.

If any required check was skipped, explain why:

- Full `test:ci` not run end-to-end locally (Linux-only steps on Windows).
- No Codecov patch-coverage obligation: the diff touches only `terraform/**` (HCL + README) and `test/**`, both outside Codecov's `coverage.include`. Noting that explicitly per the issue's Test Coverage Requirements rather than omitting the section.

## Safety

- [x] No secrets, wallets, hotkeys, trust scores, rewards, private rankings, or private maintainer evidence. No credential or token is added; `hcloud_token`/`ssh_public_key` handling is untouched.
- [x] **Security-relevant, and deliberately conservative**: the default (`expose_grafana = false`) opens nothing, so applying this changes no operator's firewall until they opt in. The port can only ever open to `admin_ip_allowlist`, and the test enforces that it can never be widened to `0.0.0.0/0` without failing CI. The README warns to restrict `admin_ip_allowlist` before enabling, since its own default is permissive.
- [x] No auth/cookie/CORS/GitHub App/session change; no application runtime code touched.
- [x] No API/OpenAPI/MCP change; no schema change; no generated artifact affected.
- [x] No UI changes; no changelog edit.
