### PR TITLE
docs(selfhost): document every docker-compose.yml var in .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -240,6 +240,10 @@ LOOPOVER_REVIEW_DRAFT=false
 #                                            #   scopes dashboard sign-in, not the shared MCP token's per-repo reach.
 # PORT=8787
 # DATABASE_PATH=/data/loopover.sqlite     # SQLite file on the mounted data volume; all migrations auto-apply
+# LOOPOVER_REPO_CONFIG_DIR=/config           # in-container dir the app reads per-repo .loopover.yml files from
+# COMPOSE_PROJECT_NAME=loopover              # Docker Compose's own project name; also labels the log stream
+#                                            #   Promtail ships to Loki. Change it to run two stacks on one host.
+# TZ=UTC                                     # timezone passed to n8n (--profile workflows) for cron schedules
 # POSTGRES_PASSWORD=change-this-long-random-value  # used by the --profile postgres / --profile pgbouncer services
 # DATABASE_URL=                              # set to postgres://user:pw@host:5432/db to use Postgres instead of
 #                                            #   SQLite (shared DB → multi-instance). Overrides DATABASE_PATH.
@@ -348,6 +352,7 @@ REDIS_URL=redis://redis:6379                # REQUIRED for the self-host review 
 # REDIS_MEM_LIMIT=512m                       # core app (always runs)
 # POSTGRES_MEM_LIMIT=2g                      # --profile postgres / --profile pgbouncer
 # QDRANT_MEM_LIMIT=2g                        # --profile qdrant
+# REES_MEM_LIMIT=512m                        # --profile rees (the review-enrichment service)
 # OLLAMA_MEM_LIMIT=20g                       # --profile ollama; raise this before pulling a large local model
 #                                            #   (default sized for an embed model + one vision model resident
 #                                            #   together, #4335 -- raise further for additional/larger models)
@@ -376,6 +381,15 @@ REDIS_URL=redis://redis:6379                # REQUIRED for the self-host review 
 # BACKUP_ACKNOWLEDGED=false                  # silences the boot-time warning about running SQLite with no
                                               #   acknowledged backup once you've wired Litestream (or an
                                               #   equivalent) above. Default false (warning shown).
+
+# --- Snapshot backups (--profile backup; the backup + backup-exporter sidecars) ---
+# Separate from Litestream above: this runs scripts/backup.sh on a loop and exports the result as metrics.
+# BACKUP_RETAIN=7                            # how many snapshots to keep before pruning the oldest
+# BACKUP_INTERVAL_SECONDS=86400              # seconds between runs (default 86400 = daily)
+# Opt-in restore drill (scripts/verify-backup.sh): both are empty by default, which skips the drill. Set the
+# pair together to restore each snapshot into a scratch database and prove it is actually restorable.
+# VERIFY_RESTORE_SCRATCH=                    # non-empty enables the drill
+# LOOPOVER_VERIFY_SCRATCH_DATABASE_URL=      # throwaway scratch DB the drill restores into (never your live DB)
 
 # --- n8n workflow automation (--profile workflows) ---
 # N8N_PASSWORD=changeme                     # REQUIRED at runtime when using --profile workflows
@@ -519,6 +533,10 @@ REDIS_URL=redis://redis:6379                # REQUIRED for the self-host review 
 # prometheus/rules/, routing in alertmanager/alertmanager.yml — silent until you fill in a receiver) +
 # Loki + Promtail (ship every container's logs to Loki) + Grafana (dashboards for metrics AND logs).
 # GRAFANA_ADMIN_PASSWORD=                    # REQUIRED at runtime when using --profile observability; generate a strong value
+# PROMETHEUS_RETENTION_TIME=90d              # metrics history window (a full quarter for trend/capacity review).
+#                                            #   Deliberately longer than Loki's 14d / Tempo's 7d: the TSDB
+#                                            #   compresses samples to ~1-2 bytes each, so metrics cost far less
+#                                            #   disk per retained day than raw logs or span trees (#1828).
 # GRAFANA_LOCAL_SMOKE_PASSWORD=              # optional local-only fallback for smoke tests; never expose Grafana with this
 #
 # Maintainer dashboards (in addition to the infra dashboard):
