### PR TITLE
fix(miner): share repo-clone.js's path-safety validation across owner/repo CLI parsers

### DIFF
--- a/packages/loopover-miner/lib/attempt-cli.js
+++ b/packages/loopover-miner/lib/attempt-cli.js
@@ -27,6 +27,7 @@ import { initEventLedger } from "./event-ledger.js";
 import { initAttemptLog } from "./attempt-log.js";
 import { initGovernorLedger } from "./governor-ledger.js";
 import { openWorktreeAllocator } from "./worktree-allocator.js";
+import { isValidRepoSegment } from "./repo-clone.js";
 import { REJECTION_REASON_AI_USAGE_POLICY_BAN, REJECTION_REASON_OWN_SUBMISSION_REJECTED, resolveRejectionSignaled } from "./rejection-signal.js";
 import { cleanupAttemptWorktree, prepareAttemptWorktree } from "./attempt-worktree.js";
 import { fetchSelfReviewContext } from "./self-review-context.js";
@@ -46,6 +47,7 @@ function parseRepoTarget(value) {
   const trimmed = typeof value === "string" ? value.trim() : "";
   const [owner, repo, extra] = trimmed.split("/");
   if (!owner || !repo || extra !== undefined) return null;
+  if (!isValidRepoSegment(owner) || !isValidRepoSegment(repo)) return null;
   return `${owner}/${repo}`;
 }
 

--- a/packages/loopover-miner/lib/claim-ledger-cli.js
+++ b/packages/loopover-miner/lib/claim-ledger-cli.js
@@ -1,5 +1,6 @@
 import { CLAIM_STATUSES, openClaimLedger } from "./claim-ledger.js";
 import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
+import { isValidRepoSegment } from "./repo-clone.js";
 
 const CLAIM_CLAIM_USAGE =
   "Usage: loopover-miner claim claim <owner/repo> <issue#> [--note <text>] [--api-base-url <url>] [--dry-run] [--json]";
