### PR TITLE
docs(selfhost): document ams-observability and backup in the compose PROFILES header

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,22 +10,25 @@
 #
 # PROFILES — activate optional services by passing --profile <name> (combine freely):
 #
-#   (none)                  SQLite + Redis single-node stack (default — no flags needed)
-#   --profile postgres      pgvector/pg16 shared database (multi-instance capable)
-#   --profile pgbouncer     PgBouncer connection pooler in front of Postgres
-#   --profile qdrant        Qdrant vector database for RAG
-#   --profile ollama        Local Ollama AI backend
-#   --profile gpu           GPU metrics exporter (nvidia-smi -> Prometheus -> Grafana), requires the NVIDIA
-#                           Container Toolkit; combine with --profile ollama on a GPU host
-#   --profile visual-review Headless Chromium (browserless) for before/after PR screenshot capture
-#   --profile rees          Review-enrichment service (REES) for heavier PR analysis, in-network only
-#   --profile litestream    Continuous SQLite backup to S3/B2/R2 via Litestream
-#   --profile workflows     n8n workflow automation (Slack/Teams/email fan-out, scheduled reports)
-#   --profile storage       MinIO S3-compatible object store (Litestream destination, artifact blobs)
-#   --profile caddy         Caddy HTTPS terminator with auto-TLS (set DOMAIN= in .env)
-#   --profile observability Prometheus + Alertmanager + Loki + Promtail + Grafana (pre-wired)
-#   --profile tailscale     Tailscale sidecar — access the stack via your tailnet
-#   --profile runners       GitHub Actions self-hosted runner
+#   (none)                      SQLite + Redis single-node stack (default — no flags needed)
+#   --profile postgres          pgvector/pg16 shared database (multi-instance capable)
+#   --profile pgbouncer         PgBouncer connection pooler in front of Postgres
+#   --profile qdrant            Qdrant vector database for RAG
+#   --profile ollama            Local Ollama AI backend
+#   --profile gpu               GPU metrics exporter (nvidia-smi -> Prometheus -> Grafana), requires the NVIDIA
+#                               Container Toolkit; combine with --profile ollama on a GPU host
+#   --profile visual-review     Headless Chromium (browserless) for before/after PR screenshot capture
+#   --profile rees              Review-enrichment service (REES) for heavier PR analysis, in-network only
+#   --profile litestream        Continuous SQLite backup to S3/B2/R2 via Litestream
+#   --profile workflows         n8n workflow automation (Slack/Teams/email fan-out, scheduled reports)
+#   --profile storage           MinIO S3-compatible object store (Litestream destination, artifact blobs)
+#   --profile caddy             Caddy HTTPS terminator with auto-TLS (set DOMAIN= in .env)
+#   --profile observability     Prometheus + Alertmanager + Loki + Promtail + Grafana (pre-wired)
+#   --profile ams-observability Exports AMS (loopover-miner) attempt-log/prediction-ledger data to the
+#                               AMS Attempt Log / Prediction Ledger Grafana datasources
+#   --profile tailscale         Tailscale sidecar — access the stack via your tailnet
+#   --profile runners           GitHub Actions self-hosted runner
+#   --profile backup            Scheduled Postgres/SQLite + Qdrant-snapshot backups with freshness metrics
 #
 # Examples:
 #   ./scripts/deploy-selfhost-image.sh                            # SQLite + Redis, published image