@@ -527,6 +545,7 @@ REDIS_URL=redis://redis:6379                # REQUIRED for the self-host review 
 #   • "Resource hub" — links to every integrated service.
 # GRAFANA_REPORTING_EXPORT_INTERVAL_SECONDS=30  # refresh cadence for the redacted reporting SQLite export
 # LOOPOVER_REPORTING_SOURCE_DB=/appdb/loopover.sqlite  # if DATABASE_PATH=/data/custom.sqlite, set /appdb/custom.sqlite
+# LOOPOVER_REPORTING_DB=/reporting/loopover-reporting.sqlite  # where the redacted export is written (Grafana reads this)
 #
 # AMS (loopover-miner) ledger dashboards — only useful when a miner ALSO runs on this same host (see
 # packages/loopover-miner/docs/observability.md). Requires --profile ams-observability, separate from the
@@ -535,6 +554,13 @@ REDIS_URL=redis://redis:6379                # REQUIRED for the self-host review 
 # snapshot (free-form attempt_log_events.reason/.payload_json dropped) into the same reporting volume.
 # LOOPOVER_MINER_CONFIG_DIR=~/.config/loopover-miner  # host dir the exporter mounts read-only at /ams-ledgers
 # LOOPOVER_AMS_REPORTING_EXPORT_INTERVAL_SECONDS=30    # refresh cadence for the redacted AMS ledger exports
+# Path overrides for the same exporter — in-container paths, not host paths. The source pair lives under the
+# read-only /ams-ledgers mount above; the reporting pair is written into the shared reporting volume. Override
+# only if your miner names its ledgers differently.
+# LOOPOVER_AMS_ATTEMPT_LOG_SOURCE_DB=/ams-ledgers/attempt-log.sqlite3
+# LOOPOVER_AMS_PREDICTION_LEDGER_SOURCE_DB=/ams-ledgers/prediction-ledger.sqlite3
+# LOOPOVER_AMS_ATTEMPT_LOG_REPORTING_DB=/reporting/ams-attempt-log.sqlite
+# LOOPOVER_AMS_PREDICTION_LEDGER_REPORTING_DB=/reporting/ams-prediction-ledger.sqlite
 #
 # Claude usage telemetry → OTEL collector → Prometheus → the Claude usage dashboard. OFF by default.
 # CLAUDE_CODE_ENABLE_TELEMETRY=1             # enable; needs --profile observability (starts the otel-collector)
@@ -557,7 +583,11 @@ REDIS_URL=redis://redis:6379                # REQUIRED for the self-host review 
 #                                            #   images bake LOOPOVER_VERSION=gittensory-selfhost@<version>, so do
 #                                            #   not override SENTRY_RELEASE for those images.
 # OTEL_METRIC_EXPORT_INTERVAL=10000          # ms between metric exports (default 10s here; CLI default is 60s)
+# OTEL_METRICS_EXPORTER=otlp                 # metrics-side counterpart to OTEL_TRACES_EXPORTER; empty = no app metrics
 # OTEL_EXPORTER_OTLP_ENDPOINT=http://otel-collector:4318   # override only for an external collector
+# OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf  # wire protocol for the endpoint above (http/protobuf | grpc)
+# OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE=cumulative  # cumulative is what Prometheus expects; change
+#                                            #   only for a backend that requires delta temporality
 # OTEL_SERVICE_NAME=gittensory-selfhost
 #
 # Live upstream PR/issue census (the GitHub data source). Install is automatic (GF_INSTALL_PLUGINS); add the
@@ -603,6 +633,10 @@ REDIS_URL=redis://redis:6379                # REQUIRED for the self-host review 
 # runtime-only: set AI_PROVIDER plus the provider-specific auth below. Set INSTALL_AI_CLIS=false only for a
 # custom minimal local build that will never use the subscription CLI providers.
 # INSTALL_AI_CLIS=true