@@ -12,7 +13,7 @@ function parseRepoArg(value, usage) {
   if (!value) return { error: usage };
   const trimmed = value.trim();
   const [owner, repo, extra] = trimmed.split("/");
-  if (!owner || !repo || extra !== undefined) {
+  if (!owner || !repo || extra !== undefined || !isValidRepoSegment(owner) || !isValidRepoSegment(repo)) {
     return { error: "Repository must be in owner/repo form." };
   }
   return { repoFullName: `${owner}/${repo}` };

--- a/packages/loopover-miner/lib/claim-ledger.js
+++ b/packages/loopover-miner/lib/claim-ledger.js
@@ -1,6 +1,7 @@
 import { DatabaseSync } from "node:sqlite";
 import { DEFAULT_FORGE_CONFIG } from "./forge-config.js";
 import { normalizeLocalStoreDbPath, openLocalStoreDb, resolveLocalStoreDbPath } from "./local-store.js";
+import { isValidRepoSegment } from "./repo-clone.js";
 import { applySchemaMigrations } from "./schema-version.js";
 import { CLAIM_LEDGER_PURGE_SPEC, purgeStoreByRepo } from "./store-maintenance.js";
 
@@ -27,6 +28,7 @@ function normalizeRepoFullName(repoFullName) {
   if (typeof repoFullName !== "string") throw new Error("invalid_repo_full_name");
   const [owner, repo, extra] = repoFullName.trim().split("/");
   if (!owner || !repo || extra !== undefined) throw new Error("invalid_repo_full_name");
+  if (!isValidRepoSegment(owner) || !isValidRepoSegment(repo)) throw new Error("invalid_repo_full_name");
   return `${owner}/${repo}`;
 }
 

--- a/packages/loopover-miner/lib/cross-repo-evaluation.js
+++ b/packages/loopover-miner/lib/cross-repo-evaluation.js
@@ -8,7 +8,7 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { buildCodingTaskSpec } from "./coding-task-spec.js";
 import { resolveMinerGoalSpec } from "./miner-goal-spec.js";
-import { resolveRepoCloneDir } from "./repo-clone.js";
+import { isValidRepoSegment, resolveRepoCloneDir } from "./repo-clone.js";
 import { detectRepoStack } from "./stack-detection.js";
 
 /** Failure taxonomy surfaced in per-repo reports (#4788). */
@@ -33,14 +33,8 @@ export const DEFAULT_CROSS_REPO_MANIFEST_RELATIVE_PATH = "benchmarks/cross-repo/
 export const MAX_CROSS_REPO_MANIFEST_BYTES = 65_536;
 export const MAX_CROSS_REPO_MANIFEST_REPOS = 100;
 
-const REPO_SEGMENT_PATTERN = /^[A-Za-z0-9._-]+$/;
-
 function cloneEmptyManifest(warnings = []) {
   return { present: false, manifest: { repos: [] }, warnings };
-}
-
-function isPathTraversalSegment(segment) {
-  return segment === "." || segment === "..";
 }
 
 /** Canonical `owner/repo` with exactly one slash and safe segments; anything else → null. */
@@ -48,8 +42,7 @@ export function normalizeCrossRepoFullName(value) {
   if (typeof value !== "string") return null;
   const [owner, repo, extra] = value.trim().split("/");
   if (!owner || !repo || extra !== undefined) return null;
-  if (!REPO_SEGMENT_PATTERN.test(owner) || !REPO_SEGMENT_PATTERN.test(repo)) return null;
-  if (isPathTraversalSegment(owner) || isPathTraversalSegment(repo)) return null;
+  if (!isValidRepoSegment(owner) || !isValidRepoSegment(repo)) return null;
   return `${owner}/${repo}`;
 }
 

--- a/packages/loopover-miner/lib/event-ledger-cli.js
+++ b/packages/loopover-miner/lib/event-ledger-cli.js
@@ -1,5 +1,6 @@
 import { initEventLedger } from "./event-ledger.js";
 import { argsWantJson, describeCliError, reportCliFailure } from "./cli-error.js";
+import { isValidRepoSegment } from "./repo-clone.js";
 
 const LEDGER_LIST_USAGE =
   "Usage: loopover-miner ledger list [--repo <owner/repo>] [--since <seq>] [--type <eventType>] [--json]";
@@ -8,7 +9,7 @@ function parseRepoArg(value, usage) {
   if (!value) return { error: usage };
   const trimmed = value.trim();
   const [owner, repo, extra] = trimmed.split("/");
-  if (!owner || !repo || extra !== undefined) {
+  if (!owner || !repo || extra !== undefined || !isValidRepoSegment(owner) || !isValidRepoSegment(repo)) {
     return { error: "Repository must be in owner/repo form." };
   }
   return { repoFullName: `${owner}/${repo}` };

--- a/packages/loopover-miner/lib/repo-clone.d.ts
+++ b/packages/loopover-miner/lib/repo-clone.d.ts
@@ -2,6 +2,12 @@ export function resolveRepoCloneBaseDir(env?: Record<string, string | undefined>
 
 export function resolveRepoCloneDir(repoFullName: string, env?: Record<string, string | undefined>): string;
 
+export const REPO_SEGMENT_PATTERN: RegExp;
+
+export function isPathTraversalSegment(segment: string): boolean;
+
+export function isValidRepoSegment(segment: unknown): boolean;
+
 export type EnsureRepoClonedResult = { ok: boolean; repoPath: string; error?: string };
 
 export type RunGitFn = (args: string[], cwd: string, timeoutMs: number) => Promise<{ ok: boolean; stdout: string; stderr: string }>;

--- a/packages/loopover-miner/lib/repo-clone.js
+++ b/packages/loopover-miner/lib/repo-clone.js
@@ -31,10 +31,17 @@ export function resolveRepoCloneBaseDir(env = process.env) {
 // GitHub owner/repo names are restricted to alphanumerics, hyphens, underscores, and periods, and are never
 // exactly "." or ".." -- both are rejected here so a value like "../foo" can't make resolveRepoCloneDir's
 // join(cloneBaseDir, owner, repo) escape the intended clone directory (a real path-traversal finding).
-const REPO_SEGMENT_PATTERN = /^[A-Za-z0-9._-]+$/;
+// Exported so every other owner/repo parser in this package (#5831) shares this one definition instead of
+// duplicating it (cross-repo-evaluation.js) or skipping it entirely (attempt-cli.js, claim-ledger-cli.js,
+// event-ledger-cli.js, claim-ledger.js).
+export const REPO_SEGMENT_PATTERN = /^[A-Za-z0-9._-]+$/;
 
-function isPathTraversalSegment(segment) {
+export function isPathTraversalSegment(segment) {
   return segment === "." || segment === "..";
+}
+
+export function isValidRepoSegment(segment) {
+  return typeof segment === "string" && REPO_SEGMENT_PATTERN.test(segment) && !isPathTraversalSegment(segment);
 }
 
 // Reject values that git would interpret as options when passed as argv (e.g. `--upload-pack=...`).
@@ -46,8 +53,7 @@ function normalizeRepoFullName(repoFullName) {
   if (typeof repoFullName !== "string") throw new Error("invalid_repo_full_name");
   const [owner, repo, extra] = repoFullName.trim().split("/");
   if (!owner || !repo || extra !== undefined) throw new Error("invalid_repo_full_name");
-  if (!REPO_SEGMENT_PATTERN.test(owner) || !REPO_SEGMENT_PATTERN.test(repo)) throw new Error("invalid_repo_full_name");
-  if (isPathTraversalSegment(owner) || isPathTraversalSegment(repo)) throw new Error("invalid_repo_full_name");
+  if (!isValidRepoSegment(owner) || !isValidRepoSegment(repo)) throw new Error("invalid_repo_full_name");
   return { owner, repo, repoFullName: `${owner}/${repo}` };
 }
 

--- a/test/unit/miner-attempt-cli.test.ts
+++ b/test/unit/miner-attempt-cli.test.ts
@@ -165,6 +165,24 @@ describe("parseAttemptArgs (#5132)", () => {
     });
   });
 
+  // #5831: repo-clone.js's path-safety validation (character set + no "."/".." segments) must also gate
+  // this CLI's own early parser, not just the downstream prepareWorktree -> repo-clone.js call -- for
+  // both the owner and repo segment independently.
+  it("rejects a repo target with an unsafe owner or repo segment", () => {
+    expect(parseAttemptArgs(["../etc", "7", "--miner-login", "alice"])).toEqual({
+      error: "Repository must be in owner/repo form: ../etc",
+    });
+    expect(parseAttemptArgs(["owner/..", "7", "--miner-login", "alice"])).toEqual({
+      error: "Repository must be in owner/repo form: owner/..",
+    });
+    expect(parseAttemptArgs(["owner baz/repo", "7", "--miner-login", "alice"])).toEqual({
+      error: "Repository must be in owner/repo form: owner baz/repo",
+    });
+    expect(parseAttemptArgs(["owner/repo baz", "7", "--miner-login", "alice"])).toEqual({
+      error: "Repository must be in owner/repo form: owner/repo baz",
+    });
+  });
+
   it("rejects a non-positive or non-integer issue number", () => {
     expect(parseAttemptArgs(["acme/widgets", "0", "--miner-login", "alice"])).toEqual({
       error: "Issue number must be a positive integer: 0",

--- a/test/unit/miner-claim-ledger-cli.test.ts
+++ b/test/unit/miner-claim-ledger-cli.test.ts
@@ -58,6 +58,21 @@ describe("loopover-miner claim ledger CLI (#4290)", () => {
     expect(parseClaimClaimArgs(["acme", "42"])).toEqual({
       error: "Repository must be in owner/repo form.",
     });
+    // #5831: an unsafe path-traversal/character-set segment must be rejected here too, matching
+    // repo-clone.js's own validation, instead of being persisted as a claim-ledger key unvalidated --
+    // for both the owner and repo segment independently.
+    expect(parseClaimClaimArgs(["../etc", "42"])).toEqual({
+      error: "Repository must be in owner/repo form.",
+    });
+    expect(parseClaimClaimArgs(["acme/..", "42"])).toEqual({
+      error: "Repository must be in owner/repo form.",
+    });
+    expect(parseClaimClaimArgs(["acme baz/widgets", "42"])).toEqual({
+      error: "Repository must be in owner/repo form.",
+    });
+    expect(parseClaimClaimArgs(["acme/widgets baz", "42"])).toEqual({
+      error: "Repository must be in owner/repo form.",
+    });
     expect(parseClaimClaimArgs(["acme/widgets", "0"])).toEqual({
       error: "issue number must be a positive integer.",
     });

--- a/test/unit/miner-claim-ledger.test.ts
+++ b/test/unit/miner-claim-ledger.test.ts
@@ -131,6 +131,17 @@ describe("loopover-miner claim ledger (#2314)", () => {
     expect(() => ledger.listClaims({ status: "bogus" as never })).toThrow("invalid_status");
   });
 
+  // #5831: an unsafe path-traversal/invalid-character segment must be rejected here too, matching
+  // repo-clone.js's own validation, instead of being silently accepted and persisted as a ledger key --
+  // for both the owner and repo segment independently.
+  it("rejects a repoFullName with a path-traversal or invalid-character segment", () => {
+    const ledger = tempLedger();
+    expect(() => ledger.recordClaim({ repoFullName: "../etc", issueNumber: 1 })).toThrow("invalid_repo_full_name");
+    expect(() => ledger.recordClaim({ repoFullName: "o/..", issueNumber: 1 })).toThrow("invalid_repo_full_name");
+    expect(() => ledger.recordClaim({ repoFullName: "o baz/a", issueNumber: 1 })).toThrow("invalid_repo_full_name");
+    expect(() => ledger.recordClaim({ repoFullName: "o/a baz", issueNumber: 1 })).toThrow("invalid_repo_full_name");
+  });
+
   it("claim-then-list, then release, excludes released rows from the active-only filter (#3354)", () => {
     const ledger = tempLedger();
     ledger.recordClaim({ repoFullName: "o/a", issueNumber: 10 });

--- a/test/unit/miner-cross-repo-evaluation.test.ts
+++ b/test/unit/miner-cross-repo-evaluation.test.ts
@@ -55,6 +55,16 @@ describe("cross-repo evaluation harness (#4788)", () => {
       expect(normalizeCrossRepoFullName("../evil/repo")).toBeNull();
       expect(normalizeCrossRepoFullName(12)).toBeNull();
     });
+
+    // #5831: this file's own copy of the path-safety check now comes from repo-clone.js's shared
+    // isValidRepoSegment -- exercise a traversal/invalid-character segment in both the owner and repo
+    // position (a "one slash" value, unlike "../evil/repo" above which is rejected earlier for having two).
+    it("rejects an unsafe owner or repo segment even with exactly one slash", () => {
+      expect(normalizeCrossRepoFullName("../foo")).toBeNull();
+      expect(normalizeCrossRepoFullName("foo/..")).toBeNull();
+      expect(normalizeCrossRepoFullName("ac me/widgets")).toBeNull();
+      expect(normalizeCrossRepoFullName("acme/wid gets")).toBeNull();
+    });
   });
 
   describe("parseCrossRepoEvaluationManifest", () => {

--- a/test/unit/miner-event-ledger-cli.test.ts
+++ b/test/unit/miner-event-ledger-cli.test.ts
@@ -66,6 +66,26 @@ describe("loopover-miner event ledger CLI (#2290)", () => {
     });
   });
 
+  // #5831: --repo's own parser must reject the same class of malformed/unsafe identifier repo-clone.js
+  // already rejects, not just "missing slash" -- for both the owner and repo segment independently.
+  it("rejects an unsafe --repo value", () => {
+    expect(parseLedgerListArgs(["--repo", "acme"])).toEqual({
+      error: "Repository must be in owner/repo form.",
+    });
+    expect(parseLedgerListArgs(["--repo", "../etc"])).toEqual({
+      error: "Repository must be in owner/repo form.",
+    });
+    expect(parseLedgerListArgs(["--repo", "acme/.."])).toEqual({
+      error: "Repository must be in owner/repo form.",
+    });
+    expect(parseLedgerListArgs(["--repo", "acme baz/widgets"])).toEqual({
+      error: "Repository must be in owner/repo form.",
+    });
+    expect(parseLedgerListArgs(["--repo", "acme/widgets baz"])).toEqual({
+      error: "Repository must be in owner/repo form.",
+    });
+  });
+
   it("filterLedgerEvents and renderLedgerTable format rows", () => {
     const events: LedgerEntry[] = [
       {


### PR DESCRIPTION
## Summary

- `repo-clone.js` already had a real path-safety check (character-set + no `.`/`..` segments) for `owner/repo` values, but `attempt-cli.js`, `claim-ledger-cli.js`, `event-ledger-cli.js`, and `claim-ledger.js` only checked "exactly one slash, both halves non-empty" — an unsafe value like `owner/..` or `owner baz/repo` was accepted at those entry points and either produced a generic downstream error or (for the two ledger CLIs) was persisted unvalidated as a ledger key.
- Extracted `repo-clone.js`'s pattern + traversal check into one exported `isValidRepoSegment` helper (alongside the existing `REPO_SEGMENT_PATTERN`/`isPathTraversalSegment`, now also exported) and pointed all five call sites — including `cross-repo-evaluation.js`'s previously duplicated copy — at the same source of truth.
- Each call site keeps its own error-reporting shape (`parseAttemptArgs`'s `{ error }`, the ledger CLIs' `reportCliFailure`, `claim-ledger.js`'s thrown `invalid_repo_full_name`) — only the validity check got stricter.

Closes #5831

## Scope

- [x] The PR title follows `type(scope): short summary` Conventional Commit format, for example `fix(api): restore profile access checks`.
- [x] This PR is focused and does not mix unrelated backend, UI, MCP, docs, dependency, and deploy changes.
- [x] This follows `CONTRIBUTING.md` and does not reintroduce GitHub Pages, VitePress, `site/`, or `CNAME`.
- [x] I linked a currently open issue this PR resolves (e.g. `Closes #123`) — a linked open issue is required for every contributor PR.

## Validation

- [x] `git diff --check`
- [x] `npm run actionlint`
- [x] `npm run typecheck`
- [x] `npm run test:coverage` locally; **`codecov/patch` requires ≥99% coverage of the lines AND branches you changed** (aim for **100%** on your diff so CI variance does not fail near the threshold). Global coverage is a non-blocking trend with a loose 90% backstop, not the gate.
- [x] `npm run test:workers`
- [x] `npm run build:mcp`
- [x] `npm run test:mcp-pack`
- [x] `npm run ui:openapi:check`
- [x] `npm run ui:lint`
- [x] `npm run ui:typecheck`
- [x] `npm run ui:build`
- [x] `npm audit --audit-level=moderate`
- [x] New or changed behavior has unit/integration tests for new branches, fallback paths, and sanitizer boundaries

If any required check was skipped, explain why:

- None skipped. This is a backend-only (`packages/loopover-miner/lib/**`) change with no `apps/loopover-ui`, OpenAPI, or wrangler-binding surface, so the UI/OpenAPI checks above are unaffected passes rather than active validations of new behavior.

## Safety

- [x] No secrets, wallet details, hotkeys, coldkeys, user PATs, private keys, raw trust scores, private rankings, or private maintainer evidence are exposed.
- [x] Public GitHub text stays sanitized, low-noise, and does not imply compensation guarantees or optimization tactics.
- [x] Auth, cookie, CORS, GitHub App, Cloudflare, or session changes include negative-path tests.
- [x] API/OpenAPI/MCP behavior is updated and tested where needed.
- [x] UI changes use live API data or real empty/error/loading states, not production mock/demo fallbacks.
- [x] Visible UI changes include a `UI Evidence` section below with JPG/JPEG or PNG screenshots arranged as organized, captioned, clickable thumbnails. SVG screenshots are not used as review evidence. Review-only screenshots or recordings are not committed to the repository.
- [x] Public docs/changelogs are updated where needed; changelogs are only edited for release-prep PRs.

## UI Evidence

Not applicable — no UI/frontend/docs-visible change.

## Notes

- `packages/loopover-miner/lib/purge-cli.js` has its own `parseRepoArg` with the same "one slash" weakness but is out of scope: it isn't listed in #5831's deliverables, and this PR keeps the diff to the exact call sites the issue calls out.
