### PR TITLE
fix(queue): close self-close review-evasion after publish, not just mid-review

### DIFF
--- a/src/queue/review-evasion.ts
+++ b/src/queue/review-evasion.ts
@@ -9,7 +9,6 @@
 import {
   getGateBlockOutcome,
   getInstallation,
-  hasActiveReviewForHeadSha,
   hasReviewedForHeadSha,
   isGlobalAgentFrozen,
   recordAuditEvent,
@@ -535,14 +534,23 @@ async function hasMaintainerOrOwnerPermission(env: Env, installationId: number, 
   return permission === "admin" || permission === "maintain" || permission === "write";
 }
 
-/** Review-evasion protection (#review-evasion-protection): a CONTRIBUTOR closing their OWN PR while
- *  loopover has an ACTIVE review pass running against its current headSha is dodging the one-shot review,
- *  not making an ordinary close. GitHub lets a contributor reopen a PR they closed themselves but NOT one
- *  closed by a maintainer or the App (#one-shot-reopen) -- so this reopens the PR (as the App) and
- *  immediately re-closes it (as the App), converting the contributor's own close into an App-authored,
- *  terminal one they cannot reopen; any later reopen attempt is caught by the EXISTING
- *  maybeRecloseDisallowedReopen guard above. Per-PR actuation-locked like its draft-dodge/reopen-reclose
- *  siblings. The strike only counts once the enforcement close actually succeeds. */
+/** Review-evasion protection (#review-evasion-protection, broadened #self-close-post-review): a CONTRIBUTOR
+ *  closing their OWN PR after loopover has run a review pass against its current headSha is dodging the
+ *  one-shot review, not making an ordinary close. GitHub lets a contributor reopen a PR they closed
+ *  themselves but NOT one closed by a maintainer or the App (#one-shot-reopen) -- so this reopens the PR (as
+ *  the App) and immediately re-closes it (as the App), converting the contributor's own close into an
+ *  App-authored, terminal one they cannot reopen; any later reopen attempt is caught by the EXISTING
+ *  maybeRecloseDisallowedReopen guard above. Uses hasReviewedForHeadSha (not hasActiveReviewForHeadSha)
+ *  deliberately, mirroring the draft-conversion sibling below: the active-only window closes the instant a
+ *  review publishes, but a human reacting to a now-VISIBLE label/comment necessarily acts AFTER that -- the
+ *  narrow window could only ever catch someone self-closing blind. Unlike the draft-conversion sibling, this
+ *  guard's own enforcement action closes the PR again -- so a redelivered/retried webhook for the SAME
+ *  original close must not re-run the reopen/close dance; a live-timeline closer check (mirrors
+ *  recloseDisallowedReopenIfNeeded's own pattern) distinguishes that from a genuinely fresh self-close.
+ *  `.loopover.yml` settings.autoCloseExemptLogins (the same shared allowlist the draft-conversion/
+ *  contributor-cap/review-nag guards already honor) is an explicit escape hatch for trusted contributors.
+ *  Per-PR actuation-locked like its draft-dodge/reopen-reclose siblings. The strike only counts once the
+ *  enforcement close actually succeeds. */
 export async function maybeCloseReviewEvasionSelfClose(
   env: Env,
   deliveryId: string,
@@ -553,11 +561,11 @@ export async function maybeCloseReviewEvasionSelfClose(
   settings: RepositorySettings,
 ): Promise<void> {
   await withPrActuationLock(env, repoFullName, pr.number, "review-evasion-self-close", () =>
-    closeReviewEvasionSelfCloseIfActive(env, deliveryId, installationId, repoFullName, pr, payload, settings),
+    closeReviewEvasionSelfCloseIfReviewed(env, deliveryId, installationId, repoFullName, pr, payload, settings),
   );
 }
 
-async function closeReviewEvasionSelfCloseIfActive(
+async function closeReviewEvasionSelfCloseIfReviewed(
   env: Env,
   deliveryId: string,
   installationId: number,
@@ -573,10 +581,24 @@ async function closeReviewEvasionSelfCloseIfActive(
   // maintainer) closing someone else's PR is an ordinary maintainer action, not evasion.
   if (!closer || !authorLogin || closer !== authorLogin) return;
   if (isProtectedAutomationAuthor(pr.authorLogin)) return;
+  if (isAutoCloseExempt(pr.authorLogin, settings.autoCloseExemptLogins)) return;
   if (!pr.headSha) return;
   const headSha = pr.headSha; // captured so the allowStaleIf closure below keeps the narrowed non-null type
   if (await hasMaintainerOrOwnerPermission(env, installationId, repoFullName, authorLogin)) return;
-  if (!(await hasActiveReviewForHeadSha(env, repoFullName, pr.number, headSha))) return;
+  if (!(await hasReviewedForHeadSha(env, repoFullName, pr.number, headSha))) return;
+  // Redelivery/retry safety (#self-close-post-review): hasReviewedForHeadSha stays true for as long as the
+  // head doesn't change -- including AFTER this very guard's own enforcement already ran below (reopen+close
+  // as the App), unlike hasActiveReviewForHeadSha, which the guard's own terminalizeActiveReviewTracking call
+  // used to flip false and rely on for exactly this dedup. A genuinely fresh self-close's most recent closer
+  // on the live timeline is the CONTRIBUTOR (this webhook's own sender); once we've already enforced, the
+  // live timeline's last closer is loopover's own bot login instead. Check that BEFORE re-running the
+  // reopen/close dance so a redelivered webhook for an already-enforced close is a true no-op -- mirrors
+  // recloseDisallowedReopenIfNeeded's identical closer-inspection pattern above. An ambiguous read (errored,
+  // or a bounded scan that didn't confidently resolve to the bot) falls through to normal enforcement rather
+  // than risk silently skipping a genuine evasion attempt -- worst case a rare double-enforcement, not a miss.
+  const botLogin = `${env.GITHUB_APP_SLUG}[bot]`.toLowerCase();
+  const lastCloser = await getLastCloserLogin(env, installationId, repoFullName, pr.number);
+  if ((lastCloser.login?.toLowerCase() ?? null) === botLogin) return;
 
   const targetKey = `${repoFullName}#${pr.number}`;
   const gateMetadata = { deliveryId, repoFullName, headSha };

--- a/test/unit/queue-lifecycle-guards.test.ts
+++ b/test/unit/queue-lifecycle-guards.test.ts
@@ -1813,6 +1813,16 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
         return Response.json({ state: url === "open" ? "open" : "closed" });
       }
       if (method === "POST" && url.endsWith("/issues/42/comments")) return Response.json({ id: 1 }, { status: 201 });
+      // getLastCloserLogin's timeline scan (#self-close-post-review redelivery-safety check): a genuinely
+      // fresh self-close's most recent "closed" event is the contributor's own. Once THIS guard's own
+      // reopen+close pair has actually happened (>=2 prior PATCH /pulls/42 calls recorded in `calls`), the
+      // live timeline's last closer becomes the bot -- mirrors what GitHub's real timeline would show after
+      // an actual reopen+re-close, letting a redelivery test assert the second delivery is a true no-op.
+      if (url.includes("/issues/42/events")) {
+        const priorPatches = calls.filter((c) => c.method === "PATCH" && c.url.endsWith("/pulls/42")).length;
+        const closer = priorPatches >= 2 ? "gittensory[bot]" : "contributor";
+        return Response.json([{ event: "closed", actor: { login: closer } }]);
+      }
       if (url.includes("/check-runs")) return Response.json({ id: 900 }, { status: 201 });
       if (url.includes("/labels")) return Response.json([{ name: "review-evasion" }]);
       if (url.includes("/pulls/42/files")) return Response.json([]);
@@ -1914,6 +1924,39 @@ describe("review-evasion protection (#review-evasion-protection)", () => {
       await processJob(env, { type: "github-webhook", deliveryId: "self-close-no-active-review", eventName: "pull_request", payload: closedPayload("contributor") });
 
       expect(calls.some((c) => c.method === "PATCH" && c.url.endsWith("/pulls/42"))).toBe(false);
+    });
+
+    it("REGRESSION (#self-close-post-review): re-closes a self-close AFTER the review already published, not just mid-computation -- the active-only window would have missed this, since a human reacting to a now-visible label necessarily acts after the pass already terminalized", async () => {
+      const calls: Array<{ url: string; method: string }> = [];
+      stubEvasionFetch(calls);
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      await setupEvasionRepo(env);
+      await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", authorLogin: "contributor", deliveryId: "review-start-1" });
+      // The review pass concludes and publishes -- exactly what happens right before a human could ever SEE
+      // a label/comment to react to (and, in practice, before they'd bother self-closing to dodge it).
+      await repositoriesModule.terminalizeActiveReviewTracking(env, "JSONbored/gittensory", 42);
+
+      await processJob(env, { type: "github-webhook", deliveryId: "self-close-post-publish", eventName: "pull_request", payload: closedPayload("contributor") });
+
+      const patches = calls.filter((c) => c.method === "PATCH" && c.url.endsWith("/pulls/42"));
+      expect(patches.length).toBeGreaterThanOrEqual(2); // reopen (state=open) then re-close (state=closed)
+      const audit = await env.DB.prepare("select outcome from audit_events where event_type = ?").bind("github_app.review_evasion_closed").first<{ outcome: string }>();
+      expect(audit?.outcome).toBe("completed");
+    });
+
+    it("REGRESSION (#self-close-post-review): honors settings.autoCloseExemptLogins -- the shared allowlist the draft-conversion/contributor-cap/review-nag guards already use", async () => {
+      const calls: Array<{ url: string; method: string }> = [];
+      stubEvasionFetch(calls);
+      const env = createTestEnv({ GITHUB_APP_PRIVATE_KEY: generateRsaPrivateKeyPem(), GITHUB_APP_SLUG: "gittensory" });
+      await setupEvasionRepo(env, { autoCloseExemptLogins: ["contributor"] });
+      await repositoriesModule.startActiveReviewTracking(env, { repoFullName: "JSONbored/gittensory", pullNumber: 42, headSha: "abc123", authorLogin: "contributor", deliveryId: "review-start-1" });
+      await repositoriesModule.terminalizeActiveReviewTracking(env, "JSONbored/gittensory", 42);
+
+      await processJob(env, { type: "github-webhook", deliveryId: "self-close-exempt", eventName: "pull_request", payload: closedPayload("contributor") });
+
+      expect(calls.some((c) => c.method === "PATCH" && c.url.endsWith("/pulls/42"))).toBe(false);
+      const audit = await env.DB.prepare("select count(*) as n from audit_events where event_type = ?").bind("github_app.review_evasion_closed").first<{ n: number }>();
+      expect(audit?.n).toBe(0);
     });
 
     it("does nothing when a THIRD PARTY closed someone else's PR (not the author) — an ordinary maintainer close, not self-close evasion", async () => {


### PR DESCRIPTION
## Summary
- The self-close review-evasion guard only fired while `hasActiveReviewForHeadSha` was true — a window that closes the instant a review publishes. A contributor reacting to a now-visible label/comment by self-closing necessarily acts AFTER that window, so the guard could only ever catch someone self-closing blind before any output existed — the same timing gap fixed for draft-conversion evasion in [PR #6080](https://github.com/JSONbored/loopover/pull/6080).
- Fixed by switching to `hasReviewedForHeadSha` (mirrors #6080) and honoring `settings.autoCloseExemptLogins`.
- Unlike draft-conversion, this guard's own enforcement action re-closes the PR (reopen + re-close as the App). That means the row-terminalization signal the OLD narrow check relied on for redelivery-safety (the guard's own success path calls `terminalizeActiveReviewTracking`, which used to flip `hasActiveReviewForHeadSha` false) no longer discriminates "genuinely reviewed" from "already enforced" once the check is broadened to `hasReviewedForHeadSha` — a redelivered/retried webhook for the same original close would otherwise double-enforce (extra API calls, and worse, a second moderation strike for one incident).
- Added a live-timeline closer check (`getLastCloserLogin`), mirroring the existing `recloseDisallowedReopenIfNeeded` guard's identical pattern just above it in the same file: if the PR's most recent "closed" timeline event was authored by the App's own bot login, this is a redelivery of an already-enforced close — true no-op. An ambiguous read (errored, or an uncovered bounded scan) falls through to normal enforcement rather than risk silently missing a genuine evasion attempt.

## Test plan
- [x] `npm run test:ci` (full local gate) green
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] New regression test: closes a self-close AFTER the tracked review already published/terminalized (the actual bug)
- [x] New regression test: honors `settings.autoCloseExemptLogins`
- [x] Existing redelivery-idempotency regression test (`no duplicate strike or duplicate enforcement on a webhook redelivery/retry`) still passes, now exercising the new live-timeline check instead of the old active/terminal transition
- [x] Spot-checked `coverage/lcov.info` DA/BRDA records for every new line/branch — 100% line and branch coverage