--- a/test/unit/docker-compose-profiles-header.test.ts
+++ b/test/unit/docker-compose-profiles-header.test.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from "node:fs";
+import { parse } from "yaml";
+import { describe, expect, it } from "vitest";
+
+// Regression check (#5812): docker-compose.yml's header comment banner is the documented entry point for
+// "which --profile flags does this file support", but nothing kept it in sync with the services that
+// actually declare a `profiles: [...]` array -- ams-observability and backup silently drifted out of it.
+// Scans both sides (the real profiles: declarations, and the --profile <name> tokens in the header banner
+// preceding `services:`) and asserts they're the same set, so a future profile addition/removal that
+// forgets the banner fails CI instead of shipping silent doc drift.
+
+interface ComposeService {
+  profiles?: string[];
+}
+interface ComposeDoc {
+  services: Record<string, ComposeService>;
+}
+
+const HEADER_PROFILE_TOKEN_PATTERN = /--profile ([a-z0-9-]+)/g;
+
+/** Every profile name any service in `doc` actually declares via `profiles: [...]`. */
+function declaredProfiles(doc: ComposeDoc): Set<string> {
+  const profiles = new Set<string>();
+  for (const service of Object.values(doc.services)) {
+    for (const profile of service.profiles ?? []) profiles.add(profile);
+  }
+  return profiles;
+}
+
+/** Every `--profile <name>` token mentioned in the header comment block (everything before the first
+ *  `services:` key -- the file's `#`-comment banner, not the machine-readable compose structure). */
+function headerBannerProfiles(fileText: string): Set<string> {
+  const servicesIndex = fileText.indexOf("\nservices:");
+  const header = servicesIndex === -1 ? fileText : fileText.slice(0, servicesIndex);
+  return new Set([...header.matchAll(HEADER_PROFILE_TOKEN_PATTERN)].map((match) => match[1]!));
+}
+
+function assertHeaderMatchesDeclared(doc: ComposeDoc, fileText: string): void {
+  const declared = [...declaredProfiles(doc)].sort();
+  const documented = [...headerBannerProfiles(fileText)].sort();
+  expect(documented).toEqual(declared);
+}
+
+describe("docker-compose.yml PROFILES header (#5812)", () => {
+  it("documents exactly the set of profiles services actually declare in the real file", () => {
+    const fileText = readFileSync("docker-compose.yml", "utf8");
+    const doc = parse(fileText) as ComposeDoc;
+    assertHeaderMatchesDeclared(doc, fileText);
+  });
+
+  it("fails when a service declares a profile missing from the header banner", () => {
+    const doc: ComposeDoc = { services: { foo: { profiles: ["postgres"] }, bar: { profiles: ["undocumented-profile"] } } };
+    const fileText = "#   --profile postgres  a database\nservices:\n  foo:\n";
+    expect(() => assertHeaderMatchesDeclared(doc, fileText)).toThrow();
+  });
+
+  it("fails when the header banner mentions a profile no service declares", () => {
+    const doc: ComposeDoc = { services: { foo: { profiles: ["postgres"] } } };
+    const fileText = "#   --profile postgres  a database\n#   --profile phantom  never declared\nservices:\n  foo:\n";
+    expect(() => assertHeaderMatchesDeclared(doc, fileText)).toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- `docker-compose.yml`'s top-of-file `PROFILES` comment banner — the documented entry point for "which `--profile` flags does this file support" — was missing two real, wired profiles: `ams-observability` (used by the `ams-reporting-exporter` service, which exports AMS/loopover-miner attempt-log/prediction-ledger data to Grafana) and `backup` (used by the `backup` and `backup-exporter` services). Both are already documented elsewhere (`.env.example`, the website docs), just not in the one place an operator is most likely to look first.
- Adds both to the banner with a one-line description matching the existing entries' style, and realigns the whole table's description column since `ams-observability` is longer than any prior entry.
- Adds a regression test (`test/unit/docker-compose-profiles-header.test.ts`) that parses every `profiles: [...]` array any service actually declares and every `--profile <name>` token in the header banner, and asserts the two sets are equal — so a future profile addition/removal that forgets to update the banner fails CI instead of shipping silent doc drift.
- The new test includes both the pass case (the real file, confirmed zero drift after this fix) and two fail cases (a fixture with a declared-but-undocumented profile, and one with a documented-but-undeclared profile), proving the check actually fails when the lists diverge.

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

Closes #5812

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [ ] `npm run typecheck`
- [ ] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [ ] `npm run test:workers`
- [ ] `npm run build:mcp`
- [ ] `npm run test:mcp-pack`
- [ ] `npm run ui:openapi:check`
- [ ] `npm run ui:lint`
- [ ] `npm run ui:typecheck`
- [ ] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- The local machine is under persistent memory contention from multiple concurrent processes on this shared box, and the full `npm run test:ci` chain's local `tsc --noEmit` step OOM-crashes reproducibly. This PR changes zero application `.ts`/`.js` source logic — only a comment block in `docker-compose.yml` and one new self-contained test file (`readFileSync`/`yaml`'s `parse`, mirroring `test/unit/docker-compose-override-example.test.ts`'s own `docker-compose.yml`-parsing pattern already in the suite). What I *could* run locally is green: `actionlint`, `db:migrations:check`, `npm audit`, and the new test file plus its sibling `docker-compose-override-example.test.ts` in isolation via `npx vitest run` — all pass, including both fail-case fixtures proving the new check works. CI's `validate-code`/`validate-tests` jobs run on GitHub's own isolated runners with no such contention and will independently confirm the rest (typecheck included) before merge — the same pattern used successfully for PRs #6079 and #6094 earlier this session.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [ ] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

Not applicable: this is a compose-file comment + test-only change, no UI/auth/session/API surface touched.

## Notes

-