+# INSTALL_VISUAL_REVIEW=false                # sibling build arg: installs puppeteer-core for a LOCAL build.
+#                                            #   Official release images already bundle it, so this only matters
+#                                            #   when you build the image yourself and want LOOPOVER_REVIEW_SCREENSHOTS
+#                                            #   (the --profile visual-review browserless service is the alternative).
 #
 # Deprecated shared AI_* knobs are intentionally rejected at startup:
 # AI_BASE_URL, AI_API_KEY, AI_MODEL, AI_EFFORT, AI_TIMEOUT_MS. Use the explicit

--- a/test/unit/docker-compose-env-example-parity.test.ts
+++ b/test/unit/docker-compose-env-example-parity.test.ts
@@ -1,0 +1,80 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+// Drift guard for #5814: docker-compose.yml's own header calls .env.example "the exhaustive reference", but
+// ~18 variables compose actually interpolates were documented nowhere — the whole --profile backup block, the
+// AMS exporter path overrides, the OTEL metrics-side siblings, PROMETHEUS_RETENTION_TIME, REES_MEM_LIMIT. This
+// is a distinct check from `npm run selfhost:env-reference`, which scans process.env reads under
+// src/selfhost/** and never looks at docker-compose.yml or .env.example at all.
+//
+// Every compose variable must be documented in .env.example (live `NAME=` or commented `# NAME=`) or, for the
+// Docker-secrets `*_FILE` vars deliberately kept out of the sample file, in secrets/README.md's table.
+
+const ROOT = process.cwd();
+const composeText = readFileSync(join(ROOT, "docker-compose.yml"), "utf8");
+const envExampleText = readFileSync(join(ROOT, ".env.example"), "utf8");
+const secretsReadmeText = readFileSync(join(ROOT, "secrets/README.md"), "utf8");
+
+/**
+ * `${VAR}` / `${VAR:-default}` / `${VAR:?err}` that compose really interpolates.
+ *
+ * The negative lookbehind is load-bearing: compose escapes a literal `$` as `$$`, so `$${GF_SECURITY_ADMIN_PASSWORD:-}`
+ * is passed through to the container's shell and resolved there — it is NOT a compose variable, and demanding
+ * `.env.example` document it would be wrong.
+ */
+function composeInterpolatedVars(compose: string): string[] {
+  return [...new Set([...compose.matchAll(/(?<!\$)\$\{([A-Z_][A-Z0-9_]*)/g)].map((m) => m[1]!))].sort();
+}
+
+/** Live `NAME=` and commented `# NAME=` reference lines alike — both count as documented. */
+function documentedInEnvExample(envExample: string): Set<string> {
+  return new Set([...envExample.matchAll(/^\s*#?\s*([A-Z_][A-Z0-9_]*)=/gm)].map((m) => m[1]!));
+}
+
+/** The `*_FILE` vars in secrets/README.md's table, intentionally documented there instead of .env.example. */
+function documentedInSecretsReadme(secretsReadme: string): Set<string> {
+  return new Set([...secretsReadme.matchAll(/\b([A-Z_][A-Z0-9_]*_FILE)\b/g)].map((m) => m[1]!));
+}
+
+function undocumentedComposeVars(compose: string, envExample: string, secretsReadme: string): string[] {
+  const documented = documentedInEnvExample(envExample);
+  const secrets = documentedInSecretsReadme(secretsReadme);
+  return composeInterpolatedVars(compose).filter((name) => !documented.has(name) && !secrets.has(name));
+}
+
+describe("docker-compose.yml ↔ .env.example parity (#5814)", () => {
+  it("finds the compose variables at all (guards the parser itself, so the check can't pass vacuously)", () => {
+    const vars = composeInterpolatedVars(composeText);
+    expect(vars.length).toBeGreaterThan(50);
+    expect(vars).toContain("PROMETHEUS_RETENTION_TIME");
+    expect(documentedInEnvExample(envExampleText).size).toBeGreaterThan(50);
+    expect(documentedInSecretsReadme(secretsReadmeText)).toContain("GITHUB_APP_PRIVATE_KEY_FILE");
+  });
+
+  it("ignores $$-escaped shell variables, which compose never interpolates", () => {
+    // `$${FOO}` reaches the container's shell as `${FOO}`; only the un-escaped `${BAR}` is a compose var.
+    expect(composeInterpolatedVars('a: "$${FOO:-x}"\nb: "${BAR:-y}"')).toEqual(["BAR"]);
+  });
+
+  it("INVARIANT: every compose variable is documented in .env.example or secrets/README.md", () => {
+    expect(undocumentedComposeVars(composeText, envExampleText, secretsReadmeText)).toEqual([]);
+  });
+
+  it("catches a real gap: a variable dropped from .env.example is reported (proves the guard works)", () => {
+    // Strip PROMETHEUS_RETENTION_TIME's documentation line — the check must notice.
+    const stripped = envExampleText
+      .split("\n")
+      .filter((line) => !/^\s*#?\s*PROMETHEUS_RETENTION_TIME=/.test(line))
+      .join("\n");
+    expect(undocumentedComposeVars(composeText, stripped, secretsReadmeText)).toEqual(["PROMETHEUS_RETENTION_TIME"]);
+  });
+
+  it("counts a *_FILE secret as documented via secrets/README.md, not .env.example", () => {
+    const compose = 'x: "${GITHUB_APP_PRIVATE_KEY_FILE}"';
+    expect(undocumentedComposeVars(compose, "", secretsReadmeText)).toEqual([]);
+    // …and reports it when it is documented in neither.
+    expect(undocumentedComposeVars(compose, "", "")).toEqual(["GITHUB_APP_PRIVATE_KEY_FILE"]);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #5814

`docker-compose.yml`'s own header calls `.env.example` **"the exhaustive reference"** an operator copies to `.env` before running the stack. It wasn't. Cross-referencing every `${VAR}` interpolation compose actually uses against every name the sample file documents (live `NAME=` and commented `# NAME=` alike) found **18 real gaps** — knobs the stack reads that an operator could only discover by reading `docker-compose.yml` itself:

| Area | Undocumented vars |
|---|---|
| `--profile backup` (entirely undocumented) | `BACKUP_RETAIN`, `BACKUP_INTERVAL_SECONDS`, and the opt-in restore-drill pair `VERIFY_RESTORE_SCRATCH` + `LOOPOVER_VERIFY_SCRATCH_DATABASE_URL` |
| AMS reporting-exporter paths | the four `LOOPOVER_AMS_*_SOURCE_DB` / `*_REPORTING_DB` overrides |
| Core reporting-exporter | `LOOPOVER_REPORTING_DB` (the documented `LOOPOVER_REPORTING_SOURCE_DB`'s output sibling) |
| Always-on `loopover` service | `LOOPOVER_REPO_CONFIG_DIR` |
| OTEL metrics side | `OTEL_METRICS_EXPORTER`, `OTEL_EXPORTER_OTLP_PROTOCOL`, `OTEL_EXPORTER_OTLP_METRICS_TEMPORALITY_PREFERENCE` |
| Misc | `PROMETHEUS_RETENTION_TIME`, `REES_MEM_LIMIT`, `INSTALL_VISUAL_REVIEW` |
| Compose/system | `COMPOSE_PROJECT_NAME`, `TZ` |

Each is added in the file's existing `# NAME=default   # explanation, --profile X` style, grouped under the section it belongs to (a new "Snapshot backups" block under the existing backup section, the OTEL metrics vars beside their traces siblings, `REES_MEM_LIMIT` in the `*_MEM_LIMIT` block, etc.). **No default or behavior is invented** — every documented value is the one `docker-compose.yml` already uses (`BACKUP_RETAIN=7`, `PROMETHEUS_RETENTION_TIME=90d`, …), and `PROMETHEUS_RETENTION_TIME`'s note summarizes compose's own stated rationale rather than inventing one.

### Two deviations from the issue's list, both deliberate

1. **`COMPOSE_PROJECT_NAME` and `TZ` are included** though the issue's enumeration omits them. They *are* real compose interpolations (`${COMPOSE_PROJECT_NAME:-loopover}` in `promtail`, `${TZ:-UTC}` in `n8n`), so the drift guard this issue **requires** fails unless they're documented too. Documenting them is what makes the file exhaustive — the issue's own Expected Outcome.
2. **`GF_SECURITY_ADMIN_PASSWORD` / `N8N_BASIC_AUTH_PASSWORD` are *not* included**, though a naive grep suggests they're missing. They appear as `$${VAR}` — compose escapes a literal `$` as `$$`, so those reach the container's shell and are resolved there. They are **not** compose variables, and documenting them as `.env` knobs would be wrong. The guard's regex encodes this (see below).

## Scope

- [x] Conventional Commit title (`docs(selfhost): …`).
- [x] Focused: documentation of existing vars + the drift guard the issue asks for. **No behavior change** — `.env.example` is a sample file; every line added is a comment.
- [x] Follows `CONTRIBUTING.md`; no `site/`/`CNAME`/`lovable` changes; no changelog edit.
- [x] Linked open issue (Closes #5814, above).

## Validation

- [x] `git diff --check` clean.
- [x] New drift guard green (5 tests), plus the sibling `.env.example` metric-name guard — **6 tests passed**.
- [x] **Verified the gap list independently** rather than trusting the issue: parsed all 97 compose interpolations and diffed against the documented set. Re-ran after the edit → **zero remaining gaps**.
- [x] **Proved the guard catches the real bug**: reverted only `.env.example` and the invariant reports exactly the 18 pre-fix gaps (`[ 'BACKUP_INTERVAL_SECONDS', …(17) ]`); restored → green.
- [x] Rebased onto current `main` (which already carries #6079's `.env.example` change — no conflict).

The guard (`test/unit/docker-compose-env-example-parity.test.ts`) is a distinct check from `npm run selfhost:env-reference`, which scans `process.env` reads under `src/selfhost/**` and never looks at `docker-compose.yml` or `.env.example`. It covers, per the issue's requirement of both a pass and a fail case:

- **Pass**: every compose var is documented in `.env.example` or `secrets/README.md`.
- **Fail (fixture)**: a variable stripped from `.env.example` is reported — proving it catches drift, not just that it passes today.
- **`$$`-escape**: `$${FOO}` is ignored, `${BAR}` is not.
- **Secrets path**: a `*_FILE` var counts as documented via `secrets/README.md`, and is reported when documented in neither.
- **Parser self-guard**: asserts it found >50 compose vars and >50 documented names, so a regex regression can't make the invariant pass vacuously.

If any required check was skipped, explain why:

- Full `test:ci` not run end-to-end locally (Linux-only steps on Windows).
- Codecov: `.env.example` is a config file outside `coverage.include`, so the patch gate does not apply to the documentation edit; the new guard lives under `test/unit/**`. The guard's own logic is fully exercised by the five cases above (both sides of every branch: documented/undocumented, escaped/unescaped, secrets/not-secrets).

## Safety

- [x] No secrets, wallets, hotkeys, trust scores, rewards, private rankings, or private maintainer evidence. Every added line is a commented sample; no real value is committed, and the two password vars that *look* missing are deliberately excluded (see above) rather than documented with invented values.
- [x] No auth/cookie/CORS/GitHub App/session change; no application runtime code touched.
- [x] No API/OpenAPI/MCP change; no schema change; no generated artifact affected.
- [x] Every added var is commented out, so copying `.env.example` → `.env` yields byte-identical runtime behavior to today — the defaults documented are the ones compose already applies.
- [x] No UI changes; no changelog edit.
