### PR TITLE
feat(miner): export buildIssueQualityReport and wire self-review issueQuality

### DIFF
--- a/packages/loopover-engine/src/index.ts
+++ b/packages/loopover-engine/src/index.ts
@@ -415,6 +415,7 @@ export {
 // (#5145, the miner's real SelfReviewContext fetcher needs to compute inDuplicateCluster the same way the
 // live gate does), not this file's full internal surface.
 export { buildCollisionReport, type CollisionCluster, type CollisionReport } from "./signals/predicted-gate-engine.js";
+export { buildIssueQualityReport } from "./signals/engine.js";
 export type { CollisionItem } from "./types/predicted-gate-types.js";
 // Unlinked-issue candidate pre-filter (#4883), extracted out of src/signals/unlinked-issue-candidates.ts so the
 // miner's self-review can run the SAME deterministic recall pass the maintainer gate uses to flag a PR's

--- a/packages/loopover-miner/lib/self-review-context.d.ts
+++ b/packages/loopover-miner/lib/self-review-context.d.ts
@@ -1,8 +1,8 @@
 import type { SelfReviewContext } from "@loopover/engine";
 
-// bounties/issueQuality are always omitted (see this file's own header comment for why), so the result is
-// SelfReviewContext minus those two optional fields rather than the full type.
-export type SelfReviewContextResult = Omit<SelfReviewContext, "bounties" | "issueQuality">;
+// `bounties` is always omitted (see this file's own header comment for why), so the result is
+// SelfReviewContext minus that optional field rather than the full type.
+export type SelfReviewContextResult = Omit<SelfReviewContext, "bounties">;
 
 // A narrower shape than `typeof fetch` on purpose: this module only ever calls it with a string URL and a
 // plain GET init, and the ambient `fetch` type in this repo's TS program is Cloudflare-Workers-flavored

--- a/packages/loopover-miner/lib/self-review-context.js
+++ b/packages/loopover-miner/lib/self-review-context.js
@@ -1,4 +1,4 @@
-import { buildCollisionReport, MAX_FOCUS_MANIFEST_BYTES, parseFocusManifestContent } from "@loopover/engine";
+import { buildCollisionReport, buildIssueQualityReport, MAX_FOCUS_MANIFEST_BYTES, parseFocusManifestContent } from "@loopover/engine";
 
 // Real SelfReviewContext fetcher (#5145, Wave 3.5). Builds the context object the miner's self-review pass
 // (packages/loopover-engine/src/miner/self-review-adapter.ts) needs, at the SAME fidelity the live gate's
@@ -9,13 +9,10 @@ import { buildCollisionReport, MAX_FOCUS_MANIFEST_BYTES, parseFocusManifestConte
 //   - `bounties`: bounty data is not GitHub-native in this codebase -- it comes from an external "Gitt"
 //     system that PUSHES data into the live gate's own internal ingest route (src/api/routes.ts). There is
 //     no public endpoint the miner could legitimately pull from instead.
-//   - `issueQuality`: built by buildIssueQualityReport, which lives only in root src/signals/engine.ts and
-//     has never been extracted into @loopover/engine (the same "not yet extracted" situation
-//     src/signals/slop.ts documented before #5133 extracted slop scoring specifically).
 //
-// Both are already optional on SelfReviewContext, and buildPredictedGateVerdict already degrades gracefully
-// without them -- omitting them here is the same tradeoff the live gate itself makes for a repo it hasn't
-// computed bounty/quality data for yet, not a corner cut specific to the miner.
+// `bounties` remains omitted for that reason. `issueQuality` is built from the same live GitHub snapshot
+// as the other fields via buildIssueQualityReport (now exported from @loopover/engine); bounty rows and
+// recent-merged PR history are passed as empty arrays because this fetcher does not yet pull either source.
 
 const GITHUB_API_VERSION = "2022-11-28";
 const DEFAULT_API_BASE_URL = "https://api.github.com";
@@ -297,10 +294,9 @@ async function fetchConfirmedContributor(login, resolved) {
 // >= 2 threshold, inDuplicateCluster would fire on the completely normal case of "one PR already closes
 // this issue," not genuine overlapping/duplicate work. Checks the target ISSUE's presence instead of a
 // not-yet-existing PR number, since the miner's own submission doesn't exist as a real PullRequestRecord yet.
-function computeInDuplicateCluster(repoFullName, issues, pullRequests, targetIssueNumbers) {
+function computeInDuplicateCluster(collisionReport, targetIssueNumbers) {
   if (targetIssueNumbers.length === 0) return false;
-  const report = buildCollisionReport(repoFullName, issues, pullRequests);
-  return report.clusters.some(
+  return collisionReport.clusters.some(
     (cluster) =>
       cluster.risk === "high" &&
       cluster.items.filter((item) => item.type === "pull_request").length >= 2 &&
@@ -310,8 +306,7 @@ function computeInDuplicateCluster(repoFullName, issues, pullRequests, targetIss
 
 /**
  * Build a real SelfReviewContext from live GitHub data, at the same fidelity the live gate's own DB-backed
- * construction produces. See this file's header for the two fields (bounties, issueQuality) deliberately
- * left undefined and why.
+ * construction produces. See this file's header for why `bounties` is deliberately left undefined.
  *
  * @param {string} repoFullName
  * @param {{
@@ -335,7 +330,10 @@ export async function fetchSelfReviewContext(repoFullName, options = {}) {
   ]);
 
   const manifest = parseFocusManifestContent(manifestContent, "repo_file");
-  const inDuplicateCluster = computeInDuplicateCluster(`${target.owner}/${target.repo}`, issues, pullRequests, resolved.linkedIssues);
+  const fullName = `${target.owner}/${target.repo}`;
+  const collisions = buildCollisionReport(fullName, issues, pullRequests);
+  const inDuplicateCluster = computeInDuplicateCluster(collisions, resolved.linkedIssues);
+  const issueQuality = buildIssueQualityReport(repo, issues, pullRequests, fullName, [], collisions, []);
 
   return {
     manifest,
@@ -344,5 +342,6 @@ export async function fetchSelfReviewContext(repoFullName, options = {}) {
     pullRequests,
     confirmedContributor,
     inDuplicateCluster,
+    issueQuality,
   };
 }

--- a/test/unit/miner-self-review-context.test.ts
+++ b/test/unit/miner-self-review-context.test.ts
@@ -199,7 +199,15 @@ describe("fetchSelfReviewContext (#5145)", () => {
     // high-risk cluster, not any overlap at all.
     expect(result.inDuplicateCluster).toBe(false);
     expect("bounties" in result).toBe(false);
-    expect("issueQuality" in result).toBe(false);
+    expect(result.issueQuality?.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          number: 7,
+          title: "Uploads should retry on 5xx",
+          status: expect.any(String),
+        }),
+      ]),
+    );
   });
 
   it("flags inDuplicateCluster true when the target issue already has 2+ open PRs referencing it (a real high-risk cluster)", async () => {
@@ -214,6 +222,20 @@ describe("fetchSelfReviewContext (#5145)", () => {
 
     const result = await fetchSelfReviewContext("acme/widgets", { linkedIssues: [7], fetchImpl: fetchImpl as never });
     expect(result.inDuplicateCluster).toBe(true);
+  });
+
+  it("populates issueQuality from the live GitHub snapshot without bounty or recent-merged inputs", async () => {
+    const fetchImpl = routedFetch({
+      "/repos/acme/widgets/issues": () => jsonResponse([issuePayload({ body: "x".repeat(220) })]),
+      "/repos/acme/widgets/pulls": () => jsonResponse([]),
+      "/repos/acme/widgets": () => jsonResponse(REPO_PAYLOAD),
+      "raw.githubusercontent.com": () => jsonResponse(null, 404),
+      "api.gittensor.io/miners": () => jsonResponse([]),
+    });
+
+    const result = await fetchSelfReviewContext("acme/widgets", { fetchImpl: fetchImpl as never });
+    expect(result.issueQuality?.issues).toHaveLength(1);
+    expect(result.issueQuality?.issues[0]).toMatchObject({ number: 7, status: expect.any(String) });
   });
 
   it("returns false for inDuplicateCluster when no linkedIssues are supplied", async () => {


### PR DESCRIPTION
## Summary
- Re-export `buildIssueQualityReport` from `@loopover/engine` (mirroring the existing `buildCollisionReport` pattern)
- Populate `issueQuality` in `fetchSelfReviewContext` from the live GitHub snapshot, reusing the collision report
- Update header/types to reflect that only `bounties` remains omitted (no external bounty source on the miner)

Closes #6057

## Test plan
- [x] Extended `miner-self-review-context.test.ts` to assert `issueQuality` is populated
- [ ] CI validate-tests + codecov patch