### PR TITLE
fix(webhook): don't trust a sparse first-ever sync as confirmed no linked issue

### DIFF
--- a/migrations/0152_pull_request_body_observed_at.sql
+++ b/migrations/0152_pull_request_body_observed_at.sql
@@ -1,0 +1,6 @@
+-- First time LoopOver observed a GENUINE (possibly empty) `body` for this PR, as opposed to a narrower webhook
+-- event whose embedded pull_request sub-object omits `body` entirely (#linked-issue-sparse-first-upsert). NULL
+-- means no real body has ever been synced yet -- downstream linked-issue hard-rule enforcement must treat that
+-- as "unverified", never as "confirmed no linked issue", so a sparse FIRST-EVER webhook can no longer trip a
+-- false-positive auto-close. Set once, never cleared (mirrors linked_issue_hard_rule_violated_at).
+ALTER TABLE pull_requests ADD COLUMN body_observed_at TEXT;

--- a/packages/loopover-engine/src/advisory/gate-advisory.ts
+++ b/packages/loopover-engine/src/advisory/gate-advisory.ts
@@ -262,7 +262,12 @@ function addPullRequestFindings(
       detail: `The pull request state is ${pr.state}.`,
     });
   }
-  const noLinkedIssueCited = pr.linkedIssues.length === 0;
+  // A sparse first-ever webhook sync (pr.bodyObservedAt EXPLICITLY null -- see #linked-issue-sparse-first-
+  // upsert) proves nothing about whether an issue is linked; only a genuinely observed body can confirm "none
+  // cited". Strict !== so `undefined` (every caller that predates this field, or that builds a
+  // PullRequestRecord directly rather than reading a DB row -- e.g. this engine's own local/preflight callers,
+  // which always hand in a freshly-read body and never hit the webhook race) stays byte-identical.
+  const noLinkedIssueCited = pr.linkedIssues.length === 0 && pr.bodyObservedAt !== null;
   if ((noLinkedIssueCited || confirmedNoOpenLinkedIssue) && requireLinkedIssue) {
     findings.push({
       code: "missing_linked_issue",

--- a/packages/loopover-engine/src/types/predicted-gate-types.ts
+++ b/packages/loopover-engine/src/types/predicted-gate-types.ts
@@ -79,6 +79,7 @@ export type PullRequestRecord = {
   updatedAt?: string | null | undefined;
   closedAt?: string | null | undefined;
   linkedIssueClaimedAt?: string | null | undefined;
+  bodyObservedAt?: string | null | undefined;
   labels: string[];
   linkedIssues: number[];
   slopRisk?: number | null | undefined;

--- a/src/db/repositories.ts
+++ b/src/db/repositories.ts
@@ -348,7 +348,12 @@ export async function upsertPullRequestFromGitHub(
   const syncedAt = nowIso();
   const lastSeenOpenAt = pr.state === "open" ? (options.seenOpenAt ?? syncedAt) : null;
   const existingClaimRows = await db
-    .select({ linkedIssuesJson: pullRequests.linkedIssuesJson, linkedIssueClaimedAt: pullRequests.linkedIssueClaimedAt, payloadJson: pullRequests.payloadJson })
+    .select({
+      linkedIssuesJson: pullRequests.linkedIssuesJson,
+      linkedIssueClaimedAt: pullRequests.linkedIssueClaimedAt,
+      payloadJson: pullRequests.payloadJson,
+      bodyObservedAt: pullRequests.bodyObservedAt,
+    })
     .from(pullRequests)
     .where(and(eq(pullRequests.repoFullName, repoFullName), eq(pullRequests.number, pr.number)))
     .limit(1);
@@ -375,6 +380,10 @@ export async function upsertPullRequestFromGitHub(
     existingClaimRow,
     observedLinkedIssueClaimedAt,
   );
+  // A genuinely observed body (even an explicitly empty one) proves this PR's linked-issue extraction is
+  // trustworthy going forward; a sparse payload (pr.body === undefined) proves nothing either way and must not
+  // start the clock. Set once, keep forever (#linked-issue-sparse-first-upsert).
+  const bodyObservedAt = existingClaimRow?.bodyObservedAt ?? (pr.body !== undefined ? syncedAt : null);
   await db
     .insert(pullRequests)
     .values({
@@ -393,6 +402,7 @@ export async function upsertPullRequestFromGitHub(
       labelsJson: jsonString(record.labels),
       linkedIssuesJson,
       linkedIssueClaimedAt,
+      bodyObservedAt,
       lastSeenOpenAt,
       payloadJson: jsonString(payload),
       updatedAt: syncedAt,
@@ -412,12 +422,13 @@ export async function upsertPullRequestFromGitHub(
         labelsJson: jsonString(record.labels),
         linkedIssuesJson,
         linkedIssueClaimedAt,
+        bodyObservedAt,
         lastSeenOpenAt,
         payloadJson: jsonString(payload),
         updatedAt: syncedAt,
       },
     });
-  return { ...record, body, linkedIssues, linkedIssueClaimedAt };
+  return { ...record, body, linkedIssues, linkedIssueClaimedAt, bodyObservedAt };
 }
 
 function resolveLinkedIssueClaimedAt(
@@ -6213,6 +6224,7 @@ function toPullRequestRecordFromRow(row: typeof pullRequests.$inferSelect): Pull
     updatedAt: payload.updated_at ?? row.updatedAt,
     closedAt: payload.closed_at,
     linkedIssueClaimedAt: row.linkedIssueClaimedAt,
+    bodyObservedAt: row.bodyObservedAt,
     labels: parseJson<string[]>(row.labelsJson, []),
     linkedIssues: parseJson<number[]>(row.linkedIssuesJson, []),
     slopRisk: row.slopRisk,

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -451,6 +451,12 @@ export const pullRequests = sqliteTable(
     labelsJson: text("labels_json").notNull().default("[]"),
     linkedIssuesJson: text("linked_issues_json").notNull().default("[]"),
     linkedIssueClaimedAt: text("linked_issue_claimed_at"),
+    // First time LoopOver observed a GENUINE (possibly empty) `body` for this PR, as opposed to a narrower
+    // webhook event whose embedded pull_request sub-object omits `body` entirely (#linked-issue-sparse-first-
+    // upsert). NULL means no real body has ever been synced yet -- linked-issue hard-rule enforcement must
+    // treat that as "unverified", never as "confirmed no linked issue". Set once, never cleared (mirrors
+    // linkedIssueHardRuleViolatedAt below).
+    bodyObservedAt: text("body_observed_at"),
     lastSeenOpenAt: text("last_seen_open_at"),
     payloadJson: text("payload_json").notNull().default("{}"),
     // Latest deterministic slop assessment (loopover-computed; written separately from the GitHub sync).

--- a/src/queue/processors.ts
+++ b/src/queue/processors.ts
@@ -7555,6 +7555,7 @@ async function maybeApplyManifestPolicyGate(
       testFileCount,
       passedValidationCount,
       hasNoIssueRationale: hasClearNoIssueRationale(args.pr),
+      bodyObserved: args.pr.bodyObservedAt !== null,
     });
     const policyCodes = new Set([
       "manifest_linked_issue_required",

--- a/src/rules/advisory.ts
+++ b/src/rules/advisory.ts
@@ -762,7 +762,14 @@ function addPullRequestFindings(
       detail: `The pull request state is ${pr.state}.`,
     });
   }
-  const noLinkedIssueCited = pr.linkedIssues.length === 0;
+  // A sparse first-ever webhook sync (pr.bodyObservedAt EXPLICITLY null -- see #linked-issue-sparse-first-
+  // upsert) proves nothing about whether an issue is linked; only a genuinely observed body can confirm "none
+  // cited". Strict !== so `undefined` (every caller/fixture that predates this field, or that builds a
+  // PullRequestRecord directly rather than reading a DB row) stays byte-identical -- only a real DB row's
+  // explicit null (never yet observed) suppresses the finding. confirmedNoOpenLinkedIssue is exempt from this
+  // gate -- it is only ever set after a caller live-verifies a NON-empty linkedIssues set against the GitHub
+  // issues API, which presupposes a real body was already parsed.
+  const noLinkedIssueCited = pr.linkedIssues.length === 0 && pr.bodyObservedAt !== null;
   if ((noLinkedIssueCited || confirmedNoOpenLinkedIssue) && requireLinkedIssue) {
     findings.push({
       code: "missing_linked_issue",

--- a/src/signals/focus-manifest.ts
+++ b/src/signals/focus-manifest.ts
@@ -653,12 +653,19 @@ export function buildFocusManifestGuidance(args: {
   // required/preferred manifest policy must not keep flagging a PR whose body already explains why no
   // issue is linked, same exemption the "Linked issue" review-panel signal already applies.
   hasNoIssueRationale?: boolean | undefined;
+  // Whether the caller has ever genuinely observed this PR's body (as opposed to deriving linkedIssueCount from
+  // a sparse webhook payload that omitted body entirely -- see PullRequestRecord.bodyObservedAt and
+  // #linked-issue-sparse-first-upsert). Default true so callers that always pass a real body directly (e.g. the
+  // MCP preflight tools) stay byte-identical; a webhook-driven caller reading from the DB must pass this
+  // explicitly so a not-yet-observed PR can't trip `manifest_linked_issue_required` off a false empty count.
+  bodyObserved?: boolean | undefined;
 }): FocusManifestGuidance {
   const { manifest } = args;
   const changedPaths = args.changedPaths.filter((path) => typeof path === "string" && path.length > 0);
   const labels = (args.labels ?? []).map((label) => label.toLowerCase());
   const linkedIssueCount = Math.max(0, args.linkedIssueCount ?? 0);
   const hasNoIssueRationale = args.hasNoIssueRationale ?? false;
+  const bodyObserved = args.bodyObserved ?? true;
   const testFileCount = Math.max(0, args.testFileCount ?? 0);
   const passedValidationCount = Math.max(0, args.passedValidationCount ?? 0);
   const codeFileCount = changedPaths.filter(isCodeFile).length;
@@ -733,7 +740,7 @@ export function buildFocusManifestGuidance(args: {
     publicNextSteps.push(`Consider a maintainer-preferred label (${manifest.preferredLabels.slice(0, 3).join(", ")}).`);
   }
 
-  if (manifest.linkedIssuePolicy === "required" && linkedIssueCount === 0 && !hasNoIssueRationale) {
+  if (manifest.linkedIssuePolicy === "required" && linkedIssueCount === 0 && bodyObserved && !hasNoIssueRationale) {
     findings.push({
       code: "manifest_linked_issue_required",
       severity: "warning",

--- a/src/types.ts
+++ b/src/types.ts
@@ -536,6 +536,11 @@ export type PullRequestRecord = {
    * duplicate winners by claim order instead of PR number ONLY when {@link createdAt} is unavailable on either
    * side of a comparison. */
   linkedIssueClaimedAt?: string | null | undefined;
+  /** First time LoopOver observed a GENUINE (possibly empty) `body` for this PR, as opposed to a narrower
+   *  webhook event whose embedded pull_request sub-object omits `body` entirely (#linked-issue-sparse-first-
+   *  upsert). `null`/absent means no real body has ever been synced yet — callers enforcing a linked-issue
+   *  requirement must treat that as unverified, never as "confirmed no linked issue". Set once, never cleared. */
+  bodyObservedAt?: string | null | undefined;
   labels: string[];
   linkedIssues: number[];
   /** Latest deterministic slop assessment (0-100) and band, persisted by the public-surface processor when

--- a/test/unit/db-parsers.test.ts
+++ b/test/unit/db-parsers.test.ts
@@ -526,6 +526,35 @@ describe("database row parser hardening", () => {
     const created = await upsertPullRequestFromGitHub(env, "owner/repo", { number: 9, title: "New PR", state: "open", user: { login: "bob" }, labels: [] });
     expect(created.linkedIssues).toEqual([]);
     expect(created.linkedIssueClaimedAt).toBeNull();
+    // REGRESSION (#linked-issue-sparse-first-upsert): the empty linkedIssues above is UNVERIFIED, not a
+    // confirmed empty body -- bodyObservedAt must stay null so downstream hard-rule enforcement can tell the
+    // two apart and skip the "no linked issue" close until a genuine body sync arrives.
+    expect(created.bodyObservedAt).toBeNull();
+    const stored = await getPullRequest(env, "owner/repo", 9);
+    expect(stored?.bodyObservedAt).toBeNull();
+  });
+
+  it("REGRESSION (#linked-issue-sparse-first-upsert): a full first-ever sync stamps bodyObservedAt immediately", async () => {
+    const env = createTestEnv();
+    // A genuinely observed body -- even one with no closing reference -- proves the empty linkedIssues result
+    // is trustworthy, so bodyObservedAt is set on the very first (non-sparse) upsert.
+    const created = await upsertPullRequestFromGitHub(env, "owner/repo", { number: 11, title: "New PR", state: "open", user: { login: "bob" }, labels: [], body: "no closing reference here" });
+    expect(created.linkedIssues).toEqual([]);
+    expect(typeof created.bodyObservedAt).toBe("string");
+    const stored = await getPullRequest(env, "owner/repo", 11);
+    expect(typeof stored?.bodyObservedAt).toBe("string");
+  });
+
+  it("REGRESSION (#linked-issue-sparse-first-upsert): a later sparse sync does not clear an already-stamped bodyObservedAt", async () => {
+    const env = createTestEnv();
+    const first = await upsertPullRequestFromGitHub(env, "owner/repo", { number: 12, title: "New PR", state: "open", user: { login: "bob" }, labels: [], body: "no closing reference here" });
+    expect(typeof first.bodyObservedAt).toBe("string");
+
+    // A later narrower webhook event omits body entirely -- the once-set observation timestamp must survive.
+    const resynced = await upsertPullRequestFromGitHub(env, "owner/repo", { number: 12, title: "New PR", state: "open", user: { login: "bob" }, labels: [] });
+    expect(resynced.bodyObservedAt).toBe(first.bodyObservedAt);
+    const stored = await getPullRequest(env, "owner/repo", 12);
+    expect(stored?.bodyObservedAt).toBe(first.bodyObservedAt);
   });
 
   it("countRecentDeadLetters counts github_app.dlq_dead_lettered audits since a cutoff, independent of any ops flag (#1276)", async () => {

--- a/test/unit/focus-manifest.test.ts
+++ b/test/unit/focus-manifest.test.ts
@@ -619,6 +619,19 @@ describe("buildFocusManifestGuidance", () => {
     expect(guidance.findings.some((finding) => finding.code === "manifest_linked_issue_required")).toBe(true);
   });
 
+  it("REGRESSION (#linked-issue-sparse-first-upsert): does NOT require a linked issue when the caller reports the body was never genuinely observed", () => {
+    // A webhook-driven caller passes bodyObserved: false when PullRequestRecord.bodyObservedAt is still null
+    // (a sparse first-ever sync) -- the zero linkedIssueCount is unverified in that state, not confirmed empty,
+    // so this must not fire the same false-positive auto-close bug PRs #5985/#5994 hit.
+    const guidance = buildFocusManifestGuidance({ manifest: wanted, changedPaths: ["src/x.ts"], linkedIssueCount: 0, testFileCount: 1, bodyObserved: false });
+    expect(guidance.findings.some((finding) => finding.code === "manifest_linked_issue_required")).toBe(false);
+  });
+
+  it("still requires a linked issue when bodyObserved is explicitly true (a genuinely observed empty body)", () => {
+    const guidance = buildFocusManifestGuidance({ manifest: wanted, changedPaths: ["src/x.ts"], linkedIssueCount: 0, testFileCount: 1, bodyObserved: true });
+    expect(guidance.findings.some((finding) => finding.code === "manifest_linked_issue_required")).toBe(true);
+  });
+
   it("REGRESSION (#no-issue-rationale-exemption): does not require a linked issue when the caller reports a clear no-issue rationale", () => {
     const guidance = buildFocusManifestGuidance({ manifest: wanted, changedPaths: ["src/x.ts"], linkedIssueCount: 0, testFileCount: 1, hasNoIssueRationale: true });
     expect(guidance.findings.some((finding) => finding.code === "manifest_linked_issue_required")).toBe(false);

--- a/test/unit/predicted-gate-engine-coverage.test.ts
+++ b/test/unit/predicted-gate-engine-coverage.test.ts
@@ -338,6 +338,14 @@ describe("predicted-gate engine module coverage (#2283)", () => {
     expect(queueHealth.findings.some((f) => f.code === "inactive_draft_prs")).toBe(true);
   });
 
+  it("REGRESSION (#linked-issue-sparse-first-upsert): does not flag missing_linked_issue when bodyObservedAt is explicitly null, but still flags it once observed", () => {
+    const unobserved = buildPullRequestAdvisory(REPO, { ...PR, linkedIssues: [], bodyObservedAt: null }, { requireLinkedIssue: true });
+    expect(unobserved.findings.some((f) => f.code === "missing_linked_issue")).toBe(false);
+
+    const observed = buildPullRequestAdvisory(REPO, { ...PR, linkedIssues: [], bodyObservedAt: "2026-07-14T00:00:00.000Z" }, { requireLinkedIssue: true });
+    expect(observed.findings.some((f) => f.code === "missing_linked_issue")).toBe(true);
+  });
+
   it("exercises gate holds, readiness score branches, and linked-issue advisory paths", () => {
     const advisory = buildPullRequestAdvisory(REPO, PR, { requireLinkedIssue: true, confirmedNoOpenLinkedIssue: true, linkedIssueAuthorLogins: ["miner1"] });
     expect(advisory.findings.some((f) => f.code === "missing_linked_issue")).toBe(true);

--- a/test/unit/queue-2.test.ts
+++ b/test/unit/queue-2.test.ts
@@ -3981,6 +3981,190 @@ describe("queue processors", () => {
     expect(JSON.stringify(gatePatches[0])).toContain("Configured validation evidence missing");
   });
 
+  // REGRESSION (#linked-issue-sparse-first-upsert): a narrower webhook event's embedded pull_request sub-object
+  // can omit `body` entirely (undefined, not GitHub's explicit `null` for a genuinely empty description) --
+  // this is the FIRST-EVER sync for the PR, so there's no prior row's linkedIssuesJson to fall back to
+  // (#linked-issue-sparse-payload-preserve only guards a RESYNC). Without bodyObservedAt tracking, the empty
+  // linkedIssues this derives gets trusted as "confirmed no linked issue" and the manifest gate closes the PR
+  // outright -- this is what happened to PRs #5985/#5994 in production.
+  it("does NOT flag manifest_linked_issue_required on a first-ever sync whose payload omits body entirely", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await persistRegistrySnapshot(
+      env,
+      normalizeRegistryPayload(
+        { "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } },
+        { kind: "raw-github", url: "https://example.test" },
+        "2026-05-23T00:00:00.000Z",
+      ),
+    );
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    await upsertInstallation(env, {
+      installation: {
+        id: 123,
+        account: { login: "JSONbored", id: 1, type: "User" },
+        repository_selection: "selected",
+        permissions: { metadata: "read", pull_requests: "write", issues: "write" },
+        events: ["pull_request"],
+      },
+      repositories: [{ name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }],
+    });
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      commentMode: "off",
+      publicSurface: "off",
+      autoLabelEnabled: false,
+      checkRunMode: "off",
+      reviewCheckMode: "required",
+      linkedIssueGateMode: "off",
+      manifestPolicyGateMode: "block",
+      requireLinkedIssue: false,
+      typeLabelsEnabled: false,
+    });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { linkedIssuePolicy: "required" });
+    await upsertPullRequestFile(env, {
+      repoFullName: "JSONbored/gittensory",
+      pullNumber: 46,
+      path: "src/feature.ts",
+      status: "modified",
+      additions: 1,
+      deletions: 0,
+      changes: 1,
+      payload: {},
+    });
+
+    const gatePatches: Array<Record<string, unknown>> = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url === "https://api.gittensor.io/miners") return Response.json([]);
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/commits/gate-sparse-body/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/check-runs") && method === "POST") return Response.json({ id: 904 }, { status: 201 });
+      if (url.includes("/check-runs/904") && method === "PATCH") {
+        gatePatches.push(JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>);
+        return Response.json({ id: 904, html_url: "https://github.com/checks/904" });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "gate-sparse-body-first-sync",
+      eventName: "pull_request",
+      payload: {
+        action: "opened",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        pull_request: {
+          number: 46,
+          title: "First sync via a sparse event shape",
+          state: "open",
+          user: { login: "contributor" },
+          head: { sha: "gate-sparse-body" },
+          labels: [],
+          // No `body` key at all -- simulates a narrower webhook event's embedded pull_request sub-object.
+        },
+      },
+    });
+
+    const stored = await getPullRequest(env, "JSONbored/gittensory", 46);
+    expect(stored?.bodyObservedAt).toBeNull();
+    expect(gatePatches).toHaveLength(1);
+    expect(gatePatches[0]).toMatchObject({ status: "completed", conclusion: "success" });
+    expect(JSON.stringify(gatePatches[0])).not.toContain("Maintainer requires a linked issue");
+    expect(JSON.stringify(gatePatches[0])).not.toContain("manifest_linked_issue_required");
+  });
+
+  // Companion to the sparse-first-sync test above: once a genuine (even empty) body has been observed for the
+  // same PR, the manifest gate must resume enforcing linkedIssuePolicy: "required" normally -- the fix only
+  // silences the false positive for the unverified window, it does not disable the policy.
+  it("still flags manifest_linked_issue_required once a genuine empty body has been observed", async () => {
+    const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: await generatePrivateKeyPem() });
+    await persistRegistrySnapshot(
+      env,
+      normalizeRegistryPayload(
+        { "JSONbored/gittensory": { emission_share: 0.01, issue_discovery_share: 0 } },
+        { kind: "raw-github", url: "https://example.test" },
+        "2026-05-23T00:00:00.000Z",
+      ),
+    );
+    await upsertRepositoryFromGitHub(env, { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }, 123);
+    await upsertInstallation(env, {
+      installation: {
+        id: 123,
+        account: { login: "JSONbored", id: 1, type: "User" },
+        repository_selection: "selected",
+        permissions: { metadata: "read", pull_requests: "write", issues: "write" },
+        events: ["pull_request"],
+      },
+      repositories: [{ name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } }],
+    });
+    await upsertRepositorySettings(env, {
+      repoFullName: "JSONbored/gittensory",
+      commentMode: "off",
+      publicSurface: "off",
+      autoLabelEnabled: false,
+      checkRunMode: "off",
+      reviewCheckMode: "required",
+      linkedIssueGateMode: "off",
+      manifestPolicyGateMode: "block",
+      requireLinkedIssue: false,
+      typeLabelsEnabled: false,
+    });
+    await upsertRepoFocusManifest(env, "JSONbored/gittensory", { linkedIssuePolicy: "required" });
+    await upsertPullRequestFile(env, {
+      repoFullName: "JSONbored/gittensory",
+      pullNumber: 47,
+      path: "src/feature.ts",
+      status: "modified",
+      additions: 1,
+      deletions: 0,
+      changes: 1,
+      payload: {},
+    });
+
+    const gatePatches: Array<Record<string, unknown>> = [];
+    vi.stubGlobal("fetch", async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = input.toString();
+      const method = init?.method ?? "GET";
+      if (url === "https://api.gittensor.io/miners") return Response.json([]);
+      if (url.includes("/access_tokens")) return Response.json({ token: "installation-token" });
+      if (url.includes("/commits/gate-observed-body/check-runs")) return Response.json({ total_count: 0, check_runs: [] });
+      if (url.includes("/check-runs") && method === "POST") return Response.json({ id: 905 }, { status: 201 });
+      if (url.includes("/check-runs/905") && method === "PATCH") {
+        gatePatches.push(JSON.parse(String(init?.body ?? "{}")) as Record<string, unknown>);
+        return Response.json({ id: 905, html_url: "https://github.com/checks/905" });
+      }
+      return new Response("not found", { status: 404 });
+    });
+
+    await processJob(env, {
+      type: "github-webhook",
+      deliveryId: "gate-observed-empty-body",
+      eventName: "pull_request",
+      payload: {
+        action: "opened",
+        installation: { id: 123, account: { login: "JSONbored", id: 1, type: "User" } },
+        repository: { name: "gittensory", full_name: "JSONbored/gittensory", private: false, owner: { login: "JSONbored" } },
+        pull_request: {
+          number: 47,
+          title: "No description at all",
+          state: "open",
+          user: { login: "contributor" },
+          head: { sha: "gate-observed-body" },
+          labels: [],
+          body: null,
+        },
+      },
+    });
+
+    const stored = await getPullRequest(env, "JSONbored/gittensory", 47);
+    expect(typeof stored?.bodyObservedAt).toBe("string");
+    expect(gatePatches).toHaveLength(1);
+    expect(gatePatches[0]).toMatchObject({ status: "completed", conclusion: "failure" });
+    expect(JSON.stringify(gatePatches[0])).toContain("Maintainer requires a linked issue");
+  });
+
   // REGRESSION (#4719 gate-review finding): passedValidationCount previously came ONLY from a PR-body
   // prose match (hasValidationNote), with zero connection to the PR's actual CI results -- a fully green
   // PR whose body simply doesn't happen to use a "tested"/"validated" word still tripped

--- a/test/unit/rules.test.ts
+++ b/test/unit/rules.test.ts
@@ -75,6 +75,49 @@ describe("advisory rules", () => {
     expect(advisory.findings.map((finding) => finding.code)).toContain("missing_linked_issue");
   });
 
+  it("REGRESSION (#linked-issue-sparse-first-upsert): does NOT flag a not-yet-body-observed PR as missing a linked issue", () => {
+    // pr.bodyObservedAt EXPLICITLY null (a real DB row) means no genuine body sync has landed yet -- the empty
+    // linkedIssues here is unverified, not a confirmed empty body. Firing the finding on this state is exactly
+    // the false-positive auto-close bug (PRs #5985/#5994) that motivated tracking this field.
+    const pr: PullRequestRecord = {
+      repoFullName: repo.fullName,
+      number: 16,
+      title: "Add registry sync",
+      state: "open",
+      authorLogin: "oktofeesh1",
+      authorAssociation: "NONE",
+      headSha: "abc123",
+      labels: ["feature"],
+      linkedIssues: [],
+      bodyObservedAt: null,
+    };
+
+    const advisory = buildPullRequestAdvisory(repo, pr, { requireLinkedIssue: true });
+
+    expect(advisory.conclusion).toBe("success");
+    expect(advisory.findings.map((finding) => finding.code)).not.toContain("missing_linked_issue");
+  });
+
+  it("still flags missing linked issue once bodyObservedAt is stamped (a genuinely observed empty body)", () => {
+    const pr: PullRequestRecord = {
+      repoFullName: repo.fullName,
+      number: 17,
+      title: "Add registry sync",
+      state: "open",
+      authorLogin: "oktofeesh1",
+      authorAssociation: "NONE",
+      headSha: "abc123",
+      labels: ["feature"],
+      linkedIssues: [],
+      bodyObservedAt: "2026-07-14T00:00:00.000Z",
+    };
+
+    const advisory = buildPullRequestAdvisory(repo, pr, { requireLinkedIssue: true });
+
+    expect(advisory.conclusion).toBe("neutral");
+    expect(advisory.findings.map((finding) => finding.code)).toContain("missing_linked_issue");
+  });
+
   it("does NOT flag a cited-but-unverified linked issue as missing (byte-identical to today when the caller hasn't confirmed it's dead)", () => {
     const pr: PullRequestRecord = {
       repoFullName: repo.fullName,


### PR DESCRIPTION
## Summary
- A narrower webhook event's embedded `pull_request` sub-object can omit `body` entirely. The existing sparse-payload protection (`#linked-issue-sparse-payload-preserve` in `upsertPullRequestFromGitHub`) only guards a RESYNC — it falls back to the *existing* row's linked-issue data when the new payload is sparse.
- On a PR's FIRST-EVER sync, there is no existing row to fall back to, so a sparse first sync derives an empty `linkedIssuesJson` from the absent body and that empty result gets trusted as **verified ground truth** by the "no linked issue" hard-rule enforcement — closing PRs that genuinely had a linked issue, before their real body ever synced. This is what happened to PRs #5985 and #5994 (reported via Discord), where the bot closed with "No linked issue detected; Maintainer requires a linked issue" despite both PRs linking an issue in their description.
- Adds `pull_requests.body_observed_at`: stamped the first time a genuine (possibly empty) body is actually observed for a PR, never cleared. `missing_linked_issue` (`src/rules/advisory.ts`) and `manifest_linked_issue_required` (`src/signals/focus-manifest.ts`) now only fire once a body has genuinely been observed — closing the false-positive window without weakening either rule once real data lands (a genuinely empty body still trips the finding as before).
- Mirrored into the engine-parity gate-decision twin (`packages/loopover-engine/src/advisory/gate-advisory.ts`, `packages/loopover-engine/src/types/predicted-gate-types.ts`) per its co-edit-or-version-bump requirement — the local/preflight MCP tools never hit this race (they always read a freshly-supplied body directly), so this is a parity-only addition there.

## Test plan
- [x] `npm run test:ci` (full local gate) green
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] `npm run engine-parity:drift-check` — 20 hand-duplicated pairs agree
- [x] New DB-layer regression tests in `test/unit/db-parsers.test.ts` (sparse-first-sync leaves `bodyObservedAt` null; a full first sync stamps it; a later sparse resync doesn't clear it)
- [x] New unit tests in `test/unit/rules.test.ts` and `test/unit/focus-manifest.test.ts` proving both findings are suppressed when unobserved and still fire once observed, with existing fixtures (which omit the new field) asserted byte-identical
- [x] New end-to-end webhook integration tests in `test/unit/queue-2.test.ts` reproducing the exact reported bug (a `pull_request.opened` payload with `body` entirely omitted) and confirming the gate no longer closes, plus a companion test confirming the policy still enforces once a genuine body is observed
- [x] New engine-twin test in `test/unit/predicted-gate-engine-coverage.test.ts`
- [x] Spot-checked `coverage/lcov.info` DA/BRDA records for every new line/branch across all changed files — 100% line and branch coverage, no zero-hit branches