### PR TITLE
perf(queue): fetch copycat candidate files concurrently, not sequentially

### DIFF
--- a/src/queue/copycat-detection.ts
+++ b/src/queue/copycat-detection.ts
@@ -61,26 +61,36 @@ export async function runCopycatAssessment(
     minScore: RepositorySettings["copycatGateMinScore"];
   },
 ): Promise<CopycatAssessment> {
-  const priorArt: CopycatPriorArtCandidate[] = [];
-
+  // Each phase's candidate list is already bounded by MAX_COPYCAT_CANDIDATES (25) before any fetch starts, so
+  // fetching every candidate's files CONCURRENTLY within a phase (rather than one listPullRequestFiles round-
+  // trip at a time, up to 50 sequential DB reads total across both phases) does not raise the worst-case fan-
+  // out -- it only removes the artificial serialization between independent reads. Promise.all preserves each
+  // phase's original candidate order in its result array regardless of resolution order, so priorArt's
+  // ordering (open siblings first, then merged) is unchanged.
   const openCandidates = args.otherOpenPullRequests.slice(0, MAX_COPYCAT_CANDIDATES);
-  for (const sibling of openCandidates) {
-    const files = await listPullRequestFiles(env, args.repoFullName, sibling.number).catch(() => []);
-    priorArt.push({ pullNumber: sibling.number, lines: comparableAddedLines(files), submittedAt: sibling.createdAt });
-  }
+  const openPriorArt: CopycatPriorArtCandidate[] = await Promise.all(
+    openCandidates.map(async (sibling) => {
+      const files = await listPullRequestFiles(env, args.repoFullName, sibling.number).catch(() => []);
+      return { pullNumber: sibling.number, lines: comparableAddedLines(files), submittedAt: sibling.createdAt };
+    }),
+  );
 
-  const remainingBudget = MAX_COPYCAT_CANDIDATES - priorArt.length;
+  let mergedPriorArt: CopycatPriorArtCandidate[] = [];
+  const remainingBudget = MAX_COPYCAT_CANDIDATES - openPriorArt.length;
   if (remainingBudget > 0) {
     const changedPathSet = new Set(args.files.map((file) => file.path));
     const recentMerged = await listRecentMergedPullRequests(env, args.repoFullName).catch(() => []);
     const overlapping = recentMerged
       .filter((candidate) => candidate.changedFiles.some((path) => changedPathSet.has(path)))
       .slice(0, remainingBudget);
-    for (const candidate of overlapping) {
-      const files = await listPullRequestFiles(env, args.repoFullName, candidate.number).catch(() => []);
-      priorArt.push({ pullNumber: candidate.number, lines: comparableAddedLines(files), submittedAt: candidate.mergedAt });
-    }
+    mergedPriorArt = await Promise.all(
+      overlapping.map(async (candidate) => {
+        const files = await listPullRequestFiles(env, args.repoFullName, candidate.number).catch(() => []);
+        return { pullNumber: candidate.number, lines: comparableAddedLines(files), submittedAt: candidate.mergedAt };
+      }),
+    );
   }
+  const priorArt = [...openPriorArt, ...mergedPriorArt];
 
   return assessCopycat({
     candidateLines: comparableAddedLines(args.files),

--- a/test/unit/copycat-detection.test.ts
+++ b/test/unit/copycat-detection.test.ts
@@ -193,6 +193,31 @@ describe("runCopycatAssessment", () => {
     expect(result.wouldAct).toBe(false);
   });
 
+  it("REGRESSION (perf/copycat-parallel-candidate-fetch): fetches each phase's candidate files CONCURRENTLY, not one listPullRequestFiles round-trip at a time", async () => {
+    const env = createTestEnv();
+    let inFlight = 0;
+    let maxInFlight = 0;
+    vi.spyOn(repositoriesModule, "listPullRequestFiles").mockImplementation(async () => {
+      inFlight += 1;
+      maxInFlight = Math.max(maxInFlight, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 5)); // hold the window open long enough for others to overlap
+      inFlight -= 1;
+      return [];
+    });
+    const manyOpenSiblings = Array.from({ length: 5 }, (_, i) => openSibling(i + 1, "2026-06-01T00:00:00Z"));
+
+    await runCopycatAssessment(env, {
+      repoFullName: REPO,
+      pr: { number: 100, createdAt: "2026-06-05T00:00:00Z" },
+      files: [file(100, "src/copy.ts", "+some content")],
+      otherOpenPullRequests: manyOpenSiblings,
+      mode: "block",
+      minScore: null,
+    });
+
+    expect(maxInFlight).toBeGreaterThan(1); // proves real overlap -- not the old strictly-sequential loop
+  });
+
   it("degrades a failed recently-merged lookup to an empty candidate list (fail-safe) instead of throwing", async () => {
     const env = createTestEnv();
     vi.spyOn(repositoriesModule, "listRecentMergedPullRequests").mockRejectedValueOnce(new Error("D1 read error"));


### PR DESCRIPTION
## Summary
- `runCopycatAssessment` fetched each of up to 25 open-sibling candidates' files via a sequential `await` loop, then repeated the exact same pattern for up to 25 recently-merged candidates -- up to 50 serialized `listPullRequestFiles` round trips in the worst case, for a single gate evaluation.
- Each phase's candidate list is already bounded by `MAX_COPYCAT_CANDIDATES` (25) *before* any fetch starts (via `.slice(...)`), so there's no reason the fetches within a phase can't run concurrently -- the sequential loop added pure latency with no correctness benefit.
- Switched both loops to `Promise.all`, which preserves each phase's original candidate ordering in the result array regardless of resolution order (`priorArt`'s open-siblings-then-merged ordering, and the containment engine's own submittedAt-based direction resolution, are both unaffected).
- This is a straight perf fix for the copycat containment engine (currently shipped but never enabled anywhere -- `gate.copycat.mode` defaults to `off`), unblocking enabling it at `warn` tier without a 50x-sequential-read cost per evaluation.

## Test plan
- [x] `npm run test:ci` (full local gate) green
- [x] `npm audit --audit-level=moderate` — 0 vulnerabilities
- [x] All 12 existing `runCopycatAssessment` tests pass unchanged (ordering, path-pre-filtering, direction exclusion, candidate cap, fail-safe degradation on a rejected fetch)
- [x] New regression test proves actual concurrent execution (tracks in-flight call count via a delayed mock, asserts `maxInFlight > 1` -- fails against the old sequential implementation)
- [x] Spot-checked `coverage/lcov.info` — zero uncovered lines/branches in the changed